### PR TITLE
Fix Redis failing to load with `inngest start` if Gateway connections existed on close

### DIFF
--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -596,9 +596,13 @@ func (d *devserver) importRedisSnapshot(ctx context.Context) (imported bool, err
 
 		case "set":
 			vals := data.Value.([]interface{})
-			strValues := make([]string, len(vals))
-			for i, v := range vals {
-				strValues[i] = v.(string)
+			strValues := []string{}
+			for _, v := range vals {
+				if strVal, ok := v.(string); ok {
+					strValues = append(strValues, strVal)
+				} else {
+					l.Warn().Interface("value", v).Msgf("skipping non-string value in set for key %s", key)
+				}
 			}
 			saddCmd := rc.B().Sadd().Key(key).Member(strValues...).Build()
 			err = rc.Do(ctx, saddCmd).Error()

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -595,8 +595,11 @@ func (d *devserver) importRedisSnapshot(ctx context.Context) (imported bool, err
 			}
 
 		case "set":
-			strValues := data.Value.([]string)
-			// err = rc.SAdd(ctx, key, strValues...).Err()
+			vals := data.Value.([]interface{})
+			strValues := make([]string, len(vals))
+			for i, v := range vals {
+				strValues[i] = v.(string)
+			}
 			saddCmd := rc.B().Sadd().Key(key).Member(strValues...).Build()
 			err = rc.Do(ctx, saddCmd).Error()
 			if err != nil {


### PR DESCRIPTION
## Description

Fixes an issue where `inngest start` fails to load a Redis dump if it contains a Set.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
