### PR TITLE
Hotfix: User cannot scroll when payload is large.

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/events/[eventName]/logs/[eventId]/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/events/[eventName]/logs/[eventId]/page.tsx
@@ -49,7 +49,7 @@ export default async function EventPage({ params }: EventPageProps) {
   }
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex h-full flex-col overflow-y-scroll">
       <header className="space-y-1 bg-white p-5 shadow">
         <h2 className="font-medium capitalize text-slate-800">
           <Time format="relative" value={new Date(event.receivedAt)} />


### PR DESCRIPTION
## Description

If the event payload code block is full height, the page cannot be scrolled, the user is stuck and the experience is broken.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
