### PR TITLE
Fix missing appid in root spans by preserving ExecutionContext

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -813,6 +813,12 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 		&status,
 	)
 
+	// Set execution context for tracing before creating the span, so that
+	// the span processor can extract AppID and other tenant information.
+	ctx = tracing.WithExecutionContext(ctx, tracing.ExecutionContext{
+		Identifier: metadata.ID,
+	})
+
 	// Always the root span.
 	runSpanRef, err = e.tracerProvider.CreateDroppableSpan(
 		ctx,

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -153,8 +153,9 @@ func (tp *otelTracerProvider) CreateDroppableSpan(
 		)
 	} else {
 		// Use a fresh context for parent traces so that there's no pollution from any
-		// other tracing.
-		ctx = context.Background()
+		// other tracing, but preserve the ExecutionContext so that the span processor
+		// can extract tenant information (AppID, FunctionID, etc.).
+		ctx = mixinExecutonContext(ctx, context.Background())
 	}
 
 	attrs := opts.Attributes


### PR DESCRIPTION
## Description

Recent change broke appId in spans. This changes fixes issue but uncertain if it reintroduces the bug that was fixed here: https://github.com/inngest/inngest/commit/5f7dc451ec4908e924698bde0495ec758ef4aa5a

## Motivation
Runs page borked in OSS

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
