### PR TITLE
poll step output

### DIFF
--- a/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
+++ b/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
@@ -181,12 +181,7 @@ export const RunDetailsV3 = (props: Props) => {
                 node: waiting ? (
                   <Waiting />
                 ) : run ? (
-                  <Timeline
-                    getResult={getResult}
-                    pathCreator={pathCreator}
-                    runID={runID}
-                    trace={run?.trace}
-                  />
+                  <Timeline pathCreator={pathCreator} runID={runID} trace={run?.trace} />
                 ) : null,
               },
             ]}
@@ -212,7 +207,11 @@ export const RunDetailsV3 = (props: Props) => {
           style={{ width: `${100 - leftWidth}%`, height: standalone ? '85vh' : height }}
         >
           {selectedStep && !selectedStep.trace.isRoot ? (
-            <StepInfo selectedStep={selectedStep} />
+            <StepInfo
+              selectedStep={selectedStep}
+              getResult={getResult}
+              pollInterval={pollInterval}
+            />
           ) : (
             <TopInfo
               slug={run?.fn.slug}

--- a/ui/packages/components/src/RunDetailsV3/Timeline.tsx
+++ b/ui/packages/components/src/RunDetailsV3/Timeline.tsx
@@ -5,7 +5,6 @@ import { isLazyDone, type Lazy } from '../utils/lazyLoad';
 import { Trace } from './Trace';
 
 type Props = {
-  getResult: React.ComponentProps<typeof Trace>['getResult'];
   pathCreator: {
     runPopout: (params: { runID: string }) => Route;
   };
@@ -13,7 +12,7 @@ type Props = {
   trace: Lazy<React.ComponentProps<typeof Trace>['trace']>;
 };
 
-export const Timeline = ({ getResult, pathCreator, runID, trace }: Props) => {
+export const Timeline = ({ pathCreator, runID, trace }: Props) => {
   if (!isLazyDone(trace)) {
     // TODO: Properly handle loading state
     return null;
@@ -26,7 +25,6 @@ export const Timeline = ({ getResult, pathCreator, runID, trace }: Props) => {
     <div className={`w-full pb-4 pr-8`}>
       <Trace
         depth={0}
-        getResult={getResult}
         maxTime={maxTime}
         minTime={minTime}
         pathCreator={pathCreator}

--- a/ui/packages/components/src/RunDetailsV3/Trace.tsx
+++ b/ui/packages/components/src/RunDetailsV3/Trace.tsx
@@ -1,17 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { Route } from 'next';
 import { RiArrowRightSLine } from '@remixicon/react';
 
-import type { Result } from '../types/functionRun';
-import { toMaybeDate } from '../utils/date';
 import { InlineSpans } from './InlineSpans';
 import { TimelineHeader } from './TimelineHeader';
 import { type Trace } from './types';
-import { FINAL_SPAN_NAME, createSpanWidths, getSpanName, useStepSelection } from './utils';
+import { FINAL_SPAN_NAME, getSpanName, useStepSelection } from './utils';
 
 type Props = {
   depth: number;
-  getResult: (outputID: string) => Promise<Result>;
   minTime: Date;
   maxTime: Date;
   pathCreator: {
@@ -21,18 +18,9 @@ type Props = {
   runID: string;
 };
 
-export function Trace({ depth, getResult, maxTime, minTime, pathCreator, trace, runID }: Props) {
+export function Trace({ depth, maxTime, minTime, pathCreator, trace, runID }: Props) {
   const [expanded, setExpanded] = useState(true);
-  const [result, setResult] = useState<Result>();
   const { selectStep, selectedStep } = useStepSelection(runID);
-
-  useEffect(() => {
-    if (expanded && !result && trace.outputID) {
-      getResult(trace.outputID).then((data) => {
-        setResult(data);
-      });
-    }
-  }, [expanded, result]);
 
   //
   // Don't show single finalization step for successful runs
@@ -56,7 +44,7 @@ export function Trace({ depth, getResult, maxTime, minTime, pathCreator, trace, 
             ? 'bg-secondary-3xSubtle'
             : 'hover:bg-canvasSubtle'
         } `}
-        onClick={() => selectStep({ trace, runID, result, pathCreator })}
+        onClick={() => selectStep({ trace, runID, pathCreator })}
       >
         <div
           className="flex w-[30%] flex-row items-center justify-start gap-1 overflow-hidden"
@@ -100,7 +88,6 @@ export function Trace({ depth, getResult, maxTime, minTime, pathCreator, trace, 
               <Trace
                 key={`${child.name}-${i}`}
                 depth={depth + 1}
-                getResult={getResult}
                 maxTime={maxTime}
                 minTime={minTime}
                 pathCreator={pathCreator}

--- a/ui/packages/components/src/RunDetailsV3/utils.ts
+++ b/ui/packages/components/src/RunDetailsV3/utils.ts
@@ -73,7 +73,6 @@ export type PathCreator = {
 export type StepInfoType = {
   trace: Trace;
   runID: string;
-  result?: Result;
   pathCreator: PathCreator;
 };
 


### PR DESCRIPTION
## Description

Moved the step output fetch down to the step component and poll it there while the parent run is still active. Useful for longer running AI workflows.

## Motivation
Ensure step output arrives in UI.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
