### PR TITLE
fix: Nil pointer in selfhosted 1.7+

### DIFF
--- a/pkg/lite/lite.go
+++ b/pkg/lite/lite.go
@@ -389,6 +389,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		runner.WithCQRS(dbcqrs),
 		runner.WithExecutor(exec),
 		runner.WithExecutionManager(dbcqrs),
+		runner.WithPauseManager(pauses.NewRedisOnlyManager(sm)),
 		runner.WithEventManager(event.NewManager()),
 		runner.WithStateManager(sm),
 		runner.WithRunnerQueue(rq),


### PR DESCRIPTION
## Description
 Fix nil pointer dereference panic in self-hosted Inngest by adding missing runner.WithPauseManager() initialization to the lite server configuration. The lite server was missing
  the pause manager that the dev server and executor already had, causing runtime crashes when the runner tried to access an uninitialized pause manager.

 ### Changes:
  - Added runner.WithPauseManager(pauses.NewRedisOnlyManager(sm)) to the runner service initialization in pkg/lite/lite.go
  - This matches the configuration already present in the dev server (pkg/devserver/devserver.go)

## Motivation
Self-hosted Inngest versions 1.7.0 and 1.7.1 were experiencing runtime panics with "invalid memory address or nil pointer dereference" errors occurring a few seconds after boot.
  The issue was tracked in #2584 where rolling back to version 1.6.4 resolved the problem.

  I believe lite server is missing the pause manager initialization in its runner service, while the executor had it configured
  correctly. This caused the runner to attempt operations on a nil pause manager, resulting in the panic.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.