### PR TITLE
fix: Update url for useFeatureFlags hook to support non default port

### DIFF
--- a/ui/apps/dev-server-ui/src/hooks/useFeatureFlags.ts
+++ b/ui/apps/dev-server-ui/src/hooks/useFeatureFlags.ts
@@ -12,7 +12,7 @@ export function useFeatureFlags() {
   useEffect(() => {
     async function fetchFeatureFlags() {
       try {
-        const response = await fetch('/dev');
+        const response = await fetch(createDevServerURL('/dev'));
         if (!response.ok) {
           throw new Error('Failed to fetch feature flags');
         }
@@ -29,4 +29,16 @@ export function useFeatureFlags() {
   }, []);
 
   return { featureFlags, loading, error };
+}
+
+/**
+ * Creates a Dev Server URL from a path. If Dev Server host is unknown, it
+ * returns the path.
+ */
+function createDevServerURL(path: string) {
+  const host = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (!host) {
+    return path;
+  }
+  return new URL(path, host).toString();
 }

--- a/ui/apps/dev-server-ui/src/hooks/useFeatureFlags.ts
+++ b/ui/apps/dev-server-ui/src/hooks/useFeatureFlags.ts
@@ -12,7 +12,7 @@ export function useFeatureFlags() {
   useEffect(() => {
     async function fetchFeatureFlags() {
       try {
-        const response = await fetch('http://localhost:8288/dev');
+        const response = await fetch('/dev');
         if (!response.ok) {
           throw new Error('Failed to fetch feature flags');
         }


### PR DESCRIPTION
## Description

This pull request includes a small change to the `useFeatureFlags` function in the `useFeatureFlags.ts` file. The change modifies the URL used to fetch feature flags to use a relative path instead of an absolute URL.

* [`ui/apps/dev-server-ui/src/hooks/useFeatureFlags.ts`](diffhunk://#diff-c3a1048870870be173548b2354dc338f6cdf0092e7752da5485d519b00f2338cL15-R15): Changed the fetch URL from 'http://localhost:8288/dev' to '/dev' to use a relative path.

This follows the pattern of in the devApi of using a relative path https://github.com/inngest/inngest/blob/07e770d510baa55e4a7a20849193a0fb606af7b7/ui/apps/dev-server-ui/src/store/devApi.ts#L31

## Motivation
When running the dev server on a non default port, the feature flag request fails, meaning that users can not use function run search even with the flag set. Additionally this also fixes it for user who are self hosting. 

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
