### PR TITLE
Fix Vercel serve path configuration deletion by making the rows controlled with stable keys

### DIFF
--- a/ui/apps/dashboard/src/routes/_authed/settings/integrations/vercel/configure/$id/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/settings/integrations/vercel/configure/$id/index.tsx
@@ -31,6 +31,19 @@ import { useVercelIntegration } from '@/queries/useVercelIntegration';
 
 const defaultPath = '/api/inngest';
 
+type ServePathRow = {
+  id: string;
+  value: string;
+};
+
+function createServePathRow(value: string): ServePathRow {
+  return {
+    // Generate a stable key for each row using a random number converted to a base-36 string.
+    id: Math.random().toString(36).slice(2),
+    value,
+  };
+}
+
 export const Route = createFileRoute(
   '/_authed/settings/integrations/vercel/configure/$id/',
 )({
@@ -50,7 +63,7 @@ function VercelConfigure() {
   const [project, setProject] = useState<VercelProject>();
   const [updated, setUpdated] = useState(false);
   const [notFound, setNotFound] = useState(false);
-  const [paths, setPaths] = useState([defaultPath]);
+  const [paths, setPaths] = useState<ServePathRow[]>([createServePathRow(defaultPath)]);
 
   //
   // For tracking loading states since urql does not offer that on mutations
@@ -67,7 +80,11 @@ function VercelConfigure() {
     // have been made as those operations are not idempotent upstream.
     const p = data.projects.find((p) => p.projectID === id);
     if (p) {
-      p.servePath && setPaths(p.servePath.split(','));
+      setPaths(
+        p.servePath
+          ? p.servePath.split(',').map((path) => createServePathRow(path))
+          : [createServePathRow(defaultPath)]
+      );
       setOriginalProject(p);
       setNotFound(false);
     } else {
@@ -84,7 +101,7 @@ function VercelConfigure() {
   }, [project]);
 
   useEffect(() => {
-    project && setProject({ ...project, servePath: paths.join(',') });
+    project && setProject({ ...project, servePath: paths.map((path) => path.value).join(',') });
   }, [paths]);
 
   const submit = useCallback(async () => {
@@ -252,16 +269,19 @@ function VercelConfigure() {
                 </div>
                 {paths.map((path, i) => (
                   <div
-                    key={`serve-path-${i}`}
+                    key={path.id}
                     className="flex flex-row items-center justify-start"
                   >
                     <div className="mr-2 w-full">
                       <Input
-                        defaultValue={path}
+                        value={path.value}
                         className="text-basis h-10 w-full px-2 py-2 text-base"
                         onChange={({ target: { value } }) => {
-                          setPaths(paths.map((p, n) => (i === n ? value : p)));
-                          setProject(project);
+                          setPaths((prevPaths) =>
+                            prevPaths.map((currentPath, n) =>
+                              i === n ? { ...currentPath, value } : currentPath
+                            )
+                          );
                         }}
                       />
                     </div>
@@ -273,7 +293,7 @@ function VercelConfigure() {
                         icon={<RiDeleteBinLine className="h-5 w-5" />}
                         className="h-10 w-10"
                         onClick={() =>
-                          setPaths(paths.filter((_, n) => n !== i))
+                          setPaths((prevPaths) => prevPaths.filter((_, n) => n !== i))
                         }
                       />
                     )}
@@ -286,10 +306,7 @@ function VercelConfigure() {
                     iconSide="left"
                     label="Add new path"
                     className="mt-3"
-                    onClick={() => {
-                      setProject({ ...project });
-                      setPaths([...paths, '']);
-                    }}
+                    onClick={() => setPaths((prevPaths) => [...prevPaths, createServePathRow('')])}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Description

User reported a bug where deleting a row would visually make it look
like the last row was deleted. Saving the change actually sent the right
data over the network but this was still a bad UI bug.

It turns out these rows were uncontrolled inputs too because they only
set defaultValue and not value, so change them to fully controlled.

The react key with array index is precisely the pitfall here since we
allow deletions
https://react.dev/learn/rendering-lists#why-does-react-need-keys

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a UI bug where deleting a serve path row would visually appear to delete the last row instead of the selected one. The fix replaces array-index-based React keys with stable UUIDs and converts uncontrolled inputs (`defaultValue`) to controlled inputs (`value`).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 07e83d8040222db27844ae81bd3618694930fda5.</sup>
<!-- /MENDRAL_SUMMARY -->