### PR TITLE
Add function started node to HistoryParser

### DIFF
--- a/ui/src/components/TimelineV2/TimelineNode/TimelineNodeRenderer.tsx
+++ b/ui/src/components/TimelineV2/TimelineNode/TimelineNodeRenderer.tsx
@@ -16,7 +16,9 @@ type RenderedData = {
 
 export default function renderTimelineNode(node: HistoryNode): RenderedData {
   let icon: JSX.Element;
-  if (node.status === 'cancelled') {
+  if (node.scope === "function" && node.status === "started") {
+    icon = <IconStatusCircleCheck />
+  } else if (node.status === 'cancelled') {
     icon = <IconStatusCircleCross className="text-slate-700" />;
   } else if (node.status === 'completed') {
     icon = <IconStatusCircleCheck />;
@@ -34,14 +36,18 @@ export default function renderTimelineNode(node: HistoryNode): RenderedData {
   }
 
   let name = '...';
-  if (node.waitForEventConfig) {
-    name = node.waitForEventConfig.eventName;
-  } else if (node.name) {
-    name = node.name;
-  } else if (node.status === 'scheduled') {
-    name = 'Waiting to start next step...';
-  } else if (node.status === 'started') {
-    name = 'Running next step...';
+  if (node.scope === "function") {
+    name = `Function ${node.status}`;
+  } else if (node.scope === "step") {
+    if (node.waitForEventConfig) {
+      name = node.waitForEventConfig.eventName;
+    } else if (node.name) {
+      name = node.name;
+    } else if (node.status === 'scheduled') {
+      name = 'Waiting to start next step...';
+    } else if (node.status === 'started') {
+      name = 'Running next step...';
+    }
   }
 
   let metadata;

--- a/ui/src/components/TimelineV2/historyParser/historyParser.test.ts
+++ b/ui/src/components/TimelineV2/historyParser/historyParser.test.ts
@@ -13,6 +13,22 @@ async function loadHistory(filename: string) {
   });
 }
 
+const baseRunStartNode = {
+  attempt: 0,
+  endedAt: expect.any(Date),
+  groupID: expect.any(String),
+  name: undefined,
+  outputItemID: undefined,
+  scheduledAt: expect.any(Date),
+  scope: 'function',
+  sleepConfig: undefined,
+  status: "started",
+  startedAt: expect.any(Date),
+  url: undefined,
+  waitForEventConfig: undefined,
+  waitForEventResult: undefined,
+} as const;
+
 const baseStepNode = {
   attempt: 0,
   endedAt: expect.any(Date),
@@ -46,6 +62,7 @@ test('cancels', async () => {
   const history = await loadHistory('cancels.json');
 
   const expectation: HistoryNode[] = [
+    baseRunStartNode,
     {
       ...baseStepNode,
       status: 'cancelled',
@@ -71,6 +88,7 @@ test('fails without steps', async () => {
   const history = await loadHistory('failsWithoutSteps.json');
 
   const expectation: HistoryNode[] = [
+    baseRunStartNode,
     {
       ...baseStepNode,
       attempt: 2,
@@ -90,6 +108,7 @@ test('fails with preceding step', async () => {
   const history = await loadHistory('failsWithPrecedingStep.json');
 
   const expectation: HistoryNode[] = [
+    baseRunStartNode,
     {
       ...baseStepNode,
       status: 'completed',
@@ -114,6 +133,7 @@ test('no steps', async () => {
   const history = await loadHistory('noSteps.json');
 
   const expectation: HistoryNode[] = [
+    baseRunStartNode,
     {
       ...baseRunEndNode,
       status: 'completed',
@@ -127,6 +147,7 @@ test('parallel steps', async () => {
   const history = await loadHistory('parallelSteps.json');
 
   const expectation: HistoryNode[] = [
+    baseRunStartNode,
     {
       ...baseStepNode,
       status: 'completed',
@@ -163,6 +184,7 @@ test('sleeps', async () => {
   const history = await loadHistory('sleeps.json');
 
   const expectation: HistoryNode[] = [
+    baseRunStartNode,
     {
       ...baseStepNode,
       status: 'completed',
@@ -184,6 +206,7 @@ test('succeeds with 2 steps', async () => {
   const history = await loadHistory('succeedsWith2Steps.json');
 
   const expectation: HistoryNode[] = [
+    baseRunStartNode,
     {
       ...baseStepNode,
       status: 'completed',
@@ -207,6 +230,7 @@ test('times out waiting for events', async () => {
   const history = await loadHistory('timesOutWaitingForEvent.json');
 
   const expectation: HistoryNode[] = [
+    baseRunStartNode,
     {
       ...baseStepNode,
       status: 'completed',
@@ -233,6 +257,7 @@ test('waits for event', async () => {
   const history = await loadHistory('waitsForEvent.json');
 
   const expectation: HistoryNode[] = [
+    baseRunStartNode,
     {
       ...baseStepNode,
       status: 'completed',

--- a/ui/src/components/TimelineV2/historyParser/historyParser.ts
+++ b/ui/src/components/TimelineV2/historyParser/historyParser.ts
@@ -25,6 +25,10 @@ export class HistoryParser {
   }
 
   append(rawItem: RunHistoryItem) {
+    if (rawItem.type === HistoryType.FunctionStarted) {
+      this.createFunctionRunStartNode(new Date(rawItem.createdAt));
+    }
+
     let node: HistoryNode;
     if (this.history[rawItem.groupID]) {
       node = { ...this.history[rawItem.groupID] };
@@ -43,7 +47,7 @@ export class HistoryParser {
     if (rawItem.type === HistoryType.FunctionFailed && node.scope === 'step') {
       // Put FunctionFailed into its own node. Its group ID is the same as
       // StepFailed but don't want to mess up the StepFailed node's data.
-      node.groupID = 'function-end';
+      node.groupID = 'function-run-end';
     }
 
     node = updateNode(node, rawItem);
@@ -79,6 +83,33 @@ export class HistoryParser {
         };
       }
     }
+  }
+
+  /**
+   * Creates a node for the function run start. This is needed because the
+   * FunctionStarted history item represents 2 things: starting the function and
+   * scheduling the first step. Since those 2 things need separate nodes, we
+   * need this method to create the function scope node.
+   */
+  private createFunctionRunStartNode(startedAt: Date) {
+    // Create a dedicated node for function run start.
+    const node: HistoryNode = {
+      attempt: 0,
+      groupID: 'function-run-start',
+
+      // Doesn't make sense for this node (since it's just for the start of
+      // the run), but we have to put something.
+      scheduledAt: startedAt,
+
+      scope: 'function',
+      startedAt,
+      status: 'started',
+    } as const;
+
+    this.history = {
+      ...this.history,
+      [node.groupID]: node,
+    };
   }
 
   /**

--- a/ui/src/components/TimelineV2/historyParser/historyParser.ts
+++ b/ui/src/components/TimelineV2/historyParser/historyParser.ts
@@ -95,12 +95,9 @@ export class HistoryParser {
     // Create a dedicated node for function run start.
     const node: HistoryNode = {
       attempt: 0,
+      endedAt: startedAt,
       groupID: 'function-run-start',
-
-      // Doesn't make sense for this node (since it's just for the start of
-      // the run), but we have to put something.
       scheduledAt: startedAt,
-
       scope: 'function',
       startedAt,
       status: 'started',

--- a/ui/src/components/TimelineV2/historyParser/updateNode.ts
+++ b/ui/src/components/TimelineV2/historyParser/updateNode.ts
@@ -1,5 +1,5 @@
 import { HistoryType, type RunHistoryItem } from '@/store/generated';
-import type { HistoryNode, Status } from './types';
+import type { HistoryNode } from './types';
 
 type Updater = (node: HistoryNode, rawItem: RunHistoryItem) => HistoryNode;
 
@@ -32,13 +32,7 @@ const updaters: {
       status: 'failed',
     } satisfies HistoryNode;
   },
-  [HistoryType.FunctionScheduled]: (node, rawItem) => {
-    return {
-      ...node,
-      scheduledAt: new Date(rawItem.createdAt),
-      status: 'scheduled',
-    } satisfies HistoryNode;
-  },
+  [HistoryType.FunctionScheduled]: noop,
   [HistoryType.FunctionStarted]: (node, rawItem) => {
     return {
       ...node,


### PR DESCRIPTION
## Description

Add a node for function run start. Before this change, the new timeline was missing a node for when the run starts.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
