### PR TITLE
Require keys in `inngest start`, disabling functionality if not present

### DIFF
--- a/pkg/cli/styles.go
+++ b/pkg/cli/styles.go
@@ -14,9 +14,10 @@ var (
 	Iris    = lipgloss.Color("#5D5FEF")
 	Fuschia = lipgloss.Color("#EF5DA8")
 
-	TextStyle  = lipgloss.NewStyle().Foreground(Color)
-	FeintStyle = TextStyle.Copy().Foreground(Feint)
-	BoldStyle  = TextStyle.Copy().Bold(true)
+	TextStyle    = lipgloss.NewStyle().Foreground(Color)
+	FeintStyle   = TextStyle.Copy().Foreground(Feint)
+	BoldStyle    = TextStyle.Copy().Bold(true)
+	WarningStyle = TextStyle.Copy().Foreground(Orange)
 )
 
 // RenderError returns a formatted error string.

--- a/pkg/config/registration/registration.go
+++ b/pkg/config/registration/registration.go
@@ -56,7 +56,8 @@ func RegisterState(f func() any) {
 }
 
 type NewDriverOpts struct {
-	SigningKey *string
+	LocalSigningKey        *string
+	RequireLocalSigningKey bool
 }
 
 // DriverConfig is an interface used to determine driver config structs.

--- a/pkg/coreapi/coreapi.go
+++ b/pkg/coreapi/coreapi.go
@@ -46,6 +46,12 @@ type Options struct {
 
 	// LocalSigningKey is the key used to sign events for self-hosted services.
 	LocalSigningKey string
+
+	// RequireKeys defines whether event and signing keys are required for the
+	// server to function. If this is true and signing keys are not defined,
+	// the server will still boot but core actions such as syncing, runs, and
+	// ingesting events will not work.
+	RequireKeys bool
 }
 
 func NewCoreApi(o Options) (*CoreAPI, error) {
@@ -88,6 +94,7 @@ func NewCoreApi(o Options) (*CoreAPI, error) {
 		Executor:        o.Executor,
 		ServerKind:      o.Config.GetServerKind(),
 		LocalSigningKey: o.LocalSigningKey,
+		RequireKeys:     o.RequireKeys,
 	}}))
 
 	// TODO - Add option for enabling GraphQL Playground

--- a/pkg/coreapi/graph/resolvers/app_mutations.go
+++ b/pkg/coreapi/graph/resolvers/app_mutations.go
@@ -36,7 +36,7 @@ func (r *mutationResolver) CreateApp(ctx context.Context, input models.CreateApp
 	}
 	app, _ := r.Data.UpsertApp(ctx, params)
 
