### PR TITLE
Update init commands to get the submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: dev
-dev: docs
+dev: submodules docs
 	goreleaser build --single-target --snapshot --clean
 
 # specifically for tests
 .PHONY: run
-run:
+run: submodules
 	TEST_MODE=true LOG_LEVEL=info DEBUG=1 go run ./cmd dev --tick=50 --no-poll --verbose $(PARAMS)
 
 # Start with debug mode in Delve
@@ -92,6 +92,11 @@ build: docs
 .PHONY: gql
 gql:
 	go run github.com/99designs/gqlgen --verbose --config ./pkg/coreapi/gqlgen.yml
+
+.PHONY: submodules
+submodules:
+	@echo "Initializing submodules..."
+	@git submodule update --init --recursive
 
 .PHONY: clean
 clean:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,8 +15,36 @@ The following instructions will help you build and run the Inngest CLI locally.
 
 ### Instructions
 
-1. Clone this repository
-2. Build the CLI by running `make dev`
-   - Your recently built CLI will be available at `./dist/innest_[system_arch]/inngest` (e.g.
+1. Clone this repository:
+   ```bash
+   git clone https://github.com/inngest/inngest.git
+   cd inngest
+   ```
+   
+   **Note**: If you already have an existing clone, you'll need to initialize the submodules:
+   ```bash
+   git submodule update --init --recursive
+   ```
+   
+   Alternatively, for new clones, you can clone with submodules automatically:
+   ```bash
+   git clone --recurse-submodules https://github.com/inngest/inngest.git
+   cd inngest
+   ```
+
+2. Build the CLI by running `make dev` (this will initialize submodules automatically)
+   - Your recently built CLI will be available at `./dist/inngest_[system_arch]/inngest` (e.g.
      `./dist/inngest_darwin_arm64/inngest`)
+
 3. Run `./dist/inngest_[system_arch]/inngest` to see the CLI in action
+
+### Troubleshooting
+
+**Build errors about missing documentation files:**
+If you encounter build errors related to missing files in `internal/embeddocs/website/`, you likely need to initialize the git submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+The documentation is stored as a git submodule pointing to the [`inngest/website`](https://github.com/inngest/website) repository.


### PR DESCRIPTION
## Description

Adds submodule commands to start commands

## Motivation
When cloning new repo / using old repo, the embedded docs aren't cloned with it, this adds the git submodule command to start commands + docs on it

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
