### PR TITLE
Add CancelRequest.ForceLifecycleHook

### DIFF
--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -187,6 +187,12 @@ type CancelRequest struct {
 	Expression     *string
 	UserID         *uuid.UUID
 	CancellationID *ulid.ULID
+
+	// ForceLifecycleHook is used to force the OnFunctionCancelled lifecycle
+	// hook to run even if the function is already finalized. This is useful
+	// when a user wants to cancel a "false stuck" function run (i.e. it isn't
+	// in the state store but the history store thinks it's running)
+	ForceLifecycleHook bool
 }
 
 type ResumeRequest struct {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1807,7 +1807,7 @@ func (e *executor) Cancel(ctx context.Context, id sv2.ID, r execution.CancelRequ
 		Err: &fnCancelledErr,
 	}); err != nil {
 		logger.From(ctx).Error().Err(err).Msg("error running finish handler")
-	} else if performedFinalization {
+	} else if performedFinalization || r.ForceLifecycleHook {
 		ctx = e.extractTraceCtx(ctx, md, nil)
 		for _, e := range e.lifecycles {
 			go e.OnFunctionCancelled(context.WithoutCancel(ctx), md, r, evts)


### PR DESCRIPTION
## Description
Add `CancelRequest.ForceLifecycleHook`. This will be used for mark "false stuck" function runs as cancelled

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
