### PR TITLE
Add RunComplete opcode

### DIFF
--- a/pkg/enums/opcode.go
+++ b/pkg/enums/opcode.go
@@ -17,4 +17,25 @@ const (
 	OpcodeAIGateway // AI gateway inference call
 	OpcodeGateway   // Gateway call
 	OpcodeWaitForSignal
+	OpcodeRunComplete // A run has completed successfully
 )
+
+// opcodeSyncMap explicitly represents the sync opcodes that can be checkpointed.
+// Every other opcode is async by default, and this is always a subset.
+var opcodeSyncMap = map[Opcode]struct{}{
+	OpcodeStep:        {},
+	OpcodeStepRun:     {},
+	OpcodeRunComplete: {},
+}
+
+// OpcodeIsSync returns whether the given opcode is synchronous.  This
+// allows us to process specific opcodes in sync runs without switching
+// to async execution.
+func OpcodeIsSync(o Opcode) bool {
+	_, ok := opcodeSyncMap[o]
+	return ok
+}
+
+func OpcodeIsAsync(o Opcode) bool {
+	return !OpcodeIsSync(o)
+}

--- a/pkg/enums/opcode_enumer.go
+++ b/pkg/enums/opcode_enumer.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-const _OpcodeName = "NoneStepStepRunStepErrorStepPlannedSleepWaitForEventInvokeFunctionAIGatewayGatewayWaitForSignal"
+const _OpcodeName = "NoneStepStepRunStepErrorStepPlannedSleepWaitForEventInvokeFunctionAIGatewayGatewayWaitForSignalRunComplete"
 
-var _OpcodeIndex = [...]uint8{0, 4, 8, 15, 24, 35, 40, 52, 66, 75, 82, 95}
+var _OpcodeIndex = [...]uint8{0, 4, 8, 15, 24, 35, 40, 52, 66, 75, 82, 95, 106}
 
