### PR TITLE
Add `runID` to `step.invoke()` when the run is scheduled

### DIFF
--- a/pkg/consts/otel.go
+++ b/pkg/consts/otel.go
@@ -52,8 +52,11 @@ const (
 
 	OtelSysStepSleepEndAt = "sys.step.sleep.end"
 
-	OtelSysStepWaitExpires = "sys.step.wait.expires"
-	OtelSysStepWaitExpired = "sys.step.wait.expired"
+	OtelSysStepWaitExpires        = "sys.step.wait.expires"
+	OtelSysStepWaitExpired        = "sys.step.wait.expired"
+	OtelSysStepWaitEventName      = "sys.step.wait.event"
+	OtelSysStepWaitExpression     = "sys.step.wait.expr"
+	OtelSysStepWaitMatchedEventID = "sys.step.wait.matched.event.id"
 
 	OtelSysStepInvokeExpires           = "sys.step.invoke.expires"
 	OtelSysStepInvokeTargetFnID        = "sys.step.invoke.fn.id"

--- a/pkg/consts/otel.go
+++ b/pkg/consts/otel.go
@@ -86,7 +86,6 @@ const (
 	OtelScopeEvent     = "event.inngest"
 	OtelScopeBatch     = "batch.inngest"
 	OtelScopeDebounce  = "debounce.inngest"
-	OtelScopeWait      = "wait.inngest"
 	OtelScopeTrigger   = "trigger.inngest"
 	OtelScopeCron      = "cron.inngest"
 	OtelScopeEnv       = "env.inngest"

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -137,6 +137,8 @@ func (e Event) IsFinishedEvent() bool {
 type InngestMetadata struct {
 	InvokeFnID          string `json:"fn_id"`
 	InvokeCorrelationId string `json:"correlation_id,omitempty"`
+	InvokeSpanID        string `json:"sid,omitempty"`
+	InvokeTimestamp     int64  `json:"ts"`
 }
 
 func (e Event) InngestMetadata() *InngestMetadata {
@@ -206,6 +208,8 @@ type NewInvocationEventOpts struct {
 	Event         Event
 	FnID          string
 	CorrelationID *string
+	SpanID        *string
+	SpanTimestamp int64
 }
 
 func NewInvocationEvent(opts NewInvocationEventOpts) Event {
@@ -222,14 +226,26 @@ func NewInvocationEvent(opts NewInvocationEventOpts) Event {
 	}
 	evt.Name = InvokeFnName
 
+	correlationID := ""
+	if opts.CorrelationID != nil {
+		correlationID = *opts.CorrelationID
+	}
+
+	spanID := ""
+	if opts.SpanID != nil {
+		spanID = *opts.SpanID
+	}
+
+	var spants int64
+	if opts.SpanTimestamp > 0 {
+		spants = opts.SpanTimestamp
+	}
+
 	evt.Data[consts.InngestEventDataPrefix] = InngestMetadata{
-		InvokeFnID: opts.FnID,
-		InvokeCorrelationId: func() string {
-			if opts.CorrelationID != nil {
-				return *opts.CorrelationID
-			}
-			return ""
-		}(),
+		InvokeFnID:          opts.FnID,
+		InvokeCorrelationId: correlationID,
+		InvokeSpanID:        spanID,
+		InvokeTimestamp:     spants,
 	}
 
 	return evt

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2261,10 +2261,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, gen state.
 	opcode := gen.Op.String()
 	now := time.Now()
 
-	psid := execSpan.SpanContext().SpanID().String()
 	sid := telemetry.NewSpanID(ctx)
-	sidstr := sid.String()
-
 	// NOTE: the context here still contains the execSpan's traceID & spanID,
 	// which is what we want because that's the parent that needs to be referenced later on
 	carrier := telemetry.NewTraceCarrier(
@@ -2313,7 +2310,6 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, gen state.
 	)
 	defer span.End()
 
-	traceStartedAt := state.Time(now)
 	err = e.sm.SavePause(ctx, state.Pause{
 		ID:                  pauseID,
 		WorkspaceID:         item.WorkspaceID,
@@ -2328,10 +2324,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, gen state.
 		Expression:          &strExpr,
 		DataKey:             gen.ID,
 		InvokeCorrelationID: &correlationID,
-		StepParentSpanID:    &psid,
-		StepSpanID:          &sidstr,
 		TriggeringEventID:   &evt.ID,
-		TraceStartedAt:      &traceStartedAt,
 		InvokeTargetFnID:    &opts.FunctionID,
 		Metadata: map[string]any{
 			consts.OtelPropagationKey: carrier,
@@ -2497,27 +2490,20 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, gen state.Ge
 		span.SetAttributes(attribute.String(consts.OtelSysStepWaitExpression, *opts.If))
 	}
 
-	psid := execSpan.SpanContext().SpanID().String()
-	sidstr := sid.String()
-	traceStartedAt := state.Time(now)
-
 	err = e.sm.SavePause(ctx, state.Pause{
-		ID:               pauseID,
-		WorkspaceID:      item.WorkspaceID,
-		Identifier:       item.Identifier,
-		GroupID:          item.GroupID,
-		Outgoing:         gen.ID,
-		Incoming:         edge.Edge.Incoming,
-		StepName:         gen.UserDefinedName(),
-		Opcode:           &opcode,
-		Expires:          state.Time(expires),
-		Event:            &opts.Event,
-		Expression:       expr,
-		ExpressionData:   data,
-		DataKey:          gen.ID,
-		StepParentSpanID: &psid,
-		StepSpanID:       &sidstr,
-		TraceStartedAt:   &traceStartedAt,
+		ID:             pauseID,
+		WorkspaceID:    item.WorkspaceID,
+		Identifier:     item.Identifier,
+		GroupID:        item.GroupID,
+		Outgoing:       gen.ID,
+		Incoming:       edge.Edge.Incoming,
+		StepName:       gen.UserDefinedName(),
+		Opcode:         &opcode,
+		Expires:        state.Time(expires),
+		Event:          &opts.Event,
+		Expression:     expr,
+		ExpressionData: data,
+		DataKey:        gen.ID,
 		Metadata: map[string]any{
 			consts.OtelPropagationKey: carrier,
 		},

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1741,7 +1741,7 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 				carrier := telemetry.NewTraceCarrier()
 				if err := carrier.Unmarshal(meta); err == nil {
 					ctx = telemetry.UserTracer().Propagator().Extract(ctx, propagation.MapCarrier(carrier.Context))
-					if carrier.IsNonZero() {
+					if carrier.CanResumePause() {
 						// Used for spans
 						triggeringEventID := ""
 						if pause.TriggeringEventID != nil {
@@ -1762,7 +1762,7 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 							telemetry.WithScope(consts.OtelScopeStep),
 							telemetry.WithName(consts.OtelSpanInvoke),
 							telemetry.WithTimestamp(carrier.Timestamp),
-							telemetry.WithSpanID(*carrier.SpanID),
+							telemetry.WithSpanID(carrier.SpanID()),
 							telemetry.WithSpanAttributes(
 								attribute.String(consts.OtelSysStepOpcode, enums.OpcodeInvokeFunction.String()),
 								attribute.String(consts.OtelSysStepInvokeTargetFnID, targetFnID),
@@ -1792,12 +1792,12 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 				carrier := telemetry.NewTraceCarrier()
 				if err := carrier.Unmarshal(meta); err == nil {
 					ctx = telemetry.UserTracer().Propagator().Extract(ctx, propagation.MapCarrier(carrier.Context))
-					if carrier.IsNonZero() {
+					if carrier.CanResumePause() {
 						_, span := telemetry.NewSpan(ctx,
 							telemetry.WithScope(consts.OtelScopeStep),
 							telemetry.WithName(consts.OtelSpanWaitForEvent),
 							telemetry.WithTimestamp(carrier.Timestamp),
-							telemetry.WithSpanID(*carrier.SpanID),
+							telemetry.WithSpanID(carrier.SpanID()),
 							telemetry.WithSpanAttributes(
 								attribute.String(consts.OtelSysStepOpcode, enums.OpcodeWaitForEvent.String()),
 								attribute.Int64(consts.OtelSysStepWaitExpires, pause.Expires.Time().UnixMilli()),

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -2,14 +2,12 @@ package state
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/oklog/ulid/v2"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // PauseMutater manages creating, leasing, and consuming pauses from a backend implementation.
@@ -188,12 +186,6 @@ type Pause struct {
 	// TriggeringEventID is the event that triggered the original run.  This allows us
 	// to exclude the original event ID when considering triggers.
 	TriggeringEventID *string `json:"tID,omitempty"`
-	// StepParentSpanID is the parent span ID for the step that caused this pause.
-	StepParentSpanID *string `json:"spsid,omitempty"`
-	// StepSpanID is the span ID for the step that caused this pause.
-	StepSpanID *string `json:"ssID,omitempty"`
-	// SpanStartedAt is the time at which the span for this pause was started.
-	TraceStartedAt *Time `json:"tsa"`
 	// Metadata is additional metadata that should be stored with the pause
 	Metadata map[string]any
 }
@@ -226,28 +218,6 @@ func (p Pause) Edge() inngest.Edge {
 
 func (p Pause) IsInvoke() bool {
 	return p.Opcode != nil && *p.Opcode == enums.OpcodeInvokeFunction.String()
-}
-
-func (p Pause) SpanIDs() (*trace.SpanID, *trace.SpanID, error) {
-	if p.StepParentSpanID == nil {
-		return nil, nil, fmt.Errorf("pause step's parent spanID is not available")
-	}
-
-	if p.StepSpanID == nil {
-		return nil, nil, fmt.Errorf("pause step's spanID is not available")
-	}
-
-	psid, err := trace.SpanIDFromHex(*p.StepParentSpanID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	sid, err := trace.SpanIDFromHex(*p.StepSpanID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &psid, &sid, nil
 }
 
 type ResumeData struct {

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -194,6 +194,8 @@ type Pause struct {
 	StepSpanID *string `json:"ssID,omitempty"`
 	// SpanStartedAt is the time at which the span for this pause was started.
 	TraceStartedAt *Time `json:"tsa"`
+	// Metadata is additional metadata that should be stored with the pause
+	Metadata map[string]any
 }
 
 func (p Pause) GetID() uuid.UUID {
@@ -220,6 +222,10 @@ func (p Pause) Edge() inngest.Edge {
 		Outgoing: p.Outgoing,
 		Incoming: p.Incoming,
 	}
+}
+
+func (p Pause) IsInvoke() bool {
+	return p.Opcode != nil && *p.Opcode == enums.OpcodeInvokeFunction.String()
 }
 
 func (p Pause) SpanIDs() (*trace.SpanID, *trace.SpanID, error) {

--- a/pkg/telemetry/propagation.go
+++ b/pkg/telemetry/propagation.go
@@ -2,25 +2,31 @@ package telemetry
 
 import (
 	"encoding/json"
-	"fmt"
-	"sync"
+	"time"
 
 	"go.opentelemetry.io/otel/trace"
 )
 
-const psidKey = "psid"
+type TraceCarrierOpt func(tc *TraceCarrier)
 
 // TraceCarrier stores the data that needs to be carried through systems.
 // e.g. pubsub, queues, etc
 type TraceCarrier struct {
-	sync.Mutex
-	Context map[string]string `json:"ctx,omitempty"`
+	Context   map[string]string `json:"ctx,omitempty"`
+	Timestamp time.Time         `json:"ts"`
+	SpanID    *trace.SpanID     `json:"sid,omitempty"`
 }
 
-func NewTraceCarrier() *TraceCarrier {
-	return &TraceCarrier{
+func NewTraceCarrier(opts ...TraceCarrierOpt) *TraceCarrier {
+	carrier := &TraceCarrier{
 		Context: map[string]string{},
 	}
+
+	for _, opt := range opts {
+		opt(carrier)
+	}
+
+	return carrier
 }
 
 func (tc *TraceCarrier) Unmarshal(data any) error {
@@ -28,27 +34,21 @@ func (tc *TraceCarrier) Unmarshal(data any) error {
 	if err != nil {
 		return err
 	}
-
 	return json.Unmarshal(byt, tc)
 }
 
-// Embed the parent spanID for propagation purposes
-func (tc *TraceCarrier) AddParentSpanID(psc trace.SpanContext) {
-	tc.Lock()
-	defer tc.Unlock()
+func (tc *TraceCarrier) IsNonZero() bool {
+	return tc.Context != nil && tc.Timestamp.UnixMilli() > 0 && tc.SpanID != nil
+}
 
-	if psc.IsValid() {
-		tc.Context[psidKey] = psc.SpanID().String()
+func WithTraceCarrierTimestamp(ts time.Time) TraceCarrierOpt {
+	return func(tc *TraceCarrier) {
+		tc.Timestamp = ts
 	}
 }
 
-// ParentSpanID returns the embedded spanID if it's available
-func (tc *TraceCarrier) ParentSpanID() (*trace.SpanID, error) {
-	val, ok := tc.Context[psidKey]
-	if !ok {
-		return nil, fmt.Errorf("spanID is not stored in carrier")
+func WithTraceCarrierSpanID(sid *trace.SpanID) TraceCarrierOpt {
+	return func(tc *TraceCarrier) {
+		tc.SpanID = sid
 	}
-
-	sid, err := trace.SpanIDFromHex(val)
-	return &sid, err
 }

--- a/pkg/telemetry/span.go
+++ b/pkg/telemetry/span.go
@@ -5,12 +5,10 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"math/rand"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/inngest/inngest/pkg/consts"
-	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/inngest/log"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -534,15 +532,6 @@ func (s *Span) SetAttributes(attrs ...attribute.KeyValue) {
 
 func (s *Span) TracerProvider() trace.TracerProvider {
 	return UserTracer().Provider()
-}
-
-// additional helper methods
-func (s *Span) SetEventIDs(evts ...event.TrackedEvent) {
-	ids := []string{}
-	for _, evt := range evts {
-		ids = append(ids, evt.GetInternalID().String())
-	}
-	s.SetAttributes(attribute.String(consts.OtelSysEventIDs, strings.Join(ids, ",")))
 }
 
 func newSpanIDGenerator() *spanIDGenerator {

--- a/pkg/telemetry/span.go
+++ b/pkg/telemetry/span.go
@@ -252,8 +252,7 @@ func NewSpan(ctx context.Context, opts ...SpanOpt) (context.Context, *Span) {
 		TraceID:    tid,
 		SpanID:     sid,
 		TraceState: psc.TraceState(),
-		TraceFlags: psc.TraceFlags(),
-		// TraceFlags: psc.TraceFlags() | trace.FlagsSampled, // NOTE: make it always sample for now, otherwise the batch span processor will ignore it
+		TraceFlags: psc.TraceFlags() | trace.FlagsSampled, // NOTE: make it always sample for now, otherwise the batch span processor will ignore it
 	}
 
 	s := &Span{


### PR DESCRIPTION
## Description

Annotate the `step.invoke` span with the target runID, so it can be used as reference when showing the trace.
This mainly helps with in-process runs where the invoke target might not have finished yet.

This PR also tweaks the wait virtual span to make sure it's reconstruction works as expected.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
