### PR TITLE
prevent compaction from being context cancelled

### DIFF
--- a/pkg/execution/pauses/block.go
+++ b/pkg/execution/pauses/block.go
@@ -740,7 +740,11 @@ func (b *blockstore) maybeCompact(ctx context.Context, index Index, blockIDs []u
 	if rand.Float64() >= sample {
 		return
 	}
+
+	ctx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	go func() {
+		defer cancel()
+
 		var maxDeletes int64
 		for _, blockID := range blockIDs {
 			size, err := b.pc.Client().Do(ctx, b.pc.Client().B().Scard().Key(blockDeleteKey(index, blockID)).Build()).AsInt64()


### PR DESCRIPTION
## Description
Prevent compaction from being cancelled when the ctx of the delete call is done.



## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
