### PR TITLE
Allow 206 as success for legacy tracing

### DIFF
--- a/pkg/run/trace_lifecycle.go
+++ b/pkg/run/trace_lifecycle.go
@@ -334,7 +334,7 @@ func (l traceLifecycle) OnFunctionFinished(
 	}
 
 	switch resp.StatusCode {
-	case 200:
+	case 200, 206:
 		span.SetStatus(codes.Ok, "success")
 		span.SetAttributes(attribute.Int64(consts.OtelSysFunctionStatusCode, enums.RunStatusCompleted.ToCode()))
 	default: // everything else are errors


### PR DESCRIPTION
## Description

Fixes a bug whereby the runs list shows "Failed" for checkpointed functions that complete without going fully async.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
