### PR TITLE
Always set inner queue name (i.Data.QueueName) during Enqueue()

### DIFF
--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -105,6 +105,10 @@ func (q *queue) Enqueue(ctx context.Context, item osqueue.Item, at time.Time) er
 		item.QueueName = queueName
 	}
 
+	if queueName != nil && *queueName == "" {
+		return fmt.Errorf("encountered empty string for queue name")
+	}
+
 	metrics.IncrQueueItemStatusCounter(ctx, metrics.CounterOpt{
 		PkgName: pkgName,
 		Tags: map[string]any{

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -100,6 +100,11 @@ func (q *queue) Enqueue(ctx context.Context, item osqueue.Item, at time.Time) er
 		queueName = item.QueueName
 	}
 
+	// ensure both QueueName attributes are always set (ItemPartitions depends on this)
+	if queueName != nil && item.QueueName == nil {
+		item.QueueName = queueName
+	}
+
 	metrics.IncrQueueItemStatusCounter(ctx, metrics.CounterOpt{
 		PkgName: pkgName,
 		Tags: map[string]any{


### PR DESCRIPTION
## Description

> [!CAUTION]
> Roll this out before #1518 

This is required for ItemPartitions to work, as we previously used the inner queueName exclusively.

One potential improvement is to deduplicate queueNames altogether, there's no reason as to why we store the same attribute twice.

https://linear.app/inngest/issue/INN-3816

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
