### PR TITLE
Function run scheduling updates

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -600,7 +600,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	st, err := e.smv2.Create(ctx, newState)
 	switch err {
 	case nil, state.ErrIdentifierExists:
-		// no-op, continue
+		// no-op: this is safe, continue
 	default:
 		return nil, fmt.Errorf("error creating run state: %w", err)
 	}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -660,7 +660,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 			}
 
 			pause := state.Pause{
-				WorkspaceID:       req.WorkspaceID,
+				WorkspaceID:       st.Identifier().WorkspaceID,
 				Identifier:        sv2.NewPauseIdentifier(metadata.ID),
 				ID:                pauseID,
 				Expires:           state.Time(expires),
@@ -698,7 +698,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	item := queue.Item{
 		JobID:                 &queueKey,
 		GroupID:               uuid.New().String(),
-		WorkspaceID:           req.WorkspaceID,
+		WorkspaceID:           st.Identifier().WorkspaceID,
 		Kind:                  queue.KindStart,
 		Identifier:            st.Identifier(),
 		CustomConcurrencyKeys: metadata.Config.CustomConcurrencyKeys,

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -606,6 +606,10 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	}
 	// override the runID from the state if it doesn't match.
 	// this can happen on scheduling retries due to errors like networking, or abrupt failures
+	//
+	// TODO: update the code from here on to reference the `state` returned instead of using
+	// previous values to avoid weird mismatch issues.
+	// right now, the only mismatch should just be the runID
 	if metadata.ID.RunID != st.RunID() {
 		metadata.ID.RunID = st.RunID()
 	}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -617,9 +617,6 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	//
 	// Create cancellation pauses immediately, only if this is a non-batch event.
 	//
-	// NOTE: on scheduling retries, this will result in duplicated pauses for cancellation.
-	// This won't be an issue since pause consumption is idempotent
-	//
 	if req.BatchID == nil {
 		for _, c := range req.Function.Cancel {
 			expires := time.Now().Add(consts.CancelTimeout)

--- a/pkg/execution/state/redis_state/lua/new.lua
+++ b/pkg/execution/state/redis_state/lua/new.lua
@@ -46,7 +46,11 @@ if stepInputs ~= nil and #stepInputs > 0 then
 end
 
 -- Save events
-redis.call("SETNX", eventsKey, events)
 redis.call("HINCRBY", metadataKey, "event_size", #events)
+
+-- Signal that the state is already created
+if redis.call("SETNX", eventsKey, events) == 1 then
+  return 1
+end
 
 return 0

--- a/pkg/execution/state/redis_state/lua/new.lua
+++ b/pkg/execution/state/redis_state/lua/new.lua
@@ -17,6 +17,11 @@ local metadata = ARGV[2]
 local steps = ARGV[3]
 local stepInputs = ARGV[4]
 
+-- state is already created
+if redis.call("EXISTS", eventsKey) == 1 then
+  return 1
+end
+
 -- Save all metadata
 local metadataJson = cjson.decode(metadata)
 for k, v in pairs(metadataJson) do
@@ -46,11 +51,7 @@ if stepInputs ~= nil and #stepInputs > 0 then
 end
 
 -- Save events
+redis.call("SETNX", eventsKey, events)
 redis.call("HINCRBY", metadataKey, "event_size", #events)
-
--- Signal that the state is already created
-if redis.call("SETNX", eventsKey, events) == 1 then
-  return 1
-end
 
 return 0

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -247,20 +247,20 @@ func (m shardedMgr) New(ctx context.Context, input state.Input) (state.State, er
 	{
 		st, err := m.idempotencyCheck(ctx, client, fnRunState.kg.Idempotency(ctx, isSharded, input.Identifier), input.Identifier)
 		switch err {
+		case nil: // no-op
 		// NOTE:
 		// This will happen as part of the transition of storing empty strings for idempotency
 		// key to ULID values.
 		// So if this error is returned, we should just continue with creating a new state, since
 		// it could mean that the state is not actually created.
-		case state.ErrInvalidIdentifier:
-			// no-op, continue
+		case state.ErrInvalidIdentifier: // no-op
 		default:
 			return nil, err
 		}
 
 		// If a state already exists with the idempotency key, then we'll just return the state here.
 		if st != nil {
-			return st, err
+			return st, nil
 		}
 	}
 

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -261,7 +261,7 @@ func (m shardedMgr) New(ctx context.Context, input state.Input) (state.State, er
 
 		// If a state already exists with the idempotency key, then we'll just return the state here.
 		if st != nil {
-			return st, nil
+			return st, state.ErrIdentifierExists
 		}
 	}
 

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -245,7 +245,8 @@ func (m shardedMgr) New(ctx context.Context, input state.Input) (state.State, er
 	// In future/other metadata stores this is (or will be) transactional.
 	//
 	{
-		st, err := m.idempotencyCheck(ctx, client, fnRunState.kg.Idempotency(ctx, isSharded, input.Identifier), input.Identifier)
+		key := fnRunState.kg.Idempotency(ctx, isSharded, input.Identifier)
+		st, err := m.idempotencyCheck(ctx, client, key, input.Identifier)
 		switch err {
 		case nil: // no-op
 		// NOTE:

--- a/pkg/execution/state/redis_state/util_test.go
+++ b/pkg/execution/state/redis_state/util_test.go
@@ -1,0 +1,19 @@
+package redis_state
+
+import (
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/rueidis"
+	"github.com/stretchr/testify/require"
+)
+
+func initRedis(t *testing.T) (*miniredis.Miniredis, rueidis.Client) {
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	return r, rc
+}

--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -35,7 +35,7 @@ type v2 struct {
 }
 
 // Create creates new state in the store for the given run ID.
-func (v v2) Create(ctx context.Context, s state.CreateState) error {
+func (v v2) Create(ctx context.Context, s state.CreateState) (statev1.State, error) {
 	batchData := make([]map[string]any, len(s.Events))
 	for n, evt := range s.Events {
 		data := map[string]any{}
@@ -45,7 +45,7 @@ func (v v2) Create(ctx context.Context, s state.CreateState) error {
 		batchData[n] = data
 
 	}
-	_, err := v.mgr.New(ctx, statev1.Input{
+	return v.mgr.New(ctx, statev1.Input{
 		Identifier: statev1.Identifier{
 			RunID:                 s.Metadata.ID.RunID,
 			WorkflowID:            s.Metadata.ID.FunctionID,
@@ -68,7 +68,6 @@ func (v v2) Create(ctx context.Context, s state.CreateState) error {
 		Steps:          s.Steps,
 		StepInputs:     s.StepInputs,
 	})
-	return err
 }
 
 // Delete deletes state, metadata, and - when pauses are included - associated pauses

--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -40,7 +40,7 @@ func (v v2) Create(ctx context.Context, s state.CreateState) (statev1.State, err
 	for n, evt := range s.Events {
 		data := map[string]any{}
 		if err := json.Unmarshal(evt, &data); err != nil {
-			return err
+			return nil, err
 		}
 		batchData[n] = data
 

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -33,6 +33,7 @@ var (
 	ErrPauseLeased        = fmt.Errorf("pause already leased")
 	ErrPauseAlreadyExists = fmt.Errorf("pause already exists")
 	ErrIdentifierExists   = fmt.Errorf("identifier already exists")
+	ErrInvalidIdentifier  = fmt.Errorf("identifier is not a valid ULID")
 	ErrFunctionCancelled  = fmt.Errorf("function cancelled")
 	ErrFunctionComplete   = fmt.Errorf("function completed")
 	ErrFunctionFailed     = fmt.Errorf("function failed")

--- a/pkg/execution/state/v2/interfaces.go
+++ b/pkg/execution/state/v2/interfaces.go
@@ -35,7 +35,7 @@ type RunService interface {
 	StateLoader
 
 	// Create creates new state in the store for the given run ID.
-	Create(ctx context.Context, s CreateState) error
+	Create(ctx context.Context, s CreateState) (state.State, error)
 	// Delete deletes state, metadata, and - when pauses are included - associated pauses
 	// for the run from the store.  Nothing referencing the run should exist in the state
 	// store after.

--- a/pkg/inngest/util_test.go
+++ b/pkg/inngest/util_test.go
@@ -5,6 +5,15 @@ import (
 	"testing"
 )
 
+func TestDeterministicSha1UUID(t *testing.T) {
+	src := "yolo"
+
+	id1 := DeterministicSha1UUID(src)
+	id2 := DeterministicSha1UUID(src)
+
+	require.Equal(t, id1, id2)
+}
+
 func TestDeterministicUUIDV7(t *testing.T) {
 	t.Run("should generate deterministic UUID v7", func(t *testing.T) {
 		seed := "1234567890123456"


### PR DESCRIPTION
## Description

Due to the lack of transactions between state creation and enqueue, there's always room for failure to enqueue function runs if `Schedule` fails abruptly due to OOMs or panics.

This attempts to make both state creation and enqueue idempotent, so everything can be reran on failures.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
