### PR TITLE
Add handler to check idempotent pause creations

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1420,6 +1420,16 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, gen state.
 		Expression:  &strExpr,
 		DataKey:     gen.ID,
 	})
+	if err == state.ErrPauseAlreadyExists {
+		if e.log != nil {
+			e.log.Warn().
+				Str("pause_id", pauseID.String()).
+				Str("run_id", item.Identifier.RunID.String()).
+				Str("workflow_id", item.Identifier.WorkflowID.String()).
+				Msg("created duplicate pause")
+		}
+		return nil
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We shouldn't be returning an error here;  pauses are deterministically created.


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
