### PR TITLE
Dont dequeue job ID in context

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1008,6 +1008,12 @@ func (e *executor) finalize(ctx context.Context, md sv2.Metadata, evts []json.Ra
 				continue
 			}
 
+			jobID := queue.JobIDFromContext(ctx)
+			if jobID != "" && qi.ID == jobID {
+				// Do not dequeue the current job that we're working on.
+				continue
+			}
+
 			err := q.Dequeue(ctx, redis_state.QueuePartition{
 				WorkflowID:  md.ID.FunctionID,
 				WorkspaceID: md.ID.Tenant.EnvID,


### PR DESCRIPTION
To prevent double dequeue.  This is already safe, but double dequeues create warnings in logs.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
