### PR TITLE
add atties for every step

### DIFF
--- a/pkg/tracing/meta/attributes.go
+++ b/pkg/tracing/meta/attributes.go
@@ -121,6 +121,7 @@ var Attrs = struct {
 	ResponseHeaders    attr[*headers.Compact]
 	ResponseStatusCode attr[*int]
 	ResponseOutputSize attr[*int]
+	ResponseSteps      attr[*ResponseOps]
 
 	IsCheckpoint attr[*bool]
 
@@ -223,4 +224,18 @@ var Attrs = struct {
 	MetadataKind:  StringishAttr[metadata.Kind]("metadata.kind"),
 	MetadataOp:    TextAttr[enums.MetadataOpcode]("metadata.op"),
 	MetadataScope: TextAttr[enums.MetadataScope]("metadata.scope"),
+}
+
+type ResponseOps []ResponseOp
+
+// ResponseOp is an op tracked for each HTTP response
+type ResponseOp struct {
+	// Op represents the type of operation invoked in the function.
+	Op enums.Opcode `json:"op"`
+	// ID represents a hashed unique ID for the operation.  This acts
+	// as the generated step ID for the state store.
+	ID string `json:"id"`
+	// Name represents the name of the step, or the sleep duration for
+	// sleeps.
+	Name string `json:"name"`
 }

--- a/pkg/tracing/meta/attributes.go
+++ b/pkg/tracing/meta/attributes.go
@@ -177,6 +177,7 @@ var Attrs = struct {
 	ResponseHeaders:                    JsonAttr[headers.Compact]("response.headers"),
 	ResponseOutputSize:                 IntAttr("response.output_size"),
 	ResponseStatusCode:                 IntAttr("response.status_code"),
+	ResponseSteps:                      JsonAttr[ResponseOps]("response.step.ops"),
 	RunID:                              ULIDAttr("run.id"),
 	SkipReason:                         TextAttr[enums.SkipReason]("run.skip_reason"),
 	SkipExistingRunID:                  StringAttr("run.skip_existing_run_id"),

--- a/pkg/tracing/util.go
+++ b/pkg/tracing/util.go
@@ -141,6 +141,17 @@ func DriverResponseAttrs(
 		rawAttrs = rawAttrs.Merge(GeneratorAttrs(op))
 	}
 
+	// always add all steps received as a debugging attie
+	steps := make(meta.ResponseOps, len(resp.Generator))
+	for n, s := range resp.Generator {
+		steps[n] = meta.ResponseOp{
+			Op:   s.Op,
+			ID:   s.ID,
+			Name: s.Name,
+		}
+	}
+	meta.AddAttr(rawAttrs, meta.Attrs.ResponseSteps, &steps)
+
 	return rawAttrs
 }
 


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `ResponseSteps` tracing attribute that records all step ops from each HTTP response as a JSON array. Defines `ResponseOps`/`ResponseOp` types in `pkg/tracing/meta/attributes.go` and populates the attribute in `DriverResponseAttrs` by mapping `resp.Generator` entries to the new type.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f568ba93b967cca6a5580d379f9d1544f9df872f.</sup>
<!-- /MENDRAL_SUMMARY -->