### PR TITLE
Fix runs issue in Cloud where old results were being displayed again

### DIFF
--- a/ui/apps/dashboard/src/components/Runs/Runs.tsx
+++ b/ui/apps/dashboard/src/components/Runs/Runs.tsx
@@ -147,6 +147,11 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
   const nextPageInfo = nextPageRes.data?.environment.runs.pageInfo;
   const hasNextPage = nextPageInfo?.hasNextPage || firstPageInfo?.hasNextPage;
   const isLoading = firstPageRes.fetching || nextPageRes.fetching;
+  console.log(
+    'hasNextPage' + hasNextPage,
+    'firstPageInfo' + firstPageInfo,
+    'nextPageInfo' + nextPageInfo
+  );
 
   let totalCount = undefined;
   if (!countRes.fetching) {
@@ -160,21 +165,31 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
   }
 
   const firstPageRuns = useMemo(() => {
+    console.log('first page runs:', firstPageRunsData);
     return parseRunsData(firstPageRunsData);
   }, [firstPageRunsData]);
 
   const nextPageRuns = useMemo(() => {
+    console.log('next page runs', nextPageRuns);
     return parseRunsData(nextPageRunsData);
   }, [nextPageRunsData]);
 
   useEffect(() => {
+    console.log('data', firstPageRuns, isScrollRequest);
     if (!isScrollRequest) {
+      console.log(
+        'first data got in',
+        'first page runs:' + firstPageRuns,
+        'isScroll' + isScrollRequest
+      );
       setRuns(firstPageRuns);
     }
   }, [firstPageRuns, isScrollRequest]);
 
   useEffect(() => {
+    console.log('data', 'next page runs:' + nextPageRuns, 'isScroll' + isScrollRequest);
     if (isScrollRequest && nextPageRuns.length > 0) {
+      console.log('got in', 'next page runs:' + nextPageRuns, 'isScroll' + isScrollRequest);
       setRuns((prevRuns) => [...prevRuns, ...nextPageRuns]);
     }
   }, [nextPageRuns, isScrollRequest]);
@@ -187,6 +202,7 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
         // Check if scrolled to the bottom
         const reachedBottom = scrollHeight - scrollTop - clientHeight < 200;
         if (reachedBottom && !isLoading && lastCursor && hasNextPage) {
+          console.log('set scroll request to true');
           setIsScrollRequest(true);
           setCursor(lastCursor);
         }
