### PR TITLE
Add a guard in case the property is nil

### DIFF
--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -244,12 +244,14 @@ func (r *ResumeRequest) SetData(data any) {
 }
 
 func (r *ResumeRequest) withKey(key string) string {
-	if withData, ok := r.With.(map[string]any)[key]; ok {
-		byt, err := json.Marshal(withData)
-		if err == nil {
-			return string(byt)
+	if r.With != nil {
+		if withData, ok := r.With.(map[string]any)[key]; ok {
+			byt, err := json.Marshal(withData)
+			if err == nil {
+				return string(byt)
+			}
+			return ""
 		}
-		return ""
 	}
 
 	return ""


### PR DESCRIPTION
## Description

`ResumeRequest`'s `With` property could be `nil` if it's not initialized properly. This will cause panics, so adding a guard against it.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
