### PR TITLE
Add ability to pin running functions to specific version

### DIFF
--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -36,15 +36,23 @@ var (
 
 // Identifier represents the unique identifier for a workflow run.
 type Identifier struct {
+	RunID ulid.ULID `json:"runID"`
+
 	WorkflowID      uuid.UUID `json:"wID"`
 	WorkflowVersion int       `json:"wv"`
-	RunID           ulid.ULID `json:"runID"`
+	// StaticVersion indicates whether the workflow is pinned to the
+	// given function definition over the life of the function.  If functions
+	// are deployed to their own URLs, this ensures that the endpoint we hit
+	// for the function (and therefore code) stays the same.  Note:  this is only
+	// important when we people use separate endpoints per function version.
+	StaticVersion bool `json:"s,omitempty"`
+
 	// Key represents a unique user-defined key to be used as part of the
 	// idempotency key.  This is appended to the workflow ID and workflow
 	// version to create a full idempotency key (via the IdempotencyKey() method).
 	//
 	// If this is not present the RunID is used as this value.
-	Key string `json:"key"`
+	Key string `json:"key,omitempty"`
 }
 
 // IdempotencyKey returns the unique key used to represent this single


### PR DESCRIPTION
The dev server has no function versions, but this allows us to pin in the cloud.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
