### PR TITLE
Use gRPC for Connect flushing API

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -724,7 +724,7 @@ func (c *connectionHandler) handleIncomingWebSocketMessage(ctx context.Context, 
 			if useGRPC {
 				transport = "grpc"
 
-				grpcClient, err := c.svc.getOrCreateGRPCClient(ctx, c.log, c.conn.EnvID, data.RequestId)
+				grpcClient, err := c.svc.getOrCreateGRPCClient(ctx, c.conn.EnvID, data.RequestId)
 				if err != nil {
 					return &connecterrors.SocketError{
 						SysCode:    syscode.CodeConnectInternal,
@@ -1282,7 +1282,7 @@ func (c *connectionHandler) handleSdkReply(ctx context.Context, msg *connectpb.C
 	}
 
 	if c.svc.shouldUseGRPC(ctx, c.conn.AccountID) {
-		grpcClient, err := c.svc.getOrCreateGRPCClient(ctx, l, c.conn.EnvID, data.RequestId)
+		grpcClient, err := c.svc.getOrCreateGRPCClient(ctx, c.conn.EnvID, data.RequestId)
 		if err != nil {
 			return err
 		}

--- a/pkg/connect/grpc/client.go
+++ b/pkg/connect/grpc/client.go
@@ -1,0 +1,140 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/inngest/inngest/pkg/logger"
+	connectpb "github.com/inngest/inngest/proto/gen/connect/v1"
+	grpcLib "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+var ErrGatewayNotFound = fmt.Errorf("gateway not found")
+
+type PingableClient interface {
+	Ping(ctx context.Context, req *connectpb.PingRequest, opts ...grpcLib.CallOption) (*connectpb.PingResponse, error)
+}
+
+type GRPCClientManager[T PingableClient] struct {
+	mu          sync.RWMutex
+	clients     map[string]T
+	connections map[string]*grpcLib.ClientConn
+	logger      logger.Logger
+	factory     func(grpcLib.ClientConnInterface) T
+	dialer      func(target string, opts ...grpcLib.DialOption) (*grpcLib.ClientConn, error)
+}
+
+type GRPCClientManagerOption[T PingableClient] func(*GRPCClientManager[T])
+
+func WithDialer[T PingableClient](dialer func(target string, opts ...grpcLib.DialOption) (*grpcLib.ClientConn, error)) GRPCClientManagerOption[T] {
+	return func(m *GRPCClientManager[T]) {
+		m.dialer = dialer
+	}
+}
+
+func WithLogger[T PingableClient](logger logger.Logger) GRPCClientManagerOption[T] {
+	return func(m *GRPCClientManager[T]) {
+		m.logger = logger
+	}
+}
+
+func NewGRPCClientManager[T PingableClient](factory func(grpcLib.ClientConnInterface) T, opts ...GRPCClientManagerOption[T]) *GRPCClientManager[T] {
+	m := &GRPCClientManager[T]{
+		clients:     make(map[string]T),
+		connections: make(map[string]*grpcLib.ClientConn),
+		factory:     factory,
+		dialer:      grpcLib.NewClient,
+		logger:      logger.VoidLogger(),
+	}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}
+
+func (m *GRPCClientManager[T]) GetClient(ctx context.Context, key string) (T, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if client, exists := m.clients[key]; exists {
+		return client, nil
+	}
+	var zero T
+	return zero, ErrGatewayNotFound
+}
+
+func (m *GRPCClientManager[T]) GetOrCreateClient(ctx context.Context, key string, grpcURL string) (T, error) {
+	m.mu.RLock()
+	if client, exists := m.clients[key]; exists {
+		m.mu.RUnlock()
+		return client, nil
+	}
+	m.mu.RUnlock()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if client, exists := m.clients[key]; exists {
+		return client, nil
+	}
+
+	m.logger.Info("grpc client not found, creating one dynamically", "key", key)
+
+	conn, err := m.dialer(grpcURL, grpcLib.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		var zero T
+		return zero, fmt.Errorf("could not create grpc client for %s: %w", grpcURL, err)
+	}
+
+	client := m.factory(conn)
+
+	result, err := client.Ping(ctx, &connectpb.PingRequest{})
+	if err != nil {
+		if closeErr := conn.Close(); closeErr != nil {
+			m.logger.Error("failed to close grpc connection after ping failure", "url", grpcURL, "error", closeErr)
+		}
+		var zero T
+		return zero, fmt.Errorf("could not ping %s: %w", grpcURL, err)
+	}
+
+	if result.GetMessage() != "ok" {
+		if closeErr := conn.Close(); closeErr != nil {
+			m.logger.Error("failed to close grpc connection after unexpected ping response", "url", grpcURL, "error", closeErr)
+		}
+		var zero T
+		return zero, fmt.Errorf("unexpected ping response from %s: %s", grpcURL, result.GetMessage())
+	}
+
+	m.clients[key] = client
+	m.connections[key] = conn
+	return client, nil
+}
+
+func (m *GRPCClientManager[T]) RemoveClient(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if conn, exists := m.connections[key]; exists {
+		if err := conn.Close(); err != nil {
+			m.logger.Error("failed to close grpc connection", "url", key, "error", err)
+		}
+		delete(m.connections, key)
+	}
+
+	delete(m.clients, key)
+}
+
+func (m *GRPCClientManager[T]) GetClientKeys() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	keys := make([]string, 0, len(m.clients))
+	for url := range m.clients {
+		keys = append(keys, url)
+	}
+	return keys
+}

--- a/pkg/connect/rest/v0/workerapi.go
+++ b/pkg/connect/rest/v0/workerapi.go
@@ -20,7 +20,6 @@ import (
 	"github.com/inngest/inngest/pkg/connect/auth"
 	"github.com/inngest/inngest/pkg/publicerr"
 	"github.com/inngest/inngest/proto/gen/connect/v1"
-	pb "github.com/inngest/inngest/proto/gen/connect/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
@@ -232,7 +231,7 @@ func (cr *connectApiRouter) flushBuffer(w http.ResponseWriter, r *http.Request) 
 		executorIP := ip.String()
 		grpcURL := net.JoinHostPort(executorIP, fmt.Sprintf("%d", connectConfig.Executor(ctx).GRPCPort))
 
-		var grpcClient pb.ConnectExecutorClient
+		var grpcClient connect.ConnectExecutorClient
 
 		cr.grpcLock.RLock()
 		grpcClient = cr.grpcClients[executorIP]
@@ -258,12 +257,12 @@ func (cr *connectApiRouter) flushBuffer(w http.ResponseWriter, r *http.Request) 
 					return
 				}
 
-				grpcClient = pb.NewConnectExecutorClient(conn)
+				grpcClient = connect.NewConnectExecutorClient(conn)
 				cr.grpcClients[executorIP] = grpcClient
 			}
 		}
 
-		result, err := grpcClient.Reply(ctx, &pb.ReplyRequest{Data: reqBody})
+		result, err := grpcClient.Reply(ctx, &connect.ReplyRequest{Data: reqBody})
 		if err != nil || !result.Success {
 			l.Error("could not notify executor to flush connect message", "err", err)
 			span.RecordError(err)

--- a/pkg/connect/rest/v0/workerapi.go
+++ b/pkg/connect/rest/v0/workerapi.go
@@ -4,7 +4,9 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 
 	"github.com/inngest/inngest/pkg/connect/state"
@@ -14,9 +16,13 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
 
+	connectConfig "github.com/inngest/inngest/pkg/config/connect"
 	"github.com/inngest/inngest/pkg/connect/auth"
 	"github.com/inngest/inngest/pkg/publicerr"
 	"github.com/inngest/inngest/proto/gen/connect/v1"
+	pb "github.com/inngest/inngest/proto/gen/connect/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -130,6 +136,7 @@ func (cr *connectApiRouter) start(w http.ResponseWriter, r *http.Request) {
 
 func (cr *connectApiRouter) flushBuffer(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	l := logger.StdlibLogger(ctx)
 
 	hashedSigningKey := r.Header.Get("Authorization")
 	{
@@ -148,10 +155,7 @@ func (cr *connectApiRouter) flushBuffer(w http.ResponseWriter, r *http.Request) 
 
 	res, err := cr.RequestAuther.AuthenticateRequest(ctx, hashedSigningKey, envOverride)
 	if err != nil {
-		logger.StdlibLogger(ctx).Error(
-			"could not authenticate connect start request",
-			"err", err,
-		)
+		l.Error("could not authenticate connect start request", "err", err)
 
 		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 401, "authentication failed"))
 		return
@@ -194,7 +198,7 @@ func (cr *connectApiRouter) flushBuffer(w http.ResponseWriter, r *http.Request) 
 		RequestId: reqBody.RequestId,
 	})
 	if err != nil {
-		logger.StdlibLogger(ctx).Error("could not marshal flush response", "err", err)
+		l.Error("could not marshal flush response", "err", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "could not marshal flush api response")
 
@@ -205,7 +209,7 @@ func (cr *connectApiRouter) flushBuffer(w http.ResponseWriter, r *http.Request) 
 	// Reliable path: Buffer the response to be picked up by the executor
 	err = cr.ConnectRequestStateManager.SaveResponse(ctx, res.EnvID, reqBody.RequestId, reqBody)
 	if err != nil && !errors.Is(err, state.ErrResponseAlreadyBuffered) {
-		logger.StdlibLogger(ctx).Error("could not buffer response", "err", err)
+		l.Error("could not buffer response", "err", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "could not buffer response")
 
@@ -213,15 +217,73 @@ func (cr *connectApiRouter) flushBuffer(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Unreliable fast-track: Notify the executor via PubSub (best-effort, this may be dropped)
-	if err := cr.ConnectResponseNotifier.NotifyExecutor(ctx, reqBody); err != nil {
-		logger.StdlibLogger(ctx).Error("could not notify executor to flush connect message", "err", err)
-		span.RecordError(err)
-		span.SetStatus(codes.Error, "could not notify executor to flush connect sdk response")
+	if cr.ShouldUseGRPC(ctx, res.AccountID) {
+		ip, err := cr.ConnectRequestStateManager.GetExecutorIP(ctx, res.EnvID, reqBody.RequestId)
+		if err != nil {
+			// Likely because the request lease has expired
+			l.Error("could not get executor IP", "err", err)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "could not get executor IP")
 
-		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "could not notify executor"))
+			_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "could not get executor"))
+			return
+		}
 
-		return
+		executorIP := ip.String()
+		grpcURL := net.JoinHostPort(executorIP, fmt.Sprintf("%d", connectConfig.Executor(ctx).GRPCPort))
+
+		var grpcClient pb.ConnectExecutorClient
+
+		cr.grpcLock.RLock()
+		grpcClient = cr.grpcClients[executorIP]
+		cr.grpcLock.RUnlock()
+
+		if grpcClient == nil {
+			// Upgrade lock to make sure that only one instance is creating a grpc client
+			cr.grpcLock.Lock()
+			defer cr.grpcLock.Unlock()
+			grpcClient = cr.grpcClients[executorIP]
+
+			if grpcClient == nil {
+				l.Info("grpc client not found for executor, creating one dynamically", "url", grpcURL)
+
+				conn, err := grpc.NewClient(grpcURL, grpc.WithTransportCredentials(insecure.NewCredentials()))
+				if err != nil {
+					l.Error("could not create grpc client", "url", grpcURL, "err", err)
+					span.RecordError(err)
+					span.SetStatus(codes.Error, "could not create grpc client")
+
+					_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "could not create grpc client"))
+
+					return
+				}
+
+				grpcClient = pb.NewConnectExecutorClient(conn)
+				cr.grpcClients[executorIP] = grpcClient
+			}
+		}
+
+		result, err := grpcClient.Reply(ctx, &pb.ReplyRequest{Data: reqBody})
+		if err != nil || !result.Success {
+			l.Error("could not notify executor to flush connect message", "err", err)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "could not notify executor to flush connect sdk response")
+
+			_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "could not notify executor"))
+			return
+		}
+
+	} else {
+		// Unreliable fast-track: Notify the executor via PubSub (best-effort, this may be dropped)
+		if err := cr.ConnectResponseNotifier.NotifyExecutor(ctx, reqBody); err != nil {
+			l.Error("could not notify executor to flush connect message", "err", err)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "could not notify executor to flush connect sdk response")
+
+			_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "could not notify executor"))
+
+			return
+		}
 	}
 
 	// Send response once executor was notified

