### PR TITLE
Fix new default level

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/support/ticketOptions.ts
+++ b/ui/apps/dashboard/src/app/(organization-active)/support/ticketOptions.ts
@@ -80,4 +80,4 @@ export const severityOptions: SeverityOption[] = [
   },
 ];
 export type BugSeverity = (typeof severityOptions)[number]['value'];
-export const DEFAULT_BUG_SEVERITY_LEVEL = '4';
+export const DEFAULT_BUG_SEVERITY_LEVEL = '3';


### PR DESCRIPTION
## Description

Previous PR cleaned up the levels, this sets the default to 3, not 4 since we got rid of 4.

## Motivation
Fix default here: 
<img width="1408" height="1192" alt="image" src="https://github.com/user-attachments/assets/bdf80c5c-90f4-4e77-b3ee-2d982d2d57ae" />


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
