### PR TITLE
fix: Unwrap extra StandardError wrapping

### DIFF
--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -412,6 +412,10 @@ func (r *DriverResponse) GetFunctionOutput() (*string, error) {
 }
 
 func isWrappedError(maybeErr []byte) bool {
+	if len(maybeErr) == 0 || maybeErr[0] != '{' {
+		return false
+	}
+
 	// Unmarshal into a struct to check if it's already wrapped.
 	// We don't care about the full structure, just whether it has
 	// the right fields.


### PR DESCRIPTION
## Description

This removes an extra layer of `{"error": ...}` wrapping from StandardError serialization in driver responses.

Before
<img width="661" height="447" alt="image" src="https://github.com/user-attachments/assets/8f1dc9f0-41f8-4fce-a548-8f8ef24b4e30" />


After
<img width="660" height="437" alt="image" src="https://github.com/user-attachments/assets/5c9404ba-493f-4382-8ad5-c7a8f26300ef" />


## Motivation

StandardErrors were not appearing correctly in traces and were showing as raw json.

https://linear.app/inngest/issue/EXE-123/check-that-permanent-failures-are-displayed-with-new-tracing

Also fixes 
EXE-196

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
