### PR TITLE
Squash timeline

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -22,6 +22,7 @@ func NewCmdDev() *cobra.Command {
 	cmd.Flags().StringP("port", "p", "8288", "port to run the API on")
 	cmd.Flags().String("dir", ".", "directory to load functions from")
 	cmd.Flags().StringSliceP("sdk-url", "u", []string{}, "SDK URLs to load functions from")
+	cmd.Flags().Bool("docker", false, "enable docker-based steps")
 
 	return cmd
 }
@@ -47,10 +48,12 @@ func doDev(cmd *cobra.Command, args []string) {
 	}
 
 	urls, _ := cmd.Flags().GetStringSlice("sdk-url")
+	docker, _ := strconv.ParseBool(cmd.Flag("docker").Value.String())
 	opts := devserver.StartOpts{
 		Config:       *conf,
 		RootDir:      cmd.Flag("dir").Value.String(),
 		URLs:         urls,
+		Docker:       docker,
 		Autodiscover: len(urls) == 0,
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/golang/mock v1.6.0
 	github.com/google/cel-go v0.11.4
-	github.com/google/go-cmp v0.5.7
 	github.com/google/uuid v1.3.0
 	github.com/gosimple/slug v1.12.0
 	github.com/hashicorp/go-multierror v1.1.1
@@ -115,6 +114,7 @@ require (
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/wire v0.5.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.2.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect

--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -141,6 +141,7 @@ type ComplexityRoot struct {
 		FunctionRun func(childComplexity int) int
 		Name        func(childComplexity int) int
 		Output      func(childComplexity int) int
+		StepID      func(childComplexity int) int
 		Type        func(childComplexity int) int
 		WaitingFor  func(childComplexity int) int
 		Workspace   func(childComplexity int) int
@@ -148,8 +149,8 @@ type ComplexityRoot struct {
 
 	StepEventWait struct {
 		EventName  func(childComplexity int) int
+		ExpiryTime func(childComplexity int) int
 		Expression func(childComplexity int) int
-		WaitUntil  func(childComplexity int) int
 	}
 
 	Workspace struct {
@@ -645,6 +646,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.StepEvent.Output(childComplexity), true
 
+	case "StepEvent.stepID":
+		if e.complexity.StepEvent.StepID == nil {
+			break
+		}
+
+		return e.complexity.StepEvent.StepID(childComplexity), true
+
 	case "StepEvent.type":
 		if e.complexity.StepEvent.Type == nil {
 			break
@@ -673,19 +681,19 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.StepEventWait.EventName(childComplexity), true
 
+	case "StepEventWait.expiryTime":
+		if e.complexity.StepEventWait.ExpiryTime == nil {
+			break
+		}
+
+		return e.complexity.StepEventWait.ExpiryTime(childComplexity), true
+
 	case "StepEventWait.expression":
 		if e.complexity.StepEventWait.Expression == nil {
 			break
 		}
 
 		return e.complexity.StepEventWait.Expression(childComplexity), true
-
-	case "StepEventWait.waitUntil":
-		if e.complexity.StepEventWait.WaitUntil == nil {
-			break
-		}
-
-		return e.complexity.StepEventWait.WaitUntil(childComplexity), true
 
 	case "Workspace.id":
 		if e.complexity.Workspace.ID == nil {
@@ -959,6 +967,7 @@ enum StepEventType {
 type StepEvent {
   workspace: Workspace
   functionRun: FunctionRun
+  stepID: String
   name: String
   type: StepEventType
   output: String
@@ -969,9 +978,9 @@ type StepEvent {
 union FunctionRunEvent = FunctionEvent | StepEvent
 
 type StepEventWait {
-  waitUntil: Time!
   eventName: String
   expression: String
+  expiryTime: Time!
 }
 
 type FunctionRun {
@@ -2645,12 +2654,12 @@ func (ec *executionContext) fieldContext_FunctionRun_waitingFor(ctx context.Cont
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "waitUntil":
-				return ec.fieldContext_StepEventWait_waitUntil(ctx, field)
 			case "eventName":
 				return ec.fieldContext_StepEventWait_eventName(ctx, field)
 			case "expression":
 				return ec.fieldContext_StepEventWait_expression(ctx, field)
+			case "expiryTime":
+				return ec.fieldContext_StepEventWait_expiryTime(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type StepEventWait", field.Name)
 		},
@@ -4002,6 +4011,47 @@ func (ec *executionContext) fieldContext_StepEvent_functionRun(ctx context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _StepEvent_stepID(ctx context.Context, field graphql.CollectedField, obj *models.StepEvent) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_StepEvent_stepID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.StepID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_StepEvent_stepID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "StepEvent",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _StepEvent_name(ctx context.Context, field graphql.CollectedField, obj *models.StepEvent) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_StepEvent_name(ctx, field)
 	if err != nil {
@@ -4202,58 +4252,14 @@ func (ec *executionContext) fieldContext_StepEvent_waitingFor(ctx context.Contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "waitUntil":
-				return ec.fieldContext_StepEventWait_waitUntil(ctx, field)
 			case "eventName":
 				return ec.fieldContext_StepEventWait_eventName(ctx, field)
 			case "expression":
 				return ec.fieldContext_StepEventWait_expression(ctx, field)
+			case "expiryTime":
+				return ec.fieldContext_StepEventWait_expiryTime(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type StepEventWait", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _StepEventWait_waitUntil(ctx context.Context, field graphql.CollectedField, obj *models.StepEventWait) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_StepEventWait_waitUntil(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.WaitUntil, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(time.Time)
-	fc.Result = res
-	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_StepEventWait_waitUntil(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "StepEventWait",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -4336,6 +4342,50 @@ func (ec *executionContext) fieldContext_StepEventWait_expression(ctx context.Co
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _StepEventWait_expiryTime(ctx context.Context, field graphql.CollectedField, obj *models.StepEventWait) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_StepEventWait_expiryTime(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ExpiryTime, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(time.Time)
+	fc.Result = res
+	return ec.marshalNTime2timeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_StepEventWait_expiryTime(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "StepEventWait",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -7249,6 +7299,10 @@ func (ec *executionContext) _StepEvent(ctx context.Context, sel ast.SelectionSet
 
 			out.Values[i] = ec._StepEvent_functionRun(ctx, field, obj)
 
+		case "stepID":
+
+			out.Values[i] = ec._StepEvent_stepID(ctx, field, obj)
+
 		case "name":
 
 			out.Values[i] = ec._StepEvent_name(ctx, field, obj)
@@ -7290,13 +7344,6 @@ func (ec *executionContext) _StepEventWait(ctx context.Context, sel ast.Selectio
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("StepEventWait")
-		case "waitUntil":
-
-			out.Values[i] = ec._StepEventWait_waitUntil(ctx, field, obj)
-
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
 		case "eventName":
 
 			out.Values[i] = ec._StepEventWait_eventName(ctx, field, obj)
@@ -7305,6 +7352,13 @@ func (ec *executionContext) _StepEventWait(ctx context.Context, sel ast.Selectio
 
 			out.Values[i] = ec._StepEventWait_expression(ctx, field, obj)
 
+		case "expiryTime":
+
+			out.Values[i] = ec._StepEventWait_expiryTime(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -104,6 +104,7 @@ type FunctionRunsQuery struct {
 type StepEvent struct {
 	Workspace   *Workspace     `json:"workspace"`
 	FunctionRun *FunctionRun   `json:"functionRun"`
+	StepID      *string        `json:"stepID"`
 	Name        *string        `json:"name"`
 	Type        *StepEventType `json:"type"`
 	Output      *string        `json:"output"`
@@ -114,9 +115,9 @@ type StepEvent struct {
 func (StepEvent) IsFunctionRunEvent() {}
 
 type StepEventWait struct {
-	WaitUntil  time.Time `json:"waitUntil"`
 	EventName  *string   `json:"eventName"`
 	Expression *string   `json:"expression"`
+	ExpiryTime time.Time `json:"expiryTime"`
 }
 
 type UpdateActionVersionInput struct {

--- a/pkg/coreapi/graph/resolvers/events.go
+++ b/pkg/coreapi/graph/resolvers/events.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
+	"github.com/oklog/ulid/v2"
 )
 
 func (r *queryResolver) Event(ctx context.Context, query models.EventQuery) (*models.Event, error) {
@@ -20,7 +21,14 @@ func (r *queryResolver) Event(ctx context.Context, query models.EventQuery) (*mo
 	}
 
 	evt := evts[0]
+
 	createdAt := time.UnixMilli(evt.Timestamp)
+	if evt.Timestamp == 0 {
+		if id, err := ulid.Parse(evt.ID); err == nil {
+			createdAt = ulid.Time(id.Time())
+		}
+	}
+
 	payloadByt, err := json.Marshal(evt.Data)
 	if err != nil {
 		return nil, err
@@ -48,7 +56,14 @@ func (r *queryResolver) Events(ctx context.Context, query models.EventsQuery) ([
 
 	for _, evt := range evts {
 		name := evt.Name
+
 		createdAt := time.UnixMilli(evt.Timestamp)
+		if evt.Timestamp == 0 {
+			if id, err := ulid.Parse(evt.ID); err == nil {
+				createdAt = ulid.Time(id.Time())
+			}
+		}
+
 		payloadByt, err := json.Marshal(evt.Data)
 		if err != nil {
 			continue

--- a/pkg/coreapi/graph/resolvers/function_run.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run.resolver.go
@@ -49,21 +49,19 @@ func (r *functionRunResolver) Timeline(ctx context.Context, obj *models.Function
 				Output:    &output,
 			}
 
-			if h.Type == enums.HistoryTypeStepWaiting {
-				stepData, ok := h.Data.(state.HistoryStepWaiting)
-				if ok {
+			switch h.Type {
+			case enums.HistoryTypeStepWaiting:
+				if stepData, ok := h.Data.(state.HistoryStepWaiting); ok {
 					event.WaitingFor = &models.StepEventWait{
-						WaitUntil:  stepData.ExpiryTime,
+						ExpiryTime: stepData.ExpiryTime,
 						EventName:  stepData.EventName,
 						Expression: stepData.Expression,
 					}
 					event.Output = nil
 				}
-			} else {
-				stepData, ok := h.Data.(state.HistoryStep)
-				if ok {
+			default:
+				if stepData, ok := h.Data.(state.HistoryStep); ok {
 					event.Name = &stepData.Name
-
 					outputByt, err := json.Marshal(stepData.Data)
 					if err != nil {
 						continue
@@ -151,7 +149,7 @@ func (r *functionRunResolver) WaitingFor(ctx context.Context, obj *models.Functi
 		stepData, ok := h.Data.(state.HistoryStepWaiting)
 		if ok {
 			wait = &models.StepEventWait{
-				WaitUntil:  stepData.ExpiryTime,
+				ExpiryTime: stepData.ExpiryTime,
 				EventName:  stepData.EventName,
 				Expression: stepData.Expression,
 			}

--- a/pkg/coreapi/schema.graphql
+++ b/pkg/coreapi/schema.graphql
@@ -121,6 +121,7 @@ enum StepEventType {
 type StepEvent {
   workspace: Workspace
   functionRun: FunctionRun
+  stepID: String
   name: String
   type: StepEventType
   output: String
@@ -131,9 +132,9 @@ type StepEvent {
 union FunctionRunEvent = FunctionEvent | StepEvent
 
 type StepEventWait {
-  waitUntil: Time!
   eventName: String
   expression: String
+  expiryTime: Time!
 }
 
 type FunctionRun {

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -358,7 +358,7 @@ func (s *svc) handleQueueItem(ctx context.Context, item queue.Item) error {
 		// and this is a no-op - things should be atomic where possible.
 		//
 		// TODO: Add a unit test to ensure WG is 0 at the end of execution.
-		if err := s.state.Scheduled(ctx, item.Identifier, next.Incoming, 0, nil); err != nil {
+		if err := s.state.Scheduled(ctx, item.Identifier, next.Incoming, 0, &at); err != nil {
 			return fmt.Errorf("unable to schedule next step: %w", err)
 		}
 	}

--- a/pkg/execution/state/history.go
+++ b/pkg/execution/state/history.go
@@ -107,14 +107,16 @@ type HistoryStep struct {
 	// needed for the UI.
 	Name    string `json:"name"`
 	Attempt int    `json:"attempt"`
-	Data    any    `json:"data"`
+	// Opcode stores the generator opcode for this step, if any.
+	Opcode enums.Opcode `json:"opcode"`
+	// Data stores data for this event, dependent on the history type.
+	Data any `json:"data"`
 }
 
+// HistoryStepWaiting is stored within HistoryStep when we create a pause to wait
+// for an event
 type HistoryStepWaiting struct {
-	// The name of the step that is waiting.
-	Name string `json:"name"`
-
-	//
+	// EventName is the name of the event we're waiting for.
 	EventName  *string   `json:"eventName"`
 	Expression *string   `json:"expression"`
 	ExpiryTime time.Time `json:"expiry"`

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -469,6 +469,7 @@ func (m mgr) Started(ctx context.Context, id state.Identifier, stepID string, at
 
 func (m mgr) Scheduled(ctx context.Context, i state.Identifier, stepID string, attempt int, at *time.Time) error {
 	now := time.Now()
+
 	err := redis.NewScript(scripts["scheduled"]).Eval(
 		ctx,
 		m.r,
@@ -480,6 +481,7 @@ func (m mgr) Scheduled(ctx context.Context, i state.Identifier, stepID string, a
 			Data: state.HistoryStep{
 				ID:      stepID,
 				Attempt: attempt,
+				Data:    at,
 			},
 		},
 		now.UnixMilli(),

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "graphql": "^16.6.0",
     "graphql-request": "4",
     "monaco-editor": "^0.34.1",
+    "ms": "^2.1.3",
     "preact": "^10.11.2",
     "react-redux": "^8.0.5",
     "react-refractor": "^2.1.7",

--- a/ui/src/components/Event/Detail.tsx
+++ b/ui/src/components/Event/Detail.tsx
@@ -82,7 +82,7 @@ export default function EventDetail() {
                   <TimelineStaticContent
                     label="Event Received"
                     date={"2022-04-28T14:34:21"}
-                    actionBtn={<Button label="Retry" />}
+                    actionBtn={<Button label="Replay" />}
                   />
                 </TimelineRow>
 
@@ -133,7 +133,7 @@ export default function EventDetail() {
                 <CodeBlock modal={setModal} tabs={funcTabs} />
               </div>
               <div className="flex justify-end px-4 border-t border-slate-800/50 pt-4 mt-4">
-                <Button label="Retry" />
+                <Button label="Replay" />
               </div>
               <div className="pr-4 mt-4">
                 <TimelineRow status={EventStatus.Completed} iconOffset={0}>

--- a/ui/src/components/Event/Section.tsx
+++ b/ui/src/components/Event/Section.tsx
@@ -95,7 +95,7 @@ export const EventSection = ({ eventId }: EventSectionProps) => {
 
           let contextBar: ComponentChild | undefined;
 
-          if (run.waitingFor?.waitUntil) {
+          if (run.waitingFor?.expiryTime) {
             if (run.waitingFor.eventName) {
               contextBar = (
                 <div className="flex-1">
@@ -120,7 +120,7 @@ export const EventSection = ({ eventId }: EventSectionProps) => {
                       Function paused for sleep until&nbsp;
                       <strong>
                         {new Date(
-                          run.waitingFor.waitUntil
+                          run.waitingFor.expiryTime
                         ).toLocaleTimeString()}
                       </strong>
                     </div>

--- a/ui/src/components/Function/RunSection.tsx
+++ b/ui/src/components/Function/RunSection.tsx
@@ -71,7 +71,7 @@ export const FunctionRunSection = ({ runId }: FunctionRunSectionProps) => {
       // button={<Button label="Open Function" icon={<IconFeed />} />}
     >
       <div className="flex justify-end px-4 border-t border-slate-800/50 pt-4 mt-4">
-        <Button label="Retry" />
+        <Button label="Rerun" />
       </div>
       <div className="pr-4 mt-4">
         {run.timeline?.map((row, i, list) => (

--- a/ui/src/components/Function/Stream.tsx
+++ b/ui/src/components/Function/Stream.tsx
@@ -15,6 +15,11 @@ export const FuncStream = () => {
   const selectedRun = useAppSelector((state) => state.global.selectedRun);
   const dispatch = useAppDispatch();
 
+  // TODO: Normalize the feed here.  The dev server API gives us _every_ event;
+  // if a step is scheduled then runs immediately we can probably hide the scheduled
+  // event.  Similarly, if a step starts then finishes immediately we can probably
+  // only show the "Step finished" event.
+
   return (
     <>
       {functions.data?.functionRuns?.map((run, i, list) => (

--- a/ui/src/components/Function/Stream.tsx
+++ b/ui/src/components/Function/Stream.tsx
@@ -15,11 +15,6 @@ export const FuncStream = () => {
   const selectedRun = useAppSelector((state) => state.global.selectedRun);
   const dispatch = useAppDispatch();
 
-  // TODO: Normalize the feed here.  The dev server API gives us _every_ event;
-  // if a step is scheduled then runs immediately we can probably hide the scheduled
-  // event.  Similarly, if a step starts then finishes immediately we can probably
-  // only show the "Step finished" event.
-
   return (
     <>
       {functions.data?.functionRuns?.map((run, i, list) => (

--- a/ui/src/components/Time.tsx
+++ b/ui/src/components/Time.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "preact/hooks";
+import { useState, useEffect, useMemo, useCallback } from "preact/hooks";
 import TimeAgo, { Formatter, ReactTimeagoProps } from "react-timeago";
 
 interface TimeProps extends ReactTimeagoProps {
@@ -6,10 +6,6 @@ interface TimeProps extends ReactTimeagoProps {
 }
 
 const formatter: Formatter = (value, unit, suffix, ms, next) => {
-  if (unit === "second") {
-    return "less then a minute ago";
-  }
-
   return next?.(value, unit, suffix, ms);
 };
 
@@ -17,7 +13,15 @@ const formatter: Formatter = (value, unit, suffix, ms, next) => {
  * TODO Add tooltip on hover with full date.
  */
 export const Time = ({ date }: TimeProps) => {
+
   const tooltip = useMemo(() => new Date(date).toLocaleString(), [date]);
 
-  return <TimeAgo date={date} formatter={formatter} title={tooltip} />;
+  // Refresh each second such that this component re-renders times appropriately.
+  const [time, setTime] = useState(new Date().valueOf());
+  useEffect(() => {
+    const interval = setInterval(() => { setTime(new Date().valueOf()) }, 1000);
+    return () => { clearInterval(interval); };
+  }, []);
+
+  return <TimeAgo date={date} formatter={formatter} title={tooltip} key={time} />;
 };

--- a/ui/src/components/Timeline/TimelineFeedContent.tsx
+++ b/ui/src/components/Timeline/TimelineFeedContent.tsx
@@ -40,7 +40,7 @@ export default function TimelineFeedContent({
           : undefined
       }
     >
-      <span className="block text-3xs text-slate-300 pb-0.5">
+      <span className="block text-3xs text-slate-400 pb-0.5">
         <Time date={date} />
       </span>
       <div className="flex items-center">
@@ -48,7 +48,7 @@ export default function TimelineFeedContent({
           <span className={`${eventStatusStyles.text}`}>{name}</span>
         </h4>
         <span
-          className={`rounded-md ${eventStatusStyles.fnBG} text-slate-100 text-3xs font-semibold leading-none flex items-center justify-center py-1.5 px-2`}
+          className={`rounded-md ${eventStatusStyles.fnBG} ${badge > 0 ? "text-slate-100" : "text-slate-400"} text-3xs font-semibold leading-none flex items-center justify-center py-1.5 px-2`}
         >
           {badge}
         </span>

--- a/ui/src/components/Timeline/TimelineScrollContainer.tsx
+++ b/ui/src/components/Timeline/TimelineScrollContainer.tsx
@@ -8,7 +8,7 @@ export default function TimelineContainer({ children }) {
   return (
     <ul
       ref={animationRef}
-      className="bg-slate-950/50 border-r border-slate-800/40 overflow-y-scroll relative py-4 pr-2.5 shrink-0 col-start-2 row-start-2 row-span-2 pt-[60px]"
+      className="bg-slate-950/50 border-r border-slate-800/40 overflow-y-scroll relative py-4 pr-2.5 shrink-0 col-start-2 row-span-2"
     >
       {children}
     </ul>

--- a/ui/src/coreapi.ts
+++ b/ui/src/coreapi.ts
@@ -43,7 +43,7 @@ export const EVENT = gql`
         startedAt
         pendingSteps
         waitingFor {
-          waitUntil
+          expiryTime
           eventName
           expression
         }
@@ -61,7 +61,7 @@ export const FUNCTION_RUN = gql`
       startedAt
       pendingSteps
       waitingFor {
-        waitUntil
+        expiryTime
         eventName
         expression
       }
@@ -77,7 +77,7 @@ export const FUNCTION_RUN = gql`
           output
           name
           waitingFor {
-            waitUntil
+            expiryTime
             eventName
             expression
           }

--- a/ui/src/store/generated.ts
+++ b/ui/src/store/generated.ts
@@ -220,6 +220,7 @@ export type StepEvent = {
   functionRun?: Maybe<FunctionRun>;
   name?: Maybe<Scalars['String']>;
   output?: Maybe<Scalars['String']>;
+  stepID?: Maybe<Scalars['String']>;
   type?: Maybe<StepEventType>;
   waitingFor?: Maybe<StepEventWait>;
   workspace?: Maybe<Workspace>;
@@ -237,8 +238,8 @@ export enum StepEventType {
 export type StepEventWait = {
   __typename?: 'StepEventWait';
   eventName?: Maybe<Scalars['String']>;
+  expiryTime: Scalars['Time'];
   expression?: Maybe<Scalars['String']>;
-  waitUntil: Scalars['Time'];
 };
 
 export type UpdateActionVersionInput = {
@@ -268,14 +269,14 @@ export type GetEventQueryVariables = Exact<{
 }>;
 
 
-export type GetEventQuery = { __typename?: 'Query', event?: { __typename?: 'Event', id: string, name?: string | null, createdAt?: any | null, status?: EventStatus | null, pendingRuns?: number | null, raw?: string | null, functionRuns?: Array<{ __typename?: 'FunctionRun', id: string, name?: string | null, status?: FunctionRunStatus | null, startedAt?: any | null, pendingSteps?: number | null, waitingFor?: { __typename?: 'StepEventWait', waitUntil: any, eventName?: string | null, expression?: string | null } | null }> | null } | null };
+export type GetEventQuery = { __typename?: 'Query', event?: { __typename?: 'Event', id: string, name?: string | null, createdAt?: any | null, status?: EventStatus | null, pendingRuns?: number | null, raw?: string | null, functionRuns?: Array<{ __typename?: 'FunctionRun', id: string, name?: string | null, status?: FunctionRunStatus | null, startedAt?: any | null, pendingSteps?: number | null, waitingFor?: { __typename?: 'StepEventWait', expiryTime: any, eventName?: string | null, expression?: string | null } | null }> | null } | null };
 
 export type GetFunctionRunQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
 
-export type GetFunctionRunQuery = { __typename?: 'Query', functionRun?: { __typename?: 'FunctionRun', id: string, name?: string | null, status?: FunctionRunStatus | null, startedAt?: any | null, pendingSteps?: number | null, waitingFor?: { __typename?: 'StepEventWait', waitUntil: any, eventName?: string | null, expression?: string | null } | null, event?: { __typename?: 'Event', id: string, raw?: string | null } | null, timeline?: Array<{ __typename: 'FunctionEvent', createdAt?: any | null, output?: string | null, functionType?: FunctionEventType | null } | { __typename: 'StepEvent', createdAt?: any | null, output?: string | null, name?: string | null, stepType?: StepEventType | null, waitingFor?: { __typename?: 'StepEventWait', waitUntil: any, eventName?: string | null, expression?: string | null } | null }> | null } | null };
+export type GetFunctionRunQuery = { __typename?: 'Query', functionRun?: { __typename?: 'FunctionRun', id: string, name?: string | null, status?: FunctionRunStatus | null, startedAt?: any | null, pendingSteps?: number | null, waitingFor?: { __typename?: 'StepEventWait', expiryTime: any, eventName?: string | null, expression?: string | null } | null, event?: { __typename?: 'Event', id: string, raw?: string | null } | null, timeline?: Array<{ __typename: 'FunctionEvent', createdAt?: any | null, output?: string | null, functionType?: FunctionEventType | null } | { __typename: 'StepEvent', createdAt?: any | null, output?: string | null, name?: string | null, stepType?: StepEventType | null, waitingFor?: { __typename?: 'StepEventWait', expiryTime: any, eventName?: string | null, expression?: string | null } | null }> | null } | null };
 
 
 export const GetEventsStreamDocument = `
@@ -319,7 +320,7 @@ export const GetEventDocument = `
       startedAt
       pendingSteps
       waitingFor {
-        waitUntil
+        expiryTime
         eventName
         expression
       }
@@ -336,7 +337,7 @@ export const GetFunctionRunDocument = `
     startedAt
     pendingSteps
     waitingFor {
-      waitUntil
+      expiryTime
       eventName
       expression
     }
@@ -352,7 +353,7 @@ export const GetFunctionRunDocument = `
         output
         name
         waitingFor {
-          waitUntil
+          expiryTime
           eventName
           expression
         }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3096,7 +3096,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.1.1:
+ms@^2.1.1, ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==


### PR DESCRIPTION
Squashes the function log timeline to hide noisy events, eg. "scheduled", "started" if the step has finished.

