### PR TITLE
turbo again

### DIFF
--- a/ui/apps/dashboard/next.config.js
+++ b/ui/apps/dashboard/next.config.js
@@ -91,6 +91,46 @@ const nextConfig = {
     // Tunnel sentry events to help circumvent ad-blockers.
     tunnelRoute: '/api/sentry',
   },
+  //
+  // Webpack is still here for production builds as next only supports turbo for dev.
+  webpack(config, { isServer }) {
+    // Configures webpack to handle SVG files with SVGR. SVGR optimizes and transforms SVG files
+    // into React components. See https://react-svgr.com/docs/next/
+
+    // Grab the existing rule that handles SVG imports
+    // @ts-ignore - this is a private property that is not typed
+    const fileLoaderRule = config.module.rules.find((rule) => rule.test?.test?.('.svg'));
+
+    config.module.rules.push(
+      // Reapply the existing rule, but only for svg imports ending in ?url
+      {
+        ...fileLoaderRule,
+        test: /\.svg$/i,
+        resourceQuery: /url/, // *.svg?url
+      },
+      // Convert all other *.svg imports to React components
+      {
+        test: /\.svg$/i,
+        issuer: fileLoaderRule.issuer,
+        resourceQuery: { not: [...fileLoaderRule.resourceQuery.not, /url/] }, // exclude if *.svg?url
+        use: ['@svgr/webpack'],
+      }
+    );
+
+    // Modify the file loader rule to ignore *.svg, since we have it handled now.
+    fileLoaderRule.exclude = /\.svg$/i;
+
+    // If client-side, don't polyfill `fs`.
+    // This is needed for `quickjs-emscripten` to work on the client. See https://github.com/justjake/quickjs-emscripten/issues/33#issuecomment-739098440
+    if (!isServer) {
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        fs: false,
+      };
+    }
+
+    return config;
+  },
 };
 
 /**

--- a/ui/apps/dashboard/next.config.js
+++ b/ui/apps/dashboard/next.config.js
@@ -5,7 +5,14 @@ const { withSentryConfig } = require('@sentry/nextjs');
 const nextConfig = {
   productionBrowserSourceMaps: true,
   experimental: {
-    // typedRoutes: true,
+    turbo: {
+      rules: {
+        '*.svg': {
+          loaders: ['@svgr/webpack'],
+          as: '*.js',
+        },
+      },
+    },
   },
   images: {
     remotePatterns: [
@@ -83,44 +90,6 @@ const nextConfig = {
     hideSourceMaps: false,
     // Tunnel sentry events to help circumvent ad-blockers.
     tunnelRoute: '/api/sentry',
-  },
-  webpack(config, { isServer }) {
-    // Configures webpack to handle SVG files with SVGR. SVGR optimizes and transforms SVG files
-    // into React components. See https://react-svgr.com/docs/next/
-
-    // Grab the existing rule that handles SVG imports
-    // @ts-ignore - this is a private property that is not typed
-    const fileLoaderRule = config.module.rules.find((rule) => rule.test?.test?.('.svg'));
-
-    config.module.rules.push(
-      // Reapply the existing rule, but only for svg imports ending in ?url
-      {
-        ...fileLoaderRule,
-        test: /\.svg$/i,
-        resourceQuery: /url/, // *.svg?url
-      },
-      // Convert all other *.svg imports to React components
-      {
-        test: /\.svg$/i,
-        issuer: fileLoaderRule.issuer,
-        resourceQuery: { not: [...fileLoaderRule.resourceQuery.not, /url/] }, // exclude if *.svg?url
-        use: ['@svgr/webpack'],
-      }
-    );
-
-    // Modify the file loader rule to ignore *.svg, since we have it handled now.
-    fileLoaderRule.exclude = /\.svg$/i;
-
-    // If client-side, don't polyfill `fs`.
-    // This is needed for `quickjs-emscripten` to work on the client. See https://github.com/justjake/quickjs-emscripten/issues/33#issuecomment-739098440
-    if (!isServer) {
-      config.resolve.fallback = {
-        ...config.resolve.fallback,
-        fs: false,
-      };
-    }
-
-    return config;
   },
 };
 

--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -12,7 +12,7 @@
   "main": "n/a",
   "scripts": {
     "dev": "pnpm install && concurrently --prefix-colors \"green.inverse,magenta.inverse,blue.inverse\" pnpm:dev:*",
-    "dev:next": "next dev -H 0.0.0.0",
+    "dev:next": "next dev -H 0.0.0.0 --turbo",
     "dev:graphql-codegen": "graphql-codegen -w",
     "build": "if test \"$VERCEL_ENV\" = \"production\"; then pnpm graphql-codegen && next build; else next build; fi",
     "start": "next start",
@@ -33,7 +33,7 @@
     "@headlessui/tailwindcss": "0.1.2",
     "@inngest/components": "workspace:*",
     "@launchdarkly/node-server-sdk": "9.0.3",
-    "@next/third-parties": "14.1.3",
+    "@next/third-parties": "14.2.13",
     "@radix-ui/react-accordion": "1.1.2",
     "@radix-ui/react-dialog": "1.0.5",
     "@radix-ui/react-popover": "1.0.7",
@@ -62,7 +62,7 @@
     "graphql-request": "6.1.0",
     "ky": "0.33.3",
     "launchdarkly-react-client-sdk": "3.0.8",
-    "next": "14.2.10",
+    "next": "14.2.13",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-syntax-highlighter": "15.5.0",
@@ -81,7 +81,7 @@
     "@graphql-codegen/cli": "3.2.2",
     "@graphql-codegen/client-preset": "2.1.0",
     "@inngest/tsconfig": "workspace:*",
-    "@next/env": "14.0.3",
+    "@next/env": "14.2.13",
     "@storybook/addon-essentials": "7.5.3",
     "@storybook/addon-interactions": "7.5.3",
     "@storybook/addon-links": "7.5.3",
@@ -104,13 +104,17 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-storybook": "0.6.15",
     "postcss": "8.4.31",
-    "quickjs-emscripten": "0.11.0",
+    "quickjs-emscripten": "0.31.0",
     "storybook": "7.5.3",
     "tailwindcss": "3.4.1",
     "ts-node": "10.9.1",
     "typescript": "5.1.3",
     "vercel": "32.4.1"
   },
+  "workspaces": [
+    "packages/*",
+    "apps/*"
+  ],
   "engines": {
     "node": "20.x",
     "pnpm": "8.15.8"

--- a/ui/apps/dashboard/src/utils/vm.ts
+++ b/ui/apps/dashboard/src/utils/vm.ts
@@ -34,7 +34,8 @@ export default async function makeVM(timeout: number = -1) {
   const disposables = new DisposableComposer();
 
   const QuickJS = await getQuickJS();
-  const vm = QuickJS.createVm();
+  const vm = QuickJS.newContext();
+
   let alive = true;
   disposables.add({
     get alive() {
@@ -47,7 +48,7 @@ export default async function makeVM(timeout: number = -1) {
   });
 
   if (timeout !== -1) {
-    vm.setInterruptHandler(shouldInterruptAfterDeadline(Date.now() + timeout));
+    vm.runtime.setInterruptHandler(shouldInterruptAfterDeadline(Date.now() + timeout));
   }
 
   const trueHandle = vm.unwrapResult(vm.evalCode('true'));
@@ -113,7 +114,7 @@ export default async function makeVM(timeout: number = -1) {
           target.then((result: any) => {
             const marshaled = marshal(result);
             deferred.resolve(marshaled);
-            vm.executePendingJobs(-1);
+            vm.runtime.executePendingJobs(-1);
           });
           return deferred.handle;
         }
@@ -381,7 +382,7 @@ export default async function makeVM(timeout: number = -1) {
      */
     dump: typedBind(vm.dump, vm),
 
