### PR TITLE
Fix: Only show search when flag is enabled

### DIFF
--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -321,11 +321,13 @@ export function RunsPage({
             <TotalCount totalCount={totalCount} />
           </div>
           <div className="flex items-center gap-2">
-            <NewButton
-              appearance="ghost"
-              label={showSearch ? 'Hide search' : 'Show search'}
-              onClick={() => setShowSearch((prev) => !prev)}
-            />
+            {hasSearchFlag && (
+              <NewButton
+                appearance="ghost"
+                label={showSearch ? 'Hide search' : 'Show search'}
+                onClick={() => setShowSearch((prev) => !prev)}
+              />
+            )}
             <TableFilter
               columnVisibility={columnVisibility}
               setColumnVisibility={setColumnVisibility}


### PR DESCRIPTION
## Description

Search toggle should only show when flip is enabled

![image](https://github.com/user-attachments/assets/4c5fdbc6-e208-4b27-9d23-7ff166d12045)


## Motivation
Bug

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
