### PR TITLE
Final fix for apps dropdown actions

### DIFF
--- a/ui/apps/dashboard/src/components/Apps/ActionsMenu.tsx
+++ b/ui/apps/dashboard/src/components/Apps/ActionsMenu.tsx
@@ -37,8 +37,10 @@ export const ActionsMenu = ({
           <OptionalTooltip
             tooltip={disableValidate ? 'No syncs. App health check not available.' : undefined}
           >
-            <RiFirstAidKitLine className="h-4 w-4" />
-            Check app health
+            <>
+              <RiFirstAidKitLine className="h-4 w-4" />
+              Check app health
+            </>
           </OptionalTooltip>
         </DropdownMenuItem>
 
@@ -49,8 +51,10 @@ export const ActionsMenu = ({
                 disableArchive ? 'Parent app is archived. Archive action not available.' : undefined
               }
             >
-              <RiArchive2Line className="h-4 w-4" />
-              {isArchived ? 'Unarchive app' : 'Archive app'}
+              <>
+                <RiArchive2Line className="h-4 w-4" />
+                {isArchived ? 'Unarchive app' : 'Archive app'}
+              </>
             </OptionalTooltip>
           </DropdownMenuItem>
         )}

--- a/ui/apps/dashboard/src/components/Apps/ActionsMenu.tsx
+++ b/ui/apps/dashboard/src/components/Apps/ActionsMenu.tsx
@@ -33,30 +33,29 @@ export const ActionsMenu = ({
         <Button kind="primary" appearance="outlined" size="medium" icon={<RiMore2Line />} />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuItem disabled={disableValidate} onSelect={showValidate}>
-          <OptionalTooltip
-            tooltip={disableValidate ? 'No syncs. App health check not available.' : undefined}
-          >
-            <>
-              <RiFirstAidKitLine className="h-4 w-4" />
-              Check app health
-            </>
-          </OptionalTooltip>
-        </DropdownMenuItem>
-
-        {(!isArchived || showUnarchive) && (
-          <DropdownMenuItem disabled={disableArchive} onSelect={showArchive} className="text-error">
-            <OptionalTooltip
-              tooltip={
-                disableArchive ? 'Parent app is archived. Archive action not available.' : undefined
-              }
-            >
-              <>
-                <RiArchive2Line className="h-4 w-4" />
-                {isArchived ? 'Unarchive app' : 'Archive app'}
-              </>
-            </OptionalTooltip>
+        <OptionalTooltip
+          tooltip={disableValidate ? 'No syncs. App health check not available.' : undefined}
+        >
+          <DropdownMenuItem disabled={disableValidate} onSelect={showValidate}>
+            <RiFirstAidKitLine className="h-4 w-4" />
+            Check app health
           </DropdownMenuItem>
+        </OptionalTooltip>
+        {(!isArchived || showUnarchive) && (
+          <OptionalTooltip
+            tooltip={
+              disableArchive ? 'Parent app is archived. Archive action not available.' : undefined
+            }
+          >
+            <DropdownMenuItem
+              disabled={disableArchive}
+              onSelect={showArchive}
+              className="text-error"
+            >
+              <RiArchive2Line className="h-4 w-4" />
+              {isArchived ? 'Unarchive app' : 'Archive app'}
+            </DropdownMenuItem>
+          </OptionalTooltip>
         )}
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Description
This fixes `React.Children.only expected to receive a single React element child. ` and undoes the previous failed fix

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
