### PR TITLE
Fix potential processor iterator race condition

### DIFF
--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -371,10 +371,9 @@ func TestProcessorIteratorCounterRaceCondition(t *testing.T) {
 	}
 
 	// Verify counters match expected values
-	// Use atomic loads to safely read the counter values
-	ctrSuccess := atomic.LoadInt32(&iter.CtrSuccess)
-	ctrConcurrency := atomic.LoadInt32(&iter.CtrConcurrency)
-	ctrRateLimit := atomic.LoadInt32(&iter.CtrRateLimit)
+	ctrSuccess := iter.CtrSuccess.Load()
+	ctrConcurrency := iter.CtrConcurrency.Load()
+	ctrRateLimit := iter.CtrRateLimit.Load()
 
 	t.Logf("CtrSuccess: %d, CtrConcurrency: %d, CtrRateLimit: %d",
 		ctrSuccess, ctrConcurrency, ctrRateLimit)
@@ -482,10 +481,9 @@ func TestProcessorIteratorCounterRaceConditionMixed(t *testing.T) {
 		receivedCount++
 	}
 
-	// Use atomic loads to safely read the counter values
-	ctrSuccess := atomic.LoadInt32(&iter.CtrSuccess)
-	ctrConcurrency := atomic.LoadInt32(&iter.CtrConcurrency)
-	ctrRateLimit := atomic.LoadInt32(&iter.CtrRateLimit)
+	ctrSuccess := iter.CtrSuccess.Load()
+	ctrConcurrency := iter.CtrConcurrency.Load()
+	ctrRateLimit := iter.CtrRateLimit.Load()
 
 	t.Logf("Actual - CtrSuccess: %d, CtrRateLimit: %d, CtrConcurrency: %d",
 		ctrSuccess, ctrRateLimit, ctrConcurrency)
@@ -580,9 +578,8 @@ func TestProcessorIteratorIsCustomKeyLimitOnlyRace(t *testing.T) {
 
 	close(workers)
 
-	// Use atomic operations to safely read the values
 	isCustomKeyLimitOnly := iter.IsCustomKeyLimitOnly.Load()
-	ctrConcurrency := atomic.LoadInt32(&iter.CtrConcurrency)
+	ctrConcurrency := iter.CtrConcurrency.Load()
 
 	// With function concurrency mixed in, IsCustomKeyLimitOnly should be false
 	t.Logf("IsCustomKeyLimitOnly: %v", isCustomKeyLimitOnly)

--- a/pkg/execution/state/redis_state/queue_item_process_test.go
+++ b/pkg/execution/state/redis_state/queue_item_process_test.go
@@ -629,10 +629,10 @@ func TestPartitionProcessRequeueAfterLimitedWithConstraintAPI(t *testing.T) {
 		require.NoError(t, err)
 
 		// first two items were successfully leased
-		require.Equal(t, 2, int(iter.CtrSuccess))
+		require.Equal(t, int32(2), iter.CtrSuccess.Load())
 
 		// third item was concurrency limited, we stopped
-		require.Equal(t, 1, int(iter.CtrConcurrency), r.Dump())
+		require.Equal(t, int32(1), iter.CtrConcurrency.Load(), r.Dump())
 
 		// we should requeue the item
 		require.True(t, iter.IsRequeuable())
@@ -766,10 +766,10 @@ func TestPartitionProcessRequeueAfterLimitedWithConstraintAPI(t *testing.T) {
 		require.NoError(t, err)
 
 		// first two items were successfully leased
-		require.Equal(t, 2, int(iter.CtrSuccess))
+		require.Equal(t, int32(2), iter.CtrSuccess.Load())
 
 		// third item was concurrency limited, we stopped
-		require.Equal(t, 1, int(iter.CtrConcurrency), r.Dump())
+		require.Equal(t, int32(1), iter.CtrConcurrency.Load(), r.Dump())
 
 		// we should requeue the item
 		require.True(t, iter.IsRequeuable())


### PR DESCRIPTION
## Description

This aims to fix a potential race condition possible with the new queue interface introduced in #3480.

The new test introduced did validate that there is a race condition which highlighted losing up to 12 out of 100 items.

### How to reproduce

Check out the first commit which adds the new test then run this in the `queue` dir:
```
go test -race -run TestProcessorIteratorCounterRaceCondition
```

## Motivation
When investigating another potential issue today, I unleashed Claude to explore #3480 for any potential issues related to parallelization. It looked like a real potential issue given our volume.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
