### PR TITLE
Adjust cloud apps cards hover and tokens

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/AppCard.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/AppCard.tsx
@@ -47,18 +47,18 @@ export function AppCard({ app, className, envSlug, isArchived }: Props) {
   const latestSyncURL = app.latestSync?.url?.replace(/^https:\/\//, '').replace(/\?.+$/, '');
   return (
     <div className={cn(cardWrapperStyles, className)}>
-      <div className={cardLeftPanelStyles}>
+      <Link
+        href={pathCreator.app({ envSlug, externalAppID: app.externalID })}
+        className={cn(cardLeftPanelStyles, 'hover:bg-canvasMuted')}
+      >
         <h2>
-          <Link
-            className="transition-color hover:text-link hover:decoration-link text-basis flex cursor-pointer items-center gap-1 font-medium underline decoration-transparent decoration-2 underline-offset-4 duration-300"
-            href={pathCreator.app({ envSlug, externalAppID: app.externalID })}
-          >
+          <div className="text-basis flex items-center gap-1 font-medium">
             {isArchived && <RiArchive2Line className="h-4 w-4" />}
             <span className="truncate" title={app.name}>
               {app.name}
             </span>
             <RiArrowRightSLine className="h-4 w-4" />
-          </Link>
+          </div>
         </h2>
         {latestSyncURL && (
           <dl>
@@ -68,7 +68,7 @@ export function AppCard({ app, className, envSlug, isArchived }: Props) {
             </dd>
           </dl>
         )}
-      </div>
+      </Link>
       <div className="flex h-56 flex-1 flex-col">
         {app.latestSync?.error && (
           <div className="bg-red-100 px-8 py-2 text-red-800">{app.latestSync.error}</div>

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/AppCard.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/AppCard.tsx
@@ -49,7 +49,7 @@ export function AppCard({ app, className, envSlug, isArchived }: Props) {
     <div className={cn(cardWrapperStyles, className)}>
       <Link
         href={pathCreator.app({ envSlug, externalAppID: app.externalID })}
-        className={cn(cardLeftPanelStyles, 'hover:bg-canvasMuted')}
+        className={cn(cardLeftPanelStyles, 'hover:bg-canvasMuted transition-colors duration-300')}
       >
         <h2>
           <div className="text-basis flex items-center gap-1 font-medium">

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/UnattachedSyncsCard.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/UnattachedSyncsCard.tsx
@@ -23,17 +23,17 @@ export const cardRightPanelStyles = 'h-44 flex-1 flex flex-col justify-center px
 export function UnattachedSyncsCard({ className, envSlug, latestSyncTime }: Props) {
   return (
     <div className={cn(cardWrapperStyles, className)}>
-      <div className={cardLeftPanelStyles}>
+      <Link
+        href={pathCreator.unattachedSyncs({ envSlug })}
+        className={cn(cardLeftPanelStyles, 'hover:bg-canvasMuted')}
+      >
         <h2>
-          <Link
-            className="transition-color hover:text-link hover:decoration-link text-basis flex cursor-pointer items-center gap-1 font-medium underline decoration-transparent decoration-2 underline-offset-4 duration-300"
-            href={pathCreator.unattachedSyncs({ envSlug })}
-          >
+          <div className="text-basis flex items-center gap-1 font-medium">
             Unattached Syncs
             <RiArrowRightSLine className="h-4 w-4" />
-          </Link>
+          </div>
         </h2>
-      </div>
+      </Link>
       <div className={cardRightPanelStyles}>
         <dl className="grid grid-cols-2 gap-4 min-[900px]:grid-cols-3">
           <p className="col-span-2 md:col-span-3">

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/UnattachedSyncsCard.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/UnattachedSyncsCard.tsx
@@ -25,7 +25,7 @@ export function UnattachedSyncsCard({ className, envSlug, latestSyncTime }: Prop
     <div className={cn(cardWrapperStyles, className)}>
       <Link
         href={pathCreator.unattachedSyncs({ envSlug })}
-        className={cn(cardLeftPanelStyles, 'hover:bg-canvasMuted')}
+        className={cn(cardLeftPanelStyles, 'hover:bg-canvasMuted transition-colors duration-300')}
       >
         <h2>
           <div className="text-basis flex items-center gap-1 font-medium">

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
@@ -79,7 +79,7 @@ export default function Page() {
           </div>
         }
       />
-      <div className="relative h-full overflow-y-auto bg-slate-100">
+      <div className="bg-canvasBase relative h-full overflow-y-auto">
         <Apps isArchived={isArchived} />
       </div>
     </>


### PR DESCRIPTION
## Description
- As per feedback from Sanjana, adjust the clickable area of apps cards and replace some color tokens

https://github.com/inngest/inngest/assets/16758464/cb3e9b00-8501-4a1f-b6c3-3c14148f7f87

## Motivation
This is part of the new design system. With the new link colors, the app cards had to be lighter

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
