### PR TITLE
[Insights]: Support cmd+enter shortcut to issue an insights query

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditor.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditor.tsx
@@ -14,11 +14,14 @@ export function InsightsSQLEditor() {
   // nevertheless executes with fresh state (query, isRunning, runQuery).
   const handleEditorMount: SQLEditorMountCallback = useLatestCallback((editor, monaco) => {
     const disposable = editor.onKeyDown((e) => {
-      if (e.keyCode === monaco.KeyCode.Enter && (e.metaKey || e.ctrlKey)) {
+      if (
+        e.keyCode === monaco.KeyCode.Enter &&
+        (e.metaKey || e.ctrlKey) &&
+        getCanRunQuery(query, isRunning)
+      ) {
         e.preventDefault();
         e.stopPropagation();
-
-        if (getCanRunQuery(query, isRunning)) runQuery();
+        runQuery();
       }
     });
 

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditor.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditor.tsx
@@ -14,14 +14,11 @@ export function InsightsSQLEditor() {
   // nevertheless executes with fresh state (query, isRunning, runQuery).
   const handleEditorMount: SQLEditorMountCallback = useLatestCallback((editor, monaco) => {
     const disposable = editor.onKeyDown((e) => {
-      if (
-        e.keyCode === monaco.KeyCode.Enter &&
-        (e.metaKey || e.ctrlKey) &&
-        getCanRunQuery(query, isRunning)
-      ) {
+      if (e.keyCode === monaco.KeyCode.Enter && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         e.stopPropagation();
-        runQuery();
+
+        if (getCanRunQuery(query, isRunning)) runQuery();
       }
     });
 

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditor.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditor.tsx
@@ -1,11 +1,43 @@
 'use client';
 
-import { SQLEditor } from '@inngest/components/SQLEditor/SQLEditor';
+import { useCallback, useLayoutEffect, useRef } from 'react';
+import { SQLEditor, type SQLEditorMountCallback } from '@inngest/components/SQLEditor/SQLEditor';
 
 import { useInsightsStateMachineContext } from '../InsightsStateMachineContext/InsightsStateMachineContext';
+import { getCanRunQuery } from './utils';
 
 export function InsightsSQLEditor() {
-  const { onChange, query } = useInsightsStateMachineContext();
+  const { onChange, query, runQuery, status } = useInsightsStateMachineContext();
+  const isRunning = status === 'loading';
 
-  return <SQLEditor content={query} onChange={onChange} />;
+  // useLatestCallback ensures Monaco's onMount gets a stable reference while the callback
+  // nevertheless executes with fresh state (query, isRunning, runQuery).
+  const handleEditorMount: SQLEditorMountCallback = useLatestCallback((editor, monaco) => {
+    const disposable = editor.onKeyDown((e) => {
+      if (e.keyCode === monaco.KeyCode.Enter && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (getCanRunQuery(query, isRunning)) runQuery();
+      }
+    });
+
+    return () => {
+      disposable.dispose();
+    };
+  });
+
+  return <SQLEditor content={query} onChange={onChange} onMount={handleEditorMount} />;
+}
+
+function useLatestCallback<A extends any[], R>(callback: (...args: A) => R) {
+  const ref = useRef(callback);
+
+  useLayoutEffect(() => {
+    ref.current = callback;
+  }, [callback]);
+
+  return useCallback((...args: A) => {
+    return ref.current(...args);
+  }, []);
 }

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditor.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditor.tsx
@@ -1,53 +1,13 @@
 'use client';
 
-import { useCallback, useLayoutEffect, useRef } from 'react';
-import { SQLEditor, type SQLEditorMountCallback } from '@inngest/components/SQLEditor/SQLEditor';
+import { SQLEditor } from '@inngest/components/SQLEditor/SQLEditor';
 
 import { useInsightsStateMachineContext } from '../InsightsStateMachineContext/InsightsStateMachineContext';
-import { getCanRunQuery } from './utils';
+import { useInsightsSQLEditorOnMountCallback } from './useInsightsSQLEditorOnMountCallback';
 
 export function InsightsSQLEditor() {
-  const { onChange, query, runQuery, status } = useInsightsStateMachineContext();
+  const { onChange, query } = useInsightsStateMachineContext();
+  const { onMount } = useInsightsSQLEditorOnMountCallback();
 
-  const latestQueryRef = useLatest(query);
-  const isRunningRef = useLatest(status === 'loading');
-
-  // useLatestCallback ensures Monaco's onMount gets a stable reference while the callback
-  // nevertheless executes with fresh state (query, isRunning, runQuery).
-  const handleEditorMount: SQLEditorMountCallback = useLatestCallback((editor, monaco) => {
-    const disposable = editor.onKeyDown((e) => {
-      if (e.keyCode === monaco.KeyCode.Enter && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        e.stopPropagation();
-
-        if (getCanRunQuery(latestQueryRef.current, isRunningRef.current)) {
-          runQuery();
-        }
-      }
-    });
-
-    return () => {
-      disposable.dispose();
-    };
-  });
-
-  return <SQLEditor content={query} onChange={onChange} onMount={handleEditorMount} />;
-}
-
-function useLatest<T>(value: T) {
-  const r = useRef(value);
-
-  useLayoutEffect(() => {
-    r.current = value;
-  }, [value]);
-
-  return r;
-}
-
-function useLatestCallback<A extends unknown[], R>(cb: (...args: A) => R) {
-  const latest = useLatest(cb);
-
-  return useCallback((...args: A) => {
-    return latest.current(...args);
-  }, []);
+  return <SQLEditor content={query} onChange={onChange} onMount={onMount} />;
 }

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorQueryButton.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorQueryButton.tsx
@@ -1,9 +1,23 @@
 'use client';
 
 import { Button } from '@inngest/components/Button/Button';
-import { RiPlayFill } from '@remixicon/react';
+import { RiCommandLine, RiCornerDownLeftFill } from '@remixicon/react';
 
 import { useInsightsStateMachineContext } from '../InsightsStateMachineContext/InsightsStateMachineContext';
+
+function QueryButtonLabel({ isRunning }: { isRunning: boolean }) {
+  if (isRunning) return null;
+
+  return (
+    <div className="flex items-center gap-2">
+      <span>Run query</span>
+      <div className="bg-primary-moderate flex shrink-0 gap-0.5 rounded-[4px] px-1 py-0.5">
+        <RiCommandLine className="h-4 w-4" />
+        <RiCornerDownLeftFill className="h-4 w-4" />
+      </div>
+    </div>
+  );
+}
 
 export function InsightsSQLEditorQueryButton() {
   const { query, runQuery, status } = useInsightsStateMachineContext();
@@ -11,11 +25,9 @@ export function InsightsSQLEditorQueryButton() {
 
   return (
     <Button
-      className="w-[110px]"
+      className="w-[135px] font-medium"
       disabled={query.trim() === '' || isRunning}
-      icon={<RiPlayFill className="h-4 w-4" />}
-      iconSide="left"
-      label={isRunning ? undefined : 'Run query'}
+      label={<QueryButtonLabel isRunning={isRunning} />}
       loading={isRunning}
       onClick={(e) => {
         runQuery();

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorQueryButton.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorQueryButton.tsx
@@ -2,18 +2,24 @@
 
 import { useEffect } from 'react';
 import { Button } from '@inngest/components/Button/Button';
+import { cn } from '@inngest/components/utils/classNames';
 import { RiCommandLine, RiCornerDownLeftFill } from '@remixicon/react';
 
 import { useInsightsStateMachineContext } from '../InsightsStateMachineContext/InsightsStateMachineContext';
 import { getCanRunQuery } from './utils';
 
-function QueryButtonLabel({ isRunning }: { isRunning: boolean }) {
+function QueryButtonLabel({ disabled, isRunning }: { disabled: boolean; isRunning: boolean }) {
   if (isRunning) return null;
 
   return (
     <div className="flex items-center gap-2">
       <span>Run query</span>
-      <div className="bg-primary-moderate flex shrink-0 gap-0.5 rounded-[4px] px-1 py-0.5">
+      <div
+        className={cn(
+          'flex shrink-0 gap-0.5 rounded-[4px] px-1 py-0.5',
+          disabled ? 'bg-muted' : 'bg-primary-moderate'
+        )}
+      >
         <RiCommandLine className="h-4 w-4" />
         <RiCornerDownLeftFill className="h-4 w-4" />
       </div>
@@ -46,7 +52,7 @@ export function InsightsSQLEditorQueryButton() {
     <Button
       className="w-[135px] font-medium"
       disabled={!canRunQuery}
-      label={<QueryButtonLabel isRunning={isRunning} />}
+      label={<QueryButtonLabel isRunning={isRunning} disabled={!canRunQuery} />}
       loading={isRunning}
       onClick={(e) => {
         runQuery();

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorQueryButton.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorQueryButton.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { useEffect } from 'react';
 import { Button } from '@inngest/components/Button/Button';
 import { RiCommandLine, RiCornerDownLeftFill } from '@remixicon/react';
 
 import { useInsightsStateMachineContext } from '../InsightsStateMachineContext/InsightsStateMachineContext';
+import { getCanRunQuery } from './utils';
 
 function QueryButtonLabel({ isRunning }: { isRunning: boolean }) {
   if (isRunning) return null;
@@ -22,11 +24,28 @@ function QueryButtonLabel({ isRunning }: { isRunning: boolean }) {
 export function InsightsSQLEditorQueryButton() {
   const { query, runQuery, status } = useInsightsStateMachineContext();
   const isRunning = status === 'loading';
+  const canRunQuery = getCanRunQuery(query, isRunning);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Enter' && (event.metaKey || event.ctrlKey) && canRunQuery) {
+        event.preventDefault();
+        event.stopPropagation();
+        runQuery();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [canRunQuery, runQuery]);
 
   return (
     <Button
       className="w-[135px] font-medium"
-      disabled={query.trim() === '' || isRunning}
+      disabled={!canRunQuery}
       label={<QueryButtonLabel isRunning={isRunning} />}
       loading={isRunning}
       onClick={(e) => {

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorSaveQueryButton.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorSaveQueryButton.tsx
@@ -26,11 +26,12 @@ export function InsightsSQLEditorSaveQueryButton({ tab }: InsightsSQLEditorSaveQ
   return (
     <Button
       appearance="outlined"
+      className="font-medium"
       disabled={disabled}
       icon={<Icon className={cn(disabled ? 'text-disabled' : 'text-muted')} size={16} />}
       iconSide="left"
       kind="secondary"
-      label="Save"
+      label="Save query"
       onClick={() => {
         const newTab: Query = { id: tab.id, name, query, saved: true };
         saveQuery(newTab, () => {

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/useInsightsSQLEditorOnMountCallback.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/useInsightsSQLEditorOnMountCallback.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useLayoutEffect, useRef } from 'react';
+import type { SQLEditorMountCallback } from '@inngest/components/SQLEditor/SQLEditor.jsx';
+
+import { useInsightsStateMachineContext } from '../InsightsStateMachineContext/InsightsStateMachineContext';
+import { getCanRunQuery } from './utils';
+
+// This hook makes use of the useLatest and useLatestCallback hooks to get around the fact that
+// onMount will only run once when the Monaco editor initially mounts. Without this approach,
+// the cmd+enter shortcut handler would see stale values.
+
+type UseInsightsSQLEditorOnMountCallbackReturn = {
+  onMount: SQLEditorMountCallback;
+};
+
+export function useInsightsSQLEditorOnMountCallback(): UseInsightsSQLEditorOnMountCallbackReturn {
+  const { query, runQuery, status } = useInsightsStateMachineContext();
+
+  const latestQueryRef = useLatest(query);
+  const isRunningRef = useLatest(status === 'loading');
+
+  const onMount: SQLEditorMountCallback = useLatestCallback((editor, monaco) => {
+    const disposable = editor.onKeyDown((e) => {
+      if (e.keyCode === monaco.KeyCode.Enter && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (getCanRunQuery(latestQueryRef.current, isRunningRef.current)) runQuery();
+      }
+    });
+
+    return () => {
+      disposable.dispose();
+    };
+  });
+
+  return { onMount };
+}
+
+// Uses a ref to ensure that the latest value is always available.
+function useLatest<T>(value: T) {
+  const r = useRef(value);
+
+  useLayoutEffect(() => {
+    r.current = value;
+  }, [value]);
+
+  return r;
+}
+
+// Extends useLatest to generate an always up-to-date callback.
+function useLatestCallback<A extends unknown[], R>(cb: (...args: A) => R) {
+  const latest = useLatest(cb);
+
+  return useCallback((...args: A) => {
+    return latest.current(...args);
+  }, []);
+}

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/useInsightsSQLEditorOnMountCallback.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/useInsightsSQLEditorOnMountCallback.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useLayoutEffect, useRef } from 'react';
-import type { SQLEditorMountCallback } from '@inngest/components/SQLEditor/SQLEditor.jsx';
+import type { SQLEditorMountCallback } from '@inngest/components/SQLEditor/SQLEditor';
 
 import { useInsightsStateMachineContext } from '../InsightsStateMachineContext/InsightsStateMachineContext';
 import { getCanRunQuery } from './utils';

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/utils.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/utils.ts
@@ -1,0 +1,3 @@
+export function getCanRunQuery(query: string, isRunning: boolean): boolean {
+  return query.trim() !== '' && !isRunning;
+}

--- a/ui/packages/components/src/SQLEditor/SQLEditor.tsx
+++ b/ui/packages/components/src/SQLEditor/SQLEditor.tsx
@@ -1,18 +1,21 @@
 'use client';
 
 import { useCallback, useRef } from 'react';
-import { Editor } from '@monaco-editor/react';
+import { Editor, type Monaco } from '@monaco-editor/react';
+import type { editor } from 'monaco-editor';
 
 import { EDITOR_OPTIONS } from './constants';
 import { useMonacoWithTheme } from './hooks/useMonacoWithTheme';
 
+export type SQLEditorMountCallback = (editor: editor.IStandaloneCodeEditor, monaco: Monaco) => void;
+
 export type SQLEditorProps = {
   content: string;
   onChange: (value: string) => void;
+  onMount?: SQLEditorMountCallback;
 };
 
-// TODO: Remove this component and use the NewCodeBlock component when it's ready.
-export function SQLEditor({ content, onChange }: SQLEditorProps) {
+export function SQLEditor({ content, onChange, onMount }: SQLEditorProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   useMonacoWithTheme(wrapperRef);
@@ -24,11 +27,19 @@ export function SQLEditor({ content, onChange }: SQLEditorProps) {
     [onChange]
   );
 
+  const handleEditorMount = useCallback(
+    (editorInstance: editor.IStandaloneCodeEditor, monaco: Monaco) => {
+      onMount?.(editorInstance, monaco);
+    },
+    [onMount]
+  );
+
   return (
     <div ref={wrapperRef} className="bg-codeEditor relative h-full">
       <Editor
         defaultLanguage="sql"
         onChange={handleContentChange}
+        onMount={handleEditorMount}
         options={EDITOR_OPTIONS}
         theme="inngest-theme"
         value={content}


### PR DESCRIPTION
## Description

This PR fulfills a request (and design expectation) for cmd+enter to issue a query to fetch new results.

<img width="268" height="44" alt="Screenshot 2025-08-28 at 3 39 18 PM" src="https://github.com/user-attachments/assets/26f192d3-6e0e-45cb-b6c1-fe2dafc48106" />

## Motivation

This makes the process of iterating on a query more pleasant for users.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
