### PR TITLE
added banner showing support availibility during thanksgiving

### DIFF
--- a/ui/apps/dashboard/src/app/(organization-active)/support/page.tsx
+++ b/ui/apps/dashboard/src/app/(organization-active)/support/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { type Route } from 'next';
 import { useSearchParams } from 'next/navigation';
 import { useAuth } from '@clerk/nextjs';
+import { Banner } from '@inngest/components/Banner';
 import { Button } from '@inngest/components/Button';
 import { Link } from '@inngest/components/Link';
 import { Pill } from '@inngest/components/Pill/Pill';
@@ -61,6 +62,13 @@ export default function Page() {
             label={isSignedIn ? 'Back To Dashboard' : 'Sign In To Dashboard'}
           />
         </div>
+        {/* Thanksgiving banner for limited support availability, won't show after November 29 and will removed this after */}
+        {new Date() < new Date('2025-11-29') && (
+          <Banner severity="info" showIcon={false}>
+            In observance of Thanksgiving, our support team will have limited availability from
+            November 26–28. Thank you for your patience as response times may be delayed.
+          </Banner>
+        )}
         <header className="border-subtle flex items-center justify-between border-b py-6">
           <h1 className="text-2xl font-semibold">Inngest Support</h1>
           <div className="" title={`Status updated at ${status.updated_at}`}>


### PR DESCRIPTION

<img width="1026" height="303" alt="Screenshot 2025-11-20 at 1 01 10 PM" src="https://github.com/user-attachments/assets/067e8faa-2e74-4d5f-81ef-ee8d291349e9" />

## Description

Added a banner saying slower support response time during thanksgiving

## Motivation
Give users a response expectation when filing a ticket during holiday

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
