### PR TITLE
Fix run span idempotency race condition

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -927,6 +927,7 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 
 	// Always the root span.
 	runSpanRef, err = e.tracerProvider.CreateDroppableSpan(
+		ctx,
 		meta.SpanNameRun,
 		runSpanOpts,
 	)


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

This moves the runSpan creation logic after http://github.com/inngest/inngest/blob/105f8f76a545faeb9fdd5c792c8f256b4e2f6e1e/pkg/execution/executor/executor.go#L891 to fix a race condition that occurs rarely where multiple runSpans are created for deduplicated events.

This seems to fix test flakiness in `TestFunctionRunListSkipped/event_idempotency` in monorepo. (Tested 100s of runs when typically the failure would appear after ~25 runs)

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

When duplicate events cause 2 calls to `executor.Schedule` to execute concurrently, we incorrectly emit `executor.run` spans with separate run IDs, then override the run ID for one of the executions, and then emit two `executor.discovery` spans with the same run ID. This causes a phantom second permanently queued run to show up in the runs list.

This change just moves the initial `executor.run` span creation until after we merge the run IDs between duplicate runs.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
