### PR TITLE
Prevent infinite iterator looping because index gets reset scan is done

### DIFF
--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -87,9 +87,6 @@ type PauseGetter interface {
 	// PauseCreatedAt returns the timestamp a pause was created, using the given
 	// workspace <> event Index.
 	PauseCreatedAt(ctx context.Context, workspaceID uuid.UUID, event string, pauseID uuid.UUID) (time.Time, error)
-
-	// GetRunPauseIDs returns all pause IDs for a given run
-	GetRunPauseIDs(ctx context.Context, runID ulid.ULID) ([]string, error)
 }
 
 // ConsumePauseOpts are the options to be passed in for consuming a pause

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -1274,11 +1274,6 @@ func (m unshardedMgr) PauseByID(ctx context.Context, pauseID uuid.UUID) (*state.
 	return pause, err
 }
 
-func (m unshardedMgr) GetRunPauseIDs(ctx context.Context, runID ulid.ULID) ([]string, error) {
-	pause := m.u.Pauses()
-	return pause.Client().Do(ctx, pause.Client().B().Smembers().Key(pause.kg.RunPauses(ctx, runID)).Build()).AsStrSlice()
-}
-
 func (m unshardedMgr) PauseByInvokeCorrelationID(ctx context.Context, wsID uuid.UUID, correlationID string) (*state.Pause, error) {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "PauseByInvokeCorrelationID"), redis_telemetry.ScopePauses)
 


### PR DESCRIPTION
## Description

Iterator `Next()` can now be called multiple times when it returns `false` in the dual iterator that wraps the buffer iterator, so calling Next on the buffer iterator should consistently be returning `false` after it's done.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
