### PR TITLE
Persist time range selected in URL state

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/DashboardTimeRangeFilter.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/DashboardTimeRangeFilter.tsx
@@ -15,44 +15,57 @@ const currentTime = new Date();
 
 const timeRanges: TimeRange[] = [
   {
+    key: '30m',
     start: new Date(currentTime.valueOf() - 30 * 60 * 1_000), // 30 Minutes
     end: currentTime,
   },
   {
+    key: '60m',
     start: new Date(currentTime.valueOf() - 60 * 60 * 1_000), // 60 Minutes
     end: currentTime,
   },
   {
+    key: '6h',
     start: new Date(currentTime.valueOf() - 6 * 60 * 60 * 1_000), // 6 Hours
     end: currentTime,
   },
   {
+    key: '12h',
     start: new Date(currentTime.valueOf() - 12 * 60 * 60 * 1_000), // 12 Hours
     end: currentTime,
   },
   {
+    key: '24h',
     start: new Date(currentTime.valueOf() - 24 * 60 * 60 * 1_000), // 24 Hours
     end: currentTime,
   },
   {
+    key: '3d',
     start: new Date(currentTime.valueOf() - 3 * 24 * 60 * 60 * 1_000), // 3 Days
     end: currentTime,
   },
   {
+    key: '7d',
     start: new Date(currentTime.valueOf() - 7 * 24 * 60 * 60 * 1_000), // 7 Days
     end: currentTime,
   },
   {
+    key: '14d',
     start: new Date(currentTime.valueOf() - 14 * 24 * 60 * 60 * 1_000), // 14 Days
     end: currentTime,
   },
   {
+    key: '30d',
     start: new Date(currentTime.valueOf() - 30 * 24 * 60 * 60 * 1_000), // 30 Days
     end: currentTime,
   },
 ];
 
 export const defaultTimeRange = timeRanges[4]!;
+
+export function getTimeRangeByKey(key: string): TimeRange | undefined {
+  return timeRanges.find((timeRange) => timeRange.key === key);
+}
 
 const GetBillingPlanDocument = graphql(`
   query GetBillingPlan {

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useState } from 'react';
 import Link from 'next/link';
 import { ChartBarIcon, ChevronRightIcon, XCircleIcon } from '@heroicons/react/20/solid';
 import {
@@ -24,7 +23,11 @@ import { Time } from '@/components/Time';
 import LoadingIcon from '@/icons/LoadingIcon';
 import { useFunction, useFunctionUsage } from '@/queries';
 import { relativeTime } from '@/utils/date';
-import DashboardTimeRangeFilter, { defaultTimeRange } from './DashboardTimeRangeFilter';
+import { useSearchParam } from '@/utils/useSearchParam';
+import DashboardTimeRangeFilter, {
+  defaultTimeRange,
+  getTimeRangeByKey,
+} from './DashboardTimeRangeFilter';
 import FunctionRunsChart, { type UsageMetrics } from './FunctionRunsChart';
 import FunctionThroughputChart from './FunctionThroughputChart';
 import LatestFailedFunctionRuns from './LatestFailedFunctionRuns';
@@ -45,7 +48,9 @@ export default function FunctionDashboardPage({ params }: FunctionDashboardProps
   });
   const function_ = data?.workspace.workflow;
 
-  const [selectedTimeRange, setSelectedTimeRange] = useState<TimeRange>(defaultTimeRange);
+  const [timeRangeParam, setTimeRangeParam] = useSearchParam('timeRange');
+  const selectedTimeRange: TimeRange =
+    getTimeRangeByKey(timeRangeParam ?? '24h') ?? defaultTimeRange;
 
   const [{ data: usage }] = useFunctionUsage({
     environmentSlug: params.environmentSlug,
@@ -90,7 +95,9 @@ export default function FunctionDashboardPage({ params }: FunctionDashboardProps
   const triggers = function_.current?.triggers || [];
 
   function handleTimeRangeChange(timeRange: TimeRange) {
-    setSelectedTimeRange(timeRange);
+    if (timeRange?.key) {
+      setTimeRangeParam(timeRange.key);
+    }
   }
 
   return (

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/TimeRangeFilter.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/TimeRangeFilter.tsx
@@ -20,6 +20,7 @@ const fieldOptions = [
 export type TimeRange = {
   start: Date;
   end: Date;
+  key?: string;
 };
 
 type TimeRangeOption = {


### PR DESCRIPTION
## Description

Move state to the URL search params so the range is persisted on refreshes, with the back button, and is sharable.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
