### PR TITLE
Add job IDs when handling generator responses

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -734,9 +734,13 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 	// consuming the pause to guarantee the event data is stored via the pause
 	// for the next run.  If the ConsumePause call comes after enqueue, the TCP
 	// conn may drop etc. and running the job may occur prior to saving state data.
-	if err := e.queue.Enqueue(
+	//
+	// jobID ensures that we idempotently enqueue the next step.
+	jobID := fmt.Sprintf("%s-%s", pause.Identifier.IdempotencyKey(), pause.DataKey)
+	err = e.queue.Enqueue(
 		ctx,
 		queue.Item{
+			JobID: &jobID,
 			// Add a new group ID for the child;  this will be a new step.
 			GroupID:     uuid.New().String(),
 			WorkspaceID: pause.WorkspaceID,
@@ -747,7 +751,8 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 			},
 		},
 		time.Now(),
-	); err != nil {
+	)
+	if err != nil && err != redis_state.ErrQueueItemExists {
 		return fmt.Errorf("error enqueueing after pause: %w", err)
 	}
 
@@ -837,7 +842,9 @@ func (e *executor) handleGeneratorStep(ctx context.Context, gen state.GeneratorO
 		return err
 	}
 
+	jobID := fmt.Sprintf("%s-%s", item.Identifier.IdempotencyKey(), gen.ID)
 	nextItem := queue.Item{
+		JobID:       &jobID,
 		WorkspaceID: item.WorkspaceID,
 		GroupID:     groupID,
 		Kind:        queue.KindEdge,
@@ -882,7 +889,6 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, gen state.Gen
 	}
 
 	jobID := fmt.Sprintf("%s-%s", item.Identifier.IdempotencyKey(), gen.ID)
-
 	nextItem := queue.Item{
 		JobID:       &jobID,
 		GroupID:     groupID, // Ensure we correlate future jobs with this group ID, eg. started/failed.
@@ -932,7 +938,9 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, gen state.Generator
 
 	until := time.Now().Add(dur)
 
+	jobID := fmt.Sprintf("%s-%s", item.Identifier.IdempotencyKey(), gen.ID)
 	err = e.queue.Enqueue(ctx, queue.Item{
+		JobID:       &jobID,
 		WorkspaceID: item.WorkspaceID,
 		// Sleeps re-enqueue the step so that we can mark the step as completed
 		// in the executor after the sleep is complete.  This will re-call the


### PR DESCRIPTION
This already exists in production and should be carried over to OSS. This ensures that any time we attempt to enqueue a step > 1 time we fail.

## Description

Please edit this to include a summary of the change (what and why).
Include screenshots if you modify the UI.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
