### PR TITLE
restore contents from dropped userland trace commits

### DIFF
--- a/pkg/api/apiv1/traces.go
+++ b/pkg/api/apiv1/traces.go
@@ -139,15 +139,6 @@ func (a router) convertOTLPAndSend(auth apiv1auth.V1Auth, req *collecttrace.Expo
 					continue
 				}
 
-				_, err = getInngestRunID(s)
-				if err != nil {
-					// If we can't find the run ID, we can't create a span.
-					// So let's skip it.
-					logger.StdlibLogger(ctx).Error("error getting runID on span ingestion, skipping", "error", err)
-					rejectedSpans++
-					continue
-				}
-
 				opts := []run.SpanOpt{
 					run.WithTraceID(tp.TraceID),
 					run.WithSpanID(trace.SpanID(s.SpanId)),
@@ -258,18 +249,6 @@ func getInngestTraceparent(s *tracev1.Span) (*TraceParent, error) {
 	}
 
 	return nil, fmt.Errorf("no traceparent attribute found")
-}
-
-func getInngestRunID(s *tracev1.Span) (string, error) {
-	for _, kv := range s.Attributes {
-		if kv.Key == consts.OtelAttrSDKRunID {
-			// This is the traceparent attribute, so we can use it to get the
-			// trace ID and span ID
-			return kv.GetValue().GetStringValue(), nil
-		}
-	}
-
-	return "", fmt.Errorf("no run ID attribute found")
 }
 
 func convertAttributes(attrs []*commonv1.KeyValue) []attribute.KeyValue {

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -28,8 +27,6 @@ import (
 	itrace "github.com/inngest/inngest/pkg/telemetry/trace"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/oklog/ulid/v2"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/trace"
 )
 
 var (
@@ -100,54 +97,26 @@ func (e executor) Execute(ctx context.Context, sl sv2.StateLoader, s sv2.Metadat
 		return nil, err
 	}
 
-	headers := map[string]string{}
-
-	span := trace.SpanFromContext(ctx)
-	sc := span.SpanContext()
-
-	// Add some items to trace state to ensure that the SDK can parrot them
-	// back to us for userland spans.
-	//
-	// After a tracing refactor, this will no longer be required to send to
-	// SDKs because they will not need to parrot back any data.
-	ts, err := sc.TraceState().Insert("inngest@app", s.ID.Tenant.AppID.String())
-	if err != nil {
-		// Not a failure; only userland spans suffer, so log and ignore
-		log.From(ctx).Warn().
+	headers := make(map[string]string)
+	if spanID, err := item.SpanID(); err != nil {
+		log.From(ctx).
+			Error().
 			Str("run_id", s.ID.RunID.String()).
-			Msg("failed to add app ID to trace state")
-	}
-
-	ts, err = ts.Insert("inngest@fn", s.ID.FunctionID.String())
-	if err != nil {
-		// Not a failure; only userland spans suffer, so log and ignore
-		log.From(ctx).Warn().
-			Str("run_id", s.ID.RunID.String()).
-			Msg("failed to add function ID to trace state")
-	}
-
-	sc = trace.NewSpanContext(trace.SpanContextConfig{
-		TraceID:    sc.TraceID(),
-		SpanID:     sc.SpanID(),
-		TraceFlags: sc.TraceFlags(),
-		TraceState: ts,
-		Remote:     sc.IsRemote(),
-	})
-	ctx = trace.ContextWithSpanContext(ctx, sc)
-	itrace.UserTracer().Propagator().Inject(ctx, propagation.MapCarrier(headers))
-	if headers["traceparent"] != "" {
-		// The span ID will be incorrect here as lifecycles can not affec the
-		// ctx. To patch, we manually set the span ID here to what we know it
-		// should be based on the item
-		parts := strings.Split(headers["traceparent"], "-")
-		if len(parts) == 4 {
-			spanID, err := item.SpanID()
-			if err != nil {
-				return nil, fmt.Errorf("error parsing span ID: %w", err)
-			}
-
-			parts[2] = spanID.String()
-			headers["traceparent"] = strings.Join(parts, "-")
+			Err(err).
+			Msg("error retrieving span ID")
+	} else {
+		headers, err = itrace.HeadersFromTraceState(
+			ctx,
+			spanID.String(),
+			s.ID.Tenant.AppID.String(),
+			s.ID.FunctionID.String(),
+		)
+		if err != nil {
+			log.From(ctx).
+				Warn().
+				Str("run_id", s.ID.RunID.String()).
+				Err(err).
+				Msg("failed to add userland data to trace state")
 		}
 	}
 


### PR DESCRIPTION
## Description

Last week we merged the userland traces and then we reverted it because of some dependency issues with the monorepo. When we re-introduced the changes, 6 commits were dropped. This is the contents of those commits, manually reconstructed since they can't simply be cherry picked and re-PR'ed because they are already on main and reverted. 

## Motivation


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
