### PR TITLE
Fix expand/contract in new traces

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/TimelineBar.tsx
+++ b/ui/packages/components/src/RunDetailsV4/TimelineBar.tsx
@@ -563,7 +563,7 @@ export function TimelineBar({
         className="relative isolate flex h-7 cursor-pointer items-center"
         onClick={() => {
           onClick?.();
-          if (expandable && !expanded) {
+          if (expandable) {
             onToggle?.();
           }
         }}


### PR DESCRIPTION
## Description

Fixes the expand/contract behavior in new traces

## Motivation
Currently, you can click anywhere on the trace row to expand the traces dropdown, but it doesn't work for collaps. This fixes that

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
