### PR TITLE
EXE-906: Create new ListRuns endpoint

### DIFF
--- a/pkg/api/v2/endpoints.go
+++ b/pkg/api/v2/endpoints.go
@@ -277,3 +277,99 @@ func (s *Service) ListWebhooks(ctx context.Context, req *apiv2.ListWebhooksReque
 func (s *Service) PatchEnv(ctx context.Context, req *apiv2.PatchEnvRequest) (*apiv2.PatchEnvsResponse, error) {
 	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Environments not implemented in OSS")
 }
+
+func (s *Service) ListRuns(ctx context.Context, req *apiv2.ListRunsRequest) (*apiv2.ListRunsResponse, error) {
+	// Check if data manager is available
+	if s.data == nil {
+		return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Run history not available")
+	}
+
+	// Validate pagination parameters
+	limit := int32(50) // default
+	if req.Limit != nil {
+		if *req.Limit < 1 {
+			return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, "Limit must be at least 1")
+		}
+		if *req.Limit > 250 {
+			return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, "Limit cannot exceed 250")
+		}
+		limit = *req.Limit
+	}
+
+	// Parse and validate time range
+	var startTime, endTime time.Time
+	var err error
+
+	if req.StartTime != nil && *req.StartTime != "" {
+		startTime, err = time.Parse(time.RFC3339, *req.StartTime)
+		if err != nil {
+			return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, "Invalid startTime format, must be RFC3339")
+		}
+	} else {
+		// Default to 24 hours ago if not specified
+		startTime = time.Now().Add(-24 * time.Hour)
+	}
+
+	if req.EndTime != nil && *req.EndTime != "" {
+		endTime, err = time.Parse(time.RFC3339, *req.EndTime)
+		if err != nil {
+			return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, "Invalid endTime format, must be RFC3339")
+		}
+	} else {
+		endTime = time.Now()
+	}
+
+	orderBy := s.mapListRunsOrderBy(req)
+	filter, err := s.mapListRunsFilter(req, startTime, endTime)
+	if err != nil {
+		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, err.Error())
+	}
+
+	// TODO: Load 1 extra item and check if there are more items to load
+	opts := s.toRunsQueryOpt(int(limit), req.Cursor, orderBy, filter)
+	traceRuns, err := s.data.GetTraceRuns(ctx, opts)
+	if err != nil {
+		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, "Invalid endTime format, must be RFC3339")
+	}
+
+	runs := make([]*apiv2.Run, 0, len(traceRuns))
+	for _, traceRun := range traceRuns {
+		// TODO: This could be optimized to reduce queries
+		app, err := s.data.GetAppByID(ctx, traceRun.AppID)
+		if err != nil {
+			return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, "Failed to load app")
+		}
+		fn, err := s.data.GetFunctionByInternalUUID(ctx, traceRun.FunctionID)
+		if err != nil {
+			return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, "Failed to load function")
+		}
+		run := &apiv2.Run{
+			Id:         traceRun.RunID,
+			AppId:      app.Name,
+			FunctionId: s.cleanFunctionId(fn.Slug, app.Name),
+			Status:     apiv2.RunStatus(traceRun.Status),
+			QueuedAt:   timestamppb.New(traceRun.QueuedAt),
+			StartedAt:  timestamppb.New(traceRun.StartedAt),
+			EndedAt:    timestamppb.New(traceRun.EndedAt),
+		}
+		runs = append(runs, run)
+	}
+
+	var cursor string
+	if len(traceRuns) > 0 {
+		cursor = traceRuns[len(traceRuns)-1].Cursor
+	}
+
+	return &apiv2.ListRunsResponse{
+		Data: runs,
+		Metadata: &apiv2.ResponseMetadata{
+			FetchedAt:   timestamppb.New(time.Now()),
+			CachedUntil: nil,
+		},
+		Page: &apiv2.Page{
+			Cursor:  &cursor,
+			HasMore: len(runs) == int(limit),
+			Limit:   limit,
+		},
+	}, nil
+}

--- a/pkg/api/v2/functions_helpers.go
+++ b/pkg/api/v2/functions_helpers.go
@@ -1,0 +1,14 @@
+package apiv2
+
+// extractFunctionIdFromFullyQualifiedId extracts the function ID from a fully qualified function ID
+// (e.g. "function-123" from "app-123-function-456")
+func (s *Service) cleanFunctionId(functionID string, appID string) string {
+	// If the functionID is in the format of "{appID}-{functionID}" (e.g., "app-123-function-456"),
+	// remove the "{appID}-" prefix if present.
+	cleaned := functionID
+	prefix := appID + "-"
+	if len(appID) > 0 && len(functionID) > len(prefix) && functionID[:len(prefix)] == prefix {
+		cleaned = functionID[len(prefix):]
+	}
+	return cleaned
+}

