### PR TITLE
Display actual error name and message for system errors in trace UI

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -34,7 +34,7 @@ var (
 
 	ErrEmptyResponse = fmt.Errorf("no response data")
 	ErrNoRetryAfter  = fmt.Errorf("no retry after present")
-	ErrNotSDK        = syscode.Error{Code: syscode.CodeNotSDK}
+	ErrNotSDK        = syscode.Error{Code: syscode.CodeNotSDK, Message: "The response did not come from an Inngest SDK"}
 
 	defaultClient = exechttp.Client(exechttp.SecureDialerOpts{})
 )
@@ -339,7 +339,7 @@ func do(ctx context.Context, c exechttp.RequestExecutor, r Request) (*Response, 
 
 	var sysErr *syscode.Error
 	if errors.Is(err, exechttp.ErrBodyTooLarge) {
-		sysErr = &syscode.Error{Code: syscode.CodeOutputTooLarge}
+		sysErr = &syscode.Error{Code: syscode.CodeOutputTooLarge, Message: "Your function's response body exceeds the maximum size limit"}
 		//
 		// downstream executor code expects system error codes here for traces
 		// and history to work properly

--- a/tests/golang/fn_output_test.go
+++ b/tests/golang/fn_output_test.go
@@ -2,7 +2,6 @@ package golang
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -48,8 +47,8 @@ func TestFnOutputTooLarge(t *testing.T) {
 	// Wait a moment for runID to be populated
 	<-time.After(2 * time.Second)
 	run := c.WaitForRunStatus(ctx, t, "FAILED", runID)
-	var output string
-	err = json.Unmarshal([]byte(run.Output), &output)
-	r.NoError(err)
-	r.Equal(syscode.CodeOutputTooLarge, output)
+
+	// The output should be a structured StandardError serialized under the "error" key.
+	expectedOutput := `{"error":{"error":"` + syscode.CodeOutputTooLarge + `: Your function's response body exceeds the maximum size limit","name":"` + syscode.CodeOutputTooLarge + `","message":"Your function's response body exceeds the maximum size limit"}}`
+	r.Equal(expectedOutput, run.Output)
 }


### PR DESCRIPTION
## Description

fix system errors (e.g. `output_too_large`, `not_sdk`) displaying as "Unknown error" in the trace UI instead of their actual name and message

affected error codes:
- `output_too_large` function response exceeds 8MB size limit
- `not_sdk` response missing x-inngest-sdk header
- Connect worker errors (`connect_all_workers_at_capacity`, `connect_no_healthy_connection`, etc.)  these already had messages but were also blocked by the errors.As mismatch

before:
<img width="1919" height="666" alt="Screenshot 2026-02-27 at 5 04 17 PM" src="https://github.com/user-attachments/assets/c9e7ecc2-6f96-4552-8b8c-4bfbeb36316c" />


after:
<img width="1919" height="666" alt="Screenshot 2026-02-27 at 5 01 27 PM" src="https://github.com/user-attachments/assets/f3e5e20d-028c-4afd-b5a3-b29003c1456f" />


## Motivation

better errors!

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
