### PR TITLE
Store headers in driver response and history

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -124,6 +124,7 @@ func DoRequest(ctx context.Context, c *http.Client, r Request) (*state.DriverRes
 			RequestVersion: resp.requestVersion,
 			StatusCode:     resp.statusCode,
 			SDK:            resp.sdk,
+			Header:         resp.header,
 		}
 		dr.Generator, err = ParseGenerator(ctx, resp.body)
 		if err != nil {
@@ -168,6 +169,7 @@ func DoRequest(ctx context.Context, c *http.Client, r Request) (*state.DriverRes
 		RequestVersion: resp.requestVersion,
 		StatusCode:     resp.statusCode,
 		SDK:            resp.sdk,
+		Header:         resp.header,
 	}
 	if resp.statusCode < 200 || resp.statusCode > 299 {
 		// Add an error to driver.Response if the status code isn't 2XX.
@@ -296,6 +298,7 @@ func do(ctx context.Context, c *http.Client, r Request) (*response, error) {
 		noRetry:        noRetry,
 		requestVersion: rv,
 		sdk:            headers[headerSDK],
+		header:         resp.Header,
 	}, err
 
 }
@@ -314,4 +317,6 @@ type response struct {
 	// sdk represents the SDK language and version used for these
 	// functions, in the format: "js:v0.1.0"
 	sdk string
+
+	header http.Header
 }

--- a/pkg/execution/history/lifecycle.go
+++ b/pkg/execution/history/lifecycle.go
@@ -377,18 +377,22 @@ func (l lifecycle) OnStepFinished(
 		)
 	}
 
-	if h.Result != nil && resp.SDK != "" {
-		parts := strings.Split(resp.SDK, ":")
-		if len(parts) == 2 {
-			// Trim prefix because the TS SDK sends "inngest-js:vX.X.X"
-			h.Result.SDKLanguage = strings.TrimPrefix(parts[0], "inngest-")
+	if h.Result != nil {
+		h.Result.Headers = resp.Header
 
-			h.Result.SDKVersion = parts[1]
-		} else {
-			l.log.Warn(
-				"invalid SDK version",
-				"sdk", resp.SDK,
-			)
+		if resp.SDK != "" {
+			parts := strings.Split(resp.SDK, ":")
+			if len(parts) == 2 {
+				// Trim prefix because the TS SDK sends "inngest-js:vX.X.X"
+				h.Result.SDKLanguage = strings.TrimPrefix(parts[0], "inngest-")
+
+				h.Result.SDKVersion = parts[1]
+			} else {
+				l.log.Warn(
+					"invalid SDK version",
+					"sdk", resp.SDK,
+				)
+			}
 		}
 	}
 

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -3,6 +3,7 @@ package state
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -283,6 +284,8 @@ type DriverResponse struct {
 	//
 	// When final is true, Retryable() always returns false.
 	final bool
+
+	Header http.Header `json:"header,omitempty"`
 }
 
 // SetFinal indicates that this error is final, regardless of the status code


### PR DESCRIPTION
## Description

Store headers in the driver response and history object. This will be used to get SDK response headers into the history store

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
