### PR TITLE
Add worker status messages

### DIFF
--- a/proto/gen/api/v2/apiv2connect/service.connect.go
+++ b/proto/gen/api/v2/apiv2connect/service.connect.go
@@ -63,24 +63,6 @@ const (
 	V2InvokeFunctionProcedure = "/api.v2.V2/InvokeFunction"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	v2ServiceDescriptor                       = v2.File_api_v2_service_proto.Services().ByName("V2")
-	v2HealthMethodDescriptor                  = v2ServiceDescriptor.Methods().ByName("Health")
-	v2XSchemaOnlyMethodDescriptor             = v2ServiceDescriptor.Methods().ByName("_SchemaOnly")
-	v2CreatePartnerAccountMethodDescriptor    = v2ServiceDescriptor.Methods().ByName("CreatePartnerAccount")
-	v2CreateEnvMethodDescriptor               = v2ServiceDescriptor.Methods().ByName("CreateEnv")
-	v2FetchPartnerAccountsMethodDescriptor    = v2ServiceDescriptor.Methods().ByName("FetchPartnerAccounts")
-	v2FetchAccountMethodDescriptor            = v2ServiceDescriptor.Methods().ByName("FetchAccount")
-	v2FetchAccountEnvsMethodDescriptor        = v2ServiceDescriptor.Methods().ByName("FetchAccountEnvs")
-	v2FetchAccountEventKeysMethodDescriptor   = v2ServiceDescriptor.Methods().ByName("FetchAccountEventKeys")
-	v2FetchAccountSigningKeysMethodDescriptor = v2ServiceDescriptor.Methods().ByName("FetchAccountSigningKeys")
-	v2CreateWebhookMethodDescriptor           = v2ServiceDescriptor.Methods().ByName("CreateWebhook")
-	v2ListWebhooksMethodDescriptor            = v2ServiceDescriptor.Methods().ByName("ListWebhooks")
-	v2PatchEnvMethodDescriptor                = v2ServiceDescriptor.Methods().ByName("PatchEnv")
-	v2InvokeFunctionMethodDescriptor          = v2ServiceDescriptor.Methods().ByName("InvokeFunction")
-)
-
 // V2Client is a client for the api.v2.V2 service.
 type V2Client interface {
 	Health(context.Context, *connect.Request[v2.HealthRequest]) (*connect.Response[v2.HealthResponse], error)
@@ -108,83 +90,84 @@ type V2Client interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewV2Client(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) V2Client {
 	baseURL = strings.TrimRight(baseURL, "/")
+	v2Methods := v2.File_api_v2_service_proto.Services().ByName("V2").Methods()
 	return &v2Client{
 		health: connect.NewClient[v2.HealthRequest, v2.HealthResponse](
 			httpClient,
 			baseURL+V2HealthProcedure,
-			connect.WithSchema(v2HealthMethodDescriptor),
+			connect.WithSchema(v2Methods.ByName("Health")),
 			connect.WithClientOptions(opts...),
 		),
 		xSchemaOnly: connect.NewClient[v2.HealthRequest, v2.ErrorResponse](
 			httpClient,
 			baseURL+V2XSchemaOnlyProcedure,
-			connect.WithSchema(v2XSchemaOnlyMethodDescriptor),
+			connect.WithSchema(v2Methods.ByName("_SchemaOnly")),
 			connect.WithClientOptions(opts...),
 		),
 		createPartnerAccount: connect.NewClient[v2.CreateAccountRequest, v2.CreateAccountResponse](
 			httpClient,
 			baseURL+V2CreatePartnerAccountProcedure,
-			connect.WithSchema(v2CreatePartnerAccountMethodDescriptor),
+			connect.WithSchema(v2Methods.ByName("CreatePartnerAccount")),
 			connect.WithClientOptions(opts...),
 		),
 		createEnv: connect.NewClient[v2.CreateEnvRequest, v2.CreateEnvResponse](
 			httpClient,
 			baseURL+V2CreateEnvProcedure,
-			connect.WithSchema(v2CreateEnvMethodDescriptor),
+			connect.WithSchema(v2Methods.ByName("CreateEnv")),
 			connect.WithClientOptions(opts...),
 		),
 		fetchPartnerAccounts: connect.NewClient[v2.FetchAccountsRequest, v2.FetchAccountsResponse](
 			httpClient,
 			baseURL+V2FetchPartnerAccountsProcedure,
-			connect.WithSchema(v2FetchPartnerAccountsMethodDescriptor),
+			connect.WithSchema(v2Methods.ByName("FetchPartnerAccounts")),
 			connect.WithClientOptions(opts...),
 		),
 		fetchAccount: connect.NewClient[v2.FetchAccountRequest, v2.FetchAccountResponse](
 			httpClient,
 			baseURL+V2FetchAccountProcedure,
-			connect.WithSchema(v2FetchAccountMethodDescriptor),
+			connect.WithSchema(v2Methods.ByName("FetchAccount")),
 			connect.WithClientOptions(opts...),
 		),
 		fetchAccountEnvs: connect.NewClient[v2.FetchAccountEnvsRequest, v2.FetchAccountEnvsResponse](
 			httpClient,
 			baseURL+V2FetchAccountEnvsProcedure,
-			connect.WithSchema(v2FetchAccountEnvsMethodDescriptor),
+			connect.WithSchema(v2Methods.ByName("FetchAccountEnvs")),
 			connect.WithClientOptions(opts...),
 		),
 		fetchAccountEventKeys: connect.NewClient[v2.FetchAccountEventKeysRequest, v2.FetchAccountEventKeysResponse](
 			httpClient,
 			baseURL+V2FetchAccountEventKeysProcedure,
-			connect.WithSchema(v2FetchAccountEventKeysMethodDescriptor),
+			connect.WithSchema(v2Methods.ByName("FetchAccountEventKeys")),
 			connect.WithClientOptions(opts...),
 		),
 		fetchAccountSigningKeys: connect.NewClient[v2.FetchAccountSigningKeysRequest, v2.FetchAccountSigningKeysResponse](
 			httpClient,
 			baseURL+V2FetchAccountSigningKeysProcedure,
-			connect.WithSchema(v2FetchAccountSigningKeysMethodDescriptor),
+			connect.WithSchema(v2Methods.ByName("FetchAccountSigningKeys")),
 			connect.WithClientOptions(opts...),
 		),
 		createWebhook: connect.NewClient[v2.CreateWebhookRequest, v2.CreateWebhookResponse](
 			httpClient,
 			baseURL+V2CreateWebhookProcedure,
-			connect.WithSchema(v2CreateWebhookMethodDescriptor),
+			connect.WithSchema(v2Methods.ByName("CreateWebhook")),
 			connect.WithClientOptions(opts...),
 		),
 		listWebhooks: connect.NewClient[v2.ListWebhooksRequest, v2.ListWebhooksResponse](
 			httpClient,
 			baseURL+V2ListWebhooksProcedure,
-			connect.WithSchema(v2ListWebhooksMethodDescriptor),
+			connect.WithSchema(v2Methods.ByName("ListWebhooks")),
 			connect.WithClientOptions(opts...),
 		),
 		patchEnv: connect.NewClient[v2.PatchEnvRequest, v2.PatchEnvsResponse](
 			httpClient,
 			baseURL+V2PatchEnvProcedure,
-			connect.WithSchema(v2PatchEnvMethodDescriptor),
+			connect.WithSchema(v2Methods.ByName("PatchEnv")),
 			connect.WithClientOptions(opts...),
 		),
 		invokeFunction: connect.NewClient[v2.InvokeFunctionRequest, v2.InvokeFunctionResponse](
 			httpClient,
 			baseURL+V2InvokeFunctionProcedure,
-			connect.WithSchema(v2InvokeFunctionMethodDescriptor),
+			connect.WithSchema(v2Methods.ByName("InvokeFunction")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -296,82 +279,83 @@ type V2Handler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Handler) {
+	v2Methods := v2.File_api_v2_service_proto.Services().ByName("V2").Methods()
 	v2HealthHandler := connect.NewUnaryHandler(
 		V2HealthProcedure,
 		svc.Health,
-		connect.WithSchema(v2HealthMethodDescriptor),
+		connect.WithSchema(v2Methods.ByName("Health")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2XSchemaOnlyHandler := connect.NewUnaryHandler(
 		V2XSchemaOnlyProcedure,
 		svc.XSchemaOnly,
-		connect.WithSchema(v2XSchemaOnlyMethodDescriptor),
+		connect.WithSchema(v2Methods.ByName("_SchemaOnly")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2CreatePartnerAccountHandler := connect.NewUnaryHandler(
 		V2CreatePartnerAccountProcedure,
 		svc.CreatePartnerAccount,
-		connect.WithSchema(v2CreatePartnerAccountMethodDescriptor),
+		connect.WithSchema(v2Methods.ByName("CreatePartnerAccount")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2CreateEnvHandler := connect.NewUnaryHandler(
 		V2CreateEnvProcedure,
 		svc.CreateEnv,
-		connect.WithSchema(v2CreateEnvMethodDescriptor),
+		connect.WithSchema(v2Methods.ByName("CreateEnv")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2FetchPartnerAccountsHandler := connect.NewUnaryHandler(
 		V2FetchPartnerAccountsProcedure,
 		svc.FetchPartnerAccounts,
-		connect.WithSchema(v2FetchPartnerAccountsMethodDescriptor),
+		connect.WithSchema(v2Methods.ByName("FetchPartnerAccounts")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2FetchAccountHandler := connect.NewUnaryHandler(
 		V2FetchAccountProcedure,
 		svc.FetchAccount,
-		connect.WithSchema(v2FetchAccountMethodDescriptor),
+		connect.WithSchema(v2Methods.ByName("FetchAccount")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2FetchAccountEnvsHandler := connect.NewUnaryHandler(
 		V2FetchAccountEnvsProcedure,
 		svc.FetchAccountEnvs,
-		connect.WithSchema(v2FetchAccountEnvsMethodDescriptor),
+		connect.WithSchema(v2Methods.ByName("FetchAccountEnvs")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2FetchAccountEventKeysHandler := connect.NewUnaryHandler(
 		V2FetchAccountEventKeysProcedure,
 		svc.FetchAccountEventKeys,
-		connect.WithSchema(v2FetchAccountEventKeysMethodDescriptor),
+		connect.WithSchema(v2Methods.ByName("FetchAccountEventKeys")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2FetchAccountSigningKeysHandler := connect.NewUnaryHandler(
 		V2FetchAccountSigningKeysProcedure,
 		svc.FetchAccountSigningKeys,
-		connect.WithSchema(v2FetchAccountSigningKeysMethodDescriptor),
+		connect.WithSchema(v2Methods.ByName("FetchAccountSigningKeys")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2CreateWebhookHandler := connect.NewUnaryHandler(
 		V2CreateWebhookProcedure,
 		svc.CreateWebhook,
-		connect.WithSchema(v2CreateWebhookMethodDescriptor),
+		connect.WithSchema(v2Methods.ByName("CreateWebhook")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2ListWebhooksHandler := connect.NewUnaryHandler(
 		V2ListWebhooksProcedure,
 		svc.ListWebhooks,
-		connect.WithSchema(v2ListWebhooksMethodDescriptor),
+		connect.WithSchema(v2Methods.ByName("ListWebhooks")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2PatchEnvHandler := connect.NewUnaryHandler(
 		V2PatchEnvProcedure,
 		svc.PatchEnv,
-		connect.WithSchema(v2PatchEnvMethodDescriptor),
+		connect.WithSchema(v2Methods.ByName("PatchEnv")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2InvokeFunctionHandler := connect.NewUnaryHandler(
 		V2InvokeFunctionProcedure,
 		svc.InvokeFunction,
-		connect.WithSchema(v2InvokeFunctionMethodDescriptor),
+		connect.WithSchema(v2Methods.ByName("InvokeFunction")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/api.v2.V2/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/proto/gen/connect/v1/connectconnect/service.connect.go
+++ b/proto/gen/connect/v1/connectconnect/service.connect.go
@@ -47,17 +47,6 @@ const (
 	ConnectExecutorPingProcedure = "/connect.v1.ConnectExecutor/Ping"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	connectGatewayServiceDescriptor       = v1.File_connect_v1_service_proto.Services().ByName("ConnectGateway")
-	connectGatewayForwardMethodDescriptor = connectGatewayServiceDescriptor.Methods().ByName("Forward")
-	connectGatewayPingMethodDescriptor    = connectGatewayServiceDescriptor.Methods().ByName("Ping")
-	connectExecutorServiceDescriptor      = v1.File_connect_v1_service_proto.Services().ByName("ConnectExecutor")
-	connectExecutorReplyMethodDescriptor  = connectExecutorServiceDescriptor.Methods().ByName("Reply")
-	connectExecutorAckMethodDescriptor    = connectExecutorServiceDescriptor.Methods().ByName("Ack")
-	connectExecutorPingMethodDescriptor   = connectExecutorServiceDescriptor.Methods().ByName("Ping")
-)
-
 // ConnectGatewayClient is a client for the connect.v1.ConnectGateway service.
 type ConnectGatewayClient interface {
 	Forward(context.Context, *connect.Request[v1.ForwardRequest]) (*connect.Response[v1.ForwardResponse], error)
@@ -73,17 +62,18 @@ type ConnectGatewayClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewConnectGatewayClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) ConnectGatewayClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	connectGatewayMethods := v1.File_connect_v1_service_proto.Services().ByName("ConnectGateway").Methods()
 	return &connectGatewayClient{
 		forward: connect.NewClient[v1.ForwardRequest, v1.ForwardResponse](
 			httpClient,
 			baseURL+ConnectGatewayForwardProcedure,
-			connect.WithSchema(connectGatewayForwardMethodDescriptor),
+			connect.WithSchema(connectGatewayMethods.ByName("Forward")),
 			connect.WithClientOptions(opts...),
 		),
 		ping: connect.NewClient[v1.PingRequest, v1.PingResponse](
 			httpClient,
 			baseURL+ConnectGatewayPingProcedure,
-			connect.WithSchema(connectGatewayPingMethodDescriptor),
+			connect.WithSchema(connectGatewayMethods.ByName("Ping")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -117,16 +107,17 @@ type ConnectGatewayHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewConnectGatewayHandler(svc ConnectGatewayHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	connectGatewayMethods := v1.File_connect_v1_service_proto.Services().ByName("ConnectGateway").Methods()
 	connectGatewayForwardHandler := connect.NewUnaryHandler(
 		ConnectGatewayForwardProcedure,
 		svc.Forward,
-		connect.WithSchema(connectGatewayForwardMethodDescriptor),
+		connect.WithSchema(connectGatewayMethods.ByName("Forward")),
 		connect.WithHandlerOptions(opts...),
 	)
 	connectGatewayPingHandler := connect.NewUnaryHandler(
 		ConnectGatewayPingProcedure,
 		svc.Ping,
-		connect.WithSchema(connectGatewayPingMethodDescriptor),
+		connect.WithSchema(connectGatewayMethods.ByName("Ping")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/connect.v1.ConnectGateway/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -168,23 +159,24 @@ type ConnectExecutorClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewConnectExecutorClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) ConnectExecutorClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	connectExecutorMethods := v1.File_connect_v1_service_proto.Services().ByName("ConnectExecutor").Methods()
 	return &connectExecutorClient{
 		reply: connect.NewClient[v1.ReplyRequest, v1.ReplyResponse](
 			httpClient,
 			baseURL+ConnectExecutorReplyProcedure,
-			connect.WithSchema(connectExecutorReplyMethodDescriptor),
+			connect.WithSchema(connectExecutorMethods.ByName("Reply")),
 			connect.WithClientOptions(opts...),
 		),
 		ack: connect.NewClient[v1.AckMessage, v1.AckResponse](
 			httpClient,
 			baseURL+ConnectExecutorAckProcedure,
-			connect.WithSchema(connectExecutorAckMethodDescriptor),
+			connect.WithSchema(connectExecutorMethods.ByName("Ack")),
 			connect.WithClientOptions(opts...),
 		),
 		ping: connect.NewClient[v1.PingRequest, v1.PingResponse](
 			httpClient,
 			baseURL+ConnectExecutorPingProcedure,
-			connect.WithSchema(connectExecutorPingMethodDescriptor),
+			connect.WithSchema(connectExecutorMethods.ByName("Ping")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -225,22 +217,23 @@ type ConnectExecutorHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewConnectExecutorHandler(svc ConnectExecutorHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	connectExecutorMethods := v1.File_connect_v1_service_proto.Services().ByName("ConnectExecutor").Methods()
 	connectExecutorReplyHandler := connect.NewUnaryHandler(
 		ConnectExecutorReplyProcedure,
 		svc.Reply,
-		connect.WithSchema(connectExecutorReplyMethodDescriptor),
+		connect.WithSchema(connectExecutorMethods.ByName("Reply")),
 		connect.WithHandlerOptions(opts...),
 	)
 	connectExecutorAckHandler := connect.NewUnaryHandler(
 		ConnectExecutorAckProcedure,
 		svc.Ack,
-		connect.WithSchema(connectExecutorAckMethodDescriptor),
+		connect.WithSchema(connectExecutorMethods.ByName("Ack")),
 		connect.WithHandlerOptions(opts...),
 	)
 	connectExecutorPingHandler := connect.NewUnaryHandler(
 		ConnectExecutorPingProcedure,
 		svc.Ping,
-		connect.WithSchema(connectExecutorPingMethodDescriptor),
+		connect.WithSchema(connectExecutorMethods.ByName("Ping")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/connect.v1.ConnectExecutor/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/proto/gen/constraintapi/v1/constraintapiconnect/service.connect.go
+++ b/proto/gen/constraintapi/v1/constraintapiconnect/service.connect.go
@@ -44,15 +44,6 @@ const (
 	ConstraintAPIReleaseProcedure = "/constraintapi.v1.ConstraintAPI/Release"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	constraintAPIServiceDescriptor           = v1.File_constraintapi_v1_service_proto.Services().ByName("ConstraintAPI")
-	constraintAPICheckMethodDescriptor       = constraintAPIServiceDescriptor.Methods().ByName("Check")
-	constraintAPIAcquireMethodDescriptor     = constraintAPIServiceDescriptor.Methods().ByName("Acquire")
-	constraintAPIExtendLeaseMethodDescriptor = constraintAPIServiceDescriptor.Methods().ByName("ExtendLease")
-	constraintAPIReleaseMethodDescriptor     = constraintAPIServiceDescriptor.Methods().ByName("Release")
-)
-
 // ConstraintAPIClient is a client for the constraintapi.v1.ConstraintAPI service.
 type ConstraintAPIClient interface {
 	Check(context.Context, *connect.Request[v1.CapacityCheckRequest]) (*connect.Response[v1.CapacityCheckResponse], error)
@@ -70,29 +61,30 @@ type ConstraintAPIClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewConstraintAPIClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) ConstraintAPIClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	constraintAPIMethods := v1.File_constraintapi_v1_service_proto.Services().ByName("ConstraintAPI").Methods()
 	return &constraintAPIClient{
 		check: connect.NewClient[v1.CapacityCheckRequest, v1.CapacityCheckResponse](
 			httpClient,
 			baseURL+ConstraintAPICheckProcedure,
-			connect.WithSchema(constraintAPICheckMethodDescriptor),
+			connect.WithSchema(constraintAPIMethods.ByName("Check")),
 			connect.WithClientOptions(opts...),
 		),
 		acquire: connect.NewClient[v1.CapacityAcquireRequest, v1.CapacityAcquireResponse](
 			httpClient,
 			baseURL+ConstraintAPIAcquireProcedure,
-			connect.WithSchema(constraintAPIAcquireMethodDescriptor),
+			connect.WithSchema(constraintAPIMethods.ByName("Acquire")),
 			connect.WithClientOptions(opts...),
 		),
 		extendLease: connect.NewClient[v1.CapacityExtendLeaseRequest, v1.CapacityExtendLeaseResponse](
 			httpClient,
 			baseURL+ConstraintAPIExtendLeaseProcedure,
-			connect.WithSchema(constraintAPIExtendLeaseMethodDescriptor),
+			connect.WithSchema(constraintAPIMethods.ByName("ExtendLease")),
 			connect.WithClientOptions(opts...),
 		),
 		release: connect.NewClient[v1.CapacityReleaseRequest, v1.CapacityReleaseResponse](
 			httpClient,
 			baseURL+ConstraintAPIReleaseProcedure,
-			connect.WithSchema(constraintAPIReleaseMethodDescriptor),
+			connect.WithSchema(constraintAPIMethods.ByName("Release")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -140,28 +132,29 @@ type ConstraintAPIHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewConstraintAPIHandler(svc ConstraintAPIHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	constraintAPIMethods := v1.File_constraintapi_v1_service_proto.Services().ByName("ConstraintAPI").Methods()
 	constraintAPICheckHandler := connect.NewUnaryHandler(
 		ConstraintAPICheckProcedure,
 		svc.Check,
-		connect.WithSchema(constraintAPICheckMethodDescriptor),
+		connect.WithSchema(constraintAPIMethods.ByName("Check")),
 		connect.WithHandlerOptions(opts...),
 	)
 	constraintAPIAcquireHandler := connect.NewUnaryHandler(
 		ConstraintAPIAcquireProcedure,
 		svc.Acquire,
-		connect.WithSchema(constraintAPIAcquireMethodDescriptor),
+		connect.WithSchema(constraintAPIMethods.ByName("Acquire")),
 		connect.WithHandlerOptions(opts...),
 	)
 	constraintAPIExtendLeaseHandler := connect.NewUnaryHandler(
 		ConstraintAPIExtendLeaseProcedure,
 		svc.ExtendLease,
-		connect.WithSchema(constraintAPIExtendLeaseMethodDescriptor),
+		connect.WithSchema(constraintAPIMethods.ByName("ExtendLease")),
 		connect.WithHandlerOptions(opts...),
 	)
 	constraintAPIReleaseHandler := connect.NewUnaryHandler(
 		ConstraintAPIReleaseProcedure,
 		svc.Release,
-		connect.WithSchema(constraintAPIReleaseMethodDescriptor),
+		connect.WithSchema(constraintAPIMethods.ByName("Release")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/constraintapi.v1.ConstraintAPI/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/proto/gen/debug/v1/debugconnect/service.connect.go
+++ b/proto/gen/debug/v1/debugconnect/service.connect.go
@@ -80,31 +80,6 @@ const (
 	DebugGetBacklogSizeProcedure = "/debug.v1.Debug/GetBacklogSize"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	debugServiceDescriptor                   = v1.File_debug_v1_service_proto.Services().ByName("Debug")
-	debugGetPartitionMethodDescriptor        = debugServiceDescriptor.Methods().ByName("GetPartition")
-	debugGetPartitionStatusMethodDescriptor  = debugServiceDescriptor.Methods().ByName("GetPartitionStatus")
-	debugGetQueueItemMethodDescriptor        = debugServiceDescriptor.Methods().ByName("GetQueueItem")
-	debugGetPauseMethodDescriptor            = debugServiceDescriptor.Methods().ByName("GetPause")
-	debugGetIndexMethodDescriptor            = debugServiceDescriptor.Methods().ByName("GetIndex")
-	debugBlockPeekMethodDescriptor           = debugServiceDescriptor.Methods().ByName("BlockPeek")
-	debugBlockDeletedMethodDescriptor        = debugServiceDescriptor.Methods().ByName("BlockDeleted")
-	debugCheckConstraintsMethodDescriptor    = debugServiceDescriptor.Methods().ByName("CheckConstraints")
-	debugGetBatchInfoMethodDescriptor        = debugServiceDescriptor.Methods().ByName("GetBatchInfo")
-	debugDeleteBatchMethodDescriptor         = debugServiceDescriptor.Methods().ByName("DeleteBatch")
-	debugRunBatchMethodDescriptor            = debugServiceDescriptor.Methods().ByName("RunBatch")
-	debugGetSingletonInfoMethodDescriptor    = debugServiceDescriptor.Methods().ByName("GetSingletonInfo")
-	debugDeleteSingletonLockMethodDescriptor = debugServiceDescriptor.Methods().ByName("DeleteSingletonLock")
-	debugGetDebounceInfoMethodDescriptor     = debugServiceDescriptor.Methods().ByName("GetDebounceInfo")
-	debugDeleteDebounceMethodDescriptor      = debugServiceDescriptor.Methods().ByName("DeleteDebounce")
-	debugRunDebounceMethodDescriptor         = debugServiceDescriptor.Methods().ByName("RunDebounce")
-	debugDeleteDebounceByIDMethodDescriptor  = debugServiceDescriptor.Methods().ByName("DeleteDebounceByID")
-	debugGetShadowPartitionMethodDescriptor  = debugServiceDescriptor.Methods().ByName("GetShadowPartition")
-	debugGetBacklogsMethodDescriptor         = debugServiceDescriptor.Methods().ByName("GetBacklogs")
-	debugGetBacklogSizeMethodDescriptor      = debugServiceDescriptor.Methods().ByName("GetBacklogSize")
-)
-
 // DebugClient is a client for the debug.v1.Debug service.
 type DebugClient interface {
 	// GetPartition retrieves the partition data from the database
@@ -159,125 +134,126 @@ type DebugClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewDebugClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) DebugClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	debugMethods := v1.File_debug_v1_service_proto.Services().ByName("Debug").Methods()
 	return &debugClient{
 		getPartition: connect.NewClient[v1.PartitionRequest, v1.PartitionResponse](
 			httpClient,
 			baseURL+DebugGetPartitionProcedure,
-			connect.WithSchema(debugGetPartitionMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("GetPartition")),
 			connect.WithClientOptions(opts...),
 		),
 		getPartitionStatus: connect.NewClient[v1.PartitionRequest, v1.PartitionStatusResponse](
 			httpClient,
 			baseURL+DebugGetPartitionStatusProcedure,
-			connect.WithSchema(debugGetPartitionStatusMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("GetPartitionStatus")),
 			connect.WithClientOptions(opts...),
 		),
 		getQueueItem: connect.NewClient[v1.QueueItemRequest, v1.QueueItemResponse](
 			httpClient,
 			baseURL+DebugGetQueueItemProcedure,
-			connect.WithSchema(debugGetQueueItemMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("GetQueueItem")),
 			connect.WithClientOptions(opts...),
 		),
 		getPause: connect.NewClient[v1.PauseRequest, v1.PauseResponse](
 			httpClient,
 			baseURL+DebugGetPauseProcedure,
-			connect.WithSchema(debugGetPauseMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("GetPause")),
 			connect.WithClientOptions(opts...),
 		),
 		getIndex: connect.NewClient[v1.IndexRequest, v1.IndexResponse](
 			httpClient,
 			baseURL+DebugGetIndexProcedure,
-			connect.WithSchema(debugGetIndexMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("GetIndex")),
 			connect.WithClientOptions(opts...),
 		),
 		blockPeek: connect.NewClient[v1.BlockPeekRequest, v1.BlockPeekResponse](
 			httpClient,
 			baseURL+DebugBlockPeekProcedure,
-			connect.WithSchema(debugBlockPeekMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("BlockPeek")),
 			connect.WithClientOptions(opts...),
 		),
 		blockDeleted: connect.NewClient[v1.BlockDeletedRequest, v1.BlockDeletedResponse](
 			httpClient,
 			baseURL+DebugBlockDeletedProcedure,
-			connect.WithSchema(debugBlockDeletedMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("BlockDeleted")),
 			connect.WithClientOptions(opts...),
 		),
 		checkConstraints: connect.NewClient[v11.CapacityCheckRequest, v1.CheckConstraintsResponse](
 			httpClient,
 			baseURL+DebugCheckConstraintsProcedure,
-			connect.WithSchema(debugCheckConstraintsMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("CheckConstraints")),
 			connect.WithClientOptions(opts...),
 		),
 		getBatchInfo: connect.NewClient[v1.BatchInfoRequest, v1.BatchInfoResponse](
 			httpClient,
 			baseURL+DebugGetBatchInfoProcedure,
-			connect.WithSchema(debugGetBatchInfoMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("GetBatchInfo")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteBatch: connect.NewClient[v1.DeleteBatchRequest, v1.DeleteBatchResponse](
 			httpClient,
 			baseURL+DebugDeleteBatchProcedure,
-			connect.WithSchema(debugDeleteBatchMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("DeleteBatch")),
 			connect.WithClientOptions(opts...),
 		),
 		runBatch: connect.NewClient[v1.RunBatchRequest, v1.RunBatchResponse](
 			httpClient,
 			baseURL+DebugRunBatchProcedure,
-			connect.WithSchema(debugRunBatchMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("RunBatch")),
 			connect.WithClientOptions(opts...),
 		),
 		getSingletonInfo: connect.NewClient[v1.SingletonInfoRequest, v1.SingletonInfoResponse](
 			httpClient,
 			baseURL+DebugGetSingletonInfoProcedure,
-			connect.WithSchema(debugGetSingletonInfoMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("GetSingletonInfo")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteSingletonLock: connect.NewClient[v1.DeleteSingletonLockRequest, v1.DeleteSingletonLockResponse](
 			httpClient,
 			baseURL+DebugDeleteSingletonLockProcedure,
-			connect.WithSchema(debugDeleteSingletonLockMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("DeleteSingletonLock")),
 			connect.WithClientOptions(opts...),
 		),
 		getDebounceInfo: connect.NewClient[v1.DebounceInfoRequest, v1.DebounceInfoResponse](
 			httpClient,
 			baseURL+DebugGetDebounceInfoProcedure,
-			connect.WithSchema(debugGetDebounceInfoMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("GetDebounceInfo")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteDebounce: connect.NewClient[v1.DeleteDebounceRequest, v1.DeleteDebounceResponse](
 			httpClient,
 			baseURL+DebugDeleteDebounceProcedure,
-			connect.WithSchema(debugDeleteDebounceMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("DeleteDebounce")),
 			connect.WithClientOptions(opts...),
 		),
 		runDebounce: connect.NewClient[v1.RunDebounceRequest, v1.RunDebounceResponse](
 			httpClient,
 			baseURL+DebugRunDebounceProcedure,
-			connect.WithSchema(debugRunDebounceMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("RunDebounce")),
 			connect.WithClientOptions(opts...),
 		),
 		deleteDebounceByID: connect.NewClient[v1.DeleteDebounceByIDRequest, v1.DeleteDebounceByIDResponse](
 			httpClient,
 			baseURL+DebugDeleteDebounceByIDProcedure,
-			connect.WithSchema(debugDeleteDebounceByIDMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("DeleteDebounceByID")),
 			connect.WithClientOptions(opts...),
 		),
 		getShadowPartition: connect.NewClient[v1.ShadowPartitionRequest, v1.ShadowPartitionResponse](
 			httpClient,
 			baseURL+DebugGetShadowPartitionProcedure,
-			connect.WithSchema(debugGetShadowPartitionMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("GetShadowPartition")),
 			connect.WithClientOptions(opts...),
 		),
 		getBacklogs: connect.NewClient[v1.BacklogsRequest, v1.BacklogsResponse](
 			httpClient,
 			baseURL+DebugGetBacklogsProcedure,
-			connect.WithSchema(debugGetBacklogsMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("GetBacklogs")),
 			connect.WithClientOptions(opts...),
 		),
 		getBacklogSize: connect.NewClient[v1.BacklogSizeRequest, v1.BacklogSizeResponse](
 			httpClient,
 			baseURL+DebugGetBacklogSizeProcedure,
-			connect.WithSchema(debugGetBacklogSizeMethodDescriptor),
+			connect.WithSchema(debugMethods.ByName("GetBacklogSize")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -458,124 +434,125 @@ type DebugHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewDebugHandler(svc DebugHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	debugMethods := v1.File_debug_v1_service_proto.Services().ByName("Debug").Methods()
 	debugGetPartitionHandler := connect.NewUnaryHandler(
 		DebugGetPartitionProcedure,
 		svc.GetPartition,
-		connect.WithSchema(debugGetPartitionMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("GetPartition")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugGetPartitionStatusHandler := connect.NewUnaryHandler(
 		DebugGetPartitionStatusProcedure,
 		svc.GetPartitionStatus,
-		connect.WithSchema(debugGetPartitionStatusMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("GetPartitionStatus")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugGetQueueItemHandler := connect.NewUnaryHandler(
 		DebugGetQueueItemProcedure,
 		svc.GetQueueItem,
-		connect.WithSchema(debugGetQueueItemMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("GetQueueItem")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugGetPauseHandler := connect.NewUnaryHandler(
 		DebugGetPauseProcedure,
 		svc.GetPause,
-		connect.WithSchema(debugGetPauseMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("GetPause")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugGetIndexHandler := connect.NewUnaryHandler(
 		DebugGetIndexProcedure,
 		svc.GetIndex,
-		connect.WithSchema(debugGetIndexMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("GetIndex")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugBlockPeekHandler := connect.NewUnaryHandler(
 		DebugBlockPeekProcedure,
 		svc.BlockPeek,
-		connect.WithSchema(debugBlockPeekMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("BlockPeek")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugBlockDeletedHandler := connect.NewUnaryHandler(
 		DebugBlockDeletedProcedure,
 		svc.BlockDeleted,
-		connect.WithSchema(debugBlockDeletedMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("BlockDeleted")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugCheckConstraintsHandler := connect.NewUnaryHandler(
 		DebugCheckConstraintsProcedure,
 		svc.CheckConstraints,
-		connect.WithSchema(debugCheckConstraintsMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("CheckConstraints")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugGetBatchInfoHandler := connect.NewUnaryHandler(
 		DebugGetBatchInfoProcedure,
 		svc.GetBatchInfo,
-		connect.WithSchema(debugGetBatchInfoMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("GetBatchInfo")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugDeleteBatchHandler := connect.NewUnaryHandler(
 		DebugDeleteBatchProcedure,
 		svc.DeleteBatch,
-		connect.WithSchema(debugDeleteBatchMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("DeleteBatch")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugRunBatchHandler := connect.NewUnaryHandler(
 		DebugRunBatchProcedure,
 		svc.RunBatch,
-		connect.WithSchema(debugRunBatchMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("RunBatch")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugGetSingletonInfoHandler := connect.NewUnaryHandler(
 		DebugGetSingletonInfoProcedure,
 		svc.GetSingletonInfo,
-		connect.WithSchema(debugGetSingletonInfoMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("GetSingletonInfo")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugDeleteSingletonLockHandler := connect.NewUnaryHandler(
 		DebugDeleteSingletonLockProcedure,
 		svc.DeleteSingletonLock,
-		connect.WithSchema(debugDeleteSingletonLockMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("DeleteSingletonLock")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugGetDebounceInfoHandler := connect.NewUnaryHandler(
 		DebugGetDebounceInfoProcedure,
 		svc.GetDebounceInfo,
-		connect.WithSchema(debugGetDebounceInfoMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("GetDebounceInfo")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugDeleteDebounceHandler := connect.NewUnaryHandler(
 		DebugDeleteDebounceProcedure,
 		svc.DeleteDebounce,
-		connect.WithSchema(debugDeleteDebounceMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("DeleteDebounce")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugRunDebounceHandler := connect.NewUnaryHandler(
 		DebugRunDebounceProcedure,
 		svc.RunDebounce,
-		connect.WithSchema(debugRunDebounceMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("RunDebounce")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugDeleteDebounceByIDHandler := connect.NewUnaryHandler(
 		DebugDeleteDebounceByIDProcedure,
 		svc.DeleteDebounceByID,
-		connect.WithSchema(debugDeleteDebounceByIDMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("DeleteDebounceByID")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugGetShadowPartitionHandler := connect.NewUnaryHandler(
 		DebugGetShadowPartitionProcedure,
 		svc.GetShadowPartition,
-		connect.WithSchema(debugGetShadowPartitionMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("GetShadowPartition")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugGetBacklogsHandler := connect.NewUnaryHandler(
 		DebugGetBacklogsProcedure,
 		svc.GetBacklogs,
-		connect.WithSchema(debugGetBacklogsMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("GetBacklogs")),
 		connect.WithHandlerOptions(opts...),
 	)
 	debugGetBacklogSizeHandler := connect.NewUnaryHandler(
 		DebugGetBacklogSizeProcedure,
 		svc.GetBacklogSize,
-		connect.WithSchema(debugGetBacklogSizeMethodDescriptor),
+		connect.WithSchema(debugMethods.ByName("GetBacklogSize")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/debug.v1.Debug/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/proto/gen/state/v2/statev2connect/state.connect.go
+++ b/proto/gen/state/v2/statev2connect/state.connect.go
@@ -58,22 +58,6 @@ const (
 	RunServiceLoadStateProcedure = "/state.v2.RunService/LoadState"
 )
 
-// These variables are the protoreflect.Descriptor objects for the RPCs defined in this package.
-var (
-	runServiceServiceDescriptor              = v2.File_state_v2_state_proto.Services().ByName("RunService")
-	runServiceCreateMethodDescriptor         = runServiceServiceDescriptor.Methods().ByName("Create")
-	runServiceDeleteMethodDescriptor         = runServiceServiceDescriptor.Methods().ByName("Delete")
-	runServiceExistsMethodDescriptor         = runServiceServiceDescriptor.Methods().ByName("Exists")
-	runServiceUpdateMetadataMethodDescriptor = runServiceServiceDescriptor.Methods().ByName("UpdateMetadata")
-	runServiceSaveStepMethodDescriptor       = runServiceServiceDescriptor.Methods().ByName("SaveStep")
-	runServiceSavePendingMethodDescriptor    = runServiceServiceDescriptor.Methods().ByName("SavePending")
-	runServiceConsumePauseMethodDescriptor   = runServiceServiceDescriptor.Methods().ByName("ConsumePause")
-	runServiceLoadMetadataMethodDescriptor   = runServiceServiceDescriptor.Methods().ByName("LoadMetadata")
-	runServiceLoadEventsMethodDescriptor     = runServiceServiceDescriptor.Methods().ByName("LoadEvents")
-	runServiceLoadStepsMethodDescriptor      = runServiceServiceDescriptor.Methods().ByName("LoadSteps")
-	runServiceLoadStateMethodDescriptor      = runServiceServiceDescriptor.Methods().ByName("LoadState")
-)
-
 // RunServiceClient is a client for the state.v2.RunService service.
 type RunServiceClient interface {
 	Create(context.Context, *connect.Request[v2.CreateStateRequest]) (*connect.Response[v2.CreateStateResponse], error)
@@ -98,71 +82,72 @@ type RunServiceClient interface {
 // http://api.acme.com or https://acme.com/grpc).
 func NewRunServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...connect.ClientOption) RunServiceClient {
 	baseURL = strings.TrimRight(baseURL, "/")
+	runServiceMethods := v2.File_state_v2_state_proto.Services().ByName("RunService").Methods()
 	return &runServiceClient{
 		create: connect.NewClient[v2.CreateStateRequest, v2.CreateStateResponse](
 			httpClient,
 			baseURL+RunServiceCreateProcedure,
-			connect.WithSchema(runServiceCreateMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("Create")),
 			connect.WithClientOptions(opts...),
 		),
 		delete: connect.NewClient[v2.DeleteStateRequest, v2.DeleteStateResponse](
 			httpClient,
 			baseURL+RunServiceDeleteProcedure,
-			connect.WithSchema(runServiceDeleteMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("Delete")),
 			connect.WithClientOptions(opts...),
 		),
 		exists: connect.NewClient[v2.ExistsRequest, v2.ExistsResponse](
 			httpClient,
 			baseURL+RunServiceExistsProcedure,
-			connect.WithSchema(runServiceExistsMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("Exists")),
 			connect.WithClientOptions(opts...),
 		),
 		updateMetadata: connect.NewClient[v2.UpdateMetadataRequest, v2.UpdateMetadataResponse](
 			httpClient,
 			baseURL+RunServiceUpdateMetadataProcedure,
-			connect.WithSchema(runServiceUpdateMetadataMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("UpdateMetadata")),
 			connect.WithClientOptions(opts...),
 		),
 		saveStep: connect.NewClient[v2.SaveStepRequest, v2.SaveStepResponse](
 			httpClient,
 			baseURL+RunServiceSaveStepProcedure,
-			connect.WithSchema(runServiceSaveStepMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("SaveStep")),
 			connect.WithClientOptions(opts...),
 		),
 		savePending: connect.NewClient[v2.SavePendingRequest, v2.SavePendingResponse](
 			httpClient,
 			baseURL+RunServiceSavePendingProcedure,
-			connect.WithSchema(runServiceSavePendingMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("SavePending")),
 			connect.WithClientOptions(opts...),
 		),
 		consumePause: connect.NewClient[v2.ConsumePauseRequest, v2.ConsumePauseResponse](
 			httpClient,
 			baseURL+RunServiceConsumePauseProcedure,
-			connect.WithSchema(runServiceConsumePauseMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("ConsumePause")),
 			connect.WithClientOptions(opts...),
 		),
 		loadMetadata: connect.NewClient[v2.LoadMetadataRequest, v2.LoadMetadataResponse](
 			httpClient,
 			baseURL+RunServiceLoadMetadataProcedure,
-			connect.WithSchema(runServiceLoadMetadataMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("LoadMetadata")),
 			connect.WithClientOptions(opts...),
 		),
 		loadEvents: connect.NewClient[v2.LoadEventsRequest, v2.LoadEventsResponse](
 			httpClient,
 			baseURL+RunServiceLoadEventsProcedure,
-			connect.WithSchema(runServiceLoadEventsMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("LoadEvents")),
 			connect.WithClientOptions(opts...),
 		),
 		loadSteps: connect.NewClient[v2.LoadStepsRequest, v2.LoadStepsResponse](
 			httpClient,
 			baseURL+RunServiceLoadStepsProcedure,
-			connect.WithSchema(runServiceLoadStepsMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("LoadSteps")),
 			connect.WithClientOptions(opts...),
 		),
 		loadState: connect.NewClient[v2.LoadStateRequest, v2.LoadStateResponse](
 			httpClient,
 			baseURL+RunServiceLoadStateProcedure,
-			connect.WithSchema(runServiceLoadStateMethodDescriptor),
+			connect.WithSchema(runServiceMethods.ByName("LoadState")),
 			connect.WithClientOptions(opts...),
 		),
 	}
@@ -259,70 +244,71 @@ type RunServiceHandler interface {
 // By default, handlers support the Connect, gRPC, and gRPC-Web protocols with the binary Protobuf
 // and JSON codecs. They also support gzip compression.
 func NewRunServiceHandler(svc RunServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
+	runServiceMethods := v2.File_state_v2_state_proto.Services().ByName("RunService").Methods()
 	runServiceCreateHandler := connect.NewUnaryHandler(
 		RunServiceCreateProcedure,
 		svc.Create,
-		connect.WithSchema(runServiceCreateMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("Create")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceDeleteHandler := connect.NewUnaryHandler(
 		RunServiceDeleteProcedure,
 		svc.Delete,
-		connect.WithSchema(runServiceDeleteMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("Delete")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceExistsHandler := connect.NewUnaryHandler(
 		RunServiceExistsProcedure,
 		svc.Exists,
-		connect.WithSchema(runServiceExistsMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("Exists")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceUpdateMetadataHandler := connect.NewUnaryHandler(
 		RunServiceUpdateMetadataProcedure,
 		svc.UpdateMetadata,
-		connect.WithSchema(runServiceUpdateMetadataMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("UpdateMetadata")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceSaveStepHandler := connect.NewUnaryHandler(
 		RunServiceSaveStepProcedure,
 		svc.SaveStep,
-		connect.WithSchema(runServiceSaveStepMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("SaveStep")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceSavePendingHandler := connect.NewUnaryHandler(
 		RunServiceSavePendingProcedure,
 		svc.SavePending,
-		connect.WithSchema(runServiceSavePendingMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("SavePending")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceConsumePauseHandler := connect.NewUnaryHandler(
 		RunServiceConsumePauseProcedure,
 		svc.ConsumePause,
-		connect.WithSchema(runServiceConsumePauseMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("ConsumePause")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceLoadMetadataHandler := connect.NewUnaryHandler(
 		RunServiceLoadMetadataProcedure,
 		svc.LoadMetadata,
-		connect.WithSchema(runServiceLoadMetadataMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("LoadMetadata")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceLoadEventsHandler := connect.NewUnaryHandler(
 		RunServiceLoadEventsProcedure,
 		svc.LoadEvents,
-		connect.WithSchema(runServiceLoadEventsMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("LoadEvents")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceLoadStepsHandler := connect.NewUnaryHandler(
 		RunServiceLoadStepsProcedure,
 		svc.LoadSteps,
-		connect.WithSchema(runServiceLoadStepsMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("LoadSteps")),
 		connect.WithHandlerOptions(opts...),
 	)
 	runServiceLoadStateHandler := connect.NewUnaryHandler(
 		RunServiceLoadStateProcedure,
 		svc.LoadState,
-		connect.WithSchema(runServiceLoadStateMethodDescriptor),
+		connect.WithSchema(runServiceMethods.ByName("LoadState")),
 		connect.WithHandlerOptions(opts...),
 	)
 	return "/state.v2.RunService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `WORKER_STATUS` message type to the connect protocol, allowing workers to periodically report in-flight request IDs and shutdown state to the gateway. The gateway receives and logs these messages with a 2-second rate limit per connection. A new `WorkerStatusIntervalFunc` hook lets callers configure the reporting interval per account/environment, defaulting to 0 (disabled). The proto definition and generated Go code are updated accordingly, with all existing message type indices bumped by one to accommodate the new `WorkerStatusData` message.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 1d21246e300c358139e537e64c6ee042c2fbad86.</sup>
<!-- /MENDRAL_SUMMARY -->