### PR TITLE
Fix schema explorer drawer CTA overlap by adjusting visibility based on available space

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorQueryTitle.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorQueryTitle.tsx
@@ -64,7 +64,7 @@ export function InsightsSQLEditorQueryTitle({ tab }: InsightsSQLEditorQueryTitle
           'text-basis mr-2 flex h-8 w-[314px] cursor-pointer items-center rounded px-2 py-2 text-sm normal-case leading-normal transition-all duration-150',
           isHovered
             ? 'bg-canvasSubtle border-muted border'
-            : 'border border-transparent bg-transparent'
+            : 'bg-canvasBase border-muted border-transparent'
         )}
         onClick={() => {
           setIsEditing(true);

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanel.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanel.tsx
@@ -48,12 +48,14 @@ export function InsightsTabPanel({
         first={
           <Section
             actions={
-              <>
-                <InsightsSQLEditorQueryEditHistoryButton tab={tab} />
+              <div className="relative flex gap-2">
+                <div className="absolute right-full -z-10">
+                  <InsightsSQLEditorQueryEditHistoryButton tab={tab} />
+                </div>
                 <InsightsSQLEditorSavedQueryActionsButton tab={tab} />
                 <InsightsSQLEditorSaveQueryButton tab={tab} />
                 <InsightsSQLEditorQueryButton />
-              </>
+              </div>
             }
             className="h-full"
             title={<InsightsSQLEditorQueryTitle tab={tab} />}


### PR DESCRIPTION
## Description
Fix schema drawer overlapping query controls

## Motivation
Good UX

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
