### PR TITLE
Don't close channel to avoid "send on closed channel" panic

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -895,7 +895,8 @@ func (c *connectionHandler) receiveRouterMessagesFromGRPC(ctx context.Context, o
 	// Ensure cleanup when function exits
 	defer func() {
 		c.svc.wsConnections.Delete(connectionID)
-		close(messageChan)
+		// NOTE: To avoid panics due to sending on a closed channel, we do not close the message channel
+		// and instead let the gc reclaim it once no more goroutine is sending to it
 	}()
 
 	close(onSubscribed)


### PR DESCRIPTION
## Description

This tiny change removes our channel close, as there may be goroutines actively writing to it. If the reader goes away and the channel starts blocking, we will circuit break the operation after five seconds. After the channel is no longer used, the garbage collector should reclaim its memory.

This fixes the "send on closed channel" panic, which was caused due to data races where we concurrently closed the channel while the gRPC client/server received a message or response and attempted to send a message through the closing channel.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
