### PR TITLE
Fix/run spans query

### DIFF
--- a/pkg/coreapi/graph/loaders/cache.go
+++ b/pkg/coreapi/graph/loaders/cache.go
@@ -1,0 +1,81 @@
+package loader
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// LookupCache provides per-request caching with singleflight deduplication
+// for frequently looked-up entities. When 100 concurrent goroutines request
+// the same key, only one DB call is made and all others wait for the result.
+type LookupCache struct {
+	mu      sync.Mutex
+	data    map[string]interface{}
+	flights map[string]*flight
+}
+
+type flight struct {
+	done chan struct{}
+	val  interface{}
+	err  error
+}
+
+type lookupCacheKey struct{}
+
+func WithLookupCache(ctx context.Context) context.Context {
+	return context.WithValue(ctx, lookupCacheKey{}, &LookupCache{
+		data:    make(map[string]interface{}),
+		flights: make(map[string]*flight),
+	})
+}
+
+func GetLookupCache(ctx context.Context) *LookupCache {
+	if c, ok := ctx.Value(lookupCacheKey{}).(*LookupCache); ok {
+		return c
+	}
+	return nil
+}
+
+// GetOrLoad returns a cached value or calls the loader function exactly once
+// per key, even under concurrent access. All concurrent callers for the same
+// key block until the single loader completes.
+func (c *LookupCache) GetOrLoad(kind string, id uuid.UUID, loader func() (interface{}, error)) (interface{}, error) {
+	key := kind + ":" + id.String()
+
+	c.mu.Lock()
+	// Check cache first
+	if v, ok := c.data[key]; ok {
+		c.mu.Unlock()
+		return v, nil
+	}
+	// Check if there's an in-flight request
+	if f, ok := c.flights[key]; ok {
+		c.mu.Unlock()
+		<-f.done
+		return f.val, f.err
+	}
+	// Start a new flight
+	f := &flight{done: make(chan struct{})}
+	c.flights[key] = f
+	c.mu.Unlock()
+
+	// Execute the loader
+	f.val, f.err = loader()
+	if f.err == nil {
+		c.mu.Lock()
+		c.data[key] = f.val
+		c.mu.Unlock()
+	}
+
+	// Unblock all waiters
+	close(f.done)
+
+	// Clean up flight
+	c.mu.Lock()
+	delete(c.flights, key)
+	c.mu.Unlock()
+
+	return f.val, f.err
+}

--- a/pkg/coreapi/graph/loaders/loader.go
+++ b/pkg/coreapi/graph/loaders/loader.go
@@ -27,6 +27,7 @@ func Middleware(params LoaderParams) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			loaders := NewLoaders(params)
 			ctx := ToCtx(r.Context(), loaders)
+			ctx = WithLookupCache(ctx)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}

--- a/pkg/coreapi/graph/resolvers/function_run_v2.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run_v2.resolver.go
@@ -13,15 +13,37 @@ func (r *functionRunV2Resolver) App(
 	ctx context.Context,
 	run *models.FunctionRunV2,
 ) (*cqrs.App, error) {
+	if cache := loader.GetLookupCache(ctx); cache != nil {
+		v, err := cache.GetOrLoad("app", run.AppID, func() (interface{}, error) {
+			return r.Data.GetAppByID(ctx, run.AppID)
+		})
+		if err != nil {
+			return nil, err
+		}
+		return v.(*cqrs.App), nil
+	}
 	return r.Data.GetAppByID(ctx, run.AppID)
 }
 
 func (r *functionRunV2Resolver) Function(ctx context.Context, fn *models.FunctionRunV2) (*models.Function, error) {
+	if cache := loader.GetLookupCache(ctx); cache != nil {
+		v, err := cache.GetOrLoad("func", fn.FunctionID, func() (interface{}, error) {
+			fun, err := r.Data.GetFunctionByInternalUUID(ctx, fn.FunctionID)
+			if err != nil {
+				return nil, fmt.Errorf("error retrieving function: %w", err)
+			}
+			return models.MakeFunction(fun)
+		})
+		if err != nil {
+			return nil, err
+		}
+		return v.(*models.Function), nil
+	}
+
 	fun, err := r.Data.GetFunctionByInternalUUID(ctx, fn.FunctionID)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving function: %w", err)
 	}
-
 	return models.MakeFunction(fun)
 }
 

