### PR TITLE
fix: check for nil persistence interval in single node mode

### DIFF
--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -215,8 +215,12 @@ func (d *devserver) Stop(ctx context.Context) error {
 	return nil
 }
 
+func (d *devserver) HasPersistence() bool {
+	return d.singleNodeServiceOpts != nil && d.singleNodeServiceOpts.PersistenceInterval != nil
+}
+
 func (d *devserver) startPersistenceRoutine(ctx context.Context) {
-	if !d.IsSingleNodeService() {
+	if !d.HasPersistence() {
 		return
 	}
 


### PR DESCRIPTION
## Description

Previously, the server would crash when using an external Redis via 'inngest start --redis-uri' as the persistence interval is disabled for external Redis instances. This adds a HasPersistence() check to ensure both singleNodeServiceOpts and PersistenceInterval are non-nil before starting the persistence routine.

## Motivation
When using an external Redis instance, we intentionally disable the persistence interval since we rely on the external Redis to handle its own persistence and snapshotting. However, the server would still attempt to start the persistence routine without checking if the interval was set, leading to a nil pointer dereference and crash.

## Related
- [Discord](https://discord.com/channels/842170679536517141/845000011040555018/1304199850031710370)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
