### PR TITLE
Add debug CLI commands for batch, debounce, and singleton

### DIFF
--- a/cmd/debug/batch.go
+++ b/cmd/debug/batch.go
@@ -1,0 +1,19 @@
+package debug
+
+import (
+	"github.com/inngest/inngest/cmd/debug/batch"
+	"github.com/urfave/cli/v3"
+)
+
+func batchCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "batch",
+		Aliases: []string{"b"},
+		Usage:   "Batch debugging commands",
+		Commands: []*cli.Command{
+			batch.InfoCommand(),
+			batch.DeleteCommand(),
+			batch.RunCommand(),
+		},
+	}
+}

--- a/cmd/debug/batch/delete.go
+++ b/cmd/debug/batch/delete.go
@@ -1,0 +1,74 @@
+package batch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/inngest/inngest/pkg/cli/output"
+	debugpkg "github.com/inngest/inngest/pkg/debug"
+	pb "github.com/inngest/inngest/proto/gen/debug/v1"
+	"github.com/urfave/cli/v3"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+)
+
+func DeleteCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "delete",
+		Aliases: []string{"d"},
+		Usage:   "Delete a batch for a function",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "function-id",
+				Aliases:  []string{"fn"},
+				Usage:    "The function ID (UUID)",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "batch-key",
+				Aliases: []string{"key"},
+				Usage:   "The batch key (defaults to 'default' if not specified)",
+			},
+			&cli.StringFlag{
+				Name:     "account-id",
+				Aliases:  []string{"acct"},
+				Usage:    "The account ID for shard selection",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			functionID := cmd.String("function-id")
+			batchKey := cmd.String("batch-key")
+			accountID := cmd.String("account-id")
+
+			dbgCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
+			if !ok {
+				return fmt.Errorf("debug context not found")
+			}
+
+			req := &pb.DeleteBatchRequest{
+				FunctionId: functionID,
+				BatchKey:   batchKey,
+				AccountId:  accountID,
+			}
+
+			resp, err := dbgCtx.Client.DeleteBatch(ctx, req)
+			if err != nil {
+				st, ok := grpcStatus.FromError(err)
+				if !ok {
+					return fmt.Errorf("failed to delete batch: %w", err)
+				}
+
+				switch st.Code() {
+				case codes.NotFound:
+					fmt.Println("no batch found to delete")
+					return nil
+				}
+
+				return fmt.Errorf("failed to delete batch: %w", err)
+			}
+
+			return output.TextDeleteBatch(resp)
+		},
+	}
+}

--- a/cmd/debug/batch/info.go
+++ b/cmd/debug/batch/info.go
@@ -1,0 +1,74 @@
+package batch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/inngest/inngest/pkg/cli/output"
+	debugpkg "github.com/inngest/inngest/pkg/debug"
+	pb "github.com/inngest/inngest/proto/gen/debug/v1"
+	"github.com/urfave/cli/v3"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+)
+
+func InfoCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "info",
+		Aliases: []string{"i"},
+		Usage:   "Get batch information for a function",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "function-id",
+				Aliases:  []string{"fn"},
+				Usage:    "The function ID (UUID)",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "batch-key",
+				Aliases: []string{"key"},
+				Usage:   "The batch key (defaults to 'default' if not specified)",
+			},
+			&cli.StringFlag{
+				Name:     "account-id",
+				Aliases:  []string{"acct"},
+				Usage:    "The account ID for shard selection",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			functionID := cmd.String("function-id")
+			batchKey := cmd.String("batch-key")
+			accountID := cmd.String("account-id")
+
+			dbgCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
+			if !ok {
+				return fmt.Errorf("debug context not found")
+			}
+
+			req := &pb.BatchInfoRequest{
+				FunctionId: functionID,
+				BatchKey:   batchKey,
+				AccountId:  accountID,
+			}
+
+			resp, err := dbgCtx.Client.GetBatchInfo(ctx, req)
+			if err != nil {
+				st, ok := grpcStatus.FromError(err)
+				if !ok {
+					return fmt.Errorf("failed to retrieve batch info: %w", err)
+				}
+
+				switch st.Code() {
+				case codes.NotFound:
+					fmt.Println("no batch found")
+					return nil
+				}
+
+				return fmt.Errorf("failed to retrieve batch info: %w", err)
+			}
+
+			return output.TextBatchInfo(resp)
+		},
+	}
+}

