### PR TITLE
fix(dashboard): invite members form is skipped

### DIFF
--- a/ui/apps/dashboard/src/middleware.ts
+++ b/ui/apps/dashboard/src/middleware.ts
@@ -30,8 +30,8 @@ export default authMiddleware({
     if (
       isUserSetup &&
       !hasActiveOrganization &&
-      request.nextUrl.pathname !== '/organization-list' &&
-      request.nextUrl.pathname !== '/create-organization'
+      !request.nextUrl.pathname.startsWith('/create-organization') &&
+      !request.nextUrl.pathname.startsWith('/organization-list')
     ) {
       const organizationListURL = new URL('/organization-list', request.url);
       organizationListURL.searchParams.append('redirect_url', request.url);
@@ -42,7 +42,8 @@ export default authMiddleware({
       isUserSetup &&
       hasActiveOrganization &&
       !isOrganizationSetup &&
-      request.nextUrl.pathname !== '/create-organization/set-up'
+      !request.nextUrl.pathname.startsWith('/create-organization') &&
+      !request.nextUrl.pathname.startsWith('/organization-list')
     ) {
       return NextResponse.redirect(new URL('/create-organization/set-up', request.url));
     }


### PR DESCRIPTION
## Description

This fixes an issue where the "Invite members" form is skipped whenever the user creates a new organization. This happens because the page is refreshed when the user submits the previous "Create organization" form, which causes the user to be redirected to the organization setup page before they have time to fill in the "invite members" form.

This PR fixes that by not redirecting the user to the setup page when they are on a page that has the form.

![CleanShot 2024-02-27 at 11 59 06@2x](https://github.com/inngest/inngest/assets/4291707/ea25c61a-fc4d-4bc2-a9ba-88078ca42d07)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
