### PR TITLE
fix: "Send to Dev Server" generates invalid URL causing 404

### DIFF
--- a/ui/packages/components/src/utils/useDevServer.tsx
+++ b/ui/packages/components/src/utils/useDevServer.tsx
@@ -4,7 +4,7 @@ import { toast } from 'sonner';
 export const devServerURL = 'http://localhost:8288';
 
 function getStreamEventURL(devServerURL: string, eventID: string): string {
-  return `${devServerURL}/stream/trigger?event=${eventID}`;
+  return `${devServerURL}/event?eventID=${eventID}`;
 }
 
 // We want the event to appear at the top of the stream, so we omit the timestamp


### PR DESCRIPTION
Fixes #3342

## Changes
- Fixed URL generation in `useDevServer.tsx` from `/stream/trigger?event=<id>` to `/event?eventID=<id>`
- The new URL matches the actual route defined in dev-server-ui routing