### PR TITLE
Fix UI error when no step output

### DIFF
--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -258,7 +258,7 @@ type FunctionRunResolver interface {
 	Output(ctx context.Context, obj *models.FunctionRun) (*string, error)
 	Timeline(ctx context.Context, obj *models.FunctionRun) ([]models.FunctionRunEvent, error)
 	History(ctx context.Context, obj *models.FunctionRun) ([]*history_reader.RunHistory, error)
-	HistoryItemOutput(ctx context.Context, obj *models.FunctionRun, id ulid.ULID) (string, error)
+	HistoryItemOutput(ctx context.Context, obj *models.FunctionRun, id ulid.ULID) (*string, error)
 }
 type MutationResolver interface {
 	CreateApp(ctx context.Context, input models.CreateAppInput) (*cqrs.App, error)
@@ -1482,7 +1482,7 @@ type FunctionRun {
 
   timeline: [FunctionRunEvent!] @deprecated
   history: [RunHistoryItem!]!
-  historyItemOutput(id: ULID!): String!
+  historyItemOutput(id: ULID!): String
   name: String @deprecated # use the embedded function field instead.
 }
 
@@ -3961,14 +3961,11 @@ func (ec *executionContext) _FunctionRun_historyItemOutput(ctx context.Context, 
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_FunctionRun_historyItemOutput(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -10082,9 +10079,6 @@ func (ec *executionContext) _FunctionRun(ctx context.Context, sel ast.SelectionS
 					}
 				}()
 				res = ec._FunctionRun_historyItemOutput(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&invalids, 1)
-				}
 				return res
 			}
 

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -191,7 +191,7 @@ type FunctionRun {
 
   timeline: [FunctionRunEvent!] @deprecated
   history: [RunHistoryItem!]!
-  historyItemOutput(id: ULID!): String!
+  historyItemOutput(id: ULID!): String
   name: String @deprecated # use the embedded function field instead.
 }
 

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -83,7 +83,7 @@ type FunctionRun struct {
 	Output            *string                      `json:"output,omitempty"`
 	Timeline          []FunctionRunEvent           `json:"timeline,omitempty"`
 	History           []*history_reader.RunHistory `json:"history"`
-	HistoryItemOutput string                       `json:"historyItemOutput"`
+	HistoryItemOutput *string                      `json:"historyItemOutput,omitempty"`
 	Name              *string                      `json:"name,omitempty"`
 }
 

