### PR TITLE
Idempotent pause resume

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -10,16 +10,4 @@
                              :mode "remote"
                              :request "attach"
                              :showLog "true")
-                            (go-test
-                             modes (go-mode go-ts-mode)
-                             command "dlv"
-                             command-args ("dap" "--listen" "127.0.0.1::autoport")
-                             command-cwd default-directory
-                             port :autoport
-                             :type "go"
-                             :mode "test"
-                             :request "launch"
-                             :showLog "true"
-                             :program "."
-                             :args [])
                             )))))

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -222,6 +222,9 @@ type ResumeRequest struct {
 	RunID     *ulid.ULID
 	StepName  string
 	IsTimeout bool
+
+	// IdempotencyKey is used to make sure pause consumption is idempotent
+	IdempotencyKey string
 }
 
 func (r *ResumeRequest) Error() string {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1625,10 +1625,11 @@ func (e *executor) HandleInvokeFinish(ctx context.Context, evt event.TrackedEven
 	}
 
 	return e.Resume(ctx, *pause, execution.ResumeRequest{
-		With:     resumeData.With,
-		EventID:  &evtID,
-		RunID:    resumeData.RunID,
-		StepName: resumeData.StepName,
+		With:           resumeData.With,
+		EventID:        &evtID,
+		RunID:          resumeData.RunID,
+		StepName:       resumeData.StepName,
+		IdempotencyKey: evtID.String(),
 	})
 }
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1529,7 +1529,9 @@ func (e *executor) handlePause(
 			}
 
 			// Ensure we consume this pause, as this isn't handled by the higher-level cancel function.
