### PR TITLE
Set timestamp to current time during run

### DIFF
--- a/cmd/commands/run.go
+++ b/cmd/commands/run.go
@@ -176,5 +176,7 @@ func fakeEvent(ctx context.Context, fn function.Function, eventName string) (map
 	mapped := map[string]interface{}{}
 	err = val.Decode(&mapped)
 
+	mapped["ts"] = time.Now().UnixMilli()
+
 	return mapped, err
 }


### PR DESCRIPTION
### Description
A small change to ensure that `ts` is set to the current time. Prior to this the data that was generated was a random integer which could have been negative so any code to test that used `ts` could fail if it was expecting a recent date.