### PR TITLE
Fix UI crash due to spare events array

### DIFF
--- a/pkg/coreapi/graph/resolvers/function_run.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run.resolver.go
@@ -123,6 +123,11 @@ func (r *functionRunResolver) Events(ctx context.Context, obj *models.FunctionRu
 			return empty, nil
 		}
 
+		// Will be nil if the run was not triggered by an event (i.e. a cron)
+		if evt == nil {
+			return empty, nil
+		}
+
 		return []*models.Event{evt}, nil
 	}
 


### PR DESCRIPTION
## Description
Fix a Dev Server stream UI crash when GraphQL returns a sparse events array (i.e. a `null` in the array). This happens for crons, since they don't have an event. I'm not sure if there are other ways the event could be `nil`

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
