### PR TITLE
fix: show error on function runs page instead of no results on error

### DIFF
--- a/ui/apps/dashboard/src/components/Runs/Runs.tsx
+++ b/ui/apps/dashboard/src/components/Runs/Runs.tsx
@@ -221,6 +221,7 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
       scope={scope}
       totalCount={totalCount}
       searchError={searchError}
+      error={nextPageRes.error || firstPageRes.error}
       infiniteScrollTrigger={
         <InfiniteScrollTrigger
           onIntersect={loadMore}

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -62,6 +62,7 @@ type Props = {
   scope: ViewScope;
   totalCount: number | undefined;
   searchError?: Error;
+  error?: Error | null;
   infiniteScrollTrigger?: React.ReactNode;
 };
 
@@ -82,6 +83,7 @@ export function RunsPage({
   scope,
   totalCount,
   searchError,
+  error,
   infiniteScrollTrigger,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -375,6 +377,8 @@ export function RunsPage({
         <RunsTable
           data={data}
           isLoading={isLoadingInitial}
+          error={error}
+          onRefresh={onRefresh}
           renderSubComponent={renderSubComponent}
           getRowCanExpand={() => true}
           visibleColumns={columnVisibility}
@@ -392,7 +396,7 @@ export function RunsPage({
             />
           </div>
         )}
-        {onRefresh && (
+        {onRefresh && !error && (
           <div className="flex flex-col items-center pt-2">
             <Button
               kind="secondary"


### PR DESCRIPTION
## Description

CEL search on function runs page times out and shows no results. Should show error instead.
## Current
<img width="1777" height="1195" alt="Screenshot 2025-10-09 at 2 01 24 PM" src="https://github.com/user-attachments/assets/12527552-0d66-4a6a-9734-230899b87e21" />

## Updated
<img width="1777" height="1195" alt="Screenshot 2025-10-09 at 1 49 03 PM" src="https://github.com/user-attachments/assets/e65c1307-5205-48ef-9de6-bd94a61d02b9" />

## Motivation
Better UX

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
