### PR TITLE
Display unpaid invoices with new icon and CTA link

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/settings/billing/PaymentIcons.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/settings/billing/PaymentIcons.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CheckIcon, ClockIcon, XMarkIcon } from '@heroicons/react/20/solid';
+import { CheckIcon, ClockIcon, ExclamationCircleIcon, XMarkIcon } from '@heroicons/react/20/solid';
 import * as Tooltip from '@radix-ui/react-tooltip';
 
 type PaymentIconProps = {
@@ -26,6 +26,10 @@ export default function PaymentIcon({ status }: PaymentIconProps) {
     case 'processing':
       icon = <ClockIcon className="mx-auto w-4 text-slate-500" />;
       label = 'Processing';
+      break;
+    case 'requires_confirmation':
+      icon = <ExclamationCircleIcon className="mx-auto w-4 text-amber-500" />;
+      label = 'Awaiting payment';
       break;
     default:
       icon = null;

--- a/ui/apps/dashboard/src/app/(dashboard)/settings/billing/Payments.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/settings/billing/Payments.tsx
@@ -70,7 +70,7 @@ export default function Payments() {
               target="_blank"
               className="font-semibold text-indigo-500 hover:text-indigo-800 hover:underline"
             >
-              View
+              {payment.status === 'requires_confirmation' ? 'Pay' : 'View'}
             </a>
           ) : null,
         })


### PR DESCRIPTION
## Description

Previously, there was no icon and it wasn't clear that the user could pay via the link.

![image](https://github.com/inngest/inngest/assets/1509457/8cea40ff-a798-4f04-be68-b48e4cf22661)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
