### PR TITLE
INN-4361: Ensure wildcards are matched during execution

### DIFF
--- a/pkg/cqrs/base_cqrs/execution.go
+++ b/pkg/cqrs/base_cqrs/execution.go
@@ -3,6 +3,7 @@ package base_cqrs
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/inngest/inngest/pkg/inngest"
 )
@@ -40,6 +41,9 @@ func (w wrapper) FunctionsScheduled(ctx context.Context) ([]inngest.Function, er
 
 // FunctionsByTrigger returns functions for the given trigger by event name.
 func (w wrapper) FunctionsByTrigger(ctx context.Context, eventName string) ([]inngest.Function, error) {
+
+	matchingTriggers := matchingTriggerNames(eventName)
+
 	// TODO: Make less naive by storing triggers and caching.
 	fns, err := w.Functions(ctx)
 	if err != nil {
@@ -48,11 +52,39 @@ func (w wrapper) FunctionsByTrigger(ctx context.Context, eventName string) ([]in
 	all := []inngest.Function{}
 	for _, fn := range fns {
 		for _, t := range fn.Triggers {
-			if t.EventTrigger != nil && t.Event == eventName {
-				all = append(all, fn)
-				break
+			if t.EventTrigger != nil {
+				for _, trigger := range matchingTriggers {
+					if t.Event == trigger {
+						all = append(all, fn)
+						break
+					}
+				}
 			}
 		}
 	}
 	return all, nil
+}
+
+// matchingTriggerNames returns all matching trigger names for the given event name
+// including wildcards.
+func matchingTriggerNames(e string) []string {
+	prefixes := []string{e}
+
+	parts := strings.Split(e, "/")
+	if len(parts) > 1 {
+		for n := range parts[0 : len(parts)-1] {
+			prefix := strings.Join(parts[0:n+1], "/")
+			prefixes = append(prefixes, prefix+"/*")
+		}
+	}
+
+	parts = strings.Split(e, ".")
+	if len(parts) > 1 {
+		for n := range parts[0 : len(parts)-1] {
+			prefix := strings.Join(parts[0:n+1], ".")
+			prefixes = append(prefixes, prefix+".*")
+		}
+	}
+
+	return prefixes
 }

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -511,6 +511,7 @@ func (s *svc) functions(ctx context.Context, tracked event.TrackedEvent) error {
 		}
 	}()
 
+	// Look up all functions have a trigger that matches the event name, including wildcards.
 	fns, err := s.data.FunctionsByTrigger(ctx, evt.Name)
 	if err != nil {
 		return fmt.Errorf("error loading functions by trigger: %w", err)
@@ -533,11 +534,7 @@ func (s *svc) functions(ctx context.Context, tracked event.TrackedEvent) error {
 		go func() {
 			defer wg.Done()
 			for _, t := range copied.Triggers {
-				if t.EventTrigger == nil || t.Event != evt.Name {
-					// This isn't triggered by an event, so we skip this trigger entirely.
-					continue
-				}
-
+				// Evaluate all expressions for matching triggers
 				if t.Expression != nil {
 					// Execute expressions here, ensuring that each function is only triggered
 					// under the correct conditions.


### PR DESCRIPTION
## Description

Create all matching wildcard patterns for incoming events.

## Motivation
INN-4361: Wildcard triggers did not work in OSS, but they worked in cloud.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
