### PR TITLE
Revert "Send parallel step IDs when re-executing"

### DIFF
--- a/pkg/api/apiv1/checkpoint.go
+++ b/pkg/api/apiv1/checkpoint.go
@@ -177,10 +177,9 @@ func (a checkpointAPI) CheckpointNewRun(w http.ResponseWriter, r *http.Request) 
 		AccountID:   auth.AccountID(),
 		WorkspaceID: auth.WorkspaceID(),
 		AppID:       input.AppID(auth.WorkspaceID()),
-		RunMode:        enums.RunModeSync,
-		Events:         []event.TrackedEvent{evt},
-		URL:            input.URL(),
-		RequestVersion: input.RequestVersion,
+		RunMode:     enums.RunModeSync,
+		Events:      []event.TrackedEvent{evt},
+		URL:         input.URL(),
 	})
 
 	metrics.IncrExecutorScheduleCount(ctx, metrics.CounterOpt{

--- a/pkg/api/apiv1/checkpoint_types.go
+++ b/pkg/api/apiv1/checkpoint_types.go
@@ -78,14 +78,6 @@ type CheckpointNewRunRequest struct {
 	// in the same step.
 	Steps []state.GeneratorOpcode `json:"steps"`
 
-	// RequestVersion represents the execution model that the SDK used when
-	// starting this run.
-	RequestVersion *int `json:"request_version,omitempty"`
-
-	// Retries indicates how many retry attempts should be made for steps in
-	// this run.
-	Retries int `json:"retries,omitempty"`
-
 	// XXX: SDK Version and language??
 }
 
@@ -146,7 +138,7 @@ func (r CheckpointNewRunRequest) Fn(appID uuid.UUID) inngest.Function {
 				ID:      "step",
 				Name:    r.FnSlug(),
 				URI:     uri,
-				Retries: inngestgo.Ptr(r.Retries),
+				Retries: inngestgo.Ptr(0),
 			},
 		},
 	}

--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -93,16 +93,15 @@ func (e executor) Execute(ctx context.Context, sl sv2.StateLoader, s sv2.Metadat
 	}
 
 	dr, _, err := ExecuteDriverRequest(ctx, e.Client, Request{
-		AccountID:      s.ID.Tenant.AccountID,
-		WorkflowID:     s.ID.FunctionID,
-		RunID:          s.ID.RunID,
-		SigningKey:     e.localSigningKey,
-		URL:            *uri,
-		Input:          input,
-		Edge:           edge,
-		Step:           step,
-		Headers:        headers,
-		RequestVersion: &s.Config.RequestVersion,
+		AccountID:  s.ID.Tenant.AccountID,
+		WorkflowID: s.ID.FunctionID,
+		RunID:      s.ID.RunID,
+		SigningKey: e.localSigningKey,
+		URL:        *uri,
+		Input:      input,
+		Edge:       edge,
+		Step:       step,
+		Headers:    headers,
 	})
 	return dr, err
 }
