### PR TITLE
Set autoClosingBrackets and autoClosingBrackets to beforeWhitespace

### DIFF
--- a/ui/packages/components/src/SQLEditor/constants.ts
+++ b/ui/packages/components/src/SQLEditor/constants.ts
@@ -3,8 +3,8 @@ import type { editor } from 'monaco-editor';
 import { FONT, LINE_HEIGHT } from '../utils/monaco';
 
 export const EDITOR_OPTIONS: editor.IEditorOptions = {
-  autoClosingBrackets: 'always',
-  autoClosingQuotes: 'always',
+  autoClosingBrackets: 'beforeWhitespace',
+  autoClosingQuotes: 'beforeWhitespace',
   contextmenu: false,
   fixedOverflowWidgets: true,
   fontFamily: FONT.font,


### PR DESCRIPTION
## Description

always was too aggressive and made it a pain to wrap text that was already in the editor

https://microsoft.github.io/monaco-editor/docs.html#types/editor_editor_api.editor.EditorAutoClosingStrategy.html

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
