### PR TITLE
Add cancellation summary to function run details

### DIFF
--- a/ui/packages/components/src/RunDetails/CancellationSummary.stories.tsx
+++ b/ui/packages/components/src/RunDetails/CancellationSummary.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { HistoryParser, type RawHistoryItem } from '../utils/historyParser';
+import { CancellationSummary } from './CancellationSummary';
+
+const meta = {
+  title: 'Components/CancellationSummary',
+  component: CancellationSummary,
+  decorators: [
+    (Story) => {
+      return (
+        <div style={{ width: 600 }}>
+          <Story />
+        </div>
+      );
+    },
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof CancellationSummary>;
+
+export default meta;
+
+type Story = StoryObj<typeof CancellationSummary>;
+
+const baseItem: RawHistoryItem = {
+  attempt: 0,
+  cancel: {
+    eventID: '01HAWKZ4BD4MHGCXSWTXHTJVGN',
+    expression: null,
+    userID: null,
+  },
+  createdAt: '2023-09-21T15:37:45.720719-04:00',
+  functionVersion: 1,
+  groupID: 'ebf329b0-badc-4cc9-b962-514f5202f2fc',
+  id: '01HAWKZ4FRPHGNVMPBJ8DBCCR5',
+  sleep: null,
+  stepName: null,
+  type: 'FunctionCancelled',
+  url: null,
+  waitForEvent: null,
+  waitResult: null,
+};
+
+export const Main: Story = {
+  args: {
+    history: new HistoryParser([baseItem]),
+  },
+};

--- a/ui/packages/components/src/RunDetails/CancellationSummary.tsx
+++ b/ui/packages/components/src/RunDetails/CancellationSummary.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Card } from '@inngest/components/Card';
+import { MetadataItem } from '@inngest/components/Metadata';
+import { IconEvent } from '@inngest/components/icons/Event';
+import type { HistoryParser } from '@inngest/components/utils/historyParser';
+
+type Props = {
+  history: HistoryParser;
+};
+
+export function CancellationSummary({ history }: Props) {
+  const { cancellation } = history;
+  if (!cancellation) {
+    return null;
+  }
+
+  return (
+    <Card accentColor="bg-gray-400">
+      <Card.Header>Cancelled</Card.Header>
+
+      <Card.Content>
+        {/* TODO: Make this a link */}
+        <MetadataItem
+          label="Event ID"
+          value={
+            <>
+              <IconEvent className="inline-block" /> {cancellation.eventID}
+            </>
+          }
+        />
+
+        <MetadataItem
+          label="Match Expression"
+          type="code"
+          value={cancellation.expression ?? 'N/A'}
+        />
+      </Card.Content>
+    </Card>
+  );
+}

--- a/ui/packages/components/src/RunDetails/RunDetails.tsx
+++ b/ui/packages/components/src/RunDetails/RunDetails.tsx
@@ -12,6 +12,7 @@ import type { FunctionRun } from '@inngest/components/types/functionRun';
 import type { FunctionVersion } from '@inngest/components/types/functionVersion';
 import type { HistoryParser } from '@inngest/components/utils/historyParser';
 
+import { CancellationSummary } from './CancellationSummary';
 import { SleepingSummary } from './SleepingSummary';
 import { WaitingSummary } from './WaitingSummary';
 import { renderRunMetadata } from './runMetadataRenderer';
@@ -77,6 +78,7 @@ export function RunDetails({
           <OutputCard content={run.output} isSuccess={isSuccess} />
         )}
 
+        <CancellationSummary history={history} />
         <WaitingSummary history={history} />
         <SleepingSummary history={history} />
       </div>

--- a/ui/packages/components/src/RunDetails/SleepingSummary.stories.tsx
+++ b/ui/packages/components/src/RunDetails/SleepingSummary.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { HistoryParser, type RawHistoryItem } from '../utils/historyParser';
 import { SleepingSummary } from './SleepingSummary';
 
 const meta = {
@@ -24,37 +25,31 @@ export default meta;
 
 type Story = StoryObj<typeof SleepingSummary>;
 
-const second = 1000;
-const minute = 60 * second;
-
-const baseSleepNode = {
+const baseItem: RawHistoryItem = {
   attempt: 0,
-  groupID: 'a',
-  scheduledAt: new Date(),
-  sleepConfig: {
-    until: new Date(Date.now() + minute),
+  cancel: null,
+  createdAt: '2023-09-22T16:22:38.136906-04:00',
+  functionVersion: 1,
+  groupID: 'bd178be1-d9ab-42be-9669-15a78eaf9f2a',
+  id: '01HAZ8Y0SRB55DT2AX1FAX5DW2',
+  sleep: {
+    until: '2023-09-22T16:22:48.136637-04:00',
   },
-  status: 'sleeping',
-} as const;
+  type: 'StepSleeping',
+  stepName: '10s',
+  url: null,
+  waitForEvent: null,
+  waitResult: null,
+};
 
 export const OneSleep: Story = {
   args: {
-    history: {
-      a: baseSleepNode,
-    },
+    history: new HistoryParser([baseItem]),
   },
 };
 
 export const TwoSleeps: Story = {
   args: {
-    history: {
-      a: {
-        ...baseSleepNode,
-      },
-      b: {
-        ...baseSleepNode,
-        groupID: 'b',
-      },
-    },
+    history: new HistoryParser([baseItem, { ...baseItem, groupID: 'b' }]),
   },
 };

--- a/ui/packages/components/src/RunDetails/WaitingSummary.stories.tsx
+++ b/ui/packages/components/src/RunDetails/WaitingSummary.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { HistoryParser, type RawHistoryItem } from '../utils/historyParser';
 import { WaitingSummary } from './WaitingSummary';
 
 const meta = {
@@ -24,39 +25,33 @@ export default meta;
 
 type Story = StoryObj<typeof WaitingSummary>;
 
-const second = 1000;
-const minute = 60 * second;
-
-const baseWaitNode = {
+const baseItem: RawHistoryItem = {
   attempt: 0,
-  groupID: 'a',
-  scheduledAt: new Date(),
-  status: 'waiting',
-  waitForEventConfig: {
-    eventName: 'app/MyEvent',
-    expression: 'async.data.foo == event.data.foo',
-    timeout: new Date(Date.now() + minute),
+  cancel: null,
+  createdAt: '2023-09-29T11:56:58.808606-04:00',
+  functionVersion: 1,
+  groupID: 'dca64663-efce-458b-8eff-5fa8e06b11a4',
+  id: '01HBGTGM1R3YX0PWD92WXFPZVK',
+  sleep: null,
+  stepName: 'bar',
+  type: 'StepWaiting',
+  url: null,
+  waitForEvent: {
+    eventName: 'bar',
+    expression: null,
+    timeout: '2023-09-29T11:57:58.808601-04:00',
   },
-} as const;
+  waitResult: null,
+};
 
 export const OneWait: Story = {
   args: {
-    history: {
-      a: baseWaitNode,
-    },
+    history: new HistoryParser([baseItem]),
   },
 };
 
 export const TwoWaits: Story = {
   args: {
-    history: {
-      a: {
-        ...baseWaitNode,
-      },
-      b: {
-        ...baseWaitNode,
-        groupID: 'b',
-      },
-    },
+    history: new HistoryParser([baseItem, { ...baseItem, groupID: 'b' }]),
   },
 };

--- a/ui/packages/components/src/utils/historyParser/historyParser.test.ts
+++ b/ui/packages/components/src/utils/historyParser/historyParser.test.ts
@@ -5,9 +5,9 @@ import { expect, test } from 'vitest';
 import { HistoryParser } from './historyParser';
 import type { HistoryNode } from './types';
 
-async function loadHistory(filename: string) {
+async function loadHistory(filename: string): Promise<HistoryParser> {
   const raw = JSON.parse(await fs.readFile(path.join(__dirname, `testData/${filename}`), 'utf8'));
-  return new HistoryParser(raw).getGroups({ sort: true });
+  return new HistoryParser(raw);
 }
 
 const baseRunStartNode = {
@@ -103,7 +103,12 @@ test('cancels', async () => {
     },
   ];
 
-  expect(history).toEqual(expectation);
+  expect(history.getGroups({ sort: true })).toEqual(expectation);
+  expect(history.cancellation).toEqual({
+    eventID: expect.any(String),
+    expression: null,
+    userID: null,
+  });
 });
 
 test('fails without steps', async () => {
@@ -124,7 +129,7 @@ test('fails without steps', async () => {
     },
   ];
 
-  expect(history).toEqual(expectation);
+  expect(history.getGroups({ sort: true })).toEqual(expectation);
 });
 
 test('fails with preceding step', async () => {
@@ -150,7 +155,7 @@ test('fails with preceding step', async () => {
     },
   ];
 
-  expect(history[2]).toEqual(expectation[2]);
+  expect(history.getGroups({ sort: true })[2]).toEqual(expectation[2]);
 });
 
 test('no steps', async () => {
@@ -164,7 +169,7 @@ test('no steps', async () => {
     },
   ];
 
-  expect(history).toEqual(expectation);
+  expect(history.getGroups({ sort: true })).toEqual(expectation);
 });
 
 test('parallel steps', async () => {
@@ -201,7 +206,7 @@ test('parallel steps', async () => {
     },
   ];
 
-  expect(history).toEqual(expectation);
+  expect(history.getGroups({ sort: true })).toEqual(expectation);
 });
 
 test('sleeps', async () => {
@@ -223,7 +228,7 @@ test('sleeps', async () => {
     },
   ];
 
-  expect(history).toEqual(expectation);
+  expect(history.getGroups({ sort: true })).toEqual(expectation);
 });
 
 test('succeeds with 2 steps', async () => {
@@ -247,7 +252,7 @@ test('succeeds with 2 steps', async () => {
     },
   ];
 
-  expect(history.slice(0, 1)).toEqual(expectation.slice(0, 1));
+  expect(history.getGroups({ sort: true }).slice(0, 1)).toEqual(expectation.slice(0, 1));
 });
 
 test('times out waiting for events', async () => {
@@ -274,7 +279,7 @@ test('times out waiting for events', async () => {
     },
   ];
 
-  expect(history).toEqual(expectation);
+  expect(history.getGroups({ sort: true })).toEqual(expectation);
 });
 
 test('waits for event', async () => {
@@ -301,5 +306,5 @@ test('waits for event', async () => {
     },
   ];
 
-  expect(history).toEqual(expectation);
+  expect(history.getGroups({ sort: true })).toEqual(expectation);
 });

--- a/ui/packages/components/src/utils/historyParser/historyParser.ts
+++ b/ui/packages/components/src/utils/historyParser/historyParser.ts
@@ -13,6 +13,7 @@ import { updateNode } from './updateNode';
  * changed in the future, but that increases complexity.
  */
 export class HistoryParser {
+  cancellation?: RawHistoryItem['cancel'];
   private groups: Record<string, HistoryNode> = {};
   runStartedAt?: Date;
 
@@ -43,9 +44,12 @@ export class HistoryParser {
       [node.groupID]: updateNode(node, rawItem),
     };
 
-    // Handle FunctionCancelled here because we need to do something that
-    // updateNode can't: mark all in-progress nodes as cancelled.
+    // Handle FunctionCancelled here because we need to do 2 things that
+    // updateNode can't:
+    // - Set the cancellation object for the whole HistoryParser object.
+    // - Mark all in-progress nodes as cancelled.
     if (rawItem.type === 'FunctionCancelled') {
+      this.cancellation = rawItem.cancel;
       this.cancelNodes(new Date(rawItem.createdAt));
     }
 


### PR DESCRIPTION
## Description

- Create and use `CancellationSummary`
- Fix Storybook for `SleepingSummary` and `WaitingSummary`
- Update `HistoryParser` to store cancellation info

The event ID is not a link but should eventually be

## Testing

![image](https://github.com/inngest/inngest/assets/20100586/7487b1bb-d91e-4671-ac26-de88aeef2412)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
