### PR TITLE
fix(dashboard): don't initialize launchdarkly client multiple times

### DIFF
--- a/ui/apps/dashboard/src/launchDarkly.ts
+++ b/ui/apps/dashboard/src/launchDarkly.ts
@@ -2,17 +2,19 @@ import { init, type LDClient } from '@launchdarkly/node-server-sdk';
 
 let launchDarklyClient: LDClient;
 
-async function initialize() {
+function initialize() {
   const launchDarklySDKKey = process.env.LAUNCH_DARKLY_SDK_KEY;
   if (!launchDarklySDKKey) {
     throw new Error('LAUNCH_DARKLY_SDK_KEY environment variable is not set.');
   }
-  const client = init(launchDarklySDKKey, { stream: false });
-  await client.waitForInitialization();
-  return client;
+  launchDarklyClient = init(launchDarklySDKKey, { stream: false });
 }
 
 export async function getLaunchDarklyClient(): Promise<LDClient> {
-  if (launchDarklyClient) return launchDarklyClient;
-  return (launchDarklyClient = await initialize());
+  if (!launchDarklyClient) {
+    initialize();
+  }
+
+  await launchDarklyClient.waitForInitialization();
+  return launchDarklyClient;
 }


### PR DESCRIPTION
## Description

The Launchdarkly client was getting initialized multiple times. I suspect this is the cause behind the [errors we see on Vercel logs](https://vercel.com/inngest/ui/logs?page=1&timeline=maximum&startDate=1704099842468&endDate=1704186242468&levels=error&selectedLogId=1704167044704704470426000000&selectedLogTimestamp=1704167044704&forceEndDate=1704184615595)

See https://github.com/launchdarkly/js-core/issues/325 for more.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
