### PR TITLE
copy: refer to metrics' "delay" instead of "freshness"

### DIFF
--- a/ui/apps/dashboard/src/components/Billing/Addons/MetricsExportEntitlementValue.tsx
+++ b/ui/apps/dashboard/src/components/Billing/Addons/MetricsExportEntitlementValue.tsx
@@ -41,7 +41,7 @@ export default function MetricsExportEntitlementValue({
           className="border-subtle"
           style={{ borderLeftWidth: '1px', borderRightWidth: '1px' }}
         ></span>
-        <span className="text-muted">Freshness</span>
+        <span className="text-muted">Delay</span>
         <span className="font-medium">{entitlementSecondsToStr(freshnessSeconds)}</span>
       </div>
     </>

--- a/ui/apps/dashboard/src/components/Integration/MetricsExportEntitlementsBanner.tsx
+++ b/ui/apps/dashboard/src/components/Integration/MetricsExportEntitlementsBanner.tsx
@@ -55,7 +55,7 @@ export default function MetricsExportEntitlementBanner({
             <span className="text-light inline-block" style={{ marginLeft: '2.5rem' }}>
               <RiHistoryLine className="h-4 w-4" style={{ marginTop: '0.24rem' }} />
             </span>
-            <span className="text-muted inline-block">Freshness</span>
+            <span className="text-muted inline-block">Delay</span>
             <span className="inline-block font-medium" style={{ marginLeft: '0.5rem' }}>
               {entitlementSecondsToStr(freshnessSeconds)}
             </span>


### PR DESCRIPTION
## Description

Per @djfarrelly's feedback on https://github.com/inngest/inngest/pull/2190 .

## Issues

- closes: https://linear.app/inngest/issue/INN-4502/copy-change-freshness-to-delay

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.
