### PR TITLE
fix(dashboard): chart is empty if `queued` is empty list

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionThroughputChart.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionThroughputChart.tsx
@@ -86,30 +86,27 @@ export default function FunctionThroughputChart({
     pause: !environment?.id,
   });
 
-  let metrics: {
-    name: string;
-    values: {
-      queued: number;
-      started: number;
-      ended: number;
-    };
-  }[] = [];
-  const queued = data?.environment.function?.queued;
-  const started = data?.environment.function?.started;
-  const ended = data?.environment.function?.ended;
-  const concurrencyLimit = data?.environment.function?.concurrencyLimit;
+  const queued = data?.environment?.function?.queued?.data ?? [];
+  const started = data?.environment?.function?.started?.data ?? [];
+  const ended = data?.environment?.function?.ended?.data ?? [];
+  const concurrencyLimit = data?.environment?.function?.concurrencyLimit?.data ?? [];
 
-  if (queued && started && ended && concurrencyLimit) {
-    metrics = queued.data.map((d, idx) => ({
-      name: d.bucket,
-      values: {
-        queued: d.value,
-        started: started.data[idx]?.value ?? 0,
-        ended: ended.data[idx]?.value ?? 0,
-        concurrencyLimit: Boolean(concurrencyLimit.data[idx]?.value),
-      },
-    }));
-  }
+  const maxLength = Math.max(queued.length, started.length, ended.length, concurrencyLimit.length);
+
+  const metrics = Array.from({ length: maxLength }).map((_, idx) => ({
+    name:
+      queued[idx]?.bucket ||
+      started[idx]?.bucket ||
+      ended[idx]?.bucket ||
+      concurrencyLimit[idx]?.bucket ||
+      '',
+    values: {
+      queued: queued[idx]?.value ?? 0,
+      started: started[idx]?.value ?? 0,
+      ended: ended[idx]?.value ?? 0,
+      concurrencyLimit: Boolean(concurrencyLimit[idx]?.value),
+    },
+  }));
 
   return (
     <SimpleLineChart

--- a/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
+++ b/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
@@ -28,7 +28,7 @@ type SimpleLineChartProps = {
   data?: {
     name: string;
     values: {
-      [key: string]: number;
+      [key: string]: number | boolean;
     };
   }[];
   legend: {


### PR DESCRIPTION
## Description

This fixes an issue where the Function Throughput chart would be empty if the `queued` value is an empty list.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
