### PR TITLE
prevent infinite loop in scanning pauses edge case

### DIFF
--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -1668,6 +1668,12 @@ func (i *scanIter) fetch(ctx context.Context) error {
 		if len(i.vals.Elements) > 0 {
 			return nil
 		}
+
+		// Prevent starting a new iteration, otherwise we risk an infinite loop if the data isn't changing
+		// and we get an empty scan with a 0 cursor which is actually possible in Redis.
+		if i.cursor == 0 {
+			return errScanDone
+		}
 	}
 
 	return fmt.Errorf("Scanned max times without finding pause values")


### PR DESCRIPTION


## Description
Redis can return consistent cursors if the data remains unchanged, which can cause an infinite loop with how we currently iterate.

This edge case scenario happens when:

- A valid non-zero cursor is returned.
- Calling HSCAN with that cursor yields no results but returns a zero cursor.

Even though the scan is considered complete at that point, the loop continued scanning with the new zero cursor, starting a new iteration indefinitely. The loop only ended if Redis’s internal hash buckets changed, which never happened in Coco AI’s "checkout/abandoned" event case.



## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
