### PR TITLE
fix(dashboard): cache isn't invalidated when switching organizations

### DIFF
--- a/ui/apps/dashboard/src/app/(auth)/create-organization/[[...create-organization]]/page.tsx
+++ b/ui/apps/dashboard/src/app/(auth)/create-organization/[[...create-organization]]/page.tsx
@@ -1,8 +1,13 @@
+import { revalidatePath } from 'next/cache';
 import { CreateOrganization } from '@clerk/nextjs';
 
 import SplitView from '@/app/(auth)/SplitView';
 
 export default function CreateOrganizationPage() {
+  // We run revalidatePath to clear Next.js cache so that the user doesn't get stale data from a
+  // previous organization if they switch organizations.
+  revalidatePath('/', 'layout');
+
   return (
     <SplitView>
       <div className="mx-auto my-auto text-center">

--- a/ui/apps/dashboard/src/app/(auth)/organization-list/[[...organization-list]]/page.tsx
+++ b/ui/apps/dashboard/src/app/(auth)/organization-list/[[...organization-list]]/page.tsx
@@ -1,3 +1,4 @@
+import { revalidatePath } from 'next/cache';
 import { OrganizationList } from '@clerk/nextjs';
 
 import SplitView from '@/app/(auth)/SplitView';
@@ -7,6 +8,10 @@ type OrganizationListPageProps = {
 };
 
 export default async function OrganizationListPage({ searchParams }: OrganizationListPageProps) {
+  // We run revalidatePath to clear Next.js cache so that the user doesn't get stale data from a
+  // previous organization if they switch organizations.
+  revalidatePath('/', 'layout');
+
   const redirectURL =
     typeof searchParams.redirect_url === 'string'
       ? searchParams.redirect_url


### PR DESCRIPTION
## Description

This fixes a bug where the Next.js cache wouldn't be cleared when the user would switch organizations.

## Motivation
See linked issue

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
