### PR TITLE
[Insights]: Revise query templates

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/templates.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/templates.ts
@@ -55,22 +55,11 @@ const RECENT_CANCELLED_FUNCTION_COUNT = makeFunctionStatusQuery('cancelled');
 // TODO: Add this back if a clear, reliable pattern for determining successes emerges.
 // const RECENT_SUCCESSFUL_FUNCTION_COUNT = makeFunctionStatusQuery('finished');
 
-const RECENT_EVENTS_QUERY = `SELECT 
-    toDateTime(ts / 1000) AS timestamp,
-    id,
-    name,
-    data,
-    v
-FROM 
-    events 
-ORDER BY 
-    timestamp DESC`;
-
 export const TEMPLATES: QueryTemplate[] = [
   {
     id: 'recent-events',
     name: 'Recent events',
-    query: RECENT_EVENTS_QUERY,
+    query: 'SELECT * FROM events',
     explanation: 'View recents events subject to row and plan history limit restrictions.',
     templateKind: 'time',
   },


### PR DESCRIPTION
## Description

This PR makes two changes:
- enriches the `SELECT * FROM events` query to be ordered by descending timestamp
- removes `RECENT_SUCCESSFUL_FUNCTION_COUNT` due to possible imperfect "success" clause
  - this one may need more investigation 

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
