### PR TITLE
fixes partial deletes of pauses

### DIFF
--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -1062,7 +1062,11 @@ func (m unshardedMgr) deletePausesForRun(ctx context.Context, callCtx context.Co
 	if pauseIDs, err := pause.Client().Do(callCtx, pause.Client().B().Smembers().Key(pause.kg.RunPauses(ctx, i.RunID)).Build()).AsStrSlice(); err == nil {
 		for _, id := range pauseIDs {
 			pauseID, _ := uuid.Parse(id)
-			_ = m.DeletePauseByID(ctx, pauseID)
+			err = m.DeletePauseByID(ctx, pauseID)
+			if err != nil {
+				// bubble the error up we can safely retry the whole process
+				return err
+			}
 		}
 	}
 
@@ -1072,16 +1076,15 @@ func (m unshardedMgr) deletePausesForRun(ctx context.Context, callCtx context.Co
 func (m unshardedMgr) DeletePauseByID(ctx context.Context, pauseID uuid.UUID) error {
 	// Attempt to fetch this pause.
 	pause, err := m.PauseByID(ctx, pauseID)
-	if err == nil && pause != nil {
-		return m.DeletePause(ctx, *pause)
+	if err != nil {
+		if errors.Is(err, state.ErrPauseNotFound) {
+			// pause doesn't exist, nothing to delete
+			return nil
+		}
+		// bubble the error up we can safely retry the whole process
+		return err
 	}
-
-	// This won't delete event keys, invoke correlations, or signals nicely,
-	// but still gets the pause yeeted. Critically, this means a dangling
-	// signal in the DB.
-	return m.DeletePause(ctx, state.Pause{
-		ID: pauseID,
-	})
+	return m.DeletePause(ctx, *pause)
 }
 
 func (m unshardedMgr) DeletePause(ctx context.Context, p state.Pause) error {


### PR DESCRIPTION
## Description

When enabling block flushing, I noticed some pauses existed only in event indexes. We were partially deleting pauses (removing them from the global pause index and the pause’s string key), but not from event indexes. Since event indexes drive block flushing, this inconsistency will be constantly causing continuous flush jobs that fail because of insufficient pauses to fill a block.

The issue happens when `pause, err := m.PauseByID(ctx, pauseID)` IO timeouts and we fallback to this clause:
```
return m.DeletePause(ctx, state.Pause{
		ID: pauseID,
	})
```

This change lets the I/O error bubble up so it can be retried by the state proxy’s gRPC retry interceptor. Also if the err is an `ErrPauseNotFound` there is no need to delete it `PauseByID` checks the same pause key that `DeletePause` deletes when only the pause ID is passed.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
