### PR TITLE
Normalize walltime to now if AtMS is prior to now

### DIFF
--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -675,7 +675,14 @@ func (q *queue) EnqueueItem(ctx context.Context, i QueueItem, at time.Time) (Que
 		return i, ErrPriorityTooHigh
 	}
 
-	i.WallTimeMS = at.UnixMilli()
+	if i.WallTimeMS == 0 {
+		i.WallTimeMS = at.UnixMilli()
+	}
+
+	if at.Before(time.Now()) {
+		// Normalize to now to minimize latency.
+		i.WallTimeMS = time.Now().UnixMilli()
+	}
 
 	// Add the At timestamp, if not included.
 	if i.AtMS == 0 {

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -144,7 +144,8 @@ func (q *queue) Enqueue(ctx context.Context, item osqueue.Item, at time.Time) er
 		Data:        item,
 		// Only use the queue name if provided by queueKindMapping.
 		// Otherwise, this defaults to WorkflowID.
-		QueueName: queueName,
+		QueueName:  queueName,
+		WallTimeMS: at.UnixMilli(),
 	}
 
 	span.SetAttributes(

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -220,7 +220,7 @@ func TestQueueEnqueueItem(t *testing.T) {
 		item, err := q.EnqueueItem(ctx, QueueItem{}, start)
 		require.NoError(t, err)
 		require.NotEqual(t, item.ID, ulid.ULID{})
-		require.Equal(t, item.WallTimeMS, start.UnixMilli())
+		require.Equal(t, time.UnixMilli(item.WallTimeMS).Truncate(time.Second), start)
 
 		// Ensure that our data is set up correctly.
 		found := getQueueItem(t, r, item.ID)


### PR DESCRIPTION
And set this in EnqueueItem before priority factor fudging


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
