### PR TITLE
Clean up source backlog pointers while normalizing

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -876,6 +876,8 @@ func PartitionConstraintConfigGetter(dbcqrs cqrs.Manager) redis_state.PartitionC
 		}
 
 		constraints := redis_state.PartitionConstraintConfig{
+			FunctionVersion: fn.FunctionVersion,
+			
 			Concurrency: redis_state.ShadowPartitionConcurrency{
 				SystemConcurrency:     consts.DefaultConcurrencyLimit,
 				AccountConcurrency:    accountLimit,

--- a/pkg/execution/state/redis_state/backlog.go
+++ b/pkg/execution/state/redis_state/backlog.go
@@ -32,6 +32,8 @@ var (
 )
 
 type PartitionConstraintConfig struct {
+	FunctionVersion int `json:"fv,omitempty,omitzero"`
+
 	Concurrency ShadowPartitionConcurrency `json:"c,omitempty,omitzero"`
 
 	// Throttle configuration, optionally specifying key. If no key is set, the throttle value will be the function ID.
@@ -273,8 +275,9 @@ type BacklogThrottle struct {
 }
 
 type QueueBacklog struct {
-	BacklogID         string `json:"id,omitempty"`
-	ShadowPartitionID string `json:"sid,omitempty"`
+	BacklogID               string `json:"id,omitempty"`
+	ShadowPartitionID       string `json:"sid,omitempty"`
+	EarliestFunctionVersion int    `json:"fv,omitempty"`
 
 	// Start marks backlogs representing items with KindStart.
 	Start bool `json:"start,omitempty"`
@@ -320,6 +323,10 @@ func (q *queue) ItemBacklog(ctx context.Context, i osqueue.QueueItem) QueueBackl
 	b := QueueBacklog{
 		BacklogID:         fmt.Sprintf("fn:%s", i.FunctionID),
 		ShadowPartitionID: i.FunctionID.String(),
+
+		// Store earliest function version. Since we do not update backlog metadata,
+		// this may be older than the latest items in the backlog.
+		EarliestFunctionVersion: i.Data.Identifier.WorkflowVersion,
 
 		// Start items should be moved into their own backlog. This is useful for
 		// function run concurrency: To determine how many new runs can start, we can
@@ -534,6 +541,16 @@ func (b QueueBacklog) isDefault() bool {
 }
 
 func (b QueueBacklog) isOutdated(constraints *PartitionConstraintConfig) enums.QueueNormalizeReason {
+	if constraints == nil {
+		return enums.QueueNormalizeReasonUnchanged
+	}
+
+	// If the backlog represents newer items than the constraints we're working on,
+	// do not attempt to mark the backlog as outdated. Constraints MUST be >= backlog function version at all times.
+	if b.EarliestFunctionVersion > 0 && constraints.FunctionVersion > 0 && b.EarliestFunctionVersion > constraints.FunctionVersion {
+		return enums.QueueNormalizeReasonUnchanged
+	}
+
 	// If this is the default backlog, don't normalize.
 	// If custom concurrency keys were added, previously-enqueued items
 	// in the default backlog do not have custom concurrency keys set.

--- a/pkg/execution/state/redis_state/backlog_normalization.go
+++ b/pkg/execution/state/redis_state/backlog_normalization.go
@@ -24,10 +24,6 @@ const (
 	NormalizePartitionPeekMax = int64(100)
 	NormalizeBacklogPeekMax   = int64(300) // same as ShadowPartitionPeekMax
 
-	// BacklogNormalizeAsyncLimit determines the minimum number of items required in an outdated backlog
-	// to require an async normalize job. For small backlogs, the added QPS may not be worth it and we should normalize JIT.
-	BacklogNormalizeAsyncLimit = 100
-
 	// BacklogRefillHardLimit sets the maximum number of items that can be refilled in a single backlogRefill operation.
 	BacklogRefillHardLimit = int64(1000)
 

--- a/pkg/execution/state/redis_state/backlog_normalization_test.go
+++ b/pkg/execution/state/redis_state/backlog_normalization_test.go
@@ -197,11 +197,9 @@ func TestQueueBacklogPrepareNormalize(t *testing.T) {
 		// still expect backlog in shadow partition
 		require.True(t, hasMember(t, r, kg.ShadowPartitionSet(shadowPartition.PartitionID), expectedBacklog.BacklogID))
 
-		backlogCount, shouldNormalizeAsync, err := q.BacklogPrepareNormalize(ctx, &expectedBacklog, &shadowPartition, 1)
+		err = q.BacklogPrepareNormalize(ctx, &expectedBacklog, &shadowPartition)
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrBacklogGarbageCollected)
-		require.False(t, shouldNormalizeAsync)
-		require.Equal(t, 0, backlogCount)
 
 		require.False(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
 		require.False(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
@@ -226,11 +224,9 @@ func TestQueueBacklogPrepareNormalize(t *testing.T) {
 
 		shadowPartition := q.ItemShadowPartition(ctx, item)
 		require.NotEmpty(t, shadowPartition.PartitionID)
-		backlogCount, shouldNormalizeAsync, err := q.BacklogPrepareNormalize(ctx, &expectedBacklog, &shadowPartition, 1)
+		err = q.BacklogPrepareNormalize(ctx, &expectedBacklog, &shadowPartition)
 		require.NoError(t, err)
 
-		require.True(t, shouldNormalizeAsync)
-		require.Equal(t, 1, backlogCount)
 		require.True(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
 		require.True(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
 		require.True(t, hasMember(t, r, kg.PartitionNormalizeSet(fnID.String()), expectedBacklog.BacklogID))
@@ -242,26 +238,6 @@ func TestQueueBacklogPrepareNormalize(t *testing.T) {
 		require.Equal(t, expectedTime, int64(score(t, r, kg.PartitionNormalizeSet(fnID.String()), expectedBacklog.BacklogID)))
 	})
 
-	t.Run("should not move if below limit", func(t *testing.T) {
-		r.FlushAll()
-
-		_, err := q.EnqueueItem(ctx, defaultShard, item, at, osqueue.EnqueueOpts{})
-		require.NoError(t, err)
-
-		expectedBacklog := q.ItemBacklog(ctx, item)
-		require.NotEmpty(t, expectedBacklog.BacklogID)
-
-		shadowPartition := q.ItemShadowPartition(ctx, item)
-		require.NotEmpty(t, shadowPartition.PartitionID)
-		backlogCount, shouldNormalizeAsync, err := q.BacklogPrepareNormalize(ctx, &expectedBacklog, &shadowPartition, 5)
-		require.NoError(t, err)
-
-		require.False(t, shouldNormalizeAsync)
-		require.Equal(t, 1, backlogCount)
-		require.False(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
-		require.False(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
-		require.False(t, hasMember(t, r, kg.PartitionNormalizeSet(fnID.String()), expectedBacklog.BacklogID))
-	})
 }
 
 func TestQueueBacklogNormalization(t *testing.T) {
@@ -329,10 +305,8 @@ func TestQueueBacklogNormalization(t *testing.T) {
 	constraints := PartitionConstraintConfig{}
 
 	// Mark backlog for normalization
-	backlogCount, shouldNormalizeAsync, err := q.BacklogPrepareNormalize(ctx, &backlog, &shadowPartition, 5)
+	err := q.BacklogPrepareNormalize(ctx, &backlog, &shadowPartition)
 	require.NoError(t, err)
-	require.True(t, shouldNormalizeAsync)
-	require.Equal(t, 10, backlogCount)
 	require.Equal(t, 10, zcard(t, rc, kg.BacklogSet(backlog.BacklogID)))
 	require.True(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
 	require.True(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
@@ -469,10 +443,8 @@ func TestQueueBacklogNormalizationWithRewrite(t *testing.T) {
 	require.NotEmpty(t, shadowPartition.PartitionID)
 
 	// Mark backlog for normalization
-	backlogCount, shouldNormalizeAsync, err := q.BacklogPrepareNormalize(ctx, &initialBacklog, &shadowPartition, 5)
+	err := q.BacklogPrepareNormalize(ctx, &initialBacklog, &shadowPartition)
 	require.NoError(t, err)
-	require.True(t, shouldNormalizeAsync)
-	require.Equal(t, 10, backlogCount)
 	require.Equal(t, 10, zcard(t, rc, kg.BacklogSet(initialBacklog.BacklogID)))
 	require.Equal(t, 0, zcard(t, rc, kg.BacklogSet(targetBacklog.BacklogID)))
 	require.True(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
@@ -554,10 +526,8 @@ func TestBacklogNormalizationScanner(t *testing.T) {
 		shadowPartition := q.ItemShadowPartition(ctx, item)
 		require.NotEmpty(t, shadowPartition.PartitionID)
 
-		backlogCount, shouldNormalizeAsync, err := q.BacklogPrepareNormalize(ctx, &backlog, &shadowPartition, 5)
+		err := q.BacklogPrepareNormalize(ctx, &backlog, &shadowPartition)
 		require.NoError(t, err)
-		require.True(t, shouldNormalizeAsync)
-		require.Equal(t, 100, backlogCount)
 		require.Equal(t, 100, zcard(t, rc, kg.BacklogSet(backlog.BacklogID)))
 		require.True(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
 		require.True(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
@@ -581,63 +551,6 @@ func TestBacklogNormalizationScanner(t *testing.T) {
 		err = q.normalizeBacklog(ctx, &backlog, &shadowPartition, &constraints)
 		require.NoError(t, err)
 		require.Equal(t, 0, zcard(t, rc, kg.BacklogSet(backlog.BacklogID)))
-		require.False(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
-		require.False(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
-		require.False(t, hasMember(t, r, kg.PartitionNormalizeSet(fnID.String()), backlog.BacklogID))
-	})
-
-	t.Run("non async normalization", func(t *testing.T) {
-		r.FlushAll()
-
-		// Create backlog
-		for i := range 3 {
-			at := clock.Now().Add(time.Duration(i*100) * time.Millisecond)
-			_, err := q.EnqueueItem(ctx, defaultShard, item, at, osqueue.EnqueueOpts{})
-			require.NoError(t, err)
-		}
-
-		// Verify backlog is created as expected
-		backlog := q.ItemBacklog(ctx, item)
-		require.NotEmpty(t, backlog.BacklogID)
-
-		shadowPartition := q.ItemShadowPartition(ctx, item)
-		require.NotEmpty(t, shadowPartition.PartitionID)
-
-		backlogCount, shouldNormalizeAsync, err := q.BacklogPrepareNormalize(ctx, &backlog, &shadowPartition, 5)
-		require.NoError(t, err)
-		require.False(t, shouldNormalizeAsync)
-		require.Equal(t, 3, backlogCount)
-		require.Equal(t, 3, zcard(t, rc, kg.BacklogSet(backlog.BacklogID)))
-		require.False(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
-		require.False(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
-		require.False(t, hasMember(t, r, kg.PartitionNormalizeSet(fnID.String()), backlog.BacklogID))
-	})
-
-	t.Run("non async normalization lease contention", func(t *testing.T) {
-		r.FlushAll()
-
-		// Create backlog
-		for i := range 3 {
-			at := clock.Now().Add(time.Duration(i*100) * time.Millisecond)
-			_, err := q.EnqueueItem(ctx, defaultShard, item, at, osqueue.EnqueueOpts{})
-			require.NoError(t, err)
-		}
-
-		// Verify backlog is created as expected
-		backlog := q.ItemBacklog(ctx, item)
-		require.NotEmpty(t, backlog.BacklogID)
-
-		shadowPartition := q.ItemShadowPartition(ctx, item)
-		require.NotEmpty(t, shadowPartition.PartitionID)
-
-		// simulate contention by leasing the backlog for normalization first
-		require.NoError(t, q.leaseBacklogForNormalization(ctx, &backlog))
-
-		backlogCount, shouldNormalizeAsync, err := q.BacklogPrepareNormalize(ctx, &backlog, &shadowPartition, 5)
-		require.NoError(t, err)
-		require.False(t, shouldNormalizeAsync)
-		require.Equal(t, 3, backlogCount)
-		require.Equal(t, 3, zcard(t, rc, kg.BacklogSet(backlog.BacklogID)))
 		require.False(t, hasMember(t, r, kg.GlobalAccountNormalizeSet(), accountId.String()))
 		require.False(t, hasMember(t, r, kg.AccountNormalizeSet(accountId), fnID.String()))
 		require.False(t, hasMember(t, r, kg.PartitionNormalizeSet(fnID.String()), backlog.BacklogID))

--- a/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogPrepareNormalize.lua
@@ -3,13 +3,10 @@
   Removes backlog pointer from shadow partition and into normalize partition.
   Will update shadow partition pointers accordingly.
 
-  Returns a tuple of {status, items_in_backlog}
-
-  Status values:
+  Return status values:
 
   1 - Moved backlog to normalize set
-  -1 - Fewer items than minimum
-  -2 - Garbage-collected empty backlog
+  -1 - Garbage-collected empty backlog
 ]]
 
 local keyBacklogMeta                     = KEYS[1]
@@ -43,16 +40,8 @@ if backlogCount == nil or backlogCount == false or backlogCount == 0 then
   -- Update pointers
   updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, keyPartitionNormalizeSet, accountID, partitionID, backlogID)
 
-  return { -2, 0 }
+  return -1
 end
-
--- If there's a minimum number of backlog items required to normalize asynchronously,
--- we do not need to move backlog pointers to the normalization ZSETs but can just normalize
--- in the same shadow scanner loop iteration.
-if normalizeAsyncMinimum > 0 and backlogCount < normalizeAsyncMinimum then
-  return { -1, backlogCount }
-end
-
 
 -- Add to normalize sets
 local currentScore = redis.call("ZSCORE", keyPartitionNormalizeSet, backlogID)
@@ -88,4 +77,4 @@ if tonumber(redis.call("ZCARD", keyShadowPartitionSet)) == 0 then
   end
 end
 
-return { 1, backlogCount }
+return 1

--- a/pkg/execution/state/redis_state/lua/queue/enqueue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/enqueue.lua
@@ -58,6 +58,7 @@ local normalizeFromBacklogID  = ARGV[15]
 -- $include(get_partition_item.lua)
 -- $include(enqueue_to_partition.lua)
 -- $include(ends_with.lua)
+-- $include(update_backlog_pointer.lua)
 
 -- Only skip idempotency checks if we're normalizing a backlog (we want to enqueue an existing item to a new backlog)
 local is_normalize = exists_without_ending(keyNormalizeFromBacklogSet, ":-")

--- a/pkg/execution/state/redis_state/lua/queue/enqueue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/enqueue.lua
@@ -94,6 +94,9 @@ end
 if is_normalize then
   redis.call("ZREM", keyNormalizeFromBacklogSet, queueID)
 
+  -- Clean up backlog pointers for old backlog
+  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, keyPartitionNormalizeSet, accountID, partitionID, backlogID)
+
   -- Clean up normalize pointers if backlog is empty
   if tonumber(redis.call("ZCARD", keyNormalizeFromBacklogSet)) == 0 then
     -- Clean up normalize pointer from partition -> normalizeFromBacklogID

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -251,12 +251,6 @@ func WithShadowPeekSizeRange(min int64, max int64) QueueOpt {
 	}
 }
 
-func WithBacklogNormalizeAsyncLimit(fn BacklogNormalizeAsyncLimitCount) QueueOpt {
-	return func(q *queue) {
-		q.backlogNormalizeAsyncLimit = fn
-	}
-}
-
 func WithBacklogRefillLimit(limit int64) QueueOpt {
 	return func(q *queue) {
 		q.backlogRefillLimit = limit
@@ -606,10 +600,6 @@ func WithDisableLeaseChecks(lc DisableLeaseChecks) QueueOpt {
 // larger amount of backlogs if there are a ton of backlog due to keys
 type QueueShadowPartitionProcessCount func(ctx context.Context, acctID uuid.UUID) int
 
-// BacklogNormalizeAsyncLimitCount determines how many items in a backlog that needs
-// to be exceeded before marking the backlog to be processed by the normalization workers
-type BacklogNormalizeAsyncLimitCount func(ctx context.Context) int
-
 func WithQueueShadowPartitionProcessCount(spc QueueShadowPartitionProcessCount) QueueOpt {
 	return func(q *queue) {
 		q.shadowPartitionProcessCount = spc
@@ -740,7 +730,6 @@ func NewQueue(primaryQueueShard QueueShard, opts ...QueueOpt) *queue {
 			return false
 		},
 		disableLeaseChecksForSystemQueues: true,
-		backlogNormalizeAsyncLimit:        func(ctx context.Context) int { return BacklogNormalizeAsyncLimit },
 		shadowPartitionProcessCount: func(ctx context.Context, acctID uuid.UUID) int {
 			return 5
 		},
@@ -842,7 +831,6 @@ type queue struct {
 	disableLeaseChecks                DisableLeaseChecks
 	disableLeaseChecksForSystemQueues bool
 
-	backlogNormalizeAsyncLimit  BacklogNormalizeAsyncLimitCount
 	shadowPartitionProcessCount QueueShadowPartitionProcessCount
 
 	// idempotencyTTL is the default or static idempotency duration apply to jobs,


### PR DESCRIPTION
## Description

This PR improves normalization as follows

- Remove immediate normalization. Having an extra entrypoint to normalization caused a lot of edge cases with contention, potentially stalling shadow partition processing, and more
- Only marking backlogs as outdated if the constraints are at least the same version or newer. In case the function config is not yet updated but new items are enqueued, backlogs should not be normalized back to an old version, ever.
- Update backlog pointers during normalization in enqueue, after removing item from old backlog: When normalizing, items are gradually moved from the old source backlog to the desired target backlog. Previously, we left pointers to now empty source backlogs in shadow partitions. This is now fixed by always updating backlog pointers.

This should lead to 1) fewer false positive normalizations 2) significantly reduced contention 3) no impact on shadow processing for non-outdated backlogs

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
