### PR TITLE
Add partition sharding within queue operations

### DIFF
--- a/pkg/execution/state/redis_state/lua/includes/has_shard_key.lua
+++ b/pkg/execution/state/redis_state/lua/includes/has_shard_key.lua
@@ -1,0 +1,3 @@
+local function has_shard_key(key)
+	return string.sub(key, -2) ~= ":-"
+end

--- a/pkg/execution/state/redis_state/lua/includes/update_pointer_score.lua
+++ b/pkg/execution/state/redis_state/lua/includes/update_pointer_score.lua
@@ -1,0 +1,21 @@
+-- This function updates a function's place in the pointer queue to the given
+-- score.  This score should almost always be the value from `get_fn_partition_score`.
+-- It's a separate function as > 1 pointer queue may be updated at a time.
+local function update_pointer_score_to(fnID, pointerQueueKey, updateTo)
+    -- Only update if set.
+    if updateTo > 0 then
+        redis.call("ZADD", pointerQueueKey, updateTo, fnID)
+    end
+end
+
+-- get_fn_partition_score returns a fn's earliest job as a score for pointer queues.
+-- This returns 0 if there are no scores available.
+local function get_fn_partition_score(fnQueueKey)
+    local earliestScore = redis.call("ZRANGE", fnQueueKey, "-inf", "+inf", "BYSCORE", "LIMIT", 0, 1, "WITHSCORES")
+    if earliestScore == nil or earliestScore == false or earliestScore[2] == nil then
+        return 0
+    end
+    -- queues are ordered by ms precision, whereas pointers are second precision.
+    -- earliest is a table containing {item, score}
+    return math.floor(tonumber(earliestScore[2]) / 1000)
+end

--- a/pkg/execution/state/redis_state/lua/queue/enqueue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/enqueue.lua
@@ -5,34 +5,37 @@ Enqueus an item within the queue.
 
 --]]
 
-local queueKey            = KEYS[1]   -- queue:item - hash: { $itemID: $item }
-local queueIndexKey       = KEYS[2]   -- queue:sorted:$workflowID - zset
-local partitionKey        = KEYS[3]   -- partition:item - hash: { $workflowID: $partition }
-local partitionCounterKey = KEYS[4]   -- partition:item:$workflowID - hash: { "n": items leased/in-progress, "len": total enqueued }
-local partitionIndexKey   = KEYS[5]   -- partition:sorted - zset
-local idempotencyKey      = KEYS[6]   -- seen:$key
+local queueKey            = KEYS[1]           -- queue:item - hash: { $itemID: $item }
+local queueIndexKey       = KEYS[2]           -- queue:sorted:$workflowID - zset
+local partitionKey        = KEYS[3]           -- partition:item - hash: { $workflowID: $partition }
+local partitionCounterKey = KEYS[4]           -- partition:item:$workflowID - hash
+local partitionIndexKey   = KEYS[5]           -- partition:sorted - zset
+local shardIndexKey       = KEYS[6]           -- shard:$name:sorted - zset
+local shardMapKey         = KEYS[7]           -- shards - hmap of shards
+local idempotencyKey      = KEYS[8]           -- seen:$key
+local keyItemIndexA       = KEYS[9]           -- custom item index 1
+local keyItemIndexB       = KEYS[10]          -- custom item index 2
 
-local keyItemIndexA       = KEYS[7]   -- custom item index 1
-local keyItemIndexB       = KEYS[8]   -- custom item index 2
-
-local queueItem      = ARGV[1] -- {id, lease id, attempt, max attempt, data, etc...}
-local queueID        = ARGV[2] -- id
-local queueScore     = tonumber(ARGV[3]) -- vesting time, in milliseconds
-local workflowID     = ARGV[4] -- $workflowID
-local partitionItem  = ARGV[5] -- {workflow, priority, leasedAt, etc}
-local partitionTime  = tonumber(ARGV[6]) -- score for partition, lower bounded to now in seconds
+local queueItem           = ARGV[1]           -- {id, lease id, attempt, max attempt, data, etc...}
+local queueID             = ARGV[2]           -- id
+local queueScore          = tonumber(ARGV[3]) -- vesting time, in milliseconds
+local workflowID          = ARGV[4]           -- $workflowID
+local partitionItem       = ARGV[5]           -- {workflow, priority, leasedAt, etc}
+local partitionTime       = tonumber(ARGV[6]) -- score for partition, lower bounded to now in seconds
+local shard               = ARGV[7]
+local shardName           = ARGV[8]
 
 -- $include(get_partition_item.lua)
 
 -- Check idempotency exists
 if redis.call("EXISTS", idempotencyKey) ~= 0 then
-	return 1
+    return 1
 end
 
 -- Make these a hash to save on memory usage
 if redis.call("HSETNX", queueKey, queueID, queueItem) == 0 then
-	-- This already exists;  return an error.
-	return 1
+    -- This already exists;  return an error.
+    return 1
 end
 
 -- We score the queue items separately, as we need to continually update the score
@@ -45,39 +48,53 @@ redis.call("ZADD", queueIndexKey, queueScore, queueID)
 -- as we want a static member excluding eg. lease IDs.  This allows us to update
 -- scores idempotently.
 redis.call("HSETNX", partitionKey, workflowID, partitionItem)
-redis.call("HSETNX", partitionCounterKey, "n", 0)   -- Atomic counter, currently leased (in progress) items.
+redis.call("HSETNX", partitionCounterKey, "n", 0)    -- Atomic counter, currently leased (in progress) items.
 redis.call("HINCRBY", partitionCounterKey, "len", 1) -- Atomic counter, length of enqueued items, set to 1 or increased.
+
+-- If this is a sharded item, upsert the shard.
+if shard ~= "" and shard ~= "null" then
+    -- NOTE: We do not want to overwrite the shard leases, so here
+    -- we fetch the shard item, set the lease values in the passed in shard
+    -- item, then write the updated value.
+    --
+    -- TODO: LEASES ???
+    redis.call("HSET", shardMapKey, shardName, shard)
+end
 
 -- Get the current score of the partition;  if queueScore < currentScore update the
 -- partition's score so that we can work on this workflow when the earliest member
 -- is available.
 local currentScore = redis.call("ZSCORE", partitionIndexKey, workflowID)
 if currentScore == false or tonumber(currentScore) > partitionTime then
-	redis.call("ZADD", partitionIndexKey, partitionTime, workflowID)
+    redis.call("ZADD", partitionIndexKey, partitionTime, workflowID)
 
-	-- Get the partition item, so that we can keep the last lease score.
-	local existing = get_partition_item(partitionKey, workflowID)
-	if existing ~= nil then
-		local decoded = cjson.decode(partitionItem)
-		decoded.last = existing.last
-		partitionItem = cjson.encode(decoded)
-	end
+    -- if this is sharded we have a shard partition to update.
+    if shard ~= "" and shard ~= "null" then
+        redis.call("ZADD", shardIndexKey, partitionTime, workflowID)
+    end
 
