### PR TITLE
Hide replay buttons for internal events

### DIFF
--- a/ui/packages/components/src/EventDetails/EventDetails.tsx
+++ b/ui/packages/components/src/EventDetails/EventDetails.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { Badge } from '@inngest/components/Badge/Badge';
 import { Button } from '@inngest/components/Button';
 import { CodeBlock, type CodeBlockAction } from '@inngest/components/CodeBlock';
@@ -60,7 +61,7 @@ export function EventDetails({
   codeBlockActions = [],
   loading = false,
 }: Props) {
-  let singleEvent = undefined;
+  let singleEvent: NonNullable<typeof events>[number] | undefined = undefined;
   if (!batchID && events?.length === 1) {
     singleEvent = events[0];
   }
@@ -69,6 +70,10 @@ export function EventDetails({
   if (batchID) {
     batch = events;
   }
+
+  const isInternalEvent = useMemo(() => {
+    return Boolean(singleEvent?.name?.startsWith('inngest/'));
+  }, [singleEvent]);
 
   let prettyPayload = undefined;
   if (singleEvent && singleEvent.payload) {
@@ -127,7 +132,7 @@ export function EventDetails({
       }
       button={
         <>
-          {singleEvent && onReplayEvent && SendEventButton && (
+          {!isInternalEvent && onReplayEvent && SendEventButton && (
             <>
               <div className="flex items-center gap-1">
                 <Button label="Replay" btnAction={onReplayEvent} />

--- a/ui/packages/components/src/EventDetails/EventDetails.tsx
+++ b/ui/packages/components/src/EventDetails/EventDetails.tsx
@@ -71,10 +71,7 @@ export function EventDetails({
     batch = events;
   }
 
-  const isInternalEvent = useMemo(() => {
-    return Boolean(singleEvent?.name?.startsWith('inngest/'));
-  }, [singleEvent]);
-
+  const isInternalEvent = Boolean(singleEvent?.name?.startsWith('inngest/'));
   let prettyPayload = undefined;
   if (singleEvent && singleEvent.payload) {
     prettyPayload = usePrettyJson(singleEvent.payload);


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

When viewing an internal event run such as `inngest/function.invoked`, hide the replay buttons, as they will not work.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