--- a/pkg/connect/state/request.go
+++ b/pkg/connect/state/request.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -188,9 +187,6 @@ func (r *redisConnectionStateManager) GetExecutorIP(ctx context.Context, envID u
 
 	reply, err := r.client.Do(ctx, cmd).ToString()
 	if err != nil {
-		if errors.Is(err, rueidis.Nil) {
-			return nil, nil
-		}
 		return nil, err
 	}
 

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -546,6 +546,9 @@ func start(ctx context.Context, opts StartOpts) error {
 			Dev:                        true,
 			EntitlementProvider:        ds,
 			ConditionalTracer:          conditionalTracer,
+			ShouldUseGRPC: func(ctx context.Context, accountID uuid.UUID) bool {
+				return false
+			},
 		},
 	})
 	if err != nil {

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -336,7 +336,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	agg := expragg.NewAggregator(ctx, 100, 100, sm.(expragg.EvaluableLoader), expressions.ExprEvaluator, nil, nil)
 
 	executorLogger := connectPubSubLogger.With("svc", "executor")
-	gatewayGRPCForwarder := connectpubsub.NewGatewayGRPCManager(ctx, connectionManager, executorLogger)
+	gatewayGRPCForwarder := connectpubsub.NewGatewayGRPCManager(ctx, connectionManager, connectpubsub.WithLogger(executorLogger))
 
 	executorProxy, err := connectpubsub.NewConnector(ctx, connectpubsub.WithRedis(connectPubSubRedis, true, connectpubsub.RedisPubSubConnectorOpts{
 		Logger:             executorLogger,

--- a/proto/connect/v1/service.proto
+++ b/proto/connect/v1/service.proto
@@ -31,6 +31,7 @@ message PingResponse {
 service ConnectExecutor {
   rpc Reply(ReplyRequest) returns (ReplyResponse) {}
   rpc Ack(AckMessage) returns (AckResponse) {}
+  rpc Ping(PingRequest) returns (PingResponse) {}
 }
 
 message ReplyRequest {

--- a/proto/gen/connect/v1/connectconnect/service.connect.go
+++ b/proto/gen/connect/v1/connectconnect/service.connect.go
@@ -47,16 +47,6 @@ const (
 	ConnectExecutorPingProcedure = "/connect.v1.ConnectExecutor/Ping"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	connectGatewayServiceDescriptor       = v1.File_connect_v1_service_proto.Services().ByName("ConnectGateway")
-	connectGatewayForwardMethodDescriptor = connectGatewayServiceDescriptor.Methods().ByName("Forward")
-	connectGatewayPingMethodDescriptor    = connectGatewayServiceDescriptor.Methods().ByName("Ping")
-	connectExecutorServiceDescriptor      = v1.File_connect_v1_service_proto.Services().ByName("ConnectExecutor")
-	connectExecutorReplyMethodDescriptor  = connectExecutorServiceDescriptor.Methods().ByName("Reply")
-	connectExecutorAckMethodDescriptor    = connectExecutorServiceDescriptor.Methods().ByName("Ack")
-)
-
 // ConnectGatewayClient is a client for the connect.v1.ConnectGateway service.
 type ConnectGatewayClient interface {
 	Forward(context.Context, *connect.Request[v1.ForwardRequest]) (*connect.Response[v1.ForwardResponse], error)
@@ -72,17 +62,18 @@ type ConnectGatewayClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewConnectGatewayClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) ConnectGatewayClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	connectGatewayMethods := v1.File_connect_v1_service_proto.Services().ByName("ConnectGateway").Methods()
 	return &connectGatewayClient{
 		forward: connect.NewClient[v1.ForwardRequest, v1.ForwardResponse](
 			httpClient,
 			baseURL+ConnectGatewayForwardProcedure,
-			connect.WithSchema(connectGatewayForwardMethodDescriptor),
+			connect.WithSchema(connectGatewayMethods.ByName("Forward")),
 			connect.WithClientOptions(opts...),
 		),
 		ping: connect.NewClient[v1.PingRequest, v1.PingResponse](
 			httpClient,
 			baseURL+ConnectGatewayPingProcedure,
-			connect.WithSchema(connectGatewayPingMethodDescriptor),
+			connect.WithSchema(connectGatewayMethods.ByName("Ping")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -116,16 +107,17 @@ type ConnectGatewayHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewConnectGatewayHandler(svc ConnectGatewayHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	connectGatewayMethods := v1.File_connect_v1_service_proto.Services().ByName("ConnectGateway").Methods()
 	connectGatewayForwardHandler := connect.NewUnaryHandler(
 		ConnectGatewayForwardProcedure,
 		svc.Forward,
-		connect.WithSchema(connectGatewayForwardMethodDescriptor),
+		connect.WithSchema(connectGatewayMethods.ByName("Forward")),
 		connect.WithHandlerOptions(opts...),
 	)
 	connectGatewayPingHandler := connect.NewUnaryHandler(
 		ConnectGatewayPingProcedure,
 		svc.Ping,
-		connect.WithSchema(connectGatewayPingMethodDescriptor),
+		connect.WithSchema(connectGatewayMethods.ByName("Ping")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/connect.v1.ConnectGateway/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -167,17 +159,18 @@ type ConnectExecutorClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewConnectExecutorClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) ConnectExecutorClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	connectExecutorMethods := v1.File_connect_v1_service_proto.Services().ByName("ConnectExecutor").Methods()
 	return &connectExecutorClient{
 		reply: connect.NewClient[v1.ReplyRequest, v1.ReplyResponse](
 			httpClient,
 			baseURL+ConnectExecutorReplyProcedure,
-			connect.WithSchema(connectExecutorReplyMethodDescriptor),
+			connect.WithSchema(connectExecutorMethods.ByName("Reply")),
 			connect.WithClientOptions(opts...),
 		),
 		ack: connect.NewClient[v1.AckMessage, v1.AckResponse](
 			httpClient,
 			baseURL+ConnectExecutorAckProcedure,
-			connect.WithSchema(connectExecutorAckMethodDescriptor),
+			connect.WithSchema(connectExecutorMethods.ByName("Ack")),
 			connect.WithClientOptions(opts...),
 		),
 		ping: connect.NewClient[v1.PingRequest, v1.PingResponse](
@@ -224,16 +217,17 @@ type ConnectExecutorHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewConnectExecutorHandler(svc ConnectExecutorHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	connectExecutorMethods := v1.File_connect_v1_service_proto.Services().ByName("ConnectExecutor").Methods()
 	connectExecutorReplyHandler := connect.NewUnaryHandler(
 		ConnectExecutorReplyProcedure,
 		svc.Reply,
-		connect.WithSchema(connectExecutorReplyMethodDescriptor),
+		connect.WithSchema(connectExecutorMethods.ByName("Reply")),
 		connect.WithHandlerOptions(opts...),
 	)
 	connectExecutorAckHandler := connect.NewUnaryHandler(
 		ConnectExecutorAckProcedure,
 		svc.Ack,
-		connect.WithSchema(connectExecutorAckMethodDescriptor),
+		connect.WithSchema(connectExecutorMethods.ByName("Ack")),
 		connect.WithHandlerOptions(opts...),
 	)
 	connectExecutorPingHandler := connect.NewUnaryHandler(

--- a/proto/gen/connect/v1/service.pb.go
+++ b/proto/gen/connect/v1/service.pb.go
@@ -409,10 +409,11 @@ const file_connect_v1_service_proto_rawDesc = "" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess2\x93\x01\n" +
 	"\x0eConnectGateway\x12D\n" +
 	"\aForward\x12\x1a.connect.v1.ForwardRequest\x1a\x1b.connect.v1.ForwardResponse\"\x00\x12;\n" +
-	"\x04Ping\x12\x17.connect.v1.PingRequest\x1a\x18.connect.v1.PingResponse\"\x002\x8b\x01\n" +
+	"\x04Ping\x12\x17.connect.v1.PingRequest\x1a\x18.connect.v1.PingResponse\"\x002\xc8\x01\n" +
 	"\x0fConnectExecutor\x12>\n" +
 	"\x05Reply\x12\x18.connect.v1.ReplyRequest\x1a\x19.connect.v1.ReplyResponse\"\x00\x128\n" +
-	"\x03Ack\x12\x16.connect.v1.AckMessage\x1a\x17.connect.v1.AckResponse\"\x00B9Z7github.com/inngest/inngest/proto/gen/connect/v1;connectb\x06proto3"
+	"\x03Ack\x12\x16.connect.v1.AckMessage\x1a\x17.connect.v1.AckResponse\"\x00\x12;\n" +
+	"\x04Ping\x12\x17.connect.v1.PingRequest\x1a\x18.connect.v1.PingResponse\"\x00B9Z7github.com/inngest/inngest/proto/gen/connect/v1;connectb\x06proto3"
 
 var (
 	file_connect_v1_service_proto_rawDescOnce sync.Once
@@ -448,12 +449,14 @@ var file_connect_v1_service_proto_depIdxs = []int32{
 	2,  // 4: connect.v1.ConnectGateway.Ping:input_type -> connect.v1.PingRequest
 	4,  // 5: connect.v1.ConnectExecutor.Reply:input_type -> connect.v1.ReplyRequest
 	6,  // 6: connect.v1.ConnectExecutor.Ack:input_type -> connect.v1.AckMessage
-	1,  // 7: connect.v1.ConnectGateway.Forward:output_type -> connect.v1.ForwardResponse
-	3,  // 8: connect.v1.ConnectGateway.Ping:output_type -> connect.v1.PingResponse
-	5,  // 9: connect.v1.ConnectExecutor.Reply:output_type -> connect.v1.ReplyResponse
-	7,  // 10: connect.v1.ConnectExecutor.Ack:output_type -> connect.v1.AckResponse
-	7,  // [7:11] is the sub-list for method output_type
-	3,  // [3:7] is the sub-list for method input_type
+	2,  // 7: connect.v1.ConnectExecutor.Ping:input_type -> connect.v1.PingRequest
+	1,  // 8: connect.v1.ConnectGateway.Forward:output_type -> connect.v1.ForwardResponse
+	3,  // 9: connect.v1.ConnectGateway.Ping:output_type -> connect.v1.PingResponse
+	5,  // 10: connect.v1.ConnectExecutor.Reply:output_type -> connect.v1.ReplyResponse
+	7,  // 11: connect.v1.ConnectExecutor.Ack:output_type -> connect.v1.AckResponse
+	3,  // 12: connect.v1.ConnectExecutor.Ping:output_type -> connect.v1.PingResponse
+	8,  // [8:13] is the sub-list for method output_type
+	3,  // [3:8] is the sub-list for method input_type
 	3,  // [3:3] is the sub-list for extension type_name
 	3,  // [3:3] is the sub-list for extension extendee
 	0,  // [0:3] is the sub-list for field type_name

--- a/proto/gen/connect/v1/service_grpc.pb.go
+++ b/proto/gen/connect/v1/service_grpc.pb.go
@@ -161,6 +161,7 @@ var ConnectGateway_ServiceDesc = grpc.ServiceDesc{
 const (
 	ConnectExecutor_Reply_FullMethodName = "/connect.v1.ConnectExecutor/Reply"
 	ConnectExecutor_Ack_FullMethodName   = "/connect.v1.ConnectExecutor/Ack"
+	ConnectExecutor_Ping_FullMethodName  = "/connect.v1.ConnectExecutor/Ping"
 )
 
 // ConnectExecutorClient is the client API for ConnectExecutor service.
@@ -169,6 +170,7 @@ const (
 type ConnectExecutorClient interface {
 	Reply(ctx context.Context, in *ReplyRequest, opts ...grpc.CallOption) (*ReplyResponse, error)
 	Ack(ctx context.Context, in *AckMessage, opts ...grpc.CallOption) (*AckResponse, error)
+	Ping(ctx context.Context, in *PingRequest, opts ...grpc.CallOption) (*PingResponse, error)
 }
 
 type connectExecutorClient struct {
@@ -199,12 +201,23 @@ func (c *connectExecutorClient) Ack(ctx context.Context, in *AckMessage, opts ..
 	return out, nil
 }
 
+func (c *connectExecutorClient) Ping(ctx context.Context, in *PingRequest, opts ...grpc.CallOption) (*PingResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(PingResponse)
+	err := c.cc.Invoke(ctx, ConnectExecutor_Ping_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ConnectExecutorServer is the server API for ConnectExecutor service.
 // All implementations must embed UnimplementedConnectExecutorServer
 // for forward compatibility.
 type ConnectExecutorServer interface {
 	Reply(context.Context, *ReplyRequest) (*ReplyResponse, error)
 	Ack(context.Context, *AckMessage) (*AckResponse, error)
+	Ping(context.Context, *PingRequest) (*PingResponse, error)
 	mustEmbedUnimplementedConnectExecutorServer()
 }
 
@@ -220,6 +233,9 @@ func (UnimplementedConnectExecutorServer) Reply(context.Context, *ReplyRequest) 
 }
 func (UnimplementedConnectExecutorServer) Ack(context.Context, *AckMessage) (*AckResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Ack not implemented")
+}
+func (UnimplementedConnectExecutorServer) Ping(context.Context, *PingRequest) (*PingResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Ping not implemented")
 }
 func (UnimplementedConnectExecutorServer) mustEmbedUnimplementedConnectExecutorServer() {}
 func (UnimplementedConnectExecutorServer) testEmbeddedByValue()                         {}
@@ -278,6 +294,24 @@ func _ConnectExecutor_Ack_Handler(srv interface{}, ctx context.Context, dec func
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ConnectExecutor_Ping_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(PingRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ConnectExecutorServer).Ping(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ConnectExecutor_Ping_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ConnectExecutorServer).Ping(ctx, req.(*PingRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // ConnectExecutor_ServiceDesc is the grpc.ServiceDesc for ConnectExecutor service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -292,6 +326,10 @@ var ConnectExecutor_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Ack",
 			Handler:    _ConnectExecutor_Ack_Handler,
+		},
+		{
+			MethodName: "Ping",
+			Handler:    _ConnectExecutor_Ping_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/gen/state/v2/statev2connect/state.connect.go
+++ b/proto/gen/state/v2/statev2connect/state.connect.go
@@ -56,21 +56,6 @@ const (
 	RunServiceLoadStateProcedure = "/state.v2.RunService/LoadState"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	runServiceServiceDescriptor              = v2.File_state_v2_state_proto.Services().ByName("RunService")
-	runServiceCreateMethodDescriptor         = runServiceServiceDescriptor.Methods().ByName("Create")
-	runServiceDeleteMethodDescriptor         = runServiceServiceDescriptor.Methods().ByName("Delete")
-	runServiceExistsMethodDescriptor         = runServiceServiceDescriptor.Methods().ByName("Exists")
-	runServiceUpdateMetadataMethodDescriptor = runServiceServiceDescriptor.Methods().ByName("UpdateMetadata")
-	runServiceSaveStepMethodDescriptor       = runServiceServiceDescriptor.Methods().ByName("SaveStep")
-	runServiceSavePendingMethodDescriptor    = runServiceServiceDescriptor.Methods().ByName("SavePending")
-	runServiceLoadMetadataMethodDescriptor   = runServiceServiceDescriptor.Methods().ByName("LoadMetadata")
-	runServiceLoadEventsMethodDescriptor     = runServiceServiceDescriptor.Methods().ByName("LoadEvents")
-	runServiceLoadStepsMethodDescriptor      = runServiceServiceDescriptor.Methods().ByName("LoadSteps")
-	runServiceLoadStateMethodDescriptor      = runServiceServiceDescriptor.Methods().ByName("LoadState")
-)
-
 // RunServiceClient is a client for the state.v2.RunService service.
 type RunServiceClient interface {
 	Create(context.Context, *connect.Request[v2.CreateStateRequest]) (*connect.Response[v2.CreateStateResponse], error)
@@ -94,65 +79,66 @@ type RunServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewRunServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) RunServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	runServiceMethods := v2.File_state_v2_state_proto.Services().ByName("RunService").Methods()
 	return &runServiceClient{
 		create: connect.NewClient[v2.CreateStateRequest, v2.CreateStateResponse](
 			httpClient,
 			baseURL+RunServiceCreateProcedure,
-			connect.WithSchema(runServiceCreateMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("Create")),
 			connect.WithClientOptions(opts...),
 		),
 		delete: connect.NewClient[v2.DeleteStateRequest, v2.DeleteStateResponse](
 			httpClient,
 			baseURL+RunServiceDeleteProcedure,
-			connect.WithSchema(runServiceDeleteMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("Delete")),
 			connect.WithClientOptions(opts...),
 		),
 		exists: connect.NewClient[v2.ExistsRequest, v2.ExistsResponse](
 			httpClient,
 			baseURL+RunServiceExistsProcedure,
-			connect.WithSchema(runServiceExistsMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("Exists")),
 			connect.WithClientOptions(opts...),
 		),
 		updateMetadata: connect.NewClient[v2.UpdateMetadataRequest, v2.UpdateMetadataResponse](
 			httpClient,
 			baseURL+RunServiceUpdateMetadataProcedure,
-			connect.WithSchema(runServiceUpdateMetadataMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("UpdateMetadata")),
 			connect.WithClientOptions(opts...),
 		),
 		saveStep: connect.NewClient[v2.SaveStepRequest, v2.SaveStepResponse](
 			httpClient,
 			baseURL+RunServiceSaveStepProcedure,
-			connect.WithSchema(runServiceSaveStepMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("SaveStep")),
 			connect.WithClientOptions(opts...),
 		),
 		savePending: connect.NewClient[v2.SavePendingRequest, v2.SavePendingResponse](
 			httpClient,
 			baseURL+RunServiceSavePendingProcedure,
-			connect.WithSchema(runServiceSavePendingMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("SavePending")),
 			connect.WithClientOptions(opts...),
 		),
 		loadMetadata: connect.NewClient[v2.LoadMetadataRequest, v2.LoadMetadataResponse](
 			httpClient,
 			baseURL+RunServiceLoadMetadataProcedure,
-			connect.WithSchema(runServiceLoadMetadataMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("LoadMetadata")),
 			connect.WithClientOptions(opts...),
 		),
 		loadEvents: connect.NewClient[v2.LoadEventsRequest, v2.LoadEventsResponse](
 			httpClient,
 			baseURL+RunServiceLoadEventsProcedure,
-			connect.WithSchema(runServiceLoadEventsMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("LoadEvents")),
 			connect.WithClientOptions(opts...),
 		),
 		loadSteps: connect.NewClient[v2.LoadStepsRequest, v2.LoadStepsResponse](
 			httpClient,
 			baseURL+RunServiceLoadStepsProcedure,
-			connect.WithSchema(runServiceLoadStepsMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("LoadSteps")),
 			connect.WithClientOptions(opts...),
 		),
 		loadState: connect.NewClient[v2.LoadStateRequest, v2.LoadStateResponse](
 			httpClient,
 			baseURL+RunServiceLoadStateProcedure,
-			connect.WithSchema(runServiceLoadStateMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("LoadState")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -242,64 +228,65 @@ type RunServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewRunServiceHandler(svc RunServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	runServiceMethods := v2.File_state_v2_state_proto.Services().ByName("RunService").Methods()
 	runServiceCreateHandler := connect.NewUnaryHandler(
 		RunServiceCreateProcedure,
 		svc.Create,
-		connect.WithSchema(runServiceCreateMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("Create")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceDeleteHandler := connect.NewUnaryHandler(
 		RunServiceDeleteProcedure,
 		svc.Delete,
-		connect.WithSchema(runServiceDeleteMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("Delete")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceExistsHandler := connect.NewUnaryHandler(
 		RunServiceExistsProcedure,
 		svc.Exists,
-		connect.WithSchema(runServiceExistsMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("Exists")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceUpdateMetadataHandler := connect.NewUnaryHandler(
 		RunServiceUpdateMetadataProcedure,
 		svc.UpdateMetadata,
-		connect.WithSchema(runServiceUpdateMetadataMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("UpdateMetadata")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceSaveStepHandler := connect.NewUnaryHandler(
 		RunServiceSaveStepProcedure,
 		svc.SaveStep,
-		connect.WithSchema(runServiceSaveStepMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("SaveStep")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceSavePendingHandler := connect.NewUnaryHandler(
 		RunServiceSavePendingProcedure,
 		svc.SavePending,
-		connect.WithSchema(runServiceSavePendingMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("SavePending")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceLoadMetadataHandler := connect.NewUnaryHandler(
 		RunServiceLoadMetadataProcedure,
 		svc.LoadMetadata,
-		connect.WithSchema(runServiceLoadMetadataMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("LoadMetadata")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceLoadEventsHandler := connect.NewUnaryHandler(
 		RunServiceLoadEventsProcedure,
 		svc.LoadEvents,
-		connect.WithSchema(runServiceLoadEventsMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("LoadEvents")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceLoadStepsHandler := connect.NewUnaryHandler(
 		RunServiceLoadStepsProcedure,
 		svc.LoadSteps,
-		connect.WithSchema(runServiceLoadStepsMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("LoadSteps")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceLoadStateHandler := connect.NewUnaryHandler(
 		RunServiceLoadStateProcedure,
 		svc.LoadState,
-		connect.WithSchema(runServiceLoadStateMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("LoadState")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/state.v2.RunService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Description

- Establish ad-hoc gRPC connections to executors
- Send buffered SDK response through gRPC when feature flag is enabled

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
