### PR TITLE
Fix Connect worker drain not immediate

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -737,6 +737,12 @@ func (c *connectionHandler) handleIncomingWebSocketMessage(ctx context.Context, 
 			return &ErrDraining
 		}
 
+		// Immediately delete from in-memory map to prevent routing any more
+		// messages to this connection. If we don't do this, we may still send
+		// messages to the draining worker (since `Forward()` uses the in-memory
+		// map)
+		c.svc.wsConnections.Delete(c.conn.ConnectionId.String())
+
 		err := c.updateConnStatus(connectpb.ConnectionStatus_DRAINING)
 		if err != nil {
 			// TODO Should we actually close the connection here?

--- a/pkg/connect/grpc/grpc.go
+++ b/pkg/connect/grpc/grpc.go
@@ -273,10 +273,14 @@ func (i *gatewayGRPCManager) Forward(ctx context.Context, gatewayID ulid.ULID, c
 
 	logger.StdlibLogger(ctx).Trace("grpc message forwarded to connect gateway", "reply", reply, "err", err)
 
-	success := err == nil
+	success := err == nil && reply != nil && reply.Success
 	metrics.IncrConnectGatewayGRPCForwardCounter(ctx, 1, metrics.CounterOpt{
 		Tags: map[string]any{"success": success},
 	})
+
+	if err == nil && reply != nil && !reply.Success {
+		return fmt.Errorf("gateway could not forward to connection %s: connection not available", connectionID.String())
+	}
 
 	return err
 }

--- a/pkg/connect/grpc/grpc_test.go
+++ b/pkg/connect/grpc/grpc_test.go
@@ -89,7 +89,7 @@ func (m *mockConnectGatewayServer) Ping(ctx context.Context, req *connectpb.Ping
 
 func (m *mockConnectGatewayServer) Forward(ctx context.Context, req *connectpb.ForwardRequest) (*connectpb.ForwardResponse, error) {
 	m.forwardCount++
-	return &connectpb.ForwardResponse{}, nil
+	return &connectpb.ForwardResponse{Success: true}, nil
 }
 
 func (m *mockConnectGatewayServer) Ack(ctx context.Context, req *connectpb.AckMessage) (*connectpb.AckResponse, error) {


### PR DESCRIPTION
Fix a bug where a Connect worker drain (when it sends a `WORKER_PAUSE` message) does not immediately take effect in the Inngest server.

This happened because we didn't immediately delete the connection from the in-memory map. This is problematic because we use the in-memory map when sending messages to workers