### PR TITLE
Force goqu to use prepared statements by default

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -57,6 +57,8 @@ func NewQueries(db *sql.DB, driver string) (q sqlc.Querier) {
 }
 
 func NewCQRS(db *sql.DB, driver string) cqrs.Manager {
+	// Force goqu to use prepared statements for consistency with sqlc
+	sq.SetDefaultPrepared(true)
 	return wrapper{
 		driver: driver,
 		q:      NewQueries(db, driver),
@@ -859,7 +861,6 @@ func (w wrapper) GetEvents(ctx context.Context, accountID uuid.UUID, workspaceID
 		Where(filter...).
 		Order(order...).
 		Limit(uint(opts.Limit)).
-		Prepared(true).
 		ToSQL()
 
 	if err != nil {
@@ -915,7 +916,6 @@ func (w wrapper) GetEventsCount(ctx context.Context, accountID uuid.UUID, worksp
 		Select(sq.COUNT("*").As("count")).
 		Where(filter...).
 		Order(order...).
-		Prepared(true).
 		ToSQL()
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Description

This is probably a better idea anyway for performance, but it also
prevents footguns with sqlc due to inconsistent parameter interpolation

## Motivation

Prevent compatibility issues with sqlc (see https://github.com/inngest/inngest/pull/2684 for an example)

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
