### PR TITLE
Fix function return parsing when a serialized JSON string is returned

### DIFF
--- a/pkg/execution/driver/httpdriver/parse.go
+++ b/pkg/execution/driver/httpdriver/parse.go
@@ -162,5 +162,5 @@ func parseResponse(byt []byte) any {
 		}
 	}
 
-	return string(byt)
+	return json.RawMessage(byt)
 }


### PR DESCRIPTION
## Description

Looks like the changes from #862 broke some integration tests around functions finishing with a string value. Specifically, they would end up in history and other outputs as double-encoded strings instead of their deserialized JSON value, e.g. `"\"\\\"Hello, Inngest!\\\"\""` instead of `"\"Hello, Inngest!\""`.

This mathces a piece of `httpdriver` was doing before the refactor:

https://github.com/inngest/inngest/blob/419a32586368171fb866f73dae423e6de33cf9f7/pkg/execution/driver/httpdriver/httpdriver.go#L197

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- #862

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
