### PR TITLE
Added correct execution count to custom/enterprise plans

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/billing/(overview)/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/billing/(overview)/page.tsx
@@ -7,12 +7,7 @@ import EntitlementListItem from '@/components/Billing/Addons/EntitlementListItem
 import BillingInformation from '@/components/Billing/BillingDetails/BillingInformation';
 import PaymentMethod from '@/components/Billing/BillingDetails/PaymentMethod';
 import { LimitBar, type Data } from '@/components/Billing/LimitBar';
-import {
-  isEnterprisePlan,
-  isHobbyFreePlan,
-  isHobbyPlan,
-  type Plan,
-} from '@/components/Billing/Plans/utils';
+import { isHobbyFreePlan, isHobbyPlan } from '@/components/Billing/Plans/utils';
 import {
   billingDetails as getBillingDetails,
   currentPlan as getCurrentPlan,
@@ -64,18 +59,16 @@ export default async function Page() {
     legacyNoRunsPlan = entitlements.runCount.limit === null;
 
     const getBillingModel = (
-      plan: Plan,
       entitlements: EntitlementUsageWithMetricsQuery['account']['entitlements']
     ) => {
-      if (isHobbyPlan(plan)) return 'hobby-executions';
-      if (plan.slug === 'pro-2025-08-08' || plan.slug === 'pro-2025-06-04') return 'pro-executions';
-      if (isEnterprisePlan(plan) && entitlements.executions.limit !== null)
-        return 'enterprise-executions';
-      return 'legacy-steps-runs';
+      if (entitlements.executions.limit !== null) return 'executions';
+      return 'steps-runs';
     };
 
-    const billingModel = getBillingModel(currentPlan, entitlements as EntitlementUsageWithMetricsQuery['account']['entitlements']);
-    const isExecutionBasedPlan = billingModel !== 'legacy-steps-runs';
+    const billingModel = getBillingModel(
+      entitlements as EntitlementUsageWithMetricsQuery['account']['entitlements']
+    );
+    const isExecutionBasedPlan = billingModel === 'executions';
 
     runs = {
       title: 'Runs',


### PR DESCRIPTION
## Description

We currently only show steps + runs for enterprise customer (check ticket for details)

This filters the account for plans which have a limit and displays it properly

<img width="1556" height="466" alt="image" src="https://github.com/user-attachments/assets/61d9b740-626a-412b-89a3-d36343734d03" />


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
