### PR TITLE
ignore already lease error for backlog normalization

### DIFF
--- a/pkg/execution/state/redis_state/backlog_normalization.go
+++ b/pkg/execution/state/redis_state/backlog_normalization.go
@@ -89,9 +89,7 @@ func (q *queue) backlogNormalizationScan(ctx context.Context) error {
 
 // iterateNormalizationPartition scans and iterate through the global normalization partition to process backlogs needing to be normalized
 func (q *queue) iterateNormalizationPartition(ctx context.Context, until time.Time, bc chan normalizeWorkerChanMsg) error {
-	// TODO: check capacity
-
-	// TODO introduce weight probability to blend account/global scanning
+	// introduce weight probability to blend account/global scanning
 	peekedAccounts, err := q.peekGlobalNormalizeAccounts(ctx, until, NormalizeAccountPeekMax)
 	if err != nil {
 		return fmt.Errorf("could not peek global normalize accounts: %w", err)

--- a/pkg/execution/state/redis_state/backlog_normalization_test.go
+++ b/pkg/execution/state/redis_state/backlog_normalization_test.go
@@ -491,46 +491,107 @@ func TestBacklogNormalizationScanner(t *testing.T) {
 		QueueName: nil,
 	}
 
-	// Create backlog
-	for i := range 100 {
-		at := clock.Now().Add(time.Duration(i*100) * time.Millisecond)
-		_, err := q.EnqueueItem(ctx, defaultShard, item, at, osqueue.EnqueueOpts{})
+	t.Run("async normalization", func(t *testing.T) {
+		r.FlushAll()
+
+		// Create backlog
+		for i := range 100 {
+			at := clock.Now().Add(time.Duration(i*100) * time.Millisecond)
+			_, err := q.EnqueueItem(ctx, defaultShard, item, at, osqueue.EnqueueOpts{})
+			require.NoError(t, err)
+		}
+
+		// Verify backlog is created as expected
+		backlog := q.ItemBacklog(ctx, item)
+		require.NotEmpty(t, backlog.BacklogID)
+
+		shadowPartition := q.ItemShadowPartition(ctx, item)
+		require.NotEmpty(t, shadowPartition.PartitionID)
+
+		backlogCount, shouldNormalizeAsync, err := q.BacklogPrepareNormalize(ctx, &backlog, &shadowPartition, 5)
 		require.NoError(t, err)
-	}
+		require.True(t, shouldNormalizeAsync)
+		require.Equal(t, 100, backlogCount)
+		require.Equal(t, 100, zcard(t, rc, kg.BacklogSet(backlog.BacklogID)))
+		require.True(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
+		require.True(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
+		require.True(t, hasMember(t, r, kg.PartitionNormalizeSet(fnID.String()), backlog.BacklogID))
 
-	// Verify backlog is created as expected
-	backlog := q.ItemBacklog(ctx, item)
-	require.NotEmpty(t, backlog.BacklogID)
+		bc := make(chan normalizeWorkerChanMsg, 1)
 
-	shadowPartition := q.ItemShadowPartition(ctx, item)
-	require.NotEmpty(t, shadowPartition.PartitionID)
+		err = q.iterateNormalizationPartition(ctx, clock.Now().Add(time.Hour), bc)
+		require.NoError(t, err)
 
-	backlogCount, shouldNormalizeAsync, err := q.BacklogPrepareNormalize(ctx, &backlog, &shadowPartition, 5)
-	require.NoError(t, err)
-	require.True(t, shouldNormalizeAsync)
-	require.Equal(t, 100, backlogCount)
-	require.Equal(t, 100, zcard(t, rc, kg.BacklogSet(backlog.BacklogID)))
-	require.True(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
-	require.True(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
-	require.True(t, hasMember(t, r, kg.PartitionNormalizeSet(fnID.String()), backlog.BacklogID))
+		select {
+		case msg := <-bc:
+			require.Equal(t, backlog, *msg.b)
+		default:
+			require.Fail(t, "did not push backlog into channel")
+			return
+		}
 
-	bc := make(chan normalizeWorkerChanMsg, 1)
+		err = q.normalizeBacklog(ctx, &backlog, &shadowPartition)
+		require.NoError(t, err)
+		require.Equal(t, 0, zcard(t, rc, kg.BacklogSet(backlog.BacklogID)))
+		require.False(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
+		require.False(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
+		require.False(t, hasMember(t, r, kg.PartitionNormalizeSet(fnID.String()), backlog.BacklogID))
+	})
 
-	err = q.iterateNormalizationPartition(ctx, clock.Now().Add(time.Hour), bc)
-	require.NoError(t, err)
+	t.Run("non async normalization", func(t *testing.T) {
+		r.FlushAll()
 
-	select {
-	case msg := <-bc:
-		require.Equal(t, backlog, *msg.b)
-	default:
-		require.Fail(t, "did not push backlog into channel")
-		return
-	}
+		// Create backlog
+		for i := range 3 {
+			at := clock.Now().Add(time.Duration(i*100) * time.Millisecond)
+			_, err := q.EnqueueItem(ctx, defaultShard, item, at, osqueue.EnqueueOpts{})
+			require.NoError(t, err)
+		}
 
-	err = q.normalizeBacklog(ctx, &backlog, &shadowPartition)
-	require.NoError(t, err)
-	require.Equal(t, 0, zcard(t, rc, kg.BacklogSet(backlog.BacklogID)))
-	require.False(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
-	require.False(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
-	require.False(t, hasMember(t, r, kg.PartitionNormalizeSet(fnID.String()), backlog.BacklogID))
+		// Verify backlog is created as expected
+		backlog := q.ItemBacklog(ctx, item)
+		require.NotEmpty(t, backlog.BacklogID)
+
+		shadowPartition := q.ItemShadowPartition(ctx, item)
+		require.NotEmpty(t, shadowPartition.PartitionID)
+
+		backlogCount, shouldNormalizeAsync, err := q.BacklogPrepareNormalize(ctx, &backlog, &shadowPartition, 5)
+		require.NoError(t, err)
+		require.False(t, shouldNormalizeAsync)
+		require.Equal(t, 3, backlogCount)
+		require.Equal(t, 3, zcard(t, rc, kg.BacklogSet(backlog.BacklogID)))
+		require.False(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
+		require.False(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
+		require.False(t, hasMember(t, r, kg.PartitionNormalizeSet(fnID.String()), backlog.BacklogID))
+	})
+
+	t.Run("non async normalization lease contention", func(t *testing.T) {
+		r.FlushAll()
+
+		// Create backlog
+		for i := range 3 {
+			at := clock.Now().Add(time.Duration(i*100) * time.Millisecond)
+			_, err := q.EnqueueItem(ctx, defaultShard, item, at, osqueue.EnqueueOpts{})
+			require.NoError(t, err)
+		}
+
+		// Verify backlog is created as expected
+		backlog := q.ItemBacklog(ctx, item)
+		require.NotEmpty(t, backlog.BacklogID)
+
+		shadowPartition := q.ItemShadowPartition(ctx, item)
+		require.NotEmpty(t, shadowPartition.PartitionID)
+
+		// simulate contention by leasing the backlog for normalization first
+		require.NoError(t, q.leaseBacklogForNormalization(ctx, &backlog))
+
+		backlogCount, shouldNormalizeAsync, err := q.BacklogPrepareNormalize(ctx, &backlog, &shadowPartition, 5)
+		require.NoError(t, err)
+		require.False(t, shouldNormalizeAsync)
+		require.Equal(t, 3, backlogCount)
+		require.Equal(t, 3, zcard(t, rc, kg.BacklogSet(backlog.BacklogID)))
+		require.False(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
+		require.False(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
+		require.False(t, hasMember(t, r, kg.PartitionNormalizeSet(fnID.String()), backlog.BacklogID))
+	})
 }

--- a/pkg/execution/state/redis_state/shadow_queue.go
+++ b/pkg/execution/state/redis_state/shadow_queue.go
@@ -201,6 +201,10 @@ func (q *queue) processShadowPartition(ctx context.Context, shadowPart *QueueSha
 					err := q.leaseBacklogForNormalization(ctx, backlog)
 					return nil, err
 				}); err != nil {
+					if errors.Is(err, errBacklogAlreadyLeasedForNormalization) {
+						continue
+					}
+
 					return err
 				}
 

--- a/pkg/execution/state/redis_state/shadow_queue_test.go
+++ b/pkg/execution/state/redis_state/shadow_queue_test.go
@@ -1960,7 +1960,7 @@ func TestShadowPartitionPointerTimings(t *testing.T) {
 		require.Len(t, peeked, 1)
 		require.Equal(t, backlog, *peeked[0])
 
-		for i := 0; i < numItems; i++ {
+		for i := range numItems {
 			itemAt := now.Add(time.Duration(i+1) * time.Second)
 			refillUntil := itemAt
 			res, err := q.BacklogRefill(ctx, &backlog, &shadowPart, refillUntil)


### PR DESCRIPTION
## Description

not ignoring contention errors will result in the queue exiting, and that shouldn't happen.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
