### PR TITLE
SDK tooling pass

### DIFF
--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -398,6 +398,7 @@ func (s *svc) scheduleGeneratorResponse(ctx context.Context, item queue.Item, r 
 		pauseID := uuid.New()
 		err = s.state.SavePause(ctx, state.Pause{
 			ID:         pauseID,
+			DataKey:    r.Generator.ID,
 			Identifier: item.Identifier,
 			Outgoing:   edge.Edge.Outgoing,
 			Incoming:   edge.Edge.Incoming,

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -41,7 +41,12 @@ func (g GeneratorOpcode) WaitForEventOpts() (*WaitForEventOpts, error) {
 		return nil, fmt.Errorf("An event name must be provided when waiting for an event")
 	}
 
-	if err := json.Unmarshal(g.Data, &opts); err != nil {
+	byt, err := json.Marshal(g.Opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(byt, &opts); err != nil {
 		return nil, err
 	}
 	return &opts, nil

--- a/ui/src/components/Event/Section.tsx
+++ b/ui/src/components/Event/Section.tsx
@@ -1,5 +1,6 @@
 import { ComponentChild } from "preact";
 import { useMemo } from "preact/hooks";
+import { usePrettyJson } from "../../hooks/usePrettyJson";
 import { useSendEventMutation } from "../../store/devApi";
 import {
   EventStatus,
@@ -9,6 +10,7 @@ import {
 import { selectRun, showEventSendModal } from "../../store/global";
 import { useAppDispatch, useAppSelector } from "../../store/hooks";
 import Button from "../Button";
+import CodeBlock from "../CodeBlock";
 import ContentCard from "../Content/ContentCard";
 import FuncCard from "../Function/FuncCard";
 import TimelineRow from "../Timeline/TimelineRow";
@@ -25,6 +27,7 @@ export const EventSection = ({ eventId }: EventSectionProps) => {
   // const [pollingInterval, setPollingInterval] = useState(1000);
   const query = useGetEventQuery({ id: eventId }, { pollingInterval: 1000 });
   const event = useMemo(() => query.data?.event, [query.data?.event]);
+  const eventPayload = usePrettyJson(event?.raw);
 
   /**
    * Stop polling for changes when an event is in a final state.
@@ -52,6 +55,11 @@ export const EventSection = ({ eventId }: EventSectionProps) => {
       active
       // button={<Button label="Open Event" icon={<IconFeed />} />}
     >
+      {eventPayload ? (
+        <div className="px-4 pt-4">
+          <CodeBlock tabs={[{ label: "Payload", content: eventPayload }]} />
+        </div>
+      ) : null}
       <div className="pr-4 pt-4">
         <TimelineRow status={EventStatus.Completed} iconOffset={0}>
           <TimelineStaticContent
@@ -104,12 +112,14 @@ export const EventSection = ({ eventId }: EventSectionProps) => {
                       Function waiting for{" "}
                       <strong>{run.waitingFor.eventName}</strong> event
                       {run.waitingFor.expression
-                        ? "matching the expression"
+                        ? " matching the expression:"
                         : ""}
                     </div>
                     {/* <div>Continue button</div> */}
                   </div>
-                  <pre>whassis</pre>
+                  <pre className="bg-slate-900 px-2 py-0.5 rounded border border-slate-700 mt-2">
+                    {run.waitingFor.expression}
+                  </pre>
                 </div>
               );
             } else {


### PR DESCRIPTION
Fixes some sporadic issues for using step functions with the dev UI:

- Show event payload in every event section, separate from function runs 56e052a8dc144d29c68ab6152b1a1391ff67d96d
- Show expression used for event matching when `waitForEvent` is used 56e052a8dc144d29c68ab6152b1a1391ff67d96d
- Ensure `pause.DataKey` is set when adding `waitForEvent` pauses b05dfee505f33815546a9c76c65cddbb9af34d32
  > Fixes pauses always being consumed with `null` data even if an event was successfully found.