### PR TITLE
Enable user to configure the number of queue workers

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -35,6 +35,7 @@ func NewCmdDev() *cobra.Command {
 	cmd.Flags().Bool("no-poll", false, "Disable polling of apps for updates")
 	cmd.Flags().Int("poll-interval", devserver.DefaultPollInterval, "Interval in seconds between polling for updates to apps")
 	cmd.Flags().Int("retry-interval", 0, "Retry interval in seconds for linear backoff when retrying functions - must be 1 or above")
+	cmd.Flags().Int("queue-workers", devserver.DefaultQueueWorkers, "Number of workers to execute steps in the queue")
 	cmd.Flags().Int("tick", 150, "The interval (in milliseconds) at which the executor checks for new work, during local development")
 
 	return cmd
@@ -86,6 +87,7 @@ func doDev(cmd *cobra.Command, args []string) {
 	noPoll := viper.GetBool("no-poll")
 	pollInterval := viper.GetInt("poll-interval")
 	retryInterval := viper.GetInt("retry-interval")
+	queueWorkers := viper.GetInt("queue-workers")
 	tick := viper.GetInt("tick")
 
 	if err := itrace.NewUserTracer(ctx, itrace.TracerOpts{
@@ -109,6 +111,7 @@ func doDev(cmd *cobra.Command, args []string) {
 		Poll:          !noPoll,
 		PollInterval:  pollInterval,
 		RetryInterval: retryInterval,
+		QueueWorkers:  queueWorkers,
 		Tick:          time.Duration(tick) * time.Millisecond,
 		URLs:          urls,
 	}

--- a/cmd/commands/internal/localconfig/devconfig.go
+++ b/cmd/commands/internal/localconfig/devconfig.go
@@ -95,6 +95,7 @@ func mapDevFlags(cmd *cobra.Command) error {
 	err = errors.Join(err, viper.BindPFlag("poll-interval", cmd.Flags().Lookup("poll-interval")))
 	err = errors.Join(err, viper.BindPFlag("port", cmd.Flags().Lookup("port")))
 	err = errors.Join(err, viper.BindPFlag("retry-interval", cmd.Flags().Lookup("retry-interval")))
+	err = errors.Join(err, viper.BindPFlag("queue-workers", cmd.Flags().Lookup("queue-workers")))
 	err = errors.Join(err, viper.BindPFlag("tick", cmd.Flags().Lookup("tick")))
 	err = errors.Join(err, viper.BindPFlag("sdk-url", cmd.Flags().Lookup("sdk-url")))
 
@@ -112,6 +113,7 @@ func mapStartFlags(cmd *cobra.Command) error {
 	err = errors.Join(err, viper.BindPFlag("postgres-uri", cmd.Flags().Lookup("postgres-uri")))
 	err = errors.Join(err, viper.BindPFlag("poll-interval", cmd.Flags().Lookup("poll-interval")))
 	err = errors.Join(err, viper.BindPFlag("retry-interval", cmd.Flags().Lookup("retry-interval")))
+	err = errors.Join(err, viper.BindPFlag("queue-workers", cmd.Flags().Lookup("queue-workers")))
 	err = errors.Join(err, viper.BindPFlag("sdk-url", cmd.Flags().Lookup("sdk-url")))
 	err = errors.Join(err, viper.BindPFlag("sqlite-dir", cmd.Flags().Lookup("sqlite-dir")))
 	err = errors.Join(err, viper.BindPFlag("tick", cmd.Flags().Lookup("tick")))

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -38,8 +38,9 @@ func NewCmdStart(rootCmd *cobra.Command) *cobra.Command {
 	baseFlags.StringP("port", "p", "8288", "Server port")
 	baseFlags.Int("poll-interval", 0, "Enable app sync polling at a specific interval in seconds. (default disabled)")
 	baseFlags.Int("retry-interval", 0, "Retry interval in seconds for linear backoff. Minimum: 1.")
-	baseFlags.StringSliceP("sdk-url", "u", []string{}, "SDK URLs to load functions from")
+	baseFlags.Int("queue-workers", devserver.DefaultQueueWorkers, "Number of workers to execute steps in the queue")
 	baseFlags.Int("tick", devserver.DefaultTick, "Interval, in milliseconds, of which to check for new work.")
+	baseFlags.StringSliceP("sdk-url", "u", []string{}, "SDK URLs to load functions from")
 	baseFlags.String("signing-key", "", "Signing key used to sign and validate data between the server and apps.")
 	baseFlags.StringSlice("event-key", []string{}, "Event key(s) that will be used by apps to send events to the server.")
 	cmd.Flags().AddFlagSet(baseFlags)
@@ -130,6 +131,7 @@ func doStart(cmd *cobra.Command, args []string) {
 		RedisURI:      viper.GetString("redis-uri"),
 		PostgresURI:   viper.GetString("postgres-uri"),
 		RetryInterval: viper.GetInt("retry-interval"),
+		QueueWorkers:  viper.GetInt("queue-workers"),
 		Tick:          time.Duration(tick) * time.Millisecond,
 		URLs:          viper.GetStringSlice("sdk-url"),
 		SQLiteDir:     viper.GetString("sqlite-dir"),

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -64,6 +64,7 @@ const (
 	DefaultTick         = 150
 	DefaultTickDuration = time.Millisecond * DefaultTick
 	DefaultPollInterval = 5
+	DefaultQueueWorkers = 100
 )
 
 // StartOpts configures the dev server
@@ -76,6 +77,7 @@ type StartOpts struct {
 	PollInterval  int           `json:"poll_interval"`
 	Tick          time.Duration `json:"tick"`
 	RetryInterval int           `json:"retry_interval"`
+	QueueWorkers  int           `json:"queue_workers"`
 
 	// SigningKey is used to decide that the server should sign requests and
 	// validate responses where applicable, modelling cloud behaviour.
@@ -189,7 +191,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			Partition:  true,
 		}),
 		redis_state.WithIdempotencyTTL(time.Hour),
-		redis_state.WithNumWorkers(100),
+		redis_state.WithNumWorkers(int32(opts.QueueWorkers)),
 		redis_state.WithPollTick(opts.Tick),
 		redis_state.WithCustomConcurrencyKeyLimitRefresher(func(ctx context.Context, i queue.QueueItem) []state.CustomConcurrency {
 			keys := i.Data.GetConcurrencyKeys()

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -64,6 +64,7 @@ type StartOpts struct {
 	URLs          []string      `json:"urls"`
 	Tick          time.Duration `json:"tick"`
 	RetryInterval int           `json:"retry_interval"`
+	QueueWorkers  int           `json:"queue_workers"`
 
 	// SigningKey is used to decide that the server should sign requests and
 	// validate responses where applicable, modelling cloud behaviour.
@@ -174,7 +175,7 @@ func start(ctx context.Context, opts StartOpts) error {
 
 	queueOpts := []redis_state.QueueOpt{
 		redis_state.WithIdempotencyTTL(time.Hour),
-		redis_state.WithNumWorkers(100),
+		redis_state.WithNumWorkers(int32(opts.QueueWorkers)),
 		redis_state.WithPollTick(tick),
 		redis_state.WithCustomConcurrencyKeyLimitRefresher(func(ctx context.Context, i queue.QueueItem) []state.CustomConcurrency {
 			keys := i.Data.GetConcurrencyKeys()


### PR DESCRIPTION
## Description

This gives the end user the ability to run the dev server or self-host mode with more resources to execute steps faster.

Currently available on beta release for testing: `npx inngest-cli@v1.4.4-beta.1 dev --queue-workers 200`

### Usage
```bash
inngest dev --queue-workers 200
inngest start --queue-workers 200
```
Config file:
```yaml
queue-workers: 200
```


## Motivation
Closes #2093
INN-4314

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
