### PR TITLE
EXE-1545: OpcodeNone not recognized as function result

### DIFF
--- a/pkg/execution/driver/httpdriver/parse_test.go
+++ b/pkg/execution/driver/httpdriver/parse_test.go
@@ -1,9 +1,12 @@
 package httpdriver
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,4 +48,32 @@ func TestParseResponse(t *testing.T) {
 		map[string]any{"nested": map[string]any{"deep": "hi"}},
 		ParseResponse([]byte(`"{\"nested\": {\"deep\": \"hi\"}}"`)),
 	)
+}
+
+// TestEmptyArrayNormalizedToOpcodeNone verifies the normalization pipeline
+// and its interaction with IsFunctionResult (EXE-1545).
+func TestEmptyArrayNormalizedToOpcodeNone(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty JSON array becomes OpcodeNone", func(t *testing.T) {
+		ops, err := ParseGenerator(context.Background(), []byte("[]"), false)
+		require.NoError(t, err)
+		require.Len(t, ops, 1)
+		require.Equal(t, enums.OpcodeNone, ops[0].Op)
+	})
+
+	t.Run("OpcodeNone from empty array is recognized as function result", func(t *testing.T) {
+		ops, err := ParseGenerator(context.Background(), []byte("[]"), false)
+		require.NoError(t, err)
+
+		resp := &state.DriverResponse{
+			Generator:  ops,
+			Output:     nil,
+			Err:        nil,
+			StatusCode: 206,
+		}
+
+		require.True(t, resp.IsFunctionResult(),
+			"response from empty SDK array should be a function result")
+	})
 }

--- a/pkg/execution/state/driver_response_test.go
+++ b/pkg/execution/state/driver_response_test.go
@@ -386,6 +386,71 @@ func TestStandardErrorSerialize(t *testing.T) {
 	}
 }
 
+// TestOpcodeNone_IsFunctionResult verifies the fix for EXE-1545: when the SDK
+// returns HTTP 206 with an empty array body `[]`, the response is normalized to
+// a single OpcodeNone. This must be recognized as a function result so that the
+// executor finalizes the run instead of leaving it stuck in "Running".
+func TestOpcodeNone_IsFunctionResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single OpcodeNone should be treated as function result", func(t *testing.T) {
+		resp := &DriverResponse{
+			Generator: []*GeneratorOpcode{
+				{Op: enums.OpcodeNone},
+			},
+			Output:     nil,
+			Err:        nil,
+			StatusCode: 206,
+		}
+
+		require.True(t, resp.IsFunctionResult(),
+			"a response with only OpcodeNone should be treated as a function result, "+
+				"otherwise the run will never be finalized and will stay in Running state")
+	})
+
+	t.Run("OpcodeNone mixed with other opcodes is not a function result", func(t *testing.T) {
+		resp := &DriverResponse{
+			Generator: []*GeneratorOpcode{
+				{Op: enums.OpcodeNone},
+				{Op: enums.OpcodeStep},
+			},
+		}
+
+		require.False(t, resp.IsFunctionResult(),
+			"OpcodeNone alongside other opcodes is a parallel fan-in, not a function result")
+	})
+
+	t.Run("nil generator is a function result", func(t *testing.T) {
+		resp := &DriverResponse{
+			Output: nil, Err: nil, Generator: nil, StatusCode: 200,
+		}
+		require.True(t, resp.IsFunctionResult())
+	})
+
+	t.Run("empty generator is a function result", func(t *testing.T) {
+		resp := &DriverResponse{
+			Output: nil, Err: nil, Generator: []*GeneratorOpcode{}, StatusCode: 200,
+		}
+		require.True(t, resp.IsFunctionResult())
+	})
+}
+
+// TestNoOutputFunctionResult verifies behavior for the "function result has no
+// output" error path — SDK returns HTTP 200 with empty body.
+func TestNoOutputFunctionResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("GetTraceFunctionOutput returns error for nil output", func(t *testing.T) {
+		resp := &DriverResponse{
+			Output: nil, Err: nil, Generator: nil, StatusCode: 200,
+		}
+		output, err := resp.GetTraceFunctionOutput()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "function result has no output")
+		require.Empty(t, output)
+	})
+}
+
 func strptr(s string) *string {
 	return &s
 }


### PR DESCRIPTION
## Description

When the SDK returns HTTP 206 with an empty array body, the response is normalized to OpcodeNone but IsFunctionResult() returns false, preventing run finalization. These tests cover the fix in IsFunctionResult() and the full normalization-to-finalization pipeline via ParseGenerator.

## Motivation
EXE-1545

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
