### PR TITLE
Fix duplicate waitForEvent steps in UI

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2703,10 +2703,7 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, i *runInstan
 		return fmt.Errorf("unable to parse wait for event expires: %w", err)
 	}
 
-	pauseID, err := inngest.DeterministicUUIDV7(i.md.ID.RunID.String() + gen.ID)
-	if err != nil {
-		return fmt.Errorf("could not generate deterministic pause ID: %w", err)
-	}
+	pauseID := inngest.DeterministicSha1UUID(i.md.ID.RunID.String() + gen.ID)
 
 	expr := opts.If
 	if expr != nil && strings.Contains(*expr, "event.") {


### PR DESCRIPTION
# Description
Fix duplicate `waitForEvent` steps appearing the UI. This only seems to happen with parallel steps when "optimized parallelism" is disabled.

We suspect it's because parallelism messes up the deterministic ID.

# Repro

```ts
inngest.createFunction(
  { id: "fn-1" },
  { event: "event-1" },
  async ({ step }) => {
    await Promise.all([
      step.waitForEvent("a", { event: "foo", timeout: "1m" }),
      step.waitForEvent("b", { event: "bar", timeout: "1m" }),
    ]);
  }
);
```

```sh
curl localhost:8288/e/foo -d '{"name": "event-1"}' \
 && sleep 1 \
 && curl localhost:8288/e/foo -d '{"name": "foo"}' \
 && sleep 1 \
 && curl localhost:8288/e/foo -d '{"name": "bar"}'
```

Results in a duplicate `b` step in the UI:
<img width="788" alt="image" src="https://github.com/user-attachments/assets/e020ce62-ee16-4381-aeee-0e7b5f2384b9" />

