### PR TITLE
Update pause timeout jobs

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2655,8 +2655,8 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, i *runInst
 		CustomConcurrencyKeys: i.item.CustomConcurrencyKeys,
 		MaxAttempts:           i.item.MaxAttempts,
 		Payload: queue.PayloadPauseTimeout{
-			PauseID:   pauseID,
-			OnTimeout: true,
+			PauseID:       pauseID,
+			CorrelationID: &correlationID,
 		},
 	}, expires, queue.EnqueueOpts{})
 	if err == redis_state.ErrQueueItemExists {
@@ -2809,8 +2809,8 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, i *runInstan
 		PriorityFactor:        i.item.PriorityFactor,
 		CustomConcurrencyKeys: i.item.CustomConcurrencyKeys,
 		Payload: queue.PayloadPauseTimeout{
-			PauseID:   pauseID,
-			OnTimeout: true,
+			PauseID: pauseID,
+			Event:   pause.Event,
 		},
 	}, expires, queue.EnqueueOpts{})
 	if err == redis_state.ErrQueueItemExists {

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -380,8 +380,10 @@ type PayloadPauseBlockFlush struct {
 // This is always enqueued from any async match;  we must correctly decrement the
 // pending count in cases where the event is not received.
 type PayloadPauseTimeout struct {
-	PauseID   uuid.UUID `json:"pauseID"`
-	OnTimeout bool      `json:"onTimeout"`
+	PauseID       uuid.UUID `json:"pauseID"`
+	Event         *string   `json:"evt,omitempty"`
+	CorrelationID *string   `json:"cID,omitempty"`
+	SignalID      *string   `json:"sID,omitempty"`
 }
 
 func HashID(_ context.Context, id string) string {


### PR DESCRIPTION
We now store the event, correlation, or signal ID in pause timeout jobs. This aids in future lookups of pauses when flushing into blobs;  for waitForEvent timeouts we need the future PauseIndex (`{workspaceID, event}`) to fetch the correct blob that contains the pause.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
