### PR TITLE
EXE-1546: Add per-function Prometheus metrics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
     needs: [check-release-type]
     steps:
       - name: Login to Docker Hub
-        if: needs.check-release-type.outputs.prerelease == ''
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USER }}
@@ -46,14 +45,13 @@ jobs:
         id: tag
         run: echo "tag=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
-        if: needs.check-release-type.outputs.prerelease == ''
         id: buildx
         uses: docker/setup-buildx-action@v3
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
           version: "~> 2"
-          args: ${{ needs.check-release-type.outputs.prerelease != '' && 'release --clean --verbose --skip=docker' || 'release --clean --verbose' }}
+          args: release --clean --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   npm:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,8 +29,8 @@ dockers:
     use: buildx
     dockerfile: 'Dockerfile.goreleaser'
     image_templates:
-    - "inngest/inngest:latest-amd64"
     - "inngest/inngest:{{ .Tag }}-amd64"
+    - "{{ if not .Prerelease }}inngest/inngest:latest-amd64{{ end }}"
     build_flag_templates:
     - "--pull"
     - "--label=org.opencontainers.image.created={{.Date}}"
@@ -45,8 +45,8 @@ dockers:
     use: buildx
     dockerfile: 'Dockerfile.goreleaser'
     image_templates:
-    - "inngest/inngest:latest-arm64v8"
     - "inngest/inngest:{{ .Tag }}-arm64v8"
+    - "{{ if not .Prerelease }}inngest/inngest:latest-arm64v8{{ end }}"
     build_flag_templates:
     - "--pull"
     - "--label=org.opencontainers.image.created={{.Date}}"
@@ -55,10 +55,10 @@ dockers:
     - "--label=org.opencontainers.image.version={{.Version}}"
     - "--platform=linux/arm64"
 docker_manifests:
-  - name_template: inngest/inngest:latest
+  - name_template: "{{ if not .Prerelease }}inngest/inngest:latest{{ end }}"
     image_templates:
