### PR TITLE
Allow storing arbitary data in steps, vs maps

### DIFF
--- a/pkg/execution/driver/dockerdriver/dockerdriver.go
+++ b/pkg/execution/driver/dockerdriver/dockerdriver.go
@@ -97,13 +97,13 @@ func (d *dockerExec) Execute(ctx context.Context, s state.State, action inngest.
 	}
 
 	resp := &state.DriverResponse{
-		Output:        map[string]interface{}{},
+		Output:        map[string]any{},
 		ActionVersion: action.Version,
 	}
 
 	if len(byt) == 0 {
 		byt, _ = io.ReadAll(stderr)
-		resp.Output["stderr"] = string(byt)
+		resp.Output.(map[string]any)["stderr"] = string(byt)
 	}
 	if exit != 0 {
 		resp.Err = fmt.Errorf("Non-zero status code: %d\nOutput: %s", exit, string(byt))
@@ -118,7 +118,7 @@ func (d *dockerExec) Execute(ctx context.Context, s state.State, action inngest.
 
 	// Return the output as JSON
 	if err := json.Unmarshal(content, &resp.Output); err != nil {
-		resp.Output["body"] = string(content)
+		resp.Output.(map[string]any)["body"] = string(content)
 	}
 
 	return resp, nil

--- a/pkg/execution/executor/service_test.go
+++ b/pkg/execution/executor/service_test.go
@@ -355,8 +355,8 @@ func TestHandleAsyncService(t *testing.T) {
 	run, err = data.sm.Load(ctx, id)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(run.Actions()))
-	require.EqualValues(t, map[string]map[string]interface{}{
-		"1": {"id": 1},
+	require.EqualValues(t, map[string]any{
+		"1": map[string]any{"id": 1},
 	}, run.Actions())
 	require.Equal(t, 2, run.Metadata().Pending)
 
@@ -366,9 +366,9 @@ func TestHandleAsyncService(t *testing.T) {
 	<-time.After(timeout + buffer)
 	run, err = data.sm.Load(ctx, id)
 	require.NoError(t, err)
-	require.EqualValues(t, map[string]map[string]interface{}{
-		"1": {"id": 1},
-		"2": {"id": 2},
+	require.EqualValues(t, map[string]any{
+		"1": map[string]any{"id": 1},
+		"2": map[string]any{"id": 2},
 	}, run.Actions())
 	require.Equal(t, 0, run.Metadata().Pending)
 

--- a/pkg/execution/executor/util_test.go
+++ b/pkg/execution/executor/util_test.go
@@ -21,8 +21,8 @@ func TestParseWait(t *testing.T) {
 		map[string]any{
 			"data": time.Now().Format(time.RFC3339),
 		},
-		map[string]map[string]any{
-			"step-1": {
+		map[string]any{
+			"step-1": map[string]any{
 				"wait": time.Now().Format(time.RFC3339),
 			},
 		},

--- a/pkg/execution/state/edges.go
+++ b/pkg/execution/state/edges.go
@@ -32,7 +32,7 @@ type Evaluator func(ctx context.Context, expression string, input map[string]int
 // edge's expressions.
 func EdgeExpressionData(ctx context.Context, s State, outgoingID string) map[string]interface{} {
 	// Add the outgoing edge's data as a "response" field for predefined edges.
-	var response map[string]interface{}
+	var response any
 	if outgoingID != "" && outgoingID != inngest.TriggerName {
 		response, _ = s.ActionID(outgoingID)
 	}

--- a/pkg/execution/state/edges_test.go
+++ b/pkg/execution/state/edges_test.go
@@ -19,8 +19,8 @@ func TestEdgeExpressionData(t *testing.T) {
 	}
 	state.EXPECT().Event().Return(event)
 
-	actions := map[string]map[string]any{
-		"first": {
+	actions := map[string]any{
+		"first": map[string]any{
 			"result": "yep",
 		},
 	}

--- a/pkg/execution/state/inmemory/inmemory.go
+++ b/pkg/execution/state/inmemory/inmemory.go
@@ -106,7 +106,7 @@ func (m *mem) Load(ctx context.Context, i state.Identifier) (state.State, error)
 		metadata:   state.Metadata{},
 		identifier: i,
 		event:      map[string]interface{}{},
-		actions:    map[string]map[string]interface{}{},
+		actions:    map[string]any{},
 		errors:     map[string]error{},
 	}
 
@@ -269,7 +269,7 @@ func (m *mem) PauseByID(ctx context.Context, id uuid.UUID) (*state.Pause, error)
 	return &pause, nil
 }
 
-func (m *mem) ConsumePause(ctx context.Context, id uuid.UUID, data map[string]any) error {
+func (m *mem) ConsumePause(ctx context.Context, id uuid.UUID, data any) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -278,7 +278,7 @@ func (m *mem) ConsumePause(ctx context.Context, id uuid.UUID, data map[string]an
 		return state.ErrPauseNotFound
 	}
 
-	if pause.DataKey != "" && len(data) > 0 {
+	if pause.DataKey != "" {
 		// Save data
 		s, ok := m.state[pause.Identifier.IdempotencyKey()]
 		if !ok {

--- a/pkg/execution/state/inmemory/instance.go
+++ b/pkg/execution/state/inmemory/instance.go
@@ -22,7 +22,7 @@ func NewStateInstance(
 	id state.Identifier,
 	metadata state.Metadata,
 	event map[string]any,
-	actions map[string]map[string]any,
+	actions map[string]any,
 	errors map[string]error,
 ) state.State {
 	return &memstate{
@@ -47,7 +47,7 @@ type memstate struct {
 	event map[string]interface{}
 
 	// Actions stores a map of all output from each individual action
-	actions map[string]map[string]interface{}
+	actions map[string]any
 
 	// errors stores a map of action errors
 	errors map[string]error
@@ -77,7 +77,7 @@ func (s memstate) Event() map[string]interface{} {
 	return s.event
 }
 
-func (s memstate) Actions() map[string]map[string]interface{} {
+func (s memstate) Actions() map[string]any {
 	return s.actions
 }
 
@@ -85,7 +85,7 @@ func (s memstate) Errors() map[string]error {
 	return s.errors
 }
 
-func (s memstate) ActionID(id string) (map[string]interface{}, error) {
+func (s memstate) ActionID(id string) (any, error) {
 	data, hasAction := s.Actions()[id]
 	err, hasError := s.Errors()[id]
 	if !hasAction && !hasError {

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -187,13 +187,13 @@ type State interface {
 	Event() map[string]interface{}
 
 	// Actions returns a map of all output from each individual action.
-	Actions() map[string]map[string]interface{}
+	Actions() map[string]any
 
 	// Errors returns all actions that have errored.
 	Errors() map[string]error
 
 	// ActionID returns the action output or error for the given ID.
-	ActionID(id string) (map[string]interface{}, error)
+	ActionID(id string) (any, error)
 
 	// ActionComplete returns whether the action with the given ID has finished,
 	// ie. has completed with data stored in state.
@@ -249,7 +249,7 @@ type Input struct {
 
 	// Steps allows users to specify pre-defined steps to run workflows from
 	// arbitrary points.
-	Steps map[string]map[string]any
+	Steps map[string]any
 }
 
 // Mutater mutates state for a given identifier, storing the state and returning
@@ -314,7 +314,7 @@ type PauseMutater interface {
 	//
 	// Any data passed when consuming a pause will be stored within function run state
 	// for future reference using the pause's DataKey.
-	ConsumePause(ctx context.Context, id uuid.UUID, data map[string]interface{}) error
+	ConsumePause(ctx context.Context, id uuid.UUID, data any) error
 }
 
 // PauseGetter allows a runner to return all existing pauses by event or by outgoing ID.  This

--- a/pkg/execution/state/state_mock_test.go
+++ b/pkg/execution/state/state_mock_test.go
@@ -52,10 +52,10 @@ func (mr *MockStateMockRecorder) ActionComplete(id interface{}) *gomock.Call {
 }
 
 // ActionID mocks base method.
-func (m *MockState) ActionID(id string) (map[string]interface{}, error) {
+func (m *MockState) ActionID(id string) (any, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ActionID", id)
-	ret0, _ := ret[0].(map[string]interface{})
+	ret0, _ := ret[0].(any)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -67,10 +67,10 @@ func (mr *MockStateMockRecorder) ActionID(id interface{}) *gomock.Call {
 }
 
 // Actions mocks base method.
-func (m *MockState) Actions() map[string]map[string]interface{} {
+func (m *MockState) Actions() map[string]any {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Actions")
-	ret0, _ := ret[0].(map[string]map[string]interface{})
+	ret0, _ := ret[0].(map[string]any)
 	return ret0
 }
 

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -184,8 +184,8 @@ func checkNew_stepdata(t *testing.T, m state.Manager) {
 		Identifier: id,
 		Workflow:   w,
 		EventData:  input.Map(),
-		Steps: map[string]map[string]any{
-			"step-a": {
+		Steps: map[string]any{
+			"step-a": map[string]any{
 				"result": "predetermined",
 			},
 		},
@@ -703,7 +703,7 @@ func checkConsumePauseWithEmptyData(t *testing.T, m state.Manager) {
 	// Load function state and assert we have the pause stored in state.
 	reloaded, err := m.Load(ctx, s.Identifier())
 	require.Nil(t, err)
-	require.Equal(t, 0, len(reloaded.Actions()), "Pause data should not be stored if data is nil/empty")
+	require.Equal(t, 1, len(reloaded.Actions()), "Pause data should still be stored if data is nil")
 }
 
 func checkConsumePauseWithEmptyDataKey(t *testing.T, m state.Manager) {


### PR DESCRIPTION
This PR changes the state store interface, allowing us to store arbitrary data as the output of a step.

We need this for #274.