### PR TITLE
Add shard partition peeking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	go.opentelemetry.io/otel/exporters/prometheus v0.44.0
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.44.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.21.0
+	go.opentelemetry.io/otel/metric v1.21.0
 	go.opentelemetry.io/otel/sdk v1.21.0
 	go.opentelemetry.io/otel/sdk/metric v1.21.0
 	go.opentelemetry.io/otel/trace v1.21.0
@@ -170,7 +171,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	github.com/zclconf/go-cty v1.8.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -20,6 +20,7 @@ type RunInfo struct {
 	Latency      time.Duration
 	SojournDelay time.Duration
 	Priority     uint
+	ShardName    *string
 }
 
 type RunFunc func(context.Context, RunInfo, Item) error

--- a/pkg/execution/state/redis_state/lua/queue/enqueue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/enqueue.lua
@@ -56,8 +56,13 @@ if shard ~= "" and shard ~= "null" then
     -- NOTE: We do not want to overwrite the shard leases, so here
     -- we fetch the shard item, set the lease values in the passed in shard
     -- item, then write the updated value.
-    --
-    -- TODO: LEASES ???
+    local existingShard = redis.call("HGET", shardMapKey, shardName)
+    if existingShard ~= nil and existingShard ~= false then
+	local updatedShard = cjson.decode(shard)
+	existingShard = cjson.decode(existingShard)
+        updatedShard.leases = existingShard.leases
+        shard = cjson.encode(updatedShard)
+    end
     redis.call("HSET", shardMapKey, shardName, shard)
 end
 

--- a/pkg/execution/state/redis_state/lua/queue/enqueue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/enqueue.lua
@@ -58,8 +58,8 @@ if shard ~= "" and shard ~= "null" then
     -- item, then write the updated value.
     local existingShard = redis.call("HGET", shardMapKey, shardName)
     if existingShard ~= nil and existingShard ~= false then
-	local updatedShard = cjson.decode(shard)
-	existingShard = cjson.decode(existingShard)
+        local updatedShard = cjson.decode(shard)
+        existingShard = cjson.decode(existingShard)
         updatedShard.leases = existingShard.leases
         shard = cjson.encode(updatedShard)
     end

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -1908,6 +1908,14 @@ func (q *queue) renewShardLease(ctx context.Context, shard *QueueShard, duration
 	}
 }
 