--- a/pkg/api/v2/runs_helpers.go
+++ b/pkg/api/v2/runs_helpers.go
@@ -1,0 +1,194 @@
+package apiv2
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/coreapi/graph/models"
+	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/enums"
+	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
+)
+
+const (
+	defaultRunItems = 40
+	maxRunItems     = 400
+)
+
+// mapListRunsFilter converts v2 API filter parameters to GraphQL filter model
+func (s *Service) mapListRunsFilter(req *apiv2.ListRunsRequest, startTime, endTime time.Time) (models.RunsFilterV2, error) {
+	// Determine time field for filtering
+	timeField := models.RunsV2OrderByFieldQueuedAt
+	if req.TimeField != nil {
+		switch *req.TimeField {
+		case apiv2.RunTimeField_QUEUED_AT:
+			timeField = models.RunsV2OrderByFieldQueuedAt
+		case apiv2.RunTimeField_STARTED_AT:
+			timeField = models.RunsV2OrderByFieldStartedAt
+		case apiv2.RunTimeField_ENDED_AT:
+			timeField = models.RunsV2OrderByFieldEndedAt
+		}
+	}
+
+	// Convert status filters
+	var statuses []models.FunctionRunStatus
+	for _, protoStatus := range req.Status {
+		var status models.FunctionRunStatus
+		switch protoStatus {
+		case apiv2.RunStatus_RUNNING:
+			status = models.FunctionRunStatusRunning
+		case apiv2.RunStatus_COMPLETED:
+			status = models.FunctionRunStatusCompleted
+		case apiv2.RunStatus_FAILED:
+			status = models.FunctionRunStatusFailed
+		case apiv2.RunStatus_CANCELLED:
+			status = models.FunctionRunStatusCancelled
+		case apiv2.RunStatus_SCHEDULED:
+			status = models.FunctionRunStatusQueued
+		default:
+			// Skip unknown statuses
+			continue
+		}
+		statuses = append(statuses, status)
+	}
+
+	filter := models.RunsFilterV2{
+		From:      startTime,
+		Until:     &endTime,
+		TimeField: &timeField,
+		Status:    statuses,
+	}
+
+	return filter, nil
+}
+
+// mapListRunsOrderBy converts v2 API ordering to GraphQL order model
+func (s *Service) mapListRunsOrderBy(req *apiv2.ListRunsRequest) []*models.RunsV2OrderBy {
+	// Default ordering: descending by queued time
+	orderBy := []*models.RunsV2OrderBy{
+		{
+			Field:     models.RunsV2OrderByFieldQueuedAt,
+			Direction: models.RunsOrderByDirectionDesc,
+		},
+	}
+
+	return orderBy
+}
+
+// toRunsQueryOpt converts filter and order parameters to cqrs query options
+// This is adapted from pkg/coreapi/graph/resolvers/runs_v2.go
+func (s *Service) toRunsQueryOpt(
+	num int,
+	cur *string,
+	order []*models.RunsV2OrderBy,
+	filter models.RunsFilterV2,
+) cqrs.GetTraceRunOpt {
+	tsfield := enums.TraceRunTimeQueuedAt
+	if filter.TimeField != nil {
+		switch *filter.TimeField {
+		case models.RunsV2OrderByFieldStartedAt:
+			tsfield = enums.TraceRunTimeStartedAt
+		case models.RunsV2OrderByFieldEndedAt:
+			tsfield = enums.TraceRunTimeEndedAt
+		}
+	}
+
+	statuses := []enums.RunStatus{}
+	if len(filter.Status) > 0 {
+		for _, s := range filter.Status {
+			var status enums.RunStatus
+			switch s {
+			case models.FunctionRunStatusQueued:
+				status = enums.RunStatusScheduled
+			case models.FunctionRunStatusRunning:
+				status = enums.RunStatusRunning
+			case models.FunctionRunStatusCompleted:
+				status = enums.RunStatusCompleted
+			case models.FunctionRunStatusCancelled:
+				status = enums.RunStatusCancelled
+			case models.FunctionRunStatusFailed:
+				status = enums.RunStatusFailed
+			default:
+				// unknown status
+				continue
+			}
+			statuses = append(statuses, status)
+		}
+	}
+
+	orderBy := []cqrs.GetTraceRunOrder{}
+	for _, o := range order {
+		var (
+			field enums.TraceRunTime
+			dir   enums.TraceRunOrder
+		)
+
+		switch o.Field {
+		case models.RunsV2OrderByFieldQueuedAt:
+			field = enums.TraceRunTimeQueuedAt
+		case models.RunsV2OrderByFieldStartedAt:
+			field = enums.TraceRunTimeStartedAt
+		case models.RunsV2OrderByFieldEndedAt:
+			field = enums.TraceRunTimeEndedAt
+		default: // unknown, skip
+			continue
+		}
+
+		switch o.Direction {
+		case models.RunsOrderByDirectionAsc:
+			dir = enums.TraceRunOrderAsc
+		case models.RunsOrderByDirectionDesc:
+			dir = enums.TraceRunOrderDesc
+		default: // unknown, skip
+			continue
+		}
+
+		orderBy = append(orderBy, cqrs.GetTraceRunOrder{Field: field, Direction: dir})
+	}
+
+	var cursor string
+	if cur != nil {
+		cursor = *cur
+	}
+
+	var cel string
+	if filter.Query != nil {
+		cel = *filter.Query
+	}
+
+	until := time.Now()
+	if filter.Until != nil {
+		until = *filter.Until
+	}
+
+	items := defaultRunItems
+	if num > 0 && num < maxRunItems {
+		items = num
+	}
+
+	var appIDs []uuid.UUID
+	if filter.AppIDs != nil {
+		appIDs = filter.AppIDs
+	}
+
+	var functionIDs []uuid.UUID
+	if filter.FunctionIDs != nil {
+		functionIDs = filter.FunctionIDs
+	}
+
+	return cqrs.GetTraceRunOpt{
+		Filter: cqrs.GetTraceRunFilter{
+			AppID:      appIDs,
+			FunctionID: functionIDs,
+			TimeField:  tsfield,
+			From:       filter.From,
+			Until:      until,
+			Status:     statuses,
+			CEL:        cel,
+		},
+		Order:   orderBy,
+		Cursor:  cursor,
+		Items:   uint(items),
+		Preview: false,
+	}
+}

--- a/pkg/api/v2/service.go
+++ b/pkg/api/v2/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/inngest/inngest/pkg/api/v2/apiv2base"
+	"github.com/inngest/inngest/pkg/cqrs"
 	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
 	"google.golang.org/grpc"
 )
@@ -18,6 +19,7 @@ type Service struct {
 	apiv2.UnimplementedV2Server
 	signingKeys SigningKeysProvider
 	eventKeys   EventKeysProvider
+	data        cqrs.Manager
 	base        *apiv2base.Base
 }
 
@@ -25,12 +27,14 @@ type Service struct {
 type ServiceOptions struct {
 	SigningKeysProvider SigningKeysProvider
 	EventKeysProvider   EventKeysProvider
+	DataManager         cqrs.Manager
 }
 
 func NewService(opts ServiceOptions) *Service {
 	return &Service{
 		signingKeys: opts.SigningKeysProvider,
 		eventKeys:   opts.EventKeysProvider,
+		data:        opts.DataManager,
 		base:        apiv2base.NewBase(),
 	}
 }

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -625,6 +625,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	serviceOpts := apiv2.ServiceOptions{
 		SigningKeysProvider: apiv2.NewSigningKeysProvider(opts.SigningKey),
 		EventKeysProvider:   apiv2.NewEventKeysProvider(opts.EventKeys),
+		DataManager:         dbcqrs,
 	}
 
 	apiv2Base := apiv2base.NewBase()

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -69,10 +69,10 @@ service V2 {
       }
     };
   }
-  
+
   // Internal method to ensure ErrorResponse schema generation (not exposed via HTTP)
   rpc _SchemaOnly(HealthRequest) returns (ErrorResponse);
-  
+
   rpc CreatePartnerAccount(CreateAccountRequest) returns (CreateAccountResponse) {
     option (google.api.http) = {
       post: "/partner/accounts",
@@ -912,6 +912,85 @@ service V2 {
       }
     };
   }
+
+  rpc ListRuns(ListRunsRequest) returns (ListRunsResponse) {
+    option (google.api.http) = {
+      get: "/runs"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List runs"
+      description: "Lists function runs with filtering by status and time range"
+      parameters: {
+        headers: {
+          name: "X-Inngest-Env"
+          description: "Filter runs by environment (e.g., 'production', 'staging', 'development')"
+          type: STRING
+          required: false
+        }
+      }
+      security: {
+        security_requirement: {
+          key: "BearerAuth"
+          value: {}
+        }
+      }
+      responses: {
+        key: "200"
+        value: {
+          description: "List of runs"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ListRunsResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "400"
+        value: {
+          description: "Bad Request - invalid query parameters"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "401"
+        value: {
+          description: "Unauthorized - authentication required"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "403"
+        value: {
+          description: "Forbidden - insufficient permissions"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "500"
+        value: {
+          description: "Internal Server Error"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+    };
+  }
 }
 
 message HealthRequest {
@@ -1201,4 +1280,71 @@ message PatchEnvRequest {
 message PatchEnvsResponse {
   Env data = 1;
   ResponseMetadata metadata = 2;
+}
+
+enum RunStatus {
+  RUNNING = 0;
+  COMPLETED = 1;
+  FAILED = 2;
+  CANCELLED = 3;
+  SCHEDULED = 4;
+  UNKNOWN = 5;
+  SKIPPED = 6;
+}
+
+enum RunTimeField {
+  QUEUED_AT = 0;
+  STARTED_AT = 1;
+  ENDED_AT = 2;
+}
+
+message ListRunsRequest {
+  optional string cursor = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Pagination cursor from previous response"
+    }
+  ];
+  optional int32 limit = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Number of runs to return per page (min: 1, max: 250)"
+      default: "50"
+    }
+  ];
+  repeated RunStatus status = 3 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Filter by run status (e.g., RUNNING, COMPLETED, FAILED)"
+    }
+  ];
+  optional string startTime = 4 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Start of time range filter in RFC 3339 format (e.g., '2025-08-01T00:00:00Z')"
+    }
+  ];
+  optional string endTime = 5 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "End of time range filter in RFC 3339 format (e.g., '2025-08-31T23:59:59Z')"
+    }
+  ];
+  optional RunTimeField timeField = 6 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Which timestamp field to filter on (QUEUED_AT, STARTED_AT, or ENDED_AT). Defaults to QUEUED_AT."
+      default: "\"QUEUED_AT\""
+    }
+  ];
+}
+
+message ListRunsResponse {
+  repeated Run data = 1;
+  ResponseMetadata metadata = 2;
+  Page page = 3;
+}
+
+message Run {
+  string id = 1;
+  string appId = 2;
+  string functionId = 3;
+  RunStatus status = 4;
+  google.protobuf.Timestamp queuedAt = 5;
+  optional google.protobuf.Timestamp startedAt = 6;
+  optional google.protobuf.Timestamp endedAt = 7;
 }

