### PR TITLE
Apply `ts` checks to cancellation pauses

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,10 @@
+# Testing
+
+### E2E testing, local builds
+
+1. `go run ./cmd/main.go dev --no-discovery`: Run the dev server using your local build: 
+2. `cd tests/js && yarn dev`: Run the JS SDK
+3. `INNGEST_SIGNING_KEY=test API_URL=http://127.0.0.1:8288 SDK_URL=http://127.0.0.1:3000/api/inngest go test ./tests -v -count=1`: Run tests
+
+To filter tests:
+`INNGEST_SIGNING_KEY=test API_URL=http://127.0.0.1:8288 SDK_URL=http://127.0.0.1:3000/api/inngest go test ./tests -v -count=1 -test.run TestSDKCancelNotReceived`

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -150,6 +150,10 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 				return err
 			}
 
+			if evt.Timestamp == 0 {
+				evt.Timestamp = time.Now().UnixMilli()
+			}
+
 			id, err := a.handler(r.Context(), &evt)
 			if err != nil {
 				a.log.Error().Str("event", evt.Name).Err(err).Msg("error handling event")

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -652,12 +652,20 @@ func Initialize(ctx context.Context, fn inngest.Function, evt event.Event, s sta
 			}
 			expires = time.Now().Add(dur)
 		}
+
+		// Ensure that we only listen to cancellation events that occur
+		// after the initial event is received.
+		expr := "(async.ts == null || async.ts > event.ts)"
+		if c.If != nil {
+			expr = expr + " && " + *c.If
+		}
+
 		err := s.SavePause(ctx, state.Pause{
 			ID:                pauseID,
 			Identifier:        id,
 			Expires:           state.Time(expires),
 			Event:             &c.Event,
-			Expression:        c.If,
+			Expression:        &expr,
 			Cancel:            true,
 			TriggeringEventID: &evt.ID,
 		})

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -660,12 +660,24 @@ func Initialize(ctx context.Context, fn inngest.Function, evt event.Event, s sta
 			expr = expr + " && " + *c.If
 		}
 
-		err := s.SavePause(ctx, state.Pause{
+		// Filter the expression data such that it contains only the variables used
+		// in the expression.
+		eval, err := expressions.NewExpressionEvaluator(ctx, expr)
+		if err != nil {
+			return &id, err
+		}
+
+		// Take the data for expressions based off of state
+		ed := expressions.NewData(map[string]any{"event": evt.Map()})
+		data := eval.FilteredAttributes(ctx, ed).Map()
+
+		err = s.SavePause(ctx, state.Pause{
 			ID:                pauseID,
 			Identifier:        id,
 			Expires:           state.Time(expires),
 			Event:             &c.Event,
 			Expression:        &expr,
+			ExpressionData:    data,
 			Cancel:            true,
 			TriggeringEventID: &evt.ID,
 		})

--- a/tests/dsl.go
+++ b/tests/dsl.go
@@ -156,7 +156,13 @@ func (t *Test) ExpectRequest(name string, queryStepID string, timeout time.Durat
 			err = json.Unmarshal(byt, er)
 			require.NoError(t.test, err)
 
+			require.NotZero(t.test, er.Event.Timestamp)
+			// Zero out the TS
+			ts := er.Event.Timestamp
+			er.Event.Timestamp = 0
 			require.EqualValues(t.test, t.requestEvent, er.Event, "Request event is incorrect")
+			er.Event.Timestamp = ts
+
 			// Unset the run ID so that our unique run ID doesn't cause issues.
 			t.requestCtx.RunID = er.Ctx.RunID
 			require.EqualValues(t.test, t.requestCtx, er.Ctx, "Request ctx is incorrect")

--- a/tests/sdk_cancel_test.go
+++ b/tests/sdk_cancel_test.go
@@ -144,6 +144,7 @@ func TestSDKCancelReceived(t *testing.T) {
 		Name: "tests/cancel.test",
 		Data: map[string]any{
 			"request_id": "123",
+			"whatever":   "this doesn't matter my friend",
 		},
 		User: map[string]interface{}{},
 	}


### PR DESCRIPTION
This ensures that we only cancel functions on events received after the triggering event, race condition free.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
