### PR TITLE
Prevent long error messages without spaces from breaking layout

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/integrations/vercel/callback/success/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/integrations/vercel/callback/success/page.tsx
@@ -17,7 +17,7 @@ export default async function SuccessPage({ searchParams }: SuccessProps) {
         <IconVercel className="text-onContrast h-6 w-6" />
       </div>
       <div className="text-basis mb-2 text-2xl leading-loose">
-        Inngest sucessfully installed on Vercel!
+        Inngest successfully installed on Vercel!
       </div>
       <div className="text-subtle mb-7 text-base">
         The Inngest integration has successfully been installed on your Vercel account.

--- a/ui/packages/components/src/CodeBlock/CodeBlock.tsx
+++ b/ui/packages/components/src/CodeBlock/CodeBlock.tsx
@@ -352,7 +352,8 @@ export function CodeBlock({ header, tab, actions = [], minLines = 0 }: CodeBlock
               <p
                 className={cn(
                   header?.status === 'error' ? 'text-status-failedText' : 'text-muted',
-                  ' px-5 py-2.5 text-sm'
+                  ' px-5 py-2.5 text-sm',
+                  'max-h-24 text-ellipsis break-words' // Handle long titles
                 )}
               >
                 {header?.title}


### PR DESCRIPTION
## Description

Fixes ultra long error messages that contain no spaces that might span 100s of characters. Fixes INN-3414

After fix:

![image](https://github.com/user-attachments/assets/7d16b19d-96ea-4552-8997-986360751ac4)


## Motivation
If there was a large output in an error message that was, for example, JSON without spaces, it would overflow horizontally and break layout:

![image](https://github.com/user-attachments/assets/e2374313-9cc9-4f50-b681-555c6e466bf2)


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
