### PR TITLE
turn new traces back on after recent fixes

### DIFF
--- a/ui/apps/dev-server-ui/src/app/(dashboard)/run/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/run/page.tsx
@@ -21,7 +21,7 @@ export default function Page() {
         getTrigger={getTrigger}
         pollInterval={2500}
         runID={runID}
-        tracesPreviewEnabled={false}
+        tracesPreviewEnabled={true}
       />
     </div>
   );

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/runs/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/runs/page.tsx
@@ -34,7 +34,7 @@ const pollInterval = 400;
 
 export default function Page() {
   const [autoRefresh, setAutoRefresh] = useState(true);
-  const [tracesPreviewEnabled, setTracesPreviewEnabled] = useState(false);
+  const [tracesPreviewEnabled, setTracesPreviewEnabled] = useState(true);
   const [filterApp] = useStringArraySearchParam('filterApp');
   const [totalCount, setTotalCount] = useState<number>();
   const [filteredStatus] = useValidatedArraySearchParam('filterStatus', isFunctionRunStatus);


### PR DESCRIPTION
## Description

After our recent round of changes to gateway runs, etc., turning new traces back on by default.

## Motivation
Better traces

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
