### PR TITLE
docs: remove `--yes` from `vercel link`

### DIFF
--- a/ui/apps/dashboard/README.md
+++ b/ui/apps/dashboard/README.md
@@ -21,7 +21,7 @@ Before being able to run the app for the first time, you need to follow the step
    [Corepack](https://nodejs.org/docs/latest-v18.x/api/corepack.html) by running
    `corepack enable; corepack prepare`
 3. Install dependencies by running `pnpm install`
-4. Link local project to our `ui` Vercel project by running `pnpm vercel link -p ui --yes`
+4. Link local project to our `ui` Vercel project by running `pnpm vercel link -p ui`
    - Make sure the command prints out `Linked to inngest/ui` and not a `ui` project in your personal scope
 5. Download environment variables by running `pnpm env:pull`
 


### PR DESCRIPTION
## Description

The `--yes` flag was causing Vercel to automatically link to my personal scope, whereas not passing it resulted in a UI that allowed me to choose the Inngest scope.

<img width="666" height="164" alt="Screenshot 2025-08-19 at 2 41 19 PM" src="https://github.com/user-attachments/assets/72e9a0d8-f920-4adc-a083-8a8db710b2ba" />

## Motivation

This bit me during setup. I thought I'd really done something silly because I didn't seem to be able to select the correct scope, but this was the trick.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [x] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
