### PR TITLE
Add `inngest/function.failed` internal event for fn failures

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -104,8 +104,7 @@ func (a *apiServer) handleEvent(ctx context.Context, e *event.Event) error {
 		ctx,
 		a.config.EventStream.Service.TopicName(),
 		pubsub.Message{
-			// TODO: Move this into a const.
-			Name:      "event/event.received",
+			Name:      event.EventReceivedName,
 			Data:      string(byt),
 			Timestamp: time.Now(),
 		},

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -5,6 +5,11 @@ import (
 	"sync"
 )
 
+const (
+	EventReceivedName = "event/event.received"
+	FnFailedName      = "inngest/function.failed"
+)
+
 type Manager struct {
 	events map[string]Event
 	l      *sync.RWMutex

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -22,8 +22,6 @@ var (
 	ErrNoStateManager    = fmt.Errorf("no state manager provided")
 	ErrNoActionLoader    = fmt.Errorf("no action loader provided")
 	ErrNoRuntimeDriver   = fmt.Errorf("runtime driver for action not found")
-	ErrNoEventStream     = fmt.Errorf("no event stream provided")
-	ErrNoPublisher       = fmt.Errorf("no publisher provided")
 )
 
 // Executor manages executing actions.  It interfaces over a state store to save

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -186,7 +186,7 @@ func (s *svc) getFailureHandler(ctx context.Context) (func(context.Context, stat
 			Data: map[string]interface{}{
 				"function_id": s.Workflow().ID,
 				"run_id":      id.RunID.String(),
-				"error":       r.Err.Error(),
+				"error":       r.UserError(),
 				"event":       s.Event(),
 			},
 		}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -184,7 +184,7 @@ func (s *svc) getFailureHandler(ctx context.Context) (func(context.Context, stat
 			Name:      event.FnFailedName,
 			Timestamp: now.UnixMilli(),
 			Data: map[string]interface{}{
-				"function_id": id.WorkflowID.String(),
+				"function_id": s.Workflow().ID,
 				"run_id":      id.RunID.String(),
 				"error":       r.Err.Error(),
 				"event":       s.Event(),

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -160,7 +160,7 @@ func (s *svc) Pre(ctx context.Context) error {
 		),
 		WithLogger(logger.From(ctx)),
 		WithConfig(s.config.Execution),
-		WithFailureHandler(&failureHandler),
+		WithFailureHandler(failureHandler),
 	)
 	if err != nil {
 		return err

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/function/env"
 	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/pubsub"
 	"github.com/inngest/inngest/pkg/service"
 	"github.com/xhit/go-str2duration/v2"
 	"golang.org/x/sync/errgroup"
@@ -142,6 +143,11 @@ func (s *svc) Pre(ctx context.Context) error {
 		drivers = append(drivers, d)
 	}
 
+	pb, err := pubsub.NewPublisher(ctx, s.config.EventStream.Service)
+	if err != nil {
+		return fmt.Errorf("failed to create publisher: %w", err)
+	}
+
 	s.exec, err = NewExecutor(
 		WithActionLoader(s.data),
 		WithStateManager(s.state),
@@ -150,6 +156,8 @@ func (s *svc) Pre(ctx context.Context) error {
 		),
 		WithLogger(logger.From(ctx)),
 		WithConfig(s.config.Execution),
+		WithEventStream(s.config.EventStream),
+		WithPublisher(pb),
 	)
 	if err != nil {
 		return err

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -236,7 +236,7 @@ func (s *svc) Events(ctx context.Context, eventId string) ([]event.Event, error)
 }
 
 func (s *svc) handleMessage(ctx context.Context, m pubsub.Message) error {
-	if m.Name != "event/event.received" {
+	if m.Name != event.EventReceivedName {
 		return fmt.Errorf("unknown event type: %s", m.Name)
 	}
 


### PR DESCRIPTION
## Summary

Adds the sending of an internal `inngest/function.failed` event when a function fails for the final time.

Unsure about the required use of `EventStream` here; it could be better.

## Todo

- [x] Create `WithFailureHandler()` for when instantiating an executor - takes a function to call when a run has failed for the final time
- [x] Ensure executor has no knowledge of required pubsub/eventstream/etc
- [ ] Tests

## Related

- inngest/inngest-js#133