### PR TITLE
Fix streaming headers

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -252,7 +252,10 @@ func HandleHttpResponse(ctx context.Context, r Request, resp *Response) (*state.
 		dr.SetError(err)
 	}
 
-	if !resp.IsSDK {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 && !resp.IsSDK {
+		// If we got a successful response but it wasn't from the SDK, then we
+		// need to fail the attempt. Otherwise, we may incorrectly mark the
+		// function run as "completed".
 		dr.SetError(ErrNotSDK)
 	}
 


### PR DESCRIPTION
- Fix a case sensitivity bug with streaming headers.
- Improve conditional around `dr.SetError(ErrNotSDK)`. We only want to set that error when getting an OK status code from something that isn't the SDK.