### PR TITLE
fix(cqrs): close query rows

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -794,6 +794,7 @@ func (w wrapper) GetEventsByExpressions(ctx context.Context, cel []string) ([]*c
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	res := []*cqrs.Event{}
 	for rows.Next() {
@@ -1667,6 +1668,7 @@ func (w wrapper) GetTraceRuns(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	res := []*cqrs.TraceRun{}
 	var count uint
@@ -2161,6 +2163,7 @@ func (w wrapper) GetWorkerConnections(ctx context.Context, opt cqrs.GetWorkerCon
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	res := []*cqrs.WorkerConnection{}
 	var count uint

--- a/pkg/cqrs/manager/cqrs.go
+++ b/pkg/cqrs/manager/cqrs.go
@@ -1675,6 +1675,7 @@ func (w wrapper) GetEventsByExpressions(ctx context.Context, cel []string) ([]*c
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	res := []*cqrs.Event{}
 	for rows.Next() {
@@ -3334,6 +3335,7 @@ func (w wrapper) GetWorkerConnections(ctx context.Context, opt cqrs.GetWorkerCon
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 
 	res := []*cqrs.WorkerConnection{}
 	var count uint


### PR DESCRIPTION
## Description

Add 2 missing defer `rows.Close()`

7 other cqrs have closing logic

https://github.com/inngest/inngest/blob/a4c5771294791883e06a97dfb83800507648acce/pkg/cqrs/manager/cqrs.go#L1754-L1758

https://github.com/inngest/inngest/blob/a4c5771294791883e06a97dfb83800507648acce/pkg/cqrs/manager/cqrs.go#L2368-L2372

https://github.com/inngest/inngest/blob/a4c5771294791883e06a97dfb83800507648acce/pkg/cqrs/manager/cqrs.go#L2823-L2827

https://github.com/inngest/inngest/blob/a4c5771294791883e06a97dfb83800507648acce/pkg/cqrs/manager/cqrs.go#L3600-L3605

https://github.com/inngest/inngest/blob/a4c5771294791883e06a97dfb83800507648acce/pkg/cqrs/manager/cqrs.go#L3750-L3769

https://github.com/inngest/inngest/blob/a4c5771294791883e06a97dfb83800507648acce/pkg/cqrs/manager/cqrs.go#L3829-L3833

https://github.com/inngest/inngest/blob/a4c5771294791883e06a97dfb83800507648acce/pkg/cqrs/manager/cqrs.go#L3924-L3929

## Release note

None.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*