### PR TITLE
Add raw argument to webhook transform

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/TransformEvent.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/TransformEvent.tsx
@@ -25,7 +25,8 @@ const preview = async (transform: string, input: string) => {
     // execute expression
     vm.evalCode(transform);
     vm.executePendingJobs(-1);
-    const res = vm.evalCode('transform(' + input + ')');
+    const escapedInput = JSON.stringify(input);
+    const res = vm.evalCode(`transform(${input}, {}, {}, ${escapedInput})`);
     const unwrapped = vm.unwrapResult(res);
     const ok = vm.dump(unwrapped);
     vm.dispose();
@@ -53,8 +54,11 @@ export function createTransform({
   commentBlock = defaultCommentBlock,
 }): string {
   return `// transform accepts the incoming JSON payload from your
-// webhook and must return an object that is in the Inngest event format
-function transform(evt, headers = {}, queryParams = {}) {
+// webhook and must return an object that is in the Inngest event format.
+//
+// The raw argument is the original stringified request body. This is useful
+// when you want to perform HMAC validation within your Inngest functions.
+function transform(evt, headers = {}, queryParams = {}, raw = "") {
   return {
     ${commentBlock}
     name: ${eventName},
@@ -92,6 +96,7 @@ export default function TransformEvents({ keyID, metadata }: FilterEventsProps) 
       return;
     }
 
+    console.log(typeof incoming, incoming);
     const result = await preview(transform, incoming);
     setOutput(result);
     if (result === '' || result.indexOf('Error') === 0) {

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/TransformEvent.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/TransformEvent.tsx
@@ -96,7 +96,6 @@ export default function TransformEvents({ keyID, metadata }: FilterEventsProps) 
       return;
     }
 
-    console.log(typeof incoming, incoming);
     const result = await preview(transform, incoming);
     setOutput(result);
     if (result === '' || result.indexOf('Error') === 0) {


### PR DESCRIPTION
## Description
Add the new `raw` argument to the webhook transform. This argument already works in the backend but was missing in the frontend.

The `raw` argument is the original stringified request body. Users need this when they want to perform HMAC validation within their Inngest functions.
