### PR TITLE
reverse the order of the error message as it's confusing

### DIFF
--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -132,7 +132,7 @@ func (a devapi) Register(w http.ResponseWriter, r *http.Request) {
 
 	expectedServerKind := r.Header.Get(headers.HeaderKeyExpectedServerKind)
 	if expectedServerKind != "" && expectedServerKind != headers.ServerKindDev {
-		a.err(ctx, w, 400, fmt.Errorf("Expected server kind %s, got %s", expectedServerKind, headers.ServerKindDev))
+		a.err(ctx, w, 400, fmt.Errorf("Expected server kind %s, got %s", headers.ServerKindDev, expectedServerKind))
 		return
 	}
 


### PR DESCRIPTION
## Description

The expected value should be first, not second.


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
