### PR TITLE
Remove claude code + gemini cli from nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,6 @@
             protoc-gen-go
             protoc-gen-go-grpc
             protoc-gen-connect-go
-            gemini-cli
             swagger-codegen3
           ];
 


### PR DESCRIPTION
## Description

removes `claude-code` and `gemini-cli` from the nix flake because the pinned nixpkgs version provides an outdated version (1.0.51 for claude code)

developers should install and update these tools independently

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
