### PR TITLE
Fix: Upsert functions upon update

### DIFF
--- a/pkg/cqrs/ddb/cqrs.go
+++ b/pkg/cqrs/ddb/cqrs.go
@@ -188,6 +188,16 @@ func (w wrapper) InsertFunction(ctx context.Context, params cqrs.InsertFunctionP
 	)
 }
 
+func (w wrapper) UpdateFunction(ctx context.Context, params cqrs.UpdateFunctionParams) (*cqrs.Function, error) {
+	return copyWriter(
+		ctx,
+		w.q.UpdateFunction,
+		params,
+		sqlc.UpdateFunctionParams{},
+		&cqrs.Function{},
+	)
+}
+
 func copyWriter[
 	PARAMS_IN any,
 	INTERNAL_PARAMS any,

--- a/pkg/cqrs/ddb/sqlc/queries.sql
+++ b/pkg/cqrs/ddb/sqlc/queries.sql
@@ -36,6 +36,14 @@ INSERT INTO functions
 	(id, app_id, name, slug, config, created_at) VALUES
 	(?, ?, ?, ?, ?, ?) RETURNING *;
 
+-- name: UpdateFunction :one
+UPDATE functions
+	SET app_id = ?, name = ?, slug = ?, config = ?, updated_at = ?
+	WHERE id = ? RETURNING *;
+
+-- name: GetFunction :one
+SELECT * FROM functions WHERE id = ?;
+
 -- name: GetFunctions :many
 SELECT * FROM functions;
 

--- a/pkg/cqrs/ddb/sqlc/schema.sql
+++ b/pkg/cqrs/ddb/sqlc/schema.sql
@@ -20,4 +20,5 @@ CREATE TABLE functions (
     slug VARCHAR NOT NULL,
     config VARCHAR NOT NULL,
     created_at TIMESTAMP NOT NULL
+    updated_at TIMESTAMP NOT NULL
 );

--- a/pkg/cqrs/functions.go
+++ b/pkg/cqrs/functions.go
@@ -40,6 +40,7 @@ type FunctionReader interface {
 
 type FunctionWriter interface {
 	InsertFunction(ctx context.Context, params InsertFunctionParams) (*Function, error)
+	UpdateFunction(ctx context.Context, params UpdateFunctionParams) (*Function, error)
 }
 
 type InsertFunctionParams struct {
@@ -49,4 +50,14 @@ type InsertFunctionParams struct {
 	Slug      string
 	Config    string
 	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type UpdateFunctionParams struct {
+	ID        uuid.UUID
+	AppID     uuid.UUID
+	Name      string
+	Slug      string
+	Config    string
+	UpdatedAt time.Time
 }


### PR DESCRIPTION
## Description

When a user added or removed functions for a given app, the checksum doesn't match, but the first duplicate function that is inserted (based on the deterministic function id) fails to be inserted and returns and error, preventing any further functions from being created.

This aims to change the insert to a upsert-like behavior which should be able to gracefully handle functions that already exist, just updating those documents.

NOTES

* We also need to soft delete functions that have been removed so we need to also iterate through any existing ones and remove them if they weren't inserted/updated.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
