### PR TITLE
Skip normalization if backlog was created on same version

### DIFF
--- a/pkg/execution/state/redis_state/backlog.go
+++ b/pkg/execution/state/redis_state/backlog.go
@@ -465,7 +465,7 @@ func (b QueueBacklog) isDefault() bool {
 func (b QueueBacklog) isOutdated(constraints PartitionConstraintConfig) enums.QueueNormalizeReason {
 	// If the backlog represents newer items than the constraints we're working on,
 	// do not attempt to mark the backlog as outdated. Constraints MUST be >= backlog function version at all times.
-	if b.EarliestFunctionVersion > 0 && constraints.FunctionVersion > 0 && b.EarliestFunctionVersion > constraints.FunctionVersion {
+	if b.EarliestFunctionVersion > 0 && constraints.FunctionVersion > 0 && b.EarliestFunctionVersion >= constraints.FunctionVersion {
 		return enums.QueueNormalizeReasonUnchanged
 	}
 


### PR DESCRIPTION
## Description

This is a performance improvement to skip backlog normalization if the given backlog was created on the _same_ version of the constraints retrieved by the executor.

This assumes we increase the version for every config change.

Previously, we only skipped if the version was _newer_ so that we would not normalize backlogs that were already running on a newer version than the current executor in case of propagation delays.

This can only be merged once https://github.com/inngest/monorepo/pull/6029 is in.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
