### PR TITLE
Display better message when in-band sync response is unsigned

### DIFF
--- a/ui/apps/dashboard/src/codedError.ts
+++ b/ui/apps/dashboard/src/codedError.ts
@@ -22,6 +22,7 @@ const codes = [
   'http_unsupported_protocol',
   'no_functions',
   'not_sdk',
+  'response_not_signed',
   'server_kind_mismatch',
   'sig_verification_failed',
   'signing_key_invalid',

--- a/ui/apps/dashboard/src/components/SyncFailure/utils.ts
+++ b/ui/apps/dashboard/src/components/SyncFailure/utils.ts
@@ -26,6 +26,7 @@ const messages = {
   missing_signing_key: 'The app is not using a signing key.',
   no_functions: 'No functions found in the app.',
   not_sdk: 'The URL is not hosting an Inngest SDK',
+  response_not_signed: 'SDK response was not signed. Is it in dev mode?',
   server_kind_mismatch: 'The app is not in cloud mode',
   sig_verification_failed:
     'Signature verification failed. Is your app using the correct signing key?',


### PR DESCRIPTION
## Description
<img width="666" alt="image" src="https://github.com/user-attachments/assets/6142d1c6-44be-41dd-b01f-6ab76c60ac83" />

## Context
In-band syncs require the SDK response to be signed. The only known case when it isn't signed is when the SDK is in "dev mode".