### PR TITLE
Set X-Inngest-Server-Kind header during registration

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/inngest/inngest/pkg/headers"
 	"github.com/inngest/inngest/pkg/publicerr"
 )
 
@@ -43,6 +44,7 @@ func Ping(ctx context.Context, url string) error {
 			},
 		)
 	}
+	req.Header.Set(headers.HeaderKeyServerKind, headers.ServerKindDev)
 	resp, err := Client.Do(req)
 	if err != nil {
 		err = handlePingError(err)


### PR DESCRIPTION
## Description

Make Dev Server send the `X-Inngest-Server-Kind` header when pinging apps

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
