### PR TITLE
INN 3298 Add color tokens to date picker

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/PauseButton.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/PauseButton.tsx
@@ -3,29 +3,33 @@
 import { useState } from 'react';
 import { Button } from '@inngest/components/Button';
 import { AlertModal } from '@inngest/components/Modal';
+import { Select } from '@inngest/components/Select/Select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';
 import { RiPauseLine, RiPlayFill } from '@remixicon/react';
 import { toast } from 'sonner';
 import { useMutation, useQuery } from 'urql';
 
 import { useEnvironment } from '@/components/Environments/environment-context';
-import { SelectInput } from '@/components/Forms/SelectInput';
 import { graphql } from '@/gql';
 
 type CurrentRunHandlingOption = {
-  label: string;
-  value: string;
+  name: string;
+  id: string;
 };
 const CURRENT_RUN_HANDLING_STRATEGY_SUSPEND = 'suspend';
 const CURRENT_RUN_HANDLING_STRATEGY_CANCEL = 'cancel';
 const currentRunHandlingOptions: CurrentRunHandlingOption[] = [
   {
-    label: 'Pause immediately, then cancel after 7 days',
-    value: CURRENT_RUN_HANDLING_STRATEGY_SUSPEND,
+    name: 'Pause immediately, then cancel after 7 days',
+    id: CURRENT_RUN_HANDLING_STRATEGY_SUSPEND,
   },
-  { label: 'Cancel immediately', value: CURRENT_RUN_HANDLING_STRATEGY_CANCEL },
+  { name: 'Cancel immediately', id: CURRENT_RUN_HANDLING_STRATEGY_CANCEL },
 ];
