### PR TITLE
CON-388 Return internal events on event types events page

### DIFF
--- a/ui/packages/components/src/Events/EventsTable.tsx
+++ b/ui/packages/components/src/Events/EventsTable.tsx
@@ -141,7 +141,7 @@ export function EventsTable({
         startTime: calculatedStartTime.toISOString(),
         endTime: endTime ?? null,
         celQuery: search,
-        includeInternalEvents: includeInternalEvents ?? false,
+        includeInternalEvents: singleEventTypePage || (includeInternalEvents ?? false),
       },
     ],
     queryFn: ({ pageParam }: { pageParam: string | null }) =>
@@ -152,7 +152,7 @@ export function EventsTable({
         startTime: calculatedStartTime.toISOString(),
         endTime: endTime ?? null,
         celQuery: search,
-        includeInternalEvents,
+        includeInternalEvents: singleEventTypePage || (includeInternalEvents ?? false),
       }),
     getNextPageParam: (lastPage) => {
       if (!lastPage || !lastPage.pageInfo.hasNextPage) {


### PR DESCRIPTION
## Description
- Ensure that we return internal events if the `<EventsPage>` is rendered inside the event types page (`singleEventTypePage == true`).
## Motivation
Fixes regression introduced in https://github.com/inngest/inngest/pull/2990

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
