### PR TITLE
[Insights]: Remove select-none in SchemaViewer ValueRow

### DIFF
--- a/ui/packages/components/src/SchemaViewer/rows/ValueRow.tsx
+++ b/ui/packages/components/src/SchemaViewer/rows/ValueRow.tsx
@@ -28,7 +28,7 @@ export function ValueRow({
   const typeText = typeLabelOverride !== undefined ? typeLabelOverride : computed;
 
   return (
-    <div className="flex select-none items-baseline gap-1.5 px-1 py-0.5">
+    <div className="flex items-baseline gap-1.5 px-1 py-0.5">
       <span
         className={cn(
           'text-sm',


### PR DESCRIPTION
## Description

This addresses feedback that text cannot be selected for copying in the `SchemaViewer`. Removing `select-none` does introduce a strange interaction where highlighting text also collapses/expands rows, but feedback suggests that is preferable in the interim until a full path copying feature exists.

## Motivation

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
