### PR TITLE
Index pauses globally

### DIFF
--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -416,6 +416,9 @@ type PauseKeyGenerator interface {
 	// Pause returns the key used to store an individual pause from its ID.
 	Pause(ctx context.Context, pauseID uuid.UUID) string
 
+	// GlobalPauseIndex returns the key used to index all pauses.
+	GlobalPauseIndex(ctx context.Context) string
+
 	// RunPauses stores pause IDs for each run as a zset
 	RunPauses(ctx context.Context, runID ulid.ULID) string
 
@@ -449,6 +452,10 @@ type pauseKeyGenerator struct {
 
 func (u pauseKeyGenerator) Pause(ctx context.Context, pauseID uuid.UUID) string {
 	return fmt.Sprintf("{%s}:pauses:%s", u.stateDefaultKey, pauseID.String())
+}
+
+func (u pauseKeyGenerator) GlobalPauseIndex(ctx context.Context) string {
+	return fmt.Sprintf("{%s}:pauses-idx", u.stateDefaultKey)
 }
 
 func (u pauseKeyGenerator) RunPauses(ctx context.Context, runID ulid.ULID) string {

--- a/pkg/execution/state/redis_state/lua/deletePause.lua
+++ b/pkg/execution/state/redis_state/lua/deletePause.lua
@@ -14,6 +14,7 @@ local pauseInvokeKey = KEYS[4]
 local keyPauseAddIdx = KEYS[5]
 local keyPauseExpIdx = KEYS[6]
 local keyRunPauses   = KEYS[7]
+local keyPausesIdx   = KEYS[8]
 
 local pauseID       = ARGV[1]
 local invokeCorrelationId = ARGV[2]
@@ -23,6 +24,9 @@ redis.call("DEL", pauseKey)
 redis.call("DEL", pauseStepKey)
 -- SREM to remove the pause for this run
 redis.call("SREM", keyRunPauses, pauseID)
+
+-- Clean up global index
+redis.call("SREM", keyPausesIdx, pauseID)
 
 if invokeCorrelationId ~= false and invokeCorrelationId ~= "" and invokeCorrelationId ~= nil then
   redis.call("HDEL", pauseInvokeKey, invokeCorrelationId)

--- a/pkg/execution/state/redis_state/lua/savePause.lua
+++ b/pkg/execution/state/redis_state/lua/savePause.lua
@@ -11,6 +11,7 @@ local pauseInvokeKey = KEYS[3]
 local keyPauseAddIdx = KEYS[4]
 local keyPauseExpIdx = KEYS[5]
 local keyRunPauses   = KEYS[6]
+local keyPausesIdx   = KEYS[7]
 
 local pause          = ARGV[1]
 local pauseID        = ARGV[2]
@@ -23,6 +24,9 @@ local nowUnixSeconds = tonumber(ARGV[6])
 if redis.call("SETNX", pauseKey, pause) == 0 then
 	return 1
 end
+
+-- Populate global index
+redis.call("SADD", keyPausesIdx, pauseID)
 
 redis.call("EXPIRE", pauseKey, extendedExpiry)
 

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -808,6 +808,7 @@ func (m unshardedMgr) SavePause(ctx context.Context, p state.Pause) error {
 		pause.kg.PauseIndex(ctx, "add", p.WorkspaceID, evt),
 		pause.kg.PauseIndex(ctx, "exp", p.WorkspaceID, evt),
 		pause.kg.RunPauses(ctx, p.Identifier.RunID),
+		pause.kg.GlobalPauseIndex(ctx),
 	}
 
 	args, err := StrSlice([]any{
@@ -1026,6 +1027,7 @@ func (m unshardedMgr) DeletePause(ctx context.Context, p state.Pause) error {
 		pause.kg.PauseIndex(ctx, "add", p.WorkspaceID, evt),
 		pause.kg.PauseIndex(ctx, "exp", p.WorkspaceID, evt),
 		runPausesKey,
+		pause.kg.GlobalPauseIndex(ctx),
 	}
 
 	status, err := scripts["deletePause"].Exec(


### PR DESCRIPTION
## Description

This creates a global pause index to facilitate migrations in the future. This will be backfilled in cloud.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
