### PR TITLE
Bundle timezone data for all builds, used for Windows without Go

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	_ "time/tzdata" // bundles timezone data, required for Windows without Go
+
 	"github.com/inngest/inngest/cmd/commands"
 )
 


### PR DESCRIPTION
## Description

Fixes an issue where Windows builds cannot access timezone information if Golang isn't installed on the target system.

⚠️ This currently bundles timezone information for all builds, meaning every binary is ~450KB larger. Ideally, we only do this for Windows builds using `-tags timetzdata`, though I'm not sure of the easiest way to do this within the Goreleaser config.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

## Related

- DataDog/terraform-provider-datadog#560
- hashicorp/nomad#18578
- hashicorp/nomad#18676
