### PR TITLE
share feature flags between cloud and dev server

### DIFF
--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -152,6 +152,23 @@ func (a devapi) Info(w http.ResponseWriter, r *http.Request) {
 		features[flag] = enabled
 	}
 
+	//
+	// inngest feature flags are a map of arbitrary key value
+	// pairs such that we can use the same feature flag names as cloud
+	if ffEnv := os.Getenv("INNGEST_FEATURE_FLAGS"); ffEnv != "" {
+		pairs := strings.Split(ffEnv, ",")
+		for _, pair := range pairs {
+			kv := strings.SplitN(strings.TrimSpace(pair), "=", 2)
+			if len(kv) == 2 {
+				key := strings.TrimSpace(kv[0])
+				valStr := strings.TrimSpace(kv[1])
+				if enabled, err := strconv.ParseBool(valStr); err == nil {
+					features[key] = enabled
+				}
+			}
+		}
+	}
+
 	ir := InfoResponse{
 		Version:             version.Print(),
 		StartOpts:           a.devserver.Opts,

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -162,8 +162,9 @@ func (a devapi) Info(w http.ResponseWriter, r *http.Request) {
 			if len(kv) == 2 {
 				key := strings.TrimSpace(kv[0])
 				valStr := strings.TrimSpace(kv[1])
-				if enabled, err := strconv.ParseBool(valStr); err == nil {
-					features[key] = enabled
+				if value, err := strconv.ParseBool(valStr); err == nil {
+					a.devserver.log.Info("setting feature flag", "key", key)
+					features[key] = value
 				}
 			}
 		}

--- a/ui/apps/dev-server-ui/README.md
+++ b/ui/apps/dev-server-ui/README.md
@@ -19,3 +19,20 @@ pnpm dev
 Edit or add your queries within `coreapi.ts` and the GraphQL Codegen should automatically create a hook to use in `store/generated.ts`.
 
 To force running the codegen run `pnpm dev:codegen`.
+
+## Feature flags
+
+You can pass feature flags to the dev server locally like so:
+
+```
+INNGEST_FEATURE_FLAGS="step-over-debugger=true,some-other-flag=false" go run ./cmd/main.go dev
+```
+
+Then, in shared components you can use the share `useBooleanFlag` hook and the flag will be checked in the appropriate place in either the dev server or cloud:
+
+```
+const { value, isReady } = booleanFlag(
+  'step-over-debugger',
+  false
+);
+```

--- a/ui/apps/dev-server-ui/src/app/SharedContextProvider.tsx
+++ b/ui/apps/dev-server-ui/src/app/SharedContextProvider.tsx
@@ -3,12 +3,12 @@ import {
   type SharedHandlers,
 } from '@inngest/components/SharedContext/SharedContext';
 
+import { useBooleanFlag } from '@/hooks/useBooleanFlag';
 import { useCancelRun } from '@/hooks/useCancelRun';
 import { useInvokeRun } from '@/hooks/useInvokeRun';
 import { useRerun } from '@/hooks/useRerun';
 import { useRerunFromStep } from '@/hooks/useRerunFromStep';
 import { useRun } from '@/hooks/useRun';
-import { useBooleanFlag } from '@/utils/featureFlags';
 import { pathCreator } from '@/utils/pathCreator';
 
 export const SharedContextProvider = ({ children }: { children: React.ReactNode }) => {

--- a/ui/apps/dev-server-ui/src/hooks/useBooleanFlag.ts
+++ b/ui/apps/dev-server-ui/src/hooks/useBooleanFlag.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import type { BooleanFlag } from '@inngest/components/SharedContext/useBooleanFlag.js';
+
+import { createDevServerURL } from './useFeatureFlags';
+
+export const useBooleanFlag = (flag: string, defaultValue: boolean = false): BooleanFlag => {
+  const [featureFlags, setFeatureFlags] = useState<Record<string, boolean>>({});
+  const [loading, setLoading] = useState(true);
+
+  const loadFeatureFlags = async () => {
+    try {
+      const response = await fetch(createDevServerURL('/dev'));
+      if (!response.ok) {
+        throw new Error('feature flag response not ok');
+      }
+      const data = await response.json();
+      setFeatureFlags(data.features || {});
+    } catch (err) {
+      console.error('error fetching feature flags', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => void loadFeatureFlags(), []);
+
+  return { isReady: !loading, value: featureFlags[flag] ?? defaultValue };
+};

--- a/ui/apps/dev-server-ui/src/hooks/useFeatureFlags.ts
+++ b/ui/apps/dev-server-ui/src/hooks/useFeatureFlags.ts
@@ -36,7 +36,7 @@ export function useFeatureFlags() {
  * Creates a Dev Server URL from a path. If Dev Server host is unknown, it
  * returns the path.
  */
-function createDevServerURL(path: string) {
+export function createDevServerURL(path: string) {
   const host = process.env.NEXT_PUBLIC_API_BASE_URL;
   if (!host) {
     return path;

--- a/ui/apps/dev-server-ui/src/utils/featureFlags.ts
+++ b/ui/apps/dev-server-ui/src/utils/featureFlags.ts
@@ -1,9 +1,0 @@
-import type { BooleanFlag } from '@inngest/components/SharedContext/useBooleanFlag.js';
-
-export const useBooleanFlag = (flag: string, defaultValue: boolean = false): BooleanFlag => {
-  if (flag === 'step-over-debugger') {
-    return { isReady: true, value: false };
-  }
-
-  return { isReady: true, value: defaultValue };
-};

--- a/ui/packages/components/src/SharedContext/SharedContext.tsx
+++ b/ui/packages/components/src/SharedContext/SharedContext.tsx
@@ -2,7 +2,6 @@
 
 import React, { createContext, useContext } from 'react';
 
-import type { Run } from '../RunsPage/types';
 import type { BooleanFlag } from './useBooleanFlag';
 import type { CancelRunPayload, CancelRunResult } from './useCancelRun';
 import type { GetRunPayload, GetRunResult } from './useGetRun';


### PR DESCRIPTION
## Description

Fleshes out our shared feature flag provider implementation for dev server such that you can use the same feature flag names from launchdarkly for the cloud in the dev server using env vars. 

If you have a launch darkly feature flag called `step-over-debugger`, you can do this in a shared component:

```
  const { value, isReady } = booleanFlag(
    'step-over-debugger',
    false
  );
```
And start the dev server like so locally:

`INNGEST_FEATURE_FLAGS="step-over-debugger=true,some-other-flag=false" go run ./cmd/main.go dev`


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
