### PR TITLE
Add `make dev` command for command local dev build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+dev:
+	goreleaser build --single-target --snapshot --rm-dist
+
 test:
 	sh -c 'cd ./pkg/cuedefs && cue vet ./tests/... -c'
 	sh -c 'cd ./pkg/cuedefs && cue eval ./tests/... -c'


### PR DESCRIPTION
I keep adding this to my `make build` command and @djfarrelly needed the same this week.

Might as well add it.