### PR TITLE
Fix extra waitForEvent step in timeline UI

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -139,11 +139,11 @@ func DoRequest(ctx context.Context, c *http.Client, r Request) (*state.DriverRes
 		// If this was a generator response with a single op, set some
 		// relevant step data so that it's easier to identify this step in
 		// history.
-		if op := dr.SingleStep(); op != nil {
+		if op := dr.HistoryVisibleStep(); op != nil {
 			dr.Step.ID = op.ID
 			dr.Step.Name = op.UserDefinedName()
 
-			if dr.IsSingleStepError() {
+			if dr.IsHistoryVisibleStepError() {
 				defaultErrMsg := state.DefaultStepErrorMessage
 				userErr := state.UserErrorFromRaw(&defaultErrMsg, op.Error)
 				if mapped, ok := userErr["message"].(string); ok {

--- a/pkg/execution/history/lifecycle.go
+++ b/pkg/execution/history/lifecycle.go
@@ -706,7 +706,7 @@ func applyResponse(
 	// If it's a completed generator step then some data is stored in the
 	// output. We'll try to extract it.
 	if len(resp.Generator) > 0 {
-		if op := resp.SingleStep(); op != nil {
+		if op := resp.HistoryVisibleStep(); op != nil {
 			h.StepID = &op.ID
 			h.StepType = getStepType(*op)
 			h.Result.Output = op.Output()


### PR DESCRIPTION
## Description

Fix extra `waitForEvent` step in timeline UI. This works by only setting the step name for `OpcodeStep`. Since the timeline UI doesn't display nodes for nameless `StepCompleted`, a `StepCompleted` `OpcodeWaitForEvent` will be hidden.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
