### PR TITLE
Synchronously commit spans in the Executor

### DIFF
--- a/pkg/tracing/execution_processor.go
+++ b/pkg/tracing/execution_processor.go
@@ -159,6 +159,9 @@ func (p *executionProcessor) OnEnd(s sdktrace.ReadOnlySpan) {
 		for _, attr := range s.Attributes() {
 			if string(attr.Key) == meta.Attrs.DropSpan.Key() && attr.Value.AsBool() {
 				// Toggle this on and off to see or remove dropped spans
+				// Notify that dropped spans have been exported to unblock,
+				// even though we're dropping them here.
+				meta.NotifySpanExported(s.SpanContext().SpanID().String(), nil)
 				return // Don't export dropped spans
 			}
 		}

--- a/pkg/tracing/meta/notifications.go
+++ b/pkg/tracing/meta/notifications.go
@@ -1,0 +1,46 @@
+package meta
+
+import (
+	"sync"
+)
+
+var (
+	spanNotifications = make(map[string]chan error)
+	notificationMu    sync.RWMutex
+)
+
+// RegisterSpanNotification creates and registers a notification channel for the
+// given span ID. The caller should wait on the returned channel to be notified
+// when a span has been exported.
+func RegisterSpanNotification(spanID string) <-chan error {
+	notificationMu.Lock()
+	defer notificationMu.Unlock()
+
+	ch := make(chan error, 1)
+	spanNotifications[spanID] = ch
+	return ch
+}
+
+// NotifySpanExported notifies any waiting goroutine that a span has been
+// exported. This should be called after the span has been successfully exported
+// (or failed to export).
+func NotifySpanExported(spanID string, err error) {
+	notificationMu.Lock()
+	ch, exists := spanNotifications[spanID]
+	if exists {
+		delete(spanNotifications, spanID)
+	}
+	notificationMu.Unlock()
+
+	if exists {
+		ch <- err
+	}
+}
+
+// CleanupSpanNotification removes a span notification without sending a result.
+// This is useful for cleanup in error scenarios.
+func CleanupSpanNotification(spanID string) {
+	notificationMu.Lock()
+	delete(spanNotifications, spanID)
+	notificationMu.Unlock()
+}

--- a/pkg/tracing/tracer_sqlc.go
+++ b/pkg/tracing/tracer_sqlc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 
 	sqlc "github.com/inngest/inngest/pkg/cqrs/base_cqrs/sqlc/sqlite"
 	"github.com/inngest/inngest/pkg/logger"
@@ -25,188 +26,173 @@ type dbExporter struct {
 
 func (e *dbExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
 	for _, span := range spans {
-		traceID := span.SpanContext().TraceID().String()
-		spanID := span.SpanContext().SpanID().String()
-		parentID := span.Parent().SpanID().String()
-		isExtensionSpan := span.Name() == meta.SpanNameDynamicExtension
-		var envID string
-		var accountID string
-		var appID string
-		var dynamicSpanID string
-		var functionID string
-		var output interface{}
-		var runID string
-		var debugSessionID string
-		var debugRunID string
+		e.exportSpan(ctx, span)
+	}
 
-		attrs := make(map[string]any)
-		for _, attr := range span.Attributes() {
-			// If output, extract and store separately
-			// This is always cleaned
-			if string(attr.Key) == meta.Attrs.StepOutput.Key() {
-				output = attr.Value.AsInterface()
+	return nil
+}
+
+func (e *dbExporter) exportSpan(ctx context.Context, span sdktrace.ReadOnlySpan) {
+	traceID := span.SpanContext().TraceID().String()
+	spanID := span.SpanContext().SpanID().String()
+	parentID := span.Parent().SpanID().String()
+	isExtensionSpan := span.Name() == meta.SpanNameDynamicExtension
+
+	var (
+		err            error
+		envID          string
+		accountID      string
+		appID          string
+		dynamicSpanID  string
+		functionID     string
+		output         interface{}
+		runID          string
+		debugSessionID string
+		debugRunID     string
+	)
+
+	defer func() {
+		if err != nil {
+			logger.StdlibLogger(ctx).Error(err.Error(),
+				"span_id", spanID,
+				"trace_id", traceID,
+				"parent_id", parentID,
+				"name", span.Name(),
+				"start_time", span.StartTime(),
+				"end_time", span.EndTime(),
+				"app_id", appID,
+				"function_id", functionID,
+			)
+		}
+
+		meta.NotifySpanExported(spanID, err)
+	}()
+
+	attrs := make(map[string]any)
+	for _, attr := range span.Attributes() {
+		// If output, extract and store separately
+		// This is always cleaned
+		if string(attr.Key) == meta.Attrs.StepOutput.Key() {
+			output = attr.Value.AsInterface()
+			continue
+		}
+
+		if string(attr.Key) == meta.Attrs.AccountID.Key() {
+			accountID = attr.Value.AsString()
+			if cleanAttrs {
 				continue
 			}
-
-			if string(attr.Key) == meta.Attrs.AccountID.Key() {
-				accountID = attr.Value.AsString()
-				if cleanAttrs {
-					continue
-				}
-			}
-
-			if string(attr.Key) == meta.Attrs.EnvID.Key() {
-				envID = attr.Value.AsString()
-				if cleanAttrs {
-					continue
-				}
-			}
-
-			// Capture but omit the run ID attribute from the span attributes
-			if string(attr.Key) == meta.Attrs.RunID.Key() {
-				runID = attr.Value.AsString()
-				if cleanAttrs {
-					continue
-				}
-			}
-
-			if string(attr.Key) == meta.Attrs.AppID.Key() {
-				appID = attr.Value.AsString()
-				if cleanAttrs {
-					continue
-				}
-			}
-
-			if string(attr.Key) == meta.Attrs.FunctionID.Key() {
-				functionID = attr.Value.AsString()
-				if cleanAttrs {
-					continue
-				}
-			}
-
-			// Capture but omit the dynamic span ID attribute from the span attributes
-			if string(attr.Key) == meta.Attrs.DynamicSpanID.Key() {
-				dynamicSpanID = attr.Value.AsString()
-				if cleanAttrs {
-					continue
-				}
-			}
-
-			// Omit drop span attribute if we're an extension span
-			if isExtensionSpan && string(attr.Key) == meta.Attrs.DropSpan.Key() {
-				if cleanAttrs {
-					continue
-				}
-			}
-
-			if string(attr.Key) == meta.Attrs.DebugSessionID.Key() {
-				debugSessionID = attr.Value.AsString()
-				if cleanAttrs {
-					continue
-				}
-			}
-
-			if string(attr.Key) == meta.Attrs.DebugRunID.Key() {
-				debugRunID = attr.Value.AsString()
-				if cleanAttrs {
-					continue
-				}
-			}
-
-			attrs[string(attr.Key)] = attr.Value.AsInterface()
 		}
 
-		// If we don't have a run ID, we can't store this span
-		if runID == "" {
-			logger.StdlibLogger(ctx).Error("span missing run ID",
-				"span_id", spanID,
-				"trace_id", traceID,
-				"parent_id", parentID,
-				"name", span.Name(),
-				"start_time", span.StartTime(),
-				"end_time", span.EndTime(),
-				"app_id", appID,
-				"function_id", functionID,
-			)
-			continue
+		if string(attr.Key) == meta.Attrs.EnvID.Key() {
+			envID = attr.Value.AsString()
+			if cleanAttrs {
+				continue
+			}
 		}
 
-		attrsByt, err := json.Marshal(attrs)
-		if err != nil {
-			logger.StdlibLogger(ctx).Error("failed to marshal span attributes",
-				"span_id", spanID,
-				"trace_id", traceID,
-				"parent_id", parentID,
-				"name", span.Name(),
-				"start_time", span.StartTime(),
-				"end_time", span.EndTime(),
-				"app_id", appID,
-				"function_id", functionID,
-				"error", err,
-			)
-			continue
+		// Capture but omit the run ID attribute from the span attributes
+		if string(attr.Key) == meta.Attrs.RunID.Key() {
+			runID = attr.Value.AsString()
+			if cleanAttrs {
+				continue
+			}
 		}
 
-		linksByt, err := json.Marshal(span.Links())
-		if err != nil {
-			logger.StdlibLogger(ctx).Error("failed to marshal span links",
-				"span_id", spanID,
-				"trace_id", traceID,
-				"parent_id", parentID,
-				"name", span.Name(),
-				"start_time", span.StartTime(),
-				"end_time", span.EndTime(),
-				"app_id", appID,
-				"function_id", functionID,
-				"error", err,
-			)
-			continue
+		if string(attr.Key) == meta.Attrs.AppID.Key() {
+			appID = attr.Value.AsString()
+			if cleanAttrs {
+				continue
+			}
 		}
 
-		err = e.q.InsertSpan(ctx, sqlc.InsertSpanParams{
-			SpanID:       spanID,
-			TraceID:      traceID,
-			ParentSpanID: sql.NullString{String: parentID, Valid: parentID != ""},
-			Name:         span.Name(),
-			StartTime:    span.StartTime(),
-			EndTime:      span.EndTime(),
-			RunID:        runID,
-			AppID:        appID,
-			FunctionID:   functionID,
-			Attributes:   string(attrsByt),
-			Links:        string(linksByt),
-			DynamicSpanID: sql.NullString{
-				String: dynamicSpanID,
-				Valid:  dynamicSpanID != "",
-			},
-			AccountID: accountID,
-			EnvID:     envID,
-			Output:    output,
-			DebugSessionID: sql.NullString{
-				String: debugSessionID,
-				Valid:  debugSessionID != "",
-			},
-			DebugRunID: sql.NullString{
-				String: debugRunID,
-				Valid:  debugRunID != "",
-			},
-		})
-		if err != nil {
-			logger.StdlibLogger(ctx).Error("failed to insert span into database",
-				"span_id", spanID,
-				"trace_id", traceID,
-				"parent_id", parentID,
-				"name", span.Name(),
-				"start_time", span.StartTime(),
-				"end_time", span.EndTime(),
-				"app_id", appID,
-				"function_id", functionID,
-				"error", err,
-			)
-			continue
+		if string(attr.Key) == meta.Attrs.FunctionID.Key() {
+			functionID = attr.Value.AsString()
+			if cleanAttrs {
+				continue
+			}
 		}
+
+		// Capture but omit the dynamic span ID attribute from the span attributes
+		if string(attr.Key) == meta.Attrs.DynamicSpanID.Key() {
+			dynamicSpanID = attr.Value.AsString()
+			if cleanAttrs {
+				continue
+			}
+		}
+
+		// Omit drop span attribute if we're an extension span
+		if isExtensionSpan && string(attr.Key) == meta.Attrs.DropSpan.Key() {
+			if cleanAttrs {
+				continue
+			}
+		}
+
+		if string(attr.Key) == meta.Attrs.DebugSessionID.Key() {
+			debugSessionID = attr.Value.AsString()
+			if cleanAttrs {
+				continue
+			}
+		}
+
+		if string(attr.Key) == meta.Attrs.DebugRunID.Key() {
+			debugRunID = attr.Value.AsString()
+			if cleanAttrs {
+				continue
+			}
+		}
+
+		attrs[string(attr.Key)] = attr.Value.AsInterface()
 	}
-	return nil
+
+	// If we don't have a run ID, we can't store this span
+	if runID == "" {
+		err = fmt.Errorf("span missing run ID")
+		return
+	}
+
+	attrsByt, err := json.Marshal(attrs)
+	if err != nil {
+		err = fmt.Errorf("failed to marshal span attributes: %w", err)
+		return
+	}
+
+	linksByt, err := json.Marshal(span.Links())
+	if err != nil {
+		err = fmt.Errorf("failed to marshal span links: %w", err)
+		return
+	}
+
+	if err = e.q.InsertSpan(ctx, sqlc.InsertSpanParams{
+		SpanID:       spanID,
+		TraceID:      traceID,
+		ParentSpanID: sql.NullString{String: parentID, Valid: parentID != ""},
+		Name:         span.Name(),
+		StartTime:    span.StartTime(),
+		EndTime:      span.EndTime(),
+		RunID:        runID,
+		AppID:        appID,
+		FunctionID:   functionID,
+		Attributes:   string(attrsByt),
+		Links:        string(linksByt),
+		DynamicSpanID: sql.NullString{
+			String: dynamicSpanID,
+			Valid:  dynamicSpanID != "",
+		},
+		AccountID: accountID,
+		EnvID:     envID,
+		Output:    output,
+		DebugSessionID: sql.NullString{
+			String: debugSessionID,
+			Valid:  debugSessionID != "",
+		},
+		DebugRunID: sql.NullString{
+			String: debugRunID,
+			Valid:  debugRunID != "",
+		},
+	}); err != nil {
+		err = fmt.Errorf("failed to insert span into database: %w", err)
+	}
 }
 
 func (e *dbExporter) Shutdown(context.Context) error { return nil }


### PR DESCRIPTION
## Description

Enables synchronous committing of spans for the incoming tracing work.

It still runs through the regular otel pipeline, so we use channels here to wait for each span to be sent individually.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
