### PR TITLE
Run tree tweaks

### DIFF
--- a/pkg/consts/otel.go
+++ b/pkg/consts/otel.go
@@ -70,11 +70,8 @@ const (
 	OtelSysStepInvokeRunID             = "sys.step.invoke.run.id"
 	OtelSysStepInvokeExpired           = "sys.step.invoke.expired"
 
-	OtelSysStepRetry         = "sys.step.retry"
-	OtelSysStepNextOpcode    = "sys.step.next.opcode"
-	OtelSysStepNextTimestamp = "sys.step.next.time"
-	OtelSysStepNextExpires   = "sys.step.next.expires"
-	OtelSysStepDelete        = "sys.step.delete"
+	OtelSysStepRetry  = "sys.step.retry"
+	OtelSysStepDelete = "sys.step.delete"
 
 	OtelSysCronTimestamp = "sys.cron.timestamp"
 	OtelSysCronExpr      = "sys.cron.expr"

--- a/pkg/consts/otel.go
+++ b/pkg/consts/otel.go
@@ -106,4 +106,9 @@ const (
 
 	OtelPropagationKey     = "sys.trace"
 	OtelPropagationLinkKey = "sys.trace.link"
+
+	// execution copies
+	OtelExecPlaceholder = "execute"
+	OtelExecFnOk        = "function success"
+	OtelExecFnErr       = "function error"
 )

--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/graph-gophers/dataloader"
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/run"
@@ -121,8 +122,9 @@ func (tr *traceReader) GetRunTrace(ctx context.Context, keys dataloader.Keys) []
 }
 
 func convertRunTreeToGQLModel(pb *rpbv2.RunSpan) (*models.RunTraceSpan, error) {
-	// no need to show the function success span
-	if pb.GetName() == "function success" && pb.GetStatus() == rpbv2.SpanStatus_COMPLETED {
+	// no need to show the function success span, if it's the only one and has no children
+	// meaning, there were no function level retries
+	if pb.GetName() == consts.OtelExecFnOk && pb.GetStatus() == rpbv2.SpanStatus_COMPLETED && len(pb.GetChildren()) < 1 {
 		return nil, ErrSkipSuccess
 	}
 

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -130,6 +130,8 @@ func (s *Span) StepOpCode() enums.Opcode {
 			return enums.OpcodeInvokeFunction
 		case enums.OpcodeWaitForEvent.String():
 			return enums.OpcodeWaitForEvent
+		case enums.OpcodeStepPlanned.String():
+			return enums.OpcodeStepPlanned
 		}
 	}
 

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -148,6 +148,7 @@ type InngestMetadata struct {
 	InvokeCorrelationId string                  `json:"correlation_id,omitempty"`
 	InvokeTraceCarrier  *telemetry.TraceCarrier `json:"tc,omitempty"`
 	InvokeExpiresAt     int64                   `json:"expire"`
+	InvokeGroupID       string                  `json:"gid"`
 	InvokeDisplayName   string                  `json:"name"`
 }
 
@@ -246,6 +247,7 @@ type NewInvocationEventOpts struct {
 	CorrelationID   *string
 	TraceCarrier    *telemetry.TraceCarrier
 	ExpiresAt       int64
+	GroupID         string
 	DisplayName     string
 }
 
@@ -273,6 +275,7 @@ func NewInvocationEvent(opts NewInvocationEventOpts) Event {
 		InvokeCorrelationId: correlationID,
 		InvokeTraceCarrier:  opts.TraceCarrier,
 		InvokeExpiresAt:     opts.ExpiresAt,
+		InvokeGroupID:       opts.GroupID,
 		InvokeDisplayName:   opts.DisplayName,
 		SourceAppID:         opts.SourceAppID,
 		SourceFnID:          opts.SourceFnID,

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -148,7 +148,6 @@ type InngestMetadata struct {
 	InvokeCorrelationId string                  `json:"correlation_id,omitempty"`
 	InvokeTraceCarrier  *telemetry.TraceCarrier `json:"tc,omitempty"`
 	InvokeExpiresAt     int64                   `json:"expire"`
-	InvokeGroupID       string                  `json:"gid"`
 	InvokeDisplayName   string                  `json:"name"`
 }
 
@@ -247,7 +246,6 @@ type NewInvocationEventOpts struct {
 	CorrelationID   *string
 	TraceCarrier    *telemetry.TraceCarrier
 	ExpiresAt       int64
-	GroupID         string
 	DisplayName     string
 }
 
@@ -275,7 +273,6 @@ func NewInvocationEvent(opts NewInvocationEventOpts) Event {
 		InvokeCorrelationId: correlationID,
 		InvokeTraceCarrier:  opts.TraceCarrier,
 		InvokeExpiresAt:     opts.ExpiresAt,
-		InvokeGroupID:       opts.GroupID,
 		InvokeDisplayName:   opts.DisplayName,
 		SourceAppID:         opts.SourceAppID,
 		SourceFnID:          opts.SourceFnID,

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -889,7 +889,7 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 
 	ctx, span := telemetry.NewSpan(ctx,
 		telemetry.WithScope(consts.OtelScopeExecution),
-		telemetry.WithName("execute"),
+		telemetry.WithName(consts.OtelExecPlaceholder),
 		telemetry.WithSpanAttributes(
 			attribute.Bool(consts.OtelUserTraceFilterKey, true),
 			attribute.String(consts.OtelSysAccountID, id.AccountID.String()),
@@ -1033,13 +1033,13 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			)
 			span.SetStepOutput(resp.Output)
 		} else if resp.IsTraceVisibleFunctionExecution() {
-			spanName := "function success"
+			spanName := consts.OtelExecFnOk
 			fnstatus := attribute.Int64(consts.OtelSysFunctionStatusCode, enums.RunStatusCompleted.ToCode())
 			fnSpan.SetStatus(codes.Ok, "success")
 			span.SetStatus(codes.Ok, "success")
 
 			if resp.StatusCode != 200 {
-				spanName = "function error"
+				spanName = consts.OtelExecFnErr
 				fnstatus = attribute.Int64(consts.OtelSysFunctionStatusCode, enums.RunStatusFailed.ToCode())
 				fnSpan.SetStatus(codes.Error, resp.Error())
 				span.SetStatus(codes.Error, resp.Error())

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2482,7 +2482,6 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, i *runInst
 			attribute.Int(consts.OtelSysStepMaxAttempt, 1), // ?
 			attribute.String(consts.OtelSysStepOpcode, enums.OpcodeInvokeFunction.String()),
 			attribute.String(consts.OtelSysStepDisplayName, gen.UserDefinedName()),
-
 			attribute.String(consts.OtelSysStepInvokeTargetFnID, opts.FunctionID),
 			attribute.Int64(consts.OtelSysStepInvokeExpires, expires.UnixMilli()),
 			attribute.String(consts.OtelSysStepInvokeTriggeringEventID, evt.ID),

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -900,6 +900,7 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			attribute.Int(consts.OtelSysStepAttempt, item.Attempt),
 			attribute.Int(consts.OtelSysStepMaxAttempt, item.GetMaxAttempts()),
 			attribute.String(consts.OtelSysStepGroupID, item.GroupID),
+			attribute.String(consts.OtelSysStepOpcode, enums.OpcodeStepPlanned.String()),
 		),
 	)
 	if item.RunInfo != nil {
@@ -1023,9 +1024,10 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 				span.SetStepOutput(op.Data)
 				span.SetStatus(codes.Ok, string(op.Data))
 			}
-		} else if resp.Retryable() {
+		} else if resp.Retryable() { // these are function retries
 			span.SetStatus(codes.Error, *resp.Err)
 			span.SetAttributes(
+				attribute.String(consts.OtelSysStepOpcode, enums.OpcodeNone.String()),
 				attribute.Int(consts.OtelSysStepStatusCode, resp.StatusCode),
 				attribute.Int(consts.OtelSysStepOutputSizeBytes, resp.OutputSize),
 			)
@@ -1044,6 +1046,7 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			}
 
 			fnSpan.SetAttributes(fnstatus)
+			span.SetAttributes(attribute.String(consts.OtelSysStepOpcode, enums.OpcodeNone.String()))
 			span.SetName(spanName)
 			fnSpan.SetFnOutput(resp.Output)
 			span.SetFnOutput(resp.Output)
@@ -2319,6 +2322,7 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, i *runInstanc
 		return nil
 	}
 	span.SetAttributes(
+		attribute.String(consts.OtelSysStepOpcode, enums.OpcodeStepPlanned.String()),
 		attribute.String(consts.OtelSysStepNextOpcode, enums.OpcodeStepPlanned.String()),
 		attribute.Int64(consts.OtelSysStepNextTimestamp, now.UnixMilli()),
 	)

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -707,8 +707,10 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 								attribute.String(consts.OtelAttrSDKRunID, mrunID.String()),
 								attribute.Int(consts.OtelSysStepAttempt, 0),    // ?
 								attribute.Int(consts.OtelSysStepMaxAttempt, 1), // ?
+								attribute.String(consts.OtelSysStepGroupID, meta.InvokeGroupID),
 								attribute.String(consts.OtelSysStepOpcode, enums.OpcodeInvokeFunction.String()),
 								attribute.String(consts.OtelSysStepDisplayName, meta.InvokeDisplayName),
+
 								attribute.String(consts.OtelSysStepInvokeTargetFnID, req.Function.ID.String()),
 								attribute.Int64(consts.OtelSysStepInvokeExpires, meta.InvokeExpiresAt),
 								attribute.String(consts.OtelSysStepInvokeTriggeringEventID, evt.ID),
@@ -1903,6 +1905,7 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 		attribute.String(consts.OtelAttrSDKRunID, pause.Identifier.RunID.String()),
 		attribute.Int(consts.OtelSysStepAttempt, 0),    // ?
 		attribute.Int(consts.OtelSysStepMaxAttempt, 1), // ?
+		attribute.String(consts.OtelSysStepGroupID, pause.GroupID),
 		attribute.String(consts.OtelSysStepDisplayName, pause.StepName),
 	}
 
