### PR TITLE
Fix flaky trace run tests

### DIFF
--- a/tests/client/client.go
+++ b/tests/client/client.go
@@ -37,6 +37,15 @@ func (c *Client) NewRequest(method string, path string, body io.Reader) (*http.R
 }
 
 func (c *Client) MustDoGQL(ctx context.Context, input graphql.RawParams) *graphql.Response {
+	resp, err := c.DoGQL(ctx, input)
+	if err != nil {
+		c.Fatalf(err.Error())
+	}
+
+	return resp
+}
+
+func (c *Client) DoGQL(ctx context.Context, input graphql.RawParams) (*graphql.Response, error) {
 	c.Helper()
 
 	resp := c.doGQL(ctx, input)
@@ -45,10 +54,10 @@ func (c *Client) MustDoGQL(ctx context.Context, input graphql.RawParams) *graphq
 		for i := 0; i < len(resp.Errors); i++ {
 			str[i] = resp.Errors[i].Message
 		}
-		c.Fatalf("err with gql: %#v", strings.Join(str, ", "))
+		return nil, fmt.Errorf("err with gql: %#v", strings.Join(str, ", "))
 	}
 
-	return resp
+	return resp, nil
 }
 
 func (c *Client) doGQL(ctx context.Context, input graphql.RawParams) *graphql.Response {

--- a/tests/client/function_run.go
+++ b/tests/client/function_run.go
@@ -215,6 +215,8 @@ func (c *Client) WaitForRunStatus(
 	return run
 }
 
+// WaitForRunTracesWithTimeout waits for run traces with a matching status for a predefined timeout and interval.
+// Once run traces are available, they are returned and tests continue. If run traces are missing or invalid, the test will fail.
 func (c *Client) WaitForRunTracesWithTimeout(ctx context.Context, t *testing.T, runID *string, status models.FunctionStatus, timeout time.Duration, interval time.Duration) *RunV2 {
 	var traces *RunV2
 	require.NotNil(t, runID)
@@ -234,6 +236,7 @@ func (c *Client) WaitForRunTracesWithTimeout(ctx context.Context, t *testing.T, 
 	return traces
 }
 
+// WaitForRunTraces waits for run traces with a matching status for up to 10 seconds, checking every 2 seconds.
 func (c *Client) WaitForRunTraces(ctx context.Context, t *testing.T, runID *string, status models.FunctionStatus) *RunV2 {
 	return c.WaitForRunTracesWithTimeout(ctx, t, runID, status, 10*time.Second, 2*time.Second)
 }

--- a/tests/golang/basic_step_test.go
+++ b/tests/golang/basic_step_test.go
@@ -153,117 +153,110 @@ func TestFunctionSteps(t *testing.T) {
 	})
 
 	t.Run("trace run should have appropriate data", func(t *testing.T) {
-		<-time.After(3 * time.Second)
+		run := c.WaitForRunTraces(ctx, t, &runID, models.FunctionStatusCompleted)
 
-		require.Eventually(t, func() bool {
-			run := c.MustRunTraces(ctx, runID)
-			require.NotNil(t, run)
-			require.Equal(t, models.FunctionStatusCompleted.String(), run.Status)
-			require.False(t, run.IsBatch)
-			require.Nil(t, run.BatchCreatedAt)
+		require.False(t, run.IsBatch)
+		require.Nil(t, run.BatchCreatedAt)
 
-			require.NotNil(t, run.Trace)
-			require.True(t, run.Trace.IsRoot)
-			require.Equal(t, 5, len(run.Trace.ChildSpans))
-			require.Equal(t, models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
+		require.NotNil(t, run.Trace)
+		require.True(t, run.Trace.IsRoot)
+		require.Equal(t, 5, len(run.Trace.ChildSpans))
+		require.Equal(t, models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
+
+		// output test
+		require.NotNil(t, run.Trace.OutputID)
+		output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+		require.NotNil(t, output)
+		require.NotNil(t, output.Data)
+		require.Contains(t, *output.Data, "true")
+
+		rootSpanID := run.Trace.SpanID
+
+		t.Run("step 1", func(t *testing.T) {
+			one := run.Trace.ChildSpans[0]
+			assert.Equal(t, "1", one.Name)
+			assert.Equal(t, 0, one.Attempts)
+			assert.False(t, one.IsRoot)
+			assert.Equal(t, rootSpanID, one.ParentSpanID)
+			assert.Equal(t, models.StepOpRun.String(), one.StepOp)
+			assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), one.Status)
+			// output test
+			assert.NotNil(t, one.OutputID)
+			oneOutput := c.RunSpanOutput(ctx, *one.OutputID)
+			c.ExpectSpanOutput(t, "hello 1", oneOutput)
+		})
+
+		t.Run("step 2", func(t *testing.T) {
+			sec := run.Trace.ChildSpans[1]
+			assert.Equal(t, "2", sec.Name)
+			assert.Equal(t, 0, sec.Attempts)
+			assert.False(t, sec.IsRoot)
+			assert.Equal(t, rootSpanID, sec.ParentSpanID)
+			assert.Equal(t, models.StepOpRun.String(), sec.StepOp)
+			assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), sec.Status)
+			// output test
+			assert.NotNil(t, sec.OutputID)
+			secOutput := c.RunSpanOutput(ctx, *sec.OutputID)
+			c.ExpectSpanOutput(t, "test", secOutput)
+		})
+
+		// third step
+		t.Run("step sleep", func(t *testing.T) {
+			thr := run.Trace.ChildSpans[2]
+			assert.Equal(t, "delay", thr.Name)
+			assert.Equal(t, 0, thr.Attempts)
+			assert.False(t, thr.IsRoot)
+			assert.Equal(t, rootSpanID, thr.ParentSpanID)
+			assert.Equal(t, models.StepOpSleep.String(), thr.StepOp)
+			assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), thr.Status)
+			assert.NotNil(t, thr.StartedAt)
+			assert.NotNil(t, thr.EndedAt)
+			assert.Nil(t, thr.OutputID)
+			// check sleep duration
+			expectedDur := (2 * time.Second).Milliseconds()
+			assert.InDelta(t, expectedDur, thr.Duration, 200)
+		})
+
+		// forth
+		t.Run("wait step", func(t *testing.T) {
+			forth := run.Trace.ChildSpans[3]
+			assert.Equal(t, "wait1", forth.Name)
+			assert.Equal(t, 0, forth.Attempts)
+			assert.False(t, forth.IsRoot)
+			assert.Equal(t, rootSpanID, forth.ParentSpanID)
+			assert.Equal(t, models.StepOpWaitForEvent.String(), forth.StepOp)
+			assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), forth.Status)
+			assert.NotNil(t, forth.StartedAt)
+			assert.NotNil(t, forth.EndedAt)
+
+			var stepInfo models.WaitForEventStepInfo
+			byt, err := json.Marshal(forth.StepInfo)
+			assert.NoError(t, err)
+			assert.NoError(t, json.Unmarshal(byt, &stepInfo))
+
+			assert.False(t, *stepInfo.TimedOut)
+			assert.NotNil(t, stepInfo.FoundEventID)
 
 			// output test
-			require.NotNil(t, run.Trace.OutputID)
-			output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
-			require.NotNil(t, output)
-			require.NotNil(t, output.Data)
-			require.Contains(t, *output.Data, "true")
+			assert.NotNil(t, forth.OutputID)
+			forthOutput := c.RunSpanOutput(ctx, *forth.OutputID)
+			c.ExpectSpanOutput(t, "api/new.event", forthOutput)
+		})
 
