### PR TITLE
Fix hang on event ingestion if at least 1 event fails parsing

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -138,6 +138,9 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 
 	// Process those incoming events
 	eg.Go(func() error {
+		// Close the idChan so that we stop appending to the ID slice.
+		defer close(idChan)
+
 		for s := range stream {
 			evt := event.Event{}
 			if err := json.Unmarshal(s.Item, &evt); err != nil {
@@ -164,8 +167,6 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 			}{s.N, id}
 		}
 
-		// Close the idChan so that we stop appending to the ID slice.
-		close(idChan)
 		return nil
 	})
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -162,7 +162,7 @@ func Start(ctx context.Context, s Service) (err error) {
 	select {
 	case sig := <-sigs:
 		// Terminating via a signal
-		l.Info().Interface("signal", sig).Msg("received signal")
+		l.Info().Interface("signal", sig).Msg("received signal; shutting down gracefully")
 		cleanup()
 	case err = <-runErr:
 		// Run terminated.  Fetch the error from the goroutine.
@@ -193,6 +193,8 @@ func Start(ctx context.Context, s Service) (err error) {
 	case <-time.After(stopTimeout(s)):
 		l.Error().Msg("service did not clean up within timeout")
 		return err
+	case sig := <-sigs:
+		l.Info().Interface("signal", sig).Msg("received signal again; shutting down immediately")
 	case stopErr := <-stopCh:
 		if stopErr != nil {
 			err = multierror.Append(err, stopErr)


### PR DESCRIPTION
## Description

Fixes a dangling channel causing hanging during event ingestion if at least one of the events fails parsing.

Also added a cold shutdown if the dev server receives >1 `SIGTERM`, because every now and again this annoys me. 😅

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
