### PR TITLE
Implement gRPC authentication and authorization middleware with interceptors

### DIFF
--- a/pkg/api/v2/adapters_test.go
+++ b/pkg/api/v2/adapters_test.go
@@ -1,0 +1,183 @@
+package apiv2
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+
+	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func TestHTTPMiddlewareToGRPCInterceptor(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("allows request when middleware allows", func(t *testing.T) {
+		allowMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Check if request has required header
+				if r.Header.Get("authorization") == "Bearer valid-token" {
+					next.ServeHTTP(w, r)
+				} else {
+					w.WriteHeader(http.StatusUnauthorized)
+				}
+			})
+		}
+
+		authzFunc := HTTPMiddlewareToGRPCInterceptor(allowMiddleware)
+
+		// Create context with valid authorization header
+		md := metadata.Pairs("authorization", "Bearer valid-token")
+		ctx := metadata.NewIncomingContext(ctx, md)
+
+		err := authzFunc(ctx, "/api.v2.V2/CreateAccount")
+		require.NoError(t, err)
+	})
+
+	t.Run("blocks request when middleware blocks", func(t *testing.T) {
+		blockMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			})
+		}
+
+		authzFunc := HTTPMiddlewareToGRPCInterceptor(blockMiddleware)
+
+		err := authzFunc(ctx, "/api.v2.V2/CreateAccount")
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.PermissionDenied, st.Code())
+	})
+
+	t.Run("checks authorization header from gRPC metadata", func(t *testing.T) {
+		headerCheckMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("authorization") == "Bearer invalid-token" {
+					w.WriteHeader(http.StatusUnauthorized)
+				} else {
+					next.ServeHTTP(w, r)
+				}
+			})
+		}
+
+		authzFunc := HTTPMiddlewareToGRPCInterceptor(headerCheckMiddleware)
+
+		// Create context with invalid authorization header
+		md := metadata.Pairs("authorization", "Bearer invalid-token")
+		ctx := metadata.NewIncomingContext(ctx, md)
+
+		err := authzFunc(ctx, "/api.v2.V2/CreateAccount")
+		require.Error(t, err)
+	})
+}
+
+func TestNewGRPCServerFromHTTPOptions(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("uses HTTP middleware for gRPC authorization", func(t *testing.T) {
+		blockMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			})
+		}
+
+		httpOpts := HTTPHandlerOptions{
+			AuthzMiddleware: blockMiddleware,
+		}
+
+		server := NewGRPCServerFromHTTPOptions(httpOpts)
+		
+		// Setup in-memory connection
+		lis := bufconn.Listen(1024 * 1024)
+		go func() {
+			_ = server.Serve(lis)
+		}()
+		defer server.Stop()
+
+		// Create client
+		conn, err := grpc.NewClient("passthrough://bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+				return lis.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		client := apiv2.NewV2Client(conn)
+
+		// Test protected method (CreateAccount) - should be blocked
+		_, err = client.CreateAccount(ctx, &apiv2.CreateAccountRequest{})
+		require.Error(t, err)
+		
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.PermissionDenied, st.Code())
+
+		// Test unprotected method (Health) - should work
+		resp, err := client.Health(ctx, &apiv2.HealthRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+	})
+
+	t.Run("works without middleware", func(t *testing.T) {
+		httpOpts := HTTPHandlerOptions{}
+
+		server := NewGRPCServerFromHTTPOptions(httpOpts)
+		
+		// Setup in-memory connection
+		lis := bufconn.Listen(1024 * 1024)
+		go func() {
+			_ = server.Serve(lis)
+		}()
+		defer server.Stop()
+
+		// Create client
+		conn, err := grpc.NewClient("passthrough://bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+				return lis.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		client := apiv2.NewV2Client(conn)
+
+		// Both methods should work without middleware
+		resp1, err := client.Health(ctx, &apiv2.HealthRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, resp1)
+
+		resp2, err := client.CreateAccount(ctx, &apiv2.CreateAccountRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, resp2)
+	})
+}
+
+func TestGRPCServerOptions(t *testing.T) {
+	t.Run("creates server with middleware", func(t *testing.T) {
+		httpMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				next.ServeHTTP(w, r)
+			})
+		}
+
+		opts := GRPCServerOptions{
+			AuthnMiddleware: httpMiddleware,
+			AuthzMiddleware: httpMiddleware,
+		}
+
+		server := NewGRPCServer(opts)
+		require.NotNil(t, server)
+	})
+}

