### PR TITLE
Add debounce support

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,4 @@
-name: E2E
+name: SDK E2E Tests
 
 on:
   push:
@@ -6,8 +6,8 @@ on:
   pull_request:
 
 jobs:
-  install:
-    name: E2E tests
+  ts:
+    name: TS SDK Tests
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -44,3 +44,29 @@ jobs:
           INNGEST_SIGNING_KEY: test
           API_URL: http://127.0.0.1:8288
           SDK_URL: http://127.0.0.1:3000/api/inngest
+  golang:
+    name: Go SDK Tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.21"
+      - name: Build dev server
+        run: |
+          go build -o ./inngest-bin ./cmd/main.go
+      - name: Run E2E tests
+        run: |
+          echo "Running dev server"
+          nohup ./inngest-bin dev --no-discovery 2> /tmp/dev-output.txt &
+          echo "Ran dev server"
+          sleep 5
+          curl http://127.0.0.1:8288/dev > /dev/null 2> /dev/null
+          go test ./tests/golang -v -count=1
+        env:
+          INNGEST_SIGNING_KEY: 7468697320697320612074657374206b6579
+          INNGEST_DEV: http://127.0.0.1:8288

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/gowebpki/jcs v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform v0.15.3
-	github.com/inngest/inngestgo v0.4.3-0.20230825203709-1ffd28d9be92
+	github.com/inngest/inngestgo v0.4.3-0.20230910152617-8ea2ceffe372
 	github.com/jedib0t/go-pretty/v6 v6.3.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/karlseguin/ccache/v2 v2.0.8

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/gowebpki/jcs v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform v0.15.3
-	github.com/inngest/inngestgo v0.4.3-0.20230910154532-ce37ea3a6eff
+	github.com/inngest/inngestgo v0.4.3-0.20231005011526-45faf732bb25
 	github.com/jedib0t/go-pretty/v6 v6.3.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/karlseguin/ccache/v2 v2.0.8

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/gowebpki/jcs v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform v0.15.3
-	github.com/inngest/inngestgo v0.4.3-0.20231005011526-45faf732bb25
+	github.com/inngest/inngestgo v0.4.3-0.20231005031934-9a8046ff59f9
 	github.com/jedib0t/go-pretty/v6 v6.3.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/karlseguin/ccache/v2 v2.0.8

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/gowebpki/jcs v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform v0.15.3
-	github.com/inngest/inngestgo v0.4.3-0.20230910152617-8ea2ceffe372
+	github.com/inngest/inngestgo v0.4.3-0.20230910154532-ce37ea3a6eff
 	github.com/jedib0t/go-pretty/v6 v6.3.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/karlseguin/ccache/v2 v2.0.8

