### PR TITLE
INN-5325: Fix webhook intent url

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/intent/create-webhook/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/intent/create-webhook/page.tsx
@@ -64,7 +64,7 @@ export default function Page() {
   }, [redirectURI]);
 
   const displayName = capitalCase(
-    name ?? domain !== null ? getNameFromDomain(domain) : 'Webhook integration'
+    name ?? (domain !== null ? getNameFromDomain(domain) : 'Webhook integration')
   );
 
   const slugifyOptions = { preserveCharacters: ['.'] };

--- a/ui/apps/dashboard/src/app/(organization-active)/intent/layout.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/intent/layout.tsx
@@ -1,12 +1,35 @@
+import Image from 'next/image';
 import { InngestLogo } from '@inngest/components/icons/logos/InngestLogo';
 
-export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+import { getProfileDisplay } from '@/queries/server-only/profile';
+
+export default async function SettingsLayout({ children }: { children: React.ReactNode }) {
+  const profile = await getProfileDisplay();
+  console.log('profile', profile);
   return (
     <div className="h-full overflow-y-scroll">
       <div className="mx-auto flex h-full max-w-screen-xl flex-col px-6">
         <header className="flex items-center justify-between py-6">
-          <InngestLogo />
-          <h1 className="hidden">Inngest</h1>
+          <div>
+            <InngestLogo />
+            <h1 className="hidden">Inngest</h1>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="bg-canvasMuted text-subtle flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs uppercase">
+              {profile.orgProfilePic ? (
+                <Image
+                  src={profile.orgProfilePic}
+                  className="h-8 w-8 rounded-full object-cover"
+                  width={32}
+                  height={32}
+                  alt="org-profile-pic"
+                />
+              ) : (
+                profile.orgName?.substring(0, 2) || '?'
+              )}
+            </div>
+            <p>{profile.orgName}</p>
+          </div>
         </header>
         <div className="flex grow items-center">{children}</div>
       </div>

--- a/ui/apps/dashboard/src/app/(organization-active)/intent/layout.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/intent/layout.tsx
@@ -5,7 +5,6 @@ import { getProfileDisplay } from '@/queries/server-only/profile';
 
 export default async function SettingsLayout({ children }: { children: React.ReactNode }) {
   const profile = await getProfileDisplay();
-  console.log('profile', profile);
   return (
     <div className="h-full overflow-y-scroll">
       <div className="mx-auto flex h-full max-w-screen-xl flex-col px-6">


### PR DESCRIPTION
## Description

Given the following webhook creation intent URL, the name parameter should be used correctly:

```
https://app.inngest.com/intent/create-webhook?name=Auth0&redirect_uri=https%3A%2F%2Fmanage.auth0.com%2Fdashboard%2F
```

Example of the `name` param working correctly:

<img width="1320" height="1476" alt="image" src="https://github.com/user-attachments/assets/c347e9a5-036f-4139-931f-239247e33470" />


## Motivation
INN-5325

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
