### PR TITLE
Fix shadow partition constraint reporting after exhausting constraints

### DIFF
--- a/pkg/execution/queue/shadow_process.go
+++ b/pkg/execution/queue/shadow_process.go
@@ -542,8 +542,7 @@ func (q *queueProcessor) ProcessShadowPartitionBacklog(
 		metrics.IncrBacklogProcessedCounter(ctx, opts)
 		metrics.IncrQueueBacklogRefilledCounter(ctx, int64(len(res.RefilledItems)), opts)
 
-		shouldFireLifecyles := len(items) > 0 && len(constraintCheckRes.ItemsToRefill) == 0 && constraintCheckRes.LimitingConstraint != enums.QueueConstraintNotLimited
-		if shouldFireLifecyles {
+		if constraintCheckRes.LimitingConstraint != enums.QueueConstraintNotLimited {
 			// NOTE:
 			// we don't want to add an extended amount of time for requeue when there are
 			// contraint hits, so we make sure to check more often in order to admit items

--- a/pkg/execution/state/redis_state/shadow_queue_test.go
+++ b/pkg/execution/state/redis_state/shadow_queue_test.go
@@ -1367,7 +1367,7 @@ func TestConstraintLifecycleReporting(t *testing.T) {
 		testLifecycles.lock.Lock()
 		assert.Equal(t, 1, len(cmLifecycles.AcquireCalls))
 		assert.Equal(t, 0, testLifecycles.acctConcurrency[accountID1], "expected account not to be hit")
-		assert.Equal(t, 1, testLifecycles.fnConcurrency[fnID1], "expected fn1 to be hit once", fnID1, testLifecycles.fnConcurrency)
+		assert.Equal(t, 2, testLifecycles.fnConcurrency[fnID1], "expected fn1 to be hit twice", fnID1, testLifecycles.fnConcurrency)
 		assert.Equal(t, 0, testLifecycles.fnConcurrency[fnID2], "expected fn2 not to be hit")
 		testLifecycles.lock.Unlock()
 	}, 1*time.Second, 100*time.Millisecond)
@@ -1388,7 +1388,7 @@ func TestConstraintLifecycleReporting(t *testing.T) {
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		testLifecycles.lock.Lock()
 		assert.Equal(t, 1, testLifecycles.acctConcurrency[accountID1])
-		assert.Equal(t, 1, testLifecycles.fnConcurrency[fnID1])
+		assert.Equal(t, 2, testLifecycles.fnConcurrency[fnID1])
 		assert.Equal(t, 0, testLifecycles.fnConcurrency[fnID2])
 		testLifecycles.lock.Unlock()
 	}, 1*time.Second, 100*time.Millisecond)


### PR DESCRIPTION
## Description

Applies change proposed in https://github.com/inngest/monorepo/pull/6743 and fixes associated test failures.

This broke in https://github.com/inngest/inngest/pull/3765

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Simplifies the condition that fires constraint lifecycle callbacks in `ProcessShadowPartitionBacklog` by removing the `len(items) > 0 && len(constraintCheckRes.ItemsToRefill) == 0` guards, intending to report constraint hits more broadly. The "Fix test" commit updates test expectations to match the new behavior rather than restoring the guard.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 24ed273e429cd4ee89260da1bb1253894297fec2.</sup>
<!-- /MENDRAL_SUMMARY -->