### PR TITLE
Make FunctionRunStatusIcon support unexpected statuses

### DIFF
--- a/ui/packages/components/src/FunctionRunStatusIcon/FunctionRunStatusIcon.tsx
+++ b/ui/packages/components/src/FunctionRunStatusIcon/FunctionRunStatusIcon.tsx
@@ -5,7 +5,10 @@ import { IconStatusCircleCross } from '@inngest/components/icons/StatusCircleCro
 import { IconStatusCircleMinus } from '@inngest/components/icons/StatusCircleMinus';
 import { type FunctionRunStatus } from '@inngest/components/types/functionRun';
 
-const icons = {
+// Explicitly assign the Record type but use satisfies to ensure:
+// - Accessing an unexpected status gives an undefined
+// - Keys must be exhaustive of all known statuses
+const icons: Record<string, React.ComponentType> = {
   CANCELLED: IconStatusCircleMinus,
   COMPLETED: IconStatusCircleCheck,
   FAILED: IconStatusCircleCross,
@@ -18,7 +21,7 @@ type Props = {
 };
 
 export function FunctionRunStatusIcon({ status, className }: Props) {
-  const Icon = icons[status];
+  const Icon = icons[status] ?? IconStatusCircleArrowPath;
 
   const title = 'Function ' + status.toLowerCase();
   return <Icon className={className} title={title} />;


### PR DESCRIPTION
## Description
Make `FunctionRunStatusIcon` support unexpected statuses

## Motivation
We don't want the UI to crash when a new status is added to the backend before the UI supports it

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
