### PR TITLE
Fix query for `GetTraceRun()` needing more IDs

### DIFF
--- a/pkg/execution/executor/reconstruct.go
+++ b/pkg/execution/executor/reconstruct.go
@@ -17,7 +17,11 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 	// Load the original run state and copy the state from the original
 	// run to the new run.
 	origTraceRun, err := tr.GetTraceRun(ctx, cqrs.TraceRunIdentifier{
-		RunID: *req.OriginalRunID,
+		RunID:       *req.OriginalRunID,
+		WorkspaceID: req.WorkspaceID,
+		AppID:       req.AppID,
+		FunctionID:  req.Function.ID,
+		AccountID:   req.AccountID,
 	})
 	if err != nil {
 		return fmt.Errorf("error loading original trace run: %w", err)


### PR DESCRIPTION
## Description

Fixes the `GetTraceRun()` query within state reconstruction needing more IDs.

Pulled out of #2038 so that PR can be UI-only.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- Pulled out of #2038

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
