### PR TITLE
INN-2912: Minor tweaks for span annotations

### DIFF
--- a/pkg/consts/otel.go
+++ b/pkg/consts/otel.go
@@ -68,5 +68,6 @@ const (
 	// otel collector filter keys
 	OtelUserTraceFilterKey = "inngest.user"
 
-	OtelPropagationKey = "sys.trace"
+	OtelPropagationKey     = "sys.trace"
+	OtelPropagationLinkKey = "sys.trace.link"
 )

--- a/pkg/consts/otel.go
+++ b/pkg/consts/otel.go
@@ -33,6 +33,7 @@ const (
 	OtelSysStepStatus          = "sys.step.status"
 	OtelSysStepStatusCode      = "sys.step.status.code"
 	OtelSysStepAttempt         = "sys.step.attempt"
+	OtelSysStepMaxAttempt      = "sys.step.attempt.max"
 	OtelSysStepOutput          = "sys.step.output"
 	OtelSysStepOutputSizeBytes = "sys.step.output.size.bytes"
 	OtelSysStepFirst           = "sys.step.first"

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -672,6 +672,7 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			attribute.Int(consts.OtelSysFunctionVersion, id.WorkflowVersion),
 			attribute.String(consts.OtelAttrSDKRunID, id.RunID.String()),
 			attribute.Int(consts.OtelSysStepAttempt, item.Attempt),
+			attribute.Int(consts.OtelSysStepMaxAttempt, item.GetMaxAttempts()),
 			attribute.String(consts.OtelSysStepGroupID, item.GroupID),
 		),
 	)

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -314,6 +314,13 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	if len(req.Events) > 1 {
 		span.SetAttributes(attribute.String(consts.OtelSysBatchID, req.BatchID.String()))
 	}
+	if req.Context != nil {
+		if val, ok := req.Context[consts.OtelPropagationLinkKey]; ok {
+			if link, ok := val.(string); ok {
+				span.SetAttributes(attribute.String(consts.OtelPropagationLinkKey, link))
+			}
+		}
+	}
 
 	var key string
 	if req.IdempotencyKey != nil {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -651,6 +651,13 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 	if len(id.EventIDs) > 1 {
 		fnSpan.SetAttributes(attribute.String(consts.OtelSysBatchID, id.BatchID.String()))
 	}
+	for _, e := range s.Events() {
+		if byt, err := json.Marshal(e); err == nil {
+			fnSpan.AddEvent(string(byt), trace.WithAttributes(
+				attribute.Bool(consts.OtelSysEventData, true),
+			))
+		}
+	}
 
 	ctx, span := telemetry.NewSpan(ctx,
 		telemetry.WithScope(consts.OtelScopeExecution),

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -342,7 +342,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		eventIDsStr = append(eventIDsStr, id.String())
 	}
 	spanID := telemetry.NewSpanID(ctx)
-	span.SetAttributes(attribute.StringSlice(consts.OtelSysEventIDs, eventIDsStr))
+	span.SetAttributes(attribute.String(consts.OtelSysEventIDs, strings.Join(eventIDsStr, ",")))
 
 	id := state.Identifier{
 		WorkflowID:      req.Function.ID,
@@ -628,7 +628,7 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			attribute.String(consts.OtelSysFunctionSlug, s.Function().GetSlug()),
 			attribute.Int(consts.OtelSysFunctionVersion, id.WorkflowVersion),
 			attribute.String(consts.OtelAttrSDKRunID, id.RunID.String()),
-			attribute.StringSlice(consts.OtelSysEventIDs, evtIDs),
+			attribute.String(consts.OtelSysEventIDs, strings.Join(evtIDs, ",")),
 			attribute.String(consts.OtelSysIdempotencyKey, id.IdempotencyKey()),
 		),
 	)

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -307,6 +307,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 			attribute.String(consts.OtelSysFunctionSlug, req.Function.GetSlug()),
 			attribute.Int(consts.OtelSysFunctionVersion, req.Function.FunctionVersion),
 			attribute.String(consts.OtelAttrSDKRunID, runID.String()),
+			attribute.String(consts.OtelSysFunctionStatus, enums.RunStatusScheduled.String()),
 		),
 	)
 	defer span.End()

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -321,6 +321,14 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 			}
 		}
 	}
+	for _, e := range req.Events {
+		evt := e.GetEvent()
+		if byt, err := json.Marshal(evt); err == nil {
+			span.AddEvent(string(byt), trace.WithAttributes(
+				attribute.Bool(consts.OtelSysEventData, true),
+			))
+		}
+	}
 
 	var key string
 	if req.IdempotencyKey != nil {

--- a/pkg/telemetry/span.go
+++ b/pkg/telemetry/span.go
@@ -64,9 +64,13 @@ func WithSpanKind(k trace.SpanKind) SpanOpt {
 	}
 }
 
-func WithLinks(l []tracesdk.Link) SpanOpt {
+func WithLinks(links ...tracesdk.Link) SpanOpt {
 	return func(s *spanOpt) {
-		s.links = l
+		for _, l := range links {
+			if l.SpanContext.IsValid() {
+				s.links = append(s.links, l)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Small tweaks to span annotations to collect relevant information related to the function run.

The `StringSlice` type is not ideal since the slice will be serialized to a string, and it makes it harder to deserialize it back to an `Array(String)` type.
Instead, make it a comma delimited string, and let the database (or whatever downstream to) handle the string splitting.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
