### PR TITLE
Test and add metrics for finalize

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -975,6 +975,13 @@ func (e *executor) HandleResponse(ctx context.Context, i *runInstance) error {
 					i.resp.Generator = []*state.GeneratorOpcode{}
 				}
 
+				metrics.IncrRunFinalizedCounter(ctx, metrics.CounterOpt{
+					PkgName: pkgName,
+					Tags: map[string]any{
+						"reason": "fail-early",
+					},
+				})
+
 				if err := e.finalize(ctx, i.md, i.events, i.f.GetSlug(), e.assignedQueueShard, *i.resp); err != nil {
 					l.Error("error running finish handler", "error", err)
 				}
@@ -1020,6 +1027,13 @@ func (e *executor) HandleResponse(ctx context.Context, i *runInstance) error {
 		// only OpcodeStepError causes try/catch to be handled and us to continue
 		// on error.
 
+		metrics.IncrRunFinalizedCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags: map[string]any{
+				"reason": "resp-err",
+			},
+		})
+
 		// TODO: Refactor state input
 		if err := e.finalize(ctx, i.md, i.events, i.f.GetSlug(), e.assignedQueueShard, *i.resp); err != nil {
 			l.Error("error running finish handler", "error", err)
@@ -1036,6 +1050,13 @@ func (e *executor) HandleResponse(ctx context.Context, i *runInstance) error {
 	// The generator length check is necessary because parallel steps in older
 	// SDK versions (e.g. 2.7.2) can result in an OpcodeNone.
 	if len(i.resp.Generator) == 0 && i.resp.IsFunctionResult() {
+		metrics.IncrRunFinalizedCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags: map[string]any{
+				"reason": "opcode-none",
+			},
+		})
+
 		// This is the function result.
 		if err := e.finalize(ctx, i.md, i.events, i.f.GetSlug(), e.assignedQueueShard, *i.resp); err != nil {
 			l.Error("error running finish handler", "error", err)
@@ -1748,6 +1769,13 @@ func (e *executor) Cancel(ctx context.Context, id sv2.ID, r execution.CancelRequ
 	if err != nil {
 		return fmt.Errorf("could not find shard for account %q: %w", md.ID.Tenant, err)
 	}
+
+	metrics.IncrRunFinalizedCounter(ctx, metrics.CounterOpt{
+		PkgName: pkgName,
+		Tags: map[string]any{
+			"reason": "cancel",
+		},
+	})
 
 	fnCancelledErr := state.ErrFunctionCancelled.Error()
 	if err := e.finalize(ctx, md, evts, f.Function.GetSlug(), shard, state.DriverResponse{

--- a/pkg/execution/executor/validate.go
+++ b/pkg/execution/executor/validate.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"time"
 
 	"github.com/inngest/inngest/pkg/expressions"
@@ -97,6 +98,13 @@ func (r *runValidator) checkStepLimit(ctx context.Context) error {
 
 		resp.Err = &gracefulErr
 		resp.SetFinal()
+
+		metrics.IncrRunFinalizedCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags: map[string]any{
+				"reason": "validation-step-limit-reached",
+			},
+		})
 
 		if err := r.e.finalize(ctx, r.md, r.evts, r.f.GetSlug(), r.e.assignedQueueShard, resp); err != nil {
 			l.Error("error running finish handler", "error", err)

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -195,6 +195,8 @@ func IsAlwaysRetryable(err error) bool {
 }
 
 type JobResponse struct {
+	// JobID is the item ID.
+	JobID string
 	// At represents the time the job is scheduled for.
 	At time.Time `json:"at"`
 	// Position represents the position for the job in the queue

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -1459,6 +1459,7 @@ func (q *queue) RunJobs(ctx context.Context, queueShardName string, workspaceID,
 			return nil, fmt.Errorf("error reading queue position: %w", err)
 		}
 		resp = append(resp, osqueue.JobResponse{
+			JobID:    qi.ID,
 			At:       time.UnixMilli(qi.AtMS),
 			Position: pos,
 			Kind:     qi.Data.Kind,

--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -455,3 +455,12 @@ func IncrQueueOutdatedBacklogCounter(ctx context.Context, opts CounterOpt) {
 		Tags:        opts.Tags,
 	})
 }
+
+func IncrRunFinalizedCounter(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "run_finalized_total",
+		Description: "The total number of calls to finalize a run.",
+		Tags:        opts.Tags,
+	})
+}

--- a/tests/execution/executor/executor_test.go
+++ b/tests/execution/executor/executor_test.go
@@ -3,7 +3,10 @@ package executor
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
+	"github.com/inngest/inngest/pkg/cqrs"
+	"golang.org/x/sync/errgroup"
 	"sync"
 	"testing"
 	"time"
@@ -75,6 +78,61 @@ func createInmemoryRedis(t *testing.T) (*miniredis.Miniredis, rueidis.Client, er
 		}
 	}()
 	return r, rc, nil
+}
+
+type fakeQueue struct {
+	queue.Queue
+
+	lock              sync.Mutex
+	dequeuedCalled    map[string]int64
+	dequeuedCalledRun map[ulid.ULID]int64
+}
+
+func (fq *fakeQueue) reset() {
+	fq.lock.Lock()
+	fq.dequeuedCalled = make(map[string]int64)
+	fq.dequeuedCalledRun = make(map[ulid.ULID]int64)
+	fq.lock.Unlock()
+}
+
+func (fq *fakeQueue) RemoveQueueItem(ctx context.Context, shard string, partitionKey string, itemID string) error {
+	qm := fq.Queue.(redis_state.QueueManager)
+	return qm.RemoveQueueItem(ctx, shard, partitionKey, itemID)
+}
+
+func (fq *fakeQueue) Requeue(ctx context.Context, queueShard redis_state.QueueShard, i queue.QueueItem, at time.Time) error {
+	qm := fq.Queue.(redis_state.QueueManager)
+	return qm.Requeue(ctx, queueShard, i, at)
+}
+
+func (fq *fakeQueue) RequeueByJobID(ctx context.Context, queueShard redis_state.QueueShard, jobID string, at time.Time) error {
+	qm := fq.Queue.(redis_state.QueueManager)
+	return qm.RequeueByJobID(ctx, queueShard, jobID, at)
+}
+
+func (fq *fakeQueue) Dequeue(ctx context.Context, queueShard redis_state.QueueShard, i queue.QueueItem) error {
+	qm := fq.Queue.(redis_state.QueueManager)
+
+	err := qm.Dequeue(ctx, queueShard, i)
+
+	fq.lock.Lock()
+	logger.StdlibLogger(ctx).Info("called fakeQueue.Dequeue()", "i", i, "err", err)
+	fq.dequeuedCalled[i.ID]++
+	fq.dequeuedCalledRun[i.Data.Identifier.RunID]++
+	fq.lock.Unlock()
+
+	return err
+}
+
+func newFakeQueue(q queue.Queue) *fakeQueue {
+	fq := &fakeQueue{
+		Queue:             q,
+		lock:              sync.Mutex{},
+		dequeuedCalled:    make(map[string]int64),
+		dequeuedCalledRun: make(map[ulid.ULID]int64),
+	}
+
+	return fq
 }
 
 func TestScheduleRaceCondition(t *testing.T) {
@@ -414,4 +472,235 @@ func TestScheduleRaceConditionWithExistingIdempotencyKey(t *testing.T) {
 	require.Len(t, hookRunIDs, 1)
 	require.Equal(t, hookRunIDs[0], successMetaIDs[0])
 	require.Equal(t, fakeRunID, hookRunIDs[0])
+}
+
+func TestFinalize(t *testing.T) {
+	ctx := context.Background()
+	_ = trace.UserTracer()
+	work := make(chan *hookData)
+
+	db, err := base_cqrs.New(base_cqrs.BaseCQRSOptions{InMemory: true})
+	require.NoError(t, err)
+
+	// Initialize the devserver
+	dbDriver := "sqlite"
+	dbcqrs := base_cqrs.NewCQRS(db, dbDriver)
+	loader := dbcqrs.(state.FunctionLoader)
+
+	fnID, accountID, wsID, appID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+
+	fn := inngest.Function{
+		ID:              fnID,
+		FunctionVersion: 1,
+		Name:            "test-fn",
+		Slug:            "test-fn",
+	}
+
+	config, err := json.Marshal(fn)
+	require.NoError(t, err)
+
+	_, err = dbcqrs.UpsertApp(ctx, cqrs.UpsertAppParams{
+		ID:   appID,
+		Name: "test-app",
+	})
+	require.NoError(t, err)
+
+	_, err = dbcqrs.InsertFunction(ctx, cqrs.InsertFunctionParams{
+		ID:     fnID,
+		AppID:  appID,
+		Name:   fn.Name,
+		Slug:   fn.Slug,
+		Config: string(config),
+	})
+	require.NoError(t, err)
+
+	_, shardedRc, err := createInmemoryRedis(t)
+	require.NoError(t, err)
+	defer shardedRc.Close()
+
+	unshardedCluster, unshardedRc, err := createInmemoryRedis(t)
+	require.NoError(t, err)
+	defer unshardedRc.Close()
+
+	unshardedClient := redis_state.NewUnshardedClient(unshardedRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
+	shardedClient := redis_state.NewShardedClient(redis_state.ShardedClientOpts{
+		UnshardedClient:        unshardedClient,
+		FunctionRunStateClient: shardedRc,
+		StateDefaultKey:        redis_state.StateDefaultKey,
+		FnRunIsSharded:         redis_state.AlwaysShardOnRun,
+		BatchClient:            shardedRc,
+		QueueDefaultKey:        redis_state.QueueDefaultKey,
+	})
+
+	queueShard := redis_state.QueueShard{Name: consts.DefaultQueueShardName, RedisClient: unshardedClient.Queue(), Kind: string(enums.QueueShardKindRedis)}
+
+	shardSelector := func(ctx context.Context, _ uuid.UUID, _ *string) (redis_state.QueueShard, error) {
+		return queueShard, nil
+	}
+
+	queueShards := map[string]redis_state.QueueShard{
+		consts.DefaultQueueShardName: queueShard,
+	}
+
+	var sm state.Manager
+	sm, err = redis_state.New(
+		ctx,
+		redis_state.WithShardedClient(shardedClient),
+		redis_state.WithUnshardedClient(unshardedClient),
+	)
+	require.NoError(t, err)
+	smv2 := redis_state.MustRunServiceV2(sm)
+
+	queueOpts := []redis_state.QueueOpt{
+		redis_state.WithIdempotencyTTL(time.Hour),
+		redis_state.WithShardSelector(shardSelector),
+		redis_state.WithQueueShardClients(queueShards),
+	}
+
+	rq := redis_state.NewQueue(queueShard, queueOpts...)
+
+	testQueue := newFakeQueue(rq)
+
+	exec, err := executor.NewExecutor(
+		executor.WithStateManager(smv2),
+		executor.WithPauseManager(pauses.NewRedisOnlyManager(sm)),
+		executor.WithQueue(testQueue),
+		executor.WithLogger(logger.StdlibLogger(ctx)),
+		executor.WithFunctionLoader(loader),
+		executor.WithLifecycleListeners(newFakeLifecycle(work)),
+		executor.WithAssignedQueueShard(queueShard),
+		executor.WithShardSelector(shardSelector),
+		executor.WithTraceReader(dbcqrs),
+	)
+	require.NoError(t, err)
+
+	now := time.Now()
+	evtID1, evtID2 := ulid.MustNew(ulid.Timestamp(now), rand.Reader), ulid.MustNew(ulid.Timestamp(now), rand.Reader)
+
+	//
+	// Schedule two runs
+	//
+
+	run1, err := exec.Schedule(ctx, execution.ScheduleRequest{
+		Function:    fn,
+		At:          &now,
+		AccountID:   accountID,
+		WorkspaceID: wsID,
+		AppID:       appID,
+		Events: []event.TrackedEvent{
+			event.NewOSSTrackedEventWithID(event.Event{
+				Name: "test/event",
+			}, evtID1),
+		},
+	})
+	require.NoError(t, err)
+
+	kg := unshardedClient.Queue().KeyGenerator()
+
+	// Validate first run
+
+	require.True(t, unshardedCluster.Exists(kg.RunIndex(run1.ID.RunID)))
+
+	state1, err := smv2.LoadState(ctx, run1.ID)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, len(state1.Metadata.Config.EventIDs))
+
+	jobs1, err := rq.RunJobs(
+		ctx,
+		queueShard.Name,
+		run1.ID.Tenant.EnvID,
+		run1.ID.FunctionID,
+		run1.ID.RunID,
+		1000,
+		0,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, jobs1, 1)
+	require.Equal(t, queue.KindStart, jobs1[0].Kind)
+
+	run2, err := exec.Schedule(ctx, execution.ScheduleRequest{
+		Function:    fn,
+		At:          &now,
+		AccountID:   accountID,
+		WorkspaceID: wsID,
+		AppID:       appID,
+		Events: []event.TrackedEvent{
+			event.NewOSSTrackedEventWithID(event.Event{
+				Name: "test/event",
+			}, evtID2),
+		},
+	})
+	require.NoError(t, err)
+
+	// Validate second run
+	require.True(t, unshardedCluster.Exists(kg.RunIndex(run2.ID.RunID)))
+
+	state2, err := smv2.LoadState(ctx, run2.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(state2.Metadata.Config.EventIDs))
+
+	jobs2, err := rq.RunJobs(
+		ctx,
+		queueShard.Name,
+		run2.ID.Tenant.EnvID,
+		run2.ID.FunctionID,
+		run2.ID.RunID,
+		1000,
+		0,
+	)
+	require.NoError(t, err)
+
+	require.Len(t, jobs2, 1)
+
+	var item2 queue.QueueItem
+	require.NoError(t, json.Unmarshal([]byte(unshardedCluster.HGet(kg.QueueItem(), jobs2[0].JobID)), &item2))
+
+	t.Run("racing finalize will dequeue each other", func(t *testing.T) {
+		//
+		// Cancel both runs concurrently (we really only care about finalize)
+		//
+
+		eg := errgroup.Group{}
+		eg.Go(func() error {
+			return exec.Cancel(ctx, run1.ID, execution.CancelRequest{})
+		})
+		eg.Go(func() error {
+			return exec.Cancel(ctx, run1.ID, execution.CancelRequest{})
+		})
+
+		require.NoError(t, eg.Wait())
+
+		testQueue.lock.Lock()
+		require.Greater(t, len(testQueue.dequeuedCalled), 0)
+		require.Equal(t, int64(2), testQueue.dequeuedCalled[jobs1[0].JobID])
+		require.Greater(t, len(testQueue.dequeuedCalledRun), 0)
+		require.Equal(t, int64(2), testQueue.dequeuedCalledRun[run1.ID.RunID])
+		testQueue.lock.Unlock()
+	})
+
+	t.Run("finalize run from a queue item will Dequeue itself", func(t *testing.T) {
+		//
+		// Cancel both runs concurrently (we really only care about finalize)
+		//
+
+		testQueue.reset()
+
+		err := exec.Cancel(ctx, run2.ID, execution.CancelRequest{})
+		require.NoError(t, err)
+
+		testQueue.lock.Lock()
+		require.Greater(t, len(testQueue.dequeuedCalled), 0)
+		require.Equal(t, int64(1), testQueue.dequeuedCalled[jobs2[0].JobID])
+		require.Greater(t, len(testQueue.dequeuedCalledRun), 0)
+		require.Equal(t, int64(1), testQueue.dequeuedCalledRun[run2.ID.RunID])
+		testQueue.lock.Unlock()
+
+		err = rq.Dequeue(ctx, queueShard, item2)
+		require.ErrorIs(t, err, redis_state.ErrQueueItemNotFound)
+
+		err = rq.Requeue(ctx, queueShard, item2, time.Now())
+		require.ErrorIs(t, err, redis_state.ErrQueueItemNotFound)
+	})
 }


### PR DESCRIPTION
## Description

This PR introduces a new metric to distinguish calls to `finalize`. Usually, these will be due to Cancel() calls, but they could also happen for old parallelism. 

Every time we call `finalize`, we will Dequeue _all_ queue items, including the one that may be actively processed and invoking the finalize call. This always leads to an `queue item not found` error in `Requeue` or `Dequeue` once the item wraps up processing. Solutions for this could be to ignore the current queue item from being Dequeued in case the caller is a queue processor.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
