### PR TITLE
INN-3143: use inline vercel connect flow, not popout

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/connect/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/connect/page.tsx
@@ -56,7 +56,7 @@ export default function VercelConnect() {
       <div>
         <NewButton
           appearance="solid"
-          href="https://vercel.com/integrations/inngest"
+          href="https://vercel.com/integrations/inngest/new"
           label="Connect Vercel to Inngest"
         />
       </div>


### PR DESCRIPTION
## Description

When I switched from inngest-local-dev to proper ingest, I didn't point it to the new inline connect flow. 

## Motivation
Better, synchronous vercel connect flow

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ x ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ x ] I've linked any associated issues to this PR.
- [ x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
