### PR TITLE
Persist function output on run span

### DIFF
--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -242,5 +242,9 @@ func (e *executor) finalizeEvents(ctx context.Context, opts execution.FinalizeOp
 }
 
 func finalizeSpanAttributes(f execution.FinalizeOpts) *meta.SerializableAttrs {
-	return tracing.DriverResponseAttrs(&f.Response, f.Optional.OutputSpanRef)
+	// We're explicitly not setting any output span reference here and passing
+	// `nil` instead. We do this because we need to be setting the function
+	// output twice - once for the execution itself and once for the run span -
+	// in order to appropriately filter this in Cloud and other data stores.
+	return tracing.DriverResponseAttrs(&f.Response, nil)
 }


### PR DESCRIPTION
## Description

Explicitly set the output of a function on the run span.

Previously we only put a reference to the _execution span_ that had the output so as not to persist the data twice needlessly, but we need this here to allow some query patterns in Cloud.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
