### PR TITLE
Fix guaranteed capacity

### DIFF
--- a/pkg/execution/state/redis_state/guaranteed_capacity_test.go
+++ b/pkg/execution/state/redis_state/guaranteed_capacity_test.go
@@ -1,0 +1,125 @@
+package redis_state
+
+import (
+	"encoding/json"
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSerializeGuaranteedCapacity(t *testing.T) {
+	cases := []struct {
+		name string
+		got  GuaranteedCapacity
+		want json.RawMessage
+	}{
+		{
+			name: "leased gc",
+			got: GuaranteedCapacity{
+				Scope:              enums.GuaranteedCapacityScopeAccount,
+				AccountID:          uuid.MustParse("c06e5559-74fd-4404-8754-d06b6f342d10"),
+				Priority:           0,
+				GuaranteedCapacity: 1,
+				Leases:             []ulid.ULID{ulid.MustParse("01J9S37W106HK23TGK5MNPY09J")},
+			},
+			want: json.RawMessage(`{"s":"Account","a":"c06e5559-74fd-4404-8754-d06b6f342d10","p":0,"gc":1,"leases":["01J9S37W106HK23TGK5MNPY09J"]}`),
+		},
+		{
+			name: "non-leased gc",
+			got: GuaranteedCapacity{
+				Scope:              enums.GuaranteedCapacityScopeAccount,
+				AccountID:          uuid.MustParse("c06e5559-74fd-4404-8754-d06b6f342d10"),
+				Priority:           0,
+				GuaranteedCapacity: 1,
+			},
+			want: json.RawMessage(`{"s":"Account","a":"c06e5559-74fd-4404-8754-d06b6f342d10","p":0,"gc":1,"leases":null}`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.Marshal(tc.got)
+			require.NoError(t, err)
+			require.JSONEq(t, string(tc.want), string(got))
+		})
+	}
+}
+
+func TestDeserializeGuaranteedCapacity(t *testing.T) {
+	cases := []struct {
+		name string
+		got  json.RawMessage
+		want GuaranteedCapacity
+	}{
+		{
+			name: "empty gc",
+			got:  json.RawMessage(`{}`),
+			want: GuaranteedCapacity{},
+		},
+		{
+			name: "gc with empty leases obj",
+			got: json.RawMessage(`{
+				"s": "Account",
+				"a": "c06e5559-74fd-4404-8754-d06b6f342d10",
+				"p": 0,
+				"gc": 1,
+				"leases": {}
+			}`),
+			want: GuaranteedCapacity{
+				Scope:              enums.GuaranteedCapacityScopeAccount,
+				AccountID:          uuid.MustParse("c06e5559-74fd-4404-8754-d06b6f342d10"),
+				Priority:           0,
+				GuaranteedCapacity: 1,
+				Leases:             nil,
+			},
+		},
+		{
+			name: "gc with empty leases obj",
+			got: json.RawMessage(`{
+				"s": "Account",
+				"a": "c06e5559-74fd-4404-8754-d06b6f342d10",
+				"p": 0,
+				"gc": 1,
+				"leases": []
+			}`),
+			want: GuaranteedCapacity{
+				Scope:              enums.GuaranteedCapacityScopeAccount,
+				AccountID:          uuid.MustParse("c06e5559-74fd-4404-8754-d06b6f342d10"),
+				Priority:           0,
+				GuaranteedCapacity: 1,
+				Leases:             []ulid.ULID{},
+			},
+		},
+		{
+			name: "gc with non-empty leases obj",
+			got: json.RawMessage(`{
+				"s": "Account",
+				"a": "c06e5559-74fd-4404-8754-d06b6f342d10",
+				"p": 0,
+				"gc": 2,
+				"leases": ["01J9S37W106HK23TGK5MNPY09J", "01J9S37YW0HHABTVCJ7WNFAV5N"]
+			}`),
+			want: GuaranteedCapacity{
+				Scope:              enums.GuaranteedCapacityScopeAccount,
+				AccountID:          uuid.MustParse("c06e5559-74fd-4404-8754-d06b6f342d10"),
+				Priority:           0,
+				GuaranteedCapacity: 2,
+				Leases: []ulid.ULID{
+					ulid.MustParse("01J9S37W106HK23TGK5MNPY09J"),
+					ulid.MustParse("01J9S37YW0HHABTVCJ7WNFAV5N"),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got GuaranteedCapacity
+			err := json.Unmarshal(tc.got, &got)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -1263,10 +1263,7 @@ func (q *queue) EnqueueItem(ctx context.Context, i QueueItem, at time.Time) (Que
 		guaranteedCapacity *GuaranteedCapacity
 
 		// initialize guaranteed capacity key for automatic cleanup
-		guaranteedCapacityKey = GuaranteedCapacity{
-			Scope:     enums.GuaranteedCapacityScopeAccount,
-			AccountID: i.Data.Identifier.AccountID,
-		}.Key()
+		guaranteedCapacityKey = guaranteedCapacityKeyForAccount(i.Data.Identifier.AccountID)
 	)
 	if q.gcf != nil && !isSystemPartition {
 		// Fetch guaranteed capacity for the given account. If there is no guaranteed

--- a/pkg/execution/state/redis_state/queue_processor_test.go
+++ b/pkg/execution/state/redis_state/queue_processor_test.go
@@ -115,7 +115,7 @@ func TestQueueRunBasic(t *testing.T) {
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 
-	idA, idB := uuid.New(), uuid.New()
+	idA, idB, accountId := uuid.New(), uuid.New(), uuid.New()
 	items := []QueueItem{
 		{
 			FunctionID: idA,
@@ -123,6 +123,7 @@ func TestQueueRunBasic(t *testing.T) {
 				Kind:        osqueue.KindEdge,
 				MaxAttempts: max(3),
 				Identifier: state.Identifier{
+					AccountID:  accountId,
 					WorkflowID: idA,
 					RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
 				},
@@ -134,6 +135,7 @@ func TestQueueRunBasic(t *testing.T) {
 				Kind:        osqueue.KindEdge,
 				MaxAttempts: max(1),
 				Identifier: state.Identifier{
+					AccountID:  accountId,
 					WorkflowID: idB,
 					RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
 				},
@@ -146,6 +148,7 @@ func TestQueueRunBasic(t *testing.T) {
 				Kind:        "test-kind",
 				MaxAttempts: max(1),
 				Identifier: state.Identifier{
+					AccountID:  accountId,
 					WorkflowID: idB,
 					RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
 				},
@@ -204,7 +207,7 @@ func TestQueueRunRetry(t *testing.T) {
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 
-	idA := uuid.New()
+	idA, accountId := uuid.New(), uuid.New()
 	items := []QueueItem{
 		{
 			FunctionID: idA,
@@ -212,6 +215,7 @@ func TestQueueRunRetry(t *testing.T) {
 				Kind:        osqueue.KindEdge,
 				MaxAttempts: max(3),
 				Identifier: state.Identifier{
+					AccountID:  accountId,
 					WorkflowID: idA,
 					RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
 				},
@@ -473,7 +477,7 @@ func TestRunPriorityFactor(t *testing.T) {
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 
-	idA, idB := uuid.New(), uuid.New()
+	idA, idB, accountId := uuid.New(), uuid.New(), uuid.New()
 	factor2 := int64(2)
 	items := []osqueue.Item{
 		{
@@ -481,6 +485,7 @@ func TestRunPriorityFactor(t *testing.T) {
 			Kind:        osqueue.KindEdge,
 			MaxAttempts: max(1),
 			Identifier: state.Identifier{
+				AccountID:  accountId,
 				WorkflowID: idA,
 				RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
 			},
@@ -490,6 +495,7 @@ func TestRunPriorityFactor(t *testing.T) {
 			Kind:        osqueue.KindEdge,
 			MaxAttempts: max(1),
 			Identifier: state.Identifier{
+				AccountID:  accountId,
 				WorkflowID: idB,
 				RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
 				// Enqueue 2 seconds prior to the actual At time
@@ -571,6 +577,7 @@ func TestQueueAllowList(t *testing.T) {
 		})
 	}()
 
+	accountId := uuid.New()
 	items := []QueueItem{
 		{
 			QueueName: &allowedQueueName,
@@ -589,7 +596,8 @@ func TestQueueAllowList(t *testing.T) {
 				Kind:        osqueue.KindEdge,
 				MaxAttempts: max(1),
 				Identifier: state.Identifier{
-					RunID: ulid.MustNew(ulid.Now(), rand.Reader),
+					AccountID: accountId,
+					RunID:     ulid.MustNew(ulid.Now(), rand.Reader),
 				},
 			},
 		},
@@ -599,7 +607,8 @@ func TestQueueAllowList(t *testing.T) {
 				Kind:        osqueue.KindEdge,
 				MaxAttempts: max(1),
 				Identifier: state.Identifier{
-					RunID: ulid.MustNew(ulid.Now(), rand.Reader),
+					AccountID: accountId,
+					RunID:     ulid.MustNew(ulid.Now(), rand.Reader),
 				},
 			},
 		},
@@ -682,6 +691,7 @@ func TestQueueDenyList(t *testing.T) {
 		})
 	}()
 
+	accountId := uuid.New()
 	items := []QueueItem{
 		{
 			QueueName: &deniedQueueName,
@@ -700,7 +710,8 @@ func TestQueueDenyList(t *testing.T) {
 				Kind:        osqueue.KindEdge,
 				MaxAttempts: max(1),
 				Identifier: state.Identifier{
-					RunID: ulid.MustNew(ulid.Now(), rand.Reader),
+					AccountID: accountId,
+					RunID:     ulid.MustNew(ulid.Now(), rand.Reader),
 				},
 			},
 		},
@@ -710,7 +721,8 @@ func TestQueueDenyList(t *testing.T) {
 				Kind:        osqueue.KindEdge,
 				MaxAttempts: max(1),
 				Identifier: state.Identifier{
-					RunID: ulid.MustNew(ulid.Now(), rand.Reader),
+					AccountID: accountId,
+					RunID:     ulid.MustNew(ulid.Now(), rand.Reader),
 				},
 			},
 		},

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -4021,13 +4021,13 @@ func TestAccountLease(t *testing.T) {
 
 	_, err = q.EnqueueItem(ctx, QueueItem{Data: osqueue.Item{Identifier: state.Identifier{AccountID: idA}}}, time.Now())
 	require.NoError(t, err)
-	exists, err := rc.Do(ctx, rc.B().Hexists().Key(q.u.kg.GuaranteedCapacityMap()).Field(GuaranteedCapacity{AccountID: idA}.Key()).Build()).AsBool()
+	exists, err := rc.Do(ctx, rc.B().Hexists().Key(q.u.kg.GuaranteedCapacityMap()).Field(guaranteedCapacityKeyForAccount(idA)).Build()).AsBool()
 	require.NoError(t, err)
 	require.True(t, exists, r.Dump())
 
 	_, err = q.EnqueueItem(ctx, QueueItem{Data: osqueue.Item{Identifier: state.Identifier{AccountID: idB}}}, time.Now())
 	require.NoError(t, err)
-	exists, err = rc.Do(ctx, rc.B().Hexists().Key(q.u.kg.GuaranteedCapacityMap()).Field(GuaranteedCapacity{AccountID: idB}.Key()).Build()).AsBool()
+	exists, err = rc.Do(ctx, rc.B().Hexists().Key(q.u.kg.GuaranteedCapacityMap()).Field(guaranteedCapacityKeyForAccount(idB)).Build()).AsBool()
 	require.NoError(t, err)
 	require.True(t, exists, r.Dump())
 


### PR DESCRIPTION
Since MemoryDB will serialize empty arrays to empty objects, we now properly handle this case when unmarshaling guaranteed capacity values in Go.

## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
