### PR TITLE
Add a "devcontainer" config for GitHub Codespaces and local VSCode Remote usage

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/go/.devcontainer/base.Dockerfile
+
+# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.18, 1.17, 1-bullseye, 1.18-bullseye, 1.17-bullseye, 1-buster, 1.18-buster, 1.17-buster
+ARG VARIANT="1.18-bullseye"
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+
+# Additional OS packages
+RUN echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list \
+  && apt-get update && export DEBIAN_FRONTEND=noninteractive \
+  && apt-get -y install --no-install-recommends curl build-essential goreleaser
+
+# Non-apt installs for user (go, Node, etc)
+USER vscode
+RUN go install cuelang.org/go/cmd/cue@latest
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/go
 {
-  "name": "Go",
+  "name": "inngest/inngest",
   "build": {
     "dockerfile": "Dockerfile",
     "args": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,8 @@
         "golang.Go",
         "brody715.vscode-cuelang",
         "HashiCorp.terraform",
-        "ms-azuretools.vscode-docker"
+        "ms-azuretools.vscode-docker",
+        "GraphQL.vscode-graphql"
       ]
     }
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,8 @@
       "extensions": [
         "golang.Go",
         "brody715.vscode-cuelang",
-        "HashiCorp.terraform"
+        "HashiCorp.terraform",
+        "HashiCorp.HCL"
       ]
     }
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,8 @@
         "golang.Go",
         "brody715.vscode-cuelang",
         "HashiCorp.terraform",
-        "HashiCorp.HCL"
+        "HashiCorp.HCL",
+        "ms-azuretools.vscode-docker"
       ]
     }
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,48 +1,44 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/go
 {
-	"name": "Go",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"args": {
-			// Update the VARIANT arg to pick a version of Go: 1, 1.18, 1.17
-			// Append -bullseye or -buster to pin to an OS version.
-			// Use -bullseye variants on local arm64/Apple Silicon.
-			"VARIANT": "1-bullseye"
-		}
-	},
-	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+  "name": "Go",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      // Update the VARIANT arg to pick a version of Go: 1, 1.18, 1.17
+      // Append -bullseye or -buster to pin to an OS version.
+      // Use -bullseye variants on local arm64/Apple Silicon.
+      "VARIANT": "1-bullseye"
+    }
+  },
+  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
 
-	// Configure tool-specific properties.
-	"customizations": {
-		// Configure properties specific to VS Code.
-		"vscode": {
-			// Set *default* container specific settings.json values on container create.
-			"settings": {
-				"go.toolsManagement.checkForUpdates": "local",
-				"go.useLanguageServer": true,
-				"go.gopath": "/go"
-			},
+  // Configure tool-specific properties.
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {
+        "go.toolsManagement.checkForUpdates": "local",
+        "go.useLanguageServer": true,
+        "go.gopath": "/go"
+      },
 
-			// Add the IDs of extensions you want installed when the container is created.
-			"extensions": [
-				"golang.Go",
-				"nickgo.cuelang",
-				"HashiCorp.terraform"
-			]
-		}
-	},
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": ["golang.Go", "nickgo.cuelang", "HashiCorp.terraform"]
+    }
+  },
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "go version",
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "go version",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode",
-	"features": {
-		"docker-from-docker": "20.10",
-		"git": "os-provided"
-	}
+  // Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "vscode",
+  "features": {
+    "docker-from-docker": "20.10",
+    "git": "os-provided"
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,48 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/go
+{
+	"name": "Go",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update the VARIANT arg to pick a version of Go: 1, 1.18, 1.17
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use -bullseye variants on local arm64/Apple Silicon.
+			"VARIANT": "1-bullseye"
+		}
+	},
+	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Set *default* container specific settings.json values on container create.
+			"settings": {
+				"go.toolsManagement.checkForUpdates": "local",
+				"go.useLanguageServer": true,
+				"go.gopath": "/go"
+			},
+
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"golang.Go",
+				"nickgo.cuelang",
+				"HashiCorp.terraform"
+			]
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "go version",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+		"docker-from-docker": "20.10",
+		"git": "os-provided"
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,11 @@
       },
 
       // Add the IDs of extensions you want installed when the container is created.
-      "extensions": ["golang.Go", "nickgo.cuelang", "HashiCorp.terraform"]
+      "extensions": [
+        "golang.Go",
+        "brody715.vscode-cuelang",
+        "HashiCorp.terraform"
+      ]
     }
   },
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,6 @@
         "golang.Go",
         "brody715.vscode-cuelang",
         "HashiCorp.terraform",
-        "HashiCorp.HCL",
         "ms-azuretools.vscode-docker"
       ]
     }


### PR DESCRIPTION
## Summary

Adds a `devcontainer.json` file (see [Developing inside a Container using Visual Studio Code Remote Development](https://code.visualstudio.com/docs/remote/containers)) to allow us to use GitHub Codespaces or a local Docker container to spin up a dev environment with all of the required tooling.

Broadly, the devcontainer will provide:

- Go 1.18
- Cue CLI
- "Docker-from-Docker" via [Moby](https://mobyproject.org) for builds
- GoReleaser CLI
- `golangci-lint` CLI
- Some common VSCode extensions to ensure we get formatting, IntelliSense, and highlighting for the different parts of the code
  - [Go](https://marketplace.visualstudio.com/items?itemName=golang.Go)
  - [vscode-cuelang](https://marketplace.visualstudio.com/items?itemName=brody715.vscode-cuelang)
  - [HashiCorp Terraform](https://marketplace.visualstudio.com/items?itemName=HashiCorp.terraform)
    > This one might be a bit overkill as it introduces a lot of panels etc for deploying; we only want it for syntax highlighting.
  - [Docker](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker)
  - [GraphQL](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql)

### Aside

It may also be worth noting down some of the tooling and some short steps in the `# Contribution` section of the docs so that folks can get up-and-running quickly when they find a change to make?