### PR TITLE
Add support for function.paused_at in ScheduleBatchPayload/RetrieveAndScheduleBatch

### DIFF
--- a/pkg/execution/batch/batch.go
+++ b/pkg/execution/batch/batch.go
@@ -78,10 +78,11 @@ type ScheduleBatchOpts struct {
 }
 
 type ScheduleBatchPayload struct {
-	BatchID         ulid.ULID `json:"batchID"`
-	AccountID       uuid.UUID `json:"acctID"`
-	WorkspaceID     uuid.UUID `json:"wsID"`
-	AppID           uuid.UUID `json:"appID"`
-	FunctionID      uuid.UUID `json:"fnID"`
-	FunctionVersion int       `json:"fnV"`
+	BatchID          ulid.ULID  `json:"batchID"`
+	AccountID        uuid.UUID  `json:"acctID"`
+	WorkspaceID      uuid.UUID  `json:"wsID"`
+	AppID            uuid.UUID  `json:"appID"`
+	FunctionID       uuid.UUID  `json:"fnID"`
+	FunctionVersion  int        `json:"fnV"`
+	FunctionPausedAt *time.Time `json:"fpAt,omitempty"`
 }

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2527,13 +2527,14 @@ func (e executor) RetrieveAndScheduleBatch(ctx context.Context, fn inngest.Funct
 
 	key := fmt.Sprintf("%s-%s", fn.ID, payload.BatchID)
 	identifier, err := e.Schedule(ctx, execution.ScheduleRequest{
-		AccountID:      payload.AccountID,
-		WorkspaceID:    payload.WorkspaceID,
-		AppID:          payload.AppID,
-		Function:       fn,
-		Events:         events,
-		BatchID:        &payload.BatchID,
-		IdempotencyKey: &key,
+		AccountID:        payload.AccountID,
+		WorkspaceID:      payload.WorkspaceID,
+		AppID:            payload.AppID,
+		Function:         fn,
+		Events:           events,
+		BatchID:          &payload.BatchID,
+		IdempotencyKey:   &key,
+		FunctionPausedAt: payload.FunctionPausedAt,
 	})
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())


### PR DESCRIPTION
## Description

This PR adds fields required for batched functions to respect the new `paused_at` field. This is necessary, along with changes in the cloud repo, to fix a corresponding, new, failing test in the cloud repo.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.
