### PR TITLE
feat: add OpcodeStepFailed support

### DIFF
--- a/pkg/api/apiv1/checkpoint.go
+++ b/pkg/api/apiv1/checkpoint.go
@@ -348,7 +348,7 @@ func (a checkpointAPI) checkpoint(ctx context.Context, input checkpointSteps, w 
 				l.Error("error saving span for checkpoint op", "error", err)
 			}
 
-		case enums.OpcodeStepError:
+		case enums.OpcodeStepError, enums.OpcodeStepFailed:
 			// StepErrors are unique.  Firstly, we must always store traces.  However, if
 			// we retry the step, we move from sync -> async, requiring jobs to be scheduled.
 			//

--- a/pkg/enums/opcode.go
+++ b/pkg/enums/opcode.go
@@ -18,6 +18,7 @@ const (
 	OpcodeGateway   // Gateway call
 	OpcodeWaitForSignal
 	OpcodeRunComplete
+	OpcodeStepFailed
 )
 
 // opcodeSyncMap explicitly represents the sync opcodes that can be checkpointed.
@@ -26,6 +27,7 @@ var opcodeSyncMap = map[Opcode]struct{}{
 	OpcodeStep:        {},
 	OpcodeStepRun:     {},
 	OpcodeRunComplete: {},
+	OpcodeStepFailed:  {},
 }
 
 // OpcodeIsSync returns whether the given opcode is synchronous.  This

--- a/pkg/enums/opcode_enumer.go
+++ b/pkg/enums/opcode_enumer.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-const _OpcodeName = "NoneStepStepRunStepErrorStepPlannedSleepWaitForEventInvokeFunctionAIGatewayGatewayWaitForSignalRunComplete"
+const _OpcodeName = "NoneStepStepRunStepErrorStepPlannedSleepWaitForEventInvokeFunctionAIGatewayGatewayWaitForSignalRunCompleteStepFailed"
 
-var _OpcodeIndex = [...]uint8{0, 4, 8, 15, 24, 35, 40, 52, 66, 75, 82, 95, 106}
+var _OpcodeIndex = [...]uint8{0, 4, 8, 15, 24, 35, 40, 52, 66, 75, 82, 95, 106, 116}
 
