### PR TITLE
INN 2582 Add banners for apps launch

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/Apps.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/Apps.tsx
@@ -66,7 +66,7 @@ export function Apps({ isArchived = false }: Props) {
           );
         })}
 
-        {latestUnattachedSyncTime && (
+        {latestUnattachedSyncTime && !isArchived && (
           <UnattachedSyncsCard envSlug={env.slug} latestSyncTime={latestUnattachedSyncTime} />
         )}
 

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/page.tsx
@@ -1,14 +1,21 @@
 'use client';
 
 import { Squares2X2Icon } from '@heroicons/react/20/solid';
+import { Link } from '@inngest/components/Link';
+import { useLocalStorage } from 'react-use';
 
 import { useEnvironment } from '@/app/(dashboard)/env/[environmentSlug]/environment-context';
+import { Banner } from '@/components/Banner';
 import Header, { type HeaderLink } from '@/components/Header/Header';
 import { useBooleanSearchParam } from '@/utils/useSearchParam';
 import { Apps } from './Apps';
 
 export default function Page() {
   const env = useEnvironment();
+  const [isAppsBannerVisible, setIsAppsBannerVisible] = useLocalStorage(
+    'AppsLaunchBannerVisible',
+    true
+  );
 
   const [isArchived] = useBooleanSearchParam('archived');
 
@@ -32,7 +39,26 @@ export default function Page() {
         links={navLinks}
         title="Apps"
       />
-      <div className="h-full overflow-y-auto bg-slate-100">
+      <div className="relative h-full overflow-y-auto bg-slate-100">
+        {isAppsBannerVisible && (
+          <Banner
+            kind="info"
+            onDismiss={() => {
+              setIsAppsBannerVisible(false);
+            }}
+            className="absolute"
+          >
+            <p className="pr-2">
+              Inngest deploys have been renamed to “<b>Syncs</b>”. All of your syncs can be found
+              within your apps.{' '}
+            </p>
+            {/* To do: wire this to the docs */}
+            {/* <Link internalNavigation={false} href="">
+            Learn More
+          </Link> */}
+          </Banner>
+        )}
+
         <Apps isArchived={isArchived} />
       </div>
     </>

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/deploys/layout.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/deploys/layout.tsx
@@ -1,5 +1,7 @@
 import { RocketLaunchIcon } from '@heroicons/react/20/solid';
 
+import { Banner } from '@/components/Banner';
+import { getBooleanFlag } from '@/components/FeatureFlags/ServerFeatureFlag';
 import Header from '@/components/Header/Header';
 import DeployButton from './DeployButton';
 import DeployList from './DeployList';
@@ -9,6 +11,7 @@ type DeploysLayoutProps = {
 };
 
 export default async function DeploysLayout({ children }: DeploysLayoutProps) {
+  const isAppsEnabled = await getBooleanFlag('apps-page');
   return (
     <>
       <Header
@@ -16,6 +19,18 @@ export default async function DeploysLayout({ children }: DeploysLayoutProps) {
         icon={<RocketLaunchIcon className="h-3.5 w-3.5 text-white" />}
         action={<DeployButton />}
       />
+      {isAppsEnabled && (
+        <Banner kind="error">
+          <p className="pr-2 text-red-800">
+            The deploys page is getting deprecated. We&apos;ve moved all this information and
+            functionality over to the <b>Apps</b> tab.
+          </p>
+          {/* To do: wire this to the docs */}
+          {/* <Link internalNavigation={false} href="">
+            Learn More
+          </Link> */}
+        </Banner>
+      )}
       <div className="flex flex-grow overflow-hidden bg-slate-50">
         <DeployList />
         {children}

--- a/ui/apps/dashboard/src/components/Banner/Banner.tsx
+++ b/ui/apps/dashboard/src/components/Banner/Banner.tsx
@@ -1,0 +1,44 @@
+import ExclamationTriangleIcon from '@heroicons/react/24/outline/ExclamationTriangleIcon';
+import InformationCircleIcon from '@heroicons/react/24/outline/InformationCircleIcon';
+import XMarkIcon from '@heroicons/react/24/outline/XMarkIcon';
+import { Button } from '@inngest/components/Button';
+import { classNames } from '@inngest/components/utils/classNames';
+
+export function Banner({
+  children,
+  className,
+  onDismiss,
+  kind,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  onDismiss?: () => void;
+  kind?: 'info' | 'error';
+}) {
+  let Icon: React.ReactNode;
+  let color: string = '';
+  if (kind == 'info') {
+    Icon = <InformationCircleIcon className="h-6 w-6 text-sky-500" />;
+    color = 'border-sky-500 bg-sky-50';
+  } else if (kind == 'error') {
+    Icon = <ExclamationTriangleIcon className="h-6 w-6 text-red-800" />;
+    color = 'border-red-500 bg-red-50';
+  }
+
+  return (
+    <div className={classNames(className, color, 'flex w-full justify-between border-y px-8 py-2')}>
+      <div className="flex items-center gap-1 text-sm">
+        {Icon}
+        {children}
+      </div>
+      {onDismiss && (
+        <Button
+          size="small"
+          appearance="text"
+          btnAction={onDismiss}
+          icon={<XMarkIcon className="h-5 w-5" />}
+        />
+      )}
+    </div>
+  );
+}

--- a/ui/apps/dashboard/src/components/Banner/index.ts
+++ b/ui/apps/dashboard/src/components/Banner/index.ts
@@ -1,0 +1,1 @@
+export { Banner } from './Banner';


### PR DESCRIPTION
## Description
- Add banner component
- Add dismissible banner for Apps page, using local storage
- Add banner for Deploys page, hidden behind the apps flag
- Bonus: hide unattached syncs in the archived tab

<img width="1512" alt="Screenshot 2024-01-12 at 16 57 55" src="https://github.com/inngest/inngest/assets/16758464/adcae9a4-0c8c-4e4f-b9ad-409e3717b5e0">

<img width="1512" alt="Screenshot 2024-01-12 at 16 44 01" src="https://github.com/inngest/inngest/assets/16758464/b043cac0-047e-423a-a387-53530ca723e6">


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
