### PR TITLE
Add missing color tokens to metrics

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/manage/[ingestKeys]/page.tsx
@@ -7,7 +7,7 @@ export default function EventKeysPage() {
 
   return (
     <div className="flex h-full w-full items-center justify-center">
-      <h2 className="text-sm font-semibold text-gray-900">
+      <h2 className="text-subtle text-sm font-semibold">
         {'Select a ' + currentContent?.type + ' on the left.'}
       </h2>
     </div>

--- a/ui/apps/dashboard/src/components/Billing/Usage/transformData.ts
+++ b/ui/apps/dashboard/src/components/Billing/Usage/transformData.ts
@@ -7,7 +7,7 @@ import { type TimeSeries } from '@/gql/graphql';
 import tailwindConfig from '../../../../tailwind.config';
 
 const {
-  theme: { textColor, colors, borderColor },
+  theme: { textColor, colors, borderColor, backgroundColor },
 } = resolveConfig(tailwindConfig);
 
 type ChartPoint = {
@@ -94,6 +94,9 @@ export function createChartOptions(
     tooltip: {
       trigger: 'axis',
       axisPointer: { type: 'shadow' },
+      backgroundColor: resolveColor(backgroundColor.canvasBase, dark),
+      borderColor: resolveColor(borderColor.subtle, dark),
+      textStyle: { color: resolveColor(textColor.basis, dark) },
     },
     legend: {
       type: 'scroll',

--- a/ui/apps/dashboard/src/components/Metrics/Concurrency.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/Concurrency.tsx
@@ -3,12 +3,17 @@ import { Info } from '@inngest/components/Info/Info';
 import { Link } from '@inngest/components/Link/Link';
 import { resolveColor } from '@inngest/components/utils/colors';
 import { isDark } from '@inngest/components/utils/theme';
+import resolveConfig from 'tailwindcss/resolveConfig';
 
 import type { VolumeMetricsQuery } from '@/gql/graphql';
+import tailwindConfig from '../../../tailwind.config';
 import type { EntityLookup } from './Dashboard';
 import { getLineChartOptions, getXAxis, lineColors, seriesOptions } from './utils';
 
 const zeroID = '00000000-0000-0000-0000-000000000000';
+const {
+  theme: { borderColor },
+} = resolveConfig(tailwindConfig);
 
 export const mapConcurrency = (
   { stepRunning: { metrics: runningMetrics } }: VolumeMetricsQuery['workspace'],
@@ -19,6 +24,9 @@ export const mapConcurrency = (
 
   const metrics = {
     yAxis: {
+      splitLine: {
+        lineStyle: { color: resolveColor(borderColor.subtle, dark, '#E2E2E2') },
+      },
       max: ({ max }: { max: number }) =>
         concurrencyLimit !== undefined && max > concurrencyLimit
           ? max

--- a/ui/apps/dashboard/src/components/Metrics/FunctionStatus.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/FunctionStatus.tsx
@@ -9,7 +9,7 @@ import type { FunctionStatusMetricsQuery, ScopedMetricsResponse } from '@/gql/gr
 import tailwindConfig from '../../../tailwind.config';
 
 const {
-  theme: { backgroundColor, colors },
+  theme: { backgroundColor, colors, textColor },
 } = resolveConfig(tailwindConfig);
 
 export type MetricsData = {
@@ -61,18 +61,23 @@ const mapMetrics = (totals: FunctionTotals) => {
   ];
 };
 
-const holeLabel = {
-  rich: {
-    name: {
-      fontSize: 12,
-      lineHeight: 16,
+const holeLabel = () => {
+  const dark = isDark();
+  return {
+    rich: {
+      name: {
+        fontSize: 12,
+        lineHeight: 16,
+        color: resolveColor(textColor.basis, dark),
+      },
+      value: {
+        fontSize: 16,
+        lineHeight: 20,
+        fontWeight: 500,
+        color: resolveColor(textColor.basis, dark),
+      },
     },
-    value: {
-      fontSize: 16,
-      lineHeight: 20,
-      fontWeight: 500,
-    },
-  },
+  };
 };
 
 const totalRuns = (totals: Array<{ value: number }>) =>
@@ -92,6 +97,7 @@ const getChartOptions = (data: PieChartData, loading: boolean = false): ChartPro
       top: 'center',
       icon: 'circle',
       selectedMode: true,
+      textStyle: { fontSize: '12px', color: resolveColor(textColor.basis, dark) },
       formatter: (name: string) =>
         [
           name,
@@ -121,7 +127,7 @@ const getChartOptions = (data: PieChartData, loading: boolean = false): ChartPro
               ? [`{name| Loading}`, `{value| ...}`].join('\n')
               : [`{name| Total runs}`, `{value| ${sum}}`].join('\n');
           },
-          ...holeLabel,
+          ...holeLabel(),
         },
         emphasis: {
           label: {
@@ -131,7 +137,7 @@ const getChartOptions = (data: PieChartData, loading: boolean = false): ChartPro
             },
             backgroundColor: resolveColor(backgroundColor.canvasBase, dark, '#fff'),
             width: 80,
-            ...holeLabel,
+            ...holeLabel(),
           },
         },
         labelLine: {

--- a/ui/apps/dashboard/src/components/Metrics/utils.ts
+++ b/ui/apps/dashboard/src/components/Metrics/utils.ts
@@ -156,6 +156,9 @@ export const getLineChartOptions = (
     yAxis: {
       type: 'value',
       minInterval: 1,
+      splitLine: {
+        lineStyle: { color: resolveColor(borderColor.subtle, dark, '#E2E2E2') },
+      },
     },
     ...data,
   };

--- a/ui/apps/dashboard/src/components/Metrics/utils.ts
+++ b/ui/apps/dashboard/src/components/Metrics/utils.ts
@@ -111,13 +111,16 @@ export const getLineChartOptions = (
   data: Partial<ChartProps['option']>,
   legendData?: LegendComponentOption['data']
 ): ChartProps['option'] => {
+  const dark = isDark();
   return {
     tooltip: {
       trigger: 'axis',
       renderMode: 'html',
       enterable: true,
       position: 'top',
-
+      backgroundColor: resolveColor(backgroundColor.canvasBase, dark),
+      borderColor: resolveColor(borderColor.subtle, dark),
+      textStyle: { color: resolveColor(textColor.basis, dark) },
       //
       // Off by default because we don't like the tooltip
       // behavior for chart groups. We toggle this programmatically
@@ -140,7 +143,7 @@ export const getLineChartOptions = (
       icon: 'circle',
       itemWidth: 10,
       itemHeight: 10,
-      textStyle: { fontSize: '12px' },
+      textStyle: { fontSize: '12px', color: resolveColor(textColor.basis, dark) },
       data: legendData,
     },
     grid: {

--- a/ui/apps/dashboard/src/components/Navigation/Profile.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Profile.tsx
@@ -38,12 +38,17 @@ export const Profile = ({ collapsed, profile }: { collapsed: boolean; profile: P
           {!collapsed && (
             <div className="ml-2 flex flex-col items-start justify-start overflow-hidden">
               <div
-                className="text-subtle leading-1 max-w-full overflow-hidden text-ellipsis text-nowrap text-sm"
+                className="text-subtle leading-1 max-w-full truncate text-sm"
                 title={profile.orgName}
               >
                 {profile.orgName}
               </div>
-              <div className="text-muted text-xs leading-4">{profile.displayName}</div>
+              <div
+                className="text-muted max-w-full truncate text-xs leading-4"
+                title={profile.displayName}
+              >
+                {profile.displayName}
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Description
- Specify colors for legends, pie chart and y-axis split lines

<img width="1509" alt="Screenshot 2025-02-18 at 18 22 20" src="https://github.com/user-attachments/assets/32b65a95-f8e0-4a9c-87b1-81f20392f9c0" />


## Motivation
For dark mode implementation

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
