### PR TITLE
Add GCRA to leasing queue items directly

### DIFF
--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -75,6 +75,20 @@ type Item struct {
 	// QueueName allows control over the queue name.  If not provided, this falls
 	// back to the queue mapping defined on the queue or the workflow ID of the fn.
 	QueueName *string `json:"qn,omitempty"`
+
+	Throttle *Throttle `json:"throttle,omitempty"`
+}
+
+type Throttle struct {
+	// Key is the unique throttling key that's used to group queue items when
+	// processing rate limiting/throttling.
+	Key string `json:"k"`
+	// Limit is the actual rate limit
+	Limit int `json:"l"`
+	// Burst is the busrsable capacity of the rate limit
+	Burst int `json:"b"`
+	// Period is the rate limit period, in seconds
+	Period int `json:"p"`
 }
 
 // GetPriorityFactor returns the priority factor for the queue item.  This fudges the job item's

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
+	osqueue "github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/oklog/ulid/v2"
 )
@@ -170,6 +171,8 @@ type QueueKeyGenerator interface {
 	GlobalPartitionIndex() string
 	// ShardPartitionIndex returns the sorted set for the shard's partition queue.
 	ShardPartitionIndex(shard string) string
+	// ThrottleKey returns the throttle key for a given queue item.
+	ThrottleKey(t *osqueue.Throttle) string
 
 	//
 	// Queue metadata keys
@@ -270,6 +273,13 @@ func (d DefaultQueueKeyGenerator) ShardPartitionIndex(shard string) string {
 		return fmt.Sprintf("%s:shard:-", d.Prefix)
 	}
 	return fmt.Sprintf("%s:shard:%s", d.Prefix, shard)
+}
+
+func (d DefaultQueueKeyGenerator) ThrottleKey(t *osqueue.Throttle) string {
+	if t == nil || t.Key == "" {
+		return fmt.Sprintf("%s:throttle:-", d.Prefix)
+	}
+	return fmt.Sprintf("%s:throttle:%s", d.Prefix, t.Key)
 }
 
 func (d DefaultQueueKeyGenerator) PartitionMeta(id string) string {

--- a/pkg/execution/state/redis_state/lua/includes/gcra.lua
+++ b/pkg/execution/state/redis_state/lua/includes/gcra.lua
@@ -1,0 +1,36 @@
+-- performs gcra rate limiting for a given key.
+-- 
+-- Returns true on success, false if the key has been rate limited.
+local function gcra(key, now_ms, period_ms, limit, burst)
+	-- Calculate the basic variables for GCRA.
+
+	local cost = 1                            -- everything counts as a single rqeuest
+	local emission  = period_ms / limit       -- how frequently we can admit new requests
+	local increment = emission * cost         -- this request's time delta
+	local variance  = period_ms * (burst + 1) -- variance takes into account bursts
+
+	-- fetch the theoretical arrival time for equally spaced requests
+	-- at exactly the rate limit
+	local tat = redis.call("GET", key)
+	if not tat then
+		tat = now_ms
+	else
+		tat = tonumber(tat)
+	end
+
+	local new_tat = math.max(tat, now_ms) + increment -- add the request's cost to the theoretical arrival time.
+	local allow_at_ms = new_tat - variance         -- handle bursts.
+
+	local diff_ms = now_ms - allow_at_ms
+
+	if diff_ms < 0 then
+		-- return {false, tat, new_tat, allow_at_ms, diff_ms}
+		return false
+	end
+
+	local expiry = math.ceil(now_ms + period_ms / 1000)
+	redis.call("SETEX", key, new_tat, expiry)
+
+	-- return {true, tat, new_tat, allow_at_ms, diff_ms}
+	return true
+end

--- a/pkg/execution/state/redis_state/lua/queue/partitionPeek.lua
+++ b/pkg/execution/state/redis_state/lua/queue/partitionPeek.lua
@@ -7,10 +7,22 @@ Peek returns partition items from the queue in order via their index.
 local partitionIndex = KEYS[1]
 local partitionKey   = KEYS[2]
 
-local peekUntil  = tonumber(ARGV[1])
-local limit      = tonumber(ARGV[2])
+local peekUntilMS  = tonumber(ARGV[1])
+local limit        = tonumber(ARGV[2])
+local sequential   = tonumber(ARGV[3])
 
-local items = redis.call("ZRANGE", partitionIndex, "-inf", peekUntil, "BYSCORE", "LIMIT", 0, limit)
+local peekUntil    = math.ceil(peekUntilMS / 1000)
+
+local count = redis.call("ZCOUNT", partitionIndex, "-inf", peekUntil)
+local offset = 0
+
+if count > limit and sequential == 0 then
+	math.randomseed(peekUntilMS);
+	-- We have to +1 then -1 to ensure that we have 0 as a valid random offset.
+	offset = math.random((count-limit)+1) - 1
+end
+
+local items = redis.call("ZRANGE", partitionIndex, "-inf", peekUntil, "BYSCORE", "LIMIT", offset, limit)
 if #items == 0 then
 	return {}
 end

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -1457,12 +1457,17 @@ func (q *queue) partitionPeek(ctx context.Context, partitionKey string, sequenti
 	// TODO: If this is an allowlist, only peek the given partitions.  Use ZMSCORE
 	// to fetch the scores for all allowed partitions, then filter where score <= until.
 	// Call an HMGET to get the partitions.
+	ms := until.UnixMilli()
 
-	unix := until.Unix()
+	isSequential := 0
+	if sequential {
+		isSequential = 1
+	}
 
 	args, err := StrSlice([]any{
-		unix,
+		ms,
 		limit,
+		isSequential,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -1102,13 +1102,6 @@ func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, dur
 	}
 }
 
-func isConcurrencyLimitError(err error) bool {
-	return err == ErrPartitionConcurrencyLimit ||
-		err == ErrAccountConcurrencyLimit ||
-		err == ErrConcurrencyLimitCustomKey0 ||
-		err == ErrConcurrencyLimitCustomKey1
-}
-
 // ExtendLease extens the lease for a given queue item, given the queue item is currently
 // leased with the given ID.  This returns a new lease ID if the lease is successfully ended.
 //

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -106,6 +106,8 @@ var (
 	ErrConcurrencyLimitCustomKey0 = fmt.Errorf("At concurrency limit 0")
 	ErrConcurrencyLimitCustomKey1 = fmt.Errorf("At concurrency limit 1")
 
+	ErrQueueItemThrottled = fmt.Errorf("queue item throttled")
+
 	// internal shard errors
 	errShardNotFound     = fmt.Errorf("shard not found")
 	errShardIndexLeased  = fmt.Errorf("shard index is already leased")
@@ -114,6 +116,10 @@ var (
 
 var (
 	rnd *frandRNG
+
+	// now is a reference to time.Now and exists for overriding within
+	// specific tests, allowing us to eg. test rate limiting with ease.
+	getNow = time.Now
 )
 
 func init() {
@@ -364,6 +370,7 @@ func NewQueue(r rueidis.Client, opts ...QueueOpt) *queue {
 type queue struct {
 	// name is the identifiable name for this worker, for logging.
 	name string
+
 	// redis stores the redis connection to use.
 	r  rueidis.Client
 	pf PriorityFinder
@@ -597,7 +604,7 @@ func (q QueueItem) Score() int64 {
 	// If this is > 2 seconds in the future, don't mess with the time.
 	// This prevents any accidental fudging of future run times, even if the
 	// kind is edge (which should never exist... but, better to be safe).
-	if q.AtMS > time.Now().Add(consts.FutureAtLimit).UnixMilli() {
+	if q.AtMS > getNow().Add(consts.FutureAtLimit).UnixMilli() {
 		return q.AtMS
 	}
 
@@ -766,9 +773,9 @@ func (q *queue) EnqueueItem(ctx context.Context, i QueueItem, at time.Time) (Que
 		i.WallTimeMS = at.UnixMilli()
 	}
 
-	if at.Before(time.Now()) {
+	if at.Before(getNow()) {
 		// Normalize to now to minimize latency.
-		i.WallTimeMS = time.Now().UnixMilli()
+		i.WallTimeMS = getNow().UnixMilli()
 	}
 
 	// Add the At timestamp, if not included.
@@ -781,11 +788,11 @@ func (q *queue) EnqueueItem(ctx context.Context, i QueueItem, at time.Time) (Que
 	}
 
 	partitionTime := at
-	if at.Before(time.Now()) {
+	if at.Before(getNow()) {
 		// We don't want to enqueue partitions (pointers to fns) before now.
 		// Doing so allows users to stay at the front of the queue for
 		// leases.
-		partitionTime = time.Now()
+		partitionTime = getNow()
 	}
 
 	// Get the queue name from the queue item.  This allows utilization of
@@ -904,7 +911,7 @@ func (q *queue) Peek(ctx context.Context, queueName string, until time.Time, lim
 	// leased here, so we may end up returning less than the total length.
 	result := make([]*QueueItem, len(items))
 	n := 0
-	now := time.Now()
+	now := getNow()
 
 	for _, str := range items {
 		qi := &QueueItem{}
@@ -963,7 +970,7 @@ func (q *queue) RequeueByJobID(ctx context.Context, partitionName string, jobID 
 			jobID,
 			strconv.Itoa(int(at.UnixMilli())),
 			partitionName,
-			strconv.Itoa(int(time.Now().UnixMilli())),
+			strconv.Itoa(int(getNow().UnixMilli())),
 		},
 	).AsInt64()
 	if err != nil {
@@ -987,7 +994,7 @@ func (q *queue) RequeueByJobID(ctx context.Context, partitionName string, jobID 
 //
 // Obtaining a lease updates the vesting time for the queue item until now() +
 // lease duration. This returns the newly acquired lease ID on success.
-func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, duration time.Duration) (*ulid.ULID, error) {
+func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, duration time.Duration, now time.Time) (*ulid.ULID, error) {
 	var (
 		ak, pk string // account, partition concurrency key
 		ac, pc int    // account, partiiton concurrency max
@@ -1019,7 +1026,7 @@ func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, dur
 		}
 	}
 
-	leaseID, err := ulid.New(ulid.Timestamp(time.Now().Add(duration).UTC()), rnd)
+	leaseID, err := ulid.New(ulid.Timestamp(getNow().Add(duration).UTC()), rnd)
 	if err != nil {
 		return nil, fmt.Errorf("error generating id: %w", err)
 	}
@@ -1042,11 +1049,12 @@ func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, dur
 		q.kg.ConcurrencyIndex(),
 		q.kg.GlobalPartitionIndex(),
 		q.kg.ShardPartitionIndex(shardName),
+		q.kg.ThrottleKey(item.Data.Throttle),
 	}
 	args, err := StrSlice([]any{
 		item.ID,
 		leaseID.String(),
-		time.Now().UnixMilli(),
+		now.UnixMilli(),
 		ac,
 		pc,
 		customLimits[0],
@@ -1061,7 +1069,7 @@ func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, dur
 		q.r,
 		keys,
 		args,
-	).AsInt64()
+	).ToInt64()
 	if err != nil {
 		return nil, fmt.Errorf("error leasing queue item: %w", err)
 	}
@@ -1081,6 +1089,8 @@ func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, dur
 		return nil, ErrConcurrencyLimitCustomKey0
 	case 6:
 		return nil, ErrConcurrencyLimitCustomKey1
+	case 7:
+		return nil, ErrQueueItemThrottled
 	default:
 		return nil, fmt.Errorf("unknown response enqueueing item: %d", status)
 	}
@@ -1123,7 +1133,7 @@ func (q *queue) ExtendLease(ctx context.Context, p QueuePartition, i QueueItem, 
 		}
 	}
 
-	newLeaseID, err := ulid.New(ulid.Timestamp(time.Now().Add(duration).UTC()), rnd)
+	newLeaseID, err := ulid.New(ulid.Timestamp(getNow().Add(duration).UTC()), rnd)
 	if err != nil {
 		return nil, fmt.Errorf("error generating id: %w", err)
 	}
@@ -1355,7 +1365,7 @@ func (q *queue) PartitionLease(ctx context.Context, p *QueuePartition, duration 
 	// XXX: Check for function throttling prior to leasing;  if it's throttled we can requeue
 	// the pointer and back off.  A question here is enqueuing new items onto the partition
 	// will reset the pointer update, leading to thrash.
-	now := time.Now()
+	now := getNow()
 	leaseExpires := now.Add(duration).UTC().Truncate(time.Millisecond)
 	leaseID, err := ulid.New(ulid.Timestamp(leaseExpires), rnd)
 	if err != nil {
@@ -1652,7 +1662,7 @@ func (q *queue) PartitionReprioritize(ctx context.Context, queueName string, pri
 }
 
 func (q *queue) InProgress(ctx context.Context, prefix string, concurrencyKey string) (int64, error) {
-	s := time.Now().UnixMilli()
+	s := getNow().UnixMilli()
 	cmd := q.r.B().Zcount().
 		Key(q.kg.Concurrency(prefix, concurrencyKey)).
 		Min(fmt.Sprintf("%d", s)).
@@ -1669,7 +1679,7 @@ func (q *queue) InProgress(ctx context.Context, prefix string, concurrencyKey st
 func (q *queue) Scavenge(ctx context.Context) (int, error) {
 	// Find all items that have an expired lease - eg. where the min time for a lease is between
 	// (0-now] in unix milliseconds.
-	now := fmt.Sprintf("%d", time.Now().UnixMilli())
+	now := fmt.Sprintf("%d", getNow().UnixMilli())
 
 	cmd := q.r.B().Zrange().
 		Key(q.kg.ConcurrencyIndex()).
@@ -1735,7 +1745,7 @@ func (q *queue) Scavenge(ctx context.Context) (int, error) {
 				resultErr = multierror.Append(resultErr, fmt.Errorf("error unmarshalling job '%s': %w", item, err))
 				continue
 			}
-			if err := q.Requeue(ctx, p, qi, time.Now()); err != nil {
+			if err := q.Requeue(ctx, p, qi, getNow()); err != nil {
 				resultErr = multierror.Append(resultErr, fmt.Errorf("error requeueing job '%s': %w", item, err))
 				continue
 			}
@@ -1762,7 +1772,7 @@ func (q *queue) ConfigLease(ctx context.Context, key string, duration time.Durat
 		return nil, ErrConfigLeaseExceedsLimits
 	}
 
-	now := time.Now()
+	now := getNow()
 	newLeaseID, err := ulid.New(ulid.Timestamp(now.Add(duration)), rnd)
 	if err != nil {
 		return nil, err
@@ -1825,7 +1835,7 @@ func (q *queue) getShards(ctx context.Context) (map[string]*QueueShard, error) {
 // from claiming the same lease index;  if workers A and B see a shard with 0 leases and both attempt
 // to claim lease "0", only one will succeed.
 func (q *queue) leaseShard(ctx context.Context, shard *QueueShard, duration time.Duration, n int) (*ulid.ULID, error) {
-	now := time.Now()
+	now := getNow()
 	leaseID, err := ulid.New(uint64(now.Add(duration).UnixMilli()), rand.Reader)
 	if err != nil {
 		return nil, err
@@ -1866,7 +1876,7 @@ func (q *queue) leaseShard(ctx context.Context, shard *QueueShard, duration time
 }
 
 func (q *queue) renewShardLease(ctx context.Context, shard *QueueShard, duration time.Duration, leaseID ulid.ULID) (*ulid.ULID, error) {
-	now := time.Now()
+	now := getNow()
 	newLeaseID, err := ulid.New(uint64(now.Add(duration).UnixMilli()), rand.Reader)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit adds GCRA to queue items.  It's possible to specify GCRA/throttling parameters directly when enqueueing an item.  If a queue item contains GCRA paremters, the queue will apply GCRA when attempting to lease the queue item.

This ensures that the queue atomically, but selectively, applies throttling as it attempts to claim items to be processed.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
