### PR TITLE
ux tweak when clicking on signing keys from a branch

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/ChildEmptyState.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/ChildEmptyState.tsx
@@ -21,7 +21,13 @@ export default function ChildEmptyState() {
             <Button
               kind="primary"
               href={`/env/${staticSlugs.branch}/manage/keys` as Route}
-              label="Manage"
+              label="Manage Event Keys"
+            />
+
+            <Button
+              kind="primary"
+              href={`/env/${staticSlugs.branch}/manage/signing-key` as Route}
+              label="Manage Signing Keys"
             />
           </div>
         </div>

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/ChildEmptyState.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/ChildEmptyState.tsx
@@ -20,12 +20,14 @@ export default function ChildEmptyState() {
           <div className="border-subtle mt-6 flex items-center gap-2 border-t py-4">
             <Button
               kind="primary"
+              appearance="outlined"
               href={`/env/${staticSlugs.branch}/manage/keys` as Route}
               label="Manage Event Keys"
             />
 
             <Button
               kind="primary"
+              appearance="outlined"
               href={`/env/${staticSlugs.branch}/manage/signing-key` as Route}
               label="Manage Signing Keys"
             />


### PR DESCRIPTION
## Description

When clicking on signing keys in a branch env the user gets directed to an interstitial page which tells them then need to manage keys from the parent branch env. But if they click on the manage keys from there it takes them to event keys not signing keys so their original intent was lost. I just added another button to the interstitial so they don't get lost.

<img width="986" alt="Screenshot 2025-01-28 at 1 12 14 PM" src="https://github.com/user-attachments/assets/2493073e-d69d-4f95-b9d9-ee66ed112744" />


## Motivation
Slightly better ux

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
