### PR TITLE
some defense on echart tooltip toggling

### DIFF
--- a/ui/packages/components/src/Chart/Chart.tsx
+++ b/ui/packages/components/src/Chart/Chart.tsx
@@ -44,8 +44,15 @@ export const Chart = ({
 
   const toggleTooltips = (show: boolean) => {
     if (chartRef.current !== null) {
-      const chart = getInstanceByDom(chartRef.current);
-      chart?.setOption({ tooltip: { show }, xAxis: { axisPointer: { label: { show } } } });
+      try {
+        const chart = getInstanceByDom(chartRef.current);
+        chart?.setOption({ tooltip: { show }, xAxis: { axisPointer: { label: { show } } } });
+      } catch (e) {
+        //
+        // fast successive toggling occasionally throws errors,
+        // catch theme so we don't pollute sentry
+        console.info('there was a problem toggling tooltip', e);
+      }
     }
   };
 


### PR DESCRIPTION
## Description
Occasionally with fast successive mouse enter/leave events, echarts will throw errors internally enabling/disabling tooltips on charts. 

Background: this manual toggling is a pretty brute force workaround because we don't like the way tooltips work by default with echarts when cursors are synched across many charts (tooltips show on all of them).

## Motivation
Don't pollute sentry with this error as it's unobtrusive to the user.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
