### PR TITLE
Allow timeout option for critical execution to force cancel and not run indefinitely

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -916,7 +916,7 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			return resp, handleErr
 		}
 		return resp, err
-	})
+	}, util.WithMaxDuration(consts.MaxFunctionTimeout))
 }
 
 func (e *executor) HandleResponse(ctx context.Context, i *runInstance) error {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -916,7 +916,7 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			return resp, handleErr
 		}
 		return resp, err
-	}, util.WithMaxDuration(consts.MaxFunctionTimeout))
+	}, util.WithTimeout(consts.MaxFunctionTimeout))
 }
 
 func (e *executor) HandleResponse(ctx context.Context, i *runInstance) error {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1839,7 +1839,7 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 			}
 		}
 		return nil
-	}, 20*time.Second)
+	}, util.WithBoundaries(20*time.Second))
 	if err != nil {
 		return err
 	}

--- a/pkg/util/critctx.go
+++ b/pkg/util/critctx.go
@@ -14,7 +14,7 @@ var (
 
 type critctx struct {
 	boundary time.Duration
-	maxDur   time.Duration
+	timeout  time.Duration
 }
 
 type CritOpt func(c *critctx)
@@ -25,9 +25,9 @@ func WithBoundaries(b time.Duration) CritOpt {
 	}
 }
 
