### PR TITLE
Add logging to redis_state.Enqueue

### DIFF
--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -590,6 +590,7 @@ func (q *queue) EnqueueItem(ctx context.Context, i QueueItem, at time.Time) (Que
 	case 0:
 		return i, nil
 	case 1:
+		q.logger.Warn().Interface("item", i).Msg("skipping duplicate queue item")
 		return i, ErrQueueItemExists
 	default:
 		return i, fmt.Errorf("unknown response enqueueing item: %d", status)


### PR DESCRIPTION
This adds logging any time a duplicate queue item is ignored via idempotency.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
