### PR TITLE
Add `--log-level` CLI flag

### DIFF
--- a/pkg/config/parse.go
+++ b/pkg/config/parse.go
@@ -143,7 +143,6 @@ func decode(i *cue.Instance) (*Config, error) {
 
 	// Ensure we set log levels and formats here, globally.
 	// XXX: This could/should be refactored;  this is messy (but minimal impact rn).
-	logger.SetLevel(c.Log.Level)
 	logger.SetFormat(c.Log.Format)
 
 	return c, nil

--- a/pkg/inngest/log/log.go
+++ b/pkg/inngest/log/log.go
@@ -10,7 +10,8 @@ import (
 )
 
 const (
-	DefaultLevel = zerolog.InfoLevel
+	DefaultLevel     = zerolog.InfoLevel
+	ViperLogLevelKey = "log.level"
 )
 
 var (
@@ -54,7 +55,7 @@ func Copy(l zerolog.Logger) zerolog.Logger {
 }
 
 func Default() *zerolog.Logger {
-	lvl, err := zerolog.ParseLevel(viper.GetString("log.level"))
+	lvl, err := zerolog.ParseLevel(viper.GetString(ViperLogLevelKey))
 	if err != nil {
 		lvl = zerolog.InfoLevel
 	}

--- a/pkg/logger/zerolog.go
+++ b/pkg/logger/zerolog.go
@@ -19,7 +19,10 @@ var (
 
 // SetLevel sets the default log level.
 func SetLevel(to string) {
-	logLevel = to
+	lvl, err := zerolog.ParseLevel(to)
+	if err == nil {
+		logLevel = lvl.String()
+	}
 }
 
 // SetLogLevel sets the default log level.


### PR DESCRIPTION
## Description

Adds a `-l, --log-level` flag for setting log levels. If it's not specified, the `-v, --verbose` flag can also be used to set `--log-level debug`.

`-v, --verbose` seems to now be entirely unused elsewhere, though.

```diff                                     
    ____                            __ 
   /  _/___  ____  ____ ____  _____/ /_
   / // __ \/ __ \/ __ '/ _ \/ ___/ __/
 _/ // / / / / / / /_/ /  __(__  ) /_  
/___/_/ /_/_/ /_/\__, /\___/____/\__/  
                /____/                 
                                       
Build event-driven queues with zero infra. 
Request features, get help, and chat with us: https://www.inngest.com/discord

Usage:
  inngest [command]

Available Commands:
  dev         Run the Inngest dev server
  help        Help about any command
  login       Logs in to your Inngest account
  version     Shows the inngest CLI version (saving time, it's: dev-)

Flags:
  -h, --help               help for inngest
      --json               Output logs as JSON.  Set to true if stdout is not a TTY.
+ -l, --log-level string   Set the log level.  One of: trace, debug, info, warn, error. (default "info")
      --prod               Use the production environment for the current command.
  -v, --verbose            Enable verbose logging.

Use "inngest [command] --help" for more information about a command.
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
