### PR TITLE
Improve service to clean code and add run timeouts

### DIFF
--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -20,6 +21,7 @@ type mockserver struct {
 	stop func(ctx context.Context) error
 
 	startTimeout time.Duration
+	runTimeout   time.Duration
 }
 
 func (m mockserver) Name() string {
@@ -48,6 +50,13 @@ func (m mockserver) StartTimeout() time.Duration {
 	return defaultTimeout
 }
 
+func (m mockserver) RunTimeout() time.Duration {
+	if m.runTimeout != 0 {
+		return m.runTimeout
+	}
+	return defaultTimeout
+}
+
 func TestStart(t *testing.T) {
 	m := mockserver{
 		pre:  func(ctx context.Context) error { return nil },
@@ -57,62 +66,109 @@ func TestStart(t *testing.T) {
 	now := time.Now()
 	err := Start(context.Background(), m)
 	require.NoError(t, err)
-	require.WithinDuration(t, time.Now(), now.Add(500*time.Millisecond), 10*time.Millisecond)
+	require.WithinDuration(t, time.Now(), now.Add(500*time.Millisecond), 25*time.Millisecond)
 }
 
-func TestSigint(t *testing.T) {
-	m := mockserver{
-		pre:  func(ctx context.Context) error { return nil },
-		run:  func(ctx context.Context) error { <-time.After(time.Hour); return nil },
-		stop: func(ctx context.Context) error { return nil },
+func TestSignals(t *testing.T) {
+	signals := map[string]syscall.Signal{
+		"SIGTERM": syscall.SIGTERM,
+		"SIGINT":  syscall.SIGINT,
 	}
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
+	for name, sig := range signals {
 
-	now := time.Now()
-	go func() {
-		err := Start(context.Background(), m)
-		require.NoError(t, err)
-		wg.Done()
-	}()
+		t.Run(fmt.Sprintf("%s: It waits the full run timeout to end", name), func(t *testing.T) {
+			timeout := 5 * time.Second
+			m := mockserver{
+				pre: func(ctx context.Context) error { return nil },
+				run: func(ctx context.Context) error {
+					start := time.Now()
+					i := 0
+					// Run for longer than the timeout, ensuring that the service ends with ErrRunTimeout.
+					for time.Now().Before(start.Add(timeout * 2)) {
+						if i > 2 {
+							require.NotNil(t, ctx.Err(), "expected ctx to be cancelled with signal")
+						}
+						i++
+						<-time.After(time.Second)
+					}
+					return nil
+				},
+				runTimeout: timeout,
+				stop:       func(ctx context.Context) error { return nil },
+			}
 
-	<-time.After(50 * time.Millisecond)
-	// XXX: We use gopsutil for support on linux and windows.
-	p, err := process.NewProcess(int32(syscall.Getpid()))
-	require.NoError(t, err)
-	err = p.Terminate()
-	require.NoError(t, err)
+			// Track when the fn is done.
+			wg := sync.WaitGroup{}
+			wg.Add(1)
 
-	wg.Wait()
-	require.WithinDuration(t, time.Now(), now.Add(50*time.Millisecond), 10*time.Millisecond)
-}
+			go func() {
+				// Block until the service finishes.
+				err := Start(context.Background(), m)
+				// The server above does not finish before the timeout.
+				require.Equal(t, true, errors.Is(err, ErrRunTimeout))
+				wg.Done()
+			}()
 
-func TestSigterm(t *testing.T) {
-	m := mockserver{
-		pre:  func(ctx context.Context) error { return nil },
-		run:  func(ctx context.Context) error { <-time.After(time.Hour); return nil },
-		stop: func(ctx context.Context) error { return nil },
+			<-time.After(50 * time.Millisecond)
+
+			start := time.Now()
+
+			// XXX: We use gopsutil for support on linux and windows.
+			p, err := process.NewProcess(int32(syscall.Getpid()))
+			require.NoError(t, err)
+			err = p.SendSignal(sig)
+			require.NoError(t, err)
+
+			wg.Wait()
+
+			// The timeout should end after runTimeout.
+			require.WithinDuration(t, time.Now(), start.Add(m.runTimeout), 50*time.Millisecond)
+		})
+
+		t.Run(fmt.Sprintf("%s: Run context is cancelled and we end the fn", name), func(t *testing.T) {
+			timeout := 5 * time.Second
+			m := mockserver{
+				pre: func(ctx context.Context) error { return nil },
+				run: func(ctx context.Context) error {
+					select {
+					case <-ctx.Done():
+						<-time.After(50 * time.Millisecond)
+						return nil
+					case <-time.After(time.Hour):
+					}
+					return nil
+				},
+				runTimeout: timeout,
+				stop:       func(ctx context.Context) error { return nil },
+			}
+
+			// Track when the fn is done.
+			wg := sync.WaitGroup{}
+			wg.Add(1)
+
+			go func() {
+				// Block until the service finishes.
+				err := Start(context.Background(), m)
+				// The server above does not finish before the timeout.
+				require.NoError(t, err)
+				wg.Done()
+			}()
+
+			<-time.After(50 * time.Millisecond)
+
+			start := time.Now()
+			p, err := process.NewProcess(int32(syscall.Getpid()))
+			require.NoError(t, err)
+			err = p.SendSignal(sig)
+			require.NoError(t, err)
+
+			wg.Wait()
+
+			// The timeout should end almost immediately.
+			require.WithinDuration(t, time.Now(), start, 100*time.Millisecond)
+		})
 	}
-
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-
-	now := time.Now()
-	go func() {
-		err := Start(context.Background(), m)
-		require.NoError(t, err)
-		wg.Done()
-	}()
-
-	<-time.After(50 * time.Millisecond)
-	p, err := process.NewProcess(int32(syscall.Getpid()))
-	require.NoError(t, err)
-	err = p.Terminate()
-	require.NoError(t, err)
-
-	wg.Wait()
-	require.WithinDuration(t, time.Now(), now.Add(50*time.Millisecond), 10*time.Millisecond)
 }
 
 func TestPreError(t *testing.T) {
@@ -171,7 +227,10 @@ func TestSingleSvcError(t *testing.T) {
 				return fmt.Errorf("boo")
 			}
 			//The others should run.
-			<-time.After(time.Minute)
+			select {
+			case <-time.After(time.Minute):
+			case <-ctx.Done():
+			}
 			return nil
 		},
 		stop: func(ctx context.Context) error {
@@ -181,7 +240,7 @@ func TestSingleSvcError(t *testing.T) {
 	}
 	now := time.Now()
 	err := StartAll(context.Background(), m, m, m)
-	require.Error(t, err)
+	require.Error(t, err, "expected service to return an error")
 	require.ErrorContains(t, err, "boo")
 	require.WithinDuration(t, time.Now(), now.Add(500*time.Millisecond), 10*time.Millisecond)
 	require.Equal(t, int32(3), atomic.LoadInt32(&invocations))


### PR DESCRIPTION
Improves service code and ensures Run waits until RunTimeout before force quitting.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
