### PR TITLE
Allow `cause` to be anything in step-level user errors

### DIFF
--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -33,7 +33,7 @@ type UserError struct {
 	NoRetry bool `json:"noRetry,omitempty"`
 
 	// Cause allows nested errors to be passed back to the SDK.
-	Cause *UserError `json:"cause,omitempty"`
+	Cause *json.RawMessage `json:"cause,omitempty"`
 }
 
 // DriverResponse is returned after a driver executes an action.  This represents any

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -33,7 +33,7 @@ type UserError struct {
 	NoRetry bool `json:"noRetry,omitempty"`
 
 	// Cause allows nested errors to be passed back to the SDK.
-	Cause *json.RawMessage `json:"cause,omitempty"`
+	Cause json.RawMessage `json:"cause,omitempty"`
 }
 
 // DriverResponse is returned after a driver executes an action.  This represents any


### PR DESCRIPTION
## Description

Complements #2088 (which allows a freer `cause` in functions reacting to `inngest/function.failed` events) by also allowing a free `cause` in step-level errors.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

## Related

- Complements #2088

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
