### PR TITLE
only have workers update semaphore capacities if conn id > time

### DIFF
--- a/pkg/connect/lifecycles/semaphore.go
+++ b/pkg/connect/lifecycles/semaphore.go
@@ -3,21 +3,39 @@ package lifecycles
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/inngest/inngest/pkg/connect"
 	"github.com/inngest/inngest/pkg/connect/state"
-	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/constraintapi"
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/util"
+	"github.com/oklog/ulid/v2"
 )
 
 type semaphoreLifecycles struct {
 	sm constraintapi.SemaphoreManager
+
+	// rolloutDate allows us to only adjust semaphore capacity after a specific time.
+	rolloutDate time.Time
 }
 
-func NewSemaphoreLifecycleListener(sm constraintapi.SemaphoreManager) connect.ConnectGatewayLifecycleListener {
-	return &semaphoreLifecycles{sm: sm}
+func NewSemaphoreLifecycleListener(sm constraintapi.SemaphoreManager, rolloutDate time.Time) connect.ConnectGatewayLifecycleListener {
+	return &semaphoreLifecycles{sm: sm, rolloutDate: rolloutDate}
+}
+
+func (s *semaphoreLifecycles) enabled(ctx context.Context, conn *state.Connection) bool {
+	if conn.Data == nil {
+		return false
+	}
+
+	ct := ulid.Time(conn.ConnectionId.Time())
+	if !s.rolloutDate.IsZero() && ct.Before(s.rolloutDate) {
+		return false
+	}
+
+	return true
 }
 
 func (s *semaphoreLifecycles) OnConnected(ctx context.Context, conn *state.Connection)          {}
@@ -29,7 +47,7 @@ func (s *semaphoreLifecycles) OnStartDisconnecting(ctx context.Context, conn *st
 // OnSynced is called after a worker group has been synced. At this point, AppID is available.
 // We adjust the app semaphore capacity by the worker's max concurrency.
 func (s *semaphoreLifecycles) OnSynced(ctx context.Context, conn *state.Connection) {
-	if conn.Data == nil {
+	if !s.enabled(ctx, conn) {
 		return
 	}
 
@@ -65,7 +83,7 @@ func (s *semaphoreLifecycles) OnSynced(ctx context.Context, conn *state.Connecti
 
 // OnDisconnected is called when a connection is lost. Decrement the app semaphore capacity.
 func (s *semaphoreLifecycles) OnDisconnected(ctx context.Context, conn *state.Connection, closeReason string) {
-	if conn.Data == nil {
+	if !s.enabled(ctx, conn) {
 		return
 	}
 

--- a/pkg/constraintapi/semaphore_manager.go
+++ b/pkg/constraintapi/semaphore_manager.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"github.com/redis/rueidis"
 )
 
@@ -53,6 +54,8 @@ func semaphoreIdempotencyKey(accountID uuid.UUID, op, idempotencyKey string) str
 }
 
 func (m *redisSemaphoreManager) SetCapacity(ctx context.Context, accountID uuid.UUID, name, idempotencyKey string, capacity int64) error {
+	start := time.Now()
+
 	keys := []string{
 		semaphoreCapacityKey(accountID, name),
 		semaphoreIdempotencyKey(accountID, "setcap", idempotencyKey),
@@ -62,10 +65,16 @@ func (m *redisSemaphoreManager) SetCapacity(ctx context.Context, accountID uuid.
 		fmt.Sprintf("%d", int(semaphoreIdempotencyTTL.Seconds())),
 	}
 
-	return scripts["semaphore_set_capacity"].Exec(ctx, m.client, keys, args).Error()
+	err := scripts["semaphore_set_capacity"].Exec(ctx, m.client, keys, args).Error()
+
+	m.recordMetrics(ctx, "set_capacity", start, err)
+
+	return err
 }
 
 func (m *redisSemaphoreManager) AdjustCapacity(ctx context.Context, accountID uuid.UUID, name, idempotencyKey string, delta int64) error {
+	start := time.Now()
+
 	keys := []string{
 		semaphoreCapacityKey(accountID, name),
 		semaphoreIdempotencyKey(accountID, "adjcap", idempotencyKey),
@@ -75,10 +84,16 @@ func (m *redisSemaphoreManager) AdjustCapacity(ctx context.Context, accountID uu
 		fmt.Sprintf("%d", int(semaphoreIdempotencyTTL.Seconds())),
 	}
 
-	return scripts["semaphore_adjust_capacity"].Exec(ctx, m.client, keys, args).Error()
+	err := scripts["semaphore_adjust_capacity"].Exec(ctx, m.client, keys, args).Error()
+
+	m.recordMetrics(ctx, "adjust_capacity", start, err)
+
+	return err
 }
 
 func (m *redisSemaphoreManager) GetCapacity(ctx context.Context, accountID uuid.UUID, name, usageValue string) (int64, int64, error) {
+	start := time.Now()
+
 	capKey := semaphoreCapacityKey(accountID, name)
 	usageKey := semaphoreUsageKey(accountID, name, usageValue)
 
@@ -91,6 +106,7 @@ func (m *redisSemaphoreManager) GetCapacity(ctx context.Context, accountID uuid.
 	if rueidis.IsRedisNil(err) {
 		capacity = 0
 	} else if err != nil {
+		m.recordMetrics(ctx, "get_capacity", start, err)
 		return 0, 0, fmt.Errorf("could not get semaphore capacity: %w", err)
 	}
 
@@ -98,13 +114,18 @@ func (m *redisSemaphoreManager) GetCapacity(ctx context.Context, accountID uuid.
 	if rueidis.IsRedisNil(err) {
 		usage = 0
 	} else if err != nil {
+		m.recordMetrics(ctx, "get_capacity", start, err)
 		return 0, 0, fmt.Errorf("could not get semaphore usage: %w", err)
 	}
+
+	m.recordMetrics(ctx, "get_capacity", start, nil)
 
 	return capacity, usage, nil
 }
 
 func (m *redisSemaphoreManager) ReleaseSemaphore(ctx context.Context, accountID uuid.UUID, name, usageValue, idempotencyKey string, weight int64) error {
+	start := time.Now()
+
 	keys := []string{
 		semaphoreUsageKey(accountID, name, usageValue),
 		semaphoreIdempotencyKey(accountID, "rel", idempotencyKey),
@@ -114,5 +135,22 @@ func (m *redisSemaphoreManager) ReleaseSemaphore(ctx context.Context, accountID 
 		fmt.Sprintf("%d", int(semaphoreIdempotencyTTL.Seconds())),
 	}
 
-	return scripts["semaphore_release"].Exec(ctx, m.client, keys, args).Error()
+	err := scripts["semaphore_release"].Exec(ctx, m.client, keys, args).Error()
+
+	m.recordMetrics(ctx, "release", start, err)
+
+	return err
+}
+
+func (m *redisSemaphoreManager) recordMetrics(ctx context.Context, operation string, start time.Time, err error) {
+	status := "success"
+	if err != nil {
+		status = "error"
+	}
+	tags := map[string]any{
+		"operation": operation,
+		"status":    status,
+	}
+	metrics.IncrConstraintAPISemaphoreCounter(ctx, metrics.CounterOpt{PkgName: pkgName, Tags: tags})
+	metrics.HistogramConstraintAPISemaphoreDuration(ctx, time.Since(start), metrics.HistogramOpt{PkgName: pkgName, Tags: tags})
 }

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -689,7 +689,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		connect.WithLifeCycles(
 			[]connect.ConnectGatewayLifecycleListener{
 				lifecycles.NewHistoryLifecycle(dbcqrs),
-				lifecycles.NewSemaphoreLifecycleListener(semaphores),
+				lifecycles.NewSemaphoreLifecycleListener(semaphores, time.Time{}),
 			}),
 	)
 

--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -935,3 +935,12 @@ func IncrConnectProxyLeaseExpiredCount(ctx context.Context, opts CounterOpt) {
 		Tags:        opts.Tags,
 	})
 }
+
+func IncrConstraintAPISemaphoreCounter(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "constraintapi_semaphore_total",
+		Description: "Total semaphore manager operations",
+		Tags:        opts.Tags,
+	})
+}

--- a/pkg/telemetry/metrics/histogram.go
+++ b/pkg/telemetry/metrics/histogram.go
@@ -623,3 +623,14 @@ func HistogramStateWrittenCounter(ctx context.Context, bytes int64, opts Histogr
 		Boundaries:  stateStoreBytesWrittenBoundaries,
 	})
 }
+
+func HistogramConstraintAPISemaphoreDuration(ctx context.Context, dur time.Duration, opts HistogramOpt) {
+	RecordIntHistogramMetric(ctx, dur.Milliseconds(), HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "constraintapi_semaphore_duration",
+		Description: "Distribution of semaphore manager operation duration",
+		Tags:        opts.Tags,
+		Unit:        "ms",
+		Boundaries:  ConstraintAPIDurationBoundaries,
+	})
+}


### PR DESCRIPTION
ensures existing connected workers cannot decrement sem capacity, as they didn't increment.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a rollout gate to `semaphoreLifecycles` so that only connections established after a configurable `rolloutDate` participate in semaphore capacity adjustments. Connections with a ULID timestamp before the rollout date are silently skipped in both `OnSynced` and `OnDisconnected`. Also adds latency/counter metrics to all four `redisSemaphoreManager` operations.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d2f51df5d8b1dc6d0055674a80e911ffac64b443.</sup>
<!-- /MENDRAL_SUMMARY -->