### PR TITLE
Fix Redis Sentinel authentication by copying main credentials when cr…

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -908,6 +908,15 @@ func connectToOrCreateRedisOption(redisURI string) (rueidis.ClientOption, error)
 		return rueidis.ClientOption{}, fmt.Errorf("error parsing redis uri: invalid format")
 	}
 
+	// Fix for Redis Sentinel authentication: rueidis.ParseURL correctly identifies
+	// Sentinel configurations but fails to populate Sentinel credentials.
+	// When a master_set is configured but Sentinel credentials are empty,
+	// copy the main credentials to Sentinel authentication.
+	if opt.Sentinel.MasterSet != "" && opt.Sentinel.Username == "" && opt.Username != "" {
+		opt.Sentinel.Username = opt.Username
+		opt.Sentinel.Password = opt.Password
+	}
+
 	// Set default overrides
 	opt.DisableCache = true
 	opt.BlockingPoolSize = consts.RedisBlockingPoolSize


### PR DESCRIPTION
…eds are present and masterset is present.

## Description

Fix for Redis Sentinel authentication: rueidis.ParseURL correctly identifies
Sentinel configurations but fails to populate Sentinel credentials.
When a master_set is configured but Sentinel credentials are empty,
copy the main credentials to Sentinel authentication.

## Motivation
Allow redis sentinel as a self-hosting option

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
