### PR TITLE
Fix completed step count not set

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -760,7 +760,7 @@ func (e *executor) Cancel(ctx context.Context, id state.Identifier, r execution.
 		return fmt.Errorf("error cancelling function: %w", err)
 	}
 
-	s, err := e.sm.Load(ctx, id.RunID)
+	s, _ := e.sm.Load(ctx, id.RunID)
 
 	for _, e := range e.lifecycles {
 		go e.OnFunctionCancelled(context.WithoutCancel(ctx), id, r, s)

--- a/pkg/execution/lifecycle.go
+++ b/pkg/execution/lifecycle.go
@@ -44,6 +44,7 @@ type LifecycleListener interface {
 		state.Identifier,
 		queue.Item,
 		state.DriverResponse,
+		state.State,
 	)
 
 	// OnFunctionCancelled is called when a function is cancelled.  This includes
@@ -53,6 +54,7 @@ type LifecycleListener interface {
 		context.Context,
 		state.Identifier,
 		CancelRequest,
+		state.State,
 	)
 
 	// OnStepScheduled is called when a new step is scheduled.  It contains the
@@ -157,6 +159,7 @@ func (NoopLifecyceListener) OnFunctionFinished(
 	state.Identifier,
 	queue.Item,
 	state.DriverResponse,
+	state.State,
 ) {
 }
 
@@ -167,6 +170,7 @@ func (NoopLifecyceListener) OnFunctionCancelled(
 	context.Context,
 	state.Identifier,
 	CancelRequest,
+	state.State,
 ) {
 }
 


### PR DESCRIPTION
## Description

Fix `History.CompletedStepCount` not set in the run end lifecycle methods.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
