### PR TITLE
Check partition backlog as part of deciding peek size

### DIFF
--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -1219,7 +1219,8 @@ func (q *queue) peekSize(ctx context.Context, p *QueuePartition) int64 {
 		size = qsize
 	}
 
-	cap := q.capacity()
+	// add 10% expecting for some workflow that will finish in the mean time
+	cap := int64(float64(q.capacity()) * 1.1)
 	if size > cap {
 		size = cap
 	}


### PR DESCRIPTION
## Description

EWMA only use concurrency limits as a factor right now.
This change will make peekSize function also consider the backlog as well deciding how many items to retrieve for processing.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
