### PR TITLE
Always dequeue pause timeout from account shard, log missing item as warning, not error

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1695,7 +1695,7 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 			})
 			if err != nil {
 				if errors.Is(err, redis_state.ErrQueueItemNotFound) {
-					logger.StdlibLogger(ctx).Warn("missing pause timeout item", "shard", shard.Name)
+					logger.StdlibLogger(ctx).Warn("missing pause timeout item", "shard", shard.Name, "pause", pause)
 				} else {
 					logger.StdlibLogger(ctx).Error("error dequeueing consumed pause job when resuming", "error", err)
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1701,8 +1701,8 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 					Kind: queue.KindPause,
 				},
 			})
-			if err != nil {
-				logger.StdlibLogger(ctx).Error("error dequeueing consumed pause job when resuming", "error", err, "pause", pause, "shard", shard, "qn", qn)
+			if err != nil && !errors.Is(err, redis_state.ErrQueueItemNotFound) {
+				logger.StdlibLogger(ctx).Error("error dequeueing consumed pause job when resuming", "error", err)
 			}
 		}
 		return nil

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1694,7 +1694,12 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 				},
 			})
 			if err != nil {
-				logger.StdlibLogger(ctx).Error("error dequeueing consumed pause job when resuming", "error", err)
+				if errors.Is(err, redis_state.ErrQueueItemNotFound) {
+					logger.StdlibLogger(ctx).Warn("missing pause timeout item", "shard", shard.Name)
+				} else {
+					logger.StdlibLogger(ctx).Error("error dequeueing consumed pause job when resuming", "error", err)
+
+				}
 			}
 		}
 		return nil


### PR DESCRIPTION
## Description

When a matching event is received in pauses and we resume a function run, we optimistically remove the timeout item, so that we don't run an unnecessary queue job.

Unlike the pause event which is a system queue, the timeout item is enqueued to the function partition. That's why it needs to be dequeued from the account-specific queue shard.

Up until now, we used the r.IsTimeout flag to decide which shard to use, which is wrong: Timeout jobs are _always_ stored in the function partition on the account shard. There's a case where existing timeouts for older pauses were created on a shard and the respective account has been migrated without moving data to the new queue shard. This would trigger the queue item not found error.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
