### PR TITLE
Fix non-unique group IDs in parallel steps

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -878,7 +878,13 @@ func (e *executor) HandleGeneratorResponse(ctx context.Context, resp *state.Driv
 	eg := errgroup.Group{}
 	for _, op := range resp.Generator {
 		copied := *op
-		eg.Go(func() error { return e.HandleGenerator(ctx, copied, item) })
+
+		// Give each op its own group ID, as we want to track each step
+		// individually.
+		newItem := item
+		newItem.GroupID = uuid.New().String()
+
+		eg.Go(func() error { return e.HandleGenerator(ctx, copied, newItem) })
 	}
 
 	return eg.Wait()


### PR DESCRIPTION
## Description

Fix non-unique group IDs when performing parallel waits/sleeps. For example, both steps in this function would have the same group ID:
```ts
inngest.createFunction(
  { name: "Send Welcome Email" },
  { event: "app/account.created" },
  async ({ event, step }) => {
    await Promise.all([
      step.waitForEvent("foo", "10s"),
      step.waitForEvent("bar", "10s"),
    ]);
  }
);
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
