### PR TITLE
[Insights]: Point Insights feedback link to support page

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
@@ -6,12 +6,13 @@ import { SHOW_DOCS_LINKS } from '../../temp-flags';
 import { InsightsTabPanelTemplatesTabGrid } from './InsightsTabPanelTemplatesTabGrid';
 
 const BASE_DOCS_URL = 'https://docs.inngest.com/';
+const ROADMAP_URL = 'https://roadmap.inngest.com/roadmap';
 
 // TODO: Update these to point to the correct URLs.
 const RESOURCES = [
   { href: BASE_DOCS_URL, label: 'How to write your own query', icon: RiQuillPenLine },
   { href: BASE_DOCS_URL, label: 'Insights documentation', icon: RiExternalLinkLine },
-  { href: BASE_DOCS_URL, label: 'Send us feedback', icon: RiChatPollLine },
+  { href: ROADMAP_URL, label: 'Send us feedback', icon: RiChatPollLine },
 ];
 
 export function InsightsTabPanelTemplatesTab() {

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
@@ -1,18 +1,32 @@
 'use client';
 
+import { Link } from '@inngest/components/Link/Link';
 import { RiChatPollLine, RiExternalLinkLine, RiQuillPenLine } from '@remixicon/react';
 
 import { SHOW_DOCS_LINKS } from '../../temp-flags';
 import { InsightsTabPanelTemplatesTabGrid } from './InsightsTabPanelTemplatesTabGrid';
 
 const BASE_DOCS_URL = 'https://docs.inngest.com/';
-const ROADMAP_URL = 'https://roadmap.inngest.com/roadmap';
 
-// TODO: Update these to point to the correct URLs.
 const RESOURCES = [
-  { href: BASE_DOCS_URL, label: 'How to write your own query', icon: RiQuillPenLine },
-  { href: BASE_DOCS_URL, label: 'Insights documentation', icon: RiExternalLinkLine },
-  { href: ROADMAP_URL, label: 'Send us feedback', icon: RiChatPollLine },
+  {
+    href: BASE_DOCS_URL,
+    label: 'How to write your own query',
+    icon: RiQuillPenLine,
+    show: SHOW_DOCS_LINKS,
+  },
+  {
+    href: BASE_DOCS_URL,
+    label: 'Insights documentation',
+    icon: RiExternalLinkLine,
+    show: SHOW_DOCS_LINKS,
+  },
+  {
+    href: '/support',
+    label: 'Send us feedback',
+    icon: RiChatPollLine,
+    show: true,
+  },
 ];
 
 export function InsightsTabPanelTemplatesTab() {
@@ -27,28 +41,25 @@ export function InsightsTabPanelTemplatesTab() {
         </div>
         <InsightsTabPanelTemplatesTabGrid />
       </div>
-      {SHOW_DOCS_LINKS && (
-        <div className="flex w-[360px] flex-shrink-0 flex-col">
-          <div className="flex flex-col gap-4">
-            <h3 className="text-muted text-xs font-medium">RESOURCES</h3>
-            <div className="flex flex-col gap-3">
-              {RESOURCES.map(({ icon: Icon, label, href }) => (
-                <div className="flex items-center gap-2" key={label}>
-                  <Icon className="text-muted-foreground h-4 w-4" />
-                  <a
-                    className="hover:text-foreground text-muted-foreground text-sm transition-colors hover:underline"
-                    href={href}
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    {label}
-                  </a>
-                </div>
-              ))}
-            </div>
+      <div className="flex w-[360px] flex-shrink-0 flex-col">
+        <div className="flex flex-col gap-4">
+          <h3 className="text-muted text-xs font-medium">RESOURCES</h3>
+          <div className="flex flex-col gap-3">
+            {RESOURCES.filter(({ show }) => show).map(({ icon: Icon, label, href }) => (
+              <div className="flex items-center gap-2" key={label}>
+                <Icon className="text-muted-foreground h-4 w-4" />
+                <Link
+                  className="text-muted-foreground hover:underline hover:decoration-current"
+                  href={href}
+                  target="_blank"
+                >
+                  {label}
+                </Link>
+              </div>
+            ))}
           </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
@@ -6,7 +6,7 @@ import { RiChatPollLine, RiExternalLinkLine, RiQuillPenLine } from '@remixicon/r
 import { SHOW_DOCS_LINKS } from '../../temp-flags';
 import { InsightsTabPanelTemplatesTabGrid } from './InsightsTabPanelTemplatesTabGrid';
 
-const BASE_DOCS_URL = 'https://docs.inngest.com/';
+const BASE_DOCS_URL = 'https://www.inngest.com/docs';
 
 const RESOURCES = [
   {

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
@@ -51,6 +51,7 @@ export function InsightsTabPanelTemplatesTab() {
                 <Link
                   className="text-muted-foreground hover:underline hover:decoration-current"
                   href={href}
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   {label}

--- a/ui/packages/components/src/Link/Link.tsx
+++ b/ui/packages/components/src/Link/Link.tsx
@@ -13,6 +13,7 @@ type CustomLinkProps = {
   iconAfter?: React.ReactNode;
   arrowOnHover?: boolean;
   target?: HTMLAttributeAnchorTarget | undefined;
+  rel?: string;
 };
 
 export type LinkProps = CustomLinkProps & NextLinkProps;


### PR DESCRIPTION
## Description

This updates the "Send us feedback" link to point to our support page. It also reveals the "Resources" section generally, which was previously hidden pending docs links. It will look better once docs links are ready as well.

---

<img width="1074" height="346" alt="Screenshot 2025-09-15 at 2 16 12 PM" src="https://github.com/user-attachments/assets/0c95bbbc-6758-4f2c-9864-77cbb5894e1e" />

## Motivation

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
