### PR TITLE
SYS-737: Reset queue item from status key sets when calling RemoveQueueItem

### DIFF
--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -261,6 +261,11 @@ type ShardOperations interface {
 	RunningCount(ctx context.Context, functionID uuid.UUID) (int64, error)
 	StatusCount(ctx context.Context, workflowID uuid.UUID, status string) (int64, error)
 	RunJobs(ctx context.Context, workspaceID, workflowID uuid.UUID, runID ulid.ULID, limit, offset int64) ([]JobResponse, error)
+
+	// CleanupStatusIndexes scans the status index sorted sets (start, in-progress, sleep) for
+	// a given function and removes orphaned entries that no longer have a corresponding queue item.
+	// This fixes index drift caused by RemoveQueueItem not cleaning up indexes.
+	CleanupStatusIndexes(ctx context.Context, fnID uuid.UUID) (removed int64, err error)
 }
 
 type BacklogRefillOptions struct {

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -200,6 +200,10 @@ func (m *mockShardForIterator) RemoveQueueItem(ctx context.Context, partitionID 
 	return nil
 }
 
+func (m *mockShardForIterator) CleanupStatusIndexes(ctx context.Context, fnID uuid.UUID) (int64, error) {
+	return 0, nil
+}
+
 func (m *mockShardForIterator) LoadQueueItem(ctx context.Context, itemID string) (*QueueItem, error) {
 	return nil, nil
 }

--- a/pkg/execution/state/redis_state/lua/queue/removeItem.lua
+++ b/pkg/execution/state/redis_state/lua/queue/removeItem.lua
@@ -13,4 +13,11 @@ local itemID = ARGV[1]
 redis.call("ZREM", queueKey, itemID)
 redis.call("HDEL", queueItemKey, itemID)
 
+-- Clean up any additional index keys (e.g. status indexes) passed by the caller.
+for i = 3, #KEYS do
+    if KEYS[i] ~= "" then
+        redis.call("ZREM", KEYS[i], itemID)
+    end
+end
+
 return 0

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -360,6 +360,16 @@ func (q *queue) RemoveQueueItem(ctx context.Context, partitionID string, itemID 
 		q.RedisClient.kg.PartitionQueueSet(enums.PartitionTypeDefault, partitionID, ""),
 		q.RedisClient.kg.QueueItem(),
 	}
+
+	// If partitionID is a valid function UUID, append status index keys so the
+	// Lua script can clean up orphaned entries from all status sorted sets.
+	if fnID, err := uuid.Parse(partitionID); err == nil {
+		keys = append(keys,
+			q.RedisClient.kg.Status("start", fnID),
+			q.RedisClient.kg.Status("in-progress", fnID),
+			q.RedisClient.kg.Status("sleep", fnID),
+		)
+	}
 	args := []string{itemID}
 
 	code, err := scripts["queue/removeItem"].Exec(

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -3318,20 +3318,11 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 
 	_, shard := newQueue(t, rc)
 	ctx := context.Background()
-	kg := &queueKeyGenerator{
-		queueDefaultKey: QueueDefaultKey,
-		queueItemKeyGenerator: queueItemKeyGenerator{
-			queueDefaultKey: QueueDefaultKey,
-		},
-	}
-
 	fnID := uuid.New()
 	acctID := uuid.New()
 	start := time.Now().Truncate(time.Second)
 
-	statusStartKey := kg.Status("start", fnID)
-	statusInProgressKey := kg.Status("in-progress", fnID)
-	statusSleepKey := kg.Status("sleep", fnID)
+
 
 	t.Run("removes start status index", func(t *testing.T) {
 		r.FlushAll()
@@ -3348,20 +3339,17 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify the status index was created by enqueue.
-		members, err := r.ZMembers(statusStartKey)
+		count, err := shard.StatusCount(ctx, fnID, "start")
 		require.NoError(t, err)
-		require.Len(t, members, 1, "status:start index should have 1 member after enqueue")
+		require.EqualValues(t, 1, count, "status:start index should have 1 member after enqueue")
 
 		// RemoveQueueItem should clean up the status index.
 		err = shard.RemoveQueueItem(ctx, fnID.String(), item.ID)
 		require.NoError(t, err)
 
-		// Key may be gone entirely (Redis deletes empty sorted sets).
-		if r.Exists(statusStartKey) {
-			members, err = r.ZMembers(statusStartKey)
-			require.NoError(t, err)
-			require.NotContains(t, members, item.ID)
-		}
+		count, err = shard.StatusCount(ctx, fnID, "start")
+		require.NoError(t, err)
+		require.EqualValues(t, 0, count, "status:start index should be empty after remove")
 	})
 
 	t.Run("removes in-progress status index", func(t *testing.T) {
@@ -3378,18 +3366,16 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 		}, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		members, err := r.ZMembers(statusInProgressKey)
+		count, err := shard.StatusCount(ctx, fnID, "in-progress")
 		require.NoError(t, err)
-		require.Len(t, members, 1, "status:in-progress index should have 1 member after enqueue")
+		require.EqualValues(t, 1, count, "status:in-progress index should have 1 member after enqueue")
 
 		err = shard.RemoveQueueItem(ctx, fnID.String(), item.ID)
 		require.NoError(t, err)
 
-		if r.Exists(statusInProgressKey) {
-			members, err = r.ZMembers(statusInProgressKey)
-			require.NoError(t, err)
-			require.NotContains(t, members, item.ID)
-		}
+		count, err = shard.StatusCount(ctx, fnID, "in-progress")
+		require.NoError(t, err)
+		require.EqualValues(t, 0, count, "status:in-progress index should be empty after remove")
 	})
 
 	t.Run("removes sleep status index", func(t *testing.T) {
@@ -3406,18 +3392,16 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 		}, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		members, err := r.ZMembers(statusSleepKey)
+		count, err := shard.StatusCount(ctx, fnID, "sleep")
 		require.NoError(t, err)
-		require.Len(t, members, 1, "status:sleep index should have 1 member after enqueue")
+		require.EqualValues(t, 1, count, "status:sleep index should have 1 member after enqueue")
 
 		err = shard.RemoveQueueItem(ctx, fnID.String(), item.ID)
 		require.NoError(t, err)
 
-		if r.Exists(statusSleepKey) {
-			members, err = r.ZMembers(statusSleepKey)
-			require.NoError(t, err)
-			require.NotContains(t, members, item.ID)
-		}
+		count, err = shard.StatusCount(ctx, fnID, "sleep")
+		require.NoError(t, err)
+		require.EqualValues(t, 0, count, "status:sleep index should be empty after remove")
 	})
 
 	t.Run("only removes targeted item from status index", func(t *testing.T) {
@@ -3434,7 +3418,7 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 		}, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		itemB, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
+		_, err = shard.EnqueueItem(ctx, osqueue.QueueItem{
 			FunctionID: fnID,
 			Data: osqueue.Item{
 				Kind: osqueue.KindStart,
@@ -3445,18 +3429,17 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 		}, start.Add(time.Second), osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		members, err := r.ZMembers(statusStartKey)
+		count, err := shard.StatusCount(ctx, fnID, "start")
 		require.NoError(t, err)
-		require.Len(t, members, 2)
+		require.EqualValues(t, 2, count)
 
 		// Remove only itemA.
 		err = shard.RemoveQueueItem(ctx, fnID.String(), itemA.ID)
 		require.NoError(t, err)
 
-		members, err = r.ZMembers(statusStartKey)
+		count, err = shard.StatusCount(ctx, fnID, "start")
 		require.NoError(t, err)
-		require.Len(t, members, 1)
-		require.Contains(t, members, itemB.ID)
+		require.EqualValues(t, 1, count)
 	})
 
 	t.Run("non-UUID partition skips status index cleanup", func(t *testing.T) {
@@ -3474,9 +3457,9 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 		}, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		members, err := r.ZMembers(statusStartKey)
+		count, err := shard.StatusCount(ctx, fnID, "start")
 		require.NoError(t, err)
-		require.Contains(t, members, item.ID)
+		require.EqualValues(t, 1, count)
 
 		// Calling with a non-UUID partition should not error, but also won't
 		// clean up status indexes (no function ID to derive keys from).
@@ -3484,8 +3467,8 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 		require.NoError(t, err)
 
 		// Status index should still contain the item since we used the wrong partition.
-		members, err = r.ZMembers(statusStartKey)
+		count, err = shard.StatusCount(ctx, fnID, "start")
 		require.NoError(t, err)
-		require.Contains(t, members, item.ID)
+		require.EqualValues(t, 1, count)
 	})
 }

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -3306,3 +3306,186 @@ func TestInvalidScoreOnRefill(t *testing.T) {
 	require.Equal(t, 1, len(res.RefilledItems))
 	require.Equal(t, qi2.ID, res.RefilledItems[0])
 }
