### PR TITLE
Add PeekRandom

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -21,10 +21,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.23'
       - name: Lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.58.0
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.61.0
           ./bin/golangci-lint run --verbose
   test-linux-race:
     strategy:
@@ -36,6 +36,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.22'
+          go-version: '1.23'
       - name: Test
         run: go test $(go list ./... | grep -v tests) -race -count=1

--- a/pkg/execution/driver/httpdriver/parse.go
+++ b/pkg/execution/driver/httpdriver/parse.go
@@ -83,7 +83,7 @@ func ParseStream(resp []byte) (*StreamResponse, error) {
 		return nil, fmt.Errorf("error reading response body to check for status code: %w", err)
 	}
 	if body.Error != nil {
-		return nil, fmt.Errorf(*body.Error)
+		return nil, fmt.Errorf("%s", *body.Error)
 	}
 	// Check to see if the body is double-encoded.
 	if len(body.Body) > 0 && body.Body[0] == '"' && body.Body[len(body.Body)-1] == '"' {

--- a/pkg/execution/state/redis_state/lua/queue/peek.lua
+++ b/pkg/execution/state/redis_state/lua/queue/peek.lua
@@ -7,10 +7,24 @@ Peek returns items from the queue that are unleased and the vesting time <= peek
 local queueIndex = KEYS[1]
 local queueKey   = KEYS[2]
 
-local peekUntil  = ARGV[1]
-local limit      = tonumber(ARGV[2])
+local peekUntil    = ARGV[1]
+local limit        = tonumber(ARGV[2])
+local randomOffset = ARGV[3]
 
-local itemIds = redis.call("ZRANGE", queueIndex, "-inf", peekUntil, "BYSCORE", "LIMIT", 0, limit)
+
+local offset = 0
+
+if randomOffset == "1" then
+	local count = redis.call("ZRANGE", queueIndex, "-inf", peekUntil)
+	if count > limit then
+		math.randomseed(peekUntil);
+		-- We have to +1 then -1 to ensure that we have 0 as a valid random offset.
+		offset = math.random((count-limit)+1) - 1
+	end
+end
+
+
+local itemIds = redis.call("ZRANGE", queueIndex, "-inf", peekUntil, "BYSCORE", "LIMIT", offset, limit)
 if #itemIds == 0 then
 	return {}
 end

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -778,13 +778,13 @@ func BenchmarkPeekTiming(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		id := uuid.New()
-		enqueue(id, int(QueuePeekMax))
-		items, err := q.Peek(ctx, &QueuePartition{FunctionID: &id}, time.Now(), QueuePeekMax)
+		enqueue(id, int(DefaultQueuePeekMax))
+		items, err := q.Peek(ctx, &QueuePartition{FunctionID: &id}, time.Now(), DefaultQueuePeekMax)
 		if err != nil {
 			panic(err)
 		}
-		if len(items) != int(QueuePeekMax) {
-			panic(fmt.Sprintf("expected %d, got %d", QueuePeekMax, len(items)))
+		if len(items) != int(DefaultQueuePeekMax) {
+			panic(fmt.Sprintf("expected %d, got %d", DefaultQueuePeekMax, len(items)))
 		}
 	}
 }
@@ -1103,11 +1103,11 @@ func TestQueuePeek(t *testing.T) {
 		})
 
 		t.Run("It should apply a peek offset", func(t *testing.T) {
-			items, err = q.Peek(ctx, &QueuePartition{FunctionID: &workflowID}, time.Now().Add(-1*time.Hour), QueuePeekMax)
+			items, err = q.Peek(ctx, &QueuePartition{FunctionID: &workflowID}, time.Now().Add(-1*time.Hour), DefaultQueuePeekMax)
 			require.NoError(t, err)
 			require.EqualValues(t, 0, len(items))
 
-			items, err = q.Peek(ctx, &QueuePartition{FunctionID: &workflowID}, c, QueuePeekMax)
+			items, err = q.Peek(ctx, &QueuePartition{FunctionID: &workflowID}, c, DefaultQueuePeekMax)
 			require.NoError(t, err)
 			require.EqualValues(t, 3, len(items))
 			require.EqualValues(t, []*osqueue.QueueItem{&ia, &ib, &ic}, items)
@@ -1118,7 +1118,7 @@ func TestQueuePeek(t *testing.T) {
 			_, err := q.Lease(ctx, ia, 50*time.Millisecond, time.Now(), nil)
 			require.NoError(t, err)
 
-			items, err = q.Peek(ctx, &QueuePartition{FunctionID: &workflowID}, d, QueuePeekMax)
+			items, err = q.Peek(ctx, &QueuePartition{FunctionID: &workflowID}, d, DefaultQueuePeekMax)
 			require.NoError(t, err)
 			require.EqualValues(t, 3, len(items))
 			require.EqualValues(t, []*osqueue.QueueItem{&ib, &ic, &id}, items)
@@ -1139,7 +1139,7 @@ func TestQueuePeek(t *testing.T) {
 			require.NoError(t, err)
 			require.EqualValues(t, 1, caught, "Items not found during scavenge\n%s", r.Dump())
 
-			items, err = q.Peek(ctx, &QueuePartition{FunctionID: &workflowID}, d, QueuePeekMax)
+			items, err = q.Peek(ctx, &QueuePartition{FunctionID: &workflowID}, d, DefaultQueuePeekMax)
 			require.NoError(t, err)
 			require.EqualValues(t, 4, len(items))
 


### PR DESCRIPTION
This adds PeekRandom to the queue, enabling us to peek from random offsets if we encounter purely key queue issues.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
