### PR TITLE
Add `--event-key` to `inngest start`

### DIFF
--- a/cmd/commands/internal/localconfig/devconfig.go
+++ b/cmd/commands/internal/localconfig/devconfig.go
@@ -107,6 +107,7 @@ func mapStartFlags(cmd *cobra.Command) error {
 	err = errors.Join(err, viper.BindPFlag("host", cmd.Flags().Lookup("host")))
 	err = errors.Join(err, viper.BindPFlag("port", cmd.Flags().Lookup("port")))
 	err = errors.Join(err, viper.BindPFlag("signing-key", cmd.Flags().Lookup("signing-key")))
+	err = errors.Join(err, viper.BindPFlag("event-key", cmd.Flags().Lookup("event-key")))
 	err = errors.Join(err, viper.BindPFlag("redis-uri", cmd.Flags().Lookup("redis-uri")))
 	err = errors.Join(err, viper.BindPFlag("poll-interval", cmd.Flags().Lookup("poll-interval")))
 	err = errors.Join(err, viper.BindPFlag("retry-interval", cmd.Flags().Lookup("retry-interval")))

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -40,7 +40,8 @@ func NewCmdStart(rootCmd *cobra.Command) *cobra.Command {
 	baseFlags.Int("retry-interval", 0, "Retry interval in seconds for linear backoff. Minimum: 1.")
 	baseFlags.StringSliceP("sdk-url", "u", []string{}, "SDK URLs to load functions from")
 	baseFlags.Int("tick", devserver.DefaultTick, "Interval, in milliseconds, of which to check for new work.")
-	baseFlags.String("signing-key", "", "Signing key")
+	baseFlags.String("signing-key", "", "Signing key used to sign and validate data between the server and apps.")
+	baseFlags.String("event-key", "", "Event key that will be used by apps to send events to the server.")
 	cmd.Flags().AddFlagSet(baseFlags)
 	groups = append(groups, FlagGroup{name: "Flags:", fs: baseFlags})
 
@@ -132,6 +133,7 @@ func doStart(cmd *cobra.Command, args []string) {
 		URLs:          viper.GetStringSlice("sdk-url"),
 		SQLiteDir:     viper.GetString("sqlite-dir"),
 		SigningKey:    viper.GetString("signing-key"),
+		EventKey:      viper.GetString("event-key"),
 	}
 
 	err = lite.New(ctx, opts)

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -41,7 +41,7 @@ func NewCmdStart(rootCmd *cobra.Command) *cobra.Command {
 	baseFlags.StringSliceP("sdk-url", "u", []string{}, "SDK URLs to load functions from")
 	baseFlags.Int("tick", devserver.DefaultTick, "Interval, in milliseconds, of which to check for new work.")
 	baseFlags.String("signing-key", "", "Signing key used to sign and validate data between the server and apps.")
-	baseFlags.String("event-key", "", "Event key that will be used by apps to send events to the server.")
+	baseFlags.String("event-key", "", "Event key(s) that will be used by apps to send events to the server.")
 	cmd.Flags().AddFlagSet(baseFlags)
 	groups = append(groups, FlagGroup{name: "Flags:", fs: baseFlags})
 
@@ -133,7 +133,7 @@ func doStart(cmd *cobra.Command, args []string) {
 		URLs:          viper.GetStringSlice("sdk-url"),
 		SQLiteDir:     viper.GetString("sqlite-dir"),
 		SigningKey:    viper.GetString("signing-key"),
-		EventKey:      viper.GetString("event-key"),
+		EventKey:      viper.GetStringSlice("event-key"),
 	}
 
 	err = lite.New(ctx, opts)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -137,7 +137,7 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if a.config.GetServerKind() == headers.ServerKindCloud && a.localEventKey != "" && key != a.localEventKey {
+	if a.localEventKey != "" && key != a.localEventKey {
 		a.writeResponse(w, apiResponse{
 			StatusCode: http.StatusUnauthorized,
 			Error:      "Event key not found",

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -35,17 +35,17 @@ type APIServiceOptions struct {
 	Config config.Config
 	Mounts []Mount
 
-	// LocalEventKey is the key used to send events to the local event API from
-	// an app. If this is set, only keys that match this value will be
-	// accepted.
-	LocalEventKey string
+	// LocalEventKeys are the keys used to send events to the local event API
+	// from an app. If this is set, only keys that match one of these values
+	// will be accepted.
+	LocalEventKeys []string
 }
 
 func NewService(opts APIServiceOptions) service.Service {
 	return &apiServer{
-		config:        opts.Config,
-		mounts:        opts.Mounts,
-		localEventKey: opts.LocalEventKey,
+		config:         opts.Config,
+		mounts:         opts.Mounts,
+		localEventKeys: opts.LocalEventKeys,
 	}
 }
 
@@ -56,10 +56,10 @@ type apiServer struct {
 
 	mounts []Mount
 
-	// localEventKey is the key used to send events to the local event API from
-	// an app. If this is set, only keys that match this value will be
-	// accepted.
-	localEventKey string
+	// localEventKeys are the keys used to send events to the local event API
+	// from an app. If this is set, only keys that match one of these values
+	// will be accepted.
+	localEventKeys []string
 }
 
 func (a *apiServer) Name() string {
@@ -70,10 +70,10 @@ func (a *apiServer) Pre(ctx context.Context) error {
 	var err error
 
 	api, err := NewAPI(Options{
-		Config:        a.config,
-		Logger:        logger.From(ctx),
-		EventHandler:  a.handleEvent,
-		LocalEventKey: a.localEventKey,
+		Config:         a.config,
+		Logger:         logger.From(ctx),
+		EventHandler:   a.handleEvent,
+		LocalEventKeys: a.localEventKeys,
 	})
 	if err != nil {
 		return err

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -70,6 +70,10 @@ type StartOpts struct {
 	// SigningKey is used to decide that the server should sign requests and
 	// validate responses where applicable, modelling cloud behaviour.
 	SigningKey *string `json:"signing_key"`
+
+	// EventKey is used to authorize incoming events, ensuring they match the
+	// given key.
+	EventKey *string `json:"event_key"`
 }
 
 // Create and start a new dev server.  The dev server is used during (surprise surprise)
@@ -351,18 +355,27 @@ func start(ctx context.Context, opts StartOpts) error {
 	if err != nil {
 		return err
 	}
+
+	ek := ""
+	if opts.EventKey != nil {
+		ek = *opts.EventKey
+	}
+
 	// Create a new data API directly in the devserver.  This allows us to inject
 	// the data API into the dev server port, providing a single router for the dev
 	// server UI, events, and API for loading data.
 	//
 	// Merge the dev server API (for handling files & registration) with the data
 	// API into the event API router.
-	ds.Apiservice = api.NewService(
-		ds.Opts.Config,
-		api.Mount{At: "/", Router: devAPI},
-		api.Mount{At: "/v0", Router: core.Router},
-		api.Mount{At: "/debug", Handler: middleware.Profiler()},
-	)
+	ds.Apiservice = api.NewService(api.APIServiceOptions{
+		Config: ds.Opts.Config,
+		Mounts: []api.Mount{
+			{At: "/", Router: devAPI},
+			{At: "/v0", Router: core.Router},
+			{At: "/debug", Handler: middleware.Profiler()},
+		},
+		LocalEventKey: ek,
+	})
 
 	return service.StartAll(ctx, ds, runner, executorSvc, ds.Apiservice)
 }

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -73,7 +73,7 @@ type StartOpts struct {
 
 	// EventKey is used to authorize incoming events, ensuring they match the
 	// given key.
-	EventKey *string `json:"event_key"`
+	EventKeys []string `json:"event_key"`
 }
 
 // Create and start a new dev server.  The dev server is used during (surprise surprise)
@@ -356,11 +356,6 @@ func start(ctx context.Context, opts StartOpts) error {
 		return err
 	}
 
-	ek := ""
-	if opts.EventKey != nil {
-		ek = *opts.EventKey
-	}
-
 	// Create a new data API directly in the devserver.  This allows us to inject
 	// the data API into the dev server port, providing a single router for the dev
 	// server UI, events, and API for loading data.
@@ -374,7 +369,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			{At: "/v0", Router: core.Router},
 			{At: "/debug", Handler: middleware.Profiler()},
 		},
-		LocalEventKey: ek,
+		LocalEventKeys: opts.EventKeys,
 	})
 
 	return service.StartAll(ctx, ds, runner, executorSvc, ds.Apiservice)

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -69,7 +69,7 @@ type StartOpts struct {
 
 	// EventKey is used to authorize incoming events, ensuring they match the
 	// given key.
-	EventKey string `json:"event_key"`
+	EventKey []string `json:"event_key"`
 }
 
 // Create and start a new dev server.  The dev server is used during (surprise surprise)
@@ -403,7 +403,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			{At: "/v0", Router: core.Router},
 			{At: "/debug", Handler: middleware.Profiler()},
 		},
-		LocalEventKey: opts.EventKey,
+		LocalEventKeys: opts.EventKey,
 	})
 
 	return service.StartAll(ctx, ds, runner, executorSvc, ds.Apiservice)


### PR DESCRIPTION
## Description

Adds the ability to provide an event key in `inngest start`:

- `inngest start --event-key 123`
- `INNGEST_EVENT_KEY=123 inngest start`

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
