### PR TITLE
runs refresh ux improvements

### DIFF
--- a/ui/apps/dashboard/src/components/Layout/Layout.tsx
+++ b/ui/apps/dashboard/src/components/Layout/Layout.tsx
@@ -26,7 +26,7 @@ export default async function Layout({ activeEnv, children }: LayoutProps) {
     <div className="fixed z-50 flex h-screen w-full flex-row justify-start overflow-y-scroll overscroll-y-none">
       <SideBar collapsed={collapsed} activeEnv={activeEnv} profile={profile} />
 
-      <div className="flex w-full flex-col">
+      <div className="flex w-full flex-col overflow-x-scroll">
         <IncidentBanner />
         {children}
       </div>

--- a/ui/apps/dashboard/src/components/Navigation/Logo.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Logo.tsx
@@ -49,7 +49,7 @@ export default function Logo({ collapsed, setCollapsed }: LogoProps) {
       <div className={`flex flex-row items-center justify-start ${collapsed ? '' : 'mr-3'} `}>
         {collapsed ? (
           <div className="cursor-pointer group-hover:hidden">
-            <InngestLogoSmallBW />
+            <InngestLogoSmallBW className="text-basis" />
           </div>
         ) : (
           <>

--- a/ui/apps/dashboard/src/components/Runs/Runs.tsx
+++ b/ui/apps/dashboard/src/components/Runs/Runs.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useState } from 'react';
-import { usePathname } from 'next/navigation';
 import { RunsPage } from '@inngest/components/RunsPage/RunsPage';
 import type { Run } from '@inngest/components/RunsPage/types';
 import { useCalculatedStartTime } from '@inngest/components/hooks/useCalculatedStartTime';

--- a/ui/apps/dashboard/src/components/Runs/Runs.tsx
+++ b/ui/apps/dashboard/src/components/Runs/Runs.tsx
@@ -44,10 +44,6 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
   ref
 ) {
   const env = useEnvironment();
-  const pathName = usePathname();
-  //
-  // Don't do page level refresh on new runs section, it's a top nav action
-  const monitorRuns = pathName.includes(`/env/${env.slug}/runs`);
 
   const [{ data: pauseData }] = useQuery({
     pause: scope !== 'fn',
@@ -232,7 +228,7 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
       isLoadingInitial={firstPageRes.fetching}
       isLoadingMore={nextPageRes.fetching}
       getRun={getRun}
-      onRefresh={monitorRuns ? undefined : onRefresh}
+      onRefresh={onRefresh}
       onScroll={fetchMoreOnScroll}
       onScrollToTop={onScrollToTop}
       getTraceResult={getTraceResult}

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/functions/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/functions/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useMemo, useRef, useState } from 'react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { BlankSlate } from '@inngest/components/BlankSlate';
 import { Header } from '@inngest/components/Header/Header';
 import { Info } from '@inngest/components/Info/Info';
@@ -9,6 +8,7 @@ import { InvokeButton } from '@inngest/components/InvokeButton';
 import { Link } from '@inngest/components/Link/Link';
 import { HorizontalPillList, Pill, PillContent } from '@inngest/components/Pill';
 import { Table } from '@inngest/components/Table';
+import { useSearchParam } from '@inngest/components/hooks/useSearchParam';
 import {
   createColumnHelper,
   getCoreRowModel,
@@ -118,21 +118,17 @@ export default function FunctionList() {
       desc: false,
     },
   ]);
-  const searchParams = useSearchParams();
-  const pathname = usePathname();
-  const { replace } = useRouter();
-  const query = searchParams.get('query');
-  const [searchInput, setSearchInput] = useState(query || '');
-  const [globalFilter, setGlobalFilter] = useState(query || '');
+  const [value, upsert, remove] = useSearchParam('query');
+
+  const [searchInput, setSearchInput] = useState(value || '');
+  const [globalFilter, setGlobalFilter] = useState(value || '');
 
   const debouncedSearch = useDebounce(() => {
-    const params = new URLSearchParams(searchParams);
     if (searchInput) {
-      params.set('query', searchInput);
+      upsert(searchInput);
     } else {
-      params.delete('query');
+      remove();
     }
-    replace(`${pathname}?${params.toString()}`);
     setGlobalFilter(searchInput);
   });
 

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/functions/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/functions/page.tsx
@@ -122,8 +122,8 @@ export default function FunctionList() {
   const pathname = usePathname();
   const { replace } = useRouter();
   const query = searchParams.get('query');
-  const [searchInput, setSearchInput] = useState(query);
-  const [globalFilter, setGlobalFilter] = useState(query);
+  const [searchInput, setSearchInput] = useState(query || '');
+  const [globalFilter, setGlobalFilter] = useState(query || '');
 
   const debouncedSearch = useDebounce(() => {
     const params = new URLSearchParams(searchParams);

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/functions/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/functions/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useRef, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { BlankSlate } from '@inngest/components/BlankSlate';
 import { Header } from '@inngest/components/Header/Header';
 import { Info } from '@inngest/components/Info/Info';
@@ -117,9 +118,21 @@ export default function FunctionList() {
       desc: false,
     },
   ]);
-  const [searchInput, setSearchInput] = useState('');
-  const [globalFilter, setGlobalFilter] = useState('');
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const { replace } = useRouter();
+  const query = searchParams.get('query');
+  const [searchInput, setSearchInput] = useState(query);
+  const [globalFilter, setGlobalFilter] = useState(query);
+
   const debouncedSearch = useDebounce(() => {
+    const params = new URLSearchParams(searchParams);
+    if (searchInput) {
+      params.set('query', searchInput);
+    } else {
+      params.delete('query');
+    }
+    replace(`${pathname}?${params.toString()}`);
     setGlobalFilter(searchInput);
   });
 

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/runs/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/runs/page.tsx
@@ -20,6 +20,7 @@ import {
 import { toMaybeDate } from '@inngest/components/utils/date';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
+import SendEventButton from '@/components/Event/SendEventButton';
 import { useCancelRun } from '@/hooks/useCancelRun';
 import { useGetRun } from '@/hooks/useGetRun';
 import { useGetTraceResult } from '@/hooks/useGetTraceResult';
@@ -162,11 +163,21 @@ export default function Page() {
           </Badge>
         }
         action={
-          <RunsActionMenu
-            setAutoRefresh={() => setAutoRefresh(!autoRefresh)}
-            autoRefresh={autoRefresh}
-            intervalSeconds={pollInterval / 1000}
-          />
+          <div className="flex flex-row items-center gap-x-1">
+            <SendEventButton
+              label="Send Test Event"
+              data={JSON.stringify({
+                name: '',
+                data: {},
+                user: {},
+              })}
+            />
+            <RunsActionMenu
+              setAutoRefresh={() => setAutoRefresh(!autoRefresh)}
+              autoRefresh={autoRefresh}
+              intervalSeconds={pollInterval / 1000}
+            />
+          </div>
         }
       />
       <RunsPage

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/runs/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/runs/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Badge } from '@inngest/components/Badge/Badge';
 import { Header } from '@inngest/components/Header/Header';
+import { RunsActionMenu } from '@inngest/components/RunsPage/ActionMenu';
 import { RunsPage } from '@inngest/components/RunsPage/RunsPage';
 import { useCalculatedStartTime } from '@inngest/components/hooks/useCalculatedStartTime';
 import {
@@ -37,6 +38,7 @@ import { pathCreator } from '@/utils/pathCreator';
 const pollInterval = 2500;
 
 export default function Page() {
+  const [autoRefresh, setAutoRefresh] = useState(true);
   const [filterApp] = useStringArraySearchParam('filterApp');
   const [totalCount, setTotalCount] = useState<number>();
   const [filteredStatus] = useValidatedArraySearchParam('filterStatus', isFunctionRunStatus);
@@ -85,7 +87,7 @@ export default function Page() {
   const { data, fetchNextPage, isFetching } = useInfiniteQuery({
     queryKey: ['runs'],
     queryFn,
-    refetchInterval: pollInterval,
+    refetchInterval: autoRefresh ? pollInterval : false,
     initialPageParam: null,
     getNextPageParam: (lastPage) => {
       if (!lastPage) {
@@ -159,6 +161,13 @@ export default function Page() {
             Beta
           </Badge>
         }
+        action={
+          <RunsActionMenu
+            setAutoRefresh={() => setAutoRefresh(!autoRefresh)}
+            autoRefresh={autoRefresh}
+            intervalSeconds={pollInterval / 1000}
+          />
+        }
       />
       <RunsPage
         apps={appsRes.data?.apps || []}
@@ -174,6 +183,7 @@ export default function Page() {
         getRun={getRun}
         onScroll={onScroll}
         onScrollToTop={onScrollToTop}
+        onRefresh={fetchNextPage}
         getTraceResult={getTraceResult}
         getTrigger={getTrigger}
         rerun={rerun}

--- a/ui/packages/components/src/RunsPage/ActionMenu.tsx
+++ b/ui/packages/components/src/RunsPage/ActionMenu.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { useState } from 'react';
+import { Listbox } from '@headlessui/react';
+import { NewButton } from '@inngest/components/Button';
+import { RiSettingsLine } from '@remixicon/react';
+
+import { Switch } from '../Switch';
+
+export type RunsActionMenuProps = {
+  setAutoRefresh: () => void;
+  autoRefresh?: boolean;
+  intervalSeconds?: number;
+};
+
+export const RunsActionMenu = ({
+  autoRefresh,
+  setAutoRefresh,
+  intervalSeconds = 5,
+}: RunsActionMenuProps) => {
+  return (
+    <Listbox>
+      <Listbox.Button as="div">
+        <NewButton
+          kind="secondary"
+          appearance="outlined"
+          size="medium"
+          icon={<RiSettingsLine />}
+          className="text-sm"
+        />
+      </Listbox.Button>
+      <div className="relative">
+        <Listbox.Options className="bg-canvasBase border-subtle shadow-tooltip absolute right-1 top-1 z-50 h-[52px] w-[247px] gap-y-0.5 rounded border shadow-2xl">
+          <Listbox.Option
+            className="text-subtle mx-2 mt-2 flex cursor-pointer flex-row items-center justify-between text-[13px]"
+            value="toggleAutoRefresh"
+          >
+            <div className="flex flex-col">
+              <div className="text-basis text-sm">Auto Refresh</div>
+              <div className="text-basis text-xs">
+                Refreshes data every {intervalSeconds} seconds
+              </div>
+            </div>
+            <Switch
+              checked={autoRefresh}
+              className="data-[state=checked]:bg-primary-moderate"
+              onClick={(e) => {
+                e.stopPropagation();
+                setAutoRefresh();
+              }}
+            />
+          </Listbox.Option>
+        </Listbox.Options>
+      </div>
+    </Listbox>
+  );
+};

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useRef, type UIEventHandler } from 'react';
 import dynamic from 'next/dynamic';
-import { Button } from '@inngest/components/Button';
+import { Button, NewButton } from '@inngest/components/Button';
 import StatusFilter from '@inngest/components/Filter/StatusFilter';
 import TimeFieldFilter from '@inngest/components/Filter/TimeFieldFilter';
 import { SelectGroup, type Option } from '@inngest/components/Select/Select';
@@ -15,7 +15,7 @@ import {
   type FunctionRunStatus,
 } from '@inngest/components/types/functionRun';
 import { durationToString, parseDuration } from '@inngest/components/utils/date';
-import { RiLoopLeftLine } from '@remixicon/react';
+import { RiLoopLeftLine, RiRefreshLine } from '@remixicon/react';
 import { type VisibilityState } from '@tanstack/react-table';
 import { useLocalStorage } from 'react-use';
 
@@ -305,15 +305,6 @@ export function RunsPage({
             setColumnVisibility={setColumnVisibility}
             options={options}
           />
-
-          {onRefresh && (
-            <Button
-              label="Refresh"
-              appearance="text"
-              btnAction={onRefresh}
-              icon={<RiLoopLeftLine />}
-            />
-          )}
         </div>
       </div>
       <RunsTable
@@ -324,15 +315,28 @@ export function RunsPage({
         visibleColumns={columnVisibility}
         scope={scope}
       />
-      {isLoadingMore && <LoadingMore />}
-      {!hasMore && !isLoadingInitial && !isLoadingMore && data.length > 1 && (
-        <div className="flex flex-col items-center py-8">
+      {!hasMore && data.length > 1 && (
+        <div className="flex flex-col items-center pt-8">
           <p className="text-subtle">No additional runs found.</p>
-          <Button
+          <NewButton
             label="Back to top"
             kind="primary"
-            appearance="text"
-            btnAction={() => scrollToTop(true)}
+            appearance="ghost"
+            onClick={() => scrollToTop(true)}
+          />
+        </div>
+      )}
+      {onRefresh && (
+        <div className="flex flex-col items-center pt-2">
+          <NewButton
+            kind="secondary"
+            appearance="outlined"
+            label="Refresh runs"
+            icon={<RiRefreshLine />}
+            iconSide="left"
+            onClick={onRefresh}
+            loading={isLoadingMore || isLoadingInitial}
+            disabled={isLoadingMore || isLoadingInitial}
           />
         </div>
       )}


### PR DESCRIPTION
## Description

Replace the flickering scroll refresh ux element with a refresh button that has it's own loader. Also adds a toggle to disable auto refresh. 

Also, adds a send test events button to the runs page and syncs function search query term to the url search params. 

<img width="665" alt="Screenshot 2024-08-20 at 8 45 45 AM" src="https://github.com/user-attachments/assets/a50e472e-1e4f-41f1-96ff-a73bc8c62da4">

<img width="555" alt="Screenshot 2024-08-20 at 8 28 08 AM" src="https://github.com/user-attachments/assets/b6f80517-8618-4c63-a6b9-2d373dde0e9e">


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
