### PR TITLE
Fix step stack leak

### DIFF
--- a/pkg/cqrs/sqlitecqrs/cqrs.go
+++ b/pkg/cqrs/sqlitecqrs/cqrs.go
@@ -1120,6 +1120,40 @@ func (w wrapper) GetSpanOutput(ctx context.Context, opts cqrs.SpanIdentifier) (*
 	return nil, fmt.Errorf("no output found")
 }
 
+func (w wrapper) GetSpanStack(ctx context.Context, opts cqrs.SpanIdentifier) ([]string, error) {
+	if opts.TraceID == "" {
+		return nil, fmt.Errorf("traceID is required to retrieve stack")
+	}
+	if opts.SpanID == "" {
+		return nil, fmt.Errorf("spanID is required to retrieve stack")
+	}
+
+	// query spans in descending order
+	spans, err := w.q.GetTraceSpanOutput(ctx, sqlc.GetTraceSpanOutputParams{
+		TraceID: opts.TraceID,
+		SpanID:  opts.SpanID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving spans for stack: %w", err)
+	}
+
+	for _, s := range spans {
+		var evts []cqrs.SpanEvent
+		err := json.Unmarshal(s.Events, &evts)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing span outputs: %w", err)
+		}
+
+		for _, evt := range evts {
+			if stack, ok := evt.Attributes[consts.OtelSysStepStack]; ok {
+				return strings.Split(stack, ","), nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no stack found")
+}
+
 type runsQueryBuilder struct {
 	filter       []sq.Expression
 	order        []sqexp.OrderedExpression

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -224,6 +224,8 @@ type TraceReader interface {
 	GetTraceSpansByRun(ctx context.Context, id TraceRunIdentifier) ([]*Span, error)
 	// GetSpanOutput retrieves the output for the specified span
 	GetSpanOutput(ctx context.Context, id SpanIdentifier) (*SpanOutput, error)
+	// GetSpanStack retrieves the step stack for the specified span
+	GetSpanStack(ctx context.Context, id SpanIdentifier) ([]string, error)
 }
 
 type GetTraceRunOpt struct {

--- a/pkg/execution/executor/reconstruct.go
+++ b/pkg/execution/executor/reconstruct.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/cqrs"
@@ -49,9 +48,14 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 			}
 		}
 		if span.SpanName == consts.OtelExecFnOk || span.SpanName == consts.OtelExecFnErr {
-			if spanStack, ok := span.SpanAttributes[consts.OtelSysStepStack]; ok {
-				stack = strings.Split(spanStack, ",")
-			}
+			stack, _ = tr.GetSpanStack(ctx, cqrs.SpanIdentifier{
+				AccountID:   req.AccountID,
+				WorkspaceID: req.WorkspaceID,
+				AppID:       req.AppID,
+				FunctionID:  req.Function.ID,
+				TraceID:     origTraceRun.TraceID,
+				SpanID:      span.SpanID,
+			})
 		}
 	}
 

--- a/pkg/run/span.go
+++ b/pkg/run/span.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"strings"
 	"sync"
 	"time"
 
@@ -536,6 +537,10 @@ func (s *Span) TracerProvider() trace.TracerProvider {
 
 func (s *Span) SetFnOutput(data any) {
 	s.setAttrData(data, consts.OtelSysFunctionOutput)
+}
+
+func (s *Span) SetStepStack(stack []string) {
+	s.setAttrData(strings.Join(stack, ","), consts.OtelSysStepStack)
 }
 
 func (s *Span) SetStepInput(data any) {

--- a/pkg/run/trace_lifecycle.go
+++ b/pkg/run/trace_lifecycle.go
@@ -641,7 +641,6 @@ func (l traceLifecycle) OnStepGatewayRequestFinished(
 			attribute.Int(consts.OtelSysStepMaxAttempt, item.GetMaxAttempts()),
 			attribute.String(consts.OtelSysStepGroupID, item.GroupID),
 			attribute.String(consts.OtelSysStepOpcode, enums.OpcodeStepPlanned.String()),
-			attribute.String(consts.OtelSysStepStack, strings.Join(md.Stack, ",")),
 		),
 	)
 	// Common attrs.
@@ -742,7 +741,6 @@ func (l traceLifecycle) OnStepFinished(
 			attribute.Int(consts.OtelSysStepMaxAttempt, item.GetMaxAttempts()),
 			attribute.String(consts.OtelSysStepGroupID, item.GroupID),
 			attribute.String(consts.OtelSysStepOpcode, enums.OpcodeStepPlanned.String()),
-			attribute.String(consts.OtelSysStepStack, strings.Join(md.Stack, ",")),
 			attribute.Bool(consts.OtelSysFunctionHasAI, md.Config.HasAI),
 		),
 	)
@@ -863,6 +861,7 @@ func (l traceLifecycle) OnStepFinished(
 				output = resp.Output
 			}
 			span.SetStepOutput(output)
+			span.SetStepStack(md.Stack)
 		} else {
 			// if it's not a step or function response that represents either a failed or a successful execution.
 


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

Following #1959, a run's stack is saved to each span, allowing reconstruction of a run's state after its completion. The stack, however, can balloon trace sizes considerably as it was being saved as an attribute instead of an event, the latter of which is omitted from high-level queries.

This PR:
- Saves the stack as an event, omitting it from high-level queries
- Ensures we only save the stack where we need it, on function-level spans

This requires upstreaming and some additional protobuf/NATS changes in Cloud.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- Caused by #1959

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
