### PR TITLE
Implement EventV2.Runs to return FunctionRunV2

### DIFF
--- a/pkg/coreapi/gqlgen.yml
+++ b/pkg/coreapi/gqlgen.yml
@@ -53,8 +53,8 @@ models:
     fields:
       raw:
         resolver: true
-#      runs:
-#        resolver: true
+      runs:
+        resolver: true
 #      source:
 #        resolver: true
   Function:

--- a/pkg/coreapi/graph/resolvers/event_v2.go
+++ b/pkg/coreapi/graph/resolvers/event_v2.go
@@ -36,8 +36,8 @@ func (er eventV2Resolver) Runs(ctx context.Context, obj *models.EventV2) ([]*mod
 		return nil, err
 	}
 
-	functionRuns := make([]*models.FunctionRunV2, len(traceRuns))
-	for i, r := range traceRuns {
+	functionRuns := make([]*models.FunctionRunV2, 0, len(traceRuns))
+	for _, r := range traceRuns {
 		// TODO dedupe cqrs.TraceRun to models.FunctionRunV2 transformation
 		var (
 			started   *time.Time
@@ -66,7 +66,7 @@ func (er eventV2Resolver) Runs(ctx context.Context, obj *models.EventV2) ([]*mod
 			continue
 		}
 
-		functionRuns[i] = &models.FunctionRunV2{
+		functionRuns = append(functionRuns, &models.FunctionRunV2{
 			ID:             runID,
 			AppID:          r.AppID,
 			FunctionID:     r.FunctionID,
@@ -81,7 +81,7 @@ func (er eventV2Resolver) Runs(ctx context.Context, obj *models.EventV2) ([]*mod
 			BatchCreatedAt: batchTime,
 			CronSchedule:   r.CronSchedule,
 			HasAi:          r.HasAI,
-		}
+		})
 	}
 	return functionRuns, nil
 }

--- a/pkg/coreapi/graph/resolvers/event_v2.go
+++ b/pkg/coreapi/graph/resolvers/event_v2.go
@@ -25,6 +25,10 @@ func (qr *queryResolver) EventV2(ctx context.Context, id ulid.ULID) (*models.Eve
 	return cqrsEventToGQLEvent(event), nil
 }
 
+func (e eventV2Resolver) Runs(ctx context.Context, obj *models.EventV2) ([]*models.FunctionRunV2, error) {
+	return []*models.FunctionRunV2{}, nil
+}
+
 func (e eventV2Resolver) Raw(ctx context.Context, obj *models.EventV2) (string, error) {
 	targetLoader := loader.FromCtx(ctx).EventLoader
 

--- a/pkg/coreapi/graph/resolvers/event_v2.go
+++ b/pkg/coreapi/graph/resolvers/event_v2.go
@@ -7,6 +7,7 @@ import (
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/oklog/ulid/v2"
+	"time"
 )
 
 func (qr *queryResolver) EventV2(ctx context.Context, id ulid.ULID) (*models.EventV2, error) {
@@ -25,11 +26,67 @@ func (qr *queryResolver) EventV2(ctx context.Context, id ulid.ULID) (*models.Eve
 	return cqrsEventToGQLEvent(event), nil
 }
 
-func (e eventV2Resolver) Runs(ctx context.Context, obj *models.EventV2) ([]*models.FunctionRunV2, error) {
-	return []*models.FunctionRunV2{}, nil
+func (er eventV2Resolver) Runs(ctx context.Context, obj *models.EventV2) ([]*models.FunctionRunV2, error) {
+	// convert cqrs TraceRun to FunctionRunV2
+
+	// This is an N+1, currently also an N+1 on cloud in the form of multiple calls to the metrics service
+	// we cannot currently use a data loader due to current db schema and https://github.com/sqlc-dev/sqlc/issues/1830
+	traceRuns, err := er.Data.GetTraceRunsByTriggerID(ctx, obj.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	functionRuns := make([]*models.FunctionRunV2, len(traceRuns))
+	for i, r := range traceRuns {
+		// TODO dedupe cqrs.TraceRun to models.FunctionRunV2 transformation
+		var (
+			started   *time.Time
+			ended     *time.Time
+			sourceID  *string
+			output    *string
+			batchTime *time.Time
+		)
+
+		if r.StartedAt.UnixMilli() > 0 {
+			started = &r.StartedAt
+		}
+		if r.EndedAt.UnixMilli() > 0 {
+			ended = &r.EndedAt
+		}
+		if len(r.SourceID) > 0 {
+			sourceID = &r.SourceID
+		}
+		if len(r.Output) > 0 {
+			s := string(r.Output)
+			output = &s
+		}
+		runID := ulid.MustParse(r.RunID)
+		status, err := models.ToFunctionRunStatus(r.Status)
+		if err != nil {
+			continue
+		}
+
+		functionRuns[i] = &models.FunctionRunV2{
+			ID:             runID,
+			AppID:          r.AppID,
+			FunctionID:     r.FunctionID,
+			TraceID:        r.TraceID,
+			QueuedAt:       r.QueuedAt,
+			StartedAt:      started,
+			EndedAt:        ended,
+			SourceID:       sourceID,
+			Status:         status,
+			Output:         output,
+			IsBatch:        r.IsBatch,
+			BatchCreatedAt: batchTime,
+			CronSchedule:   r.CronSchedule,
+			HasAi:          r.HasAI,
+		}
+	}
+	return functionRuns, nil
 }
 
-func (e eventV2Resolver) Raw(ctx context.Context, obj *models.EventV2) (string, error) {
+func (er eventV2Resolver) Raw(ctx context.Context, obj *models.EventV2) (string, error) {
 	targetLoader := loader.FromCtx(ctx).EventLoader
 
 	event, err := loader.LoadOneWithString[cqrs.Event](

--- a/pkg/coreapi/graph/resolvers/events_v2.go
+++ b/pkg/coreapi/graph/resolvers/events_v2.go
@@ -120,7 +120,6 @@ func cqrsEventToGQLEvent(e *cqrs.Event) *models.EventV2 {
 		Name:           e.EventName,
 		OccurredAt:     time.UnixMilli(e.EventTS),
 		ReceivedAt:     e.ReceivedAt,
-		Runs:           []*models.FunctionRunV2{}, // TODO
 		Version:        &e.EventVersion,
 	}
 

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/db_normalization.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/db_normalization.go
@@ -739,6 +739,20 @@ func (q NormalizedQueries) GetTraceSpanOutput(ctx context.Context, arg sqlc_sqli
 	return sqliteTraces, nil
 }
 
+func (q NormalizedQueries) GetTraceRunsByTriggerId(ctx context.Context, eventID string) ([]*sqlc_sqlite.TraceRun, error) {
+	traces, err := q.db.GetTraceRunsByTriggerId(ctx, eventID)
+	if err != nil {
+		return nil, err
+	}
+
+	sqliteTraces := make([]*sqlc_sqlite.TraceRun, len(traces))
+	for i, trace := range traces {
+		sqliteTraces[i], _ = trace.ToSQLite()
+	}
+
+	return sqliteTraces, nil
+}
+
 func (q NormalizedQueries) InsertFunctionFinish(ctx context.Context, arg sqlc_sqlite.InsertFunctionFinishParams) error {
 	var completedStepCount int32
 	if arg.CompletedStepCount.Valid {

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
@@ -252,6 +252,8 @@ SELECT * FROM traces WHERE trace_id = sqlc.arg('trace_id') AND run_id = sqlc.arg
 -- name: GetTraceSpanOutput :many
 SELECT * FROM traces WHERE trace_id = sqlc.arg('trace_id') AND span_id = sqlc.arg('span_id') ORDER BY timestamp_unix_ms DESC, duration DESC;
 
+-- name: GetTraceRunsByTriggerId :many
+SELECT * FROM trace_runs WHERE POSITION(sqlc.arg('event_id') IN trigger_ids::text) > 0;
 
 --
 -- Queue snapshots

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/querier.go
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/querier.go
@@ -48,6 +48,7 @@ type Querier interface {
 	GetSpanOutput(ctx context.Context, spanID string) (interface{}, error)
 	GetSpansByRunID(ctx context.Context, runID string) ([]*GetSpansByRunIDRow, error)
 	GetTraceRun(ctx context.Context, runID ulid.ULID) (*TraceRun, error)
+	GetTraceRunsByTriggerId(ctx context.Context, eventID string) ([]*TraceRun, error)
 	GetTraceSpanOutput(ctx context.Context, arg GetTraceSpanOutputParams) ([]*Trace, error)
 	GetTraceSpans(ctx context.Context, arg GetTraceSpansParams) ([]*Trace, error)
 	GetWorkerConnection(ctx context.Context, arg GetWorkerConnectionParams) (*WorkerConnection, error)

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
@@ -250,6 +250,9 @@ SELECT * FROM traces WHERE trace_id = @trace_id AND run_id = @run_id ORDER BY ti
 -- name: GetTraceSpanOutput :many
 select * from traces where trace_id = @trace_id AND span_id = @span_id ORDER BY timestamp_unix_ms DESC, duration DESC;
 
+-- name: GetTraceRunsByTriggerId :many
+SELECT * FROM trace_runs WHERE INSTR(CAST(trigger_ids AS TEXT), @event_id) > 0;
+
 
 --
 -- Queue snapshots

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql.go
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql.go
@@ -1142,6 +1142,51 @@ func (q *Queries) GetTraceRun(ctx context.Context, runID ulid.ULID) (*TraceRun, 
 	return &i, err
 }
 
+const getTraceRunsByTriggerId = `-- name: GetTraceRunsByTriggerId :many
+SELECT run_id, account_id, workspace_id, app_id, function_id, trace_id, queued_at, started_at, ended_at, status, source_id, trigger_ids, output, is_debounce, batch_id, cron_schedule, has_ai FROM trace_runs WHERE INSTR(CAST(trigger_ids AS TEXT), ?1) > 0
+`
+
+func (q *Queries) GetTraceRunsByTriggerId(ctx context.Context, eventID string) ([]*TraceRun, error) {
+	rows, err := q.db.QueryContext(ctx, getTraceRunsByTriggerId, eventID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*TraceRun
+	for rows.Next() {
+		var i TraceRun
+		if err := rows.Scan(
+			&i.RunID,
+			&i.AccountID,
+			&i.WorkspaceID,
+			&i.AppID,
+			&i.FunctionID,
+			&i.TraceID,
+			&i.QueuedAt,
+			&i.StartedAt,
+			&i.EndedAt,
+			&i.Status,
+			&i.SourceID,
+			&i.TriggerIds,
+			&i.Output,
+			&i.IsDebounce,
+			&i.BatchID,
+			&i.CronSchedule,
+			&i.HasAi,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getTraceSpanOutput = `-- name: GetTraceSpanOutput :many
 select timestamp, timestamp_unix_ms, trace_id, span_id, parent_span_id, trace_state, span_name, span_kind, service_name, resource_attributes, scope_name, scope_version, span_attributes, duration, status_code, status_message, events, links, run_id from traces where trace_id = ?1 AND span_id = ?2 ORDER BY timestamp_unix_ms DESC, duration DESC
 `

--- a/pkg/cqrs/cqrs.go
+++ b/pkg/cqrs/cqrs.go
@@ -31,7 +31,7 @@ type Manager interface {
 
 	// Trace / dev only
 	TraceReadWriter
-	TraceWriterDev
+	TraceReadWriterDev
 
 	// Connection history
 	ConnectionHistoryReadWriter

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -361,9 +361,11 @@ type TraceWriter interface {
 	InsertTraceRun(ctx context.Context, run *TraceRun) error
 }
 
-type TraceWriterDev interface {
+type TraceReadWriterDev interface {
 	// FindOrCreateTraceRun will return a TraceRun by runID, or create a new one if it doesn't exists
 	FindOrBuildTraceRun(ctx context.Context, opts FindOrCreateTraceRunOpt) (*TraceRun, error)
+	// Returns a list of TraceRun triggered by triggerID
+	GetTraceRunsByTriggerID(ctx context.Context, triggerID ulid.ULID) ([]*TraceRun, error)
 }
 
 type TraceReader interface {


### PR DESCRIPTION
## Description

Add associated runs with events in EventsV2

Copied tests from monorepo and added several cases which I'll backport
- multiple event types 1-1 with multiple functions
- one event fan out to multiple functions
- same event type with multiple runs to the same function
- multiple events batched to the same function


Unfortunately the current implementation has an N+1. Ideally we would use a data loader to batch these into a single db query where given a list of eventIDs/triggerIDs we fetch all the associated function runs, but we have a few things working against us here.

- Because multiple events can trigger one function (batched events), `trace_runs.trigger_ids` is a comma separated string of ULID strings (stored as a BLOB). Because it's not a JSON array we can't use `json_each` and instead have to use substring matching with INSTR/POSITION
- `trace_runs` does have a foreign key to `event_batches`, but `event_batches.event_ids` is also a comma separated string so there's no JOIN that gets around the substring matching.
- This is still fine (modulo some performance issues) as long as we could provide a list of event_ids and join against that in a query, but sqlc has an open issue where we can't use `value` from `json_each` to unnest the list into a CTE https://github.com/sqlc-dev/sqlc/issues/1830. This prevents us from using this query
  ```sql
  WITH event_ids AS (
      SELECT value AS id
      FROM json_each(sqlc.slice('trigger_ids'))
  )
  SELECT tr.*
  FROM trace_runs tr
  CROSS JOIN event_ids s
  WHERE INSTR(CAST(tr.trigger_ids AS TEXT), s.id) > 0
  GROUP BY tr.run_id;
  ```

## Motivation

parity with cloud API

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
