### PR TITLE
Ignore ui folder changes in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,11 @@ name: SDK E2E Tests
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "ui/**"
   pull_request:
+    paths-ignore:
+      - "ui/**"
 
 jobs:
   ts:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -3,7 +3,11 @@ name: Go
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "ui/**"
   pull_request:
+    paths-ignore:
+      - "ui/**"
 
 jobs:
   golangci:

--- a/.github/workflows/ui_test.yml
+++ b/.github/workflows/ui_test.yml
@@ -3,7 +3,11 @@ name: Test UI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "ui/**"
   pull_request:
+    paths-ignore:
+      - "ui/**"
 
 jobs:
   build:


### PR DESCRIPTION
## Description

Change CI to not run when changes in the `ui` folder occur. This folder doesn't exist now but will soon contain the Cloud UI.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
