### PR TITLE
add flag support for disabling polling everywhere in dev server

### DIFF
--- a/ui/apps/dev-server-ui/src/app/(dashboard)/apps/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/apps/page.tsx
@@ -8,6 +8,7 @@ import { Header } from '@inngest/components/Header/Header';
 import { Info } from '@inngest/components/Info/Info';
 import { Link } from '@inngest/components/Link';
 import { Pill } from '@inngest/components/Pill/Pill';
+import { useBooleanFlag } from '@inngest/components/SharedContext/useBooleanFlag';
 import WorkerCounter from '@inngest/components/Workers/ConnectedWorkersDescription';
 import { IconSpinner } from '@inngest/components/icons/Spinner';
 import { transformFramework, transformLanguage } from '@inngest/components/utils/appsParser';
@@ -22,7 +23,16 @@ import { useInfoQuery } from '@/store/devApi';
 import { AppMethod, useGetAppsQuery } from '@/store/generated';
 
 export default function AppList() {
-  const { data } = useGetAppsQuery(undefined, { pollingInterval: 1500 });
+  const { booleanFlag } = useBooleanFlag();
+  const { value: pollingDisabled, isReady: pollingFlagReady } = booleanFlag(
+    'polling-disabled',
+    false
+  );
+
+  const { data } = useGetAppsQuery(undefined, {
+    pollingInterval: pollingFlagReady && pollingDisabled ? 0 : 1500,
+  });
+
   const getWorkerCount = useGetWorkerCount();
   const apps = data?.apps || [];
 

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/run/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/run/page.tsx
@@ -1,12 +1,18 @@
 'use client';
 
 import { RunDetailsV3 } from '@inngest/components/RunDetailsV3/RunDetailsV3';
+import { useBooleanFlag } from '@inngest/components/SharedContext/useBooleanFlag';
 import { useSearchParam } from '@inngest/components/hooks/useSearchParam';
 import { cn } from '@inngest/components/utils/classNames';
 
 import { useGetTrigger } from '@/hooks/useGetTrigger';
 
 export default function Page() {
+  const { booleanFlag } = useBooleanFlag();
+  const { value: pollingDisabled, isReady: pollingFlagReady } = booleanFlag(
+    'polling-disabled',
+    false
+  );
   const [runID] = useSearchParam('runID');
   const getTrigger = useGetTrigger();
 
@@ -19,7 +25,7 @@ export default function Page() {
       <RunDetailsV3
         standalone
         getTrigger={getTrigger}
-        pollInterval={2500}
+        pollInterval={pollingFlagReady && pollingDisabled ? 0 : 2500}
         runID={runID}
         tracesPreviewEnabled={true}
       />

--- a/ui/apps/dev-server-ui/src/app/(dashboard)/runs/page.tsx
+++ b/ui/apps/dev-server-ui/src/app/(dashboard)/runs/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Header } from '@inngest/components/Header/Header';
 import { RunsActionMenu } from '@inngest/components/RunsPage/ActionMenu';
 import { RunsPage } from '@inngest/components/RunsPage/RunsPage';
+import { useBooleanFlag } from '@inngest/components/SharedContext/useBooleanFlag';
 import { useCalculatedStartTime } from '@inngest/components/hooks/useCalculatedStartTime';
 import {
   useSearchParam,
@@ -33,7 +34,13 @@ import {
 const pollInterval = 400;
 
 export default function Page() {
+  const { booleanFlag } = useBooleanFlag();
+  const { value: pollingDisabled, isReady: pollingFlagReady } = booleanFlag(
+    'polling-disabled',
+    false
+  );
   const [autoRefresh, setAutoRefresh] = useState(true);
+
   const [tracesPreviewEnabled, setTracesPreviewEnabled] = useState(true);
   const [filterApp] = useStringArraySearchParam('filterApp');
   const [totalCount, setTotalCount] = useState<number>();
@@ -48,6 +55,12 @@ export default function Page() {
   const [search] = useSearchParam('search');
   const calculatedStartTime = useCalculatedStartTime({ lastDays, startTime });
   const appsRes = useGetAppsQuery();
+
+  useEffect(() => {
+    if (pollingFlagReady && pollingDisabled) {
+      setAutoRefresh(false);
+    }
+  }, [pollingDisabled, pollingFlagReady]);
 
   const queryFn = useCallback(
     async ({ pageParam }: { pageParam: string | null }) => {

--- a/ui/apps/dev-server-ui/src/components/Events/EventsPage.tsx
+++ b/ui/apps/dev-server-ui/src/components/Events/EventsPage.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@inngest/components/Button/Button';
 import { EventsActionMenu } from '@inngest/components/Events/EventsActionMenu';
 import { EventsTable } from '@inngest/components/Events/EventsTable';
 import { useReplayModal } from '@inngest/components/Events/useReplayModal';
 import { Header } from '@inngest/components/Header/Header';
+import { useBooleanFlag } from '@inngest/components/SharedContext/useBooleanFlag';
 import { RiExternalLinkLine, RiRefreshLine } from '@remixicon/react';
 
 import SendEventButton from '@/components/Event/SendEventButton';
@@ -24,9 +25,20 @@ export default function EventsPage({
   eventTypeNames?: string[];
   showHeader?: boolean;
 }) {
+  const { booleanFlag } = useBooleanFlag();
+  const { value: pollingDisabled, isReady: pollingFlagReady } = booleanFlag(
+    'polling-disabled',
+    false
+  );
   const router = useRouter();
   const [autoRefresh, setAutoRefresh] = useState(true);
   const { isModalVisible, selectedEvent, openModal, closeModal } = useReplayModal();
+
+  useEffect(() => {
+    if (pollingFlagReady && pollingDisabled) {
+      setAutoRefresh(false);
+    }
+  }, [pollingDisabled, pollingFlagReady]);
 
   const getEvents = useEvents();
   const getEventDetails = useEventDetails();

--- a/ui/apps/dev-server-ui/src/components/Navigation/Manage.tsx
+++ b/ui/apps/dev-server-ui/src/components/Navigation/Manage.tsx
@@ -1,15 +1,22 @@
 import { MenuItem } from '@inngest/components/Menu/MenuItem';
+import { useBooleanFlag } from '@inngest/components/SharedContext/useBooleanFlag';
 import { AppsIcon } from '@inngest/components/icons/sections/Apps';
 import { FunctionsIcon } from '@inngest/components/icons/sections/Functions';
 
 import { useGetAppsQuery } from '@/store/generated';
 
 export default function Mange({ collapsed }: { collapsed: boolean }) {
+  const { booleanFlag } = useBooleanFlag();
+  const { value: pollingDisabled, isReady: pollingFlagReady } = booleanFlag(
+    'polling-disabled',
+    false
+  );
+
   const { hasSyncingError } = useGetAppsQuery(undefined, {
     selectFromResult: (result) => ({
       hasSyncingError: result?.data?.apps?.some((app) => app.connected === false),
     }),
-    pollingInterval: 1500,
+    pollingInterval: pollingFlagReady && pollingDisabled ? 0 : 1500,
   });
 
   return (

--- a/ui/apps/dev-server-ui/src/components/Navigation/Manage.tsx
+++ b/ui/apps/dev-server-ui/src/components/Navigation/Manage.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { MenuItem } from '@inngest/components/Menu/MenuItem';
 import { useBooleanFlag } from '@inngest/components/SharedContext/useBooleanFlag';
 import { AppsIcon } from '@inngest/components/icons/sections/Apps';
@@ -6,11 +7,18 @@ import { FunctionsIcon } from '@inngest/components/icons/sections/Functions';
 import { useGetAppsQuery } from '@/store/generated';
 
 export default function Mange({ collapsed }: { collapsed: boolean }) {
+  const [pollingInterval, setPollingInterval] = useState(1500);
   const { booleanFlag } = useBooleanFlag();
   const { value: pollingDisabled, isReady: pollingFlagReady } = booleanFlag(
     'polling-disabled',
     false
   );
+
+  useEffect(() => {
+    if (pollingFlagReady && pollingDisabled) {
+      setPollingInterval(0);
+    }
+  }, [pollingDisabled, pollingFlagReady]);
 
   const { hasSyncingError } = useGetAppsQuery(undefined, {
     selectFromResult: (result) => ({


### PR DESCRIPTION
## Description

All the polling we do in the dev server make local dev and troubleshooting infuriating.

To make it stop:
`INNGEST_FEATURE_FLAGS="step-over-debugger=true,polling-disabled=true" go run ./cmd dev --in-memory=false`

## Motivation
Better dx

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
