### PR TITLE
Fix empty function output for OpcodeRunComplete and add tests

### DIFF
--- a/pkg/execution/history/lifecycle.go
+++ b/pkg/execution/history/lifecycle.go
@@ -902,6 +902,18 @@ func applyResponse(
 		return nil
 	}
 
+	// Handle function completion opcodes which contain the function's final output.
+	// These are generator responses but represent the function result, not intermediate steps.
+	for _, op := range resp.Generator {
+		if op.Op == enums.OpcodeRunComplete || op.Op == enums.OpcodeSyncRunComplete {
+			output, _ := op.Output()
+			if output != "" {
+				h.Result.Output = output
+			}
+			return nil
+		}
+	}
+
 	if len(resp.Generator) > 0 {
 		// If we're a generator, exit now to prevent attempting to parse
 		// generator response as an output; the generator response may be in

--- a/pkg/execution/history/lifecycle_test.go
+++ b/pkg/execution/history/lifecycle_test.go
@@ -1,0 +1,100 @@
+package history
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyResponse(t *testing.T) {
+	errStr := "something went wrong"
+
+	tests := []struct {
+		name           string
+		resp           state.DriverResponse
+		expectedOutput string
+	}{
+		{
+			name: "OpcodeRunComplete with data",
+			resp: state.DriverResponse{
+				Generator: []*state.GeneratorOpcode{
+					{
+						Op:   enums.OpcodeRunComplete,
+						ID:   "done",
+						Data: json.RawMessage(`{"result":"ok"}`),
+					},
+				},
+			},
+			expectedOutput: `{"result":"ok"}`,
+		},
+		{
+			name: "OpcodeSyncRunComplete with data",
+			resp: state.DriverResponse{
+				Generator: []*state.GeneratorOpcode{
+					{
+						Op:   enums.OpcodeSyncRunComplete,
+						ID:   "done",
+						Data: json.RawMessage(`{"result":"ok"}`),
+					},
+				},
+			},
+			expectedOutput: `{"result":"ok"}`,
+		},
+		{
+			name: "OpcodeRunComplete with nil data",
+			resp: state.DriverResponse{
+				Generator: []*state.GeneratorOpcode{
+					{
+						Op: enums.OpcodeRunComplete,
+						ID: "done",
+						// Data is nil
+					},
+				},
+			},
+			expectedOutput: "",
+		},
+		{
+			name: "Regular generator step (OpcodeStep)",
+			resp: state.DriverResponse{
+				Generator: []*state.GeneratorOpcode{
+					{
+						Op:   enums.OpcodeStep,
+						ID:   "step1",
+						Name: "my step",
+						Data: json.RawMessage(`{"data":"step-output"}`),
+					},
+				},
+			},
+			// OpcodeStep goes through HistoryVisibleStep -> Output(),
+			// which for OpcodeStep returns string(g.Data) directly.
+			expectedOutput: `{"data":"step-output"}`,
+		},
+		{
+			name: "Non-generator response (simple function)",
+			resp: state.DriverResponse{
+				Output: "hello",
+			},
+			expectedOutput: "hello",
+		},
+		{
+			name: "Error response",
+			resp: state.DriverResponse{
+				Err: &errStr,
+			},
+			expectedOutput: errStr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &History{}
+			err := applyResponse(h, &tt.resp)
+			require.NoError(t, err)
+			require.NotNil(t, h.Result)
+			require.Equal(t, tt.expectedOutput, h.Result.Output)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Handle `OpcodeRunComplete`/`OpcodeSyncRunComplete` in `applyResponse()` so generator-based function completions correctly populate history output
- Add table-driven unit tests for `applyResponse()` covering run-complete, step, simple function, and error paths

## Test plan
- [ ] `go test ./pkg/execution/history/... -run TestApplyResponse -v` passes all 6 cases