+
+func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	_, shard := newQueue(t, rc)
+	ctx := context.Background()
+	kg := &queueKeyGenerator{
+		queueDefaultKey: QueueDefaultKey,
+		queueItemKeyGenerator: queueItemKeyGenerator{
+			queueDefaultKey: QueueDefaultKey,
+		},
+	}
+
+	fnID := uuid.New()
+	acctID := uuid.New()
+	start := time.Now().Truncate(time.Second)
+
+	statusStartKey := kg.Status("start", fnID)
+	statusInProgressKey := kg.Status("in-progress", fnID)
+	statusSleepKey := kg.Status("sleep", fnID)
+
+	t.Run("removes start status index", func(t *testing.T) {
+		r.FlushAll()
+
+		item, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
+			FunctionID: fnID,
+			Data: osqueue.Item{
+				Kind: osqueue.KindStart,
+				Identifier: state.Identifier{
+					AccountID: acctID,
+				},
+			},
+		}, start, osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+
+		// Verify the status index was created by enqueue.
+		members, err := r.ZMembers(statusStartKey)
+		require.NoError(t, err)
+		require.Len(t, members, 1, "status:start index should have 1 member after enqueue")
+
+		// RemoveQueueItem should clean up the status index.
+		err = shard.RemoveQueueItem(ctx, fnID.String(), item.ID)
+		require.NoError(t, err)
+
+		// Key may be gone entirely (Redis deletes empty sorted sets).
+		if r.Exists(statusStartKey) {
+			members, err = r.ZMembers(statusStartKey)
+			require.NoError(t, err)
+			require.NotContains(t, members, item.ID)
+		}
+	})
+
+	t.Run("removes in-progress status index", func(t *testing.T) {
+		r.FlushAll()
+
+		item, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
+			FunctionID: fnID,
+			Data: osqueue.Item{
+				Kind: osqueue.KindEdge,
+				Identifier: state.Identifier{
+					AccountID: acctID,
+				},
+			},
+		}, start, osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+
+		members, err := r.ZMembers(statusInProgressKey)
+		require.NoError(t, err)
+		require.Len(t, members, 1, "status:in-progress index should have 1 member after enqueue")
+
+		err = shard.RemoveQueueItem(ctx, fnID.String(), item.ID)
+		require.NoError(t, err)
+
+		if r.Exists(statusInProgressKey) {
+			members, err = r.ZMembers(statusInProgressKey)
+			require.NoError(t, err)
+			require.NotContains(t, members, item.ID)
+		}
+	})
+
+	t.Run("removes sleep status index", func(t *testing.T) {
+		r.FlushAll()
+
+		item, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
+			FunctionID: fnID,
+			Data: osqueue.Item{
+				Kind: osqueue.KindSleep,
+				Identifier: state.Identifier{
+					AccountID: acctID,
+				},
+			},
+		}, start, osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+
+		members, err := r.ZMembers(statusSleepKey)
+		require.NoError(t, err)
+		require.Len(t, members, 1, "status:sleep index should have 1 member after enqueue")
+
+		err = shard.RemoveQueueItem(ctx, fnID.String(), item.ID)
+		require.NoError(t, err)
+
+		if r.Exists(statusSleepKey) {
+			members, err = r.ZMembers(statusSleepKey)
+			require.NoError(t, err)
+			require.NotContains(t, members, item.ID)
+		}
+	})
+
+	t.Run("only removes targeted item from status index", func(t *testing.T) {
+		r.FlushAll()
+
+		itemA, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
+			FunctionID: fnID,
+			Data: osqueue.Item{
+				Kind: osqueue.KindStart,
+				Identifier: state.Identifier{
+					AccountID: acctID,
+				},
+			},
+		}, start, osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+
+		itemB, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
+			FunctionID: fnID,
+			Data: osqueue.Item{
+				Kind: osqueue.KindStart,
+				Identifier: state.Identifier{
+					AccountID: acctID,
+				},
+			},
+		}, start.Add(time.Second), osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+
+		members, err := r.ZMembers(statusStartKey)
+		require.NoError(t, err)
+		require.Len(t, members, 2)
+
+		// Remove only itemA.
+		err = shard.RemoveQueueItem(ctx, fnID.String(), itemA.ID)
+		require.NoError(t, err)
+
+		members, err = r.ZMembers(statusStartKey)
+		require.NoError(t, err)
+		require.Len(t, members, 1)
+		require.Contains(t, members, itemB.ID)
+	})
+
+	t.Run("non-UUID partition skips status index cleanup", func(t *testing.T) {
+		r.FlushAll()
+
+		// Enqueue an item so there's something in the status index.
+		item, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
+			FunctionID: fnID,
+			Data: osqueue.Item{
+				Kind: osqueue.KindStart,
+				Identifier: state.Identifier{
+					AccountID: acctID,
+				},
+			},
+		}, start, osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+
+		members, err := r.ZMembers(statusStartKey)
+		require.NoError(t, err)
+		require.Contains(t, members, item.ID)
+
+		// Calling with a non-UUID partition should not error, but also won't
+		// clean up status indexes (no function ID to derive keys from).
+		err = shard.RemoveQueueItem(ctx, "not-a-uuid", item.ID)
+		require.NoError(t, err)
+
+		// Status index should still contain the item since we used the wrong partition.
+		members, err = r.ZMembers(statusStartKey)
+		require.NoError(t, err)
+		require.Contains(t, members, item.ID)
+	})
+}

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -3322,8 +3322,6 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 	acctID := uuid.New()
 	start := time.Now().Truncate(time.Second)
 
