### PR TITLE
Adjust link icons

### DIFF
--- a/ui/apps/dashboard/src/components/AppGitCard/AppGitCard.tsx
+++ b/ui/apps/dashboard/src/components/AppGitCard/AppGitCard.tsx
@@ -24,7 +24,7 @@ export function AppGitCard({ className, sync }: Props) {
     if (repoURL) {
       commitHashValue = (
         <Link href={`${repoURL}/commit/${commitHash}` as Route} internalNavigation={false}>
-          <span className="flex-1 truncate">{commitHash.substring(0, 7)}</span>
+          <span className="truncate">{commitHash.substring(0, 7)}</span>
         </Link>
       );
     } else {
@@ -39,7 +39,7 @@ export function AppGitCard({ className, sync }: Props) {
     if (repoURL) {
       commitRefValue = (
         <Link href={`${repoURL}/tree/${commitRef}` as Route} internalNavigation={false}>
-          <span className="flex-1 truncate">{commitRef}</span>
+          <span className="truncate">{commitRef}</span>
         </Link>
       );
     } else {
@@ -53,7 +53,7 @@ export function AppGitCard({ className, sync }: Props) {
   if (repoURL) {
     repositoryValue = (
       <Link href={repoURL as Route} internalNavigation={false}>
-        <span className="flex-1 truncate">{repoURL}</span>
+        <span className="truncate">{repoURL}</span>
       </Link>
     );
   } else {

--- a/ui/apps/dashboard/src/components/AppInfoCard/PlatformSection.tsx
+++ b/ui/apps/dashboard/src/components/AppInfoCard/PlatformSection.tsx
@@ -24,7 +24,7 @@ export function PlatformSection({ sync }: Props) {
   if (vercelDeploymentID && vercelDeploymentURL) {
     deploymentValue = (
       <Link href={vercelDeploymentURL as Route} internalNavigation={false}>
-        <span className="flex-1 truncate">{vercelDeploymentID}</span>
+        <span className="truncate">{vercelDeploymentID}</span>
       </Link>
     );
   } else {
@@ -35,7 +35,7 @@ export function PlatformSection({ sync }: Props) {
   if (vercelProjectID && vercelProjectURL) {
     projectValue = (
       <Link href={vercelProjectURL as Route} internalNavigation={false}>
-        <span className="flex-1 truncate">{vercelProjectID}</span>
+        <span className="truncate">{vercelProjectID}</span>
       </Link>
     );
   } else {

--- a/ui/packages/components/src/Link/Link.tsx
+++ b/ui/packages/components/src/Link/Link.tsx
@@ -52,7 +52,7 @@ export function Link({
         href={href}
       >
         {children}
-        {showIcon && <IconArrowTopRightOnSquare />}
+        {showIcon && <IconArrowTopRightOnSquare className="h-4 w-4 shrink-0" />}
       </a>
     );
   }


### PR DESCRIPTION
## Description
Keeps icon size the same, even when link text is truncated
<img width="1000" alt="Screenshot 2024-01-26 at 15 05 42" src="https://github.com/inngest/inngest/assets/16758464/72b3339f-f4cc-4d21-aa92-108adfc51529">


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
