### PR TITLE
Add specific function invocation via events

### DIFF
--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -5,9 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -94,12 +92,6 @@ func (a *apiServer) handleEvent(ctx context.Context, e *event.Event) (string, er
 	ctx = logger.With(ctx, l)
 
 	l.Debug().Str("event", e.Name).Msg("handling event")
-
-	if strings.HasPrefix(strings.ToLower(e.Name), "inngest/") {
-		err := fmt.Errorf("event name %q is reserved for internal use", e.Name)
-		l.Error().Err(err).Msg("reserved event name rejected")
-		return "", err
-	}
 
 	if e.ID == "" {
 		// Always ensure that the event has an ID, for idempotency.

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -15,4 +15,11 @@ const (
 
 	MaxBatchSize    = 100
 	MaxBatchTimeout = 60 * time.Second
+
+	// InvokeEventName is the event name used to invoke specific functions via an
+	// API.  Note that invoking functions still sends an event in the usual manner.
+	InvokeEventName = "inngest/function.invoked"
+	// InvokeSlugKey is the data key used to store the fn name when invoking a function
+	// via an RPC-like call, abstracting event-driven fanout.
+	InvokeSlugKey = "_inngest_fn"
 )


### PR DESCRIPTION
This commit introduces an API to invoke specific functions by slug.  We do this via events.  In short:

- We create a new internal event: `inngest/function.invoked`.  This can invoke any function by slug in the current workspace (via signing keys).
- POST data to this invoke API is sent as `event.data` to the functon
- We can only ever invoke a single function
- Scheduled functions (eg. crons) can be invoked.

In the future, we can add a blocking ?async query parameter which lets the frontend await on function output.

This is _primarily_ needed to test scheduled functions via our new UI.  However, it has broad implications and should get first class support within our SDK.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
