### PR TITLE
Fix Dev Server polling and discovery

### DIFF
--- a/pkg/devserver/discovery/discovery.go
+++ b/pkg/devserver/discovery/discovery.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/inngest/inngest/pkg/util"
 )
 
 var (
@@ -71,7 +73,7 @@ func Autodiscover(ctx context.Context) map[string]struct{} {
 		for _, path := range Paths {
 			// These requests _should_ be fast as we know a port is open,
 			// so we do these sequentially.
-			url := fmt.Sprintf("http://127.0.0.1:%d%s", port, path)
+			url := util.NormalizeAppURL(fmt.Sprintf("http://127.0.0.1:%d%s", port, path), false)
 			if err := checkURL(ctx, url); err == nil {
 				if _, ok := urls[url]; !ok {
 					// only add if the URL doesn't exist;  this ensures

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -138,9 +138,7 @@ func (d *devserver) Pre(ctx context.Context) error {
 
 func (d *devserver) Run(ctx context.Context) error {
 	// Start polling the SDKs as the APIs are going live.
-	if d.opts.Poll {
-		go d.pollSDKs(ctx)
-	}
+	go d.pollSDKs(ctx)
 
 	// Add a nice output to the terminal.
 	if isatty.IsTerminal(os.Stdout.Fd()) {
@@ -236,6 +234,10 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 			for _, app := range apps {
 				// We've seen this URL.
 				urls[app.Url] = struct{}{}
+
+				if !d.opts.Poll && len(app.Error.String) == 0 {
+					continue
+				}
 
 				// Make a new PUT request to each app, indicating that the
 				// SDK should push functions to the dev server.


### PR DESCRIPTION
## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

Polling and discovery in the Dev Server can be really verbose. Many frameworks, by default, will log all incoming HTTP requests, resulting in a huge spam of logs while the Dev Server is running. This makes debugging harder and it just looks messy.

In addition, the `--no-discovery` and `--no-poll` flags can unintentionally remove features, meaning users cannot achieve a balance of automatically adding the apps they want without spamming.

## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

This PR aims to clear up the confusion of these flags the functionality it controls.

In this area, there are a few scenarios to cover. This is the behaviour we're aiming for, with ⚠️ marks representing that this is not the current functionality and will be fixed in this PR.

| Command | App present on boot? | Finds new apps? | Poll working apps? | Poll erroring apps? |
| - | - | - | - | - |
| No flags | No | Yes | Yes | Yes |
| `--no-poll` | No | Yes ⚠️ | No | Yes ⚠️ |
| `--no-discovery` | No | No | Yes | Yes |
| `--no-poll --no-discovery` | No | No | No | Yes |
| `--sdk-url` | Yes | Yes | Yes | Yes |
| `--no-poll --sdk-url` | Yes ⚠️ | Yes ⚠️ | No | Yes ⚠️ |
| `--no-discovery --sdk-url` | Yes | No | Yes | Yes |
| `--no-poll --no-discovery --sdk-url` | Yes ⚠️ | No | No | Yes ⚠️ |

From this, we see an incompatibility with `--no-poll` and other options. To fix this, if `--no-poll` is specified:

- [x] Allow initial discovery?
- [x] Continue to poll erroring apps?

With the latter, an erroring app means that either it _did_ exist or a user manually added it via the flag or UI. If this is the case, should we poll until we find it?

### UI

The UI also always shows that we are "_Auto-detecting apps..._" and doesn't actually check whether this feature is enabled or not.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
