### PR TITLE
Fix deadlock when executor is waiting for queue to quit

### DIFF
--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -719,6 +719,11 @@ func NewQueue(primaryQueueShard QueueShard, opts ...QueueOpt) *queue {
 	q.sem = &trackingSemaphore{Weighted: semaphore.NewWeighted(int64(q.numWorkers))}
 	q.workers = make(chan processItem, q.numWorkers)
 
+	// We only need one signal to exit the executionScan loop but after it exits, it
+	// waits for all workers to finish. And if any other worker would try to send to
+	// this channel we deadlock.
+	q.quit = make(chan error, q.numWorkers)
+
 	return q
 }
 


### PR DESCRIPTION


## Description
`quit` channel wasn't being initialized, which means sending to it was blocking forever; That prevents workers from exiting correctly and the execution scan deadlocks waiting for all workers to finish.

pprof goroutine dump for a stuck executor:
```
1 @ 0x47df0e 0x41424c 0x414157 0x1d18cf9 0x1d11975 0x486681 github.com/inngest/inngest/pkg/execution/state/redis_state.(*queue).process+0x1158 /app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/queue_processor.go:1285 github.com/inngest/inngest/pkg/execution/state/redis_state.(*queue).worker+0x1b4 /app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/queue_processor.go:586
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
