### PR TITLE
adds skip cache search param to post webhook delete nav

### DIFF
--- a/ui/apps/dashboard/src/components/Manage/DeleteKeyModal.tsx
+++ b/ui/apps/dashboard/src/components/Manage/DeleteKeyModal.tsx
@@ -6,6 +6,7 @@ import { useEnvironment } from '@/components/Environments/environment-context';
 import { graphql } from '@/gql';
 import useManagePageTerminology from './useManagePageTerminology';
 import { useNavigate } from '@tanstack/react-router';
+import { skipCacheSearchParam } from '@/utils/urls';
 
 const DeleteEventKey = graphql(`
   mutation DeleteEventKey($input: DeleteIngestKey!) {
@@ -50,6 +51,10 @@ export default function DeleteKeyModal({
             envSlug: env.slug,
             ingestKeys: currentContent?.param,
           },
+          search: (prev) => ({
+            ...prev,
+            [skipCacheSearchParam.name]: skipCacheSearchParam.value,
+          }),
         });
       }
     });


### PR DESCRIPTION
## Description

Turns out this was a gql cache issue, not a router cache issue...and we have a search param util to bust the cache. 

## Motivation
Don't show stale webhooks post delete.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
