### PR TITLE
Parse SDK errors on response

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -464,6 +464,11 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 }
 
 func (e *executor) HandleResponse(ctx context.Context, id state.Identifier, item queue.Item, edge inngest.Edge, resp *state.DriverResponse) error {
+	if resp.Err != nil {
+		// Ensure that we parse output and error messages correctly prior to handling.
+		resp.Output = resp.UserError()
+	}
+
 	for _, e := range e.lifecycles {
 		go e.OnStepFinished(context.WithoutCancel(ctx), id, item, edge, resp.Step, *resp)
 	}

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/exp/slog"
 )
 
-const DefaultErrorMessage = "Unknown error running SDK"
+const DefaultErrorMessage = "Function execution error"
 
 type Retryable interface {
 	Retryable() bool

--- a/pkg/execution/state/driver_response_test.go
+++ b/pkg/execution/state/driver_response_test.go
@@ -205,7 +205,7 @@ func TestDriverResponseUserError(t *testing.T) {
 			name: "with no Output and no Err",
 			r:    DriverResponse{Output: nil},
 			expected: map[string]any{
-				"error":   "Unknown error running SDK",
+				"error":   DefaultErrorMessage,
 				"name":    "Error",
 				"message": DefaultErrorMessage,
 			},
@@ -276,7 +276,7 @@ func TestDriverResponseUserError(t *testing.T) {
 			name: "non map Output",
 			r:    DriverResponse{Output: "YOLO"},
 			expected: map[string]any{
-				"error":   "Unknown error running SDK",
+				"error":   DefaultErrorMessage,
 				"name":    "Error",
 				"message": "YOLO",
 			},


### PR DESCRIPTION
This fixes a regression in main (unreleased), ensuring that errors are parsed.

Note that this is tested in the cloud;  we need to open-source these integration tests.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
