### PR TITLE
Improve OSS stack overflow handling

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -13,6 +13,13 @@ const (
 	// AbsoluteMaxEventSize is the absolute maximum size of the event payload we process.
 	AbsoluteMaxEventSize = 3 * 1024 * 1024
 
+	// DefaultMaxStepLimit is the maximum number of steps per function allowed.
+	DefaultMaxStepLimit = 1_000
+
+	// AbsoluteMaxStepLimit is the absolute maximium number of steps that an executor can
+	// be initialized with.
+	AbsoluteMaxStepLimit = 10_000
+
 	// MaxFunctionTimeout represents the longest running function or step allowed within
 	// our system.
 	MaxFunctionTimeout = 2 * time.Hour

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/config"
 	_ "github.com/inngest/inngest/pkg/config/defaults"
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/cqrs/ddb"
 	"github.com/inngest/inngest/pkg/deploy"
 	"github.com/inngest/inngest/pkg/enums"
@@ -145,6 +146,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		executor.WithLogger(logger.From(ctx)),
 		executor.WithFunctionLoader(loader),
 		executor.WithLifecycleListeners(history.NewLifecycleListener(nil, hd)),
+		executor.WithStepLimits(consts.DefaultMaxStepLimit),
 	)
 	if err != nil {
 		return err

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -159,6 +159,7 @@ type DriverResponse struct {
 // SetFinal indicates that this error is final, regardless of the status code
 // returned.  This is used to prevent retries when the max limit is reached.
 func (r *DriverResponse) SetFinal() {
+	r.NoRetry = true
 	r.final = true
 }
 


### PR DESCRIPTION
## Description

This improves the dev server's stack overflow handling, bringing step limits in line with cloud's defaults.  It also properly runs failure handlers on stack overflow.

In the future, we probably want to introduce a TOML file which allows users to configure these settings for the OSS dev server.


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
