### PR TITLE
Add replay ID to internal state

### DIFF
--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -128,6 +128,8 @@ type ScheduleRequest struct {
 	WorkspaceID uuid.UUID
 	// OriginalRunID is the ID of the ID of the original run, if this a replay.
 	OriginalRunID *ulid.ULID
+	// ReplayID is the ID of the ID of the replay, if this a replay.
+	ReplayID *uuid.UUID
 	// Events represent one or more events that the function is being triggered with.
 	Events []event.TrackedEvent
 	// BatchID refers to the batch ID, if this function is started as a batch.

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -243,6 +243,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		AccountID:       req.AccountID,
 		WorkspaceID:     req.WorkspaceID,
 		OriginalRunID:   req.OriginalRunID,
+		ReplayID:        req.ReplayID,
 	}
 
 	mapped := make([]map[string]any, len(req.Events))

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -280,9 +280,6 @@ func (m mgr) New(ctx context.Context, input state.Input) (state.State, error) {
 		RequestVersion: consts.RequestVersionUnknown, // Always use -1 to indicate unset hash version until first request.
 		Context:        input.Context,
 	}
-	if input.OriginalRunID != nil {
-		metadata.OriginalRunID = input.OriginalRunID.String()
-	}
 	if input.RunType != nil {
 		metadata.RunType = *input.RunType
 	}
@@ -1374,9 +1371,6 @@ func NewRunMetadata(data map[string]string) (*runMetadata, error) {
 			m.Debugger = true
 		}
 	}
-	if val, ok := data["originalRunID"]; ok {
-		m.OriginalRunID = val
-	}
 	if val, ok := data["runType"]; ok {
 		m.RunType = val
 	}
@@ -1413,7 +1407,7 @@ type runMetadata struct {
 	Pending                   int            `json:"pending"`
 	Debugger                  bool           `json:"debugger"`
 	RunType                   string         `json:"runType,omitempty"`
-	OriginalRunID             string         `json:"originalRunID,omitempty"`
+	ReplayID                  string         `json:"rID,omitempty"`
 	Version                   int            `json:"version"`
 	RequestVersion            int            `json:"rv"`
 	Context                   map[string]any `json:"ctx,omitempty"`
@@ -1422,16 +1416,15 @@ type runMetadata struct {
 
 func (r runMetadata) Map() map[string]any {
 	return map[string]any{
-		"id":            r.Identifier,
-		"status":        int(r.Status), // Always store this as an int
-		"pending":       r.Pending,
-		"debugger":      r.Debugger,
-		"runType":       r.RunType,
-		"originalRunID": r.OriginalRunID,
-		"version":       r.Version,
-		"rv":            r.RequestVersion,
-		"ctx":           r.Context,
-		"die":           r.DisableImmediateExecution,
+		"id":       r.Identifier,
+		"status":   int(r.Status), // Always store this as an int
+		"pending":  r.Pending,
+		"debugger": r.Debugger,
+		"runType":  r.RunType,
+		"version":  r.Version,
+		"rv":       r.RequestVersion,
+		"ctx":      r.Context,
+		"die":      r.DisableImmediateExecution,
 	}
 }
 
@@ -1449,10 +1442,6 @@ func (r runMetadata) Metadata() state.Metadata {
 
 	if r.RunType != "" {
 		m.RunType = &r.RunType
-	}
-	if r.OriginalRunID != "" {
-		id := ulid.MustParse(r.OriginalRunID)
-		m.OriginalRunID = &id
 	}
 	return m
 }

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -65,6 +65,8 @@ type Identifier struct {
 	WorkspaceID uuid.UUID `json:"wsID"`
 	// If this is a rerun, the original run ID is stored here.
 	OriginalRunID *ulid.ULID `json:"oRunID,omitempty"`
+	// ReplayID stores the ID of the replay, if this identifier belongs to a replay.
+	ReplayID *uuid.UUID `json:"rID,omitempty"`
 	// PriorityFactor is the overall priority factor for this particular function
 	// run.  This allows individual runs to take precedence within the same queue.
 	// The higher the number (up to consts.PriorityFactorMax), the higher priority
@@ -131,10 +133,6 @@ type Metadata struct {
 	// RunType indicates the run type for this particular flow.  This allows
 	// us to store whether this is eg. a manual retry
 	RunType *string `json:"runType,omitempty"`
-
-	// OriginalRunID stores the original run ID, if this run is a retry.
-	// This is some basic book-keeping.
-	OriginalRunID *ulid.ULID `json:"originalRunID,omitempty"`
 
 	// Name stores the name of the workflow as it started.
 	//
@@ -393,10 +391,6 @@ type Input struct {
 	// RunType indicates the run type for this particular flow.  This allows
 	// us to store whether this is eg. a manual retry
 	RunType *string `json:"runType,omitempty"`
-
-	// OriginalRunID stores the original run ID, if this run is a retry.
-	// This is some basic book-keeping.
-	OriginalRunID *ulid.ULID `json:"originalRunID,omitempty"`
 
 	// Steps allows users to specify pre-defined steps to run workflows from
 	// arbitrary points.


### PR DESCRIPTION
This adds replay ID to our internal state, used to track replays across function runs.  We also consolidate OriginalRunID into the identifier, instead of having this duplicated in Metadata.  This should have been removed in a previous refactor.


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
