### PR TITLE
Fix some odd queue times in incoming tracing

### DIFF
--- a/pkg/coreapi/gqlgen.yml
+++ b/pkg/coreapi/gqlgen.yml
@@ -1,5 +1,5 @@
 schema:
- - "pkg/coreapi/*.graphql"
+  - "pkg/coreapi/*.graphql"
 
 exec:
   filename: pkg/coreapi/generated/generated.go
@@ -53,8 +53,8 @@ models:
         resolver: true
       runs:
         resolver: true
-#      source:
-#        resolver: true
+  #      source:
+  #        resolver: true
   Function:
     fields:
       app:
@@ -103,6 +103,8 @@ models:
     fields:
       totalCount:
         resolver: true
+  RunTraceSpan:
+    model: github.com/inngest/inngest/pkg/coreapi/graph/models.RunTraceSpan
   HistoryType:
     model: github.com/inngest/inngest/pkg/enums.HistoryType
   HistoryStepType:

--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -308,6 +308,7 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 		gqlSpan.ChildrenSpans = []*models.RunTraceSpan{}
 		lastStepQueueTime := &gqlSpan.QueuedAt
 		isFirstChild := true
+		haveSetRunStartTime := span.Name != meta.SpanNameRun
 
 		for i, cs := range span.Children {
 			child, err := tr.convertRunSpanToGQL(ctx, cs)
@@ -318,6 +319,19 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 			// We could also not have a child, for example if we're
 			// intentionally skipping it
 			if child == nil {
+				continue
+			}
+
+			if child.Omit {
+				// We're skipping this child, but we may still want to use
+				// its data for timings.
+				if child.SpanTypeName == meta.SpanNameStepDiscovery && !haveSetRunStartTime {
+					// Discovery spans can be used to set the start time of
+					// the step if it's the first child.
+					gqlSpan.StartedAt = child.StartedAt
+					haveSetRunStartTime = true
+				}
+
 				continue
 			}
 
@@ -336,7 +350,6 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 						}
 
 						hasFinalizationChild = true
-
 					}
 				}
 			case meta.SpanNameStepDiscovery, meta.SpanNameStep:
