### PR TITLE
Disable password manager by default in Input

### DIFF
--- a/ui/packages/components/src/Forms/Input.tsx
+++ b/ui/packages/components/src/Forms/Input.tsx
@@ -19,7 +19,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     { allowPasswordManager = false, className, type = 'text', inngestSize = 'base', ...props },
     ref
   ) => {
-    let passwordManagerProps: Record<string, boolean> = {
+    let passwordManagerProps: Record<string, unknown> = {
+      autocomplete: 'off',
       'data-1p-ignore': true,
       'data-bwignore': true,
       'data-lpignore': true,

--- a/ui/packages/components/src/Forms/Input.tsx
+++ b/ui/packages/components/src/Forms/Input.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, type InputHTMLAttributes } from 'react';
 
 type InputProps = InputHTMLAttributes<HTMLInputElement> & {
+  allowPasswordManager?: boolean;
   label?: string;
   error?: string | undefined;
   inngestSize?: 'base' | 'lg';
@@ -14,7 +15,19 @@ const sizeStyles = {
 };
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type = 'text', inngestSize = 'base', ...props }, ref) => {
+  (
+    { allowPasswordManager = false, className, type = 'text', inngestSize = 'base', ...props },
+    ref
+  ) => {
+    let passwordManagerProps: Record<string, boolean> = {
+      'data-1p-ignore': true,
+      'data-bwignore': true,
+      'data-lpignore': true,
+    };
+    if (allowPasswordManager) {
+      passwordManagerProps = {};
+    }
+
     return (
       <div className="flex flex-col gap-1">
         {props.label && (
@@ -33,6 +46,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             }
             ${props.error && 'outline-error'}
             ${className}`}
+          {...passwordManagerProps}
           {...props}
         />
 


### PR DESCRIPTION
## Description
In our `Input` component, disable password manager autocomplete by default. The autocomplete is really annoying when it isn't necessary.

Before:
<img width="323" alt="Screenshot 2024-08-01 at 10 27 51" src="https://github.com/user-attachments/assets/f96fd355-d4a7-4f74-8f51-2dc85af108e1">

After:
<img width="309" alt="Screenshot 2024-08-01 at 10 28 05" src="https://github.com/user-attachments/assets/d598a084-8b49-4336-921e-da03a8673a37">

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
