### PR TITLE
feat(dashboard): add links to replay docs

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@inngest/components/Button';
 import { FunctionRunStatusIcon } from '@inngest/components/FunctionRunStatusIcon';
+import { Link } from '@inngest/components/Link';
 import { Modal } from '@inngest/components/Modal';
 import { IconReplay } from '@inngest/components/icons/Replay';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
@@ -286,15 +287,18 @@ export default function NewReplayModal({
             </p>
           </div>
         </div>
-        <div className="flex justify-end gap-2 border-t border-slate-100 px-5 py-4">
-          <Button type="button" appearance="outlined" label="Cancel" btnAction={onClose} />
-          <Button
-            label="Replay Function"
-            kind="primary"
-            type="submit"
-            icon={<IconReplay className="h-5 w-5 text-white" />}
-            disabled={isCreatingFunctionReplay}
-          />
+        <div className="flex justify-between border-t border-slate-100 px-5 py-4">
+          <Link href="https://inngest.com/docs/platform/replay">Learn about Replay</Link>
+          <div className="flex gap-2">
+            <Button type="button" appearance="outlined" label="Cancel" btnAction={onClose} />
+            <Button
+              label="Replay Function"
+              kind="primary"
+              type="submit"
+              icon={<IconReplay className="h-5 w-5 text-white" />}
+              disabled={isCreatingFunctionReplay}
+            />
+          </div>
         </div>
       </form>
     </Modal>

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/replay/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/replay/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef } from 'react';
 import { ExclamationCircleIcon } from '@heroicons/react/20/solid';
+import { Link } from '@inngest/components/Link';
 import { ReplayStatusIcon } from '@inngest/components/ReplayStatusIcon';
 import { Table } from '@inngest/components/Table';
 import type { Replay } from '@inngest/components/types/replay';
@@ -173,7 +174,14 @@ export default function FunctionReplayPage({ params }: FunctionReplayPageProps) 
             getCoreRowModel: getCoreRowModel(),
             enableSorting: false,
           }}
-          blankState={<p>You have no replays for this function.</p>}
+          blankState={
+            <p>
+              You have no replays for this function.{' '}
+              <Link className="inline-flex" href="https://inngest.com/docs/platform/replay">
+                Learn about Replay
+              </Link>
+            </p>
+          }
         />
       </div>
     </>


### PR DESCRIPTION
## Description

This adds "Learn about Replay" links to the replay docs:

![image](https://github.com/inngest/inngest/assets/4291707/a90c5f16-a326-4b1f-b9c6-c4ad18af9e79)

![image](https://github.com/inngest/inngest/assets/4291707/3a5bb651-19ea-4e31-98b2-680792eb172d)


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
