### PR TITLE
Add support for `x-inngest-event-seed-id` header

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -261,7 +261,7 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 			defer span.End()
 
 			seed := event.SeededIDFromString(
-				r.Header.Get("x-inngest-idempotency-key"),
+				r.Header.Get(headers.HeaderEventIDSeed),
 				index,
 			)
 			id, err := a.handler(ctx, &evt, seed)
@@ -333,7 +333,7 @@ func (a API) Invoke(w http.ResponseWriter, r *http.Request) {
 	evt := event.NewInvocationEvent(newInvOpts)
 
 	seed := event.SeededIDFromString(
-		r.Header.Get("x-inngest-idempotency-key"),
+		r.Header.Get(headers.HeaderEventIDSeed),
 		0,
 	)
 	evtID, err := a.handler(r.Context(), &evt, seed)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-type EventHandler func(context.Context, *event.Event) (string, error)
+type EventHandler func(context.Context, *event.Event, *event.SeededID) (string, error)
 
 type Options struct {
 	Config config.Config
@@ -220,7 +220,9 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 		// Close the idChan so that we stop appending to the ID slice.
 		defer close(idChan)
 
+		index := 0
 		for s := range stream {
+			index++
 			evt := event.Event{}
 			if err := json.Unmarshal(s.Item, &evt); err != nil {
 				return err
@@ -258,7 +260,11 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 				)
 			defer span.End()
 
-			id, err := a.handler(ctx, &evt)
+			seed := event.SeededIDFromString(
+				r.Header.Get("x-inngest-idempotency-key"),
+				index,
+			)
+			id, err := a.handler(ctx, &evt, seed)
 			if err != nil {
 				a.log.Error().Str("event", evt.Name).Err(err).Msg("error handling event")
 				return err
@@ -326,7 +332,11 @@ func (a API) Invoke(w http.ResponseWriter, r *http.Request) {
 	}
 	evt := event.NewInvocationEvent(newInvOpts)
 
-	evtID, err := a.handler(r.Context(), &evt)
+	seed := event.SeededIDFromString(
+		r.Header.Get("x-inngest-idempotency-key"),
+		0,
+	)
+	evtID, err := a.handler(r.Context(), &evt, seed)
 	if err != nil {
 		_ = publicerr.WriteHTTP(w, publicerr.Wrapf(err, 500, "Unable to create invocation event: %s", err))
 		return

--- a/pkg/api/service.go
+++ b/pkg/api/service.go
@@ -118,7 +118,11 @@ func (a *apiServer) Run(ctx context.Context) error {
 	return err
 }
 
-func (a *apiServer) handleEvent(ctx context.Context, e *event.Event) (string, error) {
+func (a *apiServer) handleEvent(
+	ctx context.Context,
+	e *event.Event,
+	seed *event.SeededID,
+) (string, error) {
 	// ctx is the request context, so we need to re-add
 	// the caller here.
 	l := logger.From(ctx).With().Str("caller", "api").Logger()
@@ -127,7 +131,10 @@ func (a *apiServer) handleEvent(ctx context.Context, e *event.Event) (string, er
 
 	l.Debug().Str("event", e.Name).Msg("handling event")
 
-	trackedEvent := event.NewOSSTrackedEvent(*e)
+	trackedEvent := event.NewOSSTrackedEvent(
+		*e,
+		seed,
+	)
 
 	byt, err := json.Marshal(trackedEvent)
 	if err != nil {

--- a/pkg/coreapi/graph/resolvers/app_mutations.go
+++ b/pkg/coreapi/graph/resolvers/app_mutations.go
@@ -114,7 +114,7 @@ func (r *mutationResolver) InvokeFunction(
 	defer span.End()
 
 	sent := false
-	_, err := r.EventHandler(ctx, &evt)
+	_, err := r.EventHandler(ctx, &evt, nil)
 	if err != nil {
 		return &sent, err
 	}

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -537,7 +537,7 @@ func createConnectPubSubRedis() rueidis.ClientOption {
 
 func getSendingEventHandler(ctx context.Context, pb pubsub.Publisher, topic string) execution.HandleSendingEvent {
 	return func(ctx context.Context, evt event.Event, item queue.Item) error {
-		trackedEvent := event.NewOSSTrackedEvent(evt)
+		trackedEvent := event.NewOSSTrackedEvent(evt, nil)
 		byt, err := json.Marshal(trackedEvent)
 		if err != nil {
 			return fmt.Errorf("error marshalling invocation event: %w", err)
@@ -573,7 +573,7 @@ func getInvokeFailHandler(ctx context.Context, pb pubsub.Publisher, topic string
 		for _, e := range evts {
 			evt := e
 			eg.Go(func() error {
-				trackedEvent := event.NewOSSTrackedEvent(evt)
+				trackedEvent := event.NewOSSTrackedEvent(evt, nil)
 				byt, err := json.Marshal(trackedEvent)
 				if err != nil {
 					return fmt.Errorf("error marshalling function finished event: %w", err)

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -5,8 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	v0 "github.com/inngest/inngest/pkg/connect/rest/v0"
-	"github.com/inngest/inngest/pkg/enums"
 	"net"
 	"net/url"
 	"os"
@@ -14,6 +12,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	v0 "github.com/inngest/inngest/pkg/connect/rest/v0"
+	"github.com/inngest/inngest/pkg/enums"
 
 	"github.com/inngest/inngest/pkg/connect/auth"
 
@@ -359,7 +360,7 @@ func (d *devserver) pollSDKs(ctx context.Context) {
 	}
 }
 
-func (d *devserver) HandleEvent(ctx context.Context, e *event.Event) (string, error) {
+func (d *devserver) HandleEvent(ctx context.Context, e *event.Event, seed *event.SeededID) (string, error) {
 	// ctx is the request context, so we need to re-add
 	// the caller here.
 	l := logger.From(ctx).With().Str("caller", d.Name()).Logger()
@@ -367,7 +368,7 @@ func (d *devserver) HandleEvent(ctx context.Context, e *event.Event) (string, er
 
 	l.Debug().Str("event", e.Name).Msg("handling event")
 
-	trackedEvent := event.NewOSSTrackedEvent(*e)
+	trackedEvent := event.NewOSSTrackedEvent(*e, seed)
 
 	byt, err := json.Marshal(trackedEvent)
 	if err != nil {

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -278,7 +278,6 @@ func (e Event) InngestMetadata() (*InngestMetadata, error) {
 }
 
 func NewOSSTrackedEvent(e Event, seed *SeededID) TrackedEvent {
-	fmt.Println("\nNewOSSTrackedEvent")
 	// Never use e.ID as the internal ID, since it's specified by the sender
 	internalID := ulid.MustNew(ulid.Now(), rand.Reader)
 
@@ -287,7 +286,6 @@ func NewOSSTrackedEvent(e Event, seed *SeededID) TrackedEvent {
 		if err == nil {
 			internalID = newInternalID
 		}
-		fmt.Println("internalID", internalID.String())
 	}
 
 	if e.ID == "" {

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -1,11 +1,15 @@
 package event
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -45,6 +49,74 @@ func NewEvent(data []byte) (*Event, error) {
 	}
 
 	return evt, nil
+}
+
+type SeededID struct {
+	// Entropy is the 10-byte entropy value used to generate the ULID.
+	Entropy []byte
+
+	// Millis is the number of milliseconds since the Unix epoch.
+	Millis int64
+}
+
+func (s *SeededID) ToULID() (ulid.ULID, error) {
+	if len(s.Entropy) != 10 {
+		return ulid.ULID{}, fmt.Errorf("entropy must be 10 bytes")
+	}
+
+	if s.Millis <= 0 {
+		return ulid.ULID{}, fmt.Errorf("millis must be greater than 0")
+	}
+
+	return ulid.New(uint64(s.Millis), bytes.NewReader(s.Entropy))
+}
+
+// SeededIDFromString parses an event idempotency key header value and returns a
+// new SeededID.
+//
+// The "value" param must be of the form "millis,entropy", where millis is the
+// number of milliseconds since the Unix epoch, and entropy is a base64-encoded
+// 10-byte value. For example: "1743130137367,eii2YKXRVTJPuA==".
+//
+// The "index" param is the index of the event in the request. This is used to
+// give each event in a multi-event payload its own unique entropy despite only
+// 1 entropy value being in the request header.
+func SeededIDFromString(value string, index int) *SeededID {
+	if value == "" {
+		return nil
+	}
+
+	parts := strings.Split(value, ",")
+	if len(parts) != 2 {
+		return nil
+	}
+
+	millis, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return nil
+	}
+	if millis <= 0 {
+		return nil
+	}
+
+	entropy, err := base64.StdEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil
+	}
+	if len(entropy) != 10 {
+		return nil
+	}
+
+	//
+	binary.BigEndian.PutUint32(
+		entropy[6:10],
+		binary.BigEndian.Uint32(entropy[6:10])+uint32(index),
+	)
+
+	return &SeededID{
+		Entropy: entropy,
+		Millis:  millis,
+	}
 }
 
 // Event represents an event sent to Inngest.
@@ -205,9 +277,19 @@ func (e Event) InngestMetadata() (*InngestMetadata, error) {
 	}
 }
 
-func NewOSSTrackedEvent(e Event) TrackedEvent {
+func NewOSSTrackedEvent(e Event, seed *SeededID) TrackedEvent {
+	fmt.Println("\nNewOSSTrackedEvent")
 	// Never use e.ID as the internal ID, since it's specified by the sender
 	internalID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	if seed != nil {
+		newInternalID, err := seed.ToULID()
+		if err == nil {
+			internalID = newInternalID
+		}
+		fmt.Println("internalID", internalID.String())
+	}
+
 	if e.ID == "" {
 		e.ID = internalID.String()
 	}

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -107,7 +107,8 @@ func SeededIDFromString(value string, index int) *SeededID {
 		return nil
 	}
 
-	//
+	// Add the index to the entropy to allow a single seed string to generate
+	// many unique ULIDs.
 	binary.BigEndian.PutUint32(
 		entropy[6:10],
 		binary.BigEndian.Uint32(entropy[6:10])+uint32(index),
@@ -284,6 +285,10 @@ func NewOSSTrackedEvent(e Event, seed *SeededID) TrackedEvent {
 	if seed != nil {
 		newInternalID, err := seed.ToULID()
 		if err == nil {
+			// IMPORTANT: This means it's possible for duplicate internal IDs in
+			// the event store. This is not ideal but it's the best we can do
+			// until we add first-class event idempotency (it's currently
+			// enforced when scheduling runs).
 			internalID = newInternalID
 		}
 	}

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -1,0 +1,154 @@
+package event
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInternalIDSeedFromString(t *testing.T) {
+	t.Run("deterministic", func(t *testing.T) {
+		// A single idempotency key should always generate the same ULID.
+
+		r := require.New(t)
+
+		now := time.Now().UnixMilli()
+		entropy := make([]byte, 10)
+		_, err := rand.Read(entropy)
+		r.NoError(err)
+		idempotencyKey := fmt.Sprintf(
+			"%d,%s",
+			now,
+			base64.StdEncoding.EncodeToString(entropy),
+		)
+
+		seed := SeededIDFromString(idempotencyKey, 0)
+		r.NotNil(seed)
+		ulid1, err := seed.ToULID()
+		r.NoError(err)
+		ulid2, err := seed.ToULID()
+		r.NoError(err)
+		r.Equal(ulid1.String(), ulid2.String())
+	})
+
+	t.Run("index varies the ULID", func(t *testing.T) {
+		// The same idempotency key with different indexes generates different
+		// ULIDs.
+
+		r := require.New(t)
+
+		now := time.Now().UnixMilli()
+		entropy := make([]byte, 10)
+		_, err := rand.Read(entropy)
+		r.NoError(err)
+		idempotencyKey := fmt.Sprintf(
+			"%d,%s",
+			now,
+			base64.StdEncoding.EncodeToString(entropy),
+		)
+
+		seed0 := SeededIDFromString(idempotencyKey, 0)
+		seed1 := SeededIDFromString(idempotencyKey, 1)
+		r.NotNil(seed0)
+		r.NotNil(seed1)
+		ulid0, err := seed0.ToULID()
+		r.NoError(err)
+		ulid1, err := seed1.ToULID()
+		r.NoError(err)
+		r.NotEqual(ulid0.String(), ulid1.String())
+	})
+
+	t.Run("high index", func(t *testing.T) {
+		// When the index is high (e.g. the max number events in a request), the
+		// ULID is still unique for each event.
+
+		r := require.New(t)
+
+		now := time.Now().UnixMilli()
+		entropy := make([]byte, 10)
+		_, err := rand.Read(entropy)
+		r.NoError(err)
+		idempotencyKey := fmt.Sprintf(
+			"%d,%s",
+			now,
+			base64.StdEncoding.EncodeToString(entropy),
+		)
+
+		var zeroULID ulid.ULID
+		uniqueIDs := map[string]struct{}{}
+		for i := 0; i < consts.MaxEvents; i++ {
+			seed := SeededIDFromString(idempotencyKey, i)
+			r.NotNil(seed)
+			id, err := seed.ToULID()
+			r.NoError(err)
+			r.NotEqual(zeroULID.String(), id.String())
+			uniqueIDs[id.String()] = struct{}{}
+		}
+
+		// No duplicates.
+		r.Len(uniqueIDs, consts.MaxEvents)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		r := require.New(t)
+
+		seed := SeededIDFromString("", 0)
+		r.Nil(seed)
+	})
+
+	t.Run("negative millis", func(t *testing.T) {
+		r := require.New(t)
+
+		entropy := make([]byte, 10)
+		_, err := rand.Read(entropy)
+		r.NoError(err)
+		idempotencyKey := fmt.Sprintf(
+			"%d,%s",
+			-1,
+			base64.StdEncoding.EncodeToString(entropy),
+		)
+
+		seed := SeededIDFromString(idempotencyKey, 0)
+		r.Nil(seed)
+	})
+
+	t.Run("too few bytes", func(t *testing.T) {
+		r := require.New(t)
+
+		now := time.Now().UnixMilli()
+		entropy := make([]byte, 9)
+		_, err := rand.Read(entropy)
+		r.NoError(err)
+		idempotencyKey := fmt.Sprintf(
+			"%d,%s",
+			now,
+			base64.StdEncoding.EncodeToString(entropy),
+		)
+
+		seed := SeededIDFromString(idempotencyKey, 0)
+		r.Nil(seed)
+	})
+
+	t.Run("too many bytes", func(t *testing.T) {
+		r := require.New(t)
+
+		now := time.Now().UnixMilli()
+		entropy := make([]byte, 11)
+		_, err := rand.Read(entropy)
+		r.NoError(err)
+		idempotencyKey := fmt.Sprintf(
+			"%d,%s",
+			now,
+			base64.StdEncoding.EncodeToString(entropy),
+		)
+
+		seed := SeededIDFromString(idempotencyKey, 0)
+		r.Nil(seed)
+	})
+}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -142,7 +142,7 @@ func (s *svc) getFinishHandler(ctx context.Context) (func(context.Context, sv2.I
 		for _, e := range events {
 			evt := e
 			eg.Go(func() error {
-				trackedEvent := event.NewOSSTrackedEvent(evt)
+				trackedEvent := event.NewOSSTrackedEvent(evt, nil)
 				byt, err := json.Marshal(trackedEvent)
 				if err != nil {
 					return fmt.Errorf("error marshalling event: %w", err)

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -268,7 +268,7 @@ func (s *svc) InitializeCrons(ctx context.Context) error {
 					ID:        time.Now().UTC().Format(time.RFC3339),
 					Name:      event.FnCronName,
 					Timestamp: time.Now().UnixMilli(),
-				})
+				}, nil)
 
 				byt, err := json.Marshal(trackedEvent)
 				if err == nil {

--- a/pkg/headers/headers.go
+++ b/pkg/headers/headers.go
@@ -21,6 +21,13 @@ const (
 	HeaderAuthorization = "Authorization"
 	HeaderContentType   = "Content-Type"
 	HeaderUserAgent     = "User-Agent"
+
+	// HeaderEventIDSeed is the header key used to send the event ID seed to the
+	// Inngest server. Its of the form "millis,entropy", where millis is the
+	// number of milliseconds since the Unix epoch, and entropy is a
+	// base64-encoded 10-byte value that's sufficiently random for ULID
+	// generation. For example: "1743130137367,eii2YKXRVTJPuA==".
+	HeaderEventIDSeed = "x-inngest-event-id-seed"
 )
 
 const (

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/inngest/inngest/pkg/connect"
 	"github.com/inngest/inngest/pkg/connect/auth"
 	"github.com/inngest/inngest/pkg/connect/lifecycles"
 	connectpubsub "github.com/inngest/inngest/pkg/connect/pubsub"
 	connectv0 "github.com/inngest/inngest/pkg/connect/rest/v0"
 	connstate "github.com/inngest/inngest/pkg/connect/state"
-	"time"
 
 	"github.com/inngest/inngest/pkg/enums"
 
@@ -565,7 +566,7 @@ func createInmemoryRedisConnectionOpt() (rueidis.ClientOption, error) {
 
 func getSendingEventHandler(pb pubsub.Publisher, topic string) execution.HandleSendingEvent {
 	return func(ctx context.Context, evt event.Event, item queue.Item) error {
-		trackedEvent := event.NewOSSTrackedEvent(evt)
+		trackedEvent := event.NewOSSTrackedEvent(evt, nil)
 		byt, err := json.Marshal(trackedEvent)
 		if err != nil {
 			return fmt.Errorf("error marshalling invocation event: %w", err)
@@ -601,7 +602,7 @@ func getInvokeFailHandler(ctx context.Context, pb pubsub.Publisher, topic string
 		for _, e := range evts {
 			evt := e
 			eg.Go(func() error {
-				trackedEvent := event.NewOSSTrackedEvent(evt)
+				trackedEvent := event.NewOSSTrackedEvent(evt, nil)
 				byt, err := json.Marshal(trackedEvent)
 				if err != nil {
 					return fmt.Errorf("error marshalling function finished event: %w", err)

--- a/tests/golang/send_idempotent_retry_test.go
+++ b/tests/golang/send_idempotent_retry_test.go
@@ -23,6 +23,7 @@ func TestSendIdempotentRetry(t *testing.T) {
 	// Resending events with the same idempotency key header results in skipped
 	// function runs.
 
+	t.Parallel()
 	ctx := context.Background()
 	r := require.New(t)
 

--- a/tests/golang/send_idempotent_retry_test.go
+++ b/tests/golang/send_idempotent_retry_test.go
@@ -1,0 +1,162 @@
+package golang
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngestgo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendIdempotentRetry(t *testing.T) {
+	// Resending events with the same idempotency key header results in skipped
+	// function runs.
+
+	ctx := context.Background()
+	r := require.New(t)
+
+	var proxyCounter int32
+
+	// Create a proxy that mimics a request reaching the Dev Server but the
+	// client receives a 500 on the first attempt. This ensures that the Dev
+	// Server's event processing logic properly handles the idempotency key
+	// header.
+	proxy := NewHTTPServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&proxyCounter, 1)
+
+		// Always forward requests.
+		req, _ := http.NewRequest(
+			r.Method,
+			fmt.Sprintf("http://0.0.0.0:8288%s", r.URL.Path),
+			r.Body,
+		)
+		req.Header = r.Header
+		resp, _ := http.DefaultClient.Do(req)
+
+		if proxyCounter == 1 {
+			// Return a 500 on the first attempt.
+			w.WriteHeader(http.StatusInternalServerError)
+		} else {
+			// Forward the response from the Dev Server.
+			for k, v := range resp.Header {
+				w.Header()[k] = v
+			}
+			w.WriteHeader(resp.StatusCode)
+			_, _ = io.Copy(w, resp.Body)
+			resp.Body.Close()
+		}
+	}))
+	defer proxy.Close()
+	proxyURL, err := url.Parse(proxy.URL())
+	r.NoError(err)
+
+	ic, server, registerFuncs := NewSDKHandler(
+		t,
+		randomSuffix("app"),
+		func(h *inngestgo.ClientOpts) {
+			h.EventURL = inngestgo.Ptr(strings.TrimSuffix(proxyURL.String(), "/"))
+		},
+	)
+	defer server.Close()
+
+	eventName := randomSuffix("event")
+	var fnCounter int32
+	_, err = inngestgo.CreateFunction(
+		ic,
+		inngestgo.FunctionOpts{ID: "fn"},
+		inngestgo.EventTrigger(eventName, nil),
+		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+			fmt.Println("trigger")
+			atomic.AddInt32(&fnCounter, 1)
+			return nil, nil
+		},
+	)
+	r.NoError(err)
+	registerFuncs()
+
+	// Send two events with the same idempotency key header. Both events trigger
+	// the function.
+	err = sendEvents(
+		ctx,
+		strings.TrimSuffix(proxyURL.String(), "/"),
+		[]inngestgo.Event{
+			{Name: eventName},
+			{Name: eventName},
+		},
+	)
+	r.NoError(err)
+
+	// Sleep long enough for the Dev Server to process the events.
+	time.Sleep(5 * time.Second)
+	r.Equal(int32(2), atomic.LoadInt32(&proxyCounter))
+	r.Equal(int32(2), atomic.LoadInt32(&fnCounter))
+}
+
+// sendEvents mimics the idempotent retry logic of the inngestgo client.
+//
+// TODO: Move this to the inngestgo package once we implement the idempotent
+// retry logic in the Dev Server and Cloud.
+func sendEvents(
+	ctx context.Context,
+	eventURL string,
+	events []inngestgo.Event,
+) error {
+	byt, err := json.Marshal(events)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		fmt.Sprintf("%s/e/test", eventURL),
+		bytes.NewBuffer(byt),
+	)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("content-type", "application/json")
+
+	// Create and set the idempotency key header.
+	millis := time.Now().UnixMilli()
+	randomByt := make([]byte, 10)
+	_, err = rand.Read(randomByt)
+	if err != nil {
+		return err
+	}
+	randomBase64 := base64.StdEncoding.EncodeToString(randomByt)
+	req.Header.Set(
+		"x-inngest-idempotency-key",
+		fmt.Sprintf("%d,%s", millis, randomBase64),
+	)
+
+	var resp *http.Response
+	maxAttempts := 5
+	for i := 1; i <= maxAttempts; i++ {
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode < 300 {
+			break
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("status code %d", resp.StatusCode)
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description
Add support for the `x-inngest-event-seed-id` header. Its value contains the data needed to deterministically generate a ULID (time and entropy). When it's set (and is valid), the Event API uses it to deterministically generate the internal event ID.

This is useful for idempotent retries when clients send events. It solves 2 issues:
- Our UI shows 2 IDs (idempotency ID and internal ID), which is confusing.
- There are some scenarios where `client.send` returns a different internal ID than the one that _actually_ triggered the run.

## Consequences
It's possible that there could be multiple DB rows with the same internal event ID. This is rare and we can't think of any significant issues caused by it, but we should still solve it in the future (e.g. replacing merge tree in ClickHouse)