### PR TITLE
chore: bump node version in CI to 20

### DIFF
--- a/.github/workflows/components_test.yml
+++ b/.github/workflows/components_test.yml
@@ -19,7 +19,7 @@ jobs:
           version: "8.15.8"
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
       - name: Install
         run: pnpm install
         working-directory: ui/packages/components

--- a/.github/workflows/dev_server_ui.yml
+++ b/.github/workflows/dev_server_ui.yml
@@ -17,9 +17,9 @@ jobs:
       - uses: pnpm/action-setup@v4.0.0
         with:
           version: "8.15.8"
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
       - name: Install
         run: pnpm install
         working-directory: ui/apps/dev-server-ui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Node/npm
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - name: Install npm dependencies
         run: npm ci
       - name: Build


### PR DESCRIPTION
## Description

Update CI setup to use node 20.
Require version upgrade to update vulnerable deps.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
