### PR TITLE
INN-3630: Skip non-default partitions in Scavenge

### DIFF
--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/inngest/inngest/pkg/enums"
 	"math/rand"
 	"runtime/debug"
 	"sync"
@@ -663,9 +662,6 @@ func (q *queue) scan(ctx context.Context) error {
 				// no longer any available workers for partition, so we can skip
 				// work
 				metrics.IncrQueueScanNoCapacityCounter(ctx, metrics.CounterOpt{PkgName: pkgName})
-				return nil
-			}
-			if p.PartitionType != int(enums.PartitionTypeDefault) {
 				return nil
 			}
 			if err := q.processPartition(ctx, &p, shard); err != nil {


### PR DESCRIPTION
## Description

> [!NOTE]  
> This PR is in preparation of key queues and must be merged and rolled out before #1518 

This skips non-default partitions in the scavenger and moves the same logic out of the queue processor and into partitionPeek to skip unknown partitions as early as possible.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
