### PR TITLE
Allow incoming tracing to fail; log only

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -561,7 +561,8 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error creating run span: %w", err)
+		// return nil, fmt.Errorf("error creating run span: %w", err)
+		l.Debug("error creating run span", "error", err)
 	}
 
 	config.NewSetFunctionTrace(runSpanRef)
@@ -1040,7 +1041,9 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			},
 		)
 		if err != nil {
-			return nil, fmt.Errorf("error creating initial step span: %w", err)
+			// return nil, fmt.Errorf("error creating initial step span: %w",
+			// err)
+			l.Debug("error creating initial step span", "error", err)
 		}
 
 	} else if isSleepResume {
@@ -1057,7 +1060,9 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			},
 		)
 		if err != nil {
-			return nil, fmt.Errorf("error creating discovery step span after sleep resume: %w", err)
+			// return nil, fmt.Errorf("error creating discovery step span
+			// after sleep resume: %w", err)
+			l.Debug("error creating discovery step span after sleep resume", "error", err)
 		}
 	} else {
 		// If we're here, we assume that the step span has already been
@@ -1078,7 +1083,8 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("error creating execution span: %w", err)
+		// return nil, fmt.Errorf("error creating execution span: %w", err)
+		l.Debug("error creating execution span", "error", err)
 	}
 
 	return util.CritT(ctx, "run step", func(ctx context.Context) (*state.DriverResponse, error) {
@@ -2212,7 +2218,9 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 				},
 			)
 			if err != nil {
-				return fmt.Errorf("error creating span for next step after resume: %w", err)
+				// return fmt.Errorf("error creating span for next step
+				// after resume: %w", err)
+				e.log.Debug("error creating span for next step after resume", "error", err)
 			}
 
 			err = e.queue.Enqueue(ctx, nextItem, time.Now(), queue.EnqueueOpts{})
@@ -2501,7 +2509,9 @@ func (e *executor) handleGeneratorStep(ctx context.Context, i *runInstance, gen 
 			},
 		)
 		if err != nil {
-			return fmt.Errorf("error creating span for next step after Step: %w", err)
+			// return fmt.Errorf("error creating span for next step after
+			// Step: %w", err)
+			e.log.Debug("error creating span for next step after Step", "error", err)
 		}
 
 		err = e.queue.Enqueue(ctx, nextItem, now, queue.EnqueueOpts{})
@@ -2645,7 +2655,9 @@ func (e *executor) handleStepError(ctx context.Context, i *runInstance, gen stat
 			},
 		)
 		if err != nil {
-			return fmt.Errorf("error creating span for next step after StepError: %w", err)
+			// return fmt.Errorf("error creating span for next step after
+			// StepError: %w", err)
+			e.log.Debug("error creating span for next step after StepError", "error", err)
 		}
 
 		err = e.queue.Enqueue(ctx, nextItem, now, queue.EnqueueOpts{})
@@ -2720,7 +2732,9 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, i *runInstanc
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error creating span for next step after StepPlanned: %w", err)
+		// return fmt.Errorf("error creating span for next step after
+		// StepPlanned: %w", err)
+		e.log.Debug("error creating span for next step after StepPlanned", "error", err)
 	}
 
 	err = e.queue.Enqueue(ctx, nextItem, now, queue.EnqueueOpts{})
@@ -2792,7 +2806,9 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, i *runInstance, gen
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error creating span for next step after Sleep: %w", err)
+		// return fmt.Errorf("error creating span for next step after Sleep:
+		// %w", err)
+		e.log.Debug("error creating span for next step after Sleep", "error", err)
 	}
 
 	err = e.queue.Enqueue(ctx, nextItem, until, queue.EnqueueOpts{
@@ -3466,7 +3482,9 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, i *runInstan
 		},
 	)
 	if err != nil {
-		return fmt.Errorf("error creating span for next step after WaitForEvent: %w", err)
+		// return fmt.Errorf("error creating span for next step after
+		// WaitForEvent: %w", err)
+		e.log.Debug("error creating span for next step after WaitForEvent", "error", err)
 	}
 
 	idx := pauses.Index{WorkspaceID: i.md.ID.Tenant.EnvID, EventName: opts.Event}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1299,11 +1299,12 @@ func (e *executor) finalize(ctx context.Context, md sv2.Metadata, evts []json.Ra
 		runStatus = enums.StepStatusFailed
 	}
 
+	targetSpan := tracing.RunSpanRefFromMetadata(&md)
 	err := e.tracerProvider.UpdateSpan(&tracing.UpdateSpanOptions{
 		EndTime:    time.Now(),
 		Debug:      &tracing.SpanDebugData{Location: "executor.finalize"},
 		Metadata:   &md,
-		TargetSpan: tracing.RunSpanRefFromMetadata(&md),
+		TargetSpan: targetSpan,
 		Status:     runStatus,
 		Attributes: tracing.DriverResponseAttrs(&resp, outputSpanRef),
 	})
@@ -1312,6 +1313,7 @@ func (e *executor) finalize(ctx context.Context, md sv2.Metadata, evts []json.Ra
 			"error updating run span end time",
 			"error", err,
 			"run_id", md.ID.RunID.String(),
+			"target_span", targetSpan,
 		)
 	}
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1309,6 +1309,7 @@ func (e *executor) finalize(ctx context.Context, md sv2.Metadata, evts []json.Ra
 		Attributes: tracing.DriverResponseAttrs(&resp, outputSpanRef),
 	})
 	if err != nil {
+		// TODO This should be a warning/error once these spans are critical.
 		l.Debug(
 			"error updating run span end time",
 			"error", err,

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -861,7 +861,7 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 			TargetSpan: tracing.SpanRefFromQueueItem(&item),
 		})
 		if err != nil {
-			return nil, fmt.Errorf("error updating sleep resume span: %w", err)
+			l.Debug("error updating sleep resume span", "error", err)
 		}
 
 		hasPendingSteps, err := e.smv2.SaveStep(ctx, sv2.ID{

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1309,7 +1309,7 @@ func (e *executor) finalize(ctx context.Context, md sv2.Metadata, evts []json.Ra
 		Attributes: tracing.DriverResponseAttrs(&resp, outputSpanRef),
 	})
 	if err != nil {
-		l.Error(
+		l.Debug(
 			"error updating run span end time",
 			"error", err,
 			"run_id", md.ID.RunID.String(),


### PR DESCRIPTION
## Description

Better logging for a particular issue and making sure that incoming tracing does not affect execution atm.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
