### PR TITLE
check new error state for no run span error as well

### DIFF
--- a/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
+++ b/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
@@ -29,6 +29,7 @@ type Props = {
 };
 
 const MIN_HEIGHT = 586;
+const NO_SPANS_ERROR = /no function run span found/gi;
 
 export const RunDetailsV3 = ({
   getTrigger,
@@ -50,7 +51,7 @@ export const RunDetailsV3 = ({
   const { selectedStep } = useStepSelection(runID);
   const { getTraceResult } = useGetTraceResult();
 
-  const { getRun } = useGetRun();
+  const { getRun, error: runError } = useGetRun();
 
   const handleMouseDown = useCallback(() => {
     setIsDragging(true);
@@ -156,7 +157,8 @@ export const RunDetailsV3 = ({
   }
 
   // Do not show the error if queued and the error is no spans
-  const noSpansFoundError = !!runRes.error?.toString().match(/no function run span found/gi);
+  const noSpansFoundError =
+    !!runRes.error?.toString().match(NO_SPANS_ERROR) || !!runError?.message.match(NO_SPANS_ERROR);
   const waiting = initialRunData?.status === 'QUEUED' && noSpansFoundError;
   const showError = waiting ? false : runRes.error || resultRes.error;
 


### PR DESCRIPTION
## Description
Recent get run fetch consolidation moved some errors, check for our queued state no run span errors in both places.

## Motivation
Unregress error noise defense.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
