### PR TITLE
[Insights]: Copy template name to tab name

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
@@ -72,7 +72,12 @@ export function useInsightsTabManager(
         createTabBase(makeEmptyUnsavedQuery());
       },
       createTabFromQuery: (query: Query | QuerySnapshot | QueryTemplate) => {
-        if (isQueryTemplate(query) || isQuerySnapshot(query)) {
+        if (isQueryTemplate(query)) {
+          createTabBase({ ...makeEmptyUnsavedQuery(), query: query.query, name: query.name });
+          return;
+        }
+
+        if (isQuerySnapshot(query)) {
           createTabBase({ ...makeEmptyUnsavedQuery(), query: query.query });
           return;
         }


### PR DESCRIPTION
## Description

Previously, opening a new tab by clicking on a query resulted in the tab being titled "Untitled query." After this change, the tab will take on the name of the template.

## Motivation
UX clarity

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
