### PR TITLE
Bump nodejs in .tool-versions to 22.16.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -4,5 +4,5 @@
 # See: https://asdf-vm.com/manage/configuration.html
 #
 
-nodejs 20.18.2
+nodejs 22.16.0
 pnpm 8.15.8


### PR DESCRIPTION
## Description

This matches what we have in the nix flake

```
$ nix develop
(nix:nix-shell-env) $ node --version
v22.16.0
```

vercel will be updated to use v22 too
https://inngest.slack.com/archives/C06AR57NCL9/p1757538303037429?thread_ts=1757533182.121659&cid=C06AR57NCL9

## Motivation

local builds breaking on node 20

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
