### PR TITLE
Store trace spans into sqlite

### DIFF
--- a/pkg/cqrs/cqrs.go
+++ b/pkg/cqrs/cqrs.go
@@ -26,6 +26,9 @@ type Manager interface {
 	EventManager
 	HistoryManager
 
+	// Trace / dev only
+	TraceReadWriter
+
 	// Scoped allows creating a new manager using a transaction.
 	WithTx(ctx context.Context) (TxManager, error)
 }

--- a/pkg/cqrs/sqlitecqrs/migrations/000001_create_apps_table.up.sql
+++ b/pkg/cqrs/sqlitecqrs/migrations/000001_create_apps_table.up.sql
@@ -130,15 +130,14 @@ CREATE TABLE trace_runs (
 	run_id CHAR(26) NOT NULL,
 
 	queued_at TIMESTAMP NOT NULL,
-	started_at TIMESTAMP,
-	ended_at TIMESTAMP,
-	duration INT,
+	started_at TIMESTAMP NOT NULL,
+	ended_at TIMESTAMP NOT NULL,
+	duration INT NOT NULL,
 
-	status INT, -- more like enum values
-	source_id BLOB,
+	status INT NOT NULL, -- more like enum values
+	source_id VARCHAR NOT NULL,
 	trigger_ids BLOB NOT NULL,
-	triggers BLOB NOT NULL,
 	output BLOB,
-	is_batch BOOLEAN,
-	is_debounce BOOLEAN
+	is_batch BOOLEAN NOT NULL,
+	is_debounce BOOLEAN NOT NULL
 );

--- a/pkg/cqrs/sqlitecqrs/sqlc/models.go
+++ b/pkg/cqrs/sqlitecqrs/sqlc/models.go
@@ -138,14 +138,13 @@ type TraceRun struct {
 	TraceID     []byte
 	RunID       ulid.ULID
 	QueuedAt    time.Time
-	StartedAt   sql.NullTime
-	EndedAt     sql.NullTime
-	Duration    sql.NullInt64
-	Status      sql.NullInt64
-	SourceID    []byte
+	StartedAt   time.Time
+	EndedAt     time.Time
+	Duration    int64
+	Status      int64
+	SourceID    string
 	TriggerIds  []byte
-	Triggers    []byte
 	Output      []byte
-	IsBatch     sql.NullBool
-	IsDebounce  sql.NullBool
+	IsBatch     bool
+	IsDebounce  bool
 }

--- a/pkg/cqrs/sqlitecqrs/sqlc/queries.sql
+++ b/pkg/cqrs/sqlitecqrs/sqlc/queries.sql
@@ -183,6 +183,6 @@ VALUES
 
 -- name: InsertTraceRun :exec
 INSERT INTO trace_runs
-	(account_id, workspace_id, app_id, function_id, trace_id, run_id, queued_at, started_at, ended_at, duration, status, source_id, trigger_ids, triggers, output, is_batch, is_debounce)
+	(account_id, workspace_id, app_id, function_id, trace_id, run_id, queued_at, started_at, ended_at, duration, status, source_id, trigger_ids, output, is_batch, is_debounce)
 VALUES
-	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);

