### PR TITLE
updated navigation sidebar and environment dropdown styling

### DIFF
--- a/ui/apps/dashboard/src/components/Navigation/Environments.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Environments.tsx
@@ -180,7 +180,7 @@ export default function EnvironmentSelectMenu({
             </Listbox.Button>
           </OptionalTooltip>
 
-          <Listbox.Options className="bg-canvasBase border-subtle absolute top-10 z-50 max-h-[calc(100vh-8rem)] w-[188px] divide-none overflow-y-auto rounded border shadow focus:outline-none">
+          <Listbox.Options className="bg-canvasBase border-subtle absolute top-10 z-50 max-h-[calc(100vh-8rem)] w-[250px] divide-none overflow-y-auto rounded border shadow focus:outline-none">
             {defaultEnvironment !== null && <EnvironmentItem environment={defaultEnvironment} />}
 
             {testEnvironments.length > 0 &&

--- a/ui/apps/dashboard/src/components/Navigation/Manage.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Manage.tsx
@@ -19,7 +19,7 @@ export default function Manage({
       {collapsed ? (
         <hr className="border-subtle mx-auto mb-1 w-6" />
       ) : (
-        <div className="text-disabled leading-4.5 mb-1 text-xs font-medium">Manage</div>
+        <div className="text-muted leading-4.5 mb-1 text-xs font-medium">Manage</div>
       )}
       <MenuItem
         href={getNavRoute(activeEnv, 'apps')}

--- a/ui/apps/dashboard/src/components/Navigation/Monitor.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Monitor.tsx
@@ -22,7 +22,7 @@ export default function Monitor({
       {collapsed ? (
         <hr className="border-subtle mx-auto mb-1 w-6" />
       ) : (
-        <div className="text-disabled leading-4.5 mb-1 text-xs font-medium">Monitor</div>
+        <div className="text-muted leading-4.5 mb-1 text-xs font-medium">Monitor</div>
       )}
       <MenuItem
         href={getNavRoute(activeEnv, 'metrics')}

--- a/ui/apps/dev-server-ui/src/components/Navigation/Manage.tsx
+++ b/ui/apps/dev-server-ui/src/components/Navigation/Manage.tsx
@@ -32,7 +32,7 @@ export default function Mange({ collapsed }: { collapsed: boolean }) {
       {collapsed ? (
         <div className="border-subtle mx-auto mb-1 w-6 border-b" />
       ) : (
-        <div className="text-muted leading-4.5 mx-2.5 mb-1 text-xs font-medium">Manage</div>
+        <div className="text-muted leading-4.5 mb-1 text-xs font-medium">Manage</div>
       )}
       <MenuItem
         href="/apps"

--- a/ui/apps/dev-server-ui/src/components/Navigation/Monitor.tsx
+++ b/ui/apps/dev-server-ui/src/components/Navigation/Monitor.tsx
@@ -1,5 +1,6 @@
 import { MenuItem } from '@inngest/components/Menu/MenuItem';
 import { EventLogsIcon } from '@inngest/components/icons/sections/EventLogs';
+import { RunsIcon } from '@inngest/components/icons/sections/Runs';
 import { RiMistLine } from '@remixicon/react';
 
 export default function Monitor({ collapsed }: { collapsed: boolean }) {
@@ -8,13 +9,13 @@ export default function Monitor({ collapsed }: { collapsed: boolean }) {
       {collapsed ? (
         <div className="border-subtle mx-auto mb-1 w-6 border-b" />
       ) : (
-        <div className="text-muted leading-4.5 mx-2.5 mb-1 text-xs font-medium">Monitor</div>
+        <div className="text-muted leading-4.5 mb-1 text-xs font-medium">Monitor</div>
       )}
       <MenuItem
         href="/runs"
         collapsed={collapsed}
         text="Runs"
-        icon={<RiMistLine className="h-[18px] w-[18px]" />}
+        icon={<RunsIcon className="h-[18px] w-[18px]" />}
       />
       <MenuItem
         href="/events"


### PR DESCRIPTION
## Description

**Sidebar on the dev server:**

- reduce the padding for the section title ("monitor" and "manage)
- replace the Runs icon
<img width="216" height="70" alt="Screenshot 2025-09-12 at 19 14 36" src="https://github.com/user-attachments/assets/62bc952b-6d5d-4ac0-abb4-3c3eb8e82837" />


**Sidebar on the cloud:**

- update colors of "monitor" and "manage" to match dev server and pass accessibility

<img width="213" height="363" alt="Screenshot 2025-09-12 at 19 14 51" src="https://github.com/user-attachments/assets/7b3ce808-b8bc-4527-8664-a0abdb65b280" />

- increase width of environment picker

<img width="297" height="244" alt="Screenshot 2025-09-12 at 19 12 42" src="https://github.com/user-attachments/assets/61e0fd92-b0d9-4b0b-9d07-1beb45fb2602" />

## Files Changed
- `ui/apps/dashboard/src/components/Navigation/Environments.tsx`
- `ui/apps/dashboard/src/components/Navigation/Manage.tsx`
- `ui/apps/dashboard/src/components/Navigation/Monitor.tsx`
- `ui/apps/dev-server-ui/src/components/Navigation/Manage.tsx`
- `ui/apps/dev-server-ui/src/components/Navigation/Monitor.tsx`


## Motivation
- UI clean up and consistency.
- Making environment selector more usable when there's long environment names

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
