### PR TITLE
Remove delayDuration from tooltips

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/ArchiveButton.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/ArchiveButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '@inngest/components/Button';
-import * as Tooltip from '@radix-ui/react-tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';
 import { RiArchive2Line, RiInboxUnarchiveLine } from '@remixicon/react';
 import { useQuery } from 'urql';
 
@@ -47,33 +47,28 @@ export default function ArchiveFunctionButton({ functionSlug }: ArchiveFunctionP
   const { isArchived } = fn;
 
   return (
-    <>
-      <Tooltip.Provider>
-        <Tooltip.Root delayDuration={0}>
-          <Tooltip.Trigger asChild>
-            <span tabIndex={0}>
-              <Button
-                icon={
-                  isArchived ? (
-                    <RiInboxUnarchiveLine className=" text-slate-300" />
-                  ) : (
-                    <RiArchive2Line className=" text-slate-300" />
-                  )
-                }
-                btnAction={() =>
-                  console.error('manual function archival has been replaced with app archival')
-                }
-                disabled
-                label={isArchived ? 'Unarchive' : 'Archive'}
-              />
-            </span>
-          </Tooltip.Trigger>
-          <Tooltip.Content className="align-center rounded-md bg-slate-800 px-2 text-xs text-slate-300">
-            Manual function archival has been replaced with app archival
-            <Tooltip.Arrow className="fill-slate-800" />
-          </Tooltip.Content>
-        </Tooltip.Root>
-      </Tooltip.Provider>
-    </>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span tabIndex={0}>
+          <Button
+            icon={
+              isArchived ? (
+                <RiInboxUnarchiveLine className=" text-slate-300" />
+              ) : (
+                <RiArchive2Line className=" text-slate-300" />
+              )
+            }
+            btnAction={() =>
+              console.error('manual function archival has been replaced with app archival')
+            }
+            disabled
+            label={isArchived ? 'Unarchive' : 'Archive'}
+          />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="align-center max-w-sm rounded-md px-2 text-xs">
+        Manual function archival has been replaced with app archival
+      </TooltipContent>
+    </Tooltip>
   );
 }

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/PauseButton.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/PauseButton.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { Button } from '@inngest/components/Button';
 import { AlertModal } from '@inngest/components/Modal';
-import * as Tooltip from '@radix-ui/react-tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';
 import { RiPauseLine, RiPlayFill } from '@remixicon/react';
 import { toast } from 'sonner';
 import { useMutation, useQuery } from 'urql';
