### PR TITLE
ensure we decompress outside of exechttp

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -166,6 +166,19 @@ func ExecuteDriverRequest(ctx context.Context, c exechttp.RequestExecutor, r Req
 func HandleHttpResponse(ctx context.Context, r Request, resp *Response) (*state.DriverResponse, error) {
 	l := logger.StdlibLogger(ctx)
 
+	// Decompress body if Content-Encoding is still set.  In the HTTP path,
+	// exechttp.DoRequest already decompresses and clears the header, so this
+	// is a no-op.  For other paths (e.g. gateway proxy) the body may still
+	// be compressed.
+	if enc := resp.Header.Get("Content-Encoding"); enc != "" {
+		decoded, err := exechttp.DecompressBody(resp.Body, enc)
+		if err != nil {
+			return nil, fmt.Errorf("error decompressing response body: %w", err)
+		}
+		resp.Body = decoded
+		resp.Header.Del("Content-Encoding")
+	}
+
 	var err error
 	if resp.StatusCode == 206 {
 		// This is a generator-based function returning opcodes.

--- a/pkg/execution/driver/httpdriver/httpdriver_test.go
+++ b/pkg/execution/driver/httpdriver/httpdriver_test.go
@@ -2,6 +2,7 @@ package httpdriver
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"crypto/rand"
 	"encoding/json"
@@ -268,11 +269,87 @@ func TestExecuteDriverRequest_DecodesBrotliGeneratorResponse(t *testing.T) {
 	require.Equal(t, "step-id", dr.Generator[0].ID)
 }
 
+func TestHandleHttpResponse_DecompressesGzipBody(t *testing.T) {
+	r := require.New(t)
+
+	body := `{"result":"ok"}`
+	compressed := gzipCompressedJSON(t, body)
+
+	resp := &Response{
+		Body:       compressed,
+		StatusCode: 200,
+		IsSDK:      true,
+		Header:     http.Header{"Content-Encoding": []string{"gzip"}},
+	}
+
+	dr, err := HandleHttpResponse(context.Background(), Request{}, resp)
+	r.NoError(err)
+	r.NotNil(dr)
+
+	// The body should have been decompressed before parsing.
+	out, ok := dr.Output.(map[string]interface{})
+	r.True(ok, "expected parsed JSON map, got %T", dr.Output)
+	r.Equal("ok", out["result"])
+}
+
+func TestHandleHttpResponse_DecompressesBrotliBody(t *testing.T) {
+	r := require.New(t)
+
+	body := `[{"op":"StepRun","id":"step-id","name":"step"}]`
+	compressed := brotliCompressedJSON(t, body)
+
+	resp := &Response{
+		Body:       compressed,
+		StatusCode: 206,
+		IsSDK:      true,
+		Header:     http.Header{"Content-Encoding": []string{"br"}},
+	}
+
+	dr, err := HandleHttpResponse(context.Background(), Request{}, resp)
+	r.NoError(err)
+	r.NotNil(dr)
+	r.Len(dr.Generator, 1)
+	r.Equal(enums.OpcodeStepRun, dr.Generator[0].Op)
+}
+
+func TestHandleHttpResponse_NoDoubleDecompress(t *testing.T) {
+	r := require.New(t)
+
+	// Simulate the HTTP path: body is already decompressed, no Content-Encoding header.
+	body := `{"result":"ok"}`
+	resp := &Response{
+		Body:       []byte(body),
+		StatusCode: 200,
+		IsSDK:      true,
+		Header:     http.Header{},
+	}
+
+	dr, err := HandleHttpResponse(context.Background(), Request{}, resp)
+	r.NoError(err)
+	r.NotNil(dr)
+
+	out, ok := dr.Output.(map[string]interface{})
+	r.True(ok, "expected parsed JSON map, got %T", dr.Output)
+	r.Equal("ok", out["result"])
+}
+
 func brotliCompressedJSON(t *testing.T, input string) []byte {
 	t.Helper()
 
 	var buf bytes.Buffer
 	writer := brotli.NewWriter(&buf)
+	_, err := writer.Write([]byte(input))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	return buf.Bytes()
+}
+
+func gzipCompressedJSON(t *testing.T, input string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
 	_, err := writer.Write([]byte(input))
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())

--- a/pkg/execution/exechttp/exechttp.go
+++ b/pkg/execution/exechttp/exechttp.go
@@ -2,6 +2,7 @@
 package exechttp
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/tls"
@@ -136,6 +137,12 @@ func (e ExtendedClient) DoRequest(ctx context.Context, r SerializableRequest) (*
 	if err != nil {
 		return nil, err
 	}
+	if bodyEncoding != "" {
+		// Clear the Content-Encoding header after decompression so that
+		// downstream consumers (e.g. HandleHttpResponse) know the body is
+		// already decoded and don't attempt to decompress again.
+		resp.Header.Del("Content-Encoding")
+	}
 	if bodyCloser != nil {
 		defer func() {
 			_ = bodyCloser.Close()
@@ -208,28 +215,74 @@ func (e ExtendedClient) DoRequest(ctx context.Context, r SerializableRequest) (*
 	return out, err
 }
 
-func decodeResponseBody(resp *http.Response) (io.Reader, string, io.Closer, error) {
-	encoding := strings.TrimSpace(resp.Header.Get("Content-Encoding"))
-	if encoding == "" {
-		return resp.Body, "", nil, nil
+// normalizeEncoding validates and normalizes a Content-Encoding header value.
+// Returns the lowercase encoding name, or an error for unsupported/multi-valued encodings.
+// An empty input returns "" with no error.
+func normalizeEncoding(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", nil
 	}
 
-	normalized := strings.ToLower(encoding)
+	normalized := strings.ToLower(trimmed)
 	if strings.Contains(normalized, ",") {
-		return nil, "", nil, fmt.Errorf("unsupported content encoding: %q", encoding)
+		return "", fmt.Errorf("unsupported content encoding: %q", raw)
 	}
 
 	switch normalized {
+	case "gzip", "br":
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("unsupported content encoding: %q", raw)
+	}
+}
+
+// DecompressBody decompresses body bytes based on a Content-Encoding value.
+// Returns the bytes unchanged if contentEncoding is empty.
+func DecompressBody(data []byte, contentEncoding string) ([]byte, error) {
+	enc, err := normalizeEncoding(contentEncoding)
+	if err != nil {
+		return nil, err
+	}
+	if enc == "" {
+		return data, nil
+	}
+
+	switch enc {
+	case "gzip":
+		reader, err := gzip.NewReader(bytes.NewReader(data))
+		if err != nil {
+			return nil, fmt.Errorf("error creating gzip decoder: %w", err)
+		}
+		defer reader.Close()
+		return io.ReadAll(reader)
+	case "br":
+		return io.ReadAll(brotli.NewReader(bytes.NewReader(data)))
+	default:
+		return nil, fmt.Errorf("unsupported content encoding: %q", contentEncoding)
+	}
+}
+
+func decodeResponseBody(resp *http.Response) (io.Reader, string, io.Closer, error) {
+	enc, err := normalizeEncoding(resp.Header.Get("Content-Encoding"))
+	if err != nil {
+		return nil, "", nil, err
+	}
+	if enc == "" {
+		return resp.Body, "", nil, nil
+	}
+
+	switch enc {
 	case "gzip":
 		reader, err := gzip.NewReader(resp.Body)
 		if err != nil {
 			return nil, "", nil, fmt.Errorf("error creating gzip decoder: %w", err)
 		}
-		return reader, normalized, reader, nil
+		return reader, enc, reader, nil
 	case "br":
-		return brotli.NewReader(resp.Body), normalized, nil, nil
+		return brotli.NewReader(resp.Body), enc, nil, nil
 	default:
-		return nil, "", nil, fmt.Errorf("unsupported content encoding: %q", encoding)
+		return nil, "", nil, fmt.Errorf("unsupported content encoding: %q", enc)
 	}
 }
 

--- a/pkg/execution/exechttp/exechttp_test.go
+++ b/pkg/execution/exechttp/exechttp_test.go
@@ -287,6 +287,68 @@ func TestDoRequest_RejectsInvalidCompressedResponse(t *testing.T) {
 	r.ErrorContains(err, "error decoding gzip response body")
 }
 
+func TestDecompressBody_Gzip(t *testing.T) {
+	r := require.New(t)
+	original := `{"result":"hello"}`
+	compressed := gzipCompressed(t, original)
+
+	decoded, err := DecompressBody(compressed, "gzip")
+	r.NoError(err)
+	r.Equal(original, string(decoded))
+}
+
+func TestDecompressBody_Brotli(t *testing.T) {
+	r := require.New(t)
+	original := `{"result":"hello"}`
+	compressed := brotliCompressed(t, original)
+
+	decoded, err := DecompressBody(compressed, "br")
+	r.NoError(err)
+	r.Equal(original, string(decoded))
+}
+
+func TestDecompressBody_EmptyEncoding(t *testing.T) {
+	r := require.New(t)
+	original := []byte(`{"result":"hello"}`)
+
+	decoded, err := DecompressBody(original, "")
+	r.NoError(err)
+	r.Equal(original, decoded)
+}
+
+func TestDecompressBody_Unsupported(t *testing.T) {
+	r := require.New(t)
+	_, err := DecompressBody([]byte("data"), "zstd")
+	r.ErrorContains(err, `unsupported content encoding: "zstd"`)
+}
+
+func TestDoRequest_ClearsContentEncodingAfterDecode(t *testing.T) {
+	r := require.New(t)
+	ctx := silenceLogger(t.Context())
+
+	expectedBody := `{"result":"hello"}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Encoding", "br")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(brotliCompressed(t, expectedBody))
+	}))
+	defer server.Close()
+
+	client := ExtendedClient{Client: server.Client()}
+	resp, err := client.DoRequest(ctx, SerializableRequest{
+		Method: http.MethodPost,
+		URL:    server.URL,
+		Body:   json.RawMessage(`{}`),
+		Header: http.Header{"Accept-Encoding": []string{"br"}},
+	})
+
+	r.NoError(err)
+	r.NotNil(resp)
+	r.Equal(expectedBody, string(resp.Body))
+	r.Empty(resp.Header.Get("Content-Encoding"), "Content-Encoding should be cleared after decompression")
+}
+
 func brotliCompressed(t *testing.T, input string) []byte {
 	t.Helper()
 


### PR DESCRIPTION


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR moves decompression out of `exechttp.DoRequest` and into `HandleHttpResponse` so that non-HTTP paths (e.g. gateway proxy) that deliver a compressed body with a `Content-Encoding` header are also decompressed before processing. It extracts a public `DecompressBody([]byte, string) ([]byte, error)` helper and a `normalizeEncoding` utility, clears the `Content-Encoding` header after decompression in `DoRequest` to prevent double-decompression, and adds unit tests for all paths.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 2274727b68db3167c745a1bfafa08d969d1ef19a.</sup>
<!-- /MENDRAL_SUMMARY -->