### PR TITLE
Don't set end time if the wait is not done yet

### DIFF
--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -783,8 +783,8 @@ func (tb *runTree) processWaitForEvent(ctx context.Context, span *cqrs.Span, mod
 			},
 		},
 	}
-	// if has ended
-	if (expired != nil && *expired) || (!timeout.IsZero() && timeout.Before(now)) {
+	// if event was found or has ended
+	if foundEvtID != nil || ((expired != nil && *expired) || (!timeout.IsZero() && timeout.Before(now))) {
 		mod.EndedAt = timestamppb.New(endedAt)
 	}
 

--- a/tests/golang/sleep_test.go
+++ b/tests/golang/sleep_test.go
@@ -86,7 +86,7 @@ func TestSleep(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("in progress sleep", func(t *testing.T) {
-		<-time.After(2 * time.Second)
+		<-time.After(4 * time.Second)
 
 		require.Eventually(t, func() bool {
 			run := c.RunTraces(ctx, runID)

--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -84,6 +84,7 @@ func TestWait(t *testing.T) {
 				assert.Equal(t, 0, len(span.ChildSpans)) // NOTE: should have no child
 				assert.Equal(t, models.RunTraceSpanStatusWaiting.String(), span.Status)
 				assert.Equal(t, models.StepOpWaitForEvent.String(), span.StepOp)
+				assert.Nil(t, span.EndedAt)
 				assert.Nil(t, span.OutputID)
 
 				var stepInfo models.WaitForEventStepInfo


### PR DESCRIPTION
## Description

Make sure the end time for wait spans are not set if the wait is not done.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
