### PR TITLE
Add bulk cancellation UI

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/cancellation/CancellationList.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/cancellation/CancellationList.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import React, { useRef } from 'react';
+import { ExclamationCircleIcon } from '@heroicons/react/20/solid';
+import { Link } from '@inngest/components/Link';
+import { Table } from '@inngest/components/Table';
+import { createColumnHelper, getCoreRowModel } from '@tanstack/react-table';
+
+import { Time } from '@/components/Time';
+import { graphql } from '@/gql';
+import LoadingIcon from '@/icons/LoadingIcon';
+import { useGraphQLQuery } from '@/utils/useGraphQLQuery';
+
+const GetCancellationsDocument = graphql(`
+  query GetCancellations($envID: ID!, $fnID: ID!) {
+    environment: workspace(id: $envID) {
+      function: workflow(id: $fnID) {
+        cancellations {
+          createdAt
+          expression
+          id
+          name
+          queuedAtMax
+          queuedAtMin
+        }
+      }
+    }
+  }
+`);
+
+const columnHelper = createColumnHelper<{
+  createdAt: Date;
+  expression: string | null;
+  name: string | null;
+  queuedAtMax: Date;
+  queuedAtMin: Date | null;
+}>();
+
+const columns = [
+  columnHelper.accessor('name', {
+    header: () => <span>Replay Name</span>,
+    cell: (props) => {
+      return props.getValue();
+    },
+  }),
+  columnHelper.accessor('createdAt', {
+    header: () => <span>Created At</span>,
+    cell: (props) => {
+      return <Time value={props.getValue()} />;
+    },
+  }),
+  columnHelper.accessor('queuedAtMin', {
+    header: () => <span>Queued At Minimum</span>,
+    cell: (props) => {
+      const value = props.getValue();
+      if (!value) {
+        return null;
+      }
+
+      return <Time value={value} />;
+    },
+  }),
+  columnHelper.accessor('queuedAtMax', {
+    header: () => <span>Queued At Maximum</span>,
+    cell: (props) => {
+      return <Time value={props.getValue()} />;
+    },
+  }),
+  columnHelper.accessor('expression', {
+    header: () => <span>Expression</span>,
+    cell: (props) => {
+      return props.getValue();
+    },
+  }),
+];
+
+type Props = {
+  envID: string;
+  fnID: string;
+};
+
+export function CancellationList({ envID, fnID }: Props) {
+  const { data, isLoading, error } = useGraphQLQuery({
+    query: GetCancellationsDocument,
+    variables: {
+      envID,
+      fnID,
+    },
+    pollIntervalInMilliseconds: 5_000,
+  });
+
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+
+  if (isLoading && !data) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <LoadingIcon />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-5">
+        <div className="inline-flex items-center gap-2 text-red-600">
+          <ExclamationCircleIcon className="h-4 w-4" />
+          <h2 className="text-sm">Could not load replays</h2>
+        </div>
+      </div>
+    );
+  }
+
+  const cancellations = data.environment.function?.cancellations?.map((c) => {
+    return {
+      ...c,
+      createdAt: new Date(c.createdAt),
+      queuedAtMax: new Date(c.queuedAtMax),
+      queuedAtMin: c.queuedAtMin ? new Date(c.queuedAtMin) : null,
+    };
+  });
+  if (!cancellations) {
+    throw new Error('Cancellations not found');
+  }
+
+  return (
+    <Table
+      tableContainerRef={tableContainerRef}
+      options={{
+        data: cancellations,
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+        enableSorting: false,
+      }}
+      blankState={
+        <p>
+          You have no replays for this function.{' '}
+          <Link className="inline-flex" href="https://inngest.com/docs/platform/replay">
+            Learn about Replay
+          </Link>
+        </p>
+      }
+    />
+  );
+}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/cancellation/CreateCancellationButton.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/cancellation/CreateCancellationButton.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Button } from '@inngest/components/Button';
+import { IconStatusCanceled } from '@inngest/components/icons/status/Canceled';
+
+import { CreateCancellationModal } from './CreateCancellationModal';
+
+type Props = {
+  onSubmit: React.ComponentProps<typeof CreateCancellationModal>['onSubmit'];
+};
+
+export function CreateCancellationButton({ onSubmit }: Props) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        btnAction={() => setIsModalOpen(true)}
+        icon={<IconStatusCanceled className="h-5 w-5 text-white" />}
+        kind="primary"
+        label="New Cancellation"
+      />
+      <CreateCancellationModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onSubmit={async (data) => {
+          await onSubmit(data);
+          setIsModalOpen(false);
+        }}
+      />
+    </>
+  );
+}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/cancellation/CreateCancellationModal.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/cancellation/CreateCancellationModal.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useState } from 'react';
+import { Alert } from '@inngest/components/Alert';
+import { Button } from '@inngest/components/Button';
+import { Link } from '@inngest/components/Link';
+import { Modal } from '@inngest/components/Modal';
+import { toast } from 'sonner';
+
+import Input from '@/components/Forms/Input';
+import { TimeInput } from '@/components/TimeRangeInput/TimeInput';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (args: {
+    expression: string | undefined;
+    name: string | undefined;
+    queuedAtMax: Date;
+    queuedAtMin: Date | undefined;
+  }) => Promise<void>;
+};
+
+export function CreateCancellationModal(props: Props) {
+  const { isOpen } = props;
+  const [error, setError] = useState<string>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [expression, setExpression] = useState<string>();
+  const [name, setName] = useState<string>();
+  const [queuedAtMax, setQueuedAtMax] = useState<Date>();
+  const [queuedAtMin, setQueuedAtMin] = useState<Date>();
+
+  function onClose() {
+    props.onClose();
+    setError(undefined);
+    setExpression(undefined);
+    setName(undefined);
+    setQueuedAtMin(undefined);
+    setQueuedAtMax(undefined);
+  }
+
+  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsLoading(true);
+    try {
+      if (!queuedAtMax) {
+        throw new Error('Queued before time is required');
+      }
+      if (queuedAtMin && queuedAtMin > queuedAtMax) {
+        throw new Error('Queued after time must be before queued before time');
+      }
+
+      await props.onSubmit({ expression, name, queuedAtMax, queuedAtMin });
+      toast.success('Created cancellation');
+      setError(undefined);
+      setExpression(undefined);
+      setName(undefined);
+      setQueuedAtMin(undefined);
+      setQueuedAtMax(undefined);
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        setError('Unknown error');
+        return;
+      }
+
+      setError(error.message);
+      throw error;
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Modal className="w-full max-w-3xl" isOpen={isOpen} onClose={onClose}>
+      <Modal.Header description="Cancel multiple function runs in bulk">
+        Create Cancellation
+      </Modal.Header>
+
+      <form onSubmit={onSubmit}>
+        <Modal.Body className="m-0">
+          <Alert className="rounded-none" severity="info">
+            Cancellation may take a few minutes to complete. In the meantime, matching runs may
+            still have the {'"Running"'} status but they will eventually cancel.
+          </Alert>
+
+          <div className="divide-y divide-slate-100">
+            <div className="flex items-start p-6">
+              <label
+                htmlFor="cancellation-name"
+                className="flex-1 text-sm font-medium text-slate-700"
+              >
+                Cancellation Name
+                <p className="text-xs text-slate-500">
+                  Specify the name to identify the cancellation on the dashboard
+                </p>
+              </label>
+
+              <div className="flex-1">
+                <Input
+                  disablePasswordManager
+                  maxLength={64}
+                  name="cancellation-name"
+                  onChange={(event) => setName(event.target.value)}
+                  type="text"
+                />
+              </div>
+            </div>
+
+            <div>
+              <div className="flex items-start p-6">
+                <label
+                  htmlFor="queued-at-min"
+                  className="flex-1 text-sm font-medium text-slate-700"
+                >
+                  Queued Time Minimum
+                  <p className="text-xs text-slate-500">Include runs queued after this time</p>
+                </label>
+
+                <div className="flex-1">
+                  <TimeInput name="queued-at-min" onChange={(date) => setQueuedAtMin(date)} />
+                </div>
+              </div>
+
+              <div className="flex items-start p-6">
+                <label
+                  htmlFor="queued-at-max"
+                  className="flex-1 text-sm font-medium text-slate-700"
+                >
+                  Queued Time Maximum (Required)
+                  <p className="text-xs text-slate-500">Include runs queued before this time</p>
+                </label>
+
+                <div className="flex-1">
+                  <TimeInput
+                    name="queued-at-max"
+                    onChange={(date) => setQueuedAtMax(date)}
+                    placeholder="now"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="p-6">
+              <label htmlFor="expression" className="text-sm font-medium text-slate-700">
+                Expression
+                <p className="text-xs text-slate-500">
+                  Include runs whose event matches a{' '}
+                  <Link
+                    className="inline-flex"
+                    internalNavigation={false}
+                    href="https://www.inngest.com/docs/apps"
+                  >
+                    CEL expression
+                  </Link>
+                  .
+                </p>
+              </label>
+
+              <div className="mt-4">
+                <Input
+                  maxLength={1024}
+                  minLength={3}
+                  name="expression"
+                  onChange={(event) => setExpression(event.target.value)}
+                  placeholder="event.data.name == 'example'"
+                  type="text"
+                />
+              </div>
+            </div>
+          </div>
+        </Modal.Body>
+
+        <Modal.Footer>
+          {error && (
+            <Alert className="mb-6" severity="error">
+              {error}
+            </Alert>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button appearance="outlined" btnAction={onClose} disabled={isLoading} label="Close" />
+            <Button
+              appearance="solid"
+              disabled={isLoading}
+              kind="danger"
+              label="Submit"
+              loading={isLoading}
+              type="submit"
+            />
+          </div>
+        </Modal.Footer>
+      </form>
+    </Modal>
+  );
+}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/cancellation/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/cancellation/page.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import React from 'react';
+import { useMutation } from 'urql';
+
+import { useEnvironment } from '@/app/(organization-active)/(dashboard)/env/[environmentSlug]/environment-context';
+import { graphql } from '@/gql';
+import { useGraphQLQuery } from '@/utils/useGraphQLQuery';
+import { CancellationList } from './CancellationList';
+import { CreateCancellationButton } from './CreateCancellationButton';
+
+const CreateCancellationDocument = graphql(`
+  mutation CreateCancellation($input: CreateCancellationInput!) {
+    createCancellation(input: $input) {
+      id
+    }
+  }
+`);
+
+const GetFunctionCancellationPageDocument = graphql(`
+  query GetFunctionCancellationPage($envID: ID!, $fnSlug: String!) {
+    environment: workspace(id: $envID) {
+      function: workflowBySlug(slug: $fnSlug) {
+        id
+      }
+    }
+  }
+`);
+
+type Props = {
+  params: {
+    slug: string;
+  };
+};
+
+export default function Page({ params }: Props) {
+  const fnSlug = decodeURIComponent(params.slug);
+  const [, createCancellation] = useMutation(CreateCancellationDocument);
+  const envID = useEnvironment().id;
+
+  const fnRes = useGraphQLQuery({
+    query: GetFunctionCancellationPageDocument,
+    variables: { envID, fnSlug },
+  });
+  if (fnRes.error) {
+    throw fnRes.error;
+  }
+  if (fnRes.isLoading) {
+    return null;
+  }
+
+  const fnID = fnRes.data.environment.function?.id;
+  if (!fnID) {
+    throw new Error('Function not found');
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-end border-b border-slate-300 px-5 py-2">
+        <CreateCancellationButton
+          onSubmit={async (data) => {
+            const res = await createCancellation({
+              input: {
+                envID,
+                expression: data.expression,
+                functionID: fnID,
+                name: data.name,
+                queuedAtMax: data.queuedAtMax.toISOString(),
+                queuedAtMin: data.queuedAtMin?.toISOString(),
+              },
+            });
+            if (res.error) {
+              // Throw error so that the modal can catch and display it
+              throw res.error;
+            }
+          }}
+        />
+      </div>
+
+      <div className="overflow-y-auto">
+        <CancellationList envID={envID} fnID={fnID} />
+      </div>
+    </>
+  );
+}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/layout.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/layout.tsx
@@ -65,6 +65,18 @@ export default function FunctionLayout({ children, params }: FunctionLayoutProps
     });
   }
 
