### PR TITLE
Implement batch keys in OSS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform v0.15.3
 	github.com/inngest/expr v0.0.0-20240201152704-a643bc6ace48
-	github.com/inngest/inngestgo v0.7.3-0.20240420014807-6d7557139285
+	github.com/inngest/inngestgo v0.7.3-0.20240521072529-2795f6b14496
 	github.com/jedib0t/go-pretty/v6 v6.3.0
 	github.com/jinzhu/copier v0.3.5
 	github.com/karlseguin/ccache/v2 v2.0.8

--- a/go.sum
+++ b/go.sum
@@ -629,8 +629,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inngest/expr v0.0.0-20240201152704-a643bc6ace48 h1:32YlbLIeO8HOMzYF3DfRLNX8hKeDb8omccWf03PHyh4=
 github.com/inngest/expr v0.0.0-20240201152704-a643bc6ace48/go.mod h1:Evn0nMuDe2NghjynoNzNwwc8ONXuFVzVr1H93tCwPyE=
-github.com/inngest/inngestgo v0.7.3-0.20240420014807-6d7557139285 h1:K3o07cPGQmIqfqIFCxVrZ+TGDJcZPod0DbXUG1/Z2MU=
-github.com/inngest/inngestgo v0.7.3-0.20240420014807-6d7557139285/go.mod h1:tpkVxqBTy8UeSeI6RhX+VW4qSmL3JEMpAnWpOyaQ5vk=
+github.com/inngest/inngestgo v0.7.3-0.20240521072529-2795f6b14496 h1:IbBHbSimWOhW6vuVoGVZj7AqqQ3BzytE9fDbUdNwTDI=
+github.com/inngest/inngestgo v0.7.3-0.20240521072529-2795f6b14496/go.mod h1:m6ToZlAR8TYHZQnCWq0NRxsFgejCBQk3Wnww4fJfFDk=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/pkg/execution/batch/batch.go
+++ b/pkg/execution/batch/batch.go
@@ -32,7 +32,7 @@ import (
 type BatchManager interface {
 	Append(ctx context.Context, bi BatchItem, fn inngest.Function) (*BatchAppendResult, error)
 	RetrieveItems(ctx context.Context, batchID ulid.ULID) ([]BatchItem, error)
-	StartExecution(ctx context.Context, fnID uuid.UUID, batchID ulid.ULID) (string, error)
+	StartExecution(ctx context.Context, batchID ulid.ULID, batchPointer string) (string, error)
 	ScheduleExecution(ctx context.Context, opts ScheduleBatchOpts) error
 	ExpireKeys(ctx context.Context, batchID ulid.ULID) error
 }
@@ -67,8 +67,9 @@ type BatchAppendResult struct {
 	//   append: An event successfully appended to an existing batch
 	//   new: A new batch was created with the passed in event
 	//   full: The batch is full and ready for execution
-	Status  enums.Batch `json:"status"`
-	BatchID string      `json:"batchID,omitempty"`
+	Status          enums.Batch `json:"status"`
+	BatchID         string      `json:"batchID,omitempty"`
+	BatchPointerKey string      `json:"batchPointerKey"`
 }
 
 type ScheduleBatchOpts struct {
@@ -79,6 +80,7 @@ type ScheduleBatchOpts struct {
 
 type ScheduleBatchPayload struct {
 	BatchID                    ulid.ULID  `json:"batchID"`
+	BatchPointer               string     `json:"batchPointer"`
 	AccountID                  uuid.UUID  `json:"acctID"`
 	WorkspaceID                uuid.UUID  `json:"wsID"`
 	AppID                      uuid.UUID  `json:"appID"`

--- a/pkg/execution/batch/batch.go
+++ b/pkg/execution/batch/batch.go
@@ -32,7 +32,9 @@ import (
 type BatchManager interface {
 	Append(ctx context.Context, bi BatchItem, fn inngest.Function) (*BatchAppendResult, error)
 	RetrieveItems(ctx context.Context, batchID ulid.ULID) ([]BatchItem, error)
-	StartExecution(ctx context.Context, batchID ulid.ULID, batchPointer string) (string, error)
+	StartExecutionWithBatchPointer(ctx context.Context, batchID ulid.ULID, batchPointer string) (string, error)
+	// deprecated, use StartExecutionWithBatchPointer
+	StartExecution(ctx context.Context, fnID uuid.UUID, batchID ulid.ULID) (string, error)
 	ScheduleExecution(ctx context.Context, opts ScheduleBatchOpts) error
 	ExpireKeys(ctx context.Context, batchID ulid.ULID) error
 }

--- a/pkg/execution/batch/lua/append.lua
+++ b/pkg/execution/batch/lua/append.lua
@@ -30,7 +30,7 @@ end
 
 -- start execution
 local batchID = get_or_create_batch_key(batchPointerKey)
-local resp = { status = "append", batchID = batchID }
+local resp = { status = "append", batchID = batchID, batchPointerKey = batchPointerKey }
 
 -- NOTE: these need to be identical to the ones in the queue key generator
 --   * Batch
@@ -50,7 +50,7 @@ local len = redis.call("RPUSH", batchKey, event)
 
 if len == 1 then
   -- newly started batch
-  resp = { status = "new", batchID = batchID }
+  resp = { status = "new", batchID = batchID, batchPointerKey = batchPointerKey }
 end
 
 -- if batch is full
@@ -61,7 +61,7 @@ if len >= batchLimit then
 
   -- change poiner so following ops don't append to this batch anymore
   update_pointer(batchPointerKey, newULID)
-  resp = { status = "full", batchID = batchID }
+  resp = { status = "full", batchID = batchID, batchPointerKey = batchPointerKey }
 end
 
 return cjson.encode(resp)

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -48,7 +48,7 @@ func (b redisBatchManager) batchKey(ctx context.Context, evt event.Event, fn inn
 			Str("expression", *fn.EventBatch.Key).
 			Interface("event", evt.Map()).
 			Msg("error evaluating batch key expression")
-		return "<invalid>", nil
+		return fn.ID.String(), fmt.Errorf("invalid expression: %w", err)
 	}
 	if str, ok := out.(string); ok {
 		return str, nil

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -163,10 +163,44 @@ func (b redisBatchManager) RetrieveItems(ctx context.Context, batchID ulid.ULID)
 
 // StartExecution sets the status to `started`
 // If it has already started, don't do anything
-func (b redisBatchManager) StartExecution(ctx context.Context, batchID ulid.ULID, batchPointer string) (string, error) {
+func (b redisBatchManager) StartExecutionWithBatchPointer(ctx context.Context, batchID ulid.ULID, batchPointer string) (string, error) {
 	keys := []string{
 		b.k.BatchMetadata(ctx, batchID),
 		batchPointer,
+	}
+	args := []string{
+		enums.BatchStatusStarted.String(),
+		ulid.Make().String(),
+	}
+
+	status, err := scripts["start"].Exec(
+		ctx,
+		b.r,
+		keys,
+		args,
+	).AsInt64()
+	if err != nil {
+		return "", fmt.Errorf("failed to start batch execution: %w", err)
+	}
+
+	switch status {
+	case 0: // haven't started, so mark mark it started
+		return enums.BatchStatusReady.String(), nil
+
+	case 1: // Already started
+		return enums.BatchStatusStarted.String(), nil
+
+	default:
+		return "", fmt.Errorf("invalid status for start batch ops: %d", status)
+	}
+}
+
+// StartExecution sets the status to `started`
+// If it has already started, don't do anything
+func (b redisBatchManager) StartExecution(ctx context.Context, fnID uuid.UUID, batchID ulid.ULID) (string, error) {
+	keys := []string{
+		b.k.BatchMetadata(ctx, batchID),
+		b.k.BatchPointer(ctx, fnID),
 	}
 	args := []string{
 		enums.BatchStatusStarted.String(),

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -39,7 +39,7 @@ type redisBatchManager struct {
 
 func (b redisBatchManager) batchKey(ctx context.Context, evt event.Event, fn inngest.Function) (string, error) {
 	if fn.EventBatch.Key == nil {
-		return fn.ID.String(), nil
+		return "default", nil
 	}
 
 	out, _, err := expressions.Evaluate(ctx, *fn.EventBatch.Key, map[string]any{"event": evt.Map()})

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -38,14 +38,14 @@ type redisBatchManager struct {
 }
 
 func (b redisBatchManager) batchKey(ctx context.Context, evt event.Event, fn inngest.Function) (string, error) {
-	if fn.Debounce.Key == nil {
+	if fn.EventBatch.Key == nil {
 		return fn.ID.String(), nil
 	}
 
 	out, _, err := expressions.Evaluate(ctx, *fn.EventBatch.Key, map[string]any{"event": evt.Map()})
 	if err != nil {
 		log.From(ctx).Error().Err(err).
-			Str("expression", *fn.Debounce.Key).
+			Str("expression", *fn.EventBatch.Key).
 			Interface("event", evt.Map()).
 			Msg("error evaluating batch key expression")
 		return "<invalid>", nil

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2629,6 +2629,7 @@ func (e *executor) AppendAndScheduleBatchWithOpts(ctx context.Context, fn innges
 				AppID:           bi.AppID,
 				FunctionID:      bi.FunctionID,
 				FunctionVersion: bi.FunctionVersion,
+				BatchPointer:    result.BatchPointerKey,
 			},
 			At: at,
 		}); err != nil {

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -304,7 +304,8 @@ func (s *svc) handleScheduledBatch(ctx context.Context, item queue.Item) error {
 	}
 
 	batchID := opts.BatchID
-	status, err := s.batcher.StartExecution(ctx, opts.FunctionID, batchID)
+	// TODO Gracefully handle old message without batch pointer as well!
+	status, err := s.batcher.StartExecution(ctx, batchID, opts.BatchPointer)
 	if err != nil {
 		return err
 	}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -304,8 +304,18 @@ func (s *svc) handleScheduledBatch(ctx context.Context, item queue.Item) error {
 	}
 
 	batchID := opts.BatchID
-	// TODO Gracefully handle old message without batch pointer as well!
-	status, err := s.batcher.StartExecution(ctx, batchID, opts.BatchPointer)
+
+	var status string
+	var err error
+	if opts.ScheduleBatchPayload.BatchPointer != "" {
+		// if we encounter a new producer, use new method
+		status, err = s.batcher.StartExecutionWithBatchPointer(ctx, batchID, opts.BatchPointer)
+	} else {
+		// otherwise, fall back to previous behavior
+		// TODO Remove when all messages include batch pointer
+		status, err = s.batcher.StartExecution(ctx, opts.FunctionID, batchID)
+	}
+
 	if err != nil {
 		return err
 	}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -307,7 +307,7 @@ func (s *svc) handleScheduledBatch(ctx context.Context, item queue.Item) error {
 
 	var status string
 	var err error
-	if opts.ScheduleBatchPayload.BatchPointer != "" {
+	if opts.BatchPointer != "" {
 		// if we encounter a new producer, use new method
 		status, err = s.batcher.StartExecutionWithBatchPointer(ctx, batchID, opts.BatchPointer)
 	} else {

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -235,6 +235,9 @@ type BatchKeyGenerator interface {
 	// BatchPointer returns the key used as the pointer reference to the
 	// actual batch
 	BatchPointer(context.Context, uuid.UUID) string
+	// BatchPointerWithKey returns the key used as the pointer reference to the
+	// actual batch for a given batchKey
+	BatchPointerWithKey(context.Context, uuid.UUID, string) string
 	// Batch returns the key used to store the specific batch of
 	// events, that is used to trigger a function run
 	Batch(context.Context, ulid.ULID) string
@@ -323,6 +326,10 @@ func (d DefaultQueueKeyGenerator) QueuePrefix() string {
 
 func (d DefaultQueueKeyGenerator) BatchPointer(ctx context.Context, workflowID uuid.UUID) string {
 	return fmt.Sprintf("%s:workflows:%s:batch", d.Prefix, workflowID)
+}
+
+func (d DefaultQueueKeyGenerator) BatchPointerWithKey(ctx context.Context, workflowID uuid.UUID, batchKey string) string {
+	return fmt.Sprintf("%s:%s", d.BatchPointer(ctx, workflowID), batchKey)
 }
 
 func (d DefaultQueueKeyGenerator) Batch(ctx context.Context, batchID ulid.ULID) string {

--- a/pkg/inngest/batch.go
+++ b/pkg/inngest/batch.go
@@ -1,8 +1,10 @@
 package inngest
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/inngest/inngest/pkg/expressions"
 	"time"
 
 	"github.com/inngest/inngest/pkg/consts"
@@ -63,7 +65,7 @@ func (c EventBatchConfig) IsEnabled() bool {
 	return c.MaxSize > 1 && c.Timeout != ""
 }
 
-func (c EventBatchConfig) IsValid() error {
+func (c EventBatchConfig) IsValid(ctx context.Context) error {
 	if c.MaxSize < 2 {
 		return syscode.Error{
 			Code:    syscode.CodeBatchSizeInvalid,
@@ -79,6 +81,16 @@ func (c EventBatchConfig) IsValid() error {
 
 	if _, err := time.ParseDuration(c.Timeout); err != nil {
 		return fmt.Errorf("invalid timeout string: %v", err)
+	}
+
+	if c.Key != nil {
+		// Ensure the expression is valid if present.
+		if exprErr := expressions.Validate(ctx, *c.Key); exprErr != nil {
+			return syscode.Error{
+				Code:    syscode.CodeBatchKeyExpressionInvalid,
+				Message: fmt.Sprintf("batch key expression is invalid: %s", exprErr),
+			}
+		}
 	}
 
 	return nil

--- a/pkg/inngest/batch.go
+++ b/pkg/inngest/batch.go
@@ -47,6 +47,8 @@ func NewEventBatchConfig(conf map[string]any) (*EventBatchConfig, error) {
 // - The batch is full
 // - The time to wait is up
 type EventBatchConfig struct {
+	Key *string `json:"key,omitempty"`
+
 	// MaxSize is the maximum number of events that can be
 	// included in a batch
 	MaxSize int `json:"maxSize"`

--- a/pkg/inngest/batch_test.go
+++ b/pkg/inngest/batch_test.go
@@ -1,6 +1,7 @@
 package inngest
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -133,7 +134,7 @@ func TestEventBatchConfigIsValid(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if err := test.config.IsValid(); err != nil {
+			if err := test.config.IsValid(context.Background()); err != nil {
 				require.ErrorContains(t, err, test.expected.Error())
 			}
 		})

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -255,7 +255,7 @@ func (f Function) Validate(ctx context.Context) error {
 	}
 
 	if f.EventBatch != nil {
-		if berr := f.EventBatch.IsValid(); berr != nil {
+		if berr := f.EventBatch.IsValid(ctx); berr != nil {
 			err = multierror.Append(err, berr)
 		}
 

--- a/pkg/syscode/codes.go
+++ b/pkg/syscode/codes.go
@@ -1,9 +1,10 @@
 package syscode
 
 const (
-	CodeBatchSizeInvalid        = "batch_size_invalid"
-	CodeComboUnsupported        = "combo_unsupported"
-	CodeConcurrencyLimitInvalid = "concurrency_limit_invalid"
-	CodeConfigInvalid           = "config_invalid"
-	CodeUnknown                 = "unknown"
+	CodeBatchSizeInvalid          = "batch_size_invalid"
+	CodeComboUnsupported          = "combo_unsupported"
+	CodeConcurrencyLimitInvalid   = "concurrency_limit_invalid"
+	CodeConfigInvalid             = "config_invalid"
+	CodeUnknown                   = "unknown"
+	CodeBatchKeyExpressionInvalid = "batch_key_expression_invalid"
 )

--- a/tests/golang/batch_test.go
+++ b/tests/golang/batch_test.go
@@ -3,6 +3,7 @@ package golang
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -138,5 +139,76 @@ func TestBatchInvoke(t *testing.T) {
 		require.EqualValues(t, 2, atomic.LoadInt32(&counter))
 		require.EqualValues(t, 5, atomic.LoadInt32(&totalEvents))
 		require.EqualValues(t, 5, atomic.LoadInt32(&invokeCounter))
+	})
+}
+
+func TestBatchEventsWithKeys(t *testing.T) {
+	type BatchEventDataWithUserId struct {
+		Time   time.Time `json:"time"`
+		UserId string    `json:"userId"`
+	}
+	type BatchEventWithKey = inngestgo.GenericEvent[BatchEventDataWithUserId, any]
+
+	ctx := context.Background()
+	h, server, registerFuncs := NewSDKHandler(t, "user-notifications")
+	defer server.Close()
+
+	var (
+		totalEvents int32
+	)
+
+	batchInvokedCounter := make(map[string]int32)
+	batchEventsCounter := make(map[string]int)
+	mut := sync.Mutex{}
+
+	batchKey := "event.data.userId"
+
+	a := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{Name: "batch test", BatchEvents: &inngest.EventBatchConfig{MaxSize: 3, Timeout: "5s", Key: &batchKey}},
+		inngestgo.EventTrigger("test/notification.send", nil),
+		func(ctx context.Context, input inngestgo.Input[BatchEventWithKey]) (any, error) {
+			mut.Lock()
+			batchInvokedCounter[input.Events[0].Data.UserId] += 1
+			batchEventsCounter[input.Events[0].Data.UserId] += len(input.Events)
+			mut.Unlock()
+			atomic.AddInt32(&totalEvents, int32(len(input.Events)))
+			return true, nil
+		},
+	)
+	h.Register(a)
+	registerFuncs()
+	// calls pkg/devserver/api.go:256
+	// wrong type in pkg/sdk/function.go:11
+
+	t.Run("trigger batch", func(t *testing.T) {
+		sequence := []string{"a", "b", "c", "a", "b", "c", "a", "b"}
+		for _, userId := range sequence {
+			_, err := inngestgo.Send(ctx, BatchEventWithKey{
+				Name: "test/notification.send",
+				Data: BatchEventDataWithUserId{Time: time.Now(), UserId: userId},
+			})
+			require.NoError(t, err)
+		}
+
+		// First trigger should be because of batch is full
+		<-time.After(2 * time.Second)
+		require.EqualValues(t, 1, batchInvokedCounter["a"])
+		require.EqualValues(t, 3, batchEventsCounter["a"])
+		require.EqualValues(t, 1, batchInvokedCounter["b"])
+		require.EqualValues(t, 3, batchEventsCounter["b"])
+		require.EqualValues(t, 0, batchInvokedCounter["c"])
+		require.EqualValues(t, 0, batchEventsCounter["c"])
+
+		require.EqualValues(t, 6, atomic.LoadInt32(&totalEvents))
+
+		<-time.After(5 * time.Second)
+		require.EqualValues(t, 1, batchInvokedCounter["a"])
+		require.EqualValues(t, 3, batchEventsCounter["a"])
+		require.EqualValues(t, 1, batchInvokedCounter["b"])
+		require.EqualValues(t, 3, batchEventsCounter["b"])
+		require.EqualValues(t, 1, batchInvokedCounter["c"])
+		require.EqualValues(t, 2, batchEventsCounter["c"])
+
+		require.EqualValues(t, 8, atomic.LoadInt32(&totalEvents))
 	})
 }

--- a/tests/golang/batch_test.go
+++ b/tests/golang/batch_test.go
@@ -177,8 +177,6 @@ func TestBatchEventsWithKeys(t *testing.T) {
 	)
 	h.Register(a)
 	registerFuncs()
-	// calls pkg/devserver/api.go:256
-	// wrong type in pkg/sdk/function.go:11
 
 	t.Run("trigger batch", func(t *testing.T) {
 		sequence := []string{"a", "b", "c", "a", "b", "c", "a", "b"}
@@ -209,6 +207,6 @@ func TestBatchEventsWithKeys(t *testing.T) {
 		require.EqualValues(t, 1, batchInvokedCounter["c"])
 		require.EqualValues(t, 2, batchEventsCounter["c"])
 
-		require.EqualValues(t, 8, atomic.LoadInt32(&totalEvents))
+		require.EqualValues(t, len(sequence), atomic.LoadInt32(&totalEvents))
 	})
 }

--- a/vendor/github.com/inngest/inngestgo/handler.go
+++ b/vendor/github.com/inngest/inngestgo/handler.go
@@ -341,7 +341,7 @@ func (h *handler) register(w http.ResponseWriter, r *http.Request) error {
 			f.EventBatch = map[string]any{
 				"maxSize": c.BatchEvents.MaxSize,
 				"timeout": c.BatchEvents.Timeout,
-				"key": c.BatchEvents.Key,
+				"key":     c.BatchEvents.Key,
 			}
 		}
 

--- a/vendor/github.com/inngest/inngestgo/handler.go
+++ b/vendor/github.com/inngest/inngestgo/handler.go
@@ -341,6 +341,7 @@ func (h *handler) register(w http.ResponseWriter, r *http.Request) error {
 			f.EventBatch = map[string]any{
 				"maxSize": c.BatchEvents.MaxSize,
 				"timeout": c.BatchEvents.Timeout,
+				"key": c.BatchEvents.Key,
 			}
 		}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -515,7 +515,7 @@ github.com/inconshreveable/mousetrap
 # github.com/inngest/expr v0.0.0-20240201152704-a643bc6ace48
 ## explicit; go 1.21.0
 github.com/inngest/expr
-# github.com/inngest/inngestgo v0.7.3-0.20240420014807-6d7557139285
+# github.com/inngest/inngestgo v0.7.3-0.20240521072529-2795f6b14496
 ## explicit; go 1.21.0
 github.com/inngest/inngestgo
 github.com/inngest/inngestgo/errors


### PR DESCRIPTION
## Description

This pull request introduces a new `key` option on the function batching configuration. When storing batches, the batch pointer now includes a hashed representation of the evaluated expression. Unlike the previous implementation where one function would have at most one associated active batch, batch keys create many batches per function.

## Motivation

Batch keys enable event aggregation or grouping by tenants: Events could be counted for user notifications, or processed together to enable other features.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR. -> https://linear.app/inngest/issue/INN-3010/implement-batch-keys-in-oss-executor
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
