### PR TITLE
Fix skipped runs have queued status

### DIFF
--- a/pkg/enums/step_status.go
+++ b/pkg/enums/step_status.go
@@ -15,6 +15,7 @@ const (
 	StepStatusErrored
 	StepStatusCancelled
 	StepStatusTimedOut
+	StepStatusSkipped
 )
 
 func (s StepStatus) IsEnded() bool {

--- a/pkg/enums/stepstatus_enumer.go
+++ b/pkg/enums/stepstatus_enumer.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 )
 
-const _StepStatusName = "UnknownScheduledRunningWaitingSleepingInvokingCompletedFailedErroredCancelledTimedOut"
+const _StepStatusName = "UnknownScheduledRunningWaitingSleepingInvokingCompletedFailedErroredCancelledTimedOutSkipped"
 
-var _StepStatusIndex = [...]uint8{0, 7, 16, 23, 30, 38, 46, 55, 61, 68, 77, 85}
+var _StepStatusIndex = [...]uint8{0, 7, 16, 23, 30, 38, 46, 55, 61, 68, 77, 85, 92}
 
-const _StepStatusLowerName = "unknownscheduledrunningwaitingsleepinginvokingcompletedfailederroredcancelledtimedout"
+const _StepStatusLowerName = "unknownscheduledrunningwaitingsleepinginvokingcompletedfailederroredcancelledtimedoutskipped"
 
 func (i StepStatus) String() string {
 	if i < 0 || i >= StepStatus(len(_StepStatusIndex)-1) {
@@ -38,9 +38,10 @@ func _StepStatusNoOp() {
 	_ = x[StepStatusErrored-(8)]
 	_ = x[StepStatusCancelled-(9)]
 	_ = x[StepStatusTimedOut-(10)]
+	_ = x[StepStatusSkipped-(11)]
 }
 
-var _StepStatusValues = []StepStatus{StepStatusUnknown, StepStatusScheduled, StepStatusRunning, StepStatusWaiting, StepStatusSleeping, StepStatusInvoking, StepStatusCompleted, StepStatusFailed, StepStatusErrored, StepStatusCancelled, StepStatusTimedOut}
+var _StepStatusValues = []StepStatus{StepStatusUnknown, StepStatusScheduled, StepStatusRunning, StepStatusWaiting, StepStatusSleeping, StepStatusInvoking, StepStatusCompleted, StepStatusFailed, StepStatusErrored, StepStatusCancelled, StepStatusTimedOut, StepStatusSkipped}
 
 var _StepStatusNameToValueMap = map[string]StepStatus{
 	_StepStatusName[0:7]:        StepStatusUnknown,
@@ -65,6 +66,8 @@ var _StepStatusNameToValueMap = map[string]StepStatus{
 	_StepStatusLowerName[68:77]: StepStatusCancelled,
 	_StepStatusName[77:85]:      StepStatusTimedOut,
 	_StepStatusLowerName[77:85]: StepStatusTimedOut,
+	_StepStatusName[85:92]:      StepStatusSkipped,
+	_StepStatusLowerName[85:92]: StepStatusSkipped,
 }
 
 var _StepStatusNames = []string{
@@ -79,6 +82,7 @@ var _StepStatusNames = []string{
 	_StepStatusName[61:68],
 	_StepStatusName[68:77],
 	_StepStatusName[77:85],
+	_StepStatusName[85:92],
 }
 
 // StepStatusString retrieves an enum value from the enum constants string name.

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -768,6 +768,14 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		}
 	}
 
+	if req.SkipReason() != enums.SkipReasonNone {
+		status := enums.StepStatusSkipped
+		meta.AddAttr(
+			runSpanOpts.Attributes,
+			meta.Attrs.DynamicStatus,
+			&status,
+		)
+	}
 	// Always the root span.
 	runSpanRef, err = e.tracerProvider.CreateDroppableSpan(
 		meta.SpanNameRun,


### PR DESCRIPTION
Fix an issue where skipped runs were getting the Queued status instead of Skipped.

Note that the skipped runs could still appear elsewhere in the product. We'll need to hardcode `status != 'Skipped'` in later PRs