### PR TITLE
Enforce `X-Inngest-Expected-Server-Kind` during registration

### DIFF
--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -129,11 +129,17 @@ func (a devapi) Info(w http.ResponseWriter, r *http.Request) {
 // Register regsters functions served via SDKs
 func (a devapi) Register(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
+	ctx := r.Context()
+
+	expectedServerKind := r.Header.Get(headers.HeaderKeyExpectedServerKind)
+	if expectedServerKind != "" && expectedServerKind != headers.ServerKindDev {
+		a.err(ctx, w, 400, fmt.Errorf("Expected server kind %s, got %s", expectedServerKind, headers.ServerKindDev))
+		return
+	}
 
 	a.devserver.handlerLock.Lock()
 	defer a.devserver.handlerLock.Unlock()
 
-	ctx := r.Context()
 	req := &sdk.RegisterRequest{}
 	if err := json.NewDecoder(r.Body).Decode(req); err != nil {
 		logger.From(ctx).Warn().Msgf("Invalid request:\n%s", err)

--- a/pkg/headers/headers.go
+++ b/pkg/headers/headers.go
@@ -8,6 +8,10 @@ const (
 	// Tells the consumers (e.g. SDKs) what kind of Inngest server they're
 	// communicating with (Cloud or Dev Server).
 	HeaderKeyServerKind = "X-Inngest-Server-Kind"
+	// Used by an SDK to tell the Inngest server what kind the SDK expects it
+	// to be, used to validate that every part of a registration is performed
+	// against the same target.
+	HeaderKeyExpectedServerKind = "X-Inngest-Expected-Server-Kind"
 )
 
 const (


### PR DESCRIPTION
## Description

Check and enforce `X-Inngest-Expected-Server-Kind` headers during Dev Server registration.

```mermaid
sequenceDiagram
autonumber

participant Dev Server
participant SDK
participant Cloud

note over Dev Server: During discovery or manually...
Dev Server->>+SDK: ➡️ PUT localhost:3000/api/inngest<br/>X-Inngest-Server-Kind: dev
note over SDK: Local app misconfigured!<br/>Will try to register with Cloud
SDK->>+Cloud: ➡️ POST api.inngest.com/fn/register<br/>X-Inngest-Expected-Server-Kind: dev
Cloud-->>-SDK: ⛔ 400 Bad Request<br/>Cannot trigger a Cloud deployment using the Dev Server.
SDK-->>-Dev Server: ⛔ 400 Bad Request<br/>Cannot trigger a Cloud deployment using the Dev Server.
note over Dev Server: Show log<br/>Display in UI
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- inngest/inngest-js#408

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
