### PR TITLE
Clean up initial edge execution path

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -463,7 +463,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	//
 	// This enures that we only ever enqueue the start job for this function once.
 	queueKey := fmt.Sprintf("%s:%s", req.Function.ID, key)
-	retries := req.Function.GetRetries() + 1
+	attempts := req.Function.GetRetries() + 1
 	item := queue.Item{
 		JobID:       &queueKey,
 		GroupID:     uuid.New().String(),

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -122,6 +122,15 @@ func (f Function) ConcurrencyLimit() int {
 	return 0
 }
 
+// GetRetries returns the number of retries for the function.
+func (f Function) GetRetries() int {
+	// This uses retries in steps; a holdover from when steps were used in our DAG based approach.
+	if len(f.Steps) == 0 || f.Steps[0].Retries == nil {
+		return consts.DefaultRetryCount
+	}
+	return *f.Steps[0].Retries
+}
+
 // GetSlug returns the function slug, defaulting to creating a slug of the function name.
 func (f Function) GetSlug() string {
 	if f.Slug != "" {


### PR DESCRIPTION
There are still some vestiges of our DAG-based days lurking around.  This code simplifies the initial executor path, consolidating on the single-step approach we've been rolling with for a couple years — which won't change.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