-const _OpcodeLowerName = "nonestepsteprunsteperrorstepplannedsleepwaitforeventinvokefunctionaigatewaygatewaywaitforsignal"
+const _OpcodeLowerName = "nonestepsteprunsteperrorstepplannedsleepwaitforeventinvokefunctionaigatewaygatewaywaitforsignalruncomplete"
 
 func (i Opcode) String() string {
 	if i < 0 || i >= Opcode(len(_OpcodeIndex)-1) {
@@ -36,33 +36,36 @@ func _OpcodeNoOp() {
 	_ = x[OpcodeAIGateway-(8)]
 	_ = x[OpcodeGateway-(9)]
 	_ = x[OpcodeWaitForSignal-(10)]
+	_ = x[OpcodeRunComplete-(11)]
 }
 
-var _OpcodeValues = []Opcode{OpcodeNone, OpcodeStep, OpcodeStepRun, OpcodeStepError, OpcodeStepPlanned, OpcodeSleep, OpcodeWaitForEvent, OpcodeInvokeFunction, OpcodeAIGateway, OpcodeGateway, OpcodeWaitForSignal}
+var _OpcodeValues = []Opcode{OpcodeNone, OpcodeStep, OpcodeStepRun, OpcodeStepError, OpcodeStepPlanned, OpcodeSleep, OpcodeWaitForEvent, OpcodeInvokeFunction, OpcodeAIGateway, OpcodeGateway, OpcodeWaitForSignal, OpcodeRunComplete}
 
 var _OpcodeNameToValueMap = map[string]Opcode{
-	_OpcodeName[0:4]:        OpcodeNone,
-	_OpcodeLowerName[0:4]:   OpcodeNone,
-	_OpcodeName[4:8]:        OpcodeStep,
-	_OpcodeLowerName[4:8]:   OpcodeStep,
-	_OpcodeName[8:15]:       OpcodeStepRun,
-	_OpcodeLowerName[8:15]:  OpcodeStepRun,
-	_OpcodeName[15:24]:      OpcodeStepError,
-	_OpcodeLowerName[15:24]: OpcodeStepError,
-	_OpcodeName[24:35]:      OpcodeStepPlanned,
-	_OpcodeLowerName[24:35]: OpcodeStepPlanned,
-	_OpcodeName[35:40]:      OpcodeSleep,
-	_OpcodeLowerName[35:40]: OpcodeSleep,
-	_OpcodeName[40:52]:      OpcodeWaitForEvent,
-	_OpcodeLowerName[40:52]: OpcodeWaitForEvent,
-	_OpcodeName[52:66]:      OpcodeInvokeFunction,
-	_OpcodeLowerName[52:66]: OpcodeInvokeFunction,
-	_OpcodeName[66:75]:      OpcodeAIGateway,
-	_OpcodeLowerName[66:75]: OpcodeAIGateway,
-	_OpcodeName[75:82]:      OpcodeGateway,
-	_OpcodeLowerName[75:82]: OpcodeGateway,
-	_OpcodeName[82:95]:      OpcodeWaitForSignal,
-	_OpcodeLowerName[82:95]: OpcodeWaitForSignal,
+	_OpcodeName[0:4]:         OpcodeNone,
+	_OpcodeLowerName[0:4]:    OpcodeNone,
+	_OpcodeName[4:8]:         OpcodeStep,
+	_OpcodeLowerName[4:8]:    OpcodeStep,
+	_OpcodeName[8:15]:        OpcodeStepRun,
+	_OpcodeLowerName[8:15]:   OpcodeStepRun,
+	_OpcodeName[15:24]:       OpcodeStepError,
+	_OpcodeLowerName[15:24]:  OpcodeStepError,
+	_OpcodeName[24:35]:       OpcodeStepPlanned,
+	_OpcodeLowerName[24:35]:  OpcodeStepPlanned,
+	_OpcodeName[35:40]:       OpcodeSleep,
+	_OpcodeLowerName[35:40]:  OpcodeSleep,
+	_OpcodeName[40:52]:       OpcodeWaitForEvent,
+	_OpcodeLowerName[40:52]:  OpcodeWaitForEvent,
+	_OpcodeName[52:66]:       OpcodeInvokeFunction,
+	_OpcodeLowerName[52:66]:  OpcodeInvokeFunction,
+	_OpcodeName[66:75]:       OpcodeAIGateway,
+	_OpcodeLowerName[66:75]:  OpcodeAIGateway,
+	_OpcodeName[75:82]:       OpcodeGateway,
+	_OpcodeLowerName[75:82]:  OpcodeGateway,
+	_OpcodeName[82:95]:       OpcodeWaitForSignal,
+	_OpcodeLowerName[82:95]:  OpcodeWaitForSignal,
+	_OpcodeName[95:106]:      OpcodeRunComplete,
+	_OpcodeLowerName[95:106]: OpcodeRunComplete,
 }
 
 var _OpcodeNames = []string{
@@ -77,6 +80,7 @@ var _OpcodeNames = []string{
 	_OpcodeName[66:75],
 	_OpcodeName[75:82],
 	_OpcodeName[82:95],
+	_OpcodeName[95:106],
 }
 
 // OpcodeString retrieves an enum value from the enum constants string name.

--- a/pkg/execution/state/opcode.go
+++ b/pkg/execution/state/opcode.go
@@ -253,6 +253,26 @@ func (g GeneratorOpcode) SignalOpts() (*SignalOpts, error) {
 	return opts, nil
 }
 
+// RunCompleteData unmarshals function output to the given pointer,
+// assuming the opcode has data within the Data field.
+//
+// NOTE: For consistency, the data must always be wrapped within
+// a `data` object, allowing us to add other metadata as non-conflicting
+// top-level keys in the future.
+func (g GeneratorOpcode) RunCompleteData(data any) error {
+	if len(g.Data) == 0 {
+		return nil
+	}
+	res := &RunCompleteData{}
+	if err := json.Unmarshal(g.Data, res); err != nil {
+		return err
+	}
+	if len(res.Data) == 0 {
+		return nil
+	}
+	return json.Unmarshal(res.Data, data)
+}
+
 type SignalOpts struct {
 	Signal     string `json:"signal"`
 	Timeout    string `json:"timeout"`
@@ -389,6 +409,12 @@ func (r *RunOpts) UnmarshalAny(a any) error {
 
 	*r = opts
 	return nil
+}
+
+type RunCompleteData struct {
+	// Data represents the run's resulting data.  Note that
+	// this may be nil.
+	Data json.RawMessage `json:"data"`
 }
 
 type WaitForEventOpts struct {


### PR DESCRIPTION
## Description

- Adds an opcode for successfully completing runs
- Also allows optional run output (data)

Note that function results (data) and finishing may be split into multiple opcodes in the future.  A function's return value may not indicate that the run ends wrt. future background steps.

This is entirely backwards compatible.

## Motivation

Simplify codepaths, QPS, and such.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
