### PR TITLE
fix(dashboard): function runs chart when selected 60 minutes

### DIFF
--- a/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
+++ b/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
@@ -135,16 +135,14 @@ export default function SimpleLineChart({
                 axisLine={false}
                 tickLine={false}
                 tickSize={2}
-                /* @ts-ignore */
-                tick={<CustomizedXAxisTick />}
+                tick={CustomizedXAxisTick}
               />
               <YAxis
                 domain={[0, 'auto']}
                 allowDataOverflow
                 axisLine={false}
                 tickLine={false}
-                /* @ts-ignore */
-                tick={<CustomizedYAxisTick />}
+                tick={CustomizedYAxisTick}
                 width={10}
               />
               <Tooltip

--- a/ui/apps/dashboard/src/components/Charts/StackedBarChart.tsx
+++ b/ui/apps/dashboard/src/components/Charts/StackedBarChart.tsx
@@ -133,7 +133,6 @@ export default function StackedBarChart({
                 top: 16,
                 bottom: 16,
               }}
-              barCategoryGap={8}
             >
               <CartesianGrid strokeDasharray="3 3" vertical={false} />
               <XAxis
@@ -141,17 +140,14 @@ export default function StackedBarChart({
                 axisLine={false}
                 tickLine={false}
                 tickSize={2}
-                interval={1}
-                /* @ts-ignore */
-                tick={<CustomizedXAxisTick />}
+                tick={CustomizedXAxisTick}
               />
               <YAxis
                 domain={[0, 'auto']}
                 allowDataOverflow
                 axisLine={false}
                 tickLine={false}
-                /* @ts-ignore */
-                tick={<CustomizedYAxisTick />}
+                tick={CustomizedYAxisTick}
                 width={10}
               />
 


### PR DESCRIPTION
## Description

This fixes the function runs chart when selecting a time range of 60 minutes on the function dashboard:

**Before**
![Arc 2023-10-17 at 10 59 53@2x](https://github.com/inngest/inngest/assets/4291707/70285e79-95a7-4405-b973-2e7cd98d493b)

**After**
![Arc 2023-10-17 at 11 00 02@2x](https://github.com/inngest/inngest/assets/4291707/05944cca-ecf9-41a8-91fe-cf098d0ea15e)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
