### PR TITLE
Add history_reader.Run.Output

### DIFF
--- a/pkg/history_drivers/memory_writer/writer.go
+++ b/pkg/history_drivers/memory_writer/writer.go
@@ -85,6 +85,11 @@ func (w *writer) writeWorkflowStart(
 	run.Run.EventID = item.EventID
 	run.Run.ID = item.RunID
 	run.Run.OriginalRunID = item.OriginalRunID
+
+	if item.Result != nil {
+		run.Run.Output = &item.Result.Output
+	}
+
 	run.Run.StartedAt = time.UnixMilli(int64(item.RunID.Time()))
 	run.Run.Status = enums.RunStatusRunning
 	run.Run.WorkflowID = item.FunctionID

--- a/pkg/history_reader/reader.go
+++ b/pkg/history_reader/reader.go
@@ -212,6 +212,7 @@ type Run struct {
 	EventID         ulid.ULID
 	ID              ulid.ULID
 	OriginalRunID   *ulid.ULID
+	Output          *string
 	StartedAt       time.Time
 	Status          enums.RunStatus
 	WorkflowID      uuid.UUID


### PR DESCRIPTION
## Description

Add `history_reader.Run.Output` so that Cloud can return run output from the history reader

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
