### PR TITLE
INN-2864 Render "Function errored" for discovery timeline nodes which fail

### DIFF
--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeRenderer.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNodeRenderer.tsx
@@ -92,6 +92,8 @@ export function renderTimelineNode({
       name = 'Running next attempt...';
     } else if (node.status === 'started') {
       name = 'Running next step...';
+    } else if (node.status === 'failed') {
+      name = 'Function errored';
     }
 
     if (


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

WIP

- [ ] When a function with no steps errors but recovers before exhausting retries, create a separate "Function errored" node

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

## Related

- INN-2864

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
