### PR TITLE
executor:  ensure `cancelOn` works with `event.ts` in the future

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -399,16 +399,10 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 				expires = time.Now().Add(dur)
 			}
 
-			// Ensure that we only listen to cancellation events that occur
-			// after the initial event is received.
-			expr := "(async.ts == null || async.ts > event.ts)"
-			if c.If != nil {
-				expr = expr + " && " + *c.If
-			}
-
 			// Evaluate the expression.  This lets us inspect the expression's attributes
 			// so that we can store only the attrs used in the expression in the pause,
 			// saving space, bandwidth, etc.
+			expr := generateCancelExpression(eventIDs[0], c.If)
 			eval, err := expressions.NewExpressionEvaluator(ctx, expr)
 			if err != nil {
 				return &id, err
@@ -1992,4 +1986,20 @@ func (e execError) Retryable() bool {
 
 func newFinalError(err error) error {
 	return execError{err: err, final: true}
+}
+
+func generateCancelExpression(eventID ulid.ULID, expr *string) string {
+	receivedAt := strconv.Itoa(int(eventID.Time()))
+
+	// Ensure that we only listen to cancellation events that occur
+	// after the initial event is received.
+	//
+	// NOTE: We don't use `event.ts` here as people can use a future-TS date
+	// to schedule future runs.  Events received between now and that date should
+	// still cancel the run.
+	res := fmt.Sprintf("(async.ts == null || async.ts > %s)", receivedAt)
+	if expr != nil {
+		res = *expr + " && " + res
+	}
+	return res
 }

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1989,15 +1989,13 @@ func newFinalError(err error) error {
 }
 
 func generateCancelExpression(eventID ulid.ULID, expr *string) string {
-	receivedAt := strconv.Itoa(int(eventID.Time()))
-
 	// Ensure that we only listen to cancellation events that occur
 	// after the initial event is received.
 	//
 	// NOTE: We don't use `event.ts` here as people can use a future-TS date
 	// to schedule future runs.  Events received between now and that date should
 	// still cancel the run.
-	res := fmt.Sprintf("(async.ts == null || async.ts > %s)", receivedAt)
+	res := fmt.Sprintf("(async.ts == null || async.ts > %d)", eventID.Time())
 	if expr != nil {
 		res = *expr + " && " + res
 	}

--- a/pkg/execution/executor/executor_test.go
+++ b/pkg/execution/executor/executor_test.go
@@ -1,0 +1,39 @@
+package executor
+
+import (
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngestgo"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCancelExpressionGen(t *testing.T) {
+	future, err := time.Parse(time.RFC3339, "2038-01-01T01:30:00.00Z")
+	require.NoError(t, err)
+
+	tests := []struct {
+		EventID    ulid.ULID
+		Expression *string
+		Expected   string
+	}{
+		// Future
+		{
+			EventID:    ulid.MustNew(uint64(future.UnixMilli()), rand.Reader),
+			Expression: nil,
+			Expected:   "(async.ts == null || async.ts > 2145922200000)",
+		},
+		{
+			EventID:    ulid.MustNew(uint64(future.UnixMilli()), rand.Reader),
+			Expression: inngestgo.StrPtr("async.data.ok == true"),
+			Expected:   "async.data.ok == true && (async.ts == null || async.ts > 2145922200000)",
+		},
+	}
+
+	for _, test := range tests {
+		actual := generateCancelExpression(test.EventID, test.Expression)
+		require.Equal(t, test.Expected, actual)
+	}
+}


### PR DESCRIPTION
We previously used `event.ts` in the cancel expression, but now we hard code the timestamp in which the initial event was received.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
