### PR TITLE
Replace @radix-ui/react-tooltip usage

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/ArchiveButton.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/ArchiveButton.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import { ArchiveBoxIcon } from '@heroicons/react/20/solid';
 import { Button } from '@inngest/components/Button';
 import { AlertModal } from '@inngest/components/Modal';
-import * as Tooltip from '@radix-ui/react-tooltip';
 import { toast } from 'sonner';
 import { useMutation, useQuery } from 'urql';
 
@@ -133,32 +132,19 @@ export default function ArchiveFunctionButton({ functionSlug }: ArchiveFunctionP
 
   return (
     <>
-      <Tooltip.Provider>
-        <Tooltip.Root delayDuration={0}>
-          <Tooltip.Trigger asChild>
-            <span tabIndex={0}>
-              <Button
-                icon={
-                  isArchived ? (
-                    <UnarchiveIcon className=" text-slate-300" />
-                  ) : (
-                    <ArchiveBoxIcon className=" text-slate-300" />
-                  )
-                }
-                btnAction={() => setIsArchivedFunctionModalVisible(true)}
-                disabled={isFetchingVersions}
-                label={isArchived ? 'Unarchive' : 'Archive'}
-              />
-            </span>
-          </Tooltip.Trigger>
-          <Tooltip.Content className="align-center rounded-md bg-slate-800 px-2 text-xs text-slate-300">
-            {isArchived
-              ? 'Reactivate function'
-              : 'Deactivate this function and archive for historic purposes'}
-            <Tooltip.Arrow className="fill-slate-800" />
-          </Tooltip.Content>
-        </Tooltip.Root>
-      </Tooltip.Provider>
+      <Button
+        icon={
+          isArchived ? (
+            <UnarchiveIcon className=" text-slate-300" />
+          ) : (
+            <ArchiveBoxIcon className=" text-slate-300" />
+          )
+        }
+        btnAction={() => setIsArchivedFunctionModalVisible(true)}
+        disabled={isFetchingVersions}
+        label={isArchived ? 'Unarchive' : 'Archive'}
+      />
+
       <ArchiveFunctionModal
         functionID={fn.id}
         functionName={fn.name || 'This function'}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/PauseButton.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/PauseButton.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import { PauseIcon, PlayIcon } from '@heroicons/react/20/solid';
 import { Button } from '@inngest/components/Button';
 import { AlertModal } from '@inngest/components/Modal';
-import * as Tooltip from '@radix-ui/react-tooltip';
 import { toast } from 'sonner';
 import { useMutation, useQuery } from 'urql';
 
@@ -169,32 +168,19 @@ export default function PauseFunctionButton({ functionSlug, disabled }: PauseFun
 
   return (
     <>
-      <Tooltip.Provider>
-        <Tooltip.Root delayDuration={0}>
-          <Tooltip.Trigger asChild>
-            <span tabIndex={0}>
-              <Button
-                icon={
-                  isPaused ? (
-                    <PlayIcon className=" text-green-600" />
-                  ) : (
-                    <PauseIcon className=" text-amber-500" />
-                  )
-                }
-                btnAction={() => setIsPauseFunctionModalVisible(true)}
-                disabled={disabled || isFetchingVersions}
-                label={isPaused ? 'Resume' : 'Pause'}
-              />
-            </span>
-          </Tooltip.Trigger>
-          <Tooltip.Content className="align-center rounded-md bg-slate-800 px-2 text-xs text-slate-300">
-            {isPaused
-              ? 'Begin running this function after a temporary pause'
-              : 'Temporarily stop a function from being run'}
-            <Tooltip.Arrow className="fill-slate-800" />
-          </Tooltip.Content>
-        </Tooltip.Root>
-      </Tooltip.Provider>
+      <Button
+        icon={
+          isPaused ? (
+            <PlayIcon className=" text-green-600" />
+          ) : (
+            <PauseIcon className=" text-amber-500" />
+          )
+        }
+        btnAction={() => setIsPauseFunctionModalVisible(true)}
+        disabled={disabled || isFetchingVersions}
+        label={isPaused ? 'Resume' : 'Pause'}
+      />
+
       <PauseFunctionModal
         functionID={fn.id}
         functionName={functionSlug}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/billing/PaymentIcons.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/billing/PaymentIcons.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { CheckIcon, ClockIcon, ExclamationCircleIcon, XMarkIcon } from '@heroicons/react/20/solid';
-import * as Tooltip from '@radix-ui/react-tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';
 
 type PaymentIconProps = {
   status: String;
@@ -37,15 +37,12 @@ export default function PaymentIcon({ status }: PaymentIconProps) {
   }
   if (icon) {
     return (
-      <Tooltip.Provider>
-        <Tooltip.Root delayDuration={0}>
-          <Tooltip.Trigger asChild>{icon}</Tooltip.Trigger>
-          <Tooltip.Content className="align-center rounded-md bg-slate-800 px-2 text-xs text-slate-300">
-            {label}
-            <Tooltip.Arrow className="fill-slate-800" />
-          </Tooltip.Content>
-        </Tooltip.Root>
-      </Tooltip.Provider>
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>{icon}</TooltipTrigger>
+        <TooltipContent className="align-center rounded-md bg-slate-800 px-2 text-xs text-slate-300">
+          {label}
+        </TooltipContent>
+      </Tooltip>
     );
   }
   return icon;

--- a/ui/apps/dashboard/src/components/Pill/HorizontalPillList.tsx
+++ b/ui/apps/dashboard/src/components/Pill/HorizontalPillList.tsx
@@ -1,4 +1,4 @@
-import * as Tooltip from '@radix-ui/react-tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';
 
 import { Pill } from '@/components/Pill/Pill';
 
@@ -20,24 +20,19 @@ export default function HorizontalPillList({
     return (
       <>
         {alwaysVisiblePills}
-        <Tooltip.Provider>
-          <Tooltip.Root delayDuration={0}>
-            <Tooltip.Trigger className="cursor-default">
-              <Pill className="bg-white px-2.5 align-middle text-slate-600">
-                +{hiddenPills.length}
-              </Pill>
-            </Tooltip.Trigger>
-            <Tooltip.Portal>
-              <Tooltip.Content
-                className="data-[state=delayed-open]:data-[side=top]:animate-slide-down-and-fade data-[state=delayed-open]:data-[side=right]:animate-slide-left-and-fade data-[state=delayed-open]:data-[side=left]:animate-slide-right-and-fade data-[state=delayed-open]:data-[side=bottom]:animate-slide-up-and-fade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
-                sideOffset={5}
-              >
-                <div className="flex flex-col gap-2">{hiddenPills}</div>
-                <Tooltip.Arrow className="fill-white" />
-              </Tooltip.Content>
-            </Tooltip.Portal>
-          </Tooltip.Root>
-        </Tooltip.Provider>
+        <Tooltip delayDuration={0}>
+          <TooltipTrigger className="cursor-default">
+            <Pill className="bg-white px-2.5 align-middle text-slate-600">
+              +{hiddenPills.length}
+            </Pill>
+          </TooltipTrigger>
+          <TooltipContent
+            className="data-[state=delayed-open]:data-[side=top]:animate-slide-down-and-fade data-[state=delayed-open]:data-[side=right]:animate-slide-left-and-fade data-[state=delayed-open]:data-[side=left]:animate-slide-right-and-fade data-[state=delayed-open]:data-[side=bottom]:animate-slide-up-and-fade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
+            sideOffset={5}
+          >
+            <div className="flex flex-col gap-2">{hiddenPills}</div>
+          </TooltipContent>
+        </Tooltip>
       </>
     );
   }


### PR DESCRIPTION
## Description
Replace `@radix-ui/react-tooltip` usage with our tooltip components. Remove tooltips on "Pause" and "Archive" function buttons, since they have modals that explain what they do

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
