### PR TITLE
Pass struct for capacity lease to add additional state

### DIFF
--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -111,9 +111,13 @@ type QueueItem struct {
 	// the partition). This is not the same as AtMS for items scheduled in the future or past.
 	EnqueuedAt int64 `json:"eat"`
 
-	// CapacityLeaseID is the optional capacity lease for this queue item.
+	// CapacityLease is the optional capacity lease for this queue item.
 	// This is set when the Constraint API feature flag is enabled and the item was refilled.
-	CapacityLeaseID *ulid.ULID `json:"clid,omitempty"`
+	CapacityLease *CapacityLease `json:"cl,omitempty"`
+}
+
+type CapacityLease struct {
+	LeaseID ulid.ULID `json:"l,omitempty"`
 }
 
 func (q *QueueItem) SetID(ctx context.Context, str string) {

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -29,6 +29,7 @@ type RunInfo struct {
 	// on the same function by limiting the number of continues possible within a given chain.
 	ContinueCount       uint
 	RefilledFromBacklog string
+	CapacityLease       *CapacityLease
 }
 
 // RunFunc represents a function called to process each item in the queue.  This may be

--- a/pkg/execution/state/redis_state/backlog.go
+++ b/pkg/execution/state/redis_state/backlog.go
@@ -628,7 +628,7 @@ type BacklogRefillResult struct {
 type backlogRefillOptions struct {
 	constraintCheckIdempotencyKey string
 	disableConstraintChecks       bool
-	capacityLeaseIDs              []ulid.ULID
+	capacityLeases                []osqueue.CapacityLease
 }
 
 type backlogRefillOptionFn func(o *backlogRefillOptions)
@@ -645,9 +645,9 @@ func WithBacklogRefillDisableConstraintChecks(disableConstraintChecks bool) back
 	}
 }
 
