### PR TITLE
Add test for hanging run on invalid wait expression

### DIFF
--- a/tests/golang/invoke_test.go
+++ b/tests/golang/invoke_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/tests/client"
 	"github.com/inngest/inngestgo"
@@ -67,8 +66,6 @@ func TestInvokeRateLimit(t *testing.T) {
 	_, err := inngestgo.Send(ctx, &event.Event{Name: evtName})
 	r.NoError(err)
 	c.WaitForRunStatus(ctx, t, "COMPLETED", &runID)
-
-	spew.Dump(c.Run(ctx, runID))
 
 	// Trigger the main function. It'll fail because the invoked function is
 	// rate limited

--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -1,0 +1,56 @@
+package golang
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/tests/client"
+	"github.com/inngest/inngestgo"
+	"github.com/inngest/inngestgo/step"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitInvalidExpression(t *testing.T) {
+	ctx := context.Background()
+	r := require.New(t)
+	c := client.New(t)
+
+	appID := "TestWaitInvalidExpression"
+	h, server, registerFuncs := NewSDKHandler(t, appID)
+	defer server.Close()
+
+	// This function will invoke the other function
+	runID := ""
+	evtName := "my-event"
+	fn := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{
+			Name: "main-fn",
+		},
+		inngestgo.EventTrigger(evtName, nil),
+		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
+			runID = input.InputCtx.RunID
+
+			_, _ = step.WaitForEvent[any](
+				ctx,
+				"wait",
+				step.WaitForEventOpts{
+					If:      inngestgo.StrPtr("invalid"),
+					Name:    "dummy",
+					Timeout: time.Second,
+				},
+			)
+
+			return nil, nil
+		},
+	)
+
+	h.Register(fn)
+	registerFuncs()
+
+	// Trigger the main function and successfully invoke the other function
+	_, err := inngestgo.Send(ctx, &event.Event{Name: evtName})
+	r.NoError(err)
+	c.WaitForRunStatus(ctx, t, "COMPLETED", &runID)
+}


### PR DESCRIPTION
## Description
Add a test to ensure runs don't hang when there's an invalid wait expression. This was recently fixed so we'll add a test to prevent a regression

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
