### PR TITLE
Store trace events with calls to SetStatus

### DIFF
--- a/pkg/run/span.go
+++ b/pkg/run/span.go
@@ -477,7 +477,8 @@ func (s *Span) SetStatus(code codes.Code, desc string) {
 			),
 		)
 
-		// Set string attribute.
+		// Set string attribute, so that we have atties as well as an event.  We do this
+		// as events are (sometimes, depending on datastores) not stored.
 		s.SetAttributes(attribute.String("internal.error", desc))
 	}
 }

--- a/pkg/run/span.go
+++ b/pkg/run/span.go
@@ -468,7 +468,24 @@ func (s *Span) RecordError(err error, opts ...trace.EventOption) {
 	s.SetStatus(codes.Error, err.Error())
 }
 
+// SetStatus sets the span status.  If this contains an error, this will
+// be tracked as an event.
 func (s *Span) SetStatus(code codes.Code, desc string) {
+	s.setStatus(code, desc)
+
+	switch code {
+	case codes.Error:
+		s.AddEvent("error",
+			trace.WithTimestamp(time.Now()),
+			trace.WithAttributes(
+				attribute.String("desc", desc),
+			),
+		)
+	}
+}
+
+// setStatus sets the status without recording an internal event.
+func (s *Span) setStatus(code codes.Code, desc string) {
 	s.Lock()
 	defer s.Unlock()
 	s.status = tracesdk.Status{

--- a/pkg/run/span.go
+++ b/pkg/run/span.go
@@ -465,7 +465,7 @@ func (s *Span) RecordError(err error, opts ...trace.EventOption) {
 	defer s.Unlock()
 
 	s.AddEvent(err.Error(), opts...)
-	s.SetStatus(codes.Error, err.Error())
+	s.setStatus(codes.Error, err.Error())
 }
 
 // SetStatus sets the span status.  If this contains an error, this will

--- a/pkg/run/span.go
+++ b/pkg/run/span.go
@@ -461,9 +461,6 @@ func (s *Span) IsRecording() bool {
 // official one doesn't actually set the status, but we'll just do it here
 // for convinence's sake.
 func (s *Span) RecordError(err error, opts ...trace.EventOption) {
-	s.Lock()
-	defer s.Unlock()
-
 	s.AddEvent(err.Error(), opts...)
 	s.setStatus(codes.Error, err.Error())
 }

--- a/pkg/run/span.go
+++ b/pkg/run/span.go
@@ -458,15 +458,13 @@ func (s *Span) IsRecording() bool {
 	return true
 }
 
-// official one doesn't actually set the status, but we'll just do it here
-// for convinence's sake.
+// RecordError sets the span status to error and tracks an error event.
 func (s *Span) RecordError(err error, opts ...trace.EventOption) {
-	s.AddEvent(err.Error(), opts...)
 	s.setStatus(codes.Error, err.Error())
 }
 
 // SetStatus sets the span status.  If this contains an error, this will
-// be tracked as an event.
+// be tracked as an event, plus an Inngest error attribute.
 func (s *Span) SetStatus(code codes.Code, desc string) {
 	s.setStatus(code, desc)
 
@@ -478,6 +476,9 @@ func (s *Span) SetStatus(code codes.Code, desc string) {
 				attribute.String("desc", desc),
 			),
 		)
+
+		// Set string attribute.
+		s.SetAttributes(attribute.String("internal.error", desc))
 	}
 }
 


### PR DESCRIPTION
allows us to capture more data

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds error event recording to `SetStatus` when the status code is `codes.Error`, capturing error descriptions as both trace events and span attributes (`internal.error`). A private `setStatus` handles the raw status assignment without triggering events, used by both `SetStatus` and `RecordError` to avoid double-recording and deadlocks.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a2cad2fd5a6ed5361474b1f4676a79314ad50b5e.</sup>
<!-- /MENDRAL_SUMMARY -->