### PR TITLE
Add support for ID fields within workflow config files

### DIFF
--- a/cmd/commands/internal/workflows/new.go
+++ b/cmd/commands/internal/workflows/new.go
@@ -2,6 +2,8 @@ package workflows
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/inngest/inngestctl/inngest"
@@ -10,6 +12,8 @@ import (
 const (
 	workflowComment = `// For documentation on workflow configuration, visit https://docs.inngest.com/docs/workflows`
 )
+
+var slugifyRegex = regexp.MustCompile(`[^a-z0-9\\-_]+`)
 
 var (
 	questions = []*survey.Question{
@@ -32,6 +36,7 @@ var (
 
 type Config struct {
 	Name        string
+	ID          string
 	TriggerType string
 	EventName   string
 	Cron        string
@@ -75,6 +80,7 @@ func (c *Config) Triggers() []inngest.Trigger {
 func (c *Config) Configuration() (string, error) {
 	output, err := inngest.FormatWorkflow(inngest.Workflow{
 		Name:     c.Name,
+		ID:       strings.ToLower(slugifyRegex.ReplaceAllString(c.Name, "-")),
 		Triggers: c.Triggers(),
 		Actions:  []inngest.Action{},
 		Edges:    []inngest.Edge{},

--- a/cmd/commands/util.go
+++ b/cmd/commands/util.go
@@ -29,7 +29,11 @@ func findWorkflow(ctx context.Context, idOrPrefix string) (*client.Workflow, err
 	candidates := []*client.Workflow{}
 	for _, f := range flows {
 		copied := f
-		if strings.HasPrefix(f.ID.String(), idOrPrefix) {
+		if f.Slug == idOrPrefix {
+			return &copied, nil
+		}
+
+		if strings.HasPrefix(f.Slug, idOrPrefix) {
 			candidates = append(candidates, &copied)
 		}
 	}

--- a/cmd/commands/workflows.go
+++ b/cmd/commands/workflows.go
@@ -66,7 +66,7 @@ var workflowsList = &cobra.Command{
 			}
 
 			row := table.Row{
-				f.ID,
+				f.Slug,
 				f.Name,
 			}
 
@@ -99,7 +99,7 @@ var workflowVersions = &cobra.Command{
 	Short: "Shows a workflow's version information.",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
-			return fmt.Errorf("No workflow ID specified.  Specify a workflow ID or it's prefix")
+			return fmt.Errorf("No workflow specified.  Specify a workflow ID (or it's prefix)")
 		}
 		return nil
 	},
@@ -204,45 +204,5 @@ var workflowNew = &cobra.Command{
 		fmt.Println("")
 		fmt.Println("Edit this file with your configuration and deploy using `inngestctl workflows deploy`.")
 		return nil
-	},
-}
-
-var workflowDeploy = &cobra.Command{
-	Use:   "deploy",
-	Short: "Deploys a new version of a workflow",
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// XXX: Read from stdin as well as an arg.
-		if len(args) == 0 {
-			return fmt.Errorf("No workflow configuration provided")
-		}
-		return nil
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx := cmd.Context()
-		state := state.RequireState(ctx)
-
-		workflow, err := findWorkflow(ctx, args[0])
-		if err != nil {
-			log.From(ctx).Fatal().Err(err).Msg("Unable to find workflow")
-		}
-
-		if versionFlag != 0 && workflow.Current != nil && workflow.Current.Version != versionFlag {
-			// Request that specific version, as by default we only request the config for
-			// the current version in the list.
-			v, err := state.Client.WorkflowVersion(ctx, state.SelectedWorkspace.ID, workflow.ID, versionFlag)
-			if err != nil {
-				log.From(ctx).Fatal().Err(err).Msg("Unable to find workflow version")
-			}
-			fmt.Println(v.Config)
-			return
-		}
-
-		// Show the current version by default
-		if workflow.Current != nil {
-			fmt.Println(workflow.Current.Config)
-			return
-		}
-
-		log.From(ctx).Fatal().Err(err).Msg("No live version to show, and no version supplied with --version flag.  Show a specific version using the --version flag")
 	},
 }

--- a/inngest/client/client.go
+++ b/inngest/client/client.go
@@ -18,9 +18,14 @@ type Client interface {
 	Account(ctx context.Context) (*Account, error)
 	Workspaces(ctx context.Context) ([]Workspace, error)
 
+	// Workflows lists all workflows in a given workspace
 	Workflows(ctx context.Context, workspaceID uuid.UUID) ([]Workflow, error)
+	// Workflow returns a specific workflow by ID
 	Workflow(ctx context.Context, workspaceID, workflowID uuid.UUID) (*Workflow, error)
+	// WorkflowVersion returns a specific workflow version for a given workflow
 	WorkflowVersion(ctx context.Context, workspaceID, workflowID uuid.UUID, version int) (*WorkflowVersion, error)
+	// LatestWorkflowVersion returns the latest workflow version by modification date for a given workflow
+	LatestWorkflowVersion(ctx context.Context, workspaceID, workflowID uuid.UUID) (*WorkflowVersion, error)
 
 	Actions(ctx context.Context, includePublic bool) ([]*Action, error)
 	UpdateActionVersion(ctx context.Context, v ActionVersionQualifier, enabled bool) (*ActionVersion, error)

--- a/inngest/internal/cuedefs/pkg/actions/actions.cue
+++ b/inngest/internal/cuedefs/pkg/actions/actions.cue
@@ -10,7 +10,7 @@ import (
 
 #Action: {
 	name: string
-	dsn:  string
+	dsn:  =~"^[a-z0-9-.]+/[a-z0-9-]+$"
 
 	version: {
 		major: >0 | *1

--- a/inngest/internal/cuedefs/pkg/workflows/workflows.cue
+++ b/inngest/internal/cuedefs/pkg/workflows/workflows.cue
@@ -8,7 +8,13 @@ import (
 
 // a workflow is an entire workflow for our app
 #Workflow: {
-	name:     string
+	// id represents the immutable identifier for the workflow, which groups all
+	// versions into a single workflow.  If this were GitHub, this would be the
+	// repository name.
+	id: =~"^[a-z0-9-]+$"
+
+	// The workflow name.
+	name: string
 
 	// The triggers which start a workflow.
 	//
@@ -50,7 +56,7 @@ import (
 }
 
 #Edge: {
-	outgoing: uint | "trigger" // Either the action ID or 'trigger'
-	incoming: uint
+	outgoing:  uint | "trigger" // Either the action ID or 'trigger'
+	incoming:  uint
 	metadata?: #EdgeMetadata
 }

--- a/inngest/workflow.go
+++ b/inngest/workflow.go
@@ -11,6 +11,13 @@ import (
 // This represents the logic for a workflow, but does not represent any specific
 // workflow in the database.
 type Workflow struct {
+	// ID is the immutable human identifier for the workflow.  This acts
+	// similarly to a git repository name;  a single workflow ID can contain
+	// many workflow versions.
+	//
+	// When deploying a specific workflow version we read the cue configuration
+	// and upsert a version to the given ID.
+	ID   string `json:"id"`
 	Name string `json:"name"`
 
 	Triggers []Trigger `json:"triggers"`
@@ -81,8 +88,7 @@ func FormatWorkflow(a Workflow) (string, error) {
 	return fmt.Sprintf(workflowTpl, def), nil
 }
 
-var workflowTpl = `
-package main
+var workflowTpl = `package main
 
 import (
 	"inngest.com/workflows"


### PR DESCRIPTION
Closes issue 280 by ensuring that we add support for ID fields within config files.  This lets us upsert workflow versions to an immutable workflow repository without adding UUIDs to the CLI.