### PR TITLE
Ensure we only save pending steps with opcode planned

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3109,7 +3109,8 @@ func (e *executor) HandleGeneratorResponse(ctx context.Context, i *runInstance, 
 
 	groups := opGroups(resp.Generator)
 
-	if stepCount > 1 && i.md.ShouldCoalesceParallelism(resp) {
+	// We only save pending steps if there's >= 1 step planned op.
+	if hasPlanOp(resp.Generator) && i.md.ShouldCoalesceParallelism(resp) {
 		if err := e.smv2.SavePending(ctx, i.md.ID, groups.IDs()); err != nil {
 			return fmt.Errorf("error saving pending steps: %w", err)
 		}
@@ -5280,4 +5281,13 @@ func (e *executor) createMetadataSpan(ctx context.Context, runCtx execution.RunC
 		md,
 		scope,
 	)
+}
+
+func hasPlanOp(ops []*state.GeneratorOpcode) bool {
+	for _, op := range ops {
+		if op.Op == enums.OpcodeStepPlanned {
+			return true
+		}
+	}
+	return false
 }

--- a/tests/golang/checkpoint_test.go
+++ b/tests/golang/checkpoint_test.go
@@ -88,3 +88,55 @@ func TestFnCheckpoint(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckpointMaxDuration(t *testing.T) {
+	ctx := context.Background()
+	r := require.New(t)
+	c := client.New(t)
+
+	inngestClient, server, registerFuncs := NewSDKHandler(t, "checkpoint")
+	defer server.Close()
+
+	rid := NewRunID()
+	evtName := "invoke-checkpoint-timeout"
+	fmt.Println(evtName)
+
+	_, err := inngestgo.CreateFunction(
+		inngestClient,
+		inngestgo.FunctionOpts{
+			ID: evtName,
+			Checkpoint: &checkpoint.Config{
+				BatchSteps:    3,
+				BatchInterval: time.Second,
+				MaxRuntime:    time.Second * 2,
+			},
+		},
+		inngestgo.EventTrigger(evtName, nil),
+		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
+			rid.Send(input.InputCtx.RunID)
+
+			for i := range 8 {
+				_, _ = step.Run(ctx, fmt.Sprintf("%d", i), func(ctx context.Context) (string, error) {
+					<-time.After(1 * time.Second)
+					return "a", nil
+				})
+				fmt.Println(i)
+			}
+			fmt.Println("c (done), ", input.InputCtx.RunID)
+			return nil, nil
+		},
+	)
+	r.NoError(err)
+	registerFuncs()
+
+	// Trigger the main function and successfully invoke the other function
+	_, err = inngestClient.Send(ctx, &event.Event{Name: evtName})
+	r.NoError(err)
+
+	runID := rid.Wait(t)
+	run := c.WaitForRunStatus(ctx, t, "COMPLETED", runID)
+	var output string
+	err = json.Unmarshal([]byte(run.Output), &output)
+	require.NotEmpty(t, runID)
+	r.NoError(err)
+}


### PR DESCRIPTION
There's a change in that async HTTP responses can now contain > 1 step with idempotency from checkpointing.  This improves the assumptions for parallelism in the state store to only save when we have plan ops.


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
