### PR TITLE
feat(dashboard): display chart's loading state when switching time

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionRunsChart.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionRunsChart.tsx
@@ -34,6 +34,7 @@ export default function FunctionRunsChart({
           default: true,
         },
       ]}
+      isLoading={isFetching}
     />
   );
 }

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionThroughputChart.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionThroughputChart.tsx
@@ -58,11 +58,11 @@ export default function FunctionThroughputChart({
   functionSlug,
   timeRange,
 }: FunctionThroughputChartProps) {
-  const [{ data: environment }] = useEnvironment({
+  const [{ data: environment, fetching: isFetchingEnvironment }] = useEnvironment({
     environmentSlug,
   });
 
-  const [{ data, fetching }] = useQuery({
+  const [{ data, fetching: isFetchingMetrics }] = useQuery({
     query: GetFnRunMetricsDocument,
     variables: {
       environmentID: environment?.id!,
@@ -111,6 +111,7 @@ export default function FunctionThroughputChart({
         { name: 'started', dataKey: 'started', color: '#82ca9d' },
         { name: 'ended', dataKey: 'ended', color: '#8884d8' },
       ]}
+      isLoading={isFetchingEnvironment || isFetchingMetrics}
     />
   );
 }

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/SDKRequestThroughput.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/SDKRequestThroughput.tsx
@@ -62,11 +62,11 @@ export default function SDKReqThroughputChart({
   functionSlug,
   timeRange,
 }: SDKReqThroughputChartProps) {
-  const [{ data: environment }] = useEnvironment({
+  const [{ data: environment, fetching: isFetchingEnvironment }] = useEnvironment({
     environmentSlug,
   });
 
-  const [{ data, fetching }] = useQuery({
+  const [{ data, fetching: isFetchingMetrics }] = useQuery({
     query: GetSDKReqMetricsDocument,
     variables: {
       environmentID: environment?.id!,
@@ -115,6 +115,7 @@ export default function SDKReqThroughputChart({
         { name: 'started', dataKey: 'started', color: '#82ca9d' },
         { name: 'ended', dataKey: 'ended', color: '#8884d8' },
       ]}
+      isLoading={isFetchingEnvironment || isFetchingMetrics}
     />
   );
 }

--- a/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
+++ b/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
@@ -14,6 +14,7 @@ import {
   YAxis,
 } from 'recharts';
 
+import LoadingIcon from '@/icons/LoadingIcon';
 import cn from '@/utils/cn';
 import { minuteTime } from '@/utils/date';
 
@@ -36,6 +37,7 @@ type SimpleLineChartProps = {
     color: string;
     default?: boolean;
   }[];
+  isLoading: boolean;
 };
 
 type AxisProps = {
@@ -80,6 +82,7 @@ export default function SimpleLineChart({
   totalDescription,
   data = [],
   legend = [],
+  isLoading,
 }: SimpleLineChartProps) {
   const flattenData = useMemo(() => {
     return data.map((d) => ({ ...d.values, name: d.name }));
@@ -102,8 +105,12 @@ export default function SimpleLineChart({
         </div>
       </header>
       <div style={{ minHeight: `${height}px` }}>
-        {data.length ? (
-          <ResponsiveContainer height={height} width="100%">
+        <ResponsiveContainer height={height} width="100%">
+          {isLoading ? (
+            <div className="flex h-full w-full items-center justify-center">
+              <LoadingIcon />
+            </div>
+          ) : (
             <LineChart data={flattenData} margin={{ top: 16, bottom: 16 }} barCategoryGap={8}>
               <CartesianGrid strokeDasharray="3 3" vertical={false} />
               <XAxis
@@ -168,10 +175,8 @@ export default function SimpleLineChart({
                 />
               ))}
             </LineChart>
-          </ResponsiveContainer>
-        ) : (
-          'Loading...'
-        )}
+          )}
+        </ResponsiveContainer>
       </div>
     </div>
   );

--- a/ui/apps/dashboard/src/components/Charts/StackedBarChart.tsx
+++ b/ui/apps/dashboard/src/components/Charts/StackedBarChart.tsx
@@ -12,6 +12,7 @@ import {
   YAxis,
 } from 'recharts';
 
+import LoadingIcon from '@/icons/LoadingIcon';
 import cn from '@/utils/cn';
 import { minuteTime } from '@/utils/date';
 
@@ -40,6 +41,7 @@ type BarChartProps = {
     /** The default series to show the min bar height when no data is present */
     default?: boolean;
   }[];
+  isLoading: boolean;
 };
 
 type AxisProps = {
@@ -83,6 +85,7 @@ export default function StackedBarChart({
   totalDescription,
   data = [],
   legend = [],
+  isLoading,
 }: BarChartProps) {
   const flattenedData = useMemo(() => data.map((d) => ({ ...d.values, name: d.name })), [data]);
 
@@ -101,8 +104,12 @@ export default function StackedBarChart({
         </div>
       </header>
       <div style={{ minHeight: `${height}px` }}>
-        {data.length ? (
-          <ResponsiveContainer height={height} width="100%">
+        <ResponsiveContainer height={height} width="100%">
+          {isLoading ? (
+            <div className="flex h-full w-full items-center justify-center">
+              <LoadingIcon />
+            </div>
+          ) : (
             <BarChart
               data={flattenedData}
               margin={{
@@ -180,10 +187,8 @@ export default function StackedBarChart({
                 </Bar>
               ))}
             </BarChart>
-          </ResponsiveContainer>
-        ) : (
-          'Loading...'
-        )}
+          )}
+        </ResponsiveContainer>
       </div>
       {/* <div className="flex justify-end gap-4">
         {legend.map((l) => (


### PR DESCRIPTION
## Description

This displays a loading indicator when switching time range in the functions dashboard:


https://github.com/inngest/inngest/assets/4291707/db35752e-cf47-45dd-9e19-aaafc8a9e997


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.