### PR TITLE
chore(dashboard): don't hide source maps in production

### DIFF
--- a/ui/apps/dashboard/next.config.js
+++ b/ui/apps/dashboard/next.config.js
@@ -75,13 +75,7 @@ const nextConfig = {
   // Optional build-time configuration for Sentry.
   // See https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#extend-nextjs-configuration
   sentry: {
-    // Use `hidden-source-map` rather than `source-map` as the Webpack `devtool`
-    // for client-side builds. (This will be the default starting in
-    // `@sentry/nextjs` version 8.0.0.) See
-    // https://webpack.js.org/configuration/devtool/ and
-    // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#use-hidden-source-map
-    // for more information.
-    hideSourceMaps: true,
+    hideSourceMaps: false,
     // Tunnel sentry events to help circumvent ad-blockers.
     tunnelRoute: '/api/sentry',
   },


### PR DESCRIPTION
## Description

Follow-up PR for https://github.com/inngest/inngest/pull/1194.

This makes sure Sentry doesn't hide source maps in production.

## Motivation
https://github.com/inngest/inngest/pull/1194 tried to enable source maps in production, but Sentry hid them anyway.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
