### PR TITLE
Fix waitForEvent missing start time in timeline UI

### DIFF
--- a/ui/packages/components/src/utils/historyParser/updateNode.ts
+++ b/ui/packages/components/src/utils/historyParser/updateNode.ts
@@ -157,6 +157,7 @@ const updaters: Record<HistoryType, Updater> = {
     return {
       ...node,
       scope: 'step',
+      startedAt: new Date(rawItem.createdAt),
       status: 'waiting',
       waitForEventConfig,
     } satisfies HistoryNode;


### PR DESCRIPTION
## Description

Before this fix, a `waitForEvent` in parallel steps didn't have a start time in the timeline UI. This is because parallel steps all have the same `StepStarted` which has a different group ID

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
