### PR TITLE
Update Executor IP on LeaseRequest

### DIFF
--- a/pkg/config/connect/executor.go
+++ b/pkg/config/connect/executor.go
@@ -19,12 +19,13 @@ var (
 	executorConfigOnce sync.Once
 )
 
-const ExecutorIPKey = "connect.executor.grpc.ip"
-const ExecutorPortKey = "connect.executor.grpc.port"
+const (
+	ExecutorIPKey   = "connect.executor.grpc.ip"
+	ExecutorPortKey = "connect.executor.grpc.port"
+)
 
 func Executor(ctx context.Context) ConnectExecutor {
 	executorConfigOnce.Do(func() {
-
 		ipStr := getWithDefault(ExecutorIPKey, "127.0.0.1", viper.GetString)
 		port := getWithDefault(ExecutorPortKey, uint32(50053), viper.GetUint32)
 
@@ -39,4 +40,13 @@ func Executor(ctx context.Context) ConnectExecutor {
 		}
 	})
 	return executorConfig
+}
+
+// SetConfig is used for testing
+func SetConfig(ctx context.Context, config ConnectExecutor) {
+	// Make sure to initialize config to avoid overriding it with sync.Once
+	Executor(ctx)
+
+	// Override the config
+	executorConfig = config
 }

--- a/pkg/connect/state/lua/lease.lua
+++ b/pkg/connect/state/lua/lease.lua
@@ -19,6 +19,14 @@ local requestItem = get_request_lease_item(keyRequestLease)
 
 -- Case 1: Request is actively leased
 if requestItem ~= nil and requestItem ~= false and requestItem.leaseID ~= nil and requestItem.leaseID ~= cjson.null and decode_ulid_time(requestItem.leaseID) > currentTime then
+  -- Maintain same lease ID with current executor IP
+  requestItem = {
+    leaseID = requestItem.leaseID,
+    executorIP = executorIP
+  }
+
+  -- Update request lease key, maintain TTL
+  redis.call("SET", keyRequestLease, cjson.encode(requestItem), "KEEPTTL")
 	return -1
 end
 


### PR DESCRIPTION
## Description

This PR updates LeaseRequest to update the lease to the latest executor IP, while preserving all other lease data.

This is an optimization for the case where an executor waiting for a connect response to come back: We always use request buffering, so the currently-processing executor _will_ receive the response. With this change, the connect gateway will be able to find the current executor processing the request to send a gRPC response.

Previously, gRPC responses would fail in case the original executor went away. This was acceptable as request buffering always works.

Since the executor claims a lease on the queue item (which is the source of the requestID), we do not have to worry about multiple executors attempting to call LeaseRequest and override the IP (thrashing) at once.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
