### PR TITLE
Render RunDetails inside row

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/RunsTable.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/RunsTable.tsx
@@ -110,16 +110,16 @@ export default function RunsTable({
         {isEmpty && (
           <tr>
             {/* TODO: when we introduce column visibility options, this colSpan has to be dinamically calculated depending on # visible columns */}
-            <td className="pt-28 text-center align-top	font-medium text-slate-600" colSpan={5}>
+            <td className="pt-28 text-center align-top font-medium text-slate-600" colSpan={5}>
               No results were found.
             </td>
           </tr>
         )}
         {!isEmpty &&
           table.getRowModel().rows.map((row) => (
-            <Fragment key={row.id}>
+            <Fragment key={row.original.id}>
               <tr
-                key={row.id}
+                key={row.original.id}
                 className="h-12 cursor-pointer hover:bg-sky-50"
                 onClick={row.getToggleExpandedHandler()}
               >
@@ -130,9 +130,10 @@ export default function RunsTable({
                 ))}
               </tr>
               {row.getIsExpanded() && (
-                <tr>
+                // Overrides tableStyles divider color
+                <tr className="!border-transparent">
                   <td colSpan={row.getVisibleCells().length}>
-                    {renderSubComponent({ id: row.id })}
+                    {renderSubComponent({ id: row.original.id })}
                   </td>
                 </tr>
               )}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/page.tsx
@@ -17,6 +17,7 @@ import { useEnvironment } from '@/app/(organization-active)/(dashboard)/env/[env
 import { graphql } from '@/gql';
 import { FunctionRunTimeFieldV2 } from '@/gql/graphql';
 import { useSearchParam, useStringArraySearchParam } from '@/utils/useSearchParam';
+import Page from '../../../runs/[runID]/page';
 import RunsTable from './RunsTable';
 import TimeFilter from './TimeFilter';
 import { toRunStatuses, toTimeField } from './utils';
@@ -48,8 +49,11 @@ const GetRunsDocument = graphql(`
 `);
 
 const renderSubComponent = ({ id }: { id: string }) => {
-  /* TODO: Render the timeline instead */
-  return <p>Subrow {id}</p>;
+  return (
+    <div className="mx-5">
+      <Page params={{ runID: id }} />
+    </div>
+  );
 };
 
 export default function RunsPage() {


### PR DESCRIPTION
## Description
- Render RunDetails inside the runs table 

https://github.com/inngest/inngest/assets/16758464/34f3822f-855f-447f-8def-36061aaef3ab

There are things that need to be added in a different PR (link to open in new tab, changing the loading from spinner to skeleton)

## Motivation
Getting the run details already here helps figuring out loading and scrolling for the entire page

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
