### PR TITLE
fix: enable environment variable configuration for connect gRPC ports

### DIFF
--- a/pkg/config/connect/executor.go
+++ b/pkg/config/connect/executor.go
@@ -3,11 +3,17 @@ package connect
 import (
 	"context"
 	"net"
+	"strings"
 	"sync"
 
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/spf13/viper"
 )
+
+func init() {
+	viper.AutomaticEnv()
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+}
 
 type ConnectExecutor struct {
 	GRPCIP   net.IP

--- a/pkg/config/connect/gateway.go
+++ b/pkg/config/connect/gateway.go
@@ -3,11 +3,17 @@ package connect
 import (
 	"context"
 	"net"
+	"strings"
 	"sync"
 
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/spf13/viper"
 )
+
+func init() {
+	viper.AutomaticEnv()
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+}
 
 type ConnectGateway struct {
 	// To be used only by the connect-gateway service. Executors will get the IPs dynamically


### PR DESCRIPTION
The connect gateway and executor gRPC ports are currently hardcoded to 50052 and 50053, making it impossible to run multiple Inngest dev servers in parallel (e.g., for isolated integration testing).

While the configuration keys `connect.gateway.grpc.port` and `connect.executor.grpc.port` exist, the underlying viper instances were never initialized to read environment variables, making them effectively unconfigurable.

## Solution

This PR adds the missing viper initialization to enable environment variable configuration:

- `CONNECT_GATEWAY_GRPC_PORT` → `connect.gateway.grpc.port`
- `CONNECT_EXECUTOR_GRPC_PORT` → `connect.executor.grpc.port`
- `CONNECT_GATEWAY_GRPC_IP` → `connect.gateway.grpc.ip`
- `CONNECT_EXECUTOR_GRPC_IP` → `connect.executor.grpc.ip`

## Changes

- Added \`viper.AutomaticEnv()\` and \`viper.SetEnvKeyReplacer()\` to both connect config files
- Added missing \`strings\` import

## Testing

### Before (ports hardcoded):
```bash
CONNECT_GATEWAY_GRPC_PORT=12345 npx inngest dev
# Gateway still binds to 50052, executor to 50053
```

### After (ports configurable):
```bash
CONNECT_GATEWAY_GRPC_PORT=12345 CONNECT_EXECUTOR_GRPC_PORT=12346 npx inngest dev  
# Gateway binds to 12345, executor to 12346
```

## Use Case

This enables running multiple isolated Inngest dev servers for parallel integration testing, which is currently impossible due to hardcoded gRPC port conflicts."