### PR TITLE
fix rest api get runs by event id

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -841,6 +841,7 @@ func toCQRSRun(run sqlc.FunctionRun, finish sqlc.FunctionFinish) *cqrs.FunctionR
 		FunctionID:      run.FunctionID,
 		FunctionVersion: run.FunctionVersion,
 		EventID:         run.EventID,
+		WorkspaceID:     run.WorkspaceID,
 	}
 	if run.BatchID != nilULID {
 		copied.BatchID = &run.BatchID

--- a/pkg/cqrs/base_cqrs/migrations/sqlite/000007_function_runs_workspace_id.down.sql
+++ b/pkg/cqrs/base_cqrs/migrations/sqlite/000007_function_runs_workspace_id.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE function_runs DROP COLUMN workspace_id;

--- a/pkg/cqrs/base_cqrs/migrations/sqlite/000007_function_runs_workspace_id.up.sql
+++ b/pkg/cqrs/base_cqrs/migrations/sqlite/000007_function_runs_workspace_id.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE function_runs ADD COLUMN workspace_id UUID;

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/models.go
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/models.go
@@ -83,6 +83,7 @@ type FunctionRun struct {
 	BatchID         ulid.ULID
 	OriginalRunID   ulid.ULID
 	Cron            sql.NullString
+	WorkspaceID     uuid.UUID
 }
 
 type History struct {

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
@@ -90,8 +90,8 @@ UPDATE functions SET archived_at = datetime('now') WHERE id IN (sqlc.slice('ids'
 
 -- name: InsertFunctionRun :exec
 INSERT INTO function_runs
-	(run_id, run_started_at, function_id, function_version, trigger_type, event_id, batch_id, original_run_id, cron) VALUES
-	(?, ?, ?, ?, ?, ?, ?, ?, ?);
+	(run_id, run_started_at, function_id, function_version, trigger_type, event_id, batch_id, original_run_id, cron, workspace_id) VALUES
+	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: InsertFunctionFinish :exec
 INSERT INTO function_finishes

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql.go
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql.go
@@ -587,7 +587,7 @@ func (q *Queries) GetFunctionBySlug(ctx context.Context, slug string) (*Function
 }
 
 const getFunctionRun = `-- name: GetFunctionRun :one
-SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron, function_finishes.run_id, function_finishes.status, function_finishes.output, function_finishes.completed_step_count, function_finishes.created_at
+SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron, function_runs.workspace_id, function_finishes.run_id, function_finishes.status, function_finishes.output, function_finishes.completed_step_count, function_finishes.created_at
   FROM function_runs
   LEFT JOIN function_finishes ON function_finishes.run_id = function_runs.run_id
   WHERE function_runs.run_id = ?1
@@ -611,6 +611,7 @@ func (q *Queries) GetFunctionRun(ctx context.Context, runID ulid.ULID) (*GetFunc
 		&i.FunctionRun.BatchID,
 		&i.FunctionRun.OriginalRunID,
 		&i.FunctionRun.Cron,
+		&i.FunctionRun.WorkspaceID,
 		&i.FunctionFinish.RunID,
 		&i.FunctionFinish.Status,
 		&i.FunctionFinish.Output,
@@ -716,7 +717,7 @@ func (q *Queries) GetFunctionRunHistory(ctx context.Context, runID ulid.ULID) ([
 }
 
 const getFunctionRuns = `-- name: GetFunctionRuns :many
-SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron, function_finishes.run_id, function_finishes.status, function_finishes.output, function_finishes.completed_step_count, function_finishes.created_at FROM function_runs
+SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron, function_runs.workspace_id, function_finishes.run_id, function_finishes.status, function_finishes.output, function_finishes.completed_step_count, function_finishes.created_at FROM function_runs
 LEFT JOIN function_finishes ON function_finishes.run_id = function_runs.run_id
 `
 
@@ -744,6 +745,7 @@ func (q *Queries) GetFunctionRuns(ctx context.Context) ([]*GetFunctionRunsRow, e
 			&i.FunctionRun.BatchID,
 			&i.FunctionRun.OriginalRunID,
 			&i.FunctionRun.Cron,
+			&i.FunctionRun.WorkspaceID,
 			&i.FunctionFinish.RunID,
 			&i.FunctionFinish.Status,
 			&i.FunctionFinish.Output,
@@ -764,7 +766,7 @@ func (q *Queries) GetFunctionRuns(ctx context.Context) ([]*GetFunctionRunsRow, e
 }
 
 const getFunctionRunsFromEvents = `-- name: GetFunctionRunsFromEvents :many
-SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron, function_finishes.run_id, function_finishes.status, function_finishes.output, function_finishes.completed_step_count, function_finishes.created_at FROM function_runs
+SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron, function_runs.workspace_id, function_finishes.run_id, function_finishes.status, function_finishes.output, function_finishes.completed_step_count, function_finishes.created_at FROM function_runs
 LEFT JOIN function_finishes ON function_finishes.run_id = function_runs.run_id
 WHERE function_runs.event_id IN (/*SLICE:event_ids*/?)
 `
@@ -803,6 +805,7 @@ func (q *Queries) GetFunctionRunsFromEvents(ctx context.Context, eventIds []ulid
 			&i.FunctionRun.BatchID,
 			&i.FunctionRun.OriginalRunID,
 			&i.FunctionRun.Cron,
+			&i.FunctionRun.WorkspaceID,
 			&i.FunctionFinish.RunID,
 			&i.FunctionFinish.Status,
 			&i.FunctionFinish.Output,
@@ -823,7 +826,7 @@ func (q *Queries) GetFunctionRunsFromEvents(ctx context.Context, eventIds []ulid
 }
 
 const getFunctionRunsTimebound = `-- name: GetFunctionRunsTimebound :many
-SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron, function_finishes.run_id, function_finishes.status, function_finishes.output, function_finishes.completed_step_count, function_finishes.created_at FROM function_runs
+SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron, function_runs.workspace_id, function_finishes.run_id, function_finishes.status, function_finishes.output, function_finishes.completed_step_count, function_finishes.created_at FROM function_runs
 LEFT JOIN function_finishes ON function_finishes.run_id = function_runs.run_id
 WHERE function_runs.run_started_at > ? AND function_runs.run_started_at <= ?
 ORDER BY function_runs.run_started_at DESC
@@ -860,6 +863,7 @@ func (q *Queries) GetFunctionRunsTimebound(ctx context.Context, arg GetFunctionR
 			&i.FunctionRun.BatchID,
 			&i.FunctionRun.OriginalRunID,
 			&i.FunctionRun.Cron,
+			&i.FunctionRun.WorkspaceID,
 			&i.FunctionFinish.RunID,
 			&i.FunctionFinish.Status,
 			&i.FunctionFinish.Output,
@@ -1352,8 +1356,8 @@ func (q *Queries) InsertFunctionFinish(ctx context.Context, arg InsertFunctionFi
 const insertFunctionRun = `-- name: InsertFunctionRun :exec
 
 INSERT INTO function_runs
-	(run_id, run_started_at, function_id, function_version, trigger_type, event_id, batch_id, original_run_id, cron) VALUES
-	(?, ?, ?, ?, ?, ?, ?, ?, ?)
+	(run_id, run_started_at, function_id, function_version, trigger_type, event_id, batch_id, original_run_id, cron, workspace_id) VALUES
+	(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `
 
 type InsertFunctionRunParams struct {
@@ -1366,6 +1370,7 @@ type InsertFunctionRunParams struct {
 	BatchID         ulid.ULID
 	OriginalRunID   ulid.ULID
 	Cron            sql.NullString
+	WorkspaceID     uuid.UUID
 }
 
 // function runs
@@ -1380,6 +1385,7 @@ func (q *Queries) InsertFunctionRun(ctx context.Context, arg InsertFunctionRunPa
 		arg.BatchID,
 		arg.OriginalRunID,
 		arg.Cron,
+		arg.WorkspaceID,
 	)
 	return err
 }

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/schema.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/schema.sql
@@ -48,7 +48,8 @@ CREATE TABLE function_runs (
 	event_id CHAR(26) NOT NULL,
 	batch_id CHAR(26),
 	original_run_id CHAR(26),
-	cron VARCHAR
+	cron VARCHAR,
+	workspace_id UUID
 );
 
 CREATE TABLE function_finishes (

--- a/pkg/devserver/lifecycle.go
+++ b/pkg/devserver/lifecycle.go
@@ -33,6 +33,7 @@ func (l Lifecycle) OnFunctionScheduled(
 		EventID:       md.Config.EventID(),
 		Cron:          md.Config.CronSchedule(),
 		OriginalRunID: md.Config.OriginalRunID,
+		WorkspaceID:   md.ID.Tenant.EnvID,
 	})
 
 	if md.Config.BatchID != nil {

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -92,6 +92,8 @@ sql:
               import: "github.com/oklog/ulid/v2"
               package: "ulid"
               type: "ULID"
+          - column: "function_runs.workspace_id"
+            go_type: "github.com/google/uuid.UUID"
 
           - column: "traces.run_id"
             go_type:
@@ -234,6 +236,8 @@ sql:
               import: "github.com/oklog/ulid/v2"
               package: "ulid"
               type: "ULID"
+          - column: "function_runs.workspace_id"
+            go_type: "github.com/google/uuid.UUID"
 
           - column: "traces.run_id"
             go_type:


### PR DESCRIPTION
## Description

Dev server api endpoint for fetching runs by event id has been failing since `1.4.0` because the run workspace id does not match the auth workspace id. Some recent change must have started using non-zero workspace ids in the dev server. This adds the workspace id to the function_runs table and persists and fetches it so so we make the event/runs endpoint work again.

## Motivation
Fix regression.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
