### PR TITLE
Update insights template to use calculated 3 days ago

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/templates.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/templates.ts
@@ -10,7 +10,9 @@ function makeEventVolumePerHourQuery(event?: string) {
 FROM
     events
 WHERE
-    event_ts > {{ start_time }}${event ? `\n    AND event_name = '${event}'` : ''}
+    event_ts > toUnixTimestamp(subtractDays(now(), 3)) * 1000${
+      event ? `\n    AND event_name = '${event}'` : ''
+    }
 GROUP BY
     hour_bucket,
     event_name


### PR DESCRIPTION
## Description

Replace template variable with 3 days ago, computed by ClickHouse functions 

## Motivation

This should be somewhat nicer because they should be able to run the
query once without any changes

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
