### PR TITLE
Adding launch week announcement to the sidebar

### DIFF
--- a/ui/apps/dashboard/src/components/Layout/SideBar.tsx
+++ b/ui/apps/dashboard/src/components/Layout/SideBar.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 
 import type { ProfileDisplayType } from '@/queries/server-only/profile';
 import type { Environment } from '@/utils/environments';
+import { AlertLaunchweek } from '../Navigation/AlertLaunchweek';
 import { Help } from '../Navigation/Help';
 import { Integrations } from '../Navigation/Integrations';
 import Logo from '../Navigation/Logo';
@@ -73,6 +74,7 @@ export default function SideBar({
         <div className="mx-4">
           <SeatOverageWidget collapsed={collapsed} />
           {isWidgetOpen && <OnboardingWidget collapsed={collapsed} closeWidget={closeWidget} />}
+          <AlertLaunchweek collapsed={collapsed} />
           <Integrations collapsed={collapsed} />
           <Help collapsed={collapsed} showWidget={showWidget} />
         </div>

--- a/ui/apps/dashboard/src/components/Navigation/AlertLaunchweek.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/AlertLaunchweek.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@inngest/components/Button';
+import { Link } from '@inngest/components/Link';
+import { RiCloseLine } from '@remixicon/react';
+
+const ALERT_NAME = 'inngest-dismissLaunchWeekAlert';
+//
+// TODO: turn this into a proper component
+export const AlertLaunchweek = ({ collapsed }: { collapsed: boolean }) => {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    // Check if already dismissed
+    if (window.localStorage.getItem(ALERT_NAME) === 'true') return;
+
+    // Show the alert if not dismissed
+    setShow(true);
+  }, []);
+
+  const dismiss = () => {
+    setShow(false);
+    window.localStorage.setItem(ALERT_NAME, 'true');
+  };
+
+  return (
+    show &&
+    !collapsed && (
+      <div className="text-basis bg-info border-secondary-2xSubtle mb-5 rounded border py-3 pl-3 pr-2 text-xs leading-tight">
+        <div className="gap-x flex flex-row items-start justify-between">
+          <div className="pt-1">
+            Launch week is here! Check out our latest features and announcements 🚀{' '}
+          </div>
+          <Button
+            icon={<RiCloseLine className="text-link" />}
+            kind="secondary"
+            appearance="ghost"
+            size="small"
+            className="ml-.5 self-start"
+            onClick={() => dismiss()}
+          />
+        </div>
+        <Link href="https://www.inngest.com/blog" className="mt-4 text-xs">
+          View announcements
+        </Link>
+      </div>
+    )
+  );
+};


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
Adding launch week announcement to the sidebar. This will live on prod MON (9/22) until Fri (9/26)

<!--- Include screenshots if you modify the UI. -->
<img width="1772" height="1191" alt="image" src="https://github.com/user-attachments/assets/be3162ef-b0ec-4a3b-bf60-4f9dd0b7d31e" />
<img width="1772" height="1191" alt="image" src="https://github.com/user-attachments/assets/32d4b921-6d59-4a6c-ba71-7e2294f7f157" />


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
