### PR TITLE
Add support for Inngest Realtime to Self-Host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.20.2-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.24.3-alpine AS build
 RUN apk add build-base
 WORKDIR /app
 COPY vendor vendor

--- a/cmd/commands/internal/localconfig/devconfig.go
+++ b/cmd/commands/internal/localconfig/devconfig.go
@@ -109,6 +109,7 @@ func mapStartFlags(cmd *cobra.Command) error {
 	err = errors.Join(err, viper.BindPFlag("port", cmd.Flags().Lookup("port")))
 	err = errors.Join(err, viper.BindPFlag("signing-key", cmd.Flags().Lookup("signing-key")))
 	err = errors.Join(err, viper.BindPFlag("event-key", cmd.Flags().Lookup("event-key")))
+	err = errors.Join(err, viper.BindPFlag("realtime-jwt-secret", cmd.Flags().Lookup("realtime-jwt-secret")))
 	err = errors.Join(err, viper.BindPFlag("redis-uri", cmd.Flags().Lookup("redis-uri")))
 	err = errors.Join(err, viper.BindPFlag("postgres-uri", cmd.Flags().Lookup("postgres-uri")))
 	err = errors.Join(err, viper.BindPFlag("poll-interval", cmd.Flags().Lookup("poll-interval")))

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -39,6 +39,7 @@ func NewCmdStart(rootCmd *cobra.Command) *cobra.Command {
 	baseFlags.StringSliceP("sdk-url", "u", []string{}, "App serve URLs to sync (ex. http://localhost:3000/api/inngest)")
 	baseFlags.String("signing-key", "", "Signing key used to sign and validate data between the server and apps.")
 	baseFlags.StringSlice("event-key", []string{}, "Event key(s) that will be used by apps to send events to the server.")
+	baseFlags.String("realtime-jwt-secret", "", "JWT secret used for realtime connections and authentication.")
 	cmd.Flags().AddFlagSet(baseFlags)
 	groups = append(groups, FlagGroup{name: "Flags:", fs: baseFlags})
 
@@ -158,6 +159,7 @@ func doStart(cmd *cobra.Command, args []string) {
 		SQLiteDir:          viper.GetString("sqlite-dir"),
 		SigningKey:         viper.GetString("signing-key"),
 		EventKey:           viper.GetStringSlice("event-key"),
+		RealtimeJWTSecret:  []byte(viper.GetString("realtime-jwt-secret")),
 		ConnectGatewayPort: viper.GetInt("connect-gateway-port"),
 	}
 


### PR DESCRIPTION
## Description

Adds required flags to lite.go to enable realtime support when self hosting

Also bumps the GoLang version in the Dockerfile to fix the build

## Motivation
To use Inngest Realtime in our application that requires self hosting

We've been running these changes in production for over a month now.

## Type of change (choose one)
- [ x ] New feature (non-breaking change that adds functionality)

## Checklist
- [ x ] I've linked any associated issues to this PR.
- [ x ] I've tested my own changes.