### PR TITLE
INN 2085 Handle large payloads in code blocks

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@headlessui/react": "1.7.17",
     "@headlessui/tailwindcss": "0.1.2",
-    "@monaco-editor/react": "4.4.6",
+    "@monaco-editor/react": "4.5.2",
     "@radix-ui/react-accordion": "1.1.2",
     "@radix-ui/react-select": "1.2.2",
     "@radix-ui/react-tooltip": "1.0.6",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -12,8 +12,8 @@ dependencies:
     specifier: 0.1.2
     version: 0.1.2(tailwindcss@3.3.3)
   '@monaco-editor/react':
-    specifier: 4.4.6
-    version: 4.4.6(monaco-editor@0.34.1)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 4.5.2
+    version: 4.5.2(monaco-editor@0.34.1)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-accordion':
     specifier: 1.1.2
     version: 1.1.2(@types/react-dom@18.0.10)(@types/react@18.0.27)(react-dom@18.2.0)(react@18.2.0)
@@ -2903,8 +2903,8 @@ packages:
       state-local: 1.0.7
     dev: false
 
-  /@monaco-editor/react@4.4.6(monaco-editor@0.34.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-Gr3uz3LYf33wlFE3eRnta4RxP5FSNxiIV9ENn2D2/rN8KgGAD8ecvcITRtsbbyuOuNkwbuHYxfeaz2Vr+CtyFA==}
+  /@monaco-editor/react@4.5.2(monaco-editor@0.34.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-emcWu6vg1OpXPiYll4aPOaXe8bwYB4UaaNTwtArFLgMoNGBzRZb2Xn0Bra2HMIFM7QLgs7fCGunHO5LkfT2LBA==}
     peerDependencies:
       monaco-editor: '>= 0.25.0 < 1'
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -2912,7 +2912,6 @@ packages:
     dependencies:
       '@monaco-editor/loader': 1.3.3(monaco-editor@0.34.1)
       monaco-editor: 0.34.1
-      prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false

