### PR TITLE
DebugAPI for System Queue based Crons

### DIFF
--- a/pkg/cli/output/partition.go
+++ b/pkg/cli/output/partition.go
@@ -30,6 +30,16 @@ func TextPartition(pt *pb.PartitionResponse, pts *pb.PartitionStatusResponse) er
 			)
 		}
 
+		cronSchedules := NewOrderedMap()
+		for _, cron := range pt.GetCrons() {
+			cronSchedules.Set(cron.JobId, OrderedData(
+				"JobID", cron.JobId,
+				"Next", cron.Next.AsTime().Format(time.RFC3339),
+				"Expr", cron.Expr,
+				"Scheduled", cron.Scheduled,
+			))
+		}
+
 		if err := w.WriteOrdered(OrderedData(
 			"Type", "Partition",
 			"ID", pt.Id,
@@ -41,6 +51,7 @@ func TextPartition(pt *pb.PartitionResponse, pts *pb.PartitionStatusResponse) er
 				"Queue Shard", shard,
 			),
 			"Triggers", fn.Triggers,
+			"CronSchedules", cronSchedules,
 			"Concurrency", OrderedData(
 				"Account", 0,
 				"Function", 0,

--- a/pkg/cli/output/text.go
+++ b/pkg/cli/output/text.go
@@ -110,6 +110,11 @@ func (tw *TextWriter) WriteOrdered(data *OrderedMap, opts ...TextOpt) error {
 		fmt.Println()
 	}
 
+	// Handle nil data gracefully
+	if data == nil {
+		return nil
+	}
+
 	indentStr := strings.Repeat(" ", tw.indent)
 	for _, key := range data.Keys() {
 		value, _ := data.Get(key)

--- a/pkg/debugapi/service.go
+++ b/pkg/debugapi/service.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/execution/cron"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/execution/state/redis_state"
 	"github.com/inngest/inngest/pkg/logger"
@@ -21,6 +22,7 @@ func NewDebugAPI(o Opts) service.Service {
 		db:        o.DB,
 		queue:     o.Queue,
 		state:     o.State,
+		croner:    o.Cron,
 		findShard: o.ShardSelector,
 	}
 }
@@ -30,6 +32,7 @@ type Opts struct {
 	DB    cqrs.Manager
 	Queue redis_state.QueueManager
 	State state.Manager
+	Cron  cron.CronManager
 
 	ShardSelector redis_state.ShardSelector
 }
@@ -41,9 +44,10 @@ type debugAPI struct {
 	log       logger.Logger
 	findShard redis_state.ShardSelector
 
-	db    cqrs.Manager
-	queue redis_state.QueueManager
-	state state.Manager
+	db     cqrs.Manager
+	queue  redis_state.QueueManager
+	state  state.Manager
+	croner cron.CronManager
 }
 
 func (d *debugAPI) Name() string {

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -670,6 +670,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			DB:            ds.Data,
 			Queue:         rq,
 			State:         ds.State,
+			Cron:          croner,
 			ShardSelector: shardSelector,
 		}))
 	}

