### PR TITLE
Step Metadata: Collapse step/step_attempt behavior

### DIFF
--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -99,7 +99,7 @@ type RunMetadataTarget struct {
 	StepID *string `json:"step_id"`
 	// StepIndex == nil is equivalent to StepIndex == 0
 	StepIndex *int `json:"step_index"`
-	// When StepAttempt == -1, select the last attempt
+	// When StepAttempt == -1 (legacy) or nil, select the last attempt
 	StepAttempt *int    `json:"step_attempt"`
 	SpanID      *string `json:"span_id"`
 }
@@ -175,14 +175,11 @@ func (a router) getParentSpan(ctx context.Context, auth apiv1auth.V1Auth, runID 
 			stepID = hex.EncodeToString(sum[:])
 		}
 
-		if target.StepAttempt == nil {
+		if target.StepAttempt == nil || *target.StepAttempt < 0 {
 			scope = enums.MetadataScopeStep
-			span, err = a.opts.TraceReader.GetStepSpanByStepID(ctx, runID, stepID, auth.AccountID(), auth.WorkspaceID())
-		} else if *target.StepAttempt < 0 {
-			scope = enums.MetadataScopeStepAttempt
 			span, err = a.opts.TraceReader.GetLatestExecutionSpanByStepID(ctx, runID, stepID, auth.AccountID(), auth.WorkspaceID())
 		} else {
-			scope = enums.MetadataScopeStepAttempt
+			scope = enums.MetadataScopeStep
 			span, err = a.opts.TraceReader.GetExecutionSpanByStepIDAndAttempt(ctx, runID, stepID, *target.StepAttempt, auth.AccountID(), auth.WorkspaceID())
 		}
 	default:

--- a/pkg/enums/metadata_scope.go
+++ b/pkg/enums/metadata_scope.go
@@ -7,6 +7,8 @@ const (
 	MetadataScopeUnknown MetadataScope = iota
 	MetadataScopeRun
 	MetadataScopeStep
+	// NOTE: StepAttempt scope is legacy now and should be treated as step scope.
+	// We keep it here for backward compatibility with old metadata that was written with this scope.
 	MetadataScopeStepAttempt
 	MetadataScopeExtendedTrace
 )

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -5320,9 +5320,7 @@ func (e *executor) createMetadataSpan(ctx context.Context, runCtx execution.RunC
 	switch scope {
 	case enums.MetadataScopeRun:
 		parent = tracing.RunSpanRefFromMetadata(runCtx.Metadata())
-	case enums.MetadataScopeStep:
-		parent = runCtx.ParentSpan()
-	case enums.MetadataScopeStepAttempt:
+	case enums.MetadataScopeStep, enums.MetadataScopeStepAttempt:
 		parent = runCtx.ExecutionSpan()
 	default:
 		return nil, fmt.Errorf("unknown metadata scope: %s", scope)


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

This collapses step/step_attempt handling to attach all step-related metadata to an execution span.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

To simplify Insights work, we're removing the concept of step-scoped metadata (attached to the parent of multiple attempts) and making all "step" metadata attached to the individual attempt. We're using the "step" scope enum for this though for simplicity.

EXE-1530

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Collapses the distinction between `MetadataScopeStep` (step-level parent span) and `MetadataScopeStepAttempt` (execution/attempt span) so that all step metadata is now attached to the individual attempt span (`ExecutionSpan()`). The API layer is updated to treat `StepAttempt == nil` and `StepAttempt < 0` identically (both resolve to the latest execution span), and the `MetadataScopeStepAttempt` enum value is preserved with a legacy comment for backward compatibility with existing stored metadata.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 37737db8a81b61b7d11a0520561723aee0d25bc2.</sup>
<!-- /MENDRAL_SUMMARY -->