### PR TITLE
Default protocol to http in Dev Server

### DIFF
--- a/pkg/coreapi/graph/resolvers/app_mutations.go
+++ b/pkg/coreapi/graph/resolvers/app_mutations.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -13,6 +14,12 @@ import (
 )
 
 func (r *mutationResolver) CreateApp(ctx context.Context, input models.CreateAppInput) (*cqrs.App, error) {
+	// URLs must contain a protocol. If not, add http since very few apps use
+	// https during development
+	if !strings.Contains(input.URL, "://") {
+		input.URL = "http://" + input.URL
+	}
+
 	// If we already have the app, return it.
 	if app, err := r.Data.GetAppByURL(ctx, input.URL); err == nil && app != nil {
 		return app, nil

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -194,6 +195,12 @@ func (d *devserver) runDiscovery(ctx context.Context) {
 func (d *devserver) pollSDKs(ctx context.Context) {
 	// Initially, add every app started with the `-u` flag
 	for _, url := range d.opts.URLs {
+		// URLs must contain a protocol. If not, add http since very few apps
+		// use https during development
+		if !strings.Contains(url, "://") {
+			url = "http://" + url
+		}
+
 		// Create a new app which holds the error message.
 		params := cqrs.InsertAppParams{
 			ID:  uuid.New(),


### PR DESCRIPTION
## Description
When the user gives an app URL to the Dev Server (via UI or CLI option), set the protocol to `http` if it isn't set

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
