### PR TITLE
restore dedupes for vite build

### DIFF
--- a/ui/apps/dashboard/vite.config.ts
+++ b/ui/apps/dashboard/vite.config.ts
@@ -21,6 +21,16 @@ export default defineConfig({
         '../../packages/components/src',
       ),
     },
+    // TODO: these can go away when all versions are aligned across monorepo
+    dedupe: [
+      'next-themes',
+      '@tanstack/react-query',
+      'react',
+      'react-dom',
+      '@tanstack/react-router',
+      '@tanstack/react-table',
+      'zod',
+    ],
   },
   optimizeDeps: {
     exclude: ['@inngest/agent-kit'],

--- a/ui/apps/dev-server-ui/vite.config.ts
+++ b/ui/apps/dev-server-ui/vite.config.ts
@@ -34,6 +34,9 @@ export default defineConfig({
         '../../packages/components/src',
       ),
     },
+    //
+    // TODO: these can go away when all versions are aligned across monorepo
+    dedupe: ['next-themes', '@tanstack/react-query', 'react', 'react-dom'],
   },
   ssr: {
     noExternal: ['@reduxjs/toolkit', '@rtk-query/graphql-request-base-query'],


### PR DESCRIPTION
## Description

Vite build dedupe removal broke the run detail view query provider. Restore it for now until we make all these versions the same.

## Motivation
Bugfix

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
