### PR TITLE
Add mutex to state metadata reads/writes

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -115,8 +115,6 @@ type Request struct {
 
 // DoRequest executes the HTTP request with the given input.
 func DoRequest(ctx context.Context, c HTTPDoer, r Request) (*state.DriverResponse, error) {
-	fmt.Println("\nDoRequest")
-
 	if c == nil {
 		c = DefaultClient
 	}
@@ -139,7 +137,6 @@ func DoRequest(ctx context.Context, c HTTPDoer, r Request) (*state.DriverRespons
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println("status code", resp.statusCode)
 
 	if resp.statusCode == 206 {
 		// This is a generator-based function returning opcodes.

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -115,6 +115,8 @@ type Request struct {
 
 // DoRequest executes the HTTP request with the given input.
 func DoRequest(ctx context.Context, c HTTPDoer, r Request) (*state.DriverResponse, error) {
+	fmt.Println("\nDoRequest")
+
 	if c == nil {
 		c = DefaultClient
 	}
@@ -137,6 +139,7 @@ func DoRequest(ctx context.Context, c HTTPDoer, r Request) (*state.DriverRespons
 	if err != nil {
 		return nil, err
 	}
+	fmt.Println("status code", resp.statusCode)
 
 	if resp.statusCode == 206 {
 		// This is a generator-based function returning opcodes.

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -407,7 +407,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	// function run spanID
 	spanID := run.NewSpanID(ctx)
 
-	config := sv2.Config{
+	config := *sv2.InitConfig(&sv2.Config{
 		FunctionVersion: req.Function.FunctionVersion,
 		SpanID:          spanID.String(),
 		EventIDs:        eventIDs,
@@ -417,7 +417,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		PriorityFactor:  &factor,
 		BatchID:         req.BatchID,
 		Context:         req.Context,
-	}
+	})
 
 	// Grab the cron schedule for function config.  This is necessary for fast
 	// lookups, trace info, etc.

--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -148,7 +148,7 @@ func (v v2) LoadMetadata(ctx context.Context, id state.ID) (state.Metadata, erro
 				AccountID: md.Identifier.AccountID,
 			},
 		},
-		Config: state.Config{
+		Config: *state.InitConfig(&state.Config{
 			FunctionVersion:       md.Identifier.WorkflowVersion,
 			SpanID:                md.SpanID,
 			StartedAt:             startedAt,
@@ -162,7 +162,7 @@ func (v v2) LoadMetadata(ctx context.Context, id state.ID) (state.Metadata, erro
 			CustomConcurrencyKeys: md.Identifier.CustomConcurrencyKeys,
 			Context:               md.Context,
 			ForceStepPlan:         md.DisableImmediateExecution,
-		},
+		}),
 		Stack: stack,
 		Metrics: state.RunMetrics{
 			EventSize: md.EventSize,

--- a/pkg/execution/state/v2/state_metadata.go
+++ b/pkg/execution/state/v2/state_metadata.go
@@ -69,6 +69,13 @@ type Tenant struct {
 	AccountID uuid.UUID
 }
 
+func InitConfig(c *Config) *Config {
+	if c.mu == nil {
+		c.mu = &sync.RWMutex{}
+	}
+	return c
+}
+
 // Config represents run config, stored within metadata.
 type Config struct {
 	// FunctionVersion stores the version of the function used when the run is
@@ -119,12 +126,12 @@ type Config struct {
 	// Context allows storing arbitrary context for a run.
 	Context map[string]any
 
-	mu sync.Mutex
+	mu *sync.RWMutex
 }
 
 func (c *Config) EventID() ulid.ULID {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	if len(c.EventIDs) > 0 {
 		return c.EventIDs[0]
@@ -155,8 +162,8 @@ func (c *Config) initContext() {
 }
 
 func (c *Config) SetCronSchedule(schedule string) {
-	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.mu.Lock()
 
 	c.initContext()
 	c.Context[cronScheduleKey] = schedule
@@ -164,8 +171,8 @@ func (c *Config) SetCronSchedule(schedule string) {
 
 // CronSchedule retrieves the stored cron schedule information if available
 func (c *Config) CronSchedule() *string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	if c.Context == nil {
 		return nil
@@ -190,8 +197,8 @@ func (c *Config) SetFunctionSlug(slug string) {
 
 // FunctionSlug retrieves the stored function slug if available
 func (c *Config) FunctionSlug() string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	if c.Context == nil {
 		return ""
@@ -215,8 +222,8 @@ func (c *Config) SetTraceLink(link string) {
 }
 
 func (c *Config) TraceLink() *string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	if c.Context == nil {
 		return nil
@@ -240,8 +247,8 @@ func (c *Config) SetDebounceFlag(flag bool) {
 }
 
 func (c *Config) DebounceFlag() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	if c.Context == nil {
 		return false
@@ -313,8 +320,8 @@ func (c *Config) SetEventIDMapping(evts []event.TrackedEvent) {
 }
 
 func (c *Config) EventIDMapping() map[string]ulid.ULID {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 
 	if c.Context == nil {
 		return nil

--- a/pkg/execution/state/v2/state_metadata.go
+++ b/pkg/execution/state/v2/state_metadata.go
@@ -3,6 +3,7 @@ package state
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -117,9 +118,14 @@ type Config struct {
 	ForceStepPlan bool
 	// Context allows storing arbitrary context for a run.
 	Context map[string]any
+
+	mu sync.Mutex
 }
 
 func (c *Config) EventID() ulid.ULID {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if len(c.EventIDs) > 0 {
 		return c.EventIDs[0]
 	}
@@ -149,12 +155,18 @@ func (c *Config) initContext() {
 }
 
 func (c *Config) SetCronSchedule(schedule string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.initContext()
 	c.Context[cronScheduleKey] = schedule
 }
 
 // CronSchedule retrieves the stored cron schedule information if available
 func (c *Config) CronSchedule() *string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.Context == nil {
 		return nil
 	}
@@ -169,12 +181,18 @@ func (c *Config) CronSchedule() *string {
 }
 
 func (c *Config) SetFunctionSlug(slug string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.initContext()
 	c.Context[fnslugKey] = slug
 }
 
 // FunctionSlug retrieves the stored function slug if available
 func (c *Config) FunctionSlug() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.Context == nil {
 		return ""
 	}
@@ -189,11 +207,17 @@ func (c *Config) FunctionSlug() string {
 }
 
 func (c *Config) SetTraceLink(link string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.initContext()
 	c.Context[traceLinkKey] = link
 }
 
 func (c *Config) TraceLink() *string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.Context == nil {
 		return nil
 	}
@@ -208,11 +232,17 @@ func (c *Config) TraceLink() *string {
 }
 
 func (c *Config) SetDebounceFlag(flag bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.initContext()
 	c.Context[debounceKey] = flag
 }
 
 func (c *Config) DebounceFlag() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.Context == nil {
 		return false
 	}
@@ -227,11 +257,17 @@ func (c *Config) DebounceFlag() bool {
 }
 
 func (c *Config) SetFunctionTrace(carrier *itrace.TraceCarrier) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.initContext()
 	c.Context[consts.OtelPropagationKey] = carrier
 }
 
 func (c *Config) FunctionTrace() *itrace.TraceCarrier {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.Context == nil {
 		return nil
 	}
@@ -259,6 +295,9 @@ func (c *Config) FunctionTrace() *itrace.TraceCarrier {
 //
 // - evtID => ULID
 func (c *Config) SetEventIDMapping(evts []event.TrackedEvent) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.initContext()
 
 	m := map[string]ulid.ULID{}
@@ -274,6 +313,9 @@ func (c *Config) SetEventIDMapping(evts []event.TrackedEvent) {
 }
 
 func (c *Config) EventIDMapping() map[string]ulid.ULID {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.Context == nil {
 		return nil
 	}


### PR DESCRIPTION
## Description
Fix `concurrent map read and map write` panic. This happens because a single state metadata object is passed to concurrent lifecycle methods, which may indirectly write.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
