### PR TITLE
Soft delete apps and functions

### DIFF
--- a/pkg/coreapi/graph/resolvers/app_mutations.go
+++ b/pkg/coreapi/graph/resolvers/app_mutations.go
@@ -30,7 +30,7 @@ func (r *mutationResolver) CreateApp(ctx context.Context, input models.CreateApp
 	}
 
 	// Create a new app which holds the error message.
-	params := cqrs.InsertAppParams{
+	params := cqrs.UpsertAppParams{
 		ID:  uuid.NewSHA1(uuid.NameSpaceOID, []byte(input.URL)),
 		Url: input.URL,
 		Error: sql.NullString{
@@ -38,7 +38,7 @@ func (r *mutationResolver) CreateApp(ctx context.Context, input models.CreateApp
 			String: deploy.DeployErrUnreachable.Error(),
 		},
 	}
-	app, _ := r.Data.InsertApp(ctx, params)
+	app, _ := r.Data.UpsertApp(ctx, params)
 
 	if res := deploy.Ping(ctx, input.URL); res.Err != nil {
 		return app, res.Err

--- a/pkg/coreapi/graph/resolvers/app_mutations.go
+++ b/pkg/coreapi/graph/resolvers/app_mutations.go
@@ -24,11 +24,6 @@ func (r *mutationResolver) CreateApp(ctx context.Context, input models.CreateApp
 		input.URL = "http://" + input.URL
 	}
 
-	// If we already have the app, return it.
-	if app, err := r.Data.GetAppByURL(ctx, input.URL); err == nil && app != nil {
-		return app, nil
-	}
-
 	// Create a new app which holds the error message.
 	params := cqrs.UpsertAppParams{
 		ID:  uuid.NewSHA1(uuid.NameSpaceOID, []byte(input.URL)),

--- a/pkg/coreapi/graph/resolvers/app_mutations.go
+++ b/pkg/coreapi/graph/resolvers/app_mutations.go
@@ -31,7 +31,7 @@ func (r *mutationResolver) CreateApp(ctx context.Context, input models.CreateApp
 
 	// Create a new app which holds the error message.
 	params := cqrs.InsertAppParams{
-		ID:  uuid.New(),
+		ID:  uuid.NewSHA1(uuid.NameSpaceOID, []byte(input.URL)),
 		Url: input.URL,
 		Error: sql.NullString{
 			Valid:  true,

--- a/pkg/coreapi/graph/resolvers/app_mutations.go
+++ b/pkg/coreapi/graph/resolvers/app_mutations.go
@@ -13,6 +13,7 @@ import (
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/deploy"
 	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/run"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -26,7 +27,7 @@ func (r *mutationResolver) CreateApp(ctx context.Context, input models.CreateApp
 
 	// Create a new app which holds the error message.
 	params := cqrs.UpsertAppParams{
-		ID:  uuid.NewSHA1(uuid.NameSpaceOID, []byte(input.URL)),
+		ID:  inngest.DeterministicAppUUID(input.URL),
 		Url: input.URL,
 		Error: sql.NullString{
 			Valid:  true,

--- a/pkg/cqrs/apps.go
+++ b/pkg/cqrs/apps.go
@@ -42,10 +42,8 @@ type AppReader interface {
 }
 
 type AppWriter interface {
-	// InsertApp creates a new app.
-	InsertApp(ctx context.Context, arg InsertAppParams) (*App, error)
-	// UpdateApp updates an app.
-	UpdateApp(ctx context.Context, arg UpdateAppParams) (*App, error)
+	// UpsertApp creates or updates an app.
+	UpsertApp(ctx context.Context, arg UpsertAppParams) (*App, error)
 	// UpdateAppError sets an app error.  A nil string
 	// clears the app error.
 	UpdateAppError(ctx context.Context, arg UpdateAppErrorParams) (*App, error)
@@ -55,7 +53,7 @@ type AppWriter interface {
 	DeleteApp(ctx context.Context, id uuid.UUID) error
 }
 
-type InsertAppParams struct {
+type UpsertAppParams struct {
 	ID          uuid.UUID
 	Name        string
 	SdkLanguage string
@@ -66,19 +64,6 @@ type InsertAppParams struct {
 	Error       sql.NullString
 	Checksum    string
 	Url         string
-}
-
-type UpdateAppParams struct {
-	ID          uuid.UUID
-	Name        string
-	SdkLanguage string
-	SdkVersion  string
-	Framework   sql.NullString
-	Metadata    string
-	Status      string
-	Error       sql.NullString
-	Checksum    string
-	DeletedAt   *time.Time
 }
 
 type UpdateAppErrorParams struct {

--- a/pkg/cqrs/apps.go
+++ b/pkg/cqrs/apps.go
@@ -44,6 +44,8 @@ type AppReader interface {
 type AppWriter interface {
 	// InsertApp creates a new app.
 	InsertApp(ctx context.Context, arg InsertAppParams) (*App, error)
+	// UpdateApp updates an app.
+	UpdateApp(ctx context.Context, arg UpdateAppParams) (*App, error)
 	// UpdateAppError sets an app error.  A nil string
 	// clears the app error.
 	UpdateAppError(ctx context.Context, arg UpdateAppErrorParams) (*App, error)
@@ -64,6 +66,19 @@ type InsertAppParams struct {
 	Error       sql.NullString
 	Checksum    string
 	Url         string
+}
+
+type UpdateAppParams struct {
+	ID          uuid.UUID
+	Name        string
+	SdkLanguage string
+	SdkVersion  string
+	Framework   sql.NullString
+	Metadata    string
+	Status      string
+	Error       sql.NullString
+	Checksum    string
+	DeletedAt   *time.Time
 }
 
 type UpdateAppErrorParams struct {

--- a/pkg/cqrs/sqlitecqrs/cqrs.go
+++ b/pkg/cqrs/sqlitecqrs/cqrs.go
@@ -122,28 +122,16 @@ func (w wrapper) GetAllApps(ctx context.Context) ([]*cqrs.App, error) {
 }
 
 // InsertApp creates a new app.
-func (w wrapper) InsertApp(ctx context.Context, arg cqrs.InsertAppParams) (*cqrs.App, error) {
+func (w wrapper) UpsertApp(ctx context.Context, arg cqrs.UpsertAppParams) (*cqrs.App, error) {
 	// Normalize the URL before inserting into the DB.
 	arg.Url = util.NormalizeAppURL(arg.Url, forceHTTPS)
 
 	return copyWriter(
 		ctx,
-		w.q.InsertApp,
+		w.q.UpsertApp,
 		arg,
-		sqlc.InsertAppParams{},
+		sqlc.UpsertAppParams{},
 		&cqrs.App{},
-	)
-}
-
-func (w wrapper) UpdateApp(ctx context.Context, arg cqrs.UpdateAppParams) (*cqrs.App, error) {
-	return copyWriter(
-		ctx,
-		w.q.UpdateApp,
-		arg,
-		sqlc.UpdateAppParams{},
-		&cqrs.App{
-			ID: arg.ID,
-		},
 	)
 }
 
@@ -162,11 +150,11 @@ func (w wrapper) UpdateAppError(ctx context.Context, arg cqrs.UpdateAppErrorPara
 	}
 
 	app.Error = arg.Error
-	params := sqlc.InsertAppParams{}
+	params := sqlc.UpsertAppParams{}
 	_ = copier.CopyWithOption(&params, app, copier.Option{DeepCopy: true})
 
 	// Recreate the app.
-	app, err = w.q.InsertApp(ctx, params)
+	app, err = w.q.UpsertApp(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -192,10 +180,10 @@ func (w wrapper) UpdateAppURL(ctx context.Context, arg cqrs.UpdateAppURLParams) 
 		return nil, err
 	}
 	app.Url = arg.Url
-	params := sqlc.InsertAppParams{}
+	params := sqlc.UpsertAppParams{}
 	_ = copier.CopyWithOption(&params, app, copier.Option{DeepCopy: true})
 	// Recreate the app.
-	app, err = w.q.InsertApp(ctx, params)
+	app, err = w.q.UpsertApp(ctx, params)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cqrs/sqlitecqrs/cqrs.go
+++ b/pkg/cqrs/sqlitecqrs/cqrs.go
@@ -135,6 +135,18 @@ func (w wrapper) InsertApp(ctx context.Context, arg cqrs.InsertAppParams) (*cqrs
 	)
 }
 
+func (w wrapper) UpdateApp(ctx context.Context, arg cqrs.UpdateAppParams) (*cqrs.App, error) {
+	return copyWriter(
+		ctx,
+		w.q.UpdateApp,
+		arg,
+		sqlc.UpdateAppParams{},
+		&cqrs.App{
+			ID: arg.ID,
+		},
+	)
+}
+
 func (w wrapper) UpdateAppError(ctx context.Context, arg cqrs.UpdateAppErrorParams) (*cqrs.App, error) {
 	// https://duckdb.org/docs/sql/indexes.html
 	//
@@ -145,7 +157,7 @@ func (w wrapper) UpdateAppError(ctx context.Context, arg cqrs.UpdateAppErrorPara
 	if err != nil {
 		return nil, err
 	}
-	if err := w.q.HardDeleteApp(ctx, arg.ID); err != nil {
+	if err := w.q.DeleteApp(ctx, arg.ID); err != nil {
 		return nil, err
 	}
 
@@ -176,7 +188,7 @@ func (w wrapper) UpdateAppURL(ctx context.Context, arg cqrs.UpdateAppURLParams) 
 	if err != nil {
 		return nil, err
 	}
-	if err := w.q.HardDeleteApp(ctx, arg.ID); err != nil {
+	if err := w.q.DeleteApp(ctx, arg.ID); err != nil {
 		return nil, err
 	}
 	app.Url = arg.Url
@@ -194,7 +206,7 @@ func (w wrapper) UpdateAppURL(ctx context.Context, arg cqrs.UpdateAppURLParams) 
 
 // DeleteApp deletes an app
 func (w wrapper) DeleteApp(ctx context.Context, id uuid.UUID) error {
-	return w.q.HardDeleteApp(ctx, id)
+	return w.q.DeleteApp(ctx, id)
 }
 
 //

--- a/pkg/cqrs/sqlitecqrs/migrations/000002_soft_delete_functions.down.sql
+++ b/pkg/cqrs/sqlitecqrs/migrations/000002_soft_delete_functions.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE functions
+DROP COLUMN deleted_at;

--- a/pkg/cqrs/sqlitecqrs/migrations/000002_soft_delete_functions.down.sql
+++ b/pkg/cqrs/sqlitecqrs/migrations/000002_soft_delete_functions.down.sql
@@ -1,2 +1,4 @@
 ALTER TABLE functions
-DROP COLUMN deleted_at;
+DROP COLUMN archived_at;
+
+ALTER TABLE RENAME COLUMN archived_at TO deleted_at;

--- a/pkg/cqrs/sqlitecqrs/migrations/000002_soft_delete_functions.up.sql
+++ b/pkg/cqrs/sqlitecqrs/migrations/000002_soft_delete_functions.up.sql
@@ -1,3 +1,7 @@
 -- Adds new column for soft deletes
 ALTER TABLE functions
-ADD COLUMN deleted_at TIMESTAMP;
+ADD COLUMN archived_at TIMESTAMP;
+
+-- Renames existing apps.deleted_at column to archived_at
+ALTER TABLE apps
+RENAME COLUMN deleted_at TO archived_at;

--- a/pkg/cqrs/sqlitecqrs/migrations/000002_soft_delete_functions.up.sql
+++ b/pkg/cqrs/sqlitecqrs/migrations/000002_soft_delete_functions.up.sql
@@ -1,0 +1,3 @@
+-- Adds new column for soft deletes
+ALTER TABLE functions
+ADD COLUMN deleted_at TIMESTAMP;

--- a/pkg/cqrs/sqlitecqrs/sqlc/models.go
+++ b/pkg/cqrs/sqlitecqrs/sqlc/models.go
@@ -23,7 +23,7 @@ type App struct {
 	Error       sql.NullString
 	Checksum    string
 	CreatedAt   time.Time
-	DeletedAt   sql.NullTime
+	ArchivedAt  sql.NullTime
 	Url         string
 }
 
@@ -55,13 +55,13 @@ type EventBatch struct {
 }
 
 type Function struct {
-	ID        uuid.UUID
-	AppID     uuid.UUID
-	Name      string
-	Slug      string
-	Config    string
-	CreatedAt time.Time
-	DeletedAt sql.NullTime
+	ID         uuid.UUID
+	AppID      uuid.UUID
+	Name       string
+	Slug       string
+	Config     string
+	CreatedAt  time.Time
+	ArchivedAt sql.NullTime
 }
 
 type FunctionFinish struct {

--- a/pkg/cqrs/sqlitecqrs/sqlc/models.go
+++ b/pkg/cqrs/sqlitecqrs/sqlc/models.go
@@ -61,6 +61,7 @@ type Function struct {
 	Slug      string
 	Config    string
 	CreatedAt time.Time
+	DeletedAt sql.NullTime
 }
 
 type FunctionFinish struct {

--- a/pkg/cqrs/sqlitecqrs/sqlc/queries.sql
+++ b/pkg/cqrs/sqlitecqrs/sqlc/queries.sql
@@ -10,29 +10,29 @@ ON CONFLICT(id) DO UPDATE SET
     status = excluded.status,
     error = excluded.error,
     checksum = excluded.checksum,
-    deleted_at = NULL
+    archived_at = NULL
 RETURNING *;
 
 -- name: GetApp :one
 SELECT * FROM apps WHERE id = ?;
 
 -- name: GetApps :many
-SELECT * FROM apps WHERE deleted_at IS NULL;
+SELECT * FROM apps WHERE archived_at IS NULL;
 
 -- name: GetAppByChecksum :one
-SELECT * FROM apps WHERE checksum = ? AND deleted_at IS NULL LIMIT 1;
+SELECT * FROM apps WHERE checksum = ? AND archived_at IS NULL LIMIT 1;
 
 -- name: GetAppByID :one
 SELECT * FROM apps WHERE id = ? LIMIT 1;
 
 -- name: GetAppByURL :one
-SELECT * FROM apps WHERE url = ? AND deleted_at IS NULL LIMIT 1;
+SELECT * FROM apps WHERE url = ? AND archived_at IS NULL LIMIT 1;
 
 -- name: GetAllApps :many
-SELECT * FROM apps WHERE deleted_at IS NULL;
+SELECT * FROM apps WHERE archived_at IS NULL;
 
 -- name: DeleteApp :exec
-UPDATE apps SET deleted_at = datetime('now') WHERE id = ?;
+UPDATE apps SET archived_at = datetime('now') WHERE id = ?;
 
 -- name: UpdateAppURL :one
 UPDATE apps SET url = ? WHERE id = ? RETURNING *;
@@ -56,29 +56,29 @@ INSERT INTO functions
 SELECT functions.*
 FROM functions
 JOIN apps ON apps.id = functions.app_id
-WHERE functions.deleted_at IS NULL
-AND apps.deleted_at IS NULL;
+WHERE functions.archived_at IS NULL
+AND apps.archived_at IS NULL;
 
 -- name: GetAppFunctions :many
-SELECT * FROM functions WHERE app_id = ? AND deleted_at IS NULL;
+SELECT * FROM functions WHERE app_id = ? AND archived_at IS NULL;
 
 -- name: GetAppFunctionsBySlug :many
-SELECT functions.* FROM functions JOIN apps ON apps.id = functions.app_id WHERE apps.name = ? AND functions.deleted_at IS NULL;
+SELECT functions.* FROM functions JOIN apps ON apps.id = functions.app_id WHERE apps.name = ? AND functions.archived_at IS NULL;
 
 -- name: GetFunctionByID :one
 SELECT * FROM functions WHERE id = ?;
 
 -- name: GetFunctionBySlug :one
-SELECT * FROM functions WHERE slug = ? AND deleted_at IS NULL;
+SELECT * FROM functions WHERE slug = ? AND archived_at IS NULL;
 
 -- name: UpdateFunctionConfig :one
-UPDATE functions SET config = ?, deleted_AT = NULL WHERE id = ? RETURNING *;
+UPDATE functions SET config = ?, archived_at = NULL WHERE id = ? RETURNING *;
 
 -- name: DeleteFunctionsByAppID :exec
-UPDATE functions SET deleted_at = datetime('now') WHERE app_id = ?;
+UPDATE functions SET archived_at = datetime('now') WHERE app_id = ?;
 
 -- name: DeleteFunctionsByIDs :exec
-UPDATE functions SET deleted_at = datetime('now') WHERE id IN (sqlc.slice('ids'));
+UPDATE functions SET archived_at = datetime('now') WHERE id IN (sqlc.slice('ids'));
 
 --
 -- function runs

--- a/pkg/cqrs/sqlitecqrs/sqlc/queries.sql
+++ b/pkg/cqrs/sqlitecqrs/sqlc/queries.sql
@@ -72,7 +72,7 @@ SELECT * FROM functions WHERE id = ?;
 SELECT * FROM functions WHERE slug = ? AND deleted_at IS NULL;
 
 -- name: UpdateFunctionConfig :one
-UPDATE functions SET config = ? WHERE id = ? RETURNING *;
+UPDATE functions SET config = ?, deleted_AT = NULL WHERE id = ? RETURNING *;
 
 -- name: DeleteFunctionsByAppID :exec
 UPDATE functions SET deleted_at = datetime('now') WHERE app_id = ?;

--- a/pkg/cqrs/sqlitecqrs/sqlc/queries.sql
+++ b/pkg/cqrs/sqlitecqrs/sqlc/queries.sql
@@ -3,6 +3,9 @@ INSERT INTO apps
 	(id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, url) VALUES
 	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING *;
 
+-- name: UpdateApp :one
+UPDATE apps SET name = ?, sdk_language = ?, sdk_version = ?, framework = ?, metadata = ?, status = ?, error = ?, checksum = ?, deleted_at = NULL WHERE id = ? RETURNING *;
+
 -- name: GetApp :one
 SELECT * FROM apps WHERE id = ?;
 
@@ -10,22 +13,19 @@ SELECT * FROM apps WHERE id = ?;
 SELECT * FROM apps WHERE deleted_at IS NULL;
 
 -- name: GetAppByChecksum :one
-SELECT * FROM apps WHERE checksum = ? LIMIT 1;
+SELECT * FROM apps WHERE checksum = ? AND deleted_at IS NULL LIMIT 1;
 
 -- name: GetAppByID :one
 SELECT * FROM apps WHERE id = ? LIMIT 1;
 
 -- name: GetAppByURL :one
-SELECT * FROM apps WHERE url = ? LIMIT 1;
+SELECT * FROM apps WHERE url = ? AND deleted_at IS NULL LIMIT 1;
 
 -- name: GetAllApps :many
-SELECT * FROM apps;
+SELECT * FROM apps WHERE deleted_at IS NULL;
 
 -- name: DeleteApp :exec
-UPDATE apps SET deleted_at = NOW() WHERE id = ?;
-
--- name: HardDeleteApp :exec
-DELETE FROM apps WHERE id = ?;
+UPDATE apps SET deleted_at = datetime('now') WHERE id = ?;
 
 -- name: UpdateAppURL :one
 UPDATE apps SET url = ? WHERE id = ? RETURNING *;
@@ -46,30 +46,28 @@ INSERT INTO functions
 	(?, ?, ?, ?, ?, ?) RETURNING *;
 
 -- name: GetFunctions :many
-SELECT * FROM functions;
+SELECT * FROM functions WHERE deleted_at IS NULL;
 
 -- name: GetAppFunctions :many
-SELECT * FROM functions WHERE app_id = ?;
+SELECT * FROM functions WHERE app_id = ? AND deleted_at IS NULL;
 
 -- name: GetAppFunctionsBySlug :many
-SELECT functions.* FROM functions JOIN apps ON apps.id = functions.app_id WHERE apps.name = ?;
+SELECT functions.* FROM functions JOIN apps ON apps.id = functions.app_id WHERE apps.name = ? AND functions.deleted_at IS NULL;
 
 -- name: GetFunctionByID :one
 SELECT * FROM functions WHERE id = ?;
 
 -- name: GetFunctionBySlug :one
-SELECT * FROM functions WHERE slug = ?;
-
+SELECT * FROM functions WHERE slug = ? AND deleted_at IS NULL;
 
 -- name: UpdateFunctionConfig :one
 UPDATE functions SET config = ? WHERE id = ? RETURNING *;
 
 -- name: DeleteFunctionsByAppID :exec
-DELETE FROM functions WHERE app_id = ?;
+UPDATE functions SET deleted_at = datetime('now') WHERE app_id = ?;
 
 -- name: DeleteFunctionsByIDs :exec
-DELETE FROM functions WHERE id IN (sqlc.slice('ids'));
-
+UPDATE functions SET deleted_at = datetime('now') WHERE id IN (sqlc.slice('ids'));
 
 --
 -- function runs

--- a/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
+++ b/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
@@ -1381,7 +1381,7 @@ ON CONFLICT(id) DO UPDATE SET
     status = excluded.status,
     error = excluded.error,
     checksum = excluded.checksum,
-    deleted_at = NULL
+    archived_at = NULL
 RETURNING id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, deleted_at, url
 `
 

--- a/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
+++ b/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
@@ -1346,7 +1346,7 @@ func (q *Queries) UpdateAppURL(ctx context.Context, arg UpdateAppURLParams) (*Ap
 }
 
 const updateFunctionConfig = `-- name: UpdateFunctionConfig :one
-UPDATE functions SET config = ? WHERE id = ? RETURNING id, app_id, name, slug, config, created_at, deleted_at
+UPDATE functions SET config = ?, deleted_AT = NULL WHERE id = ? RETURNING id, app_id, name, slug, config, created_at, deleted_at
 `
 
 type UpdateFunctionConfigParams struct {

--- a/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
+++ b/pkg/cqrs/sqlitecqrs/sqlc/queries.sql.go
@@ -16,7 +16,7 @@ import (
 )
 
 const deleteApp = `-- name: DeleteApp :exec
-UPDATE apps SET deleted_at = datetime('now') WHERE id = ?
+UPDATE apps SET archived_at = datetime('now') WHERE id = ?
 `
 
 func (q *Queries) DeleteApp(ctx context.Context, id uuid.UUID) error {
@@ -25,7 +25,7 @@ func (q *Queries) DeleteApp(ctx context.Context, id uuid.UUID) error {
 }
 
 const deleteFunctionsByAppID = `-- name: DeleteFunctionsByAppID :exec
-UPDATE functions SET deleted_at = datetime('now') WHERE app_id = ?
+UPDATE functions SET archived_at = datetime('now') WHERE app_id = ?
 `
 
 func (q *Queries) DeleteFunctionsByAppID(ctx context.Context, appID uuid.UUID) error {
@@ -34,7 +34,7 @@ func (q *Queries) DeleteFunctionsByAppID(ctx context.Context, appID uuid.UUID) e
 }
 
 const deleteFunctionsByIDs = `-- name: DeleteFunctionsByIDs :exec
-UPDATE functions SET deleted_at = datetime('now') WHERE id IN (/*SLICE:ids*/?)
+UPDATE functions SET archived_at = datetime('now') WHERE id IN (/*SLICE:ids*/?)
 `
 
 func (q *Queries) DeleteFunctionsByIDs(ctx context.Context, ids []uuid.UUID) error {
@@ -53,7 +53,7 @@ func (q *Queries) DeleteFunctionsByIDs(ctx context.Context, ids []uuid.UUID) err
 }
 
 const getAllApps = `-- name: GetAllApps :many
-SELECT id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, deleted_at, url FROM apps WHERE deleted_at IS NULL
+SELECT id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, archived_at, url FROM apps WHERE archived_at IS NULL
 `
 
 func (q *Queries) GetAllApps(ctx context.Context) ([]*App, error) {
@@ -76,7 +76,7 @@ func (q *Queries) GetAllApps(ctx context.Context) ([]*App, error) {
 			&i.Error,
 			&i.Checksum,
 			&i.CreatedAt,
-			&i.DeletedAt,
+			&i.ArchivedAt,
 			&i.Url,
 		); err != nil {
 			return nil, err
@@ -93,7 +93,7 @@ func (q *Queries) GetAllApps(ctx context.Context) ([]*App, error) {
 }
 
 const getApp = `-- name: GetApp :one
-SELECT id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, deleted_at, url FROM apps WHERE id = ?
+SELECT id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, archived_at, url FROM apps WHERE id = ?
 `
 
 func (q *Queries) GetApp(ctx context.Context, id uuid.UUID) (*App, error) {
@@ -110,14 +110,14 @@ func (q *Queries) GetApp(ctx context.Context, id uuid.UUID) (*App, error) {
 		&i.Error,
 		&i.Checksum,
 		&i.CreatedAt,
-		&i.DeletedAt,
+		&i.ArchivedAt,
 		&i.Url,
 	)
 	return &i, err
 }
 
 const getAppByChecksum = `-- name: GetAppByChecksum :one
-SELECT id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, deleted_at, url FROM apps WHERE checksum = ? AND deleted_at IS NULL LIMIT 1
+SELECT id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, archived_at, url FROM apps WHERE checksum = ? AND archived_at IS NULL LIMIT 1
 `
 
 func (q *Queries) GetAppByChecksum(ctx context.Context, checksum string) (*App, error) {
@@ -134,14 +134,14 @@ func (q *Queries) GetAppByChecksum(ctx context.Context, checksum string) (*App, 
 		&i.Error,
 		&i.Checksum,
 		&i.CreatedAt,
-		&i.DeletedAt,
+		&i.ArchivedAt,
 		&i.Url,
 	)
 	return &i, err
 }
 
 const getAppByID = `-- name: GetAppByID :one
-SELECT id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, deleted_at, url FROM apps WHERE id = ? LIMIT 1
+SELECT id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, archived_at, url FROM apps WHERE id = ? LIMIT 1
 `
 
 func (q *Queries) GetAppByID(ctx context.Context, id uuid.UUID) (*App, error) {
@@ -158,14 +158,14 @@ func (q *Queries) GetAppByID(ctx context.Context, id uuid.UUID) (*App, error) {
 		&i.Error,
 		&i.Checksum,
 		&i.CreatedAt,
-		&i.DeletedAt,
+		&i.ArchivedAt,
 		&i.Url,
 	)
 	return &i, err
 }
 
 const getAppByURL = `-- name: GetAppByURL :one
-SELECT id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, deleted_at, url FROM apps WHERE url = ? AND deleted_at IS NULL LIMIT 1
+SELECT id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, archived_at, url FROM apps WHERE url = ? AND archived_at IS NULL LIMIT 1
 `
 
 func (q *Queries) GetAppByURL(ctx context.Context, url string) (*App, error) {
@@ -182,14 +182,14 @@ func (q *Queries) GetAppByURL(ctx context.Context, url string) (*App, error) {
 		&i.Error,
 		&i.Checksum,
 		&i.CreatedAt,
-		&i.DeletedAt,
+		&i.ArchivedAt,
 		&i.Url,
 	)
 	return &i, err
 }
 
 const getAppFunctions = `-- name: GetAppFunctions :many
-SELECT id, app_id, name, slug, config, created_at, deleted_at FROM functions WHERE app_id = ? AND deleted_at IS NULL
+SELECT id, app_id, name, slug, config, created_at, archived_at FROM functions WHERE app_id = ? AND archived_at IS NULL
 `
 
 func (q *Queries) GetAppFunctions(ctx context.Context, appID uuid.UUID) ([]*Function, error) {
@@ -208,7 +208,7 @@ func (q *Queries) GetAppFunctions(ctx context.Context, appID uuid.UUID) ([]*Func
 			&i.Slug,
 			&i.Config,
 			&i.CreatedAt,
-			&i.DeletedAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -224,7 +224,7 @@ func (q *Queries) GetAppFunctions(ctx context.Context, appID uuid.UUID) ([]*Func
 }
 
 const getAppFunctionsBySlug = `-- name: GetAppFunctionsBySlug :many
-SELECT functions.id, functions.app_id, functions.name, functions.slug, functions.config, functions.created_at, functions.deleted_at FROM functions JOIN apps ON apps.id = functions.app_id WHERE apps.name = ? AND functions.deleted_at IS NULL
+SELECT functions.id, functions.app_id, functions.name, functions.slug, functions.config, functions.created_at, functions.archived_at FROM functions JOIN apps ON apps.id = functions.app_id WHERE apps.name = ? AND functions.archived_at IS NULL
 `
 
 func (q *Queries) GetAppFunctionsBySlug(ctx context.Context, name string) ([]*Function, error) {
@@ -243,7 +243,7 @@ func (q *Queries) GetAppFunctionsBySlug(ctx context.Context, name string) ([]*Fu
 			&i.Slug,
 			&i.Config,
 			&i.CreatedAt,
-			&i.DeletedAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -259,7 +259,7 @@ func (q *Queries) GetAppFunctionsBySlug(ctx context.Context, name string) ([]*Fu
 }
 
 const getApps = `-- name: GetApps :many
-SELECT id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, deleted_at, url FROM apps WHERE deleted_at IS NULL
+SELECT id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, archived_at, url FROM apps WHERE archived_at IS NULL
 `
 
 func (q *Queries) GetApps(ctx context.Context) ([]*App, error) {
@@ -282,7 +282,7 @@ func (q *Queries) GetApps(ctx context.Context) ([]*App, error) {
 			&i.Error,
 			&i.Checksum,
 			&i.CreatedAt,
-			&i.DeletedAt,
+			&i.ArchivedAt,
 			&i.Url,
 		); err != nil {
 			return nil, err
@@ -500,7 +500,7 @@ func (q *Queries) GetEventsIDbound(ctx context.Context, arg GetEventsIDboundPara
 }
 
 const getFunctionByID = `-- name: GetFunctionByID :one
-SELECT id, app_id, name, slug, config, created_at, deleted_at FROM functions WHERE id = ?
+SELECT id, app_id, name, slug, config, created_at, archived_at FROM functions WHERE id = ?
 `
 
 func (q *Queries) GetFunctionByID(ctx context.Context, id uuid.UUID) (*Function, error) {
@@ -513,13 +513,13 @@ func (q *Queries) GetFunctionByID(ctx context.Context, id uuid.UUID) (*Function,
 		&i.Slug,
 		&i.Config,
 		&i.CreatedAt,
-		&i.DeletedAt,
+		&i.ArchivedAt,
 	)
 	return &i, err
 }
 
 const getFunctionBySlug = `-- name: GetFunctionBySlug :one
-SELECT id, app_id, name, slug, config, created_at, deleted_at FROM functions WHERE slug = ? AND deleted_at IS NULL
+SELECT id, app_id, name, slug, config, created_at, archived_at FROM functions WHERE slug = ? AND archived_at IS NULL
 `
 
 func (q *Queries) GetFunctionBySlug(ctx context.Context, slug string) (*Function, error) {
@@ -532,7 +532,7 @@ func (q *Queries) GetFunctionBySlug(ctx context.Context, slug string) (*Function
 		&i.Slug,
 		&i.Config,
 		&i.CreatedAt,
-		&i.DeletedAt,
+		&i.ArchivedAt,
 	)
 	return &i, err
 }
@@ -782,11 +782,11 @@ func (q *Queries) GetFunctionRunsTimebound(ctx context.Context, arg GetFunctionR
 }
 
 const getFunctions = `-- name: GetFunctions :many
-SELECT functions.id, functions.app_id, functions.name, functions.slug, functions.config, functions.created_at, functions.deleted_at
+SELECT functions.id, functions.app_id, functions.name, functions.slug, functions.config, functions.created_at, functions.archived_at
 FROM functions
 JOIN apps ON apps.id = functions.app_id
-WHERE functions.deleted_at IS NULL
-AND apps.deleted_at IS NULL
+WHERE functions.archived_at IS NULL
+AND apps.archived_at IS NULL
 `
 
 func (q *Queries) GetFunctions(ctx context.Context) ([]*Function, error) {
@@ -805,7 +805,7 @@ func (q *Queries) GetFunctions(ctx context.Context) ([]*Function, error) {
 			&i.Slug,
 			&i.Config,
 			&i.CreatedAt,
-			&i.DeletedAt,
+			&i.ArchivedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1023,7 +1023,7 @@ const insertFunction = `-- name: InsertFunction :one
 
 INSERT INTO functions
 	(id, app_id, name, slug, config, created_at) VALUES
-	(?, ?, ?, ?, ?, ?) RETURNING id, app_id, name, slug, config, created_at, deleted_at
+	(?, ?, ?, ?, ?, ?) RETURNING id, app_id, name, slug, config, created_at, archived_at
 `
 
 type InsertFunctionParams struct {
@@ -1055,7 +1055,7 @@ func (q *Queries) InsertFunction(ctx context.Context, arg InsertFunctionParams) 
 		&i.Slug,
 		&i.Config,
 		&i.CreatedAt,
-		&i.DeletedAt,
+		&i.ArchivedAt,
 	)
 	return &i, err
 }
@@ -1288,7 +1288,7 @@ func (q *Queries) InsertTraceRun(ctx context.Context, arg InsertTraceRunParams) 
 }
 
 const updateAppError = `-- name: UpdateAppError :one
-UPDATE apps SET error = ? WHERE id = ? RETURNING id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, deleted_at, url
+UPDATE apps SET error = ? WHERE id = ? RETURNING id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, archived_at, url
 `
 
 type UpdateAppErrorParams struct {
@@ -1310,14 +1310,14 @@ func (q *Queries) UpdateAppError(ctx context.Context, arg UpdateAppErrorParams) 
 		&i.Error,
 		&i.Checksum,
 		&i.CreatedAt,
-		&i.DeletedAt,
+		&i.ArchivedAt,
 		&i.Url,
 	)
 	return &i, err
 }
 
 const updateAppURL = `-- name: UpdateAppURL :one
-UPDATE apps SET url = ? WHERE id = ? RETURNING id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, deleted_at, url
+UPDATE apps SET url = ? WHERE id = ? RETURNING id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, archived_at, url
 `
 
 type UpdateAppURLParams struct {
@@ -1339,14 +1339,14 @@ func (q *Queries) UpdateAppURL(ctx context.Context, arg UpdateAppURLParams) (*Ap
 		&i.Error,
 		&i.Checksum,
 		&i.CreatedAt,
-		&i.DeletedAt,
+		&i.ArchivedAt,
 		&i.Url,
 	)
 	return &i, err
 }
 
 const updateFunctionConfig = `-- name: UpdateFunctionConfig :one
-UPDATE functions SET config = ?, deleted_AT = NULL WHERE id = ? RETURNING id, app_id, name, slug, config, created_at, deleted_at
+UPDATE functions SET config = ?, archived_at = NULL WHERE id = ? RETURNING id, app_id, name, slug, config, created_at, archived_at
 `
 
 type UpdateFunctionConfigParams struct {
@@ -1364,7 +1364,7 @@ func (q *Queries) UpdateFunctionConfig(ctx context.Context, arg UpdateFunctionCo
 		&i.Slug,
 		&i.Config,
 		&i.CreatedAt,
-		&i.DeletedAt,
+		&i.ArchivedAt,
 	)
 	return &i, err
 }
@@ -1382,7 +1382,7 @@ ON CONFLICT(id) DO UPDATE SET
     error = excluded.error,
     checksum = excluded.checksum,
     archived_at = NULL
-RETURNING id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, deleted_at, url
+RETURNING id, name, sdk_language, sdk_version, framework, metadata, status, error, checksum, created_at, archived_at, url
 `
 
 type UpsertAppParams struct {
@@ -1423,7 +1423,7 @@ func (q *Queries) UpsertApp(ctx context.Context, arg UpsertAppParams) (*App, err
 		&i.Error,
 		&i.Checksum,
 		&i.CreatedAt,
-		&i.DeletedAt,
+		&i.ArchivedAt,
 		&i.Url,
 	)
 	return &i, err

--- a/pkg/cqrs/sqlitecqrs/sqlc/schema.sql
+++ b/pkg/cqrs/sqlitecqrs/sqlc/schema.sql
@@ -9,7 +9,7 @@ CREATE TABLE apps (
 	error TEXT,
 	checksum VARCHAR NOT NULL,
 	created_at TIMESTAMP NOT NULL,
-	deleted_at TIMESTAMP,
+	archived_at TIMESTAMP,
 	url VARCHAR NOT NULL
 );
 
@@ -35,7 +35,7 @@ CREATE TABLE functions (
 	slug VARCHAR NOT NULL,
 	config VARCHAR NOT NULL,
 	created_at TIMESTAMP NOT NULL,
-	deleted_at TIMESTAMP
+	archived_at TIMESTAMP
 );
 
 CREATE TABLE function_runs (

--- a/pkg/cqrs/sqlitecqrs/sqlc/schema.sql
+++ b/pkg/cqrs/sqlitecqrs/sqlc/schema.sql
@@ -34,7 +34,8 @@ CREATE TABLE functions (
 	name VARCHAR NOT NULL,
 	slug VARCHAR NOT NULL,
 	config VARCHAR NOT NULL,
-	created_at TIMESTAMP NOT NULL
+	created_at TIMESTAMP NOT NULL,
+	deleted_at TIMESTAMP
 );
 
 CREATE TABLE function_runs (

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -206,7 +206,7 @@ func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (err error)
 	//
 	// We need to do this as we always create an app when entering the URL
 	// via the UI.  This is a dev-server specific quirk.
-	appID := uuid.NewSHA1(uuid.NameSpaceOID, []byte(r.URL))
+	appID := inngest.DeterministicAppUUID(r.URL)
 
 	tx, err := a.devserver.Data.WithTx(ctx)
 	if err != nil {
@@ -258,7 +258,7 @@ func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (err error)
 	// For each function,
 	for _, fn := range funcs {
 		// Create a new UUID for the function.
-		fn.ID = inngest.DeterministicUUID(*fn)
+		fn.ID = fn.DeterministicUUID()
 
 		// Mark as seen.
 		seen[fn.ID] = struct{}{}

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -38,7 +38,6 @@ import (
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/expressions"
 	"github.com/inngest/inngest/pkg/history_drivers/memory_writer"
-	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/pubsub"
 	"github.com/inngest/inngest/pkg/run"
@@ -190,7 +189,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			for _, fn := range funcs {
 				f, _ := fn.InngestFunction()
 				if f.ID == uuid.Nil {
-					f.ID = inngest.DeterministicUUID(*f)
+					f.ID = f.DeterministicUUID()
 				}
 				if f.ID == p.WorkflowID && f.Concurrency != nil && f.Concurrency.PartitionConcurrency() > 0 {
 					return p.Queue(), f.Concurrency.PartitionConcurrency()

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/cli"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/cqrs"
@@ -24,6 +23,7 @@ import (
 	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/runner"
 	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/inngest/log"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/pubsub"
@@ -227,7 +227,7 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 
 		// Create a new app which holds the error message.
 		params := cqrs.UpsertAppParams{
-			ID:  uuid.NewSHA1(uuid.NameSpaceOID, []byte(url)),
+			ID:  inngest.DeterministicAppUUID(url),
 			Url: url,
 			Error: sql.NullString{
 				Valid:  true,
@@ -628,7 +628,7 @@ func upsertErroredApp(
 		}
 	}
 
-	appID := uuid.NewSHA1(uuid.NameSpaceOID, []byte(appURL))
+	appID := inngest.DeterministicAppUUID(appURL)
 	_, err = tx.GetAppByID(ctx, appID)
 	if err == sql.ErrNoRows {
 		// App doesn't exist so create it.

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -227,7 +227,7 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 
 		// Create a new app which holds the error message.
 		params := cqrs.InsertAppParams{
-			ID:  uuid.New(),
+			ID:  uuid.NewSHA1(uuid.NameSpaceOID, []byte(url)),
 			Url: url,
 			Error: sql.NullString{
 				Valid:  true,

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -226,7 +226,7 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 		}
 
 		// Create a new app which holds the error message.
-		params := cqrs.InsertAppParams{
+		params := cqrs.UpsertAppParams{
 			ID:  uuid.NewSHA1(uuid.NameSpaceOID, []byte(url)),
 			Url: url,
 			Error: sql.NullString{
@@ -234,7 +234,7 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 				String: deploy.DeployErrUnreachable.Error(),
 			},
 		}
-		if _, err := d.Data.InsertApp(ctx, params); err != nil {
+		if _, err := d.Data.UpsertApp(ctx, params); err != nil {
 			log.From(ctx).Error().Err(err).Msg("error inserting app from scan")
 		}
 	}
@@ -632,8 +632,7 @@ func upsertErroredApp(
 	_, err = tx.GetAppByID(ctx, appID)
 	if err == sql.ErrNoRows {
 		// App doesn't exist so create it.
-
-		_, err = tx.InsertApp(ctx, cqrs.InsertAppParams{
+		_, err = tx.UpsertApp(ctx, cqrs.UpsertAppParams{
 			Error: sql.NullString{
 				String: pingError.Error(),
 				Valid:  true,

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2141,10 +2141,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, i *runInst
 		return execError{err: fmt.Errorf("failed to create expression to wait for invoked function completion: %w", err)}
 	}
 
-	pauseID := uuid.NewSHA1(
-		uuid.NameSpaceOID,
-		[]byte(i.md.ID.RunID.String()+gen.ID),
-	)
+	pauseID := inngest.DeterministicSha1UUID(i.md.ID.RunID.String() + gen.ID)
 	opcode := gen.Op.String()
 	now := time.Now()
 
@@ -2246,10 +2243,7 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, i *runInstan
 		return fmt.Errorf("unable to parse wait for event expires: %w", err)
 	}
 
-	pauseID := uuid.NewSHA1(
-		uuid.NameSpaceOID,
-		[]byte(i.md.ID.RunID.String()+gen.ID),
-	)
+	pauseID := inngest.DeterministicSha1UUID(i.md.ID.RunID.String() + gen.ID)
 
 	expr := opts.If
 	if expr != nil && strings.Contains(*expr, "event.") {

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -718,7 +718,7 @@ func Initialize(ctx context.Context, opts InitOpts) (*sv2.Metadata, error) {
 		// UUID for managing state.
 		//
 		// Using a remote API, this UUID may be a surrogate primary key.
-		fn.ID = inngest.DeterministicUUID(fn)
+		fn.ID = fn.DeterministicUUID()
 	}
 
 	// Use the custom event ID (a.k.a. event idempotency key) if it exists, else

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -95,6 +95,12 @@ type Function struct {
 	Edges []Edge `json:"edges,omitempty"`
 }
 
+// DeterministicUUID returns a deterministic V3 UUID based off of the SHA1
+// hash of the function's name.
+func (f *Function) DeterministicUUID() uuid.UUID {
+	return DeterministicSha1UUID(f.Name + f.Steps[0].URI)
+}
+
 // Throttle represents concurrency over time.
 type Throttle struct {
 	// Limit is how often the function can be called within the specified period.  The
@@ -481,10 +487,15 @@ func (f Function) AllEdges(ctx context.Context) ([]Edge, error) {
 	return edges, nil
 }
 
-// DeterministicUUID returns a deterministic V3 UUID based off of the SHA1
-// hash of the function's name.
-func DeterministicUUID(f Function) uuid.UUID {
-	str := f.Name + f.Steps[0].URI
+// DeterminsiticAppUUID returns a deterministic V3 UUID based off of the SHA1
+// hash of the app's URL.
+func DeterministicAppUUID(url string) uuid.UUID {
+	return DeterministicSha1UUID(url)
+}
+
+// DeterministicSha1UUID returns a deterministic V3 UUID based off of the SHA1
+// hash of the input string.
+func DeterministicSha1UUID(str string) uuid.UUID {
 	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(str))
 }
 

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -38,7 +38,6 @@ import (
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/expressions"
 	"github.com/inngest/inngest/pkg/history_drivers/memory_writer"
-	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/pubsub"
 	"github.com/inngest/inngest/pkg/run"
@@ -179,7 +178,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			for _, fn := range funcs {
 				f, _ := fn.InngestFunction()
 				if f.ID == uuid.Nil {
-					f.ID = inngest.DeterministicUUID(*f)
+					f.ID = f.DeterministicUUID()
 				}
 				if f.ID == p.WorkflowID && f.Concurrency != nil && f.Concurrency.PartitionConcurrency() > 0 {
 					return p.Queue(), f.Concurrency.PartitionConcurrency()


### PR DESCRIPTION
## Description

In `inngest dev` and `inngest lite`, apps and functions are currently permanently deleted when removed via the UI or synced out of existence.

This PR changes functions and apps to instead be soft-deleted, ensuring we can continue to access information for them when viewing previous runs and history from apps/functions that may no longer exist.

It also fixes an issue whereby viewing the Runs (beta) tab when an app has been removed will hang.

`devserver` seems to rely in many places on app and function IDs being deterministic, so this isn't quite as sane as it could be.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
