### PR TITLE
Add FunctionConfiguration to coreapi

### DIFF
--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -79,6 +79,23 @@ type ComplexityRoot struct {
 		Url            func(childComplexity int) int
 	}
 
+	CancellationConfiguration struct {
+		Condition func(childComplexity int) int
+		Event     func(childComplexity int) int
+		Timeout   func(childComplexity int) int
+	}
+
+	ConcurrencyConfiguration struct {
+		Key   func(childComplexity int) int
+		Limit func(childComplexity int) int
+		Scope func(childComplexity int) int
+	}
+
+	ConcurrencyLimitConfiguration struct {
+		IsPlanLimit func(childComplexity int) int
+		Value       func(childComplexity int) int
+	}
+
 	ConnectV1WorkerConnection struct {
 		App              func(childComplexity int) int
 		AppID            func(childComplexity int) int
@@ -116,6 +133,11 @@ type ComplexityRoot struct {
 		TotalCount func(childComplexity int) int
 	}
 
+	DebounceConfiguration struct {
+		Key    func(childComplexity int) int
+		Period func(childComplexity int) int
+	}
+
 	Event struct {
 		CreatedAt    func(childComplexity int) int
 		ExternalID   func(childComplexity int) int
@@ -131,16 +153,34 @@ type ComplexityRoot struct {
 		Workspace    func(childComplexity int) int
 	}
 
+	EventsBatchConfiguration struct {
+		Key     func(childComplexity int) int
+		MaxSize func(childComplexity int) int
+		Timeout func(childComplexity int) int
+	}
+
 	Function struct {
-		App         func(childComplexity int) int
-		AppID       func(childComplexity int) int
-		Concurrency func(childComplexity int) int
-		Config      func(childComplexity int) int
-		ID          func(childComplexity int) int
-		Name        func(childComplexity int) int
-		Slug        func(childComplexity int) int
-		Triggers    func(childComplexity int) int
-		URL         func(childComplexity int) int
+		App           func(childComplexity int) int
+		AppID         func(childComplexity int) int
+		Concurrency   func(childComplexity int) int
+		Config        func(childComplexity int) int
+		Configuration func(childComplexity int) int
+		ID            func(childComplexity int) int
+		Name          func(childComplexity int) int
+		Slug          func(childComplexity int) int
+		Triggers      func(childComplexity int) int
+		URL           func(childComplexity int) int
+	}
+
+	FunctionConfiguration struct {
+		Cancellations func(childComplexity int) int
+		Concurrency   func(childComplexity int) int
+		Debounce      func(childComplexity int) int
+		EventsBatch   func(childComplexity int) int
+		Priority      func(childComplexity int) int
+		RateLimit     func(childComplexity int) int
+		Retries       func(childComplexity int) int
+		Throttle      func(childComplexity int) int
 	}
 
 	FunctionEvent struct {
@@ -254,6 +294,17 @@ type ComplexityRoot struct {
 		Stream                 func(childComplexity int, query models.StreamQuery) int
 		WorkerConnection       func(childComplexity int, connectionID ulid.ULID) int
 		WorkerConnections      func(childComplexity int, first int, after *string, orderBy []*models.ConnectV1WorkerConnectionsOrderBy, filter models.ConnectV1WorkerConnectionsFilter) int
+	}
+
+	RateLimitConfiguration struct {
+		Key    func(childComplexity int) int
+		Limit  func(childComplexity int) int
+		Period func(childComplexity int) int
+	}
+
+	RetryConfiguration struct {
+		IsDefault func(childComplexity int) int
+		Value     func(childComplexity int) int
 	}
 
 	RunHistoryCancel struct {
@@ -405,6 +456,13 @@ type ComplexityRoot struct {
 		Runs      func(childComplexity int) int
 		Trigger   func(childComplexity int) int
 		Type      func(childComplexity int) int
+	}
+
+	ThrottleConfiguration struct {
+		Burst  func(childComplexity int) int
+		Key    func(childComplexity int) int
+		Limit  func(childComplexity int) int
+		Period func(childComplexity int) int
 	}
 
 	UserlandSpan struct {
@@ -638,6 +696,62 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.App.Url(childComplexity), true
 
+	case "CancellationConfiguration.condition":
+		if e.complexity.CancellationConfiguration.Condition == nil {
+			break
+		}
+
+		return e.complexity.CancellationConfiguration.Condition(childComplexity), true
+
+	case "CancellationConfiguration.event":
+		if e.complexity.CancellationConfiguration.Event == nil {
+			break
+		}
+
+		return e.complexity.CancellationConfiguration.Event(childComplexity), true
+
+	case "CancellationConfiguration.timeout":
+		if e.complexity.CancellationConfiguration.Timeout == nil {
+			break
+		}
+
+		return e.complexity.CancellationConfiguration.Timeout(childComplexity), true
+
+	case "ConcurrencyConfiguration.key":
+		if e.complexity.ConcurrencyConfiguration.Key == nil {
+			break
+		}
+
+		return e.complexity.ConcurrencyConfiguration.Key(childComplexity), true
+
+	case "ConcurrencyConfiguration.limit":
+		if e.complexity.ConcurrencyConfiguration.Limit == nil {
+			break
+		}
+
+		return e.complexity.ConcurrencyConfiguration.Limit(childComplexity), true
+
+	case "ConcurrencyConfiguration.scope":
+		if e.complexity.ConcurrencyConfiguration.Scope == nil {
+			break
+		}
+
+		return e.complexity.ConcurrencyConfiguration.Scope(childComplexity), true
+
+	case "ConcurrencyLimitConfiguration.isPlanLimit":
+		if e.complexity.ConcurrencyLimitConfiguration.IsPlanLimit == nil {
+			break
+		}
+
+		return e.complexity.ConcurrencyLimitConfiguration.IsPlanLimit(childComplexity), true
+
+	case "ConcurrencyLimitConfiguration.value":
+		if e.complexity.ConcurrencyLimitConfiguration.Value == nil {
+			break
+		}
+
+		return e.complexity.ConcurrencyLimitConfiguration.Value(childComplexity), true
+
 	case "ConnectV1WorkerConnection.app":
 		if e.complexity.ConnectV1WorkerConnection.App == nil {
 			break
@@ -834,6 +948,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ConnectV1WorkerConnectionsConnection.TotalCount(childComplexity), true
 
+	case "DebounceConfiguration.key":
+		if e.complexity.DebounceConfiguration.Key == nil {
+			break
+		}
+
+		return e.complexity.DebounceConfiguration.Key(childComplexity), true
+
+	case "DebounceConfiguration.period":
+		if e.complexity.DebounceConfiguration.Period == nil {
+			break
+		}
+
+		return e.complexity.DebounceConfiguration.Period(childComplexity), true
+
 	case "Event.createdAt":
 		if e.complexity.Event.CreatedAt == nil {
 			break
@@ -918,6 +1046,27 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Event.Workspace(childComplexity), true
 
+	case "EventsBatchConfiguration.key":
+		if e.complexity.EventsBatchConfiguration.Key == nil {
+			break
+		}
+
+		return e.complexity.EventsBatchConfiguration.Key(childComplexity), true
+
+	case "EventsBatchConfiguration.maxSize":
+		if e.complexity.EventsBatchConfiguration.MaxSize == nil {
+			break
+		}
+
+		return e.complexity.EventsBatchConfiguration.MaxSize(childComplexity), true
+
+	case "EventsBatchConfiguration.timeout":
+		if e.complexity.EventsBatchConfiguration.Timeout == nil {
+			break
+		}
+
+		return e.complexity.EventsBatchConfiguration.Timeout(childComplexity), true
+
 	case "Function.app":
 		if e.complexity.Function.App == nil {
 			break
@@ -945,6 +1094,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Function.Config(childComplexity), true
+
+	case "Function.configuration":
+		if e.complexity.Function.Configuration == nil {
+			break
+		}
+
+		return e.complexity.Function.Configuration(childComplexity), true
 
 	case "Function.id":
 		if e.complexity.Function.ID == nil {
@@ -980,6 +1136,62 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Function.URL(childComplexity), true
+
+	case "FunctionConfiguration.cancellations":
+		if e.complexity.FunctionConfiguration.Cancellations == nil {
+			break
+		}
+
+		return e.complexity.FunctionConfiguration.Cancellations(childComplexity), true
+
+	case "FunctionConfiguration.concurrency":
+		if e.complexity.FunctionConfiguration.Concurrency == nil {
+			break
+		}
+
+		return e.complexity.FunctionConfiguration.Concurrency(childComplexity), true
+
+	case "FunctionConfiguration.debounce":
+		if e.complexity.FunctionConfiguration.Debounce == nil {
+			break
+		}
+
+		return e.complexity.FunctionConfiguration.Debounce(childComplexity), true
+
+	case "FunctionConfiguration.eventsBatch":
+		if e.complexity.FunctionConfiguration.EventsBatch == nil {
+			break
+		}
+
+		return e.complexity.FunctionConfiguration.EventsBatch(childComplexity), true
+
+	case "FunctionConfiguration.priority":
+		if e.complexity.FunctionConfiguration.Priority == nil {
+			break
+		}
+
+		return e.complexity.FunctionConfiguration.Priority(childComplexity), true
+
+	case "FunctionConfiguration.rateLimit":
+		if e.complexity.FunctionConfiguration.RateLimit == nil {
+			break
+		}
+
+		return e.complexity.FunctionConfiguration.RateLimit(childComplexity), true
+
+	case "FunctionConfiguration.retries":
+		if e.complexity.FunctionConfiguration.Retries == nil {
+			break
+		}
+
+		return e.complexity.FunctionConfiguration.Retries(childComplexity), true
+
+	case "FunctionConfiguration.throttle":
+		if e.complexity.FunctionConfiguration.Throttle == nil {
+			break
+		}
+
+		return e.complexity.FunctionConfiguration.Throttle(childComplexity), true
 
 	case "FunctionEvent.createdAt":
 		if e.complexity.FunctionEvent.CreatedAt == nil {
@@ -1662,6 +1874,41 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.WorkerConnections(childComplexity, args["first"].(int), args["after"].(*string), args["orderBy"].([]*models.ConnectV1WorkerConnectionsOrderBy), args["filter"].(models.ConnectV1WorkerConnectionsFilter)), true
 
+	case "RateLimitConfiguration.key":
+		if e.complexity.RateLimitConfiguration.Key == nil {
+			break
+		}
+
+		return e.complexity.RateLimitConfiguration.Key(childComplexity), true
+
+	case "RateLimitConfiguration.limit":
+		if e.complexity.RateLimitConfiguration.Limit == nil {
+			break
+		}
+
+		return e.complexity.RateLimitConfiguration.Limit(childComplexity), true
+
+	case "RateLimitConfiguration.period":
+		if e.complexity.RateLimitConfiguration.Period == nil {
+			break
+		}
+
+		return e.complexity.RateLimitConfiguration.Period(childComplexity), true
+
+	case "RetryConfiguration.isDefault":
+		if e.complexity.RetryConfiguration.IsDefault == nil {
+			break
+		}
+
+		return e.complexity.RetryConfiguration.IsDefault(childComplexity), true
+
+	case "RetryConfiguration.value":
+		if e.complexity.RetryConfiguration.Value == nil {
+			break
+		}
+
+		return e.complexity.RetryConfiguration.Value(childComplexity), true
+
 	case "RunHistoryCancel.eventID":
 		if e.complexity.RunHistoryCancel.EventID == nil {
 			break
@@ -2341,6 +2588,34 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.StreamItem.Type(childComplexity), true
 
+	case "ThrottleConfiguration.burst":
+		if e.complexity.ThrottleConfiguration.Burst == nil {
+			break
+		}
+
+		return e.complexity.ThrottleConfiguration.Burst(childComplexity), true
+
+	case "ThrottleConfiguration.key":
+		if e.complexity.ThrottleConfiguration.Key == nil {
+			break
+		}
+
+		return e.complexity.ThrottleConfiguration.Key(childComplexity), true
+
+	case "ThrottleConfiguration.limit":
+		if e.complexity.ThrottleConfiguration.Limit == nil {
+			break
+		}
+
+		return e.complexity.ThrottleConfiguration.Limit(childComplexity), true
+
+	case "ThrottleConfiguration.period":
+		if e.complexity.ThrottleConfiguration.Period == nil {
+			break
+		}
+
+		return e.complexity.ThrottleConfiguration.Period(childComplexity), true
+
 	case "UserlandSpan.resourceAttrs":
 		if e.complexity.UserlandSpan.ResourceAttrs == nil {
 			break
@@ -2774,6 +3049,7 @@ type Function {
   name: String!
   slug: String!
   config: String!
+  configuration: FunctionConfiguration # configuration is here?
   concurrency: Int!
   triggers: [FunctionTrigger!]
   url: String!
@@ -2812,6 +3088,73 @@ type FunctionEvent {
   type: FunctionEventType
   output: String
   createdAt: Time
+}
+
+type FunctionConfiguration {
+  cancellations: [CancellationConfiguration!]
+  retries: RetryConfiguration!
+  priority: String
+  eventsBatch: EventsBatchConfiguration
+  concurrency: [ConcurrencyConfiguration!]!
+  rateLimit: RateLimitConfiguration
+  debounce: DebounceConfiguration
+  throttle: ThrottleConfiguration
+}
+
+type CancellationConfiguration {
+  event: String!
+  timeout: String
+  condition: String
+}
+
+type RetryConfiguration {
+  value: Int!
+  isDefault: Boolean
+}
+
+type EventsBatchConfiguration {
+  "The maximum number of events a batch can have."
+  maxSize: Int!
+
+  "How long to wait before running the function with the batch."
+  timeout: String!
+
+  key: String
+}
+
+type ConcurrencyConfiguration {
+  scope: ConcurrencyScope!
+  limit: ConcurrencyLimitConfiguration!
+  key: String
+}
+
+enum ConcurrencyScope {
+  ACCOUNT
+  ENVIRONMENT
+  FUNCTION
+}
+
+type ConcurrencyLimitConfiguration {
+  value: Int!
+  isPlanLimit: Boolean
+}
+
+type RateLimitConfiguration {
+  limit: Int!
+  period: String!
+  key: String
+}
+
+type DebounceConfiguration {
+  period: String!
+  key: String
+}
+
+type ThrottleConfiguration {
+  burst: Int!
+  key: String
+  limit: Int!
+  period: String!
 }
 
 enum StepEventType {
@@ -4104,6 +4447,8 @@ func (ec *executionContext) fieldContext_App_functions(ctx context.Context, fiel
 				return ec.fieldContext_Function_slug(ctx, field)
 			case "config":
 				return ec.fieldContext_Function_config(ctx, field)
+			case "configuration":
+				return ec.fieldContext_Function_configuration(ctx, field)
 			case "concurrency":
 				return ec.fieldContext_Function_concurrency(ctx, field)
 			case "triggers":
@@ -4331,6 +4676,352 @@ func (ec *executionContext) fieldContext_App_autodiscovered(ctx context.Context,
 		Field:      field,
 		IsMethod:   true,
 		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CancellationConfiguration_event(ctx context.Context, field graphql.CollectedField, obj *models.CancellationConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CancellationConfiguration_event(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Event, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CancellationConfiguration_event(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CancellationConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CancellationConfiguration_timeout(ctx context.Context, field graphql.CollectedField, obj *models.CancellationConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CancellationConfiguration_timeout(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Timeout, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CancellationConfiguration_timeout(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CancellationConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CancellationConfiguration_condition(ctx context.Context, field graphql.CollectedField, obj *models.CancellationConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_CancellationConfiguration_condition(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Condition, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_CancellationConfiguration_condition(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CancellationConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ConcurrencyConfiguration_scope(ctx context.Context, field graphql.CollectedField, obj *models.ConcurrencyConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ConcurrencyConfiguration_scope(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Scope, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(models.ConcurrencyScope)
+	fc.Result = res
+	return ec.marshalNConcurrencyScope2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConcurrencyScope(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ConcurrencyConfiguration_scope(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ConcurrencyConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ConcurrencyScope does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ConcurrencyConfiguration_limit(ctx context.Context, field graphql.CollectedField, obj *models.ConcurrencyConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ConcurrencyConfiguration_limit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Limit, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.ConcurrencyLimitConfiguration)
+	fc.Result = res
+	return ec.marshalNConcurrencyLimitConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConcurrencyLimitConfiguration(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ConcurrencyConfiguration_limit(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ConcurrencyConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "value":
+				return ec.fieldContext_ConcurrencyLimitConfiguration_value(ctx, field)
+			case "isPlanLimit":
+				return ec.fieldContext_ConcurrencyLimitConfiguration_isPlanLimit(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ConcurrencyLimitConfiguration", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ConcurrencyConfiguration_key(ctx context.Context, field graphql.CollectedField, obj *models.ConcurrencyConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ConcurrencyConfiguration_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ConcurrencyConfiguration_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ConcurrencyConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ConcurrencyLimitConfiguration_value(ctx context.Context, field graphql.CollectedField, obj *models.ConcurrencyLimitConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ConcurrencyLimitConfiguration_value(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Value, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ConcurrencyLimitConfiguration_value(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ConcurrencyLimitConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ConcurrencyLimitConfiguration_isPlanLimit(ctx context.Context, field graphql.CollectedField, obj *models.ConcurrencyLimitConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ConcurrencyLimitConfiguration_isPlanLimit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsPlanLimit, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ConcurrencyLimitConfiguration_isPlanLimit(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ConcurrencyLimitConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
 		},
@@ -5639,6 +6330,91 @@ func (ec *executionContext) fieldContext_ConnectV1WorkerConnectionsConnection_to
 	return fc, nil
 }
 
+func (ec *executionContext) _DebounceConfiguration_period(ctx context.Context, field graphql.CollectedField, obj *models.DebounceConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DebounceConfiguration_period(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Period, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DebounceConfiguration_period(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DebounceConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _DebounceConfiguration_key(ctx context.Context, field graphql.CollectedField, obj *models.DebounceConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_DebounceConfiguration_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_DebounceConfiguration_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "DebounceConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Event_id(ctx context.Context, field graphql.CollectedField, obj *models.Event) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Event_id(ctx, field)
 	if err != nil {
@@ -6176,6 +6952,135 @@ func (ec *executionContext) fieldContext_Event_functionRuns(ctx context.Context,
 	return fc, nil
 }
 
+func (ec *executionContext) _EventsBatchConfiguration_maxSize(ctx context.Context, field graphql.CollectedField, obj *models.EventsBatchConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_EventsBatchConfiguration_maxSize(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MaxSize, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_EventsBatchConfiguration_maxSize(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "EventsBatchConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _EventsBatchConfiguration_timeout(ctx context.Context, field graphql.CollectedField, obj *models.EventsBatchConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_EventsBatchConfiguration_timeout(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Timeout, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_EventsBatchConfiguration_timeout(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "EventsBatchConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _EventsBatchConfiguration_key(ctx context.Context, field graphql.CollectedField, obj *models.EventsBatchConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_EventsBatchConfiguration_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_EventsBatchConfiguration_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "EventsBatchConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Function_id(ctx context.Context, field graphql.CollectedField, obj *models.Function) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Function_id(ctx, field)
 	if err != nil {
@@ -6347,6 +7252,65 @@ func (ec *executionContext) fieldContext_Function_config(ctx context.Context, fi
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Function_configuration(ctx context.Context, field graphql.CollectedField, obj *models.Function) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Function_configuration(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Configuration, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.FunctionConfiguration)
+	fc.Result = res
+	return ec.marshalOFunctionConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionConfiguration(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Function_configuration(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Function",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "cancellations":
+				return ec.fieldContext_FunctionConfiguration_cancellations(ctx, field)
+			case "retries":
+				return ec.fieldContext_FunctionConfiguration_retries(ctx, field)
+			case "priority":
+				return ec.fieldContext_FunctionConfiguration_priority(ctx, field)
+			case "eventsBatch":
+				return ec.fieldContext_FunctionConfiguration_eventsBatch(ctx, field)
+			case "concurrency":
+				return ec.fieldContext_FunctionConfiguration_concurrency(ctx, field)
+			case "rateLimit":
+				return ec.fieldContext_FunctionConfiguration_rateLimit(ctx, field)
+			case "debounce":
+				return ec.fieldContext_FunctionConfiguration_debounce(ctx, field)
+			case "throttle":
+				return ec.fieldContext_FunctionConfiguration_throttle(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FunctionConfiguration", field.Name)
 		},
 	}
 	return fc, nil
@@ -6602,6 +7566,394 @@ func (ec *executionContext) fieldContext_Function_app(ctx context.Context, field
 				return ec.fieldContext_App_autodiscovered(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type App", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FunctionConfiguration_cancellations(ctx context.Context, field graphql.CollectedField, obj *models.FunctionConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FunctionConfiguration_cancellations(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cancellations, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*models.CancellationConfiguration)
+	fc.Result = res
+	return ec.marshalOCancellationConfiguration2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐCancellationConfigurationᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FunctionConfiguration_cancellations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FunctionConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "event":
+				return ec.fieldContext_CancellationConfiguration_event(ctx, field)
+			case "timeout":
+				return ec.fieldContext_CancellationConfiguration_timeout(ctx, field)
+			case "condition":
+				return ec.fieldContext_CancellationConfiguration_condition(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type CancellationConfiguration", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FunctionConfiguration_retries(ctx context.Context, field graphql.CollectedField, obj *models.FunctionConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FunctionConfiguration_retries(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Retries, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*models.RetryConfiguration)
+	fc.Result = res
+	return ec.marshalNRetryConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐRetryConfiguration(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FunctionConfiguration_retries(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FunctionConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "value":
+				return ec.fieldContext_RetryConfiguration_value(ctx, field)
+			case "isDefault":
+				return ec.fieldContext_RetryConfiguration_isDefault(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RetryConfiguration", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FunctionConfiguration_priority(ctx context.Context, field graphql.CollectedField, obj *models.FunctionConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FunctionConfiguration_priority(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Priority, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FunctionConfiguration_priority(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FunctionConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FunctionConfiguration_eventsBatch(ctx context.Context, field graphql.CollectedField, obj *models.FunctionConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FunctionConfiguration_eventsBatch(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EventsBatch, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.EventsBatchConfiguration)
+	fc.Result = res
+	return ec.marshalOEventsBatchConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐEventsBatchConfiguration(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FunctionConfiguration_eventsBatch(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FunctionConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "maxSize":
+				return ec.fieldContext_EventsBatchConfiguration_maxSize(ctx, field)
+			case "timeout":
+				return ec.fieldContext_EventsBatchConfiguration_timeout(ctx, field)
+			case "key":
+				return ec.fieldContext_EventsBatchConfiguration_key(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type EventsBatchConfiguration", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FunctionConfiguration_concurrency(ctx context.Context, field graphql.CollectedField, obj *models.FunctionConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FunctionConfiguration_concurrency(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Concurrency, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*models.ConcurrencyConfiguration)
+	fc.Result = res
+	return ec.marshalNConcurrencyConfiguration2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConcurrencyConfigurationᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FunctionConfiguration_concurrency(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FunctionConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "scope":
+				return ec.fieldContext_ConcurrencyConfiguration_scope(ctx, field)
+			case "limit":
+				return ec.fieldContext_ConcurrencyConfiguration_limit(ctx, field)
+			case "key":
+				return ec.fieldContext_ConcurrencyConfiguration_key(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ConcurrencyConfiguration", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FunctionConfiguration_rateLimit(ctx context.Context, field graphql.CollectedField, obj *models.FunctionConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FunctionConfiguration_rateLimit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RateLimit, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.RateLimitConfiguration)
+	fc.Result = res
+	return ec.marshalORateLimitConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐRateLimitConfiguration(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FunctionConfiguration_rateLimit(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FunctionConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "limit":
+				return ec.fieldContext_RateLimitConfiguration_limit(ctx, field)
+			case "period":
+				return ec.fieldContext_RateLimitConfiguration_period(ctx, field)
+			case "key":
+				return ec.fieldContext_RateLimitConfiguration_key(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RateLimitConfiguration", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FunctionConfiguration_debounce(ctx context.Context, field graphql.CollectedField, obj *models.FunctionConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FunctionConfiguration_debounce(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Debounce, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.DebounceConfiguration)
+	fc.Result = res
+	return ec.marshalODebounceConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐDebounceConfiguration(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FunctionConfiguration_debounce(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FunctionConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "period":
+				return ec.fieldContext_DebounceConfiguration_period(ctx, field)
+			case "key":
+				return ec.fieldContext_DebounceConfiguration_key(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type DebounceConfiguration", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _FunctionConfiguration_throttle(ctx context.Context, field graphql.CollectedField, obj *models.FunctionConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_FunctionConfiguration_throttle(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Throttle, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.ThrottleConfiguration)
+	fc.Result = res
+	return ec.marshalOThrottleConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐThrottleConfiguration(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_FunctionConfiguration_throttle(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "FunctionConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "burst":
+				return ec.fieldContext_ThrottleConfiguration_burst(ctx, field)
+			case "key":
+				return ec.fieldContext_ThrottleConfiguration_key(ctx, field)
+			case "limit":
+				return ec.fieldContext_ThrottleConfiguration_limit(ctx, field)
+			case "period":
+				return ec.fieldContext_ThrottleConfiguration_period(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ThrottleConfiguration", field.Name)
 		},
 	}
 	return fc, nil
@@ -6986,6 +8338,8 @@ func (ec *executionContext) fieldContext_FunctionRun_function(ctx context.Contex
 				return ec.fieldContext_Function_slug(ctx, field)
 			case "config":
 				return ec.fieldContext_Function_config(ctx, field)
+			case "configuration":
+				return ec.fieldContext_Function_configuration(ctx, field)
 			case "concurrency":
 				return ec.fieldContext_Function_concurrency(ctx, field)
 			case "triggers":
@@ -7991,6 +9345,8 @@ func (ec *executionContext) fieldContext_FunctionRunV2_function(ctx context.Cont
 				return ec.fieldContext_Function_slug(ctx, field)
 			case "config":
 				return ec.fieldContext_Function_config(ctx, field)
+			case "configuration":
+				return ec.fieldContext_Function_configuration(ctx, field)
 			case "concurrency":
 				return ec.fieldContext_Function_concurrency(ctx, field)
 			case "triggers":
@@ -10515,6 +11871,8 @@ func (ec *executionContext) fieldContext_Query_functions(ctx context.Context, fi
 				return ec.fieldContext_Function_slug(ctx, field)
 			case "config":
 				return ec.fieldContext_Function_config(ctx, field)
+			case "configuration":
+				return ec.fieldContext_Function_configuration(ctx, field)
 			case "concurrency":
 				return ec.fieldContext_Function_concurrency(ctx, field)
 			case "triggers":
@@ -11198,6 +12556,220 @@ func (ec *executionContext) fieldContext_Query___schema(ctx context.Context, fie
 				return ec.fieldContext___Schema_directives(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type __Schema", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RateLimitConfiguration_limit(ctx context.Context, field graphql.CollectedField, obj *models.RateLimitConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RateLimitConfiguration_limit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Limit, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RateLimitConfiguration_limit(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RateLimitConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RateLimitConfiguration_period(ctx context.Context, field graphql.CollectedField, obj *models.RateLimitConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RateLimitConfiguration_period(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Period, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RateLimitConfiguration_period(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RateLimitConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RateLimitConfiguration_key(ctx context.Context, field graphql.CollectedField, obj *models.RateLimitConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RateLimitConfiguration_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RateLimitConfiguration_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RateLimitConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RetryConfiguration_value(ctx context.Context, field graphql.CollectedField, obj *models.RetryConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RetryConfiguration_value(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Value, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RetryConfiguration_value(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RetryConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RetryConfiguration_isDefault(ctx context.Context, field graphql.CollectedField, obj *models.RetryConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RetryConfiguration_isDefault(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.IsDefault, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RetryConfiguration_isDefault(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RetryConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -15637,6 +17209,179 @@ func (ec *executionContext) fieldContext_StreamItem_inBatch(ctx context.Context,
 	return fc, nil
 }
 
+func (ec *executionContext) _ThrottleConfiguration_burst(ctx context.Context, field graphql.CollectedField, obj *models.ThrottleConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ThrottleConfiguration_burst(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Burst, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ThrottleConfiguration_burst(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ThrottleConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ThrottleConfiguration_key(ctx context.Context, field graphql.CollectedField, obj *models.ThrottleConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ThrottleConfiguration_key(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Key, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ThrottleConfiguration_key(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ThrottleConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ThrottleConfiguration_limit(ctx context.Context, field graphql.CollectedField, obj *models.ThrottleConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ThrottleConfiguration_limit(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Limit, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ThrottleConfiguration_limit(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ThrottleConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ThrottleConfiguration_period(ctx context.Context, field graphql.CollectedField, obj *models.ThrottleConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ThrottleConfiguration_period(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Period, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ThrottleConfiguration_period(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ThrottleConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UserlandSpan_spanName(ctx context.Context, field graphql.CollectedField, obj *models.UserlandSpan) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UserlandSpan_spanName(ctx, field)
 	if err != nil {
@@ -18980,6 +20725,113 @@ func (ec *executionContext) _App(ctx context.Context, sel ast.SelectionSet, obj 
 	return out
 }
 
+var cancellationConfigurationImplementors = []string{"CancellationConfiguration"}
+
+func (ec *executionContext) _CancellationConfiguration(ctx context.Context, sel ast.SelectionSet, obj *models.CancellationConfiguration) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, cancellationConfigurationImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("CancellationConfiguration")
+		case "event":
+
+			out.Values[i] = ec._CancellationConfiguration_event(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "timeout":
+
+			out.Values[i] = ec._CancellationConfiguration_timeout(ctx, field, obj)
+
+		case "condition":
+
+			out.Values[i] = ec._CancellationConfiguration_condition(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var concurrencyConfigurationImplementors = []string{"ConcurrencyConfiguration"}
+
+func (ec *executionContext) _ConcurrencyConfiguration(ctx context.Context, sel ast.SelectionSet, obj *models.ConcurrencyConfiguration) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, concurrencyConfigurationImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ConcurrencyConfiguration")
+		case "scope":
+
+			out.Values[i] = ec._ConcurrencyConfiguration_scope(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "limit":
+
+			out.Values[i] = ec._ConcurrencyConfiguration_limit(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "key":
+
+			out.Values[i] = ec._ConcurrencyConfiguration_key(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var concurrencyLimitConfigurationImplementors = []string{"ConcurrencyLimitConfiguration"}
+
+func (ec *executionContext) _ConcurrencyLimitConfiguration(ctx context.Context, sel ast.SelectionSet, obj *models.ConcurrencyLimitConfiguration) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, concurrencyLimitConfigurationImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ConcurrencyLimitConfiguration")
+		case "value":
+
+			out.Values[i] = ec._ConcurrencyLimitConfiguration_value(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "isPlanLimit":
+
+			out.Values[i] = ec._ConcurrencyLimitConfiguration_isPlanLimit(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var connectV1WorkerConnectionImplementors = []string{"ConnectV1WorkerConnection"}
 
 func (ec *executionContext) _ConnectV1WorkerConnection(ctx context.Context, sel ast.SelectionSet, obj *models.ConnectV1WorkerConnection) graphql.Marshaler {
@@ -19238,6 +21090,38 @@ func (ec *executionContext) _ConnectV1WorkerConnectionsConnection(ctx context.Co
 	return out
 }
 
+var debounceConfigurationImplementors = []string{"DebounceConfiguration"}
+
+func (ec *executionContext) _DebounceConfiguration(ctx context.Context, sel ast.SelectionSet, obj *models.DebounceConfiguration) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, debounceConfigurationImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("DebounceConfiguration")
+		case "period":
+
+			out.Values[i] = ec._DebounceConfiguration_period(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "key":
+
+			out.Values[i] = ec._DebounceConfiguration_key(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var eventImplementors = []string{"Event"}
 
 func (ec *executionContext) _Event(ctx context.Context, sel ast.SelectionSet, obj *models.Event) graphql.Marshaler {
@@ -19375,6 +21259,45 @@ func (ec *executionContext) _Event(ctx context.Context, sel ast.SelectionSet, ob
 	return out
 }
 
+var eventsBatchConfigurationImplementors = []string{"EventsBatchConfiguration"}
+
+func (ec *executionContext) _EventsBatchConfiguration(ctx context.Context, sel ast.SelectionSet, obj *models.EventsBatchConfiguration) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, eventsBatchConfigurationImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("EventsBatchConfiguration")
+		case "maxSize":
+
+			out.Values[i] = ec._EventsBatchConfiguration_maxSize(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "timeout":
+
+			out.Values[i] = ec._EventsBatchConfiguration_timeout(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "key":
+
+			out.Values[i] = ec._EventsBatchConfiguration_key(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var functionImplementors = []string{"Function"}
 
 func (ec *executionContext) _Function(ctx context.Context, sel ast.SelectionSet, obj *models.Function) graphql.Marshaler {
@@ -19413,6 +21336,10 @@ func (ec *executionContext) _Function(ctx context.Context, sel ast.SelectionSet,
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		case "configuration":
+
+			out.Values[i] = ec._Function_configuration(ctx, field, obj)
+
 		case "concurrency":
 
 			out.Values[i] = ec._Function_concurrency(ctx, field, obj)
@@ -19458,6 +21385,65 @@ func (ec *executionContext) _Function(ctx context.Context, sel ast.SelectionSet,
 				return innerFunc(ctx)
 
 			})
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var functionConfigurationImplementors = []string{"FunctionConfiguration"}
+
+func (ec *executionContext) _FunctionConfiguration(ctx context.Context, sel ast.SelectionSet, obj *models.FunctionConfiguration) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, functionConfigurationImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("FunctionConfiguration")
+		case "cancellations":
+
+			out.Values[i] = ec._FunctionConfiguration_cancellations(ctx, field, obj)
+
+		case "retries":
+
+			out.Values[i] = ec._FunctionConfiguration_retries(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "priority":
+
+			out.Values[i] = ec._FunctionConfiguration_priority(ctx, field, obj)
+
+		case "eventsBatch":
+
+			out.Values[i] = ec._FunctionConfiguration_eventsBatch(ctx, field, obj)
+
+		case "concurrency":
+
+			out.Values[i] = ec._FunctionConfiguration_concurrency(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "rateLimit":
+
+			out.Values[i] = ec._FunctionConfiguration_rateLimit(ctx, field, obj)
+
+		case "debounce":
+
+			out.Values[i] = ec._FunctionConfiguration_debounce(ctx, field, obj)
+
+		case "throttle":
+
+			out.Values[i] = ec._FunctionConfiguration_throttle(ctx, field, obj)
+
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -20532,6 +22518,77 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 	return out
 }
 
+var rateLimitConfigurationImplementors = []string{"RateLimitConfiguration"}
+
+func (ec *executionContext) _RateLimitConfiguration(ctx context.Context, sel ast.SelectionSet, obj *models.RateLimitConfiguration) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, rateLimitConfigurationImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RateLimitConfiguration")
+		case "limit":
+
+			out.Values[i] = ec._RateLimitConfiguration_limit(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "period":
+
+			out.Values[i] = ec._RateLimitConfiguration_period(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "key":
+
+			out.Values[i] = ec._RateLimitConfiguration_key(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var retryConfigurationImplementors = []string{"RetryConfiguration"}
+
+func (ec *executionContext) _RetryConfiguration(ctx context.Context, sel ast.SelectionSet, obj *models.RetryConfiguration) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, retryConfigurationImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RetryConfiguration")
+		case "value":
+
+			out.Values[i] = ec._RetryConfiguration_value(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "isDefault":
+
+			out.Values[i] = ec._RetryConfiguration_isDefault(ctx, field, obj)
+
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var runHistoryCancelImplementors = []string{"RunHistoryCancel"}
 
 func (ec *executionContext) _RunHistoryCancel(ctx context.Context, sel ast.SelectionSet, obj *history_reader.RunHistoryCancel) graphql.Marshaler {
@@ -21459,6 +23516,52 @@ func (ec *executionContext) _StreamItem(ctx context.Context, sel ast.SelectionSe
 	return out
 }
 
+var throttleConfigurationImplementors = []string{"ThrottleConfiguration"}
+
+func (ec *executionContext) _ThrottleConfiguration(ctx context.Context, sel ast.SelectionSet, obj *models.ThrottleConfiguration) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, throttleConfigurationImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ThrottleConfiguration")
+		case "burst":
+
+			out.Values[i] = ec._ThrottleConfiguration_burst(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "key":
+
+			out.Values[i] = ec._ThrottleConfiguration_key(ctx, field, obj)
+
+		case "limit":
+
+			out.Values[i] = ec._ThrottleConfiguration_limit(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "period":
+
+			out.Values[i] = ec._ThrottleConfiguration_period(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
 var userlandSpanImplementors = []string{"UserlandSpan"}
 
 func (ec *executionContext) _UserlandSpan(ctx context.Context, sel ast.SelectionSet, obj *models.UserlandSpan) graphql.Marshaler {
@@ -22070,6 +24173,90 @@ func (ec *executionContext) marshalNBytes2ᚕstringᚄ(ctx context.Context, sel 
 	return ret
 }
 
+func (ec *executionContext) marshalNCancellationConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐCancellationConfiguration(ctx context.Context, sel ast.SelectionSet, v *models.CancellationConfiguration) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._CancellationConfiguration(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNConcurrencyConfiguration2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConcurrencyConfigurationᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.ConcurrencyConfiguration) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNConcurrencyConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConcurrencyConfiguration(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNConcurrencyConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConcurrencyConfiguration(ctx context.Context, sel ast.SelectionSet, v *models.ConcurrencyConfiguration) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ConcurrencyConfiguration(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNConcurrencyLimitConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConcurrencyLimitConfiguration(ctx context.Context, sel ast.SelectionSet, v *models.ConcurrencyLimitConfiguration) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ConcurrencyLimitConfiguration(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNConcurrencyScope2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConcurrencyScope(ctx context.Context, v interface{}) (models.ConcurrencyScope, error) {
+	var res models.ConcurrencyScope
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNConcurrencyScope2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConcurrencyScope(ctx context.Context, sel ast.SelectionSet, v models.ConcurrencyScope) graphql.Marshaler {
+	return v
+}
+
 func (ec *executionContext) unmarshalNConnectV1ConnectionStatus2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConnectV1ConnectionStatus(ctx context.Context, v interface{}) (models.ConnectV1ConnectionStatus, error) {
 	var res models.ConnectV1ConnectionStatus
 	err := res.UnmarshalGQL(v)
@@ -22508,6 +24695,16 @@ func (ec *executionContext) marshalNPageInfo2ᚖgithubᚗcomᚋinngestᚋinngest
 		return graphql.Null
 	}
 	return ec._PageInfo(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNRetryConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐRetryConfiguration(ctx context.Context, sel ast.SelectionSet, v *models.RetryConfiguration) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._RetryConfiguration(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNRunHistoryItem2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋhistory_readerᚐRunHistoryᚄ(ctx context.Context, sel ast.SelectionSet, v []*history_reader.RunHistory) graphql.Marshaler {
@@ -23224,6 +25421,53 @@ func (ec *executionContext) marshalOBytes2ᚖstring(ctx context.Context, sel ast
 	return res
 }
 
+func (ec *executionContext) marshalOCancellationConfiguration2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐCancellationConfigurationᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.CancellationConfiguration) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNCancellationConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐCancellationConfiguration(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalOConnectV1ConnectionStatus2ᚕgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConnectV1ConnectionStatusᚄ(ctx context.Context, v interface{}) ([]models.ConnectV1ConnectionStatus, error) {
 	if v == nil {
 		return nil, nil
@@ -23314,6 +25558,13 @@ func (ec *executionContext) marshalOConnectV1WorkerConnectionsOrderByField2ᚖgi
 	return v
 }
 
+func (ec *executionContext) marshalODebounceConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐDebounceConfiguration(ctx context.Context, sel ast.SelectionSet, v *models.DebounceConfiguration) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._DebounceConfiguration(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOEvent2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐEventᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.Event) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -23384,6 +25635,13 @@ func (ec *executionContext) marshalOEventStatus2ᚖgithubᚗcomᚋinngestᚋinng
 	return v
 }
 
+func (ec *executionContext) marshalOEventsBatchConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐEventsBatchConfiguration(ctx context.Context, sel ast.SelectionSet, v *models.EventsBatchConfiguration) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._EventsBatchConfiguration(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOFunction2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.Function) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -23436,6 +25694,13 @@ func (ec *executionContext) marshalOFunction2ᚖgithubᚗcomᚋinngestᚋinngest
 		return graphql.Null
 	}
 	return ec._Function(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOFunctionConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionConfiguration(ctx context.Context, sel ast.SelectionSet, v *models.FunctionConfiguration) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._FunctionConfiguration(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOFunctionEventType2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionEventType(ctx context.Context, v interface{}) (*models.FunctionEventType, error) {
@@ -23750,6 +26015,13 @@ func (ec *executionContext) marshalOMap2map(ctx context.Context, sel ast.Selecti
 	return res
 }
 
+func (ec *executionContext) marshalORateLimitConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐRateLimitConfiguration(ctx context.Context, sel ast.SelectionSet, v *models.RateLimitConfiguration) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._RateLimitConfiguration(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalORerunFromStepInput2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐRerunFromStepInput(ctx context.Context, v interface{}) (*models.RerunFromStepInput, error) {
 	if v == nil {
 		return nil, nil
@@ -23907,6 +26179,13 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 	}
 	res := graphql.MarshalString(*v)
 	return res
+}
+
+func (ec *executionContext) marshalOThrottleConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐThrottleConfiguration(ctx context.Context, sel ast.SelectionSet, v *models.ThrottleConfiguration) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._ThrottleConfiguration(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOTime2ᚖtimeᚐTime(ctx context.Context, v interface{}) (*time.Time, error) {

--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -3071,7 +3071,7 @@ type Function {
   name: String!
   slug: String!
   config: String!
-  configuration: FunctionConfiguration # configuration is here?
+  configuration: FunctionConfiguration!
   concurrency: Int!
   triggers: [FunctionTrigger!]
   url: String!
@@ -3113,7 +3113,7 @@ type FunctionEvent {
 }
 
 type FunctionConfiguration {
-  cancellations: [CancellationConfiguration!]
+  cancellations: [CancellationConfiguration!]!
   retries: RetryConfiguration!
   priority: String
   eventsBatch: EventsBatchConfiguration
@@ -7315,11 +7315,14 @@ func (ec *executionContext) _Function_configuration(ctx context.Context, field g
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*models.FunctionConfiguration)
 	fc.Result = res
-	return ec.marshalOFunctionConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionConfiguration(ctx, field.Selections, res)
+	return ec.marshalNFunctionConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionConfiguration(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Function_configuration(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -7629,11 +7632,14 @@ func (ec *executionContext) _FunctionConfiguration_cancellations(ctx context.Con
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.([]*models.CancellationConfiguration)
 	fc.Result = res
-	return ec.marshalOCancellationConfiguration2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐCancellationConfigurationᚄ(ctx, field.Selections, res)
+	return ec.marshalNCancellationConfiguration2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐCancellationConfigurationᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_FunctionConfiguration_cancellations(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -21491,6 +21497,9 @@ func (ec *executionContext) _Function(ctx context.Context, sel ast.SelectionSet,
 
 			out.Values[i] = ec._Function_configuration(ctx, field, obj)
 
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "concurrency":
 
 			out.Values[i] = ec._Function_concurrency(ctx, field, obj)
@@ -21561,6 +21570,9 @@ func (ec *executionContext) _FunctionConfiguration(ctx context.Context, sel ast.
 
 			out.Values[i] = ec._FunctionConfiguration_cancellations(ctx, field, obj)
 
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		case "retries":
 
 			out.Values[i] = ec._FunctionConfiguration_retries(ctx, field, obj)
@@ -24344,6 +24356,50 @@ func (ec *executionContext) marshalNBytes2ᚕstringᚄ(ctx context.Context, sel 
 	return ret
 }
 
+func (ec *executionContext) marshalNCancellationConfiguration2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐCancellationConfigurationᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.CancellationConfiguration) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNCancellationConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐCancellationConfiguration(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNCancellationConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐCancellationConfiguration(ctx context.Context, sel ast.SelectionSet, v *models.CancellationConfiguration) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -24688,6 +24744,16 @@ func (ec *executionContext) marshalNFunction2ᚖgithubᚗcomᚋinngestᚋinngest
 		return graphql.Null
 	}
 	return ec._Function(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNFunctionConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionConfiguration(ctx context.Context, sel ast.SelectionSet, v *models.FunctionConfiguration) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._FunctionConfiguration(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNFunctionQuery2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionQuery(ctx context.Context, v interface{}) (models.FunctionQuery, error) {
@@ -25597,53 +25663,6 @@ func (ec *executionContext) marshalOBytes2ᚖstring(ctx context.Context, sel ast
 	return res
 }
 
-func (ec *executionContext) marshalOCancellationConfiguration2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐCancellationConfigurationᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.CancellationConfiguration) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNCancellationConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐCancellationConfiguration(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
 func (ec *executionContext) unmarshalOConnectV1ConnectionStatus2ᚕgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐConnectV1ConnectionStatusᚄ(ctx context.Context, v interface{}) ([]models.ConnectV1ConnectionStatus, error) {
 	if v == nil {
 		return nil, nil
@@ -25870,13 +25889,6 @@ func (ec *executionContext) marshalOFunction2ᚖgithubᚗcomᚋinngestᚋinngest
 		return graphql.Null
 	}
 	return ec._Function(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalOFunctionConfiguration2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionConfiguration(ctx context.Context, sel ast.SelectionSet, v *models.FunctionConfiguration) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._FunctionConfiguration(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOFunctionEventType2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionEventType(ctx context.Context, v interface{}) (*models.FunctionEventType, error) {

--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -285,6 +285,7 @@ type ComplexityRoot struct {
 		Apps                   func(childComplexity int, filter *models.AppsFilterV1) int
 		Event                  func(childComplexity int, query models.EventQuery) int
 		Events                 func(childComplexity int, query models.EventsQuery) int
+		FunctionBySlug         func(childComplexity int, query models.FunctionQuery) int
 		FunctionRun            func(childComplexity int, query models.FunctionRunQuery) int
 		Functions              func(childComplexity int) int
 		Run                    func(childComplexity int, runID string) int
@@ -560,6 +561,7 @@ type QueryResolver interface {
 	Stream(ctx context.Context, query models.StreamQuery) ([]*models.StreamItem, error)
 	Event(ctx context.Context, query models.EventQuery) (*models.Event, error)
 	Events(ctx context.Context, query models.EventsQuery) ([]*models.Event, error)
+	FunctionBySlug(ctx context.Context, query models.FunctionQuery) (*models.Function, error)
 	Functions(ctx context.Context) ([]*models.Function, error)
 	FunctionRun(ctx context.Context, query models.FunctionRunQuery) (*models.FunctionRun, error)
 	Runs(ctx context.Context, first int, after *string, orderBy []*models.RunsV2OrderBy, filter models.RunsFilterV2) (*models.RunsV2Connection, error)
@@ -1771,6 +1773,18 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Events(childComplexity, args["query"].(models.EventsQuery)), true
 
+	case "Query.functionBySlug":
+		if e.complexity.Query.FunctionBySlug == nil {
+			break
+		}
+
+		args, err := ec.field_Query_functionBySlug_args(context.TODO(), rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.FunctionBySlug(childComplexity, args["query"].(models.FunctionQuery)), true
+
 	case "Query.functionRun":
 		if e.complexity.Query.FunctionRun == nil {
 			break
@@ -2743,6 +2757,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputCreateAppInput,
 		ec.unmarshalInputEventQuery,
 		ec.unmarshalInputEventsQuery,
+		ec.unmarshalInputFunctionQuery,
 		ec.unmarshalInputFunctionRunQuery,
 		ec.unmarshalInputFunctionRunsQuery,
 		ec.unmarshalInputRerunFromStepInput,
@@ -2854,6 +2869,8 @@ input RerunFromStepInput {
   # Get all events sent
   events(query: EventsQuery!): [Event!]
 
+  functionBySlug(query: FunctionQuery!): Function
+
   # Get all functions registered
   functions: [Function!]
 
@@ -2894,6 +2911,11 @@ input EventQuery {
 input EventsQuery {
   workspaceId: ID! = "local"
   lastEventId: ID
+}
+
+input FunctionQuery {
+  workspaceId: ID! = "local"
+  functionSlug: String!
 }
 
 input FunctionRunQuery {
@@ -3796,6 +3818,21 @@ func (ec *executionContext) field_Query_events_args(ctx context.Context, rawArgs
 	if tmp, ok := rawArgs["query"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
 		arg0, err = ec.unmarshalNEventsQuery2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐEventsQuery(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["query"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_functionBySlug_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+	var err error
+	args := map[string]interface{}{}
+	var arg0 models.FunctionQuery
+	if tmp, ok := rawArgs["query"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("query"))
+		arg0, err = ec.unmarshalNFunctionQuery2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionQuery(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -11821,6 +11858,80 @@ func (ec *executionContext) fieldContext_Query_events(ctx context.Context, field
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_events_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_functionBySlug(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_functionBySlug(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return ec.resolvers.Query().FunctionBySlug(rctx, fc.Args["query"].(models.FunctionQuery))
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*models.Function)
+	fc.Result = res
+	return ec.marshalOFunction2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunction(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_functionBySlug(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_Function_id(ctx, field)
+			case "name":
+				return ec.fieldContext_Function_name(ctx, field)
+			case "slug":
+				return ec.fieldContext_Function_slug(ctx, field)
+			case "config":
+				return ec.fieldContext_Function_config(ctx, field)
+			case "configuration":
+				return ec.fieldContext_Function_configuration(ctx, field)
+			case "concurrency":
+				return ec.fieldContext_Function_concurrency(ctx, field)
+			case "triggers":
+				return ec.fieldContext_Function_triggers(ctx, field)
+			case "url":
+				return ec.fieldContext_Function_url(ctx, field)
+			case "appID":
+				return ec.fieldContext_Function_appID(ctx, field)
+			case "app":
+				return ec.fieldContext_Function_app(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Function", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_functionBySlug_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return
 	}
@@ -20106,6 +20217,46 @@ func (ec *executionContext) unmarshalInputEventsQuery(ctx context.Context, obj i
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputFunctionQuery(ctx context.Context, obj interface{}) (models.FunctionQuery, error) {
+	var it models.FunctionQuery
+	asMap := map[string]interface{}{}
+	for k, v := range obj.(map[string]interface{}) {
+		asMap[k] = v
+	}
+
+	if _, present := asMap["workspaceId"]; !present {
+		asMap["workspaceId"] = "local"
+	}
+
+	fieldsInOrder := [...]string{"workspaceId", "functionSlug"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "workspaceId":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("workspaceId"))
+			it.WorkspaceID, err = ec.unmarshalNID2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "functionSlug":
+			var err error
+
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("functionSlug"))
+			it.FunctionSlug, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputFunctionRunQuery(ctx context.Context, obj interface{}) (models.FunctionRunQuery, error) {
 	var it models.FunctionRunQuery
 	asMap := map[string]interface{}{}
@@ -22323,6 +22474,26 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Concurrently(i, func() graphql.Marshaler {
 				return rrm(innerCtx)
 			})
+		case "functionBySlug":
+			field := field
+
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_functionBySlug(ctx, field)
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx, innerFunc)
+			}
+
+			out.Concurrently(i, func() graphql.Marshaler {
+				return rrm(innerCtx)
+			})
 		case "functions":
 			field := field
 
@@ -24517,6 +24688,11 @@ func (ec *executionContext) marshalNFunction2ᚖgithubᚗcomᚋinngestᚋinngest
 		return graphql.Null
 	}
 	return ec._Function(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNFunctionQuery2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionQuery(ctx context.Context, v interface{}) (models.FunctionQuery, error) {
+	res, err := ec.unmarshalInputFunctionQuery(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalNFunctionRun2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐFunctionRun(ctx context.Context, sel ast.SelectionSet, v models.FunctionRun) graphql.Marshaler {

--- a/pkg/coreapi/gql.query.graphql
+++ b/pkg/coreapi/gql.query.graphql
@@ -10,6 +10,8 @@ type Query {
   # Get all events sent
   events(query: EventsQuery!): [Event!]
 
+  functionBySlug(query: FunctionQuery!): Function
+
   # Get all functions registered
   functions: [Function!]
 
@@ -50,6 +52,11 @@ input EventQuery {
 input EventsQuery {
   workspaceId: ID! = "local"
   lastEventId: ID
+}
+
+input FunctionQuery {
+  workspaceId: ID! = "local"
+  functionSlug: String!
 }
 
 input FunctionRunQuery {

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -130,7 +130,7 @@ type Function {
   name: String!
   slug: String!
   config: String!
-  configuration: FunctionConfiguration
+  configuration: FunctionConfiguration!
   concurrency: Int!
   triggers: [FunctionTrigger!]
   url: String!
@@ -172,7 +172,7 @@ type FunctionEvent {
 }
 
 type FunctionConfiguration {
-  cancellations: [CancellationConfiguration!]
+  cancellations: [CancellationConfiguration!]!
   retries: RetryConfiguration!
   priority: String
   eventsBatch: EventsBatchConfiguration

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -130,6 +130,7 @@ type Function {
   name: String!
   slug: String!
   config: String!
+  configuration: FunctionConfiguration
   concurrency: Int!
   triggers: [FunctionTrigger!]
   url: String!
@@ -168,6 +169,73 @@ type FunctionEvent {
   type: FunctionEventType
   output: String
   createdAt: Time
+}
+
+type FunctionConfiguration {
+  cancellations: [CancellationConfiguration!]
+  retries: RetryConfiguration!
+  priority: String
+  eventsBatch: EventsBatchConfiguration
+  concurrency: [ConcurrencyConfiguration!]!
+  rateLimit: RateLimitConfiguration
+  debounce: DebounceConfiguration
+  throttle: ThrottleConfiguration
+}
+
+type CancellationConfiguration {
+  event: String!
+  timeout: String
+  condition: String
+}
+
+type RetryConfiguration {
+  value: Int!
+  isDefault: Boolean
+}
+
+type EventsBatchConfiguration {
+  "The maximum number of events a batch can have."
+  maxSize: Int!
+
+  "How long to wait before running the function with the batch."
+  timeout: String!
+
+  key: String
+}
+
+type ConcurrencyConfiguration {
+  scope: ConcurrencyScope!
+  limit: ConcurrencyLimitConfiguration!
+  key: String
+}
+
+enum ConcurrencyScope {
+  ACCOUNT
+  ENVIRONMENT
+  FUNCTION
+}
+
+type ConcurrencyLimitConfiguration {
+  value: Int!
+  isPlanLimit: Boolean
+}
+
+type RateLimitConfiguration {
+  limit: Int!
+  period: String!
+  key: String
+}
+
+type DebounceConfiguration {
+  period: String!
+  key: String
+}
+
+type ThrottleConfiguration {
+  burst: Int!
+  key: String
+  limit: Int!
+  period: String!
 }
 
 enum StepEventType {

--- a/pkg/coreapi/graph/models/converters.go
+++ b/pkg/coreapi/graph/models/converters.go
@@ -3,7 +3,6 @@ package models
 import (
 	"context"
 	"fmt"
-
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/logger"
@@ -40,15 +39,18 @@ func MakeFunction(f *cqrs.Function) (*Function, error) {
 		concurrency = fn.Concurrency.PartitionConcurrency()
 	}
 
+	config := ToFunctionConfiguration(fn, UnknownPlanConcurrencyLimit)
+
 	return &Function{
-		AppID:       f.AppID.String(),
-		ID:          f.ID.String(),
-		Name:        f.Name,
-		Slug:        f.Slug,
-		Config:      string(f.Config),
-		Concurrency: concurrency,
-		Triggers:    triggers,
-		URL:         fn.Steps[0].URI,
+		AppID:         f.AppID.String(),
+		ID:            f.ID.String(),
+		Name:          f.Name,
+		Slug:          f.Slug,
+		Config:        string(f.Config),
+		Configuration: config,
+		Concurrency:   concurrency,
+		Triggers:      triggers,
+		URL:           fn.Steps[0].URI,
 	}, nil
 }
 

--- a/pkg/coreapi/graph/models/function_configuration_serializer.go
+++ b/pkg/coreapi/graph/models/function_configuration_serializer.go
@@ -1,0 +1,137 @@
+package models
+
+import (
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/inngest"
+)
+
+// used for dev server since we don't have user's plan
+const UnknownPlanConcurrencyLimit = -1
+
+func ToFunctionConfiguration(fn *inngest.Function, planConcurrencyLimit int) *FunctionConfiguration {
+	var concurrencyConfig []*ConcurrencyConfiguration
+	if fn.Concurrency != nil {
+		concurrencyConfig = make([]*ConcurrencyConfiguration, len(fn.Concurrency.Limits))
+		for i, conc := range fn.Concurrency.Limits {
+			concLimit := conc.Limit
+			if planConcurrencyLimit > 0 {
+				concLimit = min(conc.Limit, planConcurrencyLimit)
+			}
+
+			concurrencyConfig[i] = &ConcurrencyConfiguration{
+				Scope: mapScope(conc.Scope),
+				Limit: &ConcurrencyLimitConfiguration{
+					Value:       concLimit,
+					IsPlanLimit: boolPtr(concLimit == planConcurrencyLimit),
+				},
+				Key: conc.Key,
+			}
+		}
+	} else {
+		concurrencyConfig = []*ConcurrencyConfiguration{
+			{
+				Scope: ConcurrencyScopeAccount,
+				Limit: &ConcurrencyLimitConfiguration{
+					Value:       planConcurrencyLimit, // TODO: render -1 as infinite on frontend?
+					IsPlanLimit: boolPtr(true),
+				},
+			},
+		}
+	}
+
+	var priority *string
+	if fn.Priority != nil && fn.Priority.Run != nil {
+		priority = fn.Priority.Run
+	}
+
+	var throttle *ThrottleConfiguration
+	if fn.Throttle != nil {
+		throttle = &ThrottleConfiguration{
+			Burst: int(fn.Throttle.Burst),
+			Key:   fn.Throttle.Key,
+			Limit: int(fn.Throttle.Limit),
+
+			// TODO: We need a custom "time.Duration to string" function that
+			// formats it more closely to what we want. For example,
+			// time.Duration.String formats `48 * time.Hour` as "48h0m0s", but
+			// we really want it to be "2d"
+			Period: fn.Throttle.Period.String(),
+		}
+	}
+
+	return &FunctionConfiguration{
+		Cancellations: mapCancellations(fn.Cancel),
+		Retries: &RetryConfiguration{
+			Value:     fn.Steps[0].RetryCount(),
+			IsDefault: boolPtr(fn.Steps[0].RetryCount() == consts.DefaultRetryCount),
+		},
+		Priority:    priority,
+		EventsBatch: mapEventsBatch(fn.EventBatch),
+		Concurrency: concurrencyConfig,
+		RateLimit:   mapRateLimit(fn.RateLimit),
+		Debounce:    mapDebounce(fn.Debounce),
+		Throttle:    throttle,
+	}
+}
+
+func mapCancellations(cancels []inngest.Cancel) []*CancellationConfiguration {
+	cancellations := make([]*CancellationConfiguration, len(cancels))
+	for i, cancel := range cancels {
+		cancellations[i] = &CancellationConfiguration{
+			Event:     cancel.Event,
+			Timeout:   cancel.Timeout,
+			Condition: cancel.If,
+		}
+	}
+	return cancellations
+}
+
+func mapEventsBatch(batch *inngest.EventBatchConfig) *EventsBatchConfiguration {
+	if batch == nil {
+		return nil
+	}
+	return &EventsBatchConfiguration{
+		MaxSize: batch.MaxSize,
+		Timeout: batch.Timeout,
+		Key:     batch.Key,
+	}
+}
+
+func mapRateLimit(limit *inngest.RateLimit) *RateLimitConfiguration {
+	if limit == nil {
+		return nil
+	}
+	return &RateLimitConfiguration{
+		Limit:  int(limit.Limit),
+		Period: limit.Period,
+		Key:    limit.Key,
+	}
+}
+
+func mapDebounce(debounce *inngest.Debounce) *DebounceConfiguration {
+	if debounce == nil {
+		return nil
+	}
+	return &DebounceConfiguration{
+		Period: debounce.Period,
+		Key:    debounce.Key,
+	}
+}
+
+func mapScope(internalEnum enums.ConcurrencyScope) ConcurrencyScope {
+	var enumMapping = map[enums.ConcurrencyScope]ConcurrencyScope{
+		enums.ConcurrencyScopeFn:      ConcurrencyScopeFunction,
+		enums.ConcurrencyScopeEnv:     ConcurrencyScopeEnvironment,
+		enums.ConcurrencyScopeAccount: ConcurrencyScopeAccount,
+	}
+
+	if gqlEnum, ok := enumMapping[internalEnum]; ok {
+		return gqlEnum
+	}
+	return ConcurrencyScopeFunction
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/pkg/coreapi/graph/models/function_configuration_serializer_test.go
+++ b/pkg/coreapi/graph/models/function_configuration_serializer_test.go
@@ -279,6 +279,7 @@ func mergeWithDefaultFunction(overlay *inngest.Function) *inngest.Function {
 
 func mergeWithDefaultFunctionConfiguration(overlay *FunctionConfiguration) *FunctionConfiguration {
 	base := &FunctionConfiguration{
+		Cancellations: []*CancellationConfiguration{},
 		Retries: &RetryConfiguration{
 			Value:     4,
 			IsDefault: boolPtr(true),

--- a/pkg/coreapi/graph/models/function_configuration_serializer_test.go
+++ b/pkg/coreapi/graph/models/function_configuration_serializer_test.go
@@ -235,16 +235,10 @@ func TestToFunctionConfiguration(t *testing.T) {
 			if err != nil {
 				t.Errorf("Invalid function configuration for test %v: %v", tt.name, err)
 			}
-			//if got := ToFunctionConfiguration(tt.args.fn, tt.args.planConcurrencyLimit); !reflect.DeepEqual(got, tt.expected) {
-			//	gotJson, _ := json.MarshalIndent(got, "", "  ")
-			//	wantJson, _ := json.MarshalIndent(tt.expected, "", "  ")
-			//	t.Errorf("ToFunctionConfiguration() = \n%s, expected \n%s", gotJson, wantJson)
-			//}
-			got := ToFunctionConfiguration(tt.fn, tt.planConcurrencyLimit)
-			gotJson, _ := json.MarshalIndent(got, "", "  ")
-			wantJson, _ := json.MarshalIndent(tt.expected, "", "  ")
-			if !reflect.DeepEqual(gotJson, wantJson) {
-				t.Errorf("ToFunctionConfiguration() = \n%s, expected \n%s", gotJson, wantJson)
+			if got := ToFunctionConfiguration(tt.fn, tt.planConcurrencyLimit); !reflect.DeepEqual(got, tt.expected) {
+				gotJson, _ := json.MarshalIndent(got, "", "  ")
+				expectedJson, _ := json.MarshalIndent(tt.expected, "", "  ")
+				t.Errorf("ToFunctionConfiguration() = \n%s, expected \n%s", gotJson, expectedJson)
 			}
 		})
 	}

--- a/pkg/coreapi/graph/models/function_configuration_serializer_test.go
+++ b/pkg/coreapi/graph/models/function_configuration_serializer_test.go
@@ -1,0 +1,305 @@
+package models
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/util"
+	"github.com/jinzhu/copier"
+)
+
+func TestToFunctionConfiguration(t *testing.T) {
+	tests := []struct {
+		name                 string
+		fn                   *inngest.Function
+		planConcurrencyLimit int
+		expected             *FunctionConfiguration
+	}{
+		{
+			name: "cancellations",
+			fn: mergeWithDefaultFunction(&inngest.Function{
+				Cancel: []inngest.Cancel{
+					{
+						Event:   "test/cancel",
+						Timeout: util.StrPtr("30m"),
+						If:      util.StrPtr("event.data.id == 2"),
+					},
+				},
+			}),
+			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
+			expected: mergeWithDefaultFunctionConfiguration(&FunctionConfiguration{
+				Cancellations: []*CancellationConfiguration{
+					{
+						Event:     "test/cancel",
+						Timeout:   util.StrPtr("30m"),
+						Condition: util.StrPtr("event.data.id == 2"),
+					},
+				},
+			}),
+		},
+		{
+			// default retries are already covered by every other test case
+			name: "retries, non-default",
+			fn: mergeWithDefaultFunction(&inngest.Function{
+				Steps: []inngest.Step{
+					{
+						ID:      "test-step",
+						Name:    "test-step",
+						URI:     "https://example.com/api/inngest?step=foo",
+						Retries: intPtr(10),
+					},
+				},
+			}),
+			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
+			expected: mergeWithDefaultFunctionConfiguration(&FunctionConfiguration{
+				Retries: &RetryConfiguration{
+					Value:     10,
+					IsDefault: boolPtr(false),
+				},
+			}),
+		},
+		{
+			name: "priority",
+			fn: mergeWithDefaultFunction(&inngest.Function{
+				Priority: &inngest.Priority{
+					Run: util.StrPtr("event.data.plan == 'enterprise' ? 180 : 0"),
+				},
+			}),
+			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
+			expected: mergeWithDefaultFunctionConfiguration(&FunctionConfiguration{
+				Priority: util.StrPtr("event.data.plan == 'enterprise' ? 180 : 0"),
+			}),
+		},
+		{
+			name: "batch events",
+			fn: mergeWithDefaultFunction(&inngest.Function{
+				EventBatch: &inngest.EventBatchConfig{
+					MaxSize: 50,
+					Timeout: "30s",
+					Key:     util.StrPtr("event.data.customer_id"),
+				},
+			}),
+			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
+			expected: mergeWithDefaultFunctionConfiguration(&FunctionConfiguration{
+				EventsBatch: &EventsBatchConfiguration{
+					MaxSize: 50,
+					Timeout: "30s",
+					Key:     util.StrPtr("event.data.customer_id"),
+				},
+			}),
+		},
+		{
+			name: "concurrency, no plan limit (i.e. dev-server)",
+			fn: mergeWithDefaultFunction(&inngest.Function{
+				Concurrency: &inngest.ConcurrencyLimits{
+					Limits: []inngest.Concurrency{
+						{
+							Scope: enums.ConcurrencyScopeAccount,
+							Limit: 20,
+							Key:   util.StrPtr("event.data.id == 2"),
+						},
+						{
+							Scope: enums.ConcurrencyScopeFn,
+							Limit: 5,
+							Key:   util.StrPtr("event.data.id == 2"),
+						},
+					},
+				},
+			}),
+			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
+			expected: mergeWithDefaultFunctionConfiguration(&FunctionConfiguration{
+				Concurrency: []*ConcurrencyConfiguration{
+					{
+						Scope: ConcurrencyScopeAccount,
+						Limit: &ConcurrencyLimitConfiguration{
+							Value:       20,
+							IsPlanLimit: boolPtr(false),
+						},
+						Key: util.StrPtr("event.data.id == 2"),
+					},
+					{
+						Scope: ConcurrencyScopeFunction,
+						Limit: &ConcurrencyLimitConfiguration{
+							Value:       5,
+							IsPlanLimit: boolPtr(false),
+						},
+						Key: util.StrPtr("event.data.id == 2"),
+					},
+				},
+			}),
+		},
+		{
+			name: "concurrency, with plan limit (i.e. cloud)",
+			fn: mergeWithDefaultFunction(&inngest.Function{
+				Concurrency: &inngest.ConcurrencyLimits{
+					Limits: []inngest.Concurrency{
+						{
+							Scope: enums.ConcurrencyScopeAccount,
+							Limit: 20,
+							Key:   util.StrPtr("event.data.id == 2"),
+						},
+						{
+							Scope: enums.ConcurrencyScopeFn,
+							Limit: 5,
+							Key:   util.StrPtr("event.data.id == 2"),
+						},
+					},
+				},
+			}),
+			planConcurrencyLimit: 10,
+			expected: mergeWithDefaultFunctionConfiguration(&FunctionConfiguration{
+				Concurrency: []*ConcurrencyConfiguration{
+					{
+						Scope: ConcurrencyScopeAccount,
+						Limit: &ConcurrencyLimitConfiguration{
+							Value:       10,
+							IsPlanLimit: boolPtr(true),
+						},
+						Key: util.StrPtr("event.data.id == 2"),
+					},
+					{
+						Scope: ConcurrencyScopeFunction,
+						Limit: &ConcurrencyLimitConfiguration{
+							Value:       5,
+							IsPlanLimit: boolPtr(false),
+						},
+						Key: util.StrPtr("event.data.id == 2"),
+					},
+				},
+			}),
+		},
+		{
+			name: "rate limit",
+			fn: mergeWithDefaultFunction(&inngest.Function{
+				RateLimit: &inngest.RateLimit{
+					Limit:  10,
+					Period: "30s",
+					Key:    util.StrPtr("event.data.customer_id"),
+				},
+			}),
+			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
+			expected: mergeWithDefaultFunctionConfiguration(&FunctionConfiguration{
+				RateLimit: &RateLimitConfiguration{
+					Limit:  10,
+					Period: "30s",
+					Key:    util.StrPtr("event.data.customer_id"),
+				},
+			}),
+		},
+		{
+			name: "debounce",
+			fn: mergeWithDefaultFunction(&inngest.Function{
+				Debounce: &inngest.Debounce{
+					Key:    nil,
+					Period: "10s",
+				},
+			}),
+			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
+			expected: mergeWithDefaultFunctionConfiguration(&FunctionConfiguration{
+				Debounce: &DebounceConfiguration{
+					Key:    nil,
+					Period: "10s",
+				},
+			}),
+		},
+		{
+			name: "throttle",
+			fn: mergeWithDefaultFunction(&inngest.Function{
+				Throttle: &inngest.Throttle{
+					Limit:  10,
+					Period: 30 * time.Minute,
+					Burst:  3,
+					Key:    util.StrPtr("event.data.customer_id"),
+				},
+			}),
+			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
+			expected: mergeWithDefaultFunctionConfiguration(&FunctionConfiguration{
+				Throttle: &ThrottleConfiguration{
+					Limit:  10,
+					Period: "30m0s",
+					Burst:  3,
+					Key:    util.StrPtr("event.data.customer_id"),
+				},
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn.Validate(context.Background())
+			if err != nil {
+				t.Errorf("Invalid function configuration for test %v: %v", tt.name, err)
+			}
+			//if got := ToFunctionConfiguration(tt.args.fn, tt.args.planConcurrencyLimit); !reflect.DeepEqual(got, tt.expected) {
+			//	gotJson, _ := json.MarshalIndent(got, "", "  ")
+			//	wantJson, _ := json.MarshalIndent(tt.expected, "", "  ")
+			//	t.Errorf("ToFunctionConfiguration() = \n%s, expected \n%s", gotJson, wantJson)
+			//}
+			got := ToFunctionConfiguration(tt.fn, tt.planConcurrencyLimit)
+			gotJson, _ := json.MarshalIndent(got, "", "  ")
+			wantJson, _ := json.MarshalIndent(tt.expected, "", "  ")
+			if !reflect.DeepEqual(gotJson, wantJson) {
+				t.Errorf("ToFunctionConfiguration() = \n%s, expected \n%s", gotJson, wantJson)
+			}
+		})
+	}
+}
+
+func mergeWithDefaultFunction(overlay *inngest.Function) *inngest.Function {
+	base := &inngest.Function{
+		Name: "test/function",
+		Triggers: []inngest.Trigger{
+			{
+				EventTrigger: &inngest.EventTrigger{
+					Event: "test/trigger",
+				},
+			},
+		},
+		Steps: []inngest.Step{
+			{
+				ID:   "test-step",
+				Name: "test-step",
+				URI:  "https://example.com/api/inngest?step=foo",
+			},
+		},
+		ID: uuid.MustParse("00000000-0000-0000-0000-000000000000"),
+	}
+	err := copier.CopyWithOption(base, overlay, copier.Option{IgnoreEmpty: true})
+	if err != nil {
+		return nil
+	}
+	return base
+
+}
+
+func mergeWithDefaultFunctionConfiguration(overlay *FunctionConfiguration) *FunctionConfiguration {
+	base := &FunctionConfiguration{
+		Retries: &RetryConfiguration{
+			Value:     4,
+			IsDefault: boolPtr(true),
+		},
+		Concurrency: []*ConcurrencyConfiguration{
+			{
+				Scope: ConcurrencyScopeAccount,
+				Limit: &ConcurrencyLimitConfiguration{
+					Value:       UnknownPlanConcurrencyLimit,
+					IsPlanLimit: boolPtr(true),
+				},
+			},
+		},
+	}
+	err := copier.CopyWithOption(base, overlay, copier.Option{IgnoreEmpty: true})
+	if err != nil {
+		return nil
+	}
+	return base
+}
+
+func intPtr(b int) *int {
+	return &b
+}

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -140,7 +140,7 @@ type Function struct {
 	Name          string                 `json:"name"`
 	Slug          string                 `json:"slug"`
 	Config        string                 `json:"config"`
-	Configuration *FunctionConfiguration `json:"configuration,omitempty"`
+	Configuration *FunctionConfiguration `json:"configuration"`
 	Concurrency   int                    `json:"concurrency"`
 	Triggers      []*FunctionTrigger     `json:"triggers,omitempty"`
 	URL           string                 `json:"url"`
@@ -149,7 +149,7 @@ type Function struct {
 }
 
 type FunctionConfiguration struct {
-	Cancellations []*CancellationConfiguration `json:"cancellations,omitempty"`
+	Cancellations []*CancellationConfiguration `json:"cancellations"`
 	Retries       *RetryConfiguration          `json:"retries"`
 	Priority      *string                      `json:"priority,omitempty"`
 	EventsBatch   *EventsBatchConfiguration    `json:"eventsBatch,omitempty"`

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -169,6 +169,11 @@ type FunctionEvent struct {
 
 func (FunctionEvent) IsFunctionRunEvent() {}
 
+type FunctionQuery struct {
+	WorkspaceID  string `json:"workspaceId"`
+	FunctionSlug string `json:"functionSlug"`
+}
+
 type FunctionRun struct {
 	ID                string                       `json:"id"`
 	FunctionID        string                       `json:"functionID"`

--- a/pkg/coreapi/graph/resolvers/function.go
+++ b/pkg/coreapi/graph/resolvers/function.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/pkg/cqrs"
 )
@@ -14,9 +15,7 @@ func (r *functionResolver) App(ctx context.Context, obj *models.Function) (*cqrs
 }
 
 func (qr *queryResolver) FunctionBySlug(ctx context.Context, query models.FunctionQuery) (*models.Function, error) {
-	dummyLocalWorkspaceID := uuid.MustParse("6c6f6361-6c00-0000-0000-000000000000")
-
-	fn, err := qr.Data.GetFunctionByExternalID(ctx, dummyLocalWorkspaceID, "local", query.FunctionSlug)
+	fn, err := qr.Data.GetFunctionByExternalID(ctx, consts.DevServerEnvID, "local", query.FunctionSlug)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/coreapi/graph/resolvers/function.go
+++ b/pkg/coreapi/graph/resolvers/function.go
@@ -12,3 +12,13 @@ func (r *functionResolver) App(ctx context.Context, obj *models.Function) (*cqrs
 	appID := uuid.MustParse(obj.AppID)
 	return r.Data.GetAppByID(ctx, appID)
 }
+
+func (qr *queryResolver) FunctionBySlug(ctx context.Context, query models.FunctionQuery) (*models.Function, error) {
+	dummyLocalWorkspaceID := uuid.MustParse("6c6f6361-6c00-0000-0000-000000000000")
+
+	fn, err := qr.Data.GetFunctionByExternalID(ctx, dummyLocalWorkspaceID, "local", query.FunctionSlug)
+	if err != nil {
+		return nil, err
+	}
+	return models.MakeFunction(fn)
+}

--- a/ui/apps/dev-server-ui/src/store/generated.ts
+++ b/ui/apps/dev-server-ui/src/store/generated.ts
@@ -250,6 +250,11 @@ export enum FunctionEventType {
   Started = 'STARTED'
 }
 
+export type FunctionQuery = {
+  functionSlug: Scalars['String'];
+  workspaceId?: Scalars['ID'];
+};
+
 export type FunctionRun = {
   __typename?: 'FunctionRun';
   batchCreatedAt: Maybe<Scalars['Time']>;
@@ -457,6 +462,7 @@ export type Query = {
   apps: Array<App>;
   event: Maybe<Event>;
   events: Maybe<Array<Event>>;
+  functionBySlug: Maybe<Function>;
   functionRun: Maybe<FunctionRun>;
   functions: Maybe<Array<Function>>;
   run: Maybe<FunctionRunV2>;
@@ -486,6 +492,11 @@ export type QueryEventArgs = {
 
 export type QueryEventsArgs = {
   query: EventsQuery;
+};
+
+
+export type QueryFunctionBySlugArgs = {
+  query: FunctionQuery;
 };
 
 

--- a/ui/apps/dev-server-ui/src/store/generated.ts
+++ b/ui/apps/dev-server-ui/src/store/generated.ts
@@ -55,6 +55,32 @@ export type AppsFilterV1 = {
   method?: InputMaybe<AppMethod>;
 };
 
+export type CancellationConfiguration = {
+  __typename?: 'CancellationConfiguration';
+  condition: Maybe<Scalars['String']>;
+  event: Scalars['String'];
+  timeout: Maybe<Scalars['String']>;
+};
+
+export type ConcurrencyConfiguration = {
+  __typename?: 'ConcurrencyConfiguration';
+  key: Maybe<Scalars['String']>;
+  limit: ConcurrencyLimitConfiguration;
+  scope: ConcurrencyScope;
+};
+
+export type ConcurrencyLimitConfiguration = {
+  __typename?: 'ConcurrencyLimitConfiguration';
+  isPlanLimit: Maybe<Scalars['Boolean']>;
+  value: Scalars['Int'];
+};
+
+export enum ConcurrencyScope {
+  Account = 'ACCOUNT',
+  Environment = 'ENVIRONMENT',
+  Function = 'FUNCTION'
+}
+
 export enum ConnectV1ConnectionStatus {
   Connected = 'CONNECTED',
   Disconnected = 'DISCONNECTED',
@@ -132,6 +158,12 @@ export type CreateAppInput = {
   url: Scalars['String'];
 };
 
+export type DebounceConfiguration = {
+  __typename?: 'DebounceConfiguration';
+  key: Maybe<Scalars['String']>;
+  period: Scalars['String'];
+};
+
 export type Event = {
   __typename?: 'Event';
   createdAt: Maybe<Scalars['Time']>;
@@ -162,6 +194,15 @@ export enum EventStatus {
   Running = 'RUNNING'
 }
 
+export type EventsBatchConfiguration = {
+  __typename?: 'EventsBatchConfiguration';
+  key: Maybe<Scalars['String']>;
+  /** The maximum number of events a batch can have. */
+  maxSize: Scalars['Int'];
+  /** How long to wait before running the function with the batch. */
+  timeout: Scalars['String'];
+};
+
 export type EventsQuery = {
   lastEventId?: InputMaybe<Scalars['ID']>;
   workspaceId?: Scalars['ID'];
@@ -173,11 +214,24 @@ export type Function = {
   appID: Scalars['String'];
   concurrency: Scalars['Int'];
   config: Scalars['String'];
+  configuration: Maybe<FunctionConfiguration>;
   id: Scalars['String'];
   name: Scalars['String'];
   slug: Scalars['String'];
   triggers: Maybe<Array<FunctionTrigger>>;
   url: Scalars['String'];
+};
+
+export type FunctionConfiguration = {
+  __typename?: 'FunctionConfiguration';
+  cancellations: Maybe<Array<CancellationConfiguration>>;
+  concurrency: Array<ConcurrencyConfiguration>;
+  debounce: Maybe<DebounceConfiguration>;
+  eventsBatch: Maybe<EventsBatchConfiguration>;
+  priority: Maybe<Scalars['String']>;
+  rateLimit: Maybe<RateLimitConfiguration>;
+  retries: RetryConfiguration;
+  throttle: Maybe<ThrottleConfiguration>;
 };
 
 export type FunctionEvent = {
@@ -480,9 +534,22 @@ export type QueryWorkerConnectionsArgs = {
   orderBy: Array<ConnectV1WorkerConnectionsOrderBy>;
 };
 
+export type RateLimitConfiguration = {
+  __typename?: 'RateLimitConfiguration';
+  key: Maybe<Scalars['String']>;
+  limit: Scalars['Int'];
+  period: Scalars['String'];
+};
+
 export type RerunFromStepInput = {
   input?: InputMaybe<Scalars['Bytes']>;
   stepID: Scalars['String'];
+};
+
+export type RetryConfiguration = {
+  __typename?: 'RetryConfiguration';
+  isDefault: Maybe<Scalars['Boolean']>;
+  value: Scalars['Int'];
 };
 
 export type RunHistoryCancel = {
@@ -720,6 +787,14 @@ export enum StreamType {
   Cron = 'CRON',
   Event = 'EVENT'
 }
+
+export type ThrottleConfiguration = {
+  __typename?: 'ThrottleConfiguration';
+  burst: Scalars['Int'];
+  key: Maybe<Scalars['String']>;
+  limit: Scalars['Int'];
+  period: Scalars['String'];
+};
 
 export type UpdateAppInput = {
   id: Scalars['String'];


### PR DESCRIPTION
## Description

This is the backend necessary so we can show function configuration details in the dev server frontend.

I copied over the FunctionConfiguration gql schema from monorepo as well as the serialization code, but refactored it slightly
so we should be able to easily share it between monorepo and inngest/inngest going forward

This can currently be tested by going to http://localhost:8288/v0 and using the following query
```
query GetFunction($functionSlug: String!) {
  functionBySlug(query: { functionSlug: $functionSlug }) {
    name
    id
    concurrency
    config
    configuration {
      cancellations {
        event
        timeout
        condition
      }
      retries {
        value
        isDefault
      }
      priority
      eventsBatch {
        maxSize
        timeout
        key
      }
      concurrency {
        scope
        limit {
          value
          isPlanLimit
        }
        key
      }
      rateLimit {
        limit
        period
        key
      }
      debounce {
        period
        key
      }
      throttle {
        burst
        key
        limit
        period
      }
    }
    slug
    url
  }
}
```

## Motivation

We want to show function configuration in the dev server

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
