### PR TITLE
Remove Windows pin for v0.14.6; Windows builds now work again

### DIFF
--- a/npm/postinstall.ts
+++ b/npm/postinstall.ts
@@ -54,17 +54,6 @@ async function getBinaryUrl(): Promise<URL> {
 
   let version = process.env.npm_package_version?.trim();
   debug("npm_package_version:", version);
-  /**
-   * Windows builds are currently not working past v0.14.6, so let's pin to that
-   * version here if we're on Windows.
-   */
-  if (platform.platform === "windows") {
-    debug("Windows detected; pinning to v0.14.6");
-    console.warn(
-      "Windows detected; pinning to last known working version 0.14.6"
-    );
-    version = "0.14.6";
-  }
 
   if (!version) {
     throw new Error("Could not find package version to install binary");
@@ -104,16 +93,6 @@ function getArchPlatform() {
 
   if (!platform) {
     throw new Error(`Unsupported platform: ${process.platform}`);
-  }
-
-  /**
-   * Windows x64 builds pre v0.15 had an 'x86_64' suffix instead of 'amd64'.
-   * We are explicitly pinning Windows versions to 0.14.6 for now, so handle
-   * this problem here.
-   */
-  if (platform.platform === "windows" && arch === "amd64") {
-    debug("Old Windows x64 build; using 'x86_64' to access binary");
-    return { arch: "x86_64", platform };
   }
 
   return { arch, platform };


### PR DESCRIPTION
## Description

Remove Windows pin for `v0.14.6`; Windows builds now work again! 🥳

We also remove a check that converts windows_amd64 to windows_x86_64 when downloading the binary. This is no longer needed, as the postinstall script is unique to every npm deployment, meaning this version of the script won't be used to install earlier versions.

Tested by running the `postinstall` script to check downloading and unpacking of the binary, then used as a dev server for local integration tests. Tested against Node v14, v16, v18, v20.

```
System:
  OS: Windows 10 10.0.22621
  CPU: (16) x64 12th Gen Intel(R) Core(TM) i5-12600K
  Memory: 14.23 GB / 31.82 GB
```

- Reverses #575
- Possible following #645
- Further fix for #548 
- Further fix for #449 

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
