### PR TITLE
Spike on optimistic rendering in run details

### DIFF
--- a/ui/apps/dev-server-ui/src/app/(dashboard)/run/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/run/page.tsx
@@ -35,6 +35,7 @@ export default function Page() {
         pollInterval={2500}
         rerun={rerun}
         runID={runID}
+        // TODO - initialRunData={{}}
       />
     </div>
   );

--- a/ui/packages/components/src/DetailsCard/Element.tsx
+++ b/ui/packages/components/src/DetailsCard/Element.tsx
@@ -40,10 +40,42 @@ export function LazyElementWrapper<T>({
   }
 
   return (
-    <div className={cn('w-64 text-sm', className)}>
-      <dt className="text-subtle text-xs">{label}</dt>
-      <dd className="truncate">{content}</dd>
-    </div>
+    <ElementWrapper label={label} className={className}>
+      {content}
+    </ElementWrapper>
+  );
+}
+
+// Optimistically render an initial value while waiting for a
+// lazy loaded value to render the final component
+export function OptimisticElementWrapper<T, InitialType>({
+  children,
+  optimisticChildren,
+  className,
+  label,
+  lazy,
+  initial,
+}: {
+  children: (loaded: T) => React.ReactNode;
+  optimisticChildren: (loaded: InitialType) => React.ReactNode;
+  className?: string;
+  label: string;
+  lazy: Lazy<T>;
+  initial?: InitialType;
+}) {
+  let content;
+  if (isLazyDone(lazy)) {
+    content = children(lazy);
+  } else if (initial) {
+    content = optimisticChildren(initial);
+  } else {
+    content = <SkeletonElement />;
+  }
+
+  return (
+    <ElementWrapper label={label} className={className}>
+      {content}
+    </ElementWrapper>
   );
 }
 

--- a/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
+import type { Run as InitialRunData } from '../RunsPage/types';
 import { StatusCell } from '../Table';
 import { Trace } from '../TimelineV2';
 import { Timeline } from '../TimelineV2/Timeline';
