### PR TITLE
Idea: Use the HTTP hostname in the returned WebSocket URL.

### DIFF
--- a/pkg/connect/rest/v0/v0.go
+++ b/pkg/connect/rest/v0/v0.go
@@ -2,6 +2,8 @@ package v0
 
 import (
 	"context"
+	"net/url"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/google/uuid"
@@ -9,7 +11,6 @@ import (
 	"github.com/inngest/inngest/pkg/connect/pubsub"
 	"github.com/inngest/inngest/pkg/connect/state"
 	"github.com/inngest/inngest/pkg/headers"
-	"net/url"
 )
 
 type Opts struct {
@@ -42,7 +43,7 @@ type ConnectGatewayRetriever interface {
 	// may still return a gateway from an excluded group.
 	//
 	// On a successful request, the gateway group name and URL are returned.
-	RetrieveGateway(ctx context.Context, accountId uuid.UUID, envId uuid.UUID, exclude []string) (string, *url.URL, error)
+	RetrieveGateway(ctx context.Context, accountId uuid.UUID, envId uuid.UUID, exclude []string, hostname string) (string, *url.URL, error)
 }
 
 type connectApiRouter struct {

--- a/pkg/connect/rest/v0/workerapi.go
+++ b/pkg/connect/rest/v0/workerapi.go
@@ -3,6 +3,7 @@ package v0
 import (
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/inngest/inngest/pkg/connect/auth"
@@ -70,7 +71,9 @@ func (a *connectApiRouter) start(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gatewayGroup, gatewayUrl, err := a.ConnectGatewayRetriever.RetrieveGateway(ctx, res.AccountID, res.EnvID, reqBody.ExcludeGateways)
+	host := r.Host
+	hostname := strings.Split(host, ":")[0]
+	gatewayGroup, gatewayUrl, err := a.ConnectGatewayRetriever.RetrieveGateway(ctx, res.AccountID, res.EnvID, reqBody.ExcludeGateways, hostname)
 	if err != nil {
 		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "could not retrieve gateway"))
 		return

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/inngest/inngest/pkg/enums"
 	"net"
 	"net/url"
 	"os"
@@ -13,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/inngest/inngest/pkg/enums"
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/connect/auth"
@@ -652,8 +653,8 @@ func (d *devserver) CheckConnectionLimit(_ context.Context, _ *auth.Response) (b
 	return true, nil
 }
 
-func (d *devserver) RetrieveGateway(_ context.Context, _, _ uuid.UUID, _ []string) (string, *url.URL, error) {
-	parsed, err := url.Parse("ws://127.0.0.1:8289/v0/connect")
+func (d *devserver) RetrieveGateway(_ context.Context, _, _ uuid.UUID, _ []string, hostname string) (string, *url.URL, error) {
+	parsed, err := url.Parse("ws://" + hostname + ":8289/v0/connect")
 	if err != nil {
 		return "", nil, err
 	}


### PR DESCRIPTION
## Description

When the dev server, or self-host is running on something other than 127.0.0.1, like on a public URL or in a Docker container using a custom network hostname, the dev server should attempt to automatically re-write the websocket URL on the same hostname that the HTTP request was received on. This saves the end user from having to intercept and re-write the gateway endpoint.

## Motivation
When running an app in Docker and the dev server on a host machine or another Docker container, connect does not work without writing a custom `rewriteGatewayEndpoint` function. We should aim to avoid as much config/customization out of the box during development. For example:

```
docker run --rm --name connect-app -e INNGEST_DEV=http://host.docker.internal:8288 connect-app
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
