### PR TITLE
run trace codeblock layout poc

### DIFF
--- a/ui/apps/dashboard/src/gql/graphql.ts
+++ b/ui/apps/dashboard/src/gql/graphql.ts
@@ -566,6 +566,18 @@ export type EntitlementConnectWorkerConnections = {
   limit: Maybe<Scalars['Int']>;
 };
 
+export type EntitlementEvents = {
+  __typename?: 'EntitlementEvents';
+  limit: Maybe<Scalars['Int']>;
+  overageAllowed: Scalars['Boolean'];
+};
+
+export type EntitlementExecutions = {
+  __typename?: 'EntitlementExecutions';
+  limit: Maybe<Scalars['Int']>;
+  overageAllowed: Scalars['Boolean'];
+};
+
 export type EntitlementInt = {
   __typename?: 'EntitlementInt';
   limit: Scalars['Int'];
@@ -622,6 +634,8 @@ export type Entitlements = {
   eventBatchCount: EntitlementInt;
   eventBatchTimeout: EntitlementInt;
   eventSize: EntitlementInt;
+  events: EntitlementEvents;
+  executions: EntitlementExecutions;
   hipaa: EntitlementBool;
   history: EntitlementInt;
   metricsExport: EntitlementBool;
@@ -629,8 +643,12 @@ export type Entitlements = {
   metricsExportGranularity: EntitlementInt;
   otelTraces: EntitlementBool;
   planID: Maybe<Scalars['UUID']>;
+  realtimeConnections: EntitlementInt;
+  realtimeMessages: EntitlementInt;
   runCount: EntitlementRunCount;
+  runDuration: EntitlementInt;
   stepCount: EntitlementStepCount;
+  tracingCustomSpans: EntitlementInt;
   userCount: EntitlementUserCount;
 };
 
@@ -2184,14 +2202,12 @@ export type WaitForEventStepInfo = {
 export type Workflow = {
   __typename?: 'Workflow';
   app: App;
-  appName: Maybe<Scalars['String']>;
   archivedAt: Maybe<Scalars['Time']>;
   cancellationRunCount: Scalars['Int'];
   cancellations: CancellationConnection;
   configuration: FunctionConfiguration;
   current: Maybe<WorkflowVersion>;
   failureHandler: Maybe<Workflow>;
-  fnTriggers: Array<FunctionTrigger>;
   id: Scalars['ID'];
   isArchived: Scalars['Boolean'];
   isParentArchived: Scalars['Boolean'];
@@ -2273,7 +2289,6 @@ export type WorkflowVersion = {
   createdAt: Scalars['Time'];
   deploy: Maybe<Deploy>;
   description: Maybe<Scalars['NullString']>;
-  fnTriggers: Array<FunctionTrigger>;
   retries: Scalars['Int'];
   throttleCount: Scalars['Int'];
   throttlePeriod: Scalars['String'];

--- a/ui/packages/components/src/Debugger/StepHistory.tsx
+++ b/ui/packages/components/src/Debugger/StepHistory.tsx
@@ -4,7 +4,7 @@ import { RiLightbulbLine } from '@remixicon/react';
 import { AITrace } from '../AI/AITrace';
 import { Button } from '../Button';
 import { Pill } from '../Pill';
-import { NewIO } from '../RunDetailsV3/NewIO';
+import { IO } from '../RunDetailsV3/IO';
 import { Tabs } from '../RunDetailsV3/Tabs';
 import { StatusDot } from '../Status/StatusDot';
 import { getStatusTextClass } from '../Status/statusClasses';
@@ -88,7 +88,7 @@ export const StepHistory = ({
                     {
                       label: 'Input',
                       id: 'input',
-                      node: <NewIO raw={JSON.stringify(input, null, 2)} title="Input" />,
+                      node: <IO raw={JSON.stringify(input, null, 2)} title="Input" />,
                     },
                   ]
                 : []),
@@ -97,7 +97,7 @@ export const StepHistory = ({
                     {
                       label: 'Output',
                       id: 'output',
-                      node: <NewIO title="output" raw={JSON.stringify(output, null, 2)} />,
+                      node: <IO title="output" raw={JSON.stringify(output, null, 2)} />,
                     },
                   ]
                 : []),
@@ -105,13 +105,13 @@ export const StepHistory = ({
               {
                 label: 'Tools',
                 id: 'tools',
-                node: <NewIO title="Tools" raw='{"tools": "coming soon..."}' />,
+                node: <IO title="Tools" raw='{"tools": "coming soon..."}' />,
               },
 
               {
                 label: 'State',
                 id: 'state',
-                node: <NewIO title="State" raw='{"state": "coming soon..."}' />,
+                node: <IO title="State" raw='{"state": "coming soon..."}' />,
               },
             ]}
           />

--- a/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
+++ b/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { Button } from '@inngest/components/Button';
 import { CopyButton } from '@inngest/components/CopyButton';
 import { maxRenderedOutputSizeBytes } from '@inngest/components/constants';
@@ -11,17 +11,15 @@ import { cn } from '@inngest/components/utils/classNames';
 import { FONT, LINE_HEIGHT, createColors, createRules } from '@inngest/components/utils/monaco';
 import Editor, { useMonaco } from '@monaco-editor/react';
 import { RiCollapseDiagonalLine, RiDownload2Line, RiExpandDiagonalLine } from '@remixicon/react';
-import { type editor } from 'monaco-editor';
 import { JSONTree } from 'react-json-tree';
 import { useLocalStorage } from 'react-use';
 
 import { Alert } from '../Alert';
 import { Fullscreen } from '../Fullscreen/Fullscreen';
 import SegmentedControl from '../SegmentedControl/SegmentedControl';
+import { Skeleton } from '../Skeleton';
 import { jsonTreeTheme } from '../utils/jsonTree';
 import { isDark } from '../utils/theme';
-
-const DEFAULT_MAX_HEIGHT = 500;
 
 export type CodeBlockAction = {
   label: string;
@@ -44,29 +42,36 @@ interface CodeBlockProps {
     handleChange?: (value: string) => void;
   };
   actions?: CodeBlockAction[];
-  maxHeight?: number;
+  defaultHeight?: number;
+  height?: number;
   allowFullScreen?: boolean;
   parsed?: boolean;
+  loading?: boolean;
 }
 
 export const NewCodeBlock = ({
   header,
   tab,
   actions = [],
-  maxHeight = DEFAULT_MAX_HEIGHT,
+  height = 0,
   allowFullScreen = false,
   parsed = true,
+  loading = false,
 }: CodeBlockProps) => {
   const [dark, _] = useState(isDark());
-  const [editorHeight, setEditorHeight] = useState(maxHeight);
+  const [editorHeight, setEditorHeight] = useState(height);
   const [fullScreen, setFullScreen] = useState(false);
   const [mode, setMode] = useState<'rich' | 'raw'>('rich');
   const wrapperRef = useRef<HTMLDivElement>(null);
   const [wordWrap, setWordWrap] = useLocalStorage('wordWrap', false);
 
   const { handleCopyClick, isCopying } = useCopyToClipboard();
-  const updateHeight = (editor: editor.IStandaloneCodeEditor) =>
-    setEditorHeight(editor.getContentHeight());
+  const updateHeight = useCallback(
+    (newHeight?: number) => {
+      newHeight && newHeight !== editorHeight && setEditorHeight(newHeight);
+    },
+    [editorHeight]
+  );
 
   const monaco = useMonaco();
   const { content, readOnly = true, language = 'json' } = tab;
@@ -120,7 +125,7 @@ export const NewCodeBlock = ({
           fullScreen && 'bg-codeEditor fixed inset-0 z-[52]'
         )}
       >
-        <div className={cn('bg-canvasSubtle border-subtle min-h-12 border-b')}>
+        <div className={cn('bg-canvasSubtle')}>
           <div
             className={cn(
               'bg-canvasBase flex items-center justify-between border-l-4 border-l-transparent',
@@ -197,12 +202,7 @@ export const NewCodeBlock = ({
             )}
           </div>
         </div>
-        <div
-          ref={wrapperRef}
-          className={`m-0 overflow-y-auto ${
-            fullScreen ? `bg-codeEditor` : `bg-canvasBase max-h-[${maxHeight}px]`
-          }`}
-        >
+        <div ref={wrapperRef} className={cn('bg-codeEditor h-full overflow-y-auto')}>
           {isOutputTooLarge ? (
             <>
               <Alert severity="warning">Output size is too large to render {`( > 1MB )`}</Alert>
@@ -216,6 +216,8 @@ export const NewCodeBlock = ({
                 />
               </div>
             </>
+          ) : loading ? (
+            <Skeleton className="h-24 w-full" />
           ) : parsed && mode === 'rich' ? (
             <JSONTree
               hideRoot={true}
@@ -233,24 +235,33 @@ export const NewCodeBlock = ({
             />
           ) : (
             <Editor
+              className={cn('h-full', editorHeight && `h-[${editorHeight}px]`)}
               theme="inngest-theme"
               defaultLanguage={language}
               value={content}
-              height={editorHeight}
               options={{
                 wordWrap: wordWrap ? 'on' : 'off',
                 contextmenu: false,
-                readOnly: readOnly,
+                readOnly,
                 minimap: { enabled: false },
                 fontFamily: FONT.font,
                 fontSize: FONT.size,
                 fontWeight: 'light',
                 lineHeight: LINE_HEIGHT,
+                renderLineHighlight: 'none',
+                renderWhitespace: 'none',
+                automaticLayout: true,
                 scrollBeyondLastLine: false,
+                padding: {
+                  top: 10,
+                  bottom: 10,
+                },
                 scrollbar: {
                   alwaysConsumeMouseWheel: false,
-                  horizontal: 'hidden',
+                  horizontalScrollbarSize: 0,
+                  verticalScrollbarSize: 0,
                   vertical: 'hidden',
+                  horizontal: 'hidden',
                 },
                 guides: {
                   indentation: false,
@@ -258,7 +269,7 @@ export const NewCodeBlock = ({
                   highlightActiveIndentation: false,
                 },
               }}
-              onMount={(editor) => editor.onDidContentSizeChange(() => updateHeight(editor))}
+              onMount={(editor) => updateHeight(editor.getContentHeight())}
             />
           )}
         </div>

--- a/ui/packages/components/src/RunDetailsV3/IO.tsx
+++ b/ui/packages/components/src/RunDetailsV3/IO.tsx
@@ -1,23 +1,26 @@
-import { CodeBlock, type CodeBlockAction } from '../CodeBlock';
+import { type CodeBlockAction } from '../CodeBlock';
+import { NewCodeBlock } from '../NewCodeBlock/NewCodeBlock';
 
 export type IOProps = {
   title: string;
   actions?: CodeBlockAction[];
   raw?: string;
   error?: boolean;
+  loading?: boolean;
 };
 
-export const IO = ({ title, actions, raw, error }: IOProps) => {
+export const IO = ({ title, actions, raw, error, loading = false }: IOProps) => {
   return (
-    <div className="text-muted h-full overflow-y-scroll" onWheel={(e) => e.stopPropagation()}>
-      <CodeBlock
+    <div className="text-muted bg-codeEditor h-full">
+      <NewCodeBlock
         actions={actions}
         header={{ title, ...(error && { status: 'error' }) }}
         tab={{
           content: raw ?? 'Unknown',
         }}
-        alwaysFullHeight={true}
         allowFullScreen={true}
+        parsed={false}
+        loading={loading}
       />
     </div>
   );

--- a/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
+++ b/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
@@ -154,7 +154,11 @@ export const RunDetailsV3 = (props: Props) => {
           </div>
         </div>
       )}
-      <div ref={containerRef} className="flex flex-row">
+      <div
+        ref={containerRef}
+        className="flex flex-row"
+        style={{ minHeight: MIN_HEIGHT, maxHeight: 'calc(100vh - 240px)' }}
+      >
         <div ref={leftColumnRef} className="flex flex-col gap-2" style={{ width: `${leftWidth}%` }}>
           <div ref={runInfoRef} className="px-4">
             <RunInfo
@@ -172,19 +176,22 @@ export const RunDetailsV3 = (props: Props) => {
               />
             )}
           </div>
-          <Tabs
-            tabs={[
-              {
-                label: 'Trace',
-                id: 'trace',
-                node: waiting ? (
-                  <Waiting />
-                ) : run ? (
-                  <Timeline runID={runID} trace={run?.trace} />
-                ) : null,
-              },
-            ]}
-          />
+
+          <div className="overflow-hidden">
+            <Tabs
+              tabs={[
+                {
+                  label: 'Trace',
+                  id: 'trace',
+                  node: waiting ? (
+                    <Waiting />
+                  ) : run ? (
+                    <Timeline runID={runID} trace={run?.trace} />
+                  ) : null,
+                },
+              ]}
+            />
+          </div>
         </div>
 
         <div className="relative cursor-col-resize" onMouseDown={handleMouseDown}>
@@ -202,8 +209,8 @@ export const RunDetailsV3 = (props: Props) => {
         </div>
 
         <div
-          className="border-muted flex flex-col justify-start"
-          style={{ width: `${100 - leftWidth}%`, height: standalone ? '85vh' : height }}
+          className="border-muted flex flex-col justify-start overflow-hidden"
+          style={{ width: `${100 - leftWidth}%` }}
         >
           {selectedStep && !selectedStep.trace.isRoot ? (
             <StepInfo

--- a/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
+++ b/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
@@ -107,8 +107,6 @@ export const RunDetailsV3 = (props: Props) => {
   const runRes = useQuery({
     queryKey: ['run', runID, { preview: props.tracesPreviewEnabled }],
     queryFn: useCallback(() => {
-      console.log('lollllyep', { 'props.tracesPreviewEnabled': props.tracesPreviewEnabled });
-
       return getRun(runID, props.tracesPreviewEnabled);
     }, [getRun, runID, props.tracesPreviewEnabled]),
     retry: 3,

--- a/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
@@ -134,15 +134,23 @@ export const StepInfo = ({
   const [rerunModalOpen, setRerunModalOpen] = useState(false);
   const { runID, trace } = selectedStep;
   const [result, setResult] = useState<Result>();
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     let intervalId: ReturnType<typeof setInterval> | undefined;
 
-    const refreshResult = () => {
-      if (trace.outputID) {
-        getResult(trace.outputID).then(setResult);
-      } else {
-        setResult(undefined);
+    const refreshResult = async () => {
+      try {
+        setLoading(true);
+        if (trace.outputID) {
+          setResult(await getResult(trace.outputID));
+        } else {
+          setResult(undefined);
+        }
+      } catch (error) {
+        console.error('error loading step result', error);
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -195,7 +203,7 @@ export const StepInfo = ({
   const prettyErrorBody = usePrettyErrorBody(result?.error);
 
   return (
-    <div className="sticky top-14 flex flex-col justify-start gap-2 overflow-hidden">
+    <div className="sticky top-14 flex h-full flex-col justify-start gap-2 overflow-hidden">
       <div className="flex min-h-11 w-full flex-row items-center justify-between border-none px-4">
         <div
           className="text-basis flex cursor-pointer items-center justify-start gap-2"
@@ -280,7 +288,7 @@ export const StepInfo = ({
                   {
                     label: 'Input',
                     id: 'input',
-                    node: <IO title="Step Input" raw={prettyInput} />,
+                    node: <IO title="Step Input" raw={prettyInput} loading={loading} />,
                   },
                 ]
               : []),
@@ -289,7 +297,7 @@ export const StepInfo = ({
                   {
                     label: 'Output',
                     id: 'output',
-                    node: <IO title="Step Output" raw={prettyOutput} />,
+                    node: <IO title="Step Output" raw={prettyOutput} loading={loading} />,
                   },
                 ]
               : []),
@@ -305,6 +313,7 @@ export const StepInfo = ({
                         }`}
                         raw={prettyErrorBody ?? ''}
                         error={true}
+                        loading={loading}
                       />
                     ),
                   },

--- a/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
@@ -203,7 +203,7 @@ export const StepInfo = ({
   const prettyErrorBody = usePrettyErrorBody(result?.error);
 
   return (
-    <div className="sticky top-14 flex h-full flex-col justify-start gap-2 overflow-hidden">
+    <div className="flex h-full flex-col justify-start gap-2">
       <div className="flex min-h-11 w-full flex-row items-center justify-between border-none px-4">
         <div
           className="text-basis flex cursor-pointer items-center justify-start gap-2"
@@ -277,11 +277,9 @@ export const StepInfo = ({
         </div>
       )}
 
-      {trace.isUserland && trace.userlandSpan ? (
-        <UserlandAttrs userlandSpan={trace.userlandSpan} />
-      ) : (
+      <div className="flex-1">
         <Tabs
-          defaultActive={result?.error ? 'error' : prettyInput ? 'input' : 'output'}
+          defaultActive={result?.error ? 'error' : 'output'}
           tabs={[
             ...(prettyInput
               ? [
@@ -321,7 +319,7 @@ export const StepInfo = ({
               : []),
           ]}
         />
-      )}
+      </div>
     </div>
   );
 };

--- a/ui/packages/components/src/RunDetailsV3/Tabs.tsx
+++ b/ui/packages/components/src/RunDetailsV3/Tabs.tsx
@@ -49,7 +49,7 @@ export const Tabs = ({ tabs, defaultActive = '' }: { tabs: TabsType; defaultActi
           </Tab>
         ))}
       </div>
-      <div className="relative h-full">
+      <div className="relative h-full overflow-y-auto">
         {tabs.map((tab, i) => {
           const tabActive = active === tab.id || (active == '' && i === 0);
           return (

--- a/ui/packages/components/src/RunDetailsV3/Tabs.tsx
+++ b/ui/packages/components/src/RunDetailsV3/Tabs.tsx
@@ -37,7 +37,7 @@ export const Tabs = ({ tabs, defaultActive = '' }: { tabs: TabsType; defaultActi
   }, [defaultActive]);
 
   return (
-    <div className="flex w-full flex-col">
+    <div className="flex h-full w-full flex-col">
       <div className="border-muted flex w-full flex-row gap-4 border-b px-4">
         {tabs.map((t: TabType, i: number) => (
           <Tab
@@ -49,19 +49,20 @@ export const Tabs = ({ tabs, defaultActive = '' }: { tabs: TabsType; defaultActi
           </Tab>
         ))}
       </div>
-      <div className="relative">
-        {tabs.map((tab, i) => (
-          <div
-            key={`content-${i}`}
-            className={`w-full ${
-              active === tab.id || (active == '' && i === 0)
-                ? 'visible opacity-100'
-                : 'invisible h-0 opacity-0'
-            }`}
-          >
-            {tab.node}
-          </div>
-        ))}
+      <div className="relative h-full">
+        {tabs.map((tab, i) => {
+          const tabActive = active === tab.id || (active == '' && i === 0);
+          return (
+            <div
+              key={`content-${i}`}
+              className={`w-full ${
+                tabActive ? 'visible h-full opacity-100' : 'invisible h-0 opacity-0'
+              }`}
+            >
+              {tabActive && tab.node}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/ui/packages/components/src/RunDetailsV3/TopInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/TopInfo.tsx
@@ -129,7 +129,7 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
   }
 
   return (
-    <div className="sticky top-14 flex flex-col justify-start gap-2 overflow-hidden">
+    <div className="sticky top-14 flex h-full flex-col justify-start gap-2 overflow-hidden">
       <div className="flex h-11 w-full flex-row items-center justify-between border-none px-4 pt-2">
         <div
           className="text-basis flex cursor-pointer items-center justify-start gap-2"
@@ -240,7 +240,7 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
         </div>
       )}
 
-      <div className="">
+      <div className="h-full">
         <Tabs
           defaultActive={result?.error ? 'error' : prettyPayload ? 'input' : 'output'}
           tabs={[
@@ -250,7 +250,12 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
                     label: 'Input',
                     id: 'input',
                     node: (
-                      <IO title="Function Payload" raw={prettyPayload} actions={codeBlockActions} />
+                      <IO
+                        title="Function Payload"
+                        raw={prettyPayload}
+                        actions={codeBlockActions}
+                        loading={isPending}
+                      />
                     ),
                   },
                 ]
@@ -260,7 +265,7 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
                   {
                     label: 'Output',
                     id: 'output',
-                    node: <IO title="Output" raw={prettyOutput} />,
+                    node: <IO title="Output" raw={prettyOutput} loading={isPending} />,
                   },
                 ]
               : []),
@@ -276,6 +281,7 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
                         }`}
                         raw={prettyErrorBody ?? ''}
                         error={true}
+                        loading={isPending}
                       />
                     ),
                   },

--- a/ui/packages/components/src/RunDetailsV3/TopInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/TopInfo.tsx
@@ -129,7 +129,7 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
   }
 
   return (
-    <div className="sticky top-14 flex h-full flex-col justify-start gap-2 overflow-hidden">
+    <div className="flex h-full flex-col justify-start gap-2">
       <div className="flex h-11 w-full flex-row items-center justify-between border-none px-4 pt-2">
         <div
           className="text-basis flex cursor-pointer items-center justify-start gap-2"
@@ -240,7 +240,7 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
         </div>
       )}
 
-      <div className="h-full">
+      <div className="flex-1">
         <Tabs
           defaultActive={result?.error ? 'error' : prettyPayload ? 'input' : 'output'}
           tabs={[


### PR DESCRIPTION
## Description

Backports the new code editor to the run traces, sets a max height on the run row to make large run layouts more manageable and adds a dual scrolling experiment to address the issue of keeping step info in view as they scroll the timeline.

## Motivation
Attempt to make layouts for large runs more resilient.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
