### PR TITLE
Reduce sidebar menu spacing

### DIFF
--- a/ui/apps/dashboard/src/components/Navigation/Manage.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Manage.tsx
@@ -19,7 +19,7 @@ export default function Manage({
       {collapsed ? (
         <hr className="border-subtle mx-auto mb-1 w-6" />
       ) : (
-        <div className="text-disabled leading-4.5 mx-0 mb-1 text-xs font-medium">Manage</div>
+        <div className="text-disabled leading-4.5 mb-1 text-xs font-medium">Manage</div>
       )}
       <MenuItem
         href={getNavRoute(activeEnv, 'apps')}

--- a/ui/apps/dashboard/src/components/Navigation/Monitor.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Monitor.tsx
@@ -22,7 +22,7 @@ export default function Monitor({
       {collapsed ? (
         <hr className="border-subtle mx-auto mb-1 w-6" />
       ) : (
-        <div className="text-disabled leading-4.5 mx-0 mb-1 text-xs font-medium">Monitor</div>
+        <div className="text-disabled leading-4.5 mb-1 text-xs font-medium">Monitor</div>
       )}
       <MenuItem
         href={getNavRoute(activeEnv, 'metrics')}

--- a/ui/packages/components/src/Button/Button.tsx
+++ b/ui/packages/components/src/Button/Button.tsx
@@ -13,8 +13,6 @@ import {
   getSpinnerStyles,
 } from './buttonStyles';
 
-// testing as well
-
 export type ButtonKind = 'primary' | 'secondary' | 'danger';
 export type ButtonAppearance = 'solid' | 'outlined' | 'ghost';
 export type ButtonSize = 'small' | 'medium' | 'large';


### PR DESCRIPTION
## Description

- Reduced the space between menu items so the nav feels less spread out  
- Left-aligned the **Monitor** and **Manage** section titles for cleaner alignment 

<img width="1961" height="1976" alt="image" src="https://github.com/user-attachments/assets/31b9f2e7-4946-4215-8414-2094fbe5cfa4" />

## Motivation
Design/FE refinement

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.
