### PR TITLE
Emphasize Connect CTAs in Integrations

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/integrations.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/integrations.tsx
@@ -49,7 +49,7 @@ const INTEGRATIONS: Integration[] = [
         <Button
           disabled={hasError}
           kind="primary"
-          appearance="solid"
+          appearance={enabled ? 'outlined' : 'solid'}
           size="medium"
           href={url}
           label={label}
@@ -69,7 +69,7 @@ const INTEGRATIONS: Integration[] = [
       <Button
         disabled={hasError}
         kind="primary"
-        appearance="solid"
+        appearance={enabled ? 'outlined' : 'solid'}
         size="medium"
         href={enabled ? '/settings/integrations/neon' : '/settings/integrations/neon/connect'}
         label={enabled ? 'Manage' : 'Connect'}
@@ -86,7 +86,7 @@ const INTEGRATIONS: Integration[] = [
       <Button
         disabled={hasError}
         kind="primary"
-        appearance="solid"
+        appearance={enabled ? 'outlined' : 'solid'}
         size="medium"
         href={
           enabled ? '/settings/integrations/supabase' : '/settings/integrations/supabase/connect'
@@ -122,7 +122,7 @@ const INTEGRATIONS: Integration[] = [
     actionButton: () => (
       <Button
         iconSide="left"
-        appearance="solid"
+        appearance="outlined"
         size="medium"
         label="Configure"
         href="/settings/integrations/prometheus"


### PR DESCRIPTION
## Description

This changes "Manage" and "Configure" buttons to use `appearance="outlined"`.

**Before:**

![before](https://github.com/user-attachments/assets/e82a2bb2-ad7e-45d2-b1df-1e2820b39871)
---
**After:**

![after](https://github.com/user-attachments/assets/41cb0186-d041-48e2-8c55-dad86ca148fa)


## Motivation
This emphasizes the "Connect" buttons by relatively de-emphasizing the "Manage" and "Configure" buttons.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
