### PR TITLE
Add ability for release workflow to publish to other npm tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,13 @@ jobs:
         run: |
           npm config set git-tag-version false
           npm version ${{ github.ref_name }}
-          npm publish --access public
+
+          prerelease=$(echo ${{ github.ref_name }} | awk -F '-' '{print $2}' | awk -F '.' '{print $1}')
+          if [ -z "$prerelease" ]; then
+            npm publish --access public
+          else
+            npm publish --tag $prerelease --access public
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
With this, if we tag a prerelease version, e.g. `v0.10.0-tag.1`, it'll be published at `inngest-cli@tag` on npm.

Intended to be used primarily for releasing an `inngest-cli@next` for #351 and inngest/inngest-js#45.