### PR TITLE
Add Metadata() fetch call to state.Loader interface

### DIFF
--- a/pkg/enums/run_status.go
+++ b/pkg/enums/run_status.go
@@ -21,6 +21,15 @@ const (
 	RunStatusCancelled
 )
 
+// RunStatusEnded returns whether the function has ended based off of the
+// run status.
+func RunStatusEnded(s RunStatus) bool {
+	if s == RunStatusCancelled || s == RunStatusCompleted || s == RunStatusFailed {
+		return true
+	}
+	return false
+}
+
 func (r RunStatus) MarshalBinary() ([]byte, error) {
 	byt := []byte{}
 	return strconv.AppendInt(byt, int64(r), 10), nil

--- a/pkg/execution/state/inmemory/inmemory.go
+++ b/pkg/execution/state/inmemory/inmemory.go
@@ -128,6 +128,19 @@ func (m *mem) New(ctx context.Context, input state.Input) (state.State, error) {
 
 }
 
+func (m *mem) Metadata(ctx context.Context, runID ulid.ULID) (*state.Metadata, error) {
+	m.lock.RLock()
+	s, ok := m.state[runID]
+	m.lock.RUnlock()
+
+	if ok {
+		m := s.Metadata()
+		return &m, nil
+	}
+
+	return nil, fmt.Errorf("state not found with identifier: %s", runID.String())
+}
+
 func (m *mem) Load(ctx context.Context, runID ulid.ULID) (state.State, error) {
 	m.lock.RLock()
 	s, ok := m.state[runID]

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -350,6 +350,15 @@ func (m mgr) Cancel(ctx context.Context, id state.Identifier) error {
 	return fmt.Errorf("unknown return value cancelling function: %d", status)
 }
 
+func (m mgr) Metadata(ctx context.Context, runID ulid.ULID) (*state.Metadata, error) {
+	metadata, err := m.metadata(ctx, runID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load metadata: %w", err)
+	}
+	meta := metadata.Metadata()
+	return &meta, nil
+}
+
 func (m mgr) Load(ctx context.Context, runID ulid.ULID) (state.State, error) {
 	// XXX: Use a pipeliner to improve speed.
 	metadata, err := m.metadata(ctx, runID)

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -177,6 +177,10 @@ type FunctionCallback func(context.Context, Identifier, enums.RunStatus)
 
 // Loader allows loading of previously stored state based off of a given Identifier.
 type Loader interface {
+	// Metadata returns run metadata for the given identifier.  It may be cheaper
+	// than a full load in cases where only the metadata is necessary.
+	Metadata(ctx context.Context, runID ulid.ULID) (*Metadata, error)
+
 	// Load returns run state for the given identifier.
 	Load(ctx context.Context, runID ulid.ULID) (State, error)
 


### PR DESCRIPTION
This is cheaper than loading a full run for certain implementations and is preferable when only run metadata is necessary to load.