### PR TITLE
Strip template "description" and "tags" fields

### DIFF
--- a/pkg/cli/initialize/initialize.go
+++ b/pkg/cli/initialize/initialize.go
@@ -673,8 +673,8 @@ func (f *initModel) cloneTemplate(ctx context.Context) tea.Cmd {
 			return cloneError{fmt.Errorf("could not remove tags")}
 		}
 
-		if err := os.WriteFile(filepath.Join(tmpExamplePath, "inngest.json"), []byte(val), 0644); err != nil {
-			return cloneError{fmt.Errorf("error writing inngest.json: %s", err)}
+		if err := os.WriteFile(filepath.Join(tmpExamplePath, function.JsonConfigName), []byte(val), 0644); err != nil {
+			return cloneError{fmt.Errorf("error writing %s: %s", function.JsonConfigName, err)}
 		}
 
 		onlyOwnerWrite := 0755

--- a/pkg/cli/initialize/initialize.go
+++ b/pkg/cli/initialize/initialize.go
@@ -663,6 +663,16 @@ func (f *initModel) cloneTemplate(ctx context.Context) tea.Cmd {
 			return cloneError{fmt.Errorf("could not set new function ID: %s", err)}
 		}
 
+		val, err = sjson.Delete(val, "description")
+		if err != nil {
+			return cloneError{fmt.Errorf("could not remove description")}
+		}
+
+		val, err = sjson.Delete(val, "tags")
+		if err != nil {
+			return cloneError{fmt.Errorf("could not remove tags")}
+		}
+
 		if err := os.WriteFile(filepath.Join(tmpExamplePath, "inngest.json"), []byte(val), 0644); err != nil {
 			return cloneError{fmt.Errorf("error writing inngest.json: %s", err)}
 		}


### PR DESCRIPTION
### Summary

When cloning a template, strip any `description` and `tags` fields - these are site-specific and aren't needed for the user.

Also uses `function.JsonConfigName` instead of a hard-coded `inngest.json` for some nearby code. 😬