### PR TITLE
fix auto-collapse

### DIFF
--- a/ui/apps/dashboard/src/components/Layout/SideBar.tsx
+++ b/ui/apps/dashboard/src/components/Layout/SideBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 
 import type { Environment } from '@/utils/environments';
@@ -25,16 +25,28 @@ export default function SideBar({
   activeEnv?: Environment;
   profile: ProfileType;
 }) {
+  const navRef = useRef<HTMLDivElement>(null);
+
   const [collapsed, setCollapsed] = useState<boolean>(serverCollapsed ?? false);
   const { isWidgetOpen, showWidget, closeWidget } = useOnboardingWidget();
+
+  const autoCollapse = () =>
+    typeof window !== 'undefined' &&
+    window.matchMedia('(max-width: 800px)').matches &&
+    setCollapsed(true);
 
   useEffect(() => {
     //
     // if the user has not set a pref and they are on mobile, collapse by default
-    serverCollapsed === undefined &&
-      setCollapsed(
-        typeof window !== 'undefined' && window.matchMedia('(max-width: 800px)').matches
-      );
+    serverCollapsed === undefined && autoCollapse();
+
+    if (navRef.current !== null) {
+      window.addEventListener('resize', autoCollapse);
+
+      return () => {
+        window.removeEventListener('resize', autoCollapse);
+      };
+    }
   }, []);
 
   return (
@@ -43,6 +55,7 @@ export default function SideBar({
          top-0 flex h-screen flex-col justify-start ${
            collapsed ? 'w-[64px]' : 'w-[224px]'
          }  sticky z-[51] shrink-0 overflow-visible border-r`}
+      ref={navRef}
     >
       <Logo collapsed={collapsed} setCollapsed={setCollapsed} />
       <div className="flex grow flex-col justify-between">

--- a/ui/apps/dashboard/src/components/Navigation/Logo.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Logo.tsx
@@ -23,7 +23,7 @@ const NavToggle = ({ collapsed, setCollapsed }: LogoProps) => {
       window.cookieStore.set('navCollapsed', toggled ? 'true' : 'false');
       //
       // some downstream things, like charts, may need to redraw themselves
-      setTimeout(() => window.dispatchEvent(new Event('resize')), 200);
+      setTimeout(() => window.dispatchEvent(new Event('navToggle')), 200);
     }
   };
 

--- a/ui/packages/components/src/Chart/Chart.tsx
+++ b/ui/packages/components/src/Chart/Chart.tsx
@@ -34,10 +34,12 @@ export const Chart = ({
         chart?.resize();
       };
       window.addEventListener('resize', resizeChart);
+      window.addEventListener('navToggle', resizeChart);
 
       return () => {
         chart?.dispose();
         window.removeEventListener('resize', resizeChart);
+        window.removeEventListener('navToggle', resizeChart);
       };
     }
   }, [theme]);


### PR DESCRIPTION
## Description

Noticed this wasn't working as intended while testing metrics.

Now nav collapses on load by default if the user has not already manually expanded/collapsed on that device and it collapses on resize.

## Motivation
Better use of space.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
