### PR TITLE
Environments: increase branch environments table page size

### DIFF
--- a/ui/apps/dashboard/src/components/Environments/BranchEnvironmentListTable.tsx
+++ b/ui/apps/dashboard/src/components/Environments/BranchEnvironmentListTable.tsx
@@ -40,7 +40,7 @@ const EnableEnvironmentAutoArchiveDocument = graphql(`
   }
 `);
 
-const PER_PAGE = 5;
+const PER_PAGE = 10;
 
 type BranchEnvironmentListTableProps = {
   envs: Environment[];


### PR DESCRIPTION
## Description
This changes the page size for the branch envs table (but not the custom envs table) from 5 -> 10.

## Motivation
Branch envs tend to be more plentiful than custom envs.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
