### PR TITLE
Log pause match results for event processing observability

### DIFF
--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -576,10 +576,28 @@ func (s *svc) pauses(ctx context.Context, evt event.TrackedEvent) error {
 
 	l.Debug("handling found pauses for event")
 
-	_, err := s.executor.HandlePauses(ctx, evt)
+	res, err := s.executor.HandlePauses(ctx, evt)
 	if err != nil {
 		l.Error("error handling pauses", "error", err)
 	}
+
+	if res.Handled() > 0 {
+		l.Info("event matched pauses",
+			"pauses_processed", res.Processed(),
+			"pauses_matched", res.Handled(),
+		)
+	} else if res.Processed() > 0 {
+		l.Warn("event did not match any pauses despite pauses existing for event name",
+			"pauses_processed", res.Processed(),
+			"pauses_matched", res.Handled(),
+		)
+	} else {
+		l.Info("no pauses processed for event",
+			"pauses_processed", res.Processed(),
+			"pauses_matched", res.Handled(),
+		)
+	}
+
 	return err
 }
 


### PR DESCRIPTION
## Summary

- Surfaces `HandlePauseResult` in `runner.pauses()` so operators can see whether incoming events matched waiting pauses
- Logs at **Info** level when events match pauses (with processed/matched counts)
- Logs at **Warn** level when pauses exist for an event name but none matched the specific event — helps diagnose `waitForEvent` race conditions and expression mismatches
- Zero-latency change: only reads two `int32` values already computed by `HandlePauses`

## Context

When using `step.waitForEvent` at high volume (e.g. thousands of events for the same event name), events can arrive and be stored in the event log but silently fail to match any pause. Currently there is no logging to indicate whether an event matched or didn't match — the `HandlePauseResult` return value was being discarded. This makes it very difficult to diagnose missed matches.

## Test plan

- [ ] Verify logs appear at Info level when events successfully match pauses
- [ ] Verify logs appear at Warn level when pauses exist for event name but none match
- [ ] Verify no performance regression under load


Made with [Cursor](https://cursor.com)