### PR TITLE
INN-3541 - Change archived and active colors

### DIFF
--- a/ui/apps/dashboard/src/components/Apps/StatusMenu.tsx
+++ b/ui/apps/dashboard/src/components/Apps/StatusMenu.tsx
@@ -21,7 +21,7 @@ export const StatusMenu = ({ envSlug, archived }: { envSlug: string; archived: b
     >
       <Select.Button className="h-[28px] w-[132px] py-1 pl-2 pr-3">
         <div className="text-basis mr-2 flex flex-row items-center text-sm font-medium leading-tight">
-          <StatusIcon className={`mr-2 ${archived ? 'bg-accent-subtle' : 'bg-primary-moderate'}`} />
+          <StatusIcon className={`mr-2 ${archived ? 'bg-surfaceMuted' : 'bg-primary-moderate'}`} />
           {archived ? 'Archived' : 'Active'}
         </div>
       </Select.Button>
@@ -37,7 +37,7 @@ export const StatusMenu = ({ envSlug, archived }: { envSlug: string; archived: b
         <Link href={`/env/${envSlug}/apps?archived=true`}>
           <Select.Option key={archivedOption.id} option={archivedOption}>
             <div className="text-basis flex flex-row items-center text-sm font-medium">
-              <StatusIcon className="bg-accent-subtle mr-2" />
+              <StatusIcon className="bg-surfaceMuted mr-2" />
               {archivedOption.name}
             </div>
           </Select.Option>

--- a/ui/apps/dashboard/src/components/Environments/Environments.tsx
+++ b/ui/apps/dashboard/src/components/Environments/Environments.tsx
@@ -53,7 +53,7 @@ export default function Environments() {
           className="to-slate-940 mt-4 flex items-center justify-between rounded-lg bg-slate-900 bg-gradient-to-br from-slate-800 px-4 py-4 hover:bg-slate-800 hover:from-slate-700 hover:to-slate-900"
         >
           <h3 className="flex items-center gap-2 text-sm font-medium tracking-wide text-white">
-            <span className="block h-2 w-2 rounded-full bg-teal-400" />
+            <span className="bg-primary-moderate block h-2 w-2 rounded-full" />
             Production
           </h3>
         </Link>
@@ -79,7 +79,7 @@ export default function Environments() {
               className="mt-8 flex cursor-pointer items-center justify-between rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-sm hover:bg-slate-100/60"
             >
               <h3 className="flex items-center gap-2 text-sm font-semibold text-slate-800">
-                <span className="block h-2 w-2 rounded-full bg-teal-500" />
+                <span className="bg-primary-moderate block h-2 w-2 rounded-full" />
                 Test
               </h3>
             </Link>
@@ -138,7 +138,7 @@ export default function Environments() {
                 className="mt-8 flex cursor-pointer items-center justify-between rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-sm hover:bg-slate-100/60"
               >
                 <h3 className="flex items-center gap-2 text-sm font-semibold text-slate-800">
-                  <span className="block h-2 w-2 rounded-full bg-teal-500" />
+                  <span className="bg-primary-moderate block h-2 w-2 rounded-full" />
                   {env.name}
                 </h3>
               </Link>

--- a/ui/apps/dashboard/src/components/Environments/old/EnvironmentListTable.tsx
+++ b/ui/apps/dashboard/src/components/Environments/old/EnvironmentListTable.tsx
@@ -164,10 +164,10 @@ function TableRow(props: { env: Environment }) {
   let statusColorClass: string;
   let statusText: string;
   if (isArchived) {
-    statusColorClass = 'bg-slate-300';
+    statusColorClass = 'bg-surfaceMuted';
     statusText = 'Archived';
   } else {
-    statusColorClass = 'bg-teal-500';
+    statusColorClass = 'bg-primary-moderate';
     statusText = 'Active';
   }
 

--- a/ui/apps/dashboard/src/components/Functions/FunctionTable.tsx
+++ b/ui/apps/dashboard/src/components/Functions/FunctionTable.tsx
@@ -120,7 +120,11 @@ function createColumns(environmentSlug: string) {
             <div
               className={cn(
                 'h-2.5 w-2.5 rounded-full',
-                isArchived ? 'bg-slate-300' : isPaused ? 'bg-amber-500' : 'bg-teal-500'
+                isArchived
+                  ? 'bg-surfaceMuted'
+                  : isPaused
+                  ? 'bg-accent-subtle'
+                  : 'bg-primary-moderate'
               )}
             />
             <Link

--- a/ui/apps/dashboard/src/components/Functions/StatusMenu.tsx
+++ b/ui/apps/dashboard/src/components/Functions/StatusMenu.tsx
@@ -21,7 +21,7 @@ export const StatusMenu = ({ envSlug, archived }: { envSlug: string; archived: b
     >
       <Select.Button className="h-[28px] w-[142px] py-1 pl-2 pr-3">
         <div className="mr-2 flex flex-row items-center text-sm">
-          <StatusIcon className={`mr-2 ${archived ? 'bg-accent-subtle' : 'bg-primary-moderate'}`} />
+          <StatusIcon className={`mr-2 ${archived ? 'bg-surfaceMuted' : 'bg-primary-moderate'}`} />
           {archived ? 'Archived' : 'Active'}
         </div>
       </Select.Button>
@@ -38,7 +38,7 @@ export const StatusMenu = ({ envSlug, archived }: { envSlug: string; archived: b
         <Link href={`/env/${envSlug}/functions?archived=true`}>
           <Select.Option key={archivedOption.id} option={archivedOption}>
             <div className="text-basis flex flex-row items-center text-sm font-medium">
-              <StatusIcon className="bg-accent-subtle mr-2" />
+              <StatusIcon className="bg-surfaceMuted mr-2" />
               {archivedOption.name}
             </div>
           </Select.Option>

--- a/ui/apps/dashboard/src/components/Navigation/Environments.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Environments.tsx
@@ -237,9 +237,9 @@ function EnvironmentItem({
 }) {
   let statusColorClass: string;
   if (environment.isArchived) {
-    statusColorClass = 'bg-slate-300';
+    statusColorClass = 'bg-surfaceMuted';
   } else {
-    statusColorClass = 'bg-teal-500';
+    statusColorClass = 'bg-primary-moderate';
   }
 
   return (

--- a/ui/apps/dashboard/src/components/Navigation/old/EnvironmentSelectMenu.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/old/EnvironmentSelectMenu.tsx
@@ -115,7 +115,7 @@ export default function EnvironmentSelectMenu({ activeEnv }: EnvironmentSelectMe
                   <span
                     className={cn(
                       'mr-2 h-2 w-2 flex-shrink-0 rounded-full',
-                      selected.isArchived ? 'bg-slate-300' : 'bg-cyan-500'
+                      selected.isArchived ? 'bg-surfaceMuted' : 'bg-primary-moderate'
                     )}
                   />
                   <span className="block truncate">
@@ -201,9 +201,9 @@ function EnvironmentItem({
 }) {
   let statusColorClass: string;
   if (environment.isArchived) {
-    statusColorClass = 'bg-slate-300';
+    statusColorClass = 'bg-surfaceMuted';
   } else {
-    statusColorClass = 'bg-teal-500';
+    statusColorClass = 'bg-primary-moderate';
   }
 
   return (


### PR DESCRIPTION
## Description
- Change archived and active colors to use color tokens.

<img width="452" alt="Screenshot 2024-08-20 at 12 36 33" src="https://github.com/user-attachments/assets/48ff5b3e-44b4-4a2a-8f24-63787c0bc538">
<img width="1283" alt="Screenshot 2024-08-20 at 12 36 18" src="https://github.com/user-attachments/assets/bfa6c6f7-f744-41c9-ba41-ec621f568b98">



## Motivation
- Archived was using the same color as paused fn, leading to confusion

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
