### PR TITLE
Wait for in-progress runs to finish and gracefully exit

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -132,6 +132,7 @@ func Start(ctx context.Context, s Service) (err error) {
 		l.Error("service cleanup errored", "error", stopErr)
 		err = errors.Join(err, stopErr)
 	}
+	l.Info("service run finished", "err", err)
 
 	return err
 }
@@ -181,7 +182,15 @@ func run(ctx context.Context, stop func(), s Service) error {
 		// We received a cancellation signal.  Allow Run to continue for up
 		// to RunTimoeut period before quitting and cleaning up.
 
-		// Ensure that we prevent the paretn context from capturing signals again.
+		// Wait for Run to finish draining in-progress work (e.g. queue
+		// jobs) before proceeding to Stop. This ensures graceful
+		// shutdown completes before the stop timeout begins.
+		l.Info("waiting for service run to finish")
+		if err := <-runErr; err != nil && err != context.Canceled {
+			return err
+		}
+		l.Info("service run finished")
+
 		stop()
 	}
 	return nil


### PR DESCRIPTION
## Description

- Fix a critical bug where the service framework's run() function returned immediately on context cancellation without waiting for Run() to complete.
-  This caused in-progress queue jobs to be abandoned during shutdown — the executor would exit while jobs were still processing, leading to stuck runs.
- In the ctx.Done() branch of run(), wait for <-runErr (i.e., Run() to return) before proceeding to Stop(). This ensures q.wg.Wait() in executionScan completes and all in-flight ProcessItem calls finish before the service moves to the stop phase.

## Motivation

https://app.plain.com/workspace/w_01H5R1F69XQ35G4P7THFQGN5KB/thread/th_01KJZFP81PDRHV5F77TYVZ7905/

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