-	-- Update the partition item too
-	redis.call("HSET", partitionKey, workflowID, partitionItem)
+    -- Get the partition item, so that we can keep the last lease score.
+    local existing = get_partition_item(partitionKey, workflowID)
+    if existing ~= nil then
+        local decoded = cjson.decode(partitionItem)
+        decoded.last = existing.last
+        partitionItem = cjson.encode(decoded)
+    end
+
+    -- Set the partition item.  We must always do this so that we can
+    -- update priorities on the fly.
+    redis.call("HSET", partitionKey, workflowID, partitionItem)
 end
 
 -- Add optional indexes.
 if keyItemIndexA ~= "" and keyItemIndexA ~= false and keyItemIndexA ~= nil then
-	redis.call("ZADD", keyItemIndexA, queueScore, queueID)
+    redis.call("ZADD", keyItemIndexA, queueScore, queueID)
 end
 if keyItemIndexB ~= "" and keyItemIndexB ~= false and keyItemIndexB ~= nil then
-	redis.call("ZADD", keyItemIndexB, queueScore, queueID)
+    redis.call("ZADD", keyItemIndexB, queueScore, queueID)
 end
 
 -- TODO: For the given workflow ID increase scheduled count, store a history item,
 -- etc:  this can be atomic in the redis queue as it combines state + queue.
 
 return 0
-
-

--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -12,48 +12,51 @@ Output:
 
 ]]
 
-local queueKey      = KEYS[1]
-local queueIndexKey = KEYS[2]
-local partitionKey  = KEYS[3]
+local queueKey               = KEYS[1]
+local queueIndexKey          = KEYS[2]
+local partitionKey           = KEYS[3]
 -- We push our queue item ID into each concurrency queue
-local accountConcurrencyKey   = KEYS[4] -- Account concurrency level
-local partitionConcurrencyKey = KEYS[5] -- When leasing an item we need to place the lease into this key.
-local customConcurrencyKeyA   = KEYS[6] -- Optional for eg. for concurrency amongst steps 
-local customConcurrencyKeyB   = KEYS[7] -- Optional for eg. for concurrency amongst steps 
+local accountConcurrencyKey  = KEYS[4] -- Account concurrency level
+local functionConcurrencyKey = KEYS[5] -- When leasing an item we need to place the lease into this key.
+local customConcurrencyKeyA  = KEYS[6] -- Optional for eg. for concurrency amongst steps
+local customConcurrencyKeyB  = KEYS[7] -- Optional for eg. for concurrency amongst steps
 -- We push pointers to partition concurrency items to the partition concurrency item
-local concurrencyPointer      = KEYS[8]
+local concurrencyPointer     = KEYS[8]
+local globalPointerKey       = KEYS[9]
+local shardPointerKey        = KEYS[10]
 
-local queueID       = ARGV[1]
-local newLeaseKey   = ARGV[2]
-local currentTime   = tonumber(ARGV[3]) -- in ms
+local queueID                = ARGV[1]
+local newLeaseKey            = ARGV[2]
+local currentTime            = tonumber(ARGV[3]) -- in ms
 -- We check concurrency limits when leasing queue items: an account-level concurrency limit,
 -- and a custom key.  The custom key is option.  It's used to add concurrency limits to individual
 -- steps across differing functions
-local accountConcurrency   = tonumber(ARGV[4])
-local partitionConcurrency = tonumber(ARGV[5])
-local customConcurrencyA   = tonumber(ARGV[6])
-local customConcurrencyB   = tonumber(ARGV[7])
-local partitionName        = ARGV[8]
+local accountConcurrency     = tonumber(ARGV[4])
+local partitionConcurrency   = tonumber(ARGV[5])
+local customConcurrencyA     = tonumber(ARGV[6])
+local customConcurrencyB     = tonumber(ARGV[7])
+local partitionName          = ARGV[8] -- Same as fn queue name/workflow ID
 
 -- Use our custom Go preprocessor to inject the file from ./includes/
 -- $include(decode_ulid_time.lua)
 -- $include(check_concurrency.lua)
 -- $include(get_queue_item.lua)
 -- $include(set_item_peek_time.lua)
+-- $include(update_pointer_score.lua)
 
 -- first, get the queue item.  we must do this and bail early if the queue item
 -- was not found.
-local item = get_queue_item(queueKey, queueID)
+local item                   = get_queue_item(queueKey, queueID)
 if item == nil then
-	return 1
+    return 1
 end
 
 -- Grab the current time from the new lease key.
 local nextTime = decode_ulid_time(newLeaseKey)
--- check if the item is leased. 
+-- check if the item is leased.
 if item.leaseID ~= nil and item.leaseID ~= cjson.null and decode_ulid_time(item.leaseID) > currentTime then
-	-- This is already leased;  don't let this requester lease the item.
-	return 2
+    -- This is already leased;  don't let this requester lease the item.
+    return 2
 end
 
 -- Track the earliest time this job was attempted in the queue.
@@ -63,24 +66,24 @@ item = set_item_peek_time(queueKey, queueID, item, currentTime)
 -- leasing the partition and do not need to be checked again (only one worker can run a partition at
 -- once, and the capacity is kept in memory after leasing a partition)
 if partitionConcurrency > 0 then
-	if check_concurrency(currentTime, partitionConcurrencyKey, partitionConcurrency) <= 0 then
-		return 3
-	end
+    if check_concurrency(currentTime, functionConcurrencyKey, partitionConcurrency) <= 0 then
+        return 3
+    end
 end
 if accountConcurrency > 0 then
-	if check_concurrency(currentTime, accountConcurrencyKey, accountConcurrency) <= 0 then
-		return 4
-	end
+    if check_concurrency(currentTime, accountConcurrencyKey, accountConcurrency) <= 0 then
+        return 4
+    end
 end
 if customConcurrencyA > 0 then
-	if check_concurrency(currentTime, customConcurrencyKeyA, customConcurrencyA) <= 0 then
-		return 5
-	end
+    if check_concurrency(currentTime, customConcurrencyKeyA, customConcurrencyA) <= 0 then
+        return 5
+    end
 end
 if customConcurrencyB > 0 then
-	if check_concurrency(currentTime, customConcurrencyKeyB, customConcurrencyB) <= 0 then
-		return 6
-	end
+    if check_concurrency(currentTime, customConcurrencyKeyB, customConcurrencyB) <= 0 then
+        return 6
+    end
 end
 
 -- Update the item's lease key.
@@ -88,32 +91,43 @@ item.leaseID = newLeaseKey
 redis.call("HSET", queueKey, queueID, cjson.encode(item))
 
 -- Add the item to all concurrency keys
