### PR TITLE
Avoid input state mutation

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -556,12 +556,11 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	newState := sv2.CreateState{
 		Events:   evts,
 		Metadata: metadata,
-		Steps:    []state.InputStep{},
+		Steps:    []state.MemoizedStep{},
 	}
 
 	if req.OriginalRunID != nil && req.FromStep != nil && req.FromStep.StepID != "" {
-		var err error
-		if newState.Steps, err = reconstruct(ctx, e.traceReader, req); err != nil {
+		if err := reconstruct(ctx, e.traceReader, req, &newState); err != nil {
 			return nil, fmt.Errorf("error reconstructing input state: %w", err)
 		}
 	}

--- a/pkg/execution/executor/reconstruct.go
+++ b/pkg/execution/executor/reconstruct.go
@@ -10,9 +10,10 @@ import (
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/state"
+	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 )
 
-func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.ScheduleRequest) ([]state.InputStep, error) {
+func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.ScheduleRequest, newState *sv2.CreateState) error {
 
 	// Load the original run state and copy the state from the original
 	// run to the new run.
@@ -20,7 +21,7 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 		RunID: *req.OriginalRunID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error loading original trace run: %w", err)
+		return fmt.Errorf("error loading original trace run: %w", err)
 	}
 
 	spans, err := tr.GetTraceSpansByRun(ctx, cqrs.TraceRunIdentifier{
@@ -32,7 +33,7 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 		RunID:       *req.OriginalRunID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error loading trace spans: %w", err)
+		return fmt.Errorf("error loading trace spans: %w", err)
 	}
 
 	// Get the stack and organize spans by step IDs
@@ -58,28 +59,22 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 		// This can happen for older runs that don't save the stack; we
 		// shouldn't try to recover from this as we could accidentally
 		// make the run resolve to a different path without it.
-		return nil, fmt.Errorf("stack not found in original run")
+		return fmt.Errorf("stack not found in original run")
 	}
 
 	if !foundStepToRunFrom {
 		// This implementation has been given a step to run from that
 		// doesn't exist in this run.  This is a bad request.
-		return nil, fmt.Errorf("step to run from not found in original run")
+		return fmt.Errorf("step to run from not found in original run")
 	}
 
-	steps := []state.InputStep{}
+	steps := []state.MemoizedStep{}
 
 	// Copy the state from the original run to the new run.
 	for _, stepID := range stack {
 		if stepID == req.FromStep.StepID {
 			// We've reached the step to run from, so we can stop
-			// copying and memoize the input data instead.
-			if req.FromStep.Input != nil {
-				steps = append(steps, state.InputStep{
-					ID:   stepID,
-					Data: map[string]any{"input": req.FromStep.Input},
-				})
-			}
+			// copying
 
 			break
 		}
@@ -90,7 +85,7 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 			// we couldn't find the span that represents it. This
 			// indicates a data integrity issue and we should not
 			// attempt to recover from this.
-			return nil, fmt.Errorf("step found in stack but span not found in original run")
+			return fmt.Errorf("step found in stack but span not found in original run")
 		}
 
 		output, err := tr.GetSpanOutput(ctx, cqrs.SpanIdentifier{
@@ -102,13 +97,13 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 			SpanID:      span.SpanID,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("error loading span output: %w", err)
+			return fmt.Errorf("error loading span output: %w", err)
 		}
 
 		var data any
 		_ = json.Unmarshal(output.Data, &data)
 
-		memoizedStep := state.InputStep{
+		memoizedStep := state.MemoizedStep{
 			ID:   stepID,
 			Data: map[string]any{"data": data},
 		}
@@ -117,8 +112,18 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 		}
 
 		steps = append(steps, memoizedStep)
-
 	}
 
-	return steps, nil
+	newState.Steps = steps
+
+	if req.FromStep != nil && req.FromStep.Input != nil {
+		newState.StepInputs = []state.MemoizedStep{
+			{
+				ID:   req.FromStep.StepID,
+				Data: req.FromStep.Input,
+			},
+		}
+	}
+
+	return nil
 }

--- a/pkg/execution/state/redis_state/lua/new.lua
+++ b/pkg/execution/state/redis_state/lua/new.lua
@@ -43,10 +43,6 @@ if stepInputs ~= nil and #stepInputs > 0 then
   for _, stepInput in ipairs(stepInputsArray) do
     redis.call("HSET", stepInputsKey, stepInput.id, cjson.encode(stepInput.data))
   end
-
-  -- for k, v in pairs(stepInputsJson) do
-  --   redis.call("HSET", stepInputsKey, k, cjson.encode(v))
-  -- end
 end
 
 -- Save events

--- a/pkg/execution/state/redis_state/lua/saveResponse.lua
+++ b/pkg/execution/state/redis_state/lua/saveResponse.lua
@@ -17,11 +17,7 @@ local stepID  = ARGV[1]
 local data    = ARGV[2]
 
 if redis.call("HEXISTS", keyStep, stepID) == 1 then
