### PR TITLE
also run any global precommit hooks before running our husky ones

### DIFF
--- a/ui/.husky/pre-commit
+++ b/ui/.husky/pre-commit
@@ -1,5 +1,22 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# 
+# detect any global precommit hooks and run those before running ours
+GLOBAL_HOOKS_PATH=$(git config --global core.hooksPath)
+
+if [ -n "$GLOBAL_HOOKS_PATH" ]; then
+  GLOBAL_PRECOMMIT="$GLOBAL_HOOKS_PATH/pre-commit"
+  if [ -x "$GLOBAL_PRECOMMIT" ]; then
+    echo "Running user global pre-commit hook at $GLOBAL_PRECOMMIT..."
+    "$GLOBAL_PRECOMMIT"
+    STATUS=$?
+    if [ $STATUS -ne 0 ]; then
+      echo "❌ Global pre-commit hook failed. Aborting commit."
+      exit $STATUS
+    fi
+  fi
+fi
+
 cd ui/
 npx lint-staged


### PR DESCRIPTION
## Description

I have some global precommit hooks that are getting stomped by our lint staged setup, this runs them first.

## Motivation
So I stop swearing in code.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
