### PR TITLE
INN-3150 Add All to Status Filter

### DIFF
--- a/ui/packages/components/src/Filter/StatusFilter.tsx
+++ b/ui/packages/components/src/Filter/StatusFilter.tsx
@@ -22,6 +22,9 @@ export default function StatusFilter({ selectedStatuses, onStatusesChange }: Sta
   const selectedValues = options.filter((option) =>
     selectedStatuses.some((status) => isFunctionRunStatus(status) && status === option.id)
   );
+  const areAllStatusesSelected = functionRunStatuses.every((status) =>
+    selectedStatuses.includes(status)
+  );
   const statusDots = selectedStatuses.map((status) => {
     const isSelected = selectedStatuses.includes(status);
     return (
@@ -54,7 +57,14 @@ export default function StatusFilter({ selectedStatuses, onStatusesChange }: Sta
       label="Status"
     >
       <Select.Button>
-        {selectedStatuses.length > 0 && <span className="pr-2">{statusDots}</span>}
+        <div className="w-8">
+          {selectedStatuses.length > 0 && !areAllStatusesSelected && (
+            <span className="pr-2">{statusDots}</span>
+          )}
+          {(selectedStatuses.length === 0 || areAllStatusesSelected) && (
+            <span className="pr-2">All</span>
+          )}
+        </div>
       </Select.Button>
       <Select.Options>
         {options.map((option) => {

--- a/ui/packages/components/src/Filter/StatusFilter.tsx
+++ b/ui/packages/components/src/Filter/StatusFilter.tsx
@@ -55,8 +55,9 @@ export default function StatusFilter({ selectedStatuses, onStatusesChange }: Sta
         onStatusesChange(newValue);
       }}
       label="Status"
+      isLabelVisible
     >
-      <Select.Button>
+      <Select.Button isLabelVisible>
         <div className="w-7 text-left">
           {selectedStatuses.length > 0 && !areAllStatusesSelected && <span>{statusDots}</span>}
           {(selectedStatuses.length === 0 || areAllStatusesSelected) && <span>All</span>}

--- a/ui/packages/components/src/Filter/StatusFilter.tsx
+++ b/ui/packages/components/src/Filter/StatusFilter.tsx
@@ -57,13 +57,9 @@ export default function StatusFilter({ selectedStatuses, onStatusesChange }: Sta
       label="Status"
     >
       <Select.Button>
-        <div className="w-8">
-          {selectedStatuses.length > 0 && !areAllStatusesSelected && (
-            <span className="pr-2">{statusDots}</span>
-          )}
-          {(selectedStatuses.length === 0 || areAllStatusesSelected) && (
-            <span className="pr-2">All</span>
-          )}
+        <div className="w-7 text-left">
+          {selectedStatuses.length > 0 && !areAllStatusesSelected && <span>{statusDots}</span>}
+          {(selectedStatuses.length === 0 || areAllStatusesSelected) && <span>All</span>}
         </div>
       </Select.Button>
       <Select.Options>

--- a/ui/packages/components/src/Select/Select.tsx
+++ b/ui/packages/components/src/Select/Select.tsx
@@ -44,7 +44,7 @@ export function Select({
     <Listbox value={defaultValue} onChange={onChange} multiple={multiple}>
       <span
         className={cn(
-          isLabelVisible && 'divide-muted divide-x',
+          isLabelVisible && 'divide-muted bg-canvasSubtle divide-x',
           'border-muted flex items-center rounded-md border text-sm',
           className
         )}


### PR DESCRIPTION
## Description
- Make the Status filter display an "All" tag when all filters/no filters are selected.

![Screenshot 2024-06-18 at 19 35 48](https://github.com/inngest/inngest/assets/16758464/85ef0831-ceea-42eb-8325-78f1f5f9f2f4)
![Screenshot 2024-06-18 at 19 35 17](https://github.com/inngest/inngest/assets/16758464/fa123d32-adfd-469e-93a4-a0d7c405c848)



## Motivation
This increases the clickable area in the status filter select

## Type of change (choose one)
- [X] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
