### PR TITLE
[Insights]: Check loading state before error state

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext.tsx
@@ -99,8 +99,8 @@ export function getInsightsStatus({
   isError,
   isLoading,
 }: GetInsightsStatusParams): InsightsStatus {
-  if (isError) return 'error';
   if (isLoading) return 'loading';
+  if (isError) return 'error';
   if (data !== undefined) return 'success';
   return 'initial';
 }


### PR DESCRIPTION
## Description

There's a small bug where the loading state sometimes doesn't show when the previous state had an error. This fixes the issue by checking the loading state prior to the error state.

## Motivation

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
