### PR TITLE
add draining to skip skip reasons

### DIFF
--- a/pkg/enums/skipreason.go
+++ b/pkg/enums/skipreason.go
@@ -14,4 +14,7 @@ const (
 	// SkipReasonSingleton indicates that the run was skipped because another
 	// run of the same singleton function was already in progress.
 	SkipReasonSingleton
+
+	// SkipReasonFunctionDrained indicates that the function is draining.
+	SkipReasonFunctionDrained
 )

--- a/pkg/enums/skipreason_enumer.go
+++ b/pkg/enums/skipreason_enumer.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 )
 
-const _SkipReasonName = "NoneFunctionPausedSingleton"
+const _SkipReasonName = "NoneFunctionPausedSingletonFunctionDrained"
 
-var _SkipReasonIndex = [...]uint8{0, 4, 18, 27}
+var _SkipReasonIndex = [...]uint8{0, 4, 18, 27, 42}
 
-const _SkipReasonLowerName = "nonefunctionpausedsingleton"
+const _SkipReasonLowerName = "nonefunctionpausedsingletonfunctiondrained"
 
 func (i SkipReason) String() string {
 	if i < 0 || i >= SkipReason(len(_SkipReasonIndex)-1) {
@@ -30,9 +30,10 @@ func _SkipReasonNoOp() {
 	_ = x[SkipReasonNone-(0)]
 	_ = x[SkipReasonFunctionPaused-(1)]
 	_ = x[SkipReasonSingleton-(2)]
+	_ = x[SkipReasonFunctionDrained-(3)]
 }
 
-var _SkipReasonValues = []SkipReason{SkipReasonNone, SkipReasonFunctionPaused, SkipReasonSingleton}
+var _SkipReasonValues = []SkipReason{SkipReasonNone, SkipReasonFunctionPaused, SkipReasonSingleton, SkipReasonFunctionDrained}
 
 var _SkipReasonNameToValueMap = map[string]SkipReason{
 	_SkipReasonName[0:4]:        SkipReasonNone,
@@ -41,12 +42,15 @@ var _SkipReasonNameToValueMap = map[string]SkipReason{
 	_SkipReasonLowerName[4:18]:  SkipReasonFunctionPaused,
 	_SkipReasonName[18:27]:      SkipReasonSingleton,
 	_SkipReasonLowerName[18:27]: SkipReasonSingleton,
+	_SkipReasonName[27:42]:      SkipReasonFunctionDrained,
+	_SkipReasonLowerName[27:42]: SkipReasonFunctionDrained,
 }
 
 var _SkipReasonNames = []string{
 	_SkipReasonName[0:4],
 	_SkipReasonName[4:18],
 	_SkipReasonName[18:27],
+	_SkipReasonName[27:42],
 }
 
 // SkipReasonString retrieves an enum value from the enum constants string name.

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/batch"
 
 	"github.com/google/uuid"
@@ -191,6 +192,20 @@ type ScheduleRequest struct {
 	PreventDebounce bool
 	// FunctionPausedAt indicates whether the function is paused.
 	FunctionPausedAt *time.Time
+	// DrainedAt indicates the time that the function started draining.  Draining is
+	// similar to paused in that new functions skip, but current functions continue
+	// to execute.
+	DrainedAt *time.Time
+}
+
+func (r ScheduleRequest) SkipReason() enums.SkipReason {
+	if r.FunctionPausedAt != nil && r.FunctionPausedAt.Before(time.Now()) {
+		return enums.SkipReasonFunctionPaused
+	}
+	if r.DrainedAt != nil && r.DrainedAt.Before(time.Now()) {
+		return enums.SkipReasonFunctionDrained
+	}
+	return enums.SkipReasonNone
 }
 
 type ScheduleRequestFromStep struct {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -554,9 +554,8 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	config.NewSetFunctionTrace(runSpanRef)
 
 	// If this is paused, immediately end just before creating state.
-	isPaused := req.FunctionPausedAt != nil && req.FunctionPausedAt.Before(time.Now())
-	if isPaused {
-		return e.handleFunctionSkipped(ctx, req, metadata, evts, enums.SkipReasonFunctionPaused)
+	if skipped := req.SkipReason(); skipped != enums.SkipReasonNone {
+		return e.handleFunctionSkipped(ctx, req, metadata, evts, skipped)
 	}
 
 	mapped := make([]map[string]any, len(req.Events))


### PR DESCRIPTION
this allows functions to be drained:  paused for new runs, while still allowing existing runs to finish.

