### PR TITLE
Fix button flicker when polling

### DIFF
--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -243,6 +243,11 @@ export function RunsPage({
     return out;
   }, [columns]);
 
+  // Do not disable or show the button as loading if the poll interval is less than 1 second
+  // Changing state too quickly can cause the button to flicker
+  const disableRefreshButton =
+    pollInterval && pollInterval < 1000 ? isLoadingInitial : isLoadingMore || isLoadingInitial;
+
   return (
     <main
       className="bg-canvasBase text-basis h-full min-h-0 overflow-y-auto"
@@ -335,18 +340,8 @@ export function RunsPage({
             icon={<RiRefreshLine />}
             iconSide="left"
             onClick={onRefresh}
-            // Do not disable or show the button as loading if the poll interval is less than 1 second
-            // Changing state too quickly can cause the button to flicker
-            loading={
-              pollInterval && pollInterval < 1000
-                ? isLoadingInitial
-                : isLoadingMore || isLoadingInitial
-            }
-            disabled={
-              pollInterval && pollInterval < 1000
-                ? isLoadingInitial
-                : isLoadingMore || isLoadingInitial
-            }
+            loading={disableRefreshButton}
+            disabled={disableRefreshButton}
           />
         </div>
       )}

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -335,8 +335,18 @@ export function RunsPage({
             icon={<RiRefreshLine />}
             iconSide="left"
             onClick={onRefresh}
-            loading={isLoadingMore || isLoadingInitial}
-            disabled={isLoadingMore || isLoadingInitial}
+            // Do not disable or show the button as loading if the poll interval is less than 1 second
+            // Changing state too quickly can cause the button to flicker
+            loading={
+              pollInterval && pollInterval < 1000
+                ? isLoadingInitial
+                : isLoadingMore || isLoadingInitial
+            }
+            disabled={
+              pollInterval && pollInterval < 1000
+                ? isLoadingInitial
+                : isLoadingMore || isLoadingInitial
+            }
           />
         </div>
       )}


### PR DESCRIPTION
## Description

Polling changes the state of the button too quickly and causes the UI to flicker unnecessarily. Disabling the button when polling doesn't matter too much as the view is always live and up to date. There is a potential better fix than this, but this is a simple improvement for situations where we're polling (the dev server).

## Motivation
With the faster polling in #1724, this problem got even worse.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
