### PR TITLE
Revert "Use emission interval to compute variance instead of original period_ms"

### DIFF
--- a/pkg/execution/ratelimit/ratelimit_lua_test.go
+++ b/pkg/execution/ratelimit/ratelimit_lua_test.go
@@ -16,7 +16,7 @@ import (
 
 const prefix = "{rl}:"
 
-// initRedis creates miniredis/rueidis for Lua and fake clock
+// initRedis creates both miniredis/rueidis for Lua, throttled store, and fake clock
 func initRedis(t *testing.T) (*miniredis.Miniredis, rueidis.Client, clockwork.FakeClock) {
 	r := miniredis.RunT(t)
 

--- a/pkg/execution/state/redis_state/lua/includes/gcra.lua
+++ b/pkg/execution/state/redis_state/lua/includes/gcra.lua
@@ -7,7 +7,7 @@ local function gcra(key, now_ms, period_ms, limit, burst)
 
 	local emission  = period_ms / math.max(limit, 1)   -- how frequently we can admit new requests
 	local increment = emission * cost         -- this request's time delta
-	local variance  = emission * (math.max(burst, 1)) -- variance takes into account bursts
+	local variance  = period_ms * (math.max(burst, 1)) -- variance takes into account bursts
 
 	-- fetch the theoretical arrival time for equally spaced requests
 	-- at exactly the rate limit


### PR DESCRIPTION
Reverts inngest/inngest#3356