### PR TITLE
Add copy button to event name on event types

### DIFF
--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/event-types/$eventTypeName/route.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/event-types/$eventTypeName/route.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
+import { CopyButton } from '@inngest/components/CopyButton';
 import { Header } from '@inngest/components/Header/Header';
+import { useCopyToClipboard } from '@inngest/components/hooks/useCopyToClipboard';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 
 import { ActionsMenu } from '@/components/Events/ActionsMenu';
@@ -17,6 +19,7 @@ function EventTypeLayout() {
   const { envSlug, eventTypeName } = Route.useParams();
   const eventName = decodeURIComponent(eventTypeName);
   const [showArchive, setShowArchive] = useState(false);
+  const { handleCopyClick, isCopying } = useCopyToClipboard();
 
   return (
     <>
@@ -28,6 +31,15 @@ function EventTypeLayout() {
             href: pathCreator.eventType({ envSlug, eventName }),
           },
         ]}
+        infoIcon={
+          <CopyButton
+            code={eventName}
+            iconOnly
+            size="small"
+            isCopying={isCopying}
+            handleCopyClick={handleCopyClick}
+          />
+        }
         tabs={[
           {
             href: pathCreator.eventType({ envSlug, eventName }),


### PR DESCRIPTION
## Description

Adds copy button for event name

<img width="808" height="96" alt="image" src="https://github.com/user-attachments/assets/83b3021d-86c7-49ec-aff0-c397785f7da4" />


## Motivation
It can be annoying to manually highlight and select the event name due to hover state. It can also be annoying to copy the event name from the URL because `/` gets html encoded

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a copy-to-clipboard button to the event type name in the header, using the existing `CopyButton` component and `useCopyToClipboard` hook.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0fce72624674db32eac37398545ec5b0f358d7cf.</sup>
<!-- /MENDRAL_SUMMARY -->