### PR TITLE
Explicitly scope prefix for all Constraint API keys (a:<accountID>)

### DIFF
--- a/pkg/constraintapi/acquire.go
+++ b/pkg/constraintapi/acquire.go
@@ -247,6 +247,8 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 		enableDebugLogsVal = "1"
 	}
 
+	scopedKeyPrefix := fmt.Sprintf("{%s}:%s", keyPrefix, accountScope(req.AccountID))
+
 	args, err := strSlice([]any{
 		// This will be marshaled
 		rueidis.BinaryString(requestState),
@@ -257,7 +259,7 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 		now.UnixNano(),  // current time in nanoseconds for rate limiting
 
 		leaseExpiry.UnixMilli(),
-		keyPrefix,
+		scopedKeyPrefix,
 		initialLeaseIDs,
 
 		int(operationIdempotencyPeriod.Seconds()),

--- a/pkg/constraintapi/check.go
+++ b/pkg/constraintapi/check.go
@@ -127,11 +127,13 @@ func (r *redisCapacityManager) Check(ctx context.Context, req *CapacityCheckRequ
 		enableDebugLogsVal = "1"
 	}
 
+	scopedKeyPrefix := fmt.Sprintf("{%s}:%s", keyPrefix, accountScope(req.AccountID))
+
 	now := r.clock.Now()
 
 	args, err := strSlice([]any{
 		rueidis.BinaryString(data),
-		keyPrefix,
+		scopedKeyPrefix,
 		req.AccountID,
 		now.UnixMilli(),
 		now.UnixNano(),

--- a/pkg/constraintapi/extend.go
+++ b/pkg/constraintapi/extend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"fmt"
 
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/util/errs"
@@ -61,8 +62,10 @@ func (r *redisCapacityManager) ExtendLease(ctx context.Context, req *CapacityExt
 		enableDebugLogsVal = "1"
 	}
 
+	scopedKeyPrefix := fmt.Sprintf("{%s}:%s", keyPrefix, accountScope(req.AccountID))
+
 	args, err := strSlice([]any{
-		keyPrefix,
+		scopedKeyPrefix,
 		req.AccountID,
 		req.LeaseID.String(),
 		newLeaseID.String(),

--- a/pkg/constraintapi/lua/extend.lua
+++ b/pkg/constraintapi/lua/extend.lua
@@ -71,7 +71,7 @@ local keyAccountLeases = KEYS[3]
 local keyOldLeaseDetails = KEYS[4]
 local keyNewLeaseDetails = KEYS[5]
 
-local keyPrefix = ARGV[1]
+local scopedKeyPrefix = ARGV[1]
 local accountID = ARGV[2]
 local currentLeaseID = ARGV[3]
 local newLeaseID = ARGV[4]
@@ -121,7 +121,7 @@ local requestID = leaseDetails[2]
 local leaseRunID = leaseDetails[3]
 
 -- Request state must still exist
-local keyRequestState = string.format("{%s}:%s:rs:%s", keyPrefix, accountID, requestID)
+local keyRequestState = string.format("%s:rs:%s", scopedKeyPrefix, requestID)
 local requestStateStr = call("GET", keyRequestState)
 if requestStateStr == nil or requestStateStr == false or requestStateStr == "" then
 	debug(keyRequestState)

--- a/pkg/constraintapi/lua/release.lua
+++ b/pkg/constraintapi/lua/release.lua
@@ -18,7 +18,7 @@ local keyScavengerShard = KEYS[2]
 local keyAccountLeases = KEYS[3]
 local keyLeaseDetails = KEYS[4]
 
-local keyPrefix = ARGV[1]
+local scopedKeyPrefix = ARGV[1]
 local accountID = ARGV[2]
 local currentLeaseID = ARGV[3]
 local operationIdempotencyTTL = tonumber(ARGV[4])--[[@as integer]]
@@ -53,7 +53,7 @@ if requestID == false or requestID == nil or requestID == "" then
 end
 
 -- Request state must still exist
-local keyRequestState = string.format("{%s}:%s:rs:%s", keyPrefix, accountID, requestID)
+local keyRequestState = string.format("%s:rs:%s", scopedKeyPrefix, requestID)
 local requestStateStr = call("GET", keyRequestState)
 if requestStateStr == nil or requestStateStr == false or requestStateStr == "" then
 	local res = {}

--- a/pkg/constraintapi/redis.go
+++ b/pkg/constraintapi/redis.go
@@ -154,6 +154,10 @@ func NewRedisCapacityManager(
 	return manager, nil
 }
 
+func accountScope(accountID uuid.UUID) string {
+	return fmt.Sprintf("a:%s", accountID)
+}
+
 // keyScavengerShard represents the top-level sharded sorted set containing individual accounts
 func (r *redisCapacityManager) keyScavengerShard(prefix string, shard int) string {
 	return fmt.Sprintf("{%s}:css:%d", prefix, shard)
@@ -161,21 +165,21 @@ func (r *redisCapacityManager) keyScavengerShard(prefix string, shard int) strin
 
 // keyAccountLeases represents active leases for the account
 func (r *redisCapacityManager) keyAccountLeases(prefix string, accountID uuid.UUID) string {
-	return fmt.Sprintf("{%s}:%s:leaseq", prefix, accountID)
+	return fmt.Sprintf("{%s}:%s:leaseq", prefix, accountScope(accountID))
 }
 
 // keyRequestState returns the key storing per-operation request details
 func (r *redisCapacityManager) keyRequestState(prefix string, accountID uuid.UUID, requestID ulid.ULID) string {
-	return fmt.Sprintf("{%s}:%s:rs:%s", prefix, accountID, requestID)
+	return fmt.Sprintf("{%s}:%s:rs:%s", prefix, accountScope(accountID), requestID)
 }
 
 // keyOperationIdempotency returns the operation idempotency key for operation retries
 func (r *redisCapacityManager) keyOperationIdempotency(prefix string, accountID uuid.UUID, operation, idempotencyKey string) string {
-	return fmt.Sprintf("{%s}:%s:ik:op:%s:%s", prefix, accountID, operation, util.XXHash(idempotencyKey))
+	return fmt.Sprintf("{%s}:%s:ik:op:%s:%s", prefix, accountScope(accountID), operation, util.XXHash(idempotencyKey))
 }
 
 func keyConstraintCheckIdempotency(prefix string, accountID uuid.UUID, idempotencyKey string) string {
-	return fmt.Sprintf("{%s}:%s:ik:cc:%s", prefix, accountID, util.XXHash(idempotencyKey))
+	return fmt.Sprintf("{%s}:%s:ik:cc:%s", prefix, accountScope(accountID), util.XXHash(idempotencyKey))
 }
 
 // keyConstraintCheckIdempotency returns the operation idempotency key for constraint check retries
@@ -185,7 +189,7 @@ func (r *redisCapacityManager) keyConstraintCheckIdempotency(prefix string, acco
 
 // keyLeaseDetails returns the key to the hash including the lease idempotency key, lease run ID, and operation idempotency key
 func (r *redisCapacityManager) keyLeaseDetails(prefix string, accountID uuid.UUID, leaseID ulid.ULID) string {
-	return fmt.Sprintf("{%s}:%s:ld:%s", prefix, accountID, leaseID)
+	return fmt.Sprintf("{%s}:%s:ld:%s", prefix, accountScope(accountID), leaseID)
 }
 
 type keyGenerator struct {

--- a/pkg/constraintapi/release.go
+++ b/pkg/constraintapi/release.go
@@ -3,6 +3,7 @@ package constraintapi
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/util/errs"
@@ -53,8 +54,10 @@ func (r *redisCapacityManager) Release(ctx context.Context, req *CapacityRelease
 		enableDebugLogsVal = "1"
 	}
 
+	scopedKeyPrefix := fmt.Sprintf("{%s}:%s", keyPrefix, accountScope(req.AccountID))
+
 	args, err := strSlice([]any{
-		keyPrefix,
+		scopedKeyPrefix,
 		req.AccountID,
 		req.LeaseID.String(),
 		int(r.operationIdempotencyTTL.Seconds()),

--- a/pkg/constraintapi/testdata/snapshots/extend.lua
+++ b/pkg/constraintapi/testdata/snapshots/extend.lua
@@ -55,7 +55,7 @@ local keyScavengerShard = KEYS[2]
 local keyAccountLeases = KEYS[3]
 local keyOldLeaseDetails = KEYS[4]
 local keyNewLeaseDetails = KEYS[5]
-local keyPrefix = ARGV[1]
+local scopedKeyPrefix = ARGV[1]
 local accountID = ARGV[2]
 local currentLeaseID = ARGV[3]
 local newLeaseID = ARGV[4]
@@ -91,7 +91,7 @@ end
 local hashedLeaseIdempotencyKey = leaseDetails[1]
 local requestID = leaseDetails[2]
 local leaseRunID = leaseDetails[3]
-local keyRequestState = string.format("{%s}:%s:rs:%s", keyPrefix, accountID, requestID)
+local keyRequestState = string.format("%s:rs:%s", scopedKeyPrefix, requestID)
 local requestStateStr = call("GET", keyRequestState)
 if requestStateStr == nil or requestStateStr == false or requestStateStr == "" then
 	debug(keyRequestState)

--- a/pkg/constraintapi/testdata/snapshots/release.lua
+++ b/pkg/constraintapi/testdata/snapshots/release.lua
@@ -8,7 +8,7 @@ local keyOperationIdempotency = KEYS[1]
 local keyScavengerShard = KEYS[2]
 local keyAccountLeases = KEYS[3]
 local keyLeaseDetails = KEYS[4]
-local keyPrefix = ARGV[1]
+local scopedKeyPrefix = ARGV[1]
 local accountID = ARGV[2]
 local currentLeaseID = ARGV[3]
 local operationIdempotencyTTL = tonumber(ARGV[4])
@@ -32,7 +32,7 @@ if requestID == false or requestID == nil or requestID == "" then
 	res["d"] = debugLogs
 	return cjson.encode(res)
 end
-local keyRequestState = string.format("{%s}:%s:rs:%s", keyPrefix, accountID, requestID)
+local keyRequestState = string.format("%s:rs:%s", scopedKeyPrefix, requestID)
 local requestStateStr = call("GET", keyRequestState)
 if requestStateStr == nil or requestStateStr == false or requestStateStr == "" then
 	local res = {}


### PR DESCRIPTION
## Description

Currently, all Redis keys generated by the Constraint API include the account ID. This is done to break down the keyspace into smaller keys and avoid large global keys, as well as a potential preparation for sharding based on the account ID.

To allow sharding keys by different scopes in the future, we prefix the scope with a short identifier, e.g. `a:<accountID>`. This way, we can easily add and distinguish between different scopes down the road.

We are still requiring account IDs on all requests for now, until we add a new scope.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
