### PR TITLE
a little better loading and error handling on rerun from step

### DIFF
--- a/ui/apps/dashboard/src/queries/useRerunFromStep.tsx
+++ b/ui/apps/dashboard/src/queries/useRerunFromStep.tsx
@@ -1,3 +1,5 @@
+import type { RerunResult } from '@inngest/components/Rerun/RerunModal';
+
 type RerunFromStep = {
   runID: string;
   fromStep: { stepID: string; input: string };
@@ -15,8 +17,9 @@ export function useRerunFromStep(
   }: {
     runID: string;
     fromStep: { stepID: string; input: string };
-  }): Promise<void> => {
+  }): Promise<RerunResult> => {
     console.log('not yet implemented in the dashboard');
+    return { data: { rerun: {} } };
   };
 
   return rerunFromStep;

--- a/ui/packages/components/src/Rerun/RerunModal.tsx
+++ b/ui/packages/components/src/Rerun/RerunModal.tsx
@@ -15,7 +15,7 @@ export type RerunModalType = {
   rerunFromStep: (args: {
     runID: string;
     fromStep: { stepID: string; input: string };
-  }) => Promise<unknown>;
+  }) => Promise<RerunResult>;
 };
 
 type RerunResult = {
@@ -114,10 +114,10 @@ export const RerunModal = ({
             setRerunning(true);
             setError(null);
 
-            const result = (await rerunFromStep({
+            const result = await rerunFromStep({
               runID,
               fromStep: { stepID, input: patchInput(newInput) },
-            })) as RerunResult;
+            });
 
             if (result?.error) {
               console.error('rerun from step error', result.error);

--- a/ui/packages/components/src/Rerun/RerunModal.tsx
+++ b/ui/packages/components/src/Rerun/RerunModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { RiCloseLine } from '@remixicon/react';
 
@@ -48,13 +48,16 @@ export const RerunModal = ({
   const [newInput, setNewInput] = useState(input);
   const router = useRouter();
   const [rerunning, setRerunning] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setError(null);
+    }
+  }, [open]);
 
   return (
-    <Modal
-      className="flex max-w-[1200px] flex-col p-6"
-      isOpen={open}
-      onClose={() => setOpen(false)}
-    >
+    <Modal className="flex max-w-[1200px] flex-col p-6" isOpen={open} onClose={close}>
       <div className="mb-6 flex flex-row items-center justify-between gap-6">
         <div className="flex flex-col gap-2">
           <span className="text-basis text-xl">Rerun from step </span>
@@ -96,7 +99,8 @@ export const RerunModal = ({
           />
         </div>
       </div>
-      <div className="mt-6 flex flex-row justify-end gap-2">
+      <div className="mt-6 flex flex-row items-center justify-end gap-2">
+        <div>{error && <span className="text-error">{error}</span>}</div>
         <NewButton
           kind="secondary"
           appearance="ghost"
@@ -108,17 +112,17 @@ export const RerunModal = ({
           loading={rerunning}
           onClick={async () => {
             setRerunning(true);
+            setError(null);
 
             const result = (await rerunFromStep({
               runID,
               fromStep: { stepID, input: patchInput(newInput) },
             })) as RerunResult;
 
-            setRerunning(false);
-
             if (result?.error) {
               console.error('rerun from step error', result.error);
-              throw new Error('Rerun failed, please try again later.');
+              setError('Rerun failed, please try again later.');
+              setRerunning(false);
             }
 
             if (result?.data?.rerun) {

--- a/ui/packages/components/src/Rerun/RerunModal.tsx
+++ b/ui/packages/components/src/Rerun/RerunModal.tsx
@@ -18,7 +18,7 @@ export type RerunModalType = {
   }) => Promise<RerunResult>;
 };
 
-type RerunResult = {
+export type RerunResult = {
   data?: {
     rerun: Record<string, unknown>;
   };
@@ -119,13 +119,13 @@ export const RerunModal = ({
               fromStep: { stepID, input: patchInput(newInput) },
             });
 
-            if (result?.error) {
+            if (result.error) {
               console.error('rerun from step error', result.error);
               setError('Rerun failed, please try again later.');
               setRerunning(false);
             }
 
-            if (result?.data?.rerun) {
+            if (result.data?.rerun) {
               router.push(`/run?runID=${result.data.rerun}`);
             }
           }}

--- a/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV2/RunInfo.tsx
@@ -31,10 +31,7 @@ type Props = {
     runPopout: (params: { runID: string }) => Route;
   };
   rerun: (args: { fnID: string; runID: string }) => Promise<unknown>;
-  rerunFromStep: (args: {
-    runID: string;
-    fromStep: { stepID: string; input: string };
-  }) => Promise<unknown>;
+  rerunFromStep: React.ComponentProps<typeof RunResult>['rerunFromStep'];
   initialRunData?: InitialRunData;
   run: Lazy<Run>;
   runID: string;

--- a/ui/packages/components/src/RunResult.tsx
+++ b/ui/packages/components/src/RunResult.tsx
@@ -12,10 +12,7 @@ type Props = {
   className?: string;
   result: Result;
   runID: string;
-  rerunFromStep: (args: {
-    runID: string;
-    fromStep: { stepID: string; input: string };
-  }) => Promise<unknown>;
+  rerunFromStep: React.ComponentProps<typeof RerunModal>['rerunFromStep'];
   stepID?: string;
   isSuccess?: boolean;
   stepAIEnabled?: boolean;

--- a/ui/packages/components/src/TimelineV2/Trace.tsx
+++ b/ui/packages/components/src/TimelineV2/Trace.tsx
@@ -23,10 +23,7 @@ type Props = {
   trace: Trace;
   runID: string;
   stepAIEnabled?: boolean;
-  rerunFromStep: (args: {
-    runID: string;
-    fromStep: { stepID: string; input: string };
-  }) => Promise<unknown>;
+  rerunFromStep: React.ComponentProps<typeof TraceInfo>['rerunFromStep'];
 };
 
 export function Trace({

--- a/ui/packages/components/src/TimelineV2/TraceInfo.tsx
+++ b/ui/packages/components/src/TimelineV2/TraceInfo.tsx
@@ -26,10 +26,7 @@ type Props = {
   runID: string;
   result?: Result;
   aiOutput?: ExperimentalAI;
-  rerunFromStep: (args: {
-    runID: string;
-    fromStep: { stepID: string; input: string };
-  }) => Promise<unknown>;
+  rerunFromStep: React.ComponentProps<typeof RunResult>['rerunFromStep'];
 };
 
 export function TraceInfo({


### PR DESCRIPTION
## Description

Previously the loading indicator stopped before redirected page loaded, which can take a couple seconds.  Also, the thrown error killed modal.

## Motivation
Better loading and error.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
