### PR TITLE
Add color tokens to traces

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/FunctionList.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/FunctionList.tsx
@@ -23,7 +23,7 @@ export function FunctionList({ envSlug, functions }: Props) {
 
   return (
     <main
-      className="min-h-0 overflow-y-auto rounded-lg border border-slate-300 [&>table]:border-b-0"
+      className="border-muted min-h-0 overflow-y-auto rounded-lg border [&>table]:border-b-0"
       ref={tableContainerRef}
     >
       <Table

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/Sync/FunctionList.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/Sync/FunctionList.tsx
@@ -57,7 +57,7 @@ export function FunctionList({ removedFunctions, syncedFunctions }: Props) {
         collapsible
       >
         <CollapsibleCardItem value="syncedFunctions">
-          <CollapsibleCardHeader className="flex h-11 items-center justify-between border-b border-transparent px-6 text-sm font-medium text-slate-600 data-[state=open]:border-slate-300">
+          <CollapsibleCardHeader className="data-[state=open]:border-muted flex h-11 items-center justify-between border-b border-transparent px-6 text-sm font-medium text-slate-600">
             <p>Synced Functions ({syncedFunctions.length})</p>
             <CollapsibleCardTrigger
               asChild
@@ -107,7 +107,7 @@ export function FunctionList({ removedFunctions, syncedFunctions }: Props) {
         collapsible
       >
         <CollapsibleCardItem value="RemovedFunctions">
-          <CollapsibleCardHeader className="flex h-11 items-center justify-between border-b border-transparent px-6 text-sm font-medium text-slate-600 data-[state=open]:border-slate-300">
+          <CollapsibleCardHeader className="data-[state=open]:border-muted flex h-11 items-center justify-between border-b border-transparent px-6 text-sm font-medium text-slate-600">
             <p>Removed Functions ({removedFunctions.length})</p>
             <CollapsibleCardTrigger
               asChild

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/SyncList.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/syncs/SyncList.tsx
@@ -40,7 +40,7 @@ export function SyncList({
   return (
     <div
       className={classNames(
-        'w-2/5 max-w-2xl flex-shrink-0 overflow-y-auto border-r border-slate-300 bg-white sm:w-1/3',
+        'border-muted w-2/5 max-w-2xl flex-shrink-0 overflow-y-auto border-r bg-white sm:w-1/3',
         className
       )}
     >
@@ -60,7 +60,7 @@ export function SyncList({
             return (
               <li
                 className={classNames(
-                  'flex cursor-pointer items-center justify-between border-b border-slate-300 text-slate-800 hover:bg-slate-100',
+                  'border-muted flex cursor-pointer items-center justify-between border-b text-slate-800 hover:bg-slate-100',
                   bgColor
                 )}
                 key={sync.id}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/events/[eventName]/logs/layout.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/events/[eventName]/logs/layout.tsx
@@ -9,7 +9,7 @@ type EventLogsLayoutProps = {
 export default function EventLogsLayout({ children, params }: EventLogsLayoutProps) {
   return (
     <div className="flex min-h-0 flex-1">
-      <div className="w-80 flex-shrink-0 overflow-y-auto border-r border-slate-300">
+      <div className="border-muted w-80 flex-shrink-0 overflow-y-auto border-r">
         <EventLogs eventName={decodeURIComponent(params.eventName)} />
       </div>
       <div className="min-w-0 flex-1 bg-slate-50">{children}</div>

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/FunctionListNotFound.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/FunctionListNotFound.tsx
@@ -75,7 +75,7 @@ export default function FunctionListNotFound() {
           </div>
         </div>
 
-        <div className="rounded-lg border border-slate-300 px-8 pt-8">
+        <div className="border-muted rounded-lg border px-8 pt-8">
           <h3 className="flex items-center text-xl font-semibold text-slate-800">
             <span className="mr-2 inline-flex h-6 w-6  items-center justify-center rounded-full bg-slate-800 text-center text-sm text-white">
               2

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/Runs.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/Runs.tsx
@@ -120,7 +120,7 @@ export default function RunsPage({ params }: RunsPageProps) {
 
   return (
     <>
-      <div className="flex items-center justify-between gap-2 border-b border-slate-300 px-5 py-2">
+      <div className="border-muted flex items-center justify-between gap-2 border-b px-5 py-2">
         <div className="gap flex items-center gap-1.5">
           <StatusFilter
             selectedStatuses={selectedStatuses}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/StatusFilter.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/StatusFilter.tsx
@@ -102,7 +102,7 @@ export default function StatusFilter({ selectedStatuses, onStatusesChange }: Sta
                             id={status}
                             checked={selected}
                             readOnly
-                            className="h-[15px] w-[15px] rounded border-slate-300 text-indigo-500 drop-shadow-sm checked:border-indigo-500 checked:drop-shadow-none"
+                            className="border-muted h-[15px] w-[15px] rounded text-indigo-500 drop-shadow-sm checked:border-indigo-500 checked:drop-shadow-none"
                           />
                         </>
                       )}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/replay/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/replay/page.tsx
@@ -18,7 +18,7 @@ export default function FunctionReplayPage({ params }: FunctionReplayPageProps) 
   return (
     <>
       {!env.isArchived && (
-        <div className="flex items-center justify-end border-b border-slate-300 px-5 py-2">
+        <div className="border-muted flex items-center justify-end border-b px-5 py-2">
           <NewReplayButton functionSlug={functionSlug} />
         </div>
       )}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/ChildEmptyState.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/ChildEmptyState.tsx
@@ -9,7 +9,7 @@ export default function ChildEmptyState() {
   return (
     <div className="h-full w-full overflow-y-scroll py-16">
       <div className="mx-auto flex w-[640px] flex-col gap-4">
-        <div className="rounded-lg border border-slate-300 px-8 pt-8">
+        <div className="border-muted rounded-lg border px-8 pt-8">
           <h3 className="flex items-center text-xl font-semibold text-slate-800">
             Manage Keys for All Branch Environments
           </h3>

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/layout.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/layout.tsx
@@ -8,7 +8,7 @@ type KeysLayoutProps = {
 export default function KeysLayout({ children }: KeysLayoutProps) {
   return (
     <div className="flex min-h-0 flex-1">
-      <div className="w-80 flex-shrink-0 border-r border-slate-300">
+      <div className="border-muted w-80 flex-shrink-0 border-r">
         <Keys />
       </div>
       <div className="h-full min-w-0 flex-1 overflow-y-auto bg-white">{children}</div>

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/billing/BillingPlanSelector.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/billing/BillingPlanSelector.tsx
@@ -59,7 +59,7 @@ export default function BillingPlanSelector({
         const className = cn(
           `rounded-lg border`,
           plan.isActive
-            ? 'bg-white border-slate-300 outline outline-2 outline-offset-4 outline-indigo-500'
+            ? 'bg-white border-muted outline outline-2 outline-offset-4 outline-indigo-500'
             : 'bg-slate-100 border-transparent',
           plan.isPremium ? 'bg-slate-900 text-white' : 'text-slate-900'
         );

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/billing/CurrentSubscription.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/billing/CurrentSubscription.tsx
@@ -26,7 +26,7 @@ export default function CurrentSubscription({
   const freeTierFeatureRows = featureRows.filter(({ showFreeTier }) => showFreeTier);
 
   return (
-    <div className="rounded-lg border border-slate-300 bg-white">
+    <div className="border-muted rounded-lg border bg-white">
       <div className="p-6">
         {isOnPaidPlan ? (
           <>

--- a/ui/apps/dashboard/src/app/(organization-active)/support/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/support/page.tsx
@@ -238,7 +238,7 @@ function SupportTickets({ isSignedIn }: { isSignedIn?: boolean }) {
   ) : (
     <div className="w-full">
       <h3 className="mb-2 text-base font-semibold">Recent tickets</h3>
-      <div className="grid w-full grid-cols-1 divide-y divide-slate-300 rounded-md border border-slate-300 text-sm">
+      <div className="border-muted grid w-full grid-cols-1 divide-y divide-slate-300 rounded-md border text-sm">
         {tickets.length > 0
           ? tickets.map((ticket) => (
               <div key={ticket.id} className="flex items-center gap-2 px-2 py-2">

--- a/ui/apps/dashboard/src/app/layout.tsx
+++ b/ui/apps/dashboard/src/app/layout.tsx
@@ -47,11 +47,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             form: 'text-left',
             formFieldLabel: 'text-slate-600',
             formFieldInput:
-              'border border-slate-300 placeholder-slate-500 shadow transition-all text-sm px-3.5 py-3 rounded-lg',
+              'border border-muted placeholder-slate-500 shadow transition-all text-sm px-3.5 py-3 rounded-lg',
             formButtonPrimary:
               'inline-flex flex-shrink-0 items-center gap-1 justify-center overflow-hidden text-sm font-regular rounded-[6px] transition-all bg-gradient-to-b from-[#6d7bfe] to-[#6366f1] hover:from-[#7986fd] hover:to-[#7679f9] text-shadow text-white font-medium px-6 py-2.5 capitalize',
             tagInputContainer:
-              'border border-slate-300 placeholder-slate-500 shadow transition-all rounded-lg focus-within:*:ring-0 *:px-3 *:p-1.5 *:text-sm',
+              'border border-muted placeholder-slate-500 shadow transition-all rounded-lg focus-within:*:ring-0 *:px-3 *:p-1.5 *:text-sm',
             footerActionText: 'text-sm font-medium text-slate-700',
             footerActionLink:
               'transition-color text-sm font-medium text-indigo-500 underline hover:text-indigo-800',

--- a/ui/apps/dashboard/src/components/AppGitCard/AppGitCard.tsx
+++ b/ui/apps/dashboard/src/components/AppGitCard/AppGitCard.tsx
@@ -62,12 +62,9 @@ export function AppGitCard({ className, sync }: Props) {
 
   return (
     <div
-      className={classNames(
-        'overflow-hidden rounded-lg border border-slate-300 bg-white',
-        className
-      )}
+      className={classNames('border-muted overflow-hidden rounded-lg border bg-white', className)}
     >
-      <div className="border-b border-slate-300 px-6 py-3 text-sm font-medium text-slate-600">
+      <div className="border-muted border-b px-6 py-3 text-sm font-medium text-slate-600">
         Commit Information
       </div>
 

--- a/ui/apps/dashboard/src/components/AppInfoCard/AppInfoCard.tsx
+++ b/ui/apps/dashboard/src/components/AppInfoCard/AppInfoCard.tsx
@@ -88,12 +88,9 @@ export function AppInfoCard({ app, className, sync, linkToSyncs, loading }: Prop
   return (
     <>
       <div
-        className={classNames(
-          'overflow-hidden rounded-lg border border-slate-300 bg-white',
-          className
-        )}
+        className={classNames('border-muted overflow-hidden rounded-lg border bg-white', className)}
       >
-        <h2 className="border-b border-slate-300 px-6 py-3 text-sm font-medium text-slate-600">
+        <h2 className="border-muted border-b px-6 py-3 text-sm font-medium text-slate-600">
           App Information
         </h2>
 

--- a/ui/apps/dashboard/src/components/CollapsibleCard/CollapsibleCard.tsx
+++ b/ui/apps/dashboard/src/components/CollapsibleCard/CollapsibleCard.tsx
@@ -12,7 +12,7 @@ const CollapsibleCardItem = forwardRef<
     <AccordionPrimitive.Item
       {...props}
       ref={forwardedRef}
-      className="rounded-lg border border-slate-300 bg-white"
+      className="border-muted rounded-lg border bg-white"
     >
       {children}
     </AccordionPrimitive.Item>

--- a/ui/apps/dashboard/src/components/Forms/Input.tsx
+++ b/ui/apps/dashboard/src/components/Forms/Input.tsx
@@ -52,7 +52,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         placeholder={placeholder}
         value={props.value}
         className={cn(
-          'border border-slate-300 text-sm leading-none placeholder-slate-500 shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline',
+          'border-muted border text-sm leading-none placeholder-slate-500 shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline',
           sizeStyles[size],
           props.readonly &&
             'cursor-not-allowed border-transparent shadow-transparent outline-transparent	',

--- a/ui/apps/dashboard/src/components/Forms/SelectInput.tsx
+++ b/ui/apps/dashboard/src/components/Forms/SelectInput.tsx
@@ -35,7 +35,7 @@ export function SelectInput<T extends string>(props: SelectProps<T>) {
       onValueChange={props.onChange}
       required={props.required}
     >
-      <Select.Trigger className="flex items-center justify-between rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm leading-none shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline data-[placeholder]:text-slate-500">
+      <Select.Trigger className="border-muted flex items-center justify-between rounded-lg border bg-white px-3 py-1.5 text-sm leading-none shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline data-[placeholder]:text-slate-500">
         <Select.Value placeholder={props.placeholder} />
         <Select.Icon className="">
           <RiArrowDownSLine className="h-5" />
@@ -43,7 +43,7 @@ export function SelectInput<T extends string>(props: SelectProps<T>) {
       </Select.Trigger>
 
       <Select.Content
-        className="z-10 w-[var(--radix-select-trigger-width)] rounded-lg border border-slate-300 bg-white py-1 text-sm leading-none shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline"
+        className="border-muted z-10 w-[var(--radix-select-trigger-width)] rounded-lg border bg-white py-1 text-sm leading-none shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline"
         position="popper"
         sideOffset={8}
       >

--- a/ui/apps/dashboard/src/components/Forms/Textarea.tsx
+++ b/ui/apps/dashboard/src/components/Forms/Textarea.tsx
@@ -16,7 +16,7 @@ export function Textarea({ value, onChange, placeholder, rows = 3, required }: T
       }}
       rows={rows}
       required={required}
-      className="w-full rounded-lg border border-slate-300 px-3 py-3 text-sm placeholder-slate-500 shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline"
+      className="border-muted w-full rounded-lg border px-3 py-3 text-sm placeholder-slate-500 shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline"
     ></textarea>
   );
 }

--- a/ui/apps/dashboard/src/components/Secret/Secret.tsx
+++ b/ui/apps/dashboard/src/components/Secret/Secret.tsx
@@ -25,7 +25,7 @@ export function Secret({ className, kind, secret }: Props) {
   return (
     <div
       className={cn(
-        'flex overflow-hidden rounded-md border border-slate-300 bg-slate-50 text-slate-500',
+        'border-muted flex overflow-hidden rounded-md border bg-slate-50 text-slate-500',
         className
       )}
     >
@@ -34,7 +34,7 @@ export function Secret({ className, kind, secret }: Props) {
       </div>
 
       <RevealButton
-        className="border-r border-slate-300"
+        className="border-muted border-r"
         isRevealed={isRevealed}
         onClick={() => setIsRevealed((prev) => !prev)}
       />

--- a/ui/packages/components/src/AppRoot/globals.css
+++ b/ui/packages/components/src/AppRoot/globals.css
@@ -145,7 +145,7 @@
     --color-background-surface-subtle: var(--color-carbon-200);
     --color-background-surface-muted: var(--color-carbon-300);
     --color-background-disabled: var(--color-carbon-50);
-    --color-background-contrast: var(--color-matcha-1000);
+    --color-background-contrast: var(--color-carbon-1000);
     --color-background-success: var(--color-matcha-0);
     --color-background-successContrast: var(--color-matcha-800);
     --color-background-error: var(--color-ruby-0);
@@ -238,7 +238,7 @@
     --color-background-surface-subtle: var(--color-carbon-800);
     --color-background-surface-muted: var(--color-carbon-700);
     --color-background-disabled: var(--color-carbon-900);
-    --color-background-contrast: var(--color-matcha-0);
+    --color-background-contrast: var(--color-carbon-0);
     --color-background-success: var(--color-matcha-800);
     --color-background-successContrast: var(--color-matcha-100);
     --color-background-error: var(--color-ruby-800);

--- a/ui/packages/components/src/Card/Card.tsx
+++ b/ui/packages/components/src/Card/Card.tsx
@@ -39,7 +39,7 @@ export function Card({ accentColor, accentPosition = 'top', children, className 
       )}
     >
       {accentColor && <div className={cn('p-0.5', accentClass, accentColor)} />}
-      <div className={cn('w-full grow overflow-hidden border border-slate-300', contentClass)}>
+      <div className={cn('border-muted w-full grow overflow-hidden border', contentClass)}>
         {children}
       </div>
     </div>
@@ -54,7 +54,7 @@ Card.Footer = ({ children, className }: PropsWithChildren<{ className?: string }
   return (
     <div
       className={cn(
-        'border-t border-slate-300 bg-white px-6 py-3 dark:border-slate-800/50 dark:bg-slate-800/40',
+        'border-muted border-t bg-white px-6 py-3 dark:border-slate-800/50 dark:bg-slate-800/40',
         className
       )}
     >
@@ -67,7 +67,7 @@ Card.Header = ({ children, className }: PropsWithChildren<{ className?: string }
   return (
     <div
       className={cn(
-        'flex flex-col gap-1 border-b border-slate-300 bg-white py-3 pl-6 pr-4 text-sm text-slate-700 dark:border-slate-800/50 dark:bg-slate-800/40 dark:text-slate-400',
+        'border-muted flex flex-col gap-1 border-b bg-white py-3 pl-6 pr-4 text-sm text-slate-700 dark:border-slate-800/50 dark:bg-slate-800/40 dark:text-slate-400',
         className
       )}
     >

--- a/ui/packages/components/src/Card/Card.tsx
+++ b/ui/packages/components/src/Card/Card.tsx
@@ -47,19 +47,12 @@ export function Card({ accentColor, accentPosition = 'top', children, className 
 }
 
 Card.Content = ({ children, className }: PropsWithChildren<{ className?: string }>) => {
-  return <div className={cn('bg-white px-6 py-4 dark:bg-slate-800/40', className)}>{children}</div>;
+  return <div className={cn('bg-canvasBase px-6 py-4 ', className)}>{children}</div>;
 };
 
 Card.Footer = ({ children, className }: PropsWithChildren<{ className?: string }>) => {
   return (
-    <div
-      className={cn(
-        'border-muted border-t bg-white px-6 py-3 dark:border-slate-800/50 dark:bg-slate-800/40',
-        className
-      )}
-    >
-      {children}
-    </div>
+    <div className={cn('border-muted bg-canvasBase border-t px-6 py-3', className)}>{children}</div>
   );
 };
 
@@ -67,7 +60,7 @@ Card.Header = ({ children, className }: PropsWithChildren<{ className?: string }
   return (
     <div
       className={cn(
-        'border-muted flex flex-col gap-1 border-b bg-white py-3 pl-6 pr-4 text-sm text-slate-700 dark:border-slate-800/50 dark:bg-slate-800/40 dark:text-slate-400',
+        'border-muted bg-canvasBase text-basis flex flex-col gap-1 border-b py-3 pl-6 pr-4 text-sm',
         className
       )}
     >

--- a/ui/packages/components/src/CodeBlock/CodeBlock.tsx
+++ b/ui/packages/components/src/CodeBlock/CodeBlock.tsx
@@ -478,8 +478,8 @@ export function CodeBlock({ header, tab, actions = [], minLines = 0 }: CodeBlock
 CodeBlock.Wrapper = ({ children }: React.PropsWithChildren) => {
   return (
     <div
-      className="w-full overflow-hidden rounded-lg border
-     border-slate-300 dark:border-slate-700/30 dark:shadow"
+      className="border-muted w-full overflow-hidden rounded-lg
+     border dark:border-slate-700/30 dark:shadow"
     >
       {children}
     </div>

--- a/ui/packages/components/src/DatePicker/DateInputButton.tsx
+++ b/ui/packages/components/src/DatePicker/DateInputButton.tsx
@@ -9,7 +9,7 @@ export const DateInputButton = forwardRef<HTMLButtonElement, DateInputButtonProp
       <button
         {...props}
         ref={forwardRef}
-        className={`h-8 rounded-lg border border-slate-300 bg-white px-3.5 text-sm leading-none shadow outline-2 outline-indigo-500 transition-all focus:outline ${className}`}
+        className={`border-muted h-8 rounded-lg border bg-white px-3.5 text-sm leading-none shadow outline-2 outline-indigo-500 transition-all focus:outline ${className}`}
       >
         <span className="flex items-center gap-2">
           <RiCalendarLine className="h-6 w-6" />

--- a/ui/packages/components/src/DatePicker/DateTimeInput.tsx
+++ b/ui/packages/components/src/DatePicker/DateTimeInput.tsx
@@ -207,7 +207,7 @@ export function DateTimeInput({
   return (
     <div
       className={cn(
-        'flex h-8 items-center rounded-lg border border-slate-300 bg-white px-3.5 text-sm leading-none text-slate-700 placeholder-slate-300 transition-all has-[:focus]:border-slate-200',
+        'border-muted flex h-8 items-center rounded-lg border bg-white px-3.5 text-sm leading-none text-slate-700 placeholder-slate-300 transition-all has-[:focus]:border-slate-200',
         !valid && 'border-rose-500 has-[:focus]:border-rose-500'
       )}
       onPaste={(e: React.ClipboardEvent<HTMLDivElement>) => {

--- a/ui/packages/components/src/DatePicker/RangePicker.tsx
+++ b/ui/packages/components/src/DatePicker/RangePicker.tsx
@@ -173,7 +173,7 @@ export const RangePicker = ({
       </PopoverTrigger>
       <PopoverContent>
         <div className="flex flex-row bg-white">
-          <div className={`${showAbsolute && 'min-h-[589px]'} w-[250px] border-r border-slate-300`}>
+          <div className={`${showAbsolute && 'min-h-[589px]'} border-muted w-[250px] border-r`}>
             <div className="m-2">
               <Input
                 ref={durationRef}
@@ -216,7 +216,7 @@ export const RangePicker = ({
             })}
             <div className="flex flex-col">
               <div
-                className={`cursor-pointer border-t border-slate-300 px-6 py-3.5 text-sm font-normal text-slate-700 hover:bg-blue-50 ${
+                className={`border-muted cursor-pointer border-t px-6 py-3.5 text-sm font-normal text-slate-700 hover:bg-blue-50 ${
                   showAbsolute && 'bg-blue-50'
                 }`}
                 onClick={() => {

--- a/ui/packages/components/src/Forms/Input.tsx
+++ b/ui/packages/components/src/Forms/Input.tsx
@@ -23,7 +23,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         )}
         <input
           ref={ref}
-          className={`border border-slate-300 text-sm leading-none placeholder-slate-400 shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline
+          className={`border-muted border text-sm leading-none placeholder-slate-400 shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline
             ${sizeStyles[inngestSize]}
             ${
               props.readOnly &&

--- a/ui/packages/components/src/RunDetails/CancellationSummary.tsx
+++ b/ui/packages/components/src/RunDetails/CancellationSummary.tsx
@@ -17,9 +17,9 @@ export function CancellationSummary({ history }: Props) {
 
   return (
     <Card accentColor="bg-status-cancelled">
-      <Card.Header>Cancelled</Card.Header>
+      <Card.Header className="bg-white dark:bg-slate-800/40">Cancelled</Card.Header>
 
-      <Card.Content>
+      <Card.Content className="bg-white dark:bg-slate-800/40">
         {/* TODO: Make this a link */}
         <MetadataItem
           label="Event ID"

--- a/ui/packages/components/src/RunDetails/SleepingSummary.tsx
+++ b/ui/packages/components/src/RunDetails/SleepingSummary.tsx
@@ -31,9 +31,9 @@ export function SleepingSummary({ history }: Props) {
             className={i < sleeps.length - 1 ? 'mb-4' : undefined}
             key={sleep.groupID}
           >
-            <Card.Header>Sleeping</Card.Header>
+            <Card.Header className="bg-white dark:bg-slate-800/40">Sleeping</Card.Header>
 
-            <Card.Content>
+            <Card.Content className="bg-white dark:bg-slate-800/40">
               <MetadataItem label="Sleep Until" value={config.until.toLocaleString()} />
             </Card.Content>
           </Card>

--- a/ui/packages/components/src/RunDetails/WaitingSummary.tsx
+++ b/ui/packages/components/src/RunDetails/WaitingSummary.tsx
@@ -32,9 +32,9 @@ export function WaitingSummary({ history }: Props) {
             className={i < waits.length - 1 ? 'mb-4' : undefined}
             key={wait.groupID}
           >
-            <Card.Header>Waiting for event</Card.Header>
+            <Card.Header className="bg-white dark:bg-slate-800/40">Waiting for event</Card.Header>
 
-            <Card.Content>
+            <Card.Content className="bg-white dark:bg-slate-800/40">
               <MetadataItem
                 label="Event Name"
                 value={

--- a/ui/packages/components/src/TimelineV2/InlineSpans.tsx
+++ b/ui/packages/components/src/TimelineV2/InlineSpans.tsx
@@ -48,7 +48,7 @@ export function InlineSpans({ className, minTime, maxTime, name, spans, widths }
     <Tooltip>
       <TooltipTrigger className="h-fit grow">
         <div className={cn('flex h-8 grow items-center', className)}>
-          <div className="h-px bg-slate-300" style={{ flexGrow: widths.before }}></div>
+          <div className="bg-contrast h-px" style={{ flexGrow: widths.before }}></div>
 
           <div
             className="flex"
@@ -63,7 +63,7 @@ export function InlineSpans({ className, minTime, maxTime, name, spans, widths }
             })}
           </div>
 
-          <div className="h-px bg-slate-300" style={{ flexGrow: widths.after }}></div>
+          <div className="bg-contrast h-px" style={{ flexGrow: widths.after }}></div>
         </div>
       </TooltipTrigger>
       <TooltipContent>

--- a/ui/packages/components/src/TimelineV2/Span.tsx
+++ b/ui/packages/components/src/TimelineV2/Span.tsx
@@ -44,7 +44,7 @@ export function Span({ className, isInline, maxTime, minTime, trace }: Props) {
       <div className="bg-contrast h-px" style={{ flexGrow: widths.before }}></div>
 
       {/* Queued part of the span */}
-      <div className="bg-surfaceMuted h-2" style={{ flexGrow: widths.queued }}></div>
+      <div className="bg-surfaceSubtle h-2" style={{ flexGrow: widths.queued }}></div>
 
       {/* Running part of the span */}
       <div

--- a/ui/packages/components/src/TimelineV2/Span.tsx
+++ b/ui/packages/components/src/TimelineV2/Span.tsx
@@ -41,10 +41,10 @@ export function Span({ className, isInline, maxTime, minTime, trace }: Props) {
       }}
     >
       {/* Gray line to the left of the span */}
-      <div className="h-px bg-slate-300" style={{ flexGrow: widths.before }}></div>
+      <div className="bg-contrast h-px" style={{ flexGrow: widths.before }}></div>
 
       {/* Queued part of the span */}
-      <div className="h-2 bg-slate-500" style={{ flexGrow: widths.queued }}></div>
+      <div className="bg-surfaceMuted h-2" style={{ flexGrow: widths.queued }}></div>
 
       {/* Running part of the span */}
       <div
@@ -57,7 +57,7 @@ export function Span({ className, isInline, maxTime, minTime, trace }: Props) {
       ></div>
 
       {/* Gray line to the right of the span */}
-      <div className="h-px bg-slate-300" style={{ flexGrow: widths.after }}></div>
+      <div className="bg-contrast h-px" style={{ flexGrow: widths.after }}></div>
     </div>
   );
 }

--- a/ui/packages/components/src/TimelineV2/TraceHeading.tsx
+++ b/ui/packages/components/src/TimelineV2/TraceHeading.tsx
@@ -35,7 +35,7 @@ export function TraceHeading({ isExpanded, isExpandable, onClickExpandToggle, tr
         <Tooltip>
           <TooltipTrigger>
             <Badge
-              className="border border-slate-400 bg-white px-1.5"
+              className="border-muted text-muted border px-1.5"
               flatSide={isRetried ? 'right' : undefined}
               kind="solid"
             >
@@ -49,7 +49,7 @@ export function TraceHeading({ isExpanded, isExpandable, onClickExpandToggle, tr
           <Tooltip>
             <TooltipTrigger>
               <Badge
-                className="border-r-1 border-l-0 border-slate-400 bg-white px-1.5"
+                className="border-r-1 border-muted text-muted border-l-0 px-1.5"
                 flatSide="left"
                 kind="solid"
               >
@@ -84,7 +84,7 @@ export function TraceHeading({ isExpanded, isExpandable, onClickExpandToggle, tr
           <span className="mt-1 h-fit self-start text-sm">{trace.name}</span>
           <div className="flex h-8 grow items-center">
             {opCodeBadge}
-            <div className="ml-2 h-px grow bg-slate-100" />
+            <div className="bg-canvasMuted ml-2 h-px grow" />
           </div>
         </div>
         <TimeWithText trace={trace} />

--- a/ui/packages/components/src/TimelineV2/TraceInfo.tsx
+++ b/ui/packages/components/src/TimelineV2/TraceInfo.tsx
@@ -145,7 +145,7 @@ export function TraceInfo({ className, pathCreator, trace, result }: Props) {
             {stepKindInfo}
           </dl>
         </Card.Content>
-        {result && <RunResult className="border-t border-slate-300" result={result} />}
+        {result && <RunResult className="border-subtle border-t" result={result} />}
       </Card>
     </div>
   );


### PR DESCRIPTION
## Description
- Replace all `border-slate-300` by `border-muted` token in the apps
- Change shared component Card colors, keep their old background in 3 components used in the old runs slideover
- Add color tokens to traces

<img width="1511" alt="Screenshot 2024-06-21 at 16 23 15" src="https://github.com/inngest/inngest/assets/16758464/8ab5e8ea-065d-47f1-972d-88ad727680b9">
<img width="1500" alt="Screenshot 2024-06-21 at 16 22 37" src="https://github.com/inngest/inngest/assets/16758464/ab3b9f1b-f2af-457a-8ef8-9d70160b7bf1">

Note: all we need to do now is change code blocks colors and replace buttons by new ones (different PRs)

## Motivation
This work is needed for the Dev Server runs page. The colors are slightly different from what was in figma, but John is aware of it.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
