### PR TITLE
Report Constraint Scavenger metrics by shard

### DIFF
--- a/pkg/constraintapi/scavenge.go
+++ b/pkg/constraintapi/scavenge.go
@@ -203,7 +203,9 @@ func (r *redisCapacityManager) scavengeShard(ctx context.Context, mi MigrationId
 	defer func() {
 		metrics.HistogramConstraintAPIScavengerShardProcessDuration(ctx, time.Since(start), metrics.HistogramOpt{
 			PkgName: scavengerPkgName,
-			Tags:    map[string]any{},
+			Tags: map[string]any{
+				"source": mi.String(),
+			},
 		})
 	}()
 
@@ -416,7 +418,9 @@ func (r *redisCapacityManager) scavengeAccount(
 		leaseAge := now.Sub(leaseID.Timestamp())
 		metrics.HistogramConstraintAPIScavengerLeaseAge(ctx, leaseAge, metrics.HistogramOpt{
 			PkgName: scavengerPkgName,
-			Tags:    map[string]any{},
+			Tags: map[string]any{
+				"source": mi.String(),
+			},
 		})
 
 		_, err := r.Release(ctx, &CapacityReleaseRequest{


### PR DESCRIPTION
## Description

This PR adds tags for Constraint scavenger metrics to identify the source (queue shard or rate limit cluster). This is useful for figuring out which cluster is experiencing pressure and potentially not `Release`-ing leases.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
