### PR TITLE
Add Event.IsInternal

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -158,7 +157,7 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 				return err
 			}
 
-			if strings.HasPrefix(strings.ToLower(evt.Name), "inngest/") {
+			if evt.IsInternal() {
 				err := fmt.Errorf("event name is reserved for internal use: %s", evt.Name)
 				return err
 			}

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -15,13 +15,14 @@ import (
 )
 
 const (
-	EventReceivedName = "event/event.received"
-	FnFailedName      = "inngest/function.failed"
-	FnFinishedName    = "inngest/function.finished"
+	EventReceivedName  = "event/event.received"
+	InternalNamePrefix = "inngest/"
+	FnFailedName       = InternalNamePrefix + "function.failed"
+	FnFinishedName     = InternalNamePrefix + "function.finished"
 	// InvokeEventName is the event name used to invoke specific functions via an
 	// API.  Note that invoking functions still sends an event in the usual manner.
-	InvokeFnName = "inngest/function.invoked"
-	FnCronName   = "inngest/scheduled.timer"
+	InvokeFnName = InternalNamePrefix + "function.invoked"
+	FnCronName   = InternalNamePrefix + "scheduled.timer"
 )
 
 var (
@@ -126,6 +127,10 @@ func (e Event) CorrelationID() string {
 	}
 
 	return ""
+}
+
+func (e Event) IsInternal() bool {
+	return strings.HasPrefix(e.Name, InternalNamePrefix)
 }
 
 // IsFinishedEvent returns true if the event is a function finished event.


### PR DESCRIPTION
## Description
Add an `Event.IsInternal` method for determining whether an event is an internal system event, which we don't allow users to send

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
