### PR TITLE
Fix duplicate pause creation

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1308,7 +1308,11 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, gen state.
 
 	logger.From(ctx).Info().Interface("opts", opts).Time("expires", expires).Str("event", eventName).Str("expr", strExpr).Msg("parsed invoke function opts")
 
-	pauseID := uuid.New()
+	pauseID := uuid.NewSHA1(
+		uuid.NameSpaceOID,
+		[]byte(item.Identifier.RunID.String()+gen.ID),
+	)
+
 	opcode := gen.Op.String()
 	err = e.sm.SavePause(ctx, state.Pause{
 		ID:          pauseID,
@@ -1398,7 +1402,11 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, gen state.Ge
 		data = expr.FilteredAttributes(ctx, ed).Map()
 	}
 
-	pauseID := uuid.New()
+	pauseID := uuid.NewSHA1(
+		uuid.NameSpaceOID,
+		[]byte(item.Identifier.RunID.String()+gen.ID),
+	)
+
 	opcode := gen.Op.String()
 	err = e.sm.SavePause(ctx, state.Pause{
 		ID:             pauseID,


### PR DESCRIPTION
## Description

Fix duplicate pause creation by having a deterministic pause ID. This bug can happen when using parallel steps

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
