### PR TITLE
Fix buttons in run details and dark mode scrollbar colors

### DIFF
--- a/ui/packages/components/src/AppRoot/globals.css
+++ b/ui/packages/components/src/AppRoot/globals.css
@@ -15,26 +15,6 @@
   }
 }
 
-/* width */
-.dark ::-webkit-scrollbar {
-  width: 10px;
-}
-
-/* Track */
-.dark ::-webkit-scrollbar-track {
-  @apply bg-slate-900;
-}
-
-/* Handle */
-.dark ::-webkit-scrollbar-thumb {
-  @apply rounded-lg bg-slate-800;
-}
-
-/* Handle on hover */
-.dark ::-webkit-scrollbar-thumb:hover {
-  @apply bg-slate-700;
-}
-
 .dark #modals {
   @apply text-sm text-slate-400;
 }
@@ -352,4 +332,32 @@
 #maze-contextual-widget-host,
 #maze-media-host {
   pointer-events: auto;
+}
+
+/* width */
+.dark ::-webkit-scrollbar {
+  width: 10px;
+}
+
+/* Track */
+.dark ::-webkit-scrollbar-track {
+  background: rgb(var(--color-carbon-700));
+}
+
+/* Handle */
+.dark ::-webkit-scrollbar-thumb {
+  @apply rounded-lg;
+  background: rgb(var(--color-carbon-400));
+}
+
+/* Handle on hover */
+.dark ::-webkit-scrollbar-thumb:hover {
+  background: rgb(var(--color-carbon-200));
+}
+
+.dark {
+  /* scrollbar-color: <thumb> <track> */
+  scrollbar-color: rgb(var(--color-carbon-400)) rgb(var(--color-carbon-700));
+  scrollbar-width: 10px;
+  scrollbar-gutter: 10px;
 }

--- a/ui/packages/components/src/Button/oldButtonStyles.ts
+++ b/ui/packages/components/src/Button/oldButtonStyles.ts
@@ -92,7 +92,7 @@ export const getDisabledStyles = ({ appearance, kind }: ButtonColorParams) => {
   if (appearance === 'solid') {
     return 'disabled:cursor-not-allowed disabled:text-slate-400 disabled:bg-slate-200 dark:disabled:text-slate-500 dark:disabled:bg-slate-800 ';
   } else if (appearance === 'outlined') {
-    return 'disabled:cursor-not-allowed disabled:text-slate-400 disabled:border-slate-200 disabled:bg-slate-100 dark:disabled:text-slate-500 dark:disabled:border-slate-800 dark:disabled:bg-slate-900';
+    return 'disabled:cursor-not-allowed disabled:text-disabled disabled:border-disabled disabled:bg-disabled';
   }
   return 'disabled:cursor-not-allowed disabled:text-slate-400 dark:disabled:text-slate-500 disabled:hover:no-underline';
 };

--- a/ui/packages/components/src/CodeBlock/CodeBlock.tsx
+++ b/ui/packages/components/src/CodeBlock/CodeBlock.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { Alert } from '@inngest/components/Alert';
-import { Button } from '@inngest/components/Button';
+import { Button, NewButton } from '@inngest/components/Button';
 import { CopyButton } from '@inngest/components/CopyButton';
 import { maxRenderedOutputSizeBytes } from '@inngest/components/constants';
 import { useCopyToClipboard } from '@inngest/components/hooks/useCopyToClipboard';
