### PR TITLE
[Insights]: Prevent results table overscroll issue

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsDataTable/states/ResultsState/ResultsTable.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsDataTable/states/ResultsState/ResultsTable.tsx
@@ -31,7 +31,7 @@ export function ResultsTable() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      <div className="flex-1 overflow-auto" id="insights-table-container">
+      <div className="flex-1 overflow-auto overscroll-none" id="insights-table-container">
         <MemoizedInsightsTable
           cellClassName="[&:not(:first-child)]:border-l [&:not(:first-child)]:border-light box-border align-top px-4 py-2.5 group focus-within:ring-2 focus-within:ring-blue-500 focus-within:ring-inset outline-none"
           columns={columns}


### PR DESCRIPTION
## Description

Fixes an issue where scrolling too strongly with the trackpad in the results table can result in the browser "back" button action being taken.

## Motivation

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
