### PR TITLE
Simplify queue

### DIFF
--- a/pkg/execution/state/redis_state/lua/includes/enqueue_to_partition.lua
+++ b/pkg/execution/state/redis_state/lua/includes/enqueue_to_partition.lua
@@ -7,15 +7,10 @@ local function enqueue_get_partition_item(partitionKey, id)
 	return nil
 end
 
-local function enqueue_to_partition(keyPartitionSet, partitionID, partitionItem, partitionType, keyPartitionMap, keyGlobalPointer, keyGlobalAccountPointer, keyAccountPartitions, queueScore, queueID, partitionTime, nowMS)
+local function enqueue_to_partition(keyPartitionSet, partitionID, partitionItem, keyPartitionMap, keyGlobalPointer, keyGlobalAccountPointer, keyAccountPartitions, queueScore, queueID, partitionTime, nowMS)
 	if partitionID == "" then
 		-- This is a blank partition, so don't even bother.  This allows us to pre-allocate
 		-- 3 partitions per item, even if an item only needs a single partition.
-		return
-	end
-
-	-- Do not enqueue to key queues
-	if partitionType ~= 0 then
 		return
 	end
 
@@ -81,15 +76,10 @@ end
 -- requeue_to_partition is similar to enqueue, but always fetches the minimum score for a partition to
 -- update global pointers instead of using the current queue item's score.
 -- Requires: update_account_queues.lua which requires update_pointer_score.lua, ends_with.lua
-local function requeue_to_partition(keyPartitionSet, partitionID, partitionItem, partitionType, keyPartitionMap, keyGlobalPointer, keyGlobalAccountPointer, keyAccountPartitions, queueScore, queueID, nowMS, accountID)
+local function requeue_to_partition(keyPartitionSet, partitionID, partitionItem, keyPartitionMap, keyGlobalPointer, keyGlobalAccountPointer, keyAccountPartitions, queueScore, queueID, nowMS, accountID)
 	if partitionID == "" then
 		-- This is a blank partition, so don't even bother.  This allows us to pre-allocate
 		-- 3 partitions per item, even if an item only needs a single partition.
-		return
-	end
-
-	if partitionType ~= 0 then
-		-- Do not requeue to key queues
 		return
 	end
 

--- a/pkg/execution/state/redis_state/lua/queue/enqueue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/enqueue.lua
@@ -13,11 +13,9 @@ local keyAccountPartitions    	= KEYS[5]           -- accounts:$accountId:partit
 local idempotencyKey          	= KEYS[6]           -- seen:$key
 local keyFnMetadata           	= KEYS[7]           -- fnMeta:$id - hash
 local guaranteedCapacityMapKey	= KEYS[8]           -- shards - hmap of shards
-local keyPartitionA           	= KEYS[9]           -- queue:sorted:$workflowID - zset
-local keyPartitionB           	= KEYS[10]           -- e.g. sorted:c|t:$workflowID - zset
-local keyPartitionC           	= KEYS[11]          -- e.g. sorted:c|t:$workflowID - zset
-local keyItemIndexA           	= KEYS[12]          -- custom item index 1
-local keyItemIndexB           	= KEYS[13]          -- custom item index 2
+local keyPartition           	  = KEYS[9]           -- queue:sorted:$workflowID - zset
+local keyItemIndexA           	= KEYS[10]          -- custom item index 1
+local keyItemIndexB           	= KEYS[11]          -- custom item index 2
 
 local queueItem           		= ARGV[1]           -- {id, lease id, attempt, max attempt, data, etc...}
 local queueID             		= ARGV[2]           -- id
@@ -25,18 +23,11 @@ local queueScore          		= tonumber(ARGV[3]) -- vesting time, in milliseconds
 local partitionTime       		= tonumber(ARGV[4]) -- score for partition, lower bounded to now in seconds
 local nowMS               		= tonumber(ARGV[5]) -- now in ms
 local fnMetadata          		= ARGV[6]          -- function meta: {paused}
-local partitionItemA      		= ARGV[7]
-local partitionItemB      		= ARGV[8]
-local partitionItemC      		= ARGV[9]
-local partitionIdA        		= ARGV[10]
-local partitionIdB        		= ARGV[11]
-local partitionIdC        		= ARGV[12]
-local partitionTypeA        	= tonumber(ARGV[13])
-local partitionTypeB        	= tonumber(ARGV[14])
-local partitionTypeC        	= tonumber(ARGV[15])
-local accountId           		= ARGV[16]
-local guaranteedCapacity      = ARGV[17]
-local guaranteedCapacityKey   = ARGV[18]
+local partitionItem      		  = ARGV[7]
+local partitionID        		  = ARGV[8]
+local accountId           		= ARGV[9]
+local guaranteedCapacity      = ARGV[10]
+local guaranteedCapacityKey   = ARGV[11]
 
 -- $include(update_pointer_score.lua)
 -- $include(ends_with.lua)
@@ -56,9 +47,7 @@ if redis.call("HSETNX", queueKey, queueID, queueItem) == 0 then
     return 1
 end
 
