### PR TITLE
Add support for custom Dockerfile

### DIFF
--- a/cmd/commands/deploy.go
+++ b/cmd/commands/deploy.go
@@ -208,7 +208,18 @@ func deployAction(ctx context.Context, a inngest.ActionVersion) (inngest.ActionV
 		return a, fmt.Errorf("error preparing action: %w", err)
 	}
 
-	config, err := cuedefs.FormatAction(a)
+	// XXX: Remove the dockerfile field from the runtime struct b/c the action shouldn't need this info
+	clean := a
+	rt, ok := clean.Runtime.Runtime.(inngest.RuntimeDocker)
+	if !ok {
+		return a, fmt.Errorf("failed to parse runtime")
+	}
+	clean.Runtime.Runtime = inngest.RuntimeDocker{
+		Entrypoint: rt.Entrypoint,
+		Memory:     rt.Memory,
+	}
+
+	config, err := cuedefs.FormatAction(clean)
 	if err != nil {
 		return a, err
 	}

--- a/inngest/runtime.go
+++ b/inngest/runtime.go
@@ -58,6 +58,7 @@ func (r *RuntimeWrapper) UnmarshalJSON(b []byte) error {
 type RuntimeDocker struct {
 	Entrypoint []string `json:"entrypoint,omitempty"`
 	Memory     *int     `json:"memory"`
+	Dockerfile string   `json:"dockerfile,omitempty"`
 }
 
 // MarshalJSON implements the JSON marshal interface so that cue can format this
@@ -68,6 +69,9 @@ func (r RuntimeDocker) MarshalJSON() ([]byte, error) {
 	}
 	if len(r.Entrypoint) > 0 {
 		data["entrypoint"] = r.Entrypoint
+	}
+	if r.Dockerfile != "" {
+		data["dockerfile"] = r.Dockerfile
 	}
 	return json.Marshal(data)
 }

--- a/pkg/cuedefs/v1/runtime.cue
+++ b/pkg/cuedefs/v1/runtime.cue
@@ -3,7 +3,8 @@ package v1
 #Runtime: #RuntimeDocker | #RuntimeHTTP
 
 #RuntimeDocker: {
-	type: "docker"
+	type:       "docker"
+	dockerfile: string | *""
 }
 
 #RuntimeHTTP: {


### PR DESCRIPTION
## Description

To enable folks with monorepos to use Dockerfiles that are outside of the path of the `inngest.json` file so files outside of the `inngest.json` context can be added. 

### Example

Example project structure
```
/functions/my-fn-a/inngest.json
/functions/my-fn-a/index.js
/src/api.js
/src/someLibrary.js
Dockerfile.my-fn
Dockerfile.api
```

`index.js`:
```js
const something = require("../../src/someLibrary")

const args = JSON.parse(process.argv.pop())
const output = something(args.data)
console.log(output)
```

`inngest.json` file:
```json
{
  "name": "Backfill User Data",
  "id": "something-cool-08kj53",
  "triggers": [
    {
      "event": "retool/backfill.requested"
    }
  ],
  "steps": {
    "my-fn": {
      "id": "my-fn",
      "path": "file://.",
      "name": "Run some code",
      "runtime": {
        "type": "docker",
        "dockerfile": "../../Dockerfile.my-fn"
      }
    }
  }
}

```

### TODO

* [ ] Add tests