### PR TITLE
INN 2416 Open modal to create keys and webhooks

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/Keys.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/Keys.tsx
@@ -33,9 +33,10 @@ const LoadingSkeleton = () => (
 );
 
 export default function Keys({ environmentSlug }: KeysProps) {
-  const [{ data: environment, fetching: fetchingEnvironment }] = useEnvironment({
-    environmentSlug,
-  });
+  const [{ data: environment, fetching: fetchingEnvironment, error: environmentError }] =
+    useEnvironment({
+      environmentSlug,
+    });
 
   const { data, isLoading, error } = useGraphQLQuery({
     query: GetKeysDocument,
@@ -68,12 +69,14 @@ export default function Keys({ environmentSlug }: KeysProps) {
     notFound();
   }
 
-  if (error) {
+  if (environmentError || error) {
     return (
       <div className="flex h-full w-full flex-col items-center justify-center gap-5">
         <div className="inline-flex items-center gap-2 text-red-600">
           <ExclamationCircleIcon className="h-4 w-4" />
-          <h2 className="text-sm">Could not load list</h2>
+          <h2 className="text-sm">{`Could not load ${
+            environmentError ? 'environment' : 'list'
+          }`}</h2>
         </div>
       </div>
     );

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/Keys.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/Keys.tsx
@@ -1,8 +1,11 @@
+'use client';
+
 import { notFound } from 'next/navigation';
+import { Skeleton } from '@inngest/components/Skeleton';
+import { useQuery } from 'urql';
 
 import { graphql } from '@/gql';
-import graphqlAPI from '@/queries/graphqlAPI';
-import { getEnvironment } from '@/queries/server-only/getEnvironment';
+import { useEnvironment } from '@/queries';
 import KeysListItem from './KeysListItem';
 
 const GetKeysDocument = graphql(`
@@ -22,25 +25,45 @@ type KeysProps = {
   environmentSlug: string;
 };
 
-export default async function Keys({ environmentSlug }: KeysProps) {
-  const environment = await getEnvironment({
+const LoadingSkeleton = () => (
+  <div className="border-b border-slate-100 px-4 py-3">
+    <Skeleton className="mb-1 block h-11 w-full" />
+  </div>
+);
+
+export default function Keys({ environmentSlug }: KeysProps) {
+  const [{ data: environment, fetching: fetchingEnvironment }] = useEnvironment({
     environmentSlug,
   });
-
-  const response = await graphqlAPI.request(GetKeysDocument, {
-    environmentID: environment.id,
+  const [{ data, fetching: fetchingKey }] = useQuery({
+    query: GetKeysDocument,
+    variables: {
+      environmentID: environment?.id!,
+    },
+    pause: !environment?.id,
   });
 
-  const keys = response?.environment?.ingestKeys;
+  const loading = fetchingEnvironment || fetchingKey;
 
-  if (!keys) {
-    notFound();
-  }
+  const keys = data?.environment?.ingestKeys;
 
   function sortFunction(a: { createdAt: string }, b: { createdAt: string }) {
     const dateA = new Date(a.createdAt).getTime();
     const dateB = new Date(b.createdAt).getTime();
     return dateA < dateB ? 1 : -1;
+  }
+
+  if (loading) {
+    return (
+      <>
+        <LoadingSkeleton />
+        <LoadingSkeleton />
+      </>
+    );
+  }
+
+  if (!keys) {
+    notFound();
   }
 
   const orderedKeys = keys.sort(sortFunction);

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/Keys.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/Keys.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { notFound } from 'next/navigation';
-import { ExclamationCircleIcon } from '@heroicons/react/20/solid';
 import { Skeleton } from '@inngest/components/Skeleton';
 
 import { graphql } from '@/gql';
@@ -65,21 +64,8 @@ export default function Keys({ environmentSlug }: KeysProps) {
     );
   }
 
-  if (!keys) {
+  if (environmentError || error || !keys) {
     notFound();
-  }
-
-  if (environmentError || error) {
-    return (
-      <div className="flex h-full w-full flex-col items-center justify-center gap-5">
-        <div className="inline-flex items-center gap-2 text-red-600">
-          <ExclamationCircleIcon className="h-4 w-4" />
-          <h2 className="text-sm">{`Could not load ${
-            environmentError ? 'environment' : 'list'
-          }`}</h2>
-        </div>
-      </div>
-    );
   }
 
   const orderedKeys = keys.sort(sortFunction);

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/DeleteKeyModal.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/DeleteKeyModal.tsx
@@ -2,11 +2,10 @@
 
 import { type Route } from 'next';
 import { useRouter } from 'next/navigation';
-import { Button } from '@inngest/components/Button';
+import { AlertModal } from '@inngest/components/Modal';
 import { toast } from 'sonner';
 import { useMutation } from 'urql';
 
-import Modal from '@/components/Modal';
 import { graphql } from '@/gql';
 import useManagePageTerminology from './../useManagePageTerminology';
 
@@ -61,12 +60,11 @@ export default function DeleteKeyModal({
   }
 
   return (
-    <Modal className="flex max-w-xl flex-col gap-4" isOpen={isOpen} onClose={onClose}>
-      <p className="pb-4">{'Are you sure you want to delete this ' + currentContent?.name + '?'}</p>
-      <div className="flex content-center justify-end">
-        <Button appearance="outlined" btnAction={() => onClose()} label="No" />
-        <Button kind="danger" appearance="text" btnAction={handleDelete} label="Yes" />
-      </div>
-    </Modal>
+    <AlertModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={'Are you sure you want to delete this ' + currentContent?.name?.toLowerCase() + '?'}
+      primaryAction={{ label: 'Yes', btnAction: () => handleDelete() }}
+    />
   );
 }

--- a/ui/packages/components/src/Skeleton/Skeleton.tsx
+++ b/ui/packages/components/src/Skeleton/Skeleton.tsx
@@ -5,7 +5,7 @@ export function Skeleton({ className }: { className?: string }) {
     <span
       className={classNames(
         className,
-        'relative block overflow-hidden rounded-md before:absolute before:inset-0 before:-translate-x-full before:animate-[shimmer_2s_infinite] before:bg-gradient-to-r before:from-transparent before:via-slate-700/70 before:to-transparent'
+        'relative block overflow-hidden rounded-md before:absolute before:inset-0 before:-translate-x-full before:animate-[shimmer_2s_infinite] before:bg-gradient-to-r before:from-transparent before:via-slate-300/70 before:to-transparent dark:before:via-slate-700/70'
       )}
     />
   );


### PR DESCRIPTION
## Description
- New flow forces users to add a name to their new keys and webhooks while creating them
- Added light variation to Skeleton shared component
- Replaced delete confirmation modal by the Alert modal shared component

https://github.com/inngest/inngest/assets/16758464/b795c751-23bf-45dc-af58-d2883ef95654

Next PRs: 
- Fix delete key mutation to return InngestKey typename instead of DeleteResponse, so the cache updates automatically
- Create settings dropdown menu, and move edit key and delete key to it

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
