### PR TITLE
Ensure run output is JSON in REST API response

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -869,7 +869,7 @@ func toCQRSRun(run sqlc.FunctionRun, finish sqlc.FunctionFinish) *cqrs.FunctionR
 	}
 	if finish.Status.Valid {
 		copied.Status, _ = enums.RunStatusString(finish.Status.String)
-		copied.Output = json.RawMessage(finish.Output.String)
+		copied.Output = util.EnsureJSON(json.RawMessage(finish.Output.String))
 		copied.EndedAt = &finish.CreatedAt.Time
 	}
 	return &copied

--- a/pkg/history_reader/reader.go
+++ b/pkg/history_reader/reader.go
@@ -11,6 +11,7 @@ import (
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/history"
 	"github.com/inngest/inngest/pkg/usage"
+	"github.com/inngest/inngest/pkg/util"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -278,8 +279,7 @@ func (r Run) ToCQRS() *cqrs.FunctionRun {
 		Cron:            r.Cron,
 	}
 	if r.Output != nil {
-		bytes := json.RawMessage(*r.Output)
-		run.Output = bytes
+		run.Output = util.EnsureJSON(json.RawMessage(*r.Output))
 	}
 	return run
 }

--- a/pkg/util/json.go
+++ b/pkg/util/json.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func EnsureJSON(v json.RawMessage) json.RawMessage {
+	if !json.Valid(v) {
+		// Wrap the output in quotes to make it valid JSON.
+		return json.RawMessage(fmt.Sprintf("%q", v))
+	}
+	return v
+}


### PR DESCRIPTION
# Description
Ensure run output is JSON in REST API response.

# Motivation
This fixes a bug where our `/v1/runs/{runID}` endpoint returned an empty response body because of a JSON marshal error. This happens when we assign invalid JSON to a field of type `json.RawMessage`.

# Testing
Before these changes:
```
$ curl -i -H 'accept: application/json' "http://localhost:8288/v1/runs/01JN4QX129V5QDZMTKCZ5528QC"
HTTP/1.1 200 OK
Cache-Control: private, max-age=3
Content-Type: application/json
Vary: Origin
X-Inngest-Server-Kind: dev
Date: Thu, 27 Feb 2025 22:19:56 GMT
Content-Length: 0
```

After these changes:
```
$ curl -i -H 'accept: application/json' "http://localhost:8288/v1/runs/01JN4QYTXP7YY6G73HESM6RWQ2"
HTTP/1.1 200 OK
Cache-Control: private, max-age=3
Content-Type: application/json
Vary: Origin
X-Inngest-Server-Kind: dev
Date: Thu, 27 Feb 2025 22:20:51 GMT
Content-Length: 720

{"data":{"run_id":"01JN4QYTXP7YY6G73HESM6RWQ2","run_started_at":"2025-02-27T22:20:42.294Z","function_id":"21a23979-3e2b-5dbf-9b18-f72a54b1e658","function_version":0,"environment_id":"00000000-0000-4000-b000-000000000000","event_id":"01JN4QYHWJ8QE46R5D83FT8HZQ","original_run_id":"01JN4QYJ036638KVZXFP6T8ZWS","status":"Failed","ended_at":"2025-02-27T22:20:42.451986Z","output":"\u003c!doctype html\u003e\n\u003chtml lang=en\u003e\n\u003ctitle\u003e405 Method Not Allowed\u003c/title\u003e\n\u003ch1\u003eMethod Not Allowed\u003c/h1\u003e\n\u003cp\u003eThe method is not allowed for the requested URL.\u003c/p\u003e\n"},"metadata":{"fetched_at":"2025-02-27T22:20:51.511318Z","cached_until":"2025-02-27T22:20:54.511318Z"}}
```