### PR TITLE
INN-3567: persist payload customizations through tab changes

### DIFF
--- a/ui/apps/dashboard/src/components/Events/SendEventModal.tsx
+++ b/ui/apps/dashboard/src/components/Events/SendEventModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Tab } from '@headlessui/react';
@@ -60,13 +60,12 @@ const buildTabs = ({
   sendEventAction,
   copyToClipboardAction,
 }: TabType) => {
-  const hasEventKey = Boolean(eventKey);
   return [
     {
       tabLabel: 'JSON Editor',
       tabTitle: 'Send Custom JSON',
       submitButtonLabel: 'Send Event',
-      submitButtonEnabled: hasEventKey,
+      submitButtonEnabled: Boolean(eventKey),
       submitAction: sendEventAction,
       codeLanguage: 'json',
       initialCode: JSON.stringify(payload, null, 2),
@@ -119,7 +118,8 @@ export function SendEventModal({
 
   const isBranchChild = environment.type === EnvironmentType.BranchChild;
   const envName = environment.name;
-  const tabs = useMemo(() => {
+
+  let tabs = useMemo(() => {
     return buildTabs({
       envName,
       payload,
@@ -208,17 +208,15 @@ export function SendEventModal({
         as="section"
         className="space-y-6"
         onChange={() => {
-          setTabs(
-            buildTabs({
-              envName,
-              payload,
-              eventKey,
-              sendEventURL,
-              isBranchChild,
-              copyToClipboardAction,
-              sendEventAction,
-            })
-          );
+          tabs = buildTabs({
+            envName,
+            payload,
+            eventKey,
+            sendEventURL,
+            isBranchChild,
+            copyToClipboardAction,
+            sendEventAction,
+          });
         }}
       >
         <header className="flex items-center justify-between">

--- a/ui/apps/dashboard/src/components/Events/SendEventModal.tsx
+++ b/ui/apps/dashboard/src/components/Events/SendEventModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Tab } from '@headlessui/react';

--- a/ui/apps/dashboard/src/components/Events/SendEventModal.tsx
+++ b/ui/apps/dashboard/src/components/Events/SendEventModal.tsx
@@ -119,8 +119,8 @@ export function SendEventModal({
 
   const isBranchChild = environment.type === EnvironmentType.BranchChild;
   const envName = environment.name;
-  const [tabs, setTabs] = useState(
-    buildTabs({
+  const tabs = useMemo(() => {
+    return buildTabs({
       envName,
       payload,
       eventKey,
@@ -128,8 +128,16 @@ export function SendEventModal({
       isBranchChild,
       copyToClipboardAction,
       sendEventAction,
-    })
-  );
+    });
+  }, [
+    copyToClipboardAction,
+    envName,
+    eventKey,
+    isBranchChild,
+    payload,
+    sendEventAction,
+    sendEventURL,
+  ]);
 
   //
   // serialize data to state on change so we can persist it between editor tab changes

--- a/ui/apps/dashboard/src/components/Events/SendEventModal.tsx
+++ b/ui/apps/dashboard/src/components/Events/SendEventModal.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { Tab } from '@headlessui/react';
 import { Alert } from '@inngest/components/Alert';
-import { Button, NewButton } from '@inngest/components/Button';
+import { NewButton } from '@inngest/components/Button';
 import ky from 'ky';
 import { toast } from 'sonner';
 import { type JsonValue } from 'type-fest';

--- a/ui/apps/dashboard/src/components/Events/SendEventModal.tsx
+++ b/ui/apps/dashboard/src/components/Events/SendEventModal.tsx
@@ -130,7 +130,7 @@ export function SendEventModal({
   const serializeData = (code: string) => {
     try {
       //
-      // look for string like has json in it with name and data fields
+      // look for string that has json in it with name and data fields
       const matches = code.match(
         /\{[^{}]*"name"\s*:\s*"[^"]*"[^{}]*"data"\s*:\s*\{[^{}]*\}[^{}]*\}/g
       );


### PR DESCRIPTION
## Description

~~Persist payload customizations through tab changes in the send event modal.~~

Persist payload customizations entered in the json editor to the other tabs.



## Motivation
User request.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
