### PR TITLE
Add traversal of parent directories to find `inngest.json` or `inngest.cue`

### DIFF
--- a/pkg/function/function.go
+++ b/pkg/function/function.go
@@ -334,7 +334,7 @@ func (f Function) action(ctx context.Context, s Step) (inngest.ActionVersion, er
 func (f *Function) canonicalize(ctx context.Context, path string) error {
 	f.dir = path
 	// dir should point to the dir, not the file.
-	if strings.HasSuffix(path, "inngest.json") || strings.HasSuffix(path, "inngest.cue") {
+	if strings.HasSuffix(path, jsonConfigName) || strings.HasSuffix(path, cueConfigName) {
 		f.dir = filepath.Dir(path)
 	}
 


### PR DESCRIPTION
Closes #139.

Adds `func findFileUp(path string) (string, []byte, error)` and refactors config finding slightly in order to have `inngest run` recurse parent directories until it finds an `inngest.json` or `inngest.cue` file.

<details>
<summary>Happy path, with file in current dir or above</summary>

![nested-inngest-run](https://user-images.githubusercontent.com/1736957/180784836-011dffa3-da2c-4f9d-a1b0-f5c878828044.gif)
</details>

<details>
<summary>Error path; searched up to root and no file</summary>

![nested-inngest-run-fail](https://user-images.githubusercontent.com/1736957/180785088-159a355c-784c-46f2-8ace-80ad01945300.gif)
</details>