### PR TITLE
Report state size before deleting

### DIFF
--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -146,6 +146,9 @@ type InvokeFailHandler func(context.Context, InvokeFailHandlerOpts, []event.Even
 // item.
 type HandleSendingEvent func(context.Context, event.Event, queue.Item) error
 
+// PreDeleteStateSizeReporter handles logging the state size before deleting state
+type PreDeleteStateSizeReporter func(context.Context, sv2.Metadata)
+
 // ScheduleRequest represents all data necessary to schedule a new function.
 type ScheduleRequest struct {
 	Function inngest.Function


### PR DESCRIPTION
## Description

This adds a simple hook to the executor to report the state size before deletion.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
