### PR TITLE
Fix streaming status code 0 and missing trace output

### DIFF
--- a/pkg/coreapi/graph/resolvers/runs_v2.go
+++ b/pkg/coreapi/graph/resolvers/runs_v2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/inngest/log"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -243,7 +244,7 @@ func (r *queryResolver) RunTraceSpanOutputByID(ctx context.Context, outputID str
 		var stepErr models.StepError
 		err := json.Unmarshal(output.Data, &stepErr)
 		if err != nil {
-			return nil, fmt.Errorf("error deserializing step error: %w", err)
+			log.From(ctx).Error().Err(err).Msg("error deserializing step error")
 		}
 
 		if stepErr.Message == "" {

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -361,14 +361,15 @@ func do(ctx context.Context, c HTTPDoer, r Request) (*response, error) {
 		stream, err := ParseStream(byt)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing stream: %w", err)
-		}
-		// These are all contained within a single wrapper.
-		body = stream.Body
-		statusCode = stream.StatusCode
+		} else {
+			// These are all contained within a single wrapper.
+			body = stream.Body
+			statusCode = stream.StatusCode
 
-		// Upsert headers from the stream.
-		for k, v := range stream.Headers {
-			headers[k] = v
+			// Upsert headers from the stream.
+			for k, v := range stream.Headers {
+				headers[k] = v
+			}
 		}
 	}
 

