### PR TITLE
Passthrough full slug to fix JS SDK w/ connect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/graph-gophers/dataloader v5.0.0+incompatible
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/inngest/expr v0.0.0-20241106234328-863dff7deec0
-	github.com/inngest/inngestgo v0.7.5-0.20250131124742-ae0eadde2a8e
+	github.com/inngest/inngestgo v0.7.5-0.20250131142046-6beb83ad6d58
 	github.com/jackc/pgx/v5 v5.5.4
 	github.com/jedib0t/go-pretty/v6 v6.3.0
 	github.com/jinzhu/copier v0.3.5

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/graph-gophers/dataloader v5.0.0+incompatible
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/inngest/expr v0.0.0-20241106234328-863dff7deec0
-	github.com/inngest/inngestgo v0.7.5-0.20250124122022-10fdd744bf35
+	github.com/inngest/inngestgo v0.7.5-0.20250131124742-ae0eadde2a8e
 	github.com/jackc/pgx/v5 v5.5.4
 	github.com/jedib0t/go-pretty/v6 v6.3.0
 	github.com/jinzhu/copier v0.3.5

--- a/go.sum
+++ b/go.sum
@@ -512,6 +512,8 @@ github.com/inngest/expr v0.0.0-20241106234328-863dff7deec0 h1:cqaGD0mx745BYyVGZ3
 github.com/inngest/expr v0.0.0-20241106234328-863dff7deec0/go.mod h1:0Dllw9clwlMWWxfiSsHY9VdE+Zjt/8SVCMxK9r39aKE=
 github.com/inngest/inngestgo v0.7.5-0.20250124122022-10fdd744bf35 h1:8j01fa2LBcXgIrtTog64ATfthmLrHrURUnuU/K4FM38=
 github.com/inngest/inngestgo v0.7.5-0.20250124122022-10fdd744bf35/go.mod h1:Ilq2+IJJG1dSselO5N85fNZqHcquAHY/Bs63PLEU/G0=
+github.com/inngest/inngestgo v0.7.5-0.20250131124742-ae0eadde2a8e h1:8o6idiJ6P+9ImLPoxlN1EORrFl6j4Q8yLiwVetYi+M0=
+github.com/inngest/inngestgo v0.7.5-0.20250131124742-ae0eadde2a8e/go.mod h1:Ilq2+IJJG1dSselO5N85fNZqHcquAHY/Bs63PLEU/G0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/go.sum
+++ b/go.sum
@@ -514,6 +514,8 @@ github.com/inngest/inngestgo v0.7.5-0.20250124122022-10fdd744bf35 h1:8j01fa2LBcX
 github.com/inngest/inngestgo v0.7.5-0.20250124122022-10fdd744bf35/go.mod h1:Ilq2+IJJG1dSselO5N85fNZqHcquAHY/Bs63PLEU/G0=
 github.com/inngest/inngestgo v0.7.5-0.20250131124742-ae0eadde2a8e h1:8o6idiJ6P+9ImLPoxlN1EORrFl6j4Q8yLiwVetYi+M0=
 github.com/inngest/inngestgo v0.7.5-0.20250131124742-ae0eadde2a8e/go.mod h1:Ilq2+IJJG1dSselO5N85fNZqHcquAHY/Bs63PLEU/G0=
