### PR TITLE
hotfix(dashboard): account setup redirect url

### DIFF
--- a/ui/apps/dashboard/src/app/(auth)/organization-list/[[...organization-list]]/page.tsx
+++ b/ui/apps/dashboard/src/app/(auth)/organization-list/[[...organization-list]]/page.tsx
@@ -1,7 +1,6 @@
 import { OrganizationList } from '@clerk/nextjs';
 
 import SplitView from '@/app/(auth)/SplitView';
-import { getBooleanFlag } from '@/components/FeatureFlags/ServerFeatureFlag';
 
 type OrganizationListPageProps = {
   searchParams: { [key: string]: string | string[] | undefined };
@@ -13,8 +12,6 @@ export default async function OrganizationListPage({ searchParams }: Organizatio
       ? searchParams.redirect_url
       : process.env.NEXT_PUBLIC_HOME_PATH;
 
-  const isOrganizationsEnabled = await getBooleanFlag('organizations');
-
   return (
     <SplitView>
       <div className="mx-auto my-auto text-center">
@@ -22,17 +19,6 @@ export default async function OrganizationListPage({ searchParams }: Organizatio
           hidePersonal={true}
           afterCreateOrganizationUrl="/sign-up/account-setup"
           afterSelectOrganizationUrl={redirectURL}
-          appearance={
-            isOrganizationsEnabled
-              ? undefined
-              : {
-                  elements: {
-                    // This hides the "Create Organization" button until this feature is ready.
-                    dividerRow: 'hidden',
-                    button: 'hidden',
-                  },
-                }
-          }
         />
       </div>
     </SplitView>

--- a/ui/apps/dashboard/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/ui/apps/dashboard/src/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -2,28 +2,18 @@ import { cookies } from 'next/headers';
 import { SignUp } from '@clerk/nextjs';
 
 import SplitView from '@/app/(auth)/SplitView';
-import { getBooleanFlag } from '@/components/FeatureFlags/ServerFeatureFlag';
 
 export default async function SignUpPage() {
   const cookieStore = cookies();
   const anonymousIDCookie = cookieStore.get('inngest_anonymous_id');
 
-  const isOrganizationsEnabled = await getBooleanFlag('organizations');
-
   return (
     <SplitView>
       <div className="mx-auto my-8 mt-auto text-center">
         <SignUp
-          afterSignUpUrl={isOrganizationsEnabled ? '/organization-list' : '/sign-up/account-setup'}
+          afterSignUpUrl="/organization-list"
           unsafeMetadata={{
             ...(anonymousIDCookie?.value && { anonymousID: anonymousIDCookie.value }),
-          }}
-          appearance={{
-            elements: {
-              // We need to hide the name fields because we don't want to overwhelm users with too
-              // many fields, but we still want to allow them later to set their name if they want to.
-              formFieldRow__name: 'hidden',
-            },
           }}
         />
       </div>

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/layout.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/layout.tsx
@@ -1,6 +1,5 @@
 import { Cog6ToothIcon } from '@heroicons/react/20/solid';
 
-import { getBooleanFlag } from '@/components/FeatureFlags/ServerFeatureFlag';
 import Header from '@/components/Header/Header';
 import AppNavigation from '@/components/Navigation/AppNavigation';
 import Toaster from '@/components/Toaster';
@@ -12,12 +11,14 @@ type SettingsLayoutProps = {
 const DEFAULT_ENV_SLUG = 'production';
 
 export default async function SettingsLayout({ children }: SettingsLayoutProps) {
-  const isOrganizationsEnabled = await getBooleanFlag('organizations');
-
   const navLinks = [
     {
       href: '/settings/user',
       text: 'User',
+    },
+    {
+      href: '/settings/organization',
+      text: 'Organization',
     },
     {
       href: '/settings/billing',
@@ -27,19 +28,7 @@ export default async function SettingsLayout({ children }: SettingsLayoutProps) 
       href: '/settings/integrations',
       text: 'Integrations',
     },
-    {
-      href: '/settings/team',
-      text: 'Team Management',
-    },
   ];
-
-  if (isOrganizationsEnabled) {
-    navLinks.splice(1, 0, {
-      href: '/settings/organization',
-      text: 'Organization',
-    });
-    navLinks.pop();
-  }
 
   return (
     <div className="flex h-full flex-col">

--- a/ui/apps/dashboard/src/components/Navigation/AppNavigation.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/AppNavigation.tsx
@@ -13,7 +13,6 @@ import OrganizationDropdown from '@/components/Navigation/OrganizationDropdown';
 import UserDropdown from '@/components/Navigation/UserDropdown';
 import InngestLogo from '@/icons/InngestLogo';
 import EventIcon from '@/icons/event.svg';
-import AccountDropdown from './AccountDropdown';
 import EnvironmentSelectMenu from './EnvironmentSelectMenu';
 import NavItem from './NavItem';
 import Navigation from './Navigation';
@@ -35,7 +34,6 @@ const BRANCH_PARENT_SLUG = 'branch';
 
 export default async function AppNavigation({ environmentSlug }: AppNavigationProps) {
   const isEventSearchEnabled = await getBooleanFlag('event-search');
-  const isOrganizationsEnabled = await getBooleanFlag('organizations');
 
   let items: NavItem[] = [
     {
@@ -100,14 +98,8 @@ export default async function AppNavigation({ environmentSlug }: AppNavigationPr
       </div>
       <div className="flex h-full items-center">
         <SearchNavigation />
-        {isOrganizationsEnabled ? (
-          <>
-            <OrganizationDropdown />
-            <UserDropdown />
-          </>
-        ) : (
-          <AccountDropdown />
-        )}
+        <OrganizationDropdown />
+        <UserDropdown />
       </div>
     </nav>
   );

--- a/ui/apps/dashboard/src/middleware.ts
+++ b/ui/apps/dashboard/src/middleware.ts
@@ -18,12 +18,7 @@ export default authMiddleware({
       return redirectToSignIn({ returnBackUrl: request.url });
     }
 
-    if (
-      isSignedIn &&
-      !hasActiveOrganization &&
-      request.nextUrl.pathname !== '/organization-list' &&
-      request.nextUrl.pathname !== '/sign-up/account-setup'
-    ) {
+    if (isSignedIn && !hasActiveOrganization && request.nextUrl.pathname !== '/organization-list') {
       const organizationListURL = new URL('/organization-list', request.url);
       organizationListURL.searchParams.append('redirect_url', request.url);
       return NextResponse.redirect(organizationListURL);


### PR DESCRIPTION
## Description

This is a hotfix to not let users get stuck on the account setup page when they don't have an active organization. This issue occurs occasionally, which might also be due to an issue with the feature flag. I'm remove them as well in case it's the source of the issue.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
