### PR TITLE
Added json method to serializable request

### DIFF
--- a/pkg/execution/exechttp/serializable_request.go
+++ b/pkg/execution/exechttp/serializable_request.go
@@ -129,6 +129,16 @@ func (s SerializableRequest) Bytes() (io.Reader, error) {
 	return &buf, nil
 }
 
+// JSON returns the marshaled serialized request as bytes without escaping special characters
+func (s SerializableRequest) JSON() ([]byte, error) {
+	reader, err := s.Bytes()
+	if err != nil {
+		return nil, err
+	}
+
+	return io.ReadAll(reader)
+}
+
 // HTTPRequest converts the serializable request into a *http.Request ready to be sent
 func (s SerializableRequest) HTTPRequest() (*http.Request, error) {
 	var body io.Reader


### PR DESCRIPTION
## Description

Fixes a bug in `SerializableRequest` where empty `body` fields in `step.fetch` would serialize incorrectly

## Motivation
When performing GET requests or POST requests with no body, the `SerializableRequest` fails to serialize properly when using `json.Marshal()`. The issue occurs because:

1. `json.Marshal()` escapes HTML characters by default
2. Form-encoded and other non-JSON content gets corrupted during serialization
3. The existing `Bytes()` method already handles this correctly with `SetEscapeHTML(false)`

This fix is needed for downstream https://github.com/inngest/monorepo/pull/4810

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
