### PR TITLE
Add disk-based response cache for executor crash recovery

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/inngest/inngest/pkg/execution/driver"
 	"github.com/inngest/inngest/pkg/execution/exechttp"
 	"github.com/inngest/inngest/pkg/execution/executor/queueref"
+	"github.com/inngest/inngest/pkg/execution/executor/responsecache"
 	"github.com/inngest/inngest/pkg/execution/pauses"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/ratelimit"
@@ -263,6 +264,13 @@ func WithStateSizeLimits(limit func(id sv2.ID) int) ExecutorOpt {
 func WithRateLimiter(rl ratelimit.RateLimiter) ExecutorOpt {
 	return func(e execution.Executor) error {
 		e.(*executor).rateLimiter = rl
+		return nil
+	}
+}
+
+func WithResponseCache(rc responsecache.ResponseCache) ExecutorOpt {
+	return func(e execution.Executor) error {
+		e.(*executor).responseCache = rc
 		return nil
 	}
 }
@@ -505,6 +513,10 @@ type executor struct {
 
 	allowStepMetadata AllowStepMetadata
 	clock             clockwork.Clock
+
+	// responseCache optionally caches SDK responses to disk for crash
+	// recovery.  If nil, caching is disabled.
+	responseCache responsecache.ResponseCache
 }
 
 func (e *executor) SetFinalizer(f execution.FinalizePublisher) {
@@ -2097,27 +2109,73 @@ func (e *executor) run(ctx context.Context, i *runInstance) (*state.DriverRespon
 		}
 	}
 
+	// Attempt to load a cached response before sending the request.  This
+	// handles the case where the executor previously sent the request,
+	// received the response, and cached it but crashed before fully
+	// processing the result.  The cache key includes the attempt number
+	// so that genuine retries still reach the SDK.
+	cacheKey := e.responseCacheKey(ctx, i)
+	if cacheKey != "" {
+		if cached, err := e.responseCache.Get(ctx, cacheKey); err != nil {
+			e.log.Warn("response cache get error", "error", err, "cache_key", cacheKey)
+		} else if cached != nil {
+			metrics.IncrResponseCacheLookupCounter(ctx, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags:    map[string]any{"status": "hit"},
+			})
+			return cached, nil
+		} else {
+			metrics.IncrResponseCacheLookupCounter(ctx, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags:    map[string]any{"status": "miss"},
+			})
+		}
+	}
+
 	for _, e := range e.lifecycles {
 		go e.OnStepStarted(context.WithoutCancel(ctx), i.md, i.item, i.edge, endpoint.String())
 	}
 
