### PR TITLE
remove ready queue instrumentation for key queue since it can cause confusion

### DIFF
--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -147,12 +146,6 @@ func (q *queue) StatusCount(ctx context.Context, workflowID uuid.UUID, status st
 
 func (q *queue) RunningCount(ctx context.Context, workflowID uuid.UUID) (int64, error) {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "RunningCount"), redis_telemetry.ScopeQueue)
-
-	l := q.log.With(
-		"method", "RunningCount",
-		"pkg", pkgName,
-		"fn_id", workflowID,
-	)
 
 	iterate := func(client *QueueClient) (int64, error) {
 		rc := client.unshardedRc


### PR DESCRIPTION
## Description

We can just continue using the run index for run count monitoring

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
