### PR TITLE
Fix sometimes seeing too many history items when parallel steps are re-reported

### DIFF
--- a/pkg/execution/history/lifecycle.go
+++ b/pkg/execution/history/lifecycle.go
@@ -689,12 +689,19 @@ func applyResponse(
 
 	// If it's a completed generator step then some data is stored in the
 	// output. We'll try to extract it.
-	if op := resp.SingleStep(); op != nil && op.Op != enums.OpcodeStepPlanned {
-		h.StepID = &op.ID
-		h.StepType = getStepType(*op)
-		h.Result.Output = op.Output()
-		stepName := op.UserDefinedName()
-		h.StepName = &stepName
+	if len(resp.Generator) > 0 {
+		if op := resp.SingleStep(); op != nil {
+			h.StepID = &op.ID
+			h.StepType = getStepType(*op)
+			h.Result.Output = op.Output()
+			stepName := op.UserDefinedName()
+			h.StepName = &stepName
+		}
+
+		// If we're a generator, exit now to prevent attempting to parse
+		// generator response as an output; the generator response may be in
+		// relation to many parallel steps, not just the one we're currently
+		// writing history for.
 		return nil
 	}
 

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -403,8 +403,10 @@ func (r *DriverResponse) Final() bool {
 
 // SingleStep returns a single generator op if this response is a generator
 // containing only one op, otherwise nil.
+//
+// Will ignore `StepPlanned` opcodes and return nil if they are the only op.
 func (r *DriverResponse) SingleStep() *GeneratorOpcode {
-	if r.Generator == nil || len(r.Generator) != 1 {
+	if r.Generator == nil || len(r.Generator) != 1 || r.Generator[0].Op == enums.OpcodeStepPlanned {
 		return nil
 	}
 	return r.Generator[0]


### PR DESCRIPTION
## Description

When parallel steps are re-reported, they can sometimes mistakenly be added as history items for that step if we unluckily end up with a single reported `StepPlanned`.

This was a mistake in the refactor of this handling from #843.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
