### PR TITLE
Fix span processing order for new tracing

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -2622,6 +2622,13 @@ func (w wrapper) GetSpanRuns(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*c
 					startTime = span.StartTime
 				}
 			}
+
+			// order the spans by start time too so that we process each
+			// update step-by-step as they happened
+			sort.Slice(spans, func(i, j int) bool {
+				return spans[i].StartTime.Before(spans[j].StartTime)
+			})
+
 			runGroups = append(runGroups, runGroup{
 				runID:         runID,
 				dynamicSpanID: dynamicSpanID,

--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -2643,7 +2643,7 @@ func (w wrapper) GetSpanRuns(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*c
 		if runGroups[i].startTime.Equal(runGroups[j].startTime) {
 			return runGroups[i].runID < runGroups[j].runID
 		}
-		return runGroups[i].startTime.Before(runGroups[j].startTime)
+		return runGroups[i].startTime.After(runGroups[j].startTime)
 	})
 
 	res := []*cqrs.TraceRun{}

--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -2636,7 +2636,7 @@ func (w wrapper) GetSpanRuns(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*c
 		if runGroups[i].startTime.Equal(runGroups[j].startTime) {
 			return runGroups[i].runID < runGroups[j].runID
 		}
-		return runGroups[i].startTime.After(runGroups[j].startTime)
+		return runGroups[i].startTime.Before(runGroups[j].startTime)
 	})
 
 	res := []*cqrs.TraceRun{}


### PR DESCRIPTION
## Description

Fixes a bug where spans were being processed in the wrong (or at least an indeterminate) direction for the Dev Server UI runs list.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
