### PR TITLE
Pub/Sub adapter pattern for multi-backend support

### DIFF
--- a/pkg/pubsub/ADAPTER_PLAN.md
+++ b/pkg/pubsub/ADAPTER_PLAN.md
@@ -1,0 +1,373 @@
+# Pub/Sub Adapter Pattern — Implementation Plan
+
+## Problem Statement
+
+The current pub/sub implementation is tightly coupled to `gocloud.dev/pubsub` via URL-based
+routing (`URLMux`). This creates several limitations:
+
+1. **Every backend must have a gocloud.dev driver** — rules out Kafka entirely, limits advanced
+   features of NATS JetStream, SQS, and RabbitMQ.
+2. **`NatsConnector` already bypasses the abstraction** — it implements its own publish/subscribe
+   with JetStream but doesn't satisfy the `Publisher`/`Subscriber` interfaces, proving the
+   current abstraction is insufficient.
+3. **`TopicURLCreator` is a URL formatter, not an adapter** — it can't express consumer groups,
+   partition keys, routing keys, visibility timeouts, or ordering keys.
+4. **No lifecycle management** — no `Close()` or `Healthy()` on the core interfaces.
+5. **Hard-coded backend `switch`** in `config/messaging.go` — adding a backend means editing
+   shared code.
+6. **Concurrency, ack/nack, and retry logic are baked into the single `broker` struct** — not
+   reusable or overridable per backend.
+
+## Goals
+
+- Define a clean `Adapter` interface that each backend implements directly.
+- Support Kafka (via **franz-go**), NATS/JetStream, AWS SQS, GCP Pub/Sub, RabbitMQ, and
+  in-memory (testing) without lowest-common-denominator compromises.
+- Give each adapter full control over connections, consumer groups, ack/nack, and concurrency.
+- Make the system extensible via a self-registering factory (no hard-coded switch).
+- Enable cross-cutting concerns (metrics, tracing, retry) via middleware decorators.
+- Preserve backward compatibility during migration.
+
+## Design
+
+### Core Interfaces (`pkg/pubsub/adapter.go`)
+
+```go
+// Adapter is the primary interface every pub/sub backend implements.
+type Adapter interface {
+    // Publish sends a message to the named topic.
+    Publish(ctx context.Context, topic string, msg Message) error
+
+    // Subscribe consumes messages from a topic, calling handler for each.
+    // It blocks until ctx is cancelled. Options control concurrency,
+    // consumer groups, etc.
+    Subscribe(ctx context.Context, topic string, handler HandlerFunc, opts ...SubscribeOption) error
+
+    // Close gracefully shuts down the adapter, flushing in-flight messages.
+    Close(ctx context.Context) error
+
+    // Healthy returns nil if the adapter is connected and operational.
+    Healthy(ctx context.Context) error
+}
+```
+
+### Message Type (`pkg/pubsub/message.go`)
+
+```go
+type Message struct {
+    // Core fields (always used)
+    ID        string            `json:"id,omitempty"`
+    Name      string            `json:"name"`
+    Version   int               `json:"v"`
+    Data      []byte            `json:"data"`
+    Timestamp time.Time         `json:"ts"`
+    Metadata  map[string]string `json:"meta,omitempty"`
+
+    // Backend hints — adapters use what they support, ignore the rest.
+    // These are not serialized; they're set in-process before Publish().
+    PartitionKey string        `json:"-"` // Kafka partition, SQS message group ID
+    OrderingKey  string        `json:"-"` // GCP Pub/Sub ordering key
+    RoutingKey   string        `json:"-"` // RabbitMQ routing key
+    Delay        time.Duration `json:"-"` // SQS delay, RabbitMQ delayed message
+    Headers      map[string]string `json:"-"` // Kafka headers, RabbitMQ headers, NATS headers
+}
+```
+
+Key change: `Data` is `[]byte` instead of `string`. The encoding strategy (JSON, protobuf,
+msgpack) is the caller's responsibility, not the adapter's.
+
+### Handler and Ack (`pkg/pubsub/handler.go`)
+
+```go
+// HandlerFunc processes a received message. The Acknowledger gives the handler
+// explicit control over ack/nack/requeue.
+type HandlerFunc func(ctx context.Context, msg Message, ack Acknowledger)
+
+// Acknowledger provides explicit message acknowledgment control.
+type Acknowledger interface {
+    Ack()
+    Nack()
+    // Requeue returns the message to the queue with an optional delay.
+    // Backends that don't support delay will ignore it.
+    Requeue(delay time.Duration)
+}
+```
+
+The current design infers ack/nack from the handler's error return. Explicit ack gives handlers
+control over partial processing, dead-letter routing, and delayed requeue.
+
+### Subscribe Options (`pkg/pubsub/options.go`)
+
+```go
+type SubscribeConfig struct {
+    Concurrency   int
+    ConsumerGroup string        // Kafka consumer group, NATS queue group, SQS queue
+    AckDeadline   time.Duration // How long before unacked messages are redelivered
+    MaxRetries    int           // Backend-level retry count (0 = backend default)
+    StartOffset   StartOffset   // Kafka: earliest/latest; NATS: deliver new/all
+}
+
+type StartOffset int
+const (
+    OffsetDefault StartOffset = iota
+    OffsetEarliest
+    OffsetLatest
+)
+
+type SubscribeOption func(*SubscribeConfig)
+
+func WithConcurrency(n int) SubscribeOption { ... }
+func WithConsumerGroup(group string) SubscribeOption { ... }
+func WithAckDeadline(d time.Duration) SubscribeOption { ... }
+func WithMaxRetries(n int) SubscribeOption { ... }
+func WithStartOffset(o StartOffset) SubscribeOption { ... }
+```
+
+### Adapter Registry (`pkg/pubsub/registry.go`)
+
+```go
+// AdapterFactory creates an adapter from backend-specific config.
+type AdapterFactory func(ctx context.Context, cfg json.RawMessage) (Adapter, error)
+
+var (
+    mu       sync.RWMutex
+    registry = map[string]AdapterFactory{}
+)
+
+// Register makes a backend available by name. Called from init().
+func Register(name string, factory AdapterFactory) {
+    mu.Lock()
+    defer mu.Unlock()
+    registry[name] = factory
+}
+
+// NewAdapter creates an adapter for the named backend.
+func NewAdapter(ctx context.Context, backend string, cfg json.RawMessage) (Adapter, error) {
+    mu.RLock()
+    factory, ok := registry[backend]
+    mu.RUnlock()
+    if !ok {
+        return nil, fmt.Errorf("unknown pubsub backend: %s", backend)
+    }
+    return factory(ctx, cfg)
+}
+```
+
+Each adapter package registers itself:
+```go
+// In adapters/kafka/kafka.go
+func init() {
+    pubsub.Register("kafka", New)
+}
+```
+
+### Middleware (`pkg/pubsub/middleware/`)
+
+```go
+type Middleware func(Adapter) Adapter
+
+// Compose applies middleware in order (outermost first).
+func Compose(adapter Adapter, mw ...Middleware) Adapter {
+    for i := len(mw) - 1; i >= 0; i-- {
+        adapter = mw[i](adapter)
+    }
+    return adapter
+}
+```
+
+Initial middleware:
+- **`WithLogging`** — log publish/subscribe events, errors.
+- **`WithMetrics`** — publish/subscribe counters, latency histograms.
+- **`WithTracing`** — OpenTelemetry span propagation.
+
+### Concurrency Helper (`pkg/pubsub/concurrency.go`)
+
+The weighted-semaphore pattern currently in `broker.go` is good. Extract it as a reusable
+helper that adapters can optionally use:
+
+```go
+// ConcurrentSubscriber wraps a base receive loop with semaphore-based concurrency.
+// Adapters that don't need custom concurrency can delegate to this.
+func ConcurrentSubscriber(
+    ctx context.Context,
+    concurrency int,
+    receive func(ctx context.Context) (Message, Acknowledger, error),
+    handler HandlerFunc,
+) error { ... }
+```
+
+## Adapter Implementations
+
+### 1. In-Memory (`pkg/pubsub/adapters/memory/`)
+
+- For testing and single-process dev server.
+- Channel-based fan-out per topic.
+- No external dependencies.
+
+### 2. NATS / JetStream (`pkg/pubsub/adapters/nats/`)
+
+- Unifies the current `broker` (via gocloud.dev) and `NatsConnector` into a single adapter.
+- Core NATS for fire-and-forget, JetStream for durable subscriptions.
+- Maps `ConsumerGroup` → NATS queue group / JetStream durable consumer.
+- Maps `Headers` → NATS message headers.
+- Uses existing `nats.go` and `nats.go/jetstream` packages.
+
+Config:
+```go
+type Config struct {
+    URLs       string `json:"urls"`
+    JetStream  bool   `json:"jetstream"`
+    StreamName string `json:"stream_name,omitempty"`
+}
+```
+
+### 3. Kafka (`pkg/pubsub/adapters/kafka/`)
+
+- Uses **franz-go** (`github.com/twmb/franz-go`) — most complete Kafka protocol implementation.
+- Maps `PartitionKey` → Kafka record key.
+- Maps `ConsumerGroup` → Kafka consumer group.
+- Maps `Headers` → Kafka record headers.
+- Maps `StartOffset` → `kgo.ConsumeResetOffset`.
+- Supports batch consumption internally, dispatches to handler per-record.
+
+Config:
+```go
+type Config struct {
+    Brokers       []string `json:"brokers"`
+    TLS           bool     `json:"tls"`
+    SASLMechanism string   `json:"sasl_mechanism,omitempty"` // PLAIN, SCRAM-SHA-256, SCRAM-SHA-512
+    SASLUser      string   `json:"sasl_user,omitempty"`
+    SASLPass      string   `json:"sasl_pass,omitempty"`
+}
+```
+
+### 4. AWS SQS (`pkg/pubsub/adapters/sqs/`)
+
+- Uses `aws-sdk-go-v2`.
+- Maps `PartitionKey` → SQS `MessageGroupId` (FIFO queues).
+- Maps `Delay` → `DelaySeconds`.
+- Maps `Ack` → `DeleteMessage`, `Nack` → no-op (visibility timeout expires), `Requeue` → `ChangeMessageVisibility`.
+- Publish goes to SNS topic or directly to SQS queue (configurable).
+
+Config:
+```go
+type Config struct {
+    Region   string `json:"region"`
+    QueueURL string `json:"queue_url"`
+    // Optional: publish to SNS topic instead of directly to SQS
+    TopicARN string `json:"topic_arn,omitempty"`
+}
+```
+
+### 5. GCP Pub/Sub (`pkg/pubsub/adapters/gcppubsub/`)
+
+- Uses `cloud.google.com/go/pubsub`.
+- Maps `OrderingKey` → GCP ordering key.
+- Maps `ConsumerGroup` → GCP subscription name.
+- Maps `Ack`/`Nack` → native GCP ack/nack.
+
+Config:
+```go
+type Config struct {
+    ProjectID      string `json:"project_id"`
+    SubscriptionID string `json:"subscription_id,omitempty"`
+}
+```
+
+### 6. RabbitMQ (`pkg/pubsub/adapters/rabbitmq/`)
+
+- Uses `github.com/rabbitmq/amqp091-go`.
+- Maps `RoutingKey` → AMQP routing key.
+- Maps `Headers` → AMQP headers (for header-based routing).
+- Maps `Ack`/`Nack`/`Requeue` → AMQP ack/nack/reject with requeue.
+- Configurable exchange type (direct, topic, fanout, headers).
+
+Config:
+```go
+type Config struct {
+    URL          string `json:"url"` // amqp://user:pass@host:5672/vhost
+    ExchangeName string `json:"exchange_name"`
+    ExchangeType string `json:"exchange_type"` // direct, topic, fanout, headers
+    QueueName    string `json:"queue_name,omitempty"`
+    Durable      bool   `json:"durable"`
+}
+```
+
+## Migration Strategy
+
+### Phase 1: Introduce new interfaces alongside existing code
+- Add `adapter.go`, `message.go`, `handler.go`, `options.go`, `registry.go`.
+- Add `concurrency.go` helper extracted from current `broker.go`.
+- No changes to existing `broker.go` or `config/messaging.go`.
+
+### Phase 2: Implement adapters
+- Start with `memory` and `nats` adapters (these cover existing test + production use).
+- Add `kafka` adapter (new capability).
+- Add `sqs` and `gcppubsub` adapters (replace gocloud.dev versions).
+- Add `rabbitmq` adapter.
+
+### Phase 3: Bridge layer for backward compatibility
+- Create a `LegacyBridge` that wraps the new `Adapter` interface and exposes the old
+  `Publisher`/`Subscriber`/`PublishSubscriber` interfaces.
+- Update `NewPublisher()`, `NewSubscriber()`, `NewPublishSubscriber()` to use the bridge
+  internally.
+- Existing callers (`api/service.go`, `runner/runner.go`, `executor/service.go`,
+  `devserver/devserver.go`) continue to work unchanged.
+
+### Phase 4: Migrate callers
+- Update callers to use `Adapter` directly.
+- Remove bridge layer and old `broker.go`.
+- Remove `gocloud.dev/pubsub` dependency.
+- Remove `TopicURLCreator` interface from config.
+
+## File Layout
+
+```
+pkg/pubsub/
+    adapter.go              # Adapter interface
+    message.go              # Message type with backend hints
+    handler.go              # HandlerFunc, Acknowledger
+    options.go              # SubscribeOption, SubscribeConfig
+    registry.go             # Register(), NewAdapter()
+    concurrency.go          # Shared semaphore-based concurrency helper
+    bridge.go               # LegacyBridge for backward compat (Phase 3)
+    middleware/
+        logging.go
+        metrics.go
+        tracing.go
+    adapters/
+        memory/
+            memory.go
+            memory_test.go
+        nats/
+            nats.go         # Unifies current broker + NatsConnector
+            nats_test.go
+        kafka/
+            kafka.go        # franz-go based
+            kafka_test.go
+        sqs/
+            sqs.go
+            sqs_test.go
+        gcppubsub/
+            gcppubsub.go
+            gcppubsub_test.go
+        rabbitmq/
+            rabbitmq.go
+            rabbitmq_test.go
+    # Legacy (removed in Phase 4)
+    broker.go               # Current gocloud.dev broker
+    broker_test.go
+    broker/
+        nats.go             # Current NatsConnector
+```
+
+## Open Questions
+
+1. **Batch publish** — Should `Adapter` have a `PublishBatch(ctx, topic, []Message)` method?
+   Kafka and SQS benefit significantly from batching. Could start without it and add later.
+2. **Dead-letter topics** — Should DLQ config be part of `SubscribeConfig` or left to
+   backend-specific configuration?
+3. **Schema registry** — Kafka ecosystems often use schema registries (Avro/Protobuf). Should
+   this be a concern of the adapter or a separate serialization layer?
+4. **Message encoding** — The current TODO says "Let's NOT use JSON, please." Should we
+   standardize on protobuf, or let callers choose the encoding and keep `Data` as `[]byte`?

