### PR TITLE
Debounce timeouts (max lifetimes)

### DIFF
--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -72,6 +72,8 @@ type DebounceItem struct {
 	EventID ulid.ULID `json:"eID"`
 	// Event represents the event data which triggers the function.
 	Event event.Event `json:"e"`
+	// Timeout is the timeout for the debounce, in unix milliseconds.
+	Timeout int64 `json:"t,omitempty"`
 }
 
 func (d DebounceItem) QueuePayload() DebouncePayload {
@@ -227,6 +229,11 @@ func (d debouncer) newDebounce(ctx context.Context, di DebounceItem, fn inngest.
 		return nil, err
 	}
 
+	// Ensure we set the debounce's max lifetime.
+	if timeout := fn.Debounce.TimeoutDuration(); timeout != nil {
+		di.Timeout = time.Now().Add(*timeout).UnixMilli()
+	}
+
 	keyPtr := d.k.DebouncePointer(ctx, fn.ID, key)
 	keyDbc := d.k.Debounce(ctx)
 
@@ -310,12 +317,22 @@ func (d debouncer) updateDebounce(ctx context.Context, di DebounceItem, fn innge
 		return fmt.Errorf("error creating debounce: %w", err)
 	}
 	switch out {
-	case 0:
+	case -1:
+		// The debounce is in progress or has just finished.  Requeue.
+		return ErrDebounceInProgress
+	case -2:
+		// The event is out-of-order and a newer event exists within the debounce.
+		// Do nothing.
+		return nil
+	default:
+		// Debounces should have a maximum timeout;  updating the debounce returns
+		// the timeout to use.
+		actualTTL := time.Second * time.Duration(out)
 		err = d.q.RequeueByJobID(
 			ctx,
 			fn.ID.String(),
 			debounceID.String(),
-			now.Add(ttl).Add(buffer).Add(time.Second),
+			now.Add(actualTTL).Add(buffer).Add(time.Second),
 		)
 		if err == redis_state.ErrQueueItemAlreadyLeased {
 			// This is in progress.
@@ -325,15 +342,6 @@ func (d debouncer) updateDebounce(ctx context.Context, di DebounceItem, fn innge
 			return fmt.Errorf("error requeueing debounce job '%s': %w", debounceID, err)
 		}
 		return nil
-	case -1:
-		// The debounce is in progress or has just finished.  Requeue.
-		return ErrDebounceInProgress
-	case -2:
-		// The event is out-of-order and a newer event exists within the debounce.
-		// Do nothing.
-		return nil
-	default:
-		return fmt.Errorf("unknown update debounce return value: %d", out)
 	}
 }
 

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	petname "github.com/dustinkirkland/golang-petname"
 	"github.com/google/uuid"
@@ -86,8 +87,19 @@ type Priority struct {
 }
 
 type Debounce struct {
-	Key    *string `json:"key"`
-	Period string  `json:"period"`
+	Key     *string `json:"key,omitempty"`
+	Period  string  `json:"period"`
+	Timeout *string `json:"timeout,omitempty"`
+}
+
+func (d Debounce) TimeoutDuration() *time.Duration {
+	if d.Timeout == nil || *d.Timeout == "" {
+		return nil
+	}
+	if dur, err := str2duration.ParseDuration(*d.Timeout); err == nil {
+		return &dur
+	}
+	return nil
 }
 
 // Cancel represents a cancellation signal for a function.  When specified, this

--- a/tests/golang/concurrency_fn_scope_test.go
+++ b/tests/golang/concurrency_fn_scope_test.go
@@ -271,7 +271,7 @@ func TestConcurrency_ScopeFunction_Key_Fn(t *testing.T) {
 
 	a := inngestgo.CreateFunction(
 		inngestgo.FunctionOpts{
-			Name: "fn concurrency",
+			Name: "multiple fn concurrency",
 			Concurrency: []inngest.Concurrency{
 				{
 					Limit: limit,

--- a/tests/golang/debounce_test.go
+++ b/tests/golang/debounce_test.go
@@ -214,3 +214,56 @@ func TestDebounce_OutOfOrderTS(t *testing.T) {
 		return atomic.LoadInt32(&counter) == 1
 	}, 10*time.Second, 100*time.Millisecond, "Expected 1, got %d", counter)
 }
+
+func TestDebounce_Timeout(t *testing.T) {
+	h, server, registerFuncs := NewSDKHandler(t)
+	defer server.Close()
+
+	var counter int32
+
+	start := time.Now()
+	period := 5 * time.Second
+	max := 10 * time.Second
+
+	a := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{
+			Name: "test out of order debounce is ignored",
+			Debounce: &inngestgo.Debounce{
+				Period:  period,
+				Timeout: &max,
+			},
+		},
+		inngestgo.EventTrigger("test/sdk", nil),
+		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
+			fmt.Println("Debounced function ran", input.Event.Data.Name)
+
+			// It should occur after the max period.
+			require.True(t, time.Now().After(start.Add(max)))
+
+			atomic.AddInt32(&counter, 1)
+			return nil, nil
+		},
+	)
+	h.Register(a)
+	registerFuncs()
+
+	go func() {
+		// Send an event every second for 20 seconds in a goroutine.
+		// This ensures that we wait up to 15s - just past the max - to receive
+		// a fn invocation.
+		for i := 0; i <= 20; i++ {
+			_, err := inngestgo.Send(context.Background(), DebounceEvent{
+				Name: "test/sdk",
+				Data: DebounceEventData{
+					Name: "debounce",
+				},
+			})
+			require.NoError(t, err)
+			<-time.After(time.Second)
+		}
+	}()
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&counter) == 1
+	}, 15*time.Second, 100*time.Millisecond, "Expected 1, got %d", counter)
+}

