### PR TITLE
Remove redis and postgres connection string details from logs

### DIFF
--- a/pkg/cqrs/base_cqrs/base_cqrs.go
+++ b/pkg/cqrs/base_cqrs/base_cqrs.go
@@ -41,7 +41,10 @@ func New(opts BaseCQRSOptions) (*sql.DB, error) {
 
 	if opts.PostgresURI != "" {
 		if !strings.HasPrefix(opts.PostgresURI, "postgres://") && !strings.HasPrefix(opts.PostgresURI, "postgresql://") {
-			return nil, fmt.Errorf("unsupported database URL: %s", opts.PostgresURI)
+			if u, parseErr := url.Parse(opts.PostgresURI); parseErr == nil {
+				return nil, fmt.Errorf("unsupported database URL: %s", u.Redacted())
+			}
+			return nil, fmt.Errorf("unsupported database URL format")
 		}
 
 		o.Do(func() {
@@ -120,7 +123,7 @@ func up(db *sql.DB, opts BaseCQRSOptions) error {
 		dbName = "postgres"
 		parsedURL, err := url.Parse(opts.PostgresURI)
 		if err != nil {
-			return fmt.Errorf("error parsing postgres URI to retrieve DB name: %w", err)
+			return fmt.Errorf("error parsing postgres URI to retrieve DB name: invalid format")
 		}
 
 		if parsedURL.Path != "" && parsedURL.Path != "/" {

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -24,8 +24,8 @@ import (
 	"github.com/inngest/inngest/pkg/config/registration"
 	"github.com/inngest/inngest/pkg/connect"
 	"github.com/inngest/inngest/pkg/connect/auth"
-	"github.com/inngest/inngest/pkg/connect/lifecycles"
 	connectgrpc "github.com/inngest/inngest/pkg/connect/grpc"
+	"github.com/inngest/inngest/pkg/connect/lifecycles"
 	connectv0 "github.com/inngest/inngest/pkg/connect/rest/v0"
 	connstate "github.com/inngest/inngest/pkg/connect/state"
 	"github.com/inngest/inngest/pkg/consts"
@@ -665,7 +665,6 @@ func createInmemoryRedis(ctx context.Context, tick time.Duration) (rueidis.Clien
 	return rc, r, nil
 }
 
-
 func getSendingEventHandler(ctx context.Context, pb pubsub.Publisher, topic string) execution.HandleSendingEvent {
 	return func(ctx context.Context, evt event.Event, item queue.Item) error {
 		trackedEvent := event.NewOSSTrackedEvent(evt, nil)
@@ -896,7 +895,7 @@ func connectToOrCreateRedisOption(redisURI string) (rueidis.ClientOption, error)
 
 	opt, err := rueidis.ParseURL(redisURI)
 	if err != nil {
-		return rueidis.ClientOption{}, fmt.Errorf("error parsing redis uri: %w", err)
+		return rueidis.ClientOption{}, fmt.Errorf("error parsing redis uri: invalid format")
 	}
 
 	// Set default overrides


### PR DESCRIPTION
## Description
Prevent connection string secrets from appearing in logs.

## Motivation
Security!

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
