### PR TITLE
[Insights]: Fix Schema Widget Resizable Overlap Issue

### DIFF
--- a/ui/apps/dev-server-ui/src/routeTree.gen.ts
+++ b/ui/apps/dev-server-ui/src/routeTree.gen.ts
@@ -8,154 +8,154 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router'
 
-import { Route as rootRouteImport } from './routes/__root';
-import { Route as DashboardRouteImport } from './routes/_dashboard';
-import { Route as IndexRouteImport } from './routes/index';
-import { Route as DashboardFunctionsRouteRouteImport } from './routes/_dashboard/functions/route';
-import { Route as DashboardRunsIndexRouteImport } from './routes/_dashboard/runs/index';
-import { Route as DashboardRunIndexRouteImport } from './routes/_dashboard/run/index';
-import { Route as DashboardEventsIndexRouteImport } from './routes/_dashboard/events/index';
-import { Route as DashboardEventIndexRouteImport } from './routes/_dashboard/event/index';
-import { Route as DashboardAppsIndexRouteImport } from './routes/_dashboard/apps/index';
-import { Route as DashboardAppsOnboardingRouteRouteImport } from './routes/_dashboard/apps/_onboarding/route';
-import { Route as DashboardFunctionsConfigIndexRouteImport } from './routes/_dashboard/functions/config/index';
-import { Route as DashboardDebuggerFunctionIndexRouteImport } from './routes/_dashboard/debugger/function/index';
-import { Route as DashboardAppsAppIndexRouteImport } from './routes/_dashboard/apps/app/index';
-import { Route as DashboardAppsOnboardingChooseTemplateRouteImport } from './routes/_dashboard/apps/_onboarding/choose-template';
-import { Route as DashboardAppsOnboardingChooseFrameworkRouteImport } from './routes/_dashboard/apps/_onboarding/choose-framework';
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as DashboardRouteImport } from './routes/_dashboard'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as DashboardFunctionsRouteRouteImport } from './routes/_dashboard/functions/route'
+import { Route as DashboardRunsIndexRouteImport } from './routes/_dashboard/runs/index'
+import { Route as DashboardRunIndexRouteImport } from './routes/_dashboard/run/index'
+import { Route as DashboardEventsIndexRouteImport } from './routes/_dashboard/events/index'
+import { Route as DashboardEventIndexRouteImport } from './routes/_dashboard/event/index'
+import { Route as DashboardAppsIndexRouteImport } from './routes/_dashboard/apps/index'
+import { Route as DashboardAppsOnboardingRouteRouteImport } from './routes/_dashboard/apps/_onboarding/route'
+import { Route as DashboardFunctionsConfigIndexRouteImport } from './routes/_dashboard/functions/config/index'
+import { Route as DashboardDebuggerFunctionIndexRouteImport } from './routes/_dashboard/debugger/function/index'
+import { Route as DashboardAppsAppIndexRouteImport } from './routes/_dashboard/apps/app/index'
+import { Route as DashboardAppsOnboardingChooseTemplateRouteImport } from './routes/_dashboard/apps/_onboarding/choose-template'
+import { Route as DashboardAppsOnboardingChooseFrameworkRouteImport } from './routes/_dashboard/apps/_onboarding/choose-framework'
 
