### PR TITLE
Only update concurrency pointer based on partition scavenger index

### DIFF
--- a/pkg/execution/state/redis_state/lua/queue/extendLease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/extendLease.lua
@@ -76,37 +76,13 @@ redis.call("ZADD", keyPartitionScavengerIndex, nextTime, item.id)
 -- For every queue that we lease from, ensure that it exists in the scavenger pointer queue
 -- so that expired leases can be re-processed.  We want to take the earliest time from the
 -- scavenger index such that we get a previously lost job if possible.
--- TODO: Remove check on keyInProgressPartition once all new executors have rolled out and no more old items are in progress
-local concurrencyScores =
-	redis.call("ZRANGE", keyConcurrencyFn, "-inf", "+inf", "BYSCORE", "LIMIT", 0, 1, "WITHSCORES")
 local scavengerIndexScores =
 	redis.call("ZRANGE", keyPartitionScavengerIndex, "-inf", "+inf", "BYSCORE", "LIMIT", 0, 1, "WITHSCORES")
-if scavengerIndexScores ~= false or concurrencyScores ~= false then
-	-- Either scavenger index or partition in progress set includes more items
+if scavengerIndexScores ~= false and scavengerIndexScores ~= nil then
+	local earliestLease = tonumber(scavengerIndexScores[2])
 
-	local earliestLease = nil
-	if scavengerIndexScores ~= false and scavengerIndexScores ~= nil then
-		earliestLease = tonumber(scavengerIndexScores[2])
-	end
-
-	-- Fall back to in progress set
-	-- TODO: Remove this check once all items are tracked in scavenger index
-	if
-		earliestLease == nil
-		or (
-    concurrencyScores ~= false and
-    concurrencyScores ~= nil and
-    #concurrencyScores > 0 and
-    tonumber(concurrencyScores[2]
-  ) < earliestLease)
-	then
-		earliestLease = tonumber(concurrencyScores[2])
-	end
-
-	if earliestLease ~= nil then
-		-- Ensure that we update the score with the earliest lease
-		redis.call("ZADD", keyConcurrencyPointer, earliestLease, partitionID)
-	end
+	-- Ensure that we update the score with the earliest lease
+	redis.call("ZADD", keyConcurrencyPointer, earliestLease, partitionID)
 end
 
 return 0

--- a/pkg/execution/state/redis_state/lua/queue/requeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/requeue.lua
@@ -123,40 +123,20 @@ end
 -- Remove item from scavenger index
 redis.call("ZREM", keyPartitionScavengerIndex, item.id)
 
--- Get the earliest item in the new scavenger index and old partition concurrency set.  We may be dequeueing
+-- Get the earliest item in the new scavenger index.  We may be dequeueing
 -- the only in-progress job and should remove this from the partition concurrency
 -- pointers, if this exists.
 --
 -- This ensures that scavengeres have updated pointer queues without the currently
 -- leased job, if exists.
-local concurrencyScores = redis.call("ZRANGE", keyInProgressPartition, "-inf", "+inf", "BYSCORE", "LIMIT", 0, 1, "WITHSCORES")
 local scavengerIndexScores = redis.call("ZRANGE", keyPartitionScavengerIndex, "-inf", "+inf", "BYSCORE", "LIMIT", 0, 1, "WITHSCORES")
-if scavengerIndexScores == false and concurrencyScores == false then
+if scavengerIndexScores == false or scavengerIndexScores == nil or #scavengerIndexScores == 0 then
   redis.call("ZREM", concurrencyPointer, partitionID)
 else
-  -- Either scavenger index or partition in progress set includes more items
+  local earliestLease = tonumber(scavengerIndexScores[2])
 
-  local earliestLease = nil
-  if scavengerIndexScores ~= false and scavengerIndexScores ~= nil then
-    earliestLease = tonumber(scavengerIndexScores[2])
-  end
-
-  -- Fall back to in progress set
-  if earliestLease == nil or (
-    concurrencyScores ~= false and
-    concurrencyScores ~= nil and
-    #concurrencyScores > 0 and
-    tonumber(concurrencyScores[2]) < earliestLease
-  ) then
-    earliestLease = tonumber(concurrencyScores[2])
-  end
-
-  if earliestLease == nil then
-    redis.call("ZREM", concurrencyPointer, partitionID)
-  else
-    -- Ensure that we update the score with the earliest lease
-    redis.call("ZADD", concurrencyPointer, earliestLease, partitionID)
-  end
+  -- Ensure that we update the score with the earliest lease
+  redis.call("ZADD", concurrencyPointer, earliestLease, partitionID)
 end
 
 if requeueToBacklog == 1 then

