### PR TITLE
don't load page view tracker locally

### DIFF
--- a/ui/apps/dashboard/src/routes/__root.tsx
+++ b/ui/apps/dashboard/src/routes/__root.tsx
@@ -9,7 +9,6 @@ import {
   createRootRouteWithContext,
 } from '@tanstack/react-router';
 
-import PageViewTracker from '@/components/Analytics/PageViewTracker';
 import SegmentAnalytics from '@/components/Analytics/SegmentAnalytics';
 import SentryUserIdentification from '@/components/Analytics/SentryUserIdentification';
 import { InngestClerkProvider } from '@/components/Clerk/Provider';
@@ -22,6 +21,14 @@ import globalsCss from '@inngest/components/AppRoot/globals.css?url';
 import { TooltipProvider } from '@inngest/components/Tooltip';
 import { QueryClient } from '@tanstack/react-query';
 import { ThemeProvider } from 'next-themes';
+
+//
+// don't load locally, causes issues with adblockers
+const PageViewTracker = React.lazy(() =>
+  import.meta.env.PROD
+    ? import('@/components/Analytics/PageViewTracker')
+    : Promise.resolve({ default: () => null }),
+);
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
@@ -91,7 +98,9 @@ function RootComponent() {
 
               <Toaster />
               <SegmentAnalytics />
-              <PageViewTracker />
+              <React.Suspense>
+                <PageViewTracker />
+              </React.Suspense>
             </ClientFeatureFlagProvider>
           </URQLProviderWrapper>
         </InngestClerkProvider>


### PR DESCRIPTION
## Description

Make it work for local devs who use firefox and tracking blockers who block this one by name alone.

## Motivation
Better local dev experience for those who use firefox + adblockers.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
