### PR TITLE
chore: expand batch buffer wait metric buckets

### DIFF
--- a/pkg/telemetry/metrics/batch_buffer.go
+++ b/pkg/telemetry/metrics/batch_buffer.go
@@ -5,8 +5,12 @@ import (
 )
 
 var (
-	batchBufferWaitDurationBoundaries = []float64{5, 10, 25, 50, 100, 200, 500, 1000, 2000, 3000, 5000}
-	batchBufferFlushSizeBoundaries    = []float64{1, 2, 5, 10, 20, 50, 100, 200, 500}
+	batchBufferWaitDurationBoundaries = []float64{
+		5, 10, 25, 50, 100, 200, 500, 1000, 2000, 3000, 5000, // <=5s
+		10000, 15000, 30000, 60000, 180000, 300000, // <=5m
+		600000, 1200000, // <= 20m
+	}
+	batchBufferFlushSizeBoundaries = []float64{1, 2, 5, 10, 20, 50, 100, 200, 500}
 )
 
 // #1 - Gauge: items currently in-memory waiting to flush


### PR DESCRIPTION
## Description

chore: expand buffer wait metric buckets

Despite having a max wait time set to 500ms, we regularly see wait times of 5s in `new-runs-highvolume` reported which is the last bucket of the histogram reported value. I suspect the value is higher in practice, expanding the buckets to observe the metric.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*