--- a/pkg/coreapi/graph/resolvers/function_run.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run.resolver.go
@@ -85,10 +85,10 @@ func (r *functionRunResolver) HistoryItemOutput(
 	ctx context.Context,
 	obj *models.FunctionRun,
 	historyID ulid.ULID,
-) (string, error) {
+) (*string, error) {
 	runID, err := ulid.Parse(obj.ID)
 	if err != nil {
-		return "", fmt.Errorf("invalid run ID: %w", err)
+		return nil, fmt.Errorf("invalid run ID: %w", err)
 	}
 
 	// For required UUID fields that don't matter in OSS.

--- a/pkg/history_drivers/memory_reader/reader.go
+++ b/pkg/history_drivers/memory_reader/reader.go
@@ -78,26 +78,30 @@ func (r *reader) GetRunHistoryItemOutput(
 	ctx context.Context,
 	historyID ulid.ULID,
 	opts history_reader.GetHistoryOutputOpts,
-) (string, error) {
+) (*string, error) {
 	r.store.Mu.RLock()
 	defer r.store.Mu.RUnlock()
 
 	if err := opts.Validate(); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	run, ok := r.store.Data[opts.RunID]
 	if !ok {
-		return "", history_reader.ErrNotFound
+		return nil, history_reader.ErrNotFound
 	}
 
 	for _, item := range run.History {
-		if item.ID == historyID && item.Result != nil {
-			return item.Result.Output, nil
+		if item.ID == historyID {
+			if item.Result == nil {
+				return nil, nil
+			}
+
+			return &item.Result.Output, nil
 		}
 	}
 
-	return "", history_reader.ErrNotFound
+	return nil, history_reader.ErrNotFound
 }
 
 func (r *reader) GetRuns(

--- a/pkg/history_reader/reader.go
+++ b/pkg/history_reader/reader.go
@@ -45,7 +45,7 @@ type Reader interface {
 		ctx context.Context,
 		historyID ulid.ULID,
 		opts GetHistoryOutputOpts,
-	) (string, error)
+	) (*string, error)
 	GetRunsByEventID(
 		ctx context.Context,
 		eventID ulid.ULID,

--- a/ui/src/components/Function/RunSection.tsx
+++ b/ui/src/components/Function/RunSection.tsx
@@ -132,7 +132,7 @@ async function getHistoryItemOutput({
 }: {
   historyItemID: string;
   runID: string;
-}): Promise<string> {
+}): Promise<string | undefined> {
   // TODO: How to get type annotations? It returns `any`.
   const res: unknown = await client.request(GetHistoryItemOutputDocument, {
     historyItemID,
@@ -153,6 +153,9 @@ async function getHistoryItemOutput({
   }
   const { historyItemOutput } = functionRun;
 
+  if (historyItemOutput === null) {
+    return undefined;
+  }
   if (typeof historyItemOutput !== 'string') {
     throw new Error('invalid response');
   }

--- a/ui/src/components/Timeline/Timeline.tsx
+++ b/ui/src/components/Timeline/Timeline.tsx
@@ -4,7 +4,7 @@ import type { HistoryNode } from './historyParser';
 import { TimelineNode } from './TimelineNode/TimelineNode';
 
 type Props = {
-  getOutput: (historyItemID: string) => Promise<string>;
+  getOutput: (historyItemID: string) => Promise<string | undefined>;
   history: Record<string, HistoryNode>;
 };
 

--- a/ui/src/components/Timeline/TimelineNode/TimelineNode.tsx
+++ b/ui/src/components/Timeline/TimelineNode/TimelineNode.tsx
@@ -13,7 +13,7 @@ import { type HistoryNode } from '../historyParser/index';
 import renderTimelineNode from './TimelineNodeRenderer';
 
 type Props = {
-  getOutput: (historyItemID: string) => Promise<string>;
+  getOutput: (historyItemID: string) => Promise<string | undefined>;
   node: HistoryNode;
   position: 'first' | 'last' | 'middle';
 };
@@ -91,7 +91,7 @@ function Content({
   getOutput,
   node,
 }: {
-  getOutput: (historyItemID: string) => Promise<string>;
+  getOutput: (historyItemID: string) => Promise<string | undefined>;
   node: HistoryNode;
 }) {
   const output = useOutput({ getOutput, outputItemID: node.outputItemID, status: node.status });
@@ -132,7 +132,7 @@ function useOutput({
   outputItemID,
   status,
 }: {
-  getOutput: (historyItemID: string) => Promise<string>;
+  getOutput: (historyItemID: string) => Promise<string | undefined>;
   outputItemID?: string;
   status: HistoryNode['status'];
 }): React.ReactNode | undefined {
@@ -151,6 +151,11 @@ function useOutput({
 
       try {
         const data = await getOutput(outputItemID);
+        if (data === undefined) {
+          setOutput(undefined);
+          return;
+        }
+
         setOutput(<OutputCard content={data} type={status} />);
       } catch (e) {
         let text = 'Error loading';

--- a/ui/src/store/generated.ts
+++ b/ui/src/store/generated.ts
@@ -113,7 +113,7 @@ export type FunctionRun = {
   function?: Maybe<Function>;
   functionID: Scalars['String'];
   history: Array<RunHistoryItem>;
-  historyItemOutput: Scalars['String'];
+  historyItemOutput?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
   /** @deprecated Field no longer supported */
   name?: Maybe<Scalars['String']>;
@@ -450,7 +450,7 @@ export type GetHistoryItemOutputQueryVariables = Exact<{
 }>;
 
 
-export type GetHistoryItemOutputQuery = { __typename?: 'Query', functionRun?: { __typename?: 'FunctionRun', historyItemOutput: string } | null };
+export type GetHistoryItemOutputQuery = { __typename?: 'Query', functionRun?: { __typename?: 'FunctionRun', historyItemOutput?: string | null } | null };
 
 
 export const GetEventsStreamDocument = `


### PR DESCRIPTION
## Description

Change the backend to no longer expect a `Result` object when looking for history output. The `Result` should eventually always exist but right now it's missing for certain kinds of steps (e.g. `waitForEvent`).

## Context

This is what the UI looked like for a `waitForEvent`:
![image](https://github.com/inngest/inngest/assets/20100586/73ae7858-0825-45ce-8a82-08c1ac941966)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