-enqueue_to_partition(keyPartitionA, partitionIdA, partitionItemA, partitionTypeA, keyPartitionMap, keyGlobalPointer, keyGlobalAccountPointer, keyAccountPartitions, queueScore, queueID, partitionTime, nowMS)
-enqueue_to_partition(keyPartitionB, partitionIdB, partitionItemB, partitionTypeB, keyPartitionMap, keyGlobalPointer, keyGlobalAccountPointer, keyAccountPartitions, queueScore, queueID, partitionTime, nowMS)
-enqueue_to_partition(keyPartitionC, partitionIdC, partitionItemC, partitionTypeC, keyPartitionMap, keyGlobalPointer, keyGlobalAccountPointer, keyAccountPartitions, queueScore, queueID, partitionTime, nowMS)
+enqueue_to_partition(keyPartition, partitionID, partitionItem, keyPartitionMap, keyGlobalPointer, keyGlobalAccountPointer, keyAccountPartitions, queueScore, queueID, partitionTime, nowMS)
 
 if exists_without_ending(keyFnMetadata, ":fnMeta:-") == true then
 	-- note to future devs: if updating metadata, be sure you do not change the "off"

--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -16,38 +16,31 @@ Output:
 ]]
 
 local keyQueueMap            	= KEYS[1]
-local keyPartitionA          	= KEYS[2]           -- queue:sorted:$workflowID - zset
-local keyPartitionB          	= KEYS[3]           -- e.g. sorted:c|t:$workflowID - zset
-local keyPartitionC          	= KEYS[4]          -- e.g. sorted:c|t:$workflowID - zset
+local keyPartitionFn          = KEYS[2]           -- queue:sorted:$workflowID - zset
 
 -- We push our queue item ID into each concurrency queue
-local keyConcurrencyA  				= KEYS[5] -- Account concurrency level
-local keyConcurrencyB  				= KEYS[6] -- When leasing an item we need to place the lease into this key.
-local keyConcurrencyC  				= KEYS[7] -- Optional for eg. for concurrency amongst steps
+local keyConcurrencyFn  				= KEYS[3] -- Account concurrency level
+local keyCustomConcurrencyKey1  = KEYS[4] -- When leasing an item we need to place the lease into this key.
+local keyCustomConcurrencyKey2  = KEYS[5] -- Optional for eg. for concurrency amongst steps
 -- We push pointers to partition concurrency items to the partition concurrency item
-local concurrencyPointer      = KEYS[8]
-local keyGlobalPointer        = KEYS[9]
-local keyGlobalAccountPointer = KEYS[10] -- accounts:sorted - zset
-local keyAccountPartitions    = KEYS[11] -- accounts:$accountId:partition:sorted - zset
-local throttleKey             = KEYS[12] -- key used for throttling function run starts.
-local keyAcctConcurrency      = KEYS[13]
+local concurrencyPointer      = KEYS[6]
+local keyGlobalPointer        = KEYS[7]
+local keyGlobalAccountPointer = KEYS[8] -- accounts:sorted - zset
+local keyAccountPartitions    = KEYS[9] -- accounts:$accountId:partition:sorted - zset
+local throttleKey             = KEYS[10] -- key used for throttling function run starts.
+local keyAcctConcurrency      = KEYS[11]
 
 local queueID      						= ARGV[1]
 local newLeaseKey  						= ARGV[2]
 local currentTime  						= tonumber(ARGV[3]) -- in ms
-local partitionIdA 						= ARGV[4]
-local partitionIdB 						= ARGV[5]
-local partitionIdC 						= ARGV[6]
+local partitionID 					  = ARGV[4]
 -- We check concurrency limits when leasing queue items.
-local concurrencyA    				= tonumber(ARGV[7])
-local concurrencyB    				= tonumber(ARGV[8])
-local concurrencyC    				= tonumber(ARGV[9])
+local concurrencyFn    				= tonumber(ARGV[5])
+local customConcurrencyKey1   = tonumber(ARGV[6])
+local customConcurrencyKey2   = tonumber(ARGV[7])
 -- And we always check against account concurrency limits
-local concurrencyAcct 				= tonumber(ARGV[10])
-local accountId       				= ARGV[11]
-local partitionTypeA = tonumber(ARGV[12])
-local partitionTypeB = tonumber(ARGV[13])
-local partitionTypeC = tonumber(ARGV[14])
+local concurrencyAcct 				= tonumber(ARGV[8])
+local accountId       				= ARGV[9]
 
 
 -- Use our custom Go preprocessor to inject the file from ./includes/
@@ -93,19 +86,19 @@ end
 -- Check the concurrency limits for the account and custom key;  partition keys are checked when
 -- leasing the partition and do not need to be checked again (only one worker can run a partition at
 -- once, and the capacity is kept in memory after leasing a partition)
-if concurrencyA > 0 then
-    if check_concurrency(currentTime, keyConcurrencyA, concurrencyA) <= 0 then
-        return 3
-    end
-end
-if concurrencyB > 0 then
-    if check_concurrency(currentTime, keyConcurrencyB, concurrencyB) <= 0 then
+if customConcurrencyKey1 > 0 then
+    if check_concurrency(currentTime, keyCustomConcurrencyKey1, customConcurrencyKey1) <= 0 then
         return 4
     end
 end
