### PR TITLE
Fix debounce timeout

### DIFF
--- a/pkg/execution/debounce/lua/updateDebounce.lua
+++ b/pkg/execution/debounce/lua/updateDebounce.lua
@@ -87,8 +87,16 @@ if existing ~= false then
 		if nextTTL > item.t then
 			ttl = math.floor((item.t - currentTime) / 1000)
 			if ttl <= 0 then
-				-- Ensure we always use a minimum.
-				ttl = 1
+				-- If we reach here then the debounce timed out (per the
+				-- function's optional timeout config)
+
+				-- Delete the debounce pointer. We want any new events with the
+				-- same key to create a new debounce
+				redis.call("DEL", keyPtr)
+
+				-- Ensure we always use a minimum, since this is used for queue
+				-- scheduling
+				return 0
 			end
 			ttl = tonumber(ttl)
 		end

--- a/tests/golang/debounce_test.go
+++ b/tests/golang/debounce_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/inngest/inngestgo"
 	"github.com/inngest/inngestgo/step"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -220,15 +221,15 @@ func TestDebounce_OutOfOrderTS(t *testing.T) {
 }
 
 func TestDebounce_Timeout(t *testing.T) {
+	r := require.New(t)
 	inngestClient, server, registerFuncs := NewSDKHandler(t, "debounce")
 	defer server.Close()
-
-	var counter int32
 
 	start := time.Now()
 	period := 5 * time.Second
 	max := 10 * time.Second
 
+	var runTime time.Time
 	_, err := inngestgo.CreateFunction(
 		inngestClient,
 		inngestgo.FunctionOpts{
@@ -240,35 +241,55 @@ func TestDebounce_Timeout(t *testing.T) {
 		},
 		inngestgo.EventTrigger("test/sdk", nil),
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
-			fmt.Println("Debounced function ran", input.Event.Data.Name)
-
-			// It should occur after the max period.
-			require.True(t, time.Now().After(start.Add(max)))
-
-			atomic.AddInt32(&counter, 1)
+			runTime = time.Now()
 			return nil, nil
 		},
 	)
-	require.NoError(t, err)
+	r.NoError(err)
 	registerFuncs()
 
+	sendEventCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
-		// Send an event every second for 20 seconds in a goroutine.
+		// Send an events for 20 seconds in a goroutine.
 		// This ensures that we wait up to 15s - just past the max - to receive
 		// a fn invocation.
-		for i := 0; i <= 20; i++ {
-			_, err := inngestClient.Send(context.Background(), DebounceEvent{
-				Name: "test/sdk",
-				Data: DebounceEventData{
-					Name: "debounce",
-				},
-			})
-			require.NoError(t, err)
-			<-time.After(time.Second)
+		for time.Since(start) < 20*time.Second {
+			select {
+			case <-sendEventCtx.Done():
+				return
+			default:
+				_, _ = inngestClient.Send(sendEventCtx, DebounceEvent{
+					Name: "test/sdk",
+					Data: DebounceEventData{
+						Name: "debounce",
+					},
+				})
+
+				// Send more than 1 per second due to a bug we fixed. We had a
+				// bug where a debounce was extended past the timeout if an
+				// event was received within 1 second before the timeout. This
+				// could happen indefinitely if events kept coming in within 1
+				// second
+				time.Sleep(500 * time.Millisecond)
+			}
 		}
 	}()
 
-	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&counter) == 1
-	}, 15*time.Second, 100*time.Millisecond, "Expected 1, got %d", counter)
+	r.EventuallyWithT(func(t *assert.CollectT) {
+		r := require.New(t)
+		r.NotZero(runTime)
+
+		// Run started within 1 second of the timeout
+		timeout := time.Duration(max).Seconds()
+		runStarted := runTime.Sub(start).Seconds()
+		r.LessOrEqual(
+			runStarted,
+			timeout+1,
+		)
+		r.GreaterOrEqual(
+			runStarted,
+			timeout-1,
+		)
+	}, 15*time.Second, 100*time.Millisecond)
 }


### PR DESCRIPTION
## Description
Fix a bug where a debounce could extend past its user-configured timeout.

This would happen when an event was received within 1 second of the debounce timeout. In that situation, we would set the debounce TTL to 1 second. But we actually want to delete the debounce and schedule the queue item immediately.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
