### PR TITLE
Add `totalCount` and event name for runs view

### DIFF
--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -312,8 +312,9 @@ type ComplexityRoot struct {
 	}
 
 	RunsV2Connection struct {
-		Edges    func(childComplexity int) int
-		PageInfo func(childComplexity int) int
+		Edges      func(childComplexity int) int
+		PageInfo   func(childComplexity int) int
+		TotalCount func(childComplexity int) int
 	}
 
 	SleepStepInfo struct {
@@ -1811,6 +1812,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.RunsV2Connection.PageInfo(childComplexity), true
 
+	case "RunsV2Connection.totalCount":
+		if e.complexity.RunsV2Connection.TotalCount == nil {
+			break
+		}
+
+		return e.complexity.RunsV2Connection.TotalCount(childComplexity), true
+
 	case "SleepStepInfo.sleepUntil":
 		if e.complexity.SleepStepInfo.SleepUntil == nil {
 			break
@@ -2535,6 +2543,7 @@ type FunctionRunV2 {
 type RunsV2Connection {
   edges: [FunctionRunV2Edge!]!
   pageInfo: PageInfo!
+  totalCount: Int!
 }
 
 type FunctionRunV2Edge {
@@ -8411,6 +8420,8 @@ func (ec *executionContext) fieldContext_Query_runs(ctx context.Context, field g
 				return ec.fieldContext_RunsV2Connection_edges(ctx, field)
 			case "pageInfo":
 				return ec.fieldContext_RunsV2Connection_pageInfo(ctx, field)
+			case "totalCount":
+				return ec.fieldContext_RunsV2Connection_totalCount(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type RunsV2Connection", field.Name)
 		},
@@ -11956,6 +11967,50 @@ func (ec *executionContext) fieldContext_RunsV2Connection_pageInfo(ctx context.C
 				return ec.fieldContext_PageInfo_endCursor(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type PageInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RunsV2Connection_totalCount(ctx context.Context, field graphql.CollectedField, obj *models.RunsV2Connection) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RunsV2Connection_totalCount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TotalCount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RunsV2Connection_totalCount(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RunsV2Connection",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -17521,6 +17576,13 @@ func (ec *executionContext) _RunsV2Connection(ctx context.Context, sel ast.Selec
 		case "pageInfo":
 
 			out.Values[i] = ec._RunsV2Connection_pageInfo(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "totalCount":
+
+			out.Values[i] = ec._RunsV2Connection_totalCount(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -363,6 +363,7 @@ type FunctionRunV2 {
 type RunsV2Connection {
   edges: [FunctionRunV2Edge!]!
   pageInfo: PageInfo!
+  totalCount: Int!
 }
 
 type FunctionRunV2Edge {

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -350,7 +350,7 @@ type FunctionRunV2 {
   status: FunctionRunStatus!
   sourceID: String # The parent trace / run that triggered this run
   triggerIDs: [ULID!]!
-  triggers: [Bytes!]!
+  eventName: String
   isBatch: Boolean!
   batchCreatedAt: Time
   cronSchedule: String

--- a/pkg/coreapi/gqlgen.yml
+++ b/pkg/coreapi/gqlgen.yml
@@ -77,8 +77,6 @@ models:
         resolver: true
       trace:
         resolver: true
-      triggers:
-        resolver: true
   RunsV2Connection:
     fields:
       totalCount:

--- a/pkg/coreapi/gqlgen.yml
+++ b/pkg/coreapi/gqlgen.yml
@@ -79,6 +79,10 @@ models:
         resolver: true
       triggers:
         resolver: true
+  RunsV2Connection:
+    fields:
+      totalCount:
+        resolver: true
   HistoryType:
     model: github.com/inngest/inngest/pkg/enums.HistoryType
   HistoryStepType:

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -118,7 +118,7 @@ type FunctionRunV2 struct {
 	Status         FunctionRunStatus `json:"status"`
 	SourceID       *string           `json:"sourceID,omitempty"`
 	TriggerIDs     []ulid.ULID       `json:"triggerIDs"`
-	Triggers       []string          `json:"triggers"`
+	EventName      *string           `json:"eventName,omitempty"`
 	IsBatch        bool              `json:"isBatch"`
 	BatchCreatedAt *time.Time        `json:"batchCreatedAt,omitempty"`
 	CronSchedule   *string           `json:"cronSchedule,omitempty"`

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -212,8 +212,9 @@ type RunsFilterV2 struct {
 }
 
 type RunsV2Connection struct {
-	Edges    []*FunctionRunV2Edge `json:"edges"`
-	PageInfo *PageInfo            `json:"pageInfo"`
+	Edges      []*FunctionRunV2Edge `json:"edges"`
+	PageInfo   *PageInfo            `json:"pageInfo"`
+	TotalCount int                  `json:"totalCount"`
 }
 
 type RunsV2OrderBy struct {

--- a/pkg/coreapi/graph/resolvers/function_run_v2.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run_v2.resolver.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -37,28 +36,6 @@ func (r *functionRunV2Resolver) Function(ctx context.Context, fn *models.Functio
 	}
 
 	return models.MakeFunction(fun)
-}
-
-func (r *functionRunV2Resolver) Triggers(ctx context.Context, fn *models.FunctionRunV2) ([]string, error) {
-	events, err := r.Data.GetEventsByInternalIDs(ctx, fn.TriggerIDs)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving triggers: %w", err)
-	}
-
-	res := []string{}
-	for _, evt := range events {
-		byt, err := json.Marshal(evt.GetEvent())
-		if err != nil {
-			return nil, fmt.Errorf("invalid event format: %w", err)
-		}
-
-		sevt := string(byt)
-		if sevt != "" {
-			res = append(res, string(byt))
-		}
-	}
-
-	return res, nil
 }
 
 func (r *functionRunV2Resolver) Trace(ctx context.Context, fn *models.FunctionRunV2) (*models.RunTraceSpan, error) {

--- a/pkg/coreapi/graph/resolvers/resolver.go
+++ b/pkg/coreapi/graph/resolvers/resolver.go
@@ -38,7 +38,9 @@ func (r *Resolver) Function() generated.FunctionResolver { return &functionResol
 
 func (r *Resolver) StreamItem() generated.StreamItemResolver { return &streamItemResolver{r} }
 
-func (r *Resolver) RunsV2Connection() generated.RunsV2ConnectionResolver { return &runsV2Resolver{r} }
+func (r *Resolver) RunsV2Connection() generated.RunsV2ConnectionResolver {
+	return &runsV2ConnResolver{r}
+}
 
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
@@ -48,4 +50,4 @@ type functionRunResolver struct{ *Resolver }
 type functionRunV2Resolver struct{ *Resolver }
 type functionResolver struct{ *Resolver }
 type streamItemResolver struct{ *Resolver }
-type runsV2Resolver struct{ *Resolver }
+type runsV2ConnResolver struct{ *Resolver }

--- a/pkg/coreapi/graph/resolvers/resolver.go
+++ b/pkg/coreapi/graph/resolvers/resolver.go
@@ -38,6 +38,8 @@ func (r *Resolver) Function() generated.FunctionResolver { return &functionResol
 
 func (r *Resolver) StreamItem() generated.StreamItemResolver { return &streamItemResolver{r} }
 
+func (r *Resolver) RunsV2Connection() generated.RunsV2ConnectionResolver { return &runsV2Resolver{r} }
+
 type mutationResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
 type eventResolver struct{ *Resolver }
@@ -46,3 +48,4 @@ type functionRunResolver struct{ *Resolver }
 type functionRunV2Resolver struct{ *Resolver }
 type functionResolver struct{ *Resolver }
 type streamItemResolver struct{ *Resolver }
+type runsV2Resolver struct{ *Resolver }

--- a/pkg/coreapi/graph/resolvers/runs_v2.go
+++ b/pkg/coreapi/graph/resolvers/runs_v2.go
@@ -306,12 +306,17 @@ func (r *runsV2Resolver) TotalCount(ctx context.Context, obj *models.RunsV2Conne
 		return 0, fmt.Errorf("failed to access cursor")
 	}
 
+	orderBy, ok := graphql.GetFieldContext(ctx).Parent.Args["orderBy"].([]*models.RunsV2OrderBy)
+	if !ok {
+		return 0, fmt.Errorf("failed to retrieve order")
+	}
+
 	filter, ok := graphql.GetFieldContext(ctx).Parent.Args["filter"].(models.RunsFilterV2)
 	if !ok {
 		return 0, fmt.Errorf("failed to access query filter")
 	}
 
-	opts := toRunsQueryOpt(0, cursor, nil, filter)
+	opts := toRunsQueryOpt(0, cursor, orderBy, filter)
 	count, err := r.Data.GetTraceRunsCount(ctx, opts)
 	if err != nil {
 		return 0, fmt.Errorf("error retrieving count for runs: %w", err)

--- a/pkg/coreapi/graph/resolvers/runs_v2.go
+++ b/pkg/coreapi/graph/resolvers/runs_v2.go
@@ -393,3 +393,8 @@ func (r *queryResolver) RunTrigger(ctx context.Context, runID string) (*models.R
 
 	return &resp, nil
 }
+
+func (r *runsV2Resolver) TotalCount(ctx context.Context, obj *models.RunsV2Connection) (int, error) {
+	return 0, fmt.Errorf("not implemented")
+}
+

--- a/pkg/coreapi/graph/resolvers/runs_v2.go
+++ b/pkg/coreapi/graph/resolvers/runs_v2.go
@@ -333,7 +333,7 @@ func (r *queryResolver) RunTrigger(ctx context.Context, runID string) (*models.R
 	return &resp, nil
 }
 
-func (r *runsV2Resolver) TotalCount(ctx context.Context, obj *models.RunsV2Connection) (int, error) {
+func (r *runsV2ConnResolver) TotalCount(ctx context.Context, obj *models.RunsV2Connection) (int, error) {
 	cursor, ok := graphql.GetFieldContext(ctx).Parent.Args["after"].(*string)
 	if !ok {
 		return 0, fmt.Errorf("failed to access cursor")

--- a/pkg/cqrs/sqlitecqrs/cqrs.go
+++ b/pkg/cqrs/sqlitecqrs/cqrs.go
@@ -1062,7 +1062,7 @@ func (w wrapper) GetTraceRuns(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*
 		}
 
 		// the cursor target should be skipped
-		if reqcursor != nil && reqcursor.ID == data.RunID.String() {
+		if reqcursor.ID == data.RunID.String() {
 			continue
 		}
 

--- a/pkg/cqrs/sqlitecqrs/cqrs.go
+++ b/pkg/cqrs/sqlitecqrs/cqrs.go
@@ -890,6 +890,10 @@ func (w wrapper) GetSpanOutput(ctx context.Context, opts cqrs.SpanIdentifier) (*
 	return output, nil
 }
 
+func (w wrapper) GetTraceRunsCount(ctx context.Context, opt cqrs.GetTraceRunOpt) (int, error) {
+	return 0, fmt.Errorf("not implemented")
+}
+
 func (w wrapper) GetTraceRuns(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*cqrs.TraceRun, error) {
 	// filters
 	filter := []sq.Expression{}

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -212,6 +212,8 @@ type TraceWriterDev interface {
 type TraceReader interface {
 	// GetTraceRuns retrieves a list of TraceRun based on the options specified
 	GetTraceRuns(ctx context.Context, opt GetTraceRunOpt) ([]*TraceRun, error)
+	// GetTraceRunsCount returns the total number of items applicable to the specified filter
+	GetTraceRunsCount(ctx context.Context, opt GetTraceRunOpt) (int, error)
 	// GetTraceRun retrieve the specified run
 	GetTraceRun(ctx context.Context, id TraceRunIdentifier) (*TraceRun, error)
 	// GetTraceSpansByRun retrieves all the spans related to the trace

--- a/tests/client/function_run.go
+++ b/tests/client/function_run.go
@@ -58,7 +58,7 @@ type FnRunPageInfo struct {
 	EndCursor   *string `json:"endCursor,omitempty"`
 }
 
-func (c *Client) FunctionRuns(ctx context.Context, opts FunctionRunOpt) ([]FnRunEdge, FnRunPageInfo) {
+func (c *Client) FunctionRuns(ctx context.Context, opts FunctionRunOpt) ([]FnRunEdge, FnRunPageInfo, int) {
 	c.Helper()
 
 	items := 40
@@ -106,6 +106,7 @@ func (c *Client) FunctionRuns(ctx context.Context, opts FunctionRunOpt) ([]FnRun
 				endCursor
 				hasNextPage
 			}
+			totalCount
 		}
 	}`,
 		cursor,
@@ -128,8 +129,9 @@ func (c *Client) FunctionRuns(ctx context.Context, opts FunctionRunOpt) ([]FnRun
 
 	type response struct {
 		Runs struct {
-			Edges    []FnRunEdge   `json:"edges"`
-			PageInfo FnRunPageInfo `json:"pageInfo"`
+			Edges      []FnRunEdge   `json:"edges"`
+			PageInfo   FnRunPageInfo `json:"pageInfo"`
+			TotalCount int           `json:"totalCount"`
 		}
 	}
 
@@ -138,7 +140,7 @@ func (c *Client) FunctionRuns(ctx context.Context, opts FunctionRunOpt) ([]FnRun
 		c.Fatalf(err.Error())
 	}
 
-	return data.Runs.Edges, data.Runs.PageInfo
+	return data.Runs.Edges, data.Runs.PageInfo, data.Runs.TotalCount
 }
 
 type Run struct {

--- a/tests/golang/function_runs_test.go
+++ b/tests/golang/function_runs_test.go
@@ -89,16 +89,20 @@ func TestFunctionRunList(t *testing.T) {
 	require.EqualValues(t, successTotal, ok)
 	require.EqualValues(t, failureTotal, failed)
 
+	total := successTotal + failureTotal
+
 	// tests
 	t.Run("retrieve all runs", func(t *testing.T) {
+
 		require.Eventually(t, func() bool {
-			edges, pageInfo := c.FunctionRuns(ctx, client.FunctionRunOpt{
+			edges, pageInfo, count := c.FunctionRuns(ctx, client.FunctionRunOpt{
 				Start: start,
 				End:   end,
 			})
 
-			assert.Equal(t, successTotal+failureTotal, len(edges))
+			assert.Equal(t, total, len(edges))
 			assert.False(t, pageInfo.HasNextPage)
+			assert.Equal(t, total, count)
 
 			// sorted by queued_at desc order by default
 			ts := time.Now()
@@ -114,7 +118,7 @@ func TestFunctionRunList(t *testing.T) {
 
 	t.Run("retrieve only successful runs sorted by started_at", func(t *testing.T) {
 		require.Eventually(t, func() bool {
-			edges, pageInfo := c.FunctionRuns(ctx, client.FunctionRunOpt{
+			edges, pageInfo, _ := c.FunctionRuns(ctx, client.FunctionRunOpt{
 				Start:     start,
 				End:       end,
 				TimeField: models.RunsV2OrderByFieldStartedAt,
@@ -141,7 +145,7 @@ func TestFunctionRunList(t *testing.T) {
 
 	t.Run("retrieve only failed runs sorted by ended_at", func(t *testing.T) {
 		require.Eventually(t, func() bool {
-			edges, pageInfo := c.FunctionRuns(ctx, client.FunctionRunOpt{
+			edges, pageInfo, _ := c.FunctionRuns(ctx, client.FunctionRunOpt{
 				Start:     start,
 				End:       end,
 				TimeField: models.RunsV2OrderByFieldEndedAt,
@@ -168,7 +172,7 @@ func TestFunctionRunList(t *testing.T) {
 
 	t.Run("retrieve only failed runs", func(t *testing.T) {
 		require.Eventually(t, func() bool {
-			edges, pageInfo := c.FunctionRuns(ctx, client.FunctionRunOpt{
+			edges, pageInfo, _ := c.FunctionRuns(ctx, client.FunctionRunOpt{
 				Start:  start,
 				End:    end,
 				Status: []string{models.FunctionRunStatusFailed.String()},
@@ -192,7 +196,7 @@ func TestFunctionRunList(t *testing.T) {
 	t.Run("paginate without additional filter", func(t *testing.T) {
 		require.Eventually(t, func() bool {
 			items := 10
-			edges, pageInfo := c.FunctionRuns(ctx, client.FunctionRunOpt{
+			edges, pageInfo, _ := c.FunctionRuns(ctx, client.FunctionRunOpt{
 				Start: start,
 				End:   end,
 				Items: items,
@@ -202,7 +206,7 @@ func TestFunctionRunList(t *testing.T) {
 			assert.True(t, pageInfo.HasNextPage)
 
 			// there should be only 3 left
-			edges, pageInfo = c.FunctionRuns(ctx, client.FunctionRunOpt{
+			edges, pageInfo, _ = c.FunctionRuns(ctx, client.FunctionRunOpt{
 				Start:  start,
 				End:    end,
 				Items:  items,
@@ -219,7 +223,7 @@ func TestFunctionRunList(t *testing.T) {
 	t.Run("paginate with status filter", func(t *testing.T) {
 		require.Eventually(t, func() bool {
 			items := 2
-			edges, pageInfo := c.FunctionRuns(ctx, client.FunctionRunOpt{
+			edges, pageInfo, total := c.FunctionRuns(ctx, client.FunctionRunOpt{
 				Start:     start,
 				End:       end,
 				TimeField: models.RunsV2OrderByFieldEndedAt,
@@ -232,9 +236,10 @@ func TestFunctionRunList(t *testing.T) {
 
 			assert.Equal(t, 2, len(edges))
 			assert.True(t, pageInfo.HasNextPage)
+			assert.Equal(t, failureTotal, total)
 
 			// there are only 3 failed runs, so there shouldn't be anymore than 1
-			edges, pageInfo = c.FunctionRuns(ctx, client.FunctionRunOpt{
+			edges, pageInfo, _ = c.FunctionRuns(ctx, client.FunctionRunOpt{
 				Start:     start,
 				End:       end,
 				TimeField: models.RunsV2OrderByFieldEndedAt,
@@ -249,6 +254,7 @@ func TestFunctionRunList(t *testing.T) {
 			remain := failureTotal - items
 			assert.Equal(t, remain, len(edges))
 			assert.False(t, pageInfo.HasNextPage)
+			assert.Equal(t, failureTotal, total)
 
 			return true
 		}, 10*time.Second, 2*time.Second)

--- a/tests/golang/sleep_test.go
+++ b/tests/golang/sleep_test.go
@@ -86,7 +86,7 @@ func TestSleep(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("in progress sleep", func(t *testing.T) {
-		<-time.After(3 * time.Second)
+		<-time.After(2 * time.Second)
 
 		require.Eventually(t, func() bool {
 			run := c.RunTraces(ctx, runID)
@@ -120,7 +120,7 @@ func TestSleep(t *testing.T) {
 			})
 
 			return true
-		}, 10*time.Second, 1*time.Second)
+		}, 10*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("expected values", func(t *testing.T) {


### PR DESCRIPTION
## Description

- Add query to retrieve the total number of runs for the queried data.
- Replace `triggers` which is currently a blob and instead just return the event name associated with the run (`null` when the run is a batch or cron)
Uses for runs view.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
