### PR TITLE
INN-2075: Add tests and additional check for invalid URIs

### DIFF
--- a/pkg/util/normalize.go
+++ b/pkg/util/normalize.go
@@ -19,6 +19,12 @@ func NormalizeAppURL(u string) string {
 		return u
 	}
 
+	// this shouldn't be valid: https://api.example.com:80/api/inngest
+	if parsed.Scheme == "https" && port != "" {
+		parsed.Host = host
+		return parsed.String()
+	}
+
 	switch host {
 	case "localhost", "127.0.0.1", "0.0.0.0":
 		parsed.Host = fmt.Sprintf("localhost:%s", port)

--- a/pkg/util/normalize_test.go
+++ b/pkg/util/normalize_test.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeAppURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputURL    string
+		expectedURL string
+	}{
+		{
+			name:        "valid URI should return without modification",
+			inputURL:    "https://api.example.com/api/inngest?fnId=hello&step=step",
+			expectedURL: "https://api.example.com/api/inngest?fnId=hello&step=step",
+		},
+		{
+			name:        "localhost related identifier should translate to 'localhost'",
+			inputURL:    "http://127.0.0.1:3000/api/inngest?fnId=hello&step=step",
+			expectedURL: "http://localhost:3000/api/inngest?fnId=hello&step=step",
+		},
+		{
+			name:        "host should not have port when using https scheme",
+			inputURL:    "https://api.example.com:80/api/inngest?fnId=hello&step=step",
+			expectedURL: "https://api.example.com/api/inngest?fnId=hello&step=step",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := NormalizeAppURL(test.inputURL)
+			require.Equal(t, test.expectedURL, result)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Seems like when trying to run Next on Netlify, there can be cases the URL submitted via registration from the SDK could include a port number even when the protocol schema is `https`.

e.g. `https://api.example.com:80/api/inngest`

Since Netlify doesn't operate like Cloudflare pages or Vercel, it requires some kind of hack to get routes working, and invalid urls like these need to be properly normalized.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
