### PR TITLE
Use `lite` as service name for `inngest lite`

### DIFF
--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -87,7 +87,11 @@ type devserver struct {
 	persistenceInterval *time.Duration
 }
 
-func (devserver) Name() string {
+func (d *devserver) Name() string {
+	if d.persistenceInterval != nil {
+		return "lite"
+	}
+
 	return "devserver"
 }
 
@@ -119,7 +123,7 @@ func (d *devserver) Run(ctx context.Context) error {
 			addr := fmt.Sprintf("%s:%d", d.Opts.Config.EventAPI.Addr, d.Opts.Config.EventAPI.Port)
 			fmt.Println("")
 			fmt.Println("")
-			fmt.Print(cli.BoldStyle.Render("\tInngest dev server online "))
+			fmt.Print(cli.BoldStyle.Render(fmt.Sprintf("\tInngest %s online ", d.Name())))
 			fmt.Printf(cli.TextStyle.Render(fmt.Sprintf("at %s, visible at the following URLs:", addr)) + "\n\n")
 			for n, ip := range localIPs() {
 				style := cli.BoldStyle
@@ -276,7 +280,7 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 func (d *devserver) HandleEvent(ctx context.Context, e *event.Event) (string, error) {
 	// ctx is the request context, so we need to re-add
 	// the caller here.
-	l := logger.From(ctx).With().Str("caller", "devserver").Logger()
+	l := logger.From(ctx).With().Str("caller", d.Name()).Logger()
 	ctx = logger.With(ctx, l)
 
 	l.Debug().Str("event", e.Name).Msg("handling event")
@@ -326,7 +330,7 @@ func (d *devserver) exportRedisSnapshot(ctx context.Context) (err error) {
 
 	snapshot := make(map[string]SnapshotValue)
 
-	l := logger.From(ctx).With().Str("caller", "devserver").Logger()
+	l := logger.From(ctx).With().Str("caller", d.Name()).Logger()
 	l.Info().Msg("exporting Redis snapshot")
 	defer func() {
 		if err != nil {
@@ -469,7 +473,7 @@ func (d *devserver) importRedisSnapshot(ctx context.Context) (err error, importe
 
 	var snapshot map[string]SnapshotValue
 
-	l := logger.From(ctx).With().Str("caller", "devserver").Logger()
+	l := logger.From(ctx).With().Str("caller", d.Name()).Logger()
 	l.Info().Msg("importing Redis snapshot")
 	defer func() {
 		if err != nil {

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -95,6 +95,16 @@ func (d *devserver) Name() string {
 	return "devserver"
 }
 
+func (d *devserver) PrettyName() string {
+	name := strings.Title(d.Name())
+
+	if name == "Devserver" {
+		return "Dev Server"
+	}
+
+	return name
+}
+
 func (d *devserver) Pre(ctx context.Context) error {
 	// Import Redis if we can and have persistence enabled
 	if d.persistenceInterval != nil {
@@ -123,7 +133,7 @@ func (d *devserver) Run(ctx context.Context) error {
 			addr := fmt.Sprintf("%s:%d", d.Opts.Config.EventAPI.Addr, d.Opts.Config.EventAPI.Port)
 			fmt.Println("")
 			fmt.Println("")
-			fmt.Print(cli.BoldStyle.Render(fmt.Sprintf("\tInngest %s online ", d.Name())))
+			fmt.Print(cli.BoldStyle.Render(fmt.Sprintf("\tInngest %s online ", d.PrettyName())))
 			fmt.Printf(cli.TextStyle.Render(fmt.Sprintf("at %s, visible at the following URLs:", addr)) + "\n\n")
 			for n, ip := range localIPs() {
 				style := cli.BoldStyle


### PR DESCRIPTION
## Description

Use `lite` for `inngest lite` logs.

```
4:26PM INF runner > starting event stream backend=redis
4:26PM INF lite > service starting
4:26PM INF runner > service starting
4:26PM INF api > service starting
4:26PM INF executor > service starting
4:26PM INF executor > subscribing to function queue
4:26PM INF api > starting server addr=0.0.0.0:8288
4:26PM INF no shard finder;  skipping shard claiming
4:26PM INF runner > subscribing to events topic=events


        Inngest lite online at 0.0.0.0:8288, visible at the following URLs:

         - http://127.0.0.1:8288 (http://localhost:8288)
         - http://10.255.255.254:8288
         - http://172.19.11.90:8288
```

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
