### PR TITLE
Extended Traces: Handle step attributes in userland spans

### DIFF
--- a/pkg/api/apiv1/traces.go
+++ b/pkg/api/apiv1/traces.go
@@ -236,6 +236,60 @@ func (a router) commitSpan(ctx context.Context, l logger.Logger, auth apiv1auth.
 		meta.Attr(meta.Attrs.EnvID, util.ToPtr(auth.WorkspaceID())),
 	)
 
+	// By default, the parent span is the trace ref we found.
+	parent := tr
+
+	if (scope.Name != "inngest" || s.Name != "inngest.execution") && len(s.ParentSpanId) == 12 {
+		// If this is not the "root" span created by an SDK, we need to listen to
+		// the parent span ID that they have set so we can preserve whatever
+		// lineage they're passing us.
+		parent, err = tr.SetParentSpanID(trace.SpanID(s.ParentSpanId))
+		if err != nil {
+			return fmt.Errorf("failed to set parent span ID: %w", err)
+		}
+	}
+
+	// Filter out/handle special inngest-defined attributes sent from the SDK
+	var userAttrs []attribute.KeyValue
+	for _, kv := range attrs {
+		switch kv.Key {
+		case consts.OtelAttrSDKRunID:
+		case consts.OtelSysFunctionID:
+		case consts.OtelSysAppID:
+		case "inngest.traceparent":
+		case "inngest.traceref":
+		case "inngest.step.parentSpanId":
+			// If the SDK has set a deterministic step parent span ID (used during
+			// checkpointing to match the executor.step span), use it to override
+			// the parent so userland spans are correctly parented under their step.
+
+			sid, sidErr := trace.SpanIDFromHex(kv.Value.AsString())
+			if sidErr == nil {
+				parent, err = tr.SetParentSpanID(sid)
+				if err != nil {
+					return fmt.Errorf("failed to set step parent span ID: %w", err)
+				}
+			}
+		case "inngest.step.id":
+			stepID := kv.Value.AsString()
+			meta.AddAttr(tenantAttrs, meta.Attrs.StepUserlandID, &stepID)
+		case "inngest.step.index":
+			stepIndex := int(kv.Value.AsInt64())
+			meta.AddAttr(tenantAttrs, meta.Attrs.StepUserlandIndex, &stepIndex)
+		case "inngest.step.hash":
+			stepHash := kv.Value.AsString()
+			meta.AddAttr(tenantAttrs, meta.Attrs.StepID, &stepHash)
+		case "inngest.step.attempt":
+			stepAttempt := int(kv.Value.AsInt64())
+			meta.AddAttr(tenantAttrs, meta.Attrs.StepAttempt, &stepAttempt)
+		default:
+			userAttrs = append(userAttrs, kv)
+		}
+	}
+
+	// Use attrs with inngest-specific attrs filtered out that would otherwise be duplicated
+	attrs = userAttrs
+
 	ourAttrs := meta.NewAttrSet(
 		meta.Attr(meta.Attrs.IsUserland, &isUserland),
 		meta.Attr(meta.Attrs.UserlandSpanID, &spanID),
@@ -250,35 +304,6 @@ func (a router) commitSpan(ctx context.Context, l logger.Logger, auth apiv1auth.
 
 	// Add some additional attributes on top
 	attrs = append(attrs, ourAttrs.Serialize()...)
-
-	// By default, the parent span is the trace ref we found.
-	parent := tr
-
-	if (scope.Name != "inngest" || s.Name != "inngest.execution") && len(s.ParentSpanId) == 12 {
-		// If this is not the "root" span created by an SDK, we need to listen to
-		// the parent span ID that they have set so we can preserve whatever
-		// lineage they're passing us.
-		parent, err = tr.SetParentSpanID(trace.SpanID(s.ParentSpanId))
-		if err != nil {
-			return fmt.Errorf("failed to set parent span ID: %w", err)
-		}
-	}
-
-	// If the SDK has set a deterministic step parent span ID (used during
-	// checkpointing to match the executor.step span), use it to override
-	// the parent so userland spans are correctly parented under their step.
-	for _, kv := range s.Attributes {
-		if kv.Key == "inngest.step.parentSpanId" {
-			sid, sidErr := trace.SpanIDFromHex(kv.GetValue().GetStringValue())
-			if sidErr == nil {
-				parent, err = tr.SetParentSpanID(sid)
-				if err != nil {
-					return fmt.Errorf("failed to set step parent span ID: %w", err)
-				}
-			}
-			break
-		}
-	}
 
 	span, err := a.opts.TracerProvider.CreateSpan(ctx, meta.SpanNameUserland, &tracing.CreateSpanOptions{
 		Debug:              &tracing.SpanDebugData{Location: "apiv1.traces.commitSpan"},

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
@@ -492,7 +492,7 @@ WHERE span_id IN (
   SELECT
     parent_span_id
   FROM spans execSpans
-  WHERE execSpans.run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND execSpans.account_id = sqlc.arg(account_id)
+  WHERE execSpans.run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND execSpans.account_id = sqlc.arg(account_id) AND name != 'userland'
   GROUP BY dynamic_span_id, parent_span_id
   HAVING
     SUM(((attributes#>>'{}')::json->>'_inngest.step.id' = sqlc.arg(step_id)::text)::int) > 0
@@ -500,7 +500,7 @@ WHERE span_id IN (
     SUM((name = 'executor.execution')::int) > 0
   ORDER BY MIN(start_time)
   LIMIT 1
-)
+) AND name != 'userland'
 GROUP BY dynamic_span_id, run_id, trace_id, parent_span_id
 HAVING SUM((name = 'executor.step.discovery')::int) > 0
 UNION ALL
@@ -519,7 +519,7 @@ SELECT
     'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
   )) AS span_fragments
 FROM spans
-WHERE run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND account_id = sqlc.arg(account_id)
+WHERE run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND account_id = sqlc.arg(account_id) AND name != 'userland'
 GROUP BY dynamic_span_id, run_id, trace_id, parent_span_id
 HAVING
   SUM(((attributes#>>'{}')::json->>'_inngest.step.id' = sqlc.arg(step_id)::text)::int) > 0
@@ -544,7 +544,7 @@ SELECT
     'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
   )) AS span_fragments
 FROM spans
-WHERE run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND account_id = sqlc.arg(account_id)
+WHERE run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND account_id = sqlc.arg(account_id) AND name != 'userland'
 GROUP BY dynamic_span_id, run_id, trace_id, parent_span_id
 HAVING
   SUM(((attributes#>>'{}')::json->>'_inngest.step.id' = sqlc.arg(step_id)::text)::int) > 0
@@ -571,7 +571,7 @@ SELECT
     'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
   )) AS span_fragments
 FROM spans b
-WHERE b.run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND b.account_id = sqlc.arg(account_id)
+WHERE b.run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND b.account_id = sqlc.arg(account_id) AND b.name != 'userland'
 GROUP BY dynamic_span_id, run_id, trace_id, parent_span_id
 HAVING
   SUM(((attributes#>>'{}')::json->>'_inngest.step.id' = sqlc.arg(step_id)::text)::int) > 0

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql.go
@@ -548,7 +548,7 @@ SELECT
     'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
   )) AS span_fragments
 FROM spans
-WHERE run_id = CAST($1 AS CHAR(26)) AND account_id = $2
+WHERE run_id = CAST($1 AS CHAR(26)) AND account_id = $2 AND name != 'userland'
 GROUP BY dynamic_span_id, run_id, trace_id, parent_span_id
 HAVING
   SUM(((attributes#>>'{}')::json->>'_inngest.step.id' = $3::text)::int) > 0
@@ -1016,7 +1016,7 @@ SELECT
     'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
   )) AS span_fragments
 FROM spans b
-WHERE b.run_id = CAST($1 AS CHAR(26)) AND b.account_id = $2
+WHERE b.run_id = CAST($1 AS CHAR(26)) AND b.account_id = $2 AND b.name != 'userland'
 GROUP BY dynamic_span_id, run_id, trace_id, parent_span_id
 HAVING
   SUM(((attributes#>>'{}')::json->>'_inngest.step.id' = $3::text)::int) > 0
@@ -1490,7 +1490,7 @@ WHERE span_id IN (
   SELECT
     parent_span_id
   FROM spans execSpans
-  WHERE execSpans.run_id = CAST($1 AS CHAR(26)) AND execSpans.account_id = $2
+  WHERE execSpans.run_id = CAST($1 AS CHAR(26)) AND execSpans.account_id = $2 AND name != 'userland'
   GROUP BY dynamic_span_id, parent_span_id
   HAVING
     SUM(((attributes#>>'{}')::json->>'_inngest.step.id' = $3::text)::int) > 0
@@ -1498,7 +1498,7 @@ WHERE span_id IN (
     SUM((name = 'executor.execution')::int) > 0
   ORDER BY MIN(start_time)
   LIMIT 1
-)
+) AND name != 'userland'
 GROUP BY dynamic_span_id, run_id, trace_id, parent_span_id
 HAVING SUM((name = 'executor.step.discovery')::int) > 0
 UNION ALL
@@ -1517,7 +1517,7 @@ SELECT
     'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
   )) AS span_fragments
 FROM spans
-WHERE run_id = CAST($1 AS CHAR(26)) AND account_id = $2
+WHERE run_id = CAST($1 AS CHAR(26)) AND account_id = $2 AND name != 'userland'
 GROUP BY dynamic_span_id, run_id, trace_id, parent_span_id
 HAVING
   SUM(((attributes#>>'{}')::json->>'_inngest.step.id' = $3::text)::int) > 0

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
@@ -462,7 +462,7 @@ WHERE span_id IN (
   SELECT
     parent_span_id
   FROM spans execSpans
-  WHERE execSpans.run_id = sqlc.arg(run_id) AND execSpans.account_id = sqlc.arg(account_id)
+  WHERE execSpans.run_id = sqlc.arg(run_id) AND execSpans.account_id = sqlc.arg(account_id) AND name != 'userland'
   GROUP BY dynamic_span_id
   HAVING
     SUM(attributes->>'$."_inngest.step.id"' = CAST(sqlc.arg(step_id) AS TEXT)) > 0
@@ -470,7 +470,7 @@ WHERE span_id IN (
     SUM(name = 'executor.execution') > 0
   ORDER BY start_time
   LIMIT 1
-)
+) AND name != 'userland'
 GROUP BY dynamic_span_id
 HAVING SUM(name = 'executor.step.discovery') > 0
 UNION ALL
@@ -489,7 +489,7 @@ SELECT
     'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
   )) AS span_fragments
 FROM spans
-WHERE run_id = sqlc.arg(run_id) AND account_id = sqlc.arg(account_id)
+WHERE run_id = sqlc.arg(run_id) AND account_id = sqlc.arg(account_id) AND name != 'userland'
 GROUP BY dynamic_span_id
 HAVING
   SUM(attributes->>'$."_inngest.step.id"' = CAST(sqlc.arg(step_id) AS TEXT)) > 0
@@ -514,7 +514,7 @@ SELECT
     'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
   )) AS span_fragments
 FROM spans
-WHERE run_id = ? AND account_id = ?
+WHERE run_id = ? AND account_id = ? AND name != 'userland'
 GROUP BY dynamic_span_id
 HAVING
   SUM(attributes->>'$."_inngest.step.id"' = CAST(sqlc.arg(step_id) AS TEXT)) > 0
@@ -541,7 +541,7 @@ SELECT
     'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
   )) AS span_fragments
 FROM spans b
-WHERE b.run_id = sqlc.arg(run_id) AND b.account_id = sqlc.arg(account_id)
+WHERE b.run_id = sqlc.arg(run_id) AND b.account_id = sqlc.arg(account_id) AND b.name != 'userland'
 GROUP BY dynamic_span_id
 HAVING
   SUM(attributes->>'$."_inngest.step.id"' = CAST(sqlc.arg(step_id) AS TEXT)) > 0

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql.go
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql.go
@@ -571,7 +571,7 @@ SELECT
     'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
   )) AS span_fragments
 FROM spans
-WHERE run_id = ? AND account_id = ?
+WHERE run_id = ? AND account_id = ? AND name != 'userland'
 GROUP BY dynamic_span_id
 HAVING
   SUM(attributes->>'$."_inngest.step.id"' = CAST(?3 AS TEXT)) > 0
@@ -1046,7 +1046,7 @@ SELECT
     'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
   )) AS span_fragments
 FROM spans b
-WHERE b.run_id = ?1 AND b.account_id = ?2
+WHERE b.run_id = ?1 AND b.account_id = ?2 AND b.name != 'userland'
 GROUP BY dynamic_span_id
 HAVING
   SUM(attributes->>'$."_inngest.step.id"' = CAST(?3 AS TEXT)) > 0
@@ -1526,7 +1526,7 @@ WHERE span_id IN (
   SELECT
     parent_span_id
   FROM spans execSpans
-  WHERE execSpans.run_id = ?1 AND execSpans.account_id = ?2
+  WHERE execSpans.run_id = ?1 AND execSpans.account_id = ?2 AND name != 'userland'
   GROUP BY dynamic_span_id
   HAVING
     SUM(attributes->>'$."_inngest.step.id"' = CAST(?3 AS TEXT)) > 0
@@ -1534,7 +1534,7 @@ WHERE span_id IN (
     SUM(name = 'executor.execution') > 0
   ORDER BY start_time
   LIMIT 1
-)
+) AND name != 'userland'
 GROUP BY dynamic_span_id
 HAVING SUM(name = 'executor.step.discovery') > 0
 UNION ALL
@@ -1553,7 +1553,7 @@ SELECT
     'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
   )) AS span_fragments
 FROM spans
-WHERE run_id = ?1 AND account_id = ?2
+WHERE run_id = ?1 AND account_id = ?2 AND name != 'userland'
 GROUP BY dynamic_span_id
 HAVING
   SUM(attributes->>'$."_inngest.step.id"' = CAST(?3 AS TEXT)) > 0


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

This handles the new attributes added in https://github.com/inngest/inngest-js/pull/1412 so that we can attach the extended trace spans more efficiently to steps for Insights.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

We want to be able to easily attach extended trace spans to their parent step for Insights querying.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR handles new step attributes (`inngest.step.id`, `inngest.step.index`, `inngest.step.hash`, `inngest.step.attempt`) sent from the SDK in userland spans. In `commitSpan`, it filters these out of the raw OTel attribute list and maps them into `tenantAttrs` before merging into `ourAttrs`. It also adds `AND name != 'userland'` to all step-lookup SQL queries to prevent userland spans from being incorrectly matched as executor spans.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 62dbaba254fc7d750ab244a22d41cdf2bf2ee609.</sup>
<!-- /MENDRAL_SUMMARY -->