### PR TITLE
Do not schedule cron jobs in the past

### DIFF
--- a/pkg/execution/cron/redis.go
+++ b/pkg/execution/cron/redis.go
@@ -278,6 +278,9 @@ func (c *redisCronManager) ScheduleNext(ctx context.Context, ci CronItem) (*Cron
 	l := c.log.With("action", "redisCronManager.ScheduleNext", "queue", kind, "functionID", ci.FunctionID, "functionVersion", ci.FunctionVersion, "cronExpr", ci.Expression, "operation", ci.Op)
 
 	from := ci.ID.Timestamp()
+	if now := time.Now(); now.After(from) {
+		from = now
+	}
 
 	// Parse the cron expression and get the next execution time
 	next, err := Next(ci.Expression, from)

--- a/pkg/execution/cron/redis_test.go
+++ b/pkg/execution/cron/redis_test.go
@@ -902,8 +902,10 @@ func TestRedisCronManager(t *testing.T) {
 
 					nextTime := time.UnixMilli(int64(nextItem.ID.Time()))
 
-					// Should be scheduled for 1AM
-					assert.True(t, nextTime.Equal(time.Date(2025, 12, 25, 1, 0, 0, 0, time.UTC)))
+					// Should be scheduled for the top of the next minute
+					assert.True(t, nextTime.After(time.Now()))
+					assert.Equal(t, 0, nextTime.Minute())
+					assert.Equal(t, 0, nextTime.Second())
 				})
 			}
 		})


### PR DESCRIPTION
## Description

This happens when the system queue is backlogged. It might be better to skip ahead to the next schedule instead of scheduling runs for all skipped schedules in quick succession immediately after the system comes back up.

After a system queue outage, we see a big flurry of missed crons being scheduled immediately after the outage:
[
<img width="641" height="260" alt="Screenshot 2026-01-20 at 8 52 54 PM" src="https://github.com/user-attachments/assets/af846362-3b9c-4f1f-a1d5-eb0d74f96e0b" />
](url)

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
