### PR TITLE
executor: log a warning if waitForEvent.If CEL expression fails validation

### DIFF
--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -376,7 +376,7 @@ func TestWaitInvalidExpressionSyntaxError(t *testing.T) {
 	r.NoError(err)
 	run := c.WaitForRunStatus(ctx, t, "FAILED", &runID)
 	assert.Equal(t,
-		`{"error":{"error":"InvalidExpression: Wait for event expression is invalid","name":"InvalidExpression","message":"Wait for event expression is invalid","stack":"error compiling expression: ERROR: \u003cinput\u003e:1:21: Syntax error: token recognition error at: '= '\n | event.data.userId === async.data.userId\n | ....................^"}}`,
+		`{"error":{"error":"InvalidExpression: Wait for event If expression failed to compile","name":"InvalidExpression","message":"Wait for event If expression failed to compile","stack":"error compiling expression: ERROR: \u003cinput\u003e:1:21: Syntax error: token recognition error at: '= '\n | event.data.userId === async.data.userId\n | ....................^"}}`,
 		run.Output,
 	)
 }


### PR DESCRIPTION
## Description

Rather than failing to process `waitForEvent` ops with forbidden CEL expressions, log a warning.

## Linear

- refs: https://linear.app/inngest/issue/INN-4732/fail-validatingcompiling-waitforevent-expressions-with-cel-macros
    - does not close; upstreaming into cloud is the last step

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.
