### PR TITLE
Automatically use same hostname for gateway in dev server

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -45,6 +45,7 @@ func NewCmdDev(rootCmd *cobra.Command) *cobra.Command {
 	advancedFlags.Int("retry-interval", 0, "Retry interval in seconds for linear backoff when retrying functions - must be 1 or above")
 	advancedFlags.Int("queue-workers", devserver.DefaultQueueWorkers, "Number of executor workers to execute steps from the queue")
 	advancedFlags.Int("tick", devserver.DefaultTick, "The interval (in milliseconds) at which the executor polls the queue")
+	advancedFlags.Int("connect-gateway-port", devserver.DefaultConnectGatewayPort, "Port to expose connect gateway endpoint")
 	cmd.Flags().AddFlagSet(advancedFlags)
 	groups = append(groups, FlagGroup{name: "Advanced Flags:", fs: advancedFlags})
 
@@ -123,6 +124,7 @@ func doDev(cmd *cobra.Command, args []string) {
 	retryInterval := viper.GetInt("retry-interval")
 	queueWorkers := viper.GetInt("queue-workers")
 	tick := viper.GetInt("tick")
+	connectGatewayPort := viper.GetInt("connect-gateway-port")
 
 	if err := itrace.NewUserTracer(ctx, itrace.TracerOpts{
 		ServiceName:   "tracing",
@@ -140,14 +142,15 @@ func doDev(cmd *cobra.Command, args []string) {
 	conf.ServerKind = headers.ServerKindDev
 
 	opts := devserver.StartOpts{
-		Autodiscover:  !noDiscovery,
-		Config:        *conf,
-		Poll:          !noPoll,
-		PollInterval:  pollInterval,
-		RetryInterval: retryInterval,
-		QueueWorkers:  queueWorkers,
-		Tick:          time.Duration(tick) * time.Millisecond,
-		URLs:          urls,
+		Autodiscover:       !noDiscovery,
+		Config:             *conf,
+		Poll:               !noPoll,
+		PollInterval:       pollInterval,
+		RetryInterval:      retryInterval,
+		QueueWorkers:       queueWorkers,
+		Tick:               time.Duration(tick) * time.Millisecond,
+		URLs:               urls,
+		ConnectGatewayPort: connectGatewayPort,
 	}
 
 	err = devserver.New(ctx, opts)

--- a/cmd/commands/internal/localconfig/devconfig.go
+++ b/cmd/commands/internal/localconfig/devconfig.go
@@ -98,6 +98,7 @@ func mapDevFlags(cmd *cobra.Command) error {
 	err = errors.Join(err, viper.BindPFlag("queue-workers", cmd.Flags().Lookup("queue-workers")))
 	err = errors.Join(err, viper.BindPFlag("tick", cmd.Flags().Lookup("tick")))
 	err = errors.Join(err, viper.BindPFlag("sdk-url", cmd.Flags().Lookup("sdk-url")))
+	err = errors.Join(err, viper.BindPFlag("connect-gateway-port", cmd.Flags().Lookup("connect-gateway-port")))
 
 	return err
 }

--- a/pkg/connect/rest/v0/v0.go
+++ b/pkg/connect/rest/v0/v0.go
@@ -33,6 +33,18 @@ type ConnectionLimiter interface {
 	CheckConnectionLimit(ctx context.Context, resp *auth.Response) (bool, error)
 }
 
+type RetrieveGatewayOpts struct {
+	AccountId uuid.UUID
+	EnvId     uuid.UUID
+
+	// Exclude is a list of gateway group names that should be excluded, if possible.
+	// Implementations can choose to return a gateway included in this list, if no other gateways are available or reasonable to select.
+	Exclude []string
+
+	// RequestHost is the value of the `Host` header supplied to the Start request.
+	RequestHost string
+}
+
 type ConnectGatewayRetriever interface {
 	// RetrieveGateway retrieves a gateway to use for a new worker connection.
 	//
@@ -42,7 +54,7 @@ type ConnectGatewayRetriever interface {
 	// may still return a gateway from an excluded group.
 	//
 	// On a successful request, the gateway group name and URL are returned.
-	RetrieveGateway(ctx context.Context, accountId uuid.UUID, envId uuid.UUID, exclude []string) (string, *url.URL, error)
+	RetrieveGateway(ctx context.Context, opts RetrieveGatewayOpts) (string, *url.URL, error)
 }
 
 type connectApiRouter struct {

--- a/pkg/connect/rest/v0/v0.go
+++ b/pkg/connect/rest/v0/v0.go
@@ -34,8 +34,8 @@ type ConnectionLimiter interface {
 }
 
 type RetrieveGatewayOpts struct {
-	AccountId uuid.UUID
-	EnvId     uuid.UUID
+	AccountID uuid.UUID
+	EnvID     uuid.UUID
 
 	// Exclude is a list of gateway group names that should be excluded, if possible.
 	// Implementations can choose to return a gateway included in this list, if no other gateways are available or reasonable to select.

--- a/pkg/connect/rest/v0/workerapi.go
+++ b/pkg/connect/rest/v0/workerapi.go
@@ -70,7 +70,12 @@ func (a *connectApiRouter) start(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	gatewayGroup, gatewayUrl, err := a.ConnectGatewayRetriever.RetrieveGateway(ctx, res.AccountID, res.EnvID, reqBody.ExcludeGateways)
+	gatewayGroup, gatewayUrl, err := a.ConnectGatewayRetriever.RetrieveGateway(ctx, RetrieveGatewayOpts{
+		AccountId:   res.AccountID,
+		EnvId:       res.EnvID,
+		Exclude:     reqBody.ExcludeGateways,
+		RequestHost: r.Host,
+	})
 	if err != nil {
 		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "could not retrieve gateway"))
 		return

--- a/pkg/connect/rest/v0/workerapi.go
+++ b/pkg/connect/rest/v0/workerapi.go
@@ -71,8 +71,8 @@ func (a *connectApiRouter) start(w http.ResponseWriter, r *http.Request) {
 	}
 
 	gatewayGroup, gatewayUrl, err := a.ConnectGatewayRetriever.RetrieveGateway(ctx, RetrieveGatewayOpts{
-		AccountId:   res.AccountID,
-		EnvId:       res.EnvID,
+		AccountID:   res.AccountID,
+		EnvID:       res.EnvID,
 		Exclude:     reqBody.ExcludeGateways,
 		RequestHost: r.Host,
 	})

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -61,10 +61,11 @@ import (
 )
 
 const (
-	DefaultTick         = 150
-	DefaultTickDuration = time.Millisecond * DefaultTick
-	DefaultPollInterval = 5
-	DefaultQueueWorkers = 100
+	DefaultTick               = 150
+	DefaultTickDuration       = time.Millisecond * DefaultTick
+	DefaultPollInterval       = 5
+	DefaultQueueWorkers       = 100
+	DefaultConnectGatewayPort = 8289
 )
 
 // StartOpts configures the dev server
@@ -92,6 +93,8 @@ type StartOpts struct {
 	// the server will still boot but core actions such as syncing, runs, and
 	// ingesting events will not work.
 	RequireKeys bool `json:"require_keys"`
+
+	ConnectGatewayPort int `json:"connectGatewayPort"`
 }
 
 // Create and start a new dev server.  The dev server is used during (surprise surprise)
@@ -443,7 +446,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		connect.WithGatewayAuthHandler(auth.NewJWTAuthHandler(consts.DevServerConnectJwtSecret)),
 		connect.WithAppLoader(dbcqrs),
 		connect.WithDev(),
-		connect.WithGatewayPublicPort(8289),
+		connect.WithGatewayPublicPort(opts.ConnectGatewayPort),
 		connect.WithApiBaseUrl(fmt.Sprintf("http://127.0.0.1:%d", opts.Config.EventAPI.Port)),
 		connect.WithLifeCycles(
 			[]connect.ConnectGatewayLifecycleListener{

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -658,9 +658,9 @@ func (d *devserver) RetrieveGateway(_ context.Context, opts v0.RetrieveGatewayOp
 		return "", nil, err
 	}
 
-	// If request host was included in the Start request, use this instead of the default loopback address.
-	// This is important for scenarios where the devserver needs to be accessed from within
-	// a Docker container.
+	// Devserver-specific convenience implementation: If request host was included in the Start request,
+	// use this instead of the default loopback address. This is important for scenarios where the devserver
+	// needs to be accessed from within a Docker container.
 	if opts.RequestHost != "" {
 		parts := strings.Split(opts.RequestHost, ":")
 		if len(parts) > 0 {


### PR DESCRIPTION
## Description

This convenience function reduces the friction for people running the devserver locally but attempting to connect from inside a container. This way, as long as the devserver API is accessible, the same host will be used for the gateway, while still considering the configured gateway port.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
