### PR TITLE
Fix handling of `StepNotFound`

### DIFF
--- a/pkg/enums/opcode.go
+++ b/pkg/enums/opcode.go
@@ -14,4 +14,5 @@ const (
 	OpcodeSleep
 	OpcodeWaitForEvent
 	OpcodeInvokeFunction
+	OpcodeStepNotFound // The SDK tried to run a particular step but couldn't find it
 )

--- a/pkg/enums/opcode_enumer.go
+++ b/pkg/enums/opcode_enumer.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-const _OpcodeName = "NoneStepStepRunStepErrorStepPlannedSleepWaitForEventInvokeFunction"
+const _OpcodeName = "NoneStepStepRunStepErrorStepPlannedSleepWaitForEventInvokeFunctionStepNotFound"
 
-var _OpcodeIndex = [...]uint8{0, 4, 8, 15, 24, 35, 40, 52, 66}
+var _OpcodeIndex = [...]uint8{0, 4, 8, 15, 24, 35, 40, 52, 66, 78}
 
-const _OpcodeLowerName = "nonestepsteprunsteperrorstepplannedsleepwaitforeventinvokefunction"
+const _OpcodeLowerName = "nonestepsteprunsteperrorstepplannedsleepwaitforeventinvokefunctionstepnotfound"
 
 func (i Opcode) String() string {
 	if i < 0 || i >= Opcode(len(_OpcodeIndex)-1) {
@@ -33,9 +33,10 @@ func _OpcodeNoOp() {
 	_ = x[OpcodeSleep-(5)]
 	_ = x[OpcodeWaitForEvent-(6)]
 	_ = x[OpcodeInvokeFunction-(7)]
+	_ = x[OpcodeStepNotFound-(8)]
 }
 
-var _OpcodeValues = []Opcode{OpcodeNone, OpcodeStep, OpcodeStepRun, OpcodeStepError, OpcodeStepPlanned, OpcodeSleep, OpcodeWaitForEvent, OpcodeInvokeFunction}
+var _OpcodeValues = []Opcode{OpcodeNone, OpcodeStep, OpcodeStepRun, OpcodeStepError, OpcodeStepPlanned, OpcodeSleep, OpcodeWaitForEvent, OpcodeInvokeFunction, OpcodeStepNotFound}
 
 var _OpcodeNameToValueMap = map[string]Opcode{
 	_OpcodeName[0:4]:        OpcodeNone,
@@ -54,6 +55,8 @@ var _OpcodeNameToValueMap = map[string]Opcode{
 	_OpcodeLowerName[40:52]: OpcodeWaitForEvent,
 	_OpcodeName[52:66]:      OpcodeInvokeFunction,
 	_OpcodeLowerName[52:66]: OpcodeInvokeFunction,
+	_OpcodeName[66:78]:      OpcodeStepNotFound,
+	_OpcodeLowerName[66:78]: OpcodeStepNotFound,
 }
 
 var _OpcodeNames = []string{
@@ -65,6 +68,7 @@ var _OpcodeNames = []string{
 	_OpcodeName[35:40],
 	_OpcodeName[40:52],
 	_OpcodeName[52:66],
+	_OpcodeName[66:78],
 }
 
 // OpcodeString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
## Description

Fixes handling of the `StepNotFound` opcode, in which a discovery step should be enqueued in order to recover a run from non-determinism or changes.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

## Related

- inngest/inngest-js#701

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
