### PR TITLE
Fix `RunJobs` not selecting the correct queue shard

### DIFF
--- a/pkg/api/apiv1/apiv1.go
+++ b/pkg/api/apiv1/apiv1.go
@@ -13,6 +13,7 @@ import (
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state/redis_state"
 	"github.com/inngest/inngest/pkg/headers"
 )
 
@@ -37,6 +38,8 @@ type Opts struct {
 	JobQueueReader queue.JobQueueReader
 	// CancellationReadWriter reads and writes cancellations to/from a backing store.
 	CancellationReadWriter cqrs.CancellationReadWriter
+	// QueueShardSelector determines the queue shard to use
+	QueueShardSelector redis_state.ShardSelector
 }
 
 // AddRoutes adds a new API handler to the given router.

--- a/pkg/api/apiv1/runs.go
+++ b/pkg/api/apiv1/runs.go
@@ -110,8 +110,15 @@ func (a router) GetFunctionRunJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	shard, err := a.opts.QueueShardSelector(ctx, auth.AccountID(), nil)
+	if err != nil {
+		_ = publicerr.WriteHTTP(w, publicerr.Wrapf(err, 500, "Internal server error"))
+		return
+	}
+
 	jobs, err := a.opts.JobQueueReader.RunJobs(
 		ctx,
+		shard.Name,
 		auth.WorkspaceID(),
 		fr.FunctionID,
 		runID,

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1054,6 +1054,7 @@ func (e *executor) finalize(ctx context.Context, md sv2.Metadata, evts []json.Ra
 		// Find all items for the current function run.
 		jobs, err := q.RunJobs(
 			ctx,
+			queueShard.Name,
 			md.ID.Tenant.EnvID,
 			md.ID.FunctionID,
 			md.ID.RunID,

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -201,6 +201,7 @@ type JobQueueReader interface {
 	// RunJobs reads items in the queue for a specific run.
 	RunJobs(
 		ctx context.Context,
+		queueShardName string,
 		workspaceID uuid.UUID,
 		workflowID uuid.UUID,
 		runID ulid.ULID,


### PR DESCRIPTION
## Description

`RunJobs` was hardcoded to use the primary queue shard, which defaults to the default shard for services that didn't configure the primary queue shard environment variable. This means we never returned items from the proper queue shards for `finalize`/`Cancel` invocations.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
