### PR TITLE
Fix: Move image arg within scope of build stage

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,5 @@
-ARG BIN=./build/inngest-linux-amd64
 FROM --platform=$BUILDPLATFORM alpine:3.16 AS inngest
+ARG BIN=./build/inngest-linux-amd64
 RUN apk add --no-cache ca-certificates tzdata && update-ca-certificates
 COPY ${BIN} /bin/inngest
 CMD ["inngest"]


### PR DESCRIPTION
## Description

The argument set above the FROM statement is not available within the scope of the build stage itself.

See: https://docs.docker.com/engine/reference/builder/#scope

### Context

Prior to this, images were built copying the `build` directory into the Dockerfile and the binary did not work as expected:

```
docker run --rm -it inngest/inngest ls /bin/inngest
Dockerfile           inngest-linux-arm64
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
