### PR TITLE
Fix nil ref if we can't find function output

### DIFF
--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -356,6 +356,12 @@ func (r *DriverResponse) GetFunctionOutput() (*string, error) {
 		}
 	}
 
+	// If output is nil, somehow we have a function result with no output. That
+	// seems wrong.
+	if output == nil {
+		return nil, fmt.Errorf("function result has no output")
+	}
+
 	// Now we have the output, we make sure it's keyed the same as regular step
 	// outputs are, either under `data` or `error`.
 	var keyedOutput *string


### PR DESCRIPTION
## Description

Superseding #2617 cc @BrunoScheufler; it's better if we return an error here as it gets handled by tracing.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
