### PR TITLE
Rever account queue changes

### DIFF
--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -642,6 +642,14 @@ func (d debouncer) debounce(ctx context.Context, di DebounceItem, fn inngest.Fun
 	return err
 }
 
+type DebounceTest interface {
+	TestQueueItem(ctx context.Context, di DebounceItem, debounceID ulid.ULID) queue.Item
+}
+
+func (d debouncer) TestQueueItem(ctx context.Context, di DebounceItem, debounceID ulid.ULID) queue.Item {
+	return d.queueItem(ctx, di, debounceID)
+}
+
 func (d debouncer) queueItem(ctx context.Context, di DebounceItem, debounceID ulid.ULID) queue.Item {
 	maxAttempts := consts.MaxRetries + 1
 

--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -642,14 +642,6 @@ func (d debouncer) debounce(ctx context.Context, di DebounceItem, fn inngest.Fun
 	return err
 }
 
-type DebounceTest interface {
-	TestQueueItem(ctx context.Context, di DebounceItem, debounceID ulid.ULID) queue.Item
-}
-
-func (d debouncer) TestQueueItem(ctx context.Context, di DebounceItem, debounceID ulid.ULID) queue.Item {
-	return d.queueItem(ctx, di, debounceID)
-}
-
 func (d debouncer) queueItem(ctx context.Context, di DebounceItem, debounceID ulid.ULID) queue.Item {
 	maxAttempts := consts.MaxRetries + 1
 
@@ -1003,4 +995,12 @@ func readRedisScripts(path string, entries []fs.DirEntry) {
 		}
 		scripts[name] = rueidis.NewLuaScript(val)
 	}
+}
+
+type DebounceTest interface {
+	TestQueueItem(ctx context.Context, di DebounceItem, debounceID ulid.ULID) queue.Item
+}
+
+func (d debouncer) TestQueueItem(ctx context.Context, di DebounceItem, debounceID ulid.ULID) queue.Item {
+	return d.queueItem(ctx, di, debounceID)
 }

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -1049,7 +1049,8 @@ func TestQueueSystemPartitions(t *testing.T) {
 
 		apIds := getAccountPartitions(t, rc, accountId)
 		// it should not add system queues to account partitions
-		require.Equal(t, 0, len(apIds))
+		require.Equal(t, 1, len(apIds))
+		require.Contains(t, apIds, qp.ID)
 	})
 }
 

