### PR TITLE
Hotfix: Ensure that modals and dialogs are at highest z-index

### DIFF
--- a/ui/apps/dashboard/src/components/Modal.tsx
+++ b/ui/apps/dashboard/src/components/Modal.tsx
@@ -35,14 +35,14 @@ export default function Modal({
           {/* The backdrop, rendered as a fixed sibling to the panel container */}
           <div
             className={cn(
-              'fixed inset-0 z-50 bg-black/50 backdrop-blur-[2px] transition-opacity',
+              'fixed inset-0 z-[100] bg-black/50 backdrop-blur-[2px] transition-opacity',
               backdropClassName
             )}
             aria-hidden="true"
           />
         </Transition.Child>
         {/* Full-screen container to center the panel */}
-        <div className="fixed inset-0 z-50 overflow-y-auto">
+        <div className="fixed inset-0 z-[100] overflow-y-auto">
           <div
             className={cn('flex min-h-full items-center justify-center p-6', containerClassName)}
           >

--- a/ui/packages/components/src/Modal/AlertModal.tsx
+++ b/ui/packages/components/src/Modal/AlertModal.tsx
@@ -32,12 +32,12 @@ export function AlertModal({
         <AlertDialog.Portal container={container}>
           <AlertDialog.Overlay asChild>
             <div
-              className="fixed inset-0 z-50 bg-black/50 backdrop-blur-[2px] transition-opacity dark:bg-[#04060C]/90"
+              className="fixed inset-0 z-[100] bg-black/50 backdrop-blur-[2px] transition-opacity dark:bg-[#04060C]/90"
               aria-hidden="true"
             />
           </AlertDialog.Overlay>
           {/* Full-screen container to center the panel */}
-          <div className="fixed inset-0 z-50 overflow-y-auto">
+          <div className="fixed inset-0 z-[100] overflow-y-auto">
             <motion.div
               className="flex min-h-full w-full items-center justify-center p-6"
               initial={{ y: -20, opacity: 0.2 }}


### PR DESCRIPTION
## Description

Modals were unreachable when there were other z-index elements like the timeline that conflicted.


## Motivation
The cancel modal was hidden below the timeline making it impossible for the user to cancel a run.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