-redis.call("ZADD", partitionConcurrencyKey, nextTime, item.id)
+redis.call("ZADD", functionConcurrencyKey, nextTime, item.id)
+
+-- Remove the item from our sorted index, as this is no longer on the queue; it's in-progress
+-- and store din functionConcurrencyKey.
+redis.call("ZREM", queueIndexKey, item.id)
+
+-- Update the fn's score in the global pointer queue to the next job, if available.
+local score = get_fn_partition_score(queueIndexKey)
+update_pointer_score_to(partitionName, globalPointerKey, score)
+-- And the same for any shards, as long as the shard name exists.
+if string.sub(shardPointerKey, -2) ~= ":-" then
+    update_pointer_score_to(partitionName, shardPointerKey, score)
+end
 
 -- NOTE: We check if concurrency > 0 here because this disables concurrency.  AccountID
 -- and custom concurrency items may not be set, but the keys need to be set for clustered
 -- mode.
 if accountConcurrency > 0 then
-	redis.call("ZADD", accountConcurrencyKey, nextTime, item.id)
+    redis.call("ZADD", accountConcurrencyKey, nextTime, item.id)
 end
 if customConcurrencyA > 0 then
-	redis.call("ZADD", customConcurrencyKeyA, nextTime, item.id)
+    redis.call("ZADD", customConcurrencyKeyA, nextTime, item.id)
 end
 if customConcurrencyB > 0 then
-	redis.call("ZADD", customConcurrencyKeyB, nextTime, item.id)
+    redis.call("ZADD", customConcurrencyKeyB, nextTime, item.id)
 end
 
--- Get the earliest item in the partition concurrency set.  If the current lease is
--- the only item in the set, we'll get the current lease.  Otherwise, we might get
--- a lost job or a previously lost job.
-local concurrencyScores = redis.call("ZRANGE", partitionConcurrencyKey, "-inf", "+inf", "BYSCORE", "LIMIT", 0, 1, "WITHSCORES")
-if concurrencyScores ~= false then
-	local earliestLease = tonumber(concurrencyScores[2])
-	-- Ensure that we update the score with the earliest lease, which may be a no-op.
-	redis.call("ZADD", concurrencyPointer, earliestLease, partitionName)
+-- Get the earliest item in the partition/fn concurrency set - all items that have
+-- been leased and are in progress.  If the current lease is the only item in the set, we'll
+-- get the current lease.  Otherwise, we might get a lost job or a previously lost job.
+local inProgressScores = redis.call("ZRANGE", functionConcurrencyKey, "-inf", "+inf", "BYSCORE", "LIMIT", 0, 1,
+    "WITHSCORES")
+if inProgressScores ~= false then
+    local earliestLease = tonumber(inProgressScores[2])
+    -- Add the earliest time to the pointer queue for in-progress, allowing us to scavenge
+    -- lost jobs easily.
+    redis.call("ZADD", concurrencyPointer, earliestLease, partitionName)
 end
-
--- Remove the item from our sorted index, as this is no longer on the queue.
-redis.call("ZREM", queueIndexKey, item.id)
 
 return 0

--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -43,6 +43,7 @@ local partitionName          = ARGV[8] -- Same as fn queue name/workflow ID
 -- $include(get_queue_item.lua)
 -- $include(set_item_peek_time.lua)
 -- $include(update_pointer_score.lua)
+-- $include(has_shard_key.lua)
 
 -- first, get the queue item.  we must do this and bail early if the queue item
 -- was not found.
@@ -101,7 +102,7 @@ redis.call("ZREM", queueIndexKey, item.id)
 local score = get_fn_partition_score(queueIndexKey)
 update_pointer_score_to(partitionName, globalPointerKey, score)
 -- And the same for any shards, as long as the shard name exists.
-if string.sub(shardPointerKey, -2) ~= ":-" then
+if has_shard_key(shardPointerKey) then
     update_pointer_score_to(partitionName, shardPointerKey, score)
 end
 

--- a/pkg/execution/state/redis_state/lua/queue/partitionLease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/partitionLease.lua
@@ -9,49 +9,50 @@ Output:
 ]]
 
 local partitionKey            = KEYS[1]
-local partitionIndexKey       = KEYS[2]
-local partitionConcurrencyKey = KEYS[3]
+local keyGlobalPartitionPtr   = KEYS[2]
+local keyShardPartitionPtr    = KEYS[3]
+local partitionConcurrencyKey = KEYS[4]
 
-local partitionID = ARGV[1]
-local leaseID     = ARGV[2]
-local currentTime = tonumber(ARGV[3]) -- in ms, to check lease validation
-local leaseTime   = tonumber(ARGV[4]) -- in seconds, as partition score
-local concurrency = tonumber(ARGV[5]) -- concurrency limit for this partition
+local partitionID             = ARGV[1]
+local leaseID                 = ARGV[2]
+local currentTime             = tonumber(ARGV[3]) -- in ms, to check lease validation
+local leaseTime               = tonumber(ARGV[4]) -- in seconds, as partition score
+local concurrency             = tonumber(ARGV[5]) -- concurrency limit for this partition
 
 -- $include(check_concurrency.lua)
 -- $include(get_partition_item.lua)
 -- $include(decode_ulid_time.lua)
+-- $include(update_pointer_score.lua)
 
-local existing = get_partition_item(partitionKey, partitionID)
+local existing                = get_partition_item(partitionKey, partitionID)
 if existing == nil or existing == false then
-	return -2
+    return -2
 end
 
 -- Check for an existing lease.
 if existing.leaseID ~= nil and existing.leaseID ~= cjson.null and decode_ulid_time(existing.leaseID) > currentTime then
-	return -3
+    return -3
 end
 
-local now_seconds = math.floor(currentTime / 1000)
 local capacity = concurrency -- initialize as the default concurrency limit
 
 local existingTime = existing.last
 
 if concurrency > 0 and #partitionConcurrencyKey > 0 then
-	-- Check that there's capacity for this partition, based off of partition-level
-	-- concurrency keys.
-	capacity = check_concurrency(currentTime, partitionConcurrencyKey, concurrency)
-	if capacity <= 0 then
-		-- There's no capacity available.  Increase the score for this partition so that
-		-- it's not immediately re-scanned.
-		redis.call("ZADD", partitionIndexKey, leaseTime, partitionID)
+    -- Check that there's capacity for this partition, based off of partition-level
+    -- concurrency keys.
+    capacity = check_concurrency(currentTime, partitionConcurrencyKey, concurrency)
+    if capacity <= 0 then
+        -- There's no capacity available.  Increase the score for this partition so that
+        -- it's not immediately re-scanned.
+        redis.call("ZADD", keyGlobalPartitionPtr, leaseTime, partitionID)
 
-		-- Update that we attempted to lease this partition, even if there was no capacity.
-		existing.last = currentTime -- in ms.
-		redis.call("HSET", partitionKey, partitionID, cjson.encode(existing))
+        -- Update that we attempted to lease this partition, even if there was no capacity.
+        existing.last = currentTime -- in ms.
+        redis.call("HSET", partitionKey, partitionID, cjson.encode(existing))
 
-		return -1
-	end
+        return -1
+    end
 end
 
 existing.leaseID = leaseID
