### PR TITLE
Add docs for using `timeout` in `step.invoke()`

### DIFF
--- a/ui/apps/website/pages/docs/reference/functions/step-invoke.mdx
+++ b/ui/apps/website/pages/docs/reference/functions/step-invoke.mdx
@@ -49,25 +49,43 @@ const mainFunction = inngest.createFunction(
           <Property name="user" type="object">
             Optional user context for the invocation.
           </Property>
+          <Property name="timeout" type="string | number | Date" version="v3.14.0+">
+            {/* Purposefully not mentioning the default timeout of 1 year, as we expect to lower this very soon. */}
+            The amount of time to wait for the invoked function to complete. The time to wait can be specified using a `number` of milliseconds, an `ms`-compatible time string like `"1 hour"`, `"30 mins"`, or `"2.5d"`, or a `Date` object.
+
+            Note that the invoked function will continue to run even if this step times out.
+          </Property>
         </Properties>
         Throwing errors within the invoked function will be reflected in the invoking function.
       </Property>
     </Properties>
   </Col>
   <Col>
+    <CodeGroup title="Invoke a function directly">
     ```ts
-    // Invoke a function directly
     const resultFromDirectCall = await step.invoke("invoke-by-definition", {
       function: anotherFunction,
       data: { ... },
     });
-
-    // Invoke a function using a function reference
+    ```
+    </CodeGroup>
+    <CodeGroup title="Invoke a function using a function reference">
+    ```ts
     const resultFromReference = await step.invoke("invoke-by-reference", {
       function: referenceFunction(...),
       data: { ... },
     });
     ```
+    </CodeGroup>
+    <CodeGroup title="Invoke a function with a timeout">
+    ```ts
+    const resultFromDirectCall = await step.invoke("invoke-with-timeout", {
+      function: anotherFunction,
+      data: { ... },
+      timeout: "1h",
+    });
+    ```
+    </CodeGroup>
   </Col>
 </Row>
 


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

Adds docs for inngest/inngest-js#484, which adds `timeout` to `step.invoke()` options.

Waiting on #1129 and subsequent upstreaming before shipping.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [x] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

## Related

- inngest/inngest-js#484
- #1129
