### PR TITLE
Stub metrics scrape endpoint in dev server REST API

### DIFF
--- a/pkg/api/apiv1/apiv1.go
+++ b/pkg/api/apiv1/apiv1.go
@@ -113,6 +113,8 @@ func (a *router) setup() {
 			r.Post("/cancellations", a.createCancellation)
 			r.Get("/cancellations", a.getCancellations)
 			r.Delete("/cancellations/{id}", a.deleteCancellation)
+
+			r.Get("/prom/{env}", a.promScrape)
 		})
 	})
 }

--- a/pkg/api/apiv1/stubs.go
+++ b/pkg/api/apiv1/stubs.go
@@ -1,0 +1,14 @@
+package apiv1
+
+import (
+	"net/http"
+
+	"github.com/inngest/inngest/pkg/publicerr"
+)
+
+func (a router) promScrape(w http.ResponseWriter, _ *http.Request) {
+	_ = publicerr.WriteHTTP(w, publicerr.Errorf(
+		http.StatusNotImplemented,
+		"not implemented",
+	))
+}


### PR DESCRIPTION
## Description

Add a stub endpoint at `/v1/prom/{env}`, mirroring the Prometheus scrape endpoint in the cloud server.

Closes: https://linear.app/inngest/issue/INN-4378/stub-prometheus-scrape-endpoint-in-self-hostoss

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.
