### PR TITLE
Correct copy in the pause modal

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/PauseButton.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/PauseButton.tsx
@@ -102,10 +102,9 @@ function PauseFunctionModal({
       )}
       {!isPaused && (
         <ul className="list-inside list-disc p-6 pb-0 leading-8">
-          <li>Existing runs will continue to run to completion.</li>
           <li>No new runs will be queued or invoked.</li>
+          <li>Existing runs will continue to run to completion.</li>
           <li>Events will continue to be received, but they will not trigger new runs.</li>
-          <li>Paused functions will be unpaused when you resync your app.</li>
           <li>Functions can be resumed at any time.</li>
         </ul>
       )}


### PR DESCRIPTION
## Description

It's no longer true that functions are unpaused on app sync. This PR corrects dashboard copy to reflect that.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.
