### PR TITLE
Add event time to stream, plus change "replay" wording

### DIFF
--- a/pkg/coreapi/graph/resolvers/events.go
+++ b/pkg/coreapi/graph/resolvers/events.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
+	"github.com/oklog/ulid/v2"
 )
 
 func (r *queryResolver) Event(ctx context.Context, query models.EventQuery) (*models.Event, error) {
@@ -20,7 +21,14 @@ func (r *queryResolver) Event(ctx context.Context, query models.EventQuery) (*mo
 	}
 
 	evt := evts[0]
+
 	createdAt := time.UnixMilli(evt.Timestamp)
+	if evt.Timestamp == 0 {
+		if id, err := ulid.Parse(evt.ID); err == nil {
+			createdAt = ulid.Time(id.Time())
+		}
+	}
+
 	payloadByt, err := json.Marshal(evt.Data)
 	if err != nil {
 		return nil, err
@@ -48,7 +56,14 @@ func (r *queryResolver) Events(ctx context.Context, query models.EventsQuery) ([
 
 	for _, evt := range evts {
 		name := evt.Name
+
 		createdAt := time.UnixMilli(evt.Timestamp)
+		if evt.Timestamp == 0 {
+			if id, err := ulid.Parse(evt.ID); err == nil {
+				createdAt = ulid.Time(id.Time())
+			}
+		}
+
 		payloadByt, err := json.Marshal(evt.Data)
 		if err != nil {
 			continue

--- a/ui/src/components/Event/Detail.tsx
+++ b/ui/src/components/Event/Detail.tsx
@@ -82,7 +82,7 @@ export default function EventDetail() {
                   <TimelineStaticContent
                     label="Event Received"
                     date={"2022-04-28T14:34:21"}
-                    actionBtn={<Button label="Retry" />}
+                    actionBtn={<Button label="Replay" />}
                   />
                 </TimelineRow>
 
@@ -133,7 +133,7 @@ export default function EventDetail() {
                 <CodeBlock modal={setModal} tabs={funcTabs} />
               </div>
               <div className="flex justify-end px-4 border-t border-slate-800/50 pt-4 mt-4">
-                <Button label="Retry" />
+                <Button label="Replay" />
               </div>
               <div className="pr-4 mt-4">
                 <TimelineRow status={EventStatus.Completed} iconOffset={0}>

--- a/ui/src/components/Event/Section.tsx
+++ b/ui/src/components/Event/Section.tsx
@@ -58,7 +58,7 @@ export const EventSection = ({ eventId }: EventSectionProps) => {
             date={event.createdAt}
             actionBtn={
               <Button
-                label="Retry"
+                label="Replay"
                 btnAction={() => {
                   sendEvent(event.raw);
                 }}

--- a/ui/src/components/Function/RunSection.tsx
+++ b/ui/src/components/Function/RunSection.tsx
@@ -71,7 +71,7 @@ export const FunctionRunSection = ({ runId }: FunctionRunSectionProps) => {
       // button={<Button label="Open Function" icon={<IconFeed />} />}
     >
       <div className="flex justify-end px-4 border-t border-slate-800/50 pt-4 mt-4">
-        <Button label="Retry" />
+        <Button label="Rerun" />
       </div>
       <div className="pr-4 mt-4">
         {run.timeline?.map((row, i, list) => (

--- a/ui/src/components/Function/Stream.tsx
+++ b/ui/src/components/Function/Stream.tsx
@@ -15,6 +15,11 @@ export const FuncStream = () => {
   const selectedRun = useAppSelector((state) => state.global.selectedRun);
   const dispatch = useAppDispatch();
 
+  // TODO: Normalize the feed here.  The dev server API gives us _every_ event;
+  // if a step is scheduled then runs immediately we can probably hide the scheduled
+  // event.  Similarly, if a step starts then finishes immediately we can probably
+  // only show the "Step finished" event.
+
   return (
     <>
       {functions.data?.functionRuns?.map((run, i, list) => (

--- a/ui/src/components/Timeline/TimelineFeedContent.tsx
+++ b/ui/src/components/Timeline/TimelineFeedContent.tsx
@@ -40,7 +40,7 @@ export default function TimelineFeedContent({
           : undefined
       }
     >
-      <span className="block text-3xs text-slate-300 pb-0.5">
+      <span className="block text-3xs text-slate-400 pb-0.5">
         <Time date={date} />
       </span>
       <div className="flex items-center">
@@ -48,7 +48,7 @@ export default function TimelineFeedContent({
           <span className={`${eventStatusStyles.text}`}>{name}</span>
         </h4>
         <span
-          className={`rounded-md ${eventStatusStyles.fnBG} text-slate-100 text-3xs font-semibold leading-none flex items-center justify-center py-1.5 px-2`}
+          className={`rounded-md ${eventStatusStyles.fnBG} ${badge > 0 ? "text-slate-100" : "text-slate-400"} text-3xs font-semibold leading-none flex items-center justify-center py-1.5 px-2`}
         >
           {badge}
         </span>

--- a/ui/src/components/Timeline/TimelineScrollContainer.tsx
+++ b/ui/src/components/Timeline/TimelineScrollContainer.tsx
@@ -8,7 +8,7 @@ export default function TimelineContainer({ children }) {
   return (
     <ul
       ref={animationRef}
-      className="bg-slate-950/50 border-r border-slate-800/40 overflow-y-scroll relative py-4 pr-2.5 shrink-0 col-start-2 row-start-2 row-span-2 pt-[60px]"
+      className="bg-slate-950/50 border-r border-slate-800/40 overflow-y-scroll relative py-4 pr-2.5 shrink-0 col-start-2 row-span-2"
     >
       {children}
     </ul>


### PR DESCRIPTION
`ts` seems to be empty with the dev server, which is an issue that needs to be fixed.  We can and should also pull out the timestamp from the ULID if timestamps are empty.

Events should use "replay" instead of retry, and functions should use "rerun".  "Retry" is only used for failures :)