### PR TITLE
Add Maze snippet to in-app layout

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/layout.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/layout.tsx
@@ -12,6 +12,31 @@ export default function OrganizationActiveLayout({ children }: OrganizationActiv
     <URQLProvider>
       <IncidentBanner />
       {children}
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
+            (function (m, a, z, e) {
+              var s, t;
+              try {
+                t = m.sessionStorage.getItem('maze-us');
+              } catch (err) {}
+
+              if (!t) {
+                t = new Date().getTime();
+                try {
+                  m.sessionStorage.setItem('maze-us', t);
+                } catch (err) {}
+              }
+
+              s = a.createElement('script');
+              s.src = z + '?apiKey=' + e;
+              s.async = true;
+              a.getElementsByTagName('head')[0].appendChild(s);
+              m.mazeUniversalSnippetApiKey = e;
+            })(window, document, 'https://snippet.maze.co/maze-universal-loader.js', 'ca524e7a-1966-427b-9289-c48994e3b9df');
+          `,
+        }}
+      ></script>
     </URQLProvider>
   );
 }


### PR DESCRIPTION
## Description

Adds the snippet. I decided to try it in the end of the page despite the [Maze docs](https://help.maze.co/hc/en-us/articles/9800356063891-Installing-the-Maze-snippet-on-your-website) recommending `<head>` to avoid any potential blocking code that might run.

## Motivation
Help get in-app feedback with for the Runs + Traces beta.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
