### PR TITLE
Drop span if enqueue rejects an item because of singleton config

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1056,6 +1056,9 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		if err != nil {
 			l.ReportError(err, "error deleting function state")
 		}
+		// If the event is being rejected because there is another singleton run already in progress,
+		// we can safely ignore the span for this schedule request
+		dropSpans()
 		return nil, ErrFunctionSkipped
 
 	default:


### PR DESCRIPTION
## Description

 Drop span if a function run is rejected at Enqueue time because it violates singleton config.

Same as #3152 where we drop spans if we reject an event earlier in `Schedule`, but singleton checks happen again later in `Enqueue` as well, so adding the same fix to the second rejection site.

## Motivation
[SYS-413 Potential traces bug for singleton fn in dev server](https://linear.app/inngest/issue/SYS-413/potential-traces-bug-for-singleton-fn-in-dev-server)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
