### PR TITLE
Add env var expansion into configuration files

### DIFF
--- a/cmd/commands/serve.go
+++ b/cmd/commands/serve.go
@@ -21,7 +21,7 @@ import (
 const (
 	ServeExecutor = "executor"
 	ServeRunner   = "runner"
-	ServeEventAPI = "events-api"
+	ServeEventAPI = "event-api"
 	ServeCoreAPI  = "core-api"
 )
 
@@ -47,6 +47,15 @@ func NewCmdServe() *cobra.Command {
 
 func serve(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
+
+	if len(args) == 0 {
+		fmt.Println("\nYou must supply one of the following services to serve:")
+		for _, svc := range serveArgs {
+			fmt.Printf("\t%s\n", svc)
+		}
+		fmt.Println("")
+		os.Exit(1)
+	}
 
 	locs := []string{}
 	if serveConf != "" {

--- a/hosting-stacks/aws-managed/main.tf
+++ b/hosting-stacks/aws-managed/main.tf
@@ -244,7 +244,7 @@ resource "aws_ecs_task_definition" "eventapi" {
       cpu       = 512
       memory    = 1024
       essential = true
-      command   = ["inngest", "serve", "events-api"]
+      command   = ["inngest", "serve", "event-api"]
       portMappings = [
         {
           containerPort = 80

--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -93,10 +93,13 @@ func read(ctx context.Context, path string) (*Config, error) {
 
 // parse parses configuration and returns the parsed config.
 func Parse(input []byte) (*Config, error) {
+	// We want to interpolate environment variables within our configuration file.
+	str := os.ExpandEnv(string(input))
+
 	cuedefs.Lock()
 	defer cuedefs.Unlock()
 
-	i, err := prepare(input)
+	i, err := prepare([]byte(str))
 	if err != nil {
 		return nil, err
 	}

--- a/tests/configs.go
+++ b/tests/configs.go
@@ -86,7 +86,7 @@ func (c *Config) Up(ctx context.Context) error {
 	// w := io.MultiWriter(buf, os.Stderr)
 
 	c.out = buf
-	c.inngest = exec.CommandContext(ctx, "inngest", "serve", "-c", filepath.Join(c.dir, "config.cue"), "runner", "executor", "events-api")
+	c.inngest = exec.CommandContext(ctx, "inngest", "serve", "-c", filepath.Join(c.dir, "config.cue"), "runner", "executor", "event-api")
 	c.inngest.Env = os.Environ()
 	c.inngest.Stderr = buf
 	c.inngest.Stdout = buf


### PR DESCRIPTION
This lets users add a standard config file without secrets,
interpolating items at runtime.

Closes https://github.com/inngest/inngest/issues/164/