### PR TITLE
Local dev server concurrency

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/config"
 	"github.com/inngest/inngest/pkg/coredata/inmemory"
 	"github.com/inngest/inngest/pkg/enums"
@@ -13,6 +14,7 @@ import (
 	"github.com/inngest/inngest/pkg/execution/runner"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/execution/state/redis_state"
+	"github.com/inngest/inngest/pkg/function"
 	"github.com/inngest/inngest/pkg/function/env"
 	"github.com/inngest/inngest/pkg/service"
 	"github.com/rueian/rueidis"
@@ -102,7 +104,11 @@ func start(ctx context.Context, opts StartOpts, loader *inmemory.ReadWriter) err
 			// partition.
 			funcs, _ := loader.Functions(ctx)
 			for _, f := range funcs {
-				if f.ID == p.WorkflowID.String() {
+				id := f.ID
+				if _, err := uuid.Parse(f.ID); err != nil {
+					id = function.DeterministicUUID(f).String()
+				}
+				if id == p.WorkflowID.String() {
 					return p.Queue(), f.Concurrency
 				}
 			}

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -108,7 +108,7 @@ func start(ctx context.Context, opts StartOpts, loader *inmemory.ReadWriter) err
 				if _, err := uuid.Parse(f.ID); err != nil {
 					id = function.DeterministicUUID(f).String()
 				}
-				if id == p.WorkflowID.String() {
+				if id == p.WorkflowID.String() && f.Concurrency > 0 {
 					return p.Queue(), f.Concurrency
 				}
 			}

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -179,6 +179,8 @@ func (e executor) Execute(ctx context.Context, s state.State, action inngest.Act
 				body = string(byt)
 			}
 		}
+	} else {
+		body = nil
 	}
 
 	// Add an error to driver.Response if the status code isn't 2XX.

--- a/tests.sh
+++ b/tests.sh
@@ -8,4 +8,4 @@ go run ./cmd/main.go dev --no-discovery > dev-stdout.txt 2> dev-stderr.txt &
 
 sleep 2
 
-INNGEST_SIGNING_KEY=test API_URL=http://127.0.0.1:8288 SDK_URL=http://127.0.0.1:3000/api/inngest go test ./tests -v
+INNGEST_SIGNING_KEY=test API_URL=http://127.0.0.1:8288 SDK_URL=http://127.0.0.1:3000/api/inngest go test ./tests -v -count=1


### PR DESCRIPTION
Ensure we respect local dev server concurrency, by checking that we use the deterministic function ID when evaluating partition concurrency keys.