### PR TITLE
Fix action menu button

### DIFF
--- a/ui/apps/dashboard/src/components/Apps/ActionsMenu.tsx
+++ b/ui/apps/dashboard/src/components/Apps/ActionsMenu.tsx
@@ -30,7 +30,7 @@ export const ActionsMenu = ({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button kind="primary" appearance="outlined" size="medium" icon={<RiMore2Line />} />
+        <Button kind="primary" appearance="outlined" size="medium" icon={<RiMore2Line />} raw />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem disabled={disableValidate} onSelect={showValidate}>

--- a/ui/packages/components/src/Button/Button.tsx
+++ b/ui/packages/components/src/Button/Button.tsx
@@ -31,6 +31,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   keys?: string[];
   prefetch?: boolean;
   scroll?: boolean;
+  raw?: boolean;
 }
 
 type LinkWrapperProps = {
@@ -95,6 +96,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       target,
       prefetch = false,
       scroll = true,
+      raw = false,
       ...props
     }: ButtonProps,
     ref
@@ -129,23 +131,31 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       </>
     );
 
+    const buttonElement = (
+      <button
+        ref={ref}
+        className={cn(
+          buttonColors,
+          buttonSizes,
+          'flex items-center justify-center whitespace-nowrap rounded-md disabled:cursor-not-allowed',
+          className
+        )}
+        type={type}
+        disabled={disabled}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+
+    if (raw) {
+      return buttonElement;
+    }
+
     return (
       <TooltipWrapper tooltip={tooltip}>
         <LinkWrapper href={href} target={target} prefetch={prefetch} scroll={scroll}>
-          <button
-            ref={ref}
-            className={cn(
-              buttonColors,
-              buttonSizes,
-              'flex items-center justify-center whitespace-nowrap rounded-md disabled:cursor-not-allowed',
-              className
-            )}
-            type={type}
-            disabled={disabled}
-            {...props}
-          >
-            {children}
-          </button>
+          {buttonElement}
         </LinkWrapper>
       </TooltipWrapper>
     );


### PR DESCRIPTION
## Description
Can't reproduce this locally but this might fix the issue in the action menu where "React.Children.only expected to receive a single React element child."

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
