### PR TITLE
npm deployment fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Set up Node/npm
         uses: actions/setup-node@v3
         with:
-          cache: 'npm'
           node-version: 16
       - name: Make sure npm can deploy
         working-directory: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,7 @@ jobs:
           go-version: 1.18
       - name: Set up Node/npm
         uses: actions/setup-node@v3
-        working-directory: npm
         with:
-          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           node-version: 16
       - name: Make sure npm can deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,8 @@ jobs:
       - name: Make sure npm can deploy
         working-directory: npm
         run: |
-          npm install --ignore-scripts
-          npm run build
           npm ci
+          npm run build
         env:
           SKIP_POSTINSTALL: true
       - name: Login to Docker Hub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,10 @@ jobs:
           go-version: 1.18
       - name: Set up Node/npm
         uses: actions/setup-node@v3
+        working-directory: npm
         with:
+          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
-          cache-dependency-path: npm/package-lock.json
           node-version: 16
       - name: Make sure npm can deploy
         working-directory: npm
@@ -55,4 +56,3 @@ jobs:
           npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/npm/.npmrc
+++ b/npm/.npmrc
@@ -1,0 +1,3 @@
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+registry=https://registry.npmjs.org/
+always-auth=true

--- a/npm/postinstall.js
+++ b/npm/postinstall.js
@@ -1,0 +1,6 @@
+/**
+ * Stub postinstall.js file to allow `npm install` to return successfully during
+ * development.
+ *
+ * This file should be overwritten before publishing via `npm run build`.
+ */


### PR DESCRIPTION
This should fix the npm deployment fun - I can babysit it and push it through once we merge.

- Re-adding the stub `postinstall.js` file
  > It's there to ensure we don't have to use `--ignore-scripts`. It's just an empty no-op file, but npm can find and run it all the same during postinstall. I think `--ignore-scripts` disables everything for our dependencies too, so might be breaking something if dependencies also rely on scripts.
- `actions/setup-node` should create an `.npmrc` file that looks and the npm registry and uses `NODE_AUTH_TOKEN` as the secret (hence that env var)
  > I think it probably did add one, but at the project root rather than in the `npm` dir; ~~adding `working-directory: npm` should fix that as well as remove the need for us to specify where the `package-lock.json` file is.~~
  >
  > ~~It does look like this might not work based on [this GitHub Community discussion](https://github.com/orgs/community/discussions/25647), but if that's the case we'll just manually create the `.npmrc` file.~~
  >
  > Added a hard-coded `.npmrc` file to circumvent this.
- Revert back to using `npm ci && npm run build`
  > [`npm ci`](https://docs.npmjs.com/cli/v8/commands/npm-ci) should do a clean install with a frozen lockfile; we should keep that step as the only way we're installing deps.
- Removed caching
  > The deps for this are tiny; we're not going to see any gains anyway atm!