@@ -140,32 +140,29 @@ export default function PauseFunctionButton({ functionSlug, disabled }: PauseFun
 
   return (
     <>
-      <Tooltip.Provider>
-        <Tooltip.Root delayDuration={0}>
-          <Tooltip.Trigger asChild>
-            <span tabIndex={0}>
-              <Button
-                icon={
-                  isPaused ? (
-                    <RiPlayFill className=" text-green-600" />
-                  ) : (
-                    <RiPauseLine className=" text-amber-500" />
-                  )
-                }
-                btnAction={() => setIsPauseFunctionModalVisible(true)}
-                disabled={disabled || isFetchingVersions}
-                label={isPaused ? 'Resume' : 'Pause'}
-              />
-            </span>
-          </Tooltip.Trigger>
-          <Tooltip.Content className="align-center rounded-md bg-slate-800 px-2 text-xs text-slate-300">
-            {isPaused
-              ? 'Begin running this function after a temporary pause'
-              : 'Temporarily stop a function from being run'}
-            <Tooltip.Arrow className="fill-slate-800" />
-          </Tooltip.Content>
-        </Tooltip.Root>
-      </Tooltip.Provider>
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>
+          <span tabIndex={0}>
+            <Button
+              icon={
+                isPaused ? (
+                  <RiPlayFill className=" text-green-600" />
+                ) : (
+                  <RiPauseLine className=" text-amber-500" />
+                )
+              }
+              btnAction={() => setIsPauseFunctionModalVisible(true)}
+              disabled={disabled || isFetchingVersions}
+              label={isPaused ? 'Resume' : 'Pause'}
+            />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className="align-center rounded-md px-2 text-xs">
+          {isPaused
+            ? 'Begin running this function after a temporary pause'
+            : 'Temporarily stop a function from being run'}
+        </TooltipContent>
+      </Tooltip>
       <PauseFunctionModal
         functionID={fn.id}
         functionName={fn.name}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/billing/PaymentIcons.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/billing/PaymentIcons.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import * as Tooltip from '@radix-ui/react-tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';
 import { RiCheckLine, RiCloseLine, RiErrorWarningLine, RiTimeLine } from '@remixicon/react';
 
 type PaymentIconProps = {
@@ -37,15 +37,10 @@ export default function PaymentIcon({ status }: PaymentIconProps) {
   }
   if (icon) {
     return (
-      <Tooltip.Provider>
-        <Tooltip.Root delayDuration={0}>
-          <Tooltip.Trigger asChild>{icon}</Tooltip.Trigger>
-          <Tooltip.Content className="align-center rounded-md bg-slate-800 px-2 text-xs text-slate-300">
-            {label}
-            <Tooltip.Arrow className="fill-slate-800" />
-          </Tooltip.Content>
-        </Tooltip.Root>
-      </Tooltip.Provider>
+      <Tooltip>
+        <TooltipTrigger asChild>{icon}</TooltipTrigger>
+        <TooltipContent className="align-center rounded-md px-2 text-xs">{label}</TooltipContent>
+      </Tooltip>
     );
   }
   return icon;

--- a/ui/apps/dashboard/src/app/layout.tsx
+++ b/ui/apps/dashboard/src/app/layout.tsx
@@ -61,7 +61,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       >
         <SentryUserIdentification />
         <ClientFeatureFlagProvider>
-          <TooltipProvider>{children}</TooltipProvider>
+          <TooltipProvider delayDuration={0}>{children}</TooltipProvider>
           <PageViewTracker />
         </ClientFeatureFlagProvider>
       </ClerkProvider>

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/layout.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/layout.tsx
@@ -37,7 +37,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           <NavbarLink icon={<IconFunction />} href="/functions" tabName="Functions" />
         </Navbar>
       </Header>
-      <TooltipProvider>{children}</TooltipProvider>
+      <TooltipProvider delayDuration={0}>{children}</TooltipProvider>
       <Toaster
         theme="dark"
         toastOptions={{

--- a/ui/apps/dev-server-ui/src/app/layout.tsx
+++ b/ui/apps/dev-server-ui/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import { AppRoot } from '@inngest/components/AppRoot';
-import { TooltipProvider } from '@inngest/components/Tooltip';
 
 import StoreProvider from '@/app/StoreProvider';
 

--- a/ui/packages/components/src/TimelineV2/InlineSpans.tsx
+++ b/ui/packages/components/src/TimelineV2/InlineSpans.tsx
@@ -67,7 +67,7 @@ export function InlineSpans({ className, minTime, maxTime, name, spans, widths }
         </div>
       </TooltipTrigger>
       <TooltipContent>
-        <div className="text-slate-700">
+        <div className="text-basis">
           {spans[0] && <Times isDelayVisible={spans.length === 1} name={name} span={spans[0]} />}
 
           {spans.length > 1 &&

--- a/ui/packages/components/src/Tooltip/Tooltip.tsx
+++ b/ui/packages/components/src/Tooltip/Tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      'animate-slide-down-fade z-50 max-w-xs rounded-md bg-white/95 px-2 py-1 text-sm text-slate-400 drop-shadow backdrop-blur-[3px] dark:bg-slate-800',
+      'animate-slide-down-and-fade z-50 max-w-xs rounded-md bg-white/95 px-2 py-1 text-sm text-slate-400 drop-shadow backdrop-blur-[3px] dark:bg-slate-800',
       className
     )}
     {...props}

--- a/ui/packages/components/src/Tooltip/Tooltip.tsx
+++ b/ui/packages/components/src/Tooltip/Tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      'animate-slide-down-and-fade bg-canvasBase text-basis shadow-tooltip z-50 max-w-xs rounded-md px-2 py-1 text-sm shadow-lg',
+      'animate-slide-down-and-fade bg-canvasBase text-basis shadow-tooltip z-50 max-w-xs rounded-md px-2 py-1 text-sm shadow-md',
       className
     )}
     {...props}

--- a/ui/packages/components/src/Tooltip/Tooltip.tsx
+++ b/ui/packages/components/src/Tooltip/Tooltip.tsx
@@ -23,7 +23,10 @@ const TooltipContent = React.forwardRef<
       className
     )}
     {...props}
-  />
+  >
+    {props.children}
+    <TooltipPrimitive.Arrow className="fill-tooltipArrow" />
+  </TooltipPrimitive.Content>
 ));
 
 const TooltipArrow = TooltipPrimitive.Arrow;

