### PR TITLE
[Insights]: Refactor Insights ahead of multi-tab support

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/insights/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/insights/page.tsx
@@ -3,43 +3,16 @@
 import { Header } from '@inngest/components/Header/Header';
 
 import { useBooleanFlag } from '@/components/FeatureFlags/hooks';
-import { InsightsDataTable } from '@/components/Insights/InsightsDataTable/InsightsDataTable';
-import { InsightsSQLEditor } from '@/components/Insights/InsightsSQLEditor/InsightsSQLEditor';
-import { InsightsSQLEditorDownloadCSVButton } from '@/components/Insights/InsightsSQLEditor/InsightsSQLEditorDownloadCSVButton';
-import { InsightsSQLEditorQueryButton } from '@/components/Insights/InsightsSQLEditor/InsightsSQLEditorQueryButton';
-import {
-  InsightsStateMachineContextProvider,
-  useInsightsStateMachineContext,
-} from '@/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext';
-import { Section } from '@/components/Insights/Section';
+import { useInsightsTabManager } from '@/components/Insights/InsightsTabManager/InsightsTabManager';
 
 function InsightsContent() {
-  const { status } = useInsightsStateMachineContext();
-  const isRunning = status === 'loading';
+  const { tabManager } = useInsightsTabManager();
 
   return (
     <>
       <Header breadcrumb={[{ text: 'Insights' }]} />
-      <main className="grid h-full w-full flex-1 grid-rows-[3fr_5fr] gap-0 overflow-hidden">
-        <Section
-          actions={<InsightsSQLEditorQueryButton />}
-          className="min-h-[255px]"
-          title="Query Editor"
-        >
-          <InsightsSQLEditor />
-        </Section>
-        <Section
-          actions={
-            <>
-              {isRunning && <span className="text-muted mr-3 text-xs">Running query...</span>}
-              <InsightsSQLEditorDownloadCSVButton />
-            </>
-          }
-          title="Results"
-        >
-          <InsightsDataTable />
-        </Section>
-      </main>
+      {/* TODO: Add templates, recent queries, saved queries sidepanel */}
+      {tabManager}
     </>
   );
 }
@@ -48,9 +21,5 @@ export default function InsightsPage() {
   const { value: isInsightsEnabled } = useBooleanFlag('insights');
   if (!isInsightsEnabled) return null;
 
-  return (
-    <InsightsStateMachineContextProvider>
-      <InsightsContent />
-    </InsightsStateMachineContextProvider>
-  );
+  return <InsightsContent />;
 }

