### PR TITLE
Support dev server auto-discovery for Astro projects

### DIFF
--- a/pkg/devserver/discovery/discovery.go
+++ b/pkg/devserver/discovery/discovery.go
@@ -21,6 +21,8 @@ var (
 		80, 443,
 		// Rails, Express & N*xt routes
 		3000, 3001, 3002, 3003, 3004, 3005, 3006, 3007, 3008, 3009, 3010,
+		// Astro
+		4321,
 		// Django
 		5000,
 		// Vite/SvelteKit


### PR DESCRIPTION
## Description

This PR adds the default Astro dev server port number (`4321`) to the list of ports scanned in the Inngest dev server autodiscovery process.

## Motivation

Currently using Inngest during development in an Astro project requires manually configuring the port number. This PR simplifies set-up for users by allowing them to benefit from autodiscovery.

I also considered adding additional port numbers as Astro will auto-increment the port number (`4322`, `4323` etc.) when the default port is already in use to mirror the `3000`, `3001` etc. but given Astro’s port numbers are not as common as the 3000s, I wasn’t sure if that might be over eager.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
