### PR TITLE
[Insights]: Temporarily hide docs side panel

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
@@ -7,8 +7,7 @@ import { InsightsTabPanelTemplatesTabGrid } from './InsightsTabPanelTemplatesTab
 const BASE_DOCS_URL = 'https://docs.inngest.com/';
 
 // TODO: Update these to point to the correct URLs and toggle the visibility.
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-const SHOW_DOCS_LINKS = false;
+const SHOW_DOCS_LINKS: boolean = false;
 const RESOURCES = [
   { href: BASE_DOCS_URL, label: 'How to write your own query', icon: RiQuillPenLine },
   { href: BASE_DOCS_URL, label: 'Insights documentation', icon: RiExternalLinkLine },

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
@@ -6,7 +6,8 @@ import { InsightsTabPanelTemplatesTabGrid } from './InsightsTabPanelTemplatesTab
 
 const BASE_DOCS_URL = 'https://docs.inngest.com/';
 
-// TODO: Update these to point to the correct URLs.
+// TODO: Update these to point to the correct URLs and toggle the visibility.
+const SHOW_DOCS_LINKS = false;
 const RESOURCES = [
   { href: BASE_DOCS_URL, label: 'How to write your own query', icon: RiQuillPenLine },
   { href: BASE_DOCS_URL, label: 'Insights documentation', icon: RiExternalLinkLine },
@@ -25,26 +26,28 @@ export function InsightsTabPanelTemplatesTab() {
         </div>
         <InsightsTabPanelTemplatesTabGrid />
       </div>
-      <div className="flex w-[360px] flex-shrink-0 flex-col">
-        <div className="flex flex-col gap-4">
-          <h3 className="text-muted text-xs font-medium">RESOURCES</h3>
-          <div className="flex flex-col gap-3">
-            {RESOURCES.map(({ icon: Icon, label, href }) => (
-              <div className="flex items-center gap-2" key={label}>
-                <Icon className="text-muted-foreground h-4 w-4" />
-                <a
-                  className="hover:text-foreground text-muted-foreground text-sm transition-colors hover:underline"
-                  href={href}
-                  rel="noopener noreferrer"
-                  target="_blank"
-                >
-                  {label}
-                </a>
-              </div>
-            ))}
+      {SHOW_DOCS_LINKS && (
+        <div className="flex w-[360px] flex-shrink-0 flex-col">
+          <div className="flex flex-col gap-4">
+            <h3 className="text-muted text-xs font-medium">RESOURCES</h3>
+            <div className="flex flex-col gap-3">
+              {RESOURCES.map(({ icon: Icon, label, href }) => (
+                <div className="flex items-center gap-2" key={label}>
+                  <Icon className="text-muted-foreground h-4 w-4" />
+                  <a
+                    className="hover:text-foreground text-muted-foreground text-sm transition-colors hover:underline"
+                    href={href}
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    {label}
+                  </a>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
@@ -7,6 +7,7 @@ import { InsightsTabPanelTemplatesTabGrid } from './InsightsTabPanelTemplatesTab
 const BASE_DOCS_URL = 'https://docs.inngest.com/';
 
 // TODO: Update these to point to the correct URLs and toggle the visibility.
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 const SHOW_DOCS_LINKS = false;
 const RESOURCES = [
   { href: BASE_DOCS_URL, label: 'How to write your own query', icon: RiQuillPenLine },


### PR DESCRIPTION
## Description

This PR temporarily uses a local constant (feature flag feels heavy) to hide docs links until the docs are ready.

<img width="218" height="99" alt="Screenshot 2025-09-02 at 11 58 20 AM" src="https://github.com/user-attachments/assets/009816df-9d5a-47e9-aefe-10f35ec42369" />

## Motivation

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
