### PR TITLE
Up SDK response max from 4MB to shared 8MB for I/O

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,8 +1,9 @@
 package consts
 
 import (
-	"github.com/google/uuid"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -28,8 +29,14 @@ const (
 	// our system.
 	MaxFunctionTimeout = 2 * time.Hour
 
+	// MaxStepOutputSize is the maximum size of the output of a step.
+	MaxStepOutputSize = 1024 * 1024 * 4 // 4MB
+
+	// MaxStepInputSize is the maximum size of the input of a step.
+	MaxStepInputSize = 1024 * 1024 * 4 // 4MB
+
 	// MaxBodySize is the maximum payload size read on any HTTP response.
-	MaxBodySize = 1024 * 1024 * 4 // 4MB
+	MaxBodySize = MaxStepOutputSize + MaxStepInputSize
 
 	// DefaultMaxStateSizeLimit is the maximum number of bytes of output state per function run allowed.
 	DefaultMaxStateSizeLimit = 1024 * 1024 * 32 // 32MB

--- a/pkg/execution/state/opcode.go
+++ b/pkg/execution/state/opcode.go
@@ -5,11 +5,17 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/dateutil"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/util/aigateway"
 	"github.com/xhit/go-str2duration/v2"
+)
+
+var (
+	ErrStepInputTooLarge  = fmt.Errorf("step input size is greater than the limit")
+	ErrStepOutputTooLarge = fmt.Errorf("step output size is greater than the limit")
 )
 
 type GeneratorOpcode struct {
@@ -34,6 +40,18 @@ type GeneratorOpcode struct {
 	Error *UserError `json:"error"`
 	// SDK versions < 3.?.? don't respond with the display name.
 	DisplayName *string `json:"displayName"`
+}
+
+func (g GeneratorOpcode) Validate() error {
+	if input, _ := g.Input(); input != "" && len(input) > consts.MaxStepInputSize {
+		return ErrStepOutputTooLarge
+	}
+
+	if output, _ := g.Output(); output != "" && len(output) > consts.MaxStepOutputSize {
+		return ErrStepOutputTooLarge
+	}
+
+	return nil
 }
 
 // Get the name of the step as defined in code by the user.


### PR DESCRIPTION
## Description

Ups the maximum body size for SDK requests from 4MB to 8MB.

Also adds checks for both the reported input and output for a function, ensuring neither field can exceed 4MB.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
