### PR TITLE
Skip replay query when no time input

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
@@ -19,7 +19,7 @@ import Placeholder from '@/components/Placeholder';
 import { TimeRangeInput } from '@/components/TimeRangeInput';
 import { graphql } from '@/gql';
 import { FunctionRunStatus } from '@/gql/graphql';
-import { useGraphQLQuery } from '@/utils/useGraphQLQuery';
+import { useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
 
 const GetFunctionEndedRunsCountDocument = graphql(`
   query GetFunctionEndedRunsCount(
@@ -109,7 +109,7 @@ export default function NewReplayModal({ functionSlug, isOpen, onClose }: NewRep
     FunctionRunStatus.Failed,
   ]);
   const environment = useEnvironment();
-  const { data, isLoading, error } = useGraphQLQuery({
+  const { data, isLoading, error } = useSkippableGraphQLQuery({
     query: GetFunctionEndedRunsCountDocument,
     variables: {
       environmentID: environment.id,
@@ -117,6 +117,7 @@ export default function NewReplayModal({ functionSlug, isOpen, onClose }: NewRep
       timeRangeStart: timeRange?.start ? timeRange.start.toISOString() : '',
       timeRangeEnd: timeRange?.end ? timeRange.end.toISOString() : '',
     },
+    skip: !timeRange,
   });
   const [{ fetching: isCreatingFunctionReplay }, createFunctionReplayMutation] = useMutation(
     CreateFunctionReplayDocument

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
@@ -109,13 +109,14 @@ export default function NewReplayModal({ functionSlug, isOpen, onClose }: NewRep
     FunctionRunStatus.Failed,
   ]);
   const environment = useEnvironment();
+
   const { data, isLoading, error } = useSkippableGraphQLQuery({
     query: GetFunctionEndedRunsCountDocument,
     variables: {
       environmentID: environment.id,
       functionSlug,
-      timeRangeStart: timeRange?.start ? timeRange.start.toISOString() : '',
-      timeRangeEnd: timeRange?.end ? timeRange.end.toISOString() : '',
+      timeRangeStart: timeRange ? timeRange.start.toISOString() : '',
+      timeRangeEnd: timeRange ? timeRange.end.toISOString() : '',
     },
     skip: !timeRange,
   });

--- a/ui/apps/dashboard/src/components/TimeRangeInput/TimeInput.tsx
+++ b/ui/apps/dashboard/src/components/TimeRangeInput/TimeInput.tsx
@@ -78,9 +78,9 @@ function reducer(state: State, action: Action): State {
         status: 'typing',
       };
     case 'stopped_typing':
-      const parsedDateTime = chrono.parseDate(state.inputString);
       // Chrono's types are wrong - parseData can return undefined
-      // eslint-disable-next-line
+      const parsedDateTime = chrono.parseDate(state.inputString) as unknown as Date | null;
+
       if (!parsedDateTime) {
         return {
           ...state,


### PR DESCRIPTION
## Description

Skip replay query when no time input. Also add a type cast to make the `node-chrono` type bug a little clearer

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
