### PR TITLE
Make sure appID is propagated to execution scheduling

### DIFF
--- a/pkg/coreapi/graph/resolvers/function_run_v2.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run_v2.resolver.go
@@ -14,19 +14,7 @@ func (r *functionRunV2Resolver) App(
 	ctx context.Context,
 	run *models.FunctionRunV2,
 ) (*cqrs.App, error) {
-	fn, err := r.Function(ctx, run)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving function: %w", err)
-	}
-
-	// TODO: Replace this with run.AppID. As of this comment, run.AppID is not
-	// set
-	appID, err := uuid.Parse(fn.AppID)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing app ID: %w", err)
-	}
-
-	return r.Data.GetAppByID(ctx, appID)
+	return r.Data.GetAppByID(ctx, run.AppID)
 }
 
 func (r *functionRunV2Resolver) Function(ctx context.Context, fn *models.FunctionRunV2) (*models.Function, error) {


### PR DESCRIPTION
## Description

This change makes sure appID and workspaceID are properly passed to function scheduling, so the data can be recorded accordingly for runs.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
