### PR TITLE
INN-2858 INN-2859 Add sync validation rules for multiple triggers

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -52,6 +52,9 @@ const (
 	// MaxConcurrencyLimits limits the max concurrency constraints for a specific function.
 	MaxConcurrencyLimits = 2
 
+	// MaxTriggers represents the maximum number of triggers a function can have.
+	MaxTriggers = 10
+
 	// MaxBatchTTL represents the maximum amount of duration the batch key will last
 	MaxBatchTTL = 10 * time.Minute
 

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -162,6 +162,12 @@ func (f Function) Validate(ctx context.Context) error {
 		}
 	}
 
+	if len(f.Triggers) < 1 {
+		err = multierror.Append(err, fmt.Errorf("At least one trigger is required"))
+	} else if len(f.Triggers) > consts.MaxTriggers {
+		err = multierror.Append(err, fmt.Errorf("This function exceeds the max number of triggers: %d", consts.MaxTriggers))
+	}
+
 	for _, t := range f.Triggers {
 		if terr := t.Validate(ctx); terr != nil {
 			err = multierror.Append(err, terr)

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -65,7 +65,7 @@ type Function struct {
 	Debounce *Debounce `json:"debounce,omitempty"`
 
 	// Trigger represnets the trigger for the function.
-	Triggers []Trigger `json:"triggers"`
+	Triggers MultipleTriggers `json:"triggers"`
 
 	// EventBatch determines how the function will process a list of incoming events
 	EventBatch *EventBatchConfig `json:"batchEvents,omitempty"`
@@ -162,16 +162,8 @@ func (f Function) Validate(ctx context.Context) error {
 		}
 	}
 
-	if len(f.Triggers) < 1 {
-		err = multierror.Append(err, fmt.Errorf("At least one trigger is required"))
-	} else if len(f.Triggers) > consts.MaxTriggers {
-		err = multierror.Append(err, fmt.Errorf("This function exceeds the max number of triggers: %d", consts.MaxTriggers))
-	}
-
-	for _, t := range f.Triggers {
-		if terr := t.Validate(ctx); terr != nil {
-			err = multierror.Append(err, terr)
-		}
+	if terr := f.Triggers.Validate(ctx); terr != nil {
+		err = multierror.Append(err, terr)
 	}
 
 	if f.EventBatch != nil {


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

Adds validation for multiple triggers when syncing.

- Must have at least 1 trigger
- Must have a maximum of 10 triggers
- Cannot have duplicate triggers

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- INN-2858
- INN-2859

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
