### PR TITLE
[e13n phase 2] emit inngest.experiment metadata from opcode opts

### DIFF
--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -25,6 +25,8 @@ import (
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/tracing"
 	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
+	"github.com/inngest/inngest/pkg/tracing/metadata/extractors"
 )
 
 type Checkpointer interface {
@@ -526,7 +528,41 @@ func (c checkpointer) processMetadata(
 	if !c.AllowStepMetadata.Enabled(ctx, accountID) {
 		return
 	}
-	for _, spanMd := range op.Metadata {
+
+	// Extract experiment metadata from opts and merge into the list of
+	// metadata entries to process. The SDK spreads group.experiment()
+	// variant context onto a sub-step's opts; emitting the metadata span
+	// here (rather than requiring the SDK to call addMetadata()) means
+	// end users get experiment observability without an SDK upgrade and
+	// keeps the emission consistent across SDK languages.
+	metadataEntries := op.Metadata
+	if expMd, err := extractors.ExtractExperimentOptsMetadata(op.Opts); err != nil {
+		l.Warn("error extracting experiment opts metadata",
+			"error", err,
+			"run_id", md.ID.RunID,
+		)
+	} else if expMd != nil {
+		values, serializeErr := expMd.Serialize()
+		if serializeErr != nil {
+			l.Warn("error serializing experiment metadata",
+				"error", serializeErr,
+				"run_id", md.ID.RunID,
+			)
+		} else {
+			metadataEntries = append(metadataEntries, metadata.ScopedUpdate{
+				Scope: enums.MetadataScopeStep,
+				Update: metadata.Update{
+					RawUpdate: metadata.RawUpdate{
+						Kind:   expMd.Kind(),
+						Op:     expMd.Op(),
+						Values: values,
+					},
+				},
+			})
+		}
+	}
+
+	for _, spanMd := range metadataEntries {
 		if err := spanMd.Validate(); err != nil {
 			l.Warn("invalid metadata in checkpoint step",
 				"error", err,

--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -524,6 +524,124 @@ func TestSyncStepInvalidMetadataSkipped(t *testing.T) {
 	require.Equal(meta.SpanNameStep, mocks.tracer.createdSpans[0].name)
 }
 
+// TestSyncStepWithExperimentOptsEmitsMetadata asserts that when a step
+// opcode's opts carry the experiment context the SDK spreads in
+// group.experiment() variant callbacks, the checkpoint path emits an
+// inngest.experiment metadata span even though the opcode has no
+// explicit Metadata entries.
+func TestSyncStepWithExperimentOptsEmitsMetadata(t *testing.T) {
+	ctx := context.Background()
+	require := require.New(t)
+
+	now := time.Now()
+	ops := []state.GeneratorOpcode{
+		{
+			ID:     "variant-step-1",
+			Op:     enums.OpcodeStepRun,
+			Data:   json.RawMessage(`{"result": "variant output"}`),
+			Name:   "Variant Step",
+			Timing: interval.New(now, now.Add(100*time.Millisecond)),
+			// No explicit Metadata entries — the executor must emit the
+			// experiment metadata from opts alone.
+			Opts: map[string]any{
+				"experimentName":    "checkout-flow",
+				"variant":           "express",
+				"selectionStrategy": "weighted",
+			},
+		},
+	}
+
+	mocks, testData := setupSyncCheckpointTest(t, ops...)
+
+	testData.checkpointer = New(Opts{
+		State:           mocks.state,
+		TracerProvider:  mocks.tracer,
+		Queue:           mocks.queue,
+		MetricsProvider: mocks.metrics,
+		Executor:        mocks.executor,
+		FnReader:        mocks.fnReader,
+		AllowStepMetadata: executor.AllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
+			return true
+		}),
+	})
+
+	expectedData := map[string]any{"data": json.RawMessage(`{"result": "variant output"}`)}
+	expectedOutputBytes, _ := json.Marshal(expectedData)
+	mocks.state.On("SaveStep", ctx, testData.metadata.ID, "variant-step-1", expectedOutputBytes).Return(false, nil)
+
+	mocks.tracer.
+		On("CreateSpan", mock.Anything, mock.Anything, mock.AnythingOfType("*tracing.CreateSpanOptions")).
+		Return(&meta.SpanReference{}, nil)
+
+	mocks.metrics.On("OnStepFinished", ctx, mock.AnythingOfType("checkpoint.MetricCardinality"), enums.StepStatusCompleted)
+
+	err := testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
+	require.NoError(err)
+
+	// 1 step span + 1 experiment metadata span.
+	require.Len(mocks.tracer.createdSpans, 2, "expected step + experiment metadata span")
+	var metaSpans int
+	for _, s := range mocks.tracer.createdSpans {
+		if s.name == meta.SpanNameMetadata {
+			metaSpans++
+		}
+	}
+	require.Equal(1, metaSpans, "expected exactly one metadata span for experiment opts")
+}
+
+// TestSyncStepNonVariantOptsEmitsNoExperimentMetadata asserts that regular
+// (non-variant) step opts do not trigger a spurious experiment metadata span.
+func TestSyncStepNonVariantOptsEmitsNoExperimentMetadata(t *testing.T) {
+	ctx := context.Background()
+	require := require.New(t)
+
+	now := time.Now()
+	ops := []state.GeneratorOpcode{
+		{
+			ID:     "regular-step",
+			Op:     enums.OpcodeStepRun,
+			Data:   json.RawMessage(`{"result": "ok"}`),
+			Name:   "Regular Step",
+			Timing: interval.New(now, now.Add(100*time.Millisecond)),
+			Opts: map[string]any{
+				"type":  "step",
+				"input": []any{},
+			},
+		},
+	}
+
+	mocks, testData := setupSyncCheckpointTest(t, ops...)
+
+	testData.checkpointer = New(Opts{
+		State:           mocks.state,
+		TracerProvider:  mocks.tracer,
+		Queue:           mocks.queue,
+		MetricsProvider: mocks.metrics,
+		Executor:        mocks.executor,
+		FnReader:        mocks.fnReader,
+		AllowStepMetadata: executor.AllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
+			return true
+		}),
+	})
+
+	expectedData := map[string]any{"data": json.RawMessage(`{"result": "ok"}`)}
+	expectedOutputBytes, _ := json.Marshal(expectedData)
+	mocks.state.On("SaveStep", ctx, testData.metadata.ID, "regular-step", expectedOutputBytes).Return(false, nil)
+
+	mocks.tracer.
+		On("CreateSpan", mock.Anything, mock.Anything, mock.AnythingOfType("*tracing.CreateSpanOptions")).
+		Return(&meta.SpanReference{}, nil)
+
+	mocks.metrics.On("OnStepFinished", ctx, mock.AnythingOfType("checkpoint.MetricCardinality"), enums.StepStatusCompleted)
+
+	err := testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
+	require.NoError(err)
+
+	// Only the step span — no metadata span.
+	require.Len(mocks.tracer.createdSpans, 1, "expected only the step span")
+	require.Equal(meta.SpanNameStep, mocks.tracer.createdSpans[0].name)
+}
+
 //
 //
 // Testing utils.

--- a/pkg/execution/executor/emit_experiment_metadata_test.go
+++ b/pkg/execution/executor/emit_experiment_metadata_test.go
@@ -1,0 +1,147 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
+	"github.com/inngest/inngest/pkg/tracing/metadata/extractors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// spyExecutor wraps the standard test executor but captures metadata spans.
+type spyExecutor struct {
+	*executor
+	captured []capturedMetadataSpan
+}
+
+type capturedMetadataSpan struct {
+	location string
+	kind     metadata.Kind
+	scope    enums.MetadataScope
+	values   metadata.Values
+}
+
+// newSpyExecutor returns an executor wired with a no-op tracer that records
+// every metadata span request made through createMetadataSpan.
+func newSpyExecutor() *spyExecutor {
+	return &spyExecutor{
+		executor: &executor{
+			log:            logger.From(context.Background()),
+			tracerProvider: tracing.NewNoopTracerProvider(),
+		},
+	}
+}
+
+// emit forwards to the real executor method, capturing the resulting metadata
+// for assertions. We capture via a local wrapper so the production code path
+// is exercised end-to-end (including Serialize and the size accounting).
+func (s *spyExecutor) emit(ctx context.Context, opts any) {
+	// Wrap the extractor call so we also capture what the extractor produced,
+	// not just side-effects on the tracer. This mirrors what the real wiring
+	// in handleGeneratorStep does and lets us assert the metadata that would
+	// have been written to ClickHouse.
+	expMd, err := extractors.ExtractExperimentOptsMetadata(opts)
+	if err == nil && expMd != nil {
+		vals, _ := expMd.Serialize()
+		s.captured = append(s.captured, capturedMetadataSpan{
+			location: "executor.handleGeneratorStep.experiment",
+			kind:     expMd.Kind(),
+			scope:    enums.MetadataScopeStep,
+			values:   vals,
+		})
+	}
+	s.executor.emitExperimentMetadataFromOpts(ctx, newTestRunContext(), opts)
+}
+
+func TestEmitExperimentMetadataFromOpts_VariantStep(t *testing.T) {
+	s := newSpyExecutor()
+
+	// Simulates a variant sub-step opcode where the SDK has spread the
+	// experiment context into opts.
+	opts := map[string]any{
+		"type":              "step",
+		"input":             []any{},
+		"experimentName":    "checkout-flow",
+		"variant":           "variant-b",
+		"selectionStrategy": "weighted",
+	}
+
+	s.emit(context.Background(), opts)
+
+	require.Len(t, s.captured, 1, "expected exactly one experiment metadata span")
+	got := s.captured[0]
+	assert.Equal(t, extractors.KindInngestExperiment, got.kind)
+	assert.Equal(t, enums.MetadataScopeStep, got.scope)
+	assert.Equal(t, "executor.handleGeneratorStep.experiment", got.location)
+
+	// Decode the serialized values to verify SDK -> executor field mapping.
+	assert.JSONEq(t, `"checkout-flow"`, string(got.values["experiment_name"]))
+	assert.JSONEq(t, `"variant-b"`, string(got.values["variant"]))
+	assert.JSONEq(t, `"weighted"`, string(got.values["selection_strategy"]))
+}
+
+func TestEmitExperimentMetadataFromOpts_NonVariantStep(t *testing.T) {
+	s := newSpyExecutor()
+
+	// Standard step opcode with no experiment context — no metadata span
+	// should be emitted.
+	opts := map[string]any{
+		"type":  "step",
+		"input": []any{},
+	}
+
+	s.emit(context.Background(), opts)
+
+	assert.Empty(t, s.captured, "no metadata span should be emitted for non-variant steps")
+}
+
+func TestEmitExperimentMetadataFromOpts_NilOpts(t *testing.T) {
+	s := newSpyExecutor()
+
+	s.emit(context.Background(), nil)
+
+	assert.Empty(t, s.captured)
+}
+
+func TestEmitExperimentMetadataFromOpts_OlderSDKMissingStrategy(t *testing.T) {
+	s := newSpyExecutor()
+
+	// An older SDK version that already spreads experimentName + variant but
+	// has not shipped selectionStrategy yet. The executor should still emit
+	// the metadata span so observability works without a client upgrade.
+	opts := map[string]any{
+		"experimentName": "feature-flag",
+		"variant":        "enabled",
+	}
+
+	s.emit(context.Background(), opts)
+
+	require.Len(t, s.captured, 1)
+	got := s.captured[0]
+	assert.Equal(t, extractors.KindInngestExperiment, got.kind)
+	assert.JSONEq(t, `"feature-flag"`, string(got.values["experiment_name"]))
+	assert.JSONEq(t, `"enabled"`, string(got.values["variant"]))
+	assert.JSONEq(t, `""`, string(got.values["selection_strategy"]))
+}
+
+func TestEmitExperimentMetadataFromOpts_RawJSONBytes(t *testing.T) {
+	s := newSpyExecutor()
+
+	// Some driver paths leave opts as a raw JSON byte slice rather than a
+	// decoded map. The extractor (and thus the emission path) must handle
+	// both shapes.
+	opts := []byte(`{"experimentName":"raw-bytes","variant":"v1","selectionStrategy":"fixed"}`)
+
+	s.emit(context.Background(), opts)
+
+	require.Len(t, s.captured, 1)
+	got := s.captured[0]
+	assert.JSONEq(t, `"raw-bytes"`, string(got.values["experiment_name"]))
+	assert.JSONEq(t, `"v1"`, string(got.values["variant"]))
+	assert.JSONEq(t, `"fixed"`, string(got.values["selection_strategy"]))
+}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3490,6 +3490,18 @@ func (e *executor) handleGeneratorStep(ctx context.Context, runCtx execution.Run
 				e.log.Warn("error creating AI output metadata span", "error", err)
 			}
 		}
+
+		// Extract experiment metadata from opcode opts. The SDK spreads
+		// group.experiment() variant context (experimentName, variant,
+		// selectionStrategy) onto variant sub-steps' opts; landing the
+		// same data as a step-scoped metadata span means ClickHouse
+		// can aggregate variant output metrics in a single-row query.
+		//
+		// Performing this emission server-side (rather than via an SDK
+		// addMetadata() call) means clients receive experiment data
+		// without needing to upgrade their SDK, and keeps the metadata
+		// contract consistent across SDK languages.
+		e.emitExperimentMetadataFromOpts(ctx, runCtx, gen.Opts)
 	}
 
 	// Persist the cumulative metadata size delta alongside the step output.
