### PR TITLE
ignore redis nil message for queue migration

### DIFF
--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -1642,6 +1642,11 @@ func (q *queue) Migrate(ctx context.Context, sourceShardName string, fnID uuid.U
 		WithQueueItemIterBatchSize(limit),
 	)
 	if err != nil {
+		// the partition doesn't exist, meaning there are no workloads
+		if errors.Is(err, rueidis.Nil) {
+			return 0, nil
+		}
+
 		return -1, fmt.Errorf("error preparing partition iteration: %w", err)
 	}
 

--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -234,12 +234,12 @@ func (q *queue) ItemsByPartition(ctx context.Context, shard QueueShard, partitio
 	cmd := rc.B().Hget().Key(hash).Field(partitionID.String()).Build()
 	byt, err := rc.Do(ctx, cmd).AsBytes()
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving partition: %w", err)
+		return nil, fmt.Errorf("error retrieving partition '%s': %w", partitionID.String(), err)
 	}
 
 	var pt QueuePartition
 	if err := json.Unmarshal(byt, &pt); err != nil {
-		return nil, fmt.Errorf("error unmarshalling queue partition: %w", err)
+		return nil, fmt.Errorf("error unmarshalling queue partition '%s': %w", partitionID.String(), err)
 	}
 
 	return func(yield func(*osqueue.QueueItem) bool) {


### PR DESCRIPTION
## Description

this simply means the partition is empty and there're nothing to process

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
