### PR TITLE
Fixed cli executed cmd telemetry

### DIFF
--- a/pkg/api/tel/tel.go
+++ b/pkg/api/tel/tel.go
@@ -72,8 +72,8 @@ func NewMetadata(ctx context.Context) *Metadata {
 func (m *Metadata) SetCliContext(cmd *cli.Command) {
 	// Build command path similar to cobra's CommandPath()
 	cmdPath := "inngest"
-	if cmd != nil && cmd.Name != "" {
-		cmdPath += " " + cmd.Name
+	if cmd != nil && cmd.Args().Len() > 0 {
+		cmdPath += " " + cmd.Args().Get(0)
 	}
 	m.Cmd = cmdPath
 }


### PR DESCRIPTION
## Description

Sending the cmd `inngest inngest` instead of `inngest dev` for tracking cmd executions in amplitude

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
