### PR TITLE
[Insights]: Move insights below events in monitor nav section

### DIFF
--- a/ui/apps/dashboard/src/components/Navigation/Monitor.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Monitor.tsx
@@ -24,14 +24,6 @@ export default function Monitor({
       ) : (
         <div className="text-disabled leading-4.5 mx-2.5 mb-1 text-xs font-medium">Monitor</div>
       )}
-      {isInsightsEnabled && (
-        <MenuItem
-          href={getNavRoute(activeEnv, 'insights')}
-          collapsed={collapsed}
-          text="Insights"
-          icon={<InsightsIcon className="h-[18px] w-[18px]" />}
-        />
-      )}
       <MenuItem
         href={getNavRoute(activeEnv, 'metrics')}
         collapsed={collapsed}
@@ -50,6 +42,14 @@ export default function Monitor({
         text="Events"
         icon={<EventLogsIcon className="h-[18px] w-[18px]" />}
       />
+      {isInsightsEnabled && (
+        <MenuItem
+          href={getNavRoute(activeEnv, 'insights')}
+          collapsed={collapsed}
+          text="Insights"
+          icon={<InsightsIcon className="h-[18px] w-[18px]" />}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

This moves Insights down in the "monitor" navbar section for now.

<img width="118" height="185" alt="Screenshot 2025-09-10 at 1 15 58 PM" src="https://github.com/user-attachments/assets/5319cb4c-f2d9-4672-9ebe-f3ae4e43c119" />

## Motivation

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
