### PR TITLE
Fix Dev Server persisting to disk

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -169,6 +169,7 @@ func doDev(cmd *cobra.Command, args []string) {
 		URLs:               urls,
 		ConnectGatewayPort: connectGatewayPort,
 		ConnectGatewayHost: conf.CoreAPI.Addr,
+		InMemory:           true,
 	}
 
 	err = devserver.New(ctx, opts)

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -105,6 +105,10 @@ type StartOpts struct {
 
 	ConnectGatewayPort int    `json:"connectGatewayPort"`
 	ConnectGatewayHost string `json:"connectGatewayHost"`
+
+	// InMemory controls whether to only use in-memory databases (as opposed to
+	// filesystem)
+	InMemory bool
 }
 
 // Create and start a new dev server.  The dev server is used during (surprise surprise)
@@ -129,7 +133,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	l := logger.StdlibLogger(ctx)
 	ctx = logger.WithStdlib(ctx, l)
 
-	db, err := base_cqrs.New(base_cqrs.BaseCQRSOptions{InMemory: false})
+	db, err := base_cqrs.New(base_cqrs.BaseCQRSOptions{InMemory: opts.InMemory})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
Fix a bug where the Dev Server persists to disk (i.e. `.inngest/main.db`)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
