### PR TITLE
Conditional observability

### DIFF
--- a/pkg/constraintapi/acquire.go
+++ b/pkg/constraintapi/acquire.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/telemetry/conditional"
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/inngest/inngest/pkg/util/errs"
@@ -157,6 +158,13 @@ type acquireScriptResponse struct {
 }
 
 func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquireRequest) (*CapacityAcquireResponse, errs.InternalError) {
+	// Set up conditional observability context for feature flag evaluation
+	ctx = conditional.WithContext(ctx,
+		conditional.WithAccountID(req.AccountID),
+		conditional.WithEnvID(req.EnvID),
+		conditional.WithFunctionID(req.FunctionID),
+	)
+
 	l := logger.StdlibLogger(ctx)
 
 	requestID, err := ulid.New(ulid.Timestamp(r.clock.Now()), rand.Reader)
@@ -177,6 +185,8 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 		"source", req.Source,
 		"migration", req.Migration,
 	)
+	// Store configured logger in context so scoped loggers can reuse its fields
+	ctx = logger.WithStdlib(ctx, l)
 
 	now := r.clock.Now()
 
@@ -201,8 +211,6 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 			"exceeded maximum allowed request delay, latency: %s, attempt: %d", requestLatency, req.RequestAttempt,
 		)
 	}
-
-	enableHighCardinalityInstrumentation := r.enableHighCardinalityInstrumentation != nil && r.enableHighCardinalityInstrumentation(ctx, req.AccountID, req.EnvID, req.FunctionID)
 
 	// Retrieve client and key prefix for current constraints
 	// NOTE: We will no longer need this once we move to a dedicated store for constraint state
@@ -373,7 +381,7 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 	)
 
 	tags := make(map[string]any)
