### PR TITLE
Make metadata URL overflow auto

### DIFF
--- a/ui/packages/components/src/RunDetails/runMetadataRenderer.tsx
+++ b/ui/packages/components/src/RunDetails/runMetadataRenderer.tsx
@@ -109,7 +109,7 @@ export function renderRunMetadata({
       {
         label: 'URL',
         size: 'large',
-        value: <div className="overflow-scroll whitespace-nowrap">{functionVersion.url}</div>,
+        value: <div className="overflow-y-auto whitespace-nowrap">{functionVersion.url}</div>,
       },
       {
         label: 'Function Version',


### PR DESCRIPTION
## Description
- Make overflow auto instead of scroll. With overflow scroll, windows users will always see the scrollbar.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
