### PR TITLE
Fix nil panic when changing cron to event trigger

### DIFF
--- a/pkg/coreapi/graph/resolvers/stream.go
+++ b/pkg/coreapi/graph/resolvers/stream.go
@@ -66,7 +66,7 @@ func (r *queryResolver) Stream(ctx context.Context, q models.StreamQuery) ([]*mo
 			if fn, err := fn.InngestFunction(); err == nil {
 				// Should always have at least 1 trigger, but we'll check anyway
 				// to avoid a panic just in case.
-				if (len(fn.Triggers)) >= 0 {
+				if (len(fn.Triggers)) >= 0 && fn.Triggers[0].CronTrigger != nil {
 					// This is a flawed way to get the cron, since this value is
 					// always the latest cron schedule. In other words, if a
 					// user updates the cron schedule for the function then


### PR DESCRIPTION
## Description

Fix nil panic that happens when getting the crontab for a function that's no longer a cron. This can happen when switching a cron-triggered function to an event-triggered function

## Testing

Crontab shows as an empty string instead of panicking:
<img width="663" alt="image" src="https://github.com/inngest/inngest/assets/20100586/0399f488-4e7e-4fea-b7c8-bdfc9bf474cd">

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
