### PR TITLE
Ignore unexpected history types in HistoryParser

### DIFF
--- a/ui/packages/components/src/utils/historyParser/types.ts
+++ b/ui/packages/components/src/utils/historyParser/types.ts
@@ -30,21 +30,26 @@ export type HistoryNode = {
   };
 };
 
-export type HistoryType =
-  | 'FunctionCancelled'
-  | 'FunctionCompleted'
-  | 'FunctionFailed'
-  | 'FunctionScheduled'
-  | 'FunctionStarted'
-  | 'FunctionStatusUpdated'
-  | 'None'
-  | 'StepCompleted'
-  | 'StepErrored'
-  | 'StepFailed'
-  | 'StepScheduled'
-  | 'StepSleeping'
-  | 'StepStarted'
-  | 'StepWaiting';
+const historyTypes = [
+  'FunctionCancelled',
+  'FunctionCompleted',
+  'FunctionFailed',
+  'FunctionScheduled',
+  'FunctionStarted',
+  'FunctionStatusUpdated',
+  'None',
+  'StepCompleted',
+  'StepErrored',
+  'StepFailed',
+  'StepScheduled',
+  'StepSleeping',
+  'StepStarted',
+  'StepWaiting',
+] as const;
+export type HistoryType = (typeof historyTypes)[number];
+export function isHistoryType(value: string): value is HistoryType {
+  return historyTypes.includes(value as HistoryType);
+}
 
 export type RawHistoryItem = {
   attempt: number;
@@ -65,7 +70,7 @@ export type RawHistoryItem = {
   } | null;
   stepName?: string | null;
   stepType?: 'Run' | 'Send' | 'Sleep' | 'Wait' | null;
-  type: HistoryType;
+  type: string;
   url?: string | null;
   waitForEvent?: {
     eventName: string;

--- a/ui/packages/components/src/utils/historyParser/updateNode.ts
+++ b/ui/packages/components/src/utils/historyParser/updateNode.ts
@@ -1,12 +1,16 @@
-import { runEndGroupID, type HistoryNode, type HistoryType, type RawHistoryItem } from './types';
+import {
+  isHistoryType,
+  runEndGroupID,
+  type HistoryNode,
+  type HistoryType,
+  type RawHistoryItem,
+} from './types';
 
 type Updater = (node: HistoryNode, rawItem: RawHistoryItem) => HistoryNode;
 
 const noop: Updater = (node) => node;
 
-const updaters: {
-  [key in HistoryType]: Updater;
-} = {
+const updaters: Record<HistoryType, Updater> = {
   FunctionCancelled: (node, rawItem) => {
     return {
       ...node,
@@ -147,7 +151,9 @@ const updaters: {
       waitForEventConfig,
     } satisfies HistoryNode;
   },
-} as const;
+} satisfies {
+  [key in HistoryType]: Updater;
+};
 
 function parseName(name: string | undefined): string | undefined {
   // This is hacky, but assume that a name of "step" means we're discovering the
@@ -173,7 +179,13 @@ function parseURL(url: string): string {
 }
 
 export function updateNode(node: HistoryNode, rawItem: RawHistoryItem): HistoryNode {
-  const update = updaters[rawItem.type];
+  const historyType = rawItem.type;
+  if (!isHistoryType(historyType)) {
+    // Return the node unchanged if the history type is unexpected.
+    return node;
+  }
+
+  const update = updaters[historyType];
   node = update(node, rawItem);
   node.attempt = rawItem.attempt;
 


### PR DESCRIPTION
## Description

Fix a bug where the UI crashed when `HistoryParser` encountered unexpected history type

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
