### PR TITLE
Add request version to metadata

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -65,4 +65,6 @@ const (
 	// in the job.  The retry count is taken from function config for every step _but_
 	// initialization.
 	SourceEdgeRetries = 20
+
+	RequestVersionUnknown = -1
 )

--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -34,6 +34,7 @@ func MarshalV1(
 	env string,
 	attempt int,
 ) ([]byte, error) {
+	md := s.Metadata()
 	req := &SDKRequest{
 		Events:  s.Events(),
 		Event:   s.Event(),
@@ -47,9 +48,10 @@ func MarshalV1(
 				Stack:   s.Stack(),
 				Current: stackIndex,
 			},
-			Attempt: attempt,
+			Attempt:                   attempt,
+			DisableImmediateExecution: md.DisableImmediateExecution,
 		},
-		DisableImmediateExecution: s.Metadata().DisableImmediateExecution,
+		Version: md.RequestVersion,
 	}
 
 	// empty the attrs that consume the most
@@ -57,6 +59,7 @@ func MarshalV1(
 		req.Events = []map[string]any{}
 		req.Actions = map[string]any{}
 		req.UseAPI = true
+		req.Context.UseAPI = true
 	}
 
 	j, err := json.Marshal(req)

--- a/pkg/execution/driver/request.go
+++ b/pkg/execution/driver/request.go
@@ -13,14 +13,13 @@ type SDKRequest struct {
 	Events  []map[string]any   `json:"events,omitempty"`
 	Actions map[string]any     `json:"steps"`
 	Context *SDKRequestContext `json:"ctx"`
-	// UseAPI tells the SDK to retrieve `Events` and `Actions` data
-	// from the API instead of expecting it to be in the request body.
-	// This is a way to get around serverless provider's request body
-	// size limits.
+	// Version indicates the version used to manage the SDK request context.
+	//
+	// A value of -1 means that the function is starting and has no version.
+	Version int `json:"version"`
+
+	// DEPRECATED: NOTE: This is moved into SDKRequestContext for V3+/Non-TS SDKs
 	UseAPI bool `json:"use_api"`
-	// DisableImmediateExecution is used to tell the SDK whether it should
-	// disallow immediate execution of steps as they are found.
-	DisableImmediateExecution bool `json:"disable_immediate_execution"`
 }
 
 // TODO:
@@ -57,6 +56,16 @@ type SDKRequestContext struct {
 
 	// Stack represents the function stack at the time of the step invocation.
 	Stack *FunctionStack `json:"stack"`
+
+	// DisableImmediateExecution is used to tell the SDK whether it should
+	// disallow immediate execution of steps as they are found.
+	DisableImmediateExecution bool `json:"disable_immediate_execution"`
+
+	// UseAPI tells the SDK to retrieve `Events` and `Actions` data
+	// from the API instead of expecting it to be in the request body.
+	// This is a way to get around serverless provider's request body
+	// size limits.
+	UseAPI bool `json:"use_api"`
 
 	// XXX: Pass in opentracing context within ctx.
 }

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -91,7 +91,7 @@ type Executor interface {
 	) error
 
 	// HandleGeneratorResponse handles all generator responses.
-	HandleGeneratorResponse(ctx context.Context, gen []*state.GeneratorOpcode, item queue.Item) error
+	HandleGeneratorResponse(ctx context.Context, resp *state.DriverResponse, item queue.Item) error
 	// HandleGenerator handles an individual generator response returned from the SDK.
 	HandleGenerator(ctx context.Context, gen state.GeneratorOpcode, item queue.Item) error
 

--- a/pkg/execution/state/README.md
+++ b/pkg/execution/state/README.md
@@ -1,0 +1,39 @@
+### SDK request versions
+
+`driver.SDKRequestContext.HashVersion` && `state.Metadata.RequestVersion` indicate the request
+version used to POST data to the SDK.  This is critically important for replay;  changing the
+request payload breaks the exactly-once guarantees of functions.
+
+Request versions can change with any of the following:
+
+- Step hashing changes
+- Input types change
+- Input data changes (eg. per-step errors)
+
+v1 & v2 of the TS SDK used a hashing method for steps which is implementation-specific.  We changed
+the way steps are hashed in v3 of the TS SDK, allowing cross-language, cross-platform live
+migrations of state.
+
+The format is as follows:
+
+* -1: The hash version is unset, and needs to be set on the first SDK response.
+* [n]: The first hash version is as specified
+
+**Current versions**
+
+- `1`: Steps are hashed in the following format: `fmt.Sprintf("%s:%d", stepID, idx)`
+
+**How it works**
+
+Whenever we instantiate a new fn, the hash version is set to `-1` - ie. unknown.  The first SDK
+request should respond with a hash version which is set in state metadata.
+
+When running steps, we can compare the stored hash version with the SDK's latest response.  If
+versions change, we can warn or fail depending on strictness.
+
+NOTE: v1 and v2 of the TS SDKs do _not_ support hash versions.  This implicitly means that a '0'
+hash version uses the TS-specific style of hashing from Jan 23-Sep 23.
+
+**SDK Compatibility**
+
+All SDKs **must** respond with an `x-inngest-req-version` header indicating the version used.