--- a/go.sum
+++ b/go.sum
@@ -604,8 +604,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/inngest/inngestgo v0.4.3-0.20231005011526-45faf732bb25 h1:xuc1qLWAkpPa2SRGzIlnkHmx47togp8YINwqxlTyJF4=
-github.com/inngest/inngestgo v0.4.3-0.20231005011526-45faf732bb25/go.mod h1:pQ4FXRoIcpbWrCzWS88NXzgZtKK20sEs+T29xyYUmxE=
+github.com/inngest/inngestgo v0.4.3-0.20231005031934-9a8046ff59f9 h1:d/b+lALBLm4c3sFpdoLJe7Rv2ZZqEmzo29O8tvKXZic=
+github.com/inngest/inngestgo v0.4.3-0.20231005031934-9a8046ff59f9/go.mod h1:pQ4FXRoIcpbWrCzWS88NXzgZtKK20sEs+T29xyYUmxE=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/go.sum
+++ b/go.sum
@@ -604,8 +604,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/inngest/inngestgo v0.4.3-0.20230910154532-ce37ea3a6eff h1:MvoDenbSGGIo06dpugYU7Fwx49rGBJjxlVVd+O8CkvQ=
-github.com/inngest/inngestgo v0.4.3-0.20230910154532-ce37ea3a6eff/go.mod h1:pQ4FXRoIcpbWrCzWS88NXzgZtKK20sEs+T29xyYUmxE=
+github.com/inngest/inngestgo v0.4.3-0.20231005011526-45faf732bb25 h1:xuc1qLWAkpPa2SRGzIlnkHmx47togp8YINwqxlTyJF4=
+github.com/inngest/inngestgo v0.4.3-0.20231005011526-45faf732bb25/go.mod h1:pQ4FXRoIcpbWrCzWS88NXzgZtKK20sEs+T29xyYUmxE=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/go.sum
+++ b/go.sum
@@ -604,8 +604,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/inngest/inngestgo v0.4.3-0.20230825203709-1ffd28d9be92 h1:CWm1dzDsNyoIcZoGW5lY7ILBU/Fbt9je2MZni8k81d8=
-github.com/inngest/inngestgo v0.4.3-0.20230825203709-1ffd28d9be92/go.mod h1:pQ4FXRoIcpbWrCzWS88NXzgZtKK20sEs+T29xyYUmxE=
+github.com/inngest/inngestgo v0.4.3-0.20230910152617-8ea2ceffe372 h1:OeoE717qwJWrG2Ungq3Kt0DZTdeKxDNtZPcp5ys3MTs=
+github.com/inngest/inngestgo v0.4.3-0.20230910152617-8ea2ceffe372/go.mod h1:pQ4FXRoIcpbWrCzWS88NXzgZtKK20sEs+T29xyYUmxE=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/go.sum
+++ b/go.sum
@@ -604,8 +604,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/inngest/inngestgo v0.4.3-0.20230910152617-8ea2ceffe372 h1:OeoE717qwJWrG2Ungq3Kt0DZTdeKxDNtZPcp5ys3MTs=
-github.com/inngest/inngestgo v0.4.3-0.20230910152617-8ea2ceffe372/go.mod h1:pQ4FXRoIcpbWrCzWS88NXzgZtKK20sEs+T29xyYUmxE=
+github.com/inngest/inngestgo v0.4.3-0.20230910154532-ce37ea3a6eff h1:MvoDenbSGGIo06dpugYU7Fwx49rGBJjxlVVd+O8CkvQ=
+github.com/inngest/inngestgo v0.4.3-0.20230910154532-ce37ea3a6eff/go.mod h1:pQ4FXRoIcpbWrCzWS88NXzgZtKK20sEs+T29xyYUmxE=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -38,6 +38,10 @@ const (
 	// MinRetryDuration is the soonest a retry can be scheduled.
 	MinRetryDuration = time.Second * 1
 
+	// MaxDebouncePeriod is the maximum period of time that can be used to configure a debounce.  This
+	// lets users delay functions for up to MaxDebouncePeriod when events are received.
+	MaxDebouncePeriod = time.Hour * 24 * 7
+
 	// MaxCancellations represents the max automatic cancellation signals per function
 	MaxCancellations = 5
 

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -38,6 +38,9 @@ const (
 	// MinRetryDuration is the soonest a retry can be scheduled.
 	MinRetryDuration = time.Second * 1
 
+	// MinDebouncePeriod is the minimum period of time that can be used to configure a debounce.
+	MinDebouncePeriod = time.Second
+
 	// MaxDebouncePeriod is the maximum period of time that can be used to configure a debounce.  This
 	// lets users delay functions for up to MaxDebouncePeriod when events are received.
 	MaxDebouncePeriod = time.Hour * 24 * 7

--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -1,0 +1,326 @@
+package debounce
+
+import (
+	"context"
+	"crypto/rand"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/execution/state/redis_state"
+	"github.com/inngest/inngest/pkg/expressions"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/oklog/ulid/v2"
+	"github.com/redis/rueidis"
+	"github.com/xhit/go-str2duration/v2"
+)
+
+//go:embed lua/*
+var embedded embed.FS
+
+var (
+	ErrDebounceExists   = fmt.Errorf("a debounce exists for this function")
+	ErrDebounceNotFound = fmt.Errorf("debounce not found")
+)
+
+var (
+	buffer = 2 * time.Second
+	// scripts stores all embedded lua scripts on initialization
+	scripts = map[string]*rueidis.Lua{}
+	include = regexp.MustCompile(`-- \$include\(([\w.]+)\)`)
+)
+
+func init() {
+	// read the lua scripts
+	entries, err := embedded.ReadDir("lua")
+	if err != nil {
+		panic(fmt.Errorf("error reading redis lua dir: %w", err))
+	}
+	readRedisScripts("lua", entries)
+}
+
+// The general strategy for debounce:
+//
+// 1. Create a new debounce key.
+// 2. Store the current event in the debounce key.
+// 3. Create a new queue item for the debounce, linking to the debounce key
+
+// DebounceItem represents a debounce stored within the debounce manager.
+//
+// DebounceItem fulfils event.TrackedEvent, allowing the use of the entire DebounceItem
+// as the triggering event data passed to executor.Schedule.
+type DebounceItem struct {
+	// AccountID represents the account for the debounce item
+	AccountID uuid.UUID `json:"aID"`
+	// WorkspaceID represents the account for the debounce item
+	WorkspaceID uuid.UUID `json:"wsID"`
+	// FunctionID represents the function ID that this debounce is for.
+	FunctionID uuid.UUID `json:"fnID"`
+	// EventID represents the internal event ID that triggers the function.
+	EventID ulid.ULID `json:"eID"`
+	// Event represents the event data which triggers the function.
+	Event event.Event `json:"e"`
+}
+
+func (d DebounceItem) QueuePayload() DebouncePayload {
+	return DebouncePayload{
+		AccountID:   d.AccountID,
+		WorkspaceID: d.WorkspaceID,
+		FunctionID:  d.FunctionID,
+	}
+}
+
+func (d DebounceItem) GetInternalID() ulid.ULID {
+	return d.EventID
+}
+
+func (d DebounceItem) GetEvent() event.Event {
+	return d.Event
+}
+
+// DebouncePayload represents the data stored within the queue's payload.
+type DebouncePayload struct {
+	DebounceID ulid.ULID `json:"debounceID"`
+	// AccountID represents the account for the debounce item
+	AccountID uuid.UUID `json:"aID"`
+	// WorkspaceID represents the account for the debounce item
+	WorkspaceID uuid.UUID `json:"wsID"`
+	// FunctionID represents the function ID that this debounce is for.
+	FunctionID uuid.UUID `json:"fnID"`
+}
+
+type Debouncer interface {
+	Debounce(ctx context.Context, d DebounceItem, fn inngest.Function) error
+	GetDebounceItem(ctx context.Context, debounceID ulid.ULID) (*DebounceItem, error)
+}
+
+func NewRedisDebouncer(r rueidis.Client, k redis_state.DebounceKeyGenerator, q redis_state.QueueManager) Debouncer {
+	return debouncer{
+		r: r,
+		k: k,
+		q: q,
+	}
+}
+
+type debouncer struct {
+	r rueidis.Client
+	k redis_state.DebounceKeyGenerator
+	q redis_state.QueueManager
+}
+
+func (d debouncer) GetDebounceItem(ctx context.Context, debounceID ulid.ULID) (*DebounceItem, error) {
+	keyDbc := d.k.Debounce(ctx)
+
+	cmd := d.r.B().Hget().Key(keyDbc).Field(debounceID.String()).Build()
+	byt, err := d.r.Do(ctx, cmd).AsBytes()
+	if rueidis.IsRedisNil(err) {
+		return nil, ErrDebounceNotFound
+	}
+
+	di := &DebounceItem{}
+	if err := json.Unmarshal(byt, &di); err != nil {
+		return nil, fmt.Errorf("error unmarshalling debounce item: %w", err)
+	}
+	return di, nil
+}
+
+func (d debouncer) Debounce(ctx context.Context, di DebounceItem, fn inngest.Function) error {
+	if fn.Debounce == nil {
+		return fmt.Errorf("fn has no debounce config")
+	}
+	ttl, err := str2duration.ParseDuration(fn.Debounce.Period)
+	if err != nil {
+		return fmt.Errorf("invalid debounce duration: %w", err)
+	}
+	return d.debounce(ctx, di, fn, ttl, 0)
+}
+
+func (d debouncer) debounce(ctx context.Context, di DebounceItem, fn inngest.Function, ttl time.Duration, n int) error {
+	// Call new debounce immediately.  If this returns ErrDebounceExists then
+	// update the debounce.  This ensures that checking and creating a debounce
+	// is atomic, and two individual threads/workers cannot create debounces simultaneously.
+	debounceID, err := d.newDebounce(ctx, di, fn, ttl)
+	if err == nil {
+		return nil
+	}
+	if err != ErrDebounceExists {
+		// There was an unkown error creating the debounce.
+		return err
+	}
+	if debounceID == nil {
+		return fmt.Errorf("expected debounce ID when debounce exists")
+	}
+
+	// A debounce must already exist for this fn.  Update it.
+	err = d.updateDebounce(ctx, di, fn, ttl, *debounceID)
+	if err == context.DeadlineExceeded {
+		if n == 4 {
+			// Only recurse 5 times.
+			return fmt.Errorf("unable to update debounce: %w", err)
+		}
+		// Re-invoke this to see if we need to extend the debounce or continue.
+		return d.debounce(ctx, di, fn, ttl, n+1)
+	}
+
+	return err
+}
+
+func (d debouncer) queueItem(ctx context.Context, di DebounceItem, debounceID ulid.ULID) queue.Item {
+	jobID := debounceID.String()
+	payload := di.QueuePayload()
+	payload.DebounceID = debounceID
+	return queue.Item{
+		JobID:       &jobID,
+		WorkspaceID: di.WorkspaceID,
+		Identifier: state.Identifier{
+			AccountID:   di.AccountID,
+			WorkspaceID: di.WorkspaceID,
+			WorkflowID:  di.FunctionID,
+		},
+		Kind:    queue.KindDebounce,
+		Payload: payload,
+	}
+}
+
+func (d debouncer) newDebounce(ctx context.Context, di DebounceItem, fn inngest.Function, ttl time.Duration) (*ulid.ULID, error) {
+	now := time.Now()
+	debounceID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	keyPtr := d.k.DebouncePointer(ctx, fn.ID)
+	keyDbc := d.k.Debounce(ctx)
+
+	byt, err := json.Marshal(di)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling debounce: %w", err)
+	}
+
+	out, err := scripts["newDebounce"].Exec(
+		ctx,
+		d.r,
+		[]string{keyPtr, keyDbc},
+		[]string{debounceID.String(), string(byt), strconv.Itoa(int(ttl.Seconds()))},
+	).ToString()
+	if err != nil {
+		return nil, fmt.Errorf("error creating debounce: %w", err)
+	}
+
+	if out == "0" {
+		// Enqueue the debounce job with extra buffer *plus* one second.  This ensures that we never
+		// attempt to start a debounce during the debounce's expiry (race conditions), and the extra
+		// second lets an updateDebounce call on TTL 0 finish, as the buffer is the updateDebounce
+		// deadline.
+		qi := d.queueItem(ctx, di, debounceID)
+		err = d.q.Enqueue(ctx, qi, now.Add(ttl).Add(buffer).Add(time.Second))
+		if err != nil {
+			return &debounceID, fmt.Errorf("error enqueueing debounce job: %w", err)
+		}
+		return &debounceID, nil
+	}
+
+	existingID, err := ulid.Parse(out)
+	if err != nil {
+		// This was not a ULID, so we have no idea what was returned.
+		return nil, fmt.Errorf("unknown new debounce return value: %s", out)
+	}
+	return &existingID, ErrDebounceExists
+}
+
+// updateDebounce updates the currently pending debounce to point to the new event ID.  It pushes
+// out the debounce's TTL, and re-enqueues the job to initialize fns from the debounce.
+func (d debouncer) updateDebounce(ctx context.Context, di DebounceItem, fn inngest.Function, ttl time.Duration, debounceID ulid.ULID) error {
+	now := time.Now()
+
+	// NOTE: This functioon has a deadline to complete.  If this fn doesn't complete within the deadline,
+	// eg, network issues, we must check if the debounce expired and re-attempt the entire thing.
+	ctx, cancel := context.WithTimeout(ctx, buffer)
+	defer cancel()
+
+	keyPtr := d.k.DebouncePointer(ctx, fn.ID)
+	keyDbc := d.k.Debounce(ctx)
+	byt, err := json.Marshal(di)
+	if err != nil {
+		return fmt.Errorf("error marshalling debounce: %w", err)
+	}
+
+	out, err := scripts["updateDebounce"].Exec(
+		ctx,
+		d.r,
+		[]string{keyPtr, keyDbc},
+		[]string{debounceID.String(), string(byt), strconv.Itoa(int(ttl.Seconds()))},
+	).AsInt64()
+	if err != nil {
+		return fmt.Errorf("error creating debounce: %w", err)
+	}
+	switch out {
+	case 0:
+		err = d.q.RequeueByJobID(
+			ctx,
+			fn.ID.String(),
+			debounceID.String(),
+			now.Add(ttl).Add(buffer).Add(time.Second),
+		)
+		if err != nil {
+			return fmt.Errorf("error requeueing debounce job '%s': %w", debounceID, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown update debounce return value: %d", out)
+	}
+}
+
+func (d debouncer) debounceKey(ctx context.Context, evt event.TrackedEvent, fn inngest.Function) (string, error) {
+	out, _, err := expressions.Evaluate(ctx, fn.Debounce.Key, map[string]any{"event": evt.GetEvent().Map()})
+	if err != nil {
+		return "", fmt.Errorf("invalid debounce expression: %w", err)
+	}
+	if str, ok := out.(string); ok {
+		return str, nil
+	}
+	return fmt.Sprintf("%v", out), nil
+}
+
+func readRedisScripts(path string, entries []fs.DirEntry) {
+	for _, e := range entries {
+		// NOTE: When using embed go always uses forward slashes as a path
+		// prefix. filepath.Join uses OS-specific prefixes which fails on
+		// windows, so we construct the path using Sprintf for all platforms
+		if e.IsDir() {
+			entries, _ := embedded.ReadDir(fmt.Sprintf("%s/%s", path, e.Name()))
+			readRedisScripts(path+"/"+e.Name(), entries)
+			continue
+		}
+
+		byt, err := embedded.ReadFile(fmt.Sprintf("%s/%s", path, e.Name()))
+		if err != nil {
+			panic(fmt.Errorf("error reading redis lua script: %w", err))
+		}
+
+		name := path + "/" + e.Name()
+		name = strings.TrimPrefix(name, "lua/")
+		name = strings.TrimSuffix(name, ".lua")
+		val := string(byt)
+
+		// Add any includes.
+		items := include.FindAllStringSubmatch(val, -1)
+		if len(items) > 0 {
+			// Replace each include
+			for _, include := range items {
+				byt, err = embedded.ReadFile(fmt.Sprintf("lua/includes/%s", include[1]))
+				if err != nil {
+					panic(fmt.Errorf("error reading redis lua include: %w", err))
+				}
+				val = strings.ReplaceAll(val, include[0], string(byt))
+			}
+		}
+		scripts[name] = rueidis.NewLuaScript(val)
+	}
+}

--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -75,9 +75,10 @@ type DebounceItem struct {
 
 func (d DebounceItem) QueuePayload() DebouncePayload {
 	return DebouncePayload{
-		AccountID:   d.AccountID,
-		WorkspaceID: d.WorkspaceID,
-		FunctionID:  d.FunctionID,
+		AccountID:       d.AccountID,
+		WorkspaceID:     d.WorkspaceID,
+		FunctionID:      d.FunctionID,
+		FunctionVersion: d.FunctionVersion,
 	}
 }
 

--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -65,6 +65,8 @@ type DebounceItem struct {
 	WorkspaceID uuid.UUID `json:"wsID"`
 	// FunctionID represents the function ID that this debounce is for.
 	FunctionID uuid.UUID `json:"fnID"`
+	// FunctionVersion represents the version of the function that was debounced.
+	FunctionVersion int `json:"fnV"`
 	// EventID represents the internal event ID that triggers the function.
 	EventID ulid.ULID `json:"eID"`
 	// Event represents the event data which triggers the function.
@@ -96,6 +98,8 @@ type DebouncePayload struct {
 	WorkspaceID uuid.UUID `json:"wsID"`
 	// FunctionID represents the function ID that this debounce is for.
 	FunctionID uuid.UUID `json:"fnID"`
+	// FunctionVersion represents the version of the function that was debounced.
+	FunctionVersion int `json:"fnV"`
 }
 
 // Debouncer represents an implementation-agnostic function debouncer, delaying function runs

--- a/pkg/execution/debounce/lua/newDebounce.lua
+++ b/pkg/execution/debounce/lua/newDebounce.lua
@@ -1,0 +1,32 @@
+--[[
+
+Creates a new debounce for the given function, or returns -1 if a
+debounce currently exists.
+
+Return values:
+- "0" (string): Success
+- "$ID": The existing debounce ID
+
+]]--
+
+local keyPtr = KEYS[1] -- fn -> debounce ptr
+local keyDbc = KEYS[2] -- debounce info key
+
+local debounceID = ARGV[1] 
+local debounce   = ARGV[2]
+local ttl        = tonumber(ARGV[3])
+
+local existing = redis.call("GET", keyPtr)
+if existing ~= nil and existing ~= false then
+	-- A debounce for this function exists.
+	return existing
+end
+
+-- Set the fn -> debounce ID pointer
+redis.call("SETEX", keyPtr, ttl, debounceID)
+-- Set debounce info
+redis.call("HSET", keyDbc, debounceID, debounce)
+
+-- TODO: Ideally, enqueue would be atomic here.  We should make enqueue a function.
+
+return "0"

--- a/pkg/execution/debounce/lua/updateDebounce.lua
+++ b/pkg/execution/debounce/lua/updateDebounce.lua
@@ -1,0 +1,21 @@
+--[[
+
+Updates a debounce to use new data.
+
+Return values:
+- 0 (int): OK
+
+]]--
+
+local keyPtr = KEYS[1] -- fn -> debounce ptr
+local keyDbc = KEYS[2] -- debounce info key
+
+local debounceID = ARGV[1] 
+local debounce   = ARGV[2]
+local ttl        = tonumber(ARGV[3])
+
+-- Set the fn -> debounce ID pointer
+redis.call("SETEX", keyPtr, ttl, debounceID)
+redis.call("HSET", keyDbc, debounceID, debounce)
+
+return 0

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -136,6 +136,10 @@ type ScheduleRequest struct {
 	IdempotencyKey *string
 	// Context represents additional context used when initialiizing function runs.
 	Context map[string]any
+	// PreventDebounce prevents debouncing this function and immediately schedules
+	// execution.  This is used after the debounce has finished to force execution
+	// of the function, instead of debouncing again.
+	PreventDebounce bool
 }
 
 // CancelRequest stores information about the incoming cancellation request within

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -207,7 +207,6 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		if err != nil {
 			return nil, err
 		}
-		e.log.Info().Interface("event", req.Events[0].GetEvent()).Msg("debouncing function")
 		return nil, ErrFunctionDebounced
 	}
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -198,11 +198,12 @@ func (e *executor) AddLifecycleListener(l execution.LifecycleListener) {
 func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) (*state.Identifier, error) {
 	if req.Function.Debounce != nil && !req.PreventDebounce {
 		err := e.debouncer.Debounce(ctx, debounce.DebounceItem{
-			AccountID:   req.AccountID,
-			WorkspaceID: req.WorkspaceID,
-			FunctionID:  req.Function.ID,
-			EventID:     req.Events[0].GetInternalID(),
-			Event:       req.Events[0].GetEvent(),
+			AccountID:       req.AccountID,
+			WorkspaceID:     req.WorkspaceID,
+			FunctionID:      req.Function.ID,
+			FunctionVersion: req.Function.FunctionVersion,
+			EventID:         req.Events[0].GetInternalID(),
+			Event:           req.Events[0].GetEvent(),
 		}, req.Function)
 		if err != nil {
 			return nil, err

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/execution"
+	"github.com/inngest/inngest/pkg/execution/debounce"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/inngest"
@@ -54,6 +55,12 @@ func WithServiceQueue(q queue.Queue) func(s *svc) {
 	}
 }
 
+func WithServiceDebouncer(d debounce.Debouncer) func(s *svc) {
+	return func(s *svc) {
+		s.debouncer = d
+	}
+}
+
 func NewService(c config.Config, opts ...Opt) service.Service {
 	svc := &svc{config: c}
 	for _, o := range opts {
@@ -71,7 +78,8 @@ type svc struct {
 	// queue allows us to enqueue next steps.
 	queue queue.Queue
 	// exec runs the specific actions.
-	exec execution.Executor
+	exec      execution.Executor
+	debouncer debounce.Debouncer
 
 	wg sync.WaitGroup
 
@@ -163,6 +171,34 @@ func (s *svc) Run(ctx context.Context) error {
 			err = s.handleQueueItem(ctx, item)
 		case queue.KindPause:
 			err = s.handlePauseTimeout(ctx, item)
+		case queue.KindDebounce:
+			d := debounce.DebouncePayload{}
+			if err := json.Unmarshal(item.Payload.(json.RawMessage), &d); err != nil {
+				return fmt.Errorf("error unmarshalling debounce payload: %w", err)
+			}
+
+			all, err := s.data.Functions(ctx)
+			if err != nil {
+				return err
+			}
+
+			for _, f := range all {
+				if f.ID == d.FunctionID {
+					di, err := s.debouncer.GetDebounceItem(ctx, d.DebounceID)
+					if err != nil {
+						return err
+					}
+					_, err = s.exec.Schedule(ctx, execution.ScheduleRequest{
+						Function:        f,
+						AccountID:       di.AccountID,
+						WorkspaceID:     di.WorkspaceID,
+						Events:          []event.TrackedEvent{di},
+						PreventDebounce: true,
+					})
+					return err
+				}
+			}
+
 		default:
 			err = fmt.Errorf("unknown payload type: %T", item.Payload)
 		}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -195,7 +195,10 @@ func (s *svc) Run(ctx context.Context) error {
 						Events:          []event.TrackedEvent{di},
 						PreventDebounce: true,
 					})
-					return err
+					if err != nil {
+						return err
+					}
+					_ = s.debouncer.DeleteDebounceItem(ctx, d.DebounceID)
 				}
 			}
 

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	KindEdge  = "edge"
-	KindSleep = "sleep"
-	KindPause = "pause"
+	KindEdge     = "edge"
+	KindSleep    = "sleep"
+	KindPause    = "pause"
+	KindDebounce = "debounce"
 )
 
 type jobIDValType struct{}

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -177,7 +177,7 @@ type QueueKeyGenerator interface {
 type DebounceKeyGenerator interface {
 	// DebouncePointer returns the key which stores the pointer to the current debounce
 	// for a given function.
-	DebouncePointer(ctx context.Context, fnID uuid.UUID) string
+	DebouncePointer(ctx context.Context, fnID uuid.UUID, key string) string
 	// Debounce returns the key for storing debounce-related data given a debounce ID.
 	Debounce(ctx context.Context) string
 }
@@ -244,8 +244,8 @@ func (d DefaultQueueKeyGenerator) BatchMetadata(ctx context.Context, batchID uli
 
 // DebouncePointer returns the key which stores the pointer to the current debounce
 // for a given function.
-func (d DefaultQueueKeyGenerator) DebouncePointer(ctx context.Context, fnID uuid.UUID) string {
-	return fmt.Sprintf("%s:debounce-ptrs:%s", d.Prefix, fnID)
+func (d DefaultQueueKeyGenerator) DebouncePointer(ctx context.Context, fnID uuid.UUID, key string) string {
+	return fmt.Sprintf("%s:debounce-ptrs:%s:%s", d.Prefix, fnID, key)
 }
 
 // Debounce returns the key for storing debounce-related data given a debounce ID.

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -174,6 +174,14 @@ type QueueKeyGenerator interface {
 	BatchMetadata(context.Context, ulid.ULID) string
 }
 
+type DebounceKeyGenerator interface {
+	// DebouncePointer returns the key which stores the pointer to the current debounce
+	// for a given function.
+	DebouncePointer(ctx context.Context, fnID uuid.UUID) string
+	// Debounce returns the key for storing debounce-related data given a debounce ID.
+	Debounce(ctx context.Context) string
+}
+
 type DefaultQueueKeyGenerator struct {
 	Prefix string
 }
@@ -232,4 +240,16 @@ func (d DefaultQueueKeyGenerator) Batch(ctx context.Context, batchID ulid.ULID) 
 
 func (d DefaultQueueKeyGenerator) BatchMetadata(ctx context.Context, batchID ulid.ULID) string {
 	return fmt.Sprintf("%s:metadata", d.Batch(ctx, batchID))
+}
+
+// DebouncePointer returns the key which stores the pointer to the current debounce
+// for a given function.
+func (d DefaultQueueKeyGenerator) DebouncePointer(ctx context.Context, fnID uuid.UUID) string {
+	return fmt.Sprintf("%s:debounce-ptrs:%s", d.Prefix, fnID)
+}
+
+// Debounce returns the key for storing debounce-related data given a debounce ID.
+// This is a hash of debounce IDs -> debounces.
+func (d DefaultQueueKeyGenerator) Debounce(ctx context.Context) string {
+	return fmt.Sprintf("%s:debounce-hash", d.Prefix)
 }

--- a/pkg/execution/state/redis_state/lua/queue/enqueue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/enqueue.lua
@@ -14,7 +14,7 @@ local idempotencyKey      = KEYS[6]   -- seen:$key
 
 local queueItem      = ARGV[1] -- {id, lease id, attempt, max attempt, data, etc...}
 local queueID        = ARGV[2] -- id
-local queueScore     = tonumber(ARGV[3]) -- vesting time, in seconds
+local queueScore     = tonumber(ARGV[3]) -- vesting time, in milliseconds
 local workflowID     = ARGV[4] -- $workflowID
 local partitionItem  = ARGV[5] -- {workflow, priority, leasedAt, etc}
 

--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -98,7 +98,7 @@ if concurrencyScores ~= false then
 	redis.call("ZADD", concurrencyPointer, earliestLease, partitionName)
 end
 
--- Remove the item from our sorted index, as this is now on the queue.
+-- Remove the item from our sorted index, as this is no longer on the queue.
 redis.call("ZREM", queueIndexKey, item.id)
 
 return 0

--- a/pkg/execution/state/redis_state/lua/queue/requeueByID.lua
+++ b/pkg/execution/state/redis_state/lua/queue/requeueByID.lua
@@ -1,0 +1,67 @@
+--[[
+
+Requeues a job by its given ID.  This returns an error if the job
+does not exist within the queue index (outstanding queue).
+
+NOTE: This
+
+Return values:
+
+- 0:  Successfully requeued
+- -1: Queue item not found
+
+]]--
+
+local keyQueueIndex     = KEYS[1]
+local keyQueueHash      = KEYS[2]
+local keyPartitionIndex = KEYS[3] -- partition:sorted - zset
+local keyPartitionHash  = KEYS[4]
+
+local jobID       = ARGV[1] -- queue item ID
+local jobScore    = tonumber(ARGV[2]) -- enqueue at, in milliseconds
+local partitionID = ARGV[3] -- function ID
+
+if redis.call("ZSCORE", keyQueueIndex, jobID) == false then
+	-- This doesn't exist.
+	return -1
+end
+
+-- $include(get_queue_item.lua)
+local item = get_queue_item(keyQueueHash, jobID)
+if item == nil then
+	return -1
+end
+
+-- $include(get_partition_item.lua)
+local existing = get_partition_item(keyPartitionHash, partitionID)
+if existing == nil then
+	return -1
+end
+
+redis.call("ZADD", keyQueueIndex, jobScore, jobID)
+
+-- Update the "at" time of the job
+item.at = jobScore
+redis.call("HSET", keyQueueHash, jobID, cjson.encode(item))
+
+
+-- Get the current score of the partition;  if queueScore < currentScore update the
+-- partition's score so that we can work on this workflow when the earliest member
+-- is available.
+-- 
+-- We might have just pushed back the earliest job, so the partitions pointer
+-- could have an earlier score than necessary.  In order to fix this, we want to scan
+-- and take the minimum time from the keyQueueIndex and use this as the score
+local minScore = redis.call("ZRANGEBYSCORE", keyQueueIndex, "-inf", "+inf", "WITHSCORES", "LIMIT", "0", "1")
+local partitionScore = math.floor(minScore[2] / 1000)
+
+local currentScore = redis.call("ZSCORE", keyPartitionIndex, partitionID)
+if currentScore == false or tonumber(currentScore) ~= partitionScore then
+	redis.call("ZADD", keyPartitionIndex, partitionScore, partitionID)
+end
+
+-- Update the partition pointer's actual AtS timestamp in the struct.
+existing.at = partitionScore
+redis.call("HSET", keyPartitionHash, partitionID, cjson.encode(existing))
+
+return 0

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -425,8 +425,6 @@ type QueueItem struct {
 	// the idempotency key immediately;  the same debounce key should become available
 	// for another debounced function run.
 	IdempotencyPeriod *time.Duration `json:"ip,omitempty"`
-
-	hashedID bool
 }
 
 func (q *QueueItem) SetID(ctx context.Context, str string) {

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -1303,7 +1303,7 @@ func TestRequeueByJobID(t *testing.T) {
 				WorkspaceID: wsA,
 				AtMS:        next.UnixMilli(),
 			}
-			item, err := q.EnqueueItem(ctx, item, next)
+			_, err := q.EnqueueItem(ctx, item, next)
 			require.NoError(t, err)
 		}
 
@@ -1315,7 +1315,7 @@ func TestRequeueByJobID(t *testing.T) {
 			WorkspaceID: wsA,
 			AtMS:        target.UnixMilli(),
 		}
-		item, err := q.EnqueueItem(ctx, item, target)
+		_, err := q.EnqueueItem(ctx, item, target)
 		require.NoError(t, err)
 
 		parts, err := q.PartitionPeek(ctx, true, at.Add(time.Hour), 10)
@@ -1358,7 +1358,7 @@ func TestRequeueByJobID(t *testing.T) {
 				WorkspaceID: wsA,
 				AtMS:        next.UnixMilli(),
 			}
-			item, err := q.EnqueueItem(ctx, item, next)
+			_, err := q.EnqueueItem(ctx, item, next)
 			require.NoError(t, err)
 		}
 
@@ -1370,7 +1370,7 @@ func TestRequeueByJobID(t *testing.T) {
 			WorkspaceID: wsA,
 			AtMS:        target.UnixMilli(),
 		}
-		item, err := q.EnqueueItem(ctx, item, target)
+		_, err := q.EnqueueItem(ctx, item, target)
 		require.NoError(t, err)
 
 		parts, err := q.PartitionPeek(ctx, true, at.Add(time.Hour), 10)

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -214,8 +214,11 @@ func (f Function) Validate(ctx context.Context) error {
 		if perr != nil {
 			err = multierror.Append(err, fmt.Errorf("The debounce period of '%s' is invalid: %w", f.Debounce.Period, perr))
 		}
+		if period < consts.MinDebouncePeriod {
+			err = multierror.Append(err, fmt.Errorf("The debounce period of '%s' is less than the min of: %s", f.Debounce.Period, consts.MinDebouncePeriod))
+		}
 		if period > consts.MaxDebouncePeriod {
-			err = multierror.Append(err, fmt.Errorf("The debounce period of '%s' is greater than the max of: %s", f.Debounce.Period, period.String()))
+			err = multierror.Append(err, fmt.Errorf("The debounce period of '%s' is greater than the max of: %s", f.Debounce.Period, consts.MaxDebouncePeriod))
 		}
 	}
 

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -78,8 +78,8 @@ type Function struct {
 }
 
 type Debounce struct {
-	Key    string `json:"key"`
-	Period string `json:"period"`
+	Key    *string `json:"key"`
+	Period string  `json:"period"`
 }
 
 func (f Function) ConcurrencyLimit() int {
@@ -201,6 +201,12 @@ func (f Function) Validate(ctx context.Context) error {
 
 	if len(f.Cancel) > consts.MaxCancellations {
 		err = multierror.Append(err, fmt.Errorf("This function exceeds the max number of cancellation events: %d", consts.MaxCancellations))
+	}
+
+	if f.Debounce != nil && f.Debounce.Key != nil {
+		if _, exprErr := expressions.NewExpressionEvaluator(ctx, *f.Debounce.Key); exprErr != nil {
+			err = multierror.Append(err, fmt.Errorf("Debounce expression is invalid: %s", exprErr))
+		}
 	}
 
 	// Validate rate limit expression

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -210,9 +210,9 @@ func (f Function) Validate(ctx context.Context) error {
 		if f.EventBatch != nil {
 			err = multierror.Append(err, fmt.Errorf("A function cannot specify batch and debounce"))
 		}
-		period, err := str2duration.ParseDuration(f.Debounce.Period)
-		if err != nil {
-			err = multierror.Append(err, fmt.Errorf("The debounce period of '%s' is invalid: %w", f.Debounce.Period, err))
+		period, perr := str2duration.ParseDuration(f.Debounce.Period)
+		if perr != nil {
+			err = multierror.Append(err, fmt.Errorf("The debounce period of '%s' is invalid: %w", f.Debounce.Period, perr))
 		}
 		if period > consts.MaxDebouncePeriod {
 			err = multierror.Append(err, fmt.Errorf("The debounce period of '%s' is greater than the max of: %s", f.Debounce.Period, period.String()))

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -207,6 +207,10 @@ func (f Function) Validate(ctx context.Context) error {
 		if _, exprErr := expressions.NewExpressionEvaluator(ctx, *f.Debounce.Key); exprErr != nil {
 			err = multierror.Append(err, fmt.Errorf("Debounce expression is invalid: %s", exprErr))
 		}
+
+		if f.EventBatch != nil {
+			err = multierror.Append(err, fmt.Errorf("A function cannot specify batch and debounce"))
+		}
 	}
 
 	// Validate rate limit expression

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -55,6 +55,8 @@ type Function struct {
 	// by an individual concurrency key.
 	Concurrency *Concurrency `json:"concurrency,omitempty"`
 
+	Debounce *Debounce `json:"debounce,omitempty"`
+
 	// Trigger represnets the trigger for the function.
 	Triggers []Trigger `json:"triggers"`
 
@@ -73,6 +75,11 @@ type Function struct {
 
 	// Edges represent edges between steps in the dag.
 	Edges []Edge `json:"edges,omitempty"`
+}
+
+type Debounce struct {
+	Key    string `json:"key"`
+	Period string `json:"period"`
 }
 
 func (f Function) ConcurrencyLimit() int {

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -207,9 +207,15 @@ func (f Function) Validate(ctx context.Context) error {
 		if _, exprErr := expressions.NewExpressionEvaluator(ctx, *f.Debounce.Key); exprErr != nil {
 			err = multierror.Append(err, fmt.Errorf("Debounce expression is invalid: %s", exprErr))
 		}
-
 		if f.EventBatch != nil {
 			err = multierror.Append(err, fmt.Errorf("A function cannot specify batch and debounce"))
+		}
+		period, err := str2duration.ParseDuration(f.Debounce.Period)
+		if err != nil {
+			err = multierror.Append(err, fmt.Errorf("The debounce period of '%s' is invalid: %w", f.Debounce.Period, err))
+		}
+		if period > consts.MaxDebouncePeriod {
+			err = multierror.Append(err, fmt.Errorf("The debounce period of '%s' is greater than the max of: %s", f.Debounce.Period, period.String()))
 		}
 	}
 

--- a/pkg/sdk/function.go
+++ b/pkg/sdk/function.go
@@ -42,6 +42,8 @@ type SDKFunction struct {
 	// function.
 	Retries *int `json:"retries,omitempty"`
 
+	Debounce *inngest.Debounce `json:"debounce,omitempty"`
+
 	// Cancel specifies cancellation signals for the function
 	Cancel []inngest.Cancel `json:"cancel,omitempty"`
 
@@ -55,6 +57,7 @@ func (s SDKFunction) Function() (*inngest.Function, error) {
 		Triggers:  s.Triggers,
 		RateLimit: s.RateLimit,
 		Cancel:    s.Cancel,
+		Debounce:  s.Debounce,
 	}
 	// Ensure we set the slug here if s.ID is nil.  This defaults to using
 	// the slugged version of the function name.

--- a/tests.sh
+++ b/tests.sh
@@ -8,4 +8,8 @@ go run ./cmd/main.go dev --no-discovery > dev-stdout.txt 2> dev-stderr.txt &
 
 sleep 5
 
+# Run JS SDK tests
 INNGEST_SIGNING_KEY=test API_URL=http://127.0.0.1:8288 SDK_URL=http://127.0.0.1:3000/api/inngest go test ./tests -v -count=1
+
+# Run Golang SDK tests
+go test ./tests/golang -v -count=1

--- a/tests/golang/basic_step_test.go
+++ b/tests/golang/basic_step_test.go
@@ -1,0 +1,61 @@
+package golang
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngestgo"
+	"github.com/inngest/inngestgo/step"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFunctionSteps(t *testing.T) {
+	h, server, registerFuncs := NewSDKHandler(t)
+	defer server.Close()
+
+	var (
+		counter int32
+	)
+
+	a := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{Name: "test sdk"},
+		inngestgo.EventTrigger("test/sdk"),
+		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+			step.Run(ctx, "1", func(ctx context.Context) (any, error) {
+				<-time.After(time.Second)
+				fmt.Println("1")
+				atomic.AddInt32(&counter, 1)
+				return input.Event, nil
+			})
+
+			step.Run(ctx, "2", func(ctx context.Context) (string, error) {
+				<-time.After(time.Second)
+				fmt.Println("2")
+				atomic.AddInt32(&counter, 1)
+				return "test", nil
+			})
+
+			step.Sleep(ctx, 2*time.Second)
+
+			fmt.Println("3")
+			atomic.AddInt32(&counter, 1)
+			return true, nil
+		},
+	)
+	h.Register(a)
+	registerFuncs()
+
+	_, err := inngestgo.Send(context.Background(), inngestgo.Event{
+		Name: "test/sdk",
+		Data: map[string]any{
+			"test": true,
+		},
+	})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&counter) == 3
+	}, 10*time.Second, time.Second)
+}

--- a/tests/golang/debounce_test.go
+++ b/tests/golang/debounce_test.go
@@ -29,7 +29,7 @@ func TestDebounce(t *testing.T) {
 		calledWith DebounceEvent
 	)
 
-	now := time.Now()
+	at := time.Now()
 	a := inngestgo.CreateFunction(
 		inngestgo.FunctionOpts{
 			Name: "test sdk",
@@ -43,7 +43,14 @@ func TestDebounce(t *testing.T) {
 
 			// We expect that this function is called after at least the debounce period
 			// of 5 seconds.
-			require.True(t, time.Now().After(now.Add(10*time.Second)))
+			now := time.Now()
+			require.True(
+				t,
+				now.After(at.Add(10*time.Second)),
+				"Expected %s, got %s",
+				at.Add(10*time.Second),
+				now,
+			)
 
 			if atomic.LoadInt32(&counter) == 0 {
 				calledWith = input.Event
@@ -77,7 +84,7 @@ func TestDebounce(t *testing.T) {
 	}
 
 	<-time.After(8 * time.Second)
-	now = time.Now()
+	at = time.Now()
 	// Send one more.
 	_, err := inngestgo.Send(context.Background(), DebounceEvent{
 		Name: "test/sdk",
@@ -93,7 +100,7 @@ func TestDebounce(t *testing.T) {
 	}, 17*time.Second, time.Second)
 	require.EqualValues(t, DebounceEventData{Counter: 999, Name: "debounce"}, calledWith.Data)
 
-	<-time.After(10 * time.Second)
+	<-time.After(4 * time.Second)
 	require.EqualValues(t, 1, counter)
 }
 

--- a/tests/golang/golang_sdk_util.go
+++ b/tests/golang/golang_sdk_util.go
@@ -103,7 +103,7 @@ func NewHTTPServer(f http.Handler) *HTTPServer {
 		MaxHeaderBytes: 1 << 20,
 	}
 	go func() {
-		go s.ListenAndServe()
+		_ = s.ListenAndServe()
 	}()
 
 	return &HTTPServer{Server: s, Port: port}

--- a/tests/golang/golang_sdk_util.go
+++ b/tests/golang/golang_sdk_util.go
@@ -1,0 +1,133 @@
+package golang
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngestgo"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slog"
+)
+
+type RegisterFunc func()
+
+type opt func(h *inngestgo.HandlerOpts)
+
+func NewSDKHandler(t *testing.T, hopts ...opt) (inngestgo.Handler, *HTTPServer, RegisterFunc) {
+	t.Helper()
+
+	key := "test"
+	inngestgo.DefaultClient = inngestgo.NewClient(inngestgo.ClientOpts{
+		EventKey: &key,
+	})
+
+	os.Setenv("INNGEST_DEV", "http://127.0.0.1:8288")
+
+	opts := inngestgo.HandlerOpts{
+		RegisterURL: inngestgo.Str("http://127.0.0.1:8288/fn/register"),
+		Logger:      slog.Default(),
+		// Env:         inngestgo.Str("test-env"),
+	}
+
+	for _, o := range hopts {
+		o(&opts)
+	}
+
+	h := inngestgo.NewHandler("Billing", opts)
+
+	server := NewHTTPServer(h)
+
+	// Update the handler's URL with this server.
+	opts.URL, _ = url.Parse(server.URL())
+	h.SetOptions(opts)
+	<-time.After(20 * time.Millisecond)
+
+	r := func() {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPut, server.LocalURL(), nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, 200, resp.StatusCode)
+		_ = resp.Body.Close()
+	}
+	return h, server, r
+}
+
+type HTTPServer struct {
+	*http.Server
+
+	Port int32
+}
+
+func (h HTTPServer) URL() string {
+	// This can be accessed by any docker container with the added network of
+	// `host.docker.internal:host-gateway`.
+	//
+	// We need this for testing actions, as the executor runs in a docker container
+	// and cannot access 127.0.0.1 (which httptest listens on).
+	// return fmt.Sprintf("http://host.docker.internal:%d/", h.Port)
+	return fmt.Sprintf("http://127.0.0.1:%d/", h.Port)
+}
+
+func (h HTTPServer) LocalURL() string {
+	// This can be accessed by any docker container with the added network of
+	// `host.docker.internal:host-gateway`.
+	//
+	// We need this for testing actions, as the executor runs in a docker container
+	// and cannot access 127.0.0.1 (which httptest listens on).
+	return fmt.Sprintf("http://127.0.0.1:%d/", h.Port)
+}
+
+// NewHTTPServer returns a new HTTP server with the given handler, listening on a
+// random port between 10_000 and 65_535 which can be accessed by any host.
+//
+// This is a copy of httptest, but listens on the docker gateway instead of 127.0.0.1
+// only - which doesn't work in tests as the executor's localhost is different.
+func NewHTTPServer(f http.Handler) *HTTPServer {
+	var port int32
+	for port < 10000 {
+		port = rand.Int31n(65335)
+	}
+
+	s := &http.Server{
+		Addr:           fmt.Sprintf("0.0.0.0:%d", port),
+		Handler:        f,
+		ReadTimeout:    60 * time.Second,
+		WriteTimeout:   60 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+	go func() {
+		go s.ListenAndServe()
+	}()
+
+	return &HTTPServer{Server: s, Port: port}
+}
+
+func NewHTTPSServer(f http.Handler) *HTTPServer {
+	var port int32
+	for port < 10000 {
+		port = rand.Int31n(65335)
+	}
+
+	s := &http.Server{
+		Addr:           fmt.Sprintf(":%d", port),
+		Handler:        f,
+		ReadTimeout:    60 * time.Second,
+		WriteTimeout:   60 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+	go func() {
+		err := s.ListenAndServe()
+		if err != nil {
+			fmt.Println(err)
+		}
+	}()
+
+	return &HTTPServer{Server: s, Port: port}
+}

--- a/vendor/github.com/inngest/inngestgo/errors.go
+++ b/vendor/github.com/inngest/inngestgo/errors.go
@@ -2,6 +2,7 @@ package inngestgo
 
 import (
 	"errors"
+	"time"
 )
 
 // NoRetryError wraps an error, preventing retries in the SDK.  This permanently
@@ -36,6 +37,53 @@ func (e noRetryError) Unwrap() error {
 func (e noRetryError) Is(target error) bool {
 	switch target.(type) {
 	case *noRetryError, noRetryError:
+		return true
+	default:
+		return false
+	}
+}
+
+// RetryAtError allows you to specify the time at which the next retry should occur. This
+// wraps your error, leaving the original cause and error message available.
+func RetryAtError(err error, at time.Time) error {
+	return retryAtError{Err: err, At: at}
+}
+
+func IsRetryAtError(err error) bool {
+	return errors.Is(err, retryAtError{})
+}
+
+func GetRetryAtTime(err error) *time.Time {
+	retryAt := &retryAtError{}
+	if ok := errors.As(err, retryAt); ok {
+		return &retryAt.At
+	}
+	return nil
+}
+
+type retryAtError struct {
+	Err error
+	At  time.Time
+}
+
+// Error fulfils the builtin go error interface.  This returns the original root cause
+// for debugging via logging - all logging interfaces & tracing packages use Error() to
+// capture error information.
+func (e retryAtError) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap fulfils errors.Unwrap, allowing us to use the builtin error functionality to
+// manage the original error, or to chain public errors.
+func (e retryAtError) Unwrap() error {
+	return e.Err
+}
+
+// Unwrap fulfils errors.Unwrap, allowing us to use the builtin error functionality to
+// manage the original error, or to chain public errors.
+func (e retryAtError) Is(target error) bool {
+	switch target.(type) {
+	case *retryAtError, retryAtError:
 		return true
 	default:
 		return false

--- a/vendor/github.com/inngest/inngestgo/funcs.go
+++ b/vendor/github.com/inngest/inngestgo/funcs.go
@@ -178,9 +178,11 @@ type Input[T any] struct {
 }
 
 type InputCtx struct {
+	Env        string `json:"env"`
 	FunctionID string `json:"fn_id"`
 	RunID      string `json:"run_id"`
 	StepID     string `json:"step_id"`
+	Attempt    int    `json:"attempt"`
 }
 
 type servableFunc struct {

--- a/vendor/github.com/inngest/inngestgo/funcs.go
+++ b/vendor/github.com/inngest/inngestgo/funcs.go
@@ -18,6 +18,7 @@ type FunctionOpts struct {
 	Idempotency *string
 	Retries     *int
 	Cancel      []inngest.Cancel
+	Debounce    *Debounce
 
 	// RateLimit allows the function to be rate limited.
 	RateLimit *RateLimit
@@ -41,6 +42,11 @@ func (f FunctionOpts) GetRateLimit() *inngest.RateLimit {
 		return nil
 	}
 	return f.RateLimit.Convert()
+}
+
+type Debounce struct {
+	Key    string        `json:"key"`
+	Period time.Duration `json:"period"`
 }
 
 type RateLimit struct {
@@ -70,22 +76,22 @@ func (r RateLimit) Convert() *inngest.RateLimit {
 // For example, if you have a signup event defined as a struct you can use this to strongly
 // type your input:
 //
-// 	type SignupEvent struct {
-// 		Name string
-// 		Data struct {
-// 			Email     string
-// 			AccountID string
-// 		}
-// 	}
+//	type SignupEvent struct {
+//		Name string
+//		Data struct {
+//			Email     string
+//			AccountID string
+//		}
+//	}
 //
-// 	f := CreateFunction(
-// 		inngestgo.FunctionOptions{Name: "Post-signup flow"},
-// 		inngestgo.EventTrigger("user/signed.up"),
-// 		func(ctx context.Context, input gosdk.Input[SignupEvent]) (any, error) {
-// 			// .. Your logic here.  input.Event will be strongly typed as a SignupEvent.
-// 			// step.Run(ctx, "Do some logic", func(ctx context.Context) (string, error) { return "hi", nil })
-// 		},
-// 	)
+//	f := CreateFunction(
+//		inngestgo.FunctionOptions{Name: "Post-signup flow"},
+//		inngestgo.EventTrigger("user/signed.up"),
+//		func(ctx context.Context, input gosdk.Input[SignupEvent]) (any, error) {
+//			// .. Your logic here.  input.Event will be strongly typed as a SignupEvent.
+//			// step.Run(ctx, "Do some logic", func(ctx context.Context) (string, error) { return "hi", nil })
+//		},
+//	)
 func CreateFunction[T any](
 	fc FunctionOpts,
 	trigger inngest.Trigger,
@@ -133,9 +139,9 @@ func CronTrigger(cron string) inngest.Trigger {
 //
 // This uses generics to strongly type input events:
 //
-// 	func(ctx context.Context, input gosdk.Input[SignupEvent]) (any, error) {
-// 		// .. Your logic here.  input.Event will be strongly typed as a SignupEvent.
-// 	}
+//	func(ctx context.Context, input gosdk.Input[SignupEvent]) (any, error) {
+//		// .. Your logic here.  input.Event will be strongly typed as a SignupEvent.
+//	}
 type SDKFunction[T any] func(ctx context.Context, input Input[T]) (any, error)
 
 // ServableFunction defines a function which can be called by a handler's Serve method.

--- a/vendor/github.com/inngest/inngestgo/handler.go
+++ b/vendor/github.com/inngest/inngestgo/handler.go
@@ -175,7 +175,26 @@ func (h *handler) SetAppName(name string) Handler {
 func (h *handler) Register(funcs ...ServableFunction) {
 	h.l.Lock()
 	defer h.l.Unlock()
-	h.funcs = append(h.funcs, funcs...)
+
+	// Create a map of functions by slug.  If we're registering a function
+	// that already exists, clear it.
+	slugs := map[string]ServableFunction{}
+	for _, f := range h.funcs {
+		slugs[f.Slug()] = f
+	}
+
+	for _, f := range funcs {
+		slugs[f.Slug()] = f
+	}
+
+	newFuncs := make([]ServableFunction, len(slugs))
+	i := 0
+	for _, f := range slugs {
+		newFuncs[i] = f
+		i++
+	}
+
+	h.funcs = newFuncs
 }
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -227,8 +246,8 @@ func (h *handler) register(w http.ResponseWriter, r *http.Request) error {
 		// Modify URL to contain fn ID, step params
 		url := h.url(r)
 		values := url.Query()
-		values.Add("fnId", fn.Slug())
-		values.Add("step", "step")
+		values.Set("fnId", fn.Slug())
+		values.Set("step", "step")
 		url.RawQuery = values.Encode()
 
 		f := sdk.SDKFunction{
@@ -248,6 +267,13 @@ func (h *handler) register(w http.ResponseWriter, r *http.Request) error {
 					},
 				},
 			},
+		}
+
+		if c.Debounce != nil {
+			f.Debounce = &inngest.Debounce{
+				Key:    c.Debounce.Key,
+				Period: c.Debounce.Period.String(),
+			}
 		}
 
 		if c.BatchEvents != nil {
@@ -440,6 +466,7 @@ func (h *handler) invoke(w http.ResponseWriter, r *http.Request) error {
 				StatusCode: 500,
 				Body:       fmt.Sprintf("error calling function: %s", err.Error()),
 				NoRetry:    IsNoRetryError(err),
+				RetryAt:    GetRetryAtTime(err),
 			})
 		}
 		if len(ops) > 0 {
@@ -461,7 +488,9 @@ func (h *handler) invoke(w http.ResponseWriter, r *http.Request) error {
 			w.Header().Add("x-inngest-no-retry", "true")
 		}
 
-		// TODO: Add retry-at.
+		if at := GetRetryAtTime(err); at != nil {
+			w.Header().Add("retry-after", at.Format(time.RFC3339))
+		}
 
 		return publicerr.Error{
 			Message: fmt.Sprintf("error calling function: %s", err.Error()),
@@ -484,7 +513,7 @@ func (h *handler) invoke(w http.ResponseWriter, r *http.Request) error {
 type StreamResponse struct {
 	StatusCode int               `json:"status"`
 	Body       any               `json:"body"`
-	RetryAt    *string           `json:"retryAt"`
+	RetryAt    *time.Time        `json:"retryAt"`
 	NoRetry    bool              `json:"noRetry"`
 	Headers    map[string]string `json:"headers"`
 }
@@ -559,6 +588,16 @@ func invoke(ctx context.Context, sf ServableFunction, input *sdkrequest.Request)
 		}
 		inputVal.FieldByName("Events").Set(reflect.ValueOf(events))
 	}
+
+	// Set InputCtx
+	callCtx := InputCtx{
+		Env:        input.CallCtx.Env,
+		FunctionID: input.CallCtx.FunctionID,
+		RunID:      input.CallCtx.RunID,
+		StepID:     input.CallCtx.StepID,
+		Attempt:    input.CallCtx.Attempt,
+	}
+	inputVal.FieldByName("InputCtx").Set(reflect.ValueOf(callCtx))
 
 	var (
 		res       []reflect.Value

--- a/vendor/github.com/inngest/inngestgo/handler.go
+++ b/vendor/github.com/inngest/inngestgo/handler.go
@@ -315,16 +315,16 @@ func (h *handler) register(w http.ResponseWriter, r *http.Request) error {
 
 	byt, err := json.Marshal(config)
 	if err != nil {
-		return err
+		return fmt.Errorf("error marshalling function config: %w", err)
 	}
 	req, err := http.NewRequest(http.MethodPost, registerURL, bytes.NewReader(byt))
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating new request: %w", err)
 	}
 
 	key, err := hashedSigningKey([]byte(h.GetSigningKey()))
 	if err != nil {
-		return err
+		return fmt.Errorf("error creating signing key: %w", err)
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", string(key)))
 	if h.GetEnv() != "" {
@@ -333,7 +333,7 @@ func (h *handler) register(w http.ResponseWriter, r *http.Request) error {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("error performing registration request: %w", err)
 	}
 	if resp.StatusCode > 299 {
 		body := map[string]any{}

--- a/vendor/github.com/inngest/inngestgo/handler.go
+++ b/vendor/github.com/inngest/inngestgo/handler.go
@@ -271,7 +271,7 @@ func (h *handler) register(w http.ResponseWriter, r *http.Request) error {
 
 		if c.Debounce != nil {
 			f.Debounce = &inngest.Debounce{
-				Key:    c.Debounce.Key,
+				Key:    &c.Debounce.Key,
 				Period: c.Debounce.Period.String(),
 			}
 		}

--- a/vendor/github.com/inngest/inngestgo/internal/sdkrequest/manager.go
+++ b/vendor/github.com/inngest/inngestgo/internal/sdkrequest/manager.go
@@ -145,7 +145,7 @@ type UnhashedOp struct {
 	Op     enums.Opcode   `json:"op"`
 	Opts   map[string]any `json:"opts"`
 	Pos    uint           `json:"pos"`
-	Parent *string        `json:"parent"`
+	Parent *string        `json:"parent,omitempty"`
 }
 
 func (u UnhashedOp) Hash() (string, error) {

--- a/vendor/github.com/inngest/inngestgo/internal/sdkrequest/request.go
+++ b/vendor/github.com/inngest/inngestgo/internal/sdkrequest/request.go
@@ -19,6 +19,7 @@ type CallCtx struct {
 	RunID      string    `json:"run_id"`
 	StepID     string    `json:"step_id"`
 	Stack      CallStack `json:"stack"`
+	Attempt    int       `json:"attempt"`
 }
 
 type CallStack struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -477,7 +477,7 @@ github.com/hashicorp/terraform/tfdiags
 # github.com/inconshreveable/mousetrap v1.0.0
 ## explicit
 github.com/inconshreveable/mousetrap
-# github.com/inngest/inngestgo v0.4.3-0.20230910152617-8ea2ceffe372
+# github.com/inngest/inngestgo v0.4.3-0.20230910154532-ce37ea3a6eff
 ## explicit; go 1.20
 github.com/inngest/inngestgo
 github.com/inngest/inngestgo/internal/sdkrequest

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -477,7 +477,7 @@ github.com/hashicorp/terraform/tfdiags
 # github.com/inconshreveable/mousetrap v1.0.0
 ## explicit
 github.com/inconshreveable/mousetrap
-# github.com/inngest/inngestgo v0.4.3-0.20230910154532-ce37ea3a6eff
+# github.com/inngest/inngestgo v0.4.3-0.20231005011526-45faf732bb25
 ## explicit; go 1.20
 github.com/inngest/inngestgo
 github.com/inngest/inngestgo/internal/sdkrequest

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -477,7 +477,7 @@ github.com/hashicorp/terraform/tfdiags
 # github.com/inconshreveable/mousetrap v1.0.0
 ## explicit
 github.com/inconshreveable/mousetrap
-# github.com/inngest/inngestgo v0.4.3-0.20230825203709-1ffd28d9be92
+# github.com/inngest/inngestgo v0.4.3-0.20230910152617-8ea2ceffe372
 ## explicit; go 1.20
 github.com/inngest/inngestgo
 github.com/inngest/inngestgo/internal/sdkrequest

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -477,7 +477,7 @@ github.com/hashicorp/terraform/tfdiags
 # github.com/inconshreveable/mousetrap v1.0.0
 ## explicit
 github.com/inconshreveable/mousetrap
-# github.com/inngest/inngestgo v0.4.3-0.20231005011526-45faf732bb25
+# github.com/inngest/inngestgo v0.4.3-0.20231005031934-9a8046ff59f9
 ## explicit; go 1.20
 github.com/inngest/inngestgo
 github.com/inngest/inngestgo/internal/sdkrequest


### PR DESCRIPTION
This PR introduces debounce support for functions as a first class configuration parameter.

Debounce requires two configuration parameters:

```
{
  key: string,
  period: time.Duration
}
```

- `key` represents a unique key for the function debounce.  This is an expression, and can use event data:  `event.data.name` returns the `name` field from `event.data` to use as the debounce key. Keys are scoped per-function.  If two separate functions use the same debounce key they do not collide.
- `period` is the period to debounce.

# What is debounce?

Debounce delays functions for the `period` specified.  If an event is sent, the function will not run until *at least* `period` has elapsed.

If any new events are received that match the same debounce key, the function is reshceduled for another `period` delay, and the triggering event is replaced with the latest event received.

For example:

```
debounce: 5s
time:     [0 1 2 3 4 5 6 7 8 9]
timeline: [* - - - - ^        ]
           |         |
	   event received
	             |
                     function runs

debounce: 5s
time:     [0 1 2 3 4 5 6 7 8 9]
timeline: [* - - * - - - - ^  ]
           |     |         |
	   event received  |
	                   |
                           function runs
```

In order to facilitate debounce, several new components and things have been added:

- The ability to easily reschedule jobs within the queue with only an ID (an alternative API to an existing Reschedule API)
- Debounce-specific managers, for creating an dupdating debounce keys

Note that extra care has been taken into consideration to resolve debounce-related race conditions.  This will be modelled with TLA+ in the future.

## To do
- [x] Add debounce transactions to state store
- [x] Ensure debounce reschedules function run
- [x] Delete debounce item after function run
- [ ] Ensure Golang integration tests run on CI


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