+  if (useBooleanFlag('bulk-cancellation-ui').value) {
+    navLinks.push({
+      href: `/env/${params.environmentSlug}/functions/${params.slug}/cancellation`,
+      text: 'Cancellation',
+      badge: (
+        <Badge kind="solid" className=" h-3.5 bg-indigo-500 px-[0.235rem] text-white">
+          New
+        </Badge>
+      ),
+    });
+  }
+
   const doesFunctionAcceptPayload =
     fn?.current?.triggers.some((trigger) => {
       return trigger.eventName;

--- a/ui/apps/dashboard/src/components/Forms/Input.tsx
+++ b/ui/apps/dashboard/src/components/Forms/Input.tsx
@@ -4,6 +4,7 @@ import cn from '@/utils/cn';
 
 type InputProps = {
   defaultValue?: HTMLAttributes<HTMLInputElement>['defaultValue'];
+  disablePasswordManager?: boolean;
   error?: string | undefined;
   name?: string;
   id?: string;
@@ -33,6 +34,17 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   const size = props.size === undefined ? 'base' : props.size;
   const placeholder = props.placeholder === undefined ? '' : props.placeholder;
   const className = props.className === undefined ? '' : props.className;
+
+  let pwManagerProps = {};
+  if (props.disablePasswordManager) {
+    // https://www.stefanjudis.com/snippets/turn-off-password-managers
+    pwManagerProps = {
+      'data-1p-ignore': 'true', // 1Password
+      'data-lpignore': 'true', // LastPass
+      'data-bwignore': 'true', // Bitwarden
+    };
+  }
+
   return (
     <div className="flex flex-col gap-1">
       {props.label && (
@@ -41,6 +53,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         </label>
       )}
       <input
+        {...pwManagerProps}
         ref={ref}
         defaultValue={props.defaultValue}
         required={props.required}

--- a/ui/apps/dashboard/src/components/TimeRangeInput/TimeInput.tsx
+++ b/ui/apps/dashboard/src/components/TimeRangeInput/TimeInput.tsx
@@ -8,7 +8,11 @@ import { useDebounce } from 'react-use';
 import Input from '@/components/Forms/Input';
 
 type Props = {
+  className?: string;
+  defaultValue?: Date;
+  label?: string;
   onChange: (newDateTime: Date) => void;
+  name?: string;
   placeholder?: string;
   required?: boolean;
 };
@@ -104,12 +108,20 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-export function TimeInput({ onChange, placeholder, required }: Props) {
+export function TimeInput({
+  className,
+  defaultValue,
+  label,
+  onChange,
+  name,
+  placeholder,
+  required,
+}: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [state, dispatch] = useReducer(reducer, {
-    inputString: '',
+    inputString: defaultValue ? defaultValue.toLocaleString() : '',
     suggestedDateTime: undefined,
-    status: 'idle',
+    status: defaultValue ? 'suggestion_applied' : 'idle',
   });
   useDebounce(
     () => {
@@ -164,7 +176,15 @@ export function TimeInput({ onChange, placeholder, required }: Props) {
   return (
     <Popover.Root open={state.status === 'focused' || state.status === 'suggestion_available'}>
       <Popover.Anchor>
+        {label && name && (
+          <label htmlFor={name} className="text-sm font-medium text-slate-700">
+            {label}
+          </label>
+        )}
+
         <Input
+          className={className}
+          name={name}
           type="text"
           value={state.inputString}
           placeholder={placeholder}

--- a/ui/apps/dashboard/src/components/TimeRangeInput/TimeInput.tsx
+++ b/ui/apps/dashboard/src/components/TimeRangeInput/TimeInput.tsx
@@ -9,8 +9,6 @@ import Input from '@/components/Forms/Input';
 
 type Props = {
   className?: string;
-  defaultValue?: Date;
-  label?: string;
   onChange: (newDateTime: Date) => void;
   name?: string;
   placeholder?: string;
@@ -108,20 +106,12 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-export function TimeInput({
-  className,
-  defaultValue,
-  label,
-  onChange,
-  name,
-  placeholder,
-  required,
-}: Props) {
+export function TimeInput({ className, onChange, name, placeholder, required }: Props) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [state, dispatch] = useReducer(reducer, {
-    inputString: defaultValue ? defaultValue.toLocaleString() : '',
+    inputString: '',
     suggestedDateTime: undefined,
-    status: defaultValue ? 'suggestion_applied' : 'idle',
+    status: 'idle',
   });
   useDebounce(
     () => {
@@ -176,12 +166,6 @@ export function TimeInput({
   return (
     <Popover.Root open={state.status === 'focused' || state.status === 'suggestion_available'}>
       <Popover.Anchor>
-        {label && name && (
-          <label htmlFor={name} className="text-sm font-medium text-slate-700">
-            {label}
-          </label>
-        )}
-
         <Input
           className={className}
           name={name}

--- a/ui/apps/dashboard/src/gql/gql.ts
+++ b/ui/apps/dashboard/src/gql/gql.ts
@@ -50,6 +50,9 @@ const documents = {
     "\n  query GetFunctionArchival($slug: String!, $environmentID: ID!) {\n    workspace(id: $environmentID) {\n      workflow: workflowBySlug(slug: $slug) {\n        id\n        isArchived\n        name\n      }\n    }\n  }\n": types.GetFunctionArchivalDocument,
     "\n  query GetFunctionVersionNumber($slug: String!, $environmentID: ID!) {\n    workspace(id: $environmentID) {\n      workflow: workflowBySlug(slug: $slug) {\n        id\n        archivedAt\n        current {\n          version\n        }\n        previous {\n          version\n        }\n      }\n    }\n  }\n": types.GetFunctionVersionNumberDocument,
     "\n  mutation PauseFunction($input: EditWorkflowInput!) {\n    editWorkflow(input: $input) {\n      workflow {\n        id\n        name\n      }\n    }\n  }\n": types.PauseFunctionDocument,
+    "\n  query GetCancellations($envID: ID!, $fnID: ID!) {\n    environment: workspace(id: $envID) {\n      function: workflow(id: $fnID) {\n        cancellations {\n          createdAt\n          expression\n          id\n          name\n          queuedAtMax\n          queuedAtMin\n        }\n      }\n    }\n  }\n": types.GetCancellationsDocument,
+    "\n  mutation CreateCancellation($input: CreateCancellationInput!) {\n    createCancellation(input: $input) {\n      id\n    }\n  }\n": types.CreateCancellationDocument,
+    "\n  query GetFunctionCancellationPage($envID: ID!, $fnSlug: String!) {\n    environment: workspace(id: $envID) {\n      function: workflowBySlug(slug: $fnSlug) {\n        id\n      }\n    }\n  }\n": types.GetFunctionCancellationPageDocument,
     "\n  mutation InvokeFunction($envID: UUID!, $data: Map, $functionSlug: String!) {\n    invokeFunction(envID: $envID, data: $data, functionSlug: $functionSlug)\n  }\n": types.InvokeFunctionDocument,
     "\n  mutation RerunFunctionRun($environmentID: ID!, $functionID: ID!, $functionRunID: ULID!) {\n    retryWorkflowRun(\n      input: { workspaceID: $environmentID, workflowID: $functionID }\n      workflowRunID: $functionRunID\n    ) {\n      id\n    }\n  }\n": types.RerunFunctionRunDocument,
     "\n  mutation CancelRun($envID: UUID!, $runID: ULID!) {\n    cancelRun(envID: $envID, runID: $runID) {\n      id\n    }\n  }\n": types.CancelRunDocument,
@@ -258,6 +261,18 @@ export function graphql(source: "\n  query GetFunctionVersionNumber($slug: Strin
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  mutation PauseFunction($input: EditWorkflowInput!) {\n    editWorkflow(input: $input) {\n      workflow {\n        id\n        name\n      }\n    }\n  }\n"): (typeof documents)["\n  mutation PauseFunction($input: EditWorkflowInput!) {\n    editWorkflow(input: $input) {\n      workflow {\n        id\n        name\n      }\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query GetCancellations($envID: ID!, $fnID: ID!) {\n    environment: workspace(id: $envID) {\n      function: workflow(id: $fnID) {\n        cancellations {\n          createdAt\n          expression\n          id\n          name\n          queuedAtMax\n          queuedAtMin\n        }\n      }\n    }\n  }\n"): (typeof documents)["\n  query GetCancellations($envID: ID!, $fnID: ID!) {\n    environment: workspace(id: $envID) {\n      function: workflow(id: $fnID) {\n        cancellations {\n          createdAt\n          expression\n          id\n          name\n          queuedAtMax\n          queuedAtMin\n        }\n      }\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation CreateCancellation($input: CreateCancellationInput!) {\n    createCancellation(input: $input) {\n      id\n    }\n  }\n"): (typeof documents)["\n  mutation CreateCancellation($input: CreateCancellationInput!) {\n    createCancellation(input: $input) {\n      id\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query GetFunctionCancellationPage($envID: ID!, $fnSlug: String!) {\n    environment: workspace(id: $envID) {\n      function: workflowBySlug(slug: $fnSlug) {\n        id\n      }\n    }\n  }\n"): (typeof documents)["\n  query GetFunctionCancellationPage($envID: ID!, $fnSlug: String!) {\n    environment: workspace(id: $envID) {\n      function: workflowBySlug(slug: $fnSlug) {\n        id\n      }\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/ui/apps/dashboard/src/gql/graphql.ts
+++ b/ui/apps/dashboard/src/gql/graphql.ts
@@ -124,6 +124,17 @@ export type BillingSubscription = {
   nextInvoiceDate: Scalars['Time'];
 };
 
+export type Cancellation = {
+  __typename?: 'Cancellation';
+  createdAt: Scalars['Time'];
+  expression: Maybe<Scalars['String']>;
+  functionID: Scalars['UUID'];
+  id: Scalars['ULID'];
+  name: Maybe<Scalars['String']>;
+  queuedAtMax: Scalars['Time'];
+  queuedAtMin: Maybe<Scalars['Time']>;
+};
+
 export type CancellationConfiguration = {
   __typename?: 'CancellationConfiguration';
   condition: Maybe<Scalars['String']>;
@@ -156,6 +167,15 @@ export enum ConcurrencyScope {
   Environment = 'ENVIRONMENT',
   Function = 'FUNCTION'
 }
+
+export type CreateCancellationInput = {
+  envID: Scalars['UUID'];
+  expression?: InputMaybe<Scalars['String']>;
+  functionID: Scalars['UUID'];
+  name?: InputMaybe<Scalars['String']>;
+  queuedAtMax: Scalars['Time'];
+  queuedAtMin?: InputMaybe<Scalars['Time']>;
+};
 
 export type CreateFunctionReplayInput = {
   fromRange: Scalars['ULID'];
@@ -507,6 +527,7 @@ export type Mutation = {
   archiveWorkflow: Maybe<WorkflowResponse>;
   cancelRun: FunctionRun;
   completeAWSMarketplaceSetup: Maybe<AwsMarketplaceSetupResponse>;
+  createCancellation: Cancellation;
   createFunctionReplay: Replay;
   createIngestKey: IngestKey;
   createStripeSubscription: CreateStripeSubscriptionResponse;
@@ -556,6 +577,11 @@ export type MutationCancelRunArgs = {
 
 export type MutationCompleteAwsMarketplaceSetupArgs = {
   input: AwsMarketplaceSetupInput;
+};
+
+
+export type MutationCreateCancellationArgs = {
+  input: CreateCancellationInput;
 };
 
 
@@ -1025,6 +1051,7 @@ export type SyncResponse = {
 };
 
 export enum SyncStatus {
+  Duplicate = 'duplicate',
   Error = 'error',
   Pending = 'pending',
   Success = 'success'
@@ -1111,6 +1138,7 @@ export type Workflow = {
   __typename?: 'Workflow';
   appName: Maybe<Scalars['String']>;
   archivedAt: Maybe<Scalars['Time']>;
+  cancellations: Array<Cancellation>;
   configuration: Maybe<FunctionConfiguration>;
   current: Maybe<WorkflowVersion>;
   failureHandler: Maybe<Workflow>;
@@ -1590,6 +1618,29 @@ export type PauseFunctionMutationVariables = Exact<{
 
 export type PauseFunctionMutation = { __typename?: 'Mutation', editWorkflow: { __typename?: 'WorkflowVersionResponse', workflow: { __typename?: 'Workflow', id: string, name: string } } | null };
 
+export type GetCancellationsQueryVariables = Exact<{
+  envID: Scalars['ID'];
+  fnID: Scalars['ID'];
+}>;
+
+
+export type GetCancellationsQuery = { __typename?: 'Query', environment: { __typename?: 'Workspace', function: { __typename?: 'Workflow', cancellations: Array<{ __typename?: 'Cancellation', createdAt: string, expression: string | null, id: string, name: string | null, queuedAtMax: string, queuedAtMin: string | null }> } | null } };
+
+export type CreateCancellationMutationVariables = Exact<{
+  input: CreateCancellationInput;
+}>;
+
+
+export type CreateCancellationMutation = { __typename?: 'Mutation', createCancellation: { __typename?: 'Cancellation', id: string } };
+
+export type GetFunctionCancellationPageQueryVariables = Exact<{
+  envID: Scalars['ID'];
+  fnSlug: Scalars['String'];
+}>;
+
+
+export type GetFunctionCancellationPageQuery = { __typename?: 'Query', environment: { __typename?: 'Workspace', function: { __typename?: 'Workflow', id: string } | null } };
+
 export type InvokeFunctionMutationVariables = Exact<{
   envID: Scalars['UUID'];
   data: InputMaybe<Scalars['Map']>;
@@ -1972,6 +2023,9 @@ export const ArchiveFunctionDocument = {"kind":"Document","definitions":[{"kind"
 export const GetFunctionArchivalDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetFunctionArchival"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"slug"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"environmentID"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"workspace"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"environmentID"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"workflow"},"name":{"kind":"Name","value":"workflowBySlug"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"slug"},"value":{"kind":"Variable","name":{"kind":"Name","value":"slug"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"isArchived"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}}]} as unknown as DocumentNode<GetFunctionArchivalQuery, GetFunctionArchivalQueryVariables>;
 export const GetFunctionVersionNumberDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetFunctionVersionNumber"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"slug"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"environmentID"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"workspace"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"environmentID"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"workflow"},"name":{"kind":"Name","value":"workflowBySlug"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"slug"},"value":{"kind":"Variable","name":{"kind":"Name","value":"slug"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"archivedAt"}},{"kind":"Field","name":{"kind":"Name","value":"current"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"version"}}]}},{"kind":"Field","name":{"kind":"Name","value":"previous"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"version"}}]}}]}}]}}]}}]} as unknown as DocumentNode<GetFunctionVersionNumberQuery, GetFunctionVersionNumberQueryVariables>;
 export const PauseFunctionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"PauseFunction"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"EditWorkflowInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"editWorkflow"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"workflow"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}}]}}]}}]}}]} as unknown as DocumentNode<PauseFunctionMutation, PauseFunctionMutationVariables>;
+export const GetCancellationsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetCancellations"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"envID"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"fnID"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"environment"},"name":{"kind":"Name","value":"workspace"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"envID"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"function"},"name":{"kind":"Name","value":"workflow"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"fnID"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"cancellations"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"expression"}},{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"queuedAtMax"}},{"kind":"Field","name":{"kind":"Name","value":"queuedAtMin"}}]}}]}}]}}]}}]} as unknown as DocumentNode<GetCancellationsQuery, GetCancellationsQueryVariables>;
+export const CreateCancellationDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateCancellation"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"CreateCancellationInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"createCancellation"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<CreateCancellationMutation, CreateCancellationMutationVariables>;
+export const GetFunctionCancellationPageDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetFunctionCancellationPage"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"envID"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"fnSlug"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"environment"},"name":{"kind":"Name","value":"workspace"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"envID"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"function"},"name":{"kind":"Name","value":"workflowBySlug"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"slug"},"value":{"kind":"Variable","name":{"kind":"Name","value":"fnSlug"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]}}]} as unknown as DocumentNode<GetFunctionCancellationPageQuery, GetFunctionCancellationPageQueryVariables>;
 export const InvokeFunctionDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"InvokeFunction"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"envID"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UUID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"data"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"Map"}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"functionSlug"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"String"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"invokeFunction"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"envID"},"value":{"kind":"Variable","name":{"kind":"Name","value":"envID"}}},{"kind":"Argument","name":{"kind":"Name","value":"data"},"value":{"kind":"Variable","name":{"kind":"Name","value":"data"}}},{"kind":"Argument","name":{"kind":"Name","value":"functionSlug"},"value":{"kind":"Variable","name":{"kind":"Name","value":"functionSlug"}}}]}]}}]} as unknown as DocumentNode<InvokeFunctionMutation, InvokeFunctionMutationVariables>;
 export const RerunFunctionRunDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"RerunFunctionRun"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"environmentID"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"functionID"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"functionRunID"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ULID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"retryWorkflowRun"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"ObjectValue","fields":[{"kind":"ObjectField","name":{"kind":"Name","value":"workspaceID"},"value":{"kind":"Variable","name":{"kind":"Name","value":"environmentID"}}},{"kind":"ObjectField","name":{"kind":"Name","value":"workflowID"},"value":{"kind":"Variable","name":{"kind":"Name","value":"functionID"}}}]}},{"kind":"Argument","name":{"kind":"Name","value":"workflowRunID"},"value":{"kind":"Variable","name":{"kind":"Name","value":"functionRunID"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<RerunFunctionRunMutation, RerunFunctionRunMutationVariables>;
 export const CancelRunDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CancelRun"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"envID"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UUID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"runID"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ULID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"cancelRun"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"envID"},"value":{"kind":"Variable","name":{"kind":"Name","value":"envID"}}},{"kind":"Argument","name":{"kind":"Name","value":"runID"},"value":{"kind":"Variable","name":{"kind":"Name","value":"runID"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]} as unknown as DocumentNode<CancelRunMutation, CancelRunMutationVariables>;

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/stream/Stream.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/stream/Stream.tsx
@@ -262,6 +262,7 @@ export default function Stream() {
       >
         <Table
           options={{
+            // @ts-expect-error TODO: Properly type this
             data: triggers ?? [],
             columns,
             getCoreRowModel: getCoreRowModel(),

--- a/ui/packages/components/src/Modal/Modal.tsx
+++ b/ui/packages/components/src/Modal/Modal.tsx
@@ -77,8 +77,8 @@ export function Modal({
   );
 }
 
-function Body({ children }: React.PropsWithChildren<{}>) {
-  return <div className="m-6">{children}</div>;
+function Body({ children, className }: React.PropsWithChildren<{ className?: string }>) {
+  return <div className={cn('m-6', className)}>{children}</div>;
 }
 
 function Footer({ children, className }: React.PropsWithChildren<{ className?: string }>) {

--- a/ui/packages/components/src/Table/Table.tsx
+++ b/ui/packages/components/src/Table/Table.tsx
@@ -5,21 +5,21 @@ import { useVirtual } from 'react-virtual';
 
 const cellStyles = 'pl-6 pr-2 py-3 whitespace-nowrap';
 
-type TableProps = {
-  options: TableOptions<any>;
+type TableProps<T> = {
+  options: TableOptions<T>;
   blankState: React.ReactNode;
-  customRowProps?: (row: Row<any>) => void;
+  customRowProps?: (row: Row<T>) => void;
   tableContainerRef: React.RefObject<HTMLDivElement>;
   isVirtualized?: boolean;
 };
 
-export function Table({
+export function Table<T>({
   options,
   blankState,
   customRowProps,
   tableContainerRef,
   isVirtualized = true,
-}: TableProps) {
+}: TableProps<T>) {
   const table = useReactTable(options);
   const { rows } = table.getRowModel();
 


### PR DESCRIPTION
> :warning: Depends on https://github.com/inngest/monorepo/pull/2507

## Description
Add the new UI for bulk run cancellation, which includes:
- New nav item (controlled by a feature flag)
- Cancellation list
- Cancellation creation button
- Cancellation creation modal

<img width="1693" alt="image" src="https://github.com/inngest/inngest/assets/20100586/12c3f435-07d5-4d84-b173-7da569fbe745">

Some other changes:
- Added a proper generic for the `Table` component, since `any` is bad
- Added `className` prop to `Modal.Body`
- Added `className` and `name` props to `TimeInput`
- Added `disablePasswordManager` prop to `Input`, since 1Password was inserting itself into the modal form

## How to review
Checkout the `cancellation-gql` branch in monorepo to get the necessary backend changes

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
