### PR TITLE
Fix invoke broken when function ID contains a slash

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -204,6 +205,11 @@ func (a API) Invoke(w http.ResponseWriter, r *http.Request) {
 	slug := chi.URLParam(r, "slug")
 	if slug == "" {
 		_ = publicerr.WriteHTTP(w, publicerr.Errorf(400, "Function slug is required"))
+		return
+	}
+	slug, err := url.QueryUnescape(slug)
+	if err != nil {
+		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 400, "Unable to decode function slug"))
 		return
 	}
 

--- a/ui/apps/dev-server-ui/src/store/devApi.ts
+++ b/ui/apps/dev-server-ui/src/store/devApi.ts
@@ -19,7 +19,7 @@ export const devApi = createApi({
       { id: string; name: string; ts: number; data?: object; user?: object; functionId?: string }
     >({
       query: ({ functionId, ...event }) => ({
-        url: functionId ? `/invoke/${functionId}` : '/e/dev_key',
+        url: functionId ? `/invoke/${encodeURIComponent(functionId)}` : '/e/dev_key',
         method: 'POST',
         body: event,
       }),


### PR DESCRIPTION
## Description

Fix invoke not working when function ID contains a slash. This was happening because we weren't encoding the function ID in the `/invoke/<function-id>` path

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