-type CurrentRunHandlingStrategy = (typeof currentRunHandlingOptions)[number]['value'];
+
+const defaultOption: CurrentRunHandlingOption = {
+  name: 'Pause immediately, then cancel after 7 days',
+  id: CURRENT_RUN_HANDLING_STRATEGY_SUSPEND,
+};
 
 const FunctionVersionNumberDocument = graphql(`
   query GetFunctionVersionNumber($slug: String!, $environmentID: ID!) {
@@ -80,16 +84,16 @@ function PauseFunctionModal({
   const [, pauseFunction] = useMutation(PauseFunctionDocument);
   const [, unpauseFunction] = useMutation(UnpauseFunctionDocument);
   const [currentRunHandlingStrategy, setCurrentRunHandlingStrategy] =
-    useState<CurrentRunHandlingStrategy>(CURRENT_RUN_HANDLING_STRATEGY_SUSPEND);
+    useState<CurrentRunHandlingOption>(currentRunHandlingOptions[0] || defaultOption);
 
   function onCloseWrapper() {
-    setCurrentRunHandlingStrategy(CURRENT_RUN_HANDLING_STRATEGY_SUSPEND);
+    setCurrentRunHandlingStrategy(currentRunHandlingOptions[0] || defaultOption);
     onClose();
   }
   function handlePause() {
     pauseFunction({
       fnID: functionID,
-      cancelRunning: currentRunHandlingStrategy == CURRENT_RUN_HANDLING_STRATEGY_CANCEL,
+      cancelRunning: currentRunHandlingStrategy.id == CURRENT_RUN_HANDLING_STRATEGY_CANCEL,
     }).then((result) => {
       if (result.error) {
         toast.error(`“${functionName}” could not be paused: ${result.error.message}`);
@@ -149,12 +153,29 @@ function PauseFunctionModal({
             <span className="text-subtle">
               Choose what to do with currently-running function runs:
             </span>
-            <SelectInput
-              value={currentRunHandlingStrategy}
-              options={currentRunHandlingOptions}
+            <Select
               onChange={setCurrentRunHandlingStrategy}
-              placeholder="How should currently-running runs be handled?"
-            />
+              isLabelVisible={false}
+              label="Pause runs"
+              multiple={false}
+              value={currentRunHandlingStrategy}
+            >
+              <Select.Button isLabelVisible={false}>
+                <div className="">
+                  {currentRunHandlingStrategy.name ||
+                    'How should currently-running runs be handled?'}
+                </div>
+              </Select.Button>
+              <Select.Options>
+                {currentRunHandlingOptions.map((option) => {
+                  return (
+                    <Select.Option key={option.id} option={option}>
+                      {option.name}
+                    </Select.Option>
+                  );
+                })}
+              </Select.Options>
+            </Select>
           </label>
         </div>
       )}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/NewReplayModal.tsx
@@ -2,20 +2,21 @@
 
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Button } from '@inngest/components/Button';
+import { NewButton } from '@inngest/components/Button';
 import { RangePicker } from '@inngest/components/DatePicker';
+import { Input } from '@inngest/components/Forms/Input';
 import { RunStatusIcon } from '@inngest/components/FunctionRunStatusIcons';
 import { Link } from '@inngest/components/Link';
 import { Modal } from '@inngest/components/Modal';
 import { IconReplay } from '@inngest/components/icons/Replay';
 import { subtractDuration } from '@inngest/components/utils/date';
 import * as ToggleGroup from '@radix-ui/react-toggle-group';
+import { RiInformationLine } from '@remixicon/react';
 import { toast } from 'sonner';
 import { ulid } from 'ulid';
 import { useMutation, useQuery } from 'urql';
 
 import { useEnvironment } from '@/components/Environments/environment-context';
-import Input from '@/components/Forms/Input';
 import Placeholder from '@/components/Placeholder';
 import { graphql } from '@/gql';
 import { ReplayRunStatus } from '@/gql/graphql';
@@ -197,18 +198,20 @@ export default function NewReplayModal({ functionSlug, isOpen, onClose }: NewRep
           Replay Function
         </span>
       }
-      description="Select which function runs to replay."
       isOpen={isOpen}
       onClose={onClose}
     >
-      <form className="divide-y divide-slate-100" onSubmit={createFunctionReplay}>
-        <div className="divide-y divide-slate-100">
-          <div className="flex items-start justify-between gap-7 px-6 py-4">
-            <label htmlFor="replayName" className="block space-y-0.5">
-              <span className="text-sm font-semibold text-slate-800">Replay Name</span>
-              <p className="text-xs text-slate-500">Give your Replay a name to reference later.</p>
+      <form onSubmit={createFunctionReplay}>
+        <div>
+          <div className="flex flex-col items-start justify-between gap-2 px-6 py-4">
+            <label htmlFor="replayName">
+              <span className="text-basis text-sm font-semibold">Replay Name</span>
+              <p className="text-subtle text-sm">
+                Provide a unique name for this replay group to easily identify the runs being
+                replayed.
+              </p>
             </label>
-            <div className="w-64">
+            <div className="w-full">
               <Input
                 type="text"
                 id="replayName"
@@ -221,12 +224,14 @@ export default function NewReplayModal({ functionSlug, isOpen, onClose }: NewRep
               />
             </div>
           </div>
-          <div className="flex flex-row justify-between px-6 py-4">
-            <div className="w-1/2 space-y-0.5">
-              <span className="text-sm font-semibold text-slate-800">Date Range</span>
-              <p className="text-xs text-slate-500">Select a specific range of function runs.</p>
+          <div className="flex flex-col justify-between gap-2 px-6 py-4">
+            <div>
+              <span className="text-basis text-sm font-semibold">Date Range</span>
+              <p className="text-subtle text-sm">
+                Choose the time range for when the runs were queued.
+              </p>
             </div>
-            <div className="w-1/2">
+            <div className="w-full">
               <RangePicker
                 upgradeCutoff={upgradeCutoff}
                 onChange={(range) =>
@@ -242,9 +247,9 @@ export default function NewReplayModal({ functionSlug, isOpen, onClose }: NewRep
           </div>
         </div>
         <div className="space-y-5 px-6 py-4">
-          <div className="space-y-0.5">
-            <span className="text-sm font-semibold text-slate-800">Statuses</span>
-            <p className="text-xs text-slate-500">Select the statuses you want to be replayed.</p>
+          <div>
+            <span className="text-basis text-sm font-semibold">Statuses</span>
+            <p className="text-subtle text-sm">Select the statuses you wish to replay.</p>
           </div>
           <ToggleGroup.Root
             type="multiple"
@@ -256,46 +261,49 @@ export default function NewReplayModal({ functionSlug, isOpen, onClose }: NewRep
             className="flex gap-5"
           >
             {statusOptions.map(({ label, value, count }) => (
-              <div key={value} className="flex flex-1 flex-col items-center gap-3.5">
+              <div key={value} className="flex flex-1">
                 <ToggleGroup.Item
-                  className="flex w-full flex-col items-center gap-1 rounded-md bg-slate-100 py-6 text-sm font-semibold text-slate-800 hover:bg-slate-200 focus:outline-1 focus:outline-indigo-500 data-[state=on]:ring data-[state=on]:ring-indigo-500 data-[state=on]:ring-offset-2"
+                  className="focus:ring-primary-moderate data-[state=on]:bg-success text-basis border-subtle hover:bg-canvasSubtle data-[state=on]:border-primary-moderate items-left flex w-full flex-col gap-1 rounded-md border p-3 text-sm"
                   value={value}
                 >
                   <RunStatusIcon status={value} className="mx-auto h-8" />
                   {label}
+                  {!timeRange && <p className="text-subtle text-sm">-- runs</p>}
+                  {timeRange && (
+                    <p aria-label={`Number of ${label} runs`} className="text-subtle text-sm">
+                      {isLoading ? (
+                        <Placeholder className="top-px inline-flex h-3 w-3 bg-slate-200" />
+                      ) : (
+                        count.toLocaleString(undefined, {
+                          notation: 'compact',
+                          compactDisplay: 'short',
+                        })
+                      )}{' '}
+                      runs
+                    </p>
+                  )}
                 </ToggleGroup.Item>
-                {timeRange && (
-                  <p aria-label={`Number of ${label} runs`} className="text-sm text-slate-500">
-                    {isLoading ? (
-                      <Placeholder className="top-px inline-flex h-3 w-3 bg-slate-200" />
-                    ) : (
-                      count.toLocaleString(undefined, {
-                        notation: 'compact',
-                        compactDisplay: 'short',
-                      })
-                    )}{' '}
-                    Runs
-                  </p>
-                )}
               </div>
             ))}
           </ToggleGroup.Root>
         </div>
-        <div className="flex flex-col gap-6 px-6 py-4">
-          <div className="max-w-sm space-y-2 text-xs text-slate-500">
+        <div className="px-6 py-4">
+          <div className="text-subtle bg-canvasSubtle rounded-md px-6 py-4 text-sm">
             <p>
-              Replayed functions are re-run from the beginning. Previously run steps and function
-              states will not be reused during the replay.
+              Note: Replayed functions are re-run from the beginning. Previously run steps and
+              function states will not be reused during the replay. The <code>event.user</code>{' '}
+              object will be empty for all runs in the replay.
             </p>
-            <p>
-              The <code>event.user</code> object will be empty for all runs in the replay.
-            </p>
+            <Link href="https://inngest.com/docs/platform/replay">Learn more about replay</Link>
           </div>
+        </div>
+        <div className="flex items-center justify-between gap-2 border-t border-slate-100 px-5 py-4">
+          {!timeRange && <p></p>}
           {timeRange && (
-            <div className="flex gap-2 self-end">
-              <p className="inline-flex gap-1.5 text-slate-500">
-                Total runs to be replayed:{' '}
-                <span className="font-medium text-slate-800">
+            <div className="flex items-center gap-2">
+              <p className="text-subtle inline-flex items-center gap-1.5 text-sm">
+                <RiInformationLine className="h-5 w-5" />A total of{' '}
+                <span className="font-bold">
                   {isLoading ? (
                     <Placeholder className="top-px inline-flex h-4 w-4 bg-slate-200" />
                   ) : (
@@ -305,19 +313,22 @@ export default function NewReplayModal({ functionSlug, isOpen, onClose }: NewRep
                     })
                   )}
                 </span>
+                runs will be replayed.
               </p>
             </div>
           )}
-        </div>
-        <div className="flex justify-between border-t border-slate-100 px-5 py-4">
-          <Link href="https://inngest.com/docs/platform/replay">Learn about Replay</Link>
           <div className="flex gap-2">
-            <Button type="button" appearance="outlined" label="Cancel" btnAction={onClose} />
-            <Button
+            <NewButton
+              type="button"
+              appearance="outlined"
+              kind="secondary"
+              label="Cancel"
+              onClick={onClose}
+            />
+            <NewButton
               label="Replay Function"
               kind="primary"
               type="submit"
-              icon={<IconReplay className="h-5 w-5 text-white" />}
               disabled={isCreatingFunctionReplay}
             />
           </div>

--- a/ui/apps/dashboard/src/app/(organization-active)/support/SupportForm.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/support/SupportForm.tsx
@@ -4,11 +4,11 @@ import { useState } from 'react';
 import { useOrganization, useUser } from '@clerk/nextjs';
 import { Alert } from '@inngest/components/Alert';
 import { Button } from '@inngest/components/Button';
+import { Textarea } from '@inngest/components/Forms/Textarea';
 import * as Sentry from '@sentry/nextjs';
 
 import { type RequestBody } from '@/app/(organization-active)/api/support-tickets/route';
 import { SelectInput } from '@/components/Forms/SelectInput';
-import { Textarea } from '@/components/Forms/Textarea';
 import {
   DEFAULT_BUG_SEVERITY_LEVEL,
   formOptions,

--- a/ui/apps/dashboard/src/components/Forms/Input.tsx
+++ b/ui/apps/dashboard/src/components/Forms/Input.tsx
@@ -29,6 +29,9 @@ const sizeStyles = {
   lg: 'text-sm px-3.5 py-3 rounded-lg',
 };
 
+/**
+ * @deprecated Use shared Input component instead
+ */
 const Input = forwardRef<HTMLInputElement, InputProps>(({ showError = true, ...props }, ref) => {
   const type = props.type === undefined ? 'text' : props.type;
   const size = props.size === undefined ? 'base' : props.size;
@@ -37,7 +40,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({ showError = true, ...p
   return (
     <div className="flex flex-col">
       {props.label && (
-        <label htmlFor={props.name} className="text-sm font-medium text-slate-700">
+        <label htmlFor={props.name} className="text-basis text-sm font-medium">
           {props.label}
         </label>
       )}
@@ -53,10 +56,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({ showError = true, ...p
         placeholder={placeholder}
         value={props.value}
         className={cn(
-          'border-muted border text-sm leading-none placeholder-slate-500 shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline',
+          'border-muted placeholder-disabled outline-primary-moderate border text-sm leading-none outline-2 transition-all focus:outline',
           sizeStyles[size],
-          props.readonly &&
-            'cursor-not-allowed border-transparent shadow-transparent outline-transparent	',
+          props.readonly && 'cursor-not-allowed border-transparent outline-transparent	',
           props.error && 'border-error',
           className
         )}
@@ -67,7 +69,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(({ showError = true, ...p
         readOnly={props.readonly}
       />
 
-      <p className="text-sm text-red-500">{showError && props.error}</p>
+      <p className="text-error text-sm">{showError && props.error}</p>
     </div>
   );
 });

--- a/ui/apps/dashboard/src/components/Forms/SelectInput.tsx
+++ b/ui/apps/dashboard/src/components/Forms/SelectInput.tsx
@@ -17,6 +17,9 @@ export interface SelectProps<T extends string> {
   required?: boolean;
 }
 
+/**
+ * @deprecated Use shared Select component instead
+ */
 export function SelectInput<T extends string>(props: SelectProps<T>) {
   // Key is to fix bug with radix-ui/react-select
   // https://github.com/radix-ui/primitives/issues/1569
@@ -35,7 +38,7 @@ export function SelectInput<T extends string>(props: SelectProps<T>) {
       onValueChange={props.onChange}
       required={props.required}
     >
-      <Select.Trigger className="border-muted flex items-center justify-between rounded-lg border bg-white px-3 py-1.5 text-sm leading-none shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline data-[placeholder]:text-slate-500">
+      <Select.Trigger className="border-muted flex items-center justify-between rounded-lg border bg-white px-3 py-1.5 text-sm leading-none outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline data-[placeholder]:text-slate-500">
         <Select.Value placeholder={props.placeholder} />
         <Select.Icon className="">
           <RiArrowDownSLine className="h-5" />

--- a/ui/packages/components/src/DatePicker/Calendar.tsx
+++ b/ui/packages/components/src/DatePicker/Calendar.tsx
@@ -29,19 +29,19 @@ export function Calendar({ selected, onSelect, month, onMonthChange }: CalendarP
 
 const classNames: DayPickerDefaultProps['classNames'] = {
   caption: 'flex justify-center items-center h-6',
-  root: 'text-slate-900 bg-white',
+  root: 'text-basis bg-canvasBase',
   months: 'flex gap-4 relative justify-center',
   caption_label: 'text-lg font-medium',
   nav_button:
-    'inline-flex justify-center items-center absolute top-0 w-6 h-6 rounded-full text-slate-900 hover:bg-gray-100',
+    'inline-flex justify-center items-center absolute top-0 w-6 h-6 rounded-full text-muted hover:bg-canvasSubtle',
   nav_button_next: 'right-0',
   nav_button_previous: 'left-0',
   table: 'border-collapse border-spacing-0 text-sm',
-  head_cell: 'w-11 pt-6 pb-4 align-middle text-center font-medium text-slate-500',
+  head_cell: 'w-11 pt-6 pb-4 align-middle text-center font-medium text-muted',
   cell: 'w-11 h-11 align-middle text-center border-0 font-medium',
-  day: 'rounded-full w-10 h-10 transition-colors hover:bg-indigo-100 aria-selected:hover:text-white aria-selected:hover:bg-indigo-600 hover:text-slate-500 focus:outline-none focus-visible:ring focus-visible:ring-indigo-500',
-  day_selected: 'text-white bg-indigo-600',
+  day: 'rounded-full w-10 h-10 transition-colors hover:bg-primary-xSubtle aria-selected:hover:text-basis aria-selected:hover:bg-primary-xSubtle hover:text-basis focus:outline-none focus-visible:ring focus-visible:ring-primary-subtle',
+  day_selected: 'text-onContrast bg-primary-moderate',
   day_today: 'font-semibold',
-  day_disabled: 'text-slate-400',
-  day_outside: 'text-slate-400',
+  day_disabled: 'text-disabled',
+  day_outside: 'text-disabled',
 };

--- a/ui/packages/components/src/DatePicker/Calendar.tsx
+++ b/ui/packages/components/src/DatePicker/Calendar.tsx
@@ -34,8 +34,8 @@ const classNames: DayPickerDefaultProps['classNames'] = {
   caption_label: 'text-lg font-medium',
   nav_button:
     'inline-flex justify-center items-center absolute top-0 w-6 h-6 rounded-full text-muted hover:bg-canvasSubtle',
-  nav_button_next: 'right-0',
-  nav_button_previous: 'left-0',
+  nav_button_next: 'right-2',
+  nav_button_previous: 'left-2',
   table: 'border-collapse border-spacing-0 text-sm',
   head_cell: 'w-11 pt-6 pb-4 align-middle text-center font-medium text-muted',
   cell: 'w-11 h-11 align-middle text-center border-0 font-medium',

--- a/ui/packages/components/src/DatePicker/DateInputButton.tsx
+++ b/ui/packages/components/src/DatePicker/DateInputButton.tsx
@@ -9,7 +9,7 @@ export const DateInputButton = forwardRef<HTMLButtonElement, DateInputButtonProp
       <button
         {...props}
         ref={forwardRef}
-        className={`border-muted bg-canvasBase outline-primary-moderate h-8 rounded-lg border px-3.5 text-sm leading-none outline-2 transition-all focus:outline ${className}`}
+        className={`border-muted bg-canvasBase outline-primary-moderate h-8 rounded-lg border px-2 text-sm leading-none outline-2 transition-all focus:outline ${className}`}
       >
         <span className="flex items-center gap-2">
           <RiCalendarLine className="text-disabled h-5 w-5" />

--- a/ui/packages/components/src/DatePicker/DateInputButton.tsx
+++ b/ui/packages/components/src/DatePicker/DateInputButton.tsx
@@ -12,7 +12,7 @@ export const DateInputButton = forwardRef<HTMLButtonElement, DateInputButtonProp
         className={`border-muted h-8 rounded-lg border bg-white px-3.5 text-sm leading-none shadow outline-2 outline-indigo-500 transition-all focus:outline ${className}`}
       >
         <span className="flex items-center gap-2">
-          <RiCalendarLine className="h-6 w-6" />
+          <RiCalendarLine className="text-disabled h-5 w-5" />
           {children}
         </span>
       </button>

--- a/ui/packages/components/src/DatePicker/DateInputButton.tsx
+++ b/ui/packages/components/src/DatePicker/DateInputButton.tsx
@@ -9,7 +9,7 @@ export const DateInputButton = forwardRef<HTMLButtonElement, DateInputButtonProp
       <button
         {...props}
         ref={forwardRef}
-        className={`border-muted h-8 rounded-lg border bg-white px-3.5 text-sm leading-none shadow outline-2 outline-indigo-500 transition-all focus:outline ${className}`}
+        className={`border-muted bg-canvasBase outline-primary-moderate h-8 rounded-lg border px-3.5 text-sm leading-none outline-2 transition-all focus:outline ${className}`}
       >
         <span className="flex items-center gap-2">
           <RiCalendarLine className="text-disabled h-5 w-5" />

--- a/ui/packages/components/src/DatePicker/DateTimeInput.tsx
+++ b/ui/packages/components/src/DatePicker/DateTimeInput.tsx
@@ -207,8 +207,8 @@ export function DateTimeInput({
   return (
     <div
       className={cn(
-        'border-muted flex h-8 items-center rounded-lg border bg-white px-3.5 text-sm leading-none text-slate-700 placeholder-slate-300 transition-all has-[:focus]:border-slate-200',
-        !valid && 'border-rose-500 has-[:focus]:border-rose-500'
+        'border-muted has-[:focus]:border-muted bg-canvasBase text-basis placeholder-disabled flex h-8 items-center rounded-lg border px-3.5 text-sm leading-none transition-all',
+        !valid && 'border-error has-[:focus]:border-error'
       )}
       onPaste={(e: React.ClipboardEvent<HTMLDivElement>) => {
         const raw = e?.clipboardData?.getData('text') || '';
@@ -225,7 +225,7 @@ export function DateTimeInput({
       }}
     >
       <input
-        className="w-7 px-0.5 text-center focus:outline-none"
+        className="bg-canvasBase w-7 px-0.5 text-center focus:outline-none"
         placeholder="MM"
         aria-label="Month"
         maxLength={2}
@@ -236,7 +236,7 @@ export function DateTimeInput({
       <span className="px-0.5">/</span>
       <input
         ref={daysRef}
-        className="w-7 px-0.5 text-center focus:outline-none"
+        className="bg-canvasBase w-7 px-0.5 text-center focus:outline-none"
         placeholder="dd"
         aria-label="Day"
         maxLength={2}
@@ -247,7 +247,7 @@ export function DateTimeInput({
       <span className="px-0.5">/</span>
       <input
         ref={yearsRef}
-        className="w-9 px-0.5 text-center focus:outline-none"
+        className="bg-canvasBase w-9 px-0.5 text-center focus:outline-none"
         placeholder="yyyy"
         aria-label="Year"
         maxLength={4}
@@ -258,7 +258,7 @@ export function DateTimeInput({
       <span className="pr-0.5">,</span>
       <input
         ref={hoursRef}
-        className="w-7 px-0.5 text-center focus:outline-none"
+        className="bg-canvasBase w-7 px-0.5 text-center focus:outline-none"
         placeholder="HH"
         aria-label="Point in time (Hours)"
         maxLength={2}
@@ -275,7 +275,7 @@ export function DateTimeInput({
       <span className="px-0.5">:</span>
       <input
         ref={minutesRef}
-        className="w-7 px-0.5 text-center focus:outline-none"
+        className="bg-canvasBase w-7 px-0.5 text-center focus:outline-none"
         placeholder="mm"
         aria-label="Point in time (Minutes)"
         maxLength={2}
@@ -288,7 +288,7 @@ export function DateTimeInput({
       <span className="px-0.5">:</span>
       <input
         ref={secondsRef}
-        className="w-7 px-0.5 text-center focus:outline-none"
+        className="bg-canvasBase w-7 px-0.5 text-center focus:outline-none"
         placeholder="ss"
         aria-label="Point in time (Seconds)"
         maxLength={2}
@@ -301,7 +301,7 @@ export function DateTimeInput({
       <span className="px-0.5">.</span>
       <input
         ref={millisecondsRef}
-        className="w-9 px-0.5 text-center focus:outline-none"
+        className="bg-canvasBase w-9 px-0.5 text-center focus:outline-none"
         placeholder="sss"
         aria-label="Point in time (Milliseconds)"
         maxLength={3}
@@ -316,7 +316,7 @@ export function DateTimeInput({
       {!is24HourFormat && (
         <input
           ref={meridiemRef}
-          className="w-7 pl-0.5 focus:outline-none"
+          className="bg-canvasBase w-7 pl-0.5 focus:outline-none"
           placeholder="AM"
           aria-label="Point in time (Period)"
           maxLength={2}

--- a/ui/packages/components/src/DatePicker/DateTimePicker.tsx
+++ b/ui/packages/components/src/DatePicker/DateTimePicker.tsx
@@ -29,7 +29,7 @@ export const DateTimePicker = ({
 
   return (
     <div>
-      <div className="mt-2 p-2 dark:bg-white">
+      <div className="bg-canvasBase mt-2 p-2">
         <Calendar
           month={calendarDate}
           selected={calendarDate}
@@ -51,9 +51,11 @@ export const DateTimePicker = ({
           }}
         />
       </div>
-      <div className="w-full border-b border-t border-slate-200 p-4">
+      <div className="border-subtle w-full border-b border-t p-4">
         <div className="flex items-center justify-between pb-4">
-          <p className="text-sm font-medium">{Intl.DateTimeFormat().resolvedOptions().timeZone}</p>
+          <p className="text-basis text-sm font-medium">
+            {Intl.DateTimeFormat().resolvedOptions().timeZone}
+          </p>
           <SwitchWrapper>
             <Switch
               checked={is24HourFormat}

--- a/ui/packages/components/src/DatePicker/RangePicker.tsx
+++ b/ui/packages/components/src/DatePicker/RangePicker.tsx
@@ -172,7 +172,7 @@ export const RangePicker = ({
           )}
         </DateInputButton>
       </PopoverTrigger>
-      <PopoverContent>
+      <PopoverContent align="start">
         <div className="bg-canvasBase flex flex-row">
           <div className={`${showAbsolute && 'min-h-[584px]'} border-muted w-[250px] border-r`}>
             <div className="px-3 py-2">

--- a/ui/packages/components/src/DatePicker/RangePicker.tsx
+++ b/ui/packages/components/src/DatePicker/RangePicker.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip';
 import * as Tabs from '@radix-ui/react-tabs';
+import { RiArrowRightSLine } from '@remixicon/react';
 import { isBefore, type Duration } from 'date-fns';
 
 import { Badge } from '../Badge';
-import { Button } from '../Button';
+import { NewButton } from '../Button';
 import { Input } from '../Forms/Input';
 import { Popover, PopoverContent, PopoverTrigger } from '../Popover';
 import {
@@ -172,9 +173,9 @@ export const RangePicker = ({
         </DateInputButton>
       </PopoverTrigger>
       <PopoverContent>
-        <div className="flex flex-row bg-white">
-          <div className={`${showAbsolute && 'min-h-[589px]'} border-muted w-[250px] border-r`}>
-            <div className="m-2">
+        <div className="bg-canvasBase flex flex-row">
+          <div className={`${showAbsolute && 'min-h-[584px]'} border-muted w-[250px] border-r`}>
+            <div className="px-3 py-2">
               <Input
                 ref={durationRef}
                 type="text"
@@ -190,7 +191,7 @@ export const RangePicker = ({
               return (
                 <div
                   key={`duration-${i}`}
-                  className={`flex flex-row items-center justify-between py-2 pl-6 pr-3 text-sm font-normal text-slate-700 hover:bg-blue-50 ${
+                  className={`text-basis hover:bg-canvasMuted flex flex-row items-center justify-between px-4 py-2 text-sm ${
                     planValid ? 'cursor-pointer' : 'cursor-not-allowed'
                   }`}
                   {...(planValid && {
@@ -205,7 +206,7 @@ export const RangePicker = ({
                   {v}
                   {!planValid && (
                     <Badge
-                      className="border-indigo-500 px-2 py-0.5 text-xs text-indigo-500"
+                      className="border-primary-intense text-primary-intense px-2 py-0.5 text-xs"
                       kind="outlined"
                     >
                       Upgrade Plan
@@ -216,48 +217,47 @@ export const RangePicker = ({
             })}
             <div className="flex flex-col">
               <div
-                className={`border-muted cursor-pointer border-t px-6 py-3.5 text-sm font-normal text-slate-700 hover:bg-blue-50 ${
-                  showAbsolute && 'bg-blue-50'
+                className={`border-muted text-basis hover:bg-canvasMuted flex cursor-pointer items-center justify-between border-t px-4 py-2 text-sm ${
+                  showAbsolute && 'bg-canvasMuted'
                 }`}
                 onClick={() => {
                   setShowAbsolute(!showAbsolute);
                   setDurationError('');
                 }}
               >
-                Absolute Range
+                Absolute range
+                <RiArrowRightSLine className="text-muted h-6 w-6" />
               </div>
               {showAbsolute && (
-                <div className="px-[22px] py-2 text-[13px] font-normal text-slate-500">
-                  {formatAbsolute(absoluteRange)}
-                </div>
+                <div className="text-subtle px-4 py-2 text-sm">{formatAbsolute(absoluteRange)}</div>
               )}
             </div>
           </div>
           {showAbsolute && (
-            <div className="flex w-[354px] flex-col">
+            <div className="bg-canvasBase flex w-[354px] flex-col">
               <Tabs.Root className="flex flex-col" value={tab} onValueChange={setTab}>
-                <Tabs.List
-                  className="border-mauve6 flex shrink-0 border-b"
-                  aria-label="Manage your account"
-                >
+                <Tabs.List className="flex shrink-0 px-4 pt-4" aria-label={`Select ${tab} date`}>
                   <Tabs.Trigger
-                    className="flex h-11 flex-1 cursor-pointer select-none items-center 
-                      justify-center bg-white px-5 text-sm text-slate-500 outline-none 
-                      data-[state=active]:text-indigo-500 data-[state=active]:shadow-[inset_0_-1px_0_0,0_1px_0_0]"
+                    className="text-subtle data-[state=active]:text-basis data-[state=active]:border-contrast flex flex-1 
+                      cursor-pointer select-none items-center justify-center border-b-2 border-transparent px-5 pb-1
+                      text-sm outline-none"
                     value="start"
                   >
                     Start
                   </Tabs.Trigger>
                   <Tabs.Trigger
-                    className="flex h-11 flex-1 cursor-pointer select-none items-center 
-                      justify-center bg-white px-5 text-sm text-slate-500 outline-none 
-                      data-[state=active]:text-indigo-500 data-[state=active]:shadow-[inset_0_-1px_0_0,0_1px_0_0]"
+                    className="text-subtle data-[state=active]:text-basis data-[state=active]:border-contrast flex flex-1 
+                      cursor-pointer select-none items-center justify-center border-b-2 border-transparent px-5 pb-1
+                      text-sm outline-none"
                     value="end"
                   >
                     End
                   </Tabs.Trigger>
                 </Tabs.List>
-                <Tabs.Content className="grow rounded-b-md bg-white outline-none" value="start">
+                <Tabs.Content
+                  className="bg-canvasBase grow rounded-b-md outline-none"
+                  value="start"
+                >
                   <DateTimePicker
                     onChange={(start: Date | undefined) => {
                       if (start) {
@@ -277,25 +277,19 @@ export const RangePicker = ({
                     }
                   />
                   <div className="flex flex-col">
-                    {startError && <p className="mx-4 mt-1 text-sm text-red-500">{startError}</p>}
+                    {startError && <p className="text-error mx-4 mt-1 text-sm">{startError}</p>}
                     <div className="flox-row flex justify-between p-4">
-                      <Button
-                        size="small"
-                        label="Cancel"
-                        appearance="text"
-                        btnAction={() => setOpen(false)}
-                      />
-                      <Button
-                        size="small"
+                      <NewButton label="Cancel" appearance="ghost" onClick={() => setOpen(false)} />
+                      <NewButton
                         label="Next"
                         kind="primary"
                         disabled={!absoluteRange?.start || !startValid}
-                        btnAction={() => setTab('end')}
+                        onClick={() => setTab('end')}
                       />
                     </div>
                   </div>
                 </Tabs.Content>
-                <Tabs.Content className="grow rounded-b-md bg-white outline-none" value="end">
+                <Tabs.Content className="bg-canvasBase grow rounded-b-md outline-none" value="end">
                   <DateTimePicker
                     onChange={(end: Date | undefined) => {
                       if (end) {
@@ -312,31 +306,24 @@ export const RangePicker = ({
                     defaultValue={absoluteRange?.end || defaultEnd || new Date()}
                   />
                   <div className="flex flex-col">
-                    {endError && <p className="mx-4 mt-1 text-sm text-red-500">{endError}</p>}
+                    {endError && <p className="text-error mx-4 mt-1 text-sm">{endError}</p>}
                     <div className="flox-row flex justify-between p-4">
-                      <Button
-                        size="small"
-                        label="Cancel"
-                        appearance="text"
-                        btnAction={() => setOpen(false)}
-                      />
+                      <NewButton label="Cancel" appearance="ghost" onClick={() => setOpen(false)} />
                       <div className="flex flex-row">
-                        <Button
-                          size="small"
+                        <NewButton
                           label="Previous"
                           kind="primary"
                           appearance="outlined"
-                          btnAction={() => setTab('start')}
+                          onClick={() => setTab('start')}
                           className="mr-2"
                         />
-                        <Button
-                          size="small"
+                        <NewButton
                           label="Apply"
                           kind="primary"
                           disabled={
                             !startValid || !endValid || !absoluteRange?.end || !absoluteRange?.start
                           }
-                          btnAction={() => {
+                          onClick={() => {
                             setDisplayValue(<AbsoluteDisplay absoluteRange={absoluteRange} />);
                             onChange({
                               type: 'absolute',

--- a/ui/packages/components/src/DatePicker/RangePicker.tsx
+++ b/ui/packages/components/src/DatePicker/RangePicker.tsx
@@ -71,14 +71,14 @@ const formatAbsolute = (absoluteRange?: AbsoluteRange) => (
 const AbsoluteDisplay = ({ absoluteRange }: { absoluteRange?: AbsoluteRange }) => (
   <Tooltip>
     <TooltipTrigger>
-      <div className="w-[180px] truncate text-slate-500">{formatAbsolute(absoluteRange)}</div>
+      <div className="text-basis w-[180px] truncate">{formatAbsolute(absoluteRange)}</div>
     </TooltipTrigger>
     <TooltipContent className="whitespace-pre-line">{formatAbsolute(absoluteRange)}</TooltipContent>
   </Tooltip>
 );
 
 const RelativeDisplay = ({ duration }: { duration: string }) => (
-  <span className="truncate text-slate-500">{duration}</span>
+  <span className="text-basis truncate">{duration}</span>
 );
 
 export const RangePicker = ({
@@ -168,7 +168,7 @@ export const RangePicker = ({
           {displayValue ? (
             displayValue
           ) : (
-            <span className="text-slate-500">{placeholder ? placeholder : 'Select dates'}</span>
+            <span className="text-disabled">{placeholder ? placeholder : 'Select dates'}</span>
           )}
         </DateInputButton>
       </PopoverTrigger>

--- a/ui/packages/components/src/Forms/Input.tsx
+++ b/ui/packages/components/src/Forms/Input.tsx
@@ -17,24 +17,24 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className="flex flex-col gap-1">
         {props.label && (
-          <label htmlFor={props.name} className="text-sm font-medium text-slate-700">
+          <label htmlFor={props.name} className="text-basis text-sm font-medium">
             {props.label}
           </label>
         )}
         <input
           ref={ref}
-          className={`border-muted border text-sm leading-none placeholder-slate-400 shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline
+          className={`bg-canvasBase border-muted placeholder-disabled text-basis outline-primary-moderate border text-sm leading-none shadow outline-2 outline-offset-2 transition-all focus:outline
             ${sizeStyles[inngestSize]}
             ${
               props.readOnly &&
               'cursor-not-allowed border-transparent shadow-transparent outline-transparent	'
             }
-            ${props.error && 'outline-red-300'}
+            ${props.error && 'outline-error'}
             ${className}`}
           {...props}
         />
 
-        {props.error && <p className="text-sm text-red-500">{props.error}</p>}
+        {props.error && <p className="text-error text-sm">{props.error}</p>}
       </div>
     );
   }

--- a/ui/packages/components/src/Forms/Input.tsx
+++ b/ui/packages/components/src/Forms/Input.tsx
@@ -23,7 +23,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         )}
         <input
           ref={ref}
-          className={`bg-canvasBase border-muted placeholder-disabled text-basis outline-primary-moderate border text-sm leading-none shadow outline-2 outline-offset-2 transition-all focus:outline
+          className={`bg-canvasBase border-muted placeholder-disabled text-basis outline-primary-moderate border text-sm leading-none outline-2 transition-all focus:outline
             ${sizeStyles[inngestSize]}
             ${
               props.readOnly &&

--- a/ui/packages/components/src/Forms/Textarea.tsx
+++ b/ui/packages/components/src/Forms/Textarea.tsx
@@ -16,7 +16,7 @@ export function Textarea({ value, onChange, placeholder, rows = 3, required }: T
       }}
       rows={rows}
       required={required}
-      className="bg-canvasBase text-basis border-muted placeholder-disabled outline-primary-moderate w-full rounded-lg border p-3 text-sm outline-2 outline-offset-2 transition-all focus:outline"
+      className="bg-canvasBase text-basis border-muted placeholder-disabled outline-primary-moderate w-full rounded-lg border p-3 text-sm outline-2 transition-all focus:outline"
     />
   );
 }

--- a/ui/packages/components/src/Forms/Textarea.tsx
+++ b/ui/packages/components/src/Forms/Textarea.tsx
@@ -16,7 +16,7 @@ export function Textarea({ value, onChange, placeholder, rows = 3, required }: T
       }}
       rows={rows}
       required={required}
-      className="border-muted w-full rounded-lg border px-3 py-3 text-sm placeholder-slate-500 shadow outline-2 outline-offset-2 outline-indigo-500 transition-all focus:outline"
-    ></textarea>
+      className="bg-canvasBase text-basis border-muted placeholder-disabled outline-primary-moderate w-full rounded-lg border p-3 text-sm outline-2 outline-offset-2 transition-all focus:outline"
+    />
   );
 }

--- a/ui/packages/components/src/Popover/Popover.tsx
+++ b/ui/packages/components/src/Popover/Popover.tsx
@@ -11,14 +11,14 @@ export const PopoverContent = forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Portal>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(({ children, className, ...props }, forwardedRef) => {
-  const container = document.getElementById('modals');
+  const container = typeof document !== 'undefined' ? document.getElementById('modals') : undefined;
   return (
     <PopoverPrimitive.Portal container={container}>
       <PopoverPrimitive.Content
         sideOffset={5}
         ref={forwardedRef}
         className={cn(
-          'z-[100] max-h-[var(--radix-popover-content-available-height)] overflow-y-auto overflow-x-hidden rounded bg-white drop-shadow',
+          'bg-canvasBase z-[100] max-h-[var(--radix-popover-content-available-height)] overflow-y-auto overflow-x-hidden rounded drop-shadow',
           className
         )}
         {...props}

--- a/ui/packages/components/src/Popover/Popover.tsx
+++ b/ui/packages/components/src/Popover/Popover.tsx
@@ -18,7 +18,7 @@ export const PopoverContent = forwardRef<
         sideOffset={5}
         ref={forwardedRef}
         className={cn(
-          'bg-canvasBase z-[100] max-h-[var(--radix-popover-content-available-height)] overflow-y-auto overflow-x-hidden rounded drop-shadow',
+          'bg-canvasBase border-muted shadow-primary z-[100] max-h-[var(--radix-popover-content-available-height)] overflow-y-auto overflow-x-hidden rounded border',
           className
         )}
         {...props}

--- a/ui/packages/components/src/Select/Select.tsx
+++ b/ui/packages/components/src/Select/Select.tsx
@@ -90,8 +90,8 @@ function Button({
 
 function Options({ children, as: Component }: React.PropsWithChildren<{ as: React.ElementType }>) {
   return (
-    <Component className="absolute mt-1 min-w-max">
-      <div className="border-muted bg-surfaceBase overflow-hidden rounded-md border py-1 drop-shadow-lg">
+    <Component className="absolute z-10 mt-1 min-w-max">
+      <div className="border-muted bg-surfaceBase z-10 overflow-hidden rounded-md border py-1 drop-shadow-lg">
         {children}
       </div>
     </Component>

--- a/ui/packages/components/src/Switch/Switch.tsx
+++ b/ui/packages/components/src/Switch/Switch.tsx
@@ -11,9 +11,9 @@ export const Switch = forwardRef<
     <SwitchPrimitive.Root
       {...props}
       ref={forwardedRef}
-      className={`relative h-6 w-[42px] cursor-default rounded-full bg-slate-600 outline-none data-[state=checked]:bg-indigo-600 ${className}`}
+      className={`bg-surfaceMuted data-[state=checked]:bg-primary-moderate relative h-6 w-[42px] cursor-default rounded-full outline-none ${className}`}
     >
-      <SwitchPrimitive.Thumb className="block h-5 w-5 translate-x-0.5 rounded-full bg-white transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-[19px]" />
+      <SwitchPrimitive.Thumb className="bg-alwaysWhite block h-5 w-5 translate-x-0.5 rounded-full transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-[19px]" />
     </SwitchPrimitive.Root>
   );
 });
@@ -28,7 +28,7 @@ interface SwitchLabelProps extends HTMLAttributes<HTMLLabelElement> {
 
 export const SwitchLabel = ({ htmlFor, children, className }: SwitchLabelProps) => {
   return (
-    <label htmlFor={htmlFor} className={cn('cursor-default font-medium text-slate-900', className)}>
+    <label htmlFor={htmlFor} className={cn('text-basis cursor-default font-medium', className)}>
       {children}
     </label>
   );

--- a/ui/packages/components/tailwind.config.ts
+++ b/ui/packages/components/tailwind.config.ts
@@ -93,6 +93,7 @@ export default {
         surfaceSubtle: 'rgb(var(--color-background-surface-subtle) / <alpha-value>)',
         surfaceMuted: 'rgb(var(--color-background-surface-muted) / <alpha-value>)',
         disabled: 'rgb(var(--color-background-disabled) / <alpha-value>)',
+        alwaysWhite: 'rgb(var(--color-foreground-alwaysWhite) / <alpha-value>)',
         contrast: 'rgb(var(--color-background-contrast) / <alpha-value>)',
         success: 'rgb(var(--color-background-success) / <alpha-value>)',
         successContrast: 'rgb(var(--color-background-successContrast) / <alpha-value>)',

--- a/ui/packages/components/tailwind.config.ts
+++ b/ui/packages/components/tailwind.config.ts
@@ -157,6 +157,8 @@ export default {
         tooltip: 'rgb(var(--color-background-canvas-muted) / <alpha-value>)',
       },
       boxShadow: {
+        primary: '0 4px 4px 0 rgba(0,0,0,0.25)',
+        // old box-shadows:
         'outline-primary-light':
           'inset 0 1px 0 0 rgba(255, 255, 255, 0.1), inset 0 0 0 1px rgba(255, 255, 255, 0.1), 0 1px 3px rgba(0, 0, 0, 0.2)',
         'outline-primary-dark':

--- a/ui/packages/components/tailwind.config.ts
+++ b/ui/packages/components/tailwind.config.ts
@@ -85,6 +85,9 @@ export default {
         warning: 'rgb(var(--color-border-warning) / <alpha-value>)',
         info: 'rgb(var(--color-border-info) / <alpha-value>)',
       },
+      outlineColor: {
+        error: 'rgb(var(--color-border-error) / <alpha-value>)',
+      },
       backgroundColor: {
         canvasBase: 'rgb(var(--color-background-canvas-base) / <alpha-value>)',
         canvasSubtle: 'rgb(var(--color-background-canvas-subtle) / <alpha-value>)',
@@ -133,6 +136,9 @@ export default {
       },
       textDecorationColor: {
         link: 'rgb(var(--color-foreground-link) / <alpha-value>)',
+      },
+      placeholderColor: {
+        disabled: 'rgb(var(--color-foreground-disabled) / <alpha-value>)',
       },
       fill: {
         // temporary tooltip token


### PR DESCRIPTION
## Description
- Add color tokens to date picker, to switch, input and popover
- Deprecate Input in Cloud, in favour of shared input component
- Deprecate SelectInput in Cloud, in favour of shared Select component
- Design tweaks to replay modal, to match the date picker styles 
- Use Select component in Pause fn modal

<img width="619" alt="Screenshot 2024-07-14 at 23 31 25" src="https://github.com/user-attachments/assets/e4ba57c1-c818-4e5c-88d3-0cfbf9cef632">
<img width="609" alt="Screenshot 2024-07-14 at 23 30 52" src="https://github.com/user-attachments/assets/dadbf638-9667-49c5-8649-5cafdf0ccade">

![Screenshot 2024-07-15 at 13 59 44](https://github.com/user-attachments/assets/2f71710e-e543-4fcc-8711-37d7be3b3469)
![Screenshot 2024-07-15 at 14 02 19](https://github.com/user-attachments/assets/9ae303ee-0f3f-4318-922b-8c8870fe0325)



## Motivation
The color tokens are necessary to create the light/dark date picker for runs

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
