### PR TITLE
Fix NonRetriableError not working with streaming

### DIFF
--- a/pkg/execution/driver/httpdriver/parse.go
+++ b/pkg/execution/driver/httpdriver/parse.go
@@ -77,14 +77,12 @@ func parseGenerator(ctx context.Context, byt []byte, noRetry bool) ([]*state.Gen
 }
 
 func ParseStream(resp []byte) (*StreamResponse, error) {
-	fmt.Println(string(resp))
 	body := &StreamResponse{}
 	if err := json.Unmarshal(resp, &body); err != nil {
 		return nil, fmt.Errorf("error reading response body to check for status code: %w", err)
 	}
 	// Check to see if the body is double-encoded.
 	if len(body.Body) > 0 && body.Body[0] == '"' && body.Body[len(body.Body)-1] == '"' {
-		fmt.Println("double encoded")
 		var str string
 		if err := json.Unmarshal(body.Body, &str); err == nil {
 			body.Body = []byte(str)

--- a/pkg/execution/driver/httpdriver/parse.go
+++ b/pkg/execution/driver/httpdriver/parse.go
@@ -77,12 +77,14 @@ func parseGenerator(ctx context.Context, byt []byte, noRetry bool) ([]*state.Gen
 }
 
 func ParseStream(resp []byte) (*StreamResponse, error) {
+	fmt.Println(string(resp))
 	body := &StreamResponse{}
 	if err := json.Unmarshal(resp, &body); err != nil {
 		return nil, fmt.Errorf("error reading response body to check for status code: %w", err)
 	}
 	// Check to see if the body is double-encoded.
 	if len(body.Body) > 0 && body.Body[0] == '"' && body.Body[len(body.Body)-1] == '"' {
+		fmt.Println("double encoded")
 		var str string
 		if err := json.Unmarshal(body.Body, &str); err == nil {
 			body.Body = []byte(str)
@@ -94,8 +96,6 @@ func ParseStream(resp []byte) (*StreamResponse, error) {
 type StreamResponse struct {
 	StatusCode int               `json:"status"`
 	Body       json.RawMessage   `json:"body"`
-	RetryAt    *string           `json:"retryAt"`
-	NoRetry    bool              `json:"noRetry"`
 	Headers    map[string]string `json:"headers"`
 }
 


### PR DESCRIPTION
## Description
`NonRetriableError` wasn't working with streaming because the Executor was expecting response body fields that didn't exist. It expected `noRetry` and `retryAt` fields, but those fields are actually headers.

The following is an example of a streaming response body:
```json
{
  "status": 400,
  "headers": {
    "Content-Type": "application/json",
    "User-Agent": "inngest-js:v3.14.0",
    "x-inngest-sdk": "inngest-js:v3.14.0",
    "x-inngest-framework": "nextjs",
    "Server-Timing": "handler, action;dur=6, res",
    "x-inngest-no-retry": "true",
    "x-inngest-req-version": "1"
  },
  "body": "{\"name\":\"NonRetriableError\",\"message\":\"Stop the process\",\"stack\":\"NonRetriableError: Stop the process\\n    at V1InngestExecution.eval [as userFnToRun] (webpack-internal:///(rsc)/./src/inngest/functions.ts:15:11)\\n    at eval (webpack-internal:///(rsc)/./node_modules/inngest/components/execution/v1.js:357:51)\\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)\",\"__serialized\":true}",
  "version": 1
}
```

## Motivation
https://linear.app/inngest/issue/INN-2795

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
