### PR TITLE
Add startTime to Dev Server workers requests

### DIFF
--- a/ui/apps/dev-server-ui/src/coreapi.ts
+++ b/ui/apps/dev-server-ui/src/coreapi.ts
@@ -500,9 +500,13 @@ export const GET_WORKER_CONNECTIONS = gql`
 `;
 
 export const COUNT_WORKER_CONNECTIONS = gql`
-  query CountWorkerConnections($appID: UUID!, $status: [ConnectV1ConnectionStatus!]) {
+  query CountWorkerConnections(
+    $appID: UUID!
+    $startTime: Time!
+    $status: [ConnectV1ConnectionStatus!]
+  ) {
     workerConnections(
-      filter: { appIDs: [$appID], status: $status, timeField: CONNECTED_AT }
+      filter: { appIDs: [$appID], from: $startTime, status: $status, timeField: CONNECTED_AT }
       orderBy: [{ field: CONNECTED_AT, direction: DESC }]
     ) {
       totalCount

--- a/ui/apps/dev-server-ui/src/hooks/useGetWorkerCount.ts
+++ b/ui/apps/dev-server-ui/src/hooks/useGetWorkerCount.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { getTimestampDaysAgo } from '@inngest/components/utils/date';
 
 import { client } from '@/store/baseApi';
 import {
@@ -14,9 +15,11 @@ type QueryVariables = {
 
 export function useGetWorkerCount() {
   return useCallback(async ({ appID, status }: QueryVariables) => {
+    const startTime = getTimestampDaysAgo({ currentDate: new Date(), days: 1 }).toISOString();
     const data: CountWorkerConnectionsQuery = await client.request(CountWorkerConnectionsDocument, {
       appID: appID,
       status,
+      startTime,
     });
 
     const workersData = data.workerConnections;

--- a/ui/apps/dev-server-ui/src/hooks/useGetWorkers.ts
+++ b/ui/apps/dev-server-ui/src/hooks/useGetWorkers.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { getTimestampDaysAgo } from '@inngest/components/utils/date';
 import { convertWorkerStatus } from '@inngest/components/utils/workerParser';
 
 import { client } from '@/store/baseApi';
@@ -20,10 +21,11 @@ type QueryVariables = {
 
 export function useGetWorkers() {
   return useCallback(async ({ appID, orderBy, cursor, pageSize, status }: QueryVariables) => {
+    const startTime = getTimestampDaysAgo({ currentDate: new Date(), days: 1 }).toISOString();
     const data: GetWorkerConnectionsQuery = await client.request(GetWorkerConnectionsDocument, {
       timeField: ConnectV1WorkerConnectionsOrderByField.ConnectedAt,
       orderBy,
-      startTime: null,
+      startTime,
       appID: appID,
       status,
       cursor,

--- a/ui/apps/dev-server-ui/src/store/generated.ts
+++ b/ui/apps/dev-server-ui/src/store/generated.ts
@@ -920,6 +920,7 @@ export type GetWorkerConnectionsQuery = { __typename?: 'Query', workerConnection
 
 export type CountWorkerConnectionsQueryVariables = Exact<{
   appID: Scalars['UUID'];
+  startTime: Scalars['Time'];
   status: InputMaybe<Array<ConnectV1ConnectionStatus> | ConnectV1ConnectionStatus>;
 }>;
 
@@ -1373,9 +1374,9 @@ export const GetWorkerConnectionsDocument = `
 }
     `;
 export const CountWorkerConnectionsDocument = `
-    query CountWorkerConnections($appID: UUID!, $status: [ConnectV1ConnectionStatus!]) {
+    query CountWorkerConnections($appID: UUID!, $startTime: Time!, $status: [ConnectV1ConnectionStatus!]) {
   workerConnections(
-    filter: {appIDs: [$appID], status: $status, timeField: CONNECTED_AT}
+    filter: {appIDs: [$appID], from: $startTime, status: $status, timeField: CONNECTED_AT}
     orderBy: [{field: CONNECTED_AT, direction: DESC}]
   ) {
     totalCount


### PR DESCRIPTION
## Description
- Following the same approach as Cloud, fetch workers data only in the last 24h

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [X] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