--- a/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
+++ b/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
@@ -1156,9 +1156,9 @@ func (q *Queries) InsertTrace(ctx context.Context, arg InsertTraceParams) error 
 
 const insertTraceRun = `-- name: InsertTraceRun :exec
 INSERT INTO trace_runs
-	(account_id, workspace_id, app_id, function_id, trace_id, run_id, queued_at, started_at, ended_at, duration, status, source_id, trigger_ids, triggers, output, is_batch, is_debounce)
+	(account_id, workspace_id, app_id, function_id, trace_id, run_id, queued_at, started_at, ended_at, duration, status, source_id, trigger_ids, output, is_batch, is_debounce)
 VALUES
-	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type InsertTraceRunParams struct {
@@ -1169,16 +1169,15 @@ type InsertTraceRunParams struct {
 	TraceID     []byte
 	RunID       ulid.ULID
 	QueuedAt    time.Time
-	StartedAt   sql.NullTime
-	EndedAt     sql.NullTime
-	Duration    sql.NullInt64
-	Status      sql.NullInt64
-	SourceID    []byte
+	StartedAt   time.Time
+	EndedAt     time.Time
+	Duration    int64
+	Status      int64
+	SourceID    string
 	TriggerIds  []byte
-	Triggers    []byte
 	Output      []byte
-	IsBatch     sql.NullBool
-	IsDebounce  sql.NullBool
+	IsBatch     bool
+	IsDebounce  bool
 }
 
 func (q *Queries) InsertTraceRun(ctx context.Context, arg InsertTraceRunParams) error {
@@ -1196,7 +1195,6 @@ func (q *Queries) InsertTraceRun(ctx context.Context, arg InsertTraceRunParams) 
 		arg.Status,
 		arg.SourceID,
 		arg.TriggerIds,
-		arg.Triggers,
 		arg.Output,
 		arg.IsBatch,
 		arg.IsDebounce,

--- a/pkg/cqrs/sqlitecqrs/sqlc/schema.sql
+++ b/pkg/cqrs/sqlitecqrs/sqlc/schema.sql
@@ -126,15 +126,14 @@ CREATE TABLE trace_runs (
 	run_id CHAR(26) NOT NULL,
 
 	queued_at TIMESTAMP NOT NULL,
-	started_at TIMESTAMP,
-	ended_at TIMESTAMP,
-	duration INT,
+	started_at TIMESTAMP NOT NULL,
+	ended_at TIMESTAMP NOT NULL,
+	duration INT NOT NULL,
 
-	status INT, -- more like enum values
-	source_id BLOB,
+	status INT NOT NULL, -- more like enum values
+	source_id VARCHAR NOT NULL,
 	trigger_ids BLOB NOT NULL,
-	triggers BLOB NOT NULL,
 	output BLOB,
-	is_batch BOOLEAN,
-	is_debounce BOOLEAN
+	is_batch BOOLEAN NOT NULL,
+	is_debounce BOOLEAN NOT NULL
 );

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -19,35 +19,50 @@ type Span struct {
 	SpanName           string            `json:"span_name"`
 	SpanKind           string            `json:"span_kind"`
 	ServiceName        string            `json:"service_name"`
-	ResourceAttributes map[string]string `json:"resource_attributes"`
+	ResourceAttributes map[string]string `json:"rattr"`
 	ScopeName          string            `json:"scope_name"`
 	ScopeVersion       string            `json:"scope_version"`
-	SpanAttributes     map[string]string `json:"span_attributes"`
+	SpanAttributes     map[string]string `json:"sattr"`
 	Duration           time.Duration     `json:"duration"`
 	StatusCode         string            `json:"status_code"`
 	StatusMessage      *string           `json:"status_message"`
+	Events             []SpanEvent       `json:"events"`
+	Links              []SpanLink        `json:"links"`
 	RunID              *ulid.ULID        `json:"run_id"`
+}
+
+type SpanEvent struct {
+	Timestamp  time.Time         `json:"ts"`
+	Name       string            `json:"name"`
+	Attributes map[string]string `json:"attr"`
+}
+
+type SpanLink struct {
+	TraceID    string            `json:"trace_id"`
+	SpanID     string            `json:"span_id"`
+	TraceState string            `json:"trace_state"`
+	Attributes map[string]string `json:"attr"`
 }
 
 // TraceRun represents a function run backed by a trace
 type TraceRun struct {
-	AccountID   uuid.UUID     `json:"account_id"`
-	WorkspaceID uuid.UUID     `json:"workspace_id"`
-	AppID       uuid.UUID     `json:"app_id"`
-	FunctionID  uuid.UUID     `json:"function_id"`
-	TraceID     string        `json:"trace_id"`
-	RunID       ulid.ULID     `json:"run_id"`
-	QueuedAt    time.Time     `json:"queued_at"`
-	StartedAt   time.Time     `json:"started_at,omitempty"`
-	EndedAt     time.Time     `json:"ended_at,omitempty"`
-	Duration    time.Duration `json:"duration"`
-	SourceID    string        `json:"source_id,omitempty"`
-	TriggerIDs  []ulid.ULID   `json:"trigger_ids"`
-	Triggers    [][]byte      `json:"triggers"`
-	Output      []byte        `json:"output,omitempty"`
-	Status      string        `json:"status"`
-	IsBatch     bool          `json:"is_batch"`
-	IsDebounce  bool          `json:"is_debounce"`
+	AccountID   uuid.UUID       `json:"account_id"`
+	WorkspaceID uuid.UUID       `json:"workspace_id"`
+	AppID       uuid.UUID       `json:"app_id"`
+	FunctionID  uuid.UUID       `json:"function_id"`
+	TraceID     string          `json:"trace_id"`
+	RunID       ulid.ULID       `json:"run_id"`
+	QueuedAt    time.Time       `json:"queued_at"`
+	StartedAt   time.Time       `json:"started_at,omitempty"`
+	EndedAt     time.Time       `json:"ended_at,omitempty"`
+	Duration    time.Duration   `json:"duration"`
+	SourceID    string          `json:"source_id,omitempty"`
+	TriggerIDs  []ulid.ULID     `json:"trigger_ids"`
+	Triggers    [][]byte        `json:"triggers"`
+	Output      []byte          `json:"output,omitempty"`
+	Status      enums.RunStatus `json:"status"`
+	IsBatch     bool            `json:"is_batch"`
+	IsDebounce  bool            `json:"is_debounce"`
 }
 
 type TraceReadWriter interface {
@@ -57,9 +72,9 @@ type TraceReadWriter interface {
 
 type TraceWriter interface {
 	// InsertSpan writes a trace span into the backing store
-	InsertSpan(ctx context.Context, span Span) error
+	InsertSpan(ctx context.Context, span *Span) error
 	// InsertTraceRun writes a trace based function run into the backing store
-	InsertTraceRun(ctx context.Context, run TraceRun) error
+	InsertTraceRun(ctx context.Context, run *TraceRun) error
 }
 
 type TraceReader interface {

--- a/pkg/devserver/span.go
+++ b/pkg/devserver/span.go
@@ -1,0 +1,162 @@
+package devserver
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/oklog/ulid/v2"
+)
+
+type spanIngestionHandler struct {
+	mu sync.Mutex
+
+	dedup map[string]*cqrs.Span
+	runs  map[string]*cqrs.TraceRun
+}
+
+func newSpanIngestionHandler() *spanIngestionHandler {
+	handler := &spanIngestionHandler{
+		dedup: map[string]*cqrs.Span{},
+		runs:  map[string]*cqrs.TraceRun{},
+	}
+
+	return handler
+}
+
+// Add adds the span and dedup it, taking the latest one needed
+func (sh *spanIngestionHandler) Add(span *cqrs.Span) {
+	sh.mu.Lock()
+	defer sh.mu.Unlock()
+
+	// marked as delete, so don't ingest in the first place
+	todelete := spanAttr(span.SpanAttributes, consts.OtelSysStepDelete)
+	if len(todelete) > 0 {
+		return
+	}
+
+	acctID := parseUUID(spanAttr(span.SpanAttributes, consts.OtelSysAccountID))
+	wsID := parseUUID(spanAttr(span.SpanAttributes, consts.OtelSysWorkspaceID))
+	appID := parseUUID(spanAttr(span.SpanAttributes, consts.OtelSysAppID))
+	fnID := parseUUID(spanAttr(span.SpanAttributes, consts.OtelSysFunctionID))
+
+	id := fmt.Sprintf("%s:%s:%s:%s:%s:%s", acctID, wsID, appID, fnID, span.TraceID, span.SpanID)
+	h := sha1.New()
+	_, _ = h.Write([]byte(id))
+	key := base64.StdEncoding.EncodeToString(h.Sum(nil))
+
+	if s, ok := sh.dedup[key]; !ok || span.Duration >= s.Duration {
+		sh.dedup[key] = span
+	}
+
+	if span.RunID != nil {
+		// construct the run
+		var run *cqrs.TraceRun
+		if r, ok := sh.runs[span.RunID.String()]; ok {
+			run = r
+		} else {
+			// New
+			// TODO: set SourceID
+			run = &cqrs.TraceRun{
+				AccountID:   acctID,
+				WorkspaceID: wsID,
+				AppID:       appID,
+				FunctionID:  fnID,
+				TraceID:     span.TraceID,
+				RunID:       *span.RunID,
+				QueuedAt:    ulid.Time(span.RunID.Time()),
+				TriggerIDs:  []ulid.ULID{},
+				Status:      enums.RunStatusUnknown,
+			}
+		}
+
+		// construct triggerIDs
+		if len(run.TriggerIDs) == 0 {
+			evtIDs := spanAttr(span.SpanAttributes, consts.OtelSysEventIDs)
+			if evtIDs != "" {
+				triggerIDs := []ulid.ULID{}
+				ids := strings.Split(evtIDs, ",")
+				for _, i := range ids {
+					if val, err := ulid.Parse(i); err == nil {
+						triggerIDs = append(triggerIDs, val)
+					}
+				}
+				run.TriggerIDs = triggerIDs
+			}
+		}
+
+		// assign output
+		if run.Output == nil || len(run.Output) == 0 {
+			output := spanAttr(span.SpanAttributes, consts.OtelSysFunctionOutput)
+			if output != "" {
+				run.Output = []byte(output)
+			}
+		}
+
+		// Update status
+		status, _ := strconv.ParseInt(spanAttr(span.SpanAttributes, consts.OtelSysFunctionStatusCode), 10, 64)
+		if status > run.Status.ToCode() {
+			run.Status = enums.RunCodeToStatus(status)
+		}
+
+		// Update timestamps
+		if span.ScopeName == consts.OtelScopeFunction {
+			if span.Timestamp.UnixMilli() > run.StartedAt.UnixMilli() {
+				run.StartedAt = span.Timestamp
+			}
+
+			if span.Duration > run.Duration {
+				run.Duration = span.Duration
+				run.EndedAt = run.StartedAt.Add(span.Duration)
+			}
+		}
+
+		// Annotate if run is batch or debounce
+		if spanAttr(span.SpanAttributes, consts.OtelSysBatchFull) != "" || spanAttr(span.SpanAttributes, consts.OtelSysBatchTimeout) != "" {
+			run.IsBatch = true
+		}
+		if spanAttr(span.SpanAttributes, consts.OtelSysDebounceTimeout) != "" {
+			run.IsDebounce = true
+		}
+
+		// assign it back
+		sh.runs[span.RunID.String()] = run
+	}
+}
+
+func (sh *spanIngestionHandler) Spans() []*cqrs.Span {
+	res := []*cqrs.Span{}
+	for _, v := range sh.dedup {
+		res = append(res, v)
+	}
+	return res
+}
+
+func (sh *spanIngestionHandler) TraceRuns() []*cqrs.TraceRun {
+	res := []*cqrs.TraceRun{}
+	for _, v := range sh.runs {
+		res = append(res, v)
+	}
+	return res
+}
+
+func spanAttr(sattr map[string]string, key string) string {
+	if v, ok := sattr[key]; ok {
+		return v
+	}
+	return ""
+}
+
+func parseUUID(str string) uuid.UUID {
+	if id, err := uuid.Parse(str); err == nil {
+		return id
+	}
+	return uuid.UUID{}
+}

--- a/pkg/devserver/span.go
+++ b/pkg/devserver/span.go
@@ -94,9 +94,10 @@ func (sh *spanIngestionHandler) Add(span *cqrs.Span) {
 
 		// assign output
 		if run.Output == nil || len(run.Output) == 0 {
-			output := spanAttr(span.SpanAttributes, consts.OtelSysFunctionOutput)
-			if output != "" {
-				run.Output = []byte(output)
+			for _, e := range span.Events {
+				if spanAttr(e.Attributes, consts.OtelSysFunctionOutput) != "" {
+					run.Output = []byte(e.Name)
+				}
 			}
 		}
 

--- a/pkg/devserver/util.go
+++ b/pkg/devserver/util.go
@@ -1,0 +1,33 @@
+package devserver
+
+import "fmt"
+
+func anyToString(value any) (string, error) {
+	var res string
+
+	switch v := value.(type) {
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		res = fmt.Sprintf("%d", v)
+	case bool:
+		res = fmt.Sprintf("%t", v)
+	case string:
+		res = v
+	default:
+		return "", fmt.Errorf("unexpected data type detected: %v", v)
+	}
+
+	return res, nil
+}
+
+func convertMap(src map[string]any) (map[string]string, error) {
+	res := map[string]string{}
+
+	for k, v := range src {
+		val, err := anyToString(v)
+		if err != nil {
+			return nil, err
+		}
+		res[k] = val
+	}
+	return res, nil
+}

--- a/pkg/devserver/util_test.go
+++ b/pkg/devserver/util_test.go
@@ -1,0 +1,50 @@
+package devserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnyToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    any
+		expected string
+		err      error
+	}{
+		{
+			name:     "should convert int values",
+			value:    10,
+			expected: "10",
+			err:      nil,
+		},
+		{
+			name:     "should convert uint values",
+			value:    uint(100),
+			expected: "100",
+			err:      nil,
+		},
+		{
+			name:     "should convert bool values",
+			value:    false,
+			expected: "false",
+			err:      nil,
+		},
+		{
+			name:     "should assign string as is",
+			value:    "hello",
+			expected: "hello",
+			err:      nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual, err := anyToString(test.value)
+
+			assert.Equal(t, test.expected, actual)
+			assert.Equal(t, test.err, err)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Store the received spans into sqlite.
Attempts to dedup and aggregate the data as much as possible before storing them, which reduce the footprint of memory being used.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
