### PR TITLE
Make sure spans are annotated correctly when there's a retry

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1000,8 +1000,10 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 
 			if op.IsError() {
 				span.SetStepOutput(op.Error)
+				span.SetStatus(codes.Error, op.Error.Message)
 			} else {
 				span.SetStepOutput(op.Data)
+				span.SetStatus(codes.Ok, string(op.Data))
 			}
 		} else if resp.Retryable() {
 			span.SetStatus(codes.Error, *resp.Err)


### PR DESCRIPTION
## Description

Set the span outputs correctly on function level retries.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
