### PR TITLE
Undo previous attempt for idempotent scheduling

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -575,8 +575,10 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 
 	err := e.smv2.Create(ctx, newState)
 	switch err {
-	case nil, state.ErrIdentifierExists:
+	case nil:
 		// no-op, continue
+	case state.ErrIdentifierExists:
+		return nil, err
 	default:
 		return nil, fmt.Errorf("error creating run state: %w", err)
 	}


### PR DESCRIPTION
## Description

This idea won't work due to lack of transactions with Redis.
Can only be done via a proper transaction model.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
