### PR TITLE
Fix `major` version struct tag

### DIFF
--- a/inngest/workflow.go
+++ b/inngest/workflow.go
@@ -124,6 +124,6 @@ type AsyncEdgeMetadata struct {
 // - Minor versions are backwards compatible improvements, fixes, or additions.  We
 //   automatically use the latest minor version within every step function.
 type VersionConstraint struct {
-	Major *uint `json:"version,omitempty"`
+	Major *uint `json:"major,omitempty"`
 	Minor *uint `json:"minor,omitempty"`
 }

--- a/pkg/cuedefs/v1/function.cue
+++ b/pkg/cuedefs/v1/function.cue
@@ -85,8 +85,8 @@ package v1
 	// version is the version constraint for the step when resolving the action to
 	// run.
 	version?: {
-		version?: uint
-		minor?:   uint
+		major?: uint
+		minor?: uint
 	}
 }
 

--- a/pkg/function/config_test.go
+++ b/pkg/function/config_test.go
@@ -381,8 +381,8 @@ function: defs.#Function & {
       step: "$trigger"
     }]
     version: {
-      version: 1
-      minor:   1
+      major: 1
+      minor: 1
     }
   }
 }`

--- a/pkg/function/config_test.go
+++ b/pkg/function/config_test.go
@@ -140,7 +140,7 @@ func TestUnmarshal(t *testing.T) {
 							}
 						],
 						"version": {
-							"version": 2,
+							"major": 2,
 							"minor": 3
 						}
 					}
@@ -273,7 +273,7 @@ func TestUnmarshal(t *testing.T) {
 							},
 						]
 						version: {
-							version: 2
+							major:   2
 							minor:   3
 						}
 					}

--- a/pkg/function/function_test.go
+++ b/pkg/function/function_test.go
@@ -285,8 +285,8 @@ workflow: workflows.#Workflow & {
     name:     "Foo"
     dsn:      "magical-id-step-step-1-test"
     version: {
-      version: 1
-      minor:   1
+      major: 1
+      minor: 1
     }
   }]
   edges: [{


### PR DESCRIPTION
This ensures that the JSON representation of version constraints is consistent.