### PR TITLE
Remove experimental label from PostgreSQL URI flag in start command help

### DIFF
--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -45,7 +45,7 @@ func NewCmdStart(rootCmd *cobra.Command) *cobra.Command {
 	persistenceFlags := pflag.NewFlagSet("persistence", pflag.ExitOnError)
 	persistenceFlags.String("sqlite-dir", "", "Directory for where to write SQLite database.")
 	persistenceFlags.String("redis-uri", "", "Redis server URI for external queue and run state. Defaults to self-contained, in-memory Redis server with periodic snapshot backups.")
-	persistenceFlags.String("postgres-uri", "", "[Experimental] PostgreSQL database URI for configuration and history persistence. Defaults to SQLite database.")
+	persistenceFlags.String("postgres-uri", "", "PostgreSQL database URI for configuration and history persistence. Defaults to SQLite database.")
 	cmd.Flags().AddFlagSet(persistenceFlags)
 	groups = append(groups, FlagGroup{name: "Persistence Flags:", fs: persistenceFlags})
 


### PR DESCRIPTION
## Description

Remove experimental label from PostgreSQL URI flag in CLI start command help copy.

## Motivation
This feature is no longer experimental.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
