### PR TITLE
Add lease denylists

### DIFF
--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -2008,7 +2008,6 @@ type leaseDenies struct {
 }
 
 func (l *leaseDenies) addThrottled(err error) {
-
 	var key keyError
 	if !errors.As(err, &key) {
 		return

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"strconv"
@@ -103,8 +104,6 @@ var (
 
 	ErrConcurrencyLimitCustomKey0 = fmt.Errorf("At concurrency limit 0")
 	ErrConcurrencyLimitCustomKey1 = fmt.Errorf("At concurrency limit 1")
-
-	ErrQueueItemThrottled = fmt.Errorf("queue item throttled")
 
 	// internal shard errors
 	errShardNotFound     = fmt.Errorf("shard not found")
@@ -989,7 +988,7 @@ func (q *queue) RequeueByJobID(ctx context.Context, partitionName string, jobID 
 //
 // Obtaining a lease updates the vesting time for the queue item until now() +
 // lease duration. This returns the newly acquired lease ID on success.
-func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, duration time.Duration, now time.Time) (*ulid.ULID, error) {
+func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, duration time.Duration, now time.Time, denies *leaseDenies) (*ulid.ULID, error) {
 	var (
 		ak, pk string // account, partition concurrency key
 		ac, pc int    // account, partiiton concurrency max
@@ -998,16 +997,31 @@ func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, dur
 		customLimits = make([]int, 2)
 	)
 
+	if item.Data.Throttle != nil && denies != nil && denies.denyThrottle(item.Data.Throttle.Key) {
+		return nil, ErrQueueItemThrottled
+	}
+
 	// Required.
 	//
 	// This should be found by calling function.ConcurrencyLimit() to return
 	// the lowest concurrency limit available.  It limits the capacity of all
 	// runs for the given function.
 	pk, pc = q.partitionConcurrencyGen(ctx, p)
+	// Check to see if this key has already been denied in the lease iteration.
+	// If so, fail early.
+	if denies != nil && denies.denyConcurrency(pk) {
+		// Note that we do not need to wrap the key as the key is already present.
+		return nil, ErrPartitionConcurrencyLimit
+	}
 
 	// optional
 	if q.accountConcurrencyGen != nil {
 		ak, ac = q.accountConcurrencyGen(ctx, item)
+		// Check to see if this key has already been denied in the lease iteration.
+		// If so, fail early.
+		if denies != nil && denies.denyConcurrency(ak) {
+			return nil, ErrAccountConcurrencyLimit
+		}
 	}
 	if q.customConcurrencyGen != nil {
 		// Get the custom concurrency key, if available.
@@ -1016,6 +1030,16 @@ func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, dur
 				// We only support two concurrency keys right now.
 				break
 			}
+
+			// Check to see if this key has already been denied in the lease iteration.
+			// If so, fail early.
+			if denies != nil && denies.denyConcurrency(item.Key) {
+				if i == 0 {
+					return nil, ErrConcurrencyLimitCustomKey0
+				}
+				return nil, ErrConcurrencyLimitCustomKey1
+			}
+
 			customKeys[i] = item.Key
 			customLimits[i] = item.Limit
 		}
@@ -1077,15 +1101,15 @@ func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, dur
 		return nil, ErrQueueItemAlreadyLeased
 	case 3:
 		// fn limit relevant to all runs in the fn
-		return nil, ErrPartitionConcurrencyLimit
+		return nil, newKeyError(ErrPartitionConcurrencyLimit, pk)
 	case 4:
-		return nil, ErrAccountConcurrencyLimit
+		return nil, newKeyError(ErrAccountConcurrencyLimit, ak)
 	case 5:
-		return nil, ErrConcurrencyLimitCustomKey0
+		return nil, newKeyError(ErrConcurrencyLimitCustomKey0, customKeys[0])
 	case 6:
-		return nil, ErrConcurrencyLimitCustomKey1
+		return nil, newKeyError(ErrConcurrencyLimitCustomKey1, customKeys[1])
 	case 7:
-		return nil, ErrQueueItemThrottled
+		return nil, newKeyError(ErrQueueItemThrottled, item.Data.Throttle.Key)
 	default:
 		return nil, fmt.Errorf("unknown response enqueueing item: %d", status)
 	}
@@ -1959,4 +1983,61 @@ func (f *frandRNG) Float64() float64 {
 
 func (f *frandRNG) Seed(seed uint64) {
 	// Do nothing.
+}
+
+func newLeaseDenyList() *leaseDenies {
+	return &leaseDenies{
+		lock:        &sync.RWMutex{},
+		concurrency: map[string]struct{}{},
+		throttle:    map[string]struct{}{},
+	}
+}
+
+// leaseDenies stores a mapping of keys that must not be leased.
+//
+// When iterating over a list of peeked queue items, each queue item may have the same
+// or different concurrency keys.  As soon as one of these concurrency keys reaches its
+// limit, any next queue items with the same keys must _never_ be considered for leasing.
+//
+// This has two benefits:  we prevent wasted work, and we prevent out of order work.
+type leaseDenies struct {
+	lock *sync.RWMutex
+
+	concurrency map[string]struct{}
+	throttle    map[string]struct{}
+}
+
+func (l *leaseDenies) addThrottled(err error) {
+
+	var key keyError
+	if !errors.As(err, &key) {
+		return
+	}
+	l.lock.Lock()
+	l.throttle[key.key] = struct{}{}
+	l.lock.Unlock()
+}
+
+func (l *leaseDenies) addConcurrency(err error) {
+	var key keyError
+	if !errors.As(err, &key) {
+		return
+	}
+	l.lock.Lock()
+	l.concurrency[key.key] = struct{}{}
+	l.lock.Unlock()
+}
+
+func (l *leaseDenies) denyConcurrency(key string) bool {
+	l.lock.RLock()
+	_, ok := l.concurrency[key]
+	l.lock.RUnlock()
+	return ok
+}
+
+func (l *leaseDenies) denyThrottle(key string) bool {
+	l.lock.RLock()
+	_, ok := l.throttle[key]
+	l.lock.RUnlock()
+	return ok
 }

--- a/pkg/execution/state/redis_state/queue_errors.go
+++ b/pkg/execution/state/redis_state/queue_errors.go
@@ -1,0 +1,30 @@
+package redis_state
+
+import "fmt"
+
+var (
+	ErrQueueItemThrottled = fmt.Errorf("queue item throttled")
+)
+
+func newKeyError(err error, key string) error {
+	return keyError{
+		cause: err,
+		key:   key,
+	}
+}
+
+// keyError is an error string which represents the custom key used when returning a
+// concurrency or throttled error.  The ErrQueueItemThrottled error must wrap this keyError
+// to embed the key directly in the top-level error class.
+type keyError struct {
+	key   string
+	cause error
+}
+
+func (k keyError) Cause() error {
+	return k.cause
+}
+
+func (k keyError) Error() string {
+	return k.cause.Error()
+}

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -667,7 +667,7 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, shard *
 
 	begin := time.Now()
 	defer func() {
-		telemetry.HistogramProcessPartitionDration(ctx, time.Now().Sub(begin).Milliseconds(), telemetry.HistogramOpt{
+		telemetry.HistogramProcessPartitionDration(ctx, time.Since(begin).Milliseconds(), telemetry.HistogramOpt{
 			PkgName: pkgName,
 		})
 	}()
@@ -845,7 +845,6 @@ ProcessLoop:
 
 		// increase success counter.
 		ctrSuccess++
-
 		q.workers <- processItem{P: *p, I: *item, S: shard}
 	}
 

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -705,20 +705,13 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, shard *
 	// iteration.
 	staticTime := getNow()
 
+	denies := newLeaseDenyList()
+
 ProcessLoop:
-	for _, qi := range queue {
+	for _, item := range queue {
 		// TODO: Create an in-memory mapping of rate limit keys that have been hit,
 		//       and don't bother to process if the queue item has a limited key.  This
 		//       lessens work done in the queue, as we can `continue` immediately.
-
-		if q.capacity() == 0 {
-			// no longer any available workers for partition, so we can skip
-			// work for now.
-			telemetry.IncrQueueProcessNoCapacityCounter(ctx, telemetry.CounterOpt{PkgName: pkgName})
-			break ProcessLoop
-		}
-
-		item := qi
 		if item.IsLeased(getNow()) {
 			telemetry.IncrQueueItemLeaseContentionCounter(ctx, telemetry.CounterOpt{PkgName: pkgName})
 			continue
@@ -727,7 +720,8 @@ ProcessLoop:
 		// Cbeck if there's capacity from our local workers atomically prior to leasing our tiems.
 		if !q.sem.TryAcquire(1) {
 			telemetry.IncrQueuePartitionProcessNoCapacityCounter(ctx, telemetry.CounterOpt{PkgName: pkgName})
-			break
+			// Break the entire loop to prevent out of order work.
+			break ProcessLoop
 		}
 
 		// Attempt to lease this item before passing this to a worker.  We have to do this
@@ -738,7 +732,15 @@ ProcessLoop:
 		//
 		// This is safe:  only one process runs scan(), and we guard the total number of
 		// available workers with the above semaphore.
-		leaseID, err := q.Lease(ctx, *p, *item, QueueLeaseDuration, staticTime)
+		leaseID, err := q.Lease(ctx, *p, *item, QueueLeaseDuration, staticTime, denies)
+
+		// NOTE: If this loop ends in an error, we must _always_ release an item from the
+		// semaphore to free capacity.  This will happen automatically when the worker
+		// finishes processing a queue item on success.
+		if err != nil {
+			// Continue on and handle the error below.
+			q.sem.Release(1)
+		}
 
 		// Check the sojourn delay for this item in the queue. Tracking system latency vs
 		// sojourn latency from concurrency is important.
@@ -761,7 +763,6 @@ ProcessLoop:
 		//
 		// Anyway, here we set the first peek item to the item's start time if there was a
 		// peek since the job was added.
-
 		if p.Last > 0 && p.Last > item.AtMS {
 			// Fudge the earliest peek time because we know this wasn't peeked and so
 			// the peek time wasn't set;  but, as we were still processing jobs after
@@ -769,15 +770,21 @@ ProcessLoop:
 			item.EarliestPeekTime = item.AtMS
 		}
 
-		// NOTE: If this loop ends in an error, we must _always_ release an item from the
-		// semaphore to free capacity.  This will happen automatically when the worker
-		// finishes processing a queue item on success.
-		if err != nil {
-			q.sem.Release(1)
+		// We may return a keyError, which masks the actual error underneath.  If so,
+		// grab the cause.
+		cause := err
+		var key keyError
+		if errors.As(err, &key) {
+			cause = key.cause
 		}
 
-		switch err {
+		switch cause {
 		case ErrQueueItemThrottled:
+			// Here we denylist each throttled key that's been limited here, then ignore
+			// any other jobs from being leased as we continue to iterate through the loop.
+			// This maintains FIFO ordering amongst all custom concurrency keys.
+			denies.addThrottled(err)
+
 			ctrRateLimit++
 			processErr = nil
 			telemetry.IncrQueueThrottledCounter(ctx, telemetry.CounterOpt{PkgName: pkgName})
@@ -799,19 +806,11 @@ ProcessLoop:
 			// so we cannot break the loop in case the next job has a different key and
 			// has capacity.
 			//
-			// In an ideal world we'd denylist each concurrency key that's been
-			// limited here, then ignore any other jobs from being leased as we continue
-			// to iterate through the loop.
-			//
-			// This maintains FIFO ordering amongst all custom concurrency keys.  For now,
-			// we move to the next job.  Note that capacity may be available for another job
-			// in the loop, meaning out of order jobs for now.
+			// Here we denylist each concurrency key that's been limited here, then ignore
+			// any other jobs from being leased as we continue to iterate through the loop.
+			// This maintains FIFO ordering amongst all custom concurrency keys.
+			denies.addConcurrency(err)
 
-			// TODO: Grab the key from the custom limit
-			//       Set key in denylist lookup table.
-			//       Modify above loop entrance:
-			//         Check lookup table for all concurrency keys
-			//         If present, skip item
 			processErr = nil
 			continue
 		case ErrQueueItemNotFound:

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -665,6 +665,13 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, shard *
 		return fmt.Errorf("error leasing partition: %w", err)
 	}
 
+	begin := time.Now()
+	defer func() {
+		telemetry.HistogramProcessPartitionDration(ctx, time.Now().Sub(begin).Milliseconds(), telemetry.HistogramOpt{
+			PkgName: pkgName,
+		})
+	}()
+
 	// Ensure that peek doesn't take longer than the partition lease, to
 	// reduce contention.
 	peekCtx, cancel := context.WithTimeout(ctx, PartitionLeaseDuration)

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -453,7 +453,7 @@ func TestQueuePeek(t *testing.T) {
 			p := QueuePartition{WorkflowID: ia.WorkflowID}
 
 			// Lease step A, and it should be removed.
-			_, err := q.Lease(ctx, p, ia, 50*time.Millisecond, getNow())
+			_, err := q.Lease(ctx, p, ia, 50*time.Millisecond, getNow(), nil)
 			require.NoError(t, err)
 
 			items, err = q.Peek(ctx, workflowID.String(), d, QueuePeekMax)
@@ -527,7 +527,7 @@ func TestQueueLease(t *testing.T) {
 		require.Equal(t, item.Queue(), item.WorkflowID.String())
 
 		now := time.Now()
-		id, err := q.Lease(ctx, p, item, time.Second, getNow())
+		id, err := q.Lease(ctx, p, item, time.Second, getNow(), nil)
 		require.NoError(t, err)
 
 		item = getQueueItem(t, r, item.ID)
@@ -545,7 +545,7 @@ func TestQueueLease(t *testing.T) {
 
 		t.Run("Leasing again should fail", func(t *testing.T) {
 			for i := 0; i < 50; i++ {
-				id, err := q.Lease(ctx, p, item, time.Second, getNow())
+				id, err := q.Lease(ctx, p, item, time.Second, getNow(), nil)
 				require.Equal(t, ErrQueueItemAlreadyLeased, err)
 				require.Nil(t, id)
 				<-time.After(5 * time.Millisecond)
@@ -564,7 +564,7 @@ func TestQueueLease(t *testing.T) {
 			})
 
 			now := time.Now()
-			id, err := q.Lease(ctx, p, item, 5*time.Second, getNow())
+			id, err := q.Lease(ctx, p, item, 5*time.Second, getNow(), nil)
 			require.NoError(t, err)
 			require.NoError(t, err)
 
@@ -589,7 +589,7 @@ func TestQueueLease(t *testing.T) {
 
 			requireItemScoreEquals(t, r, item, start)
 
-			_, err = q.Lease(ctx, p, item, time.Minute, getNow())
+			_, err = q.Lease(ctx, p, item, time.Minute, getNow(), nil)
 			require.NoError(t, err)
 
 			_, err = r.ZScore(defaultQueueKey.QueueIndex(item.WorkflowID.String()), item.ID)
@@ -613,11 +613,11 @@ func TestQueueLease(t *testing.T) {
 		p := QueuePartition{WorkflowID: itemA.WorkflowID}
 
 		t.Run("Leases with capacity", func(t *testing.T) {
-			_, err = q.Lease(ctx, p, itemA, 5*time.Second, getNow())
+			_, err = q.Lease(ctx, p, itemA, 5*time.Second, getNow(), nil)
 			require.NoError(t, err)
 		})
 		t.Run("Errors without capacity", func(t *testing.T) {
-			id, err := q.Lease(ctx, p, itemB, 5*time.Second, getNow())
+			id, err := q.Lease(ctx, p, itemB, 5*time.Second, getNow(), nil)
 			require.Nil(t, id)
 			require.Error(t, err)
 		})
@@ -642,11 +642,11 @@ func TestQueueLease(t *testing.T) {
 		p := QueuePartition{WorkflowID: itemA.WorkflowID}
 
 		t.Run("Leases with capacity", func(t *testing.T) {
-			_, err = q.Lease(ctx, p, itemA, 5*time.Second, getNow())
+			_, err = q.Lease(ctx, p, itemA, 5*time.Second, getNow(), nil)
 			require.NoError(t, err)
 		})
 		t.Run("Errors without capacity", func(t *testing.T) {
-			id, err := q.Lease(ctx, p, itemB, 5*time.Second, getNow())
+			id, err := q.Lease(ctx, p, itemB, 5*time.Second, getNow(), nil)
 			require.Nil(t, id)
 			require.Error(t, err)
 		})
@@ -676,11 +676,11 @@ func TestQueueLease(t *testing.T) {
 		p := QueuePartition{WorkflowID: itemA.WorkflowID}
 
 		t.Run("Leases with capacity", func(t *testing.T) {
-			_, err = q.Lease(ctx, p, itemA, 5*time.Second, getNow())
+			_, err = q.Lease(ctx, p, itemA, 5*time.Second, getNow(), nil)
 			require.NoError(t, err)
 		})
 		t.Run("Errors without capacity", func(t *testing.T) {
-			id, err := q.Lease(ctx, p, itemB, 5*time.Second, getNow())
+			id, err := q.Lease(ctx, p, itemB, 5*time.Second, getNow(), nil)
 			require.Nil(t, id)
 			require.Error(t, err)
 		})
@@ -703,7 +703,7 @@ func TestQueueLease(t *testing.T) {
 
 			// Nothing should update here, as there's nothing left in the fn queue
 			// so nothing happens.
-			_, err = q.Lease(ctx, p, item, 10*time.Second, getNow())
+			_, err = q.Lease(ctx, p, item, 10*time.Second, getNow(), nil)
 			require.NoError(t, err)
 
 			nextScore, err := r.ZScore(defaultQueueKey.GlobalPartitionIndex(), p.Queue())
@@ -728,7 +728,7 @@ func TestQueueLease(t *testing.T) {
 			require.EqualValues(t, atA.Unix(), score)
 
 			// Leasing the item should update the score.
-			_, err = q.Lease(ctx, p, itemA, 10*time.Second, getNow())
+			_, err = q.Lease(ctx, p, itemA, 10*time.Second, getNow(), nil)
 			require.NoError(t, err)
 
 			nextScore, err := r.ZScore(defaultQueueKey.GlobalPartitionIndex(), p.Queue())
@@ -763,7 +763,7 @@ func TestQueueExtendLease(t *testing.T) {
 		p := QueuePartition{WorkflowID: item.WorkflowID}
 
 		now := time.Now()
-		id, err := q.Lease(ctx, p, item, time.Second, getNow())
+		id, err := q.Lease(ctx, p, item, time.Second, getNow(), nil)
 		require.NoError(t, err)
 
 		item = getQueueItem(t, r, item.ID)
@@ -838,7 +838,7 @@ func TestQueueDequeue(t *testing.T) {
 
 		p := QueuePartition{WorkflowID: item.WorkflowID}
 
-		id, err := q.Lease(ctx, p, item, time.Second, getNow())
+		id, err := q.Lease(ctx, p, item, time.Second, getNow(), nil)
 		require.NoError(t, err)
 
 		t.Run("The lease exists in the partition queue", func(t *testing.T) {
@@ -939,7 +939,7 @@ func TestQueueRequeue(t *testing.T) {
 
 		p := QueuePartition{WorkflowID: item.WorkflowID}
 
-		_, err = q.Lease(ctx, p, item, time.Second, getNow())
+		_, err = q.Lease(ctx, p, item, time.Second, getNow(), nil)
 		require.NoError(t, err)
 
 		// Assert partition index is original
@@ -1348,7 +1348,7 @@ func TestQueuePartitionRequeue(t *testing.T) {
 
 		// Leasing the only job available moves the job into the concurrency queue,
 		// so the partition should be empty. when requeeing.
-		_, err := q.Lease(ctx, p, qi, 10*time.Second, getNow())
+		_, err := q.Lease(ctx, p, qi, 10*time.Second, getNow(), nil)
 		require.NoError(t, err)
 
 		requirePartitionScoreEquals(t, r, idA, next)
@@ -1499,7 +1499,7 @@ func TestQueueRequeueByJobID(t *testing.T) {
 			require.Equal(t, 1, len(partitions))
 
 			// Lease
-			lid, err := q.Lease(ctx, *partitions[0], item, time.Second*10, getNow())
+			lid, err := q.Lease(ctx, *partitions[0], item, time.Second*10, getNow(), nil)
 			require.NoError(t, err)
 			require.NotNil(t, lid)
 
@@ -1815,7 +1815,7 @@ func TestSharding(t *testing.T) {
 				require.NoError(t, err)
 				require.EqualValues(t, at.Unix(), score, "starting score should be enqueue time")
 
-				_, err = q.Lease(ctx, p, item, 5*time.Second, getNow())
+				_, err = q.Lease(ctx, p, item, 5*time.Second, getNow(), nil)
 				require.NoError(t, err)
 
 				// Check shard partition score changed in the ptr.
@@ -2132,13 +2132,13 @@ func TestQueueRateLimit(t *testing.T) {
 		r.EqualValues(1, len(partitions))
 
 		t.Run("Leasing a first item succeeds", func(t *testing.T) {
-			leaseA, err := q.Lease(ctx, *partitions[0], aa, 10*time.Second, getNow())
+			leaseA, err := q.Lease(ctx, *partitions[0], aa, 10*time.Second, getNow(), nil)
 			r.NoError(err, "leasing throttled queue item with capacity failed")
 			r.NotNil(leaseA)
 		})
 
 		t.Run("Attempting to lease another throttled key immediately fails", func(t *testing.T) {
-			leaseB, err := q.Lease(ctx, *partitions[0], ab, 10*time.Second, getNow())
+			leaseB, err := q.Lease(ctx, *partitions[0], ab, 10*time.Second, getNow(), nil)
 			r.NotNil(err, "leasing throttled queue item without capacity didn't error")
 			r.Nil(leaseB)
 		})
@@ -2159,7 +2159,7 @@ func TestQueueRateLimit(t *testing.T) {
 				},
 			}, getNow().Add(time.Second))
 			r.NoError(err)
-			lease, err := q.Lease(ctx, *partitions[0], ba, 10*time.Second, getNow())
+			lease, err := q.Lease(ctx, *partitions[0], ba, 10*time.Second, getNow(), nil)
 			r.Nil(err, "leasing throttled queue item without capacity didn't error")
 			r.NotNil(lease)
 		})
@@ -2170,7 +2170,7 @@ func TestQueueRateLimit(t *testing.T) {
 			}
 			defer func() { getNow = time.Now }()
 
-			leaseB, err := q.Lease(ctx, *partitions[0], ab, 10*time.Second, getNow())
+			leaseB, err := q.Lease(ctx, *partitions[0], ab, 10*time.Second, getNow(), nil)
 			r.Nil(err, "leasing after waiting for throttle should succeed")
 			r.NotNil(leaseB)
 		})
@@ -2208,7 +2208,7 @@ func TestQueueRateLimit(t *testing.T) {
 
 		t.Run("Leasing up to bursts succeeds", func(t *testing.T) {
 			for i := 0; i < 3; i++ {
-				lease, err := q.Lease(ctx, *partitions[0], items[i], 2*time.Second, getNow())
+				lease, err := q.Lease(ctx, *partitions[0], items[i], 2*time.Second, getNow(), nil)
 				r.NoError(err, "leasing throttled queue item with capacity failed")
 				r.NotNil(lease)
 				idx++
@@ -2216,7 +2216,7 @@ func TestQueueRateLimit(t *testing.T) {
 		})
 
 		t.Run("Leasing the 4th time fails", func(t *testing.T) {
-			lease, err := q.Lease(ctx, *partitions[0], items[idx], 1*time.Second, getNow())
+			lease, err := q.Lease(ctx, *partitions[0], items[idx], 1*time.Second, getNow(), nil)
 			r.NotNil(err, "leasing throttled queue item without capacity didn't error")
 			r.ErrorContains(err, ErrQueueItemThrottled.Error())
 			r.Nil(lease)
@@ -2228,14 +2228,14 @@ func TestQueueRateLimit(t *testing.T) {
 			}
 			defer func() { getNow = time.Now }()
 
-			lease, err := q.Lease(ctx, *partitions[0], items[idx], 2*time.Second, getNow())
+			lease, err := q.Lease(ctx, *partitions[0], items[idx], 2*time.Second, getNow(), nil)
 			r.NoError(err, "leasing throttled queue item with capacity failed")
 			r.NotNil(lease)
 
 			idx++
 
 			// It should fail, as bursting is done.
-			lease, err = q.Lease(ctx, *partitions[0], items[idx], 1*time.Second, getNow())
+			lease, err = q.Lease(ctx, *partitions[0], items[idx], 1*time.Second, getNow(), nil)
 			r.NotNil(err, "leasing throttled queue item without capacity didn't error")
 			r.ErrorContains(err, ErrQueueItemThrottled.Error())
 			r.Nil(lease)
@@ -2248,7 +2248,7 @@ func TestQueueRateLimit(t *testing.T) {
 			defer func() { getNow = time.Now }()
 
 			for i := 0; i < 3; i++ {
-				lease, err := q.Lease(ctx, *partitions[0], items[i], 2*time.Second, getNow())
+				lease, err := q.Lease(ctx, *partitions[0], items[i], 2*time.Second, getNow(), nil)
 				r.NoError(err, "leasing throttled queue item with capacity failed")
 				r.NotNil(lease)
 				idx++

--- a/pkg/telemetry/histogram.go
+++ b/pkg/telemetry/histogram.go
@@ -11,6 +11,13 @@ var (
 		60_000, 300_000, // < 10m
 		600_000, 1_800_000, // < 1h
 	}
+
+	processPartitionBoundaries = []float64{
+		5, 10, 25, 50, 100, 200, // < 1s
+		400, 600, 800, 1_000,
+		1_500, 2_000, 4_000,
+		8_000, 15_000,
+	}
 )
 
 type HistogramOpt struct {
@@ -26,5 +33,16 @@ func HistogramQueueItemLatency(ctx context.Context, value int64, opts HistogramO
 		Attributes:  opts.Tags,
 		Unit:        "ms",
 		Boundaries:  queueItemLatencyBoundaries,
+	})
+}
+
+func HistogramProcessPartitionDration(ctx context.Context, value int64, opts HistogramOpt) {
+	recordIntHistogramMetric(ctx, value, histogramOpt{
+		Name:        opts.PkgName,
+		MetricName:  "queue_process_partition_duration",
+		Description: "Distribution of how long it takes to process a partition",
+		Attributes:  opts.Tags,
+		Unit:        "ms",
+		Boundaries:  processPartitionBoundaries,
 	})
 }


### PR DESCRIPTION
This commit introduces lease denylists for queue items.  When attempting
to lease queue items, we pull a chunk of work from the queue in FIFO
order as a list of queue items. We iterate through this list, and
attempt to lease the queue item.

The queue item may fail to lease because of concurrency keys or
throttling keys.  In this case, we may still keep iterating on the list
to attempt to process *other* items with *different* concurrency keys.

We add these failed keys to a denylist, and never attempt to lease those
queue items within the same iterations.  This keeps FIFO order and
prevents queue churn.

Note that denylists are temporary and only exist per executor for the
function currently being peeked.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
