### PR TITLE
fix type error in support app

### DIFF
--- a/ui/apps/support/package.json
+++ b/ui/apps/support/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && tsc --noEmit",
     "start": "vite start",
     "format": "prettier --write .",
-    "lint": "eslint . --report-unused-disable-directives --max-warnings 0"
+    "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@clerk/tanstack-react-start": "^0.26.5",

--- a/ui/apps/support/src/components/Support/AttachmentUploadField.tsx
+++ b/ui/apps/support/src/components/Support/AttachmentUploadField.tsx
@@ -296,7 +296,7 @@ export function AttachmentUploadField({
 
       <div>
         <input
-          ref={fileInputRef}
+          ref={fileInputRef as React.RefObject<HTMLInputElement>}
           type="file"
           multiple
           accept={ACCEPTED_FILE_TYPES}


### PR DESCRIPTION
## Description

Unbreak support app build pipeline.

## Motivation
unbroken is better

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a TypeScript type error in the support app's `AttachmentUploadField` component by casting `fileInputRef` to `React.RefObject<HTMLInputElement>`, and adds a `type-check` script to `package.json` to make type checking independently runnable.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a760f2de64dc87cf21ab3b266e45145833c849db.</sup>
<!-- /MENDRAL_SUMMARY -->