--- a/cmd/debug/batch/run.go
+++ b/cmd/debug/batch/run.go
@@ -1,0 +1,90 @@
+package batch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/inngest/inngest/pkg/cli/output"
+	debugpkg "github.com/inngest/inngest/pkg/debug"
+	pb "github.com/inngest/inngest/proto/gen/debug/v1"
+	"github.com/urfave/cli/v3"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+)
+
+func RunCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "run",
+		Aliases: []string{"r"},
+		Usage:   "Trigger immediate execution of a batch",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "function-id",
+				Aliases:  []string{"fn"},
+				Usage:    "The function ID (UUID)",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "batch-key",
+				Aliases: []string{"key"},
+				Usage:   "The batch key (defaults to 'default' if not specified)",
+			},
+			&cli.StringFlag{
+				Name:     "account-id",
+				Aliases:  []string{"acct"},
+				Usage:    "The account ID for shard selection",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "workspace-id",
+				Aliases:  []string{"ws"},
+				Usage:    "The workspace ID",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "app-id",
+				Aliases:  []string{"app"},
+				Usage:    "The app ID",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			functionID := cmd.String("function-id")
+			batchKey := cmd.String("batch-key")
+			accountID := cmd.String("account-id")
+			workspaceID := cmd.String("workspace-id")
+			appID := cmd.String("app-id")
+
+			dbgCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
+			if !ok {
+				return fmt.Errorf("debug context not found")
+			}
+
+			req := &pb.RunBatchRequest{
+				FunctionId:  functionID,
+				BatchKey:    batchKey,
+				AccountId:   accountID,
+				WorkspaceId: workspaceID,
+				AppId:       appID,
+			}
+
+			resp, err := dbgCtx.Client.RunBatch(ctx, req)
+			if err != nil {
+				st, ok := grpcStatus.FromError(err)
+				if !ok {
+					return fmt.Errorf("failed to run batch: %w", err)
+				}
+
+				switch st.Code() {
+				case codes.NotFound:
+					fmt.Println("no batch found to run")
+					return nil
+				}
+
+				return fmt.Errorf("failed to run batch: %w", err)
+			}
+
+			return output.TextRunBatch(resp)
+		},
+	}
+}

--- a/cmd/debug/cmd.go
+++ b/cmd/debug/cmd.go
@@ -58,6 +58,9 @@ func Command() *cli.Command {
 			queueCommand(),
 			pauseCommand(),
 			constraintCommand(),
+			batchCommand(),
+			singletonCommand(),
+			debounceCommand(),
 		},
 	}
 }

--- a/cmd/debug/debounce.go
+++ b/cmd/debug/debounce.go
@@ -1,0 +1,19 @@
+package debug
+
+import (
+	"github.com/inngest/inngest/cmd/debug/debounce"
+	"github.com/urfave/cli/v3"
+)
+
+func debounceCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "debounce",
+		Aliases: []string{"deb"},
+		Usage:   "Debounce debugging commands",
+		Commands: []*cli.Command{
+			debounce.InfoCommand(),
+			debounce.DeleteCommand(),
+			debounce.RunCommand(),
+		},
+	}
+}

--- a/cmd/debug/debounce/delete.go
+++ b/cmd/debug/debounce/delete.go
@@ -1,0 +1,74 @@
+package debounce
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/inngest/inngest/pkg/cli/output"
+	debugpkg "github.com/inngest/inngest/pkg/debug"
+	pb "github.com/inngest/inngest/proto/gen/debug/v1"
+	"github.com/urfave/cli/v3"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+)
+
+func DeleteCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "delete",
+		Aliases: []string{"d"},
+		Usage:   "Delete a debounce for a function",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "function-id",
+				Aliases:  []string{"fn"},
+				Usage:    "The function ID (UUID)",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "debounce-key",
+				Aliases: []string{"key"},
+				Usage:   "The debounce key (from the key expression or function_id)",
+			},
+			&cli.StringFlag{
+				Name:     "account-id",
+				Aliases:  []string{"acct"},
+				Usage:    "The account ID for shard selection",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			functionID := cmd.String("function-id")
+			debounceKey := cmd.String("debounce-key")
+			accountID := cmd.String("account-id")
+
+			dbgCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
+			if !ok {
+				return fmt.Errorf("debug context not found")
+			}
+
+			req := &pb.DeleteDebounceRequest{
+				FunctionId:  functionID,
+				DebounceKey: debounceKey,
+				AccountId:   accountID,
+			}
+
+			resp, err := dbgCtx.Client.DeleteDebounce(ctx, req)
+			if err != nil {
+				st, ok := grpcStatus.FromError(err)
+				if !ok {
+					return fmt.Errorf("failed to delete debounce: %w", err)
+				}
+
+				switch st.Code() {
+				case codes.NotFound:
+					fmt.Println("no debounce found to delete")
+					return nil
+				}
+
+				return fmt.Errorf("failed to delete debounce: %w", err)
+			}
+
+			return output.TextDeleteDebounce(resp)
+		},
+	}
+}