@@ -60,6 +61,9 @@ existing.last = currentTime -- in ms.
 
 -- Update item and index score
 redis.call("HSET", partitionKey, partitionID, cjson.encode(existing))
-redis.call("ZADD", partitionIndexKey, leaseTime, partitionID) -- partition scored are in seconds.
+redis.call("ZADD", keyGlobalPartitionPtr, leaseTime, partitionID) -- partition scored are in seconds.
+if string.sub(keyShardPartitionPtr, -2) ~= ":-" then
+    update_pointer_score_to(partitionID, keyShardPartitionPtr, leaseTime)
+end
 
 return existingTime

--- a/pkg/execution/state/redis_state/lua/queue/partitionLease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/partitionLease.lua
@@ -23,6 +23,7 @@ local concurrency             = tonumber(ARGV[5]) -- concurrency limit for this 
 -- $include(get_partition_item.lua)
 -- $include(decode_ulid_time.lua)
 -- $include(update_pointer_score.lua)
+-- $include(has_shard_key.lua)
 
 local existing                = get_partition_item(partitionKey, partitionID)
 if existing == nil or existing == false then
@@ -62,7 +63,7 @@ existing.last = currentTime -- in ms.
 -- Update item and index score
 redis.call("HSET", partitionKey, partitionID, cjson.encode(existing))
 redis.call("ZADD", keyGlobalPartitionPtr, leaseTime, partitionID) -- partition scored are in seconds.
-if string.sub(keyShardPartitionPtr, -2) ~= ":-" then
+if has_shard_key(keyShardPartitionPtr) then
     update_pointer_score_to(partitionID, keyShardPartitionPtr, leaseTime)
 end
 

--- a/pkg/execution/state/redis_state/lua/queue/requeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/requeue.lua
@@ -32,6 +32,7 @@ local partitionItem           = ARGV[5]           -- {workflow, priority, leased
 -- $include(get_queue_item.lua)
 -- $include(get_partition_item.lua)
 -- $include(update_pointer_score.lua)
+-- $include(has_shard_key.lua)
 
 local item                    = get_queue_item(queueKey, queueID)
 if item == nil then
@@ -74,7 +75,7 @@ local earliestTime = get_fn_partition_score(queueIndexKey)
 if currentScore == false or tonumber(currentScore) ~= earliestTime or tonumber(currentScore) == nil then
     redis.call("ZADD", partitionIndexKey, earliestTime, functionID)
     -- And the same for any shards, as long as the shard name exists.
-    if string.sub(shardPointerKey, -2) ~= ":-" then
+    if has_shard_key(shardPointerKey, -2) then
         update_pointer_score_to(functionID, shardPointerKey, earliestTime)
     end
 end

--- a/pkg/execution/state/redis_state/lua/queue/requeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/requeue.lua
@@ -8,97 +8,101 @@ Output:
 
 ]]
 
-local queueKey          = KEYS[1] -- queue:item - hash: { $itemID: $item }
-local queueIndexKey     = KEYS[2] -- queue:sorted:$workflowID - zset
-local partitionKey      = KEYS[3] -- partition:item:$workflowID - hash { n: $leased, len: $enqueued }
-local partitionIndexKey = KEYS[4] -- partition:sorted - zset
+local queueKey                = KEYS[1] -- queue:item - hash: { $itemID: $item }
+local queueIndexKey           = KEYS[2] -- queue:sorted:$workflowID - zset
+local partitionKey            = KEYS[3] -- partition:item:$workflowID - hash { n: $leased, len: $enqueued }
+local partitionIndexKey       = KEYS[4] -- partition:sorted - zset
 -- We push our queue item ID into each concurrency queue
 local accountConcurrencyKey   = KEYS[5] -- Account concurrency level
 local partitionConcurrencyKey = KEYS[6] -- When leasing an item we need to place the lease into this key.
-local customConcurrencyKeyA   = KEYS[7] -- Optional for eg. for concurrency amongst steps 
-local customConcurrencyKeyB   = KEYS[8] -- Optional for eg. for concurrency amongst steps 
+local customConcurrencyKeyA   = KEYS[7] -- Optional for eg. for concurrency amongst steps
+local customConcurrencyKeyB   = KEYS[8] -- Optional for eg. for concurrency amongst steps
 -- We push pointers to partition concurrency items to the partition concurrency item
 local concurrencyPointer      = KEYS[9]
-local keyItemIndexA           = KEYS[10]  -- custom item index 1
-local keyItemIndexB           = KEYS[11]  -- custom item index 2
+local shardPointerKey         = KEYS[10]
+local keyItemIndexA           = KEYS[11]          -- custom item index 1
+local keyItemIndexB           = KEYS[12]          -- custom item index 2
 
-local queueItem      = ARGV[1] -- {id, lease id, attempt, max attempt, data, etc...}
-local queueID        = ARGV[2] -- id
-local queueScore     = tonumber(ARGV[3]) -- vesting time, in ms
-local partitionIndex = ARGV[4] -- workflowID
-local partitionItem  = ARGV[5] -- {workflow, priority, leasedAt, etc}
+local queueItem               = ARGV[1]           -- {id, lease id, attempt, max attempt, data, etc...}
+local queueID                 = ARGV[2]           -- id
+local queueScore              = tonumber(ARGV[3]) -- vesting time, in ms
+local functionID              = ARGV[4]           -- workflowID
+local partitionItem           = ARGV[5]           -- {workflow, priority, leasedAt, etc}
 
 -- $include(get_queue_item.lua)
-local item = get_queue_item(queueKey, queueID)
+-- $include(get_partition_item.lua)
+-- $include(update_pointer_score.lua)
+
+local item                    = get_queue_item(queueKey, queueID)
 if item == nil then
-	return 1
+    return 1
 end
 
 if item.leaseID ~= nil and item.leaseID ~= cjson.null then
-	-- Remove total number in progress if there's a lease.
-	-- XXX: This is unused and is a rough indicator.  Use concurrency queues for
-	-- an actual indicator.
-	redis.call("HINCRBY", partitionKey, "n", -1)
+    -- Remove total number in progress if there's a lease.
+    -- XXX: This is unused and is a rough indicator.  Use concurrency queues for
+    -- an actual indicator.
+    redis.call("HINCRBY", partitionKey, "n", -1)
 end
 
-redis.call("HSET", queueKey, queueID, queueItem) 
+redis.call("HSET", queueKey, queueID, queueItem)
 -- Update the queue score
 redis.call("ZADD", queueIndexKey, queueScore, queueID)
 
 -- Remove this from all in-progress queues
 redis.call("ZREM", partitionConcurrencyKey, item.id)
 if accountConcurrencyKey ~= nil and accountConcurrencyKey ~= "" then
-	redis.call("ZREM", accountConcurrencyKey, item.id)
+    redis.call("ZREM", accountConcurrencyKey, item.id)
 end
 if customConcurrencyKeyA ~= nil and customConcurrencyKeyA ~= "" then