-if concurrencyC > 0 then
-    if check_concurrency(currentTime, keyConcurrencyC, concurrencyC) <= 0 then
+if customConcurrencyKey2 > 0 then
+    if check_concurrency(currentTime, keyCustomConcurrencyKey2, customConcurrencyKey2) <= 0 then
         return 5
+    end
+end
+if concurrencyFn > 0 then
+    if check_concurrency(currentTime, keyConcurrencyFn, concurrencyFn) <= 0 then
+        return 3
     end
 end
 if concurrencyAcct > 0 then
@@ -118,41 +111,10 @@ end
 item.leaseID = newLeaseKey
 redis.call("HSET", keyQueueMap, queueID, cjson.encode(item))
 
-local function handleLease(keyPartition, keyConcurrency, concurrencyLimit, partitionID, partitionType)
-	-- If we're dealing with a default function partition, we still want to add
-	-- to the concurrency (in progress) queue. Otherwise, concurrency limits must be set.
-	if partitionType == 0 or concurrencyLimit > 0 then
+local function handleLease(keyConcurrency, concurrencyLimit)
+	if concurrencyLimit > 0 then
 		-- Add item to in-progress/concurrency queue and set score to lease expiry time to be picked up by scavenger
 		redis.call("ZADD", keyConcurrency, nextTime, item.id)
-
-		-- Remove the item from our sorted index, as this is no longer on the queue; it's in-progress
-		-- and stored in functionConcurrencyKey.
-		redis.call("ZREM", keyPartition, item.id)
-	end
-
-	if partitionType ~= 0 then
-		-- Do not add key queues to concurrency pointer
-		return
-	end
-
-	-- For every queue that we lease from, ensure that it exists in the scavenger pointer queue
-	-- so that expired leases can be re-processed.  We want to take the earliest time from the
-	-- concurrency queue such that we get a previously lost job if possible.
-	local inProgressScores = redis.call("ZRANGE", keyConcurrency, "-inf", "+inf", "BYSCORE", "LIMIT", 0, 1, "WITHSCORES")
-	if inProgressScores ~= false then
-		local earliestLease = tonumber(inProgressScores[2])
-		-- Add the earliest time to the pointer queue for in-progress, allowing us to scavenge
-		-- lost jobs easily.
-		-- Note: Previously, we stored the queue name in the zset, so we have to add an extra
-		-- check to the scavenger logic to handle partition uuids for old queue items
-
-		-- Backwards compatibility: For default partitions, use the partition ID (function ID) as the pointer
-		local pointerMember = keyConcurrency
-		if partitionType == 0 then
-			pointerMember = partitionID
-		end
-
-		redis.call("ZADD", concurrencyPointer, earliestLease, pointerMember)
 	end
 end
 
@@ -160,17 +122,33 @@ end
 -- Always add this to acct level concurrency queues
 redis.call("ZADD", keyAcctConcurrency, nextTime, item.id)
 
--- NOTE: We check if concurrency > 0 here because this disables concurrency.  AccountID
--- and custom concurrency items may not be set, but the keys need to be set for clustered
--- mode.
-if exists_without_ending(keyConcurrencyA, ":-") == true then
-	handleLease(keyPartitionA, keyConcurrencyA, concurrencyA, partitionIdA, partitionTypeA)
+-- Always add this to fn level concurrency queues for scavenging
+redis.call("ZADD", keyConcurrencyFn, nextTime, item.id)
+
+-- Remove the item from our sorted index, as this is no longer on the queue; it's in-progress
+-- and stored in functionConcurrencyKey.
+redis.call("ZREM", keyPartitionFn, item.id)
+
+-- For every queue that we lease from, ensure that it exists in the scavenger pointer queue
+-- so that expired leases can be re-processed.  We want to take the earliest time from the
+-- concurrency queue such that we get a previously lost job if possible.
+local inProgressScores = redis.call("ZRANGE", keyConcurrencyFn, "-inf", "+inf", "BYSCORE", "LIMIT", 0, 1, "WITHSCORES")
+if inProgressScores ~= false then
+  local earliestLease = tonumber(inProgressScores[2])
+  -- Add the earliest time to the pointer queue for in-progress, allowing us to scavenge
+  -- lost jobs easily.
+  -- Note: Previously, we stored the queue name in the zset, so we have to add an extra
+  -- check to the scavenger logic to handle partition uuids for old queue items
+
+  redis.call("ZADD", concurrencyPointer, earliestLease, partitionID)
 end
-if exists_without_ending(keyConcurrencyB, ":-") == true then
-	handleLease(keyPartitionB, keyConcurrencyB, concurrencyB, partitionIdB, partitionTypeB)
+
+if exists_without_ending(keyCustomConcurrencyKey1, ":-") == true then
+	handleLease(keyCustomConcurrencyKey1, customConcurrencyKey1)
 end