--- a/cmd/debug/debounce/info.go
+++ b/cmd/debug/debounce/info.go
@@ -1,0 +1,74 @@
+package debounce
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/inngest/inngest/pkg/cli/output"
+	debugpkg "github.com/inngest/inngest/pkg/debug"
+	pb "github.com/inngest/inngest/proto/gen/debug/v1"
+	"github.com/urfave/cli/v3"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+)
+
+func InfoCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "info",
+		Aliases: []string{"i"},
+		Usage:   "Get debounce information for a function",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "function-id",
+				Aliases:  []string{"fn"},
+				Usage:    "The function ID (UUID)",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "debounce-key",
+				Aliases: []string{"key"},
+				Usage:   "The debounce key (from the key expression or function_id)",
+			},
+			&cli.StringFlag{
+				Name:     "account-id",
+				Aliases:  []string{"acct"},
+				Usage:    "The account ID for shard selection",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			functionID := cmd.String("function-id")
+			debounceKey := cmd.String("debounce-key")
+			accountID := cmd.String("account-id")
+
+			dbgCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
+			if !ok {
+				return fmt.Errorf("debug context not found")
+			}
+
+			req := &pb.DebounceInfoRequest{
+				FunctionId:  functionID,
+				DebounceKey: debounceKey,
+				AccountId:   accountID,
+			}
+
+			resp, err := dbgCtx.Client.GetDebounceInfo(ctx, req)
+			if err != nil {
+				st, ok := grpcStatus.FromError(err)
+				if !ok {
+					return fmt.Errorf("failed to retrieve debounce info: %w", err)
+				}
+
+				switch st.Code() {
+				case codes.NotFound:
+					fmt.Println("no debounce found")
+					return nil
+				}
+
+				return fmt.Errorf("failed to retrieve debounce info: %w", err)
+			}
+
+			return output.TextDebounceInfo(resp)
+		},
+	}
+}

--- a/cmd/debug/debounce/run.go
+++ b/cmd/debug/debounce/run.go
@@ -1,0 +1,74 @@
+package debounce
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/inngest/inngest/pkg/cli/output"
+	debugpkg "github.com/inngest/inngest/pkg/debug"
+	pb "github.com/inngest/inngest/proto/gen/debug/v1"
+	"github.com/urfave/cli/v3"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+)
+
+func RunCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "run",
+		Aliases: []string{"r"},
+		Usage:   "Trigger immediate execution of a debounce",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "function-id",
+				Aliases:  []string{"fn"},
+				Usage:    "The function ID (UUID)",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "debounce-key",
+				Aliases: []string{"key"},
+				Usage:   "The debounce key (from the key expression or function_id)",
+			},
+			&cli.StringFlag{
+				Name:     "account-id",
+				Aliases:  []string{"acct"},
+				Usage:    "The account ID for shard selection",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			functionID := cmd.String("function-id")
+			debounceKey := cmd.String("debounce-key")
+			accountID := cmd.String("account-id")
+
+			dbgCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
+			if !ok {
+				return fmt.Errorf("debug context not found")
+			}
+
+			req := &pb.RunDebounceRequest{
+				FunctionId:  functionID,
+				DebounceKey: debounceKey,
+				AccountId:   accountID,
+			}
+
+			resp, err := dbgCtx.Client.RunDebounce(ctx, req)
+			if err != nil {
+				st, ok := grpcStatus.FromError(err)
+				if !ok {
+					return fmt.Errorf("failed to run debounce: %w", err)
+				}
+
+				switch st.Code() {
+				case codes.NotFound:
+					fmt.Println("no debounce found to run")
+					return nil
+				}
+
+				return fmt.Errorf("failed to run debounce: %w", err)
+			}
+
+			return output.TextRunDebounce(resp)
+		},
+	}
+}