-      - inngest/inngest:latest-amd64
-      - inngest/inngest:latest-arm64v8
+      - "{{ if not .Prerelease }}inngest/inngest:latest-amd64{{ end }}"
+      - "{{ if not .Prerelease }}inngest/inngest:latest-arm64v8{{ end }}"
   - name_template: inngest/inngest:{{ .Tag }}
     image_templates:
       - inngest/inngest:{{ .Tag }}-amd64

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -616,8 +616,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	// Initialize metrics API for Prometheus-compatible metrics endpoint.
 	// This provides system queue depth metrics via /metrics endpoint.
 	metricsAPI, err := metrics.NewMetricsAPI(metrics.Opts{
-		AuthMiddleware: authn.SigningKeyMiddleware(opts.SigningKey),
-		QueueManager:   rq,
+		QueueManager: rq,
 	})
 	if err != nil {
 		return err

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -447,18 +447,19 @@ func start(ctx context.Context, opts StartOpts) error {
 			return []byte(*opts.SigningKey), nil
 		}),
 		executor.WithLifecycleListeners(
-			history.NewLifecycleListener(
-				nil,
-				hd,
-				hmw,
-			),
-			Lifecycle{
-				Cqrs:       dbcqrs,
-				Pb:         pb,
-				EventTopic: opts.Config.EventStream.Service.Concrete.TopicName(),
-			},
-			run.NewTraceLifecycleListener(nil),
-			metrics.NewPrometheusLifecycleListener(),
+			append([]execution.LifecycleListener{
+				history.NewLifecycleListener(
+					nil,
+					hd,
+					hmw,
+				),
+				Lifecycle{
+					Cqrs:       dbcqrs,
+					Pb:         pb,
+					EventTopic: opts.Config.EventStream.Service.Concrete.TopicName(),
+				},
+				run.NewTraceLifecycleListener(nil),
+			}, metrics.NewLifecycleListeners()...)...,
 		),
 		executor.WithStepLimits(func(id sv2.ID) int {
 			if override, hasOverride := stepLimitOverrides[id.FunctionID.String()]; hasOverride {

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -458,6 +458,7 @@ func start(ctx context.Context, opts StartOpts) error {
 				EventTopic: opts.Config.EventStream.Service.Concrete.TopicName(),
 			},
 			run.NewTraceLifecycleListener(nil),
+			metrics.NewPrometheusLifecycleListener(),
 		),
 		executor.WithStepLimits(func(id sv2.ID) int {
 			if override, hasOverride := stepLimitOverrides[id.FunctionID.String()]; hasOverride {

--- a/pkg/metrics/lifecycle.go
+++ b/pkg/metrics/lifecycle.go
@@ -66,6 +66,15 @@ func NewPrometheusLifecycleListener() *PrometheusLifecycleListener {
 	return &PrometheusLifecycleListener{}
 }
 
+// NewLifecycleListeners returns the Prometheus lifecycle listener if the
+// experimental metrics feature is enabled, or an empty slice otherwise.
+func NewLifecycleListeners() []execution.LifecycleListener {
+	if !ExperimentalPromMetricsEnabled() {
+		return nil
+	}
+	return []execution.LifecycleListener{NewPrometheusLifecycleListener()}
+}
+
 func fnLabel(md statev2.Metadata) string {
 	if slug := md.Config.FunctionSlug(); slug != "" {
 		return slug

--- a/pkg/metrics/lifecycle.go
+++ b/pkg/metrics/lifecycle.go
@@ -1,0 +1,158 @@
+package metrics
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/execution"
+	"github.com/inngest/inngest/pkg/execution/queue"
+	statev1 "github.com/inngest/inngest/pkg/execution/state"
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	functionRunScheduled = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "inngest_function_run_scheduled_total",
+		Help: "The total number of function runs scheduled",
+	}, []string{"fn"})
+
+	functionRunStarted = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "inngest_function_run_started_total",
+		Help: "The total number of function runs started",
+	}, []string{"fn"})
+
+	functionRunEnded = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "inngest_function_run_ended_total",
+		Help: "The total number of function runs ended",
+	}, []string{"fn", "status"})
+
+	sdkReqScheduled = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "inngest_sdk_req_scheduled_total",
+		Help: "The total number of SDK invocation/step execution scheduled",
+	}, []string{"fn"})
+
+	sdkReqStarted = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "inngest_sdk_req_started_total",
+		Help: "The total number of SDK invocation/step execution started",
+	}, []string{"fn"})
+
+	sdkReqEnded = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "inngest_sdk_req_ended_total",
+		Help: "The total number of SDK invocation/step execution ended",
+	}, []string{"fn", "status"})
+)
+
+func init() {
+	registry.MustRegister(
+		functionRunScheduled,
+		functionRunStarted,
+		functionRunEnded,
+		sdkReqScheduled,
+		sdkReqStarted,
+		sdkReqEnded,
+	)
+}
+
+// PrometheusLifecycleListener implements execution.LifecycleListener and
+// records per-function Prometheus metrics.
+type PrometheusLifecycleListener struct {
+	execution.NoopLifecyceListener
+}
+
+func NewPrometheusLifecycleListener() *PrometheusLifecycleListener {
+	return &PrometheusLifecycleListener{}
+}
+
+func fnLabel(md statev2.Metadata) string {
+	if slug := md.Config.FunctionSlug(); slug != "" {
+		return slug
+	}
+	return "unknown"
+}
+
+func (l *PrometheusLifecycleListener) OnFunctionScheduled(
+	_ context.Context,
+	md statev2.Metadata,
+	_ queue.Item,
+	_ []event.TrackedEvent,
+) {
+	functionRunScheduled.WithLabelValues(fnLabel(md)).Inc()
+}
+
+func (l *PrometheusLifecycleListener) OnFunctionStarted(
+	_ context.Context,
+	md statev2.Metadata,
+	_ queue.Item,
+	_ []json.RawMessage,
+) {
+	functionRunStarted.WithLabelValues(fnLabel(md)).Inc()
+}
+
+func (l *PrometheusLifecycleListener) OnFunctionFinished(
+	_ context.Context,
+	md statev2.Metadata,
+	_ queue.Item,
+	_ []json.RawMessage,
+	resp statev1.DriverResponse,
+) {
+	status := "Completed"
+	if resp.Err != nil {
+		status = "Failed"
+	}
+	functionRunEnded.WithLabelValues(fnLabel(md), status).Inc()
+}
+
+func (l *PrometheusLifecycleListener) OnFunctionCancelled(
+	_ context.Context,
+	md statev2.Metadata,
+	_ execution.CancelRequest,
+	_ []json.RawMessage,
+) {
+	functionRunEnded.WithLabelValues(fnLabel(md), "Cancelled").Inc()
+}
+
+func (l *PrometheusLifecycleListener) OnStepScheduled(
+	_ context.Context,
+	md statev2.Metadata,
+	_ queue.Item,
+	_ *string,
+) {
+	sdkReqScheduled.WithLabelValues(fnLabel(md)).Inc()
+}
+
+func (l *PrometheusLifecycleListener) OnStepStarted(
+	_ context.Context,
+	md statev2.Metadata,
+	_ queue.Item,
+	_ inngest.Edge,
+	_ string,
+) {
+	sdkReqStarted.WithLabelValues(fnLabel(md)).Inc()
+}
+
+func (l *PrometheusLifecycleListener) OnStepFinished(
+	_ context.Context,
+	md statev2.Metadata,
+	_ queue.Item,
+	_ inngest.Edge,
+	resp *statev1.DriverResponse,
+	runErr error,
+) {
+	status := "success"
+	if runErr != nil {
+		status = "errored"
+	} else if resp != nil && resp.Err != nil {
+		if resp.Retryable() {
+			status = "errored"
+		} else {
+			status = "failed"
+		}
+	}
+	sdkReqEnded.WithLabelValues(fnLabel(md), status).Inc()
+}
+
+// Ensure interface compliance at compile time.
+var _ execution.LifecycleListener = (*PrometheusLifecycleListener)(nil)

