### PR TITLE
fix(dashboard): hover state outline on org and user dropdown

### DIFF
--- a/ui/apps/dashboard/src/components/Navigation/OrganizationDropdown.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/OrganizationDropdown.tsx
@@ -106,7 +106,7 @@ function OrganizationDropdownMenuItem(props: {
   return (
     <DropdownMenuItem
       asChild
-      className="p-2 font-medium text-slate-400 hover:bg-transparent hover:text-white"
+      className="p-2 font-medium text-slate-400 outline-none hover:bg-transparent focus:text-white"
     >
       <Link href={props.href as Route}>
         <props.icon className="size-4" />

--- a/ui/apps/dashboard/src/components/Navigation/UserDropdown.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/UserDropdown.tsx
@@ -114,7 +114,7 @@ function OrganizationDropdownMenuItem(props: {
     <DropdownMenuItem
       onSelect={props.onSelect}
       asChild
-      className="p-2 font-medium text-slate-400 hover:bg-transparent hover:text-white"
+      className="p-2 font-medium text-slate-400 outline-none hover:bg-transparent focus:text-white"
     >
       {props.href ? (
         <Link href={props.href as Route}>


### PR DESCRIPTION
## Description

This fixes an issue with the OrganizationDropdown and UserDropdown components, where each menu item would show an undesirable outline when hovered:

![CleanShot 2024-02-25 at 15 48 10@2x](https://github.com/inngest/inngest/assets/4291707/907e013f-2083-4d68-b2e6-da7a00fd8272)

[Radix Dropdown merges the `hover` and `focus` (and `focus-visible`) states into one by design.](https://github.com/radix-ui/primitives/issues/956#issuecomment-961819460). We need then to style the focus state to properly handle this behavior.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
