### PR TITLE
Fix initial run RequestVersion edge case

### DIFF
--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -277,6 +277,10 @@ func (m shardedMgr) New(ctx context.Context, input state.Input) (state.State, er
 	}
 
 	rv := consts.RequestVersionUnknown
+	// XXX: The 0-check here is to handle an edge case with older
+	// executors that didn't have RequestVersion set,
+	// thus defaulting to 0, causing the affected runs
+	// to be forced to run using executor v0.
 	if input.RequestVersion != nil && *input.RequestVersion != 0 {
 		rv = *input.RequestVersion
 	}


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

Ignore explicit 0 values on initial state creation.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

Currently there is an edge case on deploy where we end up w/ 0 in state on runs queued from versions older than #3565 and then erroneously use that instead of `-1`.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
