### PR TITLE
INN-2911: Fix empty event payloads in UI due to resolver bug

### DIFF
--- a/pkg/coreapi/graph/resolvers/event.resolver.go
+++ b/pkg/coreapi/graph/resolvers/event.resolver.go
@@ -90,16 +90,7 @@ func (r *eventResolver) Status(ctx context.Context, obj *models.Event) (*models.
 }
 
 func (r *eventResolver) Raw(ctx context.Context, obj *models.Event) (*string, error) {
-	// Runner.Events maps events by an event ID that could be either the
-	// internal or external ID. It'll be the internal ID if the event didn't
-	// have an external ID
-	var eventID string
-	if obj.ExternalID != nil {
-		eventID = *obj.ExternalID
-	} else {
-		eventID = obj.ID.String()
-	}
-
+	eventID := obj.ID.String()
 	evts, err := r.Runner.Events(ctx, eventID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

The change introduced in #1238 changed how IDs are used ([diff](https://github.com/inngest/inngest/pull/1238/files#diff-52e41636f29e1f855e51f1ad1144dd1cc18e411574f06628ddc711f2564130d5R118)) within the `runner` service. This invalidated the previous fix in #1201.

This issue happens as sometimes two different event ids are created for a single event which is another, separate issue. This is reproducible by using the Invoke or Sent event button via the UI, but doesn't happen when sending an event via curl. The fix in this PR makes this issue separate and not a problem.

Tested:
* Invoking via UI
* Send event via UI
* Send event via UI w/ id
* Send event via curl
* Send event via curl w/ id

## Motivation
This looks like there was a valid bug fix with #1201 then #1238 caused a regression due to a change in how IDs are handled.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
