### PR TITLE
Ensure an error is logged when the CLI fails to load replay events

### DIFF
--- a/cmd/commands/run.go
+++ b/cmd/commands/run.go
@@ -277,6 +277,8 @@ func buildImg(ctx context.Context, fn function.Function) error {
 func runFunction(ctx context.Context, fn function.Function, opts runFunctionOpts) error {
 	evts, err := opts.eventFunc()
 	if err != nil {
+		fmt.Println("\n" + cli.RenderError(err.Error()) + "\n")
+
 		return err
 	}
 


### PR DESCRIPTION
Currently, `inngest run --replay` will fail silently (no log, exit code `1`) if it fails to load any events, either due to auth, connectivity, or just a lack of events.

Re-introduces the log specifically for these errors.