### PR TITLE
try revalidating path in server component

### DIFF
--- a/ui/apps/dashboard/src/app/(auth)/organization-list/[[...organization-list]]/page.tsx
+++ b/ui/apps/dashboard/src/app/(auth)/organization-list/[[...organization-list]]/page.tsx
@@ -1,3 +1,5 @@
+'use server';
+
 import { revalidatePath } from 'next/cache';
 import { OrganizationList } from '@clerk/nextjs';
 

--- a/ui/apps/dashboard/src/components/Navigation/Logo.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Logo.tsx
@@ -18,8 +18,13 @@ const NavToggle = ({ collapsed, setCollapsed }: LogoProps) => {
   const toggle = async () => {
     const toggled = !collapsed;
     setCollapsed(toggled);
-    typeof window !== 'undefined' &&
+
+    if (typeof window !== 'undefined') {
       window.cookieStore.set('navCollapsed', toggled ? 'true' : 'false');
+      //
+      // some downstream things, like charts, may need to redraw themselves
+      setTimeout(() => window.dispatchEvent(new Event('resize')), 200);
+    }
   };
 
   return (


### PR DESCRIPTION
## Description

Before switching orgs we do:

`revalidatePath('/', 'layout');`

According to https://nextjs.org/docs/app/api-reference/functions/revalidatePath this should purge "all" Client-side Router Cache and revalidate the Data Cache on the next page visit. It clearly does not as we're getting stale data in our metrics lookups. 

There is no indication in the docs that "use server" is necessary but I did see a comment on one of the many bug reports about revalidatePath/revalidateTag that it may be necessary, so worth a shot. 

Also, force a window resize even on nav expand/collapse so charts resize themselves.

## Motivation
Bugfixes

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
