### PR TITLE
INN-2110: Add granularity to usage opts and deprecate period

### DIFF
--- a/pkg/history_reader/reader.go
+++ b/pkg/history_reader/reader.go
@@ -180,7 +180,8 @@ type GetUsageOpts struct {
 	WorkflowID  uuid.UUID
 	LowerTime   time.Time
 	UpperTime   time.Time
-	Period      enums.Period
+	Period      enums.Period // deprecated, no longer used
+	Granularity time.Duration
 	Statuses    []enums.RunStatus
 }
 
@@ -200,9 +201,7 @@ func (o GetUsageOpts) Validate() error {
 	if o.UpperTime.IsZero() {
 		return errors.New("upper time must be set")
 	}
-	if o.Period == enums.PeriodNone {
-		return errors.New("period must be set")
-	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description

Changing the option to allow granularity instead, which will be used as the based for time buckets between `LowerTime` and `UpperTime` when querying for data.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
