### PR TITLE
EXE-1248: Fix resizable Notch handle intercepting clicks on elements beneath it

### DIFF
--- a/ui/packages/components/src/Resizable/Notch.tsx
+++ b/ui/packages/components/src/Resizable/Notch.tsx
@@ -44,27 +44,28 @@ export function Notch({
   return (
     <div
       className={cn(
-        'absolute z-10 flex items-center justify-center',
+        'pointer-events-none absolute z-10 flex items-center justify-center',
         buildCrossAxisSizeClass(orientation),
         buildTrackClasses(orientation)
       )}
-      onPointerDown={handlePointerDown}
     >
       <div
         className={cn(
-          'bg-canvasMuted pointer-events-none absolute',
+          'bg-canvasMuted absolute',
           buildDividerClasses(orientation)
         )}
       />
       <div
         className={cn(
-          'bg-canvasSubtle border-muted pointer-events-none relative rounded-full border',
-          buildHandleSizeClasses(orientation)
+          'bg-canvasSubtle border-muted pointer-events-auto relative rounded-full border',
+          buildHandleSizeClasses(orientation),
+          buildHandleCursorClass(orientation)
         )}
+        onPointerDown={handlePointerDown}
       >
         <div
           className={cn(
-            'bg-surfaceSubtle border-muted absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border',
+            'bg-surfaceSubtle border-muted pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full border',
             buildHandleStripeClasses(orientation)
           )}
         />
@@ -89,8 +90,12 @@ function buildHandleStripeClasses(orientation: Orientation): string {
   return orientation === 'vertical' ? 'h-px w-3' : 'h-3 w-px';
 }
 
+function buildHandleCursorClass(orientation: Orientation): string {
+  return orientation === 'vertical' ? 'cursor-row-resize' : 'cursor-col-resize';
+}
+
 function buildTrackClasses(orientation: Orientation): string {
   return orientation === 'vertical'
-    ? 'left-0 right-0 top-[var(--inngest-resizable-split,50%)] -translate-y-1/2 cursor-row-resize'
-    : 'top-0 bottom-0 left-[var(--inngest-resizable-split,50%)] -translate-x-1/2 cursor-col-resize';
+    ? 'left-0 right-0 top-[var(--inngest-resizable-split,50%)] -translate-y-1/2'
+    : 'top-0 bottom-0 left-[var(--inngest-resizable-split,50%)] -translate-x-1/2';
 }


### PR DESCRIPTION
## Summary

- Fixes a bug where the resizable panel drag handle (Notch) intercepts pointer events on elements beneath it, preventing date copy buttons and other interactive elements from being clicked in the Insights results table.
- Moves `pointer-events` and `onPointerDown` from the full-width invisible track div to only the visible handle grip (the small rounded pill).

## Problem

The `Notch` component renders an absolutely positioned track div with `z-10` that spans the **full width** of the container (`left-0 right-0`). The `onPointerDown` handler was attached to this full-width track, so it intercepted clicks on any element beneath it — including the `Time` component's copy icon in the results table's date columns.

When the vertical resizable split boundary (between the SQL editor and results table in `InsightsTabPanel`) aligns near the top of the results table, the Notch's 8px-tall hit area overlays the first row(s) of date cells, making the copy button unclickable.

## Fix

1. Added `pointer-events-none` to the outer track div so its invisible full-width area passes through pointer events.
2. Moved `onPointerDown` and added `pointer-events-auto` to the visible handle grip element only.
3. Moved `cursor-row-resize` / `cursor-col-resize` to the handle grip since the track no longer receives pointer events.

## Testing

- Verify that clicking the copy icon on date cells in the Insights results table works correctly, even when the cell is near the resizable split boundary.
- Verify that the resize handle (the small rounded pill) is still draggable to resize panels.
- Verify both vertical (Insights SQL editor / results) and horizontal (main content / helper panel) resizable splits work correctly.

Closes EXE-1248

https://inngest.slack.com/archives/C069Q14GKC5/p1770327470089109?thread_ts=1770318015.547599&cid=C069Q14GKC5