### PR TITLE
Fix extra sleep trace

### DIFF
--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -363,7 +364,16 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 			haveSetRunStartTime = true
 		}
 
-		for i, cs := range span.Children {
+		// Filter out dropped spans before processing. Execution spans are
+		// exported to the DB before their DropSpan attribute is set via an
+		// EXTEND span, so they end up in the span tree with
+		// MarkedAsDropped=true. Keeping them would cause phantom "Attempt 0"
+		// entries in the UI.
+		children := slices.DeleteFunc(span.Children, func(s *cqrs.OtelSpan) bool {
+			return s == nil || s.MarkedAsDropped
+		})
+
+		for i, cs := range children {
 			child, err := tr.convertRunSpanToGQL(ctx, cs)
 			if err != nil {
 				return nil, fmt.Errorf("error converting child span: %w", err)
@@ -375,7 +385,7 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 				continue
 			}
 
-			if child.Omit || cs.MarkedAsDropped {
+			if child.Omit {
 				// We're skipping this child, but we may still want to use
 				// its data for timings.
 				if child.SpanTypeName == meta.SpanNameStepDiscovery && !haveSetRunStartTime {

--- a/pkg/coreapi/graph/loaders/trace_test.go
+++ b/pkg/coreapi/graph/loaders/trace_test.go
@@ -3,6 +3,7 @@ package loader
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/pkg/cqrs"
@@ -70,8 +71,11 @@ func TestRunTraceEnded(t *testing.T) {
 	}
 }
 
-func boolPtr(b bool) *bool     { return &b }
-func strPtr(s string) *string  { return &s }
+func boolPtr(b bool) *bool                               { return &b }
+func strPtr(s string) *string                            { return &s }
+func opcodePtr(o enums.Opcode) *enums.Opcode             { return &o }
+func stepStatusPtr(s enums.StepStatus) *enums.StepStatus { return &s }
+func durationPtr(d time.Duration) *time.Duration         { return &d }
 
 func TestConvertRunSpanToGQL_UserlandCollapse(t *testing.T) {
 	tr := &traceReader{}
@@ -105,10 +109,10 @@ func TestConvertRunSpanToGQL_UserlandCollapse(t *testing.T) {
 			Attributes:  &meta.ExtractedValues{},
 			Children: []*cqrs.OtelSpan{
 				{
-					RawOtelSpan: cqrs.RawOtelSpan{Name: SDKExecutionSpanName},
+					RawOtelSpan: cqrs.RawOtelSpan{Name: "inngest.execution"},
 					Attributes: &meta.ExtractedValues{
 						IsUserland:   boolPtr(true),
-						UserlandName: strPtr(SDKExecutionSpanName),
+						UserlandName: strPtr("inngest.execution"),
 					},
 					Children: []*cqrs.OtelSpan{
 						{
@@ -160,5 +164,99 @@ func TestConvertRunSpanToGQL_UserlandCollapse(t *testing.T) {
 		assert.True(t, result.ChildrenSpans[0].IsUserland)
 		require.Len(t, result.ChildrenSpans[0].ChildrenSpans, 1, "should preserve children")
 		assert.Equal(t, "child-span", result.ChildrenSpans[0].ChildrenSpans[0].Name)
+	})
+}
+
+// TestConvertRunSpanToGQL_DroppedChildrenSkipped verifies that MarkedAsDropped
+// children are filtered from a parent's ChildrenSpans. This prevents a bug
+// where step.sleep (and other discovery-response steps) showed a phantom
+// "Attempt 0" from a leaked execution span that was exported to the DB before
+// its DropSpan attribute was set via an EXTEND span.
+func TestConvertRunSpanToGQL_DroppedChildrenSkipped(t *testing.T) {
+	tr := &traceReader{}
+	ctx := context.Background()
+
+	// Builds the span tree that reproduces the sleep 2-attempt bug:
+	// A SpanNameStepDiscovery parent with two children:
+	//   - Child 0: execution span (MarkedAsDropped) - the leaked "scheduler" span
+	//   - Child 1: step span with sleep info - the actual sleep
+	buildSleepDiscoverySpan := func(sleepCompleted bool) *cqrs.OtelSpan {
+		stepChild := &cqrs.OtelSpan{
+			RawOtelSpan: cqrs.RawOtelSpan{Name: meta.SpanNameStep},
+			Attributes: &meta.ExtractedValues{
+				StepOp:            opcodePtr(enums.OpcodeSleep),
+				StepSleepDuration: durationPtr(5 * time.Second),
+				StepName:          strPtr("wait"),
+			},
+		}
+		if sleepCompleted {
+			stepChild.Attributes.DynamicStatus = stepStatusPtr(enums.StepStatusCompleted)
+			now := time.Now()
+			stepChild.Attributes.EndedAt = &now
+			started := now.Add(-5 * time.Second)
+			stepChild.Attributes.StartedAt = &started
+		}
+
+		return &cqrs.OtelSpan{
+			RawOtelSpan: cqrs.RawOtelSpan{Name: meta.SpanNameStepDiscovery},
+			Attributes:  &meta.ExtractedValues{},
+			Children: []*cqrs.OtelSpan{
+				{
+					// The leaked execution span - exported before DropSpan
+					// was set, then merged with its EXTEND to get
+					// MarkedAsDropped=true.
+					RawOtelSpan:     cqrs.RawOtelSpan{Name: meta.SpanNameExecution},
+					Attributes:      &meta.ExtractedValues{},
+					MarkedAsDropped: true,
+				},
+				stepChild,
+			},
+		}
+	}
+
+	t.Run("dropped execution child is skipped, completed sleep collapses", func(t *testing.T) {
+		span := buildSleepDiscoverySpan(true)
+
+		result, err := tr.convertRunSpanToGQL(ctx, span)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.False(t, result.Omit, "discovery span with a non-dropped child should not be omitted")
+		assert.Empty(t, result.ChildrenSpans, "completed sleep should collapse to zero children")
+
+		require.NotNil(t, result.StepOp, "StepOp should be propagated from child")
+		assert.Equal(t, models.StepOpSleep, *result.StepOp)
+	})
+
+	t.Run("dropped execution child is skipped, running sleep shows 1 child", func(t *testing.T) {
+		span := buildSleepDiscoverySpan(false)
+
+		result, err := tr.convertRunSpanToGQL(ctx, span)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.False(t, result.Omit)
+		require.Len(t, result.ChildrenSpans, 1, "running sleep should have exactly 1 visible child")
+		assert.Equal(t, "Attempt 0", result.ChildrenSpans[0].Name)
+	})
+
+	t.Run("all children dropped causes parent to be omitted", func(t *testing.T) {
+		span := &cqrs.OtelSpan{
+			RawOtelSpan: cqrs.RawOtelSpan{Name: meta.SpanNameStepDiscovery},
+			Attributes:  &meta.ExtractedValues{},
+			Children: []*cqrs.OtelSpan{
+				{
+					RawOtelSpan:     cqrs.RawOtelSpan{Name: meta.SpanNameExecution},
+					Attributes:      &meta.ExtractedValues{},
+					MarkedAsDropped: true,
+				},
+			},
+		}
+
+		result, err := tr.convertRunSpanToGQL(ctx, span)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.True(t, result.Omit, "discovery span with only dropped children should be omitted")
 	})
 }


### PR DESCRIPTION
## Description

There is an extra trace for sleeps, this fixes it

## Motivation

before:
<img width="1512" height="918" alt="Screenshot 2026-03-04 at 7 45 45 AM" src="https://github.com/user-attachments/assets/894dc7bf-dae3-4188-97c2-5faa31e54cfa" />

after:
<img width="1512" height="918" alt="Screenshot 2026-03-04 at 7 46 50 AM" src="https://github.com/user-attachments/assets/9e40a76a-2082-416d-ab5a-18fd1b134f0c" />


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a phantom "Attempt 0" UI entry for `step.sleep` by pre-filtering `MarkedAsDropped` children via `slices.DeleteFunc` before the span-processing loop, and simplifying the `showSpan` assignment to unconditional. The second commit adds targeted test fixtures covering completed sleep, running sleep, and all-dropped cases.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 80e6aa21c952fadcb7a6573bc000f4fbda4ca164.</sup>
<!-- /MENDRAL_SUMMARY -->