### PR TITLE
chore(release): use homebrew_casks with goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+          MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
   npm:
     runs-on: ubuntu-22.04
     needs: [goreleaser, check-release-type]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,6 +111,7 @@ jobs:
           args: release --clean --verbose --release-notes=/tmp/RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
   npm:
     runs-on: ubuntu-22.04
     needs: [goreleaser, check-release-type]

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,6 +77,19 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 
+notarize:
+  macos:
+    - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      sign:
+        certificate: "{{ .Env.MACOS_SIGN_P12 }}"
+        password: "{{ .Env.MACOS_SIGN_PASSWORD }}"
+      notarize:
+        issuer_id: "{{ .Env.MACOS_NOTARY_ISSUER_ID }}"
+        key_id: "{{ .Env.MACOS_NOTARY_KEY_ID }}"
+        key: "{{ .Env.MACOS_NOTARY_KEY }}"
+        wait: true
+        timeout: 20m
+
 snapshot:
   version_template: "{{ incpatch .Tag }}-next"
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,6 +87,23 @@ changelog:
       - '^docs:'
       - '^test:'
 
+homebrew_casks:
+  - name: inngest
+
+    # https://github.com/inngest/homebrew-tap
+    repository:
+      owner: inngest
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+
+    # auto only uploads stable releases to homebrew-tap
+    # set to false temporarily if testing prereleases too
+    skip_upload: auto
+
+    homepage: "https://www.inngest.com/"
+    description: "Inngest CLI and development server"
+
 release:
   # Repo in which the release will be created.
   # Default is extracted from the origin remote URL or empty if its private hosted.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -87,8 +87,7 @@ notarize:
         issuer_id: "{{ .Env.MACOS_NOTARY_ISSUER_ID }}"
         key_id: "{{ .Env.MACOS_NOTARY_KEY_ID }}"
         key: "{{ .Env.MACOS_NOTARY_KEY }}"
-        wait: true
-        timeout: 20m
+        wait: false
 
 snapshot:
   version_template: "{{ incpatch .Tag }}-next"
@@ -107,8 +106,15 @@ homebrew_casks:
     repository:
       owner: inngest
       name: homebrew-tap
-      branch: main
+      branch: "goreleaser/{{ .ProjectName }}-{{ .Tag }}"
       token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+      pull_request:
+        enabled: true
+        draft: true
+        base:
+          owner: inngest
+          name: homebrew-tap
+          branch: main
 
     # auto only uploads stable releases to homebrew-tap
     # set to false temporarily if testing prereleases too


### PR DESCRIPTION
## Description

Set up homebrew_casks in goreleaser to publish releases to https://github.com/inngest/homebrew-tap

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
