### PR TITLE
Always return a token when checkpointing a new run

### DIFF
--- a/pkg/api/apiv1/checkpoint.go
+++ b/pkg/api/apiv1/checkpoint.go
@@ -232,7 +232,7 @@ func (a checkpointAPI) CheckpointNewRun(w http.ResponseWriter, r *http.Request) 
 			md.ID.RunID,
 		)
 		if err != nil {
-			logger.StdlibLogger(ctx).Warn("error creating run claim JWT for async token", "error", err)
+			logger.StdlibLogger(ctx).Warn("error creating run claim JWT", "error", err)
 		}
 		jwt = claim
 


### PR DESCRIPTION
## Description

Always returns a `token` when checkpointing a new run, as otherwise we may never get one.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
