### PR TITLE
Insights: fix editor diagnostic severity

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditor.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditor.tsx
@@ -13,6 +13,21 @@ import { useInsightsSQLEditorOnMountCallback } from './hooks/useInsightsSQLEdito
 import { useSQLCompletionConfig } from './hooks/useSQLCompletionConfig';
 import { useEffect, useState } from 'react';
 
+function diagnosticSeverityToMonacoSeverity(
+  severity: 'error' | 'warning' | 'info' | 'none',
+): number {
+  switch (severity) {
+    case 'error':
+      return 8;
+    case 'warning':
+      return 4;
+    case 'info':
+      return 2;
+    default:
+      return 1; // Default to hint
+  }
+}
+
 export function InsightsSQLEditor() {
   const { onChange, query, runQuery, data } = useInsightsStateMachineContext();
   const { onMount } = useInsightsSQLEditorOnMountCallback();
@@ -135,7 +150,7 @@ export function InsightsSQLEditor() {
           startLineNumber: startPos.lineNumber,
           endColumn: endPos.column,
           endLineNumber: endPos.lineNumber,
-          severity: diag.severity === 'error' ? 8 : 4,
+          severity: diagnosticSeverityToMonacoSeverity(diag.severity),
           code: {
             // TODO: add docs links based on diagnostic code
             target: monaco.Uri.parse('http://example.com'),


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

This fixes the diagnostic severity to support severities other than error & warning.

Before
<img width="907" height="603" alt="image" src="https://github.com/user-attachments/assets/6cc3796d-cd33-4d96-8862-2c9a01cff036" />


After
<img width="964" height="589" alt="image" src="https://github.com/user-attachments/assets/dac1c750-c572-4c28-ab0c-69d7f20db5c3" />


## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

Currently we only support showing editor diagnostics with severity error & warning.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Extracts a `diagnosticSeverityToMonacoSeverity` helper to map SQL diagnostic severity strings to Monaco editor severity numbers, adding support for `info` and `none`/hint severities beyond the previous error/warning-only handling.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 01d6c72aac1b34efb58e2ec4123b8f8ea6039994.</sup>
<!-- /MENDRAL_SUMMARY -->