### PR TITLE
Check active sets on backlogs

### DIFF
--- a/pkg/execution/state/redis_state/active_checker_test.go
+++ b/pkg/execution/state/redis_state/active_checker_test.go
@@ -93,6 +93,16 @@ func TestShadowPartitionActiveCheck(t *testing.T) {
 		cluster.HSet(kg.ShadowPartitionMeta(), sp.PartitionID, string(marshaled))
 	}
 
+	t.Run("adding to active check should work", func(t *testing.T) {
+		setup(t)
+
+		err := q.AddBacklogToActiveCheck(ctx, defaultShard, accountID, backlog.BacklogID)
+		require.NoError(t, err)
+
+		require.True(t, cluster.Exists(kg.BacklogActiveCheckSet()))
+		require.True(t, hasMember(t, cluster, kg.BacklogActiveCheckSet(), backlog.BacklogID))
+	})
+
 	t.Run("should not clean up active items from account active set", func(t *testing.T) {
 		setup(t)
 

--- a/pkg/execution/state/redis_state/backlog.go
+++ b/pkg/execution/state/redis_state/backlog.go
@@ -752,8 +752,8 @@ func (q *queue) BacklogRefill(ctx context.Context, b *QueueBacklog, sp *QueueSha
 		b.customKeyActiveRuns(kg, 1), // Set for active runs with custom concurrency key 1
 		b.customKeyActiveRuns(kg, 2), // Set for active runs with custom concurrency key 2
 
-		kg.PartitionActiveCheckSet(),
-		kg.PartitionActiveCheckCooldown(sp.PartitionID),
+		kg.BacklogActiveCheckSet(),
+		kg.BacklogActiveCheckCooldown(b.BacklogID),
 	}
 
 	enableKeyQueuesVal := "0"
@@ -763,7 +763,7 @@ func (q *queue) BacklogRefill(ctx context.Context, b *QueueBacklog, sp *QueueSha
 	}
 
 	// Enable conditional spot checking (probability in queue settings + feature flag)
-	shouldSpotCheckActiveSet := q.enableActiveSpotChecks(ctx, accountID) && rand.Intn(100) <= q.runMode.ActiveCheckerSpotCheckProbability
+	shouldSpotCheckActiveSet := q.enableActiveSpotChecks(ctx, accountID) && rand.Intn(100) <= q.runMode.BacklogRefillSpotCheckProbability
 
 	args, err := StrSlice([]any{
 		b.BacklogID,

--- a/pkg/execution/state/redis_state/backlog_normalization.go
+++ b/pkg/execution/state/redis_state/backlog_normalization.go
@@ -332,9 +332,9 @@ func (q *queue) normalizeBacklog(ctx context.Context, backlog *QueueBacklog, sp 
 
 			cleanupItem := func() {
 				// If event for item cannot be found, remove it from the backlog
-				err := q.removeQueueItem(ctx, shard, shard.RedisClient.KeyGenerator().BacklogSet(backlog.BacklogID), item.ID)
+				err := q.Dequeue(ctx, shard, *item)
 				if err != nil {
-					q.log.Warn("could not remove queue item from backlog", "err", err)
+					q.log.Warn("could not dequeue queue item with missing event", "err", err)
 				}
 			}
 

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -213,8 +213,8 @@ type QueueKeyGenerator interface {
 	AccountNormalizeSet(accountID uuid.UUID) string
 	PartitionNormalizeSet(partitionID string) string
 
-	PartitionActiveCheckSet() string
-	PartitionActiveCheckCooldown(partitionID string) string
+	BacklogActiveCheckSet() string
+	BacklogActiveCheckCooldown(backlogID string) string
 
 	//
 	// Queue metadata keys
@@ -483,15 +483,15 @@ func (u queueKeyGenerator) PartitionNormalizeSet(partitionID string) string {
 
 }
 
-func (u queueKeyGenerator) PartitionActiveCheckSet() string {
-	return fmt.Sprintf("{%s}:active-check:partition:sorted", u.queueDefaultKey)
+func (u queueKeyGenerator) BacklogActiveCheckSet() string {
+	return fmt.Sprintf("{%s}:active-check:backlog:sorted", u.queueDefaultKey)
 }
 
-func (u queueKeyGenerator) PartitionActiveCheckCooldown(partitionID string) string {
-	if partitionID == "" {
-		return fmt.Sprintf("{%s}:active-check:cooldown:partition:-", u.queueDefaultKey)
+func (u queueKeyGenerator) BacklogActiveCheckCooldown(backlogID string) string {
+	if backlogID == "" {
+		return fmt.Sprintf("{%s}:active-check:cooldown:backlog:-", u.queueDefaultKey)
 	}
-	return fmt.Sprintf("{%s}:active-check:cooldown:partition:%s", u.queueDefaultKey, partitionID)
+	return fmt.Sprintf("{%s}:active-check:cooldown:backlog:%s", u.queueDefaultKey, backlogID)
 }
 
 func (u queueKeyGenerator) QueuePrefix() string {

--- a/pkg/execution/state/redis_state/lua/includes/active_check.lua
+++ b/pkg/execution/state/redis_state/lua/includes/active_check.lua
@@ -1,12 +1,12 @@
-local function add_to_active_check(keyPartitionActiveCheckSet, keyPartitionActiveCheckCooldown, partitionID, nowMS)
-  if redis.call("EXISTS", keyPartitionActiveCheckCooldown) == 1 then
+local function add_to_active_check(keyBacklogActiveCheckSet, keyBacklogActiveCheckCooldown, backlogID, nowMS)
+  if redis.call("EXISTS", keyBacklogActiveCheckCooldown) == 1 then
     return
   end
 
   -- Protect against overflowing the active check set -- this should be a best effort workload
-  if tonumber(redis.call("ZCARD", keyPartitionActiveCheckSet)) >= 1000 then
+  if tonumber(redis.call("ZCARD", keyBacklogActiveCheckSet)) >= 1000 then
     return
   end
 
-  redis.call("ZADD", keyPartitionActiveCheckSet, nowMS, partitionID)
+  redis.call("ZADD", keyBacklogActiveCheckSet, nowMS, backlogID)
 end

--- a/pkg/execution/state/redis_state/lua/queue/activeCheckAddBacklog.lua
+++ b/pkg/execution/state/redis_state/lua/queue/activeCheckAddBacklog.lua
@@ -1,0 +1,11 @@
+local keyBacklogActiveCheckSet   = KEYS[1]
+local keyBacklogActiveCheckCooldown = KEYS[2]
+
+local backlogID       = ARGV[1]
+local nowMS           = tonumber(ARGV[2])
+
+-- $include(active_check.lua)
+
+add_to_active_check(keyBacklogActiveCheckSet, keyBacklogActiveCheckCooldown, backlogID, nowMS)
+
+return 0

--- a/pkg/execution/state/redis_state/lua/queue/activeCheckRemoveBacklog.lua
+++ b/pkg/execution/state/redis_state/lua/queue/activeCheckRemoveBacklog.lua
@@ -1,0 +1,11 @@
+local keyBacklogActiveCheckSet   = KEYS[1]
+local keyBacklogActiveCheckCooldown = KEYS[2]
+
+local backlogID       = ARGV[1]
+local nowMS           = tonumber(ARGV[2])
+local cooldownSeconds = tonumber(ARGV[3])
+
+redis.call("ZREM", keyBacklogActiveCheckSet, backlogID)
+redis.call("SET", keyBacklogActiveCheckCooldown, nowMS, "EX", cooldownSeconds)
+
+return 0

--- a/pkg/execution/state/redis_state/lua/queue/backlogRefill.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogRefill.lua
@@ -51,8 +51,8 @@ local keyActiveRunsPartition              = KEYS[18]
 local keyActiveRunsCustomConcurrencyKey1  = KEYS[19]
 local keyActiveRunsCustomConcurrencyKey2  = KEYS[20]
 
-local keyPartitionActiveCheckSet          = KEYS[21]
-local keyPartitionActiveCheckCooldown  = KEYS[22]
+local keyBacklogActiveCheckSet       = KEYS[21]
+local keyBacklogActiveCheckCooldown  = KEYS[22]
 
 local backlogID     = ARGV[1]
 local partitionID   = ARGV[2]
@@ -379,12 +379,12 @@ end
 updateBacklogPointer(keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
 
 --
--- Optional: Add partition to active checker set. This will verify that all items marked as active
+-- Optional: Add backlog to active checker set. This will verify that all items marked as active
 -- are either in the ready queue or in progress.
 --
 local concurrencyConstrained = status >= 1 and status <= 4
 if concurrencyConstrained and shouldSpotCheckActiveSet == 1 then
-    add_to_active_check(keyPartitionActiveCheckSet, keyPartitionActiveCheckCooldown, partitionID, nowMS)
+    add_to_active_check(keyBacklogActiveCheckSet, keyBacklogActiveCheckCooldown, backlogID, nowMS)
 end
 
 return { status, refilled, backlogCountUntil, backlogCountTotal, constraintCapacity, refill }

--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -171,11 +171,7 @@ if exists_without_ending(keyInProgressCustomConcurrencyKey2, ":-") == true then
   handleLease(keyInProgressCustomConcurrencyKey2, customConcurrencyKey2)
 end
 
--- If item was not refilled from backlog, we must update active sets during lease
--- to account used capacity for future backlog refills
-if refilledFromBacklog ~= 1 then
-  addToActiveSets(keyActivePartition, keyActiveAccount, keyActiveCompound, keyActiveConcurrencyKey1, keyActiveConcurrencyKey2, {item.id})
-  addToActiveRunSets(keyActiveRun, keyActiveRunsPartition, keyActiveRunsAccount, keyActiveRunsCustomConcurrencyKey1, keyActiveRunsCustomConcurrencyKey2, runID, item.id)
-end
+addToActiveSets(keyActivePartition, keyActiveAccount, keyActiveCompound, keyActiveConcurrencyKey1, keyActiveConcurrencyKey2, {item.id})
+addToActiveRunSets(keyActiveRun, keyActiveRunsPartition, keyActiveRunsAccount, keyActiveRunsCustomConcurrencyKey1, keyActiveRunsCustomConcurrencyKey2, runID, item.id)
 
 return 0

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -921,8 +921,11 @@ type QueueRunMode struct {
 	// ActiveChecker enables background checking of active sets.
 	ActiveChecker bool
 
-	// ActiveCheckerSpotCheckProbability determines the weight of running spot checks on active sets when encountering concurrencity limits between 0 and 100 where 100 means always check.
-	ActiveCheckerSpotCheckProbability int
+	// BacklogRefillSpotCheckProbability determines the weight of adding backlogs to spot checks when concurrency limits between 0 and 100 where 100 means always check.
+	BacklogRefillSpotCheckProbability int
+
+	// ActiveCheckAccountCheckProbability determines the weight of running spot checks on accounts when running an active check
+	ActiveCheckAccountCheckProbability int
 }
 
 // continuation represents a partition continuation, forcung the queue to continue working

--- a/pkg/execution/state/redis_state/shadow_queue_test.go
+++ b/pkg/execution/state/redis_state/shadow_queue_test.go
@@ -510,19 +510,20 @@ func TestQueueRefillBacklog(t *testing.T) {
 				return true
 			}),
 			WithRunMode(QueueRunMode{
-				Sequential:                        true,
-				Scavenger:                         true,
-				Partition:                         true,
-				Account:                           true,
-				AccountWeight:                     85,
-				ShadowPartition:                   true,
-				AccountShadowPartition:            true,
-				AccountShadowPartitionWeight:      85,
-				ShadowContinuations:               true,
-				ShadowContinuationSkipProbability: 0,
-				NormalizePartition:                true,
-				ActiveChecker:                     true,
-				ActiveCheckerSpotCheckProbability: 100,
+				Sequential:                         true,
+				Scavenger:                          true,
+				Partition:                          true,
+				Account:                            true,
+				AccountWeight:                      85,
+				ShadowPartition:                    true,
+				AccountShadowPartition:             true,
+				AccountShadowPartitionWeight:       85,
+				ShadowContinuations:                true,
+				ShadowContinuationSkipProbability:  0,
+				NormalizePartition:                 true,
+				ActiveChecker:                      true,
+				BacklogRefillSpotCheckProbability:  100,
+				ActiveCheckAccountCheckProbability: 100,
 			}),
 			WithBacklogRefillLimit(500),
 			WithConcurrencyLimitGetter(func(ctx context.Context, p QueuePartition) PartitionConcurrencyLimits {
@@ -626,11 +627,11 @@ func TestQueueRefillBacklog(t *testing.T) {
 		require.Equal(t, 0, res.Refilled)
 		require.Equal(t, enums.QueueConstraintAccountConcurrency, res.Constraint)
 
-		require.True(t, r.Exists(kg.PartitionActiveCheckSet()))
-		members, err := r.ZMembers(kg.PartitionActiveCheckSet())
+		require.True(t, r.Exists(kg.BacklogActiveCheckSet()))
+		members, err := r.ZMembers(kg.BacklogActiveCheckSet())
 		require.NoError(t, err)
 		require.Len(t, members, 1)
-		require.Equal(t, fnID2.String(), members[0])
+		require.Equal(t, b2.BacklogID, members[0])
 	})
 }
 


### PR DESCRIPTION
## Description

This PR updates the active checker to operate on accounts. We introduce a new probability to conditionally check accounts in a subset of cases when checking backlogs to prevent running this too often. With the new setup, we have three dials

- The feature flag to enable backlog spot checks for accounts
- The probability of enrolling backlogs to spot checks when hitting concurrency limits
- The probability of checking account constraints when processing a backlog spot check

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
