### PR TITLE
Add in-memory history reader and writer

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/inngest/inngest/pkg/execution/runner"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/execution/state/redis_state"
+	"github.com/inngest/inngest/pkg/history_drivers/memory_writer"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/service"
@@ -145,7 +146,13 @@ func start(ctx context.Context, opts StartOpts) error {
 		executor.WithQueue(queue),
 		executor.WithLogger(logger.From(ctx)),
 		executor.WithFunctionLoader(loader),
-		executor.WithLifecycleListeners(history.NewLifecycleListener(nil, hd)),
+		executor.WithLifecycleListeners(
+			history.NewLifecycleListener(
+				nil,
+				hd,
+				memory_writer.NewWriter(),
+			),
+		),
 		executor.WithStepLimits(consts.DefaultMaxStepLimit),
 	)
 	if err != nil {

--- a/pkg/history_drivers/memory_reader/reader.go
+++ b/pkg/history_drivers/memory_reader/reader.go
@@ -1,0 +1,208 @@
+package memory_reader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/execution/history"
+	"github.com/inngest/inngest/pkg/history_drivers/memory_store"
+	"github.com/inngest/inngest/pkg/history_reader"
+	"github.com/inngest/inngest/pkg/usage"
+	"github.com/oklog/ulid/v2"
+)
+
+func NewReader() *reader {
+	return &reader{
+		store: memory_store.Singleton,
+	}
+}
+
+type reader struct {
+	store *memory_store.RunStore
+}
+
+func (r *reader) CountRuns(
+	ctx context.Context,
+	opts history_reader.CountRunOpts,
+) (int, error) {
+	r.store.Mu.Lock()
+	defer r.store.Mu.Unlock()
+
+	return len(r.store.Data), nil
+}
+
+func (r *reader) GetRun(
+	ctx context.Context,
+	runID ulid.ULID,
+	opts history_reader.GetRunOpts,
+) (history_reader.Run, error) {
+	r.store.Mu.Lock()
+	defer r.store.Mu.Unlock()
+
+	run, ok := r.store.Data[runID]
+	if !ok {
+		return history_reader.Run{}, history_reader.ErrNotFound
+	}
+
+	return run.Run, nil
+}
+
+func (r *reader) GetRunHistory(
+	ctx context.Context,
+	runID ulid.ULID,
+	opts history_reader.GetRunOpts,
+) ([]*history_reader.RunHistory, error) {
+	r.store.Mu.Lock()
+	defer r.store.Mu.Unlock()
+
+	run, ok := r.store.Data[runID]
+	if !ok {
+		return nil, history_reader.ErrNotFound
+	}
+
+	var items []*history_reader.RunHistory
+	for _, item := range run.History {
+		historyItem, err := toRunHistory(item)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert history item: %w", err)
+		}
+		items = append(items, historyItem)
+	}
+
+	return items, nil
+}
+
+func (r *reader) GetRunHistoryItemOutput(
+	ctx context.Context,
+	historyID ulid.ULID,
+	opts history_reader.GetHistoryOutputOpts,
+) (string, error) {
+	r.store.Mu.Lock()
+	defer r.store.Mu.Unlock()
+
+	if err := opts.Validate(); err != nil {
+		return "", err
+	}
+
+	run, ok := r.store.Data[opts.RunID]
+	if !ok {
+		return "", history_reader.ErrNotFound
+	}
+
+	for _, item := range run.History {
+		if item.ID == historyID && item.Result != nil {
+			return item.Result.Output, nil
+		}
+	}
+
+	return "", history_reader.ErrNotFound
+}
+
+func (r *reader) GetRuns(
+	ctx context.Context,
+	opts history_reader.GetRunsOpts,
+) ([]history_reader.Run, error) {
+	r.store.Mu.Lock()
+	defer r.store.Mu.Unlock()
+
+	var runs []history_reader.Run
+	for _, run := range r.store.Data {
+		runs = append(runs, run.Run)
+	}
+
+	return runs, nil
+}
+
+func (r *reader) GetRunsByEventID(
+	ctx context.Context,
+	eventID ulid.ULID,
+	opts history_reader.GetRunsByEventIDOpts,
+) ([]history_reader.Run, error) {
+	r.store.Mu.Lock()
+	defer r.store.Mu.Unlock()
+
+	var runs []history_reader.Run
+	for _, run := range r.store.Data {
+		if run.Run.EventID == eventID {
+			runs = append(runs, run.Run)
+		}
+	}
+
+	return runs, nil
+}
+
+func (r *reader) GetUsage(
+	ctx context.Context,
+	opts history_reader.GetUsageOpts,
+) ([]usage.UsageSlot, error) {
+	r.store.Mu.Lock()
+	defer r.store.Mu.Unlock()
+
+	return nil, errors.New("not implemented")
+}
+
+func toRunHistory(item history.History) (*history_reader.RunHistory, error) {
+	var cancel *history_reader.RunHistoryCancel
+	if item.Cancel != nil {
+		cancel = &history_reader.RunHistoryCancel{
+			EventID:    item.Cancel.EventID,
+			Expression: item.Cancel.Expression,
+			UserID:     item.Cancel.UserID,
+		}
+	}
+
+	historyType, err := enums.HistoryTypeString(item.Type)
+	if err != nil {
+		return nil, fmt.Errorf("invalid history type: %w", err)
+	}
+
+	var result *history_reader.RunHistoryResult
+	if item.Result != nil {
+		result = &history_reader.RunHistoryResult{
+			// TODO
+		}
+	}
+
+	var sleep *history_reader.RunHistorySleep
+	if item.Sleep != nil {
+		sleep = &history_reader.RunHistorySleep{
+			Until: item.Sleep.Until,
+		}
+	}
+
+	var waitForEvent *history_reader.RunHistoryWaitForEvent
+	if item.WaitForEvent != nil {
+		waitForEvent = &history_reader.RunHistoryWaitForEvent{
+			EventName:  item.WaitForEvent.EventName,
+			Expression: item.WaitForEvent.Expression,
+			Timeout:    item.WaitForEvent.Timeout,
+		}
+	}
+
+	var waitResult *history_reader.RunHistoryWaitResult
+	if item.WaitResult != nil {
+		waitResult = &history_reader.RunHistoryWaitResult{
+			EventID: item.WaitResult.EventID,
+			Timeout: item.WaitResult.Timeout,
+		}
+	}
+
+	return &history_reader.RunHistory{
+		Attempt:         item.Attempt,
+		Cancel:          cancel,
+		CreatedAt:       item.CreatedAt,
+		FunctionVersion: item.FunctionVersion,
+		GroupID:         item.GroupID,
+		ID:              item.ID,
+		Result:          result,
+		RunID:           item.RunID,
+		Sleep:           sleep,
+		StepName:        item.StepName,
+		Type:            historyType,
+		URL:             item.URL,
+		WaitForEvent:    waitForEvent,
+		WaitResult:      waitResult,
+	}, nil
+}

