### PR TITLE
fix(dashboard): can't invite members during second organization creation

### DIFF
--- a/ui/apps/dashboard/src/middleware.ts
+++ b/ui/apps/dashboard/src/middleware.ts
@@ -26,9 +26,11 @@ export default authMiddleware({
 
     if (
       isSignedIn &&
+      hasActiveOrganization &&
       !isAccountSetup &&
-      request.nextUrl.pathname !== '/sign-up/account-setup' &&
-      request.nextUrl.pathname !== '/organization-list'
+      request.nextUrl.pathname !== '/organization-list' &&
+      request.nextUrl.pathname !== '/create-organization' &&
+      request.nextUrl.pathname !== '/sign-up/account-setup'
     ) {
       return NextResponse.redirect(new URL('/sign-up/account-setup', request.url));
     }


### PR DESCRIPTION
## Description

This fixes a bug where the form for inviting a member would be skipped when one would create a second organization through the "Create Organization" page. This was happening because the user would be redirected by the middleware to the "Account Setup" page as soon as he had created that organization.

## Motivation
I'm currently hunting bugs around the "Organizations" feature.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
