### PR TITLE
Add support for queue indexes

### DIFF
--- a/pkg/execution/state/redis_state/lua/queue/dequeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/dequeue.lua
@@ -17,6 +17,8 @@ local customConcurrencyKeyA   = KEYS[7] -- Optional for eg. for concurrency amon
 local customConcurrencyKeyB   = KEYS[8] -- Optional for eg. for concurrency amongst steps 
 -- We push pointers to partition concurrency items to the partition concurrency item
 local concurrencyPointer      = KEYS[9]
+local keyItemIndexA           = KEYS[10]   -- custom item index 1
+local keyItemIndexB           = KEYS[11]  -- custom item index 2
 
 local queueID        = ARGV[1]
 local idempotencyTTL = tonumber(ARGV[2])
@@ -67,6 +69,14 @@ else
 		-- Ensure that we update the score with the earliest lease
 		redis.call("ZADD", concurrencyPointer, earliestLease, partitionName)
 	end
+end
+
+-- Add optional indexes.
+if keyItemIndexA ~= "" and keyItemIndexA ~= false and keyItemIndexA ~= nil then
+	redis.call("ZREM", keyItemIndexA, queueID)
+end
+if keyItemIndexB ~= "" and keyItemIndexB ~= false and keyItemIndexB ~= nil then
+	redis.call("ZREM", keyItemIndexB, queueID)
 end
 
 return 0

--- a/pkg/execution/state/redis_state/queue_indexes.go
+++ b/pkg/execution/state/redis_state/queue_indexes.go
@@ -1,0 +1,44 @@
+package redis_state
+
+import (
+	"context"
+	"fmt"
+
+	osqueue "github.com/inngest/inngest/pkg/execution/queue"
+)
+
+// QueueItemIndex represends a set of indexes for a given queue item.  We currently allow
+// up to 2 indexes per job item to be created.
+//
+// # What is an index?
+//
+// An index is a sorted ZSET of job items for a given key.  The ZSET stores all
+// oustanding AND in-progress job IDs, scored by job time in milliseconds. Because this
+// stores outstanding and in progress jobs, this _cannot_ be used to control concurrency.
+// It is used to specifically list all jobs that exist for given keys for transparency.
+//
+// A nil slice or empty strings within the slice indicate nil indexes, ie. an index
+// will not be created.
+type QueueItemIndex [2]string
+
+// QueueItemIndexer represents a function which generates indexes for a given queue item.
+type QueueItemIndexer func(ctx context.Context, i QueueItem) QueueItemIndex
+
+// DefaultQueueItemIndexes reeturn default queue item indexes for a given queue item.
+//
+// Reasonably, these indexes should always be provided for queue implementation.  If a
+// QueueItemIndexer is not provided, this function will be used with an "{queue}" predix.
+func DefaultQueueItemIndexes(ctx context.Context, prefix string, i QueueItem) QueueItemIndex {
+	switch i.Data.Kind {
+	case osqueue.KindEdge, osqueue.KindSleep:
+		// For edges and sleeps, store an index for the given run ID.
+		return QueueItemIndex{
+			fmt.Sprintf("%s:idx:run:%s", prefix, i.Data.Identifier.RunID),
+		}
+	case osqueue.KindPause:
+		// Pause jobs are an implementation detail and are not indexed.  Instead,
+		// we should store indexes for each pause <> run separately.  Consuming
+		// or deleting pauses should delete the index.
+	}
+	return QueueItemIndex{}
+}

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -737,7 +737,7 @@ func (q *queue) process(ctx context.Context, p QueuePartition, qi QueueItem, f o
 				Str("queue", qi.Queue()).
 				Int64("at_ms", at.UnixMilli()).
 				Msg("requeuing job")
-			if err := q.Requeue(ctx, p, qi, at); err != nil {
+			if err := q.Requeue(context.WithoutCancel(ctx), p, qi, at); err != nil {
 				q.logger.Error().Err(err).Interface("item", qi).Msg("error requeuing job")
 				return err
 			}
@@ -751,7 +751,7 @@ func (q *queue) process(ctx context.Context, p QueuePartition, qi QueueItem, f o
 		// Dequeue this entirely, as this permanently failed.
 		// XXX: Increase permanently failed counter here.
 		q.logger.Info().Interface("item", qi).Msg("dequeueing failed job")
-		if err := q.Dequeue(ctx, p, qi); err != nil {
+		if err := q.Dequeue(context.WithoutCancel(ctx), p, qi); err != nil {
 			return err
 		}
 
@@ -761,7 +761,7 @@ func (q *queue) process(ctx context.Context, p QueuePartition, qi QueueItem, f o
 		}
 
 	case <-doneCh:
-		if err := q.Dequeue(ctx, p, qi); err != nil {
+		if err := q.Dequeue(context.WithoutCancel(ctx), p, qi); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
A queue index represents a list of queue item IDs for a given key, regardless of whether the queue item is outstanding _or_ in-progress. This lets us index queue items across any number of keys as needed.

The initial implementation here indexes queue items across given run IDs.  This differs to partition queues as partitions group all runs together across separate outstanding and concurrency queues.

Indexes are not used within queueing or queue processing logic and are read-only for metadata APIs.


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
