### PR TITLE
Enhance PORT environment variable handling to support TCP URLs

### DIFF
--- a/cmd/commands/dev.go
+++ b/cmd/commands/dev.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/inngest/inngest/pkg/devserver"
 	"github.com/inngest/inngest/pkg/headers"
 	itrace "github.com/inngest/inngest/pkg/telemetry/trace"
+	"github.com/inngest/inngest/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -110,7 +110,7 @@ func doDev(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	port, err := strconv.Atoi(viper.GetString("port"))
+	port, err := util.ParsePort(viper.GetString("port"))
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/cmd/commands/start.go
+++ b/cmd/commands/start.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/inngest/inngest/cmd/commands/internal/localconfig"
@@ -12,6 +11,7 @@ import (
 	"github.com/inngest/inngest/pkg/devserver"
 	"github.com/inngest/inngest/pkg/headers"
 	itrace "github.com/inngest/inngest/pkg/telemetry/trace"
+	"github.com/inngest/inngest/pkg/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -102,7 +102,7 @@ func doStart(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	port, err := strconv.Atoi(viper.GetString("port"))
+	port, err := util.ParsePort(viper.GetString("port"))
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/pkg/devserver/discovery/discovery.go
+++ b/pkg/devserver/discovery/discovery.go
@@ -61,8 +61,9 @@ var (
 func init() {
 	// Use the PORT env variable, if defined.
 	if ps := os.Getenv("PORT"); ps != "" {
-		num, _ := strconv.Atoi(ps)
-		Ports = append(Ports, num)
+		if num, err := util.ParsePort(ps); err == nil {
+			Ports = append(Ports, num)
+		}
 	}
 }
 

--- a/pkg/util/port.go
+++ b/pkg/util/port.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+)
+
+// ParsePort parses a port string that can be either a plain port number
+// or a TCP URL (e.g., "tcp://192.168.194.165:8288")
+func ParsePort(ps string) (int, error) {
+	if ps == "" {
+		return 0, fmt.Errorf("port cannot be empty")
+	}
+
+	// Handle both plain port numbers and TCP URLs
+	if u, err := url.Parse(ps); err == nil && u.Scheme != "" {
+		// Extract port from URL
+		_, port, err := net.SplitHostPort(u.Host)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse port from URL %q: %w", ps, err)
+		}
+		num, err := strconv.Atoi(port)
+		if err != nil {
+			return 0, fmt.Errorf("invalid port number %q in URL %q: %w", port, ps, err)
+		}
+		return num, nil
+	} else {
+		// Try parsing as plain port number
+		num, err := strconv.Atoi(ps)
+		if err != nil {
+			return 0, fmt.Errorf("invalid port %q: %w", ps, err)
+		}
+		return num, nil
+	}
+}

