### PR TITLE
fix: Extended trace span IDs

### DIFF
--- a/pkg/api/apiv1/traces.go
+++ b/pkg/api/apiv1/traces.go
@@ -265,6 +265,7 @@ func (a router) commitSpan(ctx context.Context, l logger.Logger, auth apiv1auth.
 		EndTime:            time.Unix(0, int64(s.EndTimeUnixNano)),
 		Parent:             parent,
 		RawOtelSpanOptions: []trace.SpanStartOption{trace.WithAttributes(attrs...)},
+		SpanID:             trace.SpanID(s.SpanId),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create span: %w", err)

--- a/pkg/tracing/tracer_sqlc.go
+++ b/pkg/tracing/tracer_sqlc.go
@@ -43,7 +43,6 @@ func (e *dbExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlyS
 		var debugRunID string
 		var status string
 		var eventIdsByt []byte
-		var userlandSpanID string
 
 		attrs := make(map[string]any)
 		for _, attr := range span.Attributes() {
@@ -163,20 +162,12 @@ func (e *dbExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlyS
 			}
 
 			if string(attr.Key) == meta.Attrs.UserlandSpanID.Key() {
-				userlandSpanID = attr.Value.AsString()
 				if cleanAttrs {
 					continue
 				}
 			}
 
 			attrs[string(attr.Key)] = attr.Value.AsInterface()
-		}
-
-		// This is a userland span, so we'll trust the span ID it gave us, as
-		// it's part of a remote lineage.
-		if userlandSpanID != "" {
-			spanID = userlandSpanID
-			dynamicSpanID = userlandSpanID
 		}
 
 		// If we don't have a run ID, we can't store this span


### PR DESCRIPTION
## Description

This fixes extended trace span IDs to be consistent by using the remote span ID as the explicit span ID (and adds the ability to set an explicit span ID for parented (non-root) spans).

This also removes the now-redundant special handling for span IDs in the sqlite/postgres trace writer.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

Extended trace span IDs are inconsistent between OSS & monorepo. This also affects span metadata retrieval on extended trace spans.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