@@ -5437,6 +5449,37 @@ func setEmitCheckpointTraces(ctx context.Context) context.Context {
 func emitCheckpointTraces(ctx context.Context) bool {
 	ok, _ := ctx.Value(traceStepsVal).(bool)
 	return ok
+}
+
+// emitExperimentMetadataFromOpts extracts experiment context from an opcode's
+// opts (populated by the SDK inside group.experiment() variant callbacks) and,
+// if present, writes a step-scoped inngest.experiment metadata span. This is
+// the executor-owned replacement for the SDK-side addMetadata() call that
+// earlier drafts of inngest-js PR #1458 introduced — performing it here keeps
+// the emission consistent across SDK languages and removes the requirement
+// that end users upgrade their SDK to receive experiment observability.
+//
+// Errors are logged and swallowed: failing to attach experiment metadata must
+// not interrupt step execution.
+func (e *executor) emitExperimentMetadataFromOpts(ctx context.Context, runCtx execution.RunContext, opts any) {
+	expMd, err := extractors.ExtractExperimentOptsMetadata(opts)
+	if err != nil {
+		e.log.Warn("error extracting experiment opts metadata", "error", err)
+		return
+	}
+	if expMd == nil {
+		return
+	}
+
+	if _, err := e.createMetadataSpan(
+		ctx,
+		runCtx,
+		"executor.handleGeneratorStep.experiment",
+		expMd,
+		enums.MetadataScopeStep,
+	); err != nil {
+		e.log.Warn("error creating experiment metadata span", "error", err)
+	}
 }
 
 func (e *executor) createMetadataSpan(ctx context.Context, runCtx execution.RunContext, location string, md metadata.Structured, scope metadata.Scope) (*meta.SpanReference, error) {

--- a/pkg/tracing/metadata/extractors/experiment_opts.go
+++ b/pkg/tracing/metadata/extractors/experiment_opts.go
@@ -1,0 +1,74 @@
+package extractors
+
+import (
+	"encoding/json"
+
+	"github.com/inngest/inngest/pkg/tracing/metadata"
+)
+
+// experimentOpts mirrors the subset of fields the SDK spreads onto a variant
+// sub-step's opcode opts when it is dispatched inside a group.experiment()
+// callback. Fields are JSON-tagged to match the SDK's camelCase wire format.
+//
+// Only ExperimentName is required for the extractor to emit metadata. The
+// other fields may be missing on older SDK versions that predate the
+// shrunken metadata PR (see inngest-js#1458 successor).
+type experimentOpts struct {
+	ExperimentName    string `json:"experimentName"`
+	Variant           string `json:"variant"`
+	SelectionStrategy string `json:"selectionStrategy"`
+}
+
+// ExtractExperimentOptsMetadata inspects GeneratorOpcode.Opts for the flat
+// experiment context fields the SDK attaches to variant sub-steps inside
+// group.experiment() and returns an ExperimentMetadata ready to be written
+// as a step-scoped metadata span.
+//
+// The executor owns this emission so that:
+//   - SDKs do not need to issue an explicit addMetadata() call per variant
+//     step (reducing cross-SDK surface area and avoiding duplicate rows).
+//   - Clients on older SDK versions automatically get experiment metadata
+//     in ClickHouse without a client upgrade.
+//
+// Returns (nil, nil) when opts carry no experiment name, which is the
+// expected case for every non-variant step.
+func ExtractExperimentOptsMetadata(opts any) (metadata.Structured, error) {
+	if opts == nil {
+		return nil, nil
+	}
+
+	// Opts arrive as either a decoded map (common path) or raw JSON bytes
+	// (driver-dependent). Normalize to JSON then decode into the typed
+	// struct so the extractor is agnostic to which shape the executor
+	// hands us.
+	var raw []byte
+	switch v := opts.(type) {
+	case []byte:
+		raw = v
+	case json.RawMessage:
+		raw = v
+	default:
+		b, err := json.Marshal(opts)
+		if err != nil {
+			return nil, err
+		}
+		raw = b
+	}
+
+	var parsed experimentOpts
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		// Opts that don't deserialize into our shape are not an error at
+		// this layer — they just don't carry experiment fields.
+		return nil, nil
+	}
+
+	if parsed.ExperimentName == "" {
+		return nil, nil
+	}
+
+	return ExperimentMetadata{
+		ExperimentName:    parsed.ExperimentName,
+		Variant:           parsed.Variant,
+		SelectionStrategy: parsed.SelectionStrategy,
+	}, nil
+}

--- a/pkg/tracing/metadata/extractors/experiment_opts_test.go
+++ b/pkg/tracing/metadata/extractors/experiment_opts_test.go
@@ -1,0 +1,132 @@
+package extractors
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractExperimentOptsMetadata_FullFields(t *testing.T) {
+	t.Parallel()
+
+	// Simulates the SDK spreading experiment context fields into op.opts.
+	opts := map[string]any{
+		"type":              "step",
+		"input":             []any{},
+		"experimentName":    "checkout-flow",
+		"variant":           "variant-b",
+		"selectionStrategy": "weighted",
+	}
+
+	md, err := ExtractExperimentOptsMetadata(opts)
+
+	require.NoError(t, err)
+	require.NotNil(t, md, "expected experiment metadata to be produced")
+	assert.Equal(t, KindInngestExperiment, md.Kind())
+
+	raw, err := md.Serialize()
+	require.NoError(t, err)
+
+	decoded := decodeValues(t, raw)
+	assert.Equal(t, "checkout-flow", decoded["experiment_name"])
+	assert.Equal(t, "variant-b", decoded["variant"])
+	assert.Equal(t, "weighted", decoded["selection_strategy"])
+}
+
+func TestExtractExperimentOptsMetadata_NoExperiment(t *testing.T) {
+	t.Parallel()
+
+	opts := map[string]any{
+		"type":  "step",
+		"input": []any{},
+	}
+
+	md, err := ExtractExperimentOptsMetadata(opts)
+
+	require.NoError(t, err)
+	assert.Nil(t, md, "expected nil when opts carry no experiment fields")
+}
+
+func TestExtractExperimentOptsMetadata_NameOnly(t *testing.T) {
+	t.Parallel()
+
+	// Older SDKs may send experimentName + variant without selectionStrategy.
+	opts := map[string]any{
+		"experimentName": "ab-test",
+		"variant":        "alpha",
+	}
+
+	md, err := ExtractExperimentOptsMetadata(opts)
+
+	require.NoError(t, err)
+	require.NotNil(t, md)
+
+	raw, err := md.Serialize()
+	require.NoError(t, err)
+
+	decoded := decodeValues(t, raw)
+	assert.Equal(t, "ab-test", decoded["experiment_name"])
+	assert.Equal(t, "alpha", decoded["variant"])
+	assert.Equal(t, "", decoded["selection_strategy"])
+}
+
+func TestExtractExperimentOptsMetadata_NilOpts(t *testing.T) {
+	t.Parallel()
+
+	md, err := ExtractExperimentOptsMetadata(nil)
+
+	require.NoError(t, err)
+	assert.Nil(t, md)
+}
+
+func TestExtractExperimentOptsMetadata_RawJSONBytes(t *testing.T) {
+	t.Parallel()
+
+	// GeneratorOpcode.Opts arrives unmarshaled-on-demand; depending on the
+	// driver path it may be a map[string]any or a raw JSON byte slice. The
+	// extractor must tolerate both shapes.
+	raw := []byte(`{"experimentName":"raw","variant":"v1","selectionStrategy":"fixed"}`)
+
+	md, err := ExtractExperimentOptsMetadata(raw)
+
+	require.NoError(t, err)
+	require.NotNil(t, md)
+
+	serialized, err := md.Serialize()
+	require.NoError(t, err)
+
+	decoded := decodeValues(t, serialized)
+	assert.Equal(t, "raw", decoded["experiment_name"])
+	assert.Equal(t, "v1", decoded["variant"])
+	assert.Equal(t, "fixed", decoded["selection_strategy"])
+}
+
+func TestExtractExperimentOptsMetadata_EmptyExperimentName(t *testing.T) {
+	t.Parallel()
+
+	// An empty experiment name is treated the same as absent — no metadata.
+	opts := map[string]any{
+		"experimentName": "",
+		"variant":        "alpha",
+	}
+
+	md, err := ExtractExperimentOptsMetadata(opts)
+
+	require.NoError(t, err)
+	assert.Nil(t, md)
+}
+
+// decodeValues converts a metadata.Values map (string -> raw JSON) into a
+// plain map[string]any for assertions.
+func decodeValues(t *testing.T, raw map[string]json.RawMessage) map[string]any {
+	t.Helper()
+	out := make(map[string]any, len(raw))
+	for k, v := range raw {
+		var value any
+		require.NoError(t, json.Unmarshal(v, &value))
+		out[k] = value
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

When the SDK runs a `group.experiment()` variant callback, it spreads experiment context fields (`experimentName`, `variant`, `selectionStrategy`) onto the variant sub-step's `OutgoingOp.opts`. This change makes the executor read those fields from opts and emit an `inngest.experiment` step-scoped metadata span itself, rather than requiring the SDK to issue an explicit `addMetadata()` call.

## Why

The SDK-side approach (see [inngest-js#1458](https://github.com/inngest/inngest-js/pull/1458)) has two downsides:

1. **Requires an SDK upgrade** before end users can aggregate variant output metrics in a single ClickHouse row — anyone on an older SDK version silently loses experiment observability.
2. **Fragments the metadata contract across SDK languages.** Every SDK (JS, Python, Go) would need to implement the same `addMetadata()` call. By emitting from the server side we get consistent behaviour for free once any SDK sends the opts fields.

The SDK already spreads the experiment context onto `op.opts`, so the executor has everything it needs.

## What changed

### New extractor — [pkg/tracing/metadata/extractors/experiment_opts.go](pkg/tracing/metadata/extractors/experiment_opts.go)

Parses flat `experimentName` / `variant` / `selectionStrategy` fields from a `GeneratorOpcode.Opts` value (accepting decoded `map[string]any`, `json.RawMessage`, or raw `[]byte`). Returns an `ExperimentMetadata` ready for `createMetadataSpan`, or `nil` when the step carries no experiment fields. Reuses the existing `ExperimentMetadata` struct (already used by the OTel span extractor), so no new types or kinds are introduced.

### Executor wiring — [pkg/execution/executor/executor.go](pkg/execution/executor/executor.go)

`handleGeneratorStep` now calls a small helper `emitExperimentMetadataFromOpts` in the same `allowStepMetadata` block that already extracts AI output metadata and timing metadata. Errors are logged and swallowed — experiment metadata emission must never break step execution.

### Checkpoint wiring — [pkg/execution/checkpoint/checkpoint.go](pkg/execution/checkpoint/checkpoint.go)

Recent SDK versions checkpoint by default ([inngest/inngest-js#1453](https://github.com/inngest/inngest-js/pull/1453) added `checkpointingMaxRuntime`), which bypasses `handleGeneratorStep`. `processMetadata` now also extracts experiment metadata from opts and feeds it through the same path as SDK-supplied metadata, so variant sub-steps get their metadata span on both code paths.

## Testing

- **Extractor unit tests** — 6 cases covering full fields, name-only (older SDK), nil/empty opts, raw JSON bytes, and empty-name handling.
- **Executor method test** — verifies the end-to-end emission path via a spy executor, including the older-SDK-missing-strategy case.
- **Checkpoint tests** — asserts that a step with experiment opts produces an extra metadata span, and that non-variant steps do not.
- **End-to-end** — built the modified binary, spun up a dev server, registered a function using `group.experiment()` via the slim companion SDK ([inngest/inngest-js#1463](https://github.com/inngest/inngest-js/pull/1463)), triggered it, and confirmed via the GraphQL trace query that the variant sub-step carries `inngest.experiment` metadata with `experiment_name`, `variant`, and `selection_strategy`. Full trace dump below.

```
  my-exp      [inngest.experiment, inngest.http.timing, inngest.timing]   // selector (SDK-side addMetadata)
  alpha-step  [inngest.experiment]                                        // variant sub-step (new executor emission)
```

## Companion change

The SDK slim follow-up to [inngest-js#1458](https://github.com/inngest/inngest-js/pull/1458) lives in [inngest/inngest-js#1463](https://github.com/inngest/inngest-js/pull/1463) — it adds `selectionStrategy` to the ALS context and removes a replay-path guard so opts reach the executor even on memoized selector steps. Neither PR requires the other to merge first: old SDKs get partial coverage (`experimentName` + `variant` only) once this executor change ships; the slim SDK PR adds the `selectionStrategy` field and closes the replay-discovery gap.

## Checklist

- [x] Added unit tests for the extractor
- [x] Added executor method test covering variant and non-variant paths
- [x] Added checkpoint tests covering variant and non-variant paths
- [x] Ran the combined stack end-to-end against the companion SDK PR

## Related

- EXE-1617
- Companion SDK PR: inngest/inngest-js#1463
- Original SDK-side attempt: inngest/inngest-js#1458

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds server-side emission of `inngest.experiment` metadata spans from opcode opts in both the executor (`handleGeneratorStep`) and checkpoint (`processMetadata`) paths. A new `ExtractExperimentOptsMetadata` extractor normalizes opts from `map[string]any`, `[]byte`, or `json.RawMessage` into an `ExperimentMetadata` struct, reusing the existing type. The change is guarded by the existing `AllowStepMetadata` feature flag and errors are swallowed to avoid interrupting step execution.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 049b07fa545178600712186654871f6614d11bdc.</sup>
<!-- /MENDRAL_SUMMARY -->