### PR TITLE
Remove information about architecture from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ And, in this CLI:
 
 - The **DevServer** combines all of the components and basic drivers for each into a single system which loads all functions on disk, handles incoming events via the API and executes functions, all returning a readable output to the developer. (_Note - the DevServer does not run a Core API as functions are loaded directly from disk_)
 
-To learn how these components all work together, [check out the in-depth architecture doc](To learn how these components all work together, [check out the in-depth architecture doc](/docs/ARCHITECTURE.md). For specific information on how the DevServer works and how it compares to production [read this doc](/docs/DEVSERVER_ARCHITECTURE.md).
-).
+For specific information on how the DevServer works and how it compares to production [read this doc](/docs/DEVSERVER_ARCHITECTURE.md).
 
 <br />
 


### PR DESCRIPTION
Removing text referring to /docs/ARCHITECTURE.md since the file doesn't exists and link results in 404.