### PR TITLE
Scope pauses by workspace ID

### DIFF
--- a/pkg/devserver/devserver_test.go
+++ b/pkg/devserver/devserver_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/inngest/inngest/inngest"
 	"github.com/inngest/inngest/pkg/config"
 	"github.com/inngest/inngest/pkg/config/registration"
@@ -160,7 +161,7 @@ func TestEngine_async(t *testing.T) {
 	// And we should have a pause.
 	require.Eventually(t, func() bool {
 		n := 0
-		iter, err := sm.PausesByEvent(ctx, "test/continue")
+		iter, err := sm.PausesByEvent(ctx, uuid.UUID{}, "test/continue")
 		require.NoError(t, err)
 		for iter.Next(ctx) {
 			n++
@@ -182,7 +183,7 @@ func TestEngine_async(t *testing.T) {
 	require.EqualValues(t, 1, len(driver.Executed))
 	require.Eventually(t, func() bool {
 		n := 0
-		iter, err := sm.PausesByEvent(ctx, "test/continue")
+		iter, err := sm.PausesByEvent(ctx, uuid.UUID{}, "test/continue")
 		require.NoError(t, err)
 		for iter.Next(ctx) {
 			n++

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -314,6 +314,8 @@ func (e *executor) executeAction(ctx context.Context, id state.Identifier, actio
 		l = &log
 	}
 
+	// TODO: BEFORE RUNNING ERROR, RETURN FINAL
+
 	definition, err := e.al.Action(ctx, action.DSN, action.Version)
 	if err != nil {
 		return nil, fmt.Errorf("error loading action: %w", err)

--- a/pkg/execution/executor/service_test.go
+++ b/pkg/execution/executor/service_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/inngest/inngest/inngest"
 	"github.com/inngest/inngest/pkg/backoff"
 	"github.com/inngest/inngest/pkg/config"
@@ -354,7 +355,7 @@ func TestHandleAsyncService(t *testing.T) {
 	require.Equal(t, 0, len(run.Actions()))
 	require.Equal(t, 3, run.Metadata().Pending)
 
-	pauses, err := data.sm.PausesByEvent(ctx, "async/continue")
+	pauses, err := data.sm.PausesByEvent(ctx, uuid.UUID{}, "async/continue")
 	require.NoError(t, err)
 	require.True(t, pauses.Next(ctx))
 	pause := pauses.Val(ctx)

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -353,7 +353,8 @@ func (s *svc) functions(ctx context.Context, evt event.Event) error {
 // pauses searches for and triggers all pauses from this event.
 func (s *svc) pauses(ctx context.Context, evt event.Event) error {
 	logger.From(ctx).Trace().Msg("querying for pauses")
-	iter, err := s.state.PausesByEvent(ctx, evt.Name)
+	// TODO: Add workspace ID handling to the open source runner.
+	iter, err := s.state.PausesByEvent(ctx, uuid.UUID{}, evt.Name)
 	if err != nil {
 		return fmt.Errorf("error finding event pauses: %w", err)
 	}

--- a/pkg/execution/state/inmemory/inmemory.go
+++ b/pkg/execution/state/inmemory/inmemory.go
@@ -360,13 +360,13 @@ func (m *mem) LeasePause(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
-func (m *mem) PausesByEvent(ctx context.Context, eventName string) (state.PauseIterator, error) {
+func (m *mem) PausesByEvent(ctx context.Context, workspaceID uuid.UUID, eventName string) (state.PauseIterator, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	subset := []*state.Pause{}
 	for _, p := range m.pauses {
 		copied := p
-		if p.Event != nil && *p.Event == eventName {
+		if p.Event != nil && *p.Event == eventName && p.WorkspaceID == workspaceID {
 			subset = append(subset, &copied)
 		}
 	}
@@ -379,7 +379,7 @@ func (m *mem) PauseByStep(ctx context.Context, i state.Identifier, actionID stri
 	m.lock.Lock()
 	defer m.lock.Unlock()
 	for _, p := range m.pauses {
-		if p.Identifier.RunID == i.RunID && p.Outgoing == actionID {
+		if p.Identifier.RunID == i.RunID && p.Incoming == actionID {
 			return &p, nil
 		}
 	}

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -38,8 +38,8 @@ type PauseMutater interface {
 // PauseGetter allows a runner to return all existing pauses by event or by outgoing ID.  This
 // is required to fetch pauses to automatically continue workflows.
 type PauseGetter interface {
-	// PausesByEvent returns all pauses for a given event.
-	PausesByEvent(ctx context.Context, eventName string) (PauseIterator, error)
+	// PausesByEvent returns all pauses for a given event, in a given workspace.
+	PausesByEvent(ctx context.Context, workspaceID uuid.UUID, eventName string) (PauseIterator, error)
 
 	// PauseByStep returns a specific pause for a given workflow run, from a given step.
 	//
@@ -83,6 +83,8 @@ type PauseManager interface {
 // the function as specified by Target.
 type Pause struct {
 	ID uuid.UUID `json:"id"`
+	// WorkspaceID scopes the pause to a specific workspace.
+	WorkspaceID uuid.UUID `json:"wsID"`
 	// Identifier is the specific workflow run to resume.  This is required.
 	Identifier Identifier `json:"identifier"`
 	// Outgoing is the parent step for the pause.

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -49,7 +49,7 @@ type KeyGenerator interface {
 	PauseID(context.Context, uuid.UUID) string
 
 	// PauseEvent returns the key used to store data for
-	PauseEvent(context.Context, string) string
+	PauseEvent(context.Context, uuid.UUID, string) string
 
 	// PauseStep returns the prefix of the key used within PauseStep.  This lets us
 	// iterate through all pauses for a given identifier
@@ -98,8 +98,8 @@ func (d DefaultKeyFunc) PauseLease(ctx context.Context, id uuid.UUID) string {
 	return fmt.Sprintf("%s:pause-lease:%s", d.Prefix, id.String())
 }
 
-func (d DefaultKeyFunc) PauseEvent(ctx context.Context, event string) string {
-	return fmt.Sprintf("%s:pause-events:%s", d.Prefix, event)
+func (d DefaultKeyFunc) PauseEvent(ctx context.Context, workspaceID uuid.UUID, event string) string {
+	return fmt.Sprintf("%s:pause-events:%s:%s", d.Prefix, workspaceID, event)
 }
 
 func (d DefaultKeyFunc) PauseStepPrefix(ctx context.Context, id state.Identifier) string {


### PR DESCRIPTION
This PR scopes workspaces by pause ID, ensuring that we load pauses by event scoped by workspace in the open source repo.  This helps make the open-source implementation mirror our existing implementation in use.

We also ensure that pauses by step use the incoming ID, which is the correct way to do things.