### PR TITLE
Add poll interval flag to CLI dev command

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -28,6 +28,7 @@ func NewCmdDev() *cobra.Command {
 	cmd.Flags().StringSliceP("sdk-url", "u", []string{}, "SDK URLs to load functions from")
 	cmd.Flags().Bool("no-discovery", false, "Disable autodiscovery")
 	cmd.Flags().Bool("no-poll", false, "Disable polling of apps for updates")
+	cmd.Flags().Int("poll-interval", 5, "Interval in seconds between polling for updates to apps")
 	cmd.Flags().Int("retry-interval", 0, "Retry interval in seconds for linear backoff when retrying functions - must be 1 or above")
 
 	cmd.Flags().Int("tick", 150, "The interval (in milliseconds) at which the executor checks for new work, during local development")
@@ -74,6 +75,7 @@ func doDev(cmd *cobra.Command, args []string) {
 	// Run auto-discovery unless we've explicitly disabled it.
 	noDiscovery, _ := cmd.Flags().GetBool("no-discovery")
 	noPoll, _ := cmd.Flags().GetBool("no-poll")
+	pollInterval, _ := cmd.Flags().GetInt("poll-interval")
 	retryInterval, _ := cmd.Flags().GetInt("retry-interval")
 	tick, _ := cmd.Flags().GetInt("tick")
 
@@ -93,6 +95,7 @@ func doDev(cmd *cobra.Command, args []string) {
 		URLs:          urls,
 		Autodiscover:  !noDiscovery,
 		Poll:          !noPoll,
+		PollInterval:  pollInterval,
 		RetryInterval: retryInterval,
 		Tick:          time.Duration(tick) * time.Millisecond,
 	}

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -49,6 +49,7 @@ type StartOpts struct {
 	URLs          []string      `json:"urls"`
 	Autodiscover  bool          `json:"autodiscover"`
 	Poll          bool          `json:"poll"`
+	PollInterval  int           `json:"poll_interval"`
 	Tick          time.Duration `json:"tick"`
 	RetryInterval int           `json:"retry_interval"`
 }

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -37,10 +37,6 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-const (
-	SDKPollInterval = 5 * time.Second
-)
-
 func newService(opts StartOpts, runner runner.Runner, data cqrs.Manager, pb pubsub.Publisher) *devserver {
 	return &devserver{
 		data:        data,
@@ -202,6 +198,8 @@ func (d *devserver) runDiscovery(ctx context.Context) {
 // pollSDKs hits each SDK's register endpoint, asking them to communicate with
 // the dev server to re-register their functions.
 func (d *devserver) pollSDKs(ctx context.Context) {
+	pollInterval := time.Duration(d.opts.PollInterval)
+
 	// Initially, add every app started with the `-u` flag
 	for _, url := range d.opts.URLs {
 		// URLs must contain a protocol. If not, add http since very few apps
@@ -270,7 +268,7 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 				}
 			}
 		}
-		<-time.After(SDKPollInterval)
+		<-time.After(pollInterval)
 	}
 }
 

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -182,6 +182,7 @@ func (d *devserver) Stop(ctx context.Context) error {
 // any point.
 func (d *devserver) runDiscovery(ctx context.Context) {
 	logger.From(ctx).Info().Msg("autodiscovering locally hosted SDKs")
+	pollInterval := time.Duration(d.opts.PollInterval) * time.Second
 	for {
 		if ctx.Err() != nil {
 			return
@@ -191,14 +192,14 @@ func (d *devserver) runDiscovery(ctx context.Context) {
 			_ = discovery.Autodiscover(ctx)
 		}
 
-		<-time.After(5 * time.Second)
+		<-time.After(pollInterval)
 	}
 }
 
 // pollSDKs hits each SDK's register endpoint, asking them to communicate with
 // the dev server to re-register their functions.
 func (d *devserver) pollSDKs(ctx context.Context) {
-	pollInterval := time.Duration(d.opts.PollInterval)
+	pollInterval := time.Duration(d.opts.PollInterval) * time.Second
 
 	// Initially, add every app started with the `-u` flag
 	for _, url := range d.opts.URLs {


### PR DESCRIPTION
## Description

This allows a user to control the amount of polling pings that we send to their server.

This is a nice complement to #1274

## Motivation
A user request.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
