### PR TITLE
Add `b64decode` to expression engine

### DIFF
--- a/pkg/expressions/expressions_test.go
+++ b/pkg/expressions/expressions_test.go
@@ -113,6 +113,47 @@ func TestEvaluateExpression(t *testing.T) {
 			false,
 			"",
 		},
+		// Base64 decoding a JSON map and accesing object
+		{
+			`json_parse(b64decode(event.data.encoded)).nested.data`,
+			map[string]interface{}{
+				"event": event.Event{
+					Data: map[string]interface{}{
+						"encoded": "eyJuZXN0ZWQiOnsiZGF0YSI6InllYSJ9fQ==",
+						// this is the JSON-decoded base64 string above.
+						"decoded": map[string]any{
+							"nested": map[string]any{
+								"data": "yea",
+							},
+						},
+					},
+				},
+			},
+			"yea",
+			nil,
+			false,
+			"",
+		},
+		{
+			`json_parse(b64decode(event.data.encoded)).nested.data == "yea"`,
+			map[string]interface{}{
+				"event": event.Event{
+					Data: map[string]interface{}{
+						"encoded": "eyJuZXN0ZWQiOnsiZGF0YSI6InllYSJ9fQ==",
+						// this is the JSON-decoded base64 string above.
+						"decoded": map[string]any{
+							"nested": map[string]any{
+								"data": "yea",
+							},
+						},
+					},
+				},
+			},
+			true,
+			nil,
+			false,
+			"",
+		},
 
 		// Basic boolean expressions
 		{

--- a/pkg/expressions/expressions_test.go
+++ b/pkg/expressions/expressions_test.go
@@ -53,11 +53,68 @@ func TestEvaluateExpression(t *testing.T) {
 		expr string
 		data map[string]interface{}
 
-		expected  bool
+		expected  any
 		earliest  *time.Time
 		shouldErr bool
 		errMsg    string
 	}{
+		// Returning data
+		{
+			"event.data.name",
+			map[string]interface{}{
+				"event": event.Event{
+					Data: map[string]interface{}{
+						"name": "Tester McTestyFace",
+					},
+				},
+			},
+			"Tester McTestyFace",
+			nil,
+			false,
+			"",
+		},
+		{
+			"uppercase(event.data.name) + ' is my name'",
+			map[string]interface{}{
+				"event": event.Event{
+					Data: map[string]interface{}{
+						"name": "Tester McTestyFace",
+					},
+				},
+			},
+			"TESTER MCTESTYFACE is my name",
+			nil,
+			false,
+			"",
+		},
+
+		// Base64 decoding
+		{
+			`b64decode("aGkgdGhlcmUh") + " - b64 data"`,
+			map[string]interface{}{
+				"event": event.Event{
+					Data: map[string]interface{}{},
+				},
+			},
+			"hi there! - b64 data",
+			nil,
+			false,
+			"",
+		},
+		{
+			`b64decode("aGkgdGhlcmUh") == "hi there!"`,
+			map[string]interface{}{
+				"event": event.Event{
+					Data: map[string]interface{}{},
+				},
+			},
+			true,
+			nil,
+			false,
+			"",
+		},
+
+		// Basic boolean expressions
 		{
 			"null > 0",
 			map[string]interface{}{

--- a/pkg/expressions/overloads.go
+++ b/pkg/expressions/overloads.go
@@ -1,6 +1,7 @@
 package expressions
 
 import (
+	"encoding/base64"
 	"strings"
 	"time"
 
@@ -111,6 +112,16 @@ func celDeclarations() []*exprpb.Decl {
 			),
 		),
 		decls.NewFunction(
+			"b64decode",
+			decls.NewOverload(
+				"b64decode",
+				[]*expr.Type{decls.String},
+				decls.String,
+			),
+		),
+
+		// Time functions
+		decls.NewFunction(
 			"date",
 			decls.NewOverload(
 				"to_date",
@@ -179,6 +190,14 @@ func celOverloads() []*functions.Overload {
 			Unary: func(i ref.Val) ref.Val {
 				str, _ := i.Value().(string)
 				return types.String(strings.ToUpper(str))
+			},
+		},
+		{
+			Operator: "b64decode",
+			Unary: func(i ref.Val) ref.Val {
+				str, _ := i.Value().(string)
+				byt, _ := base64.StdEncoding.DecodeString(str)
+				return types.String(byt)
 			},
 		},
 		{

--- a/pkg/expressions/overloads.go
+++ b/pkg/expressions/overloads.go
@@ -2,6 +2,7 @@ package expressions
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"strings"
 	"time"
 
@@ -119,6 +120,14 @@ func celDeclarations() []*exprpb.Decl {
 				decls.String,
 			),
 		),
+		decls.NewFunction(
+			"json_parse",
+			decls.NewOverload(
+				"json_parse",
+				[]*expr.Type{decls.String},
+				decls.Any,
+			),
+		),
 
 		// Time functions
 		decls.NewFunction(
@@ -198,6 +207,15 @@ func celOverloads() []*functions.Overload {
 				str, _ := i.Value().(string)
 				byt, _ := base64.StdEncoding.DecodeString(str)
 				return types.String(byt)
+			},
+		},
+		{
+			Operator: "json_parse",
+			Unary: func(i ref.Val) ref.Val {
+				str, _ := i.Value().(string)
+				mapped := map[string]interface{}{}
+				_ = json.Unmarshal([]byte(str), &mapped)
+				return types.NewStringInterfaceMap(types.DefaultTypeAdapter, mapped)
 			},
 		},
 		{


### PR DESCRIPTION
This adds a custom function overload to our expression engine, allowing users to deocde base64 data within expressions.

This is needed for some platforms.  An example:  Google Pub/Sub can base64 encode data within an event;  in order to use this event data for things like event filtering, debounces, idempotency keys etc. you'll need to base64 decode the data within an expression.