### PR TITLE
feat(dashboard): retry when unauthenticated

### DIFF
--- a/ui/apps/dashboard/src/queries/URQLProvider.tsx
+++ b/ui/apps/dashboard/src/queries/URQLProvider.tsx
@@ -31,9 +31,15 @@ export default function URQLProvider({ children }: { children: React.ReactNode }
         retryExchange({
           maxNumberAttempts: 3,
           retryIf: (error) => {
-            // Retry the operation if clerk is not loaded yet and we got an unauthorized error
+            // TODO: Remove the legacy check once https://github.com/inngest/monorepo/pull/2133 has been released
+            const legacyCheck = error.graphQLErrors.some((e) =>
+              e.message?.includes('unauthorized')
+            );
+            // Retry the operation if Clerk is not loaded yet and we got an UNAUTHENTICATED error
             return (
-              !isLoaded && error.graphQLErrors.some((e) => e.message?.includes('unauthorized'))
+              !isLoaded &&
+              (legacyCheck ||
+                error.graphQLErrors.some((e) => e.extensions?.code === 'UNAUTHENTICATED'))
             );
           },
         }),


### PR DESCRIPTION
## Description

This updates the URQL's retry mechanism to rely on the GraphQLError's extension instead of the message.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
