### PR TITLE
INN-4135: generate a trace output id when processing ai gateway steps, the ui requires it

### DIFF
--- a/pkg/run/trace.go
+++ b/pkg/run/trace.go
@@ -1349,6 +1349,21 @@ func (tb *runTree) processAIGatewayGroup(ctx context.Context, span *cqrs.Span, m
 func (tb *runTree) processAIGateway(ctx context.Context, span *cqrs.Span, mod *rpbv2.RunSpan) error {
 	defer tb.markProcessed(span)
 
+	ident := &cqrs.SpanIdentifier{
+		AccountID:   tb.acctID,
+		WorkspaceID: tb.wsID,
+		AppID:       tb.appID,
+		FunctionID:  tb.fnID,
+		TraceID:     span.TraceID,
+		SpanID:      span.SpanID,
+	}
+	outputID, err := ident.Encode()
+	if err != nil {
+		return err
+	}
+
+	mod.OutputId = &outputID
+
 	stepOp := rpbv2.SpanStepOp_AI_GATEWAY
 	mod.StepOp = &stepOp
 


### PR DESCRIPTION

## Description

Our recent changes (https://github.com/inngest/inngest/pull/1998) to handle ai gateway step op codes broke ai features in the ui. The ui requires a trace step output id for those features to work. This generates the output trace id.

## Motivation
Fix regression

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
