### PR TITLE
Usage charts tweaks

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/billing/usage/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/billing/usage/page.tsx
@@ -76,8 +76,10 @@ export default function Billing({
           defaultValue={currentPage}
           size="small"
           onValueChange={setCurrentPage}
+          disabled
         >
-          <ToggleGroup.Item value="run">Run</ToggleGroup.Item>
+          {/* Disable until we have the chart data for both months */}
+          {/* <ToggleGroup.Item value="run">Run</ToggleGroup.Item> */}
           <ToggleGroup.Item value="step">Step</ToggleGroup.Item>
         </ToggleGroup>
         <Select

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/billing/usage/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/billing/usage/page.tsx
@@ -1,19 +1,16 @@
 'use client';
 
 import { useState } from 'react';
-import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { Select, type Option } from '@inngest/components/Select/Select';
 import ToggleGroup from '@inngest/components/ToggleGroup/ToggleGroup';
 import { useQuery } from 'urql';
 
+import BillableUsageChart from '@/components/Billing/Usage/BillableUsageChart';
 import UsageMetadata from '@/components/Billing/Usage/Metadata';
+import useGetBillableSteps from '@/components/Billing/Usage/useGetBillableSteps';
 import { graphql } from '@/gql';
 import { pathCreator } from '@/utils/urls';
-
-const BillableUsageChart = dynamic(() => import('@/components/Billing/Usage/BillableUsageChart'), {
-  ssr: false,
-});
 
 const GetBillingInfoDocument = graphql(`
   query GetBillingInfo {
@@ -57,10 +54,20 @@ export default function Billing({
   const [currentPage, setCurrentPage] = useState('step');
   const [selectedPeriod, setSelectedPeriod] = useState<Period>(previous ? options[1] : options[0]);
 
+  // Get timeseries to temporarily grab the total usage for previous month, since we don't have history usage on entitlements
+  const { data: billableData, fetching: fetchingBillableData } = useGetBillableSteps({
+    selectedPeriod: selectedPeriod.id,
+  });
+
   const stepCount = data?.account.entitlements.stepCount || { usage: 0, limit: 0 };
   const runCount = data?.account.entitlements.runCount || { usage: 0, limit: 0 };
   const isStepPage = currentPage === 'step';
-  const currentUsage = isStepPage ? stepCount.usage : runCount.usage;
+  const currentUsage = (() => {
+    if (selectedPeriod.id === 'previous' && billableData.length) {
+      return billableData.reduce((sum, point) => sum + (point.value || 0), 0);
+    }
+    return isStepPage ? stepCount.usage : runCount.usage;
+  })();
   const currentLimit = isStepPage ? stepCount.limit ?? Infinity : runCount.limit ?? Infinity;
   const additionalUsage = Math.max(0, currentUsage - currentLimit);
 
@@ -121,7 +128,7 @@ export default function Billing({
         />
         <UsageMetadata
           className="justify-self-end"
-          fetching={fetching}
+          fetching={fetching || fetchingBillableData}
           title={`Total ${currentPage}s`}
           value={new Intl.NumberFormat().format(currentUsage)}
         />

--- a/ui/apps/dashboard/src/components/Billing/Usage/transformData.ts
+++ b/ui/apps/dashboard/src/components/Billing/Usage/transformData.ts
@@ -103,7 +103,7 @@ export function createChartOptions(
       icon: 'circle',
       itemWidth: 10,
       itemHeight: 10,
-      textStyle: { fontSize: '12px', color: resolveColor(textColor.subtle, dark) },
+      textStyle: { fontSize: '12px', color: resolveColor(textColor.subtle, dark, '#4B4B4B') },
       data: [datasetNames.includedCount, datasetNames.additionalCount],
     },
     xAxis: {
@@ -112,15 +112,15 @@ export function createChartOptions(
       axisTick: {
         alignWithLabel: true,
         length: 2,
-        lineStyle: { color: resolveColor(borderColor.contrast, dark) },
+        lineStyle: { color: resolveColor(borderColor.contrast, dark, '#242424') },
       },
       axisLine: {
-        lineStyle: { color: resolveColor(borderColor.contrast, dark) },
+        lineStyle: { color: resolveColor(borderColor.contrast, dark, '#242424') },
       },
       axisLabel: {
         fontSize: 11,
         fontWeight: 500,
-        color: resolveColor(textColor.subtle, dark),
+        color: resolveColor(textColor.subtle, dark, '#4B4B4B'),
         margin: 10,
         interval: 1, // Show day 1, 3, 5...
         formatter: function (value: string) {
@@ -132,7 +132,7 @@ export function createChartOptions(
       axisLabel: {
         fontSize: 10,
         fontWeight: 400,
-        color: resolveColor(textColor.subtle, dark),
+        color: resolveColor(textColor.subtle, dark, '#4B4B4B'),
         verticalAlign: 'bottom',
         formatter: function (value: number) {
           if (value >= 1000) {
@@ -143,7 +143,7 @@ export function createChartOptions(
         },
       },
       splitLine: {
-        lineStyle: { color: resolveColor(borderColor.subtle, dark) },
+        lineStyle: { color: resolveColor(borderColor.subtle, dark, '#E2E2E2') },
       },
     },
     grid: {

--- a/ui/apps/dashboard/src/components/Billing/Usage/transformData.ts
+++ b/ui/apps/dashboard/src/components/Billing/Usage/transformData.ts
@@ -160,8 +160,8 @@ export function createChartOptions(
         type: 'bar',
         stack: 'x',
         itemStyle: { color: resolveColor(colors.secondary.moderate, dark, '#2389F1') },
-        barWidth: '100%',
-        barGap: '-100%',
+        barWidth: '98%',
+        barGap: '-98%',
       },
       {
         name: datasetNames.additionalCount,
@@ -169,8 +169,8 @@ export function createChartOptions(
         type: 'bar',
         stack: 'y',
         itemStyle: { color: resolveColor(colors.accent.subtle, dark, '#EC9923') },
-        barWidth: '100%',
-        barGap: '-100%',
+        barWidth: '98%',
+        barGap: '-98%',
       },
     ],
   };

--- a/ui/apps/dashboard/src/components/Billing/Usage/useGetBillableSteps.ts
+++ b/ui/apps/dashboard/src/components/Billing/Usage/useGetBillableSteps.ts
@@ -1,0 +1,45 @@
+import { useQuery } from 'urql';
+
+import { graphql } from '@/gql';
+
+const GetBillableSteps = graphql(`
+  query GetBillableSteps($month: Int!, $year: Int!) {
+    billableStepTimeSeries(timeOptions: { month: $month, year: $year }) {
+      data {
+        time
+        value
+      }
+    }
+  }
+`);
+
+export default function useGetBillableSteps({
+  selectedPeriod,
+}: {
+  selectedPeriod: 'current' | 'previous';
+}) {
+  const currentMonthIndex = new Date().getUTCMonth();
+  const options = {
+    previous: {
+      month: currentMonthIndex === 0 ? 12 : currentMonthIndex,
+      year: currentMonthIndex === 0 ? new Date().getUTCFullYear() - 1 : new Date().getUTCFullYear(),
+    },
+    current: {
+      month: currentMonthIndex + 1,
+      year: new Date().getUTCFullYear(),
+    },
+  };
+
+  const [{ data, fetching }] = useQuery({
+    query: GetBillableSteps,
+    variables: {
+      month: options[selectedPeriod].month,
+      year: options[selectedPeriod].year,
+    },
+  });
+
+  return {
+    data: data?.billableStepTimeSeries[0]?.data || [],
+    fetching,
+  };
+}

--- a/ui/packages/components/src/utils/theme.ts
+++ b/ui/packages/components/src/utils/theme.ts
@@ -2,13 +2,20 @@
 // This will futureproof us a bit if we switch to manual or system color scheme.
 // If an element ref is provided we look for a dark class in any parents.
 // This is useful for components that might have dark theme sections inside a general light theme
-export const colorScheme = (elementRef?: HTMLElement): 'light' | 'dark' =>
+export const colorScheme = (elementRef?: HTMLElement): 'light' | 'dark' => {
+  if (typeof document === 'undefined') {
+    // Default to 'light' if document is not available
+    return 'light';
+  }
   //
   // TODO: turn on when our design properly support toggling
   // localStorage.theme === 'dark' ||
   // window.matchMedia('(prefers-color-scheme: dark)').matches ||
-  (elementRef ? elementRef.closest('.dark') : document.documentElement.classList.contains('dark'))
+  return (
+    elementRef ? elementRef.closest('.dark') : document.documentElement.classList.contains('dark')
+  )
     ? 'dark'
     : 'light';
+};
 
 export const isDark = (elementRef?: HTMLElement) => colorScheme(elementRef) === 'dark';


### PR DESCRIPTION
## Description
- Temporarily disable the runs usage stats in the charts page (until we add the runs usage chart early next week)
- Add temporary trick to get step usage total for previous month, by summing up the usage timeseries (we currently don't have historic data in entitlements).
- Add trick to overcome a echarts border issue, 1px outer border of the column chart cannot be removed

<img width="1441" alt="Screenshot 2024-12-06 at 23 05 52" src="https://github.com/user-attachments/assets/69667c51-41e0-48e7-a07e-e2656a712e70">


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
