### PR TITLE
Add `inngest init --template` to clone an existing GitHub-hosted template

### DIFF
--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -129,16 +129,20 @@ func runInit(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		fmt.Println(cli.RenderError(fmt.Sprintf("Error getting current directory: %s", err)) + "\n")
-		return
-	}
+	slug := fn.Slug()
 
-	slug, err := filepath.Rel(cwd, fn.Dir())
-	if err != nil {
-		fmt.Println(cli.RenderError(fmt.Sprintf("Error getting relative path: %s", err)) + "\n")
-		return
+	if template != "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			fmt.Println(cli.RenderError(fmt.Sprintf("Error getting current directory: %s", err)) + "\n")
+			return
+		}
+
+		slug, err = filepath.Rel(cwd, fn.Dir())
+		if err != nil {
+			fmt.Println(cli.RenderError(fmt.Sprintf("Error getting relative path: %s", err)) + "\n")
+			return
+		}
 	}
 
 	fmt.Println(cli.BoldStyle.Copy().Foreground(cli.Green).Render(fmt.Sprintf("🎉 Done!  Your function has been created in ./%s", slug)))

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -115,6 +115,8 @@ func runInit(cmd *cobra.Command, args []string) {
 		tpl = &scaffold.Template{}
 	}
 
+	// Templating should only be done against scaffolds; cloned templates should
+	// be left alone as these will have already cloned and created the directory.
 	if template == "" {
 		var step function.Step
 		for _, v := range fn.Steps {

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -1,9 +1,14 @@
 package commands
 
 import (
+	"context"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
@@ -29,12 +34,15 @@ func NewCmdInit() *cobra.Command {
 	cmd.Flags().StringP("name", "n", "", "The function name")
 	cmd.Flags().String("language", "", "The language to use within your project")
 	cmd.Flags().String("url", "", "The URL to hit, if this function calls an external API")
+	cmd.Flags().StringP("template", "t", "", "The template to use for the function")
 
 	return cmd
 }
 
 func runInit(cmd *cobra.Command, args []string) {
-	if _, err := function.Load(cmd.Context(), "."); err == nil {
+	ctx := cmd.Context()
+
+	if _, err := function.Load(ctx, "."); err == nil {
 		// XXX: We can't both SilenceUsage and SilenceError, so we handle error checking inside
 		// the init function here.
 		fmt.Println("\n" + cli.RenderError("An inngest project already exists in this directory.  Remove the inngest file to continue.") + "\n")
@@ -42,8 +50,74 @@ func runInit(cmd *cobra.Command, args []string) {
 		return
 	}
 
+	// If we've been given a template, skip questions and get straight to trying
+	// to initialize the project.
+	template := cmd.Flag("template").Value.String()
+	var err error
+
+	if template != "" {
+		err = cloneTemplate(ctx, template)
+	} else {
+		err = createNewFunction(ctx, cmd)
+	}
+
+	if err != nil {
+		fmt.Println(cli.RenderError(fmt.Sprintf("%s", err)) + "\n")
+		return
+	}
+}
+
+func cloneTemplate(ctx context.Context, template string) error {
+	// template = [repo]#[path]
+	// ask for =  [fn-name]
+	//
+	// git clone https://[repo].git --depth 1 --no-checkout [fn-name]
+	// cd [fn-name]
+	// git sparse-checkout set [path] --cone
+	// cp -r [path]/* .
+	// rm -r examples/
+
+	fnName := "foo"
+	repo, examplePath, _ := strings.Cut(template, "#")
+	tmpPath, err := os.MkdirTemp("", "inngest-template-*")
+	if err != nil {
+		return err
+	}
+
+	cloneCmd := exec.Command("git", "clone", "https://"+repo+".git", "--depth", "1", tmpPath)
+	err = cloneCmd.Run()
+	if err != nil {
+		return err
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	targetDir := filepath.Join(cwd, fnName)
+
+	onlyOwnerWrite := 0755
+	if err = os.MkdirAll(targetDir, fs.FileMode(onlyOwnerWrite)); err != nil {
+		return err
+	}
+
+	err = os.Rename(filepath.Join(tmpPath, examplePath), targetDir)
+	if err != nil {
+		return fmt.Errorf("Error moving template from temp directory: %s", err)
+	}
+
+	err = os.RemoveAll(tmpPath)
+	if err != nil {
+		fmt.Println("\n" + cli.RenderWarning(fmt.Sprintf("Failed to remove temporary dir after copy: %s", err)) + "\n")
+	}
+
+	return nil
+}
+
+func createNewFunction(ctx context.Context, cmd *cobra.Command) error {
 	showWelcome := true
-	if setting, ok := clistate.GetSetting(cmd.Context(), clistate.SettingRanInit).(bool); ok {
+	if setting, ok := clistate.GetSetting(ctx, clistate.SettingRanInit).(bool); ok {
 		// only show the welcome if we haven't ran init
 		showWelcome = !setting
 	}
@@ -59,28 +133,25 @@ func runInit(cmd *cobra.Command, args []string) {
 		URL:         cmd.Flag("url").Value.String(),
 	})
 	if err != nil {
-		fmt.Println(cli.RenderError(fmt.Sprintf("Error starting init command: %s", err)) + "\n")
-		return
+		return fmt.Errorf("Error starting init command: %s", err)
 	}
 	if err := tea.NewProgram(state).Start(); err != nil {
 		log.Fatal(err)
 	}
 
 	if state.DidQuitEarly() {
-		fmt.Println("\n" + cli.RenderWarning("Quitting without making your function.  Take care!") + "\n")
-		return
+		return fmt.Errorf("Quitting without making your function. Take care!")
 	}
 
 	// Get the function from the state.
-	fn, err := state.Function(cmd.Context())
+	fn, err := state.Function(ctx)
 	if err != nil {
-		fmt.Println(cli.RenderError(fmt.Sprintf("There was an error creating the function: %s", err)) + "\n")
-		return
+		return fmt.Errorf("There was an error creating the function: %s", err)
 	}
 
 	// Save a setting which indicates that we've ran init successfully.
 	// This is used to prevent us from showing the welcome message on subsequent runs.
-	_ = clistate.SaveSetting(cmd.Context(), clistate.SettingRanInit, true)
+	_ = clistate.SaveSetting(ctx, clistate.SettingRanInit, true)
 
 	// If we have a template, render that.
 	tpl := state.Template()
@@ -95,8 +166,7 @@ func runInit(cmd *cobra.Command, args []string) {
 	}
 
 	if err := tpl.Render(*fn, step); err != nil {
-		fmt.Println(cli.RenderError(fmt.Sprintf("There was an error creating the function: %s", err)) + "\n")
-		return
+		return fmt.Errorf("There was an error creating the function: %s", err)
 	}
 
 	fmt.Println(cli.BoldStyle.Copy().Foreground(cli.Green).Render(fmt.Sprintf("🎉 Done!  Your function has been created in ./%s", fn.Slug())))
@@ -113,4 +183,6 @@ func runInit(cmd *cobra.Command, args []string) {
 	tel.Send(cmd.Context(), state.TelEvent())
 
 	fmt.Println(cli.TextStyle.Render("For more information, read our documentation at https://www.inngest.com/docs\n"))
+
+	return nil
 }

--- a/pkg/cli/initialize/initialize.go
+++ b/pkg/cli/initialize/initialize.go
@@ -593,6 +593,19 @@ func (f *initModel) cloneTemplate(ctx context.Context) tea.Cmd {
 			return cloneError{err}
 		}
 
+		// Now we've cloned, let's ensure the example path we've found is a valid
+		// function to ensure people can't just use this to accidentally git clone
+		// something that then doesn't work with inngest.
+		tmpExamplePath := filepath.Join(tmpPath, examplePath)
+		fn, err := function.Load(ctx, tmpExamplePath)
+		if err != nil {
+			return cloneError{err}
+		}
+
+		if err = fn.Validate(ctx); err != nil {
+			return cloneError{err}
+		}
+
 		onlyOwnerWrite := 0755
 		// Create every directory up-to-but-not-including the target dir
 		if err = os.MkdirAll(filepath.Dir(targetPath), fs.FileMode(onlyOwnerWrite)); err != nil {

--- a/pkg/cli/initialize/initialize.go
+++ b/pkg/cli/initialize/initialize.go
@@ -253,7 +253,7 @@ func (f *initModel) DidQuitEarly() bool {
 // This returns an error if the function is not valid.
 func (f *initModel) Function(ctx context.Context) (*function.Function, error) {
 	// If this is a template, load the function from the created template
-	if f.template != "" && f.name != "" {
+	if f.shouldCloneTemplate() {
 		if f.CloneError != nil {
 			return nil, f.CloneError
 		}

--- a/pkg/cli/initialize/initialize.go
+++ b/pkg/cli/initialize/initialize.go
@@ -258,21 +258,23 @@ func (f *initModel) Function(ctx context.Context) (*function.Function, error) {
 			return nil, f.CloneError
 		}
 
-		if f.clonedTemplate {
-			cwd, err := os.Getwd()
-			if err != nil {
-				return nil, err
-			}
-
-			targetDir := filepath.Join(cwd, f.name)
-
-			fn, err := function.Load(ctx, targetDir)
-			if err != nil {
-				return nil, err
-			}
-
-			return fn, fn.Validate(ctx)
+		if !f.clonedTemplate {
+			return nil, fmt.Errorf("template not yet cloned")
 		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+
+		targetDir := filepath.Join(cwd, f.name)
+
+		fn, err := function.Load(ctx, targetDir)
+		if err != nil {
+			return nil, err
+		}
+
+		return fn, fn.Validate(ctx)
 	}
 
 	// Attempt to find the schema that matches this event, and dump the

--- a/pkg/cli/initialize/questions.go
+++ b/pkg/cli/initialize/questions.go
@@ -43,6 +43,10 @@ var (
 			return m, cmd
 		},
 		next: func(m *initModel) InitQuestion {
+			if m.template != "" {
+				return nil
+			}
+
 			return questionTrigger
 		},
 	}


### PR DESCRIPTION
## Summary

Adds a new flag `inngest init --template`, which, when provided, will attempt to clone the given repository and directory and use the found function as a template.

The format for the value is `[repo]#[directory]`, e.g. `github.com/inngest/inngest#examples/prisma-typescript-function`.

An example command would look something like:

```sh
npx inngest-cli init --template github.com/inngest/inngest#examples/prisma-typescript-function
```

Broadly, this will:

- Push the user through the usual `inngest init` flow (welcome message, questions, etc.)
- Ask for a name if not given in the command
- Clone the given repo into a temporary directory
- Confirm that the target directory is a valid Inngest function
- Copy the target directory to the intended dir (`./[function-name]`)
- Clean up temporary files
- Confirm the function is valid again after copying to make sure nothing went wrong in transit
- Success 🥳

## Questions

- [ ] Should we forcibly change the `id` and `name` of the function after cloning? 🤔
  > I don't think we should do templating - it's nice that templates can just be any existing function - but is it sensible to change the `name` to the given name and `id` to a new randomly-generated one?

## Example

![inngest init template example](https://user-images.githubusercontent.com/1736957/185603257-d2089af7-5c5c-49b2-876c-a225dd3357c8.gif)

## Related

- inngest/website#163