### PR TITLE
Check debounce exists in hash prior to using existing debounce

### DIFF
--- a/pkg/execution/debounce/lua/newDebounce.lua
+++ b/pkg/execution/debounce/lua/newDebounce.lua
@@ -18,8 +18,12 @@ local ttl        = tonumber(ARGV[3])
 
 local existing = redis.call("GET", keyPtr)
 if existing ~= nil and existing ~= false then
-	-- A debounce for this function exists.
-	return existing
+	-- A debounce for this function exists.  Check that this is in the map, first.
+	local found = redis.call("HEXISTS", keyDbc, debounceID)
+	if found == 1 then
+		-- The debounce exists in the map, too.  Return this debounce.
+		return existing
+	end
 end
 
 -- Set the fn -> debounce ID pointer

--- a/pkg/execution/debounce/lua/updateDebounce.lua
+++ b/pkg/execution/debounce/lua/updateDebounce.lua
@@ -18,4 +18,6 @@ local ttl        = tonumber(ARGV[3])
 redis.call("SETEX", keyPtr, ttl, debounceID)
 redis.call("HSET", keyDbc, debounceID, debounce)
 
+-- TODO: This should also reschedule the job directly in an atomic transaction.
+
 return 0


### PR DESCRIPTION
Debounces may have been removed from the hash in the event of a debounce executing.  Ensure that the debounce exists if we are to update the debounce itself.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
