### PR TITLE
Fix idempotency trace issue

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,9 @@ on:
     paths-ignore:
       - "ui/**"
 
+permissions:
+  contents: read
+
 jobs:
   ts:
     name: TS SDK Tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -98,4 +98,4 @@ jobs:
           go-version: "1.24"
 
       - name: Run execution tests
-        run: go test ./tests/execution -v -count=1
+        run: go test ./tests/execution/... -v -count=1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,7 +75,7 @@ jobs:
           echo "Ran dev server"
           sleep 5
           curl http://127.0.0.1:8288/dev > /dev/null 2> /dev/null
-          go test ./Tests/golang -v -count=1
+          go test ./tests/golang -v -count=1
         env:
           API_URL: http://127.0.0.1:8288
           INNGEST_EVENT_KEY: test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -75,10 +75,29 @@ jobs:
           echo "Ran dev server"
           sleep 5
           curl http://127.0.0.1:8288/dev > /dev/null 2> /dev/null
-          go test ./tests/golang -v -count=1
+          go test ./Tests/golang -v -count=1
         env:
           API_URL: http://127.0.0.1:8288
           INNGEST_EVENT_KEY: test
           INNGEST_SIGNING_KEY: 7468697320697320612074657374206b6579
           INNGEST_DEV: http://127.0.0.1:8288
           TEST_MODE: true
+
+
+  execution:
+    name: Execution Tests
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+      - name: Build dev server
+        run: |
+          go build -o ./inngest-bin ./cmd/main.go
+      - name: Run execution tests
+        run: go test ./tests/execution -v -count=1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,8 +96,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.24"
-      - name: Build dev server
-        run: |
-          go build -o ./inngest-bin ./cmd/main.go
+
       - name: Run execution tests
         run: go test ./tests/execution -v -count=1

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -552,11 +552,13 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	default:
 		return nil, fmt.Errorf("error creating run state: %w", err)
 	}
-
 	if st == nil {
 		return nil, fmt.Errorf("missing state after create: %w", err)
 	}
 
