### PR TITLE
INN 2832 make timeline header more responsive

### DIFF
--- a/ui/packages/components/src/Badge/Badge.tsx
+++ b/ui/packages/components/src/Badge/Badge.tsx
@@ -15,7 +15,7 @@ export function Badge({
   className?: string;
   kind?: 'outlined' | 'error' | 'solid';
 }) {
-  const classNames = `text-xs leading-3 border rounded-md box-border py-1.5 px-2 flex items-center gap-1 w-fit ${kindStyles[kind]} ${className}`;
+  const classNames = `text-xs leading-3 border rounded-full box-border py-1.5 px-3 flex items-center gap-1 w-fit ${kindStyles[kind]} ${className}`;
 
   return (
     <span className={classNames}>

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeHeader/TimelineNodeHeader.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeHeader/TimelineNodeHeader.tsx
@@ -12,8 +12,8 @@ type Props = {
 
 export function TimelineNodeHeader({ icon, badge, title, metadata }: Props) {
   return (
-    <div className="flex items-start justify-between text-sm leading-8 text-slate-100">
-      <div className="mr-2 flex flex-1 items-start gap-2">
+    <div className="text-sm">
+      <div className="mr-2 flex flex-1 items-start gap-2 leading-8 text-slate-100">
         <div className="flex h-8 items-center gap-2">
           {icon}
           {badge && (
@@ -24,10 +24,10 @@ export function TimelineNodeHeader({ icon, badge, title, metadata }: Props) {
         </div>
         <p className="align-top leading-8">{title}</p>
       </div>
-      <div className="flex items-center gap-2 leading-8">
-        <p>{metadata?.label}</p>
-        <p>{metadata?.value}</p>
-      </div>
+      <dl className="ml-8 leading-8 text-slate-400">
+        <dt className="inline break-all pr-1">{metadata?.label}</dt>
+        <dd className="inline break-all">{metadata?.value}</dd>
+      </dl>
     </div>
   );
 }

--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeRenderer.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeRenderer.tsx
@@ -52,7 +52,7 @@ function getIconsForAttempts({
 
   return (
     <span className="flex items-center">
-      {firstAttempt && <span className="z-0">{getIconForStatus(firstAttempt)}</span>}
+      {firstAttempt && <span className="z-0 -ml-1">{getIconForStatus(firstAttempt)}</span>}
       <span className="bg-slate-940 z-10 -ml-[1.2rem] h-[1.2rem] w-[1.2rem] rounded-full" />
       <span className="z-20 -ml-5">{icon}</span>
     </span>


### PR DESCRIPTION
## Description
- Change Badge border to make it look less like a button (using John's suggestion)
- Make timeline metadata semantically better. Change its position so it's more responsive
<img width="1314" alt="Screenshot 2024-02-23 at 19 38 10" src="https://github.com/inngest/inngest/assets/16758464/c8eeee72-f86f-4a5d-9daa-239c7dd6b099">
<img width="547" alt="Screenshot 2024-02-23 at 19 27 02" src="https://github.com/inngest/inngest/assets/16758464/84bf4781-de12-4a86-ab59-efad433e3b6e">

## Motivation
Timeline items looked terrible for folks with longer function/ step names

## Type of change (choose one)
- [X] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
