### PR TITLE
Do not double report `waitForEvent` during parallelism

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2651,11 +2651,12 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, i *runInstan
 			consts.OtelPropagationKey: carrier,
 		},
 	})
-	if err == state.ErrPauseAlreadyExists {
-		return nil
-	}
 	if err != nil {
 		span.Cancel(ctx)
+		if err == state.ErrPauseAlreadyExists {
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

During parallelism, ensures that re-reported `waitForEvent` ops following discovery steps have their spans cancelled to ensure we don't duplicate the log in the trace view.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
