### PR TITLE
Insights templates - use milli functions directly

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/templates.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/templates.ts
@@ -2,13 +2,15 @@ import type { QueryTemplate } from '@/components/Insights/types';
 
 function makeEventVolumePerHourQuery(event?: string) {
   return `SELECT
-    toStartOfHour(toDateTime(ts / 1000)) AS hour_bucket,
+    toStartOfHour(fromUnixTimestamp64Milli(ts)) AS hour_bucket,
     name,
     COUNT(*) AS event_count
 FROM
     events
 WHERE
-    ts > toUnixTimestamp(subtractDays(now(), 3)) * 1000${event ? `\n    AND name = '${event}'` : ''}
+    ts > toUnixTimestamp64Milli(subtractDays(now64(), 3))${
+      event ? `\n    AND name = '${event}'` : ''
+    }
 GROUP BY
     hour_bucket,
     name
@@ -42,7 +44,7 @@ WHERE
       : '';
 
   return `${base}${successFilter}
-    AND ts > toUnixTimestamp(addDays(now(), -1)) * 1000
+    AND ts > toUnixTimestamp64Milli(subtractDays(now64(), 1))
 GROUP BY
     function_id
 ORDER BY


### PR DESCRIPTION
## Description

We can use Milli functions directly instead of doing math, but that also requires using now64

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
