### PR TITLE
Fix swallowed error on apps page

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/Apps.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/Apps.tsx
@@ -20,10 +20,7 @@ export function Apps({ isArchived = false }: Props) {
 
   const res = useApps({ envID: env.id, isArchived });
   if (res.error) {
-    if (!res.data) {
-      throw res.error;
-    }
-    console.error(res.error);
+    throw res.error;
   }
   if (res.isLoading && !res.data) {
     return (


### PR DESCRIPTION
## Description
Fix the apps page showing 0 apps when there's a GraphQL error.

It turns out a GraphQL query can return data _and_ errors. This bug happened because we'd ignore query errors if there was query data, but depending on what data is missing we wouldn't render any app cards. Specifically, when `app.latestSync === null` we wouldn't render any cards, so an error in the `latestSync` resolve would still return app data but we wouldn't render any of it

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
