### PR TITLE
use env.id as react key instead of index

### DIFF
--- a/ui/apps/dashboard/src/components/Environments/BranchEnvironmentListTable.tsx
+++ b/ui/apps/dashboard/src/components/Environments/BranchEnvironmentListTable.tsx
@@ -104,7 +104,7 @@ export default function BranchEnvironmentListTable({
                 </td>
               </tr>
             ) : (
-              visibleBranchEnvs.map((env, i) => <TableRow env={env} key={i} />)
+              visibleBranchEnvs.map((env) => <TableRow env={env} key={env.id} />)
             )}
           </tbody>
         </table>

--- a/ui/apps/dashboard/src/components/Environments/CustomEnvironmentListTable.tsx
+++ b/ui/apps/dashboard/src/components/Environments/CustomEnvironmentListTable.tsx
@@ -66,7 +66,7 @@ export function CustomEnvironmentListTable({
                 </td>
               </tr>
             ) : (
-              visibleCustomEnvs.map((env, i) => <TableRow env={env} key={i} />)
+              visibleCustomEnvs.map((env) => <TableRow env={env} key={env.id} />)
             )}
           </tbody>
         </table>


### PR DESCRIPTION
## Description

This uses a proper stable key instead of an array index to prevent possible React reconciliation errors. While these errors do not seem to be plausible today in practice, I ran into them while working on future changes. This change should prevent those issues from easily occurring in the future and is also just a best practice.

## Motivation

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
