### PR TITLE
[Insights]: Temporarily hide csv download button

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorDownloadCSVButton.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorDownloadCSVButton.tsx
@@ -3,7 +3,27 @@
 import { Button } from '@inngest/components/Button/Button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
 
-export function InsightsSQLEditorDownloadCSVButton() {
+interface InsightsSQLEditorDownloadCSVButtonProps {
+  temporarilyHide?: boolean;
+}
+
+export function InsightsSQLEditorDownloadCSVButton({
+  temporarilyHide = false,
+}: InsightsSQLEditorDownloadCSVButtonProps) {
+  // Maintain layout consistency when the button is temporarily hidden.
+  if (temporarilyHide) {
+    return (
+      <Button
+        appearance="ghost"
+        className="invisible"
+        disabled
+        kind="secondary"
+        label=""
+        size="medium"
+      />
+    );
+  }
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanel.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanel.tsx
@@ -44,8 +44,8 @@ export function InsightsTabPanel({ isHomeTab, isTemplatesTab, tab }: InsightsTab
       <Section
         actions={
           <>
+            <InsightsSQLEditorDownloadCSVButton temporarilyHide />
             {isRunning && <span className="text-muted mr-3 text-xs">Running query...</span>}
-            <InsightsSQLEditorDownloadCSVButton />
           </>
         }
         title={<InsightsSQLEditorResultsTitle />}


### PR DESCRIPTION
## Description

This PR hides the CSV download button until intent tracking is ready to gauge interest.

---

<img width="610" height="129" alt="Screenshot 2025-09-05 at 1 08 50 PM" src="https://github.com/user-attachments/assets/d6485420-9d1a-4dd9-b30d-bf8094b89658" />

## Motivation

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
