### PR TITLE
Fix step metadata span addressing

### DIFF
--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
@@ -503,7 +503,7 @@ WHERE span_id IN (
 )
 GROUP BY dynamic_span_id, run_id, trace_id, parent_span_id
 HAVING SUM((name = 'executor.step.discovery')::int) > 0
-UNION
+UNION ALL
 SELECT
   run_id,
   trace_id,
@@ -520,7 +520,7 @@ SELECT
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND account_id = sqlc.arg(account_id)
-GROUP BY dynamic_span_id
+GROUP BY dynamic_span_id, run_id, trace_id, parent_span_id
 HAVING
   SUM(((attributes#>>'{}')::json->>'_inngest.step.id' = sqlc.arg(step_id)::text)::int) > 0
   AND

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql.go
@@ -1511,7 +1511,7 @@ WHERE span_id IN (
 )
 GROUP BY dynamic_span_id, run_id, trace_id, parent_span_id
 HAVING SUM((name = 'executor.step.discovery')::int) > 0
-UNION
+UNION ALL
 SELECT
   run_id,
   trace_id,
@@ -1528,7 +1528,7 @@ SELECT
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST($1 AS CHAR(26)) AND account_id = $2
-GROUP BY dynamic_span_id
+GROUP BY dynamic_span_id, run_id, trace_id, parent_span_id
 HAVING
   SUM(((attributes#>>'{}')::json->>'_inngest.step.id' = $3::text)::int) > 0
   AND

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
@@ -473,7 +473,7 @@ WHERE span_id IN (
 )
 GROUP BY dynamic_span_id
 HAVING SUM(name = 'executor.step.discovery') > 0
-UNION
+UNION ALL
 SELECT
   run_id,
   trace_id,

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql.go
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql.go
@@ -1537,7 +1537,7 @@ WHERE span_id IN (
 )
 GROUP BY dynamic_span_id
 HAVING SUM(name = 'executor.step.discovery') > 0
-UNION
+UNION ALL
 SELECT
   run_id,
   trace_id,


### PR DESCRIPTION
## Description

This makes the span name constraints more explicit and handles attaching step-level metadata to `executor.step` spans (as opposed to `executor.step.discovery`)

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
