### PR TITLE
Add `--retry-interval` flag to customize the time in between retries

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -24,6 +24,7 @@ func NewCmdDev() *cobra.Command {
 	cmd.Flags().StringSliceP("sdk-url", "u", []string{}, "SDK URLs to load functions from")
 	cmd.Flags().Bool("no-discovery", false, "Disable autodiscovery")
 	cmd.Flags().Bool("no-poll", false, "Disable polling of apps for updates")
+	cmd.Flags().Int("retry-interval", 0, "Retry interval in seconds for linear backoff when retrying functions - must be 1 or above")
 
 	return cmd
 }
@@ -54,11 +55,14 @@ func doDev(cmd *cobra.Command, args []string) {
 	noDiscovery, _ := cmd.Flags().GetBool("no-discovery")
 	noPoll, _ := cmd.Flags().GetBool("no-poll")
 
+	retryInterval, _ := cmd.Flags().GetInt("retry-interval")
+
 	opts := devserver.StartOpts{
-		Config:       *conf,
-		URLs:         urls,
-		Autodiscover: !noDiscovery,
-		Poll:         !noPoll,
+		Config:        *conf,
+		URLs:          urls,
+		Autodiscover:  !noDiscovery,
+		Poll:          !noPoll,
+		RetryInterval: retryInterval,
 	}
 
 	close, err := telemetry.TracerSetup("devserver", telemetry.TracerTypeNoop)

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -55,3 +55,11 @@ func TableBackoff(attemptNum int) time.Time {
 	jitter := time.Duration(rand.Int31n(30_000)) * time.Millisecond
 	return time.Now().Add(at).Add(jitter)
 }
+
+// GetLinearBackoffFunc returns a backoff function that returns a fixed interval
+// between attempts.
+func GetLinearBackoffFunc(interval time.Duration) BackoffFunc {
+	return func(attemptNum int) time.Time {
+		return time.Now().Add(interval)
+	}
+}

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/VividCortex/ewma"
 	"github.com/hashicorp/go-multierror"
-	"github.com/inngest/inngest/pkg/backoff"
 	"github.com/inngest/inngest/pkg/execution/concurrency"
 	osqueue "github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
@@ -721,7 +720,7 @@ func (q *queue) process(ctx context.Context, p QueuePartition, qi QueueItem, f o
 		jobCancel()
 
 		if osqueue.ShouldRetry(err, qi.Data.Attempt, qi.Data.GetMaxAttempts()) {
-			at := backoff.DefaultBackoff(qi.Data.Attempt)
+			at := q.backoffFunc(qi.Data.Attempt)
 			// If the error contains a NextRetryAt method, use that to indicate
 			// when we should retry.
 			if specifier, ok := err.(osqueue.RetryAtSpecifier); ok {


### PR DESCRIPTION
## Description

Adds a `--retry-interval` flag to the Dev Server to be able to specify a linear time in-between retries, useful for rapidly testing retry logic.

It would be great to be able to adjust this from within the UI later.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
