### PR TITLE
for emscripten, don't resolve fs in the browser

### DIFF
--- a/ui/apps/dashboard/next.config.js
+++ b/ui/apps/dashboard/next.config.js
@@ -6,6 +6,11 @@ const nextConfig = {
   productionBrowserSourceMaps: true,
   experimental: {
     // typedRoutes: true,
+    turbo: {
+      resolveAlias: {
+        fs: { browser: 'empty' },
+      },
+    },
   },
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Description

Get emscripten to work with turbo for local dev by not resolving fs in the browser.

## Motivation
Make the signing key page work for local dev.

## Type of change (choose one)
- [x ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ x] I've linked any associated issues to this PR.
- [ x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
