### PR TITLE
fix: cron with trailing space fail to parse

### DIFF
--- a/ui/packages/components/src/hooks/useCron.ts
+++ b/ui/packages/components/src/hooks/useCron.ts
@@ -13,7 +13,7 @@ const getCron = (schedule: string) => {
     pattern = pattern.replace(timezonePattern, ''); // remove timezone from schedule
   }
 
-  return Cron(pattern, { timezone: timezone });
+  return Cron(pattern.trim(), { timezone: timezone });
 };
 
 interface CronDetails {


### PR DESCRIPTION
## Description

This fixes an issue with cron parsing. Cron with a trailing space in it would fail to be parsed.

It also adds a Sentry error boundary for the sidebar so we don't fail the whole page.

![image](https://github.com/inngest/inngest/assets/4291707/fe48ecc4-4c47-4fc6-89bc-b7733b89aff3)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
