### PR TITLE
Limit max cancellation signals

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -24,6 +24,9 @@ const (
 	// MinRetryDuration is the soonest a retry can be scheduled.
 	MinRetryDuration = time.Second * 1
 
+	// MaxCancellations represents the max automatic cancellation signals per function
+	MaxCancellations = 5
+
 	// FunctionIdempotencyPeriod determines how long a specific function remains idempotent
 	// when using idempotency keys.
 	FunctionIdempotencyPeriod = 24 * time.Hour

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gosimple/slug"
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/expressions"
 	"github.com/xhit/go-str2duration/v2"
 )
@@ -185,6 +186,10 @@ func (f Function) Validate(ctx context.Context) error {
 				err = multierror.Append(err, fmt.Errorf("Cancellation expression is invalid: %s", exprErr))
 			}
 		}
+	}
+
+	if len(f.Cancel) > consts.MaxCancellations {
+		err = multierror.Append(err, fmt.Errorf("This function exceeds the max number of cancellation events: %d", consts.MaxCancellations))
 	}
 
 	// Validate rate limit expression


### PR DESCRIPTION
Add an upper bound to the number of cancellation signals.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
