### PR TITLE
INN-2090: Replace MaxBatchSize with DefaultBatchSize to make it more configurable

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -45,8 +45,8 @@ const (
 	// when using idempotency keys.
 	FunctionIdempotencyPeriod = 24 * time.Hour
 
-	MaxBatchSize    = 100
-	MaxBatchTimeout = 60 * time.Second
+	DefaultBatchSize = 100
+	MaxBatchTimeout  = 60 * time.Second
 	// MaxEvents is the maximum number of events we can parse in a single batch.
 	MaxEvents = 5_000
 

--- a/pkg/inngest/batch.go
+++ b/pkg/inngest/batch.go
@@ -23,8 +23,8 @@ func NewEventBatchConfig(conf map[string]any) (*EventBatchConfig, error) {
 		return nil, fmt.Errorf("failed to decode batch config: %v", err)
 	}
 
-	if config.MaxSize > consts.MaxBatchSize {
-		config.MaxSize = consts.MaxBatchSize
+	if config.MaxSize <= 0 {
+		config.MaxSize = consts.DefaultBatchSize
 	}
 
 	dur, err := time.ParseDuration(config.Timeout)

--- a/pkg/inngest/batch_test.go
+++ b/pkg/inngest/batch_test.go
@@ -27,14 +27,14 @@ func TestNewEventBatchConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "should return allowed max values if config is over allowed values",
+			name: "should use default batch size if provided value is <= 0",
 			data: map[string]any{
-				"maxSize": 1000,
-				"timeout": "10m",
+				"maxSize": -1,
+				"timeout": "2s",
 			},
 			expected: &EventBatchConfig{
-				MaxSize: consts.MaxBatchSize,
-				Timeout: "60s",
+				MaxSize: consts.DefaultBatchSize,
+				Timeout: "2s",
 			},
 		},
 		{


### PR DESCRIPTION
## Description

The maximum batch size is currently hardcoded into the system.
Removing this limit and make it more configurable for the user. The limit can be adjusted on the service.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
