### PR TITLE
Fix `onFailure` handlers receiving badly-formatted events

### DIFF
--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -3,6 +3,7 @@ package state
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/inngest/inngest/pkg/dateutil"
@@ -267,6 +268,18 @@ func (r DriverResponse) UserError() map[string]any {
 		if bodyAsMap, ok := mapped["body"].(map[string]any); ok {
 			return bodyAsMap
 		}
+
+		// The body might be a byte array. If it is, try and unmarshal it into a map[string]any.
+		if bodyAsBytes, ok := mapped["body"].(json.RawMessage); ok {
+			// We expect the body to be stringified JSON, so make sure to unescape it for JSON decoding.
+			if s, err := strconv.Unquote(string(bodyAsBytes)); err == nil {
+				var bodyAsMap map[string]any
+				if err := json.Unmarshal([]byte(s), &bodyAsMap); err == nil {
+					return bodyAsMap
+				}
+			}
+		}
+
 		return mapped
 	}
 	if ok {


### PR DESCRIPTION
## Summary

We expect `error.body` to be stringified (read: serialized) JSON, so adding code here to try and unmarshal that correctly instead of assuming it'll be a map.

Without this, we send the raw payload output (containing `status` and `body` keys) to the SDK instead of the actual error.