### PR TITLE
Changed overlay time format.Enabled copy ISO in table

### DIFF
--- a/ui/packages/components/src/Table/Cell.tsx
+++ b/ui/packages/components/src/Table/Cell.tsx
@@ -50,7 +50,7 @@ export function PillCell({
 export function TimeCell({ date, format }: { date: Date | string; format?: 'relative' }) {
   return (
     <span className={cn(cellStyles, 'text-muted font-medium')}>
-      <Time value={date} format={format} copyable={false} />
+      <Time value={date} format={format} copyable={true} />
     </span>
   );
 }

--- a/ui/packages/components/src/Time.tsx
+++ b/ui/packages/components/src/Time.tsx
@@ -21,7 +21,7 @@ type Props = {
 };
 
 function formatDate(date: Date) {
-  return format(date, 'dd MMM yyyy, HH:mm:ss');
+  return format(date, 'dd MMM yyyy, hh:mm:ss a');
 }
 
 function formatUTCDate(date: Date) {
@@ -67,15 +67,15 @@ export function Time({ className, format, value, copyable = true }: Props) {
           {copyable && <RiFileCopyLine className="text-subtle hidden h-3 w-3 group-hover:block" />}
         </time>
       </TooltipTrigger>
-      <TooltipContent side="right" className="w-64 max-w-64 px-0">
-        <div className="mb-[6px] ml-3 mr-4 mt-1.5 flex items-center justify-between gap-2 text-sm">
-          <div className="text-light flex items-center gap-1">
+      <TooltipContent side="right" className="w-auto px-0">
+        <div className="mb-[6px] ml-3 mr-4 mt-1.5 flex items-center gap-2 whitespace-nowrap text-sm">
+          <div className="text-light flex w-16 items-center gap-1">
             <RiTimeLine className="h-[14px] w-[14px]" /> UTC
           </div>
           <time className="text-onContrast">{utcTimeString}</time>
         </div>
-        <div className="mb-[6px] ml-3 mr-4 flex items-center justify-between gap-5 text-sm">
-          <div className="text-light flex items-center gap-1">
+        <div className="mb-[6px] ml-3 mr-4 flex items-center gap-2 whitespace-nowrap text-sm">
+          <div className="text-light flex w-16 items-center gap-1">
             <RiUserSmileLine className="h-[14px] w-[14px]" /> Local
           </div>
           <time className="text-onContrast">{localTimeString}</time>


### PR DESCRIPTION
## Description
Changed the overlay to 12 hour format to match the table 
<img width="679" height="331" alt="image" src="https://github.com/user-attachments/assets/03c32830-03bf-4d55-a93d-35c6e6ee1f7e" />


Allow users to copy ISO from the table cell

This is what currently exists 
<img width="738" height="519" alt="image" src="https://github.com/user-attachments/assets/50d1f6d7-78bf-4967-9040-77cf05335e55" />


<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
