### PR TITLE
omit billing plan slug to unblock deploys

### DIFF
--- a/ui/apps/dashboard/src/components/Billing/Plans/utils.tsx
+++ b/ui/apps/dashboard/src/components/Billing/Plans/utils.tsx
@@ -7,7 +7,10 @@ import type {
   EntitlementRunCount,
 } from '@/gql/graphql';
 
-export type Plan = Omit<BillingPlan, 'entitlements' | 'features' | 'availableAddons' | 'addons'> & {
+export type Plan = Omit<
+  BillingPlan,
+  'entitlements' | 'features' | 'availableAddons' | 'addons' | 'slug'
+> & {
   entitlements: {
     concurrency: Pick<EntitlementConcurrency, 'limit'>;
     runCount: Pick<EntitlementRunCount, 'limit'>;


### PR DESCRIPTION
## Description

Omits slug field on billing plan type as it is breaking our prod ui deploys.

## Motivation


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
