### PR TITLE
Fix key queues

### DIFF
--- a/pkg/connect/pubsub/proxy.go
+++ b/pkg/connect/pubsub/proxy.go
@@ -274,6 +274,8 @@ func (i *redisPubSubConnector) Proxy(ctx, traceCtx context.Context, opts ProxyOp
 	go func() {
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case <-waitForResponseCtx.Done():
 				return
 			// Poll every two seconds with a jitter of up to 3 seconds

--- a/pkg/execution/state/redis_state/lua/queue/backlogRefill.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogRefill.lua
@@ -215,28 +215,25 @@ if refill > 0 then
     -- If queue item does not exist in hash, delete from backlog
     if itemData == false or itemData == nil or itemData == "" then
       table.insert(backlogRemArgs, itemID)  -- remove from backlog
-      goto continue
+    else
+      -- Insert new members into ready set
+      table.insert(readyArgs, itemScore)
+      table.insert(readyArgs, itemID)
+
+      -- Remove item from backlog
+      table.insert(backlogRemArgs, itemID)
+
+      -- Update queue item with refill data
+      local updatedData = cjson.decode(itemData)
+      updatedData.rf = backlogID
+      updatedData.rat = nowMS
+
+      table.insert(itemUpdateArgs, itemID)
+      table.insert(itemUpdateArgs, cjson.encode(updatedData))
+
+      -- Increment number of refilled items
+      refilled = refilled + 1
     end
-
-    -- Insert new members into ready set
-    table.insert(readyArgs, itemScore)
-    table.insert(readyArgs, itemID)
-
-    -- Remove item from backlog
-    table.insert(backlogRemArgs, itemID)
-
-    -- Update queue item with refill data
-    local updatedData = cjson.decode(itemData)
-    updatedData.rf = backlogID
-    updatedData.rat = nowMS
-
-    table.insert(itemUpdateArgs, itemID)
-    table.insert(itemUpdateArgs, cjson.encode(updatedData))
-
-    -- Increment number of refilled items
-    refilled = refilled + 1
-
-    ::continue::
   end
 
   -- "Refill" items to ready set

--- a/pkg/execution/state/redis_state/lua/queue/backlogRefill.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogRefill.lua
@@ -29,15 +29,20 @@ local keyShadowPartitionSet              = KEYS[2]
 local keyGlobalShadowPartitionSet        = KEYS[3]
 local keyGlobalAccountShadowPartitionSet = KEYS[4]
 local keyAccountShadowPartitionSet       = KEYS[5]
+
 local keyReadySet                        = KEYS[6]
-local keyQueueItemHash                   = KEYS[7]
+local keyGlobalPointer        	         = KEYS[7] -- partition:sorted - zset
+local keyGlobalAccountPointer 	         = KEYS[8] -- accounts:sorted - zset
+local keyAccountPartitions    	         = KEYS[9] -- accounts:$accountID:partition:sorted - zset
+
+local keyQueueItemHash                   = KEYS[10]
 
 -- Constraint-related accounting keys
-local keyActiveAccount           = KEYS[8]
-local keyActivePartition         = KEYS[9]
-local keyActiveConcurrencyKey1   = KEYS[10]
-local keyActiveConcurrencyKey2   = KEYS[11]
-local keyActiveCompound          = KEYS[12]
+local keyActiveAccount           = KEYS[11]
+local keyActivePartition         = KEYS[12]
+local keyActiveConcurrencyKey1   = KEYS[13]
+local keyActiveConcurrencyKey2   = KEYS[14]
+local keyActiveCompound          = KEYS[15]
 
 local backlogID     = ARGV[1]
 local partitionID   = ARGV[2]
@@ -268,6 +273,27 @@ end
 -- update gcra theoretical arrival time
 if throttleLimit > 0 then
   gcraUpdate(throttleKey, nowMS, throttlePeriod * 1000, throttleLimit, throttleBurst, refill)
+end
+
+--
+-- Adjust ready queue pointers
+--
+
+if refilled > 0 then
+  -- Get the minimum score for the queue.
+  local minScores = redis.call("ZRANGE", keyReadySet, "-inf", "+inf", "BYSCORE", "LIMIT", 0, 1, "WITHSCORES")
+  local earliestScore = tonumber(minScores[2])
+
+  -- Potentially update the queue of queues.
+  local currentScore = redis.call("ZSCORE", keyGlobalPointer, partitionID)
+  if currentScore == false or tonumber(currentScore) ~= earliestScore then
+    if nowMS == nil or nowMS == false then
+      local updateTo = earliestScore/1000
+
+      update_pointer_score_to(partitionID, keyGlobalPointer, updateTo)
+      update_account_queues(keyGlobalAccountPointer, keyAccountPartitions, partitionID, accountID, updateTo)
+    end
+  end
 end
 
 --

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -2743,7 +2743,12 @@ func (q *queue) BacklogRefill(ctx context.Context, b *QueueBacklog, sp *QueueSha
 		kg.GlobalShadowPartitionSet(),
 		kg.GlobalAccountShadowPartitions(),
 		kg.AccountShadowPartitions(accountID),
+
 		sp.readyQueueKey(kg),
+		kg.GlobalPartitionIndex(),
+		kg.GlobalAccountIndex(),
+		kg.AccountPartitionIndex(accountID),
+
 		kg.QueueItem(),
 
 		// Constraint-related accounting keys


### PR DESCRIPTION
## Description

This fixes BacklogRefill to update pointer queues if at least one item was refilled. This is necessary to notify the executor about new queue items being available to process in the ready queue. Also removed the `continue` mark in favor of if/else which is compatible with proper Redis/Valkey

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
