### PR TITLE
Support domain param and editing prefix for create webhook intent

### DIFF
--- a/ui/apps/dashboard/src/app/intent/create-webhook/page.tsx
+++ b/ui/apps/dashboard/src/app/intent/create-webhook/page.tsx
@@ -93,7 +93,7 @@ export default function Page() {
     createWebhook({
       input: {
         workspaceID: productionEnv.id,
-        name: name || '',
+        name: displayName,
         source: 'webhook',
         metadata: {
           transform,


### PR DESCRIPTION
## Description

Enable the option of passing `domain` instead of `name` for the Svix create webhook integration.

INN-2612

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
