### PR TITLE
fix: propagate SaveStep errors in checkpoint API

### DIFF
--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -165,6 +165,7 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 				}
 				if err != nil {
 					l.Error("error saving checkpointed step state", "error", err)
+					return fmt.Errorf("failed to save step %s: %w", op.ID, err)
 				}
 			}
 
@@ -412,6 +413,7 @@ func (c checkpointer) checkpointAsyncSteps(ctx context.Context, input AsyncCheck
 			}
 			if err != nil {
 				l.Error("error saving checkpointed step state", "error", err)
+				return fmt.Errorf("failed to save step %s: %w", op.ID, err)
 			}
 
 			_, err = c.TracerProvider.CreateSpan(


### PR DESCRIPTION
## Description

SaveStep errors were being logged, but not returned so the SDK was getting a 200 even when steps failed to persist, so the SDK discarded the buffered steps which led to those steps not being available further in the code. Pairs with https://github.com/inngest/inngest-js/pull/1340 to correctly handle the errors.

## Motivation

Fixes issues for customers using checkpointing

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
