### PR TITLE
Allow cache skipping in the Dev Server REST API

### DIFF
--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/runner"
 	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/headers"
 	"github.com/inngest/inngest/pkg/inngest/log"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/sdk"
@@ -84,7 +85,7 @@ func (d *devserver) Pre(ctx context.Context) error {
 	devAPI.Route("/v1", func(r chi.Router) {
 		// Add the V1 API to our dev server API.
 		cache := cache.New[[]byte](freecachestore.NewFreecache(freecache.NewCache(1024 * 1024)))
-		caching := apiv1.NewCacheMiddleware(cache)
+		caching := apiv1.NewCacheMiddleware(cache, headers.ServerKindDev)
 
 		apiv1.AddRoutes(r, apiv1.Opts{
 			CachingMiddleware: caching,

--- a/pkg/headers/headers.go
+++ b/pkg/headers/headers.go
@@ -15,6 +15,9 @@ const (
 	// to be, used to validate that every part of a registration is performed
 	// against the same target.
 	HeaderKeyExpectedServerKind = "X-Inngest-Expected-Server-Kind"
+
+	// Used by SDK tests to tell the Dev Server's REST API to skip caching
+	HeaderKeySkipCache = "X-Inngest-Skip-Cache"
 )
 
 const (


### PR DESCRIPTION
## Description
Make cache checking skippable in the cache middleware. This is purely for SDK testing purposes, since it drastically reduces test duration. We should never ever ever ever ever ever allow cache skipping in Cloud

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
