### PR TITLE
immediately call stop with sigterm

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -18,7 +18,6 @@ var (
 	defaultTimeout = 30 * time.Second
 
 	ErrPreTimeout = fmt.Errorf("service.Pre did not end within the given timeout")
-	ErrRunTimeout = fmt.Errorf("service.Run did not end within the given timeout")
 )
 
 var wg conc.WaitGroup
@@ -61,21 +60,6 @@ type StartTimeouter interface {
 func startTimeout(s Service) time.Duration {
 	if t, ok := s.(StartTimeouter); ok {
 		return t.StartTimeout()
-	}
-	return defaultTimeout
-}
-
-// RunTimeouter lets a Service define how long the Run method can block for prior
-// to starting cleanup.
-type RunTimeouter interface {
-	Service
-	RunTimeout() time.Duration
-}
-
-// runTimeout returns the timeout duration used when an interrupt is received.
-func runTimeout(s Service) time.Duration {
-	if t, ok := s.(RunTimeouter); ok {
-		return t.RunTimeout()
 	}
 	return defaultTimeout
 }


### PR DESCRIPTION
This change immediately calls stop when we receive a sigterm to begin cleanup without any delays.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
