### PR TITLE
Fix getHistoryItemOutput erroring when null

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/[runId]/StreamDetails.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/[runId]/StreamDetails.tsx
@@ -105,9 +105,5 @@ async function getHistoryItemOutput({
     throw res.error;
   }
 
-  const { historyItemOutput } = res.data?.environment.function?.run ?? {};
-  if (!historyItemOutput) {
-    throw new Error('invalid response');
-  }
-  return historyItemOutput;
+  return res.data?.environment.function?.run.historyItemOutput ?? undefined;
 }


### PR DESCRIPTION
## Description

Fix `getHistoryItemOutput` not handling null values

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
