### PR TITLE
Fix a typo in the sync reply

### DIFF
--- a/pkg/cqrs/sync/sync.go
+++ b/pkg/cqrs/sync/sync.go
@@ -8,7 +8,7 @@ type Reply struct {
 	Modified bool       `json:"modified"`
 	Message  *string    `json:"message,omitempty"`
 	Error    *string    `json:"error,omitempty"`
-	SyncID   *uuid.UUID `json:"sync_id.omitempty"`
+	SyncID   *uuid.UUID `json:"sync_id,omitempty"`
 	AppID    *uuid.UUID `json:"app_id,omitempty"`
 }
 


### PR DESCRIPTION
## Description

Field name was accidentally `sync_id.omitempty`.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
