### PR TITLE
Fix wrong groupID for sleep

### DIFF
--- a/pkg/consts/otel.go
+++ b/pkg/consts/otel.go
@@ -9,6 +9,8 @@ const (
 	OtelSpanInvoke       = "invoke"
 	OtelSpanWaitForEvent = "wait"
 	OtelSpanSleep        = "sleep"
+	OtelSpanExecute      = "execute"
+	OtelSpanRerun        = "rerun"
 
 	// system attributes
 	OtelSysAccountID      = "sys.account.id"
@@ -90,6 +92,7 @@ const (
 	OtelScopeDebounce  = "debounce.inngest"
 	OtelScopeTrigger   = "trigger.inngest"
 	OtelScopeCron      = "cron.inngest"
+	OtelScopeRerun     = "rerun.inngest"
 	OtelScopeEnv       = "env.inngest"
 	OtelScopeApp       = "app.env.inngest"
 	OtelScopeFunction  = "function.app.env.inngest"


### PR DESCRIPTION
## Description

Make sure grouping is correct.
This fixes the correlation and data representation for sleep spans.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
