### PR TITLE
Add worker pool implementation

### DIFF
--- a/pkg/util/worker_pool/pool.go
+++ b/pkg/util/worker_pool/pool.go
@@ -73,7 +73,7 @@ func (wp *WorkerPool[Input, Output]) runScheduler() {
 			continue
 		}
 
-		batchResultsChan := make(chan Result[Output], 0)
+		batchResultsChan := make(chan Result[Output])
 
 		// Create results slice for this batch
 		batchResults := make([]Result[Output], batchSize)

--- a/pkg/util/worker_pool/pool.go
+++ b/pkg/util/worker_pool/pool.go
@@ -1,0 +1,115 @@
+package worker_pool
+
+import (
+	"sync"
+)
+
+type Job[Data any] struct {
+	ID           int
+	Data         Data
+	batchResults chan Result[Data]
+}
+
+type Result[Data any] struct {
+	JobID int
+	Data  Data
+	Err   error
+}
+
+type BatchRequest[Data any] struct {
+	Jobs    []Job[Data]
+	Results chan []Result[Data]
+}
+
+type WorkerPool[Data any] struct {
+	numWorkers int
+	jobs       chan Job[Data]
+	scheduler  chan BatchRequest[Data]
+	quit       chan struct{}
+	wg         sync.WaitGroup
+	process    func(job Job[Data], workerID int) Result[Data]
+}
+
+func NewWorkerPool[Data any](numWorkers int, process func(job Job[Data], workerID int) Result[Data]) *WorkerPool[Data] {
+	return &WorkerPool[Data]{
+		numWorkers: numWorkers,
+		process:    process,
+		jobs:       make(chan Job[Data]),
+		scheduler:  make(chan BatchRequest[Data]),
+		quit:       make(chan struct{}),
+	}
+}
+
+func (wp *WorkerPool[Data]) Start() {
+	// Launch fixed number of worker goroutines
+	for i := 0; i < wp.numWorkers; i++ {
+		wp.wg.Add(1)
+		go func(workerID int) {
+			defer wp.wg.Done()
+			for {
+				select {
+				case job, ok := <-wp.jobs:
+					if !ok {
+						return
+					}
+					result := wp.process(job, workerID)
+					job.batchResults <- result
+				case <-wp.quit:
+					return
+				}
+			}
+		}(i)
+	}
+
+	// Launch scheduler goroutine
+	go wp.runScheduler()
+}
+
+func (wp *WorkerPool[Data]) runScheduler() {
+	for batch := range wp.scheduler {
+		batchSize := len(batch.Jobs)
+		if batchSize == 0 {
+			batch.Results <- []Result[Data]{}
+			continue
+		}
+
+		batchResultsChan := make(chan Result[Data], 0)
+
+		// Create results slice for this batch
+		batchResults := make([]Result[Data], batchSize)
+
+		// Launch a single collector goroutine for this batch
+		go func(results chan []Result[Data]) {
+			// Collect all results for this batch
+			for i := 0; i < batchSize; i++ {
+				result := <-batchResultsChan
+				batchResults[i] = result
+			}
+			close(batchResultsChan)
+			// Send completed batch results
+			results <- batchResults
+		}(batch.Results)
+
+		// Submit all jobs in this batch
+		for _, job := range batch.Jobs {
+			job.batchResults = batchResultsChan
+			wp.jobs <- job
+		}
+	}
+}
+
+func (wp *WorkerPool[Data]) SubmitBatch(jobs []Job[Data]) []Result[Data] {
+	resultsChan := make(chan []Result[Data], 1)
+	wp.scheduler <- BatchRequest[Data]{
+		Jobs:    jobs,
+		Results: resultsChan,
+	}
+	return <-resultsChan
+}
+
+func (wp *WorkerPool[Data]) Stop() {
+	close(wp.scheduler)
+	close(wp.quit)
+	wp.wg.Wait()
+	close(wp.jobs)
+}

