### PR TITLE
Stop stringifying primitives when parsing function resolution results

### DIFF
--- a/pkg/execution/driver/httpdriver/parse.go
+++ b/pkg/execution/driver/httpdriver/parse.go
@@ -150,15 +150,6 @@ func parseResponse(byt []byte) any {
 		}
 	}
 
-	// This isn't a map, so check the first character for json encoding.  If this isn't
-	// a string or array, then the body must be treated as text.
-	//
-	// This is a stop-gap safety check to see if SDKs respond with text that's not JSON,
-	// in the case of an internal issue or a host processing error we can't control.
-	if byt[0] != '[' && byt[0] != '"' {
-		return string(byt)
-	}
-
 	// This may have been a string-encoded object, because encoding generally
 	// sucks.  Sometimes this has happened (by who?  how?).
 	//


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

Invokes which return JSON primitives that are not objects, arrays, or strings inadvertedly stringify the output. This results in numbers, booleans, and `null` (which also covers `undefined`) always being represented as a string. For example:

- `null` becomes `"null"`
- `123` becomes `"123"`
- `true` becomes `"true"`

This can easily lead to runtime errors and in some cases be very confusing to debug. For example, if an invoke returns a `boolean`, this check will never work:

```ts
if (!invokeResult) {
  // ...
}
```

This PR removes the stringification of values and continues to treat every response as JSON. Non-JSON (non-compliant) responses will now, however, travel through our system and back to an SDK, where they will likely be unparseable and throw a runtime error, failing the function.

> [!NOTE]
> This only affects `step.invoke()` results as they rely on the output of the function, which is returned in a non-wrapped, raw state. All step returns are correctly handled as they are always an object which is handled by the current parsing.

Checking for JSON primitives within Go seems pretty rocky, and probably involves just running a regex on the stringified bytes to check if we have a string, number, boolean, or `null`.

We also need to check whether this affects older SDK versions; this parsing has no versioning across V0 and V1 [Execution Methods](https://www.notion.so/inngest/Execution-Methods-d5f419f874d249dfa750497a61389fd2), though invoke should only be present in V1+, so this _should_ be fine.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
