### PR TITLE
Fix runs not failing when output too large

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -278,6 +278,8 @@ func do(ctx context.Context, c *http.Client, r Request) (*response, error) {
 		}
 	}
 
+	// Read 1 extra byte above the max so that we can check if the response is
+	// too large
 	byt, err := io.ReadAll(io.LimitReader(resp.Body, consts.MaxBodySize+1))
 	if err != nil {
 		return nil, fmt.Errorf("error reading response body: %w", err)

--- a/pkg/syscode/codes.go
+++ b/pkg/syscode/codes.go
@@ -5,6 +5,7 @@ const (
 	CodeComboUnsupported          = "combo_unsupported"
 	CodeConcurrencyLimitInvalid   = "concurrency_limit_invalid"
 	CodeConfigInvalid             = "config_invalid"
+	CodeOutputTooLarge            = "output_too_large"
 	CodeUnknown                   = "unknown"
 	CodeBatchKeyExpressionInvalid = "batch_key_expression_invalid"
 )

--- a/tests/golang/fn_output_test.go
+++ b/tests/golang/fn_output_test.go
@@ -1,0 +1,51 @@
+package golang
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/syscode"
+	"github.com/inngest/inngest/tests/client"
+	"github.com/inngest/inngestgo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFnOutputTooLarge(t *testing.T) {
+	ctx := context.Background()
+	r := require.New(t)
+	c := client.New(t)
+
+	appID := "TestFnOutputTooLarge"
+	h, server, registerFuncs := NewSDKHandler(t, appID)
+	defer server.Close()
+
+	runID := ""
+	evtName := "my-event"
+	fn := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{
+			Name:    "my-fn",
+			Retries: inngestgo.IntPtr(0),
+		},
+		inngestgo.EventTrigger(evtName, nil),
+		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
+			runID = input.InputCtx.RunID
+			return strings.Repeat("A", consts.MaxBodySize+1), nil
+		},
+	)
+
+	h.Register(fn)
+	registerFuncs()
+
+	// Trigger the main function and successfully invoke the other function
+	_, err := inngestgo.Send(ctx, &event.Event{Name: evtName})
+	r.NoError(err)
+	run := c.WaitForRunStatus(ctx, t, "FAILED", &runID)
+	var output string
+	err = json.Unmarshal([]byte(run.Output), &output)
+	r.NoError(err)
+	r.Equal(syscode.CodeOutputTooLarge, output)
+}


### PR DESCRIPTION
## Description
Fix runs not failing when their output is too large. This happened because we truncated the output with `io.LimitReader`, rather than checking if it's too large.

![image](https://github.com/inngest/inngest/assets/20100586/3ac8f9a4-cc83-439a-94a6-ae93eb744c47)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
