### PR TITLE
Track EventID idempotence across batches

### DIFF
--- a/pkg/execution/batch/batch_test.go
+++ b/pkg/execution/batch/batch_test.go
@@ -163,13 +163,13 @@ func TestBatchAppendIdempotenceDifferentBatches(t *testing.T) {
 		lastBatchID = res.BatchID
 	}
 
-	// append the last batchitem again. Since last batch was full, this event goes to a new batch and ends up getting appended to a batch.
+	// Append the last batchitem again. This should be rejected from the next batch.
 	res, err := bm.Append(context.Background(), bi, function)
 	require.NoError(t, err)
 	require.NotEmpty(t, res.BatchID)
 	require.NotEqual(t, res.BatchID, lastBatchID)
 	require.NotEmpty(t, res.BatchPointerKey)
-	require.Equal(t, enums.BatchNew, res.Status)
+	require.Equal(t, enums.BatchItemExists, res.Status)
 }
 
 func TestBatchCleanup(t *testing.T) {
@@ -211,15 +211,22 @@ func TestBatchCleanup(t *testing.T) {
 	require.True(t, r.Exists(bc.KeyGenerator().Batch(context.Background(), fnId, ulid.MustParse(res.BatchID))))
 	require.True(t, r.Exists(bc.KeyGenerator().BatchMetadata(context.Background(), fnId, ulid.MustParse(res.BatchID))))
 	require.True(t, r.Exists(bc.KeyGenerator().BatchPointer(context.Background(), fnId)))
-	require.True(t, r.Exists(bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId, ulid.MustParse(res.BatchID))))
+	require.True(t, r.Exists(bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)))
 	require.Equal(t, 4, len(r.Keys()))
 
+	bm = NewRedisBatchManager(bc, nil, WithRedisBatchIdempotenceSetCleanupCutoff(200))
 	err = bm.DeleteKeys(context.Background(), fnId, ulid.MustParse(res.BatchID))
 	require.NoError(t, err)
 
 	require.False(t, r.Exists(bc.KeyGenerator().Batch(context.Background(), fnId, ulid.MustParse(res.BatchID))))
 	require.False(t, r.Exists(bc.KeyGenerator().BatchMetadata(context.Background(), fnId, ulid.MustParse(res.BatchID))))
-	require.False(t, r.Exists(bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId, ulid.MustParse(res.BatchID))))
+	require.True(t, r.Exists(bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)))
 	require.True(t, r.Exists(bc.KeyGenerator().BatchPointer(context.Background(), fnId)))
+	require.Equal(t, 2, len(r.Keys()))
+
+	bm = NewRedisBatchManager(bc, nil, WithRedisBatchIdempotenceSetCleanupCutoff(0))
+	err = bm.DeleteKeys(context.Background(), fnId, ulid.MustParse(res.BatchID))
+	require.NoError(t, err)
+	require.False(t, r.Exists(bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)))
 	require.Equal(t, 1, len(r.Keys()))
 }

--- a/pkg/execution/batch/lua/drop_keys.lua
+++ b/pkg/execution/batch/lua/drop_keys.lua
@@ -2,6 +2,11 @@
 --- Deletes the provided keys
 ---
 
+local batchIdempotenceKey = ARGV[1] -- This key contains all event IDs that were appended for this function
+local maxScoreToDrop = ARGV[2] -- This key denotes max score to drop from the idempotence set
+
+redis.call("ZREMRANGEBYSCORE", batchIdempotenceKey, "-inf", maxScoreToDrop)
+
 for i, key in ipairs(KEYS) do
   if i > 0 then
     redis.call("DEL", key)

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -552,8 +552,8 @@ type BatchKeyGenerator interface {
 	// events, that is used to trigger a function run
 	Batch(ctx context.Context, functionId uuid.UUID, batchId ulid.ULID) string
 	// BatchIdempotenceKey returns the key used to store the specific batch of
-	// events, that is used to check if a batch event has already been appended to a batch.
-	BatchIdempotenceKey(ctx context.Context, functionId uuid.UUID, batchId ulid.ULID) string
+	// events, that is used to check if a batch event has already been appended for a function
+	BatchIdempotenceKey(ctx context.Context, functionId uuid.UUID) string
 	// BatchMetadata returns the key used to store the metadata related
 	// to a batch
 	BatchMetadata(ctx context.Context, functionId uuid.UUID, batchId ulid.ULID) string
@@ -587,8 +587,8 @@ func (u batchKeyGenerator) Batch(ctx context.Context, functionId uuid.UUID, batc
 	return fmt.Sprintf("{%s}:batches:%s", u.PrefixByFunctionId(ctx, u.queueDefaultKey, true, functionId), batchID)
 }
 
-func (u batchKeyGenerator) BatchIdempotenceKey(ctx context.Context, functionId uuid.UUID, batchID ulid.ULID) string {
-	return fmt.Sprintf("{%s}:batch_idempotence:%s", u.PrefixByFunctionId(ctx, u.queueDefaultKey, true, functionId), batchID)
+func (u batchKeyGenerator) BatchIdempotenceKey(ctx context.Context, functionId uuid.UUID) string {
+	return fmt.Sprintf("{%s}:batch_idempotence", u.PrefixByFunctionId(ctx, u.queueDefaultKey, true, functionId))
 }
 
 func (u batchKeyGenerator) BatchMetadata(ctx context.Context, functionId uuid.UUID, batchID ulid.ULID) string {


### PR DESCRIPTION
## Description

Track EventID idempotence across batches. With this change we will continue to keep track of recent eventIDs that went into any batch for a function from the last 2 minutes to guard against reprocessing events due to transient network issues 

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