@@ -392,7 +405,10 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 
 		// For the run span, the start is the first child span's start
 		if span.Name == meta.SpanNameRun && len(gqlSpan.ChildrenSpans) > 0 {
-			gqlSpan.StartedAt = &gqlSpan.ChildrenSpans[0].QueuedAt
+			if !haveSetRunStartTime && gqlSpan.ChildrenSpans[0].StartedAt != nil {
+				gqlSpan.StartedAt = gqlSpan.ChildrenSpans[0].StartedAt
+			}
+
 			if gqlSpan.EndedAt != nil {
 				dur := int(gqlSpan.EndedAt.Sub(*gqlSpan.StartedAt).Milliseconds())
 				gqlSpan.Duration = &dur
@@ -432,7 +448,7 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 	}
 
 	if !showSpan {
-		return nil, nil
+		gqlSpan.Omit = true
 	}
 
 	if gqlSpan.Name == FinalizationSpanName {

--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -209,6 +209,8 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 		DebugRunID:     debugRunID,
 		DebugSessionID: debugSessionID,
 
+		SpanTypeName: span.Name,
+
 		// IsUserland: , TODO
 		// UserlandSpan: , TODO
 	}

--- a/pkg/coreapi/graph/models/augmented.go
+++ b/pkg/coreapi/graph/models/augmented.go
@@ -1,5 +1,12 @@
 package models
 
+import (
+	"time"
+
+	"github.com/google/uuid"
+	ulid "github.com/oklog/ulid/v2"
+)
+
 type WorkerConnectionsConnection struct {
 	Edges    []*ConnectV1WorkerConnectionEdge `json:"edges"`
 	PageInfo *PageInfo                        `json:"pageInfo"`
@@ -12,8 +19,42 @@ type WorkerConnectionsConnection struct {
 type RunsV2Connection struct {
 	Edges    []*FunctionRunV2Edge `json:"edges"`
 	PageInfo *PageInfo            `json:"pageInfo"`
- 
+
 	After   *string
 	Filter  RunsFilterV2
 	OrderBy []*RunsV2OrderBy
+}
+
+type RunTraceSpan struct {
+	AppID          uuid.UUID          `json:"appID"`
+	FunctionID     uuid.UUID          `json:"functionID"`
+	RunID          ulid.ULID          `json:"runID"`
+	Run            *FunctionRun       `json:"run"`
+	SpanID         string             `json:"spanID"`
+	TraceID        string             `json:"traceID"`
+	Name           string             `json:"name"`
+	Status         RunTraceSpanStatus `json:"status"`
+	Attempts       *int               `json:"attempts,omitempty"`
+	Duration       *int               `json:"duration,omitempty"`
+	OutputID       *string            `json:"outputID,omitempty"`
+	QueuedAt       time.Time          `json:"queuedAt"`
+	StartedAt      *time.Time         `json:"startedAt,omitempty"`
+	EndedAt        *time.Time         `json:"endedAt,omitempty"`
+	ChildrenSpans  []*RunTraceSpan    `json:"childrenSpans"`
+	StepOp         *StepOp            `json:"stepOp,omitempty"`
+	StepID         *string            `json:"stepID,omitempty"`
+	StepInfo       StepInfo           `json:"stepInfo,omitempty"`
+	StepType       string             `json:"stepType"`
+	IsRoot         bool               `json:"isRoot"`
+	ParentSpanID   *string            `json:"parentSpanID,omitempty"`
+	ParentSpan     *RunTraceSpan      `json:"parentSpan,omitempty"`
+	IsUserland     bool               `json:"isUserland"`
+	UserlandSpan   *UserlandSpan      `json:"userlandSpan,omitempty"`
+	DebugRunID     *ulid.ULID         `json:"debugRunID,omitempty"`
+	DebugSessionID *ulid.ULID         `json:"debugSessionID,omitempty"`
+	DebugPaused    bool               `json:"debugPaused"`
+
+	// Internal fields not exposed over GraphQL.
+	SpanTypeName string
+	Omit         bool
 }

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -371,36 +371,6 @@ type RunStepInfo struct {
 
 func (RunStepInfo) IsStepInfo() {}
 
-type RunTraceSpan struct {
-	AppID          uuid.UUID          `json:"appID"`
-	FunctionID     uuid.UUID          `json:"functionID"`
-	RunID          ulid.ULID          `json:"runID"`
-	Run            *FunctionRun       `json:"run"`
-	SpanID         string             `json:"spanID"`
-	TraceID        string             `json:"traceID"`
-	Name           string             `json:"name"`
-	Status         RunTraceSpanStatus `json:"status"`
-	Attempts       *int               `json:"attempts,omitempty"`
-	Duration       *int               `json:"duration,omitempty"`
-	OutputID       *string            `json:"outputID,omitempty"`
-	QueuedAt       time.Time          `json:"queuedAt"`
-	StartedAt      *time.Time         `json:"startedAt,omitempty"`
-	EndedAt        *time.Time         `json:"endedAt,omitempty"`
-	ChildrenSpans  []*RunTraceSpan    `json:"childrenSpans"`
-	StepOp         *StepOp            `json:"stepOp,omitempty"`
-	StepID         *string            `json:"stepID,omitempty"`
-	StepInfo       StepInfo           `json:"stepInfo,omitempty"`
-	StepType       string             `json:"stepType"`
-	IsRoot         bool               `json:"isRoot"`
-	ParentSpanID   *string            `json:"parentSpanID,omitempty"`
-	ParentSpan     *RunTraceSpan      `json:"parentSpan,omitempty"`
-	IsUserland     bool               `json:"isUserland"`
-	UserlandSpan   *UserlandSpan      `json:"userlandSpan,omitempty"`
-	DebugRunID     *ulid.ULID         `json:"debugRunID,omitempty"`
-	DebugSessionID *ulid.ULID         `json:"debugSessionID,omitempty"`
-	DebugPaused    bool               `json:"debugPaused"`
-}
-
 type RunTraceSpanOutput struct {
 	Input *string    `json:"input,omitempty"`
 	Data  *string    `json:"data,omitempty"`


### PR DESCRIPTION
## Description

Fixes some timing issues in the tracing roll-ups where we're not correctly using the timings of child spans when setting them for the overall run.

### Discovery step that becomes a step

Notice that before the start of the run would be incorrectly marked as the queuing of the initial discovery step, which happens immediately, following #2918.

We now mark both spans as queued until they are started properly in the discovery span's execution.

| ![Single step before](https://github.com/user-attachments/assets/2239ef21-f619-44a1-8a8a-d1a46b4bfed9) | ![Single step after](https://github.com/user-attachments/assets/8959b796-cc4a-4381-ae38-9a524acb1e70) |
| - | - |
| Before | After |

### Discovery step that is hidden

When performing parallel flows, discovery steps are hidden.

As a result of this fix, the hidden discovery now shows a gap before the steps themselves are queued; this is the discovery request itself being queued and executed under the hood.

We can, in another PR, mark this as part of "queued" as it was before, though this actually gives us a good opportunity to design how these gaps should be represented.

| ![Hidden discovery before](https://github.com/user-attachments/assets/4175aa6b-7717-4840-9aec-dc2e84d6d580) | ![Hidden discovery after](https://github.com/user-attachments/assets/c3a22d3c-0b6d-4cfe-8314-70060a1e0f81) |
| - | - |
| Before | After |

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Related

- Extra fixes following changes in #2918 to support gateways

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
