### PR TITLE
INN 2787 Use shared AlertModal component in function pause and archive modals

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/FunctionTable.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/FunctionTable.tsx
@@ -22,6 +22,7 @@ export type FunctionTableRow = {
   name: string;
   isArchived: boolean;
   isActive: boolean;
+  isPaused: boolean;
   slug: string;
   triggers: Trigger[];
   failureRate: number | undefined;
@@ -112,14 +113,14 @@ function createColumns(environmentSlug: string) {
     columnHelper.accessor('name', {
       cell: (info) => {
         const name = info.getValue();
-        const { isActive, isArchived, slug } = info.row.original;
+        const { isPaused, isArchived, slug } = info.row.original;
 
         return (
           <div className="flex items-center pl-6">
             <div
               className={cn(
                 'h-2.5 w-2.5 rounded-full',
-                isArchived ? 'bg-slate-300' : isActive ? 'bg-teal-500' : 'bg-amber-500'
+                isArchived ? 'bg-slate-300' : isPaused ? 'bg-amber-500' : 'bg-teal-500'
               )}
             />
             <Link

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/ArchiveButton.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/ArchiveButton.tsx
@@ -88,13 +88,13 @@ function ArchiveFunctionModal({
       title={`Are you sure you want to ${isArchived ? 'unarchive' : 'archive'} this function?`}
     >
       {isArchived && (
-        <p className="py-4">
+        <p className="pt-4">
           Reactivate this function. This function will resume normal functionality and will be
           invoked as new events are received. Events received while archived will not be replayed.
         </p>
       )}
       {!isArchived && (
-        <ul className="list-disc p-4 leading-8">
+        <ul className="list-disc p-4 pb-0 leading-8">
           <li>Existing runs will continue to run to completion.</li>
           <li>No new runs will be queued or invoked.</li>
           <li>Events will continue to be received, but they will not trigger new runs.</li>

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/ArchiveButton.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/ArchiveButton.tsx
@@ -4,12 +4,12 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ArchiveBoxIcon } from '@heroicons/react/20/solid';
 import { Button } from '@inngest/components/Button';
+import { AlertModal } from '@inngest/components/Modal';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { toast } from 'sonner';
 import { useMutation, useQuery } from 'urql';
 
 import { useEnvironment } from '@/app/(organization-active)/(dashboard)/env/[environmentSlug]/environment-context';
-import Modal from '@/components/Modal';
 import { graphql } from '@/gql';
 import UnarchiveIcon from '@/icons/unarchive.svg';
 
@@ -77,26 +77,33 @@ function ArchiveFunctionModal({
   }
 
   return (
-    <Modal className="flex max-w-xl flex-col gap-4" isOpen={isOpen} onClose={onClose}>
-      <p>{`Are you sure you want to ${isArchived ? 'resume' : 'archive'} this function?`}</p>
+    <AlertModal
+      className="w-1/3"
+      isOpen={isOpen}
+      onClose={onClose}
+      primaryAction={{
+        label: isArchived ? 'Unarchive' : 'Archive',
+        btnAction: handleArchive,
+      }}
+      title={`Are you sure you want to ${isArchived ? 'unarchive' : 'archive'} this function?`}
+    >
       {isArchived && (
-        <p className="pb-4 text-sm">
+        <p className="py-4">
           Reactivate this function. This function will resume normal functionality and will be
           invoked as new events are received. Events received while archived will not be replayed.
         </p>
       )}
       {!isArchived && (
-        <p className="pb-4 text-sm">
-          Deactivate this function and prevent it from running again. Archived functions and their
-          logs can be viewed at anytime. Functions can be unarchived if desired.
-        </p>
+        <ul className="list-disc p-4 leading-8">
+          <li>Existing runs will continue to run to completion.</li>
+          <li>No new runs will be queued or invoked.</li>
+          <li>Events will continue to be received, but they will not trigger new runs.</li>
+          <li>Archived functions and their logs can be viewed at any time.</li>
+          <li>Archived functions will be unarchived when you resync your app.</li>
+          <li>Functions can be unarchived at any time.</li>
+        </ul>
       )}
-
-      <div className="flex content-center justify-end">
-        <Button appearance="outlined" btnAction={() => onClose()} label="No" />
-        <Button kind="danger" appearance="text" btnAction={handleArchive} label="Yes" />
-      </div>
-    </Modal>
+    </AlertModal>
   );
 }
 

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/PauseButton.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/PauseButton.tsx
@@ -4,12 +4,12 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { PauseIcon, PlayIcon } from '@heroicons/react/20/solid';
 import { Button } from '@inngest/components/Button';
+import { AlertModal } from '@inngest/components/Modal';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { toast } from 'sonner';
 import { useMutation, useQuery } from 'urql';
 
 import { useEnvironment } from '@/app/(organization-active)/(dashboard)/env/[environmentSlug]/environment-context';
-import Modal from '@/components/Modal';
 import { graphql } from '@/gql';
 
 const FunctionVersionNumberDocument = graphql(`
@@ -111,30 +111,32 @@ function PauseFunctionModal({
   }
 
   return (
-    <Modal className="flex max-w-xl flex-col gap-4" isOpen={isOpen} onClose={onClose}>
-      <p>{`Are you sure you want to ${isPaused ? 'resume' : 'pause'} this function?`}</p>
+    <AlertModal
+      isOpen={isOpen}
+      onClose={onClose}
+      primaryAction={{
+        label: isPaused ? 'Resume' : 'Pause',
+        btnAction: isPaused ? handleResume : handlePause,
+      }}
+      title={`Are you sure you want to ${isPaused ? 'resume' : 'pause'} this function?`}
+      className="w-1/3"
+    >
       {isPaused && (
-        <p className="pb-4 text-sm">
+        <p className="py-4">
           This function will resume normal functionality and will be invoked as new events are
           received. Events received during pause will not be automatically replayed.
         </p>
       )}
       {!isPaused && (
-        <p className="pb-4 text-sm">
-          Temporarily stop this function from being run. Events can still be sent, but this function
-          will not be invoked. You can resume it at any time.
-        </p>
+        <ul className="list-disc p-4 leading-8">
+          <li>Existing runs will continue to run to completion.</li>
+          <li>No new runs will be queued or invoked.</li>
+          <li>Events will continue to be received, but they will not trigger new runs.</li>
+          <li>Paused functions will be unpaused when you resync your app.</li>
+          <li>Functions can be resumed at any time.</li>
+        </ul>
       )}
-      <div className="flex content-center justify-end">
-        <Button appearance="outlined" btnAction={() => onClose()} label="No" />
-        <Button
-          kind="danger"
-          appearance="text"
-          btnAction={isPaused ? handleResume : handlePause}
-          label="Yes"
-        />
-      </div>
-    </Modal>
+    </AlertModal>
   );
 }
 

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/PauseButton.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/PauseButton.tsx
@@ -122,13 +122,13 @@ function PauseFunctionModal({
       className="w-1/3"
     >
       {isPaused && (
-        <p className="py-4">
+        <p className="pt-4">
           This function will resume normal functionality and will be invoked as new events are
           received. Events received during pause will not be automatically replayed.
         </p>
       )}
       {!isPaused && (
-        <ul className="list-disc p-4 leading-8">
+        <ul className="list-disc p-4 pb-0 leading-8">
           <li>Existing runs will continue to run to completion.</li>
           <li>No new runs will be queued or invoked.</li>
           <li>Events will continue to be received, but they will not trigger new runs.</li>

--- a/ui/apps/dashboard/src/queries/functions.ts
+++ b/ui/apps/dashboard/src/queries/functions.ts
@@ -115,8 +115,8 @@ export function useFunctionsPage({
         return {
           ...fn,
           failureRate: undefined,
-          // When !fn.isArchived && !fn.current, the function is paused
-          isActive: !fn.isArchived && fn.current,
+          isActive: !fn.isArchived,
+          isPaused: !fn.isArchived && !fn.current,
           triggers,
           usage: undefined,
         };

--- a/ui/apps/dashboard/src/queries/functions.ts
+++ b/ui/apps/dashboard/src/queries/functions.ts
@@ -115,7 +115,8 @@ export function useFunctionsPage({
         return {
           ...fn,
           failureRate: undefined,
-          isActive: !fn.isArchived,
+          // When !fn.isArchived && !fn.current, the function is paused
+          isActive: !fn.isArchived && fn.current,
           triggers,
           usage: undefined,
         };

--- a/ui/packages/components/src/Modal/AlertModal.tsx
+++ b/ui/packages/components/src/Modal/AlertModal.tsx
@@ -1,4 +1,4 @@
-import { classNames } from '@inngest/components/utils/classNames';
+import { cn } from '@inngest/components/utils/classNames';
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import { AnimatePresence, motion } from 'framer-motion';
 
@@ -53,7 +53,7 @@ export function AlertModal({
               }}
             >
               <AlertDialog.Content
-                className={classNames(
+                className={cn(
                   className,
                   'dark:bg-slate-910 transform overflow-hidden rounded-lg bg-white shadow-xl transition-all'
                 )}


### PR DESCRIPTION
## Description
- Replace old modal by AlertModal shared component
- Tweak copy for archive and pause functions
- Fix paused status in function list

Note: this can get some design love once we work on manually trigger fn

![Screenshot 2024-02-15 at 22 58 56](https://github.com/inngest/inngest/assets/16758464/caae0047-2449-4db9-9b97-dd695fb0b959)
![Screenshot 2024-02-15 at 22 58 43](https://github.com/inngest/inngest/assets/16758464/b37dd16d-a5f8-4396-ac66-ce3859ff6bb7)

![Screenshot 2024-02-15 at 22 54 00](https://github.com/inngest/inngest/assets/16758464/b59ea1fa-44b2-40ae-9b79-c5a6ad71ba0f)


## Motivation
- Users are confused about what is the pause and archive function behaviour.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
