### PR TITLE
Update save button label and icon in Insights SQL Editor

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorSaveQueryButton.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorSaveQueryButton.tsx
@@ -8,7 +8,7 @@ import {
   TooltipTrigger,
 } from '@inngest/components/Tooltip';
 import { cn } from '@inngest/components/utils/classNames';
-import { RiBookmarkFill, RiBookmarkLine } from '@remixicon/react';
+import { RiSaveLine } from '@remixicon/react';
 
 import { KeyboardShortcutTooltip } from '../KeyboardShortcutTooltip';
 import type { Tab } from '../types';
@@ -20,9 +20,7 @@ type InsightsSQLEditorSaveQueryButtonProps = {
 };
 
 export function InsightsSQLEditorSaveQueryButton({ tab }: InsightsSQLEditorSaveQueryButtonProps) {
-  const { canSave, isSaved, isSaving, saveTab } = useSaveTab(tab);
-
-  const Icon = isSaved ? RiBookmarkFill : RiBookmarkLine;
+  const { canSave, isSaving, saveTab } = useSaveTab(tab);
 
   useDocumentShortcuts([
     {
@@ -39,10 +37,12 @@ export function InsightsSQLEditorSaveQueryButton({ tab }: InsightsSQLEditorSaveQ
             appearance="outlined"
             className="font-medium"
             disabled={!canSave}
-            icon={<Icon className={cn(!canSave ? 'text-disabled' : 'text-muted')} size={16} />}
+            icon={
+              <RiSaveLine className={cn(!canSave ? 'text-disabled' : 'text-muted')} size={16} />
+            }
             iconSide="left"
             kind="secondary"
-            label={`${isSaved ? 'Update' : 'Save'} query`}
+            label="Save"
             loading={isSaving}
             onClick={() => {
               saveTab();


### PR DESCRIPTION
## Description

- Simplify insights save button to always just say "Save"
- update icon to classic disk

## Motivation
Simplify experience

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
