### PR TITLE
embed some inngest status info in run trace errors

### DIFF
--- a/ui/apps/dashboard/src/app/SharedContextProvider.tsx
+++ b/ui/apps/dashboard/src/app/SharedContextProvider.tsx
@@ -12,6 +12,7 @@ import { useInvokeRun } from '@/queries/useInvokeRun';
 import { useRerun } from '@/queries/useRerun';
 import { useRerunFromStep } from '@/queries/useRerunFromStep';
 import { usePathCreator } from '@/utils/usePathCreator';
+import { useSystemStatus } from './(organization-active)/support/statusPage';
 
 export const SharedContextProvider = ({ children }: { children: React.ReactNode }) => {
   const rerunFromStep = useRerunFromStep();
@@ -20,6 +21,7 @@ export const SharedContextProvider = ({ children }: { children: React.ReactNode 
   const cancelRun = useCancelRun();
   const pathCreator = usePathCreator();
   const getRun = useGetRun();
+  const status = useSystemStatus();
 
   const handlers: Partial<SharedHandlers> = {
     invokeRun,
@@ -30,6 +32,7 @@ export const SharedContextProvider = ({ children }: { children: React.ReactNode 
     booleanFlag: useBooleanFlag,
     pathCreator,
     getRun,
+    inngestStatus: status,
   };
 
   return <SharedProvider handlers={handlers}>{children}</SharedProvider>;

--- a/ui/apps/dashboard/src/components/Support/Status.tsx
+++ b/ui/apps/dashboard/src/components/Support/Status.tsx
@@ -1,9 +1,11 @@
+import {
+  impactSchema,
+  type Indicator,
+  type InngestStatus as Status,
+} from '@inngest/components/SharedContext/useInngestStatus';
 import { z } from 'zod';
 
-const impactSchema = z.enum(['partial_outage', 'degraded_performance', 'full_outage']);
-
-const indicatorSchema = z.enum(['none', 'maintenance', ...impactSchema.options]);
-type Indicator = z.infer<typeof indicatorSchema>;
+export type { Status };
 
 const statusEventSchema = z.object({
   id: z.string(),
@@ -44,14 +46,6 @@ const statusPageSummaryResponseSchema = z.object({
   in_progress_maintenances: z.array(maintenanceInProgressEventSchema),
   scheduled_maintenances: z.array(maintenanceScheduledEventSchema),
 });
-
-export type Status = {
-  url: string;
-  description: string;
-  impact: Indicator;
-  indicatorColor: string;
-  updated_at: string;
-};
 
 const impactMessage: { [K in Indicator]: string } = {
   none: 'All systems operational',

--- a/ui/apps/dashboard/src/gql/graphql.ts
+++ b/ui/apps/dashboard/src/gql/graphql.ts
@@ -105,10 +105,27 @@ export type AddonMulti = {
 export type Addons = {
   __typename?: 'Addons';
   accountID: Maybe<Scalars['UUID']>;
+  advancedObservability: AdvancedObservabilityAddon;
   concurrency: Addon;
   hipaa: Addon;
   planID: Maybe<Scalars['UUID']>;
   userCount: Addon;
+};
+
+export type AdvancedObservabilityAddon = {
+  __typename?: 'AdvancedObservabilityAddon';
+  available: Scalars['Boolean'];
+  entitlements: AdvancedObservabilityEntitlements;
+  name: Scalars['String'];
+  price: Maybe<Scalars['Int']>;
+  purchased: Scalars['Boolean'];
+};
+
+export type AdvancedObservabilityEntitlements = {
+  __typename?: 'AdvancedObservabilityEntitlements';
+  history: EntitlementInt;
+  metricsExportFreshness: EntitlementInt;
+  metricsExportGranularity: EntitlementInt;
 };
 
 export type App = {

--- a/ui/apps/dev-server-ui/src/app/SharedContextProvider.tsx
+++ b/ui/apps/dev-server-ui/src/app/SharedContextProvider.tsx
@@ -27,6 +27,7 @@ export const SharedContextProvider = ({ children }: { children: React.ReactNode 
     booleanFlag: useBooleanFlag,
     cloud: false,
     getRun,
+    inngestStatus: null,
   };
 
   return <SharedProvider handlers={handlers}>{children}</SharedProvider>;

--- a/ui/packages/components/src/RunDetailsV3/ErrorInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/ErrorInfo.tsx
@@ -1,0 +1,100 @@
+import { createColumnHelper } from '@tanstack/react-table';
+
+import { useShared } from '../SharedContext/SharedContext';
+import type { InngestStatus } from '../SharedContext/useInngestStatus';
+import { getStatusBackgroundClass, getStatusTextClass } from '../Status/statusClasses';
+import NewTable from '../Table/NewTable';
+
+type ErrorTable = {
+  system: string;
+  status: string;
+};
+
+type ErrorInfoProps = {
+  error: string;
+};
+
+const InngestStatus = ({ inngestStatus }: { inngestStatus: InngestStatus | null }) =>
+  inngestStatus && (
+    <a
+      href={inngestStatus.url}
+      target="_blank"
+      className="hover:text-link bg-canvasBase hover:bg-canvasMuted text-basis flex items-center gap-2 rounded text-sm"
+    >
+      <span
+        className={'mx-1 inline-flex h-2.5 w-2.5 rounded-full'}
+        style={{ backgroundColor: inngestStatus.indicatorColor }}
+      ></span>
+      {inngestStatus.description}
+    </a>
+  );
+
+const VercelStatus = ({ inngestStatus }: { inngestStatus: InngestStatus | null }) =>
+  inngestStatus && (
+    <a
+      href={inngestStatus.url}
+      target="_blank"
+      className="hover:text-link bg-canvasBase hover:bg-canvasMuted text-basis flex items-center gap-2 rounded text-sm"
+    >
+      <div
+        className={'mx-1 inline-flex h-2.5 w-2.5 rounded-full'}
+        style={{ backgroundColor: inngestStatus.indicatorColor }}
+      />
+      {inngestStatus.description}
+    </a>
+  );
+
+const SDKError = ({ error }: ErrorInfoProps) => (
+  <div className={`flex items-center gap-2 rounded text-sm ${getStatusTextClass('FAILED')}`}>
+    <div
+      className={`mx-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full ${getStatusBackgroundClass(
+        'FAILED'
+      )}`}
+    />
+    <div className="min-w-0 overflow-x-auto whitespace-nowrap">{error}</div>
+  </div>
+);
+
+export const ErrorInfo = ({ error }: ErrorInfoProps) => {
+  const { inngestStatus, cloud } = useShared();
+  const columnHelper = createColumnHelper<ErrorTable>();
+
+  const columns = [
+    columnHelper.accessor('system', {
+      cell: (info) => {
+        const system = info.getValue();
+        return <span className="text-muted text-sm leading-tight">{system}</span>;
+      },
+      header: 'System',
+      size: 25,
+      enableSorting: false,
+    }),
+    columnHelper.accessor('status', {
+      cell: (row) => {
+        const system = row.row.original.system;
+
+        return system === 'Inngest' ? (
+          <InngestStatus inngestStatus={inngestStatus} />
+        ) : system === 'Vercel' ? null : ( // <VercelStatus inngestStatus={inngestStatus} />
+          <SDKError error={error} />
+        );
+      },
+      header: 'Status',
+      enableSorting: false,
+    }),
+  ];
+
+  return (
+    cloud && (
+      <div>
+        <NewTable
+          data={[
+            { system: 'Inngest', status: '' },
+            { system: 'SDK', status: '' },
+          ]}
+          columns={columns}
+        />
+      </div>
+    )
+  );
+};

--- a/ui/packages/components/src/RunDetailsV3/ErrorInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/ErrorInfo.tsx
@@ -86,7 +86,7 @@ export const ErrorInfo = ({ error }: ErrorInfoProps) => {
 
   return (
     cloud && (
-      <div>
+      <div className="my-2">
         <NewTable
           data={[
             { system: 'Inngest', status: '' },

--- a/ui/packages/components/src/RunDetailsV3/IO.tsx
+++ b/ui/packages/components/src/RunDetailsV3/IO.tsx
@@ -1,4 +1,5 @@
 import { CodeBlock, type CodeBlockAction } from '../CodeBlock';
+import { NewCodeBlock } from '../NewCodeBlock/NewCodeBlock';
 
 export type IOProps = {
   title: string;
@@ -8,17 +9,18 @@ export type IOProps = {
   loading?: boolean;
 };
 
-export const IO = ({ title, actions, raw, error }: IOProps) => {
+export const IO = ({ title, actions, raw, error, loading }: IOProps) => {
   return (
-    <div className="text-muted h-full overflow-y-scroll" onWheel={(e) => e.stopPropagation()}>
-      <CodeBlock
+    <div className="text-muted bg-codeEditor h-full">
+      <NewCodeBlock
         actions={actions}
         header={{ title, ...(error && { status: 'error' }) }}
         tab={{
           content: raw ?? 'Unknown',
         }}
-        alwaysFullHeight={true}
         allowFullScreen={true}
+        parsed={false}
+        loading={loading}
       />
     </div>
   );

--- a/ui/packages/components/src/RunDetailsV3/IO.tsx
+++ b/ui/packages/components/src/RunDetailsV3/IO.tsx
@@ -5,6 +5,7 @@ export type IOProps = {
   actions?: CodeBlockAction[];
   raw?: string;
   error?: boolean;
+  loading?: boolean;
 };
 
 export const IO = ({ title, actions, raw, error }: IOProps) => {

--- a/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
+++ b/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
@@ -212,8 +212,12 @@ export const RunDetailsV3 = (props: Props) => {
         </div>
 
         <div
-          className="border-muted flex flex-col justify-start"
-          style={{ width: `${100 - leftWidth}%`, height: standalone ? '85vh' : height }}
+          className="border-muted sticky top-0 flex flex-col justify-start overflow-y-auto"
+          style={{
+            width: `${100 - leftWidth}%`,
+            height: standalone ? '85vh' : height,
+            alignSelf: 'flex-start',
+          }}
         >
           {selectedStep && !selectedStep.trace.isRoot ? (
             <StepInfo

--- a/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
+++ b/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
@@ -45,7 +45,7 @@ type Run = {
   hasAI: boolean;
 };
 
-const MIN_HEIGHT = 550;
+const MIN_HEIGHT = 586;
 
 export const RunDetailsV3 = (props: Props) => {
   const containerRef = useRef<HTMLDivElement>(null);

--- a/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
+++ b/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
@@ -56,6 +56,7 @@ export const RunDetailsV3 = (props: Props) => {
   const [leftWidth, setLeftWidth] = useState(55);
   const [height, setHeight] = useState(MIN_HEIGHT);
   const [isDragging, setIsDragging] = useState(false);
+  const [windowHeight, setWindowHeight] = useState(0);
   const { selectedStep } = useStepSelection(runID);
 
   const handleMouseDown = useCallback(() => {
@@ -83,6 +84,20 @@ export const RunDetailsV3 = (props: Props) => {
     },
     [isDragging]
   );
+
+  useEffect(() => {
+    setWindowHeight(window.innerHeight);
+
+    const handleResize = () => {
+      setWindowHeight(window.innerHeight);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   useLayoutEffect(() => {
     if (!leftColumnRef.current) {
@@ -153,6 +168,10 @@ export const RunDetailsV3 = (props: Props) => {
   const waiting = props.initialRunData?.status === 'QUEUED' && noSpansFoundError;
   const showError = waiting ? false : runRes.error || resultRes.error;
 
+  //
+  // works around a variety of layout and scroll issues with our two column layout
+  const dynamicHeight = height < windowHeight * 0.85 ? height : '85vh';
+
   return (
     <>
       {standalone && run && (
@@ -215,7 +234,7 @@ export const RunDetailsV3 = (props: Props) => {
           className="border-muted sticky top-0 flex flex-col justify-start overflow-y-auto"
           style={{
             width: `${100 - leftWidth}%`,
-            height: standalone ? '85vh' : height,
+            height: dynamicHeight,
             alignSelf: 'flex-start',
           }}
         >

--- a/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
@@ -17,6 +17,7 @@ import { Time } from '../Time';
 import { usePrettyErrorBody, usePrettyJson } from '../hooks/usePrettyJson';
 import type { Result } from '../types/functionRun';
 import { formatMilliseconds, toMaybeDate } from '../utils/date';
+import { ErrorInfo } from './ErrorInfo';
 import { IO } from './IO';
 import { Tabs } from './Tabs';
 import { UserlandAttrs } from './UserlandAttrs';
@@ -134,15 +135,23 @@ export const StepInfo = ({
   const [rerunModalOpen, setRerunModalOpen] = useState(false);
   const { runID, trace } = selectedStep;
   const [result, setResult] = useState<Result>();
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     let intervalId: ReturnType<typeof setInterval> | undefined;
 
-    const refreshResult = () => {
-      if (trace.outputID) {
-        getResult(trace.outputID).then(setResult);
-      } else {
-        setResult(undefined);
+    const refreshResult = async () => {
+      try {
+        setLoading(true);
+        if (trace.outputID) {
+          setResult(await getResult(trace.outputID));
+        } else {
+          setResult(undefined);
+        }
+      } catch (error) {
+        console.error('error loading step result', error);
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -195,7 +204,7 @@ export const StepInfo = ({
   const prettyErrorBody = usePrettyErrorBody(result?.error);
 
   return (
-    <div className="sticky top-14 flex flex-col justify-start gap-2 overflow-hidden">
+    <div className="sticky top-14 flex h-full flex-col justify-start gap-2">
       <div className="flex min-h-11 w-full flex-row items-center justify-between border-none px-4">
         <div
           className="text-basis flex cursor-pointer items-center justify-start gap-2"
@@ -272,46 +281,50 @@ export const StepInfo = ({
       {trace.isUserland && trace.userlandSpan ? (
         <UserlandAttrs userlandSpan={trace.userlandSpan} />
       ) : (
-        <Tabs
-          defaultActive={result?.error ? 'error' : prettyInput ? 'input' : 'output'}
-          tabs={[
-            ...(prettyInput
-              ? [
-                  {
-                    label: 'Input',
-                    id: 'input',
-                    node: <IO title="Step Input" raw={prettyInput} />,
-                  },
-                ]
-              : []),
-            ...(prettyOutput
-              ? [
-                  {
-                    label: 'Output',
-                    id: 'output',
-                    node: <IO title="Step Output" raw={prettyOutput} />,
-                  },
-                ]
-              : []),
-            ...(result?.error
-              ? [
-                  {
-                    label: 'Error',
-                    id: 'error',
-                    node: (
-                      <IO
-                        title={`${result.error.name || 'Error'} ${
-                          result.error.message ? `: ${result.error.message}` : ''
-                        }`}
-                        raw={prettyErrorBody ?? ''}
-                        error={true}
-                      />
-                    ),
-                  },
-                ]
-              : []),
-          ]}
-        />
+        <>
+          {result?.error && <ErrorInfo error={result.error.message || 'Unknown error'} />}
+          <div className="flex-1">
+            <Tabs
+              defaultActive={result?.error ? 'error' : 'output'}
+              tabs={[
+                ...(prettyInput
+                  ? [
+                      {
+                        label: 'Input',
+                        id: 'input',
+                        node: <IO title="Step Input" raw={prettyInput} loading={loading} />,
+                      },
+                    ]
+                  : []),
+                ...(prettyOutput
+                  ? [
+                      {
+                        label: 'Output',
+                        id: 'output',
+                        node: <IO title="Step Output" raw={prettyOutput} loading={loading} />,
+                      },
+                    ]
+                  : []),
+                ...(result?.error
+                  ? [
+                      {
+                        label: 'Error details',
+                        id: 'error',
+                        node: (
+                          <IO
+                            title={result.error.message || 'Unknown error'}
+                            raw={prettyErrorBody ?? ''}
+                            error={true}
+                            loading={loading}
+                          />
+                        ),
+                      },
+                    ]
+                  : []),
+              ]}
+            />
+          </div>
+        </>
       )}
     </div>
   );

--- a/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
@@ -204,7 +204,7 @@ export const StepInfo = ({
   const prettyErrorBody = usePrettyErrorBody(result?.error);
 
   return (
-    <div className="sticky top-14 flex h-full flex-col justify-start gap-2">
+    <div className="flex h-full flex-col justify-start gap-2">
       <div className="flex min-h-11 w-full flex-row items-center justify-between border-none px-4">
         <div
           className="text-basis flex cursor-pointer items-center justify-start gap-2"

--- a/ui/packages/components/src/RunDetailsV3/Tabs.tsx
+++ b/ui/packages/components/src/RunDetailsV3/Tabs.tsx
@@ -49,19 +49,20 @@ export const Tabs = ({ tabs, defaultActive = '' }: { tabs: TabsType; defaultActi
           </Tab>
         ))}
       </div>
-      <div className="relative">
-        {tabs.map((tab, i) => (
-          <div
-            key={`content-${i}`}
-            className={`w-full ${
-              active === tab.id || (active == '' && i === 0)
-                ? 'visible opacity-100'
-                : 'invisible h-0 opacity-0'
-            }`}
-          >
-            {tab.node}
-          </div>
-        ))}
+      <div className="relative h-full overflow-y-auto">
+        {tabs.map((tab, i) => {
+          const tabActive = active === tab.id || (active == '' && i === 0);
+          return (
+            <div
+              key={`content-${i}`}
+              className={`w-full ${
+                tabActive ? 'visible h-full opacity-100' : 'invisible h-0 opacity-0'
+              }`}
+            >
+              {tabActive && tab.node}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/ui/packages/components/src/RunDetailsV3/Tabs.tsx
+++ b/ui/packages/components/src/RunDetailsV3/Tabs.tsx
@@ -37,7 +37,7 @@ export const Tabs = ({ tabs, defaultActive = '' }: { tabs: TabsType; defaultActi
   }, [defaultActive]);
 
   return (
-    <div className="flex w-full flex-col">
+    <div className="flex h-full w-full flex-col">
       <div className="border-muted flex w-full flex-row gap-4 border-b px-4">
         {tabs.map((t: TabType, i: number) => (
           <Tab

--- a/ui/packages/components/src/RunDetailsV3/TopInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/TopInfo.tsx
@@ -130,7 +130,7 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
   }
 
   return (
-    <div className="sticky top-14 flex h-full flex-col justify-start gap-2 overflow-hidden">
+    <div className="flex h-full flex-col justify-start gap-2 overflow-hidden">
       <div className="flex h-11 w-full flex-row items-center justify-between border-none px-4 pt-2">
         <div
           className="text-basis flex cursor-pointer items-center justify-start gap-2"

--- a/ui/packages/components/src/RunDetailsV3/TopInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/TopInfo.tsx
@@ -20,6 +20,7 @@ import { usePrettyErrorBody, usePrettyJson } from '../hooks/usePrettyJson';
 import { IconCloudArrowDown } from '../icons/CloudArrowDown';
 import type { Result } from '../types/functionRun';
 import { devServerURL, useDevServer } from '../utils/useDevServer';
+import { ErrorInfo } from './ErrorInfo';
 import { IO } from './IO';
 import { Tabs } from './Tabs';
 
@@ -239,8 +240,12 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
           )}
         </div>
       )}
-
-      <div className="">
+      {result?.error && (
+        <div>
+          <ErrorInfo error={result.error.message || 'Unknown error'} />
+        </div>
+      )}
+      <div>
         <Tabs
           defaultActive={result?.error ? 'error' : prettyPayload ? 'input' : 'output'}
           tabs={[
@@ -250,7 +255,12 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
                     label: 'Input',
                     id: 'input',
                     node: (
-                      <IO title="Function Payload" raw={prettyPayload} actions={codeBlockActions} />
+                      <IO
+                        title="Function Payload"
+                        raw={prettyPayload}
+                        actions={codeBlockActions}
+                        loading={isPending}
+                      />
                     ),
                   },
                 ]
@@ -260,7 +270,7 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
                   {
                     label: 'Output',
                     id: 'output',
-                    node: <IO title="Output" raw={prettyOutput} />,
+                    node: <IO title="Output" raw={prettyOutput} loading={isPending} />,
                   },
                 ]
               : []),
@@ -276,6 +286,7 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
                         }`}
                         raw={prettyErrorBody ?? ''}
                         error={true}
+                        loading={isPending}
                       />
                     ),
                   },

--- a/ui/packages/components/src/RunDetailsV3/TopInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/TopInfo.tsx
@@ -130,7 +130,7 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
   }
 
   return (
-    <div className="sticky top-14 flex flex-col justify-start gap-2 overflow-hidden">
+    <div className="sticky top-14 flex h-full flex-col justify-start gap-2 overflow-hidden">
       <div className="flex h-11 w-full flex-row items-center justify-between border-none px-4 pt-2">
         <div
           className="text-basis flex cursor-pointer items-center justify-start gap-2"
@@ -240,12 +240,8 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
           )}
         </div>
       )}
-      {result?.error && (
-        <div>
-          <ErrorInfo error={result.error.message || 'Unknown error'} />
-        </div>
-      )}
-      <div>
+      {result?.error && <ErrorInfo error={result.error.message || 'Unknown error'} />}
+      <div className="flex-1">
         <Tabs
           defaultActive={result?.error ? 'error' : prettyPayload ? 'input' : 'output'}
           tabs={[
@@ -277,13 +273,11 @@ export const TopInfo = ({ slug, getTrigger, runID, result }: TopInfoProps) => {
             ...(result?.error
               ? [
                   {
-                    label: 'Error',
+                    label: 'Error details',
                     id: 'error',
                     node: (
                       <IO
-                        title={`${result.error.name || 'Error'} ${
-                          result.error.message ? `: ${result.error.message}` : ''
-                        }`}
+                        title={result.error.message || 'Unknown error'}
                         raw={prettyErrorBody ?? ''}
                         error={true}
                         loading={isPending}

--- a/ui/packages/components/src/SharedContext/SharedContext.tsx
+++ b/ui/packages/components/src/SharedContext/SharedContext.tsx
@@ -5,6 +5,7 @@ import React, { createContext, useContext } from 'react';
 import type { BooleanFlag } from './useBooleanFlag';
 import type { CancelRunPayload, CancelRunResult } from './useCancelRun';
 import type { GetRunPayload, GetRunResult } from './useGetRun';
+import type { InngestStatus } from './useInngestStatus';
 import type { InvokeRunPayload, InvokeRunResult } from './useInvokeRun';
 import type { PathCreator } from './usePathCreator';
 import type { RerunPayload, RerunResult } from './useRerun';
@@ -20,6 +21,7 @@ export type SharedDefinitions = {
   rerun: (payload: RerunPayload) => Promise<RerunResult>;
   cancelRun: (payload: CancelRunPayload) => Promise<CancelRunResult>;
   booleanFlag: (flag: string, defaultValue?: boolean) => BooleanFlag;
+  inngestStatus: InngestStatus | null;
   pathCreator: PathCreator;
   cloud: boolean;
 };

--- a/ui/packages/components/src/SharedContext/useInngestStatus.ts
+++ b/ui/packages/components/src/SharedContext/useInngestStatus.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+
+import { useShared } from './SharedContext';
+
+export const impactSchema = z.enum(['partial_outage', 'degraded_performance', 'full_outage']);
+export const indicatorSchema = z.enum(['none', 'maintenance', ...impactSchema.options]);
+export type Indicator = z.infer<typeof indicatorSchema>;
+
+export type InngestStatus = {
+  url: string;
+  description: string;
+  impact: Indicator;
+  indicatorColor: string;
+  updated_at: string;
+};
+
+export const useRerun = () => {
+  const shared = useShared();
+  const inngestStatus = (): InngestStatus | null => shared.inngestStatus;
+
+  return {
+    inngestStatus,
+  };
+};


### PR DESCRIPTION
Implement new error/status widget ux in run traces.  Designs here: https://www.figma.com/design/EhzN868tU8eGzuEdJpYp4O/Traces?node-id=5483-11197&m=dev

Incidentally adds loading states, improves error display in the code block and fixes a bunch layout issues by pulling in the new code editor and sledgehammering some dynamic rezie scenarios. 

## Description
<img width="592" height="556" alt="Screenshot 2025-07-23 at 1 12 44 PM" src="https://github.com/user-attachments/assets/8f15abc9-66c3-490e-8959-669a1e0e5255" />

<img width="968" height="552" alt="Screenshot 2025-07-23 at 1 13 00 PM" src="https://github.com/user-attachments/assets/09fc8700-995e-4c8a-87b0-8bdc7508f23d" />

<img width="597" height="324" alt="Screenshot 2025-07-23 at 1 09 00 PM" src="https://github.com/user-attachments/assets/8c15364b-a54b-41a2-9b01-59383fa3a52f" />



## Motivation
Help reduce a lot of support calls where users assume Inngest is down when a run errors.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
