### PR TITLE
Add userland trace support to incoming tracing

### DIFF
--- a/pkg/api/apiv1/apiv1.go
+++ b/pkg/api/apiv1/apiv1.go
@@ -15,6 +15,7 @@ import (
 	"github.com/inngest/inngest/pkg/execution/realtime"
 	"github.com/inngest/inngest/pkg/execution/state/redis_state"
 	"github.com/inngest/inngest/pkg/headers"
+	"github.com/inngest/inngest/pkg/tracing"
 )
 
 // Opts represents options for the APIv1 router.
@@ -46,6 +47,8 @@ type Opts struct {
 	TraceReader cqrs.TraceReader
 	// MetricsMiddleware is used to instrument the APIv1 endpoints.
 	MetricsMiddleware MetricsMiddleware
+	// TracerProvider is used to create spans within the APIv1 endpoints.
+	TracerProvider tracing.TracerProvider
 }
 
 // AddRoutes adds a new API handler to the given router.

--- a/pkg/api/apiv1/traces.go
+++ b/pkg/api/apiv1/traces.go
@@ -4,16 +4,24 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/inngest/inngest/pkg/api/apiv1/apiv1auth"
 	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/run"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/oklog/ulid/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -73,7 +81,7 @@ func (a router) traces(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rejectedSpans := a.convertOTLPAndSend(auth, req)
+	rejectedSpans := a.convertOTLPAndSend(r.Context(), auth, req)
 
 	resp := &collecttrace.ExportTraceServiceResponse{}
 	if rejectedSpans > 0 {
@@ -119,96 +127,225 @@ func respondError(w http.ResponseWriter, r *http.Request, code int, msg string) 
 	_, _ = w.Write(data)
 }
 