-const DashboardAppsRouteImport = createFileRoute('/_dashboard/apps')();
+const DashboardAppsRouteImport = createFileRoute('/_dashboard/apps')()
 
 const DashboardRoute = DashboardRouteImport.update({
   id: '/_dashboard',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DashboardAppsRoute = DashboardAppsRouteImport.update({
   id: '/apps',
   path: '/apps',
   getParentRoute: () => DashboardRoute,
-} as any);
+} as any)
 const DashboardFunctionsRouteRoute = DashboardFunctionsRouteRouteImport.update({
   id: '/functions',
   path: '/functions',
   getParentRoute: () => DashboardRoute,
-} as any);
+} as any)
 const DashboardRunsIndexRoute = DashboardRunsIndexRouteImport.update({
   id: '/runs/',
   path: '/runs/',
   getParentRoute: () => DashboardRoute,
-} as any);
+} as any)
 const DashboardRunIndexRoute = DashboardRunIndexRouteImport.update({
   id: '/run/',
   path: '/run/',
   getParentRoute: () => DashboardRoute,
-} as any);
+} as any)
 const DashboardEventsIndexRoute = DashboardEventsIndexRouteImport.update({
   id: '/events/',
   path: '/events/',
   getParentRoute: () => DashboardRoute,
-} as any);
+} as any)
 const DashboardEventIndexRoute = DashboardEventIndexRouteImport.update({
   id: '/event/',
   path: '/event/',
   getParentRoute: () => DashboardRoute,
-} as any);
+} as any)
 const DashboardAppsIndexRoute = DashboardAppsIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => DashboardAppsRoute,
