### PR TITLE
Add `inngest run --snapshot` (expands on `--event-only`)

### DIFF
--- a/cmd/commands/run.go
+++ b/cmd/commands/run.go
@@ -132,13 +132,6 @@ func doRun(cmd *cobra.Command, args []string) {
 // Will also attempt to read an event from stdin.
 func generatedEventLoader(ctx context.Context, fn function.Function, triggerName string) func() ([]event.Event, error) {
 	return func() ([]event.Event, error) {
-		// If we're generating an event and haven't been given a random seed,
-		// generate one now.
-		if runSeed <= 0 {
-			rand.Seed(time.Now().UnixNano())
-			runSeed = rand.Int63n(1_000_000)
-		}
-
 		fi, err := os.Stdin.Stat()
 		if err != nil {
 			return []event.Event{}, err
@@ -167,6 +160,13 @@ func generatedEventLoader(ctx context.Context, fn function.Function, triggerName
 			}
 
 			return multipleEvents, nil
+		}
+
+		// If we're generating an event and haven't been given a random seed,
+		// generate one now.
+		if runSeed <= 0 {
+			rand.Seed(time.Now().UnixNano())
+			runSeed = rand.Int63n(1_000_000)
 		}
 
 		fakedEvent, err := fakeEvent(ctx, fn, triggerName)


### PR DESCRIPTION
Replaces `inngest run --event-only` with `inngest run --snapshot`, allowing you to retrieve event data from generated or replay events and then replay them later.

- Rename `--event-only` to `--snapshot`
  > Should we keep the flag name the same here?
- Add ability for `inngest run`'s stdin reading to handle multiple lines and arrays of events
- Ensure `--snapshot` can return event data for replayed events as well as generated ones

![2022-08-01 11 32 51](https://user-images.githubusercontent.com/1736957/182130543-7804e1eb-b246-4357-b872-02cea92568a2.gif)

