### PR TITLE
Fix metadata span attributes

### DIFF
--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -121,13 +121,12 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 		DynamicSpanTraceParent: fmt.Sprintf("00-%s-%s-00", parentSpan.TraceID, parentSpan.SpanID),
 	}
 
-	addTenantIDs := func(attr *meta.SerializableAttrs) {
-		meta.AddAttr(attr, meta.Attrs.AccountID, util.ToPtr(auth.AccountID()))
-		meta.AddAttr(attr, meta.Attrs.EnvID, util.ToPtr(auth.WorkspaceID()))
-		meta.AddAttr(attr, meta.Attrs.FunctionID, &parentSpan.FunctionID)
-		meta.AddAttr(attr, meta.Attrs.RunID, &parentSpan.RunID)
-		meta.AddAttr(attr, meta.Attrs.AppID, &parentSpan.AppID)
-
+	addTenantIDs := func(cfg *tracing.MetadataSpanConfig) {
+		meta.AddAttr(cfg.Attrs, meta.Attrs.AccountID, util.ToPtr(auth.AccountID()))
+		meta.AddAttr(cfg.Attrs, meta.Attrs.EnvID, util.ToPtr(auth.WorkspaceID()))
+		meta.AddAttr(cfg.Attrs, meta.Attrs.FunctionID, &parentSpan.FunctionID)
+		meta.AddAttr(cfg.Attrs, meta.Attrs.RunID, &parentSpan.RunID)
+		meta.AddAttr(cfg.Attrs, meta.Attrs.AppID, &parentSpan.AppID)
 	}
 
 	for _, md := range req.Metadata {

--- a/pkg/api/apiv1/traces.go
+++ b/pkg/api/apiv1/traces.go
@@ -270,8 +270,8 @@ func (a router) commitSpan(ctx context.Context, l logger.Logger, auth apiv1auth.
 		return fmt.Errorf("failed to create span: %w", err)
 	}
 
-	addTenantIDs := func(attrs *meta.SerializableAttrs) {
-		attrs.Merge(tenantAttrs)
+	addTenantIDs := func(cfg *tracing.MetadataSpanConfig) {
+		cfg.Attrs = cfg.Attrs.Merge(tenantAttrs)
 	}
 
 	if a.opts.MetadataOpts.Flag.Enabled(ctx, auth.AccountID()) && a.opts.MetadataOpts.SpanExtractor != nil {


### PR DESCRIPTION
## Description
This fixes metadata span attributes and introduces a new MetadataSpanConfig to contain any new configurable fields that are added in the future.

## Motivation
Extracted span metadata isn't being properly tagged with tenant attributes due to the merged attributes being discarded.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
