### PR TITLE
Add support for multiple prod envs in UI

### DIFF
--- a/ui/apps/dashboard/src/components/Environments/Environments.tsx
+++ b/ui/apps/dashboard/src/components/Environments/Environments.tsx
@@ -38,6 +38,10 @@ export default function Environments() {
     return filterEnvironments(EnvironmentType.Test, searchParam, filterStatus, envs);
   }, [searchParam, envs, filterStatus]);
 
+  const prodEnvsData = useMemo(() => {
+    return filterEnvironments(EnvironmentType.Production, searchParam, filterStatus, envs);
+  }, [searchParam, envs, filterStatus]);
+
   if (fetching) {
     return (
       <div className="my-16 flex h-full w-full items-center justify-center">
@@ -46,33 +50,37 @@ export default function Environments() {
     );
   }
 
+  const isMultiProd = prodEnvsData.total > 1;
+
   return (
     <>
       <div className="mx-auto w-full max-w-[860px] px-12 py-16">
-        <div className="flex flex-col gap-3">
-          <div className="flex flex-col gap-2">
-            <div className="flex w-full items-center justify-between">
-              <h2 className="text-xl font-medium">Production environment</h2>
+        {!isMultiProd && (
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-2">
+              <div className="flex w-full items-center justify-between">
+                <h2 className="text-xl font-medium">Production environment</h2>
+              </div>
+
+              <p className="text-muted max-w-[400px] text-sm">
+                This is where you&apos;ll deploy all of your production apps.
+              </p>
             </div>
 
-            <p className="text-muted max-w-[400px] text-sm">
-              This is where you&apos;ll deploy all of your production apps.
-            </p>
-          </div>
-
-          <div className="border-muted rounded-md border">
-            <div className="border-l-primary-moderate flex min-w-0 items-center justify-between overflow-x-auto rounded-[4px] border-l-4 px-4 py-3">
-              <h3 className="flex flex-shrink-0 items-center gap-2 text-sm font-medium tracking-wide">
-                <StatusDot status="ACTIVE" size="small" />
-                Production
-              </h3>
-              <div className="flex flex-shrink-0 items-center gap-2 pl-2">
-                <EnvViewButton env={{ slug: 'production' }} />
-                <EnvKeysDropdownButton env={{ slug: 'production' }} />
+            <div className="border-muted rounded-md border">
+              <div className="border-l-primary-moderate flex min-w-0 items-center justify-between overflow-x-auto rounded-[4px] border-l-4 px-4 py-3">
+                <h3 className="flex flex-shrink-0 items-center gap-2 text-sm font-medium tracking-wide">
+                  <StatusDot status="ACTIVE" size="small" />
+                  Production
+                </h3>
+                <div className="flex flex-shrink-0 items-center gap-2 pl-2">
+                  <EnvViewButton env={{ slug: 'production' }} />
+                  <EnvKeysDropdownButton env={{ slug: 'production' }} />
+                </div>
               </div>
             </div>
           </div>
-        </div>
+        )}
 
         <div className="mb-2 flex flex-col gap-3">
           <div className="border-subtle mt-8 flex w-full items-center justify-between border-t pt-8">
@@ -103,6 +111,21 @@ export default function Environments() {
 
         <div className="flex flex-col gap-6">
           <div className="flex flex-col gap-3 pt-6">
+            {isMultiProd && (
+              <>
+                <div className="flex w-full flex-wrap items-center justify-between gap-3">
+                  <h2 className="text-md font-medium">Production environments</h2>
+                </div>
+                <div className="border-subtle overflow-hidden rounded-md border">
+                  <CustomEnvironmentListTable
+                    envs={prodEnvsData.filtered}
+                    paginationKey={getPaginationKey(filterStatus, searchParam)}
+                    unfilteredEnvsCount={prodEnvsData.total}
+                  />
+                </div>
+              </>
+            )}
+
             <div className="flex w-full flex-wrap items-center justify-between gap-3">
               <h2 className="text-md font-medium">Custom environments</h2>
               <Button

--- a/ui/apps/dashboard/src/utils/environments.ts
+++ b/ui/apps/dashboard/src/utils/environments.ts
@@ -35,8 +35,8 @@ export function getDefaultEnvironment(
 ): Environment | null {
   let isMultiProd = false;
   let prodCount = 0;
-  for (const workspace of environments) {
-    if (workspace.type === EnvironmentType.Production) {
+  for (const env of environments) {
+    if (env.type === EnvironmentType.Production) {
       prodCount++;
     }
     if (prodCount > 1) {

--- a/ui/apps/dashboard/src/utils/environments.ts
+++ b/ui/apps/dashboard/src/utils/environments.ts
@@ -33,7 +33,30 @@ export function getActiveEnvironment(
 export function getDefaultEnvironment(
   environments: NonEmptyArray<Environment>
 ): Environment | null {
-  return environments.find((e) => e.type === EnvironmentType.Production) || null;
+  let isMultiProd = false;
+  let prodCount = 0;
+  for (const workspace of environments) {
+    if (workspace.type === EnvironmentType.Production) {
+      prodCount++;
+    }
+    if (prodCount > 1) {
+      isMultiProd = true;
+      break;
+    }
+  }
+  if (isMultiProd) {
+    return null;
+  }
+
+  const env = environments.find((e) => e.type === EnvironmentType.Production);
+  if (env) {
+    return {
+      ...env,
+      slug: 'production',
+      name: 'Production',
+    };
+  }
+  return null;
 }
 
 function getRecentCutOffDate(): Date {
@@ -123,23 +146,16 @@ export function workspaceToEnvironment(
     | 'lastDeployedAt'
   >
 ): Environment {
-  const isProduction = workspace.type === EnvironmentType.Production;
-
-  let environmentName = workspace.name;
-  if (isProduction) {
-    environmentName = 'Production';
-  }
-
   const slug = getEnvironmentSlug({
     environmentID: workspace.id,
-    environmentName,
+    environmentName: workspace.name,
     environmentSlug: workspace.slug,
     environmentType: workspace.type,
   });
 
   return {
     id: workspace.id,
-    name: environmentName,
+    name: workspace.name,
     slug,
     type: workspace.type,
     hasParent: Boolean(workspace.parentID),
@@ -169,12 +185,8 @@ export function getEnvironmentSlug({
   environmentSlug,
   environmentType,
 }: getEnvironmentSlugProps): string {
-  const isProduction = environmentType === EnvironmentType.Production;
-
   let slug = environmentSlug || '';
-  if (isProduction) {
-    slug = staticSlugs.production;
-  } else if (environmentType === EnvironmentType.BranchParent) {
+  if (environmentType === EnvironmentType.BranchParent) {
     slug = staticSlugs.branch;
   } else if (!slug) {
     slug = `${slugify(environmentName)}-${environmentID.split('-')[0]}`;


### PR DESCRIPTION
> :warning: Do not merge until https://github.com/inngest/monorepo/pull/5113 is released

## Description

Add support for multiple production environments. This only affects a single customer, since they're the only one with multi prod env support. All other accounts are unaffected by this change.

Note that there were 2 shortcuts in this PR:
1. Prod envs don't appear in the top-left env dropdown
2. The "all environments" page looks weird at the top

Resolves https://linear.app/inngest/issue/CON-271

## Testing

<img width="1683" height="952" alt="image" src="https://github.com/user-attachments/assets/b3a9ec4e-c40a-4c75-905a-16e66f1922ea" />
