### PR TITLE
Move custom span to run pkg

### DIFF
--- a/pkg/coreapi/graph/resolvers/app_mutations.go
+++ b/pkg/coreapi/graph/resolvers/app_mutations.go
@@ -13,7 +13,7 @@ import (
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/deploy"
 	"github.com/inngest/inngest/pkg/event"
-	"github.com/inngest/inngest/pkg/telemetry"
+	"github.com/inngest/inngest/pkg/run"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -105,11 +105,11 @@ func (r *mutationResolver) InvokeFunction(
 		FnID: functionSlug,
 	})
 
-	ctx, span := telemetry.NewSpan(ctx,
-		telemetry.WithName(consts.OtelSpanInvoke),
-		telemetry.WithScope(consts.OtelScopeInvoke),
-		telemetry.WithNewRoot(),
-		telemetry.WithSpanAttributes(
+	ctx, span := run.NewSpan(ctx,
+		run.WithName(consts.OtelSpanInvoke),
+		run.WithScope(consts.OtelScopeInvoke),
+		run.WithNewRoot(),
+		run.WithSpanAttributes(
 			attribute.Bool(consts.OtelUserTraceFilterKey, true),
 			attribute.String(consts.OtelSysFunctionSlug, functionSlug),
 		),

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/inngest/log"
 	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/run"
 	"github.com/inngest/inngest/pkg/telemetry"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/oklog/ulid/v2"
@@ -399,7 +400,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	evtMap := req.Events[0].GetEvent().Map()
 	factor, _ := req.Function.RunPriorityFactor(ctx, evtMap)
 	// function run spanID
-	spanID := telemetry.NewSpanID(ctx)
+	spanID := run.NewSpanID(ctx)
 
 	config := sv2.Config{
 		FunctionVersion: req.Function.FunctionVersion,
@@ -2099,7 +2100,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, i *runInst
 	opcode := gen.Op.String()
 	now := time.Now()
 
-	sid := telemetry.NewSpanID(ctx)
+	sid := run.NewSpanID(ctx)
 	// NOTE: the context here still contains the execSpan's traceID & spanID,
 	// which is what we want because that's the parent that needs to be referenced later on
 	carrier := telemetry.NewTraceCarrier(
@@ -2240,7 +2241,7 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, i *runInstan
 	opcode := gen.Op.String()
 	now := time.Now()
 
-	sid := telemetry.NewSpanID(ctx)
+	sid := run.NewSpanID(ctx)
 	// NOTE: the context here still contains the execSpan's traceID & spanID,
 	// which is what we want because that's the parent that needs to be referenced later on
 	carrier := telemetry.NewTraceCarrier(
@@ -2402,11 +2403,11 @@ func (e *executor) RetrieveAndScheduleBatch(ctx context.Context, fn inngest.Func
 	}
 
 	// root span for scheduling a batch
-	ctx, span := telemetry.NewSpan(ctx,
-		telemetry.WithScope(consts.OtelScopeBatch),
-		telemetry.WithName(consts.OtelSpanBatch),
-		telemetry.WithNewRoot(),
-		telemetry.WithSpanAttributes(
+	ctx, span := run.NewSpan(ctx,
+		run.WithScope(consts.OtelScopeBatch),
+		run.WithName(consts.OtelSpanBatch),
+		run.WithNewRoot(),
+		run.WithSpanAttributes(
 			attribute.Bool(consts.OtelUserTraceFilterKey, true),
 			attribute.String(consts.OtelSysAccountID, payload.AccountID.String()),
 			attribute.String(consts.OtelSysWorkspaceID, payload.WorkspaceID.String()),

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -22,8 +22,8 @@ import (
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/pubsub"
+	"github.com/inngest/inngest/pkg/run"
 	"github.com/inngest/inngest/pkg/service"
-	"github.com/inngest/inngest/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
 )
@@ -337,10 +337,10 @@ func (s *svc) handleDebounce(ctx context.Context, item queue.Item) error {
 				return err
 			}
 
-			ctx, span := telemetry.NewSpan(ctx,
-				telemetry.WithScope(consts.OtelScopeDebounce),
-				telemetry.WithName(consts.OtelSpanDebounce),
-				telemetry.WithSpanAttributes(
+			ctx, span := run.NewSpan(ctx,
+				run.WithScope(consts.OtelScopeDebounce),
+				run.WithName(consts.OtelSpanDebounce),
+				run.WithSpanAttributes(
 					attribute.String(consts.OtelSysAccountID, item.Identifier.AccountID.String()),
 					attribute.String(consts.OtelSysWorkspaceID, item.Identifier.WorkspaceID.String()),
 					attribute.String(consts.OtelSysAppID, item.Identifier.AppID.String()),

--- a/pkg/run/span.go
+++ b/pkg/run/span.go
@@ -1,4 +1,4 @@
-package telemetry
+package run
 
 import (
 	"context"
@@ -11,6 +11,7 @@ import (
 
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/inngest/log"
+	"github.com/inngest/inngest/pkg/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/instrumentation"
@@ -409,7 +410,7 @@ func (s *Span) End(opts ...trace.SpanEndOption) {
 		// s.SetAttributes(attribute.Bool(consts.OtelSysStepDelete, true))
 	}
 
-	if err := UserTracer().Export(s); err != nil {
+	if err := telemetry.UserTracer().Export(s); err != nil {
 		ctx := context.Background()
 		log.From(ctx).Error().Err(err).Msg("error ending span")
 	}
@@ -522,7 +523,7 @@ func (s *Span) SetAttributes(attrs ...attribute.KeyValue) {
 }
 
 func (s *Span) TracerProvider() trace.TracerProvider {
-	return UserTracer().Provider()
+	return telemetry.UserTracer().Provider()
 }
 
 func (s *Span) SetFnOutput(data any) {

--- a/pkg/run/trace_lifecycle.go
+++ b/pkg/run/trace_lifecycle.go
@@ -99,6 +99,7 @@ func (l traceLifecycle) OnFunctionScheduled(ctx context.Context, md statev2.Meta
 		if byt, err := json.Marshal(evt); err == nil {
 			span.AddEvent(string(byt), trace.WithAttributes(
 				attribute.Bool(consts.OtelSysEventData, true),
+				attribute.String(consts.OtelSysEventInternalID, e.GetInternalID().String()),
 			))
 		}
 	}
@@ -230,10 +231,14 @@ func (l traceLifecycle) OnFunctionStarted(
 		span.SetAttributes(attribute.String(consts.OtelSysFunctionLink, *md.Config.TraceLink()))
 	}
 
-	for _, e := range evts {
-		span.AddEvent(string(e), trace.WithAttributes(
-			attribute.Bool(consts.OtelSysEventData, true),
-		))
+	if err := span.SetEvents(ctx, md.Config.EventIDs, evts); err != nil {
+		l.log.Error("error setting events",
+			"lifecycle", "OnFunctionStarted",
+			"errors", err,
+			"meta", md,
+			"item", item,
+			"evts", evts,
+		)
 	}
 }
 
@@ -307,10 +312,14 @@ func (l traceLifecycle) OnFunctionFinished(
 		span.SetAttributes(attribute.String(consts.OtelSysFunctionLink, *md.Config.TraceLink()))
 	}
 
-	for _, e := range evts {
-		span.AddEvent(string(e), trace.WithAttributes(
-			attribute.Bool(consts.OtelSysEventData, true),
-		))
+	if err := span.SetEvents(ctx, md.Config.EventIDs, evts); err != nil {
+		l.log.Error("error setting events",
+			"lifecycle", "OnFunctionFinished",
+			"errors", err,
+			"meta", md,
+			"item", item,
+			"evts", evts,
+		)
 	}
 
 	switch resp.StatusCode {
@@ -378,10 +387,14 @@ func (l traceLifecycle) OnFunctionCancelled(ctx context.Context, md sv2.Metadata
 		)
 	}
 
-	for _, evt := range evts {
-		span.AddEvent(string(evt), trace.WithAttributes(
-			attribute.Bool(consts.OtelSysEventData, true),
-		))
+	if err := span.SetEvents(ctx, md.Config.EventIDs, evts); err != nil {
+		l.log.Error("error setting events",
+			"lifecycle", "OnFunctionCancelled",
+			"errors", err,
+			"meta", md,
+			"req", req,
+			"evts", evts,
+		)
 	}
 }
 

--- a/pkg/run/trace_lifecycle.go
+++ b/pkg/run/trace_lifecycle.go
@@ -51,11 +51,11 @@ func (l traceLifecycle) OnFunctionScheduled(ctx context.Context, md statev2.Meta
 	}
 
 	// span that tells when the function was queued
-	_, span := telemetry.NewSpan(ctx,
-		telemetry.WithScope(consts.OtelScopeTrigger),
-		telemetry.WithName(consts.OtelSpanTrigger),
-		telemetry.WithTimestamp(ulid.Time(runID.Time())),
-		telemetry.WithSpanAttributes(
+	_, span := NewSpan(ctx,
+		WithScope(consts.OtelScopeTrigger),
+		WithName(consts.OtelSpanTrigger),
+		WithTimestamp(ulid.Time(runID.Time())),
+		WithSpanAttributes(
 			attribute.Bool(consts.OtelUserTraceFilterKey, true),
 			attribute.String(consts.OtelSysAccountID, md.ID.Tenant.AccountID.String()),
 			attribute.String(consts.OtelSysWorkspaceID, md.ID.Tenant.EnvID.String()),
@@ -126,12 +126,12 @@ func (l traceLifecycle) OnFunctionScheduled(ctx context.Context, md statev2.Meta
 							mrunID = *meta.RunID()
 						}
 
-						_, ispan := telemetry.NewSpan(ictx,
-							telemetry.WithScope(consts.OtelScopeStep),
-							telemetry.WithName(consts.OtelSpanInvoke),
-							telemetry.WithTimestamp(meta.InvokeTraceCarrier.Timestamp),
-							telemetry.WithSpanID(sid),
-							telemetry.WithSpanAttributes(
+						_, ispan := NewSpan(ictx,
+							WithScope(consts.OtelScopeStep),
+							WithName(consts.OtelSpanInvoke),
+							WithTimestamp(meta.InvokeTraceCarrier.Timestamp),
+							WithSpanID(sid),
+							WithSpanAttributes(
 								attribute.Bool(consts.OtelUserTraceFilterKey, true),
 								attribute.String(consts.OtelSysAccountID, md.ID.Tenant.AccountID.String()),
 								attribute.String(consts.OtelSysWorkspaceID, md.ID.Tenant.EnvID.String()),
@@ -179,7 +179,7 @@ func (l traceLifecycle) OnFunctionStarted(
 	if err != nil {
 		// generate a new one here to be used for subsequent runs.
 		// this could happen for runs that started before this feature was introduced.
-		sid := telemetry.NewSpanID(ctx)
+		sid := NewSpanID(ctx)
 		spanID = &sid
 	}
 
@@ -192,12 +192,12 @@ func (l traceLifecycle) OnFunctionStarted(
 	}
 
 	// (re)Construct function span to force update the end time
-	_, span := telemetry.NewSpan(ctx,
-		telemetry.WithScope(consts.OtelScopeFunction),
-		telemetry.WithName(slug),
-		telemetry.WithTimestamp(start),
-		telemetry.WithSpanID(*spanID),
-		telemetry.WithSpanAttributes(
+	_, span := NewSpan(ctx,
+		WithScope(consts.OtelScopeFunction),
+		WithName(slug),
+		WithTimestamp(start),
+		WithSpanID(*spanID),
+		WithSpanAttributes(
 			attribute.Bool(consts.OtelUserTraceFilterKey, true),
 			attribute.String(consts.OtelSysAccountID, md.ID.Tenant.AccountID.String()),
 			attribute.String(consts.OtelSysWorkspaceID, md.ID.Tenant.EnvID.String()),
@@ -257,7 +257,7 @@ func (l traceLifecycle) OnFunctionFinished(
 	if err != nil {
 		// generate a new one here to be used for subsequent runs.
 		// this could happen for runs that started before this feature was introduced.
-		sid := telemetry.NewSpanID(ctx)
+		sid := NewSpanID(ctx)
 		spanID = &sid
 	}
 
@@ -270,12 +270,12 @@ func (l traceLifecycle) OnFunctionFinished(
 	}
 
 	// (re)Construct function span to force update the end time
-	_, span := telemetry.NewSpan(ctx,
-		telemetry.WithScope(consts.OtelScopeFunction),
-		telemetry.WithName(slug),
-		telemetry.WithTimestamp(start),
-		telemetry.WithSpanID(*spanID),
-		telemetry.WithSpanAttributes(
+	_, span := NewSpan(ctx,
+		WithScope(consts.OtelScopeFunction),
+		WithName(slug),
+		WithTimestamp(start),
+		WithSpanID(*spanID),
+		WithSpanAttributes(
 			attribute.Bool(consts.OtelUserTraceFilterKey, true),
 			attribute.String(consts.OtelSysAccountID, md.ID.Tenant.AccountID.String()),
 			attribute.String(consts.OtelSysWorkspaceID, md.ID.Tenant.EnvID.String()),
@@ -347,12 +347,12 @@ func (l traceLifecycle) OnFunctionCancelled(ctx context.Context, md sv2.Metadata
 		evtIDs[i] = eid.String()
 	}
 
-	_, span := telemetry.NewSpan(ctx,
-		telemetry.WithScope(consts.OtelScopeFunction),
-		telemetry.WithName(md.Config.FunctionSlug()),
-		telemetry.WithTimestamp(start),
-		telemetry.WithSpanID(*fnSpanID),
-		telemetry.WithSpanAttributes(
+	_, span := NewSpan(ctx,
+		WithScope(consts.OtelScopeFunction),
+		WithName(md.Config.FunctionSlug()),
+		WithTimestamp(start),
+		WithSpanID(*fnSpanID),
+		WithSpanAttributes(
 			attribute.Bool(consts.OtelUserTraceFilterKey, true),
 			attribute.String(consts.OtelSysAccountID, md.ID.Tenant.AccountID.String()),
 			attribute.String(consts.OtelSysWorkspaceID, md.ID.Tenant.EnvID.String()),
@@ -407,12 +407,12 @@ func (l traceLifecycle) OnStepStarted(
 	}
 	runID := md.ID.RunID
 
-	_, span := telemetry.NewSpan(ctx,
-		telemetry.WithScope(consts.OtelScopeExecution),
-		telemetry.WithName(consts.OtelExecPlaceholder),
-		telemetry.WithTimestamp(start),
-		telemetry.WithSpanID(*spanID),
-		telemetry.WithSpanAttributes(
+	_, span := NewSpan(ctx,
+		WithScope(consts.OtelScopeExecution),
+		WithName(consts.OtelExecPlaceholder),
+		WithTimestamp(start),
+		WithSpanID(*spanID),
+		WithSpanAttributes(
 			attribute.Bool(consts.OtelUserTraceFilterKey, true),
 			attribute.String(consts.OtelSysAccountID, md.ID.Tenant.AccountID.String()),
 			attribute.String(consts.OtelSysWorkspaceID, md.ID.Tenant.EnvID.String()),
@@ -442,7 +442,7 @@ func (l traceLifecycle) OnStepStarted(
 	// first step
 	if edge.Incoming == inngest.TriggerName {
 		// NOTE:
-		// annotate the step as the first step of the function run.
+		// annotate the step as the first step of the function
 		// this way the delay associated with this run is directly correlated to the delay of the
 		// function run itself.
 		if item.Attempt == 0 {
@@ -474,12 +474,12 @@ func (l traceLifecycle) OnStepFinished(
 	}
 	runID := md.ID.RunID
 
-	_, span := telemetry.NewSpan(ctx,
-		telemetry.WithScope(consts.OtelScopeExecution),
-		telemetry.WithName(consts.OtelExecPlaceholder),
-		telemetry.WithTimestamp(start),
-		telemetry.WithSpanID(*spanID),
-		telemetry.WithSpanAttributes(
+	_, span := NewSpan(ctx,
+		WithScope(consts.OtelScopeExecution),
+		WithName(consts.OtelExecPlaceholder),
+		WithTimestamp(start),
+		WithSpanID(*spanID),
+		WithSpanAttributes(
 			attribute.Bool(consts.OtelUserTraceFilterKey, true),
 			attribute.String(consts.OtelSysAccountID, md.ID.Tenant.AccountID.String()),
 			attribute.String(consts.OtelSysWorkspaceID, md.ID.Tenant.EnvID.String()),
@@ -509,7 +509,7 @@ func (l traceLifecycle) OnStepFinished(
 	// first step
 	if edge.Incoming == inngest.TriggerName {
 		// NOTE:
-		// annotate the step as the first step of the function run.
+		// annotate the step as the first step of the function
 		// this way the delay associated with this run is directly correlated to the delay of the
 		// function run itself.
 		if item.Attempt == 0 {
@@ -600,11 +600,11 @@ func (l traceLifecycle) OnSleep(
 	startedAt := until.Add(-1 * dur)
 	runID := md.ID.RunID
 
-	_, span := telemetry.NewSpan(ctx,
-		telemetry.WithScope(consts.OtelScopeStep),
-		telemetry.WithName(consts.OtelSpanSleep),
-		telemetry.WithTimestamp(startedAt),
-		telemetry.WithSpanAttributes(
+	_, span := NewSpan(ctx,
+		WithScope(consts.OtelScopeStep),
+		WithName(consts.OtelSpanSleep),
+		WithTimestamp(startedAt),
+		WithSpanAttributes(
 			attribute.Bool(consts.OtelUserTraceFilterKey, true),
 			attribute.String(consts.OtelSysAccountID, md.ID.Tenant.AccountID.String()),
 			attribute.String(consts.OtelSysWorkspaceID, md.ID.Tenant.EnvID.String()),
@@ -647,12 +647,12 @@ func (l traceLifecycle) OnInvokeFunction(
 	}
 	spanID := carrier.SpanID()
 
-	_, span := telemetry.NewSpan(ctx,
-		telemetry.WithScope(consts.OtelScopeStep),
-		telemetry.WithName(consts.OtelSpanInvoke),
-		telemetry.WithTimestamp(carrier.Timestamp),
-		telemetry.WithSpanID(spanID),
-		telemetry.WithSpanAttributes(
+	_, span := NewSpan(ctx,
+		WithScope(consts.OtelScopeStep),
+		WithName(consts.OtelSpanInvoke),
+		WithTimestamp(carrier.Timestamp),
+		WithSpanID(spanID),
+		WithSpanAttributes(
 			attribute.Bool(consts.OtelUserTraceFilterKey, true),
 			attribute.String(consts.OtelSysAccountID, md.ID.Tenant.AccountID.String()),
 			attribute.String(consts.OtelSysWorkspaceID, md.ID.Tenant.EnvID.String()),
@@ -716,12 +716,12 @@ func (l traceLifecycle) OnInvokeFunctionResumed(
 				runID = r.RunID.String()
 			}
 
-			_, span := telemetry.NewSpan(ctx,
-				telemetry.WithScope(consts.OtelScopeStep),
-				telemetry.WithName(consts.OtelSpanInvoke),
-				telemetry.WithTimestamp(carrier.Timestamp),
-				telemetry.WithSpanID(carrier.SpanID()),
-				telemetry.WithSpanAttributes(
+			_, span := NewSpan(ctx,
+				WithScope(consts.OtelScopeStep),
+				WithName(consts.OtelSpanInvoke),
+				WithTimestamp(carrier.Timestamp),
+				WithSpanID(carrier.SpanID()),
+				WithSpanAttributes(
 					attribute.Bool(consts.OtelUserTraceFilterKey, true),
 					attribute.String(consts.OtelSysAccountID, pause.Identifier.AccountID.String()),
 					attribute.String(consts.OtelSysWorkspaceID, pause.Identifier.WorkspaceID.String()),
@@ -792,12 +792,12 @@ func (l traceLifecycle) OnWaitForEvent(
 		return
 	}
 
-	_, span := telemetry.NewSpan(ctx,
-		telemetry.WithScope(consts.OtelScopeStep),
-		telemetry.WithName(consts.OtelSpanWaitForEvent),
-		telemetry.WithTimestamp(carrier.Timestamp),
-		telemetry.WithSpanID(carrier.SpanID()),
-		telemetry.WithSpanAttributes(
+	_, span := NewSpan(ctx,
+		WithScope(consts.OtelScopeStep),
+		WithName(consts.OtelSpanWaitForEvent),
+		WithTimestamp(carrier.Timestamp),
+		WithSpanID(carrier.SpanID()),
+		WithSpanAttributes(
 			attribute.Bool(consts.OtelUserTraceFilterKey, true),
 			attribute.String(consts.OtelSysStepOpcode, enums.OpcodeWaitForEvent.String()),
 			attribute.String(consts.OtelSysAccountID, md.ID.Tenant.AccountID.String()),
@@ -847,12 +847,12 @@ func (l traceLifecycle) OnWaitForEventResumed(
 	if err := carrier.Unmarshal(meta); err == nil {
 		ctx = telemetry.UserTracer().Propagator().Extract(ctx, propagation.MapCarrier(carrier.Context))
 		if carrier.CanResumePause() {
-			_, span := telemetry.NewSpan(ctx,
-				telemetry.WithScope(consts.OtelScopeStep),
-				telemetry.WithName(consts.OtelSpanWaitForEvent),
-				telemetry.WithTimestamp(carrier.Timestamp),
-				telemetry.WithSpanID(carrier.SpanID()),
-				telemetry.WithSpanAttributes(
+			_, span := NewSpan(ctx,
+				WithScope(consts.OtelScopeStep),
+				WithName(consts.OtelSpanWaitForEvent),
+				WithTimestamp(carrier.Timestamp),
+				WithSpanID(carrier.SpanID()),
+				WithSpanAttributes(
 					attribute.Bool(consts.OtelUserTraceFilterKey, true),
 					attribute.String(consts.OtelSysAccountID, pause.Identifier.AccountID.String()),
 					attribute.String(consts.OtelSysWorkspaceID, pause.Identifier.WorkspaceID.String()),


### PR DESCRIPTION
## Description

In certain cases, keeping the `Span` struct in telemetry will actually cause circular imports, and raise errors.
Now that there's a `run` pkg, it makes more sense to move the custom span struct there instead.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
