### PR TITLE
Separate poll ticks for shadow + normalization processing

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -268,6 +268,8 @@ func start(ctx context.Context, opts StartOpts) error {
 		redis_state.WithIdempotencyTTL(time.Hour),
 		redis_state.WithNumWorkers(int32(opts.QueueWorkers)),
 		redis_state.WithPollTick(opts.Tick),
+		redis_state.WithShadowPollTick(2 * opts.Tick),
+		redis_state.WithBacklogNormalizePollTick(5 * opts.Tick),
 		redis_state.WithCustomConcurrencyKeyLimitRefresher(func(ctx context.Context, i queue.QueueItem) []state.CustomConcurrency {
 			keys := i.Data.GetConcurrencyKeys()
 

--- a/pkg/execution/state/redis_state/backlog_normalization.go
+++ b/pkg/execution/state/redis_state/backlog_normalization.go
@@ -71,8 +71,8 @@ func (q *queue) backlogNormalizationScan(ctx context.Context) error {
 		go q.backlogNormalizationWorker(ctx, bc)
 	}
 
-	tick := q.clock.NewTicker(q.pollTick)
-	l.Debug("starting normalization scanner", "poll", q.pollTick.String())
+	tick := q.clock.NewTicker(q.backlogNormalizePollTick)
+	l.Debug("starting normalization scanner", "poll", q.backlogNormalizePollTick.String())
 
 	backoff := 200 * time.Millisecond
 

--- a/pkg/execution/state/redis_state/shadow_queue.go
+++ b/pkg/execution/state/redis_state/shadow_queue.go
@@ -617,8 +617,8 @@ func (q *queue) shadowScan(ctx context.Context) error {
 		go q.shadowWorker(ctx, qspc)
 	}
 
-	tick := q.clock.NewTicker(q.pollTick)
-	l.Debug("starting shadow scanner", "poll", q.pollTick.String())
+	tick := q.clock.NewTicker(q.shadowPollTick)
+	l.Debug("starting shadow scanner", "poll", q.shadowPollTick.String())
 
 	backoff := 200 * time.Millisecond
 


### PR DESCRIPTION
## Description

This PR separates the existing queue poll tick for shadow and backlog normalization processing, which can usually be somewhat slower in comparison.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
