### PR TITLE
fix: remove singleton tracer to prevent stale metadata

### DIFF
--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -77,9 +77,7 @@ func NewOtelTracerProvider(exp sdktrace.SpanExporter, batchTimeout time.Duration
 }
 
 func (tp *otelTracerProvider) getTracer(md *statev2.Metadata) trace.Tracer {
-	base := sdktrace.NewBatchSpanProcessor(tp.exp,
-		sdktrace.WithBatchTimeout(50*time.Millisecond),
-	)
+	base := sdktrace.NewSimpleSpanProcessor(tp.exp)
 
 	otelTP := sdktrace.NewTracerProvider(
 		sdktrace.WithSpanProcessor(newExecutionProcessor(md, base)),


### PR DESCRIPTION
## Description
Remove the tracer singleton that was capturing stale metadata

## Motivation
To make the Runs page load correctly

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
