### PR TITLE
[WIP]: Replaced Clerk Backend Calls

### DIFF
--- a/ui/apps/dashboard/src/types/globals.d.ts
+++ b/ui/apps/dashboard/src/types/globals.d.ts
@@ -1,0 +1,16 @@
+export {};
+
+declare global {
+  interface CustomJwtSessionClaims {
+    accountId?: string;
+    externalId?: string;
+    orgName?: string;
+    orgPublickMetadata?: {
+      accountId?: string;
+    };
+    fullName?: string;
+    orgHasImage?: boolean;
+    orgImageUrl?: string;
+    username?: string;
+  }
+}


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->
- Clerk backend calls are causing 429s, this PR replaces those calls with reading from the JWT
- Need to introduce new claims in JWT before this pr is merged
> [This](https://github.com/inngest/inngest/blob/jakob/fix-clerk-rate-limit/ui/apps/dashboard/src/app/(organization-active)/api/support-tickets/route.ts#L159) still uses `currentUser` as we're iterating over the emails a user has in order to link to plain, needs more thought

## Motivation
Slack [thread](https://inngest.slack.com/archives/C06AR57NCL9/p1751383031060159)

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.


![image](https://github.com/user-attachments/assets/2f50a65b-b92a-43bc-8db5-6eecda905a7b)
