### PR TITLE
Fix missing GROUP BY columns in Postgres queries

### DIFF
--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
@@ -391,7 +391,7 @@ SELECT
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST($1 AS CHAR(26))
-GROUP BY dynamic_span_id
+GROUP BY run_id, trace_id, dynamic_span_id
 ORDER BY start_time;
 
 -- name: GetSpansByDebugRunID :many
@@ -413,7 +413,7 @@ SELECT
   )) AS span_fragments
 FROM spans
 WHERE debug_run_id = CAST($1 AS CHAR(26))
-GROUP BY dynamic_span_id
+GROUP BY trace_id, run_id, debug_session_id, dynamic_span_id
 ORDER BY start_time;
 
 -- name: GetSpansByDebugSessionID :many
@@ -435,7 +435,7 @@ SELECT
   )) AS span_fragments
 FROM spans
 WHERE debug_session_id = CAST($1 AS CHAR(26))
-GROUP BY dynamic_span_id
+GROUP BY trace_id, run_id, debug_run_id, dynamic_span_id
 ORDER BY start_time;
 
 

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql.go
@@ -1086,7 +1086,7 @@ SELECT
   )) AS span_fragments
 FROM spans
 WHERE debug_run_id = CAST($1 AS CHAR(26))
-GROUP BY dynamic_span_id
+GROUP BY trace_id, run_id, debug_session_id, dynamic_span_id
 ORDER BY start_time
 `
 
@@ -1152,7 +1152,7 @@ SELECT
   )) AS span_fragments
 FROM spans
 WHERE debug_session_id = CAST($1 AS CHAR(26))
-GROUP BY dynamic_span_id
+GROUP BY trace_id, run_id, debug_run_id, dynamic_span_id
 ORDER BY start_time
 `
 
@@ -1217,7 +1217,7 @@ SELECT
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST($1 AS CHAR(26))
-GROUP BY dynamic_span_id
+GROUP BY run_id, trace_id, dynamic_span_id
 ORDER BY start_time
 `
 


### PR DESCRIPTION
## Description
Fix queries failing due to missing `GROUP BY` columns. This only affected the Dev Server when Postgres was its DB

## Motivation
https://linear.app/inngest/issue/EXE-269/postgres-queries-fail-due-to-missing-group-by-columns

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
