### PR TITLE
fix rate limit for small limits + add rate-limit test for limits over 1

### DIFF
--- a/pkg/execution/ratelimit/ratelimit.go
+++ b/pkg/execution/ratelimit/ratelimit.go
@@ -66,7 +66,7 @@ func rateLimit(ctx context.Context, store throttled.GCRAStoreCtx, key string, c 
 
 	quota := throttled.RateQuota{
 		MaxRate:  throttled.PerDuration(int(c.Limit), dur),
-		MaxBurst: int(c.Limit) / 10,
+		MaxBurst: max(1, int(c.Limit)/10),
 	}
 
 	limiter, err := throttled.NewGCRARateLimiterCtx(store, quota)

--- a/pkg/execution/ratelimit/ratelimit.go
+++ b/pkg/execution/ratelimit/ratelimit.go
@@ -54,9 +54,9 @@ func hash(res any, id uuid.UUID) string {
 
 // RateLimit checks the given key against the specified rate limit, returning true if limited.
 //
-// This allows bursts of up to 1/10th the given rate limit, by default.
+// This allows bursts of up to max(1,x/10) the given rate limit, by default.
 //
-// Tihs returns the duration until the next request will be permitted, or -1 if the rate limit
+// This returns the duration until the next request will be permitted, or -1 if the rate limit
 // has not been exceeded.
 func rateLimit(ctx context.Context, store throttled.GCRAStoreCtx, key string, c inngest.RateLimit) (bool, time.Duration, error) {
 	dur, err := str2duration.ParseDuration(c.Period)

--- a/tests/golang/rate_limit_test.go
+++ b/tests/golang/rate_limit_test.go
@@ -60,3 +60,56 @@ func TestFunctionWithRateLimit(t *testing.T) {
 
 	require.Eventually(t, func() bool { return atomic.LoadInt32(&counter) == 2 }, 5*time.Second, time.Second)
 }
+
+func TestFunctionWithRateLimitOverOne(t *testing.T) {
+	ctx := context.Background()
+	h, server, registerFuncs := NewSDKHandler(t, "rate-limit")
+	defer server.Close()
+
+	var counter int32
+	fun := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{
+			Name:      "rate-limit",
+			RateLimit: &inngestgo.RateLimit{Limit: 2, Period: 24 * time.Hour, Key: inngestgo.StrPtr("event.data.number")},
+		},
+		inngestgo.EventTrigger("test/ratelimit", nil),
+		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+			atomic.AddInt32(&counter, 1)
+			return true, nil
+		},
+	)
+	h.Register(fun)
+	registerFuncs()
+
+	// send one, it should be ok
+	_, err := inngestgo.Send(ctx, inngestgo.Event{
+		Name: "test/ratelimit",
+		Data: map[string]any{"number": 10},
+	})
+	require.NoError(t, err)
+
+	<-time.After(5 * time.Second)
+
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&counter) == 1 }, 5*time.Second, time.Second)
+
+	// send second, it should also be ok
+	_, err = inngestgo.Send(ctx, inngestgo.Event{
+		Name: "test/ratelimit",
+		Data: map[string]any{"number": 10},
+	})
+	require.NoError(t, err)
+	<-time.After(5 * time.Second)
+
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&counter) == 2 }, 5*time.Second, time.Second)
+
+	// send another, it should be rate-limited (as limit is 2),
+	// the counter should stay the same because we ignore it
+	_, err = inngestgo.Send(ctx, inngestgo.Event{
+		Name: "test/ratelimit",
+		Data: map[string]any{"number": 10},
+	})
+	require.NoError(t, err)
+	<-time.After(5 * time.Second)
+
+	require.Eventually(t, func() bool { return atomic.LoadInt32(&counter) == 2 }, 5*time.Second, time.Second)
+}


### PR DESCRIPTION
Fixes https://github.com/inngest/inngest/issues/1460

## Description

If we have a small limit for the rate-limiter (something under 10), the maxBurst ends up being 0, which only let's through one request. The maxBurst should probably be at least 1, so for small limits we let through at least one request.

I also added another test that actually tests the rate-limit, the one that is there, doesn't hit the bug.

## Motivation
I had a limit of 5 per 24h and it didn't work, ended up digging through  the code and found that it does:
limit / 10, which in this case means 5 / 10 = 0,5 which in integer results in a 0.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