-} as any);
+} as any)
 const DashboardAppsOnboardingRouteRoute =
   DashboardAppsOnboardingRouteRouteImport.update({
     id: '/_onboarding',
     getParentRoute: () => DashboardAppsRoute,
-  } as any);
+  } as any)
 const DashboardFunctionsConfigIndexRoute =
   DashboardFunctionsConfigIndexRouteImport.update({
     id: '/config/',
     path: '/config/',
     getParentRoute: () => DashboardFunctionsRouteRoute,
-  } as any);
+  } as any)
 const DashboardDebuggerFunctionIndexRoute =
   DashboardDebuggerFunctionIndexRouteImport.update({
     id: '/debugger/function/',
     path: '/debugger/function/',
     getParentRoute: () => DashboardRoute,
-  } as any);
+  } as any)
 const DashboardAppsAppIndexRoute = DashboardAppsAppIndexRouteImport.update({
   id: '/app/',
   path: '/app/',
   getParentRoute: () => DashboardAppsRoute,
-} as any);
+} as any)
 const DashboardAppsOnboardingChooseTemplateRoute =
   DashboardAppsOnboardingChooseTemplateRouteImport.update({
     id: '/choose-template',
     path: '/choose-template',
     getParentRoute: () => DashboardAppsOnboardingRouteRoute,
-  } as any);
+  } as any)
 const DashboardAppsOnboardingChooseFrameworkRoute =
   DashboardAppsOnboardingChooseFrameworkRouteImport.update({
     id: '/choose-framework',
     path: '/choose-framework',
     getParentRoute: () => DashboardAppsOnboardingRouteRoute,
-  } as any);
+  } as any)
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute;
-  '/functions': typeof DashboardFunctionsRouteRouteWithChildren;
-  '/apps': typeof DashboardAppsOnboardingRouteRouteWithChildren;
-  '/apps/': typeof DashboardAppsIndexRoute;
-  '/event': typeof DashboardEventIndexRoute;
-  '/events': typeof DashboardEventsIndexRoute;
-  '/run': typeof DashboardRunIndexRoute;
-  '/runs': typeof DashboardRunsIndexRoute;
-  '/apps/choose-framework': typeof DashboardAppsOnboardingChooseFrameworkRoute;
-  '/apps/choose-template': typeof DashboardAppsOnboardingChooseTemplateRoute;
-  '/apps/app': typeof DashboardAppsAppIndexRoute;
-  '/debugger/function': typeof DashboardDebuggerFunctionIndexRoute;
-  '/functions/config': typeof DashboardFunctionsConfigIndexRoute;
+  '/': typeof IndexRoute
+  '/functions': typeof DashboardFunctionsRouteRouteWithChildren
+  '/apps': typeof DashboardAppsOnboardingRouteRouteWithChildren
+  '/apps/': typeof DashboardAppsIndexRoute
+  '/event': typeof DashboardEventIndexRoute
+  '/events': typeof DashboardEventsIndexRoute
+  '/run': typeof DashboardRunIndexRoute
+  '/runs': typeof DashboardRunsIndexRoute
+  '/apps/choose-framework': typeof DashboardAppsOnboardingChooseFrameworkRoute
+  '/apps/choose-template': typeof DashboardAppsOnboardingChooseTemplateRoute
+  '/apps/app': typeof DashboardAppsAppIndexRoute
+  '/debugger/function': typeof DashboardDebuggerFunctionIndexRoute
+  '/functions/config': typeof DashboardFunctionsConfigIndexRoute
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute;
-  '/functions': typeof DashboardFunctionsRouteRouteWithChildren;
-  '/apps': typeof DashboardAppsIndexRoute;
-  '/event': typeof DashboardEventIndexRoute;
-  '/events': typeof DashboardEventsIndexRoute;
-  '/run': typeof DashboardRunIndexRoute;
-  '/runs': typeof DashboardRunsIndexRoute;
-  '/apps/choose-framework': typeof DashboardAppsOnboardingChooseFrameworkRoute;
-  '/apps/choose-template': typeof DashboardAppsOnboardingChooseTemplateRoute;
-  '/apps/app': typeof DashboardAppsAppIndexRoute;
-  '/debugger/function': typeof DashboardDebuggerFunctionIndexRoute;
-  '/functions/config': typeof DashboardFunctionsConfigIndexRoute;
+  '/': typeof IndexRoute
+  '/functions': typeof DashboardFunctionsRouteRouteWithChildren
+  '/apps': typeof DashboardAppsIndexRoute
+  '/event': typeof DashboardEventIndexRoute
+  '/events': typeof DashboardEventsIndexRoute
+  '/run': typeof DashboardRunIndexRoute
+  '/runs': typeof DashboardRunsIndexRoute
+  '/apps/choose-framework': typeof DashboardAppsOnboardingChooseFrameworkRoute
+  '/apps/choose-template': typeof DashboardAppsOnboardingChooseTemplateRoute
+  '/apps/app': typeof DashboardAppsAppIndexRoute
+  '/debugger/function': typeof DashboardDebuggerFunctionIndexRoute
+  '/functions/config': typeof DashboardFunctionsConfigIndexRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  '/': typeof IndexRoute;
-  '/_dashboard': typeof DashboardRouteWithChildren;
-  '/_dashboard/functions': typeof DashboardFunctionsRouteRouteWithChildren;
-  '/_dashboard/apps': typeof DashboardAppsRouteWithChildren;
-  '/_dashboard/apps/_onboarding': typeof DashboardAppsOnboardingRouteRouteWithChildren;
-  '/_dashboard/apps/': typeof DashboardAppsIndexRoute;
-  '/_dashboard/event/': typeof DashboardEventIndexRoute;
-  '/_dashboard/events/': typeof DashboardEventsIndexRoute;
-  '/_dashboard/run/': typeof DashboardRunIndexRoute;
-  '/_dashboard/runs/': typeof DashboardRunsIndexRoute;
-  '/_dashboard/apps/_onboarding/choose-framework': typeof DashboardAppsOnboardingChooseFrameworkRoute;
-  '/_dashboard/apps/_onboarding/choose-template': typeof DashboardAppsOnboardingChooseTemplateRoute;
-  '/_dashboard/apps/app/': typeof DashboardAppsAppIndexRoute;
-  '/_dashboard/debugger/function/': typeof DashboardDebuggerFunctionIndexRoute;
-  '/_dashboard/functions/config/': typeof DashboardFunctionsConfigIndexRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/_dashboard': typeof DashboardRouteWithChildren
+  '/_dashboard/functions': typeof DashboardFunctionsRouteRouteWithChildren
+  '/_dashboard/apps': typeof DashboardAppsRouteWithChildren
+  '/_dashboard/apps/_onboarding': typeof DashboardAppsOnboardingRouteRouteWithChildren
+  '/_dashboard/apps/': typeof DashboardAppsIndexRoute
+  '/_dashboard/event/': typeof DashboardEventIndexRoute
+  '/_dashboard/events/': typeof DashboardEventsIndexRoute
+  '/_dashboard/run/': typeof DashboardRunIndexRoute
+  '/_dashboard/runs/': typeof DashboardRunsIndexRoute
+  '/_dashboard/apps/_onboarding/choose-framework': typeof DashboardAppsOnboardingChooseFrameworkRoute
+  '/_dashboard/apps/_onboarding/choose-template': typeof DashboardAppsOnboardingChooseTemplateRoute
+  '/_dashboard/apps/app/': typeof DashboardAppsAppIndexRoute
+  '/_dashboard/debugger/function/': typeof DashboardDebuggerFunctionIndexRoute
+  '/_dashboard/functions/config/': typeof DashboardFunctionsConfigIndexRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
     | '/functions'
