### PR TITLE
Enable idempotent deploys of workflows via the CLI

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -1,9 +1,9 @@
 package commands
 
 import (
+	"os"
 	"strings"
 
-	"github.com/inngest/inngestctl/inngest/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -28,6 +28,6 @@ func init() {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Default().Fatal().Msgf("error: %s", err)
+		os.Exit(1)
 	}
 }

--- a/inngest/client/client.go
+++ b/inngest/client/client.go
@@ -26,6 +26,8 @@ type Client interface {
 	WorkflowVersion(ctx context.Context, workspaceID, workflowID uuid.UUID, version int) (*WorkflowVersion, error)
 	// LatestWorkflowVersion returns the latest workflow version by modification date for a given workflow
 	LatestWorkflowVersion(ctx context.Context, workspaceID, workflowID uuid.UUID) (*WorkflowVersion, error)
+	// DeployWorflow idempotently deploys a workflow, by default as a draft.  Set live to true to deploy as the live version.
+	DeployWorkflow(ctx context.Context, workspaceID uuid.UUID, config string, live bool) (*WorkflowVersion, error)
 
 	Actions(ctx context.Context, includePublic bool) ([]*Action, error)
 	UpdateActionVersion(ctx context.Context, v ActionVersionQualifier, enabled bool) (*ActionVersion, error)


### PR DESCRIPTION
This PR utilizes the `UpsertWorkflow` endpoint, which idempotently
pushes workflow configuration to Inngest.

If the configuration is unchagned since the latest version the
config remains unchanged.

Otherwise, a new workflow version is created, by default as a draft.

This can push workflows live with the use of the `--live` flag.