### PR TITLE
Ignore partition not found errors

### DIFF
--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -382,6 +382,11 @@ func (q *queue) scan(ctx context.Context) error {
 			return nil
 		}
 		if err := q.processPartition(ctx, p); err != nil {
+			if err == ErrPartitionNotFound {
+				// Another worker grabbed the partition
+				// TODO: Increase counter
+				continue
+			}
 			if errors.Unwrap(err) != context.Canceled {
 				q.logger.Error().Err(err).Msg("error processing partition")
 			}


### PR DESCRIPTION
In HA environments there can still be contention on queues due to randomness.  We should ignore these errors as they're expected.


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
