### PR TITLE
Remove CEL Compile() in favor of manual non-caching Validate call

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1479,6 +1479,10 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, gen state.Ge
 	// in the expression.
 	data := map[string]any{}
 	if opts.If != nil {
+		if err := expressions.Validate(ctx, *opts.If); err != nil {
+			return execError{err, true}
+		}
+
 		expr, err := e.newExpressionEvaluator(ctx, *opts.If)
 		if err != nil {
 			return execError{err, true}

--- a/pkg/expressions/expressions_test.go
+++ b/pkg/expressions/expressions_test.go
@@ -998,8 +998,16 @@ func TestEvaluateExpression(t *testing.T) {
 		},
 	}
 
-	for n, test := range tests {
+	for n, item := range tests {
+		test := item
 		t.Run(test.expr, func(t *testing.T) {
+			for i := 0; i <= 100; i++ {
+				// Test thread safety of evaluate and Validate()
+				go func() {
+					Evaluate(context.Background(), test.expr, test.data)
+				}()
+			}
+
 			actual, earliest, err := Evaluate(context.Background(), test.expr, test.data)
 
 			require.Equal(t, err == nil, !test.shouldErr, "unexpected err result '%v' for '%s'", err, test.expr)

--- a/pkg/expressions/expressions_test.go
+++ b/pkg/expressions/expressions_test.go
@@ -1002,9 +1002,11 @@ func TestEvaluateExpression(t *testing.T) {
 		test := item
 		t.Run(test.expr, func(t *testing.T) {
 			for i := 0; i <= 100; i++ {
-				// Test thread safety of evaluate and Validate()
 				go func() {
-					Evaluate(context.Background(), test.expr, test.data)
+					// Test thread safety of evaluate and Validate().  We don't care about the results,
+					// as these are checked below.
+					_, _, _ = Evaluate(context.Background(), test.expr, test.data)
+					_ = Validate(context.Background(), test.expr)
 				}()
 			}
 

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -227,7 +227,7 @@ func (f Function) Validate(ctx context.Context) error {
 	// Validate cancellation expressions
 	for _, c := range f.Cancel {
 		if c.If != nil {
-			if _, exprErr := expressions.NewExpressionEvaluator(ctx, *c.If); exprErr != nil {
+			if exprErr := expressions.Validate(ctx, *c.If); exprErr != nil {
 				err = multierror.Append(err, fmt.Errorf("Cancellation expression is invalid: %s", exprErr))
 			}
 		}
@@ -244,7 +244,7 @@ func (f Function) Validate(ctx context.Context) error {
 		}
 		if f.Debounce.Key != nil {
 			// Ensure the expression is valid if present.
-			if _, exprErr := expressions.NewExpressionEvaluator(ctx, *f.Debounce.Key); exprErr != nil {
+			if exprErr := expressions.Validate(ctx, *f.Debounce.Key); exprErr != nil {
 				err = multierror.Append(err, fmt.Errorf("Debounce expression is invalid: %s", exprErr))
 			}
 		}
@@ -267,7 +267,7 @@ func (f Function) Validate(ctx context.Context) error {
 
 	// Validate rate limit expression
 	if f.RateLimit != nil && f.RateLimit.Key != nil {
-		if _, exprErr := expressions.NewExpressionEvaluator(ctx, *f.RateLimit.Key); exprErr != nil {
+		if exprErr := expressions.Validate(ctx, *f.RateLimit.Key); exprErr != nil {
 			err = multierror.Append(err, fmt.Errorf("Rate limit expression is invalid: %s", exprErr))
 		}
 	}
@@ -281,8 +281,14 @@ func (f Function) RunPriorityFactor(ctx context.Context, event map[string]any) (
 		return 0, nil
 	}
 
+	// Validate the expression first.
+	if err := expressions.Validate(ctx, *f.Priority.Run); err != nil {
+		return 0, fmt.Errorf("Priority.Run expression is invalid: %s", err)
+	}
+
 	expr, err := expressions.NewExpressionEvaluator(ctx, *f.Priority.Run)
 	if err != nil {
+		// This should never happen.
 		return 0, fmt.Errorf("Priority.Run expression is invalid: %s", err)
 	}
 

--- a/pkg/inngest/trigger.go
+++ b/pkg/inngest/trigger.go
@@ -66,7 +66,7 @@ func (e EventTrigger) Validate(ctx context.Context) error {
 	}
 
 	if e.Expression != nil {
-		if _, err := expressions.NewExpressionEvaluator(ctx, *e.Expression); err != nil {
+		if err := expressions.Validate(ctx, *e.Expression); err != nil {
 			return fmt.Errorf("invalid trigger expression on '%s': %w", e.Event, err)
 		}
 	}


### PR DESCRIPTION
Fixes a CEL-go non-thread safe issue: https://github.com/google/cel-go/issues/881

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