--- a/pkg/pubsub/ADAPTER_PLAN.md
+++ b/pkg/pubsub/ADAPTER_PLAN.md
@@ -26,11 +26,63 @@ routing (`URLMux`). This creates several limitations:
 - Give each adapter full control over connections, consumer groups, ack/nack, and concurrency.
 - Make the system extensible via a self-registering factory (no hard-coded switch).
 - Enable cross-cutting concerns (metrics, tracing, retry) via middleware decorators.
-- Preserve backward compatibility during migration.
+- **Full backward compatibility** — existing callers (`Publisher`, `Subscriber`,
+  `PublishSubscriber`, `PerformFunc`, `Message`) must continue to compile and work unchanged
+  throughout the entire migration. No big-bang cutover.
+
+## Backward Compatibility Contract
+
+The following public API surface **must not break** at any point during this project:
+
+```go
+// Existing interfaces — preserved as-is
+type Publisher interface {
+    Publish(ctx context.Context, topic string, m Message) error
+}
+type Subscriber interface {
+    Subscribe(ctx context.Context, topic string, handler PerformFunc) error
+    SubscribeN(ctx context.Context, topic string, handler PerformFunc, concurrency int64) error
+}
+type PublishSubscriber interface {
+    Publisher
+    Subscriber
+}
+
+// Existing constructors — preserved as-is
+func NewPublisher(ctx context.Context, c config.MessagingService) (Publisher, error)
+func NewSubscriber(ctx context.Context, c config.MessagingService) (Subscriber, error)
+func NewPublishSubscriber(ctx context.Context, c config.MessagingService) (PublishSubscriber, error)
+
+// Existing types — preserved as-is
+type Message struct { ... }
+type PerformFunc func(context.Context, Message) error
+```
+
+### Existing callers (must remain untouched until explicit migration PR):
+
+| Caller | Usage |
+|--------|-------|
+| `pkg/api/service.go` | `pubsub.NewPublisher`, `pubsub.Publisher`, `pubsub.Message` |
+| `pkg/execution/runner/runner.go` | `pubsub.NewPublishSubscriber`, `pubsub.PublishSubscriber`, `pubsub.Publisher`, `pubsub.Message`, `handleMessage(ctx, pubsub.Message)` |
+| `pkg/execution/executor/service.go` | `pubsub.NewPublisher`, `pubsub.Publisher`, `pubsub.Message` |
+| `pkg/devserver/devserver.go` | `pubsub.NewPublisher`, `pubsub.Publisher` |
+| `pkg/devserver/service.go` | `pubsub.Publisher`, `pubsub.Message` |
+| `pkg/devserver/lifecycle.go` | `pubsub.Publisher` |
+| `pkg/config/messaging.go` | `MessagingService`, `TopicURLCreator`, all backend config structs |
+
+### Strategy: Bridge, don't break
+
+- The old interfaces (`Publisher`, `Subscriber`, `PublishSubscriber`) stay in `pubsub.go`
+  permanently — they are the stable API.
+- A `LegacyBridge` wraps new `Adapter` implementations to satisfy old interfaces.
+- `NewPublisher`/`NewSubscriber`/`NewPublishSubscriber` are updated internally to create
+  adapters + bridge, but their signatures and behavior are identical.
+- Old `broker.go` + gocloud.dev code is only removed in a final cleanup PR after all callers
+  have been verified.
 
 ## Design
 
