### PR TITLE
Fix Windows looping forever looking for config files

### DIFF
--- a/cmd/commands/internal/devconfig/devconfig.go
+++ b/cmd/commands/internal/devconfig/devconfig.go
@@ -39,8 +39,16 @@ func loadConfigFile(ctx context.Context, cmd *cobra.Command) {
 			l.Warn().Err(err).Msg("error getting current directory")
 		} else {
 			// Walk up the directory tree looking for a config file
-			for dir := cwd; dir != "/"; dir = filepath.Dir(dir) {
+			dir := cwd
+			for {
 				viper.AddConfigPath(dir)
+
+				parent := filepath.Dir(dir)
+				if parent == dir {
+					break
+				}
+
+				dir = parent
 			}
 		}
 
@@ -48,7 +56,7 @@ func loadConfigFile(ctx context.Context, cmd *cobra.Command) {
 			l.Warn().Err(err).Msg("error getting home directory")
 		} else {
 			// Fallback to ~/.config/inngest
-			viper.AddConfigPath(filepath.Join(homeDir, ".config/inngest"))
+			viper.AddConfigPath(filepath.Join(homeDir, ".config", "inngest"))
 		}
 	}
 


### PR DESCRIPTION
## Description

Fixes `inngest-cli dev` on Windows, which hangs due to a never-ending recursion looking for the root path `"/"` which will never exist.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
