### PR TITLE
Do not disable bypass protection form

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/configure/[id]/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/settings/integrations/vercel/configure/[id]/page.tsx
@@ -270,10 +270,7 @@ export default function VercelConfigure() {
               </div>
               <div className="flex flex-row gap-4">
                 <div
-                  className={`border-subtle mt-4 flex w-full flex-col gap-2 rounded-md border p-6 ${
-                    project.deploymentProtection === VercelDeploymentProtection.Disabled &&
-                    'bg-disabled'
-                  }`}
+                  className={`border-subtle mt-4 flex w-full flex-col gap-2 rounded-md border p-6`}
                 >
                   <div className="text-basis text-lg font-medium">Deployment protection key</div>
                   <div className="text-muted text-base font-normal">
@@ -287,11 +284,7 @@ export default function VercelConfigure() {
                     </Link>
                   </div>
                   <Input
-                    className={`text-basis mt-4 h-10 px-2 py-2 text-base ${
-                      project.deploymentProtection === VercelDeploymentProtection.Disabled &&
-                      'border-subtle bg-disabled'
-                    }`}
-                    readOnly={project.deploymentProtection === VercelDeploymentProtection.Disabled}
+                    className={`text-basis mt-4 h-10 px-2 py-2 text-base`}
                     onChange={({ target: { value } }) =>
                       setProject({ ...project, protectionBypassSecret: value })
                     }


### PR DESCRIPTION
## Description
There are cases where the user should be able to edit this without us locking down and disabling this form (see motivation). Let's not ever disable this form.


## Motivation
Users with advanced deployment protection using "Password Protection" on Vercel reported not being able to edit this to enable bypass protection. The field that we're using to check deployment protection is different than the password protection.

https://app.plain.com/workspace/w_01H5R1F69XQ35G4P7THFQGN5KB/thread/th_01K5DAWDGN1684YY233M1A35Z6

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
