### PR TITLE
Retry hanging and failing syncs with backoff during connect

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -274,7 +274,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 				c.closeWithConnectError(ws, &SocketError{
 					SysCode:    syscode.CodeConnectInternal,
 					StatusCode: websocket.StatusInternalError,
-					Msg:        "Internal error",
+					Msg:        "Internal error while syncing",
 				})
 
 				return

--- a/pkg/connect/state/state.go
+++ b/pkg/connect/state/state.go
@@ -259,6 +259,11 @@ func (g *WorkerGroup) Sync(ctx context.Context, groupManager WorkerGroupManager,
 			req.Header.Set(headers.HeaderAuthorization, fmt.Sprintf("Bearer %s", g.SyncData.SyncToken))
 		}
 
+		// Provide environment name for branch environments
+		if initialReq.GetEnvironment() != "" {
+			req.Header.Set("X-Inngest-Env", initialReq.GetEnvironment())
+		}
+
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return fmt.Errorf("error making sync request: %w", err)

--- a/pkg/connect/state/state.go
+++ b/pkg/connect/state/state.go
@@ -4,11 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"github.com/inngest/inngest/pkg/backoff"
+	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/publicerr"
 	"github.com/inngest/inngest/pkg/syscode"
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"github.com/oklog/ulid/v2"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -220,10 +224,24 @@ func (g *WorkerGroup) Sync(ctx context.Context, groupManager WorkerGroupManager,
 	maxRetryAttempts := 10
 	attempt := 0
 
-	var resp *http.Response
+	// Retrieve the deploy ID for the sync and update state with it if available
+	var syncReply cqrs.SyncReply
 	for {
+		attempt++
+
 		if attempt == maxRetryAttempts {
 			return fmt.Errorf("existing sync took too long to complete")
+		}
+
+		// Apply exponential backoff for retries
+		if attempt > 1 {
+			backOffDur := backoff.ExponentialJitterBackoff(attempt).Sub(time.Now())
+
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("could not wait for sync to complete")
+			case <-time.After(backOffDur):
+			}
 		}
 
 		req, err := http.NewRequest(http.MethodPost, registerURL, bytes.NewReader(byt))
@@ -241,7 +259,7 @@ func (g *WorkerGroup) Sync(ctx context.Context, groupManager WorkerGroupManager,
 			req.Header.Set(headers.HeaderAuthorization, fmt.Sprintf("Bearer %s", g.SyncData.SyncToken))
 		}
 
-		resp, err = http.DefaultClient.Do(req)
+		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			return fmt.Errorf("error making sync request: %w", err)
 		}
@@ -254,28 +272,27 @@ func (g *WorkerGroup) Sync(ctx context.Context, groupManager WorkerGroupManager,
 
 			// Wait for other sync to complete and retry
 			if perr.Code == syscode.CodeSyncAlreadyPending {
-				select {
-				case <-ctx.Done():
-					return fmt.Errorf("could not wait for sync to complete")
-				case <-time.After(2 * time.Second):
-				}
-				attempt++
 				continue
 			}
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(&syncReply); err != nil {
+			if errors.Is(err, io.EOF) {
+				logger.StdlibLogger(ctx).Warn("got EOF for connect sync, retrying", "err", err, "")
+				continue
+			}
+			return fmt.Errorf("error parsing sync response: %w", err)
 		}
 
 		break
 	}
 
-	// Retrieve the deploy ID for the sync and update state with it if available
-	var syncReply cqrs.SyncReply
-	if err := json.NewDecoder(resp.Body).Decode(&syncReply); err != nil {
-		return fmt.Errorf("error parsing sync response: %w", err)
-	}
-
-	// Update the worker group to make sure it store the appropriate IDs
+	// We always expect the App ID & Sync ID to be included in a sync result, representing either the idempotent reply or the new sync.
 	if !syncReply.IsSuccess() {
-		// We always expect the App ID & Sync ID to be included in a sync result, representing either the idempotent reply or the new sync.
+		if syncReply.Error != nil {
+			return fmt.Errorf("invalid sync result: %s", *syncReply.Error)
+		}
+
 		return fmt.Errorf("invalid sync result")
 	}
 

--- a/pkg/connect/state/state.go
+++ b/pkg/connect/state/state.go
@@ -278,7 +278,7 @@ func (g *WorkerGroup) Sync(ctx context.Context, groupManager WorkerGroupManager,
 
 		if err := json.NewDecoder(resp.Body).Decode(&syncReply); err != nil {
 			if errors.Is(err, io.EOF) {
-				logger.StdlibLogger(ctx).Warn("got EOF for connect sync, retrying", "err", err, "")
+				logger.StdlibLogger(ctx).Warn("got EOF for connect sync, retrying", "err", err)
 				continue
 			}
 			return fmt.Errorf("error parsing sync response: %w", err)

--- a/pkg/connect/state/state.go
+++ b/pkg/connect/state/state.go
@@ -278,7 +278,13 @@ func (g *WorkerGroup) Sync(ctx context.Context, groupManager WorkerGroupManager,
 
 		if err := json.NewDecoder(resp.Body).Decode(&syncReply); err != nil {
 			if errors.Is(err, io.EOF) {
-				logger.StdlibLogger(ctx).Warn("got EOF for connect sync, retrying", "err", err)
+				logger.StdlibLogger(ctx).Warn(
+					"got EOF for connect sync, retrying",
+					"err", err,
+					"conn_id", initialReq.ConnectionId,
+					"account_id", g.AccountID,
+					"env_id", g.EnvID,
+				)
 				continue
 			}
 			return fmt.Errorf("error parsing sync response: %w", err)

--- a/pkg/connect/state/state.go
+++ b/pkg/connect/state/state.go
@@ -235,7 +235,7 @@ func (g *WorkerGroup) Sync(ctx context.Context, groupManager WorkerGroupManager,
 
 		// Apply exponential backoff for retries
 		if attempt > 1 {
-			backOffDur := backoff.ExponentialJitterBackoff(attempt).Sub(time.Now())
+			backOffDur := time.Until(backoff.ExponentialJitterBackoff(attempt))
 
 			select {
 			case <-ctx.Done():


### PR DESCRIPTION
## Description

This PR adds exponential backoff retries for hanging and failing syncs. Since the syncing endpoint is idempotent, we can retry requests to ensure a more stable syncing experience. For failing syncs, we now also return the error message to improve visibility.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