--- a/proto/gen/api/v2/apiv2connect/service.connect.go
+++ b/proto/gen/api/v2/apiv2connect/service.connect.go
@@ -59,6 +59,8 @@ const (
 	V2ListWebhooksProcedure = "/api.v2.V2/ListWebhooks"
 	// V2PatchEnvProcedure is the fully-qualified name of the V2's PatchEnv RPC.
 	V2PatchEnvProcedure = "/api.v2.V2/PatchEnv"
+	// V2ListRunsProcedure is the fully-qualified name of the V2's ListRuns RPC.
+	V2ListRunsProcedure = "/api.v2.V2/ListRuns"
 )
 
 // V2Client is a client for the api.v2.V2 service.
@@ -76,6 +78,7 @@ type V2Client interface {
 	CreateWebhook(context.Context, *connect.Request[v2.CreateWebhookRequest]) (*connect.Response[v2.CreateWebhookResponse], error)
 	ListWebhooks(context.Context, *connect.Request[v2.ListWebhooksRequest]) (*connect.Response[v2.ListWebhooksResponse], error)
 	PatchEnv(context.Context, *connect.Request[v2.PatchEnvRequest]) (*connect.Response[v2.PatchEnvsResponse], error)
+	ListRuns(context.Context, *connect.Request[v2.ListRunsRequest]) (*connect.Response[v2.ListRunsResponse], error)
 }
 
 // NewV2Client constructs a client for the api.v2.V2 service. By default, it uses the Connect
@@ -161,6 +164,12 @@ func NewV2Client(httpClient connect.HTTPClient, baseURL string, opts ...connect.
 			connect.WithSchema(v2Methods.ByName("PatchEnv")),
 			connect.WithClientOptions(opts...),
 		),
