### PR TITLE
Add queued status to Dev Server

### DIFF
--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -1582,6 +1582,7 @@ enum FunctionRunStatus {
   FAILED
   CANCELLED
   RUNNING
+  QUEUED
 }
 
 enum FunctionEventType {

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -131,6 +131,7 @@ enum FunctionRunStatus {
   FAILED
   CANCELLED
   RUNNING
+  QUEUED
 }
 
 enum FunctionEventType {

--- a/pkg/coreapi/graph/models/converters.go
+++ b/pkg/coreapi/graph/models/converters.go
@@ -1,7 +1,10 @@
 package models
 
 import (
+	"fmt"
+
 	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/enums"
 )
 
 func MakeFunction(f *cqrs.Function) (*Function, error) {
@@ -62,4 +65,21 @@ func MakeFunctionRun(f *cqrs.FunctionRun) *FunctionRun {
 		r.Output = &str
 	}
 	return r
+}
+
+func ToFunctionRunStatus(s enums.RunStatus) (FunctionRunStatus, error) {
+	switch s {
+	case enums.RunStatusRunning:
+		return FunctionRunStatusRunning, nil
+	case enums.RunStatusCompleted:
+		return FunctionRunStatusCompleted, nil
+	case enums.RunStatusFailed:
+		return FunctionRunStatusFailed, nil
+	case enums.RunStatusCancelled:
+		return FunctionRunStatusCancelled, nil
+	case enums.RunStatusScheduled:
+		return FunctionRunStatusQueued, nil
+	default:
+		return FunctionRunStatusRunning, fmt.Errorf("unknown run status: %d", s)
+	}
 }

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -253,6 +253,7 @@ const (
 	FunctionRunStatusFailed    FunctionRunStatus = "FAILED"
 	FunctionRunStatusCancelled FunctionRunStatus = "CANCELLED"
 	FunctionRunStatusRunning   FunctionRunStatus = "RUNNING"
+	FunctionRunStatusQueued    FunctionRunStatus = "QUEUED"
 )
 
 var AllFunctionRunStatus = []FunctionRunStatus{
@@ -260,11 +261,12 @@ var AllFunctionRunStatus = []FunctionRunStatus{
 	FunctionRunStatusFailed,
 	FunctionRunStatusCancelled,
 	FunctionRunStatusRunning,
+	FunctionRunStatusQueued,
 }
 
 func (e FunctionRunStatus) IsValid() bool {
 	switch e {
-	case FunctionRunStatusCompleted, FunctionRunStatusFailed, FunctionRunStatusCancelled, FunctionRunStatusRunning:
+	case FunctionRunStatusCompleted, FunctionRunStatusFailed, FunctionRunStatusCancelled, FunctionRunStatusRunning, FunctionRunStatusQueued:
 		return true
 	}
 	return false

--- a/pkg/coreapi/graph/resolvers/function_run.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run.resolver.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
-	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/history_reader"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/oklog/ulid/v2"
@@ -21,16 +20,9 @@ func (r *functionRunResolver) Status(ctx context.Context, obj *models.FunctionRu
 	if err != nil {
 		return nil, fmt.Errorf("Run ID not found: %w", err)
 	}
-	status := models.FunctionRunStatusRunning
-	switch md.Status {
-	case enums.RunStatusCompleted:
-		status = models.FunctionRunStatusCompleted
-	case enums.RunStatusFailed:
-		status = models.FunctionRunStatusFailed
-	case enums.RunStatusCancelled:
-		status = models.FunctionRunStatusCancelled
-	}
-	return &status, nil
+
+	status, err := models.ToFunctionRunStatus(md.Status)
+	return &status, err
 }
 
 func (r *functionRunResolver) PendingSteps(ctx context.Context, obj *models.FunctionRun) (*int, error) {

--- a/pkg/coreapi/graph/resolvers/functions.go
+++ b/pkg/coreapi/graph/resolvers/functions.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
-	"github.com/inngest/inngest/pkg/enums"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -40,16 +39,10 @@ func (r *queryResolver) FunctionRun(ctx context.Context, query models.FunctionRu
 		return nil, fmt.Errorf("Run ID not found: %w", err)
 	}
 
-	status := models.FunctionRunStatusRunning
-
 	m := state.Metadata()
-	switch m.Status {
-	case enums.RunStatusCompleted:
-		status = models.FunctionRunStatusCompleted
-	case enums.RunStatusFailed:
-		status = models.FunctionRunStatusFailed
-	case enums.RunStatusCancelled:
-		status = models.FunctionRunStatusCancelled
+	status, err := models.ToFunctionRunStatus(m.Status)
+	if err != nil {
+		return nil, err
 	}
 
 	name := state.Function().Name
@@ -88,15 +81,9 @@ func (r *queryResolver) FunctionRuns(ctx context.Context, query models.FunctionR
 
 	for _, s := range state {
 		m := s.Metadata()
-		status := models.FunctionRunStatusRunning
-
-		switch m.Status {
-		case enums.RunStatusCompleted:
-			status = models.FunctionRunStatusCompleted
-		case enums.RunStatusFailed:
-			status = models.FunctionRunStatusFailed
-		case enums.RunStatusCancelled:
-			status = models.FunctionRunStatusCancelled
+		status, err := models.ToFunctionRunStatus(m.Status)
+		if err != nil {
+			return nil, err
 		}
 
 		startedAt := ulid.Time(m.Identifier.RunID.Time())

--- a/pkg/execution/state/redis_state/lua/cancel.lua
+++ b/pkg/execution/state/redis_state/lua/cancel.lua
@@ -11,7 +11,9 @@ Output:
 local metadataKey = KEYS[1]
 
 local value = tonumber(redis.call("HGET", metadataKey, "status"))
-if value ~= 0 then
+
+-- If run has ended (completed, failed, etc.)
+if value ~= 0 and value ~= 5 then
 	-- Return the function status as an error
 	return value;
 end

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -264,6 +264,7 @@ func (m mgr) New(ctx context.Context, input state.Input) (state.State, error) {
 		Version:        currentVersion,
 		RequestVersion: consts.RequestVersionUnknown, // Always use -1 to indicate unset hash version until first request.
 		Context:        input.Context,
+		Status:         enums.RunStatusScheduled,
 	}
 	if input.RunType != nil {
 		metadata.RunType = *input.RunType

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -181,7 +181,7 @@ func checkNew(t *testing.T, m state.Manager) {
 	require.EqualValues(t, w, found, "Returned workflow does not match input")
 	require.EqualValues(t, evt, s.Event(), "Returned event does not match input")
 	require.EqualValues(t, batch, s.Events(), "Returned events does not match input")
-	require.EqualValues(t, enums.RunStatusRunning, s.Metadata().Status, "Status is not Running")
+	require.EqualValues(t, enums.RunStatusScheduled, s.Metadata().Status, "Status is not Scheduled")
 	require.EqualValues(t, init.Context, s.Metadata().Context, "Metadata context not saved")
 	require.EqualValues(t, id, s.Metadata().Identifier, "Metadata didn't save Identifier")
 
@@ -1553,7 +1553,7 @@ func checkSetStatus(t *testing.T, m state.Manager) {
 
 	s, err := m.New(ctx, init)
 	require.NoError(t, err)
-	require.EqualValues(t, enums.RunStatusRunning, s.Metadata().Status, "Status is not Running")
+	require.EqualValues(t, enums.RunStatusScheduled, s.Metadata().Status, "Status is not Scheduled")
 
 	// Add time so that the history ticks a millisecond
 	<-time.After(time.Millisecond)
@@ -1582,7 +1582,7 @@ func checkCancel(t *testing.T, m state.Manager) {
 
 	s, err := m.New(ctx, init)
 	require.NoError(t, err)
-	require.EqualValues(t, enums.RunStatusRunning, s.Metadata().Status, "Status is not Running")
+	require.EqualValues(t, enums.RunStatusScheduled, s.Metadata().Status, "Status is not Scheduled")
 
 	// Add time so that the history ticks a millisecond
 	<-time.After(time.Millisecond)
@@ -1610,7 +1610,7 @@ func checkCancel_cancelled(t *testing.T, m state.Manager) {
 
 	s, err := m.New(ctx, init)
 	require.NoError(t, err)
-	require.EqualValues(t, enums.RunStatusRunning, s.Metadata().Status, "Status is not Running")
+	require.EqualValues(t, enums.RunStatusScheduled, s.Metadata().Status, "Status is not Scheduled")
 
 	// Add time so that the history ticks a millisecond
 	<-time.After(time.Millisecond)
@@ -1640,7 +1640,7 @@ func checkCancel_completed(t *testing.T, m state.Manager) {
 
 	s, err := m.New(ctx, init)
 	require.NoError(t, err)
-	require.EqualValues(t, enums.RunStatusRunning, s.Metadata().Status, "Status is not Running")
+	require.EqualValues(t, enums.RunStatusScheduled, s.Metadata().Status, "Status is not Scheduled")
 
 	// Add time so that the history ticks a millisecond
 	<-time.After(time.Millisecond)

--- a/ui/apps/dev-server-ui/src/store/generated.ts
+++ b/ui/apps/dev-server-ui/src/store/generated.ts
@@ -148,6 +148,7 @@ export enum FunctionRunStatus {
   Cancelled = 'CANCELLED',
   Completed = 'COMPLETED',
   Failed = 'FAILED',
+  Queued = 'QUEUED',
   Running = 'RUNNING'
 }
 


### PR DESCRIPTION
## Description
- When creating the `runMetadata` object, set `Status: enums.RunStatusScheduled` instead of letting it default to `enums.RunStatusRunning`
- Create `ToFunctionRunStatus` to avoid converting between status enums in multiple places
- Update the history writer, though that isn't actually necessary to add the queued status to our GraphQL API

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
