### PR TITLE
Add headers to DriverResponse

### DIFF
--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -19,16 +19,19 @@ type Driver interface {
 		edge inngest.Edge,
 		step inngest.Step,
 		stackIndex int,
+		attempt int,
 	) (*state.DriverResponse, error)
 }
 
-type FunctionStack struct {
-	Stack   []string `json:"stack"`
-	Current int      `json:"current"`
-}
-
 // MarshalV1 marshals state as an input to driver runtimes.
-func MarshalV1(ctx context.Context, s state.State, step inngest.Step, stackIndex int, env string) ([]byte, error) {
+func MarshalV1(
+	ctx context.Context,
+	s state.State,
+	step inngest.Step,
+	stackIndex int,
+	env string,
+	attempt int,
+) ([]byte, error) {
 	req := &SDKRequest{
 		// Events:  s.Events(),
 		Events:  []map[string]any{},
@@ -43,6 +46,7 @@ func MarshalV1(ctx context.Context, s state.State, step inngest.Step, stackIndex
 				Stack:   s.Stack(),
 				Current: stackIndex,
 			},
+			Attempt: attempt,
 		},
 	}
 

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -65,8 +65,8 @@ func CheckRedirect(req *http.Request, via []*http.Request) (err error) {
 	return nil
 }
 
-func Execute(ctx context.Context, s state.State, edge inngest.Edge, step inngest.Step, idx int) (*state.DriverResponse, error) {
-	return DefaultExecutor.Execute(ctx, s, edge, step, idx)
+func Execute(ctx context.Context, s state.State, edge inngest.Edge, step inngest.Step, idx, attempt int) (*state.DriverResponse, error) {
+	return DefaultExecutor.Execute(ctx, s, edge, step, idx, attempt)
 }
 
 type executor struct {
@@ -141,14 +141,13 @@ func ParseGenerator(ctx context.Context, byt []byte) ([]*state.GeneratorOpcode, 
 	}, nil
 }
 
-func (e executor) Execute(ctx context.Context, s state.State, edge inngest.Edge, step inngest.Step, idx int) (*state.DriverResponse, error) {
-
+func (e executor) Execute(ctx context.Context, s state.State, edge inngest.Edge, step inngest.Step, idx, attempt int) (*state.DriverResponse, error) {
 	uri, err := url.Parse(step.URI)
 	if err != nil || (uri.Scheme != "http" && uri.Scheme != "https") {
 		return nil, fmt.Errorf("Unable to use HTTP executor for non-HTTP runtime")
 	}
 
-	input, err := driver.MarshalV1(ctx, s, step, idx, "local")
+	input, err := driver.MarshalV1(ctx, s, step, idx, "local", attempt)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -173,6 +173,7 @@ func (e executor) Execute(ctx context.Context, s state.State, edge inngest.Edge,
 			Step:       step,
 			Duration:   res.Duration,
 			OutputSize: len(res.Body),
+			Headers:    res.Headers,
 		}
 		resp.Generator, err = ParseGenerator(ctx, res.Body)
 		if err != nil {

--- a/pkg/execution/driver/mockdriver/mockdriver.go
+++ b/pkg/execution/driver/mockdriver/mockdriver.go
@@ -19,7 +19,7 @@ const RuntimeName = "mock"
 type Mock struct {
 	// DynamicResponses allows users to specify a function which allows
 	// steps to return different data on each execution invocation.
-	DynamicResponses func(context.Context, state.State, inngest.Edge, inngest.Step, int) map[string]state.DriverResponse
+	DynamicResponses func(context.Context, state.State, inngest.Edge, inngest.Step, int, int) map[string]state.DriverResponse
 
 	// Responses stores the responses that a driver should return.
 	Responses map[string]state.DriverResponse
@@ -45,7 +45,7 @@ func (m *Mock) RuntimeType() string {
 	return m.RuntimeName
 }
 
-func (m *Mock) Execute(ctx context.Context, s state.State, edge inngest.Edge, step inngest.Step, idx int) (*state.DriverResponse, error) {
+func (m *Mock) Execute(ctx context.Context, s state.State, edge inngest.Edge, step inngest.Step, idx, attempt int) (*state.DriverResponse, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -56,7 +56,7 @@ func (m *Mock) Execute(ctx context.Context, s state.State, edge inngest.Edge, st
 
 	resp := m.Responses
 	if m.DynamicResponses != nil {
-		resp = m.DynamicResponses(ctx, s, edge, step, idx)
+		resp = m.DynamicResponses(ctx, s, edge, step, idx, attempt)
 	}
 	response := resp[step.ID]
 	err := m.Errors[step.ID]
@@ -77,7 +77,7 @@ type Config struct {
 	Responses map[string]state.DriverResponse
 	// DynamicResponses allows users to specify a function which allows
 	// steps to return different data on each execution invocation.
-	DynamicResponses func(context.Context, state.State, inngest.Edge, inngest.Step, int) map[string]state.DriverResponse
+	DynamicResponses func(context.Context, state.State, inngest.Edge, inngest.Step, int, int) map[string]state.DriverResponse
 	// driver stores the driver once, as a singleton per config instance.
 	driver driver.Driver
 	Driver string

--- a/pkg/execution/driver/request.go
+++ b/pkg/execution/driver/request.go
@@ -13,7 +13,6 @@ type SDKRequest struct {
 	Events  []map[string]any   `json:"events,omitempty"`
 	Actions map[string]any     `json:"steps"`
 	Context *SDKRequestContext `json:"ctx"`
-
 	// UseAPI tells the SDK to retrieve `Events` and `Actions` data
 	// from the API instead of expecting it to be in the request body.
 	// This is a way to get around serverless provider's request body
@@ -24,7 +23,6 @@ type SDKRequest struct {
 func (req *SDKRequest) IsBodySizeTooLarge() bool {
 	byt, err := json.Marshal(req)
 	if err != nil {
-		// log error
 		return false
 	}
 	return len(byt) >= consts.MaxBodySize
@@ -35,6 +33,9 @@ type SDKRequestContext struct {
 	// order to specify the ID of the function to run via RPC.
 	FunctionID uuid.UUID `json:"fn_id"`
 
+	// RunID  is the ID of the current
+	RunID ulid.ULID `json:"run_id"`
+
 	// Env is the name of the environment that the function is running in.
 	// though this is self-discoverable most of the time, for static envs
 	// the SDK has no knowledge of the name as it only has a signing key.
@@ -44,8 +45,16 @@ type SDKRequestContext struct {
 	// order to specify the step of the function to run via RPC.
 	StepID string `json:"step_id"`
 
-	// XXX: Pass in opentracing context within ctx.
-	RunID ulid.ULID `json:"run_id"`
+	// Attempt is the zero-index attempt number.
+	Attempt int `json:"attempt"`
 
+	// Stack represents the function stack at the time of the step invocation.
 	Stack *FunctionStack `json:"stack"`
+
+	// XXX: Pass in opentracing context within ctx.
+}
+
+type FunctionStack struct {
+	Stack   []string `json:"stack"`
+	Current int      `json:"current"`
 }

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -369,7 +369,7 @@ func (e *executor) executeStep(ctx context.Context, id state.Identifier, step *i
 		return nil, 0, fmt.Errorf("error saving started state: %w", err)
 	}
 
-	response, err := d.Execute(ctx, s, edge, *step, stackIndex)
+	response, err := d.Execute(ctx, s, edge, *step, stackIndex, attempt)
 	if response == nil {
 		// Add an error response here.
 		response = &state.DriverResponse{

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -37,7 +37,6 @@ var (
 // we fail to wait for the executor, workflows may finish prematurely as future
 // actions may not be scheduled.
 //
-//
 // # Running functions
 //
 // The executor schedules function execution over drivers.  A driver is a runtime-specific
@@ -373,8 +372,9 @@ func (e *executor) executeStep(ctx context.Context, id state.Identifier, step *i
 	if response == nil {
 		// Add an error response here.
 		response = &state.DriverResponse{
-			Step: *step,
-			Err:  err,
+			Step:    *step,
+			Err:     err,
+			Headers: response.Headers,
 		}
 	}
 	if err != nil && response.Err == nil {

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -143,6 +143,9 @@ type DriverResponse struct {
 	//
 	// When final is true, Retryable() always returns false.
 	final bool
+
+	// Headers from the function invocation response.
+	Headers map[string][]string `json:"headers"`
 }
 
 // SetFinal indicates that this error is final, regardless of the status code


### PR DESCRIPTION
# Changes

Add `DriverResponse.Headers` and set it after execution

# Motivation

We'd like to log the execution response headers within Worker, since that'll help us understand whether execution failures are happening at the SDK or app level