### PR TITLE
fix switch org bug

### DIFF
--- a/ui/apps/dashboard/src/components/Navigation/ProfileMenu.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/ProfileMenu.tsx
@@ -52,7 +52,7 @@ export const ProfileMenu = ({ children }: { children: ReactNode }) => {
               </div>
             </Listbox.Option>
           </Link>
-          <Link href="/organization-list">
+          <a href="/organization-list">
             <Listbox.Option
               className="text-subtle hover:bg-canvasSubtle m-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
               value="switchOrg"
@@ -62,7 +62,7 @@ export const ProfileMenu = ({ children }: { children: ReactNode }) => {
                 <div>Switch Organization</div>
               </div>
             </Listbox.Option>
-          </Link>
+          </a>
 
           <hr />
 


### PR DESCRIPTION
## Description

Although we call next's `revalidatePath` for the destination route on org switch, it does not clear all necessary caches. So don't use next route link, instead use a vanilla link to get a fresh route. 

## Motivation
Fix error on org switch.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
