### PR TITLE
Fix issue with not displaying enterprise trial plan

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/settings/billing/BillingPlanOption.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/settings/billing/BillingPlanOption.tsx
@@ -20,6 +20,7 @@ type BillingPlanOptionProps = {
   isLowerTierPlan: boolean;
   isActive: boolean;
   isPremium: boolean;
+  isTrial: boolean;
   usagePercentage: number;
   features: Record<string, unknown>;
   preventDowngrade: boolean;
@@ -47,6 +48,7 @@ export default function BillingPlanOption({
   isLowerTierPlan,
   isActive,
   isPremium,
+  isTrial,
   usagePercentage,
   features,
   preventDowngrade,
@@ -68,7 +70,7 @@ export default function BillingPlanOption({
         <PlanBadge variant={isActive || !isLowerTierPlan ? 'primary' : 'default'}>
           {badgeText}
         </PlanBadge>
-        <div className="text-lg font-bold">{cost}</div>
+        <div className="text-lg font-bold">{isTrial ? 'Trial' : cost}</div>
       </Row>
 
       <Row className="mb-1.5">
@@ -91,14 +93,14 @@ export default function BillingPlanOption({
         target={isPremium ? '_blank' : undefined}
         btnAction={!isPremium ? onClick : undefined}
         className="mt-5 w-full"
-        appearance={isActive || isLowerTierPlan ? 'outlined' : 'solid'}
-        kind={isActive ? 'danger' : isLowerTierPlan ? 'default' : 'primary'}
+        appearance={!isPremium && (isActive || isLowerTierPlan) ? 'outlined' : 'solid'}
+        kind={isActive && !isPremium ? 'danger' : isLowerTierPlan ? 'default' : 'primary'}
         disabled={preventDowngrade && isLowerTierPlan}
         label={
-          isLowerTierPlan
-            ? 'Downgrade Plan'
-            : isActive && isPremium
+          isActive && isPremium
             ? 'Contact Account Manager'
+            : isLowerTierPlan
+            ? 'Downgrade Plan'
             : isActive
             ? 'Cancel Subscription'
             : isPremium

--- a/ui/apps/dashboard/src/app/(dashboard)/settings/billing/CurrentSubscription.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/settings/billing/CurrentSubscription.tsx
@@ -5,17 +5,21 @@ import { day } from '@/utils/date';
 import { FeatureRows, featureRows } from './BillingPlanOption';
 import PaymentsButton from './PaymentsButton';
 import PlanBadge from './PlanBadge';
-import { type ExtendedBillingPlan } from './utils';
+import { isTrialPlan, type ExtendedBillingPlan } from './utils';
 
 export default function CurrentSubscription({
   subscription,
   currentPlan,
+  isCurrentPlanEnterprise,
   freePlan,
 }: {
   subscription?: BillingSubscription;
   currentPlan?: BillingPlan;
+  isCurrentPlanEnterprise: boolean;
   freePlan?: ExtendedBillingPlan;
 }) {
+  const isOnPaidPlan = isCurrentPlanEnterprise || currentPlan?.amount !== 0;
+  const isTrial = currentPlan ? isTrialPlan(currentPlan) : false;
   const nextInvoiceDate = subscription?.nextInvoiceDate
     ? day(subscription?.nextInvoiceDate)
     : undefined;
@@ -24,19 +28,27 @@ export default function CurrentSubscription({
   return (
     <div className="rounded-lg border border-slate-300 bg-white">
       <div className="p-6">
-        {nextInvoiceDate ? (
+        {isOnPaidPlan ? (
           <>
-            <h2 className="mb-6 text-[1.375rem] font-semibold">Next Payment</h2>
+            <h2 className="mb-6 text-[1.375rem] font-semibold">
+              {isTrial ? 'Your account is on a trial plan' : 'Next Payment'}
+            </h2>
             <p className="my-4 flex gap-4 text-xl">
-              <span className="font-medium">
-                ${currentPlan?.amount ? currentPlan?.amount / 100 : '0'}
-              </span>
+              {!isTrial && (
+                <span className="font-medium">
+                  ${currentPlan?.amount ? currentPlan?.amount / 100 : '0'}
+                </span>
+              )}
               <PlanBadge variant="primary">{currentPlan?.name}</PlanBadge>
             </p>
-            <p className="my-4 text-sm text-slate-600">
-              Next charge on <strong>{nextInvoiceDate}</strong>
-            </p>
-            <PaymentsButton />
+            {!!nextInvoiceDate && (
+              <>
+                <p className="my-4 text-sm text-slate-600">
+                  Next charge on <strong>{nextInvoiceDate}</strong>
+                </p>
+                <PaymentsButton />
+              </>
+            )}
           </>
         ) : (
           <>

--- a/ui/apps/dashboard/src/app/(dashboard)/settings/billing/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/settings/billing/page.tsx
@@ -104,10 +104,11 @@ export default async function Billing() {
     ? transformData(billableStepDataThisMonth, includedStepCountLimit)
     : { totalStepCount: 0 };
 
+  // Always sort enterprise plans (including trials) last no matter the amount
   const plans =
     basePlans
       ?.map((plan) => (plan ? transformPlan({ plan, currentPlan, usage: totalStepCount }) : null))
-      .sort((a, b) => (a?.amount || 0) - (b?.amount || 0)) || [];
+      .sort((a, b) => (a?.isPremium ? 1 : (a?.amount || 0) - (b?.amount || 0))) || [];
   const isCurrentPlanEnterprise = currentPlan != undefined && isEnterprisePlan(currentPlan);
   const freePlan = plans.find((p) => p?.isFreeTier);
 
@@ -122,6 +123,7 @@ export default async function Billing() {
           <CurrentSubscription
             subscription={subscription || undefined}
             currentPlan={currentPlan || undefined}
+            isCurrentPlanEnterprise={isCurrentPlanEnterprise}
             freePlan={freePlan || undefined}
           />
           <div className="col-span-3 pl-6">


### PR DESCRIPTION
## Description

The UI previously would not show if the user was on an enterprise trial due to some conditional logic in the UI working with plans that have a $0 plan amount. This fixes that logic and also updates the current subscription block to show that the user is on a trial. 

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
