### PR TITLE
Omit error code if unset

### DIFF
--- a/pkg/publicerr/publicerr.go
+++ b/pkg/publicerr/publicerr.go
@@ -81,7 +81,7 @@ func Errorf(status int, message string, opts ...interface{}) error {
 // in `gql.go` we create an ErrorPresenter middleware item which checks to see if the error
 // is a publicerr.Error and, if so, shows the friendly error directly.
 type Error struct {
-	Code string `json:"code"`
+	Code string `json:"code,omitempty"`
 	// Message represents the message to display
 	Message string `json:"error"`
 	// Data is a KV map of extra error data.
@@ -122,7 +122,7 @@ func HTTPErr(status int) Error {
 	if m == "" {
 		m = http.StatusText(http.StatusInternalServerError)
 	}
-	
+
 	return Error{
 		Message: m,
 		Status:  status,


### PR DESCRIPTION
## Description

When the code is missing, we now encode an empty string. We should just omit the field in this case, matching the previous structure.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
