### PR TITLE
wrap run io in portal to sidestep all z-index issues

### DIFF
--- a/ui/packages/components/package.json
+++ b/ui/packages/components/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-hover-card": "^1.0.7",
     "@radix-ui/react-popover": "^1.0.7",
+    "@radix-ui/react-portal": "^1.1.6",
     "@radix-ui/react-progress": "^1.1.0",
     "@radix-ui/react-select": "^1.2.2",
     "@radix-ui/react-switch": "^1.0.3",

--- a/ui/packages/components/src/CodeBlock/CodeBlock.tsx
+++ b/ui/packages/components/src/CodeBlock/CodeBlock.tsx
@@ -17,6 +17,7 @@ import { RiCollapseDiagonalLine, RiDownload2Line, RiExpandDiagonalLine } from '@
 import { type editor } from 'monaco-editor';
 import { useLocalStorage } from 'react-use';
 
+import { Fullscreen } from '../Fullscreen/Fullscreen';
 import { isDark } from '../utils/theme';
 
 const MAX_HEIGHT = 280; // Equivalent to 10 lines + padding
@@ -249,158 +250,160 @@ export function CodeBlock({
   return (
     <>
       {monaco && (
-        <div className={cn('relative', fullScreen && 'bg-canvasBase fixed inset-0 z-[52]')}>
-          <div className={cn('bg-canvasBase border-subtle border-b')}>
-            <div
-              className={cn(
-                'flex items-center justify-between border-l-4 border-l-transparent',
-                header?.status === 'error' && 'border-l-status-failed',
-                header?.status === 'success' && 'border-l-status-completed'
-              )}
-            >
-              <p
+        <Fullscreen fullScreen={fullScreen}>
+          <div className={cn('relative', fullScreen && 'bg-canvasBase fixed inset-0 z-[52]')}>
+            <div className={cn('bg-canvasBase border-subtle border-b')}>
+              <div
                 className={cn(
-                  header?.status === 'error' ? 'text-status-failedText' : 'text-subtle',
-                  ' px-5 py-2.5 text-sm',
-                  'max-h-24 text-ellipsis break-words' // Handle long titles
+                  'flex items-center justify-between border-l-4 border-l-transparent',
+                  header?.status === 'error' && 'border-l-status-failed',
+                  header?.status === 'success' && 'border-l-status-completed'
                 )}
               >
-                {header?.title}
-              </p>
-              {!isOutputTooLarge && (
-                <div className="mr-4 flex items-center gap-2 py-2">
-                  {actions.map(({ label, title, icon, onClick, disabled }, idx) => (
-                    <Button
-                      key={idx}
-                      icon={icon}
-                      onClick={onClick}
-                      size="small"
-                      aria-label={label}
-                      title={title ?? label}
-                      label={label}
-                      disabled={disabled}
-                      appearance="outlined"
-                      kind="secondary"
-                    />
-                  ))}
-                  <CopyButton
-                    size="small"
-                    code={content}
-                    isCopying={isCopying}
-                    handleCopyClick={handleCopyClick}
-                    appearance="outlined"
-                  />
-                  <Button
-                    icon={isWordWrap ? <IconOverflowText /> : <IconWrapText />}
-                    onClick={handleWrapText}
-                    size="small"
-                    aria-label={isWordWrap ? 'Do not wrap text' : 'Wrap text'}
-                    title={isWordWrap ? 'Do not wrap text' : 'Wrap text'}
-                    tooltip={isWordWrap ? 'Do not wrap text' : 'Wrap text'}
-                    appearance="outlined"
-                    kind="secondary"
-                  />
-                  {!alwaysFullHeight && (
-                    <Button
-                      onClick={handleFullHeight}
-                      size="small"
-                      icon={isFullHeight ? <IconShrinkText /> : <IconExpandText />}
-                      aria-label={isFullHeight ? 'Shrink text' : 'Expand text'}
-                      title={isFullHeight ? 'Shrink text' : 'Expand text'}
-                      tooltip={isFullHeight ? 'Shrink text' : 'Expand text'}
-                      appearance="outlined"
-                      kind="secondary"
-                    />
+                <p
+                  className={cn(
+                    header?.status === 'error' ? 'text-status-failedText' : 'text-subtle',
+                    ' px-5 py-2.5 text-sm',
+                    'max-h-24 text-ellipsis break-words' // Handle long titles
                   )}
-                  {allowFullScreen && (
-                    <Button
-                      onClick={() => setFullScreen(!fullScreen)}
+                >
+                  {header?.title}
+                </p>
+                {!isOutputTooLarge && (
+                  <div className="mr-4 flex items-center gap-2 py-2">
+                    {actions.map(({ label, title, icon, onClick, disabled }, idx) => (
+                      <Button
+                        key={idx}
+                        icon={icon}
+                        onClick={onClick}
+                        size="small"
+                        aria-label={label}
+                        title={title ?? label}
+                        label={label}
+                        disabled={disabled}
+                        appearance="outlined"
+                        kind="secondary"
+                      />
+                    ))}
+                    <CopyButton
                       size="small"
-                      icon={fullScreen ? <RiCollapseDiagonalLine /> : <RiExpandDiagonalLine />}
-                      aria-label="Full screen"
-                      title="Full screen"
-                      tooltip="Full screen"
+                      code={content}
+                      isCopying={isCopying}
+                      handleCopyClick={handleCopyClick}
+                      appearance="outlined"
+                    />
+                    <Button
+                      icon={isWordWrap ? <IconOverflowText /> : <IconWrapText />}
+                      onClick={handleWrapText}
+                      size="small"
+                      aria-label={isWordWrap ? 'Do not wrap text' : 'Wrap text'}
+                      title={isWordWrap ? 'Do not wrap text' : 'Wrap text'}
+                      tooltip={isWordWrap ? 'Do not wrap text' : 'Wrap text'}
                       appearance="outlined"
                       kind="secondary"
                     />
-                  )}
-                </div>
+                    {!alwaysFullHeight && (
+                      <Button
+                        onClick={handleFullHeight}
+                        size="small"
+                        icon={isFullHeight ? <IconShrinkText /> : <IconExpandText />}
+                        aria-label={isFullHeight ? 'Shrink text' : 'Expand text'}
+                        title={isFullHeight ? 'Shrink text' : 'Expand text'}
+                        tooltip={isFullHeight ? 'Shrink text' : 'Expand text'}
+                        appearance="outlined"
+                        kind="secondary"
+                      />
+                    )}
+                    {allowFullScreen && (
+                      <Button
+                        onClick={() => setFullScreen(!fullScreen)}
+                        size="small"
+                        icon={fullScreen ? <RiCollapseDiagonalLine /> : <RiExpandDiagonalLine />}
+                        aria-label="Full screen"
+                        title="Full screen"
+                        tooltip="Full screen"
+                        appearance="outlined"
+                        kind="secondary"
+                      />
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+            <div
+              ref={wrapperRef}
+              className={cn('relative', (alwaysFullHeight || fullScreen) && 'h-screen')}
+            >
+              {isOutputTooLarge ? (
+                <>
+                  <Alert severity="warning">Output size is too large to render {`( > 1MB )`}</Alert>
+                  <div className="flex h-24 items-center justify-center	">
+                    <Button
+                      label="Download Raw"
+                      icon={<RiDownload2Line />}
+                      onClick={() => downloadJson({ content: content })}
+                      appearance="outlined"
+                      kind="secondary"
+                    />
+                  </div>
+                </>
+              ) : (
+                <Editor
+                  className={cn('relative', (alwaysFullHeight || fullScreen) && 'h-full')}
+                  height={alwaysFullHeight || fullScreen ? '100%' : editorHeight}
+                  defaultLanguage={language}
+                  value={content}
+                  theme="inngest-theme"
+                  options={{
+                    // Need to set automaticLayout to true to avoid a resizing bug
+                    // (code block never narrows). This is combined with the
+                    // `absolute` class and explicit height prop
+                    automaticLayout: true,
+
+                    extraEditorClassName: '!w-full',
+                    readOnly: readOnly,
+                    minimap: {
+                      enabled: false,
+                    },
+                    lineNumbers: 'on',
+                    contextmenu: false,
+                    scrollBeyondLastLine: alwaysFullHeight ? true : false,
+                    fontFamily: FONT.font,
+                    fontSize: FONT.size,
+                    fontWeight: 'light',
+                    lineHeight: LINE_HEIGHT,
+                    renderLineHighlight: 'none',
+                    renderWhitespace: 'none',
+                    guides: {
+                      indentation: false,
+                      highlightActiveBracketPair: false,
+                      highlightActiveIndentation: false,
+                    },
+                    scrollbar: {
+                      verticalScrollbarSize: 10,
+                      alwaysConsumeMouseWheel: false,
+                    },
+                    padding: {
+                      top: 10,
+                      bottom: 10,
+                    },
+                    wordWrap: isWordWrap ? 'on' : 'off',
+                  }}
+                  onMount={(editor) => {
+                    handleEditorDidMount(editor);
+                    !alwaysFullHeight && updateEditorLayout(editor);
+                  }}
+                  onChange={(value) => {
+                    if (value !== undefined) {
+                      handleChange && handleChange(value);
+                      !alwaysFullHeight && updateEditorLayout(editorRef.current);
+                    }
+                  }}
+                />
               )}
             </div>
           </div>
-          <div
-            ref={wrapperRef}
-            className={cn('relative', (alwaysFullHeight || fullScreen) && 'h-screen')}
-          >
-            {isOutputTooLarge ? (
-              <>
-                <Alert severity="warning">Output size is too large to render {`( > 1MB )`}</Alert>
-                <div className="flex h-24 items-center justify-center	">
-                  <Button
-                    label="Download Raw"
-                    icon={<RiDownload2Line />}
-                    onClick={() => downloadJson({ content: content })}
-                    appearance="outlined"
-                    kind="secondary"
-                  />
-                </div>
-              </>
-            ) : (
-              <Editor
-                className={cn('relative', (alwaysFullHeight || fullScreen) && 'h-full')}
-                height={alwaysFullHeight || fullScreen ? '100%' : editorHeight}
-                defaultLanguage={language}
-                value={content}
-                theme="inngest-theme"
-                options={{
-                  // Need to set automaticLayout to true to avoid a resizing bug
-                  // (code block never narrows). This is combined with the
-                  // `absolute` class and explicit height prop
-                  automaticLayout: true,
-
-                  extraEditorClassName: '!w-full',
-                  readOnly: readOnly,
-                  minimap: {
-                    enabled: false,
-                  },
-                  lineNumbers: 'on',
-                  contextmenu: false,
-                  scrollBeyondLastLine: alwaysFullHeight ? true : false,
-                  fontFamily: FONT.font,
-                  fontSize: FONT.size,
-                  fontWeight: 'light',
-                  lineHeight: LINE_HEIGHT,
-                  renderLineHighlight: 'none',
-                  renderWhitespace: 'none',
-                  guides: {
-                    indentation: false,
-                    highlightActiveBracketPair: false,
-                    highlightActiveIndentation: false,
-                  },
-                  scrollbar: {
-                    verticalScrollbarSize: 10,
-                    alwaysConsumeMouseWheel: false,
-                  },
-                  padding: {
-                    top: 10,
-                    bottom: 10,
-                  },
-                  wordWrap: isWordWrap ? 'on' : 'off',
-                }}
-                onMount={(editor) => {
-                  handleEditorDidMount(editor);
-                  !alwaysFullHeight && updateEditorLayout(editor);
-                }}
-                onChange={(value) => {
-                  if (value !== undefined) {
-                    handleChange && handleChange(value);
-                    !alwaysFullHeight && updateEditorLayout(editorRef.current);
-                  }
-                }}
-              />
-            )}
-          </div>
-        </div>
+        </Fullscreen>
       )}
     </>
   );

--- a/ui/packages/components/src/Fullscreen/Fullscreen.tsx
+++ b/ui/packages/components/src/Fullscreen/Fullscreen.tsx
@@ -1,0 +1,14 @@
+import { Portal } from '@radix-ui/react-portal';
+
+/**
+ * A full screen portal component that side steps all intervening z-indexes
+ */
+export const Fullscreen = ({
+  fullScreen = false,
+  children,
+}: {
+  fullScreen?: boolean;
+  children: React.ReactNode;
+}) => {
+  return fullScreen ? <Portal className="absolute inset-0 z-[100]">{children}</Portal> : children;
+};

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -486,6 +486,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.0.7
         version: 1.0.7(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-portal':
+        specifier: ^1.1.6
+        version: 1.1.6(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-progress':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0)
@@ -4873,6 +4876,19 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@radix-ui/react-compose-refs@1.1.2(@types/react@18.2.11)(react@18.2.0):
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.11
+      react: 18.2.0
+    dev: false
+
   /@radix-ui/react-context@1.0.1(@types/react@18.2.11)(react@18.2.0):
     resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
     peerDependencies:
@@ -5437,6 +5453,26 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@radix-ui/react-portal@1.1.6(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-XmsIl2z1n/TsYFLIdYam2rmFwf9OC/Sh2avkbmVMDuBZIe7hSpM0cYnWPAo7nHOVx8zTuwDZGByfcqLdnzp3Vw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.0(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.2.11)(react@18.2.0)
+      '@types/react': 18.2.11
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-presence@1.0.1(@types/react-dom@18.2.4)(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==}
     peerDependencies:
@@ -5535,6 +5571,25 @@ packages:
       '@radix-ui/react-slot': 1.1.2(@types/react@18.2.11)(react@18.2.0)
       '@types/react': 18.2.11
       '@types/react-dom': 18.2.4
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-primitive@2.1.0(@types/react@18.2.11)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-/J/FhLdK0zVcILOwt5g+dH4KnkonCtkVJsa2G6JmvbbtZfBEI1gMsO3QMjseL4F/SwfAMt1Vc/0XKYKq+xJ1sw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-slot': 1.2.0(@types/react@18.2.11)(react@18.2.0)
+      '@types/react': 18.2.11
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -5712,6 +5767,20 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.2.11)(react@18.2.0)
+      '@types/react': 18.2.11
+      react: 18.2.0
+    dev: false
+
+  /@radix-ui/react-slot@1.2.0(@types/react@18.2.11)(react@18.2.0):
+    resolution: {integrity: sha512-ujc+V6r0HNDviYqIK3rW4ffgYiZ8g5DEHrGJVk4x7kTlLXRDILnKX9vAUYeIsLOoDpDJ0ujpqMkjH4w2ofuo6w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.2.11)(react@18.2.0)
       '@types/react': 18.2.11
       react: 18.2.0
     dev: false
@@ -6026,6 +6095,19 @@ packages:
     dependencies:
       '@types/react': 18.2.11
       react: 18.2.0
+
+  /@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.2.11)(react@18.2.0):
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.2.11
+      react: 18.2.0
+    dev: false
 
   /@radix-ui/react-use-previous@1.0.1(@types/react@18.2.11)(react@18.2.0):
     resolution: {integrity: sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==}


### PR DESCRIPTION
## Description

<img width="1909" alt="Screenshot 2025-04-25 at 10 31 27 AM" src="https://github.com/user-attachments/assets/fdf41147-fc19-4414-8e1b-89bb3a73a199" />


## Motivation
Restore full screen functionality for our function run io component.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