-if exists_without_ending(keyConcurrencyC, ":-") == true then
-	handleLease(keyPartitionC, keyConcurrencyC, concurrencyC, partitionIdC, partitionTypeC)
+
+if exists_without_ending(keyCustomConcurrencyKey2, ":-") == true then
+	handleLease(keyCustomConcurrencyKey2, customConcurrencyKey2)
 end
 
 return 0

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -492,8 +492,7 @@ func TestQueueEnqueueItem(t *testing.T) {
 				},
 			}
 
-			actualItemPartitions, acctLimit := q.ItemPartitions(ctx, q.primaryQueueShard, qi)
-			assert.Equal(t, 3, len(actualItemPartitions))
+			_, partitionCustomConcurrencyKey1, _, acctLimit := q.ItemPartitions(ctx, q.primaryQueueShard, qi)
 			assert.Equal(t, consts.DefaultConcurrencyLimit, acctLimit)
 
 			// Enqueue always enqueues to the default partitions - enqueueing to key queues has been disabled for now
@@ -508,7 +507,7 @@ func TestQueueEnqueueItem(t *testing.T) {
 				UnevaluatedConcurrencyHash: ck.Hash,
 			}
 
-			assert.Equal(t, customkeyQueuePartition, actualItemPartitions[0])
+			assert.Equal(t, customkeyQueuePartition, partitionCustomConcurrencyKey1)
 
 			i, err := q.EnqueueItem(ctx, q.primaryQueueShard, qi, now.Add(10*time.Second), osqueue.EnqueueOpts{})
 			require.NoError(t, err)
@@ -565,9 +564,18 @@ func TestQueueEnqueueItem(t *testing.T) {
 					}},
 			}
 
-			actualItemPartitions, acctLimit := q.ItemPartitions(ctx, q.primaryQueueShard, qi)
-			assert.Equal(t, 3, len(actualItemPartitions))
+			partitionFn, partitionCustomConcurrencyKey1, partitionCustomConcurrencyKey2, acctLimit := q.ItemPartitions(ctx, q.primaryQueueShard, qi)
 			assert.Equal(t, consts.DefaultConcurrencyLimit, acctLimit)
