### PR TITLE
Add additional data to support wait and invoke visualization

### DIFF
--- a/pkg/consts/otel.go
+++ b/pkg/consts/otel.go
@@ -22,6 +22,7 @@ const (
 	OtelSysEventIDs        = "sys.event.ids"
 
 	OtelSysBatchID      = "sys.batch.id"
+	OtelSysBatchTS      = "sys.batch.timestamp"
 	OtelSysBatchFull    = "sys.batch.full"
 	OtelSysBatchTimeout = "sys.batch.timeout"
 

--- a/pkg/devserver/lifecycle.go
+++ b/pkg/devserver/lifecycle.go
@@ -29,7 +29,7 @@ func (l lifecycle) OnFunctionScheduled(
 		RunStartedAt:  ulid.Time(md.ID.RunID.Time()),
 		FunctionID:    md.ID.FunctionID,
 		EventID:       md.Config.EventIDs[0],
-		Cron:          md.Config.CronSchedule,
+		Cron:          md.Config.CronSchedule(),
 		OriginalRunID: md.Config.OriginalRunID,
 	})
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -422,6 +422,9 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	)
 	defer span.End()
 
+	if schedule != nil {
+		span.SetAttributes(attribute.String(consts.OtelSysCronExpr, *schedule))
+	}
 	if req.BatchID != nil {
 		span.SetAttributes(attribute.String(consts.OtelSysBatchID, req.BatchID.String()))
 	}
@@ -830,6 +833,9 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			attribute.String(consts.OtelSysIdempotencyKey, id.IdempotencyKey()),
 		),
 	)
+	if md.Config.CronSchedule != nil {
+		fnSpan.SetAttributes(attribute.String(consts.OtelSysCronExpr, *md.Config.CronSchedule))
+	}
 	if id.BatchID != nil {
 		fnSpan.SetAttributes(attribute.String(consts.OtelSysBatchID, id.BatchID.String()))
 	}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1898,6 +1898,13 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 						if pause.Expression != nil {
 							span.SetAttributes(attribute.String(consts.OtelSysStepWaitExpression, *pause.Expression))
 						}
+						if r.With != nil {
+							if byt, err := json.Marshal(r.With); err == nil {
+								span.AddEvent(string(byt), trace.WithAttributes(
+									attribute.Bool(consts.OtelSysStepOutput, true),
+								))
+							}
+						}
 						if r.HasError() {
 							span.SetStatus(codes.Error, r.Error())
 						}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -836,8 +836,8 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 	if md.Config.CronSchedule != nil {
 		fnSpan.SetAttributes(attribute.String(consts.OtelSysCronExpr, *md.Config.CronSchedule))
 	}
-	if id.BatchID != nil {
-		fnSpan.SetAttributes(attribute.String(consts.OtelSysBatchID, id.BatchID.String()))
+	if md.Config.BatchID != nil {
+		fnSpan.SetAttributes(attribute.String(consts.OtelSysBatchID, md.Config.BatchID.String()))
 	}
 
 	for _, evt := range events {
@@ -989,10 +989,13 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 		} else if resp.IsTraceVisibleFunctionExecution() {
 			spanName := "function success"
 			fnstatus := attribute.Int64(consts.OtelSysFunctionStatusCode, enums.RunStatusCompleted.ToCode())
+			fnSpan.SetStatus(codes.Ok, "success")
+			span.SetStatus(codes.Ok, "success")
 
 			if resp.StatusCode != 200 {
 				spanName = "function error"
 				fnstatus = attribute.Int64(consts.OtelSysFunctionStatusCode, enums.RunStatusFailed.ToCode())
+				fnSpan.SetStatus(codes.Error, resp.Error())
 				span.SetStatus(codes.Error, resp.Error())
 			}
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -426,7 +426,10 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		span.SetAttributes(attribute.String(consts.OtelSysCronExpr, *schedule))
 	}
 	if req.BatchID != nil {
-		span.SetAttributes(attribute.String(consts.OtelSysBatchID, req.BatchID.String()))
+		span.SetAttributes(
+			attribute.String(consts.OtelSysBatchID, req.BatchID.String()),
+			attribute.Int64(consts.OtelSysBatchTS, int64(req.BatchID.Time())),
+		)
 	}
 	if req.PreventDebounce {
 		span.SetAttributes(attribute.Bool(consts.OtelSysDebounceTimeout, true))
@@ -837,7 +840,10 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 		fnSpan.SetAttributes(attribute.String(consts.OtelSysCronExpr, *md.Config.CronSchedule))
 	}
 	if md.Config.BatchID != nil {
-		fnSpan.SetAttributes(attribute.String(consts.OtelSysBatchID, md.Config.BatchID.String()))
+		fnSpan.SetAttributes(
+			attribute.String(consts.OtelSysBatchID, md.Config.BatchID.String()),
+			attribute.Int64(consts.OtelSysBatchTS, int64(md.Config.BatchID.Time())),
+		)
 	}
 
 	for _, evt := range events {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1860,6 +1860,13 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 						)
 						defer span.End()
 						span.SetAttributes(commonAttrs...)
+						if r.With != nil {
+							if byt, err := json.Marshal(r.With); err == nil {
+								span.AddEvent(string(byt), trace.WithAttributes(
+									attribute.Bool(consts.OtelSysStepOutput, true),
+								))
+							}
+						}
 						if r.HasError() {
 							span.SetStatus(codes.Error, r.Error())
 						}

--- a/pkg/execution/history/lifecycle.go
+++ b/pkg/execution/history/lifecycle.go
@@ -69,7 +69,7 @@ func (l lifecycle) OnFunctionScheduled(
 	}
 
 	h := History{
-		Cron:            md.Config.CronSchedule,
+		Cron:            md.Config.CronSchedule(),
 		ID:              ulid.MustNew(ulid.Now(), rand.Reader),
 		AccountID:       md.ID.Tenant.AccountID,
 		WorkspaceID:     md.ID.Tenant.EnvID,
@@ -115,7 +115,7 @@ func (l lifecycle) OnFunctionStarted(
 
 	h := History{
 		ID:              ulid.MustNew(ulid.Now(), rand.Reader),
-		Cron:            md.Config.CronSchedule,
+		Cron:            md.Config.CronSchedule(),
 		AccountID:       md.ID.Tenant.AccountID,
 		WorkspaceID:     md.ID.Tenant.EnvID,
 		CreatedAt:       time.Now(),
@@ -170,7 +170,7 @@ func (l lifecycle) OnFunctionFinished(
 	completedStepCount := int64(md.Metrics.StepCount)
 
 	h := History{
-		Cron:               md.Config.CronSchedule,
+		Cron:               md.Config.CronSchedule(),
 		ID:                 ulid.MustNew(ulid.Now(), rand.Reader),
 		AccountID:          md.ID.Tenant.AccountID,
 		WorkspaceID:        md.ID.Tenant.EnvID,
@@ -261,7 +261,7 @@ func (l lifecycle) OnFunctionCancelled(
 	groupID := uuid.New()
 
 	h := History{
-		Cron:               md.Config.CronSchedule,
+		Cron:               md.Config.CronSchedule(),
 		ID:                 ulid.MustNew(ulid.Now(), rand.Reader),
 		AccountID:          md.ID.Tenant.AccountID,
 		WorkspaceID:        md.ID.Tenant.EnvID,


### PR DESCRIPTION
## Description

Embed the event data into pauses so they can be referenced when needed for spans.

Also update some data reference due to changes from #1325

CronSchedule is removed from the data structure since it's not referenced anywhere, and is embedded into `Context` map instead.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