-			rootSpanID := run.Trace.SpanID
+		t.Run("trigger", func(t *testing.T) {
+			// check trigger
+			trigger := c.RunTrigger(ctx, runID)
+			assert.NotNil(t, trigger)
+			assert.NotNil(t, trigger.EventName)
+			assert.Equal(t, "test/sdk-steps", *trigger.EventName)
+			assert.Equal(t, 1, len(trigger.IDs))
+			assert.False(t, trigger.Timestamp.IsZero())
+			assert.False(t, trigger.IsBatch)
+			assert.Nil(t, trigger.BatchID)
+			assert.Nil(t, trigger.Cron)
 
-			t.Run("step 1", func(t *testing.T) {
-				one := run.Trace.ChildSpans[0]
-				assert.Equal(t, "1", one.Name)
-				assert.Equal(t, 0, one.Attempts)
-				assert.False(t, one.IsRoot)
-				assert.Equal(t, rootSpanID, one.ParentSpanID)
-				assert.Equal(t, models.StepOpRun.String(), one.StepOp)
-				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), one.Status)
-				// output test
-				assert.NotNil(t, one.OutputID)
-				oneOutput := c.RunSpanOutput(ctx, *one.OutputID)
-				c.ExpectSpanOutput(t, "hello 1", oneOutput)
-			})
-
-			t.Run("step 2", func(t *testing.T) {
-				sec := run.Trace.ChildSpans[1]
-				assert.Equal(t, "2", sec.Name)
-				assert.Equal(t, 0, sec.Attempts)
-				assert.False(t, sec.IsRoot)
-				assert.Equal(t, rootSpanID, sec.ParentSpanID)
-				assert.Equal(t, models.StepOpRun.String(), sec.StepOp)
-				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), sec.Status)
-				// output test
-				assert.NotNil(t, sec.OutputID)
-				secOutput := c.RunSpanOutput(ctx, *sec.OutputID)
-				c.ExpectSpanOutput(t, "test", secOutput)
-			})
-
-			// third step
-			t.Run("step sleep", func(t *testing.T) {
-				thr := run.Trace.ChildSpans[2]
-				assert.Equal(t, "delay", thr.Name)
-				assert.Equal(t, 0, thr.Attempts)
-				assert.False(t, thr.IsRoot)
-				assert.Equal(t, rootSpanID, thr.ParentSpanID)
-				assert.Equal(t, models.StepOpSleep.String(), thr.StepOp)
-				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), thr.Status)
-				assert.NotNil(t, thr.StartedAt)
-				assert.NotNil(t, thr.EndedAt)
-				assert.Nil(t, thr.OutputID)
-				// check sleep duration
-				expectedDur := (2 * time.Second).Milliseconds()
-				assert.InDelta(t, expectedDur, thr.Duration, 200)
-			})
-
-			// forth
-			t.Run("wait step", func(t *testing.T) {
-				forth := run.Trace.ChildSpans[3]
-				assert.Equal(t, "wait1", forth.Name)
-				assert.Equal(t, 0, forth.Attempts)
-				assert.False(t, forth.IsRoot)
-				assert.Equal(t, rootSpanID, forth.ParentSpanID)
-				assert.Equal(t, models.StepOpWaitForEvent.String(), forth.StepOp)
-				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), forth.Status)
-				assert.NotNil(t, forth.StartedAt)
-				assert.NotNil(t, forth.EndedAt)
-
-				var stepInfo models.WaitForEventStepInfo
-				byt, err := json.Marshal(forth.StepInfo)
-				assert.NoError(t, err)
-				assert.NoError(t, json.Unmarshal(byt, &stepInfo))
-
-				assert.False(t, *stepInfo.TimedOut)
-				assert.NotNil(t, stepInfo.FoundEventID)
-
-				// output test
-				assert.NotNil(t, forth.OutputID)
-				forthOutput := c.RunSpanOutput(ctx, *forth.OutputID)
-				c.ExpectSpanOutput(t, "api/new.event", forthOutput)
-			})
-
-			t.Run("trigger", func(t *testing.T) {
-				// check trigger
-				trigger := c.RunTrigger(ctx, runID)
-				assert.NotNil(t, trigger)
-				assert.NotNil(t, trigger.EventName)
-				assert.Equal(t, "test/sdk-steps", *trigger.EventName)
-				assert.Equal(t, 1, len(trigger.IDs))
-				assert.False(t, trigger.Timestamp.IsZero())
-				assert.False(t, trigger.IsBatch)
-				assert.Nil(t, trigger.BatchID)
-				assert.Nil(t, trigger.Cron)
-
-				rid := ulid.MustParse(runID)
-				assert.True(t, trigger.Timestamp.Before(ulid.Time(rid.Time())))
-			})
-
-			return true
-		}, 10*time.Second, 2*time.Second)
+			rid := ulid.MustParse(runID)
+			assert.True(t, trigger.Timestamp.Before(ulid.Time(rid.Time())))
+		})
 	})
 }

