### PR TITLE
Use run ID timestamp for first discovery span queued_at

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1155,6 +1155,7 @@ func (e *executor) schedule(
 		}
 	}
 
+	runTimestamp := runID.Timestamp()
 	runSpanOpts := &tracing.CreateSpanOptions{
 		Debug:    &tracing.SpanDebugData{Location: "executor.Schedule"},
 		Metadata: &metadata,
@@ -1163,6 +1164,7 @@ func (e *executor) schedule(
 			meta.Attr(meta.Attrs.DebugRunID, req.DebugRunID),
 			meta.Attr(meta.Attrs.EventsInput, &strEvts),
 			meta.Attr(meta.Attrs.TriggeringEventName, eventName),
+			meta.Attr(meta.Attrs.QueuedAt, &runTimestamp),
 		),
 		Seed: []byte(metadata.ID.RunID[:]),
 	}
@@ -1279,6 +1281,9 @@ func (e *executor) schedule(
 				Metadata:  &metadata,
 				QueueItem: &item,
 				Carriers:  []map[string]any{item.Metadata},
+				Attributes: meta.NewAttrSet(
+					meta.Attr(meta.Attrs.QueuedAt, &runTimestamp),
+				),
 			},
 		)
 		if err != nil {

--- a/pkg/tracing/execution_processor.go
+++ b/pkg/tracing/execution_processor.go
@@ -123,7 +123,7 @@ func (p *executionProcessor) OnStart(parent context.Context, s sdktrace.ReadWrit
 
 	case meta.SpanNameStepDiscovery:
 		{
-			meta.AddAttr(rawAttrs, meta.Attrs.QueuedAt, &now)
+			meta.AddAttrIfUnset(rawAttrs, meta.Attrs.QueuedAt, &now)
 
 			break
 		}


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

This uses the same timestamp (the run id timestamp) for queued_at for the run span and the step discovery span.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

Currently the first discovery span has an earlier queued_at timestamp than the parent run span for crons.

<img width="1390" height="716" alt="image" src="https://github.com/user-attachments/assets/63da2fa2-bdef-491c-8560-c381b4e76965" />



## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
