### PR TITLE
Disable project zero from `/v1/events/{eventID}/runs` temporarily

### DIFF
--- a/pkg/api/apiv1/events.go
+++ b/pkg/api/apiv1/events.go
@@ -14,8 +14,6 @@ import (
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/publicerr"
 	"github.com/inngest/inngest/pkg/util"
-	"github.com/inngest/inngestgo/step"
-	"github.com/inngest/inngestgo/stephttp"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -149,24 +147,16 @@ func (a API) GetEventRuns(ctx context.Context, eventID ulid.ULID) ([]*cqrs.Funct
 }
 
 func (a router) getEventRuns(w http.ResponseWriter, r *http.Request) {
-	stephttp.Configure(r.Context(), stephttp.FnOpts{
-		ID: "/v1/events/{eventID}/runs",
-	})
-
 	ctx := r.Context()
 	eventID := chi.URLParam(r, "eventID")
 
-	parsed, err := step.Run(ctx, "fetch ulid", func(ctx context.Context) (ulid.ULID, error) {
-		return ulid.Parse(eventID)
-	})
+	parsed, err := ulid.Parse(eventID)
 	if err != nil {
 		_ = publicerr.WriteHTTP(w, publicerr.Wrapf(err, 400, "Invalid event ID: %s", eventID))
 		return
 	}
 
-	runs, err := step.Run(ctx, "fetch runs via event", func(ctx context.Context) ([]*cqrs.FunctionRun, error) {
-		return a.GetEventRuns(ctx, parsed)
-	})
+	runs, err := a.GetEventRuns(ctx, parsed)
 	if err != nil {
 		_ = publicerr.WriteHTTP(w, err)
 		return
@@ -176,15 +166,12 @@ func (a router) getEventRuns(w http.ResponseWriter, r *http.Request) {
 	// for the runs found from each event, then fetch the status directly.
 	{
 		for _, run := range runs {
-			_, _ = step.Run(ctx, "trace v2: fetch status", func(ctx context.Context) (enums.RunStatus, error) {
-				rootSpan, err := a.opts.TraceReader.GetSpansByRunID(ctx, run.RunID)
-				if err != nil || rootSpan == nil {
-					_ = publicerr.WriteHTTP(w, err) // return with error since user can leave out trace_preview flag
-					return enums.RunStatusUnknown, err
-				}
-				run.Status = enums.StepStatusToRunStatus(rootSpan.Status)
-				return run.Status, nil
-			})
+			rootSpan, err := a.opts.TraceReader.GetSpansByRunID(ctx, run.RunID)
+			if err != nil {
+				_ = publicerr.WriteHTTP(w, err) // return with error since user can leave out trace_preview flag
+				return
+			}
+			run.Status = enums.StepStatusToRunStatus(rootSpan.Status)
 		}
 	}
 


### PR DESCRIPTION
## Description

We did this directly in monorepo's vendor directory with
- https://github.com/inngest/monorepo/pull/5543
- https://github.com/inngest/monorepo/pull/5546

but it was overridden by https://github.com/inngest/monorepo/pull/5551

Make the change here so we don't accidentally override on future vendor updates.

we can verify this is the correct change by checking out 8d3ec6d7 on monorepo (the commit that https://github.com/inngest/monorepo/pull/5546 created)
then running `diff monorepo/vendor/github.com/inngest/inngest/pkg/api/apiv1/events.go inngest/pkg/api/apiv1/events.go`

## Motivation

We are seeing lots of context cancellations as a result of this endpoint

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
