### PR TITLE
Add Step Metadata updatedAt field

### DIFF
--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -526,7 +526,12 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 	}
 
 	for _, md := range span.Metadata {
-		gqlSpan.Metadata = append(gqlSpan.Metadata, (*models.SpanMetadata)(md))
+		gqlSpan.Metadata = append(gqlSpan.Metadata, &models.SpanMetadata{
+			Kind:   md.Kind,
+			Scope:  md.Scope,
+			Values: md.Values,
+			// UpdatedAt: md.UpdatedAt, // after TanStack stuff is merged so UI can be updated
+		})
 	}
 
 	return gqlSpan, nil

--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -379,7 +379,7 @@ fragmentLoop:
 	}
 
 	if info != nil && isMetadata && parentSpanIDPtr != nil {
-		metadata, err := rollupSpanMetadataFromFragments(ctx, fragments)
+		metadata, err := rollupSpanMetadataFromFragments(ctx, fragments, parsedEndTime)
 		if err != nil {
 			logger.StdlibLogger(ctx).Error("error rolling up metadata span", "error", err)
 		} else {
@@ -531,9 +531,10 @@ func mapRootSpansFromRows[T normalizedSpan](ctx context.Context, spans []T) (*cq
 	return root, nil
 }
 
-func rollupSpanMetadataFromFragments(ctx context.Context, fragments []map[string]any) (*cqrs.SpanMetadata, error) {
+func rollupSpanMetadataFromFragments(ctx context.Context, fragments []map[string]any, updatedAt time.Time) (*cqrs.SpanMetadata, error) {
 	ret := &cqrs.SpanMetadata{
-		Values: metadata.Values{},
+		Values:    metadata.Values{},
+		UpdatedAt: updatedAt,
 	}
 
 	for _, fragment := range fragments {

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -341,9 +341,10 @@ type SpanLink struct {
 }
 
 type SpanMetadata struct {
-	Scope  metadata.Scope  `json:"scope"`
-	Kind   metadata.Kind   `json:"kind"`
-	Values metadata.Values `json:"values"`
+	Scope     metadata.Scope  `json:"scope"`
+	Kind      metadata.Kind   `json:"kind"`
+	Values    metadata.Values `json:"values"`
+	UpdatedAt time.Time       `json:"updated_at"`
 }
 
 // TraceRun represents a function run backed by a trace


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

This uses the last metadata span's end timestamp as the UpdatedAt field of each metadata entry for a span.

This will need an update for GQL plumbing later (or can be held off until UI is modifiable again)

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

We want to be able to see when each rolled up set of metadata spans was last updated.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
