### PR TITLE
feat(dashboard): don't sample replays when not erroring

### DIFF
--- a/ui/apps/dashboard/sentry.client.config.ts
+++ b/ui/apps/dashboard/sentry.client.config.ts
@@ -7,7 +7,7 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   tracesSampleRate: 0.2,
-  replaysSessionSampleRate: 0.1,
+  replaysSessionSampleRate: 0.0,
   replaysOnErrorSampleRate: 1.0,
 });
 


### PR DESCRIPTION
## Description

In order to reduce our usage of Sentry Replays quotas, this update the sampler to only record replays when the user encounters an error.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