--- a/cmd/debug/singleton.go
+++ b/cmd/debug/singleton.go
@@ -1,0 +1,18 @@
+package debug
+
+import (
+	"github.com/inngest/inngest/cmd/debug/singleton"
+	"github.com/urfave/cli/v3"
+)
+
+func singletonCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "singleton",
+		Aliases: []string{"s"},
+		Usage:   "Singleton debugging commands",
+		Commands: []*cli.Command{
+			singleton.InfoCommand(),
+			singleton.DeleteCommand(),
+		},
+	}
+}

--- a/cmd/debug/singleton/delete.go
+++ b/cmd/debug/singleton/delete.go
@@ -1,0 +1,67 @@
+package singleton
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/inngest/inngest/pkg/cli/output"
+	debugpkg "github.com/inngest/inngest/pkg/debug"
+	pb "github.com/inngest/inngest/proto/gen/debug/v1"
+	"github.com/urfave/cli/v3"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+)
+
+func DeleteCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "delete",
+		Aliases: []string{"d"},
+		Usage:   "Delete a singleton lock",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "singleton-key",
+				Aliases:  []string{"key"},
+				Usage:    "The singleton key (function_id-hash or just function_id)",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "account-id",
+				Aliases:  []string{"acct"},
+				Usage:    "The account ID for shard selection",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			singletonKey := cmd.String("singleton-key")
+			accountID := cmd.String("account-id")
+
+			dbgCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
+			if !ok {
+				return fmt.Errorf("debug context not found")
+			}
+
+			req := &pb.DeleteSingletonLockRequest{
+				SingletonKey: singletonKey,
+				AccountId:    accountID,
+			}
+
+			resp, err := dbgCtx.Client.DeleteSingletonLock(ctx, req)
+			if err != nil {
+				st, ok := grpcStatus.FromError(err)
+				if !ok {
+					return fmt.Errorf("failed to delete singleton lock: %w", err)
+				}
+
+				switch st.Code() {
+				case codes.NotFound:
+					fmt.Println("no singleton lock found to delete")
+					return nil
+				}
+
+				return fmt.Errorf("failed to delete singleton lock: %w", err)
+			}
+
+			return output.TextDeleteSingletonLock(resp)
+		},
+	}
+}

--- a/cmd/debug/singleton/info.go
+++ b/cmd/debug/singleton/info.go
@@ -1,0 +1,67 @@
+package singleton
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/inngest/inngest/pkg/cli/output"
+	debugpkg "github.com/inngest/inngest/pkg/debug"
+	pb "github.com/inngest/inngest/proto/gen/debug/v1"
+	"github.com/urfave/cli/v3"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+)
+
+func InfoCommand() *cli.Command {
+	return &cli.Command{
+		Name:    "info",
+		Aliases: []string{"i"},
+		Usage:   "Get singleton lock information",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "singleton-key",
+				Aliases:  []string{"key"},
+				Usage:    "The singleton key (function_id-hash or just function_id)",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "account-id",
+				Aliases:  []string{"acct"},
+				Usage:    "The account ID for shard selection",
+				Required: true,
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			singletonKey := cmd.String("singleton-key")
+			accountID := cmd.String("account-id")
+
+			dbgCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
+			if !ok {
+				return fmt.Errorf("debug context not found")
+			}
+
+			req := &pb.SingletonInfoRequest{
+				SingletonKey: singletonKey,
+				AccountId:    accountID,
+			}
+
+			resp, err := dbgCtx.Client.GetSingletonInfo(ctx, req)
+			if err != nil {
+				st, ok := grpcStatus.FromError(err)
+				if !ok {
+					return fmt.Errorf("failed to retrieve singleton info: %w", err)
+				}
+
+				switch st.Code() {
+				case codes.NotFound:
+					fmt.Println("no singleton lock found")
+					return nil
+				}
+
+				return fmt.Errorf("failed to retrieve singleton info: %w", err)
+			}
+
+			return output.TextSingletonInfo(resp)
+		},
+	}
+}

