### PR TITLE
John/brnd 32 in app alerts for new features and launch week

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/apps/page.tsx
@@ -12,6 +12,8 @@ import AppFAQ from '@/components/Apps/AppFAQ';
 import { EmptyOnboardingCard } from '@/components/Apps/EmptyAppsCard';
 import { StatusMenu } from '@/components/Apps/StatusMenu';
 import { getProdApps } from '@/components/Onboarding/actions';
+import FeaturelaunchMon from '@/components/Surveys/Featurelaunch-Mon';
+import FeaturelaunchTues from '@/components/Surveys/Featurelaunch-Tues';
 import { staticSlugs } from '@/utils/environments';
 import { pathCreator } from '@/utils/urls';
 import { Apps } from './Apps';
@@ -112,6 +114,8 @@ export default function AppsPage({
           </>
         )}
       </div>
+      <FeaturelaunchMon />
+      <FeaturelaunchTues />
     </>
   );
 }

--- a/ui/apps/dashboard/src/components/Layout/SideBar.tsx
+++ b/ui/apps/dashboard/src/components/Layout/SideBar.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 
 import type { ProfileDisplayType } from '@/queries/server-only/profile';
 import type { Environment } from '@/utils/environments';
+import { Alert } from '../Navigation/Alert';
 import { Help } from '../Navigation/Help';
 import { Integrations } from '../Navigation/Integrations';
 import Logo from '../Navigation/Logo';
