### PR TITLE
Fix wrong event returned for functionRuns

### DIFF
--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -107,6 +107,7 @@ type ComplexityRoot struct {
 
 	FunctionRun struct {
 		Event             func(childComplexity int) int
+		EventID           func(childComplexity int) int
 		FinishedAt        func(childComplexity int) int
 		Function          func(childComplexity int) int
 		FunctionID        func(childComplexity int) int
@@ -562,6 +563,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.FunctionRun.Event(childComplexity), true
+
+	case "FunctionRun.eventID":
+		if e.complexity.FunctionRun.EventID == nil {
+			break
+		}
+
+		return e.complexity.FunctionRun.EventID(childComplexity), true
 
 	case "FunctionRun.finishedAt":
 		if e.complexity.FunctionRun.FinishedAt == nil {
@@ -1514,6 +1522,7 @@ type FunctionRun {
   history: [RunHistoryItem!]!
   historyItemOutput(id: ULID!): String
   name: String @deprecated # use the embedded function field instead.
+  eventID: ID!
 }
 
 enum HistoryType {
@@ -2801,6 +2810,8 @@ func (ec *executionContext) fieldContext_Event_functionRuns(ctx context.Context,
 				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
 			case "name":
 				return ec.fieldContext_FunctionRun_name(ctx, field)
+			case "eventID":
+				return ec.fieldContext_FunctionRun_eventID(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FunctionRun", field.Name)
 		},
@@ -3344,6 +3355,8 @@ func (ec *executionContext) fieldContext_FunctionEvent_functionRun(ctx context.C
 				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
 			case "name":
 				return ec.fieldContext_FunctionRun_name(ctx, field)
+			case "eventID":
+				return ec.fieldContext_FunctionRun_eventID(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FunctionRun", field.Name)
 		},
@@ -4190,6 +4203,50 @@ func (ec *executionContext) fieldContext_FunctionRun_name(ctx context.Context, f
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FunctionRun_eventID(ctx context.Context, field graphql.CollectedField, obj *models.FunctionRun) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FunctionRun_eventID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EventID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FunctionRun_eventID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FunctionRun",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
 		},
 	}
 	return fc, nil
@@ -5218,6 +5275,8 @@ func (ec *executionContext) fieldContext_Query_functionRun(ctx context.Context, 
 				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
 			case "name":
 				return ec.fieldContext_FunctionRun_name(ctx, field)
+			case "eventID":
+				return ec.fieldContext_FunctionRun_eventID(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FunctionRun", field.Name)
 		},
@@ -5302,6 +5361,8 @@ func (ec *executionContext) fieldContext_Query_functionRuns(ctx context.Context,
 				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
 			case "name":
 				return ec.fieldContext_FunctionRun_name(ctx, field)
+			case "eventID":
+				return ec.fieldContext_FunctionRun_eventID(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FunctionRun", field.Name)
 		},
@@ -6871,6 +6932,8 @@ func (ec *executionContext) fieldContext_StepEvent_functionRun(ctx context.Conte
 				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
 			case "name":
 				return ec.fieldContext_FunctionRun_name(ctx, field)
+			case "eventID":
+				return ec.fieldContext_FunctionRun_eventID(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FunctionRun", field.Name)
 		},
@@ -7500,6 +7563,8 @@ func (ec *executionContext) fieldContext_StreamItem_runs(ctx context.Context, fi
 				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
 			case "name":
 				return ec.fieldContext_FunctionRun_name(ctx, field)
+			case "eventID":
+				return ec.fieldContext_FunctionRun_eventID(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type FunctionRun", field.Name)
 		},
@@ -9657,7 +9722,6 @@ func (ec *executionContext) _FunctionRunEvent(ctx context.Context, sel ast.Selec
 	default:
 		panic(fmt.Errorf("unexpected type %T", obj))
 	}
-	panic(fmt.Errorf("unexpected type %T", obj))
 }
 
 // endregion ************************** interface.gotpl ***************************
@@ -10325,6 +10389,13 @@ func (ec *executionContext) _FunctionRun(ctx context.Context, sel ast.SelectionS
 
 			out.Values[i] = ec._FunctionRun_name(ctx, field, obj)
 
+		case "eventID":
+
+			out.Values[i] = ec._FunctionRun_eventID(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -195,6 +195,7 @@ type FunctionRun {
   history: [RunHistoryItem!]!
   historyItemOutput(id: ULID!): String
   name: String @deprecated # use the embedded function field instead.
+  eventID: ID!
 }
 
 enum HistoryType {

--- a/pkg/coreapi/graph/models/converters.go
+++ b/pkg/coreapi/graph/models/converters.go
@@ -54,6 +54,7 @@ func MakeFunctionRun(f *cqrs.FunctionRun) *FunctionRun {
 		FunctionID: f.FunctionID.String(),
 		FinishedAt: f.EndedAt,
 		StartedAt:  &f.RunStartedAt,
+		EventID:    f.EventID.String(),
 	}
 	if len(f.Output) > 0 {
 		str := string(f.Output)

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -88,6 +88,7 @@ type FunctionRun struct {
 	History           []*history_reader.RunHistory `json:"history"`
 	HistoryItemOutput *string                      `json:"historyItemOutput,omitempty"`
 	Name              *string                      `json:"name,omitempty"`
+	EventID           string                       `json:"eventID"`
 }
 
 type FunctionRunQuery struct {

--- a/pkg/coreapi/graph/resolvers/function_run.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run.resolver.go
@@ -9,9 +9,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/pkg/enums"
-	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/history_reader"
+	"github.com/inngest/inngest/pkg/util"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -175,52 +175,26 @@ func (r *functionRunResolver) Timeline(ctx context.Context, obj *models.Function
 }
 
 func (r *functionRunResolver) Event(ctx context.Context, obj *models.FunctionRun) (*models.Event, error) {
-	history, err := r.Runner.History(ctx, state.Identifier{
-		RunID: ulid.MustParse(obj.ID),
-	})
+	eventID, err := ulid.Parse(obj.EventID)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(history) == 0 {
-		return nil, nil
-	}
-
-	// Find the function start event, which should contain the triggering event.
-	var startEvent *state.History
-	for _, h := range history {
-		if h.Type == enums.HistoryTypeFunctionStarted {
-			startEvent = &h
-			break
-		}
-	}
-
-	if startEvent == nil {
-		return nil, nil
-	}
-
-	jsonStr, err := json.Marshal(startEvent.Data)
+	evt, err := r.Data.GetEventByInternalID(ctx, eventID)
 	if err != nil {
 		return nil, err
 	}
 
-	event := &event.Event{}
-	if err := json.Unmarshal(jsonStr, event); err != nil {
-		return nil, err
-	}
-
-	createdAt := time.UnixMilli(event.Timestamp)
-	payloadByt, err := json.Marshal(event.Data)
+	payload, err := json.Marshal(evt.EventData)
 	if err != nil {
 		return nil, err
 	}
-	payload := string(payloadByt)
 
 	return &models.Event{
-		ID:        event.ID,
-		Name:      &event.Name,
-		CreatedAt: &createdAt,
-		Payload:   &payload,
+		CreatedAt: &evt.ReceivedAt,
+		ID:        evt.ID.String(),
+		Name:      &evt.EventName,
+		Payload:   util.StrPtr(string(payload)),
 	}, nil
 }
 

--- a/pkg/util/strings.go
+++ b/pkg/util/strings.go
@@ -1,0 +1,5 @@
+package util
+
+func StrPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
## Description

The `functionRuns` resolver was returning a different event each time it was run

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
