### PR TITLE
Support insights query deeplinks

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/insights/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/(dashboard)/env/[environmentSlug]/insights/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useQuery } from 'urql';
 
 import { SaveTabProvider } from '@/components/Insights/InsightsSQLEditor/SaveTabContext';
@@ -10,10 +11,13 @@ import { useInsightsTabManager } from '@/components/Insights/InsightsTabManager/
 import { TabManagerProvider } from '@/components/Insights/InsightsTabManager/TabManagerContext';
 import { QueryHelperPanel } from '@/components/Insights/QueryHelperPanel/QueryHelperPanel';
 import { StoredQueriesProvider } from '@/components/Insights/QueryHelperPanel/StoredQueriesContext';
+import { useDeepLinkHandler } from '@/components/Insights/useDeepLinkHandler';
 import { GetAccountEntitlementsDocument } from '@/gql/graphql';
 
 export default function InsightsPage() {
   const [isQueryHelperPanelVisible, setIsQueryHelperPanelVisible] = useState(true);
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
   const [{ data: entitlementsData }] = useQuery({ query: GetAccountEntitlementsDocument });
   const historyWindow = entitlementsData?.account.entitlements.history.limit;
@@ -36,20 +40,54 @@ export default function InsightsPage() {
 
   return (
     <StoredQueriesProvider tabManagerActions={actions}>
-      <SaveTabProvider>
-        <TabManagerProvider actions={actions} activeTab={activeTab}>
-          <SchemasProvider>
-            <div className="flex h-full w-full flex-1 overflow-hidden">
-              {isQueryHelperPanelVisible && (
-                <div className="w-[240px] flex-shrink-0">
-                  <QueryHelperPanel activeSavedQueryId={activeSavedQueryId} />
-                </div>
-              )}
-              <div className="flex h-full w-full flex-1 flex-col overflow-hidden">{tabManager}</div>
-            </div>
-          </SchemasProvider>
-        </TabManagerProvider>
-      </SaveTabProvider>
+      <InsightsContent
+        actions={actions}
+        activeSavedQueryId={activeSavedQueryId}
+        activeTab={activeTab}
+        isQueryHelperPanelVisible={isQueryHelperPanelVisible}
+        router={router}
+        searchParams={searchParams}
+        tabManager={tabManager}
+      />
     </StoredQueriesProvider>
+  );
+}
+
+interface InsightsContentProps {
+  actions: ReturnType<typeof useInsightsTabManager>['actions'];
+  activeSavedQueryId: string | undefined;
+  activeTab: ReturnType<typeof useInsightsTabManager>['tabs'][number] | undefined;
+  isQueryHelperPanelVisible: boolean;
+  router: ReturnType<typeof useRouter>;
+  searchParams: ReturnType<typeof useSearchParams>;
+  tabManager: JSX.Element;
+}
+
+function InsightsContent({
+  actions,
+  activeSavedQueryId,
+  activeTab,
+  isQueryHelperPanelVisible,
+  router,
+  searchParams,
+  tabManager,
+}: InsightsContentProps) {
+  useDeepLinkHandler({ actions, activeSavedQueryId, router, searchParams });
+
+  return (
+    <SaveTabProvider>
+      <TabManagerProvider actions={actions} activeTab={activeTab}>
+        <SchemasProvider>
+          <div className="flex h-full w-full flex-1 overflow-hidden">
+            {isQueryHelperPanelVisible && (
+              <div className="w-[240px] flex-shrink-0">
+                <QueryHelperPanel activeSavedQueryId={activeSavedQueryId} />
+              </div>
+            )}
+            <div className="flex h-full w-full flex-1 flex-col overflow-hidden">{tabManager}</div>
+          </div>
+        </SchemasProvider>
+      </TabManagerProvider>
+    </SaveTabProvider>
   );
 }

--- a/ui/apps/dashboard/src/components/Insights/useDeepLinkHandler.ts
+++ b/ui/apps/dashboard/src/components/Insights/useDeepLinkHandler.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react';
+import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import type { ReadonlyURLSearchParams } from 'next/navigation';
+import { toast } from 'sonner';
+
+import type { TabManagerActions } from '@/components/Insights/InsightsTabManager/InsightsTabManager';
+import { useStoredQueries } from '@/components/Insights/QueryHelperPanel/StoredQueriesContext';
+
+interface UseDeepLinkHandlerParams {
+  actions: TabManagerActions;
+  activeSavedQueryId: string | undefined;
+  router: AppRouterInstance;
+  searchParams: ReadonlyURLSearchParams;
+}
+
+export function useDeepLinkHandler({
+  actions,
+  activeSavedQueryId,
+  router,
+  searchParams,
+}: UseDeepLinkHandlerParams) {
+  const { queries, isSavedQueriesFetching } = useStoredQueries();
+  const hasProcessedInitialQueryId = useRef(false);
+
+  // Handle initial page load with query_id parameter
+  useEffect(() => {
+    if (hasProcessedInitialQueryId.current) return;
+
+    const queryIdFromUrl = searchParams.get('query_id');
+    if (!queryIdFromUrl) {
+      hasProcessedInitialQueryId.current = true;
+      return;
+    }
+
+    // Wait for saved queries to finish loading and have data
+    if (isSavedQueriesFetching || !queries.data) return;
+
+    // Mark as processed to prevent re-running
+    hasProcessedInitialQueryId.current = true;
+
+    // Check if the query exists
+    const savedQuery = queries.data.find((q) => q.id === queryIdFromUrl);
+
+    if (savedQuery) {
+      // Programmatically open the tab
+      actions.createTabFromQuery(savedQuery);
+    } else {
+      // Show error toast if query not found
+      toast.error('Unable to load query; please ensure that you have access to it');
+    }
+  }, [searchParams, queries.data, isSavedQueriesFetching, actions]);
+
+  // Update URL when active tab changes
+  useEffect(() => {
+    // Don't sync URL until we've processed the initial query_id
+    if (!hasProcessedInitialQueryId.current) return;
+
+    const currentQueryId = searchParams.get('query_id');
+    const newQueryId = activeSavedQueryId;
+
+    // Don't update if URL already has the correct query_id
+    if (currentQueryId === newQueryId) return;
+
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (newQueryId) {
+      params.set('query_id', newQueryId);
+    } else {
+      params.delete('query_id');
+    }
+
+    // Update URL without triggering navigation
+    const newUrl = params.toString() ? `?${params.toString()}` : window.location.pathname;
+    router.replace(newUrl, { scroll: false });
+  }, [activeSavedQueryId, searchParams, router]);
+}


### PR DESCRIPTION
## Description

Add support for deep links on insights queries
- show deep link when query is saved
- load query when query_id link is provided

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
