### PR TITLE
Fix UI crash when event ID is custom

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.21.0
 	gocloud.dev v0.25.0
 	gocloud.dev/pubsub/natspubsub v0.25.0
-	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 	golang.org/x/mod v0.12.0
 	golang.org/x/sync v0.6.0
 	golang.org/x/term v0.15.0
@@ -174,6 +173,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/pkg/coreapi/coreapi.go
+++ b/pkg/coreapi/coreapi.go
@@ -183,13 +183,22 @@ func (a CoreAPI) EventRuns(w http.ResponseWriter, r *http.Request) {
 	// NOTE: In development this does no authentication.  This must check API keys
 	// in self-hosted and production environments.
 	ctx := r.Context()
-	eventID := chi.URLParam(r, "eventID")
-	if eventID == "" {
+	eventIDStr := chi.URLParam(r, "eventID")
+	if eventIDStr == "" {
 		_ = publicerr.WriteHTTP(w, publicerr.Error{
 			Status:  400,
 			Message: "No event ID found",
 		})
 		return
+	}
+
+	eventID, err := ulid.Parse(eventIDStr)
+	if err != nil {
+		_ = publicerr.WriteHTTP(w, publicerr.Error{
+			Status:  400,
+			Message: "Event ID is not a valid ULID",
+			Err:     err,
+		})
 	}
 
 	runs, err := a.tracker.Runs(ctx, eventID)

--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -150,13 +150,11 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Apps         func(childComplexity int) int
-		Event        func(childComplexity int, query models.EventQuery) int
-		Events       func(childComplexity int, query models.EventsQuery) int
-		FunctionRun  func(childComplexity int, query models.FunctionRunQuery) int
-		FunctionRuns func(childComplexity int, query models.FunctionRunsQuery) int
-		Functions    func(childComplexity int) int
-		Stream       func(childComplexity int, query models.StreamQuery) int
+		Apps        func(childComplexity int) int
+		Event       func(childComplexity int, query models.EventQuery) int
+		FunctionRun func(childComplexity int, query models.FunctionRunQuery) int
+		Functions   func(childComplexity int) int
+		Stream      func(childComplexity int, query models.StreamQuery) int
 	}
 
 	RunHistoryCancel struct {
@@ -268,7 +266,7 @@ type EventResolver interface {
 	Status(ctx context.Context, obj *models.Event) (*models.EventStatus, error)
 	PendingRuns(ctx context.Context, obj *models.Event) (*int, error)
 	TotalRuns(ctx context.Context, obj *models.Event) (*int, error)
-	Raw(ctx context.Context, obj *models.Event) (*string, error)
+
 	FunctionRuns(ctx context.Context, obj *models.Event) ([]*models.FunctionRun, error)
 }
 type FunctionResolver interface {
@@ -300,10 +298,8 @@ type QueryResolver interface {
 	Apps(ctx context.Context) ([]*cqrs.App, error)
 	Stream(ctx context.Context, query models.StreamQuery) ([]*models.StreamItem, error)
 	Event(ctx context.Context, query models.EventQuery) (*models.Event, error)
-	Events(ctx context.Context, query models.EventsQuery) ([]*models.Event, error)
 	Functions(ctx context.Context) ([]*models.Function, error)
 	FunctionRun(ctx context.Context, query models.FunctionRunQuery) (*models.FunctionRun, error)
-	FunctionRuns(ctx context.Context, query models.FunctionRunsQuery) ([]*models.FunctionRun, error)
 }
 type StreamItemResolver interface {
 	InBatch(ctx context.Context, obj *models.StreamItem) (bool, error)
@@ -844,18 +840,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Event(childComplexity, args["query"].(models.EventQuery)), true
 
-	case "Query.events":
-		if e.complexity.Query.Events == nil {
-			break
-		}
-
-		args, err := ec.field_Query_events_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.Events(childComplexity, args["query"].(models.EventsQuery)), true
-
 	case "Query.functionRun":
 		if e.complexity.Query.FunctionRun == nil {
 			break
@@ -867,18 +851,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Query.FunctionRun(childComplexity, args["query"].(models.FunctionRunQuery)), true
-
-	case "Query.functionRuns":
-		if e.complexity.Query.FunctionRuns == nil {
-			break
-		}
-
-		args, err := ec.field_Query_functionRuns_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Query.FunctionRuns(childComplexity, args["query"].(models.FunctionRunsQuery)), true
 
 	case "Query.functions":
 		if e.complexity.Query.Functions == nil {
@@ -1398,17 +1370,11 @@ input UpdateAppInput {
   # Get an individual event
   event(query: EventQuery!): Event
 
-  # Get all events sent
-  events(query: EventsQuery!): [Event!]
-
   # Get all functions registered
   functions: [Function!]
 
   # Get an individual function run
   functionRun(query: FunctionRunQuery!): FunctionRun
-
-  # Get all function runs
-  functionRuns(query: FunctionRunsQuery!): [FunctionRun!]
 }
 
 input ActionVersionQuery {
@@ -1490,7 +1456,7 @@ type FunctionVersion {
 }
 
 type Event {
-  id: ID!
+  id: ULID!
   workspace: Workspace
   name: String
   createdAt: Time
@@ -1852,21 +1818,6 @@ func (ec *executionContext) field_Query_event_args(ctx context.Context, rawArgs 
 	return args, nil
 }
 
-func (ec *executionContext) field_Query_events_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 models.EventsQuery
-	if tmp, ok := rawArgs["query"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
-		arg0, err = ec.unmarshalNEventsQuery2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐEventsQuery(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["query"] = arg0
-	return args, nil
-}
-
 func (ec *executionContext) field_Query_functionRun_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
@@ -1874,21 +1825,6 @@ func (ec *executionContext) field_Query_functionRun_args(ctx context.Context, ra
 	if tmp, ok := rawArgs["query"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
 		arg0, err = ec.unmarshalNFunctionRunQuery2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionRunQuery(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["query"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_Query_functionRuns_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 models.FunctionRunsQuery
-	if tmp, ok := rawArgs["query"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
-		arg0, err = ec.unmarshalNFunctionRunsQuery2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionRunsQuery(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -2512,9 +2448,9 @@ func (ec *executionContext) _Event_id(ctx context.Context, field graphql.Collect
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(ulid.ULID)
 	fc.Result = res
-	return ec.marshalNID2string(ctx, field.Selections, res)
+	return ec.marshalNULID2githubᚗcomᚋoklogᚋulidᚋv2ᚐULID(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Event_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -2524,7 +2460,7 @@ func (ec *executionContext) fieldContext_Event_id(ctx context.Context, field gra
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type ID does not have child fields")
+			return nil, errors.New("field of type ULID does not have child fields")
 		},
 	}
 	return fc, nil
@@ -2876,7 +2812,7 @@ func (ec *executionContext) _Event_raw(ctx context.Context, field graphql.Collec
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Event().Raw(rctx, obj)
+		return obj.Raw, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -2894,8 +2830,8 @@ func (ec *executionContext) fieldContext_Event_raw(ctx context.Context, field gr
 	fc = &graphql.FieldContext{
 		Object:     "Event",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
@@ -5409,82 +5345,6 @@ func (ec *executionContext) fieldContext_Query_event(ctx context.Context, field 
 	return fc, nil
 }
 
-func (ec *executionContext) _Query_events(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_events(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().Events(rctx, fc.Args["query"].(models.EventsQuery))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.([]*models.Event)
-	fc.Result = res
-	return ec.marshalOEvent2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐEventᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_events(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_Event_id(ctx, field)
-			case "workspace":
-				return ec.fieldContext_Event_workspace(ctx, field)
-			case "name":
-				return ec.fieldContext_Event_name(ctx, field)
-			case "createdAt":
-				return ec.fieldContext_Event_createdAt(ctx, field)
-			case "payload":
-				return ec.fieldContext_Event_payload(ctx, field)
-			case "schema":
-				return ec.fieldContext_Event_schema(ctx, field)
-			case "status":
-				return ec.fieldContext_Event_status(ctx, field)
-			case "pendingRuns":
-				return ec.fieldContext_Event_pendingRuns(ctx, field)
-			case "totalRuns":
-				return ec.fieldContext_Event_totalRuns(ctx, field)
-			case "raw":
-				return ec.fieldContext_Event_raw(ctx, field)
-			case "functionRuns":
-				return ec.fieldContext_Event_functionRuns(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type Event", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_events_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Query_functions(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_functions(ctx, field)
 	if err != nil {
@@ -5630,96 +5490,6 @@ func (ec *executionContext) fieldContext_Query_functionRun(ctx context.Context, 
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_functionRun_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Query_functionRuns(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Query_functionRuns(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().FunctionRuns(rctx, fc.Args["query"].(models.FunctionRunsQuery))
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.([]*models.FunctionRun)
-	fc.Result = res
-	return ec.marshalOFunctionRun2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionRunᚄ(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Query_functionRuns(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Query",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			switch field.Name {
-			case "id":
-				return ec.fieldContext_FunctionRun_id(ctx, field)
-			case "functionID":
-				return ec.fieldContext_FunctionRun_functionID(ctx, field)
-			case "function":
-				return ec.fieldContext_FunctionRun_function(ctx, field)
-			case "workspace":
-				return ec.fieldContext_FunctionRun_workspace(ctx, field)
-			case "event":
-				return ec.fieldContext_FunctionRun_event(ctx, field)
-			case "events":
-				return ec.fieldContext_FunctionRun_events(ctx, field)
-			case "batchID":
-				return ec.fieldContext_FunctionRun_batchID(ctx, field)
-			case "batchCreatedAt":
-				return ec.fieldContext_FunctionRun_batchCreatedAt(ctx, field)
-			case "status":
-				return ec.fieldContext_FunctionRun_status(ctx, field)
-			case "waitingFor":
-				return ec.fieldContext_FunctionRun_waitingFor(ctx, field)
-			case "pendingSteps":
-				return ec.fieldContext_FunctionRun_pendingSteps(ctx, field)
-			case "startedAt":
-				return ec.fieldContext_FunctionRun_startedAt(ctx, field)
-			case "finishedAt":
-				return ec.fieldContext_FunctionRun_finishedAt(ctx, field)
-			case "output":
-				return ec.fieldContext_FunctionRun_output(ctx, field)
-			case "history":
-				return ec.fieldContext_FunctionRun_history(ctx, field)
-			case "historyItemOutput":
-				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
-			case "name":
-				return ec.fieldContext_FunctionRun_name(ctx, field)
-			case "eventID":
-				return ec.fieldContext_FunctionRun_eventID(ctx, field)
-			}
-			return nil, fmt.Errorf("no field named %q was found under type FunctionRun", field.Name)
-		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Query_functionRuns_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -10808,22 +10578,9 @@ func (ec *executionContext) _Event(ctx context.Context, sel ast.SelectionSet, ob
 
 			})
 		case "raw":
-			field := field
 
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Event_raw(ctx, field, obj)
-				return res
-			}
+			out.Values[i] = ec._Event_raw(ctx, field, obj)
 
-			out.Concurrently(i, func() graphql.Marshaler {
-				return innerFunc(ctx)
-
-			})
 		case "functionRuns":
 			field := field
 
@@ -11501,26 +11258,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
-		case "events":
-			field := field
-
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_events(ctx, field)
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
-			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return rrm(innerCtx)
-			})
 		case "functions":
 			field := field
 
@@ -11551,26 +11288,6 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_functionRun(ctx, field)
-				return res
-			}
-
-			rrm := func(ctx context.Context) graphql.Marshaler {
-				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
-			}
-
-			out.Concurrently(i, func() graphql.Marshaler {
-				return rrm(innerCtx)
-			})
-		case "functionRuns":
-			field := field
-
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Query_functionRuns(ctx, field)
 				return res
 			}
 
@@ -12627,11 +12344,6 @@ func (ec *executionContext) unmarshalNEventQuery2githubᚗcomᚋinngestᚋinnges
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalNEventsQuery2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐEventsQuery(ctx context.Context, v interface{}) (models.EventsQuery, error) {
-	res, err := ec.unmarshalInputEventsQuery(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
 func (ec *executionContext) marshalNFunction2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.Function) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
@@ -12698,11 +12410,6 @@ func (ec *executionContext) marshalNFunctionRun2ᚖgithubᚗcomᚋinngestᚋinng
 
 func (ec *executionContext) unmarshalNFunctionRunQuery2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionRunQuery(ctx context.Context, v interface{}) (models.FunctionRunQuery, error) {
 	res, err := ec.unmarshalInputFunctionRunQuery(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) unmarshalNFunctionRunsQuery2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionRunsQuery(ctx context.Context, v interface{}) (models.FunctionRunsQuery, error) {
-	res, err := ec.unmarshalInputFunctionRunsQuery(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
@@ -13246,53 +12953,6 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	}
 	res := graphql.MarshalBoolean(*v)
 	return res
-}
-
-func (ec *executionContext) marshalOEvent2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐEventᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.Event) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNEvent2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐEvent(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) marshalOEvent2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐEvent(ctx context.Context, sel ast.SelectionSet, v *models.Event) graphql.Marshaler {

--- a/pkg/coreapi/gql.query.graphql
+++ b/pkg/coreapi/gql.query.graphql
@@ -6,17 +6,11 @@ type Query {
   # Get an individual event
   event(query: EventQuery!): Event
 
-  # Get all events sent
-  events(query: EventsQuery!): [Event!]
-
   # Get all functions registered
   functions: [Function!]
 
   # Get an individual function run
   functionRun(query: FunctionRunQuery!): FunctionRun
-
-  # Get all function runs
-  functionRuns(query: FunctionRunsQuery!): [FunctionRun!]
 }
 
 input ActionVersionQuery {

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -39,7 +39,7 @@ type FunctionVersion {
 }
 
 type Event {
-  id: ID!
+  id: ULID!
   workspace: Workspace
   name: String
   createdAt: Time

--- a/pkg/coreapi/gqlgen.yml
+++ b/pkg/coreapi/gqlgen.yml
@@ -40,8 +40,6 @@ models:
         resolver: true
       status:
         resolver: true
-      raw:
-        resolver: true
   Function:
     fields:
       app:

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -28,7 +28,7 @@ type CreateAppInput struct {
 }
 
 type Event struct {
-	ID           string         `json:"id"`
+	ID           ulid.ULID      `json:"id"`
 	Workspace    *Workspace     `json:"workspace,omitempty"`
 	Name         *string        `json:"name,omitempty"`
 	CreatedAt    *time.Time     `json:"createdAt,omitempty"`

--- a/pkg/coreapi/graph/resolvers/event.resolver.go
+++ b/pkg/coreapi/graph/resolvers/event.resolver.go
@@ -15,12 +15,7 @@ func (r *eventResolver) FunctionRuns(ctx context.Context, obj *models.Event) ([]
 	accountID := uuid.UUID{}
 	workspaceID := uuid.UUID{}
 
-	eventID, err := ulid.Parse(obj.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	runs, err := r.Data.GetFunctionRunsFromEvents(ctx, accountID, workspaceID, []ulid.ULID{eventID})
+	runs, err := r.Data.GetFunctionRunsFromEvents(ctx, accountID, workspaceID, []ulid.ULID{obj.ID})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/coreapi/graph/resolvers/events.go
+++ b/pkg/coreapi/graph/resolvers/events.go
@@ -3,7 +3,6 @@ package resolvers
 import (
 	"context"
 	"encoding/json"
-	"sort"
 	"time"
 
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
@@ -30,51 +29,10 @@ func (r *queryResolver) Event(ctx context.Context, query models.EventQuery) (*mo
 	}
 
 	return &models.Event{
-		ID:        evt.EventID,
+		ID:        evt.InternalID(),
 		Name:      &evt.EventName,
 		CreatedAt: &createdAt,
 		Payload:   &payload,
+		Raw:       &payload,
 	}, nil
-}
-
-// TODO Use a dataloader to retrieve events and fetch individual fields in
-// individual resolvers; we shouldn't be mapping any of the fields in this
-// query.
-func (r *queryResolver) Events(ctx context.Context, query models.EventsQuery) ([]*models.Event, error) {
-	evts, err := r.Runner.Events(ctx, "")
-	if err != nil {
-		return nil, err
-	}
-
-	var events []*models.Event
-
-	for _, evt := range evts {
-		name := evt.Name
-
-		createdAt := time.UnixMilli(evt.Timestamp)
-		if evt.Timestamp == 0 {
-			if id, err := ulid.Parse(evt.ID); err == nil {
-				createdAt = ulid.Time(id.Time())
-			}
-		}
-
-		payloadByt, err := json.Marshal(evt.Data)
-		if err != nil {
-			continue
-		}
-		payload := string(payloadByt)
-
-		events = append(events, &models.Event{
-			ID:        evt.ID,
-			Name:      &name,
-			CreatedAt: &createdAt,
-			Payload:   &payload,
-		})
-	}
-
-	sort.Slice(events, func(i, j int) bool {
-		return events[i].ID > events[j].ID
-	})
-
-	return events, nil
 }

--- a/pkg/coreapi/graph/resolvers/function_run.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run.resolver.go
@@ -124,7 +124,7 @@ func (r *functionRunResolver) Event(ctx context.Context, obj *models.FunctionRun
 
 	return &models.Event{
 		CreatedAt: &evt.ReceivedAt,
-		ID:        evt.ID.String(),
+		ID:        evt.InternalID(),
 		Name:      &evt.EventName,
 		Payload:   util.StrPtr(string(payload)),
 	}, nil
@@ -160,7 +160,7 @@ func (r *functionRunResolver) Events(ctx context.Context, obj *models.FunctionRu
 		}
 
 		result[i] = &models.Event{
-			ID:        e.ID.String(),
+			ID:        e.InternalID(),
 			Name:      &e.EventName,
 			CreatedAt: &e.ReceivedAt,
 			Payload:   util.StrPtr(string(payload)),

--- a/ui/apps/dev-server-ui/src/coreapi.ts
+++ b/ui/apps/dev-server-ui/src/coreapi.ts
@@ -1,32 +1,5 @@
 import { gql } from 'graphql-request';
 
-export const EVENTS_STREAM = gql`
-  query GetEventsStream {
-    events(query: {}) {
-      id
-      name
-      createdAt
-      status
-      totalRuns
-    }
-  }
-`;
-
-export const FUNCTIONS_STREAM = gql`
-  query GetFunctionsStream {
-    functionRuns(query: {}) {
-      id
-      status
-      startedAt
-      pendingSteps
-      name
-      event {
-        id
-      }
-    }
-  }
-`;
-
 export const EVENT = gql`
   query GetEvent($id: ID!) {
     event(query: { eventId: $id }) {

--- a/ui/apps/dev-server-ui/src/store/generated.ts
+++ b/ui/apps/dev-server-ui/src/store/generated.ts
@@ -404,11 +404,6 @@ export type Workspace = {
   id: Scalars['ID'];
 };
 
-export type GetEventsStreamQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GetEventsStreamQuery = { __typename?: 'Query', events: Array<{ __typename?: 'Event', id: string, name: string | null, createdAt: any | null, status: EventStatus | null, totalRuns: number | null }> | null };
-
 export type GetFunctionsStreamQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -492,17 +487,6 @@ export type GetHistoryItemOutputQueryVariables = Exact<{
 export type GetHistoryItemOutputQuery = { __typename?: 'Query', functionRun: { __typename?: 'FunctionRun', historyItemOutput: string | null } | null };
 
 
-export const GetEventsStreamDocument = `
-    query GetEventsStream {
-  events(query: {}) {
-    id
-    name
-    createdAt
-    status
-    totalRuns
-  }
-}
-    `;
 export const GetFunctionsStreamDocument = `
     query GetFunctionsStream {
   functionRuns(query: {}) {
@@ -730,9 +714,6 @@ export const GetHistoryItemOutputDocument = `
 
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
-    GetEventsStream: build.query<GetEventsStreamQuery, GetEventsStreamQueryVariables | void>({
-      query: (variables) => ({ document: GetEventsStreamDocument, variables })
-    }),
     GetFunctionsStream: build.query<GetFunctionsStreamQuery, GetFunctionsStreamQueryVariables | void>({
       query: (variables) => ({ document: GetFunctionsStreamDocument, variables })
     }),
@@ -773,5 +754,5 @@ const injectedRtkApi = api.injectEndpoints({
 });
 
 export { injectedRtkApi as api };
-export const { useGetEventsStreamQuery, useLazyGetEventsStreamQuery, useGetFunctionsStreamQuery, useLazyGetFunctionsStreamQuery, useGetEventQuery, useLazyGetEventQuery, useGetFunctionRunQuery, useLazyGetFunctionRunQuery, useGetFunctionsQuery, useLazyGetFunctionsQuery, useGetAppsQuery, useLazyGetAppsQuery, useCreateAppMutation, useUpdateAppMutation, useDeleteAppMutation, useGetTriggersStreamQuery, useLazyGetTriggersStreamQuery, useGetFunctionRunStatusQuery, useLazyGetFunctionRunStatusQuery, useGetFunctionRunOutputQuery, useLazyGetFunctionRunOutputQuery, useGetHistoryItemOutputQuery, useLazyGetHistoryItemOutputQuery } = injectedRtkApi;
+export const { useGetFunctionsStreamQuery, useLazyGetFunctionsStreamQuery, useGetEventQuery, useLazyGetEventQuery, useGetFunctionRunQuery, useLazyGetFunctionRunQuery, useGetFunctionsQuery, useLazyGetFunctionsQuery, useGetAppsQuery, useLazyGetAppsQuery, useCreateAppMutation, useUpdateAppMutation, useDeleteAppMutation, useGetTriggersStreamQuery, useLazyGetTriggersStreamQuery, useGetFunctionRunStatusQuery, useLazyGetFunctionRunStatusQuery, useGetFunctionRunOutputQuery, useLazyGetFunctionRunOutputQuery, useGetHistoryItemOutputQuery, useLazyGetHistoryItemOutputQuery } = injectedRtkApi;
 


### PR DESCRIPTION
## Description
Fix a UI crash that happens when the event ID is custom. This was caused by some logic that expected a ULID but was given a custom non-ULID event ID.

The solution involves changing our logic to always expect our internal ULID, regardless of whether there's an external ID

## Motivation
https://linear.app/inngest/issue/INN-2831

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
