### PR TITLE
EXE-794: filter transient 206 sleep scheduling attempt from oss preview run trace mapping

### DIFF
--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -481,6 +481,8 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 
 		isStep := span.Name == meta.SpanNameStep || span.Name == meta.SpanNameStepDiscovery
 		if isStep {
+			filterSleepSchedulingAttempts(gqlSpan)
+
 			// Step spans should not show attempts if they only have one and
 			// have resolved
 			if len(gqlSpan.ChildrenSpans) == 1 && gqlSpan.ChildrenSpans[0].Status == models.RunTraceSpanStatusCompleted {
@@ -553,6 +555,55 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 	}
 
 	return gqlSpan, nil
+}
+
+func filterSleepSchedulingAttempts(step *models.RunTraceSpan) {
+	if step == nil || step.StepOp == nil || *step.StepOp != models.StepOpSleep || len(step.ChildrenSpans) < 2 {
+		return
+	}
+
+	keepFollowupAttempt := false
+	for _, child := range step.ChildrenSpans {
+		if child == nil || child.StepOp == nil || *child.StepOp != models.StepOpSleep {
+			continue
+		}
+
+		if child.Response == nil {
+			keepFollowupAttempt = true
+			break
+		}
+	}
+
+	if !keepFollowupAttempt {
+		return
+	}
+
+	filtered := make([]*models.RunTraceSpan, 0, len(step.ChildrenSpans))
+	for _, child := range step.ChildrenSpans {
+		if isSleepSchedulingAttempt(child) {
+			continue
+		}
+
+		filtered = append(filtered, child)
+	}
+
+	step.ChildrenSpans = filtered
+}
+
+func isSleepSchedulingAttempt(span *models.RunTraceSpan) bool {
+	if span == nil || span.StepOp == nil || *span.StepOp != models.StepOpSleep || span.Response == nil {
+		return false
+	}
+
+	if span.Response.StatusCode != 206 {
+		return false
+	}
+
+	if span.StartedAt == nil || span.EndedAt == nil {
+		return false
+	}
+
+	return span.StartedAt.Equal(*span.EndedAt)
 }
 
 func (tr *traceReader) GetLegacyRunTrace(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {

--- a/pkg/coreapi/graph/loaders/trace_test.go
+++ b/pkg/coreapi/graph/loaders/trace_test.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"testing"
+	"time"
 
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/pkg/enums"
@@ -65,4 +66,58 @@ func TestRunTraceEnded(t *testing.T) {
 	for _, s := range nonTerminal {
 		assert.False(t, models.RunTraceEnded(s), "%s should not be terminal", s)
 	}
+}
+
+func TestFilterSleepSchedulingAttempts(t *testing.T) {
+	sleepOp := models.StepOpSleep
+	now := time.Now().UTC()
+
+	t.Run("filters transient 206 scheduling attempt when follow-up sleep attempt exists", func(t *testing.T) {
+		step := &models.RunTraceSpan{
+			StepOp: &sleepOp,
+			ChildrenSpans: []*models.RunTraceSpan{
+				{
+					StepOp:    &sleepOp,
+					StartedAt: &now,
+					EndedAt:   &now,
+					Response: &models.RunTraceSpanResponseInfo{
+						StatusCode: 206,
+					},
+				},
+				{
+					StepOp:    &sleepOp,
+					StartedAt: &now,
+					EndedAt:   ptrTime(now.Add(time.Second)),
+				},
+			},
+		}
+
+		filterSleepSchedulingAttempts(step)
+		require.Len(t, step.ChildrenSpans, 1)
+		assert.Nil(t, step.ChildrenSpans[0].Response)
+	})
+
+	t.Run("keeps single sleep attempt with 206 response", func(t *testing.T) {
+		step := &models.RunTraceSpan{
+			StepOp: &sleepOp,
+			ChildrenSpans: []*models.RunTraceSpan{
+				{
+					StepOp:    &sleepOp,
+					StartedAt: &now,
+					EndedAt:   &now,
+					Response: &models.RunTraceSpanResponseInfo{
+						StatusCode: 206,
+					},
+				},
+			},
+		}
+
+		filterSleepSchedulingAttempts(step)
+		require.Len(t, step.ChildrenSpans, 1)
+		assert.Equal(t, 206, step.ChildrenSpans[0].Response.StatusCode)
+	})
+}
+
+func ptrTime(t time.Time) *time.Time {
+	return &t
 }


### PR DESCRIPTION
## Description
OSS sleep traces contain an extra transient zero-duration sleep scheduling response span that ends up getting mapped to an extra attempt in the trace ui. This simply filters that out so the trace ui matches cloud.

OSS Before:
<img width="1660" height="723" alt="Screenshot 2026-03-05 at 11 28 57 AM" src="https://github.com/user-attachments/assets/a81925ad-10b3-4b5c-a3f1-68886f84329a" />

Cloud:
<img width="1675" height="708" alt="Screenshot 2026-03-05 at 11 29 22 AM" src="https://github.com/user-attachments/assets/c7fd0f0e-3fce-4a40-b54d-1d2b898ba2db" />

OSS After:
<img width="1681" height="612" alt="Screenshot 2026-03-05 at 12 10 51 PM" src="https://github.com/user-attachments/assets/dbea6f5c-d7fc-4332-8910-577f37238ffa" />



## Motivation
Better traces.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
