### PR TITLE
fix: don't zero-out userland trace span EndedAt

### DIFF
--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -505,7 +505,7 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 		gqlSpan.StepType = gqlSpan.StepOp.String()
 	}
 
-	if models.RunTraceEnded(gqlSpan.Status) {
+	if models.RunTraceEnded(gqlSpan.Status) || gqlSpan.IsUserland {
 		startedAt := span.GetStartedAtTime()
 		endedAt := span.GetEndedAtTime()
 		if startedAt != nil && endedAt != nil {


### PR DESCRIPTION
## Description

Modifies the trace loader so that userland traces that aren't explicitly completed but _do_ have an `EndedAt` value correctly return the value.

## Motivation

Along with #3229 this addresses some weirdness with the way that userland span traces appear. 

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
