### PR TITLE
Trace/input persistence

### DIFF
--- a/pkg/cqrs/base_cqrs/migrations/postgres/000016_add_span_input_column.down.sql
+++ b/pkg/cqrs/base_cqrs/migrations/postgres/000016_add_span_input_column.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE spans DROP COLUMN input;

--- a/pkg/cqrs/base_cqrs/migrations/postgres/000016_add_span_input_column.up.sql
+++ b/pkg/cqrs/base_cqrs/migrations/postgres/000016_add_span_input_column.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE spans ADD COLUMN input JSONB;

--- a/pkg/cqrs/base_cqrs/migrations/sqlite/000016_add_span_input_column.down.sql
+++ b/pkg/cqrs/base_cqrs/migrations/sqlite/000016_add_span_input_column.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE spans DROP COLUMN input;

--- a/pkg/cqrs/base_cqrs/migrations/sqlite/000016_add_span_input_column.up.sql
+++ b/pkg/cqrs/base_cqrs/migrations/sqlite/000016_add_span_input_column.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE spans ADD COLUMN input JSON;

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/db_normalization.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/db_normalization.go
@@ -790,7 +790,7 @@ func (q NormalizedQueries) GetSpansByDebugSessionID(ctx context.Context, debugSe
 	return sqliteRows, nil
 }
 
-func (q NormalizedQueries) GetSpanOutput(ctx context.Context, spanID string) (any, error) {
+func (q NormalizedQueries) GetSpanOutput(ctx context.Context, spanID string) (*sqlc_sqlite.GetSpanOutputRow, error) {
 	// TODO
 	return nil, nil
 }

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/models.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/models.go
@@ -136,6 +136,7 @@ type Span struct {
 	RunID          string
 	EnvID          string
 	Output         pqtype.NullRawMessage
+	Input          pqtype.NullRawMessage
 	DebugRunID     sql.NullString
 	DebugSessionID sql.NullString
 	Status         sql.NullString

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
@@ -366,10 +366,11 @@ INSERT INTO spans (
   attributes,
   links,
   output,
+  input,
   debug_run_id,
   debug_session_id,
   status
-) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18);
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19);
 
 -- name: GetSpansByRunID :many
 SELECT
@@ -436,7 +437,7 @@ ORDER BY start_time;
 
 -- name: GetSpanOutput :one
 SELECT
