### PR TITLE
Add new queue kind to indicate a function to be ran.

### DIFF
--- a/pkg/api/apiv1/apiv1.go
+++ b/pkg/api/apiv1/apiv1.go
@@ -62,12 +62,22 @@ func (a *api) setup() {
 			r.Use(a.opts.CachingMiddleware.Middleware)
 		}
 
+		// Set all response type to JSON
+		r.Use(func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Add("Content-Type", "application/json")
+				next.ServeHTTP(w, r)
+			})
+		})
+
 		r.Get("/events", a.GetEvents)
 		r.Get("/events/{eventID}", a.GetEvent)
 		r.Get("/events/{eventID}/runs", a.GetEventRuns)
 		r.Get("/runs/{runID}", a.GetFunctionRun)
 		r.Delete("/runs/{runID}", a.CancelFunctionRun)
 		r.Get("/runs/{runID}/jobs", a.GetFunctionRunJobs)
+		r.Get("/functions", a.GetFunctions)
+		r.Get("/functions/{id}", a.GetFunction)
 	})
 }
 

--- a/pkg/api/apiv1/apiv1.go
+++ b/pkg/api/apiv1/apiv1.go
@@ -76,8 +76,8 @@ func (a *api) setup() {
 		r.Get("/runs/{runID}", a.GetFunctionRun)
 		r.Delete("/runs/{runID}", a.CancelFunctionRun)
 		r.Get("/runs/{runID}/jobs", a.GetFunctionRunJobs)
-		r.Get("/functions", a.GetFunctions)
-		r.Get("/functions/{id}", a.GetFunction)
+		// r.Get("/functions", a.GetFunctions)
+		// r.Get("/functions/{id}", a.GetFunction)
 	})
 }
 

--- a/pkg/api/apiv1/functions.go
+++ b/pkg/api/apiv1/functions.go
@@ -2,6 +2,10 @@ package apiv1
 
 import "net/http"
 
+// TODO: implement this
+// GetFunctions retrieves a list of functions
 func (a api) GetFunctions(w http.ResponseWriter, r *http.Request) {}
 
+// TODO: implement this
+// GetFunction retrieves a function based on the app_id and function_id
 func (a api) GetFunction(w http.ResponseWriter, r *http.Request) {}

--- a/pkg/api/apiv1/functions.go
+++ b/pkg/api/apiv1/functions.go
@@ -1,0 +1,7 @@
+package apiv1
+
+import "net/http"
+
+func (a api) GetFunctions(w http.ResponseWriter, r *http.Request) {}
+
+func (a api) GetFunction(w http.ResponseWriter, r *http.Request) {}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -440,7 +440,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		JobID:       &queueKey,
 		GroupID:     uuid.New().String(),
 		WorkspaceID: req.WorkspaceID,
