### PR TITLE
WIP: Debug mode

### DIFF
--- a/inngest/consts.go
+++ b/inngest/consts.go
@@ -1,0 +1,8 @@
+package inngest
+
+import "time"
+
+const (
+	DebugEvent   = "inngest/debug.continue"
+	DebugTimeout = 5 * time.Minute
+)


### PR DESCRIPTION
This commit adds a `--debug` flag (`-d`) which enables debug mode for
running functions locally.  Debug mode swaps each edge out for a `debug`
edge, allowing users to "step over" step functions locally.

This is required for eg. step functions which have delays or coordinate
between events.