### PR TITLE
Use version from `package.json` instead of an env variable in NPM `postinstall` script

### DIFF
--- a/npm/postinstall.ts
+++ b/npm/postinstall.ts
@@ -5,6 +5,7 @@ import fetch, { Response } from "node-fetch";
 import path from "path";
 import tar from "tar";
 import { URL } from "url";
+import packageJson from "./package.json";
 
 const rootDebug = Debug("inngest:cli");
 
@@ -52,12 +53,8 @@ async function getBinaryUrl(): Promise<URL> {
 
   debug({ arch, platform });
 
-  let version = process.env.npm_package_version?.trim();
-  debug("npm_package_version:", version);
-
-  if (!version) {
-    throw new Error("Could not find package version to install binary");
-  }
+  let version = packageJson.version.trim();
+  debug("package.json version:", version);
 
   const targetUrl = new URL(
     `https://cli.inngest.com/artifact/v${version}/inngest_${version}_${platform.platform}_${arch}${platform.extension}`

--- a/npm/tsconfig.json
+++ b/npm/tsconfig.json
@@ -7,6 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "removeComments": true
+    "removeComments": true,
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
## Description

I was trying to get `inngest-cli` working with `bun x`, and after some debugging I encountered this error:
![CleanShot 2024-01-13 at 15 28 16](https://github.com/inngest/inngest/assets/16190582/9986624b-a63f-4070-9d8c-c8408d3a3a42)

Although not an issue with `inngest-cli` directly, I looked at the source code of `postinstall.ts`, and found out that [it was using](https://github.com/inngest/inngest/blob/90d09775242d9a759d7a8854be7ab6d38056d496/npm/postinstall.ts#L55C29-L55C48) `npm_package_version` env variable to get the package version.

NPM is [already ditching this variable](https://github.com/npm/rfcs/blob/main/implemented/0021-reduce-lifecycle-script-environment.md#detailed-explanation), but it continues to work with NPM due to compatibility reasons. Bun, however, doesn't set this env variable during the execution of the postinstall script, making `inngest-cli` unable to download the correct binary.

This PR implements a more robust package version fetching — directly from the `package.json`. 

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.