### PR TITLE
Fix header timeouts

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,6 @@ config.#Config & {
 		drivers: {
 			http: config.#HTTPDriver & {
 				signingKey: "dev-signing-key"
-				timeout:    900
 			}
 			docker: config.#DockerDriver & {
 				network: "host"

--- a/pkg/cuedefs/config/config.cue
+++ b/pkg/cuedefs/config/config.cue
@@ -232,6 +232,6 @@ package config
 
 #HTTPDriver: {
 	name:        "http"
-	timeout?:    int | *900 // 15 minutes
+	timeout?:    int | *7200 // 2 hours
 	signingKey?: string
 }

--- a/pkg/execution/driver/httpdriver/config.go
+++ b/pkg/execution/driver/httpdriver/config.go
@@ -1,9 +1,6 @@
 package httpdriver
 
 import (
-	"net/http"
-	"time"
-
 	"github.com/inngest/inngest/pkg/execution/driver"
 
 	"github.com/inngest/inngest/pkg/config/registration"
@@ -27,10 +24,5 @@ func (Config) RuntimeName() string { return "http" }
 func (Config) DriverName() string { return "http" }
 
 func (c Config) NewDriver() (driver.Driver, error) {
-	return executor{
-		client: &http.Client{
-			Timeout: time.Duration(c.Timeout) * time.Second,
-		},
-		signingKey: []byte(c.SigningKey),
-	}, nil
+	return DefaultExecutor, nil
 }


### PR DESCRIPTION
Ensures that the HTTP client respects servers which take 2 hours to send headers.  Hah.