### PR TITLE
Make using tests.sh for JS SDK and Golang SDK tests easier

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -1,17 +1,93 @@
 #!/bin/bash
-sh -c 'cd ./tests/js && pnpm install > /dev/null 2> /dev/null'
+
+# Kill any existing processes on port 8288
+echo "Checking for existing processes on port 8288..."
+if lsof -ti:8288 >/dev/null 2>&1; then
+    echo "WARNING: Killing existing processes on port 8288"
+    lsof -ti:8288 | xargs kill -9 2>/dev/null || true
+else
+    echo "No processes found on port 8288"
+fi
+
+# Store background process PIDs
+pids=()
+
+# Function to kill all background processes
+cleanup() {
+    echo "Cleaning up background processes..."
+    # Print tracked PIDs before cleanup
+    echo "Background process PIDs: ${pids[*]}"
+
+    for pid in "${pids[@]}"; do
+        if kill -0 "$pid" 2>/dev/null; then
+            # Kill entire process tree
+            # technically we might need to recurse and kill all the PIDs but killing the results of
+            # pgrep -P seems to at least leave no stranglers on port 3000 and 8288
+            children=$(pgrep -P "$pid" 2>/dev/null || true)
+            if [ -n "$children" ]; then
+                echo "Killing child PIDs: $children"
+                pkill -P "$pid" 2>/dev/null || true
+            fi
+            echo "Killing parent PID: $pid"
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    done
+    wait
+    exit 0
+}
+
+# Trap SIGINT and SIGTERM to cleanup
+trap cleanup SIGINT SIGTERM
+
+# Accept optional test pattern argument
+TEST_PATTERN="${1:-}"
+
+sh -c 'cd ./tests/js && pnpm install --frozen-lockfile > /dev/null 2> /dev/null'
 sh -c 'cd ./tests/js && pnpm dev > /dev/null 2> /dev/null' &
+pids+=($!)
 
 sleep 2
 
 export TEST_MODE=true
 
 go run ./cmd/main.go dev --no-discovery > dev-stdout.txt 2> dev-stderr.txt &
+pids+=($!)
 
-sleep 5
+# Check that dev server started successfully
+echo "Waiting for dev server to start..."
+max_attempts=10
+attempt=0
+while [ $attempt -lt $max_attempts ]; do
+    if curl -s -f http://127.0.0.1:8288/health > /dev/null 2>&1; then
+        echo "Dev server started successfully"
+        break
+    fi
+    echo "Attempt $((attempt + 1))/$max_attempts: Health check failed, retrying..."
+    if [ $attempt -eq $((max_attempts - 1)) ]; then
+        echo "ERROR: Dev server failed to start after 5 seconds"
+        echo "Dev server stdout:"
+        cat dev-stdout.txt
+        echo "Dev server stderr:"
+        cat dev-stderr.txt
+        cleanup
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+done
 
 # Run JS SDK tests
-INNGEST_SIGNING_KEY=test API_URL=http://127.0.0.1:8288 SDK_URL=http://127.0.0.1:3000/api/inngest go test ./tests -v -count=1
+if [ -n "$TEST_PATTERN" ]; then
+    INNGEST_SIGNING_KEY=test API_URL=http://127.0.0.1:8288 SDK_URL=http://127.0.0.1:3000/api/inngest go test ./tests -v -count=1 -run "$TEST_PATTERN"
+else
+    INNGEST_SIGNING_KEY=test API_URL=http://127.0.0.1:8288 SDK_URL=http://127.0.0.1:3000/api/inngest go test ./tests -v -count=1
+fi
 
 # Run Golang SDK tests
-go test ./tests/golang -v -count=1
+if [ -n "$TEST_PATTERN" ]; then
+    go test ./tests/golang -v -count=1 -run "$TEST_PATTERN"
+else
+    go test ./tests/golang -v -count=1
+fi
+
+# Cleanup at the end
+cleanup


### PR DESCRIPTION
## Description

Improve tests.sh (used for local dev testing only)

mostly done with claude
- kill existing dev server processes to avoid conflict
- wait for dev server healthcheck before continuing rest of tests
- optionally take TEST_PATTERN which will pass that to both the JS/SDK
  test suites to narrow tests, e.g. `./tests.sh TestEventList`
- cleanup background processes when script exits (either normally or
  gets interrupted)
- use --frozen-lockfile to match CI behavior

As mentioned in slack, this script is not currently used by CI, so we
might eventually think about unifying them
https://github.com/inngest/inngest/blob/main/.github/workflows/e2e.yml

## Motivation

It is hard to iterate on these tests locally because they have to coordinate with a running dev server process

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
