### PR TITLE
expose monaco scollbar props so callers can control

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/CellDetail/CellDetailView.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/CellDetail/CellDetailView.tsx
@@ -82,13 +82,10 @@ function CellValueCodeBlock({
   }, [columnType, value]);
 
   return (
-    <div className="bg-codeEditor h-full overflow-hidden rounded-lg">
+    <div className="bg-codeEditor h-full overflow-hidden rounded-lg border border-subtle">
       <NewCodeBlock
-        tab={{
-          content,
-          language,
-          readOnly: true,
-        }}
+        tab={{ content, language, readOnly: true }}
+        scrollbarOptions={{ vertical: 'auto', horizontal: 'auto' }}
       />
     </div>
   );

--- a/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
+++ b/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
@@ -14,6 +14,7 @@ import {
   RiEdit2Line,
   RiExpandDiagonalLine,
 } from '@remixicon/react';
+import type { editor } from 'monaco-editor';
 import { JSONTree } from 'react-json-tree';
 import useLocalStorage from 'react-use/esm/useLocalStorage';
 
@@ -52,6 +53,7 @@ interface CodeBlockProps {
   allowFullScreen?: boolean;
   enableTreeView?: boolean;
   loading?: boolean;
+  scrollbarOptions?: editor.IEditorScrollbarOptions;
 }
 
 const jsonParse = (content: string) => {
@@ -85,6 +87,7 @@ export const NewCodeBlock = ({
   enableTreeView = false,
   loading = false,
   className,
+  scrollbarOptions,
 }: CodeBlockProps) => {
   const [dark, _] = useState(isDark());
   const [fullScreen, setFullScreen] = useState(false);
@@ -258,6 +261,7 @@ export const NewCodeBlock = ({
               theme="inngest-theme"
               language={language}
               value={editEmtpy ? EMPTY_INPUT : content}
+              height="100%"
               options={{
                 wordWrap: wordWrap ? 'on' : 'off',
                 contextmenu: false,
@@ -271,7 +275,7 @@ export const NewCodeBlock = ({
                 renderWhitespace: 'none',
                 automaticLayout: true,
                 scrollBeyondLastLine: false,
-                scrollbar: {
+                scrollbar: scrollbarOptions ?? {
                   alwaysConsumeMouseWheel: false,
                   horizontalScrollbarSize: 0,
                   verticalScrollbarSize: 0,

--- a/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
+++ b/ui/packages/components/src/TriggerDetails/TriggerDetails.tsx
@@ -4,7 +4,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@inngest/components/Too
 import * as Collapsible from '@radix-ui/react-collapsible';
 import { RiContractRightFill, RiExpandLeftFill } from '@remixicon/react';
 import { useQuery } from '@tanstack/react-query';
-import useLocalStorage from 'react-use/lib/useLocalStorage';
+import useLocalStorage from 'react-use/esm/useLocalStorage';
 
 import { Card } from '../Card';
 import { CodeBlock } from '../CodeBlock';


### PR DESCRIPTION
* border in insights
* fix bug on run details

## Description
<img width="747" height="864" alt="Screenshot 2026-02-26 at 11 45 03 AM" src="https://github.com/user-attachments/assets/383a5c88-86d7-4b02-8129-9095e88f22fb" />

## Motivation
for insights

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
