### PR TITLE
INN-3373 INN-3376 Make UI aware of `inngest dev` vs `inngest start`

### DIFF
--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -128,10 +128,11 @@ func (a devapi) Info(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ir := InfoResponse{
-		Version:   version.Print(),
-		StartOpts: a.devserver.Opts,
-		Functions: funcs,
-		Handlers:  a.devserver.handlers,
+		Version:             version.Print(),
+		StartOpts:           a.devserver.Opts,
+		Functions:           funcs,
+		Handlers:            a.devserver.handlers,
+		IsSingleNodeService: a.devserver.IsSingleNodeService(),
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	byt, _ := json.MarshalIndent(ir, "", "  ")
@@ -549,9 +550,10 @@ func (a devapi) err(ctx context.Context, w http.ResponseWriter, status int, err 
 
 type InfoResponse struct {
 	// Version lists the version of the development server
-	Version       string             `json:"version"`
-	Authenticated bool               `json:"authed"`
-	StartOpts     StartOpts          `json:"startOpts"`
-	Functions     []inngest.Function `json:"functions"`
-	Handlers      []SDKHandler       `json:"handlers"`
+	Version             string             `json:"version"`
+	Authenticated       bool               `json:"authed"`
+	StartOpts           StartOpts          `json:"startOpts"`
+	Functions           []inngest.Function `json:"functions"`
+	Handlers            []SDKHandler       `json:"handlers"`
+	IsSingleNodeService bool               `json:"isSingleNodeService"`
 }

--- a/ui/apps/dashboard/tsconfig.json
+++ b/ui/apps/dashboard/tsconfig.json
@@ -26,7 +26,6 @@
     "./sentry.edge.config.ts",
     "./sentry.server.config.ts",
     "../../packages/components/src/Menu/MenuItem.tsx",
-    "../dev-server-ui/src/components/Layout/Logo.tsx",
     "../../packages/components/src/Tooltip/OptionalTooltip.tsx"
   ],
   "exclude": ["node_modules"]

--- a/ui/apps/dev-server-ui/package.json
+++ b/ui/apps/dev-server-ui/package.json
@@ -47,7 +47,8 @@
     "react-refractor": "2.1.7",
     "refractor": "4.8.0",
     "sonner": "1.2.0",
-    "ulid": "2.3.0"
+    "ulid": "2.3.0",
+    "zod": "3.22.4"
   },
   "devDependencies": {
     "@graphql-codegen/cli": "3.2.2",

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/apps/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/apps/page.tsx
@@ -9,6 +9,7 @@ import { IconSpinner } from '@inngest/components/icons/Spinner';
 
 import AddAppButton from '@/components/App/AddAppButton';
 import AppCard from '@/components/App/AppCard';
+import { useInfoQuery } from '@/store/devApi';
 import { useGetAppsQuery } from '@/store/generated';
 
 export default function AppList() {
@@ -23,6 +24,8 @@ export default function AppList() {
       return <AppCard key={app?.id} app={app} />;
     });
   }, [apps]);
+
+  const { data: info } = useInfoQuery();
 
   return (
     <div className="flex h-full flex-col overflow-y-scroll">
@@ -40,10 +43,12 @@ export default function AppList() {
         }
         action={
           <div className="flex items-center gap-5">
-            <p className="text-btnPrimary flex items-center gap-2 text-sm leading-tight">
-              <IconSpinner className="fill-btnPrimary" />
-              Auto-detecting Apps
-            </p>
+            {info?.isDiscoveryEnabled ? (
+              <p className="text-btnPrimary flex items-center gap-2 text-sm leading-tight">
+                <IconSpinner className="fill-btnPrimary" />
+                Auto-detecting Apps
+              </p>
+            ) : null}
             <AddAppButton />
           </div>
         }

--- a/ui/apps/dev-server-ui/src/components/Layout/Logo.tsx
+++ b/ui/apps/dev-server-ui/src/components/Layout/Logo.tsx
@@ -6,6 +6,8 @@ import { InngestLogo } from '@inngest/components/icons/logos/InngestLogo';
 import { InngestLogoSmallBW } from '@inngest/components/icons/logos/InngestLogoSmall';
 import { RiContractLeftLine, RiContractRightLine } from '@remixicon/react';
 
+import { useInfoQuery } from '@/store/devApi';
+
 type LogoProps = {
   collapsed: boolean;
   setCollapsed: (arg: boolean) => void;
@@ -37,6 +39,9 @@ const NavToggle = ({ collapsed, setCollapsed }: LogoProps) => {
 };
 
 export default function Logo({ collapsed, setCollapsed }: LogoProps) {
+  const { data: info, isLoading } = useInfoQuery();
+  const isDevServer = isLoading ? false : !info?.isSingleNodeService;
+
   return (
     <div
       className={`my-5 flex h-10 w-full flex-row items-center ${
@@ -53,7 +58,9 @@ export default function Logo({ collapsed, setCollapsed }: LogoProps) {
             <Link href="/">
               <InngestLogo className="text-basis mr-1.5" width={92} />
             </Link>
-            <span className="text-primary-intense text-[11px] leading-none">DEV SERVER</span>
+            {isDevServer ? (
+              <span className="text-primary-intense text-[11px] leading-none">DEV SERVER</span>
+            ) : null}
           </div>
         )}
       </div>

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -348,6 +348,9 @@ importers:
       ulid:
         specifier: 2.3.0
         version: 2.3.0
+      zod:
+        specifier: 3.22.4
+        version: 3.22.4
     devDependencies:
       '@graphql-codegen/cli':
         specifier: 3.2.2


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

Makes the `DEV SERVER` and `Auto-detecting Apps` text conditional based on whether:
- We're running `inngest dev` instead of `inngest start`
- Autodiscovery is actually enabled

![image](https://github.com/user-attachments/assets/884b694a-4bf9-4a63-a37c-5538b964f312)

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- INN-3373
- INN-3376
- Based on #1761 (INN-3722)

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
