### PR TITLE
Only show invoke payload editor when function has event trigger

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/InvokeButton/InvokeButton.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/InvokeButton/InvokeButton.tsx
@@ -18,9 +18,10 @@ const InvokeFunctionDocument = graphql(`
 type Props = {
   disabled: boolean;
   functionSlug: string;
+  hasEventTrigger: boolean;
 };
 
-export function InvokeButton({ disabled, functionSlug }: Props) {
+export function InvokeButton({ disabled, functionSlug, hasEventTrigger }: Props) {
   const env = useEnvironment();
   const [, invokeFunction] = useMutation(InvokeFunctionDocument);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -44,6 +45,7 @@ export function InvokeButton({ disabled, functionSlug }: Props) {
       />
 
       <InvokeModal
+        hasEventTrigger={hasEventTrigger}
         isOpen={isModalOpen}
         onCancel={() => setIsModalOpen(false)}
         onConfirm={onConfirm}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/InvokeButton/InvokeButton.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/InvokeButton/InvokeButton.tsx
@@ -18,10 +18,14 @@ const InvokeFunctionDocument = graphql(`
 type Props = {
   disabled: boolean;
   functionSlug: string;
-  hasEventTrigger: boolean;
+  doesFunctionAcceptPayload: boolean;
 };
 
-export function InvokeButton({ disabled, functionSlug, hasEventTrigger }: Props) {
+export function InvokeButton({
+  disabled,
+  functionSlug,
+  doesFunctionAcceptPayload: hasEventTrigger,
+}: Props) {
   const env = useEnvironment();
   const [, invokeFunction] = useMutation(InvokeFunctionDocument);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -45,7 +49,7 @@ export function InvokeButton({ disabled, functionSlug, hasEventTrigger }: Props)
       />
 
       <InvokeModal
-        hasEventTrigger={hasEventTrigger}
+        doesFunctionAcceptPayload={hasEventTrigger}
         isOpen={isModalOpen}
         onCancel={() => setIsModalOpen(false)}
         onConfirm={onConfirm}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/InvokeButton/InvokeModal.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/InvokeButton/InvokeModal.tsx
@@ -8,12 +8,13 @@ import CodeEditor from '@/components/Textarea/CodeEditor';
 const initialCode = { data: {} };
 
 type Props = {
+  hasEventTrigger: boolean;
   isOpen: boolean;
   onCancel: () => void;
   onConfirm: (payload: { data: Record<string, unknown> }) => void;
 };
 
-export function InvokeModal({ isOpen, onCancel, onConfirm }: Props) {
+export function InvokeModal({ hasEventTrigger, isOpen, onCancel, onConfirm }: Props) {
   const [error, setError] = useState<string>();
 
   function onSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -34,6 +35,20 @@ export function InvokeModal({ isOpen, onCancel, onConfirm }: Props) {
     }
   }
 
+  let content;
+  if (hasEventTrigger) {
+    content = (
+      <CodeEditor
+        className="rounded-lg bg-slate-900 px-4"
+        initialCode={JSON.stringify(initialCode, null, 2)}
+        language="json"
+        name="code"
+      />
+    );
+  } else {
+    content = <p>This function does not have an event trigger so a payload cannot be specified.</p>;
+  }
+
   return (
     <Modal
       className="w-full max-w-3xl"
@@ -44,12 +59,7 @@ export function InvokeModal({ isOpen, onCancel, onConfirm }: Props) {
     >
       <form onSubmit={onSubmit}>
         <div className="m-6">
-          <CodeEditor
-            className="rounded-lg bg-slate-900 px-4"
-            initialCode={JSON.stringify(initialCode, null, 2)}
-            language="json"
-            name="code"
-          />
+          {content}
 
           {error && (
             <Alert className="mt-6" severity="error">

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/InvokeButton/InvokeModal.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/InvokeButton/InvokeModal.tsx
@@ -8,13 +8,18 @@ import CodeEditor from '@/components/Textarea/CodeEditor';
 const initialCode = { data: {} };
 
 type Props = {
-  hasEventTrigger: boolean;
+  doesFunctionAcceptPayload: boolean;
   isOpen: boolean;
   onCancel: () => void;
   onConfirm: (payload: { data: Record<string, unknown> }) => void;
 };
 
-export function InvokeModal({ hasEventTrigger, isOpen, onCancel, onConfirm }: Props) {
+export function InvokeModal({
+  doesFunctionAcceptPayload: hasEventTrigger,
+  isOpen,
+  onCancel,
+  onConfirm,
+}: Props) {
   const [error, setError] = useState<string>();
 
   function onSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -46,7 +51,7 @@ export function InvokeModal({ hasEventTrigger, isOpen, onCancel, onConfirm }: Pr
       />
     );
   } else {
-    content = <p>This function does not have an event trigger so a payload cannot be specified.</p>;
+    content = <p>Cron functions without event triggers cannot include payload data.</p>;
   }
 
   return (

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/layout.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/layout.tsx
@@ -56,7 +56,7 @@ export default function FunctionLayout({ children, params }: FunctionLayoutProps
     });
   }
 
-  const hasEventTrigger =
+  const doesFunctionAcceptPayload =
     fn?.current?.triggers.some((trigger) => {
       return trigger.eventName;
     }) ?? false;
@@ -75,7 +75,7 @@ export default function FunctionLayout({ children, params }: FunctionLayoutProps
                 <InvokeButton
                   functionSlug={functionSlug}
                   disabled={isArchived}
-                  hasEventTrigger={hasEventTrigger}
+                  doesFunctionAcceptPayload={doesFunctionAcceptPayload}
                 />
                 <PauseFunctionButton functionSlug={functionSlug} disabled={isArchived} />
                 <ArchiveFunctionButton functionSlug={functionSlug} />

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/layout.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/layout.tsx
@@ -56,6 +56,11 @@ export default function FunctionLayout({ children, params }: FunctionLayoutProps
     });
   }
 
+  const hasEventTrigger =
+    fn?.current?.triggers.some((trigger) => {
+      return trigger.eventName;
+    }) ?? false;
+
   return (
     <>
       <Header
@@ -67,7 +72,11 @@ export default function FunctionLayout({ children, params }: FunctionLayoutProps
             <div className="flex items-center gap-2">
               {/* Disable buttons that do not yet work */}
               <div className="flex items-center gap-2 pr-2">
-                <InvokeButton functionSlug={functionSlug} disabled={isArchived} />
+                <InvokeButton
+                  functionSlug={functionSlug}
+                  disabled={isArchived}
+                  hasEventTrigger={hasEventTrigger}
+                />
                 <PauseFunctionButton functionSlug={functionSlug} disabled={isArchived} />
                 <ArchiveFunctionButton functionSlug={functionSlug} />
               </div>


### PR DESCRIPTION
## Description
Only show the payload editor in the invoke modal when the function has an event trigger

## Motivation
Cron triggers don't have event payloads

## Testing
<img width="795" alt="image" src="https://github.com/inngest/inngest/assets/20100586/e3c49f6f-6e59-4208-ba26-cf4612613910">


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
