### PR TITLE
Enforce max. apps per connection entitlement during connect

### DIFF
--- a/pkg/connect/auth/auth.go
+++ b/pkg/connect/auth/auth.go
@@ -7,13 +7,19 @@ import (
 	"time"
 )
 
+type Entitlements struct {
+	ConnectionAllowed bool `json:"-"`
+	AppsPerConnection int  `json:"appsPerConnection"`
+}
+
 type Response struct {
-	AccountID uuid.UUID
-	EnvID     uuid.UUID
+	AccountID    uuid.UUID
+	EnvID        uuid.UUID
+	Entitlements Entitlements
 }
 
 type Handler func(context.Context, *connect.WorkerConnectRequestData) (*Response, error)
 
 type SessionTokenSigner interface {
-	SignSessionToken(accountId uuid.UUID, envId uuid.UUID, expireAfter time.Duration) (string, error)
+	SignSessionToken(accountId uuid.UUID, envId uuid.UUID, expireAfter time.Duration, entitlements Entitlements) (string, error)
 }

--- a/pkg/connect/auth/auth.go
+++ b/pkg/connect/auth/auth.go
@@ -13,13 +13,16 @@ type Entitlements struct {
 }
 
 type Response struct {
-	AccountID    uuid.UUID
-	EnvID        uuid.UUID
+	AccountID uuid.UUID
+	EnvID     uuid.UUID
+
+	// Entitlements are included in short-lived token
 	Entitlements Entitlements
 }
 
 type Handler func(context.Context, *connect.WorkerConnectRequestData) (*Response, error)
 
 type SessionTokenSigner interface {
+	// SignSessionToken issues a short-lived session token including entitlements
 	SignSessionToken(accountId uuid.UUID, envId uuid.UUID, expireAfter time.Duration, entitlements Entitlements) (string, error)
 }

