### PR TITLE
Dequeue pause item from correct shard

### DIFF
--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -198,8 +198,9 @@ type ResumeRequest struct {
 	EventID *ulid.ULID
 	// RunID is the ID of the run that causes this resume, used for invoking
 	// functions directly.
-	RunID    *ulid.ULID
-	StepName string
+	RunID     *ulid.ULID
+	StepName  string
+	IsTimeout bool
 }
 
 func (r *ResumeRequest) Error() string {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1671,9 +1671,17 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 
 		// And dequeue the timeout job to remove unneeded work from the queue, etc.
 		if q, ok := e.queue.(redis_state.QueueManager); ok {
-			// need to retrieve shard for system queue (see handleGeneratorWaitForEvent)
-			qn := queue.KindPause
-			shard, err := e.shardFinder(ctx, md.ID.Tenant.AccountID, &qn)
+			var qn *string
+			if r.IsTimeout {
+				// timeouts are enqueued to the workflow partition (see handleGeneratorWaitForEvent)
+				// this is _not_ a system partition and lives on the account shard
+			} else {
+				// pause events are enqueued to a system partition (see pauseEventListener)
+				// system partitions live on the default shard
+				queueName := fmt.Sprintf("pause:%s", pause.WorkspaceID)
+				qn = &queueName
+			}
+			shard, err := e.shardFinder(ctx, md.ID.Tenant.AccountID, qn)
 			if err != nil {
 				return fmt.Errorf("could not find shard for pause timeout item for account %q: %w", md.ID.Tenant.AccountID, err)
 			}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -272,7 +272,9 @@ func (s *svc) handlePauseTimeout(ctx context.Context, item queue.Item) error {
 		return nil
 	}
 
-	r := execution.ResumeRequest{}
+	r := execution.ResumeRequest{
+		IsTimeout: true,
+	}
 
 	// If the pause timeout is for an invocation, store an error to cause the
 	// step to fail.


### PR DESCRIPTION
## Description

<img width="901" alt="image" src="https://github.com/user-attachments/assets/70fb2bbc-9870-47ec-920f-2a98beb60f97">

Pause-related items are enqueued to two possible places

- When the item is a pause timeout: The queue item is part of the function partition, which lives on the account shard
- When the item is a pause event: The queue item is enqueued to a _system partition_, which only exists on the default shard

Previously, we attempted to dequeue pause-related items from the default shard only. This did not work for pause timeouts. This caused a couple warnings, and items would have been cleaned up automatically, so it just takes longer for them to get peeked, leased, processed, and dequeued by the executor again.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
