### PR TITLE
Migrate debounces by account

### DIFF
--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -249,6 +249,7 @@ func (d debouncer) queueManager(shouldMigrate bool) redis_state.QueueManager {
 
 // DeleteDebounceItem removes a debounce from the map.
 func (d debouncer) DeleteDebounceItem(ctx context.Context, debounceID ulid.ULID, accountID uuid.UUID) error {
+	// Determine the flag value once and pass down to prevent inconsistent values mid-deletion
 	shouldMigrate := d.shouldMigrate(ctx, accountID)
 
 	client := d.client(shouldMigrate)
@@ -293,6 +294,7 @@ func (d debouncer) deleteDebounceItem(ctx context.Context, debounceID ulid.ULID,
 
 // GetDebounceItem returns a DebounceItem given a debounce ID.
 func (d debouncer) GetDebounceItem(ctx context.Context, debounceID ulid.ULID, accountID uuid.UUID) (*DebounceItem, error) {
+	// Determine the flag value once and pass down to prevent inconsistent values mid-retrieval
 	client := d.client(d.shouldMigrate(ctx, accountID))
 	if client == nil {
 		return nil, fmt.Errorf("client did not return DebounceClient")
@@ -322,6 +324,7 @@ func (d debouncer) StartExecution(ctx context.Context, di DebounceItem, fn innge
 
 	newDebounceID := ulid.MustNew(ulid.Now(), rand.Reader)
 
+	// Determine the flag value once and pass down to prevent inconsistent values mid-execution
 	shouldMigrate := d.shouldMigrate(ctx, di.AccountID)
 
 	client := d.client(shouldMigrate)
@@ -372,6 +375,7 @@ func (d debouncer) Migrate(ctx context.Context, debounceId ulid.ULID, di Debounc
 		return fmt.Errorf("fn has no debounce config")
 	}
 
+	// Determine the flag value once and pass down to prevent inconsistent values mid-migration
 	shouldMigrate := d.shouldMigrate(ctx, di.AccountID)
 	if !shouldMigrate {
 		return fmt.Errorf("expected migration mode to be enable")
@@ -390,6 +394,7 @@ func (d debouncer) Debounce(ctx context.Context, di DebounceItem, fn inngest.Fun
 		return fmt.Errorf("invalid debounce duration: %w", err)
 	}
 
+	// Determine the flag value once and pass down to prevent inconsistent values while debouncing
 	shouldMigrate := d.shouldMigrate(ctx, di.AccountID)
 
 	return d.debounce(ctx, di, fn, ttl, 0, shouldMigrate)

--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -200,7 +200,7 @@ type debouncer struct {
 
 func (d debouncer) usePrimary(shouldMigrate bool) bool {
 	// Use primary cluster, if no secondary cluster is configured
-	if d.secondaryDebounceClient == nil {
+	if d.secondaryDebounceClient == nil || d.secondaryQueueManager == nil || d.secondaryQueueShard.Name == "" {
 		return true
 	}
 

--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -262,18 +262,24 @@ func (d debouncer) DeleteDebounceItem(ctx context.Context, debounceID ulid.ULID,
 		return fmt.Errorf("queueShard did not return QueueShard")
 	}
 
+	success := "false"
+	defer func() {
+		metrics.IncrQueueDebounceOperationCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags: map[string]any{
+				"op":          "deleted",
+				"queue_shard": queueShard.Name,
+				"success":     success,
+			},
+		})
+	}()
+
 	err := d.deleteDebounceItem(ctx, debounceID, client)
 	if err != nil {
 		return fmt.Errorf("could not delete debounce item: %w", err)
 	}
 
-	metrics.IncrQueueDebounceOperationCounter(ctx, metrics.CounterOpt{
-		PkgName: pkgName,
-		Tags: map[string]any{
-			"op":          "deleted",
-			"queue_shard": queueShard.Name,
-		},
-	})
+	success = "true"
 
 	return nil
 }

--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -135,8 +135,8 @@ func TestDebounce(t *testing.T) {
 			itemScore, err := unshardedCluster.ZScore(defaultQueueShard.RedisClient.KeyGenerator().PartitionQueueSet(enums.PartitionTypeDefault, queue.KindDebounce, ""), qi.ID)
 			require.NoError(t, err)
 			expectedQueueScore := eventTime.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			require.Equal(t, expectedQueueScore, int64(itemScore))
 		}
@@ -216,12 +216,12 @@ func TestDebounce(t *testing.T) {
 			require.NoError(t, err)
 
 			initialScore := evt0Time.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			expectedRequeueScore := eventTime.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.NotEqual(t, initialScore, expectedRequeueScore)
@@ -432,8 +432,8 @@ func TestJITDebounceMigration(t *testing.T) {
 			itemScore, err := unshardedCluster.ZScore(defaultQueueShard.RedisClient.KeyGenerator().PartitionQueueSet(enums.PartitionTypeDefault, queue.KindDebounce, ""), qi.ID)
 			require.NoError(t, err)
 			expectedQueueScore := eventTime.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			require.Equal(t, expectedQueueScore, int64(itemScore))
 		}
@@ -517,8 +517,8 @@ func TestJITDebounceMigration(t *testing.T) {
 				Add(buffer).
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			expectedRequeueScore := eventTime.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.NotEqual(t, initialScore, expectedRequeueScore)
@@ -701,8 +701,8 @@ func TestDebounceMigrationWithoutTimeout(t *testing.T) {
 			itemScore, err := unshardedCluster.ZScore(defaultQueueShard.RedisClient.KeyGenerator().PartitionQueueSet(enums.PartitionTypeDefault, queue.KindDebounce, ""), qi.ID)
 			require.NoError(t, err)
 			expectedQueueScore := eventTime.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			require.Equal(t, expectedQueueScore, int64(itemScore))
 		}
@@ -780,12 +780,12 @@ func TestDebounceMigrationWithoutTimeout(t *testing.T) {
 			require.NoError(t, err)
 
 			initialScore := evt0Time.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			expectedRequeueScore := eventTime.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.NotEqual(t, initialScore, expectedRequeueScore)
@@ -1003,8 +1003,8 @@ func TestDebounceTimeoutIsPreserved(t *testing.T) {
 			require.NoError(t, err)
 
 			expectedRequeueScore := eventTime.
-				Add(3 * time.Second). // Remaining TTL applied
-				Add(buffer). // Buffer
+				Add(3 * time.Second).        // Remaining TTL applied
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.Equal(t, expectedRequeueScore, int64(itemScore))
@@ -1192,8 +1192,8 @@ func TestDebounceExplicitMigration(t *testing.T) {
 			require.NoError(t, err)
 
 			expectedRequeueScore := eventTime.
-				Add(5 * time.Second). // Remaining TTL applied
-				Add(buffer). // Buffer
+				Add(5 * time.Second).        // Remaining TTL applied
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.Equal(t, expectedRequeueScore, int64(itemScore))

--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -336,7 +336,7 @@ func TestJITDebounceMigration(t *testing.T) {
 	oldRedisDebouncer := NewRedisDebouncer(unshardedDebounceClient, defaultQueueShard, oldQueue).(debouncer)
 	oldRedisDebouncer.c = fakeClock
 
-	newRedisDebouncer := NewRedisDebouncerWithMigration(DebouncerOpts{
+	deb, err := NewRedisDebouncerWithMigration(DebouncerOpts{
 		PrimaryDebounceClient: newSystemDebounceClient,
 		PrimaryQueue:          newQueue,
 		PrimaryQueueShard:     newSystemShard,
@@ -348,7 +348,9 @@ func TestJITDebounceMigration(t *testing.T) {
 		ShouldMigrate: func(ctx context.Context, accountID uuid.UUID) bool {
 			return true
 		},
-	}).(debouncer)
+	})
+	require.NoError(t, err)
+	newRedisDebouncer := deb.(debouncer)
 	newRedisDebouncer.c = fakeClock
 
 	ctx := context.Background()
@@ -607,7 +609,7 @@ func TestDebounceMigrationWithoutTimeout(t *testing.T) {
 	oldRedisDebouncer := NewRedisDebouncer(unshardedDebounceClient, defaultQueueShard, oldQueue).(debouncer)
 	oldRedisDebouncer.c = fakeClock
 
-	newRedisDebouncer := NewRedisDebouncerWithMigration(DebouncerOpts{
+	deb, err := NewRedisDebouncerWithMigration(DebouncerOpts{
 		PrimaryDebounceClient: newSystemDebounceClient,
 		PrimaryQueue:          newQueue,
 		PrimaryQueueShard:     newSystemShard,
@@ -619,7 +621,9 @@ func TestDebounceMigrationWithoutTimeout(t *testing.T) {
 		ShouldMigrate: func(ctx context.Context, accountID uuid.UUID) bool {
 			return true
 		},
-	}).(debouncer)
+	})
+	require.NoError(t, err)
+	newRedisDebouncer := deb.(debouncer)
 	newRedisDebouncer.c = fakeClock
 
 	ctx := context.Background()
@@ -859,7 +863,7 @@ func TestDebounceTimeoutIsPreserved(t *testing.T) {
 	oldRedisDebouncer := NewRedisDebouncer(unshardedDebounceClient, defaultQueueShard, oldQueue).(debouncer)
 	oldRedisDebouncer.c = fakeClock
 
-	newRedisDebouncer := NewRedisDebouncerWithMigration(DebouncerOpts{
+	deb, err := NewRedisDebouncerWithMigration(DebouncerOpts{
 		PrimaryDebounceClient: newSystemDebounceClient,
 		PrimaryQueue:          newQueue,
 		PrimaryQueueShard:     newSystemShard,
@@ -871,7 +875,9 @@ func TestDebounceTimeoutIsPreserved(t *testing.T) {
 		ShouldMigrate: func(ctx context.Context, accountID uuid.UUID) bool {
 			return true
 		},
-	}).(debouncer)
+	})
+	require.NoError(t, err)
+	newRedisDebouncer := deb.(debouncer)
 	newRedisDebouncer.c = fakeClock
 
 	ctx := context.Background()
@@ -1075,7 +1081,7 @@ func TestDebounceExplicitMigration(t *testing.T) {
 	oldRedisDebouncer := NewRedisDebouncer(unshardedDebounceClient, defaultQueueShard, oldQueue).(debouncer)
 	oldRedisDebouncer.c = fakeClock
 
-	newRedisDebouncer := NewRedisDebouncerWithMigration(DebouncerOpts{
+	deb, err := NewRedisDebouncerWithMigration(DebouncerOpts{
 		PrimaryDebounceClient: newSystemDebounceClient,
 		PrimaryQueue:          newQueue,
 		PrimaryQueueShard:     newSystemShard,
@@ -1087,7 +1093,9 @@ func TestDebounceExplicitMigration(t *testing.T) {
 		ShouldMigrate: func(ctx context.Context, accountID uuid.UUID) bool {
 			return true
 		},
-	}).(debouncer)
+	})
+	require.NoError(t, err)
+	newRedisDebouncer := deb.(debouncer)
 	newRedisDebouncer.c = fakeClock
 
 	ctx := context.Background()

--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -135,8 +135,8 @@ func TestDebounce(t *testing.T) {
 			itemScore, err := unshardedCluster.ZScore(defaultQueueShard.RedisClient.KeyGenerator().PartitionQueueSet(enums.PartitionTypeDefault, queue.KindDebounce, ""), qi.ID)
 			require.NoError(t, err)
 			expectedQueueScore := eventTime.
-				Add(10 * time.Second).       // Debounce period
-				Add(buffer).                 // Buffer
+				Add(10 * time.Second). // Debounce period
+				Add(buffer). // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			require.Equal(t, expectedQueueScore, int64(itemScore))
 		}
@@ -216,12 +216,12 @@ func TestDebounce(t *testing.T) {
 			require.NoError(t, err)
 
 			initialScore := evt0Time.
-				Add(10 * time.Second).       // Debounce period
-				Add(buffer).                 // Buffer
+				Add(10 * time.Second). // Debounce period
+				Add(buffer). // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			expectedRequeueScore := eventTime.
-				Add(10 * time.Second).       // Debounce period
-				Add(buffer).                 // Buffer
+				Add(10 * time.Second). // Debounce period
+				Add(buffer). // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.NotEqual(t, initialScore, expectedRequeueScore)
@@ -432,8 +432,8 @@ func TestJITDebounceMigration(t *testing.T) {
 			itemScore, err := unshardedCluster.ZScore(defaultQueueShard.RedisClient.KeyGenerator().PartitionQueueSet(enums.PartitionTypeDefault, queue.KindDebounce, ""), qi.ID)
 			require.NoError(t, err)
 			expectedQueueScore := eventTime.
-				Add(10 * time.Second).       // Debounce period
-				Add(buffer).                 // Buffer
+				Add(10 * time.Second). // Debounce period
+				Add(buffer). // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			require.Equal(t, expectedQueueScore, int64(itemScore))
 		}
@@ -517,8 +517,8 @@ func TestJITDebounceMigration(t *testing.T) {
 				Add(buffer).
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			expectedRequeueScore := eventTime.
-				Add(10 * time.Second).       // Debounce period
-				Add(buffer).                 // Buffer
+				Add(10 * time.Second). // Debounce period
+				Add(buffer). // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.NotEqual(t, initialScore, expectedRequeueScore)
@@ -701,8 +701,8 @@ func TestDebounceMigrationWithoutTimeout(t *testing.T) {
 			itemScore, err := unshardedCluster.ZScore(defaultQueueShard.RedisClient.KeyGenerator().PartitionQueueSet(enums.PartitionTypeDefault, queue.KindDebounce, ""), qi.ID)
 			require.NoError(t, err)
 			expectedQueueScore := eventTime.
-				Add(10 * time.Second).       // Debounce period
-				Add(buffer).                 // Buffer
+				Add(10 * time.Second). // Debounce period
+				Add(buffer). // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			require.Equal(t, expectedQueueScore, int64(itemScore))
 		}
@@ -780,12 +780,12 @@ func TestDebounceMigrationWithoutTimeout(t *testing.T) {
 			require.NoError(t, err)
 
 			initialScore := evt0Time.
-				Add(10 * time.Second).       // Debounce period
-				Add(buffer).                 // Buffer
+				Add(10 * time.Second). // Debounce period
+				Add(buffer). // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			expectedRequeueScore := eventTime.
-				Add(10 * time.Second).       // Debounce period
-				Add(buffer).                 // Buffer
+				Add(10 * time.Second). // Debounce period
+				Add(buffer). // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.NotEqual(t, initialScore, expectedRequeueScore)
@@ -1003,8 +1003,8 @@ func TestDebounceTimeoutIsPreserved(t *testing.T) {
 			require.NoError(t, err)
 
 			expectedRequeueScore := eventTime.
-				Add(3 * time.Second).        // Remaining TTL applied
-				Add(buffer).                 // Buffer
+				Add(3 * time.Second). // Remaining TTL applied
+				Add(buffer). // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.Equal(t, expectedRequeueScore, int64(itemScore))
@@ -1192,8 +1192,8 @@ func TestDebounceExplicitMigration(t *testing.T) {
 			require.NoError(t, err)
 
 			expectedRequeueScore := eventTime.
-				Add(5 * time.Second).        // Remaining TTL applied
-				Add(buffer).                 // Buffer
+				Add(5 * time.Second). // Remaining TTL applied
+				Add(buffer). // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.Equal(t, expectedRequeueScore, int64(itemScore))
@@ -1269,6 +1269,7 @@ func TestDebouncePrimaryChooser(t *testing.T) {
 	oldRedisDebouncer := NewRedisDebouncer(unshardedDebounceClient, defaultQueueShard, oldQueue).(debouncer)
 	oldRedisDebouncer.c = fakeClock
 
+	// Initial state: Only one primary configured, feature flag off.
 	t.Run("before two clusters are configured for migration, use primary", func(t *testing.T) {
 		deb, err := NewRedisDebouncerWithMigration(DebouncerOpts{
 			PrimaryDebounceClient: newSystemDebounceClient,
@@ -1287,6 +1288,7 @@ func TestDebouncePrimaryChooser(t *testing.T) {
 		require.True(t, newRedisDebouncer.usePrimary(false))
 	})
 
+	// Preparation for migration: Switch primary -> secondary and add new primary.
 	t.Run("when two clusters are configured, use secondary", func(t *testing.T) {
 		deb, err := NewRedisDebouncerWithMigration(DebouncerOpts{
 			PrimaryDebounceClient: newSystemDebounceClient,
@@ -1310,6 +1312,13 @@ func TestDebouncePrimaryChooser(t *testing.T) {
 		require.False(t, newRedisDebouncer.usePrimary(false))
 	})
 
+	// In a real migration: Wait until all clusters are safely deployed before flipping feature toggle.
+	// Also set feature toggle to a future date to ensure the feature flag is loaded into memory in time,
+	// to prevent clock drift. Alternatively, hard code feature flag switch timestamp (as we did with the function
+	// run state sharding rollout). Or use an atomic value in Redis.
+
+	// Start migration: Enable feature flag. This test assumes the change propagation is immediate and is registered by
+	// all consumers at once.
 	t.Run("during migration, use primary", func(t *testing.T) {
 		deb, err := NewRedisDebouncerWithMigration(DebouncerOpts{
 			PrimaryDebounceClient: newSystemDebounceClient,
@@ -1332,6 +1341,10 @@ func TestDebouncePrimaryChooser(t *testing.T) {
 		require.True(t, newRedisDebouncer.usePrimary(true))
 	})
 
+	// In a real migration: Wait until all debounces are migrated. Manually move leftover debounces.
+
+	// Once all debounces are moved from the old shard, we can remove the reference (by dropping the secondary).
+	// To prevent old deployments from using the old cluster again, we must keep the feature flag enabled during this time.
 	t.Run("after removing secondary once migration is completed, use primary", func(t *testing.T) {
 		deb, err := NewRedisDebouncerWithMigration(DebouncerOpts{
 			PrimaryDebounceClient: newSystemDebounceClient,
@@ -1352,4 +1365,6 @@ func TestDebouncePrimaryChooser(t *testing.T) {
 		require.True(t, newRedisDebouncer.usePrimary(true))
 	})
 
+	// In a real migration: Wait for rollout to finish so that the secondary cluster is not referenced in any
+	// deployment anymore. Then toggle the feature flag off again. After that, we'll wrap around to the first test case.
 }

--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -135,8 +135,8 @@ func TestDebounce(t *testing.T) {
 			itemScore, err := unshardedCluster.ZScore(defaultQueueShard.RedisClient.KeyGenerator().PartitionQueueSet(enums.PartitionTypeDefault, queue.KindDebounce, ""), qi.ID)
 			require.NoError(t, err)
 			expectedQueueScore := eventTime.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			require.Equal(t, expectedQueueScore, int64(itemScore))
 		}
@@ -216,12 +216,12 @@ func TestDebounce(t *testing.T) {
 			require.NoError(t, err)
 
 			initialScore := evt0Time.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			expectedRequeueScore := eventTime.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.NotEqual(t, initialScore, expectedRequeueScore)
@@ -240,7 +240,7 @@ func TestDebounce(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, debounceId.String(), val)
 
-		di, err := redisDebouncer.GetDebounceItem(ctx, debounceId)
+		di, err := redisDebouncer.GetDebounceItem(ctx, debounceId, accountId)
 		require.NoError(t, err)
 
 		err = redisDebouncer.StartExecution(ctx, *di, fn, debounceId)
@@ -258,7 +258,7 @@ func TestDebounce(t *testing.T) {
 
 		debounceId := ulid.MustParse(debounceIds[0])
 
-		err = redisDebouncer.DeleteDebounceItem(ctx, debounceId)
+		err = redisDebouncer.DeleteDebounceItem(ctx, debounceId, accountId)
 		require.NoError(t, err)
 
 		_, err = unshardedCluster.HKeys(debounceClient.KeyGenerator().Debounce(ctx))
@@ -345,7 +345,7 @@ func TestJITDebounceMigration(t *testing.T) {
 		SecondaryQueue:          oldQueue,
 		SecondaryQueueShard:     defaultQueueShard,
 
-		ShouldMigrate: func(ctx context.Context) bool {
+		ShouldMigrate: func(ctx context.Context, accountID uuid.UUID) bool {
 			return true
 		},
 	}).(debouncer)
@@ -430,8 +430,8 @@ func TestJITDebounceMigration(t *testing.T) {
 			itemScore, err := unshardedCluster.ZScore(defaultQueueShard.RedisClient.KeyGenerator().PartitionQueueSet(enums.PartitionTypeDefault, queue.KindDebounce, ""), qi.ID)
 			require.NoError(t, err)
 			expectedQueueScore := eventTime.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			require.Equal(t, expectedQueueScore, int64(itemScore))
 		}
@@ -515,8 +515,8 @@ func TestJITDebounceMigration(t *testing.T) {
 				Add(buffer).
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			expectedRequeueScore := eventTime.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.NotEqual(t, initialScore, expectedRequeueScore)
@@ -616,7 +616,7 @@ func TestDebounceMigrationWithoutTimeout(t *testing.T) {
 		SecondaryQueue:          oldQueue,
 		SecondaryQueueShard:     defaultQueueShard,
 
-		ShouldMigrate: func(ctx context.Context) bool {
+		ShouldMigrate: func(ctx context.Context, accountID uuid.UUID) bool {
 			return true
 		},
 	}).(debouncer)
@@ -697,8 +697,8 @@ func TestDebounceMigrationWithoutTimeout(t *testing.T) {
 			itemScore, err := unshardedCluster.ZScore(defaultQueueShard.RedisClient.KeyGenerator().PartitionQueueSet(enums.PartitionTypeDefault, queue.KindDebounce, ""), qi.ID)
 			require.NoError(t, err)
 			expectedQueueScore := eventTime.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			require.Equal(t, expectedQueueScore, int64(itemScore))
 		}
@@ -776,12 +776,12 @@ func TestDebounceMigrationWithoutTimeout(t *testing.T) {
 			require.NoError(t, err)
 
 			initialScore := evt0Time.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 			expectedRequeueScore := eventTime.
-				Add(10 * time.Second). // Debounce period
-				Add(buffer). // Buffer
+				Add(10 * time.Second).       // Debounce period
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.NotEqual(t, initialScore, expectedRequeueScore)
@@ -868,7 +868,7 @@ func TestDebounceTimeoutIsPreserved(t *testing.T) {
 		SecondaryQueue:          oldQueue,
 		SecondaryQueueShard:     defaultQueueShard,
 
-		ShouldMigrate: func(ctx context.Context) bool {
+		ShouldMigrate: func(ctx context.Context, accountID uuid.UUID) bool {
 			return true
 		},
 	}).(debouncer)
@@ -997,8 +997,8 @@ func TestDebounceTimeoutIsPreserved(t *testing.T) {
 			require.NoError(t, err)
 
 			expectedRequeueScore := eventTime.
-				Add(3 * time.Second). // Remaining TTL applied
-				Add(buffer). // Buffer
+				Add(3 * time.Second).        // Remaining TTL applied
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.Equal(t, expectedRequeueScore, int64(itemScore))
@@ -1084,7 +1084,7 @@ func TestDebounceExplicitMigration(t *testing.T) {
 		SecondaryQueue:          oldQueue,
 		SecondaryQueueShard:     defaultQueueShard,
 
-		ShouldMigrate: func(ctx context.Context) bool {
+		ShouldMigrate: func(ctx context.Context, accountID uuid.UUID) bool {
 			return true
 		},
 	}).(debouncer)
@@ -1184,8 +1184,8 @@ func TestDebounceExplicitMigration(t *testing.T) {
 			require.NoError(t, err)
 
 			expectedRequeueScore := eventTime.
-				Add(5 * time.Second). // Remaining TTL applied
-				Add(buffer). // Buffer
+				Add(5 * time.Second).        // Remaining TTL applied
+				Add(buffer).                 // Buffer
 				Add(time.Second).UnixMilli() // Allow updateDebounce on TTL 0
 
 			require.Equal(t, expectedRequeueScore, int64(itemScore))

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -359,7 +359,7 @@ func (s *svc) handleDebounce(ctx context.Context, item queue.Item) error {
 
 	for _, f := range all {
 		if f.ID == d.FunctionID {
-			di, err := s.debouncer.GetDebounceItem(ctx, d.DebounceID)
+			di, err := s.debouncer.GetDebounceItem(ctx, d.DebounceID, d.AccountID)
 			if err != nil {
 				if errors.Is(err, debounce.ErrDebounceNotFound) {
 					// This is expected after migrating items to a new primary cluster
@@ -402,7 +402,7 @@ func (s *svc) handleDebounce(ctx context.Context, item queue.Item) error {
 			if err != nil {
 				return err
 			}
-			_ = s.debouncer.DeleteDebounceItem(ctx, d.DebounceID)
+			_ = s.debouncer.DeleteDebounceItem(ctx, d.DebounceID, d.AccountID)
 		}
 	}
 

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -50,7 +50,8 @@ type RunResult struct {
 }
 
 type EnqueueOpts struct {
-	PassthroughJobId bool
+	PassthroughJobId    bool
+	ForceQueueShardName string
 }
 
 type Producer interface {

--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -298,3 +298,12 @@ func IncrQueueContinuationRemovedCounter(ctx context.Context, opts CounterOpt) {
 		Tags:        opts.Tags,
 	})
 }
+
+func IncrQueueDebounceOperationCounter(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "queue_debounce_operation",
+		Description: "The total number of debounce operations",
+		Tags:        opts.Tags,
+	})
+}


### PR DESCRIPTION
## Description

This PR adds account IDs to the debounce migration feature flag. This allow us to toggle the migration (create new debounces on new system queue + migrate existing debounces JIT) for individual accounts. When the flag evaluates to false, the system will work exactly as before (creating/updating/deleting on the old cluster)

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
