### PR TITLE
Report started runs as Runs volume on functions page

### DIFF
--- a/ui/apps/dashboard/src/components/Functions/useFunctions.ts
+++ b/ui/apps/dashboard/src/components/Functions/useFunctions.ts
@@ -117,7 +117,7 @@ export function useFunctionVolume() {
 
       const usage = {
         dailyVolumeSlots,
-        totalVolume: dailyFinishedCount,
+        totalVolume: workflow.dailyStarts.total,
       };
 
       return {


### PR DESCRIPTION
## Description

This will match users' mental model with the events count on the events
page more accurately.

Also, `function_run_ended_total` is currently inaccurate if you have
a parallel call at the end of your function, as multiple parallel discovery steps can
hit the OnFinished lifecycle hook. We will need to fix the idempotency
of this in a followup

https://github.com/inngest/inngest/blob/21e5b63bc8566f7b407029a1ad40c51a1689d13c/pkg/execution/executor/executor.go#L1898-L1901

https://github.com/inngest/inngest/blob/21e5b63bc8566f7b407029a1ad40c51a1689d13c/pkg/execution/executor/executor.go#L1957-L1960

https://github.com/inngest/inngest/blob/21e5b63bc8566f7b407029a1ad40c51a1689d13c/pkg/execution/executor/executor.go#L1987-L1990

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Switches the "Runs volume" total on the functions page from `dailyFinishedCount` (completed + cancelled + failed) to `workflow.dailyStarts.total`, aligning the displayed total with the per-slot `startCount` already used in `dailyVolumeSlots` and fixing overcounting caused by the `OnFinished` hook firing multiple times for parallel steps.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 58199d5bf46ee70b1e5e7712a96872c24474ca76.</sup>
<!-- /MENDRAL_SUMMARY -->