### PR TITLE
Fix windows mime-type errors when self-serving JS

### DIFF
--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/fs"
+	"mime"
 	"net/http"
 	"strings"
 	"time"
@@ -31,6 +32,11 @@ var (
 	// every N times, instead of spamming the console every time we poll for functions.
 	signingKeyErrorCount = 0
 )
+
+func init() {
+	// Fix invalid mime type errors when loading JS from our assets on windows.
+	_ = mime.AddExtensionType(".js", "application/javascript")
+}
 
 type devapi struct {
 	chi.Router

--- a/pkg/execution/executor/util_test.go
+++ b/pkg/execution/executor/util_test.go
@@ -74,7 +74,7 @@ func TestParseWait(t *testing.T) {
 				t,
 				time.Now().Add(test.duration),
 				time.Now().Add(duration),
-				time.Second,
+				time.Second+100*time.Millisecond,
 			)
 		})
 	}


### PR DESCRIPTION
Windows 10 doesn't include mime types for ".js" &
application/javascript;  this breaks JS when loading the dev server in windows.