### PR TITLE
Use org profile for picture

### DIFF
--- a/ui/apps/dashboard/src/components/Navigation/Profile.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Profile.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Image from 'next/image';
 import { usePathname } from 'next/navigation';
 
 import { ProfileMenu } from './ProfileMenu';
@@ -8,6 +9,7 @@ export type ProfileType = {
   displayName: string;
   isMarketplace: boolean;
   orgName?: string;
+  orgProfilePic: string | null;
 };
 
 export const Profile = ({ collapsed, profile }: { collapsed: boolean; profile: ProfileType }) => {
@@ -32,7 +34,17 @@ export const Profile = ({ collapsed, profile }: { collapsed: boolean; profile: P
           }`}
         >
           <div className="bg-canvasMuted text-subtle flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs uppercase">
-            {profile.orgName?.substring(0, 2) || '?'}
+            {profile.orgProfilePic ? (
+              <Image
+                src={profile.orgProfilePic}
+                className="h-8 w-8 rounded-full"
+                width={40}
+                height={40}
+                alt="org-profile-pic"
+              />
+            ) : (
+              profile.orgName?.substring(0, 2) || '?'
+            )}
           </div>
 
           {!collapsed && (

--- a/ui/apps/dashboard/src/components/Navigation/Profile.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Profile.tsx
@@ -37,9 +37,9 @@ export const Profile = ({ collapsed, profile }: { collapsed: boolean; profile: P
             {profile.orgProfilePic ? (
               <Image
                 src={profile.orgProfilePic}
-                className="h-8 w-8 rounded-full"
-                width={40}
-                height={40}
+                className="h-8 w-8 rounded-full object-cover"
+                width={32}
+                height={32}
                 alt="org-profile-pic"
               />
             ) : (

--- a/ui/apps/dashboard/src/queries/server-only/profile.ts
+++ b/ui/apps/dashboard/src/queries/server-only/profile.ts
@@ -19,6 +19,7 @@ export type ProfileDisplayType = {
   isMarketplace: boolean;
   orgName?: string;
   displayName: string;
+  orgProfilePic: string | null;
 };
 
 const ProfileQuery = graphql(`
@@ -33,6 +34,7 @@ const ProfileQuery = graphql(`
 export const getProfileDisplay = async (): Promise<ProfileDisplayType> => {
   let orgName: string | undefined;
   let displayName: string;
+  let orgProfilePic: string | null;
 
   const res = await graphqlAPI.request(ProfileQuery);
   if (res.account.marketplace) {
@@ -40,6 +42,7 @@ export const getProfileDisplay = async (): Promise<ProfileDisplayType> => {
 
     orgName = res.account.name ?? undefined;
     displayName = 'System';
+    orgProfilePic = null;
   } else {
     const { user, org } = await getProfile();
     orgName = org?.name;
@@ -47,12 +50,14 @@ export const getProfileDisplay = async (): Promise<ProfileDisplayType> => {
       user.firstName || user.lastName
         ? `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim()
         : user.username ?? '';
+    orgProfilePic = org?.hasImage ? org.imageUrl : null;
   }
 
   return {
     isMarketplace: Boolean(res.account.marketplace),
     orgName,
     displayName,
+    orgProfilePic,
   };
 };
 


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->
Right now, we only show the first 2 letters as the pfp in the profile. This allows us to use the org profile in clerk and fallback to the letters if none

![image](https://github.com/user-attachments/assets/05c15ee0-93b1-4dc7-b041-78a3f035b9f2)
![image](https://github.com/user-attachments/assets/c6c0d332-5171-4f94-b2f9-c4194a9574b4)

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
