### PR TITLE
EWMA backed dynamic partition peek

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
             nodePackages.typescript-language-server
             nodePackages.vscode-json-languageserver
             nodePackages.yaml-language-server
+            lua-language-server
 
             # Tools
             sqlite

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -215,6 +215,10 @@ type QueueKeyGenerator interface {
 	// Status returns the key used for status queue for the provided function.
 	Status(status string, fnID uuid.UUID) string
 
+	// ConcurrencyFnEWMA returns the key storing the amount of times of concurrency hits, used for
+	// calculating the EWMA value for the function
+	ConcurrencyFnEWMA(fnID uuid.UUID) string
+
 	// ***************** Deprecated ************************
 	BatchPointer(context.Context, uuid.UUID) string
 	Batch(context.Context, ulid.ULID) string
@@ -365,4 +369,8 @@ func (d DefaultQueueKeyGenerator) RunIndex(runID ulid.ULID) string {
 
 func (d DefaultQueueKeyGenerator) Status(status string, fnID uuid.UUID) string {
 	return fmt.Sprintf("%s:queue:status:%s:%s", d.Prefix, fnID, status)
+}
+
+func (d DefaultQueueKeyGenerator) ConcurrencyFnEWMA(fnID uuid.UUID) string {
+	return fmt.Sprintf("%s:queue:concurrency-ewma:%s", d.Prefix, fnID)
 }

--- a/pkg/execution/state/redis_state/lua/queue/setPeekEWMA.lua
+++ b/pkg/execution/state/redis_state/lua/queue/setPeekEWMA.lua
@@ -13,8 +13,14 @@ local maxSize  = ARGV[2]
 redis.call("RPUSH", ewmaKey)
 
 local len = redis.call("LLEN", ewmaKey)
+-- take out the oldest one when exceeded
 if len > maxSize then
   redis.call("LPOP", ewmaKey)
 end
+
+-- expire or override the expiration of the key after 30s
+-- this will make sure that functions that don't have a lot of load
+-- won't take up a lot of key space
+redis.call("EXPIRE", ewmaKey, 30)
 
 return 0

--- a/pkg/execution/state/redis_state/lua/queue/setPeekEWMA.lua
+++ b/pkg/execution/state/redis_state/lua/queue/setPeekEWMA.lua
@@ -7,8 +7,8 @@ old values will be discarded as the size exceeds the limit
 
 local ewmaKey = KEYS[1]
 
-local newValue = ARGV[1]
-local maxSize  = ARGV[2]
+local newValue = tonumber(ARGV[1])
+local maxSize  = tonumber(ARGV[2])
 
 redis.call("RPUSH", ewmaKey)
 

--- a/pkg/execution/state/redis_state/lua/queue/setPeekEWMA.lua
+++ b/pkg/execution/state/redis_state/lua/queue/setPeekEWMA.lua
@@ -1,0 +1,20 @@
+--[[
+
+sets the new value to the EWMA list
+old values will be discarded as the size exceeds the limit
+
+]]
+
+local ewmaKey = KEYS[1]
+
+local newValue = ARGV[1]
+local maxSize  = ARGV[2]
+
+redis.call("RPUSH", ewmaKey)
+
+local len = redis.call("LLEN", ewmaKey)
+if len > maxSize then
+  redis.call("LPOP", ewmaKey)
+end
+
+return 0

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -64,7 +64,7 @@ const (
 
 	// default values
 	QueuePeekMin            int64 = 300
-	QueuePeekMax            int64 = 2500
+	QueuePeekMax            int64 = 5000
 	QueuePeekCurrMultiplier int64 = 4 // threshold 25%
 	QueuePeekEWMALen        int   = 10
 	QueueLeaseDuration            = 20 * time.Second

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -244,7 +244,7 @@ func WithAsyncInstrumentation() QueueOpt {
 	return func(q *queue) {
 		telemetry.GaugeWorkerQueueCapacity(ctx, telemetry.GaugeOpt{
 			PkgName:  pkgName,
-			Callback: func(ctx context.Context) (int64, error) { return q.capacity(), nil },
+			Callback: func(ctx context.Context) (int64, error) { return int64(q.numWorkers), nil },
 		})
 
 		telemetry.GaugeGlobalQueuePartitionCount(ctx, telemetry.GaugeOpt{

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -2093,6 +2093,11 @@ func (q *queue) peekEWMA(ctx context.Context, fnID uuid.UUID) (int64, error) {
 		return 0, fmt.Errorf("error reading function concurrency EWMA values: %w", err)
 	}
 
+	// return early
+	if len(currVals) == 0 {
+		return 0, nil
+	}
+
 	// create a simple EWMA, add all the numbers in it and get the final value
 	// NOTE: we don't need variable since we don't want to maintain this in memory
 	mavg := ewma.NewMovingAverage()

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -204,6 +204,13 @@ func WithPeekSize(n int64) QueueOpt {
 	}
 }
 
+func WithPeekRange(min int64, max int64) QueueOpt {
+	return func(q *queue) {
+		q.peekMin = min
+		q.peekMax = max
+	}
+}
+
 // WithPollTick specifies the interval at which the queue will poll the backing store
 // for available partitions.
 func WithPollTick(t time.Duration) QueueOpt {
@@ -451,6 +458,9 @@ type queue struct {
 	numWorkers int32
 	// peek sets the number of items to check on queue peeks
 	peek int64
+	// peek min & max sets the range for partitions to peek for items
+	peekMin int64
+	peekMax int64
 	// workers is a buffered channel which allows scanners to send queue items
 	// to workers to be processed
 	workers chan processItem

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -695,7 +695,7 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, shard *
 		peek := q.peekSize(ctx, p.WorkflowID)
 		// NOTE: would love to instrument this value to see it over time per function but
 		// it's likely too high of a cardinality
-		go telemetry.HistogramPeekEWMA(ctx, peek, telemetry.HistogramOpt{PkgName: pkgName})
+		go telemetry.HistogramQueuePeekEWMA(ctx, peek, telemetry.HistogramOpt{PkgName: pkgName})
 		return q.Peek(peekCtx, p.Queue(), fetch, peek)
 	})
 	if err != nil {

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -902,7 +902,7 @@ ProcessLoop:
 		q.workers <- processItem{P: *p, I: *item, S: shard}
 	}
 
-	if err := q.setPeekEWMA(ctx, int64(ctrConcurrency+ctrRateLimit)); err != nil {
+	if err := q.setPeekEWMA(ctx, p.WorkflowID, int64(ctrConcurrency+ctrRateLimit)); err != nil {
 		log.From(ctx).Warn().Msg("error recording concurrency limit for EWMA")
 	}
 

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/VividCortex/ewma"
+	"github.com/google/uuid"
 	osqueue "github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/inngest/log"
@@ -691,7 +692,13 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, shard *
 	fetch := getNow().Truncate(time.Second).Add(PartitionLookahead)
 
 	queue, err := duration(peekCtx, "peek", func(ctx context.Context) ([]*QueueItem, error) {
-		return q.Peek(peekCtx, p.Queue(), fetch, q.peekSize())
+		// NOTE: would love to instrument this value to see it over time per function but
+		// it's likely too high of a cardinality
+		//
+		// TODO: instrument it as a distribution at least, so we get a rough idea how well the
+		// multiplier is working
+		peek := q.peekSize(ctx, p.WorkflowID)
+		return q.Peek(peekCtx, p.Queue(), fetch, peek)
 	})
 	if err != nil {
 		return err
@@ -893,6 +900,10 @@ ProcessLoop:
 			Tags:    map[string]any{"status": "success"},
 		})
 		q.workers <- processItem{P: *p, I: *item, S: shard}
+	}
+
+	if err := q.setPeekEWMA(ctx, int64(ctrConcurrency+ctrRateLimit)); err != nil {
+		log.From(ctx).Warn().Msg("error recording concurrency limit for EWMA")
 	}
 
 	// If we've hit concurrency issues OR we've only hit rate limit issues, re-enqueue the partition
@@ -1165,12 +1176,41 @@ func (q *queue) capacity() int64 {
 	return int64(q.numWorkers) - atomic.LoadInt64(&q.sem.counter)
 }
 
-// peekSize returns the total number of available workers which can consume individual
-// queue items.
-func (q *queue) peekSize() int64 {
-	size := q.peek
-	if size == 0 {
-		size = QueuePeekMax
+// peekSize returns the number of items to peek for the queue based on a couple of factors
+// 1. EWMA of concurrency limit hits
+// 2. configured min, max of peek size range
+// 3. worker capacity
+func (q *queue) peekSize(ctx context.Context, fnID uuid.UUID) int64 {
+	// retrieve the EWMA value
+	ewma, err := q.peekEWMA(ctx, fnID)
+	if err != nil {
+		// return the minimum if there's an error
+		return q.peekMin
+	}
+
+	// set multiplier
+	multiplier := q.peekCurrMultiplier
+	if multiplier == 0 {
+		multiplier = QueuePeekCurrMultiplier
+	}
+
+	// set ranges
+	min := q.peekMin
+	if min == 0 {
+		min = QueuePeekMin
+	}
+	max := q.peekMax
+	if max == 0 {
+		max = QueuePeekMax
+	}
+
+	// calculate size with EWMA and multiplier
+	size := ewma * multiplier
+	switch {
+	case size < min:
+		size = min
+	case size > max:
+		size = max
 	}
 
 	cap := q.capacity()

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -543,6 +543,7 @@ func (q *queue) worker(ctx context.Context, f osqueue.RunFunc) {
 			processCtx, cancel := context.WithCancel(context.Background())
 			err := q.process(processCtx, i.P, i.I, i.S, f)
 			q.sem.Release(1)
+			telemetry.WorkerQueueCapacityCounter(ctx, -1, telemetry.CounterOpt{PkgName: pkgName})
 			cancel()
 			if err == nil {
 				continue
@@ -898,6 +899,7 @@ ProcessLoop:
 			Tags:    map[string]any{"status": "success"},
 		})
 		q.workers <- processItem{P: *p, I: *item, S: shard}
+		telemetry.WorkerQueueCapacityCounter(ctx, 1, telemetry.CounterOpt{PkgName: pkgName})
 	}
 
 	if err := q.setPeekEWMA(ctx, p.WorkflowID, int64(ctrConcurrency+ctrRateLimit)); err != nil {

--- a/pkg/telemetry/counter.go
+++ b/pkg/telemetry/counter.go
@@ -100,3 +100,12 @@ func IncrQueueSequentialLeaseClaimsCounter(ctx context.Context, opts CounterOpt)
 		Tags:        opts.Tags,
 	})
 }
+
+func WorkerQueueCapacityCounter(ctx context.Context, incr int64, opts CounterOpt) {
+	RecordUpDownCounterMetric(ctx, incr, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "queue_worker_capacity_in_use",
+		Description: "Capacity of current worker",
+		Tags:        opts.Tags,
+	})
+}

--- a/pkg/telemetry/histogram.go
+++ b/pkg/telemetry/histogram.go
@@ -64,3 +64,13 @@ func HistogramQueuePeekSize(ctx context.Context, value int64, opts HistogramOpt)
 		Boundaries:  peekSizeBoundaries,
 	})
 }
+
+func HistogramPeekEWMA(ctx context.Context, value int64, opts HistogramOpt) {
+	RecordIntHistogramMetric(ctx, value, HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "queue_peek_ewma",
+		Description: "Distribution of the EWMA values for peeks",
+		Tags:        opts.Tags,
+		Boundaries:  peekSizeBoundaries,
+	})
+}

--- a/pkg/telemetry/histogram.go
+++ b/pkg/telemetry/histogram.go
@@ -65,7 +65,7 @@ func HistogramQueuePeekSize(ctx context.Context, value int64, opts HistogramOpt)
 	})
 }
 
-func HistogramPeekEWMA(ctx context.Context, value int64, opts HistogramOpt) {
+func HistogramQueuePeekEWMA(ctx context.Context, value int64, opts HistogramOpt) {
 	RecordIntHistogramMetric(ctx, value, HistogramOpt{
 		PkgName:     opts.PkgName,
 		MetricName:  "queue_peek_ewma",


### PR DESCRIPTION
## Description

This change introduces EWMA into partition peeking to enable a dynamic peek size.
We currently pre-configure the peek size and there's no adaptability based on usage, load, etc for the function.

The initial version of this change is purely to consider the concurrency hits since it's the typical item that lowers execution throughput.

With dynamic peeking introduced, it should improved throughput, and make the processing even more fair.
This should be able to be used as a basis to consider other metrics in the future.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
