### PR TITLE
another round of layout and ux fixes

### DIFF
--- a/ui/packages/components/src/CodeBlock/CodeBlock.tsx
+++ b/ui/packages/components/src/CodeBlock/CodeBlock.tsx
@@ -365,7 +365,7 @@ export function CodeBlock({
                   },
                   lineNumbers: 'on',
                   contextmenu: false,
-                  scrollBeyondLastLine: false,
+                  scrollBeyondLastLine: alwaysFullHeight ? true : false,
                   fontFamily: FONT.font,
                   fontSize: FONT.size,
                   fontWeight: 'light',

--- a/ui/packages/components/src/RunDetailsV3/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/RunInfo.tsx
@@ -87,7 +87,7 @@ export const RunInfo = ({
             onClick={() => setExpanded(!expanded)}
           >
             <RiArrowRightSLine
-              className={`shrink-0 transition-transform duration-500 ${
+              className={`shrink-0 transition-transform duration-[250ms] ${
                 expanded ? 'rotate-90' : ''
               }`}
             />

--- a/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
@@ -146,7 +146,9 @@ export const StepInfo = ({ selectedStep }: { selectedStep: StepInfoType }) => {
           onClick={() => setExpanded(!expanded)}
         >
           <RiArrowRightSLine
-            className={`shrink-0 transition-transform duration-500 ${expanded ? 'rotate-90' : ''}`}
+            className={`shrink-0 transition-transform duration-[250ms] ${
+              expanded ? 'rotate-90' : ''
+            }`}
           />
 
           <span className="text-basis text-sm font-normal">{trace.name}</span>

--- a/ui/packages/components/src/RunDetailsV3/TopInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/TopInfo.tsx
@@ -28,7 +28,6 @@ type TopInfoProps = {
   getTrigger: (runID: string) => Promise<Trigger>;
   result?: Result;
   runID: string;
-  height?: number;
 };
 
 export type Trigger = {
@@ -136,7 +135,9 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
           onClick={() => setExpanded(!expanded)}
         >
           <RiArrowRightSLine
-            className={`shrink-0 transition-transform duration-500 ${expanded ? 'rotate-90' : ''}`}
+            className={`shrink-0 transition-transform duration-[250ms] ${
+              expanded ? 'rotate-90' : ''
+            }`}
           />
           {isPending ? (
             <SkeletonElement />

--- a/ui/packages/components/src/RunDetailsV3/Trace.tsx
+++ b/ui/packages/components/src/RunDetailsV3/Trace.tsx
@@ -68,7 +68,7 @@ export function Trace({ depth, getResult, maxTime, minTime, pathCreator, trace, 
         >
           {hasChildren && (
             <div
-              className="flex shrink-0 flex-row items-center justify-start gap-1"
+              className="border-subtle flex flex-row items-center justify-center rounded border p-0 pl-1"
               onClick={(e) => {
                 e.stopPropagation();
                 setExpanded(!expanded);
@@ -76,14 +76,18 @@ export function Trace({ depth, getResult, maxTime, minTime, pathCreator, trace, 
             >
               <div className="text-sm font-medium leading-tight">{trace.childrenSpans?.length}</div>
               <RiArrowRightSLine
-                className={`shrink-0 transition-transform duration-500 ${
+                className={`text-subtle m-0 h-3.5 w-3.5 shrink-0 transition-transform duration-[250ms] ${
                   expanded ? 'rotate-90' : ''
                 }`}
               />
             </div>
           )}
 
-          <div className="text-basis overflow-hidden text-ellipsis whitespace-nowrap text-sm font-normal leading-tight">
+          <div
+            className={`text-basis overflow-hidden text-ellipsis whitespace-nowrap text-sm font-normal leading-tight ${
+              !hasChildren && 'pl-1.5'
+            }`}
+          >
             {trace.name}
           </div>
         </div>


### PR DESCRIPTION
## Description

Another round of test/design feedback, including:
1. min height of expanded run row
2. span expander style/ux adjustments
3. dynamic centering of drag indicator based on timeline height
4. shorter transitions
5. allow payload editor to fill vertical space to keep rows more neatly aligned

## Motivation
beter ux

<img width="833" alt="Screenshot 2025-03-04 at 12 44 43 PM" src="https://github.com/user-attachments/assets/34b8e487-5903-43eb-a972-3d523d8ed0aa" />


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
