### PR TITLE
fix: use trace status instead of run status in RunDetailsV4

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/RunDetailsV4.test.tsx
+++ b/ui/packages/components/src/RunDetailsV4/RunDetailsV4.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * RunDetailsV4 regression tests for issue #3844.
+ *
+ * Verifies that the detail view uses trace.status (not runData.status)
+ * when syncing status back to the run list via updateDynamicRunData.
+ */
+
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// --- Mocks ---
+
+const mockUpdateDynamicRunData = vi.fn();
+
+vi.mock('../SharedContext/useBooleanFlag', () => ({
+  useBooleanFlag: () => ({
+    booleanFlag: () => ({ isReady: true, value: false }),
+  }),
+}));
+
+vi.mock('../SharedContext/useGetTraceResult', () => ({
+  useGetTraceResult: () => ({ data: undefined, error: undefined, refetch: vi.fn() }),
+}));
+
+vi.mock('./runDetailsUtils', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useDynamicRunData: () => ({
+      dynamicRunData: undefined,
+      updateDynamicRunData: mockUpdateDynamicRunData,
+    }),
+    useStepSelection: () => ({ selectedStep: undefined, selectStep: vi.fn() }),
+  };
+});
+
+vi.mock('../Table/Cell', () => ({
+  StatusCell: ({ status }: { status: string }) => <span data-testid="status-cell">{status}</span>,
+}));
+
+vi.mock('../TriggerDetails', () => ({
+  TriggerDetails: () => null,
+}));
+
+vi.mock('../Error/ErrorCard', () => ({
+  ErrorCard: () => null,
+}));
+
+vi.mock('./RunInfo', () => ({
+  RunInfo: () => <div data-testid="run-info" />,
+}));
+
+vi.mock('./StepInfo', () => ({
+  StepInfo: () => null,
+}));
+
+vi.mock('./Tabs', () => ({
+  Tabs: () => <div data-testid="tabs" />,
+}));
+
+vi.mock('./Timeline', () => ({
+  Timeline: () => null,
+}));
+
+vi.mock('./TopInfo', () => ({
+  TopInfo: () => <div data-testid="top-info" />,
+}));
+
+vi.mock('./Waiting', () => ({
+  Waiting: () => null,
+}));
+
+vi.mock('../icons/DragDivider', () => ({
+  DragDivider: () => null,
+}));
+
+// jsdom doesn't provide ResizeObserver
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('RunDetailsV4 - issue #3844 status sync', () => {
+  it('calls updateDynamicRunData with trace.status, not runData.status', async () => {
+    // Mock useGetRun to return divergent statuses
+    const { useGetRun: _orig, ...rest } = await import('../SharedContext/useGetRun');
+    vi.doMock('../SharedContext/useGetRun', () => ({
+      ...rest,
+      useGetRun: () => ({
+        data: {
+          id: 'run-1',
+          status: 'RUNNING',
+          fn: { id: 'fn-1', name: 'Test Fn', slug: 'test-fn' },
+          app: { externalID: 'app-1', name: 'Test App' },
+          hasAI: false,
+          trace: {
+            status: 'COMPLETED',
+            spanID: 'span-1',
+            traceID: 'trace-1',
+            isRoot: true,
+            name: 'root',
+            endedAt: '2024-01-01T00:00:10Z',
+            childrenSpans: [],
+          },
+        },
+        error: undefined,
+        loading: false,
+        refetch: vi.fn(),
+      }),
+    }));
+
+    // Re-import after mocking
+    const { RunDetailsV4 } = await import('./RunDetailsV4');
+
+    render(
+      <RunDetailsV4
+        standalone={false}
+        runID="run-1"
+        getTrigger={vi.fn() as any}
+        initialRunData={{ status: 'RUNNING' } as any}
+      />
+    );
+
+    // updateDynamicRunData should have been called with trace.status = 'COMPLETED'
+    expect(mockUpdateDynamicRunData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runID: 'run-1',
+        status: 'COMPLETED',
+      })
+    );
+
+    // Crucially, it must NOT have been called with 'RUNNING'
+    const calls = mockUpdateDynamicRunData.mock.calls;
+    for (const call of calls) {
+      expect(call[0].status).not.toBe('RUNNING');
+    }
+  });
+});

