### PR TITLE
Simplify url structure by removing accountId from url

### DIFF
--- a/pkg/api/v2/service.go
+++ b/pkg/api/v2/service.go
@@ -233,6 +233,12 @@ func (s *Service) CreatePartnerAccount(ctx context.Context, req *apiv2.CreateAcc
 }
 
 func (s *Service) CreateEnv(ctx context.Context, req *apiv2.CreateEnvRequest) (*apiv2.CreateEnvResponse, error) {
+	// Validate required fields
+	if req.Name == "" {
+		return nil, NewError(http.StatusBadRequest, ErrorMissingField, "Environment name is required")
+	}
+
+	// For now, return not implemented since this is OSS
 	return nil, NewError(http.StatusNotImplemented, ErrorNotImplemented, "Environments not implemented in OSS")
 }
 
@@ -241,15 +247,10 @@ func (s *Service) FetchPartnerAccounts(ctx context.Context, req *apiv2.FetchAcco
 }
 
 func (s *Service) FetchAccount(ctx context.Context, req *apiv2.FetchAccountRequest) (*apiv2.FetchAccountResponse, error) {
-	return nil, NewError(http.StatusNotImplemented, ErrorNotImplemented, "Accounts not implemented in OSS")
+	return nil, NewError(http.StatusNotImplemented, ErrorNotImplemented, "Current account not implemented in OSS")
 }
 
 func (s *Service) FetchAccountEventKeys(ctx context.Context, req *apiv2.FetchAccountEventKeysRequest) (*apiv2.FetchAccountEventKeysResponse, error) {
-	// Validate required fields
-	if req.AccountId == "" {
-		return nil, NewError(http.StatusBadRequest, ErrorMissingField, "Account ID is required")
-	}
-
 	// Extract environment from X-Inngest-Env header
 	envName := GetInngestEnvHeader(ctx)
 
@@ -270,11 +271,6 @@ func (s *Service) FetchAccountEventKeys(ctx context.Context, req *apiv2.FetchAcc
 }
 
 func (s *Service) FetchAccountEnvs(ctx context.Context, req *apiv2.FetchAccountEnvsRequest) (*apiv2.FetchAccountEnvsResponse, error) {
-	// Validate required fields
-	if req.AccountId == "" {
-		return nil, NewError(http.StatusBadRequest, ErrorMissingField, "Account ID is required")
-	}
-
 	// Validate pagination parameters
 	if req.Limit != nil {
 		if *req.Limit < 1 {
@@ -287,4 +283,24 @@ func (s *Service) FetchAccountEnvs(ctx context.Context, req *apiv2.FetchAccountE
 
 	// For now, return not implemented since this is OSS
 	return nil, NewError(http.StatusNotImplemented, ErrorNotImplemented, "Account environments not implemented in OSS")
+}
+
+func (s *Service) FetchAccountSigningKeys(ctx context.Context, req *apiv2.FetchAccountSigningKeysRequest) (*apiv2.FetchAccountSigningKeysResponse, error) {
+	// Extract environment from X-Inngest-Env header
+	envName := GetInngestEnvHeader(ctx)
+
+	// Validate pagination parameters
+	if req.Limit != nil {
+		if *req.Limit < 1 {
+			return nil, NewError(http.StatusBadRequest, ErrorInvalidFieldFormat, "Limit must be at least 1")
+		}
+		if *req.Limit > 100 {
+			return nil, NewError(http.StatusBadRequest, ErrorInvalidFieldFormat, "Limit cannot exceed 100")
+		}
+	}
+
+	// For now, return not implemented since this is OSS
+	// Note: envName can be used to filter by environment when implemented
+	_ = envName
+	return nil, NewError(http.StatusNotImplemented, ErrorNotImplemented, "Account signing keys not implemented in OSS")
 }

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -161,10 +161,12 @@ service V2 {
 
   rpc CreateEnv(CreateEnvRequest) returns (CreateEnvResponse) {
     option (google.api.http) = {
-      post: "/accounts/{accountId}/envs",
+      post: "/envs",
       body : "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Create environment"
+      description: "Create custom environment"
       security: {
         security_requirement: {
           key: "BearerAuth"
@@ -316,9 +318,11 @@ service V2 {
 
   rpc FetchAccount(FetchAccountRequest) returns (FetchAccountResponse) {
     option (google.api.http) = {
-      get: "/accounts/{accountId}"
+      get: "/accounts"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get account"
+      description: "Returns the account for the authenticated user"
       security: {
         security_requirement: {
           key: "BearerAuth"
@@ -337,31 +341,9 @@ service V2 {
         }
       }
       responses: {
-        key: "400"
-        value: {
-          description: "Bad Request - invalid query parameters"
-          schema: {
-            json_schema: {
-              ref: "#/definitions/v2ErrorResponse"
-            }
-          }
-        }
-      }
-      responses: {
         key: "401"
         value: {
           description: "Unauthorized - authentication required"
-          schema: {
-            json_schema: {
-              ref: "#/definitions/v2ErrorResponse"
-            }
-          }
-        }
-      }
-      responses: {
-        key: "403"
-        value: {
-          description: "Forbidden - insufficient permissions"
           schema: {
             json_schema: {
               ref: "#/definitions/v2ErrorResponse"
@@ -385,9 +367,11 @@ service V2 {
 
   rpc FetchAccountEnvs(FetchAccountEnvsRequest) returns (FetchAccountEnvsResponse) {
     option (google.api.http) = {
-      get: "/accounts/{accountId}/envs"
+      get: "/envs"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List environments"
+      description: "List of all custom environments."
       security: {
         security_requirement: {
           key: "BearerAuth"
@@ -465,7 +449,7 @@ service V2 {
 
   rpc FetchAccountEventKeys(FetchAccountEventKeysRequest) returns (FetchAccountEventKeysResponse) {
     option (google.api.http) = {
-      get: "/accounts/{accountId}/event-keys"
+      get: "/keys/events"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "List account event keys"
@@ -555,7 +539,7 @@ service V2 {
 
   rpc FetchAccountSigningKeys(FetchAccountSigningKeysRequest) returns (FetchAccountSigningKeysResponse) {
     option (google.api.http) = {
-      get: "/accounts/{accountId}/signing-keys"
+      get: "/keys/signing"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "List account signing keys"
@@ -649,7 +633,7 @@ message HealthRequest {
 }
 
 message FetchAccountRequest {
-  string accountId = 1;
+  // Empty request message for fetching current account
 }
 
 message HealthResponse {
@@ -686,8 +670,7 @@ message CreateAccountResponse {
 }
 
 message CreateEnvRequest {
-  string accountId = 1;
-  string name = 2;
+  string name = 1;
 }
 
 message CreateEnvResponse {
@@ -757,13 +740,12 @@ message Page {
 }
 
 message FetchAccountEventKeysRequest {
-  string accountId = 1;
-  optional string cursor = 2 [
+  optional string cursor = 1 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Pagination cursor from previous response"
     }
   ];
-  optional int32 limit = 3 [
+  optional int32 limit = 2 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Number of event keys to return per page (min: 1, max: 100)"
       default: "20"
@@ -786,13 +768,12 @@ message EventKey {
 }
 
 message FetchAccountEnvsRequest {
-  string accountId = 1;
-  optional string cursor = 2 [
+  optional string cursor = 1 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Pagination cursor from previous response"
     }
   ];
-  optional int32 limit = 3 [
+  optional int32 limit = 2 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Number of environments to return per page (min: 1, max: 250)"
       default: "50"
@@ -807,13 +788,12 @@ message FetchAccountEnvsResponse {
 }
 
 message FetchAccountSigningKeysRequest {
-  string accountId = 1;
-  optional string cursor = 2 [
+  optional string cursor = 1 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Pagination cursor from previous response"
     }
   ];
-  optional int32 limit = 3 [
+  optional int32 limit = 2 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Number of signing keys to return per page (min: 1, max: 100)"
       default: "20"

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -318,7 +318,7 @@ service V2 {
 
   rpc FetchAccount(FetchAccountRequest) returns (FetchAccountResponse) {
     option (google.api.http) = {
-      get: "/accounts"
+      get: "/account"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Get account"

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -1643,7 +1643,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"PRODUCTION\x10\x00\x12\b\n" +
 	"\x04TEST\x10\x01\x12\n" +
 	"\n" +
-	"\x06BRANCH\x10\x022\xe1(\n" +
+	"\x06BRANCH\x10\x022\xe0(\n" +
 	"\x02V2\x12\xb2\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\xf8\x01\x92A\xe5\x01\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
 	"\x03401\x12K\n" +
@@ -1719,8 +1719,8 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x8a\xb5\x18\x02\b\x01\x82\xd3\xe4\x93\x02\x13\x12\x11/partner/accounts\x12\x83\x03\n" +
-	"\fFetchAccount\x12\x1b.api.v2.FetchAccountRequest\x1a\x1c.api.v2.FetchAccountResponse\"\xb7\x02\x92A\xa2\x02\x12\vGet account\x1a.Returns the account for the authenticated userJ:\n" +
+	"BearerAuth\x12\x00\x8a\xb5\x18\x02\b\x01\x82\xd3\xe4\x93\x02\x13\x12\x11/partner/accounts\x12\x82\x03\n" +
+	"\fFetchAccount\x12\x1b.api.v2.FetchAccountRequest\x1a\x1c.api.v2.FetchAccountResponse\"\xb6\x02\x92A\xa2\x02\x12\vGet account\x1a.Returns the account for the authenticated userJ:\n" +
 	"\x03200\x123\n" +
 	"\aAccount\x12(\n" +
 	"&\x1a$#/definitions/v2FetchAccountResponseJR\n" +
@@ -1732,7 +1732,8 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\v\x12\t/accounts\x12\x8d\x05\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\n" +
+	"\x12\b/account\x12\x8d\x05\n" +
 	"\x10FetchAccountEnvs\x12\x1f.api.v2.FetchAccountEnvsRequest\x1a .api.v2.FetchAccountEnvsResponse\"\xb5\x04\x92A\xa4\x04\x12\x11List environments\x1a List of all custom environments.JS\n" +
 	"\x03200\x12L\n" +
 	"\x1cList of account environments\x12,\n" +

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -111,7 +111,6 @@ func (*HealthRequest) Descriptor() ([]byte, []int) {
 
 type FetchAccountRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	AccountId     string                 `protobuf:"bytes,1,opt,name=accountId,proto3" json:"accountId,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -144,13 +143,6 @@ func (x *FetchAccountRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use FetchAccountRequest.ProtoReflect.Descriptor instead.
 func (*FetchAccountRequest) Descriptor() ([]byte, []int) {
 	return file_api_v2_service_proto_rawDescGZIP(), []int{1}
-}
-
-func (x *FetchAccountRequest) GetAccountId() string {
-	if x != nil {
-		return x.AccountId
-	}
-	return ""
 }
 
 type HealthResponse struct {
@@ -503,8 +495,7 @@ func (x *CreateAccountResponse) GetMetadata() *ResponseMetadata {
 
 type CreateEnvRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	AccountId     string                 `protobuf:"bytes,1,opt,name=accountId,proto3" json:"accountId,omitempty"`
-	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -537,13 +528,6 @@ func (x *CreateEnvRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use CreateEnvRequest.ProtoReflect.Descriptor instead.
 func (*CreateEnvRequest) Descriptor() ([]byte, []int) {
 	return file_api_v2_service_proto_rawDescGZIP(), []int{9}
-}
-
-func (x *CreateEnvRequest) GetAccountId() string {
-	if x != nil {
-		return x.AccountId
-	}
-	return ""
 }
 
 func (x *CreateEnvRequest) GetName() string {
@@ -1059,9 +1043,8 @@ func (x *Page) GetLimit() int32 {
 
 type FetchAccountEventKeysRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	AccountId     string                 `protobuf:"bytes,1,opt,name=accountId,proto3" json:"accountId,omitempty"`
-	Cursor        *string                `protobuf:"bytes,2,opt,name=cursor,proto3,oneof" json:"cursor,omitempty"`
-	Limit         *int32                 `protobuf:"varint,3,opt,name=limit,proto3,oneof" json:"limit,omitempty"`
+	Cursor        *string                `protobuf:"bytes,1,opt,name=cursor,proto3,oneof" json:"cursor,omitempty"`
+	Limit         *int32                 `protobuf:"varint,2,opt,name=limit,proto3,oneof" json:"limit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1094,13 +1077,6 @@ func (x *FetchAccountEventKeysRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use FetchAccountEventKeysRequest.ProtoReflect.Descriptor instead.
 func (*FetchAccountEventKeysRequest) Descriptor() ([]byte, []int) {
 	return file_api_v2_service_proto_rawDescGZIP(), []int{18}
-}
-
-func (x *FetchAccountEventKeysRequest) GetAccountId() string {
-	if x != nil {
-		return x.AccountId
-	}
-	return ""
 }
 
 func (x *FetchAccountEventKeysRequest) GetCursor() string {
@@ -1255,9 +1231,8 @@ func (x *EventKey) GetCreatedAt() *timestamppb.Timestamp {
 
 type FetchAccountEnvsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	AccountId     string                 `protobuf:"bytes,1,opt,name=accountId,proto3" json:"accountId,omitempty"`
-	Cursor        *string                `protobuf:"bytes,2,opt,name=cursor,proto3,oneof" json:"cursor,omitempty"`
-	Limit         *int32                 `protobuf:"varint,3,opt,name=limit,proto3,oneof" json:"limit,omitempty"`
+	Cursor        *string                `protobuf:"bytes,1,opt,name=cursor,proto3,oneof" json:"cursor,omitempty"`
+	Limit         *int32                 `protobuf:"varint,2,opt,name=limit,proto3,oneof" json:"limit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1290,13 +1265,6 @@ func (x *FetchAccountEnvsRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use FetchAccountEnvsRequest.ProtoReflect.Descriptor instead.
 func (*FetchAccountEnvsRequest) Descriptor() ([]byte, []int) {
 	return file_api_v2_service_proto_rawDescGZIP(), []int{21}
-}
-
-func (x *FetchAccountEnvsRequest) GetAccountId() string {
-	if x != nil {
-		return x.AccountId
-	}
-	return ""
 }
 
 func (x *FetchAccountEnvsRequest) GetCursor() string {
@@ -1375,9 +1343,8 @@ func (x *FetchAccountEnvsResponse) GetPage() *Page {
 
 type FetchAccountSigningKeysRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	AccountId     string                 `protobuf:"bytes,1,opt,name=accountId,proto3" json:"accountId,omitempty"`
-	Cursor        *string                `protobuf:"bytes,2,opt,name=cursor,proto3,oneof" json:"cursor,omitempty"`
-	Limit         *int32                 `protobuf:"varint,3,opt,name=limit,proto3,oneof" json:"limit,omitempty"`
+	Cursor        *string                `protobuf:"bytes,1,opt,name=cursor,proto3,oneof" json:"cursor,omitempty"`
+	Limit         *int32                 `protobuf:"varint,2,opt,name=limit,proto3,oneof" json:"limit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1410,13 +1377,6 @@ func (x *FetchAccountSigningKeysRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use FetchAccountSigningKeysRequest.ProtoReflect.Descriptor instead.
 func (*FetchAccountSigningKeysRequest) Descriptor() ([]byte, []int) {
 	return file_api_v2_service_proto_rawDescGZIP(), []int{23}
-}
-
-func (x *FetchAccountSigningKeysRequest) GetAccountId() string {
-	if x != nil {
-		return x.AccountId
-	}
-	return ""
 }
 
 func (x *FetchAccountSigningKeysRequest) GetCursor() string {
@@ -1574,9 +1534,8 @@ var File_api_v2_service_proto protoreflect.FileDescriptor
 const file_api_v2_service_proto_rawDesc = "" +
 	"\n" +
 	"\x14api/v2/service.proto\x12\x06api.v2\x1a\x1fgoogle/protobuf/timestamp.proto\x1a(third_party/google/api/annotations.proto\x1a\x14api/v2/options.proto\x1a:third_party/protoc-gen-openapiv2/options/annotations.proto\"\x0f\n" +
-	"\rHealthRequest\"3\n" +
-	"\x13FetchAccountRequest\x12\x1c\n" +
-	"\taccountId\x18\x01 \x01(\tR\taccountId\"n\n" +
+	"\rHealthRequest\"\x15\n" +
+	"\x13FetchAccountRequest\"n\n" +
 	"\x0eHealthResponse\x12&\n" +
 	"\x04data\x18\x01 \x01(\v2\x12.api.v2.HealthDataR\x04data\x124\n" +
 	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"$\n" +
@@ -1598,10 +1557,9 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x05_name\"|\n" +
 	"\x15CreateAccountResponse\x12-\n" +
 	"\x04data\x18\x01 \x01(\v2\x19.api.v2.CreateAccountDataR\x04data\x124\n" +
-	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"D\n" +
-	"\x10CreateEnvRequest\x12\x1c\n" +
-	"\taccountId\x18\x01 \x01(\tR\taccountId\x12\x12\n" +
-	"\x04name\x18\x02 \x01(\tR\x04name\"j\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"&\n" +
+	"\x10CreateEnvRequest\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"j\n" +
 	"\x11CreateEnvResponse\x12\x1f\n" +
 	"\x04data\x18\x01 \x01(\v2\v.api.v2.EnvR\x04data\x124\n" +
 	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\x88\x01\n" +
@@ -1639,11 +1597,10 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x06cursor\x18\x01 \x01(\tH\x00R\x06cursor\x88\x01\x01\x12\x18\n" +
 	"\ahasMore\x18\x02 \x01(\bR\ahasMore\x12\x14\n" +
 	"\x05limit\x18\x03 \x01(\x05R\x05limitB\t\n" +
-	"\a_cursor\"\xfd\x01\n" +
-	"\x1cFetchAccountEventKeysRequest\x12\x1c\n" +
-	"\taccountId\x18\x01 \x01(\tR\taccountId\x12J\n" +
-	"\x06cursor\x18\x02 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x00R\x06cursor\x88\x01\x01\x12^\n" +
-	"\x05limit\x18\x03 \x01(\x05BC\x92A@2:Number of event keys to return per page (min: 1, max: 100):\x0220H\x01R\x05limit\x88\x01\x01B\t\n" +
+	"\a_cursor\"\xdf\x01\n" +
+	"\x1cFetchAccountEventKeysRequest\x12J\n" +
+	"\x06cursor\x18\x01 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x00R\x06cursor\x88\x01\x01\x12^\n" +
+	"\x05limit\x18\x02 \x01(\x05BC\x92A@2:Number of event keys to return per page (min: 1, max: 100):\x0220H\x01R\x05limit\x88\x01\x01B\t\n" +
 	"\a_cursorB\b\n" +
 	"\x06_limit\"\x9d\x01\n" +
 	"\x1dFetchAccountEventKeysResponse\x12$\n" +
@@ -1655,21 +1612,19 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
 	"\venvironment\x18\x03 \x01(\tR\venvironment\x12\x10\n" +
 	"\x03key\x18\x04 \x01(\tR\x03key\x128\n" +
-	"\tcreatedAt\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"\xfa\x01\n" +
-	"\x17FetchAccountEnvsRequest\x12\x1c\n" +
-	"\taccountId\x18\x01 \x01(\tR\taccountId\x12J\n" +
-	"\x06cursor\x18\x02 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x00R\x06cursor\x88\x01\x01\x12`\n" +
-	"\x05limit\x18\x03 \x01(\x05BE\x92AB2<Number of environments to return per page (min: 1, max: 250):\x0250H\x01R\x05limit\x88\x01\x01B\t\n" +
+	"\tcreatedAt\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"\xdc\x01\n" +
+	"\x17FetchAccountEnvsRequest\x12J\n" +
+	"\x06cursor\x18\x01 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x00R\x06cursor\x88\x01\x01\x12`\n" +
+	"\x05limit\x18\x02 \x01(\x05BE\x92AB2<Number of environments to return per page (min: 1, max: 250):\x0250H\x01R\x05limit\x88\x01\x01B\t\n" +
 	"\a_cursorB\b\n" +
 	"\x06_limit\"\x93\x01\n" +
 	"\x18FetchAccountEnvsResponse\x12\x1f\n" +
 	"\x04data\x18\x01 \x03(\v2\v.api.v2.EnvR\x04data\x124\n" +
 	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\x12 \n" +
-	"\x04page\x18\x03 \x01(\v2\f.api.v2.PageR\x04page\"\x81\x02\n" +
-	"\x1eFetchAccountSigningKeysRequest\x12\x1c\n" +
-	"\taccountId\x18\x01 \x01(\tR\taccountId\x12J\n" +
-	"\x06cursor\x18\x02 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x00R\x06cursor\x88\x01\x01\x12`\n" +
-	"\x05limit\x18\x03 \x01(\x05BE\x92AB2<Number of signing keys to return per page (min: 1, max: 100):\x0220H\x01R\x05limit\x88\x01\x01B\t\n" +
+	"\x04page\x18\x03 \x01(\v2\f.api.v2.PageR\x04page\"\xe3\x01\n" +
+	"\x1eFetchAccountSigningKeysRequest\x12J\n" +
+	"\x06cursor\x18\x01 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x00R\x06cursor\x88\x01\x01\x12`\n" +
+	"\x05limit\x18\x02 \x01(\x05BE\x92AB2<Number of signing keys to return per page (min: 1, max: 100):\x0220H\x01R\x05limit\x88\x01\x01B\t\n" +
 	"\a_cursorB\b\n" +
 	"\x06_limit\"\xa1\x01\n" +
 	"\x1fFetchAccountSigningKeysResponse\x12&\n" +
@@ -1688,7 +1643,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"PRODUCTION\x10\x00\x12\b\n" +
 	"\x04TEST\x10\x01\x12\n" +
 	"\n" +
-	"\x06BRANCH\x10\x022\xc5)\n" +
+	"\x06BRANCH\x10\x022\xe1(\n" +
 	"\x02V2\x12\xb2\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\xf8\x01\x92A\xe5\x01\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
 	"\x03401\x12K\n" +
@@ -1722,8 +1677,8 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x8a\xb5\x18\x02\b\x01\x82\xd3\xe4\x93\x02\x16:\x01*\"\x11/partner/accounts\x12\xce\x04\n" +
-	"\tCreateEnv\x12\x18.api.v2.CreateEnvRequest\x1a\x19.api.v2.CreateEnvResponse\"\x8b\x04\x92A\xe2\x03JH\n" +
+	"BearerAuth\x12\x00\x8a\xb5\x18\x02\b\x01\x82\xd3\xe4\x93\x02\x16:\x01*\"\x11/partner/accounts\x12\xe8\x04\n" +
+	"\tCreateEnv\x12\x18.api.v2.CreateEnvRequest\x1a\x19.api.v2.CreateEnvResponse\"\xa5\x04\x92A\x91\x04\x12\x12Create environment\x1a\x19Create custom environmentJH\n" +
 	"\x03201\x12A\n" +
 	"\x18Env successfully created\x12%\n" +
 	"#\x1a!#/definitions/v2CreateEnvResponseJL\n" +
@@ -1744,7 +1699,8 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x1f:\x01*\"\x1a/accounts/{accountId}/envs\x12\xd6\x04\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\n" +
+	":\x01*\"\x05/envs\x12\xd6\x04\n" +
 	"\x14FetchPartnerAccounts\x12\x1c.api.v2.FetchAccountsRequest\x1a\x1d.api.v2.FetchAccountsResponse\"\x80\x04\x92A\xdd\x03\x12\x15List partner accounts\x1a/Lists sub-accounts (if you have partner access)JD\n" +
 	"\x03200\x12=\n" +
 	"\x10List of accounts\x12)\n" +
@@ -1763,27 +1719,21 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x8a\xb5\x18\x02\b\x01\x82\xd3\xe4\x93\x02\x13\x12\x11/partner/accounts\x12\xf8\x03\n" +
-	"\fFetchAccount\x12\x1b.api.v2.FetchAccountRequest\x1a\x1c.api.v2.FetchAccountResponse\"\xac\x03\x92A\x8b\x03J:\n" +
+	"BearerAuth\x12\x00\x8a\xb5\x18\x02\b\x01\x82\xd3\xe4\x93\x02\x13\x12\x11/partner/accounts\x12\x83\x03\n" +
+	"\fFetchAccount\x12\x1b.api.v2.FetchAccountRequest\x1a\x1c.api.v2.FetchAccountResponse\"\xb7\x02\x92A\xa2\x02\x12\vGet account\x1a.Returns the account for the authenticated userJ:\n" +
 	"\x03200\x123\n" +
 	"\aAccount\x12(\n" +
 	"&\x1a$#/definitions/v2FetchAccountResponseJR\n" +
-	"\x03400\x12K\n" +
-	"&Bad Request - invalid query parameters\x12!\n" +
-	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJR\n" +
 	"\x03401\x12K\n" +
 	"&Unauthorized - authentication required\x12!\n" +
-	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJP\n" +
-	"\x03403\x12I\n" +
-	"$Forbidden - insufficient permissions\x12!\n" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJA\n" +
 	"\x03500\x12:\n" +
 	"\x15Internal Server Error\x12!\n" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x17\x12\x15/accounts/{accountId}\x12\xed\x04\n" +
-	"\x10FetchAccountEnvs\x12\x1f.api.v2.FetchAccountEnvsRequest\x1a .api.v2.FetchAccountEnvsResponse\"\x95\x04\x92A\xef\x03JS\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\v\x12\t/accounts\x12\x8d\x05\n" +
+	"\x10FetchAccountEnvs\x12\x1f.api.v2.FetchAccountEnvsRequest\x1a .api.v2.FetchAccountEnvsResponse\"\xb5\x04\x92A\xa4\x04\x12\x11List environments\x1a List of all custom environments.JS\n" +
 	"\x03200\x12L\n" +
 	"\x1cList of account environments\x12,\n" +
 	"*\x1a(#/definitions/v2FetchAccountEnvsResponseJR\n" +
@@ -1804,8 +1754,8 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x1c\x12\x1a/accounts/{accountId}/envs\x12\xb6\a\n" +
-	"\x15FetchAccountEventKeys\x12$.api.v2.FetchAccountEventKeysRequest\x1a%.api.v2.FetchAccountEventKeysResponse\"\xcf\x06\x92A\xa3\x06\x12\x17List account event keys\x1a\xaf\x01Lists event keys for a specific account, optionally filtered by environment. If the environment header isn't specified, this returns the default production environment's keys.JV\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\a\x12\x05/envs\x12\xa2\a\n" +
+	"\x15FetchAccountEventKeys\x12$.api.v2.FetchAccountEventKeysRequest\x1a%.api.v2.FetchAccountEventKeysResponse\"\xbb\x06\x92A\xa3\x06\x12\x17List account event keys\x1a\xaf\x01Lists event keys for a specific account, optionally filtered by environment. If the environment header isn't specified, this returns the default production environment's keys.JV\n" +
 	"\x03200\x12O\n" +
 	"\x1aList of account event keys\x121\n" +
 	"/\x1a-#/definitions/v2FetchAccountEventKeysResponseJR\n" +
@@ -1828,8 +1778,8 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\n" +
 	"BearerAuth\x12\x00rd\n" +
 	"b\n" +
-	"\rX-Inngest-Env\x12OFilter event keys by environment (e.g., 'production', 'staging', 'development')\x18\x01\x82\xd3\xe4\x93\x02\"\x12 /accounts/{accountId}/event-keys\x12\xc9\a\n" +
-	"\x17FetchAccountSigningKeys\x12&.api.v2.FetchAccountSigningKeysRequest\x1a'.api.v2.FetchAccountSigningKeysResponse\"\xdc\x06\x92A\xae\x06\x12\x19List account signing keys\x1a\xb2\x01Lists signing keys for a specific account, optionally filtered by environment.  If the environment header isn't specified, this returns the default production environment's keys.JZ\n" +
+	"\rX-Inngest-Env\x12OFilter event keys by environment (e.g., 'production', 'staging', 'development')\x18\x01\x82\xd3\xe4\x93\x02\x0e\x12\f/keys/events\x12\xb4\a\n" +
+	"\x17FetchAccountSigningKeys\x12&.api.v2.FetchAccountSigningKeysRequest\x1a'.api.v2.FetchAccountSigningKeysResponse\"\xc7\x06\x92A\xae\x06\x12\x19List account signing keys\x1a\xb2\x01Lists signing keys for a specific account, optionally filtered by environment.  If the environment header isn't specified, this returns the default production environment's keys.JZ\n" +
 	"\x03200\x12S\n" +
 	"\x1cList of account signing keys\x123\n" +
 	"1\x1a/#/definitions/v2FetchAccountSigningKeysResponseJR\n" +
@@ -1852,7 +1802,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\n" +
 	"BearerAuth\x12\x00rf\n" +
 	"d\n" +
-	"\rX-Inngest-Env\x12QFilter signing keys by environment (e.g., 'production', 'staging', 'development')\x18\x01\x82\xd3\xe4\x93\x02$\x12\"/accounts/{accountId}/signing-keysB\xc8\x02\x92A\x91\x02\x12\x9b\x01\n" +
+	"\rX-Inngest-Env\x12QFilter signing keys by environment (e.g., 'production', 'staging', 'development')\x18\x01\x82\xd3\xe4\x93\x02\x0f\x12\r/keys/signingB\xc8\x02\x92A\x91\x02\x12\x9b\x01\n" +
 	"\x13Inngest REST API v2\x12}The v2 API delivers a significantly improved developer experience with consistent design patterns and enhanced functionality.2\x052.0.0\x1a\x0fapi.inngest.com\"\x03/v2*\x01\x02ZX\n" +
 	"V\n" +
 	"\n" +

--- a/proto/gen/api/v2/service.pb.gw.go
+++ b/proto/gen/api/v2/service.pb.gw.go
@@ -87,21 +87,12 @@ func request_V2_CreateEnv_0(ctx context.Context, marshaler runtime.Marshaler, cl
 	var (
 		protoReq CreateEnvRequest
 		metadata runtime.ServerMetadata
-		err      error
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 	if req.Body != nil {
 		_, _ = io.Copy(io.Discard, req.Body)
-	}
-	val, ok := pathParams["accountId"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "accountId")
-	}
-	protoReq.AccountId, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "accountId", err)
 	}
 	msg, err := client.CreateEnv(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
@@ -111,18 +102,9 @@ func local_request_V2_CreateEnv_0(ctx context.Context, marshaler runtime.Marshal
 	var (
 		protoReq CreateEnvRequest
 		metadata runtime.ServerMetadata
-		err      error
 	)
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-	val, ok := pathParams["accountId"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "accountId")
-	}
-	protoReq.AccountId, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "accountId", err)
 	}
 	msg, err := server.CreateEnv(ctx, &protoReq)
 	return msg, metadata, err
@@ -167,18 +149,9 @@ func request_V2_FetchAccount_0(ctx context.Context, marshaler runtime.Marshaler,
 	var (
 		protoReq FetchAccountRequest
 		metadata runtime.ServerMetadata
-		err      error
 	)
 	if req.Body != nil {
 		_, _ = io.Copy(io.Discard, req.Body)
-	}
-	val, ok := pathParams["accountId"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "accountId")
-	}
-	protoReq.AccountId, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "accountId", err)
 	}
 	msg, err := client.FetchAccount(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
@@ -188,38 +161,20 @@ func local_request_V2_FetchAccount_0(ctx context.Context, marshaler runtime.Mars
 	var (
 		protoReq FetchAccountRequest
 		metadata runtime.ServerMetadata
-		err      error
 	)
-	val, ok := pathParams["accountId"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "accountId")
-	}
-	protoReq.AccountId, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "accountId", err)
-	}
 	msg, err := server.FetchAccount(ctx, &protoReq)
 	return msg, metadata, err
 }
 
-var filter_V2_FetchAccountEnvs_0 = &utilities.DoubleArray{Encoding: map[string]int{"accountId": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+var filter_V2_FetchAccountEnvs_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 
 func request_V2_FetchAccountEnvs_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq FetchAccountEnvsRequest
 		metadata runtime.ServerMetadata
-		err      error
 	)
 	if req.Body != nil {
 		_, _ = io.Copy(io.Discard, req.Body)
-	}
-	val, ok := pathParams["accountId"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "accountId")
-	}
-	protoReq.AccountId, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "accountId", err)
 	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -235,16 +190,7 @@ func local_request_V2_FetchAccountEnvs_0(ctx context.Context, marshaler runtime.
 	var (
 		protoReq FetchAccountEnvsRequest
 		metadata runtime.ServerMetadata
-		err      error
 	)
-	val, ok := pathParams["accountId"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "accountId")
-	}
-	protoReq.AccountId, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "accountId", err)
-	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -255,24 +201,15 @@ func local_request_V2_FetchAccountEnvs_0(ctx context.Context, marshaler runtime.
 	return msg, metadata, err
 }
 
-var filter_V2_FetchAccountEventKeys_0 = &utilities.DoubleArray{Encoding: map[string]int{"accountId": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+var filter_V2_FetchAccountEventKeys_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 
 func request_V2_FetchAccountEventKeys_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq FetchAccountEventKeysRequest
 		metadata runtime.ServerMetadata
-		err      error
 	)
 	if req.Body != nil {
 		_, _ = io.Copy(io.Discard, req.Body)
-	}
-	val, ok := pathParams["accountId"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "accountId")
-	}
-	protoReq.AccountId, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "accountId", err)
 	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -288,16 +225,7 @@ func local_request_V2_FetchAccountEventKeys_0(ctx context.Context, marshaler run
 	var (
 		protoReq FetchAccountEventKeysRequest
 		metadata runtime.ServerMetadata
-		err      error
 	)
-	val, ok := pathParams["accountId"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "accountId")
-	}
-	protoReq.AccountId, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "accountId", err)
-	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -308,24 +236,15 @@ func local_request_V2_FetchAccountEventKeys_0(ctx context.Context, marshaler run
 	return msg, metadata, err
 }
 
-var filter_V2_FetchAccountSigningKeys_0 = &utilities.DoubleArray{Encoding: map[string]int{"accountId": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
+var filter_V2_FetchAccountSigningKeys_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
 
 func request_V2_FetchAccountSigningKeys_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq FetchAccountSigningKeysRequest
 		metadata runtime.ServerMetadata
-		err      error
 	)
 	if req.Body != nil {
 		_, _ = io.Copy(io.Discard, req.Body)
-	}
-	val, ok := pathParams["accountId"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "accountId")
-	}
-	protoReq.AccountId, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "accountId", err)
 	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
@@ -341,16 +260,7 @@ func local_request_V2_FetchAccountSigningKeys_0(ctx context.Context, marshaler r
 	var (
 		protoReq FetchAccountSigningKeysRequest
 		metadata runtime.ServerMetadata
-		err      error
 	)
-	val, ok := pathParams["accountId"]
-	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "accountId")
-	}
-	protoReq.AccountId, err = runtime.String(val)
-	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "accountId", err)
-	}
 	if err := req.ParseForm(); err != nil {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
@@ -413,7 +323,7 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/CreateEnv", runtime.WithHTTPPathPattern("/accounts/{accountId}/envs"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/CreateEnv", runtime.WithHTTPPathPattern("/envs"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -453,7 +363,7 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/FetchAccount", runtime.WithHTTPPathPattern("/accounts/{accountId}"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/FetchAccount", runtime.WithHTTPPathPattern("/accounts"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -473,7 +383,7 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/FetchAccountEnvs", runtime.WithHTTPPathPattern("/accounts/{accountId}/envs"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/FetchAccountEnvs", runtime.WithHTTPPathPattern("/envs"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -493,7 +403,7 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/FetchAccountEventKeys", runtime.WithHTTPPathPattern("/accounts/{accountId}/event-keys"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/FetchAccountEventKeys", runtime.WithHTTPPathPattern("/keys/events"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -513,7 +423,7 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/FetchAccountSigningKeys", runtime.WithHTTPPathPattern("/accounts/{accountId}/signing-keys"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/FetchAccountSigningKeys", runtime.WithHTTPPathPattern("/keys/signing"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -605,7 +515,7 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/CreateEnv", runtime.WithHTTPPathPattern("/accounts/{accountId}/envs"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/CreateEnv", runtime.WithHTTPPathPattern("/envs"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -639,7 +549,7 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/FetchAccount", runtime.WithHTTPPathPattern("/accounts/{accountId}"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/FetchAccount", runtime.WithHTTPPathPattern("/accounts"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -656,7 +566,7 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/FetchAccountEnvs", runtime.WithHTTPPathPattern("/accounts/{accountId}/envs"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/FetchAccountEnvs", runtime.WithHTTPPathPattern("/envs"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -673,7 +583,7 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/FetchAccountEventKeys", runtime.WithHTTPPathPattern("/accounts/{accountId}/event-keys"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/FetchAccountEventKeys", runtime.WithHTTPPathPattern("/keys/events"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -690,7 +600,7 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/FetchAccountSigningKeys", runtime.WithHTTPPathPattern("/accounts/{accountId}/signing-keys"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/FetchAccountSigningKeys", runtime.WithHTTPPathPattern("/keys/signing"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -709,12 +619,12 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 var (
 	pattern_V2_Health_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"health"}, ""))
 	pattern_V2_CreatePartnerAccount_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"partner", "accounts"}, ""))
-	pattern_V2_CreateEnv_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"accounts", "accountId", "envs"}, ""))
+	pattern_V2_CreateEnv_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"envs"}, ""))
 	pattern_V2_FetchPartnerAccounts_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"partner", "accounts"}, ""))
-	pattern_V2_FetchAccount_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"accounts", "accountId"}, ""))
-	pattern_V2_FetchAccountEnvs_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"accounts", "accountId", "envs"}, ""))
-	pattern_V2_FetchAccountEventKeys_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"accounts", "accountId", "event-keys"}, ""))
-	pattern_V2_FetchAccountSigningKeys_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"accounts", "accountId", "signing-keys"}, ""))
+	pattern_V2_FetchAccount_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"accounts"}, ""))
+	pattern_V2_FetchAccountEnvs_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"envs"}, ""))
+	pattern_V2_FetchAccountEventKeys_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"keys", "events"}, ""))
+	pattern_V2_FetchAccountSigningKeys_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"keys", "signing"}, ""))
 )
 
 var (

--- a/proto/gen/api/v2/service.pb.gw.go
+++ b/proto/gen/api/v2/service.pb.gw.go
@@ -363,7 +363,7 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/FetchAccount", runtime.WithHTTPPathPattern("/accounts"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/FetchAccount", runtime.WithHTTPPathPattern("/account"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -549,7 +549,7 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/FetchAccount", runtime.WithHTTPPathPattern("/accounts"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/FetchAccount", runtime.WithHTTPPathPattern("/account"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -621,7 +621,7 @@ var (
 	pattern_V2_CreatePartnerAccount_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"partner", "accounts"}, ""))
 	pattern_V2_CreateEnv_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"envs"}, ""))
 	pattern_V2_FetchPartnerAccounts_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"partner", "accounts"}, ""))
-	pattern_V2_FetchAccount_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"accounts"}, ""))
+	pattern_V2_FetchAccount_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"account"}, ""))
 	pattern_V2_FetchAccountEnvs_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"envs"}, ""))
 	pattern_V2_FetchAccountEventKeys_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"keys", "events"}, ""))
 	pattern_V2_FetchAccountSigningKeys_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"keys", "signing"}, ""))


### PR DESCRIPTION
## Description

- simplify url structure
  - GET  /accounts/{accountId} -> /account
  - GET  /accounts/{accountId}/envs -> /envs
  - POST /accounts/{accountId}/envs -> /envs
  - GET  /accounts/{accountId}/event-keys -> /keys/events
  - GET  /accounts/{accountId}/signing-keys -> /keys/signing
<img width="1448" height="499" alt="image" src="https://github.com/user-attachments/assets/05550f72-7907-4b51-92dc-9c23f3ff9976" />



## Motivation
Simplify API URL structure

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
