### PR TITLE
GQL workflow_versions deprecation - front end changes

### DIFF
--- a/ui/apps/dashboard/src/gql/graphql.ts
+++ b/ui/apps/dashboard/src/gql/graphql.ts
@@ -706,7 +706,6 @@ export type Event = {
   usage: Usage;
   versionCount: Scalars['Int'];
   versions: Array<Maybe<EventType>>;
-  workflows: Array<Workflow>;
   workspaceID: Maybe<Scalars['UUID']>;
 };
 
@@ -780,6 +779,7 @@ export type EventTypeV2 = {
   __typename?: 'EventTypeV2';
   envID: Scalars['UUID'];
   functions: FunctionsConnection;
+  latestSchema: Maybe<Scalars['String']>;
   name: Scalars['String'];
   usage: Usage;
 };

--- a/ui/apps/dashboard/src/gql/graphql.ts
+++ b/ui/apps/dashboard/src/gql/graphql.ts
@@ -2302,7 +2302,6 @@ export type Workflow = {
   latestVersion: WorkflowVersion;
   metrics: MetricsResponse;
   name: Scalars['String'];
-  previous: Array<Maybe<WorkflowVersion>>;
   replayCounts: ReplayRunCounts;
   /**
    * A list of all the function's replays.


### PR DESCRIPTION
## Description

- Remove eventResolver.Workflows (unused)
- Remove workflowResolver.Previous (unused)

## Motivation
Remove calls to `workflow_versions` table

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