-### Core Interfaces (`pkg/pubsub/adapter.go`)
+### Core Adapter Interface (`pkg/pubsub/adapter.go`)
 
 ```go
 // Adapter is the primary interface every pub/sub backend implements.
@@ -51,32 +103,7 @@ type Adapter interface {
 }
 ```
 
-### Message Type (`pkg/pubsub/message.go`)
-
-```go
-type Message struct {
-    // Core fields (always used)
-    ID        string            `json:"id,omitempty"`
-    Name      string            `json:"name"`
-    Version   int               `json:"v"`
-    Data      []byte            `json:"data"`
-    Timestamp time.Time         `json:"ts"`
-    Metadata  map[string]string `json:"meta,omitempty"`
-
-    // Backend hints — adapters use what they support, ignore the rest.
-    // These are not serialized; they're set in-process before Publish().
-    PartitionKey string        `json:"-"` // Kafka partition, SQS message group ID
-    OrderingKey  string        `json:"-"` // GCP Pub/Sub ordering key
-    RoutingKey   string        `json:"-"` // RabbitMQ routing key
-    Delay        time.Duration `json:"-"` // SQS delay, RabbitMQ delayed message
-    Headers      map[string]string `json:"-"` // Kafka headers, RabbitMQ headers, NATS headers
-}
-```
-
-Key change: `Data` is `[]byte` instead of `string`. The encoding strategy (JSON, protobuf,
-msgpack) is the caller's responsibility, not the adapter's.
-
-### Handler and Ack (`pkg/pubsub/handler.go`)
+### New Handler and Ack (`pkg/pubsub/handler.go`)
 
 ```go
 // HandlerFunc processes a received message. The Acknowledger gives the handler
@@ -92,9 +119,6 @@ type Acknowledger interface {
     Requeue(delay time.Duration)
 }
 ```
-
-The current design infers ack/nack from the handler's error return. Explicit ack gives handlers
-control over partial processing, dead-letter routing, and delayed requeue.
 
 ### Subscribe Options (`pkg/pubsub/options.go`)
 
@@ -123,10 +147,37 @@ func WithMaxRetries(n int) SubscribeOption { ... }
 func WithStartOffset(o StartOffset) SubscribeOption { ... }
 ```
 
+### Message Type Changes
+
+The existing `Message` struct is preserved. New backend-hint fields are added with `json:"-"`
+tags so they don't affect serialization. The existing `Data string` field is kept for backward
+compat; a future PR can add a `RawData []byte` field or change encoding.
+
+```go
+type Message struct {
+    // Existing fields — unchanged
+    Name      string         `json:"name"`
+    Version   int            `json:"v"`
+    Data      string         `json:"data"`
+    Timestamp time.Time      `json:"ts"`
+    Metadata  map[string]any `json:"meta,omitempty"`
+
+    // New: unique message identifier
+    ID string `json:"id,omitempty"`
+
+    // New: backend hints — adapters use what they support, ignore the rest.
+    // Not serialized; set in-process before Publish().
+    PartitionKey string            `json:"-"` // Kafka partition, SQS message group ID
+    OrderingKey  string            `json:"-"` // GCP Pub/Sub ordering key
+    RoutingKey   string            `json:"-"` // RabbitMQ routing key
+    Delay        time.Duration     `json:"-"` // SQS delay, RabbitMQ delayed message
+    Headers      map[string]string `json:"-"` // Kafka headers, RabbitMQ headers, NATS headers
+}
+```
+
 ### Adapter Registry (`pkg/pubsub/registry.go`)
 
 ```go
