### PR TITLE
Prefer newest connected version by default

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -233,10 +233,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 		defer func() {
 			// This is a transactional operation, it should always complete regardless of context cancellation
 			err := c.stateManager.DeleteConnection(context.Background(), conn.EnvID, conn.ConnectionId)
-			switch err {
-			case nil:
-				// no-op
-			default:
+			if err != nil {
 				ch.log.Error("error deleting connection from state", "error", err)
 			}
 

--- a/pkg/connect/group.go
+++ b/pkg/connect/group.go
@@ -13,6 +13,7 @@ import (
 	"github.com/inngest/inngest/pkg/sdk"
 	"github.com/inngest/inngest/pkg/syscode"
 	"github.com/inngest/inngest/proto/gen/connect/v1"
+	"time"
 )
 
 func workerGroupHashFromConnRequest(req *connect.WorkerConnectRequestData, authResp *auth.Response, appConfig *connect.AppConfiguration, functionHash []byte) (string, error) {
@@ -59,6 +60,7 @@ func functionConfigHash(appConfig *connect.AppConfiguration) ([]byte, error) {
 	return functionHash, nil
 }
 
+// NewWorkerGroupFromConnRequest instantiates but does not store WorkerGroup for a new session.
 func NewWorkerGroupFromConnRequest(
 	ctx context.Context,
 	req *connect.WorkerConnectRequestData,
@@ -122,6 +124,7 @@ func NewWorkerGroupFromConnRequest(
 			SyncToken: req.AuthData.SyncToken,
 			AppConfig: appConfig,
 		},
+		CreatedAt: time.Now(),
 	}
 
 	return workerGroup, nil

--- a/pkg/connect/router.go
+++ b/pkg/connect/router.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"gonum.org/v1/gonum/stat/sampleuv"
 	"log/slog"
+	"slices"
 	"time"
 )
 
@@ -199,6 +200,11 @@ func (c *connectRouterSvc) Run(ctx context.Context) error {
 
 }
 
+type connWithGroup struct {
+	conn  *connect.ConnMetadata
+	group *state.WorkerGroup
+}
+
 func (c *connectRouterSvc) getSuitableConnection(ctx context.Context, envID uuid.UUID, appID uuid.UUID, appName string, fnSlug string, log *slog.Logger) (*connect.ConnMetadata, error) {
 	conns, err := c.stateManager.GetConnectionsByAppID(ctx, envID, appID)
 	if err != nil {
@@ -209,10 +215,23 @@ func (c *connectRouterSvc) getSuitableConnection(ctx context.Context, envID uuid
 		return nil, ErrNoHealthyConnection
 	}
 
-	healthy := make([]*connect.ConnMetadata, 0, len(conns))
+	healthy := make([]connWithGroup, 0, len(conns))
 	for _, conn := range conns {
-		if c.isHealthy(ctx, envID, appID, fnSlug, conn, log) {
-			healthy = append(healthy, conn)
+		res := isHealthy(ctx, c.stateManager, envID, appID, fnSlug, conn, log)
+		if res.isHealthy {
+			healthy = append(healthy, connWithGroup{
+				conn:  conn,
+				group: res.workerGroup,
+			})
+			continue
+		}
+
+		if res.shouldDeleteUnhealthyGateway {
+			c.cleanupUnhealthyGateway(conn, log)
+		}
+
+		if res.shouldDeleteUnhealthyConnection {
+			c.cleanupUnhealthyConnection(envID, conn, log)
 		}
 	}
 
@@ -220,42 +239,91 @@ func (c *connectRouterSvc) getSuitableConnection(ctx context.Context, envID uuid
 		return nil, ErrNoHealthyConnection
 	}
 
-	weights := make([]float64, len(healthy))
-	for i := range healthy {
-		// TODO Calculate weights based on factors like version
-		weights[i] = float64(10)
+	return pickConnection(healthy, c.rnd)
+}
+
+func (c *connectRouterSvc) cleanupUnhealthyGateway(conn *connect.ConnMetadata, log *slog.Logger) {
+	gatewayId, err := ulid.Parse(conn.GatewayId)
+	if err != nil {
+		log.Error("could not clean up unhealthy gateway, invalid gateway ID", "gateway_id", conn.GatewayId, "err", err)
+		return
 	}
 
-	w := sampleuv.NewWeighted(weights, c.rnd)
+	// Clean up unhealthy gateway
+	err = c.stateManager.DeleteGateway(context.Background(), gatewayId)
+	if err != nil {
+		c.logger.Error("could not clean up inactive gateway", "gateway_id", conn.GatewayId, "err", err)
+	}
+}
+
+func (c *connectRouterSvc) cleanupUnhealthyConnection(envID uuid.UUID, conn *connect.ConnMetadata, log *slog.Logger) {
+	connId, err := ulid.Parse(conn.Id)
+	if err != nil {
+		log.Error("could not clean up inactive connection, invalid connection ID", "conn_id", conn.Id, "err", err)
+		return
+	}
+
+	// Clean up unhealthy connection
+	err = c.stateManager.DeleteConnection(context.Background(), envID, connId)
+	if err != nil {
+		log.Error("could not clean up inactive connection", "conn_id", conn.Id, "err", err)
+	}
+}
+
+func pickConnection(candidates []connWithGroup, rnd *util.FrandRNG) (*connect.ConnMetadata, error) {
+	// First, sort candidate connections by CreatedAt timestamp (newest first)
+	slices.SortStableFunc(candidates, func(a, b connWithGroup) int {
+		if a.group.CreatedAt.Before(b.group.CreatedAt) {
+			return 1
+		}
+
+		return -1
+	})
+
+	// Clamp candidates
+	if len(candidates) > 5 {
+		candidates = candidates[:5]
+	}
+
+	// Get range of versions
+	oldestVersion := candidates[0].group.CreatedAt
+	newestVersion := candidates[len(candidates)-1].group.CreatedAt
+
+	timeRange := newestVersion.Sub(oldestVersion).Seconds()
+
+	weights := make([]float64, len(candidates))
+	for i, h := range candidates {
+		weight := 1.0
+
+		// Calculate weights based on factors like version
+		if !h.group.CreatedAt.IsZero() {
+			// Normalize to range [1, 10] where newer timestamps get higher weights
+			timeDiff := h.group.CreatedAt.Sub(oldestVersion).Seconds()
+			normalizedWeight := 1.0 + 9.0*(timeDiff/timeRange)
+			weight = normalizedWeight
+		}
+
+		weights[i] = weight
+	}
+
+	w := sampleuv.NewWeighted(weights, rnd)
 	idx, ok := w.Take()
 	if !ok {
 		return nil, util.ErrWeightedSampleRead
 	}
-	chosen := healthy[idx]
+	chosen := candidates[idx]
 
-	return chosen, nil
+	return chosen.conn, nil
 }
 
-func (c *connectRouterSvc) isHealthy(ctx context.Context, envID uuid.UUID, appID uuid.UUID, fnSlug string, conn *connect.ConnMetadata, log *slog.Logger) bool {
-	var shouldDeleteConnection bool
+type isHealthyRes struct {
+	isHealthy                       bool
+	shouldDeleteUnhealthyConnection bool
+	shouldDeleteUnhealthyGateway    bool
+	workerGroup                     *state.WorkerGroup
+}
 
-	defer func() {
-		if !shouldDeleteConnection {
-			return
-		}
-
-		connId, err := ulid.Parse(conn.Id)
-		if err != nil {
-			log.Error("could not clean up inactive connection, invalid connection ID", "conn_id", conn.Id, "err", err)
-		}
-
-		// Clean up unhealthy connection
-		err = c.stateManager.DeleteConnection(context.Background(), envID, connId)
-		if err != nil {
-			log.Error("could not clean up inactive connection", "conn_id", conn.Id, "err", err)
-		}
-	}()
-
+func isHealthy(ctx context.Context, stateManager state.StateManager, envID uuid.UUID, appID uuid.UUID, fnSlug string, conn *connect.ConnMetadata, log *slog.Logger) isHealthyRes {
 	log.Debug("evaluating connection", "connection_id", conn.Id, "status", conn.Status, "last_heartbeat_at", conn.LastHeartbeatAt.AsTime())
 
 	gatewayId, err := ulid.Parse(conn.GatewayId)
@@ -263,9 +331,9 @@ func (c *connectRouterSvc) isHealthy(ctx context.Context, envID uuid.UUID, appID
 		log.Error("connection gateway id could not be parsed", "err", err, "gateway_id", conn.GatewayId)
 
 		// Clean up invalid connection
-		shouldDeleteConnection = true
-
-		return false
+		return isHealthyRes{
+			shouldDeleteUnhealthyConnection: true,
+		}
 	}
 
 	if conn.Status != connect.ConnectionStatus_READY {
@@ -273,10 +341,12 @@ func (c *connectRouterSvc) isHealthy(ctx context.Context, envID uuid.UUID, appID
 
 		if conn.Status == connect.ConnectionStatus_DISCONNECTED {
 			// Clean up disconnected connection
-			shouldDeleteConnection = true
+			return isHealthyRes{
+				shouldDeleteUnhealthyConnection: true,
+			}
 		}
 
-		return false
+		return isHealthyRes{}
 	}
 
 	// If more than two consecutive heartbeats were missed, the connection is not healthy
@@ -285,25 +355,25 @@ func (c *connectRouterSvc) isHealthy(ctx context.Context, envID uuid.UUID, appID
 		log.Debug("last heartbeat is too old")
 
 		// Clean up outdated connection
-		shouldDeleteConnection = true
-
-		return false
+		return isHealthyRes{
+			shouldDeleteUnhealthyConnection: true,
+		}
 	}
 
 	groupHash, ok := conn.SyncedWorkerGroups[appID.String()]
 	if !ok {
 		log.Error("connection missing worker group hash for app", "app_id", appID.String(), "synced_worker_groups", conn.SyncedWorkerGroups)
 
-		return false
+		return isHealthyRes{}
 	}
 
-	group, err := c.stateManager.GetWorkerGroupByHash(ctx, envID, groupHash)
+	group, err := stateManager.GetWorkerGroupByHash(ctx, envID, groupHash)
 	if err != nil {
 		log.Error("could not get worker group for connection", "group_id", groupHash)
 
-		shouldDeleteConnection = true
-
-		return false
+		return isHealthyRes{
+			shouldDeleteUnhealthyConnection: true,
+		}
 	}
 
 	var hasFn bool
@@ -317,17 +387,17 @@ func (c *connectRouterSvc) isHealthy(ctx context.Context, envID uuid.UUID, appID
 	if !hasFn {
 		log.Debug("connection does not have function", "slug", fnSlug, "available", group.FunctionSlugs)
 
-		return false
+		return isHealthyRes{}
 	}
 
 	// Ensure gateway is healthy
-	gw, err := c.stateManager.GetGateway(ctx, gatewayId)
+	gw, err := stateManager.GetGateway(ctx, gatewayId)
 	if err != nil {
 		log.Error("could not get gateway", "gateway_id", gatewayId.String())
 
-		shouldDeleteConnection = true
-
-		return false
+		return isHealthyRes{
+			shouldDeleteUnhealthyConnection: true,
+		}
 	}
 
 	log.Debug("retrieved gateway for connection", "conn_id", conn.Id, "gateway_id", gatewayId.String(), "status", gw.Status, "last_heartbeat_at", gw.LastHeartbeatAt)
@@ -337,21 +407,24 @@ func (c *connectRouterSvc) isHealthy(ctx context.Context, envID uuid.UUID, appID
 	if !gatewayIsActive || gatewayHeartbeatTimedOut {
 		log.Debug("gateway is unhealthy", "conn_id", conn.Id, "gateway_id", gatewayId.String(), "status", gw.Status, "last_heartbeat_at", gw.LastHeartbeatAt)
 
+		// Only drop gateway if it's no longer heart-beating, as an inactive gateway may be draining
 		if gatewayHeartbeatTimedOut {
-			// Clean up unhealthy gateway
-			err = c.stateManager.DeleteGateway(ctx, gatewayId)
-			if err != nil {
-				c.logger.Error("could not clean up inactive gateway", "gateway_id", conn.GatewayId, "err", err)
+			return isHealthyRes{
+				shouldDeleteUnhealthyConnection: true,
+				shouldDeleteUnhealthyGateway:    true,
 			}
 		}
 
 		// Drop associated connection
-		shouldDeleteConnection = true
-
-		return false
+		return isHealthyRes{
+			shouldDeleteUnhealthyConnection: true,
+		}
 	}
 
-	return true
+	return isHealthyRes{
+		isHealthy:   true,
+		workerGroup: group,
+	}
 }
 
 func (c *connectRouterSvc) Stop(ctx context.Context) error {

--- a/pkg/connect/router.go
+++ b/pkg/connect/router.go
@@ -239,6 +239,10 @@ func (c *connectRouterSvc) getSuitableConnection(ctx context.Context, envID uuid
 		return nil, ErrNoHealthyConnection
 	}
 
+	if len(healthy) == 1 {
+		return healthy[0].conn, nil
+	}
+
 	return pickConnection(healthy, c.rnd)
 }
 

--- a/pkg/connect/router.go
+++ b/pkg/connect/router.go
@@ -300,7 +300,7 @@ func pickConnection(candidates []connWithGroup, rnd *util.FrandRNG) (*connect.Co
 		weight := 1.0
 
 		// Calculate weights based on factors like version
-		if !h.group.CreatedAt.IsZero() {
+		if !h.group.CreatedAt.IsZero() && timeRange > 0 {
 			// Normalize to range [1, 10] where newer timestamps get higher weights
 			timeDiff := h.group.CreatedAt.Sub(oldestVersion).Seconds()
 			normalizedWeight := 1.0 + 9.0*(timeDiff/timeRange)

--- a/pkg/connect/router.go
+++ b/pkg/connect/router.go
@@ -107,7 +107,7 @@ func (c *connectRouterSvc) Run(ctx context.Context) error {
 			ctx, span := c.tracer.NewSpan(ctx, "RouteExecutorRequest", accountID, envID)
 			defer span.End()
 
-			routeTo, err := c.getSuitableConnection(ctx, envID, appID, data.AppName, data.FunctionSlug, log)
+			routeTo, err := c.getSuitableConnection(ctx, envID, appID, data.FunctionSlug, log)
 			if err != nil && !errors.Is(err, ErrNoHealthyConnection) {
 				log.Error("could not retrieve suitable connection", "err", err)
 				return
@@ -205,7 +205,7 @@ type connWithGroup struct {
 	group *state.WorkerGroup
 }
 
-func (c *connectRouterSvc) getSuitableConnection(ctx context.Context, envID uuid.UUID, appID uuid.UUID, appName string, fnSlug string, log *slog.Logger) (*connect.ConnMetadata, error) {
+func (c *connectRouterSvc) getSuitableConnection(ctx context.Context, envID uuid.UUID, appID uuid.UUID, fnSlug string, log *slog.Logger) (*connect.ConnMetadata, error) {
 	conns, err := c.stateManager.GetConnectionsByAppID(ctx, envID, appID)
 	if err != nil {
 		return nil, fmt.Errorf("could not get connections by app ID: %w", err)
@@ -297,13 +297,13 @@ func pickConnection(candidates []connWithGroup, rnd *util.FrandRNG) (*connect.Co
 
 	weights := make([]float64, len(candidates))
 	for i, h := range candidates {
-		weight := 1.0
+		weight := 10.0
 
 		// Calculate weights based on factors like version
 		if !h.group.CreatedAt.IsZero() && timeRange > 0 {
 			// Normalize to range [1, 10] where newer timestamps get higher weights
 			timeDiff := h.group.CreatedAt.Sub(oldestVersion).Seconds()
-			normalizedWeight := 1.0 + 9.0*(timeDiff/timeRange)
+			normalizedWeight := 10.0 + 90.0*(timeDiff/timeRange)
 			weight = normalizedWeight
 		}
 

--- a/pkg/connect/router_test.go
+++ b/pkg/connect/router_test.go
@@ -1,0 +1,126 @@
+package connect
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/connect/auth"
+	"github.com/inngest/inngest/pkg/connect/pubsub"
+	"github.com/inngest/inngest/pkg/connect/state"
+	"github.com/inngest/inngest/pkg/sdk"
+	"github.com/inngest/inngest/pkg/telemetry/trace"
+	"github.com/inngest/inngest/pkg/util"
+	"github.com/inngest/inngest/proto/gen/connect/v1"
+	"github.com/oklog/ulid/v2"
+	"github.com/redis/rueidis"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestFullConnectRouting(t *testing.T) {
+	ctx := context.Background()
+
+	r := miniredis.RunT(t)
+
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	stateMan := state.NewRedisConnectionStateManager(rc)
+	rcv, _ := pubsub.NewConnector(ctx, pubsub.WithNoop())
+
+	cond := trace.NewConditionalTracer(noop.Tracer{}, trace.AlwaysTrace)
+
+	svc := NewConnectMessageRouterService(
+		stateMan,
+		rcv,
+		cond,
+	)
+
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	t.Run("healthy connection should receive requests", func(t *testing.T) {
+		acctId, envId, appId, syncId := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+		connId, gatewayId := ulid.MustNew(ulid.Now(), rand.Reader), ulid.MustNew(ulid.Now(), rand.Reader)
+
+		appName := "app-1"
+
+		fn1 := sdk.SDKFunction{
+			Name: "Test Function",
+			Slug: fmt.Sprintf("%s-fn-1", appName),
+		}
+
+		fnBytes, err := json.Marshal([]sdk.SDKFunction{fn1})
+		require.NoError(t, err)
+
+		app1Config := &connect.AppConfiguration{
+			AppName:    appName,
+			AppVersion: util.StrPtr("v1"),
+			Functions:  fnBytes,
+		}
+
+		fakeReq := &connect.WorkerConnectRequestData{
+			ConnectionId: connId.String(),
+			InstanceId:   "my-worker",
+			Apps: []*connect.AppConfiguration{
+				app1Config,
+			},
+			SystemAttributes: &connect.SystemAttributes{
+				CpuCores: 10,
+				MemBytes: 1024 * 1024 * 16,
+				Os:       "linux",
+			},
+			SdkVersion:  "fake-ver",
+			SdkLanguage: "fake-sdk",
+		}
+
+		group, err := NewWorkerGroupFromConnRequest(ctx, fakeReq, &auth.Response{
+			AccountID: acctId,
+			EnvID:     envId,
+		}, app1Config)
+		require.NoError(t, err)
+		group.AppID = &appId
+		group.SyncID = &syncId
+
+		err = stateMan.UpsertConnection(ctx, &state.Connection{
+			AccountID:    acctId,
+			EnvID:        envId,
+			ConnectionId: connId,
+			WorkerIP:     "1.1.1.1",
+			Data:         fakeReq,
+			Groups: map[string]*state.WorkerGroup{
+				group.Hash: group,
+			},
+			GatewayId: gatewayId,
+		}, connect.ConnectionStatus_READY, time.Now().Truncate(time.Minute))
+		require.NoError(t, err)
+
+		conn, err := svc.getSuitableConnection(ctx, envId, appId, app1Config.AppName, fn1.Slug, log)
+		require.NoError(t, err)
+
+		require.Equal(t, connId.String(), conn.Id)
+		require.Equal(t, gatewayId.String(), conn.GatewayId)
+	})
+
+	t.Run("unhealthy connection should be filtered out", func(t *testing.T) {
+
+	})
+
+	t.Run("no healthy connection should be handled gracefully", func(t *testing.T) {
+
+	})
+
+	t.Run("newer connection should be preferred", func(t *testing.T) {
+
+	})
+}

--- a/pkg/connect/router_test.go
+++ b/pkg/connect/router_test.go
@@ -55,6 +55,11 @@ func TestFullConnectRouting(t *testing.T) {
 
 		appName := "app-1"
 
+		caps, err := json.Marshal(sdk.Capabilities{
+			Connect: sdk.ConnectV1,
+		})
+		require.NoError(t, err)
+
 		fn1 := sdk.SDKFunction{
 			Name: "Test Function",
 			Slug: fmt.Sprintf("%s-fn-1", appName),
@@ -80,8 +85,13 @@ func TestFullConnectRouting(t *testing.T) {
 				MemBytes: 1024 * 1024 * 16,
 				Os:       "linux",
 			},
-			SdkVersion:  "fake-ver",
-			SdkLanguage: "fake-sdk",
+			SdkVersion:   "fake-ver",
+			SdkLanguage:  "fake-sdk",
+			Capabilities: caps,
+			AuthData: &connect.AuthData{
+				SessionToken: "fake-session-token",
+				SyncToken:    "fake-sync-token",
+			},
 		}
 
 		group, err := NewWorkerGroupFromConnRequest(ctx, fakeReq, &auth.Response{

--- a/pkg/connect/router_test.go
+++ b/pkg/connect/router_test.go
@@ -25,33 +25,68 @@ import (
 )
 
 func TestFullConnectRouting(t *testing.T) {
-	ctx := context.Background()
+	setupRedis := func(t *testing.T) (*connectRouterSvc, state.StateManager, func()) {
+		ctx := context.Background()
 
-	r := miniredis.RunT(t)
+		r := miniredis.RunT(t)
 
-	rc, err := rueidis.NewClient(rueidis.ClientOption{
-		InitAddress:  []string{r.Addr()},
-		DisableCache: true,
-	})
-	require.NoError(t, err)
-	defer rc.Close()
+		rc, err := rueidis.NewClient(rueidis.ClientOption{
+			InitAddress:  []string{r.Addr()},
+			DisableCache: true,
+		})
+		require.NoError(t, err)
 
-	stateMan := state.NewRedisConnectionStateManager(rc)
-	rcv, _ := pubsub.NewConnector(ctx, pubsub.WithNoop())
+		stateMan := state.NewRedisConnectionStateManager(rc)
+		rcv, _ := pubsub.NewConnector(ctx, pubsub.WithNoop())
 
-	cond := trace.NewConditionalTracer(noop.Tracer{}, trace.AlwaysTrace)
+		cond := trace.NewConditionalTracer(noop.Tracer{}, trace.AlwaysTrace)
 
-	svc := NewConnectMessageRouterService(
-		stateMan,
-		rcv,
-		cond,
-	)
+		svc := NewConnectMessageRouterService(
+			stateMan,
+			rcv,
+			cond,
+		)
 
-	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+		return svc, stateMan, func() {
+			rc.Close()
+		}
+	}
 
-	t.Run("healthy connection should receive requests", func(t *testing.T) {
-		acctId, envId, appId, syncId := uuid.New(), uuid.New(), uuid.New(), uuid.New()
-		connId, gatewayId := ulid.MustNew(ulid.Now(), rand.Reader), ulid.MustNew(ulid.Now(), rand.Reader)
+	acctId, envId := uuid.New(), uuid.New()
+	gatewayId := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	type setupRes struct {
+		appId   uuid.UUID
+		syncId  uuid.UUID
+		connIds []ulid.ULID
+		appName string
+		fnSlug  string
+	}
+
+	type testConnection struct {
+		status          connect.ConnectionStatus
+		lastHeartbeatAt time.Time
+	}
+
+	newTestConn := func(status connect.ConnectionStatus, lastHeartbeatAt time.Time) testConnection {
+		return testConnection{
+			status:          status,
+			lastHeartbeatAt: lastHeartbeatAt,
+		}
+	}
+
+	setup := func(stateMan state.StateManager, connsToCreate ...testConnection) setupRes {
+		lastHeartbeatAt := time.Now()
+
+		err := stateMan.UpsertGateway(context.Background(), &state.Gateway{
+			Id:              gatewayId,
+			Status:          state.GatewayStatusActive,
+			LastHeartbeatAt: lastHeartbeatAt,
+			Hostname:        "host-1",
+		})
+		require.NoError(t, err)
+
+		appId, syncId := uuid.New(), uuid.New()
 
 		appName := "app-1"
 
@@ -74,55 +109,109 @@ func TestFullConnectRouting(t *testing.T) {
 			Functions:  fnBytes,
 		}
 
-		fakeReq := &connect.WorkerConnectRequestData{
-			ConnectionId: connId.String(),
-			InstanceId:   "my-worker",
-			Apps: []*connect.AppConfiguration{
-				app1Config,
-			},
-			SystemAttributes: &connect.SystemAttributes{
-				CpuCores: 10,
-				MemBytes: 1024 * 1024 * 16,
-				Os:       "linux",
-			},
-			SdkVersion:   "fake-ver",
-			SdkLanguage:  "fake-sdk",
-			Capabilities: caps,
-			AuthData: &connect.AuthData{
-				SessionToken: "fake-session-token",
-				SyncToken:    "fake-sync-token",
-			},
+		connIds := make([]ulid.ULID, len(connsToCreate))
+		for i, connToCreate := range connsToCreate {
+			connId := ulid.MustNew(ulid.Now(), rand.Reader)
+
+			fakeReq := &connect.WorkerConnectRequestData{
+				ConnectionId: connId.String(),
+				InstanceId:   "my-worker",
+				Apps: []*connect.AppConfiguration{
+					app1Config,
+				},
+				SystemAttributes: &connect.SystemAttributes{
+					CpuCores: 10,
+					MemBytes: 1024 * 1024 * 16,
+					Os:       "linux",
+				},
+				SdkVersion:   "fake-ver",
+				SdkLanguage:  "fake-sdk",
+				Capabilities: caps,
+				AuthData: &connect.AuthData{
+					SessionToken: "fake-session-token",
+					SyncToken:    "fake-sync-token",
+				},
+			}
+
+			group, err := NewWorkerGroupFromConnRequest(context.Background(), fakeReq, &auth.Response{
+				AccountID: acctId,
+				EnvID:     envId,
+			}, app1Config)
+			require.NoError(t, err)
+			group.AppID = &appId
+			group.SyncID = &syncId
+
+			err = stateMan.UpsertConnection(context.Background(), &state.Connection{
+				AccountID:    acctId,
+				EnvID:        envId,
+				ConnectionId: connId,
+				WorkerIP:     "1.1.1.1",
+				Data:         fakeReq,
+				Groups: map[string]*state.WorkerGroup{
+					group.Hash: group,
+				},
+				GatewayId: gatewayId,
+			}, connToCreate.status, connToCreate.lastHeartbeatAt)
+			require.NoError(t, err)
+
+			connIds[i] = connId
 		}
 
-		group, err := NewWorkerGroupFromConnRequest(ctx, fakeReq, &auth.Response{
-			AccountID: acctId,
-			EnvID:     envId,
-		}, app1Config)
-		require.NoError(t, err)
-		group.AppID = &appId
-		group.SyncID = &syncId
+		return setupRes{
+			appId:   appId,
+			syncId:  syncId,
+			connIds: connIds,
+			appName: appName,
+			fnSlug:  fn1.Slug,
+		}
+	}
 
-		err = stateMan.UpsertConnection(ctx, &state.Connection{
-			AccountID:    acctId,
-			EnvID:        envId,
-			ConnectionId: connId,
-			WorkerIP:     "1.1.1.1",
-			Data:         fakeReq,
-			Groups: map[string]*state.WorkerGroup{
-				group.Hash: group,
-			},
-			GatewayId: gatewayId,
-		}, connect.ConnectionStatus_READY, time.Now().Truncate(time.Minute))
-		require.NoError(t, err)
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-		conn, err := svc.getSuitableConnection(ctx, envId, appId, app1Config.AppName, fn1.Slug, log)
+	t.Run("single healthy connection should receive requests", func(t *testing.T) {
+		svc, stateMan, cleanup := setupRedis(t)
+		defer cleanup()
+
+		setupRes := setup(stateMan,
+			newTestConn(connect.ConnectionStatus_READY, time.Now()),
+		)
+
+		conn, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.appName, setupRes.fnSlug, log)
 		require.NoError(t, err)
 
-		require.Equal(t, connId.String(), conn.Id)
+		require.Equal(t, setupRes.connIds[0].String(), conn.Id)
 		require.Equal(t, gatewayId.String(), conn.GatewayId)
 	})
 
 	t.Run("unhealthy connection should be filtered out", func(t *testing.T) {
+		svc, stateMan, cleanup := setupRedis(t)
+		defer cleanup()
+
+		setupRes := setup(stateMan,
+			newTestConn(connect.ConnectionStatus_CONNECTED, time.Now()),
+			newTestConn(connect.ConnectionStatus_DISCONNECTING, time.Now()),
+			newTestConn(connect.ConnectionStatus_DISCONNECTED, time.Now()),
+			newTestConn(connect.ConnectionStatus_READY, time.Now()),
+		)
+
+		conn, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.appName, setupRes.fnSlug, log)
+		require.NoError(t, err)
+
+		require.Equal(t, setupRes.connIds[3].String(), conn.Id)
+		require.Equal(t, gatewayId.String(), conn.GatewayId)
+
+		conns, err := stateMan.GetConnectionsByEnvID(context.Background(), envId)
+		require.NoError(t, err)
+		require.Len(t, conns, 3) // disconnected conn should not be in there
+
+		connIds := make([]string, len(conns))
+		for i, metadata := range conns {
+			connIds[i] = metadata.Id
+		}
+
+		require.Contains(t, connIds, setupRes.connIds[0].String())
+		require.Contains(t, connIds, setupRes.connIds[1].String())
+		require.Contains(t, connIds, setupRes.connIds[3].String())
 
 	})
 

--- a/pkg/connect/router_test.go
+++ b/pkg/connect/router_test.go
@@ -46,6 +46,7 @@ func TestFullConnectRouting(t *testing.T) {
 			rcv,
 			cond,
 		)
+		require.NoError(t, svc.Pre(context.Background()))
 
 		return svc, stateMan, func() {
 			rc.Close()
@@ -176,7 +177,7 @@ func TestFullConnectRouting(t *testing.T) {
 			newTestConn(connect.ConnectionStatus_READY, time.Now()),
 		)
 
-		conn, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.appName, setupRes.fnSlug, log)
+		conn, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.fnSlug, log)
 		require.NoError(t, err)
 
 		require.Equal(t, setupRes.connIds[0].String(), conn.Id)
@@ -194,7 +195,7 @@ func TestFullConnectRouting(t *testing.T) {
 			newTestConn(connect.ConnectionStatus_READY, time.Now()),
 		)
 
-		conn, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.appName, setupRes.fnSlug, log)
+		conn, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.fnSlug, log)
 		require.NoError(t, err)
 
 		require.Equal(t, setupRes.connIds[3].String(), conn.Id)
@@ -223,7 +224,7 @@ func TestFullConnectRouting(t *testing.T) {
 			newTestConn(connect.ConnectionStatus_DISCONNECTED, time.Now()),
 		)
 
-		_, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.appName, setupRes.fnSlug, log)
+		_, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.fnSlug, log)
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrNoHealthyConnection)
 	})
@@ -237,7 +238,7 @@ func TestFullConnectRouting(t *testing.T) {
 			newTestConn(connect.ConnectionStatus_DISCONNECTED, time.Now()),
 		)
 
-		_, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.appName, setupRes.fnSlug, log)
+		_, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.fnSlug, log)
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrNoHealthyConnection)
 	})
@@ -251,7 +252,7 @@ func TestFullConnectRouting(t *testing.T) {
 			newTestConn(connect.ConnectionStatus_READY, time.Now()),
 		)
 
-		_, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, "fn-2", setupRes.fnSlug, log)
+		_, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, "fn-2", log)
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrNoHealthyConnection)
 	})

--- a/pkg/connect/router_test.go
+++ b/pkg/connect/router_test.go
@@ -24,177 +24,200 @@ import (
 	"time"
 )
 
-func TestFullConnectRouting(t *testing.T) {
-	setupRedis := func(t *testing.T) (*connectRouterSvc, state.StateManager, func()) {
-		ctx := context.Background()
+func setupRedis(t *testing.T) (*connectRouterSvc, state.StateManager, func()) {
+	ctx := context.Background()
 
-		r := miniredis.RunT(t)
+	r := miniredis.RunT(t)
 
-		rc, err := rueidis.NewClient(rueidis.ClientOption{
-			InitAddress:  []string{r.Addr()},
-			DisableCache: true,
-		})
-		require.NoError(t, err)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
 
-		stateMan := state.NewRedisConnectionStateManager(rc)
-		rcv, _ := pubsub.NewConnector(ctx, pubsub.WithNoop())
+	stateMan := state.NewRedisConnectionStateManager(rc)
+	rcv, _ := pubsub.NewConnector(ctx, pubsub.WithNoop())
 
-		cond := trace.NewConditionalTracer(noop.Tracer{}, trace.AlwaysTrace)
+	cond := trace.NewConditionalTracer(noop.Tracer{}, trace.AlwaysTrace)
 
-		svc := NewConnectMessageRouterService(
-			stateMan,
-			rcv,
-			cond,
-		)
-		require.NoError(t, svc.Pre(context.Background()))
+	svc := NewConnectMessageRouterService(
+		stateMan,
+		rcv,
+		cond,
+	)
+	require.NoError(t, svc.Pre(context.Background()))
 
-		return svc, stateMan, func() {
-			rc.Close()
-		}
+	return svc, stateMan, func() {
+		rc.Close()
 	}
+}
+
+type setupRes struct {
+	acctId    uuid.UUID
+	envId     uuid.UUID
+	gatewayId ulid.ULID
+
+	appId   uuid.UUID
+	syncId  uuid.UUID
+	connIds []ulid.ULID
+	appName string
+	fnSlug  string
+}
+
+type testConnection struct {
+	status          connect.ConnectionStatus
+	lastHeartbeatAt time.Time
+}
+
+func newTestConn(status connect.ConnectionStatus, lastHeartbeatAt time.Time) testConnection {
+	return testConnection{
+		status:          status,
+		lastHeartbeatAt: lastHeartbeatAt,
+	}
+}
+
+type setupOpts struct {
+	acctId    uuid.UUID
+	envId     uuid.UUID
+	gatewayId *ulid.ULID
+
+	// use fnId if provided, otherwise default to "fn-1"
+	fnId string
+
+	// use appName if provided, otherwise default to "app-1"
+	appName string
+
+	// use appId if provided, otherwise create new
+	appId uuid.UUID
+
+	// use syncId if provided, otherwise create new
+	syncId uuid.UUID
+}
+
+func setup(t *testing.T, stateMan state.StateManager, opts setupOpts, connsToCreate ...testConnection) setupRes {
+	lastHeartbeatAt := time.Now()
 
 	acctId, envId := uuid.New(), uuid.New()
+	if opts.acctId != uuid.Nil {
+		acctId = opts.acctId
+	}
+
+	if opts.envId != uuid.Nil {
+		envId = opts.envId
+	}
+
 	gatewayId := ulid.MustNew(ulid.Now(), rand.Reader)
-
-	type setupRes struct {
-		appId   uuid.UUID
-		syncId  uuid.UUID
-		connIds []ulid.ULID
-		appName string
-		fnSlug  string
+	if opts.gatewayId != nil {
+		gatewayId = *opts.gatewayId
 	}
 
-	type testConnection struct {
-		status          connect.ConnectionStatus
-		lastHeartbeatAt time.Time
+	err := stateMan.UpsertGateway(context.Background(), &state.Gateway{
+		Id:              gatewayId,
+		Status:          state.GatewayStatusActive,
+		LastHeartbeatAt: lastHeartbeatAt,
+		Hostname:        "host-1",
+	})
+	require.NoError(t, err)
+
+	fnId := "fn-1"
+	if opts.fnId != "" {
+		fnId = opts.fnId
 	}
 
-	newTestConn := func(status connect.ConnectionStatus, lastHeartbeatAt time.Time) testConnection {
-		return testConnection{
-			status:          status,
-			lastHeartbeatAt: lastHeartbeatAt,
+	appId, syncId := uuid.New(), uuid.New()
+	if opts.appId != uuid.Nil {
+		appId = opts.appId
+	}
+
+	if opts.syncId != uuid.Nil {
+		syncId = opts.syncId
+	}
+
+	appName := "app-1"
+	if opts.appName != "" {
+		appName = opts.appName
+	}
+
+	caps, err := json.Marshal(sdk.Capabilities{
+		Connect: sdk.ConnectV1,
+	})
+	require.NoError(t, err)
+
+	fn1 := sdk.SDKFunction{
+		Name: "Test Function",
+		Slug: fmt.Sprintf("%s-%s", appName, fnId),
+	}
+
+	fnBytes, err := json.Marshal([]sdk.SDKFunction{fn1})
+	require.NoError(t, err)
+
+	app1Config := &connect.AppConfiguration{
+		AppName:    appName,
+		AppVersion: util.StrPtr("v1"),
+		Functions:  fnBytes,
+	}
+
+	connIds := make([]ulid.ULID, len(connsToCreate))
+	for i, connToCreate := range connsToCreate {
+		connId := ulid.MustNew(ulid.Now(), rand.Reader)
+
+		fakeReq := &connect.WorkerConnectRequestData{
+			ConnectionId: connId.String(),
+			InstanceId:   "my-worker",
+			Apps: []*connect.AppConfiguration{
+				app1Config,
+			},
+			SystemAttributes: &connect.SystemAttributes{
+				CpuCores: 10,
+				MemBytes: 1024 * 1024 * 16,
+				Os:       "linux",
+			},
+			SdkVersion:   "fake-ver",
+			SdkLanguage:  "fake-sdk",
+			Capabilities: caps,
+			AuthData: &connect.AuthData{
+				SessionToken: "fake-session-token",
+				SyncToken:    "fake-sync-token",
+			},
 		}
-	}
 
-	type setupOpts struct {
-		// use fnId if provided, otherwise default to "fn-1"
-		fnId string
+		group, err := NewWorkerGroupFromConnRequest(context.Background(), fakeReq, &auth.Response{
+			AccountID: acctId,
+			EnvID:     envId,
+		}, app1Config)
+		require.NoError(t, err)
+		group.AppID = &appId
+		group.SyncID = &syncId
 
-		// use appName if provided, otherwise default to "app-1"
-		appName string
-
-		// use appId if provided, otherwise create new
-		appId uuid.UUID
-
-		// use syncId if provided, otherwise create new
-		syncId uuid.UUID
-	}
-
-	setup := func(stateMan state.StateManager, opts setupOpts, connsToCreate ...testConnection) setupRes {
-		lastHeartbeatAt := time.Now()
-
-		err := stateMan.UpsertGateway(context.Background(), &state.Gateway{
-			Id:              gatewayId,
-			Status:          state.GatewayStatusActive,
-			LastHeartbeatAt: lastHeartbeatAt,
-			Hostname:        "host-1",
-		})
+		err = stateMan.UpsertConnection(context.Background(), &state.Connection{
+			AccountID:    acctId,
+			EnvID:        envId,
+			ConnectionId: connId,
+			WorkerIP:     "1.1.1.1",
+			Data:         fakeReq,
+			Groups: map[string]*state.WorkerGroup{
+				group.Hash: group,
+			},
+			GatewayId: gatewayId,
+		}, connToCreate.status, connToCreate.lastHeartbeatAt)
 		require.NoError(t, err)
 
-		fnId := "fn-1"
-		if opts.fnId != "" {
-			fnId = opts.fnId
-		}
-
-		appId, syncId := uuid.New(), uuid.New()
-		if opts.appId != uuid.Nil {
-			appId = opts.appId
-		}
-
-		if opts.syncId != uuid.Nil {
-			syncId = opts.syncId
-		}
-
-		appName := "app-1"
-		if opts.appName != "" {
-			appName = opts.appName
-		}
-
-		caps, err := json.Marshal(sdk.Capabilities{
-			Connect: sdk.ConnectV1,
-		})
-		require.NoError(t, err)
-
-		fn1 := sdk.SDKFunction{
-			Name: "Test Function",
-			Slug: fmt.Sprintf("%s-%s", appName, fnId),
-		}
-
-		fnBytes, err := json.Marshal([]sdk.SDKFunction{fn1})
-		require.NoError(t, err)
-
-		app1Config := &connect.AppConfiguration{
-			AppName:    appName,
-			AppVersion: util.StrPtr("v1"),
-			Functions:  fnBytes,
-		}
-
-		connIds := make([]ulid.ULID, len(connsToCreate))
-		for i, connToCreate := range connsToCreate {
-			connId := ulid.MustNew(ulid.Now(), rand.Reader)
-
-			fakeReq := &connect.WorkerConnectRequestData{
-				ConnectionId: connId.String(),
-				InstanceId:   "my-worker",
-				Apps: []*connect.AppConfiguration{
-					app1Config,
-				},
-				SystemAttributes: &connect.SystemAttributes{
-					CpuCores: 10,
-					MemBytes: 1024 * 1024 * 16,
-					Os:       "linux",
-				},
-				SdkVersion:   "fake-ver",
-				SdkLanguage:  "fake-sdk",
-				Capabilities: caps,
-				AuthData: &connect.AuthData{
-					SessionToken: "fake-session-token",
-					SyncToken:    "fake-sync-token",
-				},
-			}
-
-			group, err := NewWorkerGroupFromConnRequest(context.Background(), fakeReq, &auth.Response{
-				AccountID: acctId,
-				EnvID:     envId,
-			}, app1Config)
-			require.NoError(t, err)
-			group.AppID = &appId
-			group.SyncID = &syncId
-
-			err = stateMan.UpsertConnection(context.Background(), &state.Connection{
-				AccountID:    acctId,
-				EnvID:        envId,
-				ConnectionId: connId,
-				WorkerIP:     "1.1.1.1",
-				Data:         fakeReq,
-				Groups: map[string]*state.WorkerGroup{
-					group.Hash: group,
-				},
-				GatewayId: gatewayId,
-			}, connToCreate.status, connToCreate.lastHeartbeatAt)
-			require.NoError(t, err)
-
-			connIds[i] = connId
-		}
-
-		return setupRes{
-			appId:   appId,
-			syncId:  syncId,
-			connIds: connIds,
-			appName: appName,
-			fnSlug:  fn1.Slug,
-		}
+		connIds[i] = connId
 	}
+
+	return setupRes{
+		acctId:    acctId,
+		envId:     envId,
+		gatewayId: gatewayId,
+		appId:     appId,
+		syncId:    syncId,
+		connIds:   connIds,
+		appName:   appName,
+		fnSlug:    fn1.Slug,
+	}
+}
+
+func TestFullConnectRouting(t *testing.T) {
 
 	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
@@ -202,35 +225,35 @@ func TestFullConnectRouting(t *testing.T) {
 		svc, stateMan, cleanup := setupRedis(t)
 		defer cleanup()
 
-		setupRes := setup(stateMan, setupOpts{},
+		setupRes := setup(t, stateMan, setupOpts{},
 			newTestConn(connect.ConnectionStatus_READY, time.Now()),
 		)
 
-		conn, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.fnSlug, log)
+		conn, err := svc.getSuitableConnection(context.Background(), setupRes.envId, setupRes.appId, setupRes.fnSlug, log)
 		require.NoError(t, err)
 
 		require.Equal(t, setupRes.connIds[0].String(), conn.Id)
-		require.Equal(t, gatewayId.String(), conn.GatewayId)
+		require.Equal(t, setupRes.gatewayId.String(), conn.GatewayId)
 	})
 
 	t.Run("unhealthy connection should be filtered out", func(t *testing.T) {
 		svc, stateMan, cleanup := setupRedis(t)
 		defer cleanup()
 
-		setupRes := setup(stateMan, setupOpts{},
+		setupRes := setup(t, stateMan, setupOpts{},
 			newTestConn(connect.ConnectionStatus_CONNECTED, time.Now()),
 			newTestConn(connect.ConnectionStatus_DISCONNECTING, time.Now()),
 			newTestConn(connect.ConnectionStatus_DISCONNECTED, time.Now()),
 			newTestConn(connect.ConnectionStatus_READY, time.Now()),
 		)
 
-		conn, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.fnSlug, log)
+		conn, err := svc.getSuitableConnection(context.Background(), setupRes.envId, setupRes.appId, setupRes.fnSlug, log)
 		require.NoError(t, err)
 
 		require.Equal(t, setupRes.connIds[3].String(), conn.Id)
-		require.Equal(t, gatewayId.String(), conn.GatewayId)
+		require.Equal(t, setupRes.gatewayId.String(), conn.GatewayId)
 
-		conns, err := stateMan.GetConnectionsByEnvID(context.Background(), envId)
+		conns, err := stateMan.GetConnectionsByEnvID(context.Background(), setupRes.envId)
 		require.NoError(t, err)
 		require.Len(t, conns, 3) // disconnected conn should not be in there
 
@@ -248,41 +271,63 @@ func TestFullConnectRouting(t *testing.T) {
 		svc, stateMan, cleanup := setupRedis(t)
 		defer cleanup()
 
-		setupRes := setup(stateMan, setupOpts{},
+		setupRes := setup(t, stateMan, setupOpts{},
 			newTestConn(connect.ConnectionStatus_DISCONNECTING, time.Now()),
 			newTestConn(connect.ConnectionStatus_DISCONNECTED, time.Now()),
 		)
 
-		_, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.fnSlug, log)
+		_, err := svc.getSuitableConnection(context.Background(), setupRes.envId, setupRes.appId, setupRes.fnSlug, log)
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrNoHealthyConnection)
 	})
 
 	t.Run("newer connection should be preferred", func(t *testing.T) {
+		// This test is intuitively, but not actually correct. It's good to keep this as a reminder
+		// on why the implementation works counter to this test: With connect, we want to prefer newer versions
+		// but still send some traffic to connections running older versions. Routing thus doesn't filter out older versions,
+		// it merely increases the chances of a connection running a newer version being picked.
+		t.Skip("this test serves as an explainer and should not run")
+
 		svc, stateMan, cleanup := setupRedis(t)
 		defer cleanup()
 
-		setupRes := setup(stateMan, setupOpts{},
-			newTestConn(connect.ConnectionStatus_DISCONNECTING, time.Now()),
-			newTestConn(connect.ConnectionStatus_DISCONNECTED, time.Now()),
+		setupOldVersion := setup(t, stateMan, setupOpts{
+			fnId: "fn-1",
+		},
+			newTestConn(connect.ConnectionStatus_READY, time.Now()),
 		)
 
-		_, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, setupRes.fnSlug, log)
-		require.Error(t, err)
-		require.ErrorIs(t, err, ErrNoHealthyConnection)
+		<-time.After(1 * time.Second)
+
+		setupNewVersion := setup(t, stateMan, setupOpts{
+			acctId:    setupOldVersion.acctId,
+			envId:     setupOldVersion.envId,
+			gatewayId: &setupOldVersion.gatewayId,
+			fnId:      "fn-1",
+			appName:   setupOldVersion.appName,
+			appId:     setupOldVersion.appId,
+			syncId:    setupOldVersion.syncId,
+		},
+			newTestConn(connect.ConnectionStatus_READY, time.Now()),
+		)
+
+		conn, err := svc.getSuitableConnection(context.Background(), setupOldVersion.envId, setupOldVersion.appId, setupOldVersion.fnSlug, log)
+		require.NoError(t, err)
+		require.Equal(t, setupNewVersion.connIds[0].String(), conn.Id)
+		require.NotEqual(t, setupOldVersion.connIds[0].String(), conn.Id)
 	})
 
 	t.Run("connection without functions should be ignored", func(t *testing.T) {
 		svc, stateMan, cleanup := setupRedis(t)
 		defer cleanup()
 
-		setupRes := setup(stateMan, setupOpts{},
+		setupRes := setup(t, stateMan, setupOpts{},
 			newTestConn(connect.ConnectionStatus_READY, time.Now()),
 			newTestConn(connect.ConnectionStatus_READY, time.Now()),
 		)
 
 		// Try to route message for fn-1 (this does not exist)
-		_, err := svc.getSuitableConnection(context.Background(), envId, setupRes.appId, "fn-2", log)
+		_, err := svc.getSuitableConnection(context.Background(), setupRes.envId, setupRes.appId, "fn-2", log)
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrNoHealthyConnection)
 	})
@@ -291,7 +336,7 @@ func TestFullConnectRouting(t *testing.T) {
 		svc, stateMan, cleanup := setupRedis(t)
 		defer cleanup()
 
-		setupOldVersion := setup(stateMan, setupOpts{
+		setupOldVersion := setup(t, stateMan, setupOpts{
 			fnId: "fn-1",
 		},
 			newTestConn(connect.ConnectionStatus_READY, time.Now()),
@@ -299,20 +344,141 @@ func TestFullConnectRouting(t *testing.T) {
 
 		<-time.After(1 * time.Second)
 
-		setupNewVersion := setup(stateMan, setupOpts{
-			fnId:    "fn-2", // note: different fn slug
-			appName: setupOldVersion.appName,
-			appId:   setupOldVersion.appId,
-			syncId:  setupOldVersion.syncId,
+		setupNewVersion := setup(t, stateMan, setupOpts{
+			acctId:    setupOldVersion.acctId,
+			envId:     setupOldVersion.envId,
+			gatewayId: &setupOldVersion.gatewayId,
+			fnId:      "fn-2", // note: different fn slug
+			appName:   setupOldVersion.appName,
+			appId:     setupOldVersion.appId,
+			syncId:    setupOldVersion.syncId,
 		},
 			newTestConn(connect.ConnectionStatus_READY, time.Now()),
 			newTestConn(connect.ConnectionStatus_READY, time.Now()),
 		)
 
 		// Try to route message for fn-1 (this does not exist in newer version)
-		conn, err := svc.getSuitableConnection(context.Background(), envId, setupOldVersion.appId, setupOldVersion.fnSlug, log)
+		conn, err := svc.getSuitableConnection(context.Background(), setupOldVersion.envId, setupOldVersion.appId, setupOldVersion.fnSlug, log)
 		require.NoError(t, err)
 		require.NotEqual(t, setupNewVersion.connIds[0].String(), conn.Id)
 		require.Equal(t, setupOldVersion.connIds[0].String(), conn.Id)
 	})
 }
+
+func TestIsHealthy(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	t.Run("ready connection should be marked as healthy", func(t *testing.T) {
+		_, stateMan, cleanup := setupRedis(t)
+		defer cleanup()
+
+		setupRes := setup(t, stateMan, setupOpts{}, newTestConn(connect.ConnectionStatus_READY, time.Now()))
+
+		conn, err := stateMan.GetConnection(context.Background(), setupRes.envId, setupRes.connIds[0])
+		require.NoError(t, err)
+
+		res := isHealthy(context.Background(), stateMan, setupRes.envId, setupRes.appId, setupRes.fnSlug, conn, log)
+
+		require.True(t, res.isHealthy)
+		require.False(t, res.shouldDeleteUnhealthyConnection)
+		require.False(t, res.shouldDeleteUnhealthyGateway)
+	})
+}
+
+func TestGetConnectionWeight(t *testing.T) {
+	createVersion := func(prefix string, versionTime time.Time, numCandidates int) []connWithGroup {
+		conns := make([]connWithGroup, numCandidates)
+		group := &state.WorkerGroup{CreatedAt: versionTime}
+		for i := range numCandidates {
+			conns[i] = connWithGroup{
+				conn: &connect.ConnMetadata{
+					Id: fmt.Sprintf("%s-%d", prefix, i),
+				},
+				group: group,
+			}
+		}
+		return conns
+	}
+
+	t.Run("newer connections should receive higher weights", func(t *testing.T) {
+		candidates := make([]connWithGroup, 0)
+
+		t1 := time.Date(2025, 02, 25, 0, 0, 0, 0, time.Local)
+		oldConns := createVersion("old", t1, 3)
+		candidates = append(candidates, oldConns...)
+
+		diff := 10 * time.Minute
+
+		t2 := t1.Add(diff)
+		newConns := createVersion("new", t2, 3)
+		candidates = append(candidates, newConns...)
+
+		sortByGroupCreatedAt(candidates)
+
+		distr := getVersionTimeDistribution(candidates)
+		require.Equal(t, distr.timeRange, diff.Seconds())
+		require.Equal(t, t1, distr.oldestVersionCreatedAt)
+		require.Equal(t, t2, distr.newestVersionCreatedAt)
+
+		oldConnWeight := getConnectionWeight(distr.timeRange, distr.oldestVersionCreatedAt, oldConns[0])
+		require.NotZero(t, oldConnWeight)
+
+		newConnWeight := getConnectionWeight(distr.timeRange, distr.oldestVersionCreatedAt, newConns[0])
+		require.NotZero(t, newConnWeight)
+
+		require.Greater(t, newConnWeight, oldConnWeight)
+	})
+
+	t.Run("scoring should work with a single group", func(t *testing.T) {
+		candidates := make([]connWithGroup, 0)
+
+		t1 := time.Date(2025, 02, 25, 0, 0, 0, 0, time.Local)
+		oldConns := createVersion("old", t1, 3)
+		candidates = append(candidates, oldConns...)
+
+		diff := time.Duration(0)
+
+		sortByGroupCreatedAt(candidates)
+
+		distr := getVersionTimeDistribution(candidates)
+		require.Equal(t, distr.timeRange, diff.Seconds())
+		require.Equal(t, t1, distr.oldestVersionCreatedAt)
+		require.Equal(t, t1, distr.newestVersionCreatedAt)
+
+		oldConnWeight := getConnectionWeight(distr.timeRange, distr.oldestVersionCreatedAt, oldConns[0])
+		require.NotZero(t, oldConnWeight)
+	})
+
+	t.Run("scoring should work with multiple groups", func(t *testing.T) {
+		candidates := make([]connWithGroup, 0)
+
+		t0 := time.Date(2025, 02, 25, 0, 0, 0, 0, time.Local)
+		numGroups := 10
+		diff := 10 * time.Minute
+		for i := range numGroups {
+			tn := t0.Add(time.Duration(i) * diff)
+			conns := createVersion(fmt.Sprintf("v-%d", i), tn, 1)
+			candidates = append(candidates, conns...)
+		}
+
+		sortByGroupCreatedAt(candidates)
+
+		distr := getVersionTimeDistribution(candidates)
+		require.Equal(t, distr.timeRange, (time.Duration(numGroups-1) * diff).Seconds())
+		require.Equal(t, t0, distr.oldestVersionCreatedAt)
+		require.Equal(t, t0.Add(time.Duration(numGroups-1)*diff), distr.newestVersionCreatedAt)
+
+		for i := range candidates {
+			if i == 0 || i == len(candidates)-1 {
+				continue
+			}
+
+			oldConnWeight := getConnectionWeight(distr.timeRange, distr.oldestVersionCreatedAt, candidates[i-1])
+			newConnWeight := getConnectionWeight(distr.timeRange, distr.oldestVersionCreatedAt, candidates[i])
+
+			require.Greater(t, newConnWeight, oldConnWeight)
+		}
+	})
+}
+
+func TestPickConnection(t *testing.T) {}

--- a/pkg/connect/state/state.go
+++ b/pkg/connect/state/state.go
@@ -103,6 +103,9 @@ type WorkerGroup struct {
 	// - User provided identifier (e.g. git sha, release tag, etc)
 	Hash string `json:"hash"`
 
+	// CreatedAt records the time this worker group was first created
+	CreatedAt time.Time `json:"created_at"`
+
 	// used for syncing
 	SyncData SyncData `json:"-"`
 }
@@ -155,6 +158,7 @@ func (g *WorkerGroup) Sync(ctx context.Context, groupManager WorkerGroupManager,
 	if existingGroup != nil && existingGroup.SyncID != nil && existingGroup.AppID != nil {
 		g.AppID = existingGroup.AppID
 		g.SyncID = existingGroup.SyncID
+		g.CreatedAt = existingGroup.CreatedAt
 		return nil
 	}
 


### PR DESCRIPTION
## Description

This updates the connect router to prefer newer worker groups (which are mostly equivalent to newer versions/deploys). This does not rule out routing to older versions, in scenarios where most workers are still running the old version (i.e. active deployments).

This PR also adds a variety of unit and integration tests for most of the routing flow, including scoring connections, selecting the most suitable connection, etc. Testing actual message flow is handled by end-to-end connect tests.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
