### PR TITLE
Allow callers to distinguish CEL validation errors from other errors

### DIFF
--- a/pkg/expressions/error.go
+++ b/pkg/expressions/error.go
@@ -1,0 +1,71 @@
+package expressions
+
+import (
+	"fmt"
+	"github.com/hashicorp/go-multierror"
+)
+
+var (
+	ErrCompileFailed    = fmt.Errorf("expression compilation failed")
+	ErrValidationFailed = fmt.Errorf("validation failed")
+)
+
+type CompileError struct {
+	err error
+	msg string
+}
+
+func NewCompileError(err error) *CompileError {
+	return &CompileError{
+		err: multierror.Append(ErrCompileFailed, err),
+		msg: err.Error(),
+	}
+}
+
+func (c *CompileError) Error() string {
+	return fmt.Sprintf("error compiling expression: %s", c.msg)
+}
+
+func (c *CompileError) Unwrap() error {
+	return c.err
+}
+
+func (c *CompileError) Message() string {
+	return c.msg
+}
+
+func (c *CompileError) Is(tgt error) bool {
+	_, ok := tgt.(*CompileError)
+	return ok
+}
+
+type validationError struct {
+	err error
+	msg string
+}
+
+func newValidationErr(err error) error {
+	if err == nil {
+		return &validationError{
+			err: ErrValidationFailed,
+			msg: ErrValidationFailed.Error(),
+		}
+	} else {
+		return &validationError{
+			err: multierror.Append(ErrValidationFailed, err),
+			msg: err.Error(),
+		}
+	}
+}
+
+func (v *validationError) Error() string {
+	return fmt.Sprintf("validation failed: %s", v.msg)
+}
+
+func (v *validationError) Unwrap() error {
+	return v.err
+}
+
+func (v *validationError) Message() string {
+	return v.msg
+}

--- a/pkg/expressions/expressions.go
+++ b/pkg/expressions/expressions.go
@@ -15,7 +15,6 @@ package expressions
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/google/cel-go/cel"
@@ -318,29 +317,4 @@ func (e *expressionEvaluator) parseAttributes(ctx context.Context) error {
 	}
 	e.attrs = attrs
 	return nil
-}
-
-type CompileError struct {
-	Err error
-}
-
-func NewCompileError(err error) *CompileError {
-	return &CompileError{Err: err}
-}
-
-func (c *CompileError) Error() string {
-	return fmt.Sprintf("error compiling expression: %s", c.Err)
-}
-
-func (c *CompileError) Unwrap() error {
-	return c.Err
-}
-
-func (c *CompileError) Message() string {
-	return c.Err.Error()
-}
-
-func (c *CompileError) Is(tgt error) bool {
-	_, ok := tgt.(*CompileError)
-	return ok
 }

--- a/pkg/expressions/validation.go
+++ b/pkg/expressions/validation.go
@@ -47,20 +47,13 @@ func DefaultRestrictiveValidationPolicy() *ValidationPolicy {
 	}
 }
 
-func validationErr(err error) error {
-	if err == nil {
-		return fmt.Errorf("validation failed")
-	}
-	return fmt.Errorf("validation failed: %w", err)
-}
-
 // Validate calls parse and check on an ASTs using NON CACHING parsing.  This MUST be non-caching
 // as calling Check on an AST is not thread safe.
 func Validate(_ context.Context, policy *ValidationPolicy, expression string) error {
 	// Compile the expression as new.
 	env, err := exprenv.Env()
 	if err != nil {
-		return validationErr(err)
+		return err
 	}
 
 	ast, issues := env.Compile(expression)
@@ -75,7 +68,7 @@ func Validate(_ context.Context, policy *ValidationPolicy, expression string) er
 
 	if policy != nil {
 		if err = validateAST(policy, expr.GetExpr()); err != nil {
-			return validationErr(err)
+			return newValidationErr(err)
 		}
 	}
 

--- a/pkg/expressions/validation_test.go
+++ b/pkg/expressions/validation_test.go
@@ -2,6 +2,7 @@ package expressions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 )
@@ -23,11 +24,6 @@ func Test_Validation(t *testing.T) {
 			expr:        "event.data.foo == 1",
 			policy:      DefaultRestrictiveValidationPolicy(),
 			expectValid: true,
-		},
-		{
-			expr:        "event.data.x is not an integer less than 2",
-			policy:      nil,
-			expectValid: false,
 		},
 		{
 			expr:        "event.name.endsWith(\"foo\")",
@@ -315,6 +311,8 @@ func Test_Validation(t *testing.T) {
 				t.Errorf("expected to be valid; got: %v\nexpr: %s", err, tt.expr)
 			} else if err == nil && !tt.expectValid {
 				t.Errorf("expected to be invalid; got: validation passed\nexpr: %s", tt.expr)
+			} else if err != nil && !errors.Is(err, ErrValidationFailed) {
+				t.Errorf("expected validation error; got: %v\nexpr: %s", err, tt.expr)
 			} else if err != nil {
 				t.Logf("[info] validation error was: %v", err)
 			}


### PR DESCRIPTION
## Description

This PR allows callers to distinguish CEL validation failures from compilation or other errors, allowing them to e.g. warn instead of fail on CEL expressions that violate policy.

## Linear

- refs: https://linear.app/inngest/issue/INN-4732/fail-validatingcompiling-waitforevent-expressions-with-cel-macros

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.
