### PR TITLE
[Security]: Add report-only CSP

### DIFF
--- a/ui/apps/dashboard/src/middleware.ts
+++ b/ui/apps/dashboard/src/middleware.ts
@@ -191,12 +191,17 @@ function getAppURL(): string | null {
 
 // TODO: Remove -Report-Only once we're confident CSP is working as expected.
 function withCSPResponseHeaderReportOnly(response: Response) {
-  const appURL = getAppURL();
-  if (!appURL) return response;
+  try {
+    const appURL = getAppURL();
+    if (!appURL) return response;
 
-  response.headers.set('Content-Security-Policy-Report-Only', makeCSPHeader(appURL));
+    response.headers.set('Content-Security-Policy-Report-Only', makeCSPHeader(appURL));
 
-  return response;
+    return response;
+  } catch (_) {
+    // Never fail to process a request.
+    return response;
+  }
 }
 
 function combineCSPURLs(urls: string[]): string {


### PR DESCRIPTION
## Description

This will allow us to start reporting CSP violations for actions that are outside of our expected. This is a report-only CSP, so it will not block interactions until we are comfortable with converting it to enforcement mode.

**NOTE:** I'm splitting off a ticket to send these reports to Sentry, due to some current blockers. For now, these violations will appears as logs in the console.

## Motivation

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
