### PR TITLE
Ensure defaults for Dev Server polling interval are sensible

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -50,7 +50,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const defaultTick = time.Millisecond * 150
+const (
+	DefaultTick         = time.Millisecond * 150
+	DefaultPollInterval = 5
+)
 
 // StartOpts configures the dev server
 type StartOpts struct {
@@ -92,7 +95,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	}
 
 	if opts.Tick == 0 {
-		opts.Tick = defaultTick
+		opts.Tick = DefaultTick
 	}
 
 	// Initialize the devserver
@@ -372,7 +375,7 @@ func createInmemoryRedis(ctx context.Context, tick time.Duration) (rueidis.Clien
 	// If tick is lower than 250ms, tick every 100ms.  This lets us save
 	// CPU for standard dev-server testing.
 	poll := time.Second
-	if tick < defaultTick {
+	if tick < DefaultTick {
 		poll = time.Millisecond * 50
 	}
 

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -372,7 +372,7 @@ func createInmemoryRedis(ctx context.Context, tick time.Duration) (rueidis.Clien
 		return nil, err
 	}
 
-	// If tick is lower than 250ms, tick every 100ms.  This lets us save
+	// If tick is lower than the default, tick every 50ms.  This lets us save
 	// CPU for standard dev-server testing.
 	poll := time.Second
 	if tick < DefaultTick {

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -36,6 +36,12 @@ import (
 )
 
 func NewService(opts StartOpts, runner runner.Runner, data cqrs.Manager, pb pubsub.Publisher, stepLimitOverrides map[string]int, stateSizeLimitOverrides map[string]int, rc rueidis.Client, hw history.Driver, persistenceInterval *time.Duration) *devserver {
+	// If the polling interval is 0, reset it to a sensible value to avoid
+	// hammering the SDKs and burning CPU.
+	if opts.PollInterval == 0 {
+		opts.PollInterval = 5
+	}
+
 	return &devserver{
 		Data:                    data,
 		Runner:                  runner,

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -39,7 +39,7 @@ func NewService(opts StartOpts, runner runner.Runner, data cqrs.Manager, pb pubs
 	// If the polling interval is 0, reset it to a sensible value to avoid
 	// hammering the SDKs and burning CPU.
 	if opts.PollInterval == 0 {
-		opts.PollInterval = 5
+		opts.PollInterval = DefaultPollInterval
 	}
 
 	return &devserver{

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -50,8 +50,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const defaultTick = time.Millisecond * 150
-
 var redisSingleton *miniredis.Miniredis
 
 // StartOpts configures the dev server
@@ -87,7 +85,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		return err
 	}
 
-	tick := defaultTick
+	tick := devserver.DefaultTick
 
 	// Initialize the devserver
 	dbcqrs := sqlitecqrs.NewCQRS(db)


### PR DESCRIPTION
## Description

Fixes a bug where a default (zero-value) `PollInterval` for the Dev Server will hammer SDKs as fast as it can.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
