### PR TITLE
Separate RegisterRequest normalization

### DIFF
--- a/pkg/cqrs/sqlitecqrs/cqrs.go
+++ b/pkg/cqrs/sqlitecqrs/cqrs.go
@@ -20,6 +20,10 @@ import (
 	"github.com/oklog/ulid/v2"
 )
 
+const (
+	forceHTTPS = false
+)
+
 var (
 	// end represents a ulid ending with 'Z', eg. a far out cursor.
 	endULID = ulid.ULID([16]byte{'Z'})
@@ -97,7 +101,7 @@ func (w wrapper) GetAppByID(ctx context.Context, id uuid.UUID) (*cqrs.App, error
 
 func (w wrapper) GetAppByURL(ctx context.Context, url string) (*cqrs.App, error) {
 	// Normalize the URL before inserting into the DB.
-	url = util.NormalizeAppURL(url)
+	url = util.NormalizeAppURL(url, forceHTTPS)
 
 	f := func(ctx context.Context) (*sqlc.App, error) {
 		return w.q.GetAppByURL(ctx, url)
@@ -113,7 +117,7 @@ func (w wrapper) GetAllApps(ctx context.Context) ([]*cqrs.App, error) {
 // InsertApp creates a new app.
 func (w wrapper) InsertApp(ctx context.Context, arg cqrs.InsertAppParams) (*cqrs.App, error) {
 	// Normalize the URL before inserting into the DB.
-	arg.Url = util.NormalizeAppURL(arg.Url)
+	arg.Url = util.NormalizeAppURL(arg.Url, forceHTTPS)
 
 	return copyWriter(
 		ctx,
@@ -154,7 +158,7 @@ func (w wrapper) UpdateAppError(ctx context.Context, arg cqrs.UpdateAppErrorPara
 
 func (w wrapper) UpdateAppURL(ctx context.Context, arg cqrs.UpdateAppURLParams) (*cqrs.App, error) {
 	// Normalize the URL before inserting into the DB.
-	arg.Url = util.NormalizeAppURL(arg.Url)
+	arg.Url = util.NormalizeAppURL(arg.Url, forceHTTPS)
 
 	// https://duckdb.org/docs/sql/indexes.html
 	//

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -164,7 +164,8 @@ func (a devapi) Register(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (err error) {
-	r.URL = util.NormalizeAppURL(r.URL)
+	forceHTTPS := false
+	r.URL = util.NormalizeAppURL(r.URL, forceHTTPS)
 
 	sum, err := r.Checksum()
 	if err != nil {

--- a/pkg/util/normalize.go
+++ b/pkg/util/normalize.go
@@ -4,32 +4,52 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 )
 
 // NormalizeAppURL normalizes localhost and 127.0.0.1 as the same string.  This
 // ensures that we don't add duplicate apps.
-func NormalizeAppURL(u string) string {
+func NormalizeAppURL(u string, forceHTTPS bool) string {
 	parsed, err := url.Parse(u)
 	if err != nil {
 		return u
 	}
 
-	host, port, err := net.SplitHostPort(parsed.Host)
-	if err != nil {
-		return u
+	parsed = stripDeployID(*parsed)
+
+	if forceHTTPS {
+		if parsed.Scheme != "https" {
+			parsed.Scheme = "https"
+		}
 	}
 
-	// this shouldn't be valid: https://api.example.com:80/api/inngest
-	if parsed.Scheme == "https" && port != "" {
-		parsed.Host = host
-		return parsed.String()
+	if strings.Contains(parsed.Host, ":") {
+		host, port, err := net.SplitHostPort(parsed.Host)
+		if err != nil {
+			return u
+		}
+
+		// this shouldn't be valid: https://api.example.com:80/api/inngest
+		if parsed.Scheme == "https" && port != "" {
+			parsed.Host = host
+			return parsed.String()
+		}
+
+		switch host {
+		case "localhost", "127.0.0.1", "0.0.0.0":
+			parsed.Host = fmt.Sprintf("localhost:%s", port)
+			return parsed.String()
+		default:
+			return u
+		}
 	}
 
-	switch host {
-	case "localhost", "127.0.0.1", "0.0.0.0":
-		parsed.Host = fmt.Sprintf("localhost:%s", port)
-		return parsed.String()
-	default:
-		return u
-	}
+	return parsed.String()
+}
+
+func stripDeployID(u url.URL) *url.URL {
+	qp := u.Query()
+	qp.Del("deployId")
+	u.RawQuery = qp.Encode()
+	return &u
 }

--- a/pkg/util/normalize.go
+++ b/pkg/util/normalize.go
@@ -26,12 +26,6 @@ func NormalizeAppURL(u string, forceHTTPS bool) string {
 	if strings.Contains(parsed.Host, ":") {
 		host, port, err := net.SplitHostPort(parsed.Host)
 		if err != nil {
-			return u
-		}
-
-		// this shouldn't be valid: https://api.example.com:80/api/inngest
-		if parsed.Scheme == "https" && port != "" {
-			parsed.Host = host
 			return parsed.String()
 		}
 
@@ -40,7 +34,7 @@ func NormalizeAppURL(u string, forceHTTPS bool) string {
 			parsed.Host = fmt.Sprintf("localhost:%s", port)
 			return parsed.String()
 		default:
-			return u
+			return parsed.String()
 		}
 	}
 

--- a/pkg/util/normalize_test.go
+++ b/pkg/util/normalize_test.go
@@ -24,11 +24,6 @@ func TestNormalizeAppURL(t *testing.T) {
 			expectedURL: "http://localhost:3000/api/inngest?fnId=hello&step=step",
 		},
 		{
-			name:        "host should not have port when using https scheme",
-			inputURL:    "https://api.example.com:80/api/inngest?fnId=hello&step=step",
-			expectedURL: "https://api.example.com/api/inngest?fnId=hello&step=step",
-		},
-		{
 			name:        "force https",
 			inputURL:    "http://api.example.com/api/inngest",
 			expectedURL: "https://api.example.com/api/inngest",

--- a/pkg/util/normalize_test.go
+++ b/pkg/util/normalize_test.go
@@ -11,6 +11,7 @@ func TestNormalizeAppURL(t *testing.T) {
 		name        string
 		inputURL    string
 		expectedURL string
+		forceHTTPS  bool
 	}{
 		{
 			name:        "valid URI should return without modification",
@@ -27,11 +28,22 @@ func TestNormalizeAppURL(t *testing.T) {
 			inputURL:    "https://api.example.com:80/api/inngest?fnId=hello&step=step",
 			expectedURL: "https://api.example.com/api/inngest?fnId=hello&step=step",
 		},
+		{
+			name:        "force https",
+			inputURL:    "http://api.example.com/api/inngest",
+			expectedURL: "https://api.example.com/api/inngest",
+			forceHTTPS:  true,
+		},
+		{
+			name:        "strip deployId query param",
+			inputURL:    "https://api.example.com/api/inngest?deployId=1234",
+			expectedURL: "https://api.example.com/api/inngest",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := NormalizeAppURL(test.inputURL)
+			result := NormalizeAppURL(test.inputURL, test.forceHTTPS)
 			require.Equal(t, test.expectedURL, result)
 		})
 	}

--- a/tests/main.go
+++ b/tests/main.go
@@ -251,7 +251,8 @@ func introspect(test *Test) (*sdk.RegisterRequest, error) {
 	found := false
 	for _, f := range funcs {
 		for i := range f.Steps {
-			f.Steps[i].URI = util.NormalizeAppURL(f.Steps[i].URI)
+			forceHTTPS := false
+			f.Steps[i].URI = util.NormalizeAppURL(f.Steps[i].URI, forceHTTPS)
 		}
 		if f.Slug == test.ID {
 			found = true


### PR DESCRIPTION
## Description
- Separate `RegisterRequest` normalization into its own method
- Create `FromReadCloser` function to abstract away the `RegisterRequest` creation implementation details (normalization, env, and platform)
- Strip `deployId` search param during URL normalization
- Optionally force HTTPS during URL normalization. Cloud needs this

## Motivation
Separating normalization and validation is important because we want to normalize before any processing. This solves problems like:
- We're getting the checksum before normalizing
- We're doing some validation before getting/creating the `deploys` row, which means some sync failure scenarios don't save an actionable info in the `deploys` table

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
