### PR TITLE
Create app in Dev Server on registration error

### DIFF
--- a/pkg/coreapi/graph/resolvers/app_mutations.go
+++ b/pkg/coreapi/graph/resolvers/app_mutations.go
@@ -29,8 +29,8 @@ func (r *mutationResolver) CreateApp(ctx context.Context, input models.CreateApp
 	}
 	app, _ := r.Data.InsertApp(ctx, params)
 
-	if err := deploy.Ping(ctx, input.URL); err != nil {
-		return app, err
+	if res := deploy.Ping(ctx, input.URL); res.Err != nil {
+		return app, res.Err
 	}
 
 	<-time.After(100 * time.Millisecond)

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -221,12 +221,12 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 
 				// Make a new PUT request to each app, indicating that the
 				// SDK should push functions to the dev server.
-				err := deploy.Ping(ctx, app.Url)
-				if err != nil {
+				res := deploy.Ping(ctx, app.Url)
+				if res.Err != nil {
 					_, _ = d.data.UpdateAppError(ctx, cqrs.UpdateAppErrorParams{
 						ID: app.ID,
 						Error: sql.NullString{
-							String: err.Error(),
+							String: res.Err.Error(),
 							Valid:  true,
 						},
 					})
@@ -249,7 +249,36 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 				if _, ok := urls[u]; ok {
 					continue
 				}
-				_ = deploy.Ping(ctx, u)
+				res := deploy.Ping(ctx, u)
+
+				// If there was an SDK error then we should still create the
+				// app. Otherwise, users will have a harder time figuring out
+				// why the Dev Server can't find their app.
+				if res.Err != nil && res.IsSDK {
+					tx, err := d.data.WithTx(ctx)
+					if err != nil {
+						continue
+					}
+
+					_, err = tx.InsertApp(ctx, cqrs.InsertAppParams{
+						Error: sql.NullString{
+							String: res.Err.Error(),
+							Valid:  true,
+						},
+						ID:  uuid.NewSHA1(uuid.NameSpaceOID, []byte(u)),
+						Url: u,
+					})
+					if err != nil {
+						logger.From(ctx).Error().Err(err).Msg("error inserting app")
+						continue
+					}
+
+					err = tx.Commit(ctx)
+					if err != nil {
+						logger.From(ctx).Error().Err(err).Msg("error inserting app")
+						continue
+					}
+				}
 			}
 		}
 		<-time.After(SDKPollInterval)

--- a/pkg/headers/headers.go
+++ b/pkg/headers/headers.go
@@ -5,6 +5,9 @@ import (
 )
 
 const (
+	// SDK version (e.g. "js:v3.2.1")
+	HeaderKeySDK = "X-Inngest-SDK"
+
 	// Tells the consumers (e.g. SDKs) what kind of Inngest server they're
 	// communicating with (Cloud or Dev Server).
 	HeaderKeyServerKind = "X-Inngest-Server-Kind"


### PR DESCRIPTION
## Description

In the Dev Server, create an app if the SDK ping returns an error.

Previously, SDK ping rejections would not result in an app appearing in the Dev Server UI. This made it harder to debug why registration was failing. Note that this didn't prevent _all_ registration errors from creating apps -- only a subset of registration errors.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
