### PR TITLE
Fix max SDK request body size

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -35,8 +35,13 @@ const (
 	// MaxStepInputSize is the maximum size of the input of a step.
 	MaxStepInputSize = 1024 * 1024 * 4 // 4MB
 
-	// MaxBodySize is the maximum payload size read on any HTTP response.
-	MaxBodySize = MaxStepOutputSize + MaxStepInputSize
+	// MaxSDKResponseBodySize is the maximum payload size in the response from
+	// the SDK.
+	MaxSDKResponseBodySize = MaxStepOutputSize + MaxStepInputSize
+
+	// MaxSDKRequestBodySize is the maximum payload size in the request to the
+	// SDK.
+	MaxSDKRequestBodySize = 1024 * 1024 * 4 // 4MB
 
 	// DefaultMaxStateSizeLimit is the maximum number of bytes of output state per function run allowed.
 	DefaultMaxStateSizeLimit = 1024 * 1024 * 32 // 32MB

--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -81,7 +81,7 @@ func MarshalV1(
 	}
 
 	// Ensure that we're not sending data that's too large to the SDK.
-	if md.Metrics.StateSize <= (consts.MaxBodySize - 1024) {
+	if md.Metrics.StateSize <= (consts.MaxSDKRequestBodySize - 1024) {
 		// Load the actual function state here.
 		steps, err := sl.LoadSteps(ctx, md.ID)
 		if err != nil {
@@ -146,7 +146,7 @@ func MarshalV1(
 	// And here, to double check, ensure that the length isn't excessive once again.
 	// This is because, as Jack points out, for backcompat we send both events and the
 	// first event.  We also may have incorrect state sizes for runs before this is tracked.
-	if len(j) > consts.MaxBodySize {
+	if len(j) > consts.MaxSDKRequestBodySize {
 		req.Events = []map[string]any{}
 		req.Actions = map[string]any{}
 		req.UseAPI = true

--- a/pkg/execution/driver/httpdriver/httpdriver_test.go
+++ b/pkg/execution/driver/httpdriver/httpdriver_test.go
@@ -189,7 +189,7 @@ func TestParseStream(t *testing.T) {
 
 func TestStreamResponseTooLarge(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		data := make([]byte, consts.MaxBodySize)
+		data := make([]byte, consts.MaxSDKResponseBodySize)
 		_, err := rand.Read(data)
 		require.NoError(t, err)
 

--- a/pkg/execution/driver/httpdriver/util.go
+++ b/pkg/execution/driver/httpdriver/util.go
@@ -52,7 +52,7 @@ func ExecuteRequest(ctx context.Context, c HTTPDoer, req *http.Request) (*http.R
 
 	// Read 1 extra byte above the max so that we can check if the response is
 	// too large
-	byt, err := io.ReadAll(io.LimitReader(resp.Body, consts.MaxBodySize+1))
+	byt, err := io.ReadAll(io.LimitReader(resp.Body, consts.MaxSDKResponseBodySize+1))
 	if err != nil {
 		return resp, nil, dur, fmt.Errorf("error reading response body: %w", err)
 	}
@@ -83,7 +83,7 @@ func ExecuteRequest(ctx context.Context, c HTTPDoer, req *http.Request) (*http.R
 		}
 	}
 
-	if len(byt) > consts.MaxBodySize {
+	if len(byt) > consts.MaxSDKResponseBodySize {
 		return resp, byt, dur, ErrBodyTooLarge
 	}
 

--- a/pkg/telemetry/trace/tracer.go
+++ b/pkg/telemetry/trace/tracer.go
@@ -105,7 +105,7 @@ func (o TracerOpts) MaxPayloadSizeBytes() int {
 		return size
 	}
 
-	return (consts.AbsoluteMaxEventSize + consts.MaxBodySize) * 2
+	return (consts.AbsoluteMaxEventSize + consts.MaxSDKResponseBodySize) * 2
 }
 
 func NewUserTracer(ctx context.Context, opts TracerOpts) error {

--- a/tests/golang/fn_output_test.go
+++ b/tests/golang/fn_output_test.go
@@ -33,7 +33,7 @@ func TestFnOutputTooLarge(t *testing.T) {
 		inngestgo.EventTrigger(evtName, nil),
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
 			runID = input.InputCtx.RunID
-			return strings.Repeat("A", consts.MaxBodySize+1), nil
+			return strings.Repeat("A", consts.MaxSDKResponseBodySize+1), nil
 		},
 	)
 


### PR DESCRIPTION
Fix an accidental increase of the max SDK request body size.

This happened because we were sharing the same constant for requests _and_ responses. This was OK until we increased the max SDK response size because of the new step input feature for AI.