### PR TITLE
Consolidate useGraphQLQuery

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/useApp.ts
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/useApp.ts
@@ -1,7 +1,7 @@
 import type { Function } from '@inngest/components/types/function';
 
 import { graphql } from '@/gql';
-import { useGraphQLQuery_TEMPORARY } from '@/utils/useGraphQLQuery';
+import { useGraphQLQuery } from '@/utils/useGraphQLQuery';
 
 const query = graphql(`
   query App($envID: ID!, $externalAppID: String!) {
@@ -47,7 +47,7 @@ const query = graphql(`
 `);
 
 export function useApp({ envID, externalAppID }: { envID: string; externalAppID: string }) {
-  const res = useGraphQLQuery_TEMPORARY({
+  const res = useGraphQLQuery({
     pollIntervalInMilliseconds: 10_000,
     query,
     variables: { envID, externalAppID },

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/useApps.ts
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/useApps.ts
@@ -1,5 +1,5 @@
 import { graphql } from '@/gql';
-import { useGraphQLQuery_TEMPORARY } from '@/utils/useGraphQLQuery';
+import { useGraphQLQuery } from '@/utils/useGraphQLQuery';
 
 const query = graphql(`
   query Apps($envID: ID!) {
@@ -30,7 +30,7 @@ const query = graphql(`
 `);
 
 export function useApps({ envID, isArchived }: { envID: string; isArchived: boolean }) {
-  const res = useGraphQLQuery_TEMPORARY({
+  const res = useGraphQLQuery({
     pollIntervalInMilliseconds: 2_000,
     query,
     variables: { envID },


### PR DESCRIPTION
## Description
- Delete `useGraphQLQuery_TEMPORARY` since it's battle-tested
- Make  `useGraphQLQuery` wrap `useSkippableGraphQLQuery` since its logic is exactly the same, just with skipping. This cuts down on duplicate code

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
