### PR TITLE
Add batching to batching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/inngest/expr v0.0.0-20260130112310-06d5fe6bb6fd
 	github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48
-	github.com/inngest/inngestgo v0.15.0
+	github.com/inngest/inngestgo v0.15.1-0.20260204010937-b4832022aecc
 	github.com/jackc/pgx/v5 v5.5.4
 	github.com/jinzhu/copier v0.3.5
 	github.com/jonboulle/clockwork v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.37.0
 	go.opentelemetry.io/otel/trace v1.37.0
 	go.opentelemetry.io/proto/otlp v1.7.0
+	go.uber.org/goleak v1.3.0
 	gocloud.dev v0.40.0
 	gocloud.dev/pubsub/natspubsub v0.25.0
 	golang.org/x/mod v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -587,8 +587,8 @@ github.com/inngest/expr v0.0.0-20260130112310-06d5fe6bb6fd h1:9IQrqM4SxWZKaTMnX6
 github.com/inngest/expr v0.0.0-20260130112310-06d5fe6bb6fd/go.mod h1:1RxlLkgZcEArmo0DF8Id0vWPaVXimsoetXrUGbEpQfs=
 github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48 h1:8NwXUrQTQjWrfGj99JgesfTbCYujtnLHusePp7YyFU8=
 github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48/go.mod h1:7SNLkGaD+tiTey1IF9WUNDNurTfqNZqjbdPZo3CmLW4=
