### PR TITLE
Devserver: publish on localhost via realtime forwarding

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -408,6 +408,11 @@ func start(ctx context.Context, opts StartOpts) error {
 		ConnMaxLifetime: opts.PostgresConnMaxLifetime,
 	}))
 
+	url := opts.Config.CoreAPI.Addr
+	if url == "0.0.0.0" {
+		url = "127.0.0.1"
+	}
+
 	exec, err := executor.NewExecutor(
 		executor.WithHTTPClient(httpClient),
 		executor.WithStateManager(smv2),
@@ -458,7 +463,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		executor.WithTraceReader(dbcqrs),
 		executor.WithRealtimeConfig(executor.ExecutorRealtimeConfig{
 			Secret:     consts.DevServerRealtimeJWTSecret,
-			PublishURL: fmt.Sprintf("http://%s:%d/v1/realtime/publish", opts.Config.CoreAPI.Addr, opts.Config.CoreAPI.Port),
+			PublishURL: fmt.Sprintf("http://%s:%d/v1/realtime/publish", url, opts.Config.CoreAPI.Port),
 		}),
 		executor.WithTracerProvider(tracer),
 	)


### PR DESCRIPTION
The devserver should publish on 127.0.0.1 instead of 0.0.0.0 for dev server forwarding



## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
