### PR TITLE
Fix TS type collision errors

### DIFF
--- a/cmd/commands/types.go
+++ b/cmd/commands/types.go
@@ -176,6 +176,7 @@ func typescript(cmd *cobra.Command, args []string) (string, error) {
 
 	// Add a type to allow users to define custom types
 	b.WriteString("type CustomEvent = {\n")
+	b.WriteString("  name: string;\n")
 	b.WriteString("  data: Record<string, any>;\n")
 	b.WriteString("  user?: Record<string, any>;\n")
 	b.WriteString("};\n\n")

--- a/cmd/commands/types.go
+++ b/cmd/commands/types.go
@@ -166,6 +166,11 @@ func typescript(cmd *cobra.Command, args []string) (string, error) {
 		suffix := ";"
 		ts = strings.Replace(ts, fmt.Sprintf("%sstring%s", prefix, suffix), fmt.Sprintf("%s\"%s\"%s", prefix, eventId, suffix), 1)
 
+		// Replace any instance of `{}` with `Record<string, never>`. TS types
+		// declare `{}` as "any object", which means it could be pretty much
+		// anything in JS.
+		ts = strings.Replace(ts, "{}", "Record<string, never>", -1)
+
 		b.WriteString(ts + "\n")
 	}
 

--- a/cmd/commands/types.go
+++ b/cmd/commands/types.go
@@ -198,6 +198,7 @@ func typescript(cmd *cobra.Command, args []string) (string, error) {
 	b.WriteString(" * >({ name: \"My App\" });\n")
 	b.WriteString(" * ```\n")
 	b.WriteString(" */\n")
+	b.WriteString("// eslint-disable-next-line @typescript-eslint/ban-types\n")
 	b.WriteString("export type Events<CustomEvents extends Record<string, CustomEvent> = {}> =\n")
 	b.WriteString("  Readonly<Omit<CustomEvents, keyof GeneratedEvents> & GeneratedEvents>;")
 

--- a/pkg/function/trigger.go
+++ b/pkg/function/trigger.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"cuelang.org/go/cue"
-	"github.com/gosimple/slug"
 	"github.com/inngest/event-schemas/pkg/fakedata"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/expressions"
@@ -53,9 +52,20 @@ type EventTrigger struct {
 }
 
 func (e EventTrigger) TitleName() string {
-	words := strings.ReplaceAll(slug.Make(e.Event), "-", " ")
-	words = strings.ReplaceAll(words, "_", " ")
-	return strings.ReplaceAll(strings.Title(words), " ", "")
+	joiner := "_"
+	replacements := []string{".", "/", "-"}
+
+	rep := e.Event
+	for k, v := range replacements {
+		rep = strings.ReplaceAll(rep, v, strings.Repeat(joiner, k+1))
+	}
+
+	words := strings.Split(rep, joiner)
+	for i, w := range words {
+		words[i] = strings.Title(w)
+	}
+
+	return strings.Join(words, joiner)
 }
 
 func (e EventTrigger) Validate(ctx context.Context) error {

--- a/pkg/scaffold/template_test.go
+++ b/pkg/scaffold/template_test.go
@@ -110,7 +110,7 @@ export interface First {
   ts: number;
 };
 
-export interface SecondEvent {
+export interface Second_Event {
   name: string;
   data: {
     account: string;
@@ -121,7 +121,7 @@ export interface SecondEvent {
   ts: number;
 };
 
-export type EventTriggers = First | SecondEvent;
+export type EventTriggers = First | Second_Event;
 
 export type Args = {
   event: EventTriggers;


### PR DESCRIPTION
Fixes a few problems with TS type generation causing collisions and issues with types within the SDK.

- Fix ESLint rules potentially throwing for the generated file; add an ESLint exception line for type banning to the generated file 9bb58b4e742c3efa22344deb20bbe4eefc783158
- Use `Record<string, never>` instead of `{}`, as `{}` represents almost any JS entity 4893110fd746707b09eeac798a52bf8f0d7aba3b
- Use custom slugs for TS event type names - `github.pr` and `github/pr` would previously collide e13c193532e60b0550a0ca25349c5cb10be9b94f
- Require that `CustomEvent`s passed to `new Inngest()` have a `name` to be in-line with other event payloads 0511f28ccf42b7b21d1fd4f2a89d507a3f6b490c