### PR TITLE
Update ended_at timestamps in dev server traces

### DIFF
--- a/pkg/coreapi/graph/models/augmented.go
+++ b/pkg/coreapi/graph/models/augmented.go
@@ -58,3 +58,7 @@ type RunTraceSpan struct {
 	SpanTypeName string
 	Omit         bool
 }
+
+func RunTraceEnded(s RunTraceSpanStatus) bool {
+	return s == RunTraceSpanStatusCompleted || s == RunTraceSpanStatusCancelled || s == RunTraceSpanStatusFailed
+}

--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -209,9 +209,14 @@ func mapRootSpansFromRows[T normalizedSpan](ctx context.Context, spans []T) (*cq
 				TraceID:      traceID,
 				ParentSpanID: parentSpanIDPtr,
 				StartTime:    parsedStartTime,
-				EndTime:      parsedEndTime,
-				Name:         "",
-				Attributes:   make(map[string]any),
+				// NOTE:
+				// The end time is only valid if this span denotes a step end, or the run end.
+				// EG. if this is an "Executor.run" span, this would never have an end time.
+				// However, this is the actual span commit time.  We must handle this when we
+				// parse the spans.
+				EndTime:    parsedEndTime,
+				Name:       "",
+				Attributes: make(map[string]any),
 			},
 			Status:          enums.StepStatusRunning,
 			RunID:           runID,


### PR DESCRIPTION
This commit changes ended at and cancelling in the dev server.  Otel spans always have an EndedAt field which denotes the committed time. We roll these "start" and "end" spans into a single span in GQL. Previously, we'd plainly copy the EndedAt time for any span.  We only want to do this if the span has resolved (completed, failed, cancelled).


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
