### PR TITLE
[Insights]: Add select * from events query template

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/templates.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/templates.ts
@@ -59,6 +59,13 @@ const RECENT_SUCCESSFUL_FUNCTION_COUNT = makeFunctionStatusQuery('finished');
 
 export const TEMPLATES: QueryTemplate[] = [
   {
+    id: 'recent-events',
+    name: 'Recent events',
+    query: 'SELECT * FROM events',
+    explanation: 'View recents events subject to row and plan history limit restrictions.',
+    templateKind: 'time',
+  },
+  {
     id: 'event-type-volume-per-hour',
     name: 'Events by type per hour',
     query: EVENT_TYPE_VOLUME_PER_HOUR_QUERY,


### PR DESCRIPTION
## Description

This is a quick and easy template that users can use to view all recent events data, from which they might want to construct more nuanced queries.

<img width="843" height="622" alt="Screenshot 2025-09-22 at 10 55 52 AM" src="https://github.com/user-attachments/assets/035d6323-6de6-4ad5-87a0-e66b98f24203" />

## Motivation

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
