### PR TITLE
Fix 500 when loading insights page by using Uri off lazy loaded monaco instance

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditor.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditor.tsx
@@ -1,7 +1,6 @@
 import {
   SQLEditor,
   type SQLEditorMarkerData,
-  SQLEditorURI,
 } from '@inngest/components/SQLEditor/SQLEditor';
 import { useInsightsStateMachineContext } from '../InsightsStateMachineContext/InsightsStateMachineContext';
 import { hasUnsavedChanges } from '../InsightsTabManager/InsightsTabManager';
@@ -139,7 +138,7 @@ export function InsightsSQLEditor() {
           severity: diag.severity === 'error' ? 8 : 4,
           code: {
             // TODO: add docs links based on diagnostic code
-            target: SQLEditorURI.parse('http://example.com'),
+            target: monaco.Uri.parse('http://example.com'),
             value: diag.code,
           },
           message: diag.message, // TODO: pretty message by code

--- a/ui/packages/components/src/SQLEditor/SQLEditor.tsx
+++ b/ui/packages/components/src/SQLEditor/SQLEditor.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react';
 import { Editor, type Monaco } from '@monaco-editor/react';
-import { Uri, type editor } from 'monaco-editor';
+import type { editor } from 'monaco-editor';
 
 import { EDITOR_OPTIONS } from './constants';
 import { useMonacoWithTheme } from './hooks/useMonacoWithTheme';
@@ -13,7 +13,6 @@ export type SQLEditorMountCallback = (editor: editor.IStandaloneCodeEditor, mona
 export type SQLEditorInstance = editor.IStandaloneCodeEditor;
 export type SQLEditorMarkerData = editor.IMarkerData;
 export type SQLEditorModel = editor.ITextModel;
-export const SQLEditorURI = Uri;
 
 export type SQLEditorProps = {
   completionConfig: SQLCompletionConfig;


### PR DESCRIPTION
## Description

This Uri import would cause monaco-editor to be loaded during SSR/serverless function initialization, but monaco-editor is a browser-only library that requires browser APIs

Should fix errors like this
```
Error in renderToPipeableStream: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'monaco-editor' imported from /var/task/chunks/_/index--Egx-5Sg.mjs
    at packageResolve (node:internal/modules/esm/resolve:877:9)
    at moduleResolve (node:internal/modules/esm/resolve:950:18)
    at moduleResolveWithNodePath (node:internal/modules/esm/resolve:1192:14)
    at defaultResolve (node:internal/modules/esm/resolve:1235:79)
    at nextResolve (node:internal/modules/esm/hooks:864:28)
    at resolve (file:///var/task/node_modules/import-in-the-middle/create-hook.mjs:345:26)
    at nextResolve (node:internal/modules/esm/hooks:864:28)
    at Hooks.resolve (node:internal/modules/esm/hooks:306:30)
    at handleMessage (node:internal/modules/esm/worker:196:24)
    at checkForMessages (node:internal/modules/esm/worker:138:28) {
  code: 'ERR_MODULE_NOT_FOUND'
```

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
