### PR TITLE
Ignore partition not found errors during processing

### DIFF
--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -201,8 +201,14 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, f osque
 		// TODO: Increase metric for partition contention
 		return nil
 	}
+	if err == ErrPartitionNotFound {
+		// Another worker must have pocessed this partition between
+		// this worker's peek and process.  Increase partition
+		// contention metric and continue.  This is unsolvable.
+		return nil
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("error leasing partition: %w", err)
 	}
 
 	// Ensure that peek doesn't take longer than the partition lease, to

--- a/tests/testdsl/testdsl.go
+++ b/tests/testdsl/testdsl.go
@@ -245,7 +245,7 @@ func RequireStepRetries(step string, count int) Proc {
 			}
 		}
 
-		fmt.Printf("> Checking step %s permanently failed after %d retries (waiting %f seconds)\n", step, count-1, time.Until(backoffTime).Seconds())
+		fmt.Printf("> Checking step %s permanently failed after %d retries (waiting %f seconds)\n", step, count-1, time.Until(backoffTime.Add(20*time.Second)).Seconds())
 		if err := timeout(time.Until(backoffTime), func() error {
 			return requireLogFields(ctx, td, map[string]any{
 				"caller":  "executor",


### PR DESCRIPTION
We can safely ignore this error as partitions are only deleted after processing;  this error occurs when two or more workers are attempting to process partitions with contention, and one has already processed all jobs before another worker attempts to lease the partition.