--- a/ui/packages/components/src/RunDetailsV4/RunDetailsV4.tsx
+++ b/ui/packages/components/src/RunDetailsV4/RunDetailsV4.tsx
@@ -241,25 +241,21 @@ export const RunDetailsV4 = ({
     return () => clearTimeout(timeoutId);
   }, [runData?.trace.endedAt, pollInterval]);
 
+  const traceStatus = runData?.trace?.status;
+
   useEffect(() => {
-    if (!runData?.status || runData?.status === initialRunData?.status) {
+    if (!traceStatus || traceStatus === initialRunData?.status) {
       return;
     }
 
     updateDynamicRunData({
       runID,
-      status: runData.status,
-      endedAt: runData.trace.endedAt ?? undefined,
+      status: traceStatus,
+      endedAt: runData?.trace.endedAt ?? undefined,
     });
-  }, [
-    runData?.trace.endedAt,
-    runData?.status,
-    initialRunData?.status,
-    updateDynamicRunData,
-    runID,
-  ]);
+  }, [runData?.trace.endedAt, traceStatus, initialRunData?.status, updateDynamicRunData, runID]);
 
-  const waiting = isWaiting(initialRunData?.status || runData?.status, runError, resultError);
+  const waiting = isWaiting(initialRunData?.status || traceStatus, runError, resultError);
   const showError = waiting ? false : runError || resultError;
 
   // Works around a variety of layout and scroll issues with two column layout

--- a/ui/packages/components/src/RunDetailsV4/RunDetailsV4.tsx
+++ b/ui/packages/components/src/RunDetailsV4/RunDetailsV4.tsx
@@ -269,7 +269,7 @@ export const RunDetailsV4 = ({
       {standalone && runData && (
         <div className="border-muted flex flex-row items-start justify-between border-b px-4 pb-4">
           <div className="flex flex-col gap-1">
-            <StatusCell status={runData.status} />
+            <StatusCell status={traceStatus || runData.status} />
             <p className="text-basis text-2xl font-medium">{runData.fn.name}</p>
             <p className="text-subtle font-mono">{runID}</p>
           </div>


### PR DESCRIPTION
Fixes #3844

## Summary

Regression from #3788. `RunDetailsV4.tsx` uses `runData.status` to sync status back to the run list via `updateDynamicRunData`, but `RunDetailsV3.tsx` correctly uses `runData.trace.status`. These two fields can diverge during status transitions, causing the list to show "Completed" while the detail view shows "Running".

## Changes

- Extract `traceStatus` from `runData?.trace?.status`
- Use `traceStatus` in the `useEffect` that calls `updateDynamicRunData` (both the guard condition and the status value)
- Use `traceStatus` in the `isWaiting` call
- Use `traceStatus` for the standalone detail header `StatusCell`, falling back to `runData.status`
- Add regression test verifying `updateDynamicRunData` receives trace status, not run status

## Test Plan

- `pnpm test` passes (256 tests, 14 files)
- Manual: trigger a function run, verify clicking a "Completed" run does not flash to "Running"

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a status divergence bug (#3844) where `RunDetailsV4` was syncing `runData.status` (run metadata status) back to the list view via `updateDynamicRunData`, while the detail view displayed `runData.trace.status` (root span status). These two fields can diverge during transitions, causing the list to show "Completed" while the detail shows "Running". The fix extracts `traceStatus` from `runData?.trace?.status` and uses it consistently throughout the component, aligning with `RunDetailsV3`'s existing behavior. A regression test is added to verify the correct status is passed to `updateDynamicRunData`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d1c2eae22b82847e13da653d92474f545d8f6bce.</sup>
<!-- /MENDRAL_SUMMARY -->