### PR TITLE
Preserve HTTP methods on redirect

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver_test.go
+++ b/pkg/execution/driver/httpdriver/httpdriver_test.go
@@ -1,0 +1,31 @@
+package httpdriver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedirect(t *testing.T) {
+	count := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch count {
+		case 8:
+			require.Equal(t, http.MethodPost, r.Method)
+			_, _ = w.Write([]byte("ok"))
+		default:
+			w.Header().Add("location", "/redirected/")
+			w.WriteHeader(301)
+		}
+		count++
+	}))
+	defer ts.Close()
+
+	res, status, err := DefaultExecutor.do(context.Background(), ts.URL, nil)
+	require.NoError(t, err)
+	require.Equal(t, 200, status)
+	require.Equal(t, []byte("ok"), res)
+}


### PR DESCRIPTION
https://railway.app, in some circumstances, 301 redirecs the Inngest API to the same URL with an added "\r\n" suffix.  This breaks the httpdriver's POST calls;  go turns POSTs into GETs on 301 redirects according to the early HTTP spec.

This PR keeps HTTP methods the same across all redirects.