### PR TITLE
Maybe fix flaky TestWaitGroup

### DIFF
--- a/tests/client/function_run.go
+++ b/tests/client/function_run.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -227,23 +228,22 @@ func (c *Client) WaitForRunTraces(ctx context.Context, t *testing.T, runID *stri
 
 	var traces *RunV2
 	require.NotNil(t, runID)
-	require.Eventually(t, func() bool {
-		if *runID == "" {
-			return false
-		}
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		a := assert.New(t)
+		a.NotEmpty(runID)
 
 		run, err := c.RunTraces(ctx, *runID)
-		traces = run
-
-		// NOTE: we force the function to return early to prevent panics in the next assertion.
-		// We cannot use require.NotNil as this will cause an uncaught panic (see https://github.com/stretchr/testify/issues/1457)
-		ready := err == nil && run != nil && run.Status == opts.Status.String()
+		a.NoError(err)
+		a.NotNil(run)
+		a.Equal(run.Status, opts.Status.String())
 
 		if opts.ChildSpanCount > 0 {
-			ready = ready && run.Trace != nil && run.Trace.IsRoot && len(run.Trace.ChildSpans) == opts.ChildSpanCount
+			a.NotNil(run.Trace)
+			a.True(run.Trace.IsRoot)
+			a.Len(run.Trace.ChildSpans, opts.ChildSpanCount)
 		}
 
-		return ready
+		traces = run
 	}, opts.Timeout, opts.Interval)
 
 	return traces


### PR DESCRIPTION
## Description
- Wait for the `WaitForEvent` to appear in history.
- Add assertions to `WaitForRunTraces` so that it's clearer where we ultimately fail.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
