### PR TITLE
Add GetActiveRunIDs and CountActiveRuns to history reader

### DIFF
--- a/pkg/history_drivers/memory_reader/reader.go
+++ b/pkg/history_drivers/memory_reader/reader.go
@@ -202,6 +202,20 @@ func (r *reader) CountReplayRuns(ctx context.Context, opts history_reader.CountR
 	return history_reader.ReplayRunCounts{}, errors.New("not implemented")
 }
 
+func (r *reader) GetActiveRunIDs(
+	ctx context.Context,
+	opts history_reader.GetActiveRunIDsOpts,
+) ([]ulid.ULID, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (r *reader) CountActiveRuns(
+	ctx context.Context,
+	opts history_reader.CountActiveRunsOpts,
+) (int, error) {
+	return 0, errors.New("not implemented")
+}
+
 func toRunHistory(item history.History) (*history_reader.RunHistory, error) {
 	var cancel *history_reader.RunHistoryCancel
 	if item.Cancel != nil {

--- a/pkg/history_reader/reader.go
+++ b/pkg/history_reader/reader.go
@@ -58,6 +58,20 @@ type Reader interface {
 	) ([]Run, error)
 	GetUsage(ctx context.Context, opts GetUsageOpts) ([]usage.UsageSlot, error)
 
+	// GetActiveRunIDs returns the IDs of runs that are queued or running (i.e.
+	// not ended)
+	GetActiveRunIDs(
+		ctx context.Context,
+		opts GetActiveRunIDsOpts,
+	) ([]ulid.ULID, error)
+
+	// GetActiveRunIDs returns a count of runs that are queued or running (i.e.
+	// not ended)
+	CountActiveRuns(
+		ctx context.Context,
+		opts CountActiveRunsOpts,
+	) (int, error)
+
 	// This also embeds the V1 function reader interface.
 	cqrs.APIV1FunctionRunReader
 }
@@ -396,4 +410,71 @@ func (c CountReplayRunsOpts) Validate() error {
 		Cursor:      nil,
 	}
 	return gRROpts.Validate()
+}
+
+type GetActiveRunIDsOpts struct {
+	AccountID   uuid.UUID
+	WorkspaceID uuid.UUID
+	WorkflowID  uuid.UUID
+	LowerTime   time.Time
+	UpperTime   time.Time
+	Limit       int
+	Cursor      *ulid.ULID
+}
+
+func (c GetActiveRunIDsOpts) Validate() error {
+	if c.AccountID == uuid.Nil {
+		return errors.New("account ID must be provided")
+	}
+	if c.WorkspaceID == uuid.Nil {
+		return errors.New("workspace ID must be provided")
+	}
+	if c.WorkflowID == uuid.Nil {
+		return errors.New("workflow ID must be provided")
+	}
+	if c.LowerTime.IsZero() {
+		return errors.New("lower time must be provided")
+	}
+	if c.UpperTime.IsZero() {
+		return errors.New("upper time must be provided")
+	}
+	if c.UpperTime.Before(c.LowerTime) {
+		return errors.New("upper/end time must be after lower/start time")
+	}
+	if c.Limit < 0 {
+		return errors.New("limit must be positive")
+	}
+
+	return nil
+}
+
+type CountActiveRunsOpts struct {
+	AccountID   uuid.UUID
+	WorkspaceID uuid.UUID
+	WorkflowID  uuid.UUID
+	LowerTime   *time.Time
+	UpperTime   time.Time
+}
+
+func (c CountActiveRunsOpts) Validate() error {
+	if c.AccountID == uuid.Nil {
+		return errors.New("account ID must be provided")
+	}
+	if c.WorkspaceID == uuid.Nil {
+		return errors.New("workspace ID must be provided")
+	}
+	if c.WorkflowID == uuid.Nil {
+		return errors.New("workflow ID must be provided")
+	}
+	if c.LowerTime.IsZero() {
+		return errors.New("lower time must be provided")
+	}
+	if c.UpperTime.IsZero() {
+		return errors.New("upper time must be provided")
+	}
+	if c.LowerTime != nil && c.UpperTime.Before(*c.LowerTime) {
+		return errors.New("upper/end time must be after lower/start time")
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Description
Add `GetActiveRunIDs` and `CountActiveRuns` to the history reader interface. We'll use these for bulk cancellation

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
