### PR TITLE
Create new ping command for health checks

### DIFF
--- a/cmd/commands/ping.go
+++ b/cmd/commands/ping.go
@@ -1,0 +1,73 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/inngest/inngest/pkg/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+)
+
+func NewCmdPing(rootCmd *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "ping",
+		Short: "Ping the Inngest server",
+		Run:   doPing,
+	}
+	baseFlags := pflag.NewFlagSet("base", pflag.ExitOnError)
+	baseFlags.String("host", "localhost", "Inngest server hostname")
+	baseFlags.StringP("port", "p", "8288", "Inngest server port")
+	cmd.Flags().AddFlagSet(baseFlags)
+
+	return cmd
+}
+
+func doPing(cmd *cobra.Command, args []string) {
+	ctx := cmd.Context()
+	_, err := config.Dev(ctx)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	err = errors.Join(err, viper.BindPFlag("host", cmd.Flags().Lookup("host")))
+	err = errors.Join(err, viper.BindPFlag("port", cmd.Flags().Lookup("port")))
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+
+	viper.SetEnvPrefix("INNGEST")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	viper.AutomaticEnv()
+
+	portString := viper.GetString("port")
+
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		fmt.Println("Error parsing port:", err)
+		os.Exit(1)
+	}
+
+	url := fmt.Sprintf("http://%s:%d/ping", viper.GetString("host"), port)
+	resp, err := http.Get(url)
+	if err != nil {
+		fmt.Println("Error pinging the Inngest server:", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Println("Error pinging the Inngest server:", resp.Status)
+		os.Exit(1)
+		return
+	}
+
+	os.Exit(0)
+}

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -72,6 +72,7 @@ func Execute() {
 	rootCmd.AddCommand(NewCmdDev(rootCmd))
 	rootCmd.AddCommand(NewCmdVersion())
 	rootCmd.AddCommand(NewCmdStart(rootCmd))
+	rootCmd.AddCommand(NewCmdPing(rootCmd))
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
## Description

Create new `ping` command to hit the health check endpoint.

INN-5313

## Motivation
For creating a health check in Docker/Docker Compose, we need to use a command and this saves us from having to bundle curl in the image.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
