### PR TITLE
Use errors.New instead of fmt to avoid heap allocation

### DIFF
--- a/pkg/usage/metrics.go
+++ b/pkg/usage/metrics.go
@@ -1,14 +1,14 @@
 package usage
 
 import (
-	"fmt"
+	"errors"
 	"time"
 )
 
 var (
-	ErrNoMetricsName      = fmt.Errorf("metrics' name must be specified")
-	ErrNoMetricsTimeRange = fmt.Errorf("metrics' time range (from/to - ISO8601 format) must be specified")
-	ErrInvalidMetricsTimeRange = fmt.Errorf("invalid time range for metrics")
+	ErrNoMetricsName           = errors.New("metrics' name must be specified")
+	ErrNoMetricsTimeRange      = errors.New("metrics' time range (from/to - ISO8601 format) must be specified")
+	ErrInvalidMetricsTimeRange = errors.New("invalid time range for metrics")
 )
 
 // MetricsRequest represents a client request for metrics based on time range


### PR DESCRIPTION
## Description
The `fmt.Errorf` does a heap allocation when formatting errors. The existing error slugs do not do any special formatting and having fmt there imo is an overkill. So I changed it to use simple `errors.New`

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [X] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
