### PR TITLE
fix(dashboard): sentry doesn't send logs when unauthenticated

### DIFF
--- a/ui/apps/dashboard/src/middleware.ts
+++ b/ui/apps/dashboard/src/middleware.ts
@@ -1,7 +1,7 @@
 import { authMiddleware } from '@clerk/nextjs';
 
 export default authMiddleware({
-  publicRoutes: ['/password-reset', '/support'],
+  publicRoutes: ['/password-reset', '/support', '/api/sentry'],
   ignoredRoutes: '/(images|_next/static|_next/image|favicon)(.*)',
 });
 


### PR DESCRIPTION
## Description

When the user is unauthenticated, we weren't sending telemetry to Sentry because the `/api/sentry` route was being protected.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
