### PR TITLE
Fix crash when changing runs filter

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/RunsTable.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/RunsTable.tsx
@@ -42,7 +42,10 @@ export default function RunsTable({
   renderSubComponent,
 }: RunsTableProps) {
   // Render 8 empty lines for skeletons when data is loading
-  const tableData = useMemo(() => (isLoading ? Array(8).fill({}) : data), [isLoading, data]);
+  const tableData = useMemo(
+    () => (isLoading ? Array(8).fill(loadingRow) : data),
+    [isLoading, data]
+  );
 
   const tableColumns = useMemo(
     () =>
@@ -128,7 +131,7 @@ export default function RunsTable({
                   </td>
                 ))}
               </tr>
-              {row.getIsExpanded() && (
+              {row.getIsExpanded() && !isLoadingRow(row.original) && (
                 // Overrides tableStyles divider color
                 <tr className="!border-transparent">
                   <td colSpan={row.getVisibleCells().length}>
@@ -225,3 +228,15 @@ const columns = [
     enableSorting: false,
   }),
 ];
+
+const loadingRow = {
+  isLoadingRow: true,
+} as const;
+
+/**
+ * Whether a row is a loading skeleton object. This is important because the
+ * loading skeleton rows don't have fields, but the row schema requires them
+ */
+function isLoadingRow(row: Run): boolean {
+  return (row as any).isLoadingRow;
+}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/page.tsx
@@ -19,7 +19,7 @@ import { graphql } from '@/gql';
 import { RunsOrderByField } from '@/gql/graphql';
 import { useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
 import { useSearchParam, useStringArraySearchParam } from '@/utils/useSearchParam';
-import RunsTable from './RunsTable';
+import RunsTable, { type Run } from './RunsTable';
 import TimeFilter from './TimeFilter';
 import { parseRunsData, toRunStatuses, toTimeField } from './utils';
 
@@ -90,7 +90,7 @@ export default function RunsPage({
   /* TODO: When we have absolute time, the start date will be either coming from the date picker or the relative time */
   const [startTime, setStartTime] = useState<Date>(new Date());
   const [cursor, setCursor] = useState('');
-  const [runs, setRuns] = useState<any[]>([]);
+  const [runs, setRuns] = useState<Run[]>([]);
   const [isScrollRequest, setIsScrollRequest] = useState(false);
 
   useEffect(() => {
@@ -251,7 +251,6 @@ export default function RunsPage({
         />
       </div>
       <RunsTable
-        //@ts-ignore
         data={runs}
         isLoading={firstPageRes.isLoading}
         renderSubComponent={renderSubComponent}


### PR DESCRIPTION
## Description
The crash was happening since `row.current.id` is `undefined` when the loading skeleton is rendered

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
