### PR TITLE
Status dropdown navigates to status page

### DIFF
--- a/ui/apps/dashboard/src/components/Navigation/Help.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Help.tsx
@@ -78,7 +78,7 @@ export const Help = ({ collapsed, showWidget }: { collapsed: boolean; showWidget
               </div>
             </Listbox.Option>
           </NextLink>
-          <NextLink href="/support" target="_blank">
+          <NextLink href="https://status.inngest.com" target="_blank">
             <Listbox.Option
               className="text-muted hover:bg-canvasSubtle mx-2 mt-2 flex h-8 cursor-pointer items-center px-2 text-[13px]"
               value="status"


### PR DESCRIPTION
## Description

The status widget in dashboard currently navigates to `/support`. Needs to navigate to status page

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
