### PR TITLE
Support multipart/form-data in ParseStream

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -193,7 +193,13 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 	stream := make(chan eventstream.StreamItem)
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
-		return eventstream.ParseStream(ctx, r.Body, stream, consts.AbsoluteMaxEventSize)
+		return eventstream.ParseStream(
+			ctx,
+			r.Body,
+			stream,
+			consts.AbsoluteMaxEventSize,
+			r.Header.Get("Content-Type"),
+		)
 	})
 
 	// Create a new channel which holds all event IDs as a slice.

--- a/pkg/eventstream/eventstream_test.go
+++ b/pkg/eventstream/eventstream_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"math/rand"
+	"mime/multipart"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,127 +16,276 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func TestParseStream_Single(t *testing.T) {
-	// A large string just under the event size
-	data := make([]byte, 1024*200)
-	_, err := rand.Read(data)
-	require.NoError(t, err)
-	str := hex.EncodeToString(data)
+func TestParseStream_JSON(t *testing.T) {
+	// application/json
+	contentType := "application/json"
 
-	actual := event.Event{
-		Name: "1",
-		Data: map[string]any{
-			"order":  float64(1),
-			"string": str,
-		},
-	}
-
-	byt, err := json.Marshal(actual)
-	require.NoError(t, err)
-	r := bytes.NewReader(byt)
-	stream := make(chan StreamItem)
-
-	eg := errgroup.Group{}
-	eg.Go(func() error {
-		return ParseStream(context.Background(), r, stream, 512*1024)
-	})
-
-	n := 0
-	for item := range stream {
-		evt := event.Event{}
-		err := json.Unmarshal(item.Item, &evt)
+	t.Run("single", func(t *testing.T) {
+		// A large string just under the event size
+		data := make([]byte, 1024*200)
+		_, err := rand.Read(data)
 		require.NoError(t, err)
-		require.EqualValues(t, actual, evt)
-		n++
-	}
+		str := hex.EncodeToString(data)
 
-	require.NoError(t, eg.Wait())
-	require.EqualValues(t, n, 1)
-}
-
-func TestParseStream_Multiple(t *testing.T) {
-	evts := []event.Event{
-		{
+		actual := event.Event{
 			Name: "1",
 			Data: map[string]any{
-				"order": float64(1),
+				"order":  float64(1),
+				"string": str,
 			},
-		},
-		{
-			Name: "2",
-			Data: map[string]any{
-				"order": float64(2),
-			},
-		},
-		{
-			Name: "3",
-			Data: map[string]any{
-				"order": float64(3),
-			},
-		},
-	}
+		}
 
-	byt, err := json.Marshal(evts)
-	require.NoError(t, err)
+		byt, err := json.Marshal(actual)
+		require.NoError(t, err)
+		r := bytes.NewReader(byt)
+		stream := make(chan StreamItem)
 
-	r := bytes.NewReader(byt)
-	stream := make(chan StreamItem)
+		eg := errgroup.Group{}
+		eg.Go(func() error {
+			return ParseStream(context.Background(), r, stream, 512*1024, contentType)
+		})
 
-	eg := errgroup.Group{}
-	eg.Go(func() error {
-		return ParseStream(context.Background(), r, stream, 512*1024)
+		n := 0
+		for item := range stream {
+			evt := event.Event{}
+			err := json.Unmarshal(item.Item, &evt)
+			require.NoError(t, err)
+			require.EqualValues(t, actual, evt)
+			n++
+		}
+
+		require.NoError(t, eg.Wait())
+		require.EqualValues(t, n, 1)
 	})
 
-	n := 0
-	for item := range stream {
-		evt := event.Event{}
-		err := json.Unmarshal(item.Item, &evt)
-		require.NoError(t, err)
-		require.EqualValues(t, evts[n], evt)
-		n++
-	}
+	t.Run("multiple", func(t *testing.T) {
+		evts := []event.Event{
+			{
+				Name: "1",
+				Data: map[string]any{
+					"order": float64(1),
+				},
+			},
+			{
+				Name: "2",
+				Data: map[string]any{
+					"order": float64(2),
+				},
+			},
+			{
+				Name: "3",
+				Data: map[string]any{
+					"order": float64(3),
+				},
+			},
+		}
 
-	require.NoError(t, eg.Wait())
-	require.EqualValues(t, n, 3)
+		byt, err := json.Marshal(evts)
+		require.NoError(t, err)
+
+		r := bytes.NewReader(byt)
+		stream := make(chan StreamItem)
+
+		eg := errgroup.Group{}
+		eg.Go(func() error {
+			return ParseStream(context.Background(), r, stream, 512*1024, contentType)
+		})
+
+		n := 0
+		for item := range stream {
+			evt := event.Event{}
+			err := json.Unmarshal(item.Item, &evt)
+			require.NoError(t, err)
+			require.EqualValues(t, evts[n], evt)
+			n++
+		}
+
+		require.NoError(t, eg.Wait())
+		require.EqualValues(t, n, 3)
+	})
+
+	t.Run("max size", func(t *testing.T) {
+		data := make([]byte, 1024*512)
+		_, err := rand.Read(data)
+		require.NoError(t, err)
+
+		str := hex.EncodeToString(data)
+
+		evts := []event.Event{
+			{
+				Name: "large",
+				Data: map[string]any{
+					"order": float64(1),
+					"large": str,
+				},
+			},
+		}
+
+		byt, err := json.Marshal(evts)
+		require.NoError(t, err)
+
+		r := bytes.NewReader(byt)
+		stream := make(chan StreamItem)
+
+		eg := errgroup.Group{}
+		eg.Go(func() error {
+			return ParseStream(context.Background(), r, stream, 256*1024, contentType)
+		})
+
+		n := 0
+		for range stream {
+			n++
+		}
+
+		<-time.After(10 * time.Millisecond)
+
+		err = eg.Wait()
+		require.EqualValues(t, n, 0)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), ErrEventTooLarge.Error())
+	})
 }
 
-func TestParseStream_MaxSize(t *testing.T) {
-	data := make([]byte, 1024*512)
-	_, err := rand.Read(data)
-	require.NoError(t, err)
+func TestParseStream_Multipart(t *testing.T) {
+	// multipart/form-data
 
-	str := hex.EncodeToString(data)
+	t.Run("single form field", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
 
-	evts := []event.Event{
-		{
-			Name: "large",
-			Data: map[string]any{
-				"order": float64(1),
-				"large": str,
-			},
-		},
-	}
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+		r.NoError(writer.WriteField("name", "Alice"))
+		r.NoError(writer.Close())
 
-	byt, err := json.Marshal(evts)
-	require.NoError(t, err)
+		contentType := writer.FormDataContentType()
+		stream := make(chan StreamItem)
+		eg := errgroup.Group{}
+		eg.Go(func() error {
+			return ParseStream(ctx, body, stream, 512*1024, contentType)
+		})
 
-	r := bytes.NewReader(byt)
-	stream := make(chan StreamItem)
-
-	eg := errgroup.Group{}
-	eg.Go(func() error {
-		return ParseStream(context.Background(), r, stream, 256*1024)
+		n := 0
+		for item := range stream {
+			// The multipart parser creates a JSON object with form fields as keys
+			var result map[string]string
+			r.NoError(json.Unmarshal(item.Item, &result))
+			r.Equal("Alice", result["name"])
+			n++
+		}
+		r.NoError(eg.Wait())
+		r.Equal(1, n)
 	})
 
-	n := 0
-	for range stream {
-		n++
-	}
+	t.Run("multiple form fields", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
 
-	<-time.After(10 * time.Millisecond)
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+		r.NoError(writer.WriteField("name", "Alice"))
+		r.NoError(writer.WriteField("age", "25"))
+		r.NoError(writer.Close())
 
-	err = eg.Wait()
-	require.EqualValues(t, n, 0)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), ErrEventTooLarge.Error())
+		contentType := writer.FormDataContentType()
+		stream := make(chan StreamItem)
+		eg := errgroup.Group{}
+		eg.Go(func() error {
+			return ParseStream(ctx, body, stream, 512*1024, contentType)
+		})
+
+		n := 0
+		for item := range stream {
+			var result map[string]string
+			r.NoError(json.Unmarshal(item.Item, &result))
+			r.Equal(map[string]string{
+				"name": "Alice",
+				"age":  "25",
+			}, result)
+			n++
+		}
+		r.NoError(eg.Wait())
+		r.Equal(1, n)
+	})
+
+	t.Run("empty form fields", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
+
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+		r.NoError(writer.WriteField("empty1", ""))
+		r.NoError(writer.WriteField("valid", "value"))
+		r.NoError(writer.WriteField("empty2", ""))
+		r.NoError(writer.Close())
+
+		contentType := writer.FormDataContentType()
+		stream := make(chan StreamItem)
+		eg := errgroup.Group{}
+		eg.Go(func() error {
+			return ParseStream(ctx, body, stream, 512*1024, contentType)
+		})
+
+		n := 0
+		for item := range stream {
+			var result map[string]string
+			r.NoError(json.Unmarshal(item.Item, &result))
+			r.Equal(map[string]string{
+				"valid": "value",
+			}, result)
+			n++
+		}
+		r.NoError(eg.Wait())
+		r.Equal(1, n)
+	})
+
+	t.Run("max size exceeded", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
+
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+		largeData := strings.Repeat("x", 300*1024)
+		r.NoError(writer.WriteField("large_field", largeData))
+		r.NoError(writer.Close())
+
+		contentType := writer.FormDataContentType()
+		stream := make(chan StreamItem)
+		eg := errgroup.Group{}
+		eg.Go(func() error {
+			return ParseStream(ctx, body, stream, 256*1024, contentType) // 256KB limit
+		})
+
+		n := 0
+		for range stream {
+			n++
+		}
+		err := eg.Wait()
+		r.Equal(0, n)
+		r.Error(err)
+		r.Contains(err.Error(), ErrEventTooLarge.Error())
+	})
+
+	t.Run("no form fields", func(t *testing.T) {
+		r := require.New(t)
+		ctx := context.Background()
+
+		body := &bytes.Buffer{}
+		writer := multipart.NewWriter(body)
+		r.NoError(writer.Close())
+
+		contentType := writer.FormDataContentType()
+		stream := make(chan StreamItem)
+		eg := errgroup.Group{}
+		eg.Go(func() error {
+			return ParseStream(ctx, body, stream, 512*1024, contentType)
+		})
+
+		n := 0
+		for range stream {
+			n++
+		}
+		r.NoError(eg.Wait())
+		r.Equal(0, n)
+	})
 }


### PR DESCRIPTION
## Description
Add support for processing events in `multipart/form-data` requests.

## Motivation
Support `multipart/form-data` webhooks.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
