### PR TITLE
Invalidate require cache on release for concurrency

### DIFF
--- a/pkg/constraintapi/acquire_test.go
+++ b/pkg/constraintapi/acquire_test.go
@@ -648,3 +648,279 @@ func TestAcquireCacheAccountScopedFlag(t *testing.T) {
 	assert.True(t, r.Exists(targetCacheKey), "target account cache key should exist")
 	assert.False(t, r.Exists(otherCacheKey), "other account cache key should NOT exist")
 }
+
+func TestAcquireCacheInvalidatedOnRelease(t *testing.T) {
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+	cm, r, clock, ctx := newTestSetup(t, enableAllCache())
+
+	config := ConstraintConfig{
+		FunctionVersion: 1,
+		Concurrency: ConcurrencyConfig{
+			FunctionConcurrency: 1,
+		},
+	}
+	constraints := []ConstraintItem{
+		{
+			Kind: ConstraintKindConcurrency,
+			Concurrency: &ConcurrencyConstraint{
+				Scope: enums.ConcurrencyScopeFn,
+				Mode:  enums.ConcurrencyModeStep,
+			},
+		},
+	}
+
+	// Fill capacity
+	resp1, err := cm.Acquire(ctx, makeAcquireRequest(accountID, envID, fnID, clock, config, constraints, "fill"))
+	require.NoError(t, err)
+	require.Len(t, resp1.Leases, 1)
+
+	// Exhaust — cache key should be set
+	resp2, err := cm.Acquire(ctx, makeAcquireRequest(accountID, envID, fnID, clock, config, constraints, "exhaust"))
+	require.NoError(t, err)
+	require.Empty(t, resp2.Leases)
+
+	cacheKey := cm.keyConstraintCache(accountID, envID, fnID, constraints[0])
+	require.True(t, r.Exists(cacheKey), "cache key should exist after exhaustion")
+
+	// Release the lease
+	_, err = cm.Release(ctx, &CapacityReleaseRequest{
+		IdempotencyKey: "release-1",
+		AccountID:      accountID,
+		LeaseID:        resp1.Leases[0].LeaseID,
+		Source:         LeaseSource{Service: ServiceExecutor},
+	})
+	require.NoError(t, err)
+
+	// Cache key should be deleted
+	assert.False(t, r.Exists(cacheKey), "cache key should be deleted after release")
+
+	// Acquire should succeed (not blocked by stale cache)
+	resp3, err := cm.Acquire(ctx, makeAcquireRequest(accountID, envID, fnID, clock, config, constraints, "after-release"))
+	require.NoError(t, err)
+	assert.Len(t, resp3.Leases, 1, "should get lease after release invalidated cache")
+	assert.Equal(t, 0, resp3.internalDebugState.CacheHit, "should not be a cache hit")
+}
+
+func TestAcquireCacheNotInvalidatedForThrottleOnRelease(t *testing.T) {
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+	cm, r, clock, ctx := newTestSetup(t, enableAllCache())
+
+	config := ConstraintConfig{
+		FunctionVersion: 1,
+		Concurrency: ConcurrencyConfig{
+			FunctionConcurrency: 1,
+		},
+		Throttle: []ThrottleConfig{
+			{
+				Scope:  enums.ThrottleScopeFn,
+				Limit:  1,
+				Burst:  1,
+				Period: 60,
+			},
+		},
+	}
+	constraints := []ConstraintItem{
+		{
+			Kind: ConstraintKindConcurrency,
+			Concurrency: &ConcurrencyConstraint{
+				Scope: enums.ConcurrencyScopeFn,
+				Mode:  enums.ConcurrencyModeStep,
+			},
+		},
+		{
+			Kind: ConstraintKindThrottle,
+			Throttle: &ThrottleConstraint{
+				Scope:            enums.ThrottleScopeFn,
+				EvaluatedKeyHash: "test-hash",
+			},
+		},
+	}
+
+	// Fill capacity
+	resp1, err := cm.Acquire(ctx, makeAcquireRequest(accountID, envID, fnID, clock, config, constraints, "fill"))
+	require.NoError(t, err)
+	require.Len(t, resp1.Leases, 1)
+
+	// Build cache keys by explicit constraint kind (sortConstraints reorders the slice)
+	concurrencyCacheKey := cm.keyConstraintCache(accountID, envID, fnID, ConstraintItem{
+		Kind:        ConstraintKindConcurrency,
+		Concurrency: &ConcurrencyConstraint{Scope: enums.ConcurrencyScopeFn, Mode: enums.ConcurrencyModeStep},
+	})
+	throttleCacheKey := cm.keyConstraintCache(accountID, envID, fnID, ConstraintItem{
+		Kind:     ConstraintKindThrottle,
+		Throttle: &ThrottleConstraint{Scope: enums.ThrottleScopeFn, EvaluatedKeyHash: "test-hash"},
+	})
+
+	// Manually set both cache keys (simulates prior acquires that exhausted each constraint)
+	retryAtMS := clock.Now().Add(10 * time.Second).UnixMilli()
+	require.NoError(t, r.Set(concurrencyCacheKey, fmt.Sprintf("%d", retryAtMS)))
+	r.SetTTL(concurrencyCacheKey, 30*time.Second)
+	require.NoError(t, r.Set(throttleCacheKey, fmt.Sprintf("%d", retryAtMS)))
+	r.SetTTL(throttleCacheKey, 30*time.Second)
+
+	// Release the lease
+	_, err = cm.Release(ctx, &CapacityReleaseRequest{
+		IdempotencyKey: "release-1",
+		AccountID:      accountID,
+		LeaseID:        resp1.Leases[0].LeaseID,
+		Source:         LeaseSource{Service: ServiceExecutor},
+	})
+	require.NoError(t, err)
+
+	// Concurrency cache key should be deleted, throttle should remain
+	assert.False(t, r.Exists(concurrencyCacheKey), "concurrency cache key should be deleted after release")
+	assert.True(t, r.Exists(throttleCacheKey), "throttle cache key should still exist after release")
+}
+
+func TestAcquireCacheInvalidatedWithCustomKey(t *testing.T) {
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+	cm, r, clock, ctx := newTestSetup(t, enableAllCache())
+
+	config := ConstraintConfig{
+		FunctionVersion: 1,
+		Concurrency: ConcurrencyConfig{
+			CustomConcurrencyKeys: []CustomConcurrencyLimit{
+				{
+					Scope:             enums.ConcurrencyScopeFn,
+					Limit:             1,
+					KeyExpressionHash: "keyhash123",
+				},
+			},
+		},
+	}
+	constraints := []ConstraintItem{
+		{
+			Kind: ConstraintKindConcurrency,
+			Concurrency: &ConcurrencyConstraint{
+				Scope:              enums.ConcurrencyScopeFn,
+				Mode:               enums.ConcurrencyModeStep,
+				KeyExpressionHash:  "keyhash123",
+				EvaluatedKeyHash:   "evalhash456",
+			},
+		},
+	}
+
+	// Fill capacity
+	resp1, err := cm.Acquire(ctx, makeAcquireRequest(accountID, envID, fnID, clock, config, constraints, "fill"))
+	require.NoError(t, err)
+	require.Len(t, resp1.Leases, 1)
+
+	// Exhaust
+	resp2, err := cm.Acquire(ctx, makeAcquireRequest(accountID, envID, fnID, clock, config, constraints, "exhaust"))
+	require.NoError(t, err)
+	require.Empty(t, resp2.Leases)
+
+	cacheKey := cm.keyConstraintCache(accountID, envID, fnID, constraints[0])
+	require.True(t, r.Exists(cacheKey), "custom key cache should exist after exhaustion")
+
+	// Release
+	_, err = cm.Release(ctx, &CapacityReleaseRequest{
+		IdempotencyKey: "release-1",
+		AccountID:      accountID,
+		LeaseID:        resp1.Leases[0].LeaseID,
+		Source:         LeaseSource{Service: ServiceExecutor},
+	})
+	require.NoError(t, err)
+
+	assert.False(t, r.Exists(cacheKey), "custom key cache should be deleted after release")
+}
+
+func TestAcquireCacheInvalidatedMultipleConstraints(t *testing.T) {
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+	cm, r, clock, ctx := newTestSetup(t, enableAllCache())
+
+	config := ConstraintConfig{
+		FunctionVersion: 1,
+		Concurrency: ConcurrencyConfig{
+			FunctionConcurrency: 1,
+			AccountConcurrency:  1,
+		},
+	}
+	constraints := []ConstraintItem{
+		{
+			Kind: ConstraintKindConcurrency,
+			Concurrency: &ConcurrencyConstraint{
+				Scope: enums.ConcurrencyScopeFn,
+				Mode:  enums.ConcurrencyModeStep,
+			},
+		},
+		{
+			Kind: ConstraintKindConcurrency,
+			Concurrency: &ConcurrencyConstraint{
+				Scope: enums.ConcurrencyScopeAccount,
+				Mode:  enums.ConcurrencyModeStep,
+			},
+		},
+	}
+
+	// Fill capacity
+	resp1, err := cm.Acquire(ctx, makeAcquireRequest(accountID, envID, fnID, clock, config, constraints, "fill"))
+	require.NoError(t, err)
+	require.Len(t, resp1.Leases, 1)
+
+	// Exhaust
+	resp2, err := cm.Acquire(ctx, makeAcquireRequest(accountID, envID, fnID, clock, config, constraints, "exhaust"))
+	require.NoError(t, err)
+	require.Empty(t, resp2.Leases)
+
+	fnCacheKey := cm.keyConstraintCache(accountID, envID, fnID, constraints[0])
+	acctCacheKey := cm.keyConstraintCache(accountID, envID, fnID, constraints[1])
+	require.True(t, r.Exists(fnCacheKey), "fn concurrency cache key should exist")
+	require.True(t, r.Exists(acctCacheKey), "account concurrency cache key should exist")
+
+	// Release
+	_, err = cm.Release(ctx, &CapacityReleaseRequest{
+		IdempotencyKey: "release-1",
+		AccountID:      accountID,
+		LeaseID:        resp1.Leases[0].LeaseID,
+		Source:         LeaseSource{Service: ServiceExecutor},
+	})
+	require.NoError(t, err)
+
+	assert.False(t, r.Exists(fnCacheKey), "fn concurrency cache key should be deleted after release")
+	assert.False(t, r.Exists(acctCacheKey), "account concurrency cache key should be deleted after release")
+}
+
+func TestAcquireCacheNotInvalidatedWhenCacheDisabled(t *testing.T) {
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+	// Create manager WITHOUT cache enabled
+	cm, r, clock, ctx := newTestSetup(t, nil)
+
+	config := ConstraintConfig{
+		FunctionVersion: 1,
+		Concurrency: ConcurrencyConfig{
+			FunctionConcurrency: 1,
+		},
+	}
+	constraints := []ConstraintItem{
+		{
+			Kind: ConstraintKindConcurrency,
+			Concurrency: &ConcurrencyConstraint{
+				Scope: enums.ConcurrencyScopeFn,
+				Mode:  enums.ConcurrencyModeStep,
+			},
+		},
+	}
+
+	// Manually set a cache key to verify it's NOT deleted on release
+	cacheKey := cm.keyConstraintCache(accountID, envID, fnID, constraints[0])
+	require.NotEmpty(t, cacheKey)
+	require.NoError(t, r.Set(cacheKey, "12345"))
+
+	// Fill capacity
+	resp1, err := cm.Acquire(ctx, makeAcquireRequest(accountID, envID, fnID, clock, config, constraints, "fill"))
+	require.NoError(t, err)
+	require.Len(t, resp1.Leases, 1)
+
+	// Release
+	_, err = cm.Release(ctx, &CapacityReleaseRequest{
+		IdempotencyKey: "release-1",
+		AccountID:      accountID,
+		LeaseID:        resp1.Leases[0].LeaseID,
+		Source:         LeaseSource{Service: ServiceExecutor},
+	})
+	require.NoError(t, err)
+
+	// Cache key should still exist since cache invalidation is disabled
+	assert.True(t, r.Exists(cacheKey), "cache key should NOT be deleted when cache is disabled")
+}

