### PR TITLE
Check debounce job lease when rescheduling debounce

### DIFF
--- a/pkg/execution/debounce/lua/updateDebounce.lua
+++ b/pkg/execution/debounce/lua/updateDebounce.lua
@@ -4,18 +4,49 @@ Updates a debounce to use new data.
 
 Return values:
 - 0 (int): OK
+- -1: Debounce is already in progress, as the queue item is leased.
 
 ]]--
 
 local keyPtr = KEYS[1] -- fn -> debounce ptr
 local keyDbc = KEYS[2] -- debounce info key
+-- We need queue details to check if the debounce job is in progress (leased).  If so, we fail
+-- and create a new debounce job.
+local keyQueueHash = KEYS[3]
 
-local debounceID = ARGV[1] 
-local debounce   = ARGV[2]
-local ttl        = tonumber(ARGV[3])
+local debounceID  = ARGV[1] 
+local debounce    = ARGV[2]
+local ttl         = tonumber(ARGV[3])
+local queueJobID  = ARGV[4]
+local currentTime = tonumber(ARGV[5]) -- in ms
+
+
+-- copied from get_queue_item.lua
+local function get_queue_item(queueKey, queueID)
+	local fetched = redis.call("HGET", queueKey, queueID)
+	if fetched ~= false then
+		return cjson.decode(fetched)
+	end
+	return nil
+end
+
+-- Check that the queue item is not leased (ie. this debounce is not in progress)
+local item = get_queue_item(keyQueueHash, queueJobID)
+if item == nil then
+	-- The queue item was not found.  Return a new debounce.
+	return -1
+end
+if item.leaseID ~= nil and item.leaseID ~= cjson.null and decode_ulid_time(item.leaseID) > currentTime then
+	-- The debounce queue item is leased. 
+	return -1
+end
 
 -- Set the fn -> debounce ID pointer
 redis.call("SETEX", keyPtr, ttl, debounceID)
 redis.call("HSET", keyDbc, debounceID, debounce)
 
+-- TODO: This should also reschedule the job directly in an atomic transaction.
+
 return 0
+
+

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -178,6 +178,9 @@ type QueueKeyGenerator interface {
 }
 
 type DebounceKeyGenerator interface {
+	// QueueItem returns the key for the hash containing all items within a
+	// queue for a function.  This is used to check leases on debounce jobs.
+	QueueItem() string
 	// DebouncePointer returns the key which stores the pointer to the current debounce
 	// for a given function.
 	DebouncePointer(ctx context.Context, fnID uuid.UUID, key string) string

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -353,7 +353,7 @@ func TestQueueEnqueueItemIdempotency(t *testing.T) {
 		p := QueuePartition{WorkflowID: item.WorkflowID}
 
 		require.NoError(t, err)
-		require.Equal(t, hashID(ctx, "once"), item.ID)
+		require.Equal(t, HashID(ctx, "once"), item.ID)
 		require.NotEqual(t, i.ID, item.ID)
 		found := getQueueItem(t, r, item.ID)
 		require.Equal(t, item, found)
@@ -375,7 +375,7 @@ func TestQueueEnqueueItemIdempotency(t *testing.T) {
 
 		item, err = q.EnqueueItem(ctx, i, start)
 		require.NoError(t, err)
-		require.Equal(t, hashID(ctx, "once"), item.ID)
+		require.Equal(t, HashID(ctx, "once"), item.ID)
 		require.NotEqual(t, i.ID, item.ID)
 		found = getQueueItem(t, r, item.ID)
 		require.Equal(t, item, found)


### PR DESCRIPTION
If the debounce's job is leased do not allow the debounce to be updated. This ensures that debounces received at exactly the same time as an in-progress debounce cannot interfere with the executing debounce; instead, a new debounce will be created.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
