### PR TITLE
Persist the trigger name through as an attr in tracing

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -518,7 +518,8 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	for n, item := range req.Events {
 		evt := item.GetEvent()
 		if eventName == nil {
-			eventName = &evt.Name
+			name := evt.Name
+			eventName = &name
 		}
 
 		// serialize this data to the span at the same time

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -512,9 +512,15 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		eventIDs = append(eventIDs, id)
 	}
 
+	var eventName *string
+
 	evts := make([]json.RawMessage, len(req.Events))
 	for n, item := range req.Events {
 		evt := item.GetEvent()
+		if eventName == nil {
+			eventName = &evt.Name
+		}
+
 		// serialize this data to the span at the same time
 		byt, err := json.Marshal(evt)
 		if err != nil {
@@ -595,6 +601,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 			meta.Attr(meta.Attrs.DebugSessionID, req.DebugSessionID),
 			meta.Attr(meta.Attrs.DebugRunID, req.DebugRunID),
 			meta.Attr(meta.Attrs.EventsInput, &strEvts),
+			meta.Attr(meta.Attrs.TriggeringEventName, eventName),
 		),
 	}
 	if req.RunMode == enums.RunModeSync {

--- a/pkg/tracing/meta/attributes.go
+++ b/pkg/tracing/meta/attributes.go
@@ -17,18 +17,19 @@ var Attrs = struct {
 	EndedAt   attr[*time.Time]
 
 	// Run attributes
-	AccountID       attr[*uuid.UUID]
-	AppID           attr[*uuid.UUID]
-	BatchID         attr[*ulid.ULID]
-	BatchTimestamp  attr[*time.Time]
-	CronSchedule    attr[*string]
-	DropSpan        attr[*bool]
-	EnvID           attr[*uuid.UUID]
-	EventIDs        attr[*[]string]
-	EventsInput     attr[*string]
-	FunctionID      attr[*uuid.UUID]
-	FunctionVersion attr[*int]
-	RunID           attr[*ulid.ULID]
+	AccountID           attr[*uuid.UUID]
+	AppID               attr[*uuid.UUID]
+	BatchID             attr[*ulid.ULID]
+	BatchTimestamp      attr[*time.Time]
+	CronSchedule        attr[*string]
+	DropSpan            attr[*bool]
+	EnvID               attr[*uuid.UUID]
+	EventIDs            attr[*[]string]
+	EventsInput         attr[*string]
+	TriggeringEventName attr[*string]
+	FunctionID          attr[*uuid.UUID]
+	FunctionVersion     attr[*int]
+	RunID               attr[*ulid.ULID]
 
 	// Dynamic span controls
 	DynamicSpanID attr[*string]
@@ -127,6 +128,7 @@ var Attrs = struct {
 	EnvID:                              UUIDAttr("env.id"),
 	EventIDs:                           StringSliceAttr("event.ids"),
 	EventsInput:                        StringAttr("events.input"),
+	TriggeringEventName:                StringAttr("event.trigger.name"),
 	FunctionID:                         UUIDAttr("function.id"),
 	FunctionVersion:                    IntAttr("function.version"),
 	InternalLocation:                   StringAttr("internal.location"),

--- a/pkg/tracing/meta/extracted_values_gen.go
+++ b/pkg/tracing/meta/extracted_values_gen.go
@@ -27,6 +27,7 @@ type ExtractedValues struct {
 	EnvID *uuid.UUID
 	EventIDs *[]string
 	EventsInput *string
+	TriggeringEventName *string
 	FunctionID *uuid.UUID
 	FunctionVersion *int
 	RunID *ulid.ULID


### PR DESCRIPTION
## Description

Cloud has a requirement whereby the event names are fetched from the runs list query and not from the event IDs. This means we also end up querying the entire event/batch input just to get this value.

For incoming tracing, let's not do that, and instead just persist the value here. In Cloud we'll pull this in to the table with a MV.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
