### PR TITLE
Fix bad Windows paths in virtual FS

### DIFF
--- a/pkg/cqrs/base_cqrs/base_cqrs.go
+++ b/pkg/cqrs/base_cqrs/base_cqrs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -111,7 +112,7 @@ func up(db *sql.DB, opts BaseCQRSOptions) error {
 
 	// Grab the migration driver.
 	if opts.PostgresURI != "" {
-		src, err = iofs.New(FS, filepath.Join("migrations", "postgres"))
+		src, err = iofs.New(FS, path.Join("migrations", "postgres"))
 		if err != nil {
 			return err
 		}
@@ -135,7 +136,7 @@ func up(db *sql.DB, opts BaseCQRSOptions) error {
 			return err
 		}
 	} else {
-		src, err = iofs.New(FS, filepath.Join("migrations", "sqlite"))
+		src, err = iofs.New(FS, path.Join("migrations", "sqlite"))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

Fixes driver initialisation on Windows:
```
failed to init driver with path migrations\sqlite: open migrations\sqlite: file does not exist
```

When using `filepath.Join()` on Windows, the Windows path separator `\` is used instead of the unix `/`.

When interacting with Go's virtual filesystem, however, `\` is not compatible. Using `path.Join()` instead ensures we always use the unix `/` here.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
