### PR TITLE
Improve queued bar color in dark mode

### DIFF
--- a/ui/packages/components/src/TimelineV2/Span.tsx
+++ b/ui/packages/components/src/TimelineV2/Span.tsx
@@ -45,7 +45,10 @@ export function Span({ className, isInline, maxTime, minTime, trace }: Props) {
 
       {/* Queued part of the span */}
       {widths.queued > 0 && (
-        <div className="bg-surfaceSubtle h-2" style={{ flexGrow: widths.queued }}></div>
+        <div
+          className="bg-surfaceSubtle dark:bg-surfaceMuted h-2"
+          style={{ flexGrow: widths.queued }}
+        ></div>
       )}
 
       {/* Running part of the span */}


### PR DESCRIPTION
## Description

After:
<img width="315" alt="Screen Shot 2025-01-10 at 10 36 23 AM" src="https://github.com/user-attachments/assets/3d059e3f-cd34-4b05-bea2-8cf4ad1be19a" />


Before: 
<img width="239" alt="Screen Shot 2025-01-10 at 10 36 29 AM" src="https://github.com/user-attachments/assets/0a75749e-a96d-4650-9401-0f6b54574143" />


## Motivation
The bar in dark mode looked bad, like there was an issue rendering the UI.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
