### PR TITLE
Changes the "Attempts" label in the dev server to signify retries

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/StepInfo.test.tsx
+++ b/ui/packages/components/src/RunDetailsV4/StepInfo.test.tsx
@@ -140,12 +140,12 @@ function renderStepInfo(trace: Trace, { debug = false }: { debug?: boolean } = {
 }
 
 describe('StepInfo retry attempt badge', () => {
-  it('renders "Attempt 3" when trace.attempts = 2', () => {
+  it('renders "2 retries" when trace.attempts = 2', () => {
     const trace = makeTrace({ attempts: 2 });
     renderStepInfo(trace);
     const badge = screen.getByTestId('retry-attempt-badge');
     expect(badge).toBeTruthy();
-    expect(badge.textContent).toContain('Attempt 3');
+    expect(badge.textContent).toContain('2 retries');
   });
 
   it('does not render badge when trace.attempts = 0 and status is COMPLETED', () => {
@@ -154,12 +154,10 @@ describe('StepInfo retry attempt badge', () => {
     expect(screen.queryByTestId('retry-attempt-badge')).toBeNull();
   });
 
-  it('renders badge when trace.attempts = 0 and status is FAILED', () => {
+  it('does not render badge when trace.attempts = 0 and status is FAILED', () => {
     const trace = makeTrace({ attempts: 0, status: 'FAILED' });
     renderStepInfo(trace);
-    const badge = screen.getByTestId('retry-attempt-badge');
-    expect(badge).toBeTruthy();
-    expect(badge.textContent).toContain('Attempt 1');
+    expect(screen.queryByTestId('retry-attempt-badge')).toBeNull();
   });
 
   it('does not render badge when trace.attempts = null', () => {
@@ -168,17 +166,17 @@ describe('StepInfo retry attempt badge', () => {
     expect(screen.queryByTestId('retry-attempt-badge')).toBeNull();
   });
 
-  it('shows correct 1-based attempt numbers', () => {
-    // attempts=1 → "Attempt 2"
+  it('shows correct retry labels', () => {
+    // attempts=1 → "1 retry"
     const trace1 = makeTrace({ attempts: 1 });
     const { unmount: unmount1 } = renderStepInfo(trace1);
-    expect(screen.getByTestId('retry-attempt-badge').textContent).toContain('Attempt 2');
+    expect(screen.getByTestId('retry-attempt-badge').textContent).toContain('1 retry');
     unmount1();
 
-    // attempts=5 → "Attempt 6"
+    // attempts=5 → "5 retries"
     const trace5 = makeTrace({ attempts: 5 });
     renderStepInfo(trace5);
-    expect(screen.getByTestId('retry-attempt-badge').textContent).toContain('Attempt 6');
+    expect(screen.getByTestId('retry-attempt-badge').textContent).toContain('5 retries');
   });
 });
 

--- a/ui/packages/components/src/RunDetailsV4/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/StepInfo.tsx
@@ -271,14 +271,14 @@ export const StepInfo = ({
           />
 
           <span className="text-basis text-sm font-normal">{trace.name}</span>
-          {trace.attempts !== null && (trace.attempts > 0 || trace.status === 'FAILED') && (
+          {trace.attempts !== null && trace.attempts > 0 && (
             <span data-testid="retry-attempt-badge">
               <Pill
                 className={`${getStatusBackgroundClass(trace.status)} ${getStatusTextClass(
                   trace.status
                 )}`}
               >
-                Attempt {trace.attempts + 1}
+                {trace.attempts} {trace.attempts === 1 ? 'retry' : 'retries'}
               </Pill>
             </span>
           )}


### PR DESCRIPTION
## Description

Used to be "Attempts: x" now it's "x retries" because the header already has attempts in the title

## Motivation
EXE-1446
<img width="2547" height="747" alt="Screenshot 2026-03-24 at 1 04 03 PM" src="https://github.com/user-attachments/assets/bf4f11df-af0a-4045-8d0d-2790b7a4fe84" />


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Changes the retry attempt badge in the dev server UI from "Attempt N" (1-based) to "N retries" (0-based count), and removes the badge for failed steps with 0 attempts.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ad2aa62f01997e678f58fad0a74eafbb588fba79.</sup>
<!-- /MENDRAL_SUMMARY -->