### PR TITLE
Ensure we copy binaries and use glibc inside containers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,47 @@ on:
       - "v*"
 
 jobs:
+  windows-build:
+    runs-on: windows-latest
+    staeps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.20'
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.6.2
+      - name: Set sha
+        id: sha
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Set tag
+        id: tag
+        run: echo "tag=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_OUTPUT
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build UI
+        run: make build-ui
+
+      - name: Build app
+        run: |
+          go build -o /builds/inngest-windows-amd64 -ldflags="-s -w -X github.com/inngest/inngest/pkg/inngest/version.Version=${{ steps.tag.outputs.tag }} -X github.com/inngest/inngest/pkg/inngest/version.Hash=${{ steps.sha.outputs.sha }}" ./cmd/main.go
+      - name: 'Upload Artifact'
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows-amd64
+          path: ./build/inngest-windows-amd64
+          retention-days: 1
+
   goreleaser:
     runs-on: ubuntu-latest
+    needs: [windows-build]
     steps:
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -47,13 +86,19 @@ jobs:
           dest: build
           prefix: inngest
           pkg: cmd
-          targets: linux/arm64,linux/amd64,darwin/arm64,darwin/amd64,windows/amd64
+          targets: linux/arm64,linux/amd64,darwin/arm64,darwin/amd64
           v: false
           x: false
           race: false
           ldflags: -s -w -X github.com/inngest/inngest/pkg/inngest/version.Version=${{ steps.tag.outputs.tag }} -X github.com/inngest/inngest/pkg/inngest/version.Hash=${{ steps.sha.outputs.sha }}
           buildmode: default
           trimpath: true
+
+      - name: 'Download windows artifacts'
+        uses: actions/download-artifact@v3
+        with:
+          name: windows-amd64
+          path: ./build/
 
       - name: 'Upload Artifact'
         uses: actions/upload-artifact@v3

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,7 @@ dockers:
     - "inngest/inngest:{{ .Tag }}-amd64"
     build_flag_templates:
     - "--pull"
-    - "--build-arg=BIN=./build/inngest-linux-amd64"
+    - "--build-arg=BIN=inngest-linux-amd64"
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -38,7 +38,7 @@ dockers:
     - "inngest/inngest:{{ .Tag }}-arm64v8"
     build_flag_templates:
     - "--pull"
-    - "--build-arg=BIN=./build/inngest-linux-arm64"
+    - "--build-arg=BIN=inngest-linux-arm64"
     - "--label=org.opencontainers.image.created={{.Date}}"
     - "--label=org.opencontainers.image.title={{.ProjectName}}"
     - "--label=org.opencontainers.image.revision={{.FullCommit}}"

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,5 @@
-ARG BIN=./build/inngest-linux-amd64
-FROM --platform=$BUILDPLATFORM alpine:3.16 AS inngest
-RUN apk add --no-cache ca-certificates tzdata && update-ca-certificates
-COPY ${BIN} /bin/inngest
+FROM --platform=$BUILDPLATFORM debian:stable-slim AS inngest
+ARG BIN=inngest-linux-amd64
+RUN apt-get update && apt-get install -y ca-certificates tzdata && update-ca-certificates
+COPY $BIN /bin/inngest
 CMD ["inngest"]


### PR DESCRIPTION
## Description

Even though we pass `-static` to `ld` during compilation, we're compiling against glibc instead of musl - so we switch out the base image for debian slim to fix containers using CGO.

We also need to change the files that we copy in using non-relative paths:

```
(git)-[fix/goreleaser-docker] % docker run --rm -ti 49445b0cbf30

    ____                            __
   /  _/___  ____  ____ ____  _____/ /_
   / // __ \/ __ \/ __ '/ _ \/ ___/ __/
 _/ // / / / / / / /_/ /  __(__  ) /_
/___/_/ /_/_/ /_/\__, /\___/____/\__/
                /____/

Build event-driven queues with zero infra.
Request features, get help, and chat with us: https://www.inngest.com/discord

Usage:
  inngest [command]

Available Commands:
  dev         Run the Inngest dev server
  help        Help about any command
  login       Logs in to your Inngest account
  serve       Start an Inngest service for self hosting
  version     Shows the inngest CLI version (saving time, it's: dev-)

Flags:
  -h, --help      help for inngest
      --json      Output logs as JSON.  Set to true if stdout is not a TTY.
      --prod      Use the production environment for the current command.
  -v, --verbose   Enable verbose logging.

Use "inngest [command] --help" for more information about a command.
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
