### PR TITLE
Move async gauge instrumentation as part of initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Thumbs.db
 /.vercel/
 
 .idea
+/tmp/

--- a/pkg/telemetry/gauge.go
+++ b/pkg/telemetry/gauge.go
@@ -9,7 +9,7 @@ type GaugeOpt struct {
 }
 
 func GaugeQueueItemLatencyEWMA(ctx context.Context, value int64, opts GaugeOpt) {
-	recordGaugeMetric(ctx, gaugeOpt{
+	registerAsyncGauge(ctx, gaugeOpt{
 		Name:        opts.PkgName,
 		MetricName:  "queue_item_latency_ewma",
 		Description: "The moving average of the queue item latency",
@@ -21,7 +21,7 @@ func GaugeQueueItemLatencyEWMA(ctx context.Context, value int64, opts GaugeOpt) 
 }
 
 func GaugeWorkerQueueCapacity(ctx context.Context, value int64, opts GaugeOpt) {
-	recordGaugeMetric(ctx, gaugeOpt{
+	registerAsyncGauge(ctx, gaugeOpt{
 		Name:        opts.PkgName,
 		MetricName:  "queue_capacity_total",
 		Description: "Capacity of current worker",
@@ -33,7 +33,7 @@ func GaugeWorkerQueueCapacity(ctx context.Context, value int64, opts GaugeOpt) {
 }
 
 func GaugeGlobalQueuePartitionCount(ctx context.Context, opts GaugeOpt) {
-	recordGaugeMetric(ctx, gaugeOpt{
+	registerAsyncGauge(ctx, gaugeOpt{
 		Name:        opts.PkgName,
 		MetricName:  "queue_global_partition_count",
 		Description: "Number of total partitions in the global queue",
@@ -43,7 +43,7 @@ func GaugeGlobalQueuePartitionCount(ctx context.Context, opts GaugeOpt) {
 }
 
 func GaugeGlobalQueuePartitionAvailable(ctx context.Context, opts GaugeOpt) {
-	recordGaugeMetric(ctx, gaugeOpt{
+	registerAsyncGauge(ctx, gaugeOpt{
 		Name:        opts.PkgName,
 		MetricName:  "queue_global_partition_available_count",
 		Description: "Number of available partitions in the global queue",
@@ -53,7 +53,7 @@ func GaugeGlobalQueuePartitionAvailable(ctx context.Context, opts GaugeOpt) {
 }
 
 func GaugeQueueShardCount(ctx context.Context, value int64, opts GaugeOpt) {
-	recordGaugeMetric(ctx, gaugeOpt{
+	registerAsyncGauge(ctx, gaugeOpt{
 		Name:        opts.PkgName,
 		MetricName:  "queue_shards_count",
 		Description: "Number of shards in the queue",
@@ -65,7 +65,7 @@ func GaugeQueueShardCount(ctx context.Context, value int64, opts GaugeOpt) {
 }
 
 func GaugeQueueShardGuaranteedCapacityCount(ctx context.Context, value int64, opts GaugeOpt) {
-	recordGaugeMetric(ctx, gaugeOpt{
+	registerAsyncGauge(ctx, gaugeOpt{
 		Name:        opts.PkgName,
 		MetricName:  "queue_shards_guaranteed_capacity_count",
 		Description: "Shard guaranteed capacity",
@@ -77,7 +77,7 @@ func GaugeQueueShardGuaranteedCapacityCount(ctx context.Context, value int64, op
 }
 
 func GaugeQueueShardLeaseCount(ctx context.Context, value int64, opts GaugeOpt) {
-	recordGaugeMetric(ctx, gaugeOpt{
+	registerAsyncGauge(ctx, gaugeOpt{
 		Name:        opts.PkgName,
 		MetricName:  "queue_shards_lease_count",
 		Description: "Shard current lease count",
@@ -89,7 +89,7 @@ func GaugeQueueShardLeaseCount(ctx context.Context, value int64, opts GaugeOpt) 
 }
 
 func GaugeQueueShardPartitionAvailableCount(ctx context.Context, opts GaugeOpt) {
-	recordGaugeMetric(ctx, gaugeOpt{
+	registerAsyncGauge(ctx, gaugeOpt{
 		Name:        opts.PkgName,
 		MetricName:  "queue_shard_partition_available_count",
 		Description: "The number of shard partitions available",

--- a/pkg/telemetry/gauge.go
+++ b/pkg/telemetry/gauge.go
@@ -35,7 +35,7 @@ func GaugeWorkerQueueCapacity(ctx context.Context, value int64, opts GaugeOpt) {
 func GaugeGlobalQueuePartitionCount(ctx context.Context, opts GaugeOpt) {
 	recordGaugeMetric(ctx, gaugeOpt{
 		Name:        opts.PkgName,
-		MetricName:  "queue_global_partition_total_count",
+		MetricName:  "queue_global_partition_count",
 		Description: "Number of total partitions in the global queue",
 		Attributes:  opts.Tags,
 		Callback:    opts.Observer,

--- a/pkg/telemetry/utils.go
+++ b/pkg/telemetry/utils.go
@@ -105,7 +105,7 @@ type GaugeCallback func(ctx context.Context) (int64, error)
 
 // RecordGaugeMetric records the gauge value via a callback.
 // The callback needs to be passed in so it doesn't get captured as a closure when instrumenting the value
-func recordGaugeMetric(ctx context.Context, opts gaugeOpt) {
+func registerAsyncGauge(ctx context.Context, opts gaugeOpt) {
 	// use the global one by default
 	meter := otel.Meter(opts.Name)
 	if opts.Meter != nil {


### PR DESCRIPTION
## Description

The current otel gauge APIs only allow observables, and not sync instrumentation.
Move them to queue initialization instead so we don't attempt to register the callbacks multiple times. Which also contributes to memory growth.

Ref:
https://pkg.go.dev/go.opentelemetry.io/otel/metric#hdr-Measurements

Also add an internal registry to make sure metrics are not registered multiple times.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
