### PR TITLE
Fix trace viz for root and finalization

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/TimelineBar.tsx
+++ b/ui/packages/components/src/RunDetailsV4/TimelineBar.tsx
@@ -68,7 +68,7 @@ const BAR_STYLES: Record<BarStyleKey, BarStyle> = {
   },
   'timing.inngest': {
     barColor: 'bg-slate-300',
-    barHeight: 'tall',
+    barHeight: 'short',
     durationColor: 'text-basis',
     labelFormat: 'default',
     textColor: 'text-light',

--- a/ui/packages/components/src/RunDetailsV4/TimelineBar.types.ts
+++ b/ui/packages/components/src/RunDetailsV4/TimelineBar.types.ts
@@ -44,7 +44,7 @@ export type BarStyleKey =
   | 'step.waitForEvent'
   | 'step.invoke'
   // Timing categories
-  | 'timing.inngest' // Queue time (short, gray)
+  | 'timing.inngest' // Queue/delay time (short, gray)
   | 'timing.server' // Execution time (tall, barber-pole, status color)
   | 'timing.connecting' // Connection time (short, dotted border, status color)
   // HTTP timing phases (nested under server execution)


### PR DESCRIPTION
## Description

* Added `generateDelaySegments` function to create delay + execution segments for bars lacking `timingBreakdown`, ensuring checkpoint/queue delays are visually represented as a gray bar followed by the execution portion.
* Updated `TimelineBarRenderer` to use `generateDelaySegments` as a fallback when `generateBarSegments` returns undefined, improving segment rendering for root and finalization bars.

## Motivation
- Speed Tracer fix

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*