+		listRuns: connect.NewClient[v2.ListRunsRequest, v2.ListRunsResponse](
+			httpClient,
+			baseURL+V2ListRunsProcedure,
+			connect.WithSchema(v2Methods.ByName("ListRuns")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -178,6 +187,7 @@ type v2Client struct {
 	createWebhook           *connect.Client[v2.CreateWebhookRequest, v2.CreateWebhookResponse]
 	listWebhooks            *connect.Client[v2.ListWebhooksRequest, v2.ListWebhooksResponse]
 	patchEnv                *connect.Client[v2.PatchEnvRequest, v2.PatchEnvsResponse]
+	listRuns                *connect.Client[v2.ListRunsRequest, v2.ListRunsResponse]
 }
 
 // Health calls api.v2.V2.Health.
@@ -240,6 +250,11 @@ func (c *v2Client) PatchEnv(ctx context.Context, req *connect.Request[v2.PatchEn
 	return c.patchEnv.CallUnary(ctx, req)
 }
 
+// ListRuns calls api.v2.V2.ListRuns.
+func (c *v2Client) ListRuns(ctx context.Context, req *connect.Request[v2.ListRunsRequest]) (*connect.Response[v2.ListRunsResponse], error) {
+	return c.listRuns.CallUnary(ctx, req)
+}
+
 // V2Handler is an implementation of the api.v2.V2 service.
 type V2Handler interface {
 	Health(context.Context, *connect.Request[v2.HealthRequest]) (*connect.Response[v2.HealthResponse], error)
@@ -255,6 +270,7 @@ type V2Handler interface {
 	CreateWebhook(context.Context, *connect.Request[v2.CreateWebhookRequest]) (*connect.Response[v2.CreateWebhookResponse], error)
 	ListWebhooks(context.Context, *connect.Request[v2.ListWebhooksRequest]) (*connect.Response[v2.ListWebhooksResponse], error)
 	PatchEnv(context.Context, *connect.Request[v2.PatchEnvRequest]) (*connect.Response[v2.PatchEnvsResponse], error)
+	ListRuns(context.Context, *connect.Request[v2.ListRunsRequest]) (*connect.Response[v2.ListRunsResponse], error)
 }
 
 // NewV2Handler builds an HTTP handler from the service implementation. It returns the path on which
@@ -336,6 +352,12 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 		connect.WithSchema(v2Methods.ByName("PatchEnv")),
 		connect.WithHandlerOptions(opts...),
 	)
+	v2ListRunsHandler := connect.NewUnaryHandler(
+		V2ListRunsProcedure,
+		svc.ListRuns,
+		connect.WithSchema(v2Methods.ByName("ListRuns")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/api.v2.V2/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case V2HealthProcedure:
@@ -362,6 +384,8 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 			v2ListWebhooksHandler.ServeHTTP(w, r)
 		case V2PatchEnvProcedure:
 			v2PatchEnvHandler.ServeHTTP(w, r)
+		case V2ListRunsProcedure:
+			v2ListRunsHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -417,4 +441,8 @@ func (UnimplementedV2Handler) ListWebhooks(context.Context, *connect.Request[v2.
 
 func (UnimplementedV2Handler) PatchEnv(context.Context, *connect.Request[v2.PatchEnvRequest]) (*connect.Response[v2.PatchEnvsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.PatchEnv is not implemented"))
+}
+
+func (UnimplementedV2Handler) ListRuns(context.Context, *connect.Request[v2.ListRunsRequest]) (*connect.Response[v2.ListRunsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.ListRuns is not implemented"))
 }

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -119,6 +119,116 @@ func (FilterType) EnumDescriptor() ([]byte, []int) {
 	return file_api_v2_service_proto_rawDescGZIP(), []int{1}
 }
 
+type RunStatus int32
+
+const (
+	RunStatus_RUNNING   RunStatus = 0
+	RunStatus_COMPLETED RunStatus = 1
+	RunStatus_FAILED    RunStatus = 2
+	RunStatus_CANCELLED RunStatus = 3
+	RunStatus_SCHEDULED RunStatus = 4
+	RunStatus_UNKNOWN   RunStatus = 5
+	RunStatus_SKIPPED   RunStatus = 6
+)
+
+// Enum value maps for RunStatus.
+var (
+	RunStatus_name = map[int32]string{
+		0: "RUNNING",
+		1: "COMPLETED",
+		2: "FAILED",
+		3: "CANCELLED",
+		4: "SCHEDULED",
+		5: "UNKNOWN",
+		6: "SKIPPED",
+	}
+	RunStatus_value = map[string]int32{
+		"RUNNING":   0,
+		"COMPLETED": 1,
+		"FAILED":    2,
+		"CANCELLED": 3,
+		"SCHEDULED": 4,
+		"UNKNOWN":   5,
+		"SKIPPED":   6,
+	}
+)
+
+func (x RunStatus) Enum() *RunStatus {
+	p := new(RunStatus)
+	*p = x
+	return p
+}
+
+func (x RunStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RunStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_v2_service_proto_enumTypes[2].Descriptor()
+}
+
+func (RunStatus) Type() protoreflect.EnumType {
+	return &file_api_v2_service_proto_enumTypes[2]
+}
+
+func (x RunStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RunStatus.Descriptor instead.
+func (RunStatus) EnumDescriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{2}
+}
+
+type RunTimeField int32
+
+const (
+	RunTimeField_QUEUED_AT  RunTimeField = 0
+	RunTimeField_STARTED_AT RunTimeField = 1
+	RunTimeField_ENDED_AT   RunTimeField = 2
+)
+
+// Enum value maps for RunTimeField.
+var (
+	RunTimeField_name = map[int32]string{
+		0: "QUEUED_AT",
+		1: "STARTED_AT",
+		2: "ENDED_AT",
+	}
+	RunTimeField_value = map[string]int32{
+		"QUEUED_AT":  0,
+		"STARTED_AT": 1,
+		"ENDED_AT":   2,
+	}
+)
+
+func (x RunTimeField) Enum() *RunTimeField {
+	p := new(RunTimeField)
+	*p = x
+	return p
+}
+
+func (x RunTimeField) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RunTimeField) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_v2_service_proto_enumTypes[3].Descriptor()
+}
+
+func (RunTimeField) Type() protoreflect.EnumType {
+	return &file_api_v2_service_proto_enumTypes[3]
+}
+
+func (x RunTimeField) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RunTimeField.Descriptor instead.
+func (RunTimeField) EnumDescriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{3}
+}
+
 type HealthRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -2087,6 +2197,242 @@ func (x *PatchEnvsResponse) GetMetadata() *ResponseMetadata {
 	return nil
 }
 
+type ListRunsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Cursor        *string                `protobuf:"bytes,1,opt,name=cursor,proto3,oneof" json:"cursor,omitempty"`
+	Limit         *int32                 `protobuf:"varint,2,opt,name=limit,proto3,oneof" json:"limit,omitempty"`
+	Status        []RunStatus            `protobuf:"varint,3,rep,packed,name=status,proto3,enum=api.v2.RunStatus" json:"status,omitempty"`
+	StartTime     *string                `protobuf:"bytes,4,opt,name=startTime,proto3,oneof" json:"startTime,omitempty"`
+	EndTime       *string                `protobuf:"bytes,5,opt,name=endTime,proto3,oneof" json:"endTime,omitempty"`
+	TimeField     *RunTimeField          `protobuf:"varint,6,opt,name=timeField,proto3,enum=api.v2.RunTimeField,oneof" json:"timeField,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRunsRequest) Reset() {
+	*x = ListRunsRequest{}
+	mi := &file_api_v2_service_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRunsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRunsRequest) ProtoMessage() {}
+
+func (x *ListRunsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRunsRequest.ProtoReflect.Descriptor instead.
+func (*ListRunsRequest) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *ListRunsRequest) GetCursor() string {
+	if x != nil && x.Cursor != nil {
+		return *x.Cursor
+	}
+	return ""
+}
+
+func (x *ListRunsRequest) GetLimit() int32 {
+	if x != nil && x.Limit != nil {
+		return *x.Limit
+	}
+	return 0
+}
+
+func (x *ListRunsRequest) GetStatus() []RunStatus {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+func (x *ListRunsRequest) GetStartTime() string {
+	if x != nil && x.StartTime != nil {
+		return *x.StartTime
+	}
+	return ""
+}
+
+func (x *ListRunsRequest) GetEndTime() string {
+	if x != nil && x.EndTime != nil {
+		return *x.EndTime
+	}
+	return ""
+}
+
+func (x *ListRunsRequest) GetTimeField() RunTimeField {
+	if x != nil && x.TimeField != nil {
+		return *x.TimeField
+	}
+	return RunTimeField_QUEUED_AT
+}
+
+type ListRunsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Data          []*Run                 `protobuf:"bytes,1,rep,name=data,proto3" json:"data,omitempty"`
+	Metadata      *ResponseMetadata      `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	Page          *Page                  `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRunsResponse) Reset() {
+	*x = ListRunsResponse{}
+	mi := &file_api_v2_service_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRunsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRunsResponse) ProtoMessage() {}
+
+func (x *ListRunsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRunsResponse.ProtoReflect.Descriptor instead.
+func (*ListRunsResponse) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *ListRunsResponse) GetData() []*Run {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+func (x *ListRunsResponse) GetMetadata() *ResponseMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *ListRunsResponse) GetPage() *Page {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+type Run struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	AppId         string                 `protobuf:"bytes,2,opt,name=appId,proto3" json:"appId,omitempty"`
+	FunctionId    string                 `protobuf:"bytes,3,opt,name=functionId,proto3" json:"functionId,omitempty"`
+	Status        RunStatus              `protobuf:"varint,4,opt,name=status,proto3,enum=api.v2.RunStatus" json:"status,omitempty"`
+	QueuedAt      *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=queuedAt,proto3" json:"queuedAt,omitempty"`
+	StartedAt     *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=startedAt,proto3,oneof" json:"startedAt,omitempty"`
+	EndedAt       *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=endedAt,proto3,oneof" json:"endedAt,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Run) Reset() {
+	*x = Run{}
+	mi := &file_api_v2_service_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Run) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Run) ProtoMessage() {}
+
+func (x *Run) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Run.ProtoReflect.Descriptor instead.
+func (*Run) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *Run) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *Run) GetAppId() string {
+	if x != nil {
+		return x.AppId
+	}
+	return ""
+}
+
+func (x *Run) GetFunctionId() string {
+	if x != nil {
+		return x.FunctionId
+	}
+	return ""
+}
+
+func (x *Run) GetStatus() RunStatus {
+	if x != nil {
+		return x.Status
+	}
+	return RunStatus_RUNNING
+}
+
+func (x *Run) GetQueuedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.QueuedAt
+	}
+	return nil
+}
+
+func (x *Run) GetStartedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartedAt
+	}
+	return nil
+}
+
+func (x *Run) GetEndedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.EndedAt
+	}
+	return nil
+}
+
 var File_api_v2_service_proto protoreflect.FileDescriptor
 
 const file_api_v2_service_proto_rawDesc = "" +
@@ -2243,7 +2589,40 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\v_isArchived\"j\n" +
 	"\x11PatchEnvsResponse\x12\x1f\n" +
 	"\x04data\x18\x01 \x01(\v2\v.api.v2.EnvR\x04data\x124\n" +
