### PR TITLE
[Fix]: Improve function configuration table tooltip placement

### DIFF
--- a/ui/packages/components/src/FunctionConfiguration/ConfigurationTable.tsx
+++ b/ui/packages/components/src/FunctionConfiguration/ConfigurationTable.tsx
@@ -64,7 +64,7 @@ export default function ConfigurationTable({
                     >
                       <code className="font-mono">{entry.value}</code>
                     </TooltipTrigger>
-                    <TooltipContent className="p-3 text-sm">
+                    <TooltipContent className="p-3 text-sm" side="left">
                       <code>{entry.value}</code>
                     </TooltipContent>
                   </Tooltip>


### PR DESCRIPTION
## Description

This ~fixes an issue where tooltip configuration table key values truncate due to lack of available space. The `~` is present because the quick fix is to move the tooltips to the left (because the sections are on the right margin) and theoretically the problem could persist, although it would take a substantial key value.

## Motivation

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
