### PR TITLE
Fix empty x-inngest-server-kind header

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -12,6 +12,7 @@ import (
 	"github.com/inngest/inngest/cmd/commands/internal/localconfig"
 	"github.com/inngest/inngest/pkg/config"
 	"github.com/inngest/inngest/pkg/devserver"
+	"github.com/inngest/inngest/pkg/headers"
 	itrace "github.com/inngest/inngest/pkg/telemetry/trace"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -99,6 +100,8 @@ func doDev(cmd *cobra.Command, args []string) {
 	defer func() {
 		_ = itrace.CloseUserTracer(ctx)
 	}()
+
+	conf.ServerKind = headers.ServerKindDev
 
 	opts := devserver.StartOpts{
 		Autodiscover:  !noDiscovery,

--- a/pkg/headers/headers.go
+++ b/pkg/headers/headers.go
@@ -25,6 +25,10 @@ const (
 )
 
 func StaticHeadersMiddleware(serverKind string) func(next http.Handler) http.Handler {
+	if serverKind == "" {
+		panic("server kind must be set")
+	}
+
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set(HeaderKeyServerKind, serverKind)


### PR DESCRIPTION
## Description
Fix empty `x-inngest-server-kind` header

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
