### PR TITLE
Instant mass backlog cancellation

### DIFF
--- a/pkg/api/apiv1/apiv1.go
+++ b/pkg/api/apiv1/apiv1.go
@@ -29,10 +29,14 @@ type Opts struct {
 	Executor execution.Executor
 	// EventReader allows reading of events from storage.
 	EventReader EventReader
+	// FunctionReader reads functions from a backing store.
+	FunctionReader cqrs.FunctionReader
 	// FunctionRunReader reads function runs, history, etc. from backing storage
 	FunctionRunReader cqrs.APIV1FunctionRunReader
 	// JobQueueReader reads information around a function run's job queues.
 	JobQueueReader queue.JobQueueReader
+	// CancellationReadWriter reads and writes cancellations to/from a backing store.
+	CancellationReadWriter cqrs.CancellationReadWriter
 }
 
 // AddRoutes adds a new API handler to the given router.
@@ -71,8 +75,11 @@ func (a *api) setup() {
 		r.Get("/runs/{runID}", a.GetFunctionRun)
 		r.Delete("/runs/{runID}", a.CancelFunctionRun)
 		r.Get("/runs/{runID}/jobs", a.GetFunctionRunJobs)
-		// r.Get("/functions", a.GetFunctions)
-		// r.Get("/functions/{id}", a.GetFunction)
+
+		r.Get("/apps/{appName}/functions", a.GetAppFunctions) // Returns an app and all of its functions.
+
+		r.Post("/cancellations", a.CreateCancellation)
+		r.Get("/cancellations", a.GetCancellations)
 	})
 }
 

--- a/pkg/api/apiv1/cancellation.go
+++ b/pkg/api/apiv1/cancellation.go
@@ -31,9 +31,9 @@ func (a api) GetCancellations(w http.ResponseWriter, r *http.Request) {
 
 type CreateCancellationBody struct {
 	// AppID is the client ID specified via the SDK in the app that defines the function.
-	AppID string `json:"appID"`
+	AppID string `json:"app_id"`
 	// FunctionID is the function ID string specified in configuration via the SDK.
-	FunctionID string     `json:"functionID"`
+	FunctionID string     `json:"function_id"`
 	From       *time.Time `json:"from"`
 	To         time.Time  `json:"to"`
 	If         *string    `json:"if,omitempty"`

--- a/pkg/api/apiv1/cancellation.go
+++ b/pkg/api/apiv1/cancellation.go
@@ -1,0 +1,82 @@
+package apiv1
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/publicerr"
+	"github.com/oklog/ulid/v2"
+)
+
+func (a api) GetCancellations(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	auth, err := a.opts.AuthFinder(ctx)
+	if err != nil {
+		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 401, "No auth found"))
+		return
+	}
+
+	all, err := a.opts.CancellationReadWriter.Cancellations(ctx, auth.WorkspaceID())
+	if err != nil {
+		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "Error listing cancellations"))
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(all)
+
+}
+
+type CreateCancellationBody struct {
+	// AppID is the client ID specified via the SDK in the app that defines the function.
+	AppID string `json:"appID"`
+	// FunctionID is the function ID string specified in configuration via the SDK.
+	FunctionID string     `json:"functionID"`
+	From       *time.Time `json:"from"`
+	To         time.Time  `json:"to"`
+	If         *string    `json:"if,omitempty"`
+}
+
+func (a api) CreateCancellation(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	auth, err := a.opts.AuthFinder(ctx)
+	if err != nil {
+		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 401, "No auth found"))
+		return
+	}
+
+	opts := CreateCancellationBody{}
+	if err := json.NewDecoder(r.Body).Decode(&opts); err != nil {
+		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 400, "Invalid cancellation request"))
+		return
+	}
+
+	fn, err := a.opts.FunctionReader.GetFunctionByExternalID(
+		ctx,
+		auth.WorkspaceID(),
+		opts.AppID,
+		opts.FunctionID,
+	)
+	if err != nil {
+		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 404, "Function not found"))
+		return
+	}
+
+	// Create a new cancellation for the given function ID
+	cancel := cqrs.Cancellation{
+		ID:          ulid.MustNew(ulid.Now(), rand.Reader),
+		WorkspaceID: auth.WorkspaceID(),
+		FunctionID:  fn.ID,
+		From:        opts.From,
+		To:          opts.To,
+		If:          opts.If,
+	}
+	if err := a.opts.CancellationReadWriter.CreateCancellation(ctx, cancel); err != nil {
+		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "Error creating function"))
+		return
+	}
+
+	_ = json.NewEncoder(w).Encode(cancel)
+}

