### PR TITLE
Fix connect worker API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,9 +29,9 @@ require (
 	github.com/fatih/structs v1.1.0
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/go-chi/cors v1.2.1
-	github.com/gogo/protobuf v1.3.2
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golang-migrate/migrate/v4 v4.16.2
+	github.com/golang/protobuf v1.5.4
 	github.com/google/cel-go v0.21.0
 	github.com/google/uuid v1.6.0
 	github.com/gosimple/slug v1.12.0
@@ -127,10 +127,10 @@ require (
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.2.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0 // indirect
-	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/s2a-go v0.1.7 // indirect
 	github.com/google/wire v0.5.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.2 // indirect

--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -562,6 +562,7 @@ func (c *connectionHandler) handleIncomingWebSocketMessage(ctx context.Context, 
 		// Always handle SDK reply, even if gateway is draining
 		err := c.handleSdkReply(context.Background(), msg)
 		if err != nil {
+			c.log.Error("could not handle sdk reply", "err", err)
 			// TODO Should we actually close the connection here?
 			return &SocketError{
 				SysCode:    syscode.CodeConnectInternal,

--- a/pkg/connect/rest/v0/workerapi.go
+++ b/pkg/connect/rest/v0/workerapi.go
@@ -1,12 +1,13 @@
 package v0
 
 import (
-	"github.com/gogo/protobuf/proto"
+	"io"
+	"net/http"
+
+	"github.com/golang/protobuf/proto"
 	"github.com/inngest/inngest/pkg/connect/auth"
 	"github.com/inngest/inngest/pkg/publicerr"
 	"github.com/inngest/inngest/proto/gen/connect/v1"
-	"io"
-	"net/http"
 )
 
 func (a *connectApiRouter) start(w http.ResponseWriter, r *http.Request) {
@@ -87,8 +88,10 @@ func (a *connectApiRouter) flushBuffer(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Remove "Bearer " prefix
-		hashedSigningKey = hashedSigningKey[7:]
+		if len(hashedSigningKey) > 7 {
+			// Remove "Bearer " prefix
+			hashedSigningKey = hashedSigningKey[7:]
+		}
 	}
 
 	envOverride := r.Header.Get("X-Inngest-Env")
@@ -104,18 +107,21 @@ func (a *connectApiRouter) flushBuffer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	byt, err := io.ReadAll(io.LimitReader(r.Body, 1024*1024))
+	byt, err := io.ReadAll(r.Body)
 	if err != nil {
 		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 400, "could not read request body"))
 		return
 	}
 
+	if len(byt) == 0 {
+		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 400, "missing request body"))
+		return
+	}
+
 	reqBody := &connect.SDKResponse{}
-	if len(byt) > 0 {
-		if err := proto.Unmarshal(byt, reqBody); err != nil {
-			_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 400, "could not unmarshal request"))
-			return
-		}
+	if err := proto.Unmarshal(byt, reqBody); err != nil {
+		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 400, "could not unmarshal request"))
+		return
 	}
 
 	// Marshal response before notifying executor, marshaling should never fail


### PR DESCRIPTION
## Description

This fixes using the wrong protobuf package, causing panics (which are recovered by the http stack, yet annoying) when invoking the flush endpoint in the Worker API.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
