### PR TITLE
Verify shard lease is set before exiting shard lease loop

### DIFF
--- a/pkg/execution/queue/shard_lease.go
+++ b/pkg/execution/queue/shard_lease.go
@@ -41,12 +41,9 @@ func (q *queueProcessor) claimShardLease(ctx context.Context) {
 	}
 
 	// Attempt to claim the lease immediately before waiting for the ticker.
-	claimed, err := q.tryClaimShardLease(ctx, shards)
-	if err != nil {
-		q.quit <- err
-		return
-	}
-	if claimed {
+	_, _ = q.tryClaimShardLease(ctx, shards)
+
+	if q.shardLease() != nil {
 		return
 	}
 
@@ -58,13 +55,13 @@ func (q *queueProcessor) claimShardLease(ctx context.Context) {
 			return
 		case <-tick.Chan():
 			// Attempt to claim the lease.
-			claimed, err := q.tryClaimShardLease(ctx, shards)
+			_, err := q.tryClaimShardLease(ctx, shards)
 			if err != nil {
 				q.quit <- err
 				return
 			}
 
-			if claimed {
+			if q.shardLease() != nil {
 				tick.Stop()
 				return
 			}


### PR DESCRIPTION
## Description

Verify shard lease is set before exiting shard lease loop

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
