### PR TITLE
Fix gocache bug not caching properly with redis

### DIFF
--- a/pkg/api/apiv1/apiv1.go
+++ b/pkg/api/apiv1/apiv1.go
@@ -26,7 +26,7 @@ type Opts struct {
 	AuthMiddleware func(http.Handler) http.Handler
 	// CachingMiddleware caches API responses, if the handler specifies
 	// a max-age.
-	CachingMiddleware CachingMiddleware
+	CachingMiddleware CachingMiddleware[[]byte]
 	// WorkspaceFinder returns the authenticated workspace given the current context.
 	AuthFinder apiv1auth.AuthFinder
 	// Executor is required to cancel and manage function executions.

--- a/pkg/api/apiv1/events.go
+++ b/pkg/api/apiv1/events.go
@@ -158,5 +158,5 @@ func (a router) getEventRuns(w http.ResponseWriter, r *http.Request) {
 		_ = publicerr.WriteHTTP(w, err)
 		return
 	}
-	_ = WriteCachedResponse(w, runs, 5*time.Second)
+	_ = WriteCachedResponse(w, runs, 15*time.Second)
 }

--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -581,3 +581,20 @@ func ActiveBacklogNormalizeCount(ctx context.Context, incr int64, opts CounterOp
 		Tags:        opts.Tags,
 	})
 }
+
+func IncrAPICacheHit(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "http_api_cache_hit",
+		Description: "The number of times a HTTP API request is served from cache",
+		Tags:        opts.Tags,
+	})
+}
+func IncrAPICacheMiss(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "http_api_cache_miss",
+		Description: "The number of times a HTTP API request is not served from cache",
+		Tags:        opts.Tags,
+	})
+}


### PR DESCRIPTION
## Description

- Fixes gocache bug in Cloud, also keeps it compatible with freecache in OSS which does not support storing strings as far as I checked
	https://github.com/eko/gocache/issues/197#issuecomment-1679348756
- Add cache hit/miss metrics that we patched last friday. 
- Cache event runs API for 15 seconds instead of 5 (also patched in Cloud since last week)

## Motivation
https://linear.app/inngest/issue/SYS-278/fix-gocache-bug-impacting-cache-on-prod

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
