### PR TITLE
Inngest discovery latency fix

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/Timeline.tsx
+++ b/ui/packages/components/src/RunDetailsV4/Timeline.tsx
@@ -511,14 +511,11 @@ function TimelineBarRenderer({
   // Pre-compute timing sub-bar positions from the parent bar's position.
   // This ensures sub-bars visually align with the parent's compound segments.
   //
-  // For the Inngest portion: prefer timingBreakdown.inngestMs (from metadata),
-  // but fall back to inngestBreakdown.totalMs (from timestamps) so we still
-  // show the Inngest bar even when metadata is missing or reports 0.
+  // timingBreakdown.inngestMs already includes discovery time
+  // so the Inngest bar encompasses all its sub-phases.
   const timingPositions = (() => {
-    const breakdownInngestMs = bar.timingBreakdown?.inngestMs ?? 0;
+    const inngestMs = bar.timingBreakdown?.inngestMs ?? 0;
     const executionMs = bar.timingBreakdown?.executionMs ?? 0;
-    const inngestMs =
-      breakdownInngestMs > 0 ? breakdownInngestMs : bar.inngestBreakdown?.totalMs ?? 0;
     const totalMs = inngestMs + executionMs;
     if (totalMs <= 0) return null;
 

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
@@ -400,6 +400,114 @@ describe('traceConversion', () => {
       expect(childBar?.inngestBreakdown).toBeUndefined();
     });
 
+    it('computes discoveryMs as inter-step gap, not total elapsed time', () => {
+      // Reproduces bug: without the fix, late-step would
+      // get discoveryMs = 5000 (entire run elapsed time), making the
+      // Inngest bar (5s+) vastly exceed the step bar (~40ms).
+      // With the fix, discoveryMs is the gap between the previous sibling
+      // ending and this step being queued (~5ms).
+      const trace = createTrace({
+        isRoot: true,
+        startedAt: '2024-01-01T00:00:00Z',
+        endedAt: '2024-01-01T00:00:05.100Z',
+        childrenSpans: [
+          createTrace({
+            spanID: 'slow-step-1',
+            stepOp: 'RUN',
+            queuedAt: '2024-01-01T00:00:00.001Z', // 1ms after run start
+            startedAt: '2024-01-01T00:00:00.010Z',
+            endedAt: '2024-01-01T00:00:03Z', // 3s execution
+          }),
+          createTrace({
+            spanID: 'slow-step-2',
+            stepOp: 'RUN',
+            queuedAt: '2024-01-01T00:00:03.002Z', // 2ms after slow-step-1 ended
+            startedAt: '2024-01-01T00:00:03.010Z',
+            endedAt: '2024-01-01T00:00:05Z', // 2s execution
+          }),
+          createTrace({
+            spanID: 'late-step',
+            stepOp: 'RUN',
+            queuedAt: '2024-01-01T00:00:05.005Z', // 5ms after slow-step-2 ended
+            startedAt: '2024-01-01T00:00:05.040Z', // 35ms queue wait
+            endedAt: '2024-01-01T00:00:05.046Z', // 6ms execution
+          }),
+        ],
+      });
+      const result = traceToTimelineData(trace, { runID: 'run-1' });
+
+      const step1 = result.bars[0]?.children?.[0];
+      const step2 = result.bars[0]?.children?.[1];
+      const step3 = result.bars[0]?.children?.[2];
+
+      // First step: discoveryMs = gap from runStartedAt to step queued = 1ms
+      expect(step1?.inngestBreakdown?.discoveryMs).toBe(1);
+
+      // Second step: discoveryMs = gap from slow-step-1 end to step queued = 2ms
+      expect(step2?.inngestBreakdown?.discoveryMs).toBe(2);
+
+      // Late step: discoveryMs = gap from slow-step-2 end to step queued = 5ms
+      // NOT 5005ms (which would be the old runStartedAt-based calculation)
+      expect(step3?.inngestBreakdown?.discoveryMs).toBe(5);
+
+      // late-step bar duration is small (~41ms), and the Inngest bar
+      // should fit within it since discoveryMs is only 5ms
+      // inngestMs = startedAt - queuedAt = 5.040 - 5.005 = 35ms
+      expect(step3?.timingBreakdown?.inngestMs).toBe(35);
+      expect(step3?.timingBreakdown?.executionMs).toBe(6);
+      expect(step3?.timingBreakdown?.totalMs).toBe(41);
+    });
+
+    it('widens timingBreakdown.inngestMs to include discovery when inngestBreakdown exceeds it', () => {
+      const trace = createTrace({
+        isRoot: true,
+        startedAt: '2024-01-01T00:00:00Z',
+        endedAt: '2024-01-01T00:00:10Z',
+        childrenSpans: [
+          createTrace({
+            spanID: 'prev-step',
+            stepOp: 'RUN',
+            queuedAt: '2024-01-01T00:00:00Z',
+            startedAt: '2024-01-01T00:00:00.010Z',
+            endedAt: '2024-01-01T00:00:03Z', // ends at T+3s
+          }),
+          createTrace({
+            spanID: 'run-step',
+            stepOp: 'RUN',
+            queuedAt: '2024-01-01T00:00:03.100Z', // 100ms gap after prev-step
+            startedAt: '2024-01-01T00:00:05Z',
+            endedAt: '2024-01-01T00:00:10Z',
+            metadata: [
+              {
+                scope: 'step_attempt',
+                kind: 'inngest.timing',
+                updatedAt: '2024-01-01T00:00:10Z',
+                values: {
+                  queue_delay_ms: 800,
+                  system_latency_ms: 200,
+                  total_inngest_ms: 1000,
+                },
+              },
+            ],
+          }),
+        ],
+      });
+      const result = traceToTimelineData(trace, { runID: 'run-1' });
+      const bar = result.bars[0]?.children?.[1]; // second child
+
+      // discoveryMs = gap from prev-step end (T+3) to this step queued (T+3.1) = 100ms
+      expect(bar?.inngestBreakdown?.discoveryMs).toBe(100);
+      expect(bar?.inngestBreakdown?.queueDelayMs).toBe(800);
+      expect(bar?.inngestBreakdown?.systemLatencyMs).toBe(200);
+      expect(bar?.inngestBreakdown?.totalMs).toBe(1100);
+
+      // timingBreakdown.inngestMs (1000 from metadata) < inngestBreakdown.totalMs (1100)
+      // so it gets widened to include discovery
+      expect(bar?.timingBreakdown?.inngestMs).toBe(1100);
+      expect(bar?.timingBreakdown?.executionMs).toBe(5000);
+      expect(bar?.timingBreakdown?.totalMs).toBe(6100);
+    });
+
     it('handles zero queue time', () => {
       const trace = createTrace({
         isRoot: true,

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
@@ -119,16 +119,24 @@ function getTimingFromMetadata(
  * Extract per-step Inngest overhead breakdown from metadata + timestamps.
  * Combines discovery time (from timestamps) with concurrency delay and
  * system latency (from inngest.timing metadata).
+ *
+ * @param previousStepEndMs - End time of the previous sibling step. Discovery
+ *   time is measured as the gap between the previous step completing and this
+ *   step being queued — i.e. the actual Inngest processing overhead between
+ *   steps, not total elapsed time since the run started.
  */
 function getInngestBreakdown(
   trace: Trace,
-  runStartedAtMs: number | null
+  previousStepEndMs: number | null
 ): InngestBreakdownData | null {
   if (!trace.queuedAt) return null;
 
-  // Discovery: time from when the run started executing to when this step was queued
+  // Discovery: time between the previous step completing and this step being
+  // queued. This captures actual Inngest processing overhead (executor work,
+  // span creation, queue enqueue) rather than total run elapsed time.
   const stepQueuedAt = new Date(trace.queuedAt).getTime();
-  const discoveryMs = runStartedAtMs !== null ? Math.max(0, stepQueuedAt - runStartedAtMs) : 0;
+  const discoveryMs =
+    previousStepEndMs !== null ? Math.max(0, stepQueuedAt - previousStepEndMs) : 0;
 
   // Concurrency delay + system latency from metadata
   let queueDelayMs = 0;
@@ -178,7 +186,7 @@ function traceToBarData(
   trace: Trace,
   orgName?: string,
   rootStatus?: string,
-  runStartedAtMs?: number | null
+  previousStepEndMs?: number | null
 ): TimelineBarData {
   const isStepRun = isStepRunSpan(trace) && !trace.isUserland;
   // Prefer server-computed timing from metadata, fall back to span-timestamp calculation
@@ -200,10 +208,40 @@ function traceToBarData(
     ? Math.max(0, new Date(trace.startedAt).getTime() - new Date(trace.queuedAt).getTime())
     : undefined;
 
-  // Per-step Inngest overhead breakdown (discovery + metadata timing)
+  // Per-step Inngest overhead breakdown (discovery + metadata timing).
+  // Discovery is the gap between the previous step ending and this step
+  // being queued — actual Inngest processing overhead between steps.
   const inngestBreakdown = isStepRun
-    ? getInngestBreakdown(trace, runStartedAtMs ?? null) ?? undefined
+    ? getInngestBreakdown(trace, previousStepEndMs ?? null) ?? undefined
     : undefined;
+
+  // The Inngest bar should encompass all non-customer time: discovery +
+  // concurrency delay + system latency. timingBreakdown.inngestMs only
+  // captures queue + system overhead, so widen it to include discovery
+  // so the sub-phases fit inside the Inngest bar.
+  if (timingBreakdown && inngestBreakdown && inngestBreakdown.totalMs > timingBreakdown.inngestMs) {
+    timingBreakdown = {
+      ...timingBreakdown,
+      inngestMs: inngestBreakdown.totalMs,
+      totalMs: inngestBreakdown.totalMs + timingBreakdown.executionMs,
+    };
+  }
+
+  // Convert children while tracking each sibling's end time so the next
+  // sibling's discoveryMs measures the actual inter-step gap, not total
+  // elapsed time since the run started.
+  let childBars: TimelineBarData[] | undefined;
+  if (trace.childrenSpans && trace.childrenSpans.length > 0) {
+    childBars = [];
+    let prevEndMs = previousStepEndMs ?? null;
+    for (const child of trace.childrenSpans) {
+      const bar = traceToBarData(child, orgName, rootStatus, prevEndMs);
+      childBars.push(bar);
+      if (bar.endTime) {
+        prevEndMs = bar.endTime.getTime();
+      }
+    }
+  }
 
   return {
     id: trace.spanID,
@@ -211,9 +249,7 @@ function traceToBarData(
     startTime: new Date(trace.queuedAt),
     endTime: trace.endedAt ? new Date(trace.endedAt) : null,
     style: getStyleForTrace(trace),
-    children: trace.childrenSpans?.map((child) =>
-      traceToBarData(child, orgName, rootStatus, runStartedAtMs)
-    ),
+    children: childBars,
     timingBreakdown,
     httpTimingBreakdown,
     inngestBreakdown,
@@ -248,7 +284,10 @@ export function traceToTimelineData(
     }
   });
 
-  // Run startedAt timestamp for computing per-step discovery time
+  // Run startedAt is used as the initial "previous step end" for the first
+  // child. Each subsequent child uses the prior sibling's endTime, so
+  // discoveryMs measures the actual inter-step gap (Inngest processing
+  // overhead) rather than total elapsed time since the run started.
   const runStartedAtMs = trace.startedAt ? new Date(trace.startedAt).getTime() : null;
 
   // Convert root trace (rename to "Run")


### PR DESCRIPTION
## Description

fixes discovery step latency

## Motivation
https://inngest.slack.com/archives/C06K5S9S3K6/p1775134562462009

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes discovery latency calculation in the timeline visualization. Previously, `discoveryMs` was computed as the gap from run start to step queued, causing late steps in long-running functions to show inflated Inngest overhead bars. The fix changes the baseline to the previous sibling's end time, so `discoveryMs` reflects actual inter-step processing overhead. Also widens `timingBreakdown.inngestMs` to include discovery when the breakdown total exceeds the metadata-reported value.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0bf972820e78932c81e270028d0548d747f26bc9.</sup>
<!-- /MENDRAL_SUMMARY -->