### PR TITLE
Open-source idempotency in redis queue

### DIFF
--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -22,6 +22,9 @@ const (
 //
 // TODO: Refactor this with the QueueItem in redis state to remove duplicates.
 type Item struct {
+	// JobID is an internal ID used to deduplicate queue items.
+	JobID *string `json:"-"`
+	// Workspace is the ID that this workspace job belongs to
 	WorkspaceID uuid.UUID `json:"wsID"`
 	// Kind represents the job type and payload kind stored within Payload.
 	Kind string `json:"kind"`

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -129,10 +129,11 @@ type QueueKeyGenerator interface {
 	// PartitionMeta returns the key to store metadata for partitions, eg.
 	// the number of items enqueued, number in progress, etc.
 	PartitionMeta(id string) string
-
 	// Sequential returns the key which allows a worker to claim sequential processing
 	// of the partitions.
 	Sequential() string
+	// Idempotency stores the map for storing idempotency keys in redis
+	Idempotency(key string) string
 }
 
 type DefaultQueueKeyGenerator struct {
@@ -161,4 +162,8 @@ func (d DefaultQueueKeyGenerator) PartitionMeta(id string) string {
 
 func (d DefaultQueueKeyGenerator) Sequential() string {
 	return fmt.Sprintf("%s:queue:sequential", d.Prefix)
+}
+
+func (d DefaultQueueKeyGenerator) Idempotency(key string) string {
+	return fmt.Sprintf("%s:queue:seen:%s", d.Prefix, key)
 }

--- a/pkg/execution/state/redis_state/lua/queue/dequeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/dequeue.lua
@@ -1,16 +1,18 @@
 --[[
 
 Output:
-  0: Successfully leased item
+  0: Successfully dequeued item
   1: Queue item not found
 
 ]]
 
-local queueKey      = KEYS[1]
-local queueIndexKey = KEYS[2]
-local partitionKey  = KEYS[3]
+local queueKey       = KEYS[1]
+local queueIndexKey  = KEYS[2]
+local partitionKey   = KEYS[3]
+local idempotencyKey = KEYS[4]
 
 local queueID = ARGV[1]
+local idempotencyTTL = tonumber(ARGV[2])
 
 -- $include(get_queue_item.lua)
 -- Fetch this item to see if it was in progress prior to deleting.
@@ -22,6 +24,7 @@ end
 redis.call("HDEL", queueKey, queueID)
 redis.call("ZREM", queueIndexKey, queueID)
 redis.call("HINCRBY", partitionKey, "len", -1) -- len of enqueued items decreases
+redis.call("SETEX", idempotencyKey, idempotencyTTL, "")
 
 if item.leaseID ~= nil and item.leaseID ~= cjson.null then
 	-- Remove total number in progress, if there's a lease.

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -32,14 +32,23 @@ func init() {
 }
 
 func (q *queue) Enqueue(ctx context.Context, item osqueue.Item, at time.Time) error {
+	id := ""
+	if item.JobID != nil {
+		id = *item.JobID
+	}
+
 	_, err := q.EnqueueItem(ctx, QueueItem{
+		ID:          id,
 		AtMS:        at.UnixMilli(),
 		WorkspaceID: item.WorkspaceID,
 		WorkflowID:  item.Identifier.WorkflowID,
 		Data:        item,
 	}, at)
+	if err != nil {
+		return err
+	}
 	logger.From(ctx).Debug().Interface("item", item).Msg("enqueued item")
-	return err
+	return nil
 }
 
 func (q *queue) Run(ctx context.Context, f osqueue.RunFunc) error {


### PR DESCRIPTION
This PR introduces idempotency over a configurable period to jobs in the partitioned queue.

When a job is dequeued, we enter the job ID into an idempotency key with a configurable timeout.  Enqeueuing jobs ensures that the idempotency key doesn't exist and that the job doesn't exist.