### PR TITLE
Filter error that doesn't need to be retried

### DIFF
--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -187,7 +187,7 @@ func (v v2) LoadMetadata(ctx context.Context, id state.ID) (state.Metadata, erro
 func (v v2) UpdateMetadata(ctx context.Context, id state.ID, mutation state.MutableConfig) error {
 	_, err := util.WithRetry(
 		ctx,
-		"run.UpdateMetadata",
+		"state.UpdateMetadata",
 		func(ctx context.Context) (bool, error) {
 			err := v.mgr.UpdateMetadata(ctx, id.Tenant.AccountID, id.RunID, statev1.MetadataUpdate{
 				DisableImmediateExecution: mutation.ForceStepPlan,
@@ -214,7 +214,7 @@ func (v v2) SaveStep(ctx context.Context, id state.ID, stepID string, data []byt
 
 	return util.WithRetry(
 		ctx,
-		"run.SaveStep",
+		"state.SaveStep",
 		func(ctx context.Context) (bool, error) {
 			return v.mgr.SaveResponse(ctx, v1id, stepID, string(data))
 		},
@@ -234,7 +234,7 @@ func (v v2) SavePending(ctx context.Context, id state.ID, pending []string) erro
 
 	_, err := util.WithRetry(
 		ctx,
-		"run.SavePending",
+		"state.SavePending",
 		func(ctx context.Context) (bool, error) {
 			err := v.mgr.SavePending(ctx, v1id, pending)
 			return false, err

--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -73,7 +73,7 @@ func NewRetryConf(opts ...RetryConfSetting) RetryConf {
 
 // WithRetry wraps a function with retry logic and returns the result of the successful call,
 // or the error after retries have been exhausted
-func WithRetry[T any](ctx context.Context, fn Retryable[T], conf RetryConf) (T, error) {
+func WithRetry[T any](ctx context.Context, action string, fn Retryable[T], conf RetryConf) (T, error) {
 	var (
 		result  T
 		lastErr error
@@ -92,6 +92,7 @@ func WithRetry[T any](ctx context.Context, fn Retryable[T], conf RetryConf) (T, 
 		l.Warn("error on retriable function attempt",
 			"error", err,
 			"attempt", attempt,
+			"action", action,
 			"conf", conf,
 		)
 
@@ -127,6 +128,7 @@ func WithRetry[T any](ctx context.Context, fn Retryable[T], conf RetryConf) (T, 
 
 	l.Error("retriable function failed",
 		"error", lastErr,
+		"action", action,
 		"conf", conf,
 	)
 	return result, fmt.Errorf("%w: %v", ErrMaxAttemptReached, lastErr)

--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -89,13 +89,6 @@ func WithRetry[T any](ctx context.Context, action string, fn Retryable[T], conf 
 			return result, nil
 		}
 
-		l.Warn("error on retriable function attempt",
-			"error", err,
-			"attempt", attempt,
-			"action", action,
-			"conf", conf,
-		)
-
 		lastErr = err
 		if attempt == conf.MaxAttempts {
 			break
@@ -106,6 +99,13 @@ func WithRetry[T any](ctx context.Context, action string, fn Retryable[T], conf 
 		if conf.RetryableErrors != nil && !conf.RetryableErrors(err) {
 			return result, err
 		}
+
+		l.Warn("error on retriable function attempt",
+			"error", err,
+			"attempt", attempt,
+			"action", action,
+			"conf", conf,
+		)
 
 		// calculate next backoff
 		nextBackoff := backoff * time.Duration(conf.BackoffFactor)


### PR DESCRIPTION
## Description

Add `action` arg for better logging, and filter out `duplicate response` for retries.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
