### PR TITLE
Fix payments table overflow

### DIFF
--- a/ui/apps/dashboard/src/components/Table.tsx
+++ b/ui/apps/dashboard/src/components/Table.tsx
@@ -35,7 +35,7 @@ export default function Table<T extends Row>({
             data.map((row, idx) => (
               <tr className="truncate" key={`tr-${idx}`}>
                 {columns.map((column, idx) => (
-                  <td className={cn('p-3', column.className)} key={`td-${idx}`}>
+                  <td className={cn('truncate p-3', column.className)} key={`td-${idx}`}>
                     {column.render ? column.render(row) : row[column.key]}
                   </td>
                 ))}


### PR DESCRIPTION
## Description

For long plan names that create long invoice names, the column always overflows text. See screenshot for after (w/ truncation) and before.

![image](https://github.com/inngest/inngest/assets/1509457/b9177002-6907-401a-b3af-bf66f7d9ee3c)


## Motivation
Without this, the table looks terrible.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
