### PR TITLE
Sort span metadata by scope and then kind

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -1,6 +1,7 @@
 package base_cqrs
 
 import (
+	"cmp"
 	"context"
 	"crypto/rand"
 	"database/sql"
@@ -8,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -663,6 +665,12 @@ func sorter(span *cqrs.OtelSpan) {
 
 		// sort based on SpanID if two spans have equal timestamps
 		return span.Children[i].SpanID < span.Children[j].SpanID
+	})
+
+	slices.SortFunc(span.Metadata, func(a, b *cqrs.SpanMetadata) int {
+		return cmp.Or(
+			cmp.Compare(a.Scope, b.Scope),
+			cmp.Compare(a.Kind, b.Kind))
 	})
 
 	for _, child := range span.Children {


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

This sorts span metadata by its scope and then its kind.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

We want metadata to appear in a deterministic order

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