--- a/pkg/cqrs/base_cqrs/migrations/postgres/000019_add_span_query_indexes.down.sql
+++ b/pkg/cqrs/base_cqrs/migrations/postgres/000019_add_span_query_indexes.down.sql
@@ -1,0 +1,3 @@
+-- Drop indexes added for the optimized GetSpanRuns query.
+DROP INDEX IF EXISTS idx_spans_executor_run_start;
+DROP INDEX IF EXISTS idx_spans_run_dynamic_endtime_status;

--- a/pkg/cqrs/base_cqrs/migrations/postgres/000019_add_span_query_indexes.up.sql
+++ b/pkg/cqrs/base_cqrs/migrations/postgres/000019_add_span_query_indexes.up.sql
@@ -1,0 +1,17 @@
+-- Indexes to support the optimized GetSpanRuns query.
+--
+-- Note: CREATE INDEX (without CONCURRENTLY) acquires a write lock. On large
+-- tables, operators may prefer to run these manually with CONCURRENTLY before
+-- applying the migration. IF NOT EXISTS ensures idempotency either way.
+--
+-- For root span lookup with ORDER BY start_time DESC, run_id.
+-- Partial index covers the common filters, enabling index scan with LIMIT pushdown.
+-- Note: the filter matches newSpanRunsQueryBuilder which excludes 'Skipped' (not 'Cancelled').
+CREATE INDEX IF NOT EXISTS idx_spans_executor_run_start
+    ON spans(start_time DESC, run_id)
+    WHERE name = 'executor.run' AND debug_run_id IS NULL AND (status IS NULL OR status <> 'Skipped');
+
+-- For correlated subqueries: MAX(end_time) and latest status per (run_id, dynamic_span_id).
+-- The INCLUDE(status) enables index-only scans (0 heap fetches) for both lookups.
+CREATE INDEX IF NOT EXISTS idx_spans_run_dynamic_endtime_status
+    ON spans(run_id, dynamic_span_id, end_time DESC) INCLUDE (status);


### PR DESCRIPTION
## Description

Fixes #3612 - I think an attempt was made with https://github.com/inngest/inngest/pull/3652  but that wont actually fix the underlying behavior.                                                                                                                                                                                                    

  Optimizes the `GetSpanRuns` query path for PostgreSQL, addressing the runs list page being unusable on large self-hosted datasets. Three changes:

  1. **Database indexes** (migration 000019): A partial index on root spans for LIMIT pushdown, and a covering index for correlated subquery lookups. `IF NOT EXISTS` is used so operators can optionally run these
  manually with `CONCURRENTLY` before applying the migration to avoid write locks on large tables.

  2. **Query rewrite** (PostgreSQL only): The original query used `GROUP BY` over all spans with `MIN()`/`MAX()` aggregates and a correlated status subquery per group. With `GROUP BY + LIMIT`, Postgres must fully
  aggregate all groups before applying LIMIT — making the query O(total_runs) regardless of page size. The rewrite queries root spans (`name='executor.run'`) directly, applies ORDER BY + LIMIT early, then runs
  correlated subqueries only on the result set (~40 rows). The SQLite path is unchanged.

  3. **Singleflight cache** for `App()` and `Function()` field resolvers: gqlgen resolves fields concurrently, causing 40+ duplicate DB calls per field per page. A per-request cache with channel-based deduplication
   ensures one DB call per unique key. Falls back to direct DB calls if the cache is not in context.

I structured them as three separate commits in case you would like me to resolve them 

  ### Behavioral notes

  - The PostgreSQL query path activates when `w.isPostgres()` is true and `opt.Preview` is true. SQLite behavior is completely unchanged.
  - The status filter now applies to the root span's status rather than any span in the run group. The original behavior could return runs whose displayed status didn't match the filter (the filter applied
  pre-GROUP BY on individual span rows, but the displayed status came from the latest span). The new behavior is more consistent.
  - `GetTraceRunsCount` uses `COUNT(DISTINCT run_id)` on PostgreSQL instead of fetching all rows and calling `len()`.
  - Migration number 000019 is currently free on main — if there's a collision with an in-flight PR, happy to renumber.

### Tests

I didn't see any existing tests for postgres specific queries and didn't see any unit testing for the dataloaders so I didn't add any.

## Motivation

On a self-hosted deployment with ~1.2M spans / ~88K runs (PostgreSQL on RDS), the runs list page took 40-90 seconds to load. After this change it completes in <100 ms. This both fixes initial page load and allows for the infinite scroll in pagination to actually work seamlessly.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
