### PR TITLE
Fix hanging run when invoking a rate-limited function

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -226,7 +226,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			},
 		),
 		executor.WithStepLimits(func(id sv2.ID) int { return consts.DefaultMaxStepLimit }),
-		executor.WithInvokeNotFoundHandler(getInvokeNotFoundHandler(ctx, pb, opts.Config.EventStream.Service.Concrete.TopicName())),
+		executor.WithInvokeFailHandler(getInvokeFailHandler(ctx, pb, opts.Config.EventStream.Service.Concrete.TopicName())),
 		executor.WithSendingEventHandler(getSendingEventHandler(ctx, pb, opts.Config.EventStream.Service.Concrete.TopicName())),
 		executor.WithDebouncer(debouncer),
 		executor.WithBatcher(batcher),
@@ -328,8 +328,8 @@ func getSendingEventHandler(ctx context.Context, pb pubsub.Publisher, topic stri
 	}
 }
 
-func getInvokeNotFoundHandler(ctx context.Context, pb pubsub.Publisher, topic string) execution.InvokeNotFoundHandler {
-	return func(ctx context.Context, opts execution.InvokeNotFoundHandlerOpts, evts []event.Event) error {
+func getInvokeFailHandler(ctx context.Context, pb pubsub.Publisher, topic string) execution.InvokeFailHandler {
+	return func(ctx context.Context, opts execution.InvokeFailHandlerOpts, evts []event.Event) error {
 		eg := errgroup.Group{}
 
 		for _, e := range evts {

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -133,6 +133,10 @@ func (e Event) IsFinishedEvent() bool {
 	return e.Name == FnFinishedName
 }
 
+func (e Event) IsInvokeEvent() bool {
+	return e.Name == InvokeFnName
+}
+
 // InngestMetadata represents metadata for an event that is used to invoke a
 // function. Note that this metadata is not present on all functions. For
 // accessing an event's correlation ID, prefer using `Event.CorrelationID()`.

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -105,8 +105,8 @@ type Executor interface {
 	// run completion
 	SetFinalizer(f FinalizePublisher)
 
-	// InvokeNotFoundHandler invokes the invoke not found handler.
-	InvokeNotFoundHandler(context.Context, InvokeNotFoundHandlerOpts) error
+	// InvokeFailHandler invokes the invoke fail handler.
+	InvokeFailHandler(context.Context, InvokeFailHandlerOpts) error
 
 	AppendAndScheduleBatchWithOpts(ctx context.Context, fn inngest.Function, bi batch.BatchItem, opts *BatchExecOpts) error
 	// deprecated; use AppendAndScheduleBatchWithOpts in new code
@@ -118,7 +118,7 @@ type Executor interface {
 }
 
 // PublishFinishedEventOpts represents the options for publishing a finished event.
-type InvokeNotFoundHandlerOpts struct {
+type InvokeFailHandlerOpts struct {
 	OriginalEvent event.TrackedEvent
 	FunctionID    string
 	RunID         string
@@ -136,9 +136,10 @@ type BatchExecOpts struct {
 // It should be used to send the given events.
 type FinalizePublisher func(context.Context, sv2.ID, []event.Event) error
 
-// InvokeNotFoundHandler is a function that handles invocations failing due to
-// the function not being found. It is passed a list of events to send.
-type InvokeNotFoundHandler func(context.Context, InvokeNotFoundHandlerOpts, []event.Event) error
+// InvokeFailHandler is a function that handles invocations failing due to the
+// function failing to run (not found, rate-limited). It is passed a list of
+// events to send.
+type InvokeFailHandler func(context.Context, InvokeFailHandlerOpts, []event.Event) error
 
 // HandleSendingEvent handles sending an event given an event and the queue
 // item.

--- a/pkg/execution/executor/util.go
+++ b/pkg/execution/executor/util.go
@@ -67,7 +67,7 @@ func (g OpcodeGroups) All() []OpcodeGroup {
 	return []OpcodeGroup{g.PriorityGroup, g.OtherGroup}
 }
 
-func CreateInvokeNotFoundEvent(ctx context.Context, opts execution.InvokeNotFoundHandlerOpts) event.Event {
+func CreateInvokeFailedEvent(ctx context.Context, opts execution.InvokeFailHandlerOpts) event.Event {
 	now := time.Now()
 	data := map[string]interface{}{
 		"function_id": opts.FunctionID,

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -640,7 +640,7 @@ func (s *svc) initialize(ctx context.Context, fn inngest.Function, evt event.Tra
 			return err
 		}
 		if limited {
-			if evt.GetEvent().Name == event.InvokeFnName {
+			if evt.GetEvent().IsInvokeEvent() {
 				// This function was invoked by another function, so we need to
 				// ensure that the invoker fails. If we don't do this, it'll
 				// hang forever

--- a/tests/client/function_run.go
+++ b/tests/client/function_run.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
@@ -137,4 +138,72 @@ func (c *Client) FunctionRuns(ctx context.Context, opts FunctionRunOpt) ([]FnRun
 	}
 
 	return data.Runs.Edges, data.Runs.PageInfo
+}
+
+type run struct {
+	Status string `json:"status"`
+}
+
+func (c *Client) Run(ctx context.Context, runID string) run {
+	c.Helper()
+
+	query := `
+		query GetRun($runID: ID!) {
+			functionRun(query: { functionRunId: $runID }) {
+				status
+			}
+		}`
+
+	resp := c.MustDoGQL(ctx, graphql.RawParams{
+		Query: query,
+		Variables: map[string]any{
+			"runID": runID,
+		},
+	})
+	if len(resp.Errors) > 0 {
+		c.Fatalf("err with gql: %#v", resp.Errors)
+	}
+
+	type response struct {
+		FunctionRun run `json:"functionRun"`
+	}
+
+	data := &response{}
+	if err := json.Unmarshal(resp.Data, data); err != nil {
+		c.Fatalf(err.Error())
+	}
+
+	return data.FunctionRun
+}
+
+func (c *Client) WaitForRunStatus(
+	ctx context.Context,
+	t *testing.T,
+	expectedStatus string,
+	runID *string,
+) {
+	t.Helper()
+
+	start := time.Now()
+	status := ""
+	for {
+		if runID != nil && *runID != "" {
+			status = c.Run(ctx, *runID).Status
+			if status == expectedStatus {
+				break
+			}
+		}
+
+		if time.Since(start) > 5*time.Second {
+			var msg string
+			if runID == nil || *runID == "" {
+				msg = "Run ID is empty"
+			} else {
+				msg = fmt.Sprintf("Expected status %s, got %s", expectedStatus, status)
+			}
+			t.Fatalf(msg)
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
 }

--- a/tests/golang/invoke_test.go
+++ b/tests/golang/invoke_test.go
@@ -11,10 +11,12 @@ import (
 	"github.com/inngest/inngestgo"
 	"github.com/inngest/inngestgo/step"
 	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInvokeRateLimit(t *testing.T) {
 	ctx := context.Background()
+	r := require.New(t)
 	c := client.New(t)
 
 	appID := "InvokeRateLimit-" + ulid.MustNew(ulid.Now(), nil).String()
@@ -62,7 +64,8 @@ func TestInvokeRateLimit(t *testing.T) {
 	registerFuncs()
 
 	// Trigger the main function and successfully invoke the other function
-	inngestgo.Send(ctx, &event.Event{Name: evtName})
+	_, err := inngestgo.Send(ctx, &event.Event{Name: evtName})
+	r.NoError(err)
 	c.WaitForRunStatus(ctx, t, "COMPLETED", &runID)
 
 	spew.Dump(c.Run(ctx, runID))
@@ -70,6 +73,7 @@ func TestInvokeRateLimit(t *testing.T) {
 	// Trigger the main function. It'll fail because the invoked function is
 	// rate limited
 	runID = ""
-	inngestgo.Send(ctx, &event.Event{Name: evtName})
+	_, err = inngestgo.Send(ctx, &event.Event{Name: evtName})
+	r.NoError(err)
 	c.WaitForRunStatus(ctx, t, "FAILED", &runID)
 }

--- a/tests/golang/invoke_test.go
+++ b/tests/golang/invoke_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/tests/client"
 	"github.com/inngest/inngestgo"
@@ -64,7 +63,7 @@ func TestInvokeRateLimit(t *testing.T) {
 
 	// Trigger the main function and successfully invoke the other function
 	inngestgo.Send(ctx, &event.Event{Name: evtName})
-	c.WaitForRunStatus(ctx, t, enums.RunStatusCompleted.String(), &runID)
+	c.WaitForRunStatus(ctx, t, "COMPLETED", &runID)
 
 	spew.Dump(c.Run(ctx, runID))
 

--- a/tests/golang/invoke_test.go
+++ b/tests/golang/invoke_test.go
@@ -1,0 +1,76 @@
+package golang
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/tests/client"
+	"github.com/inngest/inngestgo"
+	"github.com/inngest/inngestgo/step"
+	"github.com/oklog/ulid/v2"
+)
+
+func TestInvokeRateLimit(t *testing.T) {
+	ctx := context.Background()
+	c := client.New(t)
+
+	appID := "InvokeRateLimit-" + ulid.MustNew(ulid.Now(), nil).String()
+	h, server, registerFuncs := NewSDKHandler(t, appID)
+	defer server.Close()
+
+	// This function will be invoked by the main function
+	invokedFnName := "invoked-fn"
+	invokedFn := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{
+			Name: invokedFnName,
+			RateLimit: &inngestgo.RateLimit{
+				Limit:  1,
+				Period: 1 * time.Minute,
+			},
+			Retries: inngestgo.IntPtr(0),
+		},
+		inngestgo.EventTrigger("none", nil),
+		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
+			return nil, nil
+		},
+	)
+
+	// This function will invoke the other function
+	runID := ""
+	evtName := "my-event"
+	mainFn := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{
+			Name: "main-fn",
+		},
+		inngestgo.EventTrigger(evtName, nil),
+		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
+			runID = input.InputCtx.RunID
+
+			_, _ = step.Invoke[any](
+				ctx,
+				"invoke",
+				step.InvokeOpts{FunctionId: appID + "-" + invokedFnName})
+
+			return nil, nil
+		},
+	)
+
+	h.Register(invokedFn, mainFn)
+	registerFuncs()
+
+	// Trigger the main function and successfully invoke the other function
+	inngestgo.Send(ctx, &event.Event{Name: evtName})
+	c.WaitForRunStatus(ctx, t, enums.RunStatusCompleted.String(), &runID)
+
+	spew.Dump(c.Run(ctx, runID))
+
+	// Trigger the main function. It'll fail because the invoked function is
+	// rate limited
+	runID = ""
+	inngestgo.Send(ctx, &event.Event{Name: evtName})
+	c.WaitForRunStatus(ctx, t, "FAILED", &runID)
+}


### PR DESCRIPTION
## Description
Fix `step.invoke` hanging when the invoked function is rate-limited. This caused runs to get permanently stuck as "running". Since `InvokeNotFoundHandler` is now used for both the "not found" and "rate limited" invoke scenarios, this PR renames it to `InvokeFailHandler`

I think we'll need to implement a similar fix in Cloud

## Issue
https://linear.app/inngest/issue/INN-3093

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
