### PR TITLE
Upgrade Go version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.20.2-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS build
 RUN apk add build-base
 WORKDIR /app
 COPY vendor vendor


### PR DESCRIPTION
## Description

Update the Go version in the Dockerfile so that the compiling will succeed

## Motivation
Without this change, running a Docker build would result in error like:

```
0.405 go: errors parsing go.mod:
0.405 /app/go.mod:5: unknown directive: toolchain
```

or 

```
0.195 go: go.mod requires go >= 1.24 (running go 1.22.12; GOTOOLCHAIN=local)
------
Dockerfile:8
--------------------
   7 |     ARG TARGETOS
   8 | >>> RUN --mount=type=cache,target=/root/.cache/go-build \
   9 | >>>     GOFLAGS=-mod=vendor GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /go/bin/inngest cmd/main.go
``` 

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
