### PR TITLE
INN-3328: force circular mono on the other "code editor"

### DIFF
--- a/ui/apps/dashboard/src/components/Textarea/CodeEditor.tsx
+++ b/ui/apps/dashboard/src/components/Textarea/CodeEditor.tsx
@@ -43,7 +43,7 @@ export default function CodeEditor({
   const numberOfLinesArray = Array.from({ length: numberOfLines }, (_, i) => i + 1);
 
   return (
-    <div className={cn('flex min-h-[200px] font-mono', className)}>
+    <div className={cn('dark flex min-h-[200px] font-mono', className)}>
       <label className="hidden" htmlFor={textAreaID}>
         {label ?? name}
       </label>
@@ -67,7 +67,7 @@ export default function CodeEditor({
         </SyntaxHighlighter>
         {!readOnly && (
           <textarea
-            className="absolute inset-0 z-10 h-full w-full resize-none overflow-auto whitespace-pre border-none bg-transparent py-2 pl-2 text-sm leading-5 text-transparent caret-white focus:ring-0 focus-visible:outline-none"
+            className="text-basis bg-canvasBase absolute inset-0 z-10 h-full w-full resize-none overflow-auto whitespace-pre border-none py-2 pl-2 font-[CircularXXMono] text-sm leading-5 caret-white focus:ring-0 focus-visible:outline-none"
             id={textAreaID}
             name={name}
             value={code}


### PR DESCRIPTION
## Description

Not 100% sure what was going on here, but the introduction of our circular fonts did not play well with the text styles that we had on this component. I removed the transparency stuff, used our current color scheme tokens and forced circular mono here which fixes the issue.

## Motivation
Remove cursor out of sync with text issue in the filter events "code editor".

Here's the fix in action:
https://github.com/user-attachments/assets/19ed2fbb-e5e7-45b4-9f5b-66e74d2597af

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ x] I've linked any associated issues to this PR.
- [ x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
