### PR TITLE
Peek partitions 1s ahead of time

### DIFF
--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -232,7 +232,8 @@ func (q *queue) scan(ctx context.Context, f osqueue.RunFunc) error {
 		return nil
 	}
 
-	partitions, err := q.PartitionPeek(ctx, q.isSequential(), time.Now(), PartitionPeekMax)
+	// Peek 1s into the future to pull jobs off ahead of time, minimizing 0 latency
+	partitions, err := q.PartitionPeek(ctx, q.isSequential(), time.Now().Add(time.Second), PartitionPeekMax)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This allows us to pull partitions with jobs available in 1s;  we can then lease and consume jobs up to 1000ms before they're due to be ran and wait in-memory prior to handling the job.  This lowers latency for jobs starting close to the tick of a second, improving p50-p99 latency.