### PR TITLE
Decrease animation duration for SlideOver from 500ms to 250ms

### DIFF
--- a/ui/apps/dev-server-ui/src/components/SlideOver.tsx
+++ b/ui/apps/dev-server-ui/src/components/SlideOver.tsx
@@ -27,10 +27,10 @@ export default function SlideOver({ children, onClose, size }: SlideOverProps) {
         <Transition.Child
           as={Fragment}
           appear={true}
-          enter="ease-in-out duration-500"
+          enter="ease-in-out duration-[250ms]"
           enterFrom="opacity-0"
           enterTo="opacity-100"
-          leave="ease-in-out duration-500"
+          leave="ease-in-out duration-[250ms]"
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
@@ -46,20 +46,20 @@ export default function SlideOver({ children, onClose, size }: SlideOverProps) {
             >
               <Transition.Child
                 as="div"
-                enter="transform transition ease-in-out duration-500 sm:duration-700"
+                enter="transform transition ease-in-out duration-[250ms]"
                 enterFrom="translate-x-full"
                 enterTo="translate-x-0"
-                leave="transform transition ease-in-out duration-500 sm:duration-700"
+                leave="transform transition ease-in-out duration-[250ms]"
                 leaveFrom="translate-x-0"
                 leaveTo="translate-x-full"
               >
                 <Dialog.Panel className="pointer-events-auto relative h-full w-screen">
                   <Transition.Child
                     as="div"
-                    enter="ease-in-out duration-500"
+                    enter="ease-in-out duration-[250ms]"
                     enterFrom="opacity-0"
                     enterTo="opacity-100"
-                    leave="ease-in-out duration-500"
+                    leave="ease-in-out duration-[250ms]"
                     leaveFrom="opacity-100"
                     leaveTo="opacity-0"
                   />


### PR DESCRIPTION
## Description

- Decrease SlideOver animation duration from 500ms to 250ms. This applies to both upcoming Function config and existing Streams

- Sanjana also agreed we don't need the responsive `sm:duration-700` anymore

- `duration-250` doesn't exist in tailwind 3, so I just used `duration-[250ms]`. We are already doing this in a few places in RunsV3 as well.
  https://v3.tailwindcss.com/docs/transition-duration

## Motivation

Per discussion with Sanjana, we want this to be faster for Function config. Although it is a bit fast for Streams, we do not mind applying it there either because less implementation complexity and that page should be changing soon.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
