### PR TITLE
chore(dashboard): enable source maps in production

### DIFF
--- a/ui/apps/dashboard/next.config.js
+++ b/ui/apps/dashboard/next.config.js
@@ -3,6 +3,7 @@ const { withSentryConfig } = require('@sentry/nextjs');
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  productionBrowserSourceMaps: true,
   experimental: {
     typedRoutes: true,
   },


### PR DESCRIPTION
## Description

This enables source maps in production.

Since our app is already open source, it's safe to enable them.

## Motivation
[The Clerk team is helping us with debugging an issue that is only happening in production. Enabling source maps would allow them to trace the bug more easily.](https://inngest.slack.com/archives/C05CPPWHWHF/p1709054262141809?thread_ts=1708959081.201609&cid=C05CPPWHWHF)

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
