### PR TITLE
INN-3360: placeholder env not found message until we have a good ux for it

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/layout.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/layout.tsx
@@ -1,3 +1,6 @@
+import type { ReactNode } from 'react';
+import { Alert } from '@inngest/components/Alert/Alert';
+
 import { ArchivedEnvBanner } from '@/components/ArchivedEnvBanner';
 import { getEnv } from '@/components/Environments/data';
 import { EnvironmentProvider } from '@/components/Environments/environment-context';
@@ -5,13 +8,30 @@ import { getBooleanFlag } from '@/components/FeatureFlags/ServerFeatureFlag';
 import Layout from '@/components/Layout/Layout';
 import AppNavigation from '@/components/Navigation/old/AppNavigation';
 import Toaster from '@/components/Toaster';
+import type { Environment } from '@/utils/environments';
 
 type RootLayoutProps = {
   params: {
     environmentSlug: string;
   };
-  children: React.ReactNode;
+  children: ReactNode;
 };
+
+const NotFound = () => (
+  <div className="mt-16 flex place-content-center">
+    <Alert severity="warning">Environment not found.</Alert>
+  </div>
+);
+
+const Env = ({ env, children }: { env?: Environment; children: ReactNode }) =>
+  env ? (
+    <>
+      <ArchivedEnvBanner env={env} />
+      <EnvironmentProvider env={env}>{children}</EnvironmentProvider>
+    </>
+  ) : (
+    <NotFound />
+  );
 
 export default async function RootLayout({
   params: { environmentSlug },
@@ -22,16 +42,13 @@ export default async function RootLayout({
 
   return newIANav ? (
     <Layout activeEnv={env}>
-      <ArchivedEnvBanner env={env} />
-      <EnvironmentProvider env={env}>{children}</EnvironmentProvider>
+      <Env env={env}>{children}</Env>
     </Layout>
   ) : (
     <>
       <div className="isolate flex h-full flex-col">
         <AppNavigation activeEnv={env} envSlug={environmentSlug} />
-
-        <ArchivedEnvBanner env={env} />
-        <EnvironmentProvider env={env}>{children}</EnvironmentProvider>
+        <Env env={env}>{children}</Env>
       </div>
       <Toaster
         toastOptions={{

--- a/ui/apps/dashboard/src/components/Environments/data.ts
+++ b/ui/apps/dashboard/src/components/Environments/data.ts
@@ -1,8 +1,16 @@
 import { getEnvironment } from '@/queries/server-only/getEnvironment';
 import { type Environment } from '@/utils/environments';
 
-export const getEnv = async (slug: string): Promise<Environment> => {
-  const env = await getEnvironment({ environmentSlug: slug });
+export const getEnv = async (slug: string): Promise<Environment | undefined> => {
+  try {
+    return await getEnvironment({ environmentSlug: slug });
+  } catch (e: any) {
+    console.error('error fetching env', e);
 
-  return env;
+    if (e.message && e.message.includes('no rows')) {
+      return undefined;
+    }
+
+    throw e;
+  }
 };


### PR DESCRIPTION
## Description

I'll work with John to put a nice ux on this. Until then here's a placeholder so we don't barf an sql error message at the user.

<img width="655" alt="Screenshot 2024-07-31 at 11 35 44 AM" src="https://github.com/user-attachments/assets/da928dbf-82d3-4e45-9fcb-a2c7fbcce058">

## Motivation
Better error messaging.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
