### PR TITLE
change to use buffer for span exports

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # UI
-/ui @anafilipadealmeida @goodoldneon @djfarrelly @jacobheric
+/ui @anafilipadealmeida @amh4r @djfarrelly @jacobheric
 
 # Execution
 /pkg/execution @tonyhb @darwin67 @BrunoScheufler

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,7 @@
 # UI
 /ui @anafilipadealmeida @goodoldneon @djfarrelly @jacobheric
 
-# Backend
-/cmd @tonyhb @djfarrelly @darwin67 @goodoldneon @jpwilliams @BrunoScheufler
-/pkg @tonyhb @djfarrelly @darwin67 @goodoldneon @jpwilliams @BrunoScheufler
+# Execution
+/pkg/execution @tonyhb @darwin67 @BrunoScheufler
+/pkg/telemetry @tonyhb @darwin67 @BrunoScheufler
+/pkg/run @tonyhb @darwin67 @BrunoScheufler

--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -105,7 +105,7 @@ func (tr *traceReader) GetRunTrace(ctx context.Context, keys dataloader.Keys) []
 							)
 						}
 
-						if span.ChildrenSpans != nil && len(span.ChildrenSpans) > 0 {
+						if len(span.ChildrenSpans) > 0 {
 							primeTree(ctx, span.ChildrenSpans)
 						}
 					}
@@ -252,7 +252,7 @@ func convertRunTreeToGQLModel(pb *rpbv2.RunSpan) (*models.RunTraceSpan, error) {
 	}
 
 	// iterate over children recursively
