### PR TITLE
[Insights]: Prevent query editor perf issue via memoization

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsDataTable/states/ResultsState/ResultsTable.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsDataTable/states/ResultsState/ResultsTable.tsx
@@ -9,6 +9,20 @@ import type { InsightsFetchResult } from '@/components/Insights/InsightsStateMac
 import { ResultsTableFooter, assertData } from './ResultsTableFooter';
 import { useColumns } from './useColumns';
 
+type InsightsEntry = InsightsFetchResult['rows'][number];
+type InsightsColumnValue = InsightsEntry['values'][string];
+type InsightsTableProps = {
+  cellClassName: string;
+  columns: ColumnDef<InsightsEntry, InsightsColumnValue>[];
+  data: InsightsEntry[];
+};
+
+function InsightsTable({ columns, data, cellClassName }: InsightsTableProps) {
+  return <Table<InsightsEntry> cellClassName={cellClassName} columns={columns} data={data} />;
+}
+
+const MemoizedInsightsTable = memo(InsightsTable);
+
 export function ResultsTable() {
   const { data } = useInsightsStateMachineContext();
 
@@ -29,17 +43,3 @@ export function ResultsTable() {
     </div>
   );
 }
-
-type InsightsEntry = InsightsFetchResult['rows'][number];
-type InsightsColumnValue = InsightsEntry['values'][string];
-type InsightsTableProps = {
-  cellClassName: string;
-  columns: ColumnDef<InsightsEntry, InsightsColumnValue>[];
-  data: InsightsEntry[];
-};
-
-function InsightsTable({ columns, data, cellClassName }: InsightsTableProps) {
-  return <Table<InsightsEntry> cellClassName={cellClassName} columns={columns} data={data} />;
-}
-
-const MemoizedInsightsTable = memo(InsightsTable);


### PR DESCRIPTION
## Description

This fixes a perf issue associated with the table re-rendering on every keystroke in the query editor.

## Motivation

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
