### PR TITLE
Execution lifecycle fixes

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -883,7 +883,7 @@ func (e *executor) handleGeneratorStep(ctx context.Context, gen state.GeneratorO
 		GroupID:     groupID,
 		Kind:        queue.KindEdge,
 		Identifier:  item.Identifier,
-		Attempt:     item.Attempt,
+		Attempt:     0,
 		MaxAttempts: item.MaxAttempts,
 		Payload:     queue.PayloadEdge{Edge: nextEdge},
 	}
@@ -929,7 +929,7 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, gen state.Gen
 		WorkspaceID: item.WorkspaceID,
 		Kind:        queue.KindEdge,
 		Identifier:  item.Identifier,
-		Attempt:     item.Attempt,
+		Attempt:     0,
 		MaxAttempts: item.MaxAttempts,
 		Payload: queue.PayloadEdge{
 			Edge: nextEdge,

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -795,7 +795,7 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 	}
 
 	for _, e := range e.lifecycles {
-		go e.OnWaitForEventResumed(context.WithoutCancel(ctx), pause.Identifier, r)
+		go e.OnWaitForEventResumed(context.WithoutCancel(ctx), pause.Identifier, r, pause.GroupID)
 	}
 
 	return nil
@@ -883,7 +883,7 @@ func (e *executor) handleGeneratorStep(ctx context.Context, gen state.GeneratorO
 		GroupID:     groupID,
 		Kind:        queue.KindEdge,
 		Identifier:  item.Identifier,
-		Attempt:     0,
+		Attempt:     item.Attempt,
 		MaxAttempts: item.MaxAttempts,
 		Payload:     queue.PayloadEdge{Edge: nextEdge},
 	}
@@ -929,7 +929,7 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, gen state.Gen
 		WorkspaceID: item.WorkspaceID,
 		Kind:        queue.KindEdge,
 		Identifier:  item.Identifier,
-		Attempt:     0,
+		Attempt:     item.Attempt,
 		MaxAttempts: item.MaxAttempts,
 		Payload: queue.PayloadEdge{
 			Edge: nextEdge,
@@ -982,7 +982,7 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, gen state.Generator
 		GroupID:     groupID,
 		Kind:        queue.KindSleep,
 		Identifier:  item.Identifier,
-		Attempt:     0,
+		Attempt:     item.Attempt,
 		MaxAttempts: item.MaxAttempts,
 		Payload:     queue.PayloadEdge{Edge: nextEdge},
 	}, until)

--- a/pkg/execution/history/history.go
+++ b/pkg/execution/history/history.go
@@ -72,7 +72,8 @@ type Result struct {
 	ErrorCode   *string             `json:"error_code"`
 	Framework   *string             `json:"framework"`
 	Headers     map[string][]string `json:"response_headers"`
-	Output      any                 `json:"output"`
+	Output      string              `json:"output"`
+	RawOutput   any                 `json:"raw_output"`
 	Platform    *string             `json:"platform"`
 	SDKLanguage string              `json:"sdk_language"`
 	SDKVersion  string              `json:"sdk_version"`

--- a/pkg/execution/lifecycle.go
+++ b/pkg/execution/lifecycle.go
@@ -99,6 +99,7 @@ type LifecycleListener interface {
 		context.Context,
 		state.Identifier,
 		ResumeRequest,
+		string,
 	)
 
 	// OnSleep is called when a sleep step is scheduled.  The
@@ -211,6 +212,7 @@ func (NoopLifecyceListener) OnWaitForEventResumed(
 	context.Context,
 	state.Identifier,
 	ResumeRequest,
+	string,
 ) {
 }
 


### PR DESCRIPTION
## Description

Fix a few executor lifecycle issues that were found during history work.

- Replace hard-coded `Attempt: 0` with the actual attempt number.
- Set missing group IDs.
- Extract completed step info from the response output (`applyResponse` function).

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