-  -- input, TODO
+  input,
   output
 FROM spans
 WHERE span_id = $1

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/schema.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/schema.sql
@@ -211,6 +211,7 @@ CREATE TABLE spans (
   run_id TEXT NOT NULL,
   env_id TEXT NOT NULL,
   output JSONB,
+  input JSONB,
   debug_run_id TEXT,
   debug_session_id TEXT,
   status TEXT,

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/models.go
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/models.go
@@ -136,6 +136,7 @@ type Span struct {
 	RunID          string
 	EnvID          string
 	Output         interface{}
+	Input          interface{}
 	DebugRunID     sql.NullString
 	DebugSessionID sql.NullString
 	Status         sql.NullString

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/querier.go
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/querier.go
@@ -46,7 +46,7 @@ type Querier interface {
 	// Queue snapshots
 	//
 	GetQueueSnapshotChunks(ctx context.Context, snapshotID interface{}) ([]*GetQueueSnapshotChunksRow, error)
-	GetSpanOutput(ctx context.Context, spanID string) (interface{}, error)
+	GetSpanOutput(ctx context.Context, spanID string) (*GetSpanOutputRow, error)
 	GetSpansByDebugRunID(ctx context.Context, debugRunID sql.NullString) ([]*GetSpansByDebugRunIDRow, error)
 	GetSpansByDebugSessionID(ctx context.Context, debugSessionID sql.NullString) ([]*GetSpansByDebugSessionIDRow, error)
 	GetSpansByRunID(ctx context.Context, runID string) ([]*GetSpansByRunIDRow, error)

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
@@ -341,10 +341,11 @@ INSERT INTO spans (
   attributes,
   links,
   output,
+  input,
   debug_run_id,
   debug_session_id,
   status
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: GetSpansByRunID :many
 SELECT
@@ -407,7 +408,7 @@ ORDER BY start_time;
 
 -- name: GetSpanOutput :one
 SELECT
-  -- input, TODO
+  input,
   output
 FROM spans
 WHERE span_id = ?

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/schema.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/schema.sql
@@ -208,6 +208,7 @@ CREATE TABLE spans (
   run_id TEXT NOT NULL,
   env_id TEXT NOT NULL,
   output JSON,
+  input JSON,
   debug_run_id TEXT,
   debug_session_id TEXT,
   status TEXT,

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -578,6 +578,13 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		Config: config,
 	}
 
+	bytEvts, err := json.Marshal(evts)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling events: %w", err)
+	}
+
+	strEvts := string(bytEvts)
+
 	// XXX: If this is a sync run, always add the start time to the span.  We do this
 	// because sync runs have already started by the time we call Schedule;  theyre
 	// in-process, and Schedule gets called via an API endpoint when the run starts.
@@ -587,6 +594,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		Attributes: meta.NewAttrSet(
 			meta.Attr(meta.Attrs.DebugSessionID, req.DebugSessionID),
 			meta.Attr(meta.Attrs.DebugRunID, req.DebugRunID),
+			meta.Attr(meta.Attrs.EventsInput, &strEvts),
 		),
 	}
 	if req.RunMode == enums.RunModeSync {

--- a/pkg/tracing/meta/attributes.go
+++ b/pkg/tracing/meta/attributes.go
@@ -25,6 +25,7 @@ var Attrs = struct {
 	DropSpan        attr[*bool]
 	EnvID           attr[*uuid.UUID]
 	EventIDs        attr[*[]string]
+	EventsInput     attr[*string]
 	FunctionID      attr[*uuid.UUID]
 	FunctionVersion attr[*int]
 	RunID           attr[*ulid.ULID]
@@ -125,6 +126,7 @@ var Attrs = struct {
 	EndedAt:                            TimeAttr("ended_at"),
 	EnvID:                              UUIDAttr("env.id"),
 	EventIDs:                           StringSliceAttr("event.ids"),
+	EventsInput:                        StringAttr("events.input"),
 	FunctionID:                         UUIDAttr("function.id"),
 	FunctionVersion:                    IntAttr("function.version"),
 	InternalLocation:                   StringAttr("internal.location"),

--- a/pkg/tracing/meta/extracted_values_gen.go
+++ b/pkg/tracing/meta/extracted_values_gen.go
@@ -26,6 +26,7 @@ type ExtractedValues struct {
 	DropSpan *bool
 	EnvID *uuid.UUID
 	EventIDs *[]string
+	EventsInput *string
 	FunctionID *uuid.UUID
 	FunctionVersion *int
 	RunID *ulid.ULID

--- a/pkg/tracing/tracer_sqlc.go
+++ b/pkg/tracing/tracer_sqlc.go
@@ -35,6 +35,7 @@ func (e *dbExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlyS
 		var dynamicSpanID string
 		var functionID string
 		var output any
+		var input any
 		var runID string
 		var debugSessionID string
 		var debugRunID string
@@ -46,6 +47,13 @@ func (e *dbExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlyS
 			// This is always cleaned
 			if string(attr.Key) == meta.Attrs.StepOutput.Key() {
 				output = attr.Value.AsInterface()
+				continue
+			}
+
+			// If input, extract and store separately
+			// This is always cleaned
+			if string(attr.Key) == meta.Attrs.EventsInput.Key() {
+				input = attr.Value.AsInterface()
 				continue
 			}
 
@@ -199,6 +207,7 @@ func (e *dbExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlyS
 			AccountID: accountID,
 			EnvID:     envID,
 			Output:    output,
+			Input:     input,
 			DebugSessionID: sql.NullString{
 				String: debugSessionID,
 				Valid:  debugSessionID != "",


### PR DESCRIPTION
## Description

Save event input when saving the initial run span.

Event IDs are already added within the span processor.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
