### PR TITLE
Start collecting peeked item metrics

### DIFF
--- a/pkg/telemetry/metrics/histogram.go
+++ b/pkg/telemetry/metrics/histogram.go
@@ -585,3 +585,14 @@ func HistogramQueueRatioTopBacklogItemsToPeekedItems(ctx context.Context, count 
 		},
 	})
 }
+
+func HistogramQueueBacklogGroupingDuration(ctx context.Context, dur int64, opts HistogramOpt) {
+	RecordIntHistogramMetric(ctx, dur, HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "queue_backlog_grouping_duration",
+		Description: "Distribution of time required to group all peeked items by backlog",
+		Tags:        opts.Tags,
+		Unit:        "ms",
+		Boundaries:  ConstraintAPIDurationBoundaries,
+	})
+}


### PR DESCRIPTION
## Description

This PR adds sampled instrumentation to 5% of partition processing attempts. We group items by backlogs and calculate the "compression ratio" of backlogs to peeked items, understanding the potential ceiling for reducing Acquire calls. We also count the size distribution of "chains" of successive items with the same key.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