-func WithBacklogRefillItemCapacityLeaseIDs(itemCapacityLeaseIDs []ulid.ULID) backlogRefillOptionFn {
+func WithBacklogRefillItemCapacityLeases(itemCapacityLeases []osqueue.CapacityLease) backlogRefillOptionFn {
 	return func(o *backlogRefillOptions) {
-		o.capacityLeaseIDs = itemCapacityLeaseIDs
+		o.capacityLeases = itemCapacityLeases
 	}
 }
 
@@ -750,9 +750,9 @@ func (q *queue) BacklogRefill(
 	shouldSpotCheckActiveSet := checkConstraints && rand.Intn(100) <= refillProbability
 
 	// Ensure capacityLeaseIDs is never nil to avoid JSON marshaling to "null"
-	capacityLeaseIDs := o.capacityLeaseIDs
+	capacityLeaseIDs := o.capacityLeases
 	if capacityLeaseIDs == nil {
-		capacityLeaseIDs = []ulid.ULID{}
+		capacityLeaseIDs = []osqueue.CapacityLease{}
 	}
 
 	args, err := StrSlice([]any{

--- a/pkg/execution/state/redis_state/lua/queue/backlogRefill.lua
+++ b/pkg/execution/state/redis_state/lua/queue/backlogRefill.lua
@@ -88,11 +88,11 @@ local checkConstraints = tonumber(ARGV[16])
 local shouldSpotCheckActiveSet = tonumber(ARGV[17])
 
 -- Constraint API rollout
-local itemCapacityLeaseIDs = {}
+local itemCapacityLeases = {}
 if ARGV[18] ~= nil and ARGV[18] ~= "" and ARGV[18] ~= "null" then
   local success, result = pcall(cjson.decode, ARGV[18])
   if success and type(result) == "table" then
-    itemCapacityLeaseIDs = result
+    itemCapacityLeases = result
   end
 end
 
@@ -301,9 +301,9 @@ if refill > 0 then
       updatedData.rf = backlogID
       updatedData.rat = nowMS
 
-      -- Update item with Capacity Lease ID if lease acquired
-      if itemCapacityLeaseIDs ~= nil and #itemCapacityLeaseIDs > 0 then
-        updatedData.clid = itemCapacityLeaseIDs[i]
+      -- Update item with Capacity Lease if lease acquired
+      if itemCapacityLeases ~= nil and #itemCapacityLeases > 0 then
+        updatedData.cl = itemCapacityLeases[i]
       end
 
       if checkConstraints == 1 and updatedData.data ~= nil and updatedData.data.identifier ~= nil and updatedData.data.identifier.runID ~= nil then

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -1019,7 +1019,7 @@ type processItem struct {
 	// PCtr represents the number of times the partition has been continued.
 	PCtr uint
 
-	capacityLeaseID *ulid.ULID
+	capacityLease *osqueue.CapacityLease
 
 	// disableConstraintUpdates determines whether ExtendLease, Requeue,
 	// and Dequeue should update constraint state.
@@ -1043,11 +1043,15 @@ type capacityLease struct {
 	capacityLeaseLock      sync.Mutex
 }
 
-func newCapacityLease(initialLeaseID *ulid.ULID) *capacityLease {
-	return &capacityLease{
-		currentCapacityLeaseID: initialLeaseID,
-		capacityLeaseLock:      sync.Mutex{},
+func newCapacityLease(initialLease *osqueue.CapacityLease) *capacityLease {
+	cl := &capacityLease{
+		capacityLeaseLock: sync.Mutex{},
 	}
+	if initialLease != nil {
+		cl.currentCapacityLeaseID = &initialLease.LeaseID
+	}
+
+	return cl
 }
 
 func (p *capacityLease) set(leaseID *ulid.ULID) {

--- a/pkg/execution/state/redis_state/queue_item_process_test.go
+++ b/pkg/execution/state/redis_state/queue_item_process_test.go
@@ -149,7 +149,7 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 			I:                        qi,
 			P:                        p,
 			disableConstraintUpdates: false,
-			capacityLeaseID:          nil,
+			capacityLease:            nil,
 		}, func(ctx context.Context, ri osqueue.RunInfo, i osqueue.Item) (osqueue.RunResult, error) {
 			atomic.AddInt64(&counter, 1)
 			return osqueue.RunResult{}, nil
@@ -187,7 +187,7 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 			I:                        qi,
 			P:                        p,
 			disableConstraintUpdates: false,
-			capacityLeaseID:          nil,
+			capacityLease:            nil,
 		}, func(ctx context.Context, ri osqueue.RunInfo, i osqueue.Item) (osqueue.RunResult, error) {
 			<-time.After(3 * time.Second)
 			atomic.AddInt64(&counter, 1)
@@ -277,7 +277,9 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 			I:                        qi,
 			P:                        p,
 			disableConstraintUpdates: true,
-			capacityLeaseID:          &resp.Leases[0].LeaseID,
+			capacityLease: &osqueue.CapacityLease{
+				LeaseID: resp.Leases[0].LeaseID,
+			},
 		}, func(ctx context.Context, ri osqueue.RunInfo, i osqueue.Item) (osqueue.RunResult, error) {
 			go func() {
 				for {
@@ -534,7 +536,9 @@ func TestQueueProcessorPreLeaseWithConstraintAPI(t *testing.T) {
 		cmLifecycles.reset()
 
 		// Set capacity lease ID
-		qi.CapacityLeaseID = &resp.Leases[0].LeaseID
+		qi.CapacityLease = &osqueue.CapacityLease{
+			LeaseID: resp.Leases[0].LeaseID,
+		}
 
 		p := q.ItemPartition(ctx, shard, qi)
 
@@ -559,7 +563,7 @@ func TestQueueProcessorPreLeaseWithConstraintAPI(t *testing.T) {
 		// Expect item to be sent to worker with capacity lease + request to disable constraint updates
 		item := <-q.workers
 		require.Equal(t, qi, item.I)
-		require.Equal(t, qi.CapacityLeaseID, item.capacityLeaseID)
+		require.Equal(t, qi.CapacityLease, item.capacityLease)
 		require.True(t, item.disableConstraintUpdates)
 	})
 }

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -1106,7 +1106,7 @@ func (q *queue) process(
 	p := i.P
 	continuationCtr := i.PCtr
 
-	capacityLeaseID := newCapacityLease(i.capacityLeaseID)
+	capacityLeaseID := newCapacityLease(i.capacityLease)
 
 	disableConstraintUpdates := i.disableConstraintUpdates
 
@@ -1177,7 +1177,7 @@ func (q *queue) process(
 				// - the item is enqueued to a system queue
 				// - the Constraint API is disabled or the current account is not enrolled
 				// - the Constraint API provided a lease which expired at the time of leasing the queue item
-				if i.capacityLeaseID == nil {
+				if i.capacityLease == nil {
 					q.log.Trace("item has no capacity lease, skipping lease extension")
 					continue
 				}
@@ -1336,6 +1336,7 @@ func (q *queue) process(
 			QueueShardName:      q.primaryQueueShard.Name,
 			ContinueCount:       continuationCtr,
 			RefilledFromBacklog: qi.RefilledFrom,
+			CapacityLease:       i.capacityLease,
 		}
 
 		// Call the run func.
@@ -2136,7 +2137,7 @@ func (p *processor) process(ctx context.Context, item *osqueue.QueueItem) error 
 		I:    *item,
 		PCtr: p.partitionContinueCtr,
 
-		capacityLeaseID: constraintRes.leaseID,
+		capacityLease: constraintRes.capacityLease,
 		// Disable constraint updates in case we skipped constraint checks.
 		// This should always be linked, as we want consistent behavior while
 		// processing a queue item.

--- a/pkg/execution/state/redis_state/shadow_queue.go
+++ b/pkg/execution/state/redis_state/shadow_queue.go
@@ -541,7 +541,7 @@ func (q *queue) processShadowPartitionBacklog(
 					constraints,
 					WithBacklogRefillConstraintCheckIdempotencyKey(operationIdempotencyKey),
 					WithBacklogRefillDisableConstraintChecks(constraintCheckRes.skipConstraintChecks),
-					WithBacklogRefillItemCapacityLeaseIDs(constraintCheckRes.itemCapacityLeases),
+					WithBacklogRefillItemCapacityLeases(constraintCheckRes.itemCapacityLeases),
 				)
 			},
 			map[string]any{

--- a/tests/execution/queue/lua_compatibility_test.go
+++ b/tests/execution/queue/lua_compatibility_test.go
@@ -368,7 +368,9 @@ func TestLuaCompatibility(t *testing.T) {
 					constraints,
 					redis_state.WithBacklogRefillConstraintCheckIdempotencyKey("acquire-refill"),
 					redis_state.WithBacklogRefillDisableConstraintChecks(true),
-					redis_state.WithBacklogRefillItemCapacityLeaseIDs([]ulid.ULID{capacityLeaseID}),
+					redis_state.WithBacklogRefillItemCapacityLeases([]queue.CapacityLease{{
+						LeaseID: capacityLeaseID,
+					}}),
 				)
 				require.NoError(t, err)
 				require.NotNil(t, res)
@@ -377,7 +379,7 @@ func TestLuaCompatibility(t *testing.T) {
 
 				refilled, err := q.ItemByID(ctx, qi2.ID)
 				require.NoError(t, err)
-				require.Equal(t, capacityLeaseID.String(), refilled.CapacityLeaseID.String())
+				require.Equal(t, capacityLeaseID.String(), refilled.CapacityLease.LeaseID.String())
 			})
 
 			t.Run("current time is returned for rate limiting", func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR refactors the queue to pass around a struct for the Capacity Lease. This struct will be stored in the queue item when refilled, and otherwise passed in memory.

The current lease ID may be different once the item starts processing, the idea for the struct is to add additional state, e.g. for worker concurrency. This state will be determined by the Constraint API, returned through the Acquire response, sent over Protobuf, then received by the queue and stored in the new struct.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
