### PR TITLE
INN-4846 UI tweaks to events page

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
@@ -4,9 +4,9 @@ import { useEffect, useState } from 'react';
 import { SkeletonCard } from '@inngest/components/Apps/AppCard';
 import { Button } from '@inngest/components/Button';
 import { Header } from '@inngest/components/Header/Header';
+import { Info } from '@inngest/components/Info/Info';
 import { Link } from '@inngest/components/Link/Link';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
-import { RiAddLine, RiQuestionLine } from '@remixicon/react';
+import { RiAddLine } from '@remixicon/react';
 
 import AppFAQ from '@/components/Apps/AppFAQ';
 import { EmptyOnboardingCard } from '@/components/Apps/EmptyAppsCard';
@@ -17,27 +17,14 @@ import { pathCreator } from '@/utils/urls';
 import { Apps } from './Apps';
 
 const AppInfo = () => (
-  <Tooltip>
-    <TooltipTrigger>
-      <RiQuestionLine className="text-subtle h-[18px] w-[18px]" />
-    </TooltipTrigger>
-    <TooltipContent
-      side="right"
-      sideOffset={2}
-      hasArrow={false}
-      className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"
-    >
-      <div className="border-subtle border-b px-4 py-2 ">
-        Apps map directly to your products or services.
-      </div>
-
-      <div className="px-4 py-2">
-        <Link href="https://www.inngest.com/docs/apps" target="_blank">
-          Learn how apps work
-        </Link>
-      </div>
-    </TooltipContent>
-  </Tooltip>
+  <Info
+    text="Apps map directly to your products or services."
+    action={
+      <Link href="https://www.inngest.com/docs/apps" target="_blank">
+        Learn how apps work
+      </Link>
+    }
+  />
 );
 
 type LoadingState = {

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
@@ -24,6 +24,7 @@ const AppInfo = () => (
     <TooltipContent
       side="right"
       sideOffset={2}
+      hasArrow={false}
       className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"
     >
       <div className="border-subtle border-b px-4 py-2 ">

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/event-types/[eventTypeName]/layout.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/event-types/[eventTypeName]/layout.tsx
@@ -2,10 +2,13 @@
 
 import { useState } from 'react';
 import { Header } from '@inngest/components/Header/Header';
+import { Pill } from '@inngest/components/Pill/Pill';
 
 import { ActionsMenu } from '@/components/Events/ActionsMenu';
 import ArchiveEventModal from '@/components/Events/ArchiveEventModal';
 import SendEventButton from '@/components/Events/SendEventButton';
+import { useBooleanFlag } from '@/components/FeatureFlags/hooks';
+import { pathCreator } from '@/utils/urls';
 
 type EventLayoutProps = {
   children: React.ReactNode;
@@ -19,22 +22,22 @@ export default function EventLayout({
   children,
   params: { environmentSlug: envSlug, eventTypeName: eventSlug },
 }: EventLayoutProps) {
-  const eventTypesPath = `/env/${envSlug}/event-types`;
   const eventsPath = `/env/${envSlug}/event-types/${eventSlug}/events`;
-  const eventPath = `/env/${envSlug}/event-types/${eventSlug}`;
   const eventName = decodeURIComponent(eventSlug);
   const [showArchive, setShowArchive] = useState(false);
+
+  const isNewEventsEnabled = useBooleanFlag('events-pages');
 
   return (
     <>
       <Header
         breadcrumb={[
-          { text: 'Event types', href: eventTypesPath },
-          { text: eventName, href: eventPath },
+          { text: 'Event types', href: pathCreator.eventTypes({ envSlug }) },
+          { text: eventName, href: pathCreator.eventType({ envSlug, eventName }) },
         ]}
         tabs={[
           {
-            href: eventPath,
+            href: pathCreator.eventType({ envSlug, eventName }),
             children: 'Dashboard',
             exactRouteMatch: true,
           },
@@ -42,6 +45,19 @@ export default function EventLayout({
             href: eventsPath,
             children: 'Events',
           },
+          ...(isNewEventsEnabled.isReady && isNewEventsEnabled.value
+            ? [
+                {
+                  children: (
+                    <div className="m-0 flex flex-row items-center justify-start space-x-1 p-0">
+                      <div>Events</div>
+                      <Pill kind="primary">Beta</Pill>
+                    </div>
+                  ),
+                  href: pathCreator.eventTypeEvents({ envSlug, eventName }),
+                },
+              ]
+            : []),
         ]}
         action={
           <div className="flex flex-row items-center justify-end gap-x-1">

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/event-types/[eventTypeName]/new-events/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/event-types/[eventTypeName]/new-events/page.tsx
@@ -11,6 +11,7 @@ export default function Page({
       <EventsPage
         environmentSlug={envSlug}
         eventTypeNames={[decodedEventTypeName]}
+        singleEventTypePage
         showHeader={false}
       />
     </>

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/event-types/[eventTypeName]/new-events/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/event-types/[eventTypeName]/new-events/page.tsx
@@ -1,0 +1,18 @@
+import EventsPage from '@/components/Events/EventsPage';
+
+export default function Page({
+  params: { environmentSlug: envSlug, eventTypeName },
+}: {
+  params: { environmentSlug: string; eventTypeName: string };
+}) {
+  const decodedEventTypeName = decodeURIComponent(eventTypeName);
+  return (
+    <>
+      <EventsPage
+        environmentSlug={envSlug}
+        eventTypeNames={[decodedEventTypeName]}
+        showHeader={false}
+      />
+    </>
+  );
+}

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/new-events/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/new-events/page.tsx
@@ -1,96 +1,11 @@
 'use client';
 
-import { useMemo } from 'react';
-import { useRouter } from 'next/navigation';
-import { Button } from '@inngest/components/Button/Button';
-import { EventsTable } from '@inngest/components/Events/EventsTable';
-import { InternalEventsToggle } from '@inngest/components/Events/InternalEventsToggle';
-import { Header } from '@inngest/components/Header/Header';
-import { RefreshButton } from '@inngest/components/Refresh/RefreshButton';
-import { RiExternalLinkLine, RiRefreshLine } from '@remixicon/react';
+import EventsPage from '@/components/Events/EventsPage';
 
-import { useAllEventTypes } from '@/components/EventTypes/useEventTypes';
-import { EventInfo } from '@/components/Events/EventInfo';
-import { ExpandedRowActions } from '@/components/Events/ExpandedRowActions';
-import SendEventButton from '@/components/Events/SendEventButton';
-import { SendEventModal } from '@/components/Events/SendEventModal';
-import { useEventDetails, useEventPayload, useEvents } from '@/components/Events/useEvents';
-import { useReplayModal } from '@/components/Events/useReplayModal';
-import { createInternalPathCreator } from '@/components/Events/utils';
-import { useAccountFeatures } from '@/utils/useAccountFeatures';
-
-export default function EventsPage({
+export default function Page({
   params: { environmentSlug: envSlug },
 }: {
   params: { environmentSlug: string };
 }) {
-  const router = useRouter();
-  const internalPathCreator = useMemo(() => createInternalPathCreator(envSlug), [envSlug]);
-  const { isModalVisible, selectedEvent, openModal, closeModal } = useReplayModal();
-
-  const getEvents = useEvents();
-  const getEventDetails = useEventDetails();
-  const getEventPayload = useEventPayload();
-  const getEventTypes = useAllEventTypes();
-  const features = useAccountFeatures();
-
-  return (
-    <>
-      <Header
-        breadcrumb={[{ text: 'Events' }]}
-        infoIcon={<EventInfo />}
-        action={
-          <div className="flex items-center gap-1.5">
-            <RefreshButton />
-            <SendEventButton />
-            <InternalEventsToggle />
-          </div>
-        }
-      />
-      <EventsTable
-        pathCreator={internalPathCreator}
-        getEvents={getEvents}
-        getEventDetails={getEventDetails}
-        getEventPayload={getEventPayload}
-        getEventTypes={getEventTypes}
-        features={{
-          history: features.data?.history ?? 7,
-        }}
-        emptyActions={
-          <>
-            <Button
-              appearance="outlined"
-              label="Refresh"
-              onClick={() => router.refresh()}
-              icon={<RiRefreshLine />}
-              iconSide="left"
-            />
-            <Button
-              label="Go to docs"
-              href="https://www.inngest.com/docs/events"
-              target="_blank"
-              icon={<RiExternalLinkLine />}
-              iconSide="left"
-            />
-          </>
-        }
-        expandedRowActions={({ eventName, payload }) => (
-          <ExpandedRowActions
-            eventName={eventName}
-            payload={payload}
-            onReplay={openModal}
-            envSlug={envSlug}
-          />
-        )}
-      />
-      {selectedEvent && (
-        <SendEventModal
-          isOpen={isModalVisible}
-          eventName={selectedEvent.name}
-          onClose={closeModal}
-          initialData={selectedEvent.data}
-        />
-      )}
-    </>
-  );
+  return <EventsPage environmentSlug={envSlug} showHeader />;
 }

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/projects.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/projects.tsx
@@ -93,7 +93,7 @@ export default function VercelProjects({ integration }: { integration: VercelInt
                       {p.isEnabled ? 'enabled' : 'disabled'}
                     </Pill>
                   </div>
-                  <div className="mt-4 flex flex-row items-center justify-start">
+                  <div className="mt-4 flex flex-row items-center justify-start gap-1">
                     <div className="text-basis text-xl font-medium">{p.name}</div>
                     {p.deploymentProtection !== VercelDeploymentProtection.Disabled && (
                       <Info

--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/projects.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/projects.tsx
@@ -3,11 +3,11 @@
 import { useState } from 'react';
 import { Button } from '@inngest/components/Button';
 import { Card } from '@inngest/components/Card/Card';
+import { Info } from '@inngest/components/Info/Info';
 import { Link } from '@inngest/components/Link/Link';
 import { Pill } from '@inngest/components/Pill';
 import { Select } from '@inngest/components/Select/Select';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
-import { RiInformationLine, RiRefreshLine } from '@remixicon/react';
+import { RiRefreshLine } from '@remixicon/react';
 
 import { VercelDeploymentProtection, type VercelIntegration } from '@/gql/graphql';
 
@@ -96,30 +96,27 @@ export default function VercelProjects({ integration }: { integration: VercelInt
                   <div className="mt-4 flex flex-row items-center justify-start">
                     <div className="text-basis text-xl font-medium">{p.name}</div>
                     {p.deploymentProtection !== VercelDeploymentProtection.Disabled && (
-                      <Tooltip>
-                        <TooltipTrigger>
-                          <RiInformationLine className="text-accent-subtle ml-2 h-4 w-4 cursor-pointer" />
-                        </TooltipTrigger>
-                        <TooltipContent className="rounded p-0">
-                          <div className="border-subtle border">
-                            <div className="text-basis px-4 pt-2 text-sm font-medium">
+                      <Info
+                        text={
+                          <>
+                            <div className="text-sm font-medium">
                               Deployment protection is enabled
                             </div>
-                            <div className="text-muted my-2 px-4 text-sm font-normal">
+                            <div className="mt-2 text-sm font-normal">
                               Inngest may not be able to communicate with your application by
                               default.
                             </div>
-                            <div className="bg-disabled w-full px-4 py-2">
-                              <Link
-                                target="_blank"
-                                href="https://www.inngest.com/docs/deploy/vercel#bypassing-deployment-protection"
-                              >
-                                Learn more
-                              </Link>
-                            </div>
-                          </div>
-                        </TooltipContent>
-                      </Tooltip>
+                          </>
+                        }
+                        action={
+                          <Link
+                            target="_blank"
+                            href="https://www.inngest.com/docs/deploy/vercel#bypassing-deployment-protection"
+                          >
+                            Learn more
+                          </Link>
+                        }
+                      />
                     )}
                   </div>
                   <div className="text-muted mt-2 text-base font-normal leading-snug">

--- a/ui/apps/dashboard/src/components/EventTypes/EventTypesInfo.tsx
+++ b/ui/apps/dashboard/src/components/EventTypes/EventTypesInfo.tsx
@@ -9,6 +9,7 @@ export const EventTypesInfo = () => (
     </TooltipTrigger>
     <TooltipContent
       side="right"
+      hasArrow={false}
       sideOffset={2}
       className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"
     >

--- a/ui/apps/dashboard/src/components/EventTypes/EventTypesInfo.tsx
+++ b/ui/apps/dashboard/src/components/EventTypes/EventTypesInfo.tsx
@@ -1,27 +1,13 @@
+import { Info } from '@inngest/components/Info/Info';
 import { Link } from '@inngest/components/Link/Link';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
-import { RiQuestionLine } from '@remixicon/react';
 
 export const EventTypesInfo = () => (
-  <Tooltip>
-    <TooltipTrigger>
-      <RiQuestionLine className="text-subtle h-[18px] w-[18px]" />
-    </TooltipTrigger>
-    <TooltipContent
-      side="right"
-      hasArrow={false}
-      sideOffset={2}
-      className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"
-    >
-      <div className="border-subtle border-b px-4 py-2 ">
-        List of all Inngest event types in the current environment.
-      </div>
-
-      <div className="px-4 py-2">
-        <Link href={'https://www.inngest.com/docs/events'} target="_blank">
-          Learn how events work
-        </Link>
-      </div>
-    </TooltipContent>
-  </Tooltip>
+  <Info
+    text="List of all Inngest event types in the current environment."
+    action={
+      <Link href={'https://www.inngest.com/docs/events'} target="_blank">
+        Learn how events work
+      </Link>
+    }
+  />
 );

--- a/ui/apps/dashboard/src/components/Events/EventInfo.tsx
+++ b/ui/apps/dashboard/src/components/Events/EventInfo.tsx
@@ -8,6 +8,7 @@ export const EventInfo = () => (
       <RiQuestionLine className="text-subtle h-[18px] w-[18px]" />
     </TooltipTrigger>
     <TooltipContent
+      hasArrow={false}
       side="right"
       sideOffset={2}
       className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"

--- a/ui/apps/dashboard/src/components/Events/EventInfo.tsx
+++ b/ui/apps/dashboard/src/components/Events/EventInfo.tsx
@@ -1,27 +1,13 @@
+import { Info } from '@inngest/components/Info/Info';
 import { Link } from '@inngest/components/Link/Link';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
-import { RiQuestionLine } from '@remixicon/react';
 
 export const EventInfo = () => (
-  <Tooltip>
-    <TooltipTrigger>
-      <RiQuestionLine className="text-subtle h-[18px] w-[18px]" />
-    </TooltipTrigger>
-    <TooltipContent
-      hasArrow={false}
-      side="right"
-      sideOffset={2}
-      className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"
-    >
-      <div className="border-subtle border-b px-4 py-2 ">
-        List of all Inngest events in the current environment.
-      </div>
-
-      <div className="px-4 py-2">
-        <Link href={'https://www.inngest.com/docs/events'} target="_blank">
-          Learn how events work
-        </Link>
-      </div>
-    </TooltipContent>
-  </Tooltip>
+  <Info
+    text="List of all Inngest events in the current environment."
+    action={
+      <Link href={'https://www.inngest.com/docs/events'} target="_blank">
+        Learn how events work
+      </Link>
+    }
+  />
 );

--- a/ui/apps/dashboard/src/components/Events/EventsPage.tsx
+++ b/ui/apps/dashboard/src/components/Events/EventsPage.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@inngest/components/Button/Button';
+import { EventsTable } from '@inngest/components/Events/EventsTable';
+import { InternalEventsToggle } from '@inngest/components/Events/InternalEventsToggle';
+import { Header } from '@inngest/components/Header/Header';
+import { RefreshButton } from '@inngest/components/Refresh/RefreshButton';
+import { RiExternalLinkLine, RiRefreshLine } from '@remixicon/react';
+
+import { useAllEventTypes } from '@/components/EventTypes/useEventTypes';
+import { EventInfo } from '@/components/Events/EventInfo';
+import { ExpandedRowActions } from '@/components/Events/ExpandedRowActions';
+import SendEventButton from '@/components/Events/SendEventButton';
+import { SendEventModal } from '@/components/Events/SendEventModal';
+import { useEventDetails, useEventPayload, useEvents } from '@/components/Events/useEvents';
+import { useReplayModal } from '@/components/Events/useReplayModal';
+import { createInternalPathCreator } from '@/components/Events/utils';
+import { useAccountFeatures } from '@/utils/useAccountFeatures';
+
+export default function EventsPage({
+  environmentSlug: envSlug,
+  eventTypeNames,
+  showHeader = true,
+}: {
+  environmentSlug: string;
+  eventTypeNames?: string[];
+  showHeader?: boolean;
+}) {
+  const router = useRouter();
+  const internalPathCreator = useMemo(() => createInternalPathCreator(envSlug), [envSlug]);
+  const { isModalVisible, selectedEvent, openModal, closeModal } = useReplayModal();
+
+  const getEvents = useEvents();
+  const getEventDetails = useEventDetails();
+  const getEventPayload = useEventPayload();
+  const getEventTypes = useAllEventTypes();
+  const features = useAccountFeatures();
+
+  return (
+    <>
+      {showHeader && (
+        <Header
+          breadcrumb={[{ text: 'Events' }]}
+          infoIcon={<EventInfo />}
+          action={
+            <div className="flex items-center gap-1.5">
+              <RefreshButton />
+              <SendEventButton />
+              <InternalEventsToggle />
+            </div>
+          }
+        />
+      )}
+      <EventsTable
+        pathCreator={internalPathCreator}
+        getEvents={getEvents}
+        getEventDetails={getEventDetails}
+        getEventPayload={getEventPayload}
+        getEventTypes={getEventTypes}
+        eventNames={eventTypeNames}
+        features={{
+          history: features.data?.history ?? 7,
+        }}
+        emptyActions={
+          <>
+            <Button
+              appearance="outlined"
+              label="Refresh"
+              onClick={() => router.refresh()}
+              icon={<RiRefreshLine />}
+              iconSide="left"
+            />
+            <Button
+              label="Go to docs"
+              href="https://www.inngest.com/docs/events"
+              target="_blank"
+              icon={<RiExternalLinkLine />}
+              iconSide="left"
+            />
+          </>
+        }
+        expandedRowActions={({ eventName, payload }) => (
+          <ExpandedRowActions
+            eventName={eventName}
+            payload={payload}
+            onReplay={openModal}
+            envSlug={envSlug}
+          />
+        )}
+      />
+      {selectedEvent && (
+        <SendEventModal
+          isOpen={isModalVisible}
+          eventName={selectedEvent.name}
+          onClose={closeModal}
+          initialData={selectedEvent.data}
+        />
+      )}
+    </>
+  );
+}

--- a/ui/apps/dashboard/src/components/Events/EventsPage.tsx
+++ b/ui/apps/dashboard/src/components/Events/EventsPage.tsx
@@ -23,10 +23,12 @@ export default function EventsPage({
   environmentSlug: envSlug,
   eventTypeNames,
   showHeader = true,
+  singleEventTypePage = false,
 }: {
   environmentSlug: string;
   eventTypeNames?: string[];
   showHeader?: boolean;
+  singleEventTypePage?: boolean;
 }) {
   const router = useRouter();
   const internalPathCreator = useMemo(() => createInternalPathCreator(envSlug), [envSlug]);
@@ -60,6 +62,7 @@ export default function EventsPage({
         getEventPayload={getEventPayload}
         getEventTypes={getEventTypes}
         eventNames={eventTypeNames}
+        singleEventTypePage={singleEventTypePage}
         features={{
           history: features.data?.history ?? 7,
         }}

--- a/ui/apps/dashboard/src/components/Functions/FunctionInfo.tsx
+++ b/ui/apps/dashboard/src/components/Functions/FunctionInfo.tsx
@@ -10,6 +10,7 @@ export const FunctionInfo = () => (
     <TooltipContent
       side="right"
       sideOffset={2}
+      hasArrow={false}
       className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"
     >
       <div className="border-subtle border-b px-4 py-2 ">

--- a/ui/apps/dashboard/src/components/Functions/FunctionInfo.tsx
+++ b/ui/apps/dashboard/src/components/Functions/FunctionInfo.tsx
@@ -1,27 +1,13 @@
+import { Info } from '@inngest/components/Info/Info';
 import { Link } from '@inngest/components/Link/Link';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
-import { RiQuestionLine } from '@remixicon/react';
 
 export const FunctionInfo = () => (
-  <Tooltip>
-    <TooltipTrigger>
-      <RiQuestionLine className="text-subtle h-[18px] w-[18px]" />
-    </TooltipTrigger>
-    <TooltipContent
-      side="right"
-      sideOffset={2}
-      hasArrow={false}
-      className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"
-    >
-      <div className="border-subtle border-b px-4 py-2 ">
-        List of all Inngest functions in the current environment.
-      </div>
-
-      <div className="px-4 py-2">
-        <Link href={'https://www.inngest.com/docs/functions'} target="_blank">
-          Learn how to create a function
-        </Link>
-      </div>
-    </TooltipContent>
-  </Tooltip>
+  <Info
+    text="List of all Inngest functions in the current environment."
+    action={
+      <Link href={'https://www.inngest.com/docs/functions'} target="_blank">
+        Learn how to create a function
+      </Link>
+    }
+  />
 );

--- a/ui/apps/dashboard/src/components/Manage/EventKeyInfo.tsx
+++ b/ui/apps/dashboard/src/components/Manage/EventKeyInfo.tsx
@@ -10,6 +10,7 @@ export const EventKeyInfo = () => (
     <TooltipContent
       side="right"
       sideOffset={2}
+      hasArrow={false}
       className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"
     >
       <div className="border-subtle border-b px-4 py-2 ">

--- a/ui/apps/dashboard/src/components/Manage/EventKeyInfo.tsx
+++ b/ui/apps/dashboard/src/components/Manage/EventKeyInfo.tsx
@@ -1,27 +1,13 @@
+import { Info } from '@inngest/components/Info/Info';
 import { Link } from '@inngest/components/Link/Link';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
-import { RiQuestionLine } from '@remixicon/react';
 
 export const EventKeyInfo = () => (
-  <Tooltip>
-    <TooltipTrigger>
-      <RiQuestionLine className="text-subtle h-[18px] w-[18px]" />
-    </TooltipTrigger>
-    <TooltipContent
-      side="right"
-      sideOffset={2}
-      hasArrow={false}
-      className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"
-    >
-      <div className="border-subtle border-b px-4 py-2 ">
-        Event keys are unique keys that allow applications to send Inngest events.
-      </div>
-
-      <div className="px-4 py-2">
-        <Link href={'https://www.inngest.com/docs/events/creating-an-event-key'} target="_blank">
-          Learn more
-        </Link>
-      </div>
-    </TooltipContent>
-  </Tooltip>
+  <Info
+    text="Event keys are unique keys that allow applications to send Inngest events."
+    action={
+      <Link href={'https://www.inngest.com/docs/events/creating-an-event-key'} target="_blank">
+        Learn more
+      </Link>
+    }
+  />
 );

--- a/ui/apps/dashboard/src/components/Manage/SigningKeyInfo.tsx
+++ b/ui/apps/dashboard/src/components/Manage/SigningKeyInfo.tsx
@@ -1,28 +1,14 @@
+import { Info } from '@inngest/components/Info/Info';
 import { Link } from '@inngest/components/Link/Link';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
-import { RiQuestionLine } from '@remixicon/react';
 
 export const SigningKeyInfo = () => (
-  <Tooltip>
-    <TooltipTrigger>
-      <RiQuestionLine className="text-subtle h-[18px] w-[18px]" />
-    </TooltipTrigger>
-    <TooltipContent
-      side="right"
-      sideOffset={2}
-      hasArrow={false}
-      className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"
-    >
-      <div className="border-subtle border-b px-4 py-2 ">
-        Use the secret signing key with the Inngest SDK to enable us securely communicate with your
-        application.
-      </div>
-
-      <div className="px-4 py-2">
-        <Link href={'https://www.inngest.com/docs/platform/signing-keys'} target="_blank">
-          Learn how create a webhook
-        </Link>
-      </div>
-    </TooltipContent>
-  </Tooltip>
+  <Info
+    text="Use the secret signing key with the Inngest SDK to enable us securely communicate with your
+        application."
+    action={
+      <Link href={'https://www.inngest.com/docs/platform/signing-keys'} target="_blank">
+        Learn how create a webhook
+      </Link>
+    }
+  />
 );

--- a/ui/apps/dashboard/src/components/Manage/SigningKeyInfo.tsx
+++ b/ui/apps/dashboard/src/components/Manage/SigningKeyInfo.tsx
@@ -10,6 +10,7 @@ export const SigningKeyInfo = () => (
     <TooltipContent
       side="right"
       sideOffset={2}
+      hasArrow={false}
       className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"
     >
       <div className="border-subtle border-b px-4 py-2 ">

--- a/ui/apps/dashboard/src/components/Manage/WebhookInfo.tsx
+++ b/ui/apps/dashboard/src/components/Manage/WebhookInfo.tsx
@@ -1,25 +1,13 @@
+import { Info } from '@inngest/components/Info/Info';
 import { Link } from '@inngest/components/Link/Link';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
-import { RiQuestionLine } from '@remixicon/react';
 
 export const WebhookInfo = () => (
-  <Tooltip>
-    <TooltipTrigger>
-      <RiQuestionLine className="text-subtle h-[18px] w-[18px]" />
-    </TooltipTrigger>
-    <TooltipContent
-      side="right"
-      sideOffset={2}
-      hasArrow={false}
-      className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"
-    >
-      <div className="border-subtle border-b px-4 py-2 ">Sources for events for developers.</div>
-
-      <div className="px-4 py-2">
-        <Link href={'https://www.inngest.com/docs/platform/webhooks'} target="_blank">
-          Learn how create a webhook
-        </Link>
-      </div>
-    </TooltipContent>
-  </Tooltip>
+  <Info
+    text="Sources for events for developers."
+    action={
+      <Link href={'https://www.inngest.com/docs/platform/webhooks'} target="_blank">
+        Learn how create a webhook
+      </Link>
+    }
+  />
 );

--- a/ui/apps/dashboard/src/components/Manage/WebhookInfo.tsx
+++ b/ui/apps/dashboard/src/components/Manage/WebhookInfo.tsx
@@ -10,6 +10,7 @@ export const WebhookInfo = () => (
     <TooltipContent
       side="right"
       sideOffset={2}
+      hasArrow={false}
       className="border-muted text-muted mt-6 flex flex-col rounded-md border p-0 text-sm"
     >
       <div className="border-subtle border-b px-4 py-2 ">Sources for events for developers.</div>

--- a/ui/apps/dashboard/src/components/Navigation/OnboardingWidget.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/OnboardingWidget.tsx
@@ -84,7 +84,7 @@ export default function OnboardingWidget({
                       }}
                     />
                   </TooltipTrigger>
-                  <TooltipContent side="right" className="dark max-w-40">
+                  <TooltipContent side="right" className="max-w-40">
                     <p>{onboardingWidgetContent.tooltip.close}</p>
                   </TooltipContent>
                 </Tooltip>

--- a/ui/apps/dashboard/src/components/Navigation/QuickSearch/QuickSearch.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/QuickSearch/QuickSearch.tsx
@@ -49,12 +49,7 @@ export function QuickSearch({ collapsed, envSlug, envName }: Props) {
             />
           </TooltipTrigger>
 
-          <TooltipContent
-            className="border-muted text-muted mt-1 w-32 rounded border text-xs"
-            hasArrow={false}
-            side="bottom"
-            sideOffset={2}
-          >
+          <TooltipContent className="w-32 rounded text-xs" side="bottom" sideOffset={2}>
             You can also use <span className="font-bold">⌘ K</span> or{' '}
             <span className="font-bold">Ctrl K</span> to search
           </TooltipContent>

--- a/ui/apps/dashboard/src/components/Navigation/QuickSearch/QuickSearch.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/QuickSearch/QuickSearch.tsx
@@ -50,7 +50,8 @@ export function QuickSearch({ collapsed, envSlug, envName }: Props) {
           </TooltipTrigger>
 
           <TooltipContent
-            className="border-muted text-muted w-32 rounded border text-xs"
+            className="border-muted text-muted mt-1 w-32 rounded border text-xs"
+            hasArrow={false}
             side="bottom"
             sideOffset={2}
           >

--- a/ui/apps/dashboard/src/utils/urls.ts
+++ b/ui/apps/dashboard/src/utils/urls.ts
@@ -52,6 +52,7 @@ export const pathCreator = {
   createApp({ envSlug }: { envSlug: string }): Route {
     return `/env/${envSlug}/apps/sync-new` as Route;
   },
+  // TODO: use eventPopout instead once we release new events
   event({
     envSlug,
     eventName,
@@ -65,6 +66,7 @@ export const pathCreator = {
       eventName
     )}/events/${eventID}` as Route;
   },
+  // TODO: rename new-events to events and adjust redirect once we release new events
   eventPopout({ envSlug, eventID }: { envSlug: string; eventID: string }): Route {
     return `/env/${envSlug}/new-events/${eventID}` as Route;
   },
@@ -73,6 +75,10 @@ export const pathCreator = {
   },
   eventTypes({ envSlug }: { envSlug: string }): Route {
     return `/env/${envSlug}/event-types` as Route;
+  },
+  // TODO: rename new-events to events once we release new events
+  eventTypeEvents({ envSlug, eventName }: { envSlug: string; eventName: string }): Route {
+    return `/env/${envSlug}/event-types/${encodeURIComponent(eventName)}/new-events` as Route;
   },
   envs(): Route {
     return '/env' as Route;

--- a/ui/packages/components/src/AppRoot/globals.css
+++ b/ui/packages/components/src/AppRoot/globals.css
@@ -74,6 +74,7 @@ input[type='number'] {
     /* Carbon Colors */
     --color-carbon-0: 254 254 254;
     --color-carbon-50: 246 246 246;
+    --color-carbon-75: 240 240 240;
     --color-carbon-100: 226 226 226;
     --color-carbon-200: 204 204 204;
     --color-carbon-300: 176 176 176;
@@ -187,6 +188,7 @@ input[type='number'] {
     --color-background-btn-dangerHover: var(--color-ruby-800);
     --color-background-btn-dangerPressed: var(--color-ruby-900);
     --color-background-btn-dangerDisabled: var(--color-ruby-300);
+    --color-background-tableHeader: var(--color-carbon-75);
 
     --color-border-light: var(--color-carbon-50);
     --color-border-subtle: var(--color-carbon-100);
@@ -294,7 +296,7 @@ input[type='number'] {
     --color-background-warningContrast: var(--color-honey-100);
     --color-background-info: var(--color-breeze-900);
     --color-background-infoContrast: var(--color-breeze-100);
-    --color-background-codeEditor: var(--color-carbon-900);
+    --color-background-codeEditor: var(--color-carbon-950);
     --color-background-btn-primary: var(--color-matcha-600);
     --color-background-btn-primaryHover: var(--color-matcha-700);
     --color-background-btn-primaryPressed: var(--color-matcha-900);
@@ -303,6 +305,7 @@ input[type='number'] {
     --color-background-btn-dangerHover: var(--color-ruby-800);
     --color-background-btn-dangerPressed: var(--color-ruby-900);
     --color-background-btn-dangerDisabled: var(--color-ruby-300);
+    --color-background-tableHeader: var(--color-carbon-900);
 
     --color-border-light: var(--color-carbon-950);
     --color-border-subtle: var(--color-carbon-800);

--- a/ui/packages/components/src/Events/EventDetails.tsx
+++ b/ui/packages/components/src/Events/EventDetails.tsx
@@ -2,8 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import NextLink from 'next/link';
-import { Skeleton } from '@inngest/components/Skeleton';
 import { ErrorCard } from '@inngest/components/Error/ErrorCard';
+import { Skeleton } from '@inngest/components/Skeleton';
 import { Time } from '@inngest/components/Time';
 import { usePrettyJson } from '@inngest/components/hooks/usePrettyJson';
 import { type Event } from '@inngest/components/types/event';
@@ -167,7 +167,7 @@ export function EventDetails({
           <div ref={eventInfoRef} className="flex flex-col">
             <div className="mb-3 flex h-8 items-center justify-between gap-1 px-4">
               <div className="flex items-center gap-2">
-                <p className="text-muted text-sm">{eventName}</p>
+                <p className="text-basis text-base">{eventName}</p>
                 {!standalone && (
                   <Link
                     size="medium"

--- a/ui/packages/components/src/Events/EventsTable.tsx
+++ b/ui/packages/components/src/Events/EventsTable.tsx
@@ -43,6 +43,7 @@ export function EventsTable({
   getEventDetails,
   getEventPayload,
   getEventTypes,
+  eventNames,
   pathCreator,
   emptyActions,
   expandedRowActions,
@@ -82,6 +83,7 @@ export function EventsTable({
   getEventDetails: ({ eventID }: { eventID: string }) => Promise<Event>;
   getEventPayload: ({ eventID }: { eventID: string }) => Promise<Pick<Event, 'payload'>>;
   getEventTypes: () => Promise<Required<Pick<EventType, 'name' | 'id'>>[]>;
+  eventNames?: string[];
   features: Pick<Features, 'history'>;
   standalone?: boolean;
 }) {
@@ -128,7 +130,7 @@ export function EventsTable({
     queryKey: [
       'events',
       {
-        eventNames: filteredEvent,
+        eventNames: filteredEvent || eventNames || null,
         source,
         startTime: calculatedStartTime.toISOString(),
         endTime: endTime ?? null,
@@ -139,7 +141,7 @@ export function EventsTable({
     queryFn: ({ pageParam }: { pageParam: string | null }) =>
       getEvents({
         cursor: pageParam,
-        eventNames: filteredEvent ?? null,
+        eventNames: filteredEvent ?? eventNames ?? null,
         source,
         startTime: calculatedStartTime.toISOString(),
         endTime: endTime ?? null,

--- a/ui/packages/components/src/Events/EventsTable.tsx
+++ b/ui/packages/components/src/Events/EventsTable.tsx
@@ -44,6 +44,7 @@ export function EventsTable({
   getEventPayload,
   getEventTypes,
   eventNames,
+  singleEventTypePage,
   pathCreator,
   emptyActions,
   expandedRowActions,
@@ -84,10 +85,11 @@ export function EventsTable({
   getEventPayload: ({ eventID }: { eventID: string }) => Promise<Pick<Event, 'payload'>>;
   getEventTypes: () => Promise<Required<Pick<EventType, 'name' | 'id'>>[]>;
   eventNames?: string[];
+  singleEventTypePage?: boolean;
   features: Pick<Features, 'history'>;
   standalone?: boolean;
 }) {
-  const columns = useColumns({ pathCreator });
+  const columns = useColumns({ pathCreator, singleEventTypePage });
   const [showSearch, setShowSearch] = useState(false);
   const [lastDays] = useSearchParam('last');
   const [startTime] = useSearchParam('start');

--- a/ui/packages/components/src/Events/EventsTable.tsx
+++ b/ui/packages/components/src/Events/EventsTable.tsx
@@ -159,11 +159,23 @@ export function EventsTable({
       totalCount: data.pages[data.pages.length - 1]?.totalCount ?? 0,
     }),
   });
+  /* TODO: Find out what to do with the event types filter, since it will affect performance */
 
-  const { data: eventTypesData } = useQuery({
-    queryKey: ['event-types'],
-    queryFn: () => getEventTypes(),
-  });
+  // const { data: eventTypesData } = useQuery({
+  //   queryKey: ['event-types'],
+  //   queryFn: () => getEventTypes(),
+  // });
+
+  // const onEventFilterChange = useCallback(
+  //   (value: string[]) => {
+  //     if (value.length > 0) {
+  //       setFilteredEvent(value);
+  //     } else {
+  //       removeFilteredEvent();
+  //     }
+  //   },
+  //   [removeFilteredEvent, setFilteredEvent]
+  // );
 
   const onSearchChange = useCallback(
     (value: string) => {
@@ -174,17 +186,6 @@ export function EventsTable({
       }
     },
     [setSearch, removeSearch]
-  );
-
-  const onEventFilterChange = useCallback(
-    (value: string[]) => {
-      if (value.length > 0) {
-        setFilteredEvent(value);
-      } else {
-        removeFilteredEvent();
-      }
-    },
-    [removeFilteredEvent, setFilteredEvent]
   );
 
   const onDaysChange = useCallback(
@@ -239,13 +240,12 @@ export function EventsTable({
       <div className="bg-canvasBase sticky top-0 z-10">
         <div className="m-3 flex items-center justify-between gap-2">
           <div className="flex items-center gap-2">
-            {/* TODO: Wire entity */}
-            <EntityFilter
+            {/* <EntityFilter
               type="event"
               onFilterChange={onEventFilterChange}
               selectedEntities={filteredEvent ?? []}
               entities={eventTypesData ?? []}
-            />
+            /> */}
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button

--- a/ui/packages/components/src/Events/columns.tsx
+++ b/ui/packages/components/src/Events/columns.tsx
@@ -31,8 +31,8 @@ export function useColumns({
         const receivedAt = info.getValue();
         return <TimeCell date={receivedAt} />;
       },
+      size: 200,
       header: 'Received at',
-      maxSize: 400,
       enableSorting: false,
       id: ensureColumnID('receivedAt'),
     }),
@@ -41,8 +41,8 @@ export function useColumns({
         const name = info.getValue();
         return <TextCell>{name}</TextCell>;
       },
+      size: 300,
       header: 'Event name',
-      maxSize: 400,
       enableSorting: false,
       id: ensureColumnID('name'),
     }),
@@ -82,6 +82,7 @@ export function useColumns({
           />
         );
       },
+      size: 500,
       header: 'Functions triggered',
       enableSorting: false,
       id: ensureColumnID('runs'),

--- a/ui/packages/components/src/Events/columns.tsx
+++ b/ui/packages/components/src/Events/columns.tsx
@@ -22,8 +22,10 @@ function ensureColumnID(id: ColumnID): ColumnID {
 
 export function useColumns({
   pathCreator,
+  singleEventTypePage,
 }: {
   pathCreator: React.ComponentProps<typeof EventsTable>['pathCreator'];
+  singleEventTypePage: React.ComponentProps<typeof EventsTable>['singleEventTypePage'];
 }) {
   const columns = [
     columnHelper.accessor('receivedAt', {
@@ -36,16 +38,20 @@ export function useColumns({
       enableSorting: false,
       id: ensureColumnID('receivedAt'),
     }),
-    columnHelper.accessor('name', {
-      cell: (info) => {
-        const name = info.getValue();
-        return <TextCell>{name}</TextCell>;
-      },
-      size: 300,
-      header: 'Event name',
-      enableSorting: false,
-      id: ensureColumnID('name'),
-    }),
+    ...(!singleEventTypePage
+      ? [
+          columnHelper.accessor('name', {
+            cell: (info) => {
+              const name = info.getValue();
+              return <TextCell>{name}</TextCell>;
+            },
+            size: 300,
+            header: 'Event name',
+            enableSorting: false,
+            id: ensureColumnID('name'),
+          }),
+        ]
+      : []),
     columnHelper.accessor('runs', {
       cell: (info) => {
         const runs = info.getValue();

--- a/ui/packages/components/src/Info/Info.tsx
+++ b/ui/packages/components/src/Info/Info.tsx
@@ -1,21 +1,21 @@
 import type { ReactNode } from 'react';
 import { RiQuestionLine } from '@remixicon/react';
 
-import { Tooltip, TooltipContent, TooltipTrigger } from '../Tooltip';
+import { Popover, PopoverContent, PopoverTrigger } from '../Popover';
 
 export const Info = ({ text, action }: { text: string; action: ReactNode }) => (
-  <Tooltip>
-    <TooltipTrigger>
+  <Popover>
+    <PopoverTrigger>
       <RiQuestionLine className="text-subtle h-[18px] w-[18px]" />
-    </TooltipTrigger>
-    <TooltipContent
+    </PopoverTrigger>
+    <PopoverContent
       side="right"
-      sideOffset={2}
-      className="border-subtle text-subtle mt-6 flex flex-col rounded-md border p-0 text-sm leading-tight"
+      align="start"
+      className="text-subtle flex max-w-xs flex-col text-sm leading-tight"
     >
-      <div className="border-subtle text-subtle border-b p-3 text-sm leading-tight">{text}</div>
+      <div className="border-subtle border-b px-4 py-2 text-sm leading-tight">{text}</div>
 
-      <div className="p-3">{action}</div>
-    </TooltipContent>
-  </Tooltip>
+      <div className="px-4 py-2">{action}</div>
+    </PopoverContent>
+  </Popover>
 );

--- a/ui/packages/components/src/Info/Info.tsx
+++ b/ui/packages/components/src/Info/Info.tsx
@@ -1,9 +1,11 @@
+'use client';
+
 import type { ReactNode } from 'react';
 import { RiQuestionLine } from '@remixicon/react';
 
 import { Popover, PopoverContent, PopoverTrigger } from '../Popover';
 
-export const Info = ({ text, action }: { text: string; action: ReactNode }) => (
+export const Info = ({ text, action }: { text: string | ReactNode; action: ReactNode }) => (
   <Popover>
     <PopoverTrigger>
       <RiQuestionLine className="text-subtle h-[18px] w-[18px]" />

--- a/ui/packages/components/src/Pill/Pill.tsx
+++ b/ui/packages/components/src/Pill/Pill.tsx
@@ -104,7 +104,7 @@ export function Pill({
       {isTruncated ? (
         <Tooltip delayDuration={0}>
           <TooltipTrigger asChild>{pillWrapper}</TooltipTrigger>
-          <TooltipContent sideOffset={5} className="text-muted p-2 text-xs" side="bottom">
+          <TooltipContent sideOffset={5} className="p-2 text-xs" side="bottom">
             {tooltipText}
           </TooltipContent>
         </Tooltip>

--- a/ui/packages/components/src/Popover/Popover.tsx
+++ b/ui/packages/components/src/Popover/Popover.tsx
@@ -18,7 +18,7 @@ export const PopoverContent = forwardRef<
         sideOffset={5}
         ref={forwardedRef}
         className={cn(
-          'bg-canvasBase border-muted shadow-primary z-[100] max-h-[var(--radix-popover-content-available-height)] overflow-y-auto overflow-x-hidden rounded border',
+          'bg-canvasBase border-muted z-[100] max-h-[var(--radix-popover-content-available-height)] overflow-y-auto overflow-x-hidden rounded border',
           className
         )}
         {...props}

--- a/ui/packages/components/src/RunDetailsV3/InlineSpans.tsx
+++ b/ui/packages/components/src/RunDetailsV3/InlineSpans.tsx
@@ -115,11 +115,11 @@ function Times({
     <>
       <p className="mb-2 font-bold">{name}</p>
       <div className="flex gap-16">
-        <ElementWrapper className="w-fit" label="Duration">
+        <ElementWrapper className="[&>dt]:text-light w-fit" label="Duration">
           {duration > 0 ? formatDuration(duration) : '-'}
         </ElementWrapper>
 
-        <ElementWrapper className="w-fit" label="Delay">
+        <ElementWrapper className="[&>dt]:text-light w-fit" label="Delay">
           {isDelayVisible && delay > 0 ? formatDuration(delay) : '-'}
         </ElementWrapper>
       </div>

--- a/ui/packages/components/src/RunDetailsV3/InlineSpans.tsx
+++ b/ui/packages/components/src/RunDetailsV3/InlineSpans.tsx
@@ -83,7 +83,7 @@ export function InlineSpans({ className, minTime, maxTime, trace }: Props) {
         <div className="bg-canvasMuted h-0" style={{ flexGrow: widths.after }} />
       </div>
       <TooltipContent>
-        <div className="text-basis">
+        <div>
           <Times isDelayVisible={spans.length === 0} name={spanName} span={trace} />
         </div>
       </TooltipContent>

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -274,7 +274,7 @@ export function RunsPage({
   return (
     <main className="bg-canvasBase text-basis no-scrollbar flex-1 overflow-hidden focus-visible:outline-none">
       <div className="bg-canvasBase sticky top-0 z-10 flex flex-col">
-        <div className="border-subtle flex h-[58px] items-center justify-between gap-2 border-b px-3">
+        <div className="flex h-[58px] items-center justify-between gap-2 px-3">
           <div className="flex items-center gap-2">
             <SelectGroup>
               <TimeFieldFilter

--- a/ui/packages/components/src/RunsPage/RunsTable.tsx
+++ b/ui/packages/components/src/RunsPage/RunsTable.tsx
@@ -89,7 +89,7 @@ export default function RunsTable({
   });
 
   const tableStyles = 'w-full';
-  const tableHeadStyles = 'bg-canvasSubtle sticky top-0 z-[2]';
+  const tableHeadStyles = 'bg-tableHeader sticky top-0 z-[2]';
   const tableBodyStyles = 'divide-y divide-light';
   const tableColumnStyles = 'px-4';
 
@@ -141,7 +141,7 @@ export default function RunsTable({
             <Fragment key={row.original.id}>
               <tr
                 key={row.original.id}
-                className="hover:bg-canvasSubtle/40 h-[42px] cursor-pointer"
+                className="hover:bg-canvasSubtle h-[42px] cursor-pointer"
                 onClick={() => {
                   if (expandedRunIDs.includes(row.original.id)) {
                     setExpandedRunIDs((prev) => {

--- a/ui/packages/components/src/Table/Cell.tsx
+++ b/ui/packages/components/src/Table/Cell.tsx
@@ -83,11 +83,11 @@ export function NumberCell({ value, term }: { value: number; term?: string }) {
       </TooltipTrigger>
       <TooltipContent
         sideOffset={5}
-        className="text-muted flex items-baseline gap-0.5 p-2 text-xs"
+        className="flex items-baseline gap-0.5 p-2 text-xs"
         side="right"
       >
-        <span className="text-basis text-sm font-medium">{Intl.NumberFormat().format(value)}</span>
-        {term && <span className="text-subtle text-[11px]">{term}</span>}
+        <span className="text-sm font-medium">{Intl.NumberFormat().format(value)}</span>
+        {term && <span className="text-[11px]">{term}</span>}
       </TooltipContent>
     </Tooltip>
   );

--- a/ui/packages/components/src/Table/Cell.tsx
+++ b/ui/packages/components/src/Table/Cell.tsx
@@ -50,7 +50,7 @@ export function PillCell({
 export function TimeCell({ date, format }: { date: Date | string; format?: 'relative' }) {
   return (
     <span className={cn(cellStyles, 'text-muted font-medium')}>
-      <Time value={date} format={format} />
+      <Time value={date} format={format} copyable={false} />
     </span>
   );
 }

--- a/ui/packages/components/src/Table/NewTable.tsx
+++ b/ui/packages/components/src/Table/NewTable.tsx
@@ -162,7 +162,7 @@ export default function Table<T>({
                   className={cn(
                     hasId(row.original) && expandedIDs.includes(row.original.id)
                       ? 'h-[42px]'
-                      : 'border-light h-[42px] border-b',
+                      : 'border-light box-border h-[42px] border-b',
                     onRowClick ? 'hover:bg-canvasSubtle/40 cursor-pointer' : ''
                   )}
                   onClick={() => {
@@ -182,7 +182,12 @@ export default function Table<T>({
                           width: cell.column.getSize(),
                           maxWidth: cell.column.getSize(),
                         }}
-                        className={cn(isIconOnlyColumn ? '' : tableColumnStyles)}
+                        className={cn(
+                          i === 0 && hasId(row.original) && expandedIDs.includes(row.original.id)
+                            ? expandedRowSideBorder
+                            : '',
+                          isIconOnlyColumn ? '' : tableColumnStyles
+                        )}
                       >
                         {flexRender(cell.column.columnDef.cell, cell.getContext())}
                       </td>

--- a/ui/packages/components/src/Table/NewTable.tsx
+++ b/ui/packages/components/src/Table/NewTable.tsx
@@ -88,7 +88,7 @@ export default function Table<T>({
   });
 
   const tableStyles = 'w-full';
-  const tableHeadStyles = 'bg-canvasSubtle sticky top-0 z-[2]';
+  const tableHeadStyles = 'bg-tableHeader sticky top-0 z-[2]';
   const tableColumnStyles = 'px-4';
   const expandedRowSideBorder =
     'before:bg-surfaceMuted relative before:absolute before:bottom-0 before:left-0 before:top-0 before:w-0.5';
@@ -163,7 +163,7 @@ export default function Table<T>({
                     hasId(row.original) && expandedIDs.includes(row.original.id)
                       ? 'h-[42px]'
                       : 'border-light box-border h-[42px] border-b',
-                    onRowClick ? 'hover:bg-canvasSubtle/40 cursor-pointer' : ''
+                    onRowClick ? 'hover:bg-canvasSubtle cursor-pointer' : ''
                   )}
                   onClick={() => {
                     const modalsContainer = document.getElementById('modals');

--- a/ui/packages/components/src/Table/Table.tsx
+++ b/ui/packages/components/src/Table/Table.tsx
@@ -53,7 +53,7 @@ export function Table<T>({
               <th
                 className={cn(
                   cellStyles,
-                  'bg-canvasSubtle text-muted text-xs font-medium',
+                  'bg-tableHeader text-muted text-xs font-medium',
                   header.column.getIsPinned() && 'sticky left-0 z-[4]',
                   header.column.getCanSort() && 'cursor-pointer'
                 )}
@@ -103,7 +103,7 @@ export function Table<T>({
               <tr
                 key={row.id}
                 {...(customRowProps ? customRowProps(row) : {})}
-                className="bg-canvasBase hover:bg-canvasSubtle/40"
+                className="bg-canvasBase hover:bg-canvasSubtle"
               >
                 {row.getVisibleCells().map((cell) => (
                   <td

--- a/ui/packages/components/src/Table/Table.tsx
+++ b/ui/packages/components/src/Table/Table.tsx
@@ -132,7 +132,7 @@ export function Table<T>({
             <tr
               key={row.id}
               {...(customRowProps ? customRowProps(row) : {})}
-              className="bg-canvaseBase hover:bg-canvasSubtle/50"
+              className="bg-canvaseBase hover:bg-canvasSubtle"
             >
               {row.getVisibleCells().map((cell) => (
                 <td

--- a/ui/packages/components/src/Time.tsx
+++ b/ui/packages/components/src/Time.tsx
@@ -17,6 +17,7 @@ type Props = {
   className?: string;
   format?: 'relative';
   value: Date | string;
+  copyable?: boolean;
 };
 
 function formatDate(date: Date) {
@@ -27,7 +28,7 @@ function formatUTCDate(date: Date) {
   return formatInTimeZone(date, 'UTC', 'dd MMM yyyy, HH:mm:ss');
 }
 
-export function Time({ className, format, value }: Props) {
+export function Time({ className, format, value, copyable = true }: Props) {
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text);
     toast.success('Copied to clipboard');
@@ -50,35 +51,34 @@ export function Time({ className, format, value }: Props) {
         <time
           suppressHydrationWarning={true}
           className={cn(
-            'hover:bg-canvasSubtle group flex items-center gap-1 whitespace-nowrap pr-4 hover:pr-0',
+            'group flex items-center gap-1 whitespace-nowrap',
+            copyable && 'hover:bg-canvasSubtle  cursor-pointer pr-4 hover:pr-0',
             className
           )}
           dateTime={date.toISOString()}
           onClick={(e) => {
+            if (!copyable) return;
             e.stopPropagation();
             e.preventDefault();
             copyToClipboard(date.toISOString());
           }}
         >
           {dateString}
-          <RiFileCopyLine className="text-subtle hidden h-3 w-3 group-hover:block" />
+          {copyable && <RiFileCopyLine className="text-subtle hidden h-3 w-3 group-hover:block" />}
         </time>
       </TooltipTrigger>
-      <TooltipContent side="bottom" className="w-60 max-w-60 px-0">
-        <div className="text-subtle border-subtle border-b px-3 py-2 text-xs">
-          Click to copy ISO timestamp
-        </div>
-        <div className="mb-[6px] ml-3 mr-4 mt-3 flex items-center justify-between gap-2 text-sm">
-          <div className="text-muted flex items-center gap-1">
+      <TooltipContent side="right" className="w-64 max-w-64 px-0">
+        <div className="mb-[6px] ml-3 mr-4 mt-1.5 flex items-center justify-between gap-2 text-sm">
+          <div className="text-light flex items-center gap-1">
             <RiTimeLine className="h-[14px] w-[14px]" /> UTC
           </div>
-          <time className="text-subtle">{utcTimeString}</time>
+          <time className="text-onContrast">{utcTimeString}</time>
         </div>
-        <div className="mb-[6px] ml-3 mr-4 mt-3 flex items-center justify-between gap-5 text-sm">
-          <div className="text-muted flex items-center gap-1">
+        <div className="mb-[6px] ml-3 mr-4 flex items-center justify-between gap-5 text-sm">
+          <div className="text-light flex items-center gap-1">
             <RiUserSmileLine className="h-[14px] w-[14px]" /> Local
           </div>
-          <time className="text-subtle">{localTimeString}</time>
+          <time className="text-onContrast">{localTimeString}</time>
         </div>
       </TooltipContent>
     </Tooltip>

--- a/ui/packages/components/src/TimelineV2/InlineSpans.tsx
+++ b/ui/packages/components/src/TimelineV2/InlineSpans.tsx
@@ -106,11 +106,11 @@ function Times({
     <>
       <p className="mb-2 font-bold">{name}</p>
       <div className="flex gap-16">
-        <ElementWrapper className="w-fit" label="Duration">
+        <ElementWrapper className="text-light w-fit" label="Duration">
           {duration > 0 ? formatMilliseconds(duration) : '-'}
         </ElementWrapper>
 
-        <ElementWrapper className="w-fit" label="Delay">
+        <ElementWrapper className="text-light w-fit" label="Delay">
           {isDelayVisible && delay > 0 ? formatMilliseconds(delay) : '-'}
         </ElementWrapper>
       </div>

--- a/ui/packages/components/src/TimelineV2/InlineSpans.tsx
+++ b/ui/packages/components/src/TimelineV2/InlineSpans.tsx
@@ -106,11 +106,11 @@ function Times({
     <>
       <p className="mb-2 font-bold">{name}</p>
       <div className="flex gap-16">
-        <ElementWrapper className="text-light w-fit" label="Duration">
+        <ElementWrapper className="[&>dt]:text-light w-fit" label="Duration">
           {duration > 0 ? formatMilliseconds(duration) : '-'}
         </ElementWrapper>
 
-        <ElementWrapper className="text-light w-fit" label="Delay">
+        <ElementWrapper className="[&>dt]:text-light w-fit" label="Delay">
           {isDelayVisible && delay > 0 ? formatMilliseconds(delay) : '-'}
         </ElementWrapper>
       </div>

--- a/ui/packages/components/src/TimelineV2/InlineSpans.tsx
+++ b/ui/packages/components/src/TimelineV2/InlineSpans.tsx
@@ -59,7 +59,7 @@ export function InlineSpans({ className, minTime, maxTime, name, spans, widths }
         </div>
       </TooltipTrigger>
       <TooltipContent>
-        <div className="text-basis">
+        <div>
           {spans[0] && <Times isDelayVisible={spans.length === 1} name={name} span={spans[0]} />}
 
           {spans.length > 1 &&

--- a/ui/packages/components/src/Tooltip/OptionalTooltip.tsx
+++ b/ui/packages/components/src/Tooltip/OptionalTooltip.tsx
@@ -13,10 +13,7 @@ export const OptionalTooltip = ({
   tooltip ? (
     <Tooltip>
       <TooltipTrigger asChild>{children}</TooltipTrigger>
-      <TooltipContent
-        side={side}
-        className="text-muted flex h-8 items-center px-4 text-xs leading-[18px]"
-      >
+      <TooltipContent side={side} className="flex h-8 items-center px-4 text-xs leading-[18px]">
         {tooltip}
       </TooltipContent>
     </Tooltip>

--- a/ui/packages/components/src/Tooltip/Tooltip.tsx
+++ b/ui/packages/components/src/Tooltip/Tooltip.tsx
@@ -25,13 +25,13 @@ const TooltipContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'animate-slide-down-and-fade bg-canvasBase text-basis shadow-tooltip z-[52] max-w-xs rounded-md px-2 py-1 text-sm shadow-md',
+        'animate-slide-down-and-fade bg-contrast text-onContrast z-[52] max-w-xs rounded-md px-2 py-1 text-sm',
         className
       )}
       {...props}
     >
       {props.children}
-      {hasArrow && <TooltipPrimitive.Arrow className="fill-tooltipArrow" />}
+      {hasArrow && <TooltipPrimitive.Arrow className="fill-contrast" />}
     </TooltipPrimitive.Content>
   </TooltipPrimitive.Portal>
 ));

--- a/ui/packages/components/src/Tooltip/Tooltip.tsx
+++ b/ui/packages/components/src/Tooltip/Tooltip.tsx
@@ -11,10 +11,15 @@ const Tooltip = TooltipPrimitive.Root;
 
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
+interface TooltipContentProps
+  extends React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> {
+  hasArrow?: boolean;
+}
+
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+  TooltipContentProps
+>(({ className, sideOffset = 4, hasArrow = true, ...props }, ref) => (
   <TooltipPrimitive.Portal>
     <TooltipPrimitive.Content
       ref={ref}
@@ -26,7 +31,7 @@ const TooltipContent = React.forwardRef<
       {...props}
     >
       {props.children}
-      <TooltipPrimitive.Arrow className="fill-tooltipArrow" />
+      {hasArrow && <TooltipPrimitive.Arrow className="fill-tooltipArrow" />}
     </TooltipPrimitive.Content>
   </TooltipPrimitive.Portal>
 ));

--- a/ui/packages/components/src/Workers/WorkersCounter.tsx
+++ b/ui/packages/components/src/Workers/WorkersCounter.tsx
@@ -35,29 +35,28 @@ export default function WorkersCounter({ counts, className }: Props) {
             })}
         </div>
       </TooltipTrigger>
-      <TooltipContent
-        side="bottom"
-        sideOffset={0}
-        align="start"
-        className="border-subtle flex flex-col gap-1 rounded-md border p-2 pr-3 text-xs"
-      >
-        {groupedWorkerStatuses
-          .filter((status) => counts[status] !== null)
-          .map((status) => (
-            <div key={status} className="flex items-center gap-1">
-              <div
-                className={cn(
-                  'h-[10px] w-[10px] rounded-full border',
-                  getStatusBackgroundClass(status),
-                  getStatusBorderClass(status)
-                )}
-              />
-              <div className="flex w-full items-center justify-between gap-3">
-                <div className="text-muted lowercase first-letter:capitalize">{status} workers</div>
-                {counts[status] || 0}
+      <TooltipContent side="bottom" sideOffset={0} align="start" className="p-2 pr-3 text-xs">
+        <div className="flex flex-col gap-1">
+          {groupedWorkerStatuses
+            .filter((status) => counts[status] !== null)
+            .map((status) => (
+              <div key={status} className="flex items-center gap-1">
+                <div
+                  className={cn(
+                    'h-[10px] w-[10px] rounded-full border',
+                    getStatusBackgroundClass(status),
+                    getStatusBorderClass(status)
+                  )}
+                />
+                <div className="flex w-full items-center justify-between gap-3">
+                  <div className="text-light lowercase first-letter:capitalize">
+                    {status} workers
+                  </div>
+                  {counts[status] || 0}
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+        </div>
       </TooltipContent>
     </Tooltip>
   );

--- a/ui/packages/components/tailwind.config.ts
+++ b/ui/packages/components/tailwind.config.ts
@@ -179,6 +179,7 @@ export default {
         // temporary tooltip token
         tooltipArrow: 'rgb(var(--color-background-canvas-base) / <alpha-value>)',
         onContrast: 'rgb(var(--color-foreground-onContrast) / <alpha-value>)',
+        contrast: 'rgb(var(--color-background-contrast) / <alpha-value>)',
         basis: 'rgb(var(--color-foreground-base) / <alpha-value>)',
         subtle: 'rgb(var(--color-foreground-subtle) / <alpha-value>)',
         muted: 'rgb(var(--color-foreground-muted) / <alpha-value>)',

--- a/ui/packages/components/tailwind.config.ts
+++ b/ui/packages/components/tailwind.config.ts
@@ -130,6 +130,7 @@ export default {
         btnDangerHover: 'rgb(var(--color-background-btn-dangerHover) / <alpha-value>)',
         btnDangerPressed: 'rgb(var(--color-background-btn-dangerPressed) / <alpha-value>)',
         btnDangerDisabled: 'rgb(var(--color-background-btn-dangerDisabled) / <alpha-value>)',
+        tableHeader: 'rgb(var(--color-background-tableHeader) / <alpha-value>)',
       },
       textColor: {
         basis: 'rgb(var(--color-foreground-base) / <alpha-value>)',


### PR DESCRIPTION
## Description
- UI tweaks to make the pages more similar to the designs
- Render events page filtered by event type inside each event type page
- Tooltips: follow design system colors
- Popover: transform info tooltips with links into popovers

<img width="1510" alt="Screenshot 2025-05-27 at 17 49 55" src="https://github.com/user-attachments/assets/a5c1b483-9404-4eeb-b087-e78aee8346e4" />

These elements use the <Info> shared component, that is now a Popover:
--
<img width="812" alt="Screenshot 2025-05-27 at 17 51 14" src="https://github.com/user-attachments/assets/065d09d1-9c80-4431-bbbe-c8b909c63d67" />


Tooltips colors from design system:  
--
<img width="574" alt="Screenshot 2025-05-27 at 17 51 23" src="https://github.com/user-attachments/assets/32bdd0dc-dc57-4629-8e14-b42a005ed43b" />



## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