@@ -120,12 +119,11 @@ type Request struct {
 	// the SigningKey below will be used to sign the input.
 	Signature string
 	// SigningKey, if set, signs the input using this key.
-	SigningKey     []byte
-	URL            url.URL
-	Input          []byte
-	Edge           inngest.Edge
-	Step           inngest.Step
-	RequestVersion *int
+	SigningKey []byte
+	URL        url.URL
+	Input      []byte
+	Edge       inngest.Edge
+	Step       inngest.Step
 
 	// Headers are additional headers to add to the request.
 	Headers map[string]string
@@ -307,16 +305,6 @@ func do(ctx context.Context, c exechttp.RequestExecutor, r Request) (*Response, 
 
 	// Always add the run ID
 	req.Header.Add("X-Run-ID", r.RunID.String())
-
-	if r.RequestVersion != nil {
-		req.Header.Add(headerspkg.HeaderKeyRequestVersion, fmt.Sprintf("%d", *r.RequestVersion))
-	}
-
-	if r.Edge.IncomingGeneratorStep != "" {
-		req.Header.Add(headerspkg.HeaderInngestStepID, r.Edge.IncomingGeneratorStep)
-	} else {
-		req.Header.Add(headerspkg.HeaderInngestStepID, r.Edge.Incoming)
-	}
 
 	// Perform the request.
 	resp, err := c.DoRequest(ctx, req)

--- a/pkg/execution/driver/httpv2/httpv2.go
+++ b/pkg/execution/driver/httpv2/httpv2.go
@@ -87,11 +87,6 @@ func (d httpv2) sync(ctx context.Context, opts driver.V2RequestOpts) (*state.Dri
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("X-Inngest-Signature", sig)
 	req.Header.Add("X-Run-ID", opts.Metadata.ID.RunID.String())
-	req.Header.Add(headers.HeaderKeyRequestVersion, fmt.Sprintf("%d", opts.Metadata.Config.RequestVersion))
-
-	if opts.StepID != nil {
-		req.Header.Add(headers.HeaderInngestStepID, *opts.StepID)
-	}
 
 	resp, err := d.Client.DoRequest(ctx, req)
 

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -273,16 +273,6 @@ type ScheduleRequest struct {
 	DebugSessionID *ulid.ULID
 	// DebugRunID is the ID of the debugger run that this function is being scheduled from.
 	DebugRunID *ulid.ULID
-	// RequestVersion represents the executor request versioning/hashing style
-	// used to manage state.
-	//
-	// This lets us send the hashing style to SDKs so that we can execute in
-	// the correct format with backcompat guarantees built in.
-	//
-	// We usually wait for the SDK to decide this, but allow passing it in here
-	// if we're queuing a function as a result of a sync run going async, as
-	// the SDK has already been run at that point.
-	RequestVersion *int
 }
 
 func (r ScheduleRequest) SkipReason() enums.SkipReason {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -933,7 +933,7 @@ func (e *executor) schedule(
 	// function run spanID
 	spanID := run.NewSpanID(ctx)
 
-	cfg := sv2.Config{
+	config := *sv2.InitConfig(&sv2.Config{
 		FunctionVersion: req.Function.FunctionVersion,
 		SpanID:          spanID.String(),
 		EventIDs:        eventIDs,
@@ -943,13 +943,7 @@ func (e *executor) schedule(
 		PriorityFactor:  &factor,
 		BatchID:         req.BatchID,
 		Context:         req.Context,
-		RequestVersion:  consts.RequestVersionUnknown,
-	}
-	if req.RequestVersion != nil {
-		cfg.RequestVersion = *req.RequestVersion
-	}
-
-	config := *sv2.InitConfig(&cfg)
+	})
 
 	// If we have a specifc URL to hit for this run, add it to context.
 	if req.URL != "" {
@@ -2040,7 +2034,7 @@ func (e *executor) executeDriverV2(ctx context.Context, run *runInstance, d driv
 		SigningKey: sk,
 		Attempt:    run.AttemptCount(),
 		Index:      run.stackIndex,
-		StepID:     &run.edge.IncomingGeneratorStep,
+		StepID:     &run.edge.Outgoing,
 		QueueRef:   queueref.StringFromCtx(ctx),
 		URL:        url,
 	})

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -276,16 +276,11 @@ func (m shardedMgr) New(ctx context.Context, input state.Input) (state.State, er
 		}
 	}
 
-	rv := consts.RequestVersionUnknown
-	if input.RequestVersion != nil {
-		rv = *input.RequestVersion
-	}
-
 	metadata := runMetadata{
 		Identifier:     input.Identifier,
 		Debugger:       input.Debugger,
 		Version:        currentVersion,
-		RequestVersion: rv,
+		RequestVersion: consts.RequestVersionUnknown, // Always use -1 to indicate unset hash version until first request.
 		Context:        input.Context,
 		Status:         enums.RunStatusScheduled,
 		SpanID:         input.SpanID,

--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -90,7 +90,6 @@ func (v v2) Create(ctx context.Context, s state.CreateState) (state.State, error
 		SpanID:         s.Metadata.Config.SpanID,
 		Steps:          s.Steps,
 		StepInputs:     s.StepInputs,
-		RequestVersion: &s.Metadata.Config.RequestVersion,
 	})
 	switch err {
 	case nil:

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -458,8 +458,4 @@ type Input struct {
 
 	// SpanID is the id used for the new function run
 	SpanID string
-
-	// RequestVersion represents the executor request versioning/hashing style
-	// used to manage state.
-	RequestVersion *int
 }

--- a/pkg/headers/headers.go
+++ b/pkg/headers/headers.go
@@ -27,10 +27,6 @@ const (
 	// XXX: This is exctracted from httpdriver and needs documenting.
 	HeaderKeyRequestVersion = "x-inngest-req-version"
 
-	// HeaderInngestStepID represents the step we wish to execute when
-	// processing parallel steps.
-	HeaderInngestStepID = "X-Inngest-Step-ID"
-
 	HeaderAuthorization = "Authorization"
 	HeaderContentType   = "Content-Type"
 	HeaderUserAgent     = "User-Agent"


### PR DESCRIPTION
Reverts inngest/inngest#3565

Placeholder PR to revert changes released earlier today. This will hold open and we'll upstream these changes manually. If we can sort out a forward fix, we will close this revert PR.