### PR TITLE
Distinguish between Dev Server and Prod Server in CLI startup output.

### DIFF
--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -127,6 +127,10 @@ func (d *devserver) PrettyName() string {
 		return ""
 	}
 
+	if d.Opts.Config.ServerKind == "cloud" {
+		return "Server"
+	}
+
 	return "Dev Server"
 }
 


### PR DESCRIPTION
## Description

Show different messages for `dev` and `start` commands

Dev mode (`inngest dev`)
```sh
        Inngest Dev Server online at 0.0.0.0:8288, visible at the following URLs:

         - http://127.0.0.1:8288 (http://localhost:8288)
         - http://192.168.68.78:8288
         - http://192.168.139.3:8288
```

Prod mode (`inngest start`)
```sh
        Inngest Server online at 0.0.0.0:8288, visible at the following URLs:

         - http://127.0.0.1:8288 (http://localhost:8288)
         - http://192.168.68.78:8288
         - http://192.168.139.3:8288
```


## Motivation
Improved experience for self-hosters 

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
