### PR TITLE
Retry pause creation on invokes

### DIFF
--- a/pkg/execution/pauses/error.go
+++ b/pkg/execution/pauses/error.go
@@ -1,0 +1,18 @@
+package pauses
+
+import (
+	"errors"
+
+	"github.com/inngest/inngest/pkg/execution/state"
+)
+
+func WritePauseRetryableError(err error) bool {
+	switch {
+	case errors.Is(err, state.ErrSignalConflict):
+		return false
+	case errors.Is(err, state.ErrPauseAlreadyExists):
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
## Description

This has come up a bunch that runs could hang forever if the pause creation fails and the workflow doesn't have retries setup.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
