### PR TITLE
Reduce batch processor timeout for dev server

### DIFF
--- a/pkg/cqrs/sqlitecqrs/cqrs.go
+++ b/pkg/cqrs/sqlitecqrs/cqrs.go
@@ -967,7 +967,6 @@ func (w wrapper) GetSpanOutput(ctx context.Context, opts cqrs.SpanIdentifier) (*
 		return nil, fmt.Errorf("error retrieving spans for output: %w", err)
 	}
 
-	var output *cqrs.SpanOutput
 	for _, s := range spans {
 		var evts []cqrs.SpanEvent
 		err := json.Unmarshal(s.Events, &evts)
@@ -985,21 +984,19 @@ func (w wrapper) GetSpanOutput(ctx context.Context, opts cqrs.SpanIdentifier) (*
 					isError = true
 				}
 
-				output = &cqrs.SpanOutput{
+				return &cqrs.SpanOutput{
 					Data:             []byte(evt.Name),
 					Timestamp:        evt.Timestamp,
 					Attributes:       evt.Attributes,
 					IsError:          isError,
 					IsFunctionOutput: isFnOutput,
 					IsStepOutput:     isStepOutput,
-				}
-
-				break
+				}, nil
 			}
 		}
 	}
 
-	return output, nil
+	return nil, fmt.Errorf("no output found")
 }
 
 type runsQueryBuilder struct {

--- a/pkg/telemetry/trace/tracer.go
+++ b/pkg/telemetry/trace/tracer.go
@@ -291,7 +291,7 @@ func newOTLPHTTPTraceProvider(ctx context.Context, opts TracerOpts) (Tracer, err
 		return nil, fmt.Errorf("error create otlp http trace client: %w", err)
 	}
 
-	sp := trace.NewBatchSpanProcessor(exp)
+	sp := trace.NewBatchSpanProcessor(exp, trace.WithBatchTimeout(100*time.Millisecond))
 	tp := trace.NewTracerProvider(
 		trace.WithSpanProcessor(sp),
 		trace.WithResource(resource.NewWithAttributes(

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/runs/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/runs/page.tsx
@@ -36,7 +36,7 @@ import {
 } from '@/store/generated';
 import { pathCreator } from '@/utils/pathCreator';
 
-const pollInterval = 2500;
+const pollInterval = 400;
 
 export default function Page() {
   const [autoRefresh, setAutoRefresh] = useState(true);


### PR DESCRIPTION
## Description

Batch processor has a default timeout of ~5s.
This is too slow for the dev server experience so lowering it to 100ms.

Also reducing the UI polling to 400ms.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
