### PR TITLE
Remove GraphQL parent access

### DIFF
--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -432,7 +432,7 @@ type ConnectV1WorkerConnectionResolver interface {
 	App(ctx context.Context, obj *models.ConnectV1WorkerConnection) (*cqrs.App, error)
 }
 type ConnectV1WorkerConnectionsConnectionResolver interface {
-	TotalCount(ctx context.Context, obj *models.ConnectV1WorkerConnectionsConnection) (int, error)
+	TotalCount(ctx context.Context, obj *models.WorkerConnectionsConnection) (int, error)
 }
 type EventResolver interface {
 	Status(ctx context.Context, obj *models.Event) (*models.EventStatus, error)
@@ -486,7 +486,7 @@ type QueryResolver interface {
 	Run(ctx context.Context, runID string) (*models.FunctionRunV2, error)
 	RunTraceSpanOutputByID(ctx context.Context, outputID string) (*models.RunTraceSpanOutput, error)
 	RunTrigger(ctx context.Context, runID string) (*models.RunTraceTrigger, error)
-	WorkerConnections(ctx context.Context, first int, after *string, orderBy []*models.ConnectV1WorkerConnectionsOrderBy, filter models.ConnectV1WorkerConnectionsFilter) (*models.ConnectV1WorkerConnectionsConnection, error)
+	WorkerConnections(ctx context.Context, first int, after *string, orderBy []*models.ConnectV1WorkerConnectionsOrderBy, filter models.ConnectV1WorkerConnectionsFilter) (*models.WorkerConnectionsConnection, error)
 	WorkerConnection(ctx context.Context, connectionID ulid.ULID) (*models.ConnectV1WorkerConnection, error)
 }
 type RunsV2ConnectionResolver interface {
@@ -5208,7 +5208,7 @@ func (ec *executionContext) fieldContext_ConnectV1WorkerConnectionEdge_cursor(ct
 	return fc, nil
 }
 
-func (ec *executionContext) _ConnectV1WorkerConnectionsConnection_edges(ctx context.Context, field graphql.CollectedField, obj *models.ConnectV1WorkerConnectionsConnection) (ret graphql.Marshaler) {
+func (ec *executionContext) _ConnectV1WorkerConnectionsConnection_edges(ctx context.Context, field graphql.CollectedField, obj *models.WorkerConnectionsConnection) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ConnectV1WorkerConnectionsConnection_edges(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -5258,7 +5258,7 @@ func (ec *executionContext) fieldContext_ConnectV1WorkerConnectionsConnection_ed
 	return fc, nil
 }
 
-func (ec *executionContext) _ConnectV1WorkerConnectionsConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *models.ConnectV1WorkerConnectionsConnection) (ret graphql.Marshaler) {
+func (ec *executionContext) _ConnectV1WorkerConnectionsConnection_pageInfo(ctx context.Context, field graphql.CollectedField, obj *models.WorkerConnectionsConnection) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ConnectV1WorkerConnectionsConnection_pageInfo(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -5312,7 +5312,7 @@ func (ec *executionContext) fieldContext_ConnectV1WorkerConnectionsConnection_pa
 	return fc, nil
 }
 
-func (ec *executionContext) _ConnectV1WorkerConnectionsConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *models.ConnectV1WorkerConnectionsConnection) (ret graphql.Marshaler) {
+func (ec *executionContext) _ConnectV1WorkerConnectionsConnection_totalCount(ctx context.Context, field graphql.CollectedField, obj *models.WorkerConnectionsConnection) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ConnectV1WorkerConnectionsConnection_totalCount(ctx, field)
 	if err != nil {
 		return graphql.Null
@@ -10638,9 +10638,9 @@ func (ec *executionContext) _Query_workerConnections(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*models.ConnectV1WorkerConnectionsConnection)
+	res := resTmp.(*models.WorkerConnectionsConnection)
 	fc.Result = res
-	return ec.marshalNConnectV1WorkerConnectionsConnection2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConnectV1WorkerConnectionsConnection(ctx, field.Selections, res)
+	return ec.marshalNConnectV1WorkerConnectionsConnection2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐWorkerConnectionsConnection(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_workerConnections(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -18338,7 +18338,7 @@ func (ec *executionContext) _ConnectV1WorkerConnectionEdge(ctx context.Context, 
 
 var connectV1WorkerConnectionsConnectionImplementors = []string{"ConnectV1WorkerConnectionsConnection"}
 
-func (ec *executionContext) _ConnectV1WorkerConnectionsConnection(ctx context.Context, sel ast.SelectionSet, obj *models.ConnectV1WorkerConnectionsConnection) graphql.Marshaler {
+func (ec *executionContext) _ConnectV1WorkerConnectionsConnection(ctx context.Context, sel ast.SelectionSet, obj *models.WorkerConnectionsConnection) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, connectV1WorkerConnectionsConnectionImplementors)
 	out := graphql.NewFieldSet(fields)
 	var invalids uint32
@@ -21198,11 +21198,11 @@ func (ec *executionContext) marshalNConnectV1WorkerConnectionEdge2ᚖgithubᚗco
 	return ec._ConnectV1WorkerConnectionEdge(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNConnectV1WorkerConnectionsConnection2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConnectV1WorkerConnectionsConnection(ctx context.Context, sel ast.SelectionSet, v models.ConnectV1WorkerConnectionsConnection) graphql.Marshaler {
+func (ec *executionContext) marshalNConnectV1WorkerConnectionsConnection2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐWorkerConnectionsConnection(ctx context.Context, sel ast.SelectionSet, v models.WorkerConnectionsConnection) graphql.Marshaler {
 	return ec._ConnectV1WorkerConnectionsConnection(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNConnectV1WorkerConnectionsConnection2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConnectV1WorkerConnectionsConnection(ctx context.Context, sel ast.SelectionSet, v *models.ConnectV1WorkerConnectionsConnection) graphql.Marshaler {
+func (ec *executionContext) marshalNConnectV1WorkerConnectionsConnection2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐWorkerConnectionsConnection(ctx context.Context, sel ast.SelectionSet, v *models.WorkerConnectionsConnection) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "the requested element is null which the schema does not allow")

--- a/pkg/coreapi/gqlgen.yml
+++ b/pkg/coreapi/gqlgen.yml
@@ -86,6 +86,7 @@ models:
       totalCount:
         resolver: true
   ConnectV1WorkerConnectionsConnection:
+    model: github.com/inngest/inngest/pkg/coreapi/graph/models.WorkerConnectionsConnection
     fields:
       totalCount:
         resolver: true

--- a/pkg/coreapi/gqlgen.yml
+++ b/pkg/coreapi/gqlgen.yml
@@ -82,6 +82,7 @@ models:
       app:
         resolver: true
   RunsV2Connection:
+    model: github.com/inngest/inngest/pkg/coreapi/graph/models.RunsV2Connection
     fields:
       totalCount:
         resolver: true

--- a/pkg/coreapi/graph/models/augmented.go
+++ b/pkg/coreapi/graph/models/augmented.go
@@ -1,0 +1,10 @@
+package models
+
+type WorkerConnectionsConnection struct {
+	Edges    []*ConnectV1WorkerConnectionEdge `json:"edges"`
+	PageInfo *PageInfo                        `json:"pageInfo"`
+
+	After   *string
+	Filter  ConnectV1WorkerConnectionsFilter
+	OrderBy []*ConnectV1WorkerConnectionsOrderBy
+}

--- a/pkg/coreapi/graph/models/augmented.go
+++ b/pkg/coreapi/graph/models/augmented.go
@@ -8,3 +8,12 @@ type WorkerConnectionsConnection struct {
 	Filter  ConnectV1WorkerConnectionsFilter
 	OrderBy []*ConnectV1WorkerConnectionsOrderBy
 }
+
+type RunsV2Connection struct {
+	Edges    []*FunctionRunV2Edge `json:"edges"`
+	PageInfo *PageInfo            `json:"pageInfo"`
+ 
+	After   *string
+	Filter  RunsFilterV2
+	OrderBy []*RunsV2OrderBy
+}

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -61,12 +61,6 @@ type ConnectV1WorkerConnectionEdge struct {
 	Cursor string                     `json:"cursor"`
 }
 
-type ConnectV1WorkerConnectionsConnection struct {
-	Edges      []*ConnectV1WorkerConnectionEdge `json:"edges"`
-	PageInfo   *PageInfo                        `json:"pageInfo"`
-	TotalCount int                              `json:"totalCount"`
-}
-
 type ConnectV1WorkerConnectionsFilter struct {
 	From      *time.Time                              `json:"from,omitempty"`
 	Until     *time.Time                              `json:"until,omitempty"`

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -271,12 +271,6 @@ type RunsFilterV2 struct {
 	Query       *string             `json:"query,omitempty"`
 }
 
-type RunsV2Connection struct {
-	Edges      []*FunctionRunV2Edge `json:"edges"`
-	PageInfo   *PageInfo            `json:"pageInfo"`
-	TotalCount int                  `json:"totalCount"`
-}
-
 type RunsV2OrderBy struct {
 	Field     RunsV2OrderByField   `json:"field"`
 	Direction RunsOrderByDirection `json:"direction"`

--- a/pkg/coreapi/graph/resolvers/connect_v1.resolver.go
+++ b/pkg/coreapi/graph/resolvers/connect_v1.resolver.go
@@ -3,7 +3,6 @@ package resolvers
 import (
 	"context"
 	"fmt"
-	"github.com/99designs/gqlgen/graphql"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/pkg/cqrs"
@@ -26,23 +25,8 @@ func (r *connectV1workerConnectionConnResolver) App(ctx context.Context, obj *mo
 	return r.Data.GetAppByID(ctx, *obj.AppID)
 }
 
-func (r *connectV1workerConnectionResolver) TotalCount(ctx context.Context, obj *models.ConnectV1WorkerConnectionsConnection) (int, error) {
-	cursor, ok := graphql.GetFieldContext(ctx).Parent.Args["after"].(*string)
-	if !ok {
-		return 0, fmt.Errorf("failed to access cursor")
-	}
-
-	orderBy, ok := graphql.GetFieldContext(ctx).Parent.Args["orderBy"].([]*models.ConnectV1WorkerConnectionsOrderBy)
-	if !ok {
-		return 0, fmt.Errorf("failed to retrieve order")
-	}
-
-	filter, ok := graphql.GetFieldContext(ctx).Parent.Args["filter"].(models.ConnectV1WorkerConnectionsFilter)
-	if !ok {
-		return 0, fmt.Errorf("failed to access query filter")
-	}
-
-	opts := toWorkerConnectionsQueryOpt(0, cursor, orderBy, filter)
+func (r *connectV1workerConnectionResolver) TotalCount(ctx context.Context, obj *models.WorkerConnectionsConnection) (int, error) {
+	opts := toWorkerConnectionsQueryOpt(0, obj.After, obj.OrderBy, obj.Filter)
 	count, err := r.Data.GetWorkerConnectionsCount(ctx, opts)
 	if err != nil {
 		return 0, fmt.Errorf("error retrieving count for worker connections: %w", err)
@@ -51,7 +35,7 @@ func (r *connectV1workerConnectionResolver) TotalCount(ctx context.Context, obj 
 	return count, nil
 }
 
-func (r *queryResolver) WorkerConnections(ctx context.Context, first int, after *string, orderBy []*models.ConnectV1WorkerConnectionsOrderBy, filter models.ConnectV1WorkerConnectionsFilter) (*models.ConnectV1WorkerConnectionsConnection, error) {
+func (r *queryResolver) WorkerConnections(ctx context.Context, first int, after *string, orderBy []*models.ConnectV1WorkerConnectionsOrderBy, filter models.ConnectV1WorkerConnectionsFilter) (*models.WorkerConnectionsConnection, error) {
 	opts := toWorkerConnectionsQueryOpt(first, after, orderBy, filter)
 	workerConns, err := r.Data.GetWorkerConnections(ctx, opts)
 	if err != nil {
@@ -86,9 +70,12 @@ func (r *queryResolver) WorkerConnections(ctx context.Context, first int, after 
 		EndCursor:   ecursor,
 	}
 
-	return &models.ConnectV1WorkerConnectionsConnection{
+	return &models.WorkerConnectionsConnection{
 		Edges:    edges,
 		PageInfo: pageInfo,
+		After:    after,
+		Filter:   filter,
+		OrderBy:  orderBy,
 	}, nil
 }
 


### PR DESCRIPTION
## Description

Removes accessing the GraphQL resolver parent.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
