### PR TITLE
Load all workspace events

### DIFF
--- a/inngest/client/events.go
+++ b/inngest/client/events.go
@@ -11,6 +11,11 @@ import (
 	"github.com/oklog/ulid/v2"
 )
 
+var (
+	SchemaSourceCustom      = "custom"
+	SchemaSourceIntegration = "integration"
+)
+
 type PaginatedEvents struct {
 	Page struct {
 		Cursor string

--- a/pkg/cli/initialize/questions.go
+++ b/pkg/cli/initialize/questions.go
@@ -232,16 +232,18 @@ func renderEvent(m *initModel) string {
 		cli.BoldStyle.Render(fmt.Sprintf("%d. Event trigger:", m.transitions)) +
 			cli.TextStyle.Copy().Foreground(cli.Feint).Render(" (enter to continue)") + "\n",
 	)
-	b.WriteString(m.textinput.View() + "\n\n\n")
+	b.WriteString(m.textinput.View() + "\n")
 
 	if m.eventFetchError != nil {
-		b.WriteString("\n" + cli.RenderWarning(fmt.Sprintf("We couldn't fetch your latest events from our API: %s", m.eventFetchError)) + "\n")
+		b.WriteString("\n" + cli.RenderWarning(m.eventFetchError.Error()) + "\n\n")
 	}
 
 	if m.height < 20 {
 		b.WriteString("\n" + cli.RenderWarning("Your TTY doesn't have enough height to render the event browser") + "\n")
 		return b.String()
 	}
+
+	b.WriteString("\n")
 
 	// Render two columns of text.
 	headerMsg := lipgloss.JoinVertical(lipgloss.Center,


### PR DESCRIPTION
This PR changes `init` to return events from all workspaces, then shows
which workspaces the event has been seen within.

In the future we should also show the last seen at date, allowing users
to select recently active events.

Closes #115
Closes #90 