### PR TITLE
Add cancellation via pauses to runner

### DIFF
--- a/pkg/cuedefs/v1/function.cue
+++ b/pkg/cuedefs/v1/function.cue
@@ -21,6 +21,8 @@ package v1
 		count:  uint & >=1 | *1
 		period: string
 	}
+
+	cancel?: [...#Cancel]
 }
 
 #EventTrigger: {
@@ -115,4 +117,14 @@ package v1
 		// if the event is not received within the TTL.
 		onTimeout?: bool
 	}
+}
+
+#Cancel: {
+	// event is the event name that will cancel this function
+	event: string
+	// timeout is the time at which the function can be cancelled, defaulting
+	// to the max runtime length.
+	timeout?: string
+	// if is an optional expression to match when cancelling the function.
+	if?: string
 }

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -55,7 +55,11 @@ func (g GeneratorOpcode) SleepDuration() (time.Duration, error) {
 	// Quick heuristic to check if this is likely a date layout
 	if len(g.Name) >= 10 {
 		if parsed, err := dateutil.Parse(g.Name); err == nil {
-			return time.Until(parsed).Round(time.Second), nil
+			at := time.Until(parsed).Round(time.Second)
+			if at < 0 {
+				return time.Duration(0), nil
+			}
+			return at, nil
 		}
 	}
 

--- a/pkg/execution/state/driver_response_test.go
+++ b/pkg/execution/state/driver_response_test.go
@@ -229,6 +229,15 @@ func TestGeneratorSleepDuration(t *testing.T) {
 	require.Nil(t, err)
 	require.WithinDuration(t, time.Now().Truncate(time.Second).Add(duration), at, time.Second)
 
+	// Check that this works with a timestamp
+	g = GeneratorOpcode{
+		Op:   enums.OpcodeSleep,
+		Name: "2022-01-01T10:30:00.468Z",
+	}
+	duration, err = g.SleepDuration()
+	require.Nil(t, err)
+	require.EqualValues(t, 0, duration.Seconds())
+
 	// Check that this works with a duration string
 	g = GeneratorOpcode{
 		Op:   enums.OpcodeSleep,

--- a/pkg/execution/state/inmemory/inmemory.go
+++ b/pkg/execution/state/inmemory/inmemory.go
@@ -162,6 +162,15 @@ func (m *mem) Cancel(ctx context.Context, i state.Identifier) error {
 		return fmt.Errorf("identifier not found")
 	}
 
+	switch s.Metadata().Status {
+	case state.RunStatusComplete:
+		return state.ErrFunctionComplete
+	case state.RunStatusFailed:
+		return state.ErrFunctionFailed
+	case state.RunStatusCancelled:
+		return state.ErrFunctionCancelled
+	}
+
 	instance := s.(memstate)
 	instance.metadata.Status = state.RunStatusCancelled
 	m.state[i.IdempotencyKey()] = instance

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -1,0 +1,70 @@
+package state
+
+import (
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/inngest"
+)
+
+// Pause allows steps of a function to be paused until some condition in the future.
+//
+// It pauses a specific workflow run via an Identifier, at a specific step in
+// the function as specified by Target.
+type Pause struct {
+	ID uuid.UUID `json:"id"`
+	// Identifier is the specific workflow run to resume.  This is required.
+	Identifier Identifier `json:"identifier"`
+	// Outgoing is the parent step for the pause.
+	Outgoing string `json:"outgoing"`
+	// Incoming is the step to run after the pause completes.
+	Incoming string `json:"incoming"`
+	// Expires is a time at which the pause can no longer be consumed.  This
+	// gives each pause of a function a TTL.  This is required.
+	//
+	// NOTE: the pause should remain within the backing state store for
+	// some perioud after the expiry time for checking timeout branches:
+	//
+	// If this pause has its OnTimeout flag set to true, we only traverse
+	// the edge if the event *has not* been received.  In order to check
+	// this, we enqueue a job that executes on the pause timeout:  if the
+	// pause has not yet been consumed we can safely assume the event was
+	// not received.  Therefore, we must be able to load the pause for some
+	// time after timeout.
+	Expires Time `json:"expires"`
+	// Event is an optional event that can resume the pause automatically,
+	// often paired with an expression.
+	Event *string `json:"event"`
+	// Expression is an optional expression that must match for the pause
+	// to be resumed.
+	Expression *string `json:"expression"`
+	// ExpressionData _optionally_ stores only the data that we need to evaluate
+	// the expression from the event.  This allows us to load pauses from the
+	// state store without round trips to fetch the entire function state.  If
+	// this is empty and the pause contains an expression, function state will
+	// be loaded from the store.
+	ExpressionData map[string]any `json:"data"`
+	// OnTimeout indicates that this incoming edge should only be ran
+	// when the pause times out, if set to true.
+	OnTimeout bool `json:"onTimeout"`
+	// DataKey is the name of the step to use when adding data to the function
+	// run's state after consuming this step.
+	//
+	// This allows us to create arbitrary "step" names for storing async event
+	// data from matching events in async edges, eg. `waitForEvent`.
+	//
+	// If DataKey is empty and data is provided when consuming a pause, no
+	// data will be saved in the function state.
+	DataKey string `json:"dataKey,omitempty"`
+	// Cancellation indicates whether this pause exists as a cancellation
+	// clause for a function.
+	//
+	// If so, when the matching pause is returned after processing an event
+	// the function's status is set to cancelled, preventing any future work.
+	Cancel bool `json:"cancel,omitempty"`
+}
+
+func (p Pause) Edge() inngest.Edge {
+	return inngest.Edge{
+		Outgoing: p.Outgoing,
+		Incoming: p.Incoming,
+	}
+}

--- a/pkg/execution/state/redis_state/lua/cancel.lua
+++ b/pkg/execution/state/redis_state/lua/cancel.lua
@@ -1,0 +1,20 @@
+--[[
+
+Output:
+  0: Successfully cancelled
+  1: Function already completed
+  2: Function already errored
+  3: Function already cancelled
+
+]]
+
+local metadataKey = KEYS[1]
+
+local value = tonumber(redis.call("HGET", metadataKey, "status"))
+if value ~= 0 then
+	-- Return the function status as an error
+	return value;
+end
+
+redis.call("HSET", metadataKey, "status", 3)
+return 0;

--- a/pkg/execution/state/redis_state/lua/finalize.lua
+++ b/pkg/execution/state/redis_state/lua/finalize.lua
@@ -1,0 +1,18 @@
+--[[
+
+Output:
+  0: Successfully finalized
+  1: Function ended
+
+]]
+
+local metadataKey = KEYS[1]
+
+if redis.call("HINCRBY", metadataKey, "pending", -1) ~= 0 then
+	return 0;
+end
+
+-- Set status to complete
+redis.call("HSET", metadataKey, "status", 1)
+
+return 1;

--- a/pkg/function/function.go
+++ b/pkg/function/function.go
@@ -67,6 +67,9 @@ type Function struct {
 	// that we have a single action specified in the current directory using
 	Steps map[string]Step `json:"steps,omitempty"`
 
+	// Cancel specifies cancellation signals for the function
+	Cancel []Cancel `json:"cancel,omitempty"`
+
 	// dir is an internal field which maps the root directory for the function
 	dir string
 }
@@ -89,6 +92,15 @@ type After struct {
 
 	// TODO: support multiple steps all finishing prior to running this once.
 	// Steps []string `json:"steps,omitempty"`
+}
+
+// Cancel represents a cancellation signal for a function.  When specified, this
+// will set up pauses which automatically cancel the function based off of matching
+// events and expressions.
+type Cancel struct {
+	Event   string  `json:"event"`
+	Timeout *string `json:"timeout"`
+	If      *string `json:"if"`
 }
 
 // New returns a new, empty function with a randomly generated ID.


### PR DESCRIPTION
This commit introduces pauses which act as cancellation signals to running functions.  Matching events are consumed by the runner and, if the pause's Cancel flag is true, will set the state for the function run to Cancelled, preventing any future step execution.