### PR TITLE
Fixed mcp tool schema for newer clients

### DIFF
--- a/pkg/devserver/mcp.go
+++ b/pkg/devserver/mcp.go
@@ -252,16 +252,16 @@ func (h *MCPHandler) createMCPServer() *mcp.Server {
 // SendEventArgs represents the arguments for sending an event
 type SendEventArgs struct {
 	Name        string `json:"name"`
-	Data        any    `json:"data,omitempty"`
-	User        any    `json:"user,omitempty"`
+	Data        any    `json:"data,omitempty" jsonschema:"true"`
+	User        any    `json:"user,omitempty" jsonschema:"true"`
 	EventIDSeed string `json:"eventIdSeed,omitempty"`
 }
 
 // InvokeFunctionArgs represents the arguments for invoking a function
 type InvokeFunctionArgs struct {
 	FunctionID string `json:"functionId"`
-	Data       any    `json:"data,omitempty"`
-	User       any    `json:"user,omitempty"`
+	Data       any    `json:"data,omitempty" jsonschema:"true"`
+	User       any    `json:"user,omitempty" jsonschema:"true"`
 	Timeout    int    `json:"timeout,omitempty"`
 }
 


### PR DESCRIPTION
## Description

Newer mcp clients are stricter on tool schema, this fixes the invalid schemaa definitions for `Data` and `User`

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
