### PR TITLE
Fix use of `waitForEvent` maybe causing duplicate calls with parallelism

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1229,7 +1229,9 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, gen state.Ge
 	// the pause so this race will conclude by calling the function once, as only
 	// one thread can lease and consume a pause;  the other will find that the
 	// pause is no longer available and return.
+	jobID := fmt.Sprintf("%s-%s-%s", item.Identifier.IdempotencyKey(), gen.ID, "wait")
 	err = e.queue.Enqueue(ctx, queue.Item{
+		JobID:       &jobID,
 		WorkspaceID: item.WorkspaceID,
 		// Use the same group ID, allowing us to track the cancellation of
 		// the step correctly.


### PR DESCRIPTION
## Description

Currently, `JobID` isn't set when enqueuing a job for `waitForEvent`. This results in a couple of behaviours. First, this means that `id` here in `Enqueue()` is never set to a non-empty string.

https://github.com/inngest/inngest/blob/edaeff74278bf6bb2fb019933045b4b4d79b8001/pkg/execution/state/redis_state/queue_processor.go#L114-L117

Further down the chain, this results in a completely new ID being generated for the job. `i.ID` here is our empty string.

https://github.com/inngest/inngest/blob/edaeff74278bf6bb2fb019933045b4b4d79b8001/pkg/execution/state/redis_state/queue.go#L623-L630

This ID is used to create an idempotency key to ensure we don't re-enqueue existing work, seen being used here:

https://github.com/inngest/inngest/blob/edaeff74278bf6bb2fb019933045b4b4d79b8001/pkg/execution/state/redis_state/queue.go#L674

The v1 execution method means that duplicate work can be passed back to the executor during parallelism and we rely on that work being idempotently queued. These generated IDs break that contract.

In most cases, this likely won't be affecting many users, but using a `waitForEvent()` parallel to other steps may cause that `waitForEvent()` call be to queued multiple times, resulting in later steps and actions also being queued multiple times.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
