### PR TITLE
Add edge tiemout handling to services

### DIFF
--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/inngest/inngest-cli/inngest"
 	"github.com/inngest/inngest-cli/pkg/execution/state"
 )
@@ -35,4 +36,10 @@ func GetEdge(i Item) (*inngest.Edge, error) {
 // the incoming step of the edge.
 type PayloadEdge struct {
 	Edge inngest.Edge `json:"edge"`
+}
+
+// PayloadPauseTimeout is the payload stored when enqueueing a pause timeout, eg.
+// a future task to check whether an event has been received yet.
+type PayloadPauseTimeout struct {
+	PauseID uuid.UUID `json:"pauseID"`
 }

--- a/pkg/execution/state/inmemory/inmemory_test.go
+++ b/pkg/execution/state/inmemory/inmemory_test.go
@@ -1,110 +1,14 @@
 package inmemory
 
 import (
-	"context"
-	"crypto/rand"
 	"testing"
-	"time"
 
-	"github.com/google/uuid"
-	"github.com/inngest/inngest-cli/inngest"
-	"github.com/inngest/inngest-cli/pkg/execution/queue"
 	"github.com/inngest/inngest-cli/pkg/execution/state"
 	"github.com/inngest/inngest-cli/pkg/execution/state/testharness"
-	"github.com/oklog/ulid/v2"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStateHarness(t *testing.T) {
 	testharness.CheckState(t, func() (state.Manager, func()) {
 		return NewStateManager(), func() {}
 	})
-}
-
-func TestInMemoryPause(t *testing.T) {
-	ctx := context.Background()
-	sm := NewStateManager()
-
-	id := state.Identifier{
-		RunID: ulid.MustNew(ulid.Now(), rand.Reader),
-	}
-
-	s, err := sm.New(ctx, inngest.Workflow{}, id, map[string]any{})
-	require.NoError(t, err)
-
-	pauseID := uuid.New()
-
-	// Deleting a noneixstent pause should error.
-	err = sm.ConsumePause(ctx, pauseID)
-	require.ErrorIs(t, state.ErrPauseNotFound, err)
-
-	// Deleting a pause works as expected.
-	err = sm.SavePause(ctx, state.Pause{
-		ID:         pauseID,
-		Identifier: s.Identifier(),
-		// XXX: Right now, in memory state does not validate that the outgoing and
-		// incoming edges exist in the workflow, so this won't break.  Yet.
-		Outgoing: "a",
-		Incoming: "b",
-		Expires:  time.Now().Add(time.Second),
-	})
-	require.NoError(t, err)
-
-	err = sm.ConsumePause(ctx, pauseID)
-	require.NoError(t, err)
-
-	// And you can't re-consume pauses.
-	err = sm.ConsumePause(ctx, pauseID)
-	require.ErrorIs(t, err, state.ErrPauseNotFound)
-
-	// Create a new pause, and wait until the expires
-
-	pauseID = uuid.New()
-	err = sm.SavePause(ctx, state.Pause{
-		ID:         pauseID,
-		Identifier: s.Identifier(),
-		Outgoing:   "b",
-		Incoming:   "c",
-		Expires:    time.Now().Add(20 * time.Millisecond),
-	})
-	require.NoError(t, err)
-	<-time.After(21 * time.Millisecond)
-
-	// The pause should be "not found"
-	err = sm.ConsumePause(ctx, pauseID)
-	require.NotNil(t, err)
-	require.ErrorIs(t, err, state.ErrPauseNotFound)
-
-	// And finally, a pause that is OnTimeout should enqueue an edge.
-	pauseID = uuid.New()
-	pre := time.Now()
-	err = sm.SavePause(ctx, state.Pause{
-		ID:         pauseID,
-		Identifier: s.Identifier(),
-		Outgoing:   "c",
-		Incoming:   "d",
-		Expires:    time.Now().Add(20 * time.Millisecond),
-		OnTimeout:  true,
-	})
-	require.NoError(t, err)
-
-	select {
-	case next := <-sm.Channel():
-		require.WithinDuration(
-			t,
-			pre,
-			time.Now().Add(-20*time.Millisecond),
-			5*time.Millisecond,
-		)
-		require.EqualValues(
-			t,
-			inngest.Edge{
-				Outgoing: "c",
-				Incoming: "d",
-			},
-			next.Payload.(queue.PayloadEdge).Edge,
-		)
-	case <-time.After(time.Second):
-		t.Fatalf("Didn't receive enqueued item on pause timeout")
-	}
 }


### PR DESCRIPTION
This commit introduces a new queue item for asynchronous edge timeouts.

When specifying functions, it's possible for you to specify that the
edge between steps should only be traversed if a matching event is
received within a time period.  This is easy:  we save a pause, and for
each event resume matching pauses.

You can also specify edges that must be traversed if this event is _not_
received.

This PR adds:

- A new Queue item to be executed when the edge's TTL occurs.
- A new Queue handler to check for the expired - but unconsumed - pause
  at TTL.  If present, we traverse the step via enqueueing the step.
- A state method for loading pauses by ID, including recently expired
  pauses.

We also include new test harness methods for the state harness.