### PR TITLE
chore: re-enable server-side LaunchDarkly

### DIFF
--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -32,6 +32,7 @@
     "@headlessui/tailwindcss": "0.1.2",
     "@heroicons/react": "2.0.16",
     "@inngest/components": "workspace:*",
+    "@launchdarkly/node-server-sdk": "9.0.3",
     "@radix-ui/react-dialog": "1.0.5",
     "@radix-ui/react-popover": "1.0.7",
     "@radix-ui/react-select": "1.2.2",

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/event-search/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/event-search/page.tsx
@@ -1,3 +1,4 @@
+import { ServerFeatureFlag } from '@/components/FeatureFlags/ServerFeatureFlag';
 import { EventSearch } from './EventSearch';
 
 type Props = {
@@ -7,11 +8,9 @@ type Props = {
 };
 
 export default async function Page({ params: { environmentSlug } }: Props) {
-  // TEMPORARILY DISABLED TO TEST IF LAUNCHDARKLY IS CAUSING ISSUES
   return (
-    <></>
-    // <ServerFeatureFlag flag="event-search">
-    //   <EventSearch environmentSlug={environmentSlug} />
-    // </ServerFeatureFlag>
+    <ServerFeatureFlag flag="event-search">
+      <EventSearch environmentSlug={environmentSlug} />
+    </ServerFeatureFlag>
   );
 }

--- a/ui/apps/dashboard/src/components/FeatureFlags/ServerFeatureFlag.tsx
+++ b/ui/apps/dashboard/src/components/FeatureFlags/ServerFeatureFlag.tsx
@@ -1,56 +1,56 @@
-// import type { PropsWithChildren } from 'react';
-// import { currentUser } from '@clerk/nextjs';
-// import * as Sentry from '@sentry/nextjs';
-//
-// import { getLaunchDarklyClient } from '@/launchDarkly';
-//
-// type Props = PropsWithChildren<{
-//   defaultValue?: boolean;
-//   flag: string;
-// }>;
-//
-// // Conditionally renders children based on a feature flag.
-// export async function ServerFeatureFlag({ children, defaultValue = false, flag }: Props) {
-//   const isEnabled = await getBooleanFlag(flag, { defaultValue });
-//   if (isEnabled) {
-//     return <>{children}</>;
-//   }
-//
-//   return null;
-// }
-//
-// export async function getBooleanFlag(
-//   flag: string,
-//   { defaultValue = false }: { defaultValue?: boolean } = {}
-// ): Promise<boolean> {
-//   const user = await currentUser();
-//
-//   try {
-//     const client = await getLaunchDarklyClient();
-//
-//     const accountID =
-//       user?.publicMetadata.accountID && typeof user?.publicMetadata.accountID === 'string'
-//         ? user?.publicMetadata.accountID
-//         : 'Unknown';
-//
-//     const context = {
-//       account: {
-//         key: accountID,
-//         name: 'Unknown', // TODO: Add account name whenever we have adopted Clerk Organizations
-//       },
-//       kind: 'multi',
-//       user: {
-//         anonymous: false,
-//         key: user?.externalId ?? 'Unknown',
-//         name: `${user?.firstName ?? ''} ${user?.lastName ?? ''}`.trim() || 'Unknown',
-//       },
-//     } as const;
-//
-//     const variation = await client.variation(flag, context, defaultValue);
-//     return variation;
-//   } catch (err) {
-//     Sentry.captureException(err);
-//     console.error('Failed to get LaunchDarkly variation', err);
-//     return false;
-//   }
-// }
+import type { PropsWithChildren } from 'react';
+import { currentUser } from '@clerk/nextjs';
+import * as Sentry from '@sentry/nextjs';
+
+import { getLaunchDarklyClient } from '@/launchDarkly';
+
+type Props = PropsWithChildren<{
+  defaultValue?: boolean;
+  flag: string;
+}>;
+
+// Conditionally renders children based on a feature flag.
+export async function ServerFeatureFlag({ children, defaultValue = false, flag }: Props) {
+  const isEnabled = await getBooleanFlag(flag, { defaultValue });
+  if (isEnabled) {
+    return <>{children}</>;
+  }
+
+  return null;
+}
+
+export async function getBooleanFlag(
+  flag: string,
+  { defaultValue = false }: { defaultValue?: boolean } = {}
+): Promise<boolean> {
+  const user = await currentUser();
+
+  try {
+    const client = await getLaunchDarklyClient();
+
+    const accountID =
+      user?.publicMetadata.accountID && typeof user?.publicMetadata.accountID === 'string'
+        ? user?.publicMetadata.accountID
+        : 'Unknown';
+
+    const context = {
+      account: {
+        key: accountID,
+        name: 'Unknown', // TODO: Add account name whenever we have adopted Clerk Organizations
+      },
+      kind: 'multi',
+      user: {
+        anonymous: false,
+        key: user?.externalId ?? 'Unknown',
+        name: `${user?.firstName ?? ''} ${user?.lastName ?? ''}`.trim() || 'Unknown',
+      },
+    } as const;
+
+    const variation = await client.variation(flag, context, defaultValue);
+    return variation;
+  } catch (err) {
+    Sentry.captureException(err);
+    console.error('Failed to get LaunchDarkly variation', err);
+    return false;
+  }
+}

--- a/ui/apps/dashboard/src/components/Navigation/AppNavigation.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/AppNavigation.tsx
@@ -7,6 +7,7 @@ import {
   WrenchIcon,
 } from '@heroicons/react/20/solid';
 
+import { getBooleanFlag } from '@/components/FeatureFlags/ServerFeatureFlag';
 import InngestLogo from '@/icons/InngestLogo';
 import EventIcon from '@/icons/event.svg';
 import AccountDropdown from './AccountDropdown';
@@ -29,9 +30,7 @@ const ALL_ENVIRONMENTS_SLUG = 'all';
 const BRANCH_PARENT_SLUG = 'branch';
 
 export default async function AppNavigation({ environmentSlug }: AppNavigationProps) {
-  // TEMPORARILY DISABLED TO TEST IF LAUNCHDARKLY IS CAUSING ISSUES
-  // const isEventSearchEnabled = await getBooleanFlag('event-search');
-  const isEventSearchEnabled = false;
+  const isEventSearchEnabled = await getBooleanFlag('event-search');
 
   let items: NavItem[] = [
     {

--- a/ui/apps/dashboard/src/launchDarkly.ts
+++ b/ui/apps/dashboard/src/launchDarkly.ts
@@ -1,20 +1,18 @@
-// This probably won't work for edge functions! When we start using feature
-// flags in edge functions, we'll probably need to use
-// @launchdarkly/vercel-server-sdk.
-// import { init, type LDClient } from 'launchdarkly-node-server-sdk';
-//
-// let client: LDClient | undefined = undefined;
-//
-// export async function getLaunchDarklyClient(): Promise<LDClient> {
-//   if (!client) {
-//     const { LAUNCH_DARKLY_SDK_KEY } = process.env;
-//     if (!LAUNCH_DARKLY_SDK_KEY) {
-//       throw new Error('missing LAUNCH_DARKLY_SDK_KEY env var');
-//     }
-//
-//     client = init(LAUNCH_DARKLY_SDK_KEY);
-//     await client.waitForInitialization();
-//   }
-//
-//   return client;
-// }
+import { init, type LDClient } from '@launchdarkly/node-server-sdk';
+
+let launchDarklyClient: LDClient;
+
+async function initialize() {
+  const launchDarklySDKKey = process.env.LAUNCH_DARKLY_SDK_KEY;
+  if (!launchDarklySDKKey) {
+    throw new Error('LAUNCH_DARKLY_SDK_KEY environment variable is not set.');
+  }
+  const client = init(launchDarklySDKKey);
+  await client.waitForInitialization();
+  return client;
+}
+
+export async function getLaunchDarklyClient(): Promise<LDClient> {
+  if (launchDarklyClient) return launchDarklyClient;
+  return (launchDarklyClient = await initialize());
+}

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@inngest/components':
         specifier: workspace:*
         version: link:../../packages/components
+      '@launchdarkly/node-server-sdk':
+        specifier: 9.0.3
+        version: 9.0.3
       '@radix-ui/react-dialog':
         specifier: 1.0.5
         version: 1.0.5(@types/react-dom@18.2.4)(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0)
@@ -5699,6 +5702,27 @@ packages:
   /@juggle/resize-observer@3.4.0:
     resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
     dev: true
+
+  /@launchdarkly/js-sdk-common@2.1.0:
+    resolution: {integrity: sha512-163KRinNJgoh9ybup2BHr9jHzTsnNlb2AknLgV2edCe0cZoiiCOLTzo4KDJFY7B7EImMMyRmTefXvb6d64eF8Q==}
+    dev: false
+
+  /@launchdarkly/js-server-sdk-common@2.1.0:
+    resolution: {integrity: sha512-76oI2ISVh9kwRXerYRg1ou7p4QhJn+NslXZKvT1AmCNaF4Ni8FZhZLBXzg5Onh1tm41DqfYjB4W54xK6kSPzPQ==}
+    dependencies:
+      '@launchdarkly/js-sdk-common': 2.1.0
+      semver: 7.5.4
+    dev: false
+
+  /@launchdarkly/node-server-sdk@9.0.3:
+    resolution: {integrity: sha512-sxXMitMOgXc53y9yGQoDpTJ9xIAoVWUtXoNf2qYLGj6grNhLwFrwhRCpoFu3+t1dI6jVzP26mrVKtT6RsrgFTg==}
+    dependencies:
+      '@launchdarkly/js-server-sdk-common': 2.1.0
+      https-proxy-agent: 5.0.1
+      launchdarkly-eventsource: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /@mapbox/node-pre-gyp@1.0.11:
     resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
@@ -15116,6 +15140,11 @@ packages:
       language-subtag-registry: 0.3.22
     dev: true
 
+  /launchdarkly-eventsource@2.0.1:
+    resolution: {integrity: sha512-zyceGtRni8ct4es5hH8Q+2evvttItb5lOKMm8JtudZbfQFfVdH55NitgJQoGTRYkIvyMGjcaXnyt0FlzCTfspA==}
+    engines: {node: '>=0.12.0'}
+    dev: false
+
   /launchdarkly-js-client-sdk@3.1.3:
     resolution: {integrity: sha512-/JR/ri8z3bEj9RFTTKDjd+con4F1MsWUea1MmBDtFj4gDA0l9NDm1KzhMKiIeoBdmB2rSaeFYe4CaYOEp8IryA==}
     dependencies:
@@ -15423,7 +15452,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
-    dev: true
 
   /lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -18031,7 +18059,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
@@ -20111,7 +20138,6 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
 
   /yaml-ast-parser@0.0.43:
     resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}


### PR DESCRIPTION
## Description

This re-enables server-side LaunchDarkly.

LaunchDarkly was causing errors. The errors might have been fixed with the latest version which includes a fix to https://github.com/launchdarkly/js-core/issues/312

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
