### PR TITLE
Remove concept of legacy test environment

### DIFF
--- a/ui/apps/dashboard/src/components/Environments/Environments.tsx
+++ b/ui/apps/dashboard/src/components/Environments/Environments.tsx
@@ -4,27 +4,20 @@ import { type Route } from 'next';
 import Link from 'next/link';
 import { Button } from '@inngest/components/Button';
 import { Link as InngestLink } from '@inngest/components/Link';
-import { RiErrorWarningLine } from '@remixicon/react';
 
 import Toaster from '@/components/Toaster';
 import LoadingIcon from '@/icons/LoadingIcon';
 import { useEnvironments } from '@/queries';
-import { EnvironmentType, LEGACY_TEST_MODE_NAME } from '@/utils/environments';
+import { EnvironmentType } from '@/utils/environments';
 import { EnvironmentArchiveButton } from './EnvironmentArchiveButton';
 import EnvironmentListTable from './EnvironmentListTable';
 
 export default function Environments() {
   const [{ data: envs = [], fetching }] = useEnvironments();
 
-  // Break the environments into different groups
-  const legacyTestMode = envs.find(
-    (env) => env.type === EnvironmentType.Test && env.name === LEGACY_TEST_MODE_NAME
-  );
   const branchParent = envs.find((env) => env.type === EnvironmentType.BranchParent);
   const branches = envs.filter((env) => env.type === EnvironmentType.BranchChild);
-  const otherTestEnvs = envs.filter(
-    (env) => env.type === EnvironmentType.Test && env.name !== LEGACY_TEST_MODE_NAME
-  );
+  const customEnvs = envs.filter((env) => env.type === EnvironmentType.Test);
 
   if (fetching) {
     return (
@@ -57,38 +50,6 @@ export default function Environments() {
             Production
           </h3>
         </Link>
-        {Boolean(legacyTestMode) && (
-          <div className="mt-12 border-t border-slate-100 pt-8">
-            <div className="mb-4 flex w-full items-center  justify-between">
-              <h2 className="text-lg font-medium text-slate-800">Test Mode</h2>
-              <div className="flex items-center gap-2">
-                <Button
-                  href={`/env/${legacyTestMode?.slug}/manage`}
-                  appearance="outlined"
-                  label="Manage"
-                />
-                <Button
-                  href={`/env/${legacyTestMode?.slug}/apps` as Route}
-                  kind="primary"
-                  label="Go To Apps"
-                />
-              </div>
-            </div>
-            <Link
-              href={`/env/${legacyTestMode?.slug}/functions` as Route}
-              className="mt-8 flex cursor-pointer items-center justify-between rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-sm hover:bg-slate-100/60"
-            >
-              <h3 className="flex items-center gap-2 text-sm font-semibold text-slate-800">
-                <span className="bg-primary-moderate block h-2 w-2 rounded-full" />
-                Test
-              </h3>
-            </Link>
-            <p className="mt-4 text-sm text-amber-600">
-              <RiErrorWarningLine className="mr-1 inline-block h-4 w-4 text-amber-500" />
-              Test mode is a legacy environment
-            </p>
-          </div>
-        )}
 
         {Boolean(branchParent) && (
           <div className="mt-12 border-t border-slate-100 pt-8">
@@ -116,8 +77,8 @@ export default function Environments() {
           </div>
         )}
 
-        {otherTestEnvs.length > 0 &&
-          otherTestEnvs.map((env) => (
+        {customEnvs.length > 0 &&
+          customEnvs.map((env) => (
             <div key={env.id} className="mt-12 border-t border-slate-100 pt-8">
               <div className="mb-4 flex w-full items-center  justify-between">
                 <h2 className="text-lg font-medium text-slate-800">{env.name}</h2>

--- a/ui/apps/dashboard/src/components/Navigation/Environments.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Environments.tsx
@@ -20,7 +20,6 @@ import cn from '@/utils/cn';
 import {
   EnvironmentType,
   getDefaultEnvironment,
-  getLegacyTestMode,
   getSortedBranchEnvironments,
   getTestEnvironments,
   type Environment,
@@ -137,7 +136,6 @@ export default function EnvironmentSelectMenu({
 
   const defaultEnvironment = getDefaultEnvironment(envs);
   const includeArchived = false;
-  const legacyTestMode = getLegacyTestMode(envs, includeArchived);
   const mostRecentlyCreatedBranchEnvironments = getSortedBranchEnvironments(
     envs,
     includeArchived
@@ -180,12 +178,6 @@ export default function EnvironmentSelectMenu({
 
           <Listbox.Options className="bg-canvasBase border-subtle overflow-y-truncate absolute top-10 z-50 w-[188px] divide-none rounded border shadow focus:outline-none">
             {defaultEnvironment !== null && <EnvironmentItem environment={defaultEnvironment} />}
-
-            {legacyTestMode !== null && (
-              <div>
-                <EnvironmentItem environment={legacyTestMode} name="Test mode" />
-              </div>
-            )}
 
             {testEnvironments.length > 0 &&
               testEnvironments.map((env) => <EnvironmentItem key={env.id} environment={env} />)}

--- a/ui/apps/dashboard/src/utils/environments.ts
+++ b/ui/apps/dashboard/src/utils/environments.ts
@@ -5,8 +5,6 @@ import { type NonEmptyArray } from '@/utils/isNonEmptyArray';
 
 export { EnvironmentType };
 
-export const LEGACY_TEST_MODE_NAME = 'Test';
-
 /** Environment is a "workspace" right now */
 export type Environment = {
   type: EnvironmentType;
@@ -36,20 +34,6 @@ export function getDefaultEnvironment(
   environments: NonEmptyArray<Environment>
 ): Environment | null {
   return environments.find((e) => e.type === EnvironmentType.Production) || null;
-}
-
-export function getLegacyTestMode(
-  environments: NonEmptyArray<Environment>,
-  includeArchived = true
-): Environment | null {
-  return (
-    environments.find((env) => {
-      if (!includeArchived && env.isArchived) {
-        return false;
-      }
-      return env.type === EnvironmentType.Test && env.name === LEGACY_TEST_MODE_NAME;
-    }) || null
-  );
 }
 
 function getRecentCutOffDate(): Date {
@@ -119,7 +103,7 @@ export function getTestEnvironments(
     if (!includeArchived && env.isArchived) {
       return false;
     }
-    return env.type === EnvironmentType.Test && env.name !== LEGACY_TEST_MODE_NAME;
+    return env.type === EnvironmentType.Test;
   });
 }
 
@@ -140,13 +124,9 @@ export function workspaceToEnvironment(
   >
 ): Environment {
   const isProduction = workspace.type === EnvironmentType.Production;
-  const isTestWorkspace = workspace.type === EnvironmentType.Test;
-  const isLegacyTestMode = isTestWorkspace && workspace.name === 'default';
 
   let environmentName = workspace.name;
-  if (isLegacyTestMode) {
-    environmentName = LEGACY_TEST_MODE_NAME;
-  } else if (isProduction) {
+  if (isProduction) {
     environmentName = 'Production';
   }
 
@@ -190,14 +170,9 @@ export function getEnvironmentSlug({
   environmentType,
 }: getEnvironmentSlugProps): string {
   const isProduction = environmentType === EnvironmentType.Production;
-  const isTestWorkspace = environmentType === EnvironmentType.Test;
-  const isLegacyTestMode = isTestWorkspace && environmentName === 'default';
 
   let slug = environmentSlug || '';
-  if (isLegacyTestMode) {
-    environmentName = LEGACY_TEST_MODE_NAME;
-    slug = slugify(environmentName);
-  } else if (isProduction) {
+  if (isProduction) {
     slug = staticSlugs.production;
   } else if (environmentType === EnvironmentType.BranchParent) {
     slug = staticSlugs.branch;


### PR DESCRIPTION
## Description
Remove the concept of the "legacy test environment". Instead, treat this environment like a normal custom environment.

## Motivation
When a user creates a custom environment named "Test", we incorrectly show the legacy warnings.

## Context
A long time ago, every account had 2 environments: production and test. We later introduced branch environments and custom environments.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
