### PR TITLE
Add idempotency keys to state.Identifier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+test:
+	go test ./... -race -count=1
+	golangci-lint run
+
 snapshot:
 	goreleaser release --snapshot --skip-publish --rm-dist
 

--- a/pkg/execution/executor/executor_test.go
+++ b/pkg/execution/executor/executor_test.go
@@ -110,7 +110,11 @@ func TestExecute_state(t *testing.T) {
 		},
 	}
 
-	s, err := sm.New(ctx, w, ulid.MustNew(ulid.Now(), rand.Reader), map[string]interface{}{})
+	id := state.Identifier{
+		RunID: ulid.MustNew(ulid.Now(), rand.Reader),
+	}
+
+	s, err := sm.New(ctx, w, id, map[string]interface{}{})
 	require.Nil(t, err)
 
 	driver := &mockdriver.Mock{
@@ -251,7 +255,11 @@ func TestExecute_edge_expressions(t *testing.T) {
 		},
 	}
 
-	s, err := sm.New(ctx, w, ulid.MustNew(ulid.Now(), rand.Reader), map[string]interface{}{
+	id := state.Identifier{
+		RunID: ulid.MustNew(ulid.Now(), rand.Reader),
+	}
+
+	s, err := sm.New(ctx, w, id, map[string]interface{}{
 		"data": map[string]interface{}{
 			"run":    true,
 			"string": "yes",

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -50,11 +50,16 @@ func (i *InMemoryRunner) Start(ctx context.Context) error {
 
 // NewRun initializes a new run for the given workflow.
 func (i *InMemoryRunner) NewRun(ctx context.Context, f inngest.Workflow, data map[string]interface{}) (*state.Identifier, error) {
-	state, err := i.sm.New(ctx, f, ulid.MustNew(ulid.Now(), rand.Reader), data)
+
+	id := state.Identifier{
+		WorkflowID: f.UUID,
+		RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
+	}
+
+	_, err := i.sm.New(ctx, f, id, data)
 	if err != nil {
 		return nil, fmt.Errorf("error initializing new run: %w", err)
 	}
-	id := state.Identifier()
 
 	err = i.Enqueue(ctx, queue.Item{
 		Identifier: id,

--- a/pkg/execution/state/inmemory/inmemory_test.go
+++ b/pkg/execution/state/inmemory/inmemory_test.go
@@ -16,14 +16,20 @@ import (
 )
 
 func TestStateHarness(t *testing.T) {
-	testharness.CheckState(t, func() state.Manager { return NewStateManager() })
+	testharness.CheckState(t, func() (state.Manager, func()) {
+		return NewStateManager(), func() {}
+	})
 }
 
 func TestInMemoryPause(t *testing.T) {
 	ctx := context.Background()
 	sm := NewStateManager()
 
-	s, err := sm.New(ctx, inngest.Workflow{}, ulid.MustNew(ulid.Now(), rand.Reader), map[string]any{})
+	id := state.Identifier{
+		RunID: ulid.MustNew(ulid.Now(), rand.Reader),
+	}
+
+	s, err := sm.New(ctx, inngest.Workflow{}, id, map[string]any{})
 	require.NoError(t, err)
 
 	pauseID := uuid.New()

--- a/pkg/execution/state/inmemory/instance.go
+++ b/pkg/execution/state/inmemory/instance.go
@@ -27,9 +27,8 @@ func NewStateInstance(
 ) state.State {
 	return &memstate{
 		workflow:   w,
-		workflowID: id.WorkflowID,
+		identifier: id,
 		metadata:   metadata,
-		runID:      id.RunID,
 		event:      event,
 		actions:    actions,
 		errors:     errors,
@@ -39,10 +38,9 @@ func NewStateInstance(
 type memstate struct {
 	workflow inngest.Workflow
 
-	metadata state.Metadata
+	identifier state.Identifier
 
-	workflowID uuid.UUID
-	runID      ulid.ULID
+	metadata state.Metadata
 
 	// Event is the root data that triggers the workflow, which is typically
 	// an Inngest event.
@@ -60,10 +58,7 @@ func (s memstate) Metadata() state.Metadata {
 }
 
 func (s memstate) Identifier() state.Identifier {
-	return state.Identifier{
-		WorkflowID: s.workflowID,
-		RunID:      s.runID,
-	}
+	return s.identifier
 }
 
 func (s memstate) Workflow() inngest.Workflow {
@@ -71,11 +66,11 @@ func (s memstate) Workflow() inngest.Workflow {
 }
 
 func (s memstate) WorkflowID() uuid.UUID {
-	return s.workflowID
+	return s.identifier.WorkflowID
 }
 
 func (s memstate) RunID() ulid.ULID {
-	return s.runID
+	return s.identifier.RunID
 }
 
 func (s memstate) Event() map[string]interface{} {

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -34,7 +34,7 @@ type Identifier struct {
 	RunID      ulid.ULID `json:"runID"`
 	// Key represents a unique idempotency key used to deduplicate this
 	// workflow run amongst other runs for the same workflow.
-	Key string `json:"key:"`
+	Key string `json:"key"`
 }
 
 func (i Identifier) IdempotencyKey() string {

--- a/pkg/pubsub/broker_test.go
+++ b/pkg/pubsub/broker_test.go
@@ -169,7 +169,7 @@ func TestCancellation(t *testing.T) {
 
 	select {
 	case <-time.After(1 * time.Second):
-		t.Fail()
+		t.Fatal()
 	case received := <-ok:
 		require.EqualValues(t, sent, received)
 	}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -49,13 +49,13 @@ func (m mockserver) StartTimeout() time.Duration {
 func TestStart(t *testing.T) {
 	m := mockserver{
 		pre:  func(ctx context.Context) error { return nil },
-		run:  func(ctx context.Context) error { <-time.After(50 * time.Millisecond); return nil },
+		run:  func(ctx context.Context) error { <-time.After(500 * time.Millisecond); return nil },
 		stop: func(ctx context.Context) error { return nil },
 	}
 	now := time.Now()
 	err := Start(context.Background(), m)
 	require.NoError(t, err)
-	require.WithinDuration(t, time.Now(), now.Add(50*time.Millisecond), 5*time.Millisecond)
+	require.WithinDuration(t, time.Now(), now.Add(500*time.Millisecond), 10*time.Millisecond)
 }
 
 func TestSigint(t *testing.T) {


### PR DESCRIPTION
This allows us to atomically create workflows when calling New(),
failing if the given idempotency key already exists.