### PR TITLE
Add extended trace spans metrics & reduce log noise

### DIFF
--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -752,3 +752,12 @@ func IncrConstraintAPIScavengerReclaimedLeasesCounter(ctx context.Context, count
 		Tags:        opts.Tags,
 	})
 }
+
+func IncrExtendedTraceSpansTotal(ctx context.Context, count int64, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "extended_trace_spans_total",
+		Description: "Total number of extended trace spans",
+		Tags:        opts.Tags,
+	})
+}


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

This adds a new `extended_trace_spans_total` metric to count the number of successful and failed extended trace span commits.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