+
+			// We enqueue to the function-specific queue for backwards-compatibility reasons
+			expectedDefaultPartition := QueuePartition{
+				ID:               fnID.String(),
+				FunctionID:       &fnID,
+				AccountID:        accountId,
+				ConcurrencyLimit: consts.DefaultConcurrencyLimit,
+			}
+			assert.Equal(t, expectedDefaultPartition, partitionFn)
+
 			keyQueueA := QueuePartition{
 				ID:                         q.primaryQueueShard.RedisClient.kg.PartitionQueueSet(enums.PartitionTypeConcurrencyKey, fnID.String(), hashA),
 				PartitionType:              int(enums.PartitionTypeConcurrencyKey),
@@ -578,7 +586,7 @@ func TestQueueEnqueueItem(t *testing.T) {
 				EvaluatedConcurrencyKey:    ckA.Key,
 				UnevaluatedConcurrencyHash: ckA.Hash,
 			}
-			assert.Equal(t, keyQueueA, actualItemPartitions[0])
+			assert.Equal(t, keyQueueA, partitionCustomConcurrencyKey1)
 
 			keyQueueB := QueuePartition{
 				ID:                         q.primaryQueueShard.RedisClient.kg.PartitionQueueSet(enums.PartitionTypeConcurrencyKey, fnID.String(), hashB),
@@ -590,16 +598,7 @@ func TestQueueEnqueueItem(t *testing.T) {
 				EvaluatedConcurrencyKey:    ckB.Key,
 				UnevaluatedConcurrencyHash: ckB.Hash,
 			}
-			assert.Equal(t, keyQueueB, actualItemPartitions[1])
-
-			// We enqueue to the function-specific queue for backwards-compatibility reasons
-			expectedDefaultPartition := QueuePartition{
-				ID:               fnID.String(),
-				FunctionID:       &fnID,
-				AccountID:        accountId,
-				ConcurrencyLimit: consts.DefaultConcurrencyLimit,
-			}
-			assert.Equal(t, expectedDefaultPartition, actualItemPartitions[2])
+			assert.Equal(t, keyQueueB, partitionCustomConcurrencyKey2)
 
 			i, err := q.EnqueueItem(ctx, q.primaryQueueShard, qi, now.Add(10*time.Second), osqueue.EnqueueOpts{})
 			require.NoError(t, err)
@@ -1616,6 +1615,7 @@ func TestQueueLease(t *testing.T) {
 			require.NoError(t, err)
 			itemA2, err := q.EnqueueItem(ctx, q.primaryQueueShard, osqueue.QueueItem{FunctionID: fnIDA, Data: osqueue.Item{CustomConcurrencyKeys: []state.CustomConcurrency{ckA}}}, start, osqueue.EnqueueOpts{})
 			require.NoError(t, err)
+
 			itemB1, err := q.EnqueueItem(ctx, q.primaryQueueShard, osqueue.QueueItem{FunctionID: fnIDB, Data: osqueue.Item{CustomConcurrencyKeys: []state.CustomConcurrency{ckB}}}, start, osqueue.EnqueueOpts{})
 			require.NoError(t, err)
 			itemB2, err := q.EnqueueItem(ctx, q.primaryQueueShard, osqueue.QueueItem{FunctionID: fnIDB, Data: osqueue.Item{CustomConcurrencyKeys: []state.CustomConcurrency{ckB}}}, start, osqueue.EnqueueOpts{})
@@ -1747,11 +1747,9 @@ func TestQueueLease(t *testing.T) {
 				defaultPartition := getDefaultPartition(t, r, uuid.Nil)
 
 				// The partition should use a custom ID for the concurrency key.
-				parts, _ := q.ItemPartitions(ctx, q.primaryQueueShard, itemA)
-				pa1, pa2 := parts[0], parts[1]
+				_, pa1, pa2, _ := q.ItemPartitions(ctx, q.primaryQueueShard, itemA)
 
-				parts, _ = q.ItemPartitions(ctx, q.primaryQueueShard, itemB)
-				pb1, pb2 := parts[0], parts[1]
+				_, pb1, pb2, _ := q.ItemPartitions(ctx, q.primaryQueueShard, itemB)
 
 				require.Equal(t, "{queue}:sorted:c:00000000-0000-0000-0000-000000000000<2gu959eo1zbsi>", pa1.ID)
 				require.Equal(t, "{queue}:sorted:c:00000000-0000-0000-0000-000000000000<1x6209w26mx6i>", pa2.ID)
@@ -1808,8 +1806,7 @@ func TestQueueLease(t *testing.T) {
 			_, err = q.EnqueueItem(ctx, q.primaryQueueShard, osqueue.QueueItem{}, atB, osqueue.EnqueueOpts{})
 			require.NoError(t, err)
 
-			parts, _ := q.ItemPartitions(ctx, q.primaryQueueShard, itemA)
-			p := parts[0]
+			p, _, _, _ := q.ItemPartitions(ctx, q.primaryQueueShard, itemA)
 
 			score, err := r.ZScore(defaultQueueKey.GlobalPartitionIndex(), p.Queue())
 			require.NoError(t, err)
@@ -1906,19 +1903,18 @@ func TestQueueLease(t *testing.T) {
 		}
 
 		// Sanity check: Ensure partitions are created properly and keys match old system
-		parts, _ := q.ItemPartitions(ctx, q.primaryQueueShard, qi)
-		require.Equal(t, 3, len(parts))
+		fnPart, custom1, custom2, _ := q.ItemPartitions(ctx, q.primaryQueueShard, qi)
 		require.Equal(t, QueuePartition{
 			ID:               systemQueueName,
 			QueueName:        &systemQueueName,
 			ConcurrencyLimit: consts.DefaultConcurrencyLimit,
-		}, parts[0])
-		require.True(t, parts[0].IsSystem())
-		require.Equal(t, QueuePartition{}, parts[1])
-		require.Equal(t, QueuePartition{}, parts[2])
+		}, fnPart)
+		require.True(t, fnPart.IsSystem())
+		require.Equal(t, QueuePartition{}, custom1)
+		require.Equal(t, QueuePartition{}, custom2)
 
-		require.Equal(t, "{queue}:queue:sorted:schedule-batch", parts[0].zsetKey(kg))
-		require.Equal(t, "{queue}:concurrency:p:00000000-0000-0000-0000-000000000000", parts[0].concurrencyKey(kg))
+		require.Equal(t, "{queue}:queue:sorted:schedule-batch", fnPart.zsetKey(kg))
+		require.Equal(t, "{queue}:concurrency:p:00000000-0000-0000-0000-000000000000", fnPart.concurrencyKey(kg))
 
 		item, err := q.EnqueueItem(ctx, q.primaryQueueShard, qi, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
@@ -2057,8 +2053,7 @@ func TestQueueExtendLease(t *testing.T) {
 		item = getQueueItem(t, r, item.ID)
 		require.Nil(t, item.LeaseID)
 
-		parts, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
-		p := parts[0]
+		p, _, _, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
 
 		now := time.Now()
 		id, err := q.Lease(ctx, item, time.Second, time.Now(), nil)
@@ -2141,19 +2136,19 @@ func TestQueueExtendLease(t *testing.T) {
 		require.Nil(t, err)
 
 		// First 2 partitions will be custom.
-		parts, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
-		require.Equal(t, int(enums.PartitionTypeConcurrencyKey), parts[0].PartitionType)
-		require.Equal(t, int(enums.PartitionTypeConcurrencyKey), parts[1].PartitionType)
-		require.Equal(t, int(enums.PartitionTypeDefault), parts[2].PartitionType)
+		fnPart, custom1, custom2, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
+		require.Equal(t, int(enums.PartitionTypeDefault), fnPart.PartitionType)
+		require.Equal(t, int(enums.PartitionTypeConcurrencyKey), custom1.PartitionType)
+		require.Equal(t, int(enums.PartitionTypeConcurrencyKey), custom2.PartitionType)
 
 		// Lease the item.
 		id, err := q.Lease(ctx, item, time.Second, q.clock.Now(), nil)
 		require.NoError(t, err)
 		require.NotNil(t, id)
 
-		score0, err := r.ZMScore(parts[0].concurrencyKey(q.primaryQueueShard.RedisClient.kg), item.ID)
+		score0, err := r.ZMScore(fnPart.concurrencyKey(q.primaryQueueShard.RedisClient.kg), item.ID)
 		require.NoError(t, err)
-		score1, err := r.ZMScore(parts[1].concurrencyKey(q.primaryQueueShard.RedisClient.kg), item.ID)
+		score1, err := r.ZMScore(custom1.concurrencyKey(q.primaryQueueShard.RedisClient.kg), item.ID)
 		require.NoError(t, err)
 		require.Equal(t, score0[0], score1[0], "Partition scores should match after leasing")
 
@@ -2162,9 +2157,9 @@ func TestQueueExtendLease(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, id)
 
-			newScore0, err := r.ZMScore(parts[0].concurrencyKey(q.primaryQueueShard.RedisClient.kg), item.ID)
+			newScore0, err := r.ZMScore(fnPart.concurrencyKey(q.primaryQueueShard.RedisClient.kg), item.ID)
 			require.NoError(t, err)
-			newScore1, err := r.ZMScore(parts[1].concurrencyKey(q.primaryQueueShard.RedisClient.kg), item.ID)
+			newScore1, err := r.ZMScore(custom1.concurrencyKey(q.primaryQueueShard.RedisClient.kg), item.ID)
 			require.NoError(t, err)
 
 			require.Equal(t, newScore0, newScore1, "Partition scores should match after leasing")
@@ -2181,11 +2176,11 @@ func TestQueueExtendLease(t *testing.T) {
 			mem, err := r.ZMembers(q.primaryQueueShard.RedisClient.kg.ConcurrencyIndex())
 			require.NoError(t, err)
 			require.Equal(t, 1, len(mem), "scavenge queue should have 1 item", mem)
-			require.NotContains(t, mem, parts[0].concurrencyKey(q.primaryQueueShard.RedisClient.kg))
-			require.NotContains(t, mem, parts[1].concurrencyKey(q.primaryQueueShard.RedisClient.kg))
-			require.Contains(t, mem, parts[2].ID)
+			require.Contains(t, mem, fnPart.ID)
+			require.NotContains(t, mem, custom1.concurrencyKey(q.primaryQueueShard.RedisClient.kg))
+			require.NotContains(t, mem, custom2.concurrencyKey(q.primaryQueueShard.RedisClient.kg))
 
-			score, err := r.ZMScore(q.primaryQueueShard.RedisClient.kg.ConcurrencyIndex(), parts[2].ID)
+			score, err := r.ZMScore(q.primaryQueueShard.RedisClient.kg.ConcurrencyIndex(), fnPart.ID)
 			require.NoError(t, err)
 			require.NotZero(t, score[0])
 
@@ -2193,7 +2188,7 @@ func TestQueueExtendLease(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, id)
 
-			nextScore, err := r.ZMScore(q.primaryQueueShard.RedisClient.kg.ConcurrencyIndex(), parts[2].ID)
+			nextScore, err := r.ZMScore(q.primaryQueueShard.RedisClient.kg.ConcurrencyIndex(), fnPart.ID)
 			require.NoError(t, err)
 
 			require.NotEqual(t, score[0], nextScore[0])
@@ -2281,10 +2276,10 @@ func TestQueueDequeue(t *testing.T) {
 		require.Nil(t, err)
 
 		// First 2 partitions will be custom, third one default
-		parts, acctLimit := q.ItemPartitions(ctx, q.primaryQueueShard, itemA)
-		require.Equal(t, int(enums.PartitionTypeConcurrencyKey), parts[0].PartitionType)
-		require.Equal(t, int(enums.PartitionTypeConcurrencyKey), parts[1].PartitionType)
-		require.Equal(t, int(enums.PartitionTypeDefault), parts[2].PartitionType)
+		fnPart, custom1, custom2, acctLimit := q.ItemPartitions(ctx, q.primaryQueueShard, itemA)
+		require.Equal(t, int(enums.PartitionTypeDefault), fnPart.PartitionType)
+		require.Equal(t, int(enums.PartitionTypeConcurrencyKey), custom1.PartitionType)
+		require.Equal(t, int(enums.PartitionTypeConcurrencyKey), custom2.PartitionType)
 
 		require.Equal(t, consts.DefaultConcurrencyLimit, acctLimit)
 
@@ -2294,7 +2289,7 @@ func TestQueueDequeue(t *testing.T) {
 
 		// Note: Originally, this test used the concurrency key queue for testing Dequeue(),
 		// but this was changed to the default partition, as we do not enqueue to key queues anymore.
-		partitionToDequeue := parts[2]
+		partitionToDequeue := fnPart
 
 		// Force requeue the partition such that it's pushed forward, pretending there's
 		// no capacity.
@@ -2351,19 +2346,19 @@ func TestQueueDequeue(t *testing.T) {
 			require.Nil(t, err)
 
 			// First 2 partitions will be custom.
-			parts, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
-			require.Equal(t, int(enums.PartitionTypeConcurrencyKey), parts[0].PartitionType)
-			require.Equal(t, int(enums.PartitionTypeConcurrencyKey), parts[1].PartitionType)
-			require.Equal(t, int(enums.PartitionTypeDefault), parts[2].PartitionType)
+			fnPart, custom1, custom2, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
+			require.Equal(t, int(enums.PartitionTypeDefault), fnPart.PartitionType)
+			require.Equal(t, int(enums.PartitionTypeConcurrencyKey), custom1.PartitionType)
+			require.Equal(t, int(enums.PartitionTypeConcurrencyKey), custom2.PartitionType)
 
 			err = q.Dequeue(ctx, q.primaryQueueShard, item)
 			require.Nil(t, err)
 
 			t.Run("The outstanding partition items should be empty", func(t *testing.T) {
-				mem, _ := r.ZMembers(parts[0].zsetKey(q.primaryQueueShard.RedisClient.kg))
+				mem, _ := r.ZMembers(fnPart.zsetKey(q.primaryQueueShard.RedisClient.kg))
 				require.Equal(t, 0, len(mem))
 
-				mem, _ = r.ZMembers(parts[1].zsetKey(q.primaryQueueShard.RedisClient.kg))
+				mem, _ = r.ZMembers(custom1.zsetKey(q.primaryQueueShard.RedisClient.kg))
 				require.NoError(t, err)
 				require.Equal(t, 0, len(mem))
 			})
@@ -2397,9 +2392,9 @@ func TestQueueDequeue(t *testing.T) {
 			require.Nil(t, err)
 
 			// First 2 partitions will be custom.
-			parts, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
-			require.Equal(t, int(enums.PartitionTypeConcurrencyKey), parts[0].PartitionType)
-			require.Equal(t, int(enums.PartitionTypeConcurrencyKey), parts[1].PartitionType)
+			_, custom1, custom2, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
+			require.Equal(t, int(enums.PartitionTypeConcurrencyKey), custom1.PartitionType)
+			require.Equal(t, int(enums.PartitionTypeConcurrencyKey), custom2.PartitionType)
 
 			id, err := q.Lease(ctx, item, 10*time.Second, time.Now(), nil)
 			require.NoError(t, err)
@@ -2415,19 +2410,19 @@ func TestQueueDequeue(t *testing.T) {
 			require.Nil(t, err)
 
 			t.Run("The outstanding partition items should be empty", func(t *testing.T) {
-				mem, _ := r.ZMembers(parts[0].zsetKey(q.primaryQueueShard.RedisClient.kg))
+				mem, _ := r.ZMembers(custom1.zsetKey(q.primaryQueueShard.RedisClient.kg))
 				require.Equal(t, 0, len(mem))
 
-				mem, _ = r.ZMembers(parts[1].zsetKey(q.primaryQueueShard.RedisClient.kg))
+				mem, _ = r.ZMembers(custom2.zsetKey(q.primaryQueueShard.RedisClient.kg))
 				require.NoError(t, err)
 				require.Equal(t, 0, len(mem))
 			})
 
 			t.Run("The concurrenty partition items should be empty", func(t *testing.T) {
-				mem, _ := r.ZMembers(parts[0].concurrencyKey(q.primaryQueueShard.RedisClient.kg))
+				mem, _ := r.ZMembers(custom1.concurrencyKey(q.primaryQueueShard.RedisClient.kg))
 				require.Equal(t, 0, len(mem))
 
-				mem, _ = r.ZMembers(parts[1].concurrencyKey(q.primaryQueueShard.RedisClient.kg))
+				mem, _ = r.ZMembers(custom2.concurrencyKey(q.primaryQueueShard.RedisClient.kg))
 				require.NoError(t, err)
 				require.Equal(t, 0, len(mem))
 			})
@@ -2537,10 +2532,10 @@ func TestQueueDequeue(t *testing.T) {
 			QueueName: &customQueueName,
 		}, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
-		parts, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
+		fnPart, _, _, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
 
 		itemCountMatches := func(num int) {
-			zsetKey := parts[0].zsetKey(q.primaryQueueShard.RedisClient.kg)
+			zsetKey := fnPart.zsetKey(q.primaryQueueShard.RedisClient.kg)
 			items, err := rc.Do(ctx, rc.B().
 				Zrangebyscore().
 				Key(zsetKey).
@@ -2554,7 +2549,7 @@ func TestQueueDequeue(t *testing.T) {
 		concurrencyItemCountMatches := func(num int) {
 			items, err := rc.Do(ctx, rc.B().
 				Zrangebyscore().
-				Key(parts[0].concurrencyKey(q.primaryQueueShard.RedisClient.kg)).
+				Key(fnPart.concurrencyKey(q.primaryQueueShard.RedisClient.kg)).
 				Min("-inf").
 				Max("+inf").
 				Build()).AsStrSlice()
@@ -2575,7 +2570,7 @@ func TestQueueDequeue(t *testing.T) {
 		mem, err := r.ZMembers(q.primaryQueueShard.RedisClient.kg.ConcurrencyIndex())
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(mem))
-		assert.Contains(t, mem[0], parts[0].ID)
+		assert.Contains(t, mem[0], fnPart.ID)
 
 		// Dequeue the item.
 		err = q.Dequeue(ctx, q.primaryQueueShard, item)
@@ -2731,17 +2726,17 @@ func TestQueueRequeue(t *testing.T) {
 		item, err := q.EnqueueItem(ctx, q.primaryQueueShard, item, now, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		parts, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
+		fnPart, custom1, custom2, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
 
 		// Get all scores
-		require.False(t, r.Exists(parts[0].zsetKey(q.primaryQueueShard.RedisClient.kg)))
-		require.False(t, r.Exists(parts[1].zsetKey(q.primaryQueueShard.RedisClient.kg)))
-		itemScoreDefault, _ := r.ZMScore(parts[2].zsetKey(q.primaryQueueShard.RedisClient.kg), item.ID)
-		partScoreDefault, _ := r.ZMScore(q.primaryQueueShard.RedisClient.kg.GlobalPartitionIndex(), parts[2].ID)
-		accountPartScore, _ := r.ZMScore(q.primaryQueueShard.RedisClient.kg.AccountPartitionIndex(acctID), parts[2].ID)
+		require.False(t, r.Exists(custom1.zsetKey(q.primaryQueueShard.RedisClient.kg)))
+		require.False(t, r.Exists(custom2.zsetKey(q.primaryQueueShard.RedisClient.kg)))
+		itemScoreDefault, _ := r.ZMScore(fnPart.zsetKey(q.primaryQueueShard.RedisClient.kg), item.ID)
+		partScoreDefault, _ := r.ZMScore(q.primaryQueueShard.RedisClient.kg.GlobalPartitionIndex(), fnPart.ID)
+		accountPartScore, _ := r.ZMScore(q.primaryQueueShard.RedisClient.kg.AccountPartitionIndex(acctID), fnPart.ID)
 		accountScore, _ := r.ZMScore(q.primaryQueueShard.RedisClient.kg.GlobalAccountIndex(), acctID.String())
 
-		require.NotEmpty(t, itemScoreDefault, "Couldn't find item in '%s':\n%s", parts[0].zsetKey(q.primaryQueueShard.RedisClient.kg), r.Dump())
+		require.NotEmpty(t, itemScoreDefault, "Couldn't find item in '%s':\n%s", custom1.zsetKey(q.primaryQueueShard.RedisClient.kg), r.Dump())
 		require.NotEmpty(t, partScoreDefault)
 		require.Equal(t, partScoreDefault, accountPartScore, "expected account partitions to match global partitions")
 		require.Equal(t, accountPartScore[0], accountScore[0], "expected account score to match earliest account partition")
@@ -2755,9 +2750,9 @@ func TestQueueRequeue(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("It requeues all partitions", func(t *testing.T) {
-			newItemScore, _ := r.ZMScore(parts[2].zsetKey(q.primaryQueueShard.RedisClient.kg), item.ID)
-			newPartScore, _ := r.ZMScore(q.primaryQueueShard.RedisClient.kg.GlobalPartitionIndex(), parts[2].ID)
-			newAccountPartScore, _ := r.ZMScore(q.primaryQueueShard.RedisClient.kg.AccountPartitionIndex(acctID), parts[2].ID)
+			newItemScore, _ := r.ZMScore(fnPart.zsetKey(q.primaryQueueShard.RedisClient.kg), item.ID)
+			newPartScore, _ := r.ZMScore(q.primaryQueueShard.RedisClient.kg.GlobalPartitionIndex(), fnPart.ID)
+			newAccountPartScore, _ := r.ZMScore(q.primaryQueueShard.RedisClient.kg.AccountPartitionIndex(acctID), fnPart.ID)
 			newAccountScore, _ := r.ZMScore(q.primaryQueueShard.RedisClient.kg.GlobalAccountIndex(), acctID.String())
 
 			require.NotEqual(t, itemScoreDefault, newItemScore)
@@ -3465,14 +3460,14 @@ func TestQueuePartitionRequeue(t *testing.T) {
 				},
 			}
 
-			parts, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
+			fnPart, custom1, _, _ := q.ItemPartitions(ctx, q.primaryQueueShard, item)
 
-			originalPart := parts[0]
+			originalPart := custom1
 			require.Equal(t, "{queue}:concurrency:custom:a:4d59bf95-28b6-5423-b1a8-604046826e33:3cwxlkg53rr2c", originalPart.concurrencyKey(q.primaryQueueShard.RedisClient.kg))
 
 			// Originally, this test was designed to run on concurrency key queues. Since we don't enqueue these anymore,
 			// p has been changed to the default function partition.
-			p := parts[1]
+			p := fnPart
 
 			item, err := q.EnqueueItem(ctx, q.primaryQueueShard, item, now, osqueue.EnqueueOpts{})
 			require.NoError(t, err)


### PR DESCRIPTION
## Description

This will make it easier to build key queues.

The core of this update is refactoring ItemPartitions to always return the default partition first. This makes it infinitely easier to write Lua scripts because we don't have to repeat the same operation 3 times and check whether the partition type is default. The default partition is always returned anyway, so it's safe to assume the first returned queue partition is for a function or system queue partition.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