--- a/ui/packages/components/src/Tooltip/Tooltip.tsx
+++ b/ui/packages/components/src/Tooltip/Tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      'animate-slide-down-and-fade z-50 max-w-xs rounded-md bg-white/95 px-2 py-1 text-sm text-slate-400 drop-shadow backdrop-blur-[3px] dark:bg-slate-800',
+      'animate-slide-down-and-fade bg-canvasBase text-basis shadow-tooltip z-50 max-w-xs rounded-md px-2 py-1 text-sm shadow-lg',
       className
     )}
     {...props}

--- a/ui/packages/components/tailwind.config.ts
+++ b/ui/packages/components/tailwind.config.ts
@@ -127,6 +127,8 @@ export default {
         link: 'rgb(var(--color-foreground-link) / <alpha-value>)',
       },
       fill: {
+        // temporary tooltip token
+        tooltipArrow: 'rgb(var(--color-background-canvas-base) / <alpha-value>)',
         onContrast: 'rgb(var(--color-foreground-onContrast) / <alpha-value>)',
         subtle: 'rgb(var(--color-foreground-subtle) / <alpha-value>)',
         alwaysWhite: 'rgb(var(--color-foreground-alwaysWhite) / <alpha-value>)',
@@ -137,7 +139,7 @@ export default {
         dashboard: '1fr 1fr 1fr 432px',
       },
       boxShadowColor: {
-        // temporary token
+        // temporary tooltip token
         tooltip: 'rgb(var(--color-background-canvas-muted) / <alpha-value>)',
       },
       boxShadow: {

--- a/ui/packages/components/tailwind.config.ts
+++ b/ui/packages/components/tailwind.config.ts
@@ -136,6 +136,10 @@ export default {
       gridTemplateColumns: {
         dashboard: '1fr 1fr 1fr 432px',
       },
+      boxShadowColor: {
+        // temporary token
+        tooltip: 'rgb(var(--color-background-canvas-muted) / <alpha-value>)',
+      },
       boxShadow: {
         'outline-primary-light':
           'inset 0 1px 0 0 rgba(255, 255, 255, 0.1), inset 0 0 0 1px rgba(255, 255, 255, 0.1), 0 1px 3px rgba(0, 0, 0, 0.2)',


### PR DESCRIPTION
## Description

- Remove default delayDuration of 700 from tooltips
- Use shared tooltip component everywhere
- Use color tokens in tooltips

<img width="628" alt="Screenshot 2024-06-21 at 01 13 39" src="https://github.com/inngest/inngest/assets/16758464/a8000f3c-0082-49d1-928e-b71a15efe639">
his to include a summary of the change (what). -->

## Type of change (choose one)
- [X] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
