### PR TITLE
Fix: Always render error if it's not parsable

### DIFF
--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.stories.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.stories.tsx
@@ -106,7 +106,10 @@ export const Errored: Story = {
     node: {
       ...defaultNode,
       status: 'errored',
+      outputItemID: '123',
+      attempts: {},
     },
+    getOutput: async () => 'error code: 524',
   },
 };
 

--- a/ui/packages/components/src/utils/outputRenderer.ts
+++ b/ui/packages/components/src/utils/outputRenderer.ts
@@ -50,6 +50,9 @@ export function renderOutput({
         output = error.stack ?? '';
       } catch (error) {
         console.error("Error parsing 'jsonObject' JSON:", error);
+        message = 'Unable to parse error message';
+        errorName = 'Unknown Error';
+        output = content;
       }
     } else if (!isOutputTooLarge) {
       if (typeof content === 'string') {


### PR DESCRIPTION
## Description

Previously, if the error was something raw, like `error code: 524`, we would not render anything. This ensures that we take whatever string that we have and render it as an "Unknown error" to at least present the user with some information for debugging purposes.

![image](https://github.com/inngest/inngest/assets/1509457/3e205bc8-01fe-48b8-9d47-49f5c2f9379d)


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
