### PR TITLE
Refactor CSP report handling to use eventType for cspViolationEvent

### DIFF
--- a/ui/apps/dashboard/src/routes/api/csp-report.ts
+++ b/ui/apps/dashboard/src/routes/api/csp-report.ts
@@ -1,6 +1,11 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { inngest } from '@/lib/inngest/client';
 import { isRecord } from '@inngest/components/utils/object';
+import { eventType } from 'inngest';
+
+const cspViolationEvent = eventType('app/csp-violation.reported', {
+  version: '2025-01-08.1',
+});
 
 /**
  * Normalizes CSP report request bodies from two potential structures:
@@ -63,10 +68,7 @@ export const Route = createFileRoute('/api/csp-report')({
       POST: async ({ request }) => {
         const body = await request.json();
         const normalizedBody = normalizeCspReport(body);
-        await inngest.send({
-          name: 'app/csp-violation.reported',
-          data: normalizedBody,
-        });
+        await inngest.send(cspViolationEvent.create(normalizedBody));
         return new Response(null, { status: 200 });
       },
     },


### PR DESCRIPTION
## Description

Use SDK v4 eventType to add version back to csp 

## Motivation
fix

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Refactors the CSP violation event dispatch to use the Inngest SDK v4 `eventType` helper, replacing the inline `inngest.send({ name, data })` call with a typed `cspViolationEvent.create(normalizedBody)`. The primary motivation is restoring the `v` (version) field that was missing from the previous send call.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0d23e6d33438330ed1e16c2f5d9318a36a2bad58.</sup>
<!-- /MENDRAL_SUMMARY -->