### PR TITLE
[SYS-370] Add Int64 Data Type As Alias For Number in GraphQL

### DIFF
--- a/ui/apps/dashboard/graphql.config.js
+++ b/ui/apps/dashboard/graphql.config.js
@@ -36,6 +36,7 @@ const config = {
               EdgeType: 'unknown',
               FilterType: 'string',
               IngestSource: 'string',
+              Int64: 'number',
               IP: 'string',
               JSON: 'null | boolean | number | string | Record<string, unknown> | unknown[]',
               Map: 'Record<string, unknown>',

--- a/ui/apps/dashboard/src/gql/graphql.ts
+++ b/ui/apps/dashboard/src/gql/graphql.ts
@@ -19,6 +19,7 @@ export type Scalars = {
   FilterType: string;
   IP: string;
   IngestSource: string;
+  Int64: number;
   JSON: null | boolean | number | string | Record<string, unknown> | unknown[];
   Map: Record<string, unknown>;
   NullString: null | string;
@@ -261,6 +262,7 @@ export type BillingPlan = {
 
 export type BillingSubscription = {
   __typename?: 'BillingSubscription';
+  nextInvoiceAmount: Scalars['Int'];
   nextInvoiceDate: Scalars['Time'];
 };
 
@@ -388,6 +390,7 @@ export type ConnectV1WorkerConnection = {
   id: Scalars['ULID'];
   instanceId: Scalars['String'];
   lastHeartbeatAt: Maybe<Scalars['Time']>;
+  maxWorkerConcurrency: Scalars['Int64'];
   memBytes: Scalars['Int'];
   os: Scalars['String'];
   sdkLang: Scalars['String'];
@@ -433,6 +436,13 @@ export enum ConnectV1WorkerConnectionsOrderByField {
   DisconnectedAt = 'DISCONNECTED_AT',
   LastHeartbeatAt = 'LAST_HEARTBEAT_AT'
 }
+
+export type ConnectV1WorkerMetricsFilter = {
+  from: Scalars['Time'];
+  instanceIDs?: InputMaybe<Array<Scalars['String']>>;
+  name: Scalars['String'];
+  until?: InputMaybe<Scalars['Time']>;
+};
 
 export type CreateCancellationInput = {
   envID: Scalars['UUID'];
@@ -2474,6 +2484,7 @@ export type Workspace = {
   apps: Array<App>;
   archivedEvent: Maybe<ArchivedEvent>;
   cdcConnections: Array<CdcConnection>;
+  connectWorkerMetrics: ScopedMetricsResponse;
   createdAt: Scalars['Time'];
   event: Maybe<Event>;
   eventByNames: Array<EventType>;
@@ -2533,6 +2544,11 @@ export type WorkspaceAppsArgs = {
 
 export type WorkspaceArchivedEventArgs = {
   id: Scalars['ULID'];
+};
+
+
+export type WorkspaceConnectWorkerMetricsArgs = {
+  filter: ConnectV1WorkerMetricsFilter;
 };
 
 


### PR DESCRIPTION
## Description

Add Int64 Data Type As Alias For Number  in GraphQL

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->
We introduced a new data type for Int64, that maps to 'number'. We add that as part of the graphql-config.ts file and then run `pnpm graphql-codegen` 

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
