### PR TITLE
Fix missing timeline output for errored attempts

### DIFF
--- a/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
+++ b/ui/packages/components/src/Timeline/TimelineNode/TimelineNode.tsx
@@ -146,9 +146,10 @@ function useOutput({
       return;
     }
 
-    // We should only fetch output if the node has ended. There are some edge
-    // cases where a node can have an output item ID but not be in an end state
-    if (!isEndStatus(nodeStatus)) {
+    // We should only fetch output if the node has ended or errored ("errored"
+    // means there will be a retry). There are some edge cases where a node can
+    // have an output item ID but not be in an end state
+    if (!isEndStatus(nodeStatus) && nodeStatus != 'errored') {
       return;
     }
 


### PR DESCRIPTION
## Description
Fix missing timeline output when a step errors but will retry

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
