### PR TITLE
Enable expand and collapse trigger details

### DIFF
--- a/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
+++ b/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
@@ -125,13 +125,15 @@ export function TriggerDetails({ className, getTrigger }: Props) {
     >
       {!showEventPanel && (
         <Collapsible.Trigger asChild>
-          <span className="flex h-7 w-7 items-center justify-center rounded-full border border-slate-400">
-            <Tooltip>
-              <TooltipTrigger>
-                <RiExpandLeftFill className="h-5 w-5	text-slate-400" />
-              </TooltipTrigger>
-              <TooltipContent>Show trigger details</TooltipContent>
-            </Tooltip>
+          <span className="pt-2">
+            <span className="border-muted flex h-7 w-7 items-center justify-center rounded-full border">
+              <Tooltip>
+                <TooltipTrigger>
+                  <RiExpandLeftFill className="text-subtle hover:text-muted	h-5 w-5" />
+                </TooltipTrigger>
+                <TooltipContent>Show trigger details</TooltipContent>
+              </Tooltip>
+            </span>
           </span>
         </Collapsible.Trigger>
       )}
@@ -142,7 +144,12 @@ export function TriggerDetails({ className, getTrigger }: Props) {
               <Card.Header className="h-11 flex-row items-center gap-2">
                 <div className="text-basis flex grow items-center gap-2">Trigger details</div>
                 <Collapsible.Trigger asChild>
-                  <Button size="large" appearance="text" icon={<RiContractRightFill />} />
+                  <Button
+                    size="large"
+                    appearance="text"
+                    icon={<RiContractRightFill />}
+                    className="text-subtle hover:text-muted"
+                  />
                 </Collapsible.Trigger>
               </Card.Header>
 

--- a/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
+++ b/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
@@ -119,7 +119,7 @@ export function TriggerDetails({ className, getTrigger }: Props) {
 
   return (
     <Collapsible.Root
-      className={cn(showEventPanel && 'w-2/5', 'flex flex-col gap-5', className)}
+      className={cn(showEventPanel && 'w-3/4 2xl:w-2/5', 'flex flex-col gap-5', className)}
       open={showEventPanel}
       onOpenChange={setShowEventPanel}
     >

--- a/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
+++ b/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { GSP_NO_RETURNED_VALUE } from 'next/dist/lib/constants';
-// import { Button } from '@inngest/components/Button';
-// import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';
+import { Button } from '@inngest/components/Button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';
 import * as Collapsible from '@radix-ui/react-collapsible';
-// import { RiContractRightFill, RiExpandLeftFill } from '@remixicon/react';
+import { RiContractRightFill, RiExpandLeftFill } from '@remixicon/react';
 import { useLocalStorage } from 'react-use';
 
 import { Card } from '../Card';
@@ -124,8 +123,7 @@ export function TriggerDetails({ className, getTrigger }: Props) {
       open={showEventPanel}
       onOpenChange={setShowEventPanel}
     >
-      {/* TODO: Enable the collapsed feature */}
-      {/* {!showEventPanel && (
+      {!showEventPanel && (
         <Collapsible.Trigger asChild>
           <span className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-400">
             <Tooltip>
@@ -136,16 +134,16 @@ export function TriggerDetails({ className, getTrigger }: Props) {
             </Tooltip>
           </span>
         </Collapsible.Trigger>
-      )} */}
+      )}
       <Collapsible.Content>
         {showEventPanel && (
           <>
             <Card>
               <Card.Header className="h-11 flex-row items-center gap-2">
                 <div className="text-basis flex grow items-center gap-2">Trigger details</div>
-                {/* <Collapsible.Trigger asChild>
+                <Collapsible.Trigger asChild>
                   <Button size="large" appearance="text" icon={<RiContractRightFill />} />
-                </Collapsible.Trigger> */}
+                </Collapsible.Trigger>
               </Card.Header>
 
               <Card.Content>

--- a/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
+++ b/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
@@ -128,7 +128,7 @@ export function TriggerDetails({ className, getTrigger }: Props) {
           <span className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-400">
             <Tooltip>
               <TooltipTrigger>
-                <RiExpandLeftFill className="text-slate-400" />
+                <RiExpandLeftFill className="h-5 w-5	text-slate-400" />
               </TooltipTrigger>
               <TooltipContent>Show trigger details</TooltipContent>
             </Tooltip>

--- a/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
+++ b/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
@@ -125,7 +125,7 @@ export function TriggerDetails({ className, getTrigger }: Props) {
     >
       {!showEventPanel && (
         <Collapsible.Trigger asChild>
-          <span className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-400">
+          <span className="flex h-7 w-7 items-center justify-center rounded-full border border-slate-400">
             <Tooltip>
               <TooltipTrigger>
                 <RiExpandLeftFill className="h-5 w-5	text-slate-400" />


### PR DESCRIPTION
## Description
- Re-enable ability to expand/collapse trigger details, following the [fix](https://github.com/inngest/inngest/pull/1482)
of Code Block bug that was affecting the layout.
- Tweak panel widths to look better in smaller screens.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
