### PR TITLE
Add some more logging when kafka span export fails

### DIFF
--- a/pkg/telemetry/exporters/kafka.go
+++ b/pkg/telemetry/exporters/kafka.go
@@ -212,7 +212,12 @@ func (e *kafkaSpanExporter) ExportSpans(ctx context.Context, spans []trace.ReadO
 				status = "error"
 
 				if strings.Contains(err.Error(), consts.KafkaMsgTooLargeError) {
-					l.Error("error", err, "span proto size", proto.Size(span), "marhsalled span proto size", len(byt), "span.output size", len(span.Output))
+					batchSize := len(span.Events)
+					evtPayloadSizes := make([]int, len(span.Events))
+					for i, evt := range span.Events {
+						evtPayloadSizes[i] = len(evt.Name)
+					}
+					l.Error("error on producing span MESSAGE_TOO_LARGE", "error", err, "span proto size", proto.Size(span), "marhsalled span proto size", len(byt), "span.output size", len(span.Output), "batchSize", batchSize, "evt payload sizes:", evtPayloadSizes)
 				}
 			}
 


### PR DESCRIPTION
## Description

Add some more logging when kafka span export fails with MESSAGE_TOO_LARGE.

We log the number of events and size of each event's payload in the batch.


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
