### PR TITLE
Fix Connect closing ws connection when lease is deleted

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -810,7 +810,11 @@ func (c *connectionHandler) handleIncomingWebSocketMessage(ctx context.Context, 
 
 			newLeaseID, err := c.svc.stateManager.ExtendRequestLease(ctx, c.conn.EnvID, data.RequestId, leaseID, consts.ConnectWorkerRequestLeaseDuration)
 			if err != nil {
-				if errors.Is(err, state.ErrRequestLeaseExpired) || errors.Is(err, state.ErrRequestLeased) {
+				switch {
+				case errors.Is(err, state.ErrRequestLeaseExpired),
+					errors.Is(err, state.ErrRequestLeased),
+					errors.Is(err, state.ErrRequestLeaseNotFound):
+
 					c.log.ReportError(err, "lease was claimed by other worker or expired",
 						logger.WithErrorReportTags(map[string]string{
 							"req_id":   data.RequestId,
@@ -846,15 +850,20 @@ func (c *connectionHandler) handleIncomingWebSocketMessage(ctx context.Context, 
 					}
 
 					return nil
-				}
 
-				c.log.ReportError(err, "unexpected error extending lease")
+				default:
+					c.log.ReportError(err, "unexpected error extending lease",
+						logger.WithErrorReportTags(map[string]string{
+							"req_id":   data.RequestId,
+							"lease_id": leaseID.String(),
+						}))
 
-				// This should never happen
-				return &connecterrors.SocketError{
-					SysCode:    syscode.CodeConnectInternal,
-					StatusCode: websocket.StatusInternalError,
-					Msg:        "unexpected error extending lease",
+					// This should never happen
+					return &connecterrors.SocketError{
+						SysCode:    syscode.CodeConnectInternal,
+						StatusCode: websocket.StatusInternalError,
+						Msg:        "unexpected error extending lease",
+					}
 				}
 			}
 


### PR DESCRIPTION
## Description
Fixes the case where a Connect worker will continuously keep reconnecting and failing when a request lease was deleted. 

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