@@ -18,6 +19,7 @@ type Props = {
   cancelRun: (runID: string) => Promise<unknown>;
   getResult: (outputID: string) => Promise<Result>;
   getRun: (runID: string) => Promise<Run>;
+  initialRunData: InitialRunData;
   getTrigger: React.ComponentProps<typeof TriggerDetails>['getTrigger'];
   pathCreator: React.ComponentProps<typeof RunInfo>['pathCreator'];
   pollInterval?: number;
@@ -106,6 +108,7 @@ export function RunDetails(props: Props) {
                 className="mb-4"
                 pathCreator={pathCreator}
                 rerun={rerun}
+                initialRunData={props.initialRunData}
                 run={nullishToLazy(run)}
                 runID={runID}
                 standalone={standalone}

--- a/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
@@ -3,15 +3,18 @@ import type { Route } from 'next';
 import { CancelRunButton } from '../CancelRunButton';
 import { Card } from '../Card';
 import {
+  ElementWrapper,
   IDElement,
   LazyElementWrapper,
   LinkElement,
+  OptimisticElementWrapper,
   TextElement,
   TimeElement,
 } from '../DetailsCard/Element';
 import { Link } from '../Link';
 import { RerunButton } from '../RerunButtonV2';
 import { RunResult } from '../RunResult';
+import type { Run as InitialRunData } from '../RunsPage/types';
 import type { Result } from '../types/functionRun';
 import { cn } from '../utils/classNames';
 import { formatMilliseconds, toMaybeDate } from '../utils/date';
@@ -27,6 +30,7 @@ type Props = {
     runPopout: (params: { runID: string }) => Route;
   };
   rerun: (args: { fnID: string; runID: string }) => Promise<unknown>;
+  initialRunData: InitialRunData;
   run: Lazy<Run>;
   runID: string;
   result?: Result;
@@ -57,6 +61,7 @@ export function RunInfo({
   className,
   pathCreator,
   rerun,
+  initialRunData,
   run,
   runID,
   standalone,
@@ -92,13 +97,16 @@ export function RunInfo({
         <Card.Content>
           <div>
             <dl className="flex flex-wrap gap-4">
-              <LazyElementWrapper label="Run ID" lazy={run}>
-                {(run: Run) => {
-                  return <IDElement>{run.id}</IDElement>;
-                }}
-              </LazyElementWrapper>
+              <ElementWrapper label="Run ID">
+                <IDElement>{runID}</IDElement>
+              </ElementWrapper>
 
-              <LazyElementWrapper label="App" lazy={run}>
+              <OptimisticElementWrapper
+                label="App"
+                lazy={run}
+                initial={initialRunData}
+                optimisticChildren={(initialRun: Run) => <>{initialRun.app.name}</>}
+              >
                 {(run: Run) => {
                   return (
                     <LinkElement
@@ -110,9 +118,14 @@ export function RunInfo({
                     </LinkElement>
                   );
                 }}
-              </LazyElementWrapper>
+              </OptimisticElementWrapper>
 
-              <LazyElementWrapper label="Function" lazy={run}>
+              <OptimisticElementWrapper
+                label="Function"
+                lazy={run}
+                initial={initialRunData}
+                optimisticChildren={(initialRun: Run) => <>{initialRun.function.name}</>}
+              >
                 {(run: Run) => {
                   return (
                     <LinkElement
@@ -124,7 +137,7 @@ export function RunInfo({
                     </LinkElement>
                   );
                 }}
-              </LazyElementWrapper>
+              </OptimisticElementWrapper>
 
               <LazyElementWrapper label="Duration" lazy={run}>
                 {(run: Run) => {
@@ -140,6 +153,19 @@ export function RunInfo({
                   return <TextElement>{durationText}</TextElement>;
                 }}
               </LazyElementWrapper>
+
+              <OptimisticElementWrapper
+                label="Queued at"
+                lazy={run}
+                initial={initialRunData}
+                optimisticChildren={(initialRun: Run) =>
+                  initialRun.queuedAt ?? <TimeElement date={new Date(initialRun.queuedAt)} />
+                }
+              >
+                {(run: Run) => {
+                  return <TimeElement date={new Date(run.trace.queuedAt)} />;
+                }}
+              </OptimisticElementWrapper>
 
               <LazyElementWrapper label="Queued at" lazy={run}>
                 {(run: Run) => {

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -208,18 +208,19 @@ export function RunsPage({
   );
 
   const renderSubComponent = useCallback(
-    ({ id }: { id: string }) => {
+    (rowData: Run) => {
       return (
         <div className="border-subtle border-l-4 pb-6">
           <RunDetails
             cancelRun={cancelRun}
             getResult={getTraceResult}
             getRun={getRun}
+            initialRunData={rowData}
             getTrigger={getTrigger}
             pathCreator={pathCreator}
             pollInterval={pollInterval}
             rerun={rerun}
-            runID={id}
+            runID={rowData.id}
             standalone={false}
           />
         </div>

--- a/ui/packages/components/src/RunsPage/RunsTable.tsx
+++ b/ui/packages/components/src/RunsPage/RunsTable.tsx
@@ -21,7 +21,7 @@ type RunsTableProps = {
   sorting?: SortingState;
   setSorting?: OnChangeFn<SortingState>;
   isLoading?: boolean;
-  renderSubComponent: (props: { id: string }) => React.ReactElement;
+  renderSubComponent: (props: Run) => React.ReactElement;
   getRowCanExpand: (row: Row<Run>) => boolean;
   visibleColumns?: VisibilityState;
   scope: ViewScope;
@@ -137,39 +137,42 @@ export default function RunsTable({
           </tr>
         )}
         {!isEmpty &&
-          table.getRowModel().rows.map((row) => (
-            <Fragment key={row.original.id}>
-              <tr
-                key={row.original.id}
-                className="hover:bg-canvasSubtle/50 h-12 cursor-pointer"
-                onClick={() => {
-                  if (expandedRunIDs.includes(row.original.id)) {
-                    setExpandedRunIDs((prev) => {
-                      return prev.filter((id) => id !== row.original.id);
-                    });
-                  } else {
-                    setExpandedRunIDs((prev) => {
-                      return [...prev, row.original.id];
-                    });
-                  }
-                }}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <td className={tableColumnStyles} key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </td>
-                ))}
-              </tr>
-              {expandedRunIDs.includes(row.original.id) && !isLoadingRow(row.original) && (
-                // Overrides tableStyles divider color
-                <tr className="!border-transparent">
-                  <td colSpan={row.getVisibleCells().length}>
-                    {renderSubComponent({ id: row.original.id })}
-                  </td>
+          table.getRowModel().rows.map((row) => {
+            console.log(row, row.getVisibleCells());
+            return (
+              <Fragment key={row.original.id}>
+                <tr
+                  key={row.original.id}
+                  className="hover:bg-canvasSubtle/50 h-12 cursor-pointer"
+                  onClick={() => {
+                    if (expandedRunIDs.includes(row.original.id)) {
+                      setExpandedRunIDs((prev) => {
+                        return prev.filter((id) => id !== row.original.id);
+                      });
+                    } else {
+                      setExpandedRunIDs((prev) => {
+                        return [...prev, row.original.id];
+                      });
+                    }
+                  }}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <td className={tableColumnStyles} key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
                 </tr>
-              )}
-            </Fragment>
-          ))}
+                {expandedRunIDs.includes(row.original.id) && !isLoadingRow(row.original) && (
+                  // Overrides tableStyles divider color
+                  <tr className="!border-transparent">
+                    <td colSpan={row.getVisibleCells().length}>
+                      {renderSubComponent({ id: row.original.id, ...row.original })}
+                    </td>
+                  </tr>
+                )}
+              </Fragment>
+            );
+          })}
       </tbody>
       {!isEmpty && (
         <tfoot>


### PR DESCRIPTION
## Description

Pass initial data via props to immediately render some run details data and lazy load the enhanced data in it's place or be in addition to the initial data.

## Motivation

This will improve perceived load times.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
