### PR TITLE
Ignore partition GC when scanning

### DIFF
--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -387,9 +387,10 @@ func (q *queue) scan(ctx context.Context) error {
 			return nil
 		}
 		if err := q.processPartition(ctx, p); err != nil {
-			if err == ErrPartitionNotFound {
-				// Another worker grabbed the partition
-				// TODO: Increase counter
+			if err == ErrPartitionNotFound || err == ErrPartitionGarbageCollected {
+				// Another worker grabbed the partition, or the partition was deleted
+				// during the scan by an another worker.
+				// TODO: Increase internal metrics
 				continue
 			}
 			if errors.Unwrap(err) != context.Canceled {


### PR DESCRIPTION
With many workers running, partition GCs are a fact of life and should be ignored.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
