### PR TITLE
DOCS - Minor Typo In v2 API Example

### DIFF
--- a/docs/api_v2_examples.json
+++ b/docs/api_v2_examples.json
@@ -70,28 +70,28 @@
       }
     }
   },
-  "/env/{id}": {
+  "/envs/{id}": {
     "patch": {
       "200": {
-        "// TODO": "Add example data for patch /env/{id} 200"
+        "// TODO": "Add example data for patch /envs/{id} 200"
       },
       "400": {
-        "// TODO": "Add example data for patch /env/{id} 400"
+        "// TODO": "Add example data for patch /envs/{id} 400"
       },
       "401": {
-        "// TODO": "Add example data for patch /env/{id} 401"
+        "// TODO": "Add example data for patch /envs/{id} 401"
       },
       "403": {
-        "// TODO": "Add example data for patch /env/{id} 403"
+        "// TODO": "Add example data for patch /envs/{id} 403"
       },
       "404": {
-        "// TODO": "Add example data for patch /env/{id} 404"
+        "// TODO": "Add example data for patch /envs/{id} 404"
       },
       "422": {
-        "// TODO": "Add example data for patch /env/{id} 422"
+        "// TODO": "Add example data for patch /envs/{id} 422"
       },
       "500": {
-        "// TODO": "Add example data for patch /env/{id} 500"
+        "// TODO": "Add example data for patch /envs/{id} 500"
       }
     }
   },


### PR DESCRIPTION
## Description

DOCS - Minor Typo In v2 API Example

## Motivation

Minor Typo In v2 API Example. I saw this while trying to understand some of the other code/endpoints: https://github.com/inngest/inngest/blob/4b886853663dfb86878a53dc5f785ec86a30b4a9/proto/api/v2/service.proto#L824

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [x] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
