### PR TITLE
Add max attempts for debounce queue item

### DIFF
--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -7,14 +7,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/inngest/inngest/pkg/enums"
-	"github.com/inngest/inngest/pkg/telemetry/metrics"
-	"github.com/jonboulle/clockwork"
 	"io/fs"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/telemetry/metrics"
+	"github.com/jonboulle/clockwork"
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/event"
@@ -643,6 +645,8 @@ func (d debouncer) debounce(ctx context.Context, di DebounceItem, fn inngest.Fun
 }
 
 func (d debouncer) queueItem(ctx context.Context, di DebounceItem, debounceID ulid.ULID) queue.Item {
+	maxAttempts := consts.MaxRetries + 1
+
 	jobID := debounceID.String()
 	payload := di.QueuePayload()
 	payload.DebounceID = debounceID
@@ -655,8 +659,9 @@ func (d debouncer) queueItem(ctx context.Context, di DebounceItem, debounceID ul
 			AppID:       di.AppID,
 			WorkflowID:  di.FunctionID,
 		},
-		Kind:    queue.KindDebounce,
-		Payload: payload,
+		Kind:        queue.KindDebounce,
+		Payload:     payload,
+		MaxAttempts: &maxAttempts,
 	}
 }
 


### PR DESCRIPTION
## Description

Explicitly set max retry attempt for debounce queue item to 21 times, so it will attempt for longer amount of time.
On system failure, a default retry maximum of 4 times is likely way to little.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
