### PR TITLE
Add enable-persistence option to start command

### DIFF
--- a/cmd/commands/internal/localconfig/devconfig.go
+++ b/cmd/commands/internal/localconfig/devconfig.go
@@ -114,6 +114,7 @@ func mapStartFlags(cmd *cobra.Command) error {
 	err = errors.Join(err, viper.BindPFlag("sdk-url", cmd.Flags().Lookup("sdk-url")))
 	err = errors.Join(err, viper.BindPFlag("sqlite-dir", cmd.Flags().Lookup("sqlite-dir")))
 	err = errors.Join(err, viper.BindPFlag("tick", cmd.Flags().Lookup("tick")))
+	err = errors.Join(err, viper.BindPFlag("enable-persistence", cmd.Flags().Lookup("enable-persistence")))
 
 	return err
 }

--- a/cmd/commands/internal/localconfig/devconfig.go
+++ b/cmd/commands/internal/localconfig/devconfig.go
@@ -114,7 +114,6 @@ func mapStartFlags(cmd *cobra.Command) error {
 	err = errors.Join(err, viper.BindPFlag("sdk-url", cmd.Flags().Lookup("sdk-url")))
 	err = errors.Join(err, viper.BindPFlag("sqlite-dir", cmd.Flags().Lookup("sqlite-dir")))
 	err = errors.Join(err, viper.BindPFlag("tick", cmd.Flags().Lookup("tick")))
-	err = errors.Join(err, viper.BindPFlag("enable-persistence", cmd.Flags().Lookup("enable-persistence")))
 
 	return err
 }

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -42,6 +42,7 @@ func NewCmdStart(rootCmd *cobra.Command) *cobra.Command {
 	baseFlags.Int("tick", devserver.DefaultTick, "Interval, in milliseconds, of which to check for new work.")
 	baseFlags.String("signing-key", "", "Signing key used to sign and validate data between the server and apps.")
 	baseFlags.StringSlice("event-key", []string{}, "Event key(s) that will be used by apps to send events to the server.")
+	baseFlags.BoolP("enable-persistence", "", true, "Controls whether state is persisted. (default true)")
 	cmd.Flags().AddFlagSet(baseFlags)
 	groups = append(groups, FlagGroup{name: "Flags:", fs: baseFlags})
 
@@ -125,15 +126,16 @@ func doStart(cmd *cobra.Command, args []string) {
 	}
 
 	opts := lite.StartOpts{
-		Config:        *conf,
-		PollInterval:  viper.GetInt("poll-interval"),
-		RedisURI:      viper.GetString("redis-uri"),
-		RetryInterval: viper.GetInt("retry-interval"),
-		Tick:          time.Duration(tick) * time.Millisecond,
-		URLs:          viper.GetStringSlice("sdk-url"),
-		SQLiteDir:     viper.GetString("sqlite-dir"),
-		SigningKey:    viper.GetString("signing-key"),
-		EventKey:      viper.GetStringSlice("event-key"),
+		Config:            *conf,
+		PollInterval:      viper.GetInt("poll-interval"),
+		RedisURI:          viper.GetString("redis-uri"),
+		RetryInterval:     viper.GetInt("retry-interval"),
+		Tick:              time.Duration(tick) * time.Millisecond,
+		URLs:              viper.GetStringSlice("sdk-url"),
+		SQLiteDir:         viper.GetString("sqlite-dir"),
+		SigningKey:        viper.GetString("signing-key"),
+		EventKey:          viper.GetStringSlice("event-key"),
+		EnablePersistence: viper.GetBool("enable-persistence"),
 	}
 
 	err = lite.New(ctx, opts)

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -42,7 +42,6 @@ func NewCmdStart(rootCmd *cobra.Command) *cobra.Command {
 	baseFlags.Int("tick", devserver.DefaultTick, "Interval, in milliseconds, of which to check for new work.")
 	baseFlags.String("signing-key", "", "Signing key used to sign and validate data between the server and apps.")
 	baseFlags.StringSlice("event-key", []string{}, "Event key(s) that will be used by apps to send events to the server.")
-	baseFlags.BoolP("enable-persistence", "", true, "Controls whether state is persisted. (default true)")
 	cmd.Flags().AddFlagSet(baseFlags)
 	groups = append(groups, FlagGroup{name: "Flags:", fs: baseFlags})
 
@@ -135,7 +134,7 @@ func doStart(cmd *cobra.Command, args []string) {
 		SQLiteDir:         viper.GetString("sqlite-dir"),
 		SigningKey:        viper.GetString("signing-key"),
 		EventKey:          viper.GetStringSlice("event-key"),
-		EnablePersistence: viper.GetBool("enable-persistence"),
+		EnablePersistence: !config.IsEnvVarFalsy("INNGEST_EXPERIMENTAL_ENABLE_PERSISTENCE"),
 	}
 
 	err = lite.New(ctx, opts)

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -1,0 +1,11 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+func IsEnvVarFalsy(key string) bool {
+	val := strings.ToLower(os.Getenv(key))
+	return val == "false" || val == "0"
+}

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -70,6 +70,8 @@ type StartOpts struct {
 	// EventKey is used to authorize incoming events, ensuring they match the
 	// given key.
 	EventKey []string `json:"event_key"`
+
+	EnablePersistence bool `json:"enable_persistence"`
 }
 
 // Create and start a new dev server.  The dev server is used during (surprise surprise)
@@ -319,15 +321,24 @@ func start(ctx context.Context, opts StartOpts) error {
 		runner.WithPublisher(pb),
 	)
 
-	// The devserver embeds the event API.
-	pi := consts.StartDefaultPersistenceInterval
-	persistenceInterval := &pi
-	if opts.RedisURI != "" {
-		// If we're using an external Redis, we rely on that to persist and
-		// manage snapshotting
-		persistenceInterval = nil
+	var snso *devserver.SingleNodeServiceOpts
+	if opts.EnablePersistence {
+		// The devserver embeds the event API.
+		pi := consts.StartDefaultPersistenceInterval
+		persistenceInterval := &pi
+		if opts.RedisURI != "" {
+			// If we're using an external Redis, we rely on that to persist and
+			// manage snapshotting
+			persistenceInterval = nil
 
-		logger.From(ctx).Info().Msgf("using external Redis %s; disabling in-memory persistence and snapshotting", opts.RedisURI)
+			logger.From(ctx).Info().Msgf("using external Redis %s; disabling in-memory persistence and snapshotting", opts.RedisURI)
+		}
+
+		snso = &devserver.SingleNodeServiceOpts{
+			PersistenceInterval: persistenceInterval,
+		}
+	} else {
+		logger.From(ctx).Info().Msg("persistence disabled")
 	}
 
 	dsOpts := devserver.StartOpts{
@@ -346,9 +357,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	}
 
 	// The devserver embeds the event API.
-	ds := devserver.NewService(dsOpts, runner, dbcqrs, pb, stepLimitOverrides, stateSizeLimitOverrides, unshardedRc, hd, &devserver.SingleNodeServiceOpts{
-		PersistenceInterval: persistenceInterval,
-	})
+	ds := devserver.NewService(dsOpts, runner, dbcqrs, pb, stepLimitOverrides, stateSizeLimitOverrides, unshardedRc, hd, snso)
 	// embed the tracker
 	ds.Tracker = t
 	ds.State = sm


### PR DESCRIPTION
## Description
Add `enable-persistence` option to `start` command. This is useful for end user integration tests, since everything should be ephemeral.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
