### PR TITLE
Prevent source name wrapping in event logs list

### DIFF
--- a/ui/apps/dashboard/src/components/Events/LatestLogsList.tsx
+++ b/ui/apps/dashboard/src/components/Events/LatestLogsList.tsx
@@ -3,7 +3,6 @@ import { useRouter } from 'next/navigation';
 import { Button } from '@inngest/components/Button';
 import { Pill } from '@inngest/components/Pill';
 import { IDCell, TimeCell } from '@inngest/components/Table/Cell';
-import { RiKey2Fill } from '@remixicon/react';
 import { useQuery } from 'urql';
 
 import { useEnvironment } from '@/components/Environments/environment-context';
@@ -107,7 +106,6 @@ export default function LatestLogsList({ environmentSlug, eventName }: LatestLog
                       </td>
                       <td>
                         <Pill appearance="outlined">
-                          <RiKey2Fill className="text-basis h-4 pr-1" />
                           {e.source?.name}
                         </Pill>
                       </td>


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->
The source name text in the event logs list was wrapping to multiple lines, causing poor readability and a broken UI appearance. This was particularly noticeable with longer source names.

Modified the Source column to display text in a single line without wrapping by simplifying the implementation and applying proper whitespace handling.

### Before

<img width="1254" alt="image" src="https://github.com/user-attachments/assets/548b48c7-7596-4ebd-ba0a-ddb86d8534f4" />

### After

<img width="1243" alt="image" src="https://github.com/user-attachments/assets/51506556-efa7-4a02-9fac-ca2a43837c5c" />

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->
To improve readability and UI consistency in the events log list. Long source names should be displayed properly without breaking into multiple lines, ensuring a clean and professional appearance of the interface.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
