### PR TITLE
Allow setting an end time for fresh spans

### DIFF
--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -48,6 +48,7 @@ type CreateSpanOptions struct {
 	QueueItem          *queue.Item
 	RawOtelSpanOptions []trace.SpanStartOption
 	StartTime          time.Time
+	EndTime            time.Time
 }
 
 type UpdateSpanOptions struct {
@@ -143,6 +144,9 @@ func (tp *otelTracerProvider) CreateDroppableSpan(
 		if opts.Debug.Location != "" {
 			meta.AddAttr(attrs, meta.Attrs.InternalLocation, &opts.Debug.Location)
 		}
+	}
+	if !opts.EndTime.IsZero() {
+		meta.AddAttr(attrs, meta.Attrs.EndedAt, &opts.EndTime)
 	}
 
 	spanOptions := append(


### PR DESCRIPTION
## Description

Allow folks to set an end time for spans via the top-level API, which internally sets the correct attribute.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

In cases where we're recording spans retroactively, it's required that we specifically set the start and end times. We can totally set the attribute manually, but this just keeps it nice and explicit.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
