### PR TITLE
Support deploy command to self-hosted Core API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ cmd/cmd
 target/
 dist/
 testfns/
+
+main

--- a/inngest/client/functions.go
+++ b/inngest/client/functions.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// XXX: To avoid a import cycle (function uses state which uses client),
+// we create a client specific type matching function.FunctionVersion
+type FunctionVersion struct {
+	FunctionID string     `json:"functionId"`
+	Version    int        `json:"version"`
+	Config     string     `json:"config"`
+	ValidFrom  *time.Time `json:"validFrom"`
+	ValidTo    *time.Time `json:"validTo"`
+	CreatedAt  time.Time  `json:"createdAt"`
+	UpdatedAt  time.Time  `json:"updatedAt"`
+}
+
+// DeployFunction deploys a function for a given environment. Live determines if the function is a draft or live.
+func (c httpClient) DeployFunction(ctx context.Context, config string, env string, live bool) (*FunctionVersion, error) {
+	query := `
+		mutation DeployFunction($config: String!, $env: Environment, $live: Boolean) {
+			deployFunction(input: {
+				config: $config
+				env: $env
+				live: $live
+			}) {
+				functionId version config validFrom validTo createdAt updatedAt
+			}
+		}`
+
+	type response struct {
+		DeployFunction *FunctionVersion
+	}
+	resp, err := c.DoGQL(ctx, Params{Query: query, Variables: map[string]interface{}{
+		"config": config,
+		"env":    env,
+		"live":   live,
+	}})
+	if err != nil {
+		return nil, err
+	}
+
+	data := &response{}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		return nil, fmt.Errorf("error unmarshalling function version: %w", err)
+	}
+
+	return data.DeployFunction, nil
+}

--- a/inngest/clistate/clistate.go
+++ b/inngest/clistate/clistate.go
@@ -124,6 +124,10 @@ func AccountID(ctx context.Context) uuid.UUID {
 }
 
 func AccountIdentifier(ctx context.Context) (string, error) {
+	if os.Getenv("INNGEST_DSN_PREFIX") != "" {
+		return os.Getenv("INNGEST_DSN_PREFIX"), nil
+	}
+
 	state, err := GetState(ctx)
 	if err != nil {
 		return "", err
@@ -191,7 +195,7 @@ func Workspace(ctx context.Context) (client.Workspace, error) {
 			return ws, nil
 		}
 	}
-	return client.Workspace{}, fmt.Errorf("No workspace found")
+	return client.Workspace{}, fmt.Errorf("no workspace found")
 }
 
 func RequireState(ctx context.Context) *State {

--- a/pkg/coreapi/coreapi.go
+++ b/pkg/coreapi/coreapi.go
@@ -33,8 +33,8 @@ func NewCoreApi(o Options) (*CoreAPI, error) {
 	}}))
 
 	// TODO - Add option for enabling GraphQL Playground
-	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
-	http.Handle("/query", srv)
+	http.Handle("/", playground.Handler("GraphQL playground", "/gql"))
+	http.Handle("/gql", srv)
 
 	return a, nil
 }

--- a/pkg/coreapi/graph/resolvers/functions.go
+++ b/pkg/coreapi/graph/resolvers/functions.go
@@ -25,8 +25,7 @@ func (r *mutationResolver) DeployFunction(ctx context.Context, input models.Depl
 		return nil, err
 	}
 
