### PR TITLE
Add informational return value to HandePause

### DIFF
--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -97,7 +97,7 @@ type Executor interface {
 
 	// HandlePauses handles pauses loaded from an incoming event.  This delegates to Cancel and
 	// Resume where necessary, depending on pauses that have been loaded and matched.
-	HandlePauses(ctx context.Context, iter state.PauseIterator, event event.TrackedEvent) error
+	HandlePauses(ctx context.Context, iter state.PauseIterator, event event.TrackedEvent) (HandlePauseResult, error)
 	// Cancel cancels an in-progress function run, preventing any enqueued or future steps from running.
 	Cancel(ctx context.Context, runID ulid.ULID, r CancelRequest) error
 	// Resume resumes an in-progress function run from the given waitForEvent pause.
@@ -180,4 +180,18 @@ type ResumeRequest struct {
 	// functions directly.
 	RunID    *ulid.ULID
 	StepName string
+}
+
+// HandlePauseResult returns status information about pause handling.
+type HandlePauseResult [2]int32
+
+// Processed returns the number of pauses processed.
+func (h HandlePauseResult) Processed() int32 {
+	return h[0]
+}
+
+// Processed returns the number of pauses handled, eg. pauses that matched
+// and successfully impacted runs (either by cancellation or continuing).
+func (h HandlePauseResult) Handled() int32 {
+	return h[1]
 }

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -484,7 +484,8 @@ func (s *svc) pauses(ctx context.Context, evt event.TrackedEvent) error {
 	if err != nil {
 		return fmt.Errorf("error finding event pauses: %w", err)
 	}
-	return s.executor.HandlePauses(ctx, iter, evt)
+	_, err = s.executor.HandlePauses(ctx, iter, evt)
+	return err
 }
 
 func (s *svc) initialize(ctx context.Context, fn inngest.Function, evt event.TrackedEvent) error {


### PR DESCRIPTION
This changes HandlePauses to return metrics around the pause functionality, including:

- Number of pauses processed
- Number of pauses resumed/cancelled


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
