### PR TITLE
Fix connection string username parsing

### DIFF
--- a/ui/packages/components/src/PostgresIntegrations/Neon/Auth.tsx
+++ b/ui/packages/components/src/PostgresIntegrations/Neon/Auth.tsx
@@ -2,10 +2,8 @@ import { useEffect, useState } from 'react';
 import { NewButton } from '@inngest/components/Button';
 import { Input } from '@inngest/components/Forms/Input';
 import { NewLink } from '@inngest/components/Link';
-import {
-  IntegrationSteps,
-  parseConnectionString,
-} from '@inngest/components/PostgresIntegrations/types';
+import { IntegrationSteps } from '@inngest/components/PostgresIntegrations/types';
+import { parseConnectionString } from '@inngest/components/PostgresIntegrations/utils';
 import { cn } from '@inngest/components/utils/classNames';
 
 export default function NeonAuth({

--- a/ui/packages/components/src/PostgresIntegrations/Neon/Connect.tsx
+++ b/ui/packages/components/src/PostgresIntegrations/Neon/Connect.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { AccordionList } from '@inngest/components/AccordionCard/AccordionList';
 import { NewButton } from '@inngest/components/Button';
 import { NewLink } from '@inngest/components/Link';
-import { parseConnectionString } from '@inngest/components/PostgresIntegrations/types';
+import { parseConnectionString } from '@inngest/components/PostgresIntegrations/utils';
 import { IconSpinner } from '@inngest/components/icons/Spinner';
 import { RiCheckboxCircleFill, RiCloseCircleFill } from '@remixicon/react';
 

--- a/ui/packages/components/src/PostgresIntegrations/Neon/Format.tsx
+++ b/ui/packages/components/src/PostgresIntegrations/Neon/Format.tsx
@@ -1,10 +1,8 @@
 import { useState } from 'react';
 import { NewButton } from '@inngest/components/Button';
 import { NewLink } from '@inngest/components/Link';
-import {
-  IntegrationSteps,
-  parseConnectionString,
-} from '@inngest/components/PostgresIntegrations/types';
+import { IntegrationSteps } from '@inngest/components/PostgresIntegrations/types';
+import { parseConnectionString } from '@inngest/components/PostgresIntegrations/utils';
 
 export default function NeonFormat({
   onSuccess,

--- a/ui/packages/components/src/PostgresIntegrations/utils.test.ts
+++ b/ui/packages/components/src/PostgresIntegrations/utils.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { parseConnectionString } from './utils';
+
+describe('parseConnectionString', (t) => {
+  it('test basic connection string', () => {
+    const connectionString = 'postgres://user:password@host/db';
+    const parsed = parseConnectionString(connectionString);
+
+    assert.notEqual(parsed, null);
+    assert.deepStrictEqual(parsed, {
+      name: 'Neon-host',
+      engine: 'postgresql',
+      adminConn: connectionString,
+    });
+  });
+
+  it('test alternate protocol and domains', () => {
+    const connectionString = 'postgresql://user:password@host.com/db';
+    const parsed = parseConnectionString(connectionString);
+
+    assert.notEqual(parsed, null);
+    assert.deepStrictEqual(parsed, {
+      name: 'Neon-host.com',
+      engine: 'postgresql',
+      adminConn: connectionString,
+    });
+  });
+
+  it('test user name with delimiters', () => {
+    const connectionString = 'postgres://user-name_underscore:password@host.with.domain/db';
+    const parsed = parseConnectionString(connectionString);
+
+    console.log(parsed);
+
+    assert.notEqual(parsed, null);
+    assert.deepStrictEqual(parsed, {
+      name: 'Neon-host.with.domain',
+      engine: 'postgresql',
+      adminConn: connectionString,
+    });
+  });
+
+  it('test neon connection string', () => {
+    const connectionString =
+      'postgresql://my-database_owner:038hvrd1d@ep-raspy-dust-a5l80fd3.us-east-2.aws.neon.tech/my-database?sslmode=require';
+    const parsed = parseConnectionString(connectionString);
+
+    assert.notEqual(parsed, null);
+    assert.deepStrictEqual(parsed, {
+      name: 'Neon-ep-raspy-dust-a5l80fd3.us-east-2.aws.neon.tech',
+      engine: 'postgresql',
+      adminConn: connectionString,
+    });
+  });
+});

--- a/ui/packages/components/src/PostgresIntegrations/utils.ts
+++ b/ui/packages/components/src/PostgresIntegrations/utils.ts
@@ -1,0 +1,16 @@
+const regex = /postgresq?l?:\/\/([\w-]+):([^@]+)@([^/]+)/;
+
+export function parseConnectionString(connectionString: string) {
+  const match = connectionString.match(regex);
+
+  if (match) {
+    const [, username, password, host] = match;
+    return {
+      name: `Neon-${host}`,
+      engine: 'postgresql',
+      adminConn: connectionString,
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Description

Cover a wide range of valid usernames.

The test added can be run using `tsx ./utils.test.ts`

The file was extracted from types to simplify test running and remove from a "types" file that sounds like it's more just to do with TypeScript types.

## Motivation

The previous connection string parsing would not correctly handle usernames with hyphens.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