--- a/pkg/execution/state/redis_state/lua/updateMetadata.lua
+++ b/pkg/execution/state/redis_state/lua/updateMetadata.lua
@@ -5,9 +5,11 @@ local keyMetadata = KEYS[1]
 local ctx      = ARGV[1]
 local debugger = ARGV[2]
 local die      = ARGV[3] -- disable immediate execution
+local rv       = ARGV[4] -- request version
 
 redis.call("HSET", keyMetadata, "ctx", ctx)
 redis.call("HSET", keyMetadata, "die", die)
 redis.call("HSET", keyMetadata, "debugger", debugger)
+redis.call("HSET", keyMetadata, "rv", rv)
 
 return 0

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -128,9 +128,25 @@ type Metadata struct {
 	// DEPRECATED
 	Pending int `json:"pending"`
 
-	// Version is the used for making sure workloads runs are backward compatible
-	// and work without issues during breaking changes to backend logic
+	// Version represents the version of _metadata_ in particular.
+	//
+	// TODO: This should be removed and made specific to each particular state
+	// implementation.
 	Version int `json:"version"`
+
+	// RequestVersion represents the executor request versioning/hashing style
+	// used to manage state.
+	//
+	// TS v3, Go, Rust, Elixir, and Java all use the same hashing style (1).
+	//
+	// TS v1 + v2 use a unique hashing style (0) which cannot be transferred
+	// to other languages.
+	//
+	// This lets us send the hashing style to SDKs so that we can execute in
+	// the correct format with backcompat guarantees built in.
+	//
+	// NOTE: We can only know this the first time an SDK is responding to a step.
+	RequestVersion int `json:"rv"`
 
 	// Context allows storing any other contextual data in metadata.
 	Context map[string]any `json:"ctx,omitempty"`
@@ -144,6 +160,7 @@ type MetadataUpdate struct {
 	Debugger                  bool           `json:"debugger"`
 	Context                   map[string]any `json:"ctx,omitempty"`
 	DisableImmediateExecution bool           `json:"disableImmediateExecution,omitempty"`
+	RequestVersion            int            `json:"rv"`
 }
 
 // State represents the current state of a fn run.  It is data-structure

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -323,6 +323,7 @@ func checkUpdateMetadata(t *testing.T, m state.Manager) {
 			"ok":      true,
 			"another": "yes",
 		},
+		RequestVersion: 2,
 	}
 
 	err = m.UpdateMetadata(ctx, runID, update)
