### PR TITLE
Add indexes to event stream parsing

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -177,10 +177,16 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 		return nil
 	})
 
-	if err := eg.Wait(); err != nil {
+	err := eg.Wait()
+
+	if max+1 > len(ids) {
+		max = len(ids) - 1
+	}
+
+	if err != nil {
 		w.WriteHeader(400)
 		_ = json.NewEncoder(w).Encode(apiutil.EventAPIResponse{
-			IDs:    ids[0:max],
+			IDs:    ids[0 : max+1],
 			Status: 400,
 			Error:  err,
 		})
@@ -189,7 +195,7 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(200)
 	_ = json.NewEncoder(w).Encode(apiutil.EventAPIResponse{
-		IDs:    ids[0:max],
+		IDs:    ids[0 : max+1],
 		Status: 200,
 	})
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -119,29 +119,36 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create a new channel which receives a stream of events from the incoming HTTP request
-	byteStream := make(chan json.RawMessage)
+	stream := make(chan eventstream.StreamItem)
 	eg := errgroup.Group{}
 	eg.Go(func() error {
-		return eventstream.ParseStream(ctx, r.Body, byteStream, a.config.EventAPI.MaxSize)
+		return eventstream.ParseStream(ctx, r.Body, stream, a.config.EventAPI.MaxSize)
 	})
 
 	// Create a new channel which holds all event IDs as a slice.
 	var (
-		ids    = []string{}
-		idChan = make(chan string)
+		max    int
+		ids    = make([]string, consts.MaxEvents)
+		idChan = make(chan struct {
+			int
+			string
+		})
 	)
 	eg.Go(func() error {
 		for item := range idChan {
-			ids = append(ids, item)
+			if max < item.int {
+				max = item.int
+			}
+			ids[item.int] = item.string
 		}
 		return nil
 	})
 
 	// Process those incoming events
 	eg.Go(func() error {
-		for byt := range byteStream {
+		for s := range stream {
 			evt := event.Event{}
-			if err := json.Unmarshal(byt, &evt); err != nil {
+			if err := json.Unmarshal(s.Item, &evt); err != nil {
 				return err
 			}
 
@@ -159,7 +166,10 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 				a.log.Error().Str("event", evt.Name).Err(err).Msg("error handling event")
 				return err
 			}
-			idChan <- id
+			idChan <- struct {
+				int
+				string
+			}{s.N, id}
 		}
 
 		// Close the idChan so that we stop appending to the ID slice.
@@ -170,7 +180,7 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 	if err := eg.Wait(); err != nil {
 		w.WriteHeader(400)
 		_ = json.NewEncoder(w).Encode(apiutil.EventAPIResponse{
-			IDs:    ids,
+			IDs:    ids[0:max],
 			Status: 400,
 			Error:  err,
 		})
@@ -179,7 +189,7 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(200)
 	_ = json.NewEncoder(w).Encode(apiutil.EventAPIResponse{
-		IDs:    ids,
+		IDs:    ids[0:max],
 		Status: 200,
 	})
 }

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -33,6 +33,8 @@ const (
 
 	MaxBatchSize    = 100
 	MaxBatchTimeout = 60 * time.Second
+	// MaxEvents is the maximum number of events we can parse in a single batch.
+	MaxEvents = 5_000
 
 	// InvokeEventName is the event name used to invoke specific functions via an
 	// API.  Note that invoking functions still sends an event in the usual manner.

--- a/pkg/eventstream/eventstream.go
+++ b/pkg/eventstream/eventstream.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/inngest/inngest/pkg/consts"
 )
 
 var (
@@ -12,8 +14,10 @@ var (
 	ErrEventTooLarge      = fmt.Errorf("Event is over the max size")
 )
 
-// MaxEvents is the maximum number of events we can parse in a single batch.
-const MaxEvents = 10_000
+type StreamItem struct {
+	N    int
+	Item json.RawMessage
+}
 
 // ParseStream parses a reader, publishing a stream of JSON-encoded events to the given channel,
 // ensuring that no individual event is too large.
@@ -35,7 +39,7 @@ const MaxEvents = 10_000
 //              // handle error
 //      }
 //
-func ParseStream(ctx context.Context, r io.Reader, stream chan json.RawMessage, maxSize int) error {
+func ParseStream(ctx context.Context, r io.Reader, stream chan StreamItem, maxSize int) error {
 	defer func() {
 		close(stream)
 	}()
@@ -71,13 +75,13 @@ func ParseStream(ctx context.Context, r io.Reader, stream chan json.RawMessage, 
 			return fmt.Errorf("%w: Max %d bytes / Size %d bytes", ErrEventTooLarge, maxSize, len(data))
 		}
 
-		stream <- data
+		stream <- StreamItem{Item: data}
 	case '[':
 		i := 0
 		// Parse a stream of tokens
 		for d.More() {
-			if i == MaxEvents {
-				return fmt.Errorf("maximum events parsed within a batch: %d", MaxEvents)
+			if i == consts.MaxEvents {
+				return fmt.Errorf("maximum events parsed within a batch: %d", consts.MaxEvents)
 			}
 
 			jsonEvt := json.RawMessage{}
@@ -87,7 +91,7 @@ func ParseStream(ctx context.Context, r io.Reader, stream chan json.RawMessage, 
 			if len(jsonEvt) > maxSize {
 				return fmt.Errorf("%w: Max %d bytes / Size %d bytes", ErrEventTooLarge, maxSize, len(jsonEvt))
 			}
-			stream <- jsonEvt
+			stream <- StreamItem{N: i, Item: jsonEvt}
 			i++
 		}
 	default:

--- a/pkg/eventstream/eventstream_test.go
+++ b/pkg/eventstream/eventstream_test.go
@@ -32,7 +32,7 @@ func TestParseStream_Single(t *testing.T) {
 	byt, err := json.Marshal(actual)
 	require.NoError(t, err)
 	r := bytes.NewReader(byt)
-	stream := make(chan json.RawMessage)
+	stream := make(chan StreamItem)
 
 	eg := errgroup.Group{}
 	eg.Go(func() error {
@@ -40,9 +40,9 @@ func TestParseStream_Single(t *testing.T) {
 	})
 
 	n := 0
-	for byt := range stream {
+	for item := range stream {
 		evt := event.Event{}
-		err := json.Unmarshal(byt, &evt)
+		err := json.Unmarshal(item.Item, &evt)
 		require.NoError(t, err)
 		require.EqualValues(t, actual, evt)
 		n++
@@ -78,7 +78,7 @@ func TestParseStream_Multiple(t *testing.T) {
 	require.NoError(t, err)
 
 	r := bytes.NewReader(byt)
-	stream := make(chan json.RawMessage)
+	stream := make(chan StreamItem)
 
 	eg := errgroup.Group{}
 	eg.Go(func() error {
@@ -86,9 +86,9 @@ func TestParseStream_Multiple(t *testing.T) {
 	})
 
 	n := 0
-	for byt := range stream {
+	for item := range stream {
 		evt := event.Event{}
-		err := json.Unmarshal(byt, &evt)
+		err := json.Unmarshal(item.Item, &evt)
 		require.NoError(t, err)
 		require.EqualValues(t, evts[n], evt)
 		n++
@@ -119,7 +119,7 @@ func TestParseStream_MaxSize(t *testing.T) {
 	require.NoError(t, err)
 
 	r := bytes.NewReader(byt)
-	stream := make(chan json.RawMessage)
+	stream := make(chan StreamItem)
 
 	eg := errgroup.Group{}
 	eg.Go(func() error {

--- a/tests/sdk_cancel_via_api_test.go
+++ b/tests/sdk_cancel_via_api_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -106,10 +107,14 @@ func TestCancelFunctionViaAPI(t *testing.T) {
 					return err
 				}
 				defer resp.Body.Close()
+
+				byt, _ := io.ReadAll(resp.Body)
+
 				ids := []ulid.ULID{}
-				if err := json.NewDecoder(resp.Body).Decode(&ids); err != nil {
-					return err
+				if err := json.Unmarshal(byt, &ids); err != nil {
+					return fmt.Errorf("cannot get event runs: %w\n\n%s", err, byt)
 				}
+
 				for _, id := range ids {
 					// Cancel run
 					route = fmt.Sprintf("%s/v0/runs/%s", apiURL.String(), id)


### PR DESCRIPTION
This ensures that the response for event IDs contains the same order as incoming events, fixing any race conditions.