### PR TITLE
removing chat logic

### DIFF
--- a/ui/apps/support/src/components/Support/AttachmentUploadField.tsx
+++ b/ui/apps/support/src/components/Support/AttachmentUploadField.tsx
@@ -33,7 +33,7 @@ type UseAttachmentUploadOptions = {
 };
 
 export function useAttachmentUpload({
-  context = "chat",
+  context = "emailEntry",
   onError,
 }: UseAttachmentUploadOptions) {
   const getUploadUrlFn = useServerFn(getUploadUrl);

--- a/ui/apps/support/src/data/plain.ts
+++ b/ui/apps/support/src/data/plain.ts
@@ -337,12 +337,7 @@ export type TimeLineEntryEdge = {
           __typename: "MachineUserActor";
           machineUser: { fullName: string };
         };
-    entry:
-      | EmailEntry
-      | CustomEntry
-      | SlackMessageEntry
-      | SlackReplyEntry
-      | ChatEntry;
+    entry: EmailEntry | CustomEntry | SlackMessageEntry | SlackReplyEntry;
   };
 };
 
@@ -450,13 +445,6 @@ type SlackReplyEntry = {
   lastEditedOnSlackAt: DateTime;
 };
 
-type ChatEntry = {
-  __typename: "ChatEntry";
-  chatId: string;
-  /** Aliased as `chatText` in the query to avoid GraphQL type conflict with Slack entries */
-  chatText: string;
-  attachments: Array<Attachment>;
-};
 export const getTimelineEntriesForTicket = createServerFn({ method: "GET" })
   .middleware([authMiddleware])
   .inputValidator((data: { ticketId: string }) => data)
@@ -562,14 +550,6 @@ export const getTimelineEntriesForTicket = createServerFn({ method: "GET" })
                           unixTimestamp
                         }
                       }
-                      ... on ChatEntry {
-                        chatId
-                        chatText: text
-                        attachments {
-                          id
-                          fileName
-                        }
-                      }
                     }
                   }
                 }
@@ -608,8 +588,7 @@ export const getTimelineEntriesForTicket = createServerFn({ method: "GET" })
               typename === "EmailEntry" ||
               typename === "SlackMessageEntry" ||
               // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-              typename === "SlackReplyEntry" ||
-              typename === "ChatEntry"
+              typename === "SlackReplyEntry"
             );
           })
           .sort(
@@ -1256,7 +1235,7 @@ export type AttachmentUploadUrlResult = {
   error?: string;
 };
 
-export type AttachmentUploadContext = "chat" | "customEntry";
+export type AttachmentUploadContext = "emailEntry" | "customEntry";
 
 export const getUploadUrl = createServerFn({ method: "POST" })
   .middleware([authMiddleware])
@@ -1271,7 +1250,7 @@ export const getUploadUrl = createServerFn({ method: "POST" })
     try {
       const userEmail = context.userEmail;
       const { fileName, fileSizeBytes } = data;
-      const uploadContext = data.context || "chat";
+      const uploadContext = data.context || "emailEntry";
 
       // Server-side validation
       // We use a generic MIME check based on extension since we don't have the real MIME here
@@ -1303,7 +1282,7 @@ export const getUploadUrl = createServerFn({ method: "POST" })
       const attachmentType =
         uploadContext === "customEntry"
           ? AttachmentType.CustomTimelineEntry
-          : AttachmentType.Chat;
+          : AttachmentType.Email;
 
       const res = await plainClient.createAttachmentUploadUrl({
         customerId: customer.data.id,

--- a/ui/apps/support/src/routes/_authed/case.$ticketId.tsx
+++ b/ui/apps/support/src/routes/_authed/case.$ticketId.tsx
@@ -441,8 +441,6 @@ function TimelineEntry({
       ? entry.node.entry.components
           .map((component) => component.text)
           .join("\n")
-      : entry.node.entry.__typename === "ChatEntry"
-      ? entry.node.entry.chatText || ""
       : entry.node.entry.text || "";
 
   return (
@@ -517,8 +515,7 @@ function TimelineEntry({
 
         {(entry.node.entry.__typename === "EmailEntry" ||
           entry.node.entry.__typename === "SlackMessageEntry" ||
-          entry.node.entry.__typename === "SlackReplyEntry" ||
-          entry.node.entry.__typename === "ChatEntry") &&
+          entry.node.entry.__typename === "SlackReplyEntry") &&
           entry.node.entry.attachments.length > 0 && (
             <div className="flex flex-row flex-wrap gap-1">
               {entry.node.entry.attachments.map((attachment) => (


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes `ChatEntry` support from the support UI — strips the GraphQL fragment, TypeScript type, timeline rendering logic, and attachment upload context for chat. Updates the default attachment upload context from `"chat"` to `"emailEntry"` and maps non-`customEntry` uploads to `AttachmentType.Email` instead of `AttachmentType.Chat`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d6656203e52af263ba911148d7a16c827cc0d7d0.</sup>
<!-- /MENDRAL_SUMMARY -->