+	var resp *state.DriverResponse
+	var err error
+
 	switch d := e.fnDriver(ctx, i.f).(type) {
 	case driver.DriverV2:
-		return e.executeDriverV2(ctx, i, d, endpoint.String())
+		resp, err = e.executeDriverV2(ctx, i, d, endpoint.String())
 	case driver.DriverV1:
-		{
-			// Execute the actual step using V1 drivers.  The V1 driver embeds errors in driver
-			// response and has generally difficult error management.
-			response, err := e.executeDriverV1(ctx, i)
-			if response.Err != nil && err == nil {
-				// This step errored, so always return an error.
-				return response, fmt.Errorf("%s", *response.Err)
-			}
-			return response, err
+		resp, err = e.executeDriverV1(ctx, i)
+		if resp != nil && resp.Err != nil && err == nil {
+			err = fmt.Errorf("%s", *resp.Err)
 		}
 	default:
 		return nil, fmt.Errorf("%w: '%s'", ErrNoRuntimeDriver, inngest.Driver(i.f))
 	}
+
+	// Cache the response so that a crash before we finish processing
+	// doesn't force a duplicate request to the SDK.  We cache all
+	// non-nil responses, including user errors—only nil responses
+	// (internal failures where the request never reached the SDK) are
+	// skipped.
+	if cacheKey != "" && resp != nil {
+		if cacheErr := e.responseCache.Set(ctx, cacheKey, resp); cacheErr != nil {
+			e.log.Warn("response cache set error", "error", cacheErr, "cache_key", cacheKey)
+		}
+	}
+
+	return resp, err
+}
+
+// responseCacheKey returns a cache key for the current execution attempt,
+// or an empty string if caching is disabled or the job ID is unavailable.
+func (e *executor) responseCacheKey(ctx context.Context, i *runInstance) string {
+	if e.responseCache == nil {
+		return ""
+	}
+	jobID := queue.JobIDFromContext(ctx)
+	if jobID == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s:%d", jobID, i.item.Attempt)
 }
 
 func (e *executor) executeDriverV2(ctx context.Context, run *runInstance, d driver.DriverV2, url string) (*state.DriverResponse, error) {

--- a/pkg/execution/executor/responsecache/disk.go
+++ b/pkg/execution/executor/responsecache/disk.go
@@ -1,0 +1,253 @@
+package responsecache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/logger"
+)
+
+const (
+	DefaultTTL             = 2 * time.Minute
+	DefaultCleanupInterval = 30 * time.Second
+)
+
+// DiskCacheOpt configures a DiskCache.
+type DiskCacheOpt struct {
+	// Dir is the base directory for cache files.
+	// Defaults to os.TempDir()/inngest-response-cache.
+	Dir string
+
+	// TTL controls how long cached responses are kept.  Files older than
+	// this are removed by the background cleanup goroutine.
+	// Defaults to 2 minutes.
+	TTL time.Duration
+
+	// CleanupInterval controls how often the cleanup goroutine runs.
+	// Defaults to 30 seconds.
+	CleanupInterval time.Duration
+
+	Logger logger.Logger
+}
+
+// DiskCache implements ResponseCache by writing serialized responses to
+// individual files on disk.  A background goroutine periodically removes
+// files older than the configured TTL so that the disk doesn't fill up.
+//
+// In production this directory will typically be backed by a Kubernetes
+// ephemeral volume.
+type DiskCache struct {
+	dir             string
+	ttl             time.Duration
+	cleanupInterval time.Duration
+	done            chan struct{}
+	log             logger.Logger
+}
+
+// NewDiskCache creates a DiskCache rooted at the given directory.  The
+// directory is created if it does not exist.  A background goroutine is
+// started immediately to clean up expired entries.
+func NewDiskCache(opts DiskCacheOpt) (*DiskCache, error) {
+	if opts.Dir == "" {
+		opts.Dir = filepath.Join(os.TempDir(), "inngest-response-cache")
+	}
+	if opts.TTL == 0 {
+		opts.TTL = DefaultTTL
+	}
+	if opts.CleanupInterval == 0 {
+		opts.CleanupInterval = DefaultCleanupInterval
+	}
+
+	if err := os.MkdirAll(opts.Dir, 0700); err != nil {
+		return nil, fmt.Errorf("creating response cache dir: %w", err)
+	}
+
+	dc := &DiskCache{
+		dir:             opts.Dir,
+		ttl:             opts.TTL,
+		cleanupInterval: opts.CleanupInterval,
+		done:            make(chan struct{}),
+		log:             opts.Logger,
+	}
+
+	go dc.cleanupLoop()
+
+	return dc, nil
+}
+
+// Get reads a cached response from disk.  Returns (nil, nil) on cache miss.
+// Corrupt files are silently removed and treated as a miss.
+func (dc *DiskCache) Get(_ context.Context, key string) (*state.DriverResponse, error) {
+	path := dc.pathFor(key)
+
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading cached response: %w", err)
+	}
+
+	resp, err := deserialize(data)
+	if err != nil {
+		// Corrupt entry — delete and treat as miss.
+		_ = os.Remove(path)
+		return nil, nil
+	}
+
+	return resp, nil
+}
+
+// Set writes a response to disk atomically (write tmp + rename).
+func (dc *DiskCache) Set(_ context.Context, key string, resp *state.DriverResponse) error {
+	data, err := serialize(resp)
+	if err != nil {
+		return fmt.Errorf("serializing response: %w", err)
+	}
+
+	path := dc.pathFor(key)
+	tmp := path + ".tmp"
+
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("writing cache file: %w", err)
+	}
+
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming cache file: %w", err)
+	}
+
+	return nil
+}
+
+// Close stops the background cleanup goroutine.
+func (dc *DiskCache) Close() error {
+	close(dc.done)
+	return nil
+}
+
+// pathFor returns the file path for a given cache key.  The key is hashed
+// with SHA-256 to produce a safe, fixed-length filename.
+func (dc *DiskCache) pathFor(key string) string {
+	h := sha256.Sum256([]byte(key))
+	return filepath.Join(dc.dir, fmt.Sprintf("%x.json", h))
+}
+
+func (dc *DiskCache) cleanupLoop() {
+	ticker := time.NewTicker(dc.cleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-dc.done:
+			return
+		case <-ticker.C:
+			dc.cleanup()
+		}
+	}
+}
+
+func (dc *DiskCache) cleanup() {
+	entries, err := os.ReadDir(dc.dir)
+	if err != nil {
+		if dc.log != nil {
+			dc.log.Warn("response cache cleanup: read dir error", "error", err)
+		}
+		return
+	}
+
+	cutoff := time.Now().Add(-dc.ttl)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			_ = os.Remove(filepath.Join(dc.dir, entry.Name()))
+		}
+	}
+}
+
+// --- serialization helpers ---
+
+// cachedResponse is the on-disk JSON envelope.  It stores the marshalled
+// DriverResponse together with the unexported "final" flag which cannot
+// survive a plain json.Marshal round-trip.
+type cachedResponse struct {
+	Response json.RawMessage `json:"response"`
+	Final    bool            `json:"final"`
+}
+
+func serialize(resp *state.DriverResponse) ([]byte, error) {
+	// Normalise Output to json.RawMessage so that it round-trips
+	// deterministically (the field is typed as `any`).
+	if resp.Output != nil {
+		normalised, err := outputToRaw(resp.Output)
+		if err != nil {
+			return nil, fmt.Errorf("normalising output: %w", err)
+		}
+		// Work on a shallow copy so we don't mutate the caller's
+		// response.
+		clone := *resp
+		clone.Output = normalised
+		resp = &clone
+	}
+
+	raw, err := json.Marshal(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	env := cachedResponse{
+		Response: raw,
+		Final:    resp.Final(),
+	}
+	return json.Marshal(env)
+}
+
+func deserialize(data []byte) (*state.DriverResponse, error) {
+	var env cachedResponse
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, err
+	}
+
+	var resp state.DriverResponse
+	if err := json.Unmarshal(env.Response, &resp); err != nil {
+		return nil, err
+	}
+
+	if env.Final {
+		resp.SetFinal()
+	}
+
+	return &resp, nil
+}
+
+// outputToRaw converts the DriverResponse.Output (typed as `any`) into a
+// json.RawMessage so that JSON marshal/unmarshal round-trips cleanly.
+func outputToRaw(v any) (json.RawMessage, error) {
+	switch t := v.(type) {
+	case json.RawMessage:
+		return t, nil
+	case []byte:
+		return json.RawMessage(t), nil
+	case string:
+		return json.RawMessage(t), nil
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		return json.RawMessage(b), nil
+	}
+}

