### PR TITLE
Add deleteAppByName mutation

### DIFF
--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -139,9 +139,10 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		CreateApp func(childComplexity int, input models.CreateAppInput) int
-		DeleteApp func(childComplexity int, id string) int
-		UpdateApp func(childComplexity int, input models.UpdateAppInput) int
+		CreateApp       func(childComplexity int, input models.CreateAppInput) int
+		DeleteApp       func(childComplexity int, id string) int
+		DeleteAppByName func(childComplexity int, name string) int
+		UpdateApp       func(childComplexity int, input models.UpdateAppInput) int
 	}
 
 	Query struct {
@@ -271,6 +272,7 @@ type MutationResolver interface {
 	CreateApp(ctx context.Context, input models.CreateAppInput) (*cqrs.App, error)
 	UpdateApp(ctx context.Context, input models.UpdateAppInput) (*cqrs.App, error)
 	DeleteApp(ctx context.Context, id string) (string, error)
+	DeleteAppByName(ctx context.Context, name string) (bool, error)
 }
 type QueryResolver interface {
 	Apps(ctx context.Context) ([]*cqrs.App, error)
@@ -752,6 +754,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Mutation.DeleteApp(childComplexity, args["id"].(string)), true
+
+	case "Mutation.deleteAppByName":
+		if e.complexity.Mutation.DeleteAppByName == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_deleteAppByName_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.DeleteAppByName(childComplexity, args["name"].(string)), true
 
 	case "Mutation.updateApp":
 		if e.complexity.Mutation.UpdateApp == nil {
@@ -1248,6 +1262,7 @@ var sources = []*ast.Source{
   createApp(input: CreateAppInput!): App!
   updateApp(input: UpdateAppInput!): App!
   deleteApp(id: String!): String! # returns the ID of the deleted app
+  deleteAppByName(name: String!): Boolean!
 }
 
 input CreateAppInput {
@@ -1621,6 +1636,21 @@ func (ec *executionContext) field_Mutation_createApp_args(ctx context.Context, r
 		}
 	}
 	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_deleteAppByName_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 string
+	if tmp, ok := rawArgs["name"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+		arg0, err = ec.unmarshalNString2string(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["name"] = arg0
 	return args, nil
 }
 
@@ -4796,6 +4826,61 @@ func (ec *executionContext) fieldContext_Mutation_deleteApp(ctx context.Context,
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_deleteApp_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_deleteAppByName(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_deleteAppByName(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().DeleteAppByName(rctx, fc.Args["name"].(string))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(bool)
+	fc.Result = res
+	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_deleteAppByName(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_deleteAppByName_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -9657,7 +9742,6 @@ func (ec *executionContext) _FunctionRunEvent(ctx context.Context, sel ast.Selec
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
-	panic(fmt.Errorf("unexpected type %T", obj))
 }
 
 // endregion ************************** interface.gotpl ***************************
@@ -10476,6 +10560,15 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_deleteApp(ctx, field)
+			})
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "deleteAppByName":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_deleteAppByName(ctx, field)
 			})
 
 			if out.Values[i] == graphql.Null {

--- a/pkg/coreapi/gql.mutations.graphql
+++ b/pkg/coreapi/gql.mutations.graphql
@@ -2,6 +2,7 @@ type Mutation {
   createApp(input: CreateAppInput!): App!
   updateApp(input: UpdateAppInput!): App!
   deleteApp(id: String!): String! # returns the ID of the deleted app
+  deleteAppByName(name: String!): Boolean!
 }
 
 input CreateAppInput {

--- a/pkg/coreapi/graph/resolvers/app_mutations.go
+++ b/pkg/coreapi/graph/resolvers/app_mutations.go
@@ -63,3 +63,21 @@ func (r *mutationResolver) DeleteApp(ctx context.Context, idstr string) (string,
 	}
 	return idstr, nil
 }
+
+func (r *mutationResolver) DeleteAppByName(
+	ctx context.Context,
+	name string,
+) (bool, error) {
+	apps, err := r.Data.GetApps(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	for _, app := range apps {
+		if app.Name == name {
+			return true, r.Data.DeleteApp(ctx, app.ID)
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
## Description

Add `deleteAppByName` mutation. Integration tests can use this to cleanup apps they create

## Context

Running integration tests against a long-running Dev Server results in a buildup of ephemeral test apps. These tests need to be able to clean up after themselves

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