-func WithMaxDuration(dur time.Duration) CritOpt {
+func WithTimeout(dur time.Duration) CritOpt {
 	return func(c *critctx) {
-		c.maxDur = dur
+		c.timeout = dur
 	}
 }
 
@@ -72,9 +72,9 @@ func CritT[T any](ctx context.Context, name string, f func(ctx context.Context) 
 		logger.StdlibLogger(ctx).Warn("context canceled before entering crit", "name", name)
 	}
 
-	if cr.maxDur > 0 {
+	if cr.timeout > 0 {
 		var cancel func()
-		ctx, cancel = context.WithTimeout(ctx, cr.maxDur)
+		ctx, cancel = context.WithTimeout(ctx, cr.timeout)
 		defer cancel()
 
 		doneCh := make(chan T)

--- a/pkg/util/critctx.go
+++ b/pkg/util/critctx.go
@@ -8,6 +8,10 @@ import (
 	"github.com/inngest/inngest/pkg/logger"
 )
 
+var (
+	ErrCritContextDeadlineExceeded = fmt.Errorf("function cancelled due to execution duration exceeded specified time frame")
+)
+
 type critctx struct {
 	boundary time.Duration
 	maxDur   time.Duration
@@ -89,7 +93,7 @@ func CritT[T any](ctx context.Context, name string, f func(ctx context.Context) 
 		case resp = <-doneCh:
 		case err = <-errCh:
 		case <-ctx.Done():
-			err = ctx.Err()
+			err = ErrCritContextDeadlineExceeded
 		}
 
 		return

--- a/pkg/util/critctx.go
+++ b/pkg/util/critctx.go
@@ -8,21 +8,21 @@ import (
 	"github.com/inngest/inngest/pkg/logger"
 )
 
-type crit struct {
-	boundaries []time.Duration
-	maxDur     time.Duration
+type critctx struct {
+	boundary time.Duration
+	maxDur   time.Duration
 }
 
-type CritOpt func(c *crit)
+type CritOpt func(c *critctx)
 
-func WithBoundaries(b ...time.Duration) CritOpt {
-	return func(c *crit) {
-		c.boundaries = b
+func WithBoundaries(b time.Duration) CritOpt {
+	return func(c *critctx) {
+		c.boundary = b
 	}
 }
 
 func WithMaxDuration(dur time.Duration) CritOpt {
-	return func(c *crit) {
+	return func(c *critctx) {
 		c.maxDur = dur
 	}
 }
@@ -36,41 +36,37 @@ func Crit(ctx context.Context, name string, f func(ctx context.Context) error, o
 // for checking context deadlines;  if the parent ctx has a deadline shorter than the boundary we exit
 // immediately with an error.
 func CritT[T any](ctx context.Context, name string, f func(ctx context.Context) (T, error), opts ...CritOpt) (resp T, err error) {
-	cr := crit{
-		boundaries: []time.Duration{},
-	}
+	cr := critctx{}
 
 	for _, apply := range opts {
 		apply(&cr)
 	}
+
+	pre := time.Now()
 
 	// If withinBounds is set, we have some time period in which we must complete the Crit
 	// section.
 	//
 	// Check the parent context to see if there's a deadline, and if the deadline < withinBounds
 	// don't even bother.  The crit section must exist within some retryable process.
-	if len(cr.boundaries) == 1 {
-		if dl, ok := ctx.Deadline(); ok && time.Until(dl) < cr.boundaries[0] {
+	if cr.boundary > 0 {
+		if dl, ok := ctx.Deadline(); ok && time.Until(dl) < cr.boundary {
 			return resp, fmt.Errorf("context deadline shorter than critical bounds: %s", name)
 		}
+
+		// XXX: Instrument critical section durations and error responses via the names.
+		defer func() {
+			actual := time.Since(pre)
+			if actual > cr.boundary {
+				// This took longer than the predefined boundary, so log a fat warning.
+				logger.StdlibLogger(ctx).Warn("critical section took longer than boundary", "name", name, "duration_ms", actual.Milliseconds())
+			}
+		}()
 	}
 
 	if ctx.Err() == context.Canceled {
 		logger.StdlibLogger(ctx).Warn("context canceled before entering crit", "name", name)
 	}
 
-	pre := time.Now()
-	resp, err = f(context.WithoutCancel(ctx))
-
-	// XXX: Instrument critical section durations and error responses via the names.
-
-	if len(cr.boundaries) == 1 {
-		actual := time.Since(pre)
-		if actual > cr.boundaries[0] {
-			// This took longer than the predefined boundaries, so log a fat warning.
-			logger.StdlibLogger(ctx).Warn("critical section took longer than boundaries", "name", name, "duration_ms", actual.Milliseconds())
-		}
-	}
-
-	return resp, err
+	return f(context.WithoutCancel(ctx))
 }

--- a/pkg/util/critctx.go
+++ b/pkg/util/critctx.go
@@ -68,5 +68,13 @@ func CritT[T any](ctx context.Context, name string, f func(ctx context.Context) 
 		logger.StdlibLogger(ctx).Warn("context canceled before entering crit", "name", name)
 	}
 
-	return f(context.WithoutCancel(ctx))
+	if cr.maxDur > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, cr.maxDur)
+		defer cancel()
+	} else {
+		ctx = context.WithoutCancel(ctx)
+	}
+
+	return f(ctx)
 }

--- a/pkg/util/critctx.go
+++ b/pkg/util/critctx.go
@@ -8,22 +8,49 @@ import (
 	"github.com/inngest/inngest/pkg/logger"
 )
 
-func Crit(ctx context.Context, name string, f func(ctx context.Context) error, withinBounds ...time.Duration) error {
-	_, err := CritT(ctx, name, func(ctx context.Context) (any, error) { return nil, f(ctx) }, withinBounds...)
+type crit struct {
+	boundaries []time.Duration
+	maxDur     time.Duration
+}
+
+type CritOpt func(c *crit)
+
+func WithBoundaries(b ...time.Duration) CritOpt {
+	return func(c *crit) {
+		c.boundaries = b
+	}
+}
+
+func WithMaxDuration(dur time.Duration) CritOpt {
+	return func(c *crit) {
+		c.maxDur = dur
+	}
+}
+
+func Crit(ctx context.Context, name string, f func(ctx context.Context) error, opts ...CritOpt) error {
+	_, err := CritT(ctx, name, func(ctx context.Context) (any, error) { return nil, f(ctx) }, opts...)
 	return err
 }
 
 // Crit is a util to wrap a lambda with a non-cancellable context.  It allows an optional time boundary
 // for checking context deadlines;  if the parent ctx has a deadline shorter than the boundary we exit
 // immediately with an error.
-func CritT[T any](ctx context.Context, name string, f func(ctx context.Context) (T, error), withinBounds ...time.Duration) (resp T, err error) {
+func CritT[T any](ctx context.Context, name string, f func(ctx context.Context) (T, error), opts ...CritOpt) (resp T, err error) {
+	cr := crit{
+		boundaries: []time.Duration{},
+	}
+
+	for _, apply := range opts {
+		apply(&cr)
+	}
+
 	// If withinBounds is set, we have some time period in which we must complete the Crit
 	// section.
 	//
 	// Check the parent context to see if there's a deadline, and if the deadline < withinBounds
 	// don't even bother.  The crit section must exist within some retryable process.
-	if len(withinBounds) == 1 {
-		if dl, ok := ctx.Deadline(); ok && time.Until(dl) < withinBounds[0] {
+	if len(cr.boundaries) == 1 {
+		if dl, ok := ctx.Deadline(); ok && time.Until(dl) < cr.boundaries[0] {
 			return resp, fmt.Errorf("context deadline shorter than critical bounds: %s", name)
 		}
 	}
@@ -37,9 +64,9 @@ func CritT[T any](ctx context.Context, name string, f func(ctx context.Context) 
 
 	// XXX: Instrument critical section durations and error responses via the names.
 
-	if len(withinBounds) == 1 {
+	if len(cr.boundaries) == 1 {
 		actual := time.Since(pre)
-		if actual > withinBounds[0] {
+		if actual > cr.boundaries[0] {
 			// This took longer than the predefined boundaries, so log a fat warning.
 			logger.StdlibLogger(ctx).Warn("critical section took longer than boundaries", "name", name, "duration_ms", actual.Milliseconds())
 		}

--- a/pkg/util/critctx_test.go
+++ b/pkg/util/critctx_test.go
@@ -112,7 +112,7 @@ func TestCrit(t *testing.T) {
 			<-time.After(1 * time.Second)
 			called = true
 			return nil
-		}, WithMaxDuration(2*time.Second))
+		}, WithTimeout(2*time.Second))
 
 		require.True(t, called)
 		require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestCrit(t *testing.T) {
 			<-time.After(1 * time.Second)
 			called = true
 			return nil
-		}, WithMaxDuration(100*time.Millisecond))
+		}, WithTimeout(100*time.Millisecond))
 
 		require.False(t, called)
 		require.Equal(t, ErrCritContextDeadlineExceeded, err)

--- a/pkg/util/critctx_test.go
+++ b/pkg/util/critctx_test.go
@@ -104,16 +104,26 @@ func TestCrit(t *testing.T) {
 		require.Contains(t, buf.String(), "critical section took longer than boundary")
 	})
 
-	t.Run("Returns context deadline error if execution exceeds expected duration", func(t *testing.T) {
+	t.Run("It should get the proper result if within specified time frame", func(t *testing.T) {
 		ctx := context.Background()
 		var called bool
 
 		err := Crit(ctx, "long", func(ctx context.Context) error {
 			<-time.After(1 * time.Second)
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
+			called = true
+			return nil
+		}, WithMaxDuration(2*time.Second))
 
+		require.True(t, called)
+		require.NoError(t, err)
+	})
+
+	t.Run("It should return context deadline error if execution exceeds expected duration", func(t *testing.T) {
+		ctx := context.Background()
+		var called bool
+
+		err := Crit(ctx, "long", func(ctx context.Context) error {
+			<-time.After(1 * time.Second)
 			called = true
 			return nil
 		}, WithMaxDuration(100*time.Millisecond))

--- a/pkg/util/critctx_test.go
+++ b/pkg/util/critctx_test.go
@@ -129,6 +129,6 @@ func TestCrit(t *testing.T) {
 		}, WithMaxDuration(100*time.Millisecond))
 
 		require.False(t, called)
-		require.Equal(t, context.DeadlineExceeded, err)
+		require.Equal(t, ErrCritContextDeadlineExceeded, err)
 	})
 }

--- a/pkg/util/critctx_test.go
+++ b/pkg/util/critctx_test.go
@@ -73,7 +73,7 @@ func TestCrit(t *testing.T) {
 			}
 			called = true
 			return nil
-		}, time.Second)
+		}, WithBoundaries(time.Second))
 
 		// Not called:  deadline too short.
 		require.False(t, called)
@@ -96,7 +96,7 @@ func TestCrit(t *testing.T) {
 			}
 			called = true
 			return nil
-		}, time.Millisecond)
+		}, WithBoundaries(time.Millisecond))
 
 		require.True(t, called)
 		require.Nil(t, err)


### PR DESCRIPTION
## Description

Update `CritT` to accept a timeout option so it doesn't end up running indefinitely unintentionally.

And update execution to enforce the max function timeout duration using it.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
