### PR TITLE
Ensure we write JSON to history

### DIFF
--- a/pkg/execution/state/history_test.go
+++ b/pkg/execution/state/history_test.go
@@ -94,4 +94,27 @@ func TestHistoryBinaryMarshalling(t *testing.T) {
 		_, ok := dec.Data.(HistoryStep)
 		require.True(t, ok)
 	})
+
+	t.Run("Step data", func(t *testing.T) {
+		DefaultHistoryEncoding = HistoryEncodingJSON
+		h := History{
+			ID:        ulid.MustNew(ulid.Now(), rand.Reader),
+			Type:      enums.HistoryTypeFunctionStarted,
+			CreatedAt: time.Now().UTC().Truncate(time.Second),
+			Data: HistoryStep{
+				ID:   "hashid",
+				Name: "Step name",
+				Data: map[string]any{
+					"hello": "guvna",
+				},
+			},
+		}
+
+		byt, err := h.MarshalBinary()
+		require.NoError(t, err)
+		exp, err := json.Marshal(h)
+		require.NoError(t, err)
+		require.Equal(t, exp, byt)
+	})
+
 }

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -503,7 +503,7 @@ func (m mgr) SaveResponse(ctx context.Context, i state.Identifier, r state.Drive
 			ID:      r.Step.ID,
 			Name:    r.Step.Name,
 			Attempt: attempt,
-			Data:    data,
+			Data:    r.Output,
 		},
 	}
 
@@ -526,7 +526,7 @@ func (m mgr) SaveResponse(ctx context.Context, i state.Identifier, r state.Drive
 		now.UnixMilli(),
 	).Int()
 	if err != nil {
-		return 0, fmt.Errorf("error finalizing: %w", err)
+		return 0, fmt.Errorf("error saving response: %w", err)
 	}
 
 	if r.Err != nil && r.Final() {


### PR DESCRIPTION
Previously we were writing a mix of JSON and base64 enconded JSON (by passing the []byte encoded JSON array of data).  This fixes history to be a single JSON object.