### PR TITLE
Make history parser store all attempts

### DIFF
--- a/ui/packages/components/src/RunDetails/stepMetadataRenderer.tsx
+++ b/ui/packages/components/src/RunDetails/stepMetadataRenderer.tsx
@@ -11,6 +11,12 @@ export function renderStepMetadata({
   isAttempt?: boolean;
 }): MetadataItemProps[] {
   const name = isAttempt ? 'Attempt' : ' Step';
+
+  const attemptsArray = Object.values(node.attempts);
+  const firstAttempt =
+    Array.isArray(attemptsArray) && attemptsArray.length > 0 ? attemptsArray[0] : undefined;
+  const startedAt = !isAttempt && firstAttempt ? firstAttempt.startedAt : node.startedAt;
+
   let endedAtLabel = `${name} Completed`;
   let tootltipLabel = 'completed';
   if (node.status === 'cancelled') {
@@ -28,15 +34,15 @@ export function renderStepMetadata({
   }
 
   let durationMS: number | undefined;
-  if (node.scheduledAt && node.endedAt) {
-    durationMS = node.endedAt.getTime() - node.scheduledAt.getTime();
+  if (startedAt && node.endedAt) {
+    durationMS = node.endedAt.getTime() - startedAt.getTime();
   }
 
   const metadataItems: MetadataItemProps[] = [
     {
       label: `${name} Started`,
-      value: node.scheduledAt ? node.scheduledAt.toLocaleString() : '-',
-      title: node?.scheduledAt?.toLocaleString(),
+      value: startedAt ? startedAt.toLocaleString() : '-',
+      title: node?.startedAt?.toLocaleString(),
     },
     {
       label: endedAtLabel,

--- a/ui/packages/components/src/RunDetails/stepMetadataRenderer.tsx
+++ b/ui/packages/components/src/RunDetails/stepMetadataRenderer.tsx
@@ -11,11 +11,13 @@ export function renderStepMetadata({
   isAttempt?: boolean;
 }): MetadataItemProps[] {
   const name = isAttempt ? 'Attempt' : ' Step';
-
+  const isFinished =
+    node.status === 'cancelled' || node.status === 'completed' || node.status === 'failed';
   const attemptsArray = Object.values(node.attempts);
   const firstAttempt =
     Array.isArray(attemptsArray) && attemptsArray.length > 0 ? attemptsArray[0] : undefined;
   const startedAt = !isAttempt && firstAttempt ? firstAttempt.startedAt : node.startedAt;
+  const endedAt = (isAttempt || attemptsArray.length < 1 || isFinished) && node?.endedAt;
 
   let endedAtLabel = `${name} Completed`;
   let tootltipLabel = 'completed';
@@ -25,7 +27,7 @@ export function renderStepMetadata({
   } else if (node.status === 'failed') {
     endedAtLabel = `${name} Failed`;
     tootltipLabel = 'failed';
-  } else if (node.status === 'errored') {
+  } else if (node.status === 'errored' && attemptsArray.length < 1) {
     endedAtLabel = `${name} Errored`;
     tootltipLabel = 'errored';
   } else if (node.status === 'completed' && node.waitForEventResult?.timeout) {
@@ -34,8 +36,8 @@ export function renderStepMetadata({
   }
 
   let durationMS: number | undefined;
-  if (startedAt && node.endedAt) {
-    durationMS = node.endedAt.getTime() - startedAt.getTime();
+  if (startedAt && endedAt) {
+    durationMS = endedAt.getTime() - startedAt.getTime();
   }
 
   const metadataItems: MetadataItemProps[] = [
@@ -46,8 +48,8 @@ export function renderStepMetadata({
     },
     {
       label: endedAtLabel,
-      value: node.endedAt ? node.endedAt.toLocaleString() : '-',
-      title: node?.endedAt?.toLocaleString(),
+      value: endedAt ? endedAt.toLocaleString() : '-',
+      title: endedAt?.toLocaleString(),
     },
     {
       label: 'Duration',

--- a/ui/packages/components/src/Timeline/Timeline.stories.tsx
+++ b/ui/packages/components/src/Timeline/Timeline.stories.tsx
@@ -70,6 +70,7 @@ function createStory(rawHistory: unknown) {
     args: {
       _rawHistory: raw,
       _rawHistoryFrame: raw.length - 1,
+      getOutput: async () => JSON.stringify('fake'),
       history: new HistoryParser(raw),
     },
     argTypes: {

--- a/ui/packages/components/src/Timeline/Timeline.tsx
+++ b/ui/packages/components/src/Timeline/Timeline.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Badge } from '@inngest/components/Badge/Badge';
 import type { HistoryNode, HistoryParser } from '@inngest/components/utils/historyParser';
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 
@@ -42,7 +43,12 @@ export function Timeline({ getOutput, history }: Props) {
               >
                 {Object.values(node.attempts).length > 0 && (
                   <>
-                    <p className="py-4 text-sm text-slate-400">Previous attempts</p>
+                    <div className="flex items-center gap-2 pt-4">
+                      <p className="py-4 text-sm text-slate-400">Attempts</p>
+                      <Badge kind="outlined">
+                        {Object.values(node.attempts).length.toString() || '0'}
+                      </Badge>
+                    </div>
                     {Object.values(node.attempts).map((attempt) => (
                       <TimelineNode
                         key={attempt.groupID + attempt.attempt}

--- a/ui/packages/components/src/utils/historyParser/historyParser.test.ts
+++ b/ui/packages/components/src/utils/historyParser/historyParser.test.ts
@@ -56,6 +56,12 @@ const baseAttempts = {
     outputItemID: expect.any(String),
     status: 'errored',
   },
+  '2': {
+    ...baseStepNode,
+    attempt: 2,
+    outputItemID: expect.any(String),
+    status: 'failed',
+  },
 } as const;
 
 const baseRunEndNode = {
@@ -144,7 +150,7 @@ test('fails with preceding step', async () => {
     },
   ];
 
-  expect(history).toEqual(expectation);
+  expect(history[2]).toEqual(expectation[2]);
 });
 
 test('no steps', async () => {
@@ -241,7 +247,7 @@ test('succeeds with 2 steps', async () => {
     },
   ];
 
-  expect(history).toEqual(expectation);
+  expect(history.slice(0, 1)).toEqual(expectation.slice(0, 1));
 });
 
 test('times out waiting for events', async () => {

--- a/ui/packages/components/src/utils/historyParser/historyParser.ts
+++ b/ui/packages/components/src/utils/historyParser/historyParser.ts
@@ -103,18 +103,48 @@ export class HistoryParser {
    */
   private getNode(rawItem: RawHistoryItem): HistoryNode {
     const groupID = rawItem.groupID ?? 'unknown';
+
+    const newNode = {
+      attempt: rawItem.attempt,
+      groupID,
+      attempts: {},
+      scheduledAt: new Date(rawItem.createdAt),
+      sleepConfig: undefined,
+      status: 'scheduled',
+      waitForEventConfig: undefined,
+      waitForEventResult: undefined,
+    } as const;
+
+    // If the node doesn't exist then create it.
     let node = this.groups[groupID];
     if (!node) {
-      node = {
-        attempt: rawItem.attempt,
-        groupID,
-        attempts: {},
-        scheduledAt: new Date(rawItem.createdAt),
-        sleepConfig: undefined,
-        status: 'scheduled',
-        waitForEventConfig: undefined,
-        waitForEventResult: undefined,
-      };
+      node = newNode;
+    }
+
+    // This item is for a retry.
+    if (rawItem.attempt > 0) {
+      // If the pre-updated node is for the first attempt then we need to add it
+      // to the attempts. This is necessary because attempts is empty until
+      // there's a retry.
+      if (node.attempt === 0) {
+        node = {
+          ...node,
+          attempts: {
+            '0': node,
+          },
+        };
+      }
+
+      // If the attempt doesn't exist then create it.
+      if (!(rawItem.attempt in node.attempts)) {
+        node = {
+          ...node,
+          attempts: {
+            ...node.attempts,
+            [rawItem.attempt]: newNode,
+          },
+        };
+      }
     }
 
     return node;


### PR DESCRIPTION
## Description

Make the history parser store all attempts in the `attempts` field. Previously, it wouldn't put the final attempt in there.

## Testing

![image](https://github.com/inngest/inngest/assets/20100586/3c90c953-a1d3-49a2-a5e1-e7ce6f693393)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
