### PR TITLE
Don't send spans for events dropped due to singleton config

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -889,6 +889,9 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 						l.ReportError(err, "error canceling singleton run")
 					}
 				default:
+					// If the event is being rejected because there is another singleton run already in progress,
+					//  we can safely ignore the span for this schedule request
+					dropSpans()
 					// Immediately end before creating state
 					return nil, ErrFunctionSkipped
 				}


### PR DESCRIPTION
## Description

#3115 made this same change for duplicate queue items, extending the same for queue items rejected due to singleton config.

**Before**
<img width="2502" height="1336" alt="Screenshot 2025-10-17 at 1 55 10 PM" src="https://github.com/user-attachments/assets/d3aeb7f5-174a-49f1-b33e-babd05f562fe" />

**After:**
<img width="2533" height="1382" alt="Screenshot 2025-10-17 at 1 52 43 PM" src="https://github.com/user-attachments/assets/4c07e2c8-8b02-486d-b25e-97de51b67531" />


## Motivation
SYS-413

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
