### PR TITLE
Use sqlite-interactive for local dev

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,7 +101,7 @@
             lua-language-server
 
             # Tools
-            sqlite
+            sqlite-interactive
             sqlc
             buf
             protobuf


### PR DESCRIPTION
## Description

This changes the use of `sqlite` to `sqlite-interactive` to include readline support for local development convenience.

## Motivation
The plain sqlite package doesn't include readline support so any use of the `sqlite3` CLI tool is painful

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
