### PR TITLE
Rename signing_key_fallback_hash in introspection

### DIFF
--- a/docs/SDK_SPEC.md
+++ b/docs/SDK_SPEC.md
@@ -919,11 +919,11 @@ If the request passes signature validation, then the response schema MUST be:
 ```ts
 {
   extra?: Record<string, any>
-	fallback_signing_key_hash: string
 	function_count: number
 	has_event_key: boolean
 	has_signing_key: boolean
 	mode: "cloud" | "dev"
+	signing_key_fallback_hash: string
 	signing_key_hash: string
 }
 ```


### PR DESCRIPTION
## Description
Rename `signing_key_fallback_hash` in the introspection endpoint response to more closely match its associated env var (`INNGEST_SIGNING_KEY_FALLBACK`)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [x] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
