### PR TITLE
Update API ignoring `StepPlanned` opcodes

### DIFF
--- a/pkg/consts/otel.go
+++ b/pkg/consts/otel.go
@@ -60,6 +60,7 @@ const (
 	OtelSysStepAIRequest       = "sys.step.ai.req" // ai request metadata
 	OtelSysStepAIResponse      = "sys.step.ai.res" // ai response metadata
 	OtelSysStepRunType         = "sys.step.run.type"
+	OtelSysStepPlan            = "sys.step.plan" // indicate this is a planning step
 
 	OtelSysStepSleepEndAt = "sys.step.sleep.end"
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2055,9 +2055,14 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, i *runInstanc
 		// We do, though, want to store the incomin step ID name _without_ overriding
 		// the actual DAG step, though.
 		// Run the same action.
-		IncomingGeneratorStep: gen.ID,
-		Outgoing:              edge.Edge.Outgoing,
-		Incoming:              edge.Edge.Incoming,
+		IncomingGeneratorStep:     gen.ID,
+		IncomingGeneratorStepName: gen.Name,
+		Outgoing:                  edge.Edge.Outgoing,
+		Incoming:                  edge.Edge.Incoming,
+	}
+	// prefer DisplayName if available
+	if gen.DisplayName != nil {
+		nextEdge.IncomingGeneratorStepName = *gen.DisplayName
 	}
 
 	// Update the group ID in context;  we're scheduling a step, and we want

--- a/pkg/inngest/graph.go
+++ b/pkg/inngest/graph.go
@@ -18,6 +18,9 @@ type Edge struct {
 	//
 	// We cannot use "Incoming" here as the incoming name still needs to tbe the generator.
 	IncomingGeneratorStep string `json:"gen,omitempty"`
+	// IncomingGeneratorStepName is the name from step planned. it should be empty for
+	// other cases
+	IncomingGeneratorStepName string `json:"gen_name,omitempty"`
 	// Outgoing is the name of the generator step or step that last ran.
 	Outgoing string `json:"outgoing"`
 }

