### PR TITLE
feat(dashboard): force users to have an active organization

### DIFF
--- a/ui/apps/dashboard/src/app/(auth)/organization-list/[[...organization-list]]/page.tsx
+++ b/ui/apps/dashboard/src/app/(auth)/organization-list/[[...organization-list]]/page.tsx
@@ -1,21 +1,38 @@
 import { OrganizationList } from '@clerk/nextjs';
 
 import SplitView from '@/app/(logged-out)/SplitView';
+import { getBooleanFlag } from '@/components/FeatureFlags/ServerFeatureFlag';
 
-export default function OrganizationListPage() {
+type OrganizationListPageProps = {
+  searchParams: { [key: string]: string | string[] | undefined };
+};
+
+export default async function OrganizationListPage({ searchParams }: OrganizationListPageProps) {
+  const redirectURL =
+    typeof searchParams.redirect_url === 'string'
+      ? searchParams.redirect_url
+      : process.env.NEXT_PUBLIC_HOME_PATH;
+
+  const isOrganizationsEnabled = await getBooleanFlag('organizations');
+
   return (
     <SplitView>
       <div className="mx-auto my-auto text-center">
         <OrganizationList
           hidePersonal={true}
-          afterSelectOrganizationUrl={process.env.NEXT_PUBLIC_HOME_PATH}
-          appearance={{
-            elements: {
-              // This hides the "Create Organization" button until this feature is ready.
-              dividerRow: 'hidden',
-              button: 'hidden',
-            },
-          }}
+          afterCreateOrganizationUrl="/sign-up/account-setup"
+          afterSelectOrganizationUrl={redirectURL}
+          appearance={
+            isOrganizationsEnabled
+              ? undefined
+              : {
+                  elements: {
+                    // This hides the "Create Organization" button until this feature is ready.
+                    dividerRow: 'hidden',
+                    button: 'hidden',
+                  },
+                }
+          }
         />
       </div>
     </SplitView>

--- a/ui/apps/dashboard/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/ui/apps/dashboard/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -2,15 +2,19 @@ import { cookies } from 'next/headers';
 import { SignUp } from '@clerk/nextjs';
 
 import SplitView from '@/app/(logged-out)/SplitView';
+import { getBooleanFlag } from '@/components/FeatureFlags/ServerFeatureFlag';
 
-export default function SignUpPage() {
+export default async function SignUpPage() {
   const cookieStore = cookies();
   const anonymousIDCookie = cookieStore.get('inngest_anonymous_id');
+
+  const isOrganizationsEnabled = await getBooleanFlag('organizations');
 
   return (
     <SplitView>
       <div className="mx-auto my-8 mt-auto text-center">
         <SignUp
+          afterSignUpUrl={isOrganizationsEnabled ? '/organization-list' : '/sign-up/account-setup'}
           unsafeMetadata={{
             ...(anonymousIDCookie?.value && { anonymousID: anonymousIDCookie.value }),
           }}

--- a/ui/apps/dashboard/src/app/(auth)/sign-up/account-setup/page.tsx
+++ b/ui/apps/dashboard/src/app/(auth)/sign-up/account-setup/page.tsx
@@ -23,6 +23,7 @@ export default function AccountSetupPage() {
 
     // We need to refresh the token before redirecting so that the token contains the account ID
     getToken({ skipCache: true }).then(() => {
+      // We use `replace` so that the user doesn't get redirected back to this page if they click the back button
       router.replace(process.env.NEXT_PUBLIC_HOME_PATH as Route);
     });
   }, [getToken, isAccountSetup, router]);

--- a/ui/apps/dashboard/src/app/(auth)/sign-up/account-setup/page.tsx
+++ b/ui/apps/dashboard/src/app/(auth)/sign-up/account-setup/page.tsx
@@ -3,38 +3,29 @@
 import { useEffect, useState } from 'react';
 import type { Route } from 'next';
 import { useRouter } from 'next/navigation';
-import { useUser } from '@clerk/nextjs';
+import { useAuth, useOrganization, useOrganizationList, useUser } from '@clerk/nextjs';
 import { ExclamationCircleIcon } from '@heroicons/react/20/solid';
 
+import { useBooleanFlag } from '@/components/FeatureFlags/hooks';
 import LoadingIcon from '@/icons/LoadingIcon';
 
 export default function AccountSetupPage() {
   const router = useRouter();
   const secondsElapsed = useSecondsElapsed();
+  const { getToken } = useAuth();
   const { user } = useUser();
-
-  const isAccountSetup = user && user.externalId && user.publicMetadata.accountID;
-
-  // Reload the user until the account is set up
-  useEffect(() => {
-    if (!user || isAccountSetup) return;
-
-    const intervalID = setInterval(() => {
-      user.reload();
-    }, 500);
-
-    return () => {
-      clearInterval(intervalID);
-    };
-  }, [isAccountSetup, user]);
+  useForceActiveOrganization();
+  const isAccountSetup = useIsAccountSetup();
 
   // Redirect to the home page once the account is set up
   useEffect(() => {
     if (!isAccountSetup) return;
 
-    // We use `replace` so that the user doesn't get redirected back to this page if they click the back button
-    router.replace(process.env.NEXT_PUBLIC_HOME_PATH as Route);
-  }, [isAccountSetup, router]);
+    // We need to refresh the token before redirecting so that the token contains the account ID
+    getToken({ skipCache: true }).then(() => {
+      router.replace(process.env.NEXT_PUBLIC_HOME_PATH as Route);
+    });
+  }, [getToken, isAccountSetup, router]);
 
   useEffect(() => {
     if (secondsElapsed !== 10) return;
@@ -66,6 +57,74 @@ export default function AccountSetupPage() {
       <LoadingIcon />
     </div>
   );
+}
+
+/**
+ * This forces the user to have an active organization when the organizations feature is not
+ * enabled. When the organizations feature is enabled, the user will already have an active
+ * organization set up by the `/organization-list` page.
+ */
+function useForceActiveOrganization() {
+  const { value: isOrganizationsEnabled } = useBooleanFlag('organizations');
+  const { isLoaded, userMemberships, setActive } = useOrganizationList({
+    userMemberships: {
+      infinite: true,
+    },
+  });
+  const { organization } = useOrganization();
+
+  useEffect(() => {
+    if (!isOrganizationsEnabled && isLoaded && userMemberships.data[0] && !organization) {
+      setActive({ organization: userMemberships.data[0].organization });
+    }
+  }, [isLoaded, isOrganizationsEnabled, organization, setActive, userMemberships.data]);
+
+  // Reload memberships if the user doesn't have an active organization
+  useEffect(() => {
+    if (isOrganizationsEnabled || !isLoaded || userMemberships.data[0] || organization) return;
+
+    const intervalID = setInterval(() => {
+      userMemberships.revalidate();
+    }, 500);
+
+    return () => {
+      clearInterval(intervalID);
+    };
+  }, [
+    isLoaded,
+    isOrganizationsEnabled,
+    organization,
+    setActive,
+    userMemberships,
+    userMemberships.data,
+  ]);
+}
+
+/**
+ * This hook returns true if the user's account is set up. It will reload the organization until
+ * the account is set up.
+ *
+ * @returns {boolean}
+ */
+function useIsAccountSetup(): boolean {
+  const { organization } = useOrganization();
+
+  const isAccountSetup = Boolean(organization?.publicMetadata.accountID);
+
+  // Reload the organization until the account is set up
+  useEffect(() => {
+    if (!organization || isAccountSetup) return;
+
+    const intervalID = setInterval(() => {
+      organization.reload();
+    }, 500);
+
+    return () => {
+      clearInterval(intervalID);
+    };
+  }, [isAccountSetup, organization]);
+
+  return isAccountSetup;
 }
 
 function useSecondsElapsed() {

--- a/ui/apps/dashboard/src/middleware.ts
+++ b/ui/apps/dashboard/src/middleware.ts
@@ -11,6 +11,7 @@ export default authMiddleware({
   ignoredRoutes: '/(images|_next/static|_next/image|favicon)(.*)',
   afterAuth(auth, request) {
     const isSignedIn = !!auth.userId;
+    const hasActiveOrganization = !!auth.orgId;
     const isAccountSetup =
       isSignedIn && auth.sessionClaims.externalID && auth.sessionClaims.accountID;
 
@@ -18,7 +19,23 @@ export default authMiddleware({
       return redirectToSignIn({ returnBackUrl: request.url });
     }
 
-    if (isSignedIn && !isAccountSetup && request.nextUrl.pathname !== '/sign-up/account-setup') {
+    if (
+      isSignedIn &&
+      !hasActiveOrganization &&
+      request.nextUrl.pathname !== '/organization-list' &&
+      request.nextUrl.pathname !== '/sign-up/account-setup'
+    ) {
+      const organizationListURL = new URL('/organization-list', request.url);
+      organizationListURL.searchParams.append('redirect_url', request.url);
+      return NextResponse.redirect(organizationListURL);
+    }
+
+    if (
+      isSignedIn &&
+      !isAccountSetup &&
+      request.nextUrl.pathname !== '/sign-up/account-setup' &&
+      request.nextUrl.pathname !== '/organization-list'
+    ) {
       return NextResponse.redirect(new URL('/sign-up/account-setup', request.url));
     }
 

--- a/ui/apps/dashboard/src/middleware.ts
+++ b/ui/apps/dashboard/src/middleware.ts
@@ -12,8 +12,7 @@ export default authMiddleware({
   afterAuth(auth, request) {
     const isSignedIn = !!auth.userId;
     const hasActiveOrganization = !!auth.orgId;
-    const isAccountSetup =
-      isSignedIn && auth.sessionClaims.externalID && auth.sessionClaims.accountID;
+    const isAccountSetup = isSignedIn && hasActiveOrganization && !!auth.sessionClaims.accountID;
 
     if (!isSignedIn && !auth.isPublicRoute) {
       return redirectToSignIn({ returnBackUrl: request.url });


### PR DESCRIPTION
## Description

This forces users to have an active organization by redirecting them to the "Organization List" page.

On the `account-setup` page, we auto-select the newly created organization for them.

This is needed since we'll be extracting the account ID from the user's active organization.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