@@ -335,6 +336,7 @@ func checkUpdateMetadata(t *testing.T, m state.Manager) {
 	require.EqualValues(t, true, found.DisableImmediateExecution)
 	require.EqualValues(t, true, found.Debugger)
 	require.EqualValues(t, update.Context, found.Context)
+	require.EqualValues(t, 2, found.RequestVersion)
 }
 
 func checkScheduled(t *testing.T, m state.Manager) {

--- a/tests/sdk_cancel_test.go
+++ b/tests/sdk_cancel_test.go
@@ -74,10 +74,10 @@ func TestSDKCancelNotReceived(t *testing.T) {
 			// All executor requests should have this event.
 			test.SetRequestEvent(evt),
 			// And the executor should start its requests with this context.
-			test.SetRequestContext(SDKCtx{
-				FnID:   inngest.DeterministicUUID(abstract.Function).String(),
-				StepID: "step",
-				Stack: driver.FunctionStack{
+			test.SetRequestContext(driver.SDKRequestContext{
+				FunctionID: inngest.DeterministicUUID(abstract.Function),
+				StepID:     "step",
+				Stack: &driver.FunctionStack{
 					Current: 0,
 				},
 			}),
@@ -200,10 +200,10 @@ func TestSDKCancelReceived(t *testing.T) {
 			test.SetRequestSteps(nil),
 			test.SetRequestSteps(map[string]any{}),
 			// And the executor should start its requests with this context.
-			test.SetRequestContext(SDKCtx{
-				FnID:   inngest.DeterministicUUID(abstract.Function).String(),
-				StepID: "step",
-				Stack: driver.FunctionStack{
+			test.SetRequestContext(driver.SDKRequestContext{
+				FunctionID: inngest.DeterministicUUID(abstract.Function),
+				StepID:     "step",
+				Stack: &driver.FunctionStack{
 					Current: 0,
 				},
 			}),

--- a/tests/sdk_cancel_via_api_test.go
+++ b/tests/sdk_cancel_via_api_test.go
@@ -74,10 +74,10 @@ func TestCancelFunctionViaAPI(t *testing.T) {
 			// All executor requests should have this event.
 			test.SetRequestEvent(evt),
 			// And the executor should start its requests with this context.
-			test.SetRequestContext(SDKCtx{
-				FnID:   inngest.DeterministicUUID(abstract.Function).String(),
-				StepID: "step",
-				Stack: driver.FunctionStack{
+			test.SetRequestContext(driver.SDKRequestContext{
+				FunctionID: inngest.DeterministicUUID(abstract.Function),
+				StepID:     "step",
+				Stack: &driver.FunctionStack{
 					Current: 0,
 				},
 			}),

--- a/tests/sdk_function_test.go
+++ b/tests/sdk_function_test.go
@@ -57,10 +57,10 @@ func TestSDKFunctions(t *testing.T) {
 		// All executor requests should have this event.
 		test.SetRequestEvent(evt),
 		// And the executor should start its requests with this context.
-		test.SetRequestContext(SDKCtx{
-			FnID:   inngest.DeterministicUUID(test.Function).String(),
-			StepID: "step",
-			Stack: driver.FunctionStack{
+		test.SetRequestContext(driver.SDKRequestContext{
+			FunctionID: inngest.DeterministicUUID(test.Function),
+			StepID:     "step",
+			Stack: &driver.FunctionStack{
 				Current: 0,
 			},
 		}),

--- a/tests/sdk_no_retry_test.go
+++ b/tests/sdk_no_retry_test.go
@@ -52,10 +52,10 @@ func TestSDKNoRetry(t *testing.T) {
 		// All executor requests should have this event.
 		test.SetRequestEvent(evt),
 		// And the executor should start its requests with this context.
-		test.SetRequestContext(SDKCtx{
-			FnID:   inngest.DeterministicUUID(test.Function).String(),
-			StepID: "step",
-			Stack: driver.FunctionStack{
+		test.SetRequestContext(driver.SDKRequestContext{
+			FunctionID: inngest.DeterministicUUID(test.Function),
+			StepID:     "step",
+			Stack: &driver.FunctionStack{
 				Current: 0,
 			},
 		}),

--- a/tests/sdk_step_test.go
+++ b/tests/sdk_step_test.go
@@ -70,10 +70,10 @@ func TestSDKSteps(t *testing.T) {
 		// All executor requests should have this event.
 		test.SetRequestEvent(evt),
 		// And the executor should start its requests with this context.
-		test.SetRequestContext(SDKCtx{
-			FnID:   inngest.DeterministicUUID(test.Function).String(),
-			StepID: "step",
-			Stack: driver.FunctionStack{
+		test.SetRequestContext(driver.SDKRequestContext{
+			FunctionID: inngest.DeterministicUUID(test.Function),
+			StepID:     "step",
+			Stack: &driver.FunctionStack{
 				Current: 0,
 			},
 		}),

--- a/tests/sdk_wait_for_event_test.go
+++ b/tests/sdk_wait_for_event_test.go
@@ -70,10 +70,10 @@ func TestSDKWaitForEvent(t *testing.T) {
 			// All executor requests should have this event.
 			test.SetRequestEvent(evt),
 			// And the executor should start its requests with this context.
-			test.SetRequestContext(SDKCtx{
-				FnID:   inngest.DeterministicUUID(abstract.Function).String(),
-				StepID: "step",
-				Stack: driver.FunctionStack{
+			test.SetRequestContext(driver.SDKRequestContext{
+				FunctionID: inngest.DeterministicUUID(abstract.Function),
+				StepID:     "step",
+				Stack: &driver.FunctionStack{
 					Current: 0,
 				},
 			}),
@@ -182,10 +182,10 @@ func TestSDKWaitForEvent_NoEvent(t *testing.T) {
 			// All executor requests should have this event.
 			test.SetRequestEvent(evt),
 			// And the executor should start its requests with this context.
-			test.SetRequestContext(SDKCtx{
-				FnID:   inngest.DeterministicUUID(abstract.Function).String(),
-				StepID: "step",
-				Stack: driver.FunctionStack{
+			test.SetRequestContext(driver.SDKRequestContext{
+				FunctionID: inngest.DeterministicUUID(abstract.Function),
+				StepID:     "step",
+				Stack: &driver.FunctionStack{
 					Current: 0,
 				},
 			}),


### PR DESCRIPTION
This PR supports request versions per function run.  The request version is discovered on the first SDK call with generator responses.  This allows us to store the 'version' that an SDK uses for hashing/request response styles.

We then use this version for the lifetime of the function.  Without this, incompatible changes released are never backwards compatible - breaking any in-progress functions.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
