### PR TITLE
INN-3784 Add `inngest start --sqlite-dir`

### DIFF
--- a/cmd/commands/internal/localconfig/devconfig.go
+++ b/cmd/commands/internal/localconfig/devconfig.go
@@ -103,6 +103,7 @@ func mapStartFlags(cmd *cobra.Command) error {
 	err = errors.Join(err, viper.BindPFlag("redis-uri", cmd.Flags().Lookup("redis-uri")))
 	err = errors.Join(err, viper.BindPFlag("poll-interval", cmd.Flags().Lookup("poll-interval")))
 	err = errors.Join(err, viper.BindPFlag("urls", cmd.Flags().Lookup("sdk-url")))
+	err = errors.Join(err, viper.BindPFlag("sqlite-dir", cmd.Flags().Lookup("sqlite-dir")))
 
 	return err
 }

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -44,7 +44,7 @@ func NewCmdStart(rootCmd *cobra.Command) *cobra.Command {
 	groups = append(groups, FlagGroup{name: "Flags:", fs: baseFlags})
 
 	persistenceFlags := pflag.NewFlagSet("persistence", pflag.ExitOnError)
-	// persistenceFlags.String("sqlite-dir", "", "Directory for where to write SQLite database.")
+	persistenceFlags.String("sqlite-dir", "", "Directory for where to write SQLite database.")
 	persistenceFlags.String("redis-uri", "", "Redis server URI for external queue and run state. Defaults to self-contained, in-memory Redis server with periodic snapshot backups.")
 	// persistenceFlags.String("postgres-uri", "", "[Experimental] PostgreSQL database URI for configuration and history persistence. Defaults to SQLite database.")
 	cmd.Flags().AddFlagSet(persistenceFlags)
@@ -129,6 +129,7 @@ func doStart(cmd *cobra.Command, args []string) {
 		RetryInterval: viper.GetInt("retry-interval"),
 		Tick:          time.Duration(tick) * time.Millisecond,
 		URLs:          viper.GetStringSlice("urls"),
+		SQLiteDir:     viper.GetString("sqlite-dir"),
 	}
 
 	err = lite.New(ctx, opts)

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -109,8 +109,12 @@ const (
 	// StartMaxQueueSnapshots is the maximum number of snapshots we keep.
 	StartMaxQueueSnapshots = 5
 
-	DevServerTempDir = ".inngest"
-	DevServerDbFile  = "main.db"
+	DefaultInngestConfigDir = ".inngest"
+	SQLiteDbFileName        = "main.db"
+	// DevServerHistoryFile is the file where the history is stored.
+	//
+	// @deprecated Used in the in-memory writer when persiting, though this
+	// should not be actively used any more.
 	DevServerHistoryFile = "dev_history.json"
 
 	PauseExpiredDeletionGracePeriod = time.Second * 10

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -109,8 +109,8 @@ const (
 	// StartMaxQueueSnapshots is the maximum number of snapshots we keep.
 	StartMaxQueueSnapshots = 5
 
-	DevServerTempDir     = ".inngest"
-	DevServerDbFile      = "dev_db.db"
+	DevServerTempDir = ".inngest"
+	DevServerDbFile  = "main.db"
 	DevServerHistoryFile = "dev_history.json"
 
 	PauseExpiredDeletionGracePeriod = time.Second * 10

--- a/pkg/cqrs/sqlitecqrs/sqlitecqrs.go
+++ b/pkg/cqrs/sqlitecqrs/sqlitecqrs.go
@@ -37,7 +37,7 @@ func New(opts SqliteCQRSOptions) (*sql.DB, error) {
 	} else {
 		o.Do(func() {
 			// make the dir if it doesn't exist
-			dir := consts.DevServerTempDir
+			dir := consts.DefaultInngestConfigDir
 			if opts.Directory != "" {
 				dir = opts.Directory
 				if !filepath.IsAbs(opts.Directory) {
@@ -58,7 +58,7 @@ func New(opts SqliteCQRSOptions) (*sql.DB, error) {
 				}
 			}
 
-			file := filepath.Join(dir, consts.DevServerDbFile)
+			file := filepath.Join(dir, consts.SQLiteDbFileName)
 
 			db, err = sql.Open("sqlite", fmt.Sprintf("file:%s?cache=shared", file))
 		})
@@ -103,7 +103,7 @@ func up(db *sql.DB, opts SqliteCQRSOptions) error {
 
 	dbName := "file:inngest?mode=memory&cache=shared"
 	if !opts.InMemory {
-		dbName = fmt.Sprintf("file:%s?cache=shared", fmt.Sprintf("%s/%s", consts.DevServerTempDir, consts.DevServerDbFile))
+		dbName = fmt.Sprintf("file:%s?cache=shared", fmt.Sprintf("%s/%s", consts.DefaultInngestConfigDir, consts.SQLiteDbFileName))
 	}
 
 	m, err := migrate.NewWithInstance("iofs", source, dbName, driver)

--- a/pkg/cqrs/sqlitecqrs/sqlitecqrs.go
+++ b/pkg/cqrs/sqlitecqrs/sqlitecqrs.go
@@ -43,7 +43,6 @@ func New(opts SqliteCQRSOptions) (*sql.DB, error) {
 				if !filepath.IsAbs(opts.Directory) {
 					wd, err := os.Getwd()
 					if err != nil {
-						err = fmt.Errorf("error getting working directory to decide on SQLite storage path: %w", err)
 						return
 					}
 

--- a/pkg/history_drivers/memory_writer/writer.go
+++ b/pkg/history_drivers/memory_writer/writer.go
@@ -31,7 +31,7 @@ func NewWriter(ctx context.Context, opts WriterOptions) history.Driver {
 	l := log.From(ctx).With().Str("caller", "memory_writer").Logger()
 
 	// read data from file and populate memory_store.Singleton
-	file, err := os.ReadFile(fmt.Sprintf("%s/%s", consts.DevServerTempDir, consts.DevServerHistoryFile))
+	file, err := os.ReadFile(fmt.Sprintf("%s/%s", consts.DefaultInngestConfigDir, consts.DevServerHistoryFile))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return w
@@ -71,7 +71,7 @@ func (w *writer) Close(ctx context.Context) error {
 		return err
 	}
 
-	err = os.WriteFile(fmt.Sprintf("%s/%s", consts.DevServerTempDir, consts.DevServerHistoryFile), b, 0600)
+	err = os.WriteFile(fmt.Sprintf("%s/%s", consts.DefaultInngestConfigDir, consts.DevServerHistoryFile), b, 0600)
 	if err != nil {
 		l.Error().Err(err).Msg("error writing history data to file")
 		return err

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -59,6 +59,7 @@ type StartOpts struct {
 	URLs          []string      `json:"urls"`
 	Tick          time.Duration `json:"tick"`
 	RetryInterval int           `json:"retry_interval"`
+	SQLiteDir     string        `json:"sqlite-dir"`
 }
 
 // Create and start a new dev server.  The dev server is used during (surprise surprise)
@@ -83,7 +84,10 @@ func New(ctx context.Context, opts StartOpts) error {
 }
 
 func start(ctx context.Context, opts StartOpts) error {
-	db, err := sqlitecqrs.New(sqlitecqrs.SqliteCQRSOptions{InMemory: false})
+	db, err := sqlitecqrs.New(sqlitecqrs.SqliteCQRSOptions{
+		InMemory:  false,
+		Directory: opts.SQLiteDir,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

Adds `inngest start --sqlite-dir` to control the location of the persistence files generated.

Defaults to `./.inngest` and accepts both relative and absolute paths.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- INN-3784
- Based on #1761 (INN-3722)

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
