### PR TITLE
Fix active checker issues

### DIFF
--- a/pkg/execution/state/redis_state/active_checker.go
+++ b/pkg/execution/state/redis_state/active_checker.go
@@ -216,7 +216,7 @@ func (q *queue) accountActiveCheck(
 		l.Debug("removing invalid items from account active key", "mode", "account", "invalid", invalidItems, "partition_id", sp.PartitionID, "active", keyActive, "in_progress", keyInProgress, "readonly", readOnly)
 
 		if !readOnly {
-			cmd := client.B().Zrem().Key(keyActive).Member(invalidItems...).Build()
+			cmd := client.B().Srem().Key(keyActive).Member(invalidItems...).Build()
 			err := client.Do(ctx, cmd).Error()
 			if err != nil {
 				return fmt.Errorf("could not remove invalid items from active set: %w", err)
@@ -252,7 +252,7 @@ func (q *queue) partitionActiveCheck(
 		l.Debug("removing invalid items from active key", "mode", "partition", "invalid", invalidItems, "partition_id", sp.PartitionID, "active", keyActive, "ready", keyReady, "in_progress", keyInProgress, "readonly", readOnly)
 
 		if !readOnly {
-			cmd := client.B().Zrem().Key(keyActive).Member(invalidItems...).Build()
+			cmd := client.B().Srem().Key(keyActive).Member(invalidItems...).Build()
 			err := client.Do(ctx, cmd).Error()
 			if err != nil {
 				return fmt.Errorf("could not remove invalid items from active set: %w", err)
@@ -283,7 +283,7 @@ func (q *queue) customConcurrencyActiveCheck(ctx context.Context, sp *QueueShado
 		l.Debug("removing invalid items from active key", "invalid", "mode", "custom_concurrency", "bcc", bcc, invalidItems, "partition_id", sp.PartitionID, "active", keyActive, "ready", keyReady, "in_progress", keyInProgress, "readonly", readOnly)
 
 		if !readOnly {
-			cmd := client.B().Zrem().Key(keyActive).Member(invalidItems...).Build()
+			cmd := client.B().Srem().Key(keyActive).Member(invalidItems...).Build()
 			err := client.Do(ctx, cmd).Error()
 			if err != nil {
 				return fmt.Errorf("could not remove invalid items from active set: %w", err)

--- a/pkg/execution/state/redis_state/active_checker_test.go
+++ b/pkg/execution/state/redis_state/active_checker_test.go
@@ -111,7 +111,7 @@ func TestShadowPartitionActiveCheck(t *testing.T) {
 		qi, err := q.EnqueueItem(ctx, defaultShard, item, clock.Now(), osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		_, err = cluster.ZAdd(sp.accountActiveKey(kg), float64(clock.Now().UnixMilli()), qi.ID)
+		_, err = cluster.SAdd(sp.accountActiveKey(kg), qi.ID)
 		require.NoError(t, err)
 
 		_, err = q.backlogActiveCheck(ctx, &backlog, client, kg, l)
@@ -128,7 +128,7 @@ func TestShadowPartitionActiveCheck(t *testing.T) {
 		qi, err := q.EnqueueItem(ctx, defaultShard, item, clock.Now(), osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		_, err = cluster.ZAdd(sp.accountActiveKey(kg), float64(clock.Now().UnixMilli()), qi.ID)
+		_, err = cluster.SAdd(sp.accountActiveKey(kg), qi.ID)
 		require.NoError(t, err)
 
 		_, err = q.backlogActiveCheck(ctx, &backlog, client, kg, l)
@@ -145,7 +145,7 @@ func TestShadowPartitionActiveCheck(t *testing.T) {
 		_, err := q.EnqueueItem(ctx, defaultShard, item, clock.Now(), osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		_, err = cluster.ZAdd(sp.accountActiveKey(kg), float64(clock.Now().UnixMilli()), "missing-lol")
+		_, err = cluster.SAdd(sp.accountActiveKey(kg), "missing-lol")
 		require.NoError(t, err)
 
 		_, err = q.backlogActiveCheck(ctx, &backlog, client, kg, l)
@@ -162,7 +162,7 @@ func TestShadowPartitionActiveCheck(t *testing.T) {
 		qi, err := q.EnqueueItem(ctx, defaultShard, item, clock.Now(), osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		_, err = cluster.ZAdd(sp.activeKey(kg), float64(clock.Now().UnixMilli()), qi.ID)
+		_, err = cluster.SAdd(sp.activeKey(kg), qi.ID)
 		require.NoError(t, err)
 
 		_, err = q.backlogActiveCheck(ctx, &backlog, client, kg, l)
@@ -179,7 +179,7 @@ func TestShadowPartitionActiveCheck(t *testing.T) {
 		qi, err := q.EnqueueItem(ctx, defaultShard, item, clock.Now(), osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		_, err = cluster.ZAdd(sp.activeKey(kg), float64(clock.Now().UnixMilli()), qi.ID)
+		_, err = cluster.SAdd(sp.activeKey(kg), qi.ID)
 		require.NoError(t, err)
 
 		_, err = q.backlogActiveCheck(ctx, &backlog, client, kg, l)
@@ -196,7 +196,7 @@ func TestShadowPartitionActiveCheck(t *testing.T) {
 		_, err := q.EnqueueItem(ctx, defaultShard, item, clock.Now(), osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		_, err = cluster.ZAdd(sp.activeKey(kg), float64(clock.Now().UnixMilli()), "missing-lol")
+		_, err = cluster.SAdd(sp.activeKey(kg), "missing-lol")
 		require.NoError(t, err)
 
 		_, err = q.backlogActiveCheck(ctx, &backlog, client, kg, l)
@@ -213,7 +213,7 @@ func TestShadowPartitionActiveCheck(t *testing.T) {
 		qi, err := q.EnqueueItem(ctx, defaultShard, item, clock.Now(), osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		_, err = cluster.ZAdd(backlog.customKeyActive(kg, 1), float64(clock.Now().UnixMilli()), qi.ID)
+		_, err = cluster.SAdd(backlog.customKeyActive(kg, 1), qi.ID)
 		require.NoError(t, err)
 
 		_, err = q.backlogActiveCheck(ctx, &backlog, client, kg, l)
@@ -230,7 +230,7 @@ func TestShadowPartitionActiveCheck(t *testing.T) {
 		qi, err := q.EnqueueItem(ctx, defaultShard, item, clock.Now(), osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		_, err = cluster.ZAdd(backlog.customKeyActive(kg, 1), float64(clock.Now().UnixMilli()), qi.ID)
+		_, err = cluster.SAdd(backlog.customKeyActive(kg, 1), qi.ID)
 		require.NoError(t, err)
 
 		_, err = q.backlogActiveCheck(ctx, &backlog, client, kg, l)
@@ -247,7 +247,7 @@ func TestShadowPartitionActiveCheck(t *testing.T) {
 		qi, err = q.EnqueueItem(ctx, defaultShard, item, clock.Now(), osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		_, err = cluster.ZAdd(backlog.customKeyActive(kg, 1), float64(clock.Now().UnixMilli()), "missing-lol")
+		_, err = cluster.SAdd(backlog.customKeyActive(kg, 1), "missing-lol")
 		require.NoError(t, err)
 
 		_, err = q.backlogActiveCheck(ctx, &backlog, client, kg, l)


### PR DESCRIPTION
## Description

This PR fixes the active scanner to use *Set*-based commands.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
