### PR TITLE
Allow setting override idempotency TTL on queue items

### DIFF
--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -51,6 +51,11 @@ type EnqueueOpts struct {
 	PassthroughJobId       bool
 	ForceQueueShardName    string
 	NormalizeFromBacklogID string
+	// IdempotencyPerioud allows customizing the idempotency period for this queue
+	// item.  For example, after a debounce queue has been consumed we want to remove
+	// the idempotency key immediately;  the same debounce key should become available
+	// for another debounced function run.
+	IdempotencyPeriod *time.Duration `json:"ip,omitempty"`
 }
 
 type Producer interface {

--- a/pkg/execution/state/redis_state/queue_op.go
+++ b/pkg/execution/state/redis_state/queue_op.go
@@ -135,6 +135,10 @@ func (q *queue) Dequeue(ctx context.Context, queueShard QueueShard, i osqueue.Qu
 	if q.idempotencyTTLFunc != nil {
 		idempotency = q.idempotencyTTLFunc(ctx, i)
 	}
+	// If custom idempotency period is set on the queue item, use that
+	if i.IdempotencyPeriod != nil {
+		idempotency = *i.IdempotencyPeriod
+	}
 
 	args, err := StrSlice([]any{
 		i.ID,

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -119,6 +119,11 @@ func (q *queue) Enqueue(ctx context.Context, item osqueue.Item, at time.Time, op
 		return err
 	}
 
+	// Pass optional idempotency period to queue item
+	if opts.IdempotencyPeriod != nil {
+		qi.IdempotencyPeriod = opts.IdempotencyPeriod
+	}
+
 	// Use the queue item's score, ensuring we process older function runs first
 	// (eg. before at)
 	next := time.UnixMilli(qi.Score(q.clock.Now()))


### PR DESCRIPTION
## Description

It looks like we exposed a customizable idempotency TTL on the queue item structure, but we never used it when dequeueing items (instead just using the static ttl and overriding with the dynamic function).

For the new pause flushing jobs, @KiKoS0 needs to enqueue a system queue item which should have deduplication/idempotency while processing, but not after. Since we check on the item ID to prevent enqueueing an item with the same ID, this ensures idempotency while processing the item, as long as we use a deterministic queue item ID.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
