### PR TITLE
Add new history to GraphQL

### DIFF
--- a/pkg/coreapi/coreapi.go
+++ b/pkg/coreapi/coreapi.go
@@ -17,6 +17,7 @@ import (
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/execution/runner"
 	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/history_drivers/memory_reader"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/publicerr"
 	"github.com/oklog/ulid/v2"
@@ -55,8 +56,9 @@ func NewCoreApi(o Options) (*CoreAPI, error) {
 	a.Use(cors.Handler)
 
 	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &resolvers.Resolver{
-		Data:   o.Data,
-		Runner: o.Runner,
+		Data:          o.Data,
+		HistoryReader: memory_reader.NewReader(),
+		Runner:        o.Runner,
 	}}))
 
 	// TODO - Add option for enabling GraphQL Playground

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -5,6 +5,10 @@ The environment for the function to be run: `"prod"` or `"test"`
 """
 scalar Environment
 
+scalar Uint
+scalar ULID
+scalar UUID
+
 type Workspace {
   id: ID!
 }
@@ -24,7 +28,7 @@ enum StreamType {
 
 type FunctionVersion {
   functionId: ID!
-  version: Int!
+  version: Uint!
   config: String!
 
   validFrom: Time
@@ -186,5 +190,71 @@ type FunctionRun {
   output: String # JSON encoded output of the function, or JSON encoded error if this is a failure.
 
   timeline: [FunctionRunEvent!] @deprecated
+  history: [RunHistoryItem!]!
+  historyItemOutput(id: ULID!): String!
   name: String @deprecated # use the embedded function field instead.
+}
+
+enum HistoryType {
+	FunctionCancelled
+	FunctionCompleted
+	FunctionFailed
+	FunctionScheduled
+	FunctionStarted
+	FunctionStatusUpdated
+	None
+	StepCompleted
+	StepErrored
+	StepFailed
+	StepScheduled
+	StepSleeping
+	StepStarted
+	StepWaiting
+}
+
+type RunHistoryItem {
+  attempt: Int!
+  cancel: RunHistoryCancel
+  createdAt: Time!
+  functionVersion: Int!
+  groupID: UUID
+  id: ULID!
+  result: RunHistoryResult
+  sleep: RunHistorySleep
+  stepName: String
+  type: HistoryType!
+  url: String
+  waitForEvent: RunHistoryWaitForEvent
+  waitResult: RunHistoryWaitResult
+}
+
+type RunHistoryCancel {
+  eventID: ULID
+  expression: String
+  userID: UUID
+}
+
+type RunHistoryResult {
+  durationMS: Int!
+  errorCode: String
+  framework: String
+  platform: String
+  sdkLanguage: String!
+  sdkVersion: String!
+  sizeBytes: Int!
+}
+
+type RunHistorySleep {
+  until: Time!
+}
+
+type RunHistoryWaitForEvent {
+  eventName: String!
+  expression: String
+  timeout: Time!
+}
+
+type RunHistoryWaitResult {
+  eventID: ULID
+  timeout: Boolean!
 }

--- a/pkg/coreapi/gqlgen.yml
+++ b/pkg/coreapi/gqlgen.yml
@@ -18,10 +18,8 @@ struct_tag: json
 models:
   NullString:
     model: github.com/inngest/inngest/pkg/coreapi.NullString
-  Int:
-    model:
-      - github.com/99designs/gqlgen/graphql.Int
-      - github.com/99designs/gqlgen/graphql.Uint
+  Uint:
+    model: github.com/99designs/gqlgen/graphql.Uint
   Environment:
     model: github.com/inngest/inngest/pkg/coreapi/graph/models.Environment
   App:
@@ -46,6 +44,10 @@ models:
         resolver: true
   FunctionRun:
     fields:
+      history:
+        resolver: true
+      historyItemOutput:
+        resolver: true
       timeline:
         resolver: true
       event:
@@ -62,3 +64,21 @@ models:
         resolver: true
       finishedAt:
         resolver: true
+  HistoryType:
+    model: github.com/inngest/inngest/pkg/enums.HistoryType
+  RunHistoryItem:
+    model: github.com/inngest/inngest/pkg/history_reader.RunHistory
+  RunHistoryCancel:
+    model: github.com/inngest/inngest/pkg/history_reader.RunHistoryCancel
+  RunHistoryResult:
+    model: github.com/inngest/inngest/pkg/history_reader.RunHistoryResult
+  RunHistorySleep:
+    model: github.com/inngest/inngest/pkg/history_reader.RunHistorySleep
+  RunHistoryWaitForEvent:
+    model: github.com/inngest/inngest/pkg/history_reader.RunHistoryWaitForEvent
+  RunHistoryWaitResult:
+    model: github.com/inngest/inngest/pkg/history_reader.RunHistoryWaitResult
+  ULID:
+    model: github.com/inngest/inngest/pkg/gql_scalars.ULID
+  UUID:
+    model: github.com/inngest/inngest/pkg/gql_scalars.UUID

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"strconv"
 	"time"
+
+	"github.com/inngest/inngest/pkg/history_reader"
 )
 
 type FunctionRunEvent interface {
@@ -68,19 +70,21 @@ type FunctionEvent struct {
 func (FunctionEvent) IsFunctionRunEvent() {}
 
 type FunctionRun struct {
-	ID           string             `json:"id"`
-	FunctionID   string             `json:"functionID"`
-	Function     *Function          `json:"function,omitempty"`
-	Workspace    *Workspace         `json:"workspace,omitempty"`
-	Event        *Event             `json:"event,omitempty"`
-	Status       *FunctionRunStatus `json:"status,omitempty"`
-	WaitingFor   *StepEventWait     `json:"waitingFor,omitempty"`
-	PendingSteps *int               `json:"pendingSteps,omitempty"`
-	StartedAt    *time.Time         `json:"startedAt,omitempty"`
-	FinishedAt   *time.Time         `json:"finishedAt,omitempty"`
-	Output       *string            `json:"output,omitempty"`
-	Timeline     []FunctionRunEvent `json:"timeline,omitempty"`
-	Name         *string            `json:"name,omitempty"`
+	ID                string                       `json:"id"`
+	FunctionID        string                       `json:"functionID"`
+	Function          *Function                    `json:"function,omitempty"`
+	Workspace         *Workspace                   `json:"workspace,omitempty"`
+	Event             *Event                       `json:"event,omitempty"`
+	Status            *FunctionRunStatus           `json:"status,omitempty"`
+	WaitingFor        *StepEventWait               `json:"waitingFor,omitempty"`
+	PendingSteps      *int                         `json:"pendingSteps,omitempty"`
+	StartedAt         *time.Time                   `json:"startedAt,omitempty"`
+	FinishedAt        *time.Time                   `json:"finishedAt,omitempty"`
+	Output            *string                      `json:"output,omitempty"`
+	Timeline          []FunctionRunEvent           `json:"timeline,omitempty"`
+	History           []*history_reader.RunHistory `json:"history"`
+	HistoryItemOutput string                       `json:"historyItemOutput"`
+	Name              *string                      `json:"name,omitempty"`
 }
 
 type FunctionRunQuery struct {

--- a/pkg/coreapi/graph/resolvers/resolver.go
+++ b/pkg/coreapi/graph/resolvers/resolver.go
@@ -6,11 +6,13 @@ import (
 	"github.com/inngest/inngest/pkg/coreapi/generated"
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/execution/runner"
+	"github.com/inngest/inngest/pkg/history_reader"
 )
 
 type Resolver struct {
-	Data   cqrs.Manager
-	Runner runner.Runner
+	Data          cqrs.Manager
+	HistoryReader history_reader.Reader
+	Runner        runner.Runner
 }
 
 // Query returns generated.QueryResolver implementation.

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -179,6 +179,7 @@ func (e executor) Execute(ctx context.Context, s state.State, item queue.Item, e
 		dr := &state.DriverResponse{
 			Step:       step,
 			Duration:   resp.duration,
+			Output:     string(resp.body),
 			OutputSize: len(resp.body),
 			NoRetry:    resp.noRetry,
 			RetryAt:    resp.retryAt,

--- a/pkg/gql_scalars/ulid.go
+++ b/pkg/gql_scalars/ulid.go
@@ -1,0 +1,25 @@
+package types
+
+import (
+	"io"
+	"strconv"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/oklog/ulid/v2"
+	"github.com/pkg/errors"
+)
+
+func MarshalULID(id ulid.ULID) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		_, _ = io.WriteString(w, strconv.Quote(id.String()))
+	})
+}
+
+func UnmarshalULID(v interface{}) (ulid.ULID, error) {
+	switch v := v.(type) {
+	case string:
+		return ulid.Parse(v)
+	default:
+		return ulid.ULID{}, errors.Errorf("%T is not a ULID", v)
+	}
+}

--- a/pkg/gql_scalars/uuid.go
+++ b/pkg/gql_scalars/uuid.go
@@ -1,0 +1,25 @@
+package types
+
+import (
+	"io"
+	"strconv"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+)
+
+func MarshalUUID(u uuid.UUID) graphql.Marshaler {
+	return graphql.WriterFunc(func(w io.Writer) {
+		_, _ = io.WriteString(w, strconv.Quote(u.String()))
+	})
+}
+
+func UnmarshalUUID(v interface{}) (uuid.UUID, error) {
+	switch v := v.(type) {
+	case string:
+		return uuid.Parse(v)
+	default:
+		return uuid.Nil, errors.Errorf("%T is not a uuid", v)
+	}
+}

--- a/ui/src/store/generated.ts
+++ b/ui/src/store/generated.ts
@@ -14,6 +14,9 @@ export type Scalars = {
   /** The environment for the function to be run: `"prod"` or `"test"` */
   Environment: any;
   Time: any;
+  ULID: any;
+  UUID: any;
+  Uint: any;
 };
 
 export type ActionVersionQuery = {
@@ -109,6 +112,8 @@ export type FunctionRun = {
   finishedAt?: Maybe<Scalars['Time']>;
   function?: Maybe<Function>;
   functionID: Scalars['String'];
+  history: Array<RunHistoryItem>;
+  historyItemOutput: Scalars['String'];
   id: Scalars['ID'];
   /** @deprecated Field no longer supported */
   name?: Maybe<Scalars['String']>;
@@ -121,6 +126,11 @@ export type FunctionRun = {
   timeline?: Maybe<Array<FunctionRunEvent>>;
   waitingFor?: Maybe<StepEventWait>;
   workspace?: Maybe<Workspace>;
+};
+
+
+export type FunctionRunHistoryItemOutputArgs = {
+  id: Scalars['ULID'];
 };
 
 export type FunctionRunEvent = FunctionEvent | StepEvent;
@@ -167,8 +177,25 @@ export type FunctionVersion = {
   updatedAt: Scalars['Time'];
   validFrom?: Maybe<Scalars['Time']>;
   validTo?: Maybe<Scalars['Time']>;
-  version: Scalars['Int'];
+  version: Scalars['Uint'];
 };
+
+export enum HistoryType {
+  FunctionCancelled = 'FunctionCancelled',
+  FunctionCompleted = 'FunctionCompleted',
+  FunctionFailed = 'FunctionFailed',
+  FunctionScheduled = 'FunctionScheduled',
+  FunctionStarted = 'FunctionStarted',
+  FunctionStatusUpdated = 'FunctionStatusUpdated',
+  None = 'None',
+  StepCompleted = 'StepCompleted',
+  StepErrored = 'StepErrored',
+  StepFailed = 'StepFailed',
+  StepScheduled = 'StepScheduled',
+  StepSleeping = 'StepSleeping',
+  StepStarted = 'StepStarted',
+  StepWaiting = 'StepWaiting'
+}
 
 export type Mutation = {
   __typename?: 'Mutation';
@@ -226,6 +253,59 @@ export type QueryFunctionRunsArgs = {
 
 export type QueryStreamArgs = {
   query: StreamQuery;
+};
+
+export type RunHistoryCancel = {
+  __typename?: 'RunHistoryCancel';
+  eventID?: Maybe<Scalars['ULID']>;
+  expression?: Maybe<Scalars['String']>;
+  userID?: Maybe<Scalars['UUID']>;
+};
+
+export type RunHistoryItem = {
+  __typename?: 'RunHistoryItem';
+  attempt: Scalars['Int'];
+  cancel?: Maybe<RunHistoryCancel>;
+  createdAt: Scalars['Time'];
+  functionVersion: Scalars['Int'];
+  groupID?: Maybe<Scalars['UUID']>;
+  id: Scalars['ULID'];
+  result?: Maybe<RunHistoryResult>;
+  sleep?: Maybe<RunHistorySleep>;
+  stepName?: Maybe<Scalars['String']>;
+  type: HistoryType;
+  url?: Maybe<Scalars['String']>;
+  waitForEvent?: Maybe<RunHistoryWaitForEvent>;
+  waitResult?: Maybe<RunHistoryWaitResult>;
+};
+
+export type RunHistoryResult = {
+  __typename?: 'RunHistoryResult';
+  durationMS: Scalars['Int'];
+  errorCode?: Maybe<Scalars['String']>;
+  framework?: Maybe<Scalars['String']>;
+  platform?: Maybe<Scalars['String']>;
+  sdkLanguage: Scalars['String'];
+  sdkVersion: Scalars['String'];
+  sizeBytes: Scalars['Int'];
+};
+
+export type RunHistorySleep = {
+  __typename?: 'RunHistorySleep';
+  until: Scalars['Time'];
+};
+
+export type RunHistoryWaitForEvent = {
+  __typename?: 'RunHistoryWaitForEvent';
+  eventName: Scalars['String'];
+  expression?: Maybe<Scalars['String']>;
+  timeout: Scalars['Time'];
+};
+
+export type RunHistoryWaitResult = {
+  __typename?: 'RunHistoryWaitResult';
+  eventID?: Maybe<Scalars['ULID']>;
+  timeout: Scalars['Boolean'];
 };
 
 export type StepEvent = {


### PR DESCRIPTION
> :warning: Stacked on $625.

## Description

- Add history reader to API.
- GraphQL
  - Replace `Int` model map with `Uint`. It was originally `Int` to allow `uint` types to map to `Int` in GraphQL. Instead, we'll use a new `Uint` scalar type (which we can map to `number` on the TypeScript side).
  - Other changes for the new history.
- Fix missing `state.DriverResponse.Output` in when status is `206`.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
