### PR TITLE
Log body when stream isn't valid JSON

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -372,6 +372,11 @@ func do(ctx context.Context, c exechttp.RequestExecutor, r Request) (*Response, 
 	if resp.StatusCode == 201 && sysErr == nil {
 		stream, err := ParseStream(resp.Body)
 		if err != nil {
+			l.Error(
+				"error parsing SDK response stream",
+				"error", err,
+				"body", string(resp.Body),
+			)
 			return nil, resp.StatResult, fmt.Errorf("error parsing stream: %w", err)
 		} else {
 			// These are all contained within a single wrapper.


### PR DESCRIPTION
## Description
When we get invalid JSON in an SDK streaming response, log the body.

## Motivation
Some users are reporting `error parsing stream: error reading response body to check for status code: unexpected end of JSON input` step errors, but right now we can't know what the invalid JSON looks like