### PR TITLE
Re-add `--sdk-url` flag to `inngest lite`

### DIFF
--- a/cmd/commands/internal/localconfig/devconfig.go
+++ b/cmd/commands/internal/localconfig/devconfig.go
@@ -100,6 +100,7 @@ func mapLiteFlags(cmd *cobra.Command) error {
 	var err error
 	err = errors.Join(err, viper.BindPFlag("host", cmd.Flags().Lookup("host")))
 	err = errors.Join(err, viper.BindPFlag("port", cmd.Flags().Lookup("port")))
+	err = errors.Join(err, viper.BindPFlag("urls", cmd.Flags().Lookup("sdk-url")))
 
 	return err
 }

--- a/cmd/commands/lite.go
+++ b/cmd/commands/lite.go
@@ -24,6 +24,7 @@ func NewCmdLite() *cobra.Command {
 	cmd.Flags().String("config", "", "Path to the configuration file")
 	cmd.Flags().String("host", "", "host to run the API on")
 	cmd.Flags().StringP("port", "p", "8288", "port to run the API on")
+	cmd.Flags().StringSliceP("sdk-url", "u", []string{}, "SDK URLs to load functions from")
 
 	return cmd
 }
@@ -69,6 +70,7 @@ func doLite(cmd *cobra.Command, args []string) {
 
 	opts := lite.StartOpts{
 		Config: *conf,
+		URLs:   viper.GetStringSlice("urls"),
 	}
 
 	err = lite.New(ctx, opts)

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -54,6 +54,7 @@ var redisSingleton *miniredis.Miniredis
 type StartOpts struct {
 	Config  config.Config `json:"-"`
 	RootDir string        `json:"dir"`
+	URLs    []string      `json:"urls"`
 }
 
 // Create and start a new dev server.  The dev server is used during (surprise surprise)
@@ -288,6 +289,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	ds := devserver.NewService(devserver.StartOpts{
 		Config:  opts.Config,
 		RootDir: opts.RootDir,
+		URLs:    opts.URLs,
 		Tick:    tick,
 	}, runner, dbcqrs, pb, stepLimitOverrides, stateSizeLimitOverrides, unshardedRc, hd, &persistenceInterval)
 	// embed the tracker


### PR DESCRIPTION
## Description

Re-adds `--sdk-url` flag and config option for `inngest lite`, allowing us to set some known apps up immediately.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