@@ -197,6 +213,7 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
 
   const onScrollToTop = useCallback(() => {
     setIsScrollRequest(false);
+    console.log('set scroll request to false');
   }, []);
 
   const onRefresh = useCallback(() => {

--- a/ui/apps/dashboard/src/components/Runs/Runs.tsx
+++ b/ui/apps/dashboard/src/components/Runs/Runs.tsx
@@ -147,15 +147,6 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
   const nextPageInfo = nextPageRes.data?.environment.runs.pageInfo;
   const hasNextPage = isScrollRequest ? nextPageInfo?.hasNextPage : firstPageInfo?.hasNextPage;
   const isLoading = firstPageRes.fetching || nextPageRes.fetching;
-  console.log(
-    '1',
-    'hasNextPage: ',
-    hasNextPage,
-    'firstPageInfo: ',
-    firstPageInfo,
-    'nextPageInfo: ',
-    nextPageInfo
-  );
 
   let totalCount = undefined;
   if (!countRes.fetching) {
@@ -176,26 +167,14 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
     return parseRunsData(nextPageRunsData);
   }, [nextPageRunsData]);
 
-  console.log(
-    '2',
-    'firstPageRunsData: ',
-    firstPageRunsData,
-    'nextPageRunsData: ',
-    nextPageRunsData
-  );
-
   useEffect(() => {
-    console.log('3', firstPageRuns, isScrollRequest);
     if (!isScrollRequest) {
-      console.log('4', 'first page runs: ', firstPageRuns, 'isScroll: ', isScrollRequest);
       setRuns(firstPageRuns);
     }
   }, [firstPageRuns, isScrollRequest]);
 
   useEffect(() => {
-    console.log('5', 'next page runs: ', nextPageRuns, 'isScroll: ', isScrollRequest);
     if (isScrollRequest && nextPageRuns.length > 0) {
-      console.log('6', 'next page runs: ', nextPageRuns, 'isScroll: ', isScrollRequest);
       setRuns((prevRuns) => [...prevRuns, ...nextPageRuns]);
     }
   }, [nextPageRuns, isScrollRequest]);
@@ -208,7 +187,6 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
         // Check if scrolled to the bottom
         const reachedBottom = scrollHeight - scrollTop - clientHeight < 200;
         if (reachedBottom && !isLoading && lastCursor && hasNextPage) {
-          console.log('set scroll request to true');
           setIsScrollRequest(true);
           setCursor(lastCursor);
         }
@@ -219,7 +197,6 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
 
   const onScrollToTop = useCallback(() => {
     setIsScrollRequest(false);
-    console.log('set scroll request to false');
   }, []);
 
   const onRefresh = useCallback(() => {

--- a/ui/apps/dashboard/src/components/Runs/Runs.tsx
+++ b/ui/apps/dashboard/src/components/Runs/Runs.tsx
@@ -145,7 +145,7 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
   const nextPageRunsData = nextPageRes.data?.environment.runs.edges;
   const firstPageInfo = firstPageRes.data?.environment.runs.pageInfo;
   const nextPageInfo = nextPageRes.data?.environment.runs.pageInfo;
-  const hasNextPage = nextPageInfo?.hasNextPage || firstPageInfo?.hasNextPage;
+  const hasNextPage = isScrollRequest ? nextPageInfo?.hasNextPage : firstPageInfo?.hasNextPage;
   const isLoading = firstPageRes.fetching || nextPageRes.fetching;
   console.log(
     '1',

--- a/ui/apps/dashboard/src/components/Runs/Runs.tsx
+++ b/ui/apps/dashboard/src/components/Runs/Runs.tsx
@@ -165,14 +165,14 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
   }
 
   const firstPageRuns = useMemo(() => {
-    console.log('first page runs:', firstPageRunsData);
     return parseRunsData(firstPageRunsData);
   }, [firstPageRunsData]);
 
   const nextPageRuns = useMemo(() => {
-    console.log('next page runs', nextPageRuns);
     return parseRunsData(nextPageRunsData);
   }, [nextPageRunsData]);
+
+  console.log('firstPageRunsData' + firstPageRunsData, 'nextPageRunsData' + nextPageRunsData);
 
   useEffect(() => {
     console.log('data', firstPageRuns, isScrollRequest);

--- a/ui/apps/dashboard/src/components/Runs/Runs.tsx
+++ b/ui/apps/dashboard/src/components/Runs/Runs.tsx
@@ -148,9 +148,13 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
   const hasNextPage = nextPageInfo?.hasNextPage || firstPageInfo?.hasNextPage;
   const isLoading = firstPageRes.fetching || nextPageRes.fetching;
   console.log(
-    'hasNextPage' + hasNextPage,
-    'firstPageInfo' + firstPageInfo,
-    'nextPageInfo' + nextPageInfo
+    '1',
+    'hasNextPage: ',
+    hasNextPage,
+    'firstPageInfo: ',
+    firstPageInfo,
+    'nextPageInfo: ',
+    nextPageInfo
   );
 
   let totalCount = undefined;
@@ -172,24 +176,26 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
     return parseRunsData(nextPageRunsData);
   }, [nextPageRunsData]);
 
-  console.log('firstPageRunsData' + firstPageRunsData, 'nextPageRunsData' + nextPageRunsData);
+  console.log(
+    '2',
+    'firstPageRunsData: ',
+    firstPageRunsData,
+    'nextPageRunsData: ',
+    nextPageRunsData
+  );
 
   useEffect(() => {
-    console.log('data', firstPageRuns, isScrollRequest);
+    console.log('3', firstPageRuns, isScrollRequest);
     if (!isScrollRequest) {
-      console.log(
-        'first data got in',
-        'first page runs:' + firstPageRuns,
-        'isScroll' + isScrollRequest
-      );
+      console.log('4', 'first page runs: ', firstPageRuns, 'isScroll: ', isScrollRequest);
       setRuns(firstPageRuns);
     }
   }, [firstPageRuns, isScrollRequest]);
 
   useEffect(() => {
-    console.log('data', 'next page runs:' + nextPageRuns, 'isScroll' + isScrollRequest);
+    console.log('5', 'next page runs: ', nextPageRuns, 'isScroll: ', isScrollRequest);
     if (isScrollRequest && nextPageRuns.length > 0) {
-      console.log('got in', 'next page runs:' + nextPageRuns, 'isScroll' + isScrollRequest);
+      console.log('6', 'next page runs: ', nextPageRuns, 'isScroll: ', isScrollRequest);
       setRuns((prevRuns) => [...prevRuns, ...nextPageRuns]);
     }
   }, [nextPageRuns, isScrollRequest]);

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/runs/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/runs/page.tsx
@@ -85,7 +85,7 @@ export default function Page() {
     [filterApp, filteredStatus, calculatedStartTime, timeField]
   );
 
-  const { data, fetchNextPage, isFetching } = useInfiniteQuery({
+  const { data, fetchNextPage, isFetching, hasNextPage } = useInfiniteQuery({
     queryKey: ['runs'],
     queryFn,
     refetchInterval: autoRefresh ? pollInterval : false,
@@ -188,7 +188,7 @@ export default function Page() {
         features={{
           history: Number.MAX_SAFE_INTEGER,
         }}
-        hasMore={false}
+        hasMore={hasNextPage ?? false}
         isLoadingInitial={isFetching && runs === undefined}
         isLoadingMore={isFetching && runs !== undefined}
         getRun={getRun}

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -87,7 +87,7 @@ export function RunsPage({
   totalCount,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
-  console.log('runs page', 'data:' + data, 'has more' + hasMore);
+  console.log('runs page', 'data: ', data, 'has more: ', hasMore);
   const columns = useScopedColumns(scope);
 
   const displayAllColumns = useMemo(() => {

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -87,7 +87,6 @@ export function RunsPage({
   totalCount,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
-  console.log('runs page', 'data: ', data, 'has more: ', hasMore);
   const columns = useScopedColumns(scope);
 
   const displayAllColumns = useMemo(() => {

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -87,7 +87,7 @@ export function RunsPage({
   totalCount,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
-
+  console.log('runs page', 'data:' + data, 'has more' + hasMore);
   const columns = useScopedColumns(scope);
 
   const displayAllColumns = useMemo(() => {


### PR DESCRIPTION
## Description
For runs with more than one page, hasNextPage was always set to `true` causing some side effects that affected the data array.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