-	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata*/\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\xf0\x05\n" +
+	"\x0fListRunsRequest\x12J\n" +
+	"\x06cursor\x18\x01 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x00R\x06cursor\x88\x01\x01\x12X\n" +
+	"\x05limit\x18\x02 \x01(\x05B=\x92A:24Number of runs to return per page (min: 1, max: 250):\x0250H\x01R\x05limit\x88\x01\x01\x12g\n" +
+	"\x06status\x18\x03 \x03(\x0e2\x11.api.v2.RunStatusB<\x92A927Filter by run status (e.g., RUNNING, COMPLETED, FAILED)R\x06status\x12t\n" +
+	"\tstartTime\x18\x04 \x01(\tBQ\x92AN2LStart of time range filter in RFC 3339 format (e.g., '2025-08-01T00:00:00Z')H\x02R\tstartTime\x88\x01\x01\x12n\n" +
+	"\aendTime\x18\x05 \x01(\tBO\x92AL2JEnd of time range filter in RFC 3339 format (e.g., '2025-08-31T23:59:59Z')H\x03R\aendTime\x88\x01\x01\x12\xaa\x01\n" +
+	"\ttimeField\x18\x06 \x01(\x0e2\x14.api.v2.RunTimeFieldBq\x92An2_Which timestamp field to filter on (QUEUED_AT, STARTED_AT, or ENDED_AT). Defaults to QUEUED_AT.:\v\"QUEUED_AT\"H\x04R\ttimeField\x88\x01\x01B\t\n" +
+	"\a_cursorB\b\n" +
+	"\x06_limitB\f\n" +
+	"\n" +
+	"_startTimeB\n" +
+	"\n" +
+	"\b_endTimeB\f\n" +
+	"\n" +
+	"_timeField\"\x8b\x01\n" +
+	"\x10ListRunsResponse\x12\x1f\n" +
+	"\x04data\x18\x01 \x03(\v2\v.api.v2.RunR\x04data\x124\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\x12 \n" +
+	"\x04page\x18\x03 \x01(\v2\f.api.v2.PageR\x04page\"\xc2\x02\n" +
+	"\x03Run\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
+	"\x05appId\x18\x02 \x01(\tR\x05appId\x12\x1e\n" +
+	"\n" +
+	"functionId\x18\x03 \x01(\tR\n" +
+	"functionId\x12)\n" +
+	"\x06status\x18\x04 \x01(\x0e2\x11.api.v2.RunStatusR\x06status\x126\n" +
+	"\bqueuedAt\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\bqueuedAt\x12=\n" +
+	"\tstartedAt\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\tstartedAt\x88\x01\x01\x129\n" +
+	"\aendedAt\x18\a \x01(\v2\x1a.google.protobuf.TimestampH\x01R\aendedAt\x88\x01\x01B\f\n" +
+	"\n" +
+	"_startedAtB\n" +
+	"\n" +
+	"\b_endedAt*/\n" +
 	"\aEnvType\x12\x0e\n" +
 	"\n" +
 	"PRODUCTION\x10\x00\x12\b\n" +
@@ -2253,7 +2632,21 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\n" +
 	"FilterType\x12\t\n" +
 	"\x05ALLOW\x10\x00\x12\b\n" +
-	"\x04DENY\x10\x012\xd8;\n" +
+	"\x04DENY\x10\x01*k\n" +
+	"\tRunStatus\x12\v\n" +
+	"\aRUNNING\x10\x00\x12\r\n" +
+	"\tCOMPLETED\x10\x01\x12\n" +
+	"\n" +
+	"\x06FAILED\x10\x02\x12\r\n" +
+	"\tCANCELLED\x10\x03\x12\r\n" +
+	"\tSCHEDULED\x10\x04\x12\v\n" +
+	"\aUNKNOWN\x10\x05\x12\v\n" +
+	"\aSKIPPED\x10\x06*;\n" +
+	"\fRunTimeField\x12\r\n" +
+	"\tQUEUED_AT\x10\x00\x12\x0e\n" +
+	"\n" +
+	"STARTED_AT\x10\x01\x12\f\n" +
+	"\bENDED_AT\x10\x022\xe0@\n" +
 	"\x02V2\x12\xb2\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\xf8\x01\x92A\xe5\x01\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
 	"\x03401\x12K\n" +
@@ -2490,7 +2883,28 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x0e\n" +
 	"\n" +
 	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x0f:\x01*2\n" +
-	"/envs/{id}B\xc8\x02\x92A\x91\x02\x12\x9b\x01\n" +
+	"/envs/{id}\x12\x85\x05\n" +
+	"\bListRuns\x12\x17.api.v2.ListRunsRequest\x1a\x18.api.v2.ListRunsResponse\"\xc5\x04\x92A\xb4\x04\x12\tList runs\x1a;Lists function runs with filtering by status and time rangeJ;\n" +
+	"\x03200\x124\n" +
+	"\fList of runs\x12$\n" +
+	"\"\x1a #/definitions/v2ListRunsResponseJR\n" +
+	"\x03400\x12K\n" +
+	"&Bad Request - invalid query parameters\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJR\n" +
+	"\x03401\x12K\n" +
+	"&Unauthorized - authentication required\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJP\n" +
+	"\x03403\x12I\n" +
+	"$Forbidden - insufficient permissions\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJA\n" +
+	"\x03500\x12:\n" +
+	"\x15Internal Server Error\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
+	"\x0e\n" +
+	"\n" +
+	"BearerAuth\x12\x00r^\n" +
+	"\\\n" +
+	"\rX-Inngest-Env\x12IFilter runs by environment (e.g., 'production', 'staging', 'development')\x18\x01\x82\xd3\xe4\x93\x02\a\x12\x05/runsB\xc8\x02\x92A\x91\x02\x12\x9b\x01\n" +
 	"\x13Inngest REST API v2\x12}The v2 API delivers a significantly improved developer experience with consistent design patterns and enhanced functionality.2\x052.0.0\x1a\x0fapi.inngest.com\"\x03/v2*\x01\x02ZX\n" +
 	"V\n" +
 	"\n" +
@@ -2508,120 +2922,136 @@ func file_api_v2_service_proto_rawDescGZIP() []byte {
 	return file_api_v2_service_proto_rawDescData
 }
 
