### PR TITLE
Keep last partition lease time when enqueueing

### DIFF
--- a/pkg/execution/state/redis_state/lua/queue/enqueue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/enqueue.lua
@@ -59,7 +59,9 @@ if currentScore == false or tonumber(currentScore) > partitionScore then
 	-- Get the partition item, so that we can keep the last lease score.
 	local existing = get_partition_item(partitionKey, workflowID)
 	if existing ~= nil then
-		partitionItem.last = existing.last
+		local decoded = cjson.decode(partitionItem)
+		decoded.last = existing.last
+		partitionItem = cjson.encode(decoded)
 	end
 
 	-- Update the partition item too


### PR DESCRIPTION
When enqueueing, we update the partition item if the new job < the earliest job in the queue.  We should keep the last lease time on the partition item.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
