### PR TITLE
Fix missing timing metadata on checkpointed steps

### DIFF
--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -25,6 +25,7 @@ import (
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/tracing"
 	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/inngest/inngest/pkg/tracing/metadata/extractors"
 )
 
 type Checkpointer interface {
@@ -196,6 +197,7 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 			}
 
 			c.processMetadata(ctx, l, input.AccountID, input.Metadata, stepSpanRef, op, "checkpoint.SyncStep.metadata")
+			c.processTimingMetadata(ctx, l, input.AccountID, input.Metadata, stepSpanRef, "checkpoint.SyncStep.timing")
 
 			go c.MetricsProvider.OnStepFinished(ctx, MetricCardinality{
 				AccountID: input.AccountID,
@@ -234,6 +236,7 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 			}
 
 			c.processMetadata(ctx, l, input.AccountID, input.Metadata, stepSpanRef, op, "checkpoint.SyncErr.metadata")
+			c.processTimingMetadata(ctx, l, input.AccountID, input.Metadata, stepSpanRef, "checkpoint.SyncErr.timing")
 
 			err = c.Executor.HandleGenerator(ctx, runCtx, op)
 			if errors.Is(err, executor.ErrHandledStepError) {
@@ -432,6 +435,7 @@ func (c checkpointer) checkpointAsyncSteps(ctx context.Context, input AsyncCheck
 			}
 
 			c.processMetadata(ctx, l, input.AccountID, &md, stepSpanRef, op, "checkpoint.AsyncStep.metadata")
+			c.processTimingMetadata(ctx, l, input.AccountID, &md, stepSpanRef, "checkpoint.AsyncStep.timing")
 
 		default:
 			// Return an error
@@ -512,6 +516,55 @@ func (c checkpointer) fn(ctx context.Context, fnID uuid.UUID) (*inngest.Function
 		return nil, fmt.Errorf("error loading function: %w", err)
 	}
 	return cfn.InngestFunction()
+}
+
+// processTimingMetadata generates inngest.timing metadata for checkpointed steps.
+//
+// In the standard executor path, timing metadata is derived from queue RunInfo
+// (queue delay, system latency) and httpstat (network timing). Checkpointed steps
+// bypass the queue and don't have individual HTTP round-trips, so these values
+// are all zero — reflecting the reduced overhead that checkpointing provides.
+func (c checkpointer) processTimingMetadata(
+	ctx context.Context,
+	l logger.Logger,
+	accountID uuid.UUID,
+	md *state.Metadata,
+	stepSpanRef *meta.SpanReference,
+	location string,
+) {
+	if !c.AllowStepMetadata.Enabled(ctx, accountID) {
+		return
+	}
+
+	// Checkpointed steps have zero platform overhead: no queue wait, no system
+	// latency between queue lease and execution, and no individual HTTP call.
+	zero := int64(0)
+	timingMd := &extractors.TimingMetadata{
+		QueueDelayMs:    &zero,
+		SystemLatencyMs: &zero,
+		TotalInngestMs:  &zero,
+	}
+
+	parent := stepSpanRef
+	if parent == nil {
+		parent = tracing.RunSpanRefFromMetadata(md)
+	}
+
+	if _, err := tracing.CreateMetadataSpan(
+		ctx,
+		c.TracerProvider,
+		parent,
+		location,
+		"checkpoint",
+		md,
+		timingMd,
+		enums.MetadataScopeStepAttempt,
+	); err != nil {
+		l.Warn("error creating timing metadata span in checkpoint",
+			"error", err,
+			"run_id", md.ID.RunID,
+		)
+	}
 }
 
 func (c checkpointer) processMetadata(

--- a/pkg/execution/checkpoint/checkpoint_async_test.go
+++ b/pkg/execution/checkpoint/checkpoint_async_test.go
@@ -217,19 +217,20 @@ func TestAsyncStepWithMetadataCreatesMetadataSpans(t *testing.T) {
 	err := testData.checkpointer.CheckpointAsyncSteps(ctx, testData.asyncCheckpoint)
 	require.NoError(err)
 
-	// Assert that both step and metadata spans were created
-	require.Len(mocks.tracer.createdSpans, 2, "Expected 1 step span + 1 metadata span")
-	var hasStep, hasMetadata bool
+	// Assert that step, userland metadata, and timing metadata spans were created
+	require.Len(mocks.tracer.createdSpans, 3, "Expected 1 step span + 1 userland metadata span + 1 timing metadata span")
+	var hasStep bool
+	metadataCount := 0
 	for _, s := range mocks.tracer.createdSpans {
 		if s.name == meta.SpanNameStep {
 			hasStep = true
 		}
 		if s.name == meta.SpanNameMetadata {
-			hasMetadata = true
+			metadataCount++
 		}
 	}
 	require.True(hasStep, "Expected a step span")
-	require.True(hasMetadata, "Expected a metadata span")
+	require.Equal(2, metadataCount, "Expected 2 metadata spans (userland + timing)")
 }
 
 //

--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -298,19 +298,20 @@ func TestSyncStepWithMetadataCreatesMetadataSpans(t *testing.T) {
 	err := testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
 	require.NoError(err)
 
-	// Assert that both step and metadata spans were created
-	require.Len(mocks.tracer.createdSpans, 2, "Expected 1 step span + 1 metadata span")
-	var hasStep, hasMetadata bool
+	// Assert that step, userland metadata, and timing metadata spans were created
+	require.Len(mocks.tracer.createdSpans, 3, "Expected 1 step span + 1 userland metadata span + 1 timing metadata span")
+	var hasStep bool
+	metadataCount := 0
 	for _, s := range mocks.tracer.createdSpans {
 		if s.name == meta.SpanNameStep {
 			hasStep = true
 		}
 		if s.name == meta.SpanNameMetadata {
-			hasMetadata = true
+			metadataCount++
 		}
 	}
 	require.True(hasStep, "Expected a step span")
-	require.True(hasMetadata, "Expected a metadata span")
+	require.Equal(2, metadataCount, "Expected 2 metadata spans (userland + timing)")
 }
 
 // TestSyncStepErrorWithMetadataCreatesMetadataSpans asserts that a sync step error with metadata
@@ -376,19 +377,20 @@ func TestSyncStepErrorWithMetadataCreatesMetadataSpans(t *testing.T) {
 	err := testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
 	require.NoError(err)
 
-	// Assert step + metadata spans were created
-	require.Len(mocks.tracer.createdSpans, 2, "Expected 1 step span + 1 metadata span")
-	var hasStep, hasMetadata bool
+	// Assert step, userland metadata, and timing metadata spans were created
+	require.Len(mocks.tracer.createdSpans, 3, "Expected 1 step span + 1 userland metadata span + 1 timing metadata span")
+	var hasStep bool
+	metadataCount := 0
 	for _, s := range mocks.tracer.createdSpans {
 		if s.name == meta.SpanNameStep {
 			hasStep = true
 		}
 		if s.name == meta.SpanNameMetadata {
-			hasMetadata = true
+			metadataCount++
 		}
 	}
 	require.True(hasStep, "Expected a step span")
-	require.True(hasMetadata, "Expected a metadata span")
+	require.Equal(2, metadataCount, "Expected 2 metadata spans (userland + timing)")
 }
 
 // TestSyncStepNoMetadataWhenFlagDisabled asserts that no metadata spans are created
@@ -519,9 +521,19 @@ func TestSyncStepInvalidMetadataSkipped(t *testing.T) {
 	err := testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
 	require.NoError(err, "Invalid metadata should not cause an error")
 
-	// Assert only the step span was created, invalid metadata was skipped
-	require.Len(mocks.tracer.createdSpans, 1, "Expected only 1 step span, invalid metadata skipped")
-	require.Equal(meta.SpanNameStep, mocks.tracer.createdSpans[0].name)
+	// Assert the step span and timing metadata span were created; invalid userland metadata was skipped
+	require.Len(mocks.tracer.createdSpans, 2, "Expected 1 step span + 1 timing metadata span, invalid userland metadata skipped")
+	var hasStep, hasTiming bool
+	for _, s := range mocks.tracer.createdSpans {
+		if s.name == meta.SpanNameStep {
+			hasStep = true
+		}
+		if s.name == meta.SpanNameMetadata {
+			hasTiming = true
+		}
+	}
+	require.True(hasStep, "Expected a step span")
+	require.True(hasTiming, "Expected a timing metadata span")
 }
 
 //


### PR DESCRIPTION
## Description

`inngest.timing` metadata is missing on steps 2+ when checkpointing is enabled. In a 3-step function, only step-1 gets timing metadata; steps 2 and 3 get none. Non-checkpoint mode correctly produces timing metadata on every step.

The root cause is that the executor generates timing metadata (via `extractors.BuildTimingMetadata` and `extractors.ExtractHTTPTimingMetadata`) after its HTTP call to the SDK, but the checkpoint handler — which processes steps that the SDK reported via checkpoint API calls — never generates timing metadata. It only processes metadata already embedded in the SDK's opcodes (`op.Metadata`), and the SDK doesn't include server-side timing.

This PR adds a `processTimingMetadata()` method to the checkpoint handler that generates `inngest.timing` metadata for each checkpointed step with zero values for queue delay, system latency, and total Inngest overhead. This accurately reflects that checkpointed steps have no platform overhead — they execute sequentially within a single SDK invocation without being individually queued or making separate HTTP round-trips.

`inngest.http.timing` is intentionally NOT generated for checkpointed steps since there is no per-step HTTP request to measure.

### Changes
- `checkpoint.go`: New `processTimingMetadata()` method called after `processMetadata()` in all 3 step handling paths (sync success, sync error, async)
- Updated test expectations in `checkpoint_sync_test.go` and `checkpoint_async_test.go` to account for the additional timing metadata span

## Motivation

Consistent timing metadata across checkpoint and non-checkpoint modes. Without this, dashboard UIs and tooling that rely on `inngest.timing` metadata show incomplete data for checkpoint-enabled functions.

Discovered during the checkpointing metadata investigation (see `inngest-js#1447` for the companion SDK fix).

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `processTimingMetadata()` to the checkpoint handler so that checkpointed steps (steps 2+ in a multi-step function) emit `inngest.timing` metadata spans with zero-valued platform overhead metrics, matching the behavior of the standard executor path. Three call sites are added (sync success, sync error, async), and test expectations are updated to account for the additional span.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 60f0aa04828be2d8dba86e09f605753cec2c6f23.</sup>
<!-- /MENDRAL_SUMMARY -->