### PR TITLE
fix a variety of vercel integration update state bugs

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/configure/[id]/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/configure/[id]/page.tsx
@@ -143,8 +143,6 @@ export default function VercelConfigure() {
   // project is enabled. This is mostly because not all extra inputs are saved
   // when enabling a project (e.g. the protection bypass secret)
   const areExtraSettingsVisible = project?.isEnabled;
-  console.log('project', project?.isEnabled);
-  console.log('areExtraSettingsVisible', areExtraSettingsVisible);
 
   if (fetching) {
     return (

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/configure/[id]/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/configure/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import NextLink from 'next/link';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
 import { Alert } from '@inngest/components/Alert/Alert';
 import { Button } from '@inngest/components/Button/index';
 import { Input } from '@inngest/components/Forms/Input';

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/page.tsx
@@ -8,6 +8,9 @@ import { RiArrowRightSLine, RiExternalLinkLine } from '@remixicon/react';
 import { vercelIntegration } from '../data';
 import VercelProjects from './projects';
 
+export const dynamic = 'force-dynamic';
+export const fetchCache = 'force-no-store';
+
 export default async function VercelIntegrationPage() {
   const integrations = await vercelIntegration();
 

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/useVercelIntegration.ts
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/useVercelIntegration.ts
@@ -41,12 +41,13 @@ export function useVercelIntegration(): {
     isLoading: isLoadingAllProjects,
     error,
   } = useRestAPIRequest<VercelProjectAPIResponse>({ url, method: 'GET', pause: !url });
+
   const [{ data: savedVercelProjects, fetching: isLoadingSavedProjects }] = useQuery({
     query: GetSavedVercelProjectsDocument,
     variables: {
       environmentID: defaultEnv?.id || '',
     },
-    pause: !defaultEnv?.id,
+    requestPolicy: 'network-only',
   });
 
   const projects = mergeVercelProjectData({


### PR DESCRIPTION
## Description

Sentry indicates that we regularly get errors on vercel project updates. These errors are either "id already exists" on enable and "record not found" disable. This happens because the upstream gql actually adds and removes a vercel project record for these ops. 

Because we track enable/disable and update states manually in this component (and separately) it's very easy to get into the error states by issuing successive updates by leaving and re-entering the component. 

This fixes those issues by consolidating our update state to a single source of truth and tracking it in one place.

## Motivation
Remove frequent errors from vercel integration project updates.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
