### PR TITLE
Fixes `inngest/function.failed` events carrying incorrect error schema

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -762,29 +762,7 @@ func (e *executor) runFinishHandler(ctx context.Context, id state.Identifier, s 
 	// Prepare events that we must send
 	var events []event.Event
 	now := time.Now()
-
-	var (
-		output    any
-		errorData map[string]any
-	)
-
-	// normalize repsonses :grimace:
-	output = resp.Output
-	if v, ok := output.(map[string]any); ok {
-		errorData = v
-		if resp.Err != nil {
-			if msg, ok := errorData["message"].(string); !ok || msg == "" {
-				errorData["message"] = *resp.Err
-			}
-			if _, ok := errorData["error"]; !ok && resp.Err != nil {
-				errorData["error"] = *resp.Err
-			}
-		}
-	} else {
-		errorData = map[string]any{
-			"error": resp.Err,
-		}
-	}
+	errorData := resp.StandardError()
 
 	// Legacy - send inngest/function.failed
 	if resp.Err != nil && !strings.Contains(*resp.Err, state.ErrFunctionCancelled.Error()) {

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/inngest/inngest/pkg/dateutil"
@@ -440,9 +441,38 @@ func (r *DriverResponse) StandardError() StandardError {
 		Message: DefaultErrorMessage,
 	}
 
-	if v, ok := r.Output.(map[string]any); ok {
+	var raw map[string]any
+
+	switch rawJson := r.Output.(type) {
+	case json.RawMessage:
+		// Try to unmarshal, but don't return on error, use raw map as fallback
+		_ = json.Unmarshal(rawJson, &raw)
+	case map[string]any:
+		raw = rawJson
+	default:
+		// Handle other types by setting their value directly as a message
+		switch v := r.Output.(type) {
+		case []byte:
+			if len(v) > 0 {
+				raw = map[string]any{"message": string(v)}
+			}
+		case string:
+			if len(v) > 0 {
+				raw = map[string]any{"message": v}
+			}
+		case interface{}:
+			if v != nil {
+				raw = map[string]any{"message": v}
+			}
+		}
+	}
+
+	// Process the raw map if it's not empty
+	if len(raw) > 0 {
+		processed, _ := processErrorFields(raw)
+
 		for _, key := range []string{"error", "name", "message", "stack"} {
-			if val, ok := v[key].(string); ok && val != "" {
+			if val, ok := processed[key].(string); ok && val != "" {
 				switch key {
 				case "error":
 					ret.Error = val
@@ -467,4 +497,45 @@ func (r *DriverResponse) StandardError() StandardError {
 	}
 
 	return ret
+}
+
+// processErrorFields looks for an error field then a body field to handle
+// error messages from step responses.
+func processErrorFields(input map[string]any) (map[string]any, error) {
+	fields := []string{"error", "body"}
+	for _, f := range fields {
+		// Attempt to fetch the JS/SDK error from the body.
+		switch v := input[f].(type) {
+		case map[string]any:
+			return v, nil
+		case json.RawMessage:
+			if mapped, err := processErrorString(string(v)); err == nil {
+				return mapped, nil
+			}
+		case []byte:
+			if mapped, err := processErrorString(string(v)); err == nil {
+				return mapped, nil
+			}
+		case string:
+			if mapped, err := processErrorString(v); err == nil {
+				return mapped, nil
+			}
+		}
+	}
+	return input, nil
+}
+
+// processErrorString attempts to unquote and unmarshal a JSON-encoded string
+func processErrorString(s string) (map[string]any, error) {
+	// Bound inner error fields to 32kb
+	if len(s) > 32*1024 {
+		return nil, fmt.Errorf("error field too large")
+	}
+
+	if unquote, err := strconv.Unquote(s); err == nil {
+		s = unquote
+	}
+	mapped := map[string]any{}
+	err := json.Unmarshal([]byte(s), &mapped)
+	return mapped, err
 }

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -13,6 +13,7 @@ import (
 	"github.com/xhit/go-str2duration/v2"
 )
 
+const DefaultErrorName = "Error"
 const DefaultErrorMessage = "Function execution error"
 const DefaultStepErrorMessage = "Step execution error"
 
@@ -423,4 +424,47 @@ func (r *DriverResponse) HistoryVisibleStep() *GeneratorOpcode {
 	}
 
 	return op
+}
+
+type StandardError struct {
+	Error   string `json:"error"`
+	Name    string `json:"name"`
+	Message string `json:"message"`
+	Stack   string `json:"stack,omitempty"`
+}
+
+func (r *DriverResponse) StandardError() StandardError {
+	ret := StandardError{
+		Error:   DefaultErrorMessage,
+		Name:    DefaultErrorName,
+		Message: DefaultErrorMessage,
+	}
+
+	if v, ok := r.Output.(map[string]any); ok {
+		for _, key := range []string{"error", "name", "message", "stack"} {
+			if val, ok := v[key].(string); ok && val != "" {
+				switch key {
+				case "error":
+					ret.Error = val
+				case "name":
+					ret.Name = val
+				case "message":
+					ret.Message = val
+				case "stack":
+					ret.Stack = val
+				}
+			}
+		}
+	}
+
+	if r.Err != nil {
+		if ret.Error == DefaultErrorMessage {
+			ret.Error = *r.Err
+		}
+		if ret.Message == DefaultErrorMessage {
+			ret.Message = *r.Err
+		}
+	}
+
+	return ret
 }

--- a/pkg/execution/state/driver_response_test.go
+++ b/pkg/execution/state/driver_response_test.go
@@ -53,24 +53,24 @@ func TestDriverResponseFormatError(t *testing.T) {
 	tests := []struct {
 		name     string
 		r        DriverResponse
-		expected map[string]any
+		expected StandardError
 	}{
 		{
 			name: "with no Output and Err",
 			r:    DriverResponse{Output: nil, Err: strptr("something went wrong")},
-			expected: map[string]any{
-				"error":   "something went wrong",
-				"name":    "Error",
-				"message": "something went wrong",
+			expected: StandardError{
+				Error:   "something went wrong",
+				Name:    "Error",
+				Message: "something went wrong",
 			},
 		},
 		{
 			name: "with no Output and no Err",
 			r:    DriverResponse{Output: nil},
-			expected: map[string]any{
-				"error":   DefaultErrorMessage,
-				"name":    "Error",
-				"message": DefaultErrorMessage,
+			expected: StandardError{
+				Error:   DefaultErrorMessage,
+				Name:    "Error",
+				Message: DefaultErrorMessage,
 			},
 		},
 		{
@@ -80,21 +80,10 @@ func TestDriverResponseFormatError(t *testing.T) {
 					"error": `{"name":"Error","message":"test"}`,
 				},
 			},
-			expected: map[string]any{
-				"name":    "Error",
-				"message": "test",
-			},
-		},
-		{
-			name: "with Output and no body",
-			r: DriverResponse{Output: map[string]any{
-				"data": "error response",
-			}},
-			expected: map[string]any{
-				// Auto-fill required fields
-				"name":    "Error",
-				"message": DefaultErrorMessage,
-				"data":    "error response",
+			expected: StandardError{
+				Error:   DefaultErrorMessage,
+				Name:    "Error",
+				Message: "test",
 			},
 		},
 		// encoded JS errors
@@ -103,11 +92,11 @@ func TestDriverResponseFormatError(t *testing.T) {
 			r: DriverResponse{Output: map[string]any{
 				"body": "{\"name\":\"Error\",\"message\":\"lolk\",\"stack\":\"stack\",\"__serialized\":true}",
 			}},
-			expected: map[string]any{
-				"name":         "Error",
-				"message":      "lolk",
-				"stack":        "stack",
-				"__serialized": true,
+			expected: StandardError{
+				Error:   DefaultErrorMessage,
+				Name:    "Error",
+				Message: "lolk",
+				Stack:   "stack",
 			},
 		},
 		{
@@ -115,11 +104,11 @@ func TestDriverResponseFormatError(t *testing.T) {
 			r: DriverResponse{Output: map[string]any{
 				"body": json.RawMessage("{\"name\":\"Error\",\"message\":\"lolk\",\"stack\":\"stack\",\"__serialized\":true}"),
 			}},
-			expected: map[string]any{
-				"name":         "Error",
-				"message":      "lolk",
-				"stack":        "stack",
-				"__serialized": true,
+			expected: StandardError{
+				Error:   DefaultErrorMessage,
+				Name:    "Error",
+				Message: "lolk",
+				Stack:   "stack",
 			},
 		},
 		{
@@ -127,36 +116,38 @@ func TestDriverResponseFormatError(t *testing.T) {
 			r: DriverResponse{Output: map[string]any{
 				"body": []byte("{\"name\":\"Error\",\"message\":\"lolk\",\"stack\":\"stack\",\"__serialized\":true}"),
 			}},
-			expected: map[string]any{
-				"name":         "Error",
-				"message":      "lolk",
-				"stack":        "stack",
-				"__serialized": true,
+			expected: StandardError{
+				Error:   DefaultErrorMessage,
+				Name:    "Error",
+				Message: "lolk",
+				Stack:   "stack",
 			},
 		},
 
 		{
 			name: "non map Output",
 			r:    DriverResponse{Output: "YOLO"},
-			expected: map[string]any{
-				"name":    "Error",
-				"message": "YOLO",
+			expected: StandardError{
+				Error:   DefaultErrorMessage,
+				Name:    "Error",
+				Message: "YOLO",
 			},
 		},
 
 		{
 			name: "non map Output with error",
 			r:    DriverResponse{Output: "YOLO", Err: strptr("502 broken")},
-			expected: map[string]any{
-				"name":    "Error",
-				"message": "YOLO",
+			expected: StandardError{
+				Error:   "502 broken",
+				Name:    "Error",
+				Message: "YOLO",
 			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// require.EqualValues(t, test.expected, test.r.UserError(), test.name)
+			require.EqualValues(t, test.expected, test.r.StandardError(), test.name)
 		})
 	}
 }


### PR DESCRIPTION
## Description

Fixes the schema for `inngest/function.failed` events having changed and no longer appropriately unpacking errors received when an SDK was not returning the error.

| ![image](https://github.com/inngest/inngest/assets/1736957/7132beea-124c-4841-a98f-7faee0072b5b) | ![image](https://github.com/inngest/inngest/assets/1736957/843ca5ff-bbf5-43ba-9a90-b42b567603ad) |
| - | - |
| Before | After |

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
