### PR TITLE
[Insights]: Reduce width of resources section

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/InsightsTabPanelTemplatesTab.tsx
@@ -40,7 +40,7 @@ export function InsightsTabPanelTemplatesTab() {
         </div>
         <InsightsTabPanelTemplatesTabGrid />
       </div>
-      <div className="flex w-[360px] flex-shrink-0 flex-col">
+      <div className="flex w-[270px] flex-shrink-0 flex-col">
         <div className="flex flex-col gap-4">
           <h3 className="text-muted text-xs font-medium">RESOURCES</h3>
           <div className="flex flex-col gap-3">


### PR DESCRIPTION
## Description

This is a layout improvement. It reduces the width allotted to the "resources" section from `360px` to `270px`, which reduces the amount of empty space on the right side.

---
**Before:**

<img width="1332" height="629" alt="Screenshot 2025-10-14 at 12 22 48 PM" src="https://github.com/user-attachments/assets/4de3f917-f320-4e38-9fe0-e49d3a973a98" />

---
**After:**

<img width="1330" height="610" alt="Screenshot 2025-10-14 at 12 22 59 PM" src="https://github.com/user-attachments/assets/89a48aac-4b1a-4ac3-ad9b-702be03aa386" />

## Motivation

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
