### PR TITLE
Add refetch to useGraphQLQuery

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/event-search/useRun.ts
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/event-search/useRun.ts
@@ -138,6 +138,7 @@ export function useRun({
     return {
       ...baseInitialFetchFailed,
       error: data,
+      refetch: res.refetch,
     };
   }
 

--- a/ui/apps/dashboard/src/utils/useRestAPIRequest.ts
+++ b/ui/apps/dashboard/src/utils/useRestAPIRequest.ts
@@ -18,7 +18,7 @@ export function useRestAPIRequest<T>({
   url: string | URL | null;
   method: string;
   pause?: boolean;
-}): FetchResult<T, { skippable: true }> {
+}): Omit<FetchResult<T, { skippable: true }>, 'refetch'> {
   const { getToken } = useAuth();
   const [data, setData] = useState<any>();
   const [isLoading, setIsLoading] = useState<boolean>(false);

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/stream/useEvent.ts
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/stream/useEvent.ts
@@ -47,12 +47,16 @@ export function useEvent(eventID: string | null): FetchResult<Data, { skippable:
 
   if (query.isLoading) {
     if (!data) {
-      return baseInitialFetchLoading;
+      return {
+        ...baseInitialFetchLoading,
+        refetch: query.refetch,
+      };
     }
 
     return {
       ...baseRefetchLoading,
       data,
+      refetch: query.refetch,
     };
   }
 
@@ -64,6 +68,7 @@ export function useEvent(eventID: string | null): FetchResult<Data, { skippable:
     return {
       ...baseInitialFetchFailed,
       error: new Error(query.error.message),
+      refetch: query.refetch,
     };
   }
 
@@ -72,11 +77,13 @@ export function useEvent(eventID: string | null): FetchResult<Data, { skippable:
     return {
       ...baseInitialFetchFailed,
       error: new Error('finished loading but missing data'),
+      refetch: query.refetch,
     };
   }
 
   return {
     ...baseFetchSucceeded,
     data,
+    refetch: query.refetch,
   };
 }

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/stream/useRun.ts
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/stream/useRun.ts
@@ -63,12 +63,16 @@ export function useRun(runID: string | null): FetchResult<Data, { skippable: tru
 
   if (query.isLoading) {
     if (!data) {
-      return baseInitialFetchLoading;
+      return {
+        ...baseInitialFetchLoading,
+        refetch: query.refetch,
+      };
     }
 
     return {
       ...baseRefetchLoading,
       data,
+      refetch: query.refetch,
     };
   }
 
@@ -80,6 +84,7 @@ export function useRun(runID: string | null): FetchResult<Data, { skippable: tru
     return {
       ...baseInitialFetchFailed,
       error: new Error(query.error.message),
+      refetch: query.refetch,
     };
   }
 
@@ -88,11 +93,13 @@ export function useRun(runID: string | null): FetchResult<Data, { skippable: tru
     return {
       ...baseInitialFetchFailed,
       error: new Error('finished loading but missing data'),
+      refetch: query.refetch,
     };
   }
 
   return {
     ...baseFetchSucceeded,
     data,
+    refetch: query.refetch,
   };
 }

--- a/ui/packages/components/src/types/fetch.ts
+++ b/ui/packages/components/src/types/fetch.ts
@@ -91,12 +91,13 @@ type FetchResultWithSkip<
 type FetchResultWithoutSkip<
   // Required
   TData = never
-> =
+> = (
   | InitialFetchFailed
   | InitialFetchLoading
   | Succeeded<TData>
   | RefetchFailed<TData>
-  | RefetchLoading<TData>;
+  | RefetchLoading<TData>
+) & { refetch: () => void };
 
 type Options = {
   skippable?: boolean;


### PR DESCRIPTION
## Description
Change `useGraphQLQuery` to return a `refetch` function. It automatically ignores the local cache

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
