### PR TITLE
Always enable Constraint API for devserver tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,13 +17,12 @@ env:
 
 jobs:
   ts:
-    name: "TS SDK / OS: (${{ matrix.os }}), key-queues: ${{ matrix.experimentalKeyQueues }}, constraint-api: ${{ matrix.enableConstraintAPI }}"
+    name: "TS SDK / OS: (${{ matrix.os }}), key-queues: ${{ matrix.experimentalKeyQueues }}"
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
         experimentalKeyQueues: [false, true]
-        enableConstraintAPI: [false, true]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -60,7 +59,7 @@ jobs:
           cd ../../
           echo "Running dev server"
           mkdir $GOCOVERDIR
-          nohup ./inngest-bin dev --no-discovery 2> /tmp/devserver-logs-kq-${{ matrix.experimentalKeyQueues }}-api-${{ matrix.enableConstraintAPI }}.txt &
+          nohup ./inngest-bin dev --no-discovery 2> /tmp/devserver-logs-kq-${{ matrix.experimentalKeyQueues }}-api.txt &
           echo "Ran dev server"
           sleep 5
           curl http://127.0.0.1:8288/dev > /dev/null 2> /dev/null
@@ -71,7 +70,7 @@ jobs:
           SDK_URL: http://127.0.0.1:3000/api/inngest
           TEST_MODE: true
           EXPERIMENTAL_KEY_QUEUES_ENABLE: "${{ matrix.experimentalKeyQueues }}"
-          ENABLE_CONSTRAINT_API: "${{ matrix.enableConstraintAPI }}"
+          ENABLE_CONSTRAINT_API: true
           LOG_LEVEL: trace
 
       - name: Convert coverage for tooling
@@ -84,8 +83,8 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: devserver-logs-kq-${{ matrix.experimentalKeyQueues }}-api-${{ matrix.enableConstraintAPI }}
-          path: /tmp/devserver-logs-kq-${{ matrix.experimentalKeyQueues }}-api-${{ matrix.enableConstraintAPI }}.txt
+          name: devserver-logs-kq-${{ matrix.experimentalKeyQueues }}-api
+          path: /tmp/devserver-logs-kq-${{ matrix.experimentalKeyQueues }}-api.txt
           retention-days: 7
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the `enableConstraintAPI` matrix dimension from the TS SDK e2e workflow, hardcoding `ENABLE_CONSTRAINT_API=true` so the Constraint API is always enabled in devserver tests. This halves the number of TS SDK CI matrix jobs (from 4 to 2) and updates log file names and artifact names accordingly.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7f6b549f0448f5d7747435d14272fe6791c6477a.</sup>
<!-- /MENDRAL_SUMMARY -->