-	redis.call("ZREM", customConcurrencyKeyA, item.id)
+    redis.call("ZREM", customConcurrencyKeyA, item.id)
 end
 if customConcurrencyKeyB ~= nil and customConcurrencyKeyB ~= "" then
-	redis.call("ZREM", customConcurrencyKeyB, item.id)
+    redis.call("ZREM", customConcurrencyKeyB, item.id)
 end
 
 -- Fetch partition index;  ensure this is the same as our lowest queue item score
-local currentScore = redis.call("ZSCORE", partitionIndexKey, partitionIndex)
+local currentScore = redis.call("ZSCORE", partitionIndexKey, functionID)
 
 -- Peek the earliest time from the queue index.  We need to know
 -- the earliest time for the entire function set, as we may be
 -- rescheduling the only time in the queue;  this is the only way
 -- to update the partiton index.
-local earliestQueueScore = redis.call("ZRANGE", queueIndexKey, "-inf", "+inf", "BYSCORE", "LIMIT", 0, 1, "WITHSCORES")
-
--- queues are ordered by ms precision, whereas pointers are second precision.
-local earliestTime = math.floor(tonumber(earliestQueueScore[2]) / 1000)
+local earliestTime = get_fn_partition_score(queueIndexKey)
 
 -- earliest is a table containing {item, score}
 if currentScore == false or tonumber(currentScore) ~= earliestTime or tonumber(currentScore) == nil then
-	redis.call("ZADD", partitionIndexKey, earliestTime, partitionIndex)
-	-- Update the partition item too
-	redis.call("HSET", partitionKey, "item", partitionItem)
+    redis.call("ZADD", partitionIndexKey, earliestTime, functionID)
+    -- And the same for any shards, as long as the shard name exists.
+    if string.sub(shardPointerKey, -2) ~= ":-" then
+        update_pointer_score_to(functionID, shardPointerKey, earliestTime)
+    end
 end
 
 -- Get the earliest item in the partition concurrency set.  We may be requeueing
 -- the only in-progress job and should remove this from the partition concurrency
 -- pointers, if this exists.
-local concurrencyScores = redis.call("ZRANGE", partitionConcurrencyKey, "-inf", "+inf", "BYSCORE", "LIMIT", 0, 1, "WITHSCORES")
+local concurrencyScores = redis.call("ZRANGE", partitionConcurrencyKey, "-inf", "+inf", "BYSCORE", "LIMIT", 0, 1,
+    "WITHSCORES")
 if concurrencyScores == false then
-	redis.call("ZREM", concurrencyPointer, partitionIndex)
+    redis.call("ZREM", concurrencyPointer, functionID)
 else
-	local earliestLease = tonumber(concurrencyScores[2])
-	if earliestLease == nil then
-		redis.call("ZREM", concurrencyPointer, partitionIndex)
-	else
-		-- Ensure that we update the score with the earliest lease
-		redis.call("ZADD", concurrencyPointer, earliestLease, partitionIndex)
-	end
+    local earliestLease = tonumber(concurrencyScores[2])
+    if earliestLease == nil then
+        redis.call("ZREM", concurrencyPointer, functionID)
+    else
+        -- Ensure that we update the score with the earliest lease
+        redis.call("ZADD", concurrencyPointer, earliestLease, functionID)
+    end
 end
 
 
 -- Add optional indexes.
 if keyItemIndexA ~= "" and keyItemIndexA ~= false and keyItemIndexA ~= nil then
-	redis.call("ZADD", keyItemIndexA, queueScore, queueID)
+    redis.call("ZADD", keyItemIndexA, queueScore, queueID)
 end
 if keyItemIndexB ~= "" and keyItemIndexB ~= false and keyItemIndexB ~= nil then
-	redis.call("ZADD", keyItemIndexB, queueScore, queueID)
+    redis.call("ZADD", keyItemIndexB, queueScore, queueID)
 end
 
 return 0

--- a/pkg/execution/state/redis_state/lua/queue/requeueByID.lua
+++ b/pkg/execution/state/redis_state/lua/queue/requeueByID.lua
@@ -33,6 +33,7 @@ end
 -- $include(get_queue_item.lua)
 -- $include(update_pointer_score.lua)
 -- $include(get_partition_item.lua)
+-- $include(has_shard_key.lua)
 
 local item = get_queue_item(keyQueueHash, jobID)
 if item == nil then
@@ -70,7 +71,7 @@ local partitionScore = math.floor(minScore[2] / 1000)
 local currentScore = redis.call("ZSCORE", keyGlobalIndex, partitionID)
 if currentScore == false or tonumber(currentScore) ~= partitionScore then
     redis.call("ZADD", keyGlobalIndex, partitionScore, partitionID)
-    if string.sub(keyShardIndex, -2) ~= ":-" then
+    if has_shard_key(keyShardIndex) then
         update_pointer_score_to(partitionID, keyShardIndex, partitionScore)
     end
 end

--- a/pkg/execution/state/redis_state/lua/queue/requeueByID.lua
+++ b/pkg/execution/state/redis_state/lua/queue/requeueByID.lua
@@ -11,40 +11,44 @@ Return values:
 - -1: Queue item not found
 - -2: Queue item is leased and being worked on.
 
-]]--
+]]
+--
 
 local keyQueueIndex     = KEYS[1]
 local keyQueueHash      = KEYS[2]
-local keyPartitionIndex = KEYS[3] -- partition:sorted - zset
-local keyPartitionHash  = KEYS[4]
+local keyPartitionIndex = KEYS[3]           -- partition:sorted - zset
+local keyShardIndex     = KEYS[4]           -- shard zset
+local keyPartitionHash  = KEYS[5]           -- partition hash
 
-local jobID       = ARGV[1] -- queue item ID
-local jobScore    = tonumber(ARGV[2]) -- enqueue at, in milliseconds
-local partitionID = ARGV[3] -- function ID
-local currentTime = tonumber(ARGV[4]) -- in ms
+local jobID             = ARGV[1]           -- queue item ID
+local jobScore          = tonumber(ARGV[2]) -- enqueue at, in milliseconds
+local partitionID       = ARGV[3]           -- function ID
+local currentTime       = tonumber(ARGV[4]) -- in ms
 
 if redis.call("ZSCORE", keyQueueIndex, jobID) == false then
-	-- This doesn't exist.
-	return -1
+    -- This doesn't exist.
+    return -1
 end
 
 -- $include(get_queue_item.lua)
+-- $include(update_pointer_score.lua)
+
 local item = get_queue_item(keyQueueHash, jobID)
 if item == nil then
-	return -1
+    return -1
 end
 
 -- Ensure that we're not requeueing a leased job.
 if item.leaseID ~= nil and item.leaseID ~= cjson.null and decode_ulid_time(item.leaseID) > currentTime then
