### PR TITLE
Use a single port for the devserver

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -21,7 +21,13 @@ import (
 // APIs can be mounted to this service to provide additional functionality.
 //
 // XXX (tonyhb): refactor this to remove extra mounts.
-func NewService(c config.Config, mounts ...chi.Router) service.Service {
+
+type Mount struct {
+	At     string
+	Router chi.Router
+}
+
+func NewService(c config.Config, mounts ...Mount) service.Service {
 	return &apiServer{
 		config: c,
 		mounts: mounts,
@@ -33,7 +39,7 @@ type apiServer struct {
 	api       *API
 	publisher pubsub.Publisher
 
-	mounts []chi.Router
+	mounts []Mount
 }
 
 func (a *apiServer) Name() string {
@@ -54,7 +60,7 @@ func (a *apiServer) Pre(ctx context.Context) error {
 	a.api = api.(*API)
 
 	for _, m := range a.mounts {
-		api.Mount("/", m)
+		api.Mount(m.At, m.Router)
 	}
 
 	a.publisher, err = pubsub.NewPublisher(ctx, a.config.EventStream.Service)

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/inngest/inngest/pkg/cli"
 	"github.com/inngest/inngest/pkg/config"
-	"github.com/inngest/inngest/pkg/coreapi"
 	"github.com/inngest/inngest/pkg/coredata/inmemory"
 	inmemorydatastore "github.com/inngest/inngest/pkg/coredata/inmemory"
 	"github.com/inngest/inngest/pkg/enums"
@@ -92,7 +91,6 @@ func start(ctx context.Context, opts StartOpts, loader *inmemorydatastore.FSLoad
 		executor.WithEnvReader(envreader),
 		executor.WithState(sm),
 	)
-	coreapi := coreapi.NewService(opts.Config, coreapi.WithRunner(runner))
 
 	// Add notifications to the state manager so that we can store new function runs
 	// in the core API service.
@@ -106,7 +104,7 @@ func start(ctx context.Context, opts StartOpts, loader *inmemorydatastore.FSLoad
 		})
 	}
 
-	return service.StartAll(ctx, ds, runner, exec, coreapi)
+	return service.StartAll(ctx, ds, runner, exec)
 }
 
 func prepareDockerImages(ctx context.Context, dir string) (*inmemorydatastore.FSLoader, error) {

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -88,6 +88,9 @@ func (d *devserver) Pre(ctx context.Context) error {
 		APIReadWriter: datarw,
 		Runner:        d.runner,
 	})
+	if err != nil {
+		return err
+	}
 
 	// Create a new data API directly in the devserver.  This allows us to inject
 	// the data API into the dev server port, providing a single router for the dev
@@ -95,7 +98,11 @@ func (d *devserver) Pre(ctx context.Context) error {
 
 	// Merge the dev server API (for handling files & registration) with the data
 	// API into the event API router.
-	d.apiservice = api.NewService(d.opts.Config, api.Mount{"/", devAPI}, api.Mount{"/v0", core.Router})
+	d.apiservice = api.NewService(
+		d.opts.Config,
+		api.Mount{At: "/", Router: devAPI},
+		api.Mount{At: "/v0", Router: core.Router},
+	)
 
 	// Fetch workspace information in the background, retrying if this
 	// errors out.  This is optimistic, and it doesn't matter if it fails.

--- a/ui/src/store/baseApi.ts
+++ b/ui/src/store/baseApi.ts
@@ -2,9 +2,9 @@ import { createApi } from "@reduxjs/toolkit/query/react";
 import { graphqlRequestBaseQuery } from "@rtk-query/graphql-request-base-query";
 import { GraphQLClient } from "graphql-request";
 
-const hostname = window.location.hostname;
+const hostname = window.location.host;
 
-export const client = new GraphQLClient(`http://${hostname}:8300/gql`);
+export const client = new GraphQLClient(`http://${hostname}/v0/gql`);
 
 export const api = createApi({
   baseQuery: graphqlRequestBaseQuery({ client }),

--- a/ui/src/store/devApi.ts
+++ b/ui/src/store/devApi.ts
@@ -25,10 +25,13 @@ export const devApi = createApi({
         /**
          * In dev mode, always assume that the dev server API is available at 8288. This
          * allows us to use a separate hot-reloading port for the UI when developing.
+         *
+         * NOTE: This has been removed to allow people to run `inngest dev --port 8111`:
+         * users run multiple copies of inngest - one for dev, one for tests - as mock
+         * environments.
          */
         if (import.meta.env.DEV) {
           const localDevUrl = new URL(url, devUrl);
-          localDevUrl.port = "8288";
           url = localDevUrl.href;
         }
 


### PR DESCRIPTION
This moves the ingest API, the core data API, and the dev server hosting UI into a single port with routers mounted at different prefixes.

Running `inngest dev --port 9191` will boot the dev server on port 9191 with all APIs listening on that port.

You can then run your project with
`INNGEST_DEVSERVER_URL=http://127.0.0.1:9191` as an environment variable to connect to a specific instance of the devserver