### PR TITLE
Use getter for event ID, and ignore dupe responses for sleeps

### DIFF
--- a/pkg/devserver/lifecycle.go
+++ b/pkg/devserver/lifecycle.go
@@ -28,7 +28,7 @@ func (l lifecycle) OnFunctionScheduled(
 		RunID:         md.ID.RunID,
 		RunStartedAt:  ulid.Time(md.ID.RunID.Time()),
 		FunctionID:    md.ID.FunctionID,
-		EventID:       md.Config.FirstEventID(),
+		EventID:       md.Config.EventID(),
 		Cron:          md.Config.CronSchedule(),
 		OriginalRunID: md.Config.OriginalRunID,
 	})

--- a/pkg/execution/history/lifecycle.go
+++ b/pkg/execution/history/lifecycle.go
@@ -81,7 +81,7 @@ func (l lifecycle) OnFunctionScheduled(
 		Type:            enums.HistoryTypeFunctionScheduled.String(),
 		Attempt:         int64(item.Attempt),
 		IdempotencyKey:  md.IdempotencyKey(),
-		EventID:         md.Config.FirstEventID(),
+		EventID:         md.Config.EventID(),
 		BatchID:         md.Config.BatchID,
 	}
 	for _, d := range l.drivers {
@@ -126,7 +126,7 @@ func (l lifecycle) OnFunctionStarted(
 		Type:            enums.HistoryTypeFunctionStarted.String(),
 		Attempt:         int64(item.Attempt),
 		IdempotencyKey:  md.IdempotencyKey(),
-		EventID:         md.Config.FirstEventID(),
+		EventID:         md.Config.EventID(),
 		LatencyMS:       &latencyMS,
 		BatchID:         md.Config.BatchID,
 	}
@@ -147,7 +147,7 @@ func (l lifecycle) OnFunctionSkipped(
 		AccountID:   md.ID.Tenant.AccountID,
 		BatchID:     md.Config.BatchID,
 		Cron:        s.CronSchedule,
-		EventID:     md.Config.FirstEventID(),
+		EventID:     md.Config.EventID(),
 		RunID:       md.ID.RunID,
 		CreatedAt:   time.Now(),
 		SkipReason:  &s.Reason,
@@ -200,7 +200,7 @@ func (l lifecycle) OnFunctionFinished(
 		Type:               enums.HistoryTypeFunctionCompleted.String(),
 		Attempt:            int64(item.Attempt),
 		IdempotencyKey:     md.IdempotencyKey(),
-		EventID:            md.Config.FirstEventID(),
+		EventID:            md.Config.EventID(),
 		BatchID:            md.Config.BatchID,
 	}
 
@@ -290,7 +290,7 @@ func (l lifecycle) OnFunctionCancelled(
 		RunID:              md.ID.RunID,
 		Type:               enums.HistoryTypeFunctionCancelled.String(),
 		IdempotencyKey:     md.IdempotencyKey(),
-		EventID:            md.Config.FirstEventID(),
+		EventID:            md.Config.EventID(),
 		Cancel:             &req,
 		BatchID:            md.Config.BatchID,
 	}
@@ -336,7 +336,7 @@ func (l lifecycle) OnStepScheduled(
 		Type:            enums.HistoryTypeStepScheduled.String(),
 		Attempt:         int64(item.Attempt),
 		IdempotencyKey:  md.IdempotencyKey(),
-		EventID:         md.Config.FirstEventID(),
+		EventID:         md.Config.EventID(),
 		StepName:        stepName,
 		StepID:          &edge.Edge.Incoming, // TODO: Add step name to edge.
 		BatchID:         md.Config.BatchID,
@@ -380,7 +380,7 @@ func (l lifecycle) OnStepStarted(
 		Type:            enums.HistoryTypeStepStarted.String(),
 		Attempt:         int64(item.Attempt),
 		IdempotencyKey:  md.IdempotencyKey(),
-		EventID:         md.Config.FirstEventID(),
+		EventID:         md.Config.EventID(),
 		StepName:        &edge.Incoming,
 		StepID:          &edge.Incoming, // TODO: Add step name to edge.
 		URL:             &url,
@@ -424,7 +424,7 @@ func (l lifecycle) OnStepFinished(
 		Type:            enums.HistoryTypeStepCompleted.String(),
 		Attempt:         int64(item.Attempt),
 		IdempotencyKey:  md.IdempotencyKey(),
-		EventID:         md.Config.FirstEventID(),
+		EventID:         md.Config.EventID(),
 		StepName:        &resp.Step.Name,
 		StepID:          &edge.Incoming,
 		URL:             &step.URI,
@@ -514,7 +514,7 @@ func (l lifecycle) OnWaitForEvent(
 		Type:            enums.HistoryTypeStepWaiting.String(),
 		Attempt:         int64(item.Attempt),
 		IdempotencyKey:  md.IdempotencyKey(),
-		EventID:         md.Config.FirstEventID(),
+		EventID:         md.Config.EventID(),
 		StepName:        &stepName,
 		StepID:          &op.ID,
 		WaitForEvent: &WaitForEvent{
@@ -569,7 +569,7 @@ func (l lifecycle) OnWaitForEventResumed(
 		RunID:           md.ID.RunID,
 		Type:            enums.HistoryTypeStepCompleted.String(),
 		IdempotencyKey:  md.IdempotencyKey(),
-		EventID:         md.Config.FirstEventID(),
+		EventID:         md.Config.EventID(),
 		WaitResult: &WaitResult{
 			EventID: req.EventID,
 			Timeout: req.EventID == nil,
@@ -641,7 +641,7 @@ func (l lifecycle) OnInvokeFunction(
 		AccountID:       md.ID.Tenant.AccountID,
 		Attempt:         int64(item.Attempt),
 		CreatedAt:       time.Now(),
-		EventID:         md.Config.FirstEventID(),
+		EventID:         md.Config.EventID(),
 		FunctionID:      md.ID.FunctionID,
 		FunctionVersion: int64(md.Config.FunctionVersion),
 		GroupID:         groupID,
@@ -694,7 +694,7 @@ func (l lifecycle) OnInvokeFunctionResumed(
 		AccountID:       md.ID.Tenant.AccountID,
 		WorkspaceID:     md.ID.Tenant.EnvID,
 		CreatedAt:       time.Now(),
-		EventID:         md.Config.FirstEventID(),
+		EventID:         md.Config.EventID(),
 		FunctionID:      md.ID.FunctionID,
 		FunctionVersion: int64(md.Config.FunctionVersion),
 		GroupID:         groupIDUUID,
@@ -761,7 +761,7 @@ func (l lifecycle) OnSleep(
 		Type:            enums.HistoryTypeStepSleeping.String(),
 		Attempt:         int64(item.Attempt),
 		IdempotencyKey:  md.IdempotencyKey(),
-		EventID:         md.Config.FirstEventID(),
+		EventID:         md.Config.EventID(),
 		StepName:        &stepName,
 		StepID:          &op.ID,
 		Sleep: &Sleep{

--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -47,7 +47,7 @@ func (v v2) Create(ctx context.Context, s state.CreateState) error {
 			RunID:                 s.Metadata.ID.RunID,
 			WorkflowID:            s.Metadata.ID.FunctionID,
 			WorkflowVersion:       s.Metadata.Config.FunctionVersion,
-			EventID:               s.Metadata.Config.FirstEventID(),
+			EventID:               s.Metadata.Config.EventID(),
 			EventIDs:              s.Metadata.Config.EventIDs,
 			Key:                   s.Metadata.Config.Idempotency,
 			AccountID:             s.Metadata.ID.Tenant.AccountID,

--- a/pkg/execution/state/v2/state_metadata.go
+++ b/pkg/execution/state/v2/state_metadata.go
@@ -113,6 +113,13 @@ type Config struct {
 	Context map[string]any
 }
 
+func (c *Config) EventID() ulid.ULID {
+	if len(c.EventIDs) > 0 {
+		return c.EventIDs[0]
+	}
+	return ulid.ULID{}
+}
+
 func (c *Config) GetSpanID() (*trace.SpanID, error) {
 	if c.SpanID != "" {
 		sid, err := trace.SpanIDFromHex(c.SpanID)
@@ -141,15 +148,6 @@ func (c *Config) CronSchedule() *string {
 	}
 
 	return nil
-}
-
-// FirstEventID returns the first event ID in the list of event IDs.
-// If there are no event IDs, it returns an empty ULID.
-func (c *Config) FirstEventID() ulid.ULID {
-	if len(c.EventIDs) > 0 {
-		return c.EventIDs[0]
-	}
-	return ulid.ULID{}
 }
 
 // RunMetrics stores state-level run metrics.


### PR DESCRIPTION
Improve how we fetch events from config.

- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