-func (a router) convertOTLPAndSend(auth apiv1auth.V1Auth, req *collecttrace.ExportTraceServiceRequest) (rejectedSpans int64) {
-	ctx := context.Background()
+func (a router) convertOTLPAndSend(ctx context.Context, auth apiv1auth.V1Auth, req *collecttrace.ExportTraceServiceRequest) int64 {
+	var (
+		errs atomic.Int64
+		wg   sync.WaitGroup
+	)
+
+	l := logger.StdlibLogger(ctx).With(
+		"account_id", auth.AccountID(),
+		"workspace_id", auth.WorkspaceID(),
+	)
 
 	for _, rs := range req.ResourceSpans {
 		res := convertResource(rs.Resource)
 
 		for _, ss := range rs.ScopeSpans {
-			scope := ss.Scope.GetName()
-
 			for _, s := range ss.Spans {
-				// To be valid, each span must have an "inngest.traceparent"
-				// attribute
-				tp, err := getInngestTraceparent(s)
-				if err != nil {
-					// If we can't find the traceparent, we can't create a
-					// span. So let's skip it.
-					rejectedSpans++
-					continue
-				}
 
-				opts := []run.SpanOpt{
-					run.WithTraceID(tp.TraceID),
-					run.WithSpanID(trace.SpanID(s.SpanId)),
-					run.WithName(s.Name),
-					run.WithSpanKind(trace.SpanKind(s.Kind)),
-					run.WithScope(scope),
-					run.WithLinks(convertLinks(s.Links)...),
-					run.WithTimestamp(time.Unix(0, int64(s.StartTimeUnixNano))),
-				}
+				wg.Add(2)
 
-				attrs := convertAttributes(s.Attributes)
+				go func() {
+					defer wg.Done()
+					defer func() {
+						if r := recover(); r != nil {
+							l.Error("failed to commit legacy span with", "panic", r)
+							errs.Add(1)
+						}
+					}()
 
-				if err := hasRequiredAttributes(s.Attributes, []string{
-					consts.OtelSysAppID,
-					consts.OtelAttrSDKRunID,
-					consts.OtelSysFunctionID,
-				}); err != nil {
-					logger.StdlibLogger(ctx).Error("missing required attributes, skipping ingestion", "error", err)
-					rejectedSpans++
-					continue
-				}
+					err := a.commitLegacySpan(ctx, auth, res, ss.Scope.GetName(), s)
+					if err != nil {
+						l.Error("failed to commit legacy span with", "error", err)
+						errs.Add(1)
+						return
+					}
+				}()
 
-				// Add the run ID to attrs so we can query for it later
-				attrs = append(attrs,
-					attribute.KeyValue{
-						Key:   attribute.Key(consts.OtelSysAccountID),
-						Value: attribute.StringValue(auth.AccountID().String()),
-					},
-					attribute.KeyValue{
-						Key:   attribute.Key(consts.OtelSysWorkspaceID),
-						Value: attribute.StringValue(auth.WorkspaceID().String()),
-					},
-				)
+				go func() {
+					defer wg.Done()
+					defer func() {
+						if r := recover(); r != nil {
+							l.Error("failed to commit span with", "panic", r)
+							errs.Add(1)
+						}
+					}()
 
-				// Always mark the span as userland
-				attrs = append(attrs, attribute.KeyValue{
-					Key:   attribute.Key(consts.OtelScopeUserland),
-					Value: attribute.BoolValue(true),
-				})
-
-				opts = append(opts, run.WithSpanAttributes(attrs...))
-
-				if scope == "inngest" && s.Name == "inngest.execution" {
-					// This is the "root" span created by an SDK, so let's
-					// set its parent to our span ID
-					opts = append(opts, run.WithParentSpanID(trace.SpanID(tp.SpanID)))
-				} else if len(s.ParentSpanId) == 12 {
-					opts = append(opts, run.WithParentSpanID(trace.SpanID(s.ParentSpanId)))
-				}
-
-				if res != nil {
-					opts = append(opts, run.WithServiceName(resourceServiceName(res)))
-				}
-
-				_, span := run.NewSpan(ctx, opts...)
-
-				for _, e := range convertEvents(s.Events) {
-					span.AddEvent(e.Name, trace.WithTimestamp(e.Time), trace.WithAttributes(e.Attributes...))
-				}
-
-				if s.Status != nil {
-					span.SetStatus(traceStatusCode(s.Status.Code), s.Status.Message)
-				}
-
-				span.End(trace.WithTimestamp(time.Unix(0, int64(s.EndTimeUnixNano))))
+					err := a.commitSpan(res, ss.Scope, s)
+					if err != nil {
+						l.Error("failed to commit span with", "error", err)
+						errs.Add(1)
+						return
+					}
+				}()
 			}
 		}
 	}
 
-	return
+	wg.Wait()
+
+	return errs.Load()
+}
+
+func (a router) commitSpan(res *resource.Resource, scope *commonv1.InstrumentationScope, s *tracev1.Span) error {
+	// To be valid, each span must have an "inngest.traceref" attribute
+	tr, err := getInngestTraceRef(s)
+	if err != nil {
+		// If we can't find the traceref, we can't create a span. So let's
+		// skip it.
+		return fmt.Errorf("failed to get traceref: %w", err)
+	}
+
+	attrs := convertAttributes(s.Attributes)
+
+	status := enums.StepStatusUnknown
+	if s.Status != nil {
+		switch s.Status.Code {
+		case tracev1.Status_STATUS_CODE_ERROR:
+			status = enums.StepStatusFailed
+		case tracev1.Status_STATUS_CODE_OK:
+			status = enums.StepStatusCompleted
+		}
+	}
+
+	// Legacy, but try to pull the run ID out from the attributes using the
+	// legacy key.
+	var runID ulid.ULID
+	for _, kv := range attrs {
+		if kv.Key == consts.OtelAttrSDKRunID {
+			runID, err = ulid.Parse(kv.Value.AsString())
+			if err != nil {
+				return fmt.Errorf("failed to parse run ID from attributes: %w", err)
+			}
+
+			break
+		}
+	}
+
+	spanID := trace.SpanID(s.SpanId).String()
+	spanKind := trace.SpanKind(s.Kind).String()
+	resourceServiceName := resourceServiceName(res)
+	isUserland := true
+
+	ourAttrs := meta.NewAttrSet(
+		meta.Attr(meta.Attrs.IsUserland, &isUserland),
+		meta.Attr(meta.Attrs.UserlandSpanID, &spanID),
+		meta.Attr(meta.Attrs.DynamicSpanID, &spanID),
+		meta.Attr(meta.Attrs.UserlandName, &s.Name),
+		meta.Attr(meta.Attrs.DynamicStatus, &status),
+		meta.Attr(meta.Attrs.RunID, &runID),
+		meta.Attr(meta.Attrs.UserlandKind, &spanKind),
+		meta.Attr(meta.Attrs.UserlandServiceName, &resourceServiceName),
+		meta.Attr(meta.Attrs.UserlandScopeName, &scope.Name),
+		meta.Attr(meta.Attrs.UserlandScopeVersion, &scope.Version),
+	)
+
+	// Add some additional attributes on top
+	attrs = append(attrs, ourAttrs.Serialize()...)
+
+	// By default, the parent span is the trace ref we found.
+	parent := tr
+
+	if (scope.Name != "inngest" || s.Name != "inngest.execution") && len(s.ParentSpanId) == 12 {
+		// If this is not the "root" span created by an SDK, we need to listen to
+		// the parent span ID that they have set so we can preserve whatever
+		// lineage they're passing us.
+		parent, err = tr.SetParentSpanID(trace.SpanID(s.ParentSpanId))
+		if err != nil {
+			return fmt.Errorf("failed to set parent span ID: %w", err)
+		}
+	}
+
+	_, err = a.opts.TracerProvider.CreateSpan(meta.SpanNameUserland, &tracing.CreateSpanOptions{
+		Debug:              &tracing.SpanDebugData{Location: "apiv1.traces.commitSpan"},
+		StartTime:          time.Unix(0, int64(s.StartTimeUnixNano)),
+		EndTime:            time.Unix(0, int64(s.EndTimeUnixNano)),
+		Parent:             parent,
+		RawOtelSpanOptions: []trace.SpanStartOption{trace.WithAttributes(attrs...)},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create span: %w", err)
+	}
+
+	return nil
+}
+
+func (a router) commitLegacySpan(ctx context.Context, auth apiv1auth.V1Auth, res *resource.Resource, scope string, s *tracev1.Span) error {
+	// To be valid, each span must have an "inngest.traceparent" attribute
+	tp, err := getInngestTraceparent(s)
+	if err != nil {
+		// If we can't find the traceparent, we can't create a span. So let's
+		// skip it.
+		return fmt.Errorf("failed to get traceparent: %w", err)
+	}
+
+	opts := []run.SpanOpt{
+		run.WithTraceID(tp.TraceID),
+		run.WithSpanID(trace.SpanID(s.SpanId)),
+		run.WithName(s.Name),
+		run.WithSpanKind(trace.SpanKind(s.Kind)),
+		run.WithScope(scope),
+		run.WithLinks(convertLinks(s.Links)...),
+		run.WithTimestamp(time.Unix(0, int64(s.StartTimeUnixNano))),
+	}
+
+	attrs := convertAttributes(s.Attributes)
+
+	if err := hasRequiredAttributes(s.Attributes, []string{
+		consts.OtelSysAppID,
+		consts.OtelAttrSDKRunID,
+		consts.OtelSysFunctionID,
+	}); err != nil {
+		logger.StdlibLogger(ctx).Error("missing required attributes, skipping ingestion", "error", err)
+		return fmt.Errorf("missing required attributes: %w", err)
+	}
+
+	// Add the run ID to attrs so we can query for it later
+	attrs = append(attrs,
+		attribute.KeyValue{
+			Key:   attribute.Key(consts.OtelSysAccountID),
+			Value: attribute.StringValue(auth.AccountID().String()),
+		},
+		attribute.KeyValue{
+			Key:   attribute.Key(consts.OtelSysWorkspaceID),
+			Value: attribute.StringValue(auth.WorkspaceID().String()),
+		},
+	)
+
+	// Always mark the span as userland
+	attrs = append(attrs, attribute.KeyValue{
+		Key:   attribute.Key(consts.OtelScopeUserland),
+		Value: attribute.BoolValue(true),
+	})
+
+	opts = append(opts, run.WithSpanAttributes(attrs...))
+
+	if scope == "inngest" && s.Name == "inngest.execution" {
+		// This is the "root" span created by an SDK, so let's set its parent
+		// to our span ID
+		opts = append(opts, run.WithParentSpanID(trace.SpanID(tp.SpanID)))
+	} else if len(s.ParentSpanId) == 12 {
+		opts = append(opts, run.WithParentSpanID(trace.SpanID(s.ParentSpanId)))
+	}
+
+	if res != nil {
+		opts = append(opts, run.WithServiceName(resourceServiceName(res)))
+	}
+
+	_, span := run.NewSpan(ctx, opts...)
+
+	for _, e := range convertEvents(s.Events) {
+		span.AddEvent(e.Name, trace.WithTimestamp(e.Time), trace.WithAttributes(e.Attributes...))
+	}
+
+	if s.Status != nil {
+		span.SetStatus(traceStatusCode(s.Status.Code), s.Status.Message)
+	}
+
+	span.End(trace.WithTimestamp(time.Unix(0, int64(s.EndTimeUnixNano))))
+
+	return nil
 }
 
 func getInngestTraceparent(s *tracev1.Span) (*TraceParent, error) {
@@ -251,9 +388,43 @@ func getInngestTraceparent(s *tracev1.Span) (*TraceParent, error) {
 	return nil, fmt.Errorf("no traceparent attribute found")
 }
 
+func getInngestTraceRef(s *tracev1.Span) (*meta.SpanReference, error) {
+	for _, kv := range s.Attributes {
+		if kv.Key != "inngest.traceref" {
+			continue
+		}
+
+		sr := &meta.SpanReference{}
+
+		traceRefStr, err := url.QueryUnescape(kv.GetValue().GetStringValue())
+		if err != nil {
+			return nil, fmt.Errorf("failed to unescape trace reference: %w", err)
+		}
+
+		err = json.Unmarshal([]byte(traceRefStr), sr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal span reference: %w", err)
+		}
+
+		err = sr.Validate()
+		if err != nil {
+			return nil, fmt.Errorf("invalid span reference: %w", err)
+		}
+
+		return sr, nil
+	}
+
+	return nil, fmt.Errorf("no span reference found in attributes")
+}
+
 func convertAttributes(attrs []*commonv1.KeyValue) []attribute.KeyValue {
 	out := make([]attribute.KeyValue, 0, len(attrs))
 	for _, kv := range attrs {
+		// Filter out any attributes that have our prefixes
+		if strings.HasPrefix(kv.Key, meta.AttrKeyPrefix) {
+			continue
+		}
+
 		out = append(out, attribute.KeyValue{
 			Key:   attribute.Key(kv.Key),
 			Value: convertAnyValue(kv.Value),

--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -220,7 +220,7 @@ func (w wrapper) GetSpansByRunID(ctx context.Context, runID ulid.ULID) (*cqrs.Ot
 
 		}
 
-		if span.ParentSpanID == nil || *span.ParentSpanID == "" || *span.ParentSpanID == "0000000000000000" {
+		if (span.Attributes.IsUserland == nil || !*span.Attributes.IsUserland) && (span.ParentSpanID == nil || *span.ParentSpanID == "" || *span.ParentSpanID == "0000000000000000") {
 			root = spanMap[span.SpanID]
 			continue
 		}

--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -134,7 +134,6 @@ func (w wrapper) GetSpansByRunID(ctx context.Context, runID ulid.ULID) (*cqrs.Ot
 
 		var outputSpanID *string
 		var fragments []map[string]interface{}
-		groupedAttrs := make(map[string]any)
 		_ = json.Unmarshal([]byte(span.SpanFragments.(string)), &fragments)
 
 		for _, fragment := range fragments {
@@ -151,7 +150,7 @@ func (w wrapper) GetSpansByRunID(ctx context.Context, runID ulid.ULID) (*cqrs.Ot
 					return nil, err
 				}
 
-				maps.Copy(groupedAttrs, fragmentAttr)
+				maps.Copy(newSpan.RawOtelSpan.Attributes, fragmentAttr)
 
 				if outputRef, ok := fragment["output_span_id"].(string); ok {
 					outputSpanID = &outputRef
@@ -160,7 +159,7 @@ func (w wrapper) GetSpansByRunID(ctx context.Context, runID ulid.ULID) (*cqrs.Ot
 			}
 		}
 
-		newSpan.Attributes, err = meta.ExtractTypedValues(ctx, groupedAttrs)
+		newSpan.Attributes, err = meta.ExtractTypedValues(ctx, newSpan.RawOtelSpan.Attributes)
 		if err != nil {
 			return nil, fmt.Errorf("error extracting typed values from span attributes: %w", err)
 		}

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -387,6 +387,8 @@ func start(ctx context.Context, opts StartOpts) error {
 
 	hmw := memory_writer.NewWriter(ctx, memory_writer.WriterOptions{DumpToFile: false})
 
+	tp := tracing.NewSqlcTracerProvider(base_cqrs.NewQueries(db, dbDriver))
+
 	exec, err := executor.NewExecutor(
 		executor.WithHTTPClient(httpClient),
 		executor.WithStateManager(smv2),
@@ -440,7 +442,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			Secret:     consts.DevServerRealtimeJWTSecret,
 			PublishURL: fmt.Sprintf("http://%s:%d/v1/realtime/publish", opts.Config.CoreAPI.Addr, opts.Config.CoreAPI.Port),
 		}),
-		executor.WithTracerProvider(tracing.NewSqlcTracerProvider(base_cqrs.NewQueries(db, dbDriver))),
+		executor.WithTracerProvider(tp),
 	)
 	if err != nil {
 		return err
@@ -502,6 +504,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			Broadcaster:        broadcaster,
 			RealtimeJWTSecret:  consts.DevServerRealtimeJWTSecret,
 			TraceReader:        ds.Data,
+			TracerProvider:     tp,
 		})
 	})
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1499,6 +1499,11 @@ func (e *executor) executeDriverForStep(ctx context.Context, i *runInstance) (*s
 
 	step := &i.f.Steps[0]
 
+	if i.execSpan != nil {
+		// Allow deep driver code to grab the execution span from context
+		ctx = i.execSpan.SetToCtx(ctx)
+	}
+
 	response, err := d.Execute(ctx, e.smv2, i.md, i.item, i.edge, *step, i.stackIndex, i.item.Attempt)
 
 	// TODO: Steps.

--- a/pkg/telemetry/trace/tracer.go
+++ b/pkg/telemetry/trace/tracer.go
@@ -203,7 +203,7 @@ func HeadersFromTraceState(
 	}
 
 	if span, err := meta.GetSpanReferenceFromCtx(ctx); err == nil {
-		if spanStr, err := span.QueryString(); err == nil {
+		if spanStr, err := span.MarshalForSDK(); err == nil {
 			if ts, err = ts.Insert("inngest@traceref", spanStr); err != nil {
 				return headers, fmt.Errorf("failed to add trace reference to trace state: %w", err)
 			}

--- a/pkg/telemetry/trace/tracer.go
+++ b/pkg/telemetry/trace/tracer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/telemetry/exporters"
+	"github.com/inngest/inngest/pkg/tracing/meta"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/jaeger"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
@@ -188,10 +189,10 @@ func HeadersFromTraceState(
 	functionID string,
 ) (map[string]string, error) {
 	headers := make(map[string]string)
-	span := oteltrace.SpanFromContext(ctx)
-	sc := span.SpanContext()
+	legacySpan := oteltrace.SpanFromContext(ctx)
+	lsc := legacySpan.SpanContext()
 
-	ts, err := sc.TraceState().Insert("inngest@app", appID)
+	ts, err := lsc.TraceState().Insert("inngest@app", appID)
 	if err != nil {
 		return headers, fmt.Errorf("failed to add app ID to trace state: %w", err)
 	}
@@ -201,15 +202,23 @@ func HeadersFromTraceState(
 		return headers, fmt.Errorf("failed to add function ID to trace state: %w", err)
 	}
 
-	sc = oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
-		TraceID:    sc.TraceID(),
-		SpanID:     sc.SpanID(),
-		TraceFlags: sc.TraceFlags(),
+	if span, err := meta.GetSpanReferenceFromCtx(ctx); err == nil {
+		if spanStr, err := span.QueryString(); err == nil {
+			if ts, err = ts.Insert("inngest@traceref", spanStr); err != nil {
+				return headers, fmt.Errorf("failed to add trace reference to trace state: %w", err)
+			}
+		}
+	}
+
+	lsc = oteltrace.NewSpanContext(oteltrace.SpanContextConfig{
+		TraceID:    lsc.TraceID(),
+		SpanID:     lsc.SpanID(),
+		TraceFlags: lsc.TraceFlags(),
 		TraceState: ts,
-		Remote:     sc.IsRemote(),
+		Remote:     lsc.IsRemote(),
 	})
 
-	newCtx := oteltrace.ContextWithSpanContext(ctx, sc)
+	newCtx := oteltrace.ContextWithSpanContext(ctx, lsc)
 	UserTracer().Propagator().Inject(newCtx, propagation.MapCarrier(headers))
 
 	if headers["traceparent"] != "" {

--- a/pkg/tracing/meta/attributes.go
+++ b/pkg/tracing/meta/attributes.go
@@ -88,6 +88,16 @@ var Attrs = struct {
 	ResponseStatusCode attr[*int]
 	ResponseOutputSize attr[*int]
 
+	// Userland attributes
+	IsUserland                 attr[*bool]
+	UserlandSpanID             attr[*string]
+	UserlandName               attr[*string]
+	UserlandKind               attr[*string]
+	UserlandServiceName        attr[*string]
+	UserlandScopeName          attr[*string]
+	UserlandScopeVersion       attr[*string]
+	UserlandResourceAttributes attr[*string]
+
 	// Debugger attributes
 	DebugSessionID attr[*ulid.ULID]
 	DebugRunID     attr[*ulid.ULID]
@@ -121,25 +131,33 @@ var Attrs = struct {
 	StepGatewayResponseStatusCode:      IntAttr("step.gateway.response.status_code"),
 	// StepHasOutput is used to mark that a specific span has an output in the
 	// attributes, in place of the output itself.
-	StepHasOutput:             BoolAttr("step.has_output"),
-	StepID:                    StringAttr("step.id"),
-	StepInvokeFinishEventID:   ULIDAttr("step.invoke.finish.event.id"),
-	StepInvokeFunctionID:      StringAttr("step.invoke.function.id"),
-	StepInvokeRunID:           ULIDAttr("step.invoke.run.id"),
-	StepInvokeTriggerEventID:  ULIDAttr("step.invoke.trigger.event.id"),
-	StepMaxAttempts:           IntAttr("step.max_attempts"),
-	StepName:                  StringAttr("step.name"),
-	StepOp:                    StepOpAttr("step.op"),
-	StepOutput:                StringAttr("step.output"),
-	StepOutputRef:             StringAttr("step.output_ref"),
-	StepRunType:               StringAttr("step.run.type"),
-	StepSignalName:            StringAttr("step.signal.name"),
-	StepSleepDuration:         DurationAttr("step.sleep.duration"),
-	StepWaitExpired:           BoolAttr("step.wait.expired"),
-	StepWaitExpiry:            TimeAttr("step.wait.expiry"),
-	StepWaitForEventIf:        StringAttr("step.wait_for_event.if"),
-	StepWaitForEventMatchedID: ULIDAttr("step.wait_for_event.matched_id"),
-	StepWaitForEventName:      StringAttr("step.wait_for_event.name"),
-	DebugSessionID:            ULIDAttr("debug.session.id"),
-	DebugRunID:                ULIDAttr("debug.run.id"),
+	StepHasOutput:              BoolAttr("step.has_output"),
+	StepID:                     StringAttr("step.id"),
+	StepInvokeFinishEventID:    ULIDAttr("step.invoke.finish.event.id"),
+	StepInvokeFunctionID:       StringAttr("step.invoke.function.id"),
+	StepInvokeRunID:            ULIDAttr("step.invoke.run.id"),
+	StepInvokeTriggerEventID:   ULIDAttr("step.invoke.trigger.event.id"),
+	StepMaxAttempts:            IntAttr("step.max_attempts"),
+	StepName:                   StringAttr("step.name"),
+	StepOp:                     StepOpAttr("step.op"),
+	StepOutput:                 StringAttr("step.output"),
+	StepOutputRef:              StringAttr("step.output_ref"),
+	StepRunType:                StringAttr("step.run.type"),
+	StepSignalName:             StringAttr("step.signal.name"),
+	StepSleepDuration:          DurationAttr("step.sleep.duration"),
+	StepWaitExpired:            BoolAttr("step.wait.expired"),
+	StepWaitExpiry:             TimeAttr("step.wait.expiry"),
+	StepWaitForEventIf:         StringAttr("step.wait_for_event.if"),
+	StepWaitForEventMatchedID:  ULIDAttr("step.wait_for_event.matched_id"),
+	StepWaitForEventName:       StringAttr("step.wait_for_event.name"),
+	UserlandSpanID:             StringAttr("userland.span.id"),
+	IsUserland:                 BoolAttr("userland"),
+	UserlandKind:               StringAttr("userland.kind"),
+	UserlandServiceName:        StringAttr("userland.service.name"),
+	UserlandScopeName:          StringAttr("userland.scope.name"),
+	UserlandScopeVersion:       StringAttr("userland.scope.version"),
+	UserlandResourceAttributes: StringAttr("userland.resource.attributes"),
+	UserlandName:               StringAttr("userland.name"),
+	DebugSessionID:             ULIDAttr("debug.session.id"),
+	DebugRunID:                 ULIDAttr("debug.run.id"),
 }

--- a/pkg/tracing/meta/consts.go
+++ b/pkg/tracing/meta/consts.go
@@ -16,6 +16,7 @@ const (
 	SpanNameStep             = "executor.step"
 	SpanNameExecution        = "executor.execution"
 	SpanNameDynamicExtension = "EXTEND"
+	SpanNameUserland         = "userland"
 
 	// Link attributes
 	LinkAttributeType            = "_inngest.link.type"

--- a/pkg/tracing/meta/extracted_values_gen.go
+++ b/pkg/tracing/meta/extracted_values_gen.go
@@ -59,6 +59,14 @@ type ExtractedValues struct {
 	ResponseHeaders *http.Header
 	ResponseStatusCode *int
 	ResponseOutputSize *int
+	IsUserland *bool
+	UserlandSpanID *string
+	UserlandName *string
+	UserlandKind *string
+	UserlandServiceName *string
+	UserlandScopeName *string
+	UserlandScopeVersion *string
+	UserlandResourceAttributes *string
 	DebugSessionID *ulid.ULID
 	DebugRunID *ulid.ULID
 }

--- a/pkg/tracing/meta/models.go
+++ b/pkg/tracing/meta/models.go
@@ -1,5 +1,15 @@
 package meta
 
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
 type SpanReference struct {
 	TraceParent string `json:"tp"`
 	TraceState  string `json:"ts"`
@@ -9,4 +19,110 @@ type SpanReference struct {
 	DynamicSpanTraceParent string `json:"dstp,omitempty"`
 	DynamicSpanTraceState  string `json:"dsts,omitempty"`
 	DynamicSpanID          string `json:"dsid,omitempty"`
+}
+
+type ctxKey struct{}
+
+func (sr *SpanReference) Validate() error {
+	if sr.TraceParent == "" {
+		return fmt.Errorf("span reference missing traceparent; every span must have a traceparent")
+	}
+
+	return nil
+}
+
+func (sr *SpanReference) TraceID() (string, error) {
+	// Return the trace ID from the traceparent
+	if sr.TraceParent == "" {
+		return "", fmt.Errorf("span reference missing traceparent; cannot get trace ID")
+	}
+
+	parts := strings.Split(sr.TraceParent, "-")
+	if len(parts) != 4 || len(parts[1]) != 32 {
+		return "", fmt.Errorf("invalid traceparent format")
+	}
+
+	return parts[1], nil
+}
+
+func (sr *SpanReference) SpanID() (string, error) {
+	// Return the span ID from the traceparent
+	if sr.TraceParent == "" {
+		return "", fmt.Errorf("span reference missing traceparent; cannot get span ID")
+	}
+
+	parts := strings.Split(sr.TraceParent, "-")
+	if len(parts) != 4 || len(parts[2]) != 12 {
+		return "", fmt.Errorf("invalid traceparent format")
+	}
+
+	return parts[2], nil
+}
+
+// SetParentSpanID alters the TraceParent to include the parent span ID.
+func (sr *SpanReference) SetParentSpanID(parentSpanID trace.SpanID) (*SpanReference, error) {
+	err := sr.Validate()
+	if err != nil {
+		return nil, fmt.Errorf("span reference was not valid, so cannot set parent span ID: %w", err)
+	}
+
+	parts := strings.Split(sr.TraceParent, "-")
+	if len(parts) != 4 {
+		return nil, fmt.Errorf("invalid traceparent format; expected 4 parts, got %d", len(parts))
+	}
+
+	parts[2] = parentSpanID.String()
+
+	// If we're updating this, it's for userland spans, so we intentionally
+	// remove all dynamic span information.
+	return &SpanReference{
+		TraceParent: strings.Join(parts, "-"),
+		TraceState:  sr.TraceState,
+	}, nil
+
+}
+
+func (sr *SpanReference) SetToCtx(ctx context.Context) context.Context {
+	if sr == nil {
+		return ctx
+	}
+
+	return context.WithValue(ctx, ctxKey{}, sr)
+}
+
+func (sr *SpanReference) QueryString() (string, error) {
+	if sr == nil {
+		return "", fmt.Errorf("span reference is nil")
+	}
+
+	byt, err := json.Marshal(sr)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal span reference: %w", err)
+	}
+
+	escaped := url.QueryEscape(string(byt))
+
+	return escaped, nil
+}
+
+func GetSpanReferenceFromCtx(ctx context.Context) (*SpanReference, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context is nil")
+	}
+
+	val := ctx.Value(ctxKey{})
+	if val == nil {
+		return nil, fmt.Errorf("no span reference found in context")
+	}
+
+	sr, ok := val.(*SpanReference)
+	if !ok {
+		return nil, fmt.Errorf("span reference in context is not of type *SpanReference")
+	}
+
+	if sr == nil {
+		return nil, fmt.Errorf("span reference in context is nil")
+	}
+
+	return sr, sr.Validate()
 }

--- a/pkg/tracing/meta/models.go
+++ b/pkg/tracing/meta/models.go
@@ -90,12 +90,19 @@ func (sr *SpanReference) SetToCtx(ctx context.Context) context.Context {
 	return context.WithValue(ctx, ctxKey{}, sr)
 }
 
-func (sr *SpanReference) QueryString() (string, error) {
+func (sr *SpanReference) MarshalForSDK() (string, error) {
 	if sr == nil {
 		return "", fmt.Errorf("span reference is nil")
 	}
 
-	byt, err := json.Marshal(sr)
+	// We only want some values; dynamic span information is not needed when
+	// passing this.
+	srForSDK := &SpanReference{
+		TraceParent: sr.TraceParent,
+		TraceState:  sr.TraceState,
+	}
+
+	byt, err := json.Marshal(srForSDK)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal span reference: %w", err)
 	}

--- a/pkg/tracing/meta/serializers.go
+++ b/pkg/tracing/meta/serializers.go
@@ -41,22 +41,6 @@ func AddAttr[T any](r *SerializableAttrs, attr attr[T], value T) {
 	r.Attrs = append(r.Attrs, Attr(attr, value))
 }
 
-func GetAttr[T any](r *SerializableAttrs, attr attr[*T]) (*T, bool) {
-	// Attributes that are applied later will override earlier ones, so we
-	// iterate in reverse order.
-	for i := len(r.Attrs) - 1; i >= 0; i-- {
-		if r.Attrs[i].key == attr.Key() {
-			if val, ok := r.Attrs[i].value.(T); ok {
-				return &val, true
-			}
-
-			return nil, false
-		}
-	}
-
-	return nil, false
-}
-
 func (r *SerializableAttrs) AddErr(err error) {
 	if r.es == nil {
 		r.es = util.NewErrSet()

--- a/pkg/tracing/meta/serializers.go
+++ b/pkg/tracing/meta/serializers.go
@@ -41,6 +41,22 @@ func AddAttr[T any](r *SerializableAttrs, attr attr[T], value T) {
 	r.Attrs = append(r.Attrs, Attr(attr, value))
 }
 
+func GetAttr[T any](r *SerializableAttrs, attr attr[*T]) (*T, bool) {
+	// Attributes that are applied later will override earlier ones, so we
+	// iterate in reverse order.
+	for i := len(r.Attrs) - 1; i >= 0; i-- {
+		if r.Attrs[i].key == attr.Key() {
+			if val, ok := r.Attrs[i].value.(T); ok {
+				return &val, true
+			}
+
+			return nil, false
+		}
+	}
+
+	return nil, false
+}
+
 func (r *SerializableAttrs) AddErr(err error) {
 	if r.es == nil {
 		r.es = util.NewErrSet()

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -192,13 +192,6 @@ func (tp *otelTracerProvider) CreateDroppableSpan(
 		spanRef.DynamicSpanTraceState = opts.Parent.TraceState
 	}
 
-	// If this is a userland span, we trust their span ID to be the dynamic
-	// span ID instead of context, so as to preserve their lineage. Also, a
-	// userland span will never be dynamic!
-	if userlandSpanID, ok := meta.GetAttr(attrs, meta.Attrs.UserlandSpanID); ok {
-		spanRef.DynamicSpanID = *userlandSpanID
-	}
-
 	span.SetAttributes(
 		attribute.String(meta.Attrs.DynamicSpanID.Key(), spanRef.DynamicSpanID),
 	)

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -122,9 +122,16 @@ func (tp *otelTracerProvider) CreateDroppableSpan(
 	name string,
 	opts *CreateSpanOptions,
 ) (*DroppableSpan, error) {
+	attrs := opts.Attributes
+	if attrs == nil {
+		attrs = meta.NewAttrSet()
+	}
+
 	st := opts.StartTime
 	if st.IsZero() {
 		st = time.Now()
+	} else {
+		meta.AddAttr(attrs, meta.Attrs.StartedAt, &st)
 	}
 
 	ctx := context.Background()
@@ -135,13 +142,6 @@ func (tp *otelTracerProvider) CreateDroppableSpan(
 		}
 		ctx = defaultPropagator.Extract(context.Background(), carrier)
 	}
-
-	attrs := opts.Attributes
-	if attrs == nil {
-		attrs = meta.NewAttrSet()
-	}
-
-	meta.AddAttr(attrs, meta.Attrs.StartedAt, &st)
 
 	if opts.Debug != nil {
 		if opts.Debug.Location != "" {

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -189,6 +189,13 @@ func (tp *otelTracerProvider) CreateDroppableSpan(
 		spanRef.DynamicSpanTraceState = opts.Parent.TraceState
 	}
 
+	// If this is a userland span, we trust their span ID to be the dynamic
+	// span ID instead of context, so as to preserve their lineage. Also, a
+	// userland span will never be dynamic!
+	if userlandSpanID, ok := meta.GetAttr(attrs, meta.Attrs.UserlandSpanID); ok {
+		spanRef.DynamicSpanID = *userlandSpanID
+	}
+
 	span.SetAttributes(
 		attribute.String(meta.Attrs.DynamicSpanID.Key(), spanRef.DynamicSpanID),
 	)

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -140,6 +140,9 @@ func (tp *otelTracerProvider) CreateDroppableSpan(
 	if attrs == nil {
 		attrs = meta.NewAttrSet()
 	}
+
+	meta.AddAttr(attrs, meta.Attrs.StartedAt, &st)
+
 	if opts.Debug != nil {
 		if opts.Debug.Location != "" {
 			meta.AddAttr(attrs, meta.Attrs.InternalLocation, &opts.Debug.Location)

--- a/pkg/tracing/tracer_sqlc.go
+++ b/pkg/tracing/tracer_sqlc.go
@@ -128,6 +128,7 @@ func (e *dbExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlyS
 		// it's part of a remote lineage.
 		if userlandSpanID != "" {
 			spanID = userlandSpanID
+			dynamicSpanID = userlandSpanID
 		}
 
 		// If we don't have a run ID, we can't store this span

--- a/pkg/tracing/tracer_sqlc.go
+++ b/pkg/tracing/tracer_sqlc.go
@@ -38,6 +38,7 @@ func (e *dbExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlyS
 		var runID string
 		var debugSessionID string
 		var debugRunID string
+		var userlandSpanID string
 
 		attrs := make(map[string]any)
 		for _, attr := range span.Attributes() {
@@ -113,7 +114,20 @@ func (e *dbExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlyS
 				}
 			}
 
+			if string(attr.Key) == meta.Attrs.UserlandSpanID.Key() {
+				userlandSpanID = attr.Value.AsString()
+				if cleanAttrs {
+					continue
+				}
+			}
+
 			attrs[string(attr.Key)] = attr.Value.AsInterface()
+		}
+
+		// This is a userland span, so we'll trust the span ID it gave us, as
+		// it's part of a remote lineage.
+		if userlandSpanID != "" {
+			spanID = userlandSpanID
 		}
 
 		// If we don't have a run ID, we can't store this span


### PR DESCRIPTION
## Description

Adds support for userland traces to incoming tracing.

- Userland trace ingestion now creates spans for both incoming and outgoing tracing
- A few new attributes added for userland traces
- A little code to pass required state to SDKs
- Requires that users are updated to inngest/inngest-js#1040, as more data is needed
  - It's actually less data than before, but we need both incoming and outgoing trace context atm...

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- Requires inngest/inngest-js#1040

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
