### PR TITLE
Add queue lifecycle listener

### DIFF
--- a/pkg/execution/state/redis_state/queue_concurrency_test.go
+++ b/pkg/execution/state/redis_state/queue_concurrency_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -22,7 +23,6 @@ func init() {
 }
 
 func TestQueuePartitionConcurrency(t *testing.T) {
-
 	r := miniredis.RunT(t)
 
 	rc, err := rueidis.NewClient(rueidis.ClientOption{
@@ -39,6 +39,7 @@ func TestQueuePartitionConcurrency(t *testing.T) {
 	limit_10 := uuid.New()
 	workflowIDs := []uuid.UUID{limit_1, limit_10}
 
+	// Limit function concurrency by workflow ID.
 	pkf := func(ctx context.Context, p QueuePartition) (string, int) {
 		switch p.WorkflowID {
 		case limit_1:
@@ -51,10 +52,17 @@ func TestQueuePartitionConcurrency(t *testing.T) {
 		}
 	}
 
+	// Create a new lifecycle listener.  This should be invoked each time we hit limits.
+	ll := testLifecycleListener{
+		l:           &sync.Mutex{},
+		concurrency: map[uuid.UUID]int{},
+	}
+
 	q := NewQueue(
 		rc,
 		WithNumWorkers(100),
 		WithPartitionConcurrencyKeyGenerator(pkf),
+		WithQueueLifecycles(ll),
 	)
 
 	var (
@@ -110,7 +118,21 @@ func TestQueuePartitionConcurrency(t *testing.T) {
 		}
 	}
 
+	require.NotZero(t, ll.concurrency[limit_1])
+
 	diff := time.Since(start).Seconds()
 	require.Greater(t, int(diff), 10, "10 jobs should have taken at least 10 seconds")
 	require.Less(t, int(diff), 40, "10 jobs should have taken fewer than 40 seconds") // an extra 2x latency due to race checker
+}
+
+type testLifecycleListener struct {
+	l           *sync.Mutex
+	concurrency map[uuid.UUID]int
+}
+
+func (t testLifecycleListener) OnConcurrencyLimitReached(ctx context.Context, fnID uuid.UUID) {
+	t.l.Lock()
+	i := t.concurrency[fnID]
+	t.concurrency[fnID] = i + 1
+	t.l.Unlock()
 }

--- a/pkg/execution/state/redis_state/queue_lifecycle.go
+++ b/pkg/execution/state/redis_state/queue_lifecycle.go
@@ -1,0 +1,17 @@
+package redis_state
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// QueueLifecycleListener represents a lifecycle listener for queue-related specifics.
+type QueueLifecycleListener interface {
+	// OnConcurrencyLimitReached is called when a queue item cannot be processed due to
+	// concurrency constraints.
+	//
+	// In the future, we should specify which concurrency limit was reached (account,
+	// partition, or custom).
+	OnConcurrencyLimitReached(ctx context.Context, fnID uuid.UUID) error
+}

--- a/pkg/execution/state/redis_state/queue_lifecycle.go
+++ b/pkg/execution/state/redis_state/queue_lifecycle.go
@@ -13,5 +13,5 @@ type QueueLifecycleListener interface {
 	//
 	// In the future, we should specify which concurrency limit was reached (account,
 	// partition, or custom).
-	OnConcurrencyLimitReached(ctx context.Context, fnID uuid.UUID) error
+	OnConcurrencyLimitReached(ctx context.Context, fnID uuid.UUID)
 }


### PR DESCRIPTION
Stub out a new queue lifecycle interface which currently accepts a single method ran when partitions hit their concurrency limit (across any concurrency metric;  acct, partition, or custom).

In the future we'll pad these lifecycle methods with extra detail, such as "on queue failed", "on requeue", etc.


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.
