### PR TITLE
Dynamically set trace endpoint based on configured port

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -129,9 +129,10 @@ func doDev(cmd *cobra.Command, args []string) {
 	tick := viper.GetInt("tick")
 	connectGatewayPort := viper.GetInt("connect-gateway-port")
 
+	traceEndpoint := fmt.Sprintf("localhost:%d", port)
 	if err := itrace.NewUserTracer(ctx, itrace.TracerOpts{
 		ServiceName:   "tracing",
-		TraceEndpoint: "localhost:8288",
+		TraceEndpoint: traceEndpoint,
 		TraceURLPath:  "/dev/traces",
 		Type:          itrace.TracerTypeOTLPHTTP,
 	}); err != nil {
@@ -144,7 +145,7 @@ func doDev(cmd *cobra.Command, args []string) {
 
 	if err := itrace.NewSystemTracer(ctx, itrace.TracerOpts{
 		ServiceName:   "tracing-system",
-		TraceEndpoint: "localhost:8288",
+		TraceEndpoint: traceEndpoint,
 		TraceURLPath:  "/dev/traces/system",
 		Type:          itrace.TracerTypeOTLPHTTP,
 	}); err != nil {

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -114,9 +114,10 @@ func doStart(cmd *cobra.Command, args []string) {
 		conf.CoreAPI.Addr = host
 	}
 
+	traceEndpoint := fmt.Sprintf("localhost:%d", port)
 	if err := itrace.NewUserTracer(ctx, itrace.TracerOpts{
 		ServiceName:   "tracing",
-		TraceEndpoint: "localhost:8288",
+		TraceEndpoint: traceEndpoint,
 		TraceURLPath:  "/dev/traces",
 		Type:          itrace.TracerTypeOTLPHTTP,
 	}); err != nil {
@@ -129,7 +130,7 @@ func doStart(cmd *cobra.Command, args []string) {
 
 	if err := itrace.NewSystemTracer(ctx, itrace.TracerOpts{
 		ServiceName:   "tracing-system",
-		TraceEndpoint: "localhost:8288",
+		TraceEndpoint: traceEndpoint,
 		TraceURLPath:  "/dev/traces/system",
 		Type:          itrace.TracerTypeOTLPHTTP,
 	}); err != nil {


### PR DESCRIPTION
## Description

Set trace endpoint based on configured port and remove hard coded port value.

## Motivation
Fixes #2236

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
