### PR TITLE
Fix time serialization being values CH struggles with

### DIFF
--- a/pkg/tracing/meta/serializers.go
+++ b/pkg/tracing/meta/serializers.go
@@ -224,7 +224,10 @@ func TimeAttr(key string) attr[*time.Time] {
 				return BlankAttr
 			}
 
-			return attribute.Int64(withPrefix(key), v.UnixMilli())
+			return attribute.String(
+				withPrefix(key),
+				fmt.Sprintf("%d", v.UnixMilli()),
+			)
 		},
 		deserialize: func(v any) (*time.Time, bool) {
 			switch v := v.(type) {


### PR DESCRIPTION
## Description

These were being serialized as a float, which CH understandably struggled parsing with some of its date-related functions.

This ensures we correctly serialize time as an easy unix timestamp string.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
