### PR TITLE
Sever parent context timeout in CritT

### DIFF
--- a/pkg/util/critctx.go
+++ b/pkg/util/critctx.go
@@ -74,7 +74,9 @@ func CritT[T any](ctx context.Context, name string, f func(ctx context.Context) 
 
 	if cr.timeout > 0 {
 		var cancel func()
-		ctx, cancel = context.WithTimeout(ctx, cr.timeout)
+		ctx, cancel = context.WithTimeout(
+			context.WithoutCancel(ctx), cr.timeout,
+		)
 		defer cancel()
 
 		doneCh := make(chan T)


### PR DESCRIPTION
## Description
Sever the parent context timeout in `CritT`.

## Motivation
This may fix the following error we occasionally see:
```
Error performing request to SDK URL: rpc error: code = DeadlineExceeded desc = context deadline exceeded
```