### PR TITLE
Filter internal events in EventsV2 resolver

### DIFF
--- a/pkg/coreapi/graph/resolvers/events_connection.go
+++ b/pkg/coreapi/graph/resolvers/events_connection.go
@@ -16,7 +16,7 @@ func (r *eventsConnectionResolver) TotalCount(
 ) (int, error) {
 	filter := graphql.GetFieldContext(ctx).Parent.Args["filter"].(models.EventsFilter)
 
-	opts := &cqrs.WorkspaceEventsOpts{
+	opts := cqrs.WorkspaceEventsOpts{
 		Limit: cqrs.MaxEvents, // pass in dummy value to pass validation, but won't be used in actual count query
 		Names: filter.EventNames,
 	}

--- a/pkg/coreapi/graph/resolvers/events_connection.go
+++ b/pkg/coreapi/graph/resolvers/events_connection.go
@@ -17,12 +17,14 @@ func (r *eventsConnectionResolver) TotalCount(
 	filter := graphql.GetFieldContext(ctx).Parent.Args["filter"].(models.EventsFilter)
 
 	opts := cqrs.WorkspaceEventsOpts{
-		Limit: cqrs.MaxEvents, // pass in dummy value to pass validation, but won't be used in actual count query
-		Names: filter.EventNames,
+		Limit:                 cqrs.MaxEvents, // pass in dummy value to pass validation, but won't be used in actual count query
+		Names:                 filter.EventNames,
+		IncludeInternalEvents: filter.IncludeInternalEvents,
+		Oldest:                filter.From,
 	}
-	opts.Oldest = filter.From
 
-	opts.Newest = time.Now() // TODO: this is slightly problematic for total count as user pages through results
+	// this relies on the frontend not requesting TotalCount except on loading the first page
+	opts.Newest = time.Now()
 	if filter.Until != nil {
 		opts.Newest = *filter.Until
 	}

--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -844,59 +844,119 @@ func (w wrapper) GetEvents(ctx context.Context, accountID uuid.UUID, workspaceID
 		opts.Cursor = &endULID
 	}
 
-	var (
-		evts []*sqlc.Event
-		err  error
-	)
+	builder := newEventsQueryBuilder(ctx, *opts)
+	filter := builder.filter
+	order := builder.order
 
-	if len(opts.Names) == 0 {
-		params := sqlc.WorkspaceEventsParams{
-			Cursor: *opts.Cursor,
-			Before: opts.Newest,
-			After:  opts.Oldest,
-			Limit:  int64(opts.Limit),
-		}
-		evts, err = w.q.WorkspaceEvents(ctx, params)
-	} else {
-		params := sqlc.WorkspaceNamedEventsParams{
-			Names:  opts.Names,
-			Cursor: *opts.Cursor,
-			Before: opts.Newest,
-			After:  opts.Oldest,
-			Limit:  int64(opts.Limit),
-		}
-		evts, err = w.q.WorkspaceNamedEvents(ctx, params)
-	}
+	sql, args, err := sq.Dialect(w.dialect()).
+		From("events").
+		Select(
+			"internal_id",
+			"account_id",
+			"workspace_id",
+			"source",
+			"source_id",
+			"received_at",
+			"event_id",
+			"event_name",
+			"event_data",
+			"event_user",
+			"event_v",
+			"event_ts",
+		).
+		Where(filter...).
+		Order(order...).
+		Limit(uint(opts.Limit)).
+		Prepared(true).
+		ToSQL()
 
 	if err != nil {
 		return nil, err
 	}
-	out := make([]*cqrs.Event, len(evts))
-	for n, evt := range evts {
-		val := convertEvent(evt)
-		out[n] = &val
+
+	rows, err := w.db.QueryContext(ctx, sql, args...)
+	if err != nil {
+		return nil, err
 	}
+	defer rows.Close()
+
+	out := make([]*cqrs.Event, 0, opts.Limit)
+	for rows.Next() {
+		data := sqlc.Event{}
+		if err := rows.Scan(
+			&data.InternalID,
+			&data.AccountID,
+			&data.WorkspaceID,
+			&data.Source,
+			&data.SourceID,
+			&data.ReceivedAt,
+			&data.EventID,
+			&data.EventName,
+			&data.EventData,
+			&data.EventUser,
+			&data.EventV,
+			&data.EventTs,
+		); err != nil {
+			return nil, err
+		}
+		val := convertEvent(&data)
+		out = append(out, &val)
+	}
+
 	return out, nil
 }
 
-func (w wrapper) GetEventsCount(ctx context.Context, accountID uuid.UUID, workspaceID uuid.UUID, opts *cqrs.WorkspaceEventsOpts) (int64, error) {
+func (w wrapper) GetEventsCount(ctx context.Context, accountID uuid.UUID, workspaceID uuid.UUID, opts cqrs.WorkspaceEventsOpts) (int64, error) {
 	if err := opts.Validate(); err != nil {
 		return 0, err
 	}
 
-	if len(opts.Names) == 0 {
-		params := sqlc.WorkspaceCountEventsParams{
-			Before: opts.Newest,
-			After:  opts.Oldest,
-		}
-		return w.q.WorkspaceCountEvents(ctx, params)
-	} else {
-		params := sqlc.WorkspaceCountNamedEventsParams{
-			Names:  opts.Names,
-			Before: opts.Newest,
-			After:  opts.Oldest,
-		}
-		return w.q.WorkspaceCountNamedEvents(ctx, params)
+	// We don't want to consider cursor pagination for total count, so overwrite input param
+	opts.Cursor = &endULID
+
+	builder := newEventsQueryBuilder(ctx, opts)
+	filter := builder.filter
+	order := builder.order
+
+	sql, args, err := sq.Dialect(w.dialect()).
+		From("events").
+		Select(sq.COUNT("*").As("count")).
+		Where(filter...).
+		Order(order...).
+		Prepared(true).
+		ToSQL()
+
+	var count int64
+	err = w.db.QueryRowContext(ctx, sql, args...).Scan(&count)
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+type eventsQueryBuilder struct {
+	filter []sq.Expression
+	order  []sqexp.OrderedExpression
+}
+
+func newEventsQueryBuilder(ctx context.Context, opt cqrs.WorkspaceEventsOpts) *eventsQueryBuilder {
+	filter := []sq.Expression{}
+
+	filter = append(filter, sq.C("received_at").Lte(opt.Newest))
+	filter = append(filter, sq.C("received_at").Gte(opt.Oldest))
+	if opt.Cursor != nil {
+		filter = append(filter, sq.C("internal_id").Lt(*opt.Cursor))
+	}
+	if len(opt.Names) > 0 {
+		filter = append(filter, sq.C("event_name").In(opt.Names))
+	}
+
+	order := []sqexp.OrderedExpression{}
+	order = append(order, sq.C("internal_id").Desc())
+
+	return &eventsQueryBuilder{
+		filter: filter,
+		order:  order,
 	}
 }
 

--- a/pkg/cqrs/events.go
+++ b/pkg/cqrs/events.go
@@ -126,7 +126,7 @@ type EventReader interface {
 	// GetEvents returns the latest events for a given workspace.
 	GetEvents(ctx context.Context, accountID uuid.UUID, workspaceID uuid.UUID, opts *WorkspaceEventsOpts) ([]*Event, error)
 	// GetEventsCount returns the total count of events filtered by event name and from/until time range
-	GetEventsCount(ctx context.Context, accountID uuid.UUID, workspaceID uuid.UUID, opts *WorkspaceEventsOpts) (int64, error)
+	GetEventsCount(ctx context.Context, accountID uuid.UUID, workspaceID uuid.UUID, opts WorkspaceEventsOpts) (int64, error)
 	// GetEvent returns a specific event given an ID.
 	GetEvent(ctx context.Context, id ulid.ULID, accountID uuid.UUID, workspaceID uuid.UUID) (*Event, error)
 }

--- a/pkg/cqrs/events.go
+++ b/pkg/cqrs/events.go
@@ -89,7 +89,8 @@ type WorkspaceEventsOpts struct {
 	Newest time.Time
 	// Oldest represents the oldest events to load.  Events older than this
 	// cutoff will not be loaded.
-	Oldest time.Time
+	Oldest                time.Time
+	IncludeInternalEvents bool
 }
 
 func (o *WorkspaceEventsOpts) Validate() error {


### PR DESCRIPTION
## Description

Allow filtering out internal events in EventsV2 resolver.

Because this adds a conditional filter and we will have more filters coming (CEL search), this PR also rewrites the sqlc queries to use the goqu query builder.

- Mostly followed the pattern of other uses of goqu in this codebase
- Pass opts by copy instead of by reference so that we can safely modify it in TotalCount. It seems most other instances of `opts` structs in cqrs are passing copies anyway
- Also changed TotalCount to explicitly ignore the input cursor, since that'll defeat the purpose of getting the total count

One gotcha here is how sqlc/goqu/modernc sqlite driver handle dates

SQLite does not have a native date/time type and typically relies on strings in ISO8601 or another format
- https://www.sqlite.org/datatype3.html#date_and_time_datatype
- https://www.sqlite.org/lang_datefunc.html#tmval

We currently have `events.received_at` typed as `TIMESTAMP`, which is using a storage class of `TEXT`.
[`TIMESTAMP` is not an official SQLite type but it is recognized by our SQLite driver modernc.org/sqlite](https://github.com/inngest/inngest/blob/791f6997b13dbec44a4f6c67c1c10e45ad3b2aa0/vendor/modernc.org/sqlite/sqlite.go#L267)

What we are actually storing for `received at` are values like `2025-07-01 20:45:06.908081 +0000 UTC m=+4994.600868167` which is golang's `time.String()` format, including wall clock and monotonic clock times. This would break the lexicographic ordering that we rely on for SQL queries, so [modernc.org/sqlite trims the monotonic portion off for us when parsing](https://github.com/inngest/inngest/blob/791f6997b13dbec44a4f6c67c1c10e45ad3b2aa0/vendor/modernc.org/sqlite/sqlite.go#L309-L311)

sqlc compiles SQL queries into Go code with prepared statements and passes time values as arguments, so it relies entirely on this sqlite driver behavior.

However, [goqu interpolates parameters by default](https://doug-martin.github.io/goqu/docs/interpolation.html). When interpolating times, it does not rely on the sqlite driver and [instead follows its own logic](https://github.com/inngest/inngest/blob/791f6997b13dbec44a4f6c67c1c10e45ad3b2aa0/vendor/github.com/doug-martin/goqu/v9/sqlgen/expression_sql_generator.go#L304-L308), using [`time.RFC3339Nano` for sqlite](https://github.com/inngest/inngest/blob/791f6997b13dbec44a4f6c67c1c10e45ad3b2aa0/vendor/github.com/doug-martin/goqu/v9/dialect/sqlite3/sqlite3.go#L33) e.g.  `2025-07-01T20:45:06.908081000Z07:00`

This is a big problem because the `T` in the middle breaks lexicographic sorting with existing times in the Go string format, e.g.

```
// without T
'2025-07-08 19:00:49.618000 +0000 UTC m=+48.127515126' <= '2025-07-08 19:07:09.290'
'2025-07-08 19:00:49.618000 +0000 UTC m=+48.127515126' >= '2025-07-08 19:00:09.290'

// with a T
'2025-07-08 19:00:49.618000 +0000 UTC m=+48.127515126' <= '2025-07-08T19:07:09.290991Z'
'2025-07-08 19:00:49.618000 +0000 UTC m=+48.127515126' >= '2025-07-08T19:00:09.290991Z' // returns FALSE!!
```

So we must use prepared statements with goqu queries to have consistent time formatting relying on the modernc sqlite driver behavior.

This also affects comparison with ULID blobs, because the sqlite driver correctly treats them as byte arrays and goqu interpolation tries to make it into a string.

Queries before with sqlc:
```
-- name: WorkspaceNamedEvents :many
SELECT internal_id, account_id, workspace_id, source, source_id, received_at, event_id, event_name, event_data, event_user, event_v, event_ts FROM events WHERE internal_id < ? AND received_at <= ? AND received_at >= ? AND event_name in (?) ORDER BY internal_id DESC LIMIT ?
args [{ 1 [1 151 255 171 220 51 21 226 123 201 0 215 217 173 131 158]} { 2 2025-07-12 17:25:44.592419 +0000 UTC m=+5.783303876} { 3 2025-07-12 17:24:42.582052 +0000 UTC} { 4 evt-649a21da-496e-43f6-bd21-041bc037380e} { 5 40}]

-- name: WorkspaceCountNamedEvents :one
SELECT count(*) FROM events WHERE received_at <= ?1 AND received_at >= ?2 AND event_name in (?)
args [{ 1 2025-07-12 17:25:44.59364 +0000 UTC m=+5.784524876} { 2 2025-07-12 17:24:42.582052 +0000 UTC} { 3 evt-649a21da-496e-43f6-bd21-041bc037380e}]
```

Queries after with goqu:
```
SELECT `internal_id`, `account_id`, `workspace_id`, `source`, `source_id`, `received_at`, `event_id`, `event_name`, `event_data`, `event_user`, `event_v`, `event_ts` FROM `events` WHERE ((`received_at` <= ?) AND (`received_at` >= ?) AND (`internal_id` < ?) AND (`event_name` IN (?))) ORDER BY `internal_id` DESC LIMIT ?
args [{ 1 2025-07-12 17:23:15.497742 +0000 UTC m=+6.828472959} { 2 2025-07-12 17:22:13.489983 +0000 UTC} { 3 [1 151 255 169 149 207 133 119 249 140 50 57 42 225 19 187]} { 4 evt-de2eaa8b-8560-4bcb-9b67-400be4ca64ce} { 5 40}]

SELECT COUNT(*) AS `count` FROM `events` WHERE ((`received_at` <= ?) AND (`received_at` >= ?) AND (`internal_id` < ?) AND (`event_name` IN (?))) ORDER BY `internal_id` DESC
args [{ 1 2025-07-12 17:23:15.498837 +0000 UTC m=+6.829568334} { 2 2025-07-12 17:22:13.489983 +0000 UTC} { 3 [90 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]} { 4 evt-de2eaa8b-8560-4bcb-9b67-400be4ca64ce}]
```

## Motivation

more parity with cloud API

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
