### PR TITLE
better handle long errors in run trace outputs

### DIFF
--- a/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
+++ b/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
@@ -124,96 +124,93 @@ export const NewCodeBlock = ({
           fullScreen && 'bg-codeEditor fixed inset-0 z-[52]'
         )}
       >
-        <div className={cn('bg-canvasSubtle')}>
-          <div className={cn('bg-codeEditor flex items-center justify-between')}>
-            <p
-              className={cn(
-                header?.status === 'error' ? 'text-status-failedText' : 'text-subtle',
-                'px-5 pt-2.5 text-sm',
-                'max-h-24 max-w-96 text-ellipsis break-words'
-              )}
-            >
-              {parsed ? (
-                <SegmentedControl defaultValue={mode}>
-                  <SegmentedControl.Button value="rich" onClick={() => setMode('rich')}>
-                    <div className="overflow-x-hidden overflow-y-hidden text-ellipsis whitespace-nowrap">
-                      Parsed {header?.title}
-                    </div>
-                  </SegmentedControl.Button>
-                  <SegmentedControl.Button value="raw" onClick={() => setMode('raw')}>
-                    <div className="overflow-x-hidden overflow-y-hidden text-ellipsis whitespace-nowrap">
-                      Raw {header?.title}
-                    </div>
-                  </SegmentedControl.Button>
-                </SegmentedControl>
-              ) : (
-                <Pill
-                  kind={header?.status === 'error' ? 'error' : 'default'}
-                  appearance="outlined"
-                  className="my-2 max-w-96 overflow-x-auto rounded-full p-3"
+        <div
+          className={cn('bg-codeEditor mx-4 mt-2 flex flex-row items-center justify-between gap-4')}
+        >
+          <div
+            className={cn(
+              header?.status === 'error' ? 'text-status-failedText' : 'text-subtle',
+              'inline-flex max-h-24 w-0 grow overflow-hidden text-ellipsis whitespace-nowrap text-sm'
+            )}
+          >
+            {parsed ? (
+              <SegmentedControl defaultValue={mode}>
+                <SegmentedControl.Button value="rich" onClick={() => setMode('rich')}>
+                  <div className="overflow-x-hidden overflow-y-hidden text-ellipsis whitespace-nowrap">
+                    Parsed {header?.title}
+                  </div>
+                </SegmentedControl.Button>
+                <SegmentedControl.Button value="raw" onClick={() => setMode('raw')}>
+                  <div className="w-0 overflow-x-hidden overflow-y-hidden text-ellipsis whitespace-nowrap">
+                    Raw {header?.title}
+                  </div>
+                </SegmentedControl.Button>
+              </SegmentedControl>
+            ) : (
+              <Pill
+                kind={header?.status === 'error' ? 'error' : 'default'}
+                appearance="outlined"
+                className="my-2 overflow-x-auto rounded-full p-3"
+              >
+                <OptionalTooltip
+                  tooltip={header?.title?.length && header?.title?.length > 55 ? header?.title : ''}
+                  side="left"
                 >
-                  <OptionalTooltip
-                    tooltip={
-                      header?.title?.length && header?.title?.length > 55 ? header?.title : ''
-                    }
-                    side="left"
-                  >
-                    <div className="overflow-x-hidden overflow-y-hidden text-ellipsis whitespace-nowrap">
-                      {header?.title}
-                    </div>
-                  </OptionalTooltip>
-                </Pill>
-              )}
-            </p>
+                  <div className="overflow-x-hidden overflow-y-hidden text-ellipsis whitespace-nowrap">
+                    {header?.title}
+                  </div>
+                </OptionalTooltip>
+              </Pill>
+            )}
+          </div>
 
