### PR TITLE
Allow users to specify date strings within sleeps

### DIFF
--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/inngest/inngest/inngest"
+	"github.com/inngest/inngest/pkg/dateutil"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/xhit/go-str2duration/v2"
 )
@@ -50,6 +51,14 @@ func (g GeneratorOpcode) SleepDuration() (time.Duration, error) {
 	if g.Op != enums.OpcodeSleep {
 		return 0, fmt.Errorf("unable to return sleep duration for opcode %s", g.Op.String())
 	}
+
+	// Quick heuristic to check if this is likely a date layout
+	if len(g.Name) >= 10 {
+		if parsed, err := dateutil.Parse(g.Name); err == nil {
+			return time.Until(parsed).Round(time.Second), nil
+		}
+	}
+
 	return str2duration.ParseDuration(g.Name)
 }
 

--- a/pkg/execution/state/driver_response_test.go
+++ b/pkg/execution/state/driver_response_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/inngest/inngest/pkg/enums"
 	"github.com/stretchr/testify/require"
 )
 
@@ -167,7 +169,6 @@ func TestDriverResponseRetryable(t *testing.T) {
 }
 
 func TestDriverResponseFinal(t *testing.T) {
-
 	tests := []struct {
 		name     string
 		r        DriverResponse
@@ -215,4 +216,25 @@ func TestDriverResponseFinal(t *testing.T) {
 			require.Equal(t, test.expected, actual)
 		})
 	}
+}
+
+func TestGeneratorSleepDuration(t *testing.T) {
+	// Check that this works with a timestamp
+	at := time.Now().Truncate(time.Second).Add(time.Minute)
+	g := GeneratorOpcode{
+		Op:   enums.OpcodeSleep,
+		Name: at.Format(time.RFC3339),
+	}
+	duration, err := g.SleepDuration()
+	require.Nil(t, err)
+	require.WithinDuration(t, time.Now().Truncate(time.Second).Add(duration), at, time.Second)
+
+	// Check that this works with a duration string
+	g = GeneratorOpcode{
+		Op:   enums.OpcodeSleep,
+		Name: "60s",
+	}
+	duration, err = g.SleepDuration()
+	require.Nil(t, err)
+	require.WithinDuration(t, time.Now().Truncate(time.Second).Add(time.Minute), time.Now().Add(duration), time.Second)
 }


### PR DESCRIPTION
This allows the SDK to calculate deltas based off of durations themselves, vs passing the duration to our executor.  In effect, this reduces latency:  there is additional processing time when a step returns the sleep incurred by how we run steps via HTTP.

This helps decrease that latency to make sleeps more accurate.