-		Kind:        queue.KindEdge,
+		Kind:        queue.KindStart,
 		Identifier:  id,
 		Attempt:     0,
 		MaxAttempts: &sourceEdgeRetries,

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -160,7 +160,7 @@ func (s *svc) Run(ctx context.Context) error {
 
 		var err error
 		switch item.Kind {
-		case queue.KindEdge, queue.KindSleep:
+		case queue.KindStart, queue.KindEdge, queue.KindSleep:
 			err = s.handleQueueItem(ctx, item)
 		case queue.KindPause:
 			err = s.handlePauseTimeout(ctx, item)

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	// KindStart represents a state that the function state has been created but not started yet.
+	// KindStart represents a queue state that the function state has been created but not started yet.
 	// Essentially a status that represents the backlog.
 	KindStart    = "start"
 	KindEdge     = "edge"

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -12,6 +12,9 @@ import (
 )
 
 const (
+	// KindStart represents a state that the function state has been created but not started yet.
+	// Essentially a status that represents the backlog.
+	KindStart    = "start"
 	KindEdge     = "edge"
 	KindSleep    = "sleep"
 	KindPause    = "pause"
@@ -84,7 +87,7 @@ type Item struct {
 // Note: the returned time is the factor in milliseconds.
 func (i Item) GetPriorityFactor() int64 {
 	switch i.Kind {
-	case KindEdge:
+	case KindStart, KindEdge:
 		// Only support edges right now.  We don't account for the factor on other queue entries,
 		// else eg. sleeps would wake up at the wrong time.
 		if i.Identifier.PriorityFactor != nil {
@@ -132,7 +135,7 @@ func (i *Item) UnmarshalJSON(b []byte) error {
 	}
 
 	switch temp.Kind {
-	case KindEdge, KindSleep:
+	case KindStart, KindEdge, KindSleep:
 		// Edge and Sleep are the same;  the only difference is that the executor
 		// runner should always save nil to the state store using the outgoing edge's
 		// ID when processing a sleep so that the state + stack are updated properly.

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -104,6 +104,11 @@ func (i Item) GetMaxAttempts() int {
 	return *i.MaxAttempts
 }
 
+// IsStepKind determines if the item is considered a step
+func (i Item) IsStepKind() bool {
+	return i.Kind == KindStart || i.Kind == KindEdge || i.Kind == KindSleep
+}
+
 func (i *Item) UnmarshalJSON(b []byte) error {
 	type kind struct {
 		GroupID     string            `json:"groupID"`

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -189,6 +189,9 @@ type QueueKeyGenerator interface {
 
 	// RunIndex returns the index for storing job IDs associated with run IDs.
 	RunIndex(runID ulid.ULID) string
+
+	// Status returns the key used for status queue for the provided function.
+	Status(status string, fnID uuid.UUID) string
 }
 
 type DebounceKeyGenerator interface {
@@ -276,4 +279,8 @@ func (d DefaultQueueKeyGenerator) Debounce(ctx context.Context) string {
 
 func (d DefaultQueueKeyGenerator) RunIndex(runID ulid.ULID) string {
 	return fmt.Sprintf("%s:idx:run:%s", d.Prefix, runID)
+}
+
+func (d DefaultQueueKeyGenerator) Status(status string, fnID uuid.UUID) string {
+	return fmt.Sprintf("%s:queue:status:%s:%s", d.Prefix, fnID, status)
 }

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -476,7 +476,7 @@ func (q *QueueItem) SetID(ctx context.Context, str string) {
 // are not sleeps (eg. immediate runs)
 func (q QueueItem) Score() int64 {
 	// If this is not an edge, we can ignore this.
-	if q.Data.Kind != osqueue.KindEdge || q.Data.Attempt > 0 {
+	if (q.Data.Kind != osqueue.KindStart && q.Data.Kind != osqueue.KindEdge) || q.Data.Attempt > 0 {
 		return q.AtMS
 	}
 

--- a/pkg/execution/state/redis_state/queue_indexes.go
+++ b/pkg/execution/state/redis_state/queue_indexes.go
@@ -33,15 +33,26 @@ func QueueItemIndexerFunc(ctx context.Context, i QueueItem, kg QueueKeyGenerator
 		return QueueItemIndex{
 			kg.Status("start", i.WorkflowID),
 		}
-	case osqueue.KindEdge, osqueue.KindSleep:
+	case osqueue.KindEdge:
 		// For edges and sleeps, store an index for the given run ID.
 		return QueueItemIndex{
 			kg.RunIndex(i.Data.Identifier.RunID),
+			kg.Status("in-progress", i.WorkflowID),
+		}
+	case osqueue.KindSleep:
+		return QueueItemIndex{
+			kg.RunIndex(i.Data.Identifier.RunID),
+			kg.Status("sleep", i.WorkflowID),
 		}
 	case osqueue.KindPause:
 		// Pause jobs are an implementation detail and are not indexed.  Instead,
 		// we should store indexes for each pause <> run separately.  Consuming
 		// or deleting pauses should delete the index.
+		return QueueItemIndex{
+			kg.Status("pause", i.WorkflowID),
+		}
+
+	default:
+		return QueueItemIndex{}
 	}
-	return QueueItemIndex{}
 }

--- a/pkg/execution/state/redis_state/queue_indexes.go
+++ b/pkg/execution/state/redis_state/queue_indexes.go
@@ -48,11 +48,6 @@ func QueueItemIndexerFunc(ctx context.Context, i QueueItem, kg QueueKeyGenerator
 		// Pause jobs are an implementation detail and are not indexed.  Instead,
 		// we should store indexes for each pause <> run separately.  Consuming
 		// or deleting pauses should delete the index.
-		return QueueItemIndex{
-			kg.Status("pause", i.WorkflowID),
-		}
-
-	default:
-		return QueueItemIndex{}
 	}
+	return QueueItemIndex{}
 }

--- a/pkg/execution/state/redis_state/queue_indexes.go
+++ b/pkg/execution/state/redis_state/queue_indexes.go
@@ -29,7 +29,7 @@ type QueueItemIndexer func(ctx context.Context, i QueueItem, kg QueueKeyGenerato
 // QueueItemIndexer is not provided, this function will be used with an "{queue}" predix.
 func QueueItemIndexerFunc(ctx context.Context, i QueueItem, kg QueueKeyGenerator) QueueItemIndex {
 	switch i.Data.Kind {
-	case osqueue.KindEdge, osqueue.KindSleep:
+	case osqueue.KindStart, osqueue.KindEdge, osqueue.KindSleep:
 		// For edges and sleeps, store an index for the given run ID.
 		return QueueItemIndex{
 			kg.RunIndex(i.Data.Identifier.RunID),

--- a/pkg/execution/state/redis_state/queue_indexes.go
+++ b/pkg/execution/state/redis_state/queue_indexes.go
@@ -29,7 +29,11 @@ type QueueItemIndexer func(ctx context.Context, i QueueItem, kg QueueKeyGenerato
 // QueueItemIndexer is not provided, this function will be used with an "{queue}" predix.
 func QueueItemIndexerFunc(ctx context.Context, i QueueItem, kg QueueKeyGenerator) QueueItemIndex {
 	switch i.Data.Kind {
-	case osqueue.KindStart, osqueue.KindEdge, osqueue.KindSleep:
+	case osqueue.KindStart:
+		return QueueItemIndex{
+			kg.Status("start", i.WorkflowID),
+		}
+	case osqueue.KindEdge, osqueue.KindSleep:
 		// For edges and sleeps, store an index for the given run ID.
 		return QueueItemIndex{
 			kg.RunIndex(i.Data.Identifier.RunID),


### PR DESCRIPTION
## Description

The `start` kind represents a status that the function state has been created but has not been worked on by the executor. Once the function starts, subsequent executions will be changed to use the existing `edge` kind.

There are essentially zero difference between `start` and `edge`. The main reason to having this status is to be used as a differentiator when introspecting the queue.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