+	// NOTE: if the runID mismatches, it means there's already a state available
+	// and we need to override the one we already have to make sure we're using
+	// the correct metedata values
 	if metadata.ID.RunID != st.Identifier().RunID {
 		id := sv2.IDFromV1(st.Identifier())
 		metadata, err = e.smv2.LoadMetadata(ctx, id)

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -546,18 +546,23 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 
 	st, err := e.smv2.Create(ctx, newState)
 	switch err {
-	case nil: // no-op
-	case state.ErrIdentifierExists:
-		// override metadata from the existing state
+	case nil, state.ErrIdentifierExists: // no-op
+	case state.ErrIdentifierTomestone:
+		return nil, ErrFunctionSkippedIdempotency
+	default:
+		return nil, fmt.Errorf("error creating run state: %w", err)
+	}
+
+	if st == nil {
+		return nil, fmt.Errorf("missing state after create: %w", err)
+	}
+
+	if metadata.ID.RunID != st.Identifier().RunID {
 		id := sv2.IDFromV1(st.Identifier())
 		metadata, err = e.smv2.LoadMetadata(ctx, id)
 		if err != nil {
 			return nil, err
 		}
-	case state.ErrIdentifierTomestone:
-		return nil, ErrFunctionSkippedIdempotency
-	default:
-		return nil, fmt.Errorf("error creating run state: %w", err)
 	}
 
 	//

--- a/pkg/execution/executor/executor_test.go
+++ b/pkg/execution/executor/executor_test.go
@@ -1,0 +1,425 @@
+package executor
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/cqrs/base_cqrs"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/execution"
+	"github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/execution/state/redis_state"
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/util"
+	"github.com/oklog/ulid/v2"
+	"github.com/redis/rueidis"
+	"github.com/stretchr/testify/require"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeLifecycle struct {
+	execution.NoopLifecyceListener
+
+	lock         sync.Mutex
+	scheduledCtr int64
+	runIDs       []ulid.ULID
+	evtIDs       []ulid.ULID
+}
+
+func (f *fakeLifecycle) OnFunctionScheduled(
+	ctx context.Context,
+	md statev2.Metadata,
+	qi queue.Item,
+	evt []event.TrackedEvent,
+) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	f.scheduledCtr += 1
+	f.runIDs = append(f.runIDs, md.ID.RunID)
+	f.evtIDs = append(f.evtIDs, evt[0].GetInternalID())
+}
+
+func createInmemoryRedis(ctx context.Context) (*miniredis.Miniredis, rueidis.Client, error) {
+
+	r := miniredis.NewMiniRedis()
+	_ = r.Start()
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// If tick is lower than the default, tick every 50ms.  This lets us save
+	// CPU for standard dev-server testing.
+	poll := 150 * time.Millisecond
+
+	go func() {
+		for range time.Tick(poll) {
+			r.FastForward(poll)
+		}
+	}()
+	return r, rc, nil
+}
+
+func TestScheduleRaceCondition(t *testing.T) {
+	var testLifecycle = &fakeLifecycle{}
+
+	db, err := base_cqrs.New(base_cqrs.BaseCQRSOptions{InMemory: true})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Initialize the devserver
+	dbDriver := "sqlite"
+	dbcqrs := base_cqrs.NewCQRS(db, dbDriver)
+	loader := dbcqrs.(state.FunctionLoader)
+
+	stateRedis, shardedRc, err := createInmemoryRedis(ctx)
+	require.NoError(t, err)
+
+	queueRedis, unshardedRc, err := createInmemoryRedis(ctx)
+	require.NoError(t, err)
+
+	unshardedClient := redis_state.NewUnshardedClient(unshardedRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
+	shardedClient := redis_state.NewShardedClient(redis_state.ShardedClientOpts{
+		UnshardedClient:        unshardedClient,
+		FunctionRunStateClient: shardedRc,
+		StateDefaultKey:        redis_state.StateDefaultKey,
+		FnRunIsSharded:         redis_state.AlwaysShardOnRun,
+		BatchClient:            shardedRc,
+		QueueDefaultKey:        redis_state.QueueDefaultKey,
+	})
+
+	queueShard := redis_state.QueueShard{Name: consts.DefaultQueueShardName, RedisClient: unshardedClient.Queue(), Kind: string(enums.QueueShardKindRedis)}
+
+	shardSelector := func(ctx context.Context, _ uuid.UUID, _ *string) (redis_state.QueueShard, error) {
+		return queueShard, nil
+	}
+
+	queueShards := map[string]redis_state.QueueShard{
+		consts.DefaultQueueShardName: queueShard,
+	}
+
+	var sm state.Manager
+	sm, err = redis_state.New(
+		ctx,
+		redis_state.WithShardedClient(shardedClient),
+		redis_state.WithUnshardedClient(unshardedClient),
+	)
+	require.NoError(t, err)
+	smv2 := redis_state.MustRunServiceV2(sm)
+
+	queueOpts := []redis_state.QueueOpt{
+		redis_state.WithIdempotencyTTL(time.Hour),
+		redis_state.WithShardSelector(shardSelector),
+		redis_state.WithQueueShardClients(queueShards),
+	}
+
+	rq := redis_state.NewQueue(queueShard, queueOpts...)
+
+	exec, err := NewExecutor(
+		WithStateManager(smv2),
+		WithPauseManager(sm),
+		WithQueue(rq),
+		WithLogger(logger.From(ctx)),
+		WithFunctionLoader(loader),
+		WithLifecycleListeners(
+			testLifecycle,
+		),
+		WithAssignedQueueShard(queueShard),
+		WithShardSelector(shardSelector),
+		WithTraceReader(dbcqrs),
+	)
+	require.NoError(t, err)
+
+	fnID, accountID, wsID, appID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+
+	fn := inngest.Function{
+		ConfigVersion:   0,
+		ID:              fnID,
+		FunctionVersion: 0,
+		Name:            "",
+		Slug:            "",
+		Priority:        nil,
+		Timeouts:        nil,
+		Concurrency:     nil,
+		Debounce:        nil,
+		Triggers:        nil,
+		EventBatch:      nil,
+		RateLimit:       nil,
+		Throttle:        nil,
+		Cancel:          nil,
+		Steps:           nil,
+	}
+
+	now := time.Now()
+
+	at := now
+
+	key := "same-idempotency-key"
+
+	wg := sync.WaitGroup{}
+
+	var runnerLock sync.Mutex
+	var successCount, errCount int64
+	var successMetaIDs []ulid.ULID
+	var successEventIDs []ulid.ULID
+
+	runner := func() {
+		defer wg.Done()
+
+		evtID := ulid.MustNew(ulid.Timestamp(at), rand.Reader)
+
+		evt := event.NewOSSTrackedEvent(event.Event{
+			Name: "cron-resumed",
+			ID:   evtID.String(),
+		}, event.SeededIDFromString("", 0))
+		md, err := exec.Schedule(ctx, execution.ScheduleRequest{
+			Function:       fn,
+			At:             &at,
+			AccountID:      accountID,
+			WorkspaceID:    wsID,
+			AppID:          appID,
+			Events:         []event.TrackedEvent{evt},
+			IdempotencyKey: &key,
+		})
+
+		runnerLock.Lock()
+		defer runnerLock.Unlock()
+
+		if err != nil {
+			errCount++
+			return
+		}
+
+		successCount++
+		successMetaIDs = append(successMetaIDs, md.ID.RunID)
+		successEventIDs = append(successEventIDs, evtID)
+	}
+
+	iterations := 1000
+	for range iterations {
+		wg.Add(1)
+
+		go runner()
+	}
+
+	wg.Wait()
+
+	require.Equal(t, 1, int(successCount))
+	require.Equal(t, iterations-1, int(errCount))
+
+	require.Len(t, successMetaIDs, 1)
+
+	require.Equal(t, 1, int(testLifecycle.scheduledCtr))
+	require.Len(t, testLifecycle.runIDs, 1)
+
+	// This is expected: One could reach the state creation earlier, BUT: the run ID must diverge
+	// require.Equal(t, testLifecycle.evtIDs[0], successEventIDs[0])
+
+	for _, d := range successMetaIDs {
+		require.Equal(t, testLifecycle.runIDs[0], d)
+	}
+
+	fmt.Println("state redis:")
+	fmt.Println(stateRedis.Dump())
+
+	fmt.Println("queue redis:")
+	fmt.Println(queueRedis.Dump())
+
+}
+
+func TestScheduleRaceConditionWithExistingIdempotencyKey(t *testing.T) {
+	var testLifecycle = &fakeLifecycle{}
+
+	db, err := base_cqrs.New(base_cqrs.BaseCQRSOptions{InMemory: true})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Initialize the devserver
+	dbDriver := "sqlite"
+	dbcqrs := base_cqrs.NewCQRS(db, dbDriver)
+	loader := dbcqrs.(state.FunctionLoader)
+
+	stateRedis, shardedRc, err := createInmemoryRedis(ctx)
+	require.NoError(t, err)
+
+	queueRedis, unshardedRc, err := createInmemoryRedis(ctx)
+	require.NoError(t, err)
+
+	unshardedClient := redis_state.NewUnshardedClient(unshardedRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
+	shardedClient := redis_state.NewShardedClient(redis_state.ShardedClientOpts{
+		UnshardedClient:        unshardedClient,
+		FunctionRunStateClient: shardedRc,
+		StateDefaultKey:        redis_state.StateDefaultKey,
+		FnRunIsSharded:         redis_state.AlwaysShardOnRun,
+		BatchClient:            shardedRc,
+		QueueDefaultKey:        redis_state.QueueDefaultKey,
+	})
+
+	queueShard := redis_state.QueueShard{Name: consts.DefaultQueueShardName, RedisClient: unshardedClient.Queue(), Kind: string(enums.QueueShardKindRedis)}
+
+	shardSelector := func(ctx context.Context, _ uuid.UUID, _ *string) (redis_state.QueueShard, error) {
+		return queueShard, nil
+	}
+
+	queueShards := map[string]redis_state.QueueShard{
+		consts.DefaultQueueShardName: queueShard,
+	}
+
+	var sm state.Manager
+	sm, err = redis_state.New(
+		ctx,
+		redis_state.WithShardedClient(shardedClient),
+		redis_state.WithUnshardedClient(unshardedClient),
+	)
+	require.NoError(t, err)
+	smv2 := redis_state.MustRunServiceV2(sm)
+
+	queueOpts := []redis_state.QueueOpt{
+		redis_state.WithIdempotencyTTL(time.Hour),
+		redis_state.WithShardSelector(shardSelector),
+		redis_state.WithQueueShardClients(queueShards),
+	}
+
+	rq := redis_state.NewQueue(queueShard, queueOpts...)
+
+	exec, err := NewExecutor(
+		WithStateManager(smv2),
+		WithPauseManager(sm),
+		WithQueue(rq),
+		WithLogger(logger.From(ctx)),
+		WithFunctionLoader(loader),
+		WithLifecycleListeners(
+			testLifecycle,
+		),
+		WithAssignedQueueShard(queueShard),
+		WithShardSelector(shardSelector),
+		WithTraceReader(dbcqrs),
+	)
+	require.NoError(t, err)
+
+	fnID, accountID, wsID, appID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+
+	fn := inngest.Function{
+		ConfigVersion:   0,
+		ID:              fnID,
+		FunctionVersion: 0,
+		Name:            "",
+		Slug:            "",
+		Priority:        nil,
+		Timeouts:        nil,
+		Concurrency:     nil,
+		Debounce:        nil,
+		Triggers:        nil,
+		EventBatch:      nil,
+		RateLimit:       nil,
+		Throttle:        nil,
+		Cancel:          nil,
+		Steps:           nil,
+	}
+
+	now := time.Now()
+
+	at := now
+
+	key := "same-idempotency-key"
+
+	wg := sync.WaitGroup{}
+
+	var runnerLock sync.Mutex
+	var successCount, errCount int64
+	var successMetaIDs []ulid.ULID
+	var successEventIDs []ulid.ULID
+
+	fakeRunID := ulid.MustNew(ulid.Timestamp(now.Add(-16*time.Hour)), rand.Reader)
+
+	// Simulate an existing request
+	require.NoError(t, stateRedis.Set(shardedClient.FunctionRunState().KeyGenerator().Idempotency(ctx, true, state.Identifier{
+		WorkflowID: fnID,
+		Key:        fmt.Sprintf("%s-%s", util.XXHash(fnID.String()), util.XXHash(key)),
+		AccountID:  accountID,
+	}), fakeRunID.String()))
+
+	runner := func() {
+		defer wg.Done()
+
+		evtID := ulid.MustNew(ulid.Timestamp(at), rand.Reader)
+
+		evt := event.NewOSSTrackedEvent(event.Event{
+			Name: "cron-resumed",
+			ID:   evtID.String(),
+		}, event.SeededIDFromString("", 0))
+		md, err := exec.Schedule(ctx, execution.ScheduleRequest{
+			Function:       fn,
+			At:             &at,
+			AccountID:      accountID,
+			WorkspaceID:    wsID,
+			AppID:          appID,
+			Events:         []event.TrackedEvent{evt},
+			IdempotencyKey: &key,
+		})
+
+		runnerLock.Lock()
+		defer runnerLock.Unlock()
+
+		if err != nil {
+			errCount++
+			return
+		}
+
+		successCount++
+		successMetaIDs = append(successMetaIDs, md.ID.RunID)
+		successEventIDs = append(successEventIDs, evtID)
+	}
+
+	iterations := 2
+	for range iterations {
+		wg.Add(1)
+
+		go runner()
+	}
+
+	wg.Wait()
+
+	fmt.Println("fake run ID: ", fakeRunID.String())
+	fmt.Println("lifecycle run ID: ", testLifecycle.runIDs[0].String())
+	fmt.Println("success run ID: ", successMetaIDs[0].String())
+
+	fmt.Println("state redis:")
+	fmt.Println(stateRedis.Dump())
+
+	fmt.Println("queue redis:")
+	fmt.Println(queueRedis.Dump())
+
+	require.Equal(t, 1, int(successCount))
+	require.Equal(t, iterations-1, int(errCount))
+
+	require.Len(t, successMetaIDs, 1)
+
+	require.Equal(t, 1, int(testLifecycle.scheduledCtr))
+	require.Len(t, testLifecycle.runIDs, 1)
+
+	// This is expected: One could reach the state creation earlier, BUT: the run ID must diverge
+	// require.Equal(t, testLifecycle.evtIDs[0], successEventIDs[0])
+
+	for _, d := range successMetaIDs {
+		require.Equal(t, testLifecycle.runIDs[0], d)
+	}
+
+	require.Equal(t, fakeRunID, testLifecycle.runIDs[0])
+
+}

--- a/tests/golang/event_idempotency_test.go
+++ b/tests/golang/event_idempotency_test.go
@@ -6,22 +6,33 @@ import (
 	"testing"
 	"time"
 
+	"github.com/inngest/inngest/pkg/coreapi/graph/models"
+	"github.com/inngest/inngest/tests/client"
 	"github.com/inngest/inngestgo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestEventIdempotency(t *testing.T) {
 	ctx := context.Background()
 	r := require.New(t)
+	c := client.New(t)
 	inngestClient, server, registerFuncs := NewSDKHandler(t, "test")
 	defer server.Close()
 
-	var counter int32
+	var (
+		counter int32
+		runID   string
+	)
 	_, err := inngestgo.CreateFunction(
 		inngestClient,
 		inngestgo.FunctionOpts{ID: "test"},
 		inngestgo.EventTrigger("test", nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+			if runID == "" {
+				runID = input.InputCtx.RunID
+			}
+
 			atomic.AddInt32(&counter, 1)
 			return nil, nil
 		},
@@ -39,9 +50,9 @@ func TestEventIdempotency(t *testing.T) {
 
 	t.Run("same ID", func(t *testing.T) {
 		// Only 1 run if multiple events have the same ID
-
-		sendEvent("abc")
-		sendEvent("abc")
+		for range 5 {
+			sendEvent("abc")
+		}
 
 		r.Eventually(func() bool {
 			return atomic.LoadInt32(&counter) == 1
@@ -51,6 +62,22 @@ func TestEventIdempotency(t *testing.T) {
 		<-time.After(100 * time.Millisecond)
 
 		r.Equal(int32(1), atomic.LoadInt32(&counter))
+
+		t.Run("trace run should have appropriate data", func(t *testing.T) {
+			run := c.WaitForRunTraces(ctx, t, &runID, client.WaitForRunTracesOptions{
+				Status:         models.FunctionStatusCompleted,
+				ChildSpanCount: 1,
+			})
+			require.False(t, run.IsBatch)
+			require.Nil(t, run.BatchCreatedAt)
+
+			t.Run("exec", func(t *testing.T) {
+				exec := run.Trace.ChildSpans[0]
+
+				assert.Equal(t, "function success", exec.Name)
+				assert.False(t, exec.IsRoot)
+			})
+		})
 	})
 
 	t.Run("different IDs", func(t *testing.T) {


### PR DESCRIPTION
## Description

There's weird case where the metadata is not overwritten as expected, causing the scheduling lifecycle hook to record the wrong run ID
Update this to make sure metadata are corrected if runIDs are different due to idempotent state creation..

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