--- a/ui/src/components/Code/CodeBlock.stories.tsx
+++ b/ui/src/components/Code/CodeBlock.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import CodeBlock from './CodeBlock';
+
+const meta = {
+  title: 'Components/CodeBlock',
+  component: CodeBlock,
+  decorators: [
+    (Story) => (
+      <div className="w-80">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof CodeBlock>;
+
+export default meta;
+
+type Story = StoryObj<typeof CodeBlock>;
+
+export const Default: Story = {
+  args: {
+    tabs: [
+      {
+        label: 'Output',
+        content: '{\n  "customerId": "cus_1234"\n}',
+      },
+    ],
+  },
+};
+
+export const MultipleTabs: Story = {
+  args: {
+    tabs: [
+      {
+        label: 'Output',
+        content: '{\n  "customerId": "cus_1234"\n}',
+      },
+      {
+        label: 'Error',
+        content: '{\n  "error": "invalid status code: 500"\n}',
+      },
+    ],
+  },
+};

--- a/ui/src/components/Code/CodeBlock.tsx
+++ b/ui/src/components/Code/CodeBlock.tsx
@@ -96,61 +96,50 @@ export default function CodeBlock({ tabs }: CodeBlockProps) {
         </div>
       </div>
       <div>
-        {monaco &&
-          tabs.map((tab, i) => (
-            <div
-              className={classNames(
-                i === activeTab ? ` ` : `opacity-0 pointer-events-none`,
-                `col-start-1 row-start-1 transition-all duration-150`,
-              )}
-            >
-              <Editor
-                defaultLanguage="json"
-                value={tabs[i].content}
-                theme="inngest-theme"
-                options={{
-                  readOnly: true,
-                  minimap: {
-                    enabled: false,
-                  },
-                  lineNumbers: 'on',
-                  extraEditorClassName: '',
-                  contextmenu: false,
-                  scrollBeyondLastLine: false,
-                  wordWrap: 'on',
-                  fontFamily: 'Roboto_Mono',
-                  fontSize: 13,
-                  fontWeight: 'light',
-                  lineHeight: 26,
-                  renderLineHighlight: 'none', // no line selected borders being shown
-                  renderWhitespace: 'none', // no indentation spaces being shown
-                  guides: {
-                    indentation: false, // no indentation vertical lines being shown
-                    highlightActiveBracketPair: false,
-                    highlightActiveIndentation: false,
-                  },
-                  scrollbar: { verticalScrollbarSize: 10 },
-                  padding: {
-                    top: 10,
-                    bottom: 10,
-                  },
-                }}
-                onMount={(editor) => {
-                  const numberOfLines = editor.getModel()?.getLineCount();
-                  // To do: should calculate with getContentHeight instead of number of lines but for some reason the value is wrong
-                  if (numberOfLines && numberOfLines <= 10) {
-                    // If there are 10 or fewer lines, set the editor's height to the content height
-                    const contentHeight = numberOfLines * 26 + 20;
-                    editor.layout({ height: contentHeight, width: 0 });
-                  } else {
-                    // If there are more than 10 lines, set a fixed height with a scrollbar
-                    const fixedHeight = 10 * 26 + 20;
-                    editor.layout({ height: fixedHeight, width: 0 });
-                  }
-                }}
-              />
-            </div>
-          ))}
+        {monaco && (
+          <Editor
+            defaultLanguage="json"
+            value={tabs[activeTab].content}
+            theme="inngest-theme"
+            options={{
+              readOnly: true,
+              minimap: {
+                enabled: false,
+              },
+              lineNumbers: 'on',
+              extraEditorClassName: '',
+              contextmenu: false,
+              scrollBeyondLastLine: false,
+              wordWrap: 'on',
+              fontFamily: 'Roboto_Mono',
+              fontSize: 13,
+              fontWeight: 'light',
+              lineHeight: 26,
+              renderLineHighlight: 'none',
+              renderWhitespace: 'none',
+              guides: {
+                indentation: false,
+                highlightActiveBracketPair: false,
+                highlightActiveIndentation: false,
+              },
+              scrollbar: { verticalScrollbarSize: 10 },
+              padding: {
+                top: 10,
+                bottom: 10,
+              },
+            }}
+            onMount={(editor) => {
+              const numberOfLines = editor.getModel()?.getLineCount();
+              if (numberOfLines && numberOfLines <= 10) {
+                const contentHeight = numberOfLines * 26 + 20;
+                editor.layout({ height: contentHeight, width: 0 });
+              } else {
+                const fixedHeight = 10 * 26 + 20;
+                editor.layout({ height: fixedHeight, width: 0 });
+              }
+            }}
+          />
+        )}
       </div>
     </div>
   );

--- a/ui/src/components/Code/CodeBlock.tsx
+++ b/ui/src/components/Code/CodeBlock.tsx
@@ -2,7 +2,10 @@ import { useEffect, useState } from 'react';
 import Editor, { useMonaco } from '@monaco-editor/react';
 
 import useCopyToClipboard from '@/hooks/useCopyToClipboard';
-import classNames from '../../utils/classnames';
+import { IconArrayDownTray } from '@/icons';
+import classNames from '@/utils/classnames';
+import { maxRenderedOutputSizeBytes } from '@/utils/constants';
+import Button from '../Button/Button';
 import CopyButton from '../Button/CopyButton';
 
 interface CodeBlockProps {
@@ -60,8 +63,28 @@ export default function CodeBlock({ tabs }: CodeBlockProps) {
     setActiveTab(index);
   };
 
+  let isOutputTooLarge;
+  if (tabs[activeTab].content.length > maxRenderedOutputSizeBytes) {
+    isOutputTooLarge = true;
+  } else {
+    isOutputTooLarge = false;
+  }
+
+  const downloadJson = ({ content }) => {
+    const jsonContent = JSON.stringify(JSON.parse(content), null, 2); // Parse and stringify for pretty formatting
+    const blob = new Blob([jsonContent], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const element = document.createElement('a');
+    element.href = url;
+    element.download = 'data.json'; // Set the file name with a .json extension
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+    URL.revokeObjectURL(url);
+  };
+
   return (
-    <div className="w-full bg-slate-800/30 border border-slate-700/30 rounded-lg shadow overflow-hidden">
+    <div className="w-full bg-slate-800/40 border border-slate-700/30 rounded-lg shadow overflow-hidden">
       <div className="bg-slate-800/40 flex justify-between shadow border-b border-slate-700/20">
         <div className="flex -mb-px">
           {tabs.map((tab, i) => (
@@ -87,60 +110,77 @@ export default function CodeBlock({ tabs }: CodeBlockProps) {
             </>
           ))}
         </div>
-        <div className="flex gap-2 items-center mr-2">
-          <CopyButton
-            code={tabs[activeTab].content}
-            isCopying={isCopying}
-            handleCopyClick={handleCopyClick}
-          />
-        </div>
-      </div>
-      <div>
-        {monaco && (
-          <Editor
-            defaultLanguage="json"
-            value={tabs[activeTab].content}
-            theme="inngest-theme"
-            options={{
-              readOnly: true,
-              minimap: {
-                enabled: false,
-              },
-              lineNumbers: 'on',
-              extraEditorClassName: '',
-              contextmenu: false,
-              scrollBeyondLastLine: false,
-              wordWrap: 'on',
-              fontFamily: 'Roboto_Mono',
-              fontSize: 13,
-              fontWeight: 'light',
-              lineHeight: 26,
-              renderLineHighlight: 'none',
-              renderWhitespace: 'none',
-              guides: {
-                indentation: false,
-                highlightActiveBracketPair: false,
-                highlightActiveIndentation: false,
-              },
-              scrollbar: { verticalScrollbarSize: 10 },
-              padding: {
-                top: 10,
-                bottom: 10,
-              },
-            }}
-            onMount={(editor) => {
-              const numberOfLines = editor.getModel()?.getLineCount();
-              if (numberOfLines && numberOfLines <= 10) {
-                const contentHeight = numberOfLines * 26 + 20;
-                editor.layout({ height: contentHeight, width: 0 });
-              } else {
-                const fixedHeight = 10 * 26 + 20;
-                editor.layout({ height: fixedHeight, width: 0 });
-              }
-            }}
-          />
+        {!isOutputTooLarge && (
+          <div className="flex gap-2 items-center mr-2">
+            <CopyButton
+              code={tabs[activeTab].content}
+              isCopying={isCopying}
+              handleCopyClick={handleCopyClick}
+            />
+          </div>
         )}
       </div>
+      {isOutputTooLarge ? (
+        <>
+          <div className="px-5 py-2.5 text-3xs bg-amber-500/40 text-white">
+            Output size is too large to render {`( > 1MB )`}
+          </div>
+          <div className="h-24 flex items-center justify-center	">
+            <Button
+              label="Download Raw"
+              icon={<IconArrayDownTray />}
+              btnAction={() => downloadJson({ content: tabs[activeTab].content })}
+            />
+          </div>
+        </>
+      ) : (
+        <div>
+          {monaco && (
+            <Editor
+              defaultLanguage="json"
+              value={tabs[activeTab].content}
+              theme="inngest-theme"
+              options={{
+                readOnly: true,
+                minimap: {
+                  enabled: false,
+                },
+                lineNumbers: 'on',
+                extraEditorClassName: '',
+                contextmenu: false,
+                scrollBeyondLastLine: false,
+                wordWrap: 'on',
+                fontFamily: 'Roboto_Mono',
+                fontSize: 13,
+                fontWeight: 'light',
+                lineHeight: 26,
+                renderLineHighlight: 'none',
+                renderWhitespace: 'none',
+                guides: {
+                  indentation: false,
+                  highlightActiveBracketPair: false,
+                  highlightActiveIndentation: false,
+                },
+                scrollbar: { verticalScrollbarSize: 10 },
+                padding: {
+                  top: 10,
+                  bottom: 10,
+                },
+              }}
+              onMount={(editor) => {
+                const numberOfLines = editor.getModel()?.getLineCount();
+                if (numberOfLines && numberOfLines <= 10) {
+                  const contentHeight = numberOfLines * 26 + 20;
+                  editor.layout({ height: contentHeight, width: 0 });
+                } else {
+                  const fixedHeight = 10 * 26 + 20;
+                  editor.layout({ height: fixedHeight, width: 0 });
+                }
+              }}
+            />
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/src/icons/ArrayDownTray.tsx
+++ b/ui/src/icons/ArrayDownTray.tsx
@@ -1,0 +1,18 @@
+export function IconArrayDownTray({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      height="16"
+      width="16"
+    >
+      <path
+        fillRule="evenodd"
+        d="M12 2.25a.75.75 0 01.75.75v11.69l3.22-3.22a.75.75 0 111.06 1.06l-4.5 4.5a.75.75 0 01-1.06 0l-4.5-4.5a.75.75 0 111.06-1.06l3.22 3.22V3a.75.75 0 01.75-.75zm-9 13.5a.75.75 0 01.75.75v2.25a1.5 1.5 0 001.5 1.5h13.5a1.5 1.5 0 001.5-1.5V16.5a.75.75 0 011.5 0v2.25a3 3 0 01-3 3H5.25a3 3 0 01-3-3V16.5a.75.75 0 01.75-.75z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}

--- a/ui/src/icons/index.tsx
+++ b/ui/src/icons/index.tsx
@@ -19,6 +19,7 @@ export { IconWebhook } from './Webhook';
 export { IconMagnifyingGlass } from './MagnifyingGlass';
 export { IconCheck } from './Check';
 export { IconInfo } from './Info';
+export { IconArrayDownTray } from './ArrayDownTray';
 
 // Circle Status Icons
 export { IconStatusCircleCheck } from './StatusCircleCheck';

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -1,0 +1,1 @@
+export const maxRenderedOutputSizeBytes = 1024 * 1024;


### PR DESCRIPTION
## Description

- Download JSON outputs > 1MB instead of rendering them
- Fix code block styles to render multiple tabs properly
<img width="588" alt="Screenshot 2023-09-28 at 00 24 50" src="https://github.com/inngest/inngest/assets/16758464/692e8064-f53b-4458-8b03-03d1e5279d26">

https://github.com/inngest/inngest/assets/16758464/36bbcffc-519d-4203-a506-2ee189b3cb0a


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
