### PR TITLE
Singleton "queue" mode

### DIFF
--- a/pkg/enums/singleton_mode.go
+++ b/pkg/enums/singleton_mode.go
@@ -10,4 +10,10 @@ const (
 
 	// SingletonModeCancel cancels the currently running singleton instance and starts the new one.
 	SingletonModeCancel
+
+	// SingletonModeQueue skips new runs if another singleton is in the queue.  When a run starts,
+	// we can enqueue another single run which will take place after the current run.  This essentially
+	// is a semaphore to ensure only one instance exists in the queue, but we let another item queue
+	// while any function is running.
+	SingletonModeQueue
 )

--- a/pkg/enums/singletonmode_enumer.go
+++ b/pkg/enums/singletonmode_enumer.go
@@ -10,11 +10,11 @@ import (
 	"strings"
 )
 
-const _SingletonModeName = "skipcancel"
+const _SingletonModeName = "skipcancelqueue"
 
-var _SingletonModeIndex = [...]uint8{0, 4, 10}
+var _SingletonModeIndex = [...]uint8{0, 4, 10, 15}
 
-const _SingletonModeLowerName = "skipcancel"
+const _SingletonModeLowerName = "skipcancelqueue"
 
 func (i SingletonMode) String() string {
 	if i < 0 || i >= SingletonMode(len(_SingletonModeIndex)-1) {
@@ -29,20 +29,24 @@ func _SingletonModeNoOp() {
 	var x [1]struct{}
 	_ = x[SingletonModeSkip-(0)]
 	_ = x[SingletonModeCancel-(1)]
+	_ = x[SingletonModeQueue-(2)]
 }
 
-var _SingletonModeValues = []SingletonMode{SingletonModeSkip, SingletonModeCancel}
+var _SingletonModeValues = []SingletonMode{SingletonModeSkip, SingletonModeCancel, SingletonModeQueue}
 
 var _SingletonModeNameToValueMap = map[string]SingletonMode{
-	_SingletonModeName[0:4]:       SingletonModeSkip,
-	_SingletonModeLowerName[0:4]:  SingletonModeSkip,
-	_SingletonModeName[4:10]:      SingletonModeCancel,
-	_SingletonModeLowerName[4:10]: SingletonModeCancel,
+	_SingletonModeName[0:4]:        SingletonModeSkip,
+	_SingletonModeLowerName[0:4]:   SingletonModeSkip,
+	_SingletonModeName[4:10]:       SingletonModeCancel,
+	_SingletonModeLowerName[4:10]:  SingletonModeCancel,
+	_SingletonModeName[10:15]:      SingletonModeQueue,
+	_SingletonModeLowerName[10:15]: SingletonModeQueue,
 }
 
 var _SingletonModeNames = []string{
 	_SingletonModeName[0:4],
 	_SingletonModeName[4:10],
+	_SingletonModeName[10:15],
 }
 
 // SingletonModeString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
This PR lands singleton queue mode - similar to singleton skip, except that as soon as a function starts running, we allow one other run to be enqueued.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
