### PR TITLE
INN-3450: prevent future dates by default

### DIFF
--- a/ui/packages/components/src/DatePicker/RangePicker.tsx
+++ b/ui/packages/components/src/DatePicker/RangePicker.tsx
@@ -34,6 +34,7 @@ type RangePickerProps = Omit<DateButtonProps, 'defaultValue' | 'onChange'> & {
   defaultValue?: RangeChangeProps;
   upgradeCutoff?: Date;
   triggerComponent?: React.ComponentType<DateButtonProps>;
+  allowFuture?: boolean;
 };
 
 const RELATIVES = {
@@ -82,6 +83,7 @@ export const RangePicker = ({
   defaultValue,
   upgradeCutoff,
   triggerComponent: TriggerComponent = DateInputButton,
+  allowFuture = false,
   ...props
 }: RangePickerProps) => {
   const getInitialDisplayValue = (defaultValue: RangeChangeProps | undefined): ReactNode => {
@@ -141,6 +143,11 @@ export const RangePicker = ({
       setStartError('Please upgrade for increased history limits');
       setStartValid(false);
     }
+
+    if (!allowFuture && absoluteRange?.end && isBefore(new Date(), absoluteRange.end)) {
+      setEndError('End date is in the future');
+      setEndValid(false);
+    }
   };
 
   useEffect(() => {
@@ -149,6 +156,10 @@ export const RangePicker = ({
       setDurationError('');
     };
   }, []);
+
+  useEffect(() => {
+    validateRange();
+  }, [absoluteRange]);
 
   const processDuration = (e: any) => {
     if (e.key !== 'Enter') {
@@ -275,7 +286,6 @@ export const RangePicker = ({
                           ...absoluteRange,
                           start,
                         });
-                        validateRange();
                       }
                     }}
                     valid={startValid}
@@ -305,10 +315,8 @@ export const RangePicker = ({
                       if (end) {
                         setAbsoluteRange({
                           ...absoluteRange,
-
                           end,
                         });
-                        validateRange();
                       }
                     }}
                     valid={endValid}


### PR DESCRIPTION
## Description

Add option to validate against future dates, make that the default.  Also, validate absolute dates whenever they change. Ther were lots of ways to get invalid dates through the picker. 

## Motivation
Fix user bug report about future dates.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
