### PR TITLE
feat(dashboard): retry unauthenticated requests

### DIFF
--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -48,6 +48,7 @@
     "@team-plain/typescript-sdk": "3.0.1",
     "@urql/exchange-auth": "2.1.6",
     "@urql/exchange-request-policy": "1.0.2",
+    "@urql/exchange-retry": "1.2.0",
     "change-case": "4.1.2",
     "chrono-node": "2.7.0",
     "clsx": "1.2.1",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@urql/exchange-request-policy':
         specifier: 1.0.2
         version: 1.0.2(graphql@16.8.1)
+      '@urql/exchange-retry':
+        specifier: 1.2.0
+        version: 1.2.0(graphql@16.8.1)
       change-case:
         specifier: 4.1.2
         version: 4.1.2
@@ -9809,6 +9812,15 @@ packages:
 
   /@urql/exchange-request-policy@1.0.2(graphql@16.8.1):
     resolution: {integrity: sha512-IEC7BQGe6y5Wx3XY5PUUKSaB2TQcYkdBPw1pvgQFd09HxHyizGiB1u2Ziupz2Rmf29Eu/ZlJyxIIHcpebIliWg==}
+    dependencies:
+      '@urql/core': 4.1.1(graphql@16.8.1)
+      wonka: 6.3.2
+    transitivePeerDependencies:
+      - graphql
+    dev: false
+
+  /@urql/exchange-retry@1.2.0(graphql@16.8.1):
+    resolution: {integrity: sha512-1O/biKiVhhn0EtvDF4UOvz325K4RrLupfL8rHcmqD2TBLv4qVDWQuzx4JGa1FfqjjRb+C9TNZ6w19f32Mq85Ug==}
     dependencies:
       '@urql/core': 4.1.1(graphql@16.8.1)
       wonka: 6.3.2


### PR DESCRIPTION
## Description

This retries unauthenticated requests on the frontend and logs the error to Sentry if it still fails after the retries.

I still have to figure out how we can retry requests that happened in Server components. It might be easier to just convert those into client components.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
