### PR TITLE
Expose queue items to drivers

### DIFF
--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/gowebpki/jcs"
+	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/inngest"
 )
@@ -16,6 +17,7 @@ type Driver interface {
 	Execute(
 		ctx context.Context,
 		s state.State,
+		item queue.Item,
 		edge inngest.Edge,
 		step inngest.Step,
 		stackIndex int,

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/inngest/inngest/pkg/dateutil"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/driver"
+	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/inngest"
 	"golang.org/x/mod/semver"
@@ -71,8 +72,8 @@ func CheckRedirect(req *http.Request, via []*http.Request) (err error) {
 	return nil
 }
 
-func Execute(ctx context.Context, s state.State, edge inngest.Edge, step inngest.Step, idx, attempt int) (*state.DriverResponse, error) {
-	return DefaultExecutor.Execute(ctx, s, edge, step, idx, attempt)
+func Execute(ctx context.Context, s state.State, item queue.Item, edge inngest.Edge, step inngest.Step, idx, attempt int) (*state.DriverResponse, error) {
+	return DefaultExecutor.Execute(ctx, s, item, edge, step, idx, attempt)
 }
 
 type executor struct {
@@ -147,7 +148,7 @@ func ParseGenerator(ctx context.Context, byt []byte) ([]*state.GeneratorOpcode, 
 	}, nil
 }
 
-func (e executor) Execute(ctx context.Context, s state.State, edge inngest.Edge, step inngest.Step, idx, attempt int) (*state.DriverResponse, error) {
+func (e executor) Execute(ctx context.Context, s state.State, item queue.Item, edge inngest.Edge, step inngest.Step, idx, attempt int) (*state.DriverResponse, error) {
 	uri, err := url.Parse(step.URI)
 	if err != nil || (uri.Scheme != "http" && uri.Scheme != "https") {
 		return nil, fmt.Errorf("Unable to use HTTP executor for non-HTTP runtime")

--- a/pkg/execution/driver/mockdriver/mockdriver.go
+++ b/pkg/execution/driver/mockdriver/mockdriver.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/inngest/inngest/pkg/config/registration"
 	"github.com/inngest/inngest/pkg/execution/driver"
+	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/inngest"
 )
@@ -19,7 +20,7 @@ const RuntimeName = "mock"
 type Mock struct {
 	// DynamicResponses allows users to specify a function which allows
 	// steps to return different data on each execution invocation.
-	DynamicResponses func(context.Context, state.State, inngest.Edge, inngest.Step, int, int) map[string]state.DriverResponse
+	DynamicResponses func(context.Context, state.State, queue.Item, inngest.Edge, inngest.Step, int, int) map[string]state.DriverResponse
 
 	// Responses stores the responses that a driver should return.
 	Responses map[string]state.DriverResponse
@@ -45,7 +46,7 @@ func (m *Mock) RuntimeType() string {
 	return m.RuntimeName
 }
 
-func (m *Mock) Execute(ctx context.Context, s state.State, edge inngest.Edge, step inngest.Step, idx, attempt int) (*state.DriverResponse, error) {
+func (m *Mock) Execute(ctx context.Context, s state.State, item queue.Item, edge inngest.Edge, step inngest.Step, idx, attempt int) (*state.DriverResponse, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -56,7 +57,7 @@ func (m *Mock) Execute(ctx context.Context, s state.State, edge inngest.Edge, st
 
 	resp := m.Responses
 	if m.DynamicResponses != nil {
-		resp = m.DynamicResponses(ctx, s, edge, step, idx, attempt)
+		resp = m.DynamicResponses(ctx, s, item, edge, step, idx, attempt)
 	}
 	response := resp[step.ID]
 	err := m.Errors[step.ID]
@@ -77,7 +78,7 @@ type Config struct {
 	Responses map[string]state.DriverResponse
 	// DynamicResponses allows users to specify a function which allows
 	// steps to return different data on each execution invocation.
-	DynamicResponses func(context.Context, state.State, inngest.Edge, inngest.Step, int, int) map[string]state.DriverResponse
+	DynamicResponses func(context.Context, state.State, queue.Item, inngest.Edge, inngest.Step, int, int) map[string]state.DriverResponse
 	// driver stores the driver once, as a singleton per config instance.
 	driver driver.Driver
 	Driver string

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -518,7 +518,8 @@ func (e *executor) executeDriverForStep(ctx context.Context, id state.Identifier
 	if err := e.sm.Started(ctx, id, step.ID, item.Attempt); err != nil {
 		return nil, fmt.Errorf("error saving started state: %w", err)
 	}
-	response, err := d.Execute(ctx, s, edge, *step, stackIndex, item.Attempt)
+
+	response, err := d.Execute(ctx, s, item, edge, *step, stackIndex, item.Attempt)
 	if response == nil {
 		response = &state.DriverResponse{
 			Step: *step,


### PR DESCRIPTION
## Description

Allows existing async drivers to replicate queue items easily.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