-github.com/inngest/inngestgo v0.15.0 h1:WiIhGUL8D8MnnySBdjDyRcxjsOXLQQWF+1hV4oslWc8=
-github.com/inngest/inngestgo v0.15.0/go.mod h1:2Qm4ULk506Zwt8MJXHfTZ4lthY1WTpYksXK1z6lEM/U=
+github.com/inngest/inngestgo v0.15.1-0.20260204010937-b4832022aecc h1:FD+iis04Q5HvCXeIyzRo1RNrZRK8QnFAIkmmYVthHZI=
+github.com/inngest/inngestgo v0.15.1-0.20260204010937-b4832022aecc/go.mod h1:2Qm4ULk506Zwt8MJXHfTZ4lthY1WTpYksXK1z6lEM/U=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/pkg/execution/batch/batch.go
+++ b/pkg/execution/batch/batch.go
@@ -40,11 +40,19 @@ func HashBatchKey(batchKey string) string {
 //
 //	#4 needs to happen in one transaction in order to make sure there will not be any race conditions.
 type BatchManager interface {
+	// Append appends items to a batch.  This may buffer in-memory for functions with
+	// the same ID prior to appending.
+	//
+	// If this happens, the Append function will block until the batch commits.
 	Append(ctx context.Context, bi BatchItem, fn inngest.Function) (*BatchAppendResult, error)
-	RetrieveItems(ctx context.Context, functionId uuid.UUID, batchID ulid.ULID) ([]BatchItem, error)
-	StartExecution(ctx context.Context, functionId uuid.UUID, batchID ulid.ULID, batchPointer string) (string, error)
+	// BulkAppend is used to append items from a buffer
+	BulkAppend(ctx context.Context, items []BatchItem, fn inngest.Function) (*BulkAppendResult, error)
+
+	RetrieveItems(ctx context.Context, functionID uuid.UUID, batchID ulid.ULID) ([]BatchItem, error)
+	StartExecution(ctx context.Context, functionID uuid.UUID, batchID ulid.ULID, batchPointer string) (string, error)
 	ScheduleExecution(ctx context.Context, opts ScheduleBatchOpts) error
-	DeleteKeys(ctx context.Context, functionId uuid.UUID, batchID ulid.ULID) error
+
+	DeleteKeys(ctx context.Context, functionID uuid.UUID, batchID ulid.ULID) error
 	// GetBatchInfo retrieves information about the current batch for a function and batch key.
 	// This is used for debugging and introspection.
 	GetBatchInfo(ctx context.Context, functionID uuid.UUID, batchKey string) (*BatchInfo, error)
@@ -53,6 +61,8 @@ type BatchManager interface {
 	DeleteBatch(ctx context.Context, functionID uuid.UUID, batchKey string) (*DeleteBatchResult, error)
 	// RunBatch schedules immediate execution of a batch by creating a timeout job that runs in one second.
 	RunBatch(ctx context.Context, opts RunBatchOpts) (*RunBatchResult, error)
+	// Close gracefully shuts down the batch manager, flushing any pending buffers.
+	Close() error
 }
 
 // BatchInfo contains information about a batch for debugging purposes.

--- a/pkg/execution/batch/batch_test.go
+++ b/pkg/execution/batch/batch_test.go
@@ -29,7 +29,7 @@ func TestBatchSizeLimit(t *testing.T) {
 
 	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
 	// make the size limit crazy small (10 bytes) for verification purposes
-	bm := NewRedisBatchManager(bc, nil, WithRedisBatchSizeLimit(10))
+	bm := NewRedisBatchManager(bc, nil, WithoutBuffer(), WithRedisBatchSizeLimit(10))
 
 	accountId := uuid.New()
 	fnId := uuid.New()
@@ -71,7 +71,7 @@ func TestBatchAppendIdempotence(t *testing.T) {
 	defer rc.Close()
 
 	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
-	bm := NewRedisBatchManager(bc, nil)
+	bm := NewRedisBatchManager(bc, nil, WithoutBuffer())
 
 	accountId := uuid.New()
 	fnId := uuid.New()

--- a/pkg/execution/batch/batch_test.go
+++ b/pkg/execution/batch/batch_test.go
@@ -139,7 +139,7 @@ func TestBatchAppendIdempotenceDifferentBatches(t *testing.T) {
 	defer rc.Close()
 
 	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
-	bm := NewRedisBatchManager(bc, nil)
+	bm := NewRedisBatchManager(bc, nil, WithoutBuffer()) // Test direct append behavior
 
 	accountId := uuid.New()
 	fnId := uuid.New()
@@ -202,7 +202,7 @@ func TestBatchCleanup(t *testing.T) {
 	defer rc.Close()
 
 	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
-	bm := NewRedisBatchManager(bc, nil)
+	bm := NewRedisBatchManager(bc, nil, WithoutBuffer()) // Test direct append behavior
 
 	accountId := uuid.New()
 	fnId := uuid.New()
@@ -434,7 +434,8 @@ func TestBatchCleanupIdempotenceKeyExpires(t *testing.T) {
 	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
 	// Set a large deletion cutoff to keep the eventIDs in the idempotence set.
 	// Set a 5s TLL to ensure that after 5s of inactivity, the key is cleared.
-	bm := NewRedisBatchManager(bc, nil, WithRedisBatchIdempotenceSetTTL(5), WithRedisBatchIdempotenceSetCleanupCutoff(300))
+	// Disable buffer to test direct append behavior.
+	bm := NewRedisBatchManager(bc, nil, WithoutBuffer(), WithRedisBatchIdempotenceSetTTL(5), WithRedisBatchIdempotenceSetCleanupCutoff(300))
 
 	accountId := uuid.New()
 	fnId := uuid.New()

--- a/pkg/execution/batch/buffer.go
+++ b/pkg/execution/batch/buffer.go
@@ -255,6 +255,15 @@ func (ab *appendBuffer) flush(buf *batchBuffer, mgr BatchManager) {
 		}
 		close(p.pending.done)
 	}
+
+	// clean up empty buffer to prevent unbounded map growth.
+	ab.mu.Lock()
+	buf.mu.Lock()
+	if len(buf.items) == 0 {
+		delete(ab.buffers, buf.key)
+	}
+	buf.mu.Unlock()
+	ab.mu.Unlock()
 }
 
 // mapBulkStatus maps a bulk append status to an individual item status.

--- a/pkg/execution/batch/buffer.go
+++ b/pkg/execution/batch/buffer.go
@@ -1,0 +1,352 @@
+package batch
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/oklog/ulid/v2"
+)
+
+const (
+	// DefaultMaxBufferDuration is the default max time to buffer events in-memory
+	// before flushing.  must be less than the event ack deadline
+	DefaultMaxBufferDuration = 2 * time.Second
+
+	// DefaultMaxBufferSize is the default max events per buffer key before flush
+	DefaultMaxBufferSize = 100
+)
+
+// appendBuffer manages in-memory buffering for batch appends across varying
+// functions and batch pointers.
+type appendBuffer struct {
+	maxDuration time.Duration
+	maxSize     int
+	buffers     map[bufferKey]*batchBuffer
+	mu          sync.Mutex
+	closed      chan struct{} // signals shutdown to unblock waiting appends
+	log         logger.Logger
+}
+
+// bufferKey identifies a unique buffer based on function and batch pointer,
+// used to isolate in-mem batches
+type bufferKey struct {
+	FunctionID   uuid.UUID
+	BatchPointer string
+}
+
+// pendingItem tracks an item and its waiter channel in a buffer
+type pendingItem struct {
+	item BatchItem
+	fn   inngest.Function
+	// resultCh is used to communicate to each Append call for every batch
+	// item appended
+	resultCh chan appendResult
+}
+
+// appendResult is sent to waiters when flush completes.
+type appendResult struct {
+	result *BatchAppendResult
+	err    error
+}
+
+// batchBuffer holds pending items for a specific buffer key
+type batchBuffer struct {
+	mu      sync.Mutex
+	key     bufferKey
+	items   []pendingItem
+	seenIDs map[string]struct{} // Local dedup
+	timer   *time.Timer
+	fn      inngest.Function // Function config for batch settings
+}
+
+// newAppendBuffer creates a new appendBuffer with the given configuration.
+func newAppendBuffer(maxDuration time.Duration, maxSize int, log logger.Logger) *appendBuffer {
+	// Clamp maxDuration to 5s max due to pub/sub ACK deadline
+	if maxDuration > 5*time.Second {
+		maxDuration = 5 * time.Second
+	}
+	if maxDuration <= 0 {
+		maxDuration = DefaultMaxBufferDuration
+	}
+	if maxSize <= 0 {
+		maxSize = DefaultMaxBufferSize
+	}
+
+	return &appendBuffer{
+		maxDuration: maxDuration,
+		maxSize:     maxSize,
+		buffers:     make(map[bufferKey]*batchBuffer),
+		closed:      make(chan struct{}),
+		log:         log,
+	}
+}
+
+// append adds an item to a buffer. This method BLOCKS until the event is committed
+// to Redis, ensuring events are not ACK'd until persisted.
+func (ab *appendBuffer) append(ctx context.Context, bi BatchItem, fn inngest.Function, mgr *redisBatchManager) (*BatchAppendResult, error) {
+	// Compute buffer key using the batch pointer
+	batchPointer, err := mgr.batchPointer(ctx, fn, bi.Event)
+	if err != nil {
+		return nil, err
+	}
+	key := bufferKey{FunctionID: fn.ID, BatchPointer: batchPointer}
+
+	// Get or create buffer
+	buf := ab.getOrCreateBuffer(key, fn)
+
+	// Create result channel for this caller
+	resultCh := make(chan appendResult, 1)
+
+	buf.mu.Lock()
+
+	// Local dedup check - return immediately if already seen in this buffer
+	eventIDStr := bi.EventID.String()
+	if _, seen := buf.seenIDs[eventIDStr]; seen {
+		buf.mu.Unlock()
+		return &BatchAppendResult{
+			Status:          enums.BatchItemExists,
+			BatchPointerKey: batchPointer,
+		}, nil
+	}
+
+	// Add to buffer with waiter channel
+	buf.items = append(buf.items, pendingItem{
+		item:     bi,
+		fn:       fn,
+		resultCh: resultCh,
+	})
+	buf.seenIDs[eventIDStr] = struct{}{}
+
+	shouldFlush := len(buf.items) >= ab.maxSize
+
+	// Start timer if not running (first item in buffer)
+	if len(buf.items) == 1 && !shouldFlush {
+		buf.timer = time.AfterFunc(ab.maxDuration, func() {
+			ab.flush(buf, mgr)
+		})
+	}
+
+	buf.mu.Unlock()
+
+	// Trigger immediate flush if buffer is full
+	if shouldFlush {
+		ab.flush(buf, mgr)
+	}
+
+	// block until result is available
+	select {
+	case result := <-resultCh:
+		return result.result, result.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-ab.closed:
+		return nil, context.Canceled
+	}
+}
+
+// getOrCreateBuffer returns the buffer for the given key, creating it if needed.
+func (ab *appendBuffer) getOrCreateBuffer(key bufferKey, fn inngest.Function) *batchBuffer {
+	ab.mu.Lock()
+	defer ab.mu.Unlock()
+
+	if buf, exists := ab.buffers[key]; exists {
+		return buf
+	}
+
+	buf := &batchBuffer{
+		key:     key,
+		items:   make([]pendingItem, 0),
+		seenIDs: make(map[string]struct{}),
+		fn:      fn,
+	}
+	ab.buffers[key] = buf
+	return buf
+}
+
+// flush commits all pending items in a buffer to Redis atomically.
+func (ab *appendBuffer) flush(buf *batchBuffer, mgr BatchManager) {
+	buf.mu.Lock()
+
+	// nothing to flush.  buffer may have been appended to after timer started
+	// which hit max cap.
+	if len(buf.items) == 0 {
+		buf.mu.Unlock()
+		return
+	}
+
+	var (
+		// snapshot before resetting
+		pending = buf.items
+		fn      = buf.fn
+	)
+	buf.reset()
+
+	buf.mu.Unlock()
+
+	// extract BatchItems for the bulk call
+	items := make([]BatchItem, len(pending))
+	for i, p := range pending {
+		items[i] = p.item
+	}
+
+	// call BulkAppend - this commits all items atomically
+	bulkResult, err := mgr.BulkAppend(context.Background(), items, fn)
+
+	// Send results to all waiters
+	for i, p := range pending {
+		var result appendResult
+
+		switch err {
+		case nil:
+			// Map bulk status to individual BatchAppendResult status
+			status := ab.mapBulkStatus(bulkResult.Status, i)
+			result = appendResult{
+				result: &BatchAppendResult{
+					Status:          status,
+					BatchID:         bulkResult.BatchID,
+					BatchPointerKey: bulkResult.BatchPointer,
+				},
+				err: nil,
+			}
+		default:
+			result = appendResult{
+				result: nil,
+				err:    err,
+			}
+		}
+
+		// non-blocking send (channel has buffer of 1)
+		select {
+		case p.resultCh <- result:
+		default:
+			// Channel already has a result or is closed
+		}
+	}
+
+	// handle scheduling based on result
+	if err == nil && bulkResult != nil {
+		ab.handleScheduling(bulkResult, fn, items[0], mgr)
+	}
+}
+
+// mapBulkStatus maps a bulk append status to an individual item status.
+func (ab *appendBuffer) mapBulkStatus(bulkStatus string, itemIndex int) enums.Batch {
+	switch bulkStatus {
+	case "new":
+		// First item in a new batch
+		if itemIndex == 0 {
+			return enums.BatchNew
+		}
+		return enums.BatchAppend
+	case "full", "maxsize":
+		// Batch is complete
+		return enums.BatchFull
+	case "overflow":
+		// Batch overflowed - items split between batches
+		return enums.BatchFull
+	case "itemexists":
+		return enums.BatchItemExists
+	default:
+		return enums.BatchAppend
+	}
+}
+
+// handleScheduling schedules batch execution based on the bulk append result.
+func (ab *appendBuffer) handleScheduling(result *BulkAppendResult, fn inngest.Function, firstItem BatchItem, mgr BatchManager) {
+	timeout, err := time.ParseDuration(fn.EventBatch.Timeout)
+	if err != nil {
+		ab.log.Error("failed to parse batch timeout", "error", err, "timeout", fn.EventBatch.Timeout)
+		timeout = 60 * time.Second // fallback
+	}
+
+	switch result.Status {
+	case "new":
+		// Schedule batch timeout for the new batch
+		batchID, err := ulid.Parse(result.BatchID)
+		if err != nil {
+			ab.log.Error("failed to parse batch ID", "error", err, "batchID", result.BatchID)
+			return
+		}
+
+		scheduleErr := mgr.ScheduleExecution(context.Background(), ScheduleBatchOpts{
+			ScheduleBatchPayload: ScheduleBatchPayload{
+				BatchID:         batchID,
+				BatchPointer:    result.BatchPointer,
+				AccountID:       firstItem.AccountID,
+				WorkspaceID:     firstItem.WorkspaceID,
+				AppID:           firstItem.AppID,
+				FunctionID:      fn.ID,
+				FunctionVersion: firstItem.FunctionVersion,
+			},
+			At: time.Now().Add(timeout),
+		})
+		if scheduleErr != nil {
+			ab.log.Error("failed to schedule batch execution", "error", scheduleErr)
+		}
+
+	case "overflow":
+		// Schedule timeout for the overflow batch
+		if result.NextBatchID != "" {
+			nextBatchID, err := ulid.Parse(result.NextBatchID)
+			if err != nil {
+				ab.log.Error("failed to parse next batch ID", "error", err, "batchID", result.NextBatchID)
+				return
+			}
+
+			// The overflow batch needs scheduling - the original batch is already full/started
+			scheduleErr := mgr.ScheduleExecution(context.Background(), ScheduleBatchOpts{
+				ScheduleBatchPayload: ScheduleBatchPayload{
+					BatchID:         nextBatchID,
+					BatchPointer:    result.BatchPointer,
+					AccountID:       firstItem.AccountID,
+					WorkspaceID:     firstItem.WorkspaceID,
+					AppID:           firstItem.AppID,
+					FunctionID:      fn.ID,
+					FunctionVersion: firstItem.FunctionVersion,
+				},
+				At: time.Now().Add(timeout),
+			})
+			if scheduleErr != nil {
+				ab.log.Error("failed to schedule overflow batch execution", "error", scheduleErr)
+			}
+		}
+	}
+	// For "full", "maxsize", "append", "itemexists" - no scheduling needed
+	// The batch is either already scheduled or doesn't need new scheduling
+}
+
+// close shuts down the appendBuffer, flushing all pending buffers.
+func (ab *appendBuffer) close(mgr *redisBatchManager) error {
+	// Flush all remaining buffers before closing the channel
+	// so that pending waiters receive their results
+	ab.mu.Lock()
+	buffersToFlush := make([]*batchBuffer, 0, len(ab.buffers))
+	for _, buf := range ab.buffers {
+		buffersToFlush = append(buffersToFlush, buf)
+	}
+	ab.mu.Unlock()
+
+	for _, buf := range buffersToFlush {
+		ab.flush(buf, mgr)
+	}
+
+	// Close channel to unblock any remaining waiters
+	close(ab.closed)
+
+	return nil
+}
+
+// reset resets a batch buffer
+func (buf *batchBuffer) reset() {
+	buf.items = make([]pendingItem, 0)
+	buf.seenIDs = make(map[string]struct{})
+	if buf.timer != nil {
+		buf.timer.Stop()
+		buf.timer = nil
+	}
+}

--- a/pkg/execution/batch/buffer_test.go
+++ b/pkg/execution/batch/buffer_test.go
@@ -320,8 +320,8 @@ func TestBufferedBatchManager(t *testing.T) {
 
 		// First append starts blocking (we don't wait for it)
 		go func() {
-			_, err = buffered.Append(context.Background(), bi, fn)
-			require.NoError(t, err)
+			_, appendErr := buffered.Append(context.Background(), bi, fn)
+			require.NoError(t, appendErr)
 		}()
 
 		// Give time for first append to add to buffer
@@ -411,8 +411,8 @@ func TestBufferedBatchManager(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 
 		// Close should flush the buffer
-		err = buffered.Close()
-		require.NoError(t, err)
+		closeErr := buffered.Close()
+		require.NoError(t, closeErr)
 
 		// Wait for append to complete
 		select {

--- a/pkg/execution/batch/buffer_test.go
+++ b/pkg/execution/batch/buffer_test.go
@@ -1,0 +1,594 @@
+package batch
+
+import (
+	"context"
+	"crypto/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/execution/state/redis_state"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/oklog/ulid/v2"
+	"github.com/redis/rueidis"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBulkAppend(t *testing.T) {
+	r := miniredis.RunT(t)
+
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
+	bm := NewRedisBatchManager(bc, nil)
+
+	// Cast to *redisBatchManager to access BulkAppend
+	rbm, ok := bm.(*redisBatchManager)
+	require.True(t, ok)
+
+	accountId := uuid.New()
+	workspaceId := uuid.New()
+	appId := uuid.New()
+	fnId := uuid.New()
+
+	fn := inngest.Function{
+		ID: fnId,
+		EventBatch: &inngest.EventBatchConfig{
+			MaxSize: 10,
+			Timeout: "60s",
+		},
+	}
+
+	t.Run("bulk append creates new batch", func(t *testing.T) {
+		items := make([]BatchItem, 3)
+		for i := 0; i < 3; i++ {
+			items[i] = BatchItem{
+				AccountID:       accountId,
+				WorkspaceID:     workspaceId,
+				AppID:           appId,
+				FunctionID:      fnId,
+				FunctionVersion: 1,
+				EventID:         ulid.MustNew(ulid.Now(), rand.Reader),
+				Event: event.Event{
+					Name: "test/event",
+					Data: map[string]any{"index": i},
+				},
+			}
+		}
+
+		result, err := rbm.BulkAppend(context.Background(), items, fn)
+		require.NoError(t, err)
+		require.Equal(t, "new", result.Status)
+		require.NotEmpty(t, result.BatchID)
+		require.Equal(t, 3, result.Committed)
+		require.Equal(t, 0, result.Duplicates)
+
+		// Verify items are in Redis
+		info, err := rbm.GetBatchInfo(context.Background(), fnId, "")
+		require.NoError(t, err)
+		require.Len(t, info.Items, 3)
+	})
+
+	t.Run("bulk append with duplicates", func(t *testing.T) {
+		newFnId := uuid.New()
+		fn := inngest.Function{
+			ID: newFnId,
+			EventBatch: &inngest.EventBatchConfig{
+				MaxSize: 10,
+				Timeout: "60s",
+			},
+		}
+
+		eventID := ulid.MustNew(ulid.Now(), rand.Reader)
+		items := []BatchItem{
+			{
+				AccountID:   accountId,
+				WorkspaceID: workspaceId,
+				AppID:       appId,
+				FunctionID:  newFnId,
+				EventID:     eventID,
+				Event:       event.Event{Name: "test/event", Data: map[string]any{"a": 1}},
+			},
+			{
+				AccountID:   accountId,
+				WorkspaceID: workspaceId,
+				AppID:       appId,
+				FunctionID:  newFnId,
+				EventID:     eventID, // Duplicate
+				Event:       event.Event{Name: "test/event", Data: map[string]any{"a": 2}},
+			},
+			{
+				AccountID:   accountId,
+				WorkspaceID: workspaceId,
+				AppID:       appId,
+				FunctionID:  newFnId,
+				EventID:     ulid.MustNew(ulid.Now(), rand.Reader),
+				Event:       event.Event{Name: "test/event", Data: map[string]any{"a": 3}},
+			},
+		}
+
+		result, err := rbm.BulkAppend(context.Background(), items, fn)
+		require.NoError(t, err)
+		require.Equal(t, "new", result.Status)
+		require.Equal(t, 2, result.Committed)
+		require.Equal(t, 1, result.Duplicates)
+
+		// Verify only 2 items in Redis
+		info, err := rbm.GetBatchInfo(context.Background(), newFnId, "")
+		require.NoError(t, err)
+		require.Len(t, info.Items, 2)
+	})
+
+	t.Run("bulk append fills batch", func(t *testing.T) {
+		newFnId := uuid.New()
+		fn := inngest.Function{
+			ID: newFnId,
+			EventBatch: &inngest.EventBatchConfig{
+				MaxSize: 5,
+				Timeout: "60s",
+			},
+		}
+
+		items := make([]BatchItem, 5)
+		for i := 0; i < 5; i++ {
+			items[i] = BatchItem{
+				AccountID:   accountId,
+				WorkspaceID: workspaceId,
+				AppID:       appId,
+				FunctionID:  newFnId,
+				EventID:     ulid.MustNew(ulid.Now(), rand.Reader),
+				Event:       event.Event{Name: "test/event", Data: map[string]any{"i": i}},
+			}
+		}
+
+		result, err := rbm.BulkAppend(context.Background(), items, fn)
+		require.NoError(t, err)
+		require.Equal(t, "full", result.Status)
+		require.Equal(t, 5, result.Committed)
+	})
+
+	t.Run("bulk append with overflow", func(t *testing.T) {
+		newFnId := uuid.New()
+		fn := inngest.Function{
+			ID: newFnId,
+			EventBatch: &inngest.EventBatchConfig{
+				MaxSize: 3,
+				Timeout: "60s",
+			},
+		}
+
+		// Add 5 items to a batch with max size 3
+		items := make([]BatchItem, 5)
+		for i := 0; i < 5; i++ {
+			items[i] = BatchItem{
+				AccountID:   accountId,
+				WorkspaceID: workspaceId,
+				AppID:       appId,
+				FunctionID:  newFnId,
+				EventID:     ulid.MustNew(ulid.Now(), rand.Reader),
+				Event:       event.Event{Name: "test/event", Data: map[string]any{"i": i}},
+			}
+		}
+
+		result, err := rbm.BulkAppend(context.Background(), items, fn)
+		require.NoError(t, err)
+		require.Equal(t, "overflow", result.Status)
+		require.Equal(t, 5, result.Committed)
+		require.Equal(t, 2, result.OverflowCount)
+		require.NotEmpty(t, result.NextBatchID)
+		require.NotEqual(t, result.BatchID, result.NextBatchID)
+	})
+}
+
+func TestBufferedBatchManager(t *testing.T) {
+	r := miniredis.RunT(t)
+
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
+
+	t.Run("blocking append with timer flush", func(t *testing.T) {
+		buffered := NewRedisBatchManager(bc, nil,
+			WithBufferSettings(100*time.Millisecond, 100), // High size so timer triggers flush
+		)
+		defer buffered.Close()
+
+		fnId := uuid.New()
+		fn := inngest.Function{
+			ID: fnId,
+			EventBatch: &inngest.EventBatchConfig{
+				MaxSize: 10,
+				Timeout: "60s",
+			},
+		}
+
+		bi := BatchItem{
+			AccountID:   uuid.New(),
+			WorkspaceID: uuid.New(),
+			AppID:       uuid.New(),
+			FunctionID:  fnId,
+			EventID:     ulid.MustNew(ulid.Now(), rand.Reader),
+			Event:       event.Event{Name: "test/event", Data: map[string]any{"a": 1}},
+		}
+
+		start := time.Now()
+		result, err := buffered.Append(context.Background(), bi, fn)
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, enums.BatchNew, result.Status)
+
+		// Should have waited for timer (100ms)
+		require.GreaterOrEqual(t, elapsed, 90*time.Millisecond)
+
+		// Verify item is in Redis
+		info, err := buffered.GetBatchInfo(context.Background(), fnId, "")
+		require.NoError(t, err)
+		require.Len(t, info.Items, 1)
+	})
+
+	t.Run("blocking append with size flush", func(t *testing.T) {
+		buffered := NewRedisBatchManager(bc, nil,
+			WithBufferSettings(5*time.Second, 3), // Long timer so size triggers flush
+		)
+		defer buffered.Close()
+
+		fnId := uuid.New()
+		fn := inngest.Function{
+			ID: fnId,
+			EventBatch: &inngest.EventBatchConfig{
+				MaxSize: 10,
+				Timeout: "60s",
+			},
+		}
+
+		var wg sync.WaitGroup
+		results := make([]*BatchAppendResult, 3)
+		errors := make([]error, 3)
+
+		// Launch 3 goroutines that will all block until buffer flushes
+		for i := 0; i < 3; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				bi := BatchItem{
+					AccountID:   uuid.New(),
+					WorkspaceID: uuid.New(),
+					AppID:       uuid.New(),
+					FunctionID:  fnId,
+					EventID:     ulid.MustNew(ulid.Now(), rand.Reader),
+					Event:       event.Event{Name: "test/event", Data: map[string]any{"idx": idx}},
+				}
+				results[idx], errors[idx] = buffered.Append(context.Background(), bi, fn)
+			}(i)
+		}
+
+		wg.Wait()
+
+		// All should succeed
+		for i := 0; i < 3; i++ {
+			require.NoError(t, errors[i])
+			require.NotNil(t, results[i])
+		}
+
+		// Verify all items are in Redis
+		info, err := buffered.GetBatchInfo(context.Background(), fnId, "")
+		require.NoError(t, err)
+		require.Len(t, info.Items, 3)
+	})
+
+	t.Run("local dedup returns immediately", func(t *testing.T) {
+		buffered := NewRedisBatchManager(bc, nil,
+			WithBufferSettings(5*time.Second, 100),
+		)
+		defer buffered.Close()
+
+		fnId := uuid.New()
+		fn := inngest.Function{
+			ID: fnId,
+			EventBatch: &inngest.EventBatchConfig{
+				MaxSize: 10,
+				Timeout: "60s",
+			},
+		}
+
+		eventID := ulid.MustNew(ulid.Now(), rand.Reader)
+		bi := BatchItem{
+			AccountID:   uuid.New(),
+			WorkspaceID: uuid.New(),
+			AppID:       uuid.New(),
+			FunctionID:  fnId,
+			EventID:     eventID,
+			Event:       event.Event{Name: "test/event"},
+		}
+
+		// First append starts blocking (we don't wait for it)
+		go func() {
+			_, err = buffered.Append(context.Background(), bi, fn)
+			require.NoError(t, err)
+		}()
+
+		// Give time for first append to add to buffer
+		time.Sleep(10 * time.Millisecond)
+
+		// Second append with same event ID should return immediately
+		start := time.Now()
+		result, err := buffered.Append(context.Background(), bi, fn)
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, enums.BatchItemExists, result.Status)
+		require.Less(t, elapsed, 50*time.Millisecond, "dedup should return immediately")
+	})
+
+	t.Run("context cancellation unblocks", func(t *testing.T) {
+		buffered := NewRedisBatchManager(bc, nil,
+			WithBufferSettings(5*time.Second, 100),
+		)
+		defer buffered.Close()
+
+		fnId := uuid.New()
+		fn := inngest.Function{
+			ID: fnId,
+			EventBatch: &inngest.EventBatchConfig{
+				MaxSize: 10,
+				Timeout: "60s",
+			},
+		}
+
+		bi := BatchItem{
+			AccountID:   uuid.New(),
+			WorkspaceID: uuid.New(),
+			AppID:       uuid.New(),
+			FunctionID:  fnId,
+			EventID:     ulid.MustNew(ulid.Now(), rand.Reader),
+			Event:       event.Event{Name: "test/event"},
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		result, err := buffered.Append(ctx, bi, fn)
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		require.Nil(t, result)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Less(t, elapsed, 200*time.Millisecond, "should unblock on context cancel")
+	})
+
+	t.Run("close flushes pending buffers", func(t *testing.T) {
+		buffered := NewRedisBatchManager(bc, nil,
+			WithBufferSettings(5*time.Second, 100),
+		)
+
+		fnId := uuid.New()
+		fn := inngest.Function{
+			ID: fnId,
+			EventBatch: &inngest.EventBatchConfig{
+				MaxSize: 10,
+				Timeout: "60s",
+			},
+		}
+
+		bi := BatchItem{
+			AccountID:   uuid.New(),
+			WorkspaceID: uuid.New(),
+			AppID:       uuid.New(),
+			FunctionID:  fnId,
+			EventID:     ulid.MustNew(ulid.Now(), rand.Reader),
+			Event:       event.Event{Name: "test/event"},
+		}
+
+		var appendErr error
+		var appendResult *BatchAppendResult
+		done := make(chan struct{})
+
+		go func() {
+			appendResult, appendErr = buffered.Append(context.Background(), bi, fn)
+			close(done)
+		}()
+
+		// Give time for append to add to buffer
+		time.Sleep(20 * time.Millisecond)
+
+		// Close should flush the buffer
+		err = buffered.Close()
+		require.NoError(t, err)
+
+		// Wait for append to complete
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("append did not complete after close")
+		}
+
+		require.NoError(t, appendErr)
+		require.NotNil(t, appendResult)
+
+		// Verify item is in Redis - use a fresh manager without buffering for verification
+		verifier := NewRedisBatchManager(bc, nil)
+		defer verifier.Close()
+		info, err := verifier.GetBatchInfo(context.Background(), fnId, "")
+		require.NoError(t, err)
+		require.Len(t, info.Items, 1)
+	})
+
+	t.Run("without buffering appends directly", func(t *testing.T) {
+		// Test that without WithBuffering, Append goes directly to Redis (no blocking)
+		direct := NewRedisBatchManager(bc, nil, WithoutBuffer())
+		defer direct.Close()
+
+		fnId := uuid.New()
+		fn := inngest.Function{
+			ID: fnId,
+			EventBatch: &inngest.EventBatchConfig{
+				MaxSize: 10,
+				Timeout: "60s",
+			},
+		}
+
+		bi := BatchItem{
+			AccountID:   uuid.New(),
+			WorkspaceID: uuid.New(),
+			AppID:       uuid.New(),
+			FunctionID:  fnId,
+			EventID:     ulid.MustNew(ulid.Now(), rand.Reader),
+			Event:       event.Event{Name: "test/event"},
+		}
+
+		start := time.Now()
+		result, err := direct.Append(context.Background(), bi, fn)
+		elapsed := time.Since(start)
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		// Should be fast (no buffering delay)
+		require.Less(t, elapsed, 50*time.Millisecond)
+
+		// Verify item is in Redis
+		info, err := direct.GetBatchInfo(context.Background(), fnId, "")
+		require.NoError(t, err)
+		require.Len(t, info.Items, 1)
+	})
+}
+
+func TestBufferedBatchManagerConcurrency(t *testing.T) {
+	r := miniredis.RunT(t)
+
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
+	buffered := NewRedisBatchManager(bc, nil,
+		WithBufferSettings(50*time.Millisecond, 20),
+	)
+	defer buffered.Close()
+
+	fnId := uuid.New()
+	fn := inngest.Function{
+		ID: fnId,
+		EventBatch: &inngest.EventBatchConfig{
+			MaxSize: 100,
+			Timeout: "60s",
+		},
+	}
+
+	const numGoroutines = 50
+	var wg sync.WaitGroup
+	var successCount atomic.Int32
+	var errorCount atomic.Int32
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			bi := BatchItem{
+				AccountID:   uuid.New(),
+				WorkspaceID: uuid.New(),
+				AppID:       uuid.New(),
+				FunctionID:  fnId,
+				EventID:     ulid.MustNew(ulid.Now(), rand.Reader),
+				Event:       event.Event{Name: "test/event", Data: map[string]any{"idx": idx}},
+			}
+			result, err := buffered.Append(context.Background(), bi, fn)
+			if err != nil {
+				errorCount.Add(1)
+				return
+			}
+			if result != nil && result.Status != enums.BatchItemExists {
+				successCount.Add(1)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	require.Equal(t, int32(0), errorCount.Load(), "should have no errors")
+	require.Equal(t, int32(numGoroutines), successCount.Load(), "all appends should succeed")
+
+	// Verify all items are in Redis
+	info, err := buffered.GetBatchInfo(context.Background(), fnId, "")
+	require.NoError(t, err)
+	require.Len(t, info.Items, numGoroutines)
+}
+
+func TestBufferedBatchManagerMultipleBufferKeys(t *testing.T) {
+	r := miniredis.RunT(t)
+
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
+	buffered := NewRedisBatchManager(bc, nil,
+		WithBufferSettings(100*time.Millisecond, 100),
+	)
+	defer buffered.Close()
+
+	// Function with batch key expression
+	fnId := uuid.New()
+	fn := inngest.Function{
+		ID: fnId,
+		EventBatch: &inngest.EventBatchConfig{
+			MaxSize: 10,
+			Timeout: "60s",
+			Key:     strPtr("event.data.tenant"),
+		},
+	}
+
+	var wg sync.WaitGroup
+
+	// Send events to two different tenants
+	tenants := []string{"tenant-a", "tenant-b"}
+	for _, tenant := range tenants {
+		wg.Add(1)
+		go func(tenantName string) {
+			defer wg.Done()
+			bi := BatchItem{
+				AccountID:   uuid.New(),
+				WorkspaceID: uuid.New(),
+				AppID:       uuid.New(),
+				FunctionID:  fnId,
+				EventID:     ulid.MustNew(ulid.Now(), rand.Reader),
+				Event:       event.Event{Name: "test/event", Data: map[string]any{"tenant": tenantName}},
+			}
+			_, appendErr := buffered.Append(context.Background(), bi, fn)
+			require.NoError(t, appendErr)
+		}(tenant)
+	}
+
+	wg.Wait()
+
+	// Each tenant should have their own batch
+	for _, tenant := range tenants {
+		info, err := buffered.GetBatchInfo(context.Background(), fnId, tenant)
+		require.NoError(t, err)
+		require.Len(t, info.Items, 1, "tenant %s should have 1 item", tenant)
+	}
+}

--- a/pkg/execution/batch/lua/bulk_append.lua
+++ b/pkg/execution/batch/lua/bulk_append.lua
@@ -136,10 +136,11 @@ end
 local batchFull = finalLen >= batchLimit or batchMemorySize >= batchSizeLimit
 
 if batchFull then
-  -- Mark current batch as started
-  if not is_status_empty(batchMetadataKey) then
-    set_batch_status(batchMetadataKey, batchStatusStarted)
-  end
+  -- NOTE: We intentionally do NOT set status to "started" here.
+  -- The batch pointer is updated to prevent new items from being added,
+  -- and start.lua will set status to "started" when execution begins.
+  -- Setting it here would cause start.lua to skip execution thinking
+  -- the batch is already running.
 
   -- Check if we have overflow events
   if #eventsForOverflow > 0 then

--- a/pkg/execution/batch/lua/bulk_append.lua
+++ b/pkg/execution/batch/lua/bulk_append.lua
@@ -1,0 +1,180 @@
+--
+-- This script runs bulk batch append ops in an atomic action.
+-- It accepts multiple events and handles overflow atomically - if adding N events
+-- exceeds MaxSize, the script splits into current + new batch.
+--
+
+local batchPointerKey = KEYS[1]      -- key to the batch pointer
+
+local batchLimit = tonumber(ARGV[1]) -- max size configured for this batch
+local batchSizeLimit = tonumber(ARGV[2])
+local prefix = ARGV[3]               -- the prefix used for redis
+local batchStatusAppending = ARGV[4]
+local batchStatusStarted = ARGV[5]
+local nowUnixSeconds = tonumber(ARGV[6])
+local idempotenceSetTTL = tonumber(ARGV[7])
+local newULID = ARGV[8]              -- ULID to update the pointer with if the batch is full or doesn't exist
+local overflowULID = ARGV[9]         -- ULID to use for overflow batch if needed
+local eventCount = tonumber(ARGV[10])
+
+-- Events are passed as pairs: eventID1, event1, eventID2, event2, ...
+-- Starting at ARGV[11]
+
+-- helper functions
+-- $include(helpers.lua)
+
+local function get_or_create_batch_key(key)
+  local val = redis.call("GET", key)
+
+  -- if empty or doesn't exist
+  if is_empty(val) then
+    -- create new pointer by setting the ULID
+    update_pointer(batchPointerKey, newULID)
+    val = newULID
+  end
+
+  return val
+end
+
+-- start execution
+local batchID = get_or_create_batch_key(batchPointerKey)
+local isNewBatch = (batchID == newULID)
+
+-- NOTE: these need to be identical to the ones in the queue key generator
+--   * Batch
+--   * BatchMetadata
+local keyfmt = "%s:batches:%s"
+local idempotenceKeyFmt = "%s:batch_idempotence"
+local batchKey = string.format(keyfmt, prefix, batchID)
+local batchIdempotenceKey = string.format(idempotenceKeyFmt, prefix)
+local batchMetadataKey = string.format("%s:metadata", batchKey)
+
+-- set the batch status if it doesn't exist but don't overwrite
+-- this is necessary for functions that never enabled batch before
+if is_status_empty(batchMetadataKey) then
+  set_batch_status(batchMetadataKey, batchStatusAppending)
+end
+
+-- Collect all events and check for duplicates
+local eventsToAdd = {}
+local duplicateCount = 0
+local argOffset = 11
+
+for i = 1, eventCount do
+  local eventID = ARGV[argOffset + (i - 1) * 2]
+  local eventData = ARGV[argOffset + (i - 1) * 2 + 1]
+
+  -- check if event has already been appended
+  local newEvent = redis.call("ZADD", batchIdempotenceKey, "NX", nowUnixSeconds, eventID)
+  if newEvent == 0 then
+    duplicateCount = duplicateCount + 1
+  else
+    table.insert(eventsToAdd, eventData)
+  end
+end
+
+-- Update idempotence set TTL
+redis.call("EXPIRE", batchIdempotenceKey, idempotenceSetTTL)
+
+-- If all events were duplicates, return early
+if #eventsToAdd == 0 then
+  local currentLen = redis.call("LLEN", batchKey)
+  local status = "append"
+  if currentLen == 0 or isNewBatch then
+    status = "new"
+  end
+  return cjson.encode({
+    status = "itemexists",
+    batchID = batchID,
+    batchPointerKey = batchPointerKey,
+    committed = 0,
+    duplicates = duplicateCount
+  })
+end
+
+-- Get current batch length
+local currentLen = redis.call("LLEN", batchKey)
+local capacity = batchLimit - currentLen
+
+-- Determine how many events fit in current batch
+local eventsForCurrentBatch = {}
+local eventsForOverflow = {}
+
+if #eventsToAdd <= capacity then
+  -- All events fit in current batch
+  eventsForCurrentBatch = eventsToAdd
+else
+  -- Split events between current batch and overflow
+  for i = 1, capacity do
+    table.insert(eventsForCurrentBatch, eventsToAdd[i])
+  end
+  for i = capacity + 1, #eventsToAdd do
+    table.insert(eventsForOverflow, eventsToAdd[i])
+  end
+end
+
+-- Add events to current batch
+local finalLen = currentLen
+if #eventsForCurrentBatch > 0 then
+  finalLen = redis.call("RPUSH", batchKey, unpack(eventsForCurrentBatch))
+end
+
+-- Check batch size limit
+local batchMemorySize = redis.call("MEMORY", "USAGE", batchKey) or 0
+
+-- Determine the result status
+local status = "append"
+local nextBatchID = nil
+local overflowCount = 0
+
+-- Check if this was the first item(s) in a new batch
+if currentLen == 0 then
+  status = "new"
+end
+
+-- Check if batch is full (count or size limit)
+local batchFull = finalLen >= batchLimit or batchMemorySize >= batchSizeLimit
+
+if batchFull then
+  -- Mark current batch as started
+  if not is_status_empty(batchMetadataKey) then
+    set_batch_status(batchMetadataKey, batchStatusStarted)
+  end
+
+  -- Check if we have overflow events
+  if #eventsForOverflow > 0 then
+    -- Create new batch for overflow
+    update_pointer(batchPointerKey, overflowULID)
+    nextBatchID = overflowULID
+
+    -- Set up new batch
+    local overflowBatchKey = string.format(keyfmt, prefix, overflowULID)
+    local overflowMetadataKey = string.format("%s:metadata", overflowBatchKey)
+
+    -- Add overflow events to new batch
+    redis.call("RPUSH", overflowBatchKey, unpack(eventsForOverflow))
+    set_batch_status(overflowMetadataKey, batchStatusAppending)
+
+    overflowCount = #eventsForOverflow
+    status = "overflow"
+  else
+    -- No overflow, just rotate the pointer for next batch
+    update_pointer(batchPointerKey, overflowULID)
+
+    if batchMemorySize >= batchSizeLimit then
+      status = "maxsize"
+    else
+      status = "full"
+    end
+  end
+end
+
+return cjson.encode({
+  status = status,
+  batchID = batchID,
+  batchPointerKey = batchPointerKey,
+  committed = #eventsForCurrentBatch + overflowCount,
+  duplicates = duplicateCount,
+  nextBatchID = nextBatchID,
+  overflowCount = overflowCount
+})

--- a/pkg/execution/batch/lua/bulk_append.lua
+++ b/pkg/execution/batch/lua/bulk_append.lua
@@ -174,7 +174,7 @@ return cjson.encode({
   status = status,
   batchID = batchID,
   batchPointerKey = batchPointerKey,
-  committed = #eventsForCurrentBatch + overflowCount,
+  committed = #eventsToAdd,
   duplicates = duplicateCount,
   nextBatchID = nextBatchID,
   overflowCount = overflowCount

--- a/pkg/execution/batch/lua/start.lua
+++ b/pkg/execution/batch/lua/start.lua
@@ -26,7 +26,7 @@ end
 -- This prevents overwriting the pointer when bulk_append has already
 -- created an overflow batch and updated the pointer to it.
 local currentPointer = redis.call("GET", batchPointerKey)
-if batchID == nil or batchID == "" or currentPointer == batchID then
+if is_empty(batchID) or is_empty(currentPointer) or currentPointer == batchID then
   update_pointer(batchPointerKey, newBatchID)
 end
 

--- a/pkg/execution/batch/lua/start.lua
+++ b/pkg/execution/batch/lua/start.lua
@@ -4,12 +4,14 @@
 -- Return values:
 --   0: Can start
 --   1: Already started
+--  -1: Batch metadata absent
 --
 local batchMetadataKey = KEYS[1] -- key for batch metadata
 local batchPointerKey = KEYS[2]  -- key for pointer
 
 local batchStatusStarted = ARGV[1]
 local newBatchID = ARGV[2] -- the ULID for a new batch
+local batchID = ARGV[3]    -- the batch ID being started (optional, for conditional pointer update)
 
 -- $include(helpers.lua)
 
@@ -20,7 +22,13 @@ if status == batchStatusStarted then
   return 1
 end
 
-update_pointer(batchPointerKey, newBatchID)
+-- Only update the pointer if it currently points to this batch.
+-- This prevents overwriting the pointer when bulk_append has already
+-- created an overflow batch and updated the pointer to it.
+local currentPointer = redis.call("GET", batchPointerKey)
+if batchID == nil or batchID == "" or currentPointer == batchID then
+  update_pointer(batchPointerKey, newBatchID)
+end
 
 if is_status_empty(batchMetadataKey) then
   -- status doesn't exist, something is wrong, abort

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -260,6 +260,7 @@ func (b *redisBatchManager) StartExecution(ctx context.Context, functionId uuid.
 	args := []string{
 		enums.BatchStatusStarted.String(),
 		ulid.Make().String(),
+		batchID.String(), // Pass batchID for conditional pointer update
 	}
 
 	status, err := retriableScripts["start"].Exec(

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -202,6 +202,9 @@ func (s *svc) Run(ctx context.Context) error {
 }
 
 func (s *svc) Stop(ctx context.Context) error {
+	if s.batcher != nil {
+		return s.batcher.Close()
+	}
 	return nil
 }
 

--- a/pkg/telemetry/metrics/batch_buffer.go
+++ b/pkg/telemetry/metrics/batch_buffer.go
@@ -1,0 +1,145 @@
+package metrics
+
+import (
+	"context"
+)
+
+var (
+	batchBufferWaitDurationBoundaries = []float64{5, 10, 25, 50, 100, 200, 500, 1000, 2000, 3000, 5000}
+	batchBufferFlushSizeBoundaries    = []float64{1, 2, 5, 10, 20, 50, 100, 200, 500}
+)
+
+// #1 - Gauge: items currently in-memory waiting to flush
+func GaugeBatchBufferItemsPending(ctx context.Context, val int64, opts GaugeOpt) {
+	RecordGaugeMetric(ctx, val, GaugeOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "batch_buffer_items_pending",
+		Description: "Items currently in-memory waiting to flush",
+		Tags:        opts.Tags,
+	})
+}
+
+// #2 - Gauge: active buffer keys (fn + batch pointer combos)
+func GaugeBatchBufferKeysActive(ctx context.Context, val int64, opts GaugeOpt) {
+	RecordGaugeMetric(ctx, val, GaugeOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "batch_buffer_keys_active",
+		Description: "Active buffer keys (fn + batch pointer combos)",
+		Tags:        opts.Tags,
+	})
+}
+
+// #3 - Counter: flush count by trigger type
+func IncrBatchBufferFlushCounter(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "batch_buffer_flush_total",
+		Description: "Total number of batch buffer flushes",
+		Tags:        opts.Tags,
+	})
+}
+
+// #4 - Counter: items flushed by trigger type
+func IncrBatchBufferItemsFlushedCounter(ctx context.Context, count int64, opts CounterOpt) {
+	RecordCounterMetric(ctx, count, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "batch_buffer_items_flushed_total",
+		Description: "Total number of items flushed from batch buffer",
+		Tags:        opts.Tags,
+	})
+}
+
+// #5 - Counter: in-memory duplicate catches
+func IncrBatchBufferDedupCounter(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "batch_buffer_dedup_total",
+		Description: "Total number of in-memory duplicate event catches",
+		Tags:        opts.Tags,
+	})
+}
+
+// #6 - Histogram: time items wait in buffer before flush
+func HistogramBatchBufferWaitDuration(ctx context.Context, dur int64, opts HistogramOpt) {
+	RecordIntHistogramMetric(ctx, dur, HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "batch_buffer_wait_duration",
+		Description: "Distribution of time items wait in buffer before flush",
+		Tags:        opts.Tags,
+		Unit:        "ms",
+		Boundaries:  batchBufferWaitDurationBoundaries,
+	})
+}
+
+// #7 - Histogram: items per flush
+func HistogramBatchBufferFlushSize(ctx context.Context, val int64, opts HistogramOpt) {
+	RecordIntHistogramMetric(ctx, val, HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "batch_buffer_flush_size",
+		Description: "Distribution of items per flush",
+		Tags:        opts.Tags,
+		Boundaries:  batchBufferFlushSizeBoundaries,
+	})
+}
+
+// #8 - Histogram: BulkAppend Redis call latency
+func HistogramBatchBufferRedisFlushDuration(ctx context.Context, dur int64, opts HistogramOpt) {
+	RecordIntHistogramMetric(ctx, dur, HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "batch_buffer_redis_flush_duration",
+		Description: "Distribution of BulkAppend Redis call latency",
+		Tags:        opts.Tags,
+		Unit:        "ms",
+		Boundaries:  DefaultBoundaries,
+	})
+}
+
+// #9 - Counter: BulkAppend results by status
+func IncrBatchBufferBulkAppendCounter(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "batch_buffer_bulk_append_total",
+		Description: "Total number of BulkAppend results by status",
+		Tags:        opts.Tags,
+	})
+}
+
+// #10 - Counter: items committed to Redis
+func IncrBatchBufferItemsCommittedCounter(ctx context.Context, count int64, opts CounterOpt) {
+	RecordCounterMetric(ctx, count, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "batch_buffer_items_committed_total",
+		Description: "Total number of items committed to Redis",
+		Tags:        opts.Tags,
+	})
+}
+
+// #11 - Counter: Redis-level duplicates
+func IncrBatchBufferItemsDuplicatedCounter(ctx context.Context, count int64, opts CounterOpt) {
+	RecordCounterMetric(ctx, count, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "batch_buffer_items_duplicated_total",
+		Description: "Total number of Redis-level duplicate items",
+		Tags:        opts.Tags,
+	})
+}
+
+// #12 - Counter: errors by error_type
+func IncrBatchBufferErrorsCounter(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "batch_buffer_errors_total",
+		Description: "Total number of batch buffer errors",
+		Tags:        opts.Tags,
+	})
+}
+
+// #13 - Counter: execution schedule operations
+func IncrBatchBufferScheduleCounter(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "batch_buffer_schedule_total",
+		Description: "Total number of batch buffer execution schedule operations",
+		Tags:        opts.Tags,
+	})
+}