--- a/pkg/constraintapi/lua/release.lua
+++ b/pkg/constraintapi/lua/release.lua
@@ -23,6 +23,7 @@ local accountID = ARGV[2]
 local currentLeaseID = ARGV[3]
 local operationIdempotencyTTL = tonumber(ARGV[4])--[[@as integer]]
 local enableDebugLogs = tonumber(ARGV[5]) == 1
+local enableCacheInvalidation = ARGV[6] == "1"
 
 ---@type string[]
 local debugLogs = {}
@@ -125,5 +126,30 @@ local encoded = cjson.encode(res)
 
 -- Set operation idempotency TTL
 call("SET", keyOperationIdempotency, encoded, "EX", tostring(operationIdempotencyTTL))
+
+-- Invalidate concurrency constraint cache on release
+if enableCacheInvalidation then
+	local cacheKeysToDelete = {}
+	for _, c in ipairs(constraints) do
+		if c.k == 2 and c.c then
+			local scope = c.c.s or 0
+			local sl = (scope == 2 and "a") or (scope == 1 and "e") or "f"
+			local cacheKey
+			if c.c.h ~= nil and c.c.h ~= "" then
+				cacheKey = accountID .. ":c:" .. sl .. ":" .. c.c.h .. ":" .. (c.c.eh or "")
+			elseif scope == 0 then
+				cacheKey = accountID .. ":c:" .. sl .. ":" .. requestDetails.f
+			elseif scope == 1 then
+				cacheKey = accountID .. ":c:" .. sl .. ":" .. requestDetails.e
+			else
+				cacheKey = accountID .. ":c:" .. sl
+			end
+			table.insert(cacheKeysToDelete, scopedKeyPrefix .. ":cache:" .. cacheKey)
+		end
+	end
+	if #cacheKeysToDelete > 0 then
+		call("DEL", unpack(cacheKeysToDelete))
+	end
+end
 
 return encoded