-var file_api_v2_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_api_v2_service_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_api_v2_service_proto_goTypes = []any{
 	(EnvType)(0),                            // 0: api.v2.EnvType
 	(FilterType)(0),                         // 1: api.v2.FilterType
-	(*HealthRequest)(nil),                   // 2: api.v2.HealthRequest
-	(*FetchAccountRequest)(nil),             // 3: api.v2.FetchAccountRequest
-	(*HealthResponse)(nil),                  // 4: api.v2.HealthResponse
-	(*HealthData)(nil),                      // 5: api.v2.HealthData
-	(*Error)(nil),                           // 6: api.v2.Error
-	(*ErrorResponse)(nil),                   // 7: api.v2.ErrorResponse
-	(*ResponseMetadata)(nil),                // 8: api.v2.ResponseMetadata
-	(*CreateAccountRequest)(nil),            // 9: api.v2.CreateAccountRequest
-	(*CreateAccountResponse)(nil),           // 10: api.v2.CreateAccountResponse
-	(*CreateEnvRequest)(nil),                // 11: api.v2.CreateEnvRequest
-	(*CreateEnvResponse)(nil),               // 12: api.v2.CreateEnvResponse
-	(*Env)(nil),                             // 13: api.v2.Env
-	(*CreateAccountData)(nil),               // 14: api.v2.CreateAccountData
-	(*FetchAccountsRequest)(nil),            // 15: api.v2.FetchAccountsRequest
-	(*FetchAccountsResponse)(nil),           // 16: api.v2.FetchAccountsResponse
-	(*FetchAccountResponse)(nil),            // 17: api.v2.FetchAccountResponse
-	(*Account)(nil),                         // 18: api.v2.Account
-	(*Page)(nil),                            // 19: api.v2.Page
-	(*FetchAccountEventKeysRequest)(nil),    // 20: api.v2.FetchAccountEventKeysRequest
-	(*FetchAccountEventKeysResponse)(nil),   // 21: api.v2.FetchAccountEventKeysResponse
-	(*EventKey)(nil),                        // 22: api.v2.EventKey
-	(*FetchAccountEnvsRequest)(nil),         // 23: api.v2.FetchAccountEnvsRequest
-	(*FetchAccountEnvsResponse)(nil),        // 24: api.v2.FetchAccountEnvsResponse
-	(*FetchAccountSigningKeysRequest)(nil),  // 25: api.v2.FetchAccountSigningKeysRequest
-	(*FetchAccountSigningKeysResponse)(nil), // 26: api.v2.FetchAccountSigningKeysResponse
-	(*SigningKey)(nil),                      // 27: api.v2.SigningKey
-	(*CreateWebhookRequest)(nil),            // 28: api.v2.CreateWebhookRequest
-	(*CreateWebhookResponse)(nil),           // 29: api.v2.CreateWebhookResponse
-	(*EventFilter)(nil),                     // 30: api.v2.EventFilter
-	(*ListWebhooksRequest)(nil),             // 31: api.v2.ListWebhooksRequest
-	(*ListWebhooksResponse)(nil),            // 32: api.v2.ListWebhooksResponse
-	(*Webhook)(nil),                         // 33: api.v2.Webhook
-	(*PatchEnvRequest)(nil),                 // 34: api.v2.PatchEnvRequest
-	(*PatchEnvsResponse)(nil),               // 35: api.v2.PatchEnvsResponse
-	(*timestamppb.Timestamp)(nil),           // 36: google.protobuf.Timestamp
+	(RunStatus)(0),                          // 2: api.v2.RunStatus
+	(RunTimeField)(0),                       // 3: api.v2.RunTimeField
+	(*HealthRequest)(nil),                   // 4: api.v2.HealthRequest
+	(*FetchAccountRequest)(nil),             // 5: api.v2.FetchAccountRequest
+	(*HealthResponse)(nil),                  // 6: api.v2.HealthResponse
+	(*HealthData)(nil),                      // 7: api.v2.HealthData
+	(*Error)(nil),                           // 8: api.v2.Error
+	(*ErrorResponse)(nil),                   // 9: api.v2.ErrorResponse
+	(*ResponseMetadata)(nil),                // 10: api.v2.ResponseMetadata
+	(*CreateAccountRequest)(nil),            // 11: api.v2.CreateAccountRequest
+	(*CreateAccountResponse)(nil),           // 12: api.v2.CreateAccountResponse
+	(*CreateEnvRequest)(nil),                // 13: api.v2.CreateEnvRequest
+	(*CreateEnvResponse)(nil),               // 14: api.v2.CreateEnvResponse
+	(*Env)(nil),                             // 15: api.v2.Env
+	(*CreateAccountData)(nil),               // 16: api.v2.CreateAccountData
+	(*FetchAccountsRequest)(nil),            // 17: api.v2.FetchAccountsRequest
+	(*FetchAccountsResponse)(nil),           // 18: api.v2.FetchAccountsResponse
+	(*FetchAccountResponse)(nil),            // 19: api.v2.FetchAccountResponse
+	(*Account)(nil),                         // 20: api.v2.Account
+	(*Page)(nil),                            // 21: api.v2.Page
+	(*FetchAccountEventKeysRequest)(nil),    // 22: api.v2.FetchAccountEventKeysRequest
+	(*FetchAccountEventKeysResponse)(nil),   // 23: api.v2.FetchAccountEventKeysResponse
+	(*EventKey)(nil),                        // 24: api.v2.EventKey
+	(*FetchAccountEnvsRequest)(nil),         // 25: api.v2.FetchAccountEnvsRequest
+	(*FetchAccountEnvsResponse)(nil),        // 26: api.v2.FetchAccountEnvsResponse
+	(*FetchAccountSigningKeysRequest)(nil),  // 27: api.v2.FetchAccountSigningKeysRequest
+	(*FetchAccountSigningKeysResponse)(nil), // 28: api.v2.FetchAccountSigningKeysResponse
+	(*SigningKey)(nil),                      // 29: api.v2.SigningKey
+	(*CreateWebhookRequest)(nil),            // 30: api.v2.CreateWebhookRequest
+	(*CreateWebhookResponse)(nil),           // 31: api.v2.CreateWebhookResponse
+	(*EventFilter)(nil),                     // 32: api.v2.EventFilter
+	(*ListWebhooksRequest)(nil),             // 33: api.v2.ListWebhooksRequest
+	(*ListWebhooksResponse)(nil),            // 34: api.v2.ListWebhooksResponse
+	(*Webhook)(nil),                         // 35: api.v2.Webhook
+	(*PatchEnvRequest)(nil),                 // 36: api.v2.PatchEnvRequest
+	(*PatchEnvsResponse)(nil),               // 37: api.v2.PatchEnvsResponse
+	(*ListRunsRequest)(nil),                 // 38: api.v2.ListRunsRequest
+	(*ListRunsResponse)(nil),                // 39: api.v2.ListRunsResponse
+	(*Run)(nil),                             // 40: api.v2.Run
+	(*timestamppb.Timestamp)(nil),           // 41: google.protobuf.Timestamp
 }
 var file_api_v2_service_proto_depIdxs = []int32{
-	5,  // 0: api.v2.HealthResponse.data:type_name -> api.v2.HealthData
-	8,  // 1: api.v2.HealthResponse.metadata:type_name -> api.v2.ResponseMetadata
-	6,  // 2: api.v2.ErrorResponse.errors:type_name -> api.v2.Error
-	36, // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
-	36, // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
-	14, // 5: api.v2.CreateAccountResponse.data:type_name -> api.v2.CreateAccountData
-	8,  // 6: api.v2.CreateAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
-	13, // 7: api.v2.CreateEnvResponse.data:type_name -> api.v2.Env
-	8,  // 8: api.v2.CreateEnvResponse.metadata:type_name -> api.v2.ResponseMetadata
+	7,  // 0: api.v2.HealthResponse.data:type_name -> api.v2.HealthData
+	10, // 1: api.v2.HealthResponse.metadata:type_name -> api.v2.ResponseMetadata
+	8,  // 2: api.v2.ErrorResponse.errors:type_name -> api.v2.Error
+	41, // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
+	41, // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
+	16, // 5: api.v2.CreateAccountResponse.data:type_name -> api.v2.CreateAccountData
+	10, // 6: api.v2.CreateAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
+	15, // 7: api.v2.CreateEnvResponse.data:type_name -> api.v2.Env
+	10, // 8: api.v2.CreateEnvResponse.metadata:type_name -> api.v2.ResponseMetadata
 	0,  // 9: api.v2.Env.type:type_name -> api.v2.EnvType
-	36, // 10: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
-	36, // 11: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
-	36, // 12: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
-	18, // 13: api.v2.FetchAccountsResponse.data:type_name -> api.v2.Account
-	8,  // 14: api.v2.FetchAccountsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	19, // 15: api.v2.FetchAccountsResponse.page:type_name -> api.v2.Page
-	18, // 16: api.v2.FetchAccountResponse.data:type_name -> api.v2.Account
-	8,  // 17: api.v2.FetchAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
-	36, // 18: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
-	36, // 19: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
-	22, // 20: api.v2.FetchAccountEventKeysResponse.data:type_name -> api.v2.EventKey
-	8,  // 21: api.v2.FetchAccountEventKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
-	19, // 22: api.v2.FetchAccountEventKeysResponse.page:type_name -> api.v2.Page
-	36, // 23: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
-	13, // 24: api.v2.FetchAccountEnvsResponse.data:type_name -> api.v2.Env
-	8,  // 25: api.v2.FetchAccountEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	19, // 26: api.v2.FetchAccountEnvsResponse.page:type_name -> api.v2.Page
-	27, // 27: api.v2.FetchAccountSigningKeysResponse.data:type_name -> api.v2.SigningKey
-	8,  // 28: api.v2.FetchAccountSigningKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
-	19, // 29: api.v2.FetchAccountSigningKeysResponse.page:type_name -> api.v2.Page
-	36, // 30: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
-	30, // 31: api.v2.CreateWebhookRequest.event_filter:type_name -> api.v2.EventFilter
-	33, // 32: api.v2.CreateWebhookResponse.data:type_name -> api.v2.Webhook
-	8,  // 33: api.v2.CreateWebhookResponse.metadata:type_name -> api.v2.ResponseMetadata
+	41, // 10: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
+	41, // 11: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
+	41, // 12: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
+	20, // 13: api.v2.FetchAccountsResponse.data:type_name -> api.v2.Account
+	10, // 14: api.v2.FetchAccountsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	21, // 15: api.v2.FetchAccountsResponse.page:type_name -> api.v2.Page
+	20, // 16: api.v2.FetchAccountResponse.data:type_name -> api.v2.Account
+	10, // 17: api.v2.FetchAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
+	41, // 18: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
+	41, // 19: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
+	24, // 20: api.v2.FetchAccountEventKeysResponse.data:type_name -> api.v2.EventKey
+	10, // 21: api.v2.FetchAccountEventKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
+	21, // 22: api.v2.FetchAccountEventKeysResponse.page:type_name -> api.v2.Page
+	41, // 23: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
+	15, // 24: api.v2.FetchAccountEnvsResponse.data:type_name -> api.v2.Env
+	10, // 25: api.v2.FetchAccountEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	21, // 26: api.v2.FetchAccountEnvsResponse.page:type_name -> api.v2.Page
+	29, // 27: api.v2.FetchAccountSigningKeysResponse.data:type_name -> api.v2.SigningKey
+	10, // 28: api.v2.FetchAccountSigningKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
+	21, // 29: api.v2.FetchAccountSigningKeysResponse.page:type_name -> api.v2.Page
+	41, // 30: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
+	32, // 31: api.v2.CreateWebhookRequest.event_filter:type_name -> api.v2.EventFilter
+	35, // 32: api.v2.CreateWebhookResponse.data:type_name -> api.v2.Webhook
+	10, // 33: api.v2.CreateWebhookResponse.metadata:type_name -> api.v2.ResponseMetadata
 	1,  // 34: api.v2.EventFilter.filter:type_name -> api.v2.FilterType
-	33, // 35: api.v2.ListWebhooksResponse.data:type_name -> api.v2.Webhook
-	8,  // 36: api.v2.ListWebhooksResponse.metadata:type_name -> api.v2.ResponseMetadata
-	19, // 37: api.v2.ListWebhooksResponse.page:type_name -> api.v2.Page
-	30, // 38: api.v2.Webhook.event_filter:type_name -> api.v2.EventFilter
-	36, // 39: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
-	36, // 40: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
-	13, // 41: api.v2.PatchEnvsResponse.data:type_name -> api.v2.Env
-	8,  // 42: api.v2.PatchEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	2,  // 43: api.v2.V2.Health:input_type -> api.v2.HealthRequest
-	2,  // 44: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
-	9,  // 45: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
-	11, // 46: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
-	15, // 47: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
-	3,  // 48: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
-	23, // 49: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
-	20, // 50: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
-	25, // 51: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
-	28, // 52: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
-	31, // 53: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
-	34, // 54: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
-	4,  // 55: api.v2.V2.Health:output_type -> api.v2.HealthResponse
-	7,  // 56: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
-	10, // 57: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
-	12, // 58: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
-	16, // 59: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
-	17, // 60: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
-	24, // 61: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
-	21, // 62: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
-	26, // 63: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
-	29, // 64: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
-	32, // 65: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
-	35, // 66: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
-	55, // [55:67] is the sub-list for method output_type
-	43, // [43:55] is the sub-list for method input_type
-	43, // [43:43] is the sub-list for extension type_name
-	43, // [43:43] is the sub-list for extension extendee
-	0,  // [0:43] is the sub-list for field type_name
+	35, // 35: api.v2.ListWebhooksResponse.data:type_name -> api.v2.Webhook
+	10, // 36: api.v2.ListWebhooksResponse.metadata:type_name -> api.v2.ResponseMetadata
+	21, // 37: api.v2.ListWebhooksResponse.page:type_name -> api.v2.Page
+	32, // 38: api.v2.Webhook.event_filter:type_name -> api.v2.EventFilter
+	41, // 39: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
+	41, // 40: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
+	15, // 41: api.v2.PatchEnvsResponse.data:type_name -> api.v2.Env
+	10, // 42: api.v2.PatchEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	2,  // 43: api.v2.ListRunsRequest.status:type_name -> api.v2.RunStatus
+	3,  // 44: api.v2.ListRunsRequest.timeField:type_name -> api.v2.RunTimeField
+	40, // 45: api.v2.ListRunsResponse.data:type_name -> api.v2.Run
+	10, // 46: api.v2.ListRunsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	21, // 47: api.v2.ListRunsResponse.page:type_name -> api.v2.Page
+	2,  // 48: api.v2.Run.status:type_name -> api.v2.RunStatus
+	41, // 49: api.v2.Run.queuedAt:type_name -> google.protobuf.Timestamp
+	41, // 50: api.v2.Run.startedAt:type_name -> google.protobuf.Timestamp
+	41, // 51: api.v2.Run.endedAt:type_name -> google.protobuf.Timestamp
+	4,  // 52: api.v2.V2.Health:input_type -> api.v2.HealthRequest
+	4,  // 53: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
+	11, // 54: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
+	13, // 55: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
+	17, // 56: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
+	5,  // 57: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
+	25, // 58: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
+	22, // 59: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
+	27, // 60: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
+	30, // 61: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
+	33, // 62: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
+	36, // 63: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
+	38, // 64: api.v2.V2.ListRuns:input_type -> api.v2.ListRunsRequest
+	6,  // 65: api.v2.V2.Health:output_type -> api.v2.HealthResponse
+	9,  // 66: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
+	12, // 67: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
+	14, // 68: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
+	18, // 69: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
+	19, // 70: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
+	26, // 71: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
+	23, // 72: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
+	28, // 73: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
+	31, // 74: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
+	34, // 75: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
+	37, // 76: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
+	39, // 77: api.v2.V2.ListRuns:output_type -> api.v2.ListRunsResponse
+	65, // [65:78] is the sub-list for method output_type
+	52, // [52:65] is the sub-list for method input_type
+	52, // [52:52] is the sub-list for extension type_name
+	52, // [52:52] is the sub-list for extension extendee
+	0,  // [0:52] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_service_proto_init() }
@@ -2641,13 +3071,15 @@ func file_api_v2_service_proto_init() {
 	file_api_v2_service_proto_msgTypes[29].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[31].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[32].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[34].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[36].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v2_service_proto_rawDesc), len(file_api_v2_service_proto_rawDesc)),
