### PR TITLE
Fix goreleaser version replacement

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,8 +11,8 @@ builds:
     binary: inngest
     ldflags:
       - -s -w
-      - -X github.com/inngest/inngest/inngest/version.Version={{.Version}}
-      - -X github.com/inngest/inngest/inngest/version.Hash={{.ShortCommit}}
+      - -X github.com/inngest/inngest/pkg/inngest/version.Version={{.Version}}
+      - -X github.com/inngest/inngest/pkg/inngest/version.Hash={{.ShortCommit}}
     goos:
       - linux
       - windows


### PR DESCRIPTION
## Description

During the major refactor in #434, the `version.go` file changed locations. Goreleaser was no longer updating the version as part of the build, leaving all versions to `dev-`.