### PR TITLE
Revert default run status change

### DIFF
--- a/pkg/execution/state/redis_state/lua/cancel.lua
+++ b/pkg/execution/state/redis_state/lua/cancel.lua
@@ -11,9 +11,7 @@ Output:
 local metadataKey = KEYS[1]
 
 local value = tonumber(redis.call("HGET", metadataKey, "status"))
-
--- If run has ended (completed, failed, etc.)
-if value ~= 0 and value ~= 5 then
+if value ~= 0 then
 	-- Return the function status as an error
 	return value;
 end

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -264,7 +264,6 @@ func (m mgr) New(ctx context.Context, input state.Input) (state.State, error) {
 		Version:        currentVersion,
 		RequestVersion: consts.RequestVersionUnknown, // Always use -1 to indicate unset hash version until first request.
 		Context:        input.Context,
-		Status:         enums.RunStatusScheduled,
 	}
 	if input.RunType != nil {
 		metadata.RunType = *input.RunType

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -181,7 +181,7 @@ func checkNew(t *testing.T, m state.Manager) {
 	require.EqualValues(t, w, found, "Returned workflow does not match input")
 	require.EqualValues(t, evt, s.Event(), "Returned event does not match input")
 	require.EqualValues(t, batch, s.Events(), "Returned events does not match input")
-	require.EqualValues(t, enums.RunStatusScheduled, s.Metadata().Status, "Status is not Scheduled")
+	require.EqualValues(t, enums.RunStatusRunning, s.Metadata().Status, "Status is not Scheduled")
 	require.EqualValues(t, init.Context, s.Metadata().Context, "Metadata context not saved")
 	require.EqualValues(t, id, s.Metadata().Identifier, "Metadata didn't save Identifier")
 
@@ -1553,7 +1553,7 @@ func checkSetStatus(t *testing.T, m state.Manager) {
 
 	s, err := m.New(ctx, init)
 	require.NoError(t, err)
-	require.EqualValues(t, enums.RunStatusScheduled, s.Metadata().Status, "Status is not Scheduled")
+	require.EqualValues(t, enums.RunStatusRunning, s.Metadata().Status, "Status is not Scheduled")
 
 	// Add time so that the history ticks a millisecond
 	<-time.After(time.Millisecond)
@@ -1582,7 +1582,7 @@ func checkCancel(t *testing.T, m state.Manager) {
 
 	s, err := m.New(ctx, init)
 	require.NoError(t, err)
-	require.EqualValues(t, enums.RunStatusScheduled, s.Metadata().Status, "Status is not Scheduled")
+	require.EqualValues(t, enums.RunStatusRunning, s.Metadata().Status, "Status is not Scheduled")
 
 	// Add time so that the history ticks a millisecond
 	<-time.After(time.Millisecond)
@@ -1610,7 +1610,7 @@ func checkCancel_cancelled(t *testing.T, m state.Manager) {
 
 	s, err := m.New(ctx, init)
 	require.NoError(t, err)
-	require.EqualValues(t, enums.RunStatusScheduled, s.Metadata().Status, "Status is not Scheduled")
+	require.EqualValues(t, enums.RunStatusRunning, s.Metadata().Status, "Status is not Scheduled")
 
 	// Add time so that the history ticks a millisecond
 	<-time.After(time.Millisecond)
@@ -1640,7 +1640,7 @@ func checkCancel_completed(t *testing.T, m state.Manager) {
 
 	s, err := m.New(ctx, init)
 	require.NoError(t, err)
-	require.EqualValues(t, enums.RunStatusScheduled, s.Metadata().Status, "Status is not Scheduled")
+	require.EqualValues(t, enums.RunStatusRunning, s.Metadata().Status, "Status is not Scheduled")
 
 	// Add time so that the history ticks a millisecond
 	<-time.After(time.Millisecond)


### PR DESCRIPTION
## Description
Revert the change to the default run status when creating a run in the state store.

This change is no longer needed since the UI doesn't use the state store to determine run status anymore. It was a flawed change anyway since the status isn't updated to `Running` after the run starts 😄.

## Testing
Verified that runs show as scheduled and then running in the UI

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
