### PR TITLE
Swap to using CH for get fn run & jobs & cancel fn run

### DIFF
--- a/pkg/api/apiv1/runs.go
+++ b/pkg/api/apiv1/runs.go
@@ -28,7 +28,8 @@ func (a router) GetFunctionRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fr, err := a.opts.FunctionRunReader.GetFunctionRun(ctx, auth.AccountID(), auth.WorkspaceID(), runID)
+	fr, err := a.opts.TraceReader.GetRun(ctx, runID, auth.AccountID(), auth.WorkspaceID())
+
 	if err != nil {
 		_ = publicerr.WriteHTTP(w, publicerr.Wrapf(err, 500, "Unable to load function run: %s", chi.URLParam(r, "runID")))
 		return
@@ -45,12 +46,8 @@ func (a API) CancelFunctionRun(ctx context.Context, runID ulid.ULID) error {
 		return publicerr.Wrap(err, 401, "No auth found")
 	}
 
-	fr, err := a.opts.FunctionRunReader.GetFunctionRun(
-		ctx,
-		auth.AccountID(),
-		auth.WorkspaceID(),
-		runID,
-	)
+	fr, err := a.opts.TraceReader.GetRun(ctx, runID, auth.AccountID(), auth.WorkspaceID())
+
 	if err != nil {
 		return publicerr.Wrapf(err, 404, "Unable to load function run: %s", runID)
 	}
@@ -99,12 +96,8 @@ func (a router) GetFunctionRunJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fr, err := a.opts.FunctionRunReader.GetFunctionRun(
-		ctx,
-		auth.AccountID(),
-		auth.WorkspaceID(),
-		runID,
-	)
+	fr, err := a.opts.TraceReader.GetRun(ctx, runID, auth.AccountID(), auth.WorkspaceID())
+
 	if err != nil {
 		_ = publicerr.WriteHTTP(w, publicerr.Wrapf(err, 500, "Unable to load function run: %s", chi.URLParam(r, "runID")))
 		return

--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -1560,6 +1560,15 @@ func (w wrapper) GetEventRuns(
 	return result, nil
 }
 
+func (w wrapper) GetRun(
+	ctx context.Context,
+	runID ulid.ULID,
+	accountID uuid.UUID,
+	workspaceID uuid.UUID,
+) (*cqrs.FunctionRun, error) {
+	return w.GetFunctionRun(ctx, accountID, workspaceID, runID)
+}
+
 //
 // Connect
 //
@@ -2033,10 +2042,10 @@ func (w wrapper) GetWorkerConnections(ctx context.Context, opt cqrs.GetWorkerCon
 // copyWriter allows running duck-db specific functions as CQRS functions, copying CQRS types to DDB types
 // automatically.
 func copyWriter[
-	PARAMS_IN any,
-	INTERNAL_PARAMS any,
-	IN any,
-	OUT any,
+PARAMS_IN any,
+INTERNAL_PARAMS any,
+IN any,
+OUT any,
 ](
 	ctx context.Context,
 	f func(context.Context, INTERNAL_PARAMS) (IN, error),
@@ -2059,8 +2068,8 @@ func copyWriter[
 }
 
 func copyInto[
-	IN any,
-	OUT any,
+IN any,
+OUT any,
 ](
 	ctx context.Context,
 	f func(context.Context) (IN, error),

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -267,6 +267,8 @@ type TraceReader interface {
 	OtelTracesEnabled(ctx context.Context, accountID uuid.UUID) (bool, error)
 	// GetEventRuns returns the runs that were triggered by an event.
 	GetEventRuns(ctx context.Context, eventID ulid.ULID, accountID uuid.UUID, workspaceID uuid.UUID) ([]*FunctionRun, error)
+	// GetRun returns a single function run.
+	GetRun(ctx context.Context, runID ulid.ULID, accountID uuid.UUID, workspaceID uuid.UUID) (*FunctionRun, error)
 }
 
 type GetTraceRunOpt struct {


### PR DESCRIPTION
## Description
Switch to using ClickHouse instead of BigQuery for getting runs by ID for these REST APIs:
- `v1/runs/{runID}`
- `v1/runs/{runID}/jobs`
- `DELETE v1/runs/{runID}`


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
