### PR TITLE
Move Docker warning to point to our own docs for specific instructions

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -41,7 +41,7 @@ func NewBuilder(ctx context.Context, opts BuilderUIOpts) (*BuilderUI, error) {
 			//
 			// Provide some simple hints to point to user towards installing Docker,
 			// and ideally our justification for requiring it.
-			fmt.Println("\n" + RenderWarning("Looks like there was a problem loading Docker.\n\nDocker is a required dependency for the CLI in order to build, run, and deploy your functions.\n\nYou can find more information on installing Docker on your system here: https://docs.docker.com/get-docker/."))
+			fmt.Println("\n" + RenderWarning("Looks like there was a problem loading Docker.\n\nDocker is a required dependency for the CLI in order to build, run, and deploy your functions.\n\nYou can find more information here: https://www.inngest.com/docs/installation/."))
 
 			return nil, err
 		}


### PR DESCRIPTION
## Summary

Points the Docker warning to our docs for more specific instructions on Docker, Docker Buildx, and installs.

Waiting for inngest/website#177 before merging.

## Related

- [ ] inngest/website#177