### PR TITLE
Change duplicate sync status text and icon

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/Sync/Sync.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/Sync/Sync.tsx
@@ -53,7 +53,7 @@ export function Sync({ externalAppID, syncID }: Props) {
         {sync.error && <SyncErrorCard className="mb-4" error={sync.error} />}
 
         {sync.status === 'duplicate' && (
-          <Alert severity="info">
+          <Alert className="mb-4" severity="info">
             No changes detected since the previous sync. Function bodies may have changed, but those
             are not inspected when syncing.
           </Alert>

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/Sync/Sync.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/Sync/Sync.tsx
@@ -54,8 +54,8 @@ export function Sync({ externalAppID, syncID }: Props) {
 
         {sync.status === 'duplicate' && (
           <Alert className="mb-4" severity="info">
-            No changes detected since the previous sync. Function bodies may have changed, but those
-            are not inspected when syncing.
+            Function configurations have not changed since the last successful sync. Logic in
+            function handlers may have changed, but they are not inspecting when syncing.
           </Alert>
         )}
 

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/Sync/Sync.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/Sync/Sync.tsx
@@ -7,7 +7,6 @@ import { useEnvironment } from '@/app/(organization-active)/(dashboard)/env/[env
 import { AppGitCard } from '@/components/AppGitCard/AppGitCard';
 import { AppInfoCard } from '@/components/AppInfoCard';
 import { SyncErrorCard } from '@/components/SyncErrorCard';
-import { SyncStatus } from '@/gql/graphql';
 import { FunctionList } from './FunctionList';
 import { useSync } from './useSync';
 
@@ -48,34 +47,25 @@ export function Sync({ externalAppID, syncID }: Props) {
   const { app } = syncRes.data.environment;
   const { sync } = syncRes.data;
 
-  let functions = null;
-  if (sync.status === SyncStatus.Success) {
-    functions = (
-      <FunctionList
-        removedFunctions={sync.removedFunctions}
-        syncedFunctions={sync.syncedFunctions}
-      />
-    );
-    // TODO: Replace with SyncStatus.duplicate after we deploy the API changes
-  } else if (sync.status === 'duplicate') {
-    functions = (
-      <Alert severity="info">
-        This sync is a duplicate because none of the function configurations changed since the
-        previous successful sync. If you would like to view its functions, please navigate to the
-        previous successful sync.
-      </Alert>
-    );
-  }
-
   return (
     <div className="h-full w-full overflow-y-auto">
       <div className="mx-auto w-full max-w-[1200px] p-4">
         {sync.error && <SyncErrorCard className="mb-4" error={sync.error} />}
 
+        {sync.status === 'duplicate' && (
+          <Alert severity="info">
+            No changes detected since the previous sync. Function bodies may have changed, but those
+            are not inspected when syncing.
+          </Alert>
+        )}
+
         <AppInfoCard app={app} className="mb-4" sync={sync} linkToSyncs />
         <AppGitCard className="mb-4" sync={sync} />
 
-        {functions}
+        <FunctionList
+          removedFunctions={sync.removedFunctions}
+          syncedFunctions={sync.syncedFunctions}
+        />
       </div>
     </div>
   );

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/SyncList.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/SyncList.tsx
@@ -67,7 +67,7 @@ export function SyncList({
                 onClick={() => onClick(sync.id)}
               >
                 <div className="flex items-center">
-                  <div className="hidden w-36 p-4 align-middle lg:block">
+                  <div className="hidden w-40 p-4 align-middle lg:block">
                     <SyncStatusPill status={sync.status} />
                   </div>
                   <div className="px-2 py-4 align-middle lg:hidden">

--- a/ui/apps/dashboard/src/components/SyncStatusPill.tsx
+++ b/ui/apps/dashboard/src/components/SyncStatusPill.tsx
@@ -1,18 +1,17 @@
 import { CheckIcon, ExclamationTriangleIcon, MinusIcon } from '@heroicons/react/20/solid';
-import { IconDuplicate } from '@inngest/components/icons/Duplicate';
 import { IconStatusRunning } from '@inngest/components/icons/status/Running';
 import { type SyncStatus } from '@inngest/components/types/sync';
 import { cn } from '@inngest/components/utils/classNames';
 
 const syncStatusIcons: Record<string, React.ComponentType> = {
-  duplicate: IconDuplicate,
+  duplicate: CheckIcon,
   error: ExclamationTriangleIcon,
   pending: IconStatusRunning,
   success: CheckIcon,
 } as const satisfies { [key in SyncStatus]: unknown };
 
 const syncStatusText: Record<string, string> = {
-  duplicate: 'Duplicate',
+  duplicate: 'No change',
   error: 'Error',
   pending: 'Syncing',
   success: 'Success',

--- a/ui/apps/dashboard/src/components/SyncStatusPill.tsx
+++ b/ui/apps/dashboard/src/components/SyncStatusPill.tsx
@@ -11,7 +11,7 @@ const syncStatusIcons: Record<string, React.ComponentType> = {
 } as const satisfies { [key in SyncStatus]: unknown };
 
 const syncStatusText: Record<string, string> = {
-  duplicate: 'No change',
+  duplicate: 'No Change',
   error: 'Error',
   pending: 'Syncing',
   success: 'Success',


### PR DESCRIPTION
## Description
- Change duplicate sync status text to "No Change"
- Change duplicate sync icon to match success' icon
- Change duplicate sync alert text and move it to the top of the page

## Context
The backend doesn't create syncs with the "duplicate" status yet. That'll happen in this PR: https://github.com/inngest/monorepo/pull/2458

## Testing
![image](https://github.com/inngest/inngest/assets/20100586/de03e0a0-9ba4-427a-af87-149c583a1d3f)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
