### PR TITLE
Use known error for missing events

### DIFF
--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -478,6 +478,9 @@ func (m mgr) Load(ctx context.Context, runID ulid.ULID) (state.State, error) {
 		cmd := m.r.B().Get().Key(m.kf.Event(ctx, id)).Build()
 		byt, err := m.r.Do(ctx, cmd).AsBytes()
 		if err != nil {
+			if err == rueidis.Nil {
+				return nil, state.ErrEventNotFound
+			}
 			return nil, fmt.Errorf("failed to get event; %w", err)
 		}
 		event := map[string]any{}

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -37,6 +37,7 @@ var (
 	ErrFunctionFailed     = fmt.Errorf("function failed")
 	ErrFunctionOverflowed = fmt.Errorf("function has too many steps")
 	ErrDuplicateResponse  = fmt.Errorf("duplicate response")
+	ErrEventNotFound      = fmt.Errorf("event not found in state store")
 )
 
 const (


### PR DESCRIPTION
## Description

Currently, we simply return a "redis nil message" error, which is hard to handle correctly in upstream functions.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
