### PR TITLE
INN-2110: Add API structure for timeseries related data for metrics

### DIFF
--- a/pkg/usage/metrics.go
+++ b/pkg/usage/metrics.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -9,6 +10,22 @@ type MetricsRequest struct {
 	Name string    `json:"name"`
 	From time.Time `json:"from"`
 	To   time.Time `json:"to"`
+}
+
+func (mr MetricsRequest) Valid() (bool, error) {
+	if mr.Name == "" {
+		return false, fmt.Errorf("metrics' name must be specified")
+	}
+
+	if mr.From.IsZero() || mr.To.IsZero() {
+		return false, fmt.Errorf("metrics' time range (from/to - ISO8601 format) must be specified")
+	}
+
+	if mr.To.Sub(mr.From) < 0 {
+		return false, fmt.Errorf("invalid time range for metrics")
+	}
+
+	return true, nil
 }
 
 func (mr MetricsRequest) Granularity() string {

--- a/pkg/usage/metrics.go
+++ b/pkg/usage/metrics.go
@@ -18,20 +18,20 @@ type MetricsRequest struct {
 	To   time.Time `json:"to"`
 }
 
-func (mr MetricsRequest) Valid() (bool, error) {
+func (mr MetricsRequest) Valid() error {
 	if mr.Name == "" {
-		return false, NoMetricsNameErr
+		return NoMetricsNameErr
 	}
 
 	if mr.From.IsZero() || mr.To.IsZero() {
-		return false, NoMetricsTimeRangeErr
+		return NoMetricsTimeRangeErr
 	}
 
 	if mr.To.Sub(mr.From) < 0 {
-		return false, InvalidMetricsTimeRangeErr
+		return InvalidMetricsTimeRangeErr
 	}
 
-	return true, nil
+	return nil
 }
 
 // Granularity returns the predefined aggregation period for

--- a/pkg/usage/metrics.go
+++ b/pkg/usage/metrics.go
@@ -1,0 +1,50 @@
+package usage
+
+import (
+	"time"
+)
+
+// MetricsRequest represents a client request for metrics based on time range
+type MetricsRequest struct {
+	Name string    `json:"name"`
+	From time.Time `json:"from"`
+	To   time.Time `json:"to"`
+}
+
+func (mr MetricsRequest) Granularity() string {
+	dur := mr.To.Sub(mr.From)
+	day := 24 * time.Hour
+
+	switch {
+	case dur >= 30*day:
+		return "12h"
+	case dur >= 14*day:
+		return "6h"
+	case dur >= 7*day:
+		return "3h"
+	case dur >= 3*day:
+		return "1h"
+	case dur >= 1*day:
+		return "30m"
+	case dur >= 12*time.Hour:
+		return "15m"
+	case dur >= 6*time.Hour:
+		return "10m"
+	default:
+		return "5m"
+	}
+}
+
+// MetricsResponse represents an API response to a MetricsRequest
+type MetricsResponse struct {
+	From        time.Time     `json:"from"`
+	To          time.Time     `json:"to"`
+	Granularity string        `json:"granularity"`
+	Data        []MetricsData `json:"data"`
+}
+
+// MetricsData represents a single slot of timeseries data.
+type MetricsData struct {
+	Bucket time.Time `json:"bucket"`
+	Value  float64   `json:"value"`
+}

--- a/pkg/usage/metrics.go
+++ b/pkg/usage/metrics.go
@@ -5,6 +5,12 @@ import (
 	"time"
 )
 
+var (
+	NoMetricsNameErr           = fmt.Errorf("metrics' name must be specified")
+	NoMetricsTimeRangeErr      = fmt.Errorf("metrics' time range (from/to - ISO8601 format) must be specified")
+	InvalidMetricsTimeRangeErr = fmt.Errorf("invalid time range for metrics")
+)
+
 // MetricsRequest represents a client request for metrics based on time range
 type MetricsRequest struct {
 	Name string    `json:"name"`
@@ -14,20 +20,22 @@ type MetricsRequest struct {
 
 func (mr MetricsRequest) Valid() (bool, error) {
 	if mr.Name == "" {
-		return false, fmt.Errorf("metrics' name must be specified")
+		return false, NoMetricsNameErr
 	}
 
 	if mr.From.IsZero() || mr.To.IsZero() {
-		return false, fmt.Errorf("metrics' time range (from/to - ISO8601 format) must be specified")
+		return false, NoMetricsTimeRangeErr
 	}
 
 	if mr.To.Sub(mr.From) < 0 {
-		return false, fmt.Errorf("invalid time range for metrics")
+		return false, InvalidMetricsTimeRangeErr
 	}
 
 	return true, nil
 }
 
+// Granularity returns the predefined aggregation period for
+// the query
 func (mr MetricsRequest) Granularity() string {
 	dur := mr.To.Sub(mr.From)
 	day := 24 * time.Hour

--- a/pkg/usage/metrics.go
+++ b/pkg/usage/metrics.go
@@ -37,6 +37,7 @@ func (mr MetricsRequest) Granularity() string {
 
 // MetricsResponse represents an API response to a MetricsRequest
 type MetricsResponse struct {
+	Name        string        `json:"name"`
 	From        time.Time     `json:"from"`
 	To          time.Time     `json:"to"`
 	Granularity string        `json:"granularity"`

--- a/pkg/usage/metrics_test.go
+++ b/pkg/usage/metrics_test.go
@@ -1,11 +1,65 @@
 package usage
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMetricsRequestValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      *MetricsRequest
+		expected bool
+		err      error
+	}{
+		{
+			name: "valid request returns true",
+			req: &MetricsRequest{
+				Name: "something",
+				From: time.Now().Add(-1 * time.Hour),
+				To:   time.Now(),
+			},
+			expected: true,
+			err:      nil,
+		},
+		{
+			name:     "missing name returns false",
+			req:      &MetricsRequest{},
+			expected: false,
+			err:      errors.New("metrics' name must be specified"),
+		},
+		{
+			name: "missing time range will returns false",
+			req: &MetricsRequest{
+				Name: "something",
+			},
+			expected: false,
+			err:      errors.New("metrics' time range (from/to - ISO8601 format) must be specified"),
+		},
+		{
+			name: "opposite time range (to < from) returns false",
+			req: &MetricsRequest{
+				Name: "something",
+				From: time.Now().Add(-1 * time.Hour),
+				To:   time.Now().Add(-2 * time.Hour),
+			},
+			expected: false,
+			err:      errors.New("invalid time range for metrics"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ok, err := test.req.Valid()
+
+			assert.Equal(t, test.expected, ok)
+			assert.Equal(t, test.err, err)
+		})
+	}
+}
 
 func TestMetricsRequestGranularity(t *testing.T) {
 	tests := []struct {

--- a/pkg/usage/metrics_test.go
+++ b/pkg/usage/metrics_test.go
@@ -1,0 +1,68 @@
+package usage
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricsRequestGranularity(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      *MetricsRequest
+		expected string
+	}{
+		{
+			name:     "empty req defaults to 5m",
+			req:      &MetricsRequest{},
+			expected: "5m",
+		},
+		{
+			name:     ">= 1h range returns 5m granularity",
+			req:      &MetricsRequest{From: time.Now().Add(-2 * time.Hour), To: time.Now()},
+			expected: "5m",
+		},
+		{
+			name:     ">= 6h range returns 10m granularity",
+			req:      &MetricsRequest{From: time.Now().Add(-7 * time.Hour), To: time.Now()},
+			expected: "10m",
+		},
+		{
+			name:     ">= 12h range returns 15m granularity",
+			req:      &MetricsRequest{From: time.Now().Add(-12 * time.Hour), To: time.Now()},
+			expected: "15m",
+		},
+		{
+			name:     ">= 1d range returns 30m granularity",
+			req:      &MetricsRequest{From: time.Now().Add(-24 * time.Hour), To: time.Now()},
+			expected: "30m",
+		},
+		{
+			name:     ">= 3d range returns 1h granularity",
+			req:      &MetricsRequest{From: time.Now().Add(4 * -24 * time.Hour), To: time.Now()},
+			expected: "1h",
+		},
+		{
+			name:     ">= 7d returns 3h granularity",
+			req:      &MetricsRequest{From: time.Now().Add(8 * -24 * time.Hour), To: time.Now()},
+			expected: "3h",
+		},
+		{
+			name:     ">= 14d range returns 6h granularity",
+			req:      &MetricsRequest{From: time.Now().Add(15 * -24 * time.Hour), To: time.Now()},
+			expected: "6h",
+		},
+		{
+			name:     ">= 30d range returns 12h granularity",
+			req:      &MetricsRequest{From: time.Now().Add(31 * -24 * time.Hour), To: time.Now()},
+			expected: "12h",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.req.Granularity())
+		})
+	}
+}

--- a/pkg/usage/metrics_test.go
+++ b/pkg/usage/metrics_test.go
@@ -9,10 +9,9 @@ import (
 
 func TestMetricsRequestValid(t *testing.T) {
 	tests := []struct {
-		name     string
-		req      *MetricsRequest
-		expected bool
-		err      error
+		name string
+		req  *MetricsRequest
+		err  error
 	}{
 		{
 			name: "valid request returns true",
@@ -21,22 +20,19 @@ func TestMetricsRequestValid(t *testing.T) {
 				From: time.Now().Add(-1 * time.Hour),
 				To:   time.Now(),
 			},
-			expected: true,
-			err:      nil,
+			err: nil,
 		},
 		{
-			name:     "missing name returns false",
-			req:      &MetricsRequest{},
-			expected: false,
-			err:      NoMetricsNameErr,
+			name: "missing name returns false",
+			req:  &MetricsRequest{},
+			err:  NoMetricsNameErr,
 		},
 		{
 			name: "missing time range will returns false",
 			req: &MetricsRequest{
 				Name: "something",
 			},
-			expected: false,
-			err:      NoMetricsTimeRangeErr,
+			err: NoMetricsTimeRangeErr,
 		},
 		{
 			name: "opposite time range (to < from) returns false",
@@ -45,17 +41,13 @@ func TestMetricsRequestValid(t *testing.T) {
 				From: time.Now().Add(-1 * time.Hour),
 				To:   time.Now().Add(-2 * time.Hour),
 			},
-			expected: false,
-			err:      InvalidMetricsTimeRangeErr,
+			err: InvalidMetricsTimeRangeErr,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ok, err := test.req.Valid()
-
-			assert.Equal(t, test.expected, ok)
-			assert.Equal(t, test.err, err)
+			assert.Equal(t, test.err, test.req.Valid())
 		})
 	}
 }

--- a/pkg/usage/metrics_test.go
+++ b/pkg/usage/metrics_test.go
@@ -1,7 +1,6 @@
 package usage
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -29,7 +28,7 @@ func TestMetricsRequestValid(t *testing.T) {
 			name:     "missing name returns false",
 			req:      &MetricsRequest{},
 			expected: false,
-			err:      errors.New("metrics' name must be specified"),
+			err:      NoMetricsNameErr,
 		},
 		{
 			name: "missing time range will returns false",
@@ -37,7 +36,7 @@ func TestMetricsRequestValid(t *testing.T) {
 				Name: "something",
 			},
 			expected: false,
-			err:      errors.New("metrics' time range (from/to - ISO8601 format) must be specified"),
+			err:      NoMetricsTimeRangeErr,
 		},
 		{
 			name: "opposite time range (to < from) returns false",
@@ -47,7 +46,7 @@ func TestMetricsRequestValid(t *testing.T) {
 				To:   time.Now().Add(-2 * time.Hour),
 			},
 			expected: false,
-			err:      errors.New("invalid time range for metrics"),
+			err:      InvalidMetricsTimeRangeErr,
 		},
 	}
 


### PR DESCRIPTION
## Description

Provide a more appropriate structure to handle timeseries request and response through APIs.
This will add the pre-defined aggregation granularity of the data as well.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
