### PR TITLE
Use TraceReader instead of FunctionRunReader for Extended Trace spans

### DIFF
--- a/pkg/api/apiv1/apiv1.go
+++ b/pkg/api/apiv1/apiv1.go
@@ -35,8 +35,6 @@ type Opts struct {
 	Queue queue.Queue
 	// FunctionReader reads functions from a backing store.
 	FunctionReader cqrs.FunctionReader
-	// FunctionRunReader reads function runs, history, etc. from backing storage
-	FunctionRunReader cqrs.APIV1FunctionRunReader
 	// JobQueueReader reads information around a function run's job queues.
 	JobQueueReader queue.JobQueueReader
 	// CancellationReadWriter reads and writes cancellations to/from a backing store.

--- a/pkg/api/apiv1/traces.go
+++ b/pkg/api/apiv1/traces.go
@@ -207,7 +207,7 @@ func (a router) commitSpan(ctx context.Context, auth apiv1auth.V1Auth, res *reso
 	resourceServiceName := resourceServiceName(res)
 	isUserland := true
 
-	run, err := a.opts.FunctionRunReader.GetFunctionRun(ctx, auth.AccountID(), auth.WorkspaceID(), runID)
+	run, err := a.opts.TraceReader.GetRun(ctx, runID, auth.AccountID(), auth.WorkspaceID())
 	if err != nil {
 		return fmt.Errorf("function run not found: %w", err)
 	}

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -578,7 +578,6 @@ func start(ctx context.Context, opts StartOpts) error {
 			AuthMiddleware:     authn.SigningKeyMiddleware(opts.SigningKey),
 			CachingMiddleware:  caching,
 			FunctionReader:     ds.Data,
-			FunctionRunReader:  ds.Data,
 			JobQueueReader:     ds.Queue.(queue.JobQueueReader),
 			Executor:           ds.Executor,
 			Queue:              rq,


### PR DESCRIPTION
## Description

This makes the extended trace span endpoint use `TraceReader` to get function runs instead of `FunctionRunReader`. This also removes the now unused FunctionRunReader to eliminate confusion in the future as FunctionRunReader is old-trace derived.

A followup monorepo PR will be needed to stop passing FunctionRunReader into api opts.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

Extended Trace span commits were using the old function run reader source which is bigquery-based instead of the new trace spans.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
