### PR TITLE
Put new Cloud StreamDetails behind a feature flag

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/[runId]/layout.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/[runId]/layout.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import { ClockIcon, RectangleStackIcon, RocketLaunchIcon } from '@heroicons/react/20/solid';
 import { HistoryParser } from '@inngest/components/utils/historyParser';
 
+import { getBooleanFlag } from '@/components/FeatureFlags/ServerFeatureFlag';
 import { Time } from '@/components/Time';
 import { graphql } from '@/gql';
 import EventIcon from '@/icons/event.svg';
@@ -10,9 +11,6 @@ import graphqlAPI from '@/queries/graphqlAPI';
 import { getEnvironment } from '@/queries/server-only/getEnvironment';
 import FunctionRunStatusCard from './FunctionRunStatusCard';
 import { StreamDetails } from './StreamDetails';
-
-// TODO: Delete this when the new stream details are ready.
-const isNewStreamDetailsVisible = false;
 
 const GetFunctionRunDetailsDocument = graphql(`
   query GetFunctionRunDetails($environmentID: ID!, $functionSlug: String!, $functionRunID: ULID!) {
@@ -133,7 +131,7 @@ export default async function FunctionRunDetailsLayout({
     throw new Error('missing run');
   }
 
-  if (isNewStreamDetailsVisible) {
+  if (await getBooleanFlag('new-run-details')) {
     return (
       <StreamDetails
         envID={environment.id}

--- a/ui/apps/dashboard/src/components/FeatureFlags/ServerFeatureFlag.tsx
+++ b/ui/apps/dashboard/src/components/FeatureFlags/ServerFeatureFlag.tsx
@@ -10,6 +10,18 @@ type Props = PropsWithChildren<{
 
 // Conditionally renders children based on a feature flag.
 export async function ServerFeatureFlag({ children, defaultValue = false, flag }: Props) {
+  const isEnabled = await getBooleanFlag(flag, { defaultValue });
+  if (isEnabled) {
+    return <>{children}</>;
+  }
+
+  return null;
+}
+
+export async function getBooleanFlag(
+  flag: string,
+  { defaultValue = false }: { defaultValue?: boolean } = {}
+): Promise<boolean> {
   const user = await currentUser();
   const client = await getLaunchDarklyClient();
 
@@ -31,10 +43,5 @@ export async function ServerFeatureFlag({ children, defaultValue = false, flag }
     },
   } as const;
 
-  const isEnabled = await client.variation(flag, context, defaultValue);
-  if (isEnabled) {
-    return <>{children}</>;
-  }
-
-  return null;
+  return client.variation(flag, context, defaultValue);
 }


### PR DESCRIPTION
## Description

- Refactor `getBooleanFlag` out of `ServerFeatureFlag`
- Put new Cloud `StreamDetails` behind a flag that already exists in LaunchDarkly

## Testing

Page works properly when toggling the flag

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
