### PR TITLE
Log when status code is 0

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -372,6 +372,14 @@ func do(ctx context.Context, c HTTPDoer, r Request) (*response, error) {
 		}
 	}
 
+	if resp.StatusCode == 0 {
+		// Unreachable
+		log.From(ctx).Error().Err(err).
+			Str("body", string(byt)).
+			Str("run_id", r.RunID.String()).
+			Msg("status code is 0")
+	}
+
 	// Check the retry status from the headers and versions.
 	noRetry = !shouldRetry(statusCode, headers[headerNoRetry], headers[headerSDK])
 


### PR DESCRIPTION
## Description
A user reported that sometimes they see `invalid status code: 0` on failing runs. This shouldn't happen so we'll add a log for further debugging.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