--- a/pkg/history_drivers/memory_store/store.go
+++ b/pkg/history_drivers/memory_store/store.go
@@ -1,0 +1,26 @@
+package memory_store
+
+import (
+	"sync"
+
+	"github.com/inngest/inngest/pkg/execution/history"
+	"github.com/inngest/inngest/pkg/history_reader"
+	"github.com/oklog/ulid/v2"
+)
+
+var (
+	Singleton = &RunStore{
+		Data: map[ulid.ULID]RunData{},
+		Mu:   &sync.Mutex{},
+	}
+)
+
+type RunData struct {
+	Run     history_reader.Run
+	History []history.History
+}
+
+type RunStore struct {
+	Data map[ulid.ULID]RunData
+	Mu   *sync.Mutex
+}

--- a/pkg/history_drivers/memory_writer/writer.go
+++ b/pkg/history_drivers/memory_writer/writer.go
@@ -1,0 +1,102 @@
+package memory_writer
+
+import (
+	"context"
+	"time"
+
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/execution/history"
+	"github.com/inngest/inngest/pkg/history_drivers/memory_store"
+	"github.com/inngest/inngest/pkg/history_reader"
+	"github.com/inngest/inngest/pkg/inngest/log"
+)
+
+func NewWriter() history.Driver {
+	return &writer{
+		store: memory_store.Singleton,
+	}
+}
+
+type writer struct {
+	store *memory_store.RunStore
+}
+
+func (w *writer) Close() error {
+	return nil
+}
+
+func (w *writer) Write(
+	ctx context.Context,
+	item history.History,
+) error {
+	w.store.Mu.Lock()
+	defer w.store.Mu.Unlock()
+
+	if item.Type == enums.HistoryTypeFunctionStarted.String() {
+		w.writeWorkflowStart(ctx, item)
+	} else if item.Type == enums.HistoryTypeFunctionCancelled.String() ||
+		item.Type == enums.HistoryTypeFunctionCompleted.String() ||
+		item.Type == enums.HistoryTypeFunctionFailed.String() {
+		w.writeWorkflowEnd(ctx, item)
+	}
+
+	w.writeHistory(ctx, item)
+	return nil
+}
+
+func (w *writer) writeHistory(
+	ctx context.Context,
+	item history.History,
+) {
+	run := w.store.Data[item.RunID]
+	run.History = append(run.History, item)
+	w.store.Data[item.RunID] = run
+}
+
+func (w *writer) writeWorkflowEnd(
+	ctx context.Context,
+	item history.History,
+) {
+	var status enums.RunStatus
+	switch item.Type {
+	case enums.HistoryTypeFunctionCancelled.String():
+		status = enums.RunStatusCancelled
+	case enums.HistoryTypeFunctionCompleted.String():
+		status = enums.RunStatusCompleted
+	case enums.HistoryTypeFunctionFailed.String():
+		status = enums.RunStatusFailed
+	default:
+		log.From(ctx).Error().Str("type", item.Type).
+			Msg("unknown history type")
+	}
+
+	run := w.store.Data[item.RunID]
+	run.Run.EndedAt = timePtr(time.Now())
+	run.Run.Status = status
+	w.store.Data[item.RunID] = run
+}
+
+func (w *writer) writeWorkflowStart(
+	ctx context.Context,
+	item history.History,
+) {
+	data := memory_store.RunData{
+		Run: history_reader.Run{
+			AccountID:       item.AccountID,
+			BatchID:         item.BatchID,
+			EventID:         item.EventID,
+			ID:              item.RunID,
+			OriginalRunID:   item.OriginalRunID,
+			StartedAt:       time.UnixMilli(int64(item.RunID.Time())),
+			Status:          enums.RunStatusRunning,
+			WorkflowID:      item.FunctionID,
+			WorkspaceID:     item.WorkspaceID,
+			WorkflowVersion: int(item.FunctionVersion),
+		},
+	}
+	w.store.Data[item.RunID] = data
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/pkg/history_reader/reader.go
+++ b/pkg/history_reader/reader.go
@@ -36,12 +36,12 @@ type Reader interface {
 		opts GetRunOpts,
 	) (Run, error)
 	GetRuns(ctx context.Context, opts GetRunsOpts) ([]Run, error)
-	GetRunHistories(
+	GetRunHistory(
 		ctx context.Context,
 		runID ulid.ULID,
 		opts GetRunOpts,
 	) ([]*RunHistory, error)
-	GetRunHistoryOutput(
+	GetRunHistoryItemOutput(
 		ctx context.Context,
 		historyID ulid.ULID,
 		opts GetHistoryOutputOpts,


### PR DESCRIPTION
## Description

- Create an in-memory reader and writer for the new history mechanism.
- Add the in-memory writer to the lifecycle listeners.

## Context

The reader isn't used yet, but will be in future PRs.

## Testing

Ran a function and nothing failed.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
