### PR TITLE
Add support for external concurrency services

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -22,10 +22,10 @@ jobs:
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.1
           ./bin/golangci-lint run --verbose
-  test:
+  test-linux-race:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -35,3 +35,16 @@ jobs:
           go-version: 1.18
       - name: Test
         run: go test $(go list ./... | grep -v tests) -race -count=1
+  test-windows:
+    strategy:
+      matrix:
+        os: [windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+      - name: Test
+        run: go test $(go list ./... | grep -v tests) -count=1

--- a/pkg/execution/concurrency/concurrency.go
+++ b/pkg/execution/concurrency/concurrency.go
@@ -1,0 +1,47 @@
+package concurrency
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/execution/queue"
+)
+
+var (
+	ErrAtConcurrencyLimit = fmt.Errorf("at concurrency limit")
+)
+
+// ConcurrencyAdder adds items to external concurrency queues, returning an ErrAtConcurrencyLimit
+// if it's not possible to add the item due to capacity issues.
+type ConcurrencyAdder interface {
+	// Add inserts a new item into the concurrency service.  This
+	// will count towards concurrency limits until the specified timeout or until the key is
+	// removed via a call to Done().
+	//
+	// Add must return an ErrAtConcurrencyLimit if there is no capacity for the given
+	// function ID/key.
+	Add(ctx context.Context, functionID uuid.UUID, qi queue.Item) error
+}
+
+// ConcurrencyService defines a concurrency service which tracks concurrency by function IDs.  As
+// items are claimed.  This service lives outside of the state store and queue, allowing transactionality
+// at a higher level.
+type ConcurrencyService interface {
+	ConcurrencyAdder
+
+	// Done removes the given key from concurrency limits for a function.
+	//
+	// It is expected that Done is manually called outside of the state store and queue; the
+	// implementer must decide how to complete items and remove them from concurrency limits.
+	Done(ctx context.Context, functionID uuid.UUID, key string) error
+
+	// Check returns whether there's capacity within concurrency limits for a given
+	// function ID.
+	//
+	// When processing items it's safer to call Add, which should atomically check concurrency
+	// limits and only add the item if there's capacity.  This is not intended for use when
+	// adding items to the concurrency service, otherwise race conditions may cause us to exceed
+	// concurrency limits.
+	Check(ctx context.Context, functionID uuid.UUID, limit int) error
+}

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -469,6 +469,10 @@ func (q *queue) EnqueueItem(ctx context.Context, i QueueItem, at time.Time) (Que
 	// Add the At timestamp.
 	i.AtMS = at.UnixMilli()
 
+	if i.Data.JobID == nil {
+		i.Data.JobID = &i.ID
+	}
+
 	// Get the queue name from the queue item.  This allows utilization of
 	// the partitioned queue for jobs with custom queue names, vs utilizing
 	// workflow IDs in every case.

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -564,6 +564,8 @@ func (q *queue) Peek(ctx context.Context, queueName string, until time.Time, lim
 			// Leased item, don't return.
 			continue
 		}
+		// The nested osqueue.Item never has an ID set;  always re-set it
+		qi.Data.JobID = &qi.ID
 		result[n] = qi
 		n++
 

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -449,6 +449,8 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, f osque
 			case ErrPartitionConcurrencyLimit, ErrConcurrencyLimit:
 				q.scope.Counter(counterConcurrencyLimit).Inc(1)
 				q.sem.Release(1)
+				// Since the queue is at capacity, return the error so that we
+				// don't keep hammering with "does the queue have room?" logic.
 				return err
 			case ErrQueueItemNotFound:
 				q.scope.Counter(counterQueueItemsGone).Inc(1)

--- a/pkg/execution/state/redis_state/queue_processor_test.go
+++ b/pkg/execution/state/redis_state/queue_processor_test.go
@@ -247,7 +247,7 @@ func TestQueueRunExtended(t *testing.T) {
 		rc,
 		// We can't add more than 8128 goroutines when detecting race conditions,
 		// so lower the number of workers.
-		WithNumWorkers(1000),
+		WithNumWorkers(200),
 		WithLogger(&l),
 	)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -274,7 +274,7 @@ func TestQueueRunExtended(t *testing.T) {
 					rc,
 					// We can't add more than 8128 goroutines when detecting race conditions,
 					// so lower the number of workers.
-					WithNumWorkers(1000),
+					WithNumWorkers(200),
 					WithLogger(&l),
 				)
 

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -191,11 +191,11 @@ func TestQueuePeek(t *testing.T) {
 		c := b.Add(2 * time.Second)
 		d := c.Add(2 * time.Second)
 
-		ia, err := q.EnqueueItem(ctx, QueueItem{}, a)
+		ia, err := q.EnqueueItem(ctx, QueueItem{ID: "a"}, a)
 		require.NoError(t, err)
-		ib, err := q.EnqueueItem(ctx, QueueItem{}, b)
+		ib, err := q.EnqueueItem(ctx, QueueItem{ID: "b"}, b)
 		require.NoError(t, err)
-		ic, err := q.EnqueueItem(ctx, QueueItem{}, c)
+		ic, err := q.EnqueueItem(ctx, QueueItem{ID: "c"}, c)
 		require.NoError(t, err)
 
 		items, err := q.Peek(ctx, workflowID.String(), time.Now().Add(time.Hour), 10)
@@ -204,7 +204,7 @@ func TestQueuePeek(t *testing.T) {
 		require.EqualValues(t, []*QueueItem{&ia, &ib, &ic}, items)
 		require.NotEqualValues(t, []*QueueItem{&ib, &ia, &ic}, items)
 
-		id, err := q.EnqueueItem(ctx, QueueItem{}, d)
+		id, err := q.EnqueueItem(ctx, QueueItem{ID: "d"}, d)
 		require.NoError(t, err)
 
 		items, err = q.Peek(ctx, workflowID.String(), time.Now().Add(time.Hour), 10)

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -1023,6 +1023,7 @@ func getQueueItem(t *testing.T, r *miniredis.Miniredis, id string) QueueItem {
 	require.NotEmpty(t, val)
 	i := QueueItem{}
 	err := json.Unmarshal([]byte(val), &i)
+	i.Data.JobID = &i.ID
 	require.NoError(t, err)
 	return i
 }


### PR DESCRIPTION
This PR allows out-of-queue concurrency limiting via any external service.  The queue adds items to the concurrency queue, but external code is expected to remove items from the queue;  this doesn't happen automatically.