### PR TITLE
fix(dashboard): webhooks don't save

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/TransformEvent.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/TransformEvent.tsx
@@ -3,6 +3,7 @@
 import { useContext, useEffect, useState } from 'react';
 import type { Route } from 'next';
 import { usePathname, useRouter } from 'next/navigation';
+import { useClerk } from '@clerk/nextjs';
 import { Button } from '@inngest/components/Button';
 import { CodeBlock } from '@inngest/components/CodeBlock';
 import { toast } from 'sonner';
@@ -83,6 +84,7 @@ export default function TransformEvents({ keyID, metadata, keyName }: FilterEven
   const [output, setOutput] = useState(defaultOutput);
   const { save } = useContext(Context);
   const router = useRouter();
+  const clerk = useClerk();
   const pathname = usePathname();
   const page = getManageKey(pathname);
 
@@ -170,17 +172,21 @@ export default function TransformEvents({ keyID, metadata, keyName }: FilterEven
         />
       </div>
       <div className="mb-6">
-        <CodeBlock
-          tabs={[
-            {
-              label: 'Payload',
-              content: rawTransform ?? defaultTransform,
-              readOnly: false,
-              language: 'javascript',
-              handleChange: handleTransformCodeChange,
-            },
-          ]}
-        />
+        {/* This is needed because Monaco editor collides with Clerk which causes bugs.
+          See https://github.com/clerk/javascript/issues/1643 */}
+        {clerk.loaded && (
+          <CodeBlock
+            tabs={[
+              {
+                label: 'Payload',
+                content: rawTransform ?? defaultTransform,
+                readOnly: false,
+                language: 'javascript',
+                handleChange: handleTransformCodeChange,
+              },
+            ]}
+          />
+        )}
       </div>
       <div className="mb-5 flex gap-5">
         <div className="w-6/12">
@@ -188,30 +194,38 @@ export default function TransformEvents({ keyID, metadata, keyName }: FilterEven
           <p className="mb-6 text-sm text-slate-700">
             Paste the incoming JSON payload here to test your transform.
           </p>
-          <CodeBlock
-            tabs={[
-              {
-                label: 'Payload',
-                content: incoming,
-                readOnly: false,
-                language: 'json',
-                handleChange: handleIncomingCodeChange,
-              },
-            ]}
-          />
+          {/* This is needed because Monaco editor collides with Clerk which causes bugs.
+          See https://github.com/clerk/javascript/issues/1643 */}
+          {clerk.loaded && (
+            <CodeBlock
+              tabs={[
+                {
+                  label: 'Payload',
+                  content: incoming,
+                  readOnly: false,
+                  language: 'json',
+                  handleChange: handleIncomingCodeChange,
+                },
+              ]}
+            />
+          )}
         </div>
         <div className="w-6/12">
           <h2 className="pb-1 text-lg font-semibold">Transformed Event</h2>
           <p className="mb-6 text-sm text-slate-700">Preview the transformed JSON payload here.</p>
-          <CodeBlock
-            tabs={[
-              {
-                label: 'Payload',
-                content: output,
-                language: 'json',
-              },
-            ]}
-          />
+          {/* This is needed because Monaco editor collides with Clerk which causes bugs.
+          See https://github.com/clerk/javascript/issues/1643 */}
+          {clerk.loaded && (
+            <CodeBlock
+              tabs={[
+                {
+                  label: 'Payload',
+                  content: output,
+                  language: 'json',
+                },
+              ]}
+            />
+          )}
         </div>
       </div>
       <div className="mb-8 flex justify-end">

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/TransformEvent.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/TransformEvent.tsx
@@ -3,11 +3,10 @@
 import { useContext, useEffect, useState } from 'react';
 import type { Route } from 'next';
 import { usePathname, useRouter } from 'next/navigation';
-import { useClerk } from '@clerk/nextjs';
 import { Button } from '@inngest/components/Button';
-import { CodeBlock } from '@inngest/components/CodeBlock';
 import { toast } from 'sonner';
 
+import DashboardCodeBlock from '@/components/DashboardCodeBlock/DashboardCodeBlock';
 import { getManageKey } from '@/utils/urls';
 import makeVM from '@/utils/vm';
 import { Context } from './Context';
@@ -84,7 +83,6 @@ export default function TransformEvents({ keyID, metadata, keyName }: FilterEven
   const [output, setOutput] = useState(defaultOutput);
   const { save } = useContext(Context);
   const router = useRouter();
-  const clerk = useClerk();
   const pathname = usePathname();
   const page = getManageKey(pathname);
 
@@ -172,21 +170,17 @@ export default function TransformEvents({ keyID, metadata, keyName }: FilterEven
         />
       </div>
       <div className="mb-6">
-        {/* This is needed because Monaco editor collides with Clerk which causes bugs.
-          See https://github.com/clerk/javascript/issues/1643 */}
-        {clerk.loaded && (
-          <CodeBlock
-            tabs={[
-              {
-                label: 'Payload',
-                content: rawTransform ?? defaultTransform,
-                readOnly: false,
-                language: 'javascript',
-                handleChange: handleTransformCodeChange,
-              },
-            ]}
-          />
-        )}
+        <DashboardCodeBlock
+          tabs={[
+            {
+              label: 'Payload',
+              content: rawTransform ?? defaultTransform,
+              readOnly: false,
+              language: 'javascript',
+              handleChange: handleTransformCodeChange,
+            },
+          ]}
+        />
       </div>
       <div className="mb-5 flex gap-5">
         <div className="w-6/12">
@@ -194,38 +188,30 @@ export default function TransformEvents({ keyID, metadata, keyName }: FilterEven
           <p className="mb-6 text-sm text-slate-700">
             Paste the incoming JSON payload here to test your transform.
           </p>
-          {/* This is needed because Monaco editor collides with Clerk which causes bugs.
-          See https://github.com/clerk/javascript/issues/1643 */}
-          {clerk.loaded && (
-            <CodeBlock
-              tabs={[
-                {
-                  label: 'Payload',
-                  content: incoming,
-                  readOnly: false,
-                  language: 'json',
-                  handleChange: handleIncomingCodeChange,
-                },
-              ]}
-            />
-          )}
+          <DashboardCodeBlock
+            tabs={[
+              {
+                label: 'Payload',
+                content: incoming,
+                readOnly: false,
+                language: 'json',
+                handleChange: handleIncomingCodeChange,
+              },
+            ]}
+          />
         </div>
         <div className="w-6/12">
           <h2 className="pb-1 text-lg font-semibold">Transformed Event</h2>
           <p className="mb-6 text-sm text-slate-700">Preview the transformed JSON payload here.</p>
-          {/* This is needed because Monaco editor collides with Clerk which causes bugs.
-          See https://github.com/clerk/javascript/issues/1643 */}
-          {clerk.loaded && (
-            <CodeBlock
-              tabs={[
-                {
-                  label: 'Payload',
-                  content: output,
-                  language: 'json',
-                },
-              ]}
-            />
-          )}
+          <DashboardCodeBlock
+            tabs={[
+              {
+                label: 'Payload',
+                content: output,
+                language: 'json',
+              },
+            ]}
+          />
         </div>
       </div>
       <div className="mb-8 flex justify-end">

--- a/ui/apps/dashboard/src/components/DashboardCodeBlock/DashboardCodeBlock.tsx
+++ b/ui/apps/dashboard/src/components/DashboardCodeBlock/DashboardCodeBlock.tsx
@@ -1,0 +1,18 @@
+import type { ComponentProps } from 'react';
+import { useClerk } from '@clerk/nextjs';
+import { CodeBlock } from '@inngest/components/CodeBlock';
+
+/**
+ * This component is a wrapper around the CodeBlock component from @inngest/components. It is a
+ * workaround for a bug between Monaco and Clerk.
+ *
+ * @see {@link https://github.com/clerk/javascript/issues/1643} related Clerk issue
+ * @see {@link https://clerk.com/docs/troubleshooting/script-loading} related Clerk documentation
+ */
+export default function DashboardCodeBlock(props: ComponentProps<typeof CodeBlock>) {
+  const clerk = useClerk();
+
+  if (!clerk.loaded) return;
+
+  return <CodeBlock {...props} />;
+}


### PR DESCRIPTION
## Description

This fixes an issue with the webhook page. Currently, we're not able to save webhook changes on the Dashboard due to a conflict between Monaco and Clerk. See https://github.com/clerk/javascript/issues/1643 for context.

Fix source: https://clerk.com/docs/troubleshooting/script-loading#script-loading

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
