### PR TITLE
Queue uses a mock-able replacement for time package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/inngest/inngestgo v0.7.3-0.20240718000349-c9247956e061
 	github.com/jedib0t/go-pretty/v6 v6.3.0
 	github.com/jinzhu/copier v0.3.5
+	github.com/jonboulle/clockwork v0.4.0
 	github.com/karlseguin/ccache/v2 v2.0.8
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -686,6 +686,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
+github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/joyent/triton-go v0.0.0-20180313100802-d8f9c0314926/go.mod h1:U+RSyWxWd04xTqnuOQxnai7XGS2PrPY2cfGoDKtMHjA=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/inngest/inngest/pkg/telemetry/redis_telemetry"
 	"math"
 	"strconv"
 	"strings"
@@ -14,29 +13,31 @@ import (
 	"time"
 	"unsafe"
 
-	"golang.org/x/sync/semaphore"
-
 	"github.com/VividCortex/ewma"
 	"github.com/cespare/xxhash/v2"
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-multierror"
+	"github.com/jonboulle/clockwork"
+	"github.com/oklog/ulid/v2"
+	"github.com/redis/rueidis"
+	"github.com/rs/zerolog"
+	"golang.org/x/sync/semaphore"
+	"gonum.org/v1/gonum/stat/sampleuv"
+	"lukechampine.com/frand"
+
 	"github.com/inngest/inngest/pkg/backoff"
 	"github.com/inngest/inngest/pkg/consts"
 	osqueue "github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/telemetry"
+	"github.com/inngest/inngest/pkg/telemetry/redis_telemetry"
 	"github.com/inngest/inngest/pkg/util"
-	"github.com/oklog/ulid/v2"
-	"github.com/redis/rueidis"
-	"github.com/rs/zerolog"
-	"gonum.org/v1/gonum/stat/sampleuv"
-	"lukechampine.com/frand"
 )
 
-var (
-	PartitionSelectionMax int64 = 100
-	PartitionPeekMax      int64 = PartitionSelectionMax * 3
+const (
+	PartitionSelectionMax = int64(100)
+	PartitionPeekMax      = PartitionSelectionMax * 3
 )
 
 const (
@@ -122,10 +123,6 @@ var (
 
 var (
 	rnd *frandRNG
-
-	// now is a reference to time.Now and exists for overriding within
-	// specific tests, allowing us to eg. test rate limiting with ease.
-	getNow = time.Now
 )
 
 func init() {
@@ -248,14 +245,14 @@ func WithAsyncInstrumentation() QueueOpt {
 			PkgName: pkgName,
 			Callback: func(ctx context.Context) (int64, error) {
 				dur := time.Hour * 24 * 365
-				return q.partitionSize(ctx, q.u.kg.GlobalPartitionIndex(), getNow().Add(dur))
+				return q.partitionSize(ctx, q.u.kg.GlobalPartitionIndex(), q.clock.Now().Add(dur))
 			},
 		})
 
 		telemetry.GaugeGlobalQueuePartitionAvailable(ctx, telemetry.GaugeOpt{
 			PkgName: pkgName,
 			Callback: func(ctx context.Context) (int64, error) {
-				return q.partitionSize(ctx, q.u.kg.GlobalPartitionIndex(), getNow().Add(PartitionLookahead))
+				return q.partitionSize(ctx, q.u.kg.GlobalPartitionIndex(), q.clock.Now().Add(PartitionLookahead))
 			},
 		})
 
@@ -283,7 +280,7 @@ func WithAsyncInstrumentation() QueueOpt {
 				PkgName: pkgName,
 				Tags:    tags,
 				Callback: func(ctx context.Context) (int64, error) {
-					return q.partitionSize(ctx, q.u.kg.ShardPartitionIndex(shard.Name), getNow().Add(PartitionLookahead))
+					return q.partitionSize(ctx, q.u.kg.ShardPartitionIndex(shard.Name), q.clock.Now().Add(PartitionLookahead))
 				},
 			})
 		}
@@ -380,6 +377,13 @@ func WithBackoffFunc(f backoff.BackoffFunc) func(q *queue) {
 	}
 }
 
+// WithClock allows replacing the queue's default (real) clock by a mock, for testing.
+func WithClock(c clockwork.Clock) func(q *queue) {
+	return func(q *queue) {
+		q.clock = c
+	}
+}
+
 // QueueItemConcurrencyKeyGenerator returns concurrenc keys given a queue item to limits.
 //
 // Each queue item can have its own concurrency keys.  For example, you can define
