### PR TITLE
Remove static version from state.Identifier

### DIFF
--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -138,9 +138,6 @@ type HandleSendingEvent func(context.Context, event.Event, queue.Item) error
 // ScheduleRequest represents all data necessary to schedule a new function.
 type ScheduleRequest struct {
 	Function inngest.Function
-	// StaticVersion represents the ability to pin this function to a specific version,
-	// disabling live migrations.
-	StaticVersion bool `json:"s,omitempty"`
 	// At allows functions to be scheduled in the future.
 	At *time.Time
 	// AccountID is the account that the request belongs to.

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -281,7 +281,6 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	id := state.Identifier{
 		WorkflowID:      req.Function.ID,
 		WorkflowVersion: req.Function.FunctionVersion,
-		StaticVersion:   req.StaticVersion,
 		RunID:           runID,
 		BatchID:         req.BatchID,
 		EventID:         req.Events[0].GetInternalID(),

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -43,12 +43,6 @@ type Identifier struct {
 	// WorkflowVersion tracks the version of the function that was live
 	// at the time of the trigger.
 	WorkflowVersion int `json:"wv"`
-	// StaticVersion indicates whether the workflow is pinned to the
-	// given function definition over the life of the function.  If functions
-	// are deployed to their own URLs, this ensures that the endpoint we hit
-	// for the function (and therefore code) stays the same.  Note:  this is only
-	// important when we people use separate endpoints per function version.
-	StaticVersion bool `json:"s,omitempty"`
 	// EventID tracks the event ID that started the function.
 	EventID ulid.ULID `json:"evtID"`
 	// BatchID tracks the batch ID for the function, if the function uses batching.
@@ -280,6 +274,7 @@ type StateLoader interface {
 
 // FunctionLoader loads function definitions based off of an identifier.
 type FunctionLoader interface {
+	// LoadFunction should always return the latest live version of a function
 	LoadFunction(ctx context.Context, identifier Identifier) (*inngest.Function, error)
 }
 


### PR DESCRIPTION
We're always upgrading to the latest live version of a function.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
