### PR TITLE
Properly handle Redis network errors in Constraint API

### DIFF
--- a/pkg/constraintapi/lua.go
+++ b/pkg/constraintapi/lua.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"net"
 	"os"
@@ -352,6 +353,11 @@ func isNetworkError(err error) bool {
 	}
 	var dnsErr *net.DNSError
 	if errors.As(err, &dnsErr) {
+		return true
+	}
+	// rueidis returns io.EOF and io.ErrUnexpectedEOF directly from its bufio
+	// read loop without wrapping them in *net.OpError, so check explicitly.
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}
 	return false

--- a/pkg/constraintapi/lua_test.go
+++ b/pkg/constraintapi/lua_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"net"
 	"os"
@@ -331,6 +332,30 @@ func TestLuaError(t *testing.T) {
 		{
 			name:       "wrapped net.DNSError returns network_error",
 			err:        fmt.Errorf("redis: %w", dnsErr),
+			wantStatus: "network_error",
+			wantRetry:  true,
+		},
+		{
+			name:       "io.EOF returns network_error",
+			err:        io.EOF,
+			wantStatus: "network_error",
+			wantRetry:  true,
+		},
+		{
+			name:       "wrapped io.EOF returns network_error",
+			err:        fmt.Errorf("redis: %w", io.EOF),
+			wantStatus: "network_error",
+			wantRetry:  true,
+		},
+		{
+			name:       "io.ErrUnexpectedEOF returns network_error",
+			err:        io.ErrUnexpectedEOF,
+			wantStatus: "network_error",
+			wantRetry:  true,
+		},
+		{
+			name:       "wrapped io.ErrUnexpectedEOF returns network_error",
+			err:        fmt.Errorf("redis: %w", io.ErrUnexpectedEOF),
 			wantStatus: "network_error",
 			wantRetry:  true,
 		},


### PR DESCRIPTION
## Description

This PR expands error detection in the Constraint API to handle most network errors, including DNS lookup, dial and connection reset errors.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
