### PR TITLE
Remove event_ from columns in insights templates

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/templates.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/templates.ts
@@ -4,21 +4,19 @@ import type { QueryTemplate } from '@/components/Insights/types';
 
 function makeEventVolumePerHourQuery(event?: string) {
   return `SELECT
-    toStartOfHour(toDateTime(event_ts / 1000)) AS hour_bucket,
-    event_name,
+    toStartOfHour(toDateTime(ts / 1000)) AS hour_bucket,
+    name,
     COUNT(*) AS event_count
 FROM
     events
 WHERE
-    event_ts > toUnixTimestamp(subtractDays(now(), 3)) * 1000${
-      event ? `\n    AND event_name = '${event}'` : ''
-    }
+    ts > toUnixTimestamp(subtractDays(now(), 3)) * 1000${event ? `\n    AND name = '${event}'` : ''}
 GROUP BY
     hour_bucket,
-    event_name
+    name
 ORDER BY
     hour_bucket,
-    event_name DESC`;
+    name DESC`;
 }
 
 const EVENT_TYPE_VOLUME_PER_HOUR_QUERY = makeEventVolumePerHourQuery();
@@ -32,21 +30,21 @@ const COUNT_ALIAS_MAP: Record<'failed' | 'cancelled' | 'finished', string> = {
 
 function makeFunctionStatusQuery(outcome: 'failed' | 'cancelled' | 'finished') {
   const base = `SELECT
-    simpleJSONExtractString(event_data, 'function_id') as function_id,
+    simpleJSONExtractString(data, 'function_id') as function_id,
     COUNT(*) as ${COUNT_ALIAS_MAP[outcome]}
 FROM
     events
 WHERE
-    event_name = 'inngest/function.${outcome}'`;
+    name = 'inngest/function.${outcome}'`;
 
   const successFilter =
     outcome === 'finished'
       ? `
-    AND JSONExtractBool(event_data, 'result', 'success') = true`
+    AND JSONExtractBool(data, 'result', 'success') = true`
       : '';
 
   return `${base}${successFilter}
-    AND event_ts > toUnixTimestamp(addDays(now(), -1)) * 1000
+    AND ts > toUnixTimestamp(addDays(now(), -1)) * 1000
 GROUP BY
     function_id
 ORDER BY


### PR DESCRIPTION
## Description

Update templates to match https://github.com/inngest/monorepo/pull/5250 behavior

## Motivation

We always wanted to expose these columns without `event_` anyway, and should do it before launch to minimize migration pain.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
