### PR TITLE
add and style the new metrics chart tooltip

### DIFF
--- a/ui/apps/dashboard/src/components/Metrics/ChartTooltip.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/ChartTooltip.tsx
@@ -1,4 +1,4 @@
-import type { DefaultLabelFormatterCallbackParams } from '@inngest/components/Chart/Chart.jsx';
+import type { DefaultLabelFormatterCallbackParams } from '@inngest/components/Chart/Chart';
 import { RiFileCopyLine } from '@remixicon/react';
 
 export const ChartTooltip = ({

--- a/ui/apps/dashboard/src/components/Metrics/ChartTooltip.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/ChartTooltip.tsx
@@ -9,10 +9,10 @@ export const ChartTooltip = ({
 }: DefaultLabelFormatterCallbackParams) => {
   return (
     <div
-      style={{ maxWidth: '300px;', borderColor: String(color) }}
+      style={{ maxWidth: '300px', borderColor: String(color) }}
       className={` flex flex-col justify-start gap-1 border-l-4 py-2`}
     >
-      <div className="text-subtle overflow-hidden text-ellipsis px-3 pt-1 text-xs font-medium uppercase tracking-wide">
+      <div className="text-subtle overflow-hidden text-ellipsis px-3 text-xs font-medium uppercase tracking-wide">
         {seriesName}
       </div>
       <div className="text-basis px-3 font-normal leading-normal">{String(value)}</div>

--- a/ui/apps/dashboard/src/components/Metrics/ChartTooltip.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/ChartTooltip.tsx
@@ -1,0 +1,26 @@
+import type { DefaultLabelFormatterCallbackParams } from '@inngest/components/Chart/Chart.jsx';
+import { RiFileCopyLine } from '@remixicon/react';
+
+export const ChartTooltip = ({
+  seriesName,
+  value,
+  name,
+  color,
+}: DefaultLabelFormatterCallbackParams) => {
+  return (
+    <div
+      style={{ maxWidth: '300px;', borderColor: String(color) }}
+      className={` flex flex-col justify-start gap-1 border-l-4 py-2`}
+    >
+      <div className="text-subtle overflow-hidden text-ellipsis px-3 pt-1 text-xs font-medium uppercase tracking-wide">
+        {seriesName}
+      </div>
+      <div className="text-basis px-3 font-normal leading-normal">{String(value)}</div>
+      <hr />
+      <div className="text-subtle flex flex-row items-center justify-start gap-2 px-3 text-xs leading-normal">
+        <RiFileCopyLine className="h-3 w-3 cursor-pointer" />
+        <div>{name}</div>
+      </div>
+    </div>
+  );
+};

--- a/ui/apps/dashboard/src/components/Metrics/utils.ts
+++ b/ui/apps/dashboard/src/components/Metrics/utils.ts
@@ -6,14 +6,16 @@ import type {
 import { resolveColor } from '@inngest/components/utils/colors';
 import { differenceInMilliseconds, lightFormat, toDate } from '@inngest/components/utils/date';
 import { isDark } from '@inngest/components/utils/theme';
+import ReactDOMServer from 'react-dom/server';
 import resolveConfig from 'tailwindcss/resolveConfig';
 
 import type { MetricsData, ScopedMetric } from '@/gql/graphql';
 import tailwindConfig from '../../../tailwind.config';
+import { ChartTooltip } from './ChartTooltip';
 import type { EntityLookup, EntityType } from './Dashboard';
 
 const {
-  theme: { colors },
+  theme: { colors, backgroundColor, textColor, borderColor },
 } = resolveConfig(tailwindConfig);
 
 export type LineChartData = {
@@ -40,7 +42,7 @@ export const seriesOptions: LineSeriesOption = {
   showSymbol: false,
   lineStyle: { width: 1 },
   emphasis: {
-    focus: 'series',
+    focus: 'none',
   },
 };
 
@@ -75,15 +77,19 @@ export const convertLookup = (entities?: EntityType[]): EntityLookup | {} =>
 export const sum = (data?: MetricsData[]) =>
   data ? data.reduce((acc, { value }) => acc + value, 0) : 0;
 
+export const formatNumber = (number?: number | bigint) => (number || 0).toLocaleString(undefined);
+
 export const getLineChartOptions = (
   data: Partial<ChartProps['option']>,
   legendData?: LegendComponentOption['data']
 ): ChartProps['option'] => {
   return {
     tooltip: {
-      trigger: 'axis',
+      trigger: 'item',
       renderMode: 'html',
       enterable: true,
+      position: 'top',
+
       //
       // Off by default because we don't like the tooltip
       // behavior for chart groups. We toggle this programmatically
@@ -93,9 +99,16 @@ export const getLineChartOptions = (
       // Attach tooltips to a dedicated dom node above interim parents
       // with low z-indexes
       appendTo: () => document.getElementById('chart-tooltip'),
-      extraCssText: 'max-height: 350px; overflow-y: scroll;',
-      className: 'no-scrollbar',
-      transitionDuration: 1.5,
+      transitionDuration: 1,
+      //
+      // rendering our tooltip componen to a string doesn't support click events
+      // so wrap the whole thing in a vanilla js clipboard cliip handler
+      formatter: (params: any) =>
+        `<div onclick="navigator.clipboard.writeText('${
+          params.name
+        }')">${ReactDOMServer.renderToString(ChartTooltip(params))}</div>`,
+      padding: 0,
+      extraCssText: `border: 0px;`,
     },
     legend: {
       type: 'scroll',
@@ -122,6 +135,40 @@ export const getLineChartOptions = (
   };
 };
 
+export const getXAxis = (metrics: ScopedMetric[]) => {
+  const dark = isDark();
+
+  const diff = timeDiff(metrics[0]?.data[0]?.bucket, metrics[0]?.data.at(-1)?.bucket);
+  const dataLength = metrics[0]?.data?.length || 30;
+
+  return {
+    type: 'category' as const,
+    boundaryGap: true,
+    data: metrics[0]?.data.map(({ bucket }) => bucket) || ['No Data Found'],
+    axisPointer: {
+      show: true,
+      type: 'line' as const,
+      label: {
+        show: false,
+        borderWidth: 1,
+        padding: 8,
+        borderColor: resolveColor(borderColor.subtle, dark),
+        color: resolveColor(textColor.basis, dark),
+        backgroundColor: resolveColor(backgroundColor.canvasBase, dark),
+        shadowColor: resolveColor(borderColor.subtle, dark),
+        shadowBlur: 4,
+        formatter: ({ value }: any) => dateFormat(value, diff),
+      },
+      triggerTooltip: false,
+    },
+    axisLabel: {
+      interval: dataLength <= 40 ? 2 : dataLength / (dataLength / 12),
+      formatter: (value: string) => dateFormat(value, diff),
+      margin: 10,
+    },
+  };
+};
+
 export const mapEntityLines = (
   metrics: ScopedMetric[],
   entities: EntityLookup,
@@ -129,21 +176,8 @@ export const mapEntityLines = (
 ) => {
   const dark = isDark();
 
-  const diff = timeDiff(metrics[0]?.data[0]?.bucket, metrics[0]?.data.at(-1)?.bucket);
-  const dataLength = metrics[0]?.data?.length || 30;
-
   return {
-    xAxis: {
-      type: 'category' as const,
-      boundaryGap: true,
-      data: metrics[0]?.data.map(({ bucket }) => bucket) || ['No Data Found'],
-      axisPointer: { show: true, type: 'line' as const, label: { show: false } },
-      axisLabel: {
-        interval: dataLength <= 40 ? 2 : dataLength / (dataLength / 12),
-        formatter: (value: string) => dateFormat(value, diff),
-        margin: 10,
-      },
-    },
+    xAxis: getXAxis(metrics),
     series: metrics.map((f, i) => {
       return {
         ...seriesOptions,

--- a/ui/apps/dashboard/src/components/Metrics/utils.ts
+++ b/ui/apps/dashboard/src/components/Metrics/utils.ts
@@ -101,7 +101,7 @@ export const getLineChartOptions = (
       appendTo: () => document.getElementById('chart-tooltip'),
       transitionDuration: 1,
       //
-      // rendering our tooltip componen to a string doesn't support click events
+      // rendering our tooltip component to a string removes click events,
       // so wrap the whole thing in a vanilla js clipboard cliip handler
       formatter: (params: any) =>
         `<div onclick="navigator.clipboard.writeText('${

--- a/ui/apps/dashboard/src/components/Metrics/utils.ts
+++ b/ui/apps/dashboard/src/components/Metrics/utils.ts
@@ -150,6 +150,7 @@ export const getXAxis = (metrics: ScopedMetric[]) => {
       type: 'line' as const,
       label: {
         show: false,
+        snap: true,
         borderWidth: 1,
         padding: 8,
         borderColor: resolveColor(borderColor.subtle, dark),

--- a/ui/packages/components/src/Chart/Chart.tsx
+++ b/ui/packages/components/src/Chart/Chart.tsx
@@ -5,13 +5,14 @@ import {
   connect,
   getInstanceByDom,
   init,
+  type DefaultLabelFormatterCallbackParams,
   type EChartsOption,
   type LegendComponentOption,
   type LineSeriesOption,
   type SetOptionOpts,
 } from 'echarts';
 
-export type { LineSeriesOption, LegendComponentOption };
+export type { LineSeriesOption, LegendComponentOption, DefaultLabelFormatterCallbackParams };
 
 export interface ChartProps {
   option: EChartsOption;
@@ -30,10 +31,10 @@ export const Chart = ({
 }: ChartProps) => {
   const chartRef = useRef<HTMLDivElement>(null);
 
-  const toggleTooltip = (show: boolean) => {
+  const toggleTooltips = (show: boolean) => {
     if (chartRef.current !== null) {
       const chart = getInstanceByDom(chartRef.current);
-      chart?.setOption({ tooltip: { show } });
+      chart?.setOption({ tooltip: { show }, xAxis: { axisPointer: { label: { show } } } });
     }
   };
 
@@ -71,8 +72,8 @@ export const Chart = ({
     <div
       ref={chartRef}
       className={className}
-      {...(group && { onMouseEnter: () => toggleTooltip(true) })}
-      {...(group && { onMouseLeave: () => toggleTooltip(false) })}
+      {...(group && { onMouseEnter: () => toggleTooltips(true) })}
+      {...(group && { onMouseLeave: () => toggleTooltips(false) })}
     />
   );
 };


### PR DESCRIPTION
## Description

Adds a custom tooltip component that better matches the designs and shims it into the charts. 
<img width="364" alt="Screenshot 2024-10-09 at 4 48 16 PM" src="https://github.com/user-attachments/assets/40ee8c65-d9d1-45cf-b5c6-2d8e81c86de4">
<img width="651" alt="Screenshot 2024-10-09 at 4 48 08 PM" src="https://github.com/user-attachments/assets/f3ac8c67-80ac-4545-9c6a-4e80724eef3b">


## Motivation
Better tooltip

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
