### PR TITLE
Fix history not extracting and using invocation outputs for timeline

### DIFF
--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -2,6 +2,7 @@ package execution
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -181,6 +182,26 @@ type ResumeRequest struct {
 	// functions directly.
 	RunID    *ulid.ULID
 	StepName string
+}
+
+func (r *ResumeRequest) Error() string {
+	return r.withKey("error")
+}
+
+func (r *ResumeRequest) Data() string {
+	return r.withKey("data")
+}
+
+func (r *ResumeRequest) withKey(key string) string {
+	if withData, ok := r.With.(map[string]any)[key]; ok {
+		byt, err := json.Marshal(withData)
+		if err == nil {
+			return string(byt)
+		}
+		return ""
+	}
+
+	return ""
 }
 
 // HandlePauseResult returns status information about pause handling.

--- a/pkg/execution/history/lifecycle.go
+++ b/pkg/execution/history/lifecycle.go
@@ -647,6 +647,18 @@ func (l lifecycle) OnInvokeFunctionResumed(
 		WorkspaceID: id.WorkspaceID,
 		StepName:    stepName,
 	}
+
+	if withErr := req.Error(); withErr != "" {
+		h.Type = enums.HistoryTypeStepFailed.String()
+		h.Result = &Result{
+			Output: withErr,
+		}
+	} else if withData := req.Data(); withData != "" {
+		h.Result = &Result{
+			Output: withData,
+		}
+	}
+
 	for _, d := range l.drivers {
 		if err := d.Write(context.WithoutCancel(ctx), h); err != nil {
 			l.log.Error("execution lifecycle error", "lifecycle", "onInvokeFunctionResumed", "error", err)


### PR DESCRIPTION
## Description

Fixes the timeline incorrectly showing that a `step.invoke()` call succeeded if it failed, including not showing the error alongside that erroring invocation.

Before and after for a failing invocation:

| ![image](https://github.com/inngest/inngest/assets/1736957/9ffcafe9-6413-403c-b512-4fb370195041) | ![image](https://github.com/inngest/inngest/assets/1736957/f09976b9-9c03-414e-89ba-2afbc4b74009) |
| - | - |
| Before | After |

Note that the `...` "step" still exists. This shows that the function is being re-executed to give the developer a chance to handle the error. We can improve how this is demonstrated to a user in a later PR.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
