### PR TITLE
Ensure `step.waitForEvent` mutates history correctly

### DIFF
--- a/pkg/coreapi/graph/resolvers/function_run.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run.resolver.go
@@ -51,11 +51,12 @@ func (r *functionRunResolver) Timeline(ctx context.Context, obj *models.Function
 
 			switch h.Type {
 			case enums.HistoryTypeStepWaiting:
-				if stepData, ok := h.Data.(state.HistoryStepWaiting); ok {
+				if step, ok := h.Data.(state.HistoryStep); ok {
+					data, _ := step.Data.(state.HistoryStepWaitingData)
 					event.WaitingFor = &models.StepEventWait{
-						ExpiryTime: stepData.ExpiryTime,
-						EventName:  stepData.EventName,
-						Expression: stepData.Expression,
+						ExpiryTime: data.ExpiryTime,
+						EventName:  data.EventName,
+						Expression: data.Expression,
 					}
 					event.Output = nil
 				}
@@ -145,9 +146,9 @@ func (r *functionRunResolver) WaitingFor(ctx context.Context, obj *models.Functi
 			wait = nil
 			continue
 		}
-
-		stepData, ok := h.Data.(state.HistoryStepWaiting)
+		step, ok := h.Data.(state.HistoryStep)
 		if ok {
+			stepData, _ := step.Data.(state.HistoryStepWaitingData)
 			wait = &models.StepEventWait{
 				ExpiryTime: stepData.ExpiryTime,
 				EventName:  stepData.EventName,

--- a/pkg/enums/history_type.go
+++ b/pkg/enums/history_type.go
@@ -13,11 +13,10 @@ const (
 	HistoryTypeFunctionFailed
 	HistoryTypeFunctionCancelled
 
-	HistoryTypeStepScheduled //
-	HistoryTypeStepStarted   //
-	HistoryTypeStepCompleted //
-	HistoryTypeStepErrored   //
-	HistoryTypeStepFailed
-
-	HistoryTypeStepWaiting
+	HistoryTypeStepScheduled
+	HistoryTypeStepStarted
+	HistoryTypeStepCompleted
+	HistoryTypeStepErrored // Errored
+	HistoryTypeStepFailed  // Permanently failed
+	HistoryTypeStepWaiting // Waiting for an event
 )

--- a/pkg/execution/state/history.go
+++ b/pkg/execution/state/history.go
@@ -3,6 +3,7 @@ package state
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -19,7 +20,8 @@ var (
 	// This can be changed on init to change how we globally store history.
 	DefaultHistoryEncoding = HistoryEncodingGZIP
 
-	rnd *frandRNG
+	rnd         *frandRNG
+	groupCtxVal = groupIDValType{}
 )
 
 const (
@@ -29,6 +31,18 @@ const (
 
 func init() {
 	rnd = &frandRNG{RNG: frand.New(), lock: &sync.Mutex{}}
+}
+
+// WithGroupID returns a context that stores the given group ID inside.
+func WithGroupID(ctx context.Context, groupID string) context.Context {
+	return context.WithValue(ctx, groupCtxVal, groupID)
+}
+
+// GroupIDFromContext returns the group ID given the current context, or an
+// empty string if there's no group ID.
+func GroupIDFromContext(ctx context.Context) string {
+	str, _ := ctx.Value(groupCtxVal).(string)
+	return str
 }
 
 // NewHistory returns a new history struct with an ID created at the time of
@@ -224,3 +238,5 @@ func (f *frandRNG) Float64() float64 {
 func (f *frandRNG) Seed(seed uint64) {
 	// Do nothing.
 }
+
+type groupIDValType struct{}

--- a/pkg/execution/state/history.go
+++ b/pkg/execution/state/history.go
@@ -44,7 +44,14 @@ func HistoryID() ulid.ULID {
 }
 
 type History struct {
-	ID         ulid.ULID         `json:"id"`
+	ID ulid.ULID `json:"id"`
+	// GroupID allows multiple history items to be correlated with each other,
+	// grouping them into a single step.
+	//
+	// We need this for generator steps;  there are multiple history items for
+	// a single step, but we only have data for eg. the step name in the last
+	// history item (code can run any step, and we don't know that ahead of time).
+	GroupID    string            `json:"gid"`
 	Type       enums.HistoryType `json:"type"`
 	Identifier Identifier        `json:"run"`
 	CreatedAt  time.Time         `json:"createdAt"`
@@ -57,6 +64,7 @@ func (h *History) UnmarshalJSON(data []byte) error {
 	// type.
 	m := struct {
 		ID         ulid.ULID         `json:"id"`
+		GroupID    string            `json:"gid"`
 		Type       enums.HistoryType `json:"type"`
 		Identifier Identifier        `json:"run"`
 		CreatedAt  time.Time         `json:"createdAt"`
@@ -66,6 +74,7 @@ func (h *History) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	h.ID = m.ID
+	h.GroupID = m.GroupID
 	h.Type = m.Type
 	h.Identifier = m.Identifier
 	h.CreatedAt = m.CreatedAt

--- a/pkg/execution/state/history.go
+++ b/pkg/execution/state/history.go
@@ -98,7 +98,8 @@ func (h *History) UnmarshalJSON(data []byte) error {
 		enums.HistoryTypeStepStarted,
 		enums.HistoryTypeStepCompleted,
 		enums.HistoryTypeStepErrored,
-		enums.HistoryTypeStepFailed:
+		enums.HistoryTypeStepFailed,
+		enums.HistoryTypeStepWaiting:
 		// Assume that for step history items we must have a HistoryStep
 		// struct within data.
 		v := HistoryStep{}
@@ -194,7 +195,7 @@ type HistoryStep struct {
 
 // HistoryStepWaiting is stored within HistoryStep when we create a pause to wait
 // for an event
-type HistoryStepWaiting struct {
+type HistoryStepWaitingData struct {
 	// EventName is the name of the event we're waiting for.
 	EventName  *string   `json:"eventName"`
 	Expression *string   `json:"expression"`

--- a/pkg/execution/state/inmemory/inmemory.go
+++ b/pkg/execution/state/inmemory/inmemory.go
@@ -400,10 +400,14 @@ func (m *mem) SavePause(ctx context.Context, p state.Pause) error {
 		Type:       enums.HistoryTypeStepWaiting,
 		Identifier: p.Identifier,
 		CreatedAt:  time.UnixMilli(time.Now().UnixMilli()),
-		Data: state.HistoryStepWaiting{
-			EventName:  p.Event,
-			Expression: p.Expression,
-			ExpiryTime: time.Time(p.Expires),
+		Data: state.HistoryStep{
+			ID:   p.Incoming,
+			Name: p.StepName,
+			Data: state.HistoryStepWaitingData{
+				EventName:  p.Event,
+				Expression: p.Expression,
+				ExpiryTime: time.Time(p.Expires),
+			},
 		},
 	})
 
@@ -489,6 +493,23 @@ func (m *mem) ConsumePause(ctx context.Context, id uuid.UUID, data any) error {
 		instance.stack = append(instance.stack, pause.DataKey)
 		m.state[pause.Identifier.RunID] = instance
 	}
+
+	stepID := pause.Incoming
+	if pause.DataKey != "" {
+		stepID = pause.DataKey
+	}
+	m.setHistory(ctx, pause.Identifier, state.History{
+		ID:         state.HistoryID(),
+		GroupID:    state.GroupIDFromContext(ctx),
+		Type:       enums.HistoryTypeStepCompleted,
+		Identifier: pause.Identifier,
+		CreatedAt:  time.UnixMilli(time.Now().UnixMilli()),
+		Data: state.HistoryStep{
+			ID:   stepID,
+			Name: pause.StepName,
+			Data: data,
+		},
+	})
 
 	delete(m.pauses, id)
 	return nil

--- a/pkg/execution/state/inmemory/inmemory.go
+++ b/pkg/execution/state/inmemory/inmemory.go
@@ -395,14 +395,20 @@ func (m *mem) SavePause(ctx context.Context, p state.Pause) error {
 
 	m.pauses[p.ID] = p
 
+	stepID := p.Incoming
+	if p.DataKey != "" {
+		stepID = p.DataKey
+	}
+
 	m.setHistory(ctx, p.Identifier, state.History{
 		ID:         state.HistoryID(),
 		Type:       enums.HistoryTypeStepWaiting,
 		Identifier: p.Identifier,
 		CreatedAt:  time.UnixMilli(time.Now().UnixMilli()),
 		Data: state.HistoryStep{
-			ID:   p.Incoming,
-			Name: p.StepName,
+			ID:      stepID,
+			Name:    p.StepName,
+			Attempt: p.Attempt,
 			Data: state.HistoryStepWaitingData{
 				EventName:  p.Event,
 				Expression: p.Expression,

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -138,6 +138,9 @@ type Pause struct {
 	// via an async driver.  This lets the executor resume as-is with the current
 	// context, ensuring that we retry correctly.
 	Attempt int `json:"att,omitempty"`
+	// GroupID stores the group ID for this step and history, allowing us to correlate
+	// event receives with other history items.
+	GroupID string `json:"groupID"`
 }
 
 func (p Pause) Edge() inngest.Edge {

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -91,6 +91,8 @@ type Pause struct {
 	Outgoing string `json:"outgoing"`
 	// Incoming is the step to run after the pause completes.
 	Incoming string `json:"incoming"`
+	// StepName is the readable step name of the step to save within history.
+	StepName string `json:"stepName"`
 	// Expires is a time at which the pause can no longer be consumed.  This
 	// gives each pause of a function a TTL.  This is required.
 	//

--- a/pkg/execution/state/redis_state/lua/consumePause.lua
+++ b/pkg/execution/state/redis_state/lua/consumePause.lua
@@ -14,10 +14,13 @@ local pauseStepKey  = KEYS[2]
 local pauseEventKey = KEYS[3]
 local actionKey     = KEYS[4]
 local stackKey      = KEYS[5]
+local historyKey    = KEYS[6]
 
 local pauseID      = ARGV[1]
 local pauseDataKey = ARGV[2] -- used to set data in run state store
 local pauseDataVal = ARGV[3] -- data to set
+local log          = ARGV[4]
+local logTime      = ARGV[5]
 
 local pause = redis.call("GET", pauseKey)
 if pause == false or pause == nil then
@@ -36,5 +39,7 @@ if actionKey ~= nil and pauseDataKey ~= "" then
 	redis.call("RPUSH", stackKey, pauseDataKey)
 	redis.call("HSET", actionKey, pauseDataKey, pauseDataVal)
 end
+
+redis.call("ZADD", historyKey, logTime, log)
 
 return 0

--- a/pkg/execution/state/redis_state/lua/savePause.lua
+++ b/pkg/execution/state/redis_state/lua/savePause.lua
@@ -1,12 +1,16 @@
 local pauseKey    = KEYS[1]
 local stepKey     = KEYS[2]
 local pauseEvtKey = KEYS[3]
+local historyKey  = KEYS[4]
 
-local pause     = ARGV[1]
-local pauseID   = ARGV[2]
-local event     = ARGV[3] 
+local pause          = ARGV[1]
+local pauseID        = ARGV[2]
+local event          = ARGV[3] 
 local newExpiry      = tonumber(ARGV[4])
 local extendedExpiry = tonumber(ARGV[5])
+local log            = ARGV[6]
+local logTime        = ARGV[7]
+
 
 if redis.call("SETNX", pauseKey, pause) == 0 then
 	return 1
@@ -18,5 +22,7 @@ redis.call("SETEX", stepKey, newExpiry, pauseID)
 if event ~= false and event ~= "" and event ~= nil then
 	redis.call("HSET", pauseEvtKey, pauseID, pause)
 end
+
+redis.call("ZADD", historyKey, logTime, log)
 
 return 0

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/inngest/inngest/pkg/backoff"
 	"github.com/inngest/inngest/pkg/execution/concurrency"
 	osqueue "github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/oklog/ulid/v2"
 	"github.com/uber-go/tally/v4"
 	"golang.org/x/sync/errgroup"
@@ -554,6 +555,10 @@ func (q *queue) process(ctx context.Context, p QueuePartition, qi QueueItem, f o
 	// to inspect job IDs, eg. for tracing or logging, without having to thread this down as
 	// arguments.
 	jobCtx = osqueue.WithJobID(jobCtx, qi.ID)
+	// Same with the group ID, if it exists.
+	if qi.Data.GroupID != "" {
+		jobCtx = state.WithGroupID(jobCtx, qi.Data.GroupID)
+	}
 
 	go func() {
 		defer func() {

--- a/pkg/execution/state/redis_state/queue_processor_test.go
+++ b/pkg/execution/state/redis_state/queue_processor_test.go
@@ -144,6 +144,8 @@ func TestQueueRunBasic(t *testing.T) {
 		_ = q.Run(ctx, func(ctx context.Context, item osqueue.Item) error {
 			logger.From(ctx).Debug().Interface("item", item).Msg("received item")
 			atomic.AddInt32(&handled, 1)
+			id := osqueue.JobIDFromContext(ctx)
+			require.NotEmpty(t, id, "No job ID was passed via context")
 			return nil
 		})
 	}()

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -643,6 +643,30 @@ func (m mgr) SavePause(ctx context.Context, p state.Pause) error {
 		m.kf.PauseID(ctx, p.ID),
 		m.kf.PauseStep(ctx, p.Identifier, p.Incoming),
 		m.kf.PauseEvent(ctx, p.WorkspaceID, evt),
+		m.kf.History(ctx, p.Identifier.RunID),
+	}
+
+	stepID := p.Incoming
+	if p.DataKey != "" {
+		stepID = p.DataKey
+	}
+	now := time.Now()
+	log := state.History{
+		ID:         state.HistoryID(),
+		GroupID:    state.GroupIDFromContext(ctx),
+		Type:       enums.HistoryTypeStepWaiting,
+		Identifier: p.Identifier,
+		CreatedAt:  now,
+		Data: state.HistoryStep{
+			ID:      stepID,
+			Name:    p.StepName,
+			Attempt: p.Attempt,
+			Data: state.HistoryStepWaitingData{
+				EventName:  p.Event,
+				Expression: p.Expression,
+				ExpiryTime: time.Time(p.Expires),
+			},
+		},
 	}
 
 	status, err := scripts["savePause"].Eval(
@@ -657,6 +681,8 @@ func (m mgr) SavePause(ctx context.Context, p state.Pause) error {
 		// Add at least 10 minutes to this pause, allowing us to process the
 		// pause by ID for 10 minutes past expiry.
 		int(time.Until(p.Expires.Time().Add(10*time.Minute)).Seconds()),
+		log,
+		now.UnixMilli(),
 	).Int64()
 	if err != nil {
 		return fmt.Errorf("error finalizing: %w", err)
@@ -714,6 +740,26 @@ func (m mgr) ConsumePause(ctx context.Context, id uuid.UUID, data any) error {
 		eventKey,
 		m.kf.Actions(ctx, p.Identifier),
 		m.kf.Stack(ctx, p.Identifier.RunID),
+		m.kf.History(ctx, p.Identifier.RunID),
+	}
+
+	stepID := p.Incoming
+	if p.DataKey != "" {
+		stepID = p.DataKey
+	}
+	now := time.Now()
+	log := state.History{
+		ID:         state.HistoryID(),
+		GroupID:    state.GroupIDFromContext(ctx),
+		Type:       enums.HistoryTypeStepCompleted,
+		Identifier: p.Identifier,
+		CreatedAt:  now,
+		Data: state.HistoryStep{
+			ID:      stepID,
+			Name:    p.StepName,
+			Attempt: p.Attempt,
+			Data:    data,
+		},
 	}
 
 	status, err := scripts["consumePause"].Eval(
@@ -724,6 +770,8 @@ func (m mgr) ConsumePause(ctx context.Context, id uuid.UUID, data any) error {
 		id.String(),
 		p.DataKey,
 		string(marshalledData),
+		log,
+		now.UnixMilli(),
 	).Int64()
 	if err != nil {
 		return fmt.Errorf("error consuming pause: %w", err)

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -606,8 +606,8 @@ func (m mgr) Finalized(ctx context.Context, i state.Identifier, stepID string, a
 		m.r,
 		[]string{m.kf.RunMetadata(ctx, i.RunID), m.kf.History(ctx, i.RunID)},
 		state.History{
-			ID:         state.HistoryID(),
-			GroupID:    state.GroupIDFromContext(ctx),
+			ID: state.HistoryID(),
+			// Function completions have no group ID.
 			Type:       history,
 			Identifier: i,
 			CreatedAt:  now,

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -335,6 +335,7 @@ func (m mgr) Cancel(ctx context.Context, id state.Identifier) error {
 		[]string{m.kf.RunMetadata(ctx, id.RunID), m.kf.History(ctx, id.RunID)},
 		state.History{
 			ID:         state.HistoryID(),
+			GroupID:    state.GroupIDFromContext(ctx),
 			Type:       enums.HistoryTypeFunctionCancelled,
 			Identifier: id,
 			CreatedAt:  now,
@@ -487,6 +488,7 @@ func (m mgr) SaveResponse(ctx context.Context, i state.Identifier, r state.Drive
 			typ = enums.HistoryTypeStepFailed
 			funcFailHistory = state.History{
 				ID:         state.HistoryID(),
+				GroupID:    state.GroupIDFromContext(ctx),
 				Type:       enums.HistoryTypeFunctionFailed,
 				Identifier: i,
 				CreatedAt:  now,
@@ -496,6 +498,7 @@ func (m mgr) SaveResponse(ctx context.Context, i state.Identifier, r state.Drive
 
 	stepHistory := state.History{
 		ID:         state.HistoryID(),
+		GroupID:    state.GroupIDFromContext(ctx),
 		Type:       typ,
 		Identifier: i,
 		CreatedAt:  now,
@@ -544,6 +547,7 @@ func (m mgr) Started(ctx context.Context, id state.Identifier, stepID string, at
 		Score: float64(now.UnixMilli()),
 		Member: state.History{
 			ID:         state.HistoryID(),
+			GroupID:    state.GroupIDFromContext(ctx),
 			Type:       enums.HistoryTypeStepStarted,
 			Identifier: id,
 			CreatedAt:  now,
@@ -564,6 +568,7 @@ func (m mgr) Scheduled(ctx context.Context, i state.Identifier, stepID string, a
 		[]string{m.kf.RunMetadata(ctx, i.RunID), m.kf.History(ctx, i.RunID)},
 		state.History{
 			ID:         state.HistoryID(),
+			GroupID:    state.GroupIDFromContext(ctx),
 			Type:       enums.HistoryTypeStepScheduled,
 			Identifier: i,
 			CreatedAt:  now,
@@ -602,6 +607,7 @@ func (m mgr) Finalized(ctx context.Context, i state.Identifier, stepID string, a
 		[]string{m.kf.RunMetadata(ctx, i.RunID), m.kf.History(ctx, i.RunID)},
 		state.History{
 			ID:         state.HistoryID(),
+			GroupID:    state.GroupIDFromContext(ctx),
 			Type:       history,
 			Identifier: i,
 			CreatedAt:  now,

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -1516,6 +1516,9 @@ func checkCancel(t *testing.T, m state.Manager) {
 	require.NoError(t, err)
 	require.EqualValues(t, enums.RunStatusRunning, s.Metadata().Status, "Status is not Running")
 
+	// Add time so that the history ticks a millisecond
+	<-time.After(time.Millisecond)
+
 	err = m.Cancel(ctx, s.Identifier())
 	require.NoError(t, err)
 
@@ -1547,6 +1550,9 @@ func checkCancel_cancelled(t *testing.T, m state.Manager) {
 	require.NoError(t, err)
 	require.EqualValues(t, enums.RunStatusRunning, s.Metadata().Status, "Status is not Running")
 
+	// Add time so that the history ticks a millisecond
+	<-time.After(time.Millisecond)
+
 	err = m.Cancel(ctx, s.Identifier())
 	require.NoError(t, err)
 	reloaded, err := m.Load(ctx, s.RunID())
@@ -1576,12 +1582,18 @@ func checkCancel_completed(t *testing.T, m state.Manager) {
 	require.NoError(t, err)
 	require.EqualValues(t, enums.RunStatusRunning, s.Metadata().Status, "Status is not Running")
 
+	// Add time so that the history ticks a millisecond
+	<-time.After(time.Millisecond)
+
 	err = m.Finalized(ctx, s.Identifier(), w.Steps[0].ID, 0)
 	require.NoError(t, err)
 
 	s, err = m.Load(ctx, s.RunID())
 	require.NoError(t, err)
 	require.EqualValues(t, enums.RunStatusCompleted, s.Metadata().Status, "Status is not Complete after finalizing")
+
+	// Add time so that the history ticks a millisecond
+	<-time.After(time.Millisecond)
 
 	err = m.Cancel(ctx, s.Identifier())
 	require.Equal(t, err, state.ErrFunctionComplete)

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -692,6 +692,7 @@ func checkConsumePause(t *testing.T, m state.Manager) {
 		Identifier: s.Identifier(),
 		Outgoing:   inngest.TriggerName,
 		Incoming:   w.Steps[0].ID,
+		StepName:   w.Steps[0].Name,
 		Expires:    state.Time(time.Now().Add(state.PauseLeaseDuration * 2)),
 	}
 	err = m.SavePause(ctx, pause)
@@ -713,7 +714,12 @@ func checkConsumePause(t *testing.T, m state.Manager) {
 		history, err := m.History(ctx, s.RunID())
 		require.NoError(t, err)
 		require.Equal(t, 3, len(history))
-		require.Equal(t, enums.HistoryTypeStepCompleted, history[len(history)-1].Type)
+		last := history[len(history)-1]
+		require.Equal(t, enums.HistoryTypeStepCompleted, last.Type)
+		hs, ok := last.Data.(state.HistoryStep)
+		require.True(t, ok)
+		require.Equal(t, w.Steps[0].ID, hs.ID)
+		require.Equal(t, w.Steps[0].Name, hs.Name)
 	})
 
 	t.Run("Consuming a pause again fails", func(t *testing.T) {

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -705,6 +705,10 @@ func checkConsumePause(t *testing.T, m state.Manager) {
 	require.Equal(t, enums.HistoryTypeStepWaiting, history[len(history)-1].Type)
 
 	t.Run("Consuming a pause works", func(t *testing.T) {
+		// Add 1ms, ensuring that the step completed history
+		// item is always after the pause history item. history is MS precision,
+		// and without this there's a small but real chance of flakiness.
+		<-time.After(time.Millisecond)
 		// Consuming the pause should work.
 		err = m.ConsumePause(ctx, pause.ID, nil)
 		require.NoError(t, err)
@@ -1873,6 +1877,9 @@ func setup(t *testing.T, m state.Manager) state.State {
 
 	s, err := m.New(ctx, init)
 	require.NoError(t, err)
+	// Add a millisecond so that this history item always comes first.  There
+	// are some race conditions here, as history items are MS precision.
+	<-time.After(time.Millisecond)
 
 	return s
 }


### PR DESCRIPTION
This PR asserts that we add waiting and complete steps when pauses are added and consumed, respectively.