-            {!isOutputTooLarge && (
-              <div className="mr-4 flex items-center gap-2 py-2">
-                {actions.map(({ label, title, icon, onClick, disabled }, idx) => (
-                  <Button
-                    key={idx}
-                    icon={icon}
-                    onClick={onClick}
-                    size="small"
-                    aria-label={label}
-                    title={title ?? label}
-                    label={label}
-                    disabled={disabled}
-                    appearance="outlined"
-                    kind="secondary"
-                  />
-                ))}
-                <CopyButton
-                  size="small"
-                  code={content}
-                  isCopying={isCopying}
-                  handleCopyClick={handleCopyClick}
-                  appearance="outlined"
-                />
+          {!isOutputTooLarge && (
+            <div className="flex items-center gap-2">
+              {actions.map(({ label, title, icon, onClick, disabled }, idx) => (
                 <Button
-                  icon={wordWrap ? <IconOverflowText /> : <IconWrapText />}
-                  onClick={() => setWordWrap(!wordWrap)}
+                  key={idx}
+                  icon={icon}
+                  onClick={onClick}
                   size="small"
-                  aria-label={wordWrap ? 'Do not wrap text' : 'Wrap text'}
-                  title={wordWrap ? 'Do not wrap text' : 'Wrap text'}
-                  tooltip={wordWrap ? 'Do not wrap text' : 'Wrap text'}
+                  aria-label={label}
+                  title={title ?? label}
+                  label={label}
+                  disabled={disabled}
                   appearance="outlined"
                   kind="secondary"
                 />
-                {allowFullScreen && (
-                  <Button
-                    onClick={() => setFullScreen(!fullScreen)}
-                    size="small"
-                    icon={fullScreen ? <RiCollapseDiagonalLine /> : <RiExpandDiagonalLine />}
-                    aria-label="Full screen"
-                    title="Full screen"
-                    tooltip="Full screen"
-                    appearance="outlined"
-                    kind="secondary"
-                  />
-                )}
-              </div>
-            )}
-          </div>
+              ))}
+              <CopyButton
+                size="small"
+                code={content}
+                isCopying={isCopying}
+                handleCopyClick={handleCopyClick}
+                appearance="outlined"
+              />
+              <Button
+                icon={wordWrap ? <IconOverflowText /> : <IconWrapText />}
+                onClick={() => setWordWrap(!wordWrap)}
+                size="small"
+                aria-label={wordWrap ? 'Do not wrap text' : 'Wrap text'}
+                title={wordWrap ? 'Do not wrap text' : 'Wrap text'}
+                tooltip={wordWrap ? 'Do not wrap text' : 'Wrap text'}
+                appearance="outlined"
+                kind="secondary"
+              />
+              {allowFullScreen && (
+                <Button
+                  onClick={() => setFullScreen(!fullScreen)}
+                  size="small"
+                  icon={fullScreen ? <RiCollapseDiagonalLine /> : <RiExpandDiagonalLine />}
+                  aria-label="Full screen"
+                  title="Full screen"
+                  tooltip="Full screen"
+                  appearance="outlined"
+                  kind="secondary"
+                />
+              )}
+            </div>
+          )}
         </div>
         <div className={cn('bg-codeEditor h-full overflow-y-auto py-3')}>
           {isOutputTooLarge && !editEmtpy ? (

--- a/ui/packages/components/src/RunDetailsV3/ErrorInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/ErrorInfo.tsx
@@ -24,19 +24,23 @@ const InngestStatus = ({ inngestStatus }: { inngestStatus: InngestStatus | null 
         className={'mx-1 inline-flex h-2.5 w-2.5 rounded-full'}
         style={{ backgroundColor: inngestStatus.indicatorColor }}
       ></span>
-      {inngestStatus.description}
+      <div className="w-0 grow overflow-hidden text-ellipsis whitespace-nowrap">
+        {inngestStatus.description}
+      </div>
     </LinkElement>
   );
 
 const SDKError = ({ error }: ErrorInfoProps) => (
-  <div className={`flex items-center gap-2 rounded text-sm ${getStatusTextClass('FAILED')}`}>
+  <div
+    className={`flex min-w-0 items-center gap-2 rounded text-sm ${getStatusTextClass('FAILED')}`}
+  >
     <div
       className={`mx-1 inline-flex h-2.5 w-2.5 shrink-0 rounded-full ${getStatusBackgroundClass(
         'FAILED'
       )}`}
     />
     <OptionalTooltip tooltip={error?.length > 55 ? error : ''} side="left">
-      <div className="min-w-0 overflow-x-hidden text-ellipsis whitespace-nowrap">{error}</div>
+      <div className="w-0 grow overflow-hidden text-ellipsis whitespace-nowrap">{error}</div>
     </OptionalTooltip>
   </div>
 );
@@ -52,7 +56,6 @@ export const ErrorInfo = ({ error }: ErrorInfoProps) => {
         return <span className="text-muted text-sm leading-tight">{system}</span>;
       },
       header: 'System',
-      size: 25,
       enableSorting: false,
     }),
     columnHelper.accessor('status', {
@@ -79,6 +82,7 @@ export const ErrorInfo = ({ error }: ErrorInfoProps) => {
             { system: 'App', status: '', error },
           ]}
           columns={columns}
+          cellClassName="[&:first-child]:w-24"
         />
       </div>
     )


### PR DESCRIPTION
## Description

Better handle long errors in run trace outputs
<img width="1185" height="445" alt="Screenshot 2025-09-15 at 4 40 26 PM" src="https://github.com/user-attachments/assets/5d1fd596-dd4b-4cbb-8c96-47662fc7e0b7" />



## Motivation
Prevent unnecessary horizontal scrolling

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
