### PR TITLE
Add env to ctx

### DIFF
--- a/pkg/execution/driver/dockerdriver/dockerdriver.go
+++ b/pkg/execution/driver/dockerdriver/dockerdriver.go
@@ -152,7 +152,7 @@ func (d *dockerExec) start(ctx context.Context, state state.State, wa inngest.St
 }
 
 func (d *dockerExec) startOpts(ctx context.Context, state state.State, wa inngest.Step, idx int) (docker.CreateContainerOptions, error) {
-	marshalled, err := driver.MarshalV1(ctx, state, wa, idx)
+	marshalled, err := driver.MarshalV1(ctx, state, wa, idx, "local")
 	if err != nil {
 		return docker.CreateContainerOptions{}, fmt.Errorf("error marshalling state")
 	}

--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -37,7 +37,7 @@ type FunctionStack struct {
 }
 
 // MarshalV1 marshals state as an input to driver runtimes.
-func MarshalV1(ctx context.Context, s state.State, step inngest.Step, stackIndex int) ([]byte, error) {
+func MarshalV1(ctx context.Context, s state.State, step inngest.Step, stackIndex int, env string) ([]byte, error) {
 	data := map[string]interface{}{
 		"event": s.Event(),
 		"steps": s.Actions(),
@@ -45,6 +45,10 @@ func MarshalV1(ctx context.Context, s state.State, step inngest.Step, stackIndex
 			// fn_id is used within entrypoints to SDK-based functions in
 			// order to specify the ID of the function to run via RPC.
 			"fn_id": s.Workflow().ID,
+			// env is the name of the environment that the function is running in.
+			// though this is self-discoverable most of the time, for static envs
+			// the SDK has no knowledge of the name as it only has a signing key.
+			"env": env,
 			// step_id is used within entrypoints to SDK-based functions in
 			// order to specify the step of the function to run via RPC.
 			"step_id": step.ID,

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -127,7 +127,7 @@ func (e executor) Execute(ctx context.Context, s state.State, action inngest.Act
 		return nil, fmt.Errorf("Unable to use HTTP executor for non-HTTP runtime")
 	}
 
-	input, err := driver.MarshalV1(ctx, s, step, idx)
+	input, err := driver.MarshalV1(ctx, s, step, idx, "local")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows the SDK to fetch env names when running.

Note:  open-source uses a static "local" env;  we'll want to configure this as and when we do direct integrations with dev server <> cloud.