### PR TITLE
Insights: Use sql-formatter clickhouse dialect for SQL formatting

### DIFF
--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -84,7 +84,7 @@
     "recharts": "^2.4.3",
     "remark-gfm": "^4.0.1",
     "sonner": "^1.2.0",
-    "sql-formatter": "^15.6.10",
+    "sql-formatter": "^15.7.1",
     "srvx": "0.8.15",
     "type-fest": "^3.7.2",
     "ulid": "^2.3.0",

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/hooks/useInsightsSQLEditorOnMountCallback.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/hooks/useInsightsSQLEditorOnMountCallback.ts
@@ -11,6 +11,7 @@ import { bindEditorShortcuts } from '../actions/handleShortcuts';
 import { markTemplateVars } from '../actions/markTemplateVars';
 import { getCanRunQuery } from '../utils';
 import { useLatest, useLatestCallback } from './useLatestCallback';
+import { clickhouse, formatDialect } from 'sql-formatter';
 
 type UseInsightsSQLEditorOnMountCallbackReturn = {
   onMount: SQLEditorMountCallback;
@@ -58,6 +59,17 @@ export function useInsightsSQLEditorOnMountCallback(): UseInsightsSQLEditorOnMou
           handler: tabManagerActions.createNewTab,
         },
       ]);
+
+      monaco.languages.registerDocumentFormattingEditProvider('sql', {
+        provideDocumentFormattingEdits: (model) => {
+          return [
+            {
+              range: model.getFullModelRange(),
+              text: formatDialect(model.getValue(), { dialect: clickhouse }),
+            },
+          ];
+        },
+      });
 
       const markersDisposable = markTemplateVars(editor, monaco);
 

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -246,8 +246,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       sql-formatter:
-        specifier: ^15.6.10
-        version: 15.6.10
+        specifier: ^15.7.1
+        version: 15.7.1
       srvx:
         specifier: 0.8.15
         version: 0.8.15
@@ -823,7 +823,7 @@ importers:
         version: 1.2.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       sql-formatter:
         specifier: ^15.6.10
-        version: 15.6.10
+        version: 15.7.1
       tailwind-merge:
         specifier: ^1.10.0
         version: 1.10.0
@@ -12354,8 +12354,8 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  sql-formatter@15.6.10:
-    resolution: {integrity: sha512-0bJOPQrRO/JkjQhiThVayq0hOKnI1tHI+2OTkmT7TGtc6kqS+V7kveeMzRW+RNQGxofmTmet9ILvztyuxv0cJQ==}
+  sql-formatter@15.7.1:
+    resolution: {integrity: sha512-O8h51MnuQAnsInO7is6VoBGeB9wFvXhiTi4AqY5yGWUdF7fNcEDA6F67AAD4OvV4Seb95bPXaAPmnSii/mModg==}
     hasBin: true
 
   srvx@0.10.1:
@@ -28377,7 +28377,7 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  sql-formatter@15.6.10:
+  sql-formatter@15.7.1:
     dependencies:
       argparse: 2.0.1
       nearley: 2.20.1


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->


This uses sql-formatter w/ the clickhouse dialect for SQL formatting in the Insights SQL editor. sql-formatter added CH-syntax support in 15.7.0


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

Currently we misformat some CH-specific SQL syntax.

EXE-1275

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
