### PR TITLE
INN-3476: a handful of ui/ux fixes

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/Apps.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/Apps.tsx
@@ -24,7 +24,7 @@ export function Apps({ isArchived = false }: Props) {
   }
   if (res.isLoading && !res.data) {
     return (
-      <div className="mb-4 mt-16 flex items-center justify-center">
+      <div className="mb-4 flex items-center justify-center">
         <div className="w-full max-w-[1200px]">
           <SkeletonCard />
         </div>

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
@@ -62,7 +62,7 @@ export default async function AppsPage({
           )
         }
       />
-      <div className="bg-canvasBase mx-auto flex h-full w-full max-w-[1200px] flex-col overflow-y-auto px-6 pt-16">
+      <div className="bg-canvasBase mx-auto flex h-full w-full max-w-[1200px] flex-col px-6 pt-16">
         <div className="relative flex w-full flex-row justify-end">
           <StatusMenu archived={isArchived} envSlug={envSlug} />
         </div>

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
@@ -63,7 +63,7 @@ export default async function AppsPage({
         }
       />
       <div className="bg-canvasBase mx-auto flex h-full w-full max-w-[1200px] flex-col px-6 pt-16">
-        <div className="relative flex w-full flex-row justify-end">
+        <div className="relative flex w-full flex-row justify-start">
           <StatusMenu archived={isArchived} envSlug={envSlug} />
         </div>
         <Apps isArchived={isArchived} />

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/event-search/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/event-search/page.tsx
@@ -11,7 +11,9 @@ export default async function Page({
   return (
     <ServerFeatureFlag flag="event-search">
       {newIANav && <EventsHeader envSlug={envSlug} eventSearch={true} sendEvents={false} />}
-      <EventSearch />
+      <div className="bg-canvasBase flex h-full w-full flex-col">
+        <EventSearch />
+      </div>
     </ServerFeatureFlag>
   );
 }

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/page.tsx
@@ -27,7 +27,9 @@ export default async function FunctionPage({
       ) : (
         <FunctionsHeader />
       )}
-      <FunctionList envSlug={environmentSlug} archived={archived} />
+      <div className="bg-canvasBase flex h-full w-full flex-col">
+        <FunctionList envSlug={environmentSlug} archived={archived} />
+      </div>
     </>
   );
 }

--- a/ui/apps/dashboard/src/components/Apps/StatusMenu.tsx
+++ b/ui/apps/dashboard/src/components/Apps/StatusMenu.tsx
@@ -19,7 +19,7 @@ export const StatusMenu = ({ envSlug, archived }: { envSlug: string; archived: b
       value={archived ? archivedOption : activeOption}
       className="mb-5"
     >
-      <Select.Button className="w-[124px] px-4">
+      <Select.Button className="h-[28px] w-[132px] py-1 pl-2 pr-3">
         <div className="text-basis mr-2 flex flex-row items-center text-sm font-medium leading-tight">
           <StatusIcon className={`mr-2 ${archived ? 'bg-accent-subtle' : 'bg-primary-moderate'}`} />
           {archived ? 'Archived' : 'Active'}

--- a/ui/apps/dashboard/src/components/Events/EventList.tsx
+++ b/ui/apps/dashboard/src/components/Events/EventList.tsx
@@ -25,7 +25,7 @@ export const EventList = () => {
   }
 
   return (
-    <main className="min-h-0 flex-1 overflow-y-auto bg-slate-100">
+    <main className="min-h-0 flex-1 bg-slate-100">
       <table className="relative w-full border-b border-slate-200 bg-white">
         <thead className="shadow-outline-primary-light sticky top-0 z-10 bg-white">
           <tr>

--- a/ui/apps/dashboard/src/components/Functions/FunctionsList.tsx
+++ b/ui/apps/dashboard/src/components/Functions/FunctionsList.tsx
@@ -23,7 +23,7 @@ export const FunctionList = ({ envSlug, archived }: FunctionListProps) => {
   return (
     <div className="bg-canvasBase flex min-h-0 flex-1 flex-col divide-y">
       {newIANav && (
-        <div className="flex h-10 flex-row items-center justify-end px-6">
+        <div className="mx-4 my-1 flex h-10 flex-row items-center justify-start">
           <StatusMenu archived={!!archived} envSlug={envSlug} />
         </div>
       )}

--- a/ui/apps/dashboard/src/components/Functions/StatusMenu.tsx
+++ b/ui/apps/dashboard/src/components/Functions/StatusMenu.tsx
@@ -19,7 +19,7 @@ export const StatusMenu = ({ envSlug, archived }: { envSlug: string; archived: b
       value={archived ? archivedOption : activeOption}
       className="z-[49] mr-3 h-[30px]"
     >
-      <Select.Button className="h-[28px] w-[142px]">
+      <Select.Button className="h-[28px] w-[142px] py-1 pl-2 pr-3">
         <div className="mr-2 flex flex-row items-center text-sm">
           <StatusIcon className={`mr-2 ${archived ? 'bg-accent-subtle' : 'bg-primary-moderate'}`} />
           {archived ? 'Archived' : 'Active'}

--- a/ui/apps/dashboard/src/components/Functions/StatusMenu.tsx
+++ b/ui/apps/dashboard/src/components/Functions/StatusMenu.tsx
@@ -17,7 +17,7 @@ export const StatusMenu = ({ envSlug, archived }: { envSlug: string; archived: b
       label="Pause runs"
       multiple={false}
       value={archived ? archivedOption : activeOption}
-      className="z-50 mr-3 h-[30px]"
+      className="z-[49] mr-3 h-[30px]"
     >
       <Select.Button className="h-[28px] w-[142px]">
         <div className="mr-2 flex flex-row items-center text-sm">

--- a/ui/apps/dashboard/src/components/Header/Back.tsx
+++ b/ui/apps/dashboard/src/components/Header/Back.tsx
@@ -5,7 +5,7 @@ import { OptionalTooltip } from '../Navigation/OptionalTooltip';
 
 export const Back = ({ className }: { className?: string }) => {
   return (
-    <OptionalTooltip tooltip="Back to environment">
+    <OptionalTooltip tooltip="Back to environment" side={'bottom'}>
       <NewButton
         kind="secondary"
         appearance="outlined"
@@ -13,7 +13,6 @@ export const Back = ({ className }: { className?: string }) => {
         icon={<RiArrowLeftLine />}
         className={className}
         href="/"
-        scroll={false}
       />
     </OptionalTooltip>
   );

--- a/ui/apps/dashboard/src/components/Header/Back.tsx
+++ b/ui/apps/dashboard/src/components/Header/Back.tsx
@@ -1,16 +1,20 @@
 import { NewButton } from '@inngest/components/Button';
 import { RiArrowLeftLine } from '@remixicon/react';
 
+import { OptionalTooltip } from '../Navigation/OptionalTooltip';
+
 export const Back = ({ className }: { className?: string }) => {
   return (
-    <NewButton
-      kind="secondary"
-      appearance="outlined"
-      size="small"
-      icon={<RiArrowLeftLine />}
-      className={className}
-      href="/"
-      scroll={false}
-    />
+    <OptionalTooltip tooltip="Back to environment">
+      <NewButton
+        kind="secondary"
+        appearance="outlined"
+        size="small"
+        icon={<RiArrowLeftLine />}
+        className={className}
+        href="/"
+        scroll={false}
+      />
+    </OptionalTooltip>
   );
 };

--- a/ui/apps/dashboard/src/components/Header/Back.tsx
+++ b/ui/apps/dashboard/src/components/Header/Back.tsx
@@ -5,7 +5,7 @@ import { OptionalTooltip } from '../Navigation/OptionalTooltip';
 
 export const Back = ({ className }: { className?: string }) => {
   return (
-    <OptionalTooltip tooltip="Back to environment" side={'bottom'}>
+    <OptionalTooltip tooltip="Back to environment" side="bottom">
       <NewButton
         kind="secondary"
         appearance="outlined"

--- a/ui/apps/dashboard/src/components/Header/Back.tsx
+++ b/ui/apps/dashboard/src/components/Header/Back.tsx
@@ -10,6 +10,7 @@ export const Back = ({ className }: { className?: string }) => {
       icon={<RiArrowLeftLine />}
       className={className}
       href="/"
+      scroll={false}
     />
   );
 };

--- a/ui/apps/dashboard/src/components/Header/Back.tsx
+++ b/ui/apps/dashboard/src/components/Header/Back.tsx
@@ -1,11 +1,7 @@
-'use client';
-
-import { useRouter } from 'next/navigation';
 import { NewButton } from '@inngest/components/Button';
 import { RiArrowLeftLine } from '@remixicon/react';
 
 export const Back = ({ className }: { className?: string }) => {
-  const router = useRouter();
   return (
     <NewButton
       kind="secondary"
@@ -13,7 +9,7 @@ export const Back = ({ className }: { className?: string }) => {
       size="small"
       icon={<RiArrowLeftLine />}
       className={className}
-      onClick={() => router.back()}
+      href="/"
     />
   );
 };

--- a/ui/apps/dashboard/src/components/Header/Header.tsx
+++ b/ui/apps/dashboard/src/components/Header/Header.tsx
@@ -27,7 +27,7 @@ export const Header = ({
   backNav = false,
 }: HeaderType) => {
   return (
-    <div className="flex flex-col justify-start border-b">
+    <div className="sticky top-0 z-50 flex flex-col justify-start border-b">
       <div
         className={`bg-canvasBase border-subtle flex h-[52px] flex-row items-center justify-between px-4 ${className}`}
       >
@@ -39,7 +39,7 @@ export const Header = ({
         <div>{action}</div>
       </div>
       {tabs && (
-        <div className="flex flex-row items-center justify-start space-x-3 px-4">
+        <div className="bg-canvasBase flex flex-row items-center justify-start space-x-3 px-4">
           {tabs.map(({ href, children, exactRouteMatch }) => (
             <HeaderTab key={href} href={href as Route} exactRouteMatch={exactRouteMatch}>
               {children}

--- a/ui/apps/dashboard/src/components/Layout/SideBar.tsx
+++ b/ui/apps/dashboard/src/components/Layout/SideBar.tsx
@@ -1,14 +1,12 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { RiPlugLine } from '@remixicon/react';
 
 import type { Environment } from '@/utils/environments';
 import { Alert } from '../Navigation/Alert';
 import { Help } from '../Navigation/Help';
 import { Integrations } from '../Navigation/Integrations';
 import Logo from '../Navigation/Logo';
-import { MenuItem } from '../Navigation/MenuItem';
 import Navigation from '../Navigation/Navigation';
 import { Profile, type ProfileType } from '../Navigation/Profile';
 

--- a/ui/apps/dashboard/src/components/Layout/SideBar.tsx
+++ b/ui/apps/dashboard/src/components/Layout/SideBar.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { RiPlugLine } from '@remixicon/react';
 
 import type { Environment } from '@/utils/environments';
 import { Alert } from '../Navigation/Alert';
 import { Help } from '../Navigation/Help';
 import { Integrations } from '../Navigation/Integrations';
 import Logo from '../Navigation/Logo';
+import { MenuItem } from '../Navigation/MenuItem';
 import Navigation from '../Navigation/Navigation';
 import { Profile, type ProfileType } from '../Navigation/Profile';
 
@@ -41,13 +43,13 @@ export default function SideBar({
       <div className="flex grow flex-col justify-between">
         <Navigation collapsed={collapsed} activeEnv={activeEnv} />
 
-        <div>
+        <div className="mx-4">
           {!collapsed && <Alert />}
 
           <Integrations collapsed={collapsed} />
           <Help collapsed={collapsed} />
-          <Profile collapsed={collapsed} profile={profile} />
         </div>
+        <Profile collapsed={collapsed} profile={profile} />
       </div>
     </nav>
   );

--- a/ui/apps/dashboard/src/components/Navigation/Alert.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Alert.tsx
@@ -22,7 +22,7 @@ export const Alert = () => {
 
   return (
     show && (
-      <div className="text-info bg-info border-secondary-2xSubtle pl- m-5 rounded border py-3 pl-3 pr-2 text-xs leading-tight">
+      <div className="text-info bg-info border-secondary-2xSubtle mb-5 rounded border py-3 pl-3 pr-2 text-xs leading-tight">
         <div className="gap-x flex flex-row items-start justify-between">
           <div>We&apos;ve reimagined our information architecture for better navigation.</div>
           <NewButton

--- a/ui/apps/dashboard/src/components/Navigation/Environments.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Environments.tsx
@@ -5,8 +5,14 @@ import { type Route } from 'next';
 import Link from 'next/link';
 import { usePathname, useRouter, useSelectedLayoutSegments } from 'next/navigation';
 import { Listbox } from '@headlessui/react';
-import { Alert } from '@inngest/components/Alert/Alert';
-import { RiCloudFill, RiCloudLine, RiExpandUpDownLine, RiLoopLeftLine } from '@remixicon/react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
+import {
+  RiCloudFill,
+  RiCloudLine,
+  RiErrorWarningLine,
+  RiExpandUpDownLine,
+  RiLoopLeftLine,
+} from '@remixicon/react';
 
 import { useEnvironments } from '@/queries';
 import cn from '@/utils/cn';
@@ -114,9 +120,18 @@ export default function EnvironmentSelectMenu({
   if (error) {
     console.error('error fetching envs', error);
     return (
-      <Alert severity="error" className="mx-auto flex h-8 w-full items-center text-sm">
-        Env Error
-      </Alert>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="bg-error text-error flex h-8 w-full items-center justify-start gap-x-2 rounded px-2">
+            <RiErrorWarningLine className="w-4" />
+            {!collapsed && <div>Env Error</div>}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="right" className="text-error bg-error rounded text-xs">
+          Error loading environments. Please try again or contact support if the issue does not
+          resolve.
+        </TooltipContent>
+      </Tooltip>
     );
   }
 

--- a/ui/apps/dashboard/src/components/Navigation/Environments.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Environments.tsx
@@ -75,7 +75,7 @@ const SelectedDisplay = ({
   selected: Environment | null;
   collapsed: boolean;
 }) => (
-  <span className={`flex  flex-row items-center ${collapsed ? '' : 'min-w-0 truncate'}`}>
+  <span className={`flex flex-row items-center ${collapsed ? '' : 'min-w-0 truncate'}`}>
     {selected ? (
       <span className="block">
         {selected.type === EnvironmentType.BranchParent
@@ -113,7 +113,7 @@ export default function EnvironmentSelectMenu({
   const [{ fetching, data: envs = [] }] = useEnvironments();
 
   if (fetching || !isNonEmptyArray(envs)) {
-    return <Skeleton className={`h-8 ${collapsed ? 'w-8 px-1' : 'w-[146px] px-2'}`} />;
+    return <Skeleton className={`h-8 ${collapsed ? 'w-8 px-1' : 'w-[158px]'}`} />;
   }
 
   const defaultEnvironment = getDefaultEnvironment(envs);
@@ -143,8 +143,8 @@ export default function EnvironmentSelectMenu({
           <OptionalTooltip tooltip={collapsed && tooltip(selected)}>
             <Listbox.Button
               className={`border-muted bg-canvasBase text-primary-intense hover:bg-canvasSubtle px-2 ${
-                collapsed ? `w-8` : !activeEnv ? 'w-[186px]' : 'w-[146px]'
-              } m-0 h-8 overflow-hidden rounded border text-sm ${open && 'border-primary-intense'}`}
+                collapsed ? `w-8` : !activeEnv ? 'w-[196px]' : 'w-[158px]'
+              } h-8 overflow-hidden rounded border text-sm ${open && 'border-primary-intense'}`}
             >
               <div
                 className={`flex flex-row items-center  ${
@@ -159,7 +159,7 @@ export default function EnvironmentSelectMenu({
             </Listbox.Button>
           </OptionalTooltip>
 
-          <Listbox.Options className="bg-canvasBase border-subtle absolute top-10 z-50 w-[188px] divide-none overflow-y-scroll rounded border shadow focus:outline-none">
+          <Listbox.Options className="bg-canvasBase border-subtle overflow-y-truncate absolute top-10 z-50 w-[188px] divide-none rounded border shadow focus:outline-none">
             {defaultEnvironment !== null && <EnvironmentItem environment={defaultEnvironment} />}
 
             {legacyTestMode !== null && (
@@ -233,7 +233,7 @@ function EnvironmentItem({
       )}
     >
       <span className={cn('block h-1.5 w-1.5 shrink-0 rounded-full', statusColorClass)} />
-      <span className="truncate">{name || environment.name}</span>
+      <span className="truncate">"{name || environment.name}"</span>
     </Listbox.Option>
   );
 }

--- a/ui/apps/dashboard/src/components/Navigation/Environments.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Environments.tsx
@@ -5,7 +5,7 @@ import { type Route } from 'next';
 import Link from 'next/link';
 import { usePathname, useRouter, useSelectedLayoutSegments } from 'next/navigation';
 import { Listbox } from '@headlessui/react';
-import { Skeleton } from '@inngest/components/Skeleton/Skeleton';
+import { Alert } from '@inngest/components/Alert/Alert';
 import { RiCloudFill, RiCloudLine, RiExpandUpDownLine, RiLoopLeftLine } from '@remixicon/react';
 
 import { useEnvironments } from '@/queries';
@@ -18,7 +18,6 @@ import {
   getTestEnvironments,
   type Environment,
 } from '@/utils/environments';
-import isNonEmptyArray from '@/utils/isNonEmptyArray';
 import { OptionalTooltip } from './OptionalTooltip';
 
 // Some URLs cannot just swap between environments,
@@ -110,10 +109,15 @@ export default function EnvironmentSelectMenu({
   const router = useRouter();
   const [selected, setSelected] = useState<Environment | null>(null);
   const nextPathname = useSwitchablePathname();
-  const [{ fetching, data: envs = [] }] = useEnvironments();
+  const [{ data: envs = [], error }] = useEnvironments();
 
-  if (fetching || !isNonEmptyArray(envs)) {
-    return <Skeleton className={`h-8 ${collapsed ? 'w-8 px-1' : 'w-[158px]'}`} />;
+  if (error) {
+    console.error('error fetching envs', error);
+    return (
+      <Alert severity="error" className="mx-auto flex h-8 w-full items-center text-sm">
+        Env Error
+      </Alert>
+    );
   }
 
   const defaultEnvironment = getDefaultEnvironment(envs);
@@ -233,7 +237,7 @@ function EnvironmentItem({
       )}
     >
       <span className={cn('block h-1.5 w-1.5 shrink-0 rounded-full', statusColorClass)} />
-      <span className="truncate">"{name || environment.name}"</span>
+      <span className="truncate">{name || environment.name}</span>
     </Listbox.Option>
   );
 }

--- a/ui/apps/dashboard/src/components/Navigation/Help.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Help.tsx
@@ -51,10 +51,7 @@ export const Help = ({ collapsed }: { collapsed: boolean }) => {
               </div>
             </Listbox.Option>
           </Link>
-          <Link
-            href="https://discord.com/channels/842170679536517141/1051516534029291581"
-            target="_blank"
-          >
+          <Link href="https://www.inngest.com/discord" target="_blank">
             <Listbox.Option
               className="text-subtle hover:bg-canvasSubtle mx-2 my-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
               value="discord"

--- a/ui/apps/dashboard/src/components/Navigation/Help.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Help.tsx
@@ -19,90 +19,88 @@ export const Help = ({ collapsed }: { collapsed: boolean }) => {
   const status = useSystemStatus();
 
   return (
-    <div className={`${collapsed ? 'items-center' : 'mx-4'}`}>
-      <Listbox>
-        <Listbox.Button className="w-full ring-0">
-          <MenuItem
-            collapsed={collapsed}
-            text="Help and Feedback"
-            icon={<RiQuestionLine className="h-[18px] w-[18px]" />}
-          />
-        </Listbox.Button>
-        <div className="relative">
-          <Listbox.Options className="bg-canvasBase absolute -right-48 bottom-0 z-50 ml-8 w-[199px] gap-y-0.5 rounded border shadow ring-0 focus:outline-none">
-            <Link href="https://www.inngest.com/docs?ref=support-center" target="_blank">
-              <Listbox.Option
-                className="text-subtle hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
-                value="docs"
-              >
-                <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start">
-                  <RiExternalLinkLine className="text-subtle mr-2 h-4 w-4 " />
-                  <div>Inngest Documentation</div>
-                </div>
-              </Listbox.Option>
-            </Link>
-            <Link href="/support" target="_blank">
-              <Listbox.Option
-                className="text-subtle hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
-                value="support"
-              >
-                <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start">
-                  <RiMailLine className="text-subtle mr-2 h-4 w-4" />
-                  <div>Support</div>
-                </div>
-              </Listbox.Option>
-            </Link>
-            <Link
-              href="https://discord.com/channels/842170679536517141/1051516534029291581"
-              target="_blank"
+    <Listbox>
+      <Listbox.Button className="w-full ring-0">
+        <MenuItem
+          collapsed={collapsed}
+          text="Help and Feedback"
+          icon={<RiQuestionLine className="h-[18px] w-[18px]" />}
+        />
+      </Listbox.Button>
+      <div className="relative">
+        <Listbox.Options className="bg-canvasBase absolute -right-48 bottom-0 z-50 ml-8 w-[199px] gap-y-0.5 rounded border shadow ring-0 focus:outline-none">
+          <Link href="https://www.inngest.com/docs?ref=support-center" target="_blank">
+            <Listbox.Option
+              className="text-subtle hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
+              value="docs"
             >
-              <Listbox.Option
-                className="text-subtle hover:bg-canvasSubtle mx-2 my-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
-                value="discord"
-              >
-                <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start">
-                  <RiDiscordLine className="text-subtle mr-2 h-4 w-4" />
-                  <div>Join Discord</div>
-                </div>
-              </Listbox.Option>
-            </Link>
-            <hr />
-            <Link href="https://roadmap.inngest.com/roadmap" target="_blank">
-              <Listbox.Option
-                className="text-subtle hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
-                value="roadmap"
-              >
-                <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start">
-                  <RiRoadMapLine className="text-subtle mr-2 h-4 w-4" />
-                  <div>Inngest Roadmap</div>
-                </div>
-              </Listbox.Option>
-            </Link>
-            <Link href="/support" target="_blank">
-              <Listbox.Option
-                className="text-subtle hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
-                value="status"
-              >
-                <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start">
-                  <SystemStatusIcon status={status} className="mx-0 mr-2 h-3.5 w-3.5" />
-                  <div>Status</div>
-                </div>
-              </Listbox.Option>
-            </Link>
-            <Link href="https://roadmap.inngest.com/changelog" target="_blank">
-              <Listbox.Option
-                className="text-subtle hover:bg-canvasSubtle m-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
-                value="releaseNotes"
-              >
-                <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start">
-                  <RiArticleLine className="text-subtle mr-2 h-4 w-4" />
-                  <div>Release Notes</div>
-                </div>
-              </Listbox.Option>
-            </Link>
-          </Listbox.Options>
-        </div>
-      </Listbox>
-    </div>
+              <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start">
+                <RiExternalLinkLine className="text-subtle mr-2 h-4 w-4 " />
+                <div>Inngest Documentation</div>
+              </div>
+            </Listbox.Option>
+          </Link>
+          <Link href="/support" target="_blank">
+            <Listbox.Option
+              className="text-subtle hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
+              value="support"
+            >
+              <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start">
+                <RiMailLine className="text-subtle mr-2 h-4 w-4" />
+                <div>Support</div>
+              </div>
+            </Listbox.Option>
+          </Link>
+          <Link
+            href="https://discord.com/channels/842170679536517141/1051516534029291581"
+            target="_blank"
+          >
+            <Listbox.Option
+              className="text-subtle hover:bg-canvasSubtle mx-2 my-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
+              value="discord"
+            >
+              <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start">
+                <RiDiscordLine className="text-subtle mr-2 h-4 w-4" />
+                <div>Join Discord</div>
+              </div>
+            </Listbox.Option>
+          </Link>
+          <hr />
+          <Link href="https://roadmap.inngest.com/roadmap" target="_blank">
+            <Listbox.Option
+              className="text-subtle hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
+              value="roadmap"
+            >
+              <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start">
+                <RiRoadMapLine className="text-subtle mr-2 h-4 w-4" />
+                <div>Inngest Roadmap</div>
+              </div>
+            </Listbox.Option>
+          </Link>
+          <Link href="/support" target="_blank">
+            <Listbox.Option
+              className="text-subtle hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
+              value="status"
+            >
+              <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start">
+                <SystemStatusIcon status={status} className="mx-0 mr-2 h-3.5 w-3.5" />
+                <div>Status</div>
+              </div>
+            </Listbox.Option>
+          </Link>
+          <Link href="https://roadmap.inngest.com/changelog" target="_blank">
+            <Listbox.Option
+              className="text-subtle hover:bg-canvasSubtle m-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
+              value="releaseNotes"
+            >
+              <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start">
+                <RiArticleLine className="text-subtle mr-2 h-4 w-4" />
+                <div>Release Notes</div>
+              </div>
+            </Listbox.Option>
+          </Link>
+        </Listbox.Options>
+      </div>
+    </Listbox>
   );
 };

--- a/ui/apps/dashboard/src/components/Navigation/Integrations.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Integrations.tsx
@@ -3,12 +3,10 @@ import { RiPlugLine } from '@remixicon/react';
 import { MenuItem } from './MenuItem';
 
 export const Integrations = ({ collapsed }: { collapsed: boolean }) => (
-  <div className={`${collapsed ? 'items-center' : 'mx-4'}`}>
-    <MenuItem
-      href="/settings/integrations"
-      collapsed={collapsed}
-      text="Integrations"
-      icon={<RiPlugLine className="h-[18px] w-[18px]" />}
-    />
-  </div>
+  <MenuItem
+    href="/settings/integrations"
+    collapsed={collapsed}
+    text="Integrations"
+    icon={<RiPlugLine className="h-[18px] w-[18px]" />}
+  />
 );

--- a/ui/apps/dashboard/src/components/Navigation/KeysMenu.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/KeysMenu.tsx
@@ -21,8 +21,7 @@ export default function KeysMenu({
           kind="secondary"
           appearance={collapsed ? 'ghost' : 'outlined'}
           size="medium"
-          icon={<RiEqualizer2Line className="fill-subtle" />}
-          className={collapsed ? 'mt-2.5' : 'ml-2.5'}
+          icon={<RiEqualizer2Line className="fill-subtle w-[18px]" />}
         />
       </Listbox.Button>
       <div className="relative">

--- a/ui/apps/dashboard/src/components/Navigation/Logo.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Logo.tsx
@@ -49,7 +49,7 @@ export default function Logo({ collapsed, setCollapsed }: LogoProps) {
           </div>
         ) : (
           <>
-            <Link href={process.env.NEXT_PUBLIC_HOME_PATH as Route}>
+            <Link href={process.env.NEXT_PUBLIC_HOME_PATH as Route} scroll={false}>
               <InngestLogo className="text-basis mr-2" width={92} />
             </Link>
           </>

--- a/ui/apps/dashboard/src/components/Navigation/Logo.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Logo.tsx
@@ -41,12 +41,8 @@ const NavToggle = ({ collapsed, setCollapsed }: LogoProps) => {
 
 export default function Logo({ collapsed, setCollapsed }: LogoProps) {
   return (
-    <div
-      className={`mt-4 flex h-[28px] w-full flex-row items-center ${
-        collapsed ? 'justify-center' : 'ml-4 justify-start'
-      }`}
-    >
-      <div className={`flex flex-row items-center justify-start ${collapsed ? '' : 'mr-2'} `}>
+    <div className={`mx-4 mt-4 flex h-[28px] flex-row items-center justify-between`}>
+      <div className={`flex flex-row items-center justify-start ${collapsed ? '' : 'mr-3'} `}>
         {collapsed ? (
           <div className="cursor-pointer group-hover:hidden">
             <InngestLogoSmallBW />
@@ -54,7 +50,7 @@ export default function Logo({ collapsed, setCollapsed }: LogoProps) {
         ) : (
           <>
             <Link href={process.env.NEXT_PUBLIC_HOME_PATH as Route}>
-              <InngestLogo className="text-basis mr-3" width={92} />
+              <InngestLogo className="text-basis mr-2" width={92} />
             </Link>
           </>
         )}

--- a/ui/apps/dashboard/src/components/Navigation/Manage.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Manage.tsx
@@ -15,7 +15,7 @@ export default function Manage({
   collapsed: boolean;
 }) {
   return (
-    <div className={`jusity-center flex flex-col ${collapsed ? 'mt-2' : 'mt-4'}`}>
+    <div className={`flex w-full flex-col ${collapsed ? 'mt-2' : 'mt-4'}`}>
       {collapsed ? (
         <hr className="bg-subtle mx-auto mb-1 w-6" />
       ) : (

--- a/ui/apps/dashboard/src/components/Navigation/MenuItem.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/MenuItem.tsx
@@ -28,7 +28,7 @@ export const MenuItem = ({
     <OptionalLink href={comingSoon ? '' : href} prefetch={prefetch}>
       <OptionalTooltip tooltip={comingSoon ? 'Coming soon...' : collapsed ? text : ''}>
         <div
-          className={`my-1 flex h-8 w-full w-full flex-row items-center rounded px-1.5  ${
+          className={`my-1 flex h-8 w-full flex-row items-center rounded px-1.5  ${
             comingSoon
               ? 'text-disabled hover:bg-disabled cursor-not-allowed'
               : active

--- a/ui/apps/dashboard/src/components/Navigation/MenuItem.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/MenuItem.tsx
@@ -28,9 +28,7 @@ export const MenuItem = ({
     <OptionalLink href={comingSoon ? '' : href} prefetch={prefetch}>
       <OptionalTooltip tooltip={comingSoon ? 'Coming soon...' : collapsed ? text : ''}>
         <div
-          className={`m-1 flex h-8 flex-row items-center rounded px-1.5 ${
-            collapsed ? 'justify-center ' : 'justify-start'
-          }  ${
+          className={`my-1 flex h-8 w-full w-full flex-row items-center rounded px-1.5  ${
             comingSoon
               ? 'text-disabled hover:bg-disabled cursor-not-allowed'
               : active

--- a/ui/apps/dashboard/src/components/Navigation/Monitor.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Monitor.tsx
@@ -15,7 +15,7 @@ export default function Monitor({
 }) {
   const { isReady, value: isRunsEnabled } = useBooleanFlag('env-level-runs-page');
   return (
-    <div className={`jusity-center flex flex-col ${collapsed ? 'mt-2' : 'mt-5'}`}>
+    <div className={`flex w-full flex-col  ${collapsed ? 'mt-2' : 'mt-5'}`}>
       {collapsed ? (
         <hr className="bg-subtle mx-auto mb-1 w-6" />
       ) : (

--- a/ui/apps/dashboard/src/components/Navigation/Navigation.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Navigation.tsx
@@ -14,22 +14,19 @@ export const getNavRoute = (activeEnv: EnvType, link: string) => `/env/${activeE
 
 export default function Navigation({ collapsed, activeEnv }: NavProps) {
   return (
-    <div
-      className={`text-basis flex h-full w-full flex-col items-start ${
-        collapsed ? 'items-center' : 'ml-4'
-      } mt-5 flex`}
-    >
-      <div className="flex flex-col justify-start">
-        <div className={`flex ${collapsed ? 'flex-col' : 'flex-row'} items-center justify-center`}>
-          <Environments activeEnv={activeEnv} collapsed={collapsed} />
+    <div className={`text-basis mx-4 mt-5 flex h-full flex-col`}>
+      <div
+        className={`flex ${
+          collapsed ? 'flex-col' : 'flex-row'
+        } w-full justify-between gap-x-1 gap-y-2`}
+      >
+        <Environments activeEnv={activeEnv} collapsed={collapsed} />
 
-          {activeEnv && <KeysMenu activeEnv={activeEnv} collapsed={collapsed} />}
-        </div>
-        <div className="flex flex-col">
-          {activeEnv && <Monitor activeEnv={activeEnv} collapsed={collapsed} />}
-          {activeEnv && <Manage activeEnv={activeEnv} collapsed={collapsed} />}
-        </div>
+        {activeEnv && <KeysMenu activeEnv={activeEnv} collapsed={collapsed} />}
       </div>
+
+      {activeEnv && <Monitor activeEnv={activeEnv} collapsed={collapsed} />}
+      {activeEnv && <Manage activeEnv={activeEnv} collapsed={collapsed} />}
     </div>
   );
 }

--- a/ui/apps/dashboard/src/components/Navigation/Navigation.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Navigation.tsx
@@ -1,3 +1,6 @@
+import { Suspense } from 'react';
+import { Skeleton } from '@inngest/components/Skeleton/Skeleton';
+
 import type { Environment as EnvType } from '@/utils/environments';
 import Environments from './Environments';
 import KeysMenu from './KeysMenu';
@@ -20,7 +23,9 @@ export default function Navigation({ collapsed, activeEnv }: NavProps) {
           collapsed ? 'flex-col' : 'flex-row'
         } w-full justify-between gap-x-1 gap-y-2`}
       >
-        <Environments activeEnv={activeEnv} collapsed={collapsed} />
+        <Suspense fallback={<Skeleton className={`h-8 w-full`} />}>
+          <Environments activeEnv={activeEnv} collapsed={collapsed} />
+        </Suspense>
 
         {activeEnv && <KeysMenu activeEnv={activeEnv} collapsed={collapsed} />}
       </div>

--- a/ui/apps/dashboard/src/components/Navigation/OptionalTooltip.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/OptionalTooltip.tsx
@@ -4,15 +4,17 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Too
 export const OptionalTooltip = ({
   children,
   tooltip,
+  side = 'right',
 }: {
   children: ReactNode;
   tooltip?: ReactNode;
+  side?: 'top' | 'bottom' | 'right' | 'left';
 }) =>
   tooltip ? (
     <Tooltip>
       <TooltipTrigger asChild>{children}</TooltipTrigger>
       <TooltipContent
-        side="right"
+        side={side}
         className="text-subtle flex h-8 items-center px-4 text-xs leading-[18px]"
       >
         {tooltip}

--- a/ui/apps/dashboard/src/components/Navigation/Profile.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Profile.tsx
@@ -16,9 +16,7 @@ export const Profile = ({ collapsed, profile }: { collapsed: boolean; profile: P
   return (
     <ProfileMenu>
       <div
-        className={`border-subtle mt-2 flex h-16 w-full flex-row items-center justify-start border-t p-3.5 ${
-          collapsed ? 'justify-center' : 'justify-start'
-        }`}
+        className={`border-subtle mt-2 flex h-16 w-full flex-row items-center justify-start border-t px-2.5 `}
       >
         <div
           className={`flex w-full flex-row items-center rounded p-1 ${

--- a/ui/apps/dashboard/src/components/Navigation/ProfileMenu.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/ProfileMenu.tsx
@@ -19,7 +19,7 @@ export const ProfileMenu = ({ children }: { children: ReactNode }) => {
       <Listbox.Button className="w-full cursor-pointer ring-0">{children}</Listbox.Button>
       <div className="relative">
         <Listbox.Options className="bg-canvasBase absolute -right-48 bottom-4 z-50 ml-8 w-[199px] rounded border shadow ring-0 focus:outline-none">
-          <Link href="/settings/organization/organization-settings">
+          <Link href="/settings/organization/organization-settings" scroll={false}>
             <Listbox.Option
               className="text-subtle hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
               value="org"
@@ -30,7 +30,7 @@ export const ProfileMenu = ({ children }: { children: ReactNode }) => {
               </div>
             </Listbox.Option>
           </Link>
-          <Link href="/settings/organization">
+          <Link href="/settings/organization" scroll={false}>
             <Listbox.Option
               className="text-subtle hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
               value="members"
@@ -41,7 +41,7 @@ export const ProfileMenu = ({ children }: { children: ReactNode }) => {
               </div>
             </Listbox.Option>
           </Link>
-          <Link href="/settings/billing">
+          <Link href="/settings/billing" scroll={false}>
             <Listbox.Option
               className="text-subtle hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
               value="billing"
@@ -66,7 +66,7 @@ export const ProfileMenu = ({ children }: { children: ReactNode }) => {
 
           <hr />
 
-          <Link href="/settings/user">
+          <Link href="/settings/user" scroll={false}>
             <Listbox.Option
               className="text-subtle hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
               value="userProfile"

--- a/ui/packages/components/src/Button/Button.tsx
+++ b/ui/packages/components/src/Button/Button.tsx
@@ -31,6 +31,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   iconSide?: 'right' | 'left';
   keys?: string[];
   prefetch?: boolean;
+  scroll?: boolean;
 }
 
 export const LinkWrapper = ({
@@ -38,14 +39,16 @@ export const LinkWrapper = ({
   href,
   target,
   prefetch = false,
+  scroll = true,
 }: {
   children: ReactNode;
   href?: string | UrlObject;
   target?: string;
   prefetch?: boolean;
+  scroll?: boolean;
 }) =>
   href ? (
-    <Link href={href as Route} target={target} prefetch={prefetch}>
+    <Link href={href as Route} target={target} prefetch={prefetch} scroll={scroll}>
       {children}
     </Link>
   ) : (
@@ -86,6 +89,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       disabled,
       target,
       prefetch = false,
+      scroll = true,
       ...props
     }: ButtonProps,
     ref
@@ -140,7 +144,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     return (
       <TooltipWrapper tooltip={tooltip}>
-        <LinkWrapper href={href} target={target} prefetch={prefetch}>
+        <LinkWrapper href={href} target={target} prefetch={prefetch} scroll={scroll}>
           <button
             ref={ref}
             className={cn(


### PR DESCRIPTION
## Description

* equalize side nav x-axis padding
* fix lower side nav hover states
* fix org widget distending
* fix scroll bar issues on most top level pages
* fix back from non-env pages
* fix false env select loader
* better discord invite link
* move function/apps active/inactive menus to the left, make them look the same

<img width="233" alt="Screenshot 2024-08-09 at 9 42 10 AM" src="https://github.com/user-attachments/assets/085813a4-e9ca-447a-8985-4d2a3a162565">


<img width="248" alt="Screenshot 2024-08-09 at 9 42 01 AM" src="https://github.com/user-attachments/assets/d713f559-c84e-4778-8f28-24b445f8835b">

<img width="641" alt="Screenshot 2024-08-09 at 10 00 40 AM" src="https://github.com/user-attachments/assets/c1a903e6-7e7d-4750-9d4f-812c76e434ac">



## Motivation
Clean up ui/ux/issues

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
