### PR TITLE
Add rerun mutation to Dev Server GQL

### DIFF
--- a/pkg/coreapi/gql.mutations.graphql
+++ b/pkg/coreapi/gql.mutations.graphql
@@ -12,6 +12,7 @@ type Mutation {
   ): Boolean
 
   cancelRun(runID: ULID!): FunctionRun!
+  rerun(runID: ULID!): ULID!
 }
 
 input CreateAppInput {

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -168,6 +168,21 @@ func NewOSSTrackedEvent(e Event) TrackedEvent {
 	}
 }
 
+// NewOSSTrackedEventWithID creates a new TrackedEvent with the given internal
+// ID. For internal use only: users should never be able to specify the internal
+// ID.
+//
+// We created this function because rerunning a function using
+// NewOSSTrackedEvent resulted in the wrong event ID in the history store. If
+// that behavior changes, then maybe this function isn't needed anymore
+func NewOSSTrackedEventWithID(e Event, internalID ulid.ULID) TrackedEvent {
+	e.ID = internalID.String()
+	return ossTrackedEvent{
+		Id:    internalID,
+		Event: e,
+	}
+}
+
 func NewOSSTrackedEventFromString(data string) (*ossTrackedEvent, error) {
 	evt := &ossTrackedEvent{}
 	if err := json.Unmarshal([]byte(data), evt); err != nil {


### PR DESCRIPTION
## Description
Create a GraphQL mutation for rerunning a function run

## Motivation
This functionality exists in Cloud but not the Dev Server

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
