### PR TITLE
Update partition processing

### DIFF
--- a/pkg/execution/queue/consts.go
+++ b/pkg/execution/queue/consts.go
@@ -113,10 +113,11 @@ const (
 )
 
 const (
-	defaultNumWorkers                  = 100
-	defaultNumShadowWorkers            = 100
-	defaultBacklogNormalizationWorkers = 10
-	defaultBacklogNormalizeConcurrency = int64(20)
+	defaultNumWorkers                        = 100
+	defaultNumShadowWorkers                  = 100
+	defaultNumPartitionWorkers         int32 = 50
+	defaultBacklogNormalizationWorkers       = 10
+	defaultBacklogNormalizeConcurrency       = int64(20)
 )
 
 const (

--- a/pkg/execution/queue/continuation.go
+++ b/pkg/execution/queue/continuation.go
@@ -89,46 +89,31 @@ func (q *queueProcessor) scanContinuations(ctx context.Context) error {
 		return nil
 	}
 
-	// Have some chance of skipping continuations in this iteration.
-	if rand.Float64() <= consts.QueueContinuationSkipProbability {
+	// Have some chance of skipping continuations in this iteration.  And, if someone
+	// else has continuations locked, don't bother.
+	if rand.Float64() <= consts.QueueContinuationSkipProbability || !q.continuesLock.TryLock() {
 		return nil
 	}
 
-	eg := errgroup.Group{}
-	// If we have continued partitions, process those immediately.
-	q.continuesLock.Lock()
 	for _, c := range q.continues {
-		cont := c
-		eg.Go(func() error {
-			p := cont.partition
-			if q.capacity() == 0 {
-				// no longer any available workers for partition, so we can skip
-				// work
-				metrics.IncrQueueScanNoCapacityCounter(ctx, metrics.CounterOpt{PkgName: pkgName})
-				return nil
-			}
-
-			logger.StdlibLogger(ctx).Trace("continue partition processing", "partition_id", p.ID, "count", c.count)
-
-			if err := q.ProcessPartition(ctx, p, cont.count, false); err != nil {
-				if err == ErrPartitionNotFound || err == ErrPartitionGarbageCollected {
-					q.removeContinue(ctx, p, false)
-					return nil
-				}
-				if errors.Unwrap(err) != context.Canceled {
-					logger.StdlibLogger(ctx).Error("error processing partition", "error", err)
-				}
-				return err
-			}
-
-			metrics.IncrQueuePartitionProcessedCounter(ctx, metrics.CounterOpt{
-				PkgName: pkgName,
-			})
-			return nil
-		})
+		if q.capacity() == 0 || q.partitionCapacity() == 0 {
+			break
+		}
+		if !q.partitionSem.TryAcquire(1) {
+			break
+		}
+		select {
+		case q.partitions <- partitionMsg{
+			partition:         c.partition,
+			continuationCount: c.count,
+		}:
+			// Sent successfully
+		default:
+			q.partitionSem.Release(1)
+		}
 	}
 	q.continuesLock.Unlock()
-	return eg.Wait()
+	return nil
 }
 
 // AddShadowContinue is the equivalent of addContinue for shadow partitions

--- a/pkg/execution/queue/instrumentation.go
+++ b/pkg/execution/queue/instrumentation.go
@@ -47,6 +47,8 @@ func (q *queueProcessor) runInstrumentation(ctx context.Context) {
 			}
 		case <-tick.Chan():
 			metrics.GaugeWorkerQueueCapacity(ctx, int64(q.numWorkers), metrics.GaugeOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": q.primaryQueueShard.Name()}})
+			metrics.GaugePartitionProcessorCapacity(ctx, q.partitionCapacity(), metrics.GaugeOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": q.primaryQueueShard.Name()}})
+			metrics.GaugePartitionProcessorInFlight(ctx, q.partitionSem.Count(), metrics.GaugeOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": q.primaryQueueShard.Name()}})
 
 			shardAssignmentConfig := q.primaryQueueShard.ShardAssignmentConfig()
 			metrics.GaugeShardLeaseCapacity(ctx, int64(shardAssignmentConfig.NumExecutors), metrics.GaugeOpt{PkgName: pkgName, Tags: map[string]any{"shard_group": shardAssignmentConfig.ShardGroup, "queue_shard": q.primaryQueueShard.Name(), "segment": q.ShardLeaseKeySuffix}})

--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -90,6 +90,12 @@ func WithShadowNumWorkers(n int32) QueueOpt {
 	}
 }
 
+func WithNumPartitionWorkers(n int32) QueueOpt {
+	return func(q *QueueOptions) {
+		q.numPartitionWorkers = n
+	}
+}
+
 func WithPeekSizeRange(min int64, max int64) QueueOpt {
 	return func(q *QueueOptions) {
 		if max > AbsoluteQueuePeekMax {
@@ -400,6 +406,8 @@ type QueueOptions struct {
 	numWorkers int32
 	// numShadowWorkers stores the number of workers available to concurrently scan partitions
 	numShadowWorkers int32
+	// numPartitionWorkers stores the number of goroutines available to concurrently process partitions.
+	numPartitionWorkers int32
 	// numBacklogNormalizationWorkers stores the maximum number of workers available to concurrenctly scan normalization partitions
 	numBacklogNormalizationWorkers int32
 	// peek min & max sets the range for partitions to peek for items
@@ -765,6 +773,7 @@ func NewQueueOptions(
 		},
 		numWorkers:                     defaultNumWorkers,
 		numShadowWorkers:               defaultNumShadowWorkers,
+		numPartitionWorkers:            defaultNumPartitionWorkers,
 		numBacklogNormalizationWorkers: defaultBacklogNormalizationWorkers,
 		pollTick:                       defaultPollTick,
 		shadowPollTick:                 defaultShadowPollTick,

--- a/pkg/telemetry/metrics/gauge.go
+++ b/pkg/telemetry/metrics/gauge.go
@@ -137,3 +137,21 @@ func GaugeAggregatorPendingDeletes(ctx context.Context, value int64, opts GaugeO
 		Tags:        opts.Tags,
 	})
 }
+
+func GaugePartitionProcessorCapacity(ctx context.Context, val int64, opts GaugeOpt) {
+	RecordGaugeMetric(ctx, val, GaugeOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "partition_processor_capacity",
+		Description: "Available capacity in the partition processor pool",
+		Tags:        opts.Tags,
+	})
+}
+
+func GaugePartitionProcessorInFlight(ctx context.Context, val int64, opts GaugeOpt) {
+	RecordGaugeMetric(ctx, val, GaugeOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "partition_processor_in_flight",
+		Description: "Number of partitions currently being processed",
+		Tags:        opts.Tags,
+	})
+}


### PR DESCRIPTION
This PR introduces a cap on how many partitions can be concurrently scanned, and drops other partitions if the sem is full.

This allows us to add backpressure to any backing datastore.  We also skip scans if partition processing is currently at capacity.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
