### PR TITLE
Fix executor for connect

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -99,9 +99,8 @@ func (w wrapper) LoadFunction(ctx context.Context, envID, fnID uuid.UUID) (*stat
 	}
 
 	return &state.ExecutorFunction{
-		Function:     def,
-		Paused:       false, // dev server does not support pausing
-		AppIsConnect: app.ConnectionType == enums.AppConnectionTypeConnect.String(),
+		Function: def,
+		Paused:   false, // dev server does not support pausing
 	}, nil
 }
 
@@ -1997,10 +1996,10 @@ func (w wrapper) GetWorkerConnections(ctx context.Context, opt cqrs.GetWorkerCon
 // copyWriter allows running duck-db specific functions as CQRS functions, copying CQRS types to DDB types
 // automatically.
 func copyWriter[
-	PARAMS_IN any,
-	INTERNAL_PARAMS any,
-	IN any,
-	OUT any,
+PARAMS_IN any,
+INTERNAL_PARAMS any,
+IN any,
+OUT any,
 ](
 	ctx context.Context,
 	f func(context.Context, INTERNAL_PARAMS) (IN, error),
@@ -2023,8 +2022,8 @@ func copyWriter[
 }
 
 func copyInto[
-	IN any,
-	OUT any,
+IN any,
+OUT any,
 ](
 	ctx context.Context,
 	f func(context.Context) (IN, error),

--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -93,11 +93,6 @@ func (w wrapper) LoadFunction(ctx context.Context, envID, fnID uuid.UUID) (*stat
 		return nil, err
 	}
 
-	app, err := w.GetAppByID(ctx, fn.AppID)
-	if err != nil {
-		return nil, err
-	}
-
 	return &state.ExecutorFunction{
 		Function: def,
 		Paused:   false, // dev server does not support pausing

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -711,14 +711,13 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 }
 
 type runInstance struct {
-	md           sv2.Metadata
-	f            inngest.Function
-	events       []json.RawMessage
-	item         queue.Item
-	edge         inngest.Edge
-	resp         *state.DriverResponse
-	stackIndex   int
-	appIsConnect bool
+	md         sv2.Metadata
+	f          inngest.Function
+	events     []json.RawMessage
+	item       queue.Item
+	edge       inngest.Edge
+	resp       *state.DriverResponse
+	stackIndex int
 }
 
 // Execute loads a workflow and the current run state, then executes the
@@ -867,13 +866,12 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 	}
 
 	instance := runInstance{
-		md:           md,
-		f:            *ef.Function,
-		events:       events,
-		item:         item,
-		edge:         edge,
-		stackIndex:   stackIndex,
-		appIsConnect: ef.AppIsConnect,
+		md:         md,
+		f:          *ef.Function,
+		events:     events,
+		item:       item,
+		edge:       edge,
+		stackIndex: stackIndex,
 	}
 
 	resp, err := e.run(ctx, &instance)
@@ -1204,9 +1202,6 @@ func (e *executor) executeDriverForStep(ctx context.Context, i *runInstance) (*s
 	url, _ := i.f.URI()
 
 	driverName := inngest.SchemeDriver(url.Scheme)
-	if i.appIsConnect {
-		driverName = "connect"
-	}
 
 	d, ok := e.runtimeDrivers[driverName]
 	if !ok {

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -362,8 +362,6 @@ type ExecutorFunction struct {
 	Function *inngest.Function `json:"function"`
 	// Paused indicates whether the function is currently paused.
 	Paused bool `json:"paused"`
-
-	AppIsConnect bool `json:"appIsConnect"`
 }
 
 // Mutater mutates state for a given identifier, storing the state and returning


### PR DESCRIPTION
## Description

This removes the early override for connect apps and instead users the driver URL scheme, which is wss for connect.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
