### PR TITLE
Use stack index from previous state save

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -228,13 +228,16 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, edge innges
 		if log != nil {
 			log.Warn().Msg("step already executed")
 		}
-		// TODO: Index ???
+
+		// Get the index from the previous save.
+		idx, _ := e.sm.StackIndex(ctx, id.RunID, edge.Incoming)
+
 		// This has already successfully been executed.
 		return &state.DriverResponse{
 			Scheduled: false,
 			Output:    resp,
 			Err:       nil,
-		}, 0, nil
+		}, idx, nil
 	}
 
 	resp, idx, err := e.run(ctx, id, edge, s, attempt, stackIndex)


### PR DESCRIPTION
This ensures that attempting a previously stored step returns the correct index.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
