### PR TITLE
[Insights]: Temporarily hide query example links

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsDataTable/states/EmptyState.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsDataTable/states/EmptyState.tsx
@@ -3,24 +3,32 @@
 import { Button } from '@inngest/components/Button';
 import { RiExternalLinkLine } from '@remixicon/react';
 
+import { SHOW_EXAMPLES_LINK } from '@/components/Insights/temp-flags';
 import { IconLayoutWrapper } from './IconLayoutWrapper';
 
-// TODO: Add link to examples.
 export function EmptyState() {
+  const subheaderPrefix =
+    'Run a query to analyze your data and the results will be displayed here.';
+  const subheader = SHOW_EXAMPLES_LINK
+    ? `${subheaderPrefix} If you need a starting point, check out our examples.`
+    : subheaderPrefix;
+
   return (
     <IconLayoutWrapper
       action={
-        <Button
-          appearance="outlined"
-          disabled
-          icon={<RiExternalLinkLine />}
-          iconSide="left"
-          kind="primary"
-          label="See examples"
-        />
+        SHOW_EXAMPLES_LINK ? (
+          <Button
+            appearance="outlined"
+            disabled
+            icon={<RiExternalLinkLine />}
+            iconSide="left"
+            kind="primary"
+            label="See examples"
+          />
+        ) : null
       }
       header="Your query results will appear here"
-      subheader="Run a query to analyze your data and the results will be displayed here. If you need a starting point, check out our examples."
+      subheader={subheader}
     />
   );
 }

--- a/ui/apps/dashboard/src/components/Insights/InsightsDataTable/states/ResultsState/NoResults.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsDataTable/states/ResultsState/NoResults.tsx
@@ -3,25 +3,33 @@
 import { Button } from '@inngest/components/Button';
 import { RiExternalLinkLine } from '@remixicon/react';
 
+import { SHOW_EXAMPLES_LINK } from '@/components/Insights/temp-flags';
 import { IconLayoutWrapper } from '../IconLayoutWrapper';
 
-// TODO: Add link to examples.
 export function NoResults() {
+  const subheaderPrefix =
+    "We couldn't find any results matching your search. Try adjusting your query";
+  const subheader = SHOW_EXAMPLES_LINK
+    ? `${subheaderPrefix} or browse our examples for inspiration.`
+    : `${subheaderPrefix}.`;
+
   return (
     <IconLayoutWrapper
       action={
-        <Button
-          appearance="outlined"
-          disabled
-          icon={<RiExternalLinkLine />}
-          iconSide="left"
-          kind="primary"
-          label="See examples"
-          size="medium"
-        />
+        SHOW_EXAMPLES_LINK ? (
+          <Button
+            appearance="outlined"
+            disabled
+            icon={<RiExternalLinkLine />}
+            iconSide="left"
+            kind="primary"
+            label="See examples"
+            size="medium"
+          />
+        ) : null
       }
       header="No results found"
-      subheader="We couldn't find any results matching your search. Try adjusting your query or browse our examples for inspiration."
+      subheader={subheader}
     />
   );
 }

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
@@ -2,12 +2,12 @@
 
 import { RiChatPollLine, RiExternalLinkLine, RiQuillPenLine } from '@remixicon/react';
 
+import { SHOW_DOCS_LINKS } from '../../temp-flags';
 import { InsightsTabPanelTemplatesTabGrid } from './InsightsTabPanelTemplatesTabGrid';
 
 const BASE_DOCS_URL = 'https://docs.inngest.com/';
 
-// TODO: Update these to point to the correct URLs and toggle the visibility.
-const SHOW_DOCS_LINKS: boolean = false;
+// TODO: Update these to point to the correct URLs.
 const RESOURCES = [
   { href: BASE_DOCS_URL, label: 'How to write your own query', icon: RiQuillPenLine },
   { href: BASE_DOCS_URL, label: 'Insights documentation', icon: RiExternalLinkLine },

--- a/ui/apps/dashboard/src/components/Insights/temp-flags.ts
+++ b/ui/apps/dashboard/src/components/Insights/temp-flags.ts
@@ -1,0 +1,4 @@
+// TODO: Remove once docs are updated.
+
+export const SHOW_DOCS_LINKS: boolean = false;
+export const SHOW_EXAMPLES_LINK: boolean = false;


### PR DESCRIPTION
## Description

This temporarily hides links to examples (in docs) of valid queries until they are ready.

---

**Before:**

<img width="414" height="230" alt="Screenshot 2025-09-03 at 1 39 51 PM" src="https://github.com/user-attachments/assets/2a67d158-eb42-44b4-bf0a-bbdd572bb97d" />

<img width="409" height="224" alt="Screenshot 2025-09-03 at 1 38 27 PM" src="https://github.com/user-attachments/assets/a360a131-e9fe-42df-9280-0a4e4924e9b8" />

---

**After:**

<img width="428" height="206" alt="Screenshot 2025-09-03 at 1 39 36 PM" src="https://github.com/user-attachments/assets/6bda4c94-cf01-4a24-9d02-ee52eef958b6" />

<img width="410" height="205" alt="Screenshot 2025-09-03 at 1 38 02 PM" src="https://github.com/user-attachments/assets/a7ae38fd-1456-4fda-9c65-6453ce78946f" />


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
