### PR TITLE
Add optional caching of expression data per pause

### DIFF
--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -323,13 +323,19 @@ func (s *svc) pauses(ctx context.Context, evt event.Event) error {
 			Msg("handling pause")
 
 		if pause.Expression != nil {
-			s, err := s.state.Load(ctx, pause.Identifier)
-			if err != nil {
-				return err
+			data := pause.ExpressionData
+
+			if len(data) == 0 {
+				// The pause had no expression data, so always load
+				// state for the function to retrieve expression data.
+				s, err := s.state.Load(ctx, pause.Identifier)
+				if err != nil {
+					return err
+				}
+				// Get expression data from the executor for the given run ID.
+				data = state.EdgeExpressionData(ctx, s, pause.Outgoing)
 			}
 
-			// Get expression data from the executor for the given run ID.
-			data := state.EdgeExpressionData(ctx, s, pause.Outgoing)
 			// Add the async event data to the expression
 			data["async"] = evtMap
 			// Compile and run the expression.

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -75,6 +75,12 @@ type Pause struct {
 	// Expression is an optional expression that must match for the pause
 	// to be resumed.
 	Expression *string `json:"expression"`
+	// ExpressionData _optionally_ stores only the data that we need to evaluate
+	// the expression from the event.  This allows us to load pauses from the
+	// state store without round trips to fetch the entire function state.  If
+	// this is empty and the pause contains an expression, function state will
+	// be loaded from the store.
+	ExpressionData map[string]any `json:"data"`
 	// OnTimeout indicates that this incoming edge should only be ran
 	// when the pause times out, if set to true.
 	OnTimeout bool `json:"onTimeout"`


### PR DESCRIPTION
This lets us store a partial of all event/step/response data for async edge expressions in the pause directly.

This reduces N+1 calls to load function state (which can be costly/large) when evaluating edge expressions, as the data needed for the expression is already returned within the pause.