### PR TITLE
Hotfix: Vercel integration empty state

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/page.tsx
@@ -14,7 +14,12 @@ export default function VercelIntegrationPage() {
     );
   }
   if (error) {
-    throw error;
+    // HACK - This is a hack as we don't have error codes,
+    // match against the error message
+    if (!error.message.match(/(haven't integrated with Vercel yet)/gi)) {
+      console.log(error);
+      throw error;
+    }
   }
   return <VercelIntegrationForm vercelIntegration={data} />;
 }

--- a/ui/apps/dashboard/src/utils/useRestAPIRequest.ts
+++ b/ui/apps/dashboard/src/utils/useRestAPIRequest.ts
@@ -42,7 +42,13 @@ export function useRestAPIRequest<T>({
       if (!response.ok || response.status >= 400) {
         setData(null);
         setIsLoading(false);
-        return setError(new Error(response.statusText));
+        try {
+          const data = await response.json();
+          const error = data.error || response.statusText;
+          return setError(new Error(error));
+        } catch (err) {
+          return setError(new Error(response.statusText));
+        }
       }
       const data = await response.json();
 


### PR DESCRIPTION
## Description

Fix handling the REST API's response of a 400 to show blank state. Follows #1244.

## Motivation

Users without the Vercel integration installed saw an empty error page.

```json
{
    "code": "",
    "data": null,
    "error": "You haven't integrated with Vercel yet.",
    "status": 400
}
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
