### PR TITLE
Fix width issue in branch environment names 

### DIFF
--- a/ui/apps/dashboard/src/components/Environments/EnvironmentListTable.tsx
+++ b/ui/apps/dashboard/src/components/Environments/EnvironmentListTable.tsx
@@ -173,8 +173,10 @@ function TableRow(props: { env: Environment }) {
 
   return (
     <tr className="hover:bg-slate-100/60">
-      <td className="px-4 py-4">
-        <h3 className="flex items-center gap-2 text-sm font-semibold text-slate-800">{name}</h3>
+      <td className="max-w-80 px-4 py-4">
+        <h3 className="flex items-center gap-2 break-all text-sm font-semibold text-slate-800">
+          {name}
+        </h3>
       </td>
       <td>
         <div className="flex items-center gap-2 px-4" title={`Last synced at ${lastDeployedAt}`}>


### PR DESCRIPTION
## Description
- The environments table has a max width, so we needed to put a width limit to the branch names for things to be functional
Note: instead of truncating with a tooltip, I added a word breaker. We should redesign the entire page at some point

<img width="836" alt="Screenshot 2024-09-24 at 18 39 58" src="https://github.com/user-attachments/assets/c7e8b9d8-74c7-4170-8811-abbb58fe3e79">


## Motivation
Reported by one user via Plain

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
