### PR TITLE
Increase redwood ports used during autodiscovery

### DIFF
--- a/pkg/devserver/discovery.go
+++ b/pkg/devserver/discovery.go
@@ -26,7 +26,7 @@ var (
 		// Other common ports
 		8000, 8080, 8081, 8888,
 		// Redwood
-		8910, 8911,
+		8910, 8911, 8912, 8913, 8914, 8915,
 	}
 
 	// Paths indicate the paths we attempt to hit when a web server is available.


### PR DESCRIPTION
We now scan 8910-8915 in case the first couple are unavailable.