### PR TITLE
Updated loading shimmer

### DIFF
--- a/ui/apps/dashboard/src/components/Events/EventList.tsx
+++ b/ui/apps/dashboard/src/components/Events/EventList.tsx
@@ -9,7 +9,6 @@ import { cn } from '@inngest/components/utils/classNames';
 
 import MiniStackedBarChart from '@/components/Charts/MiniStackedBarChart';
 import { useEnvironment } from '@/components/Environments/environment-context';
-import LoadingIcon from '@/icons/LoadingIcon';
 import { useEventTypes, useEventTypesVolume } from '@/queries';
 import { pathCreator } from '@/utils/urls';
 import EventListNotFound from './EventListNotFound';

--- a/ui/apps/dashboard/src/components/Events/EventList.tsx
+++ b/ui/apps/dashboard/src/components/Events/EventList.tsx
@@ -81,15 +81,7 @@ function EventTypesListPaginationPage({
   const isFirstPage = page === 1;
 
   if (isFetchingEvents) {
-    return (
-      <tr>
-        <td colSpan={3} className="h-56">
-          <div className="relative flex items-center justify-center">
-            <LoadingIcon />
-          </div>
-        </td>
-      </tr>
-    );
+    return <LoadingTableRows count={6} />;
   }
 
   if (isFirstPage && events.length === 0) {
@@ -179,7 +171,25 @@ function EventTypesListPaginationPage({
 function Shimmer({ className }: { className?: string }) {
   return (
     <div className={`flex ${className}`}>
-      <Skeleton className="block h-5 w-full" />
+      <Skeleton className="block h-3 w-full" />
     </div>
   );
+}
+
+function LoadingTableRows({ count = 6 }: { count?: number }) {
+  return new Array(count).fill(0).map((_, idx) => (
+    <tr key={idx} className="h-[46.5px]">
+      <td className="w-96">
+        <Shimmer className="max-w-52 px-4" />
+      </td>
+      <td className="space-x-2 px-2">
+        <Shimmer className="max-w-36 px-2" />
+      </td>
+      <td className="w-60 py-1 pl-2 pr-6">
+        <div className="flex w-56 items-center justify-end gap-2">
+          <Shimmer className="w-[212px] px-2.5" />
+        </div>
+      </td>
+    </tr>
+  ));
 }

--- a/ui/packages/components/src/RunsPage/RunsTable.tsx
+++ b/ui/packages/components/src/RunsPage/RunsTable.tsx
@@ -68,7 +68,7 @@ export default function RunsTable({
       isLoading
         ? columns.map((column) => ({
             ...column,
-            cell: () => <Skeleton className="my-4 block h-4" />,
+            cell: () => <Skeleton className="my-4 block h-3" />,
           }))
         : columns,
     [isLoading]

--- a/ui/packages/components/src/Skeleton/Skeleton.tsx
+++ b/ui/packages/components/src/Skeleton/Skeleton.tsx
@@ -4,7 +4,8 @@ export function Skeleton({ className }: { className?: string }) {
   return (
     <span
       className={cn(
-        'before:via-canvasMuted/70 relative block overflow-hidden rounded-md before:absolute before:inset-0 before:-translate-x-full before:animate-[shimmer_2s_infinite] before:bg-gradient-to-r before:from-transparent before:to-transparent',
+        'bg-canvasMuted/20 relative block overflow-hidden rounded-sm',
+        'before:via-canvasMuted/30 before:absolute before:inset-0 before:-translate-x-full before:animate-[shimmer_2s_infinite] before:bg-gradient-to-r before:from-transparent before:to-transparent',
         className
       )}
     />


### PR DESCRIPTION
## Description

Adds a subtle background to ensure that the shimmer retains shape to look like an actual loading placeholder instead of a animated loading bar. 

![Screen Cast 2025-01-02 at 2 41 51 PM](https://github.com/user-attachments/assets/753b2ee4-02ae-4e57-aa33-f08d579865bf)


## Motivation
It's jarring to see tens of loading bars - the shimmer is more subtle. 

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
