### PR TITLE
Allow queue kind -> queue name mapping

### DIFF
--- a/pkg/devserver/devserver_test.go
+++ b/pkg/devserver/devserver_test.go
@@ -167,7 +167,7 @@ func TestEngine_async(t *testing.T) {
 			n++
 		}
 		return n == 1
-	}, 100*time.Millisecond, 10*time.Millisecond)
+	}, 200*time.Millisecond, 10*time.Millisecond)
 
 	// 3.
 	// Once we have the pause, we can send another event.  This shouldn't continue
@@ -189,7 +189,7 @@ func TestEngine_async(t *testing.T) {
 			n++
 		}
 		return n == 1
-	}, 100*time.Millisecond, 10*time.Millisecond)
+	}, 200*time.Millisecond, 10*time.Millisecond)
 
 	// 4.
 	// Finally, assert that sending an event which matches the pause conditions

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -886,7 +886,7 @@ func requireItemScoreEquals(t *testing.T, r *miniredis.Miniredis, item QueueItem
 	score, err := r.ZScore(defaultQueueKey.QueueIndex(item.WorkflowID.String()), item.ID)
 	parsed := time.UnixMilli(int64(score))
 	require.NoError(t, err)
-	require.WithinDuration(t, expected.Truncate(time.Millisecond), parsed, 10*time.Millisecond)
+	require.WithinDuration(t, expected.Truncate(time.Millisecond), parsed, 15*time.Millisecond)
 }
 
 func requirePartitionScoreEquals(t *testing.T, r *miniredis.Miniredis, wid uuid.UUID, expected time.Time) {


### PR DESCRIPTION
This PR introduces a new helper option for the redis queue, allowing the queue to select queue names within `Enqueue` based off of job kinds. If there's no mapping for a job kind the queue name is left nil, which defaults to the workflow ID.

This helps resolve interface differences with the top-level queue package and this state's implementation;  we currently can't enqueue a redis_state.QueueItem directly and so can't choose a queue name without this mapping.

In the future we should refactor the queue package and redis queue to resolve differences and clean up this API.