### PR TITLE
Peek further ahead of queue dynamically

### DIFF
--- a/pkg/execution/state/redis_state/lua/queue/extendPartitionLease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/extendPartitionLease.lua
@@ -1,0 +1,55 @@
+--[[
+
+Output:
+  0: Successfully extended lease
+  1: Partition not found
+  2: Partition has no lease
+  3: Lease ID doesn't match (indicating someone else took the lease)
+]]
+
+local partitionKey            = KEYS[1]
+local keyGlobalPartitionPtr   = KEYS[2]
+local keyShardPartitionPtr    = KEYS[3]
+local partitionConcurrencyKey = KEYS[4]
+
+local partitionID    = ARGV[1]
+local currentLeaseID = ARGV[2]
+local newLeaseID     = ARGV[3]
+
+-- $include(check_concurrency.lua)
+-- $include(get_partition_item.lua)
+-- $include(decode_ulid_time.lua)
+-- $include(update_pointer_score.lua)
+-- $include(has_shard_key.lua)
+
+local nextTime = decode_ulid_time(newLeaseID)
+
+-- check if the partition exists
+local existing = get_partition_item(partitionKey, partitionID)
+if existing == nil or existing == false then
+  return 1
+end
+
+-- check if lease already exists or not
+if existing.leaseID == nil or existing.leaseID == cjson.null then
+  return 2
+end
+-- check if the leaseID matches or not
+if existing.leaseID ~= currentLeaseID then
+  return 3
+end
+
+-- update the lease
+-- NOTE: should `last` also be updated???
+existing.leaseID = newLeaseID
+
+-- update item and index score
+redis.call("HSET", partitionKey, partitionID, cjson.encode(existing))
+-- update the score for the partition
+redis.call("ZADD", keyGlobalPartitionPtr, nextTime, partitionID)
+
+if has_shard_key(keyShardPartitionPtr) then
+	update_pointer_score_to(partitionID, keyShardPartitionPtr, nextTime)
+end
+
+return 0

--- a/pkg/execution/state/redis_state/lua/queue/peek.lua
+++ b/pkg/execution/state/redis_state/lua/queue/peek.lua
@@ -8,9 +8,10 @@ local queueIndex = KEYS[1]
 local queueKey   = KEYS[2]
 
 local peekUntil  = ARGV[1]
-local limit      = tonumber(ARGV[2])
+local offset     = tonumber(ARGV[2])
+local limit      = tonumber(ARGV[3])
 