-const _OpcodeLowerName = "nonestepsteprunsteperrorstepplannedsleepwaitforeventinvokefunctionaigatewaygatewaywaitforsignalruncomplete"
+const _OpcodeLowerName = "nonestepsteprunsteperrorstepplannedsleepwaitforeventinvokefunctionaigatewaygatewaywaitforsignalruncompletestepfailed"
 
 func (i Opcode) String() string {
 	if i < 0 || i >= Opcode(len(_OpcodeIndex)-1) {
@@ -37,35 +37,38 @@ func _OpcodeNoOp() {
 	_ = x[OpcodeGateway-(9)]
 	_ = x[OpcodeWaitForSignal-(10)]
 	_ = x[OpcodeRunComplete-(11)]
+	_ = x[OpcodeStepFailed-(12)]
 }
 
-var _OpcodeValues = []Opcode{OpcodeNone, OpcodeStep, OpcodeStepRun, OpcodeStepError, OpcodeStepPlanned, OpcodeSleep, OpcodeWaitForEvent, OpcodeInvokeFunction, OpcodeAIGateway, OpcodeGateway, OpcodeWaitForSignal, OpcodeRunComplete}
+var _OpcodeValues = []Opcode{OpcodeNone, OpcodeStep, OpcodeStepRun, OpcodeStepError, OpcodeStepPlanned, OpcodeSleep, OpcodeWaitForEvent, OpcodeInvokeFunction, OpcodeAIGateway, OpcodeGateway, OpcodeWaitForSignal, OpcodeRunComplete, OpcodeStepFailed}
 
 var _OpcodeNameToValueMap = map[string]Opcode{
-	_OpcodeName[0:4]:         OpcodeNone,
-	_OpcodeLowerName[0:4]:    OpcodeNone,
-	_OpcodeName[4:8]:         OpcodeStep,
-	_OpcodeLowerName[4:8]:    OpcodeStep,
-	_OpcodeName[8:15]:        OpcodeStepRun,
-	_OpcodeLowerName[8:15]:   OpcodeStepRun,
-	_OpcodeName[15:24]:       OpcodeStepError,
-	_OpcodeLowerName[15:24]:  OpcodeStepError,
-	_OpcodeName[24:35]:       OpcodeStepPlanned,
-	_OpcodeLowerName[24:35]:  OpcodeStepPlanned,
-	_OpcodeName[35:40]:       OpcodeSleep,
-	_OpcodeLowerName[35:40]:  OpcodeSleep,
-	_OpcodeName[40:52]:       OpcodeWaitForEvent,
-	_OpcodeLowerName[40:52]:  OpcodeWaitForEvent,
-	_OpcodeName[52:66]:       OpcodeInvokeFunction,
-	_OpcodeLowerName[52:66]:  OpcodeInvokeFunction,
-	_OpcodeName[66:75]:       OpcodeAIGateway,
-	_OpcodeLowerName[66:75]:  OpcodeAIGateway,
-	_OpcodeName[75:82]:       OpcodeGateway,
-	_OpcodeLowerName[75:82]:  OpcodeGateway,
-	_OpcodeName[82:95]:       OpcodeWaitForSignal,
-	_OpcodeLowerName[82:95]:  OpcodeWaitForSignal,
-	_OpcodeName[95:106]:      OpcodeRunComplete,
-	_OpcodeLowerName[95:106]: OpcodeRunComplete,
+	_OpcodeName[0:4]:          OpcodeNone,
+	_OpcodeLowerName[0:4]:     OpcodeNone,
+	_OpcodeName[4:8]:          OpcodeStep,
+	_OpcodeLowerName[4:8]:     OpcodeStep,
+	_OpcodeName[8:15]:         OpcodeStepRun,
+	_OpcodeLowerName[8:15]:    OpcodeStepRun,
+	_OpcodeName[15:24]:        OpcodeStepError,
+	_OpcodeLowerName[15:24]:   OpcodeStepError,
+	_OpcodeName[24:35]:        OpcodeStepPlanned,
+	_OpcodeLowerName[24:35]:   OpcodeStepPlanned,
+	_OpcodeName[35:40]:        OpcodeSleep,
+	_OpcodeLowerName[35:40]:   OpcodeSleep,
+	_OpcodeName[40:52]:        OpcodeWaitForEvent,
+	_OpcodeLowerName[40:52]:   OpcodeWaitForEvent,
+	_OpcodeName[52:66]:        OpcodeInvokeFunction,
+	_OpcodeLowerName[52:66]:   OpcodeInvokeFunction,
+	_OpcodeName[66:75]:        OpcodeAIGateway,
+	_OpcodeLowerName[66:75]:   OpcodeAIGateway,
+	_OpcodeName[75:82]:        OpcodeGateway,
+	_OpcodeLowerName[75:82]:   OpcodeGateway,
+	_OpcodeName[82:95]:        OpcodeWaitForSignal,
+	_OpcodeLowerName[82:95]:   OpcodeWaitForSignal,
+	_OpcodeName[95:106]:       OpcodeRunComplete,
+	_OpcodeLowerName[95:106]:  OpcodeRunComplete,
+	_OpcodeName[106:116]:      OpcodeStepFailed,
+	_OpcodeLowerName[106:116]: OpcodeStepFailed,
 }
 
 var _OpcodeNames = []string{
@@ -81,6 +84,7 @@ var _OpcodeNames = []string{
 	_OpcodeName[75:82],
 	_OpcodeName[82:95],
 	_OpcodeName[95:106],
+	_OpcodeName[106:116],
 }
 
 // OpcodeString retrieves an enum value from the enum constants string name.

--- a/pkg/execution/driver/connectdriver/connectdriver.go
+++ b/pkg/execution/driver/connectdriver/connectdriver.go
@@ -80,7 +80,7 @@ func (e executor) Execute(ctx context.Context, sl sv2.StateLoader, s sv2.Metadat
 		})
 	}()
 
-	input, err := driver.MarshalV1(ctx, sl, s, step, idx, "", attempt)
+	input, err := driver.MarshalV1(ctx, sl, s, step, idx, "", attempt, item.GetMaxAttempts())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -90,6 +90,7 @@ func MarshalV1(
 	stackIndex int,
 	env string,
 	attempt int,
+	maxAttempts int,
 ) ([]byte, error) {
 	rawEvts, err := sl.LoadEvents(ctx, md.ID)
 	if err != nil {
@@ -125,6 +126,7 @@ func MarshalV1(
 				Current: stackIndex,
 			},
 			Attempt:                   attempt,
+			MaxAttempts:               maxAttempts,
 			DisableImmediateExecution: md.Config.ForceStepPlan,
 		},
 		Version: md.Config.RequestVersion,

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -66,7 +66,7 @@ func (e executor) Execute(ctx context.Context, sl sv2.StateLoader, s sv2.Metadat
 		return nil, err
 	}
 
-	input, err := driver.MarshalV1(ctx, sl, s, step, idx, "", attempt)
+	input, err := driver.MarshalV1(ctx, sl, s, step, idx, "", attempt, item.GetMaxAttempts())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/execution/driver/request.go
+++ b/pkg/execution/driver/request.go
@@ -41,6 +41,9 @@ type SDKRequestContext struct {
 	// Attempt is the zero-index attempt number.
 	Attempt int `json:"attempt"`
 
+	// MaxAttempts is the maximum number of attempts allowed for this function.
+	MaxAttempts int `json:"max_attempts"`
+
 	// Stack represents the function stack at the time of the step invocation.
 	Stack *FunctionStack `json:"stack"`
 

--- a/pkg/execution/state/opcode.go
+++ b/pkg/execution/state/opcode.go
@@ -111,7 +111,7 @@ func (g GeneratorOpcode) Input() (string, error) {
 func (g GeneratorOpcode) Output() (string, error) {
 	// OpcodeStepError MUST always wrap the output in an "error"
 	// field, allowing the SDK to differentiate between an error and data.
-	if g.Op == enums.OpcodeStepError {
+	if g.Op == enums.OpcodeStepError || g.Op == enums.OpcodeStepFailed {
 		byt, err := json.Marshal(map[string]any{"error": g.Error})
 		return string(byt), err
 	}

--- a/pkg/tracing/meta/consts.go
+++ b/pkg/tracing/meta/consts.go
@@ -15,6 +15,7 @@ const (
 	SpanNameStepDiscovery    = "executor.step.discovery"
 	SpanNameStep             = "executor.step"
 	SpanNameExecution        = "executor.execution"
+	SpanNameStepFailed       = "executor.failed"
 	SpanNameDynamicExtension = "EXTEND"
 
 	// Link attributes

--- a/pkg/tracing/util.go
+++ b/pkg/tracing/util.go
@@ -206,7 +206,7 @@ func generatorAttrs(op *state.GeneratorOpcode) *meta.SerializableAttrs {
 			}
 		}
 
-	case enums.OpcodeStep, enums.OpcodeStepRun, enums.OpcodeStepError:
+	case enums.OpcodeStep, enums.OpcodeStepRun, enums.OpcodeStepError, enums.OpcodeStepFailed:
 		{
 			// Output (success or error)
 			if output, err := op.Output(); err == nil {

--- a/tests/dsl.go
+++ b/tests/dsl.go
@@ -183,6 +183,7 @@ func (t *Test) ExpectRequest(name string, queryStepID string, timeout time.Durat
 			require.EqualValues(t.test, t.requestEvent, er.Event, "Request event is incorrect")
 			er.Event.Timestamp = ts
 			er.Event.ID = evtID
+			er.Ctx.MaxAttempts = 0
 
 			for _, m := range modifiers {
 				m(&t.requestCtx)


### PR DESCRIPTION
## Description

Add a StepFailed opcode that is used to signify that a step has failed in a non-retryable manner. Also adds `MaxAttempts` so that an SDK is able to know that a function is out of retries.

## Motivation

* [Spec](https://www.notion.so/inngest/StepFailed-opcode-269b64753bbd8020aed9f3281dde572b?source=copy_link)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
