### PR TITLE
Fix bug that kills the connect WS when polling happens fast

### DIFF
--- a/pkg/connect/rest/v0/workerapi.go
+++ b/pkg/connect/rest/v0/workerapi.go
@@ -216,36 +216,34 @@ func (cr *connectApiRouter) flushBuffer(w http.ResponseWriter, r *http.Request) 
 
 	if cr.ShouldUseGRPC(ctx, res.AccountID) {
 		ip, err := cr.ConnectRequestStateManager.GetExecutorIP(ctx, res.EnvID, reqBody.RequestId)
-		if err != nil {
-			// Likely because the request lease has expired
+		switch {
+		case err == nil:
+			executorIP := ip.String()
+			grpcURL := net.JoinHostPort(executorIP, fmt.Sprintf("%d", connectConfig.Executor(ctx).GRPCPort))
+			grpcClient, err := cr.grpcClientManager.GetOrCreateClient(ctx, executorIP, grpcURL)
+			if err != nil {
+				l.Error("could not create grpc client", "url", grpcURL, "err", err)
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "could not create grpc client")
+				_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "could not create grpc client"))
+				return
+			}
+			result, err := grpcClient.Reply(ctx, &connectpb.ReplyRequest{Data: reqBody})
+			if err != nil || !result.Success {
+				l.Error("could not notify executor to flush connect message", "err", err)
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "could not notify executor to flush connect sdk response")
+				_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "could not notify executor"))
+				return
+			}
+		case errors.Is(err, state.ErrExecutorNotFound):
+			l.Debug("executor not found in lease, reply was likely picked up by polling")
+		default:
 			l.Error("could not get executor IP", "err", err)
 			span.RecordError(err)
 			span.SetStatus(codes.Error, "could not get executor IP")
 
 			_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "could not get executor"))
-			return
-		}
-
-		executorIP := ip.String()
-		grpcURL := net.JoinHostPort(executorIP, fmt.Sprintf("%d", connectConfig.Executor(ctx).GRPCPort))
-
-		grpcClient, err := cr.grpcClientManager.GetOrCreateClient(ctx, executorIP, grpcURL)
-		if err != nil {
-			l.Error("could not create grpc client", "url", grpcURL, "err", err)
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "could not create grpc client")
-
-			_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "could not create grpc client"))
-			return
-		}
-
-		result, err := grpcClient.Reply(ctx, &connectpb.ReplyRequest{Data: reqBody})
-		if err != nil || !result.Success {
-			l.Error("could not notify executor to flush connect message", "err", err)
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "could not notify executor to flush connect sdk response")
-
-			_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 500, "could not notify executor"))
 			return
 		}
 

--- a/pkg/connect/state/request.go
+++ b/pkg/connect/state/request.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -23,6 +24,7 @@ var (
 	ErrRequestLeaseNotFound = fmt.Errorf("request not leased")
 
 	ErrResponseAlreadyBuffered = fmt.Errorf("response already buffered")
+	ErrExecutorNotFound        = fmt.Errorf("executor not found")
 )
 
 type Lease struct {
@@ -186,8 +188,8 @@ func (r *redisConnectionStateManager) GetExecutorIP(ctx context.Context, envID u
 	cmd := r.client.B().Get().Key(r.keyRequestLease(envID, requestID)).Build()
 
 	reply, err := r.client.Do(ctx, cmd).ToString()
-	if err != nil {
-		return nil, err
+	if errors.Is(err, rueidis.Nil) {
+		return nil, ErrExecutorNotFound
 	}
 
 	lease := Lease{}


### PR DESCRIPTION

## Description

Sometimes executors will poll at a precise moment and get the response faster than gRPC, what was happening in that case is that the lease gets cleaned up by the executor. The gateway fails to find the executor IP to get the right gRPC client and the ws connection gets killed because of the error.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