@@ -418,6 +422,7 @@ func NewQueue(u *QueueClient, opts ...QueueOpt) *queue {
 		backoffFunc:    backoff.DefaultBackoff,
 		shardLeases:    []leasedShard{},
 		shardLeaseLock: &sync.Mutex{},
+		clock:          clockwork.NewRealClock(),
 	}
 
 	for _, opt := range opts {
@@ -516,6 +521,8 @@ type queue struct {
 
 	// backoffFunc is the backoff function to use when retrying operations.
 	backoffFunc backoff.BackoffFunc
+
+	clock clockwork.Clock
 }
 
 // processItem references the queue partition and queue item to be processed by a worker.
@@ -665,7 +672,11 @@ func (q *QueueItem) SetID(ctx context.Context, str string) {
 //
 // We can ONLY do this for the first attempt, and we can ONLY do this for edges that
 // are not sleeps (eg. immediate runs)
-func (q QueueItem) Score() int64 {
+func (q QueueItem) Score(now time.Time) int64 {
+	if now.IsZero() {
+		now = time.Now()
+	}
+
 	// If this is not a start/simple edge/edge error, we can ignore this.
 	if (q.Data.Kind != osqueue.KindStart &&
 		q.Data.Kind != osqueue.KindEdge &&
@@ -676,7 +687,7 @@ func (q QueueItem) Score() int64 {
 	// If this is > 2 seconds in the future, don't mess with the time.
 	// This prevents any accidental fudging of future run times, even if the
 	// kind is edge (which should never exist... but, better to be safe).
-	if q.AtMS > getNow().Add(consts.FutureAtLimit).UnixMilli() {
+	if q.AtMS > now.Add(consts.FutureAtLimit).UnixMilli() {
 		return q.AtMS
 	}
 
@@ -892,9 +903,9 @@ func (q *queue) EnqueueItem(ctx context.Context, i QueueItem, at time.Time) (Que
 		i.WallTimeMS = at.UnixMilli()
 	}
 
-	if at.Before(getNow()) {
+	if at.Before(q.clock.Now()) {
 		// Normalize to now to minimize latency.
-		i.WallTimeMS = getNow().UnixMilli()
+		i.WallTimeMS = q.clock.Now().UnixMilli()
 	}
 
 	// Add the At timestamp, if not included.
@@ -907,11 +918,11 @@ func (q *queue) EnqueueItem(ctx context.Context, i QueueItem, at time.Time) (Que
 	}
 
 	partitionTime := at
-	if at.Before(getNow()) {
+	if at.Before(q.clock.Now()) {
 		// We don't want to enqueue partitions (pointers to fns) before now.
 		// Doing so allows users to stay at the front of the queue for
 		// leases.
-		partitionTime = getNow()
+		partitionTime = q.clock.Now()
 	}
 
 	// Get the queue name from the queue item.  This allows utilization of
@@ -964,7 +975,7 @@ func (q *queue) EnqueueItem(ctx context.Context, i QueueItem, at time.Time) (Que
 		partitionTime.Unix(),
 		shard,
 		shardName,
-		getNow().UnixMilli(),
+		q.clock.Now().UnixMilli(),
 	})
 
 	if err != nil {
@@ -1041,14 +1052,14 @@ func (q *queue) Peek(ctx context.Context, queueName string, until time.Time, lim
 	}
 
 	if isPeekNext {
-		i, err := q.decodeQueueItemFromPeek(items[0].(string), getNow())
+		i, err := q.decodeQueueItemFromPeek(items[0].(string), q.clock.Now())
 		if err != nil {
 			return nil, err
 		}
 		return []*QueueItem{i}, nil
 	}
 
-	now := getNow()
+	now := q.clock.Now()
 	return util.ParallelDecode(items, func(val any) (*QueueItem, error) {
 		str, _ := val.(string)
 		return q.decodeQueueItemFromPeek(str, now)
@@ -1106,7 +1117,7 @@ func (q *queue) RequeueByJobID(ctx context.Context, partitionName string, jobID 
 			jobID,
 			strconv.Itoa(int(at.UnixMilli())),
 			partitionName,
-			strconv.Itoa(int(getNow().UnixMilli())),
+			strconv.Itoa(int(q.clock.Now().UnixMilli())),
 		},
 	).AsInt64()
 	if err != nil {
@@ -1189,7 +1200,7 @@ func (q *queue) Lease(ctx context.Context, p QueuePartition, item QueueItem, dur
 		}
 	}
 
-	leaseID, err := ulid.New(ulid.Timestamp(getNow().Add(duration).UTC()), rnd)
+	leaseID, err := ulid.New(ulid.Timestamp(q.clock.Now().Add(duration).UTC()), rnd)
 	if err != nil {
 		return nil, fmt.Errorf("error generating id: %w", err)
 	}
@@ -1291,7 +1302,7 @@ func (q *queue) ExtendLease(ctx context.Context, p QueuePartition, i QueueItem, 
 		}
 	}
 
-	newLeaseID, err := ulid.New(ulid.Timestamp(getNow().Add(duration).UTC()), rnd)
+	newLeaseID, err := ulid.New(ulid.Timestamp(q.clock.Now().Add(duration).UTC()), rnd)
 	if err != nil {
 		return nil, fmt.Errorf("error generating id: %w", err)
 	}
@@ -1533,7 +1544,7 @@ func (q *queue) PartitionLease(ctx context.Context, p *QueuePartition, duration 
 	// XXX: Check for function throttling prior to leasing;  if it's throttled we can requeue
 	// the pointer and back off.  A question here is enqueuing new items onto the partition
 	// will reset the pointer update, leading to thrash.
-	now := getNow()
+	now := q.clock.Now()
 	leaseExpires := now.Add(duration).UTC().Truncate(time.Millisecond)
 	leaseID, err := ulid.New(ulid.Timestamp(leaseExpires), rnd)
 	if err != nil {
@@ -1862,7 +1873,7 @@ func (q *queue) PartitionReprioritize(ctx context.Context, queueName string, pri
 func (q *queue) InProgress(ctx context.Context, prefix string, concurrencyKey string) (int64, error) {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "InProgress"), redis_telemetry.ScopeQueue)
 
-	s := getNow().UnixMilli()
+	s := q.clock.Now().UnixMilli()
 	cmd := q.u.unshardedRc.B().Zcount().
 		Key(q.u.kg.Concurrency(prefix, concurrencyKey)).
 		Min(fmt.Sprintf("%d", s)).
@@ -1881,7 +1892,7 @@ func (q *queue) Scavenge(ctx context.Context) (int, error) {
 
 	// Find all items that have an expired lease - eg. where the min time for a lease is between
 	// (0-now] in unix milliseconds.
-	now := fmt.Sprintf("%d", getNow().UnixMilli())
+	now := fmt.Sprintf("%d", q.clock.Now().UnixMilli())
 
 	cmd := q.u.unshardedRc.B().Zrange().
 		Key(q.u.kg.ConcurrencyIndex()).
@@ -1947,7 +1958,7 @@ func (q *queue) Scavenge(ctx context.Context) (int, error) {
 				resultErr = multierror.Append(resultErr, fmt.Errorf("error unmarshalling job '%s': %w", item, err))
 				continue
 			}
-			if err := q.Requeue(ctx, p, qi, getNow()); err != nil {
+			if err := q.Requeue(ctx, p, qi, q.clock.Now()); err != nil {
 				resultErr = multierror.Append(resultErr, fmt.Errorf("error requeueing job '%s': %w", item, err))
 				continue
 			}
@@ -1976,7 +1987,7 @@ func (q *queue) ConfigLease(ctx context.Context, key string, duration time.Durat
 		return nil, ErrConfigLeaseExceedsLimits
 	}
 
-	now := getNow()
+	now := q.clock.Now()
 	newLeaseID, err := ulid.New(ulid.Timestamp(now.Add(duration)), rnd)
 	if err != nil {
 		return nil, err
@@ -2043,7 +2054,7 @@ func (q *queue) getShards(ctx context.Context) (map[string]*QueueShard, error) {
 func (q *queue) leaseShard(ctx context.Context, shard *QueueShard, duration time.Duration, n int) (*ulid.ULID, error) {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "leaseShard"), redis_telemetry.ScopeQueue)
 
-	now := getNow()
+	now := q.clock.Now()
 	leaseID, err := ulid.New(uint64(now.Add(duration).UnixMilli()), rand.Reader)
 	if err != nil {
 		return nil, err
@@ -2086,7 +2097,7 @@ func (q *queue) leaseShard(ctx context.Context, shard *QueueShard, duration time
 func (q *queue) renewShardLease(ctx context.Context, shard *QueueShard, duration time.Duration, leaseID ulid.ULID) (*ulid.ULID, error) {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "RunJobs"), redis_telemetry.ScopeQueue)
 
-	now := getNow()
+	now := q.clock.Now()
 	newLeaseID, err := ulid.New(uint64(now.Add(duration).UnixMilli()), rand.Reader)
 	if err != nil {
 		return nil, err

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -118,7 +118,7 @@ func (q *queue) Enqueue(ctx context.Context, item osqueue.Item, at time.Time) er
 
 	// Use the queue item's score, ensuring we process older function runs first
 	// (eg. before at)
-	next := time.UnixMilli(qi.Score())
+	next := time.UnixMilli(qi.Score(q.clock.Now()))
 
 	if factor := qi.Data.GetPriorityFactor(); factor != 0 {
 		// Ensure we mutate the AtMS time by the given priority factor.
@@ -142,7 +142,7 @@ func (q *queue) Run(ctx context.Context, f osqueue.RunFunc) error {
 	go q.claimSequentialLease(ctx)
 	go q.runScavenger(ctx)
 
-	tick := time.NewTicker(q.pollTick)
+	tick := q.clock.NewTicker(q.pollTick)
 
 	q.logger.Debug().
 		Str("poll", q.pollTick.String()).
@@ -161,7 +161,7 @@ LOOP:
 			q.logger.Error().Err(err).Msg("quitting runner internally")
 			tick.Stop()
 			break LOOP
-		case <-tick.C:
+		case <-tick.Chan():
 			if q.capacity() < minWorkersFree {
 				// Wait until we have more workers free.  This stops us from
 				// claiming a partition to work on a single job, ensuring we
@@ -201,8 +201,8 @@ func (q *queue) claimShards(ctx context.Context) {
 		return
 	}
 
-	scanTick := time.NewTicker(ShardTickTime)
-	leaseTick := time.NewTicker(ShardLeaseTime / 2)
+	scanTick := q.clock.NewTicker(ShardTickTime)
+	leaseTick := q.clock.NewTicker(ShardLeaseTime / 2)
 
 	// records whether we're leasing
 	var leasing int32
@@ -211,7 +211,7 @@ func (q *queue) claimShards(ctx context.Context) {
 		if q.isSequential() {
 			// Sequential workers never lease shards.  They always run in order
 			// on the global partition queue.
-			<-scanTick.C
+			<-scanTick.Chan()
 			continue
 		}
 
@@ -221,7 +221,7 @@ func (q *queue) claimShards(ctx context.Context) {
 			scanTick.Stop()
 			leaseTick.Stop()
 			return
-		case <-scanTick.C:
+		case <-scanTick.Chan():
 			go func() {
 				if !atomic.CompareAndSwapInt32(&leasing, 0, 1) {
 					// Only one lease can occur at once.
@@ -246,11 +246,11 @@ func (q *queue) claimShards(ctx context.Context) {
 						return
 					}
 					if retry {
-						<-time.After(time.Duration(rand.Intn(50)) * time.Millisecond)
+						<-q.clock.After(time.Duration(rand.Intn(50)) * time.Millisecond)
 					}
 				}
 			}()
-		case <-leaseTick.C:
+		case <-leaseTick.Chan():
 			// Copy the slice to prevent locking/concurrent access.
 			existingLeases := q.getShardLeases()
 
@@ -372,7 +372,7 @@ func (q *queue) filterShards(ctx context.Context, shards map[string]*QueueShard)
 
 		validLeases := []ulid.ULID{}
 		for _, l := range v.Leases {
-			if time.UnixMilli(int64(l.Time())).After(getNow()) {
+			if time.UnixMilli(int64(l.Time())).After(q.clock.Now()) {
 				validLeases = append(validLeases, l)
 			}
 		}
@@ -427,13 +427,13 @@ func (q *queue) claimSequentialLease(ctx context.Context) {
 	q.seqLeaseID = leaseID
 	q.seqLeaseLock.Unlock()
 
-	tick := time.NewTicker(ConfigLeaseDuration / 3)
+	tick := q.clock.NewTicker(ConfigLeaseDuration / 3)
 	for {
 		select {
 		case <-ctx.Done():
 			tick.Stop()
 			return
-		case <-tick.C:
+		case <-tick.Chan():
 			leaseID, err := q.ConfigLease(ctx, q.u.kg.Sequential(), ConfigLeaseDuration, q.sequentialLease())
 			if err == ErrConfigAlreadyLeased {
 				// This is expected; every time there is > 1 runner listening to the
@@ -475,8 +475,8 @@ func (q *queue) runScavenger(ctx context.Context) {
 	q.scavengerLeaseID = leaseID // no-op if not leased
 	q.scavengerLeaseLock.Unlock()
 
-	tick := time.NewTicker(ConfigLeaseDuration / 3)
-	scavenge := time.NewTicker(30 * time.Second)
+	tick := q.clock.NewTicker(ConfigLeaseDuration / 3)
+	scavenge := q.clock.NewTicker(30 * time.Second)
 
 	for {
 		select {
@@ -484,7 +484,7 @@ func (q *queue) runScavenger(ctx context.Context) {
 			tick.Stop()
 			scavenge.Stop()
 			return
-		case <-scavenge.C:
+		case <-scavenge.Chan():
 			// Scavenge the items
 			if q.isScavenger() {
 				count, err := q.Scavenge(ctx)
@@ -495,7 +495,7 @@ func (q *queue) runScavenger(ctx context.Context) {
 					q.logger.Info().Int("len", count).Msg("scavenged lost jobs")
 				}
 			}
-		case <-tick.C:
+		case <-tick.Chan():
 			// Attempt to re-lease the lock.
 			leaseID, err := q.ConfigLease(ctx, q.u.kg.Scavenger(), ConfigLeaseDuration, q.scavengerLease())
 			if err == ErrConfigAlreadyLeased {
@@ -585,8 +585,8 @@ func (q *queue) scan(ctx context.Context) error {
 	}
 
 	// Peek 1s into the future to pull jobs off ahead of time, minimizing 0 latency
-	partitions, err := duration(ctx, "partition_peek", func(ctx context.Context) ([]*QueuePartition, error) {
-		return q.partitionPeek(ctx, partitionKey, q.isSequential(), getNow().Add(PartitionLookahead), PartitionPeekMax)
+	partitions, err := duration(ctx, "partition_peek", q.clock.Now(), func(ctx context.Context) ([]*QueuePartition, error) {
+		return q.partitionPeek(ctx, partitionKey, q.isSequential(), q.clock.Now().Add(PartitionLookahead), PartitionPeekMax)
 	})
 	if err != nil {
 		return err
@@ -642,7 +642,7 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, shard *
 	// items are dynamic generators).  This means that we have to delay
 	// processing the partition by N seconds, meaning the latency is increased by
 	// up to this period for scheduled items behind the concurrency limits.
-	_, err := duration(ctx, "partition_lease", func(ctx context.Context) (*ulid.ULID, error) {
+	_, err := duration(ctx, "partition_lease", q.clock.Now(), func(ctx context.Context) (*ulid.ULID, error) {
 		return q.PartitionLease(ctx, p, PartitionLeaseDuration)
 	})
 	if err == ErrPartitionConcurrencyLimit {
@@ -653,7 +653,7 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, shard *
 			go l.OnConcurrencyLimitReached(context.WithoutCancel(ctx), p.WorkflowID)
 		}
 		telemetry.IncrQueuePartitionConcurrencyLimitCounter(ctx, telemetry.CounterOpt{PkgName: pkgName})
-		return q.PartitionRequeue(ctx, p, getNow().Truncate(time.Second).Add(PartitionConcurrencyLimitRequeueExtension), true)
+		return q.PartitionRequeue(ctx, p, q.clock.Now().Truncate(time.Second).Add(PartitionConcurrencyLimitRequeueExtension), true)
 	}
 	if err == ErrPartitionAlreadyLeased {
 		telemetry.IncrQueuePartitionLeaseContentionCounter(ctx, telemetry.CounterOpt{PkgName: pkgName})
@@ -670,9 +670,9 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, shard *
 		return fmt.Errorf("error leasing partition: %w", err)
 	}
 
-	begin := time.Now()
+	begin := q.clock.Now()
 	defer func() {
-		telemetry.HistogramProcessPartitionDuration(ctx, time.Since(begin).Milliseconds(), telemetry.HistogramOpt{
+		telemetry.HistogramProcessPartitionDuration(ctx, q.clock.Since(begin).Milliseconds(), telemetry.HistogramOpt{
 			PkgName: pkgName,
 		})
 	}()
@@ -689,9 +689,9 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, shard *
 	// within 5ms of each other, we fetch them in order but we may process them out of
 	// order, depending on how long it takes for the item to pass through the channel
 	// to the worker, how long Redis takes to lease the item, etc.
-	fetch := getNow().Truncate(time.Second).Add(PartitionLookahead)
+	fetch := q.clock.Now().Truncate(time.Second).Add(PartitionLookahead)
 
-	queue, err := duration(peekCtx, "peek", func(ctx context.Context) ([]*QueueItem, error) {
+	queue, err := duration(peekCtx, "peek", q.clock.Now(), func(ctx context.Context) ([]*QueueItem, error) {
 		peek := q.peekSize(ctx, p)
 		// NOTE: would love to instrument this value to see it over time per function but
 		// it's likely too high of a cardinality
@@ -722,7 +722,7 @@ func (q *queue) processPartition(ctx context.Context, p *QueuePartition, shard *
 	// queue items later in the array may be processed before queue items earlier in
 	// the array depending on eg. a rate limit becoming available half way through
 	// iteration.
-	staticTime := getNow()
+	staticTime := q.clock.Now()
 
 	denies := newLeaseDenyList()
 
@@ -731,7 +731,7 @@ ProcessLoop:
 		// TODO: Create an in-memory mapping of rate limit keys that have been hit,
 		//       and don't bother to process if the queue item has a limited key.  This
 		//       lessens work done in the queue, as we can `continue` immediately.
-		if item.IsLeased(getNow()) {
+		if item.IsLeased(q.clock.Now()) {
 			telemetry.IncrQueueItemProcessedCounter(ctx, telemetry.CounterOpt{
 				PkgName: pkgName,
 				Tags:    map[string]any{"status": "lease_contention"},
@@ -755,7 +755,7 @@ ProcessLoop:
 		//
 		// This is safe:  only one process runs scan(), and we guard the total number of
 		// available workers with the above semaphore.
-		leaseID, err := duration(ctx, "lease", func(ctx context.Context) (*ulid.ULID, error) {
+		leaseID, err := duration(ctx, "lease", q.clock.Now(), func(ctx context.Context) (*ulid.ULID, error) {
 			return q.Lease(ctx, *p, *item, QueueLeaseDuration, staticTime, denies)
 		})
 
@@ -914,7 +914,7 @@ ProcessLoop:
 		}
 		// Requeue this partition as we hit concurrency limits.
 		telemetry.IncrQueuePartitionConcurrencyLimitCounter(ctx, telemetry.CounterOpt{PkgName: pkgName})
-		return q.PartitionRequeue(ctx, p, getNow().Truncate(time.Second).Add(PartitionConcurrencyLimitRequeueExtension), true)
+		return q.PartitionRequeue(ctx, p, q.clock.Now().Truncate(time.Second).Add(PartitionConcurrencyLimitRequeueExtension), true)
 	}
 
 	if processErr != nil {
@@ -928,8 +928,8 @@ ProcessLoop:
 	// Requeue the partition, which reads the next unleased job or sets a time of
 	// 30 seconds.  This is why we have to lease items above, else this may return an item that is
 	// about to be leased and processed by the worker.
-	_, err = duration(ctx, "partition_requeue", func(ctx context.Context) (any, error) {
-		err = q.PartitionRequeue(ctx, p, getNow().Add(PartitionRequeueExtension), false)
+	_, err = duration(ctx, "partition_requeue", q.clock.Now(), func(ctx context.Context) (any, error) {
+		err = q.PartitionRequeue(ctx, p, q.clock.Now().Add(PartitionRequeueExtension), false)
 		return nil, err
 	})
 	if err == ErrPartitionGarbageCollected {
@@ -951,7 +951,7 @@ func (q *queue) process(ctx context.Context, p QueuePartition, qi QueueItem, s *
 	defer q.wg.Done()
 
 	// Continually the lease while this job is being processed.
-	extendLeaseTick := time.NewTicker(QueueLeaseDuration / 2)
+	extendLeaseTick := q.clock.NewTicker(QueueLeaseDuration / 2)
 	defer extendLeaseTick.Stop()
 
 	errCh := make(chan error)
@@ -963,7 +963,7 @@ func (q *queue) process(ctx context.Context, p QueuePartition, qi QueueItem, s *
 			select {
 			case <-doneCh:
 				return
-			case <-extendLeaseTick.C:
+			case <-extendLeaseTick.Chan():
 				if ctx.Err() != nil {
 					// Don't extend lease when the ctx is done.
 					return
@@ -1008,17 +1008,17 @@ func (q *queue) process(ctx context.Context, p QueuePartition, qi QueueItem, s *
 
 		// This job may be up to 1999 ms in the future, as explained in processPartition.
 		// Just... wait until the job is available.
-		delay := time.Until(time.UnixMilli(qi.AtMS))
+		delay := time.UnixMilli(qi.AtMS).Sub(q.clock.Now())
 
 		if delay > 0 {
-			<-time.After(delay)
+			<-q.clock.After(delay)
 			q.logger.Trace().
 				Int64("at", qi.AtMS).
 				Int64("ms", delay.Milliseconds()).
 				Msg("delaying job in memory")
 		}
 
-		n := getNow()
+		n := q.clock.Now()
 
 		// Track the sojourn (concurrency) latency.
 		var sojourn time.Duration
@@ -1214,7 +1214,7 @@ func (q *queue) peekSize(ctx context.Context, p *QueuePartition) int64 {
 	}
 
 	dur := time.Hour * 24
-	qsize, _ := q.partitionSize(ctx, q.u.kg.QueueIndex(p.Queue()), time.Now().Add(dur))
+	qsize, _ := q.partitionSize(ctx, q.u.kg.QueueIndex(p.Queue()), q.clock.Now().Add(dur))
 	if qsize > size {
 		size = qsize
 	}
@@ -1233,7 +1233,7 @@ func (q *queue) isSequential() bool {
 	if l == nil {
 		return false
 	}
-	return ulid.Time(l.Time()).After(getNow())
+	return ulid.Time(l.Time()).After(q.clock.Now())
 }
 
 func (q *queue) isScavenger() bool {
@@ -1241,16 +1241,19 @@ func (q *queue) isScavenger() bool {
 	if l == nil {
 		return false
 	}
-	return ulid.Time(l.Time()).After(getNow())
+	return ulid.Time(l.Time()).After(q.clock.Now())
 }
 
 // duration is a helper function to record durations of queue operations.
-func duration[T any](ctx context.Context, op string, f func(ctx context.Context) (T, error)) (T, error) {
-	now := time.Now()
+func duration[T any](ctx context.Context, op string, start time.Time, f func(ctx context.Context) (T, error)) (T, error) {
+	if start.IsZero() {
+		start = time.Now()
+	}
+
 	res, err := f(ctx)
 	telemetry.HistogramQueueOperationDuration(
 		ctx,
-		time.Since(now).Milliseconds(),
+		time.Since(start).Milliseconds(),
 		telemetry.HistogramOpt{
 			PkgName: pkgName,
 			Tags: map[string]any{

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	osqueue "github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/jonboulle/clockwork"
 	"github.com/oklog/ulid/v2"
 	"github.com/redis/rueidis"
 	"github.com/stretchr/testify/require"
@@ -160,7 +161,7 @@ func TestQueueItemScore(t *testing.T) {
 	}
 
 	for _, item := range tests {
-		actual := item.qi.Score()
+		actual := item.qi.Score(time.Now())
 		require.Equal(t, item.expected, actual)
 	}
 }
@@ -539,7 +540,7 @@ func TestQueuePeek(t *testing.T) {
 			p := QueuePartition{WorkflowID: ia.WorkflowID}
 
 			// Lease step A, and it should be removed.
-			_, err := q.Lease(ctx, p, ia, 50*time.Millisecond, getNow(), nil)
+			_, err := q.Lease(ctx, p, ia, 50*time.Millisecond, time.Now(), nil)
 			require.NoError(t, err)
 
 			items, err = q.Peek(ctx, workflowID.String(), d, QueuePeekMax)
@@ -615,7 +616,7 @@ func TestQueueLease(t *testing.T) {
 		require.Equal(t, item.Queue(), item.WorkflowID.String())
 
 		now := time.Now()
-		id, err := q.Lease(ctx, p, item, time.Second, getNow(), nil)
+		id, err := q.Lease(ctx, p, item, time.Second, time.Now(), nil)
 		require.NoError(t, err)
 
 		item = getQueueItem(t, r, item.ID)
@@ -633,7 +634,7 @@ func TestQueueLease(t *testing.T) {
 
 		t.Run("Leasing again should fail", func(t *testing.T) {
 			for i := 0; i < 50; i++ {
-				id, err := q.Lease(ctx, p, item, time.Second, getNow(), nil)
+				id, err := q.Lease(ctx, p, item, time.Second, time.Now(), nil)
 				require.Equal(t, ErrQueueItemAlreadyLeased, err)
 				require.Nil(t, id)
 				<-time.After(5 * time.Millisecond)
@@ -652,7 +653,7 @@ func TestQueueLease(t *testing.T) {
 			})
 
 			now := time.Now()
-			id, err := q.Lease(ctx, p, item, 5*time.Second, getNow(), nil)
+			id, err := q.Lease(ctx, p, item, 5*time.Second, time.Now(), nil)
 			require.NoError(t, err)
 			require.NoError(t, err)
 
@@ -677,7 +678,7 @@ func TestQueueLease(t *testing.T) {
 
 			requireItemScoreEquals(t, r, item, start)
 
-			_, err = q.Lease(ctx, p, item, time.Minute, getNow(), nil)
+			_, err = q.Lease(ctx, p, item, time.Minute, time.Now(), nil)
 			require.NoError(t, err)
 
 			_, err = r.ZScore(defaultQueueKey.QueueIndex(item.WorkflowID.String()), item.ID)
@@ -703,16 +704,16 @@ func TestQueueLease(t *testing.T) {
 		t.Run("With denylists it does not lease.", func(t *testing.T) {
 			list := newLeaseDenyList()
 			list.addConcurrency(newKeyError(ErrPartitionConcurrencyLimit, p.Queue()))
-			_, err = q.Lease(ctx, p, itemA, 5*time.Second, getNow(), list)
+			_, err = q.Lease(ctx, p, itemA, 5*time.Second, time.Now(), list)
 			require.ErrorIs(t, err, ErrPartitionConcurrencyLimit)
 		})
 
 		t.Run("Leases with capacity", func(t *testing.T) {
-			_, err = q.Lease(ctx, p, itemA, 5*time.Second, getNow(), nil)
+			_, err = q.Lease(ctx, p, itemA, 5*time.Second, time.Now(), nil)
 			require.NoError(t, err)
 		})
 		t.Run("Errors without capacity", func(t *testing.T) {
-			id, err := q.Lease(ctx, p, itemB, 5*time.Second, getNow(), nil)
+			id, err := q.Lease(ctx, p, itemB, 5*time.Second, time.Now(), nil)
 			require.Nil(t, id)
 			require.Error(t, err)
 		})
@@ -737,11 +738,11 @@ func TestQueueLease(t *testing.T) {
 		p := QueuePartition{WorkflowID: itemA.WorkflowID}
 
 		t.Run("Leases with capacity", func(t *testing.T) {
-			_, err = q.Lease(ctx, p, itemA, 5*time.Second, getNow(), nil)
+			_, err = q.Lease(ctx, p, itemA, 5*time.Second, time.Now(), nil)
 			require.NoError(t, err)
 		})
 		t.Run("Errors without capacity", func(t *testing.T) {
-			id, err := q.Lease(ctx, p, itemB, 5*time.Second, getNow(), nil)
+			id, err := q.Lease(ctx, p, itemB, 5*time.Second, time.Now(), nil)
 			require.Nil(t, id)
 			require.Error(t, err)
 		})
@@ -772,16 +773,16 @@ func TestQueueLease(t *testing.T) {
 		t.Run("With denylists it does not lease.", func(t *testing.T) {
 			list := newLeaseDenyList()
 			list.addConcurrency(newKeyError(ErrConcurrencyLimitCustomKey0, "custom-level-key"))
-			_, err = q.Lease(ctx, p, itemA, 5*time.Second, getNow(), list)
+			_, err = q.Lease(ctx, p, itemA, 5*time.Second, time.Now(), list)
 			require.ErrorIs(t, err, ErrConcurrencyLimitCustomKey0)
 		})
 
 		t.Run("Leases with capacity", func(t *testing.T) {
-			_, err = q.Lease(ctx, p, itemA, 5*time.Second, getNow(), nil)
+			_, err = q.Lease(ctx, p, itemA, 5*time.Second, time.Now(), nil)
 			require.NoError(t, err)
 		})
 		t.Run("Errors without capacity", func(t *testing.T) {
-			id, err := q.Lease(ctx, p, itemB, 5*time.Second, getNow(), nil)
+			id, err := q.Lease(ctx, p, itemB, 5*time.Second, time.Now(), nil)
 			require.Nil(t, id)
 			require.Error(t, err)
 		})
@@ -804,7 +805,7 @@ func TestQueueLease(t *testing.T) {
 
 			// Nothing should update here, as there's nothing left in the fn queue
 			// so nothing happens.
-			_, err = q.Lease(ctx, p, item, 10*time.Second, getNow(), nil)
+			_, err = q.Lease(ctx, p, item, 10*time.Second, time.Now(), nil)
 			require.NoError(t, err)
 
 			nextScore, err := r.ZScore(defaultQueueKey.GlobalPartitionIndex(), p.Queue())
@@ -829,7 +830,7 @@ func TestQueueLease(t *testing.T) {
 			require.EqualValues(t, atA.Unix(), score)
 
 			// Leasing the item should update the score.
-			_, err = q.Lease(ctx, p, itemA, 10*time.Second, getNow(), nil)
+			_, err = q.Lease(ctx, p, itemA, 10*time.Second, time.Now(), nil)
 			require.NoError(t, err)
 
 			nextScore, err := r.ZScore(defaultQueueKey.GlobalPartitionIndex(), p.Queue())
@@ -865,7 +866,7 @@ func TestQueueExtendLease(t *testing.T) {
 		p := QueuePartition{WorkflowID: item.WorkflowID}
 
 		now := time.Now()
-		id, err := q.Lease(ctx, p, item, time.Second, getNow(), nil)
+		id, err := q.Lease(ctx, p, item, time.Second, time.Now(), nil)
 		require.NoError(t, err)
 
 		item = getQueueItem(t, r, item.ID)
@@ -942,7 +943,7 @@ func TestQueueDequeue(t *testing.T) {
 
 		p := QueuePartition{WorkflowID: item.WorkflowID}
 
-		id, err := q.Lease(ctx, p, item, time.Second, getNow(), nil)
+		id, err := q.Lease(ctx, p, item, time.Second, time.Now(), nil)
 		require.NoError(t, err)
 
 		t.Run("The lease exists in the partition queue", func(t *testing.T) {
@@ -1043,7 +1044,7 @@ func TestQueueRequeue(t *testing.T) {
 
 		p := QueuePartition{WorkflowID: item.WorkflowID}
 
-		_, err = q.Lease(ctx, p, item, time.Second, getNow(), nil)
+		_, err = q.Lease(ctx, p, item, time.Second, time.Now(), nil)
 		require.NoError(t, err)
 
 		// Assert partition index is original
@@ -1530,7 +1531,7 @@ func TestQueuePartitionRequeue(t *testing.T) {
 
 		// Leasing the only job available moves the job into the concurrency queue,
 		// so the partition should be empty. when requeeing.
-		_, err := q.Lease(ctx, p, qi, 10*time.Second, getNow(), nil)
+		_, err := q.Lease(ctx, p, qi, 10*time.Second, time.Now(), nil)
 		require.NoError(t, err)
 
 		requirePartitionScoreEquals(t, r, idA, next)
@@ -1681,6 +1682,7 @@ func TestQueueRequeueByJobID(t *testing.T) {
 			return p.Queue(), 100
 		},
 		itemIndexer: QueueItemIndexerFunc,
+		clock:       clockwork.NewRealClock(),
 	}
 
 	wsA, wsB := uuid.New(), uuid.New()
@@ -1743,7 +1745,7 @@ func TestQueueRequeueByJobID(t *testing.T) {
 			require.Equal(t, 1, len(partitions))
 
 			// Lease
-			lid, err := q.Lease(ctx, *partitions[0], item, time.Second*10, getNow(), nil)
+			lid, err := q.Lease(ctx, *partitions[0], item, time.Second*10, time.Now(), nil)
 			require.NoError(t, err)
 			require.NotNil(t, lid)
 
@@ -1921,6 +1923,7 @@ func TestQueueLeaseSequential(t *testing.T) {
 		pf: func(ctx context.Context, item QueueItem) uint {
 			return PriorityMin
 		},
+		clock: clockwork.NewRealClock(),
 	}
 
 	var (
@@ -2058,7 +2061,7 @@ func TestSharding(t *testing.T) {
 				require.NoError(t, err)
 				require.EqualValues(t, at.Unix(), score, "starting score should be enqueue time")
 
-				_, err = q.Lease(ctx, p, item, 5*time.Second, getNow(), nil)
+				_, err = q.Lease(ctx, p, item, 5*time.Second, time.Now(), nil)
 				require.NoError(t, err)
 
 				// Check shard partition score changed in the ptr.
@@ -2333,7 +2336,8 @@ func TestQueueRateLimit(t *testing.T) {
 	require.NoError(t, err)
 	defer rc.Close()
 	ctx := context.Background()
-	q := NewQueue(NewQueueClient(rc, QueueDefaultKey))
+	clock := clockwork.NewFakeClock()
+	q := NewQueue(NewQueueClient(rc, QueueDefaultKey), WithClock(clock))
 
 	idA, idB := uuid.New(), uuid.New()
 
@@ -2355,7 +2359,7 @@ func TestQueueRateLimit(t *testing.T) {
 				},
 				Throttle: throttle,
 			},
-		}, getNow())
+		}, clock.Now())
 		r.NoError(err)
 
 		ab, err := q.EnqueueItem(ctx, QueueItem{
@@ -2366,27 +2370,33 @@ func TestQueueRateLimit(t *testing.T) {
 				},
 				Throttle: throttle,
 			},
-		}, getNow().Add(time.Second))
+		}, clock.Now().Add(time.Second))
 		r.NoError(err)
 
 		// Leasing A should succeed, then B should fail.
-		partitions, err := q.PartitionPeek(ctx, true, getNow().Add(5*time.Second), 5)
+		partitions, err := q.PartitionPeek(ctx, true, clock.Now().Add(5*time.Second), 5)
 		r.NoError(err)
 		r.EqualValues(1, len(partitions))
 
+		// clock.Advance(10 * time.Millisecond)
+
 		t.Run("Leasing a first item succeeds", func(t *testing.T) {
-			leaseA, err := q.Lease(ctx, *partitions[0], aa, 10*time.Second, getNow(), nil)
+			leaseA, err := q.Lease(ctx, *partitions[0], aa, 10*time.Second, clock.Now(), nil)
 			r.NoError(err, "leasing throttled queue item with capacity failed")
 			r.NotNil(leaseA)
 		})
 
+		// clock.Advance(10 * time.Millisecond)
+
 		t.Run("Attempting to lease another throttled key immediately fails", func(t *testing.T) {
-			leaseB, err := q.Lease(ctx, *partitions[0], ab, 10*time.Second, getNow(), nil)
+			leaseB, err := q.Lease(ctx, *partitions[0], ab, 10*time.Second, clock.Now(), nil)
 			r.NotNil(err, "leasing throttled queue item without capacity didn't error")
 			r.Nil(leaseB)
 		})
 
-		t.Run("Leasing another funciton succeeds", func(t *testing.T) {
+		// clock.Advance(10 * time.Millisecond)
+
+		t.Run("Leasing another function succeeds", func(t *testing.T) {
 			ba, err := q.EnqueueItem(ctx, QueueItem{
 				WorkflowID: idB,
 				Data: osqueue.Item{
@@ -2400,26 +2410,26 @@ func TestQueueRateLimit(t *testing.T) {
 						Burst:  0, // No burst.
 					},
 				},
-			}, getNow().Add(time.Second))
+			}, clock.Now().Add(time.Second))
 			r.NoError(err)
-			lease, err := q.Lease(ctx, *partitions[0], ba, 10*time.Second, getNow(), nil)
+			lease, err := q.Lease(ctx, *partitions[0], ba, 10*time.Second, clock.Now(), nil)
 			r.Nil(err, "leasing throttled queue item without capacity didn't error")
 			r.NotNil(lease)
 		})
 
-		t.Run("Leasing after the period succeeds", func(t *testing.T) {
-			getNow = func() time.Time {
-				return time.Now().Add(time.Duration(throttle.Period) * time.Second)
-			}
-			defer func() { getNow = time.Now }()
+		// clock.Advance(10 * time.Millisecond)
 
-			leaseB, err := q.Lease(ctx, *partitions[0], ab, 10*time.Second, getNow(), nil)
+		t.Run("Leasing after the period succeeds", func(t *testing.T) {
+			clock.Advance(time.Duration(throttle.Period)*time.Second + time.Second)
+
+			leaseB, err := q.Lease(ctx, *partitions[0], ab, 10*time.Second, clock.Now(), nil)
 			r.Nil(err, "leasing after waiting for throttle should succeed")
 			r.NotNil(leaseB)
 		})
 	})
 
 	mr.FlushAll()
+	clock.Advance(10 * time.Second)
 
 	t.Run("With bursts", func(t *testing.T) {
 		throttle := &osqueue.Throttle{
@@ -2437,13 +2447,14 @@ func TestQueueRateLimit(t *testing.T) {
 					Identifier: state.Identifier{WorkflowID: idA},
 					Throttle:   throttle,
 				},
-			}, getNow())
+			}, clock.Now())
+			clock.Advance(1 * time.Millisecond)
 			r.NoError(err)
 			items = append(items, item)
 		}
 
 		// Leasing A should succeed, then B should fail.
-		partitions, err := q.PartitionPeek(ctx, true, getNow().Add(5*time.Second), 5)
+		partitions, err := q.PartitionPeek(ctx, true, clock.Now().Add(5*time.Second), 5)
 		r.NoError(err)
 		r.EqualValues(1, len(partitions))
 
@@ -2451,7 +2462,7 @@ func TestQueueRateLimit(t *testing.T) {
 
 		t.Run("Leasing up to bursts succeeds", func(t *testing.T) {
 			for i := 0; i < 3; i++ {
-				lease, err := q.Lease(ctx, *partitions[0], items[i], 2*time.Second, getNow(), nil)
+				lease, err := q.Lease(ctx, *partitions[0], items[i], 2*time.Second, clock.Now(), nil)
 				r.NoError(err, "leasing throttled queue item with capacity failed")
 				r.NotNil(lease)
 				idx++
@@ -2459,39 +2470,33 @@ func TestQueueRateLimit(t *testing.T) {
 		})
 
 		t.Run("Leasing the 4th time fails", func(t *testing.T) {
-			lease, err := q.Lease(ctx, *partitions[0], items[idx], 1*time.Second, getNow(), nil)
+			lease, err := q.Lease(ctx, *partitions[0], items[idx], 1*time.Second, clock.Now(), nil)
 			r.NotNil(err, "leasing throttled queue item without capacity didn't error")
 			r.ErrorContains(err, ErrQueueItemThrottled.Error())
 			r.Nil(lease)
 		})
 
 		t.Run("After 10s, we can re-lease once as bursting is done.", func(t *testing.T) {
-			getNow = func() time.Time {
-				return time.Now().Add(time.Duration(throttle.Period) * time.Second).Add(time.Second)
-			}
-			defer func() { getNow = time.Now }()
+			clock.Advance(time.Duration(throttle.Period)*time.Second + time.Second)
 
-			lease, err := q.Lease(ctx, *partitions[0], items[idx], 2*time.Second, getNow(), nil)
+			lease, err := q.Lease(ctx, *partitions[0], items[idx], 2*time.Second, clock.Now(), nil)
 			r.NoError(err, "leasing throttled queue item with capacity failed")
 			r.NotNil(lease)
 
 			idx++
 
 			// It should fail, as bursting is done.
-			lease, err = q.Lease(ctx, *partitions[0], items[idx], 1*time.Second, getNow(), nil)
+			lease, err = q.Lease(ctx, *partitions[0], items[idx], 1*time.Second, clock.Now(), nil)
 			r.NotNil(err, "leasing throttled queue item without capacity didn't error")
 			r.ErrorContains(err, ErrQueueItemThrottled.Error())
 			r.Nil(lease)
 		})
 
 		t.Run("After another 40s, we can burst again", func(t *testing.T) {
-			getNow = func() time.Time {
-				return time.Now().Add(time.Duration(throttle.Period*4) * time.Second)
-			}
-			defer func() { getNow = time.Now }()
+			clock.Advance(time.Duration(throttle.Period*4) * time.Second)
 
 			for i := 0; i < 3; i++ {
-				lease, err := q.Lease(ctx, *partitions[0], items[i], 2*time.Second, getNow(), nil)
+				lease, err := q.Lease(ctx, *partitions[0], items[i], 2*time.Second, clock.Now(), nil)
 				r.NoError(err, "leasing throttled queue item with capacity failed")
 				r.NotNil(lease)
 				idx++

--- a/vendor/github.com/jonboulle/clockwork/.editorconfig
+++ b/vendor/github.com/jonboulle/clockwork/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab

--- a/vendor/github.com/jonboulle/clockwork/.gitignore
+++ b/vendor/github.com/jonboulle/clockwork/.gitignore
@@ -1,0 +1,27 @@
+/.idea/
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+
+*.swp

--- a/vendor/github.com/jonboulle/clockwork/LICENSE
+++ b/vendor/github.com/jonboulle/clockwork/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/jonboulle/clockwork/README.md
+++ b/vendor/github.com/jonboulle/clockwork/README.md
@@ -1,0 +1,80 @@
+# clockwork
+
+[![Mentioned in Awesome Go](https://awesome.re/mentioned-badge-flat.svg)](https://github.com/avelino/awesome-go#utilities)
+
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/jonboulle/clockwork/ci.yaml?style=flat-square)](https://github.com/jonboulle/clockwork/actions?query=workflow%3ACI)
+[![Go Report Card](https://goreportcard.com/badge/github.com/jonboulle/clockwork?style=flat-square)](https://goreportcard.com/report/github.com/jonboulle/clockwork)
+![Go Version](https://img.shields.io/badge/go%20version-%3E=1.15-61CFDD.svg?style=flat-square)
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/mod/github.com/jonboulle/clockwork)
+
+**A simple fake clock for Go.**
+
+
+## Usage
+
+Replace uses of the `time` package with the `clockwork.Clock` interface instead.
+
+For example, instead of using `time.Sleep` directly:
+
+```go
+func myFunc() {
+	time.Sleep(3 * time.Second)
+	doSomething()
+}
+```
+
+Inject a clock and use its `Sleep` method instead:
+
+```go
+func myFunc(clock clockwork.Clock) {
+	clock.Sleep(3 * time.Second)
+	doSomething()
+}
+```
+
+Now you can easily test `myFunc` with a `FakeClock`:
+
+```go
+func TestMyFunc(t *testing.T) {
+	c := clockwork.NewFakeClock()
+
+	// Start our sleepy function
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		myFunc(c)
+		wg.Done()
+	}()
+
+	// Ensure we wait until myFunc is sleeping
+	c.BlockUntil(1)
+
+	assertState()
+
+	// Advance the FakeClock forward in time
+	c.Advance(3 * time.Second)
+
+	// Wait until the function completes
+	wg.Wait()
+
+	assertState()
+}
+```
+
+and in production builds, simply inject the real clock instead:
+
+```go
+myFunc(clockwork.NewRealClock())
+```
+
+See [example_test.go](example_test.go) for a full example.
+
+
+# Credits
+
+clockwork is inspired by @wickman's [threaded fake clock](https://gist.github.com/wickman/3840816), and the [Golang playground](https://blog.golang.org/playground#TOC_3.1.)
+
+
+## License
+
+Apache License, Version 2.0. Please see [License File](LICENSE) for more information.

--- a/vendor/github.com/jonboulle/clockwork/clockwork.go
+++ b/vendor/github.com/jonboulle/clockwork/clockwork.go
@@ -1,0 +1,349 @@
+package clockwork
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Clock provides an interface that packages can use instead of directly using
+// the [time] module, so that chronology-related behavior can be tested.
+type Clock interface {
+	After(d time.Duration) <-chan time.Time
+	Sleep(d time.Duration)
+	Now() time.Time
+	Since(t time.Time) time.Duration
+	NewTicker(d time.Duration) Ticker
+	NewTimer(d time.Duration) Timer
+	AfterFunc(d time.Duration, f func()) Timer
+}
+
+// FakeClock provides an interface for a clock which can be manually advanced
+// through time.
+//
+// FakeClock maintains a list of "waiters," which consists of all callers
+// waiting on the underlying clock (i.e. Tickers and Timers including callers of
+// Sleep or After). Users can call BlockUntil to block until the clock has an
+// expected number of waiters.
+type FakeClock interface {
+	Clock
+	// Advance advances the FakeClock to a new point in time, ensuring any existing
+	// waiters are notified appropriately before returning.
+	Advance(d time.Duration)
+	// BlockUntil blocks until the FakeClock has the given number of waiters.
+	BlockUntil(waiters int)
+}
+
+// NewRealClock returns a Clock which simply delegates calls to the actual time
+// package; it should be used by packages in production.
+func NewRealClock() Clock {
+	return &realClock{}
+}
+
+// NewFakeClock returns a FakeClock implementation which can be
+// manually advanced through time for testing. The initial time of the
+// FakeClock will be the current system time.
+//
+// Tests that require a deterministic time must use NewFakeClockAt.
+func NewFakeClock() FakeClock {
+	return NewFakeClockAt(time.Now())
+}
+
+// NewFakeClockAt returns a FakeClock initialised at the given time.Time.
+func NewFakeClockAt(t time.Time) FakeClock {
+	return &fakeClock{
+		time: t,
+	}
+}
+
+type realClock struct{}
+
+func (rc *realClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}
+
+func (rc *realClock) Sleep(d time.Duration) {
+	time.Sleep(d)
+}
+
+func (rc *realClock) Now() time.Time {
+	return time.Now()
+}
+
+func (rc *realClock) Since(t time.Time) time.Duration {
+	return rc.Now().Sub(t)
+}
+
+func (rc *realClock) NewTicker(d time.Duration) Ticker {
+	return realTicker{time.NewTicker(d)}
+}
+
+func (rc *realClock) NewTimer(d time.Duration) Timer {
+	return realTimer{time.NewTimer(d)}
+}
+
+func (rc *realClock) AfterFunc(d time.Duration, f func()) Timer {
+	return realTimer{time.AfterFunc(d, f)}
+}
+
+type fakeClock struct {
+	// l protects all attributes of the clock, including all attributes of all
+	// waiters and blockers.
+	l        sync.RWMutex
+	waiters  []expirer
+	blockers []*blocker
+	time     time.Time
+}
+
+// blocker is a caller of BlockUntil.
+type blocker struct {
+	count int
+
+	// ch is closed when the underlying clock has the specificed number of blockers.
+	ch chan struct{}
+}
+
+// expirer is a timer or ticker that expires at some point in the future.
+type expirer interface {
+	// expire the expirer at the given time, returning the desired duration until
+	// the next expiration, if any.
+	expire(now time.Time) (next *time.Duration)
+
+	// Get and set the expiration time.
+	expiry() time.Time
+	setExpiry(time.Time)
+}
+
+// After mimics [time.After]; it waits for the given duration to elapse on the
+// fakeClock, then sends the current time on the returned channel.
+func (fc *fakeClock) After(d time.Duration) <-chan time.Time {
+	return fc.NewTimer(d).Chan()
+}
+
+// Sleep blocks until the given duration has passed on the fakeClock.
+func (fc *fakeClock) Sleep(d time.Duration) {
+	<-fc.After(d)
+}
+
+// Now returns the current time of the fakeClock
+func (fc *fakeClock) Now() time.Time {
+	fc.l.RLock()
+	defer fc.l.RUnlock()
+	return fc.time
+}
+
+// Since returns the duration that has passed since the given time on the
+// fakeClock.
+func (fc *fakeClock) Since(t time.Time) time.Duration {
+	return fc.Now().Sub(t)
+}
+
+// NewTicker returns a Ticker that will expire only after calls to
+// fakeClock.Advance() have moved the clock past the given duration.
+func (fc *fakeClock) NewTicker(d time.Duration) Ticker {
+	var ft *fakeTicker
+	ft = &fakeTicker{
+		firer: newFirer(),
+		d:     d,
+		reset: func(d time.Duration) { fc.set(ft, d) },
+		stop:  func() { fc.stop(ft) },
+	}
+	fc.set(ft, d)
+	return ft
+}
+
+// NewTimer returns a Timer that will fire only after calls to
+// fakeClock.Advance() have moved the clock past the given duration.
+func (fc *fakeClock) NewTimer(d time.Duration) Timer {
+	return fc.newTimer(d, nil)
+}
+
+// AfterFunc mimics [time.AfterFunc]; it returns a Timer that will invoke the
+// given function only after calls to fakeClock.Advance() have moved the clock
+// past the given duration.
+func (fc *fakeClock) AfterFunc(d time.Duration, f func()) Timer {
+	return fc.newTimer(d, f)
+}
+
+// newTimer returns a new timer, using an optional afterFunc.
+func (fc *fakeClock) newTimer(d time.Duration, afterfunc func()) *fakeTimer {
+	var ft *fakeTimer
+	ft = &fakeTimer{
+		firer: newFirer(),
+		reset: func(d time.Duration) bool {
+			fc.l.Lock()
+			defer fc.l.Unlock()
+			// fc.l must be held across the calls to stopExpirer & setExpirer.
+			stopped := fc.stopExpirer(ft)
+			fc.setExpirer(ft, d)
+			return stopped
+		},
+		stop: func() bool { return fc.stop(ft) },
+
+		afterFunc: afterfunc,
+	}
+	fc.set(ft, d)
+	return ft
+}
+
+// Advance advances fakeClock to a new point in time, ensuring waiters and
+// blockers are notified appropriately before returning.
+func (fc *fakeClock) Advance(d time.Duration) {
+	fc.l.Lock()
+	defer fc.l.Unlock()
+	end := fc.time.Add(d)
+	// Expire the earliest waiter until the earliest waiter's expiration is after
+	// end.
+	//
+	// We don't iterate because the callback of the waiter might register a new
+	// waiter, so the list of waiters might change as we execute this.
+	for len(fc.waiters) > 0 && !end.Before(fc.waiters[0].expiry()) {
+		w := fc.waiters[0]
+		fc.waiters = fc.waiters[1:]
+
+		// Use the waiter's expriation as the current time for this expiration.
+		now := w.expiry()
+		fc.time = now
+		if d := w.expire(now); d != nil {
+			// Set the new exipration if needed.
+			fc.setExpirer(w, *d)
+		}
+	}
+	fc.time = end
+}
+
+// BlockUntil blocks until the fakeClock has the given number of waiters.
+//
+// Prefer BlockUntilContext, which offers context cancellation to prevent
+// deadlock.
+//
+// Deprecation warning: This function might be deprecated in later versions.
+func (fc *fakeClock) BlockUntil(n int) {
+	b := fc.newBlocker(n)
+	if b == nil {
+		return
+	}
+	<-b.ch
+}
+
+// BlockUntilContext blocks until the fakeClock has the given number of waiters
+// or the context is cancelled.
+func (fc *fakeClock) BlockUntilContext(ctx context.Context, n int) error {
+	b := fc.newBlocker(n)
+	if b == nil {
+		return nil
+	}
+
+	select {
+	case <-b.ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (fc *fakeClock) newBlocker(n int) *blocker {
+	fc.l.Lock()
+	defer fc.l.Unlock()
+	// Fast path: we already have >= n waiters.
+	if len(fc.waiters) >= n {
+		return nil
+	}
+	// Set up a new blocker to wait for more waiters.
+	b := &blocker{
+		count: n,
+		ch:    make(chan struct{}),
+	}
+	fc.blockers = append(fc.blockers, b)
+	return b
+}
+
+// stop stops an expirer, returning true if the expirer was stopped.
+func (fc *fakeClock) stop(e expirer) bool {
+	fc.l.Lock()
+	defer fc.l.Unlock()
+	return fc.stopExpirer(e)
+}
+
+// stopExpirer stops an expirer, returning true if the expirer was stopped.
+//
+// The caller must hold fc.l.
+func (fc *fakeClock) stopExpirer(e expirer) bool {
+	for i, t := range fc.waiters {
+		if t == e {
+			// Remove element, maintaining order.
+			copy(fc.waiters[i:], fc.waiters[i+1:])
+			fc.waiters[len(fc.waiters)-1] = nil
+			fc.waiters = fc.waiters[:len(fc.waiters)-1]
+			return true
+		}
+	}
+	return false
+}
+
+// set sets an expirer to expire at a future point in time.
+func (fc *fakeClock) set(e expirer, d time.Duration) {
+	fc.l.Lock()
+	defer fc.l.Unlock()
+	fc.setExpirer(e, d)
+}
+
+// setExpirer sets an expirer to expire at a future point in time.
+//
+// The caller must hold fc.l.
+func (fc *fakeClock) setExpirer(e expirer, d time.Duration) {
+	if d.Nanoseconds() <= 0 {
+		// special case - trigger immediately, never reset.
+		//
+		// TODO: Explain what cases this covers.
+		e.expire(fc.time)
+		return
+	}
+	// Add the expirer to the set of waiters and notify any blockers.
+	e.setExpiry(fc.time.Add(d))
+	fc.waiters = append(fc.waiters, e)
+	sort.Slice(fc.waiters, func(i int, j int) bool {
+		return fc.waiters[i].expiry().Before(fc.waiters[j].expiry())
+	})
+
+    // Notify blockers of our new waiter.
+	var blocked []*blocker
+	count := len(fc.waiters)
+	for _, b := range fc.blockers {
+		if b.count <= count {
+			close(b.ch)
+			continue
+		}
+		blocked = append(blocked, b)
+	}
+	fc.blockers = blocked
+}
+
+// firer is used by fakeTimer and fakeTicker used to help implement expirer.
+type firer struct {
+	// The channel associated with the firer, used to send expriation times.
+	c chan time.Time
+
+	// The time when the firer expires. Only meaningful if the firer is currently
+	// one of a fakeClock's waiters.
+	exp time.Time
+}
+
+func newFirer() firer {
+	return firer{c: make(chan time.Time, 1)}
+}
+
+func (f *firer) Chan() <-chan time.Time {
+	return f.c
+}
+
+// expiry implements expirer.
+func (f *firer) expiry() time.Time {
+	return f.exp
+}
+
+// setExpiry implements expirer.
+func (f *firer) setExpiry(t time.Time) {
+	f.exp = t
+}

--- a/vendor/github.com/jonboulle/clockwork/context.go
+++ b/vendor/github.com/jonboulle/clockwork/context.go
@@ -1,0 +1,25 @@
+package clockwork
+
+import (
+	"context"
+)
+
+// contextKey is private to this package so we can ensure uniqueness here. This
+// type identifies context values provided by this package.
+type contextKey string
+
+// keyClock provides a clock for injecting during tests. If absent, a real clock should be used.
+var keyClock = contextKey("clock") // clockwork.Clock
+
+// AddToContext creates a derived context that references the specified clock.
+func AddToContext(ctx context.Context, clock Clock) context.Context {
+	return context.WithValue(ctx, keyClock, clock)
+}
+
+// FromContext extracts a clock from the context. If not present, a real clock is returned.
+func FromContext(ctx context.Context) Clock {
+	if clock, ok := ctx.Value(keyClock).(Clock); ok {
+		return clock
+	}
+	return NewRealClock()
+}

--- a/vendor/github.com/jonboulle/clockwork/ticker.go
+++ b/vendor/github.com/jonboulle/clockwork/ticker.go
@@ -1,0 +1,48 @@
+package clockwork
+
+import "time"
+
+// Ticker provides an interface which can be used instead of directly using
+// [time.Ticker]. The real-time ticker t provides ticks through t.C which
+// becomes t.Chan() to make this channel requirement definable in this
+// interface.
+type Ticker interface {
+	Chan() <-chan time.Time
+	Reset(d time.Duration)
+	Stop()
+}
+
+type realTicker struct{ *time.Ticker }
+
+func (r realTicker) Chan() <-chan time.Time {
+	return r.C
+}
+
+type fakeTicker struct {
+	firer
+
+	// reset and stop provide the implementation of the respective exported
+	// functions.
+	reset func(d time.Duration)
+	stop  func()
+
+	// The duration of the ticker.
+	d time.Duration
+}
+
+func (f *fakeTicker) Reset(d time.Duration) {
+	f.reset(d)
+}
+
+func (f *fakeTicker) Stop() {
+	f.stop()
+}
+
+func (f *fakeTicker) expire(now time.Time) *time.Duration {
+	// Never block on expiration.
+	select {
+	case f.c <- now:
+	default:
+	}
+	return &f.d
+}

--- a/vendor/github.com/jonboulle/clockwork/timer.go
+++ b/vendor/github.com/jonboulle/clockwork/timer.go
@@ -1,0 +1,53 @@
+package clockwork
+
+import "time"
+
+// Timer provides an interface which can be used instead of directly using
+// [time.Timer]. The real-time timer t provides events through t.C which becomes
+// t.Chan() to make this channel requirement definable in this interface.
+type Timer interface {
+	Chan() <-chan time.Time
+	Reset(d time.Duration) bool
+	Stop() bool
+}
+
+type realTimer struct{ *time.Timer }
+
+func (r realTimer) Chan() <-chan time.Time {
+	return r.C
+}
+
+type fakeTimer struct {
+	firer
+
+	// reset and stop provide the implmenetation of the respective exported
+	// functions.
+	reset func(d time.Duration) bool
+	stop  func() bool
+
+	// If present when the timer fires, the timer calls afterFunc in its own
+	// goroutine rather than sending the time on Chan().
+	afterFunc func()
+}
+
+func (f *fakeTimer) Reset(d time.Duration) bool {
+	return f.reset(d)
+}
+
+func (f *fakeTimer) Stop() bool {
+	return f.stop()
+}
+
+func (f *fakeTimer) expire(now time.Time) *time.Duration {
+	if f.afterFunc != nil {
+		go f.afterFunc()
+		return nil
+	}
+
+	// Never block on expiration.
+	select {
+	case f.c <- now:
+	default:
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -538,6 +538,9 @@ github.com/jinzhu/copier
 # github.com/jmespath/go-jmespath v0.4.0
 ## explicit; go 1.14
 github.com/jmespath/go-jmespath
+# github.com/jonboulle/clockwork v0.4.0
+## explicit; go 1.15
+github.com/jonboulle/clockwork
 # github.com/json-iterator/go v1.1.12
 ## explicit; go 1.12
 github.com/json-iterator/go


### PR DESCRIPTION
## Description

This PR replaces usage of `time.Now` and related functions in `queue` and `queue_processor` by https://github.com/jonboulle/clockwork . It also replaces the (hacky and only partly-correct) `getNow` stub.

## Motivation

This ought to allow more stable and reliable tests of the queue.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
