### PR TITLE
Allow configuring the deploy ping timeout value

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -33,10 +34,19 @@ var (
 	DeployErrUnsupportedProtocol = fmt.Errorf("unsupported_protocol")
 
 	Client = http.Client{
-		Timeout:       10 * time.Second,
+		Timeout:       getPingTimeout(),
 		CheckRedirect: exechttp.CheckRedirect,
 	}
 )
+
+func getPingTimeout() time.Duration {
+	if timeoutStr := os.Getenv("INNGEST_DEPLOY_PING_TIMEOUT"); timeoutStr != "" {
+		if dur, err := time.ParseDuration(timeoutStr); err == nil && dur.Seconds() > 0 {
+			return dur
+		}
+	}
+	return 10 * time.Second
+}
 
 type pingResult struct {
 	Err error


### PR DESCRIPTION
## Description

Allow configuring the ping timeout while communicating with deploys.

## Motivation

Especially when running in local dev mode with Next.js, sometimes the initial request can take more than 10 seconds and confusing log messages can be written to the console. This allows for configuring the server with a timeout value that is larger so that the error scenario can be avoided. See https://github.com/inngest/inngest-js/issues/735 for more details.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
