### PR TITLE
Fix retry not returning unwrapped error when max retries is 1

### DIFF
--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -378,10 +378,9 @@ func (v v2) SavePending(ctx context.Context, id state.ID, pending []string) erro
 
 func (v v2) retryPolicy(opts ...util.RetryConfSetting) util.RetryConf {
 	if v.disabledRetries {
-		return util.NewRetryConf(util.WithRetryConfMaxAttempts(1))
+		opts = append(opts, util.WithRetryConfMaxAttempts(1))
 	}
-	val := util.NewRetryConf(opts...)
-	return val
+	return util.NewRetryConf(opts...)
 }
 
 // determine what errors are retriable

--- a/pkg/util/retry.go
+++ b/pkg/util/retry.go
@@ -95,15 +95,15 @@ func WithRetry[T any](ctx context.Context, action string, fn Retryable[T], conf 
 			return result, nil
 		}
 
-		lastErr = err
-		if attempt == conf.MaxAttempts {
-			break
-		}
-
 		// check if the error returned should be retried.
 		// if not, return as is
 		if conf.RetryableErrors != nil && !conf.RetryableErrors(err) {
 			return result, err
+		}
+
+		lastErr = err
+		if attempt == conf.MaxAttempts {
+			break
 		}
 
 		l.Warn("retrying function",

--- a/pkg/util/retry_test.go
+++ b/pkg/util/retry_test.go
@@ -80,7 +80,7 @@ func TestWithRetry(t *testing.T) {
 
 		require.Error(t, err)
 
-		// It should be exact equality
+		// It should be exactly equal
 		require.Equal(t, idemErr, err)
 	})
 }

--- a/pkg/util/retry_test.go
+++ b/pkg/util/retry_test.go
@@ -60,4 +60,27 @@ func TestWithRetry(t *testing.T) {
 		require.ErrorIs(t, err, notCoveredErr)
 		require.Equal(t, 3, attempt)
 	})
+
+	t.Run("does not retry when max attempts is 1 and returns unwrapped error", func(t *testing.T) {
+		idemErr := errors.New("idempotent error")
+
+		_, err := WithRetry(
+			ctx,
+			"test",
+			func(ctx context.Context) (bool, error) {
+				return false, idemErr
+			},
+			NewRetryConf(
+				WithRetryConfRetryableErrors(func(err error) bool {
+					return false
+				}),
+				WithRetryConfMaxAttempts(1),
+			),
+		)
+
+		require.Error(t, err)
+
+		// It should be exact equality
+		require.Equal(t, idemErr, err)
+	})
 }


### PR DESCRIPTION
## Description

When an error is non retriable we return the error as is, but when max retries is set to 1 that behavior changes to returning a wrapped error because we break early from the retry loop.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
