### PR TITLE
fix: resolve empty span output for preview trace spans by querying dynamic_span_id

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -1822,7 +1822,15 @@ func (w wrapper) GetSpanOutput(ctx context.Context, opts cqrs.SpanIdentifier) (*
 		return nil, fmt.Errorf("span ID or input span ID is required to retrieve output")
 	}
 
-	rows, err := w.q.GetSpanOutput(ctx, ids)
+	dynIds := make([]sql.NullString, len(ids))
+	for i, id := range ids {
+		dynIds[i] = sql.NullString{String: id, Valid: true}
+	}
+
+	rows, err := w.q.GetSpanOutput(ctx, sqlc.GetSpanOutputParams{
+		Ids:    ids,
+		DynIds: dynIds,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving span output: %w", err)
 	}

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/db_normalization.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/db_normalization.go
@@ -840,8 +840,8 @@ func (q NormalizedQueries) GetSpanBySpanID(ctx context.Context, args sqlc_sqlite
 	return row.ToSQLite()
 }
 
-func (q NormalizedQueries) GetSpanOutput(ctx context.Context, spanIds []string) ([]*sqlc_sqlite.GetSpanOutputRow, error) {
-	rows, err := q.db.GetSpanOutput(ctx, spanIds)
+func (q NormalizedQueries) GetSpanOutput(ctx context.Context, arg sqlc_sqlite.GetSpanOutputParams) ([]*sqlc_sqlite.GetSpanOutputRow, error) {
+	rows, err := q.db.GetSpanOutput(ctx, arg.Ids)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
@@ -448,7 +448,8 @@ SELECT
   output
 FROM spans
 WHERE span_id IN (SELECT UNNEST(sqlc.slice('ids')::TEXT[]))
-LIMIT 2;
+   OR (dynamic_span_id IN (SELECT UNNEST(sqlc.slice('ids')::TEXT[])) AND output IS NOT NULL)
+LIMIT 4;
 
 -- name: GetRunSpanByRunID :one
 SELECT

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql.go
@@ -1244,7 +1244,8 @@ SELECT
   output
 FROM spans
 WHERE span_id IN (SELECT UNNEST($1::TEXT[]))
-LIMIT 2
+   OR (dynamic_span_id IN (SELECT UNNEST($1::TEXT[])) AND output IS NOT NULL)
+LIMIT 4
 `
 
 type GetSpanOutputRow struct {

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/querier.go
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/querier.go
@@ -50,7 +50,7 @@ type Querier interface {
 	GetQueueSnapshotChunks(ctx context.Context, snapshotID interface{}) ([]*GetQueueSnapshotChunksRow, error)
 	GetRunSpanByRunID(ctx context.Context, arg GetRunSpanByRunIDParams) (*GetRunSpanByRunIDRow, error)
 	GetSpanBySpanID(ctx context.Context, arg GetSpanBySpanIDParams) (*GetSpanBySpanIDRow, error)
-	GetSpanOutput(ctx context.Context, ids []string) ([]*GetSpanOutputRow, error)
+	GetSpanOutput(ctx context.Context, arg GetSpanOutputParams) ([]*GetSpanOutputRow, error)
 	GetSpansByDebugRunID(ctx context.Context, debugRunID sql.NullString) ([]*GetSpansByDebugRunIDRow, error)
 	GetSpansByDebugSessionID(ctx context.Context, debugSessionID sql.NullString) ([]*GetSpansByDebugSessionIDRow, error)
 	GetSpansByRunID(ctx context.Context, runID string) ([]*GetSpansByRunIDRow, error)

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
@@ -418,7 +418,8 @@ SELECT
   output
 FROM spans
 WHERE span_id IN (sqlc.slice('ids'))
-LIMIT 2;
+   OR (dynamic_span_id IN (sqlc.slice('dyn_ids')) AND output IS NOT NULL)
+LIMIT 4;
 
 -- name: GetRunSpanByRunID :one
 SELECT


### PR DESCRIPTION
Fixes #3669 
## Description

Some trace span outputs returned empty data when queried via `runTraceSpanOutputByID`. This happened because certain spans (e.g. `executor.execution` type) had their `span_id` used in the `outputID`, but their actual output data was stored on separate EXTEND spans sharing the same `dynamic_span_id`. The `GetSpanOutput` SQL query only searched by `span_id`, so it found the original span (with NULL output) and missed the EXTEND span that held the data.

The fix adds a fallback lookup by `dynamic_span_id` in the `GetSpanOutput` query:
```sql
WHERE span_id IN (...)
   OR (dynamic_span_id IN (...) AND output IS NOT NULL)
```

This also includes necessary type adaptations from regenerating sqlc code (`interface{}` → `json.RawMessage`).

### Files changed
- **`queries.sql` (SQLite + Postgres)**: Added `dynamic_span_id` OR clause, increased LIMIT from 2 to 4
- **`cqrs.go`**: Updated wrapper to pass new `GetSpanOutputParams` with `DynIds`, adapted to `json.RawMessage` types
- **`db_normalization.go` / `normalization.go`**: Updated Postgres→SQLite bridge for new param/return types
- **`tracer_sqlc.go`**: Fixed `InsertSpanParams` field types for `json.RawMessage`
- **Generated files**: Regenerated via `sqlc generate`

<img width="1800" height="1008" alt="Screenshot 2026-02-11 at 2 17 43 PM" src="https://github.com/user-attachments/assets/f62aad3f-9993-42a6-b77e-9cc25b2a28ac" />
<img width="1800" height="1008" alt="Screenshot 2026-02-11 at 2 17 53 PM" src="https://github.com/user-attachments/assets/843b3bd9-0f9d-4f9e-b681-e1c4eceeefdc" />


## Motivation

Users reported that some span outputs appeared blank in the trace UI, even though the data existed in the database. This affected spans where the output was stored on an EXTEND span fragment rather than the primary span matching the `span_id` in the outputID.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.