### PR TITLE
Handle text responses in HTTP driver

### DIFF
--- a/ui/src/components/CodeBlock/SyntaxHighlight.tsx
+++ b/ui/src/components/CodeBlock/SyntaxHighlight.tsx
@@ -40,5 +40,14 @@ export const SyntaxHighlight = ({
   language = "json",
   className,
 }: SyntaxHighlightProps) => {
-  return <Refractor language={language} value={code} className={className} />;
+
+  // Some types are dyanmically asserted to be string;  this is a
+  // safety check in case an API fails to respond with what we expect.
+  // Refractor will throw an error and break the UI.
+  let value = code;
+  if (typeof code !== "string") {
+    value = JSON.stringify(code);
+  }
+
+  return <Refractor language={language} value={value} className={className} />;
 };

--- a/ui/src/hooks/usePrettyJson.ts
+++ b/ui/src/hooks/usePrettyJson.ts
@@ -16,7 +16,8 @@ export const usePrettyJson = (
 
       return JSON.stringify(data, null, 2);
     } catch (e) {
-      return null;
+      console.warn("Unable to parse content as JSON: ", json);
+      return "";
     }
   }, [json]);
 };


### PR DESCRIPTION
We always need to account for text responses as there are situations out of our control in which the SDK might not even be invoked.  Let's say you deploy behind a proxy and the proxy is broken.  The proxy always replies with text.  Our driver shouldn't error;  it should treat the text as output and properly retry.