### PR TITLE
Force stack to be sent as slice, even if we receive nil

### DIFF
--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -56,11 +56,6 @@ func MarshalV1(
 		}
 	}
 
-	stack := md.Stack
-	if stack == nil {
-		stack = make([]string, 0)
-	}
-
 	req := &SDKRequest{
 		// For backcompat, we always send `Event`, but `Events` could be made
 		// empty if the overall request size is too large.
@@ -74,7 +69,7 @@ func MarshalV1(
 			StepID:     step.ID,
 			RunID:      md.ID.RunID,
 			Stack: &FunctionStack{
-				Stack:   stack,
+				Stack:   md.Stack,
 				Current: stackIndex,
 			},
 			Attempt:                   attempt,

--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -56,6 +56,11 @@ func MarshalV1(
 		}
 	}
 
+	stack := md.Stack
+	if stack == nil {
+		stack = make([]string, 0)
+	}
+
 	req := &SDKRequest{
 		// For backcompat, we always send `Event`, but `Events` could be made
 		// empty if the overall request size is too large.
@@ -69,7 +74,7 @@ func MarshalV1(
 			StepID:     step.ID,
 			RunID:      md.ID.RunID,
 			Stack: &FunctionStack{
-				Stack:   md.Stack,
+				Stack:   stack,
 				Current: stackIndex,
 			},
 			Attempt:                   attempt,

--- a/pkg/execution/driver/request.go
+++ b/pkg/execution/driver/request.go
@@ -20,21 +20,6 @@ type SDKRequest struct {
 	UseAPI bool `json:"use_api"`
 }
 
-func (m *SDKRequestContext) preMarshal() {
-	stack := m.Stack.Stack
-	if stack == nil {
-		stack = make([]string, 0)
-	}
-
-	m.Stack.Stack = stack
-}
-
-func (m SDKRequestContext) MarshalJSON() ([]byte, error) {
-	m.preMarshal()
-	type alias SDKRequestContext // Avoid infinite recursion
-	return json.Marshal(alias(m))
-}
-
 type SDKRequestContext struct {
 	// FunctionID is used within entrypoints to SDK-based functions in
 	// order to specify the ID of the function to run via RPC.
@@ -74,4 +59,13 @@ type SDKRequestContext struct {
 type FunctionStack struct {
 	Stack   []string `json:"stack"`
 	Current int      `json:"current"`
+}
+
+func (m FunctionStack) MarshalJSON() ([]byte, error) {
+	if m.Stack == nil {
+		m.Stack = make([]string, 0)
+	}
+
+	type alias FunctionStack // Avoid infinite recursion
+	return json.Marshal(alias(m))
 }

--- a/pkg/execution/driver/request.go
+++ b/pkg/execution/driver/request.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"encoding/json"
 	"github.com/google/uuid"
 	"github.com/oklog/ulid/v2"
 )
@@ -17,6 +18,21 @@ type SDKRequest struct {
 
 	// DEPRECATED: NOTE: This is moved into SDKRequestContext for V3+/Non-TS SDKs
 	UseAPI bool `json:"use_api"`
+}
+
+func (m *SDKRequestContext) preMarshal() {
+	stack := m.Stack.Stack
+	if stack == nil {
+		stack = make([]string, 0)
+	}
+
+	m.Stack.Stack = stack
+}
+
+func (m SDKRequestContext) MarshalJSON() ([]byte, error) {
+	m.preMarshal()
+	type alias SDKRequestContext // Avoid infinite recursion
+	return json.Marshal(alias(m))
 }
 
 type SDKRequestContext struct {

--- a/pkg/execution/driver/request_test.go
+++ b/pkg/execution/driver/request_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func TestStack(t *testing.T) {
-	req := SDKRequest{Context: &SDKRequestContext{Stack: &FunctionStack{Stack: nil}}}
+	fnStack := FunctionStack{Stack: nil}
 
-	marshaled, err := json.Marshal(req)
+	marshaled, err := json.Marshal(fnStack)
 	require.NoError(t, err)
 
-	assert.Equal(t, "{\"event\":null,\"events\":null,\"steps\":null,\"ctx\":{\"fn_id\":\"00000000-0000-0000-0000-000000000000\",\"run_id\":\"00000000000000000000000000\",\"env\":\"\",\"step_id\":\"\",\"attempt\":0,\"stack\":{\"stack\":[],\"current\":0},\"disable_immediate_execution\":false,\"use_api\":false},\"version\":0,\"use_api\":false}", string(marshaled))
+	assert.Equal(t, "{\"stack\":[],\"current\":0}", string(marshaled))
 }

--- a/pkg/execution/driver/request_test.go
+++ b/pkg/execution/driver/request_test.go
@@ -1,1 +1,17 @@
 package driver
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestStack(t *testing.T) {
+	req := SDKRequest{Context: &SDKRequestContext{Stack: &FunctionStack{Stack: nil}}}
+
+	marshaled, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	assert.Equal(t, "{\"event\":null,\"events\":null,\"steps\":null,\"ctx\":{\"fn_id\":\"00000000-0000-0000-0000-000000000000\",\"run_id\":\"00000000000000000000000000\",\"env\":\"\",\"step_id\":\"\",\"attempt\":0,\"stack\":{\"stack\":[],\"current\":0},\"disable_immediate_execution\":false,\"use_api\":false},\"version\":0,\"use_api\":false}", string(marshaled))
+}

--- a/tests/dsl.go
+++ b/tests/dsl.go
@@ -170,6 +170,8 @@ func (t *Test) ExpectRequest(name string, queryStepID string, timeout time.Durat
 			err = json.Unmarshal(byt, er)
 			require.NoError(t.test, err)
 
+			require.NotNil(t.test, er.Ctx.Stack.Stack)
+
 			require.NotZero(t.test, er.Event.Timestamp)
 			// Zero out the TS and ID
 			ts := er.Event.Timestamp


### PR DESCRIPTION
## Description

This might not be needed but there's a discrepancy in how we provide the stack array. Previously, we returned an empty array, now we return null. SDKs need to handle this, but we may decide to hotfix this for the moment, and this PR does just that.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
