### PR TITLE
chore: sort OtelSpans deterministically in GraphQL

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -273,7 +273,12 @@ func encodeSpanOutputID(spanID string) (*string, error) {
 
 func sorter(span *cqrs.OtelSpan) {
 	sort.Slice(span.Children, func(i, j int) bool {
-		return span.Children[i].StartTime.Before(span.Children[j].StartTime)
+		if !span.Children[i].StartTime.Equal(span.Children[j].StartTime) {
+			return span.Children[i].StartTime.Before(span.Children[j].StartTime)
+		}
+
+		// sort based on SpanID if two spans have equal timestamps
+		return span.Children[i].SpanID < span.Children[j].SpanID
 	})
 
 	for _, child := range span.Children {


### PR DESCRIPTION
## Description

Modify the sorter function in `pkg/cqrs/base_cqrs/cqrs.go` so that if two spans have the same timestamp we fall back to sorting them based off of their SpanID.

## Motivation

[EXE-192](https://linear.app/inngest/issue/EXE-192/sort-steps-in-graphql)

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
