### PR TITLE
Fix run cancellations emitting failure event

### DIFF
--- a/pkg/cqrs/sqlitecqrs/history_driver.go
+++ b/pkg/cqrs/sqlitecqrs/history_driver.go
@@ -120,6 +120,10 @@ func (d historyDriver) Write(ctx context.Context, h history.History) (err error)
 			CreatedAt: sql.NullTime{Time: h.CreatedAt, Valid: true},
 			// TODO: Completed step count.
 			CompletedStepCount: sql.NullInt64{Int64: 0, Valid: true},
+			Output: sql.NullString{
+				String: "{}",
+				Valid:  true,
+			},
 		}
 		if h.Result != nil {
 			marshalled, _ := marshalJSONAsString(h.Result.Output)

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -671,7 +671,7 @@ func (e *executor) runFinishHandler(ctx context.Context, id state.Identifier, s 
 	now := time.Now()
 
 	// Legacy - send inngest/function.failed
-	if resp.Err != nil {
+	if resp.Err != nil && !strings.Contains(*resp.Err, state.ErrFunctionCancelled.Error()) {
 		events = append(events, event.Event{
 			ID:        ulid.MustNew(uint64(now.UnixMilli()), rand.Reader).String(),
 			Name:      event.FnFailedName,


### PR DESCRIPTION
## Description

Cancelled runs are not failures so they should not emit the run failure event (`inngest/function.failed`)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