-			NumEnums:      2,
-			NumMessages:   34,
+			NumEnums:      4,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/gen/api/v2/service.pb.gw.go
+++ b/proto/gen/api/v2/service.pb.gw.go
@@ -378,6 +378,41 @@ func local_request_V2_PatchEnv_0(ctx context.Context, marshaler runtime.Marshale
 	return msg, metadata, err
 }
 
+var filter_V2_ListRuns_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_V2_ListRuns_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListRunsRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_V2_ListRuns_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.ListRuns(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_V2_ListRuns_0(ctx context.Context, marshaler runtime.Marshaler, server V2Server, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListRunsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_V2_ListRuns_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ListRuns(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterV2HandlerServer registers the http handlers for service V2 to "mux".
 // UnaryRPC     :call V2Server directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -603,6 +638,26 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 			return
 		}
 		forward_V2_PatchEnv_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_V2_ListRuns_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/ListRuns", runtime.WithHTTPPathPattern("/runs"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_V2_ListRuns_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_ListRuns_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -831,6 +886,23 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		}
 		forward_V2_PatchEnv_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_V2_ListRuns_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/ListRuns", runtime.WithHTTPPathPattern("/runs"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_V2_ListRuns_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_ListRuns_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -846,6 +918,7 @@ var (
 	pattern_V2_CreateWebhook_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"env", "webhooks"}, ""))
 	pattern_V2_ListWebhooks_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"env", "webhooks"}, ""))
 	pattern_V2_PatchEnv_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"envs", "id"}, ""))
