### PR TITLE
Make partition ID always available in EnqueueItem

### DIFF
--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -199,7 +199,7 @@ func (q *queue) EnqueueItem(ctx context.Context, i osqueue.QueueItem, at time.Ti
 		shadowPartition = osqueue.ItemShadowPartition(ctx, i)
 	}
 
-	partitionID := shadowPartition.Identifier()
+	partitionID := defaultPartition.Identifier()
 	ctx, span := q.ConditionalTracer.NewSpan(ctx, "queue.EnqueueItem", partitionID.AccountID, partitionID.EnvID, partitionID.FunctionID)
 	defer span.End()
 	span.SetAttributes(attribute.String("partition_id", shadowPartition.PartitionID))


### PR DESCRIPTION
## Description

The partition ID struct containing account/env/fn IDs for the conditional tracking feature flag was pulled from the shadow partition which is only set in case key queues are enabled. This is now changed to getting it from the partition which is always available.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Switches the source of `partitionID` used for tracing span initialization in `EnqueueItem` from `shadowPartition.Identifier()` to `defaultPartition.Identifier()`. The motivation is that `shadowPartition` is only initialized when `enqueueToBacklogs` is true, so the previous code produced empty identifiers for the non-backlog path.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9759f0f350a199d4162b23ef8072bd7262a721d7.</sup>
<!-- /MENDRAL_SUMMARY -->