### PR TITLE
Stop nesting function output in "body" field

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -177,9 +177,9 @@ func (e executor) Execute(ctx context.Context, s state.State, item queue.Item, e
 	if resp.statusCode == 206 {
 		// This is a generator-based function returning opcodes.
 		dr := &state.DriverResponse{
-			Step:       step,
-			Duration:   resp.duration,
-			Output:     string(resp.body),
+			Step:           step,
+			Duration:       resp.duration,
+			Output:         string(resp.body),
 			OutputSize:     len(resp.body),
 			NoRetry:        resp.noRetry,
 			RetryAt:        resp.retryAt,
@@ -227,17 +227,15 @@ func (e executor) Execute(ctx context.Context, s state.State, item queue.Item, e
 	}
 
 	return &state.DriverResponse{
-		Step: step,
-		Output: map[string]interface{}{
-			"status": resp.statusCode,
-			"body":   body,
-		},
+		Step:           step,
+		Output:         body,
 		Err:            errstr,
 		Duration:       resp.duration,
 		OutputSize:     len(resp.body),
 		NoRetry:        resp.noRetry,
 		RetryAt:        resp.retryAt,
 		RequestVersion: resp.requestVersion,
+		StatusCode:     resp.statusCode,
 	}, nil
 }
 

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -10,6 +10,7 @@ import (
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/xhit/go-str2duration/v2"
+	"golang.org/x/exp/slog"
 )
 
 const DefaultErrorMessage = "Unknown error running SDK"
@@ -208,6 +209,8 @@ type DriverResponse struct {
 	//
 	// When final is true, Retryable() always returns false.
 	final bool
+
+	StatusCode int `json:"statusCode,omitempty"`
 }
 
 // SetFinal indicates that this error is final, regardless of the status code
@@ -266,32 +269,35 @@ func (r DriverResponse) Retryable() bool {
 		return true
 	}
 
-	status, ok := mapped["status"]
-	if !ok {
+	var status int
+	if r.StatusCode == 0 {
 		// Fall back to statusCode for AWS Lambda compatibility in
 		// an attempt to use this field.
-		status, ok = mapped["statusCode"]
+		v, ok := mapped["statusCode"]
 		if !ok {
 			// If actions don't return a status, we assume that they're
-			// always retryable.  We prefer that actions respond with a
-			// { "status": xxx, "body": ... } format to disable retries.
+			// always retryable.
 			return true
+		}
+
+		switch v := v.(type) {
+		case float64, int64, int:
+			status = int(v.(float64))
+		default:
+			slog.Default().Error(
+				"unexpected status code type",
+				"type", fmt.Sprintf("%T", v),
+			)
 		}
 	}
 
-	switch v := status.(type) {
-	case float64:
-		if int(v) > 499 {
-			return true
-		}
-	case int64:
-		if int(v) > 499 {
-			return true
-		}
-	case int:
-		if int(v) > 499 {
-			return true
-		}
+	if status == 0 {
+		slog.Default().Error("missing status code")
+		return true
+	}
+
+	if status > 499 {
+		return true
 	}
 
 	return false

--- a/ui/src/app/(dashboard)/stream/OutputList.tsx
+++ b/ui/src/app/(dashboard)/stream/OutputList.tsx
@@ -1,6 +1,6 @@
   import {
     useGetFunctionRunOutputQuery,
-    type FunctionRun,
+    FunctionRunStatus,
   } from '@/store/generated';
   
   export default function OutputList({ functionRuns }) {
@@ -22,17 +22,15 @@
     );
   }
   
-  type FunctionRunStatusSubset = Pick<FunctionRun, 'id' | 'output'>;
-  
   export function OutputItem({ functionRunID }) {
     const { data } = useGetFunctionRunOutputQuery({ id: functionRunID }, { pollingInterval: 1500 });
-    const functionRun = (data?.functionRun as FunctionRunStatusSubset) || {};
+    const {functionRun} = data ?? {}
   
     if (!functionRun || !functionRun?.output) {
       return null;
     }
     const parsedOutput = JSON.parse(functionRun.output)
-    const wasSuccessful = parsedOutput.body?.success || (parsedOutput.status.toString().startsWith('2'));
+    const wasSuccessful = functionRun.status === FunctionRunStatus.Completed
   
     return (
       <li key={functionRun?.id} data-key={functionRun?.id} className="flex gap-2 font-mono">
@@ -41,4 +39,3 @@
       </li>
     );
   }
-  

--- a/ui/src/coreapi.ts
+++ b/ui/src/coreapi.ts
@@ -186,6 +186,7 @@ export const FUNCTION_RUN_OUTPUT = gql`
     functionRun(query: { functionRunId: $id }) {
       id
       output
+      status
     }
   }
 `;

--- a/ui/src/store/generated.ts
+++ b/ui/src/store/generated.ts
@@ -442,7 +442,7 @@ export type GetFunctionRunOutputQueryVariables = Exact<{
 }>;
 
 
-export type GetFunctionRunOutputQuery = { __typename?: 'Query', functionRun?: { __typename?: 'FunctionRun', id: string, output?: string | null } | null };
+export type GetFunctionRunOutputQuery = { __typename?: 'Query', functionRun?: { __typename?: 'FunctionRun', id: string, output?: string | null, status?: FunctionRunStatus | null } | null };
 
 
 export const GetEventsStreamDocument = `
@@ -620,6 +620,7 @@ export const GetFunctionRunOutputDocument = `
   functionRun(query: {functionRunId: $id}) {
     id
     output
+    status
   }
 }
     `;


### PR DESCRIPTION
## Description

Stop nesting function output in `body` field within `DriverResponse.Output`.

Before this change, returning `"hi"` in a function resulted in this output:
```json
{
  "body": "\"hi\"",
  "status": 200
}
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
