### PR TITLE
EXE-964: Fallback to Github for binary

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -38,5 +38,8 @@
     "@types/request": "^2.48.8",
     "@types/tar": "^6.1.1",
     "typescript": "^4.7.4"
+  },
+  "prettier": {
+    "singleQuote": false
   }
 }


### PR DESCRIPTION
## Description

The primary postinstall binary download is from our CDN. If the CDN is having issues, use Github directly as the backup.

## Motivation
EXE-964 and Cloudflare outage.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
