### PR TITLE
Add GH action to run make gen protobuf

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,6 +33,19 @@ jobs:
           version: v2.2.1
           args: --verbose
 
+  gen:
+    name: 'git state after "make gen protobuf"'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: nicknovitski/nix-develop@v1.2.1
+      - name: 'Check for dirty Git state after running "make gen protobuf"'
+        run: |
+          make gen protobuf
+          git diff
+          git diff --name-only --exit-code
+
   test-linux-race:
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description
This adds a GH action to run `make gen protobuf` and ensure no files are modified.

## Motivation
This makes sure that `make gen protobuf` has been run before changes are merged if any changes have been made to the schemas.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
