### PR TITLE
Ensure `run` and `dev` use network mode host

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -27,7 +27,7 @@ func NewCmdDev() *cobra.Command {
 
 func doDev(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
-	conf, err := config.Default(ctx)
+	conf, err := config.Dev(ctx)
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/pkg/cli/run.go
+++ b/pkg/cli/run.go
@@ -132,7 +132,12 @@ func (r *RunUI) run(ctx context.Context) {
 		return
 	}
 
-	c, _ := config.Default(ctx)
+	c, err := config.Dev(ctx)
+	if err != nil {
+		r.err = err
+		return
+	}
+
 	// Create a singleton queue for initializing the fn.
 	q, err := c.Queue.Service.Concrete.Producer()
 	if err != nil {
@@ -242,7 +247,6 @@ func (r *RunUI) run(ctx context.Context) {
 					}
 
 					*execution.done = true
-
 					return
 				}
 				<-time.After(time.Millisecond * 5)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,24 @@ import (
 	"github.com/inngest/inngest/pkg/config/registration"
 )
 
+const devConfig = `package main
+
+import (
+	config "inngest.com/defs/config"
+)
+
+config.#Config & {
+	execution: {
+		drivers: {
+			http:   config.#HTTPDriver
+			docker: config.#DockerDriver & {
+				network: "host"
+			}
+		}
+	}
+}
+`
+
 // Load loads the configu from the given locations in order.  If locs is empty,
 // we use the default locations of "./inngest.(cue|json)" and "/etc/inngest.(cue|json)".
 func Load(ctx context.Context, locs ...string) (*Config, error) {
@@ -16,6 +34,10 @@ func Load(ctx context.Context, locs ...string) (*Config, error) {
 
 func Default(ctx context.Context) (*Config, error) {
 	return Parse(nil)
+}
+
+func Dev(ctx context.Context) (*Config, error) {
+	return Parse([]byte(devConfig))
 }
 
 // Config represents configuration for running the Inngest services.

--- a/pkg/cuedefs/config/config.cue
+++ b/pkg/cuedefs/config/config.cue
@@ -193,6 +193,13 @@ package config
 #DockerDriver: {
 	name:  "docker"
 	host?: string
+
+	// network represents the network name to bind to.  Within `inngest run`
+	// and `inngest dev` this is automatically set to "host", ensuring containers
+	// run with access to localhost.
+	//
+	// This is not set by default when self-hosting via `inngest serve`.
+	network?: string | "host"
 }
 
 // MockDriver is used in testing to mock and stub function executions.  You

--- a/pkg/execution/driver/dockerdriver/config.go
+++ b/pkg/execution/driver/dockerdriver/config.go
@@ -14,6 +14,8 @@ func init() {
 // services via config.cue
 type Config struct {
 	Host *string
+
+	Network string
 }
 
 func (c Config) NewDriver() (driver.Driver, error) {
@@ -38,6 +40,7 @@ func (c Config) NewDriver() (driver.Driver, error) {
 
 	return &dockerExec{
 		client: client,
+		config: &c,
 	}, nil
 }
 

--- a/pkg/execution/driver/dockerdriver/dockerdriver.go
+++ b/pkg/execution/driver/dockerdriver/dockerdriver.go
@@ -39,6 +39,7 @@ func New() (driver.Driver, error) {
 
 type dockerExec struct {
 	client *docker.Client
+	config *Config
 }
 
 type handle struct {
@@ -153,6 +154,10 @@ func (d *dockerExec) startOpts(ctx context.Context, state state.State, wa innges
 	name := fmt.Sprintf("%s-%s-%s", state.RunID(), slug.Make(wa.Name), hex.EncodeToString(byt))
 	return docker.CreateContainerOptions{
 		Name: name,
+		HostConfig: &docker.HostConfig{
+			// This driver uses net mode host.
+			NetworkMode: d.config.Network,
+		},
 		Config: &docker.Config{
 			Image: wa.DSN,
 			Cmd:   []string{string(marshalled)},


### PR DESCRIPTION
This ensures that locally our functions can access the host network and
any extra services.