### PR TITLE
Show how to disable autoscanning/discovery on boot

### DIFF
--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -128,6 +128,11 @@ func (d *devserver) Run(ctx context.Context) error {
 				fmt.Println("")
 			}
 			fmt.Println("")
+			if d.opts.Autodiscover {
+				fmt.Printf("\tScanning for available serve handlers.\n")
+				fmt.Printf("\tTo disable scanning run `inngest dev` with flags: --no-discovery -u <your-serve-url>")
+				fmt.Println("")
+			}
 			fmt.Println("")
 		}()
 	}


### PR DESCRIPTION
Output now shows:

```
        Inngest dev server online at 0.0.0.0:8288, visible at the following URLs:

         - http://127.0.0.1:8288 (http://localhost:8288)

        Scanning for available serve handlers.
        To disable scanning run `inngest dev` with flags: --no-discovery -u <your-serve-url>
```

## Type of change (choose one)

- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
