### PR TITLE
fix: Collapse steps with a single attempt

### DIFF
--- a/ui/packages/components/src/Debugger/DebugTrace.tsx
+++ b/ui/packages/components/src/Debugger/DebugTrace.tsx
@@ -5,7 +5,7 @@ import { InlineSpans } from '../RunDetailsV3/InlineSpans';
 import { StepType } from '../RunDetailsV3/StepType';
 import { TimelineHeader } from '../RunDetailsV3/TimelineHeader';
 import { type Trace } from '../RunDetailsV3/types';
-import { FINAL_SPAN_NAME, getSpanName, useStepSelection } from '../RunDetailsV3/utils';
+import { getSpanName, traceHasChildren, useStepSelection } from '../RunDetailsV3/utils';
 import { overlayDebugRuns } from './utils';
 
 type Props = {
@@ -33,16 +33,7 @@ export function DebugTrace({
 
   const runTrace = debugTraces ? overlayDebugRuns(originalTrace, debugTraces) : originalTrace;
 
-  //
-  // Don't show single finalization step for successful runs
-  // unless they have children (e.g. failed attempts)
-  const hasChildren =
-    depth === 0 &&
-    runTrace.childrenSpans?.length === 1 &&
-    runTrace.childrenSpans[0]?.name === FINAL_SPAN_NAME &&
-    (runTrace.childrenSpans[0]?.childrenSpans?.length ?? 0) == 0
-      ? false
-      : (runTrace.childrenSpans?.length ?? 0) > 0;
+  const hasChildren = traceHasChildren(depth, runTrace);
 
   const spanName = runTrace.name === 'Run' ? 'Debug Run' : getSpanName(runTrace.name);
 

--- a/ui/packages/components/src/RunDetailsV3/Trace.tsx
+++ b/ui/packages/components/src/RunDetailsV3/Trace.tsx
@@ -5,7 +5,7 @@ import { InlineSpans } from './InlineSpans';
 import { StepType } from './StepType';
 import { TimelineHeader } from './TimelineHeader';
 import { type Trace } from './types';
-import { FINAL_SPAN_NAME, getSpanName, useStepSelection } from './utils';
+import { getSpanName, traceHasChildren, useStepSelection } from './utils';
 
 type Props = {
   depth: number;
@@ -22,16 +22,8 @@ export function Trace({ depth, maxTime, minTime, trace, runID }: Props) {
   const { selectStep, selectedStep } = useStepSelection({ runID });
   const expanderRef = useRef<HTMLDivElement>(null);
 
-  //
-  // Don't show single finalization step for successful runs
-  // unless they have children (e.g. failed attempts)
-  const hasChildren =
-    depth === 0 &&
-    trace.childrenSpans?.length === 1 &&
-    trace.childrenSpans[0]?.name === FINAL_SPAN_NAME &&
-    (trace.childrenSpans[0]?.childrenSpans?.length ?? 0) == 0
-      ? false
-      : (trace.childrenSpans?.length ?? 0) > 0;
+  const hasChildren = traceHasChildren(depth, trace);
+
   const spanName = getSpanName(trace.name);
   return (
     <div className="relative flex w-full flex-col">

--- a/ui/packages/components/src/RunDetailsV3/utils.ts
+++ b/ui/packages/components/src/RunDetailsV3/utils.ts
@@ -27,6 +27,27 @@ export const maybeBooleanToString = (value: boolean | null): string | null => {
   return value ? 'True' : 'False';
 };
 
+export function traceHasChildren(depth: number, trace: Trace) {
+  // Don't show single finalization step for successful runs
+  // unless they have children (e.g. failed attempts)
+  //
+  if (
+    depth === 0 &&
+    trace.childrenSpans?.length === 1 &&
+    // TODO: maybe update name here to allow "Finalization" as well as that seems to be present in traces now
+    trace.childrenSpans[0]?.name === FINAL_SPAN_NAME &&
+    (trace.childrenSpans[0]?.childrenSpans?.length ?? 0) == 0
+  ) {
+    return false;
+  }
+
+  if (depth == 1 && trace.childrenSpans?.length === 1) {
+    return false;
+  }
+
+  return (trace.childrenSpans?.length ?? 0) > 0;
+}
+
 export function createSpanWidths({ ended, max, min, queued, started }: SpanTimes): SpanWidths {
   let beforeWidth = queued - min;
   let queuedWidth = (started ?? max) - queued;


### PR DESCRIPTION
## Description

This collapses steps (including finalization) containing a single attempt regardless of if the attempt is successful or a failure. Steps with multiple attempts are unchanged.

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

<img width="1485" height="662" alt="image" src="https://github.com/user-attachments/assets/37e0b7a4-7fd7-402a-8638-ef7d0335c8b8" />


## Motivation
This improves consistency with the behavior for success and reduces visual noise.

https://linear.app/inngest/issue/EXE-262/finalization-step-does-not-collapse-with-a-single-attempt

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
