### PR TITLE
fix: userland OTel span parenting w/checkpointing

### DIFF
--- a/pkg/api/apiv1/traces.go
+++ b/pkg/api/apiv1/traces.go
@@ -264,6 +264,22 @@ func (a router) commitSpan(ctx context.Context, l logger.Logger, auth apiv1auth.
 		}
 	}
 
+	// If the SDK has set a deterministic step parent span ID (used during
+	// checkpointing to match the executor.step span), use it to override
+	// the parent so userland spans are correctly parented under their step.
+	for _, kv := range s.Attributes {
+		if kv.Key == "inngest.step.parentSpanId" {
+			sid, sidErr := trace.SpanIDFromHex(kv.GetValue().GetStringValue())
+			if sidErr == nil {
+				parent, err = tr.SetParentSpanID(sid)
+				if err != nil {
+					return fmt.Errorf("failed to set step parent span ID: %w", err)
+				}
+			}
+			break
+		}
+	}
+
 	span, err := a.opts.TracerProvider.CreateSpan(ctx, meta.SpanNameUserland, &tracing.CreateSpanOptions{
 		Debug:              &tracing.SpanDebugData{Location: "apiv1.traces.commitSpan"},
 		StartTime:          time.Unix(0, int64(s.StartTimeUnixNano)),

--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -25,6 +25,10 @@ const (
 	DiscoveryStepSpanName    = "Discovery step"
 	GenericExecutionSpanName = "Execution"
 	FinalizationSpanName     = "Finalization"
+
+	// SDKExecutionSpanName is an alias for meta.SDKExecutionSpanName
+	// used locally for readability.
+	SDKExecutionSpanName = meta.SDKExecutionSpanName
 )
 
 var ErrSkipSuccess = fmt.Errorf("skip success span")
@@ -403,11 +407,14 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 				}
 			case meta.SpanNameStepDiscovery, meta.SpanNameStep:
 				{
-					// Don't copy status from userland spans to preserve step status
-					if !child.IsUserland {
-						gqlSpan.EndedAt = child.EndedAt
-						gqlSpan.Status = child.Status
+					// Userland spans don't carry step execution metadata;
+					// so skip all parent-property propagation for them.
+					if child.IsUserland {
+						break
 					}
+
+					gqlSpan.EndedAt = child.EndedAt
+					gqlSpan.Status = child.Status
 
 					if isFirstChild {
 						isFirstChild = false
@@ -455,15 +462,20 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 		}
 
 		// If we only have a single child, this span isn't a userland span,
-		// but the single child is, return its children.
+		// but the single child is the SDK's `"inngest.execution"` wrapper,
+		// collapse it by returning its children (if any).
 		//
 		// We do this because userland spans are always underneath an
 		// `"inngest.execution"` span created by an SDK, which houses useful
 		// information about the environment, versions, scope, etc.
 		//
-		// Critically, this means we also ignore the `"inggest.execution"`
+		// Critically, this means we also ignore the `"inngest.execution"`
 		// span itself, as we never want to display it to the user.
-		if !gqlSpan.IsUserland && len(gqlSpan.ChildrenSpans) == 1 && gqlSpan.ChildrenSpans[0].IsUserland {
+		//
+		// We only collapse when the child is specifically the SDK execution
+		// wrapper span. Other userland spans with children (e.g., spans
+		// within checkpointed steps) must be preserved in the tree.
+		if !gqlSpan.IsUserland && len(gqlSpan.ChildrenSpans) == 1 && gqlSpan.ChildrenSpans[0].IsUserland && gqlSpan.ChildrenSpans[0].Name == SDKExecutionSpanName {
 			gqlSpan.ChildrenSpans = gqlSpan.ChildrenSpans[0].ChildrenSpans
 		}
 
@@ -483,7 +495,7 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 		if isStep {
 			// Step spans should not show attempts if they only have one and
 			// have resolved
-			if len(gqlSpan.ChildrenSpans) == 1 && gqlSpan.ChildrenSpans[0].Status == models.RunTraceSpanStatusCompleted {
+			if len(gqlSpan.ChildrenSpans) == 1 && !gqlSpan.ChildrenSpans[0].IsUserland && gqlSpan.ChildrenSpans[0].Status == models.RunTraceSpanStatusCompleted {
 				gqlSpan.Response = gqlSpan.ChildrenSpans[0].Response
 				gqlSpan.Metadata = append(gqlSpan.Metadata, gqlSpan.ChildrenSpans[0].Metadata...)
 				// However, we preserve any userland spans from the

--- a/pkg/coreapi/graph/loaders/trace_test.go
+++ b/pkg/coreapi/graph/loaders/trace_test.go
@@ -1,10 +1,13 @@
 package loader
 
 import (
+	"context"
 	"testing"
 
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
+	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -65,4 +68,97 @@ func TestRunTraceEnded(t *testing.T) {
 	for _, s := range nonTerminal {
 		assert.False(t, models.RunTraceEnded(s), "%s should not be terminal", s)
 	}
+}
+
+func boolPtr(b bool) *bool     { return &b }
+func strPtr(s string) *string  { return &s }
+
+func TestConvertRunSpanToGQL_UserlandCollapse(t *testing.T) {
+	tr := &traceReader{}
+	ctx := context.Background()
+
+	t.Run("leaf userland span is preserved", func(t *testing.T) {
+		span := &cqrs.OtelSpan{
+			RawOtelSpan: cqrs.RawOtelSpan{Name: meta.SpanNameExecution},
+			Attributes:  &meta.ExtractedValues{},
+			Children: []*cqrs.OtelSpan{
+				{
+					RawOtelSpan: cqrs.RawOtelSpan{Name: "GET"},
+					Attributes: &meta.ExtractedValues{
+						IsUserland:   boolPtr(true),
+						UserlandName: strPtr("GET"),
+					},
+				},
+			},
+		}
+
+		result, err := tr.convertRunSpanToGQL(ctx, span)
+		require.NoError(t, err)
+		require.Len(t, result.ChildrenSpans, 1, "leaf userland span should not be dropped")
+		assert.True(t, result.ChildrenSpans[0].IsUserland)
+		assert.Equal(t, "GET", result.ChildrenSpans[0].Name)
+	})
+
+	t.Run("SDK execution wrapper with children is collapsed", func(t *testing.T) {
+		span := &cqrs.OtelSpan{
+			RawOtelSpan: cqrs.RawOtelSpan{Name: meta.SpanNameExecution},
+			Attributes:  &meta.ExtractedValues{},
+			Children: []*cqrs.OtelSpan{
+				{
+					RawOtelSpan: cqrs.RawOtelSpan{Name: SDKExecutionSpanName},
+					Attributes: &meta.ExtractedValues{
+						IsUserland:   boolPtr(true),
+						UserlandName: strPtr(SDKExecutionSpanName),
+					},
+					Children: []*cqrs.OtelSpan{
+						{
+							RawOtelSpan: cqrs.RawOtelSpan{Name: "GET"},
+							Attributes: &meta.ExtractedValues{
+								IsUserland:   boolPtr(true),
+								UserlandName: strPtr("GET"),
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result, err := tr.convertRunSpanToGQL(ctx, span)
+		require.NoError(t, err)
+		require.Len(t, result.ChildrenSpans, 1, "should collapse to grandchild")
+		assert.Equal(t, "GET", result.ChildrenSpans[0].Name)
+	})
+
+	t.Run("non-wrapper userland span with children is preserved", func(t *testing.T) {
+		span := &cqrs.OtelSpan{
+			RawOtelSpan: cqrs.RawOtelSpan{Name: meta.SpanNameExecution},
+			Attributes:  &meta.ExtractedValues{},
+			Children: []*cqrs.OtelSpan{
+				{
+					RawOtelSpan: cqrs.RawOtelSpan{Name: "my-span"},
+					Attributes: &meta.ExtractedValues{
+						IsUserland:   boolPtr(true),
+						UserlandName: strPtr("my-span"),
+					},
+					Children: []*cqrs.OtelSpan{
+						{
+							RawOtelSpan: cqrs.RawOtelSpan{Name: "child-span"},
+							Attributes: &meta.ExtractedValues{
+								IsUserland:   boolPtr(true),
+								UserlandName: strPtr("child-span"),
+							},
+						},
+					},
+				},
+			},
+		}
+
+		result, err := tr.convertRunSpanToGQL(ctx, span)
+		require.NoError(t, err)
+		require.Len(t, result.ChildrenSpans, 1, "should keep the userland span")
+		assert.Equal(t, "my-span", result.ChildrenSpans[0].Name)
+		assert.True(t, result.ChildrenSpans[0].IsUserland)
+		require.Len(t, result.ChildrenSpans[0].ChildrenSpans, 1, "should preserve children")
+		assert.Equal(t, "child-span", result.ChildrenSpans[0].ChildrenSpans[0].Name)
+	})
 }

--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -117,7 +117,7 @@ var sqliteSpanRunsAdapter = spanRunsAdapter{
 		var ids []string
 		if raw != nil && *raw != "" {
 			// Ignore error: return empty slice on parse failure
-		_ = json.Unmarshal([]byte(*raw), &ids)
+			_ = json.Unmarshal([]byte(*raw), &ids)
 		}
 		return ids
 	},
@@ -152,7 +152,7 @@ var postgresSpanRunsAdapter = spanRunsAdapter{
 			var innerStr string
 			if err := json.Unmarshal([]byte(*raw), &innerStr); err == nil {
 				// Ignore error: return empty slice on parse failure
-			_ = json.Unmarshal([]byte(innerStr), &ids)
+				_ = json.Unmarshal([]byte(innerStr), &ids)
 			}
 		}
 		return ids

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -210,18 +210,21 @@ func (s *Span) UserlandChildren() []*Span {
 		return s.Children
 	}
 
-	// If we're not a userland span, but our first child is, return its
-	// children.
+	// If we're not a userland span, but our first child is the SDK's
+	// `"inngest.execution"` wrapper, return its children.
 	//
 	// We do this because userland spans are always underneath an
 	// `"inngest.execution"` span created by an SDK. So in this case, we're
-	// checking that we have `Executor span -> inngest.exection span ->
+	// checking that we have `Executor span -> inngest.execution span ->
 	// userland`.
 	//
 	// Critically, this means we're also completely ignoring the
 	// `"inngest.execution"` span itself, since we never want to display it to
 	// the user.
-	if len(s.Children) > 0 && s.Children[0].IsUserland() && len(s.Children[0].Children) > 0 {
+	//
+	// We only collapse the SDK execution wrapper; other userland spans
+	// with children (e.g., from checkpointed steps) must be preserved.
+	if len(s.Children) > 0 && s.Children[0].IsUserland() && s.Children[0].SpanName == meta.SDKExecutionSpanName {
 		return s.Children[0].Children
 	}
 

--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -169,6 +169,8 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 				}
 			}
 
+			// Create a deterministic executor.step span whose ID matches what the SDK
+			// generates, so userland spans are correctly parented underneath it.
 			max := fn.MaxAttempts()
 			_, err = c.TracerProvider.CreateSpan(
 				tracing.WithExecutionContext(ctx, tracing.ExecutionContext{
@@ -179,6 +181,7 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 				meta.SpanNameStep,
 				&tracing.CreateSpanOptions{
 					Debug:      &tracing.SpanDebugData{Location: "checkpoint.SyncStep"},
+					Seed:       []byte(fmt.Sprintf("%s:%d", op.ID, runCtx.AttemptCount())),
 					Parent:     tracing.RunSpanRefFromMetadata(input.Metadata),
 					StartTime:  op.Timing.Start(),
 					EndTime:    op.Timing.End(),
@@ -214,6 +217,7 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 				meta.SpanNameStep,
 				&tracing.CreateSpanOptions{
 					Debug:      &tracing.SpanDebugData{Location: "checkpoint.SyncErr"},
+					Seed:       []byte(fmt.Sprintf("%s:%d", op.ID, runCtx.AttemptCount())),
 					Parent:     tracing.RunSpanRefFromMetadata(input.Metadata),
 					StartTime:  op.Timing.Start(),
 					EndTime:    op.Timing.End(),
@@ -223,30 +227,6 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 			if err != nil {
 				// We should never hit a blocker creating a span.  If so, warn loudly.
 				l.Error("error saving span for checkpoint step error op", "error", err)
-			}
-
-			// Create an execution span for the initial sync attempt (attempt 0) as a child
-			// of the step span. In async execution, the executor creates this in ExecutePre,
-			// but for the initial sync attempt we need to create it here.
-			if stepSpanRef != nil {
-				execStatus := enums.StepStatusFailed
-				_, _ = c.TracerProvider.CreateSpan(
-					tracing.WithExecutionContext(ctx, tracing.ExecutionContext{
-						Identifier:  input.Metadata.ID,
-						Attempt:     runCtx.AttemptCount(),
-						MaxAttempts: &max,
-					}),
-					meta.SpanNameExecution,
-					&tracing.CreateSpanOptions{
-						Debug:     &tracing.SpanDebugData{Location: "checkpoint.SyncExecErr"},
-						Parent:    stepSpanRef,
-						StartTime: op.Timing.Start(),
-						EndTime:   op.Timing.End(),
-						Attributes: meta.NewAttrSet(
-							meta.Attr(meta.Attrs.DynamicStatus, &execStatus),
-						).Merge(tracing.GeneratorAttrs(&op)),
-					},
-				)
 			}
 
 			err = c.Executor.HandleGenerator(ctx, runCtx, op)
@@ -425,7 +405,7 @@ func (c checkpointer) checkpointAsyncSteps(ctx context.Context, input AsyncCheck
 				meta.SpanNameStep,
 				&tracing.CreateSpanOptions{
 					Debug:      &tracing.SpanDebugData{Location: "checkpoint.AsyncStep"},
-					Seed:       []byte(op.ID + op.Timing.String()),
+					Seed:       []byte(fmt.Sprintf("%s:%d", op.ID, 0)),
 					Parent:     tracing.RunSpanRefFromMetadata(&md),
 					StartTime:  op.Timing.Start(),
 					EndTime:    op.Timing.End(),
@@ -436,6 +416,7 @@ func (c checkpointer) checkpointAsyncSteps(ctx context.Context, input AsyncCheck
 				// We should never hit a blocker creating a span.  If so, warn loudly.
 				l.Error("error saving span for checkpoint op", "error", err)
 			}
+
 		default:
 			// Return an error
 			l.Error("unimplemented checkpoint op", "op", op.Op)

--- a/pkg/tracing/meta/consts.go
+++ b/pkg/tracing/meta/consts.go
@@ -20,6 +20,12 @@ const (
 	SpanNameUserland         = "userland"
 	SpanNameMetadata         = "metadata"
 
+	// SDKExecutionSpanName is the name of the execution wrapper span
+	// created by SDKs (e.g., "inngest.execution"). This span houses
+	// metadata about the environment, versions, and scope, but should
+	// not be displayed to the user directly.
+	SDKExecutionSpanName = "inngest.execution"
+
 	// Link attributes
 	LinkAttributeType            = "_inngest.link.type"
 	LinkAttributeTypeFollowsFrom = "follows_from"


### PR DESCRIPTION
## Description

Userland spans created inside checkpointed steps were invisible in the UI because the executor didn't create matching step/execution spans for them to parent under, and the GQL trace loader was silently dropping leaf userland spans during collapse.

This fixes things by:
- Create deterministic executor.step and executor.execution spans in checkpoint sync/async paths using seeded span IDs
- Reparent userland spans via inngest.step.parentSpanId attribute in span ingestion
- Fix leaf userland span collapse in GQL trace conversion

## Motivation
https://linear.app/inngest/issue/EXE-1408/extended-traces-not-working

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

## Related

* https://github.com/inngest/inngest-js/pull/1359
