### PR TITLE
Fix typo causing syntax error in monospace font css attribute.

### DIFF
--- a/ui/packages/components/tailwind.config.ts
+++ b/ui/packages/components/tailwind.config.ts
@@ -8,7 +8,7 @@ export default {
     extend: {
       fontFamily: {
         sans: ['CircularXX', ...defaultTheme.fontFamily.sans],
-        mono: ['CircularXXMono)', ...defaultTheme.fontFamily.mono],
+        mono: ['CircularXXMono', ...defaultTheme.fontFamily.mono],
       },
       colors: {
         slate: {


### PR DESCRIPTION
## Description

Fix correct font name to fix css attribute to properly render Circular Mono (or any fallback mono fonts).

## Motivation
The typo in font-mono was causing this css attribute to completed.

![image](https://github.com/user-attachments/assets/e36ea2cf-2f13-4143-8cb3-ec47dbe0c7e6)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