--- a/pkg/api/apiv1/cancellation.go
+++ b/pkg/api/apiv1/cancellation.go
@@ -69,6 +69,7 @@ func (a api) CreateCancellation(w http.ResponseWriter, r *http.Request) {
 		ID:            ulid.MustNew(ulid.Now(), rand.Reader),
 		WorkspaceID:   auth.WorkspaceID(),
 		FunctionID:    fn.ID,
+		FunctionSlug:  fn.Slug,
 		StartedAfter:  opts.StartedAfter,
 		StartedBefore: opts.StartedBefore,
 		If:            opts.If,

--- a/pkg/api/apiv1/cancellation.go
+++ b/pkg/api/apiv1/cancellation.go
@@ -33,10 +33,10 @@ type CreateCancellationBody struct {
 	// AppID is the client ID specified via the SDK in the app that defines the function.
 	AppID string `json:"app_id"`
 	// FunctionID is the function ID string specified in configuration via the SDK.
-	FunctionID string     `json:"function_id"`
-	From       *time.Time `json:"from"`
-	To         time.Time  `json:"to"`
-	If         *string    `json:"if,omitempty"`
+	FunctionID    string     `json:"function_id"`
+	StartedAfter  *time.Time `json:"started_after"`
+	StartedBefore time.Time  `json:"started_before"`
+	If            *string    `json:"if,omitempty"`
 }
 
 func (a api) CreateCancellation(w http.ResponseWriter, r *http.Request) {
@@ -66,12 +66,12 @@ func (a api) CreateCancellation(w http.ResponseWriter, r *http.Request) {
 
 	// Create a new cancellation for the given function ID
 	cancel := cqrs.Cancellation{
-		ID:          ulid.MustNew(ulid.Now(), rand.Reader),
-		WorkspaceID: auth.WorkspaceID(),
-		FunctionID:  fn.ID,
-		From:        opts.From,
-		To:          opts.To,
-		If:          opts.If,
+		ID:            ulid.MustNew(ulid.Now(), rand.Reader),
+		WorkspaceID:   auth.WorkspaceID(),
+		FunctionID:    fn.ID,
+		StartedAfter:  opts.StartedAfter,
+		StartedBefore: opts.StartedBefore,
+		If:            opts.If,
 	}
 	if err := a.opts.CancellationReadWriter.CreateCancellation(ctx, cancel); err != nil {
 		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "Error creating function"))

--- a/pkg/coreapi/graph/models/converters.go
+++ b/pkg/coreapi/graph/models/converters.go
@@ -40,7 +40,7 @@ func MakeFunction(f *cqrs.Function) (*Function, error) {
 		ID:          f.ID.String(),
 		Name:        f.Name,
 		Slug:        f.Slug,
-		Config:      f.Config,
+		Config:      string(f.Config),
 		Concurrency: concurrency,
 		Triggers:    triggers,
 		URL:         fn.Steps[0].URI,

--- a/pkg/cqrs/cancellations.go
+++ b/pkg/cqrs/cancellations.go
@@ -31,12 +31,16 @@ type CancellationWriter interface {
 
 // Cancellation represents a cancellation of many function runs during the time specified.
 type Cancellation struct {
-	ID          ulid.ULID  `json:"id"`
-	WorkspaceID uuid.UUID  `json:"environment_id"`
-	FunctionID  uuid.UUID  `json:"function_id"`
-	From        *time.Time `json:"from"`
-	To          time.Time  `json:"to"`
-	If          *string    `json:"if,omitempty"`
+	ID          ulid.ULID `json:"id"`
+	WorkspaceID uuid.UUID `json:"environment_id"`
+	AppID       string    `json:"app_id"`
+	// FunctionID represents the function's internal ID.
+	FunctionID uuid.UUID `json:"function_internal_id"`
+	// FunctionSlug represents the function's external ID as defined in the SDK.
+	FunctionSlug  string     `json:"function_id"`
+	StartedAfter  *time.Time `json:"started_after"`
+	StartedBefore time.Time  `json:"started_before"`
+	If            *string    `json:"if,omitempty"`
 	// XXX (tonyhb): We can eventually add a  "kind" field: an enum allowing
 	// you to cancel only the backlog of unstarted functions or every function.
 }

--- a/pkg/cqrs/cancellations.go
+++ b/pkg/cqrs/cancellations.go
@@ -33,7 +33,6 @@ type CancellationWriter interface {
 type Cancellation struct {
 	ID          ulid.ULID `json:"id"`
 	WorkspaceID uuid.UUID `json:"environment_id"`
-	AppID       string    `json:"app_id"`
 	// FunctionID represents the function's internal ID.
 	FunctionID uuid.UUID `json:"function_internal_id"`
 	// FunctionSlug represents the function's external ID as defined in the SDK.

--- a/pkg/cqrs/cancellations.go
+++ b/pkg/cqrs/cancellations.go
@@ -32,8 +32,8 @@ type CancellationWriter interface {
 // Cancellation represents a cancellation of many function runs during the time specified.
 type Cancellation struct {
 	ID          ulid.ULID  `json:"id"`
-	WorkspaceID uuid.UUID  `json:"workspaceID"`
-	FunctionID  uuid.UUID  `json:"functionID"`
+	WorkspaceID uuid.UUID  `json:"environment_id"`
+	FunctionID  uuid.UUID  `json:"function_id"`
 	From        *time.Time `json:"from"`
 	To          time.Time  `json:"to"`
 	If          *string    `json:"if,omitempty"`

--- a/pkg/cqrs/functions.go
+++ b/pkg/cqrs/functions.go
@@ -10,12 +10,12 @@ import (
 )
 
 type Function struct {
-	ID        uuid.UUID
-	AppID     uuid.UUID
-	Slug      string
-	Name      string
-	Config    string
-	CreatedAt time.Time
+	ID        uuid.UUID       `json:"internal_id"`
+	AppID     uuid.UUID       `json:"app_id"`
+	Slug      string          `json:"id"`
+	Name      string          `json:"name"`
+	Config    json.RawMessage `json:"config"`
+	CreatedAt time.Time       `json:"created_at"`
 }
 
 func (f Function) InngestFunction() (*inngest.Function, error) {

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -88,6 +88,7 @@ func (d *devserver) Pre(ctx context.Context) error {
 		apiv1.AddRoutes(r, apiv1.Opts{
 			CachingMiddleware: caching,
 			EventReader:       d.data,
+			FunctionReader:    d.data,
 			FunctionRunReader: d.data,
 			JobQueueReader:    d.queue.(queue.JobQueueReader),
 			Executor:          d.executor,

--- a/pkg/execution/cancellation/cancellation.go
+++ b/pkg/execution/cancellation/cancellation.go
@@ -56,7 +56,7 @@ func (c checker) IsCancelled(ctx context.Context, wsID, fnID uuid.UUID, runID ul
 	for _, i := range all {
 		cancel := i
 
-		if cancel.To.Before(at) || (cancel.From != nil && cancel.From.After(at)) {
+		if at.After(cancel.StartedBefore) || (cancel.StartedAfter != nil && at.Before(*cancel.StartedAfter)) {
 			// The loader may have messed up times, so verify that the cancellation includes this
 			// run ID as within bounds.
 			continue

--- a/pkg/execution/cancellation/cancellation.go
+++ b/pkg/execution/cancellation/cancellation.go
@@ -1,0 +1,84 @@
+package cancellation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/expressions"
+	"github.com/oklog/ulid/v2"
+)
+
+// Checker checks whether the given function run is cancelled.
+type Checker interface {
+	// IsCancelled returns the ID of a CancelRequest if the function is cancelled.  If
+	// the function is not cancelled the UUID returned will be nil.
+	//
+	// The event data specified is expected to be the event that triggers a function.
+	IsCancelled(ctx context.Context, wsID uuid.UUID, fnID uuid.UUID, runID ulid.ULID, event map[string]any) (*cqrs.Cancellation, error)
+}
+
+// Reader returns all cancellations that are valid for the given point in time.
+type Reader interface {
+	// ReadAt returns cancellations which may cancel functions at the given point in time,
+	// for a specific workspace/function.
+	ReadAt(ctx context.Context, wsID uuid.UUID, fnID uuid.UUID, at time.Time) ([]cqrs.Cancellation, error)
+}
+
+// Writer manages writing cancellations to one or more datastores.
+type Writer interface {
+	// Write stores new cancellations into a datastore.
+	Write(ctx context.Context, c cqrs.Cancellation) error
+}
+
+// NewChecker returns a new cancellation checker given a reader.
+func NewChecker(r Reader) Checker {
+	return checker{r}
+}
+
+// checker implements the default checking logic.
+type checker struct{ r Reader }
+
+func (c checker) IsCancelled(ctx context.Context, wsID, fnID uuid.UUID, runID ulid.ULID, event map[string]any) (*cqrs.Cancellation, error) {
+	if c.r == nil {
+		return nil, fmt.Errorf("no cancel loader specified")
+	}
+
+	at := ulid.Time(runID.Time())
+
+	all, err := c.r.ReadAt(ctx, wsID, fnID, at)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, i := range all {
+		cancel := i
+
+		if cancel.To.Before(at) || (cancel.From != nil && cancel.From.After(at)) {
+			// The loader may have messed up times, so verify that the cancellation includes this
+			// run ID as within bounds.
+			continue
+		}
+
+		if cancel.If == nil {
+			return &cancel, nil
+		}
+
+		// This cancellation has an expression, and we should only cancel the function
+		// if the event that initialized the function matches the expression.
+		ok, _, err := expressions.EvaluateBoolean(ctx, *cancel.If, map[string]any{
+			"event": event,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return &cancel, nil
+		}
+	}
+
+	// None of the cancellations match.
+	return nil, nil
+}

--- a/pkg/execution/cancellation/redis.go
+++ b/pkg/execution/cancellation/redis.go
@@ -1,0 +1,121 @@
+package cancellation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/oklog/ulid/v2"
+	"github.com/redis/rueidis"
+)
+
+const DefaultPrefix = "{cancel}"
+
+var (
+	nilID = ulid.ULID{}
+)
+
+// NewRedisWriter writes cancellations to Redis.
+func NewRedisWriter(r rueidis.Client, prefix string) cqrs.CancellationWriter {
+	if prefix == "" {
+		prefix = DefaultPrefix
+	}
+	return redisReadWriter{r, prefix}
+}
+
+// NewRedisReader loads cancellations from Redis.
+func NewRedisReader(r rueidis.Client, prefix string) Reader {
+	if prefix == "" {
+		prefix = DefaultPrefix
+	}
+	return redisReadWriter{r, prefix}
+}
+
+type redisReadWriter struct {
+	r      rueidis.Client
+	prefix string
+}
+
+type redisWrapper struct {
+	Version      int               `json:"v"`
+	Cancellation cqrs.Cancellation `json:"c"`
+}
+
+func (r redisReadWriter) CreateCancellation(ctx context.Context, c cqrs.Cancellation) error {
+	if c.ID == nilID {
+		return fmt.Errorf("A cancellation ID must be created before writing")
+	}
+
+	// TODO: Use msgpack, capnproto, protobuf, or some other fast parser here.
+	byt, err := json.Marshal(redisWrapper{Version: 1, Cancellation: c})
+	if err != nil {
+		return err
+	}
+
+	key := r.key(c.WorkspaceID, c.FunctionID)
+
+	// TODO: We want to store overlapping indexes of cancellations
+	// using zsets which store beginning and end times of when cancellations are valid.
+	//
+	// This lets us query for valid cancellations using a fast lookup, instead of
+	// loading them all.
+	//
+	// For now, though, we're adding cancellations to a hashmap of each given workspace/
+	// function combination.
+	cmd := r.r.B().Hset().Key(key).FieldValue().FieldValue(c.ID.String(), string(byt)).Build()
+	return r.r.Do(ctx, cmd).Error()
+}
+
+func (r redisReadWriter) ReadAt(ctx context.Context, wsID uuid.UUID, fnID uuid.UUID, at time.Time) ([]cqrs.Cancellation, error) {
+	// TODO: Cancellations need to be fast.  They're loaded in the critical path on each step
+	// execution so that cancellations are immedaite.
+	//
+	// Ideally, we'd store these in-memory for instant loading.  We'd need to notify
+	// notify executors when cancellations have been modified, allowing us to only fetch
+	// items from the datastore when necessary.  Our executors are shared-nothing and do
+	// not communicate amongst each other;  this needs us to start centralizing executors
+	// to a messaging system (NATS) and ensuring heartbeats for executors so that we can
+	// continuously communicate with them and prevent them from executing in the case of
+	// networking errors.
+	//
+	// Our state store is fast enough to perform lookups to make this quick, and this doesn't
+	// increase latency beyond a few milliseconds.
+	key := r.key(wsID, fnID)
+
+	cmd := r.r.B().Hgetall().Key(key).Build()
+	all, err := r.r.Do(ctx, cmd).AsMap()
+	if err != nil {
+		return nil, err
+	}
+
+	result := []cqrs.Cancellation{}
+	for _, item := range all {
+		found := &redisWrapper{}
+		if err := item.DecodeJSON(found); err != nil {
+			return nil, err
+		}
+		// XXX: Right now there's only one version of a cancellation stored in
+		// the state store, so we don't need to handle found.Version differently.
+		c := found.Cancellation
+		if c.To.Before(at) {
+			// This cancellation is only for functions prior to the given point
+			// in time, so ignore.
+			continue
+		}
+		if c.From != nil && c.From.After(at) {
+			continue
+		}
+		result = append(result, c)
+	}
+
+	return result, nil
+}
+
+func (r redisReadWriter) key(wsID uuid.UUID, fnID uuid.UUID) string {
+	// We currently don't hash the workspace or function here.  It would cut down
+	// on key size, but we store cancellations in a map anyway.
+	return fmt.Sprintf("%s:%s:%s", r.prefix, wsID, fnID)
+}

--- a/pkg/execution/cancellation/redis.go
+++ b/pkg/execution/cancellation/redis.go
@@ -100,12 +100,12 @@ func (r redisReadWriter) ReadAt(ctx context.Context, wsID uuid.UUID, fnID uuid.U
 		// XXX: Right now there's only one version of a cancellation stored in
 		// the state store, so we don't need to handle found.Version differently.
 		c := found.Cancellation
-		if c.To.Before(at) {
+		if at.After(c.StartedBefore) {
 			// This cancellation is only for functions prior to the given point
 			// in time, so ignore.
 			continue
 		}
-		if c.From != nil && c.From.After(at) {
+		if c.StartedAfter != nil && at.Before(*c.StartedAfter) {
 			continue
 		}
 		result = append(result, c)

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -168,9 +168,10 @@ type ScheduleRequest struct {
 // CancelRequest stores information about the incoming cancellation request within
 // history.
 type CancelRequest struct {
-	EventID    *ulid.ULID
-	Expression *string
-	UserID     *uuid.UUID
+	EventID        *ulid.ULID
+	Expression     *string
+	UserID         *uuid.UUID
+	CancellationID *ulid.ULID
 }
 
 type ResumeRequest struct {

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -54,6 +54,8 @@ type Function struct {
 
 	Priority *Priority `json:"priority,omitempty"`
 
+	TTL *time.Duration `json:"ttl"`
+
 	// ConcurrencyLimits allows limiting the concurrency of running functions, optionally constrained
 	// by individual concurrency keys.
 	//


### PR DESCRIPTION
While we already have naive mass cancellation, this PR introduces greater control over backlog management and cancellation.

WIth this PR users can cancel functions in the backlog with the following data:

```
struct {
	From       *time.Time `json:"from"`
	To         time.Time  `json:"to"`
	If         *string    `json:"if,omitempty"`
}
```

This lets you cancel runs started between a given time range, and optionally cancel runs that have an event which matches an expression (to cancel a part of the backlog based off of data).

In this PR, we implement:

- [x] A state store interface and implementation, storing cancellations in the backing state store
- [x] A redis interface to query for cancellations at a specific point in time for a fn
- [x] A checker, which conditionally checks cancellation amongst runs + event data
- [x] The executor implementation

A followup PR for the dev server will include sqlite migrations and SQL storage to implement the APIs defined here.

## Type of change (choose one)

- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
