### PR TITLE
INN-3465: Improve auto discovery to reduce noise and excessive polling

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -31,7 +31,7 @@ func NewCmdDev() *cobra.Command {
 	cmd.Flags().String("host", "", "host to run the API on")
 	cmd.Flags().StringP("port", "p", "8288", "port to run the API on")
 	cmd.Flags().StringSliceP("sdk-url", "u", []string{}, "SDK URLs to load functions from")
-	cmd.Flags().Bool("no-discovery", false, "Disable autodiscovery")
+	cmd.Flags().Bool("no-discovery", false, "Disable app auto-discovery")
 	cmd.Flags().Bool("no-poll", false, "Disable polling of apps for updates")
 	cmd.Flags().Int("poll-interval", devserver.DefaultPollInterval, "Interval in seconds between polling for updates to apps")
 	cmd.Flags().Int("retry-interval", 0, "Retry interval in seconds for linear backoff when retrying functions - must be 1 or above")

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -5,8 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/inngest/inngest/pkg/connect/auth"
 	"net"
 	"net/url"
 	"os"
@@ -14,6 +12,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/connect/auth"
 
 	"github.com/inngest/inngest/pkg/cli"
 	"github.com/inngest/inngest/pkg/consts"
@@ -246,16 +247,22 @@ func (d *devserver) startPersistenceRoutine(ctx context.Context) {
 // runDiscovery attempts to run autodiscovery while the dev server is running.
 //
 // This lets the dev server start and wait for the SDK server to come up at
-
 // any point.
 func (d *devserver) runDiscovery(ctx context.Context) {
 	logger.From(ctx).Info().Msg("autodiscovering locally hosted SDKs")
 	pollInterval := time.Duration(d.Opts.PollInterval) * time.Second
-	for {
+	for d.Opts.Autodiscover {
 		if ctx.Err() != nil {
 			return
 		}
-		_ = discovery.Autodiscover(ctx)
+		// If we have found any app, disable auto-discovery
+		apps, err := d.Data.GetApps(ctx, consts.DevServerEnvId)
+		if err == nil && len(apps) > 0 {
+			log.From(ctx).Info().Msg("apps synced, disabling auto-discovery")
+			d.Opts.Autodiscover = false
+		} else {
+			_ = discovery.Autodiscover(ctx)
+		}
 
 		<-time.After(pollInterval)
 	}

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/apps/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/apps/page.tsx
@@ -13,7 +13,7 @@ import { RiExternalLinkLine, RiInformationLine } from '@remixicon/react';
 import AddAppButton from '@/components/App/AddAppButton';
 import AppActions from '@/components/App/AppActions';
 import getAppCardContent from '@/components/App/AppCardContent';
-// import AppFAQ from '@/components/App/AppFAQ';
+import AppFAQ from '@/components/App/AppFAQ';
 import { useInfoQuery } from '@/store/devApi';
 import { useGetAppsQuery } from '@/store/generated';
 
@@ -90,13 +90,13 @@ export default function AppList() {
       <div className="mx-auto my-12 w-4/5 max-w-7xl">
         <h2 className="mb-1 text-xl">Synced Apps</h2>
         <p className="text-muted text-sm">
-          Synced Inngest apps appear below. Apps will sync automatically if auto-discovery is
-          enabled, or you can sync them manually. {''}
+          Apps can be synced manually with the CLI's <InlineCode>-u</InlineCode> flag, a config
+          file, the button below, or via auto-discovery.{' '}
           <Link
             target="_blank"
             size="small"
             className="inline"
-            href="https://www.inngest.com/docs/local-development#connecting-apps-to-the-dev-server"
+            href="https://www.inngest.com/docs/dev-server#connecting-apps-to-the-dev-server"
           >
             Learn more
           </Link>
@@ -111,7 +111,7 @@ export default function AppList() {
                 {info?.isDiscoveryEnabled ? (
                   <p className="text-btnPrimary flex items-center gap-2 text-sm leading-tight">
                     <IconSpinner className="fill-btnPrimary" />
-                    Auto-detecting apps
+                    Auto-discovering apps
                   </p>
                 ) : null}
                 <AddAppButton secondary />
@@ -121,8 +121,17 @@ export default function AppList() {
               <div className="text-light flex items-center gap-1">
                 <RiInformationLine className="h-4 w-4" />
                 <p className="text-sm">
-                  Auto-detection is enabled on common ports. You can use the{' '}
-                  <InlineCode>--no-discovery</InlineCode> flag in your CLI to disable it.
+                  Auto-discovery scans common ports and paths for apps. Use the{' '}
+                  <InlineCode>--no-discovery</InlineCode> flag in your CLI to disable it.{' '}
+                  <Link
+                    target="_blank"
+                    size="small"
+                    className="inline"
+                    href="https://www.inngest.com/docs/dev-server#auto-discovery"
+                  >
+                    Learn more
+                  </Link>
+                  .
                 </p>
               </div>
             )}
@@ -130,8 +139,7 @@ export default function AppList() {
         )}
 
         <div className="my-6 flex w-full flex-col gap-10">{memoizedAppCards}</div>
-        {/* Temporarily hide FAQS, until we work on onboarding */}
-        {/* <AppFAQ /> */}
+        <AppFAQ />
       </div>
     </div>
   );

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/apps/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/apps/page.tsx
@@ -82,12 +82,6 @@ export default function AppList() {
         }
         action={
           <div className="flex items-center gap-5">
-            {apps.length > 0 && info?.isDiscoveryEnabled ? (
-              <p className="text-btnPrimary flex items-center gap-2 text-sm leading-tight">
-                <IconSpinner className="fill-btnPrimary" />
-                Auto-detecting apps
-              </p>
-            ) : null}
             <AddAppButton />
           </div>
         }

--- a/ui/apps/dev-server-ui/src/components/App/AppFAQ.tsx
+++ b/ui/apps/dev-server-ui/src/components/App/AppFAQ.tsx
@@ -1,5 +1,6 @@
 import { AccordionList } from '@inngest/components/AccordionCard/AccordionList';
 import { InlineCode } from '@inngest/components/Code';
+import { CodeLine } from '@inngest/components/CodeLine';
 import { Link } from '@inngest/components/Link';
 
 export default function AppFAQ() {
@@ -82,6 +83,34 @@ export default function AppFAQ() {
                 <p className="mb-2">
                   You can disable auto-discovery with the <InlineCode>--no-discovery</InlineCode>{' '}
                   flag.
+                </p>
+              </AccordionList.Content>
+            </AccordionList.Item>
+            <AccordionList.Item value="skip_manual_sync">
+              <AccordionList.Trigger>How can I skip manual syncing?</AccordionList.Trigger>
+              <AccordionList.Content>
+                <p className="mb-2">
+                  You can specify the URL of your apps at startup by using the{' '}
+                  <InlineCode>-u &lt;url&gt;</InlineCode> flag. You can specify more than one app
+                  URLs by using the flag multiple times. For example:
+                </p>
+                <CodeLine
+                  code="inngest dev -u http://localhost:3000/api/inngest -u http://localhost:3333/api/inngest"
+                  className="mb-2"
+                />
+                <p className="mb-2">
+                  Alternatively, you can specify the URL of your app in an{' '}
+                  <InlineCode>inngest.json</InlineCode> configuration file that you can check into
+                  version control.{' '}
+                  <Link
+                    target="_blank"
+                    size="small"
+                    className="inline"
+                    href="https://www.inngest.com/docs/dev-server#configuration-file"
+                  >
+                    Learn more in the docs
+                  </Link>
+                  .
                 </p>
               </AccordionList.Content>
             </AccordionList.Item>

--- a/ui/apps/dev-server-ui/src/components/App/AppFAQ.tsx
+++ b/ui/apps/dev-server-ui/src/components/App/AppFAQ.tsx
@@ -1,5 +1,6 @@
 import { AccordionList } from '@inngest/components/AccordionCard/AccordionList';
 import { InlineCode } from '@inngest/components/Code';
+import { Link } from '@inngest/components/Link';
 
 export default function AppFAQ() {
   return (
@@ -17,12 +18,16 @@ export default function AppFAQ() {
               </AccordionList.Content>
             </AccordionList.Item>
             <AccordionList.Item value="syncing_app">
-              <AccordionList.Trigger>What does “syncing an app” mean?</AccordionList.Trigger>
+              <AccordionList.Trigger>What does “syncing" an app mean?</AccordionList.Trigger>
               <AccordionList.Content>
                 <p className="mb-2">
-                  Your Inngest functions are defined and execute within your application. To enable
-                  Inngest to fetch your function configuration and invoke functions, it must be able
-                  to reach your app "Syncing" tells Inngest where your app is running.
+                  As your Inngest functions are defined and execute within your application, it is
+                  necessary for Inngest to be able communicate with your application to 1) read your
+                  functions' configurations and 2) invoke functions.
+                </p>
+                <p className="mb-2">
+                  "<strong>Syncing</strong>" an app establishes a connection via HTTP at the correct
+                  URL endpoint and synchronizes configuration to Inngest.
                 </p>
                 <p className="mb-2">
                   Syncing an app works by providing Inngest with the URL of your application's{' '}
@@ -35,6 +40,48 @@ export default function AppFAQ() {
                   As your functions may change, it is necessary to sync your app whenever it
                   changes. The Inngest Dev Server does this by polling for changes every 5 seconds
                   by default.
+                </p>
+              </AccordionList.Content>
+            </AccordionList.Item>
+            <AccordionList.Item value="polling">
+              <AccordionList.Trigger>
+                Why is my app being polled every few seconds?
+              </AccordionList.Trigger>
+              <AccordionList.Content>
+                <p className="mb-2">
+                  The Dev Server polls your app's serve endpoint every few seconds to check for new
+                  functions or updates to function configurations. This enables a "hot reload" like
+                  experience for your Inngest functions.
+                </p>
+                <p className="mb-2">
+                  You can adjust the polling interval using{' '}
+                  <InlineCode>--poll-interval &lt;seconds&gt;</InlineCode> or disable it completely
+                  with the <InlineCode>--no-poll</InlineCode> flag.
+                </p>
+              </AccordionList.Content>
+            </AccordionList.Item>
+            <AccordionList.Item value="auto_discovery">
+              <AccordionList.Trigger>
+                Why are other URLs not in my app being polled?
+              </AccordionList.Trigger>
+              <AccordionList.Content>
+                <p className="mb-2">
+                  The Dev Server will automatically discover and sync apps running on common ports
+                  and paths. This includes ports like 3000, 5000, 8080, and endpoints like{' '}
+                  <InlineCode>/api/inngest</InlineCode> and <InlineCode>/x/inngest</InlineCode>.{' '}
+                  <Link
+                    target="_blank"
+                    size="small"
+                    className="inline"
+                    href="https://www.inngest.com/docs/dev-server#auto-discovery"
+                  >
+                    Learn more in the docs
+                  </Link>
+                  .
+                </p>
+                <p className="mb-2">
+                  You can disable auto-discovery with the <InlineCode>--no-discovery</InlineCode>{' '}
+                  flag.
                 </p>
               </AccordionList.Content>
             </AccordionList.Item>

--- a/ui/packages/components/src/AccordionCard/AccordionList.tsx
+++ b/ui/packages/components/src/AccordionCard/AccordionList.tsx
@@ -54,7 +54,7 @@ const AccordionTrigger = forwardRef<
         className="hover:bg-canvasSubtle group w-full"
       >
         <div className="flex items-center gap-1 px-3 py-2">
-          <RiArrowDownSLine className="transform-90 h-5 w-5 transition-transform duration-500 group-data-[state=open]:-rotate-180" />
+          <RiArrowDownSLine className="transform-90 duration-50 h-5 w-5 transition-transform group-data-[state=open]:-rotate-180" />
           {children}
         </div>
       </AccordionPrimitive.Trigger>


### PR DESCRIPTION
## Description

This change disables auto-discovery automatically after the first app has been connected. This reduces additional port and endpoint scanning for additional apps after the first one is set up. 

While this could potentially break user's workflows, this is a development change that improves workflows for a majority of users, but does not risk breaking users apps in productions, although it could in if used in test environments. 

Adds additional information on apps, syncing and CLI flag options to the UI:
![image](https://github.com/user-attachments/assets/22ada9be-88c3-453d-868c-2aa67aa00d98)


## Motivation
INN-3465
https://github.com/inngest/inngest/issues/1298

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
