### PR TITLE
Hotfix: Replay time range input issues

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
@@ -183,7 +183,7 @@ export default function NewReplayModal({ functionSlug, isOpen, onClose }: NewRep
 
   return (
     <Modal
-      className="max-w-2xl p-0"
+      className="max-w-3xl p-0"
       title={
         <span className="inline-flex items-center gap-1">
           <IconReplay className="h-6 w-6" />
@@ -217,7 +217,7 @@ export default function NewReplayModal({ functionSlug, isOpen, onClose }: NewRep
           <div className="flex justify-between gap-7 px-6 py-4">
             <div className="space-y-0.5">
               <span className="text-sm font-semibold text-slate-800">Time Range</span>
-              <p className="text-xs text-slate-500">A time range to replay function runs from.</p>
+              <p className="text-xs text-slate-500">Select a specific range of function runs.</p>
             </div>
             <TimeRangeInput onChange={setTimeRange} />
           </div>

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
@@ -15,6 +15,7 @@ import { useMutation } from 'urql';
 import { useEnvironment } from '@/app/(dashboard)/env/[environmentSlug]/environment-context';
 import { type TimeRange } from '@/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/TimeRangeFilter';
 import Input from '@/components/Forms/Input';
+import Placeholder from '@/components/Placeholder';
 import { TimeRangeInput } from '@/components/TimeRangeInput';
 import { graphql } from '@/gql';
 import { FunctionRunStatus } from '@/gql/graphql';
@@ -245,10 +246,14 @@ export default function NewReplayModal({ functionSlug, isOpen, onClose }: NewRep
                   {label}
                 </ToggleGroup.Item>
                 <p aria-label={`Number of ${label} runs`} className="text-sm text-slate-500">
-                  {count.toLocaleString(undefined, {
-                    notation: 'compact',
-                    compactDisplay: 'short',
-                  })}{' '}
+                  {isLoading ? (
+                    <Placeholder className="top-px inline-flex h-3 w-3 bg-slate-200" />
+                  ) : (
+                    count.toLocaleString(undefined, {
+                      notation: 'compact',
+                      compactDisplay: 'short',
+                    })
+                  )}{' '}
                   Runs
                 </p>
               </div>
@@ -269,10 +274,14 @@ export default function NewReplayModal({ functionSlug, isOpen, onClose }: NewRep
             <p className="inline-flex gap-1.5 text-slate-500">
               Total runs to be replayed:{' '}
               <span className="font-medium text-slate-800">
-                {selectedRunsCount.toLocaleString(undefined, {
-                  notation: 'compact',
-                  compactDisplay: 'short',
-                })}
+                {isLoading ? (
+                  <Placeholder className="top-px inline-flex h-4 w-4 bg-slate-200" />
+                ) : (
+                  selectedRunsCount.toLocaleString(undefined, {
+                    notation: 'compact',
+                    compactDisplay: 'short',
+                  })
+                )}
               </span>
             </p>
           </div>

--- a/ui/apps/dashboard/src/components/TimeRangeInput/TimeInput.tsx
+++ b/ui/apps/dashboard/src/components/TimeRangeInput/TimeInput.tsx
@@ -193,7 +193,7 @@ export function TimeInput({ onChange, placeholder, required }: Props) {
                   '3 days ago',
                   '15:30:24',
                   'Jan 14',
-                  '2020-01-01T10:00:00Z',
+                  '2024-01-01T10:00:00Z',
                 ].map((example) => (
                   <button
                     className="h-5 rounded bg-slate-200 px-1.5 text-xs text-black hover:bg-slate-300"

--- a/ui/apps/dashboard/src/components/TimeRangeInput/TimeInput.tsx
+++ b/ui/apps/dashboard/src/components/TimeRangeInput/TimeInput.tsx
@@ -79,11 +79,15 @@ function reducer(state: State, action: Action): State {
       };
     case 'stopped_typing':
       const parsedDateTime = chrono.parseDate(state.inputString);
-      return {
-        ...state,
-        suggestedDateTime: undefined,
-        status: 'idle',
-      };
+      // Chrono's types are wrong - parseData can return undefined
+      // eslint-disable-next-line
+      if (!parsedDateTime) {
+        return {
+          ...state,
+          suggestedDateTime: undefined,
+          status: 'idle',
+        };
+      }
       return {
         ...state,
         suggestedDateTime: parsedDateTime,

--- a/ui/apps/dashboard/src/components/TimeRangeInput/TimeRangeInput.tsx
+++ b/ui/apps/dashboard/src/components/TimeRangeInput/TimeRangeInput.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import cn from '@/utils/cn';
 import { TimeInput } from './TimeInput';
 
 type TimeRange = {
@@ -24,7 +25,7 @@ export function TimeRangeInput({ onChange }: Props) {
     setStartDateTimeError(undefined);
     setEndDateTimeError(undefined);
     if (endDateTime && newStartDateTime > endDateTime) {
-      setStartDateTimeError('Start time must be before end time.');
+      setStartDateTimeError('Start time must be before end time');
       return;
     }
 
@@ -38,7 +39,7 @@ export function TimeRangeInput({ onChange }: Props) {
     setStartDateTimeError(undefined);
     setEndDateTimeError(undefined);
     if (startDateTime && newEndDateTime < startDateTime) {
-      setEndDateTimeError('End time must be after start time.');
+      setEndDateTimeError('End time must be after start time');
       return;
     }
 
@@ -49,13 +50,35 @@ export function TimeRangeInput({ onChange }: Props) {
 
   return (
     <div className="space-y-1">
-      <div className="flex items-center gap-2">
-        <TimeInput onChange={onStartDateTimeChange} placeholder="2 hours ago" required />
-        <span className="text-sm font-medium text-slate-400">to</span>
-        <TimeInput onChange={onEndDateTimeChange} placeholder="now" required />
+      <div className="flex items-start gap-2">
+        <div className="min-w-[190px]">
+          <TimeInput onChange={onStartDateTimeChange} placeholder="start time" required />
+          <p
+            className={cn(
+              'mt-1 pl-2 text-xs',
+              startDateTimeError ? 'text-red-500' : 'text-slate-400'
+            )}
+          >
+            {startDateTimeError
+              ? startDateTimeError
+              : startDateTime
+              ? startDateTime.toISOString()
+              : '-'}
+          </p>
+        </div>
+        <span className="mt-1.5 text-sm font-medium text-slate-400">to</span>
+        <div className="min-w-[190px]">
+          <TimeInput onChange={onEndDateTimeChange} placeholder="end time" required />
+          <p
+            className={cn(
+              'mt-1 pl-2 text-xs',
+              endDateTimeError ? 'text-red-500' : 'text-slate-400'
+            )}
+          >
+            {endDateTimeError ? endDateTimeError : endDateTime ? endDateTime.toISOString() : '-'}
+          </p>
+        </div>
       </div>
-      {startDateTimeError && <p className="text-sm text-red-500">{startDateTimeError}</p>}
-      {endDateTimeError && <p className="text-right text-sm text-red-500">{endDateTimeError}</p>}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Fix issue caused by regression. Add other UX improvements to make time range selection more obvious.

Always show the selected time, even if empty. Show errors aligned under inputs.
<img width="747" alt="Screen Shot 2024-01-15 at 5 24 11 PM" src="https://github.com/inngest/inngest/assets/1509457/c0667444-842b-4b94-9d8a-1bd41da30196">

Change placeholder to now look like something is input (previous placeholders of "now", for example, looked too similar to actual text, it wasn't obvious that that wasn't what I wrote in the box)
<img width="749" alt="Screen Shot 2024-01-15 at 5 27 45 PM" src="https://github.com/inngest/inngest/assets/1509457/877c0aa0-ada3-417f-95d0-d144658d4860">

<img width="563" alt="Screen Shot 2024-01-15 at 5 09 08 PM" src="https://github.com/inngest/inngest/assets/1509457/c46f8098-c1ac-4a56-a7b3-8c417e5f143b">

There are other UX improvements I'd like us to improve, but we need to get out the bug fix asap.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
