### PR TITLE
Remove graceful handling from batch keys

### DIFF
--- a/pkg/execution/batch/batch.go
+++ b/pkg/execution/batch/batch.go
@@ -32,9 +32,7 @@ import (
 type BatchManager interface {
 	Append(ctx context.Context, bi BatchItem, fn inngest.Function) (*BatchAppendResult, error)
 	RetrieveItems(ctx context.Context, batchID ulid.ULID) ([]BatchItem, error)
-	StartExecutionWithBatchPointer(ctx context.Context, batchID ulid.ULID, batchPointer string) (string, error)
-	// deprecated, use StartExecutionWithBatchPointer
-	StartExecution(ctx context.Context, fnID uuid.UUID, batchID ulid.ULID) (string, error)
+	StartExecution(ctx context.Context, batchID ulid.ULID, batchPointer string) (string, error)
 	ScheduleExecution(ctx context.Context, opts ScheduleBatchOpts) error
 	ExpireKeys(ctx context.Context, batchID ulid.ULID) error
 }

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -163,44 +163,10 @@ func (b redisBatchManager) RetrieveItems(ctx context.Context, batchID ulid.ULID)
 
 // StartExecution sets the status to `started`
 // If it has already started, don't do anything
-func (b redisBatchManager) StartExecutionWithBatchPointer(ctx context.Context, batchID ulid.ULID, batchPointer string) (string, error) {
+func (b redisBatchManager) StartExecution(ctx context.Context, batchID ulid.ULID, batchPointer string) (string, error) {
 	keys := []string{
 		b.k.BatchMetadata(ctx, batchID),
 		batchPointer,
-	}
-	args := []string{
-		enums.BatchStatusStarted.String(),
-		ulid.Make().String(),
-	}
-
-	status, err := scripts["start"].Exec(
-		ctx,
-		b.r,
-		keys,
-		args,
-	).AsInt64()
-	if err != nil {
-		return "", fmt.Errorf("failed to start batch execution: %w", err)
-	}
-
-	switch status {
-	case 0: // haven't started, so mark mark it started
-		return enums.BatchStatusReady.String(), nil
-
-	case 1: // Already started
-		return enums.BatchStatusStarted.String(), nil
-
-	default:
-		return "", fmt.Errorf("invalid status for start batch ops: %d", status)
-	}
-}
-
-// StartExecution sets the status to `started`
-// If it has already started, don't do anything
-func (b redisBatchManager) StartExecution(ctx context.Context, fnID uuid.UUID, batchID ulid.ULID) (string, error) {
-	keys := []string{
-		b.k.BatchMetadata(ctx, batchID),
-		b.k.BatchPointer(ctx, fnID),
 	}
 	args := []string{
 		enums.BatchStatusStarted.String(),

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -286,17 +286,7 @@ func (s *svc) handleScheduledBatch(ctx context.Context, item queue.Item) error {
 
 	batchID := opts.BatchID
 
-	var status string
-	var err error
-	if opts.BatchPointer != "" {
-		// if we encounter a new producer, use new method
-		status, err = s.batcher.StartExecutionWithBatchPointer(ctx, batchID, opts.BatchPointer)
-	} else {
-		// otherwise, fall back to previous behavior
-		// TODO Remove when all messages include batch pointer
-		status, err = s.batcher.StartExecution(ctx, opts.FunctionID, batchID)
-	}
-
+	status, err := s.batcher.StartExecution(ctx, batchID, opts.BatchPointer)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
All enqueued batches now include the batch pointer. We can remove the special handling for old messages.

## Description

Now that the batch keys backend is deployed to production, all new batches include the batch pointer key. This means we can remove the graceful handling logic.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