--- a/pkg/execution/executor/responsecache/disk_test.go
+++ b/pkg/execution/executor/responsecache/disk_test.go
@@ -1,0 +1,288 @@
+package responsecache
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCache(t *testing.T) *DiskCache {
+	t.Helper()
+	dir := t.TempDir()
+	dc, err := NewDiskCache(DiskCacheOpt{
+		Dir:             dir,
+		TTL:             2 * time.Minute,
+		CleanupInterval: time.Hour, // don't auto-clean in tests
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dc.Close() })
+	return dc
+}
+
+func TestDiskCache_Miss(t *testing.T) {
+	dc := newTestCache(t)
+	resp, err := dc.Get(context.Background(), "nonexistent")
+	require.NoError(t, err)
+	require.Nil(t, resp)
+}
+
+func TestDiskCache_RoundTrip(t *testing.T) {
+	dc := newTestCache(t)
+	ctx := context.Background()
+
+	original := &state.DriverResponse{
+		Step:           inngest.Step{ID: "step-1", Name: "my step"},
+		Duration:       500 * time.Millisecond,
+		RequestVersion: 1,
+		Output:         json.RawMessage(`{"result":"ok"}`),
+		OutputSize:     15,
+		StatusCode:     200,
+		SDK:            "go:v0.1.0",
+	}
+
+	require.NoError(t, dc.Set(ctx, "job-1:0", original))
+
+	got, err := dc.Get(ctx, "job-1:0")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	require.Equal(t, original.Step.ID, got.Step.ID)
+	require.Equal(t, original.Step.Name, got.Step.Name)
+	require.Equal(t, original.StatusCode, got.StatusCode)
+	require.Equal(t, original.SDK, got.SDK)
+	require.Equal(t, original.RequestVersion, got.RequestVersion)
+	require.Equal(t, original.OutputSize, got.OutputSize)
+
+	// Output round-trips as json.RawMessage.
+	outBytes, err := json.Marshal(got.Output)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"result":"ok"}`, string(outBytes))
+}
+
+func TestDiskCache_RoundTripWithError(t *testing.T) {
+	dc := newTestCache(t)
+	ctx := context.Background()
+
+	errStr := "something went wrong"
+	original := &state.DriverResponse{
+		Step: inngest.Step{ID: "step-err"},
+		Err:  &errStr,
+		UserError: &state.UserError{
+			Name:    "StepError",
+			Message: "bad input",
+		},
+		NoRetry: true,
+	}
+
+	require.NoError(t, dc.Set(ctx, "job-err:1", original))
+
+	got, err := dc.Get(ctx, "job-err:1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.Err)
+	require.Equal(t, errStr, *got.Err)
+	require.NotNil(t, got.UserError)
+	require.Equal(t, "StepError", got.UserError.Name)
+	require.True(t, got.NoRetry)
+}
+
+func TestDiskCache_FinalPreserved(t *testing.T) {
+	dc := newTestCache(t)
+	ctx := context.Background()
+
+	errStr := "fail"
+	original := &state.DriverResponse{
+		Step: inngest.Step{ID: "step-final"},
+		Err:  &errStr,
+	}
+	original.SetFinal()
+	require.True(t, original.Final())
+
+	require.NoError(t, dc.Set(ctx, "job-final:0", original))
+
+	got, err := dc.Get(ctx, "job-final:0")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.True(t, got.Final())
+	require.False(t, got.Retryable())
+}
+
+func TestDiskCache_OutputTypes(t *testing.T) {
+	dc := newTestCache(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		output any
+	}{
+		{"json.RawMessage", json.RawMessage(`{"key":"value"}`)},
+		{"string", `{"key":"value"}`},
+		{"[]byte", []byte(`{"key":"value"}`)},
+		{"nil", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &state.DriverResponse{
+				Step:   inngest.Step{ID: "step-" + tt.name},
+				Output: tt.output,
+			}
+
+			key := "job-" + tt.name + ":0"
+			require.NoError(t, dc.Set(ctx, key, resp))
+
+			got, err := dc.Get(ctx, key)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+
+			if tt.output == nil {
+				require.Nil(t, got.Output)
+			} else {
+				outBytes, err := json.Marshal(got.Output)
+				require.NoError(t, err)
+				require.JSONEq(t, `{"key":"value"}`, string(outBytes))
+			}
+		})
+	}
+}
+
+func TestDiskCache_CorruptFile(t *testing.T) {
+	dc := newTestCache(t)
+	ctx := context.Background()
+
+	// Write garbage to the expected path.
+	path := dc.pathFor("bad-key")
+	require.NoError(t, os.WriteFile(path, []byte("not json"), 0600))
+
+	got, err := dc.Get(ctx, "bad-key")
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	// The corrupt file should have been removed.
+	_, statErr := os.Stat(path)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func TestDiskCache_Cleanup(t *testing.T) {
+	dir := t.TempDir()
+	dc, err := NewDiskCache(DiskCacheOpt{
+		Dir:             dir,
+		TTL:             50 * time.Millisecond,
+		CleanupInterval: time.Hour,
+	})
+	require.NoError(t, err)
+	defer dc.Close()
+
+	ctx := context.Background()
+	require.NoError(t, dc.Set(ctx, "old:0", &state.DriverResponse{
+		Step: inngest.Step{ID: "old"},
+	}))
+
+	// Wait for the entry to age past the TTL.
+	time.Sleep(100 * time.Millisecond)
+
+	dc.cleanup()
+
+	got, err := dc.Get(ctx, "old:0")
+	require.NoError(t, err)
+	require.Nil(t, got, "expired entry should have been cleaned up")
+}
+
+func TestDiskCache_CleanupKeepsRecent(t *testing.T) {
+	dir := t.TempDir()
+	dc, err := NewDiskCache(DiskCacheOpt{
+		Dir:             dir,
+		TTL:             10 * time.Minute,
+		CleanupInterval: time.Hour,
+	})
+	require.NoError(t, err)
+	defer dc.Close()
+
+	ctx := context.Background()
+	require.NoError(t, dc.Set(ctx, "recent:0", &state.DriverResponse{
+		Step: inngest.Step{ID: "recent"},
+	}))
+
+	dc.cleanup()
+
+	got, err := dc.Get(ctx, "recent:0")
+	require.NoError(t, err)
+	require.NotNil(t, got, "recent entry should survive cleanup")
+}
+
+func TestDiskCache_GeneratorOpcodes(t *testing.T) {
+	dc := newTestCache(t)
+	ctx := context.Background()
+
+	original := &state.DriverResponse{
+		Step:       inngest.Step{ID: "step-gen"},
+		StatusCode: 206,
+		Generator: []*state.GeneratorOpcode{
+			{
+				ID:   "hashed-id-1",
+				Name: "my-step",
+				Data: json.RawMessage(`{"output":"data"}`),
+			},
+		},
+	}
+
+	require.NoError(t, dc.Set(ctx, "job-gen:0", original))
+
+	got, err := dc.Get(ctx, "job-gen:0")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Generator, 1)
+	require.Equal(t, "hashed-id-1", got.Generator[0].ID)
+	require.Equal(t, "my-step", got.Generator[0].Name)
+	require.JSONEq(t, `{"output":"data"}`, string(got.Generator[0].Data))
+}
+
+func TestDiskCache_DoesNotMutateOriginal(t *testing.T) {
+	dc := newTestCache(t)
+	ctx := context.Background()
+
+	m := map[string]any{"key": "value"}
+	original := &state.DriverResponse{
+		Step:   inngest.Step{ID: "step-nomut"},
+		Output: m,
+	}
+
+	require.NoError(t, dc.Set(ctx, "job-nomut:0", original))
+
+	// The original Output should still be a map, not json.RawMessage.
+	_, ok := original.Output.(map[string]any)
+	require.True(t, ok, "Set must not mutate the caller's response")
+}
+
+func TestDiskCache_AtomicWrite(t *testing.T) {
+	dc := newTestCache(t)
+	ctx := context.Background()
+
+	// Write initial value.
+	require.NoError(t, dc.Set(ctx, "atomic:0", &state.DriverResponse{
+		Step: inngest.Step{ID: "v1"},
+	}))
+
+	// Overwrite with new value.
+	require.NoError(t, dc.Set(ctx, "atomic:0", &state.DriverResponse{
+		Step: inngest.Step{ID: "v2"},
+	}))
+
+	got, err := dc.Get(ctx, "atomic:0")
+	require.NoError(t, err)
+	require.Equal(t, "v2", got.Step.ID)
+
+	// No leftover .tmp files.
+	entries, err := os.ReadDir(dc.dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		require.False(t, filepath.Ext(e.Name()) == ".tmp", "temp file should not remain")
+	}
+}

--- a/pkg/execution/executor/responsecache/responsecache.go
+++ b/pkg/execution/executor/responsecache/responsecache.go
@@ -1,0 +1,24 @@
+package responsecache
+
+import (
+	"context"
+
+	"github.com/inngest/inngest/pkg/execution/state"
+)
+
+// ResponseCache stores and retrieves DriverResponse results keyed by a unique
+// execution identifier.  This enables crash recovery: if the executor crashes
+// after receiving an SDK response but before processing it, the response can
+// be loaded from cache on retry instead of re-sending the request.
+type ResponseCache interface {
+	// Get retrieves a cached DriverResponse for the given key.
+	// Returns (nil, nil) when no cached response exists.
+	Get(ctx context.Context, key string) (*state.DriverResponse, error)
+
+	// Set stores a DriverResponse under the given key.  The implementation
+	// is responsible for automatic expiration / cleanup.
+	Set(ctx context.Context, key string, resp *state.DriverResponse) error
+
+	// Close shuts down the cache and any background goroutines.
+	Close() error
+}

--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -929,3 +929,14 @@ func IncrConstraintAPIIssuedLeaseCounter(ctx context.Context, count int64, opts 
 		Tags:        opts.Tags,
 	})
 }
+
+// IncrResponseCacheLookupCounter tracks cache hit/miss for the executor response cache.
+// Tags should include "status" with value "hit" or "miss".
+func IncrResponseCacheLookupCounter(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "executor_response_cache_lookup_total",
+		Description: "Total number of executor response cache lookups",
+		Tags:        opts.Tags,
+	})
+}


### PR DESCRIPTION
## Description

Implements a disk-based response cache for the executor to enable crash recovery. When the executor sends a request to an SDK and receives a response, it now caches that response to disk before processing it. If the executor crashes after receiving the response but before fully processing it, the cached response can be loaded on retry instead of re-sending the request to the SDK.

### Changes:
- **New `ResponseCache` interface** (`responsecache.go`): Defines the contract for caching SDK responses with `Get`, `Set`, and `Close` methods
- **New `DiskCache` implementation** (`disk.go`): File-based cache that:
  - Stores serialized `DriverResponse` objects as JSON files with SHA-256 hashed keys
  - Implements atomic writes (write-to-temp + rename) to prevent corruption
  - Runs a background cleanup goroutine to remove expired entries based on TTL
  - Handles corrupt files gracefully by removing them and treating as cache miss
  - Preserves the unexported `Final` flag through a JSON envelope
  - Normalizes the `Output` field (typed as `any`) to `json.RawMessage` for deterministic serialization
- **Executor integration** (`executor.go`):
  - Added `WithResponseCache()` option to configure the cache
  - Cache key includes job ID and attempt number to distinguish genuine retries
  - Checks cache before sending requests to SDK
  - Caches all non-nil responses (including user errors) after receiving them
  - Logs cache errors without failing the execution
- **Metrics** (`counter.go`): Added `IncrResponseCacheLookupCounter` to track cache hit/miss rates

### Test Coverage:
Comprehensive test suite (`disk_test.go`) covering:
- Cache miss behavior
- Round-trip serialization of responses with various field types
- Error handling and preservation
- Final flag preservation
- Multiple output types (json.RawMessage, string, []byte, nil)
- Corrupt file handling
- TTL-based cleanup
- Generator opcodes
- Original response immutability
- Atomic write semantics

## Motivation

Executor crashes between receiving an SDK response and fully processing it can cause duplicate requests to be sent to the SDK on retry. This is problematic for non-idempotent operations. By caching responses to disk immediately after receipt, we can recover from crashes without re-executing the step.

## Type of change
- [x] New feature (non-breaking change that adds functionality)

## Checklist
- [x] I've tested my own changes (comprehensive unit tests included).
- [x] Changes are backward compatible (cache is optional via `WithResponseCache` option).

https://claude.ai/code/session_019RRN2J1sn7vRVxxxqfjMiT