### PR TITLE
Use InlineCode Component in Prometheus Integration Flow

### DIFF
--- a/ui/apps/dashboard/src/components/PrometheusIntegration/ConfigSteps.tsx
+++ b/ui/apps/dashboard/src/components/PrometheusIntegration/ConfigSteps.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { InlineCode } from '@inngest/components/Code';
 import { RiInformationLine } from '@remixicon/react';
 
 import DashboardCodeBlock from '@/components/DashboardCodeBlock/DashboardCodeBlock';
@@ -22,8 +23,7 @@ export default function ConfigSteps({ metricsGranularitySeconds }: Props) {
         <div className="border-subtle ml-3 border-l">
           <div className="before:border-subtle before:text-basis before:bg-canvasBase relative ml-[32px] pb-7 before:absolute before:left-[-46px] before:h-[28px] before:w-[28px] before:rounded-full before:border before:text-center before:align-middle before:text-[13px] before:content-['1']">
             <div className="text-basis mb-4 text-base">
-              Select an environment to view its Prometheus{' '}
-              <code className="bg-gray-100 p-0.5">scrape_config</code>.
+              Select an environment to view its Prometheus <InlineCode>scrape_config</InlineCode>.
             </div>
             <EnvSelectMenu onSelect={setSelectedEnv} />
           </div>
@@ -32,8 +32,8 @@ export default function ConfigSteps({ metricsGranularitySeconds }: Props) {
         <div className="ml-3">
           <div className="before:border-subtle before:text-basis before:bg-canvasBase relative ml-[32px] pb-5 before:absolute before:left-[-46px] before:h-[28px] before:w-[28px] before:rounded-full before:border before:text-center before:align-middle before:text-[13px] before:content-['2']">
             <div className="text-basis mb-2 text-base">
-              Add this item to the <code className="bg-gray-100 p-0.5">scrape_configs</code> section
-              of your Prometheus configuration.
+              Add this item to the <InlineCode>scrape_configs</InlineCode> section of your
+              Prometheus configuration.
             </div>
             <div className="text-muted mb-4 text-base">
               <RiInformationLine className="text-light -mt-1 mr-1 inline-block h-5 w-5" />


### PR DESCRIPTION
## Description

This change uses the reusable `InlineCode` component for consistent inline code styling in the Prometheus Integration flow, replacing the one-off styling previously used.

<img width="1158" alt="prometheus-integration-page" src="https://github.com/user-attachments/assets/7f1a5410-0667-4cd8-a79c-9fa68816a9eb" />

Note: `MetricsExportEntitlementBanner` is hidden in screenshot

## Motivation

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
