### PR TITLE
Fix layout shift when rendering placeholders

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/FunctionTable.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/FunctionTable.tsx
@@ -97,10 +97,10 @@ export function FunctionTable({ rows = [] }: Props) {
   );
 }
 
-function Shimmer() {
+function Shimmer({ className }: { className?: string }) {
   return (
-    <div className="flex">
-      <Placeholder className="mx-4 my-4 h-2.5 w-full bg-slate-200" />
+    <div className={`flex ${className}`}>
+      <Placeholder className="my-4 h-2.5 w-full bg-slate-200" />
     </div>
   );
 }
@@ -178,7 +178,7 @@ function createColumns(environmentSlug: string) {
       cell: (info) => {
         const value = info.getValue();
         if (value === undefined) {
-          return <Shimmer />;
+          return <Shimmer className="w-12 px-2.5" />;
         }
 
         let icon;
@@ -199,11 +199,11 @@ function createColumns(environmentSlug: string) {
       cell: (info) => {
         const value = info.getValue();
         if (value === undefined) {
-          return <Shimmer />;
+          return <Shimmer className="w-[212px] px-2.5" />;
         }
 
         return (
-          <div className="flex items-center justify-end gap-2">
+          <div className="flex min-w-[212px] items-center justify-end gap-2">
             <span
               key="volume-count"
               className="overflow-hidden whitespace-nowrap text-xs text-slate-600"


### PR DESCRIPTION
## Description

The widths of the placeholders didn't match the typically rendered data size so this resulted in a layout shift that felt janky.

**After this PR:**
<img width="510" alt="Screen Shot 2024-02-13 at 5 05 48 PM" src="https://github.com/inngest/inngest/assets/1509457/9ac1021e-294d-4864-862f-e9954677c5d8">
**With data loaded**
<img width="502" alt="Screen Shot 2024-02-13 at 5 06 08 PM" src="https://github.com/inngest/inngest/assets/1509457/50149111-e3b7-475a-bdb1-4c914d886e70">

**Before this PR:**
<img width="500" alt="Screenshot 2024-02-13 at 5 06 50 PM" src="https://github.com/inngest/inngest/assets/1509457/2ea98421-fffd-4579-95cd-d958e90ba18a">

## Motivation
This is a key page in our app and this jank makes the app feel lower quality.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
