### PR TITLE
Adjust monaco code block heights

### DIFF
--- a/ui/src/components/Code/CodeBlock.tsx
+++ b/ui/src/components/Code/CodeBlock.tsx
@@ -144,7 +144,6 @@ export default function CodeBlock({ tabs }: CodeBlockProps) {
                 extraEditorClassName: '',
                 contextmenu: false,
                 scrollBeyondLastLine: false,
-                wordWrap: 'on',
                 fontFamily: 'Roboto_Mono',
                 fontSize: 13,
                 fontWeight: 'light',
@@ -163,14 +162,13 @@ export default function CodeBlock({ tabs }: CodeBlockProps) {
                 },
               }}
               onMount={(editor) => {
-                const numberOfLines = editor.getModel()?.getLineCount();
-                if (numberOfLines && numberOfLines <= 10) {
-                  const contentHeight = numberOfLines * 26 + 20;
-                  editor.layout({ height: contentHeight, width: 0 });
+                const contentHeight = editor.getContentHeight();
+                if (contentHeight > 295) {
+                  editor.layout({ height: 295, width: 0 });
                 } else {
-                  const fixedHeight = 10 * 26 + 20;
-                  editor.layout({ height: fixedHeight, width: 0 });
+                  editor.layout({ height: contentHeight, width: 0 });
                 }
+                editor.updateOptions({ wordWrap: 'on' });
               }}
             />
           )}


### PR DESCRIPTION
## Description

Adjust monaco editor code block heights.
`editor.getContentHeight` only works well if `wordWrap: 'off'`, so we're setting `wordWrap: 'on'` after calculating the height of original content.

Note: this is not the final version but it gets us one step closer to it. Still needs some logic to handle single line with wordWrap better.

![Screenshot 2023-10-02 at 14 30 49](https://github.com/inngest/inngest/assets/16758464/2a59d0a1-b806-4cbc-b78e-bfb5da5c18b3)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
