### PR TITLE
Allow waits to be created using expression data

### DIFF
--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -273,9 +273,9 @@ func (s *svc) handleQueueItem(ctx context.Context, item queue.Item) error {
 
 		at := time.Now()
 		if next.Metadata != nil && next.Metadata.Wait != nil {
-			dur, err := str2duration.ParseDuration(*next.Metadata.Wait)
+			dur, err := ParseWait(ctx, *next.Metadata.Wait, run)
 			if err != nil {
-				return fmt.Errorf("invalid wait duration: %s", *next.Metadata.Wait)
+				return err
 			}
 			at = at.Add(dur)
 		}

--- a/pkg/execution/executor/util.go
+++ b/pkg/execution/executor/util.go
@@ -1,0 +1,41 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/expressions"
+	"github.com/xhit/go-str2duration/v2"
+)
+
+func ParseWait(ctx context.Context, wait string, s state.State) (time.Duration, error) {
+	// Attempt to parse a basic duration.
+	if dur, err := str2duration.ParseDuration(wait); err == nil {
+		return dur, nil
+	}
+
+	data := state.EdgeExpressionData(ctx, s, "")
+
+	// Attempt to parse an expression, eg. "date(event.data.from) - duration(1h)"
+	out, _, err := expressions.Evaluate(ctx, wait, data)
+	if err != nil {
+		return 0, fmt.Errorf("Unable to parse wait as a duration or expression: %s", wait)
+	}
+
+	switch typ := out.(type) {
+	case time.Time:
+		return time.Until(typ), nil
+	case time.Duration:
+		return typ, nil
+	case int:
+		// Treat ints and floats as seconds.
+		return time.Duration(typ) * time.Second, nil
+	case float64:
+		// Treat ints and floats as seconds.
+		return time.Duration(typ) * time.Second, nil
+	}
+
+	return 0, fmt.Errorf("Unable to get duration from expression response: %v", out)
+}

--- a/pkg/execution/executor/util_test.go
+++ b/pkg/execution/executor/util_test.go
@@ -1,0 +1,65 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/inngest"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/execution/state/inmemory"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseWait(t *testing.T) {
+	ctx := context.Background()
+
+	state := inmemory.NewStateInstance(
+		inngest.Workflow{},
+		state.Identifier{},
+		state.Metadata{},
+		map[string]any{
+			"data": time.Now().Format(time.RFC3339),
+		},
+		nil,
+		nil,
+	)
+
+	tests := []struct {
+		wait     string
+		duration time.Duration
+		err      error
+	}{
+		{
+			wait:     "1h30m",
+			duration: 90 * time.Minute,
+			err:      nil,
+		},
+		// expression as duration
+		{
+			wait:     "duration('1h')",
+			duration: time.Hour,
+			err:      nil,
+		},
+		// event data as expression
+		{
+			wait:     "date(event.data) + duration('45m30s')",
+			duration: (time.Minute * 45) + (time.Second * 30),
+			err:      nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.wait, func(t *testing.T) {
+			duration, err := ParseWait(ctx, test.wait, state)
+			require.NoError(t, err)
+			require.WithinDuration(
+				t,
+				time.Now().Add(test.duration),
+				time.Now().Add(duration),
+				time.Second,
+			)
+		})
+	}
+
+}

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -258,7 +258,7 @@ func (s *svc) functions(ctx context.Context, evt event.Event) error {
 				if t.Expression != nil {
 					// Execute expressions here, ensuring that each function is only triggered
 					// under the correct conditions.
-					ok, _, evalerr := expressions.Evaluate(ctx, *t.Expression, map[string]interface{}{
+					ok, _, evalerr := expressions.EvaluateBoolean(ctx, *t.Expression, map[string]interface{}{
 						"event": evtMap,
 					})
 					if evalerr != nil {
@@ -324,7 +324,7 @@ func (s *svc) pauses(ctx context.Context, evt event.Event) error {
 			// Add the async event data to the expression
 			data["async"] = evtMap
 			// Compile and run the expression.
-			ok, _, err := expressions.Evaluate(ctx, *pause.Expression, data)
+			ok, _, err := expressions.EvaluateBoolean(ctx, *pause.Expression, data)
 			if err != nil {
 				return err
 			}

--- a/pkg/execution/state/edges.go
+++ b/pkg/execution/state/edges.go
@@ -17,7 +17,7 @@ var (
 	// edge expressions.
 	DefaultEdgeEvaluator = edgeEvaluator{
 		datagen:   EdgeExpressionData,
-		evaluator: expressions.Evaluate,
+		evaluator: expressions.EvaluateBoolean,
 	}
 )
 
@@ -67,7 +67,7 @@ type EdgeEvaluator interface {
 func NewEdgeEvaluator(eval Evaluator, datagen EdgeExpressionDataGen) EdgeEvaluator {
 	// TODO (tonyhb): clean this up with options.
 	if eval == nil {
-		eval = expressions.Evaluate
+		eval = expressions.EvaluateBoolean
 	}
 	if datagen == nil {
 		datagen = EdgeExpressionData

--- a/pkg/expressions/expressions_test.go
+++ b/pkg/expressions/expressions_test.go
@@ -787,6 +787,19 @@ func TestEvaluateExpression(t *testing.T) {
 			// no error, but it doesn't match.
 			"",
 		},
+		// Event data time manipulation
+		{
+			"date(event.from) + duration('6h35m10s') == date('2020-01-01T18:35:10')",
+			map[string]interface{}{
+				"event": map[string]any{
+					"from": "2020-01-01T12:00:00",
+				},
+			},
+			true,
+			nil,
+			false,
+			"",
+		},
 	}
 
 	for n, test := range tests {
@@ -970,7 +983,7 @@ func BenchmarkEvaluate(b *testing.B) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		expr, err := NewExpressionEvaluator(ctx, expression)
+		expr, err := NewBooleanEvaluator(ctx, expression)
 		if err != nil {
 			b.Fatalf("unknown error in benchmark: %s", err)
 		}
@@ -1000,7 +1013,7 @@ func BenchmarkEvaluateParallel(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			expr, _ := NewExpressionEvaluator(ctx, expression)
+			expr, _ := NewBooleanEvaluator(ctx, expression)
 			res, _, err := expr.Evaluate(ctx, data)
 			if err != nil {
 				b.Fatalf("unknown error in benchmark: %s", err)


### PR DESCRIPTION
This PR allows us to create edges which wait to invoke the next step based off expressions:

```{
        triggers: [
                {
                        event: "some/event"
                        definition: {
                                format: "cue"
                                synced: false
                                def:    "file://./events/some-event.cue"
                        }
                },
        ]
        steps: {
                remind: {
                        id:   "remind"
                        path: "file://./steps/remind"
                        name: ""
                        runtime: type: "docker"
                        after: [{
                                step: "$trigger"
                                // parse event.data.from as a date and subtract 2 seconds;  then
                                // wait until this date.
                                wait: "date(event.data.from) - duration('2s')"
                        }]
                }
        }
}
```