### PR TITLE
Invalidate too large batch sizes

### DIFF
--- a/pkg/inngest/batch.go
+++ b/pkg/inngest/batch.go
@@ -68,6 +68,12 @@ func (c EventBatchConfig) IsValid() error {
 			Message: fmt.Sprintf("batch size cannot be smaller than 2: %d", c.MaxSize),
 		}
 	}
+	if c.MaxSize > consts.DefaultBatchSize {
+		return syscode.Error{
+			Code:    syscode.CodeBatchSizeInvalid,
+			Message: fmt.Sprintf("batch size cannot be larger than %d", consts.DefaultBatchSize),
+		}
+	}
 
 	if _, err := time.ParseDuration(c.Timeout); err != nil {
 		return fmt.Errorf("invalid timeout string: %v", err)

--- a/pkg/syscode/codes.go
+++ b/pkg/syscode/codes.go
@@ -2,6 +2,7 @@ package syscode
 
 const (
 	CodeBatchSizeInvalid        = "batch_size_invalid"
+	CodeComboUnsupported        = "combo_unsupported"
 	CodeConcurrencyLimitInvalid = "concurrency_limit_invalid"
 	CodeConfigInvalid           = "config_invalid"
 	CodeUnknown                 = "unknown"


### PR DESCRIPTION
## Description
During function config validation, return an error if the batch size is too large

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
