### PR TITLE
[Insights]: Remove GQL prefix from visible error messages

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsDataTable/states/ErrorState.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsDataTable/states/ErrorState.tsx
@@ -24,7 +24,11 @@ export function ErrorState() {
       }
       severity="error"
     >
-      {error?.message ?? FALLBACK_ERROR}
+      {error ? pruneGraphQLError(error) : FALLBACK_ERROR}
     </Banner>
   );
+}
+
+function pruneGraphQLError(error: Error) {
+  return error.message.replace(/^\[GraphQL\] /, '');
 }


### PR DESCRIPTION
## Description

This removes the implementation detail that we're using GQL in visible error messages on query runs.

---

**_Before:_**

<img width="385" height="36" alt="Screenshot 2025-09-22 at 2 04 32 PM" src="https://github.com/user-attachments/assets/ef3d7ce7-cf03-4a90-9f44-4c506d8a08bd" />

**_After:_**

<img width="315" height="33" alt="Screenshot 2025-09-22 at 2 04 02 PM" src="https://github.com/user-attachments/assets/626ee02f-3d1c-48cb-a7be-3e225b5febb7" />


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
