### PR TITLE
Fix: Refresh billing data after plan update

### DIFF
--- a/ui/apps/dashboard/src/app/(dashboard)/settings/billing/BillingPlanSelector.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/settings/billing/BillingPlanSelector.tsx
@@ -16,9 +16,11 @@ import { type ExtendedBillingPlan } from './utils';
 export default function BillingPlanSelector({
   plans,
   isCurrentPlanEnterprise,
+  onUpdate,
 }: {
   plans: (ExtendedBillingPlan | null)[];
   isCurrentPlanEnterprise: boolean;
+  onUpdate: () => void;
 }) {
   const router = useRouter();
   const [checkoutData, setCheckoutData] = useState<{
@@ -46,6 +48,7 @@ export default function BillingPlanSelector({
 
   const onChangePlanSuccess = () => {
     setCheckoutData(undefined);
+    onUpdate();
     router.refresh();
   };
 

--- a/ui/apps/dashboard/src/app/(dashboard)/settings/billing/page.tsx
+++ b/ui/apps/dashboard/src/app/(dashboard)/settings/billing/page.tsx
@@ -65,7 +65,7 @@ const GetBillingInfoDocument = graphql(`
 `);
 
 export default function Billing() {
-  const [{ data, fetching }] = useQuery({
+  const [{ data, fetching }, refetch] = useQuery({
     query: GetBillingInfoDocument,
   });
 
@@ -111,7 +111,11 @@ export default function Billing() {
         </div>
       </div>
 
-      <BillingPlanSelector plans={plans} isCurrentPlanEnterprise={isCurrentPlanEnterprise} />
+      <BillingPlanSelector
+        plans={plans}
+        isCurrentPlanEnterprise={isCurrentPlanEnterprise}
+        onUpdate={() => refetch()}
+      />
 
       <section>
         <h2 id="payments" className="py-6 text-2xl font-semibold">


### PR DESCRIPTION
## Description

After the move to client components, the refresh no longer works.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
