### PR TITLE
Fix singletons checking for locks in the wrong shard

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -114,7 +114,7 @@ type StartOpts struct {
 	// RedisURI allows connecting to external Redis instead of in-memory Redis
 	RedisURI string `json:"redis_uri"`
 
-	// PostgresURI allows connecting to external Postgres instead of SQLite  
+	// PostgresURI allows connecting to external Postgres instead of SQLite
 	PostgresURI string `json:"postgres_uri"`
 
 	// SQLiteDir specifies where SQLite files should be stored
@@ -373,7 +373,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	batcher := batch.NewRedisBatchManager(shardedClient.Batch(), rq, batch.WithLogger(l))
 	debouncer := debounce.NewRedisDebouncer(unshardedClient.Debounce(), queueShard, rq)
 
-	sn := singleton.New(ctx, queueShard.RedisClient)
+	sn := singleton.New(ctx, queueShards, shardSelector)
 
 	conditionalTracer := itrace.NewConditionalTracer(itrace.ConnectTracer(), itrace.AlwaysTrace)
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -575,7 +575,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 			// the lock becomes available to any competing run. If a faster run acquires it before
 			// this one tries to, it will fail to acquire the lock and be skipped; Effectively
 			// behaving as if the singleton mode were set to skip.
-			singletonRunID, err := e.singletonMgr.HandleSingleton(ctx, singletonKey, *req.Function.Singleton)
+			singletonRunID, err := e.singletonMgr.HandleSingleton(ctx, singletonKey, *req.Function.Singleton, req.AccountID)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/execution/singleton/redis.go
+++ b/pkg/execution/singleton/redis.go
@@ -3,6 +3,7 @@ package singleton
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state/redis_state"
 	"github.com/inngest/inngest/pkg/inngest"
@@ -19,47 +20,59 @@ redis.call('del', KEYS[1])
 return v
 `
 
-func New(ctx context.Context, r *redis_state.QueueClient) Singleton {
-	return &redisStore{r: r,
-		getAndDelScript: rueidis.NewLuaScript(getAndDeleteLua),
+func New(ctx context.Context, queueShards map[string]redis_state.QueueShard, shardSelector redis_state.ShardSelector) Singleton {
+	return &redisStore{
+		queueShards: queueShards,
+		shardSelector:     shardSelector,
+		getAndDelScript:   rueidis.NewLuaScript(getAndDeleteLua),
 	}
 }
 
 type redisStore struct {
-	r               *redis_state.QueueClient
-	getAndDelScript *rueidis.Lua
+	queueShards map[string]redis_state.QueueShard
+	shardSelector     redis_state.ShardSelector
+	getAndDelScript   *rueidis.Lua
 }
 
-func (r *redisStore) HandleSingleton(ctx context.Context, key string, s inngest.Singleton) (*ulid.ULID, error) {
-	return singleton(ctx, r, key, s)
+func (r *redisStore) HandleSingleton(ctx context.Context, key string, s inngest.Singleton, accountID uuid.UUID) (*ulid.ULID, error) {
+	return singleton(ctx, r, key, s, accountID)
 }
 
-func (r *redisStore) ReleaseSingleton(ctx context.Context, key string) (*ulid.ULID, error) {
-	redisKey := r.r.KeyGenerator().SingletonKey(&queue.Singleton{Key: key})
-	client := r.r.Client()
-
-	val, err := r.getAndDelScript.Exec(ctx, client, []string{redisKey}, nil).ToString()
-	if err != nil {
-		if rueidis.IsRedisNil(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-
-	runID, err := ulid.Parse(val)
+func (r *redisStore) ReleaseSingleton(ctx context.Context, key string, accountID uuid.UUID) (*ulid.ULID, error) {
+	shard, err := r.shardByAccount(ctx, accountID)
 	if err != nil {
 		return nil, err
 	}
 
-	return &runID, nil
+	client := shard.RedisClient
+	redisKey := r.generateSingletonKey(client, key)
+
+	val, err := r.getAndDelScript.Exec(ctx, client.Client(), []string{redisKey}, nil).ToString()
+	return parseRunIDFromRedisValue(val, err)
 }
 
-func (r *redisStore) GetCurrentRunID(ctx context.Context, key string) (*ulid.ULID, error) {
-	key = r.r.KeyGenerator().SingletonKey(&queue.Singleton{Key: key})
+func (r *redisStore) GetCurrentRunID(ctx context.Context, key string, accountID uuid.UUID) (*ulid.ULID, error) {
+	shard, err := r.shardByAccount(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
 
-	client := r.r.Client()
+	client := shard.RedisClient
+	redisKey := r.generateSingletonKey(client, key)
 
-	val, err := r.r.Client().Do(ctx, client.B().Get().Key(key).Build()).ToString()
+	val, err := client.Client().Do(ctx, client.Client().B().Get().Key(redisKey).Build()).ToString()
+	return parseRunIDFromRedisValue(val, err)
+}
+
+func (r *redisStore) shardByAccount(ctx context.Context, accountID uuid.UUID) (redis_state.QueueShard, error) {
+	return r.shardSelector(ctx, accountID, nil)
+}
+
+func (r *redisStore) generateSingletonKey(client *redis_state.QueueClient, key string) string {
+	return client.KeyGenerator().SingletonKey(&queue.Singleton{Key: key})
+}
+
+func parseRunIDFromRedisValue(val string, err error) (*ulid.ULID, error) {
 	if err != nil {
 		if rueidis.IsRedisNil(err) {
 			return nil, nil

--- a/pkg/execution/singleton/singleton.go
+++ b/pkg/execution/singleton/singleton.go
@@ -18,7 +18,7 @@ var (
 )
 
 type Singleton interface {
-	HandleSingleton(ctx context.Context, key string, c inngest.Singleton) (*ulid.ULID, error)
+	HandleSingleton(ctx context.Context, key string, c inngest.Singleton, accountID uuid.UUID) (*ulid.ULID, error)
 }
 
 // SingletonKey returns the singleton key given a function ID, singleton config,
@@ -52,12 +52,12 @@ func hash(res any, id uuid.UUID) string {
 // - If the mode is SingletonModeSkip, it returns the currently held run ID without modifying the lock.
 //
 // - If the mode is SingletonModeCancel, it attempts to release the lock and returns the run ID that was released.
-func singleton(ctx context.Context, store SingletonStore, key string, s inngest.Singleton) (*ulid.ULID, error) {
+func singleton(ctx context.Context, store SingletonStore, key string, s inngest.Singleton, accountID uuid.UUID) (*ulid.ULID, error) {
 	switch s.Mode {
 	case enums.SingletonModeSkip:
-		return store.GetCurrentRunID(ctx, key)
+		return store.GetCurrentRunID(ctx, key, accountID)
 	case enums.SingletonModeCancel:
-		return store.ReleaseSingleton(ctx, key)
+		return store.ReleaseSingleton(ctx, key, accountID)
 	default:
 		return nil, fmt.Errorf("singleton mode %d not implemented", s.Mode)
 	}

--- a/pkg/execution/singleton/store.go
+++ b/pkg/execution/singleton/store.go
@@ -3,10 +3,11 @@ package singleton
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/oklog/ulid/v2"
 )
 
 type SingletonStore interface {
-	GetCurrentRunID(ctx context.Context, key string) (*ulid.ULID, error)
-	ReleaseSingleton(ctx context.Context, key string) (*ulid.ULID, error)
+	GetCurrentRunID(ctx context.Context, key string, accountID uuid.UUID) (*ulid.ULID, error)
+	ReleaseSingleton(ctx context.Context, key string, accountID uuid.UUID) (*ulid.ULID, error)
 }


### PR DESCRIPTION
## Description
The Singleton handler was only checking and releasing locks in the default queue shard (system-queue in production). However, locks are being set in the account-specific shard during queue item enqueueing. This mismatch caused the manager to miss existing locks, leading to incorrect behavior for the cancellation mode. This worked fine in local and staging environments where only a single shard is used (defaulting to queue2)

**Singletons in skip mode are not affected because the singleton handler is only doing a soft check and the lock is atomically being checked again when enqueuing.**

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.
