### PR TITLE
fix: Future-date cancellation spans

### DIFF
--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/inngest/inngest/pkg/constraintapi"
 	"github.com/inngest/inngest/pkg/consts"
@@ -25,19 +26,31 @@ import (
 	"github.com/oklog/ulid/v2"
 )
 
+// cancelationGracePeriod is the amount of time we add when marking a cancelled function as finished.  This
+// allows any in-flight steps to complete and report their status, which prevents orphaned steps and ensures
+// that the function's final status is correct.
+const cancelationGracePeriod = 10 * time.Second
+
 // Finalize performs run finalization, which involves sending the function
 // finished/failed event and deleting state.
 func (e *executor) Finalize(ctx context.Context, opts execution.FinalizeOpts) error {
 	ctx = context.WithoutCancel(ctx)
 	l := logger.StdlibLogger(ctx)
 
+	var endTimeOffset time.Duration
+	status := opts.Status()
+	if status == enums.StepStatusCancelled {
+		endTimeOffset = cancelationGracePeriod
+	}
+
 	err := e.tracerProvider.UpdateSpan(ctx, &tracing.UpdateSpanOptions{
-		EndTime:    e.now(),
-		Debug:      &tracing.SpanDebugData{Location: "executor.finalize"},
-		Metadata:   &opts.Metadata,
-		TargetSpan: tracing.RunSpanRefFromMetadata(&opts.Metadata),
-		Status:     opts.Status(),
-		Attributes: finalizeSpanAttributes(opts),
+		EndTime:       e.now(),
+		EndTimeOffset: endTimeOffset,
+		Debug:         &tracing.SpanDebugData{Location: "executor.finalize"},
+		Metadata:      &opts.Metadata,
+		TargetSpan:    tracing.RunSpanRefFromMetadata(&opts.Metadata),
+		Status:        opts.Status(),
+		Attributes:    finalizeSpanAttributes(opts),
 	})
 	if err != nil {
 		// TODO This should be a warning/error once these spans are critical.

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -70,6 +70,7 @@ type UpdateSpanOptions struct {
 	Attributes         *meta.SerializableAttrs
 	Debug              *SpanDebugData
 	EndTime            time.Time
+	EndTimeOffset      time.Duration
 	Metadata           *statev2.Metadata
 	QueueItem          *queue.Item
 	RawOtelSpanOptions []trace.SpanStartOption
@@ -341,10 +342,12 @@ func (tp *otelTracerProvider) UpdateSpan(
 		attrs = attrs.Merge(opts.Attributes)
 	}
 
+	tsWithOffset := ts.Add(opts.EndTimeOffset)
+
 	spanOpts := append(
 		[]trace.SpanStartOption{
 			trace.WithAttributes(attrs.Serialize()...),
-			trace.WithTimestamp(ts),
+			trace.WithTimestamp(tsWithOffset),
 		},
 		opts.RawOtelSpanOptions...,
 	)
@@ -352,7 +355,7 @@ func (tp *otelTracerProvider) UpdateSpan(
 	tracer := tp.getTracer(opts.Metadata)
 	_, span := tracer.Start(ctx, meta.SpanNameDynamicExtension, spanOpts...)
 
-	span.End()
+	span.End(trace.WithTimestamp(tsWithOffset))
 	return nil
 }
 


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

This future-dates cancellation spans so that their status is given priority over a concurrent run start span. We keep the original `ended_at` attribute timestamp though.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

Currently we have a race condition on run start where sometimes runs are marked as `Running` after they're marked `Canceled`

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a 10-second future-date offset (`cancelationGracePeriod`) to the OTEL span timestamp when a function run is cancelled. This ensures the cancellation span sorts after any concurrent "run start" span, fixing a race condition where runs were displayed as `Running` after being `Cancelled`. The real `ended_at` attribute is preserved using the original (non-offset) timestamp.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 14a5c2405091ce27a68c768f63f26bf39f8d707e.</sup>
<!-- /MENDRAL_SUMMARY -->