--- a/pkg/util/worker_pool/pool_test.go
+++ b/pkg/util/worker_pool/pool_test.go
@@ -1,0 +1,82 @@
+package worker_pool
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"sync"
+	"testing"
+	"time"
+)
+
+type poolData interface{}
+
+var TEST_completed = map[int]int{}
+var TEST_lock = sync.Mutex{}
+
+func processJob(job Job[poolData], workerID int) Result[poolData] {
+	fmt.Printf("processing job %d on worker %d\n", job.ID, workerID)
+	<-time.After(time.Second * 2)
+
+	TEST_lock.Lock()
+	TEST_completed[job.ID] += 1
+	TEST_lock.Unlock()
+
+	// Simulate some work being done
+	// Replace this with actual job processing logic
+	return Result[poolData]{
+		JobID: job.ID,
+		Data:  fmt.Sprintf("Processed job %d by worker %d", job.ID, workerID),
+		Err:   nil,
+	}
+}
+
+func TestPool(t *testing.T) {
+	// Create a worker pool with 50,000 workers
+	p := NewWorkerPool[poolData](50_000, processJob)
+	p.Start()
+
+	// Create two batches of jobs
+	batch1 := make([]Job[poolData], 5_000)
+	for i := range batch1 {
+		batch1[i] = Job[poolData]{
+			ID:   i,
+			Data: fmt.Sprintf("Batch 1, Job %d", i),
+		}
+	}
+
+	batch2 := make([]Job[poolData], 80_000)
+	for i := range batch2 {
+		batch2[i] = Job[poolData]{
+			ID:   i + len(batch1), // Different ID range
+			Data: fmt.Sprintf("Batch 2, Job %d", i),
+		}
+	}
+
+	// Submit batches concurrently
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		results := p.SubmitBatch(batch1)
+		fmt.Printf("Batch 1 results: %d jobs completed\n", len(results))
+	}()
+
+	go func() {
+		defer wg.Done()
+		results := p.SubmitBatch(batch2)
+		fmt.Printf("Batch 2 results: %d jobs completed\n", len(results))
+	}()
+
+	wg.Wait()
+	p.Stop()
+
+	// Verify this works
+	for i := range batch1 {
+		require.Equal(t, 1, TEST_completed[i], "did not process job %d", i)
+	}
+
+	for i := range batch2 {
+		require.Equal(t, 1, TEST_completed[i+len(batch1)], "did not process job %d", i+len(batch1))
+	}
+}

--- a/pkg/util/worker_pool/pool_test.go
+++ b/pkg/util/worker_pool/pool_test.go
@@ -8,29 +8,29 @@ import (
 	"time"
 )
 
