### PR TITLE
fix: Plumb App ID in state

### DIFF
--- a/pkg/execution/state/v2/state_metadata.go
+++ b/pkg/execution/state/v2/state_metadata.go
@@ -55,6 +55,7 @@ func V1FromMetadata(md Metadata) statev1.Identifier {
 		WorkflowVersion:       md.Config.FunctionVersion,
 		WorkspaceID:           md.ID.Tenant.EnvID,
 		AccountID:             md.ID.Tenant.AccountID,
+		AppID:                 md.ID.Tenant.AppID,
 		EventID:               md.Config.EventID(),
 		EventIDs:              md.Config.EventIDs,
 		BatchID:               md.Config.BatchID,


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

AppID was omitted from state in `V1FromMetadata`. This just sets AppID from Metadata

If this was done intentionally, just LMK and I'll change this PR to add a comment explaining why

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

App ID was being overwritten by ExecutionContext's zero AppID derived from state during span creation.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