--- a/pkg/util/port_test.go
+++ b/pkg/util/port_test.go
@@ -1,0 +1,222 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestParsePort(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    int
+		expectError bool
+		errorMsg    string
+	}{
+		// Plain port number tests
+		{
+			name:     "valid plain port number",
+			input:    "8288",
+			expected: 8288,
+		},
+		{
+			name:     "port 80",
+			input:    "80",
+			expected: 80,
+		},
+		{
+			name:     "port 443",
+			input:    "443",
+			expected: 443,
+		},
+		{
+			name:     "high port number",
+			input:    "65535",
+			expected: 65535,
+		},
+		{
+			name:     "port 1",
+			input:    "1",
+			expected: 1,
+		},
+		
+		// TCP URL tests
+		{
+			name:     "tcp url with ip and port",
+			input:    "tcp://192.168.194.165:8288",
+			expected: 8288,
+		},
+		{
+			name:     "tcp url with localhost",
+			input:    "tcp://localhost:3000",
+			expected: 3000,
+		},
+		{
+			name:     "tcp url with hostname",
+			input:    "tcp://example.com:443",
+			expected: 443,
+		},
+		{
+			name:     "tcp url with different port",
+			input:    "tcp://10.0.0.1:9000",
+			expected: 9000,
+		},
+		{
+			name:     "tcp url with ipv6",
+			input:    "tcp://[::1]:8080",
+			expected: 8080,
+		},
+		
+		// HTTP/HTTPS URL tests (should work with any scheme)
+		{
+			name:     "http url",
+			input:    "http://localhost:8000",
+			expected: 8000,
+		},
+		{
+			name:     "https url",
+			input:    "https://example.com:8443",
+			expected: 8443,
+		},
+		
+		// Error cases
+		{
+			name:        "empty string",
+			input:       "",
+			expectError: true,
+			errorMsg:    "port cannot be empty",
+		},
+		{
+			name:        "invalid port number",
+			input:       "invalid",
+			expectError: true,
+			errorMsg:    "invalid port \"invalid\"",
+		},
+		{
+			name:     "negative port number",
+			input:    "-123",
+			expected: -123, // strconv.Atoi actually allows negative numbers
+		},
+		{
+			name:        "port number too large",
+			input:       "99999",
+			expected:    99999, // strconv.Atoi allows this, validation would be separate
+		},
+		{
+			name:        "float as port",
+			input:       "8080.5",
+			expectError: true,
+			errorMsg:    "invalid port \"8080.5\"",
+		},
+		{
+			name:        "url without port",
+			input:       "tcp://localhost",
+			expectError: true,
+			errorMsg:    "failed to parse port from URL \"tcp://localhost\"",
+		},
+		{
+			name:        "url with invalid port",
+			input:       "tcp://localhost:invalid",
+			expectError: true,
+			errorMsg:    "invalid port", // Just check for the key part of the error
+		},
+		{
+			name:        "url with empty port",
+			input:       "tcp://localhost:",
+			expectError: true,
+			errorMsg:    "invalid port number \"\" in URL \"tcp://localhost:\"",
+		},
+		{
+			name:        "url with no host",
+			input:       "tcp://:8080",
+			expected:    8080, // This actually works - empty host with port
+		},
+		{
+			name:        "malformed url",
+			input:       "tcp://[invalid-ipv6:8080",
+			expectError: true,
+			errorMsg:    "invalid port", // This will fall through to plain port parsing and fail
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ParsePort(tt.input)
+			
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+					return
+				}
+				if tt.errorMsg != "" && !containsSubstring(err.Error(), tt.errorMsg) {
+					t.Errorf("expected error message to contain %q, got %q", tt.errorMsg, err.Error())
+				}
+				return
+			}
+			
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			
+			if result != tt.expected {
+				t.Errorf("expected %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestParsePortKubernetesCase(t *testing.T) {
+	// Test the specific case that was failing in Kubernetes
+	t.Run("kubernetes tcp url case", func(t *testing.T) {
+		result, err := ParsePort("tcp://192.168.194.165:8288")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if result != 8288 {
+			t.Errorf("expected 8288, got %d", result)
+		}
+	})
+}
+
+func TestParsePortEdgeCases(t *testing.T) {
+	// Test whitespace handling
+	t.Run("port with whitespace", func(t *testing.T) {
+		_, err := ParsePort(" 8080 ")
+		if err == nil {
+			t.Error("expected error for port with whitespace")
+		}
+	})
+	
+	// Test zero port
+	t.Run("zero port", func(t *testing.T) {
+		result, err := ParsePort("0")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if result != 0 {
+			t.Errorf("expected 0, got %d", result)
+		}
+	})
+	
+	// Test URL with scheme but no authority
+	t.Run("scheme only", func(t *testing.T) {
+		_, err := ParsePort("tcp://")
+		if err == nil {
+			t.Error("expected error for URL with no authority")
+		}
+	})
+}
+
+// Helper function to check if a string contains a substring
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || findSubstring(s, substr))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Description

enhances PORT environment variable handling in the discovery service to support TCP URLs commonly used in Kubernetes environments. The change modifies pkg/devserver/discovery/discovery.go:62-80 to parse both traditional port numbers (e.g., "8080") and TCP URL formats (e.g., "tcp://192.168.194.210:8288").

## Motivation
Self-hosting helm chart

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
