### PR TITLE
Hide skipped from run filter

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/StatusFilter.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/functions/[slug]/logs/StatusFilter.tsx
@@ -45,6 +45,9 @@ export default function StatusFilter({
       return !!functionIsPaused;
     } else if (status === FunctionRunStatus.Running) {
       return !functionIsPaused;
+      // Hide skipped runs from filter
+    } else if (status === FunctionRunStatus.Skipped) {
+      return false;
     }
     return true;
   });

--- a/ui/packages/components/src/Filter/StatusFilter.tsx
+++ b/ui/packages/components/src/Filter/StatusFilter.tsx
@@ -24,6 +24,9 @@ export default function StatusFilter({
       return !!functionIsPaused;
     } else if (status === 'RUNNING') {
       return !functionIsPaused;
+      // Hide skipped runs from filter
+    } else if (status === 'SKIPPED') {
+      return false;
     }
     return true;
   });


### PR DESCRIPTION
## Description
- Hides the "skipped" status from the runs filters.
Note: Darwin is opening a PR to add an exclusion in the backend, so that the runs endpoints don't retrieve them

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
