### PR TITLE
chore: Clarify ErrDenied to include timeout as a cause

### DIFF
--- a/pkg/execution/exechttp/exechttp.go
+++ b/pkg/execution/exechttp/exechttp.go
@@ -28,7 +28,7 @@ const (
 
 var (
 	ErrUnableToReach       = fmt.Errorf("Unable to reach SDK URL")
-	ErrDenied              = fmt.Errorf("Your server blocked the connection") // "connection timed out"
+	ErrDenied              = fmt.Errorf("Your server connection experienced a timeout or was blocked") // "connection timed out"
 	ErrServerClosed        = fmt.Errorf("Your server closed the request before finishing.")
 	ErrConnectionReset     = fmt.Errorf("Your server reset the connection while we were sending the request.")
 	ErrUnexpectedEnd       = fmt.Errorf("Your server reset the connection while we were reading the reply: Unexpected ending response")


### PR DESCRIPTION
## Description
This modifies the ErrDenied message to include `timeout` as a possible cause.

## Motivation
This should help clarify to users specifically what the underlying failure is in the case of a connection timeout/firewall configuration issue.
https://linear.app/inngest/issue/EXE-198/update-executor-timeout-error-message

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
