### PR TITLE
Ensure we write the correct history when finalizing

### DIFF
--- a/pkg/execution/state/redis_state/lua/cancel.lua
+++ b/pkg/execution/state/redis_state/lua/cancel.lua
@@ -9,6 +9,10 @@ Output:
 ]]
 
 local metadataKey = KEYS[1]
+local historyKey  = KEYS[2]
+
+local historyLog  = ARGV[1]
+local logTime     = tonumber(ARGV[2])
 
 local value = tonumber(redis.call("HGET", metadataKey, "status"))
 if value ~= 0 then
@@ -17,4 +21,6 @@ if value ~= 0 then
 end
 
 redis.call("HSET", metadataKey, "status", 3)
+redis.call("ZADD", historyKey, logTime, historyLog)
+
 return 0;

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -327,10 +327,18 @@ func (m mgr) metadata(ctx context.Context, runID ulid.ULID) (*runMetadata, error
 }
 
 func (m mgr) Cancel(ctx context.Context, id state.Identifier) error {
+	now := time.Now()
 	status, err := scripts["cancel"].Eval(
 		ctx,
 		m.r,
-		[]string{m.kf.RunMetadata(ctx, id.RunID)},
+		[]string{m.kf.RunMetadata(ctx, id.RunID), m.kf.History(ctx, id.RunID)},
+		state.History{
+			ID:         state.HistoryID(),
+			Type:       enums.HistoryTypeFunctionCancelled,
+			Identifier: id,
+			CreatedAt:  now,
+		},
+		now.UnixMilli(),
 	).Int64()
 	if err != nil {
 		return fmt.Errorf("error cancelling: %w", err)

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -1316,6 +1316,10 @@ func checkCancel(t *testing.T, m state.Manager) {
 	reloaded, err := m.Load(ctx, s.RunID())
 	require.NoError(t, err)
 	require.EqualValues(t, enums.RunStatusCancelled, reloaded.Metadata().Status, "Status is not Cancelled")
+
+	history, err := m.History(ctx, s.RunID())
+	require.NoError(t, err)
+	require.Equal(t, enums.HistoryTypeFunctionCancelled, history[len(history)-1].Type)
 }
 
 func checkCancel_cancelled(t *testing.T, m state.Manager) {

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -1414,6 +1414,21 @@ func checkFinalizedStatus(t *testing.T, m state.Manager) {
 		require.NoError(t, err)
 		require.Equal(t, enums.RunStatusCancelled, loaded.Metadata().Status)
 	})
+
+	t.Run("It allows Failed statuses which write to history", func(t *testing.T) {
+		s = setup(t, m)
+
+		err = m.Finalized(ctx, s.Identifier(), inngest.TriggerName, 0, enums.RunStatusFailed)
+		require.NoError(t, err)
+
+		loaded, err := m.Load(ctx, s.RunID())
+		require.NoError(t, err)
+		require.Equal(t, enums.RunStatusFailed, loaded.Metadata().Status)
+
+		history, err := m.History(ctx, s.RunID())
+		require.NoError(t, err)
+		require.Equal(t, enums.HistoryTypeFunctionFailed, history[len(history)-1].Type)
+	})
 }
 
 func checkLogs(t *testing.T, m state.Manager) {


### PR DESCRIPTION
When finalizing with a status, we must ensure we write the correct history status and trigger the correct callback status for proper logging.