### PR TITLE
Improve test config sqs start.sh

### DIFF
--- a/tests/configs.go
+++ b/tests/configs.go
@@ -69,7 +69,7 @@ func (c *Config) Validate(ctx context.Context) error {
 func (c *Config) Up(ctx context.Context) error {
 	// Run start.sh, to pre-up the config.
 	fmt.Println("> Running start.sh")
-	start := exec.Command("/bin/sh", "-c", fmt.Sprintf("cd %s && ./start.sh", c.dir))
+	start := exec.Command("/bin/bash", "-c", fmt.Sprintf("cd %s && ./start.sh", c.dir))
 	if out, err := start.CombinedOutput(); err != nil {
 		return cmdError{err: fmt.Errorf("error running start.sh: %w", err), out: out}
 	}

--- a/tests/configs/sqs/start.sh
+++ b/tests/configs/sqs/start.sh
@@ -3,14 +3,12 @@ set -e
 
 docker-compose -f ./opt/compose.yml up -d
 
-end=$((SECONDS+60))
-
-while [ $SECONDS -lt $end ]; do
+for i in {1..120}; do
 	echo "check"
 	# There shold be 6 lines with 2 queues made.
-	num=$(docker exec -ti localstack_main sh -c 'awslocal sqs list-queues' | wc -l)
-	if [ $num -gt 5 ];
-	then
+	num=$(docker exec localstack_main sh -c 'awslocal sqs list-queues' | wc -l)
+	if [ $num -gt 5 ]; then
 		exit
 	fi;
+	sleep 1;
 done

--- a/tests/testdeps.go
+++ b/tests/testdeps.go
@@ -29,12 +29,11 @@ func (TestDeps) MatchString(pat, str string) (result bool, err error) {
 	return matchRe.MatchString(str), nil
 }
 
-func (TestDeps) StartCPUProfile(w io.Writer) error { return pprof.StartCPUProfile(w) }
-func (TestDeps) StopCPUProfile()                   { pprof.StopCPUProfile() }
-func (TestDeps) ImportPath() string                { return "" }
-
 //func (TestDeps) StartTestLog(io.Writer)                                     {}
 //func (TestDeps) StopTestLog() error                                         { return nil }
+func (TestDeps) StartCPUProfile(w io.Writer) error                          { return pprof.StartCPUProfile(w) }
+func (TestDeps) StopCPUProfile()                                            { pprof.StopCPUProfile() }
+func (TestDeps) ImportPath() string                                         { return "" }
 func (TestDeps) RunFuzzWorker(fn func(corpusEntry corpusEntry) error) error { return nil }
 func (TestDeps) ReadCorpus(string, []reflect.Type) ([]corpusEntry, error)   { return nil, nil }
 func (TestDeps) SetPanicOnExit0(bool)                                       {}


### PR DESCRIPTION
Small thing I noticed while testing:  the SQS up script had a `-ti` flag which fails when executing via go tests, as we're not in a TTY.  That, and I made the script a little dumber.