### PR TITLE
Add account ID to EnvironmentReader.GetEnvironmentBySlug

### DIFF
--- a/pkg/cqrs/environments.go
+++ b/pkg/cqrs/environments.go
@@ -18,7 +18,7 @@ type Environment struct {
 // EnvironmentReader provides the function to retrieve environments
 type EnvironmentReader interface {
 	// GetEnvironmentBySlug returns the environment with the provided slug
-	GetEnvironmentBySlug(ctx context.Context, slug string) (*Environment, error)
+	GetEnvironmentBySlug(ctx context.Context, accountID uuid.UUID, slug string) (*Environment, error)
 	// GetEnvironmentByUUID returns the environment with the provided ID
 	GetEnvironmentByUUID(ctx context.Context, id uuid.UUID) (*Environment, error)
 }


### PR DESCRIPTION
We're gonna change environment slug to be unique within account, not globally unique across all accounts