### PR TITLE
Revert "Use post-pause-write time as started_at for waitForEvent"

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -4770,9 +4770,26 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, runCtx execu
 	}
 
 	lifecycleItem := runCtx.LifecycleItem()
-	idx := pauses.Index{WorkspaceID: runCtx.Metadata().ID.Tenant.EnvID, EventName: opts.Event}
+	span, err := e.tracerProvider.CreateDroppableSpan(
+		ctx,
+		meta.SpanNameStep,
+		&tracing.CreateSpanOptions{
+			Carriers:    []map[string]any{pause.Metadata, nextItem.Metadata},
+			FollowsFrom: tracing.SpanRefFromQueueItem(&lifecycleItem),
+			Debug:       &tracing.SpanDebugData{Location: "executor.handleGeneratorWaitForEvent"},
+			Metadata:    runCtx.Metadata(),
+			QueueItem:   &nextItem,
+			Parent:      tracing.RunSpanRefFromMetadata(runCtx.Metadata()),
+			Attributes:  tracing.GeneratorAttrs(&gen),
+		},
+	)
+	if err != nil {
+		// return fmt.Errorf("error creating span for next step after
+		// WaitForEvent: %w", err)
+		e.log.Debug("error creating span for next step after WaitForEvent", "error", err)
+	}
 
-	attrs := tracing.GeneratorAttrs(&gen)
+	idx := pauses.Index{WorkspaceID: runCtx.Metadata().ID.Tenant.EnvID, EventName: opts.Event}
 
 	// We really don't want this to fail, this can be retried in an idempotent way but
 	// workflows with 0 retries setup will just hang forever if pause creation fails.
@@ -4788,30 +4805,7 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, runCtx execu
 			return err
 		}
 		// Allow pause already existing to be idempotent, and continue on with enqueueing.
-	}
-
-	afterPauseTS := e.now()
-
-	span, err := e.tracerProvider.CreateDroppableSpan(
-		ctx,
-		meta.SpanNameStep,
-		&tracing.CreateSpanOptions{
-			Carriers:    []map[string]any{pause.Metadata, nextItem.Metadata},
-			FollowsFrom: tracing.SpanRefFromQueueItem(&lifecycleItem),
-			Debug:       &tracing.SpanDebugData{Location: "executor.handleGeneratorWaitForEvent"},
-			Metadata:    runCtx.Metadata(),
-			QueueItem:   &nextItem,
-			Parent:      tracing.RunSpanRefFromMetadata(runCtx.Metadata()),
-			Attributes: attrs.Merge(meta.NewAttrSet(
-				meta.Attr(meta.Attrs.QueuedAt, &now),
-				meta.Attr(meta.Attrs.StartedAt, &afterPauseTS),
-			)),
-		},
-	)
-	if err != nil {
-		// return fmt.Errorf("error creating span for next step after
-		// WaitForEvent: %w", err)
-		e.log.Debug("error creating span for next step after WaitForEvent", "error", err)
+		span.Drop()
 	}
 
 	// TODO Is this fine to leave? No attempts.

--- a/pkg/tracing/execution_processor.go
+++ b/pkg/tracing/execution_processor.go
@@ -130,14 +130,7 @@ func (p *executionProcessor) OnStart(parent context.Context, s sdktrace.ReadWrit
 
 	case meta.SpanNameStep:
 		{
-			var hasQueuedAt bool
-			for _, attr := range s.Attributes() {
-				hasQueuedAt = hasQueuedAt || string(attr.Key) == meta.Attrs.QueuedAt.Key()
-			}
-
-			if !hasQueuedAt {
-				meta.AddAttrIfUnset(rawAttrs, meta.Attrs.QueuedAt, &now)
-			}
+			meta.AddAttrIfUnset(rawAttrs, meta.Attrs.QueuedAt, &now)
 
 			if ec != nil {
 				meta.AddAttr(rawAttrs, meta.Attrs.StepMaxAttempts, ec.MaxAttempts)
@@ -145,6 +138,17 @@ func (p *executionProcessor) OnStart(parent context.Context, s sdktrace.ReadWrit
 
 				// Some steps "start" as soon as they are queued
 				startWhenQueued := ec.QueueKind == queue.KindSleep
+				if !startWhenQueued {
+					for _, attr := range s.Attributes() {
+						if string(attr.Key) == meta.Attrs.StepOp.Key() {
+							if attr.Value.Type() == attribute.STRING && attr.Value.AsString() == enums.OpcodeWaitForEvent.String() {
+								startWhenQueued = true
+								break
+							}
+						}
+					}
+				}
+
 				if startWhenQueued {
 					meta.AddAttr(rawAttrs, meta.Attrs.StartedAt, &now)
 				}


### PR DESCRIPTION
Reverts inngest/inngest#3841. It is breaking tests in monorepo.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Reverts #3841 ("Use post-pause-write time as started_at for waitForEvent") which was breaking monorepo tests. The revert restores the original span creation order (before pause write) and replaces the `afterPauseTS` approach with an attribute scan in `OnStart` that sets `startWhenQueued = true` for `OpcodeWaitForEvent` steps. One net-new behavior is added: `span.Drop()` is called when `ErrPauseAlreadyExists`, which was absent in both the original and the reverted code.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3f3f5fc196567457b80b9280b4932c8a366516f7.</sup>
<!-- /MENDRAL_SUMMARY -->