--- a/tests/golang/basic_step_test.go
+++ b/tests/golang/basic_step_test.go
@@ -156,7 +156,7 @@ func TestFunctionSteps(t *testing.T) {
 		<-time.After(3 * time.Second)
 
 		require.Eventually(t, func() bool {
-			run := c.RunTraces(ctx, runID)
+			run := c.MustRunTraces(ctx, runID)
 			require.NotNil(t, run)
 			require.Equal(t, models.FunctionStatusCompleted.String(), run.Status)
 			require.False(t, run.IsBatch)

--- a/tests/golang/batch_test.go
+++ b/tests/golang/batch_test.go
@@ -76,7 +76,7 @@ func TestBatchEvents(t *testing.T) {
 		<-time.After(3 * time.Second)
 
 		require.Eventually(t, func() bool {
-			run := c.RunTraces(ctx, runID)
+			run := c.MustRunTraces(ctx, runID)
 			require.NotNil(t, run)
 			require.Equal(t, models.FunctionStatusCompleted.String(), run.Status)
 			require.True(t, run.IsBatch)

--- a/tests/golang/batch_test.go
+++ b/tests/golang/batch_test.go
@@ -73,42 +73,35 @@ func TestBatchEvents(t *testing.T) {
 	})
 
 	t.Run("trace run should have appropriate data", func(t *testing.T) {
-		<-time.After(3 * time.Second)
+		run := c.WaitForRunTraces(ctx, t, &runID, models.FunctionStatusCompleted)
 
-		require.Eventually(t, func() bool {
-			run := c.MustRunTraces(ctx, runID)
-			require.NotNil(t, run)
-			require.Equal(t, models.FunctionStatusCompleted.String(), run.Status)
-			require.True(t, run.IsBatch)
-			require.NotNil(t, run.BatchCreatedAt)
+		require.True(t, run.IsBatch)
+		require.NotNil(t, run.BatchCreatedAt)
 
-			require.NotNil(t, run.Trace)
-			require.True(t, run.Trace.IsRoot)
-			require.Equal(t, 0, len(run.Trace.ChildSpans))
-			require.Equal(t, models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
-			// output test
-			require.NotNil(t, run.Trace.OutputID)
-			output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
-			c.ExpectSpanOutput(t, "batched!!", output)
+		require.NotNil(t, run.Trace)
+		require.True(t, run.Trace.IsRoot)
+		require.Equal(t, 0, len(run.Trace.ChildSpans))
+		require.Equal(t, models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
+		// output test
+		require.NotNil(t, run.Trace.OutputID)
+		output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+		c.ExpectSpanOutput(t, "batched!!", output)
 
-			t.Run("trigger", func(t *testing.T) {
-				// check trigger
-				trigger := c.RunTrigger(ctx, runID)
-				assert.NotNil(t, trigger)
-				assert.NotNil(t, trigger.EventName)
-				assert.Equal(t, "test/batch", *trigger.EventName)
-				assert.Equal(t, 5, len(trigger.IDs))
-				assert.False(t, trigger.Timestamp.IsZero())
-				assert.True(t, trigger.IsBatch)
-				assert.NotNil(t, trigger.BatchID)
-				assert.Nil(t, trigger.Cron)
+		t.Run("trigger", func(t *testing.T) {
+			// check trigger
+			trigger := c.RunTrigger(ctx, runID)
+			assert.NotNil(t, trigger)
+			assert.NotNil(t, trigger.EventName)
+			assert.Equal(t, "test/batch", *trigger.EventName)
+			assert.Equal(t, 5, len(trigger.IDs))
+			assert.False(t, trigger.Timestamp.IsZero())
+			assert.True(t, trigger.IsBatch)
+			assert.NotNil(t, trigger.BatchID)
+			assert.Nil(t, trigger.Cron)
 
-				rid := ulid.MustParse(runID)
-				assert.True(t, trigger.Timestamp.Before(ulid.Time(rid.Time())))
-			})
-
-			return true
-		}, 10*time.Second, 2*time.Second)
+			rid := ulid.MustParse(runID)
+			assert.True(t, trigger.Timestamp.Before(ulid.Time(rid.Time())))
+		})
 	})
 }
 

--- a/tests/golang/failure_test.go
+++ b/tests/golang/failure_test.go
@@ -173,7 +173,7 @@ func TestFunctionFailureWithRetries(t *testing.T) {
 	})
 
 	t.Run("trace run should have appropriate data", func(t *testing.T) {
-		run := c.WaitForRunTracesWithTimeout(ctx, t, &runID, models.FunctionStatusFailed, 40*time.Second, 5*time.Second)
+		run := c.WaitForRunTracesWithTimeout(ctx, t, &runID, models.FunctionStatusFailed, 1*time.Minute, 5*time.Second)
 
 		require.NotNil(t, run)
 		require.NotNil(t, run.Trace)

--- a/tests/golang/failure_test.go
+++ b/tests/golang/failure_test.go
@@ -66,7 +66,7 @@ func TestFunctionFailure(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			// function run
-			run := c.RunTraces(ctx, runID)
+			run := c.MustRunTraces(ctx, runID)
 			require.NotNil(t, run)
 			require.NotNil(t, run.Trace)
 			require.True(t, run.Trace.IsRoot)
@@ -149,7 +149,7 @@ func TestFunctionFailureWithRetries(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			// function run
-			run := c.RunTraces(ctx, runID)
+			run := c.MustRunTraces(ctx, runID)
 			require.NotNil(t, run)
 			require.NotNil(t, run.Trace)
 			require.True(t, run.Trace.IsRoot)
@@ -192,7 +192,7 @@ func TestFunctionFailureWithRetries(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			// function run
-			run := c.RunTraces(ctx, runID)
+			run := c.MustRunTraces(ctx, runID)
 			require.NotNil(t, run)
 			require.NotNil(t, run.Trace)
 			require.True(t, run.Trace.IsRoot)

--- a/tests/golang/invoke_test.go
+++ b/tests/golang/invoke_test.go
@@ -69,15 +69,16 @@ func TestInvoke(t *testing.T) {
 	r.NoError(err)
 
 	t.Run("trace run should have appropriate data", func(t *testing.T) {
+		r := require.New(t)
 		run := c.WaitForRunTraces(ctx, t, &runID, models.FunctionStatusCompleted)
 
-		require.NotNil(t, run.Trace)
-		require.Equal(t, 1, len(run.Trace.ChildSpans))
-		require.True(t, run.Trace.IsRoot)
-		require.Equal(t, models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
+		r.NotNil(run.Trace)
+		r.Equal(1, len(run.Trace.ChildSpans))
+		r.True(run.Trace.IsRoot)
+		r.Equal(models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
 
 		// output test
-		require.NotNil(t, run.Trace.OutputID)
+		r.NotNil(run.Trace.OutputID)
 		output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
 		c.ExpectSpanOutput(t, "success", output)
 

--- a/tests/golang/invoke_test.go
+++ b/tests/golang/invoke_test.go
@@ -43,7 +43,6 @@ func TestInvoke(t *testing.T) {
 	// This function will invoke the other function
 	runID := ""
 	evtName := "invoke-me"
-	var done bool
 	mainFn := inngestgo.CreateFunction(
 		inngestgo.FunctionOpts{
 			Name: "main-fn",
@@ -58,8 +57,6 @@ func TestInvoke(t *testing.T) {
 				step.InvokeOpts{FunctionId: appID + "-" + invokedFnName},
 			)
 
-			done = true
-
 			return "success", nil
 		},
 	)
@@ -72,73 +69,45 @@ func TestInvoke(t *testing.T) {
 	r.NoError(err)
 
 	t.Run("trace run should have appropriate data", func(t *testing.T) {
-		// Wait for function run to complete
-		require.Eventually(t, func() bool {
-			return done
-		}, time.Second*4, time.Second)
+		run := c.WaitForRunTraces(ctx, t, &runID, models.FunctionStatusCompleted)
 
-		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			assert.NotEmpty(ct, runID)
-			run, err := c.RunTraces(ctx, runID)
-			assert.NoError(ct, err)
-			assert.NotNil(ct, run)
+		require.NotNil(t, run.Trace)
+		require.Equal(t, 1, len(run.Trace.ChildSpans))
+		require.True(t, run.Trace.IsRoot)
+		require.Equal(t, models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
 
-			// NOTE: require tracks the error above but does not always exit immediately,
-			// so we force the function to return with an internal error to prevent panics in the
-			// next assertion.
-			// We cannot use require.NotNil as this will cause an uncaught panic (see https://github.com/stretchr/testify/issues/1457)
-			if run == nil {
-				return
-			}
+		// output test
+		require.NotNil(t, run.Trace.OutputID)
+		output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+		c.ExpectSpanOutput(t, "success", output)
 
-			assert.Equal(ct, models.FunctionStatusCompleted.String(), run.Status)
-			assert.NotNil(ct, run.Trace)
-			// same as above: exit early and retry without panic
-			if run.Trace == nil {
-				return
-			}
+		rootSpanID := run.Trace.SpanID
 
-			assert.Equal(ct, 1, len(run.Trace.ChildSpans))
-			assert.True(ct, run.Trace.IsRoot)
-			assert.Equal(ct, models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
+		t.Run("invoke", func(t *testing.T) {
+			as := assert.New(t)
+			invoke := run.Trace.ChildSpans[0]
+			as.Equal("invoke", invoke.Name)
+			as.Equal(0, invoke.Attempts)
+			as.Equal(0, len(invoke.ChildSpans))
+			as.False(invoke.IsRoot)
+			as.Equal(rootSpanID, invoke.ParentSpanID)
+			as.Equal(models.StepOpInvoke.String(), invoke.StepOp)
 
 			// output test
-			assert.NotNil(ct, run.Trace.OutputID)
-			// same as above: exit early and retry without panic
-			if run.Trace.OutputID == nil {
-				return
-			}
+			as.NotNil(invoke.OutputID)
+			invokeOutput := c.RunSpanOutput(ctx, *invoke.OutputID)
+			c.ExpectSpanOutput(t, "invoked!", invokeOutput)
 
-			output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
-			c.ExpectSpanOutput(ct, "success", output)
+			var stepInfo models.InvokeStepInfo
+			byt, err := json.Marshal(invoke.StepInfo)
+			as.NoError(err)
+			as.NoError(json.Unmarshal(byt, &stepInfo))
 
-			rootSpanID := run.Trace.SpanID
+			as.False(*stepInfo.TimedOut)
+			as.NotNil(stepInfo.ReturnEventID)
+			as.NotNil(stepInfo.RunID)
+		})
 
-			t.Run("invoke", func(t *testing.T) {
-				as := assert.New(t)
-				invoke := run.Trace.ChildSpans[0]
-				as.Equal("invoke", invoke.Name)
-				as.Equal(0, invoke.Attempts)
-				as.Equal(0, len(invoke.ChildSpans))
-				as.False(invoke.IsRoot)
-				as.Equal(rootSpanID, invoke.ParentSpanID)
-				as.Equal(models.StepOpInvoke.String(), invoke.StepOp)
-
-				// output test
-				as.NotNil(invoke.OutputID)
-				invokeOutput := c.RunSpanOutput(ctx, *invoke.OutputID)
-				c.ExpectSpanOutput(ct, "invoked!", invokeOutput)
-
-				var stepInfo models.InvokeStepInfo
-				byt, err := json.Marshal(invoke.StepInfo)
-				as.NoError(err)
-				as.NoError(json.Unmarshal(byt, &stepInfo))
-
-				as.False(*stepInfo.TimedOut)
-				as.NotNil(stepInfo.ReturnEventID)
-				as.NotNil(stepInfo.RunID)
-			})
-		}, 10*time.Second, 2*time.Second)
 	})
 }
 
@@ -200,94 +169,84 @@ func TestInvokeGroup(t *testing.T) {
 	r.NoError(err)
 
 	t.Run("in progress", func(t *testing.T) {
-		<-time.After(3 * time.Second)
+		run := c.WaitForRunTraces(ctx, t, &runID, models.FunctionStatusRunning)
+		r := require.New(t)
 
-		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			r := require.New(ct)
+		r.Nil(run.EndedAt)
+		r.Nil(run.Trace.EndedAt)
+		r.NotNil(run.Trace)
+		r.Equal(1, len(run.Trace.ChildSpans))
+		r.Equal(models.RunTraceSpanStatusRunning.String(), run.Trace.Status)
+		r.Nil(run.Trace.OutputID)
 
-			run := c.MustRunTraces(ctx, runID)
-			r.Nil(run.EndedAt)
-			r.Nil(run.Trace.EndedAt)
-			r.NotNil(models.FunctionStatusRunning.String(), run.Status)
-			r.NotNil(run.Trace)
-			r.Equal(1, len(run.Trace.ChildSpans))
-			r.Equal(models.RunTraceSpanStatusRunning.String(), run.Trace.Status)
-			r.Nil(run.Trace.OutputID)
+		rootSpanID := run.Trace.SpanID
 
-			rootSpanID := run.Trace.SpanID
+		as := assert.New(t)
 
-			as := assert.New(ct)
+		span := run.Trace.ChildSpans[0]
+		as.Equal(consts.OtelExecPlaceholder, span.Name)
+		as.Equal(0, span.Attempts)
+		as.Equal(rootSpanID, span.ParentSpanID)
+		as.False(span.IsRoot)
+		as.Equal(2, len(span.ChildSpans)) // include queued retry span
+		as.Equal(models.RunTraceSpanStatusRunning.String(), span.Status)
+		as.Equal("", span.StepOp)
+		as.Nil(span.OutputID)
 
-			span := run.Trace.ChildSpans[0]
-			as.Equal(consts.OtelExecPlaceholder, span.Name)
-			as.Equal(0, span.Attempts)
-			as.Equal(rootSpanID, span.ParentSpanID)
-			as.False(span.IsRoot)
-			as.Equal(2, len(span.ChildSpans)) // include queued retry span
-			as.Equal(models.RunTraceSpanStatusRunning.String(), span.Status)
-			as.Equal("", span.StepOp)
-			as.Nil(span.OutputID)
+		t.Run("failed", func(t *testing.T) {
+			exec := span.ChildSpans[0]
+			as.Equal("Attempt 0", exec.Name)
+			as.Equal(models.RunTraceSpanStatusFailed.String(), exec.Status)
+			as.NotNil(exec.OutputID)
 
-			t.Run("failed", func(t *testing.T) {
-				exec := span.ChildSpans[0]
-				as.Equal("Attempt 0", exec.Name)
-				as.Equal(models.RunTraceSpanStatusFailed.String(), exec.Status)
-				as.NotNil(exec.OutputID)
-
-				execOutput := c.RunSpanOutput(ctx, *exec.OutputID)
-				as.NotNil(t, execOutput)
-				c.ExpectSpanErrorOutput(ct, "", "initial error", execOutput)
-			})
-		}, 10*time.Second, 2*time.Second)
+			execOutput := c.RunSpanOutput(ctx, *exec.OutputID)
+			as.NotNil(t, execOutput)
+			c.ExpectSpanErrorOutput(t, "", "initial error", execOutput)
+		})
 	})
 
 	t.Run("trace run should have appropriate data", func(t *testing.T) {
-		<-time.After(3 * time.Second)
+		run := c.WaitForRunTraces(ctx, t, &runID, models.FunctionStatusCompleted)
 
-		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			r := require.New(ct)
-			as := assert.New(ct)
+		as := assert.New(t)
 
-			run := c.MustRunTraces(ctx, runID)
-			r.NotNil(run)
-			r.Equal(models.FunctionStatusCompleted.String(), run.Status)
-			r.NotNil(run.Trace)
-			r.Equal(1, len(run.Trace.ChildSpans))
-			r.True(run.Trace.IsRoot)
-			r.Equal(models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
+		r.Equal(models.FunctionStatusCompleted.String(), run.Status)
+		r.NotNil(run.Trace)
+		r.Equal(1, len(run.Trace.ChildSpans))
+		r.True(run.Trace.IsRoot)
+		r.Equal(models.RunTraceSpanStatusCompleted.String(), run.Trace.Status)
+
+		// output test
+		r.NotNil(run.Trace.OutputID)
+		output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+		c.ExpectSpanOutput(t, "success", output)
+
+		rootSpanID := run.Trace.SpanID
+
+		t.Run("invoke", func(t *testing.T) {
+			invoke := run.Trace.ChildSpans[0]
+			as.Equal("invoke", invoke.Name)
+			as.Equal(0, invoke.Attempts)
+			as.False(invoke.IsRoot)
+			as.Equal(rootSpanID, invoke.ParentSpanID)
+			as.Equal(2, len(invoke.ChildSpans))
+			as.Equal(models.StepOpInvoke.String(), invoke.StepOp)
+			as.NotNil(invoke.EndedAt)
 
 			// output test
-			r.NotNil(run.Trace.OutputID)
-			output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
-			c.ExpectSpanOutput(ct, "success", output)
+			as.NotNil(invoke.OutputID)
+			invokeOutput := c.RunSpanOutput(ctx, *invoke.OutputID)
+			c.ExpectSpanOutput(t, "invoked!", invokeOutput)
 
-			rootSpanID := run.Trace.SpanID
+			var stepInfo models.InvokeStepInfo
+			byt, err := json.Marshal(invoke.StepInfo)
+			as.NoError(err)
+			as.NoError(json.Unmarshal(byt, &stepInfo))
 
-			t.Run("invoke", func(t *testing.T) {
-				invoke := run.Trace.ChildSpans[0]
-				as.Equal("invoke", invoke.Name)
-				as.Equal(0, invoke.Attempts)
-				as.False(invoke.IsRoot)
-				as.Equal(rootSpanID, invoke.ParentSpanID)
-				as.Equal(2, len(invoke.ChildSpans))
-				as.Equal(models.StepOpInvoke.String(), invoke.StepOp)
-				as.NotNil(invoke.EndedAt)
-
-				// output test
-				as.NotNil(invoke.OutputID)
-				invokeOutput := c.RunSpanOutput(ctx, *invoke.OutputID)
-				c.ExpectSpanOutput(ct, "invoked!", invokeOutput)
-
-				var stepInfo models.InvokeStepInfo
-				byt, err := json.Marshal(invoke.StepInfo)
-				as.NoError(err)
-				as.NoError(json.Unmarshal(byt, &stepInfo))
-
-				as.False(*stepInfo.TimedOut)
-				as.NotNil(stepInfo.ReturnEventID)
-				as.NotNil(stepInfo.RunID)
-			})
-		}, 10*time.Second, 2*time.Second)
+			as.False(*stepInfo.TimedOut)
+			as.NotNil(stepInfo.ReturnEventID)
+			as.NotNil(stepInfo.RunID)
+		})
 	})
 }
 
@@ -346,51 +305,45 @@ func TestInvokeTimeout(t *testing.T) {
 	c.WaitForRunStatus(ctx, t, "FAILED", &runID)
 
 	t.Run("trace run should have appropriate data", func(t *testing.T) {
-		<-time.After(3 * time.Second)
 		errMsg := "Timed out waiting for invoked function to complete"
+		run := c.WaitForRunTraces(ctx, t, &runID, models.FunctionStatusFailed)
 
-		require.Eventually(t, func() bool {
-			run := c.MustRunTraces(ctx, runID)
-			require.NotNil(t, run)
-			require.Equal(t, models.FunctionStatusFailed.String(), run.Status)
-			require.NotNil(t, run.Trace)
-			require.True(t, run.Trace.IsRoot)
-			require.Equal(t, models.RunTraceSpanStatusFailed.String(), run.Trace.Status)
+		require.NotNil(t, run.Trace)
+		require.True(t, run.Trace.IsRoot)
+		require.Equal(t, models.RunTraceSpanStatusFailed.String(), run.Trace.Status)
+
+		// output test
+		require.NotNil(t, run.Trace.OutputID)
+		output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+		require.NotNil(t, output)
+		// c.ExpectSpanErrorOutput(t, errMsg, "", output)
+
+		rootSpanID := run.Trace.SpanID
+
+		t.Run("invoke", func(t *testing.T) {
+			invoke := run.Trace.ChildSpans[0]
+			assert.Equal(t, "invoke", invoke.Name)
+			assert.Equal(t, 0, invoke.Attempts)
+			assert.False(t, invoke.IsRoot)
+			assert.Equal(t, rootSpanID, invoke.ParentSpanID)
+			assert.Equal(t, models.StepOpInvoke.String(), invoke.StepOp)
+			assert.NotNil(t, invoke.EndedAt)
 
 			// output test
-			require.NotNil(t, run.Trace.OutputID)
-			output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
-			require.NotNil(t, output)
-			// c.ExpectSpanErrorOutput(t, errMsg, "", output)
+			assert.NotNil(t, invoke.OutputID)
+			invokeOutput := c.RunSpanOutput(ctx, *invoke.OutputID)
+			c.ExpectSpanErrorOutput(t, errMsg, "", invokeOutput)
 
-			rootSpanID := run.Trace.SpanID
+			var stepInfo models.InvokeStepInfo
+			byt, err := json.Marshal(invoke.StepInfo)
+			assert.NoError(t, err)
+			assert.NoError(t, json.Unmarshal(byt, &stepInfo))
 
-			t.Run("invoke", func(t *testing.T) {
-				invoke := run.Trace.ChildSpans[0]
-				assert.Equal(t, "invoke", invoke.Name)
-				assert.Equal(t, 0, invoke.Attempts)
-				assert.False(t, invoke.IsRoot)
-				assert.Equal(t, rootSpanID, invoke.ParentSpanID)
-				assert.Equal(t, models.StepOpInvoke.String(), invoke.StepOp)
-				assert.NotNil(t, invoke.EndedAt)
+			assert.True(t, *stepInfo.TimedOut)
+			assert.Nil(t, stepInfo.ReturnEventID)
+			assert.Nil(t, stepInfo.RunID)
+		})
 
-				// output test
-				assert.NotNil(t, invoke.OutputID)
-				invokeOutput := c.RunSpanOutput(ctx, *invoke.OutputID)
-				c.ExpectSpanErrorOutput(t, errMsg, "", invokeOutput)
-
-				var stepInfo models.InvokeStepInfo
-				byt, err := json.Marshal(invoke.StepInfo)
-				assert.NoError(t, err)
-				assert.NoError(t, json.Unmarshal(byt, &stepInfo))
-
-				assert.True(t, *stepInfo.TimedOut)
-				assert.Nil(t, stepInfo.ReturnEventID)
-				assert.Nil(t, stepInfo.RunID)
-			})
-
-			return true
-		}, 10*time.Second, 2*time.Second)
 	})
 }
 

--- a/tests/golang/retry_test.go
+++ b/tests/golang/retry_test.go
@@ -103,7 +103,7 @@ func TestRetry(t *testing.T) {
 		<-time.After(3 * time.Second)
 
 		require.Eventually(t, func() bool {
-			run := c.RunTraces(ctx, runID)
+			run := c.MustRunTraces(ctx, runID)
 			require.NotNil(t, run)
 			require.NotNil(t, run.Trace)
 			require.True(t, run.Trace.IsRoot)

--- a/tests/golang/sleep_test.go
+++ b/tests/golang/sleep_test.go
@@ -95,7 +95,7 @@ func TestSleep(t *testing.T) {
 
 		require.Eventually(t, func() bool {
 			require.EqualValues(t, 1, atomic.LoadInt32(&completed))
-			run := c.RunTraces(ctx, runID)
+			run := c.MustRunTraces(ctx, runID)
 			require.NotNil(t, run)
 			require.NotNil(t, run.Trace)
 			require.True(t, run.Trace.IsRoot)

--- a/tests/golang/sleep_test.go
+++ b/tests/golang/sleep_test.go
@@ -91,53 +91,47 @@ func TestSleep(t *testing.T) {
 	})
 
 	t.Run("complete", func(t *testing.T) {
-		<-time.After(4 * time.Second)
+		run := c.WaitForRunTracesWithTimeout(ctx, t, &runID, models.FunctionStatusCompleted, 9*time.Second, 3*time.Second)
+		require.EqualValues(t, 1, atomic.LoadInt32(&completed))
 
-		require.Eventually(t, func() bool {
-			require.EqualValues(t, 1, atomic.LoadInt32(&completed))
-			run := c.MustRunTraces(ctx, runID)
-			require.NotNil(t, run)
-			require.NotNil(t, run.Trace)
-			require.True(t, run.Trace.IsRoot)
-			require.Equal(t, 3, len(run.Trace.ChildSpans))
-			require.NotEqual(t, models.RunTraceSpanStatusRunning.String(), run.Trace.Status)
+		require.NotNil(t, run.Trace)
+		require.True(t, run.Trace.IsRoot)
+		require.Equal(t, 3, len(run.Trace.ChildSpans))
+		require.NotEqual(t, models.RunTraceSpanStatusRunning.String(), run.Trace.Status)
 
-			// output test
-			require.NotNil(t, run.Trace.OutputID)
-			output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
-			require.NotNil(t, output)
-			c.ExpectSpanOutput(t, "true", output)
+		// output test
+		require.NotNil(t, run.Trace.OutputID)
+		output := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+		require.NotNil(t, output)
+		c.ExpectSpanOutput(t, "true", output)
 
-			t.Run("sleep", func(t *testing.T) {
-				sleep := run.Trace.ChildSpans[0]
-				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), sleep.Status)
-				assert.Equal(t, 2, len(sleep.ChildSpans))
-				assert.Equal(t, "nap", sleep.Name)
-				assert.Equal(t, models.StepOpSleep.String(), sleep.StepOp)
-				assert.Nil(t, sleep.OutputID)
+		t.Run("sleep", func(t *testing.T) {
+			sleep := run.Trace.ChildSpans[0]
+			assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), sleep.Status)
+			assert.Equal(t, 2, len(sleep.ChildSpans))
+			assert.Equal(t, "nap", sleep.Name)
+			assert.Equal(t, models.StepOpSleep.String(), sleep.StepOp)
+			assert.Nil(t, sleep.OutputID)
 
-				// verify step info
-				info := &models.SleepStepInfo{}
-				byt, err := json.Marshal(sleep.StepInfo)
-				assert.NoError(t, err)
-				assert.NoError(t, json.Unmarshal(byt, info))
+			// verify step info
+			info := &models.SleepStepInfo{}
+			byt, err := json.Marshal(sleep.StepInfo)
+			assert.NoError(t, err)
+			assert.NoError(t, json.Unmarshal(byt, info))
 
-				assert.True(t, time.Now().After(info.SleepUntil))
+			assert.True(t, time.Now().After(info.SleepUntil))
 
-				// first is the failed attempt
-				t.Run("failed execution", func(t *testing.T) {
-					exec := sleep.ChildSpans[0]
-					assert.Equal(t, models.RunTraceSpanStatusFailed.String(), exec.Status)
-					assert.Equal(t, "Attempt 0", exec.Name)
-					assert.NotNil(t, exec.OutputID)
+			// first is the failed attempt
+			t.Run("failed execution", func(t *testing.T) {
+				exec := sleep.ChildSpans[0]
+				assert.Equal(t, models.RunTraceSpanStatusFailed.String(), exec.Status)
+				assert.Equal(t, "Attempt 0", exec.Name)
+				assert.NotNil(t, exec.OutputID)
 
-					execOutput := c.RunSpanOutput(ctx, *exec.OutputID)
-					assert.NotNil(t, execOutput)
-					c.ExpectSpanErrorOutput(t, "", "throwing an initial error", execOutput)
-				})
+				execOutput := c.RunSpanOutput(ctx, *exec.OutputID)
+				assert.NotNil(t, execOutput)
+				c.ExpectSpanErrorOutput(t, "", "throwing an initial error", execOutput)
 			})
-
-			return true
-		}, 9*time.Second, 3*time.Second)
+		})
 	})
 }

--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -66,7 +66,7 @@ func TestWait(t *testing.T) {
 		<-time.After(5 * time.Second)
 
 		require.Eventually(t, func() bool {
-			run := c.RunTraces(ctx, runID)
+			run := c.MustRunTraces(ctx, runID)
 			require.NotNil(t, models.FunctionStatusRunning.String(), run.Status)
 			require.NotNil(t, run.Trace)
 			require.Equal(t, 1, len(run.Trace.ChildSpans))
@@ -110,7 +110,7 @@ func TestWait(t *testing.T) {
 		<-time.After(5 * time.Second)
 
 		require.Eventually(t, func() bool {
-			run := c.RunTraces(ctx, runID)
+			run := c.MustRunTraces(ctx, runID)
 			require.NotNil(t, run)
 			require.Equal(t, models.FunctionStatusCompleted.String(), run.Status)
 			require.NotNil(t, run.Trace)
@@ -209,7 +209,7 @@ func TestWaitGroup(t *testing.T) {
 		<-time.After(3 * time.Second)
 
 		require.Eventually(t, func() bool {
-			run := c.RunTraces(ctx, runID)
+			run := c.MustRunTraces(ctx, runID)
 			require.NotNil(t, models.FunctionStatusRunning.String(), run.Status)
 			require.NotNil(t, run.Trace)
 			require.Equal(t, 1, len(run.Trace.ChildSpans))
@@ -252,7 +252,7 @@ func TestWaitGroup(t *testing.T) {
 		<-time.After(5 * time.Second)
 
 		require.Eventually(t, func() bool {
-			run := c.RunTraces(ctx, runID)
+			run := c.MustRunTraces(ctx, runID)
 			require.NotNil(t, run)
 			require.Equal(t, models.FunctionStatusCompleted.String(), run.Status)
 			require.NotNil(t, run.Trace)

--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -63,7 +63,7 @@ func TestWait(t *testing.T) {
 	r.NoError(err)
 
 	t.Run("in progress wait", func(t *testing.T) {
-		run := c.WaitForRunTracesWithTimeout(ctx, t, &runID, models.FunctionStatusRunning, 5*time.Second, 1*time.Second)
+		run := c.WaitForRunTracesWithTimeout(ctx, t, &runID, models.FunctionStatusRunning, 10*time.Second, 1*time.Second)
 
 		require.NotNil(t, run.Trace)
 		require.Equal(t, 1, len(run.Trace.ChildSpans))

--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -63,7 +63,7 @@ func TestWait(t *testing.T) {
 	r.NoError(err)
 
 	t.Run("in progress wait", func(t *testing.T) {
-		run := c.WaitForRunTracesWithTimeout(ctx, t, &runID, models.FunctionStatusRunning, 10*time.Second, 1*time.Second)
+		run := c.WaitForRunTraces(ctx, t, &runID, models.FunctionStatusRunning)
 
 		require.NotNil(t, run.Trace)
 		require.Equal(t, 1, len(run.Trace.ChildSpans))


### PR DESCRIPTION
This refactors some assertion logic in [`TestInvoke/trace run should have appropriate data`](https://github.com/inngest/inngest/blob/ee8e50d0af2daad954694155ec6e89c89973543a/tests/golang/invoke_test.go#L74).

Previously, we used `require.EventuallyWithT` together with fail-fast assertions such as `require.NotNil` to retry until trace data was available or up to 10 seconds. Unfortunately, [`t.FailNow()`](https://github.com/inngest/inngest/blob/0eafe3138809d3de47b0bf6bf49f1b0491200a58/vendor/github.com/stretchr/testify/assert/assertions.go#L1923) achieves fast failures by causes panics, which are not handled by `require.EventuallyWithT`.

This occasionally breaks tests, if trace data does not become available within the awaited 3-4 seconds (`<-time.After(3 * time.Second)`).

To fix the flakiness, I've replaced fail-fast requires with a single wait loop and added early returns on nil checks, so we don't run into panics. The assertion either fails after the timeout elapses or returns valid run traces. This way, we keep all existing assertions while avoiding panics either due to missing data or overly aggressive assertions.

### Related issues on the web
- https://github.com/stretchr/testify/issues/1457
- https://github.com/superfly/flyctl/pull/2760

## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
