### PR TITLE
Add stub driver to fix import cycles

### DIFF
--- a/pkg/cuedefs/config/config.cue
+++ b/pkg/cuedefs/config/config.cue
@@ -180,11 +180,7 @@ package config
 
 #Postgres: {
 	backend: "postgres"
-<<<<<<< HEAD
 	URI:     string | *"postgres://localhost:5432/postgres?sslmode=disable"
-=======
-	URI:     string | *"postgres://localhost/test"
->>>>>>> 4827d0e (Add Postgres DataStore. Add DataStore config.)
 }
 
 // Drivers handle execution of each step within a function.

--- a/pkg/function/function.go
+++ b/pkg/function/function.go
@@ -320,6 +320,9 @@ func (f Function) action(ctx context.Context, s Step) (inngest.ActionVersion, er
 		DSN:     id,
 		Runtime: s.Runtime,
 	}
+	if s.Runtime.Runtime == nil {
+		return a, fmt.Errorf("no runtime specified")
+	}
 	if s.Runtime.RuntimeType() != "http" {
 		// Non-HTTP actions can read secrets;  http actions are external APIs and so
 		// don't need secret access.

--- a/pkg/function/function_test.go
+++ b/pkg/function/function_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/inngest/inngest-cli/inngest"
 	"github.com/inngest/inngest-cli/inngest/state"
 	"github.com/inngest/inngest-cli/internal/cuedefs"
-	"github.com/inngest/inngest-cli/pkg/execution/driver/mockdriver"
 	"github.com/stretchr/testify/require"
 )
 
@@ -333,7 +332,7 @@ func TestFunctionActions_single(t *testing.T) {
 				ID:   "single",
 				Name: "single",
 				Runtime: inngest.RuntimeWrapper{
-					Runtime: &mockdriver.Mock{},
+					Runtime: &stubdriver{},
 				},
 			},
 		},

--- a/pkg/function/function_version_test.go
+++ b/pkg/function/function_version_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/inngest/inngest-cli/inngest"
-	"github.com/inngest/inngest-cli/pkg/execution/driver/mockdriver"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,14 +22,14 @@ func TestActions(t *testing.T) {
 				ID:   "first",
 				Name: "first",
 				Runtime: inngest.RuntimeWrapper{
-					Runtime: &mockdriver.Mock{},
+					Runtime: &stubdriver{},
 				},
 			},
 			"second": {
 				ID:   "second",
 				Name: "second",
 				Runtime: inngest.RuntimeWrapper{
-					Runtime: &mockdriver.Mock{},
+					Runtime: &stubdriver{},
 				},
 			},
 		},

--- a/pkg/function/mock_driver_test.go
+++ b/pkg/function/mock_driver_test.go
@@ -1,0 +1,10 @@
+package function
+
+// stubdriver implements inngest.Runtime, as this package cannot import
+// mockdriver due to import cycles.
+type stubdriver struct{}
+
+// RuntimeType fulfiils the inngest.Runtime interface.
+func (s *stubdriver) RuntimeType() string {
+	return "mock"
+}


### PR DESCRIPTION
Unfortunately, centralizing our dependencies to config means that the fn
package cannot import mockdriver.