### PR TITLE
Update debounce buffer timing and logging

### DIFF
--- a/pkg/execution/debounce/lua/updateDebounce.lua
+++ b/pkg/execution/debounce/lua/updateDebounce.lua
@@ -6,6 +6,7 @@ Return values:
 - >=0 (int): OK, and the new TTL from our debounce.
 - -1: Debounce is already in progress, as the queue item is leased.
 - -2: Event is out of order and has no effect
+- -3: Debounce queue item is not found.
 
 ]]--
 
@@ -37,8 +38,9 @@ end
 local item = get_queue_item(keyQueueHash, queueJobID)
 if item == nil then
 	-- The queue item was not found.  Return a new debounce.
-	return -1
+	return -3
 end
+
 if item.leaseID ~= nil and item.leaseID ~= cjson.null and decode_ulid_time(item.leaseID) > currentTime then
 	-- The debounce queue item is leased. 
 	return -1

--- a/pkg/execution/history/lifecycle.go
+++ b/pkg/execution/history/lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/oklog/ulid/v2"
-	"golang.org/x/exp/slog"
 )
 
 func NewLifecycleListener(l *slog.Logger, d ...Driver) execution.LifecycleListener {

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -977,7 +977,7 @@ func (q *queue) RequeueByJobID(ctx context.Context, partitionName string, jobID 
 		},
 	).AsInt64()
 	if err != nil {
-		return fmt.Errorf("error leasing queue item: %w", err)
+		return fmt.Errorf("error requeueing item: %w", err)
 	}
 	switch status {
 	case 0:

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -859,10 +859,6 @@ ProcessLoop:
 			continue
 		case ErrQueueItemAlreadyLeased:
 			q.scope.Counter(counterQueueItemsLeaseConflict).Inc(1)
-			q.logger.
-				Warn().
-				Interface("item", item).
-				Msg("worker attempting to claim existing lease")
 			// This is an okay error.  Move to the next job item.
 			processErr = nil
 			continue

--- a/tests/golang/golang_sdk_util.go
+++ b/tests/golang/golang_sdk_util.go
@@ -2,6 +2,7 @@ package golang
 
 import (
 	"fmt"
+	"log/slog"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -11,7 +12,6 @@ import (
 
 	"github.com/inngest/inngestgo"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slog"
 )
 
 const DEV_URL = "http://127.0.0.1:8288"

--- a/vendor/github.com/inngest/inngestgo/handler.go
+++ b/vendor/github.com/inngest/inngestgo/handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -21,7 +22,6 @@ import (
 	"github.com/inngest/inngestgo/errors"
 	"github.com/inngest/inngestgo/internal/sdkrequest"
 	"github.com/inngest/inngestgo/step"
-	"golang.org/x/exp/slog"
 )
 
 var (


### PR DESCRIPTION
This PR updates debounce buffer timing and queue logging to improve performance/latency, and improve timing when sending events during an active debounce.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
