### PR TITLE
fix(dashboard): account setup race condition

### DIFF
--- a/ui/apps/dashboard/src/app/(auth)/sign-up/account-setup/page.tsx
+++ b/ui/apps/dashboard/src/app/(auth)/sign-up/account-setup/page.tsx
@@ -28,12 +28,17 @@ export default function AccountSetupPage() {
     };
   }, [isAccountSetup, user]);
 
-  if (isAccountSetup) {
-    // We replace so that the user doesn't get stuck on this page if they hit the back button
-    router.replace(process.env.NEXT_PUBLIC_HOME_PATH as Route);
-  }
+  // Redirect to the home page once the account is set up
+  useEffect(() => {
+    if (!isAccountSetup) return;
 
-  if (secondsElapsed === 10) {
+    // We use `replace` so that the user doesn't get redirected back to this page if they click the back button
+    router.replace(process.env.NEXT_PUBLIC_HOME_PATH as Route);
+  }, [isAccountSetup, router]);
+
+  useEffect(() => {
+    if (secondsElapsed !== 10) return;
+
     window.inngest.send({
       name: 'app/account.setup.delayed',
       data: {
@@ -43,7 +48,7 @@ export default function AccountSetupPage() {
       user,
       v: '2023-08-31.1',
     });
-  }
+  }, [secondsElapsed, user]);
 
   if (secondsElapsed > 30) {
     return (

--- a/ui/apps/dashboard/src/middleware.ts
+++ b/ui/apps/dashboard/src/middleware.ts
@@ -1,8 +1,33 @@
-import { authMiddleware } from '@clerk/nextjs';
+import { NextResponse } from 'next/server';
+import { authMiddleware, redirectToSignIn } from '@clerk/nextjs';
+
+const homepagePath = process.env.NEXT_PUBLIC_HOME_PATH;
+if (!homepagePath) {
+  throw new Error('The NEXT_PUBLIC_HOME_PATH environment variable is not set');
+}
 
 export default authMiddleware({
   publicRoutes: ['/password-reset', '/support', '/api/sentry'],
   ignoredRoutes: '/(images|_next/static|_next/image|favicon)(.*)',
+  afterAuth(auth, request) {
+    const isSignedIn = !!auth.userId;
+    const isAccountSetup =
+      isSignedIn && auth.sessionClaims.externalID && auth.sessionClaims.accountID;
+
+    if (!isSignedIn && !auth.isPublicRoute) {
+      return redirectToSignIn({ returnBackUrl: request.url });
+    }
+
+    if (isSignedIn && !isAccountSetup && request.nextUrl.pathname !== '/sign-up/account-setup') {
+      return NextResponse.redirect(new URL('/sign-up/account-setup', request.url));
+    }
+
+    if (isAccountSetup && request.nextUrl.pathname === '/sign-up/account-setup') {
+      return NextResponse.redirect(new URL(homepagePath, request.url));
+    }
+
+    return NextResponse.next();
+  },
 });
 
 export const config = {


### PR DESCRIPTION
## Description

This fixes a race condition where we would redirect to homepage before URQL had time to inject the new session token into its operations.

This also updates the middleware to redirect users to the account setup if they're signed and don't have an account setup so that adjacent tabs don't fail.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
