### PR TITLE
Track kind in spans

### DIFF
--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -36,6 +36,7 @@ func (q *queueProcessor) ProcessItem(
 	defer span.End()
 	span.SetAttributes(attribute.String("partition_id", i.P.ID))
 	span.SetAttributes(attribute.String("item_id", i.I.ID))
+	span.SetAttributes(attribute.String("item_kind", i.I.Data.Kind))
 	span.SetAttributes(attribute.String("run_id", runID.String()))
 	if i.I.Data.JobID != nil {
 		span.SetAttributes(attribute.String("job_id", *i.I.Data.JobID))

--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -133,6 +133,7 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 	ctx, span := p.Queue.Options().ConditionalTracer.NewSpan(ctx, "queue.Process", p.Partition.AccountID, partitionIdentifier.EnvID, partitionIdentifier.FunctionID)
 	defer span.End()
 	span.SetAttributes(attribute.String("partition_id", p.Partition.ID))
+	span.SetAttributes(attribute.String("item_kind", item.Data.Kind))
 	span.SetAttributes(attribute.String("run_id", item.Data.Identifier.RunID.String()))
 	span.SetAttributes(attribute.String("item_id", item.ID))
 	if item.Data.JobID != nil {


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `item_kind` as a span attribute in two queue processing paths (`queueProcessor.ProcessItem` and `ProcessorIterator.Process`) to improve observability of queue item kinds in traces.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit eec56a3cfaa83977c76cbbf3776f1189c640f297.</sup>
<!-- /MENDRAL_SUMMARY -->