### PR TITLE
use email alone as identifier

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/api/support-tickets/route.ts
+++ b/ui/apps/dashboard/src/app/(organization-active)/api/support-tickets/route.ts
@@ -64,11 +64,7 @@ export async function POST(req: Request) {
 
   const upsertCustomerRes = await client.upsertCustomer({
     identifier: {
-      //
-      // use externalId not email,
-      // support ticket submission will forever fail if we use email as the identifier and
-      // a user changes their email address.
-      externalId: body.user.id,
+      emailAddress: body.user.email,
     },
     onCreate: {
       externalId: body.user.id,


### PR DESCRIPTION
## Description

revert email -> externalId change as this "fix" is actually worse than the previous error where it occasionally couldn't create plain users because the external id already existed.

## Motivation


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
