### PR TITLE
back out new polling interval

### DIFF
--- a/ui/apps/dashboard/src/components/RunDetails/RunDetails.tsx
+++ b/ui/apps/dashboard/src/components/RunDetails/RunDetails.tsx
@@ -24,7 +24,6 @@ export function DashboardRunDetails({ runID, standalone = true }: Props) {
         getTrigger={getTrigger}
         runID={runID}
         tracesPreviewEnabled={tracePreviewEnabled}
-        pollInterval={DEFAULT_POLL_INTERVAL}
       />
     </div>
   );

--- a/ui/apps/dashboard/src/components/Runs/Runs.tsx
+++ b/ui/apps/dashboard/src/components/Runs/Runs.tsx
@@ -225,7 +225,6 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
       scope={scope}
       totalCount={totalCount}
       searchError={searchError}
-      pollInterval={DEFAULT_POLL_INTERVAL}
     />
   );
 });

--- a/ui/apps/dashboard/src/gql/graphql.ts
+++ b/ui/apps/dashboard/src/gql/graphql.ts
@@ -1105,7 +1105,6 @@ export enum MetricsScope {
 
 export type Mutation = {
   __typename?: 'Mutation';
-  addSlackChannel: Scalars['Boolean'];
   archiveApp: App;
   archiveEnvironment: Workspace;
   archiveEvent: Maybe<Event>;


### PR DESCRIPTION
## Description
Some additional polling went out for run traces with yesterday's rerun from step changes. This back that out so we can roll that out in a more careful manner. 

## Motivation
Reduce load, reloading.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
