### PR TITLE
Add more logs around partition iterator

### DIFF
--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -165,6 +165,9 @@ func (q *queue) ItemsByPartition(ctx context.Context, partitionID string, from t
 	}
 
 	l = l.With("account_id", pt.AccountID.String())
+	if pt.EnvID != nil {
+		l = l.With("env_id", pt.EnvID.String())
+	}
 
 	return func(yield func(*osqueue.QueueItem) bool) {
 		ptFrom := from
@@ -186,6 +189,7 @@ func (q *queue) ItemsByPartition(ctx context.Context, partitionID string, from t
 				}
 				return
 			}
+			l.Info("peeked partition items", "raw_count", result.RawCount, "last_score", result.LastScore, "item_count", len(result.Items))
 
 			var start, end time.Time
 			for _, qi := range result.Items {
@@ -215,6 +219,7 @@ func (q *queue) ItemsByPartition(ctx context.Context, partitionID string, from t
 			// No raw items were fetched from the sorted set — the partition
 			// range is exhausted.
 			if result.RawCount == 0 {
+				l.Info("no more items to iterate on in partition", "raw_count", result.RawCount, "last_score", result.LastScore, "item_count", len(result.Items))
 				break
 			}
 


### PR DESCRIPTION
## Description

To better understand edge cases in the iterator

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds 5 lines of structured logging to `ItemsByPartition` in the Redis queue reader: conditionally attaches `env_id` to the logger when non-nil, logs a summary after each peek (raw count, last score, item count), and logs when the partition iterator is exhausted.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3f0fb681306516359edf53982267502ea3faad6c.</sup>
<!-- /MENDRAL_SUMMARY -->