### PR TITLE
Update executor service

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -90,7 +90,7 @@ func (a *apiServer) handleEvent(ctx context.Context, e *event.Event) error {
 			// TODO: Move this into a const.
 			Name:      "event/event.received",
 			Version:   "2022-07-01.01",
-			Data:      byt,
+			Data:      string(byt),
 			Timestamp: time.Now(),
 		},
 	)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	Log Log
 	// EventAPI configures the event API service.
 	EventAPI EventAPI
-	//
+	// Execution configures the executor, which invokes actions and steps.
 	Execution Execution
 	// EventAPI configures the event stream, which connects events to the execution engine.
 	EventStream EventStream
@@ -75,7 +75,8 @@ type State struct {
 
 type Execution struct {
 	// Drivers represents all drivers enabled.
-	Drivers map[string]registration.DriverConfig
+	Drivers   map[string]registration.DriverConfig
+	LogOutput bool
 }
 
 func (e *Execution) UnmarshalJSON(byt []byte) error {

--- a/pkg/config/messaging.go
+++ b/pkg/config/messaging.go
@@ -15,6 +15,7 @@ const (
 	MessagingInMemory  = "inmemory"
 	MessagingNATS      = "nats"
 	MessagingGCPPubSub = "gcp-pubsub"
+	MessagingSQS       = "aws-sqs"
 
 	URLTypePublish   URLType = "publish"
 	URLTypeSubscribe URLType = "subscribe"
@@ -75,6 +76,8 @@ func (m *MessagingService) UnmarshalJSON(byt []byte) error {
 		concrete = &NATSMessaging{}
 	case MessagingGCPPubSub:
 		concrete = &GCPPubSubMessaging{}
+	case MessagingSQS:
+		concrete = &SQSMessaging{}
 	default:
 		return fmt.Errorf("unknown messaging backend: %s", m.Backend)
 	}
@@ -150,4 +153,28 @@ func (g GCPPubSubMessaging) TopicURL(topic string, typ URLType) string {
 	}
 
 	return fmt.Sprintf("gcppubsub://projects/%s/subscriptions/%s", g.Project, g.Topic)
+}
+
+type SQSMessaging struct {
+	Region    string
+	AccountID string
+	Topic     string
+}
+
+func (s SQSMessaging) Backend() string {
+	return MessagingSQS
+}
+
+func (s SQSMessaging) TopicName() string {
+	return s.Topic
+}
+
+func (s SQSMessaging) TopicURL(topic string, typ URLType) string {
+	return fmt.Sprintf(
+		"awssqs://sqs.%s.amazonaws.com/%s/%s?region=%s",
+		s.Region,
+		s.AccountID,
+		s.Topic,
+		s.Region,
+	)
 }

--- a/pkg/cuedefs/config/config.cue
+++ b/pkg/cuedefs/config/config.cue
@@ -36,6 +36,11 @@ package config
 			docker: #DockerDriver
 			http:   #HTTPDriver
 		}
+
+		// logOutput logs output from steps within logs.  This may
+		// result in large logs and sensitive data being printed
+		// to stderr, and is only intended for development.
+		logOutput: bool | *false
 	}
 
 	// eventstream is used to configure the event stream pub/sub implementation.  This
@@ -58,8 +63,8 @@ package config
 	}
 }
 
-// @TODO: "inmemory" | "aws-sqs" | "gcp-pubsub" | "nats" | "redis" | *"inmemory"
-#MessagingService: #InmemMessaging | #NATSMessaging
+// @TODO: Add custom redis driver, add Kafka.
+#MessagingService: #InmemMessaging | #NATSMessaging | #SQSMessaging | #GCPPubSubMessaging
 
 // InmemMessaging defines configuration for an in-memory based event queue.  This is
 // only usable for single-container testing;  in-memory implementations only share
@@ -74,6 +79,22 @@ package config
 	backend:   "nats"
 	topic:     string
 	serverURL: string
+}
+
+// GCPPubSubMessaging defines configuration for using GCP's Pub/Sub as a
+// backing event stream.
+#GCPPubSubMessaging: {
+	backend: "gcp-pubsub"
+	project: string
+	topic:   string
+}
+
+// SQSMessaging defines configuration for using SQS as a backing event stream.
+#SQSMessaging: {
+	backend:   "aws-sqs"
+	region:    string
+	accountID: string
+	topic:     string
 }
 
 // # Queues

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -13,6 +13,7 @@ import (
 	"github.com/inngest/inngest-cli/pkg/execution/executor"
 	"github.com/inngest/inngest-cli/pkg/execution/runner"
 	"github.com/inngest/inngest-cli/pkg/function"
+	"github.com/inngest/inngest-cli/pkg/logger"
 	"github.com/inngest/inngest-cli/pkg/service"
 )
 
