### PR TITLE
Parallelize normalization, fix inconsistencies

### DIFF
--- a/pkg/execution/state/redis_state/backlog_normalization.go
+++ b/pkg/execution/state/redis_state/backlog_normalization.go
@@ -21,9 +21,12 @@ import (
 )
 
 const (
-	NormalizeAccountPeekMax   = int64(30)
+	// NormalizeAccountPeekMax sets the maximum number of accounts that can be peeked from the global normalization index.
+	NormalizeAccountPeekMax = int64(30)
+	// NormalizePartitionPeekMax sets the maximum number of backlogs that can be peeked from the shadow partition.
 	NormalizePartitionPeekMax = int64(100)
-	NormalizeBacklogPeekMax   = int64(300) // same as ShadowPartitionPeekMax
+	// NormalizeBacklogPeekMax sets the maximum number of items that can be peeked from a backlog during normalization.
+	NormalizeBacklogPeekMax = int64(100) // same as ShadowPartitionPeekMax
 
 	// BacklogRefillHardLimit sets the maximum number of items that can be refilled in a single backlogRefill operation.
 	BacklogRefillHardLimit = int64(1000)
@@ -494,7 +497,7 @@ func (q *queue) BacklogNormalizePeek(ctx context.Context, b *QueueBacklog, limit
 		q:               q,
 		opName:          "BacklogNormalizePeek",
 		keyMetadataHash: q.primaryQueueShard.RedisClient.kg.QueueItem(),
-		max:             NormalizePartitionPeekMax,
+		max:             NormalizeBacklogPeekMax,
 		maker: func() *osqueue.QueueItem {
 			return &osqueue.QueueItem{}
 		},

--- a/pkg/execution/state/redis_state/backlog_normalization_test.go
+++ b/pkg/execution/state/redis_state/backlog_normalization_test.go
@@ -416,7 +416,7 @@ func TestBacklogNormalizeItem(t *testing.T) {
 	require.True(t, hasMember(t, r, kg.ShadowPartitionSet(sp.PartitionID), sourceBacklog.BacklogID))
 	require.True(t, hasMember(t, r, kg.BacklogSet(sourceBacklog.BacklogID), qi.ID))
 
-	normalizedItem, err := q.normalizeItem(ctx, defaultShard, &sp, &latestConstraints, &sourceBacklog, qi)
+	normalizedItem, err := q.normalizeItem(ctx, defaultShard, &sp, latestConstraints, &sourceBacklog, qi)
 	require.NoError(t, err)
 
 	qi.Data.CustomConcurrencyKeys = customConc

--- a/pkg/execution/state/redis_state/backlog_normalization_test.go
+++ b/pkg/execution/state/redis_state/backlog_normalization_test.go
@@ -379,8 +379,8 @@ func TestBacklogNormalizeItem(t *testing.T) {
 		WithRefreshItemThrottle(func(ctx context.Context, item *osqueue.QueueItem) (*osqueue.Throttle, error) {
 			return throttle, nil
 		}),
-		WithPartitionConstraintConfigGetter(func(ctx context.Context, p QueueShadowPartition) (*PartitionConstraintConfig, error) {
-			return &latestConstraints, nil
+		WithPartitionConstraintConfigGetter(func(ctx context.Context, p PartitionIdentifier) PartitionConstraintConfig {
+			return latestConstraints
 		}),
 		WithClock(clock),
 	)

--- a/pkg/execution/state/redis_state/lua/queue/enqueue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/enqueue.lua
@@ -100,7 +100,7 @@ if is_normalize then
   redis.call("ZREM", keyNormalizeFromBacklogSet, queueID)
 
   -- Clean up backlog pointers for old backlog
-  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyBacklogSet, keyPartitionNormalizeSet, accountID, partitionID, backlogID)
+  updateBacklogPointer(keyShadowPartitionMeta, keyBacklogMeta, keyGlobalShadowPartitionSet, keyGlobalAccountShadowPartitionSet, keyAccountShadowPartitionSet, keyShadowPartitionSet, keyNormalizeFromBacklogSet, keyPartitionNormalizeSet, accountID, partitionID, normalizeFromBacklogID)
 
   -- Clean up normalize pointers if backlog is empty
   if tonumber(redis.call("ZCARD", keyNormalizeFromBacklogSet)) == 0 then

--- a/pkg/execution/state/redis_state/lua/queue/enqueue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/enqueue.lua
@@ -69,9 +69,13 @@ if redis.call("EXISTS", idempotencyKey) ~= 0 and not is_normalize then
 end
 
 -- Make these a hash to save on memory usage
-if redis.call("HSETNX", queueKey, queueID, queueItem) == 0 and not is_normalize then
-  -- This already exists;  return an error.
-  return 1
+if redis.call("HSETNX", queueKey, queueID, queueItem) == 0 then
+  if is_normalize then
+    redis.call("HSET", queueKey, queueID, queueItem)
+  else
+    -- This already exists;  return an error.
+    return 1
+  end
 end
 
 -- Check if the item is a singleton and if an existing item already exists

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -496,38 +496,6 @@ func WithPeekEWMA(on bool) func(q *queue) {
 	}
 }
 
-// QueueItemConcurrencyKeyLimitRefresher returns concurrency keys with current limits given a queue item.
-//
-// Each queue item can have its own concurrency keys.  For example, you can define
-// concurrency limits for steps within a function.  This ensures that there will never be
-// more than N concurrent items running at once.
-type QueueItemConcurrencyKeyLimitRefresher func(ctx context.Context, i osqueue.QueueItem) []state.CustomConcurrency
-
-type PartitionConcurrencyLimits struct {
-	// AccountLimit returns the current account concurrency limit, which is always applied. Defaults to maximum concurrency.
-	AccountLimit int
-
-	// FunctionLimit returns the function-scoped concurrency limit, if configured. Defaults to maximum concurrency.
-	FunctionLimit int
-
-	// CustomKeyLimit returns the custom concurrency limit for a concurrency key partition. Defaults to maximum concurrency.
-	CustomKeyLimit int
-}
-
-type SystemPartitionConcurrencyLimits struct {
-	// GlobalLimit returns the account-level equivalent concurrency limit for system partitions, which is always applied. Defaults to maximum concurrency.
-	GlobalLimit int
-
-	// PartitionLimit returns the partition-scoped concurrency limit, if configured. Defaults to maximum concurrency.
-	PartitionLimit int
-}
-
-// ConcurrencyLimitGetter returns the fn, account, and custom limits for a given partition.
-type ConcurrencyLimitGetter func(ctx context.Context, p QueuePartition) PartitionConcurrencyLimits
-
-// SystemConcurrencyLimitGetter returns the concurrency limits for a given system partition.
-type SystemConcurrencyLimitGetter func(ctx context.Context, p QueuePartition) SystemPartitionConcurrencyLimits
-
 // PartitionConstraintConfigGetter returns the constraint configuration for a given partition
 type PartitionConstraintConfigGetter func(ctx context.Context, p PartitionIdentifier) PartitionConstraintConfig
 


### PR DESCRIPTION
## Description

This PR adds important normalization fixes

- Bug fix: Stop/exit normalization if lease expires: Prevent multiple workers from processing normalization at the same time.
   - Leftover question: Why does lease extension sometimes fail? Will this mean long normalizations are passed around workers?
- Performance: Perform normalization in parallel (to speed up process). This can be configured by providing the `WithBacklogNormalizationConcurrency` queue option
- Bug fix: Enqueue previously updated the _target backlog_, not the _source backlog_. This was an easy-to-miss typo where backlogID should have been `normalizeFromBacklogID`, same for the backlog set key. This is now fixed.
- Bug fix: Always update item in hash when normalizing. This ensures the new throttle and custom concurrency key configuration is properly reflected in the queue item hash.
- Bug fix: Simply use number of peeked items for counter metric, fix issue with increasing cumulative total which led to incorrect reporting (seemingly explosive normalization growth)

https://linear.app/inngest/issue/SYS-250

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
