### PR TITLE
Fixes plan unit display

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/billing/(overview)/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/billing/(overview)/page.tsx
@@ -53,8 +53,10 @@ export default async function Page() {
     tooltipContent: 'A single durable function execution.',
   };
 
+  const isExecutionBasedPlan =
+    currentPlan.slug === 'pro-2025-08-08' || currentPlan.slug === 'pro-2025-06-04';
   const steps: Data = {
-    title: 'Steps',
+    title: isExecutionBasedPlan ? 'Executions' : 'Steps',
     description: `${
       entitlements.runCount.overageAllowed && !legacyNoRunsPlan
         ? 'Additional usage incurred at additional charge. Additional runs include 5 steps per run.'


### PR DESCRIPTION
## Description

Checks current plan slug and determines what is displayed

## Motivation
Currently, users on execution based plans see "Steps" in their billing dashboard

https://inngest.slack.com/archives/C0942C0DB35/p1761313941342229

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
