### PR TITLE
Use state.ErrFunctionCancelled in executor

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -18,11 +18,10 @@ import (
 )
 
 var (
-	ErrRuntimeRegistered    = fmt.Errorf("runtime is already registered")
-	ErrNoStateManager       = fmt.Errorf("no state manager provided")
-	ErrNoActionLoader       = fmt.Errorf("no action loader provided")
-	ErrNoRuntimeDriver      = fmt.Errorf("runtime driver for action not found")
-	ErrFunctionRunCancelled = fmt.Errorf("function has been cancelled")
+	ErrRuntimeRegistered = fmt.Errorf("runtime is already registered")
+	ErrNoStateManager    = fmt.Errorf("no state manager provided")
+	ErrNoActionLoader    = fmt.Errorf("no action loader provided")
+	ErrNoRuntimeDriver   = fmt.Errorf("runtime driver for action not found")
 )
 
 // Executor manages executing actions.  It interfaces over a state store to save
@@ -66,7 +65,7 @@ type Executor interface {
 	// and the context terminates, we must store the output or async data in workflow
 	// state then schedule the child functions else the workflow will terminate early.
 	//
-	// Execution will fail with no response and ErrFunctionRunCancelled if this function
+	// Execution will fail with no response and state.ErrFunctionCancelled if this function
 	// run has been cancelled by an external event or process.
 	Execute(ctx context.Context, id state.Identifier, from string, attempt int) (*state.DriverResponse, error)
 }
@@ -172,7 +171,7 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, from string
 	}
 
 	if s.Metadata().Status == enums.RunStatusCancelled {
-		return nil, ErrFunctionRunCancelled
+		return nil, state.ErrFunctionCancelled
 	}
 
 	if e.log != nil {

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -201,7 +201,7 @@ func (s *svc) handleQueueItem(ctx context.Context, item queue.Item) error {
 
 	// Check if the execution is cancelled, and if so finalize and terminate early.
 	// This prevents steps from scheduling children.
-	if err == ErrFunctionRunCancelled {
+	if err == state.ErrFunctionCancelled {
 		_ = s.state.Finalized(ctx, item.Identifier, edge.Incoming, item.Attempt)
 		return nil
 	}


### PR DESCRIPTION
This removes an execution.ErrFunctionRunCancelled error which represents the exact same use case - thats unnecessary and will cause bugs.