### PR TITLE
Fix output erroneously being two values

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -1520,7 +1520,7 @@ func (w wrapper) GetSpanOutput(ctx context.Context, opts cqrs.SpanIdentifier) (*
 	so := &cqrs.SpanOutput{}
 	var m map[string]any
 
-	so.Data = []byte(fmt.Append(nil, s))
+	so.Data = []byte(fmt.Append(nil, s.Output))
 	if err := json.Unmarshal(so.Data, &m); err == nil && m != nil {
 		if errData, ok := m["error"]; ok {
 			so.IsError = true


### PR DESCRIPTION
## Description

Fixes a tracing bug where output was shown as e.g.

```
&{<nil> {"data":{"success":true}}}
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
