### PR TITLE
Preselect ticket type via URL query string

### DIFF
--- a/ui/apps/dashboard/src/app/support/SupportForm.tsx
+++ b/ui/apps/dashboard/src/app/support/SupportForm.tsx
@@ -29,7 +29,7 @@ const instructions: { [K in Exclude<TicketType, null>]: string } = {
 type SupportFormProps = {
   isEnterprise: boolean;
   isPaid: boolean;
-  preselectedTicketType?: TicketType;
+  preselectedTicketType: TicketType;
 };
 
 export function SupportForm({

--- a/ui/apps/dashboard/src/app/support/SupportForm.tsx
+++ b/ui/apps/dashboard/src/app/support/SupportForm.tsx
@@ -29,10 +29,15 @@ const instructions: { [K in Exclude<TicketType, null>]: string } = {
 type SupportFormProps = {
   isEnterprise: boolean;
   isPaid: boolean;
+  preselectedTicketType?: TicketType;
 };
 
-export function SupportForm({ isEnterprise = false, isPaid = false }: SupportFormProps) {
-  const [ticketType, setTicketType] = useState<TicketType>(null);
+export function SupportForm({
+  isEnterprise = false,
+  isPaid = false,
+  preselectedTicketType = null,
+}: SupportFormProps) {
+  const [ticketType, setTicketType] = useState<TicketType>(preselectedTicketType);
   const [body, setBody] = useState<string>('');
 
   const [bugSeverity, setBugSeverityLevel] = useState<BugSeverity>(DEFAULT_BUG_SEVERITY_LEVEL);

--- a/ui/apps/dashboard/src/app/support/page.tsx
+++ b/ui/apps/dashboard/src/app/support/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { type Route } from 'next';
+import { useSearchParams } from 'next/navigation';
 import { useAuth } from '@clerk/nextjs';
 import { ArrowLeftIcon, CheckIcon } from '@heroicons/react/20/solid';
 import { Button } from '@inngest/components/Button';
@@ -35,6 +36,7 @@ const GetAccountSupportInfoDocument = graphql(`
 export default function Page() {
   const status = useSystemStatus();
   const { isSignedIn } = useAuth();
+  const searchParams = useSearchParams();
   const [{ data, fetching }] = useQuery({
     query: GetAccountSupportInfoDocument,
   });
@@ -42,6 +44,7 @@ export default function Page() {
   const plan = data?.account.plan;
   const isPaid = (plan?.amount || 0) > 0;
   const isEnterprise = plan ? isEnterprisePlan(plan) : false;
+  const preselectedTicketType = searchParams.get('q');
 
   return (
     <div className="h-full overflow-y-scroll">
@@ -99,7 +102,11 @@ export default function Page() {
               </>
             ) : (
               <>
-                <SupportForm isEnterprise={isEnterprise} isPaid={isPaid} />
+                <SupportForm
+                  isEnterprise={isEnterprise}
+                  isPaid={isPaid}
+                  preselectedTicketType={preselectedTicketType}
+                />
                 <SupportTickets isSignedIn={isSignedIn} />
               </>
             )}

--- a/ui/apps/dashboard/src/app/support/page.tsx
+++ b/ui/apps/dashboard/src/app/support/page.tsx
@@ -17,7 +17,7 @@ import cn from '@/utils/cn';
 import { isEnterprisePlan } from '../(dashboard)/settings/billing/utils';
 import { SupportForm } from './SupportForm';
 import { useSystemStatus } from './statusPage';
-import { getLabelTitleByTypeId } from './ticketOptions';
+import { getLabelTitleByTypeId, type TicketType } from './ticketOptions';
 
 const GetAccountSupportInfoDocument = graphql(`
   query GetAccountSupportInfo {
@@ -44,7 +44,7 @@ export default function Page() {
   const plan = data?.account.plan;
   const isPaid = (plan?.amount || 0) > 0;
   const isEnterprise = plan ? isEnterprisePlan(plan) : false;
-  const preselectedTicketType = searchParams.get('q');
+  const preselectedTicketType = searchParams.get('q') as TicketType;
 
   return (
     <div className="h-full overflow-y-scroll">


### PR DESCRIPTION
## Description

Allow a URL to preselect the ticket type to save a step for the user. Uses the existing option keys [found here](https://github.com/inngest/inngest/blob/ce67538092aebd2c4f6dd8bd688c8bee4a64ccdb/ui/apps/dashboard/src/app/support/SupportForm.tsx#L20-L27).

```
/support?q=bug
/support?q=feature
```

[Slack convo](https://inngest.slack.com/archives/C05PV209Y66/p1704476521851919)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
