### PR TITLE
Complete pause support in batch handling

### DIFF
--- a/pkg/execution/batch/batch.go
+++ b/pkg/execution/batch/batch.go
@@ -78,11 +78,11 @@ type ScheduleBatchOpts struct {
 }
 
 type ScheduleBatchPayload struct {
-	BatchID          ulid.ULID  `json:"batchID"`
-	AccountID        uuid.UUID  `json:"acctID"`
-	WorkspaceID      uuid.UUID  `json:"wsID"`
-	AppID            uuid.UUID  `json:"appID"`
-	FunctionID       uuid.UUID  `json:"fnID"`
-	FunctionVersion  int        `json:"fnV"`
-	FunctionPausedAt *time.Time `json:"fpAt,omitempty"`
+	BatchID                    ulid.ULID  `json:"batchID"`
+	AccountID                  uuid.UUID  `json:"acctID"`
+	WorkspaceID                uuid.UUID  `json:"wsID"`
+	AppID                      uuid.UUID  `json:"appID"`
+	FunctionID                 uuid.UUID  `json:"fnID"`
+	FunctionVersion            int        `json:"fnV"`
+	DeprecatedFunctionPausedAt *time.Time `json:"fpAt,omitempty"` // deprecated
 }

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -124,7 +124,12 @@ type Executor interface {
 	// InvokeNotFoundHandler invokes the invoke not found handler.
 	InvokeNotFoundHandler(context.Context, InvokeNotFoundHandlerOpts) error
 
+	AppendAndScheduleBatchWithOpts(ctx context.Context, fn inngest.Function, bi batch.BatchItem, opts BatchExecOpts) error
+	// deprecated; use AppendAndScheduleBatchWithOpts in new code
 	AppendAndScheduleBatch(ctx context.Context, fn inngest.Function, bi batch.BatchItem) error
+
+	RetrieveAndScheduleBatchWithOpts(ctx context.Context, fn inngest.Function, payload batch.ScheduleBatchPayload, opts BatchExecOpts) error
+	// deprecated; use RetrieveAndScheduleBatchWithOpts in new code
 	RetrieveAndScheduleBatch(ctx context.Context, fn inngest.Function, payload batch.ScheduleBatchPayload) error
 }
 
@@ -135,6 +140,12 @@ type InvokeNotFoundHandlerOpts struct {
 	RunID         string
 	Err           map[string]any
 	Result        any
+}
+
+// BatchExecOpts communicates state and options that are relevant only when scheduling a batch
+// to be worked on *imminently* (i.e. ~now, not at some future time).
+type BatchExecOpts struct {
+	FunctionPausedAt *time.Time
 }
 
 // FinishHandler is a function that handles functions finishing in the executor.

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -124,11 +124,11 @@ type Executor interface {
 	// InvokeNotFoundHandler invokes the invoke not found handler.
 	InvokeNotFoundHandler(context.Context, InvokeNotFoundHandlerOpts) error
 
-	AppendAndScheduleBatchWithOpts(ctx context.Context, fn inngest.Function, bi batch.BatchItem, opts BatchExecOpts) error
+	AppendAndScheduleBatchWithOpts(ctx context.Context, fn inngest.Function, bi batch.BatchItem, opts *BatchExecOpts) error
 	// deprecated; use AppendAndScheduleBatchWithOpts in new code
 	AppendAndScheduleBatch(ctx context.Context, fn inngest.Function, bi batch.BatchItem) error
 
-	RetrieveAndScheduleBatchWithOpts(ctx context.Context, fn inngest.Function, payload batch.ScheduleBatchPayload, opts BatchExecOpts) error
+	RetrieveAndScheduleBatchWithOpts(ctx context.Context, fn inngest.Function, payload batch.ScheduleBatchPayload, opts *BatchExecOpts) error
 	// deprecated; use RetrieveAndScheduleBatchWithOpts in new code
 	RetrieveAndScheduleBatch(ctx context.Context, fn inngest.Function, payload batch.ScheduleBatchPayload) error
 }

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -90,7 +90,7 @@ func NewExecutor(opts ...ExecutorOpt) (execution.Executor, error) {
 	return m, nil
 }
 
-// ExecutorOpt modifies the built in executor on creation.
+// ExecutorOpt modifies the built-in executor on creation.
 type ExecutorOpt func(m execution.Executor) error
 
 func WithCancellationChecker(c cancellation.Checker) ExecutorOpt {

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -325,7 +325,7 @@ func (s *svc) handleScheduledBatch(ctx context.Context, item queue.Item) error {
 		AppID:           item.Identifier.AppID,
 		FunctionID:      item.Identifier.WorkflowID,
 		FunctionVersion: fn.FunctionVersion,
-	}, execution.BatchExecOpts{}); err != nil {
+	}, nil); err != nil {
 		return fmt.Errorf("could not retrieve and schedule batch items: %w", err)
 	}
 

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -318,14 +318,14 @@ func (s *svc) handleScheduledBatch(ctx context.Context, item queue.Item) error {
 		return err
 	}
 
-	if err := s.exec.RetrieveAndScheduleBatch(ctx, *fn, batch.ScheduleBatchPayload{
+	if err := s.exec.RetrieveAndScheduleBatchWithOpts(ctx, *fn, batch.ScheduleBatchPayload{
 		BatchID:         batchID,
 		AccountID:       item.Identifier.AccountID,
 		WorkspaceID:     item.Identifier.WorkspaceID,
 		AppID:           item.Identifier.AppID,
 		FunctionID:      item.Identifier.WorkflowID,
 		FunctionVersion: fn.FunctionVersion,
-	}); err != nil {
+	}, execution.BatchExecOpts{}); err != nil {
 		return fmt.Errorf("could not retrieve and schedule batch items: %w", err)
 	}
 

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -616,7 +616,7 @@ func (s *svc) initialize(ctx context.Context, fn inngest.Function, evt event.Tra
 			Event:           evt.GetEvent(),
 		}
 
-		if err := s.executor.AppendAndScheduleBatchWithOpts(ctx, fn, bi, execution.BatchExecOpts{}); err != nil {
+		if err := s.executor.AppendAndScheduleBatchWithOpts(ctx, fn, bi, nil); err != nil {
 			return fmt.Errorf("could not append and schedule batch item: %w", err)
 		}
 

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -616,7 +616,7 @@ func (s *svc) initialize(ctx context.Context, fn inngest.Function, evt event.Tra
 			Event:           evt.GetEvent(),
 		}
 
-		if err := s.executor.AppendAndScheduleBatch(ctx, fn, bi); err != nil {
+		if err := s.executor.AppendAndScheduleBatchWithOpts(ctx, fn, bi, execution.BatchExecOpts{}); err != nil {
 			return fmt.Errorf("could not append and schedule batch item: %w", err)
 		}
 


### PR DESCRIPTION
## Description

This PR allows our batch scheduling logic to take the function's paused_at column into account at the point in time that the batch is being scheduled for imminent execution.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.
