### PR TITLE
unbork clerk sign-in redirects

### DIFF
--- a/ui/apps/dashboard/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/ui/apps/dashboard/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -37,9 +37,9 @@ export default function SignInPage() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const redirectTo = resolveRedirect(searchParams?.get('redirect_url'));
+  const redirectTo = resolveRedirect(searchParams.get('redirect_url'));
 
-  const error = searchParams?.get('error');
+  const error = searchParams.get('error');
   const nestedRoute = pathname !== '/sign-in';
 
   useEffect(() => {


### PR DESCRIPTION
## Description

For email/pass logins, clerk redirects after login have stopped working. Net result is that those users have to login twice.  All the quick clerk config tweaks I tried did nothing, so I just did it myself. 

## Motivation
Don't make the users login twice. 

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
