### PR TITLE
Add ErrEventCount

### DIFF
--- a/pkg/eventstream/errors.go
+++ b/pkg/eventstream/errors.go
@@ -1,0 +1,11 @@
+package eventstream
+
+import "fmt"
+
+type ErrEventCount struct {
+	Max int
+}
+
+func (e *ErrEventCount) Error() string {
+	return fmt.Sprintf("Cannot have more than %d events in a batch", e.Max)
+}

--- a/pkg/eventstream/eventstream.go
+++ b/pkg/eventstream/eventstream.go
@@ -86,7 +86,7 @@ func ParseStream(ctx context.Context, r io.Reader, stream chan StreamItem, maxSi
 		// Parse a stream of tokens
 		for d.More() {
 			if i == consts.MaxEvents {
-				return fmt.Errorf("maximum events parsed within a batch: %d", consts.MaxEvents)
+				return &ErrEventCount{Max: consts.MaxEvents}
 			}
 
 			jsonEvt := json.RawMessage{}


### PR DESCRIPTION
## Description
Add and use `ErrEventCount`. This will allow the Event API to return a specific error code when an event batch has too many events.

A new error is needed so that Event API can use `errors.Is()` or `errors.As()` on the "too many events" error