### PR TITLE
Add OnStepScheduled to traceLifecycle to emit QUEUED spans for scheduled steps

### DIFF
--- a/pkg/run/trace_lifecycle.go
+++ b/pkg/run/trace_lifecycle.go
@@ -57,10 +57,9 @@ func (l traceLifecycle) OnStepScheduled(
 	}
 
 	_, span := NewSpan(ctx,
-		// Use OtelScopeStep (not OtelScopeExecution) to avoid being grouped with
-		// execution spans in the trace tree builder. OtelScopeExecution spans share
-		// a GroupID and are treated as retry "attempts" by processExecGroup — adding
-		// a QUEUED marker there inflates the attempt count and breaks OutputId resolution.
+		// Use OtelScopeStep so the tree builder filters this span out
+		// (it skips OtelScopeStep + OpcodeStepPlanned). Using OtelScopeExecution
+		// would bypass that filter and cause grouping issues in processExecGroup.
 		WithScope(consts.OtelScopeStep),
 		WithName(name),
 		WithTimestamp(time.Now()),


### PR DESCRIPTION
## Description

When steps get scheduled but have to wait (e.g. due to concurrency limits), they were completely invisible in the run timeline. You'd see a gap between the previous step finishing and the next one starting, with no indication that anything was actually queued and waiting. For sleep steps, the wait time got lumped into the displayed sleep duration — a 5s sleep could show as 19.5s because the timeline had no idea when the step was actually scheduled vs when it started running.

The root cause was that `traceLifecycle` implements 16 different lifecycle methods (function scheduled, step started, sleep, wait-for-event, etc.) but never got around to implementing `OnStepScheduled`. It inherited a no-op from `NoopLifecyceListener`, so when the executor called `OnStepScheduled` at its 7 call sites, nothing happened — no span was created, no data written to ClickHouse, nothing for the UI to display.

The ironic part is that everything downstream was already wired up and waiting. The `SpanStatusQueued` constant existed, the GraphQL schema had `RunTraceSpanStatus.QUEUED`, the converters knew how to map it, and the UI had dedicated QUEUED styling with its own color palette. The history lifecycle even recorded `HistoryTypeStepScheduled` entries correctly. The trace lifecycle was the only layer that dropped the ball.

The fix adds a single `OnStepScheduled` method to `traceLifecycle` that creates a span with `DynamicStatus` set to `"Queued"`. It follows the same pattern as `OnStepStarted`, extracts trace context, sets standard attributes (account, workspace, function, run, attempt, group), and sets the step display name when available. The span flows through the existing export pipeline into ClickHouse, gets picked up by the GraphQL resolver, and renders in the UI with the QUEUED status styling that was already there waiting for it.


## Motivation
Better tracing

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
