### PR TITLE
Improve sync request normalization

### DIFF
--- a/pkg/cqrs/sqlitecqrs/cqrs.go
+++ b/pkg/cqrs/sqlitecqrs/cqrs.go
@@ -97,7 +97,11 @@ func (w wrapper) GetAppByID(ctx context.Context, id uuid.UUID) (*cqrs.App, error
 
 func (w wrapper) GetAppByURL(ctx context.Context, url string) (*cqrs.App, error) {
 	// Normalize the URL before inserting into the DB.
-	url = util.NormalizeAppURL(url)
+	forceHTTPS := false
+	url, err := util.NormalizeAppURL(url, forceHTTPS)
+	if err != nil {
+		return nil, err
+	}
 
 	f := func(ctx context.Context) (*sqlc.App, error) {
 		return w.q.GetAppByURL(ctx, url)
@@ -112,8 +116,14 @@ func (w wrapper) GetAllApps(ctx context.Context) ([]*cqrs.App, error) {
 
 // InsertApp creates a new app.
 func (w wrapper) InsertApp(ctx context.Context, arg cqrs.InsertAppParams) (*cqrs.App, error) {
+	var err error
+
 	// Normalize the URL before inserting into the DB.
-	arg.Url = util.NormalizeAppURL(arg.Url)
+	forceHTTPS := false
+	arg.Url, err = util.NormalizeAppURL(arg.Url, forceHTTPS)
+	if err != nil {
+		return nil, err
+	}
 
 	return copyWriter(
 		ctx,
@@ -153,8 +163,14 @@ func (w wrapper) UpdateAppError(ctx context.Context, arg cqrs.UpdateAppErrorPara
 }
 
 func (w wrapper) UpdateAppURL(ctx context.Context, arg cqrs.UpdateAppURLParams) (*cqrs.App, error) {
+	var err error
+
 	// Normalize the URL before inserting into the DB.
-	arg.Url = util.NormalizeAppURL(arg.Url)
+	forceHTTPS := false
+	arg.Url, err = util.NormalizeAppURL(arg.Url, forceHTTPS)
+	if err != nil {
+		return nil, err
+	}
 
 	// https://duckdb.org/docs/sql/indexes.html
 	//

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -164,7 +164,11 @@ func (a devapi) Register(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (err error) {
-	r.URL = util.NormalizeAppURL(r.URL)
+	forceHTTPS := false
+	r.URL, err = util.NormalizeAppURL(r.URL, forceHTTPS)
+	if err != nil {
+		return publicerr.Wrap(err, 400, "Invalid request")
+	}
 
 	sum, err := r.Checksum()
 	if err != nil {

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/url"
 	"strings"
 
@@ -17,6 +18,30 @@ import (
 var (
 	ErrNoFunctions = fmt.Errorf("No functions registered within your app")
 )
+
+type FromReadCloserOpts struct {
+	Env        string
+	ForceHTTPS bool
+	Platform   string
+}
+
+func FromReadCloser(r io.ReadCloser, opts FromReadCloserOpts) (RegisterRequest, error) {
+	fr := RegisterRequest{}
+	err := json.NewDecoder(r).Decode(&fr)
+	if err != nil {
+		return fr, err
+	}
+
+	fr.Headers.Env = opts.Env
+	fr.Headers.Platform = opts.Platform
+
+	err = fr.Normalize(opts.ForceHTTPS)
+	if err != nil {
+		return fr, err
+	}
+
+	return fr, nil
+}
 
 // RegisterRequest represents a new deploy request from SDK-based functions.
 // This lets us know that a new deploy has started and that we need to
@@ -127,10 +152,34 @@ func (f RegisterRequest) Parse(ctx context.Context) ([]*inngest.Function, error)
 				err = multierror.Append(err, fmt.Errorf("Step '%s' has an invalid driver. Only HTTP drivers may be used with SDK functions.", step.ID))
 				continue
 			}
-			step.URI = util.NormalizeAppURL(step.URI)
 			fn.Steps[n] = step
 		}
 	}
 
 	return funcs, err
+}
+
+func (f *RegisterRequest) Normalize(forceHTTPS bool) error {
+	u, err := util.NormalizeAppURL(f.URL, forceHTTPS)
+	if err != nil {
+		return err
+	}
+	f.URL = u
+
+	for _, fn := range f.Functions {
+		for _, step := range fn.Steps {
+			if rawStepURL, ok := step.Runtime["url"]; ok {
+				if stepURL, ok := rawStepURL.(string); ok {
+					u, err := util.NormalizeAppURL(stepURL, forceHTTPS)
+					if err != nil {
+						return err
+					}
+
+					step.Runtime["url"] = u
+				}
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/util/normalize.go
+++ b/pkg/util/normalize.go
@@ -4,32 +4,52 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 )
 
 // NormalizeAppURL normalizes localhost and 127.0.0.1 as the same string.  This
 // ensures that we don't add duplicate apps.
-func NormalizeAppURL(u string) string {
+func NormalizeAppURL(u string, forceHTTPS bool) (string, error) {
 	parsed, err := url.Parse(u)
 	if err != nil {
-		return u
+		return "", err
 	}
 
-	host, port, err := net.SplitHostPort(parsed.Host)
-	if err != nil {
-		return u
+	parsed = stripDeployID(*parsed)
+
+	if forceHTTPS {
+		if parsed.Scheme != "https" {
+			parsed.Scheme = "https"
+		}
 	}
 
-	// this shouldn't be valid: https://api.example.com:80/api/inngest
-	if parsed.Scheme == "https" && port != "" {
-		parsed.Host = host
-		return parsed.String()
+	if strings.Contains(parsed.Host, ":") {
+		host, port, err := net.SplitHostPort(parsed.Host)
+		if err != nil {
+			return parsed.String(), err
+		}
+
+		// this shouldn't be valid: https://api.example.com:80/api/inngest
+		if parsed.Scheme == "https" && port != "" {
+			parsed.Host = host
+			return parsed.String(), nil
+		}
+
+		switch host {
+		case "localhost", "127.0.0.1", "0.0.0.0":
+			parsed.Host = fmt.Sprintf("localhost:%s", port)
+			return parsed.String(), nil
+		default:
+			return parsed.String(), nil
+		}
 	}
 
-	switch host {
-	case "localhost", "127.0.0.1", "0.0.0.0":
-		parsed.Host = fmt.Sprintf("localhost:%s", port)
-		return parsed.String()
-	default:
-		return u
-	}
+	return parsed.String(), nil
+}
+
+func stripDeployID(u url.URL) *url.URL {
+	qp := u.Query()
+	qp.Del("deployId")
+	u.RawQuery = qp.Encode()
+	return &u
 }

--- a/pkg/util/normalize_test.go
+++ b/pkg/util/normalize_test.go
@@ -11,6 +11,7 @@ func TestNormalizeAppURL(t *testing.T) {
 		name        string
 		inputURL    string
 		expectedURL string
+		forceHTTPS  bool
 	}{
 		{
 			name:        "valid URI should return without modification",
@@ -27,11 +28,23 @@ func TestNormalizeAppURL(t *testing.T) {
 			inputURL:    "https://api.example.com:80/api/inngest?fnId=hello&step=step",
 			expectedURL: "https://api.example.com/api/inngest?fnId=hello&step=step",
 		},
+		{
+			name:        "force https",
+			inputURL:    "http://api.example.com/api/inngest",
+			expectedURL: "https://api.example.com/api/inngest",
+			forceHTTPS:  true,
+		},
+		{
+			name:        "strip deployId query param",
+			inputURL:    "https://api.example.com/api/inngest?deployId=1234",
+			expectedURL: "https://api.example.com/api/inngest",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := NormalizeAppURL(test.inputURL)
+			result, err := NormalizeAppURL(test.inputURL, test.forceHTTPS)
+			require.NoError(t, err)
 			require.Equal(t, test.expectedURL, result)
 		})
 	}


### PR DESCRIPTION
## Description
- Create `FromReadCloser`, which alleviates some of the burden of `RegisterRequest` creation from consumers. It'll ensure `RegisterRequest` is normalized and env/platform are set.
- Add `Normalize` method, which ensures all of the URLs are normalized. Other normalization logic may go here in the future.
- Change `NormalizeAppURL` to optionally force HTTPS and strip the `deployId` search param.

## Motivation
We don't want `deployId` to appear in any URLs, since it's an internal concern that's only relevant during synchronization

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
