### PR TITLE
Update exporter to default to 30MB limit for producing messages

### DIFF
--- a/pkg/telemetry/exporters/kafka.go
+++ b/pkg/telemetry/exporters/kafka.go
@@ -14,7 +14,8 @@ import (
 )
 
 var (
-	defaultMsgKey = "fn_id"
+	defaultMsgKey       = "fn_id"
+	defaultMaxProduceMB = 30 // 30MB
 )
 
 type kafkaSpanExporter struct {
@@ -28,6 +29,7 @@ type kafkaSpansExporterOpts struct {
 	key             string
 	autoCreateTopic bool
 	scramAuth       *scram.Auth
+	maxProduceMB    int
 }
 
 type KafkaSpansExporterOpts func(k *kafkaSpansExporterOpts)
@@ -63,6 +65,12 @@ func WithKafkaExporterScramAuth(user, pass string) KafkaSpansExporterOpts {
 	}
 }
 
+func WithKafkaExporterMaxProduceMB(size int) KafkaSpansExporterOpts {
+	return func(k *kafkaSpansExporterOpts) {
+		k.maxProduceMB = size
+	}
+}
+
 func NewKafkaSpanExporter(ctx context.Context, opts ...KafkaSpansExporterOpts) (trace.SpanExporter, error) {
 	conf := &kafkaSpansExporterOpts{}
 
@@ -87,6 +95,7 @@ func NewKafkaSpanExporter(ctx context.Context, opts ...KafkaSpansExporterOpts) (
 		kgo.DefaultProduceTopic(conf.topic),
 		kgo.RequiredAcks(kgo.AllISRAcks()), // Most durable with some perf hits
 
+		kgo.ProducerBatchMaxBytes(int32(conf.maxProduceMB * 1024 * 1024)),
 		// Increment metrics on data loss detection
 		kgo.ProducerOnDataLossDetected(func(topic string, partition int32) {
 			// record data loss when happened.

--- a/pkg/telemetry/exporters/kafka.go
+++ b/pkg/telemetry/exporters/kafka.go
@@ -72,7 +72,9 @@ func WithKafkaExporterMaxProduceMB(size int) KafkaSpansExporterOpts {
 }
 
 func NewKafkaSpanExporter(ctx context.Context, opts ...KafkaSpansExporterOpts) (trace.SpanExporter, error) {
-	conf := &kafkaSpansExporterOpts{}
+	conf := &kafkaSpansExporterOpts{
+		maxProduceMB: defaultMaxProduceMB,
+	}
 
 	for _, apply := range opts {
 		apply(conf)


### PR DESCRIPTION
## Description

The kafka producer defaults to 1MB limit for message sizes.
This is not large enough for traces so changing it to default to 30MB and allow customization if needed.
 

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