--- a/pkg/util/strduration/strduration.go
+++ b/pkg/util/strduration/strduration.go
@@ -24,6 +24,15 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 		return nil
 	}
 
+	// if the value is a JSON number, parse it as a time.Duration
+	if len(b) > 0 && (b[0] >= '0' && b[0] <= '9' || b[0] == '-') {
+		var n float64
+		if err := json.Unmarshal(b, &n); err == nil {
+			*d = Duration(time.Duration(n))
+			return nil
+		}
+	}
+
 	var s string
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err

--- a/pkg/util/strduration/strduration_test.go
+++ b/pkg/util/strduration/strduration_test.go
@@ -16,12 +16,100 @@ func TestStringDurationMarshalJSON(t *testing.T) {
 	require.Equal(t, `"1d30m"`, string(data))
 }
 
-func TestStringDurationUnmarshalJSON(t *testing.T) {
-	var sd Duration
+func TestStringDurationUnmarshalJSONString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Duration
+	}{
+		{
+			name:     "days and minutes",
+			input:    `"1d30m"`,
+			expected: Duration(24*time.Hour + 30*time.Minute),
+		},
+		{
+			name:     "hours only",
+			input:    `"2h"`,
+			expected: Duration(2 * time.Hour),
+		},
+		{
+			name:     "minutes only",
+			input:    `"45m"`,
+			expected: Duration(45 * time.Minute),
+		},
+		{
+			name:     "seconds only",
+			input:    `"30s"`,
+			expected: Duration(30 * time.Second),
+		},
+		{
+			name:     "hours minutes seconds",
+			input:    `"1h30m10s"`,
+			expected: Duration(time.Hour + 30*time.Minute + 10*time.Second),
+		},
+		{
+			name:     "days only",
+			input:    `"7d"`,
+			expected: Duration(7 * 24 * time.Hour),
+		},
+		{
+			name:     "weeks",
+			input:    `"1w"`,
+			expected: Duration(7 * 24 * time.Hour),
+		},
+		{
+			name:     "milliseconds",
+			input:    `"500ms"`,
+			expected: Duration(500 * time.Millisecond),
+		},
+	}
 
