### PR TITLE
Custom retries

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -6,10 +6,25 @@ const (
 	// DefaultRetryCount is used when no retry count for a step is specified.
 	DefaultRetryCount = 3
 
+	// MaxFunctionTimeout represents the longest running function or step allowed within
+	// our system.
 	MaxFunctionTimeout = 2 * time.Hour
 
 	// MaxBodySize is the maximum payload size read on any HTTP response.
 	MaxBodySize = 1024 * 1024 * 4
 
+	// MaxRetries represents the maximum number of retries for a particular function or step
+	// possible.
+	MaxRetries = 30
+
+	// MaxRetryDuration is the furthest a retry can be scheduled.  If retries are scheduled further
+	// than now plus this duration, the retry duration will automatically be lowered to this value.
+	MaxRetryDuration = time.Hour * 24
+
+	// MinRetryDuration is the soonest a retry can be scheduled.
+	MinRetryDuration = time.Second * 1
+
+	// FunctionIdempotencyPeriod determines how long a specific function remains idempotent
+	// when using idempotency keys.
 	FunctionIdempotencyPeriod = 24 * time.Hour
 )

--- a/pkg/execution/driver/httpdriver/httpdriver_test.go
+++ b/pkg/execution/driver/httpdriver/httpdriver_test.go
@@ -5,8 +5,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
+	"time"
 
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,8 +34,68 @@ func TestRedirect(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	res, status, _, err := DefaultExecutor.do(context.Background(), ts.URL, input)
+	res, err := DefaultExecutor.do(context.Background(), ts.URL, input)
 	require.NoError(t, err)
-	require.Equal(t, 200, status)
-	require.Equal(t, []byte("ok"), res)
+	require.Equal(t, 200, res.statusCode)
+	require.Equal(t, []byte("ok"), res.body)
+}
+
+func TestRetryAfter(t *testing.T) {
+	input := []byte(`{"event":{"name":"hi","data":{}}}`)
+	at := time.Now().Add(6 * time.Hour).Truncate(time.Second).UTC()
+	formats := []string{
+		time.RFC3339, // Standard
+		time.RFC1123, // HTTP spec
+	}
+	for _, f := range formats {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Retry-After", at.Format(f))
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`{"error":true}`))
+		}))
+		defer ts.Close()
+
+		res, err := DefaultExecutor.do(context.Background(), ts.URL, input)
+		require.NoError(t, err)
+		require.Equal(t, 500, res.statusCode)
+		require.Equal(t, []byte(`{"error":true}`), res.body)
+		require.NotNil(t, res.retryAt)
+		require.EqualValues(t, at, *res.retryAt)
+	}
+}
+
+func TestParseRetry(t *testing.T) {
+	now := time.Now().Truncate(time.Second).UTC()
+
+	t.Run("It clips with too much time", func(t *testing.T) {
+		at := now.Add(2 * consts.MaxRetryDuration)
+		actual, err := ParseRetry(at.Format(time.RFC3339))
+		require.NoError(t, err)
+		require.Equal(t, now.Add(consts.MaxRetryDuration), actual)
+	})
+
+	t.Run("It clips with too many seconds", func(t *testing.T) {
+		at := (2 * consts.MaxRetryDuration)
+		actual, err := ParseRetry(strconv.Itoa(int(at.Seconds())))
+		require.NoError(t, err)
+		require.Equal(t, now.Add(consts.MaxRetryDuration), actual)
+	})
+
+	t.Run("It returns a minute in seconds", func(t *testing.T) {
+		actual, err := ParseRetry("60")
+		require.NoError(t, err)
+		require.Equal(t, now.Add(time.Minute), actual)
+	})
+
+	t.Run("It uses minimums in seconds", func(t *testing.T) {
+		actual, err := ParseRetry("1")
+		require.NoError(t, err)
+		require.Equal(t, now.Add(consts.MinRetryDuration), actual)
+	})
+
+	t.Run("It uses minimums with dates", func(t *testing.T) {
+		actual, err := ParseRetry(now.Add(time.Second).Format(time.RFC1123))
+		require.NoError(t, err)
+		require.Equal(t, now.Add(consts.MinRetryDuration), actual)
+	})
 }

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -48,6 +48,12 @@ type AlwaysRetryableError interface {
 	AlwaysRetryable()
 }
 
+// RetryAtSpecifier specifies the next retry time.  If this returns a nil pointer,
+// the default retry iwll be used for the current attempt.
+type RetryAtSpecifier interface {
+	NextRetryAt() *time.Time
+}
+
 // ShouldRetry returns whether we need to retry an error.
 func ShouldRetry(err error, attempt int, max int) bool {
 	if _, ok := err.(AlwaysRetryableError); ok {

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -659,6 +659,15 @@ func (q *queue) process(ctx context.Context, p QueuePartition, qi QueueItem, f o
 
 		if osqueue.ShouldRetry(err, qi.Data.Attempt, qi.Data.GetMaxAttempts()) {
 			at := backoff.DefaultBackoff(qi.Data.Attempt)
+			// If the error contains a NextRetryAt method, use that to indicate
+			// when we should retry.
+			if specifier, ok := err.(osqueue.RetryAtSpecifier); ok {
+				next := specifier.NextRetryAt()
+				if next != nil {
+					at = *next
+				}
+			}
+
 			qi.Data.Attempt += 1
 			qi.AtMS = at.UnixMilli()
 			q.logger.Warn().Err(err).

--- a/pkg/sdk/function.go
+++ b/pkg/sdk/function.go
@@ -99,9 +99,17 @@ func (s SDKFunction) Function() (*inngest.Function, error) {
 			funcStep.Retries = &atts
 		}
 		if step.Retries == nil && s.Retries != nil {
-			// Use the function's defaults provided as syntactic sugar when registering functions
+			// Use the function's defaults provided as syntactic sugar when registering functions,
+			// only if retries is nil
 			funcStep.Retries = s.Retries
 		}
+
+		// Always enforce bounds.
+		if funcStep.Retries != nil && *funcStep.Retries > consts.MaxRetries {
+			max := consts.MaxRetries
+			funcStep.Retries = &max
+		}
+
 		f.Steps = append(f.Steps, funcStep)
 	}
 


### PR DESCRIPTION
This uses the Retry-After HTTP header to specify when failing steps or
functions should be retried, within bounds.

This also allows the SDK to opt out of retries by specifying an
`X-No-Retry: true` header tag.