### PR TITLE
don't ref clerk in catch boundary

### DIFF
--- a/ui/apps/dashboard/src/components/Error/DefaultCatchBoundary.tsx
+++ b/ui/apps/dashboard/src/components/Error/DefaultCatchBoundary.tsx
@@ -5,16 +5,12 @@ import { rootRouteId, useMatch, useRouter } from '@tanstack/react-router';
 
 import * as Sentry from '@sentry/tanstackstart-react';
 
-import { useClerk } from '@clerk/tanstack-react-start';
-
 function DefaultCatchBoundary({ error }: ErrorComponentProps) {
   const router = useRouter();
   const isRoot = useMatch({
     strict: false,
     select: (state) => state.id === rootRouteId,
   });
-
-  const { signOut, session } = useClerk();
 
   console.error(error.message);
 
@@ -48,27 +44,19 @@ function DefaultCatchBoundary({ error }: ErrorComponentProps) {
           />
         )}
 
-        {/* Provide some escape hatches here if 
-          user/org state gets out of sync with clerk */}
+        {/* Provide some escape hatches here if user/org state gets out of sync with clerk */}
         {authError && (
           <>
             <Button
               kind="secondary"
               appearance="outlined"
-              onClick={async () => {
-                await signOut({
-                  sessionId: session?.id,
-                  redirectUrl: '/sign-in/choose',
-                });
-              }}
+              href="/sign-in/choose"
               label="Sign Out"
             />
             <Button
               kind="secondary"
               appearance="outlined"
-              onClick={() => {
-                router.navigate({ to: '/organization-list/$' });
-              }}
+              href="/organization-list"
               label="Switch Org"
             />
           </>


### PR DESCRIPTION
## Description

Don't reference clerk in the catch boundary because it's not guaranteed to be there. Just link to sign out, etc instead (use `href` not `to` so we don't risk prefetch 😉).

## Motivation
Clean up our clerk related errors.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
