### PR TITLE
Ensure next handler is called when auth middleware is used.

### DIFF
--- a/pkg/execution/realtime/api_token_auth.go
+++ b/pkg/execution/realtime/api_token_auth.go
@@ -41,7 +41,8 @@ func realtimeAuthMW(jwtSecret []byte, mw func(http.Handler) http.Handler) func(h
 
 			// Call the original middelware.
 			if mw != nil {
-				mw(next)
+				res := mw(next)
+				res.ServeHTTP(w, r)
 				return
 			}
 			next.ServeHTTP(w, r)


### PR DESCRIPTION
## Description

In cloud, we pass auth middleware that loads keys so clients can fetch the token with a signing key (or future auth strategy). This ensures that the resulting middlware calls the next handler.

This was debugged and tested in the upstream cloud monorepo. This is not breaking as auth middleware is not used in OSS and it's broken in prod.

## Motivation
The fetch token endpoint is not working correctly in production.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
