### PR TITLE
Add tweaks to Incident Banner

### DIFF
--- a/.github/workflows/components_test.yml
+++ b/.github/workflows/components_test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: "8.6.2"
+          version: "8.15.8"
       - uses: actions/setup-node@v4
         with:
           node-version: "18"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8.6.2
+          version: 8.15.8
       - name: Build UI
         run: make build-ui
       - name: Build dev serve

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8.6.2
+          version: 8.15.8
       - name: Set sha
         id: sha
         run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ui_test.yml
+++ b/.github/workflows/ui_test.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2.4.0
         with:
-          version: "8.6.2"
+          version: "8.15.8"
       - uses: actions/setup-node@v3
         with:
           node-version: "18"

--- a/package.json
+++ b/package.json
@@ -1,3 +1,3 @@
 {
-  "packageManager": "pnpm@8.6.2"
+  "packageManager": "pnpm@8.15.8"
 }

--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -2,7 +2,7 @@
   "name": "inngest-js-tests",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@8.6.2",
+  "packageManager": "pnpm@8.15.8",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -113,8 +113,8 @@
   },
   "engines": {
     "node": "18.x",
-    "pnpm": "8.6.2"
+    "pnpm": "8.15.8"
   },
-  "packageManager": "pnpm@8.6.2",
+  "packageManager": "pnpm@8.15.8",
   "private": true
 }

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/FilterEvents.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/FilterEvents.tsx
@@ -77,10 +77,10 @@ export default function FilterEvents({ keyID, filter }: FilterEventsProps) {
   return (
     <form className="pt-3" onSubmit={handleSubmit}>
       <h2 className="pb-1 text-lg font-semibold">Filter Events</h2>
-      <p className="text-sm text-slate-500">
+      <p className="text-sm text-slate-700">
         Filtering allows you to specify allow or deny lists for event names and/or IP addresses.
       </p>
-      <p className="text-sm text-slate-500">
+      <p className="text-sm text-slate-700">
         Allowlists only allow specified values, whereas denylists allow all but the specified
         values.
       </p>

--- a/ui/apps/dashboard/src/app/(organization-active)/IncidentBanner.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/IncidentBanner.tsx
@@ -10,15 +10,13 @@ export default function IncidentBanner() {
   const isIncidentBannerEnabled = useBooleanFlag('incident-banner');
   const status = useSystemStatus();
 
-  if (!isIncidentBannerEnabled.value && status.indicator === 'none') return;
+  if (!isIncidentBannerEnabled.value) return;
 
-  let message = '';
+  let message = 'We are experiencing some issues.';
   let severity: Severity = 'warning';
 
-  if (isIncidentBannerEnabled.value) {
-    message = ' We are experiencing some issues.';
-  } else {
-    message = `${status.description}`;
+  if (status.indicator !== 'none') {
+    message = `${status.description} -`;
     if (status.indicator === 'minor') {
       severity = 'info';
     }
@@ -28,7 +26,7 @@ export default function IncidentBanner() {
     <Banner kind={severity}>
       {message} Please check the{' '}
       <span style={{ display: 'inline-flex' }}>
-        <Link href="https://status.inngest.com/">status page.</Link>
+        <Link href="https://status.inngest.com/">status page</Link>
       </span>
     </Banner>
   );

--- a/ui/apps/dev-server-ui/package.json
+++ b/ui/apps/dev-server-ui/package.json
@@ -83,8 +83,8 @@
   },
   "engines": {
     "node": "18.x",
-    "pnpm": "8.6.2"
+    "pnpm": "8.15.8"
   },
-  "packageManager": "pnpm@8.6.2",
+  "packageManager": "pnpm@8.15.8",
   "private": true
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,7 @@
   },
   "engines": {
     "node": "18.x",
-    "pnpm": "8.6.2"
+    "pnpm": "8.15.8"
   },
   "packageManager": "pnpm@8.6.2",
   "private": true

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,6 +15,6 @@
     "node": "18.x",
     "pnpm": "8.15.8"
   },
-  "packageManager": "pnpm@8.6.2",
+  "packageManager": "pnpm@8.15.8",
   "private": true
 }

--- a/ui/packages/components/src/AppRoot/globals.css
+++ b/ui/packages/components/src/AppRoot/globals.css
@@ -29,3 +29,7 @@
 :focus-visible {
   outline-color: white;
 }
+
+.monaco-editor .overflow-guard {
+  @apply rounded-b-lg;
+}


### PR DESCRIPTION
## Description
- Incident banner displayed only on feature flag enabled - if there is an open incident in the status page, it grabs the message and severity from it.
- Add missing css to the shared global.css file. That css was only added to the app file in https://github.com/inngest/inngest/pull/1357
- Upgrade the pnpm version to 8.15.8 so it doesn't break our CI

## Motivation
We want to have full control over when the banner goes live and is hidden

## Type of change (choose one)
- [X] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
