### PR TITLE
Display warning when deployment protection is enabled

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/settings/integrations/vercel/VercelIntegration.ts
+++ b/ui/apps/dashboard/src/app/(dashboard)/settings/integrations/vercel/VercelIntegration.ts
@@ -1,11 +1,32 @@
-type VercelProject = {
+export enum VercelDeploymentProtection {
+  Disabled = '',
+  ProdDeploymentURLsAndAllPreviews = 'prod_deployment_urls_and_all_previews',
+  Previews = 'preview',
+}
+
+export type VercelProject = {
   id: string;
   name: string;
   servePath?: string;
   isEnabled: boolean;
+  ssoProtection?: {
+    deploymentType: VercelDeploymentProtection;
+  };
 };
 
-type VercelIntegration = {
+export type VercelProjectViaAPI = {
+  id: string;
+  name: string;
+  ssoProtection?: {
+    deploymentType: VercelDeploymentProtection;
+  };
+};
+
+export type VercelProjectAPIResponse = {
+  projects: VercelProjectViaAPI[];
+};
+
+export type VercelIntegration = {
   id: string;
   name: string;
   slug: string;

--- a/ui/apps/dashboard/src/app/(dashboard)/settings/integrations/vercel/VercelIntegrationForm.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/settings/integrations/vercel/VercelIntegrationForm.tsx
@@ -4,11 +4,15 @@ import { useState } from 'react';
 import type { Route } from 'next';
 import { useRouter } from 'next/navigation';
 import { Switch } from '@headlessui/react';
-import { ArrowPathIcon } from '@heroicons/react/20/solid';
+import { ArrowPathIcon, ExclamationCircleIcon } from '@heroicons/react/20/solid';
 import { Button } from '@inngest/components/Button';
 import { toast } from 'sonner';
 
-import type VercelIntegration from '@/app/(dashboard)/settings/integrations/vercel/VercelIntegration';
+import {
+  VercelDeploymentProtection,
+  type VercelIntegration,
+} from '@/app/(dashboard)/settings/integrations/vercel/VercelIntegration';
+import AppLink from '@/components/AppLink';
 import Input from '@/components/Forms/Input';
 import VercelLogomark from '@/logos/vercel-logomark.svg';
 import VercelWordmark from '@/logos/vercel-wordmark.svg';
@@ -98,6 +102,20 @@ export default function VercelIntegrationForm({ vercelIntegration }: VercelInteg
                 projectName={project.name}
               />
               <ProjectServePathInput projectID={project.id} servePath={project.servePath} />
+              {(project.ssoProtection?.deploymentType ===
+                VercelDeploymentProtection.ProdDeploymentURLsAndAllPreviews ||
+                project.ssoProtection?.deploymentType === VercelDeploymentProtection.Previews) && (
+                <div className="flex items-center gap-2 text-sm">
+                  <ExclamationCircleIcon className="h-4 text-amber-500" /> Deployment protection
+                  enabled -{' '}
+                  <AppLink
+                    href="https://www.inngest.com/docs/deploy/vercel#bypassing-deployment-protection"
+                    target="_blank"
+                  >
+                    Learn more
+                  </AppLink>
+                </div>
+              )}
             </li>
           ))}
         </ul>

--- a/ui/apps/dashboard/src/app/(dashboard)/settings/integrations/vercel/enrichVercelProjects.ts
+++ b/ui/apps/dashboard/src/app/(dashboard)/settings/integrations/vercel/enrichVercelProjects.ts
@@ -1,7 +1,7 @@
 import { graphql } from '@/gql';
 import graphqlAPI from '@/queries/graphqlAPI';
 import { getEnvironment } from '@/queries/server-only/getEnvironment';
-import type VercelIntegration from './VercelIntegration';
+import { type VercelProject, type VercelProjectViaAPI } from './VercelIntegration';
 
 const GetSavedVercelProjectsDocument = graphql(`
   query GetSavedVercelProjects($environmentID: ID!) {
@@ -21,8 +21,8 @@ const GetSavedVercelProjectsDocument = graphql(`
  * @returns The enriched Vercel projects.
  */
 export default async function enrichVercelProjects(
-  vercelProjects: { id: string; name: string }[]
-): Promise<VercelIntegration['projects']> {
+  vercelProjects: VercelProjectViaAPI[]
+): Promise<VercelProject[]> {
   const environment = await getEnvironment({
     environmentSlug: 'production',
   });
@@ -31,7 +31,7 @@ export default async function enrichVercelProjects(
   });
   const savedVercelProjects = getSavedVercelProjectsResponse.environment.savedVercelProjects;
 
-  const projects = vercelProjects.map((project) => {
+  const projects: VercelProject[] = vercelProjects.map((project) => {
     const savedProject = savedVercelProjects.find(
       (savedProject) => savedProject.projectID === project.id
     );
@@ -41,6 +41,7 @@ export default async function enrichVercelProjects(
       name: project.name,
       servePath: savedProject?.path ?? undefined,
       isEnabled: isProjectEnabled,
+      ssoProtection: project.ssoProtection,
     };
   });
 

--- a/ui/apps/dashboard/src/app/(dashboard)/settings/integrations/vercel/getVercelIntegration.ts
+++ b/ui/apps/dashboard/src/app/(dashboard)/settings/integrations/vercel/getVercelIntegration.ts
@@ -1,11 +1,7 @@
 import restAPI, { HTTPError } from '@/queries/restAPI';
 import { getEnvironment } from '@/queries/server-only/getEnvironment';
-import type VercelIntegration from './VercelIntegration';
+import { type VercelIntegration, type VercelProjectAPIResponse } from './VercelIntegration';
 import enrichVercelProjects from './enrichVercelProjects';
-
-type VercelProjectsAPIResponse = {
-  projects: { id: string; name: string }[];
-};
 
 export default async function getVercelIntegration(): Promise<VercelIntegration> {
   const environment = await getEnvironment({
@@ -15,7 +11,7 @@ export default async function getVercelIntegration(): Promise<VercelIntegration>
   const url = new URL('/v1/integrations/vercel/projects', process.env.NEXT_PUBLIC_API_URL);
   url.searchParams.set('workspaceID', environment.id);
 
-  let response: VercelProjectsAPIResponse;
+  let response: VercelProjectAPIResponse;
   try {
     response = await restAPI(url).json<{
       projects: { id: string; name: string }[];


### PR DESCRIPTION
## Description

Display warning copy with a link to learn more when deployment protection is enabled for a given Vercel project. This should be released in tandem with a docs improvement as well as the backend API changes <PR inbound>.

This change is a response to the change that Vercel enabled "Standard Protection" for each new project from a few weeks ago onward.

Docs update: https://github.com/inngest/website/pull/595

<img width="908" alt="Screen Shot 2023-12-04 at 3 11 41 PM" src="https://github.com/inngest/inngest/assets/1509457/59de0f79-45ea-4759-a8bf-693ed909997e">


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
