### PR TITLE
Add rateLimit.burst support

### DIFF
--- a/pkg/execution/ratelimit/ratelimit.go
+++ b/pkg/execution/ratelimit/ratelimit.go
@@ -64,9 +64,14 @@ func rateLimit(ctx context.Context, store throttled.GCRAStoreCtx, key string, c 
 		return true, -1, err
 	}
 
+	maxBurst := 0
+	if c.Burst != nil {
+		maxBurst = int(*c.Burst)
+	}
+
 	quota := throttled.RateQuota{
 		MaxRate:  throttled.PerDuration(int(c.Limit), dur),
-		MaxBurst: int(c.Limit) / 10,
+		MaxBurst: maxBurst,
 	}
 
 	limiter, err := throttled.NewGCRARateLimiterCtx(store, quota)

--- a/pkg/inngest/workflow.go
+++ b/pkg/inngest/workflow.go
@@ -87,6 +87,10 @@ func (s WorkflowStep) RetryCount() int {
 }
 
 type RateLimit struct {
+	// Burst is how many extra function runs can be triggered within a time
+	// bucket. Note that increasing this value may lead to rate limit exceedance
+	Burst *uint `json:"burst,omitempty"`
+
 	// Limit is how often the function can be called within the specified period
 	Limit uint `json:"limit"`
 	// Period represents the time period for throttling the function


### PR DESCRIPTION
## Description
- Allow users to specify `rateLimit.burst`
- Remove default burst of `limit / 10`, since increasing the burst can result in rate limit exceedance

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
