### PR TITLE
Don't pass host env as default in `dockerdriver`

### DIFF
--- a/pkg/execution/driver/dockerdriver/dockerdriver.go
+++ b/pkg/execution/driver/dockerdriver/dockerdriver.go
@@ -163,7 +163,7 @@ func (d *dockerExec) startOpts(ctx context.Context, state state.State, wa innges
 	}
 	name := fmt.Sprintf("%s-%s-%s", state.RunID(), slug.Make(wa.Name), hex.EncodeToString(byt))
 
-	env := os.Environ()
+	env := []string{}
 	if d.envreader != nil {
 		parsed := d.envreader.Read(ctx, state.Workflow().ID)
 		if parsed != nil {

--- a/pkg/execution/driver/dockerdriver/dockerdriver.go
+++ b/pkg/execution/driver/dockerdriver/dockerdriver.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 


### PR DESCRIPTION
This was breaking Windows as it has some quirky output at the start when using `os.Environ()`, but also we should require users to use `.env` to pass in secrets.