### PR TITLE
refactor: store AppID and FunctionID on userland traces

### DIFF
--- a/pkg/api/apiv1/traces.go
+++ b/pkg/api/apiv1/traces.go
@@ -151,7 +151,7 @@ func (a router) convertOTLPAndSend(ctx context.Context, auth apiv1auth.V1Auth, r
 						}
 					}()
 
-					err := a.commitSpan(res, ss.Scope, s)
+					err := a.commitSpan(ctx, auth, res, ss.Scope, s)
 					if err != nil {
 						l.Error("failed to commit span with", "error", err)
 						errs.Add(1)
@@ -167,7 +167,7 @@ func (a router) convertOTLPAndSend(ctx context.Context, auth apiv1auth.V1Auth, r
 	return errs.Load()
 }
 
-func (a router) commitSpan(res *resource.Resource, scope *commonv1.InstrumentationScope, s *tracev1.Span) error {
+func (a router) commitSpan(ctx context.Context, auth apiv1auth.V1Auth, res *resource.Resource, scope *commonv1.InstrumentationScope, s *tracev1.Span) error {
 	// To be valid, each span must have an "inngest.traceref" attribute
 	tr, err := getInngestTraceRef(s)
 	if err != nil {
@@ -207,6 +207,20 @@ func (a router) commitSpan(res *resource.Resource, scope *commonv1.Instrumentati
 	resourceServiceName := resourceServiceName(res)
 	isUserland := true
 
+	run, err := a.opts.FunctionRunReader.GetFunctionRun(ctx, auth.AccountID(), auth.WorkspaceID(), runID)
+	if err != nil {
+		return fmt.Errorf("function run not found: %w", err)
+	}
+	functionID := run.FunctionID
+
+	fn, err := a.opts.FunctionReader.GetFunctionByInternalUUID(ctx, functionID)
+	if err != nil {
+		return fmt.Errorf("function not found: %w", err)
+	}
+	if fn.IsArchived() {
+		return fmt.Errorf("function is archived: %s", functionID)
+	}
+
 	ourAttrs := meta.NewAttrSet(
 		meta.Attr(meta.Attrs.IsUserland, &isUserland),
 		meta.Attr(meta.Attrs.UserlandSpanID, &spanID),
@@ -218,6 +232,8 @@ func (a router) commitSpan(res *resource.Resource, scope *commonv1.Instrumentati
 		meta.Attr(meta.Attrs.UserlandServiceName, &resourceServiceName),
 		meta.Attr(meta.Attrs.UserlandScopeName, &scope.Name),
 		meta.Attr(meta.Attrs.UserlandScopeVersion, &scope.Version),
+		meta.Attr(meta.Attrs.AppID, &fn.AppID),
+		meta.Attr(meta.Attrs.FunctionID, &functionID),
 	)
 
 	// Add some additional attributes on top


### PR DESCRIPTION
## Description

These attributes are required for the rollup to work correctly in cloud.

## Motivation

Enabling userland traces to display in cloud, a la [EXE-850: Change Default OTEL Entitlement to True](https://linear.app/inngest/issue/EXE-850/change-default-otel-entitlement-to-true)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
