### PR TITLE
feat: reset `die` after parallelism ends

### DIFF
--- a/pkg/execution/executor/force_step_plan.go
+++ b/pkg/execution/executor/force_step_plan.go
@@ -1,0 +1,23 @@
+package executor
+
+import (
+	"context"
+
+	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
+)
+
+// maybeResetForceStepPlan resets ForceStepPlan (disableImmediateExecution) to
+// false when parallelism has ended for a v2 execution, re-enabling checkpointing.
+// This is a no-op for v1 executions or when ForceStepPlan is already false.
+func (e *executor) maybeResetForceStepPlan(ctx context.Context, md *sv2.Metadata) error {
+	if md.Config.RequestVersion < 2 || !md.Config.ForceStepPlan {
+		return nil
+	}
+
+	return e.smv2.UpdateMetadata(ctx, md.ID, sv2.MutableConfig{
+		ForceStepPlan:  false,
+		RequestVersion: md.Config.RequestVersion,
+		StartedAt:      md.Config.StartedAt,
+		HasAI:          md.Config.HasAI,
+	})
+}

--- a/pkg/execution/executor/force_step_plan_test.go
+++ b/pkg/execution/executor/force_step_plan_test.go
@@ -1,0 +1,96 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockRunServiceForReset struct {
+	sv2.RunService
+	mock.Mock
+}
+
+func (m *mockRunServiceForReset) UpdateMetadata(ctx context.Context, id sv2.ID, config sv2.MutableConfig) error {
+	args := m.Called(ctx, id, config)
+	return args.Error(0)
+}
+
+func TestMaybeResetForceStepPlan(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestVersion int
+		forceStepPlan  bool
+		updateErr      error
+		expectCall     bool
+		expectErr      bool
+	}{
+		{
+			name:           "v1_noop",
+			requestVersion: 1,
+			forceStepPlan:  true,
+			expectCall:     false,
+		},
+		{
+			name:           "v2_already_false",
+			requestVersion: 2,
+			forceStepPlan:  false,
+			expectCall:     false,
+		},
+		{
+			name:           "v2_resets",
+			requestVersion: 2,
+			forceStepPlan:  true,
+			expectCall:     true,
+		},
+		{
+			name:           "v2_propagates_error",
+			requestVersion: 2,
+			forceStepPlan:  true,
+			updateErr:      errors.New("redis unavailable"),
+			expectCall:     true,
+			expectErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ms := new(mockRunServiceForReset)
+			cfg := sv2.InitConfig(&sv2.Config{
+				RequestVersion: tt.requestVersion,
+				ForceStepPlan:  tt.forceStepPlan,
+				StartedAt:      time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			})
+			md := sv2.Metadata{Config: *cfg}
+
+			if tt.expectCall {
+				ms.On("UpdateMetadata", mock.Anything, md.ID, mock.MatchedBy(func(cfg sv2.MutableConfig) bool {
+					return !cfg.ForceStepPlan &&
+						cfg.RequestVersion == tt.requestVersion &&
+						cfg.StartedAt.Equal(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+				})).Return(tt.updateErr)
+			}
+
+			e := &executor{smv2: ms}
+			err := e.maybeResetForceStepPlan(context.Background(), &md)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.updateErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			if tt.expectCall {
+				ms.AssertExpectations(t)
+			} else {
+				ms.AssertNotCalled(t, "UpdateMetadata", mock.Anything, mock.Anything, mock.Anything)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

In v2 executions, parallelism coalescing guarantees that discovery steps are only enqueued once all parallel steps complete, so we can safely reset the disable immediate execution flag to false at that point so that checkpoint is re-enabled for subsequent steps.

## Motivation

[EXE-995: Reset `die` in v2 execution version when coalescing](https://linear.app/inngest/issue/EXE-995/reset-die-in-v2-execution-version-when-coalescing)

Before:
<img width="1152" height="568" alt="Screenshot 2026-02-19 at 12 23 11 PM" src="https://github.com/user-attachments/assets/75b57914-739e-40de-bd2c-e74670626885" />

After:
<img width="1153" height="821" alt="Screenshot 2026-02-19 at 12 23 46 PM" src="https://github.com/user-attachments/assets/7265a587-03bd-4058-893c-98efceac4e7d" />

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
