### PR TITLE
Add strict ordering to debounces

### DIFF
--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -303,6 +303,7 @@ func (d debouncer) updateDebounce(ctx context.Context, di DebounceItem, fn innge
 			strconv.Itoa(int(ttl.Seconds())),
 			redis_state.HashID(ctx, debounceID.String()),
 			strconv.Itoa(int(time.Now().UnixMilli())),
+			strconv.Itoa(int(di.Event.Timestamp)),
 		},
 	).AsInt64()
 	if err != nil {
@@ -327,6 +328,10 @@ func (d debouncer) updateDebounce(ctx context.Context, di DebounceItem, fn innge
 	case -1:
 		// The debounce is in progress or has just finished.  Requeue.
 		return ErrDebounceInProgress
+	case -2:
+		// The event is out-of-order and a newer event exists within the debounce.
+		// Do nothing.
+		return nil
 	default:
 		return fmt.Errorf("unknown update debounce return value: %d", out)
 	}

--- a/pkg/execution/debounce/lua/updateDebounce.lua
+++ b/pkg/execution/debounce/lua/updateDebounce.lua
@@ -5,6 +5,7 @@ Updates a debounce to use new data.
 Return values:
 - 0 (int): OK
 - -1: Debounce is already in progress, as the queue item is leased.
+- -2: Event is out of order and has no effect
 
 ]]--
 
@@ -19,6 +20,8 @@ local debounce    = ARGV[2]
 local ttl         = tonumber(ARGV[3])
 local queueJobID  = ARGV[4]
 local currentTime = tonumber(ARGV[5]) -- in ms
+local eventTime   = tonumber(ARGV[6]) -- The `event.ts` value.  If this is less than the event stored in the debounce, we
+                                      -- will not update the debounce as it violates the debounce order.
 
 
 -- copied from get_queue_item.lua
@@ -39,6 +42,18 @@ end
 if item.leaseID ~= nil and item.leaseID ~= cjson.null and decode_ulid_time(item.leaseID) > currentTime then
 	-- The debounce queue item is leased. 
 	return -1
+end
+
+-- Get the debounce
+local existing = redis.call("HGET", keyDbc, debounceID)
+if existing ~= false then
+	-- Decode the debounce, and check whether the existing event ID is > the current event ID.  If so,
+	-- don't update the debounce.
+	local item = cjson.decode(existing)
+	if item ~= nil and item.e ~= nil and item.e.ts > eventTime then
+		-- The stored event occurs after the event we're updating, so do nothing.
+		return -2
+	end
 end
 
 -- Set the fn -> debounce ID pointer

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -225,10 +225,18 @@ func (f Function) Validate(ctx context.Context) error {
 		err = multierror.Append(err, fmt.Errorf("This function exceeds the max number of cancellation events: %d", consts.MaxCancellations))
 	}
 
-	if f.Debounce != nil && f.Debounce.Key != nil {
-		if _, exprErr := expressions.NewExpressionEvaluator(ctx, *f.Debounce.Key); exprErr != nil {
-			err = multierror.Append(err, fmt.Errorf("Debounce expression is invalid: %s", exprErr))
+	if f.Debounce != nil {
+		if f.Debounce.Key != nil && *f.Debounce.Key == "" {
+			// Some clients may send an empty string.
+			f.Debounce.Key = nil
 		}
+		if f.Debounce.Key != nil {
+			// Ensure the expression is valid if present.
+			if _, exprErr := expressions.NewExpressionEvaluator(ctx, *f.Debounce.Key); exprErr != nil {
+				err = multierror.Append(err, fmt.Errorf("Debounce expression is invalid: %s", exprErr))
+			}
+		}
+
 		// NOTE: Debounce is not valid when batch is enabled.
 		if f.EventBatch != nil {
 			err = multierror.Append(err, fmt.Errorf("A function cannot specify batch and debounce"))


### PR DESCRIPTION
When debounce is active, we want to enfore strict LIFO ordering of events within the debounce.

Given the following scenario:

> We have two events, B and A.  B has a `ts` *after* A, eg. the order of
> event.ts is [A, B]. However, B is received *before* A and processed
> before A within Inngest.
>
> EG. Inngest receives [B, A].

With debouncing, we would expect that the debounce should ignore the second event as it occurred before B.

This change enables strict ordering for events.  If a debounce is active, any received events with a `ts` value earlier than the debounce event are ignored entirely:  they do not extend the debounce and will not be used for the function run.


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Docs

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
