### PR TITLE
Add data to pause timeout jobs

### DIFF
--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -410,6 +410,13 @@ type PayloadPauseBlockFlush struct {
 type PayloadPauseTimeout struct {
 	PauseID   uuid.UUID `json:"pauseID"`
 	OnTimeout bool      `json:"onTimeout"`
+	// Event is required such that we can load the pause by ID.  This is an empty
+	// string for signals and invokes.
+	Event string `json:"e,omitempty"`
+	// StepID is the ID of the step (the hashed opcode, and the key for step state)
+	// that will be timing out.  This lets us consume the timeout idempotently without
+	// loading the pause.
+	StepID string `json:"sID"`
 }
 
 func HashID(_ context.Context, id string) string {


### PR DESCRIPTION
This PR introduces the event and step ID to timeout jobs.  In the future, this lets us load pauses from the blobstore and also resume timeouts idempotently without loading pauses at all, decreasing load on the system.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
