### PR TITLE
remove frozen lockfile so vulnerability updates passes CI

### DIFF
--- a/.github/workflows/components_test.yml
+++ b/.github/workflows/components_test.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: "20"
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
         working-directory: ui/packages/components
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/dev_server_ui.yml
+++ b/.github/workflows/dev_server_ui.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: "20"
       - name: Install
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
         working-directory: ui/apps/dev-server-ui
       - name: Type check
         run: pnpm type-check

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run E2E tests
         run: |
           cd ./tests/js
-          pnpm install --frozen-lockfile
+          pnpm install
           pnpm dev &
           sleep 5
           cd ../../


### PR DESCRIPTION
## Description

The `--frozen-lockfile` options is nice in general but makes CI fail when dependabot attempts to update a package.
Relax it so automated vulnerability updates can run on CI without issues.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
