### PR TITLE
don't show loader when doing impersonation

### DIFF
--- a/ui/apps/dashboard/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/ui/apps/dashboard/src/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -62,7 +62,7 @@ export default function SignInPage() {
   return (
     <SplitView>
       <div className="mx-auto my-auto text-center">
-        {isLoaded && isSignedIn && !nestedRoute ? (
+        {isLoaded && isSignedIn && !nestedRoute && !clerk ? (
           <div className="flex items-center justify-center">
             <LoadingIcon />
           </div>


### PR DESCRIPTION
## Description

Don't show loader on sign-in when doing clerk impersonation. This break impersonation.

## Motivation
unbreak clerk impersonation

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
