### PR TITLE
hotfix: support || expression

### DIFF
--- a/pkg/expressions/expressions_test.go
+++ b/pkg/expressions/expressions_test.go
@@ -1031,6 +1031,133 @@ func TestEvaluateExpression(t *testing.T) {
 			false,
 			"",
 		},
+
+		// Logical OR with non-boolean operands uses JS-like truthy coercion.
+		// This returns the first truthy value, enabling expressions like
+		// "event.data.ingressId || event.data.userId" as debounce keys.
+		{
+			// Both present: returns the first truthy value (lhs)
+			expr: "event.data.ingressId || event.data.userId",
+			data: map[string]interface{}{
+				"event": map[string]interface{}{
+					"data": map[string]interface{}{
+						"ingressId": "IN_Mwj9Dm8r9QP2",
+						"userId":    "e67aed6a-4cd4-4465-ba23-bca6ef584292",
+					},
+				},
+			},
+			expected:  "IN_Mwj9Dm8r9QP2",
+			shouldErr: false,
+		},
+		{
+			// lhs present, rhs missing: returns lhs
+			expr: "event.data.ingressId || event.data.missing",
+			data: map[string]interface{}{
+				"event": map[string]interface{}{
+					"data": map[string]interface{}{
+						"ingressId": "IN_Mwj9Dm8r9QP2",
+					},
+				},
+			},
+			expected:  "IN_Mwj9Dm8r9QP2",
+			shouldErr: false,
+		},
+		{
+			// lhs missing, rhs present: returns rhs (fallback)
+			expr: "event.data.missing || event.data.userId",
+			data: map[string]interface{}{
+				"event": map[string]interface{}{
+					"data": map[string]interface{}{
+						"userId": "user-123",
+					},
+				},
+			},
+			expected:  "user-123",
+			shouldErr: false,
+		},
+		{
+			// lhs is empty string (falsy), rhs present: returns rhs
+			expr: "event.data.empty || event.data.userId",
+			data: map[string]interface{}{
+				"event": map[string]interface{}{
+					"data": map[string]interface{}{
+						"empty":  "",
+						"userId": "user-123",
+					},
+				},
+			},
+			expected:  "user-123",
+			shouldErr: false,
+		},
+		{
+			// both fields missing: both unknowns are falsy, returns rhs (unknown -> false)
+			expr: "event.data.a || event.data.b",
+			data: map[string]interface{}{
+				"event": map[string]interface{}{
+					"data": map[string]interface{}{},
+				},
+			},
+			expected:  false,
+			shouldErr: false,
+		},
+		{
+			// || with boolean operands still works correctly via native CEL
+			expr: "event.data.flagA || event.data.flagB",
+			data: map[string]interface{}{
+				"event": map[string]interface{}{
+					"data": map[string]interface{}{
+						"flagA": false,
+						"flagB": true,
+					},
+				},
+			},
+			expected:  true,
+			shouldErr: false,
+		},
+		{
+			// || with boolean operands, both false
+			expr: "event.data.flagA || event.data.flagB",
+			data: map[string]interface{}{
+				"event": map[string]interface{}{
+					"data": map[string]interface{}{
+						"flagA": false,
+						"flagB": false,
+					},
+				},
+			},
+			expected:  false,
+			shouldErr: false,
+		},
+		// Logical AND with non-boolean operands uses JS-like truthy coercion.
+		// Returns the first falsy value, or the last value if all truthy.
+		{
+			// Both truthy: returns rhs (last value)
+			expr: "event.data.a && event.data.b",
+			data: map[string]interface{}{
+				"event": map[string]interface{}{
+					"data": map[string]interface{}{
+						"a": "first",
+						"b": "second",
+					},
+				},
+			},
+			expected:  "second",
+			shouldErr: false,
+		},
+		{
+			// lhs is empty string (falsy): returns lhs
+			expr: "event.data.a && event.data.b",
+			data: map[string]interface{}{
+				"event": map[string]interface{}{
+					"data": map[string]interface{}{
+						"a": "",
+						"b": "second",
+					},
+				},
+			},
+			expected:  "",
+			shouldErr: false,
+		},
 	}
 
 	for n, item := range tests {
@@ -1188,6 +1315,99 @@ func TestFilteredAttributes(t *testing.T) {
 		require.NotNil(t, test.in)
 		actual := eval.FilteredAttributes(ctx, test.in)
 		require.Equal(t, test.expected, actual)
+	}
+}
+
+// TestDebounceKeyExpressions tests expression patterns commonly used as debounce keys.
+// Debounce keys use expressions.Evaluate() (not EvaluateBoolean), expecting the result
+// to be a string key. This test documents which patterns work and which fail.
+func TestDebounceKeyExpressions(t *testing.T) {
+	eventData := map[string]interface{}{
+		"event": map[string]interface{}{
+			"data": map[string]interface{}{
+				"ingressId": "IN_Mwj9Dm8r9QP2",
+				"timestamp": "2026-03-26T08:02:01.538Z",
+				"userId":    "e67aed6a-4cd4-4465-ba23-bca6ef584292",
+			},
+			"id":   "01KMMJM9P2JQWH09SKMQM4J1DF",
+			"name": "livekit/stream.started",
+			"ts":   1774512121538,
+			"user": map[string]interface{}{},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		expr      string
+		data      map[string]interface{}
+		expected  interface{}
+		shouldErr bool
+	}{
+		{
+			name:     "simple field access returns string value",
+			expr:     "event.data.ingressId",
+			data:     eventData,
+			expected: "IN_Mwj9Dm8r9QP2",
+		},
+		{
+			name:     "string concatenation for composite key",
+			expr:     "event.data.ingressId + '-' + event.data.userId",
+			data:     eventData,
+			expected: "IN_Mwj9Dm8r9QP2-e67aed6a-4cd4-4465-ba23-bca6ef584292",
+		},
+		{
+			// This is the exact expression from the production error.
+			// || with non-boolean operands now uses JS-like truthy coercion,
+			// returning the first truthy value.
+			name:     "logical OR returns first truthy string value",
+			expr:     "event.data.ingressId || event.data.userId",
+			data:     eventData,
+			expected: "IN_Mwj9Dm8r9QP2",
+		},
+		{
+			name:     "logical OR falls back to second value when first is missing",
+			expr:     "event.data.nonexistent || event.data.userId",
+			data:     eventData,
+			expected: "e67aed6a-4cd4-4465-ba23-bca6ef584292",
+		},
+		{
+			name:     "missing field returns empty string via concatenation",
+			expr:     "event.data.ingressId + event.data.missing",
+			data:     eventData,
+			expected: "IN_Mwj9Dm8r9QP2",
+		},
+		{
+			name: "missing field alone returns false (treated as null/unknown)",
+			expr: "event.data.nonexistent",
+			data: eventData,
+			// Missing fields are treated as unknowns, which resolve to false.
+			expected: false,
+		},
+		{
+			name:     "event.id as debounce key",
+			expr:     "event.id",
+			data:     eventData,
+			expected: "01KMMJM9P2JQWH09SKMQM4J1DF",
+		},
+		{
+			name:     "event.name as debounce key",
+			expr:     "event.name",
+			data:     eventData,
+			expected: "livekit/stream.started",
+		},
+	}
+
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Evaluate(ctx, tt.expr, tt.data)
+			if tt.shouldErr {
+				require.Error(t, err, "expected error for expression: %s", tt.expr)
+				return
+			}
+			require.NoError(t, err, "unexpected error for expression: %s", tt.expr)
+			require.Equal(t, tt.expected, result, "unexpected result for expression: %s", tt.expr)
+		})
 	}
 }
 

