### PR TITLE
Fix CodeBlock collapsed feature

### DIFF
--- a/ui/packages/components/src/CodeBlock/CodeBlock.tsx
+++ b/ui/packages/components/src/CodeBlock/CodeBlock.tsx
@@ -100,6 +100,10 @@ export function CodeBlock({ header, tab, actions = [], minLines = 0 }: CodeBlock
     }
   }
 
+  function handleEditorDidMount(editor: MonacoEditorType) {
+    editorRef.current = editor;
+  }
+
   function updateEditorLayout(editor: MonacoEditorType) {
     const container = editor?.getDomNode();
     if (!editor || !container) return;
@@ -355,6 +359,7 @@ export function CodeBlock({ header, tab, actions = [], minLines = 0 }: CodeBlock
                   wordWrap: isWordWrap ? 'on' : 'off',
                 }}
                 onMount={(editor) => {
+                  handleEditorDidMount(editor);
                   updateEditorLayout(editor);
                 }}
                 onChange={(value) => {


### PR DESCRIPTION
## Description

There was a regression in https://github.com/inngest/inngest/pull/1357/files#diff-57e385b549c016d5aca17c9df39012f6245b517e3e6622bb3ea6426150436a22L136. The lack of reference was preventing the Code Block to collapse and expand.

https://github.com/user-attachments/assets/d84530e0-029e-4ad8-b8b4-c2db97c00018


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
