### PR TITLE
Fix output_too_large error when streaming

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -355,7 +355,7 @@ func do(ctx context.Context, c HTTPDoer, r Request) (*response, error) {
 	if resp.StatusCode == 201 && sysErr == nil {
 		stream, err := ParseStream(byt)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error parsing stream: %w", err)
 		}
 		// These are all contained within a single wrapper.
 		body = stream.Body

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -352,7 +352,7 @@ func do(ctx context.Context, c HTTPDoer, r Request) (*response, error) {
 	// Only SDK versions that include the status in the body are expected to
 	// send a 201 status code and namespace in this way, so failing to parse
 	// here is an error.
-	if resp.StatusCode == 201 {
+	if resp.StatusCode == 201 && sysErr == nil {
 		stream, err := ParseStream(byt)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Description
Fix improper handling of the `output_too_large` error when the SDK response is streaming. This happened because we replaced the body with the string `output_too_large`, which breaks the `ParseStream` function. We can't use the originally body when output is too large because we truncated it into invalid JSON.

## Testing
Before:
![image](https://github.com/user-attachments/assets/632b19cb-367b-4b76-81f8-035529c122b6)

After:
![image](https://github.com/user-attachments/assets/005de0f0-a030-4718-8d72-64455d31e3b2)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
