### PR TITLE
Fix tooltip

### DIFF
--- a/ui/apps/dashboard/src/components/Functions/ActionMenu.tsx
+++ b/ui/apps/dashboard/src/components/Functions/ActionMenu.tsx
@@ -54,39 +54,38 @@ export const ActionsMenu = ({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem onSelect={showInvoke} disabled={archived || paused}>
-          <OptionalTooltip
-            tooltip={
-              (archived || paused) &&
-              `Invoke not available, function is ${archived ? 'archived' : 'paused'}.`
-            }
-          >
+        <OptionalTooltip
+          tooltip={
+            (archived || paused) &&
+            `Invoke not available, function is ${archived ? 'archived' : 'paused'}.`
+          }
+        >
+          <DropdownMenuItem onSelect={showInvoke} disabled={archived || paused}>
             <RiFlashlightFill className="h-4 w-4" />
             Invoke
-          </OptionalTooltip>
-        </DropdownMenuItem>
-
-        <DropdownMenuItem onSelect={showPause} disabled={archived}>
-          <OptionalTooltip tooltip={archived && 'Pause not available, function is archived.'}>
+          </DropdownMenuItem>
+        </OptionalTooltip>
+        <OptionalTooltip tooltip={archived && 'Pause not available, function is archived.'}>
+          <DropdownMenuItem onSelect={showPause} disabled={archived}>
             {paused ? (
               <RiPlayCircleLine className="h-4 w-4" />
             ) : (
               <RiPauseCircleLine className="h-4 w-4" />
             )}
             {paused ? 'Resume' : 'Pause'}
-          </OptionalTooltip>
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={showReplay} disabled={archived || paused}>
-          <OptionalTooltip
-            tooltip={
-              (archived || paused) &&
-              `Replay not available, function is ${archived ? 'archived' : 'paused'}.`
-            }
-          >
+          </DropdownMenuItem>
+        </OptionalTooltip>
+        <OptionalTooltip
+          tooltip={
+            (archived || paused) &&
+            `Replay not available, function is ${archived ? 'archived' : 'paused'}.`
+          }
+        >
+          <DropdownMenuItem onSelect={showReplay} disabled={archived || paused}>
             <IconReplay className="h-4 w-4" />
             Replay
-          </OptionalTooltip>
-        </DropdownMenuItem>
+          </DropdownMenuItem>
+        </OptionalTooltip>
         {cancelEnabled && (
           <DropdownMenuItem onSelect={showCancel} className="text-error">
             <RiCloseCircleLine className="h-4 w-4" />


### PR DESCRIPTION
## Description

There was an error with function actions tooltips:
- React.Children.only expected to receive a single React element child.

When menu dropdown items were disabled (eg. function paused), tooltips would crash the app

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
