### PR TITLE
Fix `INNGEST_SDK_URL` not matching the same flag as `--sdk-url`

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -78,7 +78,7 @@ func doDev(cmd *cobra.Command, args []string) {
 		conf.EventAPI.Addr = host
 	}
 
-	urls := viper.GetStringSlice("urls")
+	urls := viper.GetStringSlice("sdk-url")
 
 	// Run auto-discovery unless we've explicitly disabled it.
 	noDiscovery := viper.GetBool("no-discovery")

--- a/cmd/commands/internal/localconfig/devconfig.go
+++ b/cmd/commands/internal/localconfig/devconfig.go
@@ -96,7 +96,7 @@ func mapDevFlags(cmd *cobra.Command) error {
 	err = errors.Join(err, viper.BindPFlag("port", cmd.Flags().Lookup("port")))
 	err = errors.Join(err, viper.BindPFlag("retry-interval", cmd.Flags().Lookup("retry-interval")))
 	err = errors.Join(err, viper.BindPFlag("tick", cmd.Flags().Lookup("tick")))
-	err = errors.Join(err, viper.BindPFlag("urls", cmd.Flags().Lookup("sdk-url")))
+	err = errors.Join(err, viper.BindPFlag("sdk-url", cmd.Flags().Lookup("sdk-url")))
 
 	return err
 }
@@ -109,7 +109,7 @@ func mapStartFlags(cmd *cobra.Command) error {
 	err = errors.Join(err, viper.BindPFlag("redis-uri", cmd.Flags().Lookup("redis-uri")))
 	err = errors.Join(err, viper.BindPFlag("poll-interval", cmd.Flags().Lookup("poll-interval")))
 	err = errors.Join(err, viper.BindPFlag("retry-interval", cmd.Flags().Lookup("retry-interval")))
-	err = errors.Join(err, viper.BindPFlag("urls", cmd.Flags().Lookup("sdk-url")))
+	err = errors.Join(err, viper.BindPFlag("sdk-url", cmd.Flags().Lookup("sdk-url")))
 	err = errors.Join(err, viper.BindPFlag("sqlite-dir", cmd.Flags().Lookup("sqlite-dir")))
 	err = errors.Join(err, viper.BindPFlag("tick", cmd.Flags().Lookup("tick")))
 

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -128,7 +128,7 @@ func doStart(cmd *cobra.Command, args []string) {
 		RedisURI:      viper.GetString("redis-uri"),
 		RetryInterval: viper.GetInt("retry-interval"),
 		Tick:          time.Duration(tick) * time.Millisecond,
-		URLs:          viper.GetStringSlice("urls"),
+		URLs:          viper.GetStringSlice("sdk-url"),
 		SQLiteDir:     viper.GetString("sqlite-dir"),
 	}
 


### PR DESCRIPTION
## Description

This PR ensures that `INNGEST_SDK_URL="localhost:3001 localhost:3002` works in harmony with `inngest start --sdk-url localhost:3001 --sdk-url localhost:3002`.

Previous to this, we'd need to separately handle the `INNGEST_SDK_URL` environment variable due to the binding here.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
