### PR TITLE
Ignore order for TotalCount queries

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -908,13 +908,12 @@ func (w wrapper) GetEventsCount(ctx context.Context, accountID uuid.UUID, worksp
 
 	builder := newEventsQueryBuilder(ctx, opts)
 	filter := builder.filter
-	order := builder.order
+	// ignore builder.order for count queries, it will error on Postgres
 
 	sql, args, err := sq.Dialect(w.dialect()).
 		From("events").
 		Select(sq.COUNT("*").As("count")).
 		Where(filter...).
-		Order(order...).
 		ToSQL()
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
## Description

This generated the same query for sqlite/postgres
```sql
SELECT COUNT(*) AS `count` FROM `events` WHERE ((`received_at` <= ?) AND (`received_at` >= ?) AND (`internal_id` < ?)) ORDER BY `internal_id` DESC
```

However, Postgres was stricter about including `internal_id` in the ORDER BY

`ERROR: column "events.internal_id" must appear in the GROUP BY clause or be used in an aggregate function (SQLSTATE 42803):`

Since ORDER BY doesn't matter for counts, just ignore it


To test:

1. Download https://github.com/inngest/website/blob/17a1dfcad384b4c145543d4548c557b72065491b/public/files/docker-compose.yml
2. Comment out the inngest service in the docker-compose file
3. Start the self hosted server from `inngest/inngest` (this repo)
`INNGEST_EVENT_KEY=your_event_key_here INNGEST_SIGNING_KEY=01886E57 go run ./cmd/main.go start --postgres-uri postgresql://inngest:password@localhost:5432/inngest`
4. Start dev-server-ui and an inngest app with the same event/signing key
5. Go to events page at localhost:3000/events

## Motivation

Fix error on events page for self hosted

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