-	err := json.Unmarshal([]byte(`"1d30m"`), &sd)
-	require.NoError(t, err)
-	require.Equal(t, Duration(24*time.Hour+30*time.Minute), sd)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sd Duration
+			err := json.Unmarshal([]byte(tt.input), &sd)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, sd)
+		})
+	}
+}
+
+func TestStringDurationUnmarshalJSONNumber(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Duration
+	}{
+		{
+			name:     "integer nanoseconds",
+			input:    `1000000000`,
+			expected: Duration(time.Second),
+		},
+		{
+			name:     "float nanoseconds",
+			input:    `1.5e9`,
+			expected: Duration(1500 * time.Millisecond),
+		},
+		{
+			name:     "negative nanoseconds",
+			input:    `-5000000000`,
+			expected: Duration(-5 * time.Second),
+		},
+		{
+			name:     "zero",
+			input:    `0`,
+			expected: Duration(0),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sd Duration
+			err := json.Unmarshal([]byte(tt.input), &sd)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, sd)
+		})
+	}
 }
 
 func TestStringDurationUnmarshalJSONErrors(t *testing.T) {

--- a/tests/client/function_run.go
+++ b/tests/client/function_run.go
@@ -214,7 +214,7 @@ func (c *Client) WaitForRunStatus(
 		o = opts[0]
 	}
 
-	timeout := 5 * time.Second
+	timeout := 10 * time.Second
 	if o.Timeout > 0 {
 		timeout = o.Timeout
 	}

--- a/tests/golang/batch_test.go
+++ b/tests/golang/batch_test.go
@@ -377,16 +377,21 @@ func TestBatchInvoke(t *testing.T) {
 		}
 
 		// First trigger should be because of batch is full
-		<-time.After(2 * time.Second)
-		require.EqualValues(t, 1, atomic.LoadInt32(&counter))
-		require.EqualValues(t, 3, atomic.LoadInt32(&totalEvents))
-		require.EqualValues(t, 3, atomic.LoadInt32(&invokeCounter))
+		<-time.After(1 * time.Second)
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.EqualValues(t, 1, atomic.LoadInt32(&counter))
+			assert.EqualValues(t, 3, atomic.LoadInt32(&totalEvents))
+			assert.EqualValues(t, 3, atomic.LoadInt32(&invokeCounter))
+		}, time.Second*3, time.Millisecond)
 
 		// Second trigger should be because of the batch timeout
 		<-time.After(6 * time.Second)
