### PR TITLE
Add cancellation, event resuming to executor interface

### DIFF
--- a/cmd/commands/serve.go
+++ b/cmd/commands/serve.go
@@ -35,6 +35,7 @@ func NewCmdServe() *cobra.Command {
 		Run:       serve,
 		Args:      cobra.OnlyValidArgs,
 		ValidArgs: serveArgs,
+		Hidden:    true,
 	}
 
 	cmd.Flags().StringVarP(&serveConf, "config", "c", "", "The config file location (defaults to ./inngest.(cue|json) or /etc/inngest.(cue|json)")

--- a/pkg/event/mgr_legacy.go
+++ b/pkg/event/mgr_legacy.go
@@ -1,0 +1,74 @@
+package event
+
+import "sync"
+
+type Manager struct {
+	events map[string]Event
+	l      *sync.RWMutex
+}
+
+func NewManager() Manager {
+	return Manager{
+		events: make(map[string]Event),
+		l:      &sync.RWMutex{},
+	}
+}
+
+// Fetch an individual event by its ID.
+func (e Manager) EventById(id string) *Event {
+	e.l.RLock()
+	defer e.l.RUnlock()
+
+	evt, ok := e.events[id]
+	if !ok {
+		return nil
+	}
+
+	return &evt
+}
+
+// Fetch all events with a given name.
+func (e Manager) EventsByName(name string) []Event {
+	e.l.RLock()
+	defer e.l.RUnlock()
+
+	events := []Event{}
+
+	for _, evt := range e.events {
+		if evt.Name == name {
+			events = append(events, evt)
+		}
+	}
+
+	return events
+
+}
+
+// Fetch all events.
+func (e Manager) Events() []Event {
+	e.l.RLock()
+	defer e.l.RUnlock()
+
+	events := []Event{}
+
+	for _, evt := range e.events {
+		events = append(events, evt)
+	}
+
+	return events
+}
+
+// Parse and create a new event, adding it to the in-memory map as we go.
+func (e Manager) NewEvent(data string) (*Event, error) {
+	e.l.Lock()
+	defer e.l.Unlock()
+
+	evt, err := NewEvent(data)
+	if err != nil {
+		return nil, err
+	}
+
+	e.events[evt.ID] = *evt
+
+	return evt, err
+}

--- a/pkg/execution/executor/util.go
+++ b/pkg/execution/executor/util.go
@@ -42,7 +42,7 @@ func ParseWait(ctx context.Context, wait string, s state.State, outgoingID strin
 	return 0, fmt.Errorf("Unable to get duration from expression response: %v", out)
 }
 
-func sortOps(opcodes []state.GeneratorOpcode) {
+func sortOps(opcodes []*state.GeneratorOpcode) {
 	sort.SliceStable(opcodes, func(i, j int) bool {
 		// Ensure that we process waitForEvents first, as these are highest priority:
 		// it ensures that wait triggers are saved as soon as possible.

--- a/pkg/execution/executor/util_test.go
+++ b/pkg/execution/executor/util_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/stretchr/testify/require"
@@ -80,4 +81,38 @@ func TestParseWait(t *testing.T) {
 		})
 	}
 
+}
+
+func TestSortOps(t *testing.T) {
+	input := []state.GeneratorOpcode{
+		{
+			Op: enums.OpcodeStep,
+		},
+		{
+			Op: enums.OpcodeStep,
+		},
+		{
+			Op: enums.OpcodeSleep,
+		},
+		{
+			Op: enums.OpcodeWaitForEvent,
+		},
+	}
+	expected := []state.GeneratorOpcode{
+		{
+			Op: enums.OpcodeWaitForEvent,
+		},
+		{
+			Op: enums.OpcodeStep,
+		},
+		{
+			Op: enums.OpcodeStep,
+		},
+		{
+			Op: enums.OpcodeSleep,
+		},
+	}
+
+	sortOps(input)
+	require.Equal(t, expected, input)
 }

--- a/pkg/execution/executor/util_test.go
+++ b/pkg/execution/executor/util_test.go
@@ -84,7 +84,7 @@ func TestParseWait(t *testing.T) {
 }
 
 func TestSortOps(t *testing.T) {
-	input := []state.GeneratorOpcode{
+	input := []*state.GeneratorOpcode{
 		{
 			Op: enums.OpcodeStep,
 		},
@@ -98,7 +98,7 @@ func TestSortOps(t *testing.T) {
 			Op: enums.OpcodeWaitForEvent,
 		},
 	}
-	expected := []state.GeneratorOpcode{
+	expected := []*state.GeneratorOpcode{
 		{
 			Op: enums.OpcodeWaitForEvent,
 		},
@@ -114,5 +114,5 @@ func TestSortOps(t *testing.T) {
 	}
 
 	sortOps(input)
-	require.Equal(t, expected, input)
+	require.EqualValues(t, expected, input)
 }

--- a/tests/main.go
+++ b/tests/main.go
@@ -189,7 +189,6 @@ func run(t *testing.T, test *Test) {
 
 	defer func() {
 		// De-register the app.
-		fmt.Println("REMOVING APP")
 		url := apiURL
 		url.Path = "/fn/remove"
 

--- a/tests/sdk_cancel_via_api_test.go
+++ b/tests/sdk_cancel_via_api_test.go
@@ -102,7 +102,10 @@ func TestCancelFunctionViaAPI(t *testing.T) {
 
 				// Get run ID from event
 				route := fmt.Sprintf("%s/v0/events/%s/runs", apiURL.String(), *test.lastEventID)
-				resp, err := http.Get(route)
+				req, _ := http.NewRequest(http.MethodGet, route, nil)
+				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", eventKey))
+				resp, err := http.DefaultClient.Do(req)
+
 				if err != nil {
 					return err
 				}
@@ -118,7 +121,8 @@ func TestCancelFunctionViaAPI(t *testing.T) {
 				for _, id := range ids {
 					// Cancel run
 					route = fmt.Sprintf("%s/v0/runs/%s", apiURL.String(), id)
-					req, _ := http.NewRequest(http.MethodDelete, route, nil)
+					req, _ = http.NewRequest(http.MethodDelete, route, nil)
+					req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", eventKey))
 					resp, err = http.DefaultClient.Do(req)
 					if err != nil {
 						return fmt.Errorf("error making delete request: %w", err)


### PR DESCRIPTION
This centralizes logic into one place, and allows us to start using the executor interface to manage history directly.

In the future, the state store and queue should be entirely abstracted by the executor.


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
