### PR TITLE
Remove eg.Go within processing partitions

### DIFF
--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/inngest/inngest/pkg/backoff"
 	"github.com/inngest/inngest/pkg/consts"
-	"github.com/inngest/inngest/pkg/execution/concurrency"
 	osqueue "github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/logger"
@@ -272,12 +271,6 @@ func WithAccountConcurrencyKeyGenerator(f AccountConcurrencyKeyGenerator) func(q
 	}
 }
 
-func WithConcurrencyService(s concurrency.ConcurrencyService) func(q *queue) {
-	return func(q *queue) {
-		q.concurrencyService = s
-	}
-}
-
 func WithBackoffFunc(f backoff.BackoffFunc) func(q *queue) {
 	return func(q *queue) {
 		q.backoffFunc = f
@@ -348,10 +341,6 @@ type queue struct {
 	accountConcurrencyGen   AccountConcurrencyKeyGenerator
 	partitionConcurrencyGen PartitionConcurrencyKeyGenerator
 	customConcurrencyGen    QueueItemConcurrencyKeyGenerator
-	// concurrencyService is an external concurrency limiter used when pulling
-	// jobs off of the queue.  It is only invoked for jobs with a non-zero function ID,
-	// eg. for jobs that run a function.
-	concurrencyService concurrency.ConcurrencyService
 
 	// idempotencyTTL is the default or static idempotency duration apply to jobs,
 	// if idempotencyTTLFunc is not defined.


### PR DESCRIPTION
Processing items in a partition is helpful for speed but removes the ability to properly order execution in single-concurrency queues.



## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
