### PR TITLE
On `npm publish`, include `README.md` from main repo

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -4,7 +4,7 @@
   "description": "The event-driven queue for any language.",
   "license": "SEE LICENSE IN LICENSE.md",
   "scripts": {
-    "prepublishOnly": "mkdir bin && touch bin/inngest",
+    "prepublishOnly": "mkdir bin && touch bin/inngest && cp ../README.md .",
     "postinstall": "node postinstall.js",
     "build": "tsc"
   },


### PR DESCRIPTION
The npm repo [inngest-cli](https://npmjs.com/package/inngest-cli) has no dedicated `README.md`.

We can just steal the main readme for this whenever we publish.