--- a/pkg/execution/driver/httpdriver/parse.go
+++ b/pkg/execution/driver/httpdriver/parse.go
@@ -82,6 +82,9 @@ func ParseStream(resp []byte) (*StreamResponse, error) {
 	if err := json.Unmarshal(resp, &body); err != nil {
 		return nil, fmt.Errorf("error reading response body to check for status code: %w", err)
 	}
+	if body.Error != nil {
+		return nil, fmt.Errorf(*body.Error)
+	}
 	// Check to see if the body is double-encoded.
 	if len(body.Body) > 0 && body.Body[0] == '"' && body.Body[len(body.Body)-1] == '"' {
 		var str string
@@ -93,6 +96,7 @@ func ParseStream(resp []byte) (*StreamResponse, error) {
 }
 
 type StreamResponse struct {
+	Error      *string           `json:"error"`
 	StatusCode int               `json:"status"`
 	Body       json.RawMessage   `json:"body"`
 	Headers    map[string]string `json:"headers"`

--- a/pkg/run/trace_lifecycle.go
+++ b/pkg/run/trace_lifecycle.go
@@ -327,9 +327,9 @@ func (l traceLifecycle) OnFunctionFinished(
 		span.SetAttributes(attribute.Int64(consts.OtelSysFunctionStatusCode, enums.RunStatusFailed.ToCode()))
 	}
 
-	output := resp.Output
-	if resp.Err != nil {
-		output = *resp.Err
+	var output any = resp.Err
+	if resp.Output != nil {
+		output = resp.Output
 	}
 	span.SetFnOutput(output)
 }
@@ -694,9 +694,9 @@ func (l traceLifecycle) OnStepFinished(
 				attribute.Int(consts.OtelSysStepOutputSizeBytes, resp.OutputSize),
 			)
 
-			output := resp.Output
-			if resp.Err != nil {
-				output = *resp.Err
+			var output any = resp.Err
+			if resp.Output != nil {
+				output = resp.Output
 			}
 			span.SetStepOutput(output)
 		} else if resp.IsTraceVisibleFunctionExecution() {
@@ -711,9 +711,9 @@ func (l traceLifecycle) OnStepFinished(
 			span.SetAttributes(attribute.String(consts.OtelSysStepOpcode, enums.OpcodeNone.String()))
 			span.SetName(spanName)
 
-			output := resp.Output
-			if resp.Err != nil {
-				output = *resp.Err
+			var output any = resp.Err
+			if resp.Output != nil {
+				output = resp.Output
 			}
 			span.SetStepOutput(output)
 		} else {

--- a/pkg/run/trace_lifecycle.go
+++ b/pkg/run/trace_lifecycle.go
@@ -327,7 +327,11 @@ func (l traceLifecycle) OnFunctionFinished(
 		span.SetAttributes(attribute.Int64(consts.OtelSysFunctionStatusCode, enums.RunStatusFailed.ToCode()))
 	}
 
-	span.SetFnOutput(resp.Output)
+	output := resp.Output
+	if resp.Err != nil {
+		output = *resp.Err
+	}
+	span.SetFnOutput(output)
 }
 
 func (l traceLifecycle) OnFunctionCancelled(ctx context.Context, md sv2.Metadata, req execution.CancelRequest, evts []json.RawMessage) {
@@ -689,7 +693,12 @@ func (l traceLifecycle) OnStepFinished(
 				attribute.Int(consts.OtelSysStepStatusCode, resp.StatusCode),
 				attribute.Int(consts.OtelSysStepOutputSizeBytes, resp.OutputSize),
 			)
-			span.SetStepOutput(resp.Output)
+
+			output := resp.Output
+			if resp.Err != nil {
+				output = *resp.Err
+			}
+			span.SetStepOutput(output)
 		} else if resp.IsTraceVisibleFunctionExecution() {
 			spanName := consts.OtelExecFnOk
 			span.SetStatus(codes.Ok, "success")
@@ -701,7 +710,12 @@ func (l traceLifecycle) OnStepFinished(
 
 			span.SetAttributes(attribute.String(consts.OtelSysStepOpcode, enums.OpcodeNone.String()))
 			span.SetName(spanName)
-			span.SetFnOutput(resp.Output)
+
+			output := resp.Output
+			if resp.Err != nil {
+				output = *resp.Err
+			}
+			span.SetStepOutput(output)
 		} else {
 			// if it's not a step or function response that represents either a failed or a successful execution.
 			// Do not record discovery spans and cancel it.

--- a/tests/golang/streaming_test.go
+++ b/tests/golang/streaming_test.go
@@ -73,7 +73,7 @@ func TestStreaming(t *testing.T) {
 					}
 					if tcpConn, ok := conn.(*net.TCPConn); ok {
 						// Send RST instead of FIN.
-						tcpConn.SetLinger(0)
+						_ = tcpConn.SetLinger(0)
 					}
 					conn.Close()
 				}

--- a/tests/golang/streaming_test.go
+++ b/tests/golang/streaming_test.go
@@ -1,0 +1,190 @@
+package golang
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/execution/driver"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/sdk"
+	"github.com/inngest/inngest/tests/client"
+	"github.com/inngest/inngestgo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreaming(t *testing.T) {
+	t.Run("connection reset", func(t *testing.T) {
+		ctx := context.Background()
+		r := require.New(t)
+		c := client.New(t)
+		inngestClient := inngestgo.NewClient(inngestgo.ClientOpts{
+			EventKey: toPtr("test"),
+			EventURL: toPtr("http://localhost:8288"),
+		})
+
+		var appURL *string
+		var runID *string
+
+		// Create a fake SDK that replicates a connection reset during streaming.
+		fakeSDK := NewHTTPServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Execution
+			if r.Method == http.MethodPost {
+				byt, err := io.ReadAll(r.Body)
+				if err != nil {
+					http.Error(w, "failed to read body", http.StatusInternalServerError)
+					return
+				}
+
+				request := driver.SDKRequest{}
+				err = json.Unmarshal(byt, &request)
+				if err != nil {
+					http.Error(w, "failed to unmarshal body", http.StatusInternalServerError)
+					return
+				}
+				runID = toPtr(request.Context.RunID.String())
+
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					http.Error(w, "not a flusher", http.StatusInternalServerError)
+					return
+				}
+
+				w.Write([]byte(" "))
+				flusher.Flush()
+				<-time.After(1 * time.Second)
+
+				// Reset connection using TCP reset.
+				if hijacker, ok := w.(http.Hijacker); ok {
+					conn, _, err := hijacker.Hijack()
+					if err != nil {
+						http.Error(w, "failed to reset connection", http.StatusInternalServerError)
+						return
+					}
+					if tcpConn, ok := conn.(*net.TCPConn); ok {
+						// Send RST instead of FIN.
+						tcpConn.SetLinger(0)
+					}
+					conn.Close()
+				}
+			}
+
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}))
+		defer fakeSDK.Close()
+		appURL = toPtr(fakeSDK.URL())
+
+		// Simulate an SDK syncing itself.
+		sync := func() error {
+			byt, err := json.Marshal(sdk.RegisterRequest{
+				AppName: "my-app",
+				Functions: []sdk.SDKFunction{{
+					Name: "my-fn",
+					Triggers: []inngest.Trigger{
+						{EventTrigger: &inngest.EventTrigger{Event: "my-event"}},
+					},
+					Steps: map[string]sdk.SDKStep{
+						"step-1": {
+							Name: "Step 1",
+							Retries: &sdk.StepRetries{
+								Attempts: 0,
+							},
+							Runtime: map[string]any{
+								"url": fmt.Sprintf("%s/api/inngest?fnId=another-fn", *appURL),
+							},
+						},
+					},
+				}},
+				URL: *appURL,
+			})
+			if err != nil {
+				return err
+			}
+
+			req, err := http.NewRequest(
+				http.MethodPost,
+				"http://localhost:8288/fn/register",
+				bytes.NewReader(byt),
+			)
+			if err != nil {
+				return err
+			}
+			req.Header.Set("content-type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return err
+			}
+			if resp.StatusCode != http.StatusOK {
+				// Print the body to make test failures easier to debug.
+				byt, _ := io.ReadAll(resp.Body)
+				fmt.Println(string(byt))
+				resp.Body.Close()
+
+				return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+			}
+
+			return nil
+		}
+		r.NoError(sync())
+
+		// _, err := inngestgo.Send(ctx, inngestgo.Event{
+		_, err := inngestClient.Send(ctx, inngestgo.Event{
+			Name: "my-event",
+			Data: map[string]any{"foo": "bar"},
+		})
+		r.NoError(err)
+
+		r.EventuallyWithT(func(ct *assert.CollectT) {
+			a := assert.New(ct)
+			a.NotNil(runID)
+			if runID == nil {
+				return
+			}
+
+			run, err := c.RunTraces(ctx, *runID)
+			a.NoError(err)
+			if err != nil {
+				return
+			}
+			a.Equal("FAILED", run.Status)
+
+			a.NotNil(run.Trace)
+			if run.Trace == nil {
+				return
+			}
+			a.NotNil(run.Trace.OutputID)
+			if run.Trace.OutputID == nil {
+				return
+			}
+			runOutput := c.RunSpanOutput(ctx, *run.Trace.OutputID)
+			a.NotNil(runOutput)
+			if runOutput == nil {
+				return
+			}
+			a.NotNil(runOutput.Error)
+			if runOutput.Error == nil {
+				return
+			}
+			a.NotNil(runOutput.Error.Stack)
+			if runOutput.Error.Stack == nil {
+				return
+			}
+			a.Contains(*runOutput.Error.Stack, "connection reset by peer")
+		}, 10*time.Second, time.Second)
+	})
+}
+
+func toPtr[T any](v T) *T {
+	return &v
+}

--- a/tests/golang/streaming_test.go
+++ b/tests/golang/streaming_test.go
@@ -60,7 +60,7 @@ func TestStreaming(t *testing.T) {
 					return
 				}
 
-				w.Write([]byte(" "))
+				_, _ = w.Write([]byte(" "))
 				flusher.Flush()
 				<-time.After(1 * time.Second)
 


### PR DESCRIPTION
## Description
Fix status code 0 when a streaming response has a connection reset. This happens because the status code is still 201 (since we send it immediately) but we never get the full response body.

Fix missing trace output under some circumstances. The aforementioned streaming connection reset is one example of this.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