-	if res := deploy.Ping(ctx, input.URL, r.ServerKind, r.LocalSigningKey); res.Err != nil {
+	if res := deploy.Ping(ctx, input.URL, r.ServerKind, r.LocalSigningKey, r.RequireKeys); res.Err != nil {
 		return app, res.Err
 	}
 

--- a/pkg/coreapi/graph/resolvers/resolver.go
+++ b/pkg/coreapi/graph/resolvers/resolver.go
@@ -23,6 +23,12 @@ type Resolver struct {
 
 	// LocalSigningKey is the key used to sign events for self-hosted services.
 	LocalSigningKey string
+
+	// RequireKeys defines whether event and signing keys are required for the
+	// server to function. If this is true and signing keys are not defined,
+	// the server will still boot but core actions such as syncing, runs, and
+	// ingesting events will not work.
+	RequireKeys bool
 }
 
 // Query returns generated.QueryResolver implementation.

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -24,6 +24,7 @@ var (
 	DeployErrNoBranchName        = fmt.Errorf("missing_branch_env_name")
 	DeployErrInvalidSigningKey   = fmt.Errorf("invalid_signing_key")
 	DeployErrNoSigningKey        = fmt.Errorf("missing_signing_key")
+	DeployErrNoServerSigningKey  = fmt.Errorf("missing_server_signing_key")
 	DeployErrInvalidFunction     = fmt.Errorf("invalid_function")
 	DeployErrNoFunctions         = fmt.Errorf("no_functions")
 	DeployErrUnreachable         = fmt.Errorf("unreachable")
@@ -42,7 +43,13 @@ type pingResult struct {
 	IsSDK bool
 }
 
-func Ping(ctx context.Context, url string, serverKind string, signingKey string) pingResult {
+func Ping(ctx context.Context, url string, serverKind string, signingKey string, requireKeys bool) pingResult {
+	if requireKeys && signingKey == "" {
+		return pingResult{
+			Err: DeployErrNoServerSigningKey,
+		}
+	}
+
 	isSDK := false
 
 	reqByt, err := json.Marshal(map[string]string{"url": url})

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -133,6 +133,8 @@ func (a devapi) Info(w http.ResponseWriter, r *http.Request) {
 		Functions:           funcs,
 		Handlers:            a.devserver.handlers,
 		IsSingleNodeService: a.devserver.IsSingleNodeService(),
+		IsMissingSigningKey: a.devserver.Opts.RequireKeys && !a.devserver.HasSigningKey(),
+		IsMissingEventKeys:  a.devserver.Opts.RequireKeys && !a.devserver.HasEventKeys(),
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	byt, _ := json.MarshalIndent(ir, "", "  ")
@@ -556,4 +558,12 @@ type InfoResponse struct {
 	Functions           []inngest.Function `json:"functions"`
 	Handlers            []SDKHandler       `json:"handlers"`
 	IsSingleNodeService bool               `json:"isSingleNodeService"`
+
+	// If true, the server is running in a mode where it requires a signing key
+	// to function and it is not set.
+	IsMissingSigningKey bool `json:"isMissingSigningKey"`
+
+	// If true, the server is running in a mode where it requires one or more
+	// event keys to function and they are not set.
+	IsMissingEventKeys bool `json:"isMissingEventKeys"`
 }

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -69,11 +69,17 @@ type StartOpts struct {
 
 	// SigningKey is used to decide that the server should sign requests and
 	// validate responses where applicable, modelling cloud behaviour.
-	SigningKey *string `json:"signing_key"`
+	SigningKey *string `json:"-"`
 
 	// EventKey is used to authorize incoming events, ensuring they match the
 	// given key.
-	EventKeys []string `json:"event_key"`
+	EventKeys []string `json:"-"`
+
+	// RequireKeys defines whether event and signing keys are required for the
+	// server to function. If this is true and signing keys are not defined,
+	// the server will still boot but core actions such as syncing, runs, and
+	// ingesting events will not work.
+	RequireKeys bool `json:"require_keys"`
 }
 
 // Create and start a new dev server.  The dev server is used during (surprise surprise)

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -129,6 +129,14 @@ func (d *devserver) IsSingleNodeService() bool {
 	return d.singleNodeServiceOpts != nil
 }
 
+func (d *devserver) HasSigningKey() bool {
+	return d.Opts.SigningKey != nil && *d.Opts.SigningKey != ""
+}
+
+func (d *devserver) HasEventKeys() bool {
+	return len(d.Opts.EventKeys) > 0
+}
+
 func (d *devserver) Pre(ctx context.Context) error {
 	// Import Redis if we can and have persistence enabled
 	if d.IsSingleNodeService() {
@@ -182,6 +190,15 @@ func (d *devserver) Run(ctx context.Context) error {
 				fmt.Println("")
 			}
 			fmt.Println("")
+
+			if d.Opts.RequireKeys {
+				if !d.HasSigningKey() {
+					fmt.Println(cli.WarningStyle.Render("\tWARNING: No signing key provided. Syncs and runs will not function.\n\t\t Add a signing key with a flag, environment variable, or config file.\n"))
+				}
+				if !d.HasEventKeys() {
+					fmt.Println(cli.WarningStyle.Render("\tWARNING: No event keys provided. Events will not be accepted.\n\t\t Add event keys with a flag, environment variable, or config file.\n"))
+				}
+			}
 		}()
 	}
 
@@ -286,7 +303,7 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 
 				// Make a new PUT request to each app, indicating that the
 				// SDK should push functions to the dev server.
-				res := deploy.Ping(ctx, app.Url, d.Opts.Config.ServerKind, sk)
+				res := deploy.Ping(ctx, app.Url, d.Opts.Config.ServerKind, sk, d.Opts.RequireKeys)
 				if res.Err != nil {
 					_, _ = d.Data.UpdateAppError(ctx, cqrs.UpdateAppErrorParams{
 						ID: app.ID,
@@ -307,7 +324,7 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 					continue
 				}
 
-				res := deploy.Ping(ctx, u, d.Opts.Config.ServerKind, sk)
+				res := deploy.Ping(ctx, u, d.Opts.Config.ServerKind, sk, d.Opts.RequireKeys)
 
 				// If there was an SDK error then we should still ensure the app
 				// exists. Otherwise, users will have a harder time figuring out

--- a/pkg/execution/driver/httpdriver/config.go
+++ b/pkg/execution/driver/httpdriver/config.go
@@ -24,14 +24,20 @@ func (Config) DriverName() string { return "http" }
 
 func (c Config) NewDriver(opts ...registration.NewDriverOpts) (driver.Driver, error) {
 	var skey []byte
+	requireLocalSigningKey := false
 	if len(opts) > 0 {
-		if opts[0].SigningKey != nil {
-			skey = []byte(*opts[0].SigningKey)
+		if opts[0].LocalSigningKey != nil {
+			skey = []byte(*opts[0].LocalSigningKey)
+		}
+
+		if opts[0].RequireLocalSigningKey {
+			requireLocalSigningKey = true
 		}
 	}
 
 	return &executor{
-		Client:     DefaultClient,
-		signingKey: skey,
+		Client:                 DefaultClient,
+		localSigningKey:        skey,
+		requireLocalSigningKey: requireLocalSigningKey,
 	}, nil
 }

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -232,12 +232,11 @@ func start(ctx context.Context, opts StartOpts) error {
 	}
 
 	var drivers = []driver.Driver{}
-	driverOpts := registration.NewDriverOpts{}
-	if sk != nil {
-		driverOpts.SigningKey = sk
-	}
 	for _, driverConfig := range opts.Config.Execution.Drivers {
-		d, err := driverConfig.NewDriver(driverOpts)
+		d, err := driverConfig.NewDriver(registration.NewDriverOpts{
+			RequireLocalSigningKey: true,
+			LocalSigningKey:        sk,
+		})
 		if err != nil {
 			return err
 		}

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -332,11 +332,12 @@ func start(ctx context.Context, opts StartOpts) error {
 	}
 
 	dsOpts := devserver.StartOpts{
-		Config:     opts.Config,
-		RootDir:    opts.RootDir,
-		URLs:       opts.URLs,
-		Tick:       tick,
-		SigningKey: sk,
+		Config:      opts.Config,
+		RootDir:     opts.RootDir,
+		URLs:        opts.URLs,
+		Tick:        tick,
+		SigningKey:  sk,
+		RequireKeys: true,
 	}
 
 	if opts.PollInterval > 0 {
@@ -385,6 +386,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		Executor:        ds.Executor,
 		HistoryReader:   hr,
 		LocalSigningKey: opts.SigningKey,
+		RequireKeys:     true,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Keys are now always required in `inngest start`. Not including them will display warnings and the relevant functionality (syncs, runs, event ingestion) will not work.

```
$ inngest start
4:13PM INF api > service starting
4:13PM INF runner > starting event stream backend=redis
4:13PM INF persistence > importing Redis snapshot
4:13PM INF api > starting server addr=0.0.0.0:8288
4:13PM INF runner > service starting
4:13PM INF executor > service starting
4:13PM INF executor > subscribing to function queue
4:13PM INF no shard finder;  skipping shard claiming
4:13PM INF runner > subscribing to events topic=events
4:13PM INF persistence > imported Redis snapshot size=0.24KB
4:13PM INF persistence > service starting


        Inngest online at 0.0.0.0:8288, visible at the following URLs:

         - http://127.0.0.1:8288 (http://localhost:8288)
         - http://10.255.255.254:8288
         - http://172.19.11.90:8288


        WARNING: No signing key provided. Syncs and runs will not function.
                 Add a signing key with a flag, environment variable, or config file.

        WARNING: No event keys provided. Events will not be accepted.
                 Add event keys with a flag, environment variable, or config file.
```

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
