### PR TITLE
Remove RSC on environments page

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/page.tsx
@@ -8,6 +8,7 @@ import { Button } from '@inngest/components/Button';
 import AppLink from '@/components/AppLink';
 import AppNavigation from '@/components/Navigation/AppNavigation';
 import Toaster from '@/components/Toaster';
+import LoadingIcon from '@/icons/LoadingIcon';
 import { useEnvironments } from '@/queries';
 import { EnvironmentType, LEGACY_TEST_MODE_NAME } from '@/utils/environments';
 import { EnvironmentArchiveButton } from './EnvironmentArchiveButton';
@@ -19,7 +20,11 @@ export default function Envs() {
     throw error;
   }
   if (fetching) {
-    return null;
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <LoadingIcon />
+      </div>
+    );
   }
   if (!environments) {
     // Unreachable

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { type Route } from 'next';
 import Link from 'next/link';
 import { ExclamationTriangleIcon } from '@heroicons/react/20/solid';
@@ -6,13 +8,23 @@ import { Button } from '@inngest/components/Button';
 import AppLink from '@/components/AppLink';
 import AppNavigation from '@/components/Navigation/AppNavigation';
 import Toaster from '@/components/Toaster';
-import getAllEnvironments from '@/queries/server-only/getAllEnvironments';
+import { useEnvironments } from '@/queries';
 import { EnvironmentType, LEGACY_TEST_MODE_NAME } from '@/utils/environments';
 import { EnvironmentArchiveButton } from './EnvironmentArchiveButton';
 import EnvironmentListTable from './EnvironmentListTable';
 
-export default async function Envs() {
-  const environments = await getAllEnvironments();
+export default function Envs() {
+  const [{ data: environments, fetching, error }] = useEnvironments();
+  if (error) {
+    throw error;
+  }
+  if (fetching) {
+    return null;
+  }
+  if (!environments) {
+    // Unreachable
+    throw new Error('No data');
+  }
 
   // Break the environments into different groups
   const legacyTestMode = environments.find(

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/page.tsx
@@ -28,7 +28,9 @@ export default function Envs() {
   }
   if (!environments) {
     // Unreachable
-    throw new Error('No data');
+    throw new Error(
+      'Unable to load environments. Please try again or contact support if this continues.'
+    );
   }
 
   // Break the environments into different groups

--- a/ui/apps/dashboard/src/components/Navigation/AppNavigation.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/AppNavigation.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { type Route } from 'next';
 import Link from 'next/link';
 import {
@@ -8,7 +10,7 @@ import {
 } from '@heroicons/react/20/solid';
 import { Badge } from '@inngest/components/Badge';
 
-import { getBooleanFlag } from '@/components/FeatureFlags/ServerFeatureFlag';
+import { useBooleanFlag } from '@/components/FeatureFlags/hooks';
 import OrganizationDropdown from '@/components/Navigation/OrganizationDropdown';
 import UserDropdown from '@/components/Navigation/UserDropdown';
 import InngestLogo from '@/icons/InngestLogo';
@@ -32,8 +34,8 @@ type NavItem = {
 const ALL_ENVIRONMENTS_SLUG = 'all';
 const BRANCH_PARENT_SLUG = 'branch';
 
-export default async function AppNavigation({ environmentSlug }: AppNavigationProps) {
-  const isEventSearchEnabled = await getBooleanFlag('event-search');
+export default function AppNavigation({ environmentSlug }: AppNavigationProps) {
+  const { value: isEventSearchEnabled } = useBooleanFlag('event-search');
 
   let items: NavItem[] = [
     {


### PR DESCRIPTION
## Description
Switch envs page to `"use client"`. This fixes a cache bug where stale data would display when navigating away and back to the environments page

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
