### PR TITLE
Ensure that we re-initialize crons in development runner

### DIFF
--- a/pkg/api/tel/tel.go
+++ b/pkg/api/tel/tel.go
@@ -90,7 +90,7 @@ func Wait() {
 // Disabled returns whether telemetry is disabled.
 func Disabled() bool {
 	if version.Version == "dev" && version.Hash == "" {
-		return false
+		return true
 	}
 	return os.Getenv("DO_NOT_TRACK") != ""
 }

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -166,6 +166,12 @@ func (a devapi) Register(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Re-initialize our cron manager.
+	if err := a.devserver.runner.InitializeCrons(ctx); err != nil {
+		a.err(ctx, w, 400, err)
+		return
+	}
+
 	a.devserver.handlers = append(a.devserver.handlers, *h)
 	_, _ = w.Write([]byte(`{"ok":true}`))
 

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -63,9 +63,10 @@ func start(ctx context.Context, opts StartOpts, loader *inmemorydatastore.FSLoad
 		return err
 	}
 
-	// The devserver embeds the event API.
-	ds := newService(opts, loader)
 	runner := runner.NewService(opts.Config, runner.WithExecutionLoader(loader))
+
+	// The devserver embeds the event API.
+	ds := newService(opts, loader, runner)
 	exec := executor.NewService(
 		opts.Config,
 		executor.WithExecutionLoader(loader),

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/inngest/inngest/inngest/clistate"
 	"github.com/inngest/inngest/pkg/api"
 	"github.com/inngest/inngest/pkg/coredata/inmemory"
+	"github.com/inngest/inngest/pkg/execution/runner"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/sdk"
 	"github.com/inngest/inngest/pkg/service"
@@ -20,8 +21,9 @@ const (
 	SDKPollInterval = 5 * time.Second
 )
 
-func newService(opts StartOpts, loader *inmemory.FSLoader) *devserver {
+func newService(opts StartOpts, loader *inmemory.FSLoader, runner runner.Runner) *devserver {
 	return &devserver{
+		runner:        runner,
 		loader:        loader,
 		opts:          opts,
 		urls:          opts.URLs,
@@ -39,6 +41,9 @@ func newService(opts StartOpts, loader *inmemory.FSLoader) *devserver {
 // SDKs, as they can test and use a single URL.
 type devserver struct {
 	opts StartOpts
+
+	// runner stores the runner
+	runner runner.Runner
 
 	apiservice service.Service
 


### PR DESCRIPTION
When running the dev server, recreate the cron manager every time functions are registered such that new functions are invoked.

Closes #267 