### PR TITLE
Fix `WaitForEventOpts()` parsing incorrect `GeneratorOpCode` field

### DIFF
--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -41,7 +41,12 @@ func (g GeneratorOpcode) WaitForEventOpts() (*WaitForEventOpts, error) {
 		return nil, fmt.Errorf("An event name must be provided when waiting for an event")
 	}
 
-	if err := json.Unmarshal(g.Data, &opts); err != nil {
+	byt, err := json.Marshal(g.Opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(byt, &opts); err != nil {
 		return nil, err
 	}
 	return &opts, nil


### PR DESCRIPTION
## Summary

`GeneratorOpCode.WaitForEventOpts()` was attempting to parse the wrong field `g.Data` instead of `g.Opts`. This was causing any `waitForEvent()` request from the SDK to throw an error and fail.

Integration test foundations for these types of issues are also present in [inngest/inngest-js](https://github.com/inngest/inngest-js) - we need to create some step function tests there to help highlight any issues alongside the testing in this repo.

`g.Opts` here is a `map[string]interface{}`, so we marshal it to a byte slice before unmarshalling back in to our `WaitForEventOpts` struct.

## Related

- inngest/inngest-js#55