### PR TITLE
Make sure to assign run_id in a couple other areas for root spans

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2945,16 +2945,19 @@ func (e *executor) RetrieveAndScheduleBatch(ctx context.Context, fn inngest.Func
 
 	// Don't bother if it's already there
 	if err == redis_state.ErrQueueItemExists {
+		span.SetAttributes(attribute.Bool(consts.OtelSysStepDelete, true))
 		return nil
 	}
 
 	// If function is paused, we do not schedule runs
 	if errors.Is(err, ErrFunctionSkipped) {
+		span.SetAttributes(attribute.Bool(consts.OtelSysStepDelete, true))
 		return nil
 	}
 
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
+		span.SetAttributes(attribute.Bool(consts.OtelSysStepDelete, true))
 		return err
 	}
 
@@ -2969,8 +2972,6 @@ func (e *executor) RetrieveAndScheduleBatch(ctx context.Context, fn inngest.Func
 
 	if md != nil {
 		span.SetAttributes(attribute.String(consts.OtelAttrSDKRunID, md.ID.RunID.String()))
-	} else {
-		span.SetAttributes(attribute.Bool(consts.OtelSysStepDelete, true))
 	}
 
 	return nil

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -400,7 +400,7 @@ func (s *svc) handleDebounce(ctx context.Context, item queue.Item) error {
 			)
 			defer span.End()
 
-			_, err = s.exec.Schedule(ctx, execution.ScheduleRequest{
+			md, err := s.exec.Schedule(ctx, execution.ScheduleRequest{
 				Function:         f,
 				AccountID:        di.AccountID,
 				WorkspaceID:      di.WorkspaceID,
@@ -412,6 +412,11 @@ func (s *svc) handleDebounce(ctx context.Context, item queue.Item) error {
 			if err != nil {
 				return err
 			}
+
+			if md != nil {
+				span.SetAttributes(attribute.String(consts.OtelAttrSDKRunID, md.ID.RunID.String()))
+			}
+
 			_ = s.debouncer.DeleteDebounceItem(ctx, d.DebounceID, *di, d.AccountID)
 		}
 	}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -410,6 +410,7 @@ func (s *svc) handleDebounce(ctx context.Context, item queue.Item) error {
 				FunctionPausedAt: di.FunctionPausedAt,
 			})
 			if err != nil {
+				span.SetAttributes(attribute.Bool(consts.OtelSysStepDelete, true))
 				return err
 			}
 

--- a/pkg/telemetry/exporters/kafka.go
+++ b/pkg/telemetry/exporters/kafka.go
@@ -141,13 +141,14 @@ func (e *kafkaSpanExporter) ExportSpans(ctx context.Context, spans []trace.ReadO
 	for _, sp := range spans {
 		wg.Add(1)
 
-		for _, attr := range sp.Attributes() {
-			// don't bother sending to Kafka if it's gonna be deleted anyways
-			if attr.Key == consts.OtelSysStepDelete && attr.Value.AsBool() {
-				wg.Done()
-				continue
-			}
-		}
+		// TODO: skip publishing if delete tag is set
+		// for _, attr := range sp.Attributes() {
+		// 	// don't bother sending to Kafka if it's gonna be deleted anyways
+		// 	if attr.Key == consts.OtelSysStepDelete && attr.Value.AsBool() {
+		// 		wg.Done()
+		// 		continue
+		// 	}
+		// }
 
 		span, err := SpanToProto(ctx, sp)
 		if err != nil {

--- a/pkg/telemetry/exporters/kafka.go
+++ b/pkg/telemetry/exporters/kafka.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"github.com/twmb/franz-go/pkg/kgo"

--- a/pkg/telemetry/exporters/kafka.go
+++ b/pkg/telemetry/exporters/kafka.go
@@ -177,8 +177,20 @@ func (e *kafkaSpanExporter) ExportSpans(ctx context.Context, spans []trace.ReadO
 		case "workflow_id", "wf_id", "function_id", "fn_id":
 			rec.Key = []byte(id.GetFunctionId())
 		case "run_id":
-			if id.GetRunId() != "" {
+			switch {
+			case id.GetRunId() != "":
 				rec.Key = []byte(id.GetRunId())
+			case id.GetFunctionId() != "":
+				l.Warn("missing run_id, falling back to function_id", "span", sp)
+				rec.Key = []byte(id.GetFunctionId())
+			case id.GetEnvId() != "":
+				l.Warn("missing run_id, falling back to env_id", "span", sp)
+				rec.Key = []byte(id.GetEnvId())
+			case id.GetAccountId() != "":
+				l.Warn("missing run_id, falling back to acct_id", "span", sp)
+				rec.Key = []byte(id.GetAccountId())
+			default:
+				l.Error("missing run_id, no other identifier to fallback to", "span", sp)
 			}
 		}
 


### PR DESCRIPTION
## Description

Add run_id to root spans whenever possible, and provide additional fallbacks to kafka keys when exporting spans.

Also skip sending to Kafka if the spans is marked for deletion.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
