### PR TITLE
Namespace events with "event" in rate limit key

### DIFF
--- a/pkg/execution/ratelimit/ratelimit.go
+++ b/pkg/execution/ratelimit/ratelimit.go
@@ -40,11 +40,14 @@ func RateLimitKey(ctx context.Context, id uuid.UUID, c inngest.RateLimit, evt ma
 
 	// Take a checksum of this data.  It doesn't matter if this is a map or a string;
 	// as long as we're consistent here.
+	return hash(res, id), nil
+}
+
+func hash(res any, id uuid.UUID) string {
+	fmt.Println(res)
 	ui := xxhash.Sum64String(fmt.Sprintf("%v", res))
 	sum := strconv.FormatUint(ui, 36)
-
-	// Use this function and checksum as the rate limit key.
-	return fmt.Sprintf("%s-%s", id, sum), nil
+	return fmt.Sprintf("%s-%s", id, sum)
 }
 
 // RateLimit checks the given key against the specified rate limit, returning true if limited.

--- a/pkg/execution/ratelimit/ratelimit.go
+++ b/pkg/execution/ratelimit/ratelimit.go
@@ -33,10 +33,11 @@ func RateLimitKey(ctx context.Context, id uuid.UUID, c inngest.RateLimit, evt ma
 	if err != nil {
 		return "", fmt.Errorf("unable to parse rate limit expression: %w", err)
 	}
-	res, _, err := eval.Evaluate(ctx, expressions.NewData(evt))
+	res, _, err := eval.Evaluate(ctx, expressions.NewData(map[string]any{"event": evt}))
 	if err != nil {
 		return "", ErrEvaluatingRateLimitExpression
 	}
+
 	// Take a checksum of this data.  It doesn't matter if this is a map or a string;
 	// as long as we're consistent here.
 	ui := xxhash.Sum64String(fmt.Sprintf("%v", res))

--- a/pkg/execution/ratelimit/ratelimit_test.go
+++ b/pkg/execution/ratelimit/ratelimit_test.go
@@ -1,0 +1,70 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimitKey(t *testing.T) {
+	ctx := context.Background()
+	id := uuid.New()
+	t.Run("It returns an event key", func(t *testing.T) {
+		key, err := RateLimitKey(
+			ctx,
+			id,
+			inngest.RateLimit{
+				Key: str("event.data.orderId"),
+			},
+			map[string]any{
+				"data": map[string]any{
+					"orderId": "me and yoko ono",
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.EqualValues(t, hash("me and yoko ono", id), key)
+	})
+
+	t.Run("It concats strings and stuff", func(t *testing.T) {
+		key, err := RateLimitKey(
+			ctx,
+			id,
+			inngest.RateLimit{
+				Key: str("event.data.name + '--' + event.data.id"),
+			},
+			map[string]any{
+				"data": map[string]any{
+					"name": "jj",
+					"id":   "1",
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.EqualValues(t, hash("jj--1", id), key)
+	})
+
+	t.Run("It works with missing data", func(t *testing.T) {
+		key, err := RateLimitKey(
+			ctx,
+			id,
+			inngest.RateLimit{
+				Key: str("event.data.name + '--' + event.data.id"),
+			},
+			map[string]any{
+				"data": map[string]any{
+					"name": "jj",
+				},
+			},
+		)
+		require.NoError(t, err)
+		require.EqualValues(t, hash("jj--", id), key)
+	})
+}
+
+func str(s string) *string {
+	return &s
+}

--- a/pkg/expressions/expressions_test.go
+++ b/pkg/expressions/expressions_test.go
@@ -74,6 +74,35 @@ func TestEvaluateExpression(t *testing.T) {
 			"",
 		},
 		{
+			"5 + 4",
+			map[string]interface{}{
+				"event": event.Event{
+					Data: map[string]interface{}{
+						"name": "Tester McTestyFace",
+					},
+				},
+			},
+			int64(9),
+			nil,
+			false,
+			"",
+		},
+		{
+			// missing attr
+			"event.data.name + '-' + event.data.foo",
+			map[string]interface{}{
+				"event": event.Event{
+					Data: map[string]interface{}{
+						"name": "Tester McTestyFace",
+					},
+				},
+			},
+			"Tester McTestyFace-",
+			nil,
+			false,
+			"",
+		},
+		{
 			"uppercase(event.data.name) + ' is my name'",
 			map[string]interface{}{
 				"event": event.Event{

--- a/pkg/expressions/overloads.go
+++ b/pkg/expressions/overloads.go
@@ -49,7 +49,8 @@ func celDeclarations() []*exprpb.Decl {
 		if _, ok := d.DeclKind.(*exprpb.Decl_Function); ok {
 			// This is a function that we will overload directly in the cel env to
 			// provide easier type handling.
-			if d.Name == operators.Equals ||
+			if d.Name == operators.Add ||
+				d.Name == operators.Equals ||
 				d.Name == operators.NotEquals ||
 				d.Name == operators.LessEquals ||
 				d.Name == operators.Less ||
@@ -70,6 +71,10 @@ func celDeclarations() []*exprpb.Decl {
 		//
 		// We do not need to re-implement the functionality for these overloads - they
 		// are already implemented within functions/standard using traits.
+		decls.NewFunction(
+			operators.Add,
+			decls.NewOverload("add_any",
+				[]*expr.Type{decls.Any, decls.Any}, decls.Any)),
 		decls.NewFunction(
 			operators.Equals,
 			decls.NewOverload("equals_any",

--- a/pkg/expressions/unknown.go
+++ b/pkg/expressions/unknown.go
@@ -117,6 +117,15 @@ func unknownDecorator(act interpreter.PartialActivation) interpreter.Interpretab
 // which is used in place of unknown.
 func handleUnknownCall(i interpreter.InterpretableCall, args *argColl) (interpreter.Interpretable, error) {
 	switch i.Function() {
+	case operators.Add:
+		// Find the non-unknown type and return that
+		for _, arg := range args.arguments {
+			if types.IsUnknown(arg) {
+				continue
+			}
+			return staticCall{result: arg, InterpretableCall: i}, nil
+		}
+		return staticCall{result: types.False, InterpretableCall: i}, nil
 	case operators.Equals:
 		// Comparing an unknown to null is true, else return false.
 		result := types.False


### PR DESCRIPTION
Adds tests asserting that expressions evaluate to true when adding missing data, and that we properly namespace rate limit keys in OSS.