### PR TITLE
NN-3121: disable system dark theme detection until our designs support it

### DIFF
--- a/ui/packages/components/src/utils/theme.ts
+++ b/ui/packages/components/src/utils/theme.ts
@@ -3,8 +3,10 @@
 // If an element ref is provided we look for a dark class in any parents.
 // This is useful for components that might have dark theme sections inside a general light theme
 export const colorScheme = (elementRef?: HTMLElement): 'light' | 'dark' =>
-  localStorage.theme === 'dark' ||
-  window.matchMedia('(prefers-color-scheme: dark)').matches ||
+  //
+  // TODO: turn on when our design properly support toggling
+  // localStorage.theme === 'dark' ||
+  // window.matchMedia('(prefers-color-scheme: dark)').matches ||
   (elementRef ? elementRef.closest('.dark') : document.documentElement.classList.contains('dark'))
     ? 'dark'
     : 'light';


### PR DESCRIPTION
## Description

When I updated the code block component to support light themes, I added a utility function to detect dark mode. I included a check of the system dark settings there for future proof purposes. However, our designs don't yet support toggling dark and light modes, so I've disabled that check for now.

## Motivation
Invoke function code block looks bad when users system is set to dark mode. 

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ x] I've linked any associated issues to this PR.
- [ x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