-
-
 	t.Run("removes start status index", func(t *testing.T) {
 		r.FlushAll()
 

--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -157,10 +157,10 @@ func (q *queue) CleanupStatusIndexes(ctx context.Context, fnID uuid.UUID) (int64
 				zremCmd := rc.B().Zrem().Key(key).Member(orphans...).Build()
 				removed, err := rc.Do(ctx, zremCmd).AsInt64()
 				if err != nil {
-					l.Error("error removing orphaned index entries", "error", err, "status", status, "count", len(orphans))
+					l.Error("error removing orphaned index entries", "error", err, "fnID", fnID, "status", status, "count", len(orphans))
 				} else {
 					totalRemoved += removed
-					l.Info("removed orphaned status index entries", "status", status, "removed", removed)
+					l.Info("removed orphaned status index entries", "status", status, "fnID", fnID, "removed", removed, "total_removed", totalRemoved)
 				}
 			}
 

--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -153,7 +153,7 @@ func (q *queue) CleanupStatusIndexes(ctx context.Context, fnID uuid.UUID) (int64
 				zremCmd := rc.B().Zrem().Key(key).Member(orphans...).Build()
 				removed, err := rc.Do(ctx, zremCmd).AsInt64()
 				if err != nil {
-					l.Error("error removing orphaned index entries", "error", err, "fnID", fnID, "status", status, "count", len(orphans))
+					l.Error("error removing orphaned status index entries", "error", err, "fnID", fnID, "status", status, "count", len(orphans))
 				} else {
 					totalRemoved += removed
 					l.Info("removed orphaned status index entries", "status", status, "fnID", fnID, "removed", removed, "total_removed", totalRemoved)

--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -38,8 +38,14 @@ func (q *queue) RunJobs(ctx context.Context, workspaceID, workflowID uuid.UUID, 
 		return []osqueue.JobResponse{}, nil
 	}
 
+	// ZSCAN returns interleaved [member, score] pairs;  extract only the members.
+	members := make([]string, 0, len(jobIDs.Elements)/2)
+	for i := 0; i < len(jobIDs.Elements); i += 2 {
+		members = append(members, jobIDs.Elements[i])
+	}
+
 	// Get all job items.
-	jsonItems, err := q.RedisClient.unshardedRc.Do(ctx, q.RedisClient.unshardedRc.B().Hmget().Key(q.RedisClient.kg.QueueItem()).Field(jobIDs.Elements...).Build()).AsStrSlice()
+	jsonItems, err := q.RedisClient.unshardedRc.Do(ctx, q.RedisClient.unshardedRc.B().Hmget().Key(q.RedisClient.kg.QueueItem()).Field(members...).Build()).AsStrSlice()
 	if err != nil {
 		return nil, fmt.Errorf("error reading jobs: %w", err)
 	}
@@ -128,7 +134,13 @@ func (q *queue) CleanupStatusIndexes(ctx context.Context, fnID uuid.UUID) (int64
 				continue
 			}
 
-			hmgetCmd := rc.B().Hmget().Key(queueItemKey).Field(res.Elements...).Build()
+			// ZSCAN returns interleaved [member, score] pairs;  extract only the members.
+			members := make([]string, 0, len(res.Elements)/2)
+			for i := 0; i < len(res.Elements); i += 2 {
+				members = append(members, res.Elements[i])
+			}
+
+			hmgetCmd := rc.B().Hmget().Key(queueItemKey).Field(members...).Build()
 			vals, err := rc.Do(ctx, hmgetCmd).AsStrSlice()
 			if err != nil && err != rueidis.Nil {
 				return totalRemoved, fmt.Errorf("error checking queue items for status %q: %w", status, err)
@@ -137,7 +149,7 @@ func (q *queue) CleanupStatusIndexes(ctx context.Context, fnID uuid.UUID) (int64
 			var orphans []string
 			for i, val := range vals {
 				if val == "" {
-					orphans = append(orphans, res.Elements[i])
+					orphans = append(orphans, members[i])
 				}
 			}
 
@@ -667,12 +679,18 @@ func (q *queue) ItemsByRunID(ctx context.Context, runID ulid.ULID) ([]*osqueue.Q
 		return []*osqueue.QueueItem{}, nil
 	}
 
+	// ZSCAN returns interleaved [member, score] pairs;  extract only the members.
+	members := make([]string, 0, len(itemIDs.Elements)/2)
+	for i := 0; i < len(itemIDs.Elements); i += 2 {
+		members = append(members, itemIDs.Elements[i])
+	}
+
 	items, err := rc.Do(
 		ctx,
 		rc.B().
 			Hmget().
 			Key(kg.QueueItem()).
-			Field(itemIDs.Elements...).
+			Field(members...).
 			Build(),
 	).AsStrSlice()
 	if err != nil {

--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -121,11 +121,8 @@ func (q *queue) CleanupStatusIndexes(ctx context.Context, fnID uuid.UUID) (int64
 				return totalRemoved, fmt.Errorf("error scanning status index %q: %w", status, err)
 			}
 
-			// ZSCAN returns alternating [member, score, member, score, ...] in Elements.
-			// Extract only the members (even indices).
 			var orphans []string
-			for i := 0; i < len(res.Elements); i += 2 {
-				itemID := res.Elements[i]
+			for _, itemID := range res.Elements {
 				existsCmd := rc.B().Hexists().Key(queueItemKey).Field(itemID).Build()
 				exists, err := rc.Do(ctx, existsCmd).AsBool()
 				if err != nil && !rueidis.IsRedisNil(err) {

--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -100,6 +100,64 @@ func (q *queue) StatusCount(ctx context.Context, workflowID uuid.UUID, status st
 	return count, nil
 }
 
+func (q *queue) CleanupStatusIndexes(ctx context.Context, fnID uuid.UUID) (int64, error) {
+	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "CleanupStatusIndexes"), redis_telemetry.ScopeQueue)
+
+	l := logger.StdlibLogger(ctx).With("fn_id", fnID.String())
+	rc := q.RedisClient.unshardedRc
+	kg := q.RedisClient.kg
+	queueItemKey := kg.QueueItem()
+
+	var totalRemoved int64
+
+	for _, status := range []string{"start", "in-progress", "sleep"} {
+		key := kg.Status(status, fnID)
+
+		var cursor uint64
+		for {
+			scanCmd := rc.B().Zscan().Key(key).Cursor(cursor).Count(500).Build()
+			res, err := rc.Do(ctx, scanCmd).AsScanEntry()
+			if err != nil {
+				return totalRemoved, fmt.Errorf("error scanning status index %q: %w", status, err)
+			}
+
+			// ZSCAN returns alternating [member, score, member, score, ...] in Elements.
+			// Extract only the members (even indices).
+			var orphans []string
+			for i := 0; i < len(res.Elements); i += 2 {
+				itemID := res.Elements[i]
+				existsCmd := rc.B().Hexists().Key(queueItemKey).Field(itemID).Build()
+				exists, err := rc.Do(ctx, existsCmd).AsBool()
+				if err != nil && !rueidis.IsRedisNil(err) {
+					l.Error("error checking queue item existence", "error", err, "item_id", itemID, "status", status)
+					continue
+				}
+				if !exists {
+					orphans = append(orphans, itemID)
+				}
+			}
+
+			if len(orphans) > 0 {
+				zremCmd := rc.B().Zrem().Key(key).Member(orphans...).Build()
+				removed, err := rc.Do(ctx, zremCmd).AsInt64()
+				if err != nil {
+					l.Error("error removing orphaned index entries", "error", err, "status", status, "count", len(orphans))
+				} else {
+					totalRemoved += removed
+					l.Info("removed orphaned status index entries", "status", status, "removed", removed)
+				}
+			}
+
+			cursor = res.Cursor
+			if cursor == 0 {
+				break
+			}
+		}
+	}
+
+	return totalRemoved, nil
+}
+
 func (q *queue) RunningCount(ctx context.Context, functionID uuid.UUID) (int64, error) {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "RunningCount"), redis_telemetry.ScopeQueue)
 

--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -126,30 +126,26 @@ func (q *queue) CleanupStatusIndexes(ctx context.Context, fnID uuid.UUID) (int64
 			if err != nil {
 				return totalRemoved, fmt.Errorf("error scanning status index %q: %w", status, err)
 			}
-
-			if len(res.Elements) == 0 {
-				if res.Cursor == 0 {
-					break
-				}
-				continue
-			}
-
-			// ZSCAN returns interleaved [member, score] pairs;  extract only the members.
-			members := make([]string, 0, len(res.Elements)/2)
-			for i := 0; i < len(res.Elements); i += 2 {
-				members = append(members, res.Elements[i])
-			}
-
-			hmgetCmd := rc.B().Hmget().Key(queueItemKey).Field(members...).Build()
-			vals, err := rc.Do(ctx, hmgetCmd).AsStrSlice()
-			if err != nil && err != rueidis.Nil {
-				return totalRemoved, fmt.Errorf("error checking queue items for status %q: %w", status, err)
-			}
-
+			cursor = res.Cursor
 			var orphans []string
-			for i, val := range vals {
-				if val == "" {
-					orphans = append(orphans, members[i])
+
+			if len(res.Elements) > 0 {
+				// ZSCAN returns interleaved [member, score] pairs;  extract only the members.
+				members := make([]string, 0, len(res.Elements)/2)
+				for i := 0; i < len(res.Elements); i += 2 {
+					members = append(members, res.Elements[i])
+				}
+
+				hmgetCmd := rc.B().Hmget().Key(queueItemKey).Field(members...).Build()
+				vals, err := rc.Do(ctx, hmgetCmd).AsStrSlice()
+				if err != nil && err != rueidis.Nil {
+					return totalRemoved, fmt.Errorf("error checking queue items for status %q: %w", status, err)
+				}
+
+				for i, val := range vals {
+					if val == "" {
+						orphans = append(orphans, members[i])
+					}
 				}
 			}
 
@@ -164,7 +160,6 @@ func (q *queue) CleanupStatusIndexes(ctx context.Context, fnID uuid.UUID) (int64
 				}
 			}
 
-			cursor = res.Cursor
 			if cursor == 0 {
 				break
 			}

--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -121,16 +121,23 @@ func (q *queue) CleanupStatusIndexes(ctx context.Context, fnID uuid.UUID) (int64
 				return totalRemoved, fmt.Errorf("error scanning status index %q: %w", status, err)
 			}
 
-			var orphans []string
-			for _, itemID := range res.Elements {
-				existsCmd := rc.B().Hexists().Key(queueItemKey).Field(itemID).Build()
-				exists, err := rc.Do(ctx, existsCmd).AsBool()
-				if err != nil && !rueidis.IsRedisNil(err) {
-					l.Error("error checking queue item existence", "error", err, "item_id", itemID, "status", status)
-					continue
+			if len(res.Elements) == 0 {
+				if res.Cursor == 0 {
+					break
 				}
-				if !exists {
-					orphans = append(orphans, itemID)
+				continue
+			}
+
+			hmgetCmd := rc.B().Hmget().Key(queueItemKey).Field(res.Elements...).Build()
+			vals, err := rc.Do(ctx, hmgetCmd).AsStrSlice()
+			if err != nil && err != rueidis.Nil {
+				return totalRemoved, fmt.Errorf("error checking queue items for status %q: %w", status, err)
+			}
+
+			var orphans []string
+			for i, val := range vals {
+				if val == "" {
+					orphans = append(orphans, res.Elements[i])
 				}
 			}
 


### PR DESCRIPTION
## Description

RemoveQueueItem removes the item from the partition's sorted set of queue items, but does not remove it from other "status" counters. The status counters serve our backlog dashboards in Cloud and can show incorrect backlog values because of this inconsistency.

## Motivation
https://app.plain.com/workspace/w_01H5R1F69XQ35G4P7THFQGN5KB/thread/th_01KMNTAR7PT30TX01AW0C1BJP4/


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes orphaned entries in Redis status sorted sets (`status:start`, `status:in-progress`, `status:sleep`) when `RemoveQueueItem` is called. The Lua script is extended to accept additional KEYS (indices 3+) and ZREM the item from each, and the Go caller appends the three status keys when the partition ID is a valid function UUID. A `CleanupStatusIndexes` helper is also added to the `ShardOperations` interface for scanning and removing orphaned entries from existing deployments. Follow-up commits fix a pre-existing ZSCAN bug (scores were being passed as field names to HMGET), refactor tests to use the queue interface instead of Redis directly, and add `fnID`/`total_removed` to log fields.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 457ecfcbf6a9cb11c46f5daa076d989ec266d6fd.</sup>
<!-- /MENDRAL_SUMMARY -->