### PR TITLE
Make cache size configurable

### DIFF
--- a/pkg/constraintapi/cache.go
+++ b/pkg/constraintapi/cache.go
@@ -31,6 +31,8 @@ type constraintCache struct {
 	clock   clockwork.Clock
 
 	cache                                *ccache.Cache[*constraintCacheItem]
+	maxSize                              int64
+	itemsToPrune                         uint32
 	enableHighCardinalityInstrumentation EnableHighCardinalityInstrumentation
 	enableCache                          EnableConstraintCacheFn
 	shouldCache                          ShouldCacheConstraintFn
@@ -70,6 +72,18 @@ func WithConstraintCacheEnable(enable EnableConstraintCacheFn) ConstraintCacheOp
 func WithConstraintCacheShouldCache(fn ShouldCacheConstraintFn) ConstraintCacheOption {
 	return func(c *constraintCache) {
 		c.shouldCache = fn
+	}
+}
+
+func WithConstraintCacheMaxSize(maxSize int64) ConstraintCacheOption {
+	return func(c *constraintCache) {
+		c.maxSize = maxSize
+	}
+}
+
+func WithConstraintCacheItemsToPrune(itemsToPrune uint32) ConstraintCacheOption {
+	return func(c *constraintCache) {
+		c.itemsToPrune = itemsToPrune
 	}
 }
 
@@ -239,16 +253,19 @@ func NewConstraintCache(
 	options ...ConstraintCacheOption,
 ) *constraintCache {
 	cache := &constraintCache{
-		cache: ccache.New(
-			ccache.Configure[*constraintCacheItem]().
-				MaxSize(10_000).
-				ItemsToPrune(500),
-		),
+		maxSize:      10_000,
+		itemsToPrune: 500,
 	}
 
 	for _, opt := range options {
 		opt(cache)
 	}
+
+	cache.cache = ccache.New(
+		ccache.Configure[*constraintCacheItem]().
+			MaxSize(cache.maxSize).
+			ItemsToPrune(cache.itemsToPrune),
+	)
 
 	if cache.clock == nil {
 		cache.clock = clockwork.NewRealClock()


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Moves `ccache` initialization after options are applied in `NewConstraintCache`, and adds two new option functions (`WithConstraintCacheMaxSize`, `WithConstraintCacheItemsToPrune`) to allow callers to override the default cache size (10,000) and prune count (500).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 18aeba00e00b0b0e337d73ce0be93bad55f71db0.</sup>
<!-- /MENDRAL_SUMMARY -->