--- a/pkg/constraintapi/release.go
+++ b/pkg/constraintapi/release.go
@@ -60,6 +60,11 @@ func (r *redisCapacityManager) Release(ctx context.Context, req *CapacityRelease
 		enableDebugLogsVal = "1"
 	}
 
+	enableCacheInvalidation := "0"
+	if r.enableAcquireCache != nil {
+		enableCacheInvalidation = "1"
+	}
+
 	scopedKeyPrefix := fmt.Sprintf("{cs}:%s", accountScope(req.AccountID))
 
 	args, err := strSlice([]any{
@@ -68,6 +73,7 @@ func (r *redisCapacityManager) Release(ctx context.Context, req *CapacityRelease
 		req.LeaseID.String(),
 		int(r.operationIdempotencyTTL.Seconds()),
 		enableDebugLogsVal,
+		enableCacheInvalidation,
 	})
 	if err != nil {
 		return nil, errs.Wrap(0, false, "invalid args: %w", err)

--- a/pkg/constraintapi/testdata/snapshots/release.lua
+++ b/pkg/constraintapi/testdata/snapshots/release.lua
@@ -13,6 +13,7 @@ local accountID = ARGV[2]
 local currentLeaseID = ARGV[3]
 local operationIdempotencyTTL = tonumber(ARGV[4])
 local enableDebugLogs = tonumber(ARGV[5]) == 1
+local enableCacheInvalidation = ARGV[6] == "1"
 local debugLogs = {}
 local function debug(...)
 	if enableDebugLogs then
@@ -77,4 +78,27 @@ res["f"] = requestDetails.f
 res["m"] = requestDetails.m
 local encoded = cjson.encode(res)
 call("SET", keyOperationIdempotency, encoded, "EX", tostring(operationIdempotencyTTL))
+if enableCacheInvalidation then
+	local cacheKeysToDelete = {}
+	for _, c in ipairs(constraints) do
+		if c.k == 2 and c.c then
+			local scope = c.c.s or 0
+			local sl = (scope == 2 and "a") or (scope == 1 and "e") or "f"
+			local cacheKey
+			if c.c.h ~= nil and c.c.h ~= "" then
+				cacheKey = accountID .. ":c:" .. sl .. ":" .. c.c.h .. ":" .. (c.c.eh or "")
+			elseif scope == 0 then
+				cacheKey = accountID .. ":c:" .. sl .. ":" .. requestDetails.f
+			elseif scope == 1 then
+				cacheKey = accountID .. ":c:" .. sl .. ":" .. requestDetails.e
+			else
+				cacheKey = accountID .. ":c:" .. sl
+			end
+			table.insert(cacheKeysToDelete, scopedKeyPrefix .. ":cache:" .. cacheKey)
+		end
+	end
+	if #cacheKeysToDelete > 0 then
+		call("DEL", unpack(cacheKeysToDelete))
+	end
+end
 return encoded


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds cache invalidation for concurrency constraint cache entries when a lease is released. The Lua `release.lua` script is extended with a new `enableCacheInvalidation` flag (ARGV[6]) that, when set, deletes all concurrency constraint cache keys associated with the released lease's constraints. The Go `Release()` method passes this flag based on whether `enableAcquireCache` is configured. Five new tests cover the invalidation behavior across different constraint configurations.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c1337b2515189b9a28c913aa6a2522d1cd7c4346.</sup>
<!-- /MENDRAL_SUMMARY -->