### PR TITLE
Make sure we allow local connections during `dev` and `start`

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -112,6 +112,9 @@ func New(ctx context.Context, opts StartOpts) error {
 	// Before running the development service, ensure that we change the http
 	// driver in development to use our AWS Gateway http client, attempting to
 	// automatically transform dev requests to lambda invocations.
+	//
+	// We also make sure to allow local requests.
+	httpdriver.DefaultTransport.DialContext = httpdriver.Dialer.DialContext
 	httpdriver.DefaultExecutor.Client.Transport = awsgateway.NewTransformTripper(httpdriver.DefaultExecutor.Client.Transport)
 	deploy.Client.Transport = awsgateway.NewTransformTripper(deploy.Client.Transport)
 

--- a/pkg/execution/driver/httpdriver/dialer.go
+++ b/pkg/execution/driver/httpdriver/dialer.go
@@ -62,7 +62,7 @@ type DialFunc = func(ctx context.Context, network, addr string) (net.Conn, error
 func SecureDialer(o SecureDialerOpts) DialFunc {
 	if o.dial == nil {
 		// Always use the default dialer.  Only allow overrides in testing.
-		o.dial = dialer.DialContext
+		o.dial = Dialer.DialContext
 	}
 
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	dialer = &net.Dialer{KeepAlive: 15 * time.Second}
+	Dialer = &net.Dialer{KeepAlive: 15 * time.Second}
 
 	DefaultTransport = func() *http.Transport {
 		t := &http.Transport{
@@ -55,7 +55,7 @@ var (
 
 		if util.InTestMode() {
 			// Allow local requests during testing
-			t.DialContext = dialer.DialContext
+			t.DialContext = Dialer.DialContext
 		}
 
 		return t

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -107,6 +107,9 @@ func New(ctx context.Context, opts StartOpts) error {
 	// Before running the development service, ensure that we change the http
 	// driver in development to use our AWS Gateway http client, attempting to
 	// automatically transform dev requests to lambda invocations.
+	//
+	// We also make sure to allow local requests.
+	httpdriver.DefaultTransport.DialContext = httpdriver.Dialer.DialContext
 	httpdriver.DefaultExecutor.Client.Transport = awsgateway.NewTransformTripper(httpdriver.DefaultExecutor.Client.Transport)
 	deploy.Client.Transport = awsgateway.NewTransformTripper(deploy.Client.Transport)
 


### PR DESCRIPTION
## Description

Ensure `inngest dev` and `inngest start` can still make local requests.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- Caused by #2254 

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