-type poolData interface{}
-
-var TEST_completed = map[int]int{}
-var TEST_lock = sync.Mutex{}
-
-func processJob(job Job[poolData], workerID int) Result[poolData] {
-	fmt.Printf("processing job %d on worker %d\n", job.ID, workerID)
-	<-time.After(time.Second * 2)
-
-	TEST_lock.Lock()
-	TEST_completed[job.ID] += 1
-	TEST_lock.Unlock()
-
-	// Simulate some work being done
-	// Replace this with actual job processing logic
-	return Result[poolData]{
-		JobID: job.ID,
-		Data:  fmt.Sprintf("Processed job %d by worker %d", job.ID, workerID),
-		Err:   nil,
-	}
-}
-
 func TestPool(t *testing.T) {
+	type poolData interface{}
+
+	var TEST_completed = map[int]int{}
+	var TEST_lock = sync.Mutex{}
+
+	processJob := func(job Job[poolData], workerID int) Result[poolData] {
+		fmt.Printf("processing job %d on worker %d\n", job.ID, workerID)
+		<-time.After(time.Second * 2)
+
+		TEST_lock.Lock()
+		TEST_completed[job.ID] += 1
+		TEST_lock.Unlock()
+
+		// Simulate some work being done
+		// Replace this with actual job processing logic
+		return Result[poolData]{
+			JobID: job.ID,
+			Data:  fmt.Sprintf("Processed job %d by worker %d", job.ID, workerID),
+			Err:   nil,
+		}
+	}
+
 	// Create a worker pool with 50,000 workers
 	p := NewWorkerPool[poolData](50_000, processJob)
 	p.Start()

--- a/pkg/util/worker_pool/pool_test.go
+++ b/pkg/util/worker_pool/pool_test.go
@@ -11,13 +11,14 @@ import (
 func TestPool(t *testing.T) {
 	numWorkers := 50_000
 
-	type poolData interface{}
+	type fnInput interface{}
+	type fnOutput interface{}
 
 	var TEST_completed = map[int]int{}
 	var TEST_used = map[int]int{}
 	var TEST_lock = sync.Mutex{}
 
-	processJob := func(job Job[poolData], workerID int) Result[poolData] {
+	processJob := func(job Job[fnInput, fnOutput], workerID int) Result[fnOutput] {
 		fmt.Printf("processing job %d on worker %d\n", job.ID, workerID)
 		<-time.After(time.Second * 2)
 
@@ -28,7 +29,7 @@ func TestPool(t *testing.T) {
 
 		// Simulate some work being done
 		// Replace this with actual job processing logic
-		return Result[poolData]{
+		return Result[fnOutput]{
 			JobID: job.ID,
 			Data:  fmt.Sprintf("Processed job %d by worker %d", job.ID, workerID),
 			Err:   nil,
@@ -36,21 +37,21 @@ func TestPool(t *testing.T) {
 	}
 
 	// Create a worker pool with numWorkers workers
-	p := NewWorkerPool[poolData](numWorkers, processJob)
+	p := NewWorkerPool[fnInput, fnOutput](numWorkers, processJob)
 	p.Start()
 
 	// Create two batches of jobs
-	batch1 := make([]Job[poolData], 5_000)
+	batch1 := make([]Job[fnInput, fnOutput], 5_000)
 	for i := range batch1 {
-		batch1[i] = Job[poolData]{
+		batch1[i] = Job[fnInput, fnOutput]{
 			ID:   i,
 			Data: fmt.Sprintf("Batch 1, Job %d", i),
 		}
 	}
 
-	batch2 := make([]Job[poolData], 80_000)
+	batch2 := make([]Job[fnInput, fnOutput], 80_000)
 	for i := range batch2 {
-		batch2[i] = Job[poolData]{
+		batch2[i] = Job[fnInput, fnOutput]{
 			ID:   i + len(batch1), // Different ID range
 			Data: fmt.Sprintf("Batch 2, Job %d", i),
 		}


### PR DESCRIPTION
## Description

<img width="1365" alt="image" src="https://github.com/user-attachments/assets/accab8bc-2b07-499c-81dc-ee18274ac31b" />


This PR contains the first iteration for a generic worker pool implementation that
- starts a predefined number of goroutines ahead of time
- allows to send batches of multiple jobs that will be picked up by available workers and wait for responses
- while minimizing the number of used goroutines

Specifically, we use

- Allocate and start `n` worker goroutines ahead of time
    - +1 waitgroup for waiting until all workers ended
    - +1 channel to signal exit to workers
- Allocate one scheduler goroutine
    - +1 channel for receiving scheduler messages
- For running a batch, this only allocates
    - 1 goroutine to wait for all results
    - 1 external result channel to send slice of results back to caller
    - 1 internal result channel to receive individual results from workers

## Motivation

In the past months, we've repeatedly needed to parallelize tasks across a high number of goroutines. Dynamically generating goroutines can lead to high GC costs, so starting goroutines once and reusing them across the lifetime of a service is preferred.

Instead of implementing this pattern in multiple places, we should probably reuse a trusted implementation that works. With Go's concurrency model, it's easy to miss small details which can cause huge issues that are hard to debug.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
