### PR TITLE
Prevent nil panic by checking GetBody

### DIFF
--- a/pkg/execution/driver/httpdriver/util.go
+++ b/pkg/execution/driver/httpdriver/util.go
@@ -47,7 +47,7 @@ func CheckRedirect(req *http.Request, via []*http.Request) (err error) {
 		return fmt.Errorf("stopped after 10 redirects")
 	}
 
-	if via[0].Body != nil {
+	if via[0].Body != nil && via[0].GetBody != nil {
 		req.Body, err = via[0].GetBody()
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description
Fix a nil panic caused by a missing `GetBody` method on a redirect request.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
