### PR TITLE
Apply regular auth middleware to each group indiviudally

### DIFF
--- a/pkg/api/apiv1/apiv1.go
+++ b/pkg/api/apiv1/apiv1.go
@@ -60,10 +60,7 @@ func AddRoutes(r chi.Router, o Opts) http.Handler {
 		Router: r,
 		API:    impl,
 	}
-	// Add the auth middleware, if specified.
-	if o.AuthMiddleware != nil {
-		instance.Use(o.AuthMiddleware)
-	}
+
 	instance.setup()
 	return instance
 }
@@ -95,6 +92,10 @@ func (a *router) setup() {
 		}
 
 		r.Group(func(r chi.Router) {
+			if a.opts.AuthMiddleware != nil {
+				r.Use(a.opts.AuthMiddleware)
+			}
+
 			if a.opts.CachingMiddleware != nil {
 				r.Use(a.opts.CachingMiddleware.Middleware)
 			}


### PR DESCRIPTION
## Description

Auth middleware (e.g. Clerk / signing key strategies) is applied to the entire API, including `/v1/realtime/**`, causing us to fail auth when a WebSocket connection using a JWT subscription token is created.

If this is specified API-wide, we never get to the custom `realtimeAuth` handling and immediately hit `401`.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

## Related

- Complements inngest/inngest-js#927

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
