### PR TITLE
fix hanging invoke runs when retrying from i/o timeouts

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -713,9 +713,10 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	}
 
 	st, err := e.smv2.Create(ctx, newState)
-	switch err {
-	case nil, state.ErrIdentifierExists: // no-op
-	case state.ErrIdentifierTomestone:
+	switch {
+	case err == nil: // no-op
+	case errors.Is(err, state.ErrIdentifierExists): // no-op
+	case errors.Is(err, state.ErrIdentifierTomestone):
 		return nil, ErrFunctionSkippedIdempotency
 	default:
 		return nil, fmt.Errorf("error creating run state: %w", err)


### PR DESCRIPTION
## Description

Fixes hanging invokes that get retried because of MDB i/o timeouts. This was a state proxy issue where ErrIdentifierExists was returned wrapped to the Schedule function while we are doing exact error matching instead of using errors.Is. I fixed both, made it use errors.Is just in case we encounter this issue again and also correctly unwrapped the error from the state proxy client.



## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