-// AdapterFactory creates an adapter from backend-specific config.
 type AdapterFactory func(ctx context.Context, cfg json.RawMessage) (Adapter, error)
 
 var (
@@ -134,60 +185,38 @@ var (
     registry = map[string]AdapterFactory{}
 )
 
-// Register makes a backend available by name. Called from init().
-func Register(name string, factory AdapterFactory) {
-    mu.Lock()
-    defer mu.Unlock()
-    registry[name] = factory
-}
-
-// NewAdapter creates an adapter for the named backend.
-func NewAdapter(ctx context.Context, backend string, cfg json.RawMessage) (Adapter, error) {
-    mu.RLock()
-    factory, ok := registry[backend]
-    mu.RUnlock()
-    if !ok {
-        return nil, fmt.Errorf("unknown pubsub backend: %s", backend)
-    }
-    return factory(ctx, cfg)
-}
+func Register(name string, factory AdapterFactory) { ... }
+func NewAdapter(ctx context.Context, backend string, cfg json.RawMessage) (Adapter, error) { ... }
 ```
 
-Each adapter package registers itself:
-```go
-// In adapters/kafka/kafka.go
-func init() {
-    pubsub.Register("kafka", New)
-}
-```
-
-### Middleware (`pkg/pubsub/middleware/`)
+### Legacy Bridge (`pkg/pubsub/bridge.go`)
 
 ```go
-type Middleware func(Adapter) Adapter
-
-// Compose applies middleware in order (outermost first).
-func Compose(adapter Adapter, mw ...Middleware) Adapter {
-    for i := len(mw) - 1; i >= 0; i-- {
-        adapter = mw[i](adapter)
-    }
-    return adapter
+// LegacyBridge wraps an Adapter to satisfy the existing Publisher/Subscriber/
+// PublishSubscriber interfaces. This allows existing callers to use new adapters
+// without code changes.
+type LegacyBridge struct {
+    adapter Adapter
 }
-```
 
-Initial middleware:
-- **`WithLogging`** — log publish/subscribe events, errors.
-- **`WithMetrics`** — publish/subscribe counters, latency histograms.
-- **`WithTracing`** — OpenTelemetry span propagation.
+func NewLegacyBridge(a Adapter) *LegacyBridge { ... }
+
+// Publish satisfies Publisher — delegates directly.
+func (b *LegacyBridge) Publish(ctx context.Context, topic string, m Message) error { ... }
+
+// Subscribe satisfies Subscriber — wraps old PerformFunc into new HandlerFunc,
+// translating error return to Ack/Nack.
+func (b *LegacyBridge) Subscribe(ctx context.Context, topic string, handler PerformFunc) error { ... }
+
+// SubscribeN satisfies Subscriber — same wrapping with WithConcurrency(n).
+func (b *LegacyBridge) SubscribeN(ctx context.Context, topic string, handler PerformFunc, concurrency int64) error { ... }
+```
 
 ### Concurrency Helper (`pkg/pubsub/concurrency.go`)
 
-The weighted-semaphore pattern currently in `broker.go` is good. Extract it as a reusable
-helper that adapters can optionally use:
+Extract the weighted-semaphore pattern from `broker.go` as a reusable helper:
 
 ```go
-// ConcurrentSubscriber wraps a base receive loop with semaphore-based concurrency.
-// Adapters that don't need custom concurrency can delegate to this.
 func ConcurrentSubscriber(
     ctx context.Context,
     concurrency int,
@@ -196,23 +225,118 @@ func ConcurrentSubscriber(
 ) error { ... }
 ```
 
-## Adapter Implementations
+### Middleware (`pkg/pubsub/middleware/`)
 
-### 1. In-Memory (`pkg/pubsub/adapters/memory/`)
+```go
+type Middleware func(Adapter) Adapter
 
-- For testing and single-process dev server.
-- Channel-based fan-out per topic.
-- No external dependencies.
+func Compose(adapter Adapter, mw ...Middleware) Adapter { ... }
+```
 
-### 2. NATS / JetStream (`pkg/pubsub/adapters/nats/`)
+- `WithLogging` — log publish/subscribe events, errors
+- `WithMetrics` — counters, latency histograms
+- `WithTracing` — OpenTelemetry span propagation
 
-- Unifies the current `broker` (via gocloud.dev) and `NatsConnector` into a single adapter.
-- Core NATS for fire-and-forget, JetStream for durable subscriptions.
-- Maps `ConsumerGroup` → NATS queue group / JetStream durable consumer.
-- Maps `Headers` → NATS message headers.
-- Uses existing `nats.go` and `nats.go/jetstream` packages.
+---
 
-Config:
+## Milestones
+
+This is a multi-PR project. Each milestone is a separate PR. Within each milestone,
+**tests are written first**, then the implementation is added to make them pass.
+
+### PR 1: Core Interfaces + Registry + Conformance Suite
+
+**What**: Foundation that all subsequent adapters build on. No changes to existing code paths.
+
+**Deliverables**:
+- `pkg/pubsub/adapter.go` — `Adapter` interface
+- `pkg/pubsub/handler.go` — `HandlerFunc`, `Acknowledger`
+- `pkg/pubsub/options.go` — `SubscribeConfig`, `SubscribeOption`, option funcs
+- `pkg/pubsub/registry.go` — `Register()`, `NewAdapter()`
+- `pkg/pubsub/registry_test.go` — registry unit tests
+- `pkg/pubsub/concurrency.go` — extracted semaphore helper
+- `pkg/pubsub/concurrency_test.go` — concurrency helper tests
+- `pkg/pubsub/bridge.go` — `LegacyBridge`
+- `pkg/pubsub/bridge_test.go` — bridge tests (verify old interface contract via adapter)
+- `pkg/pubsub/adaptertest/conformance.go` — shared conformance test suite
+- Add `ID`, `PartitionKey`, `OrderingKey`, `RoutingKey`, `Delay`, `Headers` fields to `Message`
+
+**Backward compat**: No existing files modified (except additive `Message` field additions).
+All existing tests pass unchanged.
+
+**Test order**: Write `registry_test.go`, `concurrency_test.go`, `bridge_test.go`, and
+`adaptertest/conformance.go` first. Bridge tests use a mock adapter to validate the translation
+from `PerformFunc` → `HandlerFunc` and error → ack/nack mapping.
+
+---
+
+### PR 2: Kafka Adapter (franz-go)
+
+**What**: First real adapter. New capability — Kafka was not previously supported.
+
+**Deliverables**:
+- `pkg/pubsub/adapters/kafka/kafka.go` — adapter implementation
+- `pkg/pubsub/adapters/kafka/kafka_test.go` — conformance + Kafka-specific tests
+
+**Config**:
+```go
+type Config struct {
+    Brokers       []string `json:"brokers"`
+    TLS           bool     `json:"tls"`
+    SASLMechanism string   `json:"sasl_mechanism,omitempty"`
+    SASLUser      string   `json:"sasl_user,omitempty"`
+    SASLPass      string   `json:"sasl_pass,omitempty"`
+}
+```
+
+**Kafka-specific tests** (build tag: `integration,kafka`; CI uses Redpanda container):
+- `TestProduceConsume` — basic round-trip
+- `TestPartitionKey` — same key lands on same partition
+- `TestConsumerGroup` — competing consumers, no duplicates
+- `TestConsumerGroupRebalance` — add/remove consumers
+- `TestKafkaHeaders` — header round-trip
+- `TestOffsetEarliest` / `TestOffsetLatest` — start position
+- `TestCommitOnAck` / `TestNackDoesNotCommit` — offset management
+- `TestBatchPerformance` — 10k messages, no per-message round-trip
+- `TestTLS` / `TestSASL` — auth/encryption
+
+**Backward compat**: Purely additive. No existing files modified.
+
+**Test order**: Write `kafka_test.go` with conformance suite call + all Kafka-specific tests
+first (they will fail/skip). Then implement `kafka.go`.
+
+---
+
+### PR 3: In-Memory Adapter
+
+**What**: Replace the gocloud.dev `mem://` backend. Used by all existing unit tests and the
+dev server.
+
+**Deliverables**:
+- `pkg/pubsub/adapters/memory/memory.go` — adapter implementation
+- `pkg/pubsub/adapters/memory/memory_test.go` — conformance + memory-specific tests
+
+**Memory-specific tests**:
+- `TestFanOut` — two subscribers each receive every message
+- `TestIsolatedTopics` — messages on topic A not received on topic B
+- `TestNoExternalDependencies` — zero config, no env vars
+
+**Backward compat**: Purely additive. Existing `broker.go` in-memory path unchanged.
+
+**Test order**: Write tests first, then implement.
+
+---
+
+### PR 4: NATS / JetStream Adapter
+
+**What**: Unify the current `broker` (gocloud.dev natspubsub) and `NatsConnector` into a
+single adapter that handles both core NATS and JetStream.
+
+**Deliverables**:
+- `pkg/pubsub/adapters/nats/nats.go` — adapter implementation
+- `pkg/pubsub/adapters/nats/nats_test.go` — conformance + NATS-specific tests
+
+**Config**:
 ```go
 type Config struct {
     URLs       string `json:"urls"`
@@ -221,52 +345,67 @@ type Config struct {
 }
 ```
 
-### 3. Kafka (`pkg/pubsub/adapters/kafka/`)
+**NATS-specific tests** (build tag: `integration,nats`; CI uses `nats:latest -js`):
+- `TestCoreNATSPublishSubscribe` — fire-and-forget
+- `TestJetStreamDurableConsumer` — survives subscriber restart
+- `TestQueueGroup` / `TestQueueGroupDifferentGroups` — competing vs fan-out
+- `TestNATSHeaders` — header round-trip
+- `TestJetStreamAckNack` — nack triggers redelivery
+- `TestConnectionReconnect` — adapter recovers after disconnect
+- `TestDrainOnClose` — buffered messages flushed
 
-- Uses **franz-go** (`github.com/twmb/franz-go`) — most complete Kafka protocol implementation.
-- Maps `PartitionKey` → Kafka record key.
-- Maps `ConsumerGroup` → Kafka consumer group.
-- Maps `Headers` → Kafka record headers.
-- Maps `StartOffset` → `kgo.ConsumeResetOffset`.
-- Supports batch consumption internally, dispatches to handler per-record.
+**Backward compat**: Purely additive. Existing `broker.go` NATS path and `broker/nats.go`
+unchanged.
 
-Config:
-```go
-type Config struct {
-    Brokers       []string `json:"brokers"`
-    TLS           bool     `json:"tls"`
-    SASLMechanism string   `json:"sasl_mechanism,omitempty"` // PLAIN, SCRAM-SHA-256, SCRAM-SHA-512
-    SASLUser      string   `json:"sasl_user,omitempty"`
-    SASLPass      string   `json:"sasl_pass,omitempty"`
-}
-```
+**Test order**: Write tests first, then implement.
 
-### 4. AWS SQS (`pkg/pubsub/adapters/sqs/`)
+---
 
-- Uses `aws-sdk-go-v2`.
-- Maps `PartitionKey` → SQS `MessageGroupId` (FIFO queues).
-- Maps `Delay` → `DelaySeconds`.
-- Maps `Ack` → `DeleteMessage`, `Nack` → no-op (visibility timeout expires), `Requeue` → `ChangeMessageVisibility`.
-- Publish goes to SNS topic or directly to SQS queue (configurable).
+### PR 5: AWS SQS Adapter
 
-Config:
+**What**: Replace the gocloud.dev `awssnssqs` backend with a direct `aws-sdk-go-v2`
+implementation.
+
+**Deliverables**:
+- `pkg/pubsub/adapters/sqs/sqs.go` — adapter implementation
+- `pkg/pubsub/adapters/sqs/sqs_test.go` — conformance + SQS-specific tests
+
+**Config**:
 ```go
 type Config struct {
     Region   string `json:"region"`
     QueueURL string `json:"queue_url"`
-    // Optional: publish to SNS topic instead of directly to SQS
-    TopicARN string `json:"topic_arn,omitempty"`
+    TopicARN string `json:"topic_arn,omitempty"` // optional SNS fan-out
 }
 ```
 
-### 5. GCP Pub/Sub (`pkg/pubsub/adapters/gcppubsub/`)
+**SQS-specific tests** (build tag: `integration,sqs`; CI uses LocalStack):
+- `TestSQSSendReceive` — basic round-trip
+- `TestSQSDelaySeconds` — `Delay` → `DelaySeconds`
+- `TestSQSFIFOMessageGroup` — `PartitionKey` → `MessageGroupId`
+- `TestSQSVisibilityTimeout` — unacked message reappears
+- `TestSQSRequeue` — `ChangeMessageVisibility`
+- `TestSQSDeleteOnAck` — ack deletes message
+- `TestSQSBatchReceive` — efficient batch polling
+- `TestSQSLongPolling` — `WaitTimeSeconds`, no busy-loop
+- `TestSNSPublish` — optional SNS topic publishing
 
-- Uses `cloud.google.com/go/pubsub`.
-- Maps `OrderingKey` → GCP ordering key.
-- Maps `ConsumerGroup` → GCP subscription name.
-- Maps `Ack`/`Nack` → native GCP ack/nack.
+**Backward compat**: Purely additive.
 
-Config:
+**Test order**: Write tests first, then implement.
+
+---
+
+### PR 6: GCP Pub/Sub Adapter
+
+**What**: Replace the gocloud.dev `gcppubsub` backend with a direct
+`cloud.google.com/go/pubsub` implementation.
+
+**Deliverables**:
+- `pkg/pubsub/adapters/gcppubsub/gcppubsub.go` — adapter implementation
+- `pkg/pubsub/adapters/gcppubsub/gcppubsub_test.go` — conformance + GCP-specific tests
+
+**Config**:
 ```go
 type Config struct {
     ProjectID      string `json:"project_id"`
@@ -274,15 +413,29 @@ type Config struct {
 }
 ```
 
-### 6. RabbitMQ (`pkg/pubsub/adapters/rabbitmq/`)
+**GCP-specific tests** (build tag: `integration,gcppubsub`; CI uses GCP emulator):
+- `TestGCPPublishSubscribe` — basic round-trip
+- `TestGCPOrderingKey` — ordering key preserves order
+- `TestGCPAckDeadline` — unacked redelivered after deadline
+- `TestGCPMultipleSubscriptions` — different subscriptions each get all messages
+- `TestGCPNack` — nack triggers redelivery
+- `TestGCPAttributeRoundTrip` — Metadata ↔ attributes
 
-- Uses `github.com/rabbitmq/amqp091-go`.
-- Maps `RoutingKey` → AMQP routing key.
-- Maps `Headers` → AMQP headers (for header-based routing).
-- Maps `Ack`/`Nack`/`Requeue` → AMQP ack/nack/reject with requeue.
-- Configurable exchange type (direct, topic, fanout, headers).
+**Backward compat**: Purely additive.
 
-Config:
+**Test order**: Write tests first, then implement.
+
+---
+
+### PR 7: RabbitMQ Adapter
+
+**What**: New capability — RabbitMQ was not previously supported.
+
+**Deliverables**:
+- `pkg/pubsub/adapters/rabbitmq/rabbitmq.go` — adapter implementation
+- `pkg/pubsub/adapters/rabbitmq/rabbitmq_test.go` — conformance + RabbitMQ-specific tests
+
+**Config**:
 ```go
 type Config struct {
     URL          string `json:"url"` // amqp://user:pass@host:5672/vhost
@@ -293,58 +446,117 @@ type Config struct {
 }
 ```
 
-## Migration Strategy
+**RabbitMQ-specific tests** (build tag: `integration,rabbitmq`; CI uses RabbitMQ container):
+- `TestDirectExchange` — routing key exact match
+- `TestTopicExchange` — wildcard routing
+- `TestFanoutExchange` — all queues receive
+- `TestHeaderExchange` — header-based routing
+- `TestAckNackRequeue` — nack with/without requeue
+- `TestDurableQueue` — survives subscriber restart
+- `TestPrefetchCount` — `WithConcurrency` → QoS prefetch
+- `TestConnectionRecovery` — auto-reconnect
 
-### Phase 1: Introduce new interfaces alongside existing code
-- Add `adapter.go`, `message.go`, `handler.go`, `options.go`, `registry.go`.
-- Add `concurrency.go` helper extracted from current `broker.go`.
-- No changes to existing `broker.go` or `config/messaging.go`.
+**Backward compat**: Purely additive.
 
-### Phase 2: Implement adapters
-- Start with `memory` and `nats` adapters (these cover existing test + production use).
-- Add `kafka` adapter (new capability).
-- Add `sqs` and `gcppubsub` adapters (replace gocloud.dev versions).
-- Add `rabbitmq` adapter.
+**Test order**: Write tests first, then implement.
 
-### Phase 3: Bridge layer for backward compatibility
-- Create a `LegacyBridge` that wraps the new `Adapter` interface and exposes the old
-  `Publisher`/`Subscriber`/`PublishSubscriber` interfaces.
-- Update `NewPublisher()`, `NewSubscriber()`, `NewPublishSubscriber()` to use the bridge
-  internally.
-- Existing callers (`api/service.go`, `runner/runner.go`, `executor/service.go`,
-  `devserver/devserver.go`) continue to work unchanged.
+---
 
-### Phase 4: Migrate callers
-- Update callers to use `Adapter` directly.
-- Remove bridge layer and old `broker.go`.
-- Remove `gocloud.dev/pubsub` dependency.
-- Remove `TopicURLCreator` interface from config.
+### PR 8: Middleware (Logging, Metrics, Tracing)
 
-## File Layout
+**What**: Cross-cutting decorator middleware.
+
+**Deliverables**:
+- `pkg/pubsub/middleware/middleware.go` — `Middleware` type, `Compose` func
+- `pkg/pubsub/middleware/logging.go` + `logging_test.go`
+- `pkg/pubsub/middleware/metrics.go` + `metrics_test.go`
+- `pkg/pubsub/middleware/tracing.go` + `tracing_test.go`
+
+**Tests**:
+- Logging: log on publish, subscribe start, errors
+- Metrics: publish counter, error counter, latency histogram, topic labels
+- Tracing: publish span, subscribe span, trace context propagation via headers
+
+**Backward compat**: Purely additive.
+
+**Test order**: Write tests first, then implement.
+
+---
+
+### PR 9: Wire In — Switch Constructors to Use Adapters + Bridge
+
+**What**: Update `NewPublisher`/`NewSubscriber`/`NewPublishSubscriber` to internally create
+new adapters + `LegacyBridge` instead of the old `broker`. This is the switchover PR.
+
+**Deliverables**:
+- Update `NewPublishSubscriber` to detect backend from `config.MessagingService` and create
+  the corresponding adapter, wrapped in `LegacyBridge`
+- Keep `broker.go` alive but unused (safety net for rollback)
+- Register all adapters via blank imports
+
+**Key constraint**: The function signatures of `NewPublisher`, `NewSubscriber`,
+`NewPublishSubscriber` do NOT change. All existing callers compile and behave identically.
+
+**Tests**:
+- Existing `broker_test.go` tests must pass (they call `NewPublishSubscriber` → bridge →
+  memory adapter)
+- All integration tests for existing callers pass
+
+**Backward compat**: Full. Same signatures, same behavior. Internal implementation changes only.
+
+---
+
+### PR 10: Cleanup — Remove gocloud.dev Dependency
+
+**What**: Remove old code now that adapters are in production.
+
+**Deliverables**:
+- Delete `pkg/pubsub/broker.go` (old gocloud.dev broker)
+- Delete `pkg/pubsub/broker/nats.go` (old NatsConnector — replaced by NATS adapter)
+- Remove gocloud.dev imports and dependencies from `go.mod`
+- Remove `TopicURLCreator` from `config/messaging.go` (or deprecate)
+- Update `config.MessagingService` to carry `json.RawMessage` for adapter config
+
+**Backward compat**: Breaking for `TopicURLCreator` users (internal only). All public
+`Publisher`/`Subscriber`/`PublishSubscriber` interfaces remain stable.
+
+---
+
+## File Layout (final state after all PRs)
 
 ```
 pkg/pubsub/
-    adapter.go              # Adapter interface
-    message.go              # Message type with backend hints
+    pubsub.go               # Original interfaces: Publisher, Subscriber, PublishSubscriber,
+                             #   PerformFunc, Message (preserved)
+    adapter.go              # New Adapter interface
     handler.go              # HandlerFunc, Acknowledger
-    options.go              # SubscribeOption, SubscribeConfig
+    options.go              # SubscribeConfig, SubscribeOption, option funcs
     registry.go             # Register(), NewAdapter()
+    registry_test.go
     concurrency.go          # Shared semaphore-based concurrency helper
-    bridge.go               # LegacyBridge for backward compat (Phase 3)
+    concurrency_test.go
+    bridge.go               # LegacyBridge (old interfaces → Adapter)
+    bridge_test.go
+    adaptertest/
+        conformance.go      # Shared conformance test suite
     middleware/
+        middleware.go        # Middleware type, Compose
         logging.go
+        logging_test.go
         metrics.go
+        metrics_test.go
         tracing.go
+        tracing_test.go
     adapters/
         memory/
             memory.go
             memory_test.go
-        nats/
-            nats.go         # Unifies current broker + NatsConnector
-            nats_test.go
         kafka/
-            kafka.go        # franz-go based
+            kafka.go        # franz-go
             kafka_test.go
+        nats/
+            nats.go
+            nats_test.go
         sqs/
             sqs.go
             sqs_test.go
@@ -354,11 +566,6 @@ pkg/pubsub/
         rabbitmq/
             rabbitmq.go
             rabbitmq_test.go
-    # Legacy (removed in Phase 4)
-    broker.go               # Current gocloud.dev broker
-    broker_test.go
-    broker/
-        nats.go             # Current NatsConnector
 ```
 
 ## Open Questions

--- a/pkg/pubsub/ADAPTER_TEST_PLAN.md
+++ b/pkg/pubsub/ADAPTER_TEST_PLAN.md
@@ -1,0 +1,322 @@
+# Pub/Sub Adapter — Test Plans
+
+## Testing Strategy
+
+### Conformance Test Suite
+
+Every adapter must pass a shared **conformance test suite** that validates the `Adapter` interface
+contract. This ensures behavioral consistency across backends while allowing backend-specific
+tests for unique features.
+
+```go
+// pkg/pubsub/adaptertest/conformance.go
+
+// RunConformance runs the full adapter conformance suite against the provided adapter.
+// Each adapter's _test.go calls this with its own setup/teardown.
+func RunConformance(t *testing.T, setup func(t *testing.T) Adapter) {
+    t.Run("Publish", func(t *testing.T) { ... })
+    t.Run("Subscribe", func(t *testing.T) { ... })
+    t.Run("Concurrency", func(t *testing.T) { ... })
+    t.Run("Acknowledgment", func(t *testing.T) { ... })
+    t.Run("Lifecycle", func(t *testing.T) { ... })
+}
+```
+
+Usage in each adapter:
+```go
+// pkg/pubsub/adapters/kafka/kafka_test.go
+func TestKafkaConformance(t *testing.T) {
+    adaptertest.RunConformance(t, func(t *testing.T) pubsub.Adapter {
+        return newTestKafkaAdapter(t)
+    })
+}
+```
+
+---
+
+## Conformance Tests (all adapters must pass)
+
+### 1. Publish / Subscribe Basics
+
+| Test | Description |
+|------|-------------|
+| `TestPublishAndReceive` | Publish a message, subscribe, assert received message matches sent (Name, Version, Data, Metadata). |
+| `TestPublishMultipleMessages` | Publish N messages, subscribe, assert all N received (order not guaranteed unless backend guarantees it). |
+| `TestSubscribeBlocksUntilCancel` | Subscribe in a goroutine, cancel context, assert Subscribe returns nil error. |
+| `TestPublishNoSubscriber` | Publish with no active subscriber — must not error (fire-and-forget semantics). |
+| `TestSubscribeReceivesOnlyAfterStart` | Publish before subscribe starts, then subscribe — behavior is backend-defined but must not panic or hang. |
+| `TestMessageDataIntegrity` | Publish messages with varying data sizes (empty, 1 byte, 1KB, 1MB) — assert exact byte-level match on receive. |
+
+### 2. Concurrency
+
+| Test | Description |
+|------|-------------|
+| `TestConcurrency` | Subscribe with `WithConcurrency(10)`, publish 10 messages that each block until signaled. Assert all 10 handlers are running concurrently. |
+| `TestConcurrencyLimit` | Subscribe with `WithConcurrency(5)`, publish 10 blocking messages. Assert only 5 handlers run concurrently; remaining 5 start after first batch completes. |
+| `TestConcurrencyOne` | Subscribe with `WithConcurrency(1)` (or default). Publish 3 messages. Assert sequential processing — second handler starts only after first completes. |
+
+### 3. Acknowledgment
+
+| Test | Description |
+|------|-------------|
+| `TestAckRemovesMessage` | Handler calls `Ack()`. Assert the message is not redelivered within a reasonable timeout. |
+| `TestNackRedelivers` | Handler calls `Nack()`. Assert the message is redelivered (for backends that support it). Backends without nack support may skip. |
+| `TestRequeueWithDelay` | Handler calls `Requeue(500ms)`. Assert the message is redelivered after approximately 500ms. Backends without delay support should redeliver immediately or skip. |
+| `TestNoAckTimesOut` | Handler neither acks nor nacks. Assert the message is eventually redelivered (for backends with ack deadlines). In-memory can skip. |
+| `TestDoubleAck` | Handler calls `Ack()` twice. Must not panic. |
+| `TestAckAfterNack` | Handler calls `Nack()` then `Ack()`. First call wins. Must not panic. |
+
+### 4. Lifecycle
+
+| Test | Description |
+|------|-------------|
+| `TestCloseStopsSubscribe` | Call `Close()` while Subscribe is blocking. Assert Subscribe returns without error. |
+| `TestCloseWaitsForInflight` | Handler is processing a message. Call `Close()`. Assert Close blocks until handler finishes. |
+| `TestCloseThenPublishErrors` | Call `Close()`, then `Publish()`. Assert Publish returns an error. |
+| `TestCloseThenSubscribeErrors` | Call `Close()`, then `Subscribe()`. Assert Subscribe returns an error. |
+| `TestCloseIdempotent` | Call `Close()` twice. Must not panic or error on second call. |
+| `TestHealthyBeforeClose` | Call `Healthy()` on a connected adapter. Assert nil error. |
+| `TestHealthyAfterClose` | Call `Close()`, then `Healthy()`. Assert non-nil error. |
+
+### 5. Context Cancellation
+
+| Test | Description |
+|------|-------------|
+| `TestPublishRespectsContext` | Pass an already-cancelled context to Publish. Assert error. |
+| `TestSubscribeCancelDrainsGracefully` | Subscribe with concurrency 5, publish 5 slow messages. Cancel context. Assert all 5 in-flight handlers complete before Subscribe returns. |
+| `TestSubscribeContextDeadline` | Subscribe with a context that has a 2s deadline. Assert Subscribe returns after ~2s without error. |
+
+### 6. Subscribe Options
+
+| Test | Description |
+|------|-------------|
+| `TestDefaultConcurrency` | Subscribe without `WithConcurrency`. Assert messages are processed (default concurrency = 1). |
+| `TestUnknownOptionsIgnored` | Future-proof: passing unrecognized options must not panic. |
+
+---
+
+## Backend-Specific Tests
+
+### In-Memory (`adapters/memory/`)
+
+| Test | Description |
+|------|-------------|
+| `TestFanOut` | Two subscribers on the same topic each receive every published message (fan-out, not competing consumers). |
+| `TestIsolatedTopics` | Messages on topic A are not received by subscribers on topic B. |
+| `TestNoExternalDependencies` | Adapter creates and operates with zero config (no URLs, no env vars). |
+
+### NATS / JetStream (`adapters/nats/`)
+
+Requires a running NATS server. Use `nats-server -js` in CI via Docker or testcontainers.
+
+| Test | Description |
+|------|-------------|
+| `TestCoreNATSPublishSubscribe` | Non-JetStream mode: fire-and-forget publish, subscriber receives. |
+| `TestJetStreamDurableConsumer` | JetStream mode: publish, stop subscriber, restart subscriber — receives messages published while offline. |
+| `TestQueueGroup` | Two subscribers with same `WithConsumerGroup("g")` — each message delivered to exactly one subscriber (competing consumers). |
+| `TestQueueGroupDifferentGroups` | Two subscribers with different consumer groups — each receives every message. |
+| `TestNATSHeaders` | Publish with `Headers`. Assert headers are present on received message. |
+| `TestJetStreamAckNack` | Nack in JetStream mode triggers redelivery. |
+| `TestConnectionReconnect` | Disconnect NATS server, reconnect. Assert adapter recovers and Healthy() returns nil after reconnect. |
+| `TestDrainOnClose` | Publish async with JetStream. Call Close(). Assert all buffered messages are flushed. |
+
+### Kafka (`adapters/kafka/`) — franz-go
+
+Requires a running Kafka broker. Use `redpanda` or `kafka` container in CI.
+
+| Test | Description |
+|------|-------------|
+| `TestProduceConsume` | Produce a record, consume it. Assert key, value, headers match. |
+| `TestPartitionKey` | Publish two messages with the same `PartitionKey`. Assert both land on the same partition. |
+| `TestConsumerGroup` | Two subscribers with same `WithConsumerGroup`. Publish 100 messages. Assert total received across both = 100 (no duplicates). |
+| `TestConsumerGroupRebalance` | Start subscriber A in group G. Start subscriber B in same group G. Assert partitions are rebalanced. Stop subscriber B. Assert A takes all partitions back. |
+| `TestKafkaHeaders` | Publish with `Headers`. Assert headers round-trip correctly. |
+| `TestOffsetEarliest` | Publish 10 messages. Subscribe with `WithStartOffset(OffsetEarliest)`. Assert all 10 received. |
+| `TestOffsetLatest` | Publish 10 messages. Subscribe with `WithStartOffset(OffsetLatest)`. Publish 5 more. Assert only 5 received. |
+| `TestCommitOnAck` | Ack a message. Restart consumer with same group. Assert acked messages are not re-received. |
+| `TestNackDoesNotCommit` | Nack a message. Restart consumer with same group. Assert nacked message is re-received. |
+| `TestBatchPerformance` | Publish 10,000 messages. Consume all. Assert throughput is reasonable (no per-message round-trips). |
+| `TestTLS` | Connect with TLS config. Assert connection succeeds and Healthy() returns nil. |
+| `TestSASL` | Connect with SASL credentials. Assert connection succeeds. |
+
+### AWS SQS (`adapters/sqs/`)
+
+Use localstack in CI for SQS emulation.
+
+| Test | Description |
+|------|-------------|
+| `TestSQSSendReceive` | Send message, receive it, assert match. |
+| `TestSQSDelaySeconds` | Publish with `Delay: 3s`. Assert message is not received for ~3s. |
+| `TestSQSFIFOMessageGroup` | Use FIFO queue. Publish with `PartitionKey` (message group ID). Assert FIFO ordering within group. |
+| `TestSQSVisibilityTimeout` | Receive message, don't ack. Assert message reappears after visibility timeout. |
+| `TestSQSRequeue` | Call `Requeue(5s)`. Assert message reappears after ~5s (via `ChangeMessageVisibility`). |
+| `TestSQSDeleteOnAck` | Ack a message. Assert `ReceiveMessage` does not return it again. |
+| `TestSQSBatchReceive` | Publish 10 messages. Assert adapter receives them efficiently (up to 10 per `ReceiveMessage` call). |
+| `TestSQSLongPolling` | Subscribe to empty queue. Assert no busy-loop (adapter should use `WaitTimeSeconds`). Verify via metric or timing. |
+| `TestSNSPublish` | If `TopicARN` configured, publish goes to SNS. Assert SQS subscription receives it. |
+
+### GCP Pub/Sub (`adapters/gcppubsub/`)
+
+Use the GCP Pub/Sub emulator in CI (`gcloud beta emulators pubsub start`).
+
+| Test | Description |
+|------|-------------|
+| `TestGCPPublishSubscribe` | Publish to topic, receive from subscription. |
+| `TestGCPOrderingKey` | Publish with `OrderingKey`. Assert messages with the same ordering key are received in order. |
+| `TestGCPAckDeadline` | Subscribe with `WithAckDeadline(5s)`. Don't ack. Assert redelivery after ~5s. |
+| `TestGCPMultipleSubscriptions` | Two subscriptions on the same topic (different groups). Assert both receive every message. |
+| `TestGCPNack` | Nack a message. Assert it is redelivered. |
+| `TestGCPAttributeRoundTrip` | Publish with `Metadata`. Assert attributes arrive on received message. |
+
+### RabbitMQ (`adapters/rabbitmq/`)
+
+Use RabbitMQ container in CI.
+
+| Test | Description |
+|------|-------------|
+| `TestDirectExchange` | Publish with routing key, bind queue with matching key. Assert received. |
+| `TestTopicExchange` | Publish with routing key `foo.bar`. Bind with `foo.*`. Assert received. Bind with `baz.*`. Assert not received. |
+| `TestFanoutExchange` | Two queues bound to fanout exchange. Assert both receive every message. |
+| `TestHeaderExchange` | Publish with `Headers`. Bind queue with header match. Assert routing works. |
+| `TestAckNackRequeue` | Nack with requeue. Assert message redelivered. Nack without requeue (dead-letter). Assert not redelivered. |
+| `TestDurableQueue` | Declare durable queue. Publish. Restart subscriber. Assert message still available. |
+| `TestPrefetchCount` | Set `WithConcurrency(5)`. Assert RabbitMQ `Qos` prefetch matches. Only 5 unacked messages at a time. |
+| `TestConnectionRecovery` | Kill RabbitMQ connection. Assert adapter reconnects automatically. |
+
+---
+
+## Middleware Tests (`middleware/`)
+
+### Logging Middleware
+
+| Test | Description |
+|------|-------------|
+| `TestLogsOnPublish` | Publish a message. Assert log entry with topic name and message name. |
+| `TestLogsOnSubscribeStart` | Subscribe. Assert log entry indicating subscription started. |
+| `TestLogsOnError` | Publish to a closed adapter. Assert error is logged. |
+
+### Metrics Middleware
+
+| Test | Description |
+|------|-------------|
+| `TestPublishCounter` | Publish 5 messages. Assert `pubsub_publish_total` counter = 5. |
+| `TestPublishErrorCounter` | Publish to closed adapter. Assert `pubsub_publish_errors_total` incremented. |
+| `TestSubscribeLatencyHistogram` | Subscribe and process a message. Assert `pubsub_subscribe_duration_seconds` has an observation. |
+| `TestMetricsHaveTopicLabel` | Publish to two topics. Assert metrics are labeled by topic. |
+
+### Tracing Middleware
+
+| Test | Description |
+|------|-------------|
+| `TestPublishCreatesSpan` | Publish a message. Assert a span with operation `pubsub.publish` and topic attribute. |
+| `TestSubscribeCreatesSpan` | Receive a message. Assert a span with operation `pubsub.process`. |
+| `TestTraceContextPropagation` | Publish with active trace context. Assert subscriber's span has the same trace ID (context propagated via headers). |
+
+---
+
+## Concurrency Helper Tests (`concurrency.go`)
+
+| Test | Description |
+|------|-------------|
+| `TestConcurrentSubscriberRespectsConcurrency` | Set concurrency=3. Feed 10 messages via receive func. Assert max 3 handlers running at once. |
+| `TestConcurrentSubscriberCancelDrains` | Start with concurrency=5, feed 5 slow messages. Cancel context. Assert function returns only after all 5 complete. |
+| `TestConcurrentSubscriberReceiveError` | Receive func returns error. Assert `ConcurrentSubscriber` returns that error after draining in-flight work. |
+
+---
+
+## Registry Tests (`registry.go`)
+
+| Test | Description |
+|------|-------------|
+| `TestRegisterAndCreate` | Register a factory, call `NewAdapter`. Assert adapter is returned. |
+| `TestUnknownBackendErrors` | Call `NewAdapter` with unregistered name. Assert descriptive error. |
+| `TestRegisterOverwrites` | Register same name twice. Assert second factory wins. |
+| `TestConcurrentRegisterSafe` | Register from multiple goroutines. Assert no race (run with `-race`). |
+
+---
+
+## Integration / End-to-End Tests
+
+These tests run against real backends (Docker containers in CI) and test the full
+publish → subscribe → ack cycle.
+
+| Test | Description |
+|------|-------------|
+| `TestE2E_MemoryAdapter` | Full cycle with in-memory adapter. Runs in every CI build. |
+| `TestE2E_NATSAdapter` | Full cycle with NATS container. |
+| `TestE2E_KafkaAdapter` | Full cycle with Redpanda/Kafka container. |
+| `TestE2E_SQSAdapter` | Full cycle with LocalStack container. |
+| `TestE2E_GCPPubSubAdapter` | Full cycle with GCP emulator container. |
+| `TestE2E_RabbitMQAdapter` | Full cycle with RabbitMQ container. |
+
+Each E2E test:
+1. Starts the backend container (via testcontainers-go or CI service).
+2. Creates the adapter.
+3. Asserts `Healthy()` returns nil.
+4. Publishes 100 messages.
+5. Subscribes with concurrency 10.
+6. Asserts all 100 received and acked.
+7. Calls `Close()`.
+8. Asserts graceful shutdown (no lost messages).
+
+---
+
+## CI Configuration
+
+```yaml
+# .github/workflows/pubsub-tests.yml (sketch)
+services:
+  nats:
+    image: nats:latest
+    command: -js
+    ports: [4222:4222]
+  redpanda:
+    image: redpandadata/redpanda:latest
+    ports: [9092:9092]
+  localstack:
+    image: localstack/localstack:latest
+    ports: [4566:4566]
+  pubsub-emulator:
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators
+    ports: [8085:8085]
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports: [5672:5672]
+```
+
+Backend-specific tests use build tags to skip when the backend is unavailable:
+
+```go
+//go:build integration && kafka
+
+package kafka_test
+```
+
+Run: `go test -tags=integration,kafka ./pkg/pubsub/adapters/kafka/`
+
+## Test File Layout
+
+```
+pkg/pubsub/
+    adaptertest/
+        conformance.go          # Shared conformance suite
+    concurrency_test.go         # ConcurrentSubscriber helper tests
+    registry_test.go            # Registry tests
+    middleware/
+        logging_test.go
+        metrics_test.go
+        tracing_test.go
+    adapters/
+        memory/
+            memory_test.go      # Conformance + memory-specific
+        nats/
+            nats_test.go        # Conformance + NATS-specific (build tag: integration,nats)
+        kafka/
+            kafka_test.go       # Conformance + Kafka-specific (build tag: integration,kafka)
+        sqs/
+            sqs_test.go         # Conformance + SQS-specific (build tag: integration,sqs)
+        gcppubsub/
+            gcppubsub_test.go   # Conformance + GCP-specific (build tag: integration,gcppubsub)
+        rabbitmq/
+            rabbitmq_test.go    # Conformance + RabbitMQ-specific (build tag: integration,rabbitmq)
+```


### PR DESCRIPTION
## Summary

- Introduces a new `Adapter` interface to replace the gocloud.dev URLMux coupling, giving each backend full control over connections, lifecycle, and backend-specific features
- Supports Kafka (franz-go), NATS/JetStream, AWS SQS, GCP Pub/Sub, RabbitMQ, and in-memory backends with richer Message type, explicit ack/nack, and functional subscribe options
- Includes phased migration strategy to preserve backward compatibility while transitioning callers

## Design highlights

- **Direct adapter interface**: `Publish`, `Subscribe`, `Close`, `Healthy` — no URL indirection
- **Self-registering factory**: `pubsub.Register("kafka", New)` — no hard-coded switch
- **Explicit `Acknowledger`**: handlers control ack/nack/requeue instead of error-return inference
- **Middleware decorators**: composable logging, metrics, tracing layers
- **Backend hints on Message**: partition key, ordering key, routing key, delay, headers — adapters use what they support, ignore the rest

## Current state

Implementation plan added at `pkg/pubsub/ADAPTER_PLAN.md`. Code changes to follow.

## Test plan

- [ ] Core interfaces compile and are usable
- [ ] In-memory adapter passes unit tests
- [ ] NATS adapter passes unit tests
- [ ] Kafka adapter passes unit tests with franz-go
- [ ] Legacy bridge preserves existing caller behavior
- [ ] Middleware decorators are composable

https://claude.ai/code/session_01Ew93dqcQxtj2DHGJDSFV1g