### PR TITLE
Catch LD errors in attempt to find unhandled promised rejection

### DIFF
--- a/ui/apps/dashboard/src/components/FeatureFlags/ServerFeatureFlag.tsx
+++ b/ui/apps/dashboard/src/components/FeatureFlags/ServerFeatureFlag.tsx
@@ -23,25 +23,34 @@ export async function getBooleanFlag(
   { defaultValue = false }: { defaultValue?: boolean } = {}
 ): Promise<boolean> {
   const user = await currentUser();
-  const client = await getLaunchDarklyClient();
 
-  const accountID =
-    user?.publicMetadata.accountID && typeof user?.publicMetadata.accountID === 'string'
-      ? user?.publicMetadata.accountID
-      : 'Unknown';
+  try {
+    const client = await getLaunchDarklyClient();
 
-  const context = {
-    account: {
-      key: accountID,
-      name: 'Unknown', // TODO: Add account name whenever we have adopted Clerk Organizations
-    },
-    kind: 'multi',
-    user: {
-      anonymous: false,
-      key: user?.externalId ?? 'Unknown',
-      name: `${user?.firstName ?? ''} ${user?.lastName ?? ''}`.trim() || 'Unknown',
-    },
-  } as const;
+    const accountID =
+      user?.publicMetadata.accountID && typeof user?.publicMetadata.accountID === 'string'
+        ? user?.publicMetadata.accountID
+        : 'Unknown';
 
-  return client.variation(flag, context, defaultValue);
+    const context = {
+      account: {
+        key: accountID,
+        name: 'Unknown', // TODO: Add account name whenever we have adopted Clerk Organizations
+      },
+      kind: 'multi',
+      user: {
+        anonymous: false,
+        key: user?.externalId ?? 'Unknown',
+        name: `${user?.firstName ?? ''} ${user?.lastName ?? ''}`.trim() || 'Unknown',
+      },
+    } as const;
+
+    const variation = await client.variation(flag, context, defaultValue);
+    return variation;
+  } catch (err) {
+    console.error('Failed to get LaunchDarkly variation', err);
+    return false;
+  }
+
+  return false;
 }

--- a/ui/apps/dashboard/src/components/FeatureFlags/ServerFeatureFlag.tsx
+++ b/ui/apps/dashboard/src/components/FeatureFlags/ServerFeatureFlag.tsx
@@ -1,5 +1,6 @@
 import type { PropsWithChildren } from 'react';
 import { currentUser } from '@clerk/nextjs';
+import * as Sentry from '@sentry/nextjs';
 
 import { getLaunchDarklyClient } from '@/launchDarkly';
 
@@ -48,9 +49,8 @@ export async function getBooleanFlag(
     const variation = await client.variation(flag, context, defaultValue);
     return variation;
   } catch (err) {
+    Sentry.captureException(err);
     console.error('Failed to get LaunchDarkly variation', err);
     return false;
   }
-
-  return false;
 }


### PR DESCRIPTION
## Description

We're seeing unhandled promise rejection errors in our app a lot and they happen to be coming on various routes and all after the Launch Darkly logs are showing. This may be a coincidence, but we need to try catch potential errors and see if this solves it over the coming days:

![image](https://github.com/inngest/inngest/assets/1509457/9030ce8e-378f-440f-9d2c-3be5c99a5d60)

We did start seeing more errors after #836 was shipped, but it could be something else.
<img width="366" alt="Screen Shot 2023-12-01 at 6 18 08 PM" src="https://github.com/inngest/inngest/assets/1509457/eeb41e8b-773a-4641-b4c3-5d2a41ea5640">


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
