### PR TITLE
use determinstic app id to prevent panic on app sync

### DIFF
--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -748,7 +748,7 @@ func upsertErroredApp(
 				String: pingError.Error(),
 				Valid:  true,
 			},
-			ID:  app.ID,
+			ID:  inngest.DeterministicAppUUID(appURL),
 			Url: appURL,
 		})
 		if err != nil {


### PR DESCRIPTION
## Description

was getting this on startup:

```panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1051c6d74]

goroutine 204 [running]:
github.com/inngest/inngest/pkg/devserver.upsertErroredApp({0x106b02c78, 0x14000f04040}, {0x106b56980, 0x14001347540}, {0x140002f6870, 0x21}, {0x106adc720, 0x14000f05880})
	/home/runner/work/inngest/inngest/pkg/devserver/service.go:751 +0x644
github.com/inngest/inngest/pkg/devserver.(*devserver).pollSDKs(0x140001c3508, {0x106b02c78, 0x14000f04040})
	/home/runner/work/inngest/inngest/pkg/devserver/service.go:369 +0x59c
created by github.com/inngest/inngest/pkg/devserver.(*devserver).Run in goroutine 54
	/home/runner/work/inngest/inngest/pkg/devserver/service.go:175 +0xd4
```

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
