### PR TITLE
onboarding redirect & yank sentry server side stuff

### DIFF
--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/onboarding/route.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/onboarding/route.tsx
@@ -2,9 +2,28 @@ import { Header } from '@inngest/components/Header/NewHeader';
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
 import { pathCreator } from '@/utils/urls';
+import {
+  OnboardingSteps,
+  type OnboardingStep,
+} from '@/components/Onboarding/types';
 
 export const Route = createFileRoute('/_authed/env/$envSlug/onboarding')({
   component: OnboardingLayout,
+  loader: ({
+    params,
+  }: {
+    params: { step?: OnboardingStep; envSlug: string };
+  }) => {
+    if (!params.step) {
+      redirect({
+        to: pathCreator.onboardingSteps({
+          envSlug: params.envSlug,
+          step: OnboardingSteps.CreateApp,
+        }),
+        throw: true,
+      });
+    }
+  },
 });
 
 function OnboardingLayout() {

--- a/ui/apps/dashboard/vite.config.ts
+++ b/ui/apps/dashboard/vite.config.ts
@@ -42,35 +42,7 @@ export default defineConfig({
   },
   plugins: [
     tanstackStart(),
-    nitroV2Plugin({
-      hooks: {
-        compiled(nitro) {
-          //
-          // Hack alert: we're inlining the server side senty init here
-          // so we don't have to eject from the nitro preset on vercel to do it the
-          // sentry way: https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/
-          // when we move to proper nitro we can use a plugin
-          const entryPath = path.join(
-            nitro.options.output.serverDir,
-            'index.mjs',
-          );
-
-          if (fs.existsSync(entryPath)) {
-            const content = fs.readFileSync(entryPath, 'utf-8');
-            const sentryInit = `import * as Sentry from "@sentry/tanstackstart-react";
-              Sentry.init({
-                dsn: process.env.VITE_SENTRY_DSN,
-                tracesSampleRate: 0.2,
-              });
-            `;
-
-            if (!content.includes('Sentry.init')) {
-              fs.writeFileSync(entryPath, sentryInit + content);
-            }
-          }
-        },
-      },
-    }),
+    nitroV2Plugin(),
     tsConfigPaths({
       projects: ['./tsconfig.json'],
     }),


### PR DESCRIPTION
## Description

Notice a missing onboarding redirect while testing the login redirect bugfix. Also pulling the server side sentry configs for now, they break the build in vercel (but not locally).

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
