### PR TITLE
Maintain an accurate state size considering inputs

### DIFF
--- a/pkg/execution/state/redis_state/lua/saveResponse.lua
+++ b/pkg/execution/state/redis_state/lua/saveResponse.lua
@@ -12,16 +12,26 @@ Output:
 local keyStep     = KEYS[1]
 local keyMetadata = KEYS[2]
 local keyStack 	  = KEYS[3]
+local keyStepInputs = KEYS[4]
 
-local stepID  = ARGV[1]
-local data    = ARGV[2]
+local stepID = ARGV[1]
+local outputData = ARGV[2]
 
 if redis.call("HEXISTS", keyStep, stepID) == 1 then
   return -1
 end
 
+-- If we're saving a response for a step that previously had input, remove the
+-- input from the state size in order to keep it as accurate as possible.
+local inputData = redis.call("HGET", keyStepInputs, stepID)
+local stateSizeDelta = #outputData
+if inputData then
+  stateSizeDelta = stateSizeDelta - #inputData
+end
+redis.call("HINCRBY", keyMetadata, "state_size", stateSizeDelta)
 redis.call("HINCRBY", keyMetadata, "step_count", 1)
-redis.call("HINCRBY", keyMetadata, "state_size", #data)
-redis.call("HSET", keyStep, stepID, data)
+
+redis.call("HSET", keyStep, stepID, outputData)
 redis.call("RPUSH", keyStack, stepID)
+
 return 0

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -711,6 +711,7 @@ func (m shardedMgr) SaveResponse(ctx context.Context, i state.Identifier, stepID
 		fnRunState.kg.Actions(ctx, isSharded, i),
 		fnRunState.kg.RunMetadata(ctx, isSharded, i.RunID),
 		fnRunState.kg.Stack(ctx, isSharded, i.RunID),
+		fnRunState.kg.ActionInputs(ctx, isSharded, i),
 	}
 	args := []string{stepID, marshalledOuptut}
 


### PR DESCRIPTION
## Description

Ensures a run's `state_size` metadata keeps up to date with both input and output by changing the `state_size` by the diff between the input and output data when saving a step response.

- Input is already included in `state_size` when creating run state
- This PR ensures we adjust `state_size` correctly when saving a response for a step for which we will no longer use the input

This ensures that the `state_size` checked when marshalling requests is accurate.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
