### PR TITLE
Fix internal metadata not disallowed for user events

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -164,13 +163,11 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 				return err
 			}
 
-			if _, ok := evt.Data["_inngest"]; ok {
-				// User event data must not have internal metadata since it can
-				// cause issues. For example, if an invoked function's event
-				// data is forwarded into a new event then it may accidentally
-				// fulfill the invocation
-				return errors.New("event data must not contain internal metadata (the _inngest key)")
-			}
+			// External event (i.e. doesn't have the "inngest/" prefix) data
+			// must not have internal metadata since it can cause issues. For
+			// example, if an invoked function's event data is forwarded into a
+			// new event then it may accidentally fulfill the invocation
+			delete(evt.Data, "_inngest")
 
 			ts := time.Now()
 			if evt.Timestamp == 0 {


### PR DESCRIPTION
## Description
Disallow internal metadata (`event.data._inngest`) for user events

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
