### PR TITLE
Omit `correlation_id` from invocation events if empty

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -111,7 +111,7 @@ func (e Event) Validate(ctx context.Context) error {
 
 type InngestMetadata struct {
 	InvokeFnID          string `json:"fn_id"`
-	InvokeCorrelationId string `json:"correlation_id"`
+	InvokeCorrelationId string `json:"correlation_id,omitempty"`
 }
 
 func (e Event) InngestMetadata() *InngestMetadata {


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

Don't include empty `correlation_id` fields in `inngest/function.invoked` events; if it's empty, it's not relevant.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
