### PR TITLE
Change default event `received_before` to 1h

### DIFF
--- a/pkg/cqrs/events.go
+++ b/pkg/cqrs/events.go
@@ -27,7 +27,7 @@ func ConvertFromEvent(internalID ulid.ULID, e event.Event) Event {
 type Event struct {
 	ID          ulid.ULID  `json:"internal_id"`
 	AccountID   uuid.UUID  `json:"account_id"`
-	WorkspaceID uuid.UUID  `json:"workspace_id"`
+	WorkspaceID uuid.UUID  `json:"environment_id"`
 	Source      string     `json:"source"`
 	SourceID    *uuid.UUID `json:"source_id"`
 	ReceivedAt  time.Time  `json:"received_at"`

--- a/pkg/cqrs/events.go
+++ b/pkg/cqrs/events.go
@@ -12,10 +12,6 @@ import (
 
 const MaxEvents = 51
 
-var (
-	year = time.Hour * 24 * 365
-)
-
 func ConvertFromEvent(internalID ulid.ULID, e event.Event) Event {
 	return Event{
 		ID:           internalID,
@@ -93,8 +89,8 @@ func (o *WorkspaceEventsOpts) Validate() error {
 		o.Newest = time.Now()
 	}
 	if o.Oldest.IsZero() {
-		// 1 year ago, ie all events
-		o.Oldest = time.Now().Add(year * -1)
+		// Default to one hour ago.
+		o.Oldest = time.Now().Add(time.Hour * -1)
 	}
 	return nil
 }

--- a/pkg/cqrs/function_runs.go
+++ b/pkg/cqrs/function_runs.go
@@ -16,7 +16,7 @@ type FunctionRun struct {
 	RunStartedAt    time.Time       `json:"run_started_at"`
 	FunctionID      uuid.UUID       `json:"function_id"`
 	FunctionVersion int64           `json:"function_version"`
-	WorkspaceID     uuid.UUID       `json:"workspace_id"`
+	WorkspaceID     uuid.UUID       `json:"environment_id"`
 	EventID         ulid.ULID       `json:"event_id"`
 	BatchID         *ulid.ULID      `json:"batch_id,omitempty"`
 	OriginalRunID   *ulid.ULID      `json:"original_run_id,omitempty"`


### PR DESCRIPTION
By default we should filter from events within the last 1h.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
