### PR TITLE
Fix trace child select

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/Timeline.tsx
+++ b/ui/packages/components/src/RunDetailsV4/Timeline.tsx
@@ -328,6 +328,7 @@ function TimelineBarRenderer({
               expandable={isTimingBarExpandable}
               expanded={isTimingBarExpanded}
               onToggle={isTimingBarExpandable ? () => onToggleExpand(timingBar.id) : undefined}
+              onClick={() => onSelectStep?.(bar.id)}
               viewStartOffset={viewStartOffset}
               viewEndOffset={viewEndOffset}
               startTime={timingBar.startTime}
@@ -357,6 +358,7 @@ function TimelineBarRenderer({
                       leftWidth={leftWidth}
                       style={httpBar.style}
                       status={bar.status}
+                      onClick={() => onSelectStep?.(bar.id)}
                       viewStartOffset={viewStartOffset}
                       viewEndOffset={viewEndOffset}
                       startTime={httpBar.startTime}


### PR DESCRIPTION
## Description

Clicking timing breakdown rows (Inngest, Your Server, HTTP timing) inside an expanded step does not select the parent step because those rows were missing onClick handlers

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `onClick` handlers to timing breakdown rows (`timingBar` and `httpBar`) inside expanded steps so that clicking them selects the parent step via `onSelectStep?.(bar.id)`, matching the existing behavior on the main bar.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit dc371acdb8266651db7f8d9053d7a1588e3b7dce.</sup>
<!-- /MENDRAL_SUMMARY -->