@@ -2365,6 +2368,7 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, i *runInstance, gen
 			attribute.String(consts.OtelAttrSDKRunID, i.item.Identifier.RunID.String()),
 			attribute.Int(consts.OtelSysStepAttempt, 0),    // ?
 			attribute.Int(consts.OtelSysStepMaxAttempt, 1), // ?
+			attribute.String(consts.OtelSysStepGroupID, i.item.GroupID),
 			attribute.String(consts.OtelSysStepOpcode, enums.OpcodeSleep.String()),
 			attribute.String(consts.OtelSysStepDisplayName, gen.UserDefinedName()),
 			attribute.Int64(consts.OtelSysStepSleepEndAt, until.UnixMilli()),
@@ -2458,6 +2462,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, i *runInst
 		CorrelationID:   &correlationID,
 		TraceCarrier:    carrier,
 		ExpiresAt:       expires.UnixMilli(),
+		GroupID:         i.item.GroupID,
 		DisplayName:     gen.UserDefinedName(),
 		SourceAppID:     i.item.Identifier.AppID.String(),
 		SourceFnID:      i.item.Identifier.WorkflowID.String(),
@@ -2480,6 +2485,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, i *runInst
 			attribute.String(consts.OtelAttrSDKRunID, i.item.Identifier.RunID.String()),
 			attribute.Int(consts.OtelSysStepAttempt, 0),    // ?
 			attribute.Int(consts.OtelSysStepMaxAttempt, 1), // ?
+			attribute.String(consts.OtelSysStepGroupID, i.item.GroupID),
 			attribute.String(consts.OtelSysStepOpcode, enums.OpcodeInvokeFunction.String()),
 			attribute.String(consts.OtelSysStepDisplayName, gen.UserDefinedName()),
 			attribute.String(consts.OtelSysStepInvokeTargetFnID, opts.FunctionID),
@@ -2642,6 +2648,7 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, i *runInstan
 			attribute.String(consts.OtelAttrSDKRunID, i.item.Identifier.RunID.String()),
 			attribute.Int(consts.OtelSysStepAttempt, 0),
 			attribute.Int(consts.OtelSysStepMaxAttempt, 1),
+			attribute.String(consts.OtelSysStepGroupID, i.item.GroupID),
 			attribute.String(consts.OtelSysStepWaitEventName, opts.Event),
 			attribute.Int64(consts.OtelSysStepWaitExpires, expires.UnixMilli()),
 			attribute.String(consts.OtelSysStepDisplayName, gen.UserDefinedName()),

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2364,7 +2364,6 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, i *runInstance, gen
 			attribute.String(consts.OtelAttrSDKRunID, i.item.Identifier.RunID.String()),
 			attribute.Int(consts.OtelSysStepAttempt, 0),    // ?
 			attribute.Int(consts.OtelSysStepMaxAttempt, 1), // ?
-			attribute.String(consts.OtelSysStepGroupID, i.item.GroupID),
 			attribute.String(consts.OtelSysStepOpcode, enums.OpcodeSleep.String()),
 			attribute.String(consts.OtelSysStepDisplayName, gen.UserDefinedName()),
 			attribute.Int64(consts.OtelSysStepSleepEndAt, until.UnixMilli()),

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2480,7 +2480,6 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, i *runInst
 			attribute.String(consts.OtelAttrSDKRunID, i.item.Identifier.RunID.String()),
 			attribute.Int(consts.OtelSysStepAttempt, 0),    // ?
 			attribute.Int(consts.OtelSysStepMaxAttempt, 1), // ?
-			attribute.String(consts.OtelSysStepGroupID, i.item.GroupID),
 			attribute.String(consts.OtelSysStepOpcode, enums.OpcodeInvokeFunction.String()),
 			attribute.String(consts.OtelSysStepDisplayName, gen.UserDefinedName()),
 
@@ -2644,7 +2643,6 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, i *runInstan
 			attribute.String(consts.OtelAttrSDKRunID, i.item.Identifier.RunID.String()),
 			attribute.Int(consts.OtelSysStepAttempt, 0),
 			attribute.Int(consts.OtelSysStepMaxAttempt, 1),
-			// attribute.String(consts.OtelSysStepGroupID, i.item.GroupID),
 			attribute.String(consts.OtelSysStepWaitEventName, opts.Event),
 			attribute.Int64(consts.OtelSysStepWaitExpires, expires.UnixMilli()),
 			attribute.String(consts.OtelSysStepDisplayName, gen.UserDefinedName()),

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2644,7 +2644,7 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, i *runInstan
 			attribute.String(consts.OtelAttrSDKRunID, i.item.Identifier.RunID.String()),
 			attribute.Int(consts.OtelSysStepAttempt, 0),
 			attribute.Int(consts.OtelSysStepMaxAttempt, 1),
-			attribute.String(consts.OtelSysStepGroupID, i.item.GroupID),
+			// attribute.String(consts.OtelSysStepGroupID, i.item.GroupID),
 			attribute.String(consts.OtelSysStepWaitEventName, opts.Event),
 			attribute.Int64(consts.OtelSysStepWaitExpires, expires.UnixMilli()),
 			attribute.String(consts.OtelSysStepDisplayName, gen.UserDefinedName()),

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -707,10 +707,8 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 								attribute.String(consts.OtelAttrSDKRunID, mrunID.String()),
 								attribute.Int(consts.OtelSysStepAttempt, 0),    // ?
 								attribute.Int(consts.OtelSysStepMaxAttempt, 1), // ?
-								attribute.String(consts.OtelSysStepGroupID, meta.InvokeGroupID),
 								attribute.String(consts.OtelSysStepOpcode, enums.OpcodeInvokeFunction.String()),
 								attribute.String(consts.OtelSysStepDisplayName, meta.InvokeDisplayName),
