### PR TITLE
Add tick, allowing the dev server to respond faster

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/inngest/inngest/pkg/config"
 	"github.com/inngest/inngest/pkg/devserver"
@@ -28,6 +29,8 @@ func NewCmdDev() *cobra.Command {
 	cmd.Flags().Bool("no-discovery", false, "Disable autodiscovery")
 	cmd.Flags().Bool("no-poll", false, "Disable polling of apps for updates")
 	cmd.Flags().Int("retry-interval", 0, "Retry interval in seconds for linear backoff when retrying functions - must be 1 or above")
+
+	cmd.Flags().Int("tick", 150, "The interval (in milliseconds) at which the executor checks for new work, during local development")
 
 	return cmd
 }
@@ -72,6 +75,7 @@ func doDev(cmd *cobra.Command, args []string) {
 	noDiscovery, _ := cmd.Flags().GetBool("no-discovery")
 	noPoll, _ := cmd.Flags().GetBool("no-poll")
 	retryInterval, _ := cmd.Flags().GetInt("retry-interval")
+	tick, _ := cmd.Flags().GetInt("tick")
 
 	opts := devserver.StartOpts{
 		Config:        *conf,
@@ -79,6 +83,7 @@ func doDev(cmd *cobra.Command, args []string) {
 		Autodiscover:  !noDiscovery,
 		Poll:          !noPoll,
 		RetryInterval: retryInterval,
+		Tick:          time.Duration(tick) * time.Millisecond,
 	}
 
 	close, err := telemetry.TracerSetup("devserver", telemetry.TracerTypeNoop)

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -37,6 +37,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const defaultTick = time.Millisecond * 150
+
 // StartOpts configures the dev server
 type StartOpts struct {
 	Config        config.Config `json:"-"`
@@ -44,6 +46,7 @@ type StartOpts struct {
 	URLs          []string      `json:"urls"`
 	Autodiscover  bool          `json:"autodiscover"`
 	Poll          bool          `json:"poll"`
+	Tick          time.Duration `json:"tick"`
 	RetryInterval int           `json:"retry_interval"`
 }
 
@@ -74,12 +77,16 @@ func start(ctx context.Context, opts StartOpts) error {
 		return err
 	}
 
+	if opts.Tick == 0 {
+		opts.Tick = defaultTick
+	}
+
 	// Initialize the devserver
 	dbcqrs := sqlitecqrs.NewCQRS(db)
 	hd := sqlitecqrs.NewHistoryDriver(db)
 	loader := dbcqrs.(state.FunctionLoader)
 
-	rc, err := createInmemoryRedis(ctx)
+	rc, err := createInmemoryRedis(ctx, opts.Tick)
 	if err != nil {
 		return err
 	}
@@ -104,7 +111,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	queueOpts := []redis_state.QueueOpt{
 		redis_state.WithIdempotencyTTL(time.Hour),
 		redis_state.WithNumWorkers(100),
-		redis_state.WithPollTick(150 * time.Millisecond),
+		redis_state.WithPollTick(opts.Tick),
 		redis_state.WithQueueKeyGenerator(queueKG),
 		redis_state.WithCustomConcurrencyKeyGenerator(func(ctx context.Context, i redis_state.QueueItem) []state.CustomConcurrency {
 			fn, err := dbcqrs.GetFunctionByInternalUUID(ctx, i.Data.Identifier.WorkspaceID, i.Data.Identifier.WorkflowID)
@@ -249,7 +256,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	return service.StartAll(ctx, ds, runner, executorSvc)
 }
 
-func createInmemoryRedis(ctx context.Context) (rueidis.Client, error) {
+func createInmemoryRedis(ctx context.Context, tick time.Duration) (rueidis.Client, error) {
 	r := miniredis.NewMiniRedis()
 	_ = r.Start()
 	rc, err := rueidis.NewClient(rueidis.ClientOption{
@@ -259,9 +266,17 @@ func createInmemoryRedis(ctx context.Context) (rueidis.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// If tick is lower than 250ms, tick every 100ms.  This lets us save
+	// CPU for standard dev-server testing.
+	poll := time.Second
+	if tick < defaultTick {
+		poll = time.Millisecond * 50
+	}
+
 	go func() {
-		for range time.Tick(time.Second) {
-			r.FastForward(time.Second)
+		for range time.Tick(poll) {
+			r.FastForward(poll)
 		}
 	}()
 	return rc, nil


### PR DESCRIPTION
By default, the dev server polls every 250ms and forwards the in-memory state store every second.  This introduces a --tick parameter, allowing the dev server to tick faster to match production.

This is not the default;  we want to save people's CPU during regular development.  It is aimed at CI/testing only.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
