### PR TITLE
Handle "Invalid Date" that is an instance of Date

### DIFF
--- a/ui/packages/components/src/Time.tsx
+++ b/ui/packages/components/src/Time.tsx
@@ -34,7 +34,7 @@ export function Time({ className, format, value, copyable = true }: Props) {
 
   const date = value instanceof Date ? value : toMaybeDate(value);
 
-  if (!(date instanceof Date) || isNaN(date)) {
+  if (!(date instanceof Date) || isNaN(date.getTime())) {
     return <span>Invalid date</span>;
   }
 


### PR DESCRIPTION
## Description

Without this, invalid dates would try to get parsed and crash later


```
> new Date("")
Invalid Date
> new Date("") instanceof Date
true
> isNaN(new Date(""))
true
```

```
> new Date()
Fri Jan 09 2026 09:22:20 GMT-0800 (Pacific Standard Time)
> new Date() instanceof Date
true
> isNaN(new Date())
false
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
