### PR TITLE
Use throttle constraint config

### DIFF
--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -53,10 +53,11 @@ local concurrencyAcct 				= tonumber(ARGV[7])
 local concurrencyPartition    = tonumber(ARGV[8])
 local customConcurrencyKey1   = tonumber(ARGV[9])
 local customConcurrencyKey2   = tonumber(ARGV[10])
+local marshaledConstraints    = ARGV[11]
 
 -- key queues v2
-local checkConstraints    = tonumber(ARGV[11])
-local refilledFromBacklog = tonumber(ARGV[12])
+local checkConstraints    = tonumber(ARGV[12])
+local refilledFromBacklog = tonumber(ARGV[13])
 
 -- Use our custom Go preprocessor to inject the file from ./includes/
 -- $include(decode_ulid_time.lua)
@@ -89,13 +90,15 @@ item = set_item_peek_time(keyQueueMap, queueID, item, currentTime)
 
 -- NOTE: we can probably skip this entire section if item comes from backlog?
 if checkConstraints == 1 then
+  local constraints = cjson.decode(marshaledConstraints)
+
 	-- Track throttling/rate limiting IF the queue item has throttling info set.  This allows
 	-- us to target specific queue items with rate limiting individually.
 	--
 	-- We handle this before concurrency as it's typically not used, and it's faster to handle than concurrency,
 	-- with o(1) operations vs o(log(n)).
-	if item.data ~= nil and item.data.throttle ~= nil and item.data.throttle.p > 0 and refilledFromBacklog == 0 then
-		local throttleResult = gcra(throttleKey, currentTime, item.data.throttle.p * 1000, item.data.throttle.l, item.data.throttle.b)
+	if item.data ~= nil and constraints.t ~= nil and constraints.t.p > 0 and refilledFromBacklog == 0 then
+		local throttleResult = gcra(throttleKey, currentTime, constraints.t.p * 1000, constraints.t.l, constraints.t.b)
 		if throttleResult == false then
 			return -7
 		end

--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -97,7 +97,7 @@ if checkConstraints == 1 then
 	--
 	-- We handle this before concurrency as it's typically not used, and it's faster to handle than concurrency,
 	-- with o(1) operations vs o(log(n)).
-	if item.data ~= nil and constraints.t ~= nil and constraints.t.p > 0 and refilledFromBacklog == 0 then
+	if constraints.t ~= nil and constraints.t.p > 0 and refilledFromBacklog == 0 then
 		local throttleResult = gcra(throttleKey, currentTime, constraints.t.p * 1000, constraints.t.l, constraints.t.b)
 		if throttleResult == false then
 			return -7

--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -97,7 +97,9 @@ if checkConstraints == 1 then
 	--
 	-- We handle this before concurrency as it's typically not used, and it's faster to handle than concurrency,
 	-- with o(1) operations vs o(log(n)).
-	if constraints.t ~= nil and constraints.t.p > 0 and refilledFromBacklog == 0 then
+  local itemHasThrottle = item.data ~= nil and item.data.throttle ~= nil
+  local throttleConstraintExists = constraints.t ~= nil and constraints.t.p > 0
+	if itemHasThrottle and throttleConstraintExists and refilledFromBacklog == 0 then
 		local throttleResult = gcra(throttleKey, currentTime, constraints.t.p * 1000, constraints.t.l, constraints.t.b)
 		if throttleResult == false then
 			return -7

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -2236,7 +2236,7 @@ func (q *queue) Lease(ctx context.Context, item osqueue.QueueItem, leaseDuration
 	case -6:
 		return nil, newKeyError(ErrAccountConcurrencyLimit, item.Data.Identifier.AccountID.String())
 	case -7:
-		if item.Data.Throttle == nil {
+		if constraints.Throttle == nil {
 			// This should never happen, as the throttle key is nil.
 			return nil, fmt.Errorf("lease attempted throttle with nil throttle config: %#v", item)
 		}

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -2112,6 +2112,11 @@ func (q *queue) Lease(ctx context.Context, item osqueue.QueueItem, leaseDuration
 		partConcurrency = constraints.Concurrency.SystemConcurrency
 	}
 
+	marshaledConstraints, err := json.Marshal(constraints)
+	if err != nil {
+		return nil, fmt.Errorf("could not marshal constraints: %w", err)
+	}
+
 	args, err := StrSlice([]any{
 		item.ID,
 		partition.PartitionID,
@@ -2126,6 +2131,7 @@ func (q *queue) Lease(ctx context.Context, item osqueue.QueueItem, leaseDuration
 		partConcurrency,
 		constraints.CustomConcurrencyLimit(1),
 		constraints.CustomConcurrencyLimit(2),
+		string(marshaledConstraints),
 
 		// Key queues v2
 		checkConstraintsVal,

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -2078,7 +2078,7 @@ func (q *queue) Lease(ctx context.Context, item osqueue.QueueItem, leaseDuration
 		checkConstraintsVal = "1"
 	}
 
-	if item.Data.Throttle.KeyExpressionHash == "" || item.Data.Throttle.KeyExpressionHash != constraints.Throttle.ThrottleKeyExpressionHash {
+	if item.Data.Throttle != nil && (item.Data.Throttle.KeyExpressionHash == "" || item.Data.Throttle.KeyExpressionHash != constraints.Throttle.ThrottleKeyExpressionHash) {
 		// TODO: Re-evaluate throttle key
 		status := "missing-expr-hash"
 		if item.Data.Throttle.KeyExpressionHash != "" {

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -2078,6 +2078,21 @@ func (q *queue) Lease(ctx context.Context, item osqueue.QueueItem, leaseDuration
 		checkConstraintsVal = "1"
 	}
 
+	if item.Data.Throttle.KeyExpressionHash == "" || item.Data.Throttle.KeyExpressionHash != constraints.Throttle.ThrottleKeyExpressionHash {
+		// TODO: Re-evaluate throttle key
+		status := "missing-expr-hash"
+		if item.Data.Throttle.KeyExpressionHash != "" {
+			status = "expr-hash-mismatch"
+		}
+
+		metrics.IncrQueueThrottleKeyExpressionMismatchCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags: map[string]any{
+				"status": status,
+			},
+		})
+	}
+
 	keys := []string{
 		kg.QueueItem(),
 		kg.ConcurrencyIndex(),

--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -590,11 +590,21 @@ func IncrAPICacheHit(ctx context.Context, opts CounterOpt) {
 		Tags:        opts.Tags,
 	})
 }
+
 func IncrAPICacheMiss(ctx context.Context, opts CounterOpt) {
 	RecordCounterMetric(ctx, 1, CounterOpt{
 		PkgName:     opts.PkgName,
 		MetricName:  "http_api_cache_miss",
 		Description: "The number of times a HTTP API request is not served from cache",
+		Tags:        opts.Tags,
+	})
+}
+
+func IncrQueueThrottleKeyExpressionMismatchCounter(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "queue_throttle_key_expr_mismatch",
+		Description: "The total number of times a throttle key expression mismatch was detected",
 		Tags:        opts.Tags,
 	})
 }


### PR DESCRIPTION
## Description

Instead of using the throttle in the queue item, this PR switches to using the latest partition constraint config. The only detail used from the item is the throttle key.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
