### PR TITLE
Fix fake AWS APIGateway request event for local dev

### DIFF
--- a/pkg/util/awsgateway/awsgateway.go
+++ b/pkg/util/awsgateway/awsgateway.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"strconv"

--- a/pkg/util/awsgateway/awsgateway.go
+++ b/pkg/util/awsgateway/awsgateway.go
@@ -131,7 +131,6 @@ func headersToMap(header http.Header) map[string]string {
 	headerMap := make(map[string]string)
 	for key, values := range header {
 		if len(values) > 0 {
-			fmt.Println("key", key, "value", values[0])
 			headerMap[strings.ToLower(key)] = values[0]
 		}
 	}

--- a/pkg/util/awsgateway/awsgateway.go
+++ b/pkg/util/awsgateway/awsgateway.go
@@ -114,7 +114,7 @@ func TransformRequest(r *http.Request) (*http.Request, error) {
 		HTTPMethod:            r.Method,
 		Headers:               headersToMap(headers),
 		QueryStringParameters: queryParams,
-		MultiValueHeaders:     r.URL.Query(),
+		MultiValueHeaders:     headers,
 		Body:                  base64.RawStdEncoding.EncodeToString(body),
 		IsBase64Encoded:       true,
 	}


### PR DESCRIPTION
## Description

When using Lambda with Docker in local development, the TypeScript SDK failed to work for invocations due to a missing content type headers ([source code](https://github.com/inngest/inngest-js/blob/00aed796dc5215d06ee90fe6952086862b002bb8/packages/inngest/src/components/InngestCommHandler.ts#L818-L822)). This workaround where the dev server mock's a APIGateway event to matching Docker image URLs, was not correctly setting all headers. This passes through headers and adds content length.

Overall, we should consider moving away from this approach and perhaps adding other instructions or some other way to do this that can step up to date with Lambda and not rely on a URL pathname to determine how to format the request payload.

## Motivation
This example repo no longer worked: https://github.com/inngest/sdk-example-aws-lambda

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
