### PR TITLE
INN-4610: trace run start/first step alignment fix & finalization

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -803,9 +803,16 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 		return nil, err
 	}
 
-	// for recording function start time after a successful step.
+	//
+	// record function start time using the same method as step started,
+	// ensures ui timeline alignment
+	start, ok := redis_state.GetItemStart(ctx)
+	if !ok {
+		start = time.Now()
+	}
+
 	if md.Config.StartedAt.IsZero() {
-		md.Config.StartedAt = time.Now()
+		md.Config.StartedAt = start
 	}
 
 	if v.stopWithoutRetry {

--- a/pkg/run/trace_lifecycle.go
+++ b/pkg/run/trace_lifecycle.go
@@ -172,7 +172,11 @@ func (l traceLifecycle) OnFunctionStarted(
 	// reassign here to make sure we have the right traceID and such
 	ctx = l.extractTraceCtx(ctx, md, true)
 
-	start := time.Now()
+	start, ok := redis_state.GetItemStart(ctx)
+	if !ok {
+		start = time.Now()
+	}
+
 	if !md.Config.StartedAt.IsZero() {
 		start = md.Config.StartedAt
 	}

--- a/ui/packages/components/src/RunDetailsV3/InlineSpans.tsx
+++ b/ui/packages/components/src/RunDetailsV3/InlineSpans.tsx
@@ -3,9 +3,9 @@ import { Fragment } from 'react';
 import { ElementWrapper } from '../DetailsCard/Element';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip';
 import { cn } from '../utils/classNames';
-import { formatMilliseconds, toMaybeDate } from '../utils/date';
+import { toMaybeDate } from '../utils/date';
 import { Span } from './Span';
-import { formatDuration } from './TimelineHeader';
+import { formatDuration, getSpanName } from './utils';
 
 type Props = {
   className?: string;
@@ -22,6 +22,7 @@ type Props = {
 };
 
 export function InlineSpans({ className, minTime, maxTime, name, spans, widths }: Props) {
+  const spanName = getSpanName(name);
   return (
     <Tooltip>
       <TooltipTrigger className="h-fit w-full grow">
@@ -46,14 +47,16 @@ export function InlineSpans({ className, minTime, maxTime, name, spans, widths }
       </TooltipTrigger>
       <TooltipContent>
         <div className="text-basis">
-          {spans[0] && <Times isDelayVisible={spans.length === 1} name={name} span={spans[0]} />}
+          {spans[0] && (
+            <Times isDelayVisible={spans.length === 1} name={spanName} span={spans[0]} />
+          )}
 
           {spans.length > 1 &&
             spans.map((span) => {
               return (
                 <Fragment key={span.spanID}>
                   <hr className="my-2" />
-                  <Times name={span.name} span={span} />
+                  <Times name={spanName} span={span} />
                   {span.spanID}
                 </Fragment>
               );

--- a/ui/packages/components/src/RunDetailsV3/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/RunInfo.tsx
@@ -20,7 +20,7 @@ import type { Result } from '../types/functionRun';
 import { toMaybeDate } from '../utils/date';
 import { isLazyDone, type Lazy } from '../utils/lazyLoad';
 import { ActionsMenu } from './ActionMenu';
-import { formatDuration } from './TimelineHeader';
+import { formatDuration } from './utils';
 
 type Props = {
   standalone: boolean;

--- a/ui/packages/components/src/RunDetailsV3/Span.tsx
+++ b/ui/packages/components/src/RunDetailsV3/Span.tsx
@@ -46,7 +46,7 @@ export function Span({ className, isInline, maxTime, minTime, trace }: Props) {
       {/* Queued part of the span */}
       {widths.queued > 0 && (
         <div
-          className="bg-surfaceSubtle dark:bg-surfaceMuted h-2"
+          className="bg-surfaceSubtle dark:bg-surfaceMuted h-1"
           style={{ flexGrow: widths.queued }}
         ></div>
       )}

--- a/ui/packages/components/src/RunDetailsV3/TimelineHeader.tsx
+++ b/ui/packages/components/src/RunDetailsV3/TimelineHeader.tsx
@@ -1,4 +1,5 @@
 import { type Trace } from './types';
+import { formatDuration } from './utils';
 
 type TimelineHeaderProps = {
   trace: Trace;
@@ -7,27 +8,6 @@ type TimelineHeaderProps = {
 };
 
 const xAxis = [25, 50, 75, 100];
-
-export const formatDuration = (ms: number): string => {
-  const units = [
-    { label: 'd', value: 86400000 }, // 24 * 60 * 60 * 1000
-    { label: 'h', value: 3600000 }, // 60 * 60 * 1000
-    { label: 'm', value: 60000 }, // 60 * 1000
-    { label: 's', value: 1000 }, // 1000
-    { label: 'ms', value: 1 },
-  ];
-
-  for (const { label, value } of units) {
-    if (ms >= value) {
-      const amount = ms / value;
-      const rounded = Math.round(amount * 10) / 10;
-      const display = rounded % 1 === 0 ? rounded.toFixed(0) : rounded.toFixed(1);
-      return `${display}${label}`;
-    }
-  }
-
-  return '0ms';
-};
 
 const getEventDurations = (start: Date, end: Date, count: number): string[] => {
   const totalMs = end.getTime() - start.getTime();

--- a/ui/packages/components/src/RunDetailsV3/Trace.tsx
+++ b/ui/packages/components/src/RunDetailsV3/Trace.tsx
@@ -7,7 +7,7 @@ import { toMaybeDate } from '../utils/date';
 import { InlineSpans } from './InlineSpans';
 import { TimelineHeader } from './TimelineHeader';
 import { type Trace } from './types';
-import { createSpanWidths, useStepSelection, type StepInfoType } from './utils';
+import { createSpanWidths, getSpanName, useStepSelection, type StepInfoType } from './utils';
 
 type Props = {
   depth: number;
@@ -88,7 +88,7 @@ export function Trace({ depth, getResult, maxTime, minTime, pathCreator, trace, 
               !hasChildren && 'pl-1.5'
             }`}
           >
-            {trace.name}
+            {getSpanName(trace.name)}
           </div>
         </div>
 

--- a/ui/packages/components/src/RunDetailsV3/utils.ts
+++ b/ui/packages/components/src/RunDetailsV3/utils.ts
@@ -4,11 +4,7 @@ import type { Result } from '@inngest/components/types/functionRun';
 
 import type { Trace } from './types';
 
-type Span = {
-  endedAt: Date | null;
-  queuedAt: Date;
-  startedAt: Date | null;
-};
+export const FINAL_SPAN_NAME = 'Finalization';
 
 export type SpanWidths = {
   after: number;
@@ -122,4 +118,29 @@ export const useStepSelection = (runID?: string) => {
   }, []);
 
   return { selectedStep, selectStep };
+};
+
+export const formatDuration = (ms: number): string => {
+  const units = [
+    { label: 'd', value: 86400000 }, // 24 * 60 * 60 * 1000
+    { label: 'h', value: 3600000 }, // 60 * 60 * 1000
+    { label: 'm', value: 60000 }, // 60 * 1000
+    { label: 's', value: 1000 }, // 1000
+    { label: 'ms', value: 1 },
+  ];
+
+  for (const { label, value } of units) {
+    if (ms >= value) {
+      const amount = ms / value;
+      const rounded = Math.round(amount * 10) / 10;
+      const display = rounded % 1 === 0 ? rounded.toFixed(0) : rounded.toFixed(1);
+      return `${display}${label}`;
+    }
+  }
+
+  return '0ms';
+};
+
+export const getSpanName = (name: string) => {
+  return name === 'function success' ? FINAL_SPAN_NAME : name;
 };


### PR DESCRIPTION
## Description

* get function run start and first step start lined up by using the same start time.
* ship the function success span and use it to fill in "finalization":

<img width="660" alt="Screenshot 2025-03-12 at 11 56 06 AM" src="https://github.com/user-attachments/assets/1a85b734-bb0f-40a1-9e6a-f3d6708b537d" />

## Motivation
Better run timelines.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
