### PR TITLE
Log slow queue operations

### DIFF
--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -312,6 +312,7 @@ LOOP:
 				// have capacity to run at least MinWorkersFree concurrent
 				// QueueItems.  This reduces latency of enqueued items when
 				// there are lots of enqueued and available jobs.
+				l.Warn("all workers busy, early exiting scan", "worker_capacity", q.capacity())
 				continue
 			}
 
@@ -626,6 +627,12 @@ func (q *queue) scanPartition(ctx context.Context, partitionKey string, peekLimi
 			"peek_until", peekUntil.Format(time.StampMilli),
 			"partition", len(partitions),
 		)
+	} else {
+		q.log.Debug("partition_peek yielded no partitions",
+			"partition_key", partitionKey,
+			"peek_until", peekUntil.Format(time.StampMilli),
+			"partition", len(partitions),
+		)
 	}
 
 	eg := errgroup.Group{}
@@ -713,6 +720,7 @@ func (q *queue) scan(ctx context.Context) error {
 		}
 
 		if len(peekedAccounts) == 0 {
+			q.log.Debug("account_peek yielded no accounts")
 			return nil
 		}
 


### PR DESCRIPTION
## Description

Log slow queue operations that take over 1s. The execution scan runs in a tick of 10ms interval - we shouldn't see any individual queue operations taking over 1s.


## Motivation
https://linear.app/inngest/issue/SYS-478/investigate-executor-intermittent-laziness

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
