### PR TITLE
Fix not using UTC everwhere in the Dev Server backend

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,11 +1,18 @@
 package main
 
 import (
+	"os"
+	"time"
 	_ "time/tzdata" // bundles timezone data, required for Windows without Go
 
 	"github.com/inngest/inngest/cmd/commands"
 )
 
 func main() {
+	// Ensure that we use UTC everywhere. This is a fix for users getting
+	// invalid timestamps due to their specific `/etc/localtime` files.
+	os.Setenv("TZ", "UTC")
+	time.Local = time.UTC
+
 	commands.Execute()
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -11,7 +11,9 @@ import (
 func main() {
 	// Ensure that we use UTC everywhere. This is a fix for users getting
 	// invalid timestamps due to their specific `/etc/localtime` files.
-	os.Setenv("TZ", "UTC")
+	if err := os.Setenv("TZ", "UTC"); err != nil {
+		panic(err)
+	}
 	time.Local = time.UTC
 
 	commands.Execute()


### PR DESCRIPTION
## Description

Go defaults to users' `/etc/localtime` files if the timezone isn't explicitly set. Since that can lead to invalid datetime strings, we want to force UTC everywhere

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
