### PR TITLE
GC expired pauses while loading them for evaluation

### DIFF
--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -808,6 +808,15 @@ func IncrQueueItemConstraintCheckFallbackCounter(ctx context.Context, reason str
 	})
 }
 
+func IncrPausesExpiredDeletedCounter(ctx context.Context, count int64, opts CounterOpt) {
+	RecordCounterMetric(ctx, count, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "pauses_expired_deleted_total",
+		Description: "Total number of expired pauses deleted during load",
+		Tags:        opts.Tags,
+	})
+}
+
 func IncrBacklogRefillConstraintCheckFallbackCounter(ctx context.Context, reason string, opts CounterOpt) {
 	if opts.Tags == nil {
 		opts.Tags = map[string]any{}


### PR DESCRIPTION

## Description
Since introducing the pause manager, loading pauses wasn't GCing expired
pauses so this adds that logic to the pause manager
`LoadEvaluablesSince` which should cover pauses coming from blocks & the
buffer.

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->


## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
