### PR TITLE
Add curl to Dockerfile to enable docker and k8s health checks

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
 FROM --platform=$BUILDPLATFORM debian:stable-slim AS inngest
-RUN apt-get update && apt-get install -y ca-certificates tzdata && update-ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates tzdata curl && update-ca-certificates
 COPY inngest /bin/inngest
 CMD ["inngest"]


### PR DESCRIPTION
## Description

Add curl to docker image

### test locally with 
```plaintext
go build -o inngest cmd/main.go && docker build -f Dockerfile.goreleaser -t test-inngest . && docker run --rm test-inngest curl --version
```

## Motivation
Needed for health checks in docker and k8s

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
