### PR TITLE
Add cancelRun mutation

### DIFF
--- a/pkg/coreapi/coreapi.go
+++ b/pkg/coreapi/coreapi.go
@@ -16,6 +16,7 @@ import (
 	"github.com/inngest/inngest/pkg/coreapi/generated"
 	"github.com/inngest/inngest/pkg/coreapi/graph/resolvers"
 	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/runner"
 	"github.com/inngest/inngest/pkg/execution/state"
@@ -37,6 +38,7 @@ type Options struct {
 	State        state.Manager
 	Queue        queue.JobQueueReader
 	EventHandler api.EventHandler
+	Executor     execution.Executor
 }
 
 func NewCoreApi(o Options) (*CoreAPI, error) {
@@ -67,6 +69,7 @@ func NewCoreApi(o Options) (*CoreAPI, error) {
 		Runner:        o.Runner,
 		Queue:         o.Queue,
 		EventHandler:  o.EventHandler,
+		Executor:      o.Executor,
 	}}))
 
 	// TODO - Add option for enabling GraphQL Playground

--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -143,6 +143,7 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
+		CancelRun       func(childComplexity int, runID ulid.ULID) int
 		CreateApp       func(childComplexity int, input models.CreateAppInput) int
 		DeleteApp       func(childComplexity int, id string) int
 		DeleteAppByName func(childComplexity int, name string) int
@@ -294,6 +295,7 @@ type MutationResolver interface {
 	DeleteApp(ctx context.Context, id string) (string, error)
 	DeleteAppByName(ctx context.Context, name string) (bool, error)
 	InvokeFunction(ctx context.Context, data map[string]interface{}, functionSlug string) (*bool, error)
+	CancelRun(ctx context.Context, runID ulid.ULID) (*models.FunctionRun, error)
 }
 type QueryResolver interface {
 	Apps(ctx context.Context) ([]*cqrs.App, error)
@@ -774,6 +776,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.FunctionVersion.Version(childComplexity), true
+
+	case "Mutation.cancelRun":
+		if e.complexity.Mutation.CancelRun == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_cancelRun_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.CancelRun(childComplexity, args["runID"].(ulid.ULID)), true
 
 	case "Mutation.createApp":
 		if e.complexity.Mutation.CreateApp == nil {
@@ -1384,6 +1398,8 @@ type Mutation {
     data: Map
     functionSlug: String!
   ): Boolean
+
+  cancelRun(runID: ULID!): FunctionRun!
 }
 
 input CreateAppInput {
@@ -1761,6 +1777,21 @@ func (ec *executionContext) field_FunctionRun_historyItemOutput_args(ctx context
 		}
 	}
 	args["id"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_cancelRun_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 ulid.ULID
+	if tmp, ok := rawArgs["runID"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("runID"))
+		arg0, err = ec.unmarshalNULID2githubᚗcomᚋoklogᚋulidᚋv2ᚐULID(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["runID"] = arg0
 	return args, nil
 }
 
@@ -5251,6 +5282,97 @@ func (ec *executionContext) fieldContext_Mutation_invokeFunction(ctx context.Con
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_invokeFunction_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_cancelRun(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_cancelRun(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Mutation().CancelRun(rctx, fc.Args["runID"].(ulid.ULID))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.FunctionRun)
+	fc.Result = res
+	return ec.marshalNFunctionRun2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionRun(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_cancelRun(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_FunctionRun_id(ctx, field)
+			case "functionID":
+				return ec.fieldContext_FunctionRun_functionID(ctx, field)
+			case "function":
+				return ec.fieldContext_FunctionRun_function(ctx, field)
+			case "workspace":
+				return ec.fieldContext_FunctionRun_workspace(ctx, field)
+			case "event":
+				return ec.fieldContext_FunctionRun_event(ctx, field)
+			case "events":
+				return ec.fieldContext_FunctionRun_events(ctx, field)
+			case "batchID":
+				return ec.fieldContext_FunctionRun_batchID(ctx, field)
+			case "batchCreatedAt":
+				return ec.fieldContext_FunctionRun_batchCreatedAt(ctx, field)
+			case "status":
+				return ec.fieldContext_FunctionRun_status(ctx, field)
+			case "waitingFor":
+				return ec.fieldContext_FunctionRun_waitingFor(ctx, field)
+			case "pendingSteps":
+				return ec.fieldContext_FunctionRun_pendingSteps(ctx, field)
+			case "startedAt":
+				return ec.fieldContext_FunctionRun_startedAt(ctx, field)
+			case "finishedAt":
+				return ec.fieldContext_FunctionRun_finishedAt(ctx, field)
+			case "output":
+				return ec.fieldContext_FunctionRun_output(ctx, field)
+			case "history":
+				return ec.fieldContext_FunctionRun_history(ctx, field)
+			case "historyItemOutput":
+				return ec.fieldContext_FunctionRun_historyItemOutput(ctx, field)
+			case "eventID":
+				return ec.fieldContext_FunctionRun_eventID(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FunctionRun", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_cancelRun_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -11330,6 +11452,15 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 				return ec._Mutation_invokeFunction(ctx, field)
 			})
 
+		case "cancelRun":
+
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_cancelRun(ctx, field)
+			})
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -12589,6 +12720,10 @@ func (ec *executionContext) marshalNFunction2ᚖgithubᚗcomᚋinngestᚋinngest
 		return graphql.Null
 	}
 	return ec._Function(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNFunctionRun2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionRun(ctx context.Context, sel ast.SelectionSet, v models.FunctionRun) graphql.Marshaler {
+	return ec._FunctionRun(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalNFunctionRun2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionRun(ctx context.Context, sel ast.SelectionSet, v *models.FunctionRun) graphql.Marshaler {

--- a/pkg/coreapi/gql.mutations.graphql
+++ b/pkg/coreapi/gql.mutations.graphql
@@ -10,6 +10,8 @@ type Mutation {
     data: Map
     functionSlug: String!
   ): Boolean
+
+  cancelRun(runID: ULID!): FunctionRun!
 }
 
 input CreateAppInput {

--- a/pkg/coreapi/graph/resolvers/resolver.go
+++ b/pkg/coreapi/graph/resolvers/resolver.go
@@ -6,6 +6,7 @@ import (
 	"github.com/inngest/inngest/pkg/api"
 	"github.com/inngest/inngest/pkg/coreapi/generated"
 	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/runner"
 	"github.com/inngest/inngest/pkg/history_reader"
@@ -17,6 +18,7 @@ type Resolver struct {
 	Runner        runner.Runner
 	Queue         queue.JobQueueReader
 	EventHandler  api.EventHandler
+	Executor      execution.Executor
 }
 
 // Query returns generated.QueryResolver implementation.

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -114,6 +114,7 @@ func (d *devserver) Pre(ctx context.Context) error {
 		State:        d.state,
 		Queue:        d.queue,
 		EventHandler: d.handleEvent,
+		Executor:     d.executor,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
Add a `cancelRun` mutation that the Dev Server UI will use to cancel function runs. This mutation is almost identical to the one in Cloud (https://github.com/inngest/monorepo/pull/2475), but it doesn't do auth and isn't concerned with account or workspace IDs.

Added `execution.Executor` as a GraphQL dependency, since it's needed to cancel runs

## Motivation
Groundwork for the "cancel run" button

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
