### PR TITLE
Remove (newly added) excessive logging

### DIFF
--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -407,9 +407,6 @@ func (q *queueProcessor) ProcessItem(
 				l.Error("error requeuing job", "error", err, "item", qi)
 				return err
 			}
-			if err != state.ErrConnectWorkerCapacity {
-				l.Debug("ProcessItem requeued job due to either lease extension error or error running the job", "err", err)
-			}
 			if _, ok := err.(QuitError); ok {
 				q.quit <- err
 				return err


### PR DESCRIPTION
## Description

The vast majority of these errors are sdk errors that get retried and this is not a good signal to capture in logs.

We already log lease extension errors so that should help track if lease extension errors are contributing to SYS-655

## Motivation



## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
