### PR TITLE
Reuse batching logic in executor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ pkg/devserver/static/
 Thumbs.db
 
 /.vercel/
+
+.idea

--- a/pkg/execution/batch/batch.go
+++ b/pkg/execution/batch/batch.go
@@ -2,7 +2,6 @@ package batch
 
 import (
 	"context"
-	"github.com/inngest/inngest/pkg/execution"
 	"time"
 
 	"github.com/google/uuid"
@@ -36,15 +35,6 @@ type BatchManager interface {
 	StartExecution(ctx context.Context, fnID uuid.UUID, batchID ulid.ULID) (string, error)
 	ScheduleExecution(ctx context.Context, opts ScheduleBatchOpts) error
 	ExpireKeys(ctx context.Context, batchID ulid.ULID) error
-}
-
-// BatchExecutor extends BatchManager and implements higher-level batch lifecycle methods for
-// both scheduling and running batch executions
-type BatchExecutor interface {
-	BatchManager
-
-	AppendAndSchedule(ctx context.Context, executor execution.Executor, fn inngest.Function, bi BatchItem) error
-	RetrieveAndSchedule(ctx context.Context, executor execution.Executor, batchID ulid.ULID, fn inngest.Function, accountId, workspaceId, appId uuid.UUID) error
 }
 
 // BatchItem represents the item that are being batched.

--- a/pkg/execution/batch/batch.go
+++ b/pkg/execution/batch/batch.go
@@ -2,6 +2,7 @@ package batch
 
 import (
 	"context"
+	"github.com/inngest/inngest/pkg/execution"
 	"time"
 
 	"github.com/google/uuid"
@@ -35,6 +36,15 @@ type BatchManager interface {
 	StartExecution(ctx context.Context, fnID uuid.UUID, batchID ulid.ULID) (string, error)
 	ScheduleExecution(ctx context.Context, opts ScheduleBatchOpts) error
 	ExpireKeys(ctx context.Context, batchID ulid.ULID) error
+}
+
+// BatchExecutor extends BatchManager and implements higher-level batch lifecycle methods for
+// both scheduling and running batch executions
+type BatchExecutor interface {
+	BatchManager
+
+	AppendAndSchedule(ctx context.Context, executor execution.Executor, fn inngest.Function, bi BatchItem) error
+	RetrieveAndSchedule(ctx context.Context, executor execution.Executor, batchID ulid.ULID, fn inngest.Function, accountId, workspaceId, appId uuid.UUID) error
 }
 
 // BatchItem represents the item that are being batched.

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -5,10 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"github.com/inngest/inngest/pkg/event"
-	"github.com/inngest/inngest/pkg/execution"
-	"github.com/inngest/inngest/pkg/telemetry"
-	"go.opentelemetry.io/otel/attribute"
 	"time"
 
 	"github.com/google/uuid"
@@ -208,96 +204,6 @@ func (b redisBatchManager) ExpireKeys(ctx context.Context, batchID ulid.ULID) er
 		args,
 	).AsInt64(); err != nil {
 		return fmt.Errorf("failed to expire batch '%s' related keys: %v", batchID, err)
-	}
-
-	return nil
-}
-
-// AppendAndSchedule appends a new batch item. If a new batch is created, it will be scheduled to run
-// after the batch timeout. If the item finalizes the batch, a function run is immediately scheduled.
-func (b redisBatchManager) AppendAndSchedule(ctx context.Context, executor execution.Executor, fn inngest.Function, bi BatchItem) error {
-	result, err := b.Append(ctx, bi, fn)
-	if err != nil {
-		return err
-	}
-
-	switch result.Status {
-	case enums.BatchAppend:
-		// noop
-	case enums.BatchNew:
-		dur, err := time.ParseDuration(fn.EventBatch.Timeout)
-		if err != nil {
-			return err
-		}
-		at := time.Now().Add(dur)
-
-		if err := b.ScheduleExecution(ctx, ScheduleBatchOpts{
-			ScheduleBatchPayload: ScheduleBatchPayload{
-				BatchID:         ulid.MustParse(result.BatchID),
-				AccountID:       bi.AccountID,
-				WorkspaceID:     bi.WorkspaceID,
-				AppID:           bi.AppID,
-				FunctionID:      bi.FunctionID,
-				FunctionVersion: bi.FunctionVersion,
-			},
-			At: at,
-		}); err != nil {
-			return err
-		}
-	case enums.BatchFull:
-		// start execution immediately
-		batchID := ulid.MustParse(result.BatchID)
-		if err := b.RetrieveAndSchedule(ctx, executor, batchID, fn, bi.AccountID, bi.WorkspaceID, bi.AppID); err != nil {
-			return fmt.Errorf("could not retrieve and schedule batch items: %w", err)
-		}
-	default:
-		return fmt.Errorf("invalid status of batch append ops: %d", result.Status)
-	}
-
-	return nil
-}
-
-// RetrieveAndSchedule retrieves all items from a started batch and schedules a function run
-func (b redisBatchManager) RetrieveAndSchedule(ctx context.Context, executor execution.Executor, batchID ulid.ULID, fn inngest.Function, accountId, workspaceId, appId uuid.UUID) error {
-	evtList, err := b.RetrieveItems(ctx, batchID)
-	if err != nil {
-		return err
-	}
-
-	events := make([]event.TrackedEvent, len(evtList))
-	for i, e := range evtList {
-		events[i] = e
-	}
-
-	ctx, span := telemetry.NewSpan(ctx,
-		telemetry.WithScope(consts.OtelScopeBatch),
-		telemetry.WithName(consts.OtelSpanBatch),
-		telemetry.WithSpanAttributes(
-			attribute.String(consts.OtelSysAccountID, accountId.String()),
-			attribute.String(consts.OtelSysWorkspaceID, workspaceId.String()),
-			attribute.String(consts.OtelSysAppID, appId.String()),
-			attribute.String(consts.OtelSysFunctionID, fn.ID.String()),
-			attribute.String(consts.OtelSysBatchID, batchID.String()),
-			attribute.Bool(consts.OtelSysBatchFull, true),
-		))
-	defer span.End()
-
-	key := fmt.Sprintf("%s-%s", fn.ID, batchID)
-	_, err = executor.Schedule(ctx, execution.ScheduleRequest{
-		AccountID:      accountId,
-		WorkspaceID:    workspaceId,
-		AppID:          appId,
-		Function:       fn,
-		Events:         events,
-		BatchID:        &batchID,
-		IdempotencyKey: &key,
-	})
-	if err != nil {
-		return err
-	}
-
-	if err := b.ExpireKeys(ctx, batchID); err != nil {
-		return err
 	}
 
 	return nil

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -162,8 +162,10 @@ func (b redisBatchManager) ScheduleExecution(ctx context.Context, opts ScheduleB
 		Identifier: state.Identifier{
 			WorkflowID:      opts.FunctionID,
 			WorkflowVersion: opts.FunctionVersion,
-			RunID:           ulid.Make(),
 			Key:             fmt.Sprintf("batchschedule:%s", opts.BatchID),
+			AccountID:       opts.AccountID,
+			WorkspaceID:     opts.WorkspaceID,
+			AppID:           opts.AppID,
 		},
 		Attempt:     0,
 		MaxAttempts: &maxAttempts,

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -3,6 +3,7 @@ package execution
 import (
 	"context"
 	"encoding/json"
+	"github.com/inngest/inngest/pkg/execution/batch"
 	"time"
 
 	"github.com/google/uuid"
@@ -121,6 +122,9 @@ type Executor interface {
 
 	// InvokeNotFoundHandler invokes the invoke not found handler.
 	InvokeNotFoundHandler(context.Context, InvokeNotFoundHandlerOpts) error
+
+	AppendAndScheduleBatch(ctx context.Context, fn inngest.Function, bi batch.BatchItem) error
+	RetrieveAndScheduleBatch(ctx context.Context, fn inngest.Function, payload batch.ScheduleBatchPayload) error
 }
 
 // PublishFinishedEventOpts represents the options for publishing a finished event.

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2348,6 +2348,7 @@ func (e executor) RetrieveAndScheduleBatch(ctx context.Context, fn inngest.Funct
 	ctx, span := telemetry.NewSpan(ctx,
 		telemetry.WithScope(consts.OtelScopeBatch),
 		telemetry.WithName(consts.OtelSpanBatch),
+		telemetry.WithNewRoot(),
 		telemetry.WithSpanAttributes(
 			attribute.Bool(consts.OtelUserTraceFilterKey, true),
 			attribute.String(consts.OtelSysAccountID, payload.AccountID.String()),

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2282,6 +2282,112 @@ func (e *executor) extractTraceCtx(ctx context.Context, id state.Identifier, ite
 	return ctx
 }
 
+// AppendAndScheduleBatch appends a new batch item. If a new batch is created, it will be scheduled to run
+// after the batch timeout. If the item finalizes the batch, a function run is immediately scheduled.
+func (e executor) AppendAndScheduleBatch(ctx context.Context, fn inngest.Function, bi batch.BatchItem) error {
+	result, err := e.batcher.Append(ctx, bi, fn)
+	if err != nil {
+		return err
+	}
+
+	switch result.Status {
+	case enums.BatchAppend:
+		// noop
+	case enums.BatchNew:
+		dur, err := time.ParseDuration(fn.EventBatch.Timeout)
+		if err != nil {
+			return err
+		}
+		at := time.Now().Add(dur)
+
+		if err := e.batcher.ScheduleExecution(ctx, batch.ScheduleBatchOpts{
+			ScheduleBatchPayload: batch.ScheduleBatchPayload{
+				BatchID:         ulid.MustParse(result.BatchID),
+				AccountID:       bi.AccountID,
+				WorkspaceID:     bi.WorkspaceID,
+				AppID:           bi.AppID,
+				FunctionID:      bi.FunctionID,
+				FunctionVersion: bi.FunctionVersion,
+			},
+			At: at,
+		}); err != nil {
+			return err
+		}
+	case enums.BatchFull:
+		// start execution immediately
+		batchID := ulid.MustParse(result.BatchID)
+		if err := e.RetrieveAndScheduleBatch(ctx, fn, batch.ScheduleBatchPayload{
+			BatchID:     batchID,
+			AppID:       bi.AppID,
+			WorkspaceID: bi.WorkspaceID,
+			AccountID:   bi.AccountID,
+		}); err != nil {
+			return fmt.Errorf("could not retrieve and schedule batch items: %w", err)
+		}
+	default:
+		return fmt.Errorf("invalid status of batch append ops: %d", result.Status)
+	}
+
+	return nil
+}
+
+// RetrieveAndScheduleBatch retrieves all items from a started batch and schedules a function run
+func (e executor) RetrieveAndScheduleBatch(ctx context.Context, fn inngest.Function, payload batch.ScheduleBatchPayload) error {
+	evtList, err := e.batcher.RetrieveItems(ctx, payload.BatchID)
+	if err != nil {
+		return err
+	}
+
+	evtIDs := make([]string, len(evtList))
+	events := make([]event.TrackedEvent, len(evtList))
+	for i, e := range evtList {
+		events[i] = e
+		evtIDs[i] = e.GetInternalID().String()
+	}
+
+	ctx, span := telemetry.NewSpan(ctx,
+		telemetry.WithScope(consts.OtelScopeBatch),
+		telemetry.WithName(consts.OtelSpanBatch),
+		telemetry.WithSpanAttributes(
+			attribute.Bool(consts.OtelUserTraceFilterKey, true),
+			attribute.String(consts.OtelSysAccountID, payload.AccountID.String()),
+			attribute.String(consts.OtelSysWorkspaceID, payload.WorkspaceID.String()),
+			attribute.String(consts.OtelSysAppID, payload.AppID.String()),
+			attribute.String(consts.OtelSysFunctionID, fn.ID.String()),
+			attribute.String(consts.OtelSysBatchID, payload.BatchID.String()),
+			attribute.Bool(consts.OtelSysBatchFull, true),
+			attribute.String(consts.OtelSysEventIDs, strings.Join(evtIDs, ",")),
+		))
+	defer span.End()
+
+	key := fmt.Sprintf("%s-%s", fn.ID, payload.BatchID)
+	identifier, err := e.Schedule(ctx, execution.ScheduleRequest{
+		AccountID:      payload.AccountID,
+		WorkspaceID:    payload.WorkspaceID,
+		AppID:          payload.AppID,
+		Function:       fn,
+		Events:         events,
+		BatchID:        &payload.BatchID,
+		IdempotencyKey: &key,
+	})
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	if identifier != nil {
+		span.SetAttributes(attribute.String(consts.OtelAttrSDKRunID, identifier.RunID.String()))
+	} else {
+		span.SetAttributes(attribute.Bool(consts.OtelSysStepDelete, true))
+	}
+
+	if err := e.batcher.ExpireKeys(ctx, payload.BatchID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // extractTraceCtxFromMap extracts the trace context from a map, if it exists.
 // If it doesn't or it is invalid, it nil.
 func extractTraceCtxFromMap(ctx context.Context, target map[string]any) (context.Context, bool) {

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -318,48 +318,8 @@ func (s *svc) handleScheduledBatch(ctx context.Context, item queue.Item) error {
 		return err
 	}
 
-	// TODO: this logic is repeated in runner, consolidate it somewhere
-	// convert batch items to tracked events
-	items, err := s.batcher.RetrieveItems(ctx, batchID)
-	if err != nil {
-		return err
-	}
-	events := make([]event.TrackedEvent, len(items))
-	for i, item := range items {
-		events[i] = item
-	}
-
-	ctx, span := telemetry.NewSpan(ctx,
-		telemetry.WithScope(consts.OtelScopeBatch),
-		telemetry.WithName(consts.OtelSpanBatch),
-		telemetry.WithSpanAttributes(
-			attribute.String(consts.OtelSysAccountID, item.Identifier.AccountID.String()),
-			attribute.String(consts.OtelSysWorkspaceID, item.Identifier.WorkspaceID.String()),
-			attribute.String(consts.OtelSysAppID, item.Identifier.AppID.String()),
-			attribute.String(consts.OtelSysFunctionID, item.Identifier.WorkflowID.String()),
-			attribute.String(consts.OtelSysBatchID, batchID.String()),
-			attribute.Bool(consts.OtelSysBatchFull, true),
-		),
-	)
-	defer span.End()
-
-	// start execution
-	id := fmt.Sprintf("%s-%s", opts.FunctionID, batchID)
-	_, err = s.exec.Schedule(ctx, execution.ScheduleRequest{
-		AccountID:      opts.AccountID,
-		WorkspaceID:    opts.WorkspaceID,
-		AppID:          opts.AppID,
-		Function:       *fn,
-		Events:         events,
-		BatchID:        &batchID,
-		IdempotencyKey: &id,
-	})
-	if err != nil {
-		return err
-	}
-
-	if err := s.batcher.ExpireKeys(ctx, batchID); err != nil {
-		return err
+	if err := s.batcher.(batch.BatchExecutor).RetrieveAndSchedule(ctx, s.Executor(), batchID, *fn, item.Identifier.AccountID, item.Identifier.WorkspaceID, item.Identifier.AppID); err != nil {
+		return fmt.Errorf("could not retrieve and schedule batch items: %w", err)
 	}
 
 	return nil

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -324,7 +324,7 @@ func (s *svc) handleScheduledBatch(ctx context.Context, item queue.Item) error {
 		WorkspaceID:     item.Identifier.WorkspaceID,
 		AppID:           item.Identifier.AppID,
 		FunctionID:      item.Identifier.WorkflowID,
-		FunctionVersion: 0,
+		FunctionVersion: fn.FunctionVersion,
 	}); err != nil {
 		return fmt.Errorf("could not retrieve and schedule batch items: %w", err)
 	}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -318,7 +318,14 @@ func (s *svc) handleScheduledBatch(ctx context.Context, item queue.Item) error {
 		return err
 	}
 
-	if err := s.batcher.(batch.BatchExecutor).RetrieveAndSchedule(ctx, s.Executor(), batchID, *fn, item.Identifier.AccountID, item.Identifier.WorkspaceID, item.Identifier.AppID); err != nil {
+	if err := s.exec.RetrieveAndScheduleBatch(ctx, *fn, batch.ScheduleBatchPayload{
+		BatchID:         batchID,
+		AccountID:       item.Identifier.AccountID,
+		WorkspaceID:     item.Identifier.WorkspaceID,
+		AppID:           item.Identifier.AppID,
+		FunctionID:      item.Identifier.WorkflowID,
+		FunctionVersion: 0,
+	}); err != nil {
 		return fmt.Errorf("could not retrieve and schedule batch items: %w", err)
 	}
 

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -616,7 +616,7 @@ func (s *svc) initialize(ctx context.Context, fn inngest.Function, evt event.Tra
 			Event:           evt.GetEvent(),
 		}
 
-		if err := s.batcher.(batch.BatchExecutor).AppendAndSchedule(ctx, s.executor, fn, bi); err != nil {
+		if err := s.executor.AppendAndScheduleBatch(ctx, fn, bi); err != nil {
 			return fmt.Errorf("could not append and schedule batch item: %w", err)
 		}
 

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -13,7 +13,6 @@ import (
 	"github.com/inngest/inngest/pkg/config"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/cqrs"
-	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/batch"
@@ -616,81 +615,9 @@ func (s *svc) initialize(ctx context.Context, fn inngest.Function, evt event.Tra
 			EventID:         evt.GetInternalID(),
 			Event:           evt.GetEvent(),
 		}
-		result, err := s.batcher.Append(ctx, bi, fn)
-		if err != nil {
-			return err
-		}
 
-		switch result.Status {
-		case enums.BatchAppend:
-			// noop
-		case enums.BatchNew:
-			dur, err := time.ParseDuration(fn.EventBatch.Timeout)
-			if err != nil {
-				return err
-			}
-			at := time.Now().Add(dur)
-
-			if err := s.batcher.ScheduleExecution(ctx, batch.ScheduleBatchOpts{
-				ScheduleBatchPayload: batch.ScheduleBatchPayload{
-					BatchID:         ulid.MustParse(result.BatchID),
-					AccountID:       bi.AccountID,
-					WorkspaceID:     bi.WorkspaceID,
-					AppID:           bi.AppID,
-					FunctionID:      bi.FunctionID,
-					FunctionVersion: bi.FunctionVersion,
-				},
-				At: at,
-			}); err != nil {
-				return err
-			}
-		case enums.BatchFull:
-			// start execution immediately
-			batchID := ulid.MustParse(result.BatchID)
-
-			// TODO: this logic is repeated in executor, consolidate it somewhere
-			evtList, err := s.batcher.RetrieveItems(ctx, batchID)
-			if err != nil {
-				return err
-			}
-
-			events := make([]event.TrackedEvent, len(evtList))
-			for i, e := range evtList {
-				events[i] = e
-			}
-
-			ctx, span := telemetry.NewSpan(ctx,
-				telemetry.WithScope(consts.OtelScopeBatch),
-				telemetry.WithName(consts.OtelSpanBatch),
-				telemetry.WithSpanAttributes(
-					attribute.String(consts.OtelSysAccountID, bi.AccountID.String()),
-					attribute.String(consts.OtelSysWorkspaceID, bi.WorkspaceID.String()),
-					attribute.String(consts.OtelSysAppID, bi.AppID.String()),
-					attribute.String(consts.OtelSysFunctionID, bi.FunctionID.String()),
-					attribute.String(consts.OtelSysBatchID, batchID.String()),
-					attribute.Bool(consts.OtelSysBatchFull, true),
-				))
-			defer span.End()
-
-			key := fmt.Sprintf("%s-%s", fn.ID, batchID)
-			_, err = s.executor.Schedule(ctx, execution.ScheduleRequest{
-				AccountID:      bi.AccountID,
-				WorkspaceID:    bi.WorkspaceID,
-				AppID:          bi.AppID,
-				Function:       fn,
-				Events:         events,
-				BatchID:        &batchID,
-				IdempotencyKey: &key,
-			})
-			if err != nil {
-				return err
-			}
-
-			if err := s.batcher.ExpireKeys(ctx, batchID); err != nil {
-				return err
-			}
-		default:
-			return fmt.Errorf("invalid status of batch append ops: %d", result.Status)
+		if err := s.batcher.(batch.BatchExecutor).AppendAndSchedule(ctx, s.executor, fn, bi); err != nil {
+			return fmt.Errorf("could not append and schedule batch item: %w", err)
 		}
 
 		return nil


### PR DESCRIPTION
## Description

This change introduces two new executor methods, `AppendAndScheduleBatch` and `RetrieveAndScheduleBatch` which offer high-level batch handling capabilities and are used throughout the batching implementation. Existing usages have been refactored to remove duplicated logic.

## Motivation

Batching logic has been dispersed throughout `runner.initialize()` and `service.handleScheduledBatch()`. There are multiple opportunities to reuse code and prevent duplication.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