-  local existingData = cjson.decode(redis.call("HGET", keyStep, stepID))
-
-  if existingData.input == nil then
-	  return -1
-  end
+  return -1
 end
 
 redis.call("HINCRBY", keyMetadata, "step_count", 1)

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -260,6 +260,22 @@ func (m shardedMgr) New(ctx context.Context, input state.Input) (state.State, er
 		return nil, err
 	}
 
+	var stepsByt []byte
+	if len(input.Steps) > 0 {
+		stepsByt, err = json.Marshal(input.Steps)
+		if err != nil {
+			return nil, fmt.Errorf("error storing run state in redis when marshalling steps: %w", err)
+		}
+	}
+
+	var stepInputsByt []byte
+	if len(input.StepInputs) > 0 {
+		stepInputsByt, err = json.Marshal(input.StepInputs)
+		if err != nil {
+			return nil, fmt.Errorf("error storing run state in redis when marshalling step inputs: %w", err)
+		}
+	}
+
 	metadata := runMetadata{
 		Identifier:     input.Identifier,
 		Debugger:       input.Debugger,
@@ -269,21 +285,12 @@ func (m shardedMgr) New(ctx context.Context, input state.Input) (state.State, er
 		Status:         enums.RunStatusScheduled,
 		SpanID:         input.SpanID,
 		EventSize:      len(events),
+		StateSize:      len(events) + len(stepsByt) + len(stepInputsByt),
+		StepCount:      len(input.Steps),
 	}
 	if input.RunType != nil {
 		metadata.RunType = *input.RunType
 	}
-
-	var stepsByt []byte
-	if len(input.Steps) > 0 {
-		stepsByt, err = json.Marshal(input.Steps)
-		if err != nil {
-			return nil, fmt.Errorf("error storing run state in redis: %w", err)
-		}
-	}
-
-	// Add total state size, including size of input steps.
-	metadata.StateSize = len(events) + len(stepsByt)
 
 	metadataByt, err := json.Marshal(metadata.Map())
 	if err != nil {
@@ -294,6 +301,7 @@ func (m shardedMgr) New(ctx context.Context, input state.Input) (state.State, er
 		events,
 		metadataByt,
 		stepsByt,
+		stepInputsByt,
 	})
 	if err != nil {
 		return nil, err
@@ -307,6 +315,7 @@ func (m shardedMgr) New(ctx context.Context, input state.Input) (state.State, er
 			fnRunState.kg.RunMetadata(ctx, isSharded, input.Identifier.RunID),
 			fnRunState.kg.Actions(ctx, isSharded, input.Identifier),
 			fnRunState.kg.Stack(ctx, isSharded, input.Identifier.RunID),
+			fnRunState.kg.ActionInputs(ctx, isSharded, input.Identifier),
 		},
 		args,
 	).AsInt64()
@@ -521,6 +530,24 @@ func (m shardedMgr) LoadSteps(ctx context.Context, accountId uuid.UUID, fnID uui
 
 	r, isSharded := fnRunState.Client(ctx, accountId, runID)
 
+	// Load action inputs
+	inputMap, err := r.Do(ctx, func(client rueidis.Client) rueidis.Completed {
+		return client.B().Hgetall().Key(fnRunState.kg.ActionInputs(ctx, isSharded, v1id)).Build()
+	}).AsStrMap()
+	if err != nil {
+		return nil, fmt.Errorf("failed loading action inputs; %w", err)
+	}
+	for stepID, marshalled := range inputMap {
+		wrapper := map[string]json.RawMessage{
+			"input": json.RawMessage(marshalled),
+		}
+		wrappedData, err := json.Marshal(wrapper)
+		if err != nil {
+			return nil, fmt.Errorf("failed to wrap action input for \"%s\"; %w", stepID, err)
+		}
+		steps[stepID] = wrappedData
+	}
+
 	// Load the actions.  This is a map of step IDs to JSON-encoded results.
 	rmap, err := r.Do(ctx, func(client rueidis.Client) rueidis.Completed {
 		return client.B().Hgetall().Key(fnRunState.kg.Actions(ctx, isSharded, v1id)).Build()
@@ -531,6 +558,7 @@ func (m shardedMgr) LoadSteps(ctx context.Context, accountId uuid.UUID, fnID uui
 	for stepID, marshalled := range rmap {
 		steps[stepID] = json.RawMessage(marshalled)
 	}
+
 	return steps, nil
 }
 
@@ -580,21 +608,44 @@ func (m shardedMgr) Load(ctx context.Context, accountId uuid.UUID, runID ulid.UL
 		}
 	}
 
-	// Load the actions.  This is a map of step IDs to JSON-encoded results.
+	actions := []state.MemoizedStep{}
+
+	// Load action inputs
+	inputMap, err := r.Do(ctx, func(client rueidis.Client) rueidis.Completed {
+		return client.B().Hgetall().Key(fnRunState.kg.ActionInputs(ctx, isSharded, id)).Build()
+	}).AsStrMap()
+	if err != nil {
+		return nil, fmt.Errorf("failed loading action inputs; %w", err)
+	}
+	for stepID, marshalled := range inputMap {
+		wrapper := map[string]json.RawMessage{
+			"input": json.RawMessage(marshalled),
+		}
+		wrappedData, err := json.Marshal(wrapper)
+		if err != nil {
+			return nil, fmt.Errorf("failed to wrap action input for \"%s\"; %w", stepID, err)
+		}
+		actions = append(actions, state.MemoizedStep{
+			ID:   stepID,
+			Data: wrappedData,
+		})
+	}
+
+	// Load the actions
 	rmap, err := r.Do(ctx, func(client rueidis.Client) rueidis.Completed {
 		return client.B().Hgetall().Key(fnRunState.kg.Actions(ctx, isSharded, id)).Build()
 	}).AsStrMap()
 	if err != nil {
 		return nil, fmt.Errorf("failed loading actions; %w", err)
 	}
-	actions := []state.InputStep{}
+
 	for stepID, marshalled := range rmap {
 		var data any
 		err = json.Unmarshal([]byte(marshalled), &data)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal step \"%s\" with data \"%s\"; %w", stepID, marshalled, err)
 		}
-		actions = append(actions, state.InputStep{
+		actions = append(actions, state.MemoizedStep{
 			ID:   stepID,
 			Data: data,
 		})

--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -63,6 +63,7 @@ func (v v2) Create(ctx context.Context, s state.CreateState) error {
 		Context:        s.Metadata.Config.Context,
 		SpanID:         s.Metadata.Config.SpanID,
 		Steps:          s.Steps,
+		StepInputs:     s.StepInputs,
 	})
 	return err
 }

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -400,7 +400,7 @@ type Mutater interface {
 	) error
 }
 
-type InputStep struct {
+type MemoizedStep struct {
 	ID   string `json:"id"`
 	Data any    `json:"data"`
 }
@@ -425,7 +425,11 @@ type Input struct {
 
 	// Steps allows users to specify pre-defined steps to run workflows from
 	// arbitrary points.
-	Steps []InputStep
+	Steps []MemoizedStep
+
+	// StepInputs allows users to specify pre-defined step inputs to run
+	// workflows from arbitrary points.
+	StepInputs []MemoizedStep
 
 	// Context is additional context for the run stored in metadata.
 	Context map[string]any

--- a/pkg/execution/state/state_instance.go
+++ b/pkg/execution/state/state_instance.go
@@ -20,7 +20,7 @@ func NewStateInstance(
 	id Identifier,
 	metadata Metadata,
 	events []map[string]any,
-	actions []InputStep,
+	actions []MemoizedStep,
 	stack []string,
 ) State {
 	return &memstate{
@@ -44,7 +44,7 @@ type memstate struct {
 	stack []string
 
 	// Actions stores a map of all output from each individual action
-	actions []InputStep
+	actions []MemoizedStep
 
 	// errors stores a map of action errors
 	errors map[string]error

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -213,7 +213,7 @@ func checkNew_stepdata(t *testing.T, m state.Manager) {
 	init := state.Input{
 		Identifier:     id,
 		EventBatchData: batch,
-		Steps: []state.InputStep{
+		Steps: []state.MemoizedStep{
 			{
 				ID:   "step-a",
 				Data: map[string]any{"result": "predetermined"},
@@ -251,7 +251,7 @@ func checkUpdateMetadata(t *testing.T, m state.Manager) {
 	init := state.Input{
 		Identifier:     id,
 		EventBatchData: batch,
-		Steps: []state.InputStep{
+		Steps: []state.MemoizedStep{
 			{
 				ID:   "step-a",
 				Data: map[string]any{"result": "predetermined"},

--- a/pkg/execution/state/v2/interfaces.go
+++ b/pkg/execution/state/v2/interfaces.go
@@ -14,7 +14,10 @@ type CreateState struct {
 	Events []json.RawMessage
 	// Steps allows users to specify pre-defined steps to run workflows from
 	// arbitrary points.
-	Steps []state.InputStep
+	Steps []state.MemoizedStep
+	// StepInputs allows users to specify pre-defined step inputs to run
+	// workflows from arbitrary points.
+	StepInputs []state.MemoizedStep
 }
 
 type StateService interface {


### PR DESCRIPTION
## Description

Avoid mutating input state by storing step input in a separate key.

- Does not use `{*}:actions:*` as we expect this to be immutable
- Does not use `{*}:metadata:*` as this is used in many places to quickly access a run's state; including inputs here could mean pulling a large amount of useless data in to memory
- Uses `{*}:inputs:*` to provide a new immutable location for edited run inputs
- Step loading and marshalling is altered to load and parse both keys

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
