### PR TITLE
Add warn log when cancel finds metadata but events are missing

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2730,6 +2730,7 @@ func (e *executor) Cancel(ctx context.Context, id sv2.ID, r execution.CancelRequ
 	evts, err := e.smv2.LoadEvents(ctx, id)
 	if errors.Is(err, state.ErrEventNotFound) {
 		// If the event has gone, another thread cancelled the function.
+		l.Warn("cancel: events not found but metadata exists, skipping finalize")
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
## Description

Log a warning during a cancel to see if this is a bug causing a customer issue.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a single `Warn` log line inside the `ErrEventNotFound` branch of `Cancel()` in `executor.go` to surface cases where metadata exists but events are missing, aiding diagnosis of a suspected customer-facing bug.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 1e5563a406c379541f1a94ed36eb4d1cbfd369fe.</sup>
<!-- /MENDRAL_SUMMARY -->