### PR TITLE
INN 2283 vertically align timeline items to the middle

### DIFF
--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.stories.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.stories.tsx
@@ -1,3 +1,4 @@
+import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { TimelineNode } from './TimelineNode';
@@ -9,7 +10,9 @@ const meta = {
     (Story) => {
       return (
         <div style={{ width: 600 }}>
-          <Story />
+          <AccordionPrimitive.Root type="multiple">
+            <Story />
+          </AccordionPrimitive.Root>
         </div>
       );
     },

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
@@ -48,7 +48,7 @@ export function TimelineNode({ position, getOutput, node }: Props) {
         )}
         aria-hidden="true"
       />
-      <AccordionPrimitive.Header className="flex gap-2 py-6">
+      <AccordionPrimitive.Header className="flex items-start gap-2 py-6">
         <div className="z-10 flex-1">
           <TimelineNodeHeader icon={icon} badge={badge} title={name} metadata={metadata} />
         </div>

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeHeader/TimelineNodeHeader.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeHeader/TimelineNodeHeader.tsx
@@ -12,9 +12,9 @@ type Props = {
 
 export function TimelineNodeHeader({ icon, badge, title, metadata }: Props) {
   return (
-    <div className="flex items-start justify-between leading-7 text-slate-100	">
+    <div className="flex items-start justify-between text-sm leading-8 text-slate-100">
       <div className="mr-2 flex flex-1 items-start gap-2">
-        <div className="flex items-center gap-2">
+        <div className="flex h-8 items-center gap-2">
           {icon}
           {badge && (
             <Badge kind="solid" className="bg-slate-800 text-slate-400">
@@ -22,11 +22,11 @@ export function TimelineNodeHeader({ icon, badge, title, metadata }: Props) {
             </Badge>
           )}
         </div>
-        <p className=" flex-1 text-base">{title}</p>
+        <p className="flex-1 align-top leading-8">{title}</p>
       </div>
-      <div className="flex items-center gap-2">
-        <p className="text-xs">{metadata?.label}</p>
-        <p className="text-sm">{metadata?.value}</p>
+      <div className="flex items-center gap-2 leading-8">
+        <p>{metadata?.label}</p>
+        <p>{metadata?.value}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Description

- Align items to the start of the row, but make it look like it's centered (so we can handle bigger names better)
- Normalize font sizes of timeline node headers


<img width="587" alt="Screenshot 2023-10-30 at 19 46 33" src="https://github.com/inngest/inngest/assets/16758464/96701685-0daa-453b-9a92-f14bcc268cea">


## Type of change (choose one)
- [X] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
