### PR TITLE
Loosen the pnpm constraint

### DIFF
--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -108,7 +108,7 @@
   },
   "engines": {
     "node": "20.x",
-    "pnpm": "8.15.8"
+    "pnpm": "8.x"
   },
   "packageManager": "pnpm@8.15.8",
   "private": true,

--- a/ui/apps/dev-server-ui/package.json
+++ b/ui/apps/dev-server-ui/package.json
@@ -78,7 +78,7 @@
   },
   "engines": {
     "node": "20.x",
-    "pnpm": "8.15.8"
+    "pnpm": "8.x"
   },
   "packageManager": "pnpm@8.15.8",
   "private": true

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,7 +15,7 @@
   },
   "engines": {
     "node": "20.x",
-    "pnpm": "8.15.8"
+    "pnpm": "8.x"
   },
   "workspaces": [
     "packages/*",


### PR DESCRIPTION
## Description

Loosen the `pnpm` constraint from `8.15.8` to `8.x`.

This is mostly to allow nicer compat with Nix, but there shouldn't be any changes in non-major versions anyway and the `packageManager` field should still pin the version most of the time.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- Some similar tweaks to #2765 

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