-		require.EqualValues(t, 2, atomic.LoadInt32(&counter))
-		require.EqualValues(t, 5, atomic.LoadInt32(&totalEvents))
-		require.EqualValues(t, 5, atomic.LoadInt32(&invokeCounter))
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.EqualValues(t, 2, atomic.LoadInt32(&counter))
+			assert.EqualValues(t, 5, atomic.LoadInt32(&totalEvents))
+			assert.EqualValues(t, 5, atomic.LoadInt32(&invokeCounter))
+		}, time.Second*9, time.Millisecond)
 	})
 }
 

--- a/tests/golang/batch_test.go
+++ b/tests/golang/batch_test.go
@@ -385,13 +385,13 @@ func TestBatchInvoke(t *testing.T) {
 		}, time.Second*3, time.Millisecond)
 
 		// Second trigger should be because of the batch timeout
-		<-time.After(6 * time.Second)
+		<-time.After(2 * time.Second)
 
 		require.EventuallyWithT(t, func(t *assert.CollectT) {
 			assert.EqualValues(t, 2, atomic.LoadInt32(&counter))
 			assert.EqualValues(t, 5, atomic.LoadInt32(&totalEvents))
 			assert.EqualValues(t, 5, atomic.LoadInt32(&invokeCounter))
-		}, time.Second*9, time.Millisecond)
+		}, time.Second*15, time.Millisecond)
 	})
 }
 

--- a/tests/golang/batch_test.go
+++ b/tests/golang/batch_test.go
@@ -322,7 +322,7 @@ func TestBatchInvoke(t *testing.T) {
 			Name: "test batching",
 			BatchEvents: &inngestgo.ConfigBatchEvents{
 				MaxSize: 3,
-				Timeout: 5 * time.Second,
+				Timeout: 2 * time.Second,
 			},
 		},
 		inngestgo.EventTrigger("batchinvoke/batch", nil),

--- a/tests/golang/batch_test.go
+++ b/tests/golang/batch_test.go
@@ -57,10 +57,10 @@ func TestBatchEvents(t *testing.T) {
 	registerFuncs()
 
 	t.Run("trigger batch", func(t *testing.T) {
-		for i := 0; i < 8; i++ {
+		for i := range 8 {
 			_, err := inngestClient.Send(ctx, BatchEvent{
 				Name: "test/batch",
-				Data: BatchEventData{Time: time.Now()},
+				Data: BatchEventData{Time: time.Now(), Num: i},
 			})
 			require.NoError(t, err)
 		}
@@ -206,7 +206,6 @@ func TestBatchWithConditionalTrigger(t *testing.T) {
 		<-time.After(6 * time.Second)
 		assert.EqualValues(t, 1, atomic.LoadInt32(&counter))
 		assert.EqualValues(t, 5, atomic.LoadInt32(&totalEvents))
-
 	})
 }
 
@@ -253,7 +252,6 @@ func TestConditionalBatching(t *testing.T) {
 		<-time.After(6 * time.Second)
 		assert.EqualValues(t, 6, atomic.LoadInt32(&counter))
 		assert.EqualValues(t, 10, atomic.LoadInt32(&totalEvents))
-
 	})
 }
 
@@ -302,7 +300,6 @@ func TestConditionalBatchingWithEventTriggerCondition(t *testing.T) {
 		<-time.After(6 * time.Second)
 		assert.EqualValues(t, 6, atomic.LoadInt32(&counter))
 		assert.EqualValues(t, 10, atomic.LoadInt32(&totalEvents))
-
 	})
 }
 
@@ -389,7 +386,7 @@ func TestBatchInvoke(t *testing.T) {
 	})
 }
 