-    executePendingJobs: typedBind(vm.executePendingJobs, vm),
+    executePendingJobs: typedBind(vm.runtime.executePendingJobs, vm),
 
     /**
      * Unwrap a VmCallResult, returning it's value on success, and throwing the dumped
@@ -396,13 +397,13 @@ export default async function makeVM(timeout: number = -1) {
      *
      * The interrupt handler can be removed with [[removeInterruptHandler]].
      */
-    setInterruptHandler: typedBind(vm.setInterruptHandler, vm),
+    setInterruptHandler: typedBind(vm.runtime.setInterruptHandler, vm),
 
     /**
      * Remove the interrupt handler, if any.
      * See [[setInterruptHandler]].
      */
-    removeInterruptHandler: typedBind(vm.removeInterruptHandler, vm),
+    removeInterruptHandler: typedBind(vm.runtime.removeInterruptHandler, vm),
 
     /**
      * Dispose of this VM's underlying resources.

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
     dependencies:
       '@clerk/nextjs':
         specifier: 4.29.3
-        version: 4.29.3(next@14.2.10)(react-dom@18.2.0)(react@18.2.0)
+        version: 4.29.3(next@14.2.13)(react-dom@18.2.0)(react@18.2.0)
       '@graphql-typed-document-node/core':
         specifier: 3.2.0
         version: 3.2.0(graphql@16.8.1)
@@ -48,8 +48,8 @@ importers:
         specifier: 9.0.3
         version: 9.0.3
       '@next/third-parties':
-        specifier: 14.1.3
-        version: 14.1.3(next@14.2.10)(react@18.2.0)
+        specifier: 14.2.13
+        version: 14.2.13(next@14.2.13)(react@18.2.0)
       '@radix-ui/react-accordion':
         specifier: 1.1.2
         version: 1.1.2(@types/react-dom@18.2.4)(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0)
@@ -76,7 +76,7 @@ importers:
         version: 4.2.0(react@18.2.0)
       '@sentry/nextjs':
         specifier: 7.88.0
-        version: 7.88.0(next@14.2.10)(react@18.2.0)(webpack@5.94.0)
+        version: 7.88.0(next@14.2.13)(react@18.2.0)(webpack@5.94.0)
       '@sindresorhus/slugify':
         specifier: 2.2.0
         version: 2.2.0
@@ -135,8 +135,8 @@ importers:
         specifier: 3.0.8
         version: 3.0.8(react-dom@18.2.0)(react@18.2.0)
       next:
-        specifier: 14.2.10
-        version: 14.2.10(@babel/core@7.25.2)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 14.2.13
+        version: 14.2.13(@babel/core@7.25.2)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -187,8 +187,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/tsconfig
       '@next/env':
-        specifier: 14.0.3
-        version: 14.0.3
+        specifier: 14.2.13
+        version: 14.2.13
       '@storybook/addon-essentials':
         specifier: 7.5.3
         version: 7.5.3(@types/react-dom@18.2.4)(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0)
@@ -203,7 +203,7 @@ importers:
         version: 7.5.3(@types/react-dom@18.2.4)(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/nextjs':
         specifier: 7.5.3
-        version: 7.5.3(@swc/core@1.7.26)(@types/react-dom@18.2.4)(@types/react@18.2.11)(esbuild@0.18.20)(next@14.2.10)(react-dom@18.2.0)(react@18.2.0)(type-fest@3.7.2)(typescript@5.1.3)(webpack@5.94.0)
+        version: 7.5.3(@swc/core@1.7.26)(@types/react-dom@18.2.4)(@types/react@18.2.11)(esbuild@0.18.20)(next@14.2.13)(react-dom@18.2.0)(react@18.2.0)(type-fest@3.7.2)(typescript@5.1.3)(webpack@5.94.0)
       '@storybook/react':
         specifier: 7.5.3
         version: 7.5.3(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
@@ -256,8 +256,8 @@ importers:
         specifier: 8.4.31
         version: 8.4.31
       quickjs-emscripten:
-        specifier: 0.11.0
-        version: 0.11.0
+        specifier: 0.31.0
+        version: 0.31.0
       storybook:
         specifier: 7.5.3
         version: 7.5.3
@@ -390,7 +390,7 @@ importers:
         version: 7.5.3(@types/react-dom@18.2.4)(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/nextjs':
         specifier: 7.5.3
-        version: 7.5.3(@swc/core@1.7.26)(@types/react-dom@18.2.4)(@types/react@18.2.11)(esbuild@0.18.20)(next@14.2.10)(react-dom@18.2.0)(react@18.2.0)(type-fest@3.7.2)(typescript@5.1.3)(webpack@5.94.0)
+        version: 7.5.3(@swc/core@1.7.26)(@types/react-dom@18.2.4)(@types/react@18.2.11)(esbuild@0.18.20)(next@14.2.10)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(webpack@5.94.0)
       '@storybook/react':
         specifier: 7.5.3
         version: 7.5.3(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
@@ -580,7 +580,7 @@ importers:
         version: 7.5.3(@types/react-dom@18.2.4)(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0)
       '@storybook/nextjs':
         specifier: 7.5.3
-        version: 7.5.3(@swc/core@1.7.26)(@types/react@18.2.11)(esbuild@0.18.20)(next@14.2.10)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(webpack@5.94.0)
+        version: 7.5.3(@swc/core@1.7.26)(@types/react-dom@18.2.4)(@types/react@18.2.11)(esbuild@0.18.20)(next@14.2.10)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(webpack@5.94.0)
       '@storybook/react':
         specifier: 7.5.3
         version: 7.5.3(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
@@ -5287,7 +5287,7 @@ packages:
       - react
     dev: false
 
-  /@clerk/nextjs@4.29.3(next@14.2.10)(react-dom@18.2.0)(react@18.2.0):
+  /@clerk/nextjs@4.29.3(next@14.2.13)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-qPBHjOAEAwKPnBx7eat6oB5SUlqWWTALeize+pY4TRYURliUk/iZtNFFr/smF87bYCNwslZ+vDRQznEQsSpSkA==}
     engines: {node: '>=14'}
     peerDependencies:
@@ -5300,7 +5300,7 @@ packages:
       '@clerk/clerk-sdk-node': 4.13.6(react@18.2.0)
       '@clerk/shared': 1.3.1(react@18.2.0)
       '@clerk/types': 3.60.0
-      next: 14.2.10(@babel/core@7.25.2)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.2.13(@babel/core@7.25.2)(react-dom@18.2.0)(react@18.2.0)
       path-to-regexp: 6.2.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -6917,6 +6917,34 @@ packages:
       chalk: 4.1.2
     dev: true
 
+  /@jitl/quickjs-ffi-types@0.31.0:
+    resolution: {integrity: sha512-1yrgvXlmXH2oNj3eFTrkwacGJbmM0crwipA3ohCrjv52gBeDaD7PsTvFYinlAnqU8iPME3LGP437yk05a2oejw==}
+    dev: true
+
+  /@jitl/quickjs-wasmfile-debug-asyncify@0.31.0:
+    resolution: {integrity: sha512-YkdzQdr1uaftFhgEnTRjTTZHk2SFZdpWO7XhOmRVbi6CEVsH9g5oNF8Ta1q3OuSJHRwwT8YsuR1YzEiEIJEk6w==}
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.31.0
+    dev: true
+
+  /@jitl/quickjs-wasmfile-debug-sync@0.31.0:
+    resolution: {integrity: sha512-8XvloaaWBONqcHXYs5tWOjdhQVxzULilIfB2hvZfS6S+fI4m2+lFiwQy7xeP8ExHmiZ7D8gZGChNkdLgjGfknw==}
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.31.0
+    dev: true
+
+  /@jitl/quickjs-wasmfile-release-asyncify@0.31.0:
+    resolution: {integrity: sha512-uz0BbQYTxNsFkvkurd7vk2dOg57ElTBLCuvNtRl4rgrtbC++NIndD5qv2+AXb6yXDD3Uy1O2PCwmoaH0eXgEOg==}
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.31.0
+    dev: true
+
+  /@jitl/quickjs-wasmfile-release-sync@0.31.0:
+    resolution: {integrity: sha512-hYduecOByj9AsAfsJhZh5nA6exokmuFC8cls39+lYmTCGY51bgjJJJwReEu7Ff7vBWaQCL6TeDdVlnp2WYz0jw==}
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.31.0
+    dev: true
+
   /@jridgewell/gen-mapping@0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
     engines: {node: '>=6.0.0'}
@@ -7122,12 +7150,11 @@ packages:
       tar-fs: 2.1.1
     dev: true
 
-  /@next/env@14.0.3:
-    resolution: {integrity: sha512-7xRqh9nMvP5xrW4/+L0jgRRX+HoNRGnfJpD+5Wq6/13j3dsdzxO3BCXn7D3hMqsDb+vjZnJq+vI7+EtgrYZTeA==}
-    dev: true
-
   /@next/env@14.2.10:
     resolution: {integrity: sha512-dZIu93Bf5LUtluBXIv4woQw2cZVZ2DJTjax5/5DOs3lzEOeKLy7GxRSr4caK9/SCPdaW6bCgpye6+n4Dh9oJPw==}
+
+  /@next/env@14.2.13:
+    resolution: {integrity: sha512-s3lh6K8cbW1h5Nga7NNeXrbe0+2jIIYK9YaA9T7IufDWnZpozdFUp6Hf0d5rNWUKu4fEuSX2rCKlGjCrtylfDw==}
 
   /@next/eslint-plugin-next@14.0.2:
     resolution: {integrity: sha512-APrYFsXfAhnysycqxHcpg6Y4i7Ukp30GzVSZQRKT3OczbzkqGjt33vNhScmgoOXYBU1CfkwgtXmNxdiwv1jKmg==}
@@ -7143,8 +7170,24 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@next/swc-darwin-arm64@14.2.13:
+    resolution: {integrity: sha512-IkAmQEa2Htq+wHACBxOsslt+jMoV3msvxCn0WFSfJSkv/scy+i/EukBKNad36grRxywaXUYJc9mxEGkeIs8Bzg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /@next/swc-darwin-x64@14.2.10:
     resolution: {integrity: sha512-Y0TC+FXbFUQ2MQgimJ/7Ina2mXIKhE7F+GUe1SgnzRmwFY3hX2z8nyVCxE82I2RicspdkZnSWMn4oTjIKz4uzA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /@next/swc-darwin-x64@14.2.13:
+    resolution: {integrity: sha512-Dv1RBGs2TTjkwEnFMVL5XIfJEavnLqqwYSD6LXgTPdEy/u6FlSrLBSSfe1pcfqhFEXRAgVL3Wpjibe5wXJzWog==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -7159,8 +7202,24 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@next/swc-linux-arm64-gnu@14.2.13:
+    resolution: {integrity: sha512-yB1tYEFFqo4ZNWkwrJultbsw7NPAAxlPXURXioRl9SdW6aIefOLS+0TEsKrWBtbJ9moTDgU3HRILL6QBQnMevg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@next/swc-linux-arm64-musl@14.2.10:
     resolution: {integrity: sha512-n2i5o3y2jpBfXFRxDREr342BGIQCJbdAUi/K4q6Env3aSx8erM9VuKXHw5KNROK9ejFSPf0LhoSkU/ZiNdacpQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@next/swc-linux-arm64-musl@14.2.13:
+    resolution: {integrity: sha512-v5jZ/FV/eHGoWhMKYrsAweQ7CWb8xsWGM/8m1mwwZQ/sutJjoFaXchwK4pX8NqwImILEvQmZWyb8pPTcP7htWg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -7175,8 +7234,24 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@next/swc-linux-x64-gnu@14.2.13:
+    resolution: {integrity: sha512-aVc7m4YL7ViiRv7SOXK3RplXzOEe/qQzRA5R2vpXboHABs3w8vtFslGTz+5tKiQzWUmTmBNVW0UQdhkKRORmGA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@next/swc-linux-x64-musl@14.2.10:
     resolution: {integrity: sha512-opFFN5B0SnO+HTz4Wq4HaylXGFV+iHrVxd3YvREUX9K+xfc4ePbRrxqOuPOFjtSuiVouwe6uLeDtabjEIbkmDA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@next/swc-linux-x64-musl@14.2.13:
+    resolution: {integrity: sha512-4wWY7/OsSaJOOKvMsu1Teylku7vKyTuocvDLTZQq0TYv9OjiYYWt63PiE1nTuZnqQ4RPvME7Xai+9enoiN0Wrg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -7191,8 +7266,24 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@next/swc-win32-arm64-msvc@14.2.13:
+    resolution: {integrity: sha512-uP1XkqCqV2NVH9+g2sC7qIw+w2tRbcMiXFEbMihkQ8B1+V6m28sshBwAB0SDmOe0u44ne1vFU66+gx/28RsBVQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@next/swc-win32-ia32-msvc@14.2.10:
     resolution: {integrity: sha512-fr3aEbSd1GeW3YUMBkWAu4hcdjZ6g4NBl1uku4gAn661tcxd1bHs1THWYzdsbTRLcCKLjrDZlNp6j2HTfrw+Bg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@next/swc-win32-ia32-msvc@14.2.13:
+    resolution: {integrity: sha512-V26ezyjPqQpDBV4lcWIh8B/QICQ4v+M5Bo9ykLN+sqeKKBxJVDpEc6biDVyluTXTC40f5IqCU0ttth7Es2ZuMw==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
@@ -7207,13 +7298,21 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@next/third-parties@14.1.3(next@14.2.10)(react@18.2.0):
-    resolution: {integrity: sha512-c3l0JnJzB5L2xXWK9DbH6nFpV1Z9vPFCiFan5l/pbwHjWGKxS8Q532MLAOW6EHB00vhCre8F/okBjGyPAGYpnw==}
+  /@next/swc-win32-x64-msvc@14.2.13:
+    resolution: {integrity: sha512-WwzOEAFBGhlDHE5Z73mNU8CO8mqMNLqaG+AO9ETmzdCQlJhVtWZnOl2+rqgVQS+YHunjOWptdFmNfbpwcUuEsw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@next/third-parties@14.2.13(next@14.2.13)(react@18.2.0):
+    resolution: {integrity: sha512-OSqD2E9JO0/GE8HT5QAUsYVXwjWtPLScAX70kO2xopwDAdRzakrsQS55Cihd862X/4bUB37ApVZ9DlHcExzeOg==}
     peerDependencies:
       next: ^13.0.0 || ^14.0.0
       react: ^18.2.0
     dependencies:
-      next: 14.2.10(@babel/core@7.25.2)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.2.13(@babel/core@7.25.2)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       third-party-capital: 1.0.20
     dev: false
@@ -9220,7 +9319,7 @@ packages:
       localforage: 1.10.0
     dev: false
 
-  /@sentry/nextjs@7.88.0(next@14.2.10)(react@18.2.0)(webpack@5.94.0):
+  /@sentry/nextjs@7.88.0(next@14.2.13)(react@18.2.0)(webpack@5.94.0):
     resolution: {integrity: sha512-tvP9KU7SeL65szenGoexABdPqCVMUTWEP9DroNvBDvTtqfETOf8RbGw8zE+bFNxQ9bjAzhJPibu6oWNcpYvXMA==}
     engines: {node: '>=8'}
     peerDependencies:
@@ -9241,7 +9340,7 @@ packages:
       '@sentry/vercel-edge': 7.88.0
       '@sentry/webpack-plugin': 1.21.0
       chalk: 3.0.0
-      next: 14.2.10(@babel/core@7.25.2)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.2.13(@babel/core@7.25.2)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       resolve: 1.22.8
       rollup: 2.78.0
@@ -10466,7 +10565,7 @@ packages:
     resolution: {integrity: sha512-TXJJd5RAKakWx4BtpwvSNdgTDkKM6RkXU8GK34S/LhidQ5Pjz3wcnqb0TxEkfhK/ztbP8nKHqXFwLfa2CYkvQw==}
     dev: true
 
-  /@storybook/nextjs@7.5.3(@swc/core@1.7.26)(@types/react-dom@18.2.4)(@types/react@18.2.11)(esbuild@0.18.20)(next@14.2.10)(react-dom@18.2.0)(react@18.2.0)(type-fest@3.7.2)(typescript@5.1.3)(webpack@5.94.0):
+  /@storybook/nextjs@7.5.3(@swc/core@1.7.26)(@types/react-dom@18.2.4)(@types/react@18.2.11)(esbuild@0.18.20)(next@14.2.10)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(webpack@5.94.0):
     resolution: {integrity: sha512-PYi9AJga6x46IN4aub9CuiKNF9mT3maTh1F9dXqE4kO+ZrbesiKcJ3Uud0D78c56/Jlr8FmHEDpO19OlgRM4kQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -10552,7 +10651,7 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@storybook/nextjs@7.5.3(@swc/core@1.7.26)(@types/react@18.2.11)(esbuild@0.18.20)(next@14.2.10)(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(webpack@5.94.0):
+  /@storybook/nextjs@7.5.3(@swc/core@1.7.26)(@types/react-dom@18.2.4)(@types/react@18.2.11)(esbuild@0.18.20)(next@14.2.13)(react-dom@18.2.0)(react@18.2.0)(type-fest@3.7.2)(typescript@5.1.3)(webpack@5.94.0):
     resolution: {integrity: sha512-PYi9AJga6x46IN4aub9CuiKNF9mT3maTh1F9dXqE4kO+ZrbesiKcJ3Uud0D78c56/Jlr8FmHEDpO19OlgRM4kQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -10597,7 +10696,7 @@ packages:
       fs-extra: 11.2.0
       image-size: 1.1.1
       loader-utils: 3.3.1
-      next: 14.2.10(@babel/core@7.25.2)(react-dom@18.2.0)(react@18.2.0)
+      next: 14.2.13(@babel/core@7.25.2)(react-dom@18.2.0)(react@18.2.0)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.94.0)
       pnp-webpack-plugin: 1.7.0(typescript@5.1.3)
       postcss: 8.4.31
@@ -19584,6 +19683,47 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
 
+  /next@14.2.13(@babel/core@7.25.2)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-BseY9YNw8QJSwLYD7hlZzl6QVDoSFHL/URN5K64kVEVpCsSOWeyjbIGK+dZUaRViHTaMQX8aqmnn0PHBbGZezg==}
+    engines: {node: '>=18.17.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.41.2
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 14.2.13
+      '@swc/helpers': 0.5.5
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001662
+      graceful-fs: 4.2.11
+      postcss: 8.4.31
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.25.2)(react@18.2.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 14.2.13
+      '@next/swc-darwin-x64': 14.2.13
+      '@next/swc-linux-arm64-gnu': 14.2.13
+      '@next/swc-linux-arm64-musl': 14.2.13
+      '@next/swc-linux-x64-gnu': 14.2.13
+      '@next/swc-linux-x64-musl': 14.2.13
+      '@next/swc-win32-arm64-msvc': 14.2.13
+      '@next/swc-win32-ia32-msvc': 14.2.13
+      '@next/swc-win32-x64-msvc': 14.2.13
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   /no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
@@ -20933,8 +21073,21 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /quickjs-emscripten@0.11.0:
-    resolution: {integrity: sha512-adOtvmMDEQD9fsFZXgV+vfnAAjPuvEvYv5QpiS3SXM0fj7NOMkY7uSJ61SdWADcT5xa6n6P7JdYIievqODsDyA==}
+  /quickjs-emscripten-core@0.31.0:
+    resolution: {integrity: sha512-oQz8p0SiKDBc1TC7ZBK2fr0GoSHZKA0jZIeXxsnCyCs4y32FStzCW4d1h6E1sE0uHDMbGITbk2zhNaytaoJwXQ==}
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.31.0
+    dev: true
+
+  /quickjs-emscripten@0.31.0:
+    resolution: {integrity: sha512-K7Yt78aRPLjPcqv3fIuLW1jW3pvwO21B9pmFOolsjM/57ZhdVXBr51GqJpalgBlkPu9foAvhEAuuQPnvIGvLvQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@jitl/quickjs-wasmfile-debug-asyncify': 0.31.0
+      '@jitl/quickjs-wasmfile-debug-sync': 0.31.0
+      '@jitl/quickjs-wasmfile-release-asyncify': 0.31.0
+      '@jitl/quickjs-wasmfile-release-sync': 0.31.0
+      quickjs-emscripten-core: 0.31.0
     dev: true
 
   /ramda@0.29.0:


### PR DESCRIPTION
## Description

Enable turbopack.

This updates next to get the turbo fixes they did for us (https://github.com/vercel/next.js/issues/69254) and update quickjs to work around issues we had with that for signing/event keys with our last attempt to upgrade turbo. 

Page loads times are still pretty bad for anything loaded the first time locally, but this helps some with hmr.

## Motivation
Chip away at local dev issues. 

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
