### PR TITLE
[Insights:Tabs]: Prevent active tab switch when closing a tab

### DIFF
--- a/ui/packages/components/src/Tabs/Tab.tsx
+++ b/ui/packages/components/src/Tabs/Tab.tsx
@@ -52,6 +52,14 @@ export const Tab = forwardRef<React.ElementRef<typeof TabsPrimitive.Trigger>, Ta
         {onClose && !disallowClose && (
           <span
             className="p-0.5"
+            onPointerDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();


### PR DESCRIPTION
## Description

This fixes an issue where clicking the close button on a tab first focuses the tab. That bug circumvents, for example, the intended behavior in Insights where closing a tab that isn't open does not change the active tab.

## Motivation

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
