### PR TITLE
fix: only trigger 1 onFailure call on parallel step failure

### DIFF
--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -223,7 +223,7 @@ func (e *executor) finalizeEvents(ctx context.Context, opts execution.FinalizeOp
 			// Legacy - send inngest/function.failed, except for when the function has been cancelled.
 			if !strings.Contains(*opts.Response.Err, state.ErrFunctionCancelled.Error()) {
 				freshEvents = append(freshEvents, event.Event{
-					ID:        ulid.MustNew(uint64(now.UnixMilli()), rand.Reader).String(),
+					ID:        opts.Metadata.ID.RunID.String(), // using the RunID as the ID prevents duped runs for parallel steps
 					Name:      event.FnFailedName,
 					Timestamp: now.UnixMilli(),
 					Data:      data,
@@ -233,7 +233,7 @@ func (e *executor) finalizeEvents(ctx context.Context, opts execution.FinalizeOp
 			// Add function cancelled event
 			if *opts.Response.Err == state.ErrFunctionCancelled.Error() {
 				freshEvents = append(freshEvents, event.Event{
-					ID:        ulid.MustNew(uint64(now.UnixMilli()), rand.Reader).String(),
+					ID:        opts.Metadata.ID.RunID.String(), // using the RunID as the ID prevents duped runs for parallel steps
 					Name:      event.FnCancelledName,
 					Timestamp: now.UnixMilli(),
 					Data:      data,


### PR DESCRIPTION
## Description

Use the existing deduplication based on the idempotency key to prevent duplicate onFailure calls when parallel steps
fail.

Note that this only prevents the duplicated onFailure event from actually scheduling -- the event itself is still sent and
recorded, which may be confusing to users. This could potentially be resolved by [this](https://linear.app/inngest/project/first-class-event-id-idempotency-84d7a96e57cd/overview) Linear project.

You can see an example of two runs of the example function here, with the earlier run executing the onFailure twice while the changes in this PR only execute the function once.
<img width="1624" height="1056" alt="Screenshot 2025-08-29 at 12 15 30 PM" src="https://github.com/user-attachments/assets/5b047882-68a3-41ba-b81a-70fa8daa9e36" />

## Motivation
[EXE-194](https://linear.app/inngest/issue/EXE-194/duplicate-onfailure-calls-when-multiple-parallel-steps-fail)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
