### PR TITLE
Make `inngest run ./dir` recursive, like `inngest deploy ./dir`

### DIFF
--- a/cmd/commands/deploy.go
+++ b/cmd/commands/deploy.go
@@ -49,21 +49,12 @@ func deploy(cmd *cobra.Command, args []string) error {
 		givenDir = args[0]
 	}
 
-	var fns []*function.Function
-	var err error
-
-	if givenDir != "" {
-		fns, err = function.LoadRecursive(ctx, givenDir)
-		if err != nil {
-			return err
-		}
-	} else {
-		fn, err := function.Load(ctx, ".")
-		if err != nil {
-			return err
-		}
-
-		fns = []*function.Function{fn}
+	fns, err := function.LoadFromPath(ctx, givenDir)
+	if err != nil {
+		return err
+	}
+	if len(fns) < 1 {
+		return fmt.Errorf("no functions found to deploy")
 	}
 
 	funcNames := make([]string, 0, len(fns))

--- a/cmd/commands/deploy.go
+++ b/cmd/commands/deploy.go
@@ -25,7 +25,7 @@ func NewCmdDeploy() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "deploy [dir]",
 		Short:   "Deploy a function to Inngest",
-		Long:    "Deploy a function to Inngest.\n\nIf no directory is provided, the we'll attempt to deploy a function in the current directory, or look for an Inngest config file in a parent directory.\n\nIf a direcotry is provided, we'll attempt to recursively find and deploy all functions in that directory.",
+		Long:    "Deploy a function to Inngest.\n\nIf no directory is provided, will attempt to deploy a function in the current directory, or look for an Inngest config file in a parent directory.\n\nIf a directory is provided, will attempt to recursively find and deploy all functions in that directory.",
 		Example: "inngest deploy",
 		Run:     doDeploy,
 	}

--- a/pkg/function/config.go
+++ b/pkg/function/config.go
@@ -23,6 +23,30 @@ const (
 	JsonConfigName = "inngest.json"
 )
 
+// LoadFromPath loads either a single Inngest function from the current
+// directory or up if `path` is empty, or multiple Inngest functions recusrively
+// if `path` is populated.
+func LoadFromPath(ctx context.Context, path string) ([]*Function, error) {
+	var fns []*Function
+	var err error
+
+	if path != "" {
+		fns, err = LoadRecursive(ctx, path)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		fn, err := Load(ctx, ".")
+		if err != nil {
+			return nil, err
+		}
+
+		fns = []*Function{fn}
+	}
+
+	return fns, err
+}
+
 // Load loads the inngest function from the given directory.  It searches for both inngest.cue
 // and inngest.json as both are supported.  If neither exist, this returns ErrNotFound.
 func Load(ctx context.Context, dir string) (*Function, error) {


### PR DESCRIPTION
## Summary

Replicates the functionality of `inngest deploy ./dir` (recursively deploying all functions found within `./dir`) to `inngest run`. It refactors out of the loading functionality of `inngest deploy` so we can use it in both places.

The drawback is that we don't have a reasonable way to support `--snapshot` or `--event-id` flags if multiple functions have been found.

The change is a small one, but I'm not sure that it complements the DX; it hamstrings some functionality around replay and data generation that doesn't feel good. What do you think, @tonyhb?