### PR TITLE
Add validation for signing key format in start command

### DIFF
--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/inngest/inngest/cmd/commands/internal/localconfig"
+	"github.com/inngest/inngest/pkg/authn"
 	"github.com/inngest/inngest/pkg/config"
 	"github.com/inngest/inngest/pkg/devserver"
 	"github.com/inngest/inngest/pkg/headers"
@@ -150,6 +151,11 @@ func doStart(cmd *cobra.Command, args []string) {
 	signingKey := viper.GetString("signing-key")
 	if signingKey == "" {
 		fmt.Println("Error: signing-key is required")
+		os.Exit(1)
+	}
+	_, err = authn.HashedSigningKey(signingKey)
+	if err != nil {
+		fmt.Printf("Error: signing-key must be a valid hexadecimal string\n")
 		os.Exit(1)
 	}
 

--- a/pkg/authn/signing_key_strategy.go
+++ b/pkg/authn/signing_key_strategy.go
@@ -61,7 +61,7 @@ func HandleSigningKey(ctx context.Context, clientProvidedKey string, trustedSign
 	normalizedTrustedKey := normalizeKey(trustedSigningKey)
 
 	// trusted key is provided in plain text, user can provide either plain text or hashed so we need to check against
-	hashedTrustedKey, _ := hashedSigningKey(normalizedTrustedKey)
+	hashedTrustedKey, _ := HashedSigningKey(normalizedTrustedKey)
 
 	// Check if client key matches either the plain text or hashed version
 	if subtle.ConstantTimeCompare([]byte(normalizedClientKey), []byte(normalizedTrustedKey)) == 1 ||
@@ -78,7 +78,7 @@ func normalizeKey(key string) string {
 	return keyRegexp.ReplaceAllString(key, "")
 }
 
-func hashedSigningKey(key string) (string, error) {
+func HashedSigningKey(key string) (string, error) {
 	key = normalizeKey(key)
 
 	dst := make([]byte, hex.DecodedLen(len(key)))

--- a/pkg/authn/signing_key_strategy_test.go
+++ b/pkg/authn/signing_key_strategy_test.go
@@ -12,7 +12,7 @@ import (
 func TestHandleSigningKey(t *testing.T) {
 	trustedKey := "signkey-test-abc123def456"
 	trustedKeyNormalized := "abc123def456"
-	hashedTrusted, err := hashedSigningKey(trustedKeyNormalized)
+	hashedTrusted, err := HashedSigningKey(trustedKeyNormalized)
 	require.NoError(t, err)
 
 	t.Run("should accept valid plain text key", func(t *testing.T) {
@@ -112,7 +112,7 @@ func TestSigningKeyMiddleware(t *testing.T) {
 	t.Run("should authenticate with hashed signing key", func(t *testing.T) {
 		middleware := SigningKeyMiddleware(&trustedKey)
 
-		hashedKey, err := hashedSigningKey("abc123def456")
+		hashedKey, err := HashedSigningKey("abc123def456")
 		require.NoError(t, err)
 
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -247,13 +247,13 @@ func TestNormalizeKey(t *testing.T) {
 func TestHashedSigningKey(t *testing.T) {
 	t.Run("should hash valid hex key", func(t *testing.T) {
 		key := "abc123def456"
-		hashed, err := hashedSigningKey(key)
+		hashed, err := HashedSigningKey(key)
 		require.NoError(t, err)
 		require.NotEmpty(t, hashed)
 		require.NotEqual(t, key, hashed)
 
 		// Hash should be deterministic
-		hashed2, err := hashedSigningKey(key)
+		hashed2, err := HashedSigningKey(key)
 		require.NoError(t, err)
 		require.Equal(t, hashed, hashed2)
 	})
@@ -262,10 +262,10 @@ func TestHashedSigningKey(t *testing.T) {
 		keyWithPrefix := "signkey-test-abc123def456"
 		keyWithoutPrefix := "abc123def456"
 
-		hashed1, err := hashedSigningKey(keyWithPrefix)
+		hashed1, err := HashedSigningKey(keyWithPrefix)
 		require.NoError(t, err)
 
-		hashed2, err := hashedSigningKey(keyWithoutPrefix)
+		hashed2, err := HashedSigningKey(keyWithoutPrefix)
 		require.NoError(t, err)
 
 		require.Equal(t, hashed1, hashed2)
@@ -273,12 +273,12 @@ func TestHashedSigningKey(t *testing.T) {
 
 	t.Run("should return error for invalid hex", func(t *testing.T) {
 		invalidHex := "xyz123"
-		_, err := hashedSigningKey(invalidHex)
+		_, err := HashedSigningKey(invalidHex)
 		require.Error(t, err)
 	})
 
 	t.Run("should handle empty string", func(t *testing.T) {
-		hashed, err := hashedSigningKey("")
+		hashed, err := HashedSigningKey("")
 		require.NoError(t, err)
 		require.NotEmpty(t, hashed)
 		// Empty string should produce a consistent hash


### PR DESCRIPTION
## Description

Add signing key validation and helper text with examples to `--signing-key` flag
<img width="1231" height="86" alt="image" src="https://github.com/user-attachments/assets/6c181930-bb6f-4615-aa21-5304ad0f576c" />


## Motivation
We were allowing any value to be used as a signing key but wiring up the authn middleware forces the key to flow through the hashing function which means the key format must match what is support in the cloud.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
