### PR TITLE
Ensure we respect retries > maximum when enqueuing children

### DIFF
--- a/inngest/action.go
+++ b/inngest/action.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+
+	"github.com/inngest/inngest/pkg/consts"
 )
 
 // ActionVersion represents a version of an action defined via its cue configuration.
@@ -40,6 +42,13 @@ type ActionVersion struct {
 	Runtime RuntimeWrapper `json:"runtime"`
 
 	Retries *RetryOptions `json:"retries,omitempty"`
+}
+
+func (av ActionVersion) RetryAttempts() int {
+	if av.Retries != nil && av.Retries.Attempts != nil {
+		return *av.Retries.Attempts
+	}
+	return consts.DefaultRetryCount
 }
 
 type VersionInfo struct {

--- a/pkg/execution/executor/executor_test.go
+++ b/pkg/execution/executor/executor_test.go
@@ -443,7 +443,7 @@ func TestExecute_edge_expressions(t *testing.T) {
 	require.ElementsMatch(t, []string{"run-step-child"}, availableIDs(edges))
 }
 
-func availableIDs(edges []inngest.Edge) []string {
+func availableIDs(edges []state.AvailableEdge) []string {
 	strs := make([]string, len(edges))
 	for n, e := range edges {
 		strs[n] = e.Incoming


### PR DESCRIPTION
We now need to know the maximum number of retries when enqueueing jobs onto the queue;  the queue handles retrying jobs.

NOTE: The executor still needs to be aware of total retry counts in order to properly update the state store, eg. when a step permanently fails.