### PR TITLE
Runs UI tweaks

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/RunsTable.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/RunsTable.tsx
@@ -22,6 +22,7 @@ export type Run = {
   id: string;
   queuedAt: string;
   endedAt: string | null;
+  startedAt: string | null;
 };
 
 type RunsTableProps = {
@@ -198,7 +199,20 @@ const columns = [
         </div>
       );
     },
-    header: 'Queued At',
+    header: 'Queued at',
+    enableSorting: false,
+  }),
+  columnHelper.accessor('startedAt', {
+    cell: (info) => {
+      const time = info.getValue();
+
+      return (
+        <div className="flex items-center">
+          {time ? <TimeCell date={new Date(time)} /> : <TextCell>-</TextCell>}
+        </div>
+      );
+    },
+    header: 'Started at',
     enableSorting: false,
   }),
   columnHelper.accessor('endedAt', {
@@ -211,7 +225,7 @@ const columns = [
         </div>
       );
     },
-    header: 'Ended At',
+    header: 'Ended at',
     enableSorting: false,
   }),
   columnHelper.accessor('durationMS', {

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/page.tsx
@@ -230,7 +230,7 @@ export default function RunsPage({
       onScroll={(e) => fetchMoreOnScroll(e.target as HTMLDivElement)}
       ref={containerRef}
     >
-      <div className="sticky top-0 flex items-center justify-between gap-2 bg-slate-50 px-8 py-2">
+      <div className="sticky top-0 z-[100] flex items-center justify-between gap-2 bg-slate-50 px-8 py-2">
         <div className="flex items-center gap-2">
           <SelectGroup>
             <TimeFieldFilter

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/page.tsx
@@ -60,7 +60,7 @@ const GetRunsDocument = graphql(`
 
 const renderSubComponent = ({ id }: { id: string }) => {
   return (
-    <div className="border-l-4 border-slate-400 pb-6 pl-5">
+    <div className="border-l-4 border-slate-400 pb-6">
       <RunDetails standalone={false} runID={id} />
     </div>
   );

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/utils.ts
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/runs/utils.ts
@@ -85,6 +85,7 @@ export function parseRunsData(runsData: PickedFunctionRunV2EdgeWithNode[] | unde
       return {
         id: edge.node.id,
         queuedAt: edge.node.queuedAt,
+        startedAt: edge.node.startedAt,
         endedAt: edge.node.endedAt,
         durationMS,
         status: edge.node.status,

--- a/ui/packages/components/src/DetailsCard/Element.tsx
+++ b/ui/packages/components/src/DetailsCard/Element.tsx
@@ -1,3 +1,5 @@
+import { InlineCode } from '@inngest/components/InlineCode';
+import { Link, type LinkProps } from '@inngest/components/Link';
 import { Skeleton } from '@inngest/components/Skeleton';
 import { Time } from '@inngest/components/Time';
 import { cn } from '@inngest/components/utils/classNames';
@@ -31,6 +33,18 @@ export function TimeElement({ date }: { date: Date }) {
       <Time value={date} />
     </span>
   );
+}
+
+export function LinkElement({ children, href, ...props }: LinkProps) {
+  return (
+    <Link href={href} {...props}>
+      {children}
+    </Link>
+  );
+}
+
+export function CodeElement({ value }: { value: string }) {
+  return <InlineCode value={value} />;
 }
 
 export function SkeletonElement() {

--- a/ui/packages/components/src/Link/Link.tsx
+++ b/ui/packages/components/src/Link/Link.tsx
@@ -4,7 +4,7 @@ import NextLink from 'next/link';
 import { cn } from '@inngest/components/utils/classNames';
 import { RiArrowRightLine, RiExternalLinkLine } from '@remixicon/react';
 
-type LinkProps = {
+export type LinkProps = {
   internalNavigation?: boolean;
   showIcon?: boolean;
   children?: React.ReactNode;

--- a/ui/packages/components/src/Link/index.ts
+++ b/ui/packages/components/src/Link/index.ts
@@ -1,1 +1,1 @@
-export { Link, defaultLinkStyles } from './Link';
+export { Link, defaultLinkStyles, type LinkProps } from './Link';

--- a/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
@@ -58,17 +58,18 @@ export function RunDetails(props: Props) {
 
   return (
     <div className="pr-4">
-      <RunInfo
-        app={app}
-        cancelRun={cancelRun}
-        className="mb-4"
-        fn={fn}
-        rerun={rerun}
-        run={run}
-        standalone={standalone}
-      />
-
-      {result && <RunResult className="mb-4" result={result} />}
+      <div className="pl-5">
+        <RunInfo
+          app={app}
+          cancelRun={cancelRun}
+          className="mb-4"
+          fn={fn}
+          rerun={rerun}
+          run={run}
+          standalone={standalone}
+        />
+        {result && <RunResult className="mb-4" result={result} />}
+      </div>
 
       <Timeline getResult={getResult} pathCreator={pathCreator} trace={run.trace} />
     </div>

--- a/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
@@ -3,10 +3,15 @@ import type { Route } from 'next';
 
 import { CancelRunButton } from '../CancelRunButton';
 import { Card } from '../Card';
-import { CodeBlock } from '../CodeBlock';
+import {
+  ElementWrapper,
+  IDElement,
+  LinkElement,
+  TextElement,
+  TimeElement,
+} from '../DetailsCard/Element';
 import { Link } from '../Link';
 import { RerunButton } from '../RerunButtonV2';
-import { Time } from '../Time';
 import { cn } from '../utils/classNames';
 import { formatMilliseconds, toMaybeDate } from '../utils/date';
 
@@ -61,40 +66,39 @@ export function RunInfo({ app, cancelRun, className, fn, rerun, run, standalone 
         <Card.Content>
           <div>
             <dl className="flex flex-wrap gap-4">
-              <Labeled label="Run ID">
-                <span className="font-mono">{run.id}</span>
-              </Labeled>
+              <ElementWrapper label="Run ID">
+                <IDElement>{run.id}</IDElement>
+              </ElementWrapper>
 
-              <Labeled label="App">
-                <Link internalNavigation href={app.url} showIcon={false}>
+              <ElementWrapper label="App">
+                <LinkElement internalNavigation href={app.url} showIcon={false}>
                   {app.name}
-                </Link>
-              </Labeled>
+                </LinkElement>
+              </ElementWrapper>
 
-              <Labeled label="Duration">{durationText}</Labeled>
+              <ElementWrapper label="Duration">
+                <TextElement>{durationText}</TextElement>
+              </ElementWrapper>
 
-              <Labeled label="Queued at">
-                <Time value={queuedAt} />
-              </Labeled>
+              <ElementWrapper label="Queued at">
+                <TimeElement date={queuedAt} />
+              </ElementWrapper>
 
-              <Labeled label="Started at">{startedAt ? <Time value={startedAt} /> : '-'}</Labeled>
+              <ElementWrapper label="Started at">
+                {startedAt ? <TimeElement date={startedAt} /> : <TextElement>-</TextElement>}
+              </ElementWrapper>
 
-              <Labeled label="Ended at">{endedAt ? <Time value={endedAt} /> : '-'}</Labeled>
+              <ElementWrapper label="Ended at">
+                {endedAt ? <TimeElement date={endedAt} /> : <TextElement>-</TextElement>}
+              </ElementWrapper>
 
-              <Labeled label="Step count">{run.trace.childrenSpans?.length ?? 0}</Labeled>
+              <ElementWrapper label="Step count">
+                <TextElement>{run.trace.childrenSpans?.length ?? 0}</TextElement>
+              </ElementWrapper>
             </dl>
           </div>
         </Card.Content>
       </Card>
-    </div>
-  );
-}
-
-function Labeled({ label, children }: React.PropsWithChildren<{ label: string }>) {
-  return (
-    <div className="w-64 text-sm">
-      <dt className="pb-2 text-slate-500">{label}</dt>
-      <dd className="truncate">{children}</dd>
     </div>
   );
 }

--- a/ui/packages/components/src/TimelineV2/Trace.tsx
+++ b/ui/packages/components/src/TimelineV2/Trace.tsx
@@ -67,9 +67,9 @@ export function Trace({
   return (
     <div
       className={cn(
-        'py-2',
+        'py-5',
         // We don't want borders or horizontal padding on step attempts
-        depth === 0 && 'px-4',
+        depth === 0 && 'px-9',
         isExpanded && 'bg-blue-50'
       )}
     >

--- a/ui/packages/components/src/TimelineV2/TraceInfo.tsx
+++ b/ui/packages/components/src/TimelineV2/TraceInfo.tsx
@@ -1,8 +1,13 @@
 import type { Route } from 'next';
 
 import { Card } from '../Card';
-import { InlineCode } from '../InlineCode';
-import { Link } from '../Link';
+import {
+  CodeElement,
+  ElementWrapper,
+  LinkElement,
+  TextElement,
+  TimeElement,
+} from '../DetailsCard/Element';
 import { Time } from '../Time';
 import { cn } from '../utils/classNames';
 import { formatMilliseconds, toMaybeDate } from '../utils/date';
@@ -47,37 +52,54 @@ export function TraceInfo({ className, pathCreator, trace }: Props) {
     const timeout = toMaybeDate(trace.stepInfo.timeout);
     stepKindInfo = (
       <>
-        <Labeled label="Run">
+        <ElementWrapper label="Run">
           {trace.stepInfo.runID ? (
-            <Link
+            <LinkElement
               href={pathCreator.runPopout({ runID: trace.stepInfo.runID })}
-              internalNavigation={false}
+              internalNavigation
+              showIcon={false}
             >
               {trace.stepInfo.runID}
-            </Link>
+            </LinkElement>
           ) : (
             '-'
           )}
-        </Labeled>
-        <Labeled label="Timeout">{timeout ? <Time value={timeout} /> : '-'}</Labeled>
-        <Labeled label="Timed out">{maybeBooleanToString(trace.stepInfo.timedOut)}</Labeled>
+        </ElementWrapper>
+        <ElementWrapper label="Timeout">
+          {timeout ? <TimeElement date={timeout} /> : <TextElement>-</TextElement>}
+        </ElementWrapper>
+        <ElementWrapper label="Timed out">
+          <TextElement>{maybeBooleanToString(trace.stepInfo.timedOut)}</TextElement>
+        </ElementWrapper>
       </>
     );
   } else if (isStepInfoSleep(trace.stepInfo)) {
     const sleepUntil = toMaybeDate(trace.stepInfo.sleepUntil);
     stepKindInfo = (
-      <Labeled label="Sleep until">{sleepUntil ? <Time value={sleepUntil} /> : '-'}</Labeled>
+      <ElementWrapper label="Sleep until">
+        {sleepUntil ? <Time value={sleepUntil} /> : <TextElement>-</TextElement>}
+      </ElementWrapper>
     );
   } else if (isStepInfoWait(trace.stepInfo)) {
     const timeout = toMaybeDate(trace.stepInfo.timeout);
     stepKindInfo = (
       <>
-        <Labeled label="Event name">{trace.stepInfo.eventName}</Labeled>
-        <Labeled label="Timeout">{timeout ? <Time value={timeout} /> : '-'}</Labeled>
-        <Labeled label="Timed out">{maybeBooleanToString(trace.stepInfo.timedOut)}</Labeled>
-        <Labeled className="w-full" label="Match expression">
-          {trace.stepInfo.expression ? <InlineCode value={trace.stepInfo.expression} /> : '-'}
-        </Labeled>
+        <ElementWrapper label="Event name">
+          <TextElement>{trace.stepInfo.eventName}</TextElement>
+        </ElementWrapper>
+        <ElementWrapper label="Timeout">
+          {timeout ? <TimeElement date={timeout} /> : <TextElement>-</TextElement>}
+        </ElementWrapper>
+        <ElementWrapper label="Timed out">
+          <TextElement>{maybeBooleanToString(trace.stepInfo.timedOut)}</TextElement>
+        </ElementWrapper>
+        <ElementWrapper className="w-full" label="Match expression">
+          {trace.stepInfo.expression ? (
+            <CodeElement value={trace.stepInfo.expression} />
+          ) : (
+            <TextElement>-</TextElement>
+          )}
+        </ElementWrapper>
       </>
     );
   }
@@ -89,39 +111,38 @@ export function TraceInfo({ className, pathCreator, trace }: Props) {
 
         <Card.Content>
           <dl className="flex flex-wrap gap-4">
-            <Labeled label="Queued at">
-              <Time value={new Date(trace.queuedAt)} />
-            </Labeled>
+            <ElementWrapper label="Queued at">
+              <TimeElement date={new Date(trace.queuedAt)} />
+            </ElementWrapper>
 
-            <Labeled label="Started at">
-              {trace.startedAt ? <Time value={new Date(trace.startedAt)} /> : '-'}
-            </Labeled>
+            <ElementWrapper label="Started at">
+              {trace.startedAt ? (
+                <TimeElement date={new Date(trace.startedAt)} />
+              ) : (
+                <TextElement>-</TextElement>
+              )}
+            </ElementWrapper>
 
-            <Labeled label="Ended at">
-              {trace.endedAt ? <Time value={new Date(trace.endedAt)} /> : '-'}
-            </Labeled>
+            <ElementWrapper label="Ended at">
+              {trace.endedAt ? (
+                <TimeElement date={new Date(trace.endedAt)} />
+              ) : (
+                <TextElement>-</TextElement>
+              )}
+            </ElementWrapper>
 
-            <Labeled label="Delay">{delayText}</Labeled>
+            <ElementWrapper label="Delay">
+              <TextElement>{delayText}</TextElement>
+            </ElementWrapper>
 
-            <Labeled label="Duration">{durationText}</Labeled>
+            <ElementWrapper label="Duration">
+              <TextElement>{durationText}</TextElement>
+            </ElementWrapper>
 
             {stepKindInfo}
           </dl>
         </Card.Content>
       </Card>
-    </div>
-  );
-}
-
-function Labeled({
-  className,
-  label,
-  children,
-}: React.PropsWithChildren<{ className?: string; label: string }>) {
-  return (
-    <div className={cn('w-64 text-sm', className)}>
-      <dt className="text-slate-500">{label}</dt>
-      <dd className="truncate">{children}</dd>
     </div>
   );
 }

--- a/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
+++ b/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
@@ -8,6 +8,7 @@ import { useLocalStorage } from 'react-use';
 import { Card } from '../Card';
 import { CodeBlock } from '../CodeBlock';
 import {
+  CodeElement,
   ElementWrapper,
   IDElement,
   SkeletonElement,
@@ -131,10 +132,10 @@ export function TriggerDetails({ className, getTrigger }: Props) {
                         </ElementWrapper>
                       </>
                     )}
-                    {type === 'CRON' && (
+                    {type === 'CRON' && trigger?.cron && (
                       <>
                         <ElementWrapper label="Cron expression">
-                          {isLoading ? <SkeletonElement /> : <IDElement>{trigger?.cron}</IDElement>}
+                          {isLoading ? <SkeletonElement /> : <CodeElement value={trigger.cron} />}
                         </ElementWrapper>
                         <ElementWrapper label="Cron ID">
                           {isLoading ? (

--- a/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
+++ b/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
@@ -159,7 +159,7 @@ export function TriggerDetails({ className, getTrigger }: Props) {
                           {isLoading ? (
                             <SkeletonElement />
                           ) : (
-                            <TextElement>{trigger.eventName}</TextElement>
+                            <TextElement>{trigger.eventName ?? '-'}</TextElement>
                           )}
                         </ElementWrapper>
                         <ElementWrapper label="Batch ID">

--- a/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
+++ b/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Button } from '@inngest/components/Button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';
+// import { Button } from '@inngest/components/Button';
+// import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';
 import * as Collapsible from '@radix-ui/react-collapsible';
-import { RiContractRightFill, RiExpandLeftFill } from '@remixicon/react';
+// import { RiContractRightFill, RiExpandLeftFill } from '@remixicon/react';
 import { useLocalStorage } from 'react-use';
 
 import { Card } from '../Card';
@@ -81,27 +81,28 @@ export function TriggerDetails({ className, getTrigger }: Props) {
       open={showEventPanel}
       onOpenChange={setShowEventPanel}
     >
-      {!showEventPanel && (
+      {/* TODO: Enable the collapsed feature */}
+      {/* {!showEventPanel && (
         <Collapsible.Trigger asChild>
-          <button className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-400">
+          <span className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-400">
             <Tooltip>
               <TooltipTrigger>
                 <RiExpandLeftFill className="text-slate-400" />
               </TooltipTrigger>
               <TooltipContent>Show trigger details</TooltipContent>
             </Tooltip>
-          </button>
+          </span>
         </Collapsible.Trigger>
-      )}
+      )} */}
       <Collapsible.Content>
         {showEventPanel && (
           <>
             <Card>
               <Card.Header className="h-11 flex-row items-center gap-2">
                 <div className="flex grow items-center gap-2">Trigger details</div>
-                <Collapsible.Trigger asChild>
+                {/* <Collapsible.Trigger asChild>
                   <Button size="large" appearance="text" icon={<RiContractRightFill />} />
-                </Collapsible.Trigger>
+                </Collapsible.Trigger> */}
               </Card.Header>
 
               <Card.Content>


### PR DESCRIPTION
## Description
- Add startedAt time to the runs table
- Fix z-index of filters sticky bar
- Make padding between elements in details table consistent by using shared Elements components
- Add default value to event name, in case of batching
- Adjust padding of expanded steps to make the bg-blue occupy more space 
- Temporarily disable the ability to collapse the Trigger details

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [X] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
