### PR TITLE
When streaming, properly access the request version from embedded headers

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -285,7 +285,7 @@ func (e executor) do(ctx context.Context, url string, input []byte) (*response, 
 		}
 	}
 
-	hv, _ := strconv.Atoi(resp.Header.Get("x-inngest-req-version"))
+	hv, _ := strconv.Atoi(resp.Header.Get(headerRequestVersion))
 
 	var retryAt *time.Time
 	if after := resp.Header.Get("retry-after"); after != "" {
@@ -322,6 +322,8 @@ func (e executor) do(ctx context.Context, url string, input []byte) (*response, 
 			retryAt = &at
 		}
 	}
+
+	hv, _ = strconv.Atoi(stream.Headers[headerRequestVersion])
 
 	return &response{
 		body:           stream.Body,

--- a/pkg/execution/driver/httpdriver/response_parsers.go
+++ b/pkg/execution/driver/httpdriver/response_parsers.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	headerSDK = "x-inngest-sdk"
+	headerSDK            = "x-inngest-sdk"
+	headerRequestVersion = "x-inngest-req-version"
 )
 
 // getSDKVersion parses the SDK version from the response header.


### PR DESCRIPTION
## Description

Fixes an issue where multi-step streamed functions in v3 would fail to retrieve the `x-inngest-req-version` header, resulting in it falling back to `0`.

Fixed by parsing the appropriate header when streaming and warning if we can't find the header where we're supposed to in both paths.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
