### PR TITLE
Base for moving invokes away from pauses

### DIFF
--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -117,14 +117,18 @@ func (e Event) CorrelationID() string {
 		}
 	}
 
-	if e.Name == FnFinishedName {
+	if e.IsFinishedEvent() {
 		if corrId, ok := e.Data[consts.InvokeCorrelationId].(string); ok {
 			return corrId
 		}
 	}
 
 	return ""
+}
 
+// IsFinishedEvent returns true if the event is a function finished event.
+func (e Event) IsFinishedEvent() bool {
+	return e.Name == FnFinishedName
 }
 
 // InngestMetadata represents metadata for an event that is used to invoke a

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -109,6 +109,27 @@ func (e Event) Validate(ctx context.Context) error {
 	return nil
 }
 
+// CorrelationID returns the correlation ID for the event.
+func (e Event) CorrelationID() string {
+	if e.Name == InvokeFnName {
+		if metadata := e.InngestMetadata(); metadata != nil {
+			return metadata.InvokeCorrelationId
+		}
+	}
+
+	if e.Name == FnFinishedName {
+		if corrId, ok := e.Data[consts.InvokeCorrelationId].(string); ok {
+			return corrId
+		}
+	}
+
+	return ""
+
+}
+
+// InngestMetadata represents metadata for an event that is used to invoke a
+// function. Note that this metadata is not present on all functions. For
+// accessing an event's correlation ID, prefer using `Event.CorrelationID()`.
 type InngestMetadata struct {
 	InvokeFnID          string `json:"fn_id"`
 	InvokeCorrelationId string `json:"correlation_id,omitempty"`

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -104,9 +104,9 @@ type Executor interface {
 	// HandlePauses handles pauses loaded from an incoming event.  This delegates to Cancel and
 	// Resume where necessary, depending on pauses that have been loaded and matched.
 	HandlePauses(ctx context.Context, iter state.PauseIterator, event event.TrackedEvent) (HandlePauseResult, error)
-	// HandleInvoke handles the invoke pauses from an incoming event. This delegates to Cancel and
+	// HandleInvokeFinish handles the invoke pauses from an incoming event. This delegates to Cancel and
 	// Resume where necessary
-	HandleInvoke(ctx context.Context, correlationID string, event event.TrackedEvent) error
+	HandleInvokeFinish(ctx context.Context, correlationID string, event event.TrackedEvent) error
 	// Cancel cancels an in-progress function run, preventing any enqueued or future steps from running.
 	Cancel(ctx context.Context, runID ulid.ULID, r CancelRequest) error
 	// Resume resumes an in-progress function run from the given waitForEvent pause.

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -104,6 +104,9 @@ type Executor interface {
 	// HandlePauses handles pauses loaded from an incoming event.  This delegates to Cancel and
 	// Resume where necessary, depending on pauses that have been loaded and matched.
 	HandlePauses(ctx context.Context, iter state.PauseIterator, event event.TrackedEvent) (HandlePauseResult, error)
+	// HandleInvoke handles the invoke pauses from an incoming event. This delegates to Cancel and
+	// Resume where necessary
+	HandleInvoke(ctx context.Context, correlationID string, event event.TrackedEvent) error
 	// Cancel cancels an in-progress function run, preventing any enqueued or future steps from running.
 	Cancel(ctx context.Context, runID ulid.ULID, r CancelRequest) error
 	// Resume resumes an in-progress function run from the given waitForEvent pause.

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -106,7 +106,7 @@ type Executor interface {
 	HandlePauses(ctx context.Context, iter state.PauseIterator, event event.TrackedEvent) (HandlePauseResult, error)
 	// HandleInvokeFinish handles the invoke pauses from an incoming event. This delegates to Cancel and
 	// Resume where necessary
-	HandleInvokeFinish(ctx context.Context, correlationID string, event event.TrackedEvent) error
+	HandleInvokeFinish(ctx context.Context, event event.TrackedEvent) error
 	// Cancel cancels an in-progress function run, preventing any enqueued or future steps from running.
 	Cancel(ctx context.Context, runID ulid.ULID, r CancelRequest) error
 	// Resume resumes an in-progress function run from the given waitForEvent pause.

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1426,9 +1426,6 @@ func (e *executor) HandleInvokeFinish(ctx context.Context, evt event.TrackedEven
 
 	// find the pause with correlationID
 	pause, err := e.sm.PauseByInvokeCorrelationID(ctx, correlationID)
-	if err == state.ErrInvokePauseNotFound || err == state.ErrPauseNotFound {
-		return nil
-	}
 	if err != nil {
 		return err
 	}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1410,7 +1410,7 @@ func (e *executor) handleAggregatePauses(ctx context.Context, evt event.TrackedE
 	return res, goerr
 }
 
-func (e *executor) HandleInvokeFinish(ctx context.Context, correlationID string, evt event.TrackedEvent) error {
+func (e *executor) HandleInvokeFinish(ctx context.Context, evt event.TrackedEvent) error {
 	evtID := evt.GetInternalID()
 
 	log := e.log
@@ -1418,6 +1418,11 @@ func (e *executor) HandleInvokeFinish(ctx context.Context, correlationID string,
 		log = logger.From(ctx)
 	}
 	l := log.With().Str("event_id", evtID.String()).Logger()
+
+	correlationID := evt.GetEvent().CorrelationID()
+	if correlationID == "" {
+		return fmt.Errorf("no correlation ID found in event when trying to handle finish")
+	}
 
 	// find the pause with correlationID
 	pause, err := e.sm.PauseByInvokeCorrelationID(ctx, correlationID)

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1975,9 +1975,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, gen state.
 	if err == state.ErrPauseAlreadyExists {
 		return nil
 	}
-
 	if err != nil {
-		// TODO: should we delete both keys if failed?
 		return err
 	}
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1075,7 +1075,7 @@ func (e *executor) HandlePauses(ctx context.Context, iter state.PauseIterator, e
 	// Use the aggregator for all funciton finished events, if there are more than
 	// 50 waiting.  It only takes a few milliseconds to iterate and handle less
 	// than 50;  anything more runs the risk of running slow.
-	if evt.GetEvent().Name == event.FnFinishedName && iter.Count() > 50 {
+	if evt.GetEvent().IsFinishedEvent() && iter.Count() > 50 {
 		aggRes, err := e.handleAggregatePauses(ctx, evt)
 		if err != nil {
 			log.From(ctx).Error().Err(err).Msg("error handling aggregate pauses")

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1426,7 +1426,8 @@ func (e *executor) HandleInvokeFinish(ctx context.Context, evt event.TrackedEven
 	}
 
 	// find the pause with correlationID
-	pause, err := e.sm.PauseByInvokeCorrelationID(ctx, correlationID)
+	wsID := evt.GetWorkspaceID()
+	pause, err := e.sm.PauseByInvokeCorrelationID(ctx, wsID, correlationID)
 	if err != nil {
 		return err
 	}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1957,7 +1957,6 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, gen state.
 	)
 
 	opcode := gen.Op.String()
-
 	err = e.sm.SavePause(ctx, state.Pause{
 		ID:                  pauseID,
 		WorkspaceID:         item.WorkspaceID,
@@ -1981,6 +1980,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, gen state.
 
 	// Enqueue a job that will timeout the pause.
 	jobID := fmt.Sprintf("%s-%s-%s", item.Identifier.IdempotencyKey(), gen.ID, "invoke")
+	// TODO I think this is fine sending no metadata, as we have no attempts.
 	err = e.queue.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
 		WorkspaceID: item.WorkspaceID,

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -175,6 +175,9 @@ func (s *svc) Run(ctx context.Context) error {
 			err = s.handleQueueItem(ctx, item)
 		case queue.KindPause:
 			err = s.handlePauseTimeout(ctx, item)
+		case queue.KindInvoke:
+			// TODO: implement handler for invoke timeout
+			err = nil
 		case queue.KindDebounce:
 			d := debounce.DebouncePayload{}
 			if err := json.Unmarshal(item.Payload.(json.RawMessage), &d); err != nil {

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -330,7 +330,7 @@ func (s *svc) handleInvokeTimeout(ctx context.Context, item queue.Item) error {
 		return fmt.Errorf("unable to get invoke timeout from queue item: %T", item.Payload)
 	}
 	pause, err := s.state.PauseByInvokeCorrelationID(ctx, invokeTimeout.CorrelationID)
-	if err == state.ErrInvokePauseNotFound {
+	if err == state.ErrInvokePauseNotFound || err == state.ErrPauseNotFound {
 		// this pause has been consumed
 		l.Debug().Interface("pause", invokeTimeout).Msg("consumed invoke pause timeout ignored")
 		return nil

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -175,8 +175,6 @@ func (s *svc) Run(ctx context.Context) error {
 			err = s.handleQueueItem(ctx, item)
 		case queue.KindPause:
 			err = s.handlePauseTimeout(ctx, item)
-		case queue.KindInvoke:
-			err = s.handleInvokeTimeout(ctx, item)
 		case queue.KindDebounce:
 			d := debounce.DebouncePayload{}
 			if err := json.Unmarshal(item.Payload.(json.RawMessage), &d); err != nil {
@@ -320,36 +318,6 @@ func (s *svc) handlePauseTimeout(ctx context.Context, item queue.Item) error {
 	}
 
 	return s.exec.Resume(ctx, *pause, r)
-}
-
-func (s *svc) handleInvokeTimeout(ctx context.Context, item queue.Item) error {
-	l := logger.From(ctx).With().Str("run_id", item.Identifier.RunID.String()).Logger()
-
-	invokeTimeout, ok := item.Payload.(queue.PayloadInvokeTimeout)
-	if !ok {
-		return fmt.Errorf("unable to get invoke timeout from queue item: %T", item.Payload)
-	}
-	pause, err := s.state.PauseByInvokeCorrelationID(ctx, invokeTimeout.CorrelationID)
-	if err == state.ErrInvokePauseNotFound || err == state.ErrPauseNotFound {
-		// this pause has been consumed
-		l.Debug().Interface("pause", invokeTimeout).Msg("consumed invoke pause timeout ignored")
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	if pause == nil {
-		return nil
-	}
-
-	// resume the pause as usual
-	err = s.exec.Resume(ctx, *pause, execution.ResumeRequest{})
-	if err != nil {
-		return err
-	}
-
-	// clean up
-	return s.state.DeleteInvoke(ctx, invokeTimeout.CorrelationID)
 }
 
 // handleScheduledBatch checks for

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -20,6 +20,7 @@ const (
 	KindPause         = "pause"
 	KindDebounce      = "debounce"
 	KindScheduleBatch = "schedule-batch"
+	KindInvoke        = "invoke"
 	KindEdgeError     = "edge-error" // KindEdgeError is used to indicate a final step error attempting a graceful save.
 )
 
@@ -191,4 +192,12 @@ type PayloadEdge struct {
 type PayloadPauseTimeout struct {
 	PauseID   uuid.UUID `json:"pauseID"`
 	OnTimeout bool      `json:"onTimeout"`
+}
+
+// PayloadInvokeTimeout is the payload stored when enqueueing an invoke timeout,
+// where it checks if the invoked function has finished yet
+type PayloadInvokeTimeout struct {
+	PauseID       uuid.UUID `json:"pauseID"`
+	CorrelationID string    `json:"cID"`
+	OnTimeout     bool      `json:"onTimeout"`
 }

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -20,7 +20,6 @@ const (
 	KindPause         = "pause"
 	KindDebounce      = "debounce"
 	KindScheduleBatch = "schedule-batch"
-	KindInvoke        = "invoke"
 	KindEdgeError     = "edge-error" // KindEdgeError is used to indicate a final step error attempting a graceful save.
 )
 
@@ -192,12 +191,4 @@ type PayloadEdge struct {
 type PayloadPauseTimeout struct {
 	PauseID   uuid.UUID `json:"pauseID"`
 	OnTimeout bool      `json:"onTimeout"`
-}
-
-// PayloadInvokeTimeout is the payload stored when enqueueing an invoke timeout,
-// where it checks if the invoked function has finished yet
-type PayloadInvokeTimeout struct {
-	PauseID       uuid.UUID `json:"pauseID"`
-	CorrelationID string    `json:"cID"`
-	OnTimeout     bool      `json:"onTimeout"`
 }

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -539,14 +539,7 @@ func (s *svc) invokes(ctx context.Context, evt event.TrackedEvent) error {
 
 	l.Trace().Msg("querying for invoke pauses")
 
-	corrId := evt.GetEvent().CorrelationID()
-	if corrId == "" {
-		return fmt.Errorf("no metadata available to lookup invoke function")
-	}
-
-	l.Trace().Str("identifier", corrId).Msg("looking for invoke trigger")
-
-	return s.executor.HandleInvokeFinish(ctx, corrId, evt)
+	return s.executor.HandleInvokeFinish(ctx, evt)
 }
 
 // pauses searches for and triggers all pauses from this event.

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -543,11 +543,7 @@ func (s *svc) invokes(ctx context.Context, evt event.TrackedEvent) error {
 		Str("identifier", meta.InvokeCorrelationId).
 		Msg("looking for invoke trigger")
 
-	// Steps
-	// - Find the pause with correlationID
-	// - Consume the pause
-
-	return nil
+	return s.executor.HandleInvoke(ctx, meta.InvokeCorrelationId, evt)
 }
 
 // pauses searches for and triggers all pauses from this event.

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -377,7 +377,6 @@ func (s *svc) handleMessage(ctx context.Context, m pubsub.Message) error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-
 		if err := s.pauses(ctx, tracked); err != nil {
 			l.Error().Err(err).Msg("error consuming pauses")
 			errs = multierror.Append(errs, err)

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -360,9 +360,22 @@ func (s *svc) handleMessage(ctx context.Context, m pubsub.Message) error {
 		}
 	}()
 
+	// nil check somewhere lol
+	if tracked.GetEvent().InngestMetadata().InvokeCorrelationId != "" {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			// this is an "inngest/function.finished" event
+			s.executor.HandleInvoke()
+
+		}()
+	}
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+
 		if err := s.pauses(ctx, tracked); err != nil {
 			l.Error().Err(err).Msg("error consuming pauses")
 			errs = multierror.Append(errs, err)

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -388,6 +388,7 @@ func (s *svc) handleMessage(ctx context.Context, m pubsub.Message) error {
 		}
 	}()
 
+	wg.Wait()
 	return errs
 }
 

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -363,7 +363,7 @@ func (s *svc) handleMessage(ctx context.Context, m pubsub.Message) error {
 	// check if this is an "inngest/function.finished" event
 	// triggered by invoke
 	corrId := tracked.GetEvent().CorrelationID()
-	if tracked.GetEvent().Name == event.FnFinishedName && corrId != "" {
+	if tracked.GetEvent().IsFinishedEvent() && corrId != "" {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -368,7 +368,12 @@ func (s *svc) handleMessage(ctx context.Context, m pubsub.Message) error {
 		go func() {
 			defer wg.Done()
 			if err := s.invokes(ctx, tracked); err != nil {
-				l.Error().Err(err).Msg("error resuming invoke")
+				if err == state.ErrInvokePauseNotFound || err == state.ErrPauseNotFound {
+					l.Warn().Err(err).Msg("can't find paused function to resume after invoke")
+					return
+				}
+
+				l.Error().Err(err).Msg("error resuming function after invoke")
 				errs = multierror.Append(errs, err)
 			}
 		}()

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -158,6 +158,8 @@ type Pause struct {
 	// this is empty and the pause contains an expression, function state will
 	// be loaded from the store.
 	ExpressionData map[string]any `json:"data"`
+	// InvokeCorrelationID is the correlation ID for the invoke pause.
+	InvokeCorrelationID *string `json:"icID,omitempty"`
 	// OnTimeout indicates that this incoming edge should only be ran
 	// when the pause times out, if set to true.
 	OnTimeout bool `json:"onTimeout"`

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -229,8 +229,7 @@ func (p Pause) GetResumeData(evt event.Event) ResumeData {
 	// data and return only what the function returned. We do this here by unpacking the function
 	// finished event to pull out the correct data to place in state.
 	isInvokeFunctionOpcode := p.Opcode != nil && *p.Opcode == enums.OpcodeInvokeFunction.String()
-	isFnFinishedEvent := evt.Name == event.FnFinishedName
-	if isInvokeFunctionOpcode && isFnFinishedEvent {
+	if isInvokeFunctionOpcode && evt.IsFinishedEvent() {
 		if retRunID, ok := evt.Data["run_id"].(string); ok {
 			if ulidRunID, _ := ulid.Parse(retRunID); ulidRunID != (ulid.ULID{}) {
 				ret.RunID = &ulidRunID

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -42,6 +42,9 @@ type PauseMutater interface {
 
 	// DeletePause permanently deletes a pause.
 	DeletePause(ctx context.Context, p Pause) error
+
+	// DeleteInvoke removes the invoke correlation ID
+	DeleteInvoke(ctx context.Context, correlationID string) error
 }
 
 // PauseGetter allows a runner to return all existing pauses by event or by outgoing ID.  This
@@ -71,6 +74,12 @@ type PauseGetter interface {
 	//
 	// This should not return consumed pauses.
 	PausesByID(ctx context.Context, pauseID ...uuid.UUID) ([]*Pause, error)
+
+	// PauseByInvokeCorrelationID returns a given pause by the correlation ID.
+	// This must return expired invoke pauses that have not yet been consumed in order to properly handle timeouts.
+	//
+	// This should not return consumed pauses.
+	PauseByInvokeCorrelationID(ctx context.Context, correlationID string) (*Pause, error)
 }
 
 // PauseIterator allows the runner to iterate over all pauses returned by a PauseGetter.  This

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -73,7 +73,7 @@ type PauseGetter interface {
 	// This must return expired invoke pauses that have not yet been consumed in order to properly handle timeouts.
 	//
 	// This should not return consumed pauses.
-	PauseByInvokeCorrelationID(ctx context.Context, correlationID string) (*Pause, error)
+	PauseByInvokeCorrelationID(ctx context.Context, wsID uuid.UUID, correlationID string) (*Pause, error)
 }
 
 // PauseIterator allows the runner to iterate over all pauses returned by a PauseGetter.  This

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -19,7 +19,7 @@ type PauseMutater interface {
 	SavePause(ctx context.Context, p Pause) error
 
 	// SaveInvokePause is similar to SavePause but only handles invoke
-	SaveInvokePause(ctx context.Context, correlationID string, p Pause) error
+	SaveInvoke(ctx context.Context, correlationID string, pauseID string) error
 
 	// LeasePause allows us to lease the pause until the next step is enqueued, at which point
 	// we can 'consume' the pause to remove it.

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -18,6 +18,9 @@ type PauseMutater interface {
 	// DAG executions.
 	SavePause(ctx context.Context, p Pause) error
 
+	// SaveInvokePause is similar to SavePause but only handles invoke
+	SaveInvokePause(ctx context.Context, correlationID string, p Pause) error
+
 	// LeasePause allows us to lease the pause until the next step is enqueued, at which point
 	// we can 'consume' the pause to remove it.
 	//

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -18,9 +18,6 @@ type PauseMutater interface {
 	// DAG executions.
 	SavePause(ctx context.Context, p Pause) error
 
-	// SaveInvokePause is similar to SavePause but only handles invoke
-	SaveInvoke(ctx context.Context, correlationID string, pauseID string) error
-
 	// LeasePause allows us to lease the pause until the next step is enqueued, at which point
 	// we can 'consume' the pause to remove it.
 	//
@@ -42,9 +39,6 @@ type PauseMutater interface {
 
 	// DeletePause permanently deletes a pause.
 	DeletePause(ctx context.Context, p Pause) error
-
-	// DeleteInvoke removes the invoke correlation ID
-	DeleteInvoke(ctx context.Context, correlationID string) error
 }
 
 // PauseGetter allows a runner to return all existing pauses by event or by outgoing ID.  This

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -70,7 +70,7 @@ type KeyGenerator interface {
 	PauseIndex(ctx context.Context, kind string, wsID uuid.UUID, event string) string
 
 	// Invoke returns the key used to store the correlation key associated with invoke functions
-	Invoke(context.Context) string
+	Invoke(ctx context.Context, wsID uuid.UUID) string
 
 	// History returns the key used to store a log entry for run hisotry
 	History(ctx context.Context, runID ulid.ULID) string
@@ -139,8 +139,8 @@ func (d DefaultKeyFunc) PauseIndex(ctx context.Context, kind string, wsID uuid.U
 	return fmt.Sprintf("%s:pause-idx:%s:%s:%s", d.Prefix, kind, wsID, event)
 }
 
-func (d DefaultKeyFunc) Invoke(ctx context.Context) string {
-	return fmt.Sprintf("%s:invoke", d.Prefix)
+func (d DefaultKeyFunc) Invoke(ctx context.Context, wsID uuid.UUID) string {
+	return fmt.Sprintf("%s:invoke:%s", d.Prefix, wsID)
 }
 
 func (d DefaultKeyFunc) History(ctx context.Context, runID ulid.ULID) string {

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -69,6 +69,9 @@ type KeyGenerator interface {
 	// added after the cache was last updated.
 	PauseIndex(ctx context.Context, kind string, wsID uuid.UUID, event string) string
 
+	// InvokePause returns the key used to store the correlation key associated with invoke functions
+	InvokePause(context.Context) string
+
 	// History returns the key used to store a log entry for run hisotry
 	History(ctx context.Context, runID ulid.ULID) string
 
@@ -134,6 +137,10 @@ func (d DefaultKeyFunc) PauseIndex(ctx context.Context, kind string, wsID uuid.U
 		return fmt.Sprintf("%s:pause-idx:%s:%s:-", d.Prefix, kind, wsID)
 	}
 	return fmt.Sprintf("%s:pause-idx:%s:%s:%s", d.Prefix, kind, wsID, event)
+}
+
+func (d DefaultKeyFunc) InvokePause(ctx context.Context) string {
+	return fmt.Sprintf("%s:invoke-pause", d.Prefix)
 }
 
 func (d DefaultKeyFunc) History(ctx context.Context, runID ulid.ULID) string {

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -69,8 +69,8 @@ type KeyGenerator interface {
 	// added after the cache was last updated.
 	PauseIndex(ctx context.Context, kind string, wsID uuid.UUID, event string) string
 
-	// InvokePause returns the key used to store the correlation key associated with invoke functions
-	InvokePause(context.Context) string
+	// Invoke returns the key used to store the correlation key associated with invoke functions
+	Invoke(context.Context) string
 
 	// History returns the key used to store a log entry for run hisotry
 	History(ctx context.Context, runID ulid.ULID) string
@@ -139,8 +139,8 @@ func (d DefaultKeyFunc) PauseIndex(ctx context.Context, kind string, wsID uuid.U
 	return fmt.Sprintf("%s:pause-idx:%s:%s:%s", d.Prefix, kind, wsID, event)
 }
 
-func (d DefaultKeyFunc) InvokePause(ctx context.Context) string {
-	return fmt.Sprintf("%s:invoke-pause", d.Prefix)
+func (d DefaultKeyFunc) Invoke(ctx context.Context) string {
+	return fmt.Sprintf("%s:invoke", d.Prefix)
 }
 
 func (d DefaultKeyFunc) History(ctx context.Context, runID ulid.ULID) string {

--- a/pkg/execution/state/redis_state/lua/consumePause.lua
+++ b/pkg/execution/state/redis_state/lua/consumePause.lua
@@ -12,12 +12,14 @@ Output:
 local pauseKey      = KEYS[1]
 local pauseStepKey  = KEYS[2]
 local pauseEventKey = KEYS[3]
-local actionKey     = KEYS[4]
-local stackKey      = KEYS[5]
+local pauseInvokeKey = KEYS[4]
+local actionKey     = KEYS[5]
+local stackKey      = KEYS[6]
 
 local pauseID      = ARGV[1]
-local pauseDataKey = ARGV[2] -- used to set data in run state store
-local pauseDataVal = ARGV[3] -- data to set
+local invokeCorrelationId = ARGV[2]
+local pauseDataKey = ARGV[3] -- used to set data in run state store
+local pauseDataVal = ARGV[4] -- data to set
 
 local pause = redis.call("GET", pauseKey)
 if pause == false or pause == nil then
@@ -39,6 +41,10 @@ end
 if actionKey ~= nil and pauseDataKey ~= "" then
 	redis.call("RPUSH", stackKey, pauseDataKey)
 	redis.call("HSET", actionKey, pauseDataKey, pauseDataVal)
+end
+
+if invokeCorrelationId ~= false and invokeCorrelationId ~= "" and invokeCorrelationId ~= nil then
+	redis.call("HDEL", pauseInvokeKey, invokeCorrelationId)
 end
 
 return 0

--- a/pkg/execution/state/redis_state/lua/deletePause.lua
+++ b/pkg/execution/state/redis_state/lua/deletePause.lua
@@ -10,9 +10,17 @@ Output:
 local pauseKey      = KEYS[1]
 local pauseStepKey  = KEYS[2]
 local pauseEventKey = KEYS[3]
+local pauseInvokeKey = KEYS[4]
+
 local pauseID       = ARGV[1]
+local invokeCorrelationId = ARGV[2]
 
 redis.call("HDEL", pauseEventKey, pauseID)
 redis.call("DEL", pauseKey)
 redis.call("DEL", pauseStepKey)
+
+if invokeCorrelationId ~= false and invokeCorrelationId ~= "" and invokeCorrelationId ~= nil then
+  redis.call("HDEL", pauseInvokeKey, invokeCorrelationId)
+end
+
 return 0

--- a/pkg/execution/state/redis_state/lua/savePause.lua
+++ b/pkg/execution/state/redis_state/lua/savePause.lua
@@ -8,15 +8,17 @@
 local pauseKey    = KEYS[1]
 local stepKey     = KEYS[2]
 local pauseEvtKey = KEYS[3]
-local keyPauseAddIdx = KEYS[4]
-local keyPauseExpIdx = KEYS[5]
+local pauseInvokeKey = KEYS[4]
+local keyPauseAddIdx = KEYS[5]
+local keyPauseExpIdx = KEYS[6]
 
 local pause          = ARGV[1]
 local pauseID        = ARGV[2]
 local event          = ARGV[3]
-local expiry         = tonumber(ARGV[4])
-local extendedExpiry = tonumber(ARGV[5])
-local nowUnixSeconds = tonumber(ARGV[6])
+local invokeCorrelationID = ARGV[4]
+local expiry         = tonumber(ARGV[5])
+local extendedExpiry = tonumber(ARGV[6])
+local nowUnixSeconds = tonumber(ARGV[7])
 
 
 if redis.call("SETNX", pauseKey, pause) == 0 then
@@ -34,6 +36,10 @@ redis.call("ZADD", keyPauseExpIdx, nowUnixSeconds+expiry, pauseID)
 
 if event ~= false and event ~= "" and event ~= nil then
 	redis.call("HSET", pauseEvtKey, pauseID, pause)
+end
+
+if invokeCorrelationID ~= false and invokeCorrelationID ~= "" and invokeCorrelationID ~= nil then
+	redis.call("HSETNX", pauseInvokeKey, invokeCorrelationID, pauseID)
 end
 
 return 0

--- a/pkg/execution/state/redis_state/lua/savePause.lua
+++ b/pkg/execution/state/redis_state/lua/savePause.lua
@@ -1,3 +1,10 @@
+-- [[
+--
+-- Output:
+--   0: Successfully saved pause
+--   1: Pause already exists
+-- ]]
+
 local pauseKey    = KEYS[1]
 local stepKey     = KEYS[2]
 local pauseEvtKey = KEYS[3]
@@ -6,7 +13,7 @@ local keyPauseExpIdx = KEYS[5]
 
 local pause          = ARGV[1]
 local pauseID        = ARGV[2]
-local event          = ARGV[3] 
+local event          = ARGV[3]
 local expiry         = tonumber(ARGV[4])
 local extendedExpiry = tonumber(ARGV[5])
 local nowUnixSeconds = tonumber(ARGV[6])

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -626,7 +626,7 @@ func (m mgr) SavePause(ctx context.Context, p state.Pause) error {
 
 func (m mgr) SaveInvoke(ctx context.Context, correlationID string, pauseID string) error {
 	// store the invoke pause item in a hash map with the correlationID as the key
-	key := m.kf.InvokePause(ctx)
+	key := m.kf.Invoke(ctx)
 	cmd := m.pauseR.B().Hsetnx().Key(key).Field(correlationID).Value(pauseID).Build()
 	status, err := m.pauseR.Do(ctx, cmd).AsInt64()
 	if err != nil {
@@ -703,7 +703,7 @@ func (m mgr) DeletePause(ctx context.Context, p state.Pause) error {
 }
 
 func (m mgr) DeleteInvoke(ctx context.Context, correlationID string) error {
-	key := m.kf.InvokePause(ctx)
+	key := m.kf.Invoke(ctx)
 	cmd := m.pauseR.B().Hdel().Key(key).Field(correlationID).Build()
 	_, err := m.pauseR.Do(ctx, cmd).AsInt64()
 	return err
@@ -783,7 +783,7 @@ func (m mgr) PauseByID(ctx context.Context, id uuid.UUID) (*state.Pause, error) 
 }
 
 func (m mgr) PauseByInvokeCorrelationID(ctx context.Context, correlationID string) (*state.Pause, error) {
-	key := m.kf.InvokePause(ctx)
+	key := m.kf.Invoke(ctx)
 	cmd := m.pauseR.B().Hget().Key(key).Field(correlationID).Build()
 	pauseIDstr, err := m.pauseR.Do(ctx, cmd).ToString()
 	if err == rueidis.Nil {

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -581,7 +581,7 @@ func (m mgr) SavePause(ctx context.Context, p state.Pause) error {
 		m.kf.PauseID(ctx, p.ID),
 		m.kf.PauseStep(ctx, p.Identifier, p.Incoming),
 		m.kf.PauseEvent(ctx, p.WorkspaceID, evt),
-		m.kf.Invoke(ctx),
+		m.kf.Invoke(ctx, p.WorkspaceID),
 		m.kf.PauseIndex(ctx, "add", p.WorkspaceID, evt),
 		m.kf.PauseIndex(ctx, "exp", p.WorkspaceID, evt),
 	}
@@ -676,7 +676,7 @@ func (m mgr) DeletePause(ctx context.Context, p state.Pause) error {
 		m.kf.PauseID(ctx, p.ID),
 		m.kf.PauseStep(ctx, p.Identifier, p.Incoming),
 		eventKey,
-		m.kf.Invoke(ctx),
+		m.kf.Invoke(ctx, p.WorkspaceID),
 	}
 	corrId := ""
 	if p.InvokeCorrelationID != nil && *p.InvokeCorrelationID != "" {
@@ -723,7 +723,7 @@ func (m mgr) ConsumePause(ctx context.Context, id uuid.UUID, data any) error {
 		m.kf.PauseID(ctx, id),
 		m.kf.PauseStep(ctx, p.Identifier, p.Incoming),
 		eventKey,
-		m.kf.Invoke(ctx),
+		m.kf.Invoke(ctx, p.WorkspaceID),
 		m.kf.Actions(ctx, p.Identifier),
 		m.kf.Stack(ctx, p.Identifier.RunID),
 	}
@@ -781,8 +781,8 @@ func (m mgr) PauseByID(ctx context.Context, id uuid.UUID) (*state.Pause, error) 
 	return pause, err
 }
 
-func (m mgr) PauseByInvokeCorrelationID(ctx context.Context, correlationID string) (*state.Pause, error) {
-	key := m.kf.Invoke(ctx)
+func (m mgr) PauseByInvokeCorrelationID(ctx context.Context, wsID uuid.UUID, correlationID string) (*state.Pause, error) {
+	key := m.kf.Invoke(ctx, wsID)
 	cmd := m.pauseR.B().Hget().Key(key).Field(correlationID).Build()
 	pauseIDstr, err := m.pauseR.Do(ctx, cmd).ToString()
 	if err == rueidis.Nil {

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -702,13 +702,6 @@ func (m mgr) DeletePause(ctx context.Context, p state.Pause) error {
 	}
 }
 
-func (m mgr) DeleteInvoke(ctx context.Context, correlationID string) error {
-	key := m.kf.Invoke(ctx)
-	cmd := m.pauseR.B().Hdel().Key(key).Field(correlationID).Build()
-	_, err := m.pauseR.Do(ctx, cmd).AsInt64()
-	return err
-}
-
 func (m mgr) ConsumePause(ctx context.Context, id uuid.UUID, data any) error {
 	p, err := m.PauseByID(ctx, id)
 	if err != nil {

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -28,7 +28,6 @@ var (
 	// already leased by another event.
 	ErrPauseLeased        = fmt.Errorf("pause already leased")
 	ErrPauseAlreadyExists = fmt.Errorf("pause already exists")
-	ErrInvokePauseExists  = fmt.Errorf("invoke pause already exists")
 	ErrIdentifierExists   = fmt.Errorf("identifier already exists")
 	ErrFunctionCancelled  = fmt.Errorf("function cancelled")
 	ErrFunctionComplete   = fmt.Errorf("function completed")

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -27,6 +27,7 @@ var (
 	// already leased by another event.
 	ErrPauseLeased        = fmt.Errorf("pause already leased")
 	ErrPauseAlreadyExists = fmt.Errorf("pause already exists")
+	ErrInvokePauseExists  = fmt.Errorf("invoke pause already exists")
 	ErrIdentifierExists   = fmt.Errorf("identifier already exists")
 	ErrFunctionCancelled  = fmt.Errorf("function cancelled")
 	ErrFunctionComplete   = fmt.Errorf("function completed")

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -22,7 +22,8 @@ var (
 	ErrStepIncomplete = fmt.Errorf("step has not yet completed")
 	// ErrPauseNotFound is returned when attempting to lease or consume a pause
 	// that doesn't exist within the backing state store.
-	ErrPauseNotFound = fmt.Errorf("pause not found")
+	ErrPauseNotFound       = fmt.Errorf("pause not found")
+	ErrInvokePauseNotFound = fmt.Errorf("invoke pause not found")
 	// ErrPauseLeased is returned when attempting to lease a pause that is
 	// already leased by another event.
 	ErrPauseLeased        = fmt.Errorf("pause already leased")


### PR DESCRIPTION
## Motivation

Invokes currently contribute many pauses with expressions to the system. These pauses are attributed to the exceedingly common `inngest/function.finished` event, which is sent after the conclusion of each individual run.

Because of this, every run triggers us to check the incoming event against all pending invocation pauses. If there are many, pulling all of these pauses from Redis to then run CEL expressions against them can be very, very slow.

## Summary

Invokes, unlike userland `step.waitForEvent()` calls, are not arbitrary expressions. We piggybacked on the expressions system to build it, but in reality every invoke pause could be found with a single O(1) lookup, as we are searching for one string.

Because of this, we can pull `step.invoke()` pauses away from `step.waitForEvent()` pauses and optimize their performance without using expressions at all.

This PR:

1. Adds a new `CorrelationID` field to pauses
https://github.com/inngest/inngest/blob/073f71f8165ffe356fedb58f02d144d27911655f/pkg/execution/state/pause.go#L155-L156
2. When saving the pause, this is set in an `invoke` hash in Redis, with a value of the pause's ID
https://github.com/inngest/inngest/blob/073f71f8165ffe356fedb58f02d144d27911655f/pkg/execution/state/redis_state/lua/savePause.lua#L41-L43
3. If this correlation ID is set, we also do not touch the `pause-events` key when saving the promise, meaning regular pause processing will never see this pause and never pull it from Redis
https://github.com/inngest/inngest/blob/073f71f8165ffe356fedb58f02d144d27911655f/pkg/execution/state/redis_state/redis_state.go#L571-L578
4. When receiving an event, we check if the event is an `inngest/function.finished` event with a correlation ID
https://github.com/inngest/inngest/blob/073f71f8165ffe356fedb58f02d144d27911655f/pkg/execution/runner/runner.go#L363-L375
5. If yes, try get the pause ID from the `invoke` hash in Redis. If we find it, consume the pause and resume the invoking function
https://github.com/inngest/inngest/blob/073f71f8165ffe356fedb58f02d144d27911655f/pkg/execution/executor/executor.go#L1422-L1423

This ensures a few things:

- Invokes continue to use pauses and much of their existing logic, so this is a small code change
- Invokes are now completely removed from regular pause processing
- Invokes no longer use expressions and are always O(1) lookups

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

## Related

- #1263
This PR removes a tonne of pressure off of the `waitForEvent` CEL expressions by taking invokes out of the equation entirely. The linked PR also addresses very large numbers of non-invoke waits.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
