### PR TITLE
Suppress missing accountID logs for system queues

### DIFF
--- a/pkg/execution/state/redis_state/backlog.go
+++ b/pkg/execution/state/redis_state/backlog.go
@@ -401,10 +401,6 @@ func (q *queue) ItemShadowPartition(ctx context.Context, i osqueue.QueueItem) Qu
 	}
 
 	accountID := i.Data.Identifier.AccountID
-	if accountID == uuid.Nil {
-		stack := string(debug.Stack())
-		q.log.Error("unexpected missing accountID in ItemShadowPartition call", "item", i, "stack", stack)
-	}
 
 	// The only case when we manually set a queueName is for system partitions
 	if queueName != nil {
@@ -432,6 +428,11 @@ func (q *queue) ItemShadowPartition(ctx context.Context, i osqueue.QueueItem) Qu
 
 			AccountID: aID,
 		}
+	}
+
+	if accountID == uuid.Nil {
+		stack := string(debug.Stack())
+		q.log.Error("unexpected missing accountID in ItemShadowPartition call", "item", i, "stack", stack)
 	}
 
 	fnID := i.FunctionID


### PR DESCRIPTION
## Description

This change suppresses logs for missing accountIDs in system queues. These are processed on the system queue shard and will not impact active sets, and the noise produced by these frequent logs is not helpful.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
