### PR TITLE
Add GQL API for retrieving span output and trigger

### DIFF
--- a/pkg/consts/otel.go
+++ b/pkg/consts/otel.go
@@ -39,6 +39,7 @@ const (
 	OtelSysFunctionEndAt      = "sys.function.time.end"
 	OtelSysFunctionStatusCode = "sys.function.status.code"
 	OtelSysFunctionOutput     = "sys.function.output"
+	OtelSysFunctionLink       = "sys.function.link"
 
 	OtelSysStepDisplayName     = "sys.step.display.name"
 	OtelSysStepOpcode          = "sys.step.opcode"

--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -181,7 +181,7 @@ func convertRunTreeToGQLModel(pb *rpbv2.RunSpan) (*models.RunTraceSpan, error) {
 		QueuedAt:     pb.GetQueuedAt().AsTime(),
 		StartedAt:    startedAt,
 		EndedAt:      endedAt,
-		OutputID:     nil, // TODO
+		OutputID:     pb.OutputId,
 		StepOp:       stepOp,
 	}
 

--- a/pkg/cqrs/sqlitecqrs/cqrs.go
+++ b/pkg/cqrs/sqlitecqrs/cqrs.go
@@ -685,6 +685,9 @@ func (w wrapper) InsertTraceRun(ctx context.Context, run *cqrs.TraceRun) error {
 	if run.BatchID != nil {
 		params.BatchID = *run.BatchID
 	}
+	if run.CronSchedule != nil {
+		params.CronSchedule = sql.NullString{String: *run.CronSchedule, Valid: true}
+	}
 	if len(run.TriggerIDs) > 0 {
 		params.TriggerIds = []byte(strings.Join(run.TriggerIDs, ","))
 	}
@@ -830,7 +833,6 @@ func (w wrapper) GetTraceRun(ctx context.Context, id cqrs.TraceRunIdentifier) (*
 		BatchID:      batchID,
 		IsBatch:      isBatch,
 		CronSchedule: cron,
-		// TODO: fill in triggers
 	}
 
 	return &trun, nil

--- a/pkg/cqrs/sqlitecqrs/sqlc/queries.sql
+++ b/pkg/cqrs/sqlitecqrs/sqlc/queries.sql
@@ -183,9 +183,9 @@ VALUES
 
 -- name: InsertTraceRun :exec
 INSERT OR REPLACE INTO trace_runs
-	(account_id, workspace_id, app_id, function_id, trace_id, run_id, queued_at, started_at, ended_at, status, source_id, trigger_ids, output, batch_id, is_debounce)
+	(account_id, workspace_id, app_id, function_id, trace_id, run_id, queued_at, started_at, ended_at, status, source_id, trigger_ids, output, batch_id, is_debounce, cron_schedule)
 VALUES
-	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: GetTraceRun :one
 SELECT * FROM trace_runs WHERE run_id = @run_id;

--- a/pkg/cqrs/sqlitecqrs/sqlc/queries.sql
+++ b/pkg/cqrs/sqlitecqrs/sqlc/queries.sql
@@ -192,3 +192,6 @@ SELECT * FROM trace_runs WHERE run_id = @run_id;
 
 -- name: GetTraceSpans :many
 SELECT * FROM traces WHERE trace_id = @trace_id AND run_id = @run_id ORDER BY timestamp_unix_ms DESC, duration DESC;
+
+-- name: GetTraceSpanOutput :many
+select * from traces where trace_id = @trace_id AND span_id = @span_id ORDER BY timestamp_unix_ms DESC, duration DESC;

--- a/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
+++ b/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
@@ -1290,27 +1290,28 @@ func (q *Queries) InsertTrace(ctx context.Context, arg InsertTraceParams) error 
 
 const insertTraceRun = `-- name: InsertTraceRun :exec
 INSERT OR REPLACE INTO trace_runs
-	(account_id, workspace_id, app_id, function_id, trace_id, run_id, queued_at, started_at, ended_at, status, source_id, trigger_ids, output, batch_id, is_debounce)
+	(account_id, workspace_id, app_id, function_id, trace_id, run_id, queued_at, started_at, ended_at, status, source_id, trigger_ids, output, batch_id, is_debounce, cron_schedule)
 VALUES
-	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type InsertTraceRunParams struct {
-	AccountID   uuid.UUID
-	WorkspaceID uuid.UUID
-	AppID       uuid.UUID
-	FunctionID  uuid.UUID
-	TraceID     []byte
-	RunID       ulid.ULID
-	QueuedAt    int64
-	StartedAt   int64
-	EndedAt     int64
-	Status      int64
-	SourceID    string
-	TriggerIds  []byte
-	Output      []byte
-	BatchID     ulid.ULID
-	IsDebounce  bool
+	AccountID    uuid.UUID
+	WorkspaceID  uuid.UUID
+	AppID        uuid.UUID
+	FunctionID   uuid.UUID
+	TraceID      []byte
+	RunID        ulid.ULID
+	QueuedAt     int64
+	StartedAt    int64
+	EndedAt      int64
+	Status       int64
+	SourceID     string
+	TriggerIds   []byte
+	Output       []byte
+	BatchID      ulid.ULID
+	IsDebounce   bool
+	CronSchedule sql.NullString
 }
 
 func (q *Queries) InsertTraceRun(ctx context.Context, arg InsertTraceRunParams) error {
@@ -1330,6 +1331,7 @@ func (q *Queries) InsertTraceRun(ctx context.Context, arg InsertTraceRunParams) 
 		arg.Output,
 		arg.BatchID,
 		arg.IsDebounce,
+		arg.CronSchedule,
 	)
 	return err
 }

--- a/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
+++ b/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
@@ -839,6 +839,58 @@ func (q *Queries) GetTraceRun(ctx context.Context, runID ulid.ULID) (*TraceRun, 
 	return &i, err
 }
 
+const getTraceSpanOutput = `-- name: GetTraceSpanOutput :many
+select timestamp, timestamp_unix_ms, trace_id, span_id, parent_span_id, trace_state, span_name, span_kind, service_name, resource_attributes, scope_name, scope_version, span_attributes, duration, status_code, status_message, events, links, run_id from traces where trace_id = ?1 AND span_id = ?2 ORDER BY timestamp_unix_ms DESC, duration DESC
+`
+
+type GetTraceSpanOutputParams struct {
+	TraceID string
+	SpanID  string
+}
+
+func (q *Queries) GetTraceSpanOutput(ctx context.Context, arg GetTraceSpanOutputParams) ([]*Trace, error) {
+	rows, err := q.db.QueryContext(ctx, getTraceSpanOutput, arg.TraceID, arg.SpanID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*Trace
+	for rows.Next() {
+		var i Trace
+		if err := rows.Scan(
+			&i.Timestamp,
+			&i.TimestampUnixMs,
+			&i.TraceID,
+			&i.SpanID,
+			&i.ParentSpanID,
+			&i.TraceState,
+			&i.SpanName,
+			&i.SpanKind,
+			&i.ServiceName,
+			&i.ResourceAttributes,
+			&i.ScopeName,
+			&i.ScopeVersion,
+			&i.SpanAttributes,
+			&i.Duration,
+			&i.StatusCode,
+			&i.StatusMessage,
+			&i.Events,
+			&i.Links,
+			&i.RunID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getTraceSpans = `-- name: GetTraceSpans :many
 SELECT timestamp, timestamp_unix_ms, trace_id, span_id, parent_span_id, trace_state, span_name, span_kind, service_name, resource_attributes, scope_name, scope_version, span_attributes, duration, status_code, status_message, events, links, run_id FROM traces WHERE trace_id = ?1 AND run_id = ?2 ORDER BY timestamp_unix_ms DESC, duration DESC
 `

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -265,6 +266,22 @@ type SpanIdentifier struct {
 	FunctionID  uuid.UUID
 	TraceID     string
 	SpanID      string
+}
+
+func (si *SpanIdentifier) Encode() (string, error) {
+	byt, err := json.Marshal(si)
+	if err != nil {
+		return "", fmt.Errorf("error encoding span identifier: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(byt), nil
+}
+
+func (si *SpanIdentifier) Decode(data string) error {
+	byt, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(byt, si)
 }
 
 // TracePageCursor represents the composite cursor used to handle pagination

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -877,6 +877,9 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			attribute.Int64(consts.OtelSysBatchTS, int64(md.Config.BatchID.Time())),
 		)
 	}
+	if md.Config.TraceLink() != nil {
+		fnSpan.SetAttributes(attribute.String(consts.OtelSysFunctionLink, *md.Config.TraceLink()))
+	}
 
 	for _, evt := range events {
 		fnSpan.AddEvent(string(evt), trace.WithAttributes(

--- a/pkg/execution/state/v2/state_metadata.go
+++ b/pkg/execution/state/v2/state_metadata.go
@@ -13,6 +13,7 @@ import (
 const (
 	cronScheduleKey = "__cron"
 	fnslugKey       = "__fnslug"
+	traceLinkKey    = "__tracelink"
 )
 
 type ID struct {
@@ -169,6 +170,27 @@ func (c *Config) FunctionSlug() string {
 	}
 
 	return ""
+}
+
+func (c *Config) SetTraceLink(link string) {
+	if c.Context == nil {
+		c.Context = map[string]any{}
+	}
+	c.Context[traceLinkKey] = link
+}
+
+func (c *Config) TraceLink() *string {
+	if c.Context == nil {
+		return nil
+	}
+
+	if v, ok := c.Context[traceLinkKey]; ok {
+		if link, ok := v.(string); ok {
+			return &link
+		}
+	}
+
+	return nil
 }
 
 // RunMetrics stores state-level run metrics.

--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -759,6 +759,13 @@ func (tb *runTree) processExec(ctx context.Context, span *cqrs.Span, mod *rpbv2.
 					mod.OutputId = &outputID
 				}
 			}
+
+			// if the name is `function error`, it's already finished
+			// and mark it as failed
+			if mod.Name == "function error" {
+				mod.Status = rpbv2.SpanStatus_FAILED
+				mod.OutputId = &outputID
+			}
 		}
 
 		mod.Children = append(mod.Children, nested)

--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -131,6 +131,8 @@ func (tb *runTree) ToRunSpan(ctx context.Context) (*rpbv2.RunSpan, error) {
 		if skipped {
 			continue
 		}
+		// the last output is the run's output
+		root.OutputId = tspan.OutputId
 		root.Children = append(root.Children, tspan)
 	}
 
@@ -195,10 +197,6 @@ func (tb *runTree) toRunSpan(ctx context.Context, s *cqrs.Span) (*rpbv2.RunSpan,
 func (tb *runTree) constructSpan(ctx context.Context, s *cqrs.Span) (*rpbv2.RunSpan, bool) {
 	// already processed skip it
 	if _, ok := tb.processed[s.SpanID]; ok {
-		return nil, true
-	}
-	// NOTE: is this check sufficient?
-	if s.SpanName == "function success" {
 		return nil, true
 	}
 

--- a/tests/client/function_run.go
+++ b/tests/client/function_run.go
@@ -355,7 +355,7 @@ func (c *Client) RunSpanOutput(ctx context.Context, outputID string) *models.Run
 		},
 	})
 	if len(resp.Errors) > 0 {
-		c.Fatalf("err with fnrun trace query: %#v", resp.Errors)
+		c.Fatalf("err with span output query: %#v", resp.Errors)
 	}
 
 	type response struct {
@@ -387,4 +387,46 @@ func (c *Client) ExpectSpanErrorOutput(t *testing.T, msg string, stack string, o
 		require.NotNil(t, output.Error.Stack)
 		require.Contains(t, *output.Error.Stack, stack)
 	}
+}
+
+func (c *Client) RunTrigger(ctx context.Context, runID string) *models.RunTraceTrigger {
+	c.Helper()
+
+	if runID == "" {
+		return nil
+	}
+
+	query := `
+		query GetTraceRunTrigger($runID: String!) {
+			runTrigger(runID: $runID) {
+				eventName
+				IDs
+				timestamp
+				payloads
+				isBatch
+				batchID
+				cron
+			}
+		}
+	`
+
+	resp := c.MustDoGQL(ctx, graphql.RawParams{
+		Query: query,
+		Variables: map[string]any{
+			"runID": runID,
+		},
+	})
+	if len(resp.Errors) > 0 {
+		c.Fatalf("err with fnrun trace query: %#v", resp.Errors)
+	}
+
+	type response struct {
+		RunTrigger *models.RunTraceTrigger
+	}
+	data := response{}
+	if err := json.Unmarshal(resp.Data, &data); err != nil {
+		c.Fatalf("err with run trigger query: %#v", err)
+	}
+
+	return data.RunTrigger
 }

--- a/tests/client/function_run.go
+++ b/tests/client/function_run.go
@@ -372,5 +372,19 @@ func (c *Client) RunSpanOutput(ctx context.Context, outputID string) *models.Run
 func (c *Client) ExpectSpanOutput(t *testing.T, expected string, output *models.RunTraceSpanOutput) {
 	require.NotNil(t, output)
 	require.NotNil(t, output.Data)
+	require.Nil(t, output.Error)
 	require.Contains(t, *output.Data, expected)
+}
+
+func (c *Client) ExpectSpanErrorOutput(t *testing.T, msg string, stack string, output *models.RunTraceSpanOutput) {
+	require.NotNil(t, output)
+	require.Nil(t, output.Data)
+	require.NotNil(t, output.Error)
+	if msg != "" {
+		require.Contains(t, output.Error.Message, msg)
+	}
+	if stack != "" {
+		require.NotNil(t, output.Error.Stack)
+		require.Contains(t, *output.Error.Stack, stack)
+	}
 }

--- a/tests/golang/basic_step_test.go
+++ b/tests/golang/basic_step_test.go
@@ -39,7 +39,7 @@ func TestFunctionSteps(t *testing.T) {
 			_, err := step.Run(ctx, "1", func(ctx context.Context) (any, error) {
 				fmt.Println("1")
 				atomic.AddInt32(&counter, 1)
-				return input.Event, nil
+				return "hello 1", nil
 			})
 			require.NoError(t, err)
 
@@ -166,8 +166,14 @@ func TestFunctionSteps(t *testing.T) {
 			require.Equal(t, 5, len(run.Trace.ChildSpans))
 			require.Equal(t, models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
 
+			// output test
+			require.NotNil(t, run.Trace.OutputID)
+			output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+			require.NotNil(t, output)
+			require.NotNil(t, output.Data)
+			require.Contains(t, *output.Data, "true")
+
 			rootSpanID := run.Trace.SpanID
-			// TODO: output test
 
 			t.Run("step 1", func(t *testing.T) {
 				one := run.Trace.ChildSpans[0]
@@ -178,11 +184,9 @@ func TestFunctionSteps(t *testing.T) {
 				assert.Equal(t, models.StepOpRun.String(), one.StepOp)
 				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), one.Status)
 				// output test
-				// assert.NotNil(t, one.OutputID)
-				// oneOutput := c.RunTraceSpanOutput(*one.OutputID)
-				// assert.NotNil(t, oneOutput)
-				// assert.NotNil(t, oneOutput.Data)
-				// assert.Contains(t, *oneOutput.Data, "hello 1")
+				assert.NotNil(t, one.OutputID)
+				oneOutput := c.RunSpanOutput(ctx, *one.OutputID)
+				c.ExpectSpanOutput(t, "hello 1", oneOutput)
 			})
 
 			t.Run("step 2", func(t *testing.T) {
@@ -194,11 +198,9 @@ func TestFunctionSteps(t *testing.T) {
 				assert.Equal(t, models.StepOpRun.String(), sec.StepOp)
 				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), sec.Status)
 				// output test
-				// assert.NotNil(t, sec.OutputID)
-				// secOutput := c.RunTraceSpanOutput(*sec.OutputID)
-				// assert.NotNil(t, secOutput)
-				// assert.NotNil(t, secOutput.Data)
-				// assert.Contains(t, *secOutput.Data, "hello 2")
+				assert.NotNil(t, sec.OutputID)
+				secOutput := c.RunSpanOutput(ctx, *sec.OutputID)
+				c.ExpectSpanOutput(t, "test", secOutput)
 			})
 
 			// third step
@@ -210,8 +212,9 @@ func TestFunctionSteps(t *testing.T) {
 				assert.Equal(t, rootSpanID, thr.ParentSpanID)
 				assert.Equal(t, models.StepOpSleep.String(), thr.StepOp)
 				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), thr.Status)
-				require.NotNil(t, thr.StartedAt)
-				require.NotNil(t, thr.EndedAt)
+				assert.NotNil(t, thr.StartedAt)
+				assert.NotNil(t, thr.EndedAt)
+				assert.Nil(t, thr.OutputID)
 				// check sleep duration
 				expectedDur := (2 * time.Second).Milliseconds()
 				assert.Equal(t, expectedDur, thr.Duration)
@@ -237,6 +240,10 @@ func TestFunctionSteps(t *testing.T) {
 				assert.False(t, *stepInfo.TimedOut)
 				assert.NotNil(t, stepInfo.FoundEventID)
 
+				// output test
+				assert.NotNil(t, forth.OutputID)
+				forthOutput := c.RunSpanOutput(ctx, *forth.OutputID)
+				c.ExpectSpanOutput(t, "api/new.event", forthOutput)
 			})
 
 			// check trigger

--- a/tests/golang/basic_step_test.go
+++ b/tests/golang/basic_step_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/inngest/inngest/tests/client"
 	"github.com/inngest/inngestgo"
 	"github.com/inngest/inngestgo/step"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -246,19 +247,21 @@ func TestFunctionSteps(t *testing.T) {
 				c.ExpectSpanOutput(t, "api/new.event", forthOutput)
 			})
 
-			// check trigger
-			// trigger := c.RunTrigger(runID)
-			// assert.NotNil(t, trigger)
-			// assert.NotNil(t, trigger.EventName)
-			// assert.Equal(t, "test/sdk", *trigger.EventName)
-			// assert.Equal(t, 1, len(trigger.IDs))
-			// assert.False(t, trigger.Timestamp.IsZero())
-			// assert.False(t, trigger.IsBatch)
-			// assert.Nil(t, trigger.BatchID)
-			// assert.Nil(t, trigger.Cron)
+			t.Run("trigger", func(t *testing.T) {
+				// check trigger
+				trigger := c.RunTrigger(ctx, runID)
+				assert.NotNil(t, trigger)
+				assert.NotNil(t, trigger.EventName)
+				assert.Equal(t, "test/sdk-steps", *trigger.EventName)
+				assert.Equal(t, 1, len(trigger.IDs))
+				assert.False(t, trigger.Timestamp.IsZero())
+				assert.False(t, trigger.IsBatch)
+				assert.Nil(t, trigger.BatchID)
+				assert.Nil(t, trigger.Cron)
 
-			// rid := ulid.MustParse(runID)
-			// assert.True(t, trigger.Timestamp.Before(ulid.Time(rid.Time())))
+				rid := ulid.MustParse(runID)
+				assert.True(t, trigger.Timestamp.Before(ulid.Time(rid.Time())))
+			})
 
 			return true
 		}, 10*time.Second, 2*time.Second)

--- a/tests/golang/batch_test.go
+++ b/tests/golang/batch_test.go
@@ -44,7 +44,7 @@ func TestBatchEvents(t *testing.T) {
 
 			atomic.AddInt32(&counter, 1)
 			atomic.AddInt32(&totalEvents, int32(len(input.Events)))
-			return true, nil
+			return "batched!!", nil
 		},
 	)
 	h.Register(a)
@@ -84,7 +84,10 @@ func TestBatchEvents(t *testing.T) {
 			require.True(t, run.Trace.IsRoot)
 			require.Equal(t, 0, len(run.Trace.ChildSpans))
 			require.Equal(t, models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
-			// TODO: output test
+			// output test
+			require.NotNil(t, run.Trace.OutputID)
+			output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+			c.ExpectSpanOutput(t, "batched!!", output)
 
 			return true
 		}, 10*time.Second, 2*time.Second)

--- a/tests/golang/batch_test.go
+++ b/tests/golang/batch_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/inngest/inngest/tests/client"
 	"github.com/inngest/inngestgo"
 	"github.com/inngest/inngestgo/step"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,6 +90,22 @@ func TestBatchEvents(t *testing.T) {
 			require.NotNil(t, run.Trace.OutputID)
 			output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
 			c.ExpectSpanOutput(t, "batched!!", output)
+
+			t.Run("trigger", func(t *testing.T) {
+				// check trigger
+				trigger := c.RunTrigger(ctx, runID)
+				assert.NotNil(t, trigger)
+				assert.NotNil(t, trigger.EventName)
+				assert.Equal(t, "test/batch", *trigger.EventName)
+				assert.Equal(t, 5, len(trigger.IDs))
+				assert.False(t, trigger.Timestamp.IsZero())
+				assert.True(t, trigger.IsBatch)
+				assert.NotNil(t, trigger.BatchID)
+				assert.Nil(t, trigger.Cron)
+
+				rid := ulid.MustParse(runID)
+				assert.True(t, trigger.Timestamp.Before(ulid.Time(rid.Time())))
+			})
 
 			return true
 		}, 10*time.Second, 2*time.Second)

--- a/tests/golang/failure_test.go
+++ b/tests/golang/failure_test.go
@@ -72,12 +72,10 @@ func TestFunctionFailure(t *testing.T) {
 			require.Equal(t, 1, len(run.Trace.ChildSpans))
 			require.Equal(t, models.RunTraceSpanStatusFailed.String(), run.Trace.Status)
 			// output test
-			// require.NotNil(t, run.Trace.OutputID)
-			// runOutput := c.RunTraceSpanOutput(*run.Trace.OutputID)
-			// require.NotNil(t, runOutput)
-			// require.Nil(t, runOutput.Data)
-			// require.NotNil(t, runOutput.StepError)
-			// require.Contains(t, *runOutput.StepError.Stack, "nope!")
+			require.NotNil(t, run.Trace.OutputID)
+			runOutput := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+			require.NotNil(t, runOutput)
+			c.ExpectSpanErrorOutput(t, "", "nope!", runOutput)
 
 			rootSpanID := run.Trace.SpanID
 
@@ -87,14 +85,12 @@ func TestFunctionFailure(t *testing.T) {
 				assert.False(t, span.IsRoot)
 				assert.Equal(t, rootSpanID, span.ParentSpanID)
 				assert.Equal(t, models.RunTraceSpanStatusFailed.String(), span.Status)
-				// assert.NotNil(t, span.OutputID)
+				assert.NotNil(t, span.OutputID)
 
 				// output test
-				// output := c.RunTraceSpanOutput(*failed.OutputID)
-				// assert.NotNil(t, output)
-				// assert.Nil(t, output.Data)
-				// assert.NotNil(t, output.StepError)
-				// assert.Contains(t, *output.StepError.Stack, "nope!")
+				output := c.RunSpanOutput(ctx, *span.OutputID)
+				assert.NotNil(t, output)
+				c.ExpectSpanErrorOutput(t, "", "nope!", output)
 			})
 
 			return true
@@ -179,6 +175,10 @@ func TestFunctionFailureWithRetries(t *testing.T) {
 					assert.Equal(t, models.RunTraceSpanStatusFailed.String(), failed.Status)
 
 					// output test
+					assert.NotNil(t, failed.OutputID)
+					output := c.RunSpanOutput(ctx, *failed.OutputID)
+					assert.NotNil(t, output)
+					c.ExpectSpanErrorOutput(t, "", "nope!", output)
 				})
 			})
 
@@ -198,12 +198,9 @@ func TestFunctionFailureWithRetries(t *testing.T) {
 			require.Equal(t, 1, len(run.Trace.ChildSpans))
 			require.Equal(t, models.RunTraceSpanStatusFailed.String(), run.Trace.Status)
 			// output test
-			// require.NotNil(t, run.Trace.OutputID)
-			// runOutput := c.RunTraceSpanOutput(*run.Trace.OutputID)
-			// require.NotNil(t, runOutput)
-			// require.Nil(t, runOutput.Data)
-			// require.NotNil(t, runOutput.StepError)
-			// require.Contains(t, *runOutput.StepError.Stack, "nope!")
+			require.NotNil(t, run.Trace.OutputID)
+			runOutput := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+			c.ExpectSpanErrorOutput(t, "", "nope!", runOutput)
 
 			rootSpanID := run.Trace.SpanID
 
@@ -216,14 +213,12 @@ func TestFunctionFailureWithRetries(t *testing.T) {
 				assert.Equal(t, 2, len(span.ChildSpans))
 				assert.Equal(t, 2, span.Attempts)
 				assert.Equal(t, models.RunTraceSpanStatusFailed.String(), span.Status)
-				// assert.NotNil(t, span.OutputID)
+				assert.NotNil(t, span.OutputID)
 
 				// output test
-				// output := c.RunTraceSpanOutput(*failed.OutputID)
-				// assert.NotNil(t, output)
-				// assert.Nil(t, output.Data)
-				// assert.NotNil(t, output.StepError)
-				// assert.Contains(t, *output.StepError.Stack, "nope!")
+				output := c.RunSpanOutput(ctx, *span.OutputID)
+				assert.NotNil(t, output)
+				c.ExpectSpanErrorOutput(t, "", "nope!", output)
 
 				t.Run("attempt 1", func(t *testing.T) {
 					one := span.ChildSpans[0]
@@ -232,14 +227,11 @@ func TestFunctionFailureWithRetries(t *testing.T) {
 					assert.Equal(t, rootSpanID, one.ParentSpanID)
 					assert.Equal(t, 1, one.Attempts)
 					assert.Equal(t, models.RunTraceSpanStatusFailed.String(), one.Status)
-					// assert.NotNil(t, span.OutputID)
+					assert.NotNil(t, one.OutputID)
 
 					// output test
-					// output := c.RunTraceSpanOutput(*failed.OutputID)
-					// assert.NotNil(t, output)
-					// assert.Nil(t, output.Data)
-					// assert.NotNil(t, output.StepError)
-					// assert.Contains(t, *output.StepError.Stack, "nope!")
+					oneOutput := c.RunSpanOutput(ctx, *one.OutputID)
+					c.ExpectSpanErrorOutput(t, "", "nope!", oneOutput)
 				})
 
 				// second attempt
@@ -250,14 +242,11 @@ func TestFunctionFailureWithRetries(t *testing.T) {
 					assert.Equal(t, rootSpanID, two.ParentSpanID)
 					assert.Equal(t, 2, two.Attempts)
 					assert.Equal(t, models.RunTraceSpanStatusFailed.String(), two.Status)
-					// assert.NotNil(t, span.OutputID)
+					assert.NotNil(t, two.OutputID)
 
 					// output test
-					// output := c.RunTraceSpanOutput(*failed.OutputID)
-					// assert.NotNil(t, output)
-					// assert.Nil(t, output.Data)
-					// assert.NotNil(t, output.StepError)
-					// assert.Contains(t, *output.StepError.Stack, "nope!")
+					twoOutput := c.RunSpanOutput(ctx, *two.OutputID)
+					c.ExpectSpanErrorOutput(t, "", "nope!", twoOutput)
 				})
 			})
 

--- a/tests/golang/throttle_test.go
+++ b/tests/golang/throttle_test.go
@@ -61,7 +61,11 @@ func TestThrottle(t *testing.T) {
 
 		// Ensure that each function finishes after 3 seconds.
 		for i := 1; i <= funcs; i++ {
-			require.EqualValues(t, i, total)
+			require.Eventually(t, func() bool {
+				require.EqualValues(t, i, total)
+
+				return true
+			}, 2*time.Second, 500*time.Millisecond)
 			<-time.After(5 * time.Second)
 		}
 	})

--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -93,10 +93,10 @@ func TestWait(t *testing.T) {
 			})
 
 			return true
-		}, 4*time.Second, 1*time.Second)
+		}, 6*time.Second, 2*time.Second)
 	})
 
-	<-time.After(3 * time.Second)
+	<-time.After(6 * time.Second)
 	// Trigger the main function
 	_, err = inngestgo.Send(ctx, &event.Event{Name: waitEvtName})
 	r.NoError(err)

--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -48,7 +48,7 @@ func TestWait(t *testing.T) {
 				},
 			)
 
-			return nil, nil
+			return "DONE", nil
 		},
 	)
 
@@ -68,6 +68,7 @@ func TestWait(t *testing.T) {
 			require.NotNil(t, run.Trace)
 			require.Equal(t, 1, len(run.Trace.ChildSpans))
 			require.Equal(t, models.RunTraceSpanStatusRunning.String(), run.Trace.Status)
+			require.Nil(t, run.Trace.OutputID)
 
 			rootSpanID := run.Trace.SpanID
 
@@ -79,6 +80,7 @@ func TestWait(t *testing.T) {
 				assert.False(t, span.IsRoot)
 				assert.Equal(t, models.RunTraceSpanStatusWaiting.String(), span.Status)
 				assert.Equal(t, models.StepOpWaitForEvent.String(), span.StepOp)
+				assert.Nil(t, span.OutputID)
 
 				var stepInfo models.WaitForEventStepInfo
 				byt, err := json.Marshal(span.StepInfo)
@@ -100,7 +102,7 @@ func TestWait(t *testing.T) {
 	r.NoError(err)
 
 	t.Run("trace run should have appropriate data", func(t *testing.T) {
-		<-time.After(3 * time.Second)
+		<-time.After(5 * time.Second)
 
 		require.Eventually(t, func() bool {
 			run := c.RunTraces(ctx, runID)
@@ -110,8 +112,12 @@ func TestWait(t *testing.T) {
 			require.Equal(t, 1, len(run.Trace.ChildSpans))
 			require.Equal(t, models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
 
+			// output test
+			require.NotNil(t, run.Trace.OutputID)
+			output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+			c.ExpectSpanOutput(t, "DONE", output)
+
 			rootSpanID := run.Trace.SpanID
-			// TODO: output test
 
 			t.Run("wait step", func(t *testing.T) {
 				span := run.Trace.ChildSpans[0]
@@ -122,7 +128,10 @@ func TestWait(t *testing.T) {
 				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), span.Status)
 				assert.Equal(t, models.StepOpWaitForEvent.String(), span.StepOp)
 
-				// TODO: output test
+				// output test
+				assert.NotNil(t, span.OutputID)
+				spanOutput := c.RunSpanOutput(ctx, *span.OutputID)
+				c.ExpectSpanOutput(t, "resume", spanOutput)
 
 				var stepInfo models.WaitForEventStepInfo
 				byt, err := json.Marshal(span.StepInfo)


### PR DESCRIPTION
## Description

Add APIs for 
1. retrieving the run span outputs, for both success and error.
2. retrieving the run's trigger

Add more integration tests to verify behavior.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