--- a/proto/debug/v1/queue.proto
+++ b/proto/debug/v1/queue.proto
@@ -16,7 +16,7 @@ message PartitionResponse {
   PartitionTenant tenant = 3;
   bytes config = 4;
   QueueShard queue_shard = 5;
-  CronSchedule cron = 6;
+  repeated CronSchedule crons = 6;
 }
 
 message PartitionStatusResponse {
@@ -48,6 +48,8 @@ message QueueShard {
 message CronSchedule {
   google.protobuf.Timestamp next = 1;
   string job_id = 2;
+  string expr = 3;
+  bool scheduled = 4;
 }
 
 //

--- a/proto/gen/debug/v1/queue.pb.go
+++ b/proto/gen/debug/v1/queue.pb.go
@@ -74,7 +74,7 @@ type PartitionResponse struct {
 	Tenant        *PartitionTenant       `protobuf:"bytes,3,opt,name=tenant,proto3" json:"tenant,omitempty"`
 	Config        []byte                 `protobuf:"bytes,4,opt,name=config,proto3" json:"config,omitempty"`
 	QueueShard    *QueueShard            `protobuf:"bytes,5,opt,name=queue_shard,json=queueShard,proto3" json:"queue_shard,omitempty"`
-	Cron          *CronSchedule          `protobuf:"bytes,6,opt,name=cron,proto3" json:"cron,omitempty"`
+	Crons         []*CronSchedule        `protobuf:"bytes,6,rep,name=crons,proto3" json:"crons,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -144,9 +144,9 @@ func (x *PartitionResponse) GetQueueShard() *QueueShard {
 	return nil
 }
 
-func (x *PartitionResponse) GetCron() *CronSchedule {
+func (x *PartitionResponse) GetCrons() []*CronSchedule {
 	if x != nil {
-		return x.Cron
+		return x.Crons
 	}
 	return nil
 }
@@ -383,6 +383,8 @@ type CronSchedule struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Next          *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=next,proto3" json:"next,omitempty"`
 	JobId         string                 `protobuf:"bytes,2,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`
+	Expr          string                 `protobuf:"bytes,3,opt,name=expr,proto3" json:"expr,omitempty"`
+	Scheduled     bool                   `protobuf:"varint,4,opt,name=scheduled,proto3" json:"scheduled,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -429,6 +431,20 @@ func (x *CronSchedule) GetJobId() string {
 		return x.JobId
 	}
 	return ""
+}
+
+func (x *CronSchedule) GetExpr() string {
+	if x != nil {
+		return x.Expr
+	}
+	return ""
+}
+
+func (x *CronSchedule) GetScheduled() bool {
+	if x != nil {
+		return x.Scheduled
+	}
+	return false
 }
 
 // Item
@@ -542,15 +558,15 @@ const file_debug_v1_queue_proto_rawDesc = "" +
 	"\n" +
 	"\x14debug/v1/queue.proto\x12\bdebug.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\"\n" +
 	"\x10PartitionRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\"\xe5\x01\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"\xe7\x01\n" +
 	"\x11PartitionResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x12\n" +
 	"\x04slug\x18\x02 \x01(\tR\x04slug\x121\n" +
 	"\x06tenant\x18\x03 \x01(\v2\x19.debug.v1.PartitionTenantR\x06tenant\x12\x16\n" +
 	"\x06config\x18\x04 \x01(\fR\x06config\x125\n" +
 	"\vqueue_shard\x18\x05 \x01(\v2\x14.debug.v1.QueueShardR\n" +
-	"queueShard\x12*\n" +
-	"\x04cron\x18\x06 \x01(\v2\x16.debug.v1.CronScheduleR\x04cron\"\xb5\x02\n" +
+	"queueShard\x12,\n" +
+	"\x05crons\x18\x06 \x03(\v2\x16.debug.v1.CronScheduleR\x05crons\"\xb5\x02\n" +
 	"\x17PartitionStatusResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x16\n" +
 	"\x06paused\x18\x02 \x01(\bR\x06paused\x12\x18\n" +
@@ -572,10 +588,12 @@ const file_debug_v1_queue_proto_rawDesc = "" +
 	"\n" +
 	"QueueShard\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x12\n" +
-	"\x04kind\x18\x02 \x01(\tR\x04kind\"U\n" +
+	"\x04kind\x18\x02 \x01(\tR\x04kind\"\x87\x01\n" +
 	"\fCronSchedule\x12.\n" +
 	"\x04next\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x04next\x12\x15\n" +
-	"\x06job_id\x18\x02 \x01(\tR\x05jobId\"c\n" +
+	"\x06job_id\x18\x02 \x01(\tR\x05jobId\x12\x12\n" +
+	"\x04expr\x18\x03 \x01(\tR\x04expr\x12\x1c\n" +
+	"\tscheduled\x18\x04 \x01(\bR\tscheduled\"c\n" +
 	"\x10QueueItemRequest\x12\x17\n" +
 	"\aitem_id\x18\x01 \x01(\tR\x06itemId\x12\x15\n" +
 	"\x06run_id\x18\x02 \x01(\tR\x05runId\x12\x1f\n" +
@@ -611,7 +629,7 @@ var file_debug_v1_queue_proto_goTypes = []any{
 var file_debug_v1_queue_proto_depIdxs = []int32{
 	3, // 0: debug.v1.PartitionResponse.tenant:type_name -> debug.v1.PartitionTenant
 	4, // 1: debug.v1.PartitionResponse.queue_shard:type_name -> debug.v1.QueueShard
-	5, // 2: debug.v1.PartitionResponse.cron:type_name -> debug.v1.CronSchedule
+	5, // 2: debug.v1.PartitionResponse.crons:type_name -> debug.v1.CronSchedule
 	8, // 3: debug.v1.CronSchedule.next:type_name -> google.protobuf.Timestamp
 	4, // [4:4] is the sub-list for method output_type
 	4, // [4:4] is the sub-list for method input_type


### PR DESCRIPTION
## Description

Debug API for function partition should spit out system job ID, cron expression, next scheduled time and whether the next cron is actually scheduled for every cron expression:

 
**go run ./cmd debug q pt 9f697b5c-f4e5-5f9d-bce5-f2020555fb16**

```
inngest/ >  go run ./cmd debug q pt 9f697b5c-f4e5-5f9d-bce5-f2020555fb16

Type:  Partition
ID:    9f697b5c-f4e5-5f9d-bce5-f2020555fb16
Slug:  test-app-multiple-cron
Tenant:
  Account:      00000000-0000-4000-a000-000000000000
  Environment:  00000000-0000-4000-b000-000000000000
  App:          83c9c0e9-70bd-5871-a8d9-4a619cdd334f
  Queue Shard:
    Name:  default
    Kind:  redis
Triggers:  [
             {
               "cron": "* * * * *"
             },
             {
               "cron": "*/2 * * * *"
             },
             {
               "cron": "*/5 * * * *"
             }
           ]
<-------------------------------------------------------------->
CronSchedule:                        
  20l3aow92jloc:
    JobID:      20l3aow92jloc
    Next:       2025-10-16T22:15:00Z
    Expr:       * * * * *
    Scheduled:  true
  20zuo1lix1x13:
    JobID:      20zuo1lix1x13
    Next:       2025-10-16T22:16:00Z
    Expr:       */2 * * * *
    Scheduled:  true
  3px4me5whzxok:
    JobID:      3px4me5whzxok
    Next:       2025-10-16T22:15:00Z
    Expr:       */5 * * * *
    Scheduled:  true             
<-------------------------------------------------------------->
Concurrency:
  Account:   0
  Function:  0
Configuration:
  Name:         multiple-cron
  Version:      0
  Priority:     <nil>
  Timeouts:     <nil>
  Concurrency:  <nil>
  Debounce:     <nil>
  Batching:     <nil>
  RateLimit:    <nil>
  Throttle:     <nil>
  Cancel:       null
  Singleton:    <nil>
  URI:          [
                  {
                    "id": "step",
                    "name": "multiple-cron",
                    "uri": "http://localhost:8080/api/inngest?fnId=test-app-multiple-cron\u0026step=step",
                    "retries": 0
                  }
                ]
```

Cron System Job IDs in the partition output can be used to look at the system queue item in full detail:

**go run ./cmd debug q i --id=14hlur12ejznc**     
```
inngest/ >  go run ./cmd debug q i --id=14hlur12ejznc            

ID:                 14hlur12ejznc
EarliestPeekTime:   0
At:                 2025-10-16T22:10:59Z
WallTime:           489070h10m59.982s
WorkspaceID:        00000000-0000-4000-b000-000000000000
FunctionID:         46418d25-9fa5-5a45-92bf-c4283c738adb
LeaseID:            <nil>
QueueName:          "cron"
IdempotencyPeriod:  <nil>
RefilledFrom:       
RefilledAt:         1970-01-01T00:00:00Z
EnqueuedAt:         2025-10-16T22:09:59Z
Data:
  JobID:    <nil>
  GroupID:  8cd56eeb-3c80-4f69-9ecd-ed6454c35b48
  Kind:     cron
  Identifier:
    AccountID:        00000000-0000-4000-a000-000000000000
    WorkspaceID:      00000000-0000-4000-b000-000000000000
    AppID:            83c9c0e9-70bd-5871-a8d9-4a619cdd334f
    FunctionID:       46418d25-9fa5-5a45-92bf-c4283c738adb
    FunctionVersion:  0
    EventIDs:         null
    RunID:            00000000000000000000000000
    Key:              
    ReplayID:         <nil>
    OriginalRunID:    <nil>
    PriorityFactor:   <nil>
  Attempt:            0
  MaxAttempts:        21
  Payload:            {
                        "id": "01K7QH73901ZTZEJAERHB5Y92C",
                        "acctID": "00000000-0000-4000-a000-000000000000",
                        "wsID": "00000000-0000-4000-b000-000000000000",
                        "appID": "83c9c0e9-70bd-5871-a8d9-4a619cdd334f",
                        "fnID": "46418d25-9fa5-5a45-92bf-c4283c738adb",
                        "fnV": 0,
                        "expr": "* * * * *",
                        "prevJobID": "14hlur12ejznc",
                        "op": "Process"
                      }
  Metadata:
  ParallelMode:  None
```


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
