### PR TITLE
Add labels to insights right sidebar

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/InsightsHelperPanelControl.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/InsightsHelperPanelControl.tsx
@@ -6,6 +6,7 @@ export interface HelperItem {
   action: () => void;
   href?: string;
   icon: ReactElement;
+  label?: string;
   title: string;
 }
 
@@ -19,18 +20,31 @@ export function InsightsHelperPanelControl({
   items,
 }: InsightsHelperPanelControlProps) {
   return (
-    <div className="border-subtle flex h-full w-[56px] flex-col items-center gap-2 border-l px-3 py-2">
+    <div className="border-subtle flex h-full w-[70px] flex-col items-center gap-2 border-l px-2 py-2">
       {items.map((item) => {
         const sharedProps = {
           'aria-label': item.title,
           className: cn(
-            'flex h-8 items-center justify-center rounded-md text-subtle transition-colors w-8',
+            'flex w-full flex-col items-center justify-center gap-0.5 rounded-md py-1 text-subtle transition-colors',
             activeTitle !== item.title && 'hover:bg-canvasSubtle',
             activeTitle === item.title &&
               'bg-secondary-4xSubtle hover:bg-secondary-3xSubtle text-info',
           ),
           title: item.title,
         } as const;
+
+        const content = (
+          <>
+            <div className="flex h-8 w-8 items-center justify-center">
+              {item.icon}
+            </div>
+            <div className="max-w-full px-1 text-center font-medium text-[9px] leading-tight text-subtle">
+              <span className="block whitespace-normal break-words">
+                {item.label ?? item.title}
+              </span>
+            </div>
+          </>
+        );
 
         if (item.href) {
           return (
@@ -41,7 +55,7 @@ export function InsightsHelperPanelControl({
               rel="noopener noreferrer"
               target="_blank"
             >
-              {item.icon}
+              {content}
             </Link>
           );
         }
@@ -53,7 +67,7 @@ export function InsightsHelperPanelControl({
             onClick={item.action}
             type="button"
           >
-            {item.icon}
+            {content}
           </button>
         );
       })}

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
@@ -567,6 +567,7 @@ function InsightsTabManagerInternal({
     if (isInsightsAgentEnabled) {
       items.push({
         title: INSIGHTS_AI,
+        label: 'INSIGHTS AI',
         icon: <InsightsHelperPanelIcon title={INSIGHTS_AI} />,
         action: () => handleSelectHelper(INSIGHTS_AI),
       });
@@ -583,6 +584,7 @@ function InsightsTabManagerInternal({
     if (isSchemaWidgetEnabled) {
       items.push({
         title: SCHEMA_EXPLORER,
+        label: 'SCHEMA EXPLORER',
         icon: <InsightsHelperPanelIcon title={SCHEMA_EXPLORER} />,
         action: () => handleSelectHelper(SCHEMA_EXPLORER),
       });


### PR DESCRIPTION
## Description
Added labels for discoverable. 

<img width="74" height="191" alt="Screenshot 2026-04-15 at 16 10 22" src="https://github.com/user-attachments/assets/733864fa-1bb7-4fb2-bcb1-8b501305869a" />

## Motivation
They help identify the icons faster.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds text labels below icons in the Insights helper panel right sidebar, making the icons more discoverable. Introduces an optional `label` field to `HelperItem`, widens the panel from 56px to 70px, and restructures each item to stack the icon above a small label text.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6921472d5499a74d2f10702b56a92f25109f82f2.</sup>
<!-- /MENDRAL_SUMMARY -->