### PR TITLE
Fix 'no functions found' instead of error

### DIFF
--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -222,24 +222,7 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 
 				// Make a new PUT request to each app, indicating that the
 				// SDK should push functions to the dev server.
-				res := deploy.Ping(ctx, app.Url)
-				if res.Err != nil {
-					_, _ = d.data.UpdateAppError(ctx, cqrs.UpdateAppErrorParams{
-						ID: app.ID,
-						Error: sql.NullString{
-							String: res.Err.Error(),
-							Valid:  true,
-						},
-					})
-				} else {
-					_, _ = d.data.UpdateAppError(ctx, cqrs.UpdateAppErrorParams{
-						ID: app.ID,
-						Error: sql.NullString{
-							String: "",
-							Valid:  false,
-						},
-					})
-				}
+				_ = deploy.Ping(ctx, app.Url)
 			}
 		}
 

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -222,7 +222,16 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 
 				// Make a new PUT request to each app, indicating that the
 				// SDK should push functions to the dev server.
-				_ = deploy.Ping(ctx, app.Url)
+				res := deploy.Ping(ctx, app.Url)
+				if res.Err != nil {
+					_, _ = d.data.UpdateAppError(ctx, cqrs.UpdateAppErrorParams{
+						ID: app.ID,
+						Error: sql.NullString{
+							String: res.Err.Error(),
+							Valid:  true,
+						},
+					})
+				}
 			}
 		}
 


### PR DESCRIPTION
## Description

Fix app card showing "no functions found" instead of an error. This was happening because the `/fn/register` endpoint was returning `200` when the config checksum was the same, making the SDK think the registration was successful.

The solution involved no longer updating that app based on the ping response. This is unnecessary because the app is already being updated in the `/fn/register` handler.

## Testing

The following video shows:
1. Invalid cron putting app in the error state
2. Fixing the invalid config puts the app in the OK state
3. Bringing the invalid cron back puts the app in the error state

https://github.com/inngest/inngest/assets/20100586/b049c29e-13a9-4fa1-97f1-482f2a2199f6

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
