### PR TITLE
Fix `x-inngest-req-version` not being passed from driver to executor

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -180,9 +180,10 @@ func (e executor) Execute(ctx context.Context, s state.State, item queue.Item, e
 			Step:       step,
 			Duration:   resp.duration,
 			Output:     string(resp.body),
-			OutputSize: len(resp.body),
-			NoRetry:    resp.noRetry,
-			RetryAt:    resp.retryAt,
+			OutputSize:     len(resp.body),
+			NoRetry:        resp.noRetry,
+			RetryAt:        resp.retryAt,
+			RequestVersion: resp.requestVersion,
 		}
 		dr.Generator, err = ParseGenerator(ctx, resp.body)
 		if err != nil {


### PR DESCRIPTION
## Description

Fixes `x-inngest-req-version` header not being passed back from the driver to the executor.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
