### PR TITLE
Change exporter key to run_id, and use fn_id as backup

### DIFF
--- a/pkg/telemetry/exporters/kafka.go
+++ b/pkg/telemetry/exporters/kafka.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	defaultMsgKey       = "fn_id"
+	defaultMsgKey       = "run_id"
 	defaultMaxProduceMB = 30 // 30MB
 )
 
@@ -170,7 +170,9 @@ func (e *kafkaSpanExporter) ExportSpans(ctx context.Context, spans []trace.ReadO
 		case "workflow_id", "wf_id", "function_id", "fn_id":
 			rec.Key = []byte(id.GetFunctionId())
 		case "run_id":
-			rec.Key = []byte(id.GetRunId())
+			if id.GetRunId() != "" {
+				rec.Key = []byte(id.GetRunId())
+			}
 		}
 
 		e.client.Produce(ctx, rec, func(r *kgo.Record, err error) {

--- a/pkg/telemetry/exporters/kafka.go
+++ b/pkg/telemetry/exporters/kafka.go
@@ -74,6 +74,7 @@ func WithKafkaExporterMaxProduceMB(size int) KafkaSpansExporterOpts {
 func NewKafkaSpanExporter(ctx context.Context, opts ...KafkaSpansExporterOpts) (trace.SpanExporter, error) {
 	conf := &kafkaSpansExporterOpts{
 		maxProduceMB: defaultMaxProduceMB,
+		key:          defaultMsgKey,
 	}
 
 	for _, apply := range opts {
@@ -86,10 +87,6 @@ func NewKafkaSpanExporter(ctx context.Context, opts ...KafkaSpansExporterOpts) (
 
 	if conf.topic == "" {
 		return nil, fmt.Errorf("no topic provided for span exporter")
-	}
-
-	if conf.key != "" {
-		conf.key = defaultMsgKey
 	}
 
 	kclopts := []kgo.Opt{


### PR DESCRIPTION
## Description

For function run spans, `run_id` will be more evenly distributed for partitions.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