+github.com/inngest/inngestgo v0.7.5-0.20250131142046-6beb83ad6d58 h1:GjROmfEGUUoRxXgDhkijdIo+9DKEtElQRd+4hFdpWKk=
+github.com/inngest/inngestgo v0.7.5-0.20250131142046-6beb83ad6d58/go.mod h1:Ilq2+IJJG1dSselO5N85fNZqHcquAHY/Bs63PLEU/G0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/pkg/connect/group.go
+++ b/pkg/connect/group.go
@@ -12,7 +12,6 @@ import (
 	"github.com/inngest/inngest/pkg/sdk"
 	"github.com/inngest/inngest/pkg/syscode"
 	"github.com/inngest/inngest/proto/gen/connect/v1"
-	"strings"
 )
 
 func workerGroupHashFromConnRequest(req *connect.WorkerConnectRequestData, authResp *auth.Response, sessionDetails *connect.SessionDetails) (string, error) {
@@ -84,7 +83,8 @@ func NewWorkerGroupFromConnRequest(
 
 	slugs := make([]string, len(functions))
 	for i, fn := range functions {
-		slugs[i] = strings.TrimPrefix(fn.Slug, fmt.Sprintf("%s-", req.AppName))
+		// Use slug as is
+		slugs[i] = fn.Slug
 	}
 
 	workerGroup := &state.WorkerGroup{

--- a/pkg/connect/router.go
+++ b/pkg/connect/router.go
@@ -189,7 +189,7 @@ func (c *connectRouterSvc) isHealthy(ctx context.Context, envId uuid.UUID, appId
 
 		// Clean up unhealthy connection
 		err = c.stateManager.DeleteConnection(context.Background(), envId, &appId, conn.GroupId, connId)
-		if err != nil {
+		if err != nil && !errors.Is(err, state.ConnDeletedWithGroupErr) {
 			c.logger.Error("could not clean up inactive connection", "conn_id", conn.Id, "err", err)
 		}
 	}()

--- a/pkg/connect/router.go
+++ b/pkg/connect/router.go
@@ -79,7 +79,7 @@ func (c *connectRouterSvc) Run(ctx context.Context) error {
 
 			// Now we're guaranteed to be the exclusive connection processing this message!
 
-			routeTo, err := c.getSuitableConnection(ctx, envId, appId, data.FunctionSlug)
+			routeTo, err := c.getSuitableConnection(ctx, envId, appId, data.FunctionSlug, log)
 			if err != nil {
 				log.Error("could not retrieve suitable connection", "err", err)
 				return
@@ -134,7 +134,7 @@ func (c *connectRouterSvc) Run(ctx context.Context) error {
 
 }
 
-func (c *connectRouterSvc) getSuitableConnection(ctx context.Context, envId uuid.UUID, appId uuid.UUID, fnSlug string) (*connect.ConnMetadata, error) {
+func (c *connectRouterSvc) getSuitableConnection(ctx context.Context, envId uuid.UUID, appId uuid.UUID, fnSlug string, log *slog.Logger) (*connect.ConnMetadata, error) {
 	conns, err := c.stateManager.GetConnectionsByAppID(ctx, envId, appId)
 	if err != nil {
 		return nil, fmt.Errorf("could not get connections by app ID: %w", err)
@@ -146,7 +146,7 @@ func (c *connectRouterSvc) getSuitableConnection(ctx context.Context, envId uuid
 
 	healthy := make([]*connect.ConnMetadata, 0, len(conns))
 	for _, conn := range conns {
-		isHealthy, err := c.isHealthy(ctx, envId, appId, fnSlug, conn)
+		isHealthy, err := c.isHealthy(ctx, envId, appId, fnSlug, conn, log)
 		if err != nil {
 			return nil, err
 		}
@@ -176,7 +176,7 @@ func (c *connectRouterSvc) getSuitableConnection(ctx context.Context, envId uuid
 	return chosen, nil
 }
 
-func (c *connectRouterSvc) isHealthy(ctx context.Context, envId uuid.UUID, appId uuid.UUID, fnSlug string, conn *connect.ConnMetadata) (isHealthy bool, err error) {
+func (c *connectRouterSvc) isHealthy(ctx context.Context, envId uuid.UUID, appId uuid.UUID, fnSlug string, conn *connect.ConnMetadata, log *slog.Logger) (isHealthy bool, err error) {
 	defer func() {
 		if isHealthy {
 			return
@@ -184,26 +184,41 @@ func (c *connectRouterSvc) isHealthy(ctx context.Context, envId uuid.UUID, appId
 
 		connId, err := ulid.Parse(conn.Id)
 		if err != nil {
-			c.logger.Error("could not clean up inactive connection, invalid connection ID", "conn_id", conn.Id, "err", err)
+			log.Error("could not clean up inactive connection, invalid connection ID", "conn_id", conn.Id, "err", err)
 		}
 
 		// Clean up unhealthy connection
 		err = c.stateManager.DeleteConnection(context.Background(), envId, &appId, conn.GroupId, connId)
 		if err != nil && !errors.Is(err, state.ConnDeletedWithGroupErr) {
-			c.logger.Error("could not clean up inactive connection", "conn_id", conn.Id, "err", err)
+			log.Error("could not clean up inactive connection", "conn_id", conn.Id, "err", err)
 		}
 	}()
 
+	log.Debug("evaluating connection", "connection_id", conn.Id, "status", conn.Status, "last_heartbeat_at", conn.LastHeartbeatAt.AsTime())
+
+	gatewayId, err := ulid.Parse(conn.GatewayId)
+	if err != nil {
+		log.Error("connection gateway id could not be parsed", "err", err, "gateway_id", conn.GatewayId)
+
+		return
+	}
+
 	if conn.Status != connect.ConnectionStatus_READY {
+		log.Debug("connection is not ready")
+
 		return
 	}
 
 	if conn.LastHeartbeatAt.AsTime().Before(time.Now().Add(-2 * WorkerHeartbeatInterval)) {
+		log.Debug("last heartbeat is too old")
+
 		return
 	}
 
 	group, err := c.stateManager.GetWorkerGroupByHash(ctx, envId, conn.GroupId)
 	if err != nil {
+		log.Error("could not get worker group for connection", "group_id", conn.GroupId)
+
 		return
 	}
 
@@ -216,21 +231,24 @@ func (c *connectRouterSvc) isHealthy(ctx context.Context, envId uuid.UUID, appId
 	}
 
 	if !hasFn {
-		return
-	}
+		log.Debug("connection does not have function", "slug", fnSlug, "available", group.FunctionSlugs)
 
-	gatewayId, err := ulid.Parse(conn.GatewayId)
-	if err != nil {
 		return
 	}
 
 	// Ensure gateway is healthy
 	gw, err := c.stateManager.GetGateway(ctx, gatewayId)
 	if err != nil {
+		log.Error("could not get gateway", "gateway_id", gatewayId.String())
+
 		return
 	}
 
+	log.Debug("retrieved gateway for connection", "conn_id", conn.Id, "gateway_id", gatewayId.String(), "status", gw.Status, "last_heartbeat_at", gw.LastHeartbeatAt)
+
 	if gw.Status != state.GatewayStatusActive || gw.LastHeartbeatAt.Before(time.Now().Add(-2*GatewayHeartbeatInterval)) {
+		log.Debug("gateway is unhealthy", "conn_id", conn.Id, "gateway_id", gatewayId.String(), "status", gw.Status, "last_heartbeat_at", gw.LastHeartbeatAt)
+
 		// Clean up unhealthy gateway
 		err = c.stateManager.DeleteGateway(ctx, gatewayId)
 		if err != nil {

--- a/vendor/github.com/inngest/inngestgo/connect.go
+++ b/vendor/github.com/inngest/inngestgo/connect.go
@@ -70,7 +70,7 @@ func (h *handler) getServableFunctionBySlug(slug string) ServableFunction {
 	h.l.RLock()
 	var fn ServableFunction
 	for _, f := range h.funcs {
-		if f.Slug() == slug {
+		if f.Slug(h.appName) == slug {
 			fn = f
 			break
 		}

--- a/vendor/github.com/inngest/inngestgo/funcs.go
+++ b/vendor/github.com/inngest/inngestgo/funcs.go
@@ -238,7 +238,7 @@ type SDKFunction[T any] func(ctx context.Context, input Input[T]) (any, error)
 // This is created via CreateFunction in this package.
 type ServableFunction interface {
 	// Slug returns the function's human-readable ID, such as "sign-up-flow".
-	Slug() string
+	Slug(appName string) string
 
 	// Name returns the function name.
 	Name() string
@@ -284,11 +284,19 @@ func (s servableFunc) Config() FunctionOpts {
 	return s.fc
 }
 
-func (s servableFunc) Slug() string {
-	if s.fc.ID == "" {
-		return slug.Make(s.fc.Name)
+func (s servableFunc) Slug(appName string) string {
+	fnSlug := s.fc.ID
+	if fnSlug == "" {
+		fnSlug = slug.Make(s.fc.Name)
 	}
-	return s.fc.ID
+
+	// Old format which only includes the fn slug
+	// This should no longer be used.
+	if appName == "" {
+		return fnSlug
+	}
+
+	return appName + "-" + fnSlug
 }
 
 func (s servableFunc) Name() string {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -525,7 +525,7 @@ github.com/inconshreveable/mousetrap
 # github.com/inngest/expr v0.0.0-20241106234328-863dff7deec0
 ## explicit; go 1.23.2
 github.com/inngest/expr
-# github.com/inngest/inngestgo v0.7.5-0.20250124122022-10fdd744bf35
+# github.com/inngest/inngestgo v0.7.5-0.20250131124742-ae0eadde2a8e
 ## explicit; go 1.23.2
 github.com/inngest/inngestgo
 github.com/inngest/inngestgo/connect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -525,7 +525,7 @@ github.com/inconshreveable/mousetrap
 # github.com/inngest/expr v0.0.0-20241106234328-863dff7deec0
 ## explicit; go 1.23.2
 github.com/inngest/expr
-# github.com/inngest/inngestgo v0.7.5-0.20250131124742-ae0eadde2a8e
+# github.com/inngest/inngestgo v0.7.5-0.20250131142046-6beb83ad6d58
 ## explicit; go 1.23.2
 github.com/inngest/inngestgo
 github.com/inngest/inngestgo/connect


### PR DESCRIPTION
## Description

This PR removes the previous logic to transform function slugs before storing in the connect metadata store for routing. During routing, we receive the `fnId` parameter.

> [!WARNING]  
> To get connect working with the Go SDK, clients must use a version including this fix https://github.com/inngest/inngestgo/pull/87

## SDK reference

- Go:
  - Before the [fix](https://github.com/inngest/inngestgo/pull/87): Supplies full slug in function id but _not_ the runtime url fnId. Metadata function slugs will include full slug. Routing will *not match*.
  - With the [fix](https://github.com/inngest/inngestgo/pull/87): Supplies full slug in function id _and_  fnId. Metadata function slugs will include full slug. Routing will match.
- JS: Supplies full slug in function id _and_  fnId. Metadata function slugs will include full slug. Routing will match.


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
