### PR TITLE
Fix z-index in runs header

### DIFF
--- a/ui/packages/components/src/RunsPage/RunsTable.tsx
+++ b/ui/packages/components/src/RunsPage/RunsTable.tsx
@@ -89,7 +89,7 @@ export default function RunsTable({
   });
 
   const tableStyles = 'w-full border-b border-subtle';
-  const tableHeadStyles = 'shadow-subtle shadow-[0_1px_0] sticky top-[59px] bg-canvasBase z-0';
+  const tableHeadStyles = 'shadow-subtle shadow-[0_1px_0] sticky top-[59px] bg-canvasBase z-[1]';
   const tableBodyStyles = 'divide-y divide-subtle';
   const tableColumnStyles = 'px-4';
 


### PR DESCRIPTION
## Description
- Fix z-index issue on runs

Turns out I had added the z-index for a reason 😅 Needs to be higher than 0 so that on scroll the codeblocks and toggles stay behind. It has to be lower than 5 so it doesn't go on top of the select filters

![Screenshot 2024-09-24 at 19 08 20](https://github.com/user-attachments/assets/a149093b-ab16-47e8-a7f8-f578549145a6)
![Screenshot 2024-09-24 at 19 07 06](https://github.com/user-attachments/assets/8a516944-5d8b-4407-8e74-afc0b87f280a)


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
