### PR TITLE
Set X-Inngest-Server-Kind header

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -15,6 +15,7 @@ import (
 	"github.com/inngest/inngest/pkg/coreapi/apiutil"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/eventstream"
+	"github.com/inngest/inngest/pkg/headers"
 	"github.com/inngest/inngest/pkg/publicerr"
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
@@ -48,6 +49,7 @@ func NewAPI(o Options) (chi.Router, error) {
 		MaxAge:           60 * 60, // 1 hour
 	})
 	api.Use(cors.Handler)
+	api.Use(headers.StaticHeadersMiddleware(headers.ServerKindDev))
 
 	api.Get("/health", api.HealthCheck)
 	api.Post("/e/{key}", api.ReceiveEvent)

--- a/pkg/coreapi/coreapi.go
+++ b/pkg/coreapi/coreapi.go
@@ -17,6 +17,7 @@ import (
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/execution/runner"
 	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/headers"
 	"github.com/inngest/inngest/pkg/history_drivers/memory_reader"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/publicerr"
@@ -54,6 +55,7 @@ func NewCoreApi(o Options) (*CoreAPI, error) {
 		AllowCredentials: false,
 	})
 	a.Use(cors.Handler)
+	a.Use(headers.StaticHeadersMiddleware(headers.ServerKindDev))
 
 	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &resolvers.Resolver{
 		Data:          o.Data,

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/api/tel"
 	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/headers"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/inngest/version"
 	"github.com/inngest/inngest/pkg/logger"
@@ -53,6 +54,7 @@ func (a *devapi) addRoutes() {
 		}
 		return http.HandlerFunc(fn)
 	})
+	a.Use(headers.StaticHeadersMiddleware(headers.ServerKindDev))
 
 	a.Get("/dev", a.Info)
 	a.Post("/fn/register", a.Register)

--- a/pkg/headers/headers.go
+++ b/pkg/headers/headers.go
@@ -1,0 +1,25 @@
+package headers
+
+import (
+	"net/http"
+)
+
+const (
+	// Tells the consumers (e.g. SDKs) what kind of Inngest server they're
+	// communicating with (Cloud or Dev Server).
+	HeaderKeyServerKind = "X-Inngest-Server-Kind"
+)
+
+const (
+	ServerKindCloud = "cloud"
+	ServerKindDev   = "dev"
+)
+
+func StaticHeadersMiddleware(serverKind string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set(HeaderKeyServerKind, serverKind)
+			next.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Set a new `X-Inngest-Server-Kind` header which will tell SDKs what kind of Inngest server they're dealing with. This is helpful for the following situations:
- Mitigate the "Dev Server triggered a Cloud deploy" scenario
- Check whether `INNGEST_BASE_URL` is actually pointing at an Inngest server

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
