### PR TITLE
Proposal: Allow overriding REST API's CreateCancellation implementation

### DIFF
--- a/pkg/api/apiv1/apiv1.go
+++ b/pkg/api/apiv1/apiv1.go
@@ -39,6 +39,10 @@ type Opts struct {
 	CancellationReadWriter cqrs.CancellationReadWriter
 }
 
+type Overrides struct {
+	CreateCancellationImpl func(context.Context, *CreateCancellationBody) (*cqrs.Cancellation, error)
+}
+
 // AddRoutes adds a new API handler to the given router.
 func AddRoutes(r chi.Router, o Opts) http.Handler {
 	if o.AuthFinder == nil {
@@ -62,7 +66,8 @@ func AddRoutes(r chi.Router, o Opts) http.Handler {
 }
 
 type API struct {
-	opts Opts
+	opts      Opts
+	overrides Overrides
 }
 
 type router struct {


### PR DESCRIPTION
## Description

This allows optionally overriding the REST API's `CreateCancellation` logic with a custom implementation.

## Motivation

This would allow Cloud to use a custom `CreateCancellation` implementation that also triggers features like eager cancellation.

I'm struggling to come up with another approach that allows sharing cancellation logic between the GQL and REST APIs.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.
