### PR TITLE
Do not run go routine or log if discovery is disabled

### DIFF
--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -130,7 +130,9 @@ func (d *devserver) Pre(ctx context.Context) error {
 	)
 
 	// Autodiscover the URLs that are hosting Inngest SDKs on the local machine.
-	go d.runDiscovery(ctx)
+	if d.opts.Autodiscover {
+		go d.runDiscovery(ctx)
+	}
 
 	return d.apiservice.Pre(ctx)
 }
@@ -188,10 +190,7 @@ func (d *devserver) runDiscovery(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-
-		if d.opts.Autodiscover {
-			_ = discovery.Autodiscover(ctx)
-		}
+		_ = discovery.Autodiscover(ctx)
 
 		<-time.After(pollInterval)
 	}


### PR DESCRIPTION
## Description

This skips running the `runDiscovery` go routine from running if auto discovery is enabled. 

## Motivation

Prior to this change, if `--no-discovery` was used, the process would still log `"autodiscovering locally hosted SDKs"` which was incorrect and misleading. 

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
