### PR TITLE
[Insights]: Modify background color of suggestions popover widget

### DIFF
--- a/ui/packages/components/src/utils/monaco.ts
+++ b/ui/packages/components/src/utils/monaco.ts
@@ -83,6 +83,7 @@ export const createColors = (isDark: boolean) => ({
   'editorLineNumber.activeForeground': resolveColor(textColor.basis, isDark),
   'editorWidget.background': resolveColor(backgroundColor.codeEditor, isDark),
   'editorWidget.border': resolveColor(borderColor.subtle, isDark),
+  'editorSuggestWidget.background': resolveColor(backgroundColor.modalBase, isDark),
   'editorBracketHighlight.foreground1': resolveColor(textColor.codeDelimiterBracketJson, isDark),
   'editorBracketHighlight.foreground2': resolveColor(textColor.codeDelimiterBracketJson, isDark),
   'editorBracketHighlight.foreground3': resolveColor(textColor.codeDelimiterBracketJson, isDark),


### PR DESCRIPTION
## Description

This addresses a design request to better differentiate the autosuggest popup from the editor background.

---

<img width="489" height="118" alt="Screenshot 2025-10-02 at 1 20 43 PM" src="https://github.com/user-attachments/assets/4cf9b13b-4cf2-4ea4-94e3-79c50c400bb1" />

---

<img width="486" height="124" alt="Screenshot 2025-10-02 at 1 21 03 PM" src="https://github.com/user-attachments/assets/421be7a2-1979-45fb-bf67-534c05904616" />


## Motivation

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
