### PR TITLE
Fix runs page crashing on invalid CEL expression

### DIFF
--- a/ui/apps/dashboard/src/components/Runs/Runs.tsx
+++ b/ui/apps/dashboard/src/components/Runs/Runs.tsx
@@ -8,7 +8,7 @@ import {
   useSearchParam,
   useStringArraySearchParam,
 } from '@inngest/components/hooks/useSearchParam';
-import { useQuery } from 'urql';
+import { CombinedError, useQuery } from 'urql';
 
 import { useEnvironment } from '@/components/Environments/environment-context';
 import { useGetRun } from '@/components/RunDetails/useGetRun';
@@ -35,6 +35,12 @@ type EnvProps = {
 };
 
 type Props = FnProps | EnvProps;
+
+const parseCelSearchError = (combinedError: CombinedError | undefined) => {
+  return combinedError?.graphQLErrors.find(
+    (error) => error.extensions.code == 'expression_invalid'
+  );
+};
 
 export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
   { functionSlug, scope }: Props,
@@ -135,9 +141,9 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
     variables: commonQueryVars,
   });
 
-  if (firstPageRes.error || nextPageRes.error || countRes.error) {
-    throw firstPageRes.error || nextPageRes.error || countRes.error;
-  }
+  const searchError = parseCelSearchError(
+    firstPageRes.error || nextPageRes.error || countRes.error
+  );
 
   const firstPageRunsData = firstPageRes.data?.environment.runs.edges;
   const nextPageRunsData = nextPageRes.data?.environment.runs.edges;
@@ -233,6 +239,7 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
       functionIsPaused={pauseData?.environment.function?.isPaused ?? false}
       scope={scope}
       totalCount={totalCount}
+      searchError={searchError}
     />
   );
 });

--- a/ui/packages/components/src/CodeSearch/CodeSearch.tsx
+++ b/ui/packages/components/src/CodeSearch/CodeSearch.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { Alert } from '@inngest/components/Alert';
 import { Button } from '@inngest/components/Button';
 import {
   FONT,
@@ -175,10 +176,12 @@ export default function CodeSearch({
   onSearch,
   placeholder,
   value,
+  searchError,
 }: {
   onSearch: (content: string) => void;
   placeholder?: string;
   value?: string;
+  searchError?: Error;
 }) {
   const [content, setContent] = useState<string>(value || '');
   const [dark, setDark] = useState(isDark());
@@ -372,6 +375,11 @@ export default function CodeSearch({
 
   return (
     <>
+      {searchError && (
+        <Alert severity="error" className="flex items-center justify-between text-sm">
+          {searchError.message}
+        </Alert>
+      )}
       {monaco && (
         <div ref={wrapperRef} className="relative">
           {!content && (

--- a/ui/packages/components/src/CodeSearch/CodeSearch.tsx
+++ b/ui/packages/components/src/CodeSearch/CodeSearch.tsx
@@ -188,7 +188,7 @@ export default function CodeSearch({
   const editorRef = useRef<MonacoEditorType>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
   const monacoRef = useRef<Monaco>();
-  const [hasValidationError, setHasValidationError] = useState(false);
+  const [editorValidationError, setEditorValidationError] = useState<ValidationError | null>(null);
   const validationTimerRef = useRef<NodeJS.Timeout>();
 
   const monaco = useMonaco();
@@ -326,10 +326,10 @@ export default function CodeSearch({
         endColumn: error.endColumn,
       };
       monacoRef.current.editor.setModelMarkers(model, 'owner', [marker]);
-      setHasValidationError(true);
+      setEditorValidationError(error);
     } else {
       monacoRef.current.editor.setModelMarkers(model, 'owner', []);
-      setHasValidationError(false);
+      setEditorValidationError(null);
     }
   };
 
@@ -344,7 +344,7 @@ export default function CodeSearch({
 
   const handleSearch = (editorContent?: string) => {
     const updatedContent = editorContent || content;
-    if (!hasValidationError) {
+    if (!editorValidationError) {
       // Remove empty lines and trim whitespace
       const processedContent = updatedContent
         .split('\n')
@@ -373,11 +373,13 @@ export default function CodeSearch({
     }, VALIDATION_DELAY);
   };
 
+  const expressionError = editorValidationError || searchError ;
+
   return (
     <>
-      {searchError && (
+      {expressionError && (
         <Alert severity="error" className="flex items-center justify-between text-sm">
-          {searchError.message}
+          {expressionError.message}
         </Alert>
       )}
       {monaco && (

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -65,6 +65,7 @@ type Props = {
   functionIsPaused?: boolean;
   scope: ViewScope;
   totalCount: number | undefined;
+  searchError?: Error;
 };
 
 export function RunsPage({
@@ -87,6 +88,7 @@ export function RunsPage({
   functionIsPaused,
   scope,
   totalCount,
+  searchError,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const columns = useScopedColumns(scope);
@@ -368,6 +370,7 @@ export function RunsPage({
               onSearch={onSearchChange}
               placeholder="event.data.userId == “1234” or output.count > 10"
               value={search}
+              searchError={searchError}
             />
           </>
         )}


### PR DESCRIPTION
## Description

Fix fatal error for invalid CEL expression in runs search

- When we get a gql error from the backend, instead of throwing to the error boundary, parse out the combined error to find the one for `expression_invalid` and display that message
![image](https://github.com/user-attachments/assets/3e1c47c8-109b-410a-9135-3ce55888bd13)


Also show error for frontend validation of CEL expression

- We don't send these queries to the backend if we detect it's invalid on the frontend when user clicks Search (but we do if user hits cmd + enter)
- Replace boolean check for error with presence of error itself

![image](https://github.com/user-attachments/assets/70d52109-20d8-4229-9bdd-77fbdf877c91)


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