--- a/pkg/expressions/unknown.go
+++ b/pkg/expressions/unknown.go
@@ -2,7 +2,9 @@ package expressions
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
+	"unsafe"
 
 	"github.com/google/cel-go/common/operators"
 	"github.com/google/cel-go/common/overloads"
@@ -25,6 +27,16 @@ func unknownDecorator(act interpreter.PartialActivation) interpreter.Interpretab
 	_ = dispatcher.Add(overloads...)
 
 	return func(i interpreter.Interpretable) (interpreter.Interpretable, error) {
+		// Handle logical OR/AND nodes.  CEL represents || and && as special
+		// evalOr/evalAnd (or evalExhaustiveOr/evalExhaustiveAnd) structs that
+		// are NOT InterpretableCall.  They require boolean operands, but users
+		// commonly write "event.data.a || event.data.b" expecting JS-like truthy
+		// coercion.  We detect these nodes via reflection and wrap them to
+		// implement truthy coercion when operands are non-boolean.
+		if wrapped, ok := maybeWrapLogicalOp(i, act); ok {
+			return wrapped, nil
+		}
+
 		// If this is a fold call, this is a macro (exists, has, etc), and is not an InterpretableCall
 		call, ok := i.(interpreter.InterpretableCall)
 		if !ok {
@@ -200,6 +212,121 @@ func handleUnknownCall(i interpreter.InterpretableCall, args *argColl) (interpre
 		// By default, return false, for eaxmple: "_<_", "@in", "@not_strictly_false"
 		// return staticCall{result: types.False, InterpretableCall: call}, nil
 		return staticCall{result: types.False, InterpretableCall: i}, nil
+	}
+}
+
+// maybeWrapLogicalOp detects CEL's internal evalOr/evalAnd (and their exhaustive
+// variants) via reflection and wraps them to implement JS-like truthy coercion
+// when operands are non-boolean.  Returns (wrapped, true) if the node was wrapped,
+// or (nil, false) if the node is not a logical operator.
+func maybeWrapLogicalOp(i interpreter.Interpretable, act interpreter.PartialActivation) (interpreter.Interpretable, bool) {
+	typeName := reflect.TypeOf(i).String()
+
+	var isOr bool
+	switch {
+	case strings.Contains(typeName, "evalOr") || strings.Contains(typeName, "evalExhaustiveOr"):
+		isOr = true
+	case strings.Contains(typeName, "evalAnd") || strings.Contains(typeName, "evalExhaustiveAnd"):
+		isOr = false
+	default:
+		return nil, false
+	}
+
+	// Extract the terms field via reflection + unsafe, since the CEL structs
+	// are unexported.  The struct layout is:
+	//   type eval{Exhaustive}{Or,And} struct {
+	//       id    int64
+	//       terms []interpreter.Interpretable
+	//   }
+	v := reflect.ValueOf(i)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	termsField := v.FieldByName("terms")
+	if !termsField.IsValid() {
+		return nil, false
+	}
+
+	// Use unsafe to read the unexported field.
+	terms := *(*[]interpreter.Interpretable)(unsafe.Pointer(termsField.UnsafeAddr()))
+
+	return &evalTruthyLogical{
+		inner: i,
+		terms: terms,
+		isOr:  isOr,
+	}, true
+}
+
+// evalTruthyLogical wraps a CEL evalOr/evalAnd node to support JS-like truthy
+// coercion for non-boolean operands.  If all operands are booleans, it delegates
+// to the original CEL evaluation.
+type evalTruthyLogical struct {
+	inner interpreter.Interpretable
+	terms []interpreter.Interpretable
+	isOr  bool
+}
+
+func (e *evalTruthyLogical) ID() int64 {
+	return e.inner.ID()
+}
+
+func (e *evalTruthyLogical) Eval(ctx interpreter.Activation) ref.Val {
+	// Evaluate all terms to check their types.
+	vals := make([]ref.Val, len(e.terms))
+	allBool := true
+	for idx, term := range e.terms {
+		vals[idx] = term.Eval(ctx)
+		if vals[idx] == nil || vals[idx].Type() != types.BoolType {
+			allBool = false
+		}
+	}
+
+	// If all operands are booleans, delegate to native CEL evaluation.
+	if allBool {
+		return e.inner.Eval(ctx)
+	}
+
+	// Apply JS-like truthy coercion.
+	if e.isOr {
+		// Return the first truthy value, or the last value.
+		for _, val := range vals {
+			if isTruthy(val) {
+				return val
+			}
+		}
+		return vals[len(vals)-1]
+	}
+
+	// AND: return the first falsy value, or the last value.
+	for _, val := range vals {
+		if !isTruthy(val) {
+			return val
+		}
+	}
+	return vals[len(vals)-1]
+}
+
+// isTruthy returns whether a CEL value is "truthy" using JS-like semantics.
+// Falsy values: unknown, error, null, false, empty string, 0, empty list/map.
+func isTruthy(v ref.Val) bool {
+	if v == nil || types.IsUnknown(v) || types.IsError(v) {
+		return false
+	}
+	switch v.Type() {
+	case types.NullType:
+		return false
+	case types.BoolType:
+		return v.Value().(bool)
+	case types.StringType:
+		return v.Value().(string) != ""
+	case types.IntType:
+		return v.Value().(int64) != 0
+	case types.UintType:
+		return v.Value().(uint64) != 0
+	case types.DoubleType:
+		return v.Value().(float64) != 0
+	default:
+		return true
 	}
 }
 


### PR DESCRIPTION
## Description


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR adds JS-like truthy coercion for `||` and `&&` operators in CEL expressions to support debounce key patterns like `event.data.ingressId || event.data.userId`. It works by using reflection and `unsafe` to intercept CEL's internal `evalOr`/`evalAnd` structs and wrap them with a custom evaluator.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f5cd927d394271cfe2f75b42266e6d8a2feb9055.</sup>
<!-- /MENDRAL_SUMMARY -->