### PR TITLE
Add event pause exists check

### DIFF
--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -41,6 +41,9 @@ type PauseGetter interface {
 	// PausesByEvent returns all pauses for a given event, in a given workspace.
 	PausesByEvent(ctx context.Context, workspaceID uuid.UUID, eventName string) (PauseIterator, error)
 
+	// EventHasPauses returns whether the event has pauses stored.
+	EventHasPauses(ctx context.Context, workspaceID uuid.UUID, eventName string) (bool, error)
+
 	// PauseByStep returns a specific pause for a given workflow run, from a given step.
 	//
 	// This is required when continuing a step function from an async step, ie. one that

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -938,6 +938,12 @@ func (m mgr) PausesByEvent(ctx context.Context, workspaceID uuid.UUID, event str
 	return &keyIter{i: 0, keys: keys, r: m.r, key: key}, nil
 }
 
+func (m mgr) EventHasPauses(ctx context.Context, workspaceID uuid.UUID, event string) (bool, error) {
+	key := m.kf.PauseEvent(ctx, workspaceID, event)
+	cmd := m.r.B().Exists().Key(key).Build()
+	return m.r.Do(ctx, cmd).AsBool()
+}
+
 func (m mgr) PauseByID(ctx context.Context, id uuid.UUID) (*state.Pause, error) {
 	cmd := m.r.B().Get().Key(m.kf.PauseID(ctx, id)).Build()
 	str, err := m.r.Do(ctx, cmd).ToString()

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -1004,6 +1004,10 @@ func checkPausesByEvent_empty(t *testing.T, m state.Manager) {
 	require.NotNil(t, iter)
 	require.False(t, iter.Next(ctx))
 	require.Nil(t, iter.Val(ctx))
+
+	exists, err := m.EventHasPauses(ctx, uuid.UUID{}, "lol/nothing.my.friend")
+	require.NoError(t, err)
+	require.False(t, exists)
 }
 
 func checkPausesByEvent_single(t *testing.T, m state.Manager) {
@@ -1053,6 +1057,14 @@ func checkPausesByEvent_single(t *testing.T, m state.Manager) {
 	}
 	err = m.SavePause(ctx, unusedB)
 	require.NoError(t, err)
+
+	exists, err := m.EventHasPauses(ctx, wsA, evtA)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	exists, err = m.EventHasPauses(ctx, wsB, evtA)
+	require.NoError(t, err)
+	require.True(t, exists)
 
 	iter, err := m.PausesByEvent(ctx, wsA, evtA)
 	require.NoError(t, err)


### PR DESCRIPTION
This allows a quick lookup to see if pauses exist for a given event.


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
