### PR TITLE
Add `inngest-cli` alias for `inngest-cli` package

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -9,6 +9,7 @@
     "build": "tsc"
   },
   "bin": {
+    "inngest-cli": "./bin/inngest",
     "inngest": "./bin/inngest"
   },
   "repository": {


### PR DESCRIPTION
Node 14's `npx` version looks like it doesn't enjoy the default `bin` definition `"inngest"` having a different name to the package itself `"inngest-cli"`.

Adding another alias so earlier versions are happy.