### PR TITLE
function status zindex

### DIFF
--- a/ui/apps/dashboard/src/components/Functions/StatusMenu.tsx
+++ b/ui/apps/dashboard/src/components/Functions/StatusMenu.tsx
@@ -17,7 +17,7 @@ export const StatusMenu = ({ envSlug, archived }: { envSlug: string; archived: b
       label="Pause runs"
       multiple={false}
       value={archived ? archivedOption : activeOption}
-      className="mr-3 h-[30px]"
+      className="z-20 mr-3 h-[30px]"
     >
       <Select.Button className="h-[28px] w-[142px] py-1 pl-2 pr-3">
         <div className="mr-2 flex flex-row items-center text-sm">

--- a/ui/apps/dashboard/src/components/Functions/StatusMenu.tsx
+++ b/ui/apps/dashboard/src/components/Functions/StatusMenu.tsx
@@ -17,7 +17,7 @@ export const StatusMenu = ({ envSlug, archived }: { envSlug: string; archived: b
       label="Pause runs"
       multiple={false}
       value={archived ? archivedOption : activeOption}
-      className="z-[49] mr-3 h-[30px]"
+      className="mr-3 h-[30px]"
     >
       <Select.Button className="h-[28px] w-[142px] py-1 pl-2 pr-3">
         <div className="mr-2 flex flex-row items-center text-sm">


### PR DESCRIPTION
## Description

Found the magic z-index number for the function status menu. That keeps it below the nav stuff and above the function page elements. 

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
