### PR TITLE
Set Poll: true in StartOpts for `inngest start`

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -129,6 +129,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		EventKeys:               eventKeys,
 		NoUI:                    localconfig.GetBoolValue(cmd, "no-ui", false),
 		Persist:                 true,
+		Poll:                    true,
 		PollInterval:            localconfig.GetIntValue(cmd, "poll-interval", devserver.DefaultPollInterval),
 		PostgresConnMaxIdleTime: cmd.Int("postgres-conn-max-idle-time"),
 		PostgresConnMaxLifetime: cmd.Int("postgres-conn-max-lifetime"),


### PR DESCRIPTION
## Description

Set `Poll: true` in `StartOpts` when constructing options for `inngest start`. Without this, the `pollSDKs()` loop skips all healthy (non-errored) apps due to the guard `if !d.Opts.Poll && len(app.Error.String) == 0 { continue }`, making `--poll-interval` and `INNGEST_POLL_INTERVAL` ineffective.

One-line addition in `cmd/start/start.go`. No behavior change for `inngest dev` which already sets `Poll: !noPoll` (defaulting to true).

## Motivation

Fixes #3791. `inngest start` accepts `--poll-interval` but never enables polling for healthy apps. Apps that sync successfully on first boot are never re-synced, even with `--poll-interval 60` and `--sdk-url` configured. Only errored apps get re-polled. This makes it impossible to pick up function changes without restarting the server.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Test plan

1. Build and run `inngest start` with `--signing-key`, `--event-key`, `--sdk-url` pointing at a test app, and `--poll-interval 5`
2. Confirm the app syncs successfully on first boot and functions appear
3. Update the test app's functions (e.g. rename a function or add a new one) and redeploy
4. Wait beyond the poll interval
5. Confirm the Inngest server picks up the new function list without a restart
6. Verify that `inngest dev` still works as before (Poll defaults to true, `--no-poll` disables it)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.