### PR TITLE
Explicitly specify enum values for RunStatus

### DIFF
--- a/pkg/enums/run_status.go
+++ b/pkg/enums/run_status.go
@@ -11,29 +11,32 @@ import (
 type RunStatus int
 
 // NOTE:
-// DO NOT EVER DELETE. There are Lua scripts that rely on the integer values in the state metadata.
-// Deleting value enum will result in a change in order, and will break things.
+// DO NOT EVER DELETE OR REUSE.
+// There are Lua scripts that rely on the integer values in the state metadata.
+// Deleting/reusing enum value will break things.
+//
+//goland:noinspection GoDeprecation
 const (
 	// RunStatusRunning indicates that the function is running.  This is the
 	// default state, even if steps are scheduled in the future.
-	RunStatusRunning RunStatus = iota
+	RunStatusRunning RunStatus = 0
 	// RunStatusCompleted indicates that the function has completed running.
-	RunStatusCompleted
+	RunStatusCompleted RunStatus = 1
 	// RunStatusFailed indicates that the function failed in one or more steps.
-	RunStatusFailed
+	RunStatusFailed RunStatus = 2
 	// RunStatusCancelled indicates that the function has been cancelled prior
 	// to any errors
-	RunStatusCancelled
+	RunStatusCancelled RunStatus = 3
 	// RunStatusOverflowed indicates that the function had too many steps ran.
 	// Deprecated.  This must be RunStatusFailed with an appropriate error code.
-	RunStatusOverflowed
+	RunStatusOverflowed RunStatus = 4
 	// RunStatusScheduled indicates that the function is scheduled but have not started
 	// processing
-	RunStatusScheduled
+	RunStatusScheduled RunStatus = 5
 	// RunStatusUnknown indicates that the function is in an unknown status.
 	// This is unlikely to happen during normal execution, and more likely when converting between
 	// the status code
-	RunStatusUnknown
+	RunStatusUnknown RunStatus = 6
 )
 
 var (


### PR DESCRIPTION
## Description

During onboarding, I noticed the scary warning comment on this enum. Rather than relying only on the order of these declarations, can we explicitly specify their values?

Or does this break https://github.com/dmarkham/enumer ?

## Motivation

Decrease the room for human error.

## Type of change

- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.
