### PR TITLE
Allow block store creation without bucket

### DIFF
--- a/pkg/execution/pauses/block.go
+++ b/pkg/execution/pauses/block.go
@@ -81,9 +81,6 @@ func NewBlockstore(opts BlockstoreOpts) (BlockStore, error) {
 	if opts.RC == nil {
 		return nil, fmt.Errorf("redis client is required")
 	}
-	if opts.Bucket == nil {
-		return nil, fmt.Errorf("bucket is required")
-	}
 	if opts.Bufferer == nil {
 		return nil, fmt.Errorf("bufferer is required")
 	}
@@ -420,6 +417,9 @@ func (b blockstore) BlocksSince(ctx context.Context, index Index, since time.Tim
 }
 
 func (b blockstore) ReadBlock(ctx context.Context, index Index, blockID ulid.ULID) (*Block, error) {
+	if b.bucket == nil {
+		return nil, fmt.Errorf("error bucket is not setup")
+	}
 	key := b.BlockKey(index, blockID)
 	logger.StdlibLogger(ctx).Debug("reading block", "block_key", key)
 	byt, err := b.bucket.ReadAll(ctx, key)


### PR DESCRIPTION
## Description

Executors will have to read some metadata from the block store struct such as the `blockSize` so this allows to create the struct without a bucket setup.


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
