### PR TITLE
Fix redirect method

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver_test.go
+++ b/pkg/execution/driver/httpdriver/httpdriver_test.go
@@ -34,7 +34,7 @@ func TestRedirect(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch count {
 		case 8:
-			require.Equal(t, http.MethodPost, r.Method)
+			require.Equal(t, http.MethodGet, r.Method)
 			byt, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 			require.Equal(t, input, byt)

--- a/pkg/execution/driver/httpdriver/util.go
+++ b/pkg/execution/driver/httpdriver/util.go
@@ -47,9 +47,6 @@ func CheckRedirect(req *http.Request, via []*http.Request) (err error) {
 		return fmt.Errorf("stopped after 10 redirects")
 	}
 
-	// If we're redirected we want to ensure that we retain the HTTP method.
-	req.Method = via[0].Method
-
 	if via[0].Body != nil {
 		req.Body, err = via[0].GetBody()
 		if err != nil {
@@ -58,7 +55,13 @@ func CheckRedirect(req *http.Request, via []*http.Request) (err error) {
 	}
 
 	req.ContentLength = via[0].ContentLength
-	req.Header = via[0].Header
+
+	// Combine headers from the original request and the redirect request
+	for k, v := range via[0].Header {
+		if len(v) > 0 {
+			req.Header.Set(k, v[0])
+		}
+	}
 
 	// Retain the original query params
 	qp := req.URL.Query()

--- a/tests/golang/redirect_test.go
+++ b/tests/golang/redirect_test.go
@@ -31,7 +31,7 @@ func TestRedirect(t *testing.T) {
 	redirectServer := NewHTTPServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			redirectCounter++
-			http.Redirect(w, r, server.URL(), http.StatusSeeOther)
+			http.Redirect(w, r, server.URL(), http.StatusTemporaryRedirect)
 		}),
 	)
 	defer redirectServer.Close()


### PR DESCRIPTION
## Description
Fix redirect HTTP method. Before this change, we'd always use the original HTTP method even if the redirect was telling us to use a different one.

Also, this PR combines the headers in the original and redirect requests, rather than replacing the redirect request headers.

## Context
This bug became apparent for Modal users. Modal sends a `303: See Other` redirect after 150 seconds, and this redirect has a `GET` method even though the original method has a `POST`

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
