### PR TITLE
Fix validation and error messages for signing-key

### DIFF
--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -36,7 +36,7 @@ func Command() *cli.Command {
 			},
 			&cli.StringFlag{
 				Name:  "signing-key",
-				Usage: "Signing key used to sign and validate data between the server and apps.",
+				Usage: "Signing key used to sign and validate data between the server and apps. Must be hex string with even number of chars",
 			},
 			&cli.StringSliceFlag{
 				Name:  "event-key",

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -78,9 +78,14 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		fmt.Println("Error: signing-key is required")
 		os.Exit(1)
 	}
+	// Check if the signing key has an even number of characters (required for hex decoding)
+	if len(signingKey)%2 != 0 {
+		fmt.Printf("Error: signing-key must be hex string with even number of chars\n")
+		os.Exit(1)
+	}
 	_, err = authn.HashedSigningKey(signingKey)
 	if err != nil {
-		fmt.Printf("Error: signing-key must be a valid hexadecimal string\n")
+		fmt.Printf("Error: signing-key must be valid hex string: %v\n", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Description

### Update validation and error messages
- check if string is even number of chars
- display error returned from `anthn.HashedSigningKey()` for easier debugging
- match error messages to documentation
<img width="1018" height="757" alt="image" src="https://github.com/user-attachments/assets/db547b0c-cdc5-4ac1-9243-bf87bb1d647c" />

## Motivation
Better, more cohesive user experience

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
