### PR TITLE
Add useSkippableGraphQLQuery

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/event-search/useEvent.ts
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/event-search/useEvent.ts
@@ -4,7 +4,7 @@ import { baseFetchFailed } from '@inngest/components/types/fetch';
 import type { FunctionRun } from '@inngest/components/types/functionRun';
 
 import { graphql } from '@/gql';
-import { useGraphQLQuery } from '@/utils/useGraphQLQuery';
+import { useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
 
 const eventQuery = graphql(`
   query GetEventSearchEvent($envID: ID!, $eventID: ULID!) {
@@ -36,7 +36,7 @@ type Data = {
 export function useEvent({ envID, eventID }: { envID: string; eventID: string | undefined }) {
   const skip = !eventID;
 
-  const res = useGraphQLQuery({
+  const res = useSkippableGraphQLQuery({
     query: eventQuery,
     skip,
     variables: {

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/event-search/useRun.ts
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/event-search/useRun.ts
@@ -5,7 +5,7 @@ import type { FunctionRun } from '@inngest/components/types/functionRun';
 import type { FunctionVersion } from '@inngest/components/types/functionVersion';
 
 import { graphql } from '@/gql';
-import { useGraphQLQuery } from '@/utils/useGraphQLQuery';
+import { useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
 
 const runQuery = graphql(`
   query GetEventSearchRun($envID: ID!, $functionID: ID!, $runID: ULID!) {
@@ -82,7 +82,7 @@ export function useRun({
 }): FetchResult<Data, { skippable: true }> {
   const skip = !functionID || !runID;
 
-  const res = useGraphQLQuery({
+  const res = useSkippableGraphQLQuery({
     query: runQuery,
     skip,
     variables: {

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
@@ -16,7 +16,7 @@ import { TimeRangeInput } from '@/components/TimeRangeInput';
 import { graphql } from '@/gql';
 import { FunctionRunStatus } from '@/gql/graphql';
 import { useEnvironment } from '@/queries';
-import { useGraphQLQuery } from '@/utils/useGraphQLQuery';
+import { useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
 
 const GetFunctionEndedRunsCountDocument = graphql(`
   query GetFunctionEndedRunsCount(
@@ -114,7 +114,7 @@ export default function NewReplayModal({
   const [{ data: environment }] = useEnvironment({
     environmentSlug,
   });
-  const { data, isLoading, error } = useGraphQLQuery({
+  const { data, isLoading, error } = useSkippableGraphQLQuery({
     query: GetFunctionEndedRunsCountDocument,
     variables: {
       environmentID: environment?.id!,

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/replay/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/replay/page.tsx
@@ -15,7 +15,7 @@ import { graphql } from '@/gql';
 import LoadingIcon from '@/icons/LoadingIcon';
 import { useEnvironment } from '@/queries';
 import { duration } from '@/utils/date';
-import { useGraphQLQuery } from '@/utils/useGraphQLQuery';
+import { useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
 
 const GetReplaysDocument = graphql(`
   query GetReplays($environmentID: ID!, $functionSlug: String!) {
@@ -101,7 +101,7 @@ export default function FunctionReplayPage({ params }: FunctionReplayPageProps) 
   const [{ data: environment, fetching: isFetchingEnvironment }] = useEnvironment({
     environmentSlug: params.environmentSlug,
   });
-  const { data, isLoading, error } = useGraphQLQuery({
+  const { data, isLoading, error } = useSkippableGraphQLQuery({
     query: GetReplaysDocument,
     variables: {
       environmentID: environment?.id!,


### PR DESCRIPTION
## Description

Split `useGraphQLQuery` into `useSkippableGraphQLQuery` and `useGraphQLQuery`. This is used in the new apps page, since its GraphQL queries aren't skippable.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
