### PR TITLE
Add pauses iterator metrics for first load

### DIFF
--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -1146,6 +1146,11 @@ func (m unshardedMgr) PauseByStep(ctx context.Context, i state.Identifier, actio
 
 // PausesByEvent returns all pauses for a given event within a workspace.
 func (m unshardedMgr) PausesByEvent(ctx context.Context, workspaceID uuid.UUID, event string) (state.PauseIterator, error) {
+	return m.pausesByEvent(ctx, workspaceID, event, time.Time{})
+}
+
+// pausesByEvent returns all pauses for a given event within a workspace.
+func (m unshardedMgr) pausesByEvent(ctx context.Context, workspaceID uuid.UUID, event string, aggregateStart time.Time) (state.PauseIterator, error) {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "PausesByEvent"), redis_telemetry.ScopePauses)
 
 	pauses := m.u.Pauses()
@@ -1159,8 +1164,9 @@ func (m unshardedMgr) PausesByEvent(ctx context.Context, workspaceID uuid.UUID, 
 	if err != nil || cnt > 1000 {
 		key := pauses.kg.PauseEvent(ctx, workspaceID, event)
 		iter := &scanIter{
-			count: cnt,
-			r:     pauses.Client(),
+			count:          cnt,
+			r:              pauses.Client(),
+			aggregateStart: aggregateStart,
 		}
 		err := iter.init(ctx, key, 1000)
 		return iter, err
@@ -1168,14 +1174,16 @@ func (m unshardedMgr) PausesByEvent(ctx context.Context, workspaceID uuid.UUID, 
 
 	// If there are less than a thousand items, query the keys
 	// for iteration.
-	iter := &bufIter{r: pauses.Client()}
+	iter := &bufIter{r: pauses.Client(), aggregateStart: aggregateStart}
 	err = iter.init(ctx, key)
 	return iter, err
 }
 
 func (m unshardedMgr) PausesByEventSince(ctx context.Context, workspaceID uuid.UUID, event string, since time.Time) (state.PauseIterator, error) {
+	start := time.Now()
+
 	if since.IsZero() {
-		return m.PausesByEvent(ctx, workspaceID, event)
+		return m.pausesByEvent(ctx, workspaceID, event, start)
 	}
 
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "PausesByEventSince"), redis_telemetry.ScopePauses)
@@ -1195,8 +1203,9 @@ func (m unshardedMgr) PausesByEventSince(ctx context.Context, workspaceID uuid.U
 	}
 
 	iter := &keyIter{
-		r:  pauses.Client(),
-		kf: pauses.kg,
+		r:     pauses.Client(),
+		kf:    pauses.kg,
+		start: start,
 	}
 	err = iter.init(ctx, ids, 100)
 	return iter, err
@@ -1265,7 +1274,8 @@ type bufIter struct {
 	val *state.Pause
 	err error
 
-	l sync.Mutex
+	l              sync.Mutex
+	aggregateStart time.Time
 }
 
 func (i *bufIter) init(ctx context.Context, key string) error {
@@ -1292,6 +1302,13 @@ func (i *bufIter) Next(ctx context.Context) bool {
 
 	if len(i.items) == 0 {
 		i.err = context.Canceled
+		if !i.aggregateStart.IsZero() {
+			dur := time.Since(i.aggregateStart).Milliseconds()
+			metrics.HistogramAggregatePausesLoadDuration(ctx, dur, metrics.HistogramOpt{
+				PkgName: pkgName,
+				// TODO: tag workspace ID eventually??
+			})
+		}
 		return false
 	}
 
@@ -1333,6 +1350,8 @@ type scanIter struct {
 	err    error
 
 	l sync.Mutex
+
+	aggregateStart time.Time
 }
 
 func (i *scanIter) Error() error {
@@ -1405,6 +1424,13 @@ func (i *scanIter) Next(ctx context.Context) bool {
 		if err == scanDoneErr {
 			// No more present.
 			i.err = context.Canceled
+			if !i.aggregateStart.IsZero() {
+				dur := time.Since(i.aggregateStart).Milliseconds()
+				metrics.HistogramAggregatePausesLoadDuration(ctx, dur, metrics.HistogramOpt{
+					PkgName: pkgName,
+					// TODO: tag workspace ID eventually??
+				})
+			}
 			return false
 		}
 		if err != nil {
@@ -1551,9 +1577,10 @@ type keyIter struct {
 	// keys stores pause IDs to fetch in batches
 	keys []string
 	// vals stores pauses as strings from MGET
-	vals []string
-	idx  int64
-	err  error
+	vals  []string
+	idx   int64
+	err   error
+	start time.Time
 }
 
 func (i *keyIter) Error() error {
@@ -1579,18 +1606,14 @@ func (i *keyIter) Index() int64 {
 }
 
 func (i *keyIter) fetch(ctx context.Context) error {
-	start := time.Now()
-	defer func() {
-		dur := time.Since(start).Milliseconds()
+	if len(i.keys) == 0 {
+		// No more present.
+		i.err = context.Canceled
+		dur := time.Since(i.start).Milliseconds()
 		metrics.HistogramAggregatePausesLoadDuration(ctx, dur, metrics.HistogramOpt{
 			PkgName: pkgName,
 			// TODO: tag workspace ID eventually??
 		})
-	}()
-
-	if len(i.keys) == 0 {
-		// No more present.
-		i.err = context.Canceled
 		return scanDoneErr
 	}
 


### PR DESCRIPTION
## Description

This PR instruments the scan and buffer iterators used for loading pauses by event, but only for loading pauses for the aggregate evaluation.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