--- a/pkg/execution/state/redis_state/queue_scavenge.go
+++ b/pkg/execution/state/redis_state/queue_scavenge.go
@@ -177,20 +177,7 @@ func (q *queue) Scavenge(ctx context.Context, limit int) (int, error) {
 			},
 		})
 
-		peekedFromInProgressKey, scavengedFromInProgressKey, err := scavengePartition(queueKey, "in_progress_key")
-		if err != nil {
-			resultErr = multierror.Append(resultErr, fmt.Errorf("could not scavenge from in progress key: %w", err))
-			continue
-		}
-		counter += scavengedFromInProgressKey
-		metrics.IncrQueueScavengerRequeuedItemsCounter(ctx, int64(peekedFromInProgressKey), metrics.CounterOpt{
-			PkgName: pkgName,
-			Tags: map[string]any{
-				"kind": "in_progress_key",
-			},
-		})
-
-		if peekedFromInProgressKey+peekedFromIndex < ScavengeConcurrencyQueuePeekSize {
+		if peekedFromIndex < ScavengeConcurrencyQueuePeekSize {
 			// Atomically attempt to drop empty pointer if we've processed all items
 			err := q.dropPartitionPointerIfEmpty(
 				ctx,

--- a/pkg/execution/state/redis_state/queue_scavenge_test.go
+++ b/pkg/execution/state/redis_state/queue_scavenge_test.go
@@ -221,7 +221,8 @@ func TestQueueScavenge(t *testing.T) {
 	})
 
 	// NOTE: This test covers backward compatibility with in-progress items tracked by the queue
-	t.Run("existing items in in-progress sets must be covered by scavenger", func(t *testing.T) {
+	// this is no longer valid since we removed the partition scavenger index
+	t.Run("existing items in in-progress sets are no longer covered by scavenger", func(t *testing.T) {
 		r.FlushAll()
 
 		q := NewQueue(
@@ -277,10 +278,10 @@ func TestQueueScavenge(t *testing.T) {
 
 		scavenged, err = q.Scavenge(ctx, 100)
 		require.NoError(t, err)
-		require.Equal(t, 1, scavenged)
+		require.Equal(t, 0, scavenged, "we no longer scavenge from in progress set")
 
-		require.False(t, r.Exists(kg.ConcurrencyIndex()))
-		require.False(t, r.Exists(kg.Concurrency("p", fnID.String())))
+		require.True(t, r.Exists(kg.ConcurrencyIndex()))
+		require.True(t, r.Exists(kg.Concurrency("p", fnID.String())))
 	})
 
 	// NOTE: This test validates scavenging logic continues to work when we progressively switch to the Constraint API.
@@ -378,7 +379,7 @@ func TestQueueScavenge(t *testing.T) {
 			require.False(t, r.Exists(kg.PartitionScavengerIndex(fnID.String())))
 		})
 
-		t.Run("lease checks for existing leases and only updates if theres no earlier lease", func(t *testing.T) {
+		t.Run("lease does not check for existing leases and only updates if theres no earlier lease", func(t *testing.T) {
 			t.Run("earlier in progress item exists", func(t *testing.T) {
 				r.FlushAll()
 
@@ -431,9 +432,9 @@ func TestQueueScavenge(t *testing.T) {
 				require.True(t, r.Exists(kg.PartitionScavengerIndex(fnID.String())))
 				require.Equal(t, leaseExpiry2.UnixMilli(), int64(score(t, r, kg.PartitionScavengerIndex(fnID.String()), item2.ID)))
 
-				// Global index must have earlier timestamp
+				// Global index must NOT have earlier timestamp after removing concurrency key
 				require.True(t, r.Exists(kg.ConcurrencyIndex()))
-				require.Equal(t, leaseExpiry1.UnixMilli(), int64(score(t, r, kg.ConcurrencyIndex(), fnID.String())))
+				require.Equal(t, leaseExpiry2.UnixMilli(), int64(score(t, r, kg.ConcurrencyIndex(), fnID.String())))
 
 				// Concurrency index must have both items
 				require.True(t, r.Exists(kg.Concurrency("p", fnID.String())))
@@ -503,7 +504,7 @@ func TestQueueScavenge(t *testing.T) {
 			})
 		})
 
-		t.Run("extend checks for existing leases and only updates if theres no earlier lease", func(t *testing.T) {
+		t.Run("extend does not checks for existing leases and only updates if theres no earlier lease", func(t *testing.T) {
 			t.Run("earlier in progress item exists", func(t *testing.T) {
 				r.FlushAll()
 
@@ -561,9 +562,9 @@ func TestQueueScavenge(t *testing.T) {
 				require.True(t, r.Exists(kg.PartitionScavengerIndex(fnID.String())))
 				require.Equal(t, leaseExpiry2.UnixMilli(), int64(score(t, r, kg.PartitionScavengerIndex(fnID.String()), item2.ID)))
 
-				// Global index must have earlier timestamp
+				// Global index must NOT have earlier timestamp
 				require.True(t, r.Exists(kg.ConcurrencyIndex()))
-				require.Equal(t, leaseExpiry1.UnixMilli(), int64(score(t, r, kg.ConcurrencyIndex(), fnID.String())))
+				require.Equal(t, leaseExpiry2.UnixMilli(), int64(score(t, r, kg.ConcurrencyIndex(), fnID.String())))
 
 				// Concurrency index must have both items
 				require.True(t, r.Exists(kg.Concurrency("p", fnID.String())))
@@ -713,7 +714,7 @@ func TestQueueScavenge(t *testing.T) {
 				require.False(t, r.Exists(kg.Concurrency("p", fnID.String())))
 			})
 
-			t.Run("update to next earliest old lease", func(t *testing.T) {
+			t.Run("does not update to next earliest old lease", func(t *testing.T) {
 				r.FlushAll()
 
 				q := NewQueue(
@@ -782,9 +783,8 @@ func TestQueueScavenge(t *testing.T) {
 				// Scavenger index must be empty (since only old item exists now)
 				require.False(t, r.Exists(kg.PartitionScavengerIndex(fnID.String())))
 
-				// Global index must have later timestamp
-				require.True(t, r.Exists(kg.ConcurrencyIndex()))
-				require.Equal(t, leaseExpiry1.UnixMilli(), int64(score(t, r, kg.ConcurrencyIndex(), fnID.String())))
+				// Global index must be empty since no more in index
+				require.False(t, r.Exists(kg.ConcurrencyIndex()))
 
 				// Concurrency index must have only one item
 				require.True(t, r.Exists(kg.Concurrency("p", fnID.String())))
@@ -948,7 +948,7 @@ func TestQueueScavenge(t *testing.T) {
 				require.False(t, r.Exists(kg.Concurrency("p", fnID.String())))
 			})
 
-			t.Run("update to next earliest old lease", func(t *testing.T) {
+			t.Run("does not update to next earliest old lease", func(t *testing.T) {
 				r.FlushAll()
 
 				q := NewQueue(
@@ -1017,9 +1017,8 @@ func TestQueueScavenge(t *testing.T) {
 				// Scavenger index must be empty (since only old item exists now)
 				require.False(t, r.Exists(kg.PartitionScavengerIndex(fnID.String())))
 
-				// Global index must have later timestamp
-				require.True(t, r.Exists(kg.ConcurrencyIndex()))
-				require.Equal(t, leaseExpiry1.UnixMilli(), int64(score(t, r, kg.ConcurrencyIndex(), fnID.String())))
+				// Global index must be empty since no more items in index
+				require.False(t, r.Exists(kg.ConcurrencyIndex()))
 
 				// Concurrency index must have only one item
 				require.True(t, r.Exists(kg.Concurrency("p", fnID.String())))


### PR DESCRIPTION
## Description

In #3337, we rolled out changes to switch over to a new index for scavenging. This has been running for the past day, and all existing runs have since finished. All current or future runs will populate the partition scavenger index, which means that we can safely remove old code.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
