### PR TITLE
Measure sync + app load duration during connection setup

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -265,6 +265,8 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 			return
 		}
 
+		appLoadStart := time.Now()
+
 		app, err := c.appLoader.GetAppByName(ctx, conn.Group.EnvID, conn.Data.AppName)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			if ctx.Err() != nil {
@@ -280,6 +282,10 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 			})
 			return
 		}
+
+		metrics.HistogramConnectAppLoaderDuration(ctx, time.Since(appLoadStart).Milliseconds(), metrics.HistogramOpt{
+			PkgName: pkgName,
+		})
 
 		if errors.Is(err, sql.ErrNoRows) || app == nil {
 			ch.log.Error("could not find app", "appName", conn.Data.AppName)

--- a/pkg/telemetry/metrics/histogram.go
+++ b/pkg/telemetry/metrics/histogram.go
@@ -148,3 +148,25 @@ func HistogramConnectSetupDuration(ctx context.Context, dur int64, opts Histogra
 		Boundaries:  PausesBoundaries,
 	})
 }
+
+func HistogramConnectSyncDuration(ctx context.Context, dur int64, opts HistogramOpt) {
+	RecordIntHistogramMetric(ctx, dur, HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "connect_gateway.connection.sync_duration",
+		Description: "End to end duration for the out-of-band sync request initiated by the connect gateway.",
+		Tags:        opts.Tags,
+		Unit:        "ms",
+		Boundaries:  PausesBoundaries,
+	})
+}
+
+func HistogramConnectAppLoaderDuration(ctx context.Context, dur int64, opts HistogramOpt) {
+	RecordIntHistogramMetric(ctx, dur, HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "connect_gateway.connection.app_loader_duration",
+		Description: "Duration for loading the app during connection setup in the connect gateway.",
+		Tags:        opts.Tags,
+		Unit:        "ms",
+		Boundaries:  PausesBoundaries,
+	})
+}


### PR DESCRIPTION
## Description

This adds more detailed metrics during the connection setup process, measuring the duration for
- syncing an app using the out-of-band process
- loading the app

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
