### PR TITLE
Garbage-collect empty outdated backlogs, always clean up backlog/partition meta

### DIFF
--- a/pkg/execution/state/redis_state/backlog.go
+++ b/pkg/execution/state/redis_state/backlog.go
@@ -737,6 +737,8 @@ func (q *queue) BacklogRefill(ctx context.Context, b *QueueBacklog, sp *QueueSha
 
 		kg.BacklogActiveCheckSet(),
 		kg.BacklogActiveCheckCooldown(b.BacklogID),
+
+		kg.PartitionNormalizeSet(sp.PartitionID),
 	}
 
 	enableKeyQueues := sp.keyQueuesEnabled(ctx, q)
@@ -902,6 +904,8 @@ func (q *queue) BacklogRequeue(ctx context.Context, backlog *QueueBacklog, sp *Q
 		kg.AccountShadowPartitions(accountID),
 		kg.ShadowPartitionSet(sp.PartitionID),
 		kg.BacklogSet(backlog.BacklogID),
+
+		kg.PartitionNormalizeSet(sp.PartitionID),
 	}
 	args, err := StrSlice([]any{
 		accountID,

--- a/pkg/execution/state/redis_state/backlog.go
+++ b/pkg/execution/state/redis_state/backlog.go
@@ -959,6 +959,8 @@ func (q *queue) BacklogPrepareNormalize(ctx context.Context, b *QueueBacklog, sp
 
 	keys := []string{
 		kg.BacklogMeta(),
+		kg.ShadowPartitionMeta(),
+
 		kg.BacklogSet(b.BacklogID),
 		kg.ShadowPartitionSet(sp.PartitionID),
 		kg.GlobalShadowPartitionSet(),

--- a/pkg/execution/state/redis_state/backlog.go
+++ b/pkg/execution/state/redis_state/backlog.go
@@ -895,6 +895,7 @@ func (q *queue) BacklogRequeue(ctx context.Context, backlog *QueueBacklog, sp *Q
 	keys := []string{
 		kg.ShadowPartitionMeta(),
 		kg.BacklogMeta(),
+		kg.ShadowPartitionMeta(),
 
 		kg.GlobalShadowPartitionSet(),
 		kg.GlobalAccountShadowPartitions(),

--- a/pkg/execution/state/redis_state/backlog.go
+++ b/pkg/execution/state/redis_state/backlog.go
@@ -705,8 +705,10 @@ func (q *queue) BacklogRefill(ctx context.Context, b *QueueBacklog, sp *QueueSha
 	}
 
 	keys := []string{
-		kg.BacklogSet(b.BacklogID),
+		kg.ShadowPartitionMeta(),
 		kg.BacklogMeta(),
+
+		kg.BacklogSet(b.BacklogID),
 		kg.ShadowPartitionSet(sp.PartitionID),
 		kg.GlobalShadowPartitionSet(),
 		kg.GlobalAccountShadowPartitions(),

--- a/pkg/execution/state/redis_state/backlog_normalization.go
+++ b/pkg/execution/state/redis_state/backlog_normalization.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/logger"
 	"math"
 	"runtime"
 	"time"
@@ -278,7 +279,7 @@ func (q *queue) normalizeBacklog(ctx context.Context, backlog *QueueBacklog, sp 
 	metrics.ActiveBacklogNormalizeCount(ctx, 1, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": q.primaryQueueShard.Name}})
 	defer metrics.ActiveBacklogNormalizeCount(ctx, -1, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": q.primaryQueueShard.Name}})
 
-	l := q.log.With(
+	l := logger.StdlibLogger(ctx).With(
 		"backlog", backlog,
 		"sp", sp,
 		"constraints", latestConstraints,

--- a/pkg/execution/state/redis_state/lua/includes/update_backlog_pointer.lua
+++ b/pkg/execution/state/redis_state/lua/includes/update_backlog_pointer.lua
@@ -1,13 +1,19 @@
-local function updateBacklogPointer(keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
+local function updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
   -- Retrieve the earliest item score in the backlog in milliseconds
   local earliestBacklogScore = get_earliest_score(keyBacklogSet)
 
   -- If backlog is empty, update dangling pointers in shadow partition
   if earliestBacklogScore == 0 then
+    -- Remove meta
+    redis.call("HDEL", keyBacklogMeta, backlogID)
+
     redis.call("ZREM", keyShadowPartitionSet, backlogID)
 
     -- If shadow partition has no more backlogs, update global/account pointers
     if tonumber(redis.call("ZCARD", keyShadowPartitionSet)) == 0 then
+      -- Remove meta
+      redis.call("HDEL", keyShadowPartitionMeta, partitionID)
+
       redis.call("ZREM", keyGlobalShadowPartitionSet, partitionID)
       redis.call("ZREM", keyAccountShadowPartitionSet, partitionID)
 

--- a/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
@@ -13,16 +13,17 @@
 ]]
 
 local keyBacklogMeta                     = KEYS[1]
+local keyShadowPartitionMeta             = KEYS[2]
 
-local keyBacklogSet                      = KEYS[2]
-local keyShadowPartitionSet              = KEYS[3]
-local keyGlobalShadowPartitionSet        = KEYS[4]
-local keyGlobalAccountShadowPartitionSet = KEYS[5]
-local keyAccountShadowPartitionSet       = KEYS[6]
+local keyBacklogSet                      = KEYS[3]
+local keyShadowPartitionSet              = KEYS[4]
+local keyGlobalShadowPartitionSet        = KEYS[5]
+local keyGlobalAccountShadowPartitionSet = KEYS[6]
+local keyAccountShadowPartitionSet       = KEYS[7]
 
-local keyGlobalNormalizeSet              = KEYS[7]
-local keyAccountNormalizeSet             = KEYS[8]
-local keyPartitionNormalizeSet           = KEYS[9]
+local keyGlobalNormalizeSet              = KEYS[8]
+local keyAccountNormalizeSet             = KEYS[9]
+local keyPartitionNormalizeSet           = KEYS[10]
 
 local backlogID             = ARGV[1]
 local partitionID           = ARGV[2]
@@ -46,7 +47,7 @@ if backlogCount == nil or backlogCount == false or backlogCount == 0 then
   redis.call("HDEL", keyBacklogMeta, backlogID)
 
   -- Update pointers
-  updateBacklogPointer(keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
+  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
 
   return { -2, 0 }
 end

--- a/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
@@ -47,7 +47,7 @@ if backlogCount == nil or backlogCount == false or backlogCount == 0 then
   redis.call("HDEL", keyBacklogMeta, backlogID)
 
   -- Update pointers
-  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
+  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, keyPartitionNormalizeSet, accountID, partitionID, backlogID)
 
   return { -2, 0 }
 end
@@ -84,8 +84,7 @@ redis.call("ZREM", keyShadowPartitionSet, backlogID)
 
 -- If shadow partition has no more backlogs, update global/account pointers
 if tonumber(redis.call("ZCARD", keyShadowPartitionSet)) == 0 then
-  -- clean up shadow partition metadata
-  redis.call("HDEL", keyShadowPartitionMeta, partitionID)
+  -- do not clean up shadow partition metadata yet, as we may still normalize
 
   redis.call("ZREM", keyGlobalShadowPartitionSet, partitionID)
   redis.call("ZREM", keyAccountShadowPartitionSet, partitionID)

--- a/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
@@ -76,7 +76,6 @@ if currentScore == false or tonumber(currentScore) > normalizeTime then
 end
 
 -- Remove from backlog and update pointers
-
 redis.call("ZREM", keyShadowPartitionSet, backlogID)
 
 -- If shadow partition has no more backlogs, update global/account pointers

--- a/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
@@ -79,6 +79,13 @@ end
 redis.call("ZREM", keyShadowPartitionSet, backlogID)
 
 -- If shadow partition has no more backlogs, update global/account pointers
-updateBacklogPointer(keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
+if tonumber(redis.call("ZCARD", keyShadowPartitionSet)) == 0 then
+  redis.call("ZREM", keyGlobalShadowPartitionSet, partitionID)
+  redis.call("ZREM", keyAccountShadowPartitionSet, partitionID)
+
+  if tonumber(redis.call("ZCARD", keyAccountShadowPartitionSet)) == 0 then
+    redis.call("ZREM", keyGlobalAccountShadowPartitionSet, accountID)
+  end
+end
 
 return { 1, backlogCount }

--- a/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
@@ -43,9 +43,6 @@ if backlogCount == nil or backlogCount == false or backlogCount == 0 then
   -- Remove pointer from shadow partition
   redis.call("ZREM", keyShadowPartitionSet, backlogID)
 
-  -- Remove meta
-  redis.call("HDEL", keyBacklogMeta, backlogID)
-
   -- Update pointers
   updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, keyPartitionNormalizeSet, accountID, partitionID, backlogID)
 

--- a/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
@@ -40,9 +40,6 @@ local backlogCount = redis.call("ZCARD", keyBacklogSet)
 
 -- If backlog is empty, garbage-collect it from shadow partition
 if backlogCount == nil or backlogCount == false or backlogCount == 0 then
-  -- Remove pointer from shadow partition
-  redis.call("ZREM", keyShadowPartitionSet, backlogID)
-
   -- Update pointers
   updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, keyPartitionNormalizeSet, accountID, partitionID, backlogID)
 

--- a/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
@@ -77,10 +77,16 @@ if currentScore == false or tonumber(currentScore) > normalizeTime then
 end
 
 -- Remove from backlog and update pointers
+-- Note: The backlog is not yet empty, but we don't want to process it,
+-- as it is outdated. That's why we don't call updateBacklogPointer which would
+-- use the earliest item score as pointer instead of dropping it altogether.
 redis.call("ZREM", keyShadowPartitionSet, backlogID)
 
 -- If shadow partition has no more backlogs, update global/account pointers
 if tonumber(redis.call("ZCARD", keyShadowPartitionSet)) == 0 then
+  -- clean up shadow partition metadata
+  redis.call("HDEL", keyShadowPartitionMeta, partitionID)
+
   redis.call("ZREM", keyGlobalShadowPartitionSet, partitionID)
   redis.call("ZREM", keyAccountShadowPartitionSet, partitionID)
 

--- a/pkg/execution/state/redis_state/lua/queue/backlogRefill.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogRefill.lua
@@ -27,34 +27,36 @@
   5 - Throttled
 ]]
 
-local keyBacklogSet                      = KEYS[1]
+local keyShadowPartitionMeta             = KEYS[1]
 local keyBacklogMeta                     = KEYS[2]
-local keyShadowPartitionSet              = KEYS[3]
-local keyGlobalShadowPartitionSet        = KEYS[4]
-local keyGlobalAccountShadowPartitionSet = KEYS[5]
-local keyAccountShadowPartitionSet       = KEYS[6]
 
-local keyReadySet                        = KEYS[7]
-local keyGlobalPointer        	         = KEYS[8] -- partition:sorted - zset
-local keyGlobalAccountPointer 	         = KEYS[9] -- accounts:sorted - zset
-local keyAccountPartitions    	         = KEYS[10] -- accounts:$accountID:partition:sorted - zset
+local keyBacklogSet                      = KEYS[3]
+local keyShadowPartitionSet              = KEYS[4]
+local keyGlobalShadowPartitionSet        = KEYS[5]
+local keyGlobalAccountShadowPartitionSet = KEYS[6]
+local keyAccountShadowPartitionSet       = KEYS[7]
 
-local keyQueueItemHash                   = KEYS[11]
+local keyReadySet                        = KEYS[8]
+local keyGlobalPointer        	         = KEYS[9] -- partition:sorted - zset
+local keyGlobalAccountPointer 	         = KEYS[10] -- accounts:sorted - zset
+local keyAccountPartitions    	         = KEYS[11] -- accounts:$accountID:partition:sorted - zset
+
+local keyQueueItemHash                   = KEYS[12]
 
 -- Constraint-related accounting keys
-local keyActiveAccount           = KEYS[12]
-local keyActivePartition         = KEYS[13]
-local keyActiveConcurrencyKey1   = KEYS[14]
-local keyActiveConcurrencyKey2   = KEYS[15]
-local keyActiveCompound          = KEYS[16]
+local keyActiveAccount           = KEYS[13]
+local keyActivePartition         = KEYS[14]
+local keyActiveConcurrencyKey1   = KEYS[15]
+local keyActiveConcurrencyKey2   = KEYS[16]
+local keyActiveCompound          = KEYS[17]
 
-local keyActiveRunsAccount                = KEYS[17]
-local keyActiveRunsPartition              = KEYS[18]
-local keyActiveRunsCustomConcurrencyKey1  = KEYS[19]
-local keyActiveRunsCustomConcurrencyKey2  = KEYS[20]
+local keyActiveRunsAccount                = KEYS[18]
+local keyActiveRunsPartition              = KEYS[19]
+local keyActiveRunsCustomConcurrencyKey1  = KEYS[20]
+local keyActiveRunsCustomConcurrencyKey2  = KEYS[21]
 
-local keyBacklogActiveCheckSet       = KEYS[21]
-local keyBacklogActiveCheckCooldown  = KEYS[22]
+local keyBacklogActiveCheckSet       = KEYS[22]
+local keyBacklogActiveCheckCooldown  = KEYS[23]
 
 local backlogID     = ARGV[1]
 local partitionID   = ARGV[2]
@@ -103,7 +105,7 @@ if backlogCountTotal == 0 then
   redis.call("HDEL", keyBacklogMeta, backlogID)
 
   -- update backlog pointers
-  updateBacklogPointer(keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
+  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
 
   return { 0, 0, 0, backlogCountTotal, 0, 0, {}, 0 }
 end
@@ -115,7 +117,7 @@ end
 
 if backlogCountUntil == 0 then
   -- update backlog pointers
-  updateBacklogPointer(keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
+  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
 
   return { 0, 0, backlogCountUntil, backlogCountTotal, 0, 0, {}, 0 }
 end
@@ -382,7 +384,7 @@ else
 end
 
 -- Always update pointers
-updateBacklogPointer(keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
+updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
 
 --
 -- Optional: Add backlog to active checker set. This will verify that all items marked as active

--- a/pkg/execution/state/redis_state/lua/queue/backlogRefill.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogRefill.lua
@@ -58,6 +58,8 @@ local keyActiveRunsCustomConcurrencyKey2  = KEYS[21]
 local keyBacklogActiveCheckSet       = KEYS[22]
 local keyBacklogActiveCheckCooldown  = KEYS[23]
 
+local keyPartitionNormalizeSet       = KEYS[24]
+
 local backlogID     = ARGV[1]
 local partitionID   = ARGV[2]
 local accountID     = ARGV[3]
@@ -105,7 +107,7 @@ if backlogCountTotal == 0 then
   redis.call("HDEL", keyBacklogMeta, backlogID)
 
   -- update backlog pointers
-  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
+  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, keyPartitionNormalizeSet, accountID, partitionID, backlogID)
 
   return { 0, 0, 0, backlogCountTotal, 0, 0, {}, 0 }
 end
@@ -117,7 +119,7 @@ end
 
 if backlogCountUntil == 0 then
   -- update backlog pointers
-  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
+  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, keyPartitionNormalizeSet, accountID, partitionID, backlogID)
 
   return { 0, 0, backlogCountUntil, backlogCountTotal, 0, 0, {}, 0 }
 end
@@ -384,7 +386,7 @@ else
 end
 
 -- Always update pointers
-updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
+updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, keyPartitionNormalizeSet, accountID, partitionID, backlogID)
 
 --
 -- Optional: Add backlog to active checker set. This will verify that all items marked as active

--- a/pkg/execution/state/redis_state/lua/queue/backlogRequeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogRequeue.lua
@@ -18,6 +18,7 @@ local keyGlobalAccountShadowPartitionSet = KEYS[5]
 local keyAccountShadowPartitionSet       = KEYS[6]
 local keyShadowPartitionSet              = KEYS[7]
 local keyBacklogSet                      = KEYS[8]
+local keyPartitionNormalizeSet           = KEYS[9]
 
 local accountID   = ARGV[1]
 local partitionID = ARGV[2]
@@ -38,7 +39,7 @@ if tonumber(redis.call("ZCARD", keyBacklogSet)) == 0 then
   redis.call("HDEL", keyBacklogMeta, backlogID)
 
   -- Update pointers
-  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
+  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, keyPartitionNormalizeSet, accountID, partitionID, backlogID)
 
   return 1
 end

--- a/pkg/execution/state/redis_state/lua/queue/backlogRequeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogRequeue.lua
@@ -11,12 +11,13 @@
 
 local keyShadowPartitionHash             = KEYS[1]
 local keyBacklogMeta                     = KEYS[2]
+local keyShadowPartitionMeta             = KEYS[3]
 
-local keyGlobalShadowPartitionSet        = KEYS[3]
-local keyGlobalAccountShadowPartitionSet = KEYS[4]
-local keyAccountShadowPartitionSet       = KEYS[5]
-local keyShadowPartitionSet              = KEYS[6]
-local keyBacklogSet                      = KEYS[7]
+local keyGlobalShadowPartitionSet        = KEYS[4]
+local keyGlobalAccountShadowPartitionSet = KEYS[5]
+local keyAccountShadowPartitionSet       = KEYS[6]
+local keyShadowPartitionSet              = KEYS[7]
+local keyBacklogSet                      = KEYS[8]
 
 local accountID   = ARGV[1]
 local partitionID = ARGV[2]
@@ -36,17 +37,8 @@ end
 if tonumber(redis.call("ZCARD", keyBacklogSet)) == 0 then
   redis.call("HDEL", keyBacklogMeta, backlogID)
 
-  redis.call("ZREM", keyShadowPartitionSet, backlogID)
-
-  -- If shadow partition has no more backlogs, update global/account pointers
-  if tonumber(redis.call("ZCARD", keyShadowPartitionSet)) == 0 then
-    redis.call("ZREM", keyGlobalShadowPartitionSet, partitionID)
-    redis.call("ZREM", keyAccountShadowPartitionSet, partitionID)
-
-    if tonumber(redis.call("ZCARD", keyAccountShadowPartitionSet)) == 0 then
-      redis.call("ZREM", keyGlobalAccountShadowPartitionSet, accountID)
-    end
-  end
+  -- Update pointers
+  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
 
   return 1
 end

--- a/pkg/execution/state/redis_state/lua/queue/dequeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/dequeue.lua
@@ -16,34 +16,37 @@ local keyGlobalPointer         = KEYS[5]
 local keyGlobalAccountPointer  = KEYS[6]           -- accounts:sorted - zset
 local keyAccountPartitions     = KEYS[7]           -- accounts:$accountID:partition:sorted - zset
 
-local keyBacklogSet                      = KEYS[8]
-local keyShadowPartitionSet              = KEYS[9]
-local keyGlobalShadowPartitionSet        = KEYS[10]
-local keyGlobalAccountShadowPartitionSet = KEYS[11]
-local keyAccountShadowPartitionSet       = KEYS[12]
+local keyShadowPartitionMeta             = KEYS[8]
+local keyBacklogMeta                     = KEYS[9]
 
-local keyInProgressAccount                  = KEYS[13]
-local keyInProgressPartition                = KEYS[14] -- Account concurrency level
-local keyInProgressCustomConcurrencyKey1    = KEYS[15] -- When leasing an item we need to place the lease into this key.
-local keyInProgressCustomConcurrencyKey2    = KEYS[16] -- Optional for eg. for concurrency amongst steps
+local keyBacklogSet                      = KEYS[10]
+local keyShadowPartitionSet              = KEYS[11]
+local keyGlobalShadowPartitionSet        = KEYS[12]
+local keyGlobalAccountShadowPartitionSet = KEYS[13]
+local keyAccountShadowPartitionSet       = KEYS[14]
 
-local keyActiveAccount             = KEYS[17]
-local keyActivePartition           = KEYS[18]
-local keyActiveConcurrencyKey1     = KEYS[19]
-local keyActiveConcurrencyKey2     = KEYS[20]
-local keyActiveCompound            = KEYS[21]
+local keyInProgressAccount                  = KEYS[15]
+local keyInProgressPartition                = KEYS[16] -- Account concurrency level
+local keyInProgressCustomConcurrencyKey1    = KEYS[17] -- When leasing an item we need to place the lease into this key.
+local keyInProgressCustomConcurrencyKey2    = KEYS[18] -- Optional for eg. for concurrency amongst steps
 
-local keyActiveRun                        = KEYS[22]
-local keyActiveRunsAccount                = KEYS[23]
-local keyActiveRunsPartition              = KEYS[24]
-local keyActiveRunsCustomConcurrencyKey1  = KEYS[25]
-local keyActiveRunsCustomConcurrencyKey2  = KEYS[26]
+local keyActiveAccount             = KEYS[19]
+local keyActivePartition           = KEYS[20]
+local keyActiveConcurrencyKey1     = KEYS[21]
+local keyActiveConcurrencyKey2     = KEYS[22]
+local keyActiveCompound            = KEYS[23]
 
-local keyIdempotency           = KEYS[27]
-local singletonRunKey          = KEYS[28]
+local keyActiveRun                        = KEYS[24]
+local keyActiveRunsAccount                = KEYS[25]
+local keyActiveRunsPartition              = KEYS[26]
+local keyActiveRunsCustomConcurrencyKey1  = KEYS[27]
+local keyActiveRunsCustomConcurrencyKey2  = KEYS[28]
 
-local keyItemIndexA            = KEYS[29]   -- custom item index 1
-local keyItemIndexB            = KEYS[30]  -- custom item index 2
+local keyIdempotency           = KEYS[29]
+local singletonRunKey          = KEYS[30]
+
+local keyItemIndexA            = KEYS[31]   -- custom item index 1
+local keyItemIndexB            = KEYS[32]  -- custom item index 2
 
 local queueID        = ARGV[1]
 local partitionID    = ARGV[2]
@@ -160,7 +163,7 @@ if backlogScore ~= nil and backlogScore ~= false and backlogScore > 0 then
   redis.call("ZREM", keyBacklogSet, queueID)
 
   -- update backlog pointers
-  updateBacklogPointer(keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
+  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
 end
 
 

--- a/pkg/execution/state/redis_state/lua/queue/dequeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/dequeue.lua
@@ -24,29 +24,30 @@ local keyShadowPartitionSet              = KEYS[11]
 local keyGlobalShadowPartitionSet        = KEYS[12]
 local keyGlobalAccountShadowPartitionSet = KEYS[13]
 local keyAccountShadowPartitionSet       = KEYS[14]
+local keyPartitionNormalizeSet           = KEYS[15]
 
-local keyInProgressAccount                  = KEYS[15]
-local keyInProgressPartition                = KEYS[16] -- Account concurrency level
-local keyInProgressCustomConcurrencyKey1    = KEYS[17] -- When leasing an item we need to place the lease into this key.
-local keyInProgressCustomConcurrencyKey2    = KEYS[18] -- Optional for eg. for concurrency amongst steps
+local keyInProgressAccount                  = KEYS[16]
+local keyInProgressPartition                = KEYS[17] -- Account concurrency level
+local keyInProgressCustomConcurrencyKey1    = KEYS[18] -- When leasing an item we need to place the lease into this key.
+local keyInProgressCustomConcurrencyKey2    = KEYS[19] -- Optional for eg. for concurrency amongst steps
 
-local keyActiveAccount             = KEYS[19]
-local keyActivePartition           = KEYS[20]
-local keyActiveConcurrencyKey1     = KEYS[21]
-local keyActiveConcurrencyKey2     = KEYS[22]
-local keyActiveCompound            = KEYS[23]
+local keyActiveAccount             = KEYS[20]
+local keyActivePartition           = KEYS[21]
+local keyActiveConcurrencyKey1     = KEYS[22]
+local keyActiveConcurrencyKey2     = KEYS[23]
+local keyActiveCompound            = KEYS[24]
 
-local keyActiveRun                        = KEYS[24]
-local keyActiveRunsAccount                = KEYS[25]
-local keyActiveRunsPartition              = KEYS[26]
-local keyActiveRunsCustomConcurrencyKey1  = KEYS[27]
-local keyActiveRunsCustomConcurrencyKey2  = KEYS[28]
+local keyActiveRun                        = KEYS[25]
+local keyActiveRunsAccount                = KEYS[26]
+local keyActiveRunsPartition              = KEYS[27]
+local keyActiveRunsCustomConcurrencyKey1  = KEYS[28]
+local keyActiveRunsCustomConcurrencyKey2  = KEYS[29]
 
-local keyIdempotency           = KEYS[29]
-local singletonRunKey          = KEYS[30]
+local keyIdempotency           = KEYS[30]
+local singletonRunKey          = KEYS[31]
 
-local keyItemIndexA            = KEYS[31]   -- custom item index 1
-local keyItemIndexB            = KEYS[32]  -- custom item index 2
+local keyItemIndexA            = KEYS[32]   -- custom item index 1
+local keyItemIndexB            = KEYS[33]  -- custom item index 2
 
 local queueID        = ARGV[1]
 local partitionID    = ARGV[2]
@@ -163,7 +164,7 @@ if backlogScore ~= nil and backlogScore ~= false and backlogScore > 0 then
   redis.call("ZREM", keyBacklogSet, queueID)
 
   -- update backlog pointers
-  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, accountID, partitionID, backlogID)
+  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, dequeue(ctx, accountID, partitionID, backlogID)
 end
 
 

--- a/pkg/execution/state/redis_state/lua/queue/dequeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/dequeue.lua
@@ -164,7 +164,7 @@ if backlogScore ~= nil and backlogScore ~= false and backlogScore > 0 then
   redis.call("ZREM", keyBacklogSet, queueID)
 
   -- update backlog pointers
-  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, dequeue(ctx, accountID, partitionID, backlogID)
+  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, keyPartitionNormalizeSet, accountID, partitionID, backlogID)
 end
 
 

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -2478,6 +2478,9 @@ func (q *queue) Dequeue(ctx context.Context, queueShard QueueShard, i osqueue.Qu
 		kg.GlobalAccountIndex(),
 		kg.AccountPartitionIndex(i.Data.Identifier.AccountID),
 
+		kg.ShadowPartitionMeta(),
+		kg.BacklogMeta(),
+
 		kg.BacklogSet(backlog.BacklogID),
 		kg.ShadowPartitionSet(partition.PartitionID),
 		kg.GlobalShadowPartitionSet(),

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -2486,6 +2486,7 @@ func (q *queue) Dequeue(ctx context.Context, queueShard QueueShard, i osqueue.Qu
 		kg.GlobalShadowPartitionSet(),
 		kg.GlobalAccountShadowPartitions(),
 		kg.AccountShadowPartitions(i.Data.Identifier.AccountID),
+		kg.PartitionNormalizeSet(partition.PartitionID),
 
 		// In progress keys
 		partition.accountInProgressKey(kg),

--- a/pkg/execution/state/redis_state/shadow_queue.go
+++ b/pkg/execution/state/redis_state/shadow_queue.go
@@ -372,8 +372,6 @@ func (q *queue) processShadowPartitionBacklog(ctx context.Context, shadowPart *Q
 		// is not being normalized right now as it wouldn't be picked up
 		// by the shadow scanner otherwise.
 		if !shouldNormalizeAsync {
-			l.Debug("normalizing backlog immediately")
-
 			if _, err := duration(ctx, q.primaryQueueShard.Name, "normalize_lease", q.clock.Now(), func(ctx context.Context) (any, error) {
 				err := q.leaseBacklogForNormalization(ctx, backlog)
 				return nil, err
@@ -384,6 +382,8 @@ func (q *queue) processShadowPartitionBacklog(ctx context.Context, shadowPart *Q
 
 				return nil, false, fmt.Errorf("could not lease backlog: %w", err)
 			}
+
+			l.Debug("normalizing backlog immediately")
 
 			_, err := durationWithTags(ctx, q.primaryQueueShard.Name, "normalize_backlog", q.clock.Now(), func(ctx context.Context) (any, error) {
 				err := q.normalizeBacklog(logger.WithStdlib(ctx, l), backlog, shadowPart, constraints)


### PR DESCRIPTION
## Description

This PR adds automatic garbage collection to empty, outdated backlogs.

During backlogNormalizePrep, we check if the backlog is empty. If it is, there's no reason to normalize it in the first place, as there are no items to move. In this case, we simply remove the dangling pointers and also drop the backlog meta (as there are no more items to be refilled).

This should prevent us from spinning on outdated backlogs. We still have to understand _why_ pointers to empty/non-existing backlog exist in shadow partitions. To this end, I've made sure to log whenever we garbage-collect backlogs. 

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
