### PR TITLE
Fix `Finalize()` trace IDs being incorrect

### DIFF
--- a/pkg/tracing/meta/attributes.go
+++ b/pkg/tracing/meta/attributes.go
@@ -32,6 +32,15 @@ var Attrs = struct {
 	// Dynamic span controls
 	DynamicSpanID attr[*string]
 	DynamicStatus attr[*enums.StepStatus]
+	// DynamicTraceID is a trace ID for this span that should overwrite
+	// whatever trace ID is currently set within the span's own context.
+	//
+	// We need this due to Go's otel library sometimes being stubborn about
+	// inheriting a particular `traceparent`'s context based on span IDs. In
+	// our particular case, a zero-value span ID (e.g. `"0000000000000000"`)
+	// would result in the entire `traceparent` being ignored and a new trace
+	// ID being created.
+	DynamicTraceID attr[*string]
 
 	// Internal and debugging
 	InternalLocation attr[*string]
@@ -110,6 +119,7 @@ var Attrs = struct {
 	BatchTimestamp:                     TimeAttr("batch.ts"),
 	CronSchedule:                       StringAttr("cron.schedule"),
 	DropSpan:                           BoolAttr("executor.drop"),
+	DynamicTraceID:                     StringAttr("dynamic.trace.id"),
 	DynamicSpanID:                      StringAttr("dynamic.span.id"),
 	DynamicStatus:                      StepStatusAttr("dynamic.status"),
 	EndedAt:                            TimeAttr("ended_at"),

--- a/pkg/tracing/meta/extracted_values_gen.go
+++ b/pkg/tracing/meta/extracted_values_gen.go
@@ -31,6 +31,7 @@ type ExtractedValues struct {
 	RunID *ulid.ULID
 	DynamicSpanID *string
 	DynamicStatus *enums.StepStatus
+	DynamicTraceID *string
 	InternalLocation *string
 	internalError *string
 	IsFunctionOutput *bool

--- a/pkg/tracing/tracer_sqlc.go
+++ b/pkg/tracing/tracer_sqlc.go
@@ -85,6 +85,15 @@ func (e *dbExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlyS
 				}
 			}
 
+			// If we've been given a trace ID, it should overwrite whatever
+			// we've found in the span's own context; the caller knows best
+			if string(attr.Key) == meta.Attrs.DynamicTraceID.Key() {
+				traceID = attr.Value.AsString()
+				if cleanAttrs {
+					continue
+				}
+			}
+
 			// Capture but omit the dynamic span ID attribute from the span attributes
 			if string(attr.Key) == meta.Attrs.DynamicSpanID.Key() {
 				dynamicSpanID = attr.Value.AsString()


### PR DESCRIPTION
## Description

Fixes the trace ID resulting from `Finalize()` calls being incorrect; otel seems to refuse to pick up any context at all if the span ID is empty (e.g. `"0000000000000000"`), so we add a method here to pass and overwrite a trace ID explicitly.

This will also need a change for the `ExportSpans()` call in `inngest/monorepo`, as it requires that the trace ID being persisted to the database takes this new attribute in to account.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- Follows from #2915, which didn't fully work

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
