### PR TITLE
chore: upgrade alpine to 3.22 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG TARGETOS
 RUN --mount=type=cache,target=/root/.cache/go-build \
     GOFLAGS=-mod=vendor GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /go/bin/inngest cmd/main.go
 
-FROM alpine:3.21 AS inngest
+FROM alpine:3.22 AS inngest
 RUN apk add --no-cache ca-certificates tzdata && update-ca-certificates
 COPY --from=build /go/bin/inngest /bin/inngest
 CMD ["inngest"]


### PR DESCRIPTION
## Description

This PR upgrades alpine version from 3.16 to 3.22.

## Motivation

Alpine 3.16 is quite old and is already unmaintained. We should bump to 3.22 which is the latest version.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
