### PR TITLE
Add CreatedAt and Name to Cancellation

### DIFF
--- a/pkg/cqrs/cancellations.go
+++ b/pkg/cqrs/cancellations.go
@@ -35,6 +35,8 @@ type CancellationWriter interface {
 
 // Cancellation represents a cancellation of many function runs during the time specified.
 type Cancellation struct {
+	CreatedAt   time.Time `json:"created_at"`
+	Name        *string   `json:"name"`
 	ID          ulid.ULID `json:"id"`
 	WorkspaceID uuid.UUID `json:"environment_id"`
 	// FunctionID represents the function's internal ID.


### PR DESCRIPTION
## Description
Add `CreatedAt` and `Name` fields to `Cancellation`.

`CreateCancellationBody` is unchanged, so users are not able to specify these fields via the REST API

## Motivation
This is necessary for implementing the bulk cancellation UI in Cloud.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
