### PR TITLE
INN-2355 Don't return empty if lock failed when fetching `/dev` from Dev Server

### DIFF
--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -104,9 +104,7 @@ func (a devapi) UI(w http.ResponseWriter, r *http.Request) {
 
 // Info returns information about the dev server and its registered functions.
 func (a devapi) Info(w http.ResponseWriter, r *http.Request) {
-	if !a.devserver.handlerLock.TryLock() {
-		return
-	}
+	a.devserver.handlerLock.Lock()
 	defer a.devserver.handlerLock.Unlock()
 
 	all, _ := a.devserver.data.GetFunctions(r.Context())


### PR DESCRIPTION
## Description

Stops returning an empty response if the lock can't be retrieved when fetching the `/dev` endpoint.

This is commonly used for checking if the dev server is active, so failing means that clients can assume it's not active and attempt to send traffic to prod instead, usually failing, as in #821.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- INN-2355
- #645 
- Fixes #821

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
