### PR TITLE
Add concurrency keys to SDK function registrations

### DIFF
--- a/pkg/sdk/function.go
+++ b/pkg/sdk/function.go
@@ -70,10 +70,14 @@ func (s SDKFunction) Function() (*inngest.Function, error) {
 	case map[string]any:
 		// Handle maps.
 		limit, ok := v["limit"].(float64)
+		key, _ := v["key"].(string)
 		if ok {
 			f.Concurrency = &inngest.Concurrency{
 				Limit: int(limit),
 			}
+		}
+		if key != "" {
+			f.Concurrency.Key = &key
 		}
 	}
 


### PR DESCRIPTION
## Description

Allows users to specify concurrency keys to create custom concurrency groups based off of event data.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