+	pattern_V2_ListRuns_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"runs"}, ""))
 )
 
 var (
@@ -860,4 +933,5 @@ var (
 	forward_V2_CreateWebhook_0           = runtime.ForwardResponseMessage
 	forward_V2_ListWebhooks_0            = runtime.ForwardResponseMessage
 	forward_V2_PatchEnv_0                = runtime.ForwardResponseMessage
+	forward_V2_ListRuns_0                = runtime.ForwardResponseMessage
 )

--- a/proto/gen/api/v2/service_grpc.pb.go
+++ b/proto/gen/api/v2/service_grpc.pb.go
@@ -31,6 +31,7 @@ const (
 	V2_CreateWebhook_FullMethodName           = "/api.v2.V2/CreateWebhook"
 	V2_ListWebhooks_FullMethodName            = "/api.v2.V2/ListWebhooks"
 	V2_PatchEnv_FullMethodName                = "/api.v2.V2/PatchEnv"
+	V2_ListRuns_FullMethodName                = "/api.v2.V2/ListRuns"
 )
 
 // V2Client is the client API for V2 service.
@@ -50,6 +51,7 @@ type V2Client interface {
 	CreateWebhook(ctx context.Context, in *CreateWebhookRequest, opts ...grpc.CallOption) (*CreateWebhookResponse, error)
 	ListWebhooks(ctx context.Context, in *ListWebhooksRequest, opts ...grpc.CallOption) (*ListWebhooksResponse, error)
 	PatchEnv(ctx context.Context, in *PatchEnvRequest, opts ...grpc.CallOption) (*PatchEnvsResponse, error)
+	ListRuns(ctx context.Context, in *ListRunsRequest, opts ...grpc.CallOption) (*ListRunsResponse, error)
 }
 
 type v2Client struct {
@@ -180,6 +182,16 @@ func (c *v2Client) PatchEnv(ctx context.Context, in *PatchEnvRequest, opts ...gr
 	return out, nil
 }
 
+func (c *v2Client) ListRuns(ctx context.Context, in *ListRunsRequest, opts ...grpc.CallOption) (*ListRunsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListRunsResponse)
+	err := c.cc.Invoke(ctx, V2_ListRuns_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // V2Server is the server API for V2 service.
 // All implementations must embed UnimplementedV2Server
 // for forward compatibility.
@@ -197,6 +209,7 @@ type V2Server interface {
 	CreateWebhook(context.Context, *CreateWebhookRequest) (*CreateWebhookResponse, error)
 	ListWebhooks(context.Context, *ListWebhooksRequest) (*ListWebhooksResponse, error)
 	PatchEnv(context.Context, *PatchEnvRequest) (*PatchEnvsResponse, error)
+	ListRuns(context.Context, *ListRunsRequest) (*ListRunsResponse, error)
 	mustEmbedUnimplementedV2Server()
 }
 
@@ -242,6 +255,9 @@ func (UnimplementedV2Server) ListWebhooks(context.Context, *ListWebhooksRequest)
 }
 func (UnimplementedV2Server) PatchEnv(context.Context, *PatchEnvRequest) (*PatchEnvsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PatchEnv not implemented")
+}
+func (UnimplementedV2Server) ListRuns(context.Context, *ListRunsRequest) (*ListRunsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListRuns not implemented")
 }
 func (UnimplementedV2Server) mustEmbedUnimplementedV2Server() {}
 func (UnimplementedV2Server) testEmbeddedByValue()            {}
@@ -480,6 +496,24 @@ func _V2_PatchEnv_Handler(srv interface{}, ctx context.Context, dec func(interfa
 	return interceptor(ctx, in, info, handler)
 }
 
+func _V2_ListRuns_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListRunsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(V2Server).ListRuns(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: V2_ListRuns_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(V2Server).ListRuns(ctx, req.(*ListRunsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // V2_ServiceDesc is the grpc.ServiceDesc for V2 service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -534,6 +568,10 @@ var V2_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "PatchEnv",
 			Handler:    _V2_PatchEnv_Handler,
+		},
+		{
+			MethodName: "ListRuns",
+			Handler:    _V2_ListRuns_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},


### PR DESCRIPTION
## Description

A v2 new endpoint to query run data matching most functionality from the runs UI.

NOTE - Did not add search (CEL) due to it not working on first attempt with the existing UI.

Example:
```
GET http://localhost:8288/api/v2/runs?startTime=2025-11-13T03:30:13.895Z&timeField=QUEUED_AT&limit=2

{
  "data": [
    {
      "id": "01K9XM718BEBDDXKGVEV15NMG8",
      "appId": "local-dev",
      "functionId": "send-billing-receipt",
      "status": "COMPLETED",
      "queuedAt": "2025-11-13T03:30:13.899Z",
      "startedAt": "2025-11-13T03:30:13.924Z",
      "endedAt": "2025-11-13T03:30:18.933Z"
    },
    {
      "id": "01K9XM718BWTEE8GX168374392",
      "appId": "local-dev",
      "functionId": "billing-etl",
      "status": "COMPLETED",
      "queuedAt": "2025-11-13T03:30:13.899Z",
      "startedAt": "2025-11-13T03:30:14.042Z",
      "endedAt": "2025-11-13T03:30:14.047Z"
    }
  ],
  "metadata": {
    "fetchedAt": "2025-11-13T03:47:01.526134Z",
    "cachedUntil": null
  },
  "page": {
    "cursor": "eyJpZCI6IjAxSzlYTTcxOEJXVEVFOEdYMTY4Mzc0MzkyIiwiYyI6eyJxdWV1ZWRfYXQiOnsiZiI6InF1ZXVlZF9hdCIsInYiOjE3NjMwMDQ2MTM4OTl9fX0=",
    "hasMore": true,
    "limit": 2
  }
}
```

## Motivation
EXE-906

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
