### PR TITLE
Fix hasUserlandChildren check for attempt spans

### DIFF
--- a/ui/packages/components/src/RunDetailsV3/InlineSpans.tsx
+++ b/ui/packages/components/src/RunDetailsV3/InlineSpans.tsx
@@ -46,7 +46,7 @@ export function InlineSpans({ className, minTime, maxTime, trace, depth }: Props
 
   // For steps with userland children, render the step itself to show proper background color
   const children = trace.childrenSpans || [];
-  const hasUserlandChildren = depth === 1 && children.some((s) => s.isUserland);
+  const hasUserlandChildren = children.some((s) => s.isUserland);
   const spans = !trace.isRoot && children.length && !hasUserlandChildren ? children : [];
   const shouldRenderParentOverlay = spans.length > 0 && !trace.isUserland;
 


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

This fixes the hasUserlandChildren check so that we render traces with extended trace spans under attempt spans correctly as non-inline spans.

Before:
<img width="710" height="755" alt="image" src="https://github.com/user-attachments/assets/d5072db1-bd9c-47e9-8764-f18f05c2c191" />

After:
<img width="699" height="608" alt="image" src="https://github.com/user-attachments/assets/a46859d6-4813-4ca5-87de-d0baa6958bf0" />


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

Currently we don't render traces with failed attempts (and thus non-collapsed attempt spans) with extended trace spans.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
