### PR TITLE
Use functions started as runs volume on function detail page

### DIFF
--- a/ui/apps/dashboard/src/components/Functions/FunctionRunsChart.tsx
+++ b/ui/apps/dashboard/src/components/Functions/FunctionRunsChart.tsx
@@ -4,7 +4,11 @@ import StackedBarChart from '@/components/Charts/StackedBarChart';
 import { useEnvironment } from '@/components/Environments/environment-context';
 import { graphql } from '@/gql';
 
-export type UsageMetrics = { totalRuns: number; totalFailures: number };
+export type UsageMetrics = {
+  totalRuns: number;
+  totalFinished: number;
+  totalFailures: number;
+};
 
 const GetFunctionRunsMetricsDocument = graphql(`
   query GetFunctionRunsMetrics(

--- a/ui/apps/dashboard/src/queries/functions.ts
+++ b/ui/apps/dashboard/src/queries/functions.ts
@@ -335,6 +335,7 @@ type UsageItem = {
   name: string;
   values: {
     totalRuns: number;
+    totalFinished: number;
     successes: number;
     failures: number;
   };
@@ -369,12 +370,13 @@ export const useFunctionUsage = ({
   // Combine usage arrays into single array
   let usage: UsageItem[] = [];
 
+  const started = data?.workspace.workflow?.dailyStarts;
   const completed = data?.workspace.workflow?.dailyCompleted;
   const cancelled = data?.workspace.workflow?.dailyCancelled;
   const failed = data?.workspace.workflow?.dailyFailures;
 
-  if (completed && cancelled && failed) {
-    usage = completed.data.map((d, idx) => {
+  if (started && completed && cancelled && failed) {
+    usage = started.data.map((d, idx) => {
       const failureCount = failed.data[idx]?.count || 0;
       const finishedCount =
         (completed.data[idx]?.count || 0) +
@@ -384,7 +386,8 @@ export const useFunctionUsage = ({
       return {
         name: d.slot,
         values: {
-          totalRuns: finishedCount,
+          totalRuns: d.count,
+          totalFinished: finishedCount,
           successes: finishedCount - failureCount,
           failures: failureCount,
         },

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/functions/$slug/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/functions/$slug/index.tsx
@@ -101,19 +101,22 @@ function RouteComponent() {
   const usageMetrics: UsageMetrics | undefined = usage?.reduce(
     (acc, u) => {
       acc.totalRuns += u.values.totalRuns;
+      acc.totalFinished += u.values.totalFinished;
       acc.totalFailures += u.values.failures;
       return acc;
     },
     {
       totalRuns: 0,
+      totalFinished: 0,
       totalFailures: 0,
     },
   );
 
-  const failureRate = !usageMetrics?.totalRuns
+  const failureRate = !usageMetrics?.totalFinished
     ? '0.00'
     : (
-        ((usageMetrics.totalFailures || 0) / (usageMetrics.totalRuns || 0)) *
+        ((usageMetrics.totalFailures || 0) /
+          (usageMetrics.totalFinished || 0)) *
         100
       ).toFixed(2);
 


### PR DESCRIPTION
## Description

This makes it more consistent with https://github.com/inngest/inngest/pull/3880 which was an incomplete fix.

TL;DR we want to use functions started as the count since it matches user intuition better as well as hides an overcounting issue we have with the functions ended metric for parallel steps.

Side note, it looks this hook builds up bucketed data (d.slot), but we end up not using the bucketed data at all and just sum into the total. So we could either simplify this by removing the bucketing, or share the query with the chart on the functions page which does depend on the bucketing and currently goes through a different code path

<img width="516" height="170" alt="image" src="https://github.com/user-attachments/assets/1fbda336-fdd7-4a94-85fd-9e0c5aecc8ca" />


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Separates "started" runs from "finished" runs in the function detail page metrics, using `dailyStarts` as the volume count and computing failure rate against `totalFinished` instead of `totalRuns`. This fixes an overcounting issue with parallel steps and aligns with PR #3880.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 31bf465dd70e486c685d4732635289bb76fdadc9.</sup>
<!-- /MENDRAL_SUMMARY -->