### PR TITLE
optimize literal boolean expressions in pause evaluation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/go-chi/cors v1.2.1
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/golang-migrate/migrate/v4 v4.16.2
+	github.com/golang/snappy v0.0.5-0.20231225225746-43d5d4cd4e0e
 	github.com/google/cel-go v0.27.0
 	github.com/google/uuid v1.6.0
 	github.com/gosimple/slug v1.12.0
@@ -43,7 +44,7 @@ require (
 	github.com/graph-gophers/dataloader v5.0.0+incompatible
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/inngest/expr v0.0.0-20260225032035-443da0a59989
+	github.com/inngest/expr v0.0.0-20260320151211-8abd2c0b8427
 	github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48
 	github.com/inngest/inngestgo v0.15.1-0.20260204010937-b4832022aecc
 	github.com/jackc/pgx/v5 v5.5.4
@@ -51,6 +52,7 @@ require (
 	github.com/jonboulle/clockwork v0.4.0
 	github.com/karlseguin/ccache/v2 v2.0.8
 	github.com/karlseguin/ccache/v3 v3.0.6
+	github.com/klauspost/compress v1.18.0
 	github.com/knadh/koanf/parsers/json v1.0.0
 	github.com/knadh/koanf/parsers/yaml v1.1.0
 	github.com/knadh/koanf/providers/env v1.1.0
@@ -64,6 +66,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.0.0
 	github.com/nats-io/nats.go v1.37.0
 	github.com/oklog/ulid/v2 v2.1.1
+	github.com/pierrec/lz4/v4 v4.1.22
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/cachecontrol v0.2.0
 	github.com/prometheus/client_golang v1.17.0
@@ -179,7 +182,6 @@ require (
 	github.com/golang/glog v1.2.4 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/mock v1.6.0 // indirect
-	github.com/golang/snappy v0.0.5-0.20231225225746-43d5d4cd4e0e // indirect
 	github.com/google/jsonschema-go v0.3.0 // indirect
 	github.com/google/s2a-go v0.1.8 // indirect
 	github.com/google/wire v0.6.0 // indirect
@@ -198,7 +200,6 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/jstemmer/go-junit-report/v2 v2.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
@@ -238,7 +239,6 @@ require (
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
-	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -595,8 +595,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/inngest/expr v0.0.0-20260225032035-443da0a59989 h1:7BafcTNYFZvJvdOG7i8+aNfsl+nX25fWpELeHOv2uo8=
-github.com/inngest/expr v0.0.0-20260225032035-443da0a59989/go.mod h1:fwLYQ2NlzdevRRQoldvMrMvCicAG6X3NaONAtxuiT8k=
+github.com/inngest/expr v0.0.0-20260320151211-8abd2c0b8427 h1:JMWUk8lr4jVdxjo67TRT/bzIwGxlzvWbVYexH+8He1Y=
+github.com/inngest/expr v0.0.0-20260320151211-8abd2c0b8427/go.mod h1:fwLYQ2NlzdevRRQoldvMrMvCicAG6X3NaONAtxuiT8k=
 github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48 h1:8NwXUrQTQjWrfGj99JgesfTbCYujtnLHusePp7YyFU8=
 github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48/go.mod h1:7SNLkGaD+tiTey1IF9WUNDNurTfqNZqjbdPZo3CmLW4=
 github.com/inngest/inngestgo v0.15.1-0.20260204010937-b4832022aecc h1:FD+iis04Q5HvCXeIyzRo1RNrZRK8QnFAIkmmYVthHZI=

--- a/pkg/expressions/expragg/pause_benchmark_test.go
+++ b/pkg/expressions/expragg/pause_benchmark_test.go
@@ -46,6 +46,111 @@ func BenchmarkPauseSameVersionFast(b *testing.B) {
 	})
 }
 
+// BenchmarkPauseConstantFalse benchmarks that constant "false" expressions are skipped
+// and not added to the slow evaluation path.
+func BenchmarkPauseConstantFalse(b *testing.B) {
+	ctx := context.Background()
+	parser := expr.NewTreeParser(exprenv.CompilerSingleton())
+
+	ae := expr.NewAggregateEvaluator(expr.AggregateEvaluatorOpts[*state.Pause]{
+		Parser:      parser,
+		Eval:        expressions.ExprEvaluator,
+		Concurrency: 1000,
+		KV:          &mockKV{},
+		Log:         logger.From(ctx).SLog(),
+	})
+	defer ae.Close()
+
+	// Add 1000 constant false expressions
+	for i := 0; i < 1000; i++ {
+		expression := "false"
+		pause := &state.Pause{
+			ID:         uuid.New(),
+			Expression: &expression,
+		}
+		_, err := ae.Add(ctx, pause)
+		if err != nil {
+			b.Fatalf("Failed to add evaluable %d: %v", i, err)
+		}
+	}
+
+	// Verify none were added to slow path
+	if ae.SlowLen() != 0 {
+		b.Fatalf("Expected 0 slow expressions, got %d", ae.SlowLen())
+	}
+	if ae.Len() != 0 {
+		b.Fatalf("Expected 0 total expressions, got %d", ae.Len())
+	}
+
+	testData := map[string]any{
+		"async": map[string]any{
+			"data": map[string]any{"foo": "bar"},
+			"name": "test-event",
+		},
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			vals, _, _ := ae.Evaluate(ctx, testData)
+			if len(vals) != 0 {
+				b.Fatalf("Expected 0 matches, got %d", len(vals))
+			}
+		}
+	})
+}
+
+// BenchmarkPauseConstantTrue benchmarks that constant "true" expressions are matched
+// without CEL evaluation.
+func BenchmarkPauseConstantTrue(b *testing.B) {
+	ctx := context.Background()
+	parser := expr.NewTreeParser(exprenv.CompilerSingleton())
+
+	ae := expr.NewAggregateEvaluator(expr.AggregateEvaluatorOpts[*state.Pause]{
+		Parser:      parser,
+		Eval:        expressions.ExprEvaluator,
+		Concurrency: 1000,
+		KV:          &mockKV{},
+		Log:         logger.From(ctx).SLog(),
+	})
+	defer ae.Close()
+
+	// Add 1000 constant true expressions
+	for i := 0; i < 1000; i++ {
+		expression := "true"
+		pause := &state.Pause{
+			ID:         uuid.New(),
+			Expression: &expression,
+		}
+		_, err := ae.Add(ctx, pause)
+		if err != nil {
+			b.Fatalf("Failed to add evaluable %d: %v", i, err)
+		}
+	}
+
+	// Verify they're tracked (not in slow path)
+	if ae.SlowLen() != 0 {
+		b.Fatalf("Expected 0 slow expressions, got %d", ae.SlowLen())
+	}
+
+	testData := map[string]any{
+		"async": map[string]any{
+			"data": map[string]any{"foo": "bar"},
+			"name": "test-event",
+		},
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			vals, _, _ := ae.Evaluate(ctx, testData)
+			if len(vals) != 1000 {
+				b.Fatalf("Expected 1000 matches, got %d", len(vals))
+			}
+		}
+	})
+}
+
 type pauseBenchmarkOpts struct {
 	useSameVersion     bool
 	useMixedExpression bool

--- a/vendor/github.com/inngest/expr/expr.go
+++ b/vendor/github.com/inngest/expr/expr.go
@@ -194,6 +194,7 @@ func NewAggregateEvaluator[T Evaluable](
 		},
 		lock:            &sync.RWMutex{},
 		constants:       map[uuid.UUID]struct{}{},
+		alwaysTrue:      map[uuid.UUID]struct{}{},
 		mixed:           map[uuid.UUID]struct{}{},
 		stopGC:          make(chan struct{}),
 		concurrency:     opts.Concurrency,
@@ -239,6 +240,10 @@ type aggregator[T Evaluable] struct {
 	// the expression containing non-aggregateable clauses.
 	constants map[uuid.UUID]struct{}
 
+	// alwaysTrue tracks evaluable IDs whose expression is a constant true literal,
+	// meaning they always match without requiring CEL evaluation.
+	alwaysTrue map[uuid.UUID]struct{}
+
 	// deleted tracks evaluable IDs that have been soft-deleted.
 	// Remove operations mark items here instead of actually removing them,
 	// avoiding lock contention during evaluation.
@@ -261,7 +266,7 @@ type aggregator[T Evaluable] struct {
 func (a *aggregator[T]) Len() int {
 	a.lock.RLock()
 	defer a.lock.RUnlock()
-	return int(atomic.LoadInt32(&a.fastLen)) + len(a.mixed) + len(a.constants)
+	return int(atomic.LoadInt32(&a.fastLen)) + len(a.mixed) + len(a.constants) + len(a.alwaysTrue)
 }
 
 // FastLen returns the number of expressions being matched by aggregated trees.
@@ -308,6 +313,22 @@ func (a *aggregator[T]) Evaluate(ctx context.Context, data map[string]any) ([]T,
 	napool := newErrPool(errPoolOpts{concurrency: a.concurrency})
 
 	a.lock.RLock()
+
+	// Always-true expressions match without CEL evaluation.
+	for uuid := range a.alwaysTrue {
+		if _, deleted := a.deleted.Load(uuid); deleted {
+			continue
+		}
+		item, err := a.kv.Get(uuid)
+		if err != nil {
+			continue
+		}
+		atomic.AddInt32(&matched, 1)
+		s.Lock()
+		result = append(result, item)
+		s.Unlock()
+	}
+
 	for uuid := range a.constants {
 		// Skip deleted items
 		if _, deleted := a.deleted.Load(uuid); deleted {
@@ -490,6 +511,20 @@ func (a *aggregator[T]) Add(ctx context.Context, eval T) (float64, error) {
 
 	if err := a.kv.Set(eval); err != nil {
 		return -1, err
+	}
+
+	if parsed.LiteralBool != nil {
+		if !*parsed.LiteralBool {
+			// This is a constant false expression which never matches.
+			// Skip adding it entirely to avoid unnecessary evaluation.
+			return -1, nil
+		}
+		// This is a constant true expression which always matches.
+		// Add it to the always-true list for fast evaluation without CEL.
+		a.lock.Lock()
+		a.alwaysTrue[parsed.EvaluableID] = struct{}{}
+		a.lock.Unlock()
+		return -1, nil
 	}
 
 	if eval.GetExpression() == "" || parsed.HasMacros {
@@ -739,6 +774,7 @@ func (a *aggregator[T]) GC(ctx context.Context) bool {
 		a.lock.Lock()
 		for _, id := range constantsToDelete {
 			delete(a.constants, id)
+			delete(a.alwaysTrue, id)
 		}
 		for _, id := range mixedToDelete {
 			delete(a.mixed, id)

--- a/vendor/github.com/inngest/expr/parser.go
+++ b/vendor/github.com/inngest/expr/parser.go
@@ -126,11 +126,27 @@ func (p *parser) Parse(ctx context.Context, eval Evaluable) (*ParsedExpression, 
 	}
 
 	node.normalize()
+
+	// Check if the expression is a constant boolean literal (true or false).
+	// A bare literal has no predicates, no ands, no ors after normalization.
+	var literalBool *bool
+	if !node.HasPredicate() && len(node.Ands) == 0 && len(node.Ors) == 0 && !hasMacros {
+		nativeExpr := ast.NativeRep().Expr()
+		if nativeExpr.Kind() == celast.LiteralKind {
+			if val := nativeExpr.AsLiteral(); val != nil {
+				if boolVal, ok := val.Value().(bool); ok {
+					literalBool = &boolVal
+				}
+			}
+		}
+	}
+
 	return &ParsedExpression{
 		Root:        *node,
 		Vars:        vars,
 		EvaluableID: eval.GetID(),
 		HasMacros:   hasMacros,
+		LiteralBool: literalBool,
 	}, nil
 }
 
@@ -154,6 +170,11 @@ type ParsedExpression struct {
 	EvaluableID uuid.UUID
 
 	HasMacros bool
+
+	// LiteralBool is non-nil when the expression is a constant boolean literal.
+	// When false, the expression never matches any input.
+	// When true, the expression always matches any input.
+	LiteralBool *bool
 }
 
 // RootGroups returns the top-level matching groups within an expression.  This is a small
@@ -811,6 +832,12 @@ func parseArrayAccess(item celast.Expr) string {
 		return ""
 	}
 	args := item.AsCall().Args()
+	if len(args) < 2 {
+		return ""
+	}
+	if args[1].Kind() != celast.LiteralKind {
+		return ""
+	}
 	return fmt.Sprintf("%s[%v]", walkSelect(args[0]), args[1].AsLiteral().Value())
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -786,7 +786,7 @@ github.com/hashicorp/hcl/hcl/token
 github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/inngest/expr v0.0.0-20260225032035-443da0a59989
+# github.com/inngest/expr v0.0.0-20260320151211-8abd2c0b8427
 ## explicit; go 1.24
 github.com/inngest/expr
 # github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48


### PR DESCRIPTION
## Description
```
go test -run='^$' -bench='BenchmarkPauseConstant' ./pkg/expressions/expragg/ -benchtime=1000x -benchmem 2>&1  nix-shell-env

goos: darwin
goarch: arm64
pkg: github.com/inngest/inngest/pkg/expressions/expragg
cpu: Apple M4 Max
BenchmarkPauseConstantFalse-14    	    1000	       479.0 ns/op	     745 B/op	      11 allocs/op
BenchmarkPauseConstantTrue-14     	    1000	    126640 ns/op	   18322 B/op	      22 allocs/op
PASS
ok  	github.com/inngest/inngest/pkg/expressions/expragg	0.450s
```

instead of

```
go test -run='^$' -bench='BenchmarkPauseConstant' ./pkg/expressions/expragg/ -benchtime=1000x -benchmem 2>&1
goos: darwin
goarch: arm64
pkg: github.com/inngest/inngest/pkg/expressions/expragg
cpu: Apple M4 Max
BenchmarkPauseConstantFalse-14    	    1000	   7063580 ns/op	17265393 B/op	   86167 allocs/op
BenchmarkPauseConstantTrue-14     	    1000	   6208783 ns/op	17281188 B/op	   86185 allocs/op
PASS
ok  	github.com/inngest/inngest/pkg/expressions/expragg	13.823s

```
## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR optimizes pause evaluation by short-circuiting constant boolean expressions in CEL. Literal `false` expressions are dropped entirely on `Add()`, and literal `true` expressions are tracked in a new `alwaysTrue` map for zero-cost matching during `Evaluate()`. The `inngest/expr` dependency is bumped to pick up the `LiteralBool` field on `ParsedExpression` and a defensive bounds check in `parseArrayAccess`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6d7ea9e58f885e791209fa16cad8ac6c5068fbe2.</sup>
<!-- /MENDRAL_SUMMARY -->