+func (q *queue) getShardLeases() []leasedShard {
+	var existingLeases []leasedShard
+	q.shardLeaseLock.Lock()
+	_ = copy(q.shardLeases, existingLeases)
+	q.shardLeaseLock.Unlock()
+	return existingLeases
+}
+
 func HashID(ctx context.Context, id string) string {
 	ui := xxhash.Sum64String(id)
 	return strconv.FormatUint(ui, 36)

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -460,6 +460,7 @@ type queue struct {
 type processItem struct {
 	P QueuePartition
 	I QueueItem
+	S *QueueShard
 }
 
 // QueueShard represents a sub-partition for a group of functions.  Shards maintain their

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -1907,10 +1907,6 @@ func (q *queue) renewShardLease(ctx context.Context, shard *QueueShard, duration
 	}
 }
 
-func (q *queue) gauge(ctx context.Context, name string, val int64, tags map[string]any) {
-	if gauge, err := q.meter.Int64ObservableGauge(name); err == nil {
-	}
-}
 func HashID(ctx context.Context, id string) string {
 	ui := xxhash.Sum64String(id)
 	return strconv.FormatUint(ui, 36)

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -25,6 +25,8 @@ import (
 	"github.com/redis/rueidis"
 	"github.com/rs/zerolog"
 	"github.com/uber-go/tally/v4"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"gonum.org/v1/gonum/stat/sampleuv"
 	"lukechampine.com/frand"
@@ -179,6 +181,12 @@ func WithQueueKeyGenerator(kg QueueKeyGenerator) func(q *queue) {
 func WithIdempotencyTTL(t time.Duration) func(q *queue) {
 	return func(q *queue) {
 		q.idempotencyTTL = t
+	}
+}
+
+func WithOtelMeter(m metric.Meter) func(q *queue) {
+	return func(q *queue) {
+		q.meter = m
 	}
 }
 
@@ -338,6 +346,7 @@ func NewQueue(r rueidis.Client, opts ...QueueOpt) *queue {
 		idempotencyTTL:     defaultIdempotencyTTL,
 		queueKindMapping:   make(map[string]string),
 		scope:              tally.NoopScope,
+		meter:              otel.Meter("redis_state.queue"),
 		tracer:             trace.NewNoopTracerProvider().Tracer("redis_queue"),
 		logger:             logger.From(context.Background()),
 		partitionConcurrencyGen: func(ctx context.Context, p QueuePartition) (string, int) {
@@ -437,6 +446,8 @@ type queue struct {
 
 	// metrics allows reporting of metrics
 	scope tally.Scope
+	meter metric.Meter
+
 	// tracer is the tracer to use for opentelemetry tracing.
 	tracer trace.Tracer
 	// backoffFunc is the backoff function to use when retrying operations.
@@ -459,8 +470,6 @@ type QueueShard struct {
 	Name string `json:"n"`
 	// Priority represents the priority for this shard.
 	Priority uint `json:"p"`
-	// Kind is the shard kind (below, but would be an enum.ShardKind in real life)
-	Kind string `json:"kind"`
 	// GuaranteedCapacity represents the minimum number of workers that must
 	// always scan this shard.  If zero, there is no guaranteed capacity for
 	// the shard.
@@ -1420,7 +1429,7 @@ func (q *queue) PartitionLease(ctx context.Context, p *QueuePartition, duration 
 	}
 }
 
-// PartitionPeek returns up to PartitionSelectionMax partition items from the queue. This
+// GlobalPartitionPeek returns up to PartitionSelectionMax partition items from the queue. This
 // returns the indexes of partitions.
 //
 // If sequential is set to true this returns partitions in order from earliest to latest
@@ -1428,6 +1437,10 @@ func (q *queue) PartitionLease(ctx context.Context, p *QueuePartition, duration 
 // randomly, with higher priority partitions more likely to be selected.  This reduces
 // lease contention amongst multiple shared-nothing workers.
 func (q *queue) PartitionPeek(ctx context.Context, sequential bool, until time.Time, limit int64) ([]*QueuePartition, error) {
+	return q.partitionPeek(ctx, q.kg.GlobalPartitionIndex(), sequential, until, limit)
+}
+
+func (q *queue) partitionPeek(ctx context.Context, partitionKey string, sequential bool, until time.Time, limit int64) ([]*QueuePartition, error) {
 	if limit > PartitionPeekMax {
 		return nil, ErrPartitionPeekMaxExceedsLimits
 	}
@@ -1888,12 +1901,16 @@ func (q *queue) renewShardLease(ctx context.Context, shard *QueueShard, duration
 	case int64(-2):
 		return nil, fmt.Errorf("lease not found")
 	case int64(0):
-		return &leaseID, nil
+		return &newLeaseID, nil
 	default:
 		return nil, fmt.Errorf("unknown lease renew return value: %T(%v)", status, status)
 	}
 }
 
+func (q *queue) gauge(ctx context.Context, name string, val int64, tags map[string]any) {
+	if gauge, err := q.meter.Int64ObservableGauge(name); err == nil {
+	}
+}
 func HashID(ctx context.Context, id string) string {
 	ui := xxhash.Sum64String(id)
 	return strconv.FormatUint(ui, 36)

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -262,6 +262,13 @@ func (q *queue) claimShards(ctx context.Context) {
 	var leasing int32
 
 	for {
+		if q.isSequential() {
+			// Sequential workers never lease shards.  They always run in order
+			// on the global partition queue.
+			<-scanTick.C
+			continue
+		}
+
 		select {
 		case <-ctx.Done():
 			// TODO: Remove leases immediately from backing store.

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -1149,7 +1149,7 @@ func (q *queue) shardGauges(ctx context.Context) {
 
 	// Report gauges to otel.
 	_, _ = q.meter.Int64ObservableGauge(
-		"queue_shards_count",
+		"inngest_queue_shards_count",
 		metric.WithDescription("Number of shards in the queue"),
 		metric.WithInt64Callback(func(ctx context.Context, o metric.Int64Observer) error {
 			o.Observe(int64(len(shards)))
@@ -1157,7 +1157,7 @@ func (q *queue) shardGauges(ctx context.Context) {
 		}),
 	)
 	_, _ = q.meter.Int64ObservableGauge(
-		"queue_shards_guaranteed_capacity_count",
+		"inngest_queue_shards_guaranteed_capacity_count",
 		metric.WithDescription("Shard guaranteed capacity, by shard name"),
 		metric.WithInt64Callback(func(ctx context.Context, o metric.Int64Observer) error {
 			for _, shard := range shards {
@@ -1169,7 +1169,7 @@ func (q *queue) shardGauges(ctx context.Context) {
 		}),
 	)
 	_, _ = q.meter.Int64ObservableGauge(
-		"queue_shards_lease_count",
+		"inngest_queue_shards_lease_count",
 		metric.WithDescription("Shard current lease count, by shard name"),
 		metric.WithInt64Callback(func(ctx context.Context, o metric.Int64Observer) error {
 			for _, shard := range shards {


### PR DESCRIPTION
This implements shard partition peeking.  For workers which lease shards, we randomly choose a leased shard to peek (fetch functions), with 5% chance of still working from the global partition.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
