### PR TITLE
change the type back to string for easier use

### DIFF
--- a/pkg/usage/metrics.go
+++ b/pkg/usage/metrics.go
@@ -67,7 +67,7 @@ type MetricsResponse struct {
 	Name        string        `json:"name"`
 	From        time.Time     `json:"from"`
 	To          time.Time     `json:"to"`
-	Granularity time.Duration `json:"granularity"`
+	Granularity string        `json:"granularity"`
 	Data        []MetricsData `json:"data"`
 }
 


### PR DESCRIPTION
## Description

Turns out time.Duration is trickier to handle for API types, so changing it back to string.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
