### PR TITLE
feat(dashboard): use short number format for metrics

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/page.tsx
@@ -96,7 +96,10 @@ export default function FunctionDashboardPage({ params }: FunctionDashboardProps
                   Volume
                 </h3>
                 <span className="text-xl font-medium text-slate-800">
-                  {usageMetrics?.totalRuns}
+                  {usageMetrics?.totalRuns.toLocaleString(undefined, {
+                    notation: 'compact',
+                    compactDisplay: 'short',
+                  })}
                 </span>
               </div>
               <div className="inline-flex gap-3">

--- a/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
+++ b/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
@@ -133,7 +133,11 @@ export default function SimpleLineChart({
                               className="mr-2 inline-flex h-3 w-3 rounded"
                               style={{ backgroundColor: l?.color || p.color }}
                             ></span>
-                            {p.value} {l?.name || p.name}
+                            {p.value?.toLocaleString(undefined, {
+                              notation: 'compact',
+                              compactDisplay: 'short',
+                            })}{' '}
+                            {l?.name || p.name}
                           </div>
                         );
                       }) || ''}

--- a/ui/apps/dashboard/src/components/Charts/StackedBarChart.tsx
+++ b/ui/apps/dashboard/src/components/Charts/StackedBarChart.tsx
@@ -150,7 +150,11 @@ export default function StackedBarChart({
                               className="mr-2 inline-flex h-3 w-3 rounded"
                               style={{ backgroundColor: l?.color || p.color }}
                             ></span>
-                            {p.value} {l?.name || p.name}
+                            {p.value?.toLocaleString(undefined, {
+                              notation: 'compact',
+                              compactDisplay: 'short',
+                            })}{' '}
+                            {l?.name || p.name}
                           </div>
                         );
                       }) || ''}


### PR DESCRIPTION
## Description

This uses the short number format for metrics on the function dashboard page:

![image](https://github.com/inngest/inngest/assets/4291707/8c1c952e-68b6-43c9-9cc3-8464b5870d7c)


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
