### PR TITLE
HTTP driver signing

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,7 +20,10 @@ config.#Config & {
 	}
 	execution: {
 		drivers: {
-			http:   config.#HTTPDriver
+			http: config.#HTTPDriver & {
+				signingKey: "dev-signing-key"
+				timeout:    900
+			}
 			docker: config.#DockerDriver & {
 				network: "host"
 			}

--- a/pkg/cuedefs/config/config.cue
+++ b/pkg/cuedefs/config/config.cue
@@ -210,5 +210,7 @@ package config
 }
 
 #HTTPDriver: {
-	name: "http"
+	name:        "http"
+	timeout?:    int | *900 // 15 minutes
+	signingKey?: string
 }

--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -9,6 +9,21 @@ import (
 	"github.com/inngest/inngest/pkg/function/env"
 )
 
+const (
+	DefaultSigningKey = []byte("test-key")
+)
+
+var signingKey struct{}
+
+func SetSigningKey(ctx context.Context, key []byte) context.Context {
+	return context.WithValue(ctx, signingKey, key)
+}
+
+func GetSigningKey(ctx context.Context) []byte {
+	val, _ := ctx.Value(signingKey).([]byte)
+	return val
+}
+
 type Driver interface {
 	inngest.Runtime
 

--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -9,21 +9,6 @@ import (
 	"github.com/inngest/inngest/pkg/function/env"
 )
 
-const (
-	DefaultSigningKey = []byte("test-key")
-)
-
-var signingKey struct{}
-
-func SetSigningKey(ctx context.Context, key []byte) context.Context {
-	return context.WithValue(ctx, signingKey, key)
-}
-
-func GetSigningKey(ctx context.Context) []byte {
-	val, _ := ctx.Value(signingKey).([]byte)
-	return val
-}
-
 type Driver interface {
 	inngest.Runtime
 

--- a/pkg/execution/driver/httpdriver/config.go
+++ b/pkg/execution/driver/httpdriver/config.go
@@ -1,6 +1,9 @@
 package httpdriver
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/inngest/inngest/pkg/execution/driver"
 
 	"github.com/inngest/inngest/pkg/config/registration"
@@ -12,7 +15,10 @@ func init() {
 
 // Config represents driver configuration for use when configuring hosted
 // services via config.cue
-type Config struct{}
+type Config struct {
+	SigningKey string
+	Timeout    int
+}
 
 // RuntimeName returns the runtime field that should invoke this driver.
 func (Config) RuntimeName() string { return "http" }
@@ -20,8 +26,11 @@ func (Config) RuntimeName() string { return "http" }
 // DriverName returns the name of this driver
 func (Config) DriverName() string { return "http" }
 
-func (Config) UnmarshalJSON(b []byte) error { return nil }
-
 func (c Config) NewDriver() (driver.Driver, error) {
-	return DefaultExecutor, nil
+	return executor{
+		client: &http.Client{
+			Timeout: time.Duration(c.Timeout) * time.Second,
+		},
+		signingKey: []byte(c.SigningKey),
+	}, nil
 }

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -45,10 +45,17 @@ func Sign(ctx context.Context, key, body []byte) string {
 	if key == nil {
 		return ""
 	}
-	mac := hmac.New(sha256.New, key)
-	_, _ = mac.Write(body)
-	sig := hex.EncodeToString(mac.Sum(nil))
+
 	now := time.Now().Unix()
+
+	mac := hmac.New(sha256.New, key)
+
+	_, _ = mac.Write(body)
+	// Write the timestamp as a unix timestamp to the hmac to prevent
+	// timing attacks.
+	_, _ = mac.Write([]byte(fmt.Sprintf("%d", now)))
+
+	sig := hex.EncodeToString(mac.Sum(nil))
 	return fmt.Sprintf("t=%d&s=%s", now, sig)
 }
 

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -44,7 +45,9 @@ func Sign(ctx context.Context, key, body []byte) string {
 	if key == nil {
 		return ""
 	}
-	sig := hmac.New(sha256.New, key).Sum(body)
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(body)
+	sig := hex.EncodeToString(mac.Sum(nil))
 	now := time.Now().Unix()
 	return fmt.Sprintf("t=%d,s=%s", now, sig)
 }

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -49,7 +49,7 @@ func Sign(ctx context.Context, key, body []byte) string {
 	_, _ = mac.Write(body)
 	sig := hex.EncodeToString(mac.Sum(nil))
 	now := time.Now().Unix()
-	return fmt.Sprintf("t=%d,s=%s", now, sig)
+	return fmt.Sprintf("t=%d&s=%s", now, sig)
 }
 
 func (e executor) Execute(ctx context.Context, s state.State, action inngest.ActionVersion, step inngest.Step) (*state.DriverResponse, error) {


### PR DESCRIPTION
This PR adds HTTP signing to the HTTP driver, ensuring that we sign all requests with HMAC-SHA256 using the key from configuration.

TODO: In the dev server, if authenticated we should use the development signing key from your workspaces.