### PR TITLE
only emit status updates when they change

### DIFF
--- a/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
+++ b/ui/packages/components/src/RunDetailsV3/RunDetailsV3.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react
 
 import { ErrorCard } from '../Error/ErrorCard';
 import type { Run as InitialRunData } from '../RunsPage/types';
-import { useShared } from '../SharedContext/SharedContext';
 import { useBooleanFlag } from '../SharedContext/useBooleanFlag';
 import { useGetRun } from '../SharedContext/useGetRun';
 import { useGetTraceResult } from '../SharedContext/useGetTraceResult';
@@ -65,7 +64,7 @@ export const RunDetailsV3 = ({
     false
   );
   const { value: tracesPreviewEnabled } = booleanFlag('traces-preview', true, true);
-  const { dynamicRunData, updateDynamicRunData } = useDynamicRunData({ runID });
+  const { updateDynamicRunData } = useDynamicRunData({ runID });
 
   const containerRef = useRef<HTMLDivElement>(null);
   const leftColumnRef = useRef<HTMLDivElement>(null);
@@ -188,12 +187,15 @@ export const RunDetailsV3 = ({
   }
 
   useEffect(() => {
-    runData?.trace.status &&
-      updateDynamicRunData({
-        runID,
-        status: runData.trace.status,
-        endedAt: runData.trace.endedAt ?? undefined,
-      });
+    if (!runData?.trace.status || runData?.trace.status === initialRunData?.status) {
+      return;
+    }
+
+    updateDynamicRunData({
+      runID,
+      status: runData.trace.status,
+      endedAt: runData.trace.endedAt ?? undefined,
+    });
   }, [runData?.trace.endedAt, runData?.trace.status]);
 
   const waiting = isWaiting(initialRunData?.status || runData?.status, runError, resultError);

--- a/ui/packages/components/src/RunDetailsV3/utils.ts
+++ b/ui/packages/components/src/RunDetailsV3/utils.ts
@@ -187,9 +187,12 @@ const dynamicRunDataEmitter = {
   },
 };
 
+//
+// This is a way for the detail trace data (which we poll) to emit updates to statuses and
+// run end times so we can immediately reflect those changes in the run list.
+// This exists because we can't currently, easily poll the run list to get realtime updates there.
 export const useDynamicRunData = ({ runID }: { runID?: string }) => {
   const [dynamicRunData, setDynamicRunData] = useState<DynamicRunData | undefined>(undefined);
-  const previousDataRef = useRef<DynamicRunData | undefined>(undefined);
 
   useEffect(() => {
     const cleanup = dynamicRunDataEmitter.subscribe(setDynamicRunData, runID);
@@ -199,10 +202,7 @@ export const useDynamicRunData = ({ runID }: { runID?: string }) => {
   }, [runID]);
 
   const updateDynamicRunData = useCallback((data: DynamicRunData | undefined) => {
-    if (JSON.stringify(previousDataRef.current) !== JSON.stringify(data)) {
-      previousDataRef.current = data;
-      dynamicRunDataEmitter.emit(data);
-    }
+    dynamicRunDataEmitter.emit(data);
   }, []);
 
   return { dynamicRunData, updateDynamicRunData };


### PR DESCRIPTION
## Description
only emit status updates when they change

## Motivation
makes the run detail status emitter less chatty

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