--- a/ui/apps/dashboard/src/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext.tsx
@@ -36,7 +36,13 @@ interface InsightsStateMachineContextValue extends InsightsState {
 
 const InsightsStateMachineContext = createContext<InsightsStateMachineContextValue | null>(null);
 
-export function InsightsStateMachineContextProvider({ children }: { children: ReactNode }) {
+export function InsightsStateMachineContextProvider({
+  children,
+  renderChildren = true,
+}: {
+  children: ReactNode;
+  renderChildren?: boolean;
+}) {
   const [queryState, dispatch] = useReducer(insightsStateMachineReducer, INITIAL_STATE);
 
   // TODO: Ensure runQuery and fetchMore cannot finish out of order
@@ -86,7 +92,7 @@ export function InsightsStateMachineContextProvider({ children }: { children: Re
         runQuery,
       }}
     >
-      {children}
+      {renderChildren ? children : null}
     </InsightsStateMachineContext.Provider>
   );
 }

--- a/ui/apps/dashboard/src/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext.tsx
@@ -36,13 +36,15 @@ interface InsightsStateMachineContextValue extends InsightsState {
 
 const InsightsStateMachineContext = createContext<InsightsStateMachineContextValue | null>(null);
 
+type InsightsStateMachineContextProviderProps = {
+  children: ReactNode;
+  renderChildren: boolean;
+};
+
 export function InsightsStateMachineContextProvider({
   children,
-  renderChildren = true,
-}: {
-  children: ReactNode;
-  renderChildren?: boolean;
-}) {
+  renderChildren,
+}: InsightsStateMachineContextProviderProps) {
   const [queryState, dispatch] = useReducer(insightsStateMachineReducer, INITIAL_STATE);
 
   // TODO: Ensure runQuery and fetchMore cannot finish out of order

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 
 import { InsightsStateMachineContextProvider } from '@/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext';
 import { InsightsTabPanel } from './InsightsTabPanel';
+import { InsightsTabsList } from './InsightsTabsList';
 
 const HOME_TAB = { id: '__home', name: 'Home' } as const;
 
@@ -59,8 +60,8 @@ export function useInsightsTabManager(): UseInsightsTabManagerReturn {
   );
 
   const tabManager = useMemo(
-    () => <InsightsTabManagerInternal activeTabId={activeTabId} tabs={tabs} />,
-    [tabs, activeTabId]
+    () => <InsightsTabManagerInternal actions={actions} activeTabId={activeTabId} tabs={tabs} />,
+    [actions, activeTabId, tabs]
   );
 
   return { actions, activeTabId, tabManager, tabs };
@@ -69,18 +70,25 @@ export function useInsightsTabManager(): UseInsightsTabManagerReturn {
 interface InsightsTabManagerInternalProps {
   activeTabId: string;
   tabs: TabConfig[];
+  actions: TabManagerActions;
 }
 
-function InsightsTabManagerInternal({ tabs, activeTabId }: InsightsTabManagerInternalProps) {
+function InsightsTabManagerInternal({
+  tabs,
+  activeTabId,
+  actions,
+}: InsightsTabManagerInternalProps) {
   return (
-    <main className="grid h-full w-full flex-1 grid-rows-[3fr_5fr] gap-0 overflow-hidden">
-      {/* TODO: Tab navigation UI */}
-      {tabs.map((tab) => (
-        <InsightsStateMachineContextProvider key={tab.id} renderChildren={tab.id === activeTabId}>
-          <InsightsTabPanel />
-        </InsightsStateMachineContextProvider>
-      ))}
-    </main>
+    <div className="flex h-full w-full flex-1 flex-col overflow-hidden">
+      <InsightsTabsList actions={actions} activeTabId={activeTabId} hide tabs={tabs} />
+      <div className="grid h-full w-full flex-1 grid-rows-[3fr_5fr] gap-0 overflow-hidden">
+        {tabs.map((tab) => (
+          <InsightsStateMachineContextProvider key={tab.id} renderChildren={tab.id === activeTabId}>
+            <InsightsTabPanel />
+          </InsightsStateMachineContextProvider>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
@@ -73,14 +73,14 @@ interface InsightsTabManagerInternalProps {
 
 function InsightsTabManagerInternal({ tabs, activeTabId }: InsightsTabManagerInternalProps) {
   return (
-    <div className="h-full w-full">
+    <main className="grid h-full w-full flex-1 grid-rows-[3fr_5fr] gap-0 overflow-hidden">
       {/* TODO: Tab navigation UI */}
       {tabs.map((tab) => (
         <InsightsStateMachineContextProvider key={tab.id} renderChildren={tab.id === activeTabId}>
           <InsightsTabPanel />
         </InsightsStateMachineContextProvider>
       ))}
-    </div>
+    </main>
   );
 }
 

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import { InsightsStateMachineContextProvider } from '@/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext';
+import { InsightsTabPanel } from './InsightsTabPanel';
+
+const HOME_TAB = { id: '__home', name: 'Home' } as const;
+
+export interface TabConfig {
+  id: string;
+  name: string;
+}
+
+export interface TabManagerActions {
+  closeTab: (id: string) => void;
+  createTab: (id: string, name?: string) => void;
+  focusTab: (id: string) => void;
+}
+
+export interface UseInsightsTabManagerReturn {
+  actions: TabManagerActions;
+  activeTabId: string;
+  tabManager: JSX.Element;
+  tabs: TabConfig[];
+}
+
+export function useInsightsTabManager(): UseInsightsTabManagerReturn {
+  const [tabs, setTabs] = useState<TabConfig[]>([HOME_TAB]);
+  const [activeTabId, setActiveTabId] = useState<string>(HOME_TAB.id);
+
+  const actions = useMemo(
+    () => ({
+      closeTab: (id: string) => {
+        if (id === HOME_TAB.id) return;
+
+        setTabs((prevTabs) => {
+          const tabIndex = prevTabs.findIndex((tab) => tab.id === id);
+          if (tabIndex === -1) return prevTabs;
+
+          const newActiveTabId = getNewActiveTabAfterClose(prevTabs, id, activeTabId);
+          setActiveTabId(newActiveTabId);
+
+          return prevTabs.filter((tab) => tab.id !== id);
+        });
+      },
+      createTab: (id: string, name = 'Untitled query') => {
+        if (tabs.some((tab) => tab.id === id)) return;
+
+        setTabs((prevTabs) => [...prevTabs, { id, name }]);
+        setActiveTabId(id);
+      },
+      focusTab: (id: string) => {
+        const tab = tabs.find((tab) => tab.id === id);
+        if (tab !== undefined) setActiveTabId(id);
+      },
+    }),
+    [activeTabId, tabs]
+  );
+
+  const tabManager = useMemo(
+    () => <InsightsTabManagerInternal activeTabId={activeTabId} tabs={tabs} />,
+    [tabs, activeTabId]
+  );
+
+  return { actions, activeTabId, tabManager, tabs };
+}
+
+interface InsightsTabManagerInternalProps {
+  activeTabId: string;
+  tabs: TabConfig[];
+}
+
+function InsightsTabManagerInternal({ tabs, activeTabId }: InsightsTabManagerInternalProps) {
+  return (
+    <div className="h-full w-full">
+      {/* TODO: Tab navigation UI */}
+      {tabs.map((tab) => (
+        <InsightsStateMachineContextProvider key={tab.id} renderChildren={tab.id === activeTabId}>
+          <InsightsTabPanel />
+        </InsightsStateMachineContextProvider>
+      ))}
+    </div>
+  );
+}
+
+function getNewActiveTabAfterClose(
+  existingTabs: TabConfig[],
+  tabIdToClose: string,
+  currentActiveTabId: string
+): string {
+  if (tabIdToClose !== currentActiveTabId) return currentActiveTabId;
+
+  const closingTabIndex = existingTabs.findIndex((tab) => tab.id === tabIdToClose);
+  if (closingTabIndex === -1) return currentActiveTabId;
+
+  // 1: Try to select the next tab (now where the closed tab was).
+  // 2: Try to select the tab before the closed tab.
+  // 3: Fallback to the home tab.
+  const remainingTabs = existingTabs.filter((tab) => tab.id !== tabIdToClose);
+  const newlySelectedTabId =
+    remainingTabs[closingTabIndex]?.id ?? remainingTabs[closingTabIndex - 1]?.id ?? HOME_TAB.id;
+  return newlySelectedTabId;
+}

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanel.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanel.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { InsightsDataTable } from '@/components/Insights/InsightsDataTable/InsightsDataTable';
+import { InsightsSQLEditor } from '@/components/Insights/InsightsSQLEditor/InsightsSQLEditor';
+import { InsightsSQLEditorDownloadCSVButton } from '@/components/Insights/InsightsSQLEditor/InsightsSQLEditorDownloadCSVButton';
+import { InsightsSQLEditorQueryButton } from '@/components/Insights/InsightsSQLEditor/InsightsSQLEditorQueryButton';
+import { useInsightsStateMachineContext } from '@/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext';
+import { Section } from '@/components/Insights/Section';
+
+export function InsightsTabPanel() {
+  const { status } = useInsightsStateMachineContext();
+  const isRunning = status === 'loading';
+
+  return (
+    <main className="grid h-full w-full flex-1 grid-rows-[3fr_5fr] gap-0 overflow-hidden">
+      <Section
+        actions={<InsightsSQLEditorQueryButton />}
+        className="min-h-[255px]"
+        title="Query Editor"
+      >
+        <InsightsSQLEditor />
+      </Section>
+      <Section
+        actions={
+          <>
+            {isRunning && <span className="text-muted mr-3 text-xs">Running query...</span>}
+            <InsightsSQLEditorDownloadCSVButton />
+          </>
+        }
+        title="Results"
+      >
+        <InsightsDataTable />
+      </Section>
+    </main>
+  );
+}

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanel.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanel.tsx
@@ -12,7 +12,7 @@ export function InsightsTabPanel() {
   const isRunning = status === 'loading';
 
   return (
-    <main className="grid h-full w-full flex-1 grid-rows-[3fr_5fr] gap-0 overflow-hidden">
+    <>
       <Section
         actions={<InsightsSQLEditorQueryButton />}
         className="min-h-[255px]"
@@ -31,6 +31,6 @@ export function InsightsTabPanel() {
       >
         <InsightsDataTable />
       </Section>
-    </main>
+    </>
   );
 }

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabsList.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabsList.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import TabCards from '@inngest/components/TabCards/TabCards';
+import { ulid } from 'ulid';
+
+import type { TabConfig, TabManagerActions } from './InsightsTabManager';
+
+// TODO: Complete implementation and remove "hide" prop.
+
+interface InsightsTabsListProps {
+  actions: TabManagerActions;
+  activeTabId: string;
+  hide?: boolean;
+  tabs: TabConfig[];
+}
+
+export function InsightsTabsList({ actions, activeTabId, hide, tabs }: InsightsTabsListProps) {
+  if (hide) return null;
+
+  const handleTabChange = (value: string) => {
+    // Don't change the active tab, just create a new one
+    if (value === '__plus') return;
+
+    actions.focusTab(value);
+  };
+
+  const handlePlusClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    actions.createTab(ulid());
+  };
+
+  return (
+    <TabCards value={activeTabId} onValueChange={handleTabChange}>
+      <TabCards.ButtonList>
+        {tabs.map((tab) => (
+          <TabCards.Button key={tab.id} value={tab.id}>
+            {tab.name}
+          </TabCards.Button>
+        ))}
+        <TabCards.Button key="__plus" value="__plus" onClick={handlePlusClick}>
+          +
+        </TabCards.Button>
+      </TabCards.ButtonList>
+    </TabCards>
+  );
+}


### PR DESCRIPTION
## Description

This PR makes the necessary non-UI changes to enable tabification the Insights page. Further work remains here:
- Remove `hide` prop and actually render the tabs list
- Fully support creating / deleting tabs
- _Bind_ tabs to recent, saved, template queries according to future related decisions

**NOTE:** Right now, the "Home" tab behaves like a normal (the only) query tab. In the future, it will likely behave more like an empty, quickstart state.

## Motivation
This will make it easier to do later work around actually implementing tabs and appropriately supporting recent, saved, and template queries.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
