### PR TITLE
Fix org name wrapping issue

### DIFF
--- a/ui/apps/dashboard/src/components/Navigation/Profile.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Profile.tsx
@@ -27,13 +27,18 @@ export const Profile = ({ collapsed, profile }: { collapsed: boolean; profile: P
               : 'hover:bg-canvasSubtle text-subtle'
           }`}
         >
-          <div className="bg-canvasMuted text-subtle flex h-8 w-8 items-center justify-center rounded-full text-xs uppercase">
+          <div className="bg-canvasMuted text-subtle flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs uppercase">
             {profile.orgName?.substring(0, 2) || '?'}
           </div>
 
           {!collapsed && (
-            <div className="ml-2 flex flex-col items-start justify-start">
-              <div className="text-subtle leading-1 text-sm">{profile.orgName}</div>
+            <div className="ml-2 flex flex-col items-start justify-start overflow-hidden">
+              <div
+                className="text-subtle leading-1 max-w-full overflow-hidden text-ellipsis text-nowrap text-sm"
+                title={profile.orgName}
+              >
+                {profile.orgName}
+              </div>
               <div className="text-muted text-xs leading-4">{profile.displayName}</div>
             </div>
           )}


### PR DESCRIPTION
## Description

After
<img width="273" alt="Screen Shot 2025-01-27 at 2 19 01 PM" src="https://github.com/user-attachments/assets/e9111b3d-d952-4419-b0e1-a89792b6d011" />

Before:
<img width="271" alt="Screen Shot 2025-01-27 at 2 19 16 PM" src="https://github.com/user-attachments/assets/c26d61d5-af05-4660-a529-180ba1bbb88c" />


## Motivation
It looked bad.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
