### PR TITLE
INN-2879 Fix Dev Server ingestion returning external IDs

### DIFF
--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -2,7 +2,6 @@ package devserver
 
 import (
 	"context"
-	"crypto/rand"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -36,7 +35,6 @@ import (
 	"github.com/inngest/inngest/pkg/sdk"
 	"github.com/inngest/inngest/pkg/service"
 	"github.com/mattn/go-isatty"
-	"github.com/oklog/ulid/v2"
 )
 
 const (
@@ -284,20 +282,20 @@ func (d *devserver) handleEvent(ctx context.Context, e *event.Event) (string, er
 
 	l.Debug().Str("event", e.Name).Msg("handling event")
 
-	internalID := ulid.MustNew(ulid.Now(), rand.Reader)
+	trackedEvent := event.NewOSSTrackedEvent(*e)
 
-	if e.ID == "" {
-		// Always ensure that the event has an ID, for idempotency.
-		e.ID = internalID.String()
-	}
-
-	byt, err := json.Marshal(e)
+	byt, err := json.Marshal(trackedEvent)
 	if err != nil {
 		l.Error().Err(err).Msg("error unmarshalling event as JSON")
 		return "", err
 	}
 
-	l.Info().Str("event_name", e.Name).Str("id", e.ID).Interface("event", e).Msg("publishing event")
+	l.Info().
+		Str("event_name", trackedEvent.GetEvent().Name).
+		Str("internal_id", trackedEvent.GetInternalID().String()).
+		Str("external_id", trackedEvent.GetEvent().ID).
+		Interface("event", trackedEvent.GetEvent()).
+		Msg("publishing event")
 
 	err = d.publisher.Publish(
 		ctx,
@@ -309,7 +307,7 @@ func (d *devserver) handleEvent(ctx context.Context, e *event.Event) (string, er
 		},
 	)
 
-	return e.ID, err
+	return trackedEvent.GetInternalID().String(), err
 }
 
 // SDKHandler represents a handler that has registered with the dev server.

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -138,22 +138,31 @@ func NewOSSTrackedEvent(e Event) TrackedEvent {
 		e.ID = internalID.String()
 	}
 	return ossTrackedEvent{
-		id:    internalID,
-		event: e,
+		Id:    internalID,
+		Event: e,
 	}
 }
 
+func NewOSSTrackedEventFromString(data string) (*ossTrackedEvent, error) {
+	evt := &ossTrackedEvent{}
+	if err := json.Unmarshal([]byte(data), evt); err != nil {
+		return nil, err
+	}
+
+	return evt, nil
+}
+
 type ossTrackedEvent struct {
-	id    ulid.ULID
-	event Event
+	Id    ulid.ULID `json:"internal_id"`
+	Event Event     `json:"event"`
 }
 
 func (o ossTrackedEvent) GetEvent() Event {
-	return o.event
+	return o.Event
 }
 
 func (o ossTrackedEvent) GetInternalID() ulid.ULID {
-	return o.id
+	return o.Id
 }
 
 func (o ossTrackedEvent) GetWorkspaceID() uuid.UUID {

--- a/pkg/event/mgr_legacy.go
+++ b/pkg/event/mgr_legacy.go
@@ -3,19 +3,19 @@ package event
 import "sync"
 
 type Manager struct {
-	events map[string]Event
+	events map[string]TrackedEvent
 	l      *sync.RWMutex
 }
 
 func NewManager() Manager {
 	return Manager{
-		events: make(map[string]Event),
+		events: make(map[string]TrackedEvent),
 		l:      &sync.RWMutex{},
 	}
 }
 
 // Fetch an individual event by its ID.
-func (e Manager) EventById(id string) *Event {
+func (e Manager) EventById(id string) TrackedEvent {
 	e.l.RLock()
 	defer e.l.RUnlock()
 
@@ -24,18 +24,18 @@ func (e Manager) EventById(id string) *Event {
 		return nil
 	}
 
-	return &evt
+	return evt
 }
 
 // Fetch all events with a given name.
-func (e Manager) EventsByName(name string) []Event {
+func (e Manager) EventsByName(name string) []TrackedEvent {
 	e.l.RLock()
 	defer e.l.RUnlock()
 
-	events := []Event{}
+	events := []TrackedEvent{}
 
 	for _, evt := range e.events {
-		if evt.Name == name {
+		if evt.GetEvent().Name == name {
 			events = append(events, evt)
 		}
 	}
@@ -45,11 +45,11 @@ func (e Manager) EventsByName(name string) []Event {
 }
 
 // Fetch all events.
-func (e Manager) Events() []Event {
+func (e Manager) Events() []TrackedEvent {
 	e.l.RLock()
 	defer e.l.RUnlock()
 
-	events := []Event{}
+	events := []TrackedEvent{}
 
 	for _, evt := range e.events {
 		events = append(events, evt)
@@ -59,16 +59,16 @@ func (e Manager) Events() []Event {
 }
 
 // Parse and create a new event, adding it to the in-memory map as we go.
-func (e Manager) NewEvent(data string) (*Event, error) {
+func (e Manager) NewEvent(data string) (TrackedEvent, error) {
 	e.l.Lock()
 	defer e.l.Unlock()
 
-	evt, err := NewEvent(data)
+	evt, err := NewOSSTrackedEventFromString(data)
 	if err != nil {
 		return nil, err
 	}
 
-	e.events[evt.ID] = *evt
+	e.events[evt.GetInternalID().String()] = *evt
 
 	return evt, err
 }

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -136,7 +136,8 @@ func (s *svc) getFinishHandler(ctx context.Context) (func(context.Context, state
 		for _, e := range events {
 			evt := e
 			eg.Go(func() error {
-				byt, err := json.Marshal(evt)
+				trackedEvent := event.NewOSSTrackedEvent(evt)
+				byt, err := json.Marshal(trackedEvent)
 				if err != nil {
 					return fmt.Errorf("error marshalling event: %w", err)
 				}
@@ -147,7 +148,7 @@ func (s *svc) getFinishHandler(ctx context.Context) (func(context.Context, state
 					pubsub.Message{
 						Name:      event.EventReceivedName,
 						Data:      string(byt),
-						Timestamp: evt.Time(),
+						Timestamp: trackedEvent.GetEvent().Time(),
 					},
 				)
 				if err != nil {


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

The return value of the ingestion endpoint on the Dev Server contains an `ids` property, which is an array of IDs for events created as a result of the request.

Following #1213, which correctly fixes UIs not using internal IDs, if an `id` is specified in an event, it will be the same ID returned from the endpoint. This is incorrect, as we should always return the internal IDs from ingestion.

| ID given | Before PR | After PR |
| -------- | --------- | -------- |
| None | Internal | Internal |
| Populated string | Custom | Internal |

This PR moves the creation of the internal ID to the point of ingestion, allowing the endpoint to correctly return the internal ID after it's been pushed to pubsub. This also matches Cloud.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- INN-2879
- #1213
- Unblocks inngest/inngest-js#518

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
