### PR TITLE
Pass in fn_id and step_id to step args via `ctx`

### DIFF
--- a/pkg/execution/driver/dockerdriver/dockerdriver.go
+++ b/pkg/execution/driver/dockerdriver/dockerdriver.go
@@ -152,7 +152,7 @@ func (d *dockerExec) start(ctx context.Context, state state.State, wa inngest.St
 }
 
 func (d *dockerExec) startOpts(ctx context.Context, state state.State, wa inngest.Step) (docker.CreateContainerOptions, error) {
-	marshalled, err := driver.MarshalV1(state)
+	marshalled, err := driver.MarshalV1(ctx, state, wa)
 	if err != nil {
 		return docker.CreateContainerOptions{}, fmt.Errorf("error marshalling state")
 	}

--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -24,12 +24,19 @@ type EnvManager interface {
 }
 
 // MarshalV1 marshals state as an input to driver runtimes.
-func MarshalV1(s state.State) ([]byte, error) {
+func MarshalV1(ctx context.Context, s state.State, step inngest.Step) ([]byte, error) {
 	data := map[string]interface{}{
 		"event": s.Event(),
 		"steps": s.Actions(),
 		"ctx": map[string]interface{}{
-			"workflow_id": s.WorkflowID(),
+			// fn_id is used within entrypoints to SDK-based functions in
+			// order to specify the ID of the function to run via RPC.
+			"fn_id": s.Workflow().ID,
+			// step_id is used within entrypoints to SDK-based functions in
+			// order to specify the step of the function to run via RPC.
+			"step_id": step.ID,
+			// XXX: Pass in opentracing context within ctx.
+			"run_id": s.RunID(),
 		},
 	}
 	return json.Marshal(data)

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -41,7 +41,7 @@ func (e executor) Execute(ctx context.Context, s state.State, action inngest.Act
 		return nil, fmt.Errorf("Unable to use HTTP executor for non-HTTP runtime")
 	}
 
-	input, err := driver.MarshalV1(s)
+	input, err := driver.MarshalV1(ctx, s, step)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This ensures that event data has the function and step ID included, which is necessary if & when running via multiplexed functions.