### PR TITLE
fix(dashboard): environment links don't work from a function page

### DIFF
--- a/ui/apps/dashboard/src/components/Navigation/EnvironmentSelectMenu.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/EnvironmentSelectMenu.tsx
@@ -30,6 +30,9 @@ import isNonEmptyArray from '@/utils/isNonEmptyArray';
 // for the user to switch context correctly
 const useSwitchablePathname = (): string => {
   const segments = useSelectedLayoutSegments();
+  const segmentsWithoutRouteGroups = segments.filter(
+    (segment) => !segment.startsWith('(') && !segment.endsWith(')')
+  );
   const pathname = usePathname();
 
   // Accounts are not environment specific
@@ -38,24 +41,24 @@ const useSwitchablePathname = (): string => {
   }
 
   // Deploys should always move to the root resource level
-  if (segments[0] === 'deploys') {
+  if (segmentsWithoutRouteGroups[0] === 'deploys') {
     return '/deploys';
   }
   // Manage paths, we drop the id at the end
-  if (segments[0] === 'manage') {
-    return '/' + segments.slice(0, 2).join('/');
+  if (segmentsWithoutRouteGroups[0] === 'manage') {
+    return '/' + segmentsWithoutRouteGroups.slice(0, 2).join('/');
   }
 
   // Logs are specific to a given environment, return to the function dashboard
-  if (segments[0] === 'functions' && segments[2] === 'logs') {
-    return '/' + segments.slice(0, 3).join('/');
+  if (segmentsWithoutRouteGroups[0] === 'functions' && segmentsWithoutRouteGroups[2] === 'logs') {
+    return '/' + segmentsWithoutRouteGroups.slice(0, 3).join('/');
   }
 
-  if (segments.length === 0) {
+  if (segmentsWithoutRouteGroups.length === 0) {
     return '/functions'; // default if selected from /env
   }
 
-  return '/' + segments.join('/');
+  return '/' + segmentsWithoutRouteGroups.join('/');
 };
 
 type EnvironmentSelectMenuProps = {


### PR DESCRIPTION
## Description

This fixes an issue where environment links wouldn't work when clicking on them from a function page.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