-	-- This is already leased;  don't let this requester lease the item.
-	return -2
+    -- This is already leased;  don't let this requester lease the item.
+    return -2
 end
 
 
 -- $include(get_partition_item.lua)
 local existing = get_partition_item(keyPartitionHash, partitionID)
 if existing == nil then
-	return -1
+    return -1
 end
 
 redis.call("ZADD", keyQueueIndex, jobScore, jobID)
@@ -58,7 +62,7 @@ redis.call("HSET", keyQueueHash, jobID, cjson.encode(item))
 -- Get the current score of the partition;  if queueScore < currentScore update the
 -- partition's score so that we can work on this workflow when the earliest member
 -- is available.
--- 
+--
 -- We might have just pushed back the earliest job, so the partitions pointer
 -- could have an earlier score than necessary.  In order to fix this, we want to scan
 -- and take the minimum time from the keyQueueIndex and use this as the score
@@ -67,7 +71,10 @@ local partitionScore = math.floor(minScore[2] / 1000)
 
 local currentScore = redis.call("ZSCORE", keyPartitionIndex, partitionID)
 if currentScore == false or tonumber(currentScore) ~= partitionScore then
-	redis.call("ZADD", keyPartitionIndex, partitionScore, partitionID)
+    redis.call("ZADD", keyPartitionIndex, partitionScore, partitionID)
+    if string.sub(keyShardIndex, -2) ~= ":-" then
+        update_pointer_score_to(partitionID, keyShardIndex, partitionScore)
+    end
 end
 
 -- Update the partition pointer's actual AtS timestamp in the struct.

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -444,19 +444,19 @@ type processItem struct {
 // exist within the global partition queue.
 type QueueShard struct {
 	// Shard name, eg. the company name for isolated execution
-	Name string
+	Name string `json:"n"`
 	// Priority represents the priority for this shard.
-	Priority uint
+	Priority uint `json:"p"`
 	// Kind is the shard kind (below, but would be an enum.ShardKind in real life)
-	Kind string
+	Kind string `json:"kind"`
 	// GuaranteedCapacity represents the minimum number of workers that must
 	// always scan this shard.  If zero, there is no guaranteed capacity for
 	// the shard.
-	GuaranteedCapacity uint
+	GuaranteedCapacity uint `json:"gc"`
 	// Leases stores the lease IDs from the workers which are currently leasing the
 	// shard.  The workers currently leasing the shard are almost guaranteed to use
 	// the shard's partition queue as their source of work.
-	Leases []ulid.ULID
+	Leases []ulid.ULID `json:"leases"`
 }
 
 // Partition returns the partition name for use when managing the pointer queue to
@@ -464,18 +464,6 @@ type QueueShard struct {
 func (q QueueShard) Partition() string {
 	return q.Name
 }
-
-const (
-	ShardKindIsolated   = "isolated-prod"   // single customer's guaranteed capacity
-	ShardKindEnterprise = "enterprise-prod" // enterprise users
-	ShardKindPaid       = "paid-prod"
-	ShardKindFree       = "free-prod"
-
-	ShardKindIsolatedTest   = "isolated-test"   // single customer's guaranteed capacity
-	ShardKindEnterpriseTest = "enterprise-test" // enterprise users
-	ShardKindPaidTest       = "paid-test"
-	ShardKindFreeTest       = "free-test"
-)
 
 // QueuePartition represents an individual queue for a workflow.  It stores the
 // time of the earliest job within the workflow.

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -927,7 +927,7 @@ func (q *queue) Peek(ctx context.Context, queueName string, until time.Time, lim
 func (q *queue) RequeueByJobID(ctx context.Context, partitionName string, jobID string, at time.Time) error {
 	jobID = HashID(ctx, jobID)
 
-	// TODO: Find the queue item.
+	// Find the queue item so that we can fetch the shard info.
 	qi := &QueueItem{}
 	if err := q.r.Do(ctx, q.r.B().Hget().Key(q.kg.QueueItem()).Field(jobID).Build()).DecodeJSON(qi); err != nil {
 		return err

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -124,6 +124,14 @@ type QueueManager interface {
 // PriorityFinder returns the priority for a given queue item.
 type PriorityFinder func(ctx context.Context, item QueueItem) uint
 
+// ShardFinder returns the given shard for a workspace ID, or nil if we should
+// not shard for the workspace.  We use a workspace ID because each individual
+// job AND partition/function lease requires this to be called.
+//
+// NOTE: This is called frequently:  for every enqueue, lease, partition lease, and so on.
+// Expect this to be called tens of thousands of times per second.
+type ShardFinder func(ctx context.Context, workspaceID uuid.UUID) *QueueShard
+
 type QueueOpt func(q *queue)
 
 func WithName(name string) func(q *queue) {
@@ -147,6 +155,12 @@ func WithMetricsScope(scope tally.Scope) func(q *queue) {
 func WithPriorityFinder(pf PriorityFinder) func(q *queue) {
 	return func(q *queue) {
 		q.pf = pf
+	}
+}
+
+func WithShardFinder(sf ShardFinder) func(q *queue) {
+	return func(q *queue) {
+		q.sf = sf
 	}
 }
 
@@ -343,6 +357,7 @@ type queue struct {
 	// redis stores the redis connection to use.
 	r  rueidis.Client
 	pf PriorityFinder
+	sf ShardFinder
 	kg QueueKeyGenerator
 
 	lifecycles []QueueLifecycleListener
@@ -422,6 +437,82 @@ type queue struct {
 type processItem struct {
 	P QueuePartition
 	I QueueItem
+}
+
+// QueueShard represents a sub-partition for a group of functions.  Shards maintain their
+// own partition queues for the functions within the shard.  Note that functions also
+// exist within the global partition queue.
+type QueueShard struct {
+	// Shard name, eg. the company name for isolated execution
+	Name string
+	// Priority represents the priority for this shard.
+	Priority uint
+	// Kind is the shard kind (below, but would be an enum.ShardKind in real life)
+	Kind string
+	// GuaranteedCapacity represents the minimum number of workers that must
+	// always scan this shard.  If zero, there is no guaranteed capacity for
+	// the shard.
+	GuaranteedCapacity uint
+	// Leases stores the lease IDs from the workers which are currently leasing the
+	// shard.  The workers currently leasing the shard are almost guaranteed to use
+	// the shard's partition queue as their source of work.
+	Leases []ulid.ULID
+}
+
+// Partition returns the partition name for use when managing the pointer queue to
+// individual queues within the shard
+func (q QueueShard) Partition() string {
+	return q.Name
+}
+
+const (
+	ShardKindIsolated   = "isolated-prod"   // single customer's guaranteed capacity
+	ShardKindEnterprise = "enterprise-prod" // enterprise users
+	ShardKindPaid       = "paid-prod"
+	ShardKindFree       = "free-prod"
+
+	ShardKindIsolatedTest   = "isolated-test"   // single customer's guaranteed capacity
+	ShardKindEnterpriseTest = "enterprise-test" // enterprise users
+	ShardKindPaidTest       = "paid-test"
+	ShardKindFreeTest       = "free-test"
+)
+
+// QueuePartition represents an individual queue for a workflow.  It stores the
+// time of the earliest job within the workflow.
+type QueuePartition struct {
+	QueueName *string `json:"queue,omitempty"`
+
+	WorkflowID  uuid.UUID `json:"wid"`
+	WorkspaceID uuid.UUID `json:"wsID"`
+
+	Priority uint `json:"p"`
+
+	// Last represents the time that this partition was last leased, as a millisecond
+	// unix epoch.  In essence, we need this to track how frequently we're leasing and
+	// attempting to run items in the partition's queue.
+	//
+	// Without this, we cannot track sojourn latency.
+	// garbage collection when the queue remains empty.
+	Last int64 `json:"last"`
+
+	// LeaseID represents a lease on this partition.  If the LeaseID is not nil,
+	// this partition can be claimed by a shared-nothing worker to work on the
+	// queue items within this partition.
+	//
+	// A lease is shortly held (eg seconds).  It should last long enough for
+	// workers to claim QueueItems only.
+	LeaseID *ulid.ULID `json:"leaseID"`
+}
+
+func (q QueuePartition) Queue() string {
+	if q.QueueName == nil {
+		return q.WorkflowID.String()
+	}
+	return *q.QueueName
+}
+
+func (q QueuePartition) MarshalBinary() ([]byte, error) {
+	return json.Marshal(q)
 }
 
 // QueueItem represents an individually queued work scheduled for some time in the
@@ -532,52 +623,6 @@ func (q QueueItem) Queue() string {
 // based on the time passed in.
 func (q QueueItem) IsLeased(time time.Time) bool {
 	return q.LeaseID != nil && ulid.Time(q.LeaseID.Time()).After(time)
-}
-
-// QueuePartition represents an individual queue for a workflow.  It stores the
-// time of the earliest job within the workflow.
-type QueuePartition struct {
-	QueueName *string `json:"queue,omitempty"`
-
-	WorkflowID uuid.UUID `json:"wid"`
-
-	Priority uint `json:"p"`
-
-	// AtS refers to the earliest QueueItem time within this partition, in
-	// seconds as a unix epoch.
-	//
-	// This is updated when taking a lease, requeuing items, etc.
-	//
-	// The S suffix differentiates between a QueueItem;  we only need second-
-	// level granularity here as queue partitions work to the nearest second.
-	AtS int64 `json:"at"`
-
-	// Last represents the time that this partition was last leased, as a millisecond
-	// unix epoch.  In essence, we need this to track how frequently we're leasing and
-	// attempting to run items in the partition's queue.
-	//
-	// Without this, we cannot track sojourn latency.
-	// garbage collection when the queue remains empty.
-	Last int64 `json:"last"`
-
-	// LeaseID represents a lease on this partition.  If the LeaseID is not nil,
-	// this partition can be claimed by a shared-nothing worker to work on the
-	// queue items within this partition.
-	//
-	// A lease is shortly held (eg seconds).  It should last long enough for
-	// workers to claim QueueItems only.
-	LeaseID *ulid.ULID `json:"leaseID"`
-}
-
-func (q QueuePartition) Queue() string {
-	if q.QueueName == nil {
-		return q.WorkflowID.String()
-	}
-	return *q.QueueName
-}
-
-func (q QueuePartition) MarshalBinary() ([]byte, error) {
-	return json.Marshal(q)
 }
 
 func (q *queue) RunJobs(ctx context.Context, workspaceID, workflowID uuid.UUID, runID ulid.ULID, limit, offset int64) ([]osqueue.JobResponse, error) {
@@ -742,18 +787,31 @@ func (q *queue) EnqueueItem(ctx context.Context, i QueueItem, at time.Time) (Que
 	qn := i.Queue()
 
 	qp := QueuePartition{
-		QueueName:  i.QueueName,
-		WorkflowID: i.WorkflowID,
-		Priority:   priority,
-		AtS:        partitionTime.Unix(),
+		QueueName:   i.QueueName,
+		WorkflowID:  i.WorkflowID,
+		WorkspaceID: i.WorkspaceID,
+		Priority:    priority,
+	}
+
+	var (
+		shard     *QueueShard
+		shardName string
+	)
+	if q.sf != nil {
+		shard = q.sf(ctx, i.WorkspaceID)
+		if shard != nil {
+			shardName = shard.Name
+		}
 	}
 
 	keys := []string{
-		q.kg.QueueItem(),       // Queue item
-		q.kg.QueueIndex(qn),    // Queue sorted set
-		q.kg.PartitionItem(),   // Partition item, map
-		q.kg.PartitionMeta(qn), // Partition item
-		q.kg.PartitionIndex(),  // Global partition queue
+		q.kg.QueueItem(),                    // Queue item
+		q.kg.QueueIndex(qn),                 // Queue sorted set
+		q.kg.PartitionItem(),                // Partition item, map
+		q.kg.PartitionMeta(qn),              // Partition item
+		q.kg.GlobalPartitionIndex(),         // Global partition queue
+		q.kg.ShardPartitionIndex(shardName), // Shard queue
+		q.kg.Shards(),
 		q.kg.Idempotency(i.ID),
 	}
 	// Append indexes
@@ -770,6 +828,8 @@ func (q *queue) EnqueueItem(ctx context.Context, i QueueItem, at time.Time) (Que
 		qn,
 		qp,
 		partitionTime.Unix(),
+		shard,
+		shardName,
 	})
 	if err != nil {
 		return i, err
@@ -867,11 +927,25 @@ func (q *queue) Peek(ctx context.Context, queueName string, until time.Time, lim
 func (q *queue) RequeueByJobID(ctx context.Context, partitionName string, jobID string, at time.Time) error {
 	jobID = HashID(ctx, jobID)
 
+	// TODO: Find the queue item.
+	qi := &QueueItem{}
+	if err := q.r.Do(ctx, q.r.B().Hget().Key(q.kg.QueueItem()).Field(jobID).Build()).DecodeJSON(qi); err != nil {
+		return err
+	}
+
+	var shardName string
+	if q.sf != nil {
+		if shard := q.sf(ctx, qi.WorkspaceID); shard != nil {
+			shardName = shard.Name
+		}
+	}
+
 	keys := []string{
 		q.kg.QueueIndex(partitionName),
 		q.kg.QueueItem(),
-		q.kg.PartitionIndex(), // Global partition queue
-		q.kg.PartitionItem(),  // Partition hash
+		q.kg.GlobalPartitionIndex(),         // Global partition queue
+		q.kg.ShardPartitionIndex(shardName), // Shard partition queue
+		q.kg.PartitionItem(),                // Partition hash
 	}
 	status, err := scripts["queue/requeueByID"].Exec(
 		ctx,
@@ -942,17 +1016,24 @@ func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, dur
 		return nil, fmt.Errorf("error generating id: %w", err)
 	}
 
+	var shardName string
+	if q.sf != nil {
+		if shard := q.sf(ctx, item.WorkspaceID); shard != nil {
+			shardName = shard.Name
+		}
+	}
+
 	keys := []string{
 		q.kg.QueueItem(),
 		q.kg.QueueIndex(item.Queue()),
 		q.kg.PartitionMeta(item.Queue()),
 		q.kg.Concurrency("account", ak),
 		q.kg.Concurrency("p", pk),
-
 		q.kg.Concurrency("custom", customKeys[0]),
 		q.kg.Concurrency("custom", customKeys[1]),
-
 		q.kg.ConcurrencyIndex(),
+		q.kg.GlobalPartitionIndex(),
+		q.kg.ShardPartitionIndex(shardName),
 	}
 	args, err := StrSlice([]any{
 		item.ID,
@@ -1042,7 +1123,7 @@ func (q *queue) ExtendLease(ctx context.Context, p QueuePartition, i QueueItem, 
 	keys := []string{
 		q.kg.QueueItem(),
 		q.kg.QueueIndex(i.Queue()),
-		q.kg.PartitionIndex(),
+		q.kg.GlobalPartitionIndex(),
 		q.kg.Concurrency("account", ak),
 		q.kg.Concurrency("p", pk),
 		q.kg.Concurrency("custom", customKeys[0]),
@@ -1197,24 +1278,24 @@ func (q *queue) Requeue(ctx context.Context, p QueuePartition, i QueueItem, at t
 	// Update the wall time that this should run at.
 	i.WallTimeMS = at.UnixMilli()
 
-	qn := i.Queue()
-
-	qp := QueuePartition{
-		QueueName:  i.QueueName,
-		WorkflowID: i.WorkflowID,
-		Priority:   priority,
-		AtS:        at.Unix(),
+	var shardName string
+	if q.sf != nil {
+		if shard := q.sf(ctx, i.WorkspaceID); shard != nil {
+			shardName = shard.Name
+		}
 	}
+
 	keys := []string{
 		q.kg.QueueItem(),
-		q.kg.QueueIndex(qn),
-		q.kg.PartitionMeta(qn),
-		q.kg.PartitionIndex(),
+		q.kg.QueueIndex(i.Queue()),
+		q.kg.PartitionMeta(i.Queue()),
+		q.kg.GlobalPartitionIndex(),
 		q.kg.Concurrency("account", ak),
 		q.kg.Concurrency("p", pk),
 		q.kg.Concurrency("custom", customKeys[0]),
 		q.kg.Concurrency("custom", customKeys[1]),
 		q.kg.ConcurrencyIndex(),
+		q.kg.ShardPartitionIndex(shardName),
 	}
 	// Append indexes
 	for _, idx := range q.itemIndexer(ctx, i, q.kg) {
@@ -1227,8 +1308,7 @@ func (q *queue) Requeue(ctx context.Context, p QueuePartition, i QueueItem, at t
 		i,
 		i.ID,
 		at.UnixMilli(),
-		qn,
-		qp,
+		i.Queue(),
 	})
 	if err != nil {
 		return err
@@ -1274,9 +1354,17 @@ func (q *queue) PartitionLease(ctx context.Context, p *QueuePartition, duration 
 		return nil, fmt.Errorf("error generating id: %w", err)
 	}
 
+	var shardName string
+	if q.sf != nil {
+		if shard := q.sf(ctx, p.WorkspaceID); shard != nil {
+			shardName = shard.Name
+		}
+	}
+
 	keys := []string{
 		q.kg.PartitionItem(),
-		q.kg.PartitionIndex(),
+		q.kg.GlobalPartitionIndex(),
+		q.kg.ShardPartitionIndex(shardName),
 		q.kg.Concurrency("p", concurrencyKey),
 	}
 
@@ -1358,7 +1446,7 @@ func (q *queue) PartitionPeek(ctx context.Context, sequential bool, until time.T
 		ctx,
 		q.r,
 		[]string{
-			q.kg.PartitionIndex(),
+			q.kg.GlobalPartitionIndex(),
 			q.kg.PartitionItem(),
 		},
 		args,
@@ -1453,22 +1541,29 @@ func checkList(check string, exact, prefixes map[string]*struct{}) bool {
 // forceAt is used to enforce the given queue time.  This is used when partitions are at a
 // concurrency limit;  we don't want to scan the partition next time, so we force the partition
 // to be at a specific time instead of taking the earliest available queue item time
-func (q *queue) PartitionRequeue(ctx context.Context, queueName string, at time.Time, forceAt bool) error {
+func (q *queue) PartitionRequeue(ctx context.Context, p *QueuePartition, at time.Time, forceAt bool) error {
+	var shardName string
+	if q.sf != nil {
+		if shard := q.sf(ctx, p.WorkspaceID); shard != nil {
+			shardName = shard.Name
+		}
+	}
+
 	keys := []string{
 		q.kg.PartitionItem(),
-		q.kg.PartitionIndex(),
-		q.kg.PartitionMeta(queueName),
-		q.kg.QueueIndex(queueName),
+		q.kg.GlobalPartitionIndex(),
+		q.kg.ShardPartitionIndex(shardName),
+		q.kg.PartitionMeta(p.Queue()),
+		q.kg.QueueIndex(p.Queue()),
 		q.kg.QueueItem(),
-		q.kg.Concurrency("p", queueName),
+		q.kg.Concurrency("p", p.Queue()),
 	}
 	force := 0
 	if forceAt {
 		force = 1
 	}
 	args, err := StrSlice([]any{
-
-		queueName,
+		p.Queue(),
 		at.Unix(),
 		force,
 	})

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -717,6 +717,7 @@ func TestQueueLease(t *testing.T) {
 			atB := atA.Add(time.Minute)
 
 			itemA, err := q.EnqueueItem(ctx, QueueItem{}, atA)
+			require.NoError(t, err)
 			itemB, err := q.EnqueueItem(ctx, QueueItem{}, atB)
 			require.NoError(t, err)
 			p := QueuePartition{WorkflowID: itemA.WorkflowID} // same for A+B
@@ -1842,9 +1843,11 @@ func TestSharding(t *testing.T) {
 			require.EqualValues(t, at.Unix(), shardTime.Unix())
 
 			// Lease the function queue for a minute
-			q.PartitionLease(ctx, &p, time.Minute)
+			_, err = q.PartitionLease(ctx, &p, time.Minute)
+			require.NoError(t, err)
 
 			leasedShardScore, err := r.ZScore(q.kg.ShardPartitionIndex(shard.Name), p.Queue())
+			require.NoError(t, err)
 			leasedShardTime := time.Unix(int64(leasedShardScore), 0)
 
 			require.NoError(t, err)


### PR DESCRIPTION
This PR introduces partition sharding during queue operations: enqueue, lease, dequeue, requeue, and partition leasing/requeueing.  This is defined as outlined in our spec.

Note that this is backwards compatible:  no changes are made to the queue or global partition pointer.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
