### PR TITLE
Update docs app links and copy

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/AppCard.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/AppCard.tsx
@@ -127,7 +127,8 @@ export function EmptyAppCard({ children }: { children: React.ReactNode }) {
       </div>
       <div className="flex flex-1 flex-col justify-center px-8">
         <p>
-          Apps on Inngest act as clients for serving your functions.{' '}
+          When you serve your functions using our serve API handler, you are hosting a new Inngest
+          app.{' '}
           <span className="hidden lg:inline">
             In order to have your functions invoked by Inngest, you must sync your app.
           </span>{' '}
@@ -136,7 +137,7 @@ export function EmptyAppCard({ children }: { children: React.ReactNode }) {
         <ol className="mt-3 hidden flex-col gap-3 md:flex">
           <li className="flex items-center gap-2">
             <span className="h-6 w-6 rounded-full bg-slate-400 text-center text-white">1</span>
-            <span className="flex-1">Deploy your app on your host environment of choice.</span>
+            <span className="flex-1">Deploy your code to your hosted platform of choice.</span>
           </li>
           <li className="flex items-center gap-2">
             <span className="h-6 w-6 rounded-full bg-slate-400 text-center text-white">2</span>

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/layout.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/[externalID]/layout.tsx
@@ -3,6 +3,7 @@
 import { Squares2X2Icon } from '@heroicons/react/20/solid';
 
 import { useEnvironment } from '@/app/(dashboard)/env/[environmentSlug]/environment-context';
+import { Alert } from '@/components/Alert';
 import Header, { type HeaderLink } from '@/components/Header/Header';
 import { Time } from '@/components/Time';
 import { ResyncButton } from './ResyncButton';
@@ -24,8 +25,11 @@ export default function Layout({ children, params: { externalID } }: Props) {
   });
   if (res.error) {
     if (res.error.message.includes('no rows')) {
-      // TODO: Make this look better.
-      return <span className="m-auto">App not found: {externalID}</span>;
+      return (
+        <div className="mt-4 flex place-content-center">
+          <Alert severity="warning">{externalID} app not found in this environment</Alert>
+        </div>
+      );
     }
     throw res.error;
   }

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/page.tsx
@@ -85,10 +85,9 @@ export default function Page() {
               Inngest deploys have been renamed to “<b>Syncs</b>”. All of your syncs can be found
               within your apps.{' '}
             </p>
-            {/* To do: wire this to the docs */}
-            {/* <Link internalNavigation={false} href="">
-            Learn More
-          </Link> */}
+            <Link internalNavigation={false} href="https://www.inngest.com/docs/apps">
+              Learn More
+            </Link>
           </Banner>
         )}
 

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/page.tsx
@@ -43,10 +43,9 @@ export default function Page() {
         action={
           <HoverCardRoot>
             <HoverCardTrigger asChild>
-              {/* To do: wire this to the docs */}
               <NextLink
                 className="flex cursor-pointer items-center gap-1 rounded-md border border-slate-200 px-2 py-1 text-slate-200 hover:border-white hover:text-white"
-                href="/"
+                href="https://www.inngest.com/docs/apps"
                 target="_blank"
                 rel="noreferrer noopener"
               >
@@ -56,15 +55,19 @@ export default function Page() {
             </HoverCardTrigger>
             <HoverCardContent className="w-72 p-2.5 text-sm">
               <p>
-                Each endpoint where you serve functions is an app. Each time you update your
-                functions, you must sync your app to Inngest. When using our Vercel or Netlify
-                Integrations, your app will be synced automatically.
+                When you serve your functions using Inngest&apos;s serve API handler, you are
+                hosting a new Inngest app.
+              </p>
+              <br />
+              <p>
+                Each time you deploy new code to your hosted platform, you must sync your app to
+                Inngest. When using our Vercel or Netlify integrations, your app will be synced
+                automatically.
               </p>
               <br />
               <p>Deploys have been renamed to “Syncs.” Syncs are found within Apps.</p>
               <br />
-              {/* To do: wire this to the docs */}
-              <Link href="/">Read Docs</Link>
+              <Link href="https://www.inngest.com/docs/apps/cloud">Read Docs</Link>
             </HoverCardContent>
           </HoverCardRoot>
         }

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/sync-new/ManualSync.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/sync-new/ManualSync.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState } from 'react';
 import { type Route } from 'next';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Button } from '@inngest/components/Button';
