### PR TITLE
Add app health check to apps page

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/layout.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/[externalID]/layout.tsx
@@ -58,7 +58,7 @@ export default function Layout({ children, params: { externalID } }: Props) {
         <ValidateModal
           isOpen={showValidate}
           onClose={() => setShowValidate(false)}
-          url={res.data.latestSync.url}
+          initialURL={res.data.latestSync.url}
         />
       )}
       {res.data && (

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
@@ -3,10 +3,16 @@
 import { useEffect, useState } from 'react';
 import { SkeletonCard } from '@inngest/components/Apps/AppCard';
 import { Button } from '@inngest/components/Button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@inngest/components/DropdownMenu/DropdownMenu';
 import { Header } from '@inngest/components/Header/Header';
 import { Link } from '@inngest/components/Link/Link';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
-import { RiAddLine, RiQuestionLine } from '@remixicon/react';
+import { RiAddLine, RiFirstAidKitLine, RiMore2Line, RiQuestionLine } from '@remixicon/react';
 
 import { EmptyOnboardingCard } from '@/components/Apps/EmptyAppsCard';
 import { StatusMenu } from '@/components/Apps/StatusMenu';
@@ -14,6 +20,7 @@ import { getProdApps } from '@/components/Onboarding/actions';
 import { staticSlugs } from '@/utils/environments';
 import { pathCreator } from '@/utils/urls';
 import { Apps } from './Apps';
+import { ValidateModal } from './[externalID]/ValidateButton/ValidateModal';
 
 const AppInfo = () => (
   <Tooltip>
@@ -66,6 +73,7 @@ export default function AppsPage({
   params: { environmentSlug: string };
   searchParams: { archived: string };
 }) {
+  const [showValidate, setShowValidate] = useState(false);
   const [{ hasProductionApps, isLoading }, setState] = useState<LoadingState>({
     hasProductionApps: true,
     isLoading: true,
@@ -88,13 +96,32 @@ export default function AppsPage({
         infoIcon={<AppInfo />}
         action={
           (!isArchived || displayOnboarding) && (
-            <Button
-              kind="primary"
-              label="Sync new app"
-              href={pathCreator.createApp({ envSlug })}
-              icon={<RiAddLine />}
-              iconSide="left"
-            />
+            <div className="flex flex-row items-center justify-end gap-x-1">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    kind="primary"
+                    appearance="outlined"
+                    size="medium"
+                    icon={<RiMore2Line />}
+                  />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onSelect={() => setShowValidate(true)}>
+                    <RiFirstAidKitLine className="h-4 w-4" />
+                    Check app health
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <Button
+                kind="primary"
+                label="Sync new app"
+                href={pathCreator.createApp({ envSlug })}
+                icon={<RiAddLine />}
+                iconSide="left"
+              />
+            </div>
           )
         }
       />
@@ -120,6 +147,8 @@ export default function AppsPage({
           </>
         )}
       </div>
+
+      <ValidateModal isOpen={showValidate} onClose={() => setShowValidate(false)} />
     </>
   );
 }


### PR DESCRIPTION
# Description
Add the existing "app health check" modal to the apps page. Previously, it was only on an an individual app's page.

# Motivation
This tool is useful for diagnosing sync issues. Before this change, users were unable to use the tool until they synced their first app, so they can get into a chicken-and-egg scenario.