### PR TITLE
Fix timeline node order

### DIFF
--- a/ui/packages/components/src/RunDetails/RunDetails.tsx
+++ b/ui/packages/components/src/RunDetails/RunDetails.tsx
@@ -80,14 +80,14 @@ export function RunDetails({
           <OutputCard content={run.output} type={type} />
         )}
 
-        <WaitingSummary history={history.groups} />
-        <SleepingSummary history={history.groups} />
+        <WaitingSummary history={history} />
+        <SleepingSummary history={history} />
       </div>
 
       <hr className="mt-8 border-slate-800/50" />
       <div className="px-5 pt-4">
         <h3 className="py-4 text-sm text-slate-400">Timeline</h3>
-        <Timeline getOutput={getHistoryItemOutput} history={history.groups} />
+        <Timeline getOutput={getHistoryItemOutput} history={history} />
       </div>
     </ContentCard>
   );

--- a/ui/packages/components/src/RunDetails/SleepingSummary.tsx
+++ b/ui/packages/components/src/RunDetails/SleepingSummary.tsx
@@ -3,10 +3,10 @@
 import { useEffect, useState } from 'react';
 import { Card } from '@inngest/components/Card';
 import { MetadataItem } from '@inngest/components/Metadata';
-import type { HistoryNode } from '@inngest/components/utils/historyParser';
+import type { HistoryNode, HistoryParser } from '@inngest/components/utils/historyParser';
 
 type Props = {
-  history: Record<string, HistoryNode>;
+  history: HistoryParser;
 };
 
 export function SleepingSummary({ history }: Props) {
@@ -43,12 +43,12 @@ export function SleepingSummary({ history }: Props) {
   );
 }
 
-function useActiveSleeps(history: Record<string, HistoryNode>): HistoryNode[] {
+function useActiveSleeps(history: HistoryParser): HistoryNode[] {
   const [nodes, setNodes] = useState<HistoryNode[]>([]);
 
   useEffect(() => {
     const newWaits: HistoryNode[] = [];
-    for (const node of Object.values(history)) {
+    for (const node of history.getGroups()) {
       if (node.status === 'sleeping') {
         newWaits.push(node);
       }

--- a/ui/packages/components/src/RunDetails/WaitingSummary.tsx
+++ b/ui/packages/components/src/RunDetails/WaitingSummary.tsx
@@ -4,10 +4,10 @@ import { useEffect, useState } from 'react';
 import { Card } from '@inngest/components/Card';
 import { MetadataItem } from '@inngest/components/Metadata';
 import { IconEvent } from '@inngest/components/icons/Event';
-import type { HistoryNode } from '@inngest/components/utils/historyParser';
+import type { HistoryNode, HistoryParser } from '@inngest/components/utils/historyParser';
 
 type Props = {
-  history: Record<string, HistoryNode>;
+  history: HistoryParser;
 };
 
 export function WaitingSummary({ history }: Props) {
@@ -59,12 +59,12 @@ export function WaitingSummary({ history }: Props) {
   );
 }
 
-function useActiveWaits(history: Record<string, HistoryNode>): HistoryNode[] {
+function useActiveWaits(history: HistoryParser): HistoryNode[] {
   const [waits, setWaits] = useState<HistoryNode[]>([]);
 
   useEffect(() => {
     const newWaits: HistoryNode[] = [];
-    for (const node of Object.values(history)) {
+    for (const node of history.getGroups()) {
       if (node.status === 'waiting') {
         newWaits.push(node);
       }

--- a/ui/packages/components/src/Timeline/Timeline.stories.tsx
+++ b/ui/packages/components/src/Timeline/Timeline.stories.tsx
@@ -39,7 +39,7 @@ const meta = {
   // is used. If there is a delayMS, then we'll simulate each history item being
   // added one at a time.
   render: ({ _rawHistory, _rawHistoryFrame, ...args }) => {
-    const [history, setHistory] = useState<Record<string, HistoryNode>>(args.history);
+    const [history, setHistory] = useState<HistoryParser>(args.history);
 
     useEffect(() => {
       const parser = new HistoryParser();
@@ -47,7 +47,7 @@ const meta = {
         // @ts-ignore
         parser.append(_rawHistory[i]);
       }
-      setHistory(parser.groups);
+      setHistory(parser);
     }, [_rawHistoryFrame]);
 
     return (
@@ -70,7 +70,7 @@ function createStory(rawHistory: unknown) {
     args: {
       _rawHistory: raw,
       _rawHistoryFrame: raw.length - 1,
-      history: new HistoryParser(raw).groups,
+      history: new HistoryParser(raw),
     },
     argTypes: {
       _rawHistory: {

--- a/ui/packages/components/src/Timeline/Timeline.tsx
+++ b/ui/packages/components/src/Timeline/Timeline.tsx
@@ -1,17 +1,17 @@
 'use client';
 
-import type { HistoryNode } from '@inngest/components/utils/historyParser';
+import type { HistoryNode, HistoryParser } from '@inngest/components/utils/historyParser';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 
 import { TimelineNode } from './TimelineNode/TimelineNode';
 
 type Props = {
   getOutput: (historyItemID: string) => Promise<string | undefined>;
-  history: Record<string, HistoryNode>;
+  history: HistoryParser;
 };
 
 export function Timeline({ getOutput, history }: Props) {
-  const nodes = Object.values(history).sort(sortAscending);
+  const nodes = history.getGroups({ sort: true });
 
   return (
     <div>

--- a/ui/packages/components/src/hooks/useParsedHistory.ts
+++ b/ui/packages/components/src/hooks/useParsedHistory.ts
@@ -6,7 +6,7 @@ export function useParsedHistory(rawHistory: RawHistoryItem[]): HistoryParser {
 
   useEffect(() => {
     if (rawHistory.length === 0) {
-      if (Object.keys(history.groups).length > 0) {
+      if (Object.keys(history.getGroups()).length > 0) {
         setHistory(new HistoryParser());
       }
 

--- a/ui/packages/components/src/utils/historyParser/historyParser.test.ts
+++ b/ui/packages/components/src/utils/historyParser/historyParser.test.ts
@@ -7,10 +7,7 @@ import type { HistoryNode } from './types';
 
 async function loadHistory(filename: string) {
   const raw = JSON.parse(await fs.readFile(path.join(__dirname, `testData/${filename}`), 'utf8'));
-
-  return Object.values(new HistoryParser(raw).groups).sort((a, b) => {
-    return a.scheduledAt.getTime() - b.scheduledAt.getTime();
-  });
+  return new HistoryParser(raw).getGroups({ sort: true });
 }
 
 const baseRunStartNode = {


### PR DESCRIPTION
## Description

Fix "start" and "end" nodes not always first and last in the timeline node.

## Testing

![image](https://github.com/inngest/inngest/assets/20100586/d08fc1c9-702c-4470-8c68-f2a46fe5a353)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
