### PR TITLE
Fix history for v2 SDK parallel steps

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -986,7 +986,9 @@ func (e *executor) HandleResponse(ctx context.Context, i *runInstance) error {
 		return i.resp
 	}
 
-	if i.resp.IsFunctionResult() {
+	// The generator length check is necessary because parallel steps in older
+	// SDK versions (e.g. 2.7.2) can result in an OpcodeNone.
+	if len(i.resp.Generator) == 0 && i.resp.IsFunctionResult() {
 		// This is the function result.
 		if err := e.finalize(ctx, i.md, i.events, i.f.GetSlug(), e.assignedQueueShard, *i.resp); err != nil {
 			l.Error("error running finish handler", "error", err)


### PR DESCRIPTION
## Description
Fix history incorrectly showing the run as failed for v2 SDK parallel steps.

## Testing
The following function with `v2.7.2` of the TS SDK:
```ts
inngest.createFunction(
  {
    id: "fn-1",
    name: "fn-1",
    retries: 1,
  },
  { event: "event-1" },
  async ({ step }) => {
    await Promise.all([
      step.run("b.1", async () => {}),
      step.run("b.2", async () => {}),
    ]);
  }
);
```

Results in the following history before this PR's change:
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/60ae1233-ce2f-4707-9e3c-bc45a37f94ac" />

And the following history after this PR's change:
<img width="1091" alt="image" src="https://github.com/user-attachments/assets/3e299f51-fc08-4d75-96ad-8600ca505730" />
