### PR TITLE
Fix the bottom of the page from being chopped off

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/layout.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/layout.tsx
@@ -6,7 +6,7 @@ type IntegrationsLayoutProps = {
 
 export default function IntegrationsLayout({ children }: IntegrationsLayoutProps) {
   return (
-    <div className="flex h-full divide-x divide-slate-100">
+    <div className="min-height-[300px] flex divide-x divide-slate-100">
       <nav className="w-60 shrink-0 p-8">
         <ul>
           <li>


### PR DESCRIPTION
## Description

Fixes the bottom of the page being chopped off after the partial fix of #1161

## Motivation
The scrolling of this page was still not fixed.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
