### PR TITLE
Expose idempotency status from rate limit

### DIFF
--- a/pkg/execution/ratelimit/lua/ratelimit.lua
+++ b/pkg/execution/ratelimit/lua/ratelimit.lua
@@ -63,18 +63,18 @@ local function retrieveAndNormalizeTat(key, now_ns, period_ns, delay_variation_t
 	if not tat then
 		return now_ns
 	end
-	
+
 	local raw_tat = tonumber(tat)
 	if not raw_tat then
 		return now_ns -- Reset if tonumber failed
 	end
-	
+
 	local clamped_tat = clampTat(raw_tat, now_ns, period_ns, delay_variation_tolerance)
 	-- If value was clamped, commit the normalization immediately
 	if raw_tat ~= clamped_tat then
 		redis.call("SET", key, clamped_tat, "KEEPTTL")
 	end
-	
+
 	return clamped_tat
 end
 
@@ -150,7 +150,7 @@ local function gcraUpdate(key, now_ns, period_ns, limit, capacity, burst)
 	-- calculate emission interval (tau) - time between each token
 	-- This matches throttled library: quota.MaxRate.period
 	local emission_interval = period_ns / limit
-	
+
 	-- Calculate delay_variation_tolerance for bounds checking
 	local total_capacity = (burst or 0) + 1
 	local delay_variation_tolerance = emission_interval * total_capacity
@@ -181,7 +181,7 @@ end
 
 -- If idempotency key is set, do not perform check again
 if idempotencyTTL > 0 and redis.call("EXISTS", idempotencyKey) == 1 then
-	return { 1, 0 }
+	return { 2, 0 }
 end
 
 -- Check if capacity > 0

--- a/pkg/execution/ratelimit/ratelimit.go
+++ b/pkg/execution/ratelimit/ratelimit.go
@@ -49,8 +49,14 @@ func WithIdempotency(key string, ttl time.Duration) RateLimitOptionFn {
 	}
 }
 
+type RateLimitResult struct {
+	Limited        bool
+	RetryAfter     time.Duration
+	IdempotencyHit bool
+}
+
 type RateLimiter interface {
-	RateLimit(ctx context.Context, key string, c inngest.RateLimit, options ...RateLimitOptionFn) (bool, time.Duration, error)
+	RateLimit(ctx context.Context, key string, c inngest.RateLimit, options ...RateLimitOptionFn) (*RateLimitResult, error)
 }
 
 // RateLimitKey returns the rate limiting key given a function ID, rate limit config,


### PR DESCRIPTION
## Description

This PR refactors the rate limiting interface to expose the idempotency status for metrics.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
