### PR TITLE
EXE-907: Create new bulk re-run endpoint

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,8 +9,8 @@
       "type": "go",
       "request": "launch",
       "mode": "auto",
-      "program": "${workspaceFolder}/cmd/main.go",
-      "args": ["dev", "-u", "http://localhost:3030/api/inngest"]
+      "program": "${workspaceFolder}/cmd",
+      "args": ["dev", "-u", "http://localhost:3939/api/inngest"]
     }
   ]
 }

--- a/docs/api_v2_examples.json
+++ b/docs/api_v2_examples.json
@@ -28,6 +28,25 @@
       }
     }
   },
+  "/bulk/rerun": {
+    "post": {
+      "200": {
+        "// TODO": "Add example data for post /bulk/rerun 200"
+      },
+      "400": {
+        "// TODO": "Add example data for post /bulk/rerun 400"
+      },
+      "401": {
+        "// TODO": "Add example data for post /bulk/rerun 401"
+      },
+      "403": {
+        "// TODO": "Add example data for post /bulk/rerun 403"
+      },
+      "500": {
+        "// TODO": "Add example data for post /bulk/rerun 500"
+      }
+    }
+  },
   "/env/webhooks": {
     "get": {
       "200": {

--- a/pkg/api/v2/service.go
+++ b/pkg/api/v2/service.go
@@ -9,6 +9,8 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/inngest/inngest/pkg/api/v2/apiv2base"
+	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/execution"
 	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
 	"google.golang.org/grpc"
 )
@@ -19,12 +21,16 @@ type Service struct {
 	signingKeys SigningKeysProvider
 	eventKeys   EventKeysProvider
 	base        *apiv2base.Base
+	data        cqrs.Manager
+	executor    execution.Executor
 }
 
 // ServiceOptions contains configuration for the V2 service
 type ServiceOptions struct {
 	SigningKeysProvider SigningKeysProvider
 	EventKeysProvider   EventKeysProvider
+	CQRSManager         cqrs.Manager
+	Executor            execution.Executor
 }
 
 func NewService(opts ServiceOptions) *Service {
@@ -32,6 +38,8 @@ func NewService(opts ServiceOptions) *Service {
 		signingKeys: opts.SigningKeysProvider,
 		eventKeys:   opts.EventKeysProvider,
 		base:        apiv2base.NewBase(),
+		data:        opts.CQRSManager,
+		executor:    opts.Executor,
 	}
 }
 

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -625,6 +625,8 @@ func start(ctx context.Context, opts StartOpts) error {
 	serviceOpts := apiv2.ServiceOptions{
 		SigningKeysProvider: apiv2.NewSigningKeysProvider(opts.SigningKey),
 		EventKeysProvider:   apiv2.NewEventKeysProvider(opts.EventKeys),
+		CQRSManager:         dbcqrs,
+		Executor:            exec,
 	}
 
 	apiv2Base := apiv2base.NewBase()

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -69,10 +69,10 @@ service V2 {
       }
     };
   }
-  
+
   // Internal method to ensure ErrorResponse schema generation (not exposed via HTTP)
   rpc _SchemaOnly(HealthRequest) returns (ErrorResponse);
-  
+
   rpc CreatePartnerAccount(CreateAccountRequest) returns (CreateAccountResponse) {
     option (google.api.http) = {
       post: "/partner/accounts",
@@ -912,6 +912,78 @@ service V2 {
       }
     };
   }
+
+  rpc BulkRerun(BulkRerunRequest) returns (BulkRerunResponse) {
+    option (google.api.http) = {
+      post: "/bulk/rerun"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Bulk rerun"
+      description: "Triggers up to 50 runs to be re-executed. Each run will be replayed with its original event data."
+      security: {
+        security_requirement: {
+          key: "BearerAuth"
+          value: {}
+        }
+      }
+      responses: {
+        key: "200"
+        value: {
+          description: "Bulk rerun results"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2BulkRerunResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "400"
+        value: {
+          description: "Bad Request - invalid input data"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "401"
+        value: {
+          description: "Unauthorized - authentication required"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "403"
+        value: {
+          description: "Forbidden - insufficient permissions"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "500"
+        value: {
+          description: "Internal Server Error"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+    };
+  }
 }
 
 message HealthRequest {
@@ -1201,4 +1273,25 @@ message PatchEnvRequest {
 message PatchEnvsResponse {
   Env data = 1;
   ResponseMetadata metadata = 2;
+}
+
+message BulkRerunRequest {
+  repeated string runIds = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "List of run IDs to rerun (max: 50)"
+      example: "[\"01HP1ZX8M3NG9VP6QN0XK7J4CY\", \"01HP1ZY9N4OH0WQ7RO1YL8K5DZ\"]"
+    }
+  ];
+}
+
+message BulkRerunResponse {
+  repeated RerunResult data = 1;
+  ResponseMetadata metadata = 2;
+}
+
+message RerunResult {
+  string originalRunId = 1;
+  optional string newRunId = 2;
+  bool success = 3;
+  optional string error = 4;
 }

--- a/proto/gen/api/v2/apiv2connect/service.connect.go
+++ b/proto/gen/api/v2/apiv2connect/service.connect.go
@@ -59,6 +59,8 @@ const (
 	V2ListWebhooksProcedure = "/api.v2.V2/ListWebhooks"
 	// V2PatchEnvProcedure is the fully-qualified name of the V2's PatchEnv RPC.
 	V2PatchEnvProcedure = "/api.v2.V2/PatchEnv"
+	// V2BulkRerunProcedure is the fully-qualified name of the V2's BulkRerun RPC.
+	V2BulkRerunProcedure = "/api.v2.V2/BulkRerun"
 )
 
 // V2Client is a client for the api.v2.V2 service.
@@ -76,6 +78,7 @@ type V2Client interface {
 	CreateWebhook(context.Context, *connect.Request[v2.CreateWebhookRequest]) (*connect.Response[v2.CreateWebhookResponse], error)
 	ListWebhooks(context.Context, *connect.Request[v2.ListWebhooksRequest]) (*connect.Response[v2.ListWebhooksResponse], error)
 	PatchEnv(context.Context, *connect.Request[v2.PatchEnvRequest]) (*connect.Response[v2.PatchEnvsResponse], error)
+	BulkRerun(context.Context, *connect.Request[v2.BulkRerunRequest]) (*connect.Response[v2.BulkRerunResponse], error)
 }
 
 // NewV2Client constructs a client for the api.v2.V2 service. By default, it uses the Connect
@@ -161,6 +164,12 @@ func NewV2Client(httpClient connect.HTTPClient, baseURL string, opts ...connect.
 			connect.WithSchema(v2Methods.ByName("PatchEnv")),
 			connect.WithClientOptions(opts...),
 		),
+		bulkRerun: connect.NewClient[v2.BulkRerunRequest, v2.BulkRerunResponse](
+			httpClient,
+			baseURL+V2BulkRerunProcedure,
+			connect.WithSchema(v2Methods.ByName("BulkRerun")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -178,6 +187,7 @@ type v2Client struct {
 	createWebhook           *connect.Client[v2.CreateWebhookRequest, v2.CreateWebhookResponse]
 	listWebhooks            *connect.Client[v2.ListWebhooksRequest, v2.ListWebhooksResponse]
 	patchEnv                *connect.Client[v2.PatchEnvRequest, v2.PatchEnvsResponse]
+	bulkRerun               *connect.Client[v2.BulkRerunRequest, v2.BulkRerunResponse]
 }
 
 // Health calls api.v2.V2.Health.
@@ -240,6 +250,11 @@ func (c *v2Client) PatchEnv(ctx context.Context, req *connect.Request[v2.PatchEn
 	return c.patchEnv.CallUnary(ctx, req)
 }
 
+// BulkRerun calls api.v2.V2.BulkRerun.
+func (c *v2Client) BulkRerun(ctx context.Context, req *connect.Request[v2.BulkRerunRequest]) (*connect.Response[v2.BulkRerunResponse], error) {
+	return c.bulkRerun.CallUnary(ctx, req)
+}
+
 // V2Handler is an implementation of the api.v2.V2 service.
 type V2Handler interface {
 	Health(context.Context, *connect.Request[v2.HealthRequest]) (*connect.Response[v2.HealthResponse], error)
@@ -255,6 +270,7 @@ type V2Handler interface {
 	CreateWebhook(context.Context, *connect.Request[v2.CreateWebhookRequest]) (*connect.Response[v2.CreateWebhookResponse], error)
 	ListWebhooks(context.Context, *connect.Request[v2.ListWebhooksRequest]) (*connect.Response[v2.ListWebhooksResponse], error)
 	PatchEnv(context.Context, *connect.Request[v2.PatchEnvRequest]) (*connect.Response[v2.PatchEnvsResponse], error)
+	BulkRerun(context.Context, *connect.Request[v2.BulkRerunRequest]) (*connect.Response[v2.BulkRerunResponse], error)
 }
 
 // NewV2Handler builds an HTTP handler from the service implementation. It returns the path on which
@@ -336,6 +352,12 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 		connect.WithSchema(v2Methods.ByName("PatchEnv")),
 		connect.WithHandlerOptions(opts...),
 	)
+	v2BulkRerunHandler := connect.NewUnaryHandler(
+		V2BulkRerunProcedure,
+		svc.BulkRerun,
+		connect.WithSchema(v2Methods.ByName("BulkRerun")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/api.v2.V2/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case V2HealthProcedure:
@@ -362,6 +384,8 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 			v2ListWebhooksHandler.ServeHTTP(w, r)
 		case V2PatchEnvProcedure:
 			v2PatchEnvHandler.ServeHTTP(w, r)
+		case V2BulkRerunProcedure:
+			v2BulkRerunHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -417,4 +441,8 @@ func (UnimplementedV2Handler) ListWebhooks(context.Context, *connect.Request[v2.
 
 func (UnimplementedV2Handler) PatchEnv(context.Context, *connect.Request[v2.PatchEnvRequest]) (*connect.Response[v2.PatchEnvsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.PatchEnv is not implemented"))
+}
+
+func (UnimplementedV2Handler) BulkRerun(context.Context, *connect.Request[v2.BulkRerunRequest]) (*connect.Response[v2.BulkRerunResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.BulkRerun is not implemented"))
 }

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -2087,6 +2087,170 @@ func (x *PatchEnvsResponse) GetMetadata() *ResponseMetadata {
 	return nil
 }
 
+type BulkRerunRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RunIds        []string               `protobuf:"bytes,1,rep,name=runIds,proto3" json:"runIds,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BulkRerunRequest) Reset() {
+	*x = BulkRerunRequest{}
+	mi := &file_api_v2_service_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BulkRerunRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BulkRerunRequest) ProtoMessage() {}
+
+func (x *BulkRerunRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BulkRerunRequest.ProtoReflect.Descriptor instead.
+func (*BulkRerunRequest) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *BulkRerunRequest) GetRunIds() []string {
+	if x != nil {
+		return x.RunIds
+	}
+	return nil
+}
+
+type BulkRerunResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Data          []*RerunResult         `protobuf:"bytes,1,rep,name=data,proto3" json:"data,omitempty"`
+	Metadata      *ResponseMetadata      `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BulkRerunResponse) Reset() {
+	*x = BulkRerunResponse{}
+	mi := &file_api_v2_service_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BulkRerunResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BulkRerunResponse) ProtoMessage() {}
+
+func (x *BulkRerunResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BulkRerunResponse.ProtoReflect.Descriptor instead.
+func (*BulkRerunResponse) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *BulkRerunResponse) GetData() []*RerunResult {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+func (x *BulkRerunResponse) GetMetadata() *ResponseMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+type RerunResult struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	OriginalRunId string                 `protobuf:"bytes,1,opt,name=originalRunId,proto3" json:"originalRunId,omitempty"`
+	NewRunId      *string                `protobuf:"bytes,2,opt,name=newRunId,proto3,oneof" json:"newRunId,omitempty"`
+	Success       bool                   `protobuf:"varint,3,opt,name=success,proto3" json:"success,omitempty"`
+	Error         *string                `protobuf:"bytes,4,opt,name=error,proto3,oneof" json:"error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RerunResult) Reset() {
+	*x = RerunResult{}
+	mi := &file_api_v2_service_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RerunResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RerunResult) ProtoMessage() {}
+
+func (x *RerunResult) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RerunResult.ProtoReflect.Descriptor instead.
+func (*RerunResult) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *RerunResult) GetOriginalRunId() string {
+	if x != nil {
+		return x.OriginalRunId
+	}
+	return ""
+}
+
+func (x *RerunResult) GetNewRunId() string {
+	if x != nil && x.NewRunId != nil {
+		return *x.NewRunId
+	}
+	return ""
+}
+
+func (x *RerunResult) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *RerunResult) GetError() string {
+	if x != nil && x.Error != nil {
+		return *x.Error
+	}
+	return ""
+}
+
 var File_api_v2_service_proto protoreflect.FileDescriptor
 
 const file_api_v2_service_proto_rawDesc = "" +
@@ -2243,7 +2407,19 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\v_isArchived\"j\n" +
 	"\x11PatchEnvsResponse\x12\x1f\n" +
 	"\x04data\x18\x01 \x01(\v2\v.api.v2.EnvR\x04data\x124\n" +
-	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata*/\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\x91\x01\n" +
+	"\x10BulkRerunRequest\x12}\n" +
+	"\x06runIds\x18\x01 \x03(\tBe\x92Ab2\"List of run IDs to rerun (max: 50)J<[\"01HP1ZX8M3NG9VP6QN0XK7J4CY\", \"01HP1ZY9N4OH0WQ7RO1YL8K5DZ\"]R\x06runIds\"r\n" +
+	"\x11BulkRerunResponse\x12'\n" +
+	"\x04data\x18\x01 \x03(\v2\x13.api.v2.RerunResultR\x04data\x124\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\xa0\x01\n" +
+	"\vRerunResult\x12$\n" +
+	"\roriginalRunId\x18\x01 \x01(\tR\roriginalRunId\x12\x1f\n" +
+	"\bnewRunId\x18\x02 \x01(\tH\x00R\bnewRunId\x88\x01\x01\x12\x18\n" +
+	"\asuccess\x18\x03 \x01(\bR\asuccess\x12\x19\n" +
+	"\x05error\x18\x04 \x01(\tH\x01R\x05error\x88\x01\x01B\v\n" +
+	"\t_newRunIdB\b\n" +
+	"\x06_error*/\n" +
 	"\aEnvType\x12\x0e\n" +
 	"\n" +
 	"PRODUCTION\x10\x00\x12\b\n" +
@@ -2253,7 +2429,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\n" +
 	"FilterType\x12\t\n" +
 	"\x05ALLOW\x10\x00\x12\b\n" +
-	"\x04DENY\x10\x012\xd8;\n" +
+	"\x04DENY\x10\x012\xb4@\n" +
 	"\x02V2\x12\xb2\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\xf8\x01\x92A\xe5\x01\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
 	"\x03401\x12K\n" +
@@ -2490,7 +2666,27 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x0e\n" +
 	"\n" +
 	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x0f:\x01*2\n" +
-	"/envs/{id}B\xc8\x02\x92A\x91\x02\x12\x9b\x01\n" +
+	"/envs/{id}\x12\xd9\x04\n" +
+	"\tBulkRerun\x12\x18.api.v2.BulkRerunRequest\x1a\x19.api.v2.BulkRerunResponse\"\x96\x04\x92A\xfc\x03\x12\n" +
+	"Bulk rerun\x1aaTriggers up to 50 runs to be re-executed. Each run will be replayed with its original event data.JB\n" +
+	"\x03200\x12;\n" +
+	"\x12Bulk rerun results\x12%\n" +
+	"#\x1a!#/definitions/v2BulkRerunResponseJL\n" +
+	"\x03400\x12E\n" +
+	" Bad Request - invalid input data\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJR\n" +
+	"\x03401\x12K\n" +
+	"&Unauthorized - authentication required\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJP\n" +
+	"\x03403\x12I\n" +
+	"$Forbidden - insufficient permissions\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJA\n" +
+	"\x03500\x12:\n" +
+	"\x15Internal Server Error\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
+	"\x0e\n" +
+	"\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x10:\x01*\"\v/bulk/rerunB\xc8\x02\x92A\x91\x02\x12\x9b\x01\n" +
 	"\x13Inngest REST API v2\x12}The v2 API delivers a significantly improved developer experience with consistent design patterns and enhanced functionality.2\x052.0.0\x1a\x0fapi.inngest.com\"\x03/v2*\x01\x02ZX\n" +
 	"V\n" +
 	"\n" +
@@ -2509,7 +2705,7 @@ func file_api_v2_service_proto_rawDescGZIP() []byte {
 }
 
 var file_api_v2_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 37)
 var file_api_v2_service_proto_goTypes = []any{
 	(EnvType)(0),                            // 0: api.v2.EnvType
 	(FilterType)(0),                         // 1: api.v2.FilterType
@@ -2547,40 +2743,43 @@ var file_api_v2_service_proto_goTypes = []any{
 	(*Webhook)(nil),                         // 33: api.v2.Webhook
 	(*PatchEnvRequest)(nil),                 // 34: api.v2.PatchEnvRequest
 	(*PatchEnvsResponse)(nil),               // 35: api.v2.PatchEnvsResponse
-	(*timestamppb.Timestamp)(nil),           // 36: google.protobuf.Timestamp
+	(*BulkRerunRequest)(nil),                // 36: api.v2.BulkRerunRequest
+	(*BulkRerunResponse)(nil),               // 37: api.v2.BulkRerunResponse
+	(*RerunResult)(nil),                     // 38: api.v2.RerunResult
+	(*timestamppb.Timestamp)(nil),           // 39: google.protobuf.Timestamp
 }
 var file_api_v2_service_proto_depIdxs = []int32{
 	5,  // 0: api.v2.HealthResponse.data:type_name -> api.v2.HealthData
 	8,  // 1: api.v2.HealthResponse.metadata:type_name -> api.v2.ResponseMetadata
 	6,  // 2: api.v2.ErrorResponse.errors:type_name -> api.v2.Error
-	36, // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
-	36, // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
+	39, // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
+	39, // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
 	14, // 5: api.v2.CreateAccountResponse.data:type_name -> api.v2.CreateAccountData
 	8,  // 6: api.v2.CreateAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
 	13, // 7: api.v2.CreateEnvResponse.data:type_name -> api.v2.Env
 	8,  // 8: api.v2.CreateEnvResponse.metadata:type_name -> api.v2.ResponseMetadata
 	0,  // 9: api.v2.Env.type:type_name -> api.v2.EnvType
-	36, // 10: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
-	36, // 11: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
-	36, // 12: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
+	39, // 10: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
+	39, // 11: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
+	39, // 12: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
 	18, // 13: api.v2.FetchAccountsResponse.data:type_name -> api.v2.Account
 	8,  // 14: api.v2.FetchAccountsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	19, // 15: api.v2.FetchAccountsResponse.page:type_name -> api.v2.Page
 	18, // 16: api.v2.FetchAccountResponse.data:type_name -> api.v2.Account
 	8,  // 17: api.v2.FetchAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
-	36, // 18: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
-	36, // 19: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
+	39, // 18: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
+	39, // 19: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
 	22, // 20: api.v2.FetchAccountEventKeysResponse.data:type_name -> api.v2.EventKey
 	8,  // 21: api.v2.FetchAccountEventKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	19, // 22: api.v2.FetchAccountEventKeysResponse.page:type_name -> api.v2.Page
-	36, // 23: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
+	39, // 23: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
 	13, // 24: api.v2.FetchAccountEnvsResponse.data:type_name -> api.v2.Env
 	8,  // 25: api.v2.FetchAccountEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	19, // 26: api.v2.FetchAccountEnvsResponse.page:type_name -> api.v2.Page
 	27, // 27: api.v2.FetchAccountSigningKeysResponse.data:type_name -> api.v2.SigningKey
 	8,  // 28: api.v2.FetchAccountSigningKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	19, // 29: api.v2.FetchAccountSigningKeysResponse.page:type_name -> api.v2.Page
-	36, // 30: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
+	39, // 30: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
 	30, // 31: api.v2.CreateWebhookRequest.event_filter:type_name -> api.v2.EventFilter
 	33, // 32: api.v2.CreateWebhookResponse.data:type_name -> api.v2.Webhook
 	8,  // 33: api.v2.CreateWebhookResponse.metadata:type_name -> api.v2.ResponseMetadata
@@ -2589,39 +2788,43 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	8,  // 36: api.v2.ListWebhooksResponse.metadata:type_name -> api.v2.ResponseMetadata
 	19, // 37: api.v2.ListWebhooksResponse.page:type_name -> api.v2.Page
 	30, // 38: api.v2.Webhook.event_filter:type_name -> api.v2.EventFilter
-	36, // 39: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
-	36, // 40: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
+	39, // 39: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
+	39, // 40: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
 	13, // 41: api.v2.PatchEnvsResponse.data:type_name -> api.v2.Env
 	8,  // 42: api.v2.PatchEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	2,  // 43: api.v2.V2.Health:input_type -> api.v2.HealthRequest
-	2,  // 44: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
-	9,  // 45: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
-	11, // 46: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
-	15, // 47: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
-	3,  // 48: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
-	23, // 49: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
-	20, // 50: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
-	25, // 51: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
-	28, // 52: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
-	31, // 53: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
-	34, // 54: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
-	4,  // 55: api.v2.V2.Health:output_type -> api.v2.HealthResponse
-	7,  // 56: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
-	10, // 57: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
-	12, // 58: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
-	16, // 59: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
-	17, // 60: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
-	24, // 61: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
-	21, // 62: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
-	26, // 63: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
-	29, // 64: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
-	32, // 65: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
-	35, // 66: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
-	55, // [55:67] is the sub-list for method output_type
-	43, // [43:55] is the sub-list for method input_type
-	43, // [43:43] is the sub-list for extension type_name
-	43, // [43:43] is the sub-list for extension extendee
-	0,  // [0:43] is the sub-list for field type_name
+	38, // 43: api.v2.BulkRerunResponse.data:type_name -> api.v2.RerunResult
+	8,  // 44: api.v2.BulkRerunResponse.metadata:type_name -> api.v2.ResponseMetadata
+	2,  // 45: api.v2.V2.Health:input_type -> api.v2.HealthRequest
+	2,  // 46: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
+	9,  // 47: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
+	11, // 48: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
+	15, // 49: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
+	3,  // 50: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
+	23, // 51: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
+	20, // 52: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
+	25, // 53: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
+	28, // 54: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
+	31, // 55: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
+	34, // 56: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
+	36, // 57: api.v2.V2.BulkRerun:input_type -> api.v2.BulkRerunRequest
+	4,  // 58: api.v2.V2.Health:output_type -> api.v2.HealthResponse
+	7,  // 59: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
+	10, // 60: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
+	12, // 61: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
+	16, // 62: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
+	17, // 63: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
+	24, // 64: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
+	21, // 65: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
+	26, // 66: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
+	29, // 67: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
+	32, // 68: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
+	35, // 69: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
+	37, // 70: api.v2.V2.BulkRerun:output_type -> api.v2.BulkRerunResponse
+	58, // [58:71] is the sub-list for method output_type
+	45, // [45:58] is the sub-list for method input_type
+	45, // [45:45] is the sub-list for extension type_name
+	45, // [45:45] is the sub-list for extension extendee
+	0,  // [0:45] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_service_proto_init() }
@@ -2641,13 +2844,14 @@ func file_api_v2_service_proto_init() {
 	file_api_v2_service_proto_msgTypes[29].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[31].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[32].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[36].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v2_service_proto_rawDesc), len(file_api_v2_service_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   34,
+			NumMessages:   37,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/gen/api/v2/service.pb.gw.go
+++ b/proto/gen/api/v2/service.pb.gw.go
@@ -378,6 +378,33 @@ func local_request_V2_PatchEnv_0(ctx context.Context, marshaler runtime.Marshale
 	return msg, metadata, err
 }
 
+func request_V2_BulkRerun_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq BulkRerunRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.BulkRerun(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_V2_BulkRerun_0(ctx context.Context, marshaler runtime.Marshaler, server V2Server, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq BulkRerunRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.BulkRerun(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterV2HandlerServer registers the http handlers for service V2 to "mux".
 // UnaryRPC     :call V2Server directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -603,6 +630,26 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 			return
 		}
 		forward_V2_PatchEnv_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodPost, pattern_V2_BulkRerun_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/BulkRerun", runtime.WithHTTPPathPattern("/bulk/rerun"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_V2_BulkRerun_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_BulkRerun_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
 
 	return nil
@@ -831,6 +878,23 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		}
 		forward_V2_PatchEnv_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_V2_BulkRerun_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/BulkRerun", runtime.WithHTTPPathPattern("/bulk/rerun"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_V2_BulkRerun_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_BulkRerun_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -846,6 +910,7 @@ var (
 	pattern_V2_CreateWebhook_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"env", "webhooks"}, ""))
 	pattern_V2_ListWebhooks_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"env", "webhooks"}, ""))
 	pattern_V2_PatchEnv_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"envs", "id"}, ""))
+	pattern_V2_BulkRerun_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"bulk", "rerun"}, ""))
 )
 
 var (
@@ -860,4 +925,5 @@ var (
 	forward_V2_CreateWebhook_0           = runtime.ForwardResponseMessage
 	forward_V2_ListWebhooks_0            = runtime.ForwardResponseMessage
 	forward_V2_PatchEnv_0                = runtime.ForwardResponseMessage
+	forward_V2_BulkRerun_0               = runtime.ForwardResponseMessage
 )

--- a/proto/gen/api/v2/service_grpc.pb.go
+++ b/proto/gen/api/v2/service_grpc.pb.go
@@ -31,6 +31,7 @@ const (
 	V2_CreateWebhook_FullMethodName           = "/api.v2.V2/CreateWebhook"
 	V2_ListWebhooks_FullMethodName            = "/api.v2.V2/ListWebhooks"
 	V2_PatchEnv_FullMethodName                = "/api.v2.V2/PatchEnv"
+	V2_BulkRerun_FullMethodName               = "/api.v2.V2/BulkRerun"
 )
 
 // V2Client is the client API for V2 service.
@@ -50,6 +51,7 @@ type V2Client interface {
 	CreateWebhook(ctx context.Context, in *CreateWebhookRequest, opts ...grpc.CallOption) (*CreateWebhookResponse, error)
 	ListWebhooks(ctx context.Context, in *ListWebhooksRequest, opts ...grpc.CallOption) (*ListWebhooksResponse, error)
 	PatchEnv(ctx context.Context, in *PatchEnvRequest, opts ...grpc.CallOption) (*PatchEnvsResponse, error)
+	BulkRerun(ctx context.Context, in *BulkRerunRequest, opts ...grpc.CallOption) (*BulkRerunResponse, error)
 }
 
 type v2Client struct {
@@ -180,6 +182,16 @@ func (c *v2Client) PatchEnv(ctx context.Context, in *PatchEnvRequest, opts ...gr
 	return out, nil
 }
 
+func (c *v2Client) BulkRerun(ctx context.Context, in *BulkRerunRequest, opts ...grpc.CallOption) (*BulkRerunResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BulkRerunResponse)
+	err := c.cc.Invoke(ctx, V2_BulkRerun_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // V2Server is the server API for V2 service.
 // All implementations must embed UnimplementedV2Server
 // for forward compatibility.
@@ -197,6 +209,7 @@ type V2Server interface {
 	CreateWebhook(context.Context, *CreateWebhookRequest) (*CreateWebhookResponse, error)
 	ListWebhooks(context.Context, *ListWebhooksRequest) (*ListWebhooksResponse, error)
 	PatchEnv(context.Context, *PatchEnvRequest) (*PatchEnvsResponse, error)
+	BulkRerun(context.Context, *BulkRerunRequest) (*BulkRerunResponse, error)
 	mustEmbedUnimplementedV2Server()
 }
 
@@ -242,6 +255,9 @@ func (UnimplementedV2Server) ListWebhooks(context.Context, *ListWebhooksRequest)
 }
 func (UnimplementedV2Server) PatchEnv(context.Context, *PatchEnvRequest) (*PatchEnvsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method PatchEnv not implemented")
+}
+func (UnimplementedV2Server) BulkRerun(context.Context, *BulkRerunRequest) (*BulkRerunResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method BulkRerun not implemented")
 }
 func (UnimplementedV2Server) mustEmbedUnimplementedV2Server() {}
 func (UnimplementedV2Server) testEmbeddedByValue()            {}
@@ -480,6 +496,24 @@ func _V2_PatchEnv_Handler(srv interface{}, ctx context.Context, dec func(interfa
 	return interceptor(ctx, in, info, handler)
 }
 
+func _V2_BulkRerun_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(BulkRerunRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(V2Server).BulkRerun(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: V2_BulkRerun_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(V2Server).BulkRerun(ctx, req.(*BulkRerunRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // V2_ServiceDesc is the grpc.ServiceDesc for V2 service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -534,6 +568,10 @@ var V2_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "PatchEnv",
 			Handler:    _V2_PatchEnv_Handler,
+		},
+		{
+			MethodName: "BulkRerun",
+			Handler:    _V2_BulkRerun_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},


### PR DESCRIPTION
## Description

An endpoint that accepts multiple run ids and re-runs them. Each re-run may potentially fail, but it doesn't fail the entire endpoint.  Current limit of 50 runs per request.

```
curl -XPOST http://localhost:8288/api/v2/bulk/rerun \
  -H "content-type: application/json" -d '{ 
    "runIds": ["01K9XTMJ7CNG4J853W5Z8K694V", "01K9XTMJ798MZ6Z589W94H9AX7"] 
  }'
{
  "data": [
    {
      "originalRunId": "01K9XTMJ7CNG4J853W5Z8K694V",
      "newRunId": "01K9XTPXGPCZFDJNXXN7F46800",
      "success": true
    },
    {
      "originalRunId": "01K9XTMJ798MZ6Z589W94H9AX7",
      "newRunId": "01K9XTPXGTNFVQ95YM7M89PT2R",
      "success": true
    }
  ],
  "metadata": {
    "fetchedAt": "2025-11-13T05:23:45.820203Z",
    "cachedUntil": null
  }
}
```


See related #3297

## Motivation
EXE-907

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
