### PR TITLE
Fix in-memory history writer race condition

### DIFF
--- a/pkg/history_drivers/memory_writer/writer.go
+++ b/pkg/history_drivers/memory_writer/writer.go
@@ -7,7 +7,6 @@ import (
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/history"
 	"github.com/inngest/inngest/pkg/history_drivers/memory_store"
-	"github.com/inngest/inngest/pkg/history_reader"
 	"github.com/inngest/inngest/pkg/inngest/log"
 )
 
@@ -80,21 +79,18 @@ func (w *writer) writeWorkflowStart(
 	ctx context.Context,
 	item history.History,
 ) {
-	data := memory_store.RunData{
-		Run: history_reader.Run{
-			AccountID:       item.AccountID,
-			BatchID:         item.BatchID,
-			EventID:         item.EventID,
-			ID:              item.RunID,
-			OriginalRunID:   item.OriginalRunID,
-			StartedAt:       time.UnixMilli(int64(item.RunID.Time())),
-			Status:          enums.RunStatusRunning,
-			WorkflowID:      item.FunctionID,
-			WorkspaceID:     item.WorkspaceID,
-			WorkflowVersion: int(item.FunctionVersion),
-		},
-	}
-	w.store.Data[item.RunID] = data
+	run := w.store.Data[item.RunID]
+	run.Run.AccountID = item.AccountID
+	run.Run.BatchID = item.BatchID
+	run.Run.EventID = item.EventID
+	run.Run.ID = item.RunID
+	run.Run.OriginalRunID = item.OriginalRunID
+	run.Run.StartedAt = time.UnixMilli(int64(item.RunID.Time()))
+	run.Run.Status = enums.RunStatusRunning
+	run.Run.WorkflowID = item.FunctionID
+	run.Run.WorkspaceID = item.WorkspaceID
+	run.Run.WorkflowVersion = int(item.FunctionVersion)
+	w.store.Data[item.RunID] = run
 }
 
 func timePtr(t time.Time) *time.Time {


### PR DESCRIPTION
## Description

Fix race condition where history is overwritten when the `FunctionStarted` item is received after another item (e.g. `StepStarted`)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
