### PR TITLE
Fix flaky test: TestPauseCancelFunction

### DIFF
--- a/tests/golang/cancel_pause_test.go
+++ b/tests/golang/cancel_pause_test.go
@@ -201,9 +201,9 @@ func TestPauseCancelFunction(t *testing.T) {
 			r := require.New(t)
 			r.Equal(int32(1), atomic.LoadInt32(&runCounter))
 			r.Equal(int32(1), atomic.LoadInt32(&runCancelled))
+			r.Equal(0, getQueueSize(consts.DevServerAccountID, uuid.MustParse(fnId)), fmt.Sprintf("fnID: %s", fnId))
 		}, 10*time.Second, 10*time.Millisecond)
 
-		require.Equal(t, 0, getQueueSize(consts.DevServerAccountID, uuid.MustParse(fnId)))
 	})
 
 	t.Run("trace run should have appropriate data", func(t *testing.T) {


### PR DESCRIPTION
## Description

Fix flaky test: TestPauseCancelFunction


```
> go test -count=100  -parallel=10 -run ^TestPauseCancelFunction github.com/inngest/inngest/tests/golang
ok      github.com/inngest/inngest/tests/golang 126.656s
```

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
