### PR TITLE
Swap Bigquery with Clickhouse in /v1/events

### DIFF
--- a/pkg/api/apiv1/apiv1.go
+++ b/pkg/api/apiv1/apiv1.go
@@ -28,8 +28,6 @@ type Opts struct {
 	AuthFinder apiv1auth.AuthFinder
 	// Executor is required to cancel and manage function executions.
 	Executor execution.Executor
-	// EventReader allows reading of events from storage.
-	EventReader EventReader
 	// FunctionReader reads functions from a backing store.
 	FunctionReader cqrs.FunctionReader
 	// FunctionRunReader reads function runs, history, etc. from backing storage

--- a/pkg/api/apiv1/events.go
+++ b/pkg/api/apiv1/events.go
@@ -24,17 +24,17 @@ const (
 // and filtering params.
 //
 // This has no API
-func (a API) GetEvents(ctx context.Context, opts *cqrs.WorkspaceEventsOpts) ([]cqrs.Event, error) {
+func (a API) GetEvents(ctx context.Context, opts *cqrs.WorkspaceEventsOpts) ([]*cqrs.Event, error) {
 	auth, err := a.opts.AuthFinder(ctx)
 	if err != nil {
 		return nil, publicerr.Wrap(err, 401, "No auth found")
 	}
 
-	if a.opts.EventReader == nil {
-		return nil, publicerr.Errorf(500, "No event reader specified")
+	if a.opts.TraceReader == nil {
+		return nil, publicerr.Errorf(500, "No trace reader specified")
 	}
 
-	events, err := a.opts.EventReader.WorkspaceEvents(ctx, auth.WorkspaceID(), opts)
+	events, err := a.opts.TraceReader.GetEvents(ctx, auth.AccountID(), auth.WorkspaceID(), opts)
 	if err != nil {
 		logger.StdlibLogger(ctx).Error("error querying events", "error", err)
 		return nil, publicerr.Wrap(err, 500, "Unable to query events")
@@ -101,10 +101,10 @@ func (a API) GetEvent(ctx context.Context, eventID ulid.ULID) (*cqrs.Event, erro
 	if err != nil {
 		return nil, publicerr.Wrap(err, 401, "No auth found")
 	}
-	if a.opts.EventReader == nil {
-		return nil, publicerr.Errorf(500, "No event reader specified")
+	if a.opts.TraceReader == nil {
+		return nil, publicerr.Errorf(500, "No trace reader specified")
 	}
-	event, err := a.opts.EventReader.FindEvent(ctx, auth.WorkspaceID(), eventID)
+	event, err := a.opts.TraceReader.GetEvent(ctx, eventID, auth.AccountID(), auth.WorkspaceID())
 	if err == sql.ErrNoRows {
 		return nil, publicerr.Wrap(err, 404, "Event not found")
 	}

--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -629,11 +629,11 @@ func (w wrapper) GetEventsByExpressions(ctx context.Context, cel []string) ([]*c
 	return res, nil
 }
 
-func (w wrapper) FindEvent(ctx context.Context, workspaceID uuid.UUID, internalID ulid.ULID) (*cqrs.Event, error) {
+func (w wrapper) GetEvent(ctx context.Context, internalID ulid.ULID, accountID uuid.UUID, workspaceID uuid.UUID) (*cqrs.Event, error) {
 	return w.GetEventByInternalID(ctx, internalID)
 }
 
-func (w wrapper) WorkspaceEvents(ctx context.Context, workspaceID uuid.UUID, opts *cqrs.WorkspaceEventsOpts) ([]cqrs.Event, error) {
+func (w wrapper) GetEvents(ctx context.Context, accountID uuid.UUID, workspaceID uuid.UUID, opts *cqrs.WorkspaceEventsOpts) ([]*cqrs.Event, error) {
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}
@@ -668,9 +668,10 @@ func (w wrapper) WorkspaceEvents(ctx context.Context, workspaceID uuid.UUID, opt
 	if err != nil {
 		return nil, err
 	}
-	out := make([]cqrs.Event, len(evts))
+	out := make([]*cqrs.Event, len(evts))
 	for n, evt := range evts {
-		out[n] = convertEvent(evt)
+		val := convertEvent(evt)
+		out[n] = &val
 	}
 	return out, nil
 }
@@ -2042,10 +2043,10 @@ func (w wrapper) GetWorkerConnections(ctx context.Context, opt cqrs.GetWorkerCon
 // copyWriter allows running duck-db specific functions as CQRS functions, copying CQRS types to DDB types
 // automatically.
 func copyWriter[
-PARAMS_IN any,
-INTERNAL_PARAMS any,
-IN any,
-OUT any,
+	PARAMS_IN any,
+	INTERNAL_PARAMS any,
+	IN any,
+	OUT any,
 ](
 	ctx context.Context,
 	f func(context.Context, INTERNAL_PARAMS) (IN, error),
@@ -2068,8 +2069,8 @@ OUT any,
 }
 
 func copyInto[
-IN any,
-OUT any,
+	IN any,
+	OUT any,
 ](
 	ctx context.Context,
 	f func(context.Context) (IN, error),

--- a/pkg/cqrs/events.go
+++ b/pkg/cqrs/events.go
@@ -123,10 +123,10 @@ type EventReader interface {
 		limit int,
 		includeInternal bool,
 	) ([]*Event, error)
-	// WorkspaceEvents returns the latest events for a given workspace.
-	WorkspaceEvents(ctx context.Context, workspaceID uuid.UUID, opts *WorkspaceEventsOpts) ([]Event, error)
-	// Find returns a specific event given an ID.
-	FindEvent(ctx context.Context, workspaceID uuid.UUID, id ulid.ULID) (*Event, error)
+	// GetEvents returns the latest events for a given workspace.
+	GetEvents(ctx context.Context, accountID uuid.UUID, workspaceID uuid.UUID, opts *WorkspaceEventsOpts) ([]*Event, error)
+	// GetEvent returns a specific event given an ID.
+	GetEvent(ctx context.Context, id ulid.ULID, accountID uuid.UUID, workspaceID uuid.UUID) (*Event, error)
 }
 
 type EventBatchOpt func(eb *EventBatch)

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -269,6 +269,10 @@ type TraceReader interface {
 	GetEventRuns(ctx context.Context, eventID ulid.ULID, accountID uuid.UUID, workspaceID uuid.UUID) ([]*FunctionRun, error)
 	// GetRun returns a single function run.
 	GetRun(ctx context.Context, runID ulid.ULID, accountID uuid.UUID, workspaceID uuid.UUID) (*FunctionRun, error)
+	// GetEvent returns a single event.
+	GetEvent(ctx context.Context, id ulid.ULID, accountID uuid.UUID, workspaceID uuid.UUID) (*Event, error)
+	// GetEvents returns a list of latest events.
+	GetEvents(ctx context.Context, accountID uuid.UUID, workspaceID uuid.UUID,opts *WorkspaceEventsOpts) ([]*Event, error)
 }
 
 type GetTraceRunOpt struct {

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -480,7 +480,6 @@ func start(ctx context.Context, opts StartOpts) error {
 
 		apiv1.AddRoutes(r, apiv1.Opts{
 			CachingMiddleware:  caching,
-			EventReader:        ds.Data,
 			FunctionReader:     ds.Data,
 			FunctionRunReader:  ds.Data,
 			JobQueueReader:     ds.Queue.(queue.JobQueueReader),

--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -453,7 +453,6 @@ func start(ctx context.Context, opts StartOpts) error {
 
 		apiv1.AddRoutes(r, apiv1.Opts{
 			CachingMiddleware:  caching,
-			EventReader:        ds.Data,
 			FunctionReader:     ds.Data,
 			FunctionRunReader:  ds.Data,
 			JobQueueReader:     ds.Queue.(queue.JobQueueReader),


### PR DESCRIPTION
## Description
Removes BigQuery usage from the `/v1/events` endpoints in favor of ClickHouse. This was the last remaining dependency on BigQuery in the APIs, so the EventReader interface has been removed from `apiv1.Opts`.

## Motivation
https://linear.app/inngest/issue/INN-4737

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
