### PR TITLE
fix(dashboard): using LD before its initialization completed

### DIFF
--- a/ui/apps/dashboard/src/launchDarkly.ts
+++ b/ui/apps/dashboard/src/launchDarkly.ts
@@ -1,6 +1,6 @@
 import { init, type LDClient } from '@launchdarkly/node-server-sdk';
 
-let launchDarklyClient: LDClient | undefined;
+let launchDarklyClient: LDClient;
 
 function initialize() {
   const launchDarklySDKKey = process.env.LAUNCH_DARKLY_SDK_KEY;
@@ -8,12 +8,12 @@ function initialize() {
     throw new Error('LAUNCH_DARKLY_SDK_KEY environment variable is not set.');
   }
   launchDarklyClient = init(launchDarklySDKKey, { stream: false });
-  return launchDarklyClient;
 }
 
 export async function getLaunchDarklyClient(): Promise<LDClient> {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- Since we run our app in a serverless environment, launchDarklyClient can potentially be persisted between invocations.
   if (!launchDarklyClient) {
-    return initialize();
+    initialize();
   }
 
   await launchDarklyClient.waitForInitialization();


### PR DESCRIPTION
## Description

The current LaunchDarkly client occasionally errors because we used it before it had time to initialize. That produces the following error:

```
warn: [LaunchDarkly] Variation called before LaunchDarkly client initialization completed (did you wait for the'ready' event?) - using default value
```

The issue was introduced in https://github.com/inngest/inngest/pull/987/files#diff-04bffd50cc165a102e8778bba6441858708a869858bf71c90c19e7752e07e04d

## Motivation

This might be causing [the issue we're seeing with the `organizations` feature flag](https://inngest.slack.com/archives/C06BL7RLQKA/p1707660560532059). However, this doesn't explain why the flag isn't falling back to `false`.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
