### PR TITLE
fix: missing trace spans for DURP steps

### DIFF
--- a/pkg/execution/driver/httpv2/httpv2.go
+++ b/pkg/execution/driver/httpv2/httpv2.go
@@ -147,6 +147,11 @@ func (d httpv2) sync(ctx context.Context, sl sv2.StateLoader, opts driver.V2Requ
 		req.Header.Add(headers.HeaderKeyForceStepPlan, "true")
 	}
 
+	req.Header.Add(headers.HeaderKeyFnID, opts.Metadata.ID.FunctionID.String())
+	if opts.QueueRef != "" {
+		req.Header.Add(headers.HeaderKeyQueueItemRef, opts.QueueRef)
+	}
+
 	if opts.StepID != nil && *opts.StepID != "" && *opts.StepID != "step" {
 		req.Header.Add(headers.HeaderInngestStepID, *opts.StepID)
 	}

--- a/pkg/execution/driver/httpv2/httpv2_test.go
+++ b/pkg/execution/driver/httpv2/httpv2_test.go
@@ -22,6 +22,7 @@ import (
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/headers"
 	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/google/uuid"
 	inngestgo "github.com/inngest/inngestgo"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
@@ -201,6 +202,86 @@ func TestSyncHeadersWithForceStepPlan(t *testing.T) {
 
 	// ForceStepPlan is set, so header should be present
 	require.Equal(t, "true", receivedHeaders.Get(headers.HeaderKeyForceStepPlan))
+}
+
+func TestSyncHeadersFnIDAndQueueRef(t *testing.T) {
+	fnID := uuid.New()
+	queueRef := "dGVzdC1qb2ItaWQ6OnRlc3Qtc2hhcmQtaWQ=" // base64-encoded job::shard
+
+	tests := []struct {
+		name             string
+		fnID             uuid.UUID
+		queueRef         string
+		expectFnID       string
+		expectQueueRef   string
+	}{
+		{
+			name:           "both fn_id and queue_ref sent",
+			fnID:           fnID,
+			queueRef:       queueRef,
+			expectFnID:     fnID.String(),
+			expectQueueRef: queueRef,
+		},
+		{
+			name:           "fn_id sent, queue_ref omitted when empty",
+			fnID:           fnID,
+			queueRef:       "",
+			expectFnID:     fnID.String(),
+			expectQueueRef: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var receivedHeaders http.Header
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedHeaders = r.Header
+				w.Header().Set(headers.HeaderKeySDK, "test-sdk")
+				opcodes := []*sv1.GeneratorOpcode{{Op: enums.OpcodeNone}}
+				w.WriteHeader(200)
+				_ = json.NewEncoder(w).Encode(opcodes)
+			}))
+			defer ts.Close()
+
+			client := exechttp.Client(exechttp.SecureDialerOpts{AllowPrivate: true})
+			d := &httpv2{Client: client}
+
+			u, _ := url.Parse(ts.URL)
+			fn := inngest.Function{
+				Driver: inngest.FunctionDriver{
+					URI: u.String(),
+					Metadata: map[string]any{
+						"type": "sync",
+					},
+				},
+			}
+
+			opts := driver.V2RequestOpts{
+				Fn:         fn,
+				SigningKey: []byte("test-signing-key"),
+				Metadata: sv2.Metadata{
+					ID: sv2.ID{
+						RunID:      ulid.MustNew(ulid.Now(), rand.Reader),
+						FunctionID: tt.fnID,
+					},
+				},
+				QueueRef: tt.queueRef,
+				URL:      u.String(),
+			}
+
+			resp, userErr, internalErr := d.Do(context.Background(), nil, opts)
+			require.NoError(t, userErr)
+			require.NoError(t, internalErr)
+			require.NotNil(t, resp)
+
+			require.Equal(t, tt.expectFnID, receivedHeaders.Get(headers.HeaderKeyFnID))
+			if tt.expectQueueRef != "" {
+				require.Equal(t, tt.expectQueueRef, receivedHeaders.Get(headers.HeaderKeyQueueItemRef))
+			} else {
+				require.Empty(t, receivedHeaders.Get(headers.HeaderKeyQueueItemRef))
+			}
+		})
+	}
 }
 
 func TestSyncNonSDKResponse(t *testing.T) {

--- a/pkg/headers/headers.go
+++ b/pkg/headers/headers.go
@@ -45,6 +45,15 @@ const (
 	// HeaderKeyForceStepPlan tells the SDK to use step planning instead of
 	// immediate execution. This is used when parallel steps are detected.
 	HeaderKeyForceStepPlan = "X-Inngest-Force-Step-Plan"
+
+	// HeaderKeyFnID sends the internal function UUID to the SDK during
+	// sync function re-entry (e.g. after waitForEvent resume), enabling
+	// async checkpointing of intermediate steps.
+	HeaderKeyFnID = "X-Inngest-Fn-ID"
+
+	// HeaderKeyQueueItemRef sends the queue item reference to the SDK
+	// during sync function re-entry, used by the async checkpoint API.
+	HeaderKeyQueueItemRef = "X-Inngest-Queue-Item-Ref"
 )
 
 const (


### PR DESCRIPTION
## Description

Send fn_id and qi_id headers from the executor to the SDK during sync function re-entry, enabling AsyncCheckpointing mode for steps that execute after a waitForEvent resumes.>

## Motivation

Better durable endpoints

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

## Related

https://github.com/inngest/inngest-js/pull/1386/changes/e294dfa77a9478250f295ffe678b9257d4d535a9

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds two new HTTP headers (`X-Inngest-Fn-ID` and `X-Inngest-Queue-Item-Ref`) sent from the executor to the SDK during sync function re-entry. `HeaderKeyFnID` is sent unconditionally; `HeaderKeyQueueItemRef` is sent only when `QueueRef` is non-empty. Both constants are defined in `pkg/headers/headers.go` and consumed in `httpv2.sync()`. A table-driven test covers both the "both headers present" and "queue ref omitted" cases.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3afd6aa745e15f3f966579979418a06cadd55e88.</sup>
<!-- /MENDRAL_SUMMARY -->