### PR TITLE
fixing the height of the datadog integration card by adding a min-hei…

### DIFF
--- a/ui/packages/components/src/Card/Card.tsx
+++ b/ui/packages/components/src/Card/Card.tsx
@@ -42,7 +42,7 @@ export function Card({
       {accentColor && <div className={cn('p-0.5', accentClass, accentColor)} />}
       <div
         className={cn(
-          'border-subtle w-full grow overflow-hidden border',
+          'border-subtle min-h-full w-full grow overflow-hidden border',
           contentClass,
           contentClassName
         )}


### PR DESCRIPTION
…ght-full to take on the height of the parent

## Description

<!--- Please edit this to include a summary of the change (what). -->
The integration for datadog's container was shorter than the prometheus container next to it. It looked bad.

<!--- Include screenshots if you modify the UI. -->
<img width="1687" height="1703" alt="image" src="https://github.com/user-attachments/assets/6a504a87-80eb-4e76-b261-cd8773eeaedf" />
This is the updated image.

<img width="1786" height="1116" alt="image" src="https://github.com/user-attachments/assets/24248627-1e89-4c73-a6d2-b3d1418ee7e4" />

This is what's on prod
## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
