### PR TITLE
Make debounced functions respect the paused_at field

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -272,13 +272,14 @@ func (e *executor) AddLifecycleListener(l execution.LifecycleListener) {
 func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) (*state.Identifier, error) {
 	if req.Function.Debounce != nil && !req.PreventDebounce {
 		err := e.debouncer.Debounce(ctx, debounce.DebounceItem{
-			AccountID:       req.AccountID,
-			WorkspaceID:     req.WorkspaceID,
-			AppID:           req.AppID,
-			FunctionID:      req.Function.ID,
-			FunctionVersion: req.Function.FunctionVersion,
-			EventID:         req.Events[0].GetInternalID(),
-			Event:           req.Events[0].GetEvent(),
+			AccountID:        req.AccountID,
+			WorkspaceID:      req.WorkspaceID,
+			AppID:            req.AppID,
+			FunctionID:       req.Function.ID,
+			FunctionVersion:  req.Function.FunctionVersion,
+			EventID:          req.Events[0].GetInternalID(),
+			Event:            req.Events[0].GetEvent(),
+			FunctionPausedAt: req.FunctionPausedAt,
 		}, req.Function)
 		if err != nil {
 			return nil, err

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -364,12 +364,13 @@ func (s *svc) handleDebounce(ctx context.Context, item queue.Item) error {
 			defer span.End()
 
 			_, err = s.exec.Schedule(ctx, execution.ScheduleRequest{
-				Function:        f,
-				AccountID:       di.AccountID,
-				WorkspaceID:     di.WorkspaceID,
-				AppID:           di.AppID,
-				Events:          []event.TrackedEvent{di},
-				PreventDebounce: true,
+				Function:         f,
+				AccountID:        di.AccountID,
+				WorkspaceID:      di.WorkspaceID,
+				AppID:            di.AppID,
+				Events:           []event.TrackedEvent{di},
+				PreventDebounce:  true,
+				FunctionPausedAt: di.FunctionPausedAt,
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
## Description

This PR makes debounced functions respect the new `paused_at` field. This fixes a corresponding, new, failing test in the cloud repo.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.
