### PR TITLE
Fix state proxy not terminating fast enough

### DIFF
--- a/pkg/telemetry/redis_telemetry/instrument.go
+++ b/pkg/telemetry/redis_telemetry/instrument.go
@@ -2,9 +2,11 @@ package redis_telemetry
 
 import (
 	"context"
+	"time"
+
+	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"github.com/redis/rueidis"
-	"time"
 )
 
 type scopeValType struct{}
@@ -156,16 +158,28 @@ func (i instrumentedClient) report(ctx context.Context, start, end time.Time, co
 func (i instrumentedClient) asyncReport(ctx context.Context, start time.Time, command string) {
 	end := time.Now()
 
-	i.reports <- &reportItem{ctx, start, end, command}
+	select {
+	case i.reports <- &reportItem{ctx, start, end, command}:
+	default:
+		logger.StdlibLogger(ctx).Error("redis telemetry report buffer full, dropping metrics", "cluster", i.cluster, "pkg", i.pkgName)
+	}
 }
 
 func (i instrumentedClient) worker(ctx context.Context) {
 	for {
 		select {
-		case <-ctx.Done():
-			return
 		case item := <-i.reports:
 			i.report(item.ctx, item.start, item.end, item.command)
+		case <-ctx.Done():
+			// Drain remaining items in the buffer before exiting.
+			for {
+				select {
+				case item := <-i.reports:
+					i.report(item.ctx, item.start, item.end, item.command)
+				default:
+					return
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Description

State proxy pods are stuck on termination because gRPC server is waiting for requests to drain but they are stuck on the buffer full channel for reporting because we kill the workers as soon as the ctx is Done.

```
goroutine profile: total 7137
6407 @ 0x47e06e 0x414585 0x4141d7 0x21a5c6d 0x21a5a5a 0x2208914 0x2258c67 0x223df47 0x224d6fb 0x3d482e5 0x3d1794b 0x50b1a56 0x3d177a3 0xb8c176 0xb91408 0xb89b1f 0x4867a1
#	0x21a5c6c	github.com/inngest/inngest/pkg/telemetry/redis_telemetry.instrumentedClient.asyncReport+0x16c	/app/vendor/github.com/inngest/inngest/pkg/telemetry/redis_telemetry/instrument.go:159
#	0x21a5a59	github.com/inngest/inngest/pkg/telemetry/redis_telemetry.instrumentedClient.Do+0x279		/app/vendor/github.com/inngest/inngest/pkg/telemetry/redis_telemetry/instrument.go:82
#	0x2208913	github.com/inngest/inngest/pkg/execution/state/redis_state.retryClusterDownClient.do+0xb3	/app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/cluster.go:33
#	0x2258c66	github.com/inngest/inngest/pkg/execution/state/redis_state.retryClusterDownClient.Do+0x86	/app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/cluster.go:53
#	0x223df46	github.com/inngest/inngest/pkg/execution/state/redis_state.shardedMgr.metadata+0x1e6		/app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/redis_state.go:494
#	0x224d6fa	github.com/inngest/inngest/pkg/execution/state/redis_state.v2.LoadMetadata+0x9a			/app/vendor/github.com/inngest/inngest/pkg/execution/state/redis_state/v2_adapter.go:255
#	0x3d482e4	github.com/tonyhb/datos/pkg/state_proxy.StateProxyServer.LoadMetadata+0x2e4			/app/pkg/state_proxy/server.go:428
#	0x3d1794a	github.com/inngest/inngest/proto/gen/state/v2._RunService_LoadMetadata_Handler.func1+0xca	/app/vendor/github.com/inngest/inngest/proto/gen/state/v2/state_grpc.pb.go:388
#	0x50b1a55	main.(*stateProxySvc).Pre.GetStateProxyInterceptors.NewLoggingInterceptor.func8+0x95		/app/pkg/state_proxy/server.go:67
#	0x3d177a2	github.com/inngest/inngest/proto/gen/state/v2._RunService_LoadMetadata_Handler+0x142		/app/vendor/github.com/inngest/inngest/proto/gen/state/v2/state_grpc.pb.go:390
#	0xb8c175	google.golang.org/grpc.(*Server).processUnaryRPC+0x1035						/app/vendor/google.golang.org/grpc/server.go:1431
#	0xb91407	google.golang.org/grpc.(*Server).handleStream+0xb87						/app/vendor/google.golang.org/grpc/server.go:1842
#	0xb89b1e	google.golang.org/grpc.(*Server).serveStreams.func2.1+0x7e					/app/vendor/google.golang.org/grpc/server.go:1061

```



## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a goroutine leak during graceful shutdown: the telemetry worker goroutines were exiting immediately on context cancellation, leaving the `reports` channel full and blocking `asyncReport` callers (gRPC handlers) indefinitely. The fix makes `asyncReport` non-blocking (drop with log on full buffer) and adds a drain loop in `worker` to flush buffered items before exiting.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6f642e8cd0cfa32614d5f86a25c7e5d108509d8e.</sup>
<!-- /MENDRAL_SUMMARY -->