### PR TITLE
Add Concurrency CTA

### DIFF
--- a/ui/apps/dashboard/src/components/Billing/Addons/EntitlementListItem.tsx
+++ b/ui/apps/dashboard/src/components/Billing/Addons/EntitlementListItem.tsx
@@ -2,6 +2,8 @@
 
 import { Button } from '@inngest/components/Button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
+import { useSearchParam } from '@inngest/components/hooks/useSearchParam';
+import { cn } from '@inngest/components/utils/classNames';
 import { RiInformationLine } from '@remixicon/react';
 
 import EntitlementListItemSelfService from '@/components/Billing/Addons/EntitlementListItemSelfService';
@@ -38,6 +40,9 @@ export default function EntitlementListItem({
   }; // No addon, or no price, implies self-service is not available.
   onChange?: () => void;
 }) {
+  const [highlight] = useSearchParam('highlight');
+
+  const highlighted = highlight === title.toLowerCase().replace(/ /g, '-');
   const tooltip = tooltipContent ? (
     <Tooltip>
       <TooltipTrigger>
@@ -127,5 +132,14 @@ export default function EntitlementListItem({
     );
   }
 
-  return <div className="mb-5">{content}</div>;
+  return (
+    <div
+      className={cn(
+        'mb-5 transition-colors duration-300',
+        highlighted && 'bg-primary-subtle/10 border-primary-subtle/20 rounded-md border p-3'
+      )}
+    >
+      {content}
+    </div>
+  );
 }

--- a/ui/apps/dashboard/src/components/Metrics/Concurrency.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/Concurrency.tsx
@@ -118,7 +118,7 @@ export const AccountConcurrency = ({
           label="Increase Concurrency"
           kind="secondary"
           appearance="outlined"
-          href={`${pathCreator.billing({ ref: 'app-concurrency-chart' })}&highlight=concurrency`}
+          href={pathCreator.billing({ ref: 'app-concurrency-chart', highlight: 'concurrency' })}
         />
       </div>
       <div className="flex h-full flex-row items-center">

--- a/ui/apps/dashboard/src/components/Metrics/Concurrency.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/Concurrency.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@inngest/components/Button';
 import { Chart } from '@inngest/components/Chart/Chart';
 import { Info } from '@inngest/components/Info/Info';
 import { Link } from '@inngest/components/Link/Link';
@@ -6,6 +7,7 @@ import { isDark } from '@inngest/components/utils/theme';
 import resolveConfig from 'tailwindcss/resolveConfig';
 
 import type { VolumeMetricsQuery } from '@/gql/graphql';
+import { pathCreator } from '@/utils/urls';
 import tailwindConfig from '../../../tailwind.config';
 import type { EntityLookup } from './Dashboard';
 import { getLineChartOptions, getXAxis, lineColors, seriesOptions } from './utils';
@@ -112,6 +114,12 @@ export const AccountConcurrency = ({
             }
           />
         </div>
+        <Button
+          label="Increase Concurrency"
+          kind="secondary"
+          appearance="outlined"
+          href={`${pathCreator.billing({ ref: 'app-concurrency-chart' })}&highlight=concurrency`}
+        />
       </div>
       <div className="flex h-full flex-row items-center">
         <Chart

--- a/ui/apps/dashboard/src/utils/urls.ts
+++ b/ui/apps/dashboard/src/utils/urls.ts
@@ -46,8 +46,24 @@ export const pathCreator = {
   appSyncs({ envSlug, externalAppID }: { envSlug: string; externalAppID: string }): Route {
     return `/env/${envSlug}/apps/${encodeURIComponent(externalAppID)}/syncs` as Route;
   },
-  billing({ ref, tab }: { ref?: string; tab?: string } = {}): Route {
-    return `/billing${tab ? `/${tab}` : ''}${ref ? `?ref=${ref}` : ''}` as Route;
+  billing({ ref, tab, highlight }: { ref?: string; tab?: string; highlight?: string } = {}): Route {
+    let path = '/billing';
+    if (tab) {
+      path += `/${tab}`;
+    }
+
+    const query = new URLSearchParams();
+    if (highlight) {
+      query.set('highlight', highlight);
+    }
+    if (ref) {
+      query.set('ref', ref);
+    }
+    if (query.toString()) {
+      path += `?${query.toString()}`;
+    }
+
+    return path as Route;
   },
   createApp({ envSlug }: { envSlug: string }): Route {
     return `/env/${envSlug}/apps/sync-new` as Route;


### PR DESCRIPTION
## Description

Adds concurrency CTA to `/[environment]/metrics` and a subtle highlight to the associated entitlement

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

<img width="2986" height="1784" alt="image" src="https://github.com/user-attachments/assets/4402e4b9-72c6-4992-94cf-4c27c6591e15" />

<img width="1496" height="897" alt="Screenshot 2025-08-06 at 10 42 53 AM" src="https://github.com/user-attachments/assets/9f565912-03cc-4063-92c6-1030ce1e807f" />
