### PR TITLE
INN-3871: use skippable queries in metrics

### DIFF
--- a/ui/apps/dashboard/src/components/Metrics/Overview.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/Overview.tsx
@@ -4,7 +4,7 @@ import { RiArrowDownSFill, RiArrowRightSFill } from '@remixicon/react';
 
 import { useEnvironment } from '@/components/Environments/environment-context';
 import { graphql } from '@/gql';
-import { useGraphQLQuery, useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
+import { useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
 import { AUTO_REFRESH_INTERVAL } from './ActionMenu';
 import type { MetricsFilters } from './Dashboard';
 import { FailedFunctions } from './FailedFunctions';

--- a/ui/apps/dashboard/src/components/Metrics/Overview.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/Overview.tsx
@@ -4,7 +4,7 @@ import { RiArrowDownSFill, RiArrowRightSFill } from '@remixicon/react';
 
 import { useEnvironment } from '@/components/Environments/environment-context';
 import { graphql } from '@/gql';
-import { useGraphQLQuery } from '@/utils/useGraphQLQuery';
+import { useGraphQLQuery, useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
 import { AUTO_REFRESH_INTERVAL } from './ActionMenu';
 import type { MetricsFilters } from './Dashboard';
 import { FailedFunctions } from './FailedFunctions';
@@ -150,7 +150,8 @@ export const MetricsOverview = ({
     scope,
   };
 
-  const { data, error } = useGraphQLQuery({
+  const { data, error } = useSkippableGraphQLQuery({
+    skip: !env.id,
     query: GetFunctionStatusMetrics,
     pollIntervalInMilliseconds: autoRefresh ? AUTO_REFRESH_INTERVAL * 1000 : 0,
     variables,

--- a/ui/apps/dashboard/src/components/Metrics/Volume.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/Volume.tsx
@@ -4,7 +4,7 @@ import { RiArrowDownSFill, RiArrowRightSFill } from '@remixicon/react';
 
 import { graphql } from '@/gql';
 import { MetricsScope } from '@/gql/graphql';
-import { useGraphQLQuery } from '@/utils/useGraphQLQuery';
+import { useGraphQLQuery, useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
 import { useEnvironment } from '../Environments/environment-context';
 import { AUTO_REFRESH_INTERVAL } from './ActionMenu';
 import { Backlog } from './Backlog';
@@ -237,7 +237,8 @@ export const MetricsVolume = ({
     scope,
   };
 
-  const { error, data } = useGraphQLQuery({
+  const { error, data } = useSkippableGraphQLQuery({
+    skip: !env.id,
     query: GetVolumeMetrics,
     pollIntervalInMilliseconds: autoRefresh ? AUTO_REFRESH_INTERVAL * 1000 : 0,
     variables,

--- a/ui/apps/dashboard/src/components/Metrics/Volume.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/Volume.tsx
@@ -4,7 +4,7 @@ import { RiArrowDownSFill, RiArrowRightSFill } from '@remixicon/react';
 
 import { graphql } from '@/gql';
 import { MetricsScope } from '@/gql/graphql';
-import { useGraphQLQuery, useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
+import { useSkippableGraphQLQuery } from '@/utils/useGraphQLQuery';
 import { useEnvironment } from '../Environments/environment-context';
 import { AUTO_REFRESH_INTERVAL } from './ActionMenu';
 import { Backlog } from './Backlog';


### PR DESCRIPTION
## Description

A tiny bit of housekeeping: don't send metrics queries when there is no env id. We were sending those along regardless earlier and polluting the logs with red herring error messages when the upstream APIs where getting errors. 

## Motivation
Less noise.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
