### PR TITLE
SYS-197: Spit out span size when message is too large for kafka

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -147,6 +147,8 @@ const (
 
 	ConnectWorkerRequestLeaseDuration = 20 * time.Second
 	ConnectWorkerRequestGracePeriod   = 5 * time.Second
+
+	KafkaMsgTooLargeError = "MESSAGE_TOO_LARGE"
 )
 
 var (

--- a/pkg/telemetry/exporters/kafka.go
+++ b/pkg/telemetry/exporters/kafka.go
@@ -3,8 +3,10 @@ package exporters
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -208,6 +210,10 @@ func (e *kafkaSpanExporter) ExportSpans(ctx context.Context, spans []trace.ReadO
 					"run_id", id.RunId,
 				)
 				status = "error"
+
+				if strings.Contains(err.Error(), consts.KafkaMsgTooLargeError) {
+					l.Error("error", err, "span proto size", proto.Size(span), "marhsalled span proto size", len(byt), "span.output size", len(span.Output))
+				}
 			}
 
 			metrics.IncrSpanExportedCounter(ctx, metrics.CounterOpt{


### PR DESCRIPTION
## Description

Spit out span size when message is too large for kafka

## Motivation

Intended to help debug alerts firing for "Error detected when producing spans" [like this one](https://app.datadoghq.com/monitors/166390037?event_id=AwAAAZijURXoMLTueQAAABhBWmlqVWdMdEFBQjJORGVNM3M1dXhMRmkAAAAkMTE5OGEzODYtY2JlOC00N2ViLWI2M2EtYzIyNWFjNjc1YThiAAAEqw&link_source=monitor_notif&from_ts=1755085757000&to_ts=1755086957000&live=false)

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
