### PR TITLE
[Insights]: Display results history limit

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/insights/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/insights/page.tsx
@@ -1,17 +1,23 @@
 'use client';
 
 import { useState } from 'react';
+import { useQuery } from 'urql';
 
 import { useBooleanFlag } from '@/components/FeatureFlags/hooks';
 import { useInsightsTabManager } from '@/components/Insights/InsightsTabManager/InsightsTabManager';
 import { TabManagerProvider } from '@/components/Insights/InsightsTabManager/TabManagerContext';
 import { QueryHelperPanel } from '@/components/Insights/QueryHelperPanel/QueryHelperPanel';
 import { StoredQueriesProvider } from '@/components/Insights/QueryHelperPanel/StoredQueriesContext';
+import { GetAccountEntitlementsDocument } from '@/gql/graphql';
 
 function InsightsContent() {
   const [isQueryHelperPanelVisible, setIsQueryHelperPanelVisible] = useState(true);
 
+  const [{ data: entitlementsData }] = useQuery({ query: GetAccountEntitlementsDocument });
+  const historyWindow = entitlementsData?.account.entitlements.history.limit;
+
   const { actions, activeTabId, tabManager, tabs } = useInsightsTabManager({
+    historyWindow,
     isQueryHelperPanelVisible,
     onToggleQueryHelperPanelVisibility: () => setIsQueryHelperPanelVisible((visible) => !visible),
   });

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorResultsTitle.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorResultsTitle.tsx
@@ -2,15 +2,20 @@
 
 import { Pill } from '@inngest/components/Pill';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
-import { useQuery } from 'urql';
-
-import { GetAccountEntitlementsDocument } from '@/gql/graphql';
 
 const ROW_LIMIT = 1000;
 
-export function InsightsSQLEditorResultsTitle() {
-  const [{ data: entitlementsData }] = useQuery({ query: GetAccountEntitlementsDocument });
-  const historyWindow = entitlementsData?.account.entitlements.history.limit ?? 7;
+type InsightsSQLEditorResultsTitleProps = {
+  historyWindow?: number;
+};
+
+export function InsightsSQLEditorResultsTitle({
+  historyWindow,
+}: InsightsSQLEditorResultsTitleProps) {
+  const historyText = historyWindow ? `${historyWindow} days` : 'specified by plan';
+  const tooltipText = historyWindow
+    ? `Based on your plan, results are limited to the past ${historyWindow} days.`
+    : 'Historical data availability is specified by your plan.';
 
   return (
     <div className="mr-1 flex items-center gap-2">
@@ -31,12 +36,12 @@ export function InsightsSQLEditorResultsTitle() {
         <TooltipTrigger asChild>
           <span>
             <Pill appearance="outlined" kind="info">
-              History limit : {historyWindow} days
+              History limit : {historyText}
             </Pill>
           </span>
         </TooltipTrigger>
         <TooltipContent className="p-2 text-xs" side="bottom" sideOffset={3}>
-          Results are limited to the past {historyWindow} days based on your plan.
+          {tooltipText}
         </TooltipContent>
       </Tooltip>
     </div>

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorResultsTitle.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorResultsTitle.tsx
@@ -2,10 +2,16 @@
 
 import { Pill } from '@inngest/components/Pill';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Tooltip/Tooltip';
+import { useQuery } from 'urql';
+
+import { GetAccountEntitlementsDocument } from '@/gql/graphql';
 
 const ROW_LIMIT = 1000;
 
 export function InsightsSQLEditorResultsTitle() {
+  const [{ data: entitlementsData }] = useQuery({ query: GetAccountEntitlementsDocument });
+  const historyWindow = entitlementsData?.account.entitlements.history.limit ?? 7;
+
   return (
     <div className="mr-1 flex items-center gap-2">
       <span className="uppercase">Results</span>
@@ -17,8 +23,20 @@ export function InsightsSQLEditorResultsTitle() {
             </Pill>
           </span>
         </TooltipTrigger>
-        <TooltipContent className="p-2 text-xs" side="right" sideOffset={3}>
+        <TooltipContent className="p-2 text-xs" side="bottom" sideOffset={3}>
           Results are currently limited to at most {ROW_LIMIT} rows.
+        </TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span>
+            <Pill appearance="outlined" kind="info">
+              History limit : {historyWindow} days
+            </Pill>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className="p-2 text-xs" side="bottom" sideOffset={3}>
+          Results are limited to the past {historyWindow} days based on your plan.
         </TooltipContent>
       </Tooltip>
     </div>

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
@@ -29,6 +29,7 @@ export interface UseInsightsTabManagerReturn {
 }
 
 export interface UseInsightsTabManagerProps {
+  historyWindow?: number;
   isQueryHelperPanelVisible: boolean;
   onToggleQueryHelperPanelVisibility: () => void;
 }
@@ -110,6 +111,7 @@ export function useInsightsTabManager(
         actions={actions}
         activeTabId={activeTabId}
         tabs={tabs}
+        historyWindow={props.historyWindow}
         isQueryHelperPanelVisible={props.isQueryHelperPanelVisible}
         onToggleQueryHelperPanelVisibility={props.onToggleQueryHelperPanelVisibility}
       />
@@ -118,6 +120,7 @@ export function useInsightsTabManager(
       actions,
       activeTabId,
       tabs,
+      props.historyWindow,
       props.isQueryHelperPanelVisible,
       props.onToggleQueryHelperPanelVisibility,
     ]
@@ -129,6 +132,7 @@ export function useInsightsTabManager(
 interface InsightsTabManagerInternalProps {
   actions: TabManagerActions;
   activeTabId: string;
+  historyWindow?: number;
   isQueryHelperPanelVisible: boolean;
   onToggleQueryHelperPanelVisibility: () => void;
   tabs: Tab[];
@@ -138,6 +142,7 @@ function InsightsTabManagerInternal({
   tabs,
   activeTabId,
   actions,
+  historyWindow,
   isQueryHelperPanelVisible,
   onToggleQueryHelperPanelVisibility,
 }: InsightsTabManagerInternalProps) {
@@ -164,6 +169,7 @@ function InsightsTabManagerInternal({
               isHomeTab={tab.id === HOME_TAB.id}
               isTemplatesTab={tab.id === TEMPLATES_TAB.id}
               tab={tab}
+              historyWindow={historyWindow}
             />
           </InsightsStateMachineContextProvider>
         ))}

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanel.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanel.tsx
@@ -16,12 +16,18 @@ import { InsightsTabPanelTemplatesTab } from './InsightsTabPanelTemplatesTab/Ins
 import { EXTERNAL_FEEDBACK_LINK } from './constants';
 
 type InsightsTabPanelProps = {
+  historyWindow?: number;
   isHomeTab?: boolean;
   isTemplatesTab?: boolean;
   tab: Tab;
 };
 
-export function InsightsTabPanel({ isHomeTab, isTemplatesTab, tab }: InsightsTabPanelProps) {
+export function InsightsTabPanel({
+  historyWindow,
+  isHomeTab,
+  isTemplatesTab,
+  tab,
+}: InsightsTabPanelProps) {
   const { status } = useInsightsStateMachineContext();
   const isRunning = status === 'loading';
 
@@ -55,7 +61,7 @@ export function InsightsTabPanel({ isHomeTab, isTemplatesTab, tab }: InsightsTab
           </>
         }
         className="border-subtle border-t"
-        title={<InsightsSQLEditorResultsTitle />}
+        title={<InsightsSQLEditorResultsTitle historyWindow={historyWindow} />}
       >
         <InsightsDataTable />
       </Section>


### PR DESCRIPTION
## Description

This shows a pill alongside the row limit pill to let users know that their results are limited based on their plan.

---

**_haven't heard back (yet) about plan entitlements:_**

<img width="455" height="104" alt="Screenshot 2025-09-22 at 12 51 06 PM" src="https://github.com/user-attachments/assets/0b35419c-a76f-40fe-bf6c-7ecde191ab0e" />

---

**_have heard back about plan entitlements:_**

<img width="466" height="139" alt="Screenshot 2025-09-22 at 12 50 41 PM" src="https://github.com/user-attachments/assets/c1f9e4a1-04ab-4c1a-92a7-f332158a8e4a" />


## Motivation

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
