### PR TITLE
Only create new group ID on parallel steps

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -875,14 +875,17 @@ func (e *executor) HandleGeneratorResponse(ctx context.Context, resp *state.Driv
 	// Ensure that we process waitForEvents first, as these are highest priority.
 	sortOps(resp.Generator)
 
+	isParallel := len(resp.Generator) > 1
 	eg := errgroup.Group{}
 	for _, op := range resp.Generator {
 		copied := *op
 
-		// Give each op its own group ID, as we want to track each step
-		// individually.
 		newItem := item
-		newItem.GroupID = uuid.New().String()
+		if isParallel {
+			// Give each opcode its own group ID, since we want to track each
+			// parellel step individually.
+			newItem.GroupID = uuid.New().String()
+		}
 
 		eg.Go(func() error { return e.HandleGenerator(ctx, copied, newItem) })
 	}


### PR DESCRIPTION
## Description

Before calling `HandleGenerator`, only create a new group ID for each opcode if we're dealing with parallel steps.

This fixes a bug where sleep history was split over 2 groups.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
