### PR TITLE
Add CLI Flag to disable UI and GQL endpoint

### DIFF
--- a/cmd/commands/internal/localconfig/devconfig.go
+++ b/cmd/commands/internal/localconfig/devconfig.go
@@ -119,6 +119,7 @@ func mapStartFlags(cmd *cobra.Command) error {
 	err = errors.Join(err, viper.BindPFlag("sqlite-dir", cmd.Flags().Lookup("sqlite-dir")))
 	err = errors.Join(err, viper.BindPFlag("tick", cmd.Flags().Lookup("tick")))
 	err = errors.Join(err, viper.BindPFlag("connect-gateway-port", cmd.Flags().Lookup("connect-gateway-port")))
+	err = errors.Join(err, viper.BindPFlag("no-ui", cmd.Flags().Lookup("no-ui")))
 
 	return err
 }

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -55,6 +55,7 @@ func NewCmdStart(rootCmd *cobra.Command) *cobra.Command {
 	advancedFlags.Int("queue-workers", devserver.DefaultQueueWorkers, "Number of executor workers to execute steps from the queue")
 	advancedFlags.Int("tick", devserver.DefaultTick, "The interval (in milliseconds) at which the executor polls the queue")
 	advancedFlags.Int("connect-gateway-port", devserver.DefaultConnectGatewayPort, "Port to expose connect gateway endpoint")
+	advancedFlags.Bool("no-ui", false, "Disable the web UI and GraphQL API endpoint")
 	cmd.Flags().AddFlagSet(advancedFlags)
 	groups = append(groups, FlagGroup{name: "Advanced Flags:", fs: advancedFlags})
 
@@ -166,6 +167,7 @@ func doStart(cmd *cobra.Command, args []string) {
 		ConnectGatewayPort: viper.GetInt("connect-gateway-port"),
 		EventKeys:          eventKeys,
 		InMemory:           false,
+		NoUI:               viper.GetBool("no-ui"),
 		PollInterval:       viper.GetInt("poll-interval"),
 		PostgresURI:        viper.GetString("postgres-uri"),
 		QueueWorkers:       viper.GetInt("queue-workers"),

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -540,7 +540,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	// start the API
 	// Create a new API endpoint which hosts SDK-related functionality for
 	// registering functions.
-	devAPI := NewDevAPI(ds)
+	devAPI := NewDevAPI(ds, DevAPIOptions{disableUI: false})
 
 	devAPI.Route("/v1", func(r chi.Router) {
 		// Add the V1 API to our dev server API.
@@ -571,6 +571,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		return fmt.Errorf("failed to create connect pubsub connector: %w", err)
 	}
 
+	// TODO wire up new EnableGraphQL option with --no-ui flag
 	core, err := coreapi.NewCoreApi(coreapi.Options{
 		Data:          ds.Data,
 		Config:        ds.Opts.Config,
@@ -880,7 +881,7 @@ func PartitionConstraintConfigGetter(dbcqrs cqrs.Manager) redis_state.PartitionC
 
 		constraints := redis_state.PartitionConstraintConfig{
 			FunctionVersion: fn.FunctionVersion,
-			
+
 			Concurrency: redis_state.ShadowPartitionConcurrency{
 				SystemConcurrency:     consts.DefaultConcurrencyLimit,
 				AccountConcurrency:    accountLimit,

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -106,6 +106,8 @@ type StartOpts struct {
 	ConnectGatewayPort int    `json:"connectGatewayPort"`
 	ConnectGatewayHost string `json:"connectGatewayHost"`
 
+	NoUI bool
+
 	// InMemory controls whether to only use in-memory databases (as opposed to
 	// filesystem)
 	InMemory bool
@@ -540,7 +542,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	// start the API
 	// Create a new API endpoint which hosts SDK-related functionality for
 	// registering functions.
-	devAPI := NewDevAPI(ds, DevAPIOptions{disableUI: false})
+	devAPI := NewDevAPI(ds, DevAPIOptions{disableUI: opts.NoUI})
 
 	devAPI.Route("/v1", func(r chi.Router) {
 		// Add the V1 API to our dev server API.
@@ -571,18 +573,18 @@ func start(ctx context.Context, opts StartOpts) error {
 		return fmt.Errorf("failed to create connect pubsub connector: %w", err)
 	}
 
-	// TODO wire up new EnableGraphQL option with --no-ui flag
 	core, err := coreapi.NewCoreApi(coreapi.Options{
-		Data:          ds.Data,
-		Config:        ds.Opts.Config,
-		Logger:        l,
-		Runner:        ds.Runner,
-		Tracker:       ds.Tracker,
-		State:         ds.State,
-		Queue:         ds.Queue,
-		EventHandler:  ds.HandleEvent,
-		Executor:      ds.Executor,
-		HistoryReader: memory_reader.NewReader(),
+		Data:           ds.Data,
+		Config:         ds.Opts.Config,
+		Logger:         l,
+		Runner:         ds.Runner,
+		Tracker:        ds.Tracker,
+		State:          ds.State,
+		Queue:          ds.Queue,
+		EventHandler:   ds.HandleEvent,
+		Executor:       ds.Executor,
+		HistoryReader:  memory_reader.NewReader(),
+		DisableGraphQL: &opts.NoUI,
 		ConnectOpts: connectv0.Opts{
 			GroupManager:               connectionManager,
 			ConnectManager:             connectionManager,

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -177,7 +177,11 @@ func (d *devserver) Run(ctx context.Context) error {
 			fmt.Println("")
 			fmt.Println("")
 			fmt.Print(cli.BoldStyle.Render(fmt.Sprintf("\tInngest%s online ", prettyName)))
-			fmt.Printf("%s\n\n", cli.TextStyle.Render(fmt.Sprintf("at %s, visible at the following URLs:", addr)))
+			if d.Opts.NoUI {
+				fmt.Printf("%s\n\n", cli.TextStyle.Render(fmt.Sprintf("at %s, web UI and GraphQL API endpoint disabled:", addr)))
+			} else {
+				fmt.Printf("%s\n\n", cli.TextStyle.Render(fmt.Sprintf("at %s, visible at the following URLs:", addr)))
+			}
 			for n, ip := range localIPs() {
 				style := cli.BoldStyle
 				if n > 0 {


### PR DESCRIPTION
## Description

Allow self-hosted application to run in _headless_ mode.

- Add a `--no-ui` CLI flag to `start`
- Do not register static file endpoints when `--no-ui` flag set
- Do not register GQL endpoint when `--no-ui` flag set

### How to use
```plaintext
inngest start --no-ui ...rest_of_command
```
or
```plaintext
export INNGEST_NO_UI=true
inngest start ...rest_of_command
```

### Screenshots

_CLI copy update when running in `--no-ui` mode_
<img width="680" height="104" alt="image" src="https://github.com/user-attachments/assets/1ccf9d66-869c-4ff9-84b7-236c2cba7ff6" />

_Returns 404 from / when running in `--no-ui` mode_
<img width="1521" height="1024" alt="image" src="https://github.com/user-attachments/assets/d3b676af-b4d6-46df-9f5a-b1ebe3501ea9" />

_Returns 404 from /v0/gql when running in `--no-ui` mode_
<img width="1279" height="954" alt="image" src="https://github.com/user-attachments/assets/b70596df-b550-4180-bacb-782b8c9cefb3" />

_Updated help copy with --no-ui under Advanced Flags_
<img width="1240" height="586" alt="image" src="https://github.com/user-attachments/assets/31dfe5bf-0c86-4a80-9191-b5234e06838d" />

## Motivation

Requested by [Cohere](https://inngest.slack.com/archives/C094808LW8K/p1752004305300749). Part of Self hosting improvements for Cohere launch in August.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