-	if enableHighCardinalityInstrumentation {
+	if conditional.IsMetricsEnabled(ctx, "constraintapi.HighCardinality") {
 		tags["function_id"] = req.FunctionID
 	}
 
@@ -399,12 +407,10 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 
 	switch parsedResponse.Status {
 	case 1, 3:
-		if enableHighCardinalityInstrumentation {
-			l.Debug(
-				"successful acquire call",
-				"leases", leases,
-			)
-		}
+		logger.StdlibLogger(conditional.WithScope(ctx, "constraintapi.HighCardinality")).Debug(
+			"successful acquire call",
+			"leases", leases,
+		)
 
 		metrics.HistogramConstraintAPIRequestStateSize(ctx, int64(len(requestState)), metrics.HistogramOpt{
 			PkgName: pkgName,

--- a/pkg/constraintapi/acquire.go
+++ b/pkg/constraintapi/acquire.go
@@ -381,7 +381,7 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 	)
 
 	tags := make(map[string]any)
-	if conditional.IsMetricsEnabled(ctx, "constraintapi.HighCardinality") {
+	if conditional.IsMetricsEnabled(ctx, "constraintapi.Acquire") {
 		tags["function_id"] = req.FunctionID
 	}
 

--- a/pkg/constraintapi/acquire.go
+++ b/pkg/constraintapi/acquire.go
@@ -407,7 +407,7 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 
 	switch parsedResponse.Status {
 	case 1, 3:
-		logger.StdlibLogger(conditional.WithScope(ctx, "constraintapi.HighCardinality")).Debug(
+		conditional.Logger(ctx, "constraintapi.Acquire").Debug(
 			"successful acquire call",
 			"leases", leases,
 		)

--- a/pkg/constraintapi/extend.go
+++ b/pkg/constraintapi/extend.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/telemetry/conditional"
 	"github.com/inngest/inngest/pkg/util/errs"
 	"github.com/oklog/ulid/v2"
 )
@@ -20,6 +20,11 @@ type extendLeaseScriptResponse struct {
 
 // ExtendLease implements CapacityManager.
 func (r *redisCapacityManager) ExtendLease(ctx context.Context, req *CapacityExtendLeaseRequest) (*CapacityExtendLeaseResponse, errs.InternalError) {
+	// Set up conditional observability context for feature flag evaluation
+	ctx = conditional.WithContext(ctx,
+		conditional.WithAccountID(req.AccountID),
+	)
+
 	l := logger.StdlibLogger(ctx)
 
 	// Validate request
@@ -33,6 +38,8 @@ func (r *redisCapacityManager) ExtendLease(ctx context.Context, req *CapacityExt
 		"source", req.Source,
 		"migration", req.Migration,
 	)
+	// Store configured logger in context so scoped loggers can reuse its fields
+	ctx = logger.WithStdlib(ctx, l)
 
 	now := r.clock.Now()
 
@@ -113,9 +120,7 @@ func (r *redisCapacityManager) ExtendLease(ctx context.Context, req *CapacityExt
 		// TODO: Track status (1: cleaned up, 2: cleaned up or lease superseded, 3: lease expired)
 		return res, nil
 	case 4:
-		if r.enableHighCardinalityInstrumentation != nil && r.enableHighCardinalityInstrumentation(ctx, req.AccountID, uuid.Nil, uuid.Nil) {
-			l.Debug("lease extended")
-		}
+		logger.StdlibLogger(conditional.WithScope(ctx, "constraintapi.HighCardinality")).Debug("lease extended")
 
 		if len(r.lifecycles) > 0 {
 			for _, hook := range r.lifecycles {

--- a/pkg/constraintapi/extend.go
+++ b/pkg/constraintapi/extend.go
@@ -120,7 +120,7 @@ func (r *redisCapacityManager) ExtendLease(ctx context.Context, req *CapacityExt
 		// TODO: Track status (1: cleaned up, 2: cleaned up or lease superseded, 3: lease expired)
 		return res, nil
 	case 4:
-		logger.StdlibLogger(conditional.WithScope(ctx, "constraintapi.HighCardinality")).Debug("lease extended")
+		conditional.Logger(ctx, "constraintapi.ExtendLease").Debug("lease extended")
 
 		if len(r.lifecycles) > 0 {
 			for _, hook := range r.lifecycles {

--- a/pkg/constraintapi/release.go
+++ b/pkg/constraintapi/release.go
@@ -106,7 +106,7 @@ func (r *redisCapacityManager) Release(ctx context.Context, req *CapacityRelease
 		// TODO: Track status (1: cleaned up, 2: cleaned up)
 		return res, nil
 	case 3:
-		logger.StdlibLogger(conditional.WithScope(ctx, "constraintapi.HighCardinality")).Debug("capacity released")
+		conditional.Logger(ctx, "constraintapi.Release").Debug("capacity released")
 
 		if len(r.lifecycles) > 0 {
 			for _, hook := range r.lifecycles {

--- a/pkg/constraintapi/release.go
+++ b/pkg/constraintapi/release.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/telemetry/conditional"
 	"github.com/inngest/inngest/pkg/util/errs"
 )
 
@@ -21,6 +21,11 @@ type releaseScriptResponse struct {
 
 // Release implements CapacityManager.
 func (r *redisCapacityManager) Release(ctx context.Context, req *CapacityReleaseRequest) (*CapacityReleaseResponse, errs.InternalError) {
+	// Set up conditional observability context for feature flag evaluation
+	ctx = conditional.WithContext(ctx,
+		conditional.WithAccountID(req.AccountID),
+	)
+
 	l := logger.StdlibLogger(ctx)
 
 	// Validate request
@@ -34,6 +39,8 @@ func (r *redisCapacityManager) Release(ctx context.Context, req *CapacityRelease
 		"source", req.Source,
 		"migration", req.Migration,
 	)
+	// Store configured logger in context so scoped loggers can reuse its fields
+	ctx = logger.WithStdlib(ctx, l)
 
 	// Retrieve client and key prefix for current constraints
 	// NOTE: We will no longer need this once we move to a dedicated store for constraint state
@@ -99,9 +106,7 @@ func (r *redisCapacityManager) Release(ctx context.Context, req *CapacityRelease
 		// TODO: Track status (1: cleaned up, 2: cleaned up)
 		return res, nil
 	case 3:
-		if r.enableHighCardinalityInstrumentation != nil && r.enableHighCardinalityInstrumentation(ctx, req.AccountID, uuid.Nil, uuid.Nil) {
-			l.Debug("capacity released")
-		}
+		logger.StdlibLogger(conditional.WithScope(ctx, "constraintapi.HighCardinality")).Debug("capacity released")
 
 		if len(r.lifecycles) > 0 {
 			for _, hook := range r.lifecycles {

--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -210,7 +210,7 @@ func (q *queueProcessor) ProcessItem(
 				}
 
 				// Record current + next lease if high-cardinality instrumentation is enabled
-				logger.StdlibLogger(conditional.WithScope(ctx, "queue.CapacityLease")).Debug(
+				conditional.Logger(ctx, "queue.CapacityLease").Debug(
 					"extended capacity lease",
 					"last_extension", time.Since(lastCapacityLeaseExtension),
 					"lease_id", currentCapacityLease.String(),
@@ -320,7 +320,7 @@ func (q *queueProcessor) ProcessItem(
 			extendCapacityLeaseTick.Stop()
 
 			if leaseID := capacityLeaseID.get(); leaseID != nil {
-				logger.StdlibLogger(conditional.WithScope(ctx, "queue.CapacityLease")).Debug(
+				conditional.Logger(ctx, "queue.CapacityLease").Debug(
 					"stopping lease extension", "lease_id", leaseID.String(),
 				)
 			}
@@ -384,7 +384,7 @@ func (q *queueProcessor) ProcessItem(
 				return
 			}
 
-			logger.StdlibLogger(conditional.WithScope(ctx, "queue.CapacityLease")).Debug(
+			conditional.Logger(ctx, "queue.CapacityLease").Debug(
 				"released capacity lease",
 				"res", res,
 				"lease_id", currentLeaseID.String(),

--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -11,6 +11,7 @@ import (
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/service"
+	"github.com/inngest/inngest/pkg/telemetry/conditional"
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -22,6 +23,14 @@ func (q *queueProcessor) ProcessItem(
 ) error {
 	accountID, envID, fnID, runID := i.I.Data.Identifier.AccountID, i.I.Data.Identifier.WorkspaceID, i.I.Data.Identifier.WorkflowID, i.I.Data.Identifier.RunID
 
+	// Set up conditional observability context for feature flag evaluation
+	ctx = conditional.WithContext(ctx,
+		conditional.WithAccountID(accountID),
+		conditional.WithEnvID(envID),
+		conditional.WithFunctionID(fnID),
+		conditional.WithRunID(runID),
+	)
+
 	l := logger.StdlibLogger(ctx).With(
 		"item_id", i.I.ID,
 		"account_id", accountID,
@@ -29,6 +38,8 @@ func (q *queueProcessor) ProcessItem(
 		"fn_id", fnID,
 		"partition_id", i.P.ID,
 	)
+	// Store configured logger in context so scoped loggers can reuse its fields
+	ctx = logger.WithStdlib(ctx, l)
 
 	ctx, span := q.ConditionalTracer.NewSpan(ctx, "queue.ProcessItem", accountID, envID)
 	defer span.End()
@@ -55,7 +66,6 @@ func (q *queueProcessor) ProcessItem(
 	defer extendLeaseTick.Stop()
 
 	capacityLeaseID := newCapacityLease(i.CapacityLease)
-	instrumentCapacityLease := i.CapacityLease != nil && q.EnableCapacityLeaseInstrumentation != nil && q.EnableCapacityLeaseInstrumentation(ctx, accountID, envID, fnID)
 
 	disableConstraintUpdates := i.DisableConstraintUpdates
 	extendCapacityLeaseTick := q.Clock().NewTicker(q.CapacityLeaseExtendInterval)
@@ -200,14 +210,12 @@ func (q *queueProcessor) ProcessItem(
 				}
 
 				// Record current + next lease if high-cardinality instrumentation is enabled
-				if instrumentCapacityLease {
-					l.Debug(
-						"extended capacity lease",
-						"last_extension", time.Since(lastCapacityLeaseExtension),
-						"lease_id", currentCapacityLease.String(),
-						"next_lease", res.LeaseID.String(),
-					)
-				}
+				logger.StdlibLogger(conditional.WithScope(ctx, "queue.CapacityLease")).Debug(
+					"extended capacity lease",
+					"last_extension", time.Since(lastCapacityLeaseExtension),
+					"lease_id", currentCapacityLease.String(),
+					"next_lease", res.LeaseID.String(),
+				)
 
 				// Update capacity lease
 				capacityLeaseID.set(res.LeaseID)
@@ -311,8 +319,10 @@ func (q *queueProcessor) ProcessItem(
 			extendLeaseTick.Stop()
 			extendCapacityLeaseTick.Stop()
 
-			if leaseID := capacityLeaseID.get(); leaseID != nil && instrumentCapacityLease {
-				l.Debug("stopping lease extension", "lease_id", leaseID.String())
+			if leaseID := capacityLeaseID.get(); leaseID != nil {
+				logger.StdlibLogger(conditional.WithScope(ctx, "queue.CapacityLease")).Debug(
+					"stopping lease extension", "lease_id", leaseID.String(),
+				)
 			}
 		}
 
@@ -374,13 +384,11 @@ func (q *queueProcessor) ProcessItem(
 				return
 			}
 
-			if instrumentCapacityLease {
-				l.Debug(
-					"released capacity lease",
-					"res", res,
-					"lease_id", currentLeaseID.String(),
-				)
-			}
+			logger.StdlibLogger(conditional.WithScope(ctx, "queue.CapacityLease")).Debug(
+				"released capacity lease",
+				"res", res,
+				"lease_id", currentLeaseID.String(),
+			)
 		})
 	}
 

--- a/pkg/telemetry/conditional/context.go
+++ b/pkg/telemetry/conditional/context.go
@@ -1,0 +1,145 @@
+package conditional
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	statev1 "github.com/inngest/inngest/pkg/execution/state"
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/oklog/ulid/v2"
+)
+
+type contextKey struct{}
+
+var ffContextKey = contextKey{}
+
+// ContextOption is a functional option for configuring FeatureFlagContext.
+type ContextOption func(*FeatureFlagContext)
+
+// WithAccountID sets the AccountID in the FeatureFlagContext.
+func WithAccountID(id uuid.UUID) ContextOption {
+	return func(f *FeatureFlagContext) {
+		f.AccountID = id
+	}
+}
+
+// WithEnvID sets the EnvID in the FeatureFlagContext.
+func WithEnvID(id uuid.UUID) ContextOption {
+	return func(f *FeatureFlagContext) {
+		f.EnvID = id
+	}
+}
+
+// WithFunctionID sets the FunctionID in the FeatureFlagContext.
+func WithFunctionID(id uuid.UUID) ContextOption {
+	return func(f *FeatureFlagContext) {
+		f.FunctionID = id
+	}
+}
+
+// WithRunID sets the RunID in the FeatureFlagContext.
+func WithRunID(id ulid.ULID) ContextOption {
+	return func(f *FeatureFlagContext) {
+		f.RunID = id
+	}
+}
+
+// WithEventID sets the EventID in the FeatureFlagContext.
+func WithEventID(id ulid.ULID) ContextOption {
+	return func(f *FeatureFlagContext) {
+		f.EventID = id
+	}
+}
+
+// WithBillingPlan sets the BillingPlan in the FeatureFlagContext.
+func WithBillingPlan(plan string) ContextOption {
+	return func(f *FeatureFlagContext) {
+		f.BillingPlan = plan
+	}
+}
+
+// WithExtra sets a custom key-value pair in the Extra map.
+func WithExtra(key string, value any) ContextOption {
+	return func(f *FeatureFlagContext) {
+		if f.Extra == nil {
+			f.Extra = make(map[string]any)
+		}
+		f.Extra[key] = value
+	}
+}
+
+// FromStateID returns ContextOptions to populate a FeatureFlagContext from a statev2.ID.
+func FromStateID(id statev2.ID) []ContextOption {
+	return []ContextOption{
+		WithAccountID(id.Tenant.AccountID),
+		WithEnvID(id.Tenant.EnvID),
+		WithFunctionID(id.FunctionID),
+		WithRunID(id.RunID),
+	}
+}
+
+// FromIdentifier returns ContextOptions to populate a FeatureFlagContext from a statev1.Identifier.
+func FromIdentifier(id statev1.Identifier) []ContextOption {
+	opts := []ContextOption{
+		WithAccountID(id.AccountID),
+		WithEnvID(id.WorkspaceID),
+		WithFunctionID(id.WorkflowID),
+		WithRunID(id.RunID),
+	}
+	// Only set EventID if it's non-zero
+	if id.EventID.Compare(ulid.ULID{}) != 0 {
+		opts = append(opts, WithEventID(id.EventID))
+	}
+	return opts
+}
+
+// FromMetadata returns ContextOptions to populate a FeatureFlagContext from statev2.Metadata.
+func FromMetadata(md statev2.Metadata) []ContextOption {
+	opts := FromStateID(md.ID)
+	eventID := md.Config.EventID()
+	if eventID.Compare(ulid.ULID{}) != 0 {
+		opts = append(opts, WithEventID(eventID))
+	}
+	return opts
+}
+
+// WithContext creates a new context with a fresh FeatureFlagContext configured with the given options.
+// Use this at request/job entry points to establish the observability context.
+func WithContext(ctx context.Context, opts ...ContextOption) context.Context {
+	ffCtx := FeatureFlagContext{}
+	for _, opt := range opts {
+		opt(&ffCtx)
+	}
+	return context.WithValue(ctx, ffContextKey, &ffCtx)
+}
+
+// AddToContext merges additional options into an existing FeatureFlagContext in the context.
+// If no FeatureFlagContext exists, it creates a new one.
+// Use this when you need to add more identifiers later in the request flow.
+func AddToContext(ctx context.Context, opts ...ContextOption) context.Context {
+	existing := GetFromContext(ctx)
+	// Clone to avoid mutating the original
+	ffCtx := existing.Clone()
+	for _, opt := range opts {
+		opt(&ffCtx)
+	}
+	return context.WithValue(ctx, ffContextKey, &ffCtx)
+}
+
+// GetFromContext retrieves the FeatureFlagContext from the context.
+// Returns an empty FeatureFlagContext if none is set.
+func GetFromContext(ctx context.Context) FeatureFlagContext {
+	v := ctx.Value(ffContextKey)
+	if v == nil {
+		return FeatureFlagContext{}
+	}
+	if ffCtx, ok := v.(*FeatureFlagContext); ok {
+		return *ffCtx
+	}
+	return FeatureFlagContext{}
+}
+
+// HasContext returns true if a FeatureFlagContext is present in the context.
+func HasContext(ctx context.Context) bool {
+	return ctx.Value(ffContextKey) != nil
+}

--- a/pkg/telemetry/conditional/context_test.go
+++ b/pkg/telemetry/conditional/context_test.go
@@ -1,0 +1,222 @@
+package conditional
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	statev1 "github.com/inngest/inngest/pkg/execution/state"
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContextOptions(t *testing.T) {
+	t.Run("WithAccountID", func(t *testing.T) {
+		id := uuid.New()
+		ctx := FeatureFlagContext{}
+		WithAccountID(id)(&ctx)
+		require.Equal(t, id, ctx.AccountID)
+	})
+
+	t.Run("WithEnvID", func(t *testing.T) {
+		id := uuid.New()
+		ctx := FeatureFlagContext{}
+		WithEnvID(id)(&ctx)
+		require.Equal(t, id, ctx.EnvID)
+	})
+
+	t.Run("WithFunctionID", func(t *testing.T) {
+		id := uuid.New()
+		ctx := FeatureFlagContext{}
+		WithFunctionID(id)(&ctx)
+		require.Equal(t, id, ctx.FunctionID)
+	})
+
+	t.Run("WithRunID", func(t *testing.T) {
+		id := ulid.Make()
+		ctx := FeatureFlagContext{}
+		WithRunID(id)(&ctx)
+		require.Equal(t, id, ctx.RunID)
+	})
+
+	t.Run("WithEventID", func(t *testing.T) {
+		id := ulid.Make()
+		ctx := FeatureFlagContext{}
+		WithEventID(id)(&ctx)
+		require.Equal(t, id, ctx.EventID)
+	})
+
+	t.Run("WithBillingPlan", func(t *testing.T) {
+		ctx := FeatureFlagContext{}
+		WithBillingPlan("enterprise")(&ctx)
+		require.Equal(t, "enterprise", ctx.BillingPlan)
+	})
+
+	t.Run("WithExtra", func(t *testing.T) {
+		ctx := FeatureFlagContext{}
+		WithExtra("key", "value")(&ctx)
+		require.Equal(t, "value", ctx.Extra["key"])
+
+		// Add another key
+		WithExtra("key2", 42)(&ctx)
+		require.Equal(t, "value", ctx.Extra["key"])
+		require.Equal(t, 42, ctx.Extra["key2"])
+	})
+}
+
+func TestFromStateID(t *testing.T) {
+	stateID := statev2.ID{
+		RunID:      ulid.Make(),
+		FunctionID: uuid.New(),
+		Tenant: statev2.Tenant{
+			AccountID: uuid.New(),
+			EnvID:     uuid.New(),
+			AppID:     uuid.New(),
+		},
+	}
+
+	opts := FromStateID(stateID)
+	require.Len(t, opts, 4)
+
+	ctx := FeatureFlagContext{}
+	for _, opt := range opts {
+		opt(&ctx)
+	}
+
+	require.Equal(t, stateID.Tenant.AccountID, ctx.AccountID)
+	require.Equal(t, stateID.Tenant.EnvID, ctx.EnvID)
+	require.Equal(t, stateID.FunctionID, ctx.FunctionID)
+	require.Equal(t, stateID.RunID, ctx.RunID)
+}
+
+func TestFromIdentifier(t *testing.T) {
+	eventID := ulid.Make()
+	identifier := statev1.Identifier{
+		RunID:       ulid.Make(),
+		WorkflowID:  uuid.New(),
+		AccountID:   uuid.New(),
+		WorkspaceID: uuid.New(),
+		EventID:     eventID,
+	}
+
+	opts := FromIdentifier(identifier)
+	require.Len(t, opts, 5) // includes EventID
+
+	ctx := FeatureFlagContext{}
+	for _, opt := range opts {
+		opt(&ctx)
+	}
+
+	require.Equal(t, identifier.AccountID, ctx.AccountID)
+	require.Equal(t, identifier.WorkspaceID, ctx.EnvID)
+	require.Equal(t, identifier.WorkflowID, ctx.FunctionID)
+	require.Equal(t, identifier.RunID, ctx.RunID)
+	require.Equal(t, identifier.EventID, ctx.EventID)
+}
+
+func TestFromIdentifier_ZeroEventID(t *testing.T) {
+	identifier := statev1.Identifier{
+		RunID:       ulid.Make(),
+		WorkflowID:  uuid.New(),
+		AccountID:   uuid.New(),
+		WorkspaceID: uuid.New(),
+		// EventID is zero
+	}
+
+	opts := FromIdentifier(identifier)
+	require.Len(t, opts, 4) // EventID not included when zero
+
+	ctx := FeatureFlagContext{}
+	for _, opt := range opts {
+		opt(&ctx)
+	}
+
+	require.False(t, ctx.HasEventID())
+}
+
+func TestWithContext(t *testing.T) {
+	accountID := uuid.New()
+	envID := uuid.New()
+
+	ctx := WithContext(context.Background(),
+		WithAccountID(accountID),
+		WithEnvID(envID),
+	)
+
+	ffCtx := GetFromContext(ctx)
+	require.Equal(t, accountID, ffCtx.AccountID)
+	require.Equal(t, envID, ffCtx.EnvID)
+}
+
+func TestAddToContext(t *testing.T) {
+	accountID := uuid.New()
+	envID := uuid.New()
+	runID := ulid.Make()
+
+	// Start with account and env
+	ctx := WithContext(context.Background(),
+		WithAccountID(accountID),
+		WithEnvID(envID),
+	)
+
+	// Add run ID later
+	ctx = AddToContext(ctx, WithRunID(runID))
+
+	ffCtx := GetFromContext(ctx)
+	require.Equal(t, accountID, ffCtx.AccountID)
+	require.Equal(t, envID, ffCtx.EnvID)
+	require.Equal(t, runID, ffCtx.RunID)
+}
+
+func TestAddToContext_NoExistingContext(t *testing.T) {
+	accountID := uuid.New()
+
+	// AddToContext on a context with no FeatureFlagContext
+	ctx := AddToContext(context.Background(), WithAccountID(accountID))
+
+	ffCtx := GetFromContext(ctx)
+	require.Equal(t, accountID, ffCtx.AccountID)
+}
+
+func TestAddToContext_DoesNotMutateOriginal(t *testing.T) {
+	accountID := uuid.New()
+	envID := uuid.New()
+
+	ctx1 := WithContext(context.Background(),
+		WithAccountID(accountID),
+		WithExtra("key", "value1"),
+	)
+
+	ctx2 := AddToContext(ctx1,
+		WithEnvID(envID),
+		WithExtra("key", "value2"),
+	)
+
+	// Original context should be unchanged
+	ffCtx1 := GetFromContext(ctx1)
+	require.False(t, ffCtx1.HasEnvID())
+	require.Equal(t, "value1", ffCtx1.Extra["key"])
+
+	// New context should have merged values
+	ffCtx2 := GetFromContext(ctx2)
+	require.Equal(t, accountID, ffCtx2.AccountID)
+	require.Equal(t, envID, ffCtx2.EnvID)
+	require.Equal(t, "value2", ffCtx2.Extra["key"])
+}
+
+func TestGetFromContext_NoContext(t *testing.T) {
+	ffCtx := GetFromContext(context.Background())
+	require.Equal(t, FeatureFlagContext{}, ffCtx)
+}
+
+func TestHasContext(t *testing.T) {
+	t.Run("no context", func(t *testing.T) {
+		require.False(t, HasContext(context.Background()))
+	})
+
+	t.Run("with context", func(t *testing.T) {
+		ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+		require.True(t, HasContext(ctx))
+	})
+}

--- a/pkg/telemetry/conditional/context_test.go
+++ b/pkg/telemetry/conditional/context_test.go
@@ -220,3 +220,53 @@ func TestHasContext(t *testing.T) {
 		require.True(t, HasContext(ctx))
 	})
 }
+
+func TestWithScope(t *testing.T) {
+	ctx := WithScope(context.Background(), "test.Scope")
+
+	scope, ok := ScopeFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, "test.Scope", scope)
+}
+
+func TestScopeFromContext(t *testing.T) {
+	t.Run("no scope", func(t *testing.T) {
+		scope, ok := ScopeFromContext(context.Background())
+		require.False(t, ok)
+		require.Empty(t, scope)
+	})
+
+	t.Run("with scope", func(t *testing.T) {
+		ctx := WithScope(context.Background(), "my.Scope")
+		scope, ok := ScopeFromContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, "my.Scope", scope)
+	})
+}
+
+func TestHasScope(t *testing.T) {
+	t.Run("no scope", func(t *testing.T) {
+		require.False(t, HasScope(context.Background()))
+	})
+
+	t.Run("with scope", func(t *testing.T) {
+		ctx := WithScope(context.Background(), "test.Scope")
+		require.True(t, HasScope(ctx))
+	})
+}
+
+func TestScopeAndFeatureFlagContextTogether(t *testing.T) {
+	accountID := uuid.New()
+
+	// Set both feature flag context and scope
+	ctx := WithContext(context.Background(), WithAccountID(accountID))
+	ctx = WithScope(ctx, "queue.Process")
+
+	// Both should be retrievable
+	ffCtx := GetFromContext(ctx)
+	require.Equal(t, accountID, ffCtx.AccountID)
+
+	scope, ok := ScopeFromContext(ctx)
+	require.True(t, ok)
+	require.Equal(t, "queue.Process", scope)
+}

--- a/pkg/telemetry/conditional/feature_flag.go
+++ b/pkg/telemetry/conditional/feature_flag.go
@@ -1,0 +1,127 @@
+package conditional
+
+import (
+	"context"
+	"sync"
+)
+
+// FeatureFlagFn is the function signature for feature flag evaluation.
+// It receives the context, all identifiers in FeatureFlagContext, the observability type,
+// and the scope, and returns whether the observability should be enabled.
+type FeatureFlagFn func(
+	ctx context.Context,
+	ffCtx FeatureFlagContext,
+	observabilityType ObservabilityType,
+	scope string,
+) bool
+
+var (
+	globalFeatureFlagFn FeatureFlagFn
+	globalMu            sync.RWMutex
+)
+
+// RegisterFeatureFlag registers a global feature flag function for conditional observability.
+// This should be called once at application startup.
+// The function is thread-safe and can be called multiple times to replace the existing function.
+func RegisterFeatureFlag(fn FeatureFlagFn) {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	globalFeatureFlagFn = fn
+}
+
+// GetFeatureFlagFn returns the currently registered feature flag function.
+// Returns nil if no function has been registered.
+func GetFeatureFlagFn() FeatureFlagFn {
+	globalMu.RLock()
+	defer globalMu.RUnlock()
+	return globalFeatureFlagFn
+}
+
+// IsEnabled checks if observability is enabled for the given parameters.
+// If no feature flag function is registered, returns false.
+func IsEnabled(
+	ctx context.Context,
+	ffCtx FeatureFlagContext,
+	observabilityType ObservabilityType,
+	scope string,
+) bool {
+	globalMu.RLock()
+	fn := globalFeatureFlagFn
+	globalMu.RUnlock()
+
+	if fn == nil {
+		return false
+	}
+	return fn(ctx, ffCtx, observabilityType, scope)
+}
+
+// IsEnabledFromContext checks if observability is enabled using the FeatureFlagContext
+// stored in the context.Context. If no FeatureFlagContext is present, returns false.
+func IsEnabledFromContext(
+	ctx context.Context,
+	observabilityType ObservabilityType,
+	scope string,
+) bool {
+	ffCtx := GetFromContext(ctx)
+	return IsEnabled(ctx, ffCtx, observabilityType, scope)
+}
+
+// IsLoggingEnabled is a convenience function that checks if logging is enabled
+// for the given scope using the FeatureFlagContext from the context.
+func IsLoggingEnabled(ctx context.Context, scope string) bool {
+	return IsEnabledFromContext(ctx, ObservabilityTypeLogs, scope)
+}
+
+// IsMetricsEnabled is a convenience function that checks if metrics are enabled
+// for the given scope using the FeatureFlagContext from the context.
+func IsMetricsEnabled(ctx context.Context, scope string) bool {
+	return IsEnabledFromContext(ctx, ObservabilityTypeMetrics, scope)
+}
+
+// IsTracingEnabled is a convenience function that checks if tracing is enabled
+// for the given scope using the FeatureFlagContext from the context.
+func IsTracingEnabled(ctx context.Context, scope string) bool {
+	return IsEnabledFromContext(ctx, ObservabilityTypeTraces, scope)
+}
+
+// AlwaysEnabled is a FeatureFlagFn that always returns true.
+// Useful for testing or when you want to enable all conditional observability.
+func AlwaysEnabled(_ context.Context, _ FeatureFlagContext, _ ObservabilityType, _ string) bool {
+	return true
+}
+
+// NeverEnabled is a FeatureFlagFn that always returns false.
+// Useful for testing or when you want to disable all conditional observability.
+func NeverEnabled(_ context.Context, _ FeatureFlagContext, _ ObservabilityType, _ string) bool {
+	return false
+}
+
+// ScopeEnabled returns a FeatureFlagFn that enables observability only for specific scopes.
+func ScopeEnabled(scopes ...string) FeatureFlagFn {
+	scopeSet := make(map[string]bool, len(scopes))
+	for _, s := range scopes {
+		scopeSet[s] = true
+	}
+	return func(_ context.Context, _ FeatureFlagContext, _ ObservabilityType, scope string) bool {
+		return scopeSet[scope]
+	}
+}
+
+// TypeEnabled returns a FeatureFlagFn that enables observability only for specific types.
+func TypeEnabled(types ...ObservabilityType) FeatureFlagFn {
+	typeSet := make(map[ObservabilityType]bool, len(types))
+	for _, t := range types {
+		typeSet[t] = true
+	}
+	return func(_ context.Context, _ FeatureFlagContext, obsType ObservabilityType, _ string) bool {
+		return typeSet[obsType]
+	}
+}
+
+// ClearFeatureFlag removes the registered feature flag function.
+// Primarily useful for testing.
+func ClearFeatureFlag() {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	globalFeatureFlagFn = nil
+}

--- a/pkg/telemetry/conditional/feature_flag_test.go
+++ b/pkg/telemetry/conditional/feature_flag_test.go
@@ -1,0 +1,134 @@
+package conditional
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterFeatureFlag(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	called := false
+	RegisterFeatureFlag(func(_ context.Context, _ FeatureFlagContext, _ ObservabilityType, _ string) bool {
+		called = true
+		return true
+	})
+
+	fn := GetFeatureFlagFn()
+	require.NotNil(t, fn)
+
+	result := fn(context.Background(), FeatureFlagContext{}, ObservabilityTypeLogs, "test")
+	require.True(t, called)
+	require.True(t, result)
+}
+
+func TestIsEnabled_NoFeatureFlagRegistered(t *testing.T) {
+	ClearFeatureFlag()
+
+	result := IsEnabled(context.Background(), FeatureFlagContext{}, ObservabilityTypeLogs, "test")
+	require.False(t, result)
+}
+
+func TestIsEnabled_WithFeatureFlag(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	targetAccountID := uuid.New()
+	RegisterFeatureFlag(func(_ context.Context, ffCtx FeatureFlagContext, obsType ObservabilityType, scope string) bool {
+		return ffCtx.AccountID == targetAccountID && obsType == ObservabilityTypeLogs
+	})
+
+	t.Run("matching account and type", func(t *testing.T) {
+		result := IsEnabled(context.Background(), FeatureFlagContext{
+			AccountID: targetAccountID,
+		}, ObservabilityTypeLogs, "test")
+		require.True(t, result)
+	})
+
+	t.Run("different account", func(t *testing.T) {
+		result := IsEnabled(context.Background(), FeatureFlagContext{
+			AccountID: uuid.New(),
+		}, ObservabilityTypeLogs, "test")
+		require.False(t, result)
+	})
+
+	t.Run("different type", func(t *testing.T) {
+		result := IsEnabled(context.Background(), FeatureFlagContext{
+			AccountID: targetAccountID,
+		}, ObservabilityTypeMetrics, "test")
+		require.False(t, result)
+	})
+}
+
+func TestIsEnabledFromContext(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	targetAccountID := uuid.New()
+	RegisterFeatureFlag(func(_ context.Context, ffCtx FeatureFlagContext, _ ObservabilityType, _ string) bool {
+		return ffCtx.AccountID == targetAccountID
+	})
+
+	t.Run("with matching context", func(t *testing.T) {
+		ctx := WithContext(context.Background(), WithAccountID(targetAccountID))
+		require.True(t, IsEnabledFromContext(ctx, ObservabilityTypeLogs, "test"))
+	})
+
+	t.Run("with different context", func(t *testing.T) {
+		ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+		require.False(t, IsEnabledFromContext(ctx, ObservabilityTypeLogs, "test"))
+	})
+
+	t.Run("no context", func(t *testing.T) {
+		require.False(t, IsEnabledFromContext(context.Background(), ObservabilityTypeLogs, "test"))
+	})
+}
+
+func TestConvenienceFunctions(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	RegisterFeatureFlag(func(_ context.Context, _ FeatureFlagContext, obsType ObservabilityType, _ string) bool {
+		return obsType == ObservabilityTypeLogs
+	})
+
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	require.True(t, IsLoggingEnabled(ctx, "test"))
+	require.False(t, IsMetricsEnabled(ctx, "test"))
+	require.False(t, IsTracingEnabled(ctx, "test"))
+}
+
+func TestAlwaysEnabled(t *testing.T) {
+	result := AlwaysEnabled(context.Background(), FeatureFlagContext{}, ObservabilityTypeLogs, "test")
+	require.True(t, result)
+}
+
+func TestNeverEnabled(t *testing.T) {
+	result := NeverEnabled(context.Background(), FeatureFlagContext{}, ObservabilityTypeLogs, "test")
+	require.False(t, result)
+}
+
+func TestScopeEnabled(t *testing.T) {
+	fn := ScopeEnabled("queue.Process", "constraintapi.Acquire")
+
+	require.True(t, fn(context.Background(), FeatureFlagContext{}, ObservabilityTypeLogs, "queue.Process"))
+	require.True(t, fn(context.Background(), FeatureFlagContext{}, ObservabilityTypeMetrics, "constraintapi.Acquire"))
+	require.False(t, fn(context.Background(), FeatureFlagContext{}, ObservabilityTypeLogs, "other.Scope"))
+}
+
+func TestTypeEnabled(t *testing.T) {
+	fn := TypeEnabled(ObservabilityTypeLogs, ObservabilityTypeTraces)
+
+	require.True(t, fn(context.Background(), FeatureFlagContext{}, ObservabilityTypeLogs, "any"))
+	require.True(t, fn(context.Background(), FeatureFlagContext{}, ObservabilityTypeTraces, "any"))
+	require.False(t, fn(context.Background(), FeatureFlagContext{}, ObservabilityTypeMetrics, "any"))
+}
+
+func TestClearFeatureFlag(t *testing.T) {
+	RegisterFeatureFlag(AlwaysEnabled)
+	require.NotNil(t, GetFeatureFlagFn())
+
+	ClearFeatureFlag()
+	require.Nil(t, GetFeatureFlagFn())
+}

--- a/pkg/telemetry/conditional/logger.go
+++ b/pkg/telemetry/conditional/logger.go
@@ -6,133 +6,21 @@ import (
 	"github.com/inngest/inngest/pkg/logger"
 )
 
-// ConditionalDebug logs a debug message if logging is enabled for the given scope.
-// Uses the logger from the context.
-func ConditionalDebug(ctx context.Context, scope string, msg string, args ...any) {
-	if !IsLoggingEnabled(ctx, scope) {
-		return
-	}
-	logger.From(ctx).DebugContext(ctx, msg, args...)
+// Logger returns the logger from context, respecting conditional scope if set.
+// This is a convenience wrapper that's equivalent to logger.From(ctx).
+//
+// For conditional logging, use the context-based approach:
+//
+//	logger.From(conditional.WithScope(ctx, "scope")).Info("message")
+//
+// Or the longer form:
+//
+//	ctx = conditional.WithScope(ctx, "scope")
+//	logger.From(ctx).Info("message")
+//
+// The logger.From() function automatically checks for conditional scope in the
+// context and returns a VoidLogger if the scope is disabled.
+func Logger(ctx context.Context) logger.Logger {
+	return logger.From(ctx)
 }
 
-// ConditionalInfo logs an info message if logging is enabled for the given scope.
-// Uses the logger from the context.
-func ConditionalInfo(ctx context.Context, scope string, msg string, args ...any) {
-	if !IsLoggingEnabled(ctx, scope) {
-		return
-	}
-	logger.From(ctx).InfoContext(ctx, msg, args...)
-}
-
-// ConditionalWarn logs a warning message if logging is enabled for the given scope.
-// Uses the logger from the context.
-func ConditionalWarn(ctx context.Context, scope string, msg string, args ...any) {
-	if !IsLoggingEnabled(ctx, scope) {
-		return
-	}
-	logger.From(ctx).WarnContext(ctx, msg, args...)
-}
-
-// ConditionalError logs an error message if logging is enabled for the given scope.
-// Uses the logger from the context.
-func ConditionalError(ctx context.Context, scope string, msg string, args ...any) {
-	if !IsLoggingEnabled(ctx, scope) {
-		return
-	}
-	logger.From(ctx).ErrorContext(ctx, msg, args...)
-}
-
-// ConditionalTrace logs a trace message if logging is enabled for the given scope.
-// Uses the logger from the context.
-func ConditionalTrace(ctx context.Context, scope string, msg string, args ...any) {
-	if !IsLoggingEnabled(ctx, scope) {
-		return
-	}
-	logger.From(ctx).TraceContext(ctx, msg, args...)
-}
-
-// ConditionalLogger is a scoped logger that conditionally logs based on feature flags.
-type ConditionalLogger struct {
-	logger logger.Logger
-	scope  string
-}
-
-// NewConditionalLogger creates a new ConditionalLogger with the given logger and scope.
-func NewConditionalLogger(l logger.Logger, scope string) *ConditionalLogger {
-	return &ConditionalLogger{
-		logger: l,
-		scope:  scope,
-	}
-}
-
-// NewConditionalLoggerFromContext creates a new ConditionalLogger using the logger from
-// the context and the given scope.
-func NewConditionalLoggerFromContext(ctx context.Context, scope string) *ConditionalLogger {
-	return NewConditionalLogger(logger.From(ctx), scope)
-}
-
-// Scope returns the scope of the conditional logger.
-func (l *ConditionalLogger) Scope() string {
-	return l.scope
-}
-
-// Debug logs a debug message if logging is enabled for this logger's scope.
-func (l *ConditionalLogger) Debug(ctx context.Context, msg string, args ...any) {
-	if !IsLoggingEnabled(ctx, l.scope) {
-		return
-	}
-	l.logger.DebugContext(ctx, msg, args...)
-}
-
-// Info logs an info message if logging is enabled for this logger's scope.
-func (l *ConditionalLogger) Info(ctx context.Context, msg string, args ...any) {
-	if !IsLoggingEnabled(ctx, l.scope) {
-		return
-	}
-	l.logger.InfoContext(ctx, msg, args...)
-}
-
-// Warn logs a warning message if logging is enabled for this logger's scope.
-func (l *ConditionalLogger) Warn(ctx context.Context, msg string, args ...any) {
-	if !IsLoggingEnabled(ctx, l.scope) {
-		return
-	}
-	l.logger.WarnContext(ctx, msg, args...)
-}
-
-// Error logs an error message if logging is enabled for this logger's scope.
-func (l *ConditionalLogger) Error(ctx context.Context, msg string, args ...any) {
-	if !IsLoggingEnabled(ctx, l.scope) {
-		return
-	}
-	l.logger.ErrorContext(ctx, msg, args...)
-}
-
-// Trace logs a trace message if logging is enabled for this logger's scope.
-func (l *ConditionalLogger) Trace(ctx context.Context, msg string, args ...any) {
-	if !IsLoggingEnabled(ctx, l.scope) {
-		return
-	}
-	l.logger.TraceContext(ctx, msg, args...)
-}
-
-// With returns a new ConditionalLogger with additional attributes.
-func (l *ConditionalLogger) With(args ...any) *ConditionalLogger {
-	return &ConditionalLogger{
-		logger: l.logger.With(args...),
-		scope:  l.scope,
-	}
-}
-
-// WithScope returns a new ConditionalLogger with a different scope.
-func (l *ConditionalLogger) WithScope(scope string) *ConditionalLogger {
-	return &ConditionalLogger{
-		logger: l.logger,
-		scope:  scope,
-	}
-}
-
-// Logger returns the underlying logger.
-func (l *ConditionalLogger) Logger() logger.Logger {
-	return l.logger
-}

--- a/pkg/telemetry/conditional/logger.go
+++ b/pkg/telemetry/conditional/logger.go
@@ -1,0 +1,138 @@
+package conditional
+
+import (
+	"context"
+
+	"github.com/inngest/inngest/pkg/logger"
+)
+
+// ConditionalDebug logs a debug message if logging is enabled for the given scope.
+// Uses the logger from the context.
+func ConditionalDebug(ctx context.Context, scope string, msg string, args ...any) {
+	if !IsLoggingEnabled(ctx, scope) {
+		return
+	}
+	logger.From(ctx).DebugContext(ctx, msg, args...)
+}
+
+// ConditionalInfo logs an info message if logging is enabled for the given scope.
+// Uses the logger from the context.
+func ConditionalInfo(ctx context.Context, scope string, msg string, args ...any) {
+	if !IsLoggingEnabled(ctx, scope) {
+		return
+	}
+	logger.From(ctx).InfoContext(ctx, msg, args...)
+}
+
+// ConditionalWarn logs a warning message if logging is enabled for the given scope.
+// Uses the logger from the context.
+func ConditionalWarn(ctx context.Context, scope string, msg string, args ...any) {
+	if !IsLoggingEnabled(ctx, scope) {
+		return
+	}
+	logger.From(ctx).WarnContext(ctx, msg, args...)
+}
+
+// ConditionalError logs an error message if logging is enabled for the given scope.
+// Uses the logger from the context.
+func ConditionalError(ctx context.Context, scope string, msg string, args ...any) {
+	if !IsLoggingEnabled(ctx, scope) {
+		return
+	}
+	logger.From(ctx).ErrorContext(ctx, msg, args...)
+}
+
+// ConditionalTrace logs a trace message if logging is enabled for the given scope.
+// Uses the logger from the context.
+func ConditionalTrace(ctx context.Context, scope string, msg string, args ...any) {
+	if !IsLoggingEnabled(ctx, scope) {
+		return
+	}
+	logger.From(ctx).TraceContext(ctx, msg, args...)
+}
+
+// ConditionalLogger is a scoped logger that conditionally logs based on feature flags.
+type ConditionalLogger struct {
+	logger logger.Logger
+	scope  string
+}
+
+// NewConditionalLogger creates a new ConditionalLogger with the given logger and scope.
+func NewConditionalLogger(l logger.Logger, scope string) *ConditionalLogger {
+	return &ConditionalLogger{
+		logger: l,
+		scope:  scope,
+	}
+}
+
+// NewConditionalLoggerFromContext creates a new ConditionalLogger using the logger from
+// the context and the given scope.
+func NewConditionalLoggerFromContext(ctx context.Context, scope string) *ConditionalLogger {
+	return NewConditionalLogger(logger.From(ctx), scope)
+}
+
+// Scope returns the scope of the conditional logger.
+func (l *ConditionalLogger) Scope() string {
+	return l.scope
+}
+
+// Debug logs a debug message if logging is enabled for this logger's scope.
+func (l *ConditionalLogger) Debug(ctx context.Context, msg string, args ...any) {
+	if !IsLoggingEnabled(ctx, l.scope) {
+		return
+	}
+	l.logger.DebugContext(ctx, msg, args...)
+}
+
+// Info logs an info message if logging is enabled for this logger's scope.
+func (l *ConditionalLogger) Info(ctx context.Context, msg string, args ...any) {
+	if !IsLoggingEnabled(ctx, l.scope) {
+		return
+	}
+	l.logger.InfoContext(ctx, msg, args...)
+}
+
+// Warn logs a warning message if logging is enabled for this logger's scope.
+func (l *ConditionalLogger) Warn(ctx context.Context, msg string, args ...any) {
+	if !IsLoggingEnabled(ctx, l.scope) {
+		return
+	}
+	l.logger.WarnContext(ctx, msg, args...)
+}
+
+// Error logs an error message if logging is enabled for this logger's scope.
+func (l *ConditionalLogger) Error(ctx context.Context, msg string, args ...any) {
+	if !IsLoggingEnabled(ctx, l.scope) {
+		return
+	}
+	l.logger.ErrorContext(ctx, msg, args...)
+}
+
+// Trace logs a trace message if logging is enabled for this logger's scope.
+func (l *ConditionalLogger) Trace(ctx context.Context, msg string, args ...any) {
+	if !IsLoggingEnabled(ctx, l.scope) {
+		return
+	}
+	l.logger.TraceContext(ctx, msg, args...)
+}
+
+// With returns a new ConditionalLogger with additional attributes.
+func (l *ConditionalLogger) With(args ...any) *ConditionalLogger {
+	return &ConditionalLogger{
+		logger: l.logger.With(args...),
+		scope:  l.scope,
+	}
+}
+
+// WithScope returns a new ConditionalLogger with a different scope.
+func (l *ConditionalLogger) WithScope(scope string) *ConditionalLogger {
+	return &ConditionalLogger{
+		logger: l.logger,
+		scope:  scope,
+	}
+}
+
+// Logger returns the underlying logger.
+func (l *ConditionalLogger) Logger() logger.Logger {
+	return l.logger
+}

--- a/pkg/telemetry/conditional/logger.go
+++ b/pkg/telemetry/conditional/logger.go
@@ -6,21 +6,21 @@ import (
 	"github.com/inngest/inngest/pkg/logger"
 )
 
-// Logger returns the logger from context, respecting conditional scope if set.
-// This is a convenience wrapper that's equivalent to logger.From(ctx).
+// Logger returns a logger from context. If a scope is provided,
+// the logger respects conditional observability settings for that scope.
+// Returns VoidLogger if the scope is disabled.
 //
-// For conditional logging, use the context-based approach:
+// Usage with scope (recommended for conditional logging):
 //
-//	logger.From(conditional.WithScope(ctx, "scope")).Info("message")
+//	conditional.Logger(ctx, "queue.CapacityLease").Debug("extended capacity lease")
 //
-// Or the longer form:
+// Usage without scope (equivalent to logger.From(ctx)):
 //
-//	ctx = conditional.WithScope(ctx, "scope")
-//	logger.From(ctx).Info("message")
-//
-// The logger.From() function automatically checks for conditional scope in the
-// context and returns a VoidLogger if the scope is disabled.
-func Logger(ctx context.Context) logger.Logger {
+//	conditional.Logger(ctx).Info("message")
+func Logger(ctx context.Context, scope ...string) logger.Logger {
+	if len(scope) > 0 {
+		return logger.From(WithScope(ctx, scope[0]))
+	}
 	return logger.From(ctx)
 }
 

--- a/pkg/telemetry/conditional/logger_test.go
+++ b/pkg/telemetry/conditional/logger_test.go
@@ -1,0 +1,247 @@
+package conditional
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConditionalDebug(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	buf := &bytes.Buffer{}
+	l := logger.From(context.Background(),
+		logger.WithLoggerLevel(logger.LevelDebug),
+		logger.WithLoggerWriter(buf),
+		logger.WithHandler(logger.TextHandler),
+	)
+	ctx := logger.WithStdlib(context.Background(), l)
+	ctx = WithContext(ctx, WithAccountID(uuid.New()))
+
+	t.Run("logs when enabled", func(t *testing.T) {
+		buf.Reset()
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		ConditionalDebug(ctx, "test.Scope", "test message", "key", "value")
+		require.Contains(t, buf.String(), "test message")
+		require.Contains(t, buf.String(), "key=value")
+	})
+
+	t.Run("does not log when disabled", func(t *testing.T) {
+		buf.Reset()
+		RegisterFeatureFlag(NeverEnabled)
+
+		ConditionalDebug(ctx, "test.Scope", "test message", "key", "value")
+		require.Empty(t, buf.String())
+	})
+}
+
+func TestConditionalInfo(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	buf := &bytes.Buffer{}
+	l := logger.From(context.Background(),
+		logger.WithLoggerLevel(logger.LevelInfo),
+		logger.WithLoggerWriter(buf),
+		logger.WithHandler(logger.TextHandler),
+	)
+	ctx := logger.WithStdlib(context.Background(), l)
+	ctx = WithContext(ctx, WithAccountID(uuid.New()))
+
+	t.Run("logs when enabled", func(t *testing.T) {
+		buf.Reset()
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		ConditionalInfo(ctx, "test.Scope", "info message")
+		require.Contains(t, buf.String(), "info message")
+	})
+
+	t.Run("does not log when disabled", func(t *testing.T) {
+		buf.Reset()
+		RegisterFeatureFlag(NeverEnabled)
+
+		ConditionalInfo(ctx, "test.Scope", "info message")
+		require.Empty(t, buf.String())
+	})
+}
+
+func TestConditionalWarn(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	buf := &bytes.Buffer{}
+	l := logger.From(context.Background(),
+		logger.WithLoggerLevel(logger.LevelWarning),
+		logger.WithLoggerWriter(buf),
+		logger.WithHandler(logger.TextHandler),
+	)
+	ctx := logger.WithStdlib(context.Background(), l)
+	ctx = WithContext(ctx, WithAccountID(uuid.New()))
+
+	t.Run("logs when enabled", func(t *testing.T) {
+		buf.Reset()
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		ConditionalWarn(ctx, "test.Scope", "warn message")
+		require.Contains(t, buf.String(), "warn message")
+	})
+
+	t.Run("does not log when disabled", func(t *testing.T) {
+		buf.Reset()
+		RegisterFeatureFlag(NeverEnabled)
+
+		ConditionalWarn(ctx, "test.Scope", "warn message")
+		require.Empty(t, buf.String())
+	})
+}
+
+func TestConditionalError(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	buf := &bytes.Buffer{}
+	l := logger.From(context.Background(),
+		logger.WithLoggerLevel(logger.LevelError),
+		logger.WithLoggerWriter(buf),
+		logger.WithHandler(logger.TextHandler),
+	)
+	ctx := logger.WithStdlib(context.Background(), l)
+	ctx = WithContext(ctx, WithAccountID(uuid.New()))
+
+	t.Run("logs when enabled", func(t *testing.T) {
+		buf.Reset()
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		ConditionalError(ctx, "test.Scope", "error message")
+		require.Contains(t, buf.String(), "error message")
+	})
+
+	t.Run("does not log when disabled", func(t *testing.T) {
+		buf.Reset()
+		RegisterFeatureFlag(NeverEnabled)
+
+		ConditionalError(ctx, "test.Scope", "error message")
+		require.Empty(t, buf.String())
+	})
+}
+
+func TestConditionalLogger(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	buf := &bytes.Buffer{}
+	l := logger.From(context.Background(),
+		logger.WithLoggerLevel(logger.LevelDebug),
+		logger.WithLoggerWriter(buf),
+		logger.WithHandler(logger.TextHandler),
+	)
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	t.Run("scoped logger logs when enabled", func(t *testing.T) {
+		buf.Reset()
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		cl := NewConditionalLogger(l, "test.Scope")
+		require.Equal(t, "test.Scope", cl.Scope())
+
+		cl.Debug(ctx, "debug message", "key", "value")
+		require.Contains(t, buf.String(), "debug message")
+	})
+
+	t.Run("scoped logger does not log when disabled", func(t *testing.T) {
+		buf.Reset()
+		RegisterFeatureFlag(NeverEnabled)
+
+		cl := NewConditionalLogger(l, "test.Scope")
+		cl.Debug(ctx, "debug message")
+		require.Empty(t, buf.String())
+	})
+
+	t.Run("With returns new logger with attributes", func(t *testing.T) {
+		buf.Reset()
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		cl := NewConditionalLogger(l, "test.Scope")
+		cl2 := cl.With("attr", "value")
+
+		require.NotSame(t, cl, cl2)
+		require.Equal(t, cl.Scope(), cl2.Scope())
+
+		cl2.Info(ctx, "info message")
+		require.Contains(t, buf.String(), "attr=value")
+	})
+
+	t.Run("WithScope returns new logger with different scope", func(t *testing.T) {
+		buf.Reset()
+		RegisterFeatureFlag(ScopeEnabled("new.Scope"))
+
+		cl := NewConditionalLogger(l, "test.Scope")
+		cl2 := cl.WithScope("new.Scope")
+
+		require.Equal(t, "test.Scope", cl.Scope())
+		require.Equal(t, "new.Scope", cl2.Scope())
+
+		// Original scope disabled
+		cl.Info(ctx, "message 1")
+		require.Empty(t, buf.String())
+
+		// New scope enabled
+		cl2.Info(ctx, "message 2")
+		require.Contains(t, buf.String(), "message 2")
+	})
+}
+
+func TestNewConditionalLoggerFromContext(t *testing.T) {
+	defer ClearFeatureFlag()
+	RegisterFeatureFlag(AlwaysEnabled)
+
+	buf := &bytes.Buffer{}
+	l := logger.From(context.Background(),
+		logger.WithLoggerLevel(logger.LevelDebug),
+		logger.WithLoggerWriter(buf),
+		logger.WithHandler(logger.TextHandler),
+	)
+	ctx := logger.WithStdlib(context.Background(), l)
+	ctx = WithContext(ctx, WithAccountID(uuid.New()))
+
+	cl := NewConditionalLoggerFromContext(ctx, "test.Scope")
+	cl.Debug(ctx, "test message")
+	require.Contains(t, buf.String(), "test message")
+}
+
+func TestConditionalLogger_AllLevels(t *testing.T) {
+	defer ClearFeatureFlag()
+	RegisterFeatureFlag(AlwaysEnabled)
+
+	buf := &bytes.Buffer{}
+	l := logger.From(context.Background(),
+		logger.WithLoggerLevel(logger.LevelTrace),
+		logger.WithLoggerWriter(buf),
+		logger.WithHandler(logger.TextHandler),
+	)
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	cl := NewConditionalLogger(l, "test.Scope")
+
+	tests := []struct {
+		name  string
+		logFn func(context.Context, string, ...any)
+		level string
+		msg   string
+	}{
+		{"trace", cl.Trace, "TRACE", "trace msg"},
+		{"debug", cl.Debug, "DEBUG", "debug msg"},
+		{"info", cl.Info, "INFO", "info msg"},
+		{"warn", cl.Warn, "WARN", "warn msg"},
+		{"error", cl.Error, "ERROR", "error msg"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf.Reset()
+			tt.logFn(ctx, tt.msg)
+			require.Contains(t, buf.String(), tt.msg)
+		})
+	}
+}

--- a/pkg/telemetry/conditional/metrics.go
+++ b/pkg/telemetry/conditional/metrics.go
@@ -6,6 +6,25 @@ import (
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 )
 
+func init() {
+	// Register the conditional metrics check with the metrics package.
+	// This enables metrics.Record*Metric() to automatically check conditional scopes.
+	metrics.RegisterConditionalCheck(conditionalMetricsCheck)
+}
+
+// conditionalMetricsCheck is called by metrics.Record*Metric() functions to determine
+// if metrics should be recorded for the current context. Returns true if metrics should
+// proceed, false if they should be skipped.
+func conditionalMetricsCheck(ctx context.Context) bool {
+	scope, ok := ScopeFromContext(ctx)
+	if !ok {
+		// No scope set, metrics proceed normally
+		return true
+	}
+	// Scope is set, check if metrics are enabled for this scope
+	return IsMetricsEnabled(ctx, scope)
+}
+
 // ConditionalCounterOpt extends metrics.CounterOpt with a Scope for conditional recording.
 type ConditionalCounterOpt struct {
 	metrics.CounterOpt

--- a/pkg/telemetry/conditional/metrics.go
+++ b/pkg/telemetry/conditional/metrics.go
@@ -1,0 +1,114 @@
+package conditional
+
+import (
+	"context"
+
+	"github.com/inngest/inngest/pkg/telemetry/metrics"
+)
+
+// ConditionalCounterOpt extends metrics.CounterOpt with a Scope for conditional recording.
+type ConditionalCounterOpt struct {
+	metrics.CounterOpt
+	Scope string
+}
+
+// ConditionalGaugeOpt extends metrics.GaugeOpt with a Scope for conditional recording.
+type ConditionalGaugeOpt struct {
+	metrics.GaugeOpt
+	Scope string
+}
+
+// ConditionalHistogramOpt extends metrics.HistogramOpt with a Scope for conditional recording.
+type ConditionalHistogramOpt struct {
+	metrics.HistogramOpt
+	Scope string
+}
+
+// RecordConditionalCounter records a counter metric if metrics are enabled for the given scope.
+func RecordConditionalCounter(ctx context.Context, incr int64, opts ConditionalCounterOpt) {
+	if !IsMetricsEnabled(ctx, opts.Scope) {
+		return
+	}
+	metrics.RecordCounterMetric(ctx, incr, opts.CounterOpt)
+}
+
+// RecordConditionalUpDownCounter records an up-down counter metric if metrics are enabled for the given scope.
+func RecordConditionalUpDownCounter(ctx context.Context, val int64, opts ConditionalCounterOpt) {
+	if !IsMetricsEnabled(ctx, opts.Scope) {
+		return
+	}
+	metrics.RecordUpDownCounterMetric(ctx, val, opts.CounterOpt)
+}
+
+// RecordConditionalGauge records a gauge metric if metrics are enabled for the given scope.
+func RecordConditionalGauge(ctx context.Context, val int64, opts ConditionalGaugeOpt) {
+	if !IsMetricsEnabled(ctx, opts.Scope) {
+		return
+	}
+	metrics.RecordGaugeMetric(ctx, val, opts.GaugeOpt)
+}
+
+// RecordConditionalHistogram records a histogram metric if metrics are enabled for the given scope.
+func RecordConditionalHistogram(ctx context.Context, value int64, opts ConditionalHistogramOpt) {
+	if !IsMetricsEnabled(ctx, opts.Scope) {
+		return
+	}
+	metrics.RecordIntHistogramMetric(ctx, value, opts.HistogramOpt)
+}
+
+// RegisterConditionalAsyncGauge registers an async gauge if metrics are enabled for the given scope.
+// Note: This checks enablement at registration time, not at observation time.
+// For dynamic enablement, use RecordConditionalGauge instead.
+func RegisterConditionalAsyncGauge(ctx context.Context, opts ConditionalGaugeOpt) {
+	if !IsMetricsEnabled(ctx, opts.Scope) {
+		return
+	}
+	metrics.RegisterAsyncGauge(ctx, opts.GaugeOpt)
+}
+
+// ScopedMetrics provides a scoped wrapper for recording conditional metrics.
+type ScopedMetrics struct {
+	scope string
+}
+
+// NewScopedMetrics creates a new ScopedMetrics with the given scope.
+func NewScopedMetrics(scope string) *ScopedMetrics {
+	return &ScopedMetrics{scope: scope}
+}
+
+// Scope returns the scope of this ScopedMetrics.
+func (s *ScopedMetrics) Scope() string {
+	return s.scope
+}
+
+// RecordCounter records a counter metric if metrics are enabled for this scope.
+func (s *ScopedMetrics) RecordCounter(ctx context.Context, incr int64, opts metrics.CounterOpt) {
+	RecordConditionalCounter(ctx, incr, ConditionalCounterOpt{
+		CounterOpt: opts,
+		Scope:      s.scope,
+	})
+}
+
+// RecordUpDownCounter records an up-down counter metric if metrics are enabled for this scope.
+func (s *ScopedMetrics) RecordUpDownCounter(ctx context.Context, val int64, opts metrics.CounterOpt) {
+	RecordConditionalUpDownCounter(ctx, val, ConditionalCounterOpt{
+		CounterOpt: opts,
+		Scope:      s.scope,
+	})
+}
+
+// RecordGauge records a gauge metric if metrics are enabled for this scope.
+func (s *ScopedMetrics) RecordGauge(ctx context.Context, val int64, opts metrics.GaugeOpt) {
+	RecordConditionalGauge(ctx, val, ConditionalGaugeOpt{
+		GaugeOpt: opts,
+		Scope:    s.scope,
+	})
+}
+
+// RecordHistogram records a histogram metric if metrics are enabled for this scope.
+func (s *ScopedMetrics) RecordHistogram(ctx context.Context, value int64, opts metrics.HistogramOpt) {
+	RecordConditionalHistogram(ctx, value, ConditionalHistogramOpt{
+		HistogramOpt: opts,
+		Scope:        s.scope,
+	})
+}

--- a/pkg/telemetry/conditional/metrics_test.go
+++ b/pkg/telemetry/conditional/metrics_test.go
@@ -1,0 +1,227 @@
+package conditional
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/telemetry/metrics"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecordConditionalCounter(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	t.Run("records when enabled", func(t *testing.T) {
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		// This should not panic - we can't easily verify the metric was recorded
+		// without setting up a full OTel pipeline, but we verify it doesn't error
+		RecordConditionalCounter(ctx, 1, ConditionalCounterOpt{
+			CounterOpt: metrics.CounterOpt{
+				PkgName:    "test",
+				MetricName: "test_counter",
+			},
+			Scope: "test.Scope",
+		})
+	})
+
+	t.Run("does not record when disabled", func(t *testing.T) {
+		RegisterFeatureFlag(NeverEnabled)
+
+		// This should return early without calling metrics
+		RecordConditionalCounter(ctx, 1, ConditionalCounterOpt{
+			CounterOpt: metrics.CounterOpt{
+				PkgName:    "test",
+				MetricName: "test_counter",
+			},
+			Scope: "test.Scope",
+		})
+	})
+}
+
+func TestRecordConditionalUpDownCounter(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	t.Run("records when enabled", func(t *testing.T) {
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		RecordConditionalUpDownCounter(ctx, 5, ConditionalCounterOpt{
+			CounterOpt: metrics.CounterOpt{
+				PkgName:    "test",
+				MetricName: "test_updown_counter",
+			},
+			Scope: "test.Scope",
+		})
+	})
+
+	t.Run("does not record when disabled", func(t *testing.T) {
+		RegisterFeatureFlag(NeverEnabled)
+
+		RecordConditionalUpDownCounter(ctx, 5, ConditionalCounterOpt{
+			CounterOpt: metrics.CounterOpt{
+				PkgName:    "test",
+				MetricName: "test_updown_counter",
+			},
+			Scope: "test.Scope",
+		})
+	})
+}
+
+func TestRecordConditionalGauge(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	t.Run("records when enabled", func(t *testing.T) {
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		RecordConditionalGauge(ctx, 42, ConditionalGaugeOpt{
+			GaugeOpt: metrics.GaugeOpt{
+				PkgName:    "test",
+				MetricName: "test_gauge",
+			},
+			Scope: "test.Scope",
+		})
+	})
+
+	t.Run("does not record when disabled", func(t *testing.T) {
+		RegisterFeatureFlag(NeverEnabled)
+
+		RecordConditionalGauge(ctx, 42, ConditionalGaugeOpt{
+			GaugeOpt: metrics.GaugeOpt{
+				PkgName:    "test",
+				MetricName: "test_gauge",
+			},
+			Scope: "test.Scope",
+		})
+	})
+}
+
+func TestRecordConditionalHistogram(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	t.Run("records when enabled", func(t *testing.T) {
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		RecordConditionalHistogram(ctx, 100, ConditionalHistogramOpt{
+			HistogramOpt: metrics.HistogramOpt{
+				PkgName:    "test",
+				MetricName: "test_histogram",
+				Boundaries: []float64{10, 50, 100, 500, 1000},
+			},
+			Scope: "test.Scope",
+		})
+	})
+
+	t.Run("does not record when disabled", func(t *testing.T) {
+		RegisterFeatureFlag(NeverEnabled)
+
+		RecordConditionalHistogram(ctx, 100, ConditionalHistogramOpt{
+			HistogramOpt: metrics.HistogramOpt{
+				PkgName:    "test",
+				MetricName: "test_histogram",
+			},
+			Scope: "test.Scope",
+		})
+	})
+}
+
+func TestScopedMetrics(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+	sm := NewScopedMetrics("test.Scope")
+
+	require.Equal(t, "test.Scope", sm.Scope())
+
+	t.Run("RecordCounter when enabled", func(t *testing.T) {
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		sm.RecordCounter(ctx, 1, metrics.CounterOpt{
+			PkgName:    "test",
+			MetricName: "scoped_counter",
+		})
+	})
+
+	t.Run("RecordUpDownCounter when enabled", func(t *testing.T) {
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		sm.RecordUpDownCounter(ctx, 5, metrics.CounterOpt{
+			PkgName:    "test",
+			MetricName: "scoped_updown_counter",
+		})
+	})
+
+	t.Run("RecordGauge when enabled", func(t *testing.T) {
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		sm.RecordGauge(ctx, 42, metrics.GaugeOpt{
+			PkgName:    "test",
+			MetricName: "scoped_gauge",
+		})
+	})
+
+	t.Run("RecordHistogram when enabled", func(t *testing.T) {
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		sm.RecordHistogram(ctx, 100, metrics.HistogramOpt{
+			PkgName:    "test",
+			MetricName: "scoped_histogram",
+		})
+	})
+
+	t.Run("methods do nothing when disabled", func(t *testing.T) {
+		RegisterFeatureFlag(NeverEnabled)
+
+		// These should all return early without recording
+		sm.RecordCounter(ctx, 1, metrics.CounterOpt{PkgName: "test", MetricName: "c"})
+		sm.RecordUpDownCounter(ctx, 1, metrics.CounterOpt{PkgName: "test", MetricName: "u"})
+		sm.RecordGauge(ctx, 1, metrics.GaugeOpt{PkgName: "test", MetricName: "g"})
+		sm.RecordHistogram(ctx, 1, metrics.HistogramOpt{PkgName: "test", MetricName: "h"})
+	})
+}
+
+func TestConditionalMetricsWithTags(t *testing.T) {
+	defer ClearFeatureFlag()
+	RegisterFeatureFlag(AlwaysEnabled)
+
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	t.Run("counter with tags", func(t *testing.T) {
+		RecordConditionalCounter(ctx, 1, ConditionalCounterOpt{
+			CounterOpt: metrics.CounterOpt{
+				PkgName:     "test",
+				MetricName:  "tagged_counter",
+				Description: "A test counter with tags",
+				Tags: map[string]any{
+					"status": "success",
+					"type":   "test",
+				},
+			},
+			Scope: "test.Scope",
+		})
+	})
+
+	t.Run("histogram with boundaries and tags", func(t *testing.T) {
+		RecordConditionalHistogram(ctx, 250, ConditionalHistogramOpt{
+			HistogramOpt: metrics.HistogramOpt{
+				PkgName:     "test",
+				MetricName:  "latency_histogram",
+				Description: "Latency in milliseconds",
+				Unit:        "ms",
+				Boundaries:  []float64{10, 50, 100, 250, 500, 1000},
+				Tags: map[string]any{
+					"endpoint": "/api/test",
+				},
+			},
+			Scope: "test.Scope",
+		})
+	})
+}

--- a/pkg/telemetry/conditional/tracer.go
+++ b/pkg/telemetry/conditional/tracer.go
@@ -1,0 +1,150 @@
+package conditional
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// ScopedConditionalTracer provides a scoped wrapper for conditional tracing.
+type ScopedConditionalTracer struct {
+	tracer trace.Tracer
+	scope  string
+}
+
+// NewScopedConditionalTracer creates a new ScopedConditionalTracer with the given tracer and scope.
+func NewScopedConditionalTracer(tracer trace.Tracer, scope string) *ScopedConditionalTracer {
+	return &ScopedConditionalTracer{
+		tracer: tracer,
+		scope:  scope,
+	}
+}
+
+// Scope returns the scope of this tracer.
+func (t *ScopedConditionalTracer) Scope() string {
+	return t.scope
+}
+
+// Tracer returns the underlying tracer.
+func (t *ScopedConditionalTracer) Tracer() trace.Tracer {
+	return t.tracer
+}
+
+// Start creates a new span if tracing is enabled for this scope.
+// If tracing is disabled, returns the original context and a noop span.
+func (t *ScopedConditionalTracer) Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	if !IsTracingEnabled(ctx, t.scope) {
+		return ctx, noop.Span{}
+	}
+	return t.tracer.Start(ctx, spanName, opts...)
+}
+
+// StartWithContext creates a new span if tracing is enabled, using the FeatureFlagContext
+// from the provided context.
+func (t *ScopedConditionalTracer) StartWithContext(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return t.Start(ctx, spanName, opts...)
+}
+
+// WithScope returns a new ScopedConditionalTracer with a different scope.
+func (t *ScopedConditionalTracer) WithScope(scope string) *ScopedConditionalTracer {
+	return &ScopedConditionalTracer{
+		tracer: t.tracer,
+		scope:  scope,
+	}
+}
+
+// ConditionalStart creates a new span if tracing is enabled for the given scope.
+// This is a package-level convenience function.
+func ConditionalStart(ctx context.Context, tracer trace.Tracer, scope string, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	if !IsTracingEnabled(ctx, scope) {
+		return ctx, noop.Span{}
+	}
+	return tracer.Start(ctx, spanName, opts...)
+}
+
+// ConditionalSpan is a wrapper that helps with conditional span creation and management.
+// It can be used when you need to conditionally start spans at multiple points.
+type ConditionalSpan struct {
+	ctx     context.Context
+	span    trace.Span
+	enabled bool
+}
+
+// StartConditionalSpan starts a conditional span and returns a ConditionalSpan wrapper.
+func StartConditionalSpan(ctx context.Context, tracer trace.Tracer, scope string, spanName string, opts ...trace.SpanStartOption) *ConditionalSpan {
+	enabled := IsTracingEnabled(ctx, scope)
+	if !enabled {
+		return &ConditionalSpan{
+			ctx:     ctx,
+			span:    noop.Span{},
+			enabled: false,
+		}
+	}
+
+	newCtx, span := tracer.Start(ctx, spanName, opts...)
+	return &ConditionalSpan{
+		ctx:     newCtx,
+		span:    span,
+		enabled: true,
+	}
+}
+
+// Context returns the context (with span if enabled).
+func (cs *ConditionalSpan) Context() context.Context {
+	return cs.ctx
+}
+
+// Span returns the span (noop if disabled).
+func (cs *ConditionalSpan) Span() trace.Span {
+	return cs.span
+}
+
+// Enabled returns whether the span is enabled.
+func (cs *ConditionalSpan) Enabled() bool {
+	return cs.enabled
+}
+
+// End ends the span if it was enabled.
+func (cs *ConditionalSpan) End(opts ...trace.SpanEndOption) {
+	if cs.enabled {
+		cs.span.End(opts...)
+	}
+}
+
+// SetAttributes sets attributes on the span if it was enabled.
+func (cs *ConditionalSpan) SetAttributes(attrs ...attribute.KeyValue) {
+	if cs.enabled {
+		cs.span.SetAttributes(attrs...)
+	}
+}
+
+// RecordError records an error on the span if it was enabled.
+func (cs *ConditionalSpan) RecordError(err error, opts ...trace.EventOption) {
+	if cs.enabled {
+		cs.span.RecordError(err, opts...)
+	}
+}
+
+// SetStatus sets the status on the span if it was enabled.
+func (cs *ConditionalSpan) SetStatus(code codes.Code, description string) {
+	if cs.enabled {
+		cs.span.SetStatus(code, description)
+	}
+}
+
+// SetName sets the name on the span if it was enabled.
+func (cs *ConditionalSpan) SetName(name string) {
+	if cs.enabled {
+		cs.span.SetName(name)
+	}
+}
+
+// AddEvent adds an event to the span if it was enabled.
+func (cs *ConditionalSpan) AddEvent(name string, opts ...trace.EventOption) {
+	if cs.enabled {
+		cs.span.AddEvent(name, opts...)
+	}
+}

--- a/pkg/telemetry/conditional/tracer_test.go
+++ b/pkg/telemetry/conditional/tracer_test.go
@@ -1,0 +1,185 @@
+package conditional
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+func TestScopedConditionalTracer(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	tracer := otel.Tracer("test")
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	t.Run("Start creates span when enabled", func(t *testing.T) {
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		sct := NewScopedConditionalTracer(tracer, "test.Scope")
+		require.Equal(t, "test.Scope", sct.Scope())
+		require.NotNil(t, sct.Tracer())
+
+		newCtx, span := sct.Start(ctx, "test-span")
+		defer span.End()
+
+		require.NotEqual(t, ctx, newCtx)
+		require.NotNil(t, span)
+		// Check it's not a noop span
+		require.NotEqual(t, noop.Span{}, span)
+	})
+
+	t.Run("Start returns noop span when disabled", func(t *testing.T) {
+		RegisterFeatureFlag(NeverEnabled)
+
+		sct := NewScopedConditionalTracer(tracer, "test.Scope")
+		newCtx, span := sct.Start(ctx, "test-span")
+
+		require.Equal(t, ctx, newCtx)
+		require.IsType(t, noop.Span{}, span)
+	})
+
+	t.Run("WithScope returns new tracer with different scope", func(t *testing.T) {
+		RegisterFeatureFlag(ScopeEnabled("new.Scope"))
+
+		sct := NewScopedConditionalTracer(tracer, "old.Scope")
+		sct2 := sct.WithScope("new.Scope")
+
+		require.Equal(t, "old.Scope", sct.Scope())
+		require.Equal(t, "new.Scope", sct2.Scope())
+
+		// Old scope disabled
+		_, span1 := sct.Start(ctx, "span1")
+		require.IsType(t, noop.Span{}, span1)
+
+		// New scope enabled
+		_, span2 := sct2.Start(ctx, "span2")
+		defer span2.End()
+		require.NotEqual(t, noop.Span{}, span2)
+	})
+}
+
+func TestConditionalStart(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	tracer := otel.Tracer("test")
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	t.Run("creates span when enabled", func(t *testing.T) {
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		newCtx, span := ConditionalStart(ctx, tracer, "test.Scope", "test-span")
+		defer span.End()
+
+		require.NotEqual(t, ctx, newCtx)
+		require.NotEqual(t, noop.Span{}, span)
+	})
+
+	t.Run("returns noop span when disabled", func(t *testing.T) {
+		RegisterFeatureFlag(NeverEnabled)
+
+		newCtx, span := ConditionalStart(ctx, tracer, "test.Scope", "test-span")
+
+		require.Equal(t, ctx, newCtx)
+		require.IsType(t, noop.Span{}, span)
+	})
+}
+
+func TestStartConditionalSpan(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	tracer := otel.Tracer("test")
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	t.Run("creates enabled span when feature flag is enabled", func(t *testing.T) {
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		cs := StartConditionalSpan(ctx, tracer, "test.Scope", "test-span")
+		defer cs.End()
+
+		require.True(t, cs.Enabled())
+		require.NotEqual(t, ctx, cs.Context())
+		require.NotEqual(t, noop.Span{}, cs.Span())
+	})
+
+	t.Run("creates disabled span when feature flag is disabled", func(t *testing.T) {
+		RegisterFeatureFlag(NeverEnabled)
+
+		cs := StartConditionalSpan(ctx, tracer, "test.Scope", "test-span")
+
+		require.False(t, cs.Enabled())
+		require.Equal(t, ctx, cs.Context())
+		require.IsType(t, noop.Span{}, cs.Span())
+	})
+}
+
+func TestConditionalSpan_Methods(t *testing.T) {
+	defer ClearFeatureFlag()
+
+	tracer := otel.Tracer("test")
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	t.Run("methods work on enabled span", func(t *testing.T) {
+		RegisterFeatureFlag(AlwaysEnabled)
+
+		cs := StartConditionalSpan(ctx, tracer, "test.Scope", "test-span")
+		defer cs.End()
+
+		// These should not panic
+		cs.SetAttributes(attribute.String("key", "value"))
+		cs.SetStatus(codes.Ok, "success")
+		cs.SetName("new-name")
+		cs.AddEvent("test-event")
+		cs.RecordError(nil)
+	})
+
+	t.Run("methods are safe on disabled span", func(t *testing.T) {
+		RegisterFeatureFlag(NeverEnabled)
+
+		cs := StartConditionalSpan(ctx, tracer, "test.Scope", "test-span")
+
+		// These should not panic even on noop span
+		cs.SetAttributes(attribute.String("key", "value"))
+		cs.SetStatus(codes.Error, "error")
+		cs.SetName("new-name")
+		cs.AddEvent("test-event")
+		cs.RecordError(nil)
+		cs.End()
+	})
+}
+
+func TestConditionalSpan_WithSpanOptions(t *testing.T) {
+	defer ClearFeatureFlag()
+	RegisterFeatureFlag(AlwaysEnabled)
+
+	tracer := otel.Tracer("test")
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	cs := StartConditionalSpan(ctx, tracer, "test.Scope", "test-span",
+		trace.WithAttributes(attribute.String("init-key", "init-value")),
+	)
+	defer cs.End()
+
+	require.True(t, cs.Enabled())
+}
+
+func TestScopedConditionalTracer_StartWithContext(t *testing.T) {
+	defer ClearFeatureFlag()
+	RegisterFeatureFlag(AlwaysEnabled)
+
+	tracer := otel.Tracer("test")
+	ctx := WithContext(context.Background(), WithAccountID(uuid.New()))
+
+	sct := NewScopedConditionalTracer(tracer, "test.Scope")
+	newCtx, span := sct.StartWithContext(ctx, "test-span")
+	defer span.End()
+
+	require.NotEqual(t, ctx, newCtx)
+	require.NotEqual(t, noop.Span{}, span)
+}

--- a/pkg/telemetry/conditional/types.go
+++ b/pkg/telemetry/conditional/types.go
@@ -1,0 +1,97 @@
+package conditional
+
+import (
+	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
+)
+
+// ObservabilityType represents the type of observability being conditionally enabled.
+type ObservabilityType string
+
+const (
+	// ObservabilityTypeLogs represents conditional logging.
+	ObservabilityTypeLogs ObservabilityType = "logs"
+	// ObservabilityTypeMetrics represents conditional metrics.
+	ObservabilityTypeMetrics ObservabilityType = "metrics"
+	// ObservabilityTypeTraces represents conditional tracing.
+	ObservabilityTypeTraces ObservabilityType = "traces"
+)
+
+// String returns the string representation of the ObservabilityType.
+func (o ObservabilityType) String() string {
+	return string(o)
+}
+
+// FeatureFlagContext contains all identifiers for feature flag evaluation.
+// Uses a struct to allow easy extension with new fields without breaking API.
+type FeatureFlagContext struct {
+	// Core identifiers (always present when available)
+	AccountID  uuid.UUID
+	EnvID      uuid.UUID
+	FunctionID uuid.UUID
+
+	// Extended identifiers (optional, set via options)
+	RunID       ulid.ULID // For run-specific enablement
+	EventID     ulid.ULID // For event-specific enablement
+	BillingPlan string    // For plan-based enablement (e.g., "enterprise", "pro")
+
+	// Extra provides an escape hatch for future identifiers without struct changes.
+	// Use this for experimental identifiers, one-off custom identifiers,
+	// or future identifiers that haven't been added to the struct yet.
+	Extra map[string]any
+}
+
+// GetExtra returns the value for the given key from the Extra map, or nil if not present.
+func (f FeatureFlagContext) GetExtra(key string) any {
+	if f.Extra == nil {
+		return nil
+	}
+	return f.Extra[key]
+}
+
+// GetExtraString returns the string value for the given key from the Extra map,
+// or an empty string if not present or not a string.
+func (f FeatureFlagContext) GetExtraString(key string) string {
+	v := f.GetExtra(key)
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// HasAccountID returns true if the AccountID is set (non-zero).
+func (f FeatureFlagContext) HasAccountID() bool {
+	return f.AccountID != uuid.Nil
+}
+
+// HasEnvID returns true if the EnvID is set (non-zero).
+func (f FeatureFlagContext) HasEnvID() bool {
+	return f.EnvID != uuid.Nil
+}
+
+// HasFunctionID returns true if the FunctionID is set (non-zero).
+func (f FeatureFlagContext) HasFunctionID() bool {
+	return f.FunctionID != uuid.Nil
+}
+
+// HasRunID returns true if the RunID is set (non-zero).
+func (f FeatureFlagContext) HasRunID() bool {
+	return f.RunID.Compare(ulid.ULID{}) != 0
+}
+
+// HasEventID returns true if the EventID is set (non-zero).
+func (f FeatureFlagContext) HasEventID() bool {
+	return f.EventID.Compare(ulid.ULID{}) != 0
+}
+
+// Clone returns a deep copy of the FeatureFlagContext.
+func (f FeatureFlagContext) Clone() FeatureFlagContext {
+	clone := f
+	if f.Extra != nil {
+		clone.Extra = make(map[string]any, len(f.Extra))
+		for k, v := range f.Extra {
+			clone.Extra[k] = v
+		}
+	}
+	return clone
+}

--- a/pkg/telemetry/conditional/types_test.go
+++ b/pkg/telemetry/conditional/types_test.go
@@ -1,0 +1,123 @@
+package conditional
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObservabilityType_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		obsType  ObservabilityType
+		expected string
+	}{
+		{"logs", ObservabilityTypeLogs, "logs"},
+		{"metrics", ObservabilityTypeMetrics, "metrics"},
+		{"traces", ObservabilityTypeTraces, "traces"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.obsType.String())
+		})
+	}
+}
+
+func TestFeatureFlagContext_HasIdentifiers(t *testing.T) {
+	t.Run("empty context has no identifiers", func(t *testing.T) {
+		ctx := FeatureFlagContext{}
+		require.False(t, ctx.HasAccountID())
+		require.False(t, ctx.HasEnvID())
+		require.False(t, ctx.HasFunctionID())
+		require.False(t, ctx.HasRunID())
+		require.False(t, ctx.HasEventID())
+	})
+
+	t.Run("context with identifiers", func(t *testing.T) {
+		ctx := FeatureFlagContext{
+			AccountID:  uuid.New(),
+			EnvID:      uuid.New(),
+			FunctionID: uuid.New(),
+			RunID:      ulid.Make(),
+			EventID:    ulid.Make(),
+		}
+		require.True(t, ctx.HasAccountID())
+		require.True(t, ctx.HasEnvID())
+		require.True(t, ctx.HasFunctionID())
+		require.True(t, ctx.HasRunID())
+		require.True(t, ctx.HasEventID())
+	})
+}
+
+func TestFeatureFlagContext_Extra(t *testing.T) {
+	t.Run("GetExtra on nil map returns nil", func(t *testing.T) {
+		ctx := FeatureFlagContext{}
+		require.Nil(t, ctx.GetExtra("key"))
+	})
+
+	t.Run("GetExtra returns value", func(t *testing.T) {
+		ctx := FeatureFlagContext{
+			Extra: map[string]any{
+				"key": "value",
+				"num": 42,
+			},
+		}
+		require.Equal(t, "value", ctx.GetExtra("key"))
+		require.Equal(t, 42, ctx.GetExtra("num"))
+		require.Nil(t, ctx.GetExtra("nonexistent"))
+	})
+
+	t.Run("GetExtraString returns string value", func(t *testing.T) {
+		ctx := FeatureFlagContext{
+			Extra: map[string]any{
+				"str": "hello",
+				"num": 42,
+			},
+		}
+		require.Equal(t, "hello", ctx.GetExtraString("str"))
+		require.Equal(t, "", ctx.GetExtraString("num"))
+		require.Equal(t, "", ctx.GetExtraString("nonexistent"))
+	})
+}
+
+func TestFeatureFlagContext_Clone(t *testing.T) {
+	t.Run("clone creates independent copy", func(t *testing.T) {
+		original := FeatureFlagContext{
+			AccountID:   uuid.New(),
+			EnvID:       uuid.New(),
+			FunctionID:  uuid.New(),
+			RunID:       ulid.Make(),
+			BillingPlan: "enterprise",
+			Extra: map[string]any{
+				"key": "value",
+			},
+		}
+
+		clone := original.Clone()
+
+		// Values should be equal
+		require.Equal(t, original.AccountID, clone.AccountID)
+		require.Equal(t, original.EnvID, clone.EnvID)
+		require.Equal(t, original.FunctionID, clone.FunctionID)
+		require.Equal(t, original.RunID, clone.RunID)
+		require.Equal(t, original.BillingPlan, clone.BillingPlan)
+		require.Equal(t, original.Extra["key"], clone.Extra["key"])
+
+		// Modifying clone's Extra should not affect original
+		clone.Extra["key"] = "modified"
+		require.Equal(t, "value", original.Extra["key"])
+		require.Equal(t, "modified", clone.Extra["key"])
+	})
+
+	t.Run("clone with nil Extra", func(t *testing.T) {
+		original := FeatureFlagContext{
+			AccountID: uuid.New(),
+		}
+
+		clone := original.Clone()
+		require.Nil(t, clone.Extra)
+	})
+}

--- a/pkg/telemetry/metrics/utils.go
+++ b/pkg/telemetry/metrics/utils.go
@@ -20,6 +20,32 @@ var (
 	registry = newRegistry()
 )
 
+// ConditionalCheckFn is a function that checks if metrics recording should be enabled.
+// It receives the context and returns false if metrics should be skipped.
+// This is set by the conditional package to enable context-based conditional metrics.
+type ConditionalCheckFn func(ctx context.Context) bool
+
+var (
+	conditionalCheckFn ConditionalCheckFn
+	conditionalCheckMu sync.RWMutex
+)
+
+// RegisterConditionalCheck registers a function that will be called by Record*Metric functions
+// to determine if metrics should be recorded. This is used by the conditional
+// package to integrate scope-based metrics.
+func RegisterConditionalCheck(fn ConditionalCheckFn) {
+	conditionalCheckMu.Lock()
+	defer conditionalCheckMu.Unlock()
+	conditionalCheckFn = fn
+}
+
+// getConditionalCheck returns the registered conditional check function.
+func getConditionalCheck() ConditionalCheckFn {
+	conditionalCheckMu.RLock()
+	defer conditionalCheckMu.RUnlock()
+	return conditionalCheckFn
+}
+
 //
 // NOTE:
 // Most of these maps probably can be done with generics.
@@ -79,8 +105,19 @@ type CounterOpt struct {
 }
 
 // RecordCounterMetric increments the counter by the provided value.
-// The meter used can either be passed in or is the global meter
+// The meter used can either be passed in or is the global meter.
+//
+// If a conditional check function has been registered (via RegisterConditionalCheck)
+// and the context has a conditional scope set, the metric will be skipped if
+// disabled for that scope.
 func RecordCounterMetric(ctx context.Context, incr int64, opts CounterOpt) {
+	// Check for conditional scope in context
+	if fn := getConditionalCheck(); fn != nil {
+		if !fn(ctx) {
+			return
+		}
+	}
+
 	attrs := []attribute.KeyValue{}
 	if opts.Tags != nil {
 		attrs = append(attrs, parseAttributes(ctx, opts.Tags)...)
@@ -97,6 +134,13 @@ func RecordCounterMetric(ctx context.Context, incr int64, opts CounterOpt) {
 }
 
 func RecordUpDownCounterMetric(ctx context.Context, val int64, opts CounterOpt) {
+	// Check for conditional scope in context
+	if fn := getConditionalCheck(); fn != nil {
+		if !fn(ctx) {
+			return
+		}
+	}
+
 	attrs := []attribute.KeyValue{}
 	if opts.Tags != nil {
 		attrs = append(attrs, parseAttributes(ctx, opts.Tags)...)
@@ -176,6 +220,13 @@ func RegisterAsyncGauge(ctx context.Context, opts GaugeOpt) {
 }
 
 func RecordGaugeMetric(ctx context.Context, val int64, opts GaugeOpt) {
+	// Check for conditional scope in context
+	if fn := getConditionalCheck(); fn != nil {
+		if !fn(ctx) {
+			return
+		}
+	}
+
 	attrs := []attribute.KeyValue{}
 	if opts.Tags != nil {
 		attrs = append(attrs, parseAttributes(ctx, opts.Tags)...)
@@ -226,8 +277,19 @@ type HistogramOpt struct {
 }
 
 // RecordIntHistogramMetric records the observed value for distributions.
-// Bucket can be provided
+// Bucket can be provided.
+//
+// If a conditional check function has been registered (via RegisterConditionalCheck)
+// and the context has a conditional scope set, the metric will be skipped if
+// disabled for that scope.
 func RecordIntHistogramMetric(ctx context.Context, value int64, opts HistogramOpt) {
+	// Check for conditional scope in context
+	if fn := getConditionalCheck(); fn != nil {
+		if !fn(ctx) {
+			return
+		}
+	}
+
 	metricName := fmt.Sprintf("%s_%s", prefix, opts.MetricName)
 	h, err := registry.getHistogram(ctx, opts)
 	if err != nil {

--- a/pkg/telemetry/metrics/utils.go
+++ b/pkg/telemetry/metrics/utils.go
@@ -30,7 +30,7 @@ var (
 	conditionalCheckMu sync.RWMutex
 )
 
-// RegisterConditionalCheck registers a function that will be called by Record*Metric functions
+// RegisterConditionalCheck registers a function that will be called by all Record metric functions
 // to determine if metrics should be recorded. This is used by the conditional
 // package to integrate scope-based metrics.
 func RegisterConditionalCheck(fn ConditionalCheckFn) {


### PR DESCRIPTION
# Conditional Observability

## Description

Introduces a new `pkg/telemetry/conditional` package that provides feature-flag-controlled observability (logging, metrics, and tracing). This enables fine-grained control over high-cardinality telemetry on a per-account, per-environment, per-function, or per-scope basis.

### Key Components

**New Package: `pkg/telemetry/conditional`**
- `context.go` - Context management with `FeatureFlagContext` for storing identifiers (AccountID, EnvID, FunctionID, RunID, etc.)
- `feature_flag.go` - Pluggable feature flag evaluation with `RegisterFeatureFlag()`
- `logger.go` - Conditional logger helper: `conditional.Logger(ctx, scope)`
- `metrics.go` - Conditional metrics recording with scope-based gating
- `tracer.go` - Conditional tracing with scope-based span creation
- `types.go` - Core types including `FeatureFlagContext` and `ObservabilityType`

**Integration Points**
- `pkg/logger/stdlib.go` - Added `RegisterConditionalCheck()` hook so `logger.From(ctx)` can return `VoidLogger` when scope is disabled
- `pkg/telemetry/metrics/utils.go` - Added conditional metrics support

### Usage

```go
// 1. Setup: Register feature flag function at startup
conditional.RegisterFeatureFlag(func(ctx context.Context, ffCtx conditional.FeatureFlagContext, obsType conditional.ObservabilityType, scope string) bool {
    // Your feature flag logic here
    return myFeatureFlagService.IsEnabled(ffCtx.AccountID, scope)
})

// 2. At request/job entry point: Set up context with identifiers
ctx = conditional.WithContext(ctx,
    conditional.WithAccountID(accountID),
    conditional.WithEnvID(envID),
    conditional.WithFunctionID(fnID),
)

// 3. Configure logger with fields and store in context
l := logger.StdlibLogger(ctx).With("account_id", accountID, "env_id", envID)
ctx = logger.WithStdlib(ctx, l)

// 4. Use conditional logging (logs only if scope is enabled for this account)
conditional.Logger(ctx, "queue.CapacityLease").Debug("extended lease", "lease_id", leaseID)

// 5. Use conditional metrics
if conditional.IsMetricsEnabled(ctx, "constraintapi.Acquire") {
    tags["function_id"] = req.FunctionID
}
```

### Files Changed

| File | Changes |
|------|---------|
| `pkg/telemetry/conditional/*.go` | New package (8 files + tests) |
| `pkg/logger/stdlib.go` | Added `RegisterConditionalCheck`, `VoidLogger` integration |
| `pkg/telemetry/metrics/utils.go` | Added conditional metrics support |
| `pkg/constraintapi/acquire.go` | Use conditional observability |
| `pkg/constraintapi/extend.go` | Use conditional observability |
| `pkg/constraintapi/release.go` | Use conditional observability |
| `pkg/execution/queue/process.go` | Use conditional observability |

## Motivation

High-cardinality observability (debug logs, per-function metrics, detailed traces) is expensive to emit for all traffic. This package allows us to:

1. **Selectively enable** detailed telemetry for specific accounts, environments, or functions
2. **Control costs** by only emitting high-cardinality data when needed for debugging
3. **Simplify code** by replacing manual feature flag checks with a unified API

### Before (explicit feature flag checks)
```go
enableHighCardinalityInstrumentation := r.enableHighCardinalityInstrumentation != nil &&
    r.enableHighCardinalityInstrumentation(ctx, req.AccountID, req.EnvID, req.FunctionID)

if enableHighCardinalityInstrumentation {
    l.Debug("successful acquire call", "leases", leases)
}
```

### After (conditional observability)
```go
conditional.Logger(ctx, "constraintapi.Acquire").Debug("successful acquire call", "leases", leases)
```

## Behavioral Notes

**Important**: The new pattern has a subtle difference from explicit `if` checks:

| Aspect | Old (explicit check) | New (VoidLogger) |
|--------|---------------------|------------------|
| Feature flag check | Before log call | Inside `Logger()` |
| `Debug()` called | Only if enabled | Always |
| Arguments evaluated | Only if enabled | **Always** |

For performance-critical paths where argument evaluation is expensive, explicit checks are still available:
```go
if conditional.IsLoggingEnabled(ctx, "scope") {
    l.Debug("message", "expensive_arg", computeExpensiveValue())
}
```

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

---

## Architecture

```
┌─────────────────────────────────────────────────────────────────┐
│                        Application Code                          │
│  conditional.Logger(ctx, "scope").Debug("msg")                  │
└─────────────────────────────────────────────────────────────────┘
                                │
                                ▼
┌─────────────────────────────────────────────────────────────────┐
│                  pkg/telemetry/conditional                       │
│  ┌─────────────┐  ┌──────────────┐  ┌─────────────────────────┐ │
│  │  context.go │  │ feature_flag │  │ logger.go / metrics.go  │ │
│  │             │  │    .go       │  │ / tracer.go             │ │
│  │ WithContext │  │              │  │                         │ │
│  │ WithScope   │  │ IsEnabled()  │  │ Logger(ctx, scope)      │ │
│  │ GetFrom...  │  │              │  │ IsMetricsEnabled()      │ │
│  └─────────────┘  └──────────────┘  └─────────────────────────┘ │
└─────────────────────────────────────────────────────────────────┘
                                │
            ┌───────────────────┼───────────────────┐
            ▼                   ▼                   ▼
┌───────────────────┐ ┌─────────────────┐ ┌─────────────────────┐
│   pkg/logger      │ │  pkg/telemetry  │ │  Feature Flag       │
│   stdlib.go       │ │  /metrics       │ │  Service            │
│                   │ │                 │ │  (registered at     │
│ RegisterCondit... │ │ RegisterCondit..│ │   startup)          │
│ From() → Void?    │ │                 │ │                     │
└───────────────────┘ └─────────────────┘ └─────────────────────┘
```

## Scopes Used

| Scope | Location | Purpose |
|-------|----------|---------|
| `queue.CapacityLease` | `pkg/execution/queue/process.go` | Capacity lease lifecycle logging |
| `constraintapi.Acquire` | `pkg/constraintapi/acquire.go` | Acquire operation logging + metrics |
| `constraintapi.ExtendLease` | `pkg/constraintapi/extend.go` | Lease extension logging |
| `constraintapi.Release` | `pkg/constraintapi/release.go` | Lease release logging |