-func TestBatchEventsWithKeys(t *testing.T) {
+func TestBatchKeyEvents(t *testing.T) {
 	type BatchEventDataWithUserId struct {
 		Time   time.Time `json:"time"`
 		UserId string    `json:"userId"`
@@ -400,9 +397,7 @@ func TestBatchEventsWithKeys(t *testing.T) {
 	inngestClient, server, registerFuncs := NewSDKHandler(t, "user-notifications")
 	defer server.Close()
 
-	var (
-		totalEvents int32
-	)
+	var totalEvents int32
 
 	batchInvokedCounter := make(map[string]int32)
 	batchEventsCounter := make(map[string]int)

--- a/tests/golang/batch_test.go
+++ b/tests/golang/batch_test.go
@@ -379,7 +379,7 @@ func TestBatchInvoke(t *testing.T) {
 		require.EqualValues(t, 3, atomic.LoadInt32(&invokeCounter))
 
 		// Second trigger should be because of the batch timeout
-		<-time.After(5 * time.Second)
+		<-time.After(6 * time.Second)
 		require.EqualValues(t, 2, atomic.LoadInt32(&counter))
 		require.EqualValues(t, 5, atomic.LoadInt32(&totalEvents))
 		require.EqualValues(t, 5, atomic.LoadInt32(&invokeCounter))

--- a/tests/golang/checkpoint_test.go
+++ b/tests/golang/checkpoint_test.go
@@ -67,8 +67,8 @@ func TestFnCheckpoint(t *testing.T) {
 						<-time.After(delay)
 						return "c", nil
 					})
-					fmt.Println("c")
 					runID = input.InputCtx.RunID
+					fmt.Println("c (done), ", runID)
 					return nil, nil
 				},
 			)

--- a/tests/golang/checkpoint_test.go
+++ b/tests/golang/checkpoint_test.go
@@ -84,6 +84,8 @@ func TestFnCheckpoint(t *testing.T) {
 				assert.NotEmpty(t, runID)
 			}, 5*time.Second, time.Millisecond)
 
+			<-time.After(4 * time.Second)
+
 			run := c.WaitForRunStatus(ctx, t, "COMPLETED", &runID)
 			var output string
 			err = json.Unmarshal([]byte(run.Output), &output)

--- a/vendor/github.com/inngest/inngestgo/.gitignore
+++ b/vendor/github.com/inngest/inngestgo/.gitignore
@@ -38,3 +38,4 @@ node_modules
 
 # AI
 CLAUDE.md
+/.claude/

--- a/vendor/github.com/inngest/inngestgo/connect.go
+++ b/vendor/github.com/inngest/inngestgo/connect.go
@@ -28,6 +28,12 @@ type ConnectOpts struct {
 	// If this value is not set we use the environment variable "INNGEST_CONNECT_MAX_WORKER_CONCURRENCY".
 	// Defaults to 0. There is no limit if this is 0.
 	MaxWorkerConcurrency *int64
+
+	// MessageReadLimit sets the max number of bytes to read for a single WebSocket message.
+	// By default (nil or 0), the connection has a message read limit of 32768 bytes (32KB).
+	// Set to -1 to disable the limit.
+	// Set to any positive value to use a custom limit.
+	MessageReadLimit *int64
 }
 
 func Connect(ctx context.Context, opts ConnectOpts) (connect.WorkerConnection, error) {
@@ -35,10 +41,6 @@ func Connect(ctx context.Context, opts ConnectOpts) (connect.WorkerConnection, e
 	connectPlaceholder := url.URL{
 		Scheme: "ws",
 		Host:   "connect",
-	}
-
-	if opts.InstanceID == nil {
-		return nil, fmt.Errorf("missing required Instance ID")
 	}
 
 	apps := make([]connect.ConnectApp, len(opts.Apps))
@@ -103,6 +105,7 @@ func Connect(ctx context.Context, opts ConnectOpts) (connect.WorkerConnection, e
 		HashedSigningKey:         hashedKey,
 		HashedSigningKeyFallback: hashedFallbackKey,
 		MaxWorkerConcurrency:     opts.MaxWorkerConcurrency,
+		MessageReadLimit:         opts.MessageReadLimit,
 		APIBaseUrl:               defaultClient.h.GetAPIBaseURL(),
 		IsDev:                    defaultClient.h.isDev(),
 		DevServerUrl:             env.DevServerURL(),

--- a/vendor/github.com/inngest/inngestgo/connect/connection.go
+++ b/vendor/github.com/inngest/inngestgo/connect/connection.go
@@ -17,6 +17,10 @@ import (
 	"time"
 )
 
+var (
+	defaultWSReadLimit int64 = 10 * 1024 * 1024 // 10MB
+)
+
 type connectReport struct {
 	reconnect bool
 	err       error
@@ -142,6 +146,13 @@ func (h *connectHandler) prepareConnection(ctx context.Context, data connectionE
 	if err != nil {
 		return nil, newReconnectErr(fmt.Errorf("could not connect to gateway: %w", err))
 	}
+
+	// Set message read limit if configured (skip if nil or 0 to use default)
+	readLimit := defaultWSReadLimit
+	if h.opts.MessageReadLimit != nil && *h.opts.MessageReadLimit != 0 {
+		readLimit = *h.opts.MessageReadLimit
+	}
+	ws.SetReadLimit(readLimit)
 
 	connectionId, err := ulid.Parse(startRes.GetConnectionId())
 	if err != nil {

--- a/vendor/github.com/inngest/inngestgo/connect/handler.go
+++ b/vendor/github.com/inngest/inngestgo/connect/handler.go
@@ -114,6 +114,12 @@ type Opts struct {
 
 	MaxWorkerConcurrency *int64
 
+	// MessageReadLimit sets the max number of bytes to read for a single WebSocket message.
+	// By default (nil or 0), the connection has a message read limit of 10MB.
+	// Set to -1 to disable the limit.
+	// Set to any positive value to use a custom limit.
+	MessageReadLimit *int64
+
 	APIBaseUrl   string
 	IsDev        bool
 	DevServerUrl string

--- a/vendor/github.com/inngest/inngestgo/handler.go
+++ b/vendor/github.com/inngest/inngestgo/handler.go
@@ -1208,6 +1208,7 @@ func invoke(
 		Mode:               sdkrequest.StepModeYield,
 		APIBaseURL:         env.APIServerURL(client.Options().APIBaseURL),
 	})
+	defer mgr.CloseCheckpointer()
 	fCtx = sdkrequest.SetManager(fCtx, mgr)
 
 	// Create a new Input type.  We don't know ahead of time the type signature as

--- a/vendor/github.com/inngest/inngestgo/internal/fn/sync.go
+++ b/vendor/github.com/inngest/inngestgo/internal/fn/sync.go
@@ -1,6 +1,10 @@
 package fn
 
-import "net/url"
+import (
+	"net/url"
+
+	"github.com/inngest/inngestgo/pkg/checkpoint"
+)
 
 func GetFnSyncConfig(fn ServableFunction) *SyncConfig {
 	config := fn.Config()
@@ -16,6 +20,7 @@ func GetFnSyncConfig(fn ServableFunction) *SyncConfig {
 		RateLimit:   config.RateLimit,
 		Throttle:    config.Throttle,
 		Debounce:    config.Debounce,
+		Checkpoint:  config.Checkpoint,
 		Timeouts:    config.Timeouts,
 		Cancel:      config.Cancel,
 		Retries:     config.Retries,
@@ -68,6 +73,8 @@ type SyncConfig struct {
 	Retries *int `json:"retries,omitempty"`
 
 	Debounce *Debounce `json:"debounce,omitempty"`
+
+	Checkpoint *checkpoint.Config `json:"checkpoint,omitempty"`
 
 	Timeouts *Timeouts `json:"timeouts,omitempty"`
 

--- a/vendor/github.com/inngest/inngestgo/internal/sdkrequest/manager.go
+++ b/vendor/github.com/inngest/inngestgo/internal/sdkrequest/manager.go
@@ -82,6 +82,9 @@ type InvocationManager interface {
 	// SetFn updates the servable function.  This is necessary because functions are discovered
 	// before the first step execution in REST-based sync functions.
 	SetFn(fn.ServableFunction)
+	// CloseCheckpointer cancels any pending background checkpoint timers.
+	// It should be called when the function invocation completes.
+	CloseCheckpointer()
 }
 
 type Opts struct {
@@ -377,6 +380,10 @@ func (r *requestCtxManager) SetSteps(steps map[string]json.RawMessage) {
 // before the first step execution in REST-based sync functions.
 func (r *requestCtxManager) SetFn(f fn.ServableFunction) {
 	r.fn = f
+}
+
+func (r *requestCtxManager) CloseCheckpointer() {
+	r.checkpointer.Close()
 }
 
 func (r *requestCtxManager) NewOp(op enums.Opcode, id string) UnhashedOp {

--- a/vendor/github.com/inngest/inngestgo/pkg/checkpoint/checkpoint.go
+++ b/vendor/github.com/inngest/inngestgo/pkg/checkpoint/checkpoint.go
@@ -1,6 +1,7 @@
 package checkpoint
 
 import (
+	"encoding/json"
 	"time"
 )
 
@@ -22,19 +23,23 @@ type Config struct {
 	//
 	// This must be higher than zero to enable batching of steps.  When enabled with BatchInterval,
 	// whichever limit is hit first will checkpoint steps.
-	BatchSteps int
+	BatchSteps int `json:"batch_steps,omitempty,omitzero"`
 
 	// BatchInterval represents the maximum time that we wait after a step runs before checkpointing.
 	// When this limit is hit, checkpointing will occur and the SDK will block until checkpointing completes.
 	//
 	// This must be higher than zero to enable batching based off of durations.  When enabled with BatchSteps,
 	// whichever lmiit is hit first will checkpoint steps.
-	BatchInterval time.Duration
+	//
+	// This is a string-encoded time.Duration field.
+	BatchInterval time.Duration `json:"batch_interval,omitempty,omitzero"`
 
 	// MaxRuntime indicates the maximum duration that a function can execute for before Inngest requires
 	// a fresh re-entry.  This is useful for serverless functions, ensuring that a fresh request is made
 	// after a maximum amount of time.
-	MaxRuntime time.Duration
+	//
+	// This is a string-encoded time.Duration field.
+	MaxRuntime time.Duration `json:"max_runtime,omitempty,omitzero"`
 
 	// MaxSteps represents the maximum number of steps the function can execute before
 	// stopping execution and waiting for another re-entry.  This is useful for serverless functions,
@@ -44,6 +49,20 @@ type Config struct {
 	// If zero, there are no limits on the number of steps that can be executed, and the SDK will execute
 	// step.run calls until an async step is reached.
 	// MaxSteps int
+}
+
+func (c Config) MarshalJSON() ([]byte, error) {
+	data := map[string]any{}
+	if c.BatchSteps > 0 {
+		data["batch_steps"] = c.BatchSteps
+	}
+	if c.BatchInterval > 0 {
+		data["batch_interval"] = c.BatchInterval.String()
+	}
+	if c.MaxRuntime > 0 {
+		data["max_runtime"] = c.MaxRuntime
+	}
+	return json.Marshal(data)
 }
 
 const (

--- a/vendor/go.uber.org/goleak/.gitignore
+++ b/vendor/go.uber.org/goleak/.gitignore
@@ -1,0 +1,5 @@
+vendor/
+/bin
+/lint.log
+/cover.out
+/cover.html

--- a/vendor/go.uber.org/goleak/.golangci.yml
+++ b/vendor/go.uber.org/goleak/.golangci.yml
@@ -1,0 +1,28 @@
+output:
+  # Make output more digestible with quickfix in vim/emacs/etc.
+  sort-results: true
+  print-issued-lines: false
+
+linters:
+  enable:
+    - gofumpt
+    - nolintlint
+    - revive
+
+linters-settings:
+  govet:
+    # These govet checks are disabled by default, but they're useful.
+    enable:
+      - niliness
+      - reflectvaluecompare
+      - sortslice
+      - unusedwrite
+
+issues:
+  # Print all issues reported by all linters.
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+  # Don't ignore some of the issues that golangci-lint considers okay.
+  # This includes documenting all exported entities.
+  exclude-use-default: false

--- a/vendor/go.uber.org/goleak/CHANGELOG.md
+++ b/vendor/go.uber.org/goleak/CHANGELOG.md
@@ -1,0 +1,74 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [1.3.0]
+### Fixed
+- Built-in ignores now match function names more accurately.
+  They will no longer ignore stacks because of file names
+  that look similar to function names. (#112)
+### Added
+- Add an `IgnoreAnyFunction` option to ignore stack traces
+  that have the provided function anywhere in the stack. (#113)
+- Ignore `testing.runFuzzing` and `testing.runFuzzTests` alongside
+  other already-ignored test functions (`testing.RunTests`, etc). (#105)
+### Changed
+- Miscellaneous CI-related fixes. (#103, #108, #114)
+
+[1.3.0]: https://github.com/uber-go/goleak/compare/v1.2.1...v1.3.0
+
+## [1.2.1]
+### Changed
+- Drop golang/x/lint dependency.
+
+[1.2.1]: https://github.com/uber-go/goleak/compare/v1.2.0...v1.2.1
+
+## [1.2.0]
+### Added
+- Add Cleanup option that can be used for registering cleanup callbacks. (#78)
+
+### Changed
+- Mark VerifyNone as a test helper. (#75)
+
+Thanks to @tallclair for their contribution to this release.
+
+[1.2.0]: https://github.com/uber-go/goleak/compare/v1.1.12...v1.2.0
+
+## [1.1.12]
+### Fixed
+- Fixed logic for ignoring trace related goroutines on Go versions 1.16 and above.
+
+[1.1.12]: https://github.com/uber-go/goleak/compare/v1.1.11...v1.1.12
+
+## [1.1.11]
+### Fixed
+- Documentation fix on how to test.
+- Update dependency on stretchr/testify to v1.7.0. (#59)
+- Update dependency on golang.org/x/tools to address CVE-2020-14040. (#62)
+
+[1.1.11]: https://github.com/uber-go/goleak/compare/v1.1.10...v1.1.11
+
+## [1.1.10]
+### Added
+- [#49]: Add option to ignore current goroutines, which checks for any additional leaks and allows for incremental adoption of goleak in larger projects.
+
+Thanks to @denis-tingajkin for their contributions to this release.
+
+[#49]: https://github.com/uber-go/goleak/pull/49
+[1.1.10]: https://github.com/uber-go/goleak/compare/v1.0.0...v1.1.10
+
+## [1.0.0]
+### Changed
+- Migrate to Go modules.
+
+### Fixed
+- Ignore trace related goroutines that cause false positives with -trace.
+
+[1.0.0]: https://github.com/uber-go/goleak/compare/v0.10.0...v1.0.0
+
+## [0.10.0]
+- Initial release.
+
+[0.10.0]: https://github.com/uber-go/goleak/compare/v0.10.0...HEAD

--- a/vendor/go.uber.org/goleak/LICENSE
+++ b/vendor/go.uber.org/goleak/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 Uber Technologies, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/go.uber.org/goleak/Makefile
+++ b/vendor/go.uber.org/goleak/Makefile
@@ -1,0 +1,45 @@
+# Directory containing the Makefile.
+PROJECT_ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+export GOBIN = $(PROJECT_ROOT)/bin
+export PATH := $(GOBIN):$(PATH)
+
+GO_FILES = $(shell find . \
+	   -path '*/.*' -prune -o \
+	   '(' -type f -a -name '*.go' ')' -print)
+
+# Additional test flags.
+TEST_FLAGS ?=
+
+.PHONY: all
+all: lint build test
+
+.PHONY: lint
+lint: golangci-lint tidy-lint
+
+.PHONY: build
+build:
+	go build ./...
+
+.PHONY: test
+test:
+	go test -v -race ./...
+	go test -v -trace=/dev/null .
+
+.PHONY: cover
+cover:
+	go test -race -coverprofile=cover.out -coverpkg=./... ./...
+	go tool cover -html=cover.out -o cover.html
+
+.PHONY: golangci-lint
+golangci-lint:
+	golangci-lint run
+
+.PHONY: tidy
+tidy:
+	go mod tidy
+
+.PHONY: tidy-lint
+tidy-lint:
+	go mod tidy
+	git diff --exit-code -- go.mod go.sum

--- a/vendor/go.uber.org/goleak/README.md
+++ b/vendor/go.uber.org/goleak/README.md
@@ -1,0 +1,74 @@
+# goleak [![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+
+Goroutine leak detector to help avoid Goroutine leaks.
+
+## Installation
+
+You can use `go get` to get the latest version:
+
+`go get -u go.uber.org/goleak`
+
+`goleak` also supports semver releases.
+
+Note that go-leak only [supports][release] the two most recent minor versions of Go.
+
+## Quick Start
+
+To verify that there are no unexpected goroutines running at the end of a test:
+
+```go
+func TestA(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// test logic here.
+}
+```
+
+Instead of checking for leaks at the end of every test, `goleak` can also be run
+at the end of every test package by creating a `TestMain` function for your
+package:
+
+```go
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+```
+
+## Determine Source of Package Leaks
+
+When verifying leaks using `TestMain`, the leak test is only run once after all tests
+have been run. This is typically enough to ensure there's no goroutines leaked from
+tests, but when there are leaks, it's hard to determine which test is causing them.
+
+You can use the following bash script to determine the source of the failing test:
+
+```sh
+# Create a test binary which will be used to run each test individually
+$ go test -c -o tests
+
+# Run each test individually, printing "." for successful tests, or the test name
+# for failing tests.
+$ for test in $(go test -list . | grep -E "^(Test|Example)"); do ./tests -test.run "^$test\$" &>/dev/null && echo -n "." || echo -e "\n$test failed"; done
+```
+
+This will only print names of failing tests which can be investigated individually. E.g.,
+
+```
+.....
+TestLeakyTest failed
+.......
+```
+
+## Stability
+
+goleak is v1 and follows [SemVer](http://semver.org/) strictly.
+
+No breaking changes will be made to exported APIs before 2.0.
+
+[doc-img]: https://godoc.org/go.uber.org/goleak?status.svg
+[doc]: https://godoc.org/go.uber.org/goleak
+[ci-img]: https://github.com/uber-go/goleak/actions/workflows/ci.yml/badge.svg
+[ci]: https://github.com/uber-go/goleak/actions/workflows/ci.yml
+[cov-img]: https://codecov.io/gh/uber-go/goleak/branch/master/graph/badge.svg
+[cov]: https://codecov.io/gh/uber-go/goleak
+[release]: https://go.dev/doc/devel/release#policy

--- a/vendor/go.uber.org/goleak/doc.go
+++ b/vendor/go.uber.org/goleak/doc.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package goleak is a Goroutine leak detector.
+package goleak // import "go.uber.org/goleak"

--- a/vendor/go.uber.org/goleak/internal/stack/doc.go
+++ b/vendor/go.uber.org/goleak/internal/stack/doc.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2017-2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package stack is used for parsing stacks from `runtime.Stack`.
+package stack

--- a/vendor/go.uber.org/goleak/internal/stack/scan.go
+++ b/vendor/go.uber.org/goleak/internal/stack/scan.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package stack
+
+import (
+	"bufio"
+	"io"
+)
+
+// scanner provides a bufio.Scanner the ability to Unscan,
+// which allows the current token to be read again
+// after the next Scan.
+type scanner struct {
+	*bufio.Scanner
+
+	unscanned bool
+}
+
+func newScanner(r io.Reader) *scanner {
+	return &scanner{Scanner: bufio.NewScanner(r)}
+}
+
+func (s *scanner) Scan() bool {
+	if s.unscanned {
+		s.unscanned = false
+		return true
+	}
+	return s.Scanner.Scan()
+}
+
+// Unscan stops the scanner from advancing its position
+// for the next Scan.
+//
+// Bytes and Text will return the same token after next Scan
+// that they do right now.
+func (s *scanner) Unscan() {
+	s.unscanned = true
+}

--- a/vendor/go.uber.org/goleak/internal/stack/stacks.go
+++ b/vendor/go.uber.org/goleak/internal/stack/stacks.go
@@ -1,0 +1,298 @@
+// Copyright (c) 2017-2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package stack
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+const _defaultBufferSize = 64 * 1024 // 64 KiB
+
+// Stack represents a single Goroutine's stack.
+type Stack struct {
+	id    int
+	state string // e.g. 'running', 'chan receive'
+
+	// The first function on the stack.
+	firstFunction string
+
+	// A set of all functions in the stack,
+	allFunctions map[string]struct{}
+
+	// Full, raw stack trace.
+	fullStack string
+}
+
+// ID returns the goroutine ID.
+func (s Stack) ID() int {
+	return s.id
+}
+
+// State returns the Goroutine's state.
+func (s Stack) State() string {
+	return s.state
+}
+
+// Full returns the full stack trace for this goroutine.
+func (s Stack) Full() string {
+	return s.fullStack
+}
+
+// FirstFunction returns the name of the first function on the stack.
+func (s Stack) FirstFunction() string {
+	return s.firstFunction
+}
+
+// HasFunction reports whether the stack has the given function
+// anywhere in it.
+func (s Stack) HasFunction(name string) bool {
+	_, ok := s.allFunctions[name]
+	return ok
+}
+
+func (s Stack) String() string {
+	return fmt.Sprintf(
+		"Goroutine %v in state %v, with %v on top of the stack:\n%s",
+		s.id, s.state, s.firstFunction, s.Full())
+}
+
+func getStacks(all bool) []Stack {
+	trace := getStackBuffer(all)
+	stacks, err := newStackParser(bytes.NewReader(trace)).Parse()
+	if err != nil {
+		// Well-formed stack traces should never fail to parse.
+		// If they do, it's a bug in this package.
+		// Panic so we can fix it.
+		panic(fmt.Sprintf("Failed to parse stack trace: %v\n%s", err, trace))
+	}
+	return stacks
+}
+
+type stackParser struct {
+	scan   *scanner
+	stacks []Stack
+	errors []error
+}
+
+func newStackParser(r io.Reader) *stackParser {
+	return &stackParser{
+		scan: newScanner(r),
+	}
+}
+
+func (p *stackParser) Parse() ([]Stack, error) {
+	for p.scan.Scan() {
+		line := p.scan.Text()
+
+		// If we see the goroutine header, start a new stack.
+		if strings.HasPrefix(line, "goroutine ") {
+			stack, err := p.parseStack(line)
+			if err != nil {
+				p.errors = append(p.errors, err)
+				continue
+			}
+			p.stacks = append(p.stacks, stack)
+		}
+	}
+
+	p.errors = append(p.errors, p.scan.Err())
+	return p.stacks, errors.Join(p.errors...)
+}
+
+// parseStack parses a single stack trace from the given scanner.
+// line is the first line of the stack trace, which should look like:
+//
+//	goroutine 123 [runnable]:
+func (p *stackParser) parseStack(line string) (Stack, error) {
+	id, state, err := parseGoStackHeader(line)
+	if err != nil {
+		return Stack{}, fmt.Errorf("parse header: %w", err)
+	}
+
+	// Read the rest of the stack trace.
+	var (
+		firstFunction string
+		fullStack     bytes.Buffer
+	)
+	funcs := make(map[string]struct{})
+	for p.scan.Scan() {
+		line := p.scan.Text()
+		if strings.HasPrefix(line, "goroutine ") {
+			// If we see the goroutine header,
+			// it's the end of this stack.
+			// Unscan so the next Scan sees the same line.
+			p.scan.Unscan()
+			break
+		}
+
+		fullStack.WriteString(line)
+		fullStack.WriteByte('\n') // scanner trims the newline
+
+		if len(line) == 0 {
+			// Empty line usually marks the end of the stack
+			// but we don't want to have to rely on that.
+			// Just skip it.
+			continue
+		}
+
+		funcName, creator, err := parseFuncName(line)
+		if err != nil {
+			return Stack{}, fmt.Errorf("parse function: %w", err)
+		}
+		if !creator {
+			// A function is part of a goroutine's stack
+			// only if it's not a "created by" function.
+			//
+			// The creator function is part of a different stack.
+			// We don't care about it right now.
+			funcs[funcName] = struct{}{}
+			if firstFunction == "" {
+				firstFunction = funcName
+			}
+
+		}
+
+		// The function name followed by a line in the form:
+		//
+		//	<tab>example.com/path/to/package/file.go:123 +0x123
+		//
+		// We don't care about the position so we can skip this line.
+		if p.scan.Scan() {
+			// Be defensive:
+			// Skip the line only if it starts with a tab.
+			bs := p.scan.Bytes()
+			if len(bs) > 0 && bs[0] == '\t' {
+				fullStack.Write(bs)
+				fullStack.WriteByte('\n')
+			} else {
+				// Put it back and let the next iteration handle it
+				// if it doesn't start with a tab.
+				p.scan.Unscan()
+			}
+		}
+
+		if creator {
+			// The "created by" line is the last line of the stack.
+			// We can stop parsing now.
+			//
+			// Note that if tracebackancestors=N is set,
+			// there may be more a traceback of the creator function
+			// following the "created by" line,
+			// but it should not be considered part of this stack.
+			// e.g.,
+			//
+			// created by testing.(*T).Run in goroutine 1
+			//         /usr/lib/go/src/testing/testing.go:1648 +0x3ad
+			// [originating from goroutine 1]:
+			// testing.(*T).Run(...)
+			//         /usr/lib/go/src/testing/testing.go:1649 +0x3ad
+			//
+			break
+		}
+	}
+
+	return Stack{
+		id:            id,
+		state:         state,
+		firstFunction: firstFunction,
+		allFunctions:  funcs,
+		fullStack:     fullStack.String(),
+	}, nil
+}
+
+// All returns the stacks for all running goroutines.
+func All() []Stack {
+	return getStacks(true)
+}
+
+// Current returns the stack for the current goroutine.
+func Current() Stack {
+	return getStacks(false)[0]
+}
+
+func getStackBuffer(all bool) []byte {
+	for i := _defaultBufferSize; ; i *= 2 {
+		buf := make([]byte, i)
+		if n := runtime.Stack(buf, all); n < i {
+			return buf[:n]
+		}
+	}
+}
+
+// Parses a single function from the given line.
+// The line is in one of these formats:
+//
+//	example.com/path/to/package.funcName(args...)
+//	example.com/path/to/package.(*typeName).funcName(args...)
+//	created by example.com/path/to/package.funcName
+//	created by example.com/path/to/package.funcName in goroutine [...]
+//
+// Also reports whether the line was a "created by" line.
+func parseFuncName(line string) (name string, creator bool, err error) {
+	if after, ok := strings.CutPrefix(line, "created by "); ok {
+		// The function name is the part after "created by "
+		// and before " in goroutine [...]".
+		idx := strings.Index(after, " in goroutine")
+		if idx >= 0 {
+			after = after[:idx]
+		}
+		name = after
+		creator = true
+	} else if idx := strings.LastIndexByte(line, '('); idx >= 0 {
+		// The function name is the part before the last '('.
+		name = line[:idx]
+	}
+
+	if name == "" {
+		return "", false, fmt.Errorf("no function found: %q", line)
+	}
+
+	return name, creator, nil
+}
+
+// parseGoStackHeader parses a stack header that looks like:
+// goroutine 643 [runnable]:\n
+// And returns the goroutine ID, and the state.
+func parseGoStackHeader(line string) (goroutineID int, state string, err error) {
+	// The scanner will have already trimmed the "\n",
+	// but we'll guard against it just in case.
+	//
+	// Trimming them separately makes them both optional.
+	line = strings.TrimSuffix(strings.TrimSuffix(line, ":"), "\n")
+	parts := strings.SplitN(line, " ", 3)
+	if len(parts) != 3 {
+		return 0, "", fmt.Errorf("unexpected format: %q", line)
+	}
+
+	id, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, "", fmt.Errorf("bad goroutine ID %q in line %q", parts[1], line)
+	}
+
+	state = strings.TrimSuffix(strings.TrimPrefix(parts[2], "["), "]")
+	return id, state, nil
+}

--- a/vendor/go.uber.org/goleak/leaks.go
+++ b/vendor/go.uber.org/goleak/leaks.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package goleak
+
+import (
+	"errors"
+	"fmt"
+
+	"go.uber.org/goleak/internal/stack"
+)
+
+// TestingT is the minimal subset of testing.TB that we use.
+type TestingT interface {
+	Error(...interface{})
+}
+
+// filterStacks will filter any stacks excluded by the given opts.
+// filterStacks modifies the passed in stacks slice.
+func filterStacks(stacks []stack.Stack, skipID int, opts *opts) []stack.Stack {
+	filtered := stacks[:0]
+	for _, stack := range stacks {
+		// Always skip the running goroutine.
+		if stack.ID() == skipID {
+			continue
+		}
+		// Run any default or user-specified filters.
+		if opts.filter(stack) {
+			continue
+		}
+		filtered = append(filtered, stack)
+	}
+	return filtered
+}
+
+// Find looks for extra goroutines, and returns a descriptive error if
+// any are found.
+func Find(options ...Option) error {
+	cur := stack.Current().ID()
+
+	opts := buildOpts(options...)
+	if opts.cleanup != nil {
+		return errors.New("Cleanup can only be passed to VerifyNone or VerifyTestMain")
+	}
+	var stacks []stack.Stack
+	retry := true
+	for i := 0; retry; i++ {
+		stacks = filterStacks(stack.All(), cur, opts)
+
+		if len(stacks) == 0 {
+			return nil
+		}
+		retry = opts.retry(i)
+	}
+
+	return fmt.Errorf("found unexpected goroutines:\n%s", stacks)
+}
+
+type testHelper interface {
+	Helper()
+}
+
+// VerifyNone marks the given TestingT as failed if any extra goroutines are
+// found by Find. This is a helper method to make it easier to integrate in
+// tests by doing:
+//
+//	defer VerifyNone(t)
+//
+// VerifyNone is currently incompatible with t.Parallel because it cannot
+// associate specific goroutines with specific tests. Thus, non-leaking
+// goroutines from other tests running in parallel could fail this check.
+// If you need to run tests in parallel, use [VerifyTestMain] instead,
+// which will verify that no leaking goroutines exist after ALL tests finish.
+func VerifyNone(t TestingT, options ...Option) {
+	opts := buildOpts(options...)
+	var cleanup func(int)
+	cleanup, opts.cleanup = opts.cleanup, nil
+
+	if h, ok := t.(testHelper); ok {
+		// Mark this function as a test helper, if available.
+		h.Helper()
+	}
+
+	if err := Find(opts); err != nil {
+		t.Error(err)
+	}
+
+	if cleanup != nil {
+		cleanup(0)
+	}
+}

--- a/vendor/go.uber.org/goleak/options.go
+++ b/vendor/go.uber.org/goleak/options.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2017-2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package goleak
+
+import (
+	"strings"
+	"time"
+
+	"go.uber.org/goleak/internal/stack"
+)
+
+// Option lets users specify custom verifications.
+type Option interface {
+	apply(*opts)
+}
+
+// We retry up to 20 times if we can't find the goroutine that
+// we are looking for. In between each attempt, we will sleep for
+// a short while to let any running goroutines complete.
+const _defaultRetries = 20
+
+type opts struct {
+	filters    []func(stack.Stack) bool
+	maxRetries int
+	maxSleep   time.Duration
+	cleanup    func(int)
+}
+
+// implement apply so that opts struct itself can be used as
+// an Option.
+func (o *opts) apply(opts *opts) {
+	opts.filters = o.filters
+	opts.maxRetries = o.maxRetries
+	opts.maxSleep = o.maxSleep
+	opts.cleanup = o.cleanup
+}
+
+// optionFunc lets us easily write options without a custom type.
+type optionFunc func(*opts)
+
+func (f optionFunc) apply(opts *opts) { f(opts) }
+
+// IgnoreTopFunction ignores any goroutines where the specified function
+// is at the top of the stack. The function name should be fully qualified,
+// e.g., go.uber.org/goleak.IgnoreTopFunction
+func IgnoreTopFunction(f string) Option {
+	return addFilter(func(s stack.Stack) bool {
+		return s.FirstFunction() == f
+	})
+}
+
+// IgnoreAnyFunction ignores goroutines where the specified function
+// is present anywhere in the stack.
+//
+// The function name must be fully qualified, e.g.,
+//
+//	go.uber.org/goleak.IgnoreAnyFunction
+//
+// For methods, the fully qualified form looks like:
+//
+//	go.uber.org/goleak.(*MyType).MyMethod
+func IgnoreAnyFunction(f string) Option {
+	return addFilter(func(s stack.Stack) bool {
+		return s.HasFunction(f)
+	})
+}
+
+// Cleanup sets up a cleanup function that will be executed at the
+// end of the leak check.
+// When passed to [VerifyTestMain], the exit code passed to cleanupFunc
+// will be set to the exit code of TestMain.
+// When passed to [VerifyNone], the exit code will be set to 0.
+// This cannot be passed to [Find].
+func Cleanup(cleanupFunc func(exitCode int)) Option {
+	return optionFunc(func(opts *opts) {
+		opts.cleanup = cleanupFunc
+	})
+}
+
+// IgnoreCurrent records all current goroutines when the option is created, and ignores
+// them in any future Find/Verify calls.
+func IgnoreCurrent() Option {
+	excludeIDSet := map[int]bool{}
+	for _, s := range stack.All() {
+		excludeIDSet[s.ID()] = true
+	}
+	return addFilter(func(s stack.Stack) bool {
+		return excludeIDSet[s.ID()]
+	})
+}
+
+func maxSleep(d time.Duration) Option {
+	return optionFunc(func(opts *opts) {
+		opts.maxSleep = d
+	})
+}
+
+func addFilter(f func(stack.Stack) bool) Option {
+	return optionFunc(func(opts *opts) {
+		opts.filters = append(opts.filters, f)
+	})
+}
+
+func buildOpts(options ...Option) *opts {
+	opts := &opts{
+		maxRetries: _defaultRetries,
+		maxSleep:   100 * time.Millisecond,
+	}
+	opts.filters = append(opts.filters,
+		isTestStack,
+		isSyscallStack,
+		isStdLibStack,
+		isTraceStack,
+	)
+	for _, option := range options {
+		option.apply(opts)
+	}
+	return opts
+}
+
+func (o *opts) filter(s stack.Stack) bool {
+	for _, filter := range o.filters {
+		if filter(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *opts) retry(i int) bool {
+	if i >= o.maxRetries {
+		return false
+	}
+
+	d := time.Duration(int(time.Microsecond) << uint(i))
+	if d > o.maxSleep {
+		d = o.maxSleep
+	}
+	time.Sleep(d)
+	return true
+}
+
+// isTestStack is a default filter installed to automatically skip goroutines
+// that the testing package runs while the user's tests are running.
+func isTestStack(s stack.Stack) bool {
+	// Until go1.7, the main goroutine ran RunTests, which started
+	// the test in a separate goroutine and waited for that test goroutine
+	// to end by waiting on a channel.
+	// Since go1.7, a separate goroutine is started to wait for signals.
+	// T.Parallel is for parallel tests, which are blocked until all serial
+	// tests have run with T.Parallel at the top of the stack.
+	// testing.runFuzzTests is for fuzz testing, it's blocked until the test
+	// function with all seed corpus have run.
+	// testing.runFuzzing is for fuzz testing, it's blocked until a failing
+	// input is found.
+	switch s.FirstFunction() {
+	case "testing.RunTests", "testing.(*T).Run", "testing.(*T).Parallel", "testing.runFuzzing", "testing.runFuzzTests":
+		// In pre1.7 and post-1.7, background goroutines started by the testing
+		// package are blocked waiting on a channel.
+		return strings.HasPrefix(s.State(), "chan receive")
+	}
+	return false
+}
+
+func isSyscallStack(s stack.Stack) bool {
+	// Typically runs in the background when code uses CGo:
+	// https://github.com/golang/go/issues/16714
+	return s.HasFunction("runtime.goexit") && strings.HasPrefix(s.State(), "syscall")
+}
+
+func isStdLibStack(s stack.Stack) bool {
+	// Importing os/signal starts a background goroutine.
+	// The name of the function at the top has changed between versions.
+	if f := s.FirstFunction(); f == "os/signal.signal_recv" || f == "os/signal.loop" {
+		return true
+	}
+
+	// Using signal.Notify will start a runtime goroutine.
+	return s.HasFunction("runtime.ensureSigM")
+}

--- a/vendor/go.uber.org/goleak/testmain.go
+++ b/vendor/go.uber.org/goleak/testmain.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package goleak
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// Variables for stubbing in unit tests.
+var (
+	_osExit             = os.Exit
+	_osStderr io.Writer = os.Stderr
+)
+
+// TestingM is the minimal subset of testing.M that we use.
+type TestingM interface {
+	Run() int
+}
+
+// VerifyTestMain can be used in a TestMain function for package tests to
+// verify that there were no goroutine leaks.
+// To use it, your TestMain function should look like:
+//
+//	func TestMain(m *testing.M) {
+//	  goleak.VerifyTestMain(m)
+//	}
+//
+// See https://golang.org/pkg/testing/#hdr-Main for more details.
+//
+// This will run all tests as per normal, and if they were successful, look
+// for any goroutine leaks and fail the tests if any leaks were found.
+func VerifyTestMain(m TestingM, options ...Option) {
+	exitCode := m.Run()
+	opts := buildOpts(options...)
+
+	var cleanup func(int)
+	cleanup, opts.cleanup = opts.cleanup, nil
+	if cleanup == nil {
+		cleanup = _osExit
+	}
+	defer func() { cleanup(exitCode) }()
+
+	if exitCode == 0 {
+		if err := Find(opts); err != nil {
+			fmt.Fprintf(_osStderr, "goleak: Errors on successful test run: %v\n", err)
+			exitCode = 1
+		}
+	}
+}

--- a/vendor/go.uber.org/goleak/tracestack_new.go
+++ b/vendor/go.uber.org/goleak/tracestack_new.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2021-2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build go1.16
+// +build go1.16
+
+package goleak
+
+import "go.uber.org/goleak/internal/stack"
+
+func isTraceStack(s stack.Stack) bool {
+	return s.HasFunction("runtime.ReadTrace")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1374,6 +1374,10 @@ go.opentelemetry.io/proto/otlp/trace/v1
 # go.uber.org/atomic v1.10.0
 ## explicit; go 1.18
 go.uber.org/atomic
+# go.uber.org/goleak v1.3.0
+## explicit; go 1.20
+go.uber.org/goleak
+go.uber.org/goleak/internal/stack
 # go.uber.org/multierr v1.11.0
 ## explicit; go 1.19
 go.uber.org/multierr

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -751,7 +751,7 @@ github.com/inngest/expr
 # github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48
 ## explicit; go 1.23.2
 github.com/inngest/go-httpstat
-# github.com/inngest/inngestgo v0.15.0
+# github.com/inngest/inngestgo v0.15.1-0.20260204010937-b4832022aecc
 ## explicit; go 1.24.0
 github.com/inngest/inngestgo
 github.com/inngest/inngestgo/connect


### PR DESCRIPTION
circular:  high throughput batches are created then initialized fast. this is great, but can also be handled in-memory within ~100ms, reducing the total # of calls to the buffering store.

this commit introduces a bunch of changes to allow in-memory buffering of batches prior to committing to the state store to reduce QPS under many events.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
