### PR TITLE
Fix missing running state in Dev Server UI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.21.0
 	gocloud.dev v0.25.0
 	gocloud.dev/pubsub/natspubsub v0.25.0
-	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 	golang.org/x/mod v0.12.0
 	golang.org/x/sync v0.6.0
 	golang.org/x/term v0.15.0
@@ -174,6 +173,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect

--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -118,7 +118,6 @@ type ComplexityRoot struct {
 		History           func(childComplexity int) int
 		HistoryItemOutput func(childComplexity int, id ulid.ULID) int
 		ID                func(childComplexity int) int
-		Name              func(childComplexity int) int
 		Output            func(childComplexity int) int
 		PendingSteps      func(childComplexity int) int
 		StartedAt         func(childComplexity int) int
@@ -279,14 +278,12 @@ type FunctionRunResolver interface {
 
 	Event(ctx context.Context, obj *models.FunctionRun) (*models.Event, error)
 	Events(ctx context.Context, obj *models.FunctionRun) ([]*models.Event, error)
-	BatchID(ctx context.Context, obj *models.FunctionRun) (*ulid.ULID, error)
+
 	BatchCreatedAt(ctx context.Context, obj *models.FunctionRun) (*time.Time, error)
-	Status(ctx context.Context, obj *models.FunctionRun) (*models.FunctionRunStatus, error)
+
 	WaitingFor(ctx context.Context, obj *models.FunctionRun) (*models.StepEventWait, error)
 	PendingSteps(ctx context.Context, obj *models.FunctionRun) (*int, error)
 
-	FinishedAt(ctx context.Context, obj *models.FunctionRun) (*time.Time, error)
-	Output(ctx context.Context, obj *models.FunctionRun) (*string, error)
 	History(ctx context.Context, obj *models.FunctionRun) ([]*history_reader.RunHistory, error)
 	HistoryItemOutput(ctx context.Context, obj *models.FunctionRun, id ulid.ULID) (*string, error)
 }
@@ -664,13 +661,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.FunctionRun.ID(childComplexity), true
-
-	case "FunctionRun.name":
-		if e.complexity.FunctionRun.Name == nil {
-			break
-		}
-
-		return e.complexity.FunctionRun.Name(childComplexity), true
 
 	case "FunctionRun.output":
 		if e.complexity.FunctionRun.Output == nil {
@@ -1649,7 +1639,6 @@ type FunctionRun {
 
   history: [RunHistoryItem!]!
   historyItemOutput(id: ULID!): String
-  name: String @deprecated # use the embedded function field instead.
   eventID: ID!
 }
 
@@ -2971,8 +2960,6 @@ func (ec *executionContext) fieldContext_Event_functionRuns(ctx context.Context,
 				return ec.fieldContext_FunctionRun_history(ctx, field)
 			case "historyItemOutput":
 				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
-			case "name":
-				return ec.fieldContext_FunctionRun_name(ctx, field)
 			case "eventID":
 				return ec.fieldContext_FunctionRun_eventID(ctx, field)
 			}
@@ -3520,8 +3507,6 @@ func (ec *executionContext) fieldContext_FunctionEvent_functionRun(ctx context.C
 				return ec.fieldContext_FunctionRun_history(ctx, field)
 			case "historyItemOutput":
 				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
-			case "name":
-				return ec.fieldContext_FunctionRun_name(ctx, field)
 			case "eventID":
 				return ec.fieldContext_FunctionRun_eventID(ctx, field)
 			}
@@ -3995,7 +3980,7 @@ func (ec *executionContext) _FunctionRun_batchID(ctx context.Context, field grap
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.FunctionRun().BatchID(rctx, obj)
+		return obj.BatchID, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -4013,8 +3998,8 @@ func (ec *executionContext) fieldContext_FunctionRun_batchID(ctx context.Context
 	fc = &graphql.FieldContext{
 		Object:     "FunctionRun",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type ULID does not have child fields")
 		},
@@ -4077,7 +4062,7 @@ func (ec *executionContext) _FunctionRun_status(ctx context.Context, field graph
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.FunctionRun().Status(rctx, obj)
+		return obj.Status, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -4095,8 +4080,8 @@ func (ec *executionContext) fieldContext_FunctionRun_status(ctx context.Context,
 	fc = &graphql.FieldContext{
 		Object:     "FunctionRun",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type FunctionRunStatus does not have child fields")
 		},
@@ -4249,7 +4234,7 @@ func (ec *executionContext) _FunctionRun_finishedAt(ctx context.Context, field g
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.FunctionRun().FinishedAt(rctx, obj)
+		return obj.FinishedAt, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -4267,8 +4252,8 @@ func (ec *executionContext) fieldContext_FunctionRun_finishedAt(ctx context.Cont
 	fc = &graphql.FieldContext{
 		Object:     "FunctionRun",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Time does not have child fields")
 		},
@@ -4290,7 +4275,7 @@ func (ec *executionContext) _FunctionRun_output(ctx context.Context, field graph
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.FunctionRun().Output(rctx, obj)
+		return obj.Output, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -4308,8 +4293,8 @@ func (ec *executionContext) fieldContext_FunctionRun_output(ctx context.Context,
 	fc = &graphql.FieldContext{
 		Object:     "FunctionRun",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
@@ -4443,47 +4428,6 @@ func (ec *executionContext) fieldContext_FunctionRun_historyItemOutput(ctx conte
 	if fc.Args, err = ec.field_FunctionRun_historyItemOutput_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _FunctionRun_name(ctx context.Context, field graphql.CollectedField, obj *models.FunctionRun) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_FunctionRun_name(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Name, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*string)
-	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_FunctionRun_name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "FunctionRun",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
 	}
 	return fc, nil
 }
@@ -5614,8 +5558,6 @@ func (ec *executionContext) fieldContext_Query_functionRun(ctx context.Context, 
 				return ec.fieldContext_FunctionRun_history(ctx, field)
 			case "historyItemOutput":
 				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
-			case "name":
-				return ec.fieldContext_FunctionRun_name(ctx, field)
 			case "eventID":
 				return ec.fieldContext_FunctionRun_eventID(ctx, field)
 			}
@@ -5704,8 +5646,6 @@ func (ec *executionContext) fieldContext_Query_functionRuns(ctx context.Context,
 				return ec.fieldContext_FunctionRun_history(ctx, field)
 			case "historyItemOutput":
 				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
-			case "name":
-				return ec.fieldContext_FunctionRun_name(ctx, field)
 			case "eventID":
 				return ec.fieldContext_FunctionRun_eventID(ctx, field)
 			}
@@ -7681,8 +7621,6 @@ func (ec *executionContext) fieldContext_StepEvent_functionRun(ctx context.Conte
 				return ec.fieldContext_FunctionRun_history(ctx, field)
 			case "historyItemOutput":
 				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
-			case "name":
-				return ec.fieldContext_FunctionRun_name(ctx, field)
 			case "eventID":
 				return ec.fieldContext_FunctionRun_eventID(ctx, field)
 			}
@@ -8316,8 +8254,6 @@ func (ec *executionContext) fieldContext_StreamItem_runs(ctx context.Context, fi
 				return ec.fieldContext_FunctionRun_history(ctx, field)
 			case "historyItemOutput":
 				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
-			case "name":
-				return ec.fieldContext_FunctionRun_name(ctx, field)
 			case "eventID":
 				return ec.fieldContext_FunctionRun_eventID(ctx, field)
 			}
@@ -11070,22 +11006,9 @@ func (ec *executionContext) _FunctionRun(ctx context.Context, sel ast.SelectionS
 
 			})
 		case "batchID":
-			field := field
 
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._FunctionRun_batchID(ctx, field, obj)
-				return res
-			}
+			out.Values[i] = ec._FunctionRun_batchID(ctx, field, obj)
 
-			out.Concurrently(i, func() graphql.Marshaler {
-				return innerFunc(ctx)
-
-			})
 		case "batchCreatedAt":
 			field := field
 
@@ -11104,22 +11027,9 @@ func (ec *executionContext) _FunctionRun(ctx context.Context, sel ast.SelectionS
 
 			})
 		case "status":
-			field := field
 
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._FunctionRun_status(ctx, field, obj)
-				return res
-			}
+			out.Values[i] = ec._FunctionRun_status(ctx, field, obj)
 
-			out.Concurrently(i, func() graphql.Marshaler {
-				return innerFunc(ctx)
-
-			})
 		case "waitingFor":
 			field := field
 
@@ -11159,39 +11069,13 @@ func (ec *executionContext) _FunctionRun(ctx context.Context, sel ast.SelectionS
 			out.Values[i] = ec._FunctionRun_startedAt(ctx, field, obj)
 
 		case "finishedAt":
-			field := field
 
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._FunctionRun_finishedAt(ctx, field, obj)
-				return res
-			}
+			out.Values[i] = ec._FunctionRun_finishedAt(ctx, field, obj)
 
-			out.Concurrently(i, func() graphql.Marshaler {
-				return innerFunc(ctx)
-
-			})
 		case "output":
-			field := field
 
-			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._FunctionRun_output(ctx, field, obj)
-				return res
-			}
+			out.Values[i] = ec._FunctionRun_output(ctx, field, obj)
 
-			out.Concurrently(i, func() graphql.Marshaler {
-				return innerFunc(ctx)
-
-			})
 		case "history":
 			field := field
 
@@ -11229,10 +11113,6 @@ func (ec *executionContext) _FunctionRun(ctx context.Context, sel ast.SelectionS
 				return innerFunc(ctx)
 
 			})
-		case "name":
-
-			out.Values[i] = ec._FunctionRun_name(ctx, field, obj)
-
 		case "eventID":
 
 			out.Values[i] = ec._FunctionRun_eventID(ctx, field, obj)

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -198,7 +198,6 @@ type FunctionRun {
 
   history: [RunHistoryItem!]!
   historyItemOutput(id: ULID!): String
-  name: String @deprecated # use the embedded function field instead.
   eventID: ID!
 }
 

--- a/pkg/coreapi/gqlgen.yml
+++ b/pkg/coreapi/gqlgen.yml
@@ -60,19 +60,11 @@ models:
         resolver: true
       batchCreatedAt:
         resolver: true
-      batchID:
-        resolver: true
       waitingFor:
         resolver: true
       pendingSteps:
         resolver: true
-      status:
-        resolver: true
       function:
-        resolver: true
-      output:
-        resolver: true
-      finishedAt:
         resolver: true
   HistoryType:
     model: github.com/inngest/inngest/pkg/enums.HistoryType

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -90,7 +90,6 @@ type FunctionRun struct {
 	Output            *string                      `json:"output,omitempty"`
 	History           []*history_reader.RunHistory `json:"history"`
 	HistoryItemOutput *string                      `json:"historyItemOutput,omitempty"`
-	Name              *string                      `json:"name,omitempty"`
 	EventID           string                       `json:"eventID"`
 }
 

--- a/pkg/coreapi/graph/resolvers/event.resolver.go
+++ b/pkg/coreapi/graph/resolvers/event.resolver.go
@@ -28,13 +28,7 @@ func (r *eventResolver) FunctionRuns(ctx context.Context, obj *models.Event) ([]
 	var out []*models.FunctionRun
 
 	for _, run := range runs {
-		fn, err := r.Data.GetFunctionByInternalUUID(ctx, workspaceID, run.FunctionID)
-		if err != nil {
-			return nil, err
-		}
-
 		outRun := models.MakeFunctionRun(run)
-		outRun.Name = &fn.Name
 		out = append(out, outRun)
 	}
 

--- a/pkg/coreapi/graph/resolvers/function_run.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run.resolver.go
@@ -15,16 +15,6 @@ import (
 	"github.com/oklog/ulid/v2"
 )
 
-func (r *functionRunResolver) Status(ctx context.Context, obj *models.FunctionRun) (*models.FunctionRunStatus, error) {
-	md, err := r.Runner.StateManager().Metadata(ctx, ulid.MustParse(obj.ID))
-	if err != nil {
-		return nil, fmt.Errorf("Run ID not found: %w", err)
-	}
-
-	status, err := models.ToFunctionRunStatus(md.Status)
-	return &status, err
-}
-
 func (r *functionRunResolver) PendingSteps(ctx context.Context, obj *models.FunctionRun) (*int, error) {
 	md, err := r.Runner.StateManager().Metadata(ctx, ulid.MustParse(obj.ID))
 	if err != nil {
@@ -45,11 +35,6 @@ func (r *functionRunResolver) Function(ctx context.Context, obj *models.Function
 		return nil, err
 	}
 	return models.MakeFunction(fn)
-}
-
-func (r *functionRunResolver) FinishedAt(ctx context.Context, obj *models.FunctionRun) (*time.Time, error) {
-	// Mapped in MakeFunctionRun
-	return obj.FinishedAt, nil
 }
 
 func (r *functionRunResolver) History(
@@ -96,11 +81,6 @@ func (r *functionRunResolver) HistoryItemOutput(
 			WorkspaceID: randomUUID,
 		},
 	)
-}
-
-func (r *functionRunResolver) Output(ctx context.Context, obj *models.FunctionRun) (*string, error) {
-	// Mapped in MakeFunctionRun
-	return obj.Output, nil
 }
 
 func (r *functionRunResolver) Event(ctx context.Context, obj *models.FunctionRun) (*models.Event, error) {
@@ -168,16 +148,6 @@ func (r *functionRunResolver) Events(ctx context.Context, obj *models.FunctionRu
 	}
 
 	return result, nil
-}
-
-func (r *functionRunResolver) BatchID(ctx context.Context, obj *models.FunctionRun) (*ulid.ULID, error) {
-	runID := ulid.MustParse(obj.ID)
-
-	if batch, err := r.Data.GetEventBatchByRunID(ctx, runID); err == nil {
-		return &batch.ID, nil
-	}
-
-	return nil, nil
 }
 
 func (r *functionRunResolver) WaitingFor(ctx context.Context, obj *models.FunctionRun) (*models.StepEventWait, error) {

--- a/pkg/coreapi/graph/resolvers/stream.go
+++ b/pkg/coreapi/graph/resolvers/stream.go
@@ -38,11 +38,14 @@ func (r *queryResolver) Stream(ctx context.Context, q models.StreamQuery) ([]*mo
 		ids[n] = evt.InternalID()
 	}
 
-	// Fetch all function runs by event
-	fns, err := r.Data.GetFunctionRunsFromEvents(
+	// Values don't matter in the Dev Server
+	accountID := uuid.New()
+	workspaceID := uuid.New()
+
+	fns, err := r.HistoryReader.GetFunctionRunsFromEvents(
 		ctx,
-		uuid.UUID{},
-		uuid.UUID{},
+		accountID,
+		workspaceID,
 		ids,
 	)
 	if err != nil {

--- a/pkg/history_drivers/memory_writer/writer.go
+++ b/pkg/history_drivers/memory_writer/writer.go
@@ -72,6 +72,11 @@ func (w *writer) writeWorkflowEnd(
 
 	run := w.store.Data[item.RunID]
 	run.Run.EndedAt = timePtr(time.Now())
+
+	if item.Result != nil {
+		run.Run.Output = &item.Result.Output
+	}
+
 	run.Run.Status = status
 	w.store.Data[item.RunID] = run
 }

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/stream/useEvent.ts
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/stream/useEvent.ts
@@ -30,7 +30,7 @@ export function useEvent(eventID: string | null): FetchResult<Data, { skippable:
     const functionRuns: Data['functionRuns'] = (event.functionRuns ?? []).map((run) => {
       return {
         id: run.id,
-        name: run.name ?? 'Unknown',
+        name: run.function?.name ?? 'Unknown',
         output: run.output ?? null,
         status: run.status ?? FunctionRunStatus.Running,
       };

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/stream/useRun.ts
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/stream/useRun.ts
@@ -41,7 +41,6 @@ export function useRun(runID: string | null): FetchResult<Data, { skippable: tru
     return {
       func: {
         ...rawRun.function,
-        name: rawRun.name ?? 'unknown',
         triggers: rawRun.function.triggers ?? [],
       },
       history: new HistoryParser(rawRun.history ?? []),

--- a/ui/apps/dev-server-ui/src/coreapi.ts
+++ b/ui/apps/dev-server-ui/src/coreapi.ts
@@ -19,7 +19,6 @@ export const FUNCTIONS_STREAM = gql`
       status
       startedAt
       pendingSteps
-      name
       event {
         id
       }
@@ -37,8 +36,10 @@ export const EVENT = gql`
       pendingRuns
       raw
       functionRuns {
+        function {
+          name
+        }
         id
-        name
         status
         startedAt
         pendingSteps
@@ -57,7 +58,6 @@ export const FUNCTION_RUN = gql`
   query GetFunctionRun($id: ID!) {
     functionRun(query: { functionRunId: $id }) {
       id
-      name
       status
       startedAt
       finishedAt
@@ -69,6 +69,7 @@ export const FUNCTION_RUN = gql`
         expression
       }
       function {
+        name
         triggers {
           type
           value

--- a/ui/apps/dev-server-ui/src/store/generated.ts
+++ b/ui/apps/dev-server-ui/src/store/generated.ts
@@ -121,8 +121,6 @@ export type FunctionRun = {
   history: Array<RunHistoryItem>;
   historyItemOutput: Maybe<Scalars['String']>;
   id: Scalars['ID'];
-  /** @deprecated Field no longer supported */
-  name: Maybe<Scalars['String']>;
   output: Maybe<Scalars['String']>;
   /** @deprecated Field no longer supported */
   pendingSteps: Maybe<Scalars['Int']>;
@@ -412,21 +410,21 @@ export type GetEventsStreamQuery = { __typename?: 'Query', events: Array<{ __typ
 export type GetFunctionsStreamQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetFunctionsStreamQuery = { __typename?: 'Query', functionRuns: Array<{ __typename?: 'FunctionRun', id: string, status: FunctionRunStatus | null, startedAt: any | null, pendingSteps: number | null, name: string | null, event: { __typename?: 'Event', id: string } | null }> | null };
+export type GetFunctionsStreamQuery = { __typename?: 'Query', functionRuns: Array<{ __typename?: 'FunctionRun', id: string, status: FunctionRunStatus | null, startedAt: any | null, pendingSteps: number | null, event: { __typename?: 'Event', id: string } | null }> | null };
 
 export type GetEventQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
 
-export type GetEventQuery = { __typename?: 'Query', event: { __typename?: 'Event', id: string, name: string | null, createdAt: any | null, status: EventStatus | null, pendingRuns: number | null, raw: string | null, functionRuns: Array<{ __typename?: 'FunctionRun', id: string, name: string | null, status: FunctionRunStatus | null, startedAt: any | null, pendingSteps: number | null, output: string | null, waitingFor: { __typename?: 'StepEventWait', expiryTime: any, eventName: string | null, expression: string | null } | null }> | null } | null };
+export type GetEventQuery = { __typename?: 'Query', event: { __typename?: 'Event', id: string, name: string | null, createdAt: any | null, status: EventStatus | null, pendingRuns: number | null, raw: string | null, functionRuns: Array<{ __typename?: 'FunctionRun', id: string, status: FunctionRunStatus | null, startedAt: any | null, pendingSteps: number | null, output: string | null, function: { __typename?: 'Function', name: string } | null, waitingFor: { __typename?: 'StepEventWait', expiryTime: any, eventName: string | null, expression: string | null } | null }> | null } | null };
 
 export type GetFunctionRunQueryVariables = Exact<{
   id: Scalars['ID'];
 }>;
 
 
-export type GetFunctionRunQuery = { __typename?: 'Query', functionRun: { __typename?: 'FunctionRun', id: string, name: string | null, status: FunctionRunStatus | null, startedAt: any | null, finishedAt: any | null, output: string | null, pendingSteps: number | null, batchID: any | null, batchCreatedAt: any | null, waitingFor: { __typename?: 'StepEventWait', expiryTime: any, eventName: string | null, expression: string | null } | null, function: { __typename?: 'Function', triggers: Array<{ __typename?: 'FunctionTrigger', type: FunctionTriggerTypes, value: string }> | null } | null, event: { __typename?: 'Event', id: string, raw: string | null } | null, events: Array<{ __typename?: 'Event', createdAt: any | null, id: string, name: string | null, raw: string | null }>, history: Array<{ __typename?: 'RunHistoryItem', attempt: number, createdAt: any, functionVersion: number, groupID: any | null, id: any, stepName: string | null, type: HistoryType, url: string | null, cancel: { __typename?: 'RunHistoryCancel', eventID: any | null, expression: string | null, userID: any | null } | null, sleep: { __typename?: 'RunHistorySleep', until: any } | null, waitForEvent: { __typename?: 'RunHistoryWaitForEvent', eventName: string, expression: string | null, timeout: any } | null, waitResult: { __typename?: 'RunHistoryWaitResult', eventID: any | null, timeout: boolean } | null, invokeFunction: { __typename?: 'RunHistoryInvokeFunction', eventID: any, functionID: string, correlationID: string, timeout: any } | null, invokeFunctionResult: { __typename?: 'RunHistoryInvokeFunctionResult', eventID: any | null, timeout: boolean, runID: any | null } | null }> } | null };
+export type GetFunctionRunQuery = { __typename?: 'Query', functionRun: { __typename?: 'FunctionRun', id: string, status: FunctionRunStatus | null, startedAt: any | null, finishedAt: any | null, output: string | null, pendingSteps: number | null, batchID: any | null, batchCreatedAt: any | null, waitingFor: { __typename?: 'StepEventWait', expiryTime: any, eventName: string | null, expression: string | null } | null, function: { __typename?: 'Function', name: string, triggers: Array<{ __typename?: 'FunctionTrigger', type: FunctionTriggerTypes, value: string }> | null } | null, event: { __typename?: 'Event', id: string, raw: string | null } | null, events: Array<{ __typename?: 'Event', createdAt: any | null, id: string, name: string | null, raw: string | null }>, history: Array<{ __typename?: 'RunHistoryItem', attempt: number, createdAt: any, functionVersion: number, groupID: any | null, id: any, stepName: string | null, type: HistoryType, url: string | null, cancel: { __typename?: 'RunHistoryCancel', eventID: any | null, expression: string | null, userID: any | null } | null, sleep: { __typename?: 'RunHistorySleep', until: any } | null, waitForEvent: { __typename?: 'RunHistoryWaitForEvent', eventName: string, expression: string | null, timeout: any } | null, waitResult: { __typename?: 'RunHistoryWaitResult', eventID: any | null, timeout: boolean } | null, invokeFunction: { __typename?: 'RunHistoryInvokeFunction', eventID: any, functionID: string, correlationID: string, timeout: any } | null, invokeFunctionResult: { __typename?: 'RunHistoryInvokeFunctionResult', eventID: any | null, timeout: boolean, runID: any | null } | null }> } | null };
 
 export type GetFunctionsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -510,7 +508,6 @@ export const GetFunctionsStreamDocument = `
     status
     startedAt
     pendingSteps
-    name
     event {
       id
     }
@@ -527,8 +524,10 @@ export const GetEventDocument = `
     pendingRuns
     raw
     functionRuns {
+      function {
+        name
+      }
       id
-      name
       status
       startedAt
       pendingSteps
@@ -546,7 +545,6 @@ export const GetFunctionRunDocument = `
     query GetFunctionRun($id: ID!) {
   functionRun(query: {functionRunId: $id}) {
     id
-    name
     status
     startedAt
     finishedAt
@@ -558,6 +556,7 @@ export const GetFunctionRunDocument = `
       expression
     }
     function {
+      name
       triggers {
         type
         value


### PR DESCRIPTION
## Description
- Make `functionRun` resolver use the history store
- Delete `FunctionRun.name` in GraphQL since it doesn't make sense (names are on functions, not runs)
- Fix history store missing run output

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