@@ -32,6 +33,12 @@ func NewDevServer(ctx context.Context, c config.Config) error {
 	// For each function, build the image.
 	if err := buildImages(ctx, funcs); err != nil {
 		return err
+	}
+
+	// The dev server _always_ logs output for development.
+	if !c.Execution.LogOutput {
+		logger.From(ctx).Info().Msg("overriding config to log step output within dev server")
+		c.Execution.LogOutput = true
 	}
 
 	return newDevServer(ctx, c, el)

--- a/pkg/execution/runner/service.go
+++ b/pkg/execution/runner/service.go
@@ -110,11 +110,9 @@ func (s *svc) Pre(ctx context.Context) error {
 
 func (s *svc) Run(ctx context.Context) error {
 	l := logger.From(ctx)
-
 	l.Info().
 		Str("topic", s.config.EventStream.Service.TopicName()).
 		Msg("subscribing to events")
-
 	err := s.pubsub.Subscribe(ctx, s.config.EventStream.Service.TopicName(), s.handleMessage)
 	if err != nil {
 		return err
@@ -188,7 +186,7 @@ func (s *svc) handleMessage(ctx context.Context, m pubsub.Message) error {
 	}
 
 	evt := &event.Event{}
-	if err := json.Unmarshal(m.Data, evt); err != nil {
+	if err := json.Unmarshal([]byte(m.Data), evt); err != nil {
 		return fmt.Errorf("error unmarshalling event: %w", err)
 	}
 

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -13,7 +13,7 @@ import (
 // an event in the future.
 type DriverResponse struct {
 	// Step represents the step that this response is for.
-	Step inngest.Step
+	Step inngest.Step `json:"step"`
 
 	// Scheduled, if set to true, represents that the action has been
 	// scheduled and will run asynchronously.  The output is not available.

--- a/pkg/pubsub/broker.go
+++ b/pkg/pubsub/broker.go
@@ -42,7 +42,9 @@ type broker struct {
 	topics map[string]*pubsub.Topic
 	// tl locks topics within the broker.
 	tl *sync.RWMutex
-	// mux...
+	// mux is the concrete mux router which each implementation is registered
+	// to.  This handles processing topic URLs (mem://, redis://) with the correct
+	// driver.
 	mux *pubsub.URLMux
 }
 

--- a/pkg/pubsub/broker_test.go
+++ b/pkg/pubsub/broker_test.go
@@ -2,7 +2,6 @@ package pubsub
 
 import (
 	"context"
-	"encoding/json"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -36,7 +35,7 @@ func TestBasicPublishSubscribe(t *testing.T) {
 	b, topic := testbroker(t)
 	ctx := context.Background()
 
-	sent := Message{Name: "basic", Data: json.RawMessage("{}")}
+	sent := Message{Name: "basic", Data: "{}"}
 	ok := make(chan Message)
 
 	go func() {
@@ -70,7 +69,7 @@ func TestSubscribeN(t *testing.T) {
 	b, topic := testbroker(t)
 	ctx := context.Background()
 
-	sent := Message{Name: "basic", Data: json.RawMessage("{}")}
+	sent := Message{Name: "basic", Data: "{}"}
 	ok := make(chan Message)
 
 	// i stores how often the run function has been invoked.
@@ -139,7 +138,7 @@ func TestCancellation(t *testing.T) {
 	b, topic := testbroker(t)
 	ctx, cancel := context.WithCancel(context.Background())
 
-	sent := Message{Name: "basic", Data: json.RawMessage("{}")}
+	sent := Message{Name: "basic", Data: "{}"}
 	ok := make(chan Message)
 
 	// Changed when Subscribe finishes in the goroutine.

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -6,12 +6,12 @@ import (
 	"time"
 )
 
-// Message represents an event sent across the pub/sub system
+// Message represents an event sent across the pub/sub system.
 type Message struct {
-	Name      string
-	Version   string
-	Data      json.RawMessage
-	Timestamp time.Time
+	Name      string    `json:"name"`
+	Version   string    `json:"v"`
+	Data      string    `json:"data"`
+	Timestamp time.Time `json:"ts"`
 }
 
 func (m Message) Encode() ([]byte, error) {


### PR DESCRIPTION
Add `logOutput` to config, allowing us to log the output of steps within the dev server.  We also add waitgroups to the executor's Run implementation, ensuring that this is handled even if backing queues do not implement waiting on shutdown.

We also add SQS & GCP configs for existing pub/sub.