### PR TITLE
Update OnFunctionCancelled lifecycle hook to accept fn events

### DIFF
--- a/pkg/execution/driver/request.go
+++ b/pkg/execution/driver/request.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"encoding/json"
+
 	"github.com/google/uuid"
 	"github.com/oklog/ulid/v2"
 )

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1777,11 +1777,6 @@ func (e *executor) Cancel(ctx context.Context, id sv2.ID, r execution.CancelRequ
 		return fmt.Errorf("unable to load run events: %w", err)
 	}
 
-	ctx = e.extractTraceCtx(ctx, md, nil)
-	for _, e := range e.lifecycles {
-		go e.OnFunctionCancelled(context.WithoutCancel(ctx), md, r)
-	}
-
 	// We need the function slug.
 	f, err := e.fl.LoadFunction(ctx, md.ID.Tenant.EnvID, md.ID.FunctionID)
 	if err != nil {
@@ -1796,7 +1791,7 @@ func (e *executor) Cancel(ctx context.Context, id sv2.ID, r execution.CancelRequ
 	} else if performedFinalization {
 		ctx = e.extractTraceCtx(ctx, md, nil)
 		for _, e := range e.lifecycles {
-			go e.OnFunctionCancelled(context.WithoutCancel(ctx), md, r)
+			go e.OnFunctionCancelled(context.WithoutCancel(ctx), md, r, evts)
 		}
 	}
 

--- a/pkg/execution/history/lifecycle.go
+++ b/pkg/execution/history/lifecycle.go
@@ -228,6 +228,7 @@ func (l lifecycle) OnFunctionCancelled(
 	ctx context.Context,
 	md sv2.Metadata,
 	req execution.CancelRequest,
+	evts []json.RawMessage,
 ) {
 	completedStepCount := int64(md.Metrics.StepCount)
 	groupID := uuid.New()
@@ -751,7 +752,7 @@ func applyResponse(
 		stepName := op.UserDefinedName()
 		h.StepName = &stepName
 	}
-	
+
 	// Only set the output to the response error string if there isn't already output. This prevents overriding errors in the user's function
 	if resp.Output == nil && resp.Error() != "" {
 		h.Result.Output = resp.Error()

--- a/pkg/execution/lifecycle.go
+++ b/pkg/execution/lifecycle.go
@@ -2,6 +2,7 @@ package execution
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/inngest/inngest/pkg/enums"
@@ -70,9 +71,10 @@ type LifecycleListener interface {
 	// the cancellation request, detailing either the event that cancelled the
 	// function or the API request information.
 	OnFunctionCancelled(
-		context.Context,
-		state.Metadata,
-		CancelRequest,
+		ctx context.Context,
+		md state.Metadata,
+		cr CancelRequest,
+		fnEvents []json.RawMessage, // All triggering function events, for tracing.
 	)
 
 	// OnStepScheduled is called when a new step is scheduled.  It contains the
@@ -214,6 +216,7 @@ func (NoopLifecyceListener) OnFunctionCancelled(
 	context.Context,
 	state.Metadata,
 	CancelRequest,
+	[]json.RawMessage,
 ) {
 }
 

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -1209,7 +1209,7 @@ func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, dur
 	case 7:
 		return nil, newKeyError(ErrQueueItemThrottled, item.Data.Throttle.Key)
 	default:
-		return nil, fmt.Errorf("unknown response enqueueing item: %d", status)
+		return nil, fmt.Errorf("unknown response leasing item: %d", status)
 	}
 }
 
@@ -1286,7 +1286,7 @@ func (q *queue) ExtendLease(ctx context.Context, p QueuePartition, i QueueItem, 
 	case 3:
 		return nil, ErrQueueItemLeaseMismatch
 	default:
-		return nil, fmt.Errorf("unknown response enqueueing item: %d", status)
+		return nil, fmt.Errorf("unknown response extending lease: %d", status)
 	}
 }
 
@@ -1453,8 +1453,12 @@ func (q *queue) Requeue(ctx context.Context, p QueuePartition, i QueueItem, at t
 	switch status {
 	case 0:
 		return nil
+	case 1:
+		// This should only ever happen if a run is cancelled and all queue items
+		// are deleted before requeueing.
+		return ErrQueueItemNotFound
 	default:
-		return fmt.Errorf("unknown response enqueueing item: %d", status)
+		return fmt.Errorf("unknown response requeueing item: %v (%T)", status, status)
 	}
 }
 


### PR DESCRIPTION
This prevents us from having to load events in the hook, which allows us to call the hook a single time after handling finalization.  We also take the opportunity to improve queueing errors.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