-	// TODO convert function to cue config
-	config, err := function.MarshalJSON(fv.Function)
+	config, err := function.MarshalCUE(fv.Function)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/coredata/coredata.go
+++ b/pkg/coredata/coredata.go
@@ -2,6 +2,7 @@ package coredata
 
 import (
 	"context"
+	"errors"
 
 	"github.com/inngest/inngest-cli/inngest"
 	"github.com/inngest/inngest-cli/inngest/client"
@@ -55,3 +56,5 @@ type APIActionWriter interface {
 	// Update an action version, e.g. when updating a Docker image has been successfully pushed to the registry
 	UpdateActionVersion(ctx context.Context, dsn string, version inngest.VersionInfo, enabled bool) (client.ActionVersion, error)
 }
+
+var ErrActionVersionNotFound error = errors.New("action version not found")

--- a/pkg/coredata/postgres/postgres.go
+++ b/pkg/coredata/postgres/postgres.go
@@ -297,7 +297,7 @@ func (rw *ReadWriter) ActionVersion(ctx context.Context, dsn string, version *in
 		return client.ActionVersion{}, err
 	}
 	if err == sql.ErrNoRows {
-		return client.ActionVersion{}, errors.New("matching action version not found")
+		return client.ActionVersion{}, coredata.ErrActionVersionNotFound
 	}
 	av.Version = &v
 
@@ -323,9 +323,8 @@ func (rw *ReadWriter) CreateActionVersion(ctx context.Context, av inngest.Action
 		return client.ActionVersion{}, err
 	}
 
-	created := client.ActionVersion{
-		ActionVersion: av,
-	}
+	created := client.ActionVersion{}
+	created.ActionVersion = av
 
 	if created.Version == nil {
 		return client.ActionVersion{}, errors.New("version must not be empty")

--- a/pkg/execution/driver/dockerdriver/push.go
+++ b/pkg/execution/driver/dockerdriver/push.go
@@ -11,7 +11,8 @@ import (
 )
 
 const (
-	DefaultRegistryHost = "registry.inngest.com"
+	DefaultRegistryHost   = "registry.inngest.com"
+	DockerHubRegistryHost = "https://index.docker.io/v1/"
 )
 
 // Digest returns the image digest for a given action.
@@ -56,6 +57,21 @@ func Push(ctx context.Context, a inngest.ActionVersion, creds []byte) (string, e
 	}
 
 	image := fmt.Sprintf("%s/%s", host, a.DSN)
+	auth := docker.AuthConfiguration{
+		Username: "jwt",
+		Password: string(creds),
+	}
+
+	// XXX: Need to handle formatting more consistency and remove specific cases
+	if host == DockerHubRegistryHost {
+		image = a.DSN
+		dockerConfig, err := docker.NewAuthConfigurationsFromCredsHelpers(host)
+		if err != nil {
+			return "", err
+		}
+		auth = *dockerConfig
+	}
+
 	err = c.TagImage(imageTag, docker.TagImageOptions{
 		Repo: image,
 		Tag:  a.Version.Tag(),
@@ -69,10 +85,7 @@ func Push(ctx context.Context, a inngest.ActionVersion, creds []byte) (string, e
 		Tag:          a.Version.Tag(),
 		Registry:     host,
 		OutputStream: os.Stderr,
-	}, docker.AuthConfiguration{
-		Username: "jwt",
-		Password: string(creds),
-	})
+	}, auth)
 
 	return id, err
 }


### PR DESCRIPTION
## Description
This forks the client based on parsing if the `INNGEST_API` environment variable. 

This is a temporary change as we should:

1. Update Inngest Cloud to support all the new GraphQL queries and mutations
2. Create a separate `pkg/coreapi/client` package which can re-use code from the `coreapi` package
3. Use a `config` GraphQL edge to allow the given `INNGEST_API` to configure the cli client, enabling config to be set centrally rather than on the per-client basis. This has the added bonus of allowing us to push configuration on a per-account basis via Inngest Cloud's GraphQL API.

### How to use

The user must currently pass their own `INNGEST_API`, `INNGEST_REGISTRY` and `INNGEST_DSN_PREFIX` to configure where to deploy. The registry and the DSN prefix should be set by the `config` edge in the future. Here's an example using a locally running Core API and Docker Hub with the `inngest` Docker Hub org which will create images with the `inngest/<action-image-name>:<action-version>` tag.

```shell
INNGEST_API="http://127.0.0.1:8300" \
  INNGEST_REGISTRY="https://index.docker.io/v1/" \ 
  INNGEST_DSN_PREFIX="inngest" \
  go run ../../cmd/main.go deploy
```