### PR TITLE
fix: executor.Schedule returns ErrFunctionSkipped when a function is paused

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -339,7 +339,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 				CronSchedule: req.Events[0].GetEvent().CronSchedule(),
 			})
 		}
-		return nil, nil
+		return nil, ErrFunctionSkipped
 	}
 
 	// span that tells when the function was queued


### PR DESCRIPTION
## Description

This fixes a bug from #1330 that was discovered while testing against the cloud repo.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.
