### PR TITLE
Implement request end logging w/ wide events

### DIFF
--- a/pkg/logger/event.go
+++ b/pkg/logger/event.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"sync"
 	"time"
 )
 
@@ -14,10 +15,19 @@ type evtCtxKey struct{}
 type eventstore struct {
 	Name   string
 	Events []Event
+	mu     sync.Mutex
 }
 
 func (e *eventstore) Append(evt Event) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	e.Events = append(e.Events, evt)
+}
+
+func (e *eventstore) Reset() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.Events = []Event{}
 }
 
 // Event represents a log event for wide logs, used in req end logging
@@ -33,6 +43,7 @@ type Event struct {
 	// Start is the start time of the event:  the time the event occurred.
 	Start time.Time `json:"start,omitempty,omitzero"`
 	// Duration is the duration for the overall function, or the duration for the event.
+	// Logged in microseconds.
 	Duration time.Duration `json:"d,omitempty,omitzero"`
 	// Metadata includes any info you want in the event.
 	Metadata map[string]any `json:"metadata,omitempty,omitzero"`
@@ -44,6 +55,15 @@ type Event struct {
 // [Logger.LogEvents]
 func NewEventStore(ctx context.Context, name string) context.Context {
 	return context.WithValue(ctx, evtCtxKeyVal, &eventstore{Name: name})
+}
+
+// ResetEventStore clears events in the event store from context.
+func ResetEventStore(ctx context.Context) {
+	es, ok := ctx.Value(evtCtxKeyVal).(*eventstore)
+	if !ok || es == nil {
+		return
+	}
+	es.Reset()
 }
 
 // AddEvent tracks an event for future logging in the current event store.

--- a/pkg/logger/event.go
+++ b/pkg/logger/event.go
@@ -27,7 +27,8 @@ func (e *eventstore) Append(evt Event) {
 func (e *eventstore) Reset() {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.Events = []Event{}
+	// Preserve the underlying array capacity for reuse.
+	e.Events = e.Events[:0]
 }
 
 // Event represents a log event for wide logs, used in req end logging

--- a/pkg/logger/event.go
+++ b/pkg/logger/event.go
@@ -3,7 +3,9 @@ package logger
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 )
@@ -13,9 +15,14 @@ var evtCtxKeyVal = evtCtxKey{}
 type evtCtxKey struct{}
 
 type eventstore struct {
-	Name   string
-	Events []Event
-	mu     sync.Mutex
+	// Name is the name for the event store container
+	Name string
+	// Events represent all events in the event store
+	Events EventList
+	// T represents the time the event store was created or was reset
+	T time.Time
+
+	mu sync.Mutex
 }
 
 func (e *eventstore) Append(evt Event) {
@@ -29,6 +36,7 @@ func (e *eventstore) Reset() {
 	defer e.mu.Unlock()
 	// Preserve the underlying array capacity for reuse.
 	e.Events = e.Events[:0]
+	e.T = time.Now()
 }
 
 // Event represents a log event for wide logs, used in req end logging
@@ -36,11 +44,11 @@ type Event struct {
 	// Name is a custom event name, optional.
 	Name string `json:"name"`
 	// Fn is the calling function that creatd the event.  This is auto-generated via the runtime
-	// package for any caller of [AddEvent] or [TrackFnAsEvent]
+	// package for any caller of [AddEvent] or [TrackFn]
 	Fn string `json:"fn"`
 	// File is the calling file && line that creatd the event.  This is auto-generated via the runtime
-	// package for any caller of [AddEvent] or [TrackFnAsEvent]
-	File string `json:"file"`
+	// package for any caller of [AddEvent] or [TrackFn]
+	// File string `json:"file,omitempty"`
 	// Start is the start time of the event:  the time the event occurred.
 	Start time.Time `json:"start,omitempty,omitzero"`
 	// Duration is the duration for the overall function, or the duration for the event.
@@ -50,12 +58,54 @@ type Event struct {
 	Metadata map[string]any `json:"metadata,omitempty,omitzero"`
 }
 
+// LogValue implements slog.LogValuer so that each Event renders as a structured
+// group when passed to slog.Any.
+func (e Event) LogValue() slog.Value {
+	var attrs []slog.Attr
+	if e.Name != "" {
+		attrs = append(attrs, slog.String("name", e.Name))
+	}
+	if e.Fn != "" {
+		fn := e.Fn
+		if i := strings.LastIndex(fn, "/"); i >= 0 {
+			fn = fn[i+1:]
+		}
+		attrs = append(attrs, slog.String("fn", fn))
+	}
+	// if e.File != "" {
+	// 	attrs = append(attrs, slog.String("file", e.File))
+	// }
+	if !e.Start.IsZero() {
+		attrs = append(attrs, slog.Time("start", e.Start))
+	}
+	if e.Duration > 0 {
+		attrs = append(attrs, slog.Duration("d", e.Duration))
+	}
+	for k, v := range e.Metadata {
+		attrs = append(attrs, slog.Any(k, v))
+	}
+	return slog.GroupValue(attrs...)
+}
+
+// EventList is a slice of Event that implements slog.LogValuer so that
+// slog.Any("events", eventList) produces numbered groups ("0", "1", …).
+type EventList []Event
+
+// LogValue implements slog.LogValuer for EventList.
+func (el EventList) LogValue() slog.Value {
+	attrs := make([]slog.Attr, len(el))
+	for i, e := range el {
+		attrs[i] = slog.Any(fmt.Sprintf("%d", i), e)
+	}
+	return slog.GroupValue(attrs...)
+}
+
 // NewEventStore creates a new event store in context for wide logging.
 //
-// This collects all events added via `TrackFnAsEvent` and `AddEvent` for logging via
+// This collects all events added via `TrackFn` and `AddEvent` for logging via
 // [Logger.LogEvents]
 func NewEventStore(ctx context.Context, name string) context.Context {
-	return context.WithValue(ctx, evtCtxKeyVal, &eventstore{Name: name})
+	return context.WithValue(ctx, evtCtxKeyVal, &eventstore{Name: name, T: time.Now()})
 }
 
 // ResetEventStore clears events in the event store from context.
@@ -75,23 +125,22 @@ func AddEvent(ctx context.Context, e Event) {
 	}
 
 	if e.Fn == "" {
-		pc, file, line, _ := runtime.Caller(1)
+		pc, _, _, _ := runtime.Caller(1)
 		e.Fn = runtime.FuncForPC(pc).Name()
-		e.File = fmt.Sprintf("%s:%d", file, line)
 	}
 
 	es.Append(e)
 }
 
-// TrackFnAsEvent tracks a method as an event.  This also tracks method duratins.  Usage:
+// TrackFn tracks a method as an event.  This also tracks method duratins.  Usage:
 //
-//	defer logging.TrackFnAsEvent(ctx)
-func TrackFnAsEvent(ctx context.Context) func() {
-	pc, file, line, _ := runtime.Caller(1)
+//	defer logging.TrackFn(ctx)
+func TrackFn(ctx context.Context, metadata map[string]any) func() {
+	pc, _, _, _ := runtime.Caller(1)
 	evt := Event{
-		Fn:    runtime.FuncForPC(pc).Name(),
-		File:  fmt.Sprintf("%s:%d", file, line),
-		Start: time.Now(),
+		Fn:       runtime.FuncForPC(pc).Name(),
+		Start:    time.Now(),
+		Metadata: metadata,
 	}
 
 	return func() {

--- a/pkg/logger/event.go
+++ b/pkg/logger/event.go
@@ -1,0 +1,80 @@
+package logger
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"time"
+)
+
+var evtCtxKeyVal = evtCtxKey{}
+
+type evtCtxKey struct{}
+
+type eventstore struct {
+	Name   string
+	Events []Event
+}
+
+func (e *eventstore) Append(evt Event) {
+	e.Events = append(e.Events, evt)
+}
+
+// Event represents a log event for wide logs, used in req end logging
+type Event struct {
+	// Name is a custom event name, optional.
+	Name string `json:"name"`
+	// Fn is the calling function that creatd the event.  This is auto-generated via the runtime
+	// package for any caller of [AddEvent] or [TrackFnAsEvent]
+	Fn string `json:"fn"`
+	// File is the calling file && line that creatd the event.  This is auto-generated via the runtime
+	// package for any caller of [AddEvent] or [TrackFnAsEvent]
+	File string `json:"file"`
+	// Start is the start time of the event:  the time the event occurred.
+	Start time.Time `json:"start,omitempty,omitzero"`
+	// Duration is the duration for the overall function, or the duration for the event.
+	Duration time.Duration `json:"d,omitempty,omitzero"`
+	// Metadata includes any info you want in the event.
+	Metadata map[string]any `json:"metadata,omitempty,omitzero"`
+}
+
+// NewEventStore creates a new event store in context for wide logging.
+//
+// This collects all events added via `TrackFnAsEvent` and `AddEvent` for logging via
+// [Logger.LogEvents]
+func NewEventStore(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, evtCtxKeyVal, &eventstore{Name: name})
+}
+
+// AddEvent tracks an event for future logging in the current event store.
+func AddEvent(ctx context.Context, e Event) {
+	es, ok := ctx.Value(evtCtxKeyVal).(*eventstore)
+	if !ok || es == nil {
+		return
+	}
+
+	if e.Fn == "" {
+		pc, file, line, _ := runtime.Caller(1)
+		e.Fn = runtime.FuncForPC(pc).Name()
+		e.File = fmt.Sprintf("%s:%d", file, line)
+	}
+
+	es.Append(e)
+}
+
+// TrackFnAsEvent tracks a method as an event.  This also tracks method duratins.  Usage:
+//
+//	defer logging.TrackFnAsEvent(ctx)
+func TrackFnAsEvent(ctx context.Context) func() {
+	pc, file, line, _ := runtime.Caller(1)
+	evt := Event{
+		Fn:    runtime.FuncForPC(pc).Name(),
+		File:  fmt.Sprintf("%s:%d", file, line),
+		Start: time.Now(),
+	}
+
+	return func() {
+		evt.Duration = time.Since(evt.Start)
+		AddEvent(ctx, evt)
+	}
+}

--- a/pkg/logger/event_test.go
+++ b/pkg/logger/event_test.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -38,7 +39,7 @@ func TestAddEvent_AppendsEvent(t *testing.T) {
 	// Fn and File are auto-populated by runtime.Caller.
 	require.NotEmpty(t, evt.Fn)
 	require.True(t, strings.Contains(evt.Fn, "TestAddEvent_AppendsEvent"))
-	require.True(t, strings.HasSuffix(evt.File, "event_test.go:31"), "expected caller file, got %s", evt.File)
+	require.True(t, strings.HasSuffix(evt.File, "event_test.go:32"), "expected caller file, got %s", evt.File)
 }
 
 func TestAddEvent_PresetFnFile(t *testing.T) {
@@ -100,6 +101,24 @@ func TestMultipleEvents(t *testing.T) {
 	require.Equal(t, "third", store.Events[2].Name)
 }
 
+func TestEvent_MarshalJSON_ZeroDurationOmitted(t *testing.T) {
+	evt := Event{
+		Name: "simple",
+		Fn:   "pkg.Func",
+		File: "pkg/f.go:1",
+	}
+
+	data, err := json.Marshal(evt)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	err = json.Unmarshal(data, &raw)
+	require.NoError(t, err)
+
+	_, exists := raw["d"]
+	require.False(t, exists, "zero duration should be omitted")
+}
+
 func TestLogEvents(t *testing.T) {
 	ctx := NewEventStore(context.Background(), "log-test")
 	AddEvent(ctx, Event{Name: "evt1", Metadata: map[string]any{"key": "val"}})
@@ -108,8 +127,7 @@ func TestLogEvents(t *testing.T) {
 	var buf bytes.Buffer
 	l := newLogger(WithLoggerWriter(&buf), WithHandler(JSONHandler))
 
-	l.LogEvents(ctx)
-	l.Info("request complete")
+	l.LogEvents(ctx).Info("request complete")
 
 	output := buf.String()
 	require.Contains(t, output, "events_name")
@@ -123,8 +141,7 @@ func TestLogEvents_NoStore(t *testing.T) {
 	l := newLogger(WithLoggerWriter(&buf), WithHandler(JSONHandler))
 
 	// Should not panic and should not add events attrs.
-	l.LogEvents(context.Background())
-	l.Info("no events")
+	l.LogEvents(context.Background()).Info("no events")
 
 	output := buf.String()
 	require.NotContains(t, output, "events_name")
@@ -137,8 +154,7 @@ func TestLogEvents_EmptyStore(t *testing.T) {
 	l := newLogger(WithLoggerWriter(&buf), WithHandler(JSONHandler))
 
 	// Empty store should be a no-op.
-	l.LogEvents(ctx)
-	l.Info("no events")
+	l.LogEvents(ctx).Info("no events")
 
 	output := buf.String()
 	require.NotContains(t, output, "events_name")

--- a/pkg/logger/event_test.go
+++ b/pkg/logger/event_test.go
@@ -1,0 +1,145 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewEventStore(t *testing.T) {
+	ctx := NewEventStore(context.Background(), "test-request")
+
+	store, ok := ctx.Value(evtCtxKeyVal).(*eventstore)
+	require.True(t, ok)
+	require.NotNil(t, store)
+	require.Equal(t, "test-request", store.Name)
+	require.Empty(t, store.Events)
+}
+
+func TestAddEvent_NoStore(t *testing.T) {
+	// Should not panic on a bare context.
+	AddEvent(context.Background(), Event{Name: "orphan"})
+}
+
+func TestAddEvent_AppendsEvent(t *testing.T) {
+	ctx := NewEventStore(context.Background(), "req")
+
+	AddEvent(ctx, Event{Name: "something-happened"})
+
+	store := ctx.Value(evtCtxKeyVal).(*eventstore)
+	require.Len(t, store.Events, 1)
+
+	evt := store.Events[0]
+	require.Equal(t, "something-happened", evt.Name)
+	// Fn and File are auto-populated by runtime.Caller.
+	require.NotEmpty(t, evt.Fn)
+	require.True(t, strings.Contains(evt.Fn, "TestAddEvent_AppendsEvent"))
+	require.True(t, strings.HasSuffix(evt.File, "event_test.go:31"), "expected caller file, got %s", evt.File)
+}
+
+func TestAddEvent_PresetFnFile(t *testing.T) {
+	ctx := NewEventStore(context.Background(), "req")
+
+	AddEvent(ctx, Event{
+		Name: "preset",
+		Fn:   "custom/pkg.MyFunc",
+		File: "custom/file.go:99",
+	})
+
+	store := ctx.Value(evtCtxKeyVal).(*eventstore)
+	require.Len(t, store.Events, 1)
+	require.Equal(t, "custom/pkg.MyFunc", store.Events[0].Fn)
+	require.Equal(t, "custom/file.go:99", store.Events[0].File)
+}
+
+func TestTrackFnAsEvent(t *testing.T) {
+	ctx := NewEventStore(context.Background(), "req")
+
+	func() {
+		defer TrackFnAsEvent(ctx)()
+		time.Sleep(5 * time.Millisecond)
+	}()
+
+	store := ctx.Value(evtCtxKeyVal).(*eventstore)
+	require.Len(t, store.Events, 1)
+
+	evt := store.Events[0]
+	require.NotEmpty(t, evt.Fn)
+	require.True(t, strings.Contains(evt.Fn, "TestTrackFnAsEvent"))
+	require.False(t, evt.Start.IsZero())
+	require.Greater(t, evt.Duration, time.Duration(0))
+}
+
+func TestTrackFnAsEvent_NoStore(t *testing.T) {
+	// Should not panic on a bare context.
+	func() {
+		defer TrackFnAsEvent(context.Background())()
+	}()
+}
+
+func TestMultipleEvents(t *testing.T) {
+	ctx := NewEventStore(context.Background(), "multi")
+
+	AddEvent(ctx, Event{Name: "first"})
+
+	func() {
+		defer TrackFnAsEvent(ctx)()
+	}()
+
+	AddEvent(ctx, Event{Name: "third"})
+
+	store := ctx.Value(evtCtxKeyVal).(*eventstore)
+	require.Len(t, store.Events, 3)
+	require.Equal(t, "first", store.Events[0].Name)
+	// TrackFnAsEvent doesn't set Name, so it's empty.
+	require.Equal(t, "", store.Events[1].Name)
+	require.Equal(t, "third", store.Events[2].Name)
+}
+
+func TestLogEvents(t *testing.T) {
+	ctx := NewEventStore(context.Background(), "log-test")
+	AddEvent(ctx, Event{Name: "evt1", Metadata: map[string]any{"key": "val"}})
+	AddEvent(ctx, Event{Name: "evt2"})
+
+	var buf bytes.Buffer
+	l := newLogger(WithLoggerWriter(&buf), WithHandler(JSONHandler))
+
+	l.LogEvents(ctx)
+	l.Info("request complete")
+
+	output := buf.String()
+	require.Contains(t, output, "events_name")
+	require.Contains(t, output, "log-test")
+	require.Contains(t, output, "evt1")
+	require.Contains(t, output, "evt2")
+}
+
+func TestLogEvents_NoStore(t *testing.T) {
+	var buf bytes.Buffer
+	l := newLogger(WithLoggerWriter(&buf), WithHandler(JSONHandler))
+
+	// Should not panic and should not add events attrs.
+	l.LogEvents(context.Background())
+	l.Info("no events")
+
+	output := buf.String()
+	require.NotContains(t, output, "events_name")
+}
+
+func TestLogEvents_EmptyStore(t *testing.T) {
+	ctx := NewEventStore(context.Background(), "empty")
+
+	var buf bytes.Buffer
+	l := newLogger(WithLoggerWriter(&buf), WithHandler(JSONHandler))
+
+	// Empty store should be a no-op.
+	l.LogEvents(ctx)
+	l.Info("no events")
+
+	output := buf.String()
+	require.NotContains(t, output, "events_name")
+}

--- a/pkg/logger/event_test.go
+++ b/pkg/logger/event_test.go
@@ -3,6 +3,8 @@ package logger
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"log/slog"
 	"strings"
 	"sync"
 	"testing"
@@ -39,7 +41,6 @@ func TestAddEvent_AppendsEvent(t *testing.T) {
 	// Fn and File are auto-populated by runtime.Caller.
 	require.NotEmpty(t, evt.Fn)
 	require.True(t, strings.Contains(evt.Fn, "TestAddEvent_AppendsEvent"))
-	require.True(t, strings.Contains(evt.File, "event_test.go:"), "expected caller file, got %s", evt.File)
 }
 
 func TestAddEvent_PresetFnFile(t *testing.T) {
@@ -48,20 +49,18 @@ func TestAddEvent_PresetFnFile(t *testing.T) {
 	AddEvent(ctx, Event{
 		Name: "preset",
 		Fn:   "custom/pkg.MyFunc",
-		File: "custom/file.go:99",
 	})
 
 	store := ctx.Value(evtCtxKeyVal).(*eventstore)
 	require.Len(t, store.Events, 1)
 	require.Equal(t, "custom/pkg.MyFunc", store.Events[0].Fn)
-	require.Equal(t, "custom/file.go:99", store.Events[0].File)
 }
 
 func TestTrackFnAsEvent(t *testing.T) {
 	ctx := NewEventStore(context.Background(), "req")
 
 	func() {
-		defer TrackFnAsEvent(ctx)()
+		defer TrackFn(ctx, nil)()
 		time.Sleep(5 * time.Millisecond)
 	}()
 
@@ -78,7 +77,7 @@ func TestTrackFnAsEvent(t *testing.T) {
 func TestTrackFnAsEvent_NoStore(t *testing.T) {
 	// Should not panic on a bare context.
 	func() {
-		defer TrackFnAsEvent(context.Background())()
+		defer TrackFn(context.Background(), nil)()
 	}()
 }
 
@@ -88,7 +87,7 @@ func TestMultipleEvents(t *testing.T) {
 	AddEvent(ctx, Event{Name: "first"})
 
 	func() {
-		defer TrackFnAsEvent(ctx)()
+		defer TrackFn(ctx, nil)()
 	}()
 
 	AddEvent(ctx, Event{Name: "third"})
@@ -189,4 +188,115 @@ func TestEventStore_ConcurrentAppend(t *testing.T) {
 
 	store := ctx.Value(evtCtxKeyVal).(*eventstore)
 	require.Len(t, store.Events, goroutines*eventsPerGoroutine)
+}
+
+func TestEvent_LogValue(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	evt := Event{
+		Name:     "test-event",
+		Fn:       "pkg.MyFunc",
+		Start:    now,
+		Duration: 5 * time.Millisecond,
+		Metadata: map[string]any{"key": "val"},
+	}
+
+	val := evt.LogValue()
+	require.Equal(t, slog.KindGroup, val.Kind())
+
+	attrs := val.Group()
+	attrMap := make(map[string]slog.Value, len(attrs))
+	for _, a := range attrs {
+		attrMap[a.Key] = a.Value
+	}
+
+	require.Equal(t, "test-event", attrMap["name"].String())
+	require.Equal(t, "pkg.MyFunc", attrMap["fn"].String()) // no slash prefix to trim
+	require.Equal(t, now, attrMap["start"].Time())
+	require.Equal(t, 5*time.Millisecond, attrMap["d"].Duration())
+	require.Equal(t, "val", attrMap["key"].Any())
+}
+
+func TestEvent_LogValue_ZeroFields(t *testing.T) {
+	evt := Event{}
+
+	val := evt.LogValue()
+	attrs := val.Group()
+	attrMap := make(map[string]slog.Value, len(attrs))
+	for _, a := range attrs {
+		attrMap[a.Key] = a.Value
+	}
+
+	// All zero-value fields should be omitted.
+	for _, key := range []string{"name", "fn", "start", "d"} {
+		_, has := attrMap[key]
+		require.False(t, has, "expected %q to be omitted for zero Event", key)
+	}
+}
+
+func TestEvent_LogValue_TrimsFn(t *testing.T) {
+	evt := Event{
+		Fn: "github.com/inngest/inngest/pkg/execution/queue.DurationWithTags[...]",
+	}
+	val := evt.LogValue()
+	attrs := val.Group()
+	attrMap := make(map[string]slog.Value, len(attrs))
+	for _, a := range attrs {
+		attrMap[a.Key] = a.Value
+	}
+	require.Equal(t, "queue.DurationWithTags[...]", attrMap["fn"].String())
+}
+
+func TestEventList_LogValue(t *testing.T) {
+	el := EventList{
+		{Name: "first", Fn: "a.Fn"},
+		{Name: "second", Fn: "b.Fn"},
+	}
+
+	val := el.LogValue()
+	require.Equal(t, slog.KindGroup, val.Kind())
+
+	attrs := val.Group()
+	require.Len(t, attrs, 2)
+	require.Equal(t, "0", attrs[0].Key)
+	require.Equal(t, "1", attrs[1].Key)
+
+	// Each element should itself be a group with event fields.
+	inner := attrs[0].Value.Resolve().Group()
+	innerMap := make(map[string]slog.Value, len(inner))
+	for _, a := range inner {
+		innerMap[a.Key] = a.Value
+	}
+	require.Equal(t, "first", innerMap["name"].String())
+}
+
+func TestLogEvents_StructuredJSON(t *testing.T) {
+	ctx := NewEventStore(context.Background(), "json-test")
+	AddEvent(ctx, Event{
+		Name:     "evt1",
+		Fn:       "pkg.Fn",
+		Metadata: map[string]any{"k": "v"},
+	})
+
+	var buf bytes.Buffer
+	l := newLogger(WithLoggerWriter(&buf), WithHandler(JSONHandler))
+
+	l.LogEvents(ctx).Info("done")
+
+	output := buf.String()
+
+	// Parse as JSON to verify structured output.
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(output), &parsed))
+
+	// events should be a nested object, not a Go %v string.
+	events, ok := parsed["events"]
+	require.True(t, ok, "expected 'events' key in JSON output")
+
+	eventsMap, ok := events.(map[string]any)
+	require.True(t, ok, "events should be a JSON object, got: %T", events)
+
+	evt0, ok := eventsMap["0"].(map[string]any)
+	require.True(t, ok, "events.0 should be a JSON object")
+	require.Equal(t, "evt1", evt0["name"])
+	require.Equal(t, "v", evt0["k"])
 }

--- a/pkg/logger/event_test.go
+++ b/pkg/logger/event_test.go
@@ -3,8 +3,8 @@ package logger
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,7 +39,7 @@ func TestAddEvent_AppendsEvent(t *testing.T) {
 	// Fn and File are auto-populated by runtime.Caller.
 	require.NotEmpty(t, evt.Fn)
 	require.True(t, strings.Contains(evt.Fn, "TestAddEvent_AppendsEvent"))
-	require.True(t, strings.HasSuffix(evt.File, "event_test.go:32"), "expected caller file, got %s", evt.File)
+	require.True(t, strings.Contains(evt.File, "event_test.go:"), "expected caller file, got %s", evt.File)
 }
 
 func TestAddEvent_PresetFnFile(t *testing.T) {
@@ -101,24 +101,6 @@ func TestMultipleEvents(t *testing.T) {
 	require.Equal(t, "third", store.Events[2].Name)
 }
 
-func TestEvent_MarshalJSON_ZeroDurationOmitted(t *testing.T) {
-	evt := Event{
-		Name: "simple",
-		Fn:   "pkg.Func",
-		File: "pkg/f.go:1",
-	}
-
-	data, err := json.Marshal(evt)
-	require.NoError(t, err)
-
-	var raw map[string]any
-	err = json.Unmarshal(data, &raw)
-	require.NoError(t, err)
-
-	_, exists := raw["d"]
-	require.False(t, exists, "zero duration should be omitted")
-}
-
 func TestLogEvents(t *testing.T) {
 	ctx := NewEventStore(context.Background(), "log-test")
 	AddEvent(ctx, Event{Name: "evt1", Metadata: map[string]any{"key": "val"}})
@@ -158,4 +140,53 @@ func TestLogEvents_EmptyStore(t *testing.T) {
 
 	output := buf.String()
 	require.NotContains(t, output, "events_name")
+}
+
+func TestResetEventStore(t *testing.T) {
+	ctx := NewEventStore(context.Background(), "reset-test")
+	AddEvent(ctx, Event{Name: "before-reset"})
+
+	store := ctx.Value(evtCtxKeyVal).(*eventstore)
+	require.Len(t, store.Events, 1)
+
+	ResetEventStore(ctx)
+	require.Empty(t, store.Events)
+
+	// After reset, LogEvents should return the original logger (no-op).
+	var buf bytes.Buffer
+	l := newLogger(WithLoggerWriter(&buf), WithHandler(JSONHandler))
+
+	returned := l.LogEvents(ctx)
+	returned.Info("after reset")
+
+	output := buf.String()
+	require.NotContains(t, output, "events_name")
+	require.Contains(t, output, "after reset")
+}
+
+func TestResetEventStore_NoStore(t *testing.T) {
+	// Should not panic on a bare context.
+	ResetEventStore(context.Background())
+}
+
+func TestEventStore_ConcurrentAppend(t *testing.T) {
+	ctx := NewEventStore(context.Background(), "concurrent")
+
+	const goroutines = 50
+	const eventsPerGoroutine = 20
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < eventsPerGoroutine; j++ {
+				AddEvent(ctx, Event{Name: "concurrent-event"})
+			}
+		}()
+	}
+	wg.Wait()
+
+	store := ctx.Value(evtCtxKeyVal).(*eventstore)
+	require.Len(t, store.Events, goroutines*eventsPerGoroutine)
 }

--- a/pkg/logger/stdlib.go
+++ b/pkg/logger/stdlib.go
@@ -73,7 +73,11 @@ type Logger interface {
 	Optional(accountID uuid.UUID, logname string) Logger
 
 	// LogEvents adds any events stored in the log line for wide logs.
-	LogEvents(ctx context.Context)
+	//
+	// Usage:
+	//
+	//     l.LogEvents(ctx).Debug("your msg", ...)
+	LogEvents(ctx context.Context) Logger
 
 	//
 	// Methods added in wrapper
@@ -304,19 +308,21 @@ func (l *logger) With(args ...any) Logger {
 	}
 }
 
-func (l *logger) LogEvents(ctx context.Context) {
+func (l *logger) LogEvents(ctx context.Context) Logger {
 	es, ok := ctx.Value(evtCtxKeyVal).(*eventstore)
 	if !ok || es == nil || len(es.Events) == 0 {
-		return
+		return l
 	}
 
-	// NOTE: we have to modify the logger in place as the interface for LogEvents
-	// doesn't return a new logger.
-	l.Logger = l.Logger.With(
+	next := l.With(
 		slog.String("events_name", es.Name),
 		slog.Any("events", es.Events),
 	)
-	l.attrs = append(l.attrs, slog.String("events_name", es.Name), slog.Any("events", es.Events))
+
+	// ensure events aren't present in next log
+	ResetEventStore(ctx)
+
+	return next
 }
 
 func (l *logger) Optional(accountID uuid.UUID, logname string) Logger {

--- a/pkg/logger/stdlib.go
+++ b/pkg/logger/stdlib.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
@@ -316,6 +317,8 @@ func (l *logger) LogEvents(ctx context.Context) Logger {
 
 	next := l.With(
 		slog.String("events_name", es.Name),
+		slog.Time("events_ts", es.T),
+		slog.Duration("events_d", time.Since(es.T)),
 		slog.Any("events", es.Events),
 	)
 

--- a/pkg/logger/stdlib.go
+++ b/pkg/logger/stdlib.go
@@ -72,6 +72,9 @@ type Logger interface {
 	// Optional uses the [DefaultLogEnabler] function to only log on truthy results
 	Optional(accountID uuid.UUID, logname string) Logger
 
+	// LogEvents adds any events stored in the log line for wide logs.
+	LogEvents(ctx context.Context)
+
 	//
 	// Methods added in wrapper
 	//
@@ -299,6 +302,21 @@ func (l *logger) With(args ...any) Logger {
 		Logger: log,
 		attrs:  append(l.attrs, args...),
 	}
+}
+
+func (l *logger) LogEvents(ctx context.Context) {
+	es, ok := ctx.Value(evtCtxKeyVal).(*eventstore)
+	if !ok || es == nil || len(es.Events) == 0 {
+		return
+	}
+
+	// NOTE: we have to modify the logger in place as the interface for LogEvents
+	// doesn't return a new logger.
+	l.Logger = l.Logger.With(
+		slog.String("events_name", es.Name),
+		slog.Any("events", es.Events),
+	)
+	l.attrs = append(l.attrs, slog.String("events_name", es.Name), slog.Any("events", es.Events))
 }
 
 func (l *logger) Optional(accountID uuid.UUID, logname string) Logger {


### PR DESCRIPTION
Yee.  Some stubs that auto-track method names/durations, and allow arbitrary events to be attached to a logger.

These *must* be manually logged via `.LogEvents` to dump all events at the end of a req

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
