### PR TITLE
Update .Resume to use new util code

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1669,82 +1669,85 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 		return fmt.Errorf("error loading metadata to resume from pause: %w", err)
 	}
 
-	// Lease this pause so that only this thread can schedule the execution.
-	//
-	// If we don't do this, there's a chance that two concurrent runners
-	// attempt to enqueue the next step of the workflow.
-	err = e.pm.LeasePause(ctx, pause.ID)
-	if err == state.ErrPauseLeased || err == state.ErrPauseNotFound {
-		// Ignore;  this is being handled by another runner.
-		return nil
-	}
-
-	if pause.OnTimeout && r.EventID != nil {
-		// Delete this pause, as an event has occured which matches
-		// the timeout.  We can do this prior to leasing a pause as it's the
-		// only work that needs to happen
-		err := e.pm.ConsumePause(ctx, pause.ID, nil)
-		if err == nil || err == state.ErrPauseNotFound {
+	util.Crit(ctx, "consume pause", func(ctx context.Context) error {
+		// Lease this pause so that only this thread can schedule the execution.
+		//
+		// If we don't do this, there's a chance that two concurrent runners
+		// attempt to enqueue the next step of the workflow.
+		err = e.pm.LeasePause(ctx, pause.ID)
+		if err == state.ErrPauseLeased || err == state.ErrPauseNotFound {
+			// Ignore;  this is being handled by another runner.
 			return nil
 		}
-		return fmt.Errorf("error consuming pause via timeout: %w", err)
-	}
 
-	if err = e.pm.ConsumePause(ctx, pause.ID, r.With); err != nil {
-		return fmt.Errorf("error consuming pause via event: %w", err)
-	}
-
-	if e.log != nil {
-		e.log.Debug().
-			Str("pause_id", pause.ID.String()).
-			Str("run_id", pause.Identifier.RunID.String()).
-			Str("workflow_id", pause.Identifier.WorkflowID.String()).
-			Bool("timeout", pause.OnTimeout).
-			Bool("cancel", pause.Cancel).
-			Msg("resuming from pause")
-	}
-
-	// Schedule an execution from the pause's entrypoint.  We do this after
-	// consuming the pause to guarantee the event data is stored via the pause
-	// for the next run.  If the ConsumePause call comes after enqueue, the TCP
-	// conn may drop etc. and running the job may occur prior to saving state data.
-	jobID := fmt.Sprintf("%s-%s", pause.Identifier.IdempotencyKey(), pause.DataKey)
-	err = e.queue.Enqueue(
-		ctx,
-		queue.Item{
-			JobID: &jobID,
-			// Add a new group ID for the child;  this will be a new step.
-			GroupID:               uuid.New().String(),
-			WorkspaceID:           pause.WorkspaceID,
-			Kind:                  queue.KindEdge,
-			Identifier:            pause.Identifier,
-			PriorityFactor:        md.Config.PriorityFactor,
-			CustomConcurrencyKeys: md.Config.CustomConcurrencyKeys,
-			MaxAttempts:           pause.MaxAttempts,
-			Payload: queue.PayloadEdge{
-				Edge: pause.Edge(),
-			},
-		},
-		time.Now(),
-	)
-	if err != nil && err != redis_state.ErrQueueItemExists {
-		return fmt.Errorf("error enqueueing after pause: %w", err)
-	}
-
-	// And dequeue the timeout job to remove unneeded work from the queue, etc.
-	if q, ok := e.queue.(redis_state.QueueManager); ok {
-		jobID := fmt.Sprintf("%s-%s", md.IdempotencyKey(), pause.DataKey)
-		err := q.Dequeue(ctx, redis_state.QueueItem{
-			ID:         redis_state.HashID(ctx, jobID),
-			FunctionID: md.ID.FunctionID,
-			Data: queue.Item{
-				Kind: queue.KindPause,
-			},
-		})
-		if err != nil {
-			logger.StdlibLogger(ctx).Error("error dequeueing consumed pause job when resuming", "error", err)
+		if pause.OnTimeout && r.EventID != nil {
+			// Delete this pause, as an event has occured which matches
+			// the timeout.  We can do this prior to leasing a pause as it's the
+			// only work that needs to happen
+			err := e.pm.ConsumePause(ctx, pause.ID, nil)
+			if err == nil || err == state.ErrPauseNotFound {
+				return nil
+			}
+			return fmt.Errorf("error consuming pause via timeout: %w", err)
 		}
-	}
+
+		if err = e.pm.ConsumePause(ctx, pause.ID, r.With); err != nil {
+			return fmt.Errorf("error consuming pause via event: %w", err)
+		}
+
+		if e.log != nil {
+			e.log.Debug().
+				Str("pause_id", pause.ID.String()).
+				Str("run_id", pause.Identifier.RunID.String()).
+				Str("workflow_id", pause.Identifier.WorkflowID.String()).
+				Bool("timeout", pause.OnTimeout).
+				Bool("cancel", pause.Cancel).
+				Msg("resuming from pause")
+		}
+
+		// Schedule an execution from the pause's entrypoint.  We do this after
+		// consuming the pause to guarantee the event data is stored via the pause
+		// for the next run.  If the ConsumePause call comes after enqueue, the TCP
+		// conn may drop etc. and running the job may occur prior to saving state data.
+		jobID := fmt.Sprintf("%s-%s", pause.Identifier.IdempotencyKey(), pause.DataKey)
+		err = e.queue.Enqueue(
+			ctx,
+			queue.Item{
+				JobID: &jobID,
+				// Add a new group ID for the child;  this will be a new step.
+				GroupID:               uuid.New().String(),
+				WorkspaceID:           pause.WorkspaceID,
+				Kind:                  queue.KindEdge,
+				Identifier:            pause.Identifier,
+				PriorityFactor:        md.Config.PriorityFactor,
+				CustomConcurrencyKeys: md.Config.CustomConcurrencyKeys,
+				MaxAttempts:           pause.MaxAttempts,
+				Payload: queue.PayloadEdge{
+					Edge: pause.Edge(),
+				},
+			},
+			time.Now(),
+		)
+		if err != nil && err != redis_state.ErrQueueItemExists {
+			return fmt.Errorf("error enqueueing after pause: %w", err)
+		}
+
+		// And dequeue the timeout job to remove unneeded work from the queue, etc.
+		if q, ok := e.queue.(redis_state.QueueManager); ok {
+			jobID := fmt.Sprintf("%s-%s", md.IdempotencyKey(), pause.DataKey)
+			err := q.Dequeue(ctx, redis_state.QueueItem{
+				ID:         redis_state.HashID(ctx, jobID),
+				FunctionID: md.ID.FunctionID,
+				Data: queue.Item{
+					Kind: queue.KindPause,
+				},
+			})
+			if err != nil {
+				logger.StdlibLogger(ctx).Error("error dequeueing consumed pause job when resuming", "error", err)
+			}
+		}
+		return nil
+	}, 20*time.Second)
 
 	if pause.IsInvoke() {
 		for _, e := range e.lifecycles {
@@ -1824,11 +1827,10 @@ func (e *executor) handleGeneratorGroup(ctx context.Context, i *runInstance, gro
 			continue
 		}
 		copied := *op
-		newItem := i.item
 		if group.ShouldStartHistoryGroup {
 			// Give each opcode its own group ID, since we want to track each
 			// parellel step individually.
-			newItem.GroupID = uuid.New().String()
+			i.item.GroupID = uuid.New().String()
 		}
 		eg.Go(func() error { return e.handleGenerator(ctx, i, copied) })
 	}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1669,7 +1669,7 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 		return fmt.Errorf("error loading metadata to resume from pause: %w", err)
 	}
 
-	util.Crit(ctx, "consume pause", func(ctx context.Context) error {
+	err = util.Crit(ctx, "consume pause", func(ctx context.Context) error {
 		// Lease this pause so that only this thread can schedule the execution.
 		//
 		// If we don't do this, there's a chance that two concurrent runners
@@ -1748,6 +1748,10 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 		}
 		return nil
 	}, 20*time.Second)
+
+	if err != nil {
+		return err
+	}
 
 	if pause.IsInvoke() {
 		for _, e := range e.lifecycles {

--- a/pkg/util/critctx.go
+++ b/pkg/util/critctx.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/inngest/inngest/pkg/logger"
+)
+
+// Crit is a util to wrap a lambda with a non-cancellable context.  It allows an optional time boundary
+// for checking context deadlines;  if the parent ctx has a deadline shorter than the boundary we exit
+// immediately with an error.
+func Crit(ctx context.Context, name string, f func(ctx context.Context) error, withinBounds ...time.Duration) error {
+	// If withinBounds is set, we have some time period in which we must complete the Crit
+	// section.
+	//
+	// Check the parent context to see if there's a deadline, and if the deadline < withinBounds
+	// don't even bother.  The crit section must exist within some retryable process.
+	if len(withinBounds) == 1 {
+		if dl, ok := ctx.Deadline(); ok && time.Until(dl) < withinBounds[0] {
+			return fmt.Errorf("context deadline shorter than critical bounds: %s", name)
+		}
+	}
+
+	if ctx.Err() == context.Canceled {
+		return fmt.Errorf("context canceled before entering crit: %s", name)
+	}
+
+	pre := time.Now()
+	err := f(context.WithoutCancel(ctx))
+
+	// XXX: Instrument critical section durations and error responses via the names.
+
+	if len(withinBounds) == 1 {
+		actual := time.Since(pre)
+		if actual > withinBounds[0] {
+			// This took longer than the predefined boundaries, so log a fat warning.
+			logger.StdlibLogger(ctx).Warn("critical section took longer than boundaries", "name", name, "duration_ms", actual.Milliseconds())
+		}
+	}
+
+	return err
+}

--- a/pkg/util/critctx_test.go
+++ b/pkg/util/critctx_test.go
@@ -1,0 +1,122 @@
+package util
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCrit(t *testing.T) {
+	bg := context.Background()
+
+	t.Run("Plain ol contexts work", func(t *testing.T) {
+		called := false
+		err := Crit(bg, "foo", func(ctx context.Context) error {
+			called = true
+			return nil
+		})
+		require.True(t, called)
+		require.Nil(t, err)
+	})
+
+	t.Run("Errors are passed back", func(t *testing.T) {
+		called := false
+		expectedErr := fmt.Errorf("no way")
+		err := Crit(bg, "foo", func(ctx context.Context) error {
+			called = true
+			return expectedErr
+		})
+		require.True(t, called)
+		require.Equal(t, err, expectedErr)
+	})
+
+	t.Run("With a context cancelled during execution", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(bg)
+
+		go func() {
+			<-time.After(10 * time.Millisecond)
+			cancel()
+		}()
+
+		called := false
+		expectedErr := fmt.Errorf("no way")
+		err := Crit(ctx, "foo", func(ctx context.Context) error {
+			<-time.After(20 * time.Millisecond)
+
+			if ctx.Err() != nil {
+				// Return the context cancelled error.
+				return ctx.Err()
+			}
+
+			called = true
+			return expectedErr
+		})
+		require.True(t, called)
+		require.Equal(t, err, expectedErr)
+	})
+
+	t.Run("It should prevent the crit from running with a short deadline", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(bg, 10*time.Millisecond)
+		defer cancel()
+
+		called := false
+		err := Crit(ctx, "foo", func(ctx context.Context) error {
+			if ctx.Err() != nil {
+				// Return the context cancelled error.
+				return ctx.Err()
+			}
+			called = true
+			return nil
+		}, time.Second)
+
+		// Not called:  deadline too short.
+		require.False(t, called)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "context deadline shorter than critical bounds")
+	})
+
+	t.Run("It should warn if the crit takes longer than ideal bounds", func(t *testing.T) {
+		called := false
+
+		buf := bytes.NewBuffer(nil)
+		log := slog.New(slog.NewJSONHandler(buf, nil))
+		ctx := logger.WithStdlib(bg, log)
+
+		err := Crit(ctx, "foo", func(ctx context.Context) error {
+			<-time.After(10 * time.Millisecond)
+			if ctx.Err() != nil {
+				// Return the context cancelled error.
+				return ctx.Err()
+			}
+			called = true
+			return nil
+		}, time.Millisecond)
+
+		require.True(t, called)
+		require.Nil(t, err)
+
+		require.Contains(t, string(buf.Bytes()), "critical section took longer than boundaries")
+	})
+
+	t.Run("With a cancelled context, the fn fails", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(bg)
+		cancel()
+
+		called := false
+		err := Crit(ctx, "foo", func(ctx context.Context) error {
+			called = true
+			return nil
+		})
+
+		require.False(t, called)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "context canceled before entering crit")
+	})
+
+}

--- a/pkg/util/critctx_test.go
+++ b/pkg/util/critctx_test.go
@@ -101,7 +101,7 @@ func TestCrit(t *testing.T) {
 		require.True(t, called)
 		require.Nil(t, err)
 
-		require.Contains(t, string(buf.Bytes()), "critical section took longer than boundaries")
+		require.Contains(t, buf.String(), "critical section took longer than boundaries")
 	})
 
 	t.Run("With a cancelled context, the fn fails", func(t *testing.T) {


### PR DESCRIPTION
The util code ensures that a fresh, non-cancellable context is used to prevent sigterm from cancelling contexts during the util's lambda.



## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
