### PR TITLE
Hotfix: Remove limit line that may be rendered as 1

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionThroughputChart.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/env/[environmentSlug]/functions/[slug]/(dashboard)/FunctionThroughputChart.tsx
@@ -108,7 +108,12 @@ export default function FunctionThroughputChart({
       desc="The number of function runs being processed over time."
       data={metrics}
       legend={[
-        { name: 'Concurrency Limit', dataKey: 'concurrencyLimit', color: colors.amber['500'] },
+        {
+          name: 'Concurrency Limit',
+          dataKey: 'concurrencyLimit',
+          color: colors.amber['500'],
+          referenceArea: true,
+        },
         { name: 'Queued', dataKey: 'queued', color: colors.slate['500'] },
         { name: 'Started', dataKey: 'started', color: colors.sky['500'] },
         { name: 'Ended', dataKey: 'ended', color: colors.teal['500'] },

--- a/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
+++ b/ui/apps/dashboard/src/components/Charts/SimpleLineChart.tsx
@@ -19,7 +19,6 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import colors from 'tailwindcss/colors';
 
 import LoadingIcon from '@/icons/LoadingIcon';
 import cn from '@/utils/cn';


### PR DESCRIPTION
## Description

The "true" line was rendering as a line of 1 which made the UI look like the concurrency limit was configured to 1. This was confusing. We do not need to render the line as it's confusing.

Before
<img width="1568" alt="Screen Shot 2024-01-25 at 2 05 47 PM" src="https://github.com/inngest/inngest/assets/1509457/2df55c4f-ecb3-41f4-8f36-ab1e44bb79fb">



After

<img width="723" alt="Screen Shot 2024-01-25 at 4 37 28 PM" src="https://github.com/inngest/inngest/assets/1509457/d27893c9-e681-4db2-acee-d49b327286bc">

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
