### PR TITLE
Temporarily pinning clerkjs for styles

### DIFF
--- a/ui/apps/dashboard/src/app/Provider.tsx
+++ b/ui/apps/dashboard/src/app/Provider.tsx
@@ -19,6 +19,7 @@ export default function Provider({ children }: React.PropsWithChildren) {
 
   return (
     <ClerkProvider
+      clerkJSVersion="5.88.0"
       appearance={{
         layout: {
           logoPlacement: 'outside' as const,


### PR DESCRIPTION
## Description

Fixes authenticator app input by pinning ClerkJS in provider

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

Route `/settings/user/security`
Before (default version):
<img width="971" height="293" alt="Screenshot 2025-08-29 at 12 28 57 PM" src="https://github.com/user-attachments/assets/87e5b5f9-3f6a-45a7-aec6-c232781a00c0" />

After (pinned version):
<img width="971" height="293" alt="image" src="https://github.com/user-attachments/assets/c17bb309-8d42-4efe-b310-288b67dc3d08" />
