### PR TITLE
Add title to Time

### DIFF
--- a/ui/apps/dashboard/src/components/AppInfoCard/AppInfoCard.tsx
+++ b/ui/apps/dashboard/src/components/AppInfoCard/AppInfoCard.tsx
@@ -100,40 +100,36 @@ export function AppInfoCard({ app, className, sync, linkToSyncs, loading }: Prop
         <dl className="flex flex-col gap-4 px-6 py-4 md:grid md:grid-cols-4">
           {/* Row 1 */}
           <Description
-            className="truncate"
-            detail={app?.externalID ?? '-'}
+            detail={<span className="truncate">{app?.externalID ?? '-'}</span>}
             term="ID"
             loading={loading}
           />
           <Description
-            className="truncate"
-            detail={sync?.sdkVersion ?? '-'}
+            detail={<span className="truncate">{sync?.sdkVersion ?? '-'}</span>}
             term="SDK Version"
             loading={loading}
           />
           <Description
-            className="col-span-2 truncate"
-            detail={lastSyncValue ?? '-'}
+            className="col-span-2"
+            detail={<span className="truncate">{lastSyncValue ?? '-'}</span>}
             term="Last Sync"
             loading={loading}
           />
 
           {/* Row 2 */}
           <Description
-            className="truncate"
             detail={<FrameworkInfo framework={sync?.framework} />}
             term="Framework"
             loading={loading}
           />
           <Description
-            className="truncate"
             detail={<LanguageInfo language={sync?.sdkLanguage} />}
             term="Language"
             loading={loading}
           />
           <Description
-            className="col-span-2 truncate"
-            detail={sync?.url ?? '-'}
+            className="col-span-2"
+            detail={<span className="truncate">{sync?.url ?? '-'}</span>}
             term="URL"
             loading={loading}
           />

--- a/ui/apps/dashboard/src/components/AppInfoCard/PlatformSection.tsx
+++ b/ui/apps/dashboard/src/components/AppInfoCard/PlatformSection.tsx
@@ -44,11 +44,7 @@ export function PlatformSection({ sync }: Props) {
 
   return (
     <>
-      <Description
-        className="truncate"
-        detail={<PlatformInfo platform={platform} />}
-        term="Platform"
-      />
+      <Description detail={<PlatformInfo platform={platform} />} term="Platform" />
       <Description detail={projectValue} term="Vercel Project" />
       <Description detail={deploymentValue} term="Vercel Deployment" />
     </>

--- a/ui/apps/dashboard/src/components/FrameworkInfo.tsx
+++ b/ui/apps/dashboard/src/components/FrameworkInfo.tsx
@@ -118,8 +118,8 @@ export function FrameworkInfo({ framework }: Props) {
 
   return (
     <span className="flex items-center">
-      {Icon && <Icon className="mr-1 text-slate-500" size={20} />}
-      {text}
+      {Icon && <Icon className="mr-1 shrink-0 text-slate-500" size={20} />}
+      <span className="truncate">{text}</span>
     </span>
   );
 }

--- a/ui/apps/dashboard/src/components/LanguageInfo.tsx
+++ b/ui/apps/dashboard/src/components/LanguageInfo.tsx
@@ -47,8 +47,8 @@ export function LanguageInfo({ language }: Props) {
 
   return (
     <span className="flex items-center">
-      {Icon && <Icon className="mr-1 text-slate-500" size={20} />}
-      <span>{text}</span>
+      {Icon && <Icon className="mr-1 shrink-0 text-slate-500" size={20} />}
+      <span className="truncate">{text}</span>
     </span>
   );
 }

--- a/ui/apps/dashboard/src/components/PlatformInfo.tsx
+++ b/ui/apps/dashboard/src/components/PlatformInfo.tsx
@@ -47,8 +47,8 @@ export function PlatformInfo({ platform }: Props) {
 
   return (
     <span className="flex items-center">
-      {Icon && <Icon className="mr-1 text-slate-500" size={20} />}
-      <span>{text}</span>
+      {Icon && <Icon className="mr-1 shrink-0 text-slate-500" size={20} />}
+      <span className="truncate">{text}</span>
     </span>
   );
 }

--- a/ui/apps/dashboard/src/components/Time.tsx
+++ b/ui/apps/dashboard/src/components/Time.tsx
@@ -21,9 +21,10 @@ export function Time({ className, format, value }: Props) {
   let title: string | undefined;
   if (format === 'relative') {
     dateString = relativeTime(value);
-    title = value.toLocaleString();
+    title = value.toString();
   } else {
     dateString = value.toLocaleString();
+    title = value.toString();
   }
 
   return (


### PR DESCRIPTION
## Description
- Adds time label with timezone for `<Time>` components
<img width="505" alt="Screenshot 2024-01-26 at 19 19 23" src="https://github.com/inngest/inngest/assets/16758464/18fe53d0-eede-4f42-a7da-f6c24365e22d">

Also noticed that description truncated items were not being truncated as expected, since the CSS was not in the right elements

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
