### PR TITLE
Turn off tanstack useQuery retries for insights

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext.tsx
@@ -53,6 +53,7 @@ export function InsightsStateMachineContextProvider({
       });
     },
     staleTime: 0,
+    retry: false,
   });
 
   const runQuery = useCallback(() => {


### PR DESCRIPTION
## Description

Tanstack retries up to 3 times by default on errors
https://tanstack.com/query/v4/docs/framework/react/guides/query-retries

We should treat all Insights errors as non retriable for now. This also
makes it quicker to iterate on bad queries.

## Motivation

We should treat all Insights errors as non retriable for now. This also
makes it quicker to iterate on bad queries.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