--- a/pkg/cli/output/batch.go
+++ b/pkg/cli/output/batch.go
@@ -1,0 +1,111 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+
+	pb "github.com/inngest/inngest/proto/gen/debug/v1"
+)
+
+func TextBatchInfo(resp *pb.BatchInfoResponse) error {
+	if resp == nil {
+		fmt.Println("no batch info found")
+		return nil
+	}
+
+	w := NewTextWriter()
+
+	if resp.BatchId == "" {
+		fmt.Println("no active batch found")
+		return nil
+	}
+
+	if err := w.WriteOrdered(OrderedData(
+		"BatchID", resp.BatchId,
+		"Status", resp.Status,
+		"ItemCount", resp.ItemCount,
+	), WithTextOptLeadSpace(true)); err != nil {
+		return err
+	}
+
+	if err := w.Flush(); err != nil {
+		return err
+	}
+
+	// Write batch items
+	if len(resp.Items) > 0 {
+		fmt.Printf("\nBatch Items:\n")
+
+		for i, item := range resp.Items {
+			fmt.Printf("\n  Item %d:\n", i+1)
+			fmt.Printf("    EventID:         %s\n", item.EventId)
+			fmt.Printf("    AccountID:       %s\n", item.AccountId)
+			fmt.Printf("    WorkspaceID:     %s\n", item.WorkspaceId)
+			fmt.Printf("    AppID:           %s\n", item.AppId)
+			fmt.Printf("    FunctionID:      %s\n", item.FunctionId)
+			fmt.Printf("    FunctionVersion: %d\n", item.FunctionVersion)
+
+			if len(item.EventData) > 0 {
+				var eventData any
+				if err := json.Unmarshal(item.EventData, &eventData); err == nil {
+					prettyJSON, _ := json.MarshalIndent(eventData, "    ", "  ")
+					fmt.Printf("    EventData:       %s\n", string(prettyJSON))
+				} else {
+					fmt.Printf("    EventData:       %s\n", string(item.EventData))
+				}
+			}
+		}
+	} else {
+		fmt.Printf("\nNo batch items found\n")
+	}
+
+	return nil
+}
+
+func TextDeleteBatch(resp *pb.DeleteBatchResponse) error {
+	if resp == nil {
+		fmt.Println("no response received")
+		return nil
+	}
+
+	w := NewTextWriter()
+
+	if !resp.Deleted {
+		fmt.Println("no batch was deleted")
+		return nil
+	}
+
+	if err := w.WriteOrdered(OrderedData(
+		"Deleted", resp.Deleted,
+		"BatchID", resp.BatchId,
+		"ItemCount", resp.ItemCount,
+	), WithTextOptLeadSpace(true)); err != nil {
+		return err
+	}
+
+	return w.Flush()
+}
+
+func TextRunBatch(resp *pb.RunBatchResponse) error {
+	if resp == nil {
+		fmt.Println("no response received")
+		return nil
+	}
+
+	w := NewTextWriter()
+
+	if !resp.Scheduled {
+		fmt.Println("no batch was scheduled for execution")
+		return nil
+	}
+
+	if err := w.WriteOrdered(OrderedData(
+		"Scheduled", resp.Scheduled,
+		"BatchID", resp.BatchId,
+		"ItemCount", resp.ItemCount,
+	), WithTextOptLeadSpace(true)); err != nil {
+		return err
+	}
+
+	return w.Flush()
+}