--- a/tests/execution/queue/system_queue_test.go
+++ b/tests/execution/queue/system_queue_test.go
@@ -1,0 +1,182 @@
+package queue
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/execution/batch"
+	"github.com/inngest/inngest/pkg/execution/debounce"
+	osqueue "github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/execution/state/redis_state"
+	"github.com/jonboulle/clockwork"
+	"github.com/oklog/ulid/v2"
+	"github.com/redis/rueidis"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestSystemQueueConfigs(t *testing.T) {
+
+	mapping := map[string]string{
+		osqueue.KindScheduleBatch: osqueue.KindScheduleBatch,
+		"pause-event":             "pause-event",
+		osqueue.KindDebounce:      osqueue.KindDebounce,
+		osqueue.KindQueueMigrate:  osqueue.KindQueueMigrate,
+	}
+
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	batchClient := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
+
+	defaultShard := redis_state.QueueShard{Kind: string(enums.QueueShardKindRedis), RedisClient: redis_state.NewQueueClient(rc, redis_state.QueueDefaultKey), Name: consts.DefaultQueueShardName}
+	kg := defaultShard.RedisClient.KeyGenerator()
+
+	clock := clockwork.NewFakeClockAt(time.Now().Truncate(time.Second))
+	now := clock.Now()
+
+	q := redis_state.NewQueue(
+		defaultShard,
+		redis_state.WithClock(clock),
+		redis_state.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID) bool {
+			return false
+		}),
+		redis_state.WithDisableLeaseChecks(func(ctx context.Context, acctID uuid.UUID) bool {
+			return true
+		}),
+		redis_state.WithKindToQueueMapping(mapping),
+		redis_state.WithShardSelector(func(ctx context.Context, accountId uuid.UUID, queueName *string) (redis_state.QueueShard, error) {
+			return defaultShard, nil
+		}),
+	)
+	ctx := context.Background()
+
+	accountId, fnID, wsID := uuid.New(), uuid.New(), uuid.New()
+
+	t.Run("batch items should be added to system queue", func(t *testing.T) {
+		r.FlushAll()
+
+		batcher := batch.NewRedisBatchManager(batchClient, q)
+
+		batchID := ulid.MustNew(ulid.Timestamp(now), rand.Reader)
+		bp := "test-pointer"
+
+		err := batcher.ScheduleExecution(ctx, batch.ScheduleBatchOpts{
+			ScheduleBatchPayload: batch.ScheduleBatchPayload{
+				BatchID:         batchID,
+				BatchPointer:    bp,
+				AccountID:       accountId,
+				WorkspaceID:     wsID,
+				FunctionID:      fnID,
+				FunctionVersion: 0,
+			},
+			At: now,
+		})
+		require.NoError(t, err)
+
+		require.True(t, r.Exists(kg.PartitionQueueSet(enums.PartitionTypeDefault, osqueue.KindScheduleBatch, "")))
+		require.True(t, r.Exists(kg.AccountPartitionIndex(accountId)))
+		require.True(t, r.Exists(kg.GlobalAccountIndex()))
+		require.True(t, hasMember(t, r, kg.GlobalAccountIndex(), accountId.String()))
+	})
+
+	t.Run("debounce timeouts should not be added to function queue", func(t *testing.T) {
+		r.FlushAll()
+
+		debouncer, err := debounce.NewRedisDebouncerWithMigration(debounce.DebouncerOpts{
+			PrimaryDebounceClient: redis_state.NewDebounceClient(rc, redis_state.QueueDefaultKey),
+			PrimaryQueue:          q,
+			PrimaryQueueShard:     defaultShard,
+			ShouldMigrate: func(ctx context.Context, accountID uuid.UUID) bool {
+				return false
+			},
+			Clock: clock,
+		})
+		require.NoError(t, err)
+
+		debounceID := ulid.MustNew(ulid.Timestamp(now), rand.Reader)
+
+		tester := debouncer.(debounce.DebounceTest)
+
+		qi := tester.TestQueueItem(ctx, debounce.DebounceItem{
+			AccountID:   accountId,
+			WorkspaceID: wsID,
+			FunctionID:  fnID,
+		}, debounceID)
+		require.NoError(t, err)
+
+		err = q.Enqueue(ctx, qi, now, osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+
+		require.True(t, r.Exists(kg.PartitionQueueSet(enums.PartitionTypeDefault, osqueue.KindDebounce, "")))
+		require.True(t, r.Exists(kg.AccountPartitionIndex(accountId)))
+		require.True(t, r.Exists(kg.GlobalAccountIndex()))
+		require.True(t, hasMember(t, r, kg.GlobalAccountIndex(), accountId.String()))
+	})
+
+	t.Run("pause timeouts should belong to fn queue", func(t *testing.T) {
+		r.FlushAll()
+
+		err := q.Enqueue(ctx, osqueue.Item{
+			WorkspaceID: wsID,
+			Kind:        osqueue.KindPause,
+			Identifier: state.Identifier{
+				WorkflowID:  fnID,
+				AccountID:   accountId,
+				WorkspaceID: wsID,
+			},
+			Payload: nil,
+		}, now, osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+
+		require.True(t, r.Exists(kg.PartitionQueueSet(enums.PartitionTypeDefault, fnID.String(), "")), r.Dump())
+		require.True(t, r.Exists(kg.AccountPartitionIndex(accountId)))
+		require.True(t, r.Exists(kg.GlobalAccountIndex()))
+		require.True(t, hasMember(t, r, kg.GlobalAccountIndex(), accountId.String()))
+	})
+
+	t.Run("pause events should not belong to fn queue", func(t *testing.T) {
+		r.FlushAll()
+
+		queueName := fmt.Sprintf("pause:%s", wsID.String())
+		err := q.Enqueue(ctx, osqueue.Item{
+			QueueName: &queueName, WorkspaceID: wsID,
+			Kind:    "pause-event",
+			Payload: nil,
+		}, now, osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+
+		require.True(t, r.Exists(kg.PartitionQueueSet(enums.PartitionTypeDefault, queueName, "")))
+		require.False(t, r.Exists(kg.AccountPartitionIndex(accountId)))
+		require.False(t, r.Exists(kg.GlobalAccountIndex()))
+		require.False(t, hasMember(t, r, kg.GlobalAccountIndex(), accountId.String()))
+	})
+
+}
+
+func hasMember(t *testing.T, r *miniredis.Miniredis, key string, member string) bool {
+	if !r.Exists(key) {
+		return false
+	}
+
+	members, err := r.ZMembers(key)
+	require.NoError(t, err)
+
+	for _, s := range members {
+		if s == member {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Description

This PR rolls the queue back to always using the Account ID stored in the item's identifier for core queue operations.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
