### PR TITLE
Redirect to stream on event/run fetch error

### DIFF
--- a/ui/apps/dev-server-ui/src/app/(dashboard)/stream/StreamDetails.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/stream/StreamDetails.tsx
@@ -22,12 +22,12 @@ export default function StreamDetails() {
 
   const eventResult = useEvent(eventID);
   if (eventResult.error) {
-    throw eventResult.error;
+    console.error(eventResult.error);
   }
 
   const runResult = useRun(runID);
   if (runResult.error) {
-    throw runResult.error;
+    console.error(runResult.error);
   }
 
   const getHistoryItemOutput = useGetHistoryItemOutput(runID);
@@ -52,6 +52,14 @@ export default function StreamDetails() {
       />
     );
   }, [eventResult.data?.payload]);
+
+  if (eventResult.error || runResult.error) {
+    // If there's an error fetching the event or run, we should redirect to the
+    // stream. This happens a lot, since restarting the Dev Server will clear
+    // all data
+    router.push('/stream');
+    return null;
+  }
 
   if (eventResult.isLoading || runResult.isLoading) {
     return (

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/stream/StreamDetails.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/stream/StreamDetails.tsx
@@ -21,14 +21,29 @@ export default function StreamDetails() {
   const runID = params.get('run');
 
   const eventResult = useEvent(eventID);
-  if (eventResult.error) {
-    console.error(eventResult.error);
-  }
+  useEffect(() => {
+    if (eventResult.error) {
+      console.error(eventResult.error);
+      toast.error(`Failed to fetch event ${eventID}`);
+    }
+  }, [eventResult.error]);
 
   const runResult = useRun(runID);
-  if (runResult.error) {
-    console.error(runResult.error);
-  }
+  useEffect(() => {
+    if (runResult.error) {
+      console.error(runResult.error);
+      toast.error(`Failed to fetch run ${runID}`);
+    }
+  }, [runResult.error]);
+
+  useEffect(() => {
+    if (eventResult.error || runResult.error) {
+      // If there's an error fetching the event or run, we should redirect to the
+      // stream. This happens a lot, since restarting the Dev Server will clear
+      // all data
+      router.replace('/stream');
+    }
+  }, [eventResult.error, runResult.error]);
 
   const getHistoryItemOutput = useGetHistoryItemOutput(runID);
   const router = useRouter();
@@ -52,14 +67,6 @@ export default function StreamDetails() {
       />
     );
   }, [eventResult.data?.payload]);
-
-  if (eventResult.error || runResult.error) {
-    // If there's an error fetching the event or run, we should redirect to the
-    // stream. This happens a lot, since restarting the Dev Server will clear
-    // all data
-    router.push('/stream');
-    return null;
-  }
 
   if (eventResult.isLoading || runResult.isLoading) {
     return (


### PR DESCRIPTION
## Description
If there's an error fetching the event or run in the stream details, then redirect back to the stream (i.e. close the slide out).

Before this PR, the UI would completely crash

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
