### PR TITLE
feat: Add indexes to increase performance of self hosting when using postgres

### DIFF
--- a/pkg/cqrs/base_cqrs/migrations/postgres/000012_add_pg_indexes.down.sql
+++ b/pkg/cqrs/base_cqrs/migrations/postgres/000012_add_pg_indexes.down.sql
@@ -1,0 +1,19 @@
+-- Drop indexes from Function Runs Table
+DROP INDEX IF EXISTS idx_function_runs_run_id;
+DROP INDEX IF EXISTS idx_function_runs_event_id;
+DROP INDEX IF EXISTS idx_function_runs_timebound;
+
+-- Drop index from Function Finishes Table
+DROP INDEX IF EXISTS idx_function_finishes_run_id;
+
+-- Drop indexes from Events Table
+DROP INDEX IF EXISTS idx_events_internal_id;
+DROP INDEX IF EXISTS idx_events_internal_id_received_range;
+DROP INDEX IF EXISTS idx_events_received_name;
+
+-- Drop indexes from History Table
+DROP INDEX IF EXISTS idx_history_id;
+DROP INDEX IF EXISTS idx_history_run_id_created;
+
+-- Drop index from Traces Table
+DROP INDEX IF EXISTS idx_traces_trace_id;

--- a/pkg/cqrs/base_cqrs/migrations/postgres/000012_add_pg_indexes.up.sql
+++ b/pkg/cqrs/base_cqrs/migrations/postgres/000012_add_pg_indexes.up.sql
@@ -1,0 +1,19 @@
+-- Function Runs Table
+CREATE INDEX IF NOT EXISTS idx_function_runs_run_id ON function_runs(run_id);
+CREATE INDEX IF NOT EXISTS idx_function_runs_event_id ON function_runs(event_id);
+CREATE INDEX IF NOT EXISTS idx_function_runs_timebound ON function_runs(run_started_at DESC, function_id);
+
+-- Function Finishes Table
+CREATE INDEX IF NOT EXISTS idx_function_finishes_run_id ON function_finishes(run_id);
+
+-- Events Table
+CREATE INDEX IF NOT EXISTS idx_events_internal_id ON events(internal_id);
+CREATE INDEX IF NOT EXISTS idx_events_internal_id_received_range ON events(internal_id, received_at DESC);
+CREATE INDEX IF NOT EXISTS idx_events_received_name ON events(received_at, event_name);
+
+-- History Table
+CREATE INDEX IF NOT EXISTS idx_history_id ON history(id);
+CREATE INDEX IF NOT EXISTS idx_history_run_id_created ON history(run_id, created_at ASC);
+
+-- Traces Table
+CREATE INDEX IF NOT EXISTS idx_traces_trace_id ON traces(trace_id);


### PR DESCRIPTION
## Description

Add strategic database indexes to improve query performance for common queries in the PostgreSQL database. This includes indexes on function_runs (for run_id, event_id, and 
  time-based function lookups), function_finishes (for run status lookups), events (for ID and time-range queries), history (for run-related queries), and traces tables.

  Note: I initially planned to use CREATE INDEX CONCURRENTLY to avoid table locks, but since the migration system runs migrations within transactions and CONCURRENTLY cannot be used
  inside transactions, I've used regular CREATE INDEX statements. Alternatively we could add look at turning on multi statement execution (https://github.com/golang-migrate/migrate/tree/master/database/postgres) which I think would work. 

## Motivation
After a month of using self hosting with postgres the dashboard becomes unusable nothing loads and it basically tanks the DB any time you try load a trace

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
