### PR TITLE
Use Time component in Runs table

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/FunctionRunList.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/FunctionRunList.tsx
@@ -9,6 +9,7 @@ import { Table } from '@inngest/components/Table';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
 import { useQuery } from 'urql';
 
+import { Time } from '@/components/Time';
 import { graphql } from '@/gql';
 import { FunctionRunStatus, FunctionRunTimeField, type RunListItem } from '@/gql/graphql';
 import { useEnvironment } from '@/queries';
@@ -97,13 +98,16 @@ function createColumns({
     }),
     columnHelper.accessor('startedAt', {
       header: () => <span>Scheduled At</span>,
-      cell: (props) => <time>{props.getValue()}</time>,
+      cell: (props) => <Time value={new Date(props.getValue())} />,
       size: 300,
       minSize: 300,
     }),
     columnHelper.accessor('endedAt', {
       header: () => <span>Ended At</span>,
-      cell: (props) => <time>{props.getValue()}</time>,
+      cell: (props) => {
+        const endedAt = props.getValue();
+        return <>{endedAt ? <Time value={new Date(endedAt)} /> : <p>-</p>}</>;
+      },
       size: 300,
       minSize: 300,
     }),


### PR DESCRIPTION
## Description
Use the Time component in both run timestamps to handle time localization
![Screenshot 2023-12-12 at 21 10 32](https://github.com/inngest/inngest/assets/16758464/d7c91b37-ce59-46f8-a4d8-a01e25975a7a)


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
