### PR TITLE
fix(dashboard): "Send Event" doesn't display created event

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/events/[eventName]/SendEventModal.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/events/[eventName]/SendEventModal.tsx
@@ -85,6 +85,7 @@ export function SendEventModal({
       success: () => {
         router.refresh();
         onClose();
+        window.location.reload(); // We need to reload page to display new events, because we can't update the URQL cache without using mutations
         return 'Event sent!';
       },
       error: 'Could not send event. Please try again later.',


### PR DESCRIPTION
## Description

This displays newly created events after using the "Send Event" modal:

https://github.com/inngest/inngest/assets/4291707/ead50d45-b7ca-4aa4-9763-cfded4adf9b2


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