--- a/pkg/cli/output/debounce.go
+++ b/pkg/cli/output/debounce.go
@@ -1,0 +1,97 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	pb "github.com/inngest/inngest/proto/gen/debug/v1"
+)
+
+func TextDebounceInfo(resp *pb.DebounceInfoResponse) error {
+	if resp == nil {
+		fmt.Println("no debounce info found")
+		return nil
+	}
+
+	w := NewTextWriter()
+
+	if !resp.HasDebounce {
+		fmt.Println("no pending debounce found")
+		return nil
+	}
+
+	// Format timeout as both unix millis and human-readable
+	timeoutStr := fmt.Sprintf("%d (%s)", resp.Timeout, time.UnixMilli(resp.Timeout).UTC().Format(time.RFC3339))
+
+	// Try to parse event data as JSON for better display
+	var eventDataDisplay any
+	if len(resp.EventData) > 0 {
+		if err := json.Unmarshal(resp.EventData, &eventDataDisplay); err != nil {
+			eventDataDisplay = string(resp.EventData)
+		}
+	}
+
+	if err := w.WriteOrdered(OrderedData(
+		"HasDebounce", resp.HasDebounce,
+		"DebounceID", resp.DebounceId,
+		"EventID", resp.EventId,
+		"Timeout", timeoutStr,
+		"AccountID", resp.AccountId,
+		"WorkspaceID", resp.WorkspaceId,
+		"FunctionID", resp.FunctionId,
+		"EventData", eventDataDisplay,
+	), WithTextOptLeadSpace(true)); err != nil {
+		return err
+	}
+
+	return w.Flush()
+}
+
+func TextDeleteDebounce(resp *pb.DeleteDebounceResponse) error {
+	if resp == nil {
+		fmt.Println("no response received")
+		return nil
+	}
+
+	w := NewTextWriter()
+
+	if !resp.Deleted {
+		fmt.Println("no debounce was deleted")
+		return nil
+	}
+
+	if err := w.WriteOrdered(OrderedData(
+		"Deleted", resp.Deleted,
+		"DebounceID", resp.DebounceId,
+		"EventID", resp.EventId,
+	), WithTextOptLeadSpace(true)); err != nil {
+		return err
+	}
+
+	return w.Flush()
+}
+
+func TextRunDebounce(resp *pb.RunDebounceResponse) error {
+	if resp == nil {
+		fmt.Println("no response received")
+		return nil
+	}
+
+	w := NewTextWriter()
+
+	if !resp.Scheduled {
+		fmt.Println("no debounce was scheduled for execution")
+		return nil
+	}
+
+	if err := w.WriteOrdered(OrderedData(
+		"Scheduled", resp.Scheduled,
+		"DebounceID", resp.DebounceId,
+		"EventID", resp.EventId,
+	), WithTextOptLeadSpace(true)); err != nil {
+		return err
+	}
+
+	return w.Flush()
+}

--- a/pkg/cli/output/singleton.go
+++ b/pkg/cli/output/singleton.go
@@ -1,0 +1,53 @@
+package output
+
+import (
+	"fmt"
+
+	pb "github.com/inngest/inngest/proto/gen/debug/v1"
+)
+
+func TextSingletonInfo(resp *pb.SingletonInfoResponse) error {
+	if resp == nil {
+		fmt.Println("no singleton info found")
+		return nil
+	}
+
+	w := NewTextWriter()
+
+	if !resp.HasLock {
+		fmt.Println("no singleton lock currently held")
+		return nil
+	}
+
+	if err := w.WriteOrdered(OrderedData(
+		"HasLock", resp.HasLock,
+		"CurrentRunID", resp.CurrentRunId,
+	), WithTextOptLeadSpace(true)); err != nil {
+		return err
+	}
+
+	return w.Flush()
+}
+
+func TextDeleteSingletonLock(resp *pb.DeleteSingletonLockResponse) error {
+	if resp == nil {
+		fmt.Println("no response received")
+		return nil
+	}
+
+	w := NewTextWriter()
+
+	if !resp.Deleted {
+		fmt.Println("no singleton lock was deleted")
+		return nil
+	}
+
+	if err := w.WriteOrdered(OrderedData(
+		"Deleted", resp.Deleted,
+		"RunID", resp.RunId,
+	), WithTextOptLeadSpace(true)); err != nil {
+		return err
+	}
+
+	return w.Flush()
+}


### PR DESCRIPTION
## Description

This PR adds three new debug command groups to the CLI for managing batch operations, debounce timers, and singleton locks:

- **Batch commands** (`debug batch`): info, delete, and run subcommands for inspecting and managing batch state
- **Debounce commands** (`debug debounce`): info, delete, and run subcommands for inspecting and managing debounce timers
- **Singleton commands** (`debug singleton`): info and delete subcommands for inspecting and managing singleton locks

Each command group communicates with the debug gRPC service to retrieve state information and trigger operations. The commands include proper error handling for NotFound cases and formatted text output for results.

## Motivation

These debug commands enable operators and developers to:
- Inspect the current state of batches, debounces, and singleton locks for troubleshooting
- Manually trigger execution of pending batches and debounces
- Delete stale or problematic batch/debounce/singleton state when needed
- Diagnose issues with function execution patterns that rely on these features

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

https://claude.ai/code/session_012FVJ2piKr5TBHiV4h4eZHh