### PR TITLE
enable chart grouping for metrics dashboard

### DIFF
--- a/ui/apps/dashboard/src/components/Metrics/Concurrency.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/Concurrency.tsx
@@ -32,7 +32,7 @@ export const mapConcurrency = (
       type: 'category' as const,
       boundaryGap: true,
       data: runningMetrics[0]?.data.map(({ bucket }) => bucket) || ['No Data Found'],
-      axisPointer: { show: true, type: 'line' as const },
+      axisPointer: { show: true, type: 'line' as const, label: { show: false } },
       axisLabel: {
         interval: dataLength <= 40 ? 2 : dataLength / (dataLength / 12),
         formatter: (value: string) => dateFormat(value, diff),

--- a/ui/apps/dashboard/src/components/Metrics/utils.ts
+++ b/ui/apps/dashboard/src/components/Metrics/utils.ts
@@ -85,6 +85,11 @@ export const getLineChartOptions = (
       renderMode: 'html',
       enterable: true,
       //
+      // Off by default because we don't like the tooltip
+      // behavior for chart groups. We toggle this programmatically
+      // per chart at the dom level
+      show: false,
+      //
       // Attach tooltips to a dedicated dom node above interim parents
       // with low z-indexes
       appendTo: () => document.getElementById('chart-tooltip'),
@@ -132,6 +137,7 @@ export const mapEntityLines = (
       type: 'category' as const,
       boundaryGap: true,
       data: metrics[0]?.data.map(({ bucket }) => bucket) || ['No Data Found'],
+      axisPointer: { show: true, type: 'line' as const, label: { show: false } },
       axisLabel: {
         interval: dataLength <= 40 ? 2 : dataLength / (dataLength / 12),
         formatter: (value: string) => dateFormat(value, diff),

--- a/ui/packages/components/src/Chart/Chart.tsx
+++ b/ui/packages/components/src/Chart/Chart.tsx
@@ -30,6 +30,13 @@ export const Chart = ({
 }: ChartProps) => {
   const chartRef = useRef<HTMLDivElement>(null);
 
+  const toggleTooltip = (show: boolean) => {
+    if (chartRef.current !== null) {
+      const chart = getInstanceByDom(chartRef.current);
+      chart?.setOption({ tooltip: { show } });
+    }
+  };
+
   useEffect(() => {
     if (chartRef.current !== null) {
       const chart = init(chartRef.current, theme);
@@ -53,12 +60,19 @@ export const Chart = ({
       const chart = getInstanceByDom(chartRef.current);
       chart?.setOption(option, settings);
 
-      // if (chart && group) {
-      //   chart.group = group;
-      //   connect(group);
-      // }
+      if (chart && group) {
+        chart.group = group;
+        connect(group);
+      }
     }
   }, [option, settings]);
 
-  return <div ref={chartRef} className={className} />;
+  return (
+    <div
+      ref={chartRef}
+      className={className}
+      {...(group && { onMouseEnter: () => toggleTooltip(true) })}
+      {...(group && { onMouseLeave: () => toggleTooltip(false) })}
+    />
+  );
 };


### PR DESCRIPTION
## Description

Group our metrics charts so we can share our axis pointer position across all charts. I'm controlling the tooltip manually so that is not also shared because we found that too busy. 

https://github.com/user-attachments/assets/645ecc1c-9b78-4544-8942-f158619da2fe

## Motivation
Highlight time series cursor position across all charts.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