-	if pb.Children != nil && len(pb.Children) > 0 {
+	if len(pb.Children) > 0 {
 		span.ChildrenSpans = []*models.RunTraceSpan{}
 
 		for _, cp := range pb.Children {

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -298,7 +298,7 @@ type TracePageCursor struct {
 }
 
 func (c *TracePageCursor) IsEmpty() bool {
-	return c.Cursors == nil || len(c.Cursors) == 0
+	return len(c.Cursors) == 0
 }
 
 // Find finds a cusor with the provided name

--- a/pkg/devserver/span.go
+++ b/pkg/devserver/span.go
@@ -89,7 +89,7 @@ func (sh *spanIngestionHandler) Add(ctx context.Context, span *cqrs.Span) {
 		}
 
 		// assign output
-		if run.Output == nil || len(run.Output) == 0 {
+		if len(run.Output) == 0 {
 			for _, e := range span.Events {
 				if spanAttr(e.Attributes, consts.OtelSysFunctionOutput) != "" {
 					run.Output = []byte(e.Name)

--- a/pkg/pubsub/broker/nats.go
+++ b/pkg/pubsub/broker/nats.go
@@ -51,6 +51,8 @@ type NatsConnector struct {
 	//
 	// the key is a combination of stream name + consumer name (e.g. trace + trace-consumer = "trace-trace-consumer")
 	consumers map[string]jetstream.Consumer
+	// The size of the buffer allowed for pending messages on async publish
+	BufferSize int
 }
 
 func NewNATSConnector(ctx context.Context, opts NatsConnOpt) (*NatsConnector, error) {
@@ -97,6 +99,7 @@ func NewNATSConnector(ctx context.Context, opts NatsConnOpt) (*NatsConnector, er
 		if p, err := strconv.Atoi(os.Getenv("NATS_JS_MAX_PENDING")); err == nil && p > 0 {
 			pending = p
 		}
+		c.BufferSize = pending
 
 		// NOTE: should there be some default jetstream options?
 		js, err := jetstream.New(conn,

--- a/pkg/telemetry/exporters/convert.go
+++ b/pkg/telemetry/exporters/convert.go
@@ -1,0 +1,244 @@
+package exporters
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/logger"
+	runv2 "github.com/inngest/inngest/proto/gen/run/v2"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func SpanToProto(ctx context.Context, sp trace.ReadOnlySpan) (*runv2.Span, error) {
+	ts := sp.StartTime()
+	dur := sp.EndTime().Sub(ts)
+	scope := sp.InstrumentationScope().Name
+
+	var psid *string
+	if sp.Parent().HasSpanID() {
+		sid := sp.Parent().SpanID().String()
+		psid = &sid
+	}
+
+	id, status, kind, attr, err := parseSpanAttributes(sp.Attributes())
+	if err != nil {
+		logger.StdlibLogger(ctx).Error("error parsing span attributes",
+			"error", err,
+			"spanAttr", sp.Attributes(),
+		)
+		return nil, err
+	}
+
+	links := make([]*runv2.SpanLink, len(sp.Links()))
+	for i, spl := range sp.Links() {
+		attrs := map[string]string{}
+		for _, kv := range spl.Attributes {
+			key := string(kv.Key)
+			val := attributeValueAsString(kv.Value)
+			attr[key] = val
+		}
+
+		links[i] = &runv2.SpanLink{
+			TraceId:    spl.SpanContext.TraceID().String(),
+			SpanId:     spl.SpanContext.SpanID().String(),
+			TraceState: spl.SpanContext.TraceFlags().String(),
+			Attributes: attrs,
+		}
+	}
+
+	events, triggers, output, err := parseSpanEvents(sp.Events())
+	if err != nil {
+		logger.StdlibLogger(ctx).Error("error parsing span events",
+			"error", err,
+			"spanEvents", sp.Events(),
+			"acctID", id.AccountId,
+			"wsID", id.EnvId,
+			"wfID", id.FunctionId,
+			"runID", id.RunId,
+		)
+		return nil, err
+	}
+
+	return &runv2.Span{
+		Id: id,
+		Ctx: &runv2.SpanContext{
+			TraceId:      sp.SpanContext().TraceID().String(),
+			ParentSpanId: psid,
+			SpanId:       sp.SpanContext().SpanID().String(),
+		},
+		Name:       sp.Name(),
+		Kind:       kind,
+		Status:     status,
+		StatusCode: sp.Status().Code.String(),
+		Scope:      scope,
+		Timestamp:  timestamppb.New(ts),
+		DurationMs: dur.Milliseconds(),
+		Attributes: attr,
+		Triggers:   triggers,
+		Output:     output,
+		Events:     events,
+		Links:      links,
+	}, nil
+}
+
+// parseSpanAttributes iterates through the span attributes and extract out data that
+func parseSpanAttributes(spanAttr []attribute.KeyValue) (*runv2.SpanIdentifier, runv2.SpanStatus, runv2.SpanStepOp, map[string]string, error) {
+	id := &runv2.SpanIdentifier{}
+	attr := map[string]string{}
+
+	var (
+		kind   runv2.SpanStepOp
+		status runv2.SpanStatus
+	)
+
+	for _, kv := range spanAttr {
+		if kv.Valid() {
+			key := string(kv.Key)
+			val := attributeValueAsString(kv.Value)
+
+			switch key {
+			case consts.OtelSysAccountID:
+				id.AccountId = val
+			case consts.OtelSysWorkspaceID:
+				id.EnvId = val
+			case consts.OtelSysAppID:
+				id.AppId = val
+			case consts.OtelSysFunctionID:
+				id.FunctionId = val
+			case consts.OtelAttrSDKRunID:
+				id.RunId = val
+			case consts.OtelSysStepOpcode:
+				kind = toProtoKind(val)
+			case consts.OtelSysFunctionStatusCode:
+				code := kv.Value.AsInt64()
+				status = toProtoStatus(enums.RunCodeToStatus(code))
+			}
+			// TODO: move this into the default case so it doesn't record everything
+			attr[key] = val
+		}
+	}
+
+	return id, status, kind, attr, nil
+}
+
+func toProtoStatus(s enums.RunStatus) runv2.SpanStatus {
+	switch s {
+	case enums.RunStatusScheduled:
+		return runv2.SpanStatus_SCHEDULED
+	case enums.RunStatusRunning:
+		return runv2.SpanStatus_RUNNING
+	case enums.RunStatusCompleted:
+		return runv2.SpanStatus_COMPLETED
+	case enums.RunStatusFailed, enums.RunStatusOverflowed:
+		return runv2.SpanStatus_FAILED
+	case enums.RunStatusCancelled:
+		return runv2.SpanStatus_CANCELLED
+	default:
+		return runv2.SpanStatus_UNKNOWN
+	}
+}
+
+func toProtoKind(code string) runv2.SpanStepOp {
+	o, err := enums.OpcodeString(code)
+	if err != nil {
+		return runv2.SpanStepOp_NONE
+	}
+
+	switch o {
+	case enums.OpcodeInvokeFunction:
+		return runv2.SpanStepOp_INVOKE
+	case enums.OpcodeWaitForEvent:
+		return runv2.SpanStepOp_WAIT_FOR_EVENT
+	case enums.OpcodeSleep:
+		return runv2.SpanStepOp_SLEEP
+	case enums.OpcodeStepRun, enums.OpcodeStep:
+		return runv2.SpanStepOp_STEP
+	case enums.OpcodeStepError:
+		return runv2.SpanStepOp_STEP_ERROR
+
+	default:
+		return runv2.SpanStepOp_RUN
+	}
+}
+
+// parseSpanEvents iterates through the otel span events and extract out
+// embedded data
+// - run triggers (events and crons)
+// - output
+func parseSpanEvents(spanEvents []trace.Event) ([]*runv2.SpanEvent, []*runv2.Trigger, []byte, error) {
+	events := []*runv2.SpanEvent{} // actual span events
+	triggers := []*runv2.Trigger{}
+	var output []byte
+
+	for _, evt := range spanEvents {
+		attr := map[string]string{}
+		var evtID string
+
+		// iterates over the list of attributes in this span event
+		// and set the type.
+		//
+		// NOTE: event data and outputs should NEVER be in the same span event
+		var typ spanEvtType
+		for _, kv := range evt.Attributes {
+			if kv.Valid() {
+				key := string(kv.Key)
+				val := attributeValueAsString(kv.Value)
+
+				switch key {
+				case consts.OtelSysEventData:
+					typ = spanEvtTypeEvent
+				case consts.OtelSysEventInternalID:
+					typ = spanEvtTypeEvent
+					evtID = kv.Value.AsString()
+				case consts.OtelSysFunctionOutput, consts.OtelSysStepOutput:
+					typ = spanEvtTypeOutput
+				}
+				// TODO: move this into the default case section
+				attr[key] = val
+			}
+		}
+
+		// update the relevant data based on type found
+		switch typ {
+		case spanEvtTypeEvent:
+			triggers = append(triggers, &runv2.Trigger{
+				InternalId: evtID,
+				Body:       []byte(evt.Name),
+			})
+		case spanEvtTypeOutput:
+			output = []byte(evt.Name)
+		}
+
+		// TODO: should be moved into the default case for switch
+		events = append(events, &runv2.SpanEvent{
+			Name:       evt.Name,
+			Timestamp:  timestamppb.New(evt.Time),
+			Attributes: attr,
+		})
+	}
+
+	return events, triggers, output, nil
+}
+
+func attributeValueAsString(v attribute.Value) string {
+	switch v.Type() {
+	case attribute.BOOL:
+		return fmt.Sprintf("%t", v.AsBool())
+	case attribute.INT64:
+		return fmt.Sprintf("%d", v.AsInt64())
+	case attribute.STRING:
+		return v.AsString()
+	case attribute.FLOAT64:
+		return fmt.Sprintf("%f", v.AsFloat64())
+	default:
+		logger.StdlibLogger(context.TODO()).Warn("not supported attribute value type",
+			"value", v,
+			"type", v.Type().String(),
+		)
+		return v.AsString()
+	}
+}

--- a/pkg/telemetry/exporters/nats.go
+++ b/pkg/telemetry/exporters/nats.go
@@ -230,6 +230,13 @@ func (e *natsSpanExporter) handleFailedExports(ctx context.Context) {
 					"stream": subj,
 				},
 			})
+			metrics.IncrSpanExportedCounter(ctx, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags: map[string]any{
+					"subject": subj,
+					"status":  status,
+				},
+			})
 		}
 	}
 }

--- a/pkg/telemetry/exporters/nats.go
+++ b/pkg/telemetry/exporters/nats.go
@@ -33,8 +33,6 @@ type natsSpanExporter struct {
 	streams    []*StreamConf
 	conn       *broker.NatsConnector
 	deadletter *StreamConf
-	// The channel to be used for sending spans to the specified queue
-	pub chan *runv2.Span
 	// The channel to be used for sending spans to the deadletter queue
 	dlc chan *runv2.Span
 }

--- a/pkg/telemetry/exporters/nats.go
+++ b/pkg/telemetry/exporters/nats.go
@@ -203,6 +203,10 @@ func (e *natsSpanExporter) handleFailedExports(ctx context.Context) {
 					"wfID", id.FunctionId,
 					"runID", id.RunId,
 				)
+
+				// wait a little before retrying again
+				<-time.After(100 * time.Millisecond)
+				e.dlc <- span
 				continue
 			}
 

--- a/pkg/telemetry/exporters/nats.go
+++ b/pkg/telemetry/exporters/nats.go
@@ -195,8 +195,11 @@ func (e *natsSpanExporter) flush(ctx context.Context, streams []*StreamConf, dea
 		return err
 	}
 	wg := sync.WaitGroup{}
+
 	spans := e.buf.Retrieve()
-	if len(spans) == 0 {
+	size := len(spans)
+	metrics.GaugeSpanExporterBuffer(ctx, int64(size), metrics.GaugeOpt{PkgName: pkgName})
+	if size == 0 {
 		// no op
 		return nil
 	}

--- a/pkg/telemetry/exporters/nats.go
+++ b/pkg/telemetry/exporters/nats.go
@@ -6,18 +6,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/inngest/inngest/pkg/consts"
-	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/pubsub/broker"
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	runv2 "github.com/inngest/inngest/proto/gen/run/v2"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type spanEvtType int
@@ -317,74 +313,11 @@ func (e *natsSpanExporter) ExportSpans(ctx context.Context, spans []trace.ReadOn
 			go func(ctx context.Context, conf StreamConf, sp trace.ReadOnlySpan) {
 				defer wg.Done()
 
-				ts := sp.StartTime()
-				dur := sp.EndTime().Sub(ts)
-				scope := sp.InstrumentationScope().Name
-
-				var psid *string
-				if sp.Parent().HasSpanID() {
-					sid := sp.Parent().SpanID().String()
-					psid = &sid
-				}
-
-				id, status, kind, attr, err := e.parseSpanAttributes(sp.Attributes())
+				span, err := SpanToProto(ctx, sp)
 				if err != nil {
-					logger.StdlibLogger(ctx).Error("error parsing span attributes",
-						"error", err,
-						"spanAttr", sp.Attributes(),
-					)
+					return
 				}
-
-				links := make([]*runv2.SpanLink, len(sp.Links()))
-				for i, spl := range sp.Links() {
-					attrs := map[string]string{}
-					for _, kv := range spl.Attributes {
-						key := string(kv.Key)
-						val := e.attributeValueAsString(kv.Value)
-						attr[key] = val
-					}
-
-					links[i] = &runv2.SpanLink{
-						TraceId:    spl.SpanContext.TraceID().String(),
-						SpanId:     spl.SpanContext.SpanID().String(),
-						TraceState: spl.SpanContext.TraceFlags().String(),
-						Attributes: attrs,
-					}
-				}
-
-				events, triggers, output, err := e.parseSpanEvents(sp.Events())
-				if err != nil {
-					logger.StdlibLogger(ctx).Error("error parsing span events",
-						"error", err,
-						"spanEvents", sp.Events(),
-						"stream", conf.Subject,
-						"acctID", id.AccountId,
-						"wsID", id.EnvId,
-						"wfID", id.FunctionId,
-						"runID", id.RunId,
-					)
-				}
-
-				span := &runv2.Span{
-					Id: id,
-					Ctx: &runv2.SpanContext{
-						TraceId:      sp.SpanContext().TraceID().String(),
-						ParentSpanId: psid,
-						SpanId:       sp.SpanContext().SpanID().String(),
-					},
-					Name:       sp.Name(),
-					Kind:       kind,
-					Status:     status,
-					StatusCode: sp.Status().Code.String(),
-					Scope:      scope,
-					Timestamp:  timestamppb.New(ts),
-					DurationMs: dur.Milliseconds(),
-					Attributes: attr,
-					Triggers:   triggers,
-					Output:     output,
-					Events:     events,
-					Links:      links,
-				}
+				id := span.Id
 
 				pending := js.PublishAsyncPending()
 				metrics.GaugeSpanBatchProcessorNatsAsyncPending(ctx, int64(pending), metrics.GaugeOpt{
@@ -488,165 +421,6 @@ func (e *natsSpanExporter) Shutdown(ctx context.Context) error {
 	}
 
 	return e.conn.Shutdown(ctx)
-}
-
-// parseSpanAttributes iterates through the span attributes and extract out data that
-func (e *natsSpanExporter) parseSpanAttributes(spanAttr []attribute.KeyValue) (*runv2.SpanIdentifier, runv2.SpanStatus, runv2.SpanStepOp, map[string]string, error) {
-	id := &runv2.SpanIdentifier{}
-	attr := map[string]string{}
-
-	var (
-		kind   runv2.SpanStepOp
-		status runv2.SpanStatus
-	)
-
-	for _, kv := range spanAttr {
-		if kv.Valid() {
-			key := string(kv.Key)
-			val := e.attributeValueAsString(kv.Value)
-
-			switch key {
-			case consts.OtelSysAccountID:
-				id.AccountId = val
-			case consts.OtelSysWorkspaceID:
-				id.EnvId = val
-			case consts.OtelSysAppID:
-				id.AppId = val
-			case consts.OtelSysFunctionID:
-				id.FunctionId = val
-			case consts.OtelAttrSDKRunID:
-				id.RunId = val
-			case consts.OtelSysStepOpcode:
-				kind = e.toProtoKind(val)
-			case consts.OtelSysFunctionStatusCode:
-				code := kv.Value.AsInt64()
-				status = e.toProtoStatus(enums.RunCodeToStatus(code))
-			}
-			// TODO: move this into the default case so it doesn't record everything
-			attr[key] = val
-		}
-	}
-
-	return id, status, kind, attr, nil
-}
-
-func (e *natsSpanExporter) toProtoStatus(s enums.RunStatus) runv2.SpanStatus {
-	switch s {
-	case enums.RunStatusScheduled:
-		return runv2.SpanStatus_SCHEDULED
-	case enums.RunStatusRunning:
-		return runv2.SpanStatus_RUNNING
-	case enums.RunStatusCompleted:
-		return runv2.SpanStatus_COMPLETED
-	case enums.RunStatusFailed, enums.RunStatusOverflowed:
-		return runv2.SpanStatus_FAILED
-	case enums.RunStatusCancelled:
-		return runv2.SpanStatus_CANCELLED
-	default:
-		return runv2.SpanStatus_UNKNOWN
-	}
-}
-
-func (e *natsSpanExporter) toProtoKind(code string) runv2.SpanStepOp {
-	o, err := enums.OpcodeString(code)
-	if err != nil {
-		return runv2.SpanStepOp_NONE
-	}
-
-	switch o {
-	case enums.OpcodeInvokeFunction:
-		return runv2.SpanStepOp_INVOKE
-	case enums.OpcodeWaitForEvent:
-		return runv2.SpanStepOp_WAIT_FOR_EVENT
-	case enums.OpcodeSleep:
-		return runv2.SpanStepOp_SLEEP
-	case enums.OpcodeStepRun, enums.OpcodeStep:
-		return runv2.SpanStepOp_STEP
-	case enums.OpcodeStepError:
-		return runv2.SpanStepOp_STEP_ERROR
-
-	default:
-		return runv2.SpanStepOp_RUN
-	}
-}
-
-// parseSpanEvents iterates through the otel span events and extract out
-// embedded data
-// - run triggers (events and crons)
-// - output
-func (e *natsSpanExporter) parseSpanEvents(spanEvents []trace.Event) ([]*runv2.SpanEvent, []*runv2.Trigger, []byte, error) {
-
-	events := []*runv2.SpanEvent{} // actual span events
-	triggers := []*runv2.Trigger{}
-	var output []byte
-
-	for _, evt := range spanEvents {
-		attr := map[string]string{}
-		var evtID string
-
-		// iterates over the list of attributes in this span event
-		// and set the type.
-		//
-		// NOTE: event data and outputs should NEVER be in the same span event
-		var typ spanEvtType
-		for _, kv := range evt.Attributes {
-			if kv.Valid() {
-				key := string(kv.Key)
-				val := e.attributeValueAsString(kv.Value)
-
-				switch key {
-				case consts.OtelSysEventData:
-					typ = spanEvtTypeEvent
-				case consts.OtelSysEventInternalID:
-					typ = spanEvtTypeEvent
-					evtID = kv.Value.AsString()
-				case consts.OtelSysFunctionOutput, consts.OtelSysStepOutput:
-					typ = spanEvtTypeOutput
-				}
-				// TODO: move this into the default case section
-				attr[key] = val
-			}
-		}
-
-		// update the relevant data based on type found
-		switch typ {
-		case spanEvtTypeEvent:
-			triggers = append(triggers, &runv2.Trigger{
-				InternalId: evtID,
-				Body:       []byte(evt.Name),
-			})
-		case spanEvtTypeOutput:
-			output = []byte(evt.Name)
-		}
-
-		// TODO: should be moved into the default case for switch
-		events = append(events, &runv2.SpanEvent{
-			Name:       evt.Name,
-			Timestamp:  timestamppb.New(evt.Time),
-			Attributes: attr,
-		})
-	}
-
-	return events, triggers, output, nil
-}
-
-func (e *natsSpanExporter) attributeValueAsString(v attribute.Value) string {
-	switch v.Type() {
-	case attribute.BOOL:
-		return fmt.Sprintf("%t", v.AsBool())
-	case attribute.INT64:
-		return fmt.Sprintf("%d", v.AsInt64())
-	case attribute.STRING:
-		return v.AsString()
-	case attribute.FLOAT64:
-		return fmt.Sprintf("%f", v.AsFloat64())
-	default:
-		logger.StdlibLogger(context.TODO()).Warn("not supported attribute value type",
-			"value", v,
-			"type", v.Type().String(),
-		)
-		return v.AsString()
-	}
 }
 
 type spanRetry struct {

--- a/pkg/telemetry/metrics/gauge.go
+++ b/pkg/telemetry/metrics/gauge.go
@@ -101,3 +101,12 @@ func GaugeSpanBatchProcessorNatsAsyncPending(ctx context.Context, val int64, opt
 		Tags:        opts.Tags,
 	})
 }
+
+func GaugeSpanExporterBuffer(ctx context.Context, val int64, opts GaugeOpt) {
+	RecordGaugeMetric(ctx, val, GaugeOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "span_exporter_buffer_size",
+		Description: "The number of messages in the NATS exporter buffer",
+		Tags:        opts.Tags,
+	})
+}

--- a/pkg/telemetry/metrics/gauge.go
+++ b/pkg/telemetry/metrics/gauge.go
@@ -92,3 +92,12 @@ func GaugeSpanBatchProcessorBufferKeys(ctx context.Context, val int64, opts Gaug
 		Tags:        opts.Tags,
 	})
 }
+
+func GaugeSpanBatchProcessorNatsAsyncPending(ctx context.Context, val int64, opts GaugeOpt) {
+	RecordGaugeMetric(ctx, val, GaugeOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "span_batch_processor_async_pending",
+		Description: "The number of messages pending to publish to NATS stream",
+		Tags:        opts.Tags,
+	})
+}

--- a/tests/client/function_run.go
+++ b/tests/client/function_run.go
@@ -26,7 +26,7 @@ type FunctionRunOpt struct {
 }
 
 func (o FunctionRunOpt) OrderBy() string {
-	if o.Order == nil || len(o.Order) == 0 {
+	if len(o.Order) == 0 {
 		return fmt.Sprintf("[ { field: %s, direction: %s } ]", models.RunsV2OrderByFieldQueuedAt, models.RunsOrderByDirectionDesc)
 	}
 


### PR DESCRIPTION
## Description

Splitting the streams doesn't provide the expected results.
Instead change to buffering if there are exporting issues, and attempt to flush them again after some time.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
