### PR TITLE
Fix Connect socket error code not sent

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -1128,6 +1128,12 @@ func (c *connectionHandler) establishConnection(ctx context.Context) (*state.Con
 			if ctx.Err() != nil {
 				return nil, &ErrDraining
 			}
+			if serr, ok := err.(connecterrors.SocketError); ok {
+				return nil, &serr
+			}
+			if serr, ok := err.(*connecterrors.SocketError); ok {
+				return nil, serr
+			}
 
 			return nil, &connecterrors.SocketError{
 				SysCode:    syscode.CodeConnectInternal,


### PR DESCRIPTION
## Description
Before this change, Connect workers would get `reason='connect_internal_error'` for invalid function configs. Now they get `reason='connect_invalid_function_config'`

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