--- a/pkg/metrics/lifecycle_test.go
+++ b/pkg/metrics/lifecycle_test.go
@@ -1,0 +1,145 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/execution"
+	"github.com/inngest/inngest/pkg/execution/queue"
+	statev1 "github.com/inngest/inngest/pkg/execution/state"
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// counterValue reads the current value of a counter from the package-level
+// registry by metric name and label values.
+func counterValue(t *testing.T, name string, labels map[string]string) float64 {
+	t.Helper()
+	families, err := registry.Gather()
+	require.NoError(t, err)
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			match := true
+			for _, lp := range m.GetLabel() {
+				if v, ok := labels[lp.GetName()]; !ok || v != lp.GetValue() {
+					match = false
+					break
+				}
+			}
+			if match && len(m.GetLabel()) == len(labels) {
+				return m.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+func mdWithSlug(slug string) statev2.Metadata {
+	md := statev2.Metadata{}
+	statev2.InitConfig(&md.Config)
+	if slug != "" {
+		md.Config.SetFunctionSlug(slug)
+	}
+	return md
+}
+
+func TestFnLabel(t *testing.T) {
+	t.Run("returns slug when present", func(t *testing.T) {
+		md := mdWithSlug("app-my-function")
+		assert.Equal(t, "app-my-function", fnLabel(md))
+	})
+
+	t.Run("returns unknown when slug is empty", func(t *testing.T) {
+		md := mdWithSlug("")
+		assert.Equal(t, "unknown", fnLabel(md))
+	})
+}
+
+func TestPrometheusLifecycleListener_FunctionRun(t *testing.T) {
+	l := NewPrometheusLifecycleListener()
+	ctx := context.Background()
+	slug := "test-fn-run"
+	md := mdWithSlug(slug)
+	labels := map[string]string{"fn": slug}
+
+	// Capture baselines (counters accumulate across tests in the same process).
+	baseScheduled := counterValue(t, "inngest_function_run_scheduled_total", labels)
+	baseStarted := counterValue(t, "inngest_function_run_started_total", labels)
+	baseCompleted := counterValue(t, "inngest_function_run_ended_total", map[string]string{"fn": slug, "status": "Completed"})
+	baseFailed := counterValue(t, "inngest_function_run_ended_total", map[string]string{"fn": slug, "status": "Failed"})
+
+	l.OnFunctionScheduled(ctx, md, queue.Item{}, nil)
+	assert.Equal(t, baseScheduled+1, counterValue(t, "inngest_function_run_scheduled_total", labels))
+
+	l.OnFunctionStarted(ctx, md, queue.Item{}, nil)
+	assert.Equal(t, baseStarted+1, counterValue(t, "inngest_function_run_started_total", labels))
+
+	// Completed
+	l.OnFunctionFinished(ctx, md, queue.Item{}, nil, statev1.DriverResponse{})
+	assert.Equal(t, baseCompleted+1, counterValue(t, "inngest_function_run_ended_total", map[string]string{"fn": slug, "status": "Completed"}))
+
+	// Failed
+	errStr := "something went wrong"
+	l.OnFunctionFinished(ctx, md, queue.Item{}, nil, statev1.DriverResponse{Err: &errStr})
+	assert.Equal(t, baseFailed+1, counterValue(t, "inngest_function_run_ended_total", map[string]string{"fn": slug, "status": "Failed"}))
+}
+
+func TestPrometheusLifecycleListener_FunctionCancelled(t *testing.T) {
+	l := NewPrometheusLifecycleListener()
+	ctx := context.Background()
+	slug := "test-fn-cancel"
+	md := mdWithSlug(slug)
+	labels := map[string]string{"fn": slug, "status": "Cancelled"}
+
+	base := counterValue(t, "inngest_function_run_ended_total", labels)
+	l.OnFunctionCancelled(ctx, md, execution.CancelRequest{}, nil)
+	assert.Equal(t, base+1, counterValue(t, "inngest_function_run_ended_total", labels))
+}
+
+func TestPrometheusLifecycleListener_StepLifecycle(t *testing.T) {
+	l := NewPrometheusLifecycleListener()
+	ctx := context.Background()
+	slug := "test-step-lc"
+	md := mdWithSlug(slug)
+	fnLabels := map[string]string{"fn": slug}
+
+	baseScheduled := counterValue(t, "inngest_sdk_req_scheduled_total", fnLabels)
+	baseStarted := counterValue(t, "inngest_sdk_req_started_total", fnLabels)
+	baseSuccess := counterValue(t, "inngest_sdk_req_ended_total", map[string]string{"fn": slug, "status": "success"})
+	baseErrored := counterValue(t, "inngest_sdk_req_ended_total", map[string]string{"fn": slug, "status": "errored"})
+	baseFailed := counterValue(t, "inngest_sdk_req_ended_total", map[string]string{"fn": slug, "status": "failed"})
+
+	l.OnStepScheduled(ctx, md, queue.Item{}, nil)
+	assert.Equal(t, baseScheduled+1, counterValue(t, "inngest_sdk_req_scheduled_total", fnLabels))
+
+	l.OnStepStarted(ctx, md, queue.Item{}, inngest.Edge{}, "http://localhost")
+	assert.Equal(t, baseStarted+1, counterValue(t, "inngest_sdk_req_started_total", fnLabels))
+
+	// success: no error
+	l.OnStepFinished(ctx, md, queue.Item{}, inngest.Edge{}, &statev1.DriverResponse{}, nil)
+	assert.Equal(t, baseSuccess+1, counterValue(t, "inngest_sdk_req_ended_total", map[string]string{"fn": slug, "status": "success"}))
+
+	// errored: runErr set
+	l.OnStepFinished(ctx, md, queue.Item{}, inngest.Edge{}, nil, assert.AnError)
+	assert.Equal(t, baseErrored+1, counterValue(t, "inngest_sdk_req_ended_total", map[string]string{"fn": slug, "status": "errored"}))
+
+	// errored: retryable response error
+	errStr := "temporary"
+	l.OnStepFinished(ctx, md, queue.Item{}, inngest.Edge{}, &statev1.DriverResponse{
+		Err:     &errStr,
+		NoRetry: false,
+	}, nil)
+	assert.Equal(t, baseErrored+2, counterValue(t, "inngest_sdk_req_ended_total", map[string]string{"fn": slug, "status": "errored"}))
+
+	// failed: non-retryable response error
+	l.OnStepFinished(ctx, md, queue.Item{}, inngest.Edge{}, &statev1.DriverResponse{
+		Err:     &errStr,
+		NoRetry: true,
+	}, nil)
+	assert.Equal(t, baseFailed+1, counterValue(t, "inngest_sdk_req_ended_total", map[string]string{"fn": slug, "status": "failed"}))
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus"
@@ -89,6 +91,18 @@ type QueueManager interface {
 type Opts struct {
 	AuthMiddleware func(http.Handler) http.Handler
 	QueueManager   QueueManager
+}
+
+// ExperimentalPromMetricsEnabled reports whether the experimental Prometheus
+// lifecycle metrics are enabled via the INNGEST_EXPERIMENTAL_PROM_METRICS
+// environment variable. The feature is off by default; set to "1", "true",
+// "yes", or any truthy value to enable. "0" always disables.
+func ExperimentalPromMetricsEnabled() bool {
+	v := strings.TrimSpace(os.Getenv("INNGEST_EXPERIMENTAL_PROM_METRICS"))
+	if v == "" || v == "0" || strings.EqualFold(v, "false") || strings.EqualFold(v, "no") {
+		return false
+	}
+	return true
 }
 
 // registry is a package-level private Prometheus registry used for all

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -91,35 +91,37 @@ type Opts struct {
 	QueueManager   QueueManager
 }
 
+// registry is a package-level private Prometheus registry used for all
+// Inngest metrics. This avoids polluting the default registry (which would
+// leak Go runtime metrics) and prevents MustRegister panics on collision.
+var registry = prometheus.NewRegistry()
+
+var queueDepthGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+	Name: "inngest_queue_depth",
+	Help: "Total depth of all system queues including backlog and ready state items",
+})
+
+func init() {
+	registry.MustRegister(queueDepthGauge)
+}
+
 // MetricsAPI provides Prometheus-compatible metrics endpoints
 type MetricsAPI struct {
 	opts       Opts
 	Router     chi.Router
 	queueGauge prometheus.Gauge
-	registry   *prometheus.Registry
 }
 
 // NewMetricsAPI creates a new metrics API instance with Prometheus integration
 func NewMetricsAPI(opts Opts) (*MetricsAPI, error) {
-	// Validate required options
 	if opts.QueueManager == nil {
 		return nil, fmt.Errorf("QueueManager is required")
 	}
 
-	registry := prometheus.NewRegistry()
-
-	queueGauge := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "inngest_queue_depth",
-		Help: "Total depth of all system queues including backlog and ready state items",
-	})
-
-	registry.MustRegister(queueGauge)
-
 	api := &MetricsAPI{
 		opts:       opts,
 		Router:     chi.NewRouter(),
-		queueGauge: queueGauge,
-		registry:   registry,
+		queueGauge: queueDepthGauge,
 	}
 
 	api.setupRoutes()
@@ -156,8 +158,7 @@ func (api *MetricsAPI) handleMetrics(w http.ResponseWriter, r *http.Request) {
 
 	api.queueGauge.Set(float64(sanitizedDepth))
 
-	// Gather metrics from registry
-	metricFamilies, err := api.registry.Gather()
+	metricFamilies, err := registry.Gather()
 	if err != nil {
 		http.Error(w, "Failed to gather metrics", http.StatusInternalServerError)
 		return

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -52,7 +52,6 @@ func TestNewMetricsAPI(t *testing.T) {
 			checkAPI: func(t *testing.T, api *MetricsAPI) {
 				assert.NotNil(t, api.Router)
 				assert.NotNil(t, api.queueGauge)
-				assert.NotNil(t, api.registry)
 				assert.Contains(t, api.queueGauge.Desc().String(), "inngest_queue_depth")
 			},
 		},
@@ -266,29 +265,27 @@ func TestMetricsAPI_prometheusIntegration(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		// Verify metric is registered
-		metricFamilies, err := api.registry.Gather()
-		require.NoError(t, err)
-		require.Len(t, metricFamilies, 1)
-
-		// Check metric family details
-		mf := metricFamilies[0]
-		assert.Equal(t, "inngest_queue_depth", mf.GetName())
-		assert.Equal(t, "Total depth of all system queues including backlog and ready state items", mf.GetHelp())
-
 		// Make a request to update the metric
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		w := httptest.NewRecorder()
 		api.Router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
 
-		// Verify the metric value was updated
-		metricFamilies, err = api.registry.Gather()
+		// Verify metric is registered and has the correct value via the registry
+		metricFamilies, err := registry.Gather()
 		require.NoError(t, err)
-		require.Len(t, metricFamilies, 1)
-		require.Len(t, metricFamilies[0].GetMetric(), 1)
 
-		metric := metricFamilies[0].GetMetric()[0]
-		assert.Equal(t, float64(12345), metric.GetGauge().GetValue())
+		var found bool
+		for _, mf := range metricFamilies {
+			if mf.GetName() == "inngest_queue_depth" {
+				found = true
+				assert.Equal(t, "Total depth of all system queues including backlog and ready state items", mf.GetHelp())
+				require.Len(t, mf.GetMetric(), 1)
+				assert.Equal(t, float64(12345), mf.GetMetric()[0].GetGauge().GetValue())
+				break
+			}
+		}
+		assert.True(t, found, "inngest_queue_depth metric family not found in registry")
 	})
 }
 


### PR DESCRIPTION
## Description
Add new Prometheus metrics which can be scraped per-function using in-memory counters. This expands the metrics available. 

High cardinality of function slugs could cause memory issues, but those totals would have to be very high.

Set `INNGEST_EXPERIMENTAL_PROM_METRICS=1` to enable new per-function metrics, unset or use `INNGEST_EXPERIMENTAL_PROM_METRICS=0` to disable.

NOTE - This is forked from the latest 1.13.x release here: https://github.com/inngest/inngest/tree/v1.13.7 - if this is stable and accepted, we can release a stable 1.13.8 release then the head of the repo to bring it into main. This will create a fork for the time being.

## Motivation
EXE-1546

Built on the changes in #3912, but back ported for `v1.13.x` and refactored with fixes and with additional tests for the lifecycle methods. This will be brought to future releases after beta testing.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds per-function Prometheus lifecycle metrics (function run and SDK step counters labeled by function slug) behind an `INNGEST_EXPERIMENTAL_PROM_METRICS` env var toggle. Refactors the metrics registry from instance-level to package-level so lifecycle metrics share the same registry as the queue depth gauge. Removes the signing-key auth requirement from `/metrics` in the dev server. The latest commit also fixes goreleaser to publish pre-release Docker images without tagging them as `latest`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 11e62b87ea524c6b6efe9f6b18d83db1a36ccc1a.</sup>
<!-- /MENDRAL_SUMMARY -->