### PR TITLE
Fix insights tabs sharing rendering bug

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
@@ -88,6 +88,7 @@ export interface TabManagerActions {
 export interface UseInsightsTabManagerReturn {
   actions: TabManagerActions;
   activeTabId: string;
+  isHydrated: boolean;
   tabManager: JSX.Element;
   tabs: Tab[];
 }
@@ -107,6 +108,7 @@ export function useInsightsTabManager(
   const [tabs, setTabs] = useState<Tab[]>([HOME_TAB]);
   const [activeTabId, setActiveTabId] = useState<string>(HOME_TAB.id);
   const hasHydratedRef = useRef(false);
+  const [isHydrated, setIsHydrated] = useState(false);
   const isInsightsAgentEnabled = useBooleanFlag('insights-agent');
   const isSchemaWidgetEnabled = useBooleanFlag('insights-schema-widget');
 
@@ -137,6 +139,7 @@ export function useInsightsTabManager(
     }
 
     hasHydratedRef.current = true;
+    setIsHydrated(true);
   }, [props.isSavedQueriesFetching, props.deepLinkQueryId]);
 
   // Save tabs to local storage whenever they change (skip first render)
@@ -283,7 +286,7 @@ export function useInsightsTabManager(
     ],
   );
 
-  return { actions, activeTabId, tabManager, tabs };
+  return { actions, activeTabId, isHydrated, tabManager, tabs };
 }
 
 interface SingleTabRendererProps {

--- a/ui/apps/dashboard/src/components/Insights/useDeepLinkHandler.ts
+++ b/ui/apps/dashboard/src/components/Insights/useDeepLinkHandler.ts
@@ -7,6 +7,7 @@ import { useStoredQueries } from '@/components/Insights/QueryHelperPanel/StoredQ
 interface UseDeepLinkHandlerParams {
   actions: TabManagerActions;
   activeSavedQueryId: string | undefined;
+  isHydrated: boolean;
   navigate: (opts: {
     search: (prev: Record<string, unknown>) => Record<string, unknown>;
     replace?: boolean;
@@ -17,15 +18,21 @@ interface UseDeepLinkHandlerParams {
 export function useDeepLinkHandler({
   actions,
   activeSavedQueryId,
+  isHydrated,
   navigate,
   search,
 }: UseDeepLinkHandlerParams) {
   const { queries, isSavedQueriesFetching } = useStoredQueries();
   const hasProcessedInitialQueryId = useRef(false);
 
-  // Handle initial page load with query_id parameter
+  // Handle initial page load with query_id parameter.
+  // Gated on isHydrated to ensure tab state has been restored from localStorage
+  // before we attempt to create a deep-linked tab. Without this gate, the hydration
+  // effect (in a parent component) can overwrite the tab created here, leaving
+  // activeTabId pointing to a nonexistent tab and causing a blank screen.
   useEffect(() => {
     if (hasProcessedInitialQueryId.current) return;
+    if (!isHydrated) return;
 
     const queryIdFromUrl =
       typeof search.query_id === 'string' ? search.query_id : undefined;
@@ -52,12 +59,13 @@ export function useDeepLinkHandler({
         'Unable to load query; please ensure that you have access to it',
       );
     }
-  }, [search, queries.data, isSavedQueriesFetching, actions]);
+  }, [search, queries.data, isSavedQueriesFetching, actions, isHydrated]);
 
   // Update URL when active tab changes
   useEffect(() => {
-    // Don't sync URL until we've processed the initial query_id
+    // Don't sync URL until we've processed the initial query_id and tabs are hydrated
     if (!hasProcessedInitialQueryId.current) return;
+    if (!isHydrated) return;
 
     const currentQueryId =
       typeof search.query_id === 'string' ? search.query_id : undefined;
@@ -79,5 +87,5 @@ export function useDeepLinkHandler({
       },
       replace: true,
     });
-  }, [activeSavedQueryId, search, navigate]);
+  }, [activeSavedQueryId, search, navigate, isHydrated]);
 }

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/insights/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/insights/index.tsx
@@ -94,13 +94,14 @@ function InsightsWithTabManager({
 }: InsightsWithTabManagerProps) {
   const { isSavedQueriesFetching } = useStoredQueries();
 
-  const { actions, activeTabId, tabManager, tabs } = useInsightsTabManager({
-    historyWindow,
-    isQueryHelperPanelVisible,
-    onToggleQueryHelperPanelVisibility,
-    isSavedQueriesFetching,
-    deepLinkQueryId,
-  });
+  const { actions, activeTabId, isHydrated, tabManager, tabs } =
+    useInsightsTabManager({
+      historyWindow,
+      isQueryHelperPanelVisible,
+      onToggleQueryHelperPanelVisibility,
+      isSavedQueriesFetching,
+      deepLinkQueryId,
+    });
 
   // Update the ref with real actions so StoredQueriesProvider can use them
   actionsRef.current = actions;
@@ -122,6 +123,7 @@ function InsightsWithTabManager({
           <InsightsContentWithDeepLink
             isQueryHelperPanelVisible={isQueryHelperPanelVisible}
             activeSavedQueryId={activeSavedQueryId}
+            isHydrated={isHydrated}
             tabManager={tabManager}
             actions={actions}
           />
@@ -134,11 +136,13 @@ function InsightsWithTabManager({
 function InsightsContentWithDeepLink({
   isQueryHelperPanelVisible,
   activeSavedQueryId,
+  isHydrated,
   tabManager,
   actions,
 }: {
   isQueryHelperPanelVisible: boolean;
   activeSavedQueryId: string | undefined;
+  isHydrated: boolean;
   tabManager: JSX.Element;
   actions: TabManagerActions;
 }) {
@@ -149,6 +153,7 @@ function InsightsContentWithDeepLink({
   useDeepLinkHandler({
     actions,
     activeSavedQueryId,
+    isHydrated,
     navigate,
     search,
   });


### PR DESCRIPTION
## Description

There's a bug when you have tabs open and you try to open a share link and it's blank

## Motivation

https://inngest.slack.com/archives/C06A1PM25MY/p1772503276544999

bugged state:
<img width="3024" height="1836" alt="image" src="https://github.com/user-attachments/assets/90edb7be-baa7-4372-ab80-c23676005902" />


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a hydration race condition where the tab manager's localStorage restore effect could overwrite a deep-linked tab created by `useDeepLinkHandler`, leaving `activeTabId` pointing to a nonexistent tab and causing a blank screen. The fix introduces an `isHydrated` state flag that gates the deep-link handler until localStorage restoration is complete.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d9b0911872d782b9cff77437fb7d859648f4b56c.</sup>
<!-- /MENDRAL_SUMMARY -->