### PR TITLE
Add run claim JWTs for sync APIs

### DIFF
--- a/pkg/api/apiv1/apiv1auth/apiv1auth.go
+++ b/pkg/api/apiv1/apiv1auth/apiv1auth.go
@@ -2,9 +2,19 @@ package apiv1auth
 
 import (
 	"context"
+	"fmt"
+	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/consts"
+	"github.com/oklog/ulid/v2"
+)
+
+const (
+	RunClaimsIssuer  = "api.inngest.com"
+	RunClaimsExpiry  = time.Hour
+	RunClaimsSubject = "run-claim"
 )
 
 // AuthFinder returns auth information from the current context.
@@ -29,4 +39,66 @@ func (nilAuth) AccountID() uuid.UUID {
 
 func (nilAuth) WorkspaceID() uuid.UUID {
 	return consts.DevServerEnvID
+}
+
+// CreateRunJWT creates a JWT for viewing the output of a specific run.
+func CreateRunJWT(secret []byte, envID uuid.UUID, runID ulid.ULID) (string, error) {
+	now := time.Now()
+	t := jwt.NewWithClaims(jwt.SigningMethodHS256, RunClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer: RunClaimsIssuer,
+			// using a specific subject allows us to check whether this is a run claim JWT immediately.
+			Subject:   RunClaimsSubject,
+			ExpiresAt: jwt.NewNumericDate(now.Add(RunClaimsExpiry)),
+			IssuedAt:  jwt.NewNumericDate(now),
+		},
+		Env:   envID,
+		RunID: runID,
+	})
+	signed, err := t.SignedString(secret)
+	if err != nil {
+		return "", fmt.Errorf("could not sign session token: %w", err)
+	}
+	return signed, nil
+}
+
+// VerifyRunJWT verifies a run claim JWT.
+func VerifyRunJWT(ctx context.Context, secret []byte, token string) (*RunClaims, error) {
+	claims := &RunClaims{}
+	_, err := jwt.ParseWithClaims(
+		token,
+		claims,
+		func(token *jwt.Token) (any, error) {
+			// Here, we could check if the token contains the signing key and
+			// verify whether the signing key is valid in order to auth the token,
+			// letting people use signing keys instead of pre-signed tokens.
+			//
+			// This is not currently permitted, and we currently always require
+			// pre-signed tokens for realtime subscriptions.
+			return secret, nil
+		},
+		jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Name}),
+		jwt.WithStrictDecoding(),
+		jwt.WithIssuedAt(),
+		jwt.WithIssuer(RunClaimsIssuer),
+		jwt.WithExpirationRequired(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("invalid realtime token: %w", err)
+	}
+	if claims.Subject != RunClaimsSubject {
+		return nil, nil
+	}
+	return claims, nil
+}
+
+// RunClaims represents claims to view a specific run, given an environment hash.
+// Note that this is embedded within a JWT.
+type RunClaims struct {
+	jwt.RegisteredClaims
+
+	// Env is the environment UUID that this run belongs to.
+	Env uuid.UUID
+	// RunID is the run ID that the claims grant access to
+	RunID ulid.ULID
 }

--- a/pkg/api/apiv1/checkpoint_types.go
+++ b/pkg/api/apiv1/checkpoint_types.go
@@ -160,6 +160,8 @@ type CheckpointNewRunResponse struct {
 	AppID uuid.UUID `json:"app_id"`
 	// RunID is the function run ID created for this execution.
 	RunID string `json:"run_id"`
+	// Token is the token that can be used to view the run output for redirects.
+	Token string `json:"token,omitempty"`
 }
 
 // runEvent creates a new event.Event from the CheckpointNewRunRequest.  This allows us to

--- a/pkg/consts/devserver.go
+++ b/pkg/consts/devserver.go
@@ -34,4 +34,5 @@ var (
 
 	DevServerConnectJwtSecret  = []byte("this-does-not-need-to-be-secret")
 	DevServerRealtimeJWTSecret = []byte("dev-mode-is-not-secret")
+	DevServerRunJWTSecret      = []byte("dev-mode-is-not-secret")
 )

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -521,7 +521,6 @@ func start(ctx context.Context, opts StartOpts) error {
 			Queue:              rq,
 			QueueShardSelector: shardSelector,
 			Broadcaster:        broadcaster,
-			RealtimeJWTSecret:  consts.DevServerRealtimeJWTSecret,
 			TraceReader:        ds.Data,
 
 			AppCreator:      dbcqrs,
@@ -529,6 +528,9 @@ func start(ctx context.Context, opts StartOpts) error {
 			EventPublisher:  runner,
 			TracerProvider:  tracer,
 			State:           smv2,
+
+			RealtimeJWTSecret: consts.DevServerRealtimeJWTSecret,
+			RunJWTSecret:      consts.DevServerRunJWTSecret,
 		})
 	})
 


### PR DESCRIPTION
This allows us to create single-scoped JWTs that allow access to a specific run ID's outputs.  Critically, we create these JWTs whenever a sync fn checkpoints and turns async.  The sync fns can then take these JWTs and give them to the original caller of the API, allowing them to fetch the output of the async fn in the future.

## Type of change (choose one)
- [x] New feature (non-breaking change that adds functionality)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
