### PR TITLE
Fix GetEventsTimebound before arg is inclusive instead of exclusive

### DIFF
--- a/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
+++ b/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
@@ -268,6 +268,11 @@ type GetEventsTimeboundParams struct {
 }
 
 func (q *Queries) GetEventsTimebound(ctx context.Context, arg GetEventsTimeboundParams) ([]*Event, error) {
+	// Subtract 1 ms because the QueryContext method is using `<=` instead of
+	// `<`. We don't need to make a +1ms change to arg.After because it's not
+	// having a similar issue.
+	arg.Before = arg.Before.Add(-1 * time.Millisecond)
+
 	rows, err := q.db.QueryContext(ctx, getEventsTimebound, arg.After, arg.Before, arg.Limit)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

Fix a duplication bug in the stream. The issue was because the `before` arg was inclusive (`<=`) instead of exclusive (`<`).

## Issue

https://linear.app/inngest/issue/INN-2108/before-param-in-stream-query-returns-includes-item-that-matches-its

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
