### PR TITLE
Make latency tracker a system job

### DIFF
--- a/pkg/execution/queue/latency.go
+++ b/pkg/execution/queue/latency.go
@@ -3,21 +3,7 @@ package queue
 import (
 	"context"
 	"fmt"
-
-	"github.com/google/uuid"
 )
-
-var (
-	LatencyAccountID  = uuid.MustParse("ffffffff-ffff-ffff-ffff-ffffffffffff")
-	LatencyEnvID      = uuid.MustParse("ffffffff-ffff-ffff-ffff-fffffffffffe")
-	LatencyFunctionID = uuid.MustParse("ffffffff-ffff-ffff-ffff-fffffffffffd")
-)
-
-// IsLatencyPartition reports whether the given partition ID belongs to
-// the latency tracking function.
-func IsLatencyPartition(id string) bool {
-	return id == LatencyFunctionID.String()
-}
 
 // runLatencyTracker is a background goroutine that periodically enqueues
 // latency tracking canary jobs into the queue.

--- a/pkg/execution/queue/latency_test.go
+++ b/pkg/execution/queue/latency_test.go
@@ -12,27 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestIsLatencyPartition(t *testing.T) {
-	tests := []struct {
-		id       string
-		expected bool
-	}{
-		{LatencyFunctionID.String(), true},
-		// Real UUIDs should never match.
-		{"00000000-0000-0000-0000-000000000000", false},
-		{"a1b2c3d4-e5f6-7890-abcd-ef1234567890", false},
-		// Other well-known latency UUIDs are not the function ID.
-		{LatencyAccountID.String(), false},
-		{LatencyEnvID.String(), false},
-		// Empty and short strings.
-		{"", false},
-		{"ffffffff", false},
-	}
-	for _, tt := range tests {
-		require.Equal(t, tt.expected, IsLatencyPartition(tt.id), "IsLatencyPartition(%q)", tt.id)
-	}
-}
-
 func TestWithLatencyPartition(t *testing.T) {
 	t.Run("sets defaults", func(t *testing.T) {
 		called := false
@@ -273,11 +252,8 @@ func TestEnqueueLatencyJob(t *testing.T) {
 		require.Equal(t, int32(1), enqueueCalled.Load())
 
 		require.Equal(t, KindLatencyTrack, enqueuedItem.Kind)
-		require.Nil(t, enqueuedItem.QueueName)
-		require.Equal(t, LatencyAccountID, enqueuedItem.Identifier.AccountID)
-		require.Equal(t, LatencyEnvID, enqueuedItem.Identifier.WorkspaceID)
-		require.Equal(t, LatencyFunctionID, enqueuedItem.Identifier.WorkflowID)
-		require.Equal(t, LatencyEnvID, enqueuedItem.WorkspaceID)
+		require.NotNil(t, enqueuedItem.QueueName)
+		require.Equal(t, "ltc", *enqueuedItem.QueueName)
 		require.NotNil(t, enqueuedItem.JobID)
 		require.Contains(t, *enqueuedItem.JobID, "ltrack-1-")
 		// Enqueue truncates times to millisecond precision internally.


### PR DESCRIPTION
## Description

As we do not provide a proper override for the latency partition, lots of dependencies (partition paused getter, partition priority getter, partition constraint config getter, all feature flags for key queues, Constraint API, etc.) will not properly resolve or log an error and return the default value. This means we basically use the latency partition like a system queue job, only that it's forced to run on the current queue shard.

This PR removes the fake identifier and sets a queue name to make the job a proper system queue. This will do the following
- Skip Constraint API (which was already disabled given the feature flag never evaluated to true)
- Skip constraint checks in partition lease and lease
- Skip constraint updates in extend lease, requeue, dequeue
- Set a higher/unlimited concurrency, etc.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