--- a/pkg/api/v2/integration_test.go
+++ b/pkg/api/v2/integration_test.go
@@ -32,9 +32,8 @@ func setupGRPCTestServer(t testing.TB) (apiv2.V2Client, func()) {
 		return lis.Dial()
 	}
 
-	conn, err := grpc.DialContext(
-		context.Background(),
-		"bufnet",
+	conn, err := grpc.NewClient(
+		"passthrough://bufnet",
 		grpc.WithContextDialer(bufDialer),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)

--- a/pkg/api/v2/interceptors.go
+++ b/pkg/api/v2/interceptors.go
@@ -1,0 +1,166 @@
+package apiv2
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+
+	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// applyAuth applies authentication and authorization middleware to a gRPC method
+func applyAuth(ctx context.Context, fullMethod string, authnMiddleware, authzMiddleware func(http.Handler) http.Handler) error {
+	// Apply authentication middleware if provided (applies to all methods)
+	if authnMiddleware != nil {
+		authnFunc := HTTPMiddlewareToGRPCInterceptor(authnMiddleware)
+		if err := authnFunc(ctx, fullMethod); err != nil {
+			return status.Error(codes.Unauthenticated, "authentication failed")
+		}
+	}
+
+	// Apply authorization middleware if this method requires it
+	if requiresAuthorization(fullMethod) {
+		if authzMiddleware != nil {
+			authzFunc := HTTPMiddlewareToGRPCInterceptor(authzMiddleware)
+			if err := authzFunc(ctx, fullMethod); err != nil {
+				return status.Error(codes.PermissionDenied, "access denied")
+			}
+		} else {
+			// No authorization middleware provided but authorization required
+			return status.Error(codes.PermissionDenied, "authorization not configured")
+		}
+	}
+
+	return nil
+}
+
+// NewAuthUnaryInterceptor creates a unary gRPC interceptor that applies authentication
+// and authorization middleware based on protobuf annotations
+func NewAuthUnaryInterceptor(authnMiddleware, authzMiddleware func(http.Handler) http.Handler) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		if err := applyAuth(ctx, info.FullMethod, authnMiddleware, authzMiddleware); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// NewAuthStreamInterceptor creates a streaming gRPC interceptor that applies authentication
+// and authorization middleware based on protobuf annotations
+func NewAuthStreamInterceptor(authnMiddleware, authzMiddleware func(http.Handler) http.Handler) grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := applyAuth(ss.Context(), info.FullMethod, authnMiddleware, authzMiddleware); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+}
+
+// requiresAuthorization checks if a gRPC method requires authorization based on protobuf annotations
+func requiresAuthorization(fullMethod string) bool {
+	// Parse the method name from the full method path
+	// Full method format: "/package.service/MethodName"
+	methodName := parseMethodName(fullMethod)
+	if methodName == "" {
+		return false
+	}
+
+	// Get the service descriptor
+	serviceDesc := apiv2.File_api_v2_service_proto.Services().ByName("V2")
+	if serviceDesc == nil {
+		return false
+	}
+
+	// Find the method descriptor
+	methods := serviceDesc.Methods()
+	for i := 0; i < methods.Len(); i++ {
+		method := methods.Get(i)
+		if string(method.Name()) == methodName {
+			return hasAuthzAnnotation(method)
+		}
+	}
+
+	return false
+}
+
+// parseMethodName extracts the method name from a full gRPC method path
+func parseMethodName(fullMethod string) string {
+	// Full method format: "/api.v2.V2/MethodName"
+	// Find the last slash and extract everything after it
+	for i := len(fullMethod) - 1; i >= 0; i-- {
+		if fullMethod[i] == '/' {
+			return fullMethod[i+1:]
+		}
+	}
+	return ""
+}
+
+// HTTPMiddlewareToGRPCInterceptor converts an HTTP middleware function to a gRPC interceptor function
+func HTTPMiddlewareToGRPCInterceptor(middleware func(http.Handler) http.Handler) func(ctx context.Context, method string) error {
+	return func(ctx context.Context, method string) error {
+		// Create a test handler that will succeed if middleware allows the request
+		testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		// Determine HTTP method from gRPC method and protobuf annotations
+		httpMethod := getHTTPMethodForGRPCMethod(method)
+
+		// Create a test request with the appropriate HTTP method
+		req := httptest.NewRequest(httpMethod, "/test", nil)
+		req = req.WithContext(ctx)
+
+		// Copy gRPC metadata to HTTP headers
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			for key, values := range md {
+				for _, value := range values {
+					req.Header.Add(key, value)
+				}
+			}
+		}
+
+		// Create a response recorder
+		rec := httptest.NewRecorder()
+
+		// Apply the middleware
+		wrappedHandler := middleware(testHandler)
+		wrappedHandler.ServeHTTP(rec, req)
+
+		// Check if middleware blocked the request
+		if rec.Code != http.StatusOK {
+			return status.Error(codes.PermissionDenied, "authorization failed")
+		}
+
+		return nil
+	}
+}
+
+// getHTTPMethodForGRPCMethod determines the HTTP method for a gRPC method by reading protobuf annotations
+func getHTTPMethodForGRPCMethod(fullMethod string) string {
+	// Parse the method name from the full method path
+	methodName := parseMethodName(fullMethod)
+	if methodName == "" {
+		return http.MethodPost // Default fallback
+	}
+
+	// Get the service descriptor
+	serviceDesc := apiv2.File_api_v2_service_proto.Services().ByName("V2")
+	if serviceDesc == nil {
+		return http.MethodPost // Default fallback
+	}
+
+	// Find the method descriptor and extract HTTP method from annotations
+	methods := serviceDesc.Methods()
+	for i := 0; i < methods.Len(); i++ {
+		method := methods.Get(i)
+		if string(method.Name()) == methodName {
+			return getHTTPMethod(method) // Use refactored function from util.go
+		}
+	}
+
+	return http.MethodPost // Default fallback
+}

