### PR TITLE
use id instead of name in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Here's an example:
 ```ts
 import { Inngest } from "inngest";
 
-const inngest = new Inngest({ name: "My App" });
+const inngest = new Inngest({ id: "my-app" });
 
 // This function will be invoked by Inngest via HTTP any time the "app/user.signup"
 // event is sent to to Inngest


### PR DESCRIPTION
## Description
Name is deprecated it seems in the latest version, so I changed this to use id like in the other docs I've seen.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [x] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
