### PR TITLE
Fix json path's bar height

### DIFF
--- a/ui/packages/components/src/Events/EventDetails.tsx
+++ b/ui/packages/components/src/Events/EventDetails.tsx
@@ -261,6 +261,7 @@ export function EventDetails({
                     content: prettyPayload,
                   }}
                   allowFullScreen={true}
+                  enableTreeView={true}
                   actions={
                     cloud
                       ? [

--- a/ui/packages/components/src/Events/EventDetails.tsx
+++ b/ui/packages/components/src/Events/EventDetails.tsx
@@ -261,7 +261,6 @@ export function EventDetails({
                     content: prettyPayload,
                   }}
                   allowFullScreen={true}
-                  enableTreeView={true}
                   actions={
                     cloud
                       ? [

--- a/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
+++ b/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
@@ -379,15 +379,15 @@ export const NewCodeBlock = ({
                     </span>
                   )}
                 </code>
-                {hoveredPath && (
+                <span className={hoveredPath ? '' : 'invisible'}>
                   <CopyButton
                     size="small"
-                    code={hoveredPath}
+                    code={hoveredPath ?? ''}
                     isCopying={isCopying}
                     handleCopyClick={handleCopyClick}
                     appearance="ghost"
                   />
-                )}
+                </span>
               </div>
             </div>
           ) : (
@@ -446,15 +446,15 @@ export const NewCodeBlock = ({
                       </span>
                     )}
                   </code>
-                  {cursorPath && (
+                  <span className={cursorPath ? '' : 'invisible'}>
                     <CopyButton
                       size="small"
-                      code={cursorPath}
+                      code={cursorPath ?? ''}
                       isCopying={isCopying}
                       handleCopyClick={handleCopyClick}
                       appearance="ghost"
                     />
-                  )}
+                  </span>
                 </div>
               )}
             </div>

--- a/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
+++ b/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Button } from '@inngest/components/Button';
 import { CopyButton } from '@inngest/components/CopyButton';
 import { maxRenderedOutputSizeBytes } from '@inngest/components/constants';
@@ -70,6 +70,89 @@ function buildJsonPath(keyPath: readonly (string | number)[]): string {
   return result;
 }
 
+/**
+ * Given pretty-printed JSON text (2-space indent) and a 1-based line number,
+ * returns the dot/bracket-notation path for that line (e.g. "data.users[0].name").
+ */
+function getJsonPathAtLine(text: string, targetLine: number): string | null {
+  const lines = text.split('\n');
+  if (targetLine < 1 || targetLine > lines.length) return null;
+
+  const pathByDepth: (string | undefined)[] = [];
+  const arrayIndices = new Map<number, number>();
+  const isArrayDepth = new Set<number>();
+
+  for (let i = 0; i < targetLine; i++) {
+    const line = lines[i]!;
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const indent = line.length - line.trimStart().length;
+    const depth = Math.floor(indent / 2);
+    const hasComma = trimmed.endsWith(',');
+
+    // Closing bracket/brace
+    if (/^[}\]]/.test(trimmed)) {
+      pathByDepth.length = depth;
+      if (hasComma && isArrayDepth.has(depth)) {
+        arrayIndices.set(depth, (arrayIndices.get(depth) ?? 0) + 1);
+      }
+      continue;
+    }
+
+    // Truncate path to current depth
+    pathByDepth.length = depth;
+
+    // If inside an array, set the index segment
+    if (isArrayDepth.has(depth)) {
+      pathByDepth[depth] = `[${arrayIndices.get(depth) ?? 0}]`;
+    }
+
+    // Object property: "key": value
+    const keyMatch = trimmed.match(/^"((?:[^"\\]|\\.)*)"\s*:\s*(.*)/);
+    if (keyMatch) {
+      const key = keyMatch[1]!;
+      const rest = keyMatch[2]!.replace(/,?\s*$/, '');
+      pathByDepth[depth] = key;
+      if (rest === '{') {
+        isArrayDepth.delete(depth + 1);
+      } else if (rest === '[') {
+        isArrayDepth.add(depth + 1);
+        arrayIndices.set(depth + 1, 0);
+      }
+      continue;
+    }
+
+    // Standalone { or [
+    if (trimmed.startsWith('{')) {
+      isArrayDepth.delete(depth + 1);
+      continue;
+    }
+    if (trimmed.startsWith('[')) {
+      isArrayDepth.add(depth + 1);
+      arrayIndices.set(depth + 1, 0);
+      continue;
+    }
+
+    // Scalar array element
+    if (hasComma && isArrayDepth.has(depth)) {
+      arrayIndices.set(depth, (arrayIndices.get(depth) ?? 0) + 1);
+    }
+  }
+
+  let result = '';
+  for (let d = 0; d < pathByDepth.length; d++) {
+    const seg = pathByDepth[d];
+    if (seg === undefined) continue;
+    if (seg.startsWith('[')) {
+      result += seg;
+    } else {
+      result += result ? `.${seg}` : seg;
+    }
+  }
+  return result || null;
+}
+
 const jsonParse = (content: string) => {
   try {
     return JSON.parse(content);
@@ -110,6 +193,8 @@ export const NewCodeBlock = ({
   const { handleCopyClick, isCopying } = useCopyToClipboard();
   const [editEmtpy, setEditEmtpy] = useState(false);
   const [hoveredPath, setHoveredPath] = useState<string | null>(null);
+  const [cursorPath, setCursorPath] = useState<string | null>(null);
+  const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
 
   const monaco = useMonaco();
   const { content, readOnly = true, language = 'json' } = tab;
@@ -289,39 +374,57 @@ export const NewCodeBlock = ({
               )}
             </div>
           ) : (
-            <Editor
-              className={cn('h-full', className)}
-              theme="inngest-theme"
-              language={language}
-              value={editEmtpy ? EMPTY_INPUT : content}
-              height="100%"
-              options={{
-                wordWrap: wordWrap ? 'on' : 'off',
-                contextmenu: false,
-                readOnly,
-                minimap: { enabled: false },
-                fontFamily: FONT.font,
-                fontSize: FONT.size,
-                fontWeight: 'light',
-                lineHeight: LINE_HEIGHT,
-                renderLineHighlight: 'none',
-                renderWhitespace: 'none',
-                automaticLayout: true,
-                scrollBeyondLastLine: false,
-                scrollbar: scrollbarOptions ?? {
-                  alwaysConsumeMouseWheel: false,
-                  horizontalScrollbarSize: 0,
-                  verticalScrollbarSize: 0,
-                  vertical: 'hidden',
-                  horizontal: 'hidden',
-                },
-                guides: {
-                  indentation: false,
-                  highlightActiveBracketPair: false,
-                  highlightActiveIndentation: false,
-                },
-              }}
-            />
+            <div className="flex h-full flex-col">
+              <div className="min-h-0 flex-1">
+                <Editor
+                  className={cn('h-full', className)}
+                  theme="inngest-theme"
+                  language={language}
+                  value={editEmtpy ? EMPTY_INPUT : content}
+                  height="100%"
+                  onMount={(ed) => {
+                    editorRef.current = ed;
+                    if (language === 'json') {
+                      ed.onDidChangeCursorPosition((e) => {
+                        const text = ed.getValue();
+                        setCursorPath(getJsonPathAtLine(text, e.position.lineNumber));
+                      });
+                    }
+                  }}
+                  options={{
+                    wordWrap: wordWrap ? 'on' : 'off',
+                    contextmenu: false,
+                    readOnly,
+                    minimap: { enabled: false },
+                    fontFamily: FONT.font,
+                    fontSize: FONT.size,
+                    fontWeight: 'light',
+                    lineHeight: LINE_HEIGHT,
+                    renderLineHighlight: 'none',
+                    renderWhitespace: 'none',
+                    automaticLayout: true,
+                    scrollBeyondLastLine: false,
+                    scrollbar: scrollbarOptions ?? {
+                      alwaysConsumeMouseWheel: false,
+                      horizontalScrollbarSize: 0,
+                      verticalScrollbarSize: 0,
+                      vertical: 'hidden',
+                      horizontal: 'hidden',
+                    },
+                    guides: {
+                      indentation: false,
+                      highlightActiveBracketPair: false,
+                      highlightActiveIndentation: false,
+                    },
+                  }}
+                />
+              </div>
+              {language === 'json' && cursorPath && (
+                <div className="bg-canvasSubtle text-muted border-subtle flex items-center border-t px-3 py-1">
+                  <code className="truncate font-mono text-xs">{cursorPath}</code>
+                </div>
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
+++ b/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
@@ -13,6 +13,7 @@ import {
   RiDownload2Line,
   RiEdit2Line,
   RiExpandDiagonalLine,
+  RiInformationLine,
 } from '@remixicon/react';
 import type { editor } from 'monaco-editor';
 import { JSONTree } from 'react-json-tree';
@@ -317,7 +318,7 @@ export const NewCodeBlock = ({
             </div>
           )}
         </div>
-        <div className={cn('bg-codeEditor h-full overflow-y-auto py-3')}>
+        <div className={cn('bg-codeEditor flex min-h-0 flex-1 flex-col pt-3')}>
           {isOutputTooLarge && !editEmtpy ? (
             <>
               <Alert severity="warning">Output size is too large to render {`( > 1MB )`}</Alert>
@@ -344,7 +345,7 @@ export const NewCodeBlock = ({
             <Skeleton className="h-24 w-full" />
           ) : enableTreeView && mode === 'raw' ? (
             <div
-              className="flex h-full flex-col"
+              className="flex min-h-0 flex-1 flex-col"
               onMouseLeave={() => setHoveredPath(null)}
             >
               <div className="min-h-0 flex-1 overflow-y-auto">
@@ -369,14 +370,28 @@ export const NewCodeBlock = ({
                   getItemString={() => null}
                 />
               </div>
-              {hoveredPath && (
-                <div className="bg-canvasSubtle text-muted border-subtle flex items-center border-t px-3 py-1">
-                  <code className="truncate font-mono text-xs">{hoveredPath}</code>
-                </div>
-              )}
+              <div className="bg-canvasSubtle text-muted border-subtle flex shrink-0 items-center justify-between border-t px-3 py-1">
+                <code className="truncate font-mono text-xs">
+                  {hoveredPath || (
+                    <span className="text-muted flex items-center gap-1">
+                      <RiInformationLine className="h-3 w-3" />
+                      Hover over a JSON key to see full path
+                    </span>
+                  )}
+                </code>
+                {hoveredPath && (
+                  <CopyButton
+                    size="small"
+                    code={hoveredPath}
+                    isCopying={isCopying}
+                    handleCopyClick={handleCopyClick}
+                    appearance="ghost"
+                  />
+                )}
+              </div>
             </div>
           ) : (
-            <div className="flex h-full flex-col">
+            <div className="flex min-h-0 flex-1 flex-col">
               <div className="min-h-0 flex-1">
                 <Editor
                   className={cn('h-full', className)}
@@ -421,9 +436,25 @@ export const NewCodeBlock = ({
                   }}
                 />
               </div>
-              {language === 'json' && cursorPath && (
-                <div className="bg-canvasSubtle text-muted border-subtle flex items-center border-t px-3 py-1">
-                  <code className="truncate font-mono text-xs">{cursorPath}</code>
+              {language === 'json' && (
+                <div className="bg-canvasSubtle text-muted border-subtle flex shrink-0 items-center justify-between border-t px-3 py-1">
+                  <code className="truncate font-mono text-xs">
+                    {cursorPath || (
+                      <span className="text-muted flex items-center gap-1">
+                        <RiInformationLine className="h-3 w-3" />
+                        Click on a JSON line to see full path
+                      </span>
+                    )}
+                  </code>
+                  {cursorPath && (
+                    <CopyButton
+                      size="small"
+                      code={cursorPath}
+                      isCopying={isCopying}
+                      handleCopyClick={handleCopyClick}
+                      appearance="ghost"
+                    />
+                  )}
                 </div>
               )}
             </div>

--- a/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
+++ b/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
@@ -194,6 +194,7 @@ export const NewCodeBlock = ({
   const [mode, setMode] = useState<'tree' | 'raw'>('raw');
   const [wordWrap, setWordWrap] = useLocalStorage('wordWrap', false);
   const { handleCopyClick, isCopying } = useCopyToClipboard();
+  const { handleCopyClick: handlePathCopyClick, isCopying: isPathCopying } = useCopyToClipboard();
   const [editEmtpy, setEditEmtpy] = useState(false);
   const [hoveredPath, setHoveredPath] = useState<string | null>(null);
   const [cursorPath, setCursorPath] = useState<string | null>(null);
@@ -383,9 +384,9 @@ export const NewCodeBlock = ({
                   <CopyButton
                     size="small"
                     code={hoveredPath ?? ''}
-                    isCopying={isCopying}
-                    handleCopyClick={handleCopyClick}
-                    appearance="ghost"
+                    isCopying={isPathCopying}
+                    handleCopyClick={handlePathCopyClick}
+                    appearance="outlined"
                   />
                 </span>
               </div>
@@ -450,9 +451,9 @@ export const NewCodeBlock = ({
                     <CopyButton
                       size="small"
                       code={cursorPath ?? ''}
-                      isCopying={isCopying}
-                      handleCopyClick={handleCopyClick}
-                      appearance="ghost"
+                      isCopying={isPathCopying}
+                      handleCopyClick={handlePathCopyClick}
+                      appearance="outlined"
                     />
                   </span>
                 </div>

--- a/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
+++ b/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
@@ -56,6 +56,20 @@ interface CodeBlockProps {
   scrollbarOptions?: editor.IEditorScrollbarOptions;
 }
 
+function buildJsonPath(keyPath: readonly (string | number)[]): string {
+  // keyPath is ordered from leaf to root, so reverse it and skip "root"
+  const parts = [...keyPath].reverse();
+  let result = '';
+  for (const part of parts) {
+    if (typeof part === 'number') {
+      result += `[${part}]`;
+    } else {
+      result += result ? `.${part}` : part;
+    }
+  }
+  return result;
+}
+
 const jsonParse = (content: string) => {
   try {
     return JSON.parse(content);
@@ -95,6 +109,7 @@ export const NewCodeBlock = ({
   const [wordWrap, setWordWrap] = useLocalStorage('wordWrap', false);
   const { handleCopyClick, isCopying } = useCopyToClipboard();
   const [editEmtpy, setEditEmtpy] = useState(false);
+  const [hoveredPath, setHoveredPath] = useState<string | null>(null);
 
   const monaco = useMonaco();
   const { content, readOnly = true, language = 'json' } = tab;
@@ -241,20 +256,38 @@ export const NewCodeBlock = ({
           ) : loading ? (
             <Skeleton className="h-24 w-full" />
           ) : enableTreeView && mode === 'raw' ? (
-            <JSONTree
-              hideRoot={true}
-              data={jsonParse(content) ?? {}}
-              shouldExpandNodeInitially={() => true}
-              theme={jsonTreeTheme(dark)}
-              labelRenderer={([key]) => (
-                <>
-                  <span className="font-mono text-[13px]">{key}</span>
-                  <span className="text-codeDelimiterBracketJson font-mono text-[13px]">:</span>
-                </>
+            <div
+              className="flex h-full flex-col"
+              onMouseLeave={() => setHoveredPath(null)}
+            >
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                <JSONTree
+                  hideRoot={true}
+                  data={jsonParse(content) ?? {}}
+                  shouldExpandNodeInitially={() => true}
+                  theme={jsonTreeTheme(dark)}
+                  labelRenderer={(keyPath) => (
+                    <span
+                      onMouseEnter={() => setHoveredPath(buildJsonPath(keyPath))}
+                    >
+                      <span className="font-mono text-[13px]">{keyPath[0]}</span>
+                      <span className="text-codeDelimiterBracketJson font-mono text-[13px]">
+                        :
+                      </span>
+                    </span>
+                  )}
+                  valueRenderer={(raw: any) => (
+                    <span className="font-mono text-[13px]">{raw}</span>
+                  )}
+                  getItemString={() => null}
+                />
+              </div>
+              {hoveredPath && (
+                <div className="bg-canvasSubtle text-muted border-subtle flex items-center border-t px-3 py-1">
+                  <code className="truncate font-mono text-xs">{hoveredPath}</code>
+                </div>
               )}
-              valueRenderer={(raw: any) => <span className="font-mono text-[13px]">{raw}</span>}
-              getItemString={() => null}
-            />
+            </div>
           ) : (
             <Editor
               className={cn('h-full', className)}

--- a/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
+++ b/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
@@ -371,7 +371,7 @@ export const NewCodeBlock = ({
                   getItemString={() => null}
                 />
               </div>
-              <div className="bg-canvasSubtle text-muted border-subtle flex shrink-0 items-center justify-between border-t px-3 py-1">
+              <div className="bg-canvasSubtle text-muted border-subtle flex min-h-8 shrink-0 items-center justify-between border-t px-3 py-1">
                 <code className="truncate font-mono text-xs">
                   {hoveredPath || (
                     <span className="text-muted flex items-center gap-1">
@@ -380,15 +380,15 @@ export const NewCodeBlock = ({
                     </span>
                   )}
                 </code>
-                <span className={hoveredPath ? '' : 'invisible'}>
+                {hoveredPath && (
                   <CopyButton
                     size="small"
-                    code={hoveredPath ?? ''}
+                    code={hoveredPath}
                     isCopying={isPathCopying}
                     handleCopyClick={handlePathCopyClick}
                     appearance="outlined"
                   />
-                </span>
+                )}
               </div>
             </div>
           ) : (
@@ -438,7 +438,7 @@ export const NewCodeBlock = ({
                 />
               </div>
               {language === 'json' && (
-                <div className="bg-canvasSubtle text-muted border-subtle flex shrink-0 items-center justify-between border-t px-3 py-1">
+                <div className="bg-canvasSubtle text-muted border-subtle flex min-h-8 shrink-0 items-center justify-between border-t px-3 py-1">
                   <code className="truncate font-mono text-xs">
                     {cursorPath || (
                       <span className="text-muted flex items-center gap-1">
@@ -447,15 +447,15 @@ export const NewCodeBlock = ({
                       </span>
                     )}
                   </code>
-                  <span className={cursorPath ? '' : 'invisible'}>
+                  {cursorPath && (
                     <CopyButton
                       size="small"
-                      code={cursorPath ?? ''}
+                      code={cursorPath}
                       isCopying={isPathCopying}
                       handleCopyClick={handlePathCopyClick}
                       appearance="outlined"
                     />
-                  </span>
+                  )}
                 </div>
               )}
             </div>

--- a/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
+++ b/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
@@ -194,6 +194,8 @@ export const NewCodeBlock = ({
   const [mode, setMode] = useState<'tree' | 'raw'>('raw');
   const [wordWrap, setWordWrap] = useLocalStorage('wordWrap', false);
   const { handleCopyClick, isCopying } = useCopyToClipboard();
+  // Shared across tree view and raw editor JSON path bars. If both modes are enabled,
+  // copying in one then switching can briefly show a stale "Copied" state in the other.
   const { handleCopyClick: handlePathCopyClick, isCopying: isPathCopying } = useCopyToClipboard();
   const [editEmtpy, setEditEmtpy] = useState(false);
   const [hoveredPath, setHoveredPath] = useState<string | null>(null);

--- a/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
+++ b/ui/packages/components/src/NewCodeBlock/NewCodeBlock.tsx
@@ -27,6 +27,8 @@ import { OptionalTooltip } from '../Tooltip/OptionalTooltip';
 import { jsonTreeTheme } from '../utils/jsonTree';
 import { isDark } from '../utils/theme';
 
+// JSON field path display: shows the full path (e.g. "data.users[0].name") at the bottom
+// of the editor when the cursor is on a line, similar to the fx terminal tool.
 const EMPTY_INPUT = JSON.stringify({ data: {} }, null, 2);
 
 export type CodeBlockAction = {


### PR DESCRIPTION
## Description
Fixing height of the JSON bar and the coppy button

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR fixes the JSON path bar height consistency using `min-h-8`, re-adds the `useRef` import and `editorRef` declaration that were accidentally dropped, separates the path bar copy state from the toolbar copy state with a dedicated `useCopyToClipboard` hook, and hides the copy button in the empty state.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a34d9dca312f69cc3736f6e2a8594ad09e1a0a4c.</sup>
<!-- /MENDRAL_SUMMARY -->