### PR TITLE
Make cmd/run utilize the new execution serivce & state interfaces

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -98,14 +98,15 @@ func (e *Execution) UnmarshalJSON(byt []byte) error {
 	e.LogOutput = names.LogOutput
 
 	for runtime, driver := range names.Drivers {
-		iface, ok := registration.RegisteredDrivers()[driver.Name]
+		f, ok := registration.RegisteredDrivers()[driver.Name]
 		if !ok {
 			return fmt.Errorf("unknown driver: %s", driver.Name)
 		}
+
+		iface := f()
 		if err := json.Unmarshal(driver.Raw, iface); err != nil {
 			return err
 		}
-
 		res, _ := iface.(registration.DriverConfig)
 		if runtime != res.RuntimeName() {
 			// Ensure the driver can run the given runtime.

--- a/pkg/config/queue.go
+++ b/pkg/config/queue.go
@@ -24,11 +24,12 @@ func (q *QueueService) UnmarshalJSON(byt []byte) error {
 	}
 	q.Backend = data.Backend
 
-	iface, ok := registration.RegisteredQueues()[q.Backend]
+	f, ok := registration.RegisteredQueues()[q.Backend]
 	if !ok {
 		return fmt.Errorf("unknown queue backend: %s", q.Backend)
 	}
 
+	iface := f()
 	if err := json.Unmarshal(byt, iface); err != nil {
 		return err
 	}

--- a/pkg/config/registration/registration.go
+++ b/pkg/config/registration/registration.go
@@ -10,40 +10,43 @@ import (
 
 var (
 	// registeredDrivers stores all registered driver configurations.
-	registeredDrivers = map[string]any{}
+	registeredDrivers = map[string]func() any{}
 
-	registeredQueues = map[string]any{}
+	registeredQueues = map[string]func() any{}
 
-	registeredStates = map[string]any{}
+	registeredStates = map[string]func() any{}
 )
 
-func RegisteredDrivers() map[string]any {
+func RegisteredDrivers() map[string]func() any {
 	return registeredDrivers
 }
 
-func RegisteredQueues() map[string]any {
+func RegisteredQueues() map[string]func() any {
 	return registeredQueues
 }
 
-func RegisteredStates() map[string]any {
+func RegisteredStates() map[string]func() any {
 	return registeredStates
 }
 
 // RegisterDriver registers a driver's configuration for use with
 // self-hosted services.
-func RegisterDriver(c DriverConfig) {
+func RegisterDriver(f func() any) {
 	// Overwrite any previous drivers.
-	registeredDrivers[c.DriverName()] = c
+	driver := f().(DriverConfig)
+	registeredDrivers[driver.DriverName()] = f
 }
 
 // RegisterQueue registers a queue for use within self hosted services/
-func RegisterQueue(c QueueConfig) {
-	registeredQueues[c.QueueName()] = c
+func RegisterQueue(f func() any) {
+	driver := f().(QueueConfig)
+	registeredQueues[driver.QueueName()] = f
 }
 
 // RegisterState registers a state manager for use within self hosted services/
-func RegisterState(c StateConfig) {
-	registeredStates[c.StateName()] = c
+func RegisterState(f func() any) {
+	driver := f().(StateConfig)
+	registeredStates[driver.StateName()] = f
 }
 
 // DriverConfig is an interface used to determine driver config structs.

--- a/pkg/config/state.go
+++ b/pkg/config/state.go
@@ -24,10 +24,11 @@ func (s *StateService) UnmarshalJSON(byt []byte) error {
 	}
 	s.Backend = data.Backend
 
-	iface, ok := registration.RegisteredStates()[s.Backend]
+	f, ok := registration.RegisteredStates()[s.Backend]
 	if !ok {
 		return fmt.Errorf("unknown state backend: %s", s.Backend)
 	}
+	iface := f()
 	if err := json.Unmarshal(byt, iface); err != nil {
 		return err
 	}

--- a/pkg/cuedefs/config/config.cue
+++ b/pkg/cuedefs/config/config.cue
@@ -3,7 +3,7 @@ package config
 // Config defines the top-level config for all services.
 #Config: {
 	log: {
-		level:  ("trace" | "debug" | "info" | "warn") | *"info"
+		level:  ("trace" | "debug" | "info" | "warn" | "error") | *"info"
 		format: "json" | *"json"
 	}
 

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -18,7 +18,7 @@ type Event struct {
 	Version   string `json:"v,omitempty"`
 }
 
-func (evt *Event) Map() map[string]interface{} {
+func (evt Event) Map() map[string]interface{} {
 	if evt.Data == nil {
 		evt.Data = make(map[string]interface{})
 	}

--- a/pkg/execution/driver/dockerdriver/config.go
+++ b/pkg/execution/driver/dockerdriver/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	registration.RegisterDriver(&Config{})
+	registration.RegisterDriver(func() any { return &Config{} })
 }
 
 // Config represents driver configuration for use when configuring hosted

--- a/pkg/execution/driver/httpdriver/config.go
+++ b/pkg/execution/driver/httpdriver/config.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	registration.RegisterDriver(&Config{})
+	registration.RegisterDriver(func() any { return &Config{} })
 }
 
 // Config represents driver configuration for use when configuring hosted

--- a/pkg/execution/driver/mockdriver/mockdriver.go
+++ b/pkg/execution/driver/mockdriver/mockdriver.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	registration.RegisterDriver(&Config{})
+	registration.RegisterDriver(func() any { return &Config{} })
 }
 
 const RuntimeName = "mock"

--- a/pkg/execution/executor/service_test.go
+++ b/pkg/execution/executor/service_test.go
@@ -1,0 +1,347 @@
+package executor
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest-cli/inngest"
+	"github.com/inngest/inngest-cli/pkg/config"
+	_ "github.com/inngest/inngest-cli/pkg/config/defaults"
+	"github.com/inngest/inngest-cli/pkg/coredata"
+	"github.com/inngest/inngest-cli/pkg/event"
+	"github.com/inngest/inngest-cli/pkg/execution/driver/mockdriver"
+	"github.com/inngest/inngest-cli/pkg/execution/queue"
+	"github.com/inngest/inngest-cli/pkg/execution/state"
+	"github.com/inngest/inngest-cli/pkg/function"
+	"github.com/inngest/inngest-cli/pkg/service"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	timeout = 50 * time.Millisecond
+	buffer  = 10 * time.Millisecond
+)
+
+type prepared struct {
+	c  *config.Config
+	q  queue.Queue
+	sm state.Manager
+	al coredata.ExecutionLoader
+	f  function.Function
+	w  inngest.Workflow
+}
+
+var (
+	syncF = function.Function{
+		ID:   "test",
+		Name: "test",
+		Triggers: []function.Trigger{
+			{
+				EventTrigger: &function.EventTrigger{
+					Event: "test-evt",
+				},
+			},
+		},
+		Steps: map[string]function.Step{
+			"1": {
+				ID: "1",
+				Runtime: inngest.RuntimeWrapper{
+					Runtime: &mockdriver.Mock{},
+				},
+			},
+			"2": {
+				ID: "2",
+				Runtime: inngest.RuntimeWrapper{
+					Runtime: &mockdriver.Mock{},
+				},
+				After: []function.After{
+					{Step: "1"},
+				},
+			},
+			"3": {
+				ID: "3",
+				Runtime: inngest.RuntimeWrapper{
+					Runtime: &mockdriver.Mock{},
+				},
+				After: []function.After{
+					{
+						Step: "2",
+					},
+				},
+			},
+		},
+	}
+	asyncF = function.Function{
+		ID:   "test",
+		Name: "test",
+		Triggers: []function.Trigger{
+			{
+				EventTrigger: &function.EventTrigger{
+					Event: "test-evt",
+				},
+			},
+		},
+		Steps: map[string]function.Step{
+			"1": {
+				ID: "1",
+				Runtime: inngest.RuntimeWrapper{
+					Runtime: &mockdriver.Mock{},
+				},
+				After: []function.After{
+					{
+						Step: inngest.TriggerName,
+						Async: &inngest.AsyncEdgeMetadata{
+							TTL:   timeout.String(),
+							Event: "async/continue",
+						},
+					},
+				},
+			},
+			"2": {
+				ID: "2",
+				Runtime: inngest.RuntimeWrapper{
+					Runtime: &mockdriver.Mock{},
+				},
+				After: []function.After{
+					{
+						Step: inngest.TriggerName,
+						Async: &inngest.AsyncEdgeMetadata{
+							TTL:   timeout.String(),
+							Event: "async/do-not-continue",
+							// This should run, as the do-not-continue is not
+							// sent and we should time out.
+							OnTimeout: true,
+						},
+					},
+				},
+			},
+			"3": {
+				ID: "3",
+				Runtime: inngest.RuntimeWrapper{
+					Runtime: &mockdriver.Mock{},
+				},
+				After: []function.After{
+					{
+						Step: inngest.TriggerName,
+						Async: &inngest.AsyncEdgeMetadata{
+							TTL:   timeout.String(),
+							Event: "async/do-not-continue",
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+func prepare(ctx context.Context, t *testing.T, f function.Function) prepared {
+	t.Helper()
+
+	// Create a new state manager and queue, in-memory
+	c, err := config.Default(ctx)
+	require.NoError(t, err)
+	sm, err := c.State.Service.Concrete.Manager(ctx)
+	require.NoError(t, err)
+	q, err := c.Queue.Service.Concrete.Queue()
+	require.NoError(t, err)
+
+	w, err := f.Workflow(ctx)
+	require.NoError(t, err)
+
+	// Create a new execution environment.
+	al := &coredata.MemoryExecutionLoader{}
+	err = al.SetFunctions(ctx, []*function.Function{&f})
+	require.NoError(t, err)
+
+	return prepared{
+		c:  c,
+		q:  q,
+		sm: sm,
+		al: al,
+		f:  f,
+		w:  *w,
+	}
+}
+
+func TestPre(t *testing.T) {
+	ctx := context.Background()
+	prepared := prepare(ctx, t, syncF)
+	// Create a new service.
+	svc := NewService(*prepared.c)
+	// This should return nil
+	err := svc.Pre(ctx)
+	require.NoError(t, err)
+}
+
+func TestHandleQueueItemTriggerService(t *testing.T) {
+	// We assume that when handling the trigger, the pending count already
+	// has a pending count of 1.
+	ctx := context.Background()
+	data := prepare(ctx, t, syncF)
+	data.c.Execution.Drivers["mock"] = &mockdriver.Config{
+		Responses: map[string]state.DriverResponse{
+			"1": {Output: map[string]interface{}{"id": 1}},
+		},
+	}
+	svc := NewService(*data.c, WithExecutionLoader(data.al))
+
+	go func() {
+		err := service.Start(ctx, svc)
+		require.NoError(t, err)
+	}()
+
+	// Create a new run.
+	id := state.Identifier{
+		WorkflowID: data.w.UUID,
+		RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
+	}
+
+	_, err := data.sm.New(ctx, data.w, id, (event.Event{
+		Name: "test",
+		Data: map[string]interface{}{
+			"data": "ya",
+		},
+	}).Map())
+	require.NoError(t, err)
+
+	// Require that we have a pending count.
+	run, err := data.sm.Load(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, 1, run.Metadata().Pending)
+
+	// Publish an entry to the queue.
+	err = data.q.Enqueue(ctx, queue.Item{
+		Kind:       queue.KindEdge,
+		Identifier: id,
+		Payload:    queue.PayloadEdge{Edge: inngest.SourceEdge},
+	}, time.Now())
+	require.NoError(t, err)
+
+	// This should execute all of our items.
+	<-time.After(buffer)
+
+	run, err = data.sm.Load(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, 3, len(run.Actions()))
+	require.Equal(t, 0, run.Metadata().Pending)
+}
+
+// TestHandleAsync ensures correctness when hitting an async edge.  Technically,
+// once we hit an async edge we need to:
+//
+// - Insert a Pause for the async expression
+// - Increase the Pending count, as the async edge is pending until either timeout
+//   or the event is received.
+func TestHandleAsyncService(t *testing.T) {
+	// We assume that when handling the trigger, the pending count already
+	// has a pending count of 1.
+	ctx := context.Background()
+	data := prepare(ctx, t, asyncF)
+	data.c.Execution.Drivers["mock"] = &mockdriver.Config{
+		Responses: map[string]state.DriverResponse{
+			"1": {Output: map[string]interface{}{"id": 1}},
+			"2": {Output: map[string]interface{}{"id": 2}},
+			"3": {Err: fmt.Errorf("should not run")},
+		},
+	}
+
+	// Ensure that we add async expressions.
+
+	svc := NewService(*data.c, WithExecutionLoader(data.al))
+	go func() {
+		err := service.Start(ctx, svc)
+		require.NoError(t, err)
+	}()
+
+	// Create a new run.
+	id := state.Identifier{
+		WorkflowID: data.w.UUID,
+		RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
+	}
+
+	_, err := data.sm.New(ctx, data.w, id, (event.Event{
+		Name: "test",
+		Data: map[string]interface{}{
+			"data": "ya",
+		},
+	}).Map())
+	require.NoError(t, err)
+
+	// Require that we have a pending count.
+	run, err := data.sm.Load(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, 1, run.Metadata().Pending)
+
+	// Publish an entry to the queue.
+	err = data.q.Enqueue(ctx, queue.Item{
+		Kind:       queue.KindEdge,
+		Identifier: id,
+		Payload:    queue.PayloadEdge{Edge: inngest.SourceEdge},
+	}, time.Now())
+	require.NoError(t, err)
+
+	// This should execute all of our items.
+	<-time.After(buffer)
+
+	// We should have only executed the trigger, with no responses saved
+	// and 3 pending.
+	//
+	// This is because all child actions require an event.
+	run, err = data.sm.Load(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(run.Actions()))
+	require.Equal(t, 3, run.Metadata().Pending)
+
+	pauses, err := data.sm.PausesByEvent(ctx, "async/continue")
+	require.NoError(t, err)
+	require.True(t, pauses.Next(ctx))
+	pause := pauses.Val(ctx)
+
+	// Pretend that we received an "async/continue" event via the runner.
+	err = data.sm.ConsumePause(ctx, pause.ID)
+	require.NoError(t, err)
+	err = data.q.Enqueue(
+		ctx,
+		queue.Item{
+			Kind:       queue.KindEdge,
+			Identifier: pause.Identifier,
+			Payload: queue.PayloadEdge{
+				Edge: inngest.Edge{
+					Incoming: pause.Incoming,
+				},
+			},
+		},
+		time.Now(),
+	)
+	require.NoError(t, err)
+
+	<-time.After(buffer)
+
+	// We should have exected the first pause.
+	//
+	// This is because all child actions require an event.
+	run, err = data.sm.Load(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(run.Actions()))
+	require.EqualValues(t, map[string]map[string]interface{}{
+		"1": {"id": 1},
+	}, run.Actions())
+	require.Equal(t, 2, run.Metadata().Pending)
+
+	// And then, after timing out of the async do not continue event,
+	// our counter should be 0 and we should have only the timeout event
+	// stored
+	<-time.After(timeout + buffer)
+	run, err = data.sm.Load(ctx, id)
+	require.NoError(t, err)
+	require.EqualValues(t, map[string]map[string]interface{}{
+		"1": {"id": 1},
+		"2": {"id": 2},
+	}, run.Actions())
+	require.Equal(t, 0, run.Metadata().Pending)
+
+}

--- a/pkg/execution/queue/inmemoryqueue/inmemory.go
+++ b/pkg/execution/queue/inmemoryqueue/inmemory.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	registration.RegisterQueue(&Config{})
+	registration.RegisterQueue(func() any { return &Config{} })
 }
 
 type Config struct {
@@ -18,6 +18,11 @@ type Config struct {
 
 	// mem stores a pointer to memory, acting as a singleton per Config
 	// instance created.
+	//
+	// We need to create "local" singletons per config struct in order to
+	// parallelize and unit test these correctly;  with a global singleton
+	// we may have unexpected data within our in-memory queue during parallel
+	// tests.
 	mem *mem
 }
 
@@ -32,6 +37,7 @@ func (c *Config) Queue() (queue.Queue, error) {
 			q: make(chan queue.Item),
 		}
 	}
+
 	return c.mem, nil
 }
 

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -85,6 +85,10 @@ type PayloadEdge struct {
 
 // PayloadPauseTimeout is the payload stored when enqueueing a pause timeout, eg.
 // a future task to check whether an event has been received yet.
+//
+// This is always enqueued from any async match;  we must correctly decrement the
+// pending count in cases where the event is not received.
 type PayloadPauseTimeout struct {
-	PauseID uuid.UUID `json:"pauseID"`
+	PauseID   uuid.UUID `json:"pauseID"`
+	OnTimeout bool      `json:"onTimeout"`
 }

--- a/pkg/execution/queue/sqsqueue/sqsqueue.go
+++ b/pkg/execution/queue/sqsqueue/sqsqueue.go
@@ -18,7 +18,7 @@ import (
 )
 
 func init() {
-	registration.RegisterQueue(&Config{})
+	registration.RegisterQueue(func() any { return &Config{} })
 }
 
 type Config struct {

--- a/pkg/execution/state/inmemory/inmemory.go
+++ b/pkg/execution/state/inmemory/inmemory.go
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	registration.RegisterState(&Config{})
+	registration.RegisterState(func() any { return &Config{} })
 }
 
 // Config registers the configuration for the in-memory state store,
@@ -70,6 +70,7 @@ func (m *mem) New(ctx context.Context, workflow inngest.Workflow, id state.Ident
 	s := memstate{
 		metadata: state.Metadata{
 			StartedAt: time.Now(),
+			Pending:   1,
 		},
 		workflow:   workflow,
 		identifier: id,

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -22,7 +22,7 @@ const (
 )
 
 func init() {
-	registration.RegisterState(&Config{})
+	registration.RegisterState(func() any { return &Config{} })
 }
 
 // Config registers the configuration for the in-memory state store,
@@ -175,6 +175,7 @@ func (m mgr) New(ctx context.Context, workflow inngest.Workflow, id state.Identi
 	metadata := runMetadata{
 		Version:   workflow.Version,
 		CreatedAt: time.Now().Truncate(time.Second),
+		Pending:   1,
 	}
 
 	// We marshal this ahead of creating a redis transaction as it's necessary

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -128,6 +128,8 @@ type State interface {
 	// for the given run.
 	Workflow() inngest.Workflow
 
+	// Metadata returns the run metadata, including the started at time
+	// as well as the pending count.
 	Metadata() Metadata
 
 	// Identifier returns the identifier for this particular run, which

--- a/pkg/function/config.go
+++ b/pkg/function/config.go
@@ -68,7 +68,7 @@ func Load(ctx context.Context, dir string) (*Function, error) {
 	if err != nil {
 		return nil, err
 	}
-	return Unmarshal(ctx, byt, abs)
+	return Unmarshal(ctx, byt, json)
 }
 
 func LoadRecursive(ctx context.Context, dir string) ([]*Function, error) {

--- a/tests/testdsl/testdsl.go
+++ b/tests/testdsl/testdsl.go
@@ -54,10 +54,13 @@ func SendTrigger(ctx context.Context, td *TestData) error {
 	fmt.Println("> Sending trigger")
 
 	var err error
-	td.TriggerData, err = function.GenerateTriggerData(ctx, time.Now().Unix(), td.Fn.Triggers)
+	evt, err := function.GenerateTriggerData(ctx, time.Now().Unix(), td.Fn.Triggers)
 	if err != nil {
 		return fmt.Errorf("error generating trigger data: %w", err)
 	}
+
+	td.TriggerData = evt.Map()
+
 	byt, _ := json.Marshal(td.TriggerData)
 	resp, err := http.Post(
 		fmt.Sprintf("http://%s:%d/e/key", td.Config.EventAPI.Addr, td.Config.EventAPI.Port),


### PR DESCRIPTION
This commit fixes commands/run and cli/run such that the run UI uses the
new execution service, initializing a new function run via the singleton
in-memory queue.

This replicates the execution environment entirely whilst manually
scheduling the function run (ie. there is no actual runner service).