### PR TITLE
Fix bad Docker error link going to old docs URL

### DIFF
--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -41,7 +41,7 @@ func NewBuilder(ctx context.Context, opts BuilderUIOpts) (*BuilderUI, error) {
 			//
 			// Provide some simple hints to point to user towards installing Docker,
 			// and ideally our justification for requiring it.
-			fmt.Println("\n" + RenderWarning("Looks like there was a problem loading Docker.\n\nDocker is a required dependency for the CLI in order to build, run, and deploy your functions.\n\nYou can find more information here: https://www.inngest.com/docs/installation/."))
+			fmt.Println("\n" + RenderWarning("Looks like there was a problem loading Docker.\n\nDocker is a required dependency for the CLI in order to build, run, and deploy your functions.\n\nYou can find more information here: https://www.inngest.com/docs/cli/installation."))
 
 			return nil, err
 		}


### PR DESCRIPTION
Fixes a bad link when receiving a Docker error in the CLI.

Was linking to https://www.inngest.com/docs/installation/, and now links to https://www.inngest.com/docs/cli/installation.

https://www.inngest.com/docs/installation (without the trailing `/`) does correctly redirect to the new location, but we might as well use the actual URL.

Good spot, @EdPoole! 🙌