### PR TITLE
INN-3783 Add env parsing to CLI flags/config

### DIFF
--- a/cmd/commands/internal/localconfig/devconfig.go
+++ b/cmd/commands/internal/localconfig/devconfig.go
@@ -102,7 +102,9 @@ func mapStartFlags(cmd *cobra.Command) error {
 	err = errors.Join(err, viper.BindPFlag("port", cmd.Flags().Lookup("port")))
 	err = errors.Join(err, viper.BindPFlag("redis-uri", cmd.Flags().Lookup("redis-uri")))
 	err = errors.Join(err, viper.BindPFlag("poll-interval", cmd.Flags().Lookup("poll-interval")))
+	err = errors.Join(err, viper.BindPFlag("retry-interval", cmd.Flags().Lookup("retry-interval")))
 	err = errors.Join(err, viper.BindPFlag("urls", cmd.Flags().Lookup("sdk-url")))
+	err = errors.Join(err, viper.BindPFlag("tick", cmd.Flags().Lookup("tick")))
 
 	return err
 }

--- a/cmd/commands/internal/localconfig/devconfig.go
+++ b/cmd/commands/internal/localconfig/devconfig.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/spf13/cobra"
@@ -35,6 +36,11 @@ func InitStartConfig(ctx context.Context, cmd *cobra.Command) error {
 
 func loadConfigFile(ctx context.Context, cmd *cobra.Command) {
 	l := logger.From(ctx).With().Logger()
+
+	// Automatially bind environment variables
+	viper.SetEnvPrefix("INNGEST")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
 
 	configPath, _ := cmd.Flags().GetString("config")
 	if configPath != "" {


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

Allows environment variables to be used to influence CLI flags, e.g.

```sh
INNGEST_HOST=foo inngest dev
# ...equivalent to...
inngest dev --host foo
```

Dashes in flags are converted to underscores, e.g.

```sh
INNGEST_POLL_INTERVAL=500 inngest dev
# ...equivalent to...
inngest dev --poll-interval 500
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- INN-3783
- Based on #1761 (INN-3722)

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*