### PR TITLE
Make sure to check constraint also has throttle set

### DIFF
--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -2078,19 +2078,27 @@ func (q *queue) Lease(ctx context.Context, item osqueue.QueueItem, leaseDuration
 		checkConstraintsVal = "1"
 	}
 
-	if item.Data.Throttle != nil && constraints.Throttle != nil && (item.Data.Throttle.KeyExpressionHash == "" || item.Data.Throttle.KeyExpressionHash != constraints.Throttle.ThrottleKeyExpressionHash) {
-		// TODO: Re-evaluate throttle key
-		status := "missing-expr-hash"
-		if item.Data.Throttle.KeyExpressionHash != "" {
-			status = "expr-hash-mismatch"
+	if item.Data.Throttle != nil {
+		var status string
+
+		if constraints.Throttle == nil {
+			status = "no-throttle"
+		} else if item.Data.Throttle.KeyExpressionHash == "" || item.Data.Throttle.KeyExpressionHash != constraints.Throttle.ThrottleKeyExpressionHash {
+			// TODO: Re-evaluate throttle key
+			status = "missing-expr-hash"
+			if item.Data.Throttle.KeyExpressionHash != "" {
+				status = "expr-hash-mismatch"
+			}
 		}
 
-		metrics.IncrQueueThrottleKeyExpressionMismatchCounter(ctx, metrics.CounterOpt{
-			PkgName: pkgName,
-			Tags: map[string]any{
-				"status": status,
-			},
-		})
+		if status != "" {
+			metrics.IncrQueueThrottleKeyExpressionMismatchCounter(ctx, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags: map[string]any{
+					"status": status,
+				},
+			})
+		}
 	}
 
 	keys := []string{


### PR DESCRIPTION
## Description

The constraint returned might also not have throttle setting available.
Make sure to check it before eval.

fixes
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1d7d396]

goroutine 123372 [running]:
github.com/inngest/inngest/pkg/execution/state/redis_state.(*queue).Lease(_, {_, _}, {{0xc00dc9ced0, 0xd}, 0x199363e18ac, 0x1992fa768d3, 0x1992f9fc7b3, {0x88, 0x83, ...}, ...}, ...)
        /app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/queue.go:2081 +0xa96
github.com/inngest/inngest/pkg/execution/state/redis_state.(*processor).process.func1({0x5853270?, 0xc001e20280?})
        /app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/queue_processor.go:1691 +0xae
github.com/inngest/inngest/pkg/execution/state/redis_state.durationWithTags[...]({0x5853270?, 0xc001e20280}, {0xc0017fa0c0, 0x6}, {0x4ea03c4, 0x5}, {0xc228a4edc5c6e98b, 0x23edcdee4, 0x84fe720}, 0xc00e1373f0, ...)
        /app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/queue_processor.go:1509 +0x306
github.com/inngest/inngest/pkg/execution/state/redis_state.duration[...](...)
        /app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/queue_processor.go:1492
github.com/inngest/inngest/pkg/execution/state/redis_state.(*processor).process(0xc00f98f380, {0x5853270, 0xc001e20280}, 0xc00dcbc800)
        /app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/queue_processor.go:1690 +0x64d
github.com/inngest/inngest/pkg/execution/state/redis_state.(*processor).iterate(0xc00f98f380, {0x5853270, 0xc001e20280})
        /app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/queue_processor.go:1625 +0x1e6
github.com/inngest/inngest/pkg/execution/state/redis_state.(*queue).processPartition(0xc0012e1508, {0x5853270, 0xc001e20280}, 0xc011fd3a00, 0x0, 0x0)
        /app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/queue_processor.go:1005 +0x2008
github.com/inngest/inngest/pkg/execution/state/redis_state.(*queue).scanPartition.func2()
        /app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/queue_processor.go:636 +0x2c5
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /app/vendor/golang.org/x/sync/errgroup/errgroup.go:93 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 20636
        /app/vendor/golang.org/x/sync/errgroup/errgroup.go:78 +0x93
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
