### PR TITLE
update pause iterator to handle concurrent errors

### DIFF
--- a/pkg/execution/driver/httpv2/httpv2.go
+++ b/pkg/execution/driver/httpv2/httpv2.go
@@ -67,12 +67,6 @@ func (d httpv2) Do(ctx context.Context, sl sv2.StateLoader, opts driver.V2Reques
 	return d.async(ctx, opts)
 }
 
-// sync re-enters synchronous functions, allowing regular API endpoints to be resumed as if they're
-// generic async functions.
-//
-// sync entry is relatively simple: we re-execute a specific API request, and we add Inngest-specific
-// headers to the request.  The SDK will then fetch the requisite function state such that it can resume
-// where it left off.
 // loadHTTPRequestEvent attempts to load the triggering event from state and parse
 // it as an HTTP request event. Returns nil if loading fails, the event name doesn't
 // match, or the event can't be parsed.
@@ -95,6 +89,12 @@ func loadHTTPRequestEvent(ctx context.Context, sl sv2.StateLoader, id sv2.ID) *i
 	return evt
 }
 
+// sync re-enters synchronous functions, allowing regular API endpoints to be resumed as if they're
+// generic async functions.
+//
+// sync entry is relatively simple: we re-execute a specific API request, and we add Inngest-specific
+// headers to the request.  The SDK will then fetch the requisite function state such that it can resume
+// where it left off.
 func (d httpv2) sync(ctx context.Context, sl sv2.StateLoader, opts driver.V2RequestOpts) (*state.DriverResponse, errs.UserError, errs.InternalError) {
 	method := http.MethodPost
 	if m, _ := opts.Fn.Driver.Metadata["method"].(string); m != "" {

--- a/pkg/execution/pauses/iterator.go
+++ b/pkg/execution/pauses/iterator.go
@@ -319,15 +319,21 @@ func (d *dualIter) fetchBlock(ctx context.Context, id ulid.ULID) {
 
 	block, err := d.blockReader.ReadBlock(ctx, d.idx, id)
 	// TODO: Maybe we should retry if it's a retriable error
-	if err != nil && d.err == nil {
-		d.l.Lock()
-		d.err = err
-		d.l.Unlock()
+	if err != nil {
+		if d.err == nil {
+			d.l.Lock()
+			d.err = err
+			d.l.Unlock()
+		}
 
 		metrics.HistogramPauseBlockFetchLatency(ctx, time.Since(start), metrics.HistogramOpt{
 			PkgName: pkgName,
 			Tags:    map[string]any{"success": false},
 		})
+		return
+	}
+
+	if block == nil {
 		return
 	}
 


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a race condition in `dualIter.fetchBlock` where concurrent goroutines could both observe `d.err == nil` and race to set it, and adds a nil guard for the returned block. Also relocates a misplaced comment in `httpv2.go` to sit directly above the function it describes.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit eb6dcba7aa73001f752c5de4540862ea6ecee794.</sup>
<!-- /MENDRAL_SUMMARY -->