### PR TITLE
fix(dashboard): empty page on sign-out

### DIFF
--- a/ui/apps/dashboard/src/components/Navigation/AccountDropdown.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/AccountDropdown.tsx
@@ -1,6 +1,6 @@
 import { type Route } from 'next';
 import Image from 'next/image';
-import { SignOutButton, currentUser } from '@clerk/nextjs';
+import { currentUser } from '@clerk/nextjs';
 import type { User } from '@clerk/nextjs/server';
 import {
   CreditCardIcon,
@@ -13,6 +13,7 @@ import {
   UserGroupIcon,
 } from '@heroicons/react/20/solid';
 
+import SignOutButton from '@/components/Navigation/SignOutButton';
 import Dropdown from '../Dropdown/Dropdown';
 import DropdownItem from '../Dropdown/DropdownItem';
 import StatusPageItem from './StatusPageItem';

--- a/ui/apps/dashboard/src/components/Navigation/SignOutButton.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/SignOutButton.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { SignOutButton as ClerkSignOutButton } from '@clerk/nextjs';
+
+type SignOutButtonProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export default function SignOutButton({ children, className }: SignOutButtonProps) {
+  return (
+    <ClerkSignOutButton
+      // @ts-expect-error type is wrong. className is accepted as a prop.
+      className={className}
+      signOutCallback={() => {
+        window.location.href = process.env.NEXT_PUBLIC_SIGN_IN_PATH || '/sign-in';
+      }}
+    >
+      {children}
+    </ClerkSignOutButton>
+  );
+}

--- a/ui/apps/dashboard/src/middleware.ts
+++ b/ui/apps/dashboard/src/middleware.ts
@@ -2,7 +2,7 @@ import { authMiddleware } from '@clerk/nextjs';
 
 export default authMiddleware({
   publicRoutes: ['/password-reset', '/support'],
-  ignoredRoutes: '/(images|_next/static|_next/image|favicon)(.*)',
+  ignoredRoutes: '/(images|api|_next/static|_next/image|favicon)(.*)',
 });
 
 export const config = {
@@ -15,6 +15,6 @@ export const config = {
      * - _next/image (image optimization files)
      * - favicon (favicon file)
      */
-    '/((?!images|_next/static|_next/image|favicon).*)',
+    '/((?!images|api|_next/static|_next/image|favicon).*)',
   ],
 };


### PR DESCRIPTION
## Description

This fixes a bug where the Clerk's provided SignIn component wouldn't render on SignOut. I suspect the issue lies in the redirect performed after sign-out. For an unknown reason, the URL is unchanged after getting redirected to the /sign-in page.

Potentially related issues:
- https://github.com/clerk/javascript/issues/1981
- https://github.com/vercel/next.js/issues/58281

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