--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -74,9 +74,9 @@ func NewRunTree(opts RunTreeOpts) (*runTree, error) {
 
 	for _, s := range opts.Spans {
 		// don't even bother
-		if s.StepOpCode() == enums.OpcodeStepPlanned {
-			continue
-		}
+		// if s.StepOpCode() == enums.OpcodeStepPlanned {
+		// 	continue
+		// }
 
 		if s.ScopeName == consts.OtelScopeFunction {
 			b.root = s
@@ -100,9 +100,9 @@ func NewRunTree(opts RunTreeOpts) (*runTree, error) {
 	// loop through again to construct parent/child relationship
 	for _, s := range opts.Spans {
 		// don't even bother
-		if s.StepOpCode() == enums.OpcodeStepPlanned {
-			continue
-		}
+		// if s.StepOpCode() == enums.OpcodeStepPlanned {
+		// 	continue
+		// }
 
 		if s.ParentSpanID != nil {
 			if parent, ok := b.spans[*s.ParentSpanID]; ok {
@@ -277,8 +277,8 @@ func (tb *runTree) toRunSpan(ctx context.Context, s *cqrs.Span) (*rpbv2.RunSpan,
 
 				return nil, false, fmt.Errorf("error grouping invoke: %w", err)
 			}
-		case enums.OpcodeStepPlanned: // don't bother
-			return nil, true, nil
+		// case enums.OpcodeStepPlanned: // don't bother
+		// 	return nil, true, nil
 		default:
 			// execution spans
 			if s.ScopeName == consts.OtelScopeExecution {

--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -199,7 +199,7 @@ func (tb *runTree) ToRunSpan(ctx context.Context) (*rpbv2.RunSpan, error) {
 	return root, nil
 }
 
-func (tb *runTree) toRunSpan(ctx context.Context, s *cqrs.Span) (*rpbv2.RunSpan, bool, error) {
+func (tb *runTree) toRunSpan(ctx context.Context, s *cqrs.Span) (span *rpbv2.RunSpan, skipped bool, err error) {
 	res, skipped := tb.constructSpan(ctx, s)
 	if skipped {
 		return nil, skipped, nil
@@ -281,8 +281,6 @@ func (tb *runTree) toRunSpan(ctx context.Context, s *cqrs.Span) (*rpbv2.RunSpan,
 
 				return nil, false, fmt.Errorf("error grouping invoke: %w", err)
 			}
-		// case enums.OpcodeStepPlanned: // don't bother
-		// 	return nil, true, nil
 		default:
 			// execution spans
 			if s.ScopeName == consts.OtelScopeExecution {

--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -73,10 +73,12 @@ func NewRunTree(opts RunTreeOpts) (*runTree, error) {
 	}
 
 	for _, s := range opts.Spans {
-		// don't even bother
-		// if s.StepOpCode() == enums.OpcodeStepPlanned {
-		// 	continue
-		// }
+		// ignore parallelism planning spans
+		if s.StepOpCode() == enums.OpcodeStepPlanned {
+			if _, ok := s.SpanAttributes[consts.OtelSysStepPlan]; ok {
+				continue
+			}
+		}
 
 		if s.ScopeName == consts.OtelScopeFunction {
 			b.root = s
@@ -99,10 +101,12 @@ func NewRunTree(opts RunTreeOpts) (*runTree, error) {
 
 	// loop through again to construct parent/child relationship
 	for _, s := range opts.Spans {
-		// don't even bother
-		// if s.StepOpCode() == enums.OpcodeStepPlanned {
-		// 	continue
-		// }
+		// ignore parallelism planning spans
+		if s.StepOpCode() == enums.OpcodeStepPlanned {
+			if _, ok := s.SpanAttributes[consts.OtelSysStepPlan]; ok {
+				continue
+			}
+		}
 
 		if s.ParentSpanID != nil {
 			if parent, ok := b.spans[*s.ParentSpanID]; ok {

--- a/pkg/run/trace_lifecycle.go
+++ b/pkg/run/trace_lifecycle.go
@@ -850,8 +850,12 @@ func (l traceLifecycle) OnStepFinished(
 			span.SetStepOutput(output)
 		} else {
 			// if it's not a step or function response that represents either a failed or a successful execution.
-			// Do not record discovery spans and cancel it.
-			_ = span.Cancel(ctx)
+
+			// annotate it as a planning step currently only used for parallelism, so we know
+			// we can ignore it when displaying on UI
+			span.SetAttributes(
+				attribute.Bool(consts.OtelSysStepPlan, true),
+			)
 		}
 	}
 }

--- a/pkg/run/trace_lifecycle.go
+++ b/pkg/run/trace_lifecycle.go
@@ -544,9 +544,17 @@ func (l traceLifecycle) OnStepStarted(
 	}
 	runID := md.ID.RunID
 
+	name := consts.OtelExecPlaceholder
+	// Check if this is a step planned from parallelism
+	if edge, _ := queue.GetEdge(item); edge != nil {
+		if edge.Edge.IncomingGeneratorStepName != "" {
+			name = edge.Edge.IncomingGeneratorStepName
+		}
+	}
+
 	_, span := NewSpan(ctx,
 		WithScope(consts.OtelScopeExecution),
-		WithName(consts.OtelExecPlaceholder),
+		WithName(name),
 		WithTimestamp(start),
 		WithSpanID(*spanID),
 		WithSpanAttributes(

--- a/tests/golang/parallel_test.go
+++ b/tests/golang/parallel_test.go
@@ -2,15 +2,19 @@ package golang
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/tests/client"
 	"github.com/inngest/inngestgo"
 	"github.com/inngest/inngestgo/experimental/group"
 	"github.com/inngest/inngestgo/step"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -19,11 +23,13 @@ type parallelTestEvt inngestgo.GenericEvent[any, any]
 func TestParallelSteps(t *testing.T) {
 	ctx := context.Background()
 
+	c := client.New(t)
 	h, server, registerFuncs := NewSDKHandler(t, "parallel")
 	defer server.Close()
 
 	var (
 		counter int32
+		runID   string
 	)
 
 	a := inngestgo.CreateFunction(
@@ -32,6 +38,10 @@ func TestParallelSteps(t *testing.T) {
 		}},
 		inngestgo.EventTrigger("test/parallel", nil),
 		func(ctx context.Context, input inngestgo.Input[parallelTestEvt]) (any, error) {
+			if runID == "" {
+				runID = input.InputCtx.RunID
+			}
+
 			res := group.Parallel(ctx,
 				func(ctx context.Context) (any, error) {
 					return step.Run(ctx, "p1", func(ctx context.Context) (any, error) {
@@ -79,10 +89,33 @@ func TestParallelSteps(t *testing.T) {
 	t.Run("verify in-progress", func(t *testing.T) {
 		<-time.After(2 * time.Second)
 		require.Equal(t, int32(2), atomic.LoadInt32(&counter))
+
+		_ = c.WaitForRunTraces(ctx, t, &runID, client.WaitForRunTracesOptions{
+			Status:         models.FunctionStatusRunning,
+			ChildSpanCount: 2,
+			Timeout:        2 * time.Second,
+			Interval:       200 * time.Millisecond,
+		})
 	})
 
 	t.Run("verify completion", func(t *testing.T) {
 		<-time.After(10 * time.Second)
 		require.Equal(t, int32(4), atomic.LoadInt32(&counter))
+
+		run := c.WaitForRunTraces(ctx, t, &runID, client.WaitForRunTracesOptions{
+			Status:         models.FunctionStatusCompleted,
+			ChildSpanCount: 4,
+			Timeout:        5 * time.Second,
+			Interval:       250 * time.Millisecond,
+		})
+
+		// check on spans
+		for _, cspan := range run.Trace.ChildSpans {
+			t.Run(fmt.Sprintf("child: %s", cspan.Name), func(t *testing.T) {
+				assert.Equal(t, 0, cspan.Attempts)
+				assert.Equal(t, models.StepOpRun.String(), cspan.StepOp)
+				assert.Equal(t, models.RunTraceSpanStatusCompleted.String(), cspan.Status)
+			})
+		}
 	})
 }

--- a/tests/golang/parallel_test.go
+++ b/tests/golang/parallel_test.go
@@ -1,0 +1,88 @@
+package golang
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngestgo"
+	"github.com/inngest/inngestgo/experimental/group"
+	"github.com/inngest/inngestgo/step"
+	"github.com/stretchr/testify/require"
+)
+
+type parallelTestEvt inngestgo.GenericEvent[any, any]
+
+func TestParallelSteps(t *testing.T) {
+	ctx := context.Background()
+
+	h, server, registerFuncs := NewSDKHandler(t, "parallel")
+	defer server.Close()
+
+	var (
+		counter int32
+	)
+
+	a := inngestgo.CreateFunction(
+		inngestgo.FunctionOpts{Name: "concurrent", Concurrency: []inngest.Concurrency{
+			{Limit: 2, Scope: enums.ConcurrencyScopeFn},
+		}},
+		inngestgo.EventTrigger("test/parallel", nil),
+		func(ctx context.Context, input inngestgo.Input[parallelTestEvt]) (any, error) {
+			res := group.Parallel(ctx,
+				func(ctx context.Context) (any, error) {
+					return step.Run(ctx, "p1", func(ctx context.Context) (any, error) {
+						atomic.AddInt32(&counter, 1)
+						<-time.After(5 * time.Second)
+						return "p1", nil
+					})
+				},
+				func(ctx context.Context) (any, error) {
+					return step.Run(ctx, "p2", func(ctx context.Context) (any, error) {
+						atomic.AddInt32(&counter, 1)
+						<-time.After(5 * time.Second)
+						return "p2", nil
+					})
+				},
+				func(ctx context.Context) (any, error) {
+					return step.Run(ctx, "p3", func(ctx context.Context) (any, error) {
+						atomic.AddInt32(&counter, 1)
+						<-time.After(5 * time.Second)
+						return "p3", nil
+					})
+				},
+				func(ctx context.Context) (any, error) {
+					return step.Run(ctx, "p4", func(ctx context.Context) (any, error) {
+						atomic.AddInt32(&counter, 1)
+						<-time.After(5 * time.Second)
+						return "p4", nil
+					})
+				},
+			)
+
+			return res, nil
+		},
+	)
+
+	h.Register(a)
+	registerFuncs()
+
+	_, err := inngestgo.Send(ctx, inngestgo.Event{
+		Name: "test/parallel",
+		Data: map[string]any{"hello": "world"},
+	})
+	require.NoError(t, err)
+
+	t.Run("verify in-progress", func(t *testing.T) {
+		<-time.After(2 * time.Second)
+		require.Equal(t, int32(2), atomic.LoadInt32(&counter))
+	})
+
+	t.Run("verify completion", func(t *testing.T) {
+		<-time.After(10 * time.Second)
+		require.Equal(t, int32(4), atomic.LoadInt32(&counter))
+	})
+}

--- a/vendor/github.com/inngest/inngestgo/experimental/group/group.go
+++ b/vendor/github.com/inngest/inngestgo/experimental/group/group.go
@@ -1,0 +1,54 @@
+package group
+
+import (
+	"context"
+
+	"github.com/inngest/inngestgo/step"
+)
+
+type Result struct {
+	Error error
+	Value any
+}
+
+func Parallel(
+	ctx context.Context,
+	fns ...func(ctx context.Context,
+	) (any, error)) []Result {
+	ctx = context.WithValue(ctx, step.ParallelKey, true)
+
+	results := []Result{}
+	isPlanned := false
+	ch := make(chan struct{}, 1)
+	var unexpectedPanic any
+	for _, fn := range fns {
+		fn := fn
+		go func(fn func(ctx context.Context) (any, error)) {
+			defer func() {
+				if r := recover(); r != nil {
+					if _, ok := r.(step.ControlHijack); ok {
+						isPlanned = true
+					} else {
+						unexpectedPanic = r
+					}
+				}
+				ch <- struct{}{}
+			}()
+
+			value, err := fn(ctx)
+			results = append(results, Result{Error: err, Value: value})
+		}(fn)
+		<-ch
+	}
+
+	if unexpectedPanic != nil {
+		// Repanic to let our normal panic recovery handle it
+		panic(unexpectedPanic)
+	}
+
+	if isPlanned {
+		panic(step.ControlHijack{})
+	}
+
+	return results
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -520,6 +520,7 @@ github.com/inngest/expr
 ## explicit; go 1.23.2
 github.com/inngest/inngestgo
 github.com/inngest/inngestgo/errors
+github.com/inngest/inngestgo/experimental/group
 github.com/inngest/inngestgo/internal/sdkrequest
 github.com/inngest/inngestgo/internal/types
 github.com/inngest/inngestgo/step


### PR DESCRIPTION
## Description

In progress runs are stored as `StepPlanned` opcode data, and the API currently ignores them, so you can't see anything that are in progress.

Removing these cases will show the in progress executions again, but we need to make sure `StepPlanned` spans are still ignored for visualization.

This will annotate pure discovery spans to make it clear they're only used for planning, so they can be ignored when data is retrieved for the UI.

Also update the name of the span with the generator name from plans.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
