### PR TITLE
SYS-211: Add tests for batching events + if triggers

### DIFF
--- a/pkg/expressions/expressions_test.go
+++ b/pkg/expressions/expressions_test.go
@@ -334,6 +334,41 @@ func TestEvaluateExpression(t *testing.T) {
 			false,
 			"",
 		},
+		{
+			// a, b, c must all be false
+			"!((has(event.data.a) && event.data.a) || (has(event.data.b) && event.data.b) || (has(event.data.c) && event.data.c))",
+			map[string]interface{}{
+				"event": event.Event{
+					Data: map[string]interface{}{
+						"a": false,
+						"b": false,
+						"c": false,
+					},
+				},
+			},
+			true,
+			nil,
+			false,
+			"",
+		},
+		{
+			// a, b, c must all be false
+			"!((has(event.data.a) && event.data.a) || (has(event.data.b) && event.data.b) || (has(event.data.c) && event.data.c))",
+			map[string]interface{}{
+				"event": event.Event{
+					Data: map[string]interface{}{
+						"a": true,
+						"b": false,
+						"c": false,
+					},
+				},
+			},
+			false,
+			nil,
+			false,
+			"",
+		},
+
 		// For more information on available macros and overloads, look at
 		// cel-go/common/operators/operators.go and
 		// cel-go/common/overloads/overloads.go.

--- a/tests/golang/batch_test.go
+++ b/tests/golang/batch_test.go
@@ -119,7 +119,7 @@ func TestBatchWithConditionalTrigger(t *testing.T) {
 	_, err := inngestgo.CreateFunction(
 		inngestClient,
 		inngestgo.FunctionOpts{ID: "batch-test", BatchEvents: &inngestgo.ConfigBatchEvents{MaxSize: 5, Timeout: 5 * time.Second}},
-		inngestgo.EventTrigger("test/batch", inngestgo.StrPtr("has(event.data.num) && event.data.num % 2 == 0")),
+		inngestgo.EventTrigger("test/batch", inngestgo.StrPtr("has(event.data.num) && int(event.data.num) % 2 == 0")),
 		func(ctx context.Context, input inngestgo.Input[BatchEvent]) (any, error) {
 			if runID == "" {
 				runID = input.InputCtx.RunID

--- a/tests/golang/batch_test.go
+++ b/tests/golang/batch_test.go
@@ -18,8 +18,11 @@ import (
 )
 
 type BatchEventData struct {
-	Time time.Time `json:"time"`
-	Num  int       `json:"num"`
+	Time                   time.Time `json:"time"`
+	Num                    int       `json:"num"`
+	Promotional            bool      `json:"promotional"`
+	NotificationNotMeeting bool      `json:"notificationNotMeeting"`
+	NotificationMeeting    bool      `json:"notificationMeeting"`
 }
 
 type BatchEvent = inngestgo.GenericEvent[BatchEventData]
@@ -102,6 +105,64 @@ func TestBatchEvents(t *testing.T) {
 			rid := ulid.MustParse(runID)
 			assert.True(t, trigger.Timestamp.Before(ulid.Time(rid.Time())))
 		})
+	})
+}
+
+func TestMunsonRepro(t *testing.T) {
+	ctx := context.Background()
+	inngestClient, server, registerFuncs := NewSDKHandler(t, "batch")
+	defer server.Close()
+
+	var (
+		counter     int32
+		totalEvents int32
+		runID       string
+	)
+
+	_, err := inngestgo.CreateFunction(
+		inngestClient,
+		inngestgo.FunctionOpts{ID: "batch-test", BatchEvents: &inngestgo.ConfigBatchEvents{MaxSize: 10, Timeout: 5 * time.Second}},
+		// english translation: only trigger function if all three bool fields are false
+		// 	-event.data.promotional
+		//  -event.data.notificationNotMeeting
+		//  -event.data.notificationMeeting
+		inngestgo.EventTrigger("test/batch", inngestgo.StrPtr("!( (has(event.data.promotional) && event.data.promotional) || (has(event.data.notificationNotMeeting) && event.data.notificationNotMeeting) || (has(event.data.notificationMeeting) && event.data.notificationMeeting) )")),
+		func(ctx context.Context, input inngestgo.Input[BatchEvent]) (any, error) {
+			if runID == "" {
+				runID = input.InputCtx.RunID
+			}
+			atomic.AddInt32(&counter, 1)
+			atomic.AddInt32(&totalEvents, int32(len(input.Events)))
+			return "batched!!", nil
+		},
+	)
+	require.NoError(t, err)
+	registerFuncs()
+
+	t.Run("trigger batch", func(t *testing.T) {
+		// generate 8 sets of events
+		// each set has 8 events with all possible combinations for the three boolean fields.
+		//		- Only one of these 8 events will pass the function trigger (false, false, false)
+		// each of the 8 sets will have one event that passes the function trigger - so 8/64 events should be valid.
+		for i := 0; i < 8; i++ {
+			for _, a := range []bool{true, false} {
+				for _, b := range []bool{true, false} {
+					for _, c := range []bool{true, false} {
+						_, err := inngestClient.Send(ctx, BatchEvent{
+							Name: "test/batch",
+							Data: BatchEventData{Num: i, Promotional: a, NotificationNotMeeting: b, NotificationMeeting: c},
+						})
+						require.NoError(t, err)
+					}
+				}
+			}
+		}
+
+		// Wait for trigger to run
+		// after batch timeout s, all 8 events should be scheduled in a single batch (batch limit is 10 events)
+		<-time.After(10 * time.Second)
+		assert.EqualValues(t, 1, atomic.LoadInt32(&counter))
+		assert.EqualValues(t, 8, atomic.LoadInt32(&totalEvents))
 	})
 }
 


### PR DESCRIPTION
## Description
This PR only adds feature tests for batching logic when event trigger has a condition expression.

- Test 1: Copy the exact same test from https://github.com/inngest/inngest/compare/darwin/batch-conditional?expand=1
  - This test was failing because of an invalid expression in the test: float64 was passed as an operand to modulo operator which is not supported
  - Fix that by casting the field to int.
<img width="1093" height="279" alt="Screenshot 2025-08-11 at 11 50 48 AM" src="https://github.com/user-attachments/assets/e5f2668c-5092-4ed3-a06d-6fca08bcb05c" />

- Test 2: Add an exact repro of this [user reported issue](https://discord.com/channels/842170679536517141/1237549917405188116/1237549917405188116). 
  - User reports that the expression doesn't work as expected, but I see from the test that it does work as intended.  

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