-import { Link as InngestLink, defaultLinkStyles } from '@inngest/components/Link';
+import { Code } from '@inngest/components/Code';
+import { Link } from '@inngest/components/Link';
 import { useLocalStorage } from 'react-use';
 import { toast } from 'sonner';
 
@@ -59,27 +59,27 @@ export default function ManualSync({ appsURL }: Props) {
     <>
       <div className="border-b border-slate-200 p-8">
         <p>
-          Inngest allows you to host your app code on any platform then invokes your functions via
-          HTTP. To deploy functions to Inngest, all you need to do is tell Inngest where to find
-          them!
+          To integrate your code hosted on another platform with Inngest, you need to inform Inngest
+          about the location of your app and functions.
         </p>
         <br />
         <p>
-          Since your code is hosted on another platform, you need to register where your functions
-          are hosted with Inngest. For example, if you set up the serve handler (
+          For example, imagine that your <Code>serve()</Code> handler (
           <Link
-            className={defaultLinkStyles}
+            showIcon={false}
             href="https://www.inngest.com/docs/reference/serve#how-the-serve-api-handler-works"
           >
             see docs
           </Link>
-          ) at /api/inngest, and your domain is https://myapp.com, you&apos;ll need to inform
-          Inngest that your app is hosted at https://myapp.com/api/inngest.
+          ) is located at /api/inngest, and your domain is myapp.com. In this scenario, you&apos;ll
+          need to inform Inngest that your apps and functions are hosted at
+          https://myapp.com/api/inngest.
         </p>
         <br />
         <p>
-          After you&apos;ve set up the serve API and deployed your application, enter the URL of
-          your application&apos;s serve endpoint to register your functions with Inngest.
+          After you&apos;ve set up the serve API and deployed your code, enter the URL of your
+          project&apos;s serve endpoint to sync your app with Inngest. Verify that you assigned the
+          signing key below to the right <Code>INNGEST_SIGNING_KEY</Code> environment variable:
         </p>
         <DeploySigningKey className="py-6" />
         <div className="border-t border-slate-200">
@@ -100,8 +100,7 @@ export default function ManualSync({ appsURL }: Props) {
         </div>
       </div>
       <div className="flex items-center justify-between px-8 py-6">
-        {/* To do:  create apps docs and link them here */}
-        <InngestLink href="https://www.inngest.com/docs/">View Docs</InngestLink>
+        <Link href="https://www.inngest.com/docs/apps/cloud">View Docs</Link>
         <div className="flex items-center gap-3">
           <Button
             label="Cancel"

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/sync-new/ManualSync.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/sync-new/ManualSync.tsx
@@ -77,9 +77,12 @@ export default function ManualSync({ appsURL }: Props) {
         </p>
         <br />
         <p>
-          After you&apos;ve set up the serve API and deployed your code, enter the URL of your
-          project&apos;s serve endpoint to sync your app with Inngest. Verify that you assigned the
-          signing key below to the right <Code>INNGEST_SIGNING_KEY</Code> environment variable:
+          After you&apos;ve set up the serve API and deployed your code,{' '}
+          <span className="font-semibold">
+            enter the URL of your project&apos;s serve endpoint to sync your app with Inngest
+          </span>
+          . Verify that you assigned the signing key below to the right{' '}
+          <Code>INNGEST_SIGNING_KEY</Code> environment variable:
         </p>
         <DeploySigningKey className="py-6" />
         <div className="border-t border-slate-200">

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/sync-new/ManualSync.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/sync-new/ManualSync.tsx
@@ -81,7 +81,7 @@ export default function ManualSync({ appsURL }: Props) {
           <span className="font-semibold">
             enter the URL of your project&apos;s serve endpoint to sync your app with Inngest
           </span>
-          . Verify that you assigned the signing key below to the right{' '}
+          . Verify that you assigned the signing key below to the {' '}
           <Code>INNGEST_SIGNING_KEY</Code> environment variable:
         </p>
         <DeploySigningKey className="py-6" />

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/sync-new/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/sync-new/page.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { type Route } from 'next';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import ArrowPathIcon from '@heroicons/react/20/solid/ArrowPathIcon';
 import Squares2X2Icon from '@heroicons/react/20/solid/Squares2X2Icon';
 import { Button } from '@inngest/components/Button';
+import { Code } from '@inngest/components/Code';
 import { CodeLine } from '@inngest/components/CodeLine';
-import { Link as InngestLink, defaultLinkStyles } from '@inngest/components/Link';
+import { Link } from '@inngest/components/Link';
 import * as Tabs from '@radix-ui/react-tabs';
 
 import Header from '@/components/Header/Header';
@@ -33,7 +33,7 @@ export default function Page({ params: { environmentSlug } }: Props) {
               <ArrowPathIcon className="h-6 w-6" />
               <h2 className="text-xl">Sync App</h2>
             </div>
-            <p>Provide the location of your App.</p>
+            <p>Provide the location of your app.</p>
           </header>
 
           <Tabs.Root defaultValue="tab1" className="bg-white">
@@ -63,22 +63,18 @@ export default function Page({ params: { environmentSlug } }: Props) {
             <Tabs.Content value="tab2">
               <div className="border-b border-slate-200 p-8">
                 <p>
-                  Inngest allows you to host your app code on any platform then invokes your
-                  functions via HTTP. To deploy functions to Inngest, all you need to do is tell
-                  Inngest where to find them!
+                  To integrate your code hosted on another platform with Inngest, you need to inform
+                  Inngest about the location of your app and functions.
                 </p>
                 <br />
                 <p>
                   Inngest enables you to host your Apps on Vercel using their serverless functions
-                  platform. This allows you to deploy your Inngest functions right alongside your
-                  existing website and API functions running on Vercel. Inngest will call your
-                  functions securely via HTTP request on-demand, whether triggered by an event or on
-                  a schedule in the case of cron jobs.
+                  platform. By using Inngest&apos;s official Vercel integration, your apps will be
+                  synced automatically.
                 </p>
               </div>
               <div className="flex items-center justify-between px-8 py-6">
-                {/* To do:  create apps docs and link them here */}
-                <InngestLink href="https://www.inngest.com/docs/">View Docs</InngestLink>
+                <Link href="https://www.inngest.com/docs/apps/cloud">View Docs</Link>
                 <div className="flex items-center gap-3">
                   <Button
                     label="Cancel"
@@ -100,33 +96,35 @@ export default function Page({ params: { environmentSlug } }: Props) {
             <Tabs.Content value="tab3">
               <div className="border-b border-slate-200 p-8">
                 <p>
-                  Inngest allows you to host your app code on any platform then invokes your
-                  functions via HTTP. To deploy functions to Inngest, all you need to do is tell
-                  Inngest where to find them!
+                  To integrate your code hosted on another platform with Inngest, you need to inform
+                  Inngest about the location of your app and functions.
                 </p>
                 <br />
                 <p>
-                  Since your code is hosted on another platform, you need to register where your
-                  functions are hosted with Inngest. For example, if you set up the serve handler (
+                  For example, imagine that your <Code>serve()</Code> handler (
                   <Link
-                    className={defaultLinkStyles}
+                    showIcon={false}
                     href="https://www.inngest.com/docs/reference/serve#how-the-serve-api-handler-works"
                   >
                     see docs
                   </Link>
-                  ) at /api/inngest, and your domain is https://myapp.com, you&apos;ll need to
-                  inform Inngest that your app is hosted at https://myapp.com/api/inngest.
+                  ) is located at /api/inngest, and your domain is myapp.com. In this scenario,
+                  you&apos;ll need to inform Inngest that your apps and functions are hosted at
+                  https://myapp.com/api/inngest.
                 </p>
                 <br />
                 <p>
-                  You can deploy from your machine or automate this within a CI/CD pipeline. Send a
-                  simple PUT request to your own application&apos;s serve endpoint.
+                  You can sync from your machine or automate this within a CI/CD pipeline.
+                  <span className="font-semibold">
+                    {' '}
+                    Send a PUT request to your own application&apos;s serve endpoint using the
+                    following command:
+                  </span>
                 </p>
                 <CodeLine code="curl -X PUT https://<your-app>.com/api/inngest" className="mt-6" />
               </div>
               <div className="flex items-center justify-between px-8 py-6">
-                {/* To do:  create apps docs and link them here */}
-                <InngestLink href="https://www.inngest.com/docs/">View Docs</InngestLink>
+                <Link href="https://www.inngest.com/docs/apps/cloud">View Docs</Link>
                 <div className="flex items-center gap-3">
                   <Button
                     label="Done"

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/deploys/layout.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/deploys/layout.tsx
@@ -1,4 +1,5 @@
 import { RocketLaunchIcon } from '@heroicons/react/20/solid';
+import { Link } from '@inngest/components/Link';
 
 import { Banner } from '@/components/Banner';
 import { getBooleanFlag } from '@/components/FeatureFlags/ServerFeatureFlag';
@@ -25,10 +26,9 @@ export default async function DeploysLayout({ children }: DeploysLayoutProps) {
             The deploys page is getting deprecated. We&apos;ve moved all this information and
             functionality over to the <b>Apps</b> tab.
           </p>
-          {/* To do: wire this to the docs */}
-          {/* <Link internalNavigation={false} href="">
+          <Link internalNavigation={false} href="https://www.inngest.com/docs/apps/cloud">
             Learn More
-          </Link> */}
+          </Link>
         </Banner>
       )}
       <div className="flex flex-grow overflow-hidden bg-slate-50">

--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/FunctionListNotFound.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/FunctionListNotFound.tsx
@@ -111,7 +111,11 @@ export default function FunctionListNotFound() {
               <Button
                 appearance="outlined"
                 target="_blank"
-                href={'https://www.inngest.com/docs/deploy?ref=app-onboarding-functions' as Route}
+                href={
+                  isAppsEnabled
+                    ? 'https://www.inngest.com/docs/apps?ref=app-onboarding-functions'
+                    : ('https://www.inngest.com/docs/deploy?ref=app-onboarding-functions' as Route)
+                }
                 label="Read The Docs"
               />
             </div>

--- a/ui/packages/components/src/Code/Code.tsx
+++ b/ui/packages/components/src/Code/Code.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+export function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <code className="inline-flex rounded bg-slate-100 px-1 font-mono text-xs font-medium tracking-tight">
+      {children}
+    </code>
+  );
+}

--- a/ui/packages/components/src/Code/index.ts
+++ b/ui/packages/components/src/Code/index.ts
@@ -1,0 +1,1 @@
+export { Code } from './Code';

--- a/ui/packages/components/src/Link/Link.tsx
+++ b/ui/packages/components/src/Link/Link.tsx
@@ -27,7 +27,11 @@ export function Link({
     return (
       <NextLink
         href={href}
-        className={classNames(className, 'group flex items-center gap-1', defaultLinkStyles)}
+        className={classNames(
+          className,
+          showIcon && 'group flex items-center gap-1',
+          defaultLinkStyles
+        )}
       >
         {children}
         {showIcon && (
@@ -38,7 +42,11 @@ export function Link({
   } else if (typeof href === 'string') {
     return (
       <a
-        className={classNames(className, 'group flex items-center gap-1', defaultLinkStyles)}
+        className={classNames(
+          className,
+          showIcon && 'group flex items-center gap-1',
+          defaultLinkStyles
+        )}
         target="_blank"
         rel="noopener noreferrer"
         href={href}


### PR DESCRIPTION
## Description
- Wire apps docs links.
- Update apps terminology in Cloud to match our docs.
- Add a basic Code component that matches the docs styles
- Fix shared Link issue (it would only affect Link components without icons, tested them and they look ok)
- Make no app found alert consistent:
<img width="1507" alt="Screenshot 2024-01-21 at 21 28 14" src="https://github.com/inngest/inngest/assets/16758464/5e5ce27f-d536-40a3-b99f-3e64a49a2d4c">

How Code component looks like:
<img width="734" alt="Screenshot 2024-01-21 at 21 37 52" src="https://github.com/inngest/inngest/assets/16758464/39c477a6-e5d6-41bc-ad9e-2cbc97b6ace3">




## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [x] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
