### PR TITLE
Use lifecycle listener to record runs

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -156,6 +156,10 @@ func start(ctx context.Context, opts StartOpts) error {
 				hd,
 				memory_writer.NewWriter(),
 			),
+			lifecycle{
+				sm:   sm,
+				cqrs: dbcqrs,
+			},
 		),
 		executor.WithStepLimits(consts.DefaultMaxStepLimit),
 		executor.WithDebouncer(debouncer),
@@ -191,18 +195,6 @@ func start(ctx context.Context, opts StartOpts) error {
 	// embed the tracker
 	ds.tracker = t
 	ds.state = sm
-
-	// Add notifications to the state manager so that we can store new function runs
-	// in the core API service.
-	if notify, ok := sm.(state.FunctionNotifier); ok {
-		notify.OnFunctionStatus(func(ctx context.Context, id state.Identifier, rs enums.RunStatus) {
-			switch rs {
-			case enums.RunStatusRunning:
-				// A new function was added, so add this to the core API
-				// for listing functions by XYZ.
-			}
-		})
-	}
 
 	return service.StartAll(ctx, ds, runner, executorSvc)
 }

--- a/pkg/devserver/lifecycle.go
+++ b/pkg/devserver/lifecycle.go
@@ -1,0 +1,45 @@
+package devserver
+
+import (
+	"context"
+
+	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/execution"
+	"github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/oklog/ulid/v2"
+)
+
+type lifecycle struct {
+	execution.NoopLifecyceListener
+
+	sm   state.Manager
+	cqrs cqrs.Manager
+}
+
+func (l lifecycle) OnFunctionScheduled(
+	ctx context.Context,
+	id state.Identifier,
+	item queue.Item,
+) {
+
+	state, err := l.sm.Load(ctx, id.RunID)
+	if err != nil {
+		return
+	}
+
+	evt := state.Event()
+
+	triggerType := "event"
+	if name, _ := evt["name"].(string); name == "inngest/scheduled.timer" {
+		triggerType = "cron"
+	}
+
+	_ = l.cqrs.InsertFunctionRun(ctx, cqrs.FunctionRun{
+		RunID:        id.RunID,
+		RunStartedAt: ulid.Time(id.RunID.Time()),
+		FunctionID:   id.WorkflowID,
+		EventID:      id.EventID,
+		TriggerType:  triggerType,
+	})
+}

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -491,26 +491,11 @@ func (s *svc) initialize(ctx context.Context, fn inngest.Function, evt event.Tra
 		Str("function_id", fn.ID.String()).
 		Str("function", fn.Name).
 		Msg("initializing fn")
-	id, err := Initialize(ctx, fn, evt, s.executor)
+	_, err := Initialize(ctx, fn, evt, s.executor)
 	if err == executor.ErrFunctionDebounced {
 		return nil
 	}
-	if err != nil {
-		return err
-	}
-
-	triggerType := "event"
-	if evt.GetEvent().Name == "inngest/scheduled.timer" {
-		triggerType = "cron"
-	}
-
-	return s.cqrs.InsertFunctionRun(ctx, cqrs.FunctionRun{
-		RunID:        id.RunID,
-		RunStartedAt: ulid.Time(id.RunID.Time()),
-		FunctionID:   fn.ID,
-		EventID:      evt.GetInternalID(),
-		TriggerType:  triggerType,
-	})
+	return err
 }
 
 // Initialize creates a new funciton run identifier for the given workflow and


### PR DESCRIPTION
This ensures that debounces are recorded in SQL and show up in the UI. Previously, the runner was responsible for recording runs (incorrectly).

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