-local items = redis.call("ZRANGE", queueIndex, "-inf", peekUntil, "BYSCORE", "LIMIT", 0, limit)
+local items = redis.call("ZRANGE", queueIndex, "-inf", peekUntil, "BYSCORE", "LIMIT", offset, limit)
 if #items == 0 then
 	return {}
 end

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -867,7 +867,7 @@ func (q *queue) EnqueueItem(ctx context.Context, i QueueItem, at time.Time) (Que
 //
 // If limit is -1, this will return the first unleased item - representing the next available item in the
 // queue.
-func (q *queue) Peek(ctx context.Context, queueName string, until time.Time, limit int64) ([]*QueueItem, error) {
+func (q *queue) Peek(ctx context.Context, queueName string, until time.Time, offset int64, limit int64) ([]*QueueItem, error) {
 	// Check whether limit is -1, peeking next available time
 	isPeekNext := limit == -1
 
@@ -882,6 +882,7 @@ func (q *queue) Peek(ctx context.Context, queueName string, until time.Time, lim
 
 	args, err := StrSlice([]any{
 		until.UnixMilli(),
+		offset,
 		limit,
 	})
 	if err != nil {

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -60,8 +60,10 @@ const (
 	PartitionConcurrencyLimitRequeueExtension = 2 * time.Second
 	PartitionLookahead                        = time.Second
 
-	QueuePeekMax        int64 = 1000
+	QueuePeekMax        int64 = 500
 	QueuePeekDefault    int64 = 250
+	QueuePeekMaxIter    int64 = 4
+	QueuePeekMaxItems   int64 = 1000
 	QueueLeaseDuration        = 10 * time.Second
 	ConfigLeaseDuration       = 10 * time.Second
 	ConfigLeaseMax            = 20 * time.Second
@@ -198,6 +200,18 @@ func WithNumWorkers(n int32) QueueOpt {
 func WithPeekSize(n int64) QueueOpt {
 	return func(q *queue) {
 		q.peek = n
+	}
+}
+
+func WithPeekMaxIterations(n int64) QueueOpt {
+	return func(q *queue) {
+		q.peekMaxIter = n
+	}
+}
+
+func WithPeekMaxItems(n int64) QueueOpt {
+	return func(q *queue) {
+		q.peekMaxItems = n
 	}
 }
 
@@ -389,7 +403,9 @@ type queue struct {
 	// numWorkers stores the number of workers available to concurrently process jobs.
 	numWorkers int32
 	// peek sets the number of items to check on queue peeks
-	peek int64
+	peek         int64
+	peekMaxItems int64
+	peekMaxIter  int64
 	// workers is a buffered channel which allows scanners to send queue items
 	// to workers to be processed
 	workers chan processItem

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -1117,6 +1117,22 @@ func (q *queue) peekSize() int64 {
 	return size
 }
 
+func (q *queue) peekItems() int64 {
+	num := q.peekMaxItems
+	if num == 0 {
+		num = QueuePeekMaxItems
+	}
+	return num
+}
+
+func (q *queue) peekIter() int64 {
+	num := q.peekMaxIter
+	if num == 0 {
+		num = QueuePeekMaxIter
+	}
+	return num
+}
+
 func (q *queue) isSequential() bool {
 	l := q.sequentialLease()
 	if l == nil {

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -729,6 +729,8 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, shard *
 		}
 	}
 
+	telemetry.IncrQueueProcessedItemsCounter(ctx, results.Handled(), telemetry.CounterOpt{PkgName: pkgName})
+
 	// If we've hit concurrency issues OR we've only hit rate limit issues, re-enqueue the partition
 	// with a force:  ensure that we won't re-scan it until 2 seconds in the future.
 	if results.IsConcurrentyLimited() {

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -685,7 +685,8 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, shard *
 	// order, depending on how long it takes for the item to pass through the channel
 	// to the worker, how long Redis takes to lease the item, etc.
 	fetch := getNow().Truncate(time.Second).Add(PartitionLookahead)
-	queue, err := q.Peek(peekCtx, p.Queue(), fetch, q.peekSize())
+	var offset int64
+	queue, err := q.Peek(peekCtx, p.Queue(), fetch, offset, q.peekSize())
 	if err != nil {
 		return err
 	}

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -782,6 +782,10 @@ func (r handleQueueItemsResult) IsConcurrentyLimited() bool {
 }
 
 func (r *handleQueueItemsResult) Accumulate(res *handleQueueItemsResult) {
+	if res == nil {
+		return
+	}
+
 	r.totalItems += res.totalItems
 	r.ctrConcurrency += res.ctrConcurrency
 	r.ctrSuccess += res.ctrSuccess

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -399,7 +399,7 @@ func TestQueuePeek(t *testing.T) {
 	workflowID := uuid.UUID{}
 
 	t.Run("It returns none with no items enqueued", func(t *testing.T) {
-		items, err := q.Peek(ctx, workflowID.String(), time.Now().Add(time.Hour), 10)
+		items, err := q.Peek(ctx, workflowID.String(), time.Now().Add(time.Hour), 0, 10)
 		require.NoError(t, err)
 		require.EqualValues(t, 0, len(items))
 	})
@@ -417,7 +417,7 @@ func TestQueuePeek(t *testing.T) {
 		ic, err := q.EnqueueItem(ctx, QueueItem{ID: "c"}, c)
 		require.NoError(t, err)
 
-		items, err := q.Peek(ctx, workflowID.String(), time.Now().Add(time.Hour), 10)
+		items, err := q.Peek(ctx, workflowID.String(), time.Now().Add(time.Hour), 0, 10)
 		require.NoError(t, err)
 		require.EqualValues(t, 3, len(items))
 		require.EqualValues(t, []*QueueItem{&ia, &ib, &ic}, items)
@@ -426,24 +426,24 @@ func TestQueuePeek(t *testing.T) {
 		id, err := q.EnqueueItem(ctx, QueueItem{ID: "d"}, d)
 		require.NoError(t, err)
 
-		items, err = q.Peek(ctx, workflowID.String(), time.Now().Add(time.Hour), 10)
+		items, err = q.Peek(ctx, workflowID.String(), time.Now().Add(time.Hour), 0, 10)
 		require.NoError(t, err)
 		require.EqualValues(t, 4, len(items))
 		require.EqualValues(t, []*QueueItem{&ia, &ib, &ic, &id}, items)
 
 		t.Run("It should limit the list", func(t *testing.T) {
-			items, err = q.Peek(ctx, workflowID.String(), time.Now().Add(time.Hour), 2)
+			items, err = q.Peek(ctx, workflowID.String(), time.Now().Add(time.Hour), 0, 2)
 			require.NoError(t, err)
 			require.EqualValues(t, 2, len(items))
 			require.EqualValues(t, []*QueueItem{&ia, &ib}, items)
 		})
 
 		t.Run("It should apply a peek offset", func(t *testing.T) {
-			items, err = q.Peek(ctx, workflowID.String(), time.Now().Add(-1*time.Hour), QueuePeekMax)
+			items, err = q.Peek(ctx, workflowID.String(), time.Now().Add(-1*time.Hour), 0, QueuePeekMax)
 			require.NoError(t, err)
 			require.EqualValues(t, 0, len(items))
 
-			items, err = q.Peek(ctx, workflowID.String(), c, QueuePeekMax)
+			items, err = q.Peek(ctx, workflowID.String(), c, 0, QueuePeekMax)
 			require.NoError(t, err)
 			require.EqualValues(t, 3, len(items))
 			require.EqualValues(t, []*QueueItem{&ia, &ib, &ic}, items)
@@ -456,7 +456,7 @@ func TestQueuePeek(t *testing.T) {
 			_, err := q.Lease(ctx, p, ia, 50*time.Millisecond, getNow(), nil)
 			require.NoError(t, err)
 
-			items, err = q.Peek(ctx, workflowID.String(), d, QueuePeekMax)
+			items, err = q.Peek(ctx, workflowID.String(), d, 0, QueuePeekMax)
 			require.NoError(t, err)
 			require.EqualValues(t, 3, len(items))
 			require.EqualValues(t, []*QueueItem{&ib, &ic, &id}, items)
@@ -477,7 +477,7 @@ func TestQueuePeek(t *testing.T) {
 			require.NoError(t, err)
 			require.EqualValues(t, 1, caught)
 
-			items, err = q.Peek(ctx, workflowID.String(), d, QueuePeekMax)
+			items, err = q.Peek(ctx, workflowID.String(), d, 0, QueuePeekMax)
 			require.NoError(t, err)
 			require.EqualValues(t, 4, len(items))
 
@@ -877,7 +877,7 @@ func TestQueueDequeue(t *testing.T) {
 		})
 
 		t.Run("It should remove the item from the queue index", func(t *testing.T) {
-			items, err := q.Peek(ctx, item.Queue(), time.Now().Add(time.Hour), 10)
+			items, err := q.Peek(ctx, item.Queue(), time.Now().Add(time.Hour), 0, 10)
 			require.NoError(t, err)
 			require.EqualValues(t, 0, len(items))
 		})
@@ -1547,7 +1547,7 @@ func TestQueueRequeueByJobID(t *testing.T) {
 		require.Nil(t, err, r.Dump())
 
 		t.Run("It updates the queue's At time", func(t *testing.T) {
-			found, err := q.Peek(ctx, wsA.String(), at.Add(10*time.Second), 5)
+			found, err := q.Peek(ctx, wsA.String(), at.Add(10*time.Second), 0, 5)
 			require.NoError(t, err)
 			require.Equal(t, 1, len(found))
 			require.NotEqual(t, item.AtMS, found[0].AtMS)
@@ -1618,7 +1618,7 @@ func TestQueueRequeueByJobID(t *testing.T) {
 		})
 
 		t.Run("It updates the queue's At time", func(t *testing.T) {
-			found, err := q.Peek(ctx, wsA.String(), at.Add(30*time.Second), 5)
+			found, err := q.Peek(ctx, wsA.String(), at.Add(30*time.Second), 0, 5)
 			require.NoError(t, err)
 			require.Equal(t, 5, len(found))
 			require.Equal(t, at.UnixMilli(), found[0].AtMS, "First job shouldn't change")

--- a/pkg/telemetry/counter.go
+++ b/pkg/telemetry/counter.go
@@ -34,6 +34,15 @@ func IncrQueueProcessNoCapacityCounter(ctx context.Context, opts CounterOpt) {
 	})
 }
 
+func IncrQueueProcessedItemsCounter(ctx context.Context, incr int64, opts CounterOpt) {
+	recordCounterMetric(ctx, incr, counterOpt{
+		Name:        opts.PkgName,
+		MetricName:  "queue_processed_items_total",
+		Description: "The actual number of newly processed queue items when processing a partition",
+		Attributes:  opts.Tags,
+	})
+}
+
 func IncrQueuePartitionLeaseContentionCounter(ctx context.Context, opts CounterOpt) {
 	recordCounterMetric(ctx, 1, counterOpt{
 		Name:        opts.PkgName,


### PR DESCRIPTION
## Description

Make function queue peek more dynamic, so it guarantees it can at least process X amount of items.

This is useful, especially when concurrency hits and the executor ends up spinning over and over the same queue items. With this change, the queue processor should be able to look further ahead even if there are concurrency limited items backing up the function queue.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
