### PR TITLE
Catch SDK Gateway DNS i/o timeouts

### DIFF
--- a/pkg/execution/driver/httpdriver/util_test.go
+++ b/pkg/execution/driver/httpdriver/util_test.go
@@ -1,0 +1,39 @@
+package httpdriver
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsDNSLookupTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "real dns lookup timeout error",
+			err:      fmt.Errorf(`Post "http://na-ashburn.sdkgateway.infra.inngest.lol:8080/request": lookup na-ashburn.sdkgateway.infra.inngest.lol on [2607:e3c0:a040:f100::a]:53: read udp [2607:e3c0:a040:f00e::a8bc]:49196->[2607:e3c0:a040:f100::a]:53: i/o timeout`),
+			expected: true,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "different error",
+			err:      fmt.Errorf("some other error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsDNSLookupTimeout(tt.err)
+			if result != tt.expected {
+				t.Errorf("IsDNSLookupTimeout() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This uses a pattern to match internal SDK gateway DNS i/o timeouts and returns a simplified error instead of returning the raw error.

## Motivation
Users should see a simpler, cleaner error code instead of the raw input. We can also use this error to add retries in the future.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
