### PR TITLE
Fix sign out alignment in menu

### DIFF
--- a/ui/apps/dashboard/src/components/Auth/SignOutButton.tsx
+++ b/ui/apps/dashboard/src/components/Auth/SignOutButton.tsx
@@ -9,7 +9,7 @@ export const SignOutButton = ({
   const { signOut, session } = useClerk();
 
   const content = (
-    <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start h-full w-full p-2">
+    <div className="hover:bg-canvasSubtle flex flex-row items-center justify-start h-full w-full">
       <RiLogoutCircleLine className="text-muted mr-2 h-4 w-4" />
       <div>Sign Out </div>
     </div>


### PR DESCRIPTION
## Description

Fixes the misalignment of the Sign Out button in the profile menu,

## Motivation
Before change:
<img width="271" height="140" alt="Screen Shot 2025-12-29 at 11 26 55 AM" src="https://github.com/user-attachments/assets/32f3dfa1-f3e3-45ab-ad6f-0e3c4d39a621" />


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
