### PR TITLE
Exclude custom concurrency keys missing in config

### DIFF
--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -234,7 +234,7 @@ func (q *queueProcessor) BacklogRefillConstraintCheck(
 		CurrentTime:          now,
 		Duration:             QueueLeaseDuration,
 		Configuration:        ConstraintConfigFromConstraints(constraints),
-		Constraints:          constraintItemsFromBacklog(shadowPart, backlog),
+		Constraints:          constraintItemsFromBacklog(shadowPart, backlog, constraints),
 		Amount:               len(items),
 		LeaseIdempotencyKeys: itemIDs,
 		LeaseRunIDs:          itemRunIDs,


### PR DESCRIPTION
## Description

Currently, we include custom concurrency keys missing in the latest configuration. This will fail in the Constraint API.

This usually happens when old queue items exist with an earlier version of a concurrency key and key queues disabled. When the custom concurrency key is removed, old items will be unable to acquire leases. This is now fixed. With key queues we properly normalize outdated items.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
