### PR TITLE
Improved queued run run details pending state

### DIFF
--- a/ui/packages/components/src/DetailsCard/Element.tsx
+++ b/ui/packages/components/src/DetailsCard/Element.tsx
@@ -40,10 +40,42 @@ export function LazyElementWrapper<T>({
   }
 
   return (
-    <div className={cn('w-64 text-sm', className)}>
-      <dt className="text-muted text-xs">{label}</dt>
-      <dd className="truncate">{content}</dd>
-    </div>
+    <ElementWrapper label={label} className={className}>
+      {content}
+    </ElementWrapper>
+  );
+}
+
+// Optimistically render an initial value while waiting for a
+// lazy loaded value to render the final component
+export function OptimisticElementWrapper<T, InitialType>({
+  children,
+  optimisticChildren,
+  className,
+  label,
+  lazy,
+  initial,
+}: {
+  children: (loaded: T) => React.ReactNode;
+  optimisticChildren: (loaded: InitialType) => React.ReactNode;
+  className?: string;
+  label: string;
+  lazy: Lazy<T>;
+  initial?: InitialType;
+}) {
+  let content;
+  if (isLazyDone(lazy)) {
+    content = children(lazy);
+  } else if (initial) {
+    content = optimisticChildren(initial);
+  } else {
+    content = <SkeletonElement />;
+  }
+
+  return (
+    <ElementWrapper label={label} className={className}>
+      {content}
+    </ElementWrapper>
   );
 }
 

