### PR TITLE
Fix a deadlock when a pause resumes with a non-default retry count

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1832,6 +1832,7 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 			Identifier:            pause.Identifier,
 			PriorityFactor:        md.Config.PriorityFactor,
 			CustomConcurrencyKeys: md.Config.CustomConcurrencyKeys,
+			MaxAttempts:           pause.MaxAttempts,
 			Payload: queue.PayloadEdge{
 				Edge: pause.Edge(),
 			},
@@ -2456,6 +2457,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, i *runInst
 		InvokeCorrelationID: &correlationID,
 		TriggeringEventID:   &evt.ID,
 		InvokeTargetFnID:    &opts.FunctionID,
+		MaxAttempts:         i.item.MaxAttempts,
 		Metadata: map[string]any{
 			consts.OtelPropagationKey: carrier,
 		},
@@ -2482,6 +2484,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, i *runInst
 		Identifier:            i.item.Identifier,
 		PriorityFactor:        i.item.PriorityFactor,
 		CustomConcurrencyKeys: i.item.CustomConcurrencyKeys,
+		MaxAttempts:           i.item.MaxAttempts,
 		Payload: queue.PayloadPauseTimeout{
 			PauseID:   pauseID,
 			OnTimeout: true,
@@ -2610,6 +2613,7 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, i *runInstan
 		Event:       &opts.Event,
 		Expression:  expr,
 		DataKey:     gen.ID,
+		MaxAttempts: i.item.MaxAttempts,
 		Metadata: map[string]any{
 			consts.OtelPropagationKey: carrier,
 		},

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -180,6 +180,10 @@ type Pause struct {
 	// via an async driver.  This lets the executor resume as-is with the current
 	// context, ensuring that we retry correctly.
 	Attempt int `json:"att,omitempty"`
+	// MaxAttempts is the maximum number of attempts we can retry.  This is
+	// included in the pause to allow the executor to set the correct maximum
+	// number of retries when enqueuing next steps.
+	MaxAttempts *int `json:"maxAtts,omitempty"`
 	// GroupID stores the group ID for this step and history, allowing us to correlate
 	// event receives with other history items.
 	GroupID string `json:"groupID"`

--- a/tests/golang/step_pause_deadlock_test.go
+++ b/tests/golang/step_pause_deadlock_test.go
@@ -47,12 +47,15 @@ func TestStepPauseDeadlockRegression(t *testing.T) {
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
 			runID = input.InputCtx.RunID
 
-			step.Invoke[any](ctx, "invoke-step", step.InvokeOpts{
+			_, err := step.Invoke[any](ctx, "invoke-step", step.InvokeOpts{
 				FunctionId: fmt.Sprintf("%s-%s", appID, "invokee-fn"),
 				Data:       map[string]any{},
 			})
+			if err != nil {
+				return nil, err
+			}
 
-			_, err := step.Run(ctx, "after-invoke-step", func(ctx context.Context) (any, error) {
+			_, err = step.Run(ctx, "after-invoke-step", func(ctx context.Context) (any, error) {
 				atomic.AddInt32(&afterStepAttempts, 1)
 				return nil, fmt.Errorf("uh oh")
 			})

--- a/tests/golang/step_pause_deadlock_test.go
+++ b/tests/golang/step_pause_deadlock_test.go
@@ -1,0 +1,75 @@
+package golang
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/tests/client"
+	"github.com/inngest/inngestgo"
+	"github.com/inngest/inngestgo/step"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression test for inngest/inngest#1430
+func TestStepPauseDeadlockRegression(t *testing.T) {
+	ctx := context.Background()
+	r := require.New(t)
+	c := client.New(t)
+
+	appID := "TestStepPauseDeadlockRegression"
+	h, server, registerFuncs := NewSDKHandler(t, appID)
+	defer server.Close()
+
+	runID := ""
+	reachedAfter := false
+	var afterStepAttempts int32 = 0
+	evtName := "my-event"
+
+	invokeeFn := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{
+			Name: "invokee-fn",
+		},
+		inngestgo.EventTrigger("youll-never-guess", nil),
+		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+			return "ok", nil
+		},
+	)
+
+	fn := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{
+			Name:    "my-fn",
+			Retries: inngestgo.IntPtr(0),
+		},
+		inngestgo.EventTrigger(evtName, nil),
+		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
+			runID = input.InputCtx.RunID
+
+			step.Invoke[any](ctx, "invoke-step", step.InvokeOpts{
+				FunctionId: fmt.Sprintf("%s-%s", appID, "invokee-fn"),
+				Data:       map[string]any{},
+			})
+
+			_, err := step.Run(ctx, "after-invoke-step", func(ctx context.Context) (any, error) {
+				atomic.AddInt32(&afterStepAttempts, 1)
+				return nil, fmt.Errorf("uh oh")
+			})
+
+			reachedAfter = true
+
+			return nil, err
+		},
+	)
+
+	h.Register(invokeeFn, fn)
+	registerFuncs()
+
+	// Trigger the main function and successfully invoke the other function
+	_, err := inngestgo.Send(ctx, &event.Event{Name: evtName})
+	r.NoError(err)
+	c.WaitForRunStatus(ctx, t, "FAILED", &runID)
+	r.Exactly(int32(1), afterStepAttempts, "after step should have been attempted exactly once")
+	r.True(reachedAfter)
+}


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

Fixes an issue where a run will deadlock when:
- A pause-powered step like `step.invoke()` or `step.waitForEvent()` is used
- In a non-parallel function
- With a retry count lower than the default of `4`
- When the following step is a `step.run()` that throws a handled error

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
