### PR TITLE
Add timeouts tests

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -759,16 +759,17 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 		return nil, fmt.Errorf("cannot load run events: %w", err)
 	}
 
-	// for recording function start time after a successful step.
-	if md.Config.StartedAt.IsZero() {
-		md.Config.StartedAt = time.Now()
-	}
-
 	// Validate that the run can execute.
 	v := newRunValidator(e, ef.Function, md, events, item) // TODO: Load events for this.
 	if err := v.validate(ctx); err != nil {
 		return nil, err
 	}
+
+	// for recording function start time after a successful step.
+	if md.Config.StartedAt.IsZero() {
+		md.Config.StartedAt = time.Now()
+	}
+
 	if v.stopWithoutRetry {
 		if e.preDeleteStateSizeReporter != nil {
 			e.preDeleteStateSizeReporter(ctx, md)

--- a/pkg/execution/executor/validate.go
+++ b/pkg/execution/executor/validate.go
@@ -166,7 +166,7 @@ func (r *runValidator) checkCancellation(ctx context.Context) error {
 func (r *runValidator) checkStartTimeout(ctx context.Context) error {
 	if r.f.Timeouts != nil {
 		since := time.Since(ulid.Time(r.md.ID.RunID.Time()))
-		if r.f.Timeouts.Start > 0 && since > r.f.Timeouts.Start {
+		if r.f.Timeouts.Start > 0 && since > r.f.Timeouts.Start && r.md.Config.StartedAt.IsZero() {
 			logger.StdlibLogger(ctx).Debug("start timeout reached", "run_id", r.md.ID.RunID.String())
 			if err := r.e.Cancel(ctx, r.md.ID, execution.CancelRequest{}); err != nil {
 				return err


### PR DESCRIPTION
Improves tests pre-release of timeouts.  This ensures we only cancel unstared functions via `timeouts.start`

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
