### PR TITLE
Redact creds when logging the Redis URL in `inngest start`

### DIFF
--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/inngest/inngest/pkg/connect"
@@ -386,7 +387,12 @@ func start(ctx context.Context, opts StartOpts) error {
 		// manage snapshotting
 		persistenceInterval = nil
 
-		logger.From(ctx).Info().Msgf("using external Redis %s; disabling in-memory persistence and snapshotting", opts.RedisURI)
+		// Mask Redis URI credentials before logging
+		loggedURI := ""
+		if u, err := url.Parse(opts.RedisURI); err == nil {
+			loggedURI = " " + u.Redacted()
+		}
+		logger.From(ctx).Info().Msgf("using external Redis%s; disabling in-memory persistence and snapshotting", loggedURI)
 	}
 
 	dsOpts := devserver.StartOpts{


### PR DESCRIPTION
## Description

Ensures Redis credentials are redacted when logging during `inngest start`.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- Fixes #2297

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
