### PR TITLE
Environments: Fix table row browser inconsistency

### DIFF
--- a/ui/apps/dashboard/src/components/Environments/BranchEnvironmentListTable.tsx
+++ b/ui/apps/dashboard/src/components/Environments/BranchEnvironmentListTable.tsx
@@ -69,7 +69,7 @@ export default function BranchEnvironmentListTable({
                 Auto-archive
               </th>
 
-              <th scope="col" className="w-0 pr-4"></th>
+              <th scope="col" className="w-0 pr-4 text-right"></th>
             </tr>
           </thead>
           <tbody className="divide-subtle divide-y px-4 py-3">
@@ -192,8 +192,8 @@ function TableRow(props: { env: Environment }) {
         )}
       </td>
 
-      <td>
-        <div className="flex items-center gap-2 px-4">
+      <td className="pr-4 text-right">
+        <div className="inline-flex items-center gap-2">
           <EnvViewButton env={props.env} />
           <EnvArchiveButton env={props.env} />
         </div>

--- a/ui/apps/dashboard/src/components/Environments/BranchEnvironmentListTable.tsx
+++ b/ui/apps/dashboard/src/components/Environments/BranchEnvironmentListTable.tsx
@@ -65,11 +65,14 @@ export default function BranchEnvironmentListTable({
                 Name
               </th>
 
-              <th scope="col" className="text-muted w-0 whitespace-nowrap pl-4 text-xs font-medium">
+              <th
+                scope="col"
+                className="text-muted w-20 whitespace-nowrap pl-4 text-xs font-medium"
+              >
                 Auto-archive
               </th>
 
-              <th scope="col" className="w-0 pr-4 text-right"></th>
+              <th scope="col" className="w-24 pr-4 text-right"></th>
             </tr>
           </thead>
           <tbody className="divide-subtle divide-y px-4 py-3">
@@ -176,7 +179,7 @@ function TableRow(props: { env: Environment }) {
         </h3>
       </td>
 
-      <td className="pl-4">
+      <td className="w-20 pl-4">
         {notNullish(isAutoArchiveEnabled) && (
           <Switch
             checked={isAutoArchiveEnabled}

--- a/ui/apps/dashboard/src/components/Environments/CustomEnvironmentListTable.tsx
+++ b/ui/apps/dashboard/src/components/Environments/CustomEnvironmentListTable.tsx
@@ -37,7 +37,7 @@ export function CustomEnvironmentListTable({
               <th scope="col" className="text-muted min-w-48 px-4 py-3 text-xs font-medium">
                 Name
               </th>
-              <th scope="col" className="w-0 pr-4 text-right"></th>
+              <th scope="col" className="w-24 pr-4 text-right"></th>
             </tr>
           </thead>
           <tbody className="divide-subtle divide-y px-4 py-3">

--- a/ui/apps/dashboard/src/components/Environments/CustomEnvironmentListTable.tsx
+++ b/ui/apps/dashboard/src/components/Environments/CustomEnvironmentListTable.tsx
@@ -37,7 +37,7 @@ export function CustomEnvironmentListTable({
               <th scope="col" className="text-muted min-w-48 px-4 py-3 text-xs font-medium">
                 Name
               </th>
-              <th scope="col" className="w-0 pr-4"></th>
+              <th scope="col" className="w-0 pr-4 text-right"></th>
             </tr>
           </thead>
           <tbody className="divide-subtle divide-y px-4 py-3">
@@ -88,8 +88,8 @@ function TableRow(props: { env: Environment }) {
         </h3>
       </td>
 
-      <td>
-        <div className="flex items-center gap-2 px-4">
+      <td className="pr-4 text-right">
+        <div className="inline-flex items-center gap-2">
           <EnvViewButton env={props.env} />
           <EnvKeysDropdownButton env={props.env} />
           <EnvArchiveButton env={props.env} />


### PR DESCRIPTION
## Description

Safari isn't great when it comes to using flexbox in tables, and it was causing some misalignment in these table rows compared to other browsers. By using more explicit widths, this PR should fix this issue.

**Before (Safari):**
<img width="750" height="98" alt="Screenshot 2025-07-23 at 2 44 43 PM" src="https://github.com/user-attachments/assets/335c9d98-5da0-4c1b-82b9-a3babcff7206" />

**After:**
<img width="484" height="96" alt="Screenshot 2025-07-23 at 2 34 15 PM" src="https://github.com/user-attachments/assets/00f22679-9e46-42db-a442-e30df684cf73" />
<img width="440" height="98" alt="Screenshot 2025-07-23 at 2 34 00 PM" src="https://github.com/user-attachments/assets/18da6475-2fdb-4ea1-b14d-65efb21547d2" />
<img width="469" height="97" alt="Screenshot 2025-07-23 at 2 33 39 PM" src="https://github.com/user-attachments/assets/e9a43a6f-8852-43b4-b888-fd848d5b19b9" />
<img width="466" height="98" alt="Screenshot 2025-07-23 at 2 33 26 PM" src="https://github.com/user-attachments/assets/59002072-a423-4dfd-b486-b0154ed12573" />

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
