### PR TITLE
Support Docker pre-releases by omitting latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
     needs: [check-release-type]
     steps:
       - name: Login to Docker Hub
-        if: needs.check-release-type.outputs.prerelease == ''
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USER }}
@@ -46,14 +45,13 @@ jobs:
         id: tag
         run: echo "tag=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
-        if: needs.check-release-type.outputs.prerelease == ''
         id: buildx
         uses: docker/setup-buildx-action@v3
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:
           version: "~> 2"
-          args: ${{ needs.check-release-type.outputs.prerelease != '' && 'release --clean --verbose --skip=docker' || 'release --clean --verbose' }}
+          args: release --clean --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   npm:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,8 +29,8 @@ dockers:
     use: buildx
     dockerfile: 'Dockerfile.goreleaser'
     image_templates:
-    - "inngest/inngest:latest-amd64"
     - "inngest/inngest:{{ .Tag }}-amd64"
+    - "{{ if not .Prerelease }}inngest/inngest:latest-amd64{{ end }}"
     build_flag_templates:
     - "--pull"
     - "--label=org.opencontainers.image.created={{.Date}}"
@@ -45,8 +45,8 @@ dockers:
     use: buildx
     dockerfile: 'Dockerfile.goreleaser'
     image_templates:
-    - "inngest/inngest:latest-arm64v8"
     - "inngest/inngest:{{ .Tag }}-arm64v8"
+    - "{{ if not .Prerelease }}inngest/inngest:latest-arm64v8{{ end }}"
     build_flag_templates:
     - "--pull"
     - "--label=org.opencontainers.image.created={{.Date}}"
@@ -55,10 +55,10 @@ dockers:
     - "--label=org.opencontainers.image.version={{.Version}}"
     - "--platform=linux/arm64"
 docker_manifests:
-  - name_template: inngest/inngest:latest
+  - name_template: "{{ if not .Prerelease }}inngest/inngest:latest{{ end }}"
     image_templates:
-      - inngest/inngest:latest-amd64
-      - inngest/inngest:latest-arm64v8
+      - "{{ if not .Prerelease }}inngest/inngest:latest-amd64{{ end }}"
+      - "{{ if not .Prerelease }}inngest/inngest:latest-arm64v8{{ end }}"
   - name_template: inngest/inngest:{{ .Tag }}
     image_templates:
       - inngest/inngest:{{ .Tag }}-amd64


### PR DESCRIPTION


## Description

This changes our goreleaser process to publish pre-release docker images, but skips the latest tag using goreleaser native methods.

## Motivation
Release #3932 as a beta release for a self-hosted customer.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR changes the goreleaser release pipeline to support pre-release Docker image publishing. Previously, pre-releases skipped Docker entirely (`--skip=docker`). Now Docker images are always built and pushed, but the `latest` tag is conditionally omitted using goreleaser's native template support (`{{ if not .Prerelease }}`). The GitHub Actions workflow is simplified by removing the conditional Docker login/buildx steps and the ternary args expression.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c5e90e1a1012372d75701636c4fc67ee32c7ac37.</sup>
<!-- /MENDRAL_SUMMARY -->