### PR TITLE
Added first sync time telemetry

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -84,6 +84,7 @@ func NewCmdDev(rootCmd *cobra.Command) *cobra.Command {
 }
 
 func doDev(cmd *cobra.Command, args []string) {
+	devStartTime := time.Now()
 
 	go func() {
 		ctx, cleanup := signal.NotifyContext(
@@ -177,6 +178,7 @@ func doDev(cmd *cobra.Command, args []string) {
 		ConnectGatewayPort: connectGatewayPort,
 		ConnectGatewayHost: conf.CoreAPI.Addr,
 		InMemory:           inMemory,
+		DevStartTime:       devStartTime,
 	}
 
 	err = devserver.New(ctx, opts)

--- a/pkg/api/tel/tel.go
+++ b/pkg/api/tel/tel.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	EventName   = "cli/command.executed"
-	CIEventName = "cli/ci.command.executed"
+	EventName            = "cli/command.executed"
+	CIEventName          = "cli/ci.command.executed"
+	TimeToFirstSyncEvent = "cli/time-to-first-sync"
 )
 
 var (
@@ -102,6 +103,29 @@ func SendEvent(ctx context.Context, name string, m *Metadata) {
 	}
 	evt := m.Event()
 	evt.Name = name
+	Send(ctx, evt)
+}
+
+func SendTimeToFirstSync(ctx context.Context, m *Metadata, durationMs int64, devStartTime time.Time) {
+	if isCI() {
+		return
+	}
+
+	evt := inngestgo.Event{
+		Name: TimeToFirstSyncEvent,
+		Data: map[string]any{
+			"account_id":     m.AccountID,
+			"device_id":      m.DeviceID,
+			"cli_version":    m.CLIVersion,
+			"os":             m.OS,
+			"duration_ms":    durationMs,
+			"dev_start_time": devStartTime.Unix(),
+			"sync_time":      time.Now().Unix(),
+		},
+		Timestamp: time.Now().UnixMilli(),
+		Version:   "2025-07-11",
+	}
+
 	Send(ctx, evt)
 }
 

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -182,6 +182,9 @@ func (a devapi) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Track time-to-first-sync telemetry if this is the first successful sync
+	a.trackFirstSync(ctx)
+
 	// Re-initialize our cron manager.
 	if err := a.devserver.Runner.InitializeCrons(ctx); err != nil {
 		l.Warn("error initializing crons", "error", err)
@@ -620,4 +623,32 @@ type InfoResponse struct {
 
 	// Features acts as an in-memory feature flag for the UI
 	Features map[string]bool `json:"features"`
+}
+
+// trackFirstSync checks if this is the first app sync and emits telemetry if so
+func (a *devapi) trackFirstSync(ctx context.Context) {
+	a.devserver.firstSyncLock.Lock()
+	defer a.devserver.firstSyncLock.Unlock()
+
+	// Only track the first sync
+	if a.devserver.firstSyncDone {
+		return
+	}
+
+	a.devserver.firstSyncDone = true
+
+	// Only emit telemetry if we have a valid dev start time
+	if a.devserver.Opts.DevStartTime.IsZero() {
+		return
+	}
+
+	// Calculate duration since dev command started
+	now := time.Now()
+	durationMs := now.Sub(a.devserver.Opts.DevStartTime).Milliseconds()
+
+	// Create metadata for telemetry
+	metadata := tel.NewMetadata(ctx)
+
+	// Send the time-to-first-sync event
+	tel.SendTimeToFirstSync(ctx, metadata, durationMs, a.devserver.Opts.DevStartTime)
 }

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -118,6 +118,9 @@ type StartOpts struct {
 
 	// SQLiteDir specifies where SQLite files should be stored
 	SQLiteDir string `json:"sqlite_dir"`
+
+	// DevStartTime tracks when the dev command was started for telemetry
+	DevStartTime time.Time `json:"-"`
 }
 
 // Create and start a new dev server.  The dev server is used during (surprise surprise)

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -57,6 +57,7 @@ func NewService(opts StartOpts, runner runner.Runner, data cqrs.Manager, pb pubs
 		Runner:                  runner,
 		Opts:                    opts,
 		handlerLock:             &sync.Mutex{},
+		firstSyncLock:           &sync.Mutex{},
 		publisher:               pb,
 		stepLimitOverrides:      stepLimitOverrides,
 		stateSizeLimitOverrides: stateSizeLimitOverrides,
@@ -97,6 +98,10 @@ type devserver struct {
 	// handlers are updated by the API (d.apiservice) when registering functions.
 	handlers    []SDKHandler
 	handlerLock *sync.Mutex
+
+	// firstSyncDone tracks whether the first app sync has occurred for telemetry
+	firstSyncDone bool
+	firstSyncLock *sync.Mutex
 
 	// These options are used to configure the server's behaviour as a
 	// single-node service instead of a dev environment.


### PR DESCRIPTION
## Description

Let's us track the first time a user syncs an app

## Motivation
We want to track how much friction there is to adopt. The current thesis is the lower time to sync, the easier to adopt. This allows us to track that

Growth repo changes https://github.com/inngest/growth/pull/95

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
