### PR TITLE
INN-3103: Add helper method in Span to store SDK resp

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -80,8 +80,10 @@ func doDev(cmd *cobra.Command, args []string) {
 	tick, _ := cmd.Flags().GetInt("tick")
 
 	if err := telemetry.NewUserTracer(ctx, telemetry.TracerOpts{
-		ServiceName: "devserver",
-		Type:        telemetry.TracerTypeOTLPHTTP,
+		ServiceName:   "devserver",
+		Type:          telemetry.TracerTypeOTLPHTTP,
+		TraceEndpoint: "localhost:8288",
+		TraceURLPath:  "/dev/traces",
 	}); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1014,7 +1014,7 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			fnSpan.SetAttributes(fnstatus)
 			span.SetName(spanName)
 			fnSpan.SetFnOutput(resp.Output)
-			span.SetStepOutput(resp.Output)
+			span.SetFnOutput(resp.Output)
 		} else {
 			// if it's not a step or function response that represents either a failed or a successful execution.
 			// Do not record discovery spans and cancel it.

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -997,7 +997,12 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 				attribute.String(consts.OtelSysStepDisplayName, op.UserDefinedName()),
 				attribute.String(consts.OtelSysStepOpcode, foundOp.String()),
 			)
-			span.SetStepOutput(op.Data)
+
+			if op.Error != nil {
+				span.SetStepOutput(op.Error)
+			} else {
+				span.SetStepOutput(op.Data)
+			}
 		} else if resp.IsTraceVisibleFunctionExecution() {
 			spanName := "function success"
 			fnstatus := attribute.Int64(consts.OtelSysFunctionStatusCode, enums.RunStatusCompleted.ToCode())

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -997,7 +997,7 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 				attribute.String(consts.OtelSysStepDisplayName, op.UserDefinedName()),
 				attribute.String(consts.OtelSysStepOpcode, foundOp.String()),
 			)
-			span.SetStepOutput(resp.Output)
+			span.SetStepOutput(op.Data)
 		} else if resp.IsTraceVisibleFunctionExecution() {
 			spanName := "function success"
 			fnstatus := attribute.Int64(consts.OtelSysFunctionStatusCode, enums.RunStatusCompleted.ToCode())

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -129,6 +129,7 @@ type QueueManager interface {
 	osqueue.JobQueueReader
 	osqueue.Queue
 
+	Dequeue(ctx context.Context, p QueuePartition, i QueueItem) error
 	Requeue(ctx context.Context, p QueuePartition, i QueueItem, at time.Time) error
 	RequeueByJobID(ctx context.Context, partitionName string, jobID string, at time.Time) error
 }

--- a/pkg/telemetry/span.go
+++ b/pkg/telemetry/span.go
@@ -560,7 +560,7 @@ func (s *Span) setOutput(data any, key string) {
 		s.AddEvent(string(v), trace.WithAttributes(attr...))
 	case json.RawMessage:
 		s.AddEvent(string(v), trace.WithAttributes(attr...))
-	case map[string]any:
+	default:
 		if byt, err := json.Marshal(v); err == nil {
 			s.AddEvent(string(byt), trace.WithAttributes(attr...))
 		}


### PR DESCRIPTION
## Description

SDK response can come in different shapes and sizes.
Add a helper method to Span to store the data in a way that's easier to consume later.

And tweak trace creator options.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
