### PR TITLE
Webhook edit UI improvements

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/TransformEvent.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/[keyID]/TransformEvent.tsx
@@ -192,7 +192,7 @@ export default function TransformEvents({ keyID, metadata }: FilterEventsProps) 
       <div className="mb-6">
         <DashboardCodeBlock
           header={{
-            title: 'Payload',
+            title: 'Transform Function',
           }}
           tab={{
             content: rawTransform ?? defaultTransform,
@@ -210,7 +210,7 @@ export default function TransformEvents({ keyID, metadata }: FilterEventsProps) 
           </p>
           <DashboardCodeBlock
             header={{
-              title: 'Payload',
+              title: 'Webhook Payload',
             }}
             tab={{
               content: incoming,
@@ -225,7 +225,7 @@ export default function TransformEvents({ keyID, metadata }: FilterEventsProps) 
           <p className="text-subtle text-sm mb-6">Preview the transformed JSON payload here.</p>
           <DashboardCodeBlock
             header={{
-              title: 'Payload',
+              title: 'Event Payload',
             }}
             tab={{
               content: output,


### PR DESCRIPTION
## Description

This PR:

- makes JavaScript errors on the webhook edit page clearer
- warns the user when their transform does not produce a valid Inngest event

## Motivation

On support yesterday I helped a user who accidentally omitted the `data` key from their webhook transform. This PR attempts to help users avoid this by warning them when their function's output does not include a `data` or `name` key.

## Screenshots

<img width="1352" alt="Screenshot 2025-01-28 at 11 14 03 AM" src="https://github.com/user-attachments/assets/2172a073-bf1e-4c6b-a033-57b230c19687" />

<img width="1363" alt="Screenshot 2025-01-28 at 11 14 49 AM" src="https://github.com/user-attachments/assets/f70d9d53-c2be-427a-a07a-932a42b93be5" />

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.
