### PR TITLE
[Insights]: Mark Insights as a beta feature

### DIFF
--- a/ui/apps/dashboard/src/components/Navigation/Monitor.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Monitor.tsx
@@ -45,6 +45,7 @@ export default function Monitor({
       {isInsightsEnabled && (
         <MenuItem
           href={getNavRoute(activeEnv, 'insights')}
+          beta
           collapsed={collapsed}
           text="Insights"
           icon={<InsightsIcon className="h-[18px] w-[18px]" />}


### PR DESCRIPTION
## Description

This adds a "Beta" label to Insights in the sidebar.

---

<img width="209" height="180" alt="Screenshot 2025-09-18 at 2 17 08 PM" src="https://github.com/user-attachments/assets/62c03e13-fa33-47c8-bb06-f43071481837" />

## Motivation

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
