### PR TITLE
Add metrics to pause block store

### DIFF
--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -617,3 +617,30 @@ func IncrQueueThrottleKeyExpressionMismatchCounter(ctx context.Context, opts Cou
 		Tags:        opts.Tags,
 	})
 }
+
+func IncrPausesFlushedToBlocks(ctx context.Context, value int64, opts CounterOpt) {
+	RecordCounterMetric(ctx, value, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "pauses_flushed_to_blocks_total",
+		Description: "Total number of pauses flushed to blocks",
+		Tags:        opts.Tags,
+	})
+}
+
+func IncrPausesBlocksCreated(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "pauses_blocks_created_total",
+		Description: "Total number of pause blocks created",
+		Tags:        opts.Tags,
+	})
+}
+
+func IncrPausesDeletedAfterBlockFlush(ctx context.Context, value int64, opts CounterOpt) {
+	RecordCounterMetric(ctx, value, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "pauses_deleted_after_flush_total",
+		Description: "Total number of pauses deleted after flushing them to blocks",
+		Tags:        opts.Tags,
+	})
+}

--- a/pkg/telemetry/metrics/histogram.go
+++ b/pkg/telemetry/metrics/histogram.go
@@ -278,3 +278,33 @@ func HistogramHTTPAPIBytesWritten(ctx context.Context, bytes int64, opts Histogr
 		Boundaries:  DefaultBoundaries,
 	})
 }
+
+func HistogramPauseBlockFlushLatency(ctx context.Context, delay time.Duration, opts HistogramOpt) {
+	RecordIntHistogramMetric(ctx, delay.Milliseconds(), HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "pauses_block_flush_duration",
+		Description: "Distribution of pauses block flush latency",
+		Tags:        opts.Tags,
+		Boundaries:  DefaultBoundaries,
+	})
+}
+
+func HistogramPauseBlockFetchLatency(ctx context.Context, delay time.Duration, opts HistogramOpt) {
+	RecordIntHistogramMetric(ctx, delay.Milliseconds(), HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "pauses_block_fetch_duration",
+		Description: "Distribution of pauses block fetching latency",
+		Tags:        opts.Tags,
+		Boundaries:  DefaultBoundaries,
+	})
+}
+
+func HistogramPauseDeleteLatencyAfterBlockFlush(ctx context.Context, delay time.Duration, opts HistogramOpt) {
+	RecordIntHistogramMetric(ctx, delay.Milliseconds(), HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "pauses_delete_after_flush_duration",
+		Description: "Distribution of pauses deletion duration after flushing a block",
+		Tags:        opts.Tags,
+		Boundaries:  PausesBoundaries,
+	})
+}


### PR DESCRIPTION
## Description
Add these following metrics/histograms to the pauses block store:
- Number of pauses flushed
- Number of blocks created
- Number of pauses deleted from buffer after a flush
- Distribution of block flushing latency
- Distribution of block fetching latency
- Distribution of pauses deletion duration after flushing a block
- Distribution of a dual iterator load latenc


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
