### PR TITLE
chore: use time.Duration instead of string for granularity

### DIFF
--- a/pkg/usage/metrics.go
+++ b/pkg/usage/metrics.go
@@ -36,27 +36,29 @@ func (mr MetricsRequest) Valid() error {
 
 // Granularity returns the predefined aggregation period for
 // the query
-func (mr MetricsRequest) Granularity() string {
+func (mr MetricsRequest) Granularity() time.Duration {
 	dur := mr.To.Sub(mr.From)
 	day := 24 * time.Hour
 
 	switch {
 	case dur >= 30*day:
-		return "12h"
+		return 12 * time.Hour
 	case dur >= 14*day:
-		return "6h"
+		return 6 * time.Hour
 	case dur >= 7*day:
-		return "3h"
+		return 3 * time.Hour
 	case dur >= 3*day:
-		return "1h"
+		return time.Hour
 	case dur >= 1*day:
-		return "30m"
+		return 30 * time.Minute
 	case dur >= 12*time.Hour:
-		return "15m"
+		return 15 * time.Minute
 	case dur >= 6*time.Hour:
-		return "10m"
+		return 10 * time.Minute
+	case dur >= 3*time.Hour:
+		return 5 * time.Minute
 	default:
-		return "5m"
+		return time.Minute
 	}
 }
 
@@ -65,7 +67,7 @@ type MetricsResponse struct {
 	Name        string        `json:"name"`
 	From        time.Time     `json:"from"`
 	To          time.Time     `json:"to"`
-	Granularity string        `json:"granularity"`
+	Granularity time.Duration `json:"granularity"`
 	Data        []MetricsData `json:"data"`
 }
 

--- a/pkg/usage/metrics_test.go
+++ b/pkg/usage/metrics_test.go
@@ -56,52 +56,52 @@ func TestMetricsRequestGranularity(t *testing.T) {
 	tests := []struct {
 		name     string
 		req      *MetricsRequest
-		expected string
+		expected time.Duration
 	}{
 		{
-			name:     "empty req defaults to 5m",
+			name:     "empty req defaults to 1m",
 			req:      &MetricsRequest{},
-			expected: "5m",
+			expected: time.Minute,
 		},
 		{
-			name:     ">= 1h range returns 5m granularity",
-			req:      &MetricsRequest{From: time.Now().Add(-2 * time.Hour), To: time.Now()},
-			expected: "5m",
+			name:     ">= 3h range returns 5m granularity",
+			req:      &MetricsRequest{From: time.Now().Add(-4 * time.Hour), To: time.Now()},
+			expected: 5 * time.Minute,
 		},
 		{
 			name:     ">= 6h range returns 10m granularity",
 			req:      &MetricsRequest{From: time.Now().Add(-7 * time.Hour), To: time.Now()},
-			expected: "10m",
+			expected: 10 * time.Minute,
 		},
 		{
 			name:     ">= 12h range returns 15m granularity",
 			req:      &MetricsRequest{From: time.Now().Add(-12 * time.Hour), To: time.Now()},
-			expected: "15m",
+			expected: 15 * time.Minute,
 		},
 		{
 			name:     ">= 1d range returns 30m granularity",
 			req:      &MetricsRequest{From: time.Now().Add(-24 * time.Hour), To: time.Now()},
-			expected: "30m",
+			expected: 30 * time.Minute,
 		},
 		{
 			name:     ">= 3d range returns 1h granularity",
 			req:      &MetricsRequest{From: time.Now().Add(4 * -24 * time.Hour), To: time.Now()},
-			expected: "1h",
+			expected: time.Hour,
 		},
 		{
 			name:     ">= 7d returns 3h granularity",
 			req:      &MetricsRequest{From: time.Now().Add(8 * -24 * time.Hour), To: time.Now()},
-			expected: "3h",
+			expected: 3 * time.Hour,
 		},
 		{
 			name:     ">= 14d range returns 6h granularity",
 			req:      &MetricsRequest{From: time.Now().Add(15 * -24 * time.Hour), To: time.Now()},
-			expected: "6h",
+			expected: 6 * time.Hour,
 		},
 		{
 			name:     ">= 30d range returns 12h granularity",
 			req:      &MetricsRequest{From: time.Now().Add(31 * -24 * time.Hour), To: time.Now()},
-			expected: "12h",
+			expected: 12 * time.Hour,
 		},
 	}
 


### PR DESCRIPTION
## Description

`time.Duration` is better when it comes to managing metrics granularity for query purposes.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
