### PR TITLE
fix(start): set Poll=true so --poll-interval actually re-syncs apps

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -129,6 +129,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		EventKeys:               eventKeys,
 		NoUI:                    localconfig.GetBoolValue(cmd, "no-ui", false),
 		Persist:                 true,
+		Poll:                    true,
 		PollInterval:            localconfig.GetIntValue(cmd, "poll-interval", devserver.DefaultPollInterval),
 		PostgresConnMaxIdleTime: cmd.Int("postgres-conn-max-idle-time"),
 		PostgresConnMaxLifetime: cmd.Int("postgres-conn-max-lifetime"),


### PR DESCRIPTION
## Summary

Fixes #3791

`inngest start` accepts `--poll-interval` and `INNGEST_POLL_INTERVAL` but never sets `StartOpts.Poll = true`. The `pollSDKs()` loop guards on this flag:

```go
if !d.Opts.Poll && len(app.Error.String) == 0 {
    continue
}
```

Since `Poll` stays at the Go zero value (`false`), only errored apps get re-polled. Healthy apps are never re-synced, making `--poll-interval` and `--sdk-url` ineffective.

## Fix

One-line change: set `Poll: true` in `cmd/start/start.go`'s `StartOpts` construction, matching `cmd/devserver/devserver.go`'s behavior.

| Command | Before | After |
|---------|--------|-------|
| `inngest dev` | `Poll: !noPoll` (true by default) ✅ | unchanged |
| `inngest start` | `Poll:` not set (false) ❌ | `Poll: true` ✅ |

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> One-line fix that sets `Poll: true` in `inngest start`'s `StartOpts`, enabling the `--poll-interval` flag to actually re-sync healthy apps. Previously, `Poll` defaulted to `false`, causing `pollSDKs()` to skip all non-errored apps.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 888c8c4ac53e6e26686336ee8c2e516bf71849e1.</sup>
<!-- /MENDRAL_SUMMARY -->