### PR TITLE
Improve queue logging with job IDs for better debugging

### DIFF
--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -2465,7 +2465,7 @@ func (q *queue) Dequeue(ctx context.Context, queueShard QueueShard, i osqueue.Qu
 	}
 	switch status {
 	case 0:
-		q.log.Debug("dequeued item", "item", i)
+		q.log.Debug("dequeued item", "job_id", i.ID, "item", i)
 
 		return nil
 	case 1:

--- a/pkg/execution/state/redis_state/shadow_queue.go
+++ b/pkg/execution/state/redis_state/shadow_queue.go
@@ -390,7 +390,7 @@ func (q *queue) processShadowPartitionBacklog(ctx context.Context, shadowPart *Q
 	if len(res.RefilledItems) > 0 {
 		q.log.Debug(
 			"refilled items to ready queue",
-			"items", res.RefilledItems,
+			"job_id", res.RefilledItems,
 			"backlog", backlog.BacklogID,
 			"partition", shadowPart.PartitionID,
 		)


### PR DESCRIPTION
## Description

This PR improves queue logging by adding job IDs to debug log statements for better debugging and traceability.

Changes include:
- Added `job_id` field to dequeue debug logs in `queue.go`
- Updated shadow queue refill logs to use `job_id` field for consistency
- Enhanced debugging capabilities by providing job identifiers in logs

## Motivation

Better logging with job IDs helps with debugging queue processing issues by providing clear identifiers for specific jobs being processed or refilled.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*