### PR TITLE
Refactor pause iterations

### DIFF
--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -67,14 +67,24 @@ type PauseGetter interface {
 // PauseIterator allows the runner to iterate over all pauses returned by a PauseGetter.  This
 // ensures that, at scale, all pauses do not need to be loaded into memory.
 type PauseIterator interface {
-	// Next advances the iterator and returns whether the next call to Val will
-	// return a non-nil pause.
+	// Count returns the count of the pause iteration at the time of querying.
+	//
+	// Due to concurrent processing, the total number of iterated fields may not match
+	// this count;  the count is a snapshot in time.
+	Count() int
+
+	// Next advances the iterator, returning an erorr or context.Canceled if the iteration
+	// is complete.
 	//
 	// Next should be called prior to any call to the iterator's Val method, after
 	// the iterator has been created.
 	//
 	// The order of the iterator is unspecified.
 	Next(ctx context.Context) bool
+
+	// Error returns the error returned during iteration, if any.  Use this to check
+	// for errors during iteration when Next() returns false.
+	Error() error
 
 	// Val returns the current Pause from the iterator.
 	Val(context.Context) *Pause

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -961,6 +961,7 @@ func (i *scanIter) init(ctx context.Context, key string, chunk int64) error {
 	}
 	i.cursor = int(scan.Cursor)
 	i.vals = scan
+	i.i = -1
 	i.l = sync.Mutex{}
 	return nil
 }

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -1173,7 +1173,7 @@ func checkPausesByEvent_multi(t *testing.T, m state.Manager) {
 	n := 0
 	for iter.Next(ctx) {
 		result := iter.Val(ctx)
-		require.NotNil(t, result, "Nil pause returned from iterator")
+		require.NotNil(t, result, "Nil pause returned from iterator: %T: %s", iter, iter.Error())
 
 		found := false
 		for _, existing := range pauses {
@@ -1238,6 +1238,7 @@ func checkPausesByEvent_concurrent(t *testing.T, m state.Manager) {
 	a := 0
 	for a <= (len(pauses)/2) && iterA.Next(ctx) {
 		result := iterA.Val(ctx)
+		require.NotNil(t, result, "Nil pause returned from iterator")
 		found := false
 		for _, existing := range pauses {
 			if existing.ID == result.ID {


### PR DESCRIPTION
- Instead of chunking keys in the buffer iterator, fetch them all
- Use an improved scan iterator with a new error interface

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
