### PR TITLE
INN-1098 Allow the executor to check status inside streamed responses

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -196,7 +196,7 @@ func (e executor) Execute(ctx context.Context, s state.State, action inngest.Act
 func (e executor) do(ctx context.Context, url string, input []byte) ([]byte, int, error) {
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(input))
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("error creating request: %w", err)
 	}
 	req.Header.Add("Content-Type", "application/json")
 
@@ -205,11 +205,11 @@ func (e executor) do(ctx context.Context, url string, input []byte) ([]byte, int
 	}
 	resp, err := e.client.Do(req)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("error executing request: %w", err)
 	}
 	byt, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("error reading response body: %w", err)
 	}
 	return byt, resp.StatusCode, nil
 }

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -211,5 +211,26 @@ func (e executor) do(ctx context.Context, url string, input []byte) ([]byte, int
 	if err != nil {
 		return nil, 0, fmt.Errorf("error reading response body: %w", err)
 	}
-	return byt, resp.StatusCode, nil
+
+	// If the responding status code is 201 Created, the response has been
+	// streamed back to us. In this case, the response body will be namespaced
+	// under the "body" key, and the status code will be namespaced under the
+	// "status" key.
+	//
+	// Only SDK versions that include the status in the body are expected to
+	// send a 201 status code and namespace in this way, so failing to parse
+	// here is an error.
+	if resp.StatusCode != 201 {
+		return byt, resp.StatusCode, nil
+	}
+
+	var body struct {
+		StatusCode int    `json:"status"`
+		Body       string `json:"body"`
+	}
+	if err := json.Unmarshal(byt, &body); err != nil {
+		return nil, 0, fmt.Errorf("error reading response body to check for status code: %w", err)
+	}
+	return []byte(body.Body), body.StatusCode, nil
+
 }


### PR DESCRIPTION
## Summary INN-1098

We can't use status codes to signify functionality for streamed responses, as we'd be sending it before we understand what we're doing or what has happened.

In these cases, the SDK (inngest/inngest-js#163) embeds the final status inside the returned body.

This small shim catches this occurence.

## Related

- inngest/inngest-js#163