### PR TITLE
Fix viper data race by not mutating with `SetDefault`

### DIFF
--- a/pkg/config/connect/executor.go
+++ b/pkg/config/connect/executor.go
@@ -24,11 +24,8 @@ func Executor(ctx context.Context) ConnectExecutor {
 		ipKey := "connect.executor.grpc.ip"
 		portKey := "connect.executor.grpc.port"
 
-		viper.SetDefault(ipKey, getOutboundIP())
-		viper.SetDefault(portKey, 50053)
-
-		ipStr := viper.GetString(ipKey)
-		port := viper.GetUint32(portKey)
+		ipStr := getWithDefault(ipKey, getOutboundIP(), viper.GetString)
+		port := getWithDefault(portKey, uint32(50053), viper.GetUint32)
 
 		ip := net.ParseIP(ipStr)
 		if ip == nil {

--- a/pkg/config/connect/gateway.go
+++ b/pkg/config/connect/gateway.go
@@ -21,16 +21,20 @@ var (
 	configOnce    sync.Once
 )
 
+func getWithDefault[T any](key string, defaultValue T, getter func(string) T) T {
+	if viper.IsSet(key) {
+		return getter(key)
+	}
+	return defaultValue
+}
+
 func Gateway(ctx context.Context) ConnectGateway {
 	configOnce.Do(func() {
 		ipKey := "connect.gateway.grpc.ip"
 		portKey := "connect.gateway.grpc.port"
 
-		viper.SetDefault(ipKey, getOutboundIP())
-		viper.SetDefault(portKey, 50052)
-
-		ipStr := viper.GetString(ipKey)
-		port := viper.GetUint32(portKey)
+		ipStr := getWithDefault(ipKey, getOutboundIP(), viper.GetString)
+		port := getWithDefault(portKey, uint32(50052), viper.GetUint32)
 
 		ip := net.ParseIP(ipStr)
 		if ip == nil {

--- a/pkg/connect/pubsub/grpc_test.go
+++ b/pkg/connect/pubsub/grpc_test.go
@@ -612,7 +612,10 @@ func TestSubscribeUnsubscribe(t *testing.T) {
 
 		// But request2 should still work - start a goroutine to consume the message
 		var receivedResp2Retry *connectpb.SDKResponse
+		var wg2 sync.WaitGroup
+		wg2.Add(1)
 		go func() {
+			defer wg2.Done()
 			select {
 			case receivedResp2Retry = <-responseCh2:
 			case <-time.After(1 * time.Second):
@@ -626,8 +629,8 @@ func TestSubscribeUnsubscribe(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, resp2Retry.Success)
 
-		// Verify the second message was received
-		time.Sleep(100 * time.Millisecond)
+		// Wait for the second message to be received
+		wg2.Wait()
 		require.NotNil(t, receivedResp2Retry)
 		require.Equal(t, requestID2, receivedResp2Retry.RequestId)
 
@@ -717,7 +720,10 @@ func TestSubscribeUnsubscribeWorkerAck(t *testing.T) {
 
 		// But request2 should still work
 		var receivedAck2Retry *connectpb.AckMessage
+		var wg2 sync.WaitGroup
+		wg2.Add(1)
 		go func() {
+			defer wg2.Done()
 			select {
 			case receivedAck2Retry = <-ackCh2:
 			case <-time.After(1 * time.Second):
@@ -731,8 +737,8 @@ func TestSubscribeUnsubscribeWorkerAck(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, resp2Retry.Success)
 
-		// Verify the second ack was received
-		time.Sleep(100 * time.Millisecond)
+		// Wait for the second ack to be received
+		wg2.Wait()
 		require.NotNil(t, receivedAck2Retry)
 		require.Equal(t, requestID2, receivedAck2Retry.RequestId)
 


### PR DESCRIPTION
## Description

Avoiding to mutate viper's internal state and instead only relying on read-only APIs.


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
