### PR TITLE
Fix: Maze survey cannot be clicked when overlay is shown

### DIFF
--- a/ui/packages/components/src/AppRoot/globals.css
+++ b/ui/packages/components/src/AppRoot/globals.css
@@ -323,3 +323,9 @@
     --color-accent-2xIntense: var(--color-honey-200);
   }
 }
+
+/* Fix Maze.co pop up interactions when overlays are visible */
+#maze-contextual-widget-host,
+#maze-media-host {
+  pointer-events: auto;
+}


### PR DESCRIPTION
## Description

We add `pointer-events: none` to the `body` tag which makes everything, even visible not interactable.

## Motivation
User report.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
