### PR TITLE
Change debounce error handling

### DIFF
--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -133,7 +133,10 @@ func (d debouncer) DeleteDebounceItem(ctx context.Context, debounceID ulid.ULID)
 	if rueidis.IsRedisNil(err) {
 		return nil
 	}
-	return fmt.Errorf("error removing debounce: %w", err)
+	if err != nil {
+		return fmt.Errorf("error removing debounce: %w", err)
+	}
+	return nil
 }
 
 // GetDebounceItem returns a DebounceItem given a debounce ID.


### PR DESCRIPTION
## Description

While some redis implementations (in-memory) return nil, here, others (memorydb) return an actual nil error that should be handled appropriately.  This doesn't cause issues in OSS or cloud — it only logs a nil error right now — but should be changed regardless.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
