### PR TITLE
Adjust HorizontalPillList

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/FunctionList.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/FunctionList.tsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 import { type Route } from 'next';
 import { Link } from '@inngest/components/Link';
-import { Pill, PillContent } from '@inngest/components/Pill';
+import { HorizontalPillList, Pill, PillContent } from '@inngest/components/Pill';
 import { Table } from '@inngest/components/Table';
 import type { Function } from '@inngest/components/types/function';
 import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
@@ -69,8 +69,9 @@ function useColumns({ envSlug }: { envSlug: string }) {
       cell: (props) => {
         const triggers = props.getValue();
         return (
-          <div className="flex gap-1">
-            {triggers.map((trigger) => {
+          <HorizontalPillList
+            alwaysVisibleCount={2}
+            pills={triggers.map((trigger) => {
               return (
                 <Pill
                   href={
@@ -84,7 +85,7 @@ function useColumns({ envSlug }: { envSlug: string }) {
                 </Pill>
               );
             })}
-          </div>
+          />
         );
       },
       header: () => <span>Triggers</span>,

--- a/ui/packages/components/src/Pill/HorizontalPillList.tsx
+++ b/ui/packages/components/src/Pill/HorizontalPillList.tsx
@@ -1,4 +1,4 @@
-import * as Tooltip from '@radix-ui/react-tooltip';
+import { Tooltip, TooltipArrow, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';
 
 import { Pill } from './Pill';
 
@@ -15,27 +15,20 @@ export function HorizontalPillList({ pills, alwaysVisibleCount }: FunctionsCellC
     const alwaysVisiblePills = pills.slice(0, alwaysVisibleCount);
 
     return (
-      <>
+      <div className="flex items-center">
         {alwaysVisiblePills}
-        <Tooltip.Provider>
-          <Tooltip.Root delayDuration={0}>
-            <Tooltip.Trigger className="cursor-default">
-              <Pill className="bg-white px-2.5 align-middle text-slate-600">
-                +{hiddenPills.length}
-              </Pill>
-            </Tooltip.Trigger>
-            <Tooltip.Portal>
-              <Tooltip.Content
-                className="data-[state=delayed-open]:data-[side=top]:animate-slide-down-and-fade data-[state=delayed-open]:data-[side=right]:animate-slide-left-and-fade data-[state=delayed-open]:data-[side=left]:animate-slide-right-and-fade data-[state=delayed-open]:data-[side=bottom]:animate-slide-up-and-fade text-violet11 select-none rounded-[4px] bg-white px-[15px] py-[10px] text-[15px] leading-none shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity]"
-                sideOffset={5}
-              >
-                <div className="flex flex-col gap-2">{hiddenPills}</div>
-                <Tooltip.Arrow className="fill-white" />
-              </Tooltip.Content>
-            </Tooltip.Portal>
-          </Tooltip.Root>
-        </Tooltip.Provider>
-      </>
+
+        <Tooltip delayDuration={0}>
+          <TooltipTrigger className="cursor-default">
+            <Pill className="px-2.5 align-middle">+{hiddenPills.length}</Pill>
+          </TooltipTrigger>
+
+          <TooltipContent sideOffset={5} className="p-3">
+            <div className="flex flex-col gap-2">{hiddenPills}</div>
+            <TooltipArrow className="fill-white dark:fill-slate-800" />
+          </TooltipContent>
+        </Tooltip>
+      </div>
     );
   }
 

--- a/ui/packages/components/src/Tooltip/Tooltip.tsx
+++ b/ui/packages/components/src/Tooltip/Tooltip.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import * as TooltipPrimitive from '@radix-ui/react-tooltip';
 
-import { classNames } from '../utils/classNames';
+import { cn } from '../utils/classNames';
 
 const TooltipProvider = TooltipPrimitive.Provider;
 
@@ -18,14 +18,16 @@ const TooltipContent = React.forwardRef<
   <TooltipPrimitive.Content
     ref={ref}
     sideOffset={sideOffset}
-    className={classNames(
-      'animate-slide-down-fade shadow-floating z-50 max-w-xs rounded-md bg-white/95 px-2 py-1 text-sm text-slate-800 ring-1 ring-black/5 backdrop-blur-[3px] dark:bg-slate-400',
+    className={cn(
+      'animate-slide-down-fade z-50 max-w-xs rounded-md bg-white/95 px-2 py-1 text-sm text-slate-400 drop-shadow backdrop-blur-[3px] dark:bg-slate-800',
       className
     )}
     {...props}
   />
 ));
 
+const TooltipArrow = TooltipPrimitive.Arrow;
+
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider, TooltipArrow };

--- a/ui/packages/components/src/Tooltip/index.ts
+++ b/ui/packages/components/src/Tooltip/index.ts
@@ -1,1 +1,1 @@
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './Tooltip';
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider, TooltipArrow } from './Tooltip';


### PR DESCRIPTION
## Description
- Wrap `<Pills>`in the `<HorizontalPillList>` in function table 
- Use shared tooltip in `<HorizontalPillList>` and adjust the styles
<img width="1512" alt="Screenshot 2024-02-28 at 22 26 42" src="https://github.com/inngest/inngest/assets/16758464/678836c9-7444-4431-83bc-0e6d559a6b64">
<img width="1512" alt="Screenshot 2024-02-28 at 22 23 13" src="https://github.com/inngest/inngest/assets/16758464/012e37f4-bdc1-4de7-bdd0-cd12285ce983">

## Motivation
Note: John designed a new way of displaying multiple pills that doesn't involve a tooltip. However, since it affects the table rows alignment and our tables are not using the same components/styles, we'll only implement it as part of the events table project.

## Type of change (choose one)
- [X] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
