### PR TITLE
Fix spread links

### DIFF
--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
@@ -136,9 +136,7 @@ function Content({
 
   return (
     <>
-      {links?.length ? (
-        <div className="flex flex-row justify-end gap-x-5 pb-5">{...links}</div>
-      ) : null}
+      {links?.length ? <div className="flex flex-row justify-end gap-x-5 pb-5">{links}</div> : null}
 
       <div className="pb-5">
         <MetadataGrid metadataItems={metadataItems} />


### PR DESCRIPTION
## Description
Storybook was broken with the error: `SyntaxError: /Users/ana/Developer/inngest/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx: Spread children are not supported in React.`

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