--- a/pkg/api/v2/interceptors_test.go
+++ b/pkg/api/v2/interceptors_test.go
@@ -1,0 +1,425 @@
+package apiv2
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+
+	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func TestGRPCInterceptors(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("authorization interceptor blocks protected methods", func(t *testing.T) {
+		authzCalled := false
+		authzMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				authzCalled = true
+				w.WriteHeader(http.StatusForbidden)
+			})
+		}
+
+		// Create gRPC server with authorization interceptor
+		server := grpc.NewServer(
+			grpc.UnaryInterceptor(NewAuthUnaryInterceptor(nil, authzMiddleware)),
+		)
+		service := NewService()
+		apiv2.RegisterV2Server(server, service)
+
+		// Setup in-memory connection
+		lis := bufconn.Listen(1024 * 1024)
+		go func() {
+			_ = server.Serve(lis)
+		}()
+		defer server.Stop()
+
+		// Create client
+		conn, err := grpc.NewClient("passthrough://bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+				return lis.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		client := apiv2.NewV2Client(conn)
+
+		// Test protected method (CreateAccount)
+		_, err = client.CreateAccount(ctx, &apiv2.CreateAccountRequest{})
+		require.Error(t, err)
+		require.True(t, authzCalled)
+		
+		// Check that it's a permission denied error
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.PermissionDenied, st.Code())
+	})
+
+	t.Run("authorization interceptor allows unprotected methods", func(t *testing.T) {
+		authzCalled := false
+		authzMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				authzCalled = true
+				w.WriteHeader(http.StatusForbidden)
+			})
+		}
+
+		// Create gRPC server with authorization interceptor
+		server := grpc.NewServer(
+			grpc.UnaryInterceptor(NewAuthUnaryInterceptor(nil, authzMiddleware)),
+		)
+		service := NewService()
+		apiv2.RegisterV2Server(server, service)
+
+		// Setup in-memory connection
+		lis := bufconn.Listen(1024 * 1024)
+		go func() {
+			_ = server.Serve(lis)
+		}()
+		defer server.Stop()
+
+		// Create client
+		conn, err := grpc.NewClient("passthrough://bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+				return lis.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		client := apiv2.NewV2Client(conn)
+
+		// Test unprotected method (Health)
+		resp, err := client.Health(ctx, &apiv2.HealthRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.False(t, authzCalled, "Authorization function should not be called for unprotected methods")
+	})
+
+	t.Run("authorization interceptor with nil middleware blocks protected methods", func(t *testing.T) {
+		// Create gRPC server with authorization interceptor but no authorization middleware
+		server := grpc.NewServer(
+			grpc.UnaryInterceptor(NewAuthUnaryInterceptor(nil, nil)),
+		)
+		service := NewService()
+		apiv2.RegisterV2Server(server, service)
+
+		// Setup in-memory connection
+		lis := bufconn.Listen(1024 * 1024)
+		go func() {
+			_ = server.Serve(lis)
+		}()
+		defer server.Stop()
+
+		// Create client
+		conn, err := grpc.NewClient("passthrough://bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+				return lis.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		client := apiv2.NewV2Client(conn)
+
+		// Test protected method (CreateAccount)
+		_, err = client.CreateAccount(ctx, &apiv2.CreateAccountRequest{})
+		require.Error(t, err)
+		
+		// Check that it's a permission denied error with specific message
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.PermissionDenied, st.Code())
+		require.Contains(t, st.Message(), "authorization not configured")
+	})
+
+	t.Run("authentication interceptor blocks all methods when authentication fails", func(t *testing.T) {
+		authnCalled := false
+		authnMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				authnCalled = true
+				w.WriteHeader(http.StatusUnauthorized)
+			})
+		}
+
+		// Create gRPC server with authentication interceptor
+		server := grpc.NewServer(
+			grpc.UnaryInterceptor(NewAuthUnaryInterceptor(authnMiddleware, nil)),
+		)
+		service := NewService()
+		apiv2.RegisterV2Server(server, service)
+
+		// Setup in-memory connection
+		lis := bufconn.Listen(1024 * 1024)
+		go func() {
+			_ = server.Serve(lis)
+		}()
+		defer server.Stop()
+
+		// Create client
+		conn, err := grpc.NewClient("passthrough://bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+				return lis.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		client := apiv2.NewV2Client(conn)
+
+		// Test unprotected method (Health) - should be blocked by authentication
+		_, err = client.Health(ctx, &apiv2.HealthRequest{})
+		require.Error(t, err)
+		require.True(t, authnCalled)
+		
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.Unauthenticated, st.Code())
+	})
+
+	t.Run("both authentication and authorization interceptors work together", func(t *testing.T) {
+		authnCalled := false
+		authzCalled := false
+
+		authnMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				authnCalled = true
+				// Allow authentication to pass
+				next.ServeHTTP(w, r)
+			})
+		}
+
+		authzMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				authzCalled = true
+				w.WriteHeader(http.StatusForbidden)
+			})
+		}
+
+		// Create gRPC server with both interceptors
+		server := grpc.NewServer(
+			grpc.UnaryInterceptor(NewAuthUnaryInterceptor(authnMiddleware, authzMiddleware)),
+		)
+		service := NewService()
+		apiv2.RegisterV2Server(server, service)
+
+		// Setup in-memory connection
+		lis := bufconn.Listen(1024 * 1024)
+		go func() {
+			_ = server.Serve(lis)
+		}()
+		defer server.Stop()
+
+		// Create client
+		conn, err := grpc.NewClient("passthrough://bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+				return lis.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		client := apiv2.NewV2Client(conn)
+
+		// Test protected method (CreateAccount) - should hit both middlewares
+		_, err = client.CreateAccount(ctx, &apiv2.CreateAccountRequest{})
+		require.Error(t, err)
+		require.True(t, authnCalled, "Authentication middleware should be called")
+		require.True(t, authzCalled, "Authorization middleware should be called")
+		
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.PermissionDenied, st.Code())
+	})
+
+	t.Run("authentication passes but authorization blocks", func(t *testing.T) {
+		authnCalled := false
+		authzCalled := false
+
+		authnMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				authnCalled = true
+				next.ServeHTTP(w, r) // Pass authentication
+			})
+		}
+
+		authzMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				authzCalled = true
+				w.WriteHeader(http.StatusForbidden) // Block authorization
+			})
+		}
+
+		// Create gRPC server with both interceptors
+		server := grpc.NewServer(
+			grpc.UnaryInterceptor(NewAuthUnaryInterceptor(authnMiddleware, authzMiddleware)),
+		)
+		service := NewService()
+		apiv2.RegisterV2Server(server, service)
+
+		// Setup in-memory connection
+		lis := bufconn.Listen(1024 * 1024)
+		go func() {
+			_ = server.Serve(lis)
+		}()
+		defer server.Stop()
+
+		// Create client
+		conn, err := grpc.NewClient("passthrough://bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+				return lis.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		client := apiv2.NewV2Client(conn)
+
+		// Test unprotected method (Health) - authn should pass, authz not called
+		resp, err := client.Health(ctx, &apiv2.HealthRequest{})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.True(t, authnCalled, "Authentication should be called for all methods")
+		require.False(t, authzCalled, "Authorization should not be called for unprotected methods")
+	})
+
+	t.Run("uses correct HTTP method from protobuf annotations", func(t *testing.T) {
+		receivedMethod := ""
+		methodCheckMiddleware := func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedMethod = r.Method
+				next.ServeHTTP(w, r)
+			})
+		}
+
+		// Create gRPC server with method-checking middleware for both authn and authz
+		server := grpc.NewServer(
+			grpc.UnaryInterceptor(NewAuthUnaryInterceptor(methodCheckMiddleware, methodCheckMiddleware)),
+		)
+		service := NewService()
+		apiv2.RegisterV2Server(server, service)
+
+		// Setup in-memory connection
+		lis := bufconn.Listen(1024 * 1024)
+		go func() {
+			_ = server.Serve(lis)
+		}()
+		defer server.Stop()
+
+		// Create client
+		conn, err := grpc.NewClient("passthrough://bufnet",
+			grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+				return lis.Dial()
+			}),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		client := apiv2.NewV2Client(conn)
+
+		// Test Health method (should use GET based on annotation)
+		_, err = client.Health(ctx, &apiv2.HealthRequest{})
+		require.NoError(t, err)
+		require.Equal(t, http.MethodGet, receivedMethod, "Health method should use GET")
+
+		// Reset for next test
+		receivedMethod = ""
+
+		// Test CreateAccount method (should use POST based on annotation)
+		_, err = client.CreateAccount(ctx, &apiv2.CreateAccountRequest{})
+		require.NoError(t, err)
+		require.Equal(t, http.MethodPost, receivedMethod, "CreateAccount method should use POST")
+	})
+}
+
+func TestParseMethodName(t *testing.T) {
+	tests := []struct {
+		name       string
+		fullMethod string
+		expected   string
+	}{
+		{
+			name:       "standard v2 method",
+			fullMethod: "/api.v2.V2/Health",
+			expected:   "Health",
+		},
+		{
+			name:       "create account method",
+			fullMethod: "/api.v2.V2/CreateAccount",
+			expected:   "CreateAccount",
+		},
+		{
+			name:       "empty string",
+			fullMethod: "",
+			expected:   "",
+		},
+		{
+			name:       "no slash",
+			fullMethod: "Health",
+			expected:   "",
+		},
+		{
+			name:       "only slash",
+			fullMethod: "/",
+			expected:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseMethodName(tt.fullMethod)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRequiresAuthorization(t *testing.T) {
+	tests := []struct {
+		name       string
+		fullMethod string
+		expected   bool
+	}{
+		{
+			name:       "health method should not require authorization",
+			fullMethod: "/api.v2.V2/Health",
+			expected:   false,
+		},
+		{
+			name:       "create account method should require authorization",
+			fullMethod: "/api.v2.V2/CreateAccount",
+			expected:   true,
+		},
+		{
+			name:       "unknown method should not require authorization",
+			fullMethod: "/api.v2.V2/UnknownMethod",
+			expected:   false,
+		},
+		{
+			name:       "invalid method path should not require authorization",
+			fullMethod: "invalid",
+			expected:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := requiresAuthorization(tt.fullMethod)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Adapt standard go authn and authz middleware for reuse as gRPC interceptors. This simplifies security by requiring only a single authentication and authorization middleware for REST API v2.

## Motivation
REST API v2

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
