### PR TITLE
Add step metadata GQL plumbing

### DIFF
--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -21,6 +21,7 @@ import (
 	"github.com/inngest/inngest/pkg/function"
 	types "github.com/inngest/inngest/pkg/gql_scalars"
 	"github.com/inngest/inngest/pkg/history_reader"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
 	ulid "github.com/oklog/ulid/v2"
 	gqlparser "github.com/vektah/gqlparser/v2"
 	"github.com/vektah/gqlparser/v2/ast"
@@ -458,6 +459,7 @@ type ComplexityRoot struct {
 		FunctionID     func(childComplexity int) int
 		IsRoot         func(childComplexity int) int
 		IsUserland     func(childComplexity int) int
+		Metadata       func(childComplexity int) int
 		Name           func(childComplexity int) int
 		OutputID       func(childComplexity int) int
 		ParentSpan     func(childComplexity int) int
@@ -505,6 +507,11 @@ type ComplexityRoot struct {
 
 	SleepStepInfo struct {
 		SleepUntil func(childComplexity int) int
+	}
+
+	SpanMetadata struct {
+		Kind   func(childComplexity int) int
+		Values func(childComplexity int) int
 	}
 
 	StepError struct {
@@ -2706,6 +2713,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.RunTraceSpan.IsUserland(childComplexity), true
 
+	case "RunTraceSpan.metadata":
+		if e.complexity.RunTraceSpan.Metadata == nil {
+			break
+		}
+
+		return e.complexity.RunTraceSpan.Metadata(childComplexity), true
+
 	case "RunTraceSpan.name":
 		if e.complexity.RunTraceSpan.Name == nil {
 			break
@@ -2934,6 +2948,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.SleepStepInfo.SleepUntil(childComplexity), true
+
+	case "SpanMetadata.kind":
+		if e.complexity.SpanMetadata.Kind == nil {
+			break
+		}
+
+		return e.complexity.SpanMetadata.Kind(childComplexity), true
+
+	case "SpanMetadata.values":
+		if e.complexity.SpanMetadata.Values == nil {
+			break
+		}
+
+		return e.complexity.SpanMetadata.Values(childComplexity), true
 
 	case "StepError.cause":
 		if e.complexity.StepError.Cause == nil {
@@ -3496,6 +3524,8 @@ scalar UUID
 scalar Bytes
 scalar Unknown
 scalar Int64
+scalar SpanMetadataKind
+scalar SpanMetadataValues
 
 "The pagination information in a connection."
 type PageInfo {
@@ -4082,6 +4112,12 @@ type RunTraceSpan {
   debugRunID: ULID
   debugSessionID: ULID
   debugPaused: Boolean!
+  metadata: [SpanMetadata!]!
+}
+
+type SpanMetadata {
+  kind: SpanMetadataKind!
+  values: SpanMetadataValues!
 }
 
 type UserlandSpan {
@@ -7499,6 +7535,8 @@ func (ec *executionContext) fieldContext_DebugRun_debugTraces(ctx context.Contex
 				return ec.fieldContext_RunTraceSpan_debugSessionID(ctx, field)
 			case "debugPaused":
 				return ec.fieldContext_RunTraceSpan_debugPaused(ctx, field)
+			case "metadata":
+				return ec.fieldContext_RunTraceSpan_metadata(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type RunTraceSpan", field.Name)
 		},
@@ -12394,6 +12432,8 @@ func (ec *executionContext) fieldContext_FunctionRunV2_trace(ctx context.Context
 				return ec.fieldContext_RunTraceSpan_debugSessionID(ctx, field)
 			case "debugPaused":
 				return ec.fieldContext_RunTraceSpan_debugPaused(ctx, field)
+			case "metadata":
+				return ec.fieldContext_RunTraceSpan_metadata(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type RunTraceSpan", field.Name)
 		},
@@ -15134,6 +15174,8 @@ func (ec *executionContext) fieldContext_Query_runTrace(ctx context.Context, fie
 				return ec.fieldContext_RunTraceSpan_debugSessionID(ctx, field)
 			case "debugPaused":
 				return ec.fieldContext_RunTraceSpan_debugPaused(ctx, field)
+			case "metadata":
+				return ec.fieldContext_RunTraceSpan_metadata(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type RunTraceSpan", field.Name)
 		},
@@ -18387,6 +18429,8 @@ func (ec *executionContext) fieldContext_RunTraceSpan_childrenSpans(ctx context.
 				return ec.fieldContext_RunTraceSpan_debugSessionID(ctx, field)
 			case "debugPaused":
 				return ec.fieldContext_RunTraceSpan_debugPaused(ctx, field)
+			case "metadata":
+				return ec.fieldContext_RunTraceSpan_metadata(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type RunTraceSpan", field.Name)
 		},
@@ -18736,6 +18780,8 @@ func (ec *executionContext) fieldContext_RunTraceSpan_parentSpan(ctx context.Con
 				return ec.fieldContext_RunTraceSpan_debugSessionID(ctx, field)
 			case "debugPaused":
 				return ec.fieldContext_RunTraceSpan_debugPaused(ctx, field)
+			case "metadata":
+				return ec.fieldContext_RunTraceSpan_metadata(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type RunTraceSpan", field.Name)
 		},
@@ -18965,6 +19011,56 @@ func (ec *executionContext) fieldContext_RunTraceSpan_debugPaused(ctx context.Co
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RunTraceSpan_metadata(ctx context.Context, field graphql.CollectedField, obj *models.RunTraceSpan) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RunTraceSpan_metadata(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Metadata, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*models.SpanMetadata)
+	fc.Result = res
+	return ec.marshalNSpanMetadata2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐSpanMetadataᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RunTraceSpan_metadata(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RunTraceSpan",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "kind":
+				return ec.fieldContext_SpanMetadata_kind(ctx, field)
+			case "values":
+				return ec.fieldContext_SpanMetadata_values(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type SpanMetadata", field.Name)
 		},
 	}
 	return fc, nil
@@ -19685,6 +19781,94 @@ func (ec *executionContext) fieldContext_SleepStepInfo_sleepUntil(ctx context.Co
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SpanMetadata_kind(ctx context.Context, field graphql.CollectedField, obj *models.SpanMetadata) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SpanMetadata_kind(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Kind, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(metadata.Kind)
+	fc.Result = res
+	return ec.marshalNSpanMetadataKind2githubᚗcomᚋinngestᚋinngestᚋpkgᚋtracingᚋmetadataᚐKind(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SpanMetadata_kind(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SpanMetadata",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type SpanMetadataKind does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _SpanMetadata_values(ctx context.Context, field graphql.CollectedField, obj *models.SpanMetadata) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_SpanMetadata_values(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Values, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(metadata.Values)
+	fc.Result = res
+	return ec.marshalNSpanMetadataValues2githubᚗcomᚋinngestᚋinngestᚋpkgᚋtracingᚋmetadataᚐValues(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_SpanMetadata_values(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SpanMetadata",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type SpanMetadataValues does not have child fields")
 		},
 	}
 	return fc, nil
@@ -27459,6 +27643,13 @@ func (ec *executionContext) _RunTraceSpan(ctx context.Context, sel ast.Selection
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "metadata":
+
+			out.Values[i] = ec._RunTraceSpan_metadata(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -27664,6 +27855,41 @@ func (ec *executionContext) _SleepStepInfo(ctx context.Context, sel ast.Selectio
 		case "sleepUntil":
 
 			out.Values[i] = ec._SleepStepInfo_sleepUntil(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var spanMetadataImplementors = []string{"SpanMetadata"}
+
+func (ec *executionContext) _SpanMetadata(ctx context.Context, sel ast.SelectionSet, obj *models.SpanMetadata) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, spanMetadataImplementors)
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("SpanMetadata")
+		case "kind":
+
+			out.Values[i] = ec._SpanMetadata_kind(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "values":
+
+			out.Values[i] = ec._SpanMetadata_values(ctx, field, obj)
 
 			if out.Values[i] == graphql.Null {
 				invalids++
@@ -29535,6 +29761,92 @@ func (ec *executionContext) unmarshalNSingletonMode2githubᚗcomᚋinngestᚋinn
 
 func (ec *executionContext) marshalNSingletonMode2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐSingletonMode(ctx context.Context, sel ast.SelectionSet, v models.SingletonMode) graphql.Marshaler {
 	return v
+}
+
+func (ec *executionContext) marshalNSpanMetadata2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐSpanMetadataᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.SpanMetadata) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNSpanMetadata2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐSpanMetadata(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNSpanMetadata2ᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐSpanMetadata(ctx context.Context, sel ast.SelectionSet, v *models.SpanMetadata) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._SpanMetadata(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNSpanMetadataKind2githubᚗcomᚋinngestᚋinngestᚋpkgᚋtracingᚋmetadataᚐKind(ctx context.Context, v interface{}) (metadata.Kind, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := metadata.Kind(tmp)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNSpanMetadataKind2githubᚗcomᚋinngestᚋinngestᚋpkgᚋtracingᚋmetadataᚐKind(ctx context.Context, sel ast.SelectionSet, v metadata.Kind) graphql.Marshaler {
+	res := graphql.MarshalString(string(v))
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNSpanMetadataValues2githubᚗcomᚋinngestᚋinngestᚋpkgᚋtracingᚋmetadataᚐValues(ctx context.Context, v interface{}) (metadata.Values, error) {
+	var res metadata.Values
+	err := res.UnmarshalGQLContext(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNSpanMetadataValues2githubᚗcomᚋinngestᚋinngestᚋpkgᚋtracingᚋmetadataᚐValues(ctx context.Context, sel ast.SelectionSet, v metadata.Values) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return graphql.WrapContextMarshaler(ctx, v)
 }
 
 func (ec *executionContext) marshalNStreamItem2ᚕᚖgithubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐStreamItemᚄ(ctx context.Context, sel ast.SelectionSet, v []*models.StreamItem) graphql.Marshaler {

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -11,6 +11,8 @@ scalar UUID
 scalar Bytes
 scalar Unknown
 scalar Int64
+scalar SpanMetadataKind
+scalar SpanMetadataValues
 
 "The pagination information in a connection."
 type PageInfo {
@@ -597,6 +599,12 @@ type RunTraceSpan {
   debugRunID: ULID
   debugSessionID: ULID
   debugPaused: Boolean!
+  metadata: [SpanMetadata!]!
+}
+
+type SpanMetadata {
+  kind: SpanMetadataKind!
+  values: SpanMetadataValues!
 }
 
 type UserlandSpan {

--- a/pkg/coreapi/gqlgen.yml
+++ b/pkg/coreapi/gqlgen.yml
@@ -129,6 +129,10 @@ models:
     model: github.com/inngest/inngest/pkg/history_reader.RunHistoryInvokeFunction
   RunHistoryInvokeFunctionResult:
     model: github.com/inngest/inngest/pkg/history_reader.RunHistoryInvokeFunctionResult
+  SpanMetadataKind:
+    model: github.com/inngest/inngest/pkg/tracing/metadata.Kind
+  SpanMetadataValues:
+    model: github.com/inngest/inngest/pkg/tracing/metadata.Values
   StreamItem:
     fields:
       inBatch:

--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -524,6 +524,10 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 		gqlSpan.EndedAt = nil
 	}
 
+	for _, md := range span.Metadata {
+		gqlSpan.Metadata = append(gqlSpan.Metadata, (*models.SpanMetadata)(md))
+	}
+
 	return gqlSpan, nil
 }
 

--- a/pkg/coreapi/graph/models/augmented.go
+++ b/pkg/coreapi/graph/models/augmented.go
@@ -53,6 +53,7 @@ type RunTraceSpan struct {
 	DebugRunID     *ulid.ULID         `json:"debugRunID,omitempty"`
 	DebugSessionID *ulid.ULID         `json:"debugSessionID,omitempty"`
 	DebugPaused    bool               `json:"debugPaused"`
+	Metadata       []*SpanMetadata    `json:"metadata,omitempty"`
 
 	// Internal fields not exposed over GraphQL.
 	SpanTypeName string

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/history_reader"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
 	ulid "github.com/oklog/ulid/v2"
 )
 
@@ -413,6 +414,11 @@ type SleepStepInfo struct {
 }
 
 func (SleepStepInfo) IsStepInfo() {}
+
+type SpanMetadata struct {
+	Kind   metadata.Kind   `json:"kind"`
+	Values metadata.Values `json:"values"`
+}
 
 type StepError struct {
 	Message string      `json:"message"`

--- a/proto/gen/run/v2/run.pb.go
+++ b/proto/gen/run/v2/run.pb.go
@@ -188,6 +188,7 @@ type RunSpan struct {
 	StepId        *string                `protobuf:"bytes,21,opt,name=step_id,json=stepId,proto3,oneof" json:"step_id,omitempty"`
 	IsUserland    bool                   `protobuf:"varint,22,opt,name=is_userland,json=isUserland,proto3" json:"is_userland,omitempty"`
 	UserlandSpan  *UserlandSpan          `protobuf:"bytes,23,opt,name=userland_span,json=userlandSpan,proto3,oneof" json:"userland_span,omitempty"`
+	Metadata      []*SpanMetadata        `protobuf:"bytes,24,rep,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -383,6 +384,13 @@ func (x *RunSpan) GetUserlandSpan() *UserlandSpan {
 	return nil
 }
 
+func (x *RunSpan) GetMetadata() []*SpanMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
 type UserlandSpan struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	SpanName      string                 `protobuf:"bytes,1,opt,name=span_name,json=spanName,proto3" json:"span_name,omitempty"`
@@ -475,6 +483,58 @@ func (x *UserlandSpan) GetResourceAttrs() []byte {
 	return nil
 }
 
+type SpanMetadata struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Kind          string                 `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`
+	Values        map[string]string      `protobuf:"bytes,2,rep,name=values,proto3" json:"values,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SpanMetadata) Reset() {
+	*x = SpanMetadata{}
+	mi := &file_run_v2_run_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SpanMetadata) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SpanMetadata) ProtoMessage() {}
+
+func (x *SpanMetadata) ProtoReflect() protoreflect.Message {
+	mi := &file_run_v2_run_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SpanMetadata.ProtoReflect.Descriptor instead.
+func (*SpanMetadata) Descriptor() ([]byte, []int) {
+	return file_run_v2_run_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *SpanMetadata) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *SpanMetadata) GetValues() map[string]string {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
 type StepInfo struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Info:
@@ -491,7 +551,7 @@ type StepInfo struct {
 
 func (x *StepInfo) Reset() {
 	*x = StepInfo{}
-	mi := &file_run_v2_run_proto_msgTypes[2]
+	mi := &file_run_v2_run_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -503,7 +563,7 @@ func (x *StepInfo) String() string {
 func (*StepInfo) ProtoMessage() {}
 
 func (x *StepInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_run_v2_run_proto_msgTypes[2]
+	mi := &file_run_v2_run_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -516,7 +576,7 @@ func (x *StepInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StepInfo.ProtoReflect.Descriptor instead.
 func (*StepInfo) Descriptor() ([]byte, []int) {
-	return file_run_v2_run_proto_rawDescGZIP(), []int{2}
+	return file_run_v2_run_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *StepInfo) GetInfo() isStepInfo_Info {
@@ -619,7 +679,7 @@ type StepInfoInvoke struct {
 
 func (x *StepInfoInvoke) Reset() {
 	*x = StepInfoInvoke{}
-	mi := &file_run_v2_run_proto_msgTypes[3]
+	mi := &file_run_v2_run_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -631,7 +691,7 @@ func (x *StepInfoInvoke) String() string {
 func (*StepInfoInvoke) ProtoMessage() {}
 
 func (x *StepInfoInvoke) ProtoReflect() protoreflect.Message {
-	mi := &file_run_v2_run_proto_msgTypes[3]
+	mi := &file_run_v2_run_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -644,7 +704,7 @@ func (x *StepInfoInvoke) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StepInfoInvoke.ProtoReflect.Descriptor instead.
 func (*StepInfoInvoke) Descriptor() ([]byte, []int) {
-	return file_run_v2_run_proto_rawDescGZIP(), []int{3}
+	return file_run_v2_run_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *StepInfoInvoke) GetTriggeringEventId() string {
@@ -698,7 +758,7 @@ type StepInfoSleep struct {
 
 func (x *StepInfoSleep) Reset() {
 	*x = StepInfoSleep{}
-	mi := &file_run_v2_run_proto_msgTypes[4]
+	mi := &file_run_v2_run_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -710,7 +770,7 @@ func (x *StepInfoSleep) String() string {
 func (*StepInfoSleep) ProtoMessage() {}
 
 func (x *StepInfoSleep) ProtoReflect() protoreflect.Message {
-	mi := &file_run_v2_run_proto_msgTypes[4]
+	mi := &file_run_v2_run_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -723,7 +783,7 @@ func (x *StepInfoSleep) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StepInfoSleep.ProtoReflect.Descriptor instead.
 func (*StepInfoSleep) Descriptor() ([]byte, []int) {
-	return file_run_v2_run_proto_rawDescGZIP(), []int{4}
+	return file_run_v2_run_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *StepInfoSleep) GetSleepUntil() *timestamppb.Timestamp {
@@ -746,7 +806,7 @@ type StepInfoWaitForEvent struct {
 
 func (x *StepInfoWaitForEvent) Reset() {
 	*x = StepInfoWaitForEvent{}
-	mi := &file_run_v2_run_proto_msgTypes[5]
+	mi := &file_run_v2_run_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -758,7 +818,7 @@ func (x *StepInfoWaitForEvent) String() string {
 func (*StepInfoWaitForEvent) ProtoMessage() {}
 
 func (x *StepInfoWaitForEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_run_v2_run_proto_msgTypes[5]
+	mi := &file_run_v2_run_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -771,7 +831,7 @@ func (x *StepInfoWaitForEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StepInfoWaitForEvent.ProtoReflect.Descriptor instead.
 func (*StepInfoWaitForEvent) Descriptor() ([]byte, []int) {
-	return file_run_v2_run_proto_rawDescGZIP(), []int{5}
+	return file_run_v2_run_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *StepInfoWaitForEvent) GetEventName() string {
@@ -820,7 +880,7 @@ type StepInfoWaitForSignal struct {
 
 func (x *StepInfoWaitForSignal) Reset() {
 	*x = StepInfoWaitForSignal{}
-	mi := &file_run_v2_run_proto_msgTypes[6]
+	mi := &file_run_v2_run_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -832,7 +892,7 @@ func (x *StepInfoWaitForSignal) String() string {
 func (*StepInfoWaitForSignal) ProtoMessage() {}
 
 func (x *StepInfoWaitForSignal) ProtoReflect() protoreflect.Message {
-	mi := &file_run_v2_run_proto_msgTypes[6]
+	mi := &file_run_v2_run_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -845,7 +905,7 @@ func (x *StepInfoWaitForSignal) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StepInfoWaitForSignal.ProtoReflect.Descriptor instead.
 func (*StepInfoWaitForSignal) Descriptor() ([]byte, []int) {
-	return file_run_v2_run_proto_rawDescGZIP(), []int{6}
+	return file_run_v2_run_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *StepInfoWaitForSignal) GetSignal() string {
@@ -878,7 +938,7 @@ type StepInfoRun struct {
 
 func (x *StepInfoRun) Reset() {
 	*x = StepInfoRun{}
-	mi := &file_run_v2_run_proto_msgTypes[7]
+	mi := &file_run_v2_run_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -890,7 +950,7 @@ func (x *StepInfoRun) String() string {
 func (*StepInfoRun) ProtoMessage() {}
 
 func (x *StepInfoRun) ProtoReflect() protoreflect.Message {
-	mi := &file_run_v2_run_proto_msgTypes[7]
+	mi := &file_run_v2_run_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -903,7 +963,7 @@ func (x *StepInfoRun) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StepInfoRun.ProtoReflect.Descriptor instead.
 func (*StepInfoRun) Descriptor() ([]byte, []int) {
-	return file_run_v2_run_proto_rawDescGZIP(), []int{7}
+	return file_run_v2_run_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *StepInfoRun) GetType() string {
@@ -923,7 +983,7 @@ type RunSpanOutput struct {
 
 func (x *RunSpanOutput) Reset() {
 	*x = RunSpanOutput{}
-	mi := &file_run_v2_run_proto_msgTypes[8]
+	mi := &file_run_v2_run_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -935,7 +995,7 @@ func (x *RunSpanOutput) String() string {
 func (*RunSpanOutput) ProtoMessage() {}
 
 func (x *RunSpanOutput) ProtoReflect() protoreflect.Message {
-	mi := &file_run_v2_run_proto_msgTypes[8]
+	mi := &file_run_v2_run_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -948,7 +1008,7 @@ func (x *RunSpanOutput) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunSpanOutput.ProtoReflect.Descriptor instead.
 func (*RunSpanOutput) Descriptor() ([]byte, []int) {
-	return file_run_v2_run_proto_rawDescGZIP(), []int{8}
+	return file_run_v2_run_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *RunSpanOutput) GetData() []byte {
@@ -976,7 +1036,7 @@ type StepError struct {
 
 func (x *StepError) Reset() {
 	*x = StepError{}
-	mi := &file_run_v2_run_proto_msgTypes[9]
+	mi := &file_run_v2_run_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -988,7 +1048,7 @@ func (x *StepError) String() string {
 func (*StepError) ProtoMessage() {}
 
 func (x *StepError) ProtoReflect() protoreflect.Message {
-	mi := &file_run_v2_run_proto_msgTypes[9]
+	mi := &file_run_v2_run_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1001,7 +1061,7 @@ func (x *StepError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StepError.ProtoReflect.Descriptor instead.
 func (*StepError) Descriptor() ([]byte, []int) {
-	return file_run_v2_run_proto_rawDescGZIP(), []int{9}
+	return file_run_v2_run_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *StepError) GetMessage() string {
@@ -1040,7 +1100,7 @@ type RunTrigger struct {
 
 func (x *RunTrigger) Reset() {
 	*x = RunTrigger{}
-	mi := &file_run_v2_run_proto_msgTypes[10]
+	mi := &file_run_v2_run_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1052,7 +1112,7 @@ func (x *RunTrigger) String() string {
 func (*RunTrigger) ProtoMessage() {}
 
 func (x *RunTrigger) ProtoReflect() protoreflect.Message {
-	mi := &file_run_v2_run_proto_msgTypes[10]
+	mi := &file_run_v2_run_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1065,7 +1125,7 @@ func (x *RunTrigger) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunTrigger.ProtoReflect.Descriptor instead.
 func (*RunTrigger) Descriptor() ([]byte, []int) {
-	return file_run_v2_run_proto_rawDescGZIP(), []int{10}
+	return file_run_v2_run_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *RunTrigger) GetEventName() string {
@@ -1121,7 +1181,7 @@ var File_run_v2_run_proto protoreflect.FileDescriptor
 
 const file_run_v2_run_proto_rawDesc = "" +
 	"\n" +
-	"\x10run/v2/run.proto\x12\x06run.v2\x1a\x1fgoogle/protobuf/timestamp.proto\"\xed\a\n" +
+	"\x10run/v2/run.proto\x12\x06run.v2\x1a\x1fgoogle/protobuf/timestamp.proto\"\x9f\b\n" +
 	"\aRunSpan\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\tR\taccountId\x12!\n" +
@@ -1151,7 +1211,8 @@ const file_run_v2_run_proto_rawDesc = "" +
 	"\astep_id\x18\x15 \x01(\tH\x06R\x06stepId\x88\x01\x01\x12\x1f\n" +
 	"\vis_userland\x18\x16 \x01(\bR\n" +
 	"isUserland\x12>\n" +
-	"\ruserland_span\x18\x17 \x01(\v2\x14.run.v2.UserlandSpanH\aR\fuserlandSpan\x88\x01\x01B\x11\n" +
+	"\ruserland_span\x18\x17 \x01(\v2\x14.run.v2.UserlandSpanH\aR\fuserlandSpan\x88\x01\x01\x120\n" +
+	"\bmetadata\x18\x18 \x03(\v2\x14.run.v2.SpanMetadataR\bmetadataB\x11\n" +
 	"\x0f_parent_span_idB\r\n" +
 	"\v_started_atB\v\n" +
 	"\t_ended_atB\f\n" +
@@ -1178,7 +1239,13 @@ const file_run_v2_run_proto_rawDesc = "" +
 	"\v_scope_nameB\x10\n" +
 	"\x0e_scope_versionB\r\n" +
 	"\v_span_attrsB\x11\n" +
-	"\x0f_resource_attrs\"\x99\x02\n" +
+	"\x0f_resource_attrs\"\x97\x01\n" +
+	"\fSpanMetadata\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x128\n" +
+	"\x06values\x18\x02 \x03(\v2 .run.v2.SpanMetadata.ValuesEntryR\x06values\x1a9\n" +
+	"\vValuesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x99\x02\n" +
 	"\bStepInfo\x12-\n" +
 	"\x05sleep\x18\x01 \x01(\v2\x15.run.v2.StepInfoSleepH\x00R\x05sleep\x122\n" +
 	"\x04wait\x18\x02 \x01(\v2\x1c.run.v2.StepInfoWaitForEventH\x00R\x04wait\x120\n" +
@@ -1289,48 +1356,52 @@ func file_run_v2_run_proto_rawDescGZIP() []byte {
 }
 
 var file_run_v2_run_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_run_v2_run_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_run_v2_run_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_run_v2_run_proto_goTypes = []any{
 	(SpanStatus)(0),               // 0: run.v2.SpanStatus
 	(SpanStepOp)(0),               // 1: run.v2.SpanStepOp
 	(*RunSpan)(nil),               // 2: run.v2.RunSpan
 	(*UserlandSpan)(nil),          // 3: run.v2.UserlandSpan
-	(*StepInfo)(nil),              // 4: run.v2.StepInfo
-	(*StepInfoInvoke)(nil),        // 5: run.v2.StepInfoInvoke
-	(*StepInfoSleep)(nil),         // 6: run.v2.StepInfoSleep
-	(*StepInfoWaitForEvent)(nil),  // 7: run.v2.StepInfoWaitForEvent
-	(*StepInfoWaitForSignal)(nil), // 8: run.v2.StepInfoWaitForSignal
-	(*StepInfoRun)(nil),           // 9: run.v2.StepInfoRun
-	(*RunSpanOutput)(nil),         // 10: run.v2.RunSpanOutput
-	(*StepError)(nil),             // 11: run.v2.StepError
-	(*RunTrigger)(nil),            // 12: run.v2.RunTrigger
-	(*timestamppb.Timestamp)(nil), // 13: google.protobuf.Timestamp
+	(*SpanMetadata)(nil),          // 4: run.v2.SpanMetadata
+	(*StepInfo)(nil),              // 5: run.v2.StepInfo
+	(*StepInfoInvoke)(nil),        // 6: run.v2.StepInfoInvoke
+	(*StepInfoSleep)(nil),         // 7: run.v2.StepInfoSleep
+	(*StepInfoWaitForEvent)(nil),  // 8: run.v2.StepInfoWaitForEvent
+	(*StepInfoWaitForSignal)(nil), // 9: run.v2.StepInfoWaitForSignal
+	(*StepInfoRun)(nil),           // 10: run.v2.StepInfoRun
+	(*RunSpanOutput)(nil),         // 11: run.v2.RunSpanOutput
+	(*StepError)(nil),             // 12: run.v2.StepError
+	(*RunTrigger)(nil),            // 13: run.v2.RunTrigger
+	nil,                           // 14: run.v2.SpanMetadata.ValuesEntry
+	(*timestamppb.Timestamp)(nil), // 15: google.protobuf.Timestamp
 }
 var file_run_v2_run_proto_depIdxs = []int32{
 	0,  // 0: run.v2.RunSpan.status:type_name -> run.v2.SpanStatus
-	13, // 1: run.v2.RunSpan.queued_at:type_name -> google.protobuf.Timestamp
-	13, // 2: run.v2.RunSpan.started_at:type_name -> google.protobuf.Timestamp
-	13, // 3: run.v2.RunSpan.ended_at:type_name -> google.protobuf.Timestamp
+	15, // 1: run.v2.RunSpan.queued_at:type_name -> google.protobuf.Timestamp
+	15, // 2: run.v2.RunSpan.started_at:type_name -> google.protobuf.Timestamp
+	15, // 3: run.v2.RunSpan.ended_at:type_name -> google.protobuf.Timestamp
 	1,  // 4: run.v2.RunSpan.step_op:type_name -> run.v2.SpanStepOp
-	4,  // 5: run.v2.RunSpan.step_info:type_name -> run.v2.StepInfo
+	5,  // 5: run.v2.RunSpan.step_info:type_name -> run.v2.StepInfo
 	2,  // 6: run.v2.RunSpan.children:type_name -> run.v2.RunSpan
 	3,  // 7: run.v2.RunSpan.userland_span:type_name -> run.v2.UserlandSpan
-	6,  // 8: run.v2.StepInfo.sleep:type_name -> run.v2.StepInfoSleep
-	7,  // 9: run.v2.StepInfo.wait:type_name -> run.v2.StepInfoWaitForEvent
-	5,  // 10: run.v2.StepInfo.invoke:type_name -> run.v2.StepInfoInvoke
-	9,  // 11: run.v2.StepInfo.run:type_name -> run.v2.StepInfoRun
-	8,  // 12: run.v2.StepInfo.wait_for_signal:type_name -> run.v2.StepInfoWaitForSignal
-	13, // 13: run.v2.StepInfoInvoke.timeout:type_name -> google.protobuf.Timestamp
-	13, // 14: run.v2.StepInfoSleep.sleep_until:type_name -> google.protobuf.Timestamp
-	13, // 15: run.v2.StepInfoWaitForEvent.timeout:type_name -> google.protobuf.Timestamp
-	13, // 16: run.v2.StepInfoWaitForSignal.timeout:type_name -> google.protobuf.Timestamp
-	11, // 17: run.v2.RunSpanOutput.error:type_name -> run.v2.StepError
-	13, // 18: run.v2.RunTrigger.timestamp:type_name -> google.protobuf.Timestamp
-	19, // [19:19] is the sub-list for method output_type
-	19, // [19:19] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	4,  // 8: run.v2.RunSpan.metadata:type_name -> run.v2.SpanMetadata
+	14, // 9: run.v2.SpanMetadata.values:type_name -> run.v2.SpanMetadata.ValuesEntry
+	7,  // 10: run.v2.StepInfo.sleep:type_name -> run.v2.StepInfoSleep
+	8,  // 11: run.v2.StepInfo.wait:type_name -> run.v2.StepInfoWaitForEvent
+	6,  // 12: run.v2.StepInfo.invoke:type_name -> run.v2.StepInfoInvoke
+	10, // 13: run.v2.StepInfo.run:type_name -> run.v2.StepInfoRun
+	9,  // 14: run.v2.StepInfo.wait_for_signal:type_name -> run.v2.StepInfoWaitForSignal
+	15, // 15: run.v2.StepInfoInvoke.timeout:type_name -> google.protobuf.Timestamp
+	15, // 16: run.v2.StepInfoSleep.sleep_until:type_name -> google.protobuf.Timestamp
+	15, // 17: run.v2.StepInfoWaitForEvent.timeout:type_name -> google.protobuf.Timestamp
+	15, // 18: run.v2.StepInfoWaitForSignal.timeout:type_name -> google.protobuf.Timestamp
+	12, // 19: run.v2.RunSpanOutput.error:type_name -> run.v2.StepError
+	15, // 20: run.v2.RunTrigger.timestamp:type_name -> google.protobuf.Timestamp
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_run_v2_run_proto_init() }
@@ -1340,27 +1411,27 @@ func file_run_v2_run_proto_init() {
 	}
 	file_run_v2_run_proto_msgTypes[0].OneofWrappers = []any{}
 	file_run_v2_run_proto_msgTypes[1].OneofWrappers = []any{}
-	file_run_v2_run_proto_msgTypes[2].OneofWrappers = []any{
+	file_run_v2_run_proto_msgTypes[3].OneofWrappers = []any{
 		(*StepInfo_Sleep)(nil),
 		(*StepInfo_Wait)(nil),
 		(*StepInfo_Invoke)(nil),
 		(*StepInfo_Run)(nil),
 		(*StepInfo_WaitForSignal)(nil),
 	}
-	file_run_v2_run_proto_msgTypes[3].OneofWrappers = []any{}
-	file_run_v2_run_proto_msgTypes[5].OneofWrappers = []any{}
+	file_run_v2_run_proto_msgTypes[4].OneofWrappers = []any{}
 	file_run_v2_run_proto_msgTypes[6].OneofWrappers = []any{}
 	file_run_v2_run_proto_msgTypes[7].OneofWrappers = []any{}
 	file_run_v2_run_proto_msgTypes[8].OneofWrappers = []any{}
 	file_run_v2_run_proto_msgTypes[9].OneofWrappers = []any{}
 	file_run_v2_run_proto_msgTypes[10].OneofWrappers = []any{}
+	file_run_v2_run_proto_msgTypes[11].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_run_v2_run_proto_rawDesc), len(file_run_v2_run_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   11,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/run/v2/run.proto
+++ b/proto/run/v2/run.proto
@@ -34,6 +34,7 @@ message RunSpan {
   optional string step_id = 21;
   bool is_userland = 22;
   optional UserlandSpan userland_span = 23;
+  repeated SpanMetadata metadata = 24;
 }
 
 message UserlandSpan {
@@ -44,6 +45,11 @@ message UserlandSpan {
   optional string scope_version = 5;
   optional bytes span_attrs = 6;
   optional bytes resource_attrs = 7;
+}
+
+message SpanMetadata {
+  string kind = 1;
+  map<string, string> values = 2;
 }
 
 enum SpanStatus {


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->
This adds span metadata rollup & plumbing through GQL.

Currently this plumbs metadata effectively as a `map[string]json.RawMessage` in GQL. Should we have full schemas for the typed metadata so that individual subfields can be queried directly in GQL? Or is having an appropriate type in Typescript sufficient? We can represent the structured metadata with a sufficiently complex union type like so 

```typescript
export type SpanMetadata =
  | SpanMetadataInngestAI
  | SpanMetadataUserland;

export type SpanMetadataInngestAI = {
  kind: 'inngest.ai';
  values: {
    url: string;
    model: string;
    system: string;
    operation_name: string;

    id?: string;
    tokens_in?: number;
    tokens_out?: number;
  };
}

export type SpanMetadataUserland = {
  kind: `userland.${string}`;
  values: Record<string, any>;
}

```

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->
We want to expose metadata in the UI eventually and we're already getting all the metadata spans during the run trace query, so just roll up metadata spans and attach them to their parent spans.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
