### PR TITLE
INN-5256: Prevent duplicate and success status pills from displaying on Apps cards

### DIFF
--- a/ui/apps/dashboard/src/components/Apps/AppCards.tsx
+++ b/ui/apps/dashboard/src/components/Apps/AppCards.tsx
@@ -15,6 +15,7 @@ import { type FlattenedApp } from '@/app/(organization-active)/(dashboard)/env/[
 import { ActionsMenu } from '@/components/Apps/ActionsMenu';
 import getAppCardContent from '@/components/Apps/AppCardContent';
 import { pathCreator } from '@/utils/urls';
+import { isSyncStatusHiddenOnAppCard } from '../SyncStatusPill';
 import { useWorkersCount } from '../Workers/useWorker';
 
 export default function AppCards({ apps, envSlug }: { apps: FlattenedApp[]; envSlug: string }) {
@@ -59,7 +60,7 @@ export default function AppCards({ apps, envSlug }: { apps: FlattenedApp[]; envS
                 url={pathCreator.app({ envSlug, externalAppID: app.externalID })}
                 app={app}
                 pill={
-                  status ? (
+                  status && !isSyncStatusHiddenOnAppCard(app.status) ? (
                     <Pill appearance="outlined" kind={appKind}>
                       {status}
                     </Pill>

--- a/ui/apps/dashboard/src/components/SyncStatusPill.tsx
+++ b/ui/apps/dashboard/src/components/SyncStatusPill.tsx
@@ -16,6 +16,16 @@ export const syncKind: Record<string, AppKind> = {
   success: 'primary',
 } as const satisfies { [key in SyncStatus]: unknown };
 
+const hiddenSyncStatusesOnAppCard = [
+  'duplicate',
+  'success',
+] as const satisfies readonly SyncStatus[];
+
+export const isSyncStatusHiddenOnAppCard = (status: string | undefined) => {
+  if (!status) return true;
+  return String(hiddenSyncStatusesOnAppCard).includes(status);
+};
+
 type Props = {
   status: string;
   iconOnly?: boolean;


### PR DESCRIPTION
## Description

Remove green status pill from Apps cards if status is duplicate or success.

Because this is my first PR, here is a very long explanation for at three line change set 😄.

On my first pass, I decided to take an approach similar to what is presented in this PR by preventing renders of the `<Pill />` component in the `<AppCards />` component when the status has a value of 'No change or 'Success'.

On a second pass, I refactored to move the logic down into the `<AppCard />` component itself because the component would be responsible for displaying it's own content and it would be more testable at the component level. To accomplish this, I passed the status as an additional prop to the `<AppCard />`.

This approach doesn't work because it changes the props to `<AppCard />` and requires changes to the dev-server-ui project. After talking to Aaron, this project never has the values "success" or "duplicate" so the solution doesn't need to be implemented there.

Final approach is to add an array of keys of SyncStatus and a helper function to the same <SyncStatusPill /> component because the sync status label mappings are in this file as well and use the helper function in the `<AppCards />` component to prevent rendering.

### Before
<img width="1517" alt="image" src="https://github.com/user-attachments/assets/1886c08d-42a4-4bf1-9616-59322a6518a5" />

### After
<img width="1517" alt="image" src="https://github.com/user-attachments/assets/6fd6b431-41e4-4b26-9330-33264a80d0f8" />

## Motivation
Quick win to learn where things are in the codebase.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
