### PR TITLE
Add toast to Replay

### DIFF
--- a/ui/apps/dev-server-ui/src/app/(dashboard)/layout.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/layout.tsx
@@ -43,7 +43,6 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
         toastOptions={{
           style: { background: colors.slate['700'] },
         }}
-        position="top-right"
       />
     </div>
   );

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/stream/StreamDetails.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/stream/StreamDetails.tsx
@@ -6,6 +6,7 @@ import { Link } from '@inngest/components/Link';
 import { RunDetails } from '@inngest/components/RunDetails';
 import { classNames } from '@inngest/components/utils/classNames';
 import type { NavigateToRunFn } from 'node_modules/@inngest/components/src/Timeline/Timeline';
+import { toast } from 'sonner';
 import { ulid } from 'ulid';
 
 import SendEventButton from '@/components/Event/SendEventButton';
@@ -73,7 +74,11 @@ export default function StreamDetails() {
       ...JSON.parse(eventResult.data.payload),
       id: eventId,
       ts: Date.now(),
-    }).unwrap();
+    })
+      .unwrap()
+      .then(() => {
+        toast.success('The event was successfully replayed.');
+      });
   }
 
   const navigateToRun: NavigateToRunFn = (opts) => {

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/stream/StreamDetails.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/stream/StreamDetails.tsx
@@ -78,6 +78,9 @@ export default function StreamDetails() {
       .unwrap()
       .then(() => {
         toast.success('The event was successfully replayed.');
+      })
+      .catch(() => {
+        toast.error('Failed to replay');
       });
   }
 


### PR DESCRIPTION
## Description
- Add toast to replay (replicated the same logic used in other parts with the same method, works for now)
- Move toast to the bottom of the screen, as the top right corner is too busy and difficult to read (it also matches Cloud)
![Screenshot 2024-03-05 at 17 26 52](https://github.com/inngest/inngest/assets/16758464/5ef5cd2d-c31e-4131-85b1-002b62e98463)


## Type of change (choose one)
- [X] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