--- a/ui/packages/components/src/DetailsCard/Element.tsx
+++ b/ui/packages/components/src/DetailsCard/Element.tsx
@@ -57,7 +57,7 @@ export function OptimisticElementWrapper<T, InitialType>({
   initial,
 }: {
   children: (loaded: T) => React.ReactNode;
-  optimisticChildren: (loaded: InitialType) => React.ReactNode;
+  optimisticChildren: (loaded: InitialType) => React.ReactNode | undefined;
   className?: string;
   label: string;
   lazy: Lazy<T>;
@@ -68,6 +68,9 @@ export function OptimisticElementWrapper<T, InitialType>({
     content = children(lazy);
   } else if (initial) {
     content = optimisticChildren(initial);
+    if (!content) {
+      content = <SkeletonElement />;
+    }
   } else {
     content = <SkeletonElement />;
   }

--- a/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
+import type { Run as InitialRunData } from '../RunsPage/types';
 import { StatusCell } from '../Table';
 import { Trace } from '../TimelineV2';
 import { Timeline } from '../TimelineV2/Timeline';
@@ -18,6 +19,7 @@ type Props = {
   cancelRun: (runID: string) => Promise<unknown>;
   getResult: (outputID: string) => Promise<Result>;
   getRun: (runID: string) => Promise<Run>;
+  initialRunData: InitialRunData;
   getTrigger: React.ComponentProps<typeof TriggerDetails>['getTrigger'];
   pathCreator: React.ComponentProps<typeof RunInfo>['pathCreator'];
   pollInterval?: number;
@@ -95,22 +97,24 @@ export function RunDetails(props: Props) {
       <div className="flex gap-4">
         <div className="grow">
           <div className="ml-8">
+            <RunInfo
+              cancelRun={cancelRun}
+              className="mb-4"
+              pathCreator={pathCreator}
+              rerun={rerun}
+              initialRunData={props.initialRunData}
+              run={nullishToLazy(run)}
+              runID={runID}
+              standalone={standalone}
+              result={resultRes.data}
+            />
             {runRes.error || resultRes.error ? (
               <ErrorCard
                 error={runRes.error || resultRes.error}
                 reset={runRes.error ? () => runRes.refetch() : () => resultRes.refetch()}
               />
             ) : (
-              <RunInfo
-                cancelRun={cancelRun}
-                className="mb-4"
-                pathCreator={pathCreator}
-                rerun={rerun}
-                run={nullishToLazy(run)}
-                runID={runID}
-                standalone={standalone}
-                result={resultRes.data}
-              />
+              <></>
             )}
           </div>
 

--- a/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
@@ -19,7 +19,7 @@ type Props = {
   cancelRun: (runID: string) => Promise<unknown>;
   getResult: (outputID: string) => Promise<Result>;
   getRun: (runID: string) => Promise<Run>;
-  initialRunData: InitialRunData;
+  initialRunData?: InitialRunData;
   getTrigger: React.ComponentProps<typeof TriggerDetails>['getTrigger'];
   pathCreator: React.ComponentProps<typeof RunInfo>['pathCreator'];
   pollInterval?: number;

--- a/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
@@ -108,7 +108,7 @@ export function RunDetails(props: Props) {
               standalone={standalone}
               result={resultRes.data}
             />
-            {runRes.error || resultRes.error ? (
+            {props.initialRunData?.status !== 'QUEUED' && (runRes.error || resultRes.error) ? (
               <ErrorCard
                 error={runRes.error || resultRes.error}
                 reset={runRes.error ? () => runRes.refetch() : () => resultRes.refetch()}

--- a/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunDetails.tsx
@@ -84,6 +84,13 @@ export function RunDetails(props: Props) {
     setPollInterval(undefined);
   }
 
+  // Do not show the error if queued and the error is no spans
+  const isNoSpansFoundError = !!runRes.error?.toString().match(/no function run span found/gi);
+  const showError =
+    props.initialRunData?.status === 'QUEUED' && isNoSpansFoundError
+      ? false
+      : runRes.error || resultRes.error;
+
   return (
     <div>
       {standalone && run && (
@@ -108,13 +115,11 @@ export function RunDetails(props: Props) {
               standalone={standalone}
               result={resultRes.data}
             />
-            {props.initialRunData?.status !== 'QUEUED' && (runRes.error || resultRes.error) ? (
+            {showError && (
               <ErrorCard
                 error={runRes.error || resultRes.error}
                 reset={runRes.error ? () => runRes.refetch() : () => resultRes.refetch()}
               />
-            ) : (
-              <></>
             )}
           </div>
 

--- a/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
@@ -164,7 +164,11 @@ export function RunInfo({
                 lazy={run}
                 initial={initialRunData}
                 optimisticChildren={(initialRun: InitialRunData) =>
-                  initialRun.queuedAt ?? <TimeElement date={new Date(initialRun.queuedAt)} />
+                  initialRun.queuedAt ? (
+                    <TimeElement date={new Date(initialRun.queuedAt)} />
+                  ) : (
+                    <TextElement>-</TextElement>
+                  )
                 }
               >
                 {(run: Run) => {
@@ -172,7 +176,14 @@ export function RunInfo({
                 }}
               </OptimisticElementWrapper>
 
-              <LazyElementWrapper label="Started at" lazy={run}>
+              <OptimisticElementWrapper
+                label="Started at"
+                lazy={run}
+                initial={initialRunData}
+                optimisticChildren={(initialRun: InitialRunData) =>
+                  initialRun?.status === 'QUEUED' ? <TextElement>-</TextElement> : null
+                }
+              >
                 {(run: Run) => {
                   const startedAt = toMaybeDate(run.trace.startedAt);
                   if (!startedAt) {
@@ -180,9 +191,16 @@ export function RunInfo({
                   }
                   return <TimeElement date={startedAt} />;
                 }}
-              </LazyElementWrapper>
+              </OptimisticElementWrapper>
 
-              <LazyElementWrapper label="Ended at" lazy={run}>
+              <OptimisticElementWrapper
+                label="Ended at"
+                lazy={run}
+                initial={initialRunData}
+                optimisticChildren={(initialRun: InitialRunData) =>
+                  initialRun?.status === 'QUEUED' ? <TextElement>-</TextElement> : null
+                }
+              >
                 {(run: Run) => {
                   const endedAt = toMaybeDate(run.trace.endedAt);
                   if (!endedAt) {
@@ -190,7 +208,7 @@ export function RunInfo({
                   }
                   return <TimeElement date={endedAt} />;
                 }}
-              </LazyElementWrapper>
+              </OptimisticElementWrapper>
             </dl>
           </div>
         </Card.Content>

--- a/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
@@ -30,7 +30,7 @@ type Props = {
     runPopout: (params: { runID: string }) => Route;
   };
   rerun: (args: { fnID: string; runID: string }) => Promise<unknown>;
-  initialRunData: InitialRunData;
+  initialRunData?: InitialRunData;
   run: Lazy<Run>;
   runID: string;
   result?: Result;

--- a/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
@@ -216,15 +216,17 @@ export function RunInfo({
           !isLazyDone(run) &&
           (initialRunData?.status === 'QUEUED' ? (
             <div className="border-muted bg-canvas border-t">
-              <div className="border-l-status-queued flex items-center justify-between border-l-4">
-                <p className="text-subtle max-h-24 text-ellipsis break-words px-5 py-2.5 text-sm">
-                  Awaiting run start...
+              <div className="border-l-status-queued flex items-center justify-start border-l-4">
+                <span className="relative ml-4 flex h-3 w-3">
+                  <span className="bg-status-queued absolute inline-flex h-full w-full animate-ping rounded-full opacity-75"></span>
+                  <span className="bg-status-queued relative inline-flex h-3 w-3 rounded-full"></span>
+                </span>
+                <p className="text-subtle max-h-24 text-ellipsis break-words py-2.5 pl-3 text-sm">
+                  Queued run awaiting start...
                 </p>
               </div>
             </div>
-          ) : (
-            ''
-          ))}
+          ) : null)}
         {result && (
           <RunResult className="border-muted border-t" result={result} isSuccess={isSuccess} />
         )}

--- a/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
@@ -196,7 +196,7 @@ export function RunInfo({
         </Card.Content>
         {!result &&
           !isLazyDone(run) &&
-          (initialRunData.status === 'QUEUED' ? (
+          (initialRunData?.status === 'QUEUED' ? (
             <div className="border-muted bg-canvas border-t">
               <div className="border-l-status-queued flex items-center justify-between border-l-4">
                 <p className="text-subtle max-h-24 text-ellipsis break-words px-5 py-2.5 text-sm">

--- a/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
@@ -217,9 +217,9 @@ export function RunInfo({
           (initialRunData?.status === 'QUEUED' ? (
             <div className="border-muted bg-canvas border-t">
               <div className="border-l-status-queued flex items-center justify-start border-l-4">
-                <span className="relative ml-4 flex h-3 w-3">
+                <span className="relative ml-4 flex h-2.5 w-2.5">
                   <span className="bg-status-queued absolute inline-flex h-full w-full animate-ping rounded-full opacity-75"></span>
-                  <span className="bg-status-queued relative inline-flex h-3 w-3 rounded-full"></span>
+                  <span className="bg-status-queued relative inline-flex h-2.5 w-2.5 rounded-full"></span>
                 </span>
                 <p className="text-subtle max-h-24 text-ellipsis break-words py-2.5 pl-3 text-sm">
                   Queued run awaiting start...

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -237,18 +237,19 @@ export function RunsPage({
   );
 
   const renderSubComponent = useCallback(
-    ({ id }: { id: string }) => {
+    (rowData: Run) => {
       return (
         <div className="border-subtle border-l-4 pb-6">
           <RunDetails
             cancelRun={cancelRun}
             getResult={getTraceResult}
             getRun={getRun}
+            initialRunData={rowData}
             getTrigger={getTrigger}
             pathCreator={pathCreator}
             pollInterval={pollInterval}
             rerun={rerun}
-            runID={id}
+            runID={rowData.id}
             standalone={false}
           />
         </div>

--- a/ui/packages/components/src/RunsPage/RunsTable.tsx
+++ b/ui/packages/components/src/RunsPage/RunsTable.tsx
@@ -21,7 +21,7 @@ type RunsTableProps = {
   sorting?: SortingState;
   setSorting?: OnChangeFn<SortingState>;
   isLoading?: boolean;
-  renderSubComponent: (props: { id: string }) => React.ReactElement;
+  renderSubComponent: (props: Run) => React.ReactElement;
   getRowCanExpand: (row: Row<Run>) => boolean;
   visibleColumns?: VisibilityState;
   scope: ViewScope;
@@ -164,7 +164,7 @@ export default function RunsTable({
                 // Overrides tableStyles divider color
                 <tr className="!border-transparent">
                   <td colSpan={row.getVisibleCells().length}>
-                    {renderSubComponent({ id: row.original.id })}
+                    {renderSubComponent({ ...row.original })}
                   </td>
                 </tr>
               )}


### PR DESCRIPTION
## Description

Renders the run details table while the run trace is loading. If the run is queued, show a special message that the run is pending start. This avoids showing the error that no spans are found when, they of course couldn't be b/c the run didn't start.

Supersedes #1652

### TODO
* [x] Final copy
* [x] Improved loading indicators
* [x] Hide error if run is queued
* [x] Show error if run is not queued
* [x] Test dev server
* [ ] ~~Test standalone view~~

NOTE - Standalone view out of scope

![Screen Cast 2024-10-21 at 4 30 34 PM](https://github.com/user-attachments/assets/90221011-fbd2-4ea7-ad10-0d5fc907c25f)


## Motivation
INN-3734

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
