### PR TITLE
Fix self-hosted syncs and request signing

### DIFF
--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -9,6 +9,7 @@ import (
 	"github.com/inngest/inngest/cmd/commands/internal/localconfig"
 	"github.com/inngest/inngest/pkg/config"
 	"github.com/inngest/inngest/pkg/devserver"
+	"github.com/inngest/inngest/pkg/headers"
 	itrace "github.com/inngest/inngest/pkg/telemetry/trace"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -156,6 +157,8 @@ func doStart(cmd *cobra.Command, args []string) {
 		fmt.Println("Error: at least one event-key is required")
 		os.Exit(1)
 	}
+
+	conf.ServerKind = headers.ServerKindCloud
 
 	opts := devserver.StartOpts{
 		Config:             *conf,

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -416,9 +416,11 @@ func start(ctx context.Context, opts StartOpts) error {
 	drivers := []driver.Driver{}
 	for _, driverConfig := range opts.Config.Execution.Drivers {
 		d, err := driverConfig.NewDriver(registration.NewDriverOpts{
-			ConnectForwarder:  executorProxy,
-			ConditionalTracer: conditionalTracer,
-			HTTPClient:        httpClient,
+			ConnectForwarder:       executorProxy,
+			ConditionalTracer:      conditionalTracer,
+			HTTPClient:             httpClient,
+			LocalSigningKey:        opts.SigningKey,
+			RequireLocalSigningKey: opts.RequireKeys,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description
- Fix self-hosted syncs. They weren't working because of the missing `x-inngest-server-kind` header
- Fix unsigned execution requests. We weren't wiring signing key stuff all the way

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
