### PR TITLE
fix: Insights data table rendering for columns with complex names

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsDataTable/states/ResultsState/useColumns.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsDataTable/states/ResultsState/useColumns.tsx
@@ -17,7 +17,7 @@ export function useColumns(data?: InsightsFetchResult): { columns: Column[] } {
 
     return cols.map(
       (col): ColumnDef<InsightsEntry, InsightsColumnValue> => ({
-        accessorKey: `values.${col.name}`,
+        accessorFn: (row) => row.values[col.name],
         cell: ({ getValue }) => {
           const value = getValue();
 


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

This switches from using the tanstack react-tables accessorKey strings to an explicit accesorFn. We don't need to access nested data, but do need to access data w/ arbitrary string names so this works for our use-case.

(before)
<img width="1074" height="89" alt="image" src="https://github.com/user-attachments/assets/d0a61e3d-f6fe-4607-b3d8-cab74d58c940" />
(after)
<img width="1081" height="84" alt="image" src="https://github.com/user-attachments/assets/d38261f7-3ce4-4e8c-8785-02d26bf5d895" />



## Motivation
<!--- Please edit this to include the reason why we are making this change. -->
We currently don't render columns with complex names properly.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
