### PR TITLE
Provide some wiggle room in "end time is before now" check when creating a cancellation

### DIFF
--- a/pkg/api/apiv1/cancellation.go
+++ b/pkg/api/apiv1/cancellation.go
@@ -104,7 +104,7 @@ func (c CreateCancellationBody) Validate() error {
 	if c.StartedBefore.IsZero() {
 		err = errors.Join(err, errors.New("started_before is required"))
 	}
-	if c.StartedBefore.After(time.Now()) {
+	if c.StartedBefore.After(time.Now().Add(5 * time.Second)) {
 		err = errors.Join(err, errors.New("started_before must be in the past"))
 	}
 	if c.StartedAfter != nil && c.StartedAfter.After(c.StartedBefore) {


### PR DESCRIPTION
## Motivation

This check has produced flaky tests in case of clock drift between the API container and the host running integration tests.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.
