### PR TITLE
Fix gap for environment dropdown

### DIFF
--- a/ui/apps/dashboard/src/components/Navigation/Environments.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Environments.tsx
@@ -209,7 +209,7 @@ export default function EnvironmentSelectMenu({
               <NextLink
                 prefetch={true}
                 href="/env"
-                className="hover:bg-canvasSubtle text-subtle flex h-10 cursor-pointer items-center gap-2 whitespace-nowrap px-3 text-[13px] font-normal"
+                className="hover:bg-canvasSubtle text-subtle flex h-10 cursor-pointer items-center gap-3 whitespace-nowrap px-3 text-[13px] font-normal"
               >
                 <RiCloudFill className="h-3 w-3" />
                 View All Environments


### PR DESCRIPTION
## Description

This matches the gap for all the EnvironmentItems and the `Sync a branch` above

### Before

<img width="209" height="212" alt="image" src="https://github.com/user-attachments/assets/5aa8053b-9f66-4d5a-a448-d855e800a548" />

### After
<img width="219" height="260" alt="Screenshot 2025-07-11 at 10 21 04 AM" src="https://github.com/user-attachments/assets/0e31c75a-1093-4fd8-a096-34b20d663e1b" />


## Motivation

OCD

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
