### PR TITLE
[SYS-370] Connect Worker Concurrency - Change UI Errors

### DIFF
--- a/pkg/connect/grpc/proxy.go
+++ b/pkg/connect/grpc/proxy.go
@@ -413,7 +413,7 @@ func (i *grpcConnector) Proxy(ctx, traceCtx context.Context, opts ProxyOpts) (*c
 			if errors.Is(err, state.ErrWorkerCapacityExceeded) {
 				return nil, syscode.Error{
 					Code:    syscode.CodeConnectRequestAssignWorkerReachedCapacity,
-					Message: "Assigned worker reached capacity before request was assigned",
+					Message: "Assigned worker reached capacity before assigment",
 				}
 			}
 		}
@@ -515,7 +515,7 @@ func (i *grpcConnector) Proxy(ctx, traceCtx context.Context, opts ProxyOpts) (*c
 		if routedInstanceID == "" {
 			return nil, syscode.Error{
 				Code:    syscode.CodeConnectRequestAssignWorkerReachedCapacity,
-				Message: "Lease expired because it wasn't not assigned to a worker.",
+				Message: "All workers reached capacity before assignment",
 			}
 		}
 

--- a/pkg/execution/driver/connectdriver/connectdriver.go
+++ b/pkg/execution/driver/connectdriver/connectdriver.go
@@ -182,11 +182,6 @@ func do(ctx, traceCtx context.Context, forwarder grpc.RequestForwarder, opts grp
 		}
 	}
 
-	// check for connect worker capacity errors
-	if sysErr != nil && (sysErr.Code == syscode.CodeConnectAllWorkersAtCapacity || sysErr.Code == syscode.CodeConnectRequestAssignWorkerReachedCapacity) {
-		return nil, state.ErrConnectWorkerCapacity
-	}
-
 	if resp == nil && err != nil {
 		return nil, err
 	}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1777,6 +1777,11 @@ func (e *executor) executeDriverV1(ctx context.Context, i *runInstance) (*state.
 			}.Serialize(execution.StateErrorKey)
 			response.Output = gracefulErr
 			response.Err = &serr.Code
+
+			// check for connect worker capacity errors after updating the UI response
+			if serr.Code == syscode.CodeConnectAllWorkersAtCapacity || serr.Code == syscode.CodeConnectRequestAssignWorkerReachedCapacity {
+				err = queue.AlwaysRetryError(state.ErrConnectWorkerCapacity)
+			}
 		} else {
 			// Set the response error if it wasn't set, or if Execute had an internal error.
 			// This ensures that we only ever need to check resp.Err to handle errors.

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -335,11 +335,6 @@ func (s *svc) handleQueueItem(ctx context.Context, item queue.Item) (bool, error
 		return false, queue.AlwaysRetryError(err)
 	}
 
-	// connect worker capacity errors should be retried
-	if errors.Is(err, state.ErrConnectWorkerCapacity) {
-		return false, queue.AlwaysRetryError(err)
-	}
-
 	if errors.Is(err, ErrHandledStepError) {
 		// Retry any next steps.
 		return false, err


### PR DESCRIPTION
## Description

Explicitly define worker capacity error in the UI instead of defining it as an Unknown Error

Previously it used to say "Unknown Error" and then the stack used to say "connect workers at capacity"

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