-			_, err = e.pm.ConsumePause(context.Background(), *pause, nil)
+			_, err = e.pm.ConsumePause(context.Background(), *pause, state.ConsumePauseOpts{
+				Data: nil,
+			})
 			if err == nil || err == state.ErrPauseLeased || err == state.ErrPauseNotFound {
 				atomic.AddInt32(&res[1], 1)
 				cleanup(ctx)
@@ -1710,7 +1712,9 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 			// Delete this pause, as an event has occured which matches
 			// the timeout.  We can do this prior to leasing a pause as it's the
 			// only work that needs to happen
-			_, err = e.pm.ConsumePause(ctx, pause, nil)
+			_, err = e.pm.ConsumePause(ctx, pause, state.ConsumePauseOpts{
+				Data: nil,
+			})
 			switch err {
 			case nil, state.ErrPauseNotFound: // no-op
 			default:
@@ -1720,7 +1724,9 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 			return e.pm.DeletePause(ctx, pause)
 		}
 
-		consumeResult, err := e.pm.ConsumePause(ctx, pause, r.With)
+		consumeResult, err := e.pm.ConsumePause(ctx, pause, state.ConsumePauseOpts{
+			Data: r.With,
+		})
 		if err != nil {
 			return fmt.Errorf("error consuming pause via event: %w", err)
 		}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1491,8 +1491,8 @@ func (e *executor) handlePause(
 			return nil
 		}
 
+		// NOTE: Make sure the event that created the pause isn't also the one resuming it
 		if pause.TriggeringEventID != nil && *pause.TriggeringEventID == evtID.String() {
-			// TODO: clean up?
 			return nil
 		}
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1460,11 +1460,7 @@ func (e *executor) handlePause(
 		cleanup := func(ctx context.Context) {
 			eg := errgroup.Group{}
 			eg.Go(func() error {
-				err := e.pm.DeletePause(context.Background(), *pause)
-				if err != nil {
-					l.Warn("error deleting pause", "error", err, "pause", pause)
-				}
-				return err
+				return e.pm.DeletePause(context.Background(), *pause)
 			})
 			eg.Go(func() error {
 				err := e.exprAggregator.RemovePause(ctx, pause)

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1496,6 +1496,10 @@ func (e *executor) handlePause(
 			return nil
 		}
 
+		// Ensure that we store the group ID for this pause, letting us properly track cancellation
+		// or continuation history
+		ctx = state.WithGroupID(ctx, pause.GroupID)
+
 		if pause.Cancel {
 			// This is a cancellation signal.  Check if the function
 			// has ended, and if so remove the pause.
@@ -1508,14 +1512,8 @@ func (e *executor) handlePause(
 				cleanup(ctx)
 				return nil
 			}
-		}
 
-		// Ensure that we store the group ID for this pause, letting us properly track cancellation
-		// or continuation history
-		ctx = state.WithGroupID(ctx, pause.GroupID)
-
-		// Cancelling a function can happen before a lease, as it's an atomic operation that will always happen.
-		if pause.Cancel {
+			// Cancelling a function can happen before a lease, as it's an atomic operation that will always happen.
 			err := e.Cancel(ctx, sv2.IDFromPause(*pause), execution.CancelRequest{
 				EventID:    &evtID,
 				Expression: pause.Expression,

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -291,7 +291,8 @@ func (s *svc) handlePauseTimeout(ctx context.Context, item queue.Item) error {
 	}
 
 	r := execution.ResumeRequest{
-		IsTimeout: true,
+		IsTimeout:      true,
+		IdempotencyKey: *item.JobID,
 	}
 
 	// If the pause timeout is for an invocation, store an error to cause the

--- a/pkg/execution/pauses/block_test.go
+++ b/pkg/execution/pauses/block_test.go
@@ -170,7 +170,7 @@ func (m *mockBufferer) PauseTimestamp(ctx context.Context, index Index, pause st
 	return time.Now(), nil
 }
 
-func (m *mockBufferer) ConsumePause(ctx context.Context, p state.Pause, data any) (state.ConsumePauseResult, error) {
+func (m *mockBufferer) ConsumePause(ctx context.Context, p state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, error) {
 	return state.ConsumePauseResult{}, fmt.Errorf("not implemented")
 }
 

--- a/pkg/execution/pauses/block_test.go
+++ b/pkg/execution/pauses/block_test.go
@@ -170,8 +170,8 @@ func (m *mockBufferer) PauseTimestamp(ctx context.Context, index Index, pause st
 	return time.Now(), nil
 }
 
-func (m *mockBufferer) ConsumePause(ctx context.Context, p state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, error) {
-	return state.ConsumePauseResult{}, fmt.Errorf("not implemented")
+func (m *mockBufferer) ConsumePause(ctx context.Context, p state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, func() error, error) {
+	return state.ConsumePauseResult{}, func() error { return nil }, fmt.Errorf("not implemented")
 }
 
 func (m *mockBufferer) Delete(ctx context.Context, index Index, pause state.Pause) error {

--- a/pkg/execution/pauses/buffer.go
+++ b/pkg/execution/pauses/buffer.go
@@ -56,6 +56,6 @@ func (r redisAdapter) PauseTimestamp(ctx context.Context, index Index, pause sta
 	return r.rsm.PauseCreatedAt(ctx, index.WorkspaceID, index.EventName, pause.ID)
 }
 
-func (r redisAdapter) ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, error) {
+func (r redisAdapter) ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, func() error, error) {
 	return r.rsm.ConsumePause(ctx, pause, opts)
 }

--- a/pkg/execution/pauses/buffer.go
+++ b/pkg/execution/pauses/buffer.go
@@ -56,6 +56,6 @@ func (r redisAdapter) PauseTimestamp(ctx context.Context, index Index, pause sta
 	return r.rsm.PauseCreatedAt(ctx, index.WorkspaceID, index.EventName, pause.ID)
 }
 
-func (r redisAdapter) ConsumePause(ctx context.Context, pause state.Pause, data any) (state.ConsumePauseResult, error) {
-	return r.rsm.ConsumePause(ctx, pause, data)
+func (r redisAdapter) ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, error) {
+	return r.rsm.ConsumePause(ctx, pause, opts)
 }

--- a/pkg/execution/pauses/manager.go
+++ b/pkg/execution/pauses/manager.go
@@ -40,7 +40,7 @@ type manager struct {
 	flushDelay time.Duration
 }
 
-func (m manager) ConsumePause(ctx context.Context, pause state.Pause, data any) (state.ConsumePauseResult, error) {
+func (m manager) ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, error) {
 	if pause.Event == nil {
 		// A Pause must always have an event for this manager, else we cannot build the
 		// Index struct for deleting pauses.  It's also no longer possible to have pauses without
@@ -72,7 +72,7 @@ func (m manager) ConsumePause(ctx context.Context, pause state.Pause, data any) 
 	// a bit of thought to work around, so we’ll just go with double deletes for now,
 	// assuming this won’t happen a ton.  this can be improved later.
 
-	res, err := m.buf.ConsumePause(ctx, pause, data)
+	res, err := m.buf.ConsumePause(ctx, pause, opts)
 	// Is this an ErrDuplicateResponse?  If so, we've already consumed this pause,
 	// so delete it.  Similarly, if the error is nil we just consumed, so go ahead
 	// and delete the pause then continue

--- a/pkg/execution/pauses/manager.go
+++ b/pkg/execution/pauses/manager.go
@@ -85,10 +85,9 @@ func (m manager) ConsumePause(ctx context.Context, pause state.Pause, opts state
 		*pause.Event,
 	}
 
-	// wrap the cleanup within another closure to add the logs
-	// seems kinda redundant
-	delete := func() error {
-		err := cleanup()
+	// override the cleanup with idx deletion
+	cleanup = func() error {
+		err := m.Delete(ctx, idx, pause)
 		if err != nil {
 			// We only log here if the delete fails. Consuming is idempotent and is the
 			// action that updates state.
@@ -102,7 +101,7 @@ func (m manager) ConsumePause(ctx context.Context, pause state.Pause, opts state
 		return err
 	}
 
-	return res, delete, nil
+	return res, cleanup, nil
 }
 
 // Write writes one or more pauses to the backing store.  Note that the index

--- a/pkg/execution/pauses/manager_test.go
+++ b/pkg/execution/pauses/manager_test.go
@@ -164,7 +164,7 @@ func TestConsumePause(t *testing.T) {
 	}
 
 	// Test consuming a pause
-	result, err := manager.ConsumePause(ctx, pause, state.ConsumePauseOpts{
+	result, _, err := manager.ConsumePause(ctx, pause, state.ConsumePauseOpts{
 		Data: "test-data",
 	})
 	require.NoError(t, err)
@@ -201,9 +201,9 @@ type mockBuffererWithConsume struct {
 	consumeCalled bool
 }
 
-func (m *mockBuffererWithConsume) ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, error) {
+func (m *mockBuffererWithConsume) ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, func() error, error) {
 	m.consumeCalled = true
-	return state.ConsumePauseResult{DidConsume: true}, nil
+	return state.ConsumePauseResult{DidConsume: true}, func() error { return nil }, nil
 }
 
 type mockBlockStore struct {

--- a/pkg/execution/pauses/manager_test.go
+++ b/pkg/execution/pauses/manager_test.go
@@ -164,10 +164,11 @@ func TestConsumePause(t *testing.T) {
 	}
 
 	// Test consuming a pause
-	result, _, err := manager.ConsumePause(ctx, pause, state.ConsumePauseOpts{
+	result, cleanup, err := manager.ConsumePause(ctx, pause, state.ConsumePauseOpts{
 		Data: "test-data",
 	})
 	require.NoError(t, err)
+	require.NoError(t, cleanup())
 	assert.Equal(t, true, result.DidConsume)
 	assert.True(t, mockBufferer.consumeCalled, "ConsumePause should be called on the buffer")
 	assert.True(t, mockBlockStore.deleteCalled, "Delete should be called on the blockstore")

--- a/pkg/execution/pauses/manager_test.go
+++ b/pkg/execution/pauses/manager_test.go
@@ -164,7 +164,9 @@ func TestConsumePause(t *testing.T) {
 	}
 
 	// Test consuming a pause
-	result, err := manager.ConsumePause(ctx, pause, "test-data")
+	result, err := manager.ConsumePause(ctx, pause, state.ConsumePauseOpts{
+		Data: "test-data",
+	})
 	require.NoError(t, err)
 	assert.Equal(t, true, result.DidConsume)
 	assert.True(t, mockBufferer.consumeCalled, "ConsumePause should be called on the buffer")
@@ -199,7 +201,7 @@ type mockBuffererWithConsume struct {
 	consumeCalled bool
 }
 
-func (m *mockBuffererWithConsume) ConsumePause(ctx context.Context, pause state.Pause, data any) (state.ConsumePauseResult, error) {
+func (m *mockBuffererWithConsume) ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, error) {
 	m.consumeCalled = true
 	return state.ConsumePauseResult{DidConsume: true}, nil
 }

--- a/pkg/execution/pauses/pauses.go
+++ b/pkg/execution/pauses/pauses.go
@@ -35,7 +35,7 @@ type Manager interface {
 	//
 	// NOTE: This consumes a pause in the buffer, then calls m.Delete to ensure the pause is
 	// deleted from the backing block store.
-	ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, error)
+	ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, func() error, error)
 
 	// Delete deletes a pause from either the block index or the buffer, depending on
 	// where the pause is stored.
@@ -69,7 +69,7 @@ type Bufferer interface {
 	PauseTimestamp(ctx context.Context, index Index, pause state.Pause) (time.Time, error)
 
 	// ConsumePause consumes a pause, writing the deleted status to the buffer.
-	ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, error)
+	ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, func() error, error)
 }
 
 // BlockStore is an implementation that reads and writes blocks.

--- a/pkg/execution/pauses/pauses.go
+++ b/pkg/execution/pauses/pauses.go
@@ -35,7 +35,7 @@ type Manager interface {
 	//
 	// NOTE: This consumes a pause in the buffer, then calls m.Delete to ensure the pause is
 	// deleted from the backing block store.
-	ConsumePause(ctx context.Context, pause state.Pause, data any) (state.ConsumePauseResult, error)
+	ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, error)
 
 	// Delete deletes a pause from either the block index or the buffer, depending on
 	// where the pause is stored.
@@ -69,7 +69,7 @@ type Bufferer interface {
 	PauseTimestamp(ctx context.Context, index Index, pause state.Pause) (time.Time, error)
 
 	// ConsumePause consumes a pause, writing the deleted status to the buffer.
-	ConsumePause(ctx context.Context, pause state.Pause, data any) (state.ConsumePauseResult, error)
+	ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, error)
 }
 
 // BlockStore is an implementation that reads and writes blocks.

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -42,7 +42,7 @@ type PauseMutater interface {
 	//
 	// Any data passed when consuming a pause will be stored within function run state
 	// for future reference using the pause's DataKey.
-	ConsumePause(ctx context.Context, p Pause, data any) (ConsumePauseResult, error)
+	ConsumePause(ctx context.Context, p Pause, opts ConsumePauseOpts) (ConsumePauseResult, error)
 
 	// DeletePause permanently deletes a pause.
 	DeletePause(ctx context.Context, p Pause) error
@@ -86,6 +86,12 @@ type PauseGetter interface {
 	// PauseCreatedAt returns the timestamp a pause was created, using the given
 	// workspace <> event Index.
 	PauseCreatedAt(ctx context.Context, workspaceID uuid.UUID, event string, pauseID uuid.UUID) (time.Time, error)
+}
+
+// ConsumePauseOpts are the options to be passed in for consuming a pause
+type ConsumePauseOpts struct {
+	IdempotencyKey string
+	Data           any
 }
 
 type ConsumePauseResult struct {

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -47,7 +47,7 @@ type PauseMutater interface {
 	//
 	// Any data passed when consuming a pause will be stored within function run state
 	// for future reference using the pause's DataKey.
-	ConsumePause(ctx context.Context, p Pause, opts ConsumePauseOpts) (ConsumePauseResult, error)
+	ConsumePause(ctx context.Context, p Pause, opts ConsumePauseOpts) (ConsumePauseResult, func() error, error)
 
 	// DeletePause permanently deletes a pause.
 	DeletePause(ctx context.Context, p Pause) error

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"time"
 
@@ -13,6 +14,10 @@ import (
 )
 
 var tsSuffix = regexp.MustCompile(`\s*&&\s*\(\s*async.ts\s+==\s*null\s*\|\|\s*async.ts\s*>\s*\d*\)\s*$`)
+
+var (
+	ErrConsumePauseKeyMissing = fmt.Errorf("no idempotency key provided for consuming pauses")
+)
 
 // PauseMutater manages creating, leasing, and consuming pauses from a backend implementation.
 type PauseMutater interface {

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -48,6 +48,9 @@ type RunStateKeyGenerator interface {
 	// Pending returns the key used to store the pending actions for a given
 	// run.
 	Pending(ctx context.Context, isSharded bool, identifier state.Identifier) string
+
+	// PauseConsumeKey is an idempotency key used for making sure pause consumptions are idempotent
+	PauseConsumeKey(ctx context.Context, isSharded bool, runID ulid.ULID, pauseID uuid.UUID) string
 }
 
 type runStateKeyGenerator struct {
@@ -106,6 +109,10 @@ func (s runStateKeyGenerator) ActionInputs(ctx context.Context, isSharded bool, 
 
 func (s runStateKeyGenerator) Pending(ctx context.Context, isSharded bool, identifier state.Identifier) string {
 	return fmt.Sprintf("{%s}:pending:%s:%s", s.Prefix(ctx, s.stateDefaultKey, isSharded, identifier.RunID), identifier.WorkflowID, identifier.RunID)
+}
+
+func (s runStateKeyGenerator) PauseConsumeKey(ctx context.Context, isSharded bool, runID ulid.ULID, pauseID uuid.UUID) string {
+	return fmt.Sprintf("{%s}:pause-key:%s", s.Prefix(ctx, s.stateDefaultKey, isSharded, runID), pauseID.String())
 }
 
 type GlobalKeyGenerator interface {

--- a/pkg/execution/state/redis_state/lua/consumePause.lua
+++ b/pkg/execution/state/redis_state/lua/consumePause.lua
@@ -9,16 +9,16 @@ Output:
 
 ]]
 
-local actionKey     = KEYS[1]
-local stackKey      = KEYS[2]
-local keyMetadata   = KEYS[3]
+local actionKey       = KEYS[1]
+local stackKey        = KEYS[2]
+local keyMetadata     = KEYS[3]
 local keyStepsPending = KEYS[4]
-local keyIdempotency = KEYS[5]
+local keyIdempotency  = KEYS[5]
 
-local pauseDataKey = ARGV[1] -- used to set data in run state store
-local pauseDataVal = ARGV[2] -- data to set
+local pauseDataKey          = ARGV[1] -- used to set data in run state store
+local pauseDataVal          = ARGV[2] -- data to set
 local pauseIdempotencyValue = ARGV[3] -- the idempotency key value
-local pauseIdempotencyUnix = tonumber(ARGV[4]) -- TTL of the idempotency key in unix timestamp
+local pauseIdempotencyUnix  = tonumber(ARGV[4]) -- TTL of the idempotency key in unix timestamp
 
 
 if actionKey ~= nil and pauseDataKey ~= "" then

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -1186,6 +1186,7 @@ func (m shardedMgr) consumePause(ctx context.Context, p *state.Pause, opts state
 	if err != nil {
 		return state.ConsumePauseResult{}, fmt.Errorf("error consuming pause: %w", err)
 	}
+
 	switch status {
 	case -1:
 		// This could be an ErrDuplicateResponse;  we're attempting to consume a pause twice.

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -1126,6 +1126,8 @@ func (m unshardedMgr) DeletePause(ctx context.Context, p state.Pause) error {
 }
 
 func (m mgr) ConsumePause(ctx context.Context, pause state.Pause, opts state.ConsumePauseOpts) (state.ConsumePauseResult, error) {
+	// NOTE: should this return an error if no idempotency key is provided?
+
 	return m.shardedMgr.consumePause(ctx, &pause, opts)
 }
 
@@ -1154,7 +1156,7 @@ func (m shardedMgr) consumePause(ctx context.Context, p *state.Pause, opts state
 	args, err := StrSlice([]any{
 		p.DataKey,
 		string(marshalledData),
-		opts.IdempotencyKey,
+		idempotencyKey,
 		time.Now().Add(consts.FunctionIdempotencyPeriod),
 	})
 	if err != nil {

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -1137,7 +1137,7 @@ func (m mgr) ConsumePause(ctx context.Context, pause state.Pause, opts state.Con
 	cleanup := func() error {
 		err := m.DeletePause(ctx, pause)
 		if err != nil {
-			logger.StdlibLogger(ctx).Error("error deleting pause", "error", err, "pause", pause)
+			logger.StdlibLogger(ctx).Error("error deleting pause after consumption", "error", err, "pause", pause)
 		}
 		return err
 	}

--- a/pkg/execution/state/redis_state/redis_state_test.go
+++ b/pkg/execution/state/redis_state/redis_state_test.go
@@ -232,7 +232,6 @@ func TestScanIter(t *testing.T) {
 	entries := 50_000
 	key := "test-scan"
 	for i := 0; i < entries; i++ {
-
 		cmd := r.B().Hset().Key(key).FieldValue().
 			FieldValue(strconv.Itoa(i), strconv.Itoa(i)).
 			Build()

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -881,8 +881,7 @@ func checkConsumePauseIdempotency(t *testing.T, m state.Manager) {
 	_, err := m.SavePause(ctx, pause)
 	require.NoError(t, err)
 
-	key := "hello"
-
+	key := uuid.NewString()
 	// consuming the pause for the first time
 	res, _, err := m.ConsumePause(ctx, pause, state.ConsumePauseOpts{
 		IdempotencyKey: key,
@@ -893,7 +892,7 @@ func checkConsumePauseIdempotency(t *testing.T, m state.Manager) {
 
 	// consuming with another idempotency key will fail
 	res, _, err = m.ConsumePause(ctx, pause, state.ConsumePauseOpts{
-		IdempotencyKey: "world",
+		IdempotencyKey: uuid.NewString(),
 		Data:           pauseData,
 	})
 	require.NoError(t, err)

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -637,7 +637,7 @@ func checkConsumePause(t *testing.T, m state.Manager) {
 		// and without this there's a small but real chance of flakiness.
 		<-time.After(time.Millisecond)
 		// Consuming the pause should work.
-		res, err := m.ConsumePause(ctx, pause, nil)
+		res, err := m.ConsumePause(ctx, pause, state.ConsumePauseOpts{Data: nil})
 		require.NoError(t, err)
 		require.True(t, res.DidConsume)
 	})
@@ -668,7 +668,7 @@ func checkConsumePauseWithData(t *testing.T, m state.Manager) {
 	require.NoError(t, err)
 
 	// Consuming the pause should work.
-	_, err = m.ConsumePause(ctx, pause, pauseData)
+	_, err = m.ConsumePause(ctx, pause, state.ConsumePauseOpts{Data: pauseData})
 	require.NoError(t, err)
 
 	// Load function state and assert we have the pause stored in state.
@@ -701,7 +701,7 @@ func checkConsumePauseWithDataIndex(t *testing.T, m state.Manager) {
 		require.NoError(t, err)
 
 		// Consuming the pause should work.
-		_, err = m.ConsumePause(ctx, pause, nil)
+		_, err = m.ConsumePause(ctx, pause, state.ConsumePauseOpts{Data: nil})
 		require.NoError(t, err)
 
 		// Load function state and assert we have the pause stored in state.
@@ -743,7 +743,7 @@ func checkConsumePauseWithDataIndex(t *testing.T, m state.Manager) {
 		data := map[string]any{"allo": "guvna"}
 
 		// Consuming the pause should work.
-		_, err = m.ConsumePause(ctx, pause, data)
+		_, err = m.ConsumePause(ctx, pause, state.ConsumePauseOpts{Data: data})
 		require.NoError(t, err)
 
 		// Load function state and assert we have the pause stored in state.
@@ -765,7 +765,7 @@ func checkConsumePauseWithEmptyData(t *testing.T, m state.Manager) {
 	// NOTE: Consuming a pause not in the store is possible;  the pause may
 	// exist in a different datasotre (block storage), so we assume that the pause
 	// data written is valid.
-	res, err := m.ConsumePause(ctx, state.Pause{ID: uuid.New()}, nil)
+	res, err := m.ConsumePause(ctx, state.Pause{ID: uuid.New()}, state.ConsumePauseOpts{Data: nil})
 	require.Nil(t, err)
 	require.True(t, res.DidConsume, "got: %#v", res)
 
@@ -786,7 +786,7 @@ func checkConsumePauseWithEmptyData(t *testing.T, m state.Manager) {
 	require.NoError(t, err)
 
 	// Consuming the pause should work.
-	res, err = m.ConsumePause(ctx, pause, nil)
+	res, err = m.ConsumePause(ctx, pause, state.ConsumePauseOpts{Data: nil})
 	require.NoError(t, err)
 	require.True(t, res.DidConsume)
 
@@ -820,7 +820,7 @@ func checkConsumePauseWithEmptyDataKey(t *testing.T, m state.Manager) {
 	require.NoError(t, err)
 
 	// Consuming the pause should work.
-	res, err := m.ConsumePause(ctx, pause, pauseData)
+	res, err := m.ConsumePause(ctx, pause, state.ConsumePauseOpts{Data: pauseData})
 	require.NoError(t, err)
 	require.True(t, res.DidConsume)
 
@@ -1159,7 +1159,7 @@ func checkPausesByEvent_consumed(t *testing.T, m state.Manager) {
 
 	// Consume the first pause, and assert that it doesn't show up in
 	// an iterator.
-	_, err = m.ConsumePause(ctx, pauses[0], nil)
+	_, err = m.ConsumePause(ctx, pauses[0], state.ConsumePauseOpts{Data: nil})
 	require.NoError(t, err)
 
 	iter, err = m.PausesByEvent(ctx, uuid.UUID{}, evtA)
@@ -1244,7 +1244,7 @@ func checkPausesByEvent_consumed(t *testing.T, m state.Manager) {
 		// There should be two pauses.
 		require.Equal(t, 2, n)
 
-		_, err = m.ConsumePause(ctx, p1, map[string]any{"ok": true})
+		_, err = m.ConsumePause(ctx, p1, state.ConsumePauseOpts{Data: map[string]any{"ok": true}})
 		require.NoError(t, err)
 
 		//
@@ -1296,7 +1296,7 @@ func checkPauseByID(t *testing.T, m state.Manager) {
 	require.EqualValues(t, pause, *found)
 
 	// Consume.
-	_, err = m.ConsumePause(ctx, pause, nil)
+	_, err = m.ConsumePause(ctx, pause, state.ConsumePauseOpts{Data: nil})
 	require.Nil(t, err, "Consuming an expired pause should work")
 
 	found, err = m.PauseByID(ctx, pause.ID)
@@ -1354,7 +1354,7 @@ func checkPausesByID(t *testing.T, m state.Manager) {
 	require.Nil(t, err)
 	require.EqualValues(t, 2, len(found))
 
-	_, err = m.ConsumePause(ctx, a, nil)
+	_, err = m.ConsumePause(ctx, a, state.ConsumePauseOpts{Data: nil})
 	// Consume.
 	require.Nil(t, err, "Consuming an expired pause should work")
 


### PR DESCRIPTION
## Description

Make sure pauses are resumed in an idempotent way so we do not get functions stucked when there's a failure during resuming the pause.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
