### PR TITLE
Improve scavenger

### DIFF
--- a/pkg/execution/state/redis_state/lua/queue/dequeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/dequeue.lua
@@ -71,7 +71,7 @@ local function handleDequeueConcurrency(keyConcurrency, keyPartitionSet, partiti
   		-- - update the concurrency pointer (used by scavenger)
   		-- - update the global or account pointer.
   		return
-  end
+  	end
 
 	-- Backwards compatibility: For default partitions, use the partition ID (function ID) as the pointer
 	local pointerMember = keyConcurrency

--- a/pkg/execution/state/redis_state/lua/queue/dropPartitionPointerIfEmpty.lua
+++ b/pkg/execution/state/redis_state/lua/queue/dropPartitionPointerIfEmpty.lua
@@ -1,0 +1,16 @@
+--[[
+  Atomically drops partition pointer from index if partition is empty.
+]]
+
+local keyIndex = KEYS[1]
+local keyPartition = KEYS[2]
+
+local pointer = ARGV[1]
+
+local count = tonumber(redis.call("ZCARD", keyPartition))
+if count == 0 then
+  redis.call("ZREM", keyIndex, pointer)
+  return 1
+end
+
+return 0

--- a/pkg/execution/state/redis_state/lua/queue/extendLease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/extendLease.lua
@@ -25,12 +25,12 @@ local queueID         = ARGV[1]
 local currentLeaseKey = ARGV[2]
 local newLeaseKey     = ARGV[3]
 
-local partitionTypeA       	= tonumber(ARGV[4])
-local partitionTypeB        = tonumber(ARGV[5])
-local partitionTypeC        = tonumber(ARGV[6])
-local partitionIdA        	= ARGV[7]
-local partitionIdB        	= ARGV[8]
-local partitionIdC        	= ARGV[9]
+local partitionTypeA	= tonumber(ARGV[4])
+local partitionTypeB 	= tonumber(ARGV[5])
+local partitionTypeC 	= tonumber(ARGV[6])
+local partitionIdA 		= ARGV[7]
+local partitionIdB 		= ARGV[8]
+local partitionIdC 		= ARGV[9]
 
 -- $include(decode_ulid_time.lua)
 -- $include(get_queue_item.lua)

--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -120,17 +120,17 @@ redis.call("HSET", keyQueueMap, queueID, cjson.encode(item))
 
 local function handleLease(keyPartition, keyConcurrency, concurrencyLimit, partitionID, partitionType)
   if partitionType == 0 or concurrencyLimit > 0 then
-      -- Add item to in-progress/concurrency queue and set score to lease expiry time to be picked up by scavenger
-      redis.call("ZADD", keyConcurrency, nextTime, item.id)
+	-- Add item to in-progress/concurrency queue and set score to lease expiry time to be picked up by scavenger
+	redis.call("ZADD", keyConcurrency, nextTime, item.id)
 
-      -- Remove the item from our sorted index, as this is no longer on the queue; it's in-progress
-      -- and stored in functionConcurrencyKey.
-      redis.call("ZREM", keyPartition, item.id)
+	-- Remove the item from our sorted index, as this is no longer on the queue; it's in-progress
+	-- and stored in functionConcurrencyKey.
+	redis.call("ZREM", keyPartition, item.id)
   end
 
-	if partitionType ~= 0 then
-  		-- Do not add key queues to concurrency pointer
-  		return
+  if partitionType ~= 0 then
+	-- Do not add key queues to concurrency pointer
+	return
   end
 
 	-- For every queue that we lease from, ensure that it exists in the scavenger pointer queue
@@ -147,8 +147,8 @@ local function handleLease(keyPartition, keyConcurrency, concurrencyLimit, parti
 		-- Backwards compatibility: For default partitions, use the partition ID (function ID) as the pointer
 		local pointerMember = keyConcurrency
 		if partitionType == 0 then
-      pointerMember = partitionID
-    end
+			pointerMember = partitionID
+		end
 
 		redis.call("ZADD", concurrencyPointer, earliestLease, pointerMember)
 	end

--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -119,6 +119,8 @@ item.leaseID = newLeaseKey
 redis.call("HSET", keyQueueMap, queueID, cjson.encode(item))
 
 local function handleLease(keyPartition, keyConcurrency, concurrencyLimit, partitionID, partitionType)
+	-- If we're dealing with a default function partition, we still want to add
+	-- to the concurrency (in progress) queue. Otherwise, concurrency limits must be set.
 	if partitionType == 0 or concurrencyLimit > 0 then
 		-- Add item to in-progress/concurrency queue and set score to lease expiry time to be picked up by scavenger
 		redis.call("ZADD", keyConcurrency, nextTime, item.id)

--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -119,7 +119,7 @@ item.leaseID = newLeaseKey
 redis.call("HSET", keyQueueMap, queueID, cjson.encode(item))
 
 local function handleLease(keyPartition, keyConcurrency, concurrencyLimit, partitionID, partitionType)
-  if partitionType == 0 or concurrencyLimit > 0 then
+	if partitionType == 0 or concurrencyLimit > 0 then
 		-- Add item to in-progress/concurrency queue and set score to lease expiry time to be picked up by scavenger
 		redis.call("ZADD", keyConcurrency, nextTime, item.id)
 
@@ -128,7 +128,7 @@ local function handleLease(keyPartition, keyConcurrency, concurrencyLimit, parti
 		redis.call("ZREM", keyPartition, item.id)
 	end
 
-  if partitionType ~= 0 then
+	if partitionType ~= 0 then
 		-- Do not add key queues to concurrency pointer
 		return
 	end

--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -120,18 +120,18 @@ redis.call("HSET", keyQueueMap, queueID, cjson.encode(item))
 
 local function handleLease(keyPartition, keyConcurrency, concurrencyLimit, partitionID, partitionType)
   if partitionType == 0 or concurrencyLimit > 0 then
-	-- Add item to in-progress/concurrency queue and set score to lease expiry time to be picked up by scavenger
-	redis.call("ZADD", keyConcurrency, nextTime, item.id)
+		-- Add item to in-progress/concurrency queue and set score to lease expiry time to be picked up by scavenger
+		redis.call("ZADD", keyConcurrency, nextTime, item.id)
 
-	-- Remove the item from our sorted index, as this is no longer on the queue; it's in-progress
-	-- and stored in functionConcurrencyKey.
-	redis.call("ZREM", keyPartition, item.id)
-  end
+		-- Remove the item from our sorted index, as this is no longer on the queue; it's in-progress
+		-- and stored in functionConcurrencyKey.
+		redis.call("ZREM", keyPartition, item.id)
+	end
 
   if partitionType ~= 0 then
-	-- Do not add key queues to concurrency pointer
-	return
-  end
+		-- Do not add key queues to concurrency pointer
+		return
+	end
 
 	-- For every queue that we lease from, ensure that it exists in the scavenger pointer queue
 	-- so that expired leases can be re-processed.  We want to take the earliest time from the

--- a/pkg/execution/state/redis_state/lua/queue/requeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/requeue.lua
@@ -65,6 +65,11 @@ redis.call("HSET", queueKey, queueID, queueItem)
 local function handleRequeueConcurrency(keyConcurrency, partitionID, partitionType)
 	redis.call("ZREM", keyConcurrency, item.id) -- Remove from in-progress queue
 
+	if partitionType ~= 0 then
+      -- If this is not a default partition, we don't need to update the concurrency pointer (used by scavenger)
+      return
+  end
+
 	-- Backwards compatibility: For default partitions, use the partition ID (function ID) as the pointer
 	local pointerMember = keyConcurrency
 	if partitionType == 0 then

--- a/pkg/execution/state/redis_state/lua/queue/requeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/requeue.lua
@@ -66,9 +66,9 @@ local function handleRequeueConcurrency(keyConcurrency, partitionID, partitionTy
 	redis.call("ZREM", keyConcurrency, item.id) -- Remove from in-progress queue
 
 	if partitionType ~= 0 then
-      -- If this is not a default partition, we don't need to update the concurrency pointer (used by scavenger)
-      return
-  end
+		-- If this is not a default partition, we don't need to update the concurrency pointer (used by scavenger)
+		return
+	end
 
 	-- Backwards compatibility: For default partitions, use the partition ID (function ID) as the pointer
 	local pointerMember = keyConcurrency

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -1442,9 +1442,9 @@ func (q *queue) SetFunctionPaused(ctx context.Context, accountId uuid.UUID, fnID
 	return nil
 }
 
-// SetFunctionPaused sets the "Paused" flag (represented in JSON as "off") for the given
-// function ID's queue partition.
-// If a function is unpaused, we requeue the partition with a score of "now" to ensure that it is processed.
+// dropPartitionPointerIfEmpty atomically drops a pointer queue member if the associated
+// ZSET is empty. This is used to ensure that we don't have pointers to empty ZSETs, in case
+// the cleanup process fails.
 func (q *queue) dropPartitionPointerIfEmpty(ctx context.Context, shard QueueShard, keyIndex, keyPartition, indexMember string) error {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "SetFunctionPaused"), redis_telemetry.ScopeQueue)
 

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -2049,6 +2049,10 @@ func (q *queue) ExtendLease(ctx context.Context, i osqueue.QueueItem, leaseID ul
 		parts[0].PartitionType,
 		parts[1].PartitionType,
 		parts[2].PartitionType,
+
+		parts[0].ID,
+		parts[1].ID,
+		parts[2].ID,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -3168,7 +3168,7 @@ func (q *queue) Scavenge(ctx context.Context, limit int) (int, error) {
 		if strings.HasPrefix(queueKey, "{q:v1}:concurrency:custom:") {
 			err := client.Do(ctx, client.B().Zrem().Key(kg.ConcurrencyIndex()).Member(partition).Build()).Error()
 			if err != nil {
-				resultErr = multierror.Append(resultErr, fmt.Errorf("error removing key queue '%s' from concurrency pointer '%s': %w", partition, err))
+				resultErr = multierror.Append(resultErr, fmt.Errorf("error removing key queue '%s' from concurrency pointer: %w", partition, err))
 			}
 			continue
 		}

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -3670,7 +3670,7 @@ func TestQueueScavenge(t *testing.T) {
 		itemCountMatches(1)
 		concurrencyItemCountMatches(0)
 
-		indexMembers, err = r.ZMembers(q.primaryQueueShard.RedisClient.kg.ConcurrencyIndex())
+		_, err = r.ZMembers(q.primaryQueueShard.RedisClient.kg.ConcurrencyIndex())
 		require.Error(t, err, r.Dump())
 		require.ErrorIs(t, err, miniredis.ErrKeyNotFound)
 


### PR DESCRIPTION
## Description

scavenging is important to move abandoned in-progress items back to the "backlog" queue partition, so they get picked up by executors again. we observed some in-progress jobs not extending their lease for a prolonged duration, indicating that scavenging is not moving at the required pace, or at all.

- key queues should never be in there anymore: key queues are only used for tracking concurrency, NOT used as an execution entrypoint, so we don't care about key queues in the scavenger
- we ALWAYS want to add a pointer to the default fn partition to the scavenger queue, so that stalling jobs get picked up
- we should gracefully clean up leftover key queue data, and remove pointers to empty concurrency queues atomically. otherwise, we may accrue unnecessary pointers, which leaves the scavenger spinning without doing any work.

with these changes
- the scavenger queue (concurrency index) should gradually empty, only including pointers to function concurrency queues with actual in progress items
- key queues should be filtered out and never added again

context
- we have concurrency queues that contain stalled items. these should have been picked up by the scavenger
- the scavenger is logging key queues, which should no longer be in there
- the scavenger must clean up leftover items fast, so we cannot build up unnecessary cruft

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
