### PR TITLE
Handle run view errors locally instead of at the page level

### DIFF
--- a/ui/packages/components/src/RunDetailsV2/ErrorCard.tsx
+++ b/ui/packages/components/src/RunDetailsV2/ErrorCard.tsx
@@ -1,0 +1,31 @@
+import { Alert } from '@inngest/components/Alert';
+import { NewButton } from '@inngest/components/Button';
+
+type Props = {
+  error: Error | any;
+  reset?: () => void;
+};
+
+export function ErrorCard({ error, reset }: Props) {
+  return (
+    <Alert
+      severity="error"
+      button={
+        reset && (
+          <NewButton
+            onClick={() => reset()}
+            kind="secondary"
+            appearance="outlined"
+            label="Reload"
+          />
+        )
+      }
+    >
+      <p className="mb-4 font-semibold">{error.message}</p>
+      <p>
+        An error occurred loading. Click reload to try again. If the problem persists, contact
+        support.
+      </p>
+    </Alert>
+  );
+}

--- a/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
@@ -10,6 +10,7 @@ import { Timeline } from '../TimelineV2/Timeline';
 import { TriggerDetails } from '../TriggerDetails';
 import type { Result } from '../types/functionRun';
 import { nullishToLazy } from '../utils/lazyLoad';
+import { ErrorCard } from './ErrorCard';
 import { RunInfo } from './RunInfo';
 
 type Props = {
@@ -75,10 +76,6 @@ export function RunDetails(props: Props) {
     }
   }, [props.cancelRun]);
 
-  if (runRes.error) {
-    throw runRes.error;
-  }
-
   const run = runRes.data;
   if (run?.trace.endedAt && pollInterval) {
     // The run won't change anymore so no need to poll
@@ -98,16 +95,23 @@ export function RunDetails(props: Props) {
       <div className="flex gap-4">
         <div className="grow">
           <div className="ml-8">
-            <RunInfo
-              cancelRun={cancelRun}
-              className="mb-4"
-              pathCreator={pathCreator}
-              rerun={rerun}
-              run={nullishToLazy(run)}
-              runID={runID}
-              standalone={standalone}
-              result={resultRes.data}
-            />
+            {runRes.error || resultRes.error ? (
+              <ErrorCard
+                error={runRes.error || resultRes.error}
+                reset={runRes.error ? () => runRes.refetch() : () => resultRes.refetch()}
+              />
+            ) : (
+              <RunInfo
+                cancelRun={cancelRun}
+                className="mb-4"
+                pathCreator={pathCreator}
+                rerun={rerun}
+                run={nullishToLazy(run)}
+                runID={runID}
+                standalone={standalone}
+                result={resultRes.data}
+              />
+            )}
           </div>
 
           {run && <Timeline getResult={getResult} pathCreator={pathCreator} trace={run.trace} />}

--- a/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
+++ b/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
@@ -16,6 +16,9 @@ import {
   TextElement,
   TimeElement,
 } from '../DetailsCard/Element';
+// NOTE - This component should be a shared component as part of the design system.
+// Until then, we re-use it from the RunDetailsV2 as these are part of the same parent UI.
+import { ErrorCard } from '../RunDetailsV2/ErrorCard';
 import { IconCloudArrowDown } from '../icons/CloudArrowDown';
 import { cn } from '../utils/classNames';
 import { devServerURL, useDevServer } from '../utils/useDevServer';
@@ -44,6 +47,7 @@ export function TriggerDetails({ className, getTrigger, runID }: Props) {
     data: trigger,
     error,
     isPending,
+    refetch,
   } = useQuery({
     queryKey: ['run-trigger', runID],
     queryFn: useCallback(() => {
@@ -124,7 +128,7 @@ export function TriggerDetails({ className, getTrigger, runID }: Props) {
   }, [trigger]);
 
   if (error) {
-    throw error;
+    return <ErrorCard error={error} reset={() => refetch()} />;
   }
 
   return (


### PR DESCRIPTION
## Description

This handles any errors locally as to more gracefully handle potential issues during the rollout. This should probably move to an error boundary around the Run Details view, but we need to handle these more gracefully as it's less disruptive as failing the entire page and making the user reload the entire runs list.

## Motivation
Follows fixes and changes in #1609 

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
