### PR TITLE
Fix non-SDK 200 responses completing function runs

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -182,6 +182,26 @@ func DoRequest(ctx context.Context, c *http.Client, r Request) (*state.DriverRes
 	if resp.sysErr != nil {
 		dr.SetError(resp.sysErr)
 	}
+
+	if dr.Err == nil && resp.statusCode == 200 && !resp.isSDK {
+		log.From(ctx).Info().
+			Interface("headers", resp.header).
+			Str("run_id", r.RunID.String()).
+			Str("url", r.URL.String()).
+			Msg("response did not come from an Inngest SDK")
+
+		err := syscode.Error{
+			Code:    syscode.CodeNotSDK,
+			Message: fmt.Sprintf("%s: response did not come from an Inngest SDK", syscode.CodeNotSDK),
+		}
+
+		dr.SetError(err)
+
+		// We need to add the error to the output so the user can see it in the
+		// UI. Also keep the body in case that helps them debug
+		dr.Output = fmt.Sprintf("%s\n\n%s", err, body)
+	}
+
 	if resp.statusCode < 200 || resp.statusCode > 299 {
 		// Add an error to driver.Response if the status code isn't 2XX.
 		//
@@ -365,6 +385,14 @@ func do(ctx context.Context, c *http.Client, r Request) (*response, error) {
 		}
 	}
 
+	isSDK := false
+	for k := range resp.Header {
+		if strings.HasPrefix(strings.ToLower(k), "x-inngest-") {
+			isSDK = true
+			break
+		}
+	}
+
 	// Get the request version
 	rv, _ := strconv.Atoi(headers[headerRequestVersion])
 	return &response{
@@ -377,6 +405,7 @@ func do(ctx context.Context, c *http.Client, r Request) (*response, error) {
 		sdk:            headers[headerSDK],
 		header:         resp.Header,
 		sysErr:         sysErr,
+		isSDK:          isSDK,
 	}, err
 
 }
@@ -400,4 +429,5 @@ type response struct {
 	header http.Header
 
 	sysErr *syscode.Error
+	isSDK  bool
 }


### PR DESCRIPTION
## Description
Fix non-SDK `200` responses causing function runs to "successfully" complete. We should handle this scenario as if it's an unreachable SDK: fail the attempt and schedule a retry.

## Testing
I changed my SDK endpoint to the following and then triggered a function:
```ts
app.post("/api/inngest", (req, res) => {
  res.json(null);
});
```

![image](https://github.com/user-attachments/assets/fc86d612-c920-4e3b-931a-de22821b1aec)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
