### PR TITLE
Add "Send to Dev Server" button to forward events

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/events/[eventName]/logs/[eventId]/EventPayload.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/events/[eventName]/logs/[eventId]/EventPayload.tsx
@@ -1,7 +1,12 @@
+'use client';
+
+import { IconLightningBolt } from '@inngest/components/icons/LightningBolt';
 import { type JsonValue } from 'type-fest';
 
-import SyntaxHighlighter from '@/components/SyntaxHighlighter';
+import DashboardCodeBlock from '@/components/DashboardCodeBlock/DashboardCodeBlock';
+import { useBooleanFlag } from '@/components/FeatureFlags/hooks';
 import { getFragmentData, graphql, type FragmentType } from '@/gql';
+import { useDevServer } from '@/utils/useDevServer';
 
 const EventPayloadFragment = graphql(`
   fragment EventPayload on ArchivedEvent {
@@ -13,8 +18,10 @@ type EventPayloadProps = {
   event: FragmentType<typeof EventPayloadFragment>;
 };
 
-export default async function EventPayload({ event }: EventPayloadProps) {
+export default function EventPayload({ event }: EventPayloadProps) {
   const { payload } = getFragmentData(EventPayloadFragment, event);
+  const { isRunning, send } = useDevServer();
+  const { value: isSendToDevServerEnabled } = useBooleanFlag('send-to-dev-server', false);
 
   let parsedPayload: string | JsonValue = '';
   if (typeof payload === 'string') {
@@ -29,15 +36,30 @@ export default async function EventPayload({ event }: EventPayloadProps) {
   const formattedPayload = JSON.stringify(parsedPayload, null, 2);
 
   return (
-    <div className="flex h-full flex-col space-y-1.5 rounded-xl bg-slate-900 text-white">
-      <header className="bg-slate-910 flex items-center justify-between rounded-t-xl p-1.5">
-        <h3 className="px-6 py-2.5">Payload</h3>
-      </header>
-      <div className="flex-1 overflow-auto">
-        <div className="p-6">
-          <SyntaxHighlighter language="json">{formattedPayload}</SyntaxHighlighter>
-        </div>
-      </div>
-    </div>
+    <DashboardCodeBlock
+      tabs={[
+        {
+          label: 'Payload',
+          content: formattedPayload,
+          language: 'json',
+          readOnly: true,
+        },
+      ]}
+      actions={
+        isSendToDevServerEnabled
+          ? [
+              {
+                label: 'Send to Dev Server',
+                title: isRunning
+                  ? 'Send event payload to running Dev Server'
+                  : 'Dev Server is not running',
+                icon: <IconLightningBolt />,
+                onClick: () => send(payload),
+                disabled: !isRunning,
+              },
+            ]
+          : []
+      }
+    />
   );
 }

--- a/ui/apps/dashboard/src/components/DashboardCodeBlock/DashboardCodeBlock.tsx
+++ b/ui/apps/dashboard/src/components/DashboardCodeBlock/DashboardCodeBlock.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import type { ComponentProps } from 'react';
 import { useClerk } from '@clerk/nextjs';
 import { CodeBlock } from '@inngest/components/CodeBlock';

--- a/ui/apps/dashboard/src/utils/useDevServer.tsx
+++ b/ui/apps/dashboard/src/utils/useDevServer.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+const devServerUrl = 'http://localhost:8288';
+
+async function sendToDevServer(payload: string) {
+  try {
+    await fetch(`${devServerUrl}/e/cloud_ui_key`, {
+      body: payload,
+      method: 'POST',
+      mode: 'cors',
+    });
+    toast.success('Sent to Dev Server', {
+      description: (
+        <>
+          View at{' '}
+          <a href={devServerUrl} className="underline" target="_blank">
+            {devServerUrl.replace(/https?:\/\//, '')}
+          </a>
+        </>
+      ),
+    });
+  } catch (err) {
+    toast.error('Failed to send to Dev Server');
+  }
+}
+
+export function useDevServer() {
+  const [isRunning, setRunning] = useState<boolean>(false);
+  useEffect(() => {
+    fetch(devServerUrl)
+      .then(() => setRunning(true))
+      .catch(() => setRunning(false));
+  }, []);
+  return {
+    isRunning,
+    send: (payload: string) => sendToDevServer(payload),
+  };
+}

--- a/ui/packages/components/src/Button/Button.tsx
+++ b/ui/packages/components/src/Button/Button.tsx
@@ -68,6 +68,8 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps<string>>(functio
       })
     : null;
 
+  console.log('label', label);
+
   const children = (
     <>
       {loading && <IconSpinner className={classNames(spinnerStyles, iconSizes)} />}

--- a/ui/packages/components/src/CodeBlock/CodeBlock.stories.tsx
+++ b/ui/packages/components/src/CodeBlock/CodeBlock.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { IconLightningBolt } from '../icons/LightningBolt';
 import { CodeBlock } from './CodeBlock';
 
 const meta = {
@@ -7,7 +8,7 @@ const meta = {
   component: CodeBlock,
   decorators: [
     (Story) => (
-      <div className="w-80">
+      <div className="w-[480px]">
         <Story />
       </div>
     ),
@@ -43,6 +44,24 @@ export const MultipleTabs: Story = {
       {
         label: 'Error',
         content: '{\n  "error": "invalid status code: 500"\n}',
+      },
+    ],
+  },
+};
+
+export const Actions: Story = {
+  args: {
+    tabs: [
+      {
+        label: 'Output',
+        content: '{\n  "customerId": "cus_1234"\n}',
+      },
+    ],
+    actions: [
+      {
+        label: 'Send to Dev Server',
+        icon: <IconLightningBolt />,
+        onClick: () => alert('Sending to dev server...'),
       },
     ],
   },

--- a/ui/packages/components/src/CodeBlock/CodeBlock.tsx
+++ b/ui/packages/components/src/CodeBlock/CodeBlock.tsx
@@ -40,9 +40,16 @@ interface CodeBlockProps {
     language?: string;
     handleChange?: (value: string) => void;
   }[];
+  actions?: {
+    label: string;
+    title?: string;
+    icon?: React.ReactNode;
+    onClick: () => void;
+    disabled?: boolean;
+  }[];
 }
 
-export function CodeBlock({ header, tabs }: CodeBlockProps) {
+export function CodeBlock({ header, tabs, actions = [] }: CodeBlockProps) {
   const [activeTab, setActiveTab] = useState(0);
   const editorRef = useRef<MonacoEditorType>(null);
 
@@ -313,7 +320,19 @@ export function CodeBlock({ header, tabs }: CodeBlockProps) {
               })}
             </div>
             {!isOutputTooLarge && (
-              <div className="mr-2 flex items-center gap-2 py-2">
+              <div className="dark mr-2 flex items-center gap-2 py-2">
+                {actions.map(({ label, title, icon, onClick, disabled }, idx) => (
+                  <Button
+                    key={idx}
+                    icon={icon}
+                    btnAction={onClick}
+                    size="small"
+                    aria-label={label}
+                    title={title ?? label}
+                    label={label}
+                    disabled={disabled}
+                  />
+                ))}
                 <CopyButton
                   size="small"
                   code={content}

--- a/ui/packages/components/src/icons/LightningBolt.tsx
+++ b/ui/packages/components/src/icons/LightningBolt.tsx
@@ -1,0 +1,20 @@
+export function IconLightningBolt({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+      className={className}
+      height="16"
+      width="16"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3.75 13.5l10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75z"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Description

The goal of this is to make it easier to test webhook events or debug production issues by forwarding events from the cloud dashboard to the dev server (when running).

This adds a new button behind a feature flip that allows the user to quickly send the event to their dev server running on the default port on localhost. This saves the user from having to copy and paste the event and can speed up local replication of webhook events or events for debugging bugs using production events.

This also uses the new codeblock component which adds a necessary Copy button to the UI.

### Open questions

* Sending the event as is copies the timestamp to the dev server so if the dev server has events that are newer, the forwarded event will show up later in the stream which is not intuitive, should we omit the timestmap? 
* Should we link directly to the event in the local dev server using the correct URL?
* Should the final copy be "Replay in Dev Server" to be inline with our widely used Replay term across cloud and dev server?
* Should there be a dev server icon instead of a lightning bolt? (prob OK while this on a feature flip)

### Full workflow

https://github.com/inngest/inngest/assets/1509457/ccf97500-db99-4f9d-b483-cdc9730f1a6e




### Disabled state
<img width="1032" alt="Screen Shot 2023-12-14 at 11 34 42 AM" src="https://github.com/inngest/inngest/assets/1509457/d39768c1-c9d3-404f-a047-630421d04cfa">



## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
