### PR TITLE
Do not attempt to import data in non-`lite` mode

### DIFF
--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -92,8 +92,10 @@ func (devserver) Name() string {
 }
 
 func (d *devserver) Pre(ctx context.Context) error {
-	// Import Redis if we can
-	_, _ = d.importRedisSnapshot(ctx)
+	// Import Redis if we can and have persistence enabled
+	if d.persistenceInterval != nil {
+		_, _ = d.importRedisSnapshot(ctx)
+	}
 
 	// Autodiscover the URLs that are hosting Inngest SDKs on the local machine.
 	if d.Opts.Autodiscover {

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -371,7 +371,6 @@ func createInmemoryRedisConnection(ctx context.Context) (rueidis.Client, error) 
 	}
 
 	rc, err := rueidis.NewClient(rueidis.ClientOption{
-		AlwaysPipelining:  false,
 		InitAddress:       []string{redisSingleton.Addr()},
 		DisableCache:      true,
 		BlockingPoolSize:  1,

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -371,6 +371,7 @@ func createInmemoryRedisConnection(ctx context.Context) (rueidis.Client, error) 
 	}
 
 	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		AlwaysPipelining:  false,
 		InitAddress:       []string{redisSingleton.Addr()},
 		DisableCache:      true,
 		BlockingPoolSize:  1,


### PR DESCRIPTION
## Description

Like exporting, ensure we only attempt to import persisted data if persistence is enabled (i.e. we're in `lite` mode).

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
