### PR TITLE
Replace simpleJSONExtractString() with data.function_id in Insights example template

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/templates.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabPanelTemplatesTab/templates.ts
@@ -31,7 +31,7 @@ const COUNT_ALIAS_MAP: Record<'failed' | 'cancelled' | 'finished', string> = {
 
 function makeFunctionStatusQuery(outcome: 'failed' | 'cancelled' | 'finished') {
   const base = `SELECT
-    simpleJSONExtractString(data, 'function_id') as function_id,
+    data.function_id AS function_id,
     COUNT(*) as ${COUNT_ALIAS_MAP[outcome]}
 FROM
     events


### PR DESCRIPTION
## Description

Replace simpleJSONExtractString() with data.function_id in Insights example template

## Motivation
Better examples for users

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
