### PR TITLE
Ensure Cue doesn't attempt to parse incorrectly on windows deploys

### DIFF
--- a/internal/cuedefs/cuedefs.go
+++ b/internal/cuedefs/cuedefs.go
@@ -35,8 +35,8 @@ var (
 // so that they can be referenced by cue files.
 func internalPackageLoader() (*load.Config, error) {
 	cfg := &load.Config{
-		Dir:        "/",
-		ModuleRoot: "/",
+		Dir:        string(filepath.Separator),
+		ModuleRoot: string(filepath.Separator),
 		Overlay:    map[string]load.Source{},
 	}
 


### PR DESCRIPTION
Cue requires fake root disks etc. even with overlays and in-memory files — ensure we add this to cue parsing of actions and workflows when deploying.