### PR TITLE
Add individual retries to timeline

### DIFF
--- a/ui/apps/dev-server-ui/src/app/(dashboard)/stream/OutputList.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/stream/OutputList.tsx
@@ -1,4 +1,4 @@
-import { renderOutput, type OutputType } from '@inngest/components/utils/outputRenderer';
+import { renderOutput } from '@inngest/components/utils/outputRenderer';
 
 import {
   FunctionRunStatus,
@@ -32,20 +32,13 @@ type FunctionRunStatusSubset = Pick<FunctionRun, 'id' | 'status' | 'output'>;
 export function OutputItem({ functionRunID }: { functionRunID: string }) {
   const { data } = useGetFunctionRunOutputQuery({ id: functionRunID }, { pollingInterval: 1500 });
   const functionRun = (data?.functionRun as FunctionRunStatusSubset) || {};
-  let type: OutputType | undefined;
 
-  if (functionRun?.status === FunctionRunStatus.Completed) {
-    type = 'completed';
-  } else if (functionRun?.status === FunctionRunStatus.Failed) {
-    type = 'failed';
-  }
-
-  if (!functionRun || !functionRun?.output || !functionRun?.status || !type) {
+  if (!functionRun || !functionRun?.output || !functionRun?.status) {
     return null;
   }
 
   const { message, errorName, output } = renderOutput({
-    type,
+    isSuccess: functionRun.status === FunctionRunStatus.Completed,
     content: functionRun.output,
   });
 

--- a/ui/packages/components/src/FuncCardFooter/FuncCardFooter.tsx
+++ b/ui/packages/components/src/FuncCardFooter/FuncCardFooter.tsx
@@ -1,27 +1,20 @@
 import { IconExclamationTriangle } from '@inngest/components/icons/ExclamationTriangle';
 import type { FunctionRun } from '@inngest/components/types/functionRun';
 import { classNames } from '@inngest/components/utils/classNames';
-import { renderOutput, type OutputType } from '@inngest/components/utils/outputRenderer';
+import { renderOutput } from '@inngest/components/utils/outputRenderer';
 
 interface FuncCardFooterProps {
   functionRun: Pick<FunctionRun, 'output' | 'status'>;
 }
 
 export function FuncCardFooter({ functionRun }: FuncCardFooterProps) {
-  let type: OutputType | undefined;
-  if (functionRun.status === 'COMPLETED') {
-    type = 'completed';
-  } else if (functionRun.status === 'FAILED') {
-    type = 'failed';
-  }
-
-  if (!functionRun || !functionRun.output || !functionRun.status || !type) {
+  if (!functionRun || !functionRun.output || !functionRun.status) {
     return null;
   }
 
   const { message, errorName } = renderOutput({
     content: functionRun.output,
-    type,
+    isSuccess: functionRun.status === 'COMPLETED',
   });
 
   const status = functionRun.status || 'Unknown';

--- a/ui/packages/components/src/OutputCard/OutputCard.tsx
+++ b/ui/packages/components/src/OutputCard/OutputCard.tsx
@@ -1,31 +1,31 @@
 import { CodeBlock } from '@inngest/components/CodeBlock';
 import { usePrettyJson } from '@inngest/components/hooks/usePrettyJson';
-import { renderOutput, type OutputType } from '@inngest/components/utils/outputRenderer';
+import { renderOutput } from '@inngest/components/utils/outputRenderer';
 
 interface OutputCardProps {
-  type: OutputType;
+  isSuccess: boolean;
   content: string;
 }
 
-export function OutputCard({ type, content }: OutputCardProps) {
-  let { message, errorName, output } = renderOutput({ type, content });
+export function OutputCard({ isSuccess, content }: OutputCardProps) {
+  let { message, errorName, output } = renderOutput({ isSuccess, content });
 
   if (!message && !output) return null;
   let color = 'bg-slate-600';
-  if (type === 'completed') {
+  if (isSuccess) {
     color = 'bg-teal-600';
-  } else if (type === 'failed') {
+  } else {
     color = 'bg-rose-600/50';
   }
 
-  output = (type === 'completed' && usePrettyJson(output)) || output;
+  output = (isSuccess && usePrettyJson(output)) || output;
 
   return (
     <CodeBlock
       header={{ title: errorName, description: message, color: color }}
       tabs={[
         {
-          label: type === 'failed' ? 'Stack Trace' : 'Output',
+          label: isSuccess ? 'Output' : 'Stack Trace',
           content: output,
         },
       ]}

--- a/ui/packages/components/src/RunDetails/RunDetails.tsx
+++ b/ui/packages/components/src/RunDetails/RunDetails.tsx
@@ -11,7 +11,6 @@ import type { Function } from '@inngest/components/types/function';
 import type { FunctionRun } from '@inngest/components/types/functionRun';
 import type { FunctionVersion } from '@inngest/components/types/functionVersion';
 import type { HistoryParser } from '@inngest/components/utils/historyParser';
-import { type OutputType } from '@inngest/components/utils/outputRenderer';
 
 import { SleepingSummary } from './SleepingSummary';
 import { WaitingSummary } from './WaitingSummary';
@@ -45,12 +44,8 @@ export function RunDetails({
     functionVersion,
     history,
   });
-  let type: OutputType | undefined;
-  if (run.status === 'COMPLETED') {
-    type = 'completed';
-  } else if (run.status === 'FAILED') {
-    type = 'failed';
-  }
+
+  const isSuccess = run.status === 'COMPLETED';
 
   return (
     <ContentCard
@@ -76,8 +71,8 @@ export function RunDetails({
       }
     >
       <div className="px-5 pt-4">
-        {run.status && run.endedAt && run.output && type && (
-          <OutputCard content={run.output} type={type} />
+        {run.status && run.endedAt && run.output && isSuccess && (
+          <OutputCard content={run.output} isSuccess={isSuccess} />
         )}
 
         <WaitingSummary history={history} />

--- a/ui/packages/components/src/RunDetails/SleepingSummary.tsx
+++ b/ui/packages/components/src/RunDetails/SleepingSummary.tsx
@@ -34,7 +34,7 @@ export function SleepingSummary({ history }: Props) {
             <Card.Header>Sleeping</Card.Header>
 
             <Card.Content>
-              <MetadataItem label="Sleep until" value={config.until.toLocaleString()} />
+              <MetadataItem label="Sleep Until" value={config.until.toLocaleString()} />
             </Card.Content>
           </Card>
         );

--- a/ui/packages/components/src/RunDetails/WaitingSummary.tsx
+++ b/ui/packages/components/src/RunDetails/WaitingSummary.tsx
@@ -36,7 +36,7 @@ export function WaitingSummary({ history }: Props) {
 
             <Card.Content>
               <MetadataItem
-                label="Event name"
+                label="Event Name"
                 value={
                   <>
                     <IconEvent className="inline-block" /> {config.eventName}
@@ -45,7 +45,7 @@ export function WaitingSummary({ history }: Props) {
               />
 
               <MetadataItem
-                label="Match expression"
+                label="Match Expression"
                 type="code"
                 value={config.expression ?? 'N/A'}
               />

--- a/ui/packages/components/src/RunDetails/runMetadataRenderer.tsx
+++ b/ui/packages/components/src/RunDetails/runMetadataRenderer.tsx
@@ -12,97 +12,49 @@ export function renderRunMetadata({
   functionRun: Pick<FunctionRun, 'endedAt' | 'id' | 'startedAt' | 'status'>;
   functionVersion?: Pick<FunctionVersion, 'url' | 'version'>;
   history: HistoryParser;
-}): MetadataItemProps[] {
-  if (!functionRun.startedAt) {
-    throw new Error('missing startedAt');
-  }
-
+}) {
   // The current startedAt is in reality the queuedAt timestamp. We are getting the real startedAt from the first history item
   const startedAt = history.runStartedAt;
   const startedAtLabel = startedAt ? shortDate(new Date(startedAt)) : '-';
+
+  let duration: number | undefined;
+  if (startedAt && functionRun.endedAt) {
+    duration = new Date(functionRun.endedAt).getTime() - new Date(startedAt).getTime();
+  }
+
+  let endedAtLabel = 'Function Completed';
+  let tootltipLabel = 'completed';
+  if (functionRun.status === 'CANCELLED') {
+    endedAtLabel = 'Function Cancelled';
+    tootltipLabel = 'cancelled';
+  } else if (functionRun.status === 'FAILED') {
+    endedAtLabel = 'Function Failed';
+    tootltipLabel = 'failed';
+  }
+
   const metadataItems: MetadataItemProps[] = [
     { label: 'Run ID', value: functionRun.id, size: 'large', type: 'code' },
     {
       label: 'Function Scheduled',
-      value: shortDate(new Date(functionRun.startedAt)),
-      title: functionRun.startedAt.toLocaleString(),
+      value: functionRun.startedAt ? shortDate(new Date(functionRun.startedAt)) : '-',
+      title: functionRun.startedAt?.toLocaleString(),
     },
-  ];
-
-  if (startedAt) {
-    metadataItems.push({
+    {
       label: 'Function Started',
       value: startedAtLabel,
-      title: startedAt.toLocaleString(),
-    });
-  }
-
-  if (functionRun.status === 'COMPLETED') {
-    if (!functionRun.endedAt) {
-      throw new Error('missing endedAt');
-    }
-    metadataItems.push({
-      label: 'Function Completed',
-      value: shortDate(new Date(functionRun.endedAt)),
-      title: functionRun.endedAt.toLocaleString(),
-    });
-    if (startedAt && functionRun.endedAt) {
-      const duration = new Date(functionRun.endedAt).getTime() - new Date(startedAt).getTime();
-      metadataItems.push({
-        label: 'Duration',
-        value: formatMilliseconds(duration),
-        tooltip: 'Time between function started and function completed',
-      });
-    }
-  }
-  if (functionRun.status === 'FAILED') {
-    if (!functionRun.endedAt) {
-      throw new Error('missing endedAt');
-    }
-    metadataItems.push({
-      label: 'Function Failed',
-      value: shortDate(new Date(functionRun.endedAt)),
-      title: functionRun.endedAt.toLocaleString(),
-    });
-    if (startedAt && functionRun.endedAt) {
-      const duration = new Date(functionRun.endedAt).getTime() - new Date(startedAt).getTime();
-      metadataItems.push({
-        label: 'Duration',
-        value: formatMilliseconds(duration),
-        tooltip: 'Time between function started and function failed',
-      });
-    }
-  }
-  if (functionRun.status === 'CANCELLED') {
-    if (!functionRun.endedAt) {
-      throw new Error('missing endedAt');
-    }
-    metadataItems.push({
-      label: 'Function Cancelled',
-      value: shortDate(new Date(functionRun.endedAt)),
-      title: functionRun.endedAt.toLocaleString(),
-    });
-    if (startedAt && functionRun.endedAt) {
-      const duration = new Date(functionRun.endedAt).getTime() - new Date(startedAt).getTime();
-      metadataItems.push({
-        label: 'Duration',
-        value: formatMilliseconds(duration),
-        tooltip: 'Time between function started and function cancelled',
-      });
-    }
-  }
-  if (functionRun.status === 'RUNNING') {
-    metadataItems.push(
-      {
-        label: 'Function Completed',
-        value: '-',
-      },
-      {
-        label: 'Duration',
-        value: '-',
-      }
-    );
-  }
+      title: startedAt?.toLocaleString(),
+    },
+    {
+      label: endedAtLabel,
+      value: functionRun.endedAt ? shortDate(new Date(functionRun.endedAt)) : '-',
+      title: functionRun?.endedAt?.toLocaleString(),
+    },
+    {
+      label: 'Duration',
+      value: duration ? formatMilliseconds(duration) : '-',
+      tooltip: `Time between function started and function ${tootltipLabel}`,
+    },
+  ];
 
   if (functionVersion) {
     metadataItems.push(

--- a/ui/packages/components/src/RunDetails/stepMetadataRenderer.tsx
+++ b/ui/packages/components/src/RunDetails/stepMetadataRenderer.tsx
@@ -10,17 +10,20 @@ export function renderStepMetadata({
   node: HistoryNode;
   isAttempt?: boolean;
 }): MetadataItemProps[] {
-  let endedAtLabel = 'Completed At';
+  let endedAtLabel = 'Completed At:';
   let tootltipLabel = 'completed';
   if (node.status === 'cancelled') {
-    endedAtLabel = 'Cancelled At';
+    endedAtLabel = 'Cancelled At:';
     tootltipLabel = 'cancelled';
   } else if (node.status === 'failed') {
-    endedAtLabel = 'Failed At';
+    endedAtLabel = 'Failed At:';
     tootltipLabel = 'failed';
   } else if (node.status === 'errored') {
-    endedAtLabel = 'Errored At';
+    endedAtLabel = 'Errored At:';
     tootltipLabel = 'errored';
+  } else if (node.status === 'completed' && node.waitForEventResult?.timeout) {
+    endedAtLabel = 'Timed Out At:';
+    tootltipLabel = 'timed out';
   }
 
   let durationMS: number | undefined;

--- a/ui/packages/components/src/RunDetails/stepMetadataRenderer.tsx
+++ b/ui/packages/components/src/RunDetails/stepMetadataRenderer.tsx
@@ -10,19 +10,20 @@ export function renderStepMetadata({
   node: HistoryNode;
   isAttempt?: boolean;
 }): MetadataItemProps[] {
-  let endedAtLabel = 'Completed At:';
+  const name = isAttempt ? 'Attempt' : ' Step';
+  let endedAtLabel = `${name} Completed`;
   let tootltipLabel = 'completed';
   if (node.status === 'cancelled') {
-    endedAtLabel = 'Cancelled At:';
+    endedAtLabel = `${name} Cancelled`;
     tootltipLabel = 'cancelled';
   } else if (node.status === 'failed') {
-    endedAtLabel = 'Failed At:';
+    endedAtLabel = `${name} Failed`;
     tootltipLabel = 'failed';
   } else if (node.status === 'errored') {
-    endedAtLabel = 'Errored At:';
+    endedAtLabel = `${name} Errored`;
     tootltipLabel = 'errored';
   } else if (node.status === 'completed' && node.waitForEventResult?.timeout) {
-    endedAtLabel = 'Timed Out At:';
+    endedAtLabel = `${name} Timed Out`;
     tootltipLabel = 'timed out';
   }
 
@@ -33,7 +34,7 @@ export function renderStepMetadata({
 
   const metadataItems: MetadataItemProps[] = [
     {
-      label: 'Started At',
+      label: `${name} Started`,
       value: node.scheduledAt ? node.scheduledAt.toLocaleString() : '-',
       title: node?.scheduledAt?.toLocaleString(),
     },
@@ -45,9 +46,7 @@ export function renderStepMetadata({
     {
       label: 'Duration',
       value: durationMS ? formatMilliseconds(durationMS) : '-',
-      tooltip: `Time between ${isAttempt ? 'attempt' : 'step'} started and ${
-        isAttempt ? 'attempt' : 'step'
-      } ${tootltipLabel}`,
+      tooltip: `Time between ${name.toLowerCase()} started and ${name.toLowerCase()} ${tootltipLabel}`,
     },
   ];
 

--- a/ui/packages/components/src/RunDetails/stepMetadataRenderer.tsx
+++ b/ui/packages/components/src/RunDetails/stepMetadataRenderer.tsx
@@ -1,0 +1,77 @@
+import { type MetadataItemProps } from '@inngest/components/Metadata/MetadataItem';
+import { IconEvent } from '@inngest/components/icons/Event';
+import { formatMilliseconds } from '@inngest/components/utils/date';
+import { type HistoryNode } from '@inngest/components/utils/historyParser';
+
+export function renderStepMetadata({
+  node,
+  isAttempt,
+}: {
+  node: HistoryNode;
+  isAttempt?: boolean;
+}): MetadataItemProps[] {
+  let endedAtLabel = 'Completed At';
+  let tootltipLabel = 'completed';
+  if (node.status === 'cancelled') {
+    endedAtLabel = 'Cancelled At';
+    tootltipLabel = 'cancelled';
+  } else if (node.status === 'failed') {
+    endedAtLabel = 'Failed At';
+    tootltipLabel = 'failed';
+  } else if (node.status === 'errored') {
+    endedAtLabel = 'Errored At';
+    tootltipLabel = 'errored';
+  }
+
+  let durationMS: number | undefined;
+  if (node.scheduledAt && node.endedAt) {
+    durationMS = node.endedAt.getTime() - node.scheduledAt.getTime();
+  }
+
+  const metadataItems: MetadataItemProps[] = [
+    {
+      label: 'Started At',
+      value: node.scheduledAt ? node.scheduledAt.toLocaleString() : '-',
+      title: node?.scheduledAt?.toLocaleString(),
+    },
+    {
+      label: endedAtLabel,
+      value: node.endedAt ? node.endedAt.toLocaleString() : '-',
+      title: node?.endedAt?.toLocaleString(),
+    },
+    {
+      label: 'Duration',
+      value: durationMS ? formatMilliseconds(durationMS) : '-',
+      tooltip: `Time between ${isAttempt ? 'attempt' : 'step'} started and ${
+        isAttempt ? 'attempt' : 'step'
+      } ${tootltipLabel}`,
+    },
+  ];
+
+  if (node.sleepConfig?.until) {
+    metadataItems.push({
+      label: 'Sleep Until',
+      value: node.sleepConfig?.until?.toLocaleString(),
+    });
+  }
+
+  if (node.waitForEventConfig) {
+    metadataItems.push(
+      {
+        label: 'Event Name',
+        value: (
+          <>
+            <IconEvent className="inline-block" /> {node.waitForEventConfig.eventName}
+          </>
+        ),
+      },
+      {
+        label: 'Match Expression',
+        value: node.waitForEventConfig.expression ?? 'N/A',
+        type: 'code',
+      }
+    );
+  }
+
+  return metadataItems;
+}

--- a/ui/packages/components/src/Timeline/Timeline.tsx
+++ b/ui/packages/components/src/Timeline/Timeline.tsx
@@ -48,7 +48,7 @@ export function Timeline({ getOutput, history }: Props) {
                         key={attempt.groupID + attempt.attempt}
                         getOutput={getOutput}
                         node={attempt}
-                        type="attempt"
+                        isAttempt
                       />
                     ))}
                   </>

--- a/ui/packages/components/src/Timeline/Timeline.tsx
+++ b/ui/packages/components/src/Timeline/Timeline.tsx
@@ -39,7 +39,21 @@ export function Timeline({ getOutput, history }: Props) {
                 position={position}
                 getOutput={getOutput}
                 node={node}
-              />
+              >
+                {Object.values(node.attempts).length > 0 && (
+                  <>
+                    <p className="py-4 text-sm text-slate-400">Previous attempts</p>
+                    {Object.values(node.attempts).map((attempt) => (
+                      <TimelineNode
+                        key={attempt.groupID + attempt.attempt}
+                        getOutput={getOutput}
+                        node={attempt}
+                        type="attempt"
+                      />
+                    ))}
+                  </>
+                )}
+              </TimelineNode>
             );
           })}
         </AccordionPrimitive.Root>

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
@@ -20,11 +20,11 @@ type Props = {
   node: HistoryNode;
   position?: 'first' | 'last' | 'middle';
   children?: React.ReactNode;
-  type?: 'attempt';
+  isAttempt?: boolean;
 };
 
-export function TimelineNode({ position, getOutput, node, children, type }: Props) {
-  const { icon, badge, name, metadata } = renderTimelineNode({ node, type });
+export function TimelineNode({ position, getOutput, node, children, isAttempt }: Props) {
+  const { icon, badge, name, metadata } = renderTimelineNode({ node, isAttempt });
   const isExpandable = node.scope === 'step';
   const [openItems, setOpenItems] = useState<string[]>([]);
 
@@ -35,7 +35,7 @@ export function TimelineNode({ position, getOutput, node, children, type }: Prop
       setOpenItems([...openItems, itemValue]);
     }
   };
-  const value = `${node.groupID}${type ? `/${type}${node.attempt}` : ''}`;
+  const value = `${node.groupID}${isAttempt ? `/attempt${node.attempt}` : ''}`;
 
   return (
     <AccordionPrimitive.Item
@@ -84,7 +84,7 @@ export function TimelineNode({ position, getOutput, node, children, type }: Prop
                 type: 'tween',
               }}
             >
-              <Content getOutput={getOutput} node={node} type={type} />
+              <Content getOutput={getOutput} node={node} isAttempt={isAttempt} />
               {children}
             </motion.div>
           </AccordionPrimitive.Content>
@@ -97,11 +97,11 @@ export function TimelineNode({ position, getOutput, node, children, type }: Prop
 function Content({
   getOutput,
   node,
-  type,
+  isAttempt,
 }: {
   getOutput: (historyItemID: string) => Promise<string | undefined>;
   node: HistoryNode;
-  type?: 'attempt';
+  isAttempt?: boolean;
 }) {
   const output = useOutput({ getOutput, outputItemID: node.outputItemID, status: node.status });
 
@@ -142,8 +142,8 @@ function Content({
               {
                 label: 'Duration',
                 value: durationMS ? formatMilliseconds(durationMS) : '-',
-                tooltip: `Time between ${type ? type : 'step'} started and ${
-                  type ? type : 'step'
+                tooltip: `Time between ${isAttempt ? 'attempt' : 'step'} started and ${
+                  isAttempt ? 'attempt' : 'step'
                 } ${tootltipLabel}`,
               },
               ...(node.sleepConfig?.until

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
@@ -61,9 +61,7 @@ export function TimelineNode({ position, getOutput, node, children, type }: Prop
             <Button
               className="group"
               icon={
-                <IconChevron
-                  className={`transform-90 text-slate-500 transition-transform duration-500 group-data-[state=open]:-rotate-180`}
-                />
+                <IconChevron className="transform-90 text-slate-500 transition-transform duration-500 group-data-[state=open]:-rotate-180" />
               }
             />
           </AccordionPrimitive.Trigger>
@@ -85,7 +83,7 @@ export function TimelineNode({ position, getOutput, node, children, type }: Prop
                 type: 'tween',
               }}
             >
-              <Content getOutput={getOutput} node={node} />
+              <Content getOutput={getOutput} node={node} type={type} />
               {children}
             </motion.div>
           </AccordionPrimitive.Content>
@@ -98,11 +96,20 @@ export function TimelineNode({ position, getOutput, node, children, type }: Prop
 function Content({
   getOutput,
   node,
+  type,
 }: {
   getOutput: (historyItemID: string) => Promise<string | undefined>;
   node: HistoryNode;
+  type?: 'attempt';
 }) {
   const output = useOutput({ getOutput, outputItemID: node.outputItemID, status: node.status });
+
+  let endedAtLabel = 'Completed At';
+  if (node.status === 'cancelled') {
+    endedAtLabel = 'Cancelled At';
+  } else if (node.status === 'failed' || node.status === 'errored') {
+    endedAtLabel = 'Failed At';
+  }
 
   let durationMS: number | undefined;
   if (node.scheduledAt && node.endedAt) {
@@ -117,14 +124,23 @@ function Content({
             {
               label: 'Started At',
               value: node.scheduledAt ? node.scheduledAt.toLocaleString() : '-',
+              title: node?.scheduledAt?.toLocaleString(),
             },
             {
-              label: 'Ended At',
+              label: endedAtLabel,
               value: node.endedAt ? node.endedAt.toLocaleString() : '-',
+              title: node?.endedAt?.toLocaleString(),
             },
             {
               label: 'Duration',
               value: durationMS ? formatMilliseconds(durationMS) : '-',
+              tooltip: `Time between ${type ? type : 'step'} started and ${type ? type : 'step'} ${
+                node.status === 'failed' || node.status === 'errored'
+                  ? 'failed'
+                  : node.status === 'cancelled'
+                  ? 'cancelled'
+                  : 'completed'
+              }`,
             },
           ]}
         />

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect, useState } from 'react';
 import { Button } from '@inngest/components/Button';
-import { MetadataGrid } from '@inngest/components/Metadata';
+import { MetadataGrid, type MetadataItemProps } from '@inngest/components/Metadata';
 import { OutputCard } from '@inngest/components/OutputCard';
 import { IconChevron } from '@inngest/components/icons/Chevron';
+import { IconEvent } from '@inngest/components/icons/Event';
 import { classNames } from '@inngest/components/utils/classNames';
 import { formatMilliseconds } from '@inngest/components/utils/date';
 import { type HistoryNode } from '@inngest/components/utils/historyParser';
@@ -126,25 +127,52 @@ function Content({
     <>
       <div className="pb-5">
         <MetadataGrid
-          metadataItems={[
-            {
-              label: 'Started At',
-              value: node.scheduledAt ? node.scheduledAt.toLocaleString() : '-',
-              title: node?.scheduledAt?.toLocaleString(),
-            },
-            {
-              label: endedAtLabel,
-              value: node.endedAt ? node.endedAt.toLocaleString() : '-',
-              title: node?.endedAt?.toLocaleString(),
-            },
-            {
-              label: 'Duration',
-              value: durationMS ? formatMilliseconds(durationMS) : '-',
-              tooltip: `Time between ${type ? type : 'step'} started and ${
-                type ? type : 'step'
-              } ${tootltipLabel}`,
-            },
-          ]}
+          metadataItems={
+            [
+              {
+                label: 'Started At',
+                value: node.scheduledAt ? node.scheduledAt.toLocaleString() : '-',
+                title: node?.scheduledAt?.toLocaleString(),
+              },
+              {
+                label: endedAtLabel,
+                value: node.endedAt ? node.endedAt.toLocaleString() : '-',
+                title: node?.endedAt?.toLocaleString(),
+              },
+              {
+                label: 'Duration',
+                value: durationMS ? formatMilliseconds(durationMS) : '-',
+                tooltip: `Time between ${type ? type : 'step'} started and ${
+                  type ? type : 'step'
+                } ${tootltipLabel}`,
+              },
+              ...(node.sleepConfig?.until
+                ? [
+                    {
+                      label: 'Sleep Until',
+                      value: node.sleepConfig?.until?.toLocaleString(),
+                    },
+                  ]
+                : []),
+              ...(node.waitForEventConfig
+                ? [
+                    {
+                      label: 'Event Name',
+                      value: (
+                        <>
+                          <IconEvent className="inline-block" /> {node.waitForEventConfig.eventName}
+                        </>
+                      ),
+                    },
+                    {
+                      label: 'Match Expression',
+                      value: node.waitForEventConfig.expression ?? 'N/A',
+                      type: 'code',
+                    },
+                  ]
+                : []),
+            ] as MetadataItemProps[]
+          }
         />
       </div>
 

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
@@ -105,10 +105,16 @@ function Content({
   const output = useOutput({ getOutput, outputItemID: node.outputItemID, status: node.status });
 
   let endedAtLabel = 'Completed At';
+  let tootltipLabel = 'completed';
   if (node.status === 'cancelled') {
     endedAtLabel = 'Cancelled At';
-  } else if (node.status === 'failed' || node.status === 'errored') {
+    tootltipLabel = 'cancelled';
+  } else if (node.status === 'failed') {
     endedAtLabel = 'Failed At';
+    tootltipLabel = 'failed';
+  } else if (node.status === 'errored') {
+    endedAtLabel = 'Errored At';
+    tootltipLabel = 'errored';
   }
 
   let durationMS: number | undefined;
@@ -134,13 +140,9 @@ function Content({
             {
               label: 'Duration',
               value: durationMS ? formatMilliseconds(durationMS) : '-',
-              tooltip: `Time between ${type ? type : 'step'} started and ${type ? type : 'step'} ${
-                node.status === 'failed' || node.status === 'errored'
-                  ? 'failed'
-                  : node.status === 'cancelled'
-                  ? 'cancelled'
-                  : 'completed'
-              }`,
+              tooltip: `Time between ${type ? type : 'step'} started and ${
+                type ? type : 'step'
+              } ${tootltipLabel}`,
             },
           ]}
         />

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
@@ -102,7 +102,11 @@ function Content({
   node: HistoryNode;
   isAttempt?: boolean;
 }) {
-  const output = useOutput({ getOutput, outputItemID: node.outputItemID, status: node.status });
+  const output = useOutput({
+    getOutput,
+    outputItemID: node.outputItemID,
+    isSuccess: node.status === 'completed',
+  });
 
   const metadataItems = renderStepMetadata({ node, isAttempt });
 
@@ -120,11 +124,11 @@ function Content({
 function useOutput({
   getOutput,
   outputItemID,
-  status,
+  isSuccess,
 }: {
   getOutput: (historyItemID: string) => Promise<string | undefined>;
   outputItemID?: string;
-  status: HistoryNode['status'];
+  isSuccess: boolean;
 }): React.ReactNode | undefined {
   const [output, setOutput] = useState<React.ReactNode>(undefined);
 
@@ -146,7 +150,7 @@ function useOutput({
           return;
         }
 
-        setOutput(<OutputCard content={data} type={status} />);
+        setOutput(<OutputCard content={data} isSuccess={isSuccess} />);
       } catch (e) {
         let text = 'Error loading';
         if (e instanceof Error) {

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
@@ -2,12 +2,11 @@
 
 import { useEffect, useState } from 'react';
 import { Button } from '@inngest/components/Button';
-import { MetadataGrid, type MetadataItemProps } from '@inngest/components/Metadata';
+import { MetadataGrid } from '@inngest/components/Metadata';
 import { OutputCard } from '@inngest/components/OutputCard';
+import { renderStepMetadata } from '@inngest/components/RunDetails/stepMetadataRenderer';
 import { IconChevron } from '@inngest/components/icons/Chevron';
-import { IconEvent } from '@inngest/components/icons/Event';
 import { classNames } from '@inngest/components/utils/classNames';
-import { formatMilliseconds } from '@inngest/components/utils/date';
 import { type HistoryNode } from '@inngest/components/utils/historyParser';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -105,75 +104,12 @@ function Content({
 }) {
   const output = useOutput({ getOutput, outputItemID: node.outputItemID, status: node.status });
 
-  let endedAtLabel = 'Completed At';
-  let tootltipLabel = 'completed';
-  if (node.status === 'cancelled') {
-    endedAtLabel = 'Cancelled At';
-    tootltipLabel = 'cancelled';
-  } else if (node.status === 'failed') {
-    endedAtLabel = 'Failed At';
-    tootltipLabel = 'failed';
-  } else if (node.status === 'errored') {
-    endedAtLabel = 'Errored At';
-    tootltipLabel = 'errored';
-  }
-
-  let durationMS: number | undefined;
-  if (node.scheduledAt && node.endedAt) {
-    durationMS = node.endedAt.getTime() - node.scheduledAt.getTime();
-  }
+  const metadataItems = renderStepMetadata({ node, isAttempt });
 
   return (
     <>
       <div className="pb-5">
-        <MetadataGrid
-          metadataItems={
-            [
-              {
-                label: 'Started At',
-                value: node.scheduledAt ? node.scheduledAt.toLocaleString() : '-',
-                title: node?.scheduledAt?.toLocaleString(),
-              },
-              {
-                label: endedAtLabel,
-                value: node.endedAt ? node.endedAt.toLocaleString() : '-',
-                title: node?.endedAt?.toLocaleString(),
-              },
-              {
-                label: 'Duration',
-                value: durationMS ? formatMilliseconds(durationMS) : '-',
-                tooltip: `Time between ${isAttempt ? 'attempt' : 'step'} started and ${
-                  isAttempt ? 'attempt' : 'step'
-                } ${tootltipLabel}`,
-              },
-              ...(node.sleepConfig?.until
-                ? [
-                    {
-                      label: 'Sleep Until',
-                      value: node.sleepConfig?.until?.toLocaleString(),
-                    },
-                  ]
-                : []),
-              ...(node.waitForEventConfig
-                ? [
-                    {
-                      label: 'Event Name',
-                      value: (
-                        <>
-                          <IconEvent className="inline-block" /> {node.waitForEventConfig.eventName}
-                        </>
-                      ),
-                    },
-                    {
-                      label: 'Match Expression',
-                      value: node.waitForEventConfig.expression ?? 'N/A',
-                      type: 'code',
-                    },
-                  ]
-                : []),
-            ] as MetadataItemProps[]
-          }
-        />
+        <MetadataGrid metadataItems={metadataItems} />
       </div>
 
       {output && <div className="pb-5">{output}</div>}

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
@@ -17,11 +17,13 @@ import { renderTimelineNode } from './TimelineNodeRenderer';
 type Props = {
   getOutput: (historyItemID: string) => Promise<string | undefined>;
   node: HistoryNode;
-  position: 'first' | 'last' | 'middle';
+  position?: 'first' | 'last' | 'middle';
+  children?: React.ReactNode;
+  type?: 'attempt';
 };
 
-export function TimelineNode({ position, getOutput, node }: Props) {
-  const { icon, badge, name, metadata } = renderTimelineNode(node);
+export function TimelineNode({ position, getOutput, node, children, type }: Props) {
+  const { icon, badge, name, metadata } = renderTimelineNode({ node, type });
   const isExpandable = node.scope === 'step';
   const [openItems, setOpenItems] = useState<string[]>([]);
 
@@ -32,19 +34,20 @@ export function TimelineNode({ position, getOutput, node }: Props) {
       setOpenItems([...openItems, itemValue]);
     }
   };
+  const value = `${node.groupID}${type ? `/${type}${node.attempt}` : ''}`;
 
   return (
     <AccordionPrimitive.Item
       className="relative border-t border-slate-800/50"
       disabled={!isExpandable}
-      value={node.groupID}
+      value={value}
     >
       <span
         className={classNames(
           'absolute left-[0.85rem] top-0 w-px bg-slate-800',
-          position === 'first' && 'top-[1.8rem] h-[calc(100%-1.8rem)]',
-          position === 'last' && 'h-[1.8rem]',
-          position === 'middle' && 'h-full'
+          position === 'first' && 'top-[1.9rem] h-[calc(100%-1.8rem)]',
+          position === 'last' && 'h-[1.9rem]',
+          position === 'middle' && 'h-[calc(100%+2px)]'
         )}
         aria-hidden="true"
       />
@@ -54,18 +57,20 @@ export function TimelineNode({ position, getOutput, node }: Props) {
         </div>
 
         {isExpandable && (
-          <AccordionPrimitive.Trigger asChild onClick={() => toggleItem(node.groupID)}>
+          <AccordionPrimitive.Trigger asChild onClick={() => toggleItem(value)}>
             <Button
               className="group"
               icon={
-                <IconChevron className="transform-90 text-slate-500 transition-transform duration-500 group-data-[state=open]:-rotate-180" />
+                <IconChevron
+                  className={`transform-90 text-slate-500 transition-transform duration-500 group-data-[state=open]:-rotate-180`}
+                />
               }
             />
           </AccordionPrimitive.Trigger>
         )}
       </AccordionPrimitive.Header>
       <AnimatePresence>
-        {openItems.includes(node.groupID) && (
+        {openItems.includes(value) && (
           <AccordionPrimitive.Content className="ml-9" forceMount>
             <motion.div
               initial={{ y: -20, opacity: 0.2 }}
@@ -81,6 +86,7 @@ export function TimelineNode({ position, getOutput, node }: Props) {
               }}
             >
               <Content getOutput={getOutput} node={node} />
+              {children}
             </motion.div>
           </AccordionPrimitive.Content>
         )}

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeRenderer.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeRenderer.tsx
@@ -102,10 +102,12 @@ export function renderTimelineNode({
       label: 'Enqueued Retry:',
       value: `${node.attempt + 1}`,
     };
-  } else if (
-    (node.status === 'failed' && node.endedAt) ||
-    (node.status === 'errored' && type === 'attempt' && node.endedAt)
-  ) {
+  } else if (node.status === 'errored' && type === 'attempt' && node.endedAt) {
+    metadata = {
+      label: 'Errored At:',
+      value: node.endedAt.toLocaleString(),
+    };
+  } else if (node.status === 'failed' && node.endedAt) {
     metadata = {
       label: 'Failed At:',
       value: node.endedAt.toLocaleString(),

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeRenderer.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeRenderer.tsx
@@ -43,7 +43,10 @@ function getIconsForAttempts({
   attempts: Record<number, HistoryNode>;
   icon: JSX.Element;
 }) {
-  const firstAttempt = Object.values(attempts)[0];
+  const attemptsArray = Object.values(attempts);
+  const firstAttempt =
+    Array.isArray(attemptsArray) && attemptsArray.length > 0 ? attemptsArray[0] : undefined;
+
   return (
     <span className="flex items-center">
       {firstAttempt && <span className="z-0">{getIconForStatus(firstAttempt)}</span>}
@@ -60,7 +63,7 @@ export function renderTimelineNode({
   node: HistoryNode;
   isAttempt?: boolean;
 }): RenderedData {
-  const hasRetries = Object.values(node.attempts)?.length > 0;
+  const hasRetries = node.attempts && Object.values(node.attempts)?.length > 0;
   let icon: JSX.Element;
   icon = getIconForStatus(node);
   if (hasRetries) {

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeRenderer.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeRenderer.tsx
@@ -55,10 +55,10 @@ function getIconsForAttempts({
 
 export function renderTimelineNode({
   node,
-  type,
+  isAttempt,
 }: {
   node: HistoryNode;
-  type?: 'attempt';
+  isAttempt?: boolean;
 }): RenderedData {
   const hasRetries = Object.values(node.attempts)?.length > 0;
   let icon: JSX.Element;
@@ -71,7 +71,7 @@ export function renderTimelineNode({
   if (node.scope === 'function') {
     name = `Function ${node.status}`;
   } else if (node.scope === 'step') {
-    if (type === 'attempt') {
+    if (isAttempt) {
       name = `Attempt ${node.attempt}`;
     } else if (node.waitForEventConfig) {
       name = node.waitForEventConfig.eventName;
@@ -97,12 +97,12 @@ export function renderTimelineNode({
       label: node.waitForEventResult?.timeout ? 'Timed Out At:' : 'Completed At:',
       value: node.endedAt.toLocaleString(),
     };
-  } else if (node.status === 'errored' && type !== 'attempt') {
+  } else if (node.status === 'errored' && !isAttempt) {
     metadata = {
       label: 'Enqueued Retry:',
       value: `${node.attempt + 1}`,
     };
-  } else if (node.status === 'errored' && type === 'attempt' && node.endedAt) {
+  } else if (node.status === 'errored' && isAttempt && node.endedAt) {
     metadata = {
       label: 'Errored At:',
       value: node.endedAt.toLocaleString(),

--- a/ui/packages/components/src/utils/outputRenderer.ts
+++ b/ui/packages/components/src/utils/outputRenderer.ts
@@ -6,13 +6,11 @@ type RenderedData = {
   output: string;
 };
 
-export type OutputType = 'failed' | 'completed';
-
 export function renderOutput({
-  type,
+  isSuccess,
   content,
 }: {
-  type: OutputType;
+  isSuccess: boolean;
   content: string;
 }): RenderedData {
   let message = '';
@@ -22,7 +20,7 @@ export function renderOutput({
   if (content) {
     const isOutputTooLarge = content.length > maxRenderedOutputSizeBytes;
 
-    if (type === 'failed' && !isOutputTooLarge) {
+    if (!isSuccess && !isOutputTooLarge) {
       try {
         const jsonObject = JSON.parse(content);
         errorName = jsonObject?.name;


### PR DESCRIPTION
## Description

- Add individual retries to steps and adjust steps metadata.
- Add sleeping and waiting for metadata to steps.

<img width="592" alt="Screenshot 2023-11-10 at 05 15 13" src="https://github.com/inngest/inngest/assets/16758464/e1ea2804-d11b-49a9-960f-d3b71a0dc47c">

<img width="587" alt="Screenshot 2023-11-10 at 12 51 27" src="https://github.com/inngest/inngest/assets/16758464/830130a0-a42a-4c92-9619-d21e04e0480c">


Outside of the scope of this PR: 
- adjust getOutput to return outputs for previous attempts

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