-
 								attribute.String(consts.OtelSysStepInvokeTargetFnID, req.Function.ID.String()),
 								attribute.Int64(consts.OtelSysStepInvokeExpires, meta.InvokeExpiresAt),
 								attribute.String(consts.OtelSysStepInvokeTriggeringEventID, evt.ID),
@@ -1902,7 +1900,6 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 		attribute.String(consts.OtelAttrSDKRunID, pause.Identifier.RunID.String()),
 		attribute.Int(consts.OtelSysStepAttempt, 0),    // ?
 		attribute.Int(consts.OtelSysStepMaxAttempt, 1), // ?
-		attribute.String(consts.OtelSysStepGroupID, pause.GroupID),
 		attribute.String(consts.OtelSysStepDisplayName, pause.StepName),
 	}
 
@@ -2457,7 +2454,6 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, i *runInst
 		CorrelationID:   &correlationID,
 		TraceCarrier:    carrier,
 		ExpiresAt:       expires.UnixMilli(),
-		GroupID:         i.item.GroupID,
 		DisplayName:     gen.UserDefinedName(),
 		SourceAppID:     i.item.Identifier.AppID.String(),
 		SourceFnID:      i.item.Identifier.WorkflowID.String(),

--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -744,8 +744,8 @@ func (tb *runTree) processExec(ctx context.Context, span *cqrs.Span, mod *rpbv2.
 			WorkspaceID: tb.wsID,
 			AppID:       tb.appID,
 			FunctionID:  tb.fnID,
-			TraceID:     span.TraceID,
-			SpanID:      span.SpanID,
+			TraceID:     nested.TraceId,
+			SpanID:      nested.SpanId,
 		}
 		outputID, err := ident.Encode()
 		if err != nil {
@@ -774,6 +774,10 @@ func (tb *runTree) processExec(ctx context.Context, span *cqrs.Span, mod *rpbv2.
 			case rpbv2.SpanStatus_COMPLETED:
 				mod.Status = rpbv2.SpanStatus_COMPLETED
 				mod.OutputId = &outputID
+
+				if p.SpanName == consts.OtelExecFnOk {
+					mod.Name = consts.OtelExecFnOk
+				}
 			case rpbv2.SpanStatus_FAILED:
 				// check if this failure is the final failure of all attempts
 				if attempt == maxAttempts {
@@ -781,10 +785,6 @@ func (tb *runTree) processExec(ctx context.Context, span *cqrs.Span, mod *rpbv2.
 					mod.Attempts = maxAttempts
 					mod.OutputId = &outputID
 				}
-			}
-
-			if p.SpanName == consts.OtelExecFnOk && status == rpbv2.SpanStatus_COMPLETED {
-				mod.Name = consts.OtelExecFnOk
 			}
 
 			// if the name is `function error`, it's already finished

--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -467,6 +467,12 @@ func (tb *runTree) processStepRunGroup(ctx context.Context, span *cqrs.Span, mod
 		tb.processed[p.SpanID] = true
 	}
 
+	// check if the nested span is the same one, if so discard it
+	if len(mod.Children) == 1 && span.SpanID == mod.Children[0].SpanId {
+		mod.SpanId = span.SpanID // reset the spanID
+		mod.Children = nil
+	}
+
 	return nil
 }
 
@@ -1088,6 +1094,12 @@ func (tb *runTree) processExecGroup(ctx context.Context, span *cqrs.Span, mod *r
 
 		mod.Children = append(mod.Children, nested)
 		tb.markProcessed(p)
+	}
+
+	// check if the nested span is the same one, if so discard it
+	if len(mod.Children) == 1 && span.SpanID == mod.Children[0].SpanId {
+		mod.SpanId = span.SpanID // reset the spanID
+		mod.Children = nil
 	}
 
 	return nil

--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -209,6 +209,8 @@ func (tb *runTree) toRunSpan(ctx context.Context, s *cqrs.Span) (*rpbv2.RunSpan,
 			if err := tb.processInvokeGroup(ctx, s, res); err != nil {
 				return nil, false, fmt.Errorf("error parsing invoke span: %w", err)
 			}
+		case enums.OpcodeStepPlanned: // don't bother
+			return nil, true, nil
 		default:
 			// execution spans
 			if s.ScopeName == consts.OtelScopeExecution {

--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -239,6 +239,9 @@ func (tb *runTree) toRunSpan(ctx context.Context, s *cqrs.Span) (*rpbv2.RunSpan,
 			}
 		case enums.OpcodeWaitForEvent:
 			if err := tb.processWaitForEventGroup(ctx, s, res); err != nil {
+				if err == ErrRedundantExecSpan {
+					return nil, true, nil // no-op
+				}
 				return nil, false, fmt.Errorf("error grouping waitForEvent: %w", err)
 			}
 		case enums.OpcodeInvokeFunction:

--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -113,12 +113,6 @@ func NewRunTree(opts RunTreeOpts) (*runTree, error) {
 		}
 	}
 
-	// for _, s := range opts.Spans {
-	// 	if s.ParentSpanID != nil {
-	// 		fmt.Printf("Span - Name: %s, Scope: %s, Op: %s, ID: %s, Parent: %s, Child: %d, TS: %d\n    %#v\n\n", s.SpanName, s.ScopeName, s.StepOpCode().String(), s.SpanID, *s.ParentSpanID, len(s.Children), s.Timestamp.UnixMilli(), s.SpanAttributes)
-	// 	}
-	// }
-
 	// sort it
 	for _, g := range b.groups {
 		if len(g) > 1 {

--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -388,7 +388,6 @@ func (tb *runTree) processStepRunGroup(ctx context.Context, span *cqrs.Span, mod
 			return err
 		}
 
-		nested.Name = fmt.Sprintf("Attempt %d", attempt)
 		nested.StepOp = &stepOp
 		nested.Attempts = attempt
 		nested.Status = status
@@ -400,6 +399,7 @@ func (tb *runTree) processStepRunGroup(ctx context.Context, span *cqrs.Span, mod
 		// last one
 		// update end time and status of the group as well
 		if i == len(peers)-1 {
+			mod.Name = nested.Name
 			mod.Attempts = attempt
 
 			switch status {
@@ -422,7 +422,7 @@ func (tb *runTree) processStepRunGroup(ctx context.Context, span *cqrs.Span, mod
 				mod.DurationMs = int64(dur / time.Millisecond)
 			}
 		}
-
+		nested.Name = fmt.Sprintf("Attempt %d", attempt)
 		mod.Children = append(mod.Children, nested)
 		tb.processed[p.SpanID] = true
 	}

--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -244,11 +244,6 @@ func (tb *runTree) toRunSpan(ctx context.Context, s *cqrs.Span) (*rpbv2.RunSpan,
 				return nil, false, fmt.Errorf("error grouping sleeps: %w", err)
 			}
 		case enums.OpcodeWaitForEvent:
-			fmt.Println("IN WAIT")
-			for _, gs := range group {
-				fmt.Printf("Attr: %s\n  %#v\n", gs.SpanName, gs.SpanAttributes)
-			}
-
 			if err := tb.processWaitForEventGroup(ctx, s, res); err != nil {
 				return nil, false, fmt.Errorf("error grouping waitForEvent: %w", err)
 			}
@@ -752,6 +747,7 @@ func (tb *runTree) processWaitForEvent(ctx context.Context, span *cqrs.Span, mod
 	}
 
 	// output
+	var outputID *string
 	if foundEvtID != nil && mod.Status == rpbv2.SpanStatus_COMPLETED {
 		ident := &cqrs.SpanIdentifier{
 			AccountID:   tb.acctID,
@@ -765,8 +761,9 @@ func (tb *runTree) processWaitForEvent(ctx context.Context, span *cqrs.Span, mod
 		if err != nil {
 			return err
 		}
-		mod.OutputId = &id
+		outputID = &id
 	}
+	mod.OutputId = outputID
 
 	return nil
 }

--- a/tests/golang/basic_step_test.go
+++ b/tests/golang/basic_step_test.go
@@ -179,7 +179,7 @@ func TestFunctionSteps(t *testing.T) {
 			t.Run("step 1", func(t *testing.T) {
 				one := run.Trace.ChildSpans[0]
 				assert.Equal(t, "1", one.Name)
-				assert.Equal(t, 1, one.Attempts)
+				assert.Equal(t, 0, one.Attempts)
 				assert.False(t, one.IsRoot)
 				assert.Equal(t, rootSpanID, one.ParentSpanID)
 				assert.Equal(t, models.StepOpRun.String(), one.StepOp)
@@ -193,7 +193,7 @@ func TestFunctionSteps(t *testing.T) {
 			t.Run("step 2", func(t *testing.T) {
 				sec := run.Trace.ChildSpans[1]
 				assert.Equal(t, "2", sec.Name)
-				assert.Equal(t, 1, sec.Attempts)
+				assert.Equal(t, 0, sec.Attempts)
 				assert.False(t, sec.IsRoot)
 				assert.Equal(t, rootSpanID, sec.ParentSpanID)
 				assert.Equal(t, models.StepOpRun.String(), sec.StepOp)

--- a/tests/golang/failure_test.go
+++ b/tests/golang/failure_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/tests/client"
 	"github.com/inngest/inngestgo"
@@ -81,7 +82,7 @@ func TestFunctionFailure(t *testing.T) {
 
 			t.Run("failed run", func(t *testing.T) {
 				span := run.Trace.ChildSpans[0]
-				assert.Equal(t, "function error", span.Name)
+				assert.Equal(t, consts.OtelExecFnErr, span.Name)
 				assert.False(t, span.IsRoot)
 				assert.Equal(t, rootSpanID, span.ParentSpanID)
 				assert.Equal(t, models.RunTraceSpanStatusFailed.String(), span.Status)
@@ -207,7 +208,7 @@ func TestFunctionFailureWithRetries(t *testing.T) {
 			// first attempt
 			t.Run("failed run", func(t *testing.T) {
 				span := run.Trace.ChildSpans[0]
-				assert.Equal(t, "execute", span.Name)
+				assert.Equal(t, consts.OtelExecPlaceholder, span.Name)
 				assert.False(t, span.IsRoot)
 				assert.Equal(t, rootSpanID, span.ParentSpanID)
 				assert.Equal(t, 2, len(span.ChildSpans))

--- a/tests/golang/failure_test.go
+++ b/tests/golang/failure_test.go
@@ -171,7 +171,7 @@ func TestFunctionFailureWithRetries(t *testing.T) {
 
 				t.Run("failed", func(t *testing.T) {
 					failed := span.ChildSpans[0]
-					assert.Equal(t, "Attempt 1", failed.Name)
+					assert.Equal(t, "Attempt 0", failed.Name)
 					assert.False(t, span.IsRoot)
 					assert.Equal(t, models.RunTraceSpanStatusFailed.String(), failed.Status)
 
@@ -221,12 +221,12 @@ func TestFunctionFailureWithRetries(t *testing.T) {
 				assert.NotNil(t, output)
 				c.ExpectSpanErrorOutput(t, "", "nope!", output)
 
-				t.Run("attempt 1", func(t *testing.T) {
+				t.Run("attempt 0", func(t *testing.T) {
 					one := span.ChildSpans[0]
-					assert.Equal(t, "Attempt 1", one.Name)
+					assert.Equal(t, "Attempt 0", one.Name)
 					assert.False(t, one.IsRoot)
 					assert.Equal(t, rootSpanID, one.ParentSpanID)
-					assert.Equal(t, 1, one.Attempts)
+					assert.Equal(t, 0, one.Attempts)
 					assert.Equal(t, models.RunTraceSpanStatusFailed.String(), one.Status)
 					assert.NotNil(t, one.OutputID)
 
@@ -236,12 +236,12 @@ func TestFunctionFailureWithRetries(t *testing.T) {
 				})
 
 				// second attempt
-				t.Run("attempt 2", func(t *testing.T) {
+				t.Run("attempt 1", func(t *testing.T) {
 					two := span.ChildSpans[1]
-					assert.Equal(t, "Attempt 2", two.Name)
+					assert.Equal(t, "Attempt 1", two.Name)
 					assert.False(t, two.IsRoot)
 					assert.Equal(t, rootSpanID, two.ParentSpanID)
-					assert.Equal(t, 2, two.Attempts)
+					assert.Equal(t, 1, two.Attempts)
 					assert.Equal(t, models.RunTraceSpanStatusFailed.String(), two.Status)
 					assert.NotNil(t, two.OutputID)
 

--- a/tests/golang/invoke_test.go
+++ b/tests/golang/invoke_test.go
@@ -91,6 +91,7 @@ func TestInvoke(t *testing.T) {
 				invoke := run.Trace.ChildSpans[0]
 				assert.Equal(t, "invoke", invoke.Name)
 				assert.Equal(t, 0, invoke.Attempts)
+				assert.Equal(t, 0, len(invoke.ChildSpans))
 				assert.False(t, invoke.IsRoot)
 				assert.Equal(t, rootSpanID, invoke.ParentSpanID)
 				assert.Equal(t, models.StepOpInvoke.String(), invoke.StepOp)

--- a/tests/golang/invoke_test.go
+++ b/tests/golang/invoke_test.go
@@ -187,7 +187,7 @@ func TestInvokeGroup(t *testing.T) {
 
 			span := run.Trace.ChildSpans[0]
 			assert.Equal(t, consts.OtelExecPlaceholder, span.Name)
-			assert.Equal(t, 1, span.Attempts)
+			assert.Equal(t, 0, span.Attempts)
 			assert.Equal(t, rootSpanID, span.ParentSpanID)
 			assert.False(t, span.IsRoot)
 			assert.Equal(t, 1, len(span.ChildSpans))
@@ -197,7 +197,7 @@ func TestInvokeGroup(t *testing.T) {
 
 			t.Run("failed", func(t *testing.T) {
 				exec := span.ChildSpans[0]
-				assert.Equal(t, "Attempt 1", exec.Name)
+				assert.Equal(t, "Attempt 0", exec.Name)
 				assert.Equal(t, models.RunTraceSpanStatusFailed.String(), exec.Status)
 				assert.NotNil(t, exec.OutputID)
 

--- a/tests/golang/invoke_test.go
+++ b/tests/golang/invoke_test.go
@@ -211,7 +211,7 @@ func TestInvokeGroup(t *testing.T) {
 	})
 
 	t.Run("trace run should have appropriate data", func(t *testing.T) {
-		<-time.After(5 * time.Second)
+		<-time.After(3 * time.Second)
 
 		require.Eventually(t, func() bool {
 			run := c.RunTraces(ctx, runID)

--- a/tests/golang/invoke_test.go
+++ b/tests/golang/invoke_test.go
@@ -3,9 +3,12 @@ package golang
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/tests/client"
@@ -90,6 +93,149 @@ func TestInvoke(t *testing.T) {
 				assert.Equal(t, 0, invoke.Attempts)
 				assert.False(t, invoke.IsRoot)
 				assert.Equal(t, rootSpanID, invoke.ParentSpanID)
+				assert.Equal(t, models.StepOpInvoke.String(), invoke.StepOp)
+
+				// output test
+				assert.NotNil(t, invoke.OutputID)
+				invokeOutput := c.RunSpanOutput(ctx, *invoke.OutputID)
+				c.ExpectSpanOutput(t, "invoked!", invokeOutput)
+
+				var stepInfo models.InvokeStepInfo
+				byt, err := json.Marshal(invoke.StepInfo)
+				assert.NoError(t, err)
+				assert.NoError(t, json.Unmarshal(byt, &stepInfo))
+
+				assert.False(t, *stepInfo.TimedOut)
+				assert.NotNil(t, stepInfo.ReturnEventID)
+				assert.NotNil(t, stepInfo.RunID)
+			})
+
+			return true
+		}, 10*time.Second, 2*time.Second)
+	})
+}
+
+func TestInvokeGroup(t *testing.T) {
+	ctx := context.Background()
+	r := require.New(t)
+	c := client.New(t)
+
+	appID := "InvokeGroup-" + ulid.MustNew(ulid.Now(), nil).String()
+	h, server, registerFuncs := NewSDKHandler(t, appID)
+	defer server.Close()
+
+	invokedFnName := "invoked-fn"
+	invokedFn := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{
+			Name:    invokedFnName,
+			Retries: inngestgo.IntPtr(0),
+		},
+		inngestgo.EventTrigger("none", nil),
+		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
+			return "invoked!", nil
+		},
+	)
+	var (
+		started int32
+		runID   string
+	)
+
+	// This function will invoke the other function
+	evtName := "invoke-group-me"
+	mainFn := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{
+			Name: "main-fn",
+		},
+		inngestgo.EventTrigger(evtName, nil),
+		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
+			runID = input.InputCtx.RunID
+
+			if atomic.LoadInt32(&started) == 0 {
+				atomic.AddInt32(&started, 1)
+				return nil, inngestgo.RetryAtError(fmt.Errorf("initial error"), time.Now().Add(5*time.Second))
+			}
+
+			_, _ = step.Invoke[any](
+				ctx,
+				"invoke",
+				step.InvokeOpts{FunctionId: appID + "-" + invokedFnName},
+			)
+
+			return "success", nil
+		},
+	)
+
+	h.Register(invokedFn, mainFn)
+	registerFuncs()
+
+	// Trigger the main function and successfully invoke the other function
+	_, err := inngestgo.Send(ctx, &event.Event{Name: evtName})
+	r.NoError(err)
+
+	t.Run("in progress", func(t *testing.T) {
+		<-time.After(3 * time.Second)
+
+		require.Eventually(t, func() bool {
+			run := c.RunTraces(ctx, runID)
+			require.NotNil(t, models.FunctionStatusRunning.String(), run.Status)
+			require.NotNil(t, run.Trace)
+			require.Equal(t, 1, len(run.Trace.ChildSpans))
+			require.Equal(t, models.RunTraceSpanStatusRunning.String(), run.Trace.Status)
+			require.Nil(t, run.Trace.OutputID)
+
+			rootSpanID := run.Trace.SpanID
+
+			span := run.Trace.ChildSpans[0]
+			assert.Equal(t, consts.OtelExecPlaceholder, span.Name)
+			assert.Equal(t, 1, span.Attempts)
+			assert.Equal(t, rootSpanID, span.ParentSpanID)
+			assert.False(t, span.IsRoot)
+			assert.Equal(t, 1, len(span.ChildSpans))
+			assert.Equal(t, models.RunTraceSpanStatusRunning.String(), span.Status)
+			assert.Equal(t, "", span.StepOp)
+			assert.Nil(t, span.OutputID)
+
+			t.Run("failed", func(t *testing.T) {
+				exec := span.ChildSpans[0]
+				assert.Equal(t, "Attempt 1", exec.Name)
+				assert.Equal(t, models.RunTraceSpanStatusFailed.String(), exec.Status)
+				assert.NotNil(t, exec.OutputID)
+
+				execOutput := c.RunSpanOutput(ctx, *exec.OutputID)
+				assert.NotNil(t, execOutput)
+				c.ExpectSpanErrorOutput(t, "", "initial error", execOutput)
+			})
+
+			return true
+		}, 10*time.Second, 2*time.Second)
+	})
+
+	t.Run("trace run should have appropriate data", func(t *testing.T) {
+		<-time.After(5 * time.Second)
+
+		require.Eventually(t, func() bool {
+			run := c.RunTraces(ctx, runID)
+			require.NotNil(t, run)
+			require.Equal(t, models.FunctionStatusCompleted.String(), run.Status)
+			require.NotNil(t, run.Trace)
+			require.Equal(t, 1, len(run.Trace.ChildSpans))
+			require.True(t, run.Trace.IsRoot)
+			require.Equal(t, models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
+
+			// output test
+			require.NotNil(t, run.Trace.OutputID)
+			output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+			c.ExpectSpanOutput(t, "success", output)
+
+			rootSpanID := run.Trace.SpanID
+
+			t.Run("invoke", func(t *testing.T) {
+				invoke := run.Trace.ChildSpans[0]
+				assert.Equal(t, "invoke", invoke.Name)
+				assert.Equal(t, 0, invoke.Attempts)
+				assert.False(t, invoke.IsRoot)
+				assert.Equal(t, rootSpanID, invoke.ParentSpanID)
+				assert.Equal(t, 2, len(invoke.ChildSpans))
 				assert.Equal(t, models.StepOpInvoke.String(), invoke.StepOp)
 
 				// output test

--- a/tests/golang/retry_test.go
+++ b/tests/golang/retry_test.go
@@ -1,0 +1,187 @@
+package golang
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/coreapi/graph/models"
+	"github.com/inngest/inngest/tests/client"
+	"github.com/inngest/inngestgo"
+	"github.com/inngest/inngestgo/step"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetry(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	c := client.New(t)
+	h, server, registerFuncs := NewSDKHandler(t, "retry-test")
+	defer server.Close()
+
+	// Create our function.
+	var (
+		counter     int32
+		stepRetried int32
+		fnRetried   int32
+		runID       string
+	)
+
+	fn := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{Name: "test retry"},
+		inngestgo.EventTrigger("test/executor-retry", nil),
+		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+			if runID == "" {
+				runID = input.InputCtx.RunID
+			}
+
+			_, _ = step.Run(ctx, "Log input, increase counter", func(ctx context.Context) (string, error) {
+				fmt.Println("step called")
+				// If this is the first run, throw an error.
+				res := atomic.AddInt32(&counter, 1)
+				switch res {
+				case 1:
+					// First attempt
+					fmt.Println("First retry, failing")
+					return "1", inngestgo.RetryAtError(fmt.Errorf("step err"), time.Now())
+				case 2:
+					// Second attempt, first retry
+					fmt.Println("Second retry, failing")
+					atomic.AddInt32(&stepRetried, 1)
+					return "2", inngestgo.RetryAtError(fmt.Errorf("second step err"), time.Now())
+				case 3:
+					fmt.Println("Final retry, completing")
+					atomic.AddInt32(&stepRetried, 1)
+				}
+				return "retry", nil
+			})
+
+			res := atomic.AddInt32(&counter, 1)
+			switch res {
+			case 4:
+				fmt.Println("Failing after step")
+				// First attempt of fn, as step blocks this call
+				return "fn error", inngestgo.RetryAtError(fmt.Errorf("fn err"), time.Now())
+			case 5:
+				// Second attempt of fn
+				atomic.AddInt32(&fnRetried, 1)
+			}
+			fmt.Println("finishing")
+			return "done", nil
+		},
+	)
+	h.Register(fn)
+
+	// Register the fns via the test SDK harness above.
+	registerFuncs()
+
+	_, err := inngestgo.Send(ctx, inngestgo.Event{
+		Name: "test/executor-retry",
+		Data: map[string]interface{}{
+			"name": "retry",
+		},
+	})
+	require.NoError(t, err)
+
+	t.Run("expected values", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			return atomic.LoadInt32(&counter) == 5
+		}, 10*time.Second, 2*time.Second)
+
+		require.EqualValues(t, 2, stepRetried, "Step should have retried twice")
+		require.EqualValues(t, 1, fnRetried, "Fn should have retried")
+	})
+
+	t.Run("trace run should have the appropriate data", func(t *testing.T) {
+		<-time.After(3 * time.Second)
+
+		require.Eventually(t, func() bool {
+			run := c.RunTraces(ctx, runID)
+			require.NotNil(t, run)
+			require.NotNil(t, run.Trace)
+			require.True(t, run.Trace.IsRoot)
+			require.Equal(t, 2, len(run.Trace.ChildSpans))
+
+			// output test
+			require.NotNil(t, run.Trace.OutputID)
+			runOutput := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+			require.NotNil(t, runOutput)
+			require.NotNil(t, runOutput.Data)
+			require.Contains(t, *runOutput.Data, "done")
+
+			rootSpanID := run.Trace.SpanID
+
+			t.Run("step retries", func(t *testing.T) {
+				step := run.Trace.ChildSpans[0]
+				assert.Equal(t, "Log input, increase counter", step.Name)
+				assert.Equal(t, 3, step.Attempts)
+				assert.Equal(t, rootSpanID, step.ParentSpanID)
+				assert.Equal(t, 3, len(step.ChildSpans))
+				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), step.Status)
+
+				assert.NotNil(t, step.OutputID)
+				output := c.RunSpanOutput(ctx, *step.OutputID)
+				assert.NotNil(t, output)
+				assert.NotNil(t, output.Data)
+				assert.Contains(t, *output.Data, "retry")
+
+				for i, span := range step.ChildSpans {
+					testName := fmt.Sprintf("step retry %d", i)
+					t.Run(testName, func(t *testing.T) {
+						attempt := i + 1
+						switch attempt {
+						case 1:
+							assert.Equal(t, fmt.Sprintf("Attempt %d", attempt), span.Name)
+							assert.Equal(t, models.RunTraceSpanStatusFailed.String(), span.Status)
+						case 2:
+							assert.Equal(t, fmt.Sprintf("Attempt %d", attempt), span.Name)
+							assert.Equal(t, models.RunTraceSpanStatusFailed.String(), span.Status)
+						// last
+						case 3:
+							assert.Equal(t, fmt.Sprintf("Attempt %d", attempt), span.Name)
+							assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), span.Status)
+						}
+					})
+				}
+			})
+
+			t.Run("function retries", func(t *testing.T) {
+				exec := run.Trace.ChildSpans[1]
+				assert.Equal(t, consts.OtelExecFnOk, exec.Name)
+				assert.Equal(t, rootSpanID, exec.ParentSpanID)
+				assert.Equal(t, 2, len(exec.ChildSpans))
+				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), exec.Status)
+
+				assert.NotNil(t, exec.OutputID)
+				output := c.RunSpanOutput(ctx, *exec.OutputID)
+				assert.NotNil(t, output)
+				assert.NotNil(t, output.Data)
+				assert.Contains(t, *output.Data, "done")
+
+				for i, span := range exec.ChildSpans {
+					testName := fmt.Sprintf("fn retry %d", i)
+					t.Run(testName, func(t *testing.T) {
+						attempt := i + 1
+						switch attempt {
+						case 1:
+							assert.Equal(t, fmt.Sprintf("Attempt %d", attempt), span.Name)
+							assert.Equal(t, models.RunTraceSpanStatusFailed.String(), span.Status)
+						// last
+						case 2:
+							assert.Equal(t, fmt.Sprintf("Attempt %d", attempt), span.Name)
+							assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), span.Status)
+						}
+					})
+				}
+			})
+
+			return true
+		}, 15*time.Second, 3*time.Second)
+	})
+
+}

--- a/tests/golang/retry_test.go
+++ b/tests/golang/retry_test.go
@@ -121,7 +121,7 @@ func TestRetry(t *testing.T) {
 			t.Run("step retries", func(t *testing.T) {
 				step := run.Trace.ChildSpans[0]
 				assert.Equal(t, "Log input, increase counter", step.Name)
-				assert.Equal(t, 3, step.Attempts)
+				assert.Equal(t, 2, step.Attempts)
 				assert.Equal(t, rootSpanID, step.ParentSpanID)
 				assert.Equal(t, 3, len(step.ChildSpans))
 				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), step.Status)
@@ -135,16 +135,16 @@ func TestRetry(t *testing.T) {
 				for i, span := range step.ChildSpans {
 					testName := fmt.Sprintf("step retry %d", i)
 					t.Run(testName, func(t *testing.T) {
-						attempt := i + 1
+						attempt := i
 						switch attempt {
+						case 0:
+							assert.Equal(t, fmt.Sprintf("Attempt %d", attempt), span.Name)
+							assert.Equal(t, models.RunTraceSpanStatusFailed.String(), span.Status)
 						case 1:
 							assert.Equal(t, fmt.Sprintf("Attempt %d", attempt), span.Name)
 							assert.Equal(t, models.RunTraceSpanStatusFailed.String(), span.Status)
-						case 2:
-							assert.Equal(t, fmt.Sprintf("Attempt %d", attempt), span.Name)
-							assert.Equal(t, models.RunTraceSpanStatusFailed.String(), span.Status)
 						// last
-						case 3:
+						case 2:
 							assert.Equal(t, fmt.Sprintf("Attempt %d", attempt), span.Name)
 							assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), span.Status)
 						}
@@ -168,13 +168,13 @@ func TestRetry(t *testing.T) {
 				for i, span := range exec.ChildSpans {
 					testName := fmt.Sprintf("fn retry %d", i)
 					t.Run(testName, func(t *testing.T) {
-						attempt := i + 1
+						attempt := i
 						switch attempt {
-						case 1:
+						case 0:
 							assert.Equal(t, fmt.Sprintf("Attempt %d", attempt), span.Name)
 							assert.Equal(t, models.RunTraceSpanStatusFailed.String(), span.Status)
 						// last
-						case 2:
+						case 1:
 							assert.Equal(t, fmt.Sprintf("Attempt %d", attempt), span.Name)
 							assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), span.Status)
 						}

--- a/tests/golang/retry_test.go
+++ b/tests/golang/retry_test.go
@@ -32,9 +32,11 @@ func TestRetry(t *testing.T) {
 		runID       string
 	)
 
+	evtName := "test/retry"
+
 	fn := inngestgo.CreateFunction(
 		inngestgo.FunctionOpts{Name: "test retry"},
-		inngestgo.EventTrigger("test/executor-retry", nil),
+		inngestgo.EventTrigger(evtName, nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
 			if runID == "" {
 				runID = input.InputCtx.RunID
@@ -81,7 +83,7 @@ func TestRetry(t *testing.T) {
 	registerFuncs()
 
 	_, err := inngestgo.Send(ctx, inngestgo.Event{
-		Name: "test/executor-retry",
+		Name: evtName,
 		Data: map[string]interface{}{
 			"name": "retry",
 		},

--- a/tests/golang/sleep_test.go
+++ b/tests/golang/sleep_test.go
@@ -57,9 +57,9 @@ func TestSleep(t *testing.T) {
 			step.Sleep(ctx, "nap", 10*time.Second)
 
 			// Ensure any time we're here it's 15 seconds after the sleep.
-			require.GreaterOrEqual(t, int(time.Now().Sub(startedAt).Seconds()), 10)
+			require.GreaterOrEqual(t, int(time.Since(startedAt).Seconds()), 10)
 
-			step.Run(ctx, "test", func(ctx context.Context) (any, error) {
+			_, _ = step.Run(ctx, "test", func(ctx context.Context) (any, error) {
 				if input.InputCtx.Attempt == 0 {
 					return nil, inngestgo.RetryAtError(fmt.Errorf("throwing a step error"), time.Now())
 				}

--- a/tests/golang/sleep_test.go
+++ b/tests/golang/sleep_test.go
@@ -167,7 +167,7 @@ func TestSleep(t *testing.T) {
 				t.Run("failed execution", func(t *testing.T) {
 					exec := sleep.ChildSpans[0]
 					assert.Equal(t, models.RunTraceSpanStatusFailed.String(), exec.Status)
-					assert.Equal(t, "Attempt 1", exec.Name)
+					assert.Equal(t, "Attempt 0", exec.Name)
 					assert.NotNil(t, exec.OutputID)
 
 					execOutput := c.RunSpanOutput(ctx, *exec.OutputID)

--- a/tests/golang/sleep_test.go
+++ b/tests/golang/sleep_test.go
@@ -1,0 +1,175 @@
+package golang
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/coreapi/graph/models"
+	"github.com/inngest/inngest/tests/client"
+	"github.com/inngest/inngestgo"
+	"github.com/inngest/inngestgo/step"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSleep(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	c := client.New(t)
+	h, server, registerFuncs := NewSDKHandler(t, "sleep-test")
+	defer server.Close()
+
+	// Create our function.
+	var (
+		started   int32
+		startedAt time.Time
+		completed int32
+		runID     string
+	)
+	evtName := "test/sleep"
+
+	a := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{Name: "test sleep"},
+		inngestgo.EventTrigger(evtName, nil),
+		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+			if runID == "" {
+				runID = input.InputCtx.RunID
+			}
+
+			if atomic.LoadInt32(&started) == 0 {
+				// Throw an immediate error
+				atomic.AddInt32(&started, 1)
+				return nil, inngestgo.RetryAtError(fmt.Errorf("throwing an initial error"), time.Now())
+			}
+
+			if atomic.LoadInt32(&started) == 1 {
+				// Set the started time
+				atomic.AddInt32(&started, 1)
+				startedAt = time.Now()
+			}
+
+			step.Sleep(ctx, "nap", 10*time.Second)
+
+			// Ensure any time we're here it's 15 seconds after the sleep.
+			require.GreaterOrEqual(t, int(time.Now().Sub(startedAt).Seconds()), 10)
+
+			step.Run(ctx, "test", func(ctx context.Context) (any, error) {
+				if input.InputCtx.Attempt == 0 {
+					return nil, inngestgo.RetryAtError(fmt.Errorf("throwing a step error"), time.Now())
+				}
+				return "done", nil
+			})
+
+			if input.InputCtx.Attempt == 0 {
+				return nil, inngestgo.RetryAtError(fmt.Errorf("throwing a fn error"), time.Now())
+			}
+
+			atomic.AddInt32(&completed, 1)
+			return true, nil
+		},
+	)
+	h.Register(a)
+
+	// Register the fns via the test SDK harness above.
+	registerFuncs()
+
+	_, err := inngestgo.Send(ctx, inngestgo.Event{
+		Name: evtName,
+		Data: map[string]any{"sleep": "ok"},
+	})
+	require.NoError(t, err)
+
+	t.Run("in progress sleep", func(t *testing.T) {
+		<-time.After(3 * time.Second)
+
+		require.Eventually(t, func() bool {
+			run := c.RunTraces(ctx, runID)
+			require.NotNil(t, run)
+			require.NotNil(t, run.Trace)
+			require.True(t, run.Trace.IsRoot)
+			require.Equal(t, 1, len(run.Trace.ChildSpans))
+			require.Equal(t, models.RunTraceSpanStatusRunning.String(), run.Trace.Status)
+			require.Nil(t, run.Trace.OutputID)
+
+			t.Run("sleep", func(t *testing.T) {
+				sleep := run.Trace.ChildSpans[0]
+				assert.Equal(t, models.RunTraceSpanStatusRunning.String(), sleep.Status)
+				assert.Equal(t, "nap", sleep.Name)
+				assert.Equal(t, models.StepOpSleep.String(), sleep.StepOp)
+
+				// verify step info
+				info := &models.SleepStepInfo{}
+				byt, err := json.Marshal(sleep.StepInfo)
+				assert.NoError(t, err)
+				assert.NoError(t, json.Unmarshal(byt, info))
+
+				assert.True(t, time.Now().Before(info.SleepUntil))
+			})
+
+			return true
+		}, 10*time.Second, 2*time.Second)
+	})
+
+	t.Run("expected values", func(t *testing.T) {
+		require.Eventually(t, func() bool {
+			return atomic.LoadInt32(&completed) == 1
+		}, time.Minute, 2*time.Second)
+	})
+
+	t.Run("complete", func(t *testing.T) {
+		<-time.After(15 * time.Second)
+
+		require.Eventually(t, func() bool {
+			require.EqualValues(t, 1, atomic.LoadInt32(&completed))
+			run := c.RunTraces(ctx, runID)
+			require.NotNil(t, run)
+			require.NotNil(t, run.Trace)
+			require.True(t, run.Trace.IsRoot)
+			require.Equal(t, 3, len(run.Trace.ChildSpans))
+			require.NotEqual(t, models.RunTraceSpanStatusRunning.String(), run.Trace.Status)
+
+			// output test
+			require.NotNil(t, run.Trace.OutputID)
+			output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+			require.NotNil(t, output)
+			c.ExpectSpanOutput(t, "true", output)
+
+			t.Run("sleep", func(t *testing.T) {
+				sleep := run.Trace.ChildSpans[0]
+				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), sleep.Status)
+				assert.Equal(t, 2, len(sleep.ChildSpans))
+				assert.Equal(t, "nap", sleep.Name)
+				assert.Equal(t, models.StepOpSleep.String(), sleep.StepOp)
+				assert.Nil(t, sleep.OutputID)
+
+				// verify step info
+				info := &models.SleepStepInfo{}
+				byt, err := json.Marshal(sleep.StepInfo)
+				assert.NoError(t, err)
+				assert.NoError(t, json.Unmarshal(byt, info))
+
+				assert.True(t, time.Now().After(info.SleepUntil))
+
+				// first is the failed attempt
+				t.Run("failed execution", func(t *testing.T) {
+					exec := sleep.ChildSpans[0]
+					assert.Equal(t, models.RunTraceSpanStatusFailed.String(), exec.Status)
+					assert.Equal(t, consts.OtelExecPlaceholder, exec.Name)
+					assert.NotNil(t, exec.OutputID)
+
+					execOutput := c.RunSpanOutput(ctx, *exec.OutputID)
+					assert.NotNil(t, execOutput)
+					c.ExpectSpanErrorOutput(t, "", "throwing an initial error", execOutput)
+				})
+			})
+
+			return true
+		}, 9*time.Second, 3*time.Second)
+	})
+}

--- a/tests/golang/sleep_test.go
+++ b/tests/golang/sleep_test.go
@@ -110,7 +110,7 @@ func TestSleep(t *testing.T) {
 
 			t.Run("failed", func(t *testing.T) {
 				exec := span.ChildSpans[0]
-				assert.Equal(t, "Attempt 1", exec.Name)
+				assert.Equal(t, "Attempt 0", exec.Name)
 				assert.Equal(t, models.RunTraceSpanStatusFailed.String(), exec.Status)
 				assert.NotNil(t, exec.OutputID)
 

--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -219,7 +219,7 @@ func TestWaitGroup(t *testing.T) {
 
 			span := run.Trace.ChildSpans[0]
 			assert.Equal(t, consts.OtelExecPlaceholder, span.Name)
-			assert.Equal(t, 1, span.Attempts)
+			assert.Equal(t, 0, span.Attempts)
 			assert.Equal(t, rootSpanID, span.ParentSpanID)
 			assert.False(t, span.IsRoot)
 			assert.Equal(t, 1, len(span.ChildSpans))
@@ -229,7 +229,7 @@ func TestWaitGroup(t *testing.T) {
 
 			t.Run("failed", func(t *testing.T) {
 				exec := span.ChildSpans[0]
-				assert.Equal(t, "Attempt 1", exec.Name)
+				assert.Equal(t, "Attempt 0", exec.Name)
 				assert.Equal(t, models.RunTraceSpanStatusFailed.String(), exec.Status)
 				assert.NotNil(t, exec.OutputID)
 

--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -63,7 +63,7 @@ func TestWait(t *testing.T) {
 	r.NoError(err)
 
 	t.Run("in progress wait", func(t *testing.T) {
-		<-time.After(3 * time.Second)
+		<-time.After(5 * time.Second)
 
 		require.Eventually(t, func() bool {
 			run := c.RunTraces(ctx, runID)
@@ -100,7 +100,7 @@ func TestWait(t *testing.T) {
 		}, 5*time.Second, 1*time.Second)
 	})
 
-	<-time.After(5 * time.Second)
+	<-time.After(10 * time.Second)
 	// Trigger the main function
 	_, err = inngestgo.Send(ctx, &event.Event{Name: waitEvtName})
 	r.NoError(err)

--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -97,10 +97,10 @@ func TestWait(t *testing.T) {
 			})
 
 			return true
-		}, 10*time.Second, 2*time.Second)
+		}, 5*time.Second, 1*time.Second)
 	})
 
-	<-time.After(6 * time.Second)
+	<-time.After(5 * time.Second)
 	// Trigger the main function
 	_, err = inngestgo.Send(ctx, &event.Event{Name: waitEvtName})
 	r.NoError(err)

--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -3,12 +3,15 @@ package golang
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/tests/client"
@@ -78,6 +81,7 @@ func TestWait(t *testing.T) {
 				assert.Equal(t, 0, span.Attempts)
 				assert.Equal(t, rootSpanID, span.ParentSpanID)
 				assert.False(t, span.IsRoot)
+				assert.Equal(t, 0, len(span.ChildSpans)) // NOTE: should have no child
 				assert.Equal(t, models.RunTraceSpanStatusWaiting.String(), span.Status)
 				assert.Equal(t, models.StepOpWaitForEvent.String(), span.StepOp)
 				assert.Nil(t, span.OutputID)
@@ -93,7 +97,7 @@ func TestWait(t *testing.T) {
 			})
 
 			return true
-		}, 6*time.Second, 2*time.Second)
+		}, 10*time.Second, 2*time.Second)
 	})
 
 	<-time.After(6 * time.Second)
@@ -132,6 +136,149 @@ func TestWait(t *testing.T) {
 				assert.NotNil(t, span.OutputID)
 				spanOutput := c.RunSpanOutput(ctx, *span.OutputID)
 				c.ExpectSpanOutput(t, "resume", spanOutput)
+
+				var stepInfo models.WaitForEventStepInfo
+				byt, err := json.Marshal(span.StepInfo)
+				assert.NoError(t, err)
+				assert.NoError(t, json.Unmarshal(byt, &stepInfo))
+
+				assert.Equal(t, waitEvtName, stepInfo.EventName)
+				assert.NotNil(t, stepInfo.TimedOut)
+				assert.False(t, *stepInfo.TimedOut)
+				assert.NotNil(t, stepInfo.FoundEventID)
+				assert.Nil(t, stepInfo.Expression)
+			})
+
+			return true
+		}, 10*time.Second, 2*time.Second)
+	})
+}
+
+func TestWaitGroup(t *testing.T) {
+	ctx := context.Background()
+	r := require.New(t)
+	c := client.New(t)
+
+	appID := "TestWaitGroup" + ulid.MustNew(ulid.Now(), nil).String()
+	h, server, registerFuncs := NewSDKHandler(t, appID)
+	defer server.Close()
+
+	var started int32
+
+	// This function will invoke the other function
+	runID := ""
+	evtName := "wait-group"
+	waitEvtName := "resume-group"
+
+	fn := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{
+			Name: "main-fn",
+		},
+		inngestgo.EventTrigger(evtName, nil),
+		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
+			runID = input.InputCtx.RunID
+
+			if atomic.LoadInt32(&started) == 0 {
+				atomic.AddInt32(&started, 1)
+				return nil, inngestgo.RetryAtError(fmt.Errorf("initial error"), time.Now().Add(5*time.Second))
+			}
+
+			_, _ = step.WaitForEvent[any](
+				ctx,
+				"wait",
+				step.WaitForEventOpts{
+					Name:    "dummy",
+					Event:   waitEvtName,
+					Timeout: 30 * time.Second,
+				},
+			)
+
+			return "DONE", nil
+		},
+	)
+
+	h.Register(fn)
+	registerFuncs()
+
+	// Trigger the main function
+	_, err := inngestgo.Send(ctx, &event.Event{Name: evtName})
+	r.NoError(err)
+
+	t.Run("in progress wait", func(t *testing.T) {
+		<-time.After(3 * time.Second)
+
+		require.Eventually(t, func() bool {
+			run := c.RunTraces(ctx, runID)
+			require.NotNil(t, models.FunctionStatusRunning.String(), run.Status)
+			require.NotNil(t, run.Trace)
+			require.Equal(t, 1, len(run.Trace.ChildSpans))
+			require.Equal(t, models.RunTraceSpanStatusRunning.String(), run.Trace.Status)
+			require.Nil(t, run.Trace.OutputID)
+
+			rootSpanID := run.Trace.SpanID
+
+			span := run.Trace.ChildSpans[0]
+			assert.Equal(t, consts.OtelExecPlaceholder, span.Name)
+			assert.Equal(t, 1, span.Attempts)
+			assert.Equal(t, rootSpanID, span.ParentSpanID)
+			assert.False(t, span.IsRoot)
+			assert.Equal(t, 1, len(span.ChildSpans))
+			assert.Equal(t, models.RunTraceSpanStatusRunning.String(), span.Status)
+			assert.Equal(t, "", span.StepOp)
+			assert.Nil(t, span.OutputID)
+
+			t.Run("failed", func(t *testing.T) {
+				exec := span.ChildSpans[0]
+				assert.Equal(t, "Attempt 1", exec.Name)
+				assert.Equal(t, models.RunTraceSpanStatusFailed.String(), exec.Status)
+				assert.NotNil(t, exec.OutputID)
+
+				execOutput := c.RunSpanOutput(ctx, *exec.OutputID)
+				assert.NotNil(t, execOutput)
+				c.ExpectSpanErrorOutput(t, "", "initial error", execOutput)
+			})
+
+			return true
+		}, 10*time.Second, 2*time.Second)
+	})
+
+	<-time.After(3 * time.Second)
+	// Trigger the main function
+	_, err = inngestgo.Send(ctx, &event.Event{Name: waitEvtName})
+	r.NoError(err)
+
+	t.Run("trace run should have appropriate data", func(t *testing.T) {
+		<-time.After(5 * time.Second)
+
+		require.Eventually(t, func() bool {
+			run := c.RunTraces(ctx, runID)
+			require.NotNil(t, run)
+			require.Equal(t, models.FunctionStatusCompleted.String(), run.Status)
+			require.NotNil(t, run.Trace)
+			require.Equal(t, 1, len(run.Trace.ChildSpans))
+			require.Equal(t, models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
+
+			// output test
+			require.NotNil(t, run.Trace.OutputID)
+			output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+			c.ExpectSpanOutput(t, "DONE", output)
+
+			rootSpanID := run.Trace.SpanID
+
+			t.Run("wait step", func(t *testing.T) {
+				span := run.Trace.ChildSpans[0]
+				assert.Equal(t, "dummy", span.Name)
+				assert.Equal(t, 0, span.Attempts)
+				assert.Equal(t, rootSpanID, span.ParentSpanID)
+				assert.False(t, span.IsRoot)
+				assert.Equal(t, 2, len(span.ChildSpans))
+				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), span.Status)
+				assert.Equal(t, models.StepOpWaitForEvent.String(), span.StepOp)
+
+				// output test
+				assert.NotNil(t, span.OutputID)
+				spanOutput := c.RunSpanOutput(ctx, *span.OutputID)
+				c.ExpectSpanOutput(t, waitEvtName, spanOutput)
 
 				var stepInfo models.WaitForEventStepInfo
 				byt, err := json.Marshal(span.StepInfo)


### PR DESCRIPTION
## Description

Update run tree logic with individual step processing and group processing based on context.

Group processing works well when a group needs to be created due to retries, and we need to make sure we construct the group accordingly.
Due to function level retries being grouped into the next step execution, all steps can potentially have multiple attempts.

Whereas there are times it's better to process the step itself.
These can be the happy path for most execution types, and also parallelism as well, where the discovery of steps could result in multiple attempts of execution.

Added more integration tests to verify scenarios.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
