### PR TITLE
EXE-905: unmarshal raw span inputs/outputs in postgresql normalization

### DIFF
--- a/pkg/cqrs/base_cqrs/sqlc/postgres/normalization.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/normalization.go
@@ -366,9 +366,23 @@ func (r *GetSpansByDebugSessionIDRow) ToSQLite() (*sqlc.GetSpansByDebugSessionID
 }
 
 func (r *GetSpanOutputRow) ToSQLite() (*sqlc.GetSpanOutputRow, error) {
+	var input, output interface{}
+
+	if r.Input.Valid {
+		if err := json.Unmarshal(r.Input.RawMessage, &input); err != nil {
+			return nil, err
+		}
+	}
+
+	if r.Output.Valid {
+		if err := json.Unmarshal(r.Output.RawMessage, &output); err != nil {
+			return nil, err
+		}
+	}
+
 	return &sqlc.GetSpanOutputRow{
-		Input:  r.Input,
-		Output: r.Output,
+		Input:  input,
+		Output: output,
 	}, nil
 }
 


### PR DESCRIPTION
## Description

Run span outputs are not showing up correctly in the UI for self hosted when running against postgresql. 

Before:
<img width="1123" height="642" alt="Screenshot 2025-11-12 at 10 46 12 AM" src="https://github.com/user-attachments/assets/e97967a8-cfb5-44d1-bdfe-005524084d3f" />
After:
<img width="907" height="804" alt="Screenshot 2025-11-12 at 10 45 42 AM" src="https://github.com/user-attachments/assets/a98d99c6-ca0c-41d8-97a5-acb58630fb67" />

User report and suggested fix here: https://github.com/inngest/inngest/pull/3282/files

Instead, I handles this at the normalization layer to keep everything above that db agnostic.

## Motivation
bugfix

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
