### PR TITLE
add index for showing how far the pauses has progressed

### DIFF
--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -100,6 +100,9 @@ type PauseIterator interface {
 
 	// Val returns the current Pause from the iterator.
 	Val(context.Context) *Pause
+
+	// Index shows how far the iterator has progressed
+	Index() int64
 }
 
 // PauseManager manages mutating and fetching pauses from a backend implementation.


### PR DESCRIPTION
## Description

Add indexing to provide insights for how far pauses progressed.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