@@ -169,8 +169,8 @@ export interface FileRouteTypes {
     | '/apps/choose-template'
     | '/apps/app'
     | '/debugger/function'
-    | '/functions/config';
-  fileRoutesByTo: FileRoutesByTo;
+    | '/functions/config'
+  fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/functions'
@@ -183,7 +183,7 @@ export interface FileRouteTypes {
     | '/apps/choose-template'
     | '/apps/app'
     | '/debugger/function'
-    | '/functions/config';
+    | '/functions/config'
   id:
     | '__root__'
     | '/'
@@ -200,141 +200,141 @@ export interface FileRouteTypes {
     | '/_dashboard/apps/_onboarding/choose-template'
     | '/_dashboard/apps/app/'
     | '/_dashboard/debugger/function/'
-    | '/_dashboard/functions/config/';
-  fileRoutesById: FileRoutesById;
+    | '/_dashboard/functions/config/'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  DashboardRoute: typeof DashboardRouteWithChildren;
+  IndexRoute: typeof IndexRoute
+  DashboardRoute: typeof DashboardRouteWithChildren
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
     '/_dashboard': {
-      id: '/_dashboard';
-      path: '';
-      fullPath: '';
-      preLoaderRoute: typeof DashboardRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/_dashboard'
+      path: ''
+      fullPath: ''
+      preLoaderRoute: typeof DashboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
-      id: '/';
-      path: '/';
-      fullPath: '/';
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_dashboard/apps': {
-      id: '/_dashboard/apps';
-      path: '/apps';
-      fullPath: '/apps';
-      preLoaderRoute: typeof DashboardAppsRouteImport;
-      parentRoute: typeof DashboardRoute;
-    };
+      id: '/_dashboard/apps'
+      path: '/apps'
+      fullPath: '/apps'
+      preLoaderRoute: typeof DashboardAppsRouteImport
+      parentRoute: typeof DashboardRoute
+    }
     '/_dashboard/functions': {
-      id: '/_dashboard/functions';
-      path: '/functions';
-      fullPath: '/functions';
-      preLoaderRoute: typeof DashboardFunctionsRouteRouteImport;
-      parentRoute: typeof DashboardRoute;
-    };
+      id: '/_dashboard/functions'
+      path: '/functions'
+      fullPath: '/functions'
+      preLoaderRoute: typeof DashboardFunctionsRouteRouteImport
+      parentRoute: typeof DashboardRoute
+    }
     '/_dashboard/runs/': {
-      id: '/_dashboard/runs/';
-      path: '/runs';
-      fullPath: '/runs';
-      preLoaderRoute: typeof DashboardRunsIndexRouteImport;
-      parentRoute: typeof DashboardRoute;
-    };
+      id: '/_dashboard/runs/'
+      path: '/runs'
+      fullPath: '/runs'
+      preLoaderRoute: typeof DashboardRunsIndexRouteImport
+      parentRoute: typeof DashboardRoute
+    }
     '/_dashboard/run/': {
-      id: '/_dashboard/run/';
-      path: '/run';
-      fullPath: '/run';
-      preLoaderRoute: typeof DashboardRunIndexRouteImport;
-      parentRoute: typeof DashboardRoute;
-    };
+      id: '/_dashboard/run/'
+      path: '/run'
+      fullPath: '/run'
+      preLoaderRoute: typeof DashboardRunIndexRouteImport
+      parentRoute: typeof DashboardRoute
+    }
     '/_dashboard/events/': {
-      id: '/_dashboard/events/';
-      path: '/events';
-      fullPath: '/events';
-      preLoaderRoute: typeof DashboardEventsIndexRouteImport;
-      parentRoute: typeof DashboardRoute;
-    };
+      id: '/_dashboard/events/'
+      path: '/events'
+      fullPath: '/events'
+      preLoaderRoute: typeof DashboardEventsIndexRouteImport
+      parentRoute: typeof DashboardRoute
+    }
     '/_dashboard/event/': {
-      id: '/_dashboard/event/';
-      path: '/event';
-      fullPath: '/event';
-      preLoaderRoute: typeof DashboardEventIndexRouteImport;
-      parentRoute: typeof DashboardRoute;
-    };
+      id: '/_dashboard/event/'
+      path: '/event'
+      fullPath: '/event'
+      preLoaderRoute: typeof DashboardEventIndexRouteImport
+      parentRoute: typeof DashboardRoute
+    }
     '/_dashboard/apps/': {
-      id: '/_dashboard/apps/';
-      path: '/';
-      fullPath: '/apps/';
-      preLoaderRoute: typeof DashboardAppsIndexRouteImport;
-      parentRoute: typeof DashboardAppsRoute;
-    };
+      id: '/_dashboard/apps/'
+      path: '/'
+      fullPath: '/apps/'
+      preLoaderRoute: typeof DashboardAppsIndexRouteImport
+      parentRoute: typeof DashboardAppsRoute
+    }
     '/_dashboard/apps/_onboarding': {
-      id: '/_dashboard/apps/_onboarding';
-      path: '/apps';
-      fullPath: '/apps';
-      preLoaderRoute: typeof DashboardAppsOnboardingRouteRouteImport;
-      parentRoute: typeof DashboardAppsRoute;
-    };
+      id: '/_dashboard/apps/_onboarding'
+      path: '/apps'
+      fullPath: '/apps'
+      preLoaderRoute: typeof DashboardAppsOnboardingRouteRouteImport
+      parentRoute: typeof DashboardAppsRoute
+    }
     '/_dashboard/functions/config/': {
-      id: '/_dashboard/functions/config/';
-      path: '/config';
-      fullPath: '/functions/config';
-      preLoaderRoute: typeof DashboardFunctionsConfigIndexRouteImport;
-      parentRoute: typeof DashboardFunctionsRouteRoute;
-    };
+      id: '/_dashboard/functions/config/'
+      path: '/config'
+      fullPath: '/functions/config'
+      preLoaderRoute: typeof DashboardFunctionsConfigIndexRouteImport
+      parentRoute: typeof DashboardFunctionsRouteRoute
+    }
     '/_dashboard/debugger/function/': {
-      id: '/_dashboard/debugger/function/';
-      path: '/debugger/function';
-      fullPath: '/debugger/function';
-      preLoaderRoute: typeof DashboardDebuggerFunctionIndexRouteImport;
-      parentRoute: typeof DashboardRoute;
-    };
+      id: '/_dashboard/debugger/function/'
+      path: '/debugger/function'
+      fullPath: '/debugger/function'
+      preLoaderRoute: typeof DashboardDebuggerFunctionIndexRouteImport
+      parentRoute: typeof DashboardRoute
+    }
     '/_dashboard/apps/app/': {
-      id: '/_dashboard/apps/app/';
-      path: '/app';
-      fullPath: '/apps/app';
-      preLoaderRoute: typeof DashboardAppsAppIndexRouteImport;
-      parentRoute: typeof DashboardAppsRoute;
-    };
+      id: '/_dashboard/apps/app/'
+      path: '/app'
+      fullPath: '/apps/app'
+      preLoaderRoute: typeof DashboardAppsAppIndexRouteImport
+      parentRoute: typeof DashboardAppsRoute
+    }
     '/_dashboard/apps/_onboarding/choose-template': {
-      id: '/_dashboard/apps/_onboarding/choose-template';
-      path: '/choose-template';
-      fullPath: '/apps/choose-template';
-      preLoaderRoute: typeof DashboardAppsOnboardingChooseTemplateRouteImport;
-      parentRoute: typeof DashboardAppsOnboardingRouteRoute;
-    };
+      id: '/_dashboard/apps/_onboarding/choose-template'
+      path: '/choose-template'
+      fullPath: '/apps/choose-template'
+      preLoaderRoute: typeof DashboardAppsOnboardingChooseTemplateRouteImport
+      parentRoute: typeof DashboardAppsOnboardingRouteRoute
+    }
     '/_dashboard/apps/_onboarding/choose-framework': {
-      id: '/_dashboard/apps/_onboarding/choose-framework';
-      path: '/choose-framework';
-      fullPath: '/apps/choose-framework';
-      preLoaderRoute: typeof DashboardAppsOnboardingChooseFrameworkRouteImport;
-      parentRoute: typeof DashboardAppsOnboardingRouteRoute;
-    };
+      id: '/_dashboard/apps/_onboarding/choose-framework'
+      path: '/choose-framework'
+      fullPath: '/apps/choose-framework'
+      preLoaderRoute: typeof DashboardAppsOnboardingChooseFrameworkRouteImport
+      parentRoute: typeof DashboardAppsOnboardingRouteRoute
+    }
   }
 }
 
 interface DashboardFunctionsRouteRouteChildren {
-  DashboardFunctionsConfigIndexRoute: typeof DashboardFunctionsConfigIndexRoute;
+  DashboardFunctionsConfigIndexRoute: typeof DashboardFunctionsConfigIndexRoute
 }
 
 const DashboardFunctionsRouteRouteChildren: DashboardFunctionsRouteRouteChildren =
   {
     DashboardFunctionsConfigIndexRoute: DashboardFunctionsConfigIndexRoute,
-  };
+  }
 
 const DashboardFunctionsRouteRouteWithChildren =
   DashboardFunctionsRouteRoute._addFileChildren(
     DashboardFunctionsRouteRouteChildren,
-  );
+  )
 
 interface DashboardAppsOnboardingRouteRouteChildren {
-  DashboardAppsOnboardingChooseFrameworkRoute: typeof DashboardAppsOnboardingChooseFrameworkRoute;
-  DashboardAppsOnboardingChooseTemplateRoute: typeof DashboardAppsOnboardingChooseTemplateRoute;
+  DashboardAppsOnboardingChooseFrameworkRoute: typeof DashboardAppsOnboardingChooseFrameworkRoute
+  DashboardAppsOnboardingChooseTemplateRoute: typeof DashboardAppsOnboardingChooseTemplateRoute
 }
 
 const DashboardAppsOnboardingRouteRouteChildren: DashboardAppsOnboardingRouteRouteChildren =
