### PR TITLE
Allow realtime to subscribe from browsers

### DIFF
--- a/pkg/execution/realtime/api.go
+++ b/pkg/execution/realtime/api.go
@@ -131,7 +131,9 @@ func (a *api) GetWebsocketUpgrade(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ws, err := websocket.Accept(w, r, nil)
+	ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true, // We don't care about verifying the origin.
+	})
 	if err != nil {
 		w.WriteHeader(400)
 		logger.StdlibLogger(ctx).Error("error upgrading ws connection", "error", err)


### PR DESCRIPTION
## Description

Skips `Origin` checks when performing WS upgrade; we want folks to be able to subscribe from browsers.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
