### PR TITLE
Don't crash apps pages on polling errors

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/Apps.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/Apps.tsx
@@ -22,6 +22,9 @@ export function Apps({ isArchived = false }: Props) {
   if (res.status === 'initial_failed') {
     throw res.error;
   }
+  if (res.status === 'refetch_failed') {
+    console.error(res.error);
+  }
   if (res.status === 'initial_loading') {
     return (
       <div className="mb-4 mt-16 flex items-center justify-center">

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/Apps.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/Apps.tsx
@@ -19,13 +19,13 @@ export function Apps({ isArchived = false }: Props) {
   const router = useRouter();
 
   const res = useApps({ envID: env.id, isArchived });
-  if (res.status === 'initial_failed') {
-    throw res.error;
-  }
-  if (res.status === 'refetch_failed') {
+  if (res.error) {
+    if (!res.data) {
+      throw res.error;
+    }
     console.error(res.error);
   }
-  if (res.status === 'initial_loading') {
+  if (res.isLoading && !res.data) {
     return (
       <div className="mb-4 mt-16 flex items-center justify-center">
         <div className="w-full max-w-[1200px]">

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/Apps.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/Apps.tsx
@@ -19,10 +19,10 @@ export function Apps({ isArchived = false }: Props) {
   const router = useRouter();
 
   const res = useApps({ envID: env.id, isArchived });
-  if (res.error) {
+  if (res.status === 'initial_failed') {
     throw res.error;
   }
-  if (res.isLoading && !res.data) {
+  if (res.status === 'initial_loading') {
     return (
       <div className="mb-4 mt-16 flex items-center justify-center">
         <div className="w-full max-w-[1200px]">

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/layout.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/layout.tsx
@@ -49,7 +49,6 @@ export default function Layout({ children, params: { externalID } }: Props) {
   let action;
   if (res.data.latestSync?.url) {
     const canResync = res.data.latestSync.platform !== 'vercel';
-    console.log(res.data.latestSync.platform);
     if (canResync) {
       action = <ResyncButton latestSyncUrl={res.data.latestSync.url} />;
     }

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/page.tsx
@@ -22,10 +22,13 @@ export default function Page({ params: { environmentSlug, externalID } }: Props)
     envID: env.id,
     externalAppID: externalID,
   });
-  if (appRes.status === 'initial_failed') {
-    throw appRes.error;
+  if (appRes.error) {
+    if (!appRes.data) {
+      throw appRes.error;
+    }
+    console.error(appRes.error);
   }
-  if (appRes.status === 'initial_loading') {
+  if (appRes.isLoading && !appRes.data) {
     return (
       <div className="h-full overflow-y-auto">
         <div className="mx-auto w-full max-w-[1200px] py-4">

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/page.tsx
@@ -22,10 +22,10 @@ export default function Page({ params: { environmentSlug, externalID } }: Props)
     envID: env.id,
     externalAppID: externalID,
   });
-  if (appRes.error) {
+  if (appRes.status === 'initial_failed') {
     throw appRes.error;
   }
-  if (appRes.isLoading && !appRes.data) {
+  if (appRes.status === 'initial_loading') {
     return (
       <div className="h-full overflow-y-auto">
         <div className="mx-auto w-full max-w-[1200px] py-4">

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/Sync/Sync.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/Sync/Sync.tsx
@@ -18,7 +18,7 @@ export function Sync({ externalAppID, syncID }: Props) {
   const env = useEnvironment();
 
   const syncRes = useSync({ envID: env.id, externalAppID, syncID });
-  if (syncRes.error) {
+  if (syncRes.status === 'initial_failed') {
     if (syncRes.error.message.includes('no rows')) {
       return (
         <div className="h-full w-full overflow-y-auto">
@@ -33,7 +33,7 @@ export function Sync({ externalAppID, syncID }: Props) {
     }
     throw syncRes.error;
   }
-  if (syncRes.isLoading) {
+  if (syncRes.status === 'initial_loading') {
     return (
       <div className="h-full w-full overflow-y-auto">
         <div className="mx-auto w-full max-w-[1200px] p-4">

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/Sync/Sync.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/Sync/Sync.tsx
@@ -18,7 +18,7 @@ export function Sync({ externalAppID, syncID }: Props) {
   const env = useEnvironment();
 
   const syncRes = useSync({ envID: env.id, externalAppID, syncID });
-  if (syncRes.status === 'initial_failed') {
+  if (syncRes.error) {
     if (syncRes.error.message.includes('no rows')) {
       return (
         <div className="h-full w-full overflow-y-auto">
@@ -33,7 +33,7 @@ export function Sync({ externalAppID, syncID }: Props) {
     }
     throw syncRes.error;
   }
-  if (syncRes.status === 'initial_loading') {
+  if (syncRes.isLoading) {
     return (
       <div className="h-full w-full overflow-y-auto">
         <div className="mx-auto w-full max-w-[1200px] p-4">

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/page.tsx
@@ -18,10 +18,10 @@ export default function Page({ params }: Props) {
   const [selectedSyncID, setSelectedSyncID] = useSearchParam('sync-id');
 
   const syncsRes = useSyncs({ envID: env.id, externalAppID });
-  if (syncsRes.error) {
+  if (syncsRes.status === 'initial_failed') {
     throw syncsRes.error;
   }
-  if (syncsRes.isLoading) {
+  if (syncsRes.status === 'initial_loading') {
     return (
       <div className="flex h-full min-h-0">
         <SyncList onClick={setSelectedSyncID} loading />

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/page.tsx
@@ -18,10 +18,10 @@ export default function Page({ params }: Props) {
   const [selectedSyncID, setSelectedSyncID] = useSearchParam('sync-id');
 
   const syncsRes = useSyncs({ envID: env.id, externalAppID });
-  if (syncsRes.status === 'initial_failed') {
+  if (syncsRes.error) {
     throw syncsRes.error;
   }
-  if (syncsRes.status === 'initial_loading') {
+  if (syncsRes.isLoading) {
     return (
       <div className="flex h-full min-h-0">
         <SyncList onClick={setSelectedSyncID} loading />

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/useApp.ts
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/useApp.ts
@@ -1,7 +1,7 @@
 import type { Function } from '@inngest/components/types/function';
 
 import { graphql } from '@/gql';
-import { useGraphQLQuery } from '@/utils/useGraphQLQuery';
+import { useGraphQLQuery_TEMPORARY } from '@/utils/useGraphQLQuery';
 
 const query = graphql(`
   query App($envID: ID!, $externalAppID: String!) {
@@ -47,7 +47,7 @@ const query = graphql(`
 `);
 
 export function useApp({ envID, externalAppID }: { envID: string; externalAppID: string }) {
-  const res = useGraphQLQuery({
+  const res = useGraphQLQuery_TEMPORARY({
     pollIntervalInMilliseconds: 10_000,
     query,
     variables: { envID, externalAppID },

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/error.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/error.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Button } from '@inngest/components/Button';
+
+type Props = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function Page({ error, reset }: Props) {
+  useEffect(() => {
+    // Log the error to an error reporting service
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="w-[600px] rounded border border-slate-300 p-4">
+        <h2>Something went wrong!</h2>
+
+        <div className="my-6 overflow-scroll rounded bg-slate-200 p-2">
+          <pre>
+            <code>{error.message}</code>
+          </pre>
+        </div>
+
+        <Button
+          btnAction={
+            // Attempt to recover by trying to re-render the segment
+            () => reset()
+          }
+          label="Try again"
+        />
+      </div>
+    </div>
+  );
+}

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/error.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/error.tsx
@@ -19,11 +19,7 @@ export default function Page({ error, reset }: Props) {
       <div className="w-[600px] rounded border border-slate-300 p-4">
         <h2>Something went wrong!</h2>
 
-        <div className="my-6 overflow-scroll rounded bg-slate-200 p-2">
-          <pre>
-            <code>{error.message}</code>
-          </pre>
-        </div>
+        <div className="my-6 overflow-scroll rounded bg-slate-200 p-2">{error.message}</div>
 
         <Button
           btnAction={

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/useApps.ts
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/useApps.ts
@@ -31,7 +31,7 @@ const query = graphql(`
 
 export function useApps({ envID, isArchived }: { envID: string; isArchived: boolean }) {
   const res = useGraphQLQuery({
-    pollIntervalInMilliseconds: 10_000,
+    pollIntervalInMilliseconds: 2_000,
     query,
     variables: { envID },
   });

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/useApps.ts
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/useApps.ts
@@ -1,5 +1,5 @@
 import { graphql } from '@/gql';
-import { useGraphQLQuery } from '@/utils/useGraphQLQuery';
+import { useGraphQLQuery_TEMPORARY } from '@/utils/useGraphQLQuery';
 
 const query = graphql(`
   query Apps($envID: ID!) {
@@ -30,7 +30,7 @@ const query = graphql(`
 `);
 
 export function useApps({ envID, isArchived }: { envID: string; isArchived: boolean }) {
-  const res = useGraphQLQuery({
+  const res = useGraphQLQuery_TEMPORARY({
     pollIntervalInMilliseconds: 2_000,
     query,
     variables: { envID },

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/event-search/useEvent.ts
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/event-search/useEvent.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { Event } from '@inngest/components/types/event';
-import { baseFetchFailed } from '@inngest/components/types/fetch';
+import { baseInitialFetchFailed } from '@inngest/components/types/fetch';
 import type { FunctionRun } from '@inngest/components/types/functionRun';
 
 import { graphql } from '@/gql';
@@ -82,7 +82,7 @@ export function useEvent({ envID, eventID }: { envID: string; eventID: string | 
   if (data instanceof Error) {
     // Should be unreachable
     return {
-      ...baseFetchFailed,
+      ...baseInitialFetchFailed,
       error: data,
     };
   }

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/event-search/useRun.ts
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/event-search/useRun.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { baseFetchFailed, type FetchResult } from '@inngest/components/types/fetch';
+import { baseInitialFetchFailed, type FetchResult } from '@inngest/components/types/fetch';
 import type { Function } from '@inngest/components/types/function';
 import type { FunctionRun } from '@inngest/components/types/functionRun';
 import type { FunctionVersion } from '@inngest/components/types/functionVersion';
@@ -136,7 +136,7 @@ export function useRun({
   if (data instanceof Error) {
     // Should be unreachable
     return {
-      ...baseFetchFailed,
+      ...baseInitialFetchFailed,
       error: data,
     };
   }

--- a/ui/apps/dashboard/src/utils/useGraphQLQuery.ts
+++ b/ui/apps/dashboard/src/utils/useGraphQLQuery.ts
@@ -134,7 +134,6 @@ export function useGraphQLQuery_TEMPORARY<
     dataRef.current = res.data;
   }
   const data = res.data ?? dataRef.current;
-  console.log(res);
 
   // Handle both fetching states (initial fetch and refetch)
   if (res.fetching) {

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/stream/useEvent.ts
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/stream/useEvent.ts
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import type { Event } from '@inngest/components/types/event';
 import {
-  baseFetchFailed,
-  baseFetchLoading,
   baseFetchSkipped,
   baseFetchSucceeded,
+  baseInitialFetchFailed,
+  baseInitialFetchLoading,
+  baseRefetchLoading,
   type FetchResult,
 } from '@inngest/components/types/fetch';
 import type { FunctionRun } from '@inngest/components/types/functionRun';
@@ -45,8 +46,12 @@ export function useEvent(eventID: string | null): FetchResult<Data, { skippable:
   }, [query.data?.event]);
 
   if (query.isLoading) {
+    if (!data) {
+      return baseInitialFetchLoading;
+    }
+
     return {
-      ...baseFetchLoading,
+      ...baseRefetchLoading,
       data,
     };
   }
@@ -57,7 +62,7 @@ export function useEvent(eventID: string | null): FetchResult<Data, { skippable:
 
   if (query.error) {
     return {
-      ...baseFetchFailed,
+      ...baseInitialFetchFailed,
       error: new Error(query.error.message),
     };
   }
@@ -65,7 +70,7 @@ export function useEvent(eventID: string | null): FetchResult<Data, { skippable:
   if (!data) {
     // Should be unreachable.
     return {
-      ...baseFetchFailed,
+      ...baseInitialFetchFailed,
       error: new Error('finished loading but missing data'),
     };
   }

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/stream/useRun.ts
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/stream/useRun.ts
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 import {
-  baseFetchFailed,
-  baseFetchLoading,
   baseFetchSkipped,
   baseFetchSucceeded,
+  baseInitialFetchFailed,
+  baseInitialFetchLoading,
+  baseRefetchLoading,
   type FetchResult,
 } from '@inngest/components/types/fetch';
 import type { Function } from '@inngest/components/types/function';
@@ -47,8 +48,12 @@ export function useRun(runID: string | null): FetchResult<Data, { skippable: tru
   }, [query.data?.functionRun]);
 
   if (query.isLoading) {
+    if (!data) {
+      return baseInitialFetchLoading;
+    }
+
     return {
-      ...baseFetchLoading,
+      ...baseRefetchLoading,
       data,
     };
   }
@@ -59,7 +64,7 @@ export function useRun(runID: string | null): FetchResult<Data, { skippable: tru
 
   if (query.error) {
     return {
-      ...baseFetchFailed,
+      ...baseInitialFetchFailed,
       error: new Error(query.error.message),
     };
   }
@@ -67,7 +72,7 @@ export function useRun(runID: string | null): FetchResult<Data, { skippable: tru
   if (!data) {
     // Should be unreachable.
     return {
-      ...baseFetchFailed,
+      ...baseInitialFetchFailed,
       error: new Error('finished loading but missing data'),
     };
   }

--- a/ui/packages/components/src/types/fetch.ts
+++ b/ui/packages/components/src/types/fetch.ts
@@ -2,14 +2,12 @@ type InitialFetchFailed = {
   error: Error;
   data: undefined;
   isLoading: false;
-  status: 'initial_failed';
 };
 
 type InitialFetchLoading = {
   error: undefined;
   data: undefined;
   isLoading: true;
-  status: 'initial_loading';
 };
 
 type Skipped = {
@@ -17,14 +15,12 @@ type Skipped = {
   data: undefined;
   isLoading: false;
   isSkipped: true;
-  status: 'skipped';
 };
 
 type Succeeded<T = never> = {
   error: undefined;
   data: T;
   isLoading: false;
-  status: 'succeeded';
 };
 
 // Same as InitialFetchFailed, but it has data
@@ -32,7 +28,6 @@ type RefetchFailed<T = never> = {
   error: Error;
   data: T;
   isLoading: false;
-  status: 'refetch_failed';
 };
 
 // Same as InitialFetchLoading, but it has data
@@ -40,14 +35,12 @@ type RefetchLoading<T = never> = {
   error: undefined;
   data: T;
   isLoading: true;
-  status: 'refetch_loading';
 };
 
 export const baseInitialFetchFailed = {
   data: undefined,
   isLoading: false,
   isSkipped: false,
-  status: 'initial_failed',
 } as const satisfies Omit<InitialFetchFailed, 'error'> & { isSkipped: false };
 
 export const baseInitialFetchLoading = {
@@ -55,7 +48,6 @@ export const baseInitialFetchLoading = {
   error: undefined,
   isLoading: true,
   isSkipped: false,
-  status: 'initial_loading',
 } as const satisfies InitialFetchLoading & { isSkipped: false };
 
 export const baseFetchSkipped = {
@@ -63,27 +55,23 @@ export const baseFetchSkipped = {
   error: undefined,
   isLoading: false,
   isSkipped: true,
-  status: 'skipped',
 } as const satisfies Skipped;
 
 export const baseFetchSucceeded = {
   error: undefined,
   isLoading: false,
   isSkipped: false,
-  status: 'succeeded',
 } as const satisfies Omit<Succeeded, 'data'> & { isSkipped: false };
 
 export const baseRefetchFailed = {
   isLoading: false,
   isSkipped: false,
-  status: 'refetch_failed',
 } as const satisfies Omit<RefetchFailed, 'data' | 'error'> & { isSkipped: false };
 
 export const baseRefetchLoading = {
   error: undefined,
   isLoading: true,
   isSkipped: false,
-  status: 'refetch_loading',
 } as const satisfies Omit<RefetchLoading, 'data'> & { isSkipped: false };
 
 // A generic type that represents failed, loading, succeeded, and skipped fetch

--- a/ui/packages/components/src/types/fetch.ts
+++ b/ui/packages/components/src/types/fetch.ts
@@ -1,32 +1,90 @@
-type FetchFailed = { error: Error; data: undefined; isLoading: false };
-type FetchLoading<T = never> = { error: undefined; data: T | undefined; isLoading: true };
-type FetchSkipped = { error: undefined; data: undefined; isLoading: false; isSkipped: true };
-type FetchSucceeded<T = never> = { error: undefined; data: T; isLoading: false };
+type InitialFetchFailed = {
+  error: Error;
+  data: undefined;
+  isLoading: false;
+  status: 'initial_failed';
+};
 
-export const baseFetchFailed = {
+type InitialFetchLoading = {
+  error: undefined;
+  data: undefined;
+  isLoading: true;
+  status: 'initial_loading';
+};
+
+type Skipped = {
+  error: undefined;
+  data: undefined;
+  isLoading: false;
+  isSkipped: true;
+  status: 'skipped';
+};
+
+type Succeeded<T = never> = {
+  error: undefined;
+  data: T;
+  isLoading: false;
+  status: 'succeeded';
+};
+
+// Same as InitialFetchFailed, but it has data
+type RefetchFailed<T = never> = {
+  error: Error;
+  data: T;
+  isLoading: false;
+  status: 'refetch_failed';
+};
+
+// Same as InitialFetchLoading, but it has data
+type RefetchLoading<T = never> = {
+  error: undefined;
+  data: T;
+  isLoading: true;
+  status: 'refetch_loading';
+};
+
+export const baseInitialFetchFailed = {
   data: undefined,
   isLoading: false,
   isSkipped: false,
-} as const satisfies Omit<FetchFailed, 'error'> & { isSkipped: false };
+  status: 'initial_failed',
+} as const satisfies Omit<InitialFetchFailed, 'error'> & { isSkipped: false };
 
-export const baseFetchLoading = {
+export const baseInitialFetchLoading = {
+  data: undefined,
   error: undefined,
   isLoading: true,
   isSkipped: false,
-} as const satisfies Omit<FetchLoading, 'data'> & { isSkipped: false };
+  status: 'initial_loading',
+} as const satisfies InitialFetchLoading & { isSkipped: false };
 
 export const baseFetchSkipped = {
   data: undefined,
   error: undefined,
   isLoading: false,
   isSkipped: true,
-} as const satisfies FetchSkipped;
+  status: 'skipped',
+} as const satisfies Skipped;
 
 export const baseFetchSucceeded = {
   error: undefined,
   isLoading: false,
   isSkipped: false,
-} as const satisfies Omit<FetchSucceeded, 'data'> & { isSkipped: false };
+  status: 'succeeded',
+} as const satisfies Omit<Succeeded, 'data'> & { isSkipped: false };
+
+export const baseRefetchFailed = {
+  isLoading: false,
+  isSkipped: false,
+  status: 'refetch_failed',
+} as const satisfies Omit<RefetchFailed, 'data' | 'error'> & { isSkipped: false };
+
+export const baseRefetchLoading = {
+  error: undefined,
+  isLoading: true,
+  isSkipped: false,
+  status: 'refetch_loading',
+} as const satisfies Omit<RefetchLoading, 'data'> & { isSkipped: false };
 
 // A generic type that represents failed, loading, succeeded, and skipped fetch
 // states.
@@ -36,7 +94,7 @@ export const baseFetchSucceeded = {
 type FetchResultWithSkip<
   // Required
   TData = never
-> = (FetchResultWithoutSkip<TData> & { isSkipped: false }) | FetchSkipped;
+> = (FetchResultWithoutSkip<TData> & { isSkipped: false }) | Skipped;
 
 // A generic type that represents failed, loading, and succeeded fetch states.
 //
@@ -45,7 +103,12 @@ type FetchResultWithSkip<
 type FetchResultWithoutSkip<
   // Required
   TData = never
-> = FetchFailed | FetchLoading<TData> | FetchSucceeded<TData>;
+> =
+  | InitialFetchFailed
+  | InitialFetchLoading
+  | Succeeded<TData>
+  | RefetchFailed<TData>
+  | RefetchLoading<TData>;
 
 type Options = {
   skippable?: boolean;


### PR DESCRIPTION
## Changes

- Update `useGraphQLQuery`:
  - To support "initial" and "refetch" states for errors and loading.
  - To still return data even when a refetch errors.
  - To have clearer discriminated unions by using a new `status` property.
- Add error boundary for apps page.

## Context

Urql seems to clear a query's cache when a query errors. This is problematic for polling because we don't want poll errors to crash the page. If it's true that this cache clearing is unavoidable with polling, then we need custom "store the result data thru failed polls" logic like this PR has.

## Testing

Losing an internet connection causes failing polls but the page uses the cached data:
https://www.loom.com/share/523cd3f644c1421881f36267444fb741

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
