### PR TITLE
Track cancellation check durations and async calls

### DIFF
--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -770,3 +770,12 @@ func IncrQueueThrottleStatus(ctx context.Context, count int64, opts CounterOpt) 
 		Tags:        opts.Tags,
 	})
 }
+
+func IncrAsyncCancellationCheckCounter(ctx context.Context, count int64, opts CounterOpt) {
+	RecordCounterMetric(ctx, count, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "async_cancellation_check",
+		Description: "Total number of async cancellation checks",
+		Tags:        opts.Tags,
+	})
+}

--- a/pkg/telemetry/metrics/histogram.go
+++ b/pkg/telemetry/metrics/histogram.go
@@ -412,3 +412,14 @@ func HistogramCancellationReadDuration(ctx context.Context, dur time.Duration, o
 		Boundaries:  cancellationReadDurationBoundaries,
 	})
 }
+
+func HistogramCancellationCheckDuration(ctx context.Context, dur time.Duration, opts HistogramOpt) {
+	RecordIntHistogramMetric(ctx, dur.Milliseconds(), HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "cancellation_check_duration",
+		Description: "Distribution of cancellation check duration",
+		Tags:        opts.Tags,
+		Unit:        "ms",
+		Boundaries:  cancellationReadDurationBoundaries,
+	})
+}


### PR DESCRIPTION
## Description

This PR instruments cancellation checks to cover overall check duration and increase a counter every time we switch to background processing.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
