### PR TITLE
Fix run hangs when negative waitForEvent timeout

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1118,27 +1118,27 @@ func (e *executor) HandleResponse(ctx context.Context, i *runInstance, resp *sta
 	if len(resp.Generator) > 0 {
 		// Handle generator responses then return.
 		if serr := e.HandleGeneratorResponse(ctx, i, resp); serr != nil {
-			if errors.Is(serr, &expressions.CompileError{}) {
+
+			// If this is an error compiling async expressions, fail the function.
+			if shouldFailEarly := errors.Is(serr, &expressions.CompileError{}); shouldFailEarly {
 				var gracefulErr *state.WrappedStandardError
 				if hasGracefulErr := errors.As(serr, &gracefulErr); hasGracefulErr {
 					serialized := gracefulErr.Serialize(execution.StateErrorKey)
 					resp.Output = nil
 					resp.Err = &serialized
 				}
-			} else if resp.Err == nil {
-				resp.Output = nil
-				resp.Err = util.StrPtr(serr.Error())
-			}
 
-			if performedFinalization, err := e.finalize(ctx, i.md, i.events, i.f.GetSlug(), *resp); err != nil {
-				logger.From(ctx).Error().Err(err).Msg("error running finish handler")
-			} else if performedFinalization {
-				for _, e := range e.lifecycles {
-					go e.OnFunctionFinished(context.WithoutCancel(ctx), i.md, i.item, *resp)
+				if performedFinalization, err := e.finalize(ctx, i.md, i.events, i.f.GetSlug(), *resp); err != nil {
+					logger.From(ctx).Error().Err(err).Msg("error running finish handler")
+				} else if performedFinalization {
+					for _, e := range e.lifecycles {
+						go e.OnFunctionFinished(context.WithoutCancel(ctx), i.md, i.item, *resp)
+					}
 				}
-			}
 
-			return nil
+				return nil
+			}
+			return fmt.Errorf("error handling generator response: %w", serr)
 		}
 		return nil
 	}

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -252,6 +252,12 @@ func (w *WaitForEventOpts) UnmarshalAny(a any) error {
 }
 
 func (w WaitForEventOpts) Expires() (time.Time, error) {
+	if w.Timeout == "" {
+		// The TypeScript SDK sets timeout to an empty string when the duration
+		// is negative
+		return time.Now(), nil
+	}
+
 	dur, err := str2duration.ParseDuration(w.Timeout)
 	if err != nil {
 		return time.Time{}, err


### PR DESCRIPTION
## Description
Fix negative `waitForEvent` timeout durations causing the run to hang.

If the `waitForEvent` timeout is an empty string then set the timeout to now (i.e. immediately timeout)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
