### PR TITLE
Add utility function to get the time a queue item function starts

### DIFF
--- a/pkg/execution/state/redis_state/queue_processor_test.go
+++ b/pkg/execution/state/redis_state/queue_processor_test.go
@@ -43,6 +43,9 @@ func TestQueueRunSequential(t *testing.T) {
 	// Run the queue.  After running this worker should claim the sequential lease.
 	go func() {
 		_ = q1.Run(q1ctx, func(ctx context.Context, item osqueue.Item) error {
+			time, ok := GetItemStart(ctx)
+			require.True(t, ok)
+			require.NotZero(t, time)
 			return nil
 		})
 	}()


### PR DESCRIPTION
Useful for people if they need to log starts - without them doing it themselves.