### PR TITLE
EXE-1239: Fix runs list pagination for self-hosted Inngest with postgres

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -3237,8 +3237,8 @@ func newSpanRunsQueryBuilder(ctx context.Context, opt cqrs.GetTraceRunOpt) *runs
 				}
 
 				// Add run_id tie-breaker
-				if runIDCursor := reqCursor.Find("run_id"); runIDCursor != nil {
-					equalityConditions = append(equalityConditions, sq.C("run_id").Gt(runIDCursor.Value))
+				if reqCursor.ID != "" {
+					equalityConditions = append(equalityConditions, sq.C("run_id").Gt(reqCursor.ID))
 				}
 
 				// Combine: (field > cursor_value) OR (field = cursor_value AND next_conditions)


### PR DESCRIPTION
## Description

Normalize the the time input prior to query as Postgres uses `TIMESTAMPTZ` and pgx has no `int64` to `timestampz` encoding plan. This throws an error.

## Motivation
EXE-1239

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
