### PR TITLE
Hotfix: wrapping very long URLs redact params

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/AppCard.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/apps/AppCard.tsx
@@ -43,6 +43,7 @@ const cardWrapperStyles =
 const cardLeftPanelStyles = 'bg-slate-910 flex w-[410px] flex-col justify-center gap-2 px-10';
 
 export function AppCard({ app, className, envSlug, isArchived }: Props) {
+  const latestSyncURL = app.latestSync?.url?.replace(/^https:\/\//, '').replace(/\?.+$/, '');
   return (
     <div className={classNames(cardWrapperStyles, className)}>
       <div className={cardLeftPanelStyles}>
@@ -56,10 +57,15 @@ export function AppCard({ app, className, envSlug, isArchived }: Props) {
             <ChevronRightIcon className="h-4 w-4" />
           </Link>
         </h2>
-        {app.latestSync?.url && (
+        {latestSyncURL && (
           <dl>
             <dt className="hidden">URL</dt>
-            <dd className="text-slate-400">{app.latestSync.url}</dd>
+            <dd
+              className="overflow-hidden text-ellipsis whitespace-nowrap text-slate-400"
+              title={app.latestSync?.url || ''}
+            >
+              {latestSyncURL}
+            </dd>
           </dl>
         )}
       </div>


### PR DESCRIPTION
## Description

This is a hotfix.

Before this change, app URLs would wrap and also overflow into the details part of the card

Before
![image](https://github.com/inngest/inngest/assets/1509457/e54f47dd-ceaf-4eab-8a15-3be6d5344676)

After
![image](https://github.com/inngest/inngest/assets/1509457/eb1241c3-80d5-43ed-a0c7-1e0bafdb16d7)


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
