### PR TITLE
Replace in-memory queue with in-memory redis-backed queue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/charmbracelet/glamour v0.5.0
 	github.com/charmbracelet/lipgloss v0.5.0
 	github.com/dustinkirkland/golang-petname v0.0.0-20191129215211-8e5a1ed0cff0
+	github.com/emperorearth/vitess v2.0.0+incompatible
 	github.com/fergusstrange/embedded-postgres v1.17.0
 	github.com/fsouza/go-dockerclient v1.7.9
 	github.com/go-chi/chi/v5 v5.0.7

--- a/go.sum
+++ b/go.sum
@@ -556,6 +556,8 @@ github.com/emicklei/proto v1.6.15 h1:XbpwxmuOPrdES97FrSfpyy67SSCV/wBIKXqgJzh6hNw
 github.com/emicklei/proto v1.6.15/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
+github.com/emperorearth/vitess v2.0.0+incompatible h1:7eSXUBece2vmaVbr1kbsO7bInefgOkKmTVvDvAiCSAE=
+github.com/emperorearth/vitess v2.0.0+incompatible/go.mod h1:I3mIiW9CmaOuEHIDu9PjIRuejD+TOzpqtNbBUqDbWRY=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/pkg/cuedefs/config/config.cue
+++ b/pkg/cuedefs/config/config.cue
@@ -117,6 +117,8 @@ package config
 #QueueService: #InmemQueue | #SQSQueue | #RedisQueue
 
 #InmemQueue: {
+	// This uses the Redis driver with an in-memory redis instance
+	// under the hood.
 	backend: "inmemory"
 }
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -230,7 +230,7 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, from string
 			if resp != nil {
 				retryable = resp.Retryable()
 			}
