### PR TITLE
[Insights]: Add missing border between query editor and results section

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanel.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanel.tsx
@@ -48,6 +48,7 @@ export function InsightsTabPanel({ isHomeTab, isTemplatesTab, tab }: InsightsTab
             {isRunning && <span className="text-muted mr-3 text-xs">Running query...</span>}
           </>
         }
+        className="border-subtle border-t"
         title={<InsightsSQLEditorResultsTitle />}
       >
         <InsightsDataTable />


### PR DESCRIPTION
## Description

Adds a missing border between the query editor and the results section.

---

<img width="662" height="673" alt="Screenshot 2025-09-09 at 9 25 00 AM" src="https://github.com/user-attachments/assets/029a1293-bf58-4c65-a162-87c407e87f2f" />

## Motivation

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
