### PR TITLE
Fix run list count after run list refresh

### DIFF
--- a/ui/apps/dashboard/src/components/Runs/Runs.tsx
+++ b/ui/apps/dashboard/src/components/Runs/Runs.tsx
@@ -130,7 +130,7 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
     tracePreviewEnabled,
   });
 
-  const [countRes] = useQuery({
+  const [countRes, countRefetch] = useQuery({
     query: CountRunsDocument,
     requestPolicy: 'network-only',
     variables: commonQueryVars,
@@ -151,6 +151,7 @@ export const Runs = forwardRef<RefreshRunsRef, Props>(function Runs(
 
   const onRefresh = useCallback(() => {
     reset();
+    countRefetch();
   }, [reset]);
 
   useImperativeHandle(ref, () => ({

--- a/ui/apps/dev-server-ui/src/routes/_dashboard/runs/index.tsx
+++ b/ui/apps/dev-server-ui/src/routes/_dashboard/runs/index.tsx
@@ -146,7 +146,7 @@ function RunsComponent() {
 
   const searchError = parseCelSearchError(error);
 
-  useEffect(() => {
+  const getTotalCount = useCallback(async () => {
     setTotalCount(undefined);
     (async () => {
       const data: CountRunsQuery = await client.request(CountRunsDocument, {
@@ -159,6 +159,15 @@ function RunsComponent() {
       setTotalCount(data.runs.totalCount);
     })();
   }, [calculatedStartTime, endTime, filteredStatus, timeField, search]);
+
+  useEffect(() => {
+    getTotalCount();
+  }, [getTotalCount]);
+
+  const onRefresh = useCallback(() => {
+    fetchNextPage();
+    getTotalCount();
+  }, [fetchNextPage, getTotalCount]);
 
   const runs = useMemo(() => {
     if (!data?.pages) {
@@ -223,7 +232,7 @@ function RunsComponent() {
         isLoadingInitial={isFetching && runs === undefined}
         isLoadingMore={isFetching && runs !== undefined}
         onScrollToTop={onScrollToTop}
-        onRefresh={fetchNextPage}
+        onRefresh={onRefresh}
         getTrigger={getTrigger}
         pollInterval={pollInterval}
         scope="env"


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

<img width="200" height="81" alt="image" src="https://github.com/user-attachments/assets/559f7b2c-1ac3-4c68-9f23-ee01f293aa92" />

This makes the runs list count update after "Refresh runs" is pressed.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

Currently the run count does not update after the "Refresh runs" button is pressed in the runs list (in both cloud and devserver)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