-			l = log.Error().Err(err).Bool("retryable", retryable)
+			l = log.Warn().Err(err).Bool("retryable", retryable)
 			msg = "error executing step"
 		}
 		l.Str("run_id", id.RunID.String()).Str("step", from).Msg(msg)

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -224,7 +224,7 @@ func (s *svc) handleQueueItem(ctx context.Context, item queue.Item) error {
 			next := item
 			next.ErrorCount += 1
 			at := backoff.LinearJitterBackoff(next.ErrorCount)
-			l.Info().Interface("edge", next).Time("at", at).Msg("enqueueing retry")
+			l.Info().Interface("edge", next).Time("at", at).Err(err).Msg("enqueueing retry")
 			if err := s.queue.Enqueue(ctx, next, at); err != nil {
 				return fmt.Errorf("unable to enqueue retry: %w", err)
 			}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -161,6 +161,7 @@ func (s *svc) Pre(ctx context.Context) error {
 func (s *svc) Run(ctx context.Context) error {
 	logger.From(ctx).Info().Msg("subscribing to function queue")
 	return s.queue.Run(ctx, func(ctx context.Context, item queue.Item) error {
+		logger.From(ctx).Info().Interface("item", item).Msg("processing queue item")
 		// Don't stop the service on errors.
 		s.wg.Add(1)
 		defer s.wg.Done()

--- a/pkg/execution/queue/inmemoryqueue/inmemory.go
+++ b/pkg/execution/queue/inmemoryqueue/inmemory.go
@@ -21,6 +21,9 @@ var (
 )
 
 func New() queue.Queue {
+	r := miniredis.NewMiniRedis()
+	r.Start()
+
 	rc := redis.NewClient(&redis.Options{
 		Addr:     r.Addr(),
 		PoolSize: 100,

--- a/pkg/execution/queue/inmemoryqueue/inmemory.go
+++ b/pkg/execution/queue/inmemoryqueue/inmemory.go
@@ -1,29 +1,36 @@
 package inmemoryqueue
 
 import (
-	"context"
 	"sync"
-	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
 	"github.com/inngest/inngest/pkg/config/registration"
 	"github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state/redis_state"
 )
 
 func init() {
+	r = miniredis.NewMiniRedis()
+	r.Start()
 	registration.RegisterQueue(func() any { return &Config{} })
 }
 
-type Config struct {
-	l sync.Mutex
+var (
+	r *miniredis.Miniredis
+)
 
-	// mem stores a pointer to memory, acting as a singleton per Config
-	// instance created.
-	//
-	// We need to create "local" singletons per config struct in order to
-	// parallelize and unit test these correctly;  with a global singleton
-	// we may have unexpected data within our in-memory queue during parallel
-	// tests.
-	mem *mem
+func New() queue.Queue {
+	rc := redis.NewClient(&redis.Options{
+		Addr:     r.Addr(),
+		PoolSize: 100,
+	})
+	return redis_state.NewQueue(rc, redis_state.WithNumWorkers(100))
+}
+
+type Config struct {
+	l  sync.Mutex
+	rq queue.Queue
 }
 
 func (c *Config) QueueName() string { return "inmemory" }
@@ -32,13 +39,11 @@ func (c *Config) Queue() (queue.Queue, error) {
 	c.l.Lock()
 	defer c.l.Unlock()
 
-	if c.mem == nil {
-		c.mem = &mem{
-			q: make(chan queue.Item),
-		}
+	if c.rq != nil {
+		return c.rq, nil
 	}
-
-	return c.mem, nil
+	c.rq = New()
+	return c.rq, nil
 }
 
 func (c *Config) Producer() (queue.Producer, error) {
@@ -47,45 +52,4 @@ func (c *Config) Producer() (queue.Producer, error) {
 
 func (c *Config) Consumer() (queue.Consumer, error) {
 	return c.Queue()
-}
-
-// MemoryQueue is a simplistic, **non production ready** queue for processing steps
-// of functions, keepign the queue in-memory with zero persistence.  It is used
-// to simulate a production environment for local testing.
-type MemoryQueue interface {
-	queue.Queue
-	// Channel returns a channel which receives available jobs on the queue.
-	// This is helpful during testing.
-	Channel() chan queue.Item
-}
-
-type mem struct {
-	q chan queue.Item
-}
-
-func (m *mem) Enqueue(ctx context.Context, item queue.Item, at time.Time) error {
-	go func() {
-		<-time.After(time.Until(at))
-		m.q <- item
-	}()
-	return nil
-}
-
-func (m *mem) Channel() chan queue.Item {
-	return m.q
-}
-
-func (m *mem) Run(ctx context.Context, f queue.RunFunc) error {
-	for {
-		select {
-		case <-ctx.Done():
-			// We are shutting down.
-			return nil
-		case item := <-m.q:
-			if err := f(ctx, item); err != nil {
-				return err
-			}
-		}
-
-	}
 }

--- a/pkg/execution/queue/inmemoryqueue/inmemory.go
+++ b/pkg/execution/queue/inmemoryqueue/inmemory.go
@@ -12,7 +12,7 @@ import (
 
 func init() {
 	r = miniredis.NewMiniRedis()
-	r.Start()
+	_ = r.Start()
 	registration.RegisterQueue(func() any { return &Config{} })
 }
 
@@ -22,7 +22,7 @@ var (
 
 func New() queue.Queue {
 	r := miniredis.NewMiniRedis()
-	r.Start()
+	_ = r.Start()
 
 	rc := redis.NewClient(&redis.Options{
 		Addr:     r.Addr(),

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -18,24 +18,38 @@ const (
 //
 // Note that each individual implementation may wrap this to add their own fields,
 // such as a job identifier.
+//
+// TODO: Refactor this with the QueueItem in redis state to remove duplicates.
 type Item struct {
+	WorkspaceID uuid.UUID `json:"-"`
 	// Kind represents the job type and payload kind stored within Payload.
 	Kind string `json:"kind"`
 	// Identifier represents the unique workflow ID and run ID for the current job.
 	Identifier state.Identifier `json:"identifier"`
-	// ErrorCount stores the total number of errors that this job has currently procesed.
-	ErrorCount int `json:"errorCount"`
+	// Attempt stores the zero index attempt counter
+	Attempt int `json:"atts"`
+	// MaxAttempts is the maximum number of attempts we can retry.  When attempts == this,
+	// do not schedule another try.  If nil, use queue.DefaultRetryCount.
+	MaxAttempts *int `json:"maxAtts,omitEmpty"`
 	// Payload stores item-specific data for use when processing the item.  For example,
 	// this may contain the function's edge for running a step.
 	Payload any `json:"payload"`
 }
 
+func (i Item) GetMaxAttempts() int {
+	if i.MaxAttempts == nil {
+		return DefaultRetryCount
+	}
+	return *i.MaxAttempts
+}
+
 func (i *Item) UnmarshalJSON(b []byte) error {
 	type kind struct {
-		Kind       string           `json:"kind"`
-		Identifier state.Identifier `json:"identifier"`
-		ErrorCount int              `json:"errorCount"`
-		Payload    json.RawMessage  `json:"payload"`
+		Kind        string           `json:"kind"`
+		Identifier  state.Identifier `json:"identifier"`
+		Attempt     int              `json:"atts"`
+		MaxAttempts *int             `json:"maxAtts,omitEmpty"`
+		Payload     json.RawMessage  `json:"payload"`
 	}
 	temp := &kind{}
 	err := json.Unmarshal(b, temp)
@@ -45,7 +59,8 @@ func (i *Item) UnmarshalJSON(b []byte) error {
 
 	i.Kind = temp.Kind
 	i.Identifier = temp.Identifier
-	i.ErrorCount = temp.ErrorCount
+	i.Attempt = temp.Attempt
+	i.MaxAttempts = temp.MaxAttempts
 
 	switch temp.Kind {
 	case KindEdge:

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -30,7 +30,7 @@ type Item struct {
 	Attempt int `json:"atts"`
 	// MaxAttempts is the maximum number of attempts we can retry.  When attempts == this,
 	// do not schedule another try.  If nil, use queue.DefaultRetryCount.
-	MaxAttempts *int `json:"maxAtts,omitEmpty"`
+	MaxAttempts *int `json:"maxAtts,omitempty"`
 	// Payload stores item-specific data for use when processing the item.  For example,
 	// this may contain the function's edge for running a step.
 	Payload any `json:"payload"`
@@ -48,7 +48,7 @@ func (i *Item) UnmarshalJSON(b []byte) error {
 		Kind        string           `json:"kind"`
 		Identifier  state.Identifier `json:"identifier"`
 		Attempt     int              `json:"atts"`
-		MaxAttempts *int             `json:"maxAtts,omitEmpty"`
+		MaxAttempts *int             `json:"maxAtts,omitempty"`
 		Payload     json.RawMessage  `json:"payload"`
 	}
 	temp := &kind{}

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+const (
+	// DefaultRetryCount is used when no retry count for a job is specified.
+	DefaultRetryCount = 5
+)
+
 type Queue interface {
 	Producer
 	Consumer
@@ -21,7 +26,48 @@ type Consumer interface {
 	// Run is a blocking function which listens to the queue and executes the
 	// given function each time a new Item becomes available.
 	//
-	// This must only return an error if we fail to subscribe to the queue's
-	// implementation and can no longer process jobs.
+	// If the error from RunFunc is of type QuitError, the Run function will
+	// always requeue the job as a retry and terminate.
+	//
+	// If the error from RunFunc is of type RetryableError, the job will be
+	// re-enqueued if Retryable() returns true.  For all other errors, the
+	// job will automatically be retried.
 	Run(context.Context, RunFunc) error
+}
+
+// QuitError is an error that, when returned, quits the queue.  This always retries
+// an error.
+type QuitError interface {
+	AlwaysRetryableError
+	Quit()
+}
+
+// RetryableError represents an error that, when returned, optionally specifies
+// whether the job can be retried.
+type RetryableError interface {
+	Retryable() bool
+}
+
+// AlwaysRetryableError ignores MaxAttempts and always retries a job.
+type AlwaysRetryableError interface {
+	AlwaysRetryable()
+}
+
+// ShouldRetry returns whether we need to retry an error.
+func ShouldRetry(err error, attempt int, max int) bool {
+	if _, ok := err.(AlwaysRetryableError); ok {
+		return true
+	}
+
+	// This error specifies internally whether it should be retried.
+	retryable, isRetry := err.(RetryableError)
+	if isRetry && !retryable.Retryable() {
+		// The error says no;  cannot be bypassed.
+		return false
+	}
+
+	// So, at this point we either have a basic, non-interface error OR
+	// a retryable error which returns Retryable() true.
+	// Check max attempts.
+	return attempt < max
 }

--- a/pkg/execution/queue/queue_test.go
+++ b/pkg/execution/queue/queue_test.go
@@ -1,0 +1,74 @@
+package queue
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type retryableError struct {
+	error
+	retry bool
+}
+
+func (r retryableError) Retryable() bool {
+	return r.retry
+}
+
+type alwaysRetry struct {
+	error
+}
+
+func (alwaysRetry) AlwaysRetryable() {}
+
+func TestShouldRetry(t *testing.T) {
+	tests := []struct {
+		err      error
+		att      int
+		max      int
+		expected bool
+	}{
+		{
+			fmt.Errorf("basic err retries"),
+			1,
+			5,
+			true,
+		},
+		{
+			fmt.Errorf("basic err fails at max attempts"),
+			5,
+			5,
+			false,
+		},
+		{
+			retryableError{error: fmt.Errorf("retries if returns true"), retry: true},
+			1,
+			5,
+			true,
+		},
+		{
+			retryableError{error: fmt.Errorf("doesnt retry at max"), retry: true},
+			5,
+			5,
+			false,
+		},
+		{
+			retryableError{error: fmt.Errorf("doesnt retry if Retryable returns false"), retry: false},
+			1,
+			5,
+			false,
+		},
+		{
+			alwaysRetry{error: fmt.Errorf("always even if over max")},
+			10,
+			5,
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		actual := ShouldRetry(test.err, test.att, test.max)
+		require.Equal(t, test.expected, actual)
+	}
+}

--- a/pkg/execution/state/inmemory/inmemory.go
+++ b/pkg/execution/state/inmemory/inmemory.go
@@ -125,23 +125,10 @@ func (m *mem) Load(ctx context.Context, i state.Identifier) (state.State, error)
 	m.lock.RUnlock()
 
 	if ok {
-		// TODO: Return an error.
 		return s, nil
 	}
 
-	state := memstate{
-		metadata:   state.Metadata{},
-		identifier: i,
-		event:      map[string]interface{}{},
-		actions:    map[string]any{},
-		errors:     map[string]error{},
-	}
-
-	m.lock.Lock()
-	m.state[i.IdempotencyKey()] = state
-	m.lock.Unlock()
-
-	return state, nil
+	return nil, fmt.Errorf("state not found with identifier: %w", i.RunID)
 }
 
 func (m *mem) Started(ctx context.Context, i state.Identifier, stepID string, attempt int) error {

--- a/pkg/execution/state/inmemory/inmemory.go
+++ b/pkg/execution/state/inmemory/inmemory.go
@@ -128,7 +128,7 @@ func (m *mem) Load(ctx context.Context, i state.Identifier) (state.State, error)
 		return s, nil
 	}
 
-	return nil, fmt.Errorf("state not found with identifier: %w", i.RunID)
+	return nil, fmt.Errorf("state not found with identifier: %s", i.RunID.String())
 }
 
 func (m *mem) Started(ctx context.Context, i state.Identifier, stepID string, attempt int) error {

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -191,7 +191,7 @@ type QueueItem struct {
 	WorkflowID  uuid.UUID `json:"wfID"`
 	WorkspaceID uuid.UUID `json:"wsID"`
 	// LeaseID is a ULID which embeds a timestamp denoting when the lease expires.
-	LeaseID *ulid.ULID `json:"leaseID,omitEmpty"`
+	LeaseID *ulid.ULID `json:"leaseID,omitempty"`
 	// Data represents the enqueued data, eg. the edge to process or the pause
 	// to resume.
 	Data osqueue.Item `json:"data"`

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -188,12 +188,10 @@ type QueueItem struct {
 	//
 	// This is necessary for rescoring partitions and checking latencies.
 	AtMS        int64     `json:"at"`
-	WorkflowID  uuid.UUID `json:"workflowID"`
-	WorkspaceID uuid.UUID `json:"workspaceID"`
-	Attempt     int       `json:"attempt"`
-	MaxAttempts int       `json:"maxAttempts"`
+	WorkflowID  uuid.UUID `json:"wfID"`
+	WorkspaceID uuid.UUID `json:"wsID"`
 	// LeaseID is a ULID which embeds a timestamp denoting when the lease expires.
-	LeaseID *ulid.ULID `json:"leaseID"`
+	LeaseID *ulid.ULID `json:"leaseID,omitEmpty"`
 	// Data represents the enqueued data, eg. the edge to process or the pause
 	// to resume.
 	Data osqueue.Item `json:"data"`

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -32,8 +32,6 @@ func init() {
 }
 
 func (q *queue) Enqueue(ctx context.Context, item osqueue.Item, at time.Time) error {
-	// TODO: Workspace ID
-	// TODO: MaxAttempts
 	_, err := q.EnqueueItem(ctx, QueueItem{
 		AtMS:       at.UnixMilli(),
 		WorkflowID: item.Identifier.WorkflowID,
@@ -340,27 +338,33 @@ func (q *queue) process(ctx context.Context, qi QueueItem, f osqueue.RunFunc) er
 	}()
 
 	select {
-	case <-errCh:
+	case err := <-errCh:
 		// Job errored or extending lease errored.  Cancel the job ASAP.
 		jobCancel()
 
-		if qi.Attempt == qi.MaxAttempts {
-			// XXX: Increase failed counter here.
-			logger.From(ctx).Debug().Interface("item", qi).Msg("dequeueing failed job")
-
-			// Dequeue entirely.
-			if err := q.Dequeue(ctx, qi); err != nil {
+		if osqueue.ShouldRetry(err, qi.Data.Attempt, qi.Data.GetMaxAttempts()) {
+			// XXX: Increase errored count
+			qi.Data.Attempt += 1
+			logger.From(ctx).Info().Err(err).Interface("item", qi).Msg("requeuing job")
+			if err := q.Requeue(ctx, qi, backoff.LinearJitterBackoff(qi.Data.Attempt)); err != nil {
+				logger.From(ctx).Error().Err(err).Interface("item", qi).Msg("error requeuing job")
 				return err
 			}
 			return nil
 		}
 
-		// TODO: Remove requeueing from the execution service;  just return a failed job here.
-		qi.Attempt += 1
-		qi.Data.ErrorCount += 1
-		if err := q.Requeue(ctx, qi, backoff.LinearJitterBackoff(qi.Attempt)); err != nil {
-			logger.From(ctx).Error().Err(err).Interface("item", qi).Msg("error requeuing job")
+		// Dequeue this entirely, as this permanently failed.
+		// XXX: Increase permanently failed counter here.
+		logger.From(ctx).Info().Interface("item", qi).Msg("dequeueing failed job")
+		if err := q.Dequeue(ctx, qi); err != nil {
+			return err
 		}
+
+		if _, ok := err.(osqueue.QuitError); ok {
+			q.quit <- err
+			return err
+		}
+
 	case <-doneCh:
 		//logger.From(ctx).Debug().Interface("item", qi).Msg("queue item complete")
 		if err := q.Dequeue(ctx, qi); err != nil {

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -306,7 +306,7 @@ func (q *queue) process(ctx context.Context, qi QueueItem, f osqueue.RunFunc) er
 		}
 
 		// Track the latency on average globally.
-		latency := time.Now().Sub(time.UnixMilli(qi.AtMS))
+		latency := time.Since(time.UnixMilli(qi.AtMS))
 		latencyAvg.AddValue(float64(latency))
 		// XXX: Add indinvidual latency to metrics
 

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -31,6 +31,18 @@ func init() {
 	latencySem = &sync.Mutex{}
 }
 
+func (q *queue) Enqueue(ctx context.Context, item osqueue.Item, at time.Time) error {
+	// TODO: Workspace ID
+	// TODO: MaxAttempts
+	_, err := q.EnqueueItem(ctx, QueueItem{
+		AtMS:       at.UnixMilli(),
+		WorkflowID: item.Identifier.WorkflowID,
+		Data:       item,
+	}, at)
+	logger.From(ctx).Trace().Interface("item", item).Msg("enqueued item")
+	return err
+}
+
 func (q *queue) Run(ctx context.Context, f osqueue.RunFunc) error {
 	for i := int32(0); i < q.numWorkers; i++ {
 		go q.worker(ctx, f)

--- a/pkg/execution/state/redis_state/queue_processor_test.go
+++ b/pkg/execution/state/redis_state/queue_processor_test.go
@@ -78,6 +78,10 @@ func TestQueueRunSequential(t *testing.T) {
 	require.True(t, ulid.Time(q1.sequentialLease().Time()).Before(time.Now()))
 }
 
+func max(i int) *int {
+	return &i
+}
+
 func TestQueueRunBasic(t *testing.T) {
 	r := miniredis.RunT(t)
 	rc := redis.NewClient(&redis.Options{Addr: r.Addr(), PoolSize: 50})
@@ -91,10 +95,10 @@ func TestQueueRunBasic(t *testing.T) {
 	idA, idB := uuid.New(), uuid.New()
 	items := []QueueItem{
 		{
-			WorkflowID:  idA,
-			MaxAttempts: 3,
+			WorkflowID: idA,
 			Data: osqueue.Item{
-				Kind: osqueue.KindEdge,
+				Kind:        osqueue.KindEdge,
+				MaxAttempts: max(3),
 				Identifier: state.Identifier{
 					WorkflowID: idA,
 					RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
@@ -102,10 +106,10 @@ func TestQueueRunBasic(t *testing.T) {
 			},
 		},
 		{
-			WorkflowID:  idB,
-			MaxAttempts: 1,
+			WorkflowID: idB,
 			Data: osqueue.Item{
-				Kind: osqueue.KindEdge,
+				Kind:        osqueue.KindEdge,
+				MaxAttempts: max(1),
 				Identifier: state.Identifier{
 					WorkflowID: idB,
 					RunID:      ulid.MustNew(ulid.Now(), rand.Reader),

--- a/pkg/execution/state/redis_state/queue_processor_test.go
+++ b/pkg/execution/state/redis_state/queue_processor_test.go
@@ -229,7 +229,11 @@ func TestQueueRunExtended(t *testing.T) {
 				added,
 				added-next,
 			)
+			latencySem.Lock()
+			// NOTE: RUNNING THIS WITH THE RACE CHECKER SIGNIFICANTLY REDUCES LATENCY.
+			// The actual latency should be checked without --race on.
 			fmt.Printf("AVG LATENCY: %dms\n", time.Duration(latencyAvg.GetEWMA()).Milliseconds())
+			latencySem.Unlock()
 			prev = next
 		}
 	}()

--- a/pkg/execution/state/redis_state/queue_processor_test.go
+++ b/pkg/execution/state/redis_state/queue_processor_test.go
@@ -229,6 +229,7 @@ func TestQueueRunExtended(t *testing.T) {
 				added,
 				added-next,
 			)
+			fmt.Printf("AVG LATENCY: %dms\n", time.Duration(latencyAvg.GetEWMA()).Milliseconds())
 			prev = next
 		}
 	}()
@@ -251,6 +252,7 @@ func TestQueueRunExtended(t *testing.T) {
 	fmt.Printf("Handled %d items\n", h)
 
 	require.EqualValues(t, a, h, "Added %d, handled %d (delta: %d)", a, h, a-h)
+
 	cancel()
 
 	<-time.After(time.Second)

--- a/vendor/github.com/emperorearth/vitess/LICENSE
+++ b/vendor/github.com/emperorearth/vitess/LICENSE
@@ -1,0 +1,28 @@
+Copyright 2012, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/emperorearth/vitess/go/ewma/ewma.go
+++ b/vendor/github.com/emperorearth/vitess/go/ewma/ewma.go
@@ -1,0 +1,70 @@
+// Copyright 2015, Google Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file
+
+// Package ewma implements exponentially weighted moving averages(EWMA).
+// See https://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average
+// for formal definitions.
+package ewma
+
+import (
+	"math"
+
+	log "github.com/golang/glog"
+)
+
+const (
+	// DefaultWeightingFactor is the default smoothing factor α
+	// The value 0.875 is used in TCP RTT estimation
+	DefaultWeightingFactor = 0.875
+)
+
+// EWMA is the class to calculate exponentially weighted moving average of a series of data
+type EWMA struct {
+	// The weighting factor α
+	weightingFactor float64
+	// The current value of the average
+	currAverage float64
+}
+
+// NewEWMA returns a EWMA object which can calculate
+// EWMA of a series of data gradually added to it
+func NewEWMA(wf float64) *EWMA {
+	if wf < 0 || wf > 1.0 {
+		log.Infof(
+			"Invalid weighting factor: %v, using default value(%v) instead.",
+			wf,
+			DefaultWeightingFactor,
+		)
+		wf = DefaultWeightingFactor
+	}
+	return &EWMA{
+		weightingFactor: wf,
+		currAverage:     math.NaN(),
+	}
+}
+
+// AddValue adds a new data point into the EWMA calculation,
+// by which the EWMA is automatically updated
+func (e *EWMA) AddValue(value float64) {
+	// the first value added
+	if math.IsNaN(e.currAverage) {
+		e.currAverage = value
+	} else {
+		e.currAverage = e.weightingFactor*e.currAverage + (1.0-e.weightingFactor)*value
+	}
+}
+
+// GetEWMA returns the EWMA calculated from historical data
+func (e *EWMA) GetEWMA() float64 {
+	if math.IsNaN(e.currAverage) {
+		// No value has been added yet, returning 0
+		return 0
+	}
+	return e.currAverage
+}
+
+// Size makes EWMA to satisfy cache.Value interface
+func (e *EWMA) Size() int {
+	return 1
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -468,6 +468,9 @@ github.com/emirpasic/gods/lists/arraylist
 github.com/emirpasic/gods/trees
 github.com/emirpasic/gods/trees/binaryheap
 github.com/emirpasic/gods/utils
+# github.com/emperorearth/vitess v2.0.0+incompatible
+## explicit
+github.com/emperorearth/vitess/go/ewma
 # github.com/fergusstrange/embedded-postgres v1.17.0
 ## explicit; go 1.13
 github.com/fergusstrange/embedded-postgres


### PR DESCRIPTION
This uses the queue we're open-sourcing for the entire dev server.  It also adds better retrying capabilities that we use internally to the open-source model.