### PR TITLE
Set overscroll-none on body to prevent accidentally going back while scrolling horizontally

### DIFF
--- a/ui/packages/components/src/AppRoot/AppRoot.tsx
+++ b/ui/packages/components/src/AppRoot/AppRoot.tsx
@@ -5,7 +5,7 @@ import { ThemeProvider } from 'next-themes';
 export function AppRoot({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="h-full" suppressHydrationWarning>
-      <body className=" bg-canvasBase text-basis h-full overflow-auto">
+      <body className=" bg-canvasBase text-basis h-full overflow-auto overscroll-none">
         <div id="app" />
         <div id="modals" />
         <ThemeProvider attribute="class" defaultTheme="system">


### PR DESCRIPTION
## Description

We have several places in our app where a user needs to scroll horizontally.
Set `overscroll: none` to prevent going back accidentally.

Reported by user scrolling horizontally through their step output

I tried setting this in a few different places at a deeper level of the DOM
but it didn't seem to prevent the back behavior

## Motivation

User report

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