--- a/pkg/connect/auth/jwt_test.go
+++ b/pkg/connect/auth/jwt_test.go
@@ -13,7 +13,7 @@ func TestSessionToken(t *testing.T) {
 	secret := []byte("this-is-a-very-strong-secret")
 
 	t.Run("should accept valid token", func(t *testing.T) {
-		created, err := signSessionToken(secret, accountId, envId, DefaultExpiry)
+		created, err := signSessionToken(secret, accountId, envId, DefaultExpiry, Entitlements{})
 		require.NoError(t, err)
 
 		response, err := VerifySessionToken(secret, created)
@@ -24,7 +24,7 @@ func TestSessionToken(t *testing.T) {
 	})
 
 	t.Run("should reject expired token", func(t *testing.T) {
-		created, err := signSessionToken(secret, accountId, envId, time.Millisecond)
+		created, err := signSessionToken(secret, accountId, envId, time.Millisecond, Entitlements{})
 		require.NoError(t, err)
 
 		<-time.After(time.Millisecond * 5)
@@ -39,7 +39,7 @@ func TestSessionToken(t *testing.T) {
 	t.Run("should reject token with invalid sig", func(t *testing.T) {
 		secretForged := []byte("this-is-the-wrong-secret")
 
-		created, err := signSessionToken(secretForged, accountId, envId, DefaultExpiry)
+		created, err := signSessionToken(secretForged, accountId, envId, DefaultExpiry, Entitlements{})
 		require.NoError(t, err)
 
 		response, err := VerifySessionToken(secret, created)

--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -30,7 +30,10 @@ const (
 	pkgName = "connect.gateway"
 )
 
-const DefaultAppsPerConnection = 10
+const (
+	DefaultAppsPerConnection = 10
+	MaxAppsPerConnection     = 100
+)
 
 func (c *connectGatewaySvc) closeWithConnectError(ws *websocket.Conn, serr *SocketError) {
 	// reason must be limited to 125 bytes and should not be dynamic,

--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -30,7 +30,7 @@ const (
 	pkgName = "connect.gateway"
 )
 
-const MaxAppsPerConnection = 50
+const MaxAppsPerConnection = 10
 
 func (c *connectGatewaySvc) closeWithConnectError(ws *websocket.Conn, serr *SocketError) {
 	// reason must be limited to 125 bytes and should not be dynamic,

--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -777,15 +777,8 @@ func (c *connectionHandler) establishConnection(ctx context.Context) (*state.Con
 
 	{
 		limit := MaxAppsPerConnection
-		if c.svc.entitlementRetriever != nil {
-			limit, err = c.svc.entitlementRetriever.AppsPerConnection(ctx, authResp.AccountID)
-			if err != nil {
-				return nil, &SocketError{
-					SysCode:    syscode.CodeConnectInternal,
-					StatusCode: websocket.StatusInternalError,
-					Msg:        "Internal error",
-				}
-			}
+		if authResp.Entitlements.AppsPerConnection != 0 {
+			limit = authResp.Entitlements.AppsPerConnection
 		}
 
 		if len(initialMessageData.Apps) > limit {

--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -30,7 +30,7 @@ const (
 	pkgName = "connect.gateway"
 )
 
-const MaxAppsPerConnection = 10
+const DefaultAppsPerConnection = 10
 
 func (c *connectGatewaySvc) closeWithConnectError(ws *websocket.Conn, serr *SocketError) {
 	// reason must be limited to 125 bytes and should not be dynamic,
@@ -776,7 +776,7 @@ func (c *connectionHandler) establishConnection(ctx context.Context) (*state.Con
 	}
 
 	{
-		limit := MaxAppsPerConnection
+		limit := DefaultAppsPerConnection
 		if authResp.Entitlements.AppsPerConnection != 0 {
 			limit = authResp.Entitlements.AppsPerConnection
 		}

--- a/pkg/connect/rest/v0/v0.go
+++ b/pkg/connect/rest/v0/v0.go
@@ -21,7 +21,7 @@ type Opts struct {
 	Signer                  auth.SessionTokenSigner
 	RequestAuther           RequestAuther
 	ConnectGatewayRetriever ConnectGatewayRetriever
-	ConnectionLimiter       ConnectionLimiter
+	EntitlementProvider     EntitlementProvider
 	ConditionalTracer       trace.ConditionalTracer
 
 	Dev bool
@@ -31,8 +31,8 @@ type RequestAuther interface {
 	AuthenticateRequest(ctx context.Context, hashedSigningKey string, env string) (*auth.Response, error)
 }
 
-type ConnectionLimiter interface {
-	CheckConnectionLimit(ctx context.Context, resp *auth.Response) (bool, error)
+type EntitlementProvider interface {
+	RetrieveConnectEntitlements(ctx context.Context, resp *auth.Response) (auth.Entitlements, error)
 }
 
 type RetrieveGatewayOpts struct {

--- a/pkg/connect/service.go
+++ b/pkg/connect/service.go
@@ -60,6 +60,10 @@ func (c *connectionCounter) Wait() {
 	c.waiter.Wait()
 }
 
+type ConnectEntitlementRetriever interface {
+	AppsPerConnection(ctx context.Context, accountId uuid.UUID) (int, error)
+}
+
 type connectGatewaySvc struct {
 	gatewayPublicPort int
 
@@ -76,11 +80,12 @@ type connectGatewaySvc struct {
 
 	runCtx context.Context
 
-	auther       auth.Handler
-	stateManager state.StateManager
-	receiver     pubsub.RequestReceiver
-	appLoader    ConnectAppLoader
-	apiBaseUrl   string
+	auther               auth.Handler
+	stateManager         state.StateManager
+	receiver             pubsub.RequestReceiver
+	appLoader            ConnectAppLoader
+	apiBaseUrl           string
+	entitlementRetriever ConnectEntitlementRetriever
 
 	hostname string
 
@@ -175,6 +180,12 @@ func WithApiBaseUrl(url string) gatewayOpt {
 func WithGroupName(groupName string) gatewayOpt {
 	return func(svc *connectGatewaySvc) {
 		svc.groupName = groupName
+	}
+}
+
+func WithEntitlementRetriever(r ConnectEntitlementRetriever) gatewayOpt {
+	return func(svc *connectGatewaySvc) {
+		svc.entitlementRetriever = r
 	}
 }
 

--- a/pkg/connect/service.go
+++ b/pkg/connect/service.go
@@ -18,7 +18,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/connect/pubsub"
 	"github.com/inngest/inngest/pkg/connect/state"
-	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/oklog/ulid/v2"
 	"golang.org/x/sync/errgroup"
@@ -31,11 +30,6 @@ const (
 )
 
 type gatewayOpt func(*connectGatewaySvc)
-
-type ConnectAppLoader interface {
-	// GetAppByName returns an app by name
-	GetAppByName(ctx context.Context, envID uuid.UUID, name string) (*cqrs.App, error)
-}
 
 type connectionCounter struct {
 	count  uint64
@@ -80,12 +74,10 @@ type connectGatewaySvc struct {
 
 	runCtx context.Context
 
-	auther               auth.Handler
-	stateManager         state.StateManager
-	receiver             pubsub.RequestReceiver
-	appLoader            ConnectAppLoader
-	apiBaseUrl           string
-	entitlementRetriever ConnectEntitlementRetriever
+	auther       auth.Handler
+	stateManager state.StateManager
+	receiver     pubsub.RequestReceiver
+	apiBaseUrl   string
 
 	hostname string
 
@@ -141,12 +133,6 @@ func WithRequestReceiver(r pubsub.RequestReceiver) gatewayOpt {
 	}
 }
 
-func WithAppLoader(l ConnectAppLoader) gatewayOpt {
-	return func(svc *connectGatewaySvc) {
-		svc.appLoader = l
-	}
-}
-
 func WithLifeCycles(lifecycles []ConnectGatewayLifecycleListener) gatewayOpt {
 	return func(svc *connectGatewaySvc) {
 		svc.lifecycles = lifecycles
@@ -180,12 +166,6 @@ func WithApiBaseUrl(url string) gatewayOpt {
 func WithGroupName(groupName string) gatewayOpt {
 	return func(svc *connectGatewaySvc) {
 		svc.groupName = groupName
-	}
-}
-
-func WithEntitlementRetriever(r ConnectEntitlementRetriever) gatewayOpt {
-	return func(svc *connectGatewaySvc) {
-		svc.entitlementRetriever = r
 	}
 }
 

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -436,7 +436,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			RequestAuther:           ds,
 			ConnectGatewayRetriever: ds,
 			Dev:                     true,
-			ConnectionLimiter:       ds,
+			EntitlementProvider:     ds,
 			ConditionalTracer:       conditionalTracer,
 		},
 	})
@@ -448,7 +448,6 @@ func start(ctx context.Context, opts StartOpts) error {
 		connect.WithConnectionStateManager(connectionManager),
 		connect.WithRequestReceiver(gatewayProxy),
 		connect.WithGatewayAuthHandler(auth.NewJWTAuthHandler(consts.DevServerConnectJwtSecret)),
-		connect.WithAppLoader(dbcqrs),
 		connect.WithDev(),
 		connect.WithGatewayPublicPort(opts.ConnectGatewayPort),
 		connect.WithApiBaseUrl(fmt.Sprintf("http://127.0.0.1:%d", opts.Config.EventAPI.Port)),

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -118,7 +118,9 @@ func New(ctx context.Context, opts StartOpts) error {
 }
 
 func start(ctx context.Context, opts StartOpts) error {
-	db, err := base_cqrs.New(base_cqrs.BaseCQRSOptions{InMemory: true})
+	db, err := base_cqrs.New(base_cqrs.BaseCQRSOptions{
+		PostgresURI: "postgresql://postgres:postgres@localhost:5432",
+	})
 	if err != nil {
 		return err
 	}
@@ -128,7 +130,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	}
 
 	// Initialize the devserver
-	dbDriver := "sqlite"
+	dbDriver := "postgres"
 	dbcqrs := base_cqrs.NewCQRS(db, dbDriver)
 	hd := base_cqrs.NewHistoryDriver(db, dbDriver)
 	loader := dbcqrs.(state.FunctionLoader)
@@ -146,7 +148,10 @@ func start(ctx context.Context, opts StartOpts) error {
 		return err
 	}
 
-	connectRc, err := createInmemoryRedis(ctx, opts.Tick)
+	connectRc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{"127.0.0.1:6379"},
+		DisableCache: true,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -118,9 +118,7 @@ func New(ctx context.Context, opts StartOpts) error {
 }
 
 func start(ctx context.Context, opts StartOpts) error {
-	db, err := base_cqrs.New(base_cqrs.BaseCQRSOptions{
-		PostgresURI: "postgresql://postgres:postgres@localhost:5432",
-	})
+	db, err := base_cqrs.New(base_cqrs.BaseCQRSOptions{InMemory: true})
 	if err != nil {
 		return err
 	}
@@ -130,7 +128,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	}
 
 	// Initialize the devserver
-	dbDriver := "postgres"
+	dbDriver := "sqlite"
 	dbcqrs := base_cqrs.NewCQRS(db, dbDriver)
 	hd := base_cqrs.NewHistoryDriver(db, dbDriver)
 	loader := dbcqrs.(state.FunctionLoader)
@@ -148,10 +146,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		return err
 	}
 
-	connectRc, err := rueidis.NewClient(rueidis.ClientOption{
-		InitAddress:  []string{"127.0.0.1:6379"},
-		DisableCache: true,
-	})
+	connectRc, err := createInmemoryRedis(ctx, opts.Tick)
 	if err != nil {
 		return err
 	}

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -648,8 +648,10 @@ func (d *devserver) AuthenticateRequest(_ context.Context, _, _ string) (*auth.R
 	}, nil
 }
 
-func (d *devserver) CheckConnectionLimit(_ context.Context, _ *auth.Response) (bool, error) {
-	return true, nil
+func (d *devserver) RetrieveConnectEntitlements(_ context.Context, _ *auth.Response) (auth.Entitlements, error) {
+	return auth.Entitlements{
+		ConnectionAllowed: true,
+	}, nil
 }
 
 func (d *devserver) RetrieveGateway(_ context.Context, opts v0.RetrieveGatewayOpts) (string, *url.URL, error) {


### PR DESCRIPTION
## Description

This PR adds entitlement enforcement for max. apps per connection. We default to 10 if no limit provider implementation is provided.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
