### PR TITLE
some more fixes with relative date picker

### DIFF
--- a/ui/packages/components/src/DatePicker/Calendar.tsx
+++ b/ui/packages/components/src/DatePicker/Calendar.tsx
@@ -30,7 +30,7 @@ export function Calendar({ selected, onSelect, month, onMonthChange }: CalendarP
 const classNames: DayPickerDefaultProps['classNames'] = {
   caption: 'flex justify-center items-center h-6',
   root: 'text-slate-900 bg-white',
-  months: 'flex gap-4 relative',
+  months: 'flex gap-4 relative justify-center',
   caption_label: 'text-lg font-medium',
   nav_button:
     'inline-flex justify-center items-center absolute top-0 w-6 h-6 rounded-full text-slate-900 hover:bg-gray-100',

--- a/ui/packages/components/src/DatePicker/DateTimeInput.tsx
+++ b/ui/packages/components/src/DatePicker/DateTimeInput.tsx
@@ -220,6 +220,7 @@ export function DateTimeInput({
         if (raw.length > 5 && isValid(d)) {
           e.preventDefault();
           populateFields(d);
+          onSelect(d);
         }
       }}
     >

--- a/ui/packages/components/src/DatePicker/RangePicker.tsx
+++ b/ui/packages/components/src/DatePicker/RangePicker.tsx
@@ -125,6 +125,11 @@ export const RangePicker = ({
       setStartValid(false);
       setEndValid(false);
     }
+
+    if (upgradeCutoff && absoluteRange?.start && isBefore(absoluteRange.start, upgradeCutoff)) {
+      setStartError('Upgrade required for requested start date');
+      setStartValid(false);
+    }
   };
 
   useEffect(() => {

--- a/ui/packages/components/src/DatePicker/RangePicker.tsx
+++ b/ui/packages/components/src/DatePicker/RangePicker.tsx
@@ -127,7 +127,7 @@ export const RangePicker = ({
     }
 
     if (upgradeCutoff && absoluteRange?.start && isBefore(absoluteRange.start, upgradeCutoff)) {
-      setStartError('Upgrade required for requested start date');
+      setStartError('Please upgrade for increased history limits');
       setStartValid(false);
     }
   };

--- a/ui/packages/components/src/DatePicker/RangePicker.tsx
+++ b/ui/packages/components/src/DatePicker/RangePicker.tsx
@@ -161,7 +161,7 @@ export const RangePicker = ({
   };
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={setOpen} modal={true}>
       <PopoverTrigger asChild>
         <DateInputButton {...props}>
           {displayValue ? (


### PR DESCRIPTION
## Description

I picked off a few of the easier fixed from Dan's feedback. The other are going to take a bit more time. This validates start/end even when pasting dates. Validates dates outside of the support contract even when using the absolute date picker...and centers the calendar days.

_update_: clicking outside the date picker popover no longer closes the parent modal.

See here the centered days on calendar and validation even pasted dates:

<img width="603" alt="Screenshot 2024-06-05 at 1 42 33 PM" src="https://github.com/inngest/inngest/assets/191780/dfb477b0-cdaf-4e30-bfcf-69d6d29b47b0">


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
