### PR TITLE
make sure the run time is recorded, and also mapped correctly when retrieved

### DIFF
--- a/pkg/cqrs/events.go
+++ b/pkg/cqrs/events.go
@@ -212,6 +212,12 @@ func WithEventBatchEventIDs(evtIDs []ulid.ULID) EventBatchOpt {
 	}
 }
 
+func WithEventBatchExecutedTime(t time.Time) EventBatchOpt {
+	return func(eb *EventBatch) {
+		eb.Time = t
+	}
+}
+
 func (eb *EventBatch) StartedAt() time.Time {
 	return ulid.Time(eb.ID.Time())
 }

--- a/pkg/cqrs/sqlitecqrs/cqrs.go
+++ b/pkg/cqrs/sqlitecqrs/cqrs.go
@@ -451,6 +451,7 @@ func convertEventBatch(obj *sqlc.EventBatch) cqrs.EventBatch {
 		cqrs.WithEventBatchAppID(obj.AppID),
 		cqrs.WithEventBatchRunID(obj.RunID),
 		cqrs.WithEventBatchEventIDs(evtIDs),
+		cqrs.WithEventBatchExecutedTime(obj.ExecutedAt),
 	)
 
 	return *eb

--- a/pkg/devserver/lifecycle.go
+++ b/pkg/devserver/lifecycle.go
@@ -35,6 +35,8 @@ func (l lifecycle) OnFunctionScheduled(
 	})
 
 	if id.BatchID != nil {
+		executedTime := ulid.Time(id.RunID.Time())
+
 		batch := cqrs.NewEventBatch(
 			cqrs.WithEventBatchID(*id.BatchID),
 			cqrs.WithEventBatchAccountID(id.AccountID),
@@ -43,6 +45,7 @@ func (l lifecycle) OnFunctionScheduled(
 			cqrs.WithEventBatchFunctionID(id.WorkflowID),
 			cqrs.WithEventBatchRunID(id.RunID),
 			cqrs.WithEventBatchEventIDs(id.EventIDs),
+			cqrs.WithEventBatchExecutedTime(executedTime),
 		)
 
 		if batch.IsMulti() {


### PR DESCRIPTION
## Description

Forgot to map the execution time on the batch correctly.
This will make sure the time recording is correct.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
