### PR TITLE
Fix missing event in SDK request

### DIFF
--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -103,6 +103,7 @@ func MarshalV1(
 	// This is because, as Jack points out, for backcompat we send both events and the
 	// first event.  We also may have incorrect state sizes for runs before this is tracked.
 	if len(j) > consts.MaxBodySize {
+		req.Event = map[string]any{}
 		req.Events = []map[string]any{}
 		req.Actions = map[string]any{}
 		req.UseAPI = true

--- a/pkg/execution/driver/request.go
+++ b/pkg/execution/driver/request.go
@@ -6,8 +6,8 @@ import (
 )
 
 type SDKRequest struct {
-	Event   map[string]any     `json:"event,omitempty"`
-	Events  []map[string]any   `json:"events,omitempty"`
+	Event   map[string]any     `json:"event"`
+	Events  []map[string]any   `json:"events"`
 	Actions map[string]any     `json:"steps"`
 	Context *SDKRequestContext `json:"ctx"`
 	// Version indicates the version used to manage the SDK request context.

--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -100,6 +100,11 @@ func (v v2) LoadState(ctx context.Context, id state.ID) (state.State, error) {
 	if state.Metadata, err = v.LoadMetadata(ctx, id); err != nil {
 		return state, err
 	}
+
+	// Reassign id since state.Metadata.ID has more complete info. Specifically,
+	// it has the function ID
+	id = state.Metadata.ID
+
 	if state.Events, err = v.LoadEvents(ctx, id); err != nil {
 		return state, err
 	}


### PR DESCRIPTION
## Description
Fix missing `event` field in SDK request when the Executor tells the SDK to "use the API"

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
