### PR TITLE
Add sleeping and waiting summary cards

### DIFF
--- a/ui/.storybook/preview.ts
+++ b/ui/.storybook/preview.ts
@@ -20,6 +20,11 @@ const preview: Preview = {
         date: /Date$/,
       },
     },
+    options: {
+      storySort: {
+        method: 'alphabetical',
+      },
+    },
   },
 };
 

--- a/ui/src/components/Function/RunSection.tsx
+++ b/ui/src/components/Function/RunSection.tsx
@@ -20,6 +20,9 @@ import TimelineRow from '../Timeline/TimelineRow';
 import renderRunMetadata from './RunMetadataRenderer';
 import RunOutputCard from './RunOutput';
 import { FunctionRunStatusIcons } from './RunStatusIcons';
+import { useParsedHistory } from '../TimelineV2/historyParser/useParsedHistory';
+import { WaitingSummary } from './WaitingSummary';
+import { SleepingSummary } from './SleepingSummary';
 
 interface FunctionRunSectionProps {
   runId: string | null | undefined;
@@ -35,6 +38,7 @@ export const FunctionRunSection = ({ runId }: FunctionRunSectionProps) => {
   const timeline = useMemo(() => normalizeSteps(run?.timeline || null), [run]);
   const selectedEvent = useAppSelector((state) => state.global.selectedEvent);
   const dispatch = useAppDispatch();
+  const history = useParsedHistory(run?.history ?? [])
 
   useEffect(() => {
     if (!run?.event?.id) {
@@ -80,11 +84,15 @@ export const FunctionRunSection = ({ runId }: FunctionRunSectionProps) => {
         </div>
       }
     >
-      {run.status && run.finishedAt && run.output && (
-        <div className="px-5 pt-4">
-          <RunOutputCard functionRun={run} />
-        </div>
-      )}
+      <div className="px-5 pt-4">
+        {run.status && run.finishedAt && run.output && (
+            <RunOutputCard functionRun={run} />
+        )}
+
+        <WaitingSummary history={history} />
+        <SleepingSummary history={history} />
+      </div>
+
       <hr className="border-slate-800/50 mt-8" />
       <div className="px-5 pt-4">
         <h3 className="text-slate-400 text-sm py-4">Timeline</h3>

--- a/ui/src/components/Function/SleepingSummary.stories.tsx
+++ b/ui/src/components/Function/SleepingSummary.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { SleepingSummary } from './SleepingSummary';
+
+const meta = {
+  title: 'Components/SleepingSummary',
+  component: SleepingSummary,
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ width: 600 }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof SleepingSummary>;
+
+export default meta;
+
+type Story = StoryObj<typeof SleepingSummary>;
+
+const second = 1000;
+const minute = 60 * second;
+
+const baseSleepNode = {
+  attempt: 0,
+  groupID: 'a',
+  scheduledAt: new Date(),
+  sleepConfig: {
+    until: new Date(Date.now() + minute),
+  },
+  status: 'sleeping',
+} as const;
+
+export const OneSleep: Story = {
+  args: {
+    history: {
+      a: baseSleepNode,
+    },
+  },
+};
+
+export const TwoSleeps: Story = {
+  args: {
+    history: {
+      a: {
+        ...baseSleepNode,
+      },
+      b: {
+        ...baseSleepNode,
+        groupID: 'b',
+      },
+    },
+  },
+};

--- a/ui/src/components/Function/SleepingSummary.tsx
+++ b/ui/src/components/Function/SleepingSummary.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+
+import MetadataItem from '../Metadata/MetadataItem';
+import type { HistoryNode } from '../TimelineV2/historyParser';
+import { StateSummaryCard } from './StateSummaryCard';
+
+type Props = {
+  history: Record<string, HistoryNode>;
+};
+
+export function SleepingSummary({ history }: Props) {
+  const sleeps = useActiveSleeps(history);
+
+  if (sleeps.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {sleeps.map((sleep, i) => {
+        const config = sleep.sleepConfig;
+        if (!config) {
+          // Should be unreachable but our types don't reflect that.
+          return null;
+        }
+
+        return (
+          <StateSummaryCard
+            className={i < sleeps.length - 1 ? 'mb-4' : undefined}
+            key={sleep.groupID}
+          >
+            <StateSummaryCard.Header barColor="#38BDF8">Sleeping</StateSummaryCard.Header>
+
+            <StateSummaryCard.Content>
+              <MetadataItem label="Sleep until" value={config.until.toLocaleString()} />
+            </StateSummaryCard.Content>
+          </StateSummaryCard>
+        );
+      })}
+    </>
+  );
+}
+
+function useActiveSleeps(history: Record<string, HistoryNode>): HistoryNode[] {
+  const [nodes, setNodes] = useState<HistoryNode[]>([]);
+
+  useEffect(() => {
+    const newWaits: HistoryNode[] = [];
+    for (const node of Object.values(history)) {
+      if (node.status === 'sleeping') {
+        newWaits.push(node);
+      }
+    }
+    setNodes(newWaits);
+  }, [history]);
+
+  return nodes;
+}

--- a/ui/src/components/Function/StateSummaryCard.tsx
+++ b/ui/src/components/Function/StateSummaryCard.tsx
@@ -1,0 +1,33 @@
+import { type PropsWithChildren } from 'react';
+
+import classNames from '@/utils/classnames';
+
+export function StateSummaryCard({
+  children,
+  className,
+}: PropsWithChildren<{ className?: string }>) {
+  return (
+    <div className={classNames('w-full bg-slate-950 rounded-lg shadow overflow-hidden', className)}>
+      {children}
+    </div>
+  );
+}
+
+StateSummaryCard.Content = function Content({ children }: PropsWithChildren) {
+  return <div className="p-2.5">{children}</div>;
+};
+
+StateSummaryCard.Header = function Content({
+  children,
+  barColor,
+}: PropsWithChildren<{ barColor?: string }>) {
+  return (
+    <>
+      <div className="pt-3" style={{ backgroundColor: barColor }}></div>
+
+      <div className="flex flex-col gap-1 px-5 py-3 border-b border-slate-700/30 text-white">
+        {children}
+      </div>
+    </>
+  );
+};

--- a/ui/src/components/Function/WaitingSummary.stories.tsx
+++ b/ui/src/components/Function/WaitingSummary.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { WaitingSummary } from './WaitingSummary';
+
+const meta = {
+  title: 'Components/WaitingSummary',
+  component: WaitingSummary,
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ width: 600 }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof WaitingSummary>;
+
+export default meta;
+
+type Story = StoryObj<typeof WaitingSummary>;
+
+const second = 1000;
+const minute = 60 * second;
+
+const baseWaitNode = {
+  attempt: 0,
+  groupID: 'a',
+  scheduledAt: new Date(),
+  status: 'waiting',
+  waitForEventConfig: {
+    eventName: 'app/MyEvent',
+    expression: 'async.data.foo == event.data.foo',
+    timeout: new Date(Date.now() + minute),
+  },
+} as const;
+
+export const OneWait: Story = {
+  args: {
+    history: {
+      a: baseWaitNode,
+    },
+  },
+};
+
+export const TwoWaits: Story = {
+  args: {
+    history: {
+      a: {
+        ...baseWaitNode,
+      },
+      b: {
+        ...baseWaitNode,
+        groupID: 'b',
+      },
+    },
+  },
+};

--- a/ui/src/components/Function/WaitingSummary.tsx
+++ b/ui/src/components/Function/WaitingSummary.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+
+import { IconEvent } from '@/icons';
+import MetadataItem from '../Metadata/MetadataItem';
+import type { HistoryNode } from '../TimelineV2/historyParser';
+import { StateSummaryCard } from './StateSummaryCard';
+
+type Props = {
+  history: Record<string, HistoryNode>;
+};
+
+export function WaitingSummary({ history }: Props) {
+  const waits = useActiveWaits(history);
+
+  if (waits.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {waits.map((wait, i) => {
+        const config = wait.waitForEventConfig;
+        if (!config) {
+          // Should be unreachable but our types don't reflect that.
+          return null;
+        }
+
+        return (
+          <StateSummaryCard
+            className={i < waits.length - 1 ? 'mb-4' : undefined}
+            key={wait.groupID}
+          >
+            <StateSummaryCard.Header barColor="#38BDF8">Waiting for event</StateSummaryCard.Header>
+
+            <StateSummaryCard.Content>
+              <MetadataItem
+                label="Event name"
+                value={
+                  <>
+                    <IconEvent className="inline-block" /> {config.eventName}
+                  </>
+                }
+              />
+
+              <MetadataItem
+                label="Match expression"
+                type="code"
+                value={config.expression ?? 'N/A'}
+              />
+
+              <MetadataItem label="Timeout" value={config.timeout.toLocaleString()} />
+            </StateSummaryCard.Content>
+          </StateSummaryCard>
+        );
+      })}
+    </>
+  );
+}
+
+function useActiveWaits(history: Record<string, HistoryNode>): HistoryNode[] {
+  const [waits, setWaits] = useState<HistoryNode[]>([]);
+
+  useEffect(() => {
+    const newWaits: HistoryNode[] = [];
+    for (const node of Object.values(history)) {
+      if (node.status === 'waiting') {
+        newWaits.push(node);
+      }
+    }
+    setWaits(newWaits);
+  }, [history]);
+
+  return waits;
+}

--- a/ui/src/components/Metadata/MetadataItem.tsx
+++ b/ui/src/components/Metadata/MetadataItem.tsx
@@ -3,9 +3,9 @@ import { IconInfo } from '@/icons';
 import classNames from '@/utils/classnames';
 
 export type MetadataItemProps = {
-  label: String;
-  value: String;
-  tooltip?: String;
+  label: string;
+  value: string | JSX.Element;
+  tooltip?: string;
   type?: 'code' | 'text';
   size?: 'small' | 'large';
 };

--- a/ui/src/components/TimelineV2/historyParser/useParsedHistory.ts
+++ b/ui/src/components/TimelineV2/historyParser/useParsedHistory.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+import type { RunHistoryItem } from '@/store/generated';
+import { HistoryParser } from './historyParser';
+import type { HistoryNode } from './types';
+
+export function useParsedHistory(rawHistory: RunHistoryItem[]): Record<string, HistoryNode> {
+  const [history, setHistory] = useState<Record<string, HistoryNode>>({});
+
+  useEffect(() => {
+    if (rawHistory.length === 0) {
+      if (Object.keys(history).length > 0) {
+        setHistory({});
+      }
+
+      // Return early to prevent infinite rerendering when consumers default
+      // the rawHistory param to an empty array.
+      return;
+    }
+
+    setHistory(new HistoryParser(rawHistory).history);
+  }, [rawHistory]);
+
+  return history;
+}

--- a/ui/src/coreapi.ts
+++ b/ui/src/coreapi.ts
@@ -91,6 +91,33 @@ export const FUNCTION_RUN = gql`
           output
         }
       }
+      history {
+        attempt
+        cancel {
+          eventID
+          expression
+          userID
+        }
+        createdAt
+        functionVersion
+        groupID
+        id
+        sleep {
+          until
+        }
+        stepName
+        type
+        url
+        waitForEvent {
+          eventName
+          expression
+          timeout
+        }
+        waitResult {
+          eventID
+          timeout
+        }
+      }
     }
   }
 `;

--- a/ui/src/store/generated.ts
+++ b/ui/src/store/generated.ts
@@ -388,7 +388,7 @@ export type GetFunctionRunQueryVariables = Exact<{
 }>;
 
 
-export type GetFunctionRunQuery = { __typename?: 'Query', functionRun?: { __typename?: 'FunctionRun', id: string, name?: string | null, status?: FunctionRunStatus | null, startedAt?: any | null, finishedAt?: any | null, output?: string | null, pendingSteps?: number | null, waitingFor?: { __typename?: 'StepEventWait', expiryTime: any, eventName?: string | null, expression?: string | null } | null, event?: { __typename?: 'Event', id: string, raw?: string | null } | null, timeline?: Array<{ __typename: 'FunctionEvent', createdAt?: any | null, output?: string | null, functionType?: FunctionEventType | null } | { __typename: 'StepEvent', createdAt?: any | null, output?: string | null, name?: string | null, stepType?: StepEventType | null, waitingFor?: { __typename?: 'StepEventWait', expiryTime: any, eventName?: string | null, expression?: string | null } | null }> | null } | null };
+export type GetFunctionRunQuery = { __typename?: 'Query', functionRun?: { __typename?: 'FunctionRun', id: string, name?: string | null, status?: FunctionRunStatus | null, startedAt?: any | null, finishedAt?: any | null, output?: string | null, pendingSteps?: number | null, waitingFor?: { __typename?: 'StepEventWait', expiryTime: any, eventName?: string | null, expression?: string | null } | null, event?: { __typename?: 'Event', id: string, raw?: string | null } | null, timeline?: Array<{ __typename: 'FunctionEvent', createdAt?: any | null, output?: string | null, functionType?: FunctionEventType | null } | { __typename: 'StepEvent', createdAt?: any | null, output?: string | null, name?: string | null, stepType?: StepEventType | null, waitingFor?: { __typename?: 'StepEventWait', expiryTime: any, eventName?: string | null, expression?: string | null } | null }> | null, history: Array<{ __typename?: 'RunHistoryItem', attempt: number, createdAt: any, functionVersion: number, groupID?: any | null, id: any, stepName?: string | null, type: HistoryType, url?: string | null, cancel?: { __typename?: 'RunHistoryCancel', eventID?: any | null, expression?: string | null, userID?: any | null } | null, sleep?: { __typename?: 'RunHistorySleep', until: any } | null, waitForEvent?: { __typename?: 'RunHistoryWaitForEvent', eventName: string, expression?: string | null, timeout: any } | null, waitResult?: { __typename?: 'RunHistoryWaitResult', eventID?: any | null, timeout: boolean } | null }> } | null };
 
 export type GetFunctionsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -531,6 +531,33 @@ export const GetFunctionRunDocument = `
         functionType: type
         createdAt
         output
+      }
+    }
+    history {
+      attempt
+      cancel {
+        eventID
+        expression
+        userID
+      }
+      createdAt
+      functionVersion
+      groupID
+      id
+      sleep {
+        until
+      }
+      stepName
+      type
+      url
+      waitForEvent {
+        eventName
+        expression
+        timeout
+      }
+      waitResult {
+        eventID
+        timeout
       }
     }
   }


### PR DESCRIPTION
## Description

Add "summary cards" for waits and sleeps. These cards appear at the top of a run's details when their associated timeline node is "active". In other words, these new cards will disappear when their wait/sleep ends.

## Testing

![image](https://github.com/inngest/inngest/assets/20100586/d74549c2-6692-4575-8ff8-86c7b7b076f5)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
