### PR TITLE
Fix span durations for spans with parallel children

### DIFF
--- a/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
@@ -154,19 +154,9 @@ export const StepInfo = ({
     (toMaybeDate(trace.startedAt) ?? new Date()).getTime() - new Date(trace.queuedAt).getTime()
   );
 
-  const duration = trace.childrenSpans?.length
-    ? trace.childrenSpans
-        .filter((child) => child.startedAt)
-        .reduce(
-          (total, child) =>
-            total +
-            ((toMaybeDate(child.endedAt) ?? new Date()).getTime() -
-              new Date(child.startedAt!).getTime()),
-          0
-        )
-    : trace.startedAt
-    ? (toMaybeDate(trace.endedAt) ?? new Date()).getTime() - new Date(trace.startedAt).getTime()
-    : 0;
+  const startedAt = toMaybeDate(trace.startedAt);
+  const endedAt = toMaybeDate(trace.endedAt);
+  const duration = startedAt ? (endedAt ?? new Date()).getTime() - startedAt.getTime() : 0;
 
   const durationText = duration > 0 ? formatMilliseconds(duration) : '-';
 


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

This makes span duration calculation in the UI based purely on the span's startedAt/endedAt rather than calculating the sum of the durations of the child spans. (Note the startedAt, endedAt, and durations in the below screenshots)

Before:
<img width="631" height="155" alt="image" src="https://github.com/user-attachments/assets/b90ce917-7cb7-45b9-9c02-db2dcb21edd9" />

After:
<img width="636" height="165" alt="image" src="https://github.com/user-attachments/assets/2e6fe5c2-db9d-449d-b9a3-cbae38430bf5" />

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

Span duration was miscalculated for spans with parallel children (relevant for userland traces)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