@@ -343,17 +343,17 @@ const DashboardAppsOnboardingRouteRouteChildren: DashboardAppsOnboardingRouteRou
       DashboardAppsOnboardingChooseFrameworkRoute,
     DashboardAppsOnboardingChooseTemplateRoute:
       DashboardAppsOnboardingChooseTemplateRoute,
-  };
+  }
 
 const DashboardAppsOnboardingRouteRouteWithChildren =
   DashboardAppsOnboardingRouteRoute._addFileChildren(
     DashboardAppsOnboardingRouteRouteChildren,
-  );
+  )
 
 interface DashboardAppsRouteChildren {
-  DashboardAppsOnboardingRouteRoute: typeof DashboardAppsOnboardingRouteRouteWithChildren;
-  DashboardAppsIndexRoute: typeof DashboardAppsIndexRoute;
-  DashboardAppsAppIndexRoute: typeof DashboardAppsAppIndexRoute;
+  DashboardAppsOnboardingRouteRoute: typeof DashboardAppsOnboardingRouteRouteWithChildren
+  DashboardAppsIndexRoute: typeof DashboardAppsIndexRoute
+  DashboardAppsAppIndexRoute: typeof DashboardAppsAppIndexRoute
 }
 
 const DashboardAppsRouteChildren: DashboardAppsRouteChildren = {
@@ -361,20 +361,20 @@ const DashboardAppsRouteChildren: DashboardAppsRouteChildren = {
     DashboardAppsOnboardingRouteRouteWithChildren,
   DashboardAppsIndexRoute: DashboardAppsIndexRoute,
   DashboardAppsAppIndexRoute: DashboardAppsAppIndexRoute,
-};
+}
 
 const DashboardAppsRouteWithChildren = DashboardAppsRoute._addFileChildren(
   DashboardAppsRouteChildren,
-);
+)
 
 interface DashboardRouteChildren {
-  DashboardFunctionsRouteRoute: typeof DashboardFunctionsRouteRouteWithChildren;
-  DashboardAppsRoute: typeof DashboardAppsRouteWithChildren;
-  DashboardEventIndexRoute: typeof DashboardEventIndexRoute;
-  DashboardEventsIndexRoute: typeof DashboardEventsIndexRoute;
-  DashboardRunIndexRoute: typeof DashboardRunIndexRoute;
-  DashboardRunsIndexRoute: typeof DashboardRunsIndexRoute;
-  DashboardDebuggerFunctionIndexRoute: typeof DashboardDebuggerFunctionIndexRoute;
+  DashboardFunctionsRouteRoute: typeof DashboardFunctionsRouteRouteWithChildren
+  DashboardAppsRoute: typeof DashboardAppsRouteWithChildren
+  DashboardEventIndexRoute: typeof DashboardEventIndexRoute
+  DashboardEventsIndexRoute: typeof DashboardEventsIndexRoute
+  DashboardRunIndexRoute: typeof DashboardRunIndexRoute
+  DashboardRunsIndexRoute: typeof DashboardRunsIndexRoute
+  DashboardDebuggerFunctionIndexRoute: typeof DashboardDebuggerFunctionIndexRoute
 }
 
 const DashboardRouteChildren: DashboardRouteChildren = {
@@ -385,26 +385,26 @@ const DashboardRouteChildren: DashboardRouteChildren = {
   DashboardRunIndexRoute: DashboardRunIndexRoute,
   DashboardRunsIndexRoute: DashboardRunsIndexRoute,
   DashboardDebuggerFunctionIndexRoute: DashboardDebuggerFunctionIndexRoute,
-};
+}
 
 const DashboardRouteWithChildren = DashboardRoute._addFileChildren(
   DashboardRouteChildren,
-);
+)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   DashboardRoute: DashboardRouteWithChildren,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from './router.tsx';
-import type { startInstance } from './start.ts';
+import type { getRouter } from './router.tsx'
+import type { startInstance } from './start.ts'
 declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }


### PR DESCRIPTION
## Description

This lessens an issue where the (invisible) click area for the Resizable overlapped the scrollbar for the Insights results table. It "lessens" it because there is still some overlap. In lieu of spending time on a more precise solution, this improves the situation. We can follow up again if users find the state after this PR frustrating.

---

<img width="239" height="280" alt="Screenshot 2025-11-03 at 9 45 21 AM" src="https://github.com/user-attachments/assets/f4dec1de-4c18-416a-82cd-e9f9f983dab1" />

---

**NOTE:** There's no visual change. The width (or height) that was changed was an invisible click target.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
