### PR TITLE
Tweak display of checkout error messages

### DIFF
--- a/ui/apps/dashboard/src/components/Billing/Plans/CheckoutModal.tsx
+++ b/ui/apps/dashboard/src/components/Billing/Plans/CheckoutModal.tsx
@@ -151,20 +151,26 @@ function CheckoutForm({ items, onSuccess }: { items: CheckoutItem[]; onSuccess: 
       <div className="mb-2 min-h-[290px]">
         <PaymentElement />
       </div>
-      <Alert severity="info" className="text-sm">
-        <p>Subscriptions are billed on the 1st of each month.</p>
-        <ul className="list-inside list-disc">
-          <li>
-            When upgrading, you will be charged a prorated amount for the remaining days of the
-            month based on the new plan.
-          </li>
-          <li>
-            If you switch from one paid plan to another, you will be credited for any unused time
-            from your previous plan, calculated on a prorated basis.
-          </li>
-          <li>Additional usage is calculated and billed at the end of the month.</li>
-        </ul>
-      </Alert>
+      {Boolean(error) ? (
+        <Alert severity="error" className="text-sm">
+          {error}
+        </Alert>
+      ) : (
+        <Alert severity="info" className="text-sm">
+          <p>Subscriptions are billed on the 1st of each month.</p>
+          <ul className="list-inside list-disc">
+            <li>
+              When upgrading, you will be charged a prorated amount for the remaining days of the
+              month based on the new plan.
+            </li>
+            <li>
+              If you switch from one paid plan to another, you will be credited for any unused time
+              from your previous plan, calculated on a prorated basis.
+            </li>
+            <li>Additional usage is calculated and billed at the end of the month.</li>
+          </ul>
+        </Alert>
+      )}
       <div className="mt-6 flex flex-row justify-end">
         <Button
           type="submit"
@@ -174,11 +180,6 @@ function CheckoutForm({ items, onSuccess }: { items: CheckoutItem[]; onSuccess: 
           label="Complete Upgrade"
         />
       </div>
-      {Boolean(error) && (
-        <Alert severity="error" className="text-sm">
-          {error}
-        </Alert>
-      )}
     </form>
   );
 }


### PR DESCRIPTION
## Description

Previously, if a checkout error occurred, it would appear below the Complete Upgrade button, with no margin/spacing between the elements.

Now:
<img width="638" alt="image" src="https://github.com/user-attachments/assets/38795af5-4724-4b43-aefe-aa3f3c3477e8" />

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.
