### PR TITLE
Improve 502s so that we show actual error messages

### DIFF
--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -306,10 +306,39 @@ func (r DriverResponse) UserError() map[string]any {
 		}
 	}
 
+	err := DefaultErrorMessage
+	if r.Err != nil {
+		err = *r.Err
+	}
+
+	output := any(DefaultErrorMessage)
+	switch v := r.Output.(type) {
+	case json.RawMessage:
+		if len(v) > 0 {
+			output = v
+		}
+	case []byte:
+		if len(v) > 0 {
+			output = v
+		}
+	case string:
+		if len(v) > 0 {
+			output = v
+		}
+	case interface{}:
+		if v != nil {
+			output = v
+		}
+	case nil:
+		// ignore.
+	default:
+		output = v
+	}
+
 	return map[string]any{
-		"error":   DefaultErrorMessage,
+		"error":   err,
 		"name":    "Error",
-		"message": DefaultErrorMessage,
+		"message": output,
 	}
 }
 

--- a/pkg/execution/state/driver_response_test.go
+++ b/pkg/execution/state/driver_response_test.go
@@ -303,14 +303,23 @@ func TestDriverResponseUserError(t *testing.T) {
 			},
 		},
 
-		// This should not happen though
 		{
 			name: "non map Output",
 			r:    DriverResponse{Output: "YOLO"},
 			expected: map[string]any{
 				"error":   "Unknown error running SDK",
 				"name":    "Error",
-				"message": DefaultErrorMessage,
+				"message": "YOLO",
+			},
+		},
+
+		{
+			name: "non map Output with error",
+			r:    DriverResponse{Output: "YOLO", Err: strptr("502 broken")},
+			expected: map[string]any{
+				"error":   "502 broken",
+				"name":    "Error",
+				"message": "YOLO",
 			},
 		},
 	}


### PR DESCRIPTION
Error messages were masked behind a default string if the SDK was entirely unavailable.

This uses the actual error message and output as the message/error, if present.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
