### PR TITLE
Surface Vercel error on integrations page

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/data.ts
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/data.ts
@@ -1,3 +1,5 @@
+import { ClientError } from 'graphql-request';
+
 import { graphql } from '@/gql/gql';
 import type { VercelIntegration } from '@/gql/graphql';
 import graphqlAPI from '@/queries/graphqlAPI';
@@ -22,13 +24,17 @@ const vercelIntegrationQuery = graphql(`
   }
 `);
 
-export async function getVercelIntegration(): Promise<VercelIntegration | null> {
+export async function getVercelIntegration(): Promise<VercelIntegration | null | Error> {
   try {
     const res = await graphqlAPI.request(vercelIntegrationQuery);
     return res.account.vercelIntegration ?? null;
   } catch (err) {
-    // TODO: Handle this in the backend instead of swallowing here.
-    console.error(err);
-    return null;
+    if (err instanceof ClientError) {
+      return new Error(err.response.errors?.[0]?.message ?? 'Unknown error');
+    }
+    if (err instanceof Error) {
+      return err;
+    }
+    return new Error('Unknown error');
   }
 }

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/integrations.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/integrations.tsx
@@ -17,7 +17,7 @@ type Integration = {
   title: string;
   slug: string;
   Icon: ReactNode;
-  actionButton: (enabled: boolean, loading?: boolean) => ReactNode;
+  actionButton: (args: { enabled: boolean; hasError?: boolean }) => ReactNode;
   description: string;
   upvoteId?: string;
 };
@@ -27,12 +27,12 @@ const INTEGRATIONS: Integration[] = [
     title: 'Vercel',
     slug: 'vercel',
     Icon: <IconVercel className="text-onContrast h-6 w-6" />,
-    actionButton: (enabled, loading) => (
+    actionButton: ({ enabled, hasError }) => (
       <Button
+        disabled={hasError}
         kind="primary"
         appearance="solid"
         size="medium"
-        loading={loading}
         href={enabled ? '/settings/integrations/vercel' : '/settings/integrations/vercel/connect'}
         label={enabled ? 'Manage' : 'Connect'}
         prefetch={true}
@@ -45,12 +45,12 @@ const INTEGRATIONS: Integration[] = [
     title: 'Neon',
     slug: 'neon',
     Icon: <IconNeon className="text-onContrast h-6 w-6" />,
-    actionButton: (enabled, loading) => (
+    actionButton: ({ enabled, hasError }) => (
       <Button
+        disabled={hasError}
         kind="primary"
         appearance="solid"
         size="medium"
-        loading={loading}
         href={enabled ? '/settings/integrations/neon' : '/settings/integrations/neon/connect'}
         label={enabled ? 'Manage' : 'Connect'}
         prefetch={true}
@@ -62,12 +62,12 @@ const INTEGRATIONS: Integration[] = [
     title: 'Supabase',
     slug: 'supabase',
     Icon: <IconSupabase className="text-onContrast h-6 w-6" />,
-    actionButton: (enabled, loading) => (
+    actionButton: ({ enabled, hasError }) => (
       <Button
+        disabled={hasError}
         kind="primary"
         appearance="solid"
         size="medium"
-        loading={loading}
         href={
           enabled ? '/settings/integrations/supabase' : '/settings/integrations/supabase/connect'
         }
@@ -129,6 +129,7 @@ const INTEGRATIONS: Integration[] = [
 
 type Props = {
   integrations: {
+    error?: string;
     slug: string;
     enabled: boolean;
     projects: unknown[];
@@ -151,28 +152,33 @@ export default function IntegrationsList({ integrations }: Props) {
           if (i.title === 'Datadog' && !ddIntegration) return;
 
           const integrationData = getIntegrationData(i.slug);
-          const isEnabled =
-            i.slug === 'vercel'
-              ? Boolean(integrationData?.enabled && integrationData.projects.length > 0)
-              : integrationData?.enabled ?? false;
+          const isEnabled = Boolean(integrationData?.enabled);
 
           return (
             <Card key={`integration-card-${n}`}>
-              <div className="flex h-[189px] w-[388px] flex-col p-6">
+              <div className="flex w-[388px] flex-col p-6">
                 <div className="align-center flex flex-row items-center justify-between">
                   <div className="bg-contrast flex h-12 w-12 items-center justify-center rounded">
                     {i.Icon}
                   </div>
-                  {i.actionButton(isEnabled)}
+                  {i.actionButton({
+                    enabled: isEnabled,
+                    hasError: Boolean(integrationData?.error),
+                  })}
                 </div>
                 <div className="text-basis mt-[18px] text-lg font-medium">{i.title}</div>
                 <div className="text-muted mt-2 text-sm leading-tight">{i.description}</div>
+                {integrationData?.error && (
+                  <div className="text-error mt-2 text-sm leading-tight">
+                    {integrationData.error}
+                  </div>
+                )}
               </div>
             </Card>
           );
         })}
         <Card className="col-span-2">
-          <div className="bg-canvasSubtle flex h-[189px] w-[800px] flex-col p-6">
+          <div className="bg-canvasSubtle flex w-[800px] flex-col p-6">
             <div className="text-basis text-lg font-medium">Can&apos;t find what you need?</div>
             <div className="text-basis mt-3 text-sm leading-tight">
               Write to our team about the integration you are looking for and we will get back to

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/page.tsx
@@ -8,14 +8,26 @@ export default async function IntegrationsPage() {
 
   const integration = await getVercelIntegration();
   if (integration) {
-    allIntegrations = [
-      {
-        slug: 'vercel',
-        enabled: true,
-        projects: integration.projects,
-      },
-      ...allIntegrations,
-    ];
+    if (integration instanceof Error) {
+      allIntegrations = [
+        {
+          enabled: true,
+          error: integration.message,
+          projects: [],
+          slug: 'vercel',
+        },
+        ...allIntegrations,
+      ];
+    } else {
+      allIntegrations = [
+        {
+          enabled: true,
+          projects: integration.projects,
+          slug: 'vercel',
+        },
+        ...allIntegrations,
+      ];
+    }
   }
 
   return <IntegrationsList integrations={allIntegrations} />;

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/page.tsx
@@ -16,6 +16,9 @@ export default async function VercelIntegrationPage() {
   if (!integration) {
     throw new Error('Failed to load Vercel integration');
   }
+  if (integration instanceof Error) {
+    throw integration;
+  }
 
   return (
     <div className="mx-auto mt-6 flex w-[800px] flex-col p-8">


### PR DESCRIPTION
Surface Vercel integration fetching errors to the integrations page. Previously, we'd swallow the error and the page would look as if the integration wasn't connected.

![Screenshot 2025-03-07 at 11 07 06](https://github.com/user-attachments/assets/9f130549-a4d6-42e3-9c53-8b126fb7e62f)