@@ -73,6 +74,7 @@ export default function SideBar({
         <div className="mx-4">
           <SeatOverageWidget collapsed={collapsed} />
           {isWidgetOpen && <OnboardingWidget collapsed={collapsed} closeWidget={closeWidget} />}
+          <Alert />
           <Integrations collapsed={collapsed} />
           <Help collapsed={collapsed} showWidget={showWidget} />
         </div>

--- a/ui/apps/dashboard/src/components/Layout/SideBar.tsx
+++ b/ui/apps/dashboard/src/components/Layout/SideBar.tsx
@@ -74,7 +74,7 @@ export default function SideBar({
         <div className="mx-4">
           <SeatOverageWidget collapsed={collapsed} />
           {isWidgetOpen && <OnboardingWidget collapsed={collapsed} closeWidget={closeWidget} />}
-          <Alert />
+          <Alert collapsed={collapsed} />
           <Integrations collapsed={collapsed} />
           <Help collapsed={collapsed} showWidget={showWidget} />
         </div>

--- a/ui/apps/dashboard/src/components/Navigation/Alert.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Alert.tsx
@@ -17,10 +17,10 @@ export const Alert = ({ collapsed }: { collapsed: boolean }) => {
     // Check if already dismissed
     if (window.localStorage.getItem(ALERT_NAME) === 'true') return;
 
-    // Check if today is during launch week (September 17-21, 2025)
+    // Check if today is during launch week (September 22-26, 2025)
     const today = new Date();
-    const startDate = new Date(2025, 8, 17); // September 17th, 2025
-    const endDate = new Date(2025, 8, 21); // September 21st, 2025
+    const startDate = new Date(2025, 8, 22); // September 22nd, 2025
+    const endDate = new Date(2025, 8, 26); // September 26th, 2025
 
     // Check if today is within the launch week range
     const isDuringLaunchWeek = today >= startDate && today <= endDate;

--- a/ui/apps/dashboard/src/components/Navigation/Alert.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Alert.tsx
@@ -8,7 +8,7 @@ import { RiCloseLine } from '@remixicon/react';
 const ALERT_NAME = 'inngest-dismissLaunchWeekAlert';
 //
 // TODO: turn this into a proper component
-export const Alert = () => {
+export const Alert = ({ collapsed }: { collapsed: boolean }) => {
   const [show, setShow] = useState(false);
 
   useEffect(() => {
@@ -36,10 +36,11 @@ export const Alert = () => {
   };
 
   return (
-    show && (
+    show &&
+    !collapsed && (
       <div className="text-basis bg-info border-secondary-2xSubtle mb-5 rounded border py-3 pl-3 pr-2 text-xs leading-tight">
         <div className="gap-x flex flex-row items-start justify-between">
-          <div class="pt-1">
+          <div className="pt-1">
             Launch week is here! Check out our latest features and announcements 🚀{' '}
           </div>
           <Button

--- a/ui/apps/dashboard/src/components/Navigation/Alert.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Alert.tsx
@@ -5,14 +5,29 @@ import { Button } from '@inngest/components/Button';
 import { Link } from '@inngest/components/Link';
 import { RiCloseLine } from '@remixicon/react';
 
-const ALERT_NAME = 'inngest-dismissIAAlert';
+const ALERT_NAME = 'inngest-dismissLaunchWeekAlert';
 //
 // TODO: turn this into a proper component
 export const Alert = () => {
   const [show, setShow] = useState(false);
 
   useEffect(() => {
-    window.localStorage.getItem(ALERT_NAME) !== 'true' && setShow(true);
+    if (typeof window === 'undefined') return;
+
+    // Check if already dismissed
+    if (window.localStorage.getItem(ALERT_NAME) === 'true') return;
+
+    // Check if today is during launch week (September 17-21, 2025)
+    const today = new Date();
+    const startDate = new Date(2025, 8, 17); // September 17th, 2025
+    const endDate = new Date(2025, 8, 21); // September 21st, 2025
+
+    // Check if today is within the launch week range
+    const isDuringLaunchWeek = today >= startDate && today <= endDate;
+
+    if (isDuringLaunchWeek) {
+      setShow(true);
+    }
   }, []);
 
   const dismiss = () => {
@@ -22,23 +37,22 @@ export const Alert = () => {
 
   return (
     show && (
-      <div className="text-info bg-info border-secondary-2xSubtle mb-5 rounded border py-3 pl-3 pr-2 text-xs leading-tight">
+      <div className="text-basis bg-info border-secondary-2xSubtle mb-5 rounded border py-3 pl-3 pr-2 text-xs leading-tight">
         <div className="gap-x flex flex-row items-start justify-between">
-          <div>We&apos;ve reimagined our information architecture for better navigation.</div>
+          <div class="pt-1">
+            Launch week is here! Check out our latest features and announcements 🚀{' '}
+          </div>
           <Button
             icon={<RiCloseLine className="text-link" />}
             kind="secondary"
             appearance="ghost"
             size="small"
-            className="ml-.5"
+            className="ml-.5 self-start"
             onClick={() => dismiss()}
           />
         </div>
-        <Link
-          href=" https://www.inngest.com/blog/reimagining-information-architecture"
-          className="mt-4"
-        >
-          Read about the redesign
+        <Link href="https://www.inngest.com/blog" className="mt-4 text-xs">
+          View announcements
         </Link>
       </div>
     )

--- a/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Mon.tsx
+++ b/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Mon.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@inngest/components/Button/index';
+import { Link } from '@inngest/components/Link';
+import { RiCloseLine } from '@remixicon/react';
+
+const HIDE_FEATURE_LAUNCH = 'inngest-feature-launch-hide';
+
+export default function FeaturelaunchMon() {
+  const [open, setOpen] = useState(() => {
+    if (typeof window === 'undefined') return false;
+
+    // Check if already dismissed
+    if (window.localStorage.getItem(HIDE_FEATURE_LAUNCH) === 'true') return false;
+
+    // Check if today is Monday, September 22nd
+    const today = new Date();
+    const targetDate = new Date(2025, 8, 18); // Month is 0-indexed, so 8 = September
+
+    // Check if it's the same date (year, month, day)
+    const isTargetDate =
+      today.getFullYear() === targetDate.getFullYear() &&
+      today.getMonth() === targetDate.getMonth() &&
+      today.getDate() === targetDate.getDate();
+
+    return isTargetDate;
+  });
+
+  const dismiss = () => {
+    setOpen(false);
+    window.localStorage.setItem(HIDE_FEATURE_LAUNCH, 'true');
+  };
+
+  return (
+    open && (
+      <div className="bg-canvasBase border-subtle absolute bottom-0 right-0 mb-6 mr-4 w-[430px] rounded border">
+        <div className="gap-x border-subtle flex flex-row items-center justify-between border-b p-3">
+          <div className="text-sm font-medium leading-tight">
+            Launch week day 1: Step.run from anywhere
+          </div>
+          <Button
+            icon={<RiCloseLine className="text-subtle h-5 w-5" />}
+            kind="secondary"
+            appearance="ghost"
+            size="small"
+            className="ml-.5"
+            onClick={() => dismiss()}
+          />
+        </div>
+        <div className="text-muted px-3 pb-3 pt-3 text-sm">
+          Run steps from anywhere in your workflow. Lorem ipsum dolor sit amet, consectetur
+          adipiscing elit.
+          <div className="pt-2">
+            <button
+              className="border-muted text-btnPrimary bg-canvasBase focus:bg-canvasSubtle hover:bg-canvasSubtle active:bg-canvasMuted disabled:border-disabled disabled:bg-disabled disabled:text-btnPrimaryDisabled relative flex h-8 items-center justify-center justify-items-center whitespace-nowrap rounded-md border px-3 py-1.5 text-xs leading-[18px] disabled:cursor-not-allowed"
+              onClick={() => window.open('https://www.inngest.com/blog', '_blank')}
+            >
+              Read the blog post
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  );
+}

--- a/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Mon.tsx
+++ b/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Mon.tsx
@@ -21,7 +21,7 @@ export default function FeaturelaunchMon() {
 
     // Check if today is Monday, September 22nd
     const today = new Date();
-    const targetDate = new Date(2025, 8, 19); // Month is 0-indexed, so 8 = September
+    const targetDate = new Date(2025, 8, 22); // Month is 0-indexed, so 8 = September
 
     // Check if it's the same date (year, month, day)
     const isTargetDate =

--- a/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Mon.tsx
+++ b/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Mon.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@inngest/components/Button/index';
 import { Link } from '@inngest/components/Link';
 import { RiCloseLine } from '@remixicon/react';
@@ -8,15 +8,20 @@ import { RiCloseLine } from '@remixicon/react';
 const HIDE_FEATURE_LAUNCH = 'inngest-feature-launch-hide';
 
 export default function FeaturelaunchMon() {
-  const [open, setOpen] = useState(() => {
-    if (typeof window === 'undefined') return false;
+  const [mounted, setMounted] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+
+    if (typeof window === 'undefined') return;
 
     // Check if already dismissed
-    if (window.localStorage.getItem(HIDE_FEATURE_LAUNCH) === 'true') return false;
+    if (window.localStorage.getItem(HIDE_FEATURE_LAUNCH) === 'true') return;
 
     // Check if today is Monday, September 22nd
     const today = new Date();
-    const targetDate = new Date(2025, 8, 18); // Month is 0-indexed, so 8 = September
+    const targetDate = new Date(2025, 8, 22); // Month is 0-indexed, so 8 = September
 
     // Check if it's the same date (year, month, day)
     const isTargetDate =
@@ -24,20 +29,24 @@ export default function FeaturelaunchMon() {
       today.getMonth() === targetDate.getMonth() &&
       today.getDate() === targetDate.getDate();
 
-    return isTargetDate;
-  });
+    if (isTargetDate) {
+      setOpen(true);
+    }
+  }, []);
 
   const dismiss = () => {
     setOpen(false);
     window.localStorage.setItem(HIDE_FEATURE_LAUNCH, 'true');
   };
 
+  if (!mounted) return null;
+
   return (
     open && (
       <div className="bg-canvasBase border-subtle absolute bottom-0 right-0 mb-6 mr-4 w-[430px] rounded border">
         <div className="gap-x border-subtle flex flex-row items-center justify-between border-b p-3">
           <div className="text-sm font-medium leading-tight">
-            Launch week day 1: Step.run from anywhere
+            Launch week day 1: Unbreakable APIs
           </div>
           <Button
             icon={<RiCloseLine className="text-subtle h-5 w-5" />}
@@ -49,8 +58,8 @@ export default function FeaturelaunchMon() {
           />
         </div>
         <div className="text-muted px-3 pb-3 pt-3 text-sm">
-          Run steps from anywhere in your workflow. Lorem ipsum dolor sit amet, consectetur
-          adipiscing elit.
+          Build unbreakable APIs using steps directly in your API endpoints, without the need for
+          background workflows
           <div className="pt-2">
             <button
               className="border-muted text-btnPrimary bg-canvasBase focus:bg-canvasSubtle hover:bg-canvasSubtle active:bg-canvasMuted disabled:border-disabled disabled:bg-disabled disabled:text-btnPrimaryDisabled relative flex h-8 items-center justify-center justify-items-center whitespace-nowrap rounded-md border px-3 py-1.5 text-xs leading-[18px] disabled:cursor-not-allowed"

--- a/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Mon.tsx
+++ b/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Mon.tsx
@@ -21,7 +21,7 @@ export default function FeaturelaunchMon() {
 
     // Check if today is Monday, September 22nd
     const today = new Date();
-    const targetDate = new Date(2025, 8, 22); // Month is 0-indexed, so 8 = September
+    const targetDate = new Date(2025, 8, 19); // Month is 0-indexed, so 8 = September
 
     // Check if it's the same date (year, month, day)
     const isTargetDate =
@@ -59,13 +59,18 @@ export default function FeaturelaunchMon() {
         </div>
         <div className="text-muted px-3 pb-3 pt-3 text-sm">
           Build unbreakable APIs using steps directly in your API endpoints, without the need for
-          background workflows
+          background workflows.
           <div className="pt-2">
             <button
               className="border-muted text-btnPrimary bg-canvasBase focus:bg-canvasSubtle hover:bg-canvasSubtle active:bg-canvasMuted disabled:border-disabled disabled:bg-disabled disabled:text-btnPrimaryDisabled relative flex h-8 items-center justify-center justify-items-center whitespace-nowrap rounded-md border px-3 py-1.5 text-xs leading-[18px] disabled:cursor-not-allowed"
-              onClick={() => window.open('https://www.inngest.com/blog', '_blank')}
+              onClick={() =>
+                window.open(
+                  'https://www.inngest.com/blog/launch-week-day-1-unbreakable-apis',
+                  '_blank'
+                )
+              }
             >
-              Read the blog post
+              Learn more
             </button>
           </div>
         </div>

--- a/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Tues.tsx
+++ b/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Tues.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@inngest/components/Button/index';
+import { Link } from '@inngest/components/Link';
+import { RiCloseLine } from '@remixicon/react';
+
+const HIDE_FEATURE_LAUNCH_TUES = 'inngest-feature-launch-tues-hide';
+
+export default function FeaturelaunchTues() {
+  const [open, setOpen] = useState(() => {
+    if (typeof window === 'undefined') return false;
+
+    // Check if already dismissed
+    if (window.localStorage.getItem(HIDE_FEATURE_LAUNCH_TUES) === 'true') return false;
+
+    // Check if today is Tuesday, September 18th
+    const today = new Date();
+    const targetDate = new Date(2025, 8, 19); // Month is 0-indexed, so 8 = September
+
+    // Check if it's the same date (year, month, day)
+    const isTargetDate =
+      today.getFullYear() === targetDate.getFullYear() &&
+      today.getMonth() === targetDate.getMonth() &&
+      today.getDate() === targetDate.getDate();
+
+    return isTargetDate;
+  });
+
+  const dismiss = () => {
+    setOpen(false);
+    window.localStorage.setItem(HIDE_FEATURE_LAUNCH_TUES, 'true');
+  };
+
+  return (
+    open && (
+      <div className="bg-canvasBase border-subtle absolute bottom-0 right-0 mb-6 mr-4 w-[430px] rounded border">
+        <div className="gap-x border-subtle flex flex-row items-center justify-between border-b p-3">
+          <div className="text-sm font-medium leading-tight">Launch week day 2: Insights</div>
+          <Button
+            icon={<RiCloseLine className="text-subtle h-5 w-5" />}
+            kind="secondary"
+            appearance="ghost"
+            size="small"
+            className="ml-.5"
+            onClick={() => dismiss()}
+          />
+        </div>
+        <div className="text-muted px-3 pb-3 pt-3 text-sm">
+          Introducing enhanced observability features for better monitoring and debugging of your
+          workflows.
+          <div className="pt-2">
+            <button
+              className="border-muted text-btnPrimary bg-canvasBase focus:bg-canvasSubtle hover:bg-canvasSubtle active:bg-canvasMuted disabled:border-disabled disabled:bg-disabled disabled:text-btnPrimaryDisabled relative flex h-8 items-center justify-center justify-items-center whitespace-nowrap rounded-md border px-3 py-1.5 text-xs leading-[18px] disabled:cursor-not-allowed"
+              onClick={() => window.open('https://www.inngest.com/blog', '_blank')}
+            >
+              Read the blog post
+            </button>
+          </div>
+        </div>
+      </div>
+    )
+  );
+}

--- a/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Tues.tsx
+++ b/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Tues.tsx
@@ -21,7 +21,7 @@ export default function FeaturelaunchTues() {
 
     // Check if today is Tuesday, September 23th
     const today = new Date();
-    const targetDate = new Date(2025, 8, 19); // Month is 0-indexed, so 8 = September
+    const targetDate = new Date(2025, 8, 23); // Month is 0-indexed, so 8 = September
 
     // Check if it's the same date (year, month, day)
     const isTargetDate =
@@ -65,7 +65,7 @@ export default function FeaturelaunchTues() {
                 window.open('https://app.inngest.com/env/production/insights', '_blank')
               }
             >
-              Use Insights
+              Use insights
             </button>
           </div>
         </div>

--- a/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Tues.tsx
+++ b/ui/apps/dashboard/src/components/Surveys/Featurelaunch-Tues.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '@inngest/components/Button/index';
 import { Link } from '@inngest/components/Link';
 import { RiCloseLine } from '@remixicon/react';
@@ -8,13 +8,18 @@ import { RiCloseLine } from '@remixicon/react';
 const HIDE_FEATURE_LAUNCH_TUES = 'inngest-feature-launch-tues-hide';
 
 export default function FeaturelaunchTues() {
-  const [open, setOpen] = useState(() => {
-    if (typeof window === 'undefined') return false;
+  const [mounted, setMounted] = useState(false);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+
+    if (typeof window === 'undefined') return;
 
     // Check if already dismissed
-    if (window.localStorage.getItem(HIDE_FEATURE_LAUNCH_TUES) === 'true') return false;
+    if (window.localStorage.getItem(HIDE_FEATURE_LAUNCH_TUES) === 'true') return;
 
-    // Check if today is Tuesday, September 18th
+    // Check if today is Tuesday, September 23th
     const today = new Date();
     const targetDate = new Date(2025, 8, 19); // Month is 0-indexed, so 8 = September
 
@@ -24,13 +29,17 @@ export default function FeaturelaunchTues() {
       today.getMonth() === targetDate.getMonth() &&
       today.getDate() === targetDate.getDate();
 
-    return isTargetDate;
-  });
+    if (isTargetDate) {
+      setOpen(true);
+    }
+  }, []);
 
   const dismiss = () => {
     setOpen(false);
     window.localStorage.setItem(HIDE_FEATURE_LAUNCH_TUES, 'true');
   };
+
+  if (!mounted) return null;
 
   return (
     open && (
@@ -47,14 +56,16 @@ export default function FeaturelaunchTues() {
           />
         </div>
         <div className="text-muted px-3 pb-3 pt-3 text-sm">
-          Introducing enhanced observability features for better monitoring and debugging of your
-          workflows.
+          You can now query events to analyze trends, usage, and performance right where your
+          workflows run. No tool switching required
           <div className="pt-2">
             <button
               className="border-muted text-btnPrimary bg-canvasBase focus:bg-canvasSubtle hover:bg-canvasSubtle active:bg-canvasMuted disabled:border-disabled disabled:bg-disabled disabled:text-btnPrimaryDisabled relative flex h-8 items-center justify-center justify-items-center whitespace-nowrap rounded-md border px-3 py-1.5 text-xs leading-[18px] disabled:cursor-not-allowed"
-              onClick={() => window.open('https://www.inngest.com/blog', '_blank')}
+              onClick={() =>
+                window.open('https://app.inngest.com/env/production/insights', '_blank')
+              }
             >
-              Read the blog post
+              Use Insights
             </button>
           </div>
         </div>

--- a/ui/apps/dashboard/src/gql/graphql.ts
+++ b/ui/apps/dashboard/src/gql/graphql.ts
@@ -1880,6 +1880,7 @@ export type RunTraceSpan = {
   stepID: Maybe<Scalars['String']>;
   stepInfo: Maybe<StepInfo>;
   stepOp: Maybe<StepOp>;
+  stepType: Scalars['String'];
   traceID: Scalars['String'];
   userlandSpan: Maybe<UserlandSpan>;
   workspace: Workspace;

--- a/ui/apps/dashboard/src/gql/graphql.ts
+++ b/ui/apps/dashboard/src/gql/graphql.ts
@@ -780,6 +780,7 @@ export type EventTypeV2 = {
   __typename?: 'EventTypeV2';
   envID: Scalars['UUID'];
   functions: FunctionsConnection;
+  latestSchema: Maybe<Scalars['String']>;
   name: Scalars['String'];
   usage: Usage;
 };


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
Adding toasts and nav alert for launch week. Added two different toasts, one for monday (unbreakable apis) and one for tuesday (insights). Nav alert is going to exist all week, though all are dismissable. 

Edited the styling a bit of the toasts as well.

<img width="1578" height="1288" alt="image" src="https://github.com/user-attachments/assets/ac2ac165-5056-4154-b61c-acbc1a28dfd3" />
<img width="1578" height="1288" alt="image" src="https://github.com/user-attachments/assets/1d2635de-4eed-40b3-a710-f433a9e79ff9" />




<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
