### PR TITLE
fix: prevent double JSON encoding of span attributes in postgres

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -429,31 +429,33 @@ fragmentLoop:
 			}
 		}
 
-		if attrs, ok := fragment["attributes"].(string); ok {
+		switch attrs := fragment["attributes"].(type) {
+		case string:
 			fragmentAttr := map[string]any{}
 			if err := json.Unmarshal([]byte(attrs), &fragmentAttr); err != nil {
 				logger.StdlibLogger(ctx).Error("error unmarshalling span attributes", "error", err)
 				return nil, err
 			}
-
 			maps.Copy(newSpan.RawOtelSpan.Attributes, fragmentAttr)
+		case map[string]any:
+			maps.Copy(newSpan.RawOtelSpan.Attributes, attrs)
+		}
 
-			if outputRef, ok := fragment["output_span_id"].(string); ok && info != nil {
-				outputSpanID = &outputRef
-				if io, ok := info.dynamicRefs[dynamicSpanID.String]; ok && io != nil {
-					io.OutputRef = outputRef
-				} else {
-					info.dynamicRefs[dynamicSpanID.String] = &IODynamicRef{OutputRef: outputRef}
-				}
+		if outputRef, ok := fragment["output_span_id"].(string); ok && info != nil {
+			outputSpanID = &outputRef
+			if io, ok := info.dynamicRefs[dynamicSpanID.String]; ok && io != nil {
+				io.OutputRef = outputRef
+			} else {
+				info.dynamicRefs[dynamicSpanID.String] = &IODynamicRef{OutputRef: outputRef}
 			}
+		}
 
-			if inputRef, ok := fragment["input_span_id"].(string); ok && info != nil {
-				inputSpanID = &inputRef
-				if io, ok := info.dynamicRefs[dynamicSpanID.String]; ok && io != nil {
-					io.InputRef = inputRef
-				} else {
-					info.dynamicRefs[dynamicSpanID.String] = &IODynamicRef{InputRef: inputRef}
-				}
+		if inputRef, ok := fragment["input_span_id"].(string); ok && info != nil {
+			inputSpanID = &inputRef
+			if io, ok := info.dynamicRefs[dynamicSpanID.String]; ok && io != nil {
+				io.InputRef = inputRef
+			} else {
+				info.dynamicRefs[dynamicSpanID.String] = &IODynamicRef{InputRef: inputRef}
 			}
 		}
 	}
@@ -618,8 +620,18 @@ func rollupSpanMetadataFromFragments(ctx context.Context, fragments []map[string
 	}
 
 	for _, fragment := range fragments {
-		attrs, ok := fragment["attributes"].(string)
-		if !ok {
+		var attrBytes []byte
+		switch attrs := fragment["attributes"].(type) {
+		case string:
+			attrBytes = []byte(attrs)
+		case map[string]any:
+			var err error
+			attrBytes, err = json.Marshal(attrs)
+			if err != nil {
+				logger.StdlibLogger(ctx).Error("error marshalling metadata span attributes", "error", err)
+				return nil, err
+			}
+		default:
 			logger.StdlibLogger(ctx).Error("error unmarshalling metadata span kind, no attributes")
 			continue
 		}
@@ -630,7 +642,7 @@ func rollupSpanMetadataFromFragments(ctx context.Context, fragments []map[string
 			Op     *metadata.Opcode `json:"_inngest.metadata.op"`
 			Values *string          `json:"_inngest.metadata.values"`
 		}
-		if err := json.Unmarshal([]byte(attrs), &fragmentAttr); err != nil {
+		if err := json.Unmarshal(attrBytes, &fragmentAttr); err != nil {
 			logger.StdlibLogger(ctx).Error("error unmarshalling metadata span attributes", "error", err)
 			return nil, err
 		}

--- a/pkg/cqrs/base_cqrs/cqrs_test.go
+++ b/pkg/cqrs/base_cqrs/cqrs_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	sqlc_psql "github.com/inngest/inngest/pkg/cqrs/base_cqrs/sqlc/postgres"
 	sqlc_sqlite "github.com/inngest/inngest/pkg/cqrs/base_cqrs/sqlc/sqlite"
 	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
 	"github.com/inngest/inngest/tests/testutil"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
@@ -1872,4 +1874,84 @@ func initCQRS(t *testing.T, opts ...withInitCQRSOpt) (cqrs.Manager, func()) {
 	}
 
 	return cm, cleanup
+}
+
+func TestRollupSpanMetadataFromFragments(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+
+	// Build a valid metadata attributes JSON string
+	metadataValues := `{"counter":42}`
+	attrsJSON := fmt.Sprintf(
+		`{"_inngest.metadata.scope":"run","_inngest.metadata.kind":"inngest.test","_inngest.metadata.op":"merge","_inngest.metadata.values":%s}`,
+		strconv.Quote(metadataValues),
+	)
+
+	t.Run("attributes as string", func(t *testing.T) {
+		fragments := []map[string]any{
+			{"attributes": attrsJSON},
+		}
+
+		result, err := rollupSpanMetadataFromFragments(ctx, fragments, now)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, enums.MetadataScopeRun, result.Scope)
+		assert.Equal(t, metadata.Kind("inngest.test"), result.Kind)
+		assert.NotEmpty(t, result.Values)
+	})
+
+	t.Run("attributes as map[string]any", func(t *testing.T) {
+		// Simulate what PostgreSQL JSONB returns: a parsed map instead of a string
+		var attrsMap map[string]any
+		require.NoError(t, json.Unmarshal([]byte(attrsJSON), &attrsMap))
+
+		fragments := []map[string]any{
+			{"attributes": attrsMap},
+		}
+
+		result, err := rollupSpanMetadataFromFragments(ctx, fragments, now)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Equal(t, enums.MetadataScopeRun, result.Scope)
+		assert.Equal(t, metadata.Kind("inngest.test"), result.Kind)
+		assert.NotEmpty(t, result.Values)
+	})
+
+	t.Run("both types produce same result", func(t *testing.T) {
+		// String attributes
+		stringFragments := []map[string]any{
+			{"attributes": attrsJSON},
+		}
+		stringResult, err := rollupSpanMetadataFromFragments(ctx, stringFragments, now)
+		require.NoError(t, err)
+
+		// Map attributes (from JSONB)
+		var attrsMap map[string]any
+		require.NoError(t, json.Unmarshal([]byte(attrsJSON), &attrsMap))
+		mapFragments := []map[string]any{
+			{"attributes": attrsMap},
+		}
+		mapResult, err := rollupSpanMetadataFromFragments(ctx, mapFragments, now)
+		require.NoError(t, err)
+
+		assert.Equal(t, stringResult.Scope, mapResult.Scope)
+		assert.Equal(t, stringResult.Kind, mapResult.Kind)
+
+		// Compare serialized values
+		stringValBytes, _ := json.Marshal(stringResult.Values)
+		mapValBytes, _ := json.Marshal(mapResult.Values)
+		assert.JSONEq(t, string(stringValBytes), string(mapValBytes))
+	})
+
+	t.Run("skips fragment with no attributes", func(t *testing.T) {
+		fragments := []map[string]any{
+			{"other_field": "value"},
+		}
+
+		result, err := rollupSpanMetadataFromFragments(ctx, fragments, now)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		// No metadata extracted since no valid attributes
+		assert.Equal(t, enums.MetadataScopeUnknown, result.Scope)
+	})
 }

--- a/pkg/cqrs/base_cqrs/cqrs_test.go
+++ b/pkg/cqrs/base_cqrs/cqrs_test.go
@@ -1876,6 +1876,95 @@ func initCQRS(t *testing.T, opts ...withInitCQRSOpt) (cqrs.Manager, func()) {
 	return cm, cleanup
 }
 
+// mockSpan implements normalizedSpan for testing mapSpanFromRow.
+type mockSpan struct {
+	traceID       string
+	runID         string
+	dynamicSpanID sql.NullString
+	parentSpanID  sql.NullString
+	startTime     interface{}
+	endTime       interface{}
+	spanFragments any
+}
+
+func (m mockSpan) GetTraceID() string              { return m.traceID }
+func (m mockSpan) GetRunID() string                { return m.runID }
+func (m mockSpan) GetDynamicSpanID() sql.NullString { return m.dynamicSpanID }
+func (m mockSpan) GetParentSpanID() sql.NullString  { return m.parentSpanID }
+func (m mockSpan) GetStartTime() interface{}        { return m.startTime }
+func (m mockSpan) GetEndTime() interface{}          { return m.endTime }
+func (m mockSpan) GetSpanFragments() any            { return m.spanFragments }
+
+func TestMapSpanFromRow_MapAttributes(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	runID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	// Span fragments with attributes as a JSON object (not a string).
+	// This is what happens when PostgreSQL returns JSONB objects directly.
+	fragments := []map[string]any{
+		{
+			"name":       "executor.run",
+			"attributes": map[string]any{"test_key": "test_value", "count": float64(42)},
+		},
+	}
+	fragmentsJSON, err := json.Marshal(fragments)
+	require.NoError(t, err)
+
+	span := mockSpan{
+		traceID:       "abc123",
+		runID:         runID.String(),
+		dynamicSpanID: sql.NullString{String: "span-1", Valid: true},
+		parentSpanID:  sql.NullString{Valid: false},
+		startTime:     now,
+		endTime:       now.Add(time.Second),
+		spanFragments: string(fragmentsJSON),
+	}
+
+	result, err := mapSpanFromRow(ctx, span, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "executor.run", result.RawOtelSpan.Name)
+	assert.Equal(t, "test_value", result.RawOtelSpan.Attributes["test_key"])
+	assert.Equal(t, float64(42), result.RawOtelSpan.Attributes["count"])
+}
+
+func TestMapSpanFromRow_StringAttributes(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	runID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	// Span fragments with attributes as a JSON string (SQLite path).
+	attrsStr := `{"test_key":"test_value","count":42}`
+	fragments := []map[string]any{
+		{
+			"name":       "executor.run",
+			"attributes": attrsStr,
+		},
+	}
+	fragmentsJSON, err := json.Marshal(fragments)
+	require.NoError(t, err)
+
+	span := mockSpan{
+		traceID:       "abc123",
+		runID:         runID.String(),
+		dynamicSpanID: sql.NullString{String: "span-1", Valid: true},
+		parentSpanID:  sql.NullString{Valid: false},
+		startTime:     now,
+		endTime:       now.Add(time.Second),
+		spanFragments: string(fragmentsJSON),
+	}
+
+	result, err := mapSpanFromRow(ctx, span, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "executor.run", result.RawOtelSpan.Name)
+	assert.Equal(t, "test_value", result.RawOtelSpan.Attributes["test_key"])
+	assert.Equal(t, float64(42), result.RawOtelSpan.Attributes["count"])
+}
+
 func TestRollupSpanMetadataFromFragments(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now()

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/db_normalization.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/db_normalization.go
@@ -858,12 +858,12 @@ func (q NormalizedQueries) InsertSpan(ctx context.Context, arg sqlc_sqlite.Inser
 	pgArg := InsertSpanParams{
 		AccountID:      arg.AccountID,
 		AppID:          arg.AppID,
-		Attributes:     toNullRawMessage(arg.Attributes),
+		Attributes:     rawJSONToNullRawMessage(arg.Attributes),
 		DynamicSpanID:  arg.DynamicSpanID,
 		EndTime:        arg.EndTime,
 		EnvID:          arg.EnvID,
 		FunctionID:     arg.FunctionID,
-		Links:          toNullRawMessage(arg.Links),
+		Links:          rawJSONToNullRawMessage(arg.Links),
 		Name:           arg.Name,
 		Output:         toNullRawMessage(arg.Output),
 		ParentSpanID:   arg.ParentSpanID,
@@ -875,7 +875,7 @@ func (q NormalizedQueries) InsertSpan(ctx context.Context, arg sqlc_sqlite.Inser
 		DebugRunID:     arg.DebugRunID,
 		DebugSessionID: arg.DebugSessionID,
 		Status:         arg.Status,
-		EventIds:       toNullRawMessage(arg.EventIds),
+		EventIds:       rawJSONToNullRawMessage(arg.EventIds),
 	}
 
 	return q.db.InsertSpan(ctx, pgArg)

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/normalization.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/normalization.go
@@ -457,3 +457,36 @@ func toNullRawMessage(v interface{}) pqtype.NullRawMessage {
 		Valid:      true,
 	}
 }
+
+// rawJSONToNullRawMessage handles values that are already valid JSON (string or []byte).
+// Unlike toNullRawMessage, it avoids double-encoding by using the raw JSON directly.
+func rawJSONToNullRawMessage(v interface{}) pqtype.NullRawMessage {
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return pqtype.NullRawMessage{Valid: false}
+		}
+		if !json.Valid([]byte(val)) {
+			return pqtype.NullRawMessage{Valid: false}
+		}
+		return pqtype.NullRawMessage{
+			RawMessage: json.RawMessage(val),
+			Valid:      true,
+		}
+	case []byte:
+		if len(val) == 0 {
+			return pqtype.NullRawMessage{Valid: false}
+		}
+		if !json.Valid(val) {
+			return pqtype.NullRawMessage{Valid: false}
+		}
+		return pqtype.NullRawMessage{
+			RawMessage: json.RawMessage(val),
+			Valid:      true,
+		}
+	case nil:
+		return pqtype.NullRawMessage{Valid: false}
+	default:
+		return toNullRawMessage(v)
+	}
+}

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/normalization_test.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/normalization_test.go
@@ -1,0 +1,123 @@
+package sqlc
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRawJSONToNullRawMessage(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     interface{}
+		wantValid bool
+		wantJSON  string
+	}{
+		{
+			name:      "valid JSON object string",
+			input:     `{"key":"value","nested":{"a":1}}`,
+			wantValid: true,
+			wantJSON:  `{"key":"value","nested":{"a":1}}`,
+		},
+		{
+			name:      "valid JSON array string",
+			input:     `["a","b","c"]`,
+			wantValid: true,
+			wantJSON:  `["a","b","c"]`,
+		},
+		{
+			name:      "valid JSON bytes",
+			input:     []byte(`{"key":"value"}`),
+			wantValid: true,
+			wantJSON:  `{"key":"value"}`,
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			wantValid: false,
+		},
+		{
+			name:      "empty bytes",
+			input:     []byte{},
+			wantValid: false,
+		},
+		{
+			name:      "nil input",
+			input:     nil,
+			wantValid: false,
+		},
+		{
+			name:      "invalid JSON string",
+			input:     `{not valid json`,
+			wantValid: false,
+		},
+		{
+			name:      "invalid JSON bytes",
+			input:     []byte(`{not valid`),
+			wantValid: false,
+		},
+		{
+			name:      "fallback to marshal for map",
+			input:     map[string]any{"key": "value"},
+			wantValid: true,
+			wantJSON:  `{"key":"value"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := rawJSONToNullRawMessage(tt.input)
+			if result.Valid != tt.wantValid {
+				t.Errorf("rawJSONToNullRawMessage() valid = %v, want %v", result.Valid, tt.wantValid)
+			}
+			if tt.wantValid {
+				if !json.Valid(result.RawMessage) {
+					t.Errorf("rawJSONToNullRawMessage() produced invalid JSON: %s", string(result.RawMessage))
+				}
+				if string(result.RawMessage) != tt.wantJSON {
+					t.Errorf("rawJSONToNullRawMessage() = %s, want %s", string(result.RawMessage), tt.wantJSON)
+				}
+			}
+		})
+	}
+}
+
+func TestRawJSONToNullRawMessage_NoDoubleEncoding(t *testing.T) {
+	// Simulate the exact flow: json.Marshal(attrs) -> string(byt) -> rawJSONToNullRawMessage
+	attrs := map[string]any{"key": "value", "count": 42}
+	byt, err := json.Marshal(attrs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result := rawJSONToNullRawMessage(string(byt))
+	if !result.Valid {
+		t.Fatal("expected valid result")
+	}
+
+	// The result should NOT start with a quote (which would indicate double encoding)
+	if result.RawMessage[0] == '"' {
+		t.Errorf("double encoding detected: result starts with quote: %s", string(result.RawMessage))
+	}
+
+	// Should be parseable as an object, not a string
+	var parsed map[string]any
+	if err := json.Unmarshal(result.RawMessage, &parsed); err != nil {
+		t.Errorf("result is not a valid JSON object: %v (raw: %s)", err, string(result.RawMessage))
+	}
+}
+
+func TestToNullRawMessage_StillWorksForGoValues(t *testing.T) {
+	// Verify toNullRawMessage still works for Output/Input path (raw Go values)
+	result := toNullRawMessage(map[string]any{"output": true})
+	if !result.Valid {
+		t.Fatal("expected valid result")
+	}
+	if !json.Valid(result.RawMessage) {
+		t.Errorf("produced invalid JSON: %s", string(result.RawMessage))
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result.RawMessage, &parsed); err != nil {
+		t.Errorf("result is not valid JSON object: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #3632

## Problem

Span attributes are stored as JSONB string type instead of JSONB object in PostgreSQL. This happens because `toNullRawMessage()` calls `json.Marshal()` on a value that is already a JSON string, double-encoding it. As a result, JSONB operators (`?`, `->`, `@>`) fail on string-typed JSONB values, and `trace_runs.is_debounce` is never true.

**Root cause chain:**
- `tracer_sqlc.go:188` — `json.Marshal(attrs)` produces JSON bytes
- `tracer_sqlc.go:230` — `string(attrsByt)` converts to Go string
- `db_normalization.go:861` — passes string to `toNullRawMessage()`
- `normalization.go:451` — `json.Marshal(v)` re-encodes the already-JSON string
- PostgreSQL stores the result as JSONB string type, not object type

## Changes

**Write path** (`normalization.go` + `db_normalization.go`):
- Add `rawJSONToNullRawMessage()` that detects pre-serialized JSON strings/bytes and wraps them directly as `json.RawMessage` without re-marshaling
- Switch `Attributes`, `Links`, and `EventIds` fields in `InsertSpan()` to use the new function
- Keep `Output` and `Input` using `toNullRawMessage()` since they receive raw Go values that need marshaling

**Read path** (`cqrs.go`):
- In `parseSpanFromRow()` and `rollupSpanMetadataFromFragments()`, use a type switch for attributes:
  - `string` → unmarshal (handles legacy double-encoded rows)
  - `map[string]any` → use directly (handles new properly-encoded JSONB objects)
- Move `output_span_id` / `input_span_id` fragment processing outside the attributes type guard

## Test Plan
- Unit tests for `rawJSONToNullRawMessage` covering valid JSON strings/bytes, empty/nil inputs, invalid JSON fallback, and map fallback
- Explicit double-encoding prevention test
- Backward compatibility test for `toNullRawMessage` with Go values
- CI matrix covers both SQLite and PostgreSQL

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes double JSON encoding of span attributes in PostgreSQL by introducing `rawJSONToNullRawMessage` that detects pre-serialized JSON strings/bytes and uses them directly without re-marshaling. Updates the read path with a type switch to handle both legacy string-encoded attributes (SQLite/old rows) and new `map[string]any` JSONB objects (PostgreSQL). Also fixes a latent bug where `output_span_id`/`input_span_id` processing was incorrectly gated on attributes being a string type.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 2951f3e9c38bc1b78c2481e71c62ebd26da77b2b.</sup>
<!-- /MENDRAL_SUMMARY -->