### PR TITLE
feat(dashboard): make chart legend colors consistent

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/events/[eventName]/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/events/[eventName]/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { ChartBarIcon, ChevronRightIcon, CodeBracketSquareIcon } from '@heroicons/react/20/solid';
+import colors from 'tailwindcss/colors';
 
 import { Alert } from '@/components/Alert';
 import Block from '@/components/Block';
@@ -54,7 +55,7 @@ export default function EventDashboard({ params }: EventDashboardProps) {
             {
               name: 'Events',
               dataKey: 'count',
-              color: '#475569',
+              color: colors.slate['600'],
               default: true,
             },
           ]}

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionRunsChart.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionRunsChart.tsx
@@ -1,3 +1,4 @@
+import colors from 'tailwindcss/colors';
 import { useQuery } from 'urql';
 
 import type { TimeRange } from '@/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/TimeRangeFilter';
@@ -104,9 +105,9 @@ export default function FunctionRunsChart({
       title="Function Runs"
       data={metrics}
       legend={[
-        { name: 'Completed', dataKey: 'completed', color: '#14B8A6' },
-        { name: 'Failed', dataKey: 'failed', color: '#EF4444' },
-        { name: 'Canceled', dataKey: 'canceled', color: '#64748B' },
+        { name: 'Completed', dataKey: 'completed', color: colors.teal['500'] },
+        { name: 'Failed', dataKey: 'failed', color: colors.red['500'] },
+        { name: 'Canceled', dataKey: 'canceled', color: colors.slate['500'] },
       ]}
       isLoading={isFetchingEnvironment || isFetchingFunctionRunsMetrics}
       error={environmentError || functionRunsMetricsError}

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionThroughputChart.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionThroughputChart.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import colors from 'tailwindcss/colors';
 import { useQuery } from 'urql';
 
 import type { TimeRange } from '@/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/TimeRangeFilter';
@@ -108,9 +109,9 @@ export default function FunctionThroughputChart({
       desc="The number of functions being processed over time"
       data={metrics}
       legend={[
-        { name: 'Queued', dataKey: 'queued', color: '#F59E0B' },
-        { name: 'Started', dataKey: 'started', color: '#0EA5E9' },
-        { name: 'Ended', dataKey: 'ended', color: '#14B8A6' },
+        { name: 'Queued', dataKey: 'queued', color: colors.amber['500'] },
+        { name: 'Started', dataKey: 'started', color: colors.sky['500'] },
+        { name: 'Ended', dataKey: 'ended', color: colors.teal['500'] },
       ]}
       isLoading={isFetchingEnvironment || isFetchingMetrics}
       error={environmentError || metricsError}

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionThroughputChart.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionThroughputChart.tsx
@@ -108,9 +108,9 @@ export default function FunctionThroughputChart({
       desc="The number of functions being processed over time"
       data={metrics}
       legend={[
-        { name: 'queued', dataKey: 'queued', color: '#fa8128' },
-        { name: 'started', dataKey: 'started', color: '#82ca9d' },
-        { name: 'ended', dataKey: 'ended', color: '#8884d8' },
+        { name: 'Queued', dataKey: 'queued', color: '#F59E0B' },
+        { name: 'Started', dataKey: 'started', color: '#0EA5E9' },
+        { name: 'Ended', dataKey: 'ended', color: '#14B8A6' },
       ]}
       isLoading={isFetchingEnvironment || isFetchingMetrics}
       error={environmentError || metricsError}

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/SDKRequestThroughput.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/SDKRequestThroughput.tsx
@@ -112,9 +112,9 @@ export default function SDKReqThroughputChart({
       desc="The number of requests to your SDKs over time executing the function and steps, including retries"
       data={metrics}
       legend={[
-        { name: 'queued', dataKey: 'queued', color: '#fa8128' },
-        { name: 'started', dataKey: 'started', color: '#82ca9d' },
-        { name: 'ended', dataKey: 'ended', color: '#8884d8' },
+        { name: 'Queued', dataKey: 'queued', color: '#F59E0B' },
+        { name: 'Started', dataKey: 'started', color: '#0EA5E9' },
+        { name: 'Ended', dataKey: 'ended', color: '#14B8A6' },
       ]}
       isLoading={isFetchingEnvironment || isFetchingMetrics}
       error={environmentError || metricsError}

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/SDKRequestThroughput.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/SDKRequestThroughput.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import colors from 'tailwindcss/colors';
 import { useQuery } from 'urql';
 
 import type { TimeRange } from '@/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/TimeRangeFilter';
@@ -112,9 +113,9 @@ export default function SDKReqThroughputChart({
       desc="The number of requests to your SDKs over time executing the function and steps, including retries"
       data={metrics}
       legend={[
-        { name: 'Queued', dataKey: 'queued', color: '#F59E0B' },
-        { name: 'Started', dataKey: 'started', color: '#0EA5E9' },
-        { name: 'Ended', dataKey: 'ended', color: '#14B8A6' },
+        { name: 'Queued', dataKey: 'queued', color: colors.amber['500'] },
+        { name: 'Started', dataKey: 'started', color: colors.sky['500'] },
+        { name: 'Ended', dataKey: 'ended', color: colors.teal['500'] },
       ]}
       isLoading={isFetchingEnvironment || isFetchingMetrics}
       error={environmentError || metricsError}

--- a/ui/apps/dashboard/src/app/(dashboard)/settings/account/[[...account]]/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/settings/account/[[...account]]/page.tsx
@@ -1,4 +1,5 @@
 import { UserProfile } from '@clerk/nextjs';
+import colors from 'tailwindcss/colors';
 
 const UserProfilePage = () => (
   <div className="min-h-0 flex-1">
@@ -7,7 +8,7 @@ const UserProfilePage = () => (
       routing="path"
       appearance={{
         variables: {
-          colorAlphaShade: '#FFF', // white to hide the Clerk's scrollbar
+          colorAlphaShade: colors.white, // white to hide the Clerk's scrollbar
         },
         elements: {
           rootBox: 'h-full',

--- a/ui/apps/dashboard/src/app/(dashboard)/settings/billing/BillableStepUsage/BillableStepUsage.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/settings/billing/BillableStepUsage/BillableStepUsage.tsx
@@ -13,16 +13,12 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
+import colors from 'tailwindcss/colors';
 
 import { type TimeSeries } from '@/gql/graphql';
 import { StepCounter } from './StepCounter';
 import { formatXAxis, formatYAxis, toLocaleUTCDateString } from './format';
 import { transformData } from './transformData';
-
-const colors = {
-  brand: '#6266f1',
-  dark: '#475569',
-} as const;
 
 const dataKeys = {
   additionalStepCount: {
@@ -152,7 +148,7 @@ export function BillableStepUsage({ data, includedStepCountLimit }: Props) {
 
             <Bar
               dataKey={dataKeys.includedStepCount.key}
-              fill={colors.dark}
+              fill={colors.slate['600']}
               name={dataKeys.includedStepCount.title}
               radius={3}
               stackId="slot"
@@ -179,7 +175,7 @@ export function BillableStepUsage({ data, includedStepCountLimit }: Props) {
 
             <Bar
               dataKey={dataKeys.additionalStepCount.key}
-              fill={colors.brand}
+              fill={colors.indigo['500']}
               name={dataKeys.additionalStepCount.title}
               radius={[3, 3, 0, 0]}
               stackId="slot"

--- a/ui/apps/dashboard/src/app/layout.tsx
+++ b/ui/apps/dashboard/src/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css';
 import React from 'react';
 import { type Metadata } from 'next';
 import { ClerkProvider } from '@clerk/nextjs';
+import colors from 'tailwindcss/colors';
 
 import { BaseWrapper } from './baseWrapper';
 
@@ -25,13 +26,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             logoPlacement: 'outside',
           },
           variables: {
-            colorPrimary: '#6366F1', // indigo-500
-            colorDanger: '#EF4444', // red-500
-            colorSuccess: '#14B8A6', // teal-500
-            colorWarning: '#F59E0B', // amber-500
-            colorAlphaShade: '#0F172A', // slate-900
-            colorText: '#1E293B', // slate-800
-            colorTextSecondary: '#475569', //slate-600
+            colorPrimary: colors.indigo['500'],
+            colorDanger: colors.red['500'],
+            colorSuccess: colors.teal['500'],
+            colorWarning: colors.amber['500'],
+            colorAlphaShade: colors.slate['900'],
+            colorText: colors.slate['800'],
+            colorTextSecondary: colors.slate['600'],
           },
           elements: {
             card: 'shadow-none border-0',

--- a/ui/apps/dashboard/src/app/support/statusPage.ts
+++ b/ui/apps/dashboard/src/app/support/statusPage.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import colors from 'tailwindcss/colors';
 
 type Indicator = 'none' | 'minor' | 'major' | 'critical';
 type StatusPageStatusResponse = {
@@ -26,10 +27,10 @@ type Status = {
 
 // We use hex colors b/c tailwind only includes what is initially rendered
 export const indicatorColor: { [K in Indicator]: string } = {
-  none: '#22c55e', // green-500
-  minor: '#fde047', // yellow-300
-  major: '#f97316', // orange-500
-  critical: '#dc2626', // red-600
+  none: colors.green['500'],
+  minor: colors.yellow['300'],
+  major: colors.orange['500'],
+  critical: colors.red['600'],
 };
 
 const STATUS_PAGE_URL = 'https://status.inngest.com';

--- a/ui/apps/dashboard/src/components/SyntaxHighlighter.tsx
+++ b/ui/apps/dashboard/src/components/SyntaxHighlighter.tsx
@@ -3,6 +3,7 @@
 import { forwardRef } from 'react';
 import ReactSyntaxHighlighter from 'react-syntax-highlighter';
 import { atomOneDark } from 'react-syntax-highlighter/dist/cjs/styles/hljs';
+import colors from 'tailwindcss/colors';
 
 import cn from '@/utils/cn';
 
@@ -12,17 +13,11 @@ type SyntaxHighlighterProps = {
   className?: string;
 };
 
-const colors = {
-  indigo: '#818cf8',
-  green: '#2dd4bf',
-  amber: '#ffb74f',
-};
-
 const theme = {
   ...atomOneDark,
-  'hljs-attr': { color: colors.indigo },
-  'hljs-string': { color: colors.green },
-  'hljs-number': { color: colors.amber },
+  'hljs-attr': { color: colors.indigo['400'] },
+  'hljs-string': { color: colors.teal['400'] },
+  'hljs-number': { color: colors.amber['300'] },
 };
 
 const SyntaxHighlighter = forwardRef(function SyntaxHighlighter(

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/layout.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@
 
 import { classNames } from '@inngest/components/utils/classNames';
 import { Toaster } from 'sonner';
+import colors from 'tailwindcss/colors';
 
 import BG from '@/components/BG';
 import Header from '@/components/Header';
@@ -41,7 +42,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         </Navbar>
       </Header>
       {children}
-      <Toaster theme="dark" toastOptions={{ style: { background: '#334155' } }} />
+      <Toaster theme="dark" toastOptions={{ style: { background: colors.slate['700'] } }} />
     </div>
   );
 }


### PR DESCRIPTION
## Description

This makes the charts in the function dashboard use consistent colors:

![Inngest Cloud (3)](https://github.com/inngest/inngest/assets/4291707/b3c5eebb-3476-4fef-96df-718c51745a16)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
