### PR TITLE
Silence expected instrumentation lease error logs

### DIFF
--- a/pkg/execution/queue/instrumentation.go
+++ b/pkg/execution/queue/instrumentation.go
@@ -60,7 +60,9 @@ func (q *queueProcessor) runInstrumentation(ctx context.Context) {
 			leaseID, err := q.primaryQueueShard.ConfigLease(ctx, "instrument", ConfigLeaseMax, q.instrumentationLease())
 
 			if err != nil {
-				logger.StdlibLogger(ctx).Error("error claiming instrumentation lease", "error", err)
+				if err != ErrConfigAlreadyLeased {
+					logger.StdlibLogger(ctx).Error("error claiming instrumentation lease", "error", err)
+				}
 				setLease(nil)
 				continue
 			}

--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -109,7 +109,7 @@ func (q *queue) StatusCount(ctx context.Context, workflowID uuid.UUID, status st
 func (q *queue) CleanupStatusIndexes(ctx context.Context, fnID uuid.UUID) (int64, error) {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "CleanupStatusIndexes"), redis_telemetry.ScopeQueue)
 
-	l := logger.StdlibLogger(ctx).With("fn_id", fnID.String())
+	l := logger.StdlibLogger(ctx).With("fn_id", fnID.String(), "method", "CleanupStatusIndexes", "queue_shard", q.Name())
 	rc := q.RedisClient.unshardedRc
 	kg := q.RedisClient.kg
 	queueItemKey := kg.QueueItem()
@@ -153,14 +153,16 @@ func (q *queue) CleanupStatusIndexes(ctx context.Context, fnID uuid.UUID) (int64
 				zremCmd := rc.B().Zrem().Key(key).Member(orphans...).Build()
 				removed, err := rc.Do(ctx, zremCmd).AsInt64()
 				if err != nil {
-					l.Error("error removing orphaned status index entries", "error", err, "fnID", fnID, "status", status, "count", len(orphans))
+					l.Error("error removing orphaned status index entries", "error", err, "status", status, "count", len(orphans))
 				} else {
 					totalRemoved += removed
-					l.Info("removed orphaned status index entries", "status", status, "fnID", fnID, "removed", removed, "total_removed", totalRemoved)
+					l.Info("removed orphaned status index entries", "status", status, "removed", removed)
 				}
 			}
 
+			l.Debug("scanning status index for orphans", "status_key", key, "cursor", cursor, "orphans_found", len(orphans), "queue_items_found", len(res.Elements), "total_removed", totalRemoved)
 			if cursor == 0 {
+				l.Debug("no more items to scan in status index", "status_key", key, "queue_shard", q.Name())
 				break
 			}
 		}


### PR DESCRIPTION
## Description

Silence expected instrumentation lease error logs

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Silences expected `ErrConfigAlreadyLeased` errors from the instrumentation lease loop (which fires on every non-leader node) and adds structured context fields to `CleanupStatusIndexes` logging, including two new `Debug`-level scan progress lines.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f50b0b31bccc85c229db584cc938d5a14133b2bf.</sup>
<!-- /MENDRAL_SUMMARY -->