@@ -254,16 +254,17 @@ export function CodeBlock({ header, tab, actions = [], minLines = 0 }: CodeBlock
               {!isOutputTooLarge && (
                 <div className="mr-4 flex items-center gap-2 py-2">
                   {actions.map(({ label, title, icon, onClick, disabled }, idx) => (
-                    <Button
+                    <NewButton
                       key={idx}
                       icon={icon}
-                      btnAction={onClick}
+                      onClick={onClick}
                       size="small"
                       aria-label={label}
                       title={title ?? label}
                       label={label}
                       disabled={disabled}
                       appearance="outlined"
+                      kind="secondary"
                     />
                   ))}
                   <CopyButton
@@ -273,23 +274,25 @@ export function CodeBlock({ header, tab, actions = [], minLines = 0 }: CodeBlock
                     handleCopyClick={handleCopyClick}
                     appearance="outlined"
                   />
-                  <Button
+                  <NewButton
                     icon={isWordWrap ? <IconOverflowText /> : <IconWrapText />}
-                    btnAction={handleWrapText}
+                    onClick={handleWrapText}
                     size="small"
                     aria-label={isWordWrap ? 'Do not wrap text' : 'Wrap text'}
                     title={isWordWrap ? 'Do not wrap text' : 'Wrap text'}
                     tooltip={isWordWrap ? 'Do not wrap text' : 'Wrap text'}
                     appearance="outlined"
+                    kind="secondary"
                   />
-                  <Button
-                    btnAction={handleFullHeight}
+                  <NewButton
+                    onClick={handleFullHeight}
                     size="small"
                     icon={isFullHeight ? <IconShrinkText /> : <IconExpandText />}
                     aria-label={isFullHeight ? 'Shrink text' : 'Expand text'}
                     title={isFullHeight ? 'Shrink text' : 'Expand text'}
                     tooltip={isFullHeight ? 'Shrink text' : 'Expand text'}
                     appearance="outlined"
+                    kind="secondary"
                   />
                 </div>
               )}

--- a/ui/packages/components/src/CopyButton/CopyButton.tsx
+++ b/ui/packages/components/src/CopyButton/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@inngest/components/Button';
+import { NewButton as Button } from '@inngest/components/Button';
 import { RiCheckLine, RiFileCopy2Line } from '@remixicon/react';
 
 type ButtonCopyProps = {
@@ -6,8 +6,8 @@ type ButtonCopyProps = {
   iconOnly?: boolean;
   isCopying: boolean;
   handleCopyClick: (code: string) => void;
-  size?: 'small' | 'regular' | 'large';
-  appearance?: 'solid' | 'outlined' | 'text';
+  size?: 'small' | 'medium' | 'large';
+  appearance?: 'solid' | 'outlined' | 'ghost';
 };
 
 export function CopyButton({
@@ -25,10 +25,10 @@ export function CopyButton({
     <Button
       disabled={!code}
       size={size}
-      kind={isCopying ? 'success' : 'default'}
-      btnAction={code ? () => handleCopyClick(code) : undefined}
+      kind={isCopying ? 'primary' : 'secondary'}
+      onClick={code ? () => handleCopyClick(code) : undefined}
       label={iconOnly ? undefined : label}
-      appearance={iconOnly ? 'text' : appearance}
+      appearance={iconOnly ? 'ghost' : isCopying ? 'solid' : appearance}
       icon={iconOnly && icon}
       title="Click to copy"
       aria-label="Copy"

--- a/ui/packages/components/src/RerunButtonV2.tsx
+++ b/ui/packages/components/src/RerunButtonV2.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Button } from '@inngest/components/Button';
+import { NewButton } from '@inngest/components/Button';
 
 type Props = {
   disabled?: boolean;
@@ -20,12 +20,12 @@ export function RerunButton(props: Props) {
   }
 
   return (
-    <Button
-      btnAction={onClick}
+    <NewButton
+      onClick={onClick}
       disabled={props.disabled}
       loading={isLoading}
       label="Rerun"
-      size="small"
+      size="medium"
     />
   );
 }


### PR DESCRIPTION
## Description

Uses `NewButton` for consistent colors. Before this used old colors like slate, etc.

<img width="736" alt="Screen Shot 2024-09-10 at 9 46 28 PM" src="https://github.com/user-attachments/assets/5f8f673f-31c4-4e5b-afa1-f5536330f593">


## Motivation
Consistency.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
