### PR TITLE
Set min height of invoke modal editor

### DIFF
--- a/ui/packages/components/src/CodeBlock/CodeBlock.tsx
+++ b/ui/packages/components/src/CodeBlock/CodeBlock.tsx
@@ -149,9 +149,10 @@ interface CodeBlockProps {
     handleChange?: (value: string) => void;
   }[];
   actions?: CodeBlockAction[];
+  minLines?: number;
 }
 
-export function CodeBlock({ className, header, tabs, actions = [] }: CodeBlockProps) {
+export function CodeBlock({ className, header, tabs, actions = [], minLines = 0 }: CodeBlockProps) {
   const [dark, setDark] = useState(isDark());
   const [activeTab, setActiveTab] = useState(0);
   const editorRef = useRef<MonacoEditorType>(null);
@@ -245,7 +246,8 @@ export function CodeBlock({ className, header, tabs, actions = [] }: CodeBlockPr
       if (isFullHeight) {
         editor.layout({ height: newHeight, width: containerWidthWithLineNumbers });
       } else {
-        const height = Math.min(MAX_HEIGHT, contentHeight);
+        const minHeight = minLines * LINE_HEIGHT + 20;
+        const height = Math.max(Math.min(MAX_HEIGHT, contentHeight), minHeight);
         editor.layout({ height: height, width: containerWidthWithLineNumbers });
       }
     }

--- a/ui/packages/components/src/InvokeButton/InvokeModal.tsx
+++ b/ui/packages/components/src/InvokeButton/InvokeModal.tsx
@@ -52,6 +52,7 @@ export function InvokeModal({ doesFunctionAcceptPayload, isOpen, onCancel, onCon
             handleChange: setRawPayload,
           },
         ]}
+        minLines={10}
       />
     );
   } else {


### PR DESCRIPTION
## Description

Ensure that the invoke modal has more space so users can properly see typical sized events 

![image](https://github.com/inngest/inngest/assets/1509457/378aaca9-0b5b-4547-9e1c-3cd4311f4ccf) ![image](https://github.com/inngest/inngest/assets/1509457/e563d73c-4423-43c7-b3e2-097ec8624833)


## Motivation

User feedback in our Discord community pointed out the fact that showing only 4 lines when pasting a big payload is not good UX.

![image](https://github.com/inngest/inngest/assets/1509457/bb9f38eb-cf3d-4010-9c40-153e1aff7e57)


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
