### PR TITLE
Add ability to send logs in SDK generator steps

### DIFF
--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -962,6 +962,7 @@ enum StepEventType {
   ERRORED
   FAILED
   WAITING
+  LOG
 }
 
 type StepEvent {

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -279,6 +279,7 @@ const (
 	StepEventTypeErrored   StepEventType = "ERRORED"
 	StepEventTypeFailed    StepEventType = "FAILED"
 	StepEventTypeWaiting   StepEventType = "WAITING"
+	StepEventTypeLog       StepEventType = "LOG"
 )
 
 var AllStepEventType = []StepEventType{
@@ -288,11 +289,12 @@ var AllStepEventType = []StepEventType{
 	StepEventTypeErrored,
 	StepEventTypeFailed,
 	StepEventTypeWaiting,
+	StepEventTypeLog,
 }
 
 func (e StepEventType) IsValid() bool {
 	switch e {
-	case StepEventTypeScheduled, StepEventTypeStarted, StepEventTypeCompleted, StepEventTypeErrored, StepEventTypeFailed, StepEventTypeWaiting:
+	case StepEventTypeScheduled, StepEventTypeStarted, StepEventTypeCompleted, StepEventTypeErrored, StepEventTypeFailed, StepEventTypeWaiting, StepEventTypeLog:
 		return true
 	}
 	return false

--- a/pkg/coreapi/graph/resolvers/function_run.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run.resolver.go
@@ -188,6 +188,8 @@ func stepEventEnum(h enums.HistoryType) models.StepEventType {
 		return models.StepEventTypeFailed
 	case enums.HistoryTypeStepWaiting:
 		return models.StepEventTypeWaiting
+	case enums.HistoryTypeStepLog:
+		return models.StepEventTypeLog
 	}
 
 	return models.StepEventTypeScheduled

--- a/pkg/coreapi/schema.graphql
+++ b/pkg/coreapi/schema.graphql
@@ -116,6 +116,7 @@ enum StepEventType {
   ERRORED
   FAILED
   WAITING
+  LOG
 }
 
 type StepEvent {

--- a/pkg/enums/history_type.go
+++ b/pkg/enums/history_type.go
@@ -18,6 +18,7 @@ const (
 	HistoryTypeStepCompleted //
 	HistoryTypeStepErrored   //
 	HistoryTypeStepFailed
+	HistoryTypeStepLog
 
 	HistoryTypeStepWaiting
 )

--- a/pkg/enums/historytype_enumer.go
+++ b/pkg/enums/historytype_enumer.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 )
 
-const _HistoryTypeName = "NoneFunctionStartedFunctionCompletedFunctionFailedFunctionCancelledStepScheduledStepStartedStepCompletedStepErroredStepFailedStepWaiting"
+const _HistoryTypeName = "NoneFunctionStartedFunctionCompletedFunctionFailedFunctionCancelledStepScheduledStepStartedStepCompletedStepErroredStepFailedStepLogStepWaiting"
 
-var _HistoryTypeIndex = [...]uint8{0, 4, 19, 36, 50, 67, 80, 91, 104, 115, 125, 136}
+var _HistoryTypeIndex = [...]uint8{0, 4, 19, 36, 50, 67, 80, 91, 104, 115, 125, 132, 143}
 
 func (i HistoryType) String() string {
 	if i < 0 || i >= HistoryType(len(_HistoryTypeIndex)-1) {
@@ -19,7 +19,7 @@ func (i HistoryType) String() string {
 	return _HistoryTypeName[_HistoryTypeIndex[i]:_HistoryTypeIndex[i+1]]
 }
 
-var _HistoryTypeValues = []HistoryType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+var _HistoryTypeValues = []HistoryType{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 
 var _HistoryTypeNameToValueMap = map[string]HistoryType{
 	_HistoryTypeName[0:4]:     0,
@@ -32,7 +32,8 @@ var _HistoryTypeNameToValueMap = map[string]HistoryType{
 	_HistoryTypeName[91:104]:  7,
 	_HistoryTypeName[104:115]: 8,
 	_HistoryTypeName[115:125]: 9,
-	_HistoryTypeName[125:136]: 10,
+	_HistoryTypeName[125:132]: 10,
+	_HistoryTypeName[132:143]: 11,
 }
 
 // HistoryTypeFromString retrieves an enum value from the enum constants string name.

--- a/pkg/enums/opcode.go
+++ b/pkg/enums/opcode.go
@@ -11,4 +11,5 @@ const (
 	OpcodeStepPlanned
 	OpcodeSleep
 	OpcodeWaitForEvent
+	OpcodeLog
 )

--- a/pkg/enums/opcode_enumer.go
+++ b/pkg/enums/opcode_enumer.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 )
 
-const _OpcodeName = "NoneStepStepPlannedSleepWaitForEvent"
+const _OpcodeName = "NoneStepStepPlannedSleepWaitForEventLog"
 
-var _OpcodeIndex = [...]uint8{0, 4, 8, 19, 24, 36}
+var _OpcodeIndex = [...]uint8{0, 4, 8, 19, 24, 36, 39}
 
 func (i Opcode) String() string {
 	if i < 0 || i >= Opcode(len(_OpcodeIndex)-1) {
@@ -19,7 +19,7 @@ func (i Opcode) String() string {
 	return _OpcodeName[_OpcodeIndex[i]:_OpcodeIndex[i+1]]
 }
 
-var _OpcodeValues = []Opcode{0, 1, 2, 3, 4}
+var _OpcodeValues = []Opcode{0, 1, 2, 3, 4, 5}
 
 var _OpcodeNameToValueMap = map[string]Opcode{
 	_OpcodeName[0:4]:   0,
@@ -27,6 +27,7 @@ var _OpcodeNameToValueMap = map[string]Opcode{
 	_OpcodeName[8:19]:  2,
 	_OpcodeName[19:24]: 3,
 	_OpcodeName[24:36]: 4,
+	_OpcodeName[36:39]: 5,
 }
 
 // OpcodeFromString retrieves an enum value from the enum constants string name.

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -528,6 +528,11 @@ func (s *svc) scheduleGeneratorResponse(ctx context.Context, origItem queue.Item
 				item.Payload = edge
 				item.Kind = queue.KindEdge
 				return s.queue.Enqueue(ctx, item, time.Now())
+			case enums.OpcodeLog:
+				if err := s.state.Log(ctx, item.Identifier, gen.ID, gen.Data); err != nil {
+					return fmt.Errorf("unable to log: %w", err)
+				}
+				return nil
 			default:
 				return fmt.Errorf("unknown opcode: %s", gen.Op.String())
 			}

--- a/pkg/execution/state/inmemory/inmemory.go
+++ b/pkg/execution/state/inmemory/inmemory.go
@@ -386,6 +386,18 @@ func (m *mem) SaveResponse(ctx context.Context, i state.Identifier, r state.Driv
 
 }
 
+func (m *mem) Log(ctx context.Context, i state.Identifier, stepID string, data any) error {
+	m.setHistory(ctx, i, state.History{
+		ID:         state.HistoryID(),
+		Type:       enums.HistoryTypeStepLog,
+		Identifier: i,
+		CreatedAt:  time.UnixMilli(time.Now().UnixMilli()),
+		Data:       data,
+	})
+
+	return nil
+}
+
 func (m *mem) SavePause(ctx context.Context, p state.Pause) error {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -261,6 +261,8 @@ type Mutater interface {
 	// This returns the position of this step in the stack, if the stack is modified.  For temporary
 	// errors the stack position is 0, ie. unmodified.
 	SaveResponse(ctx context.Context, i Identifier, r DriverResponse, attempt int) (int, error)
+
+	Log(ctx context.Context, i Identifier, stepID string, data any) error
 }
 
 // HistoryDeleter is an optional interface a state can implement, deleting specific history items

--- a/ui/src/components/Function/RunSection.tsx
+++ b/ui/src/components/Function/RunSection.tsx
@@ -151,11 +151,21 @@ const FunctionRunTimelineRow = ({
       } catch (e) {}
     }
 
+    let label = `${prefix} ${stepData.label} ${suffix}`;
+
+    if (
+      stepData.label === "log" &&
+      typeof json?.[0] === "string" &&
+      json?.[0]
+    ) {
+      label = `${json[0]} log`;
+    }
+
     return {
       ...stepData,
-      label: `${prefix} ${stepData.label} ${suffix}`.trim(),
+      label: label.trim(),
     };
-  }, [rowType, eventType, name]);
+  }, [rowType, eventType, name, json]);
 
   const tabs = [{ label: "Output", content: payload || "" }];
 
@@ -220,6 +230,10 @@ const stepEventTypeMap: Record<
   [StepEventType.Waiting]: {
     label: "waiting",
     status: EventStatus.Paused,
+  },
+  [StepEventType.Log]: {
+    label: "log",
+    status: EventStatus.Completed,
   },
 };
 

--- a/ui/src/store/generated.ts
+++ b/ui/src/store/generated.ts
@@ -230,6 +230,7 @@ export enum StepEventType {
   Completed = 'COMPLETED',
   Errored = 'ERRORED',
   Failed = 'FAILED',
+  Log = 'LOG',
   Scheduled = 'SCHEDULED',
   Started = 'STARTED',
   Waiting = 'WAITING'


### PR DESCRIPTION
## Summary

Logging is a common need which we can meet with step tooling. This PR supports inngest/inngest-js#109 by adding support for `OpcodeLog` to the executor, state store, and dev server UI.

See inngest/inngest-js#109 for end-user usage.

## Related

- [x] inngest/inngest-js#96
- [x] inngest/inngest-js#109
- [ ] Handle additional log op codes when running a step