### PR TITLE
Add methods to state store manager to support partial cache hits

### DIFF
--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -271,6 +271,11 @@ func (v v2) LoadMetadata(ctx context.Context, id state.ID) (state.Metadata, erro
 	return result, nil
 }
 
+// LoadStack returns the current stack for a run.
+func (v v2) LoadStack(ctx context.Context, id state.ID) ([]string, error) {
+	return v.mgr.stack(ctx, id.Tenant.AccountID, id.RunID)
+}
+
 // Update updates configuration on the state, eg. setting the execution
 // version after communicating with the SDK.
 func (v v2) UpdateMetadata(ctx context.Context, id state.ID, mutation state.MutableConfig) error {

--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -179,9 +179,19 @@ func (v v2) LoadEvents(ctx context.Context, id state.ID) ([]json.RawMessage, err
 	return v.mgr.LoadEvents(ctx, id.Tenant.AccountID, id.FunctionID, id.RunID)
 }
 
-// LoadEvents returns all events for a run.
+// LoadSteps returns all steps for a run.
 func (v v2) LoadSteps(ctx context.Context, id state.ID) (map[string]json.RawMessage, error) {
 	return v.mgr.LoadSteps(ctx, id.Tenant.AccountID, id.FunctionID, id.RunID)
+}
+
+// LoadStepInputs returns only the step inputs for a run.
+func (v v2) LoadStepInputs(ctx context.Context, id state.ID) (map[string]json.RawMessage, error) {
+	return v.mgr.LoadStepInputs(ctx, id.Tenant.AccountID, id.FunctionID, id.RunID)
+}
+
+// LoadStepsWithIDs returns a list of steps with the given IDs for a run.
+func (v v2) LoadStepsWithIDs(ctx context.Context, id state.ID, stepIDs []string) (map[string]json.RawMessage, error) {
+	return v.mgr.LoadStepsWithIDs(ctx, id.Tenant.AccountID, id.FunctionID, id.RunID, stepIDs)
 }
 
 // LoadState returns all state for a run.

--- a/pkg/execution/state/v2/interfaces.go
+++ b/pkg/execution/state/v2/interfaces.go
@@ -59,6 +59,8 @@ type StateLoader interface {
 	LoadEvents(ctx context.Context, id ID) ([]json.RawMessage, error)
 	// LoadState returns all steps for a run.
 	LoadSteps(ctx context.Context, id ID) (map[string]json.RawMessage, error)
+	// LoadStack returns the stack for a given run
+	LoadStack(ctx context.Context, id ID) ([]string, error)
 
 	// LoadState returns all state for a run, including steps, events, and metadata.
 	LoadState(ctx context.Context, id ID) (State, error)

--- a/pkg/execution/state/v2/interfaces.go
+++ b/pkg/execution/state/v2/interfaces.go
@@ -59,6 +59,10 @@ type StateLoader interface {
 	LoadEvents(ctx context.Context, id ID) ([]json.RawMessage, error)
 	// LoadState returns all steps for a run.
 	LoadSteps(ctx context.Context, id ID) (map[string]json.RawMessage, error)
+	// LoadStepInputs returns only the step inputs for a run.
+	LoadStepInputs(ctx context.Context, id ID) (map[string]json.RawMessage, error)
+	// LoadStepsWithIDs returns a list of steps with the given IDs for a run.
+	LoadStepsWithIDs(ctx context.Context, id ID, stepIDs []string) (map[string]json.RawMessage, error)
 	// LoadStack returns the stack for a given run
 	LoadStack(ctx context.Context, id ID) ([]string, error)
 


### PR DESCRIPTION
## Description
Add 3 new methods to state store manager so we can support partial cache hits in state proxy. Which means state proxy should be able to peek the stack for a run (which we will never cache) check which steps and step inputs are available in the cache and finally partially load from the source of truth any missing steps/inputs.


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