--- a/tests/golang/priority_test.go
+++ b/tests/golang/priority_test.go
@@ -41,7 +41,7 @@ func TestFunctionPriorityRun(t *testing.T) {
 				Run: inngestgo.StrPtr(`event.data.priority == "high" ? 5 : 0`),
 			},
 		},
-		inngestgo.EventTrigger("test/sdk", nil),
+		inngestgo.EventTrigger("test/priority", nil),
 		func(ctx context.Context, input inngestgo.Input[inngestgo.GenericEvent[map[string]any, any]]) (any, error) {
 			priority, _ := input.Event.Data["priority"].(string)
 			results <- result{
@@ -79,7 +79,7 @@ func TestFunctionPriorityRun(t *testing.T) {
 	priorities := []string{"none", "low", "high"}
 	for _, p := range priorities {
 		_, err := inngestgo.Send(context.Background(), inngestgo.Event{
-			Name: "test/sdk",
+			Name: "test/priority",
 			Data: map[string]any{
 				"priority": p,
 			},

--- a/vendor/github.com/inngest/inngestgo/funcs.go
+++ b/vendor/github.com/inngest/inngestgo/funcs.go
@@ -49,8 +49,16 @@ func (f FunctionOpts) GetRateLimit() *inngest.RateLimit {
 // Debounce represents debounce configuration used when creating a new function within
 // FunctionOpts
 type Debounce struct {
-	Key    string        `json:"key"`
+	// Key is an optional expression to use for constraining the debounce to a given
+	// value.
+	Key string `json:"key,omitempty"`
+	// Period is how long to listen for new events matching the optional key.  Any event
+	// received during this period will reschedule the debounce to run after another period
+	// interval.
 	Period time.Duration `json:"period"`
+	// Timeout specifies the optional max lifetime of a debounce, ensuring that functions
+	// run after the given duration when a debounce is rescheduled indefinitely.
+	Timeout *time.Duration `json:"timeout,omitempty"`
 }
 
 type RateLimit struct {

--- a/vendor/github.com/inngest/inngestgo/handler.go
+++ b/vendor/github.com/inngest/inngestgo/handler.go
@@ -290,6 +290,10 @@ func (h *handler) register(w http.ResponseWriter, r *http.Request) error {
 				Key:    &c.Debounce.Key,
 				Period: c.Debounce.Period.String(),
 			}
+			if c.Debounce.Timeout != nil {
+				str := c.Debounce.Timeout.String()
+				f.Debounce.Timeout = &str
+			}
 		}
 
 		if c.BatchEvents != nil {


### PR DESCRIPTION
This PR adds optional timeouts to a function's debounce configuration.
Timeouts enforce a maximum amount of time in which a debounce can be
rescheduled.  If events are received up to the timeout, we execute a
function at the end of the timeout and begin a new debounce.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
