### PR TITLE
use a per event idempotency key instead of a large zset per workflow id

### DIFF
--- a/pkg/execution/batch/batch_test.go
+++ b/pkg/execution/batch/batch_test.go
@@ -414,6 +414,222 @@ func strPtr(s string) *string {
 	return &s
 }
 
+// TestPerEventIdempotenceKeys verifies that per-event SET keys are used for dedup
+// instead of the legacy sorted set, and that they expire independently.
+func TestPerEventIdempotenceKeys(t *testing.T) {
+	r := miniredis.RunT(t)
+
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
+	bm := NewRedisBatchManager(bc, nil, WithoutBuffer(), WithRedisBatchIdempotenceSetTTL(10))
+
+	fnId := uuid.New()
+	fn := inngest.Function{
+		ID: fnId,
+		EventBatch: &inngest.EventBatchConfig{
+			MaxSize: 100,
+			Timeout: "60s",
+		},
+	}
+
+	eventID := ulid.MustNew(ulid.Now(), rand.Reader)
+	bi := BatchItem{
+		AccountID:  uuid.New(),
+		FunctionID: fnId,
+		EventID:    eventID,
+		Event:      event.Event{ID: "test"},
+	}
+
+	// Append first event
+	res, err := bm.Append(context.Background(), bi, fn)
+	require.NoError(t, err)
+	require.Equal(t, enums.BatchNew, res.Status)
+
+	// Verify per-event idem key was created (not the legacy sorted set)
+	prefix := bc.KeyGenerator().QueuePrefix(context.Background(), fnId)
+	idemKey := prefix + ":batch_idem:" + eventID.String()
+	require.True(t, r.Exists(idemKey), "per-event idem key should exist")
+	require.False(t, r.Exists(bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)), "legacy sorted set should NOT be created")
+
+	// Same event should be rejected as duplicate
+	res, err = bm.Append(context.Background(), bi, fn)
+	require.NoError(t, err)
+	require.Equal(t, enums.BatchNew, res.Status) // size == 1, so returns "new"
+
+	// Second event should work fine
+	bi2 := bi
+	bi2.EventID = ulid.MustNew(ulid.Now(), rand.Reader)
+	res, err = bm.Append(context.Background(), bi2, fn)
+	require.NoError(t, err)
+	require.Equal(t, enums.BatchAppend, res.Status)
+
+	// Per-event keys should expire independently
+	r.FastForward(11 * time.Second)
+	require.False(t, r.Exists(idemKey), "per-event idem key should have expired")
+
+	// After expiry, same event ID can be appended again (TTL window passed)
+	res, err = bm.Append(context.Background(), bi, fn)
+	require.NoError(t, err)
+	require.Equal(t, enums.BatchAppend, res.Status)
+}
+
+// TestPerEventIdempotenceLegacyFallback verifies that events written to the legacy
+// sorted set before migration are still deduped via the ZSCORE fallback.
+func TestPerEventIdempotenceLegacyFallback(t *testing.T) {
+	r := miniredis.RunT(t)
+
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
+	bm := NewRedisBatchManager(bc, nil, WithoutBuffer())
+
+	fnId := uuid.New()
+	fn := inngest.Function{
+		ID: fnId,
+		EventBatch: &inngest.EventBatchConfig{
+			MaxSize: 100,
+			Timeout: "60s",
+		},
+	}
+
+	eventID := ulid.MustNew(ulid.Now(), rand.Reader)
+	bi := BatchItem{
+		AccountID:  uuid.New(),
+		FunctionID: fnId,
+		EventID:    eventID,
+		Event:      event.Event{ID: "test"},
+	}
+
+	// Simulate a legacy event by writing directly to the old sorted set
+	legacyKey := bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)
+	r.ZAdd(legacyKey, float64(time.Now().Unix()), eventID.String())
+
+	// Append the same event — should be rejected via legacy fallback
+	res, err := bm.Append(context.Background(), bi, fn)
+	require.NoError(t, err)
+	require.Equal(t, enums.BatchItemExists, res.Status)
+
+	// A different event should go through fine
+	bi2 := bi
+	bi2.EventID = ulid.MustNew(ulid.Now(), rand.Reader)
+	res, err = bm.Append(context.Background(), bi2, fn)
+	require.NoError(t, err)
+	require.Equal(t, enums.BatchNew, res.Status)
+}
+
+// TestPerEventIdempotenceBulkAppend verifies per-event dedup works in the bulk append path.
+func TestPerEventIdempotenceBulkAppend(t *testing.T) {
+	r := miniredis.RunT(t)
+
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
+	mgr := NewRedisBatchManager(bc, nil, WithoutBuffer())
+	bm := mgr.(*redisBatchManager)
+
+	fnId := uuid.New()
+	fn := inngest.Function{
+		ID: fnId,
+		EventBatch: &inngest.EventBatchConfig{
+			MaxSize: 100,
+			Timeout: "60s",
+		},
+	}
+
+	event1ID := ulid.MustNew(ulid.Now(), rand.Reader)
+	event2ID := ulid.MustNew(ulid.Now(), rand.Reader)
+	event3ID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	items := []BatchItem{
+		{AccountID: uuid.New(), FunctionID: fnId, EventID: event1ID, Event: event.Event{ID: "e1"}},
+		{AccountID: uuid.New(), FunctionID: fnId, EventID: event2ID, Event: event.Event{ID: "e2"}},
+		{AccountID: uuid.New(), FunctionID: fnId, EventID: event3ID, Event: event.Event{ID: "e3"}},
+	}
+
+	// Bulk append 3 events
+	res, err := bm.BulkAppend(context.Background(), items, fn)
+	require.NoError(t, err)
+	require.Equal(t, 3, res.Committed)
+	require.Equal(t, 0, res.Duplicates)
+
+	// Bulk append same 3 events again — all should be duplicates
+	res, err = bm.BulkAppend(context.Background(), items, fn)
+	require.NoError(t, err)
+	require.Equal(t, "itemexists", res.Status)
+	require.Equal(t, 0, res.Committed)
+	require.Equal(t, 3, res.Duplicates)
+
+	// Bulk append mix of new and duplicate
+	event4ID := ulid.MustNew(ulid.Now(), rand.Reader)
+	mixedItems := []BatchItem{
+		{AccountID: uuid.New(), FunctionID: fnId, EventID: event1ID, Event: event.Event{ID: "e1"}}, // dup
+		{AccountID: uuid.New(), FunctionID: fnId, EventID: event4ID, Event: event.Event{ID: "e4"}}, // new
+	}
+	res, err = bm.BulkAppend(context.Background(), mixedItems, fn)
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Committed)
+	require.Equal(t, 1, res.Duplicates)
+}
+
+// TestPerEventIdempotenceBulkAppendLegacyFallback verifies the legacy ZSCORE fallback
+// works in the bulk append path.
+func TestPerEventIdempotenceBulkAppendLegacyFallback(t *testing.T) {
+	r := miniredis.RunT(t)
+
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
+	mgr := NewRedisBatchManager(bc, nil, WithoutBuffer())
+	bm := mgr.(*redisBatchManager)
+
+	fnId := uuid.New()
+	fn := inngest.Function{
+		ID: fnId,
+		EventBatch: &inngest.EventBatchConfig{
+			MaxSize: 100,
+			Timeout: "60s",
+		},
+	}
+
+	legacyEventID := ulid.MustNew(ulid.Now(), rand.Reader)
+	newEventID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	// Simulate legacy event in the old sorted set
+	legacyKey := bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)
+	r.ZAdd(legacyKey, float64(time.Now().Unix()), legacyEventID.String())
+
+	items := []BatchItem{
+		{AccountID: uuid.New(), FunctionID: fnId, EventID: legacyEventID, Event: event.Event{ID: "legacy"}},
+		{AccountID: uuid.New(), FunctionID: fnId, EventID: newEventID, Event: event.Event{ID: "new"}},
+	}
+
+	res, err := bm.BulkAppend(context.Background(), items, fn)
+	require.NoError(t, err)
+	require.Equal(t, 1, res.Committed)
+	require.Equal(t, 1, res.Duplicates)
+}
+
 func TestBatchCleanupIdempotenceKeyExpires(t *testing.T) {
 	r := miniredis.RunT(t)
 

--- a/pkg/execution/batch/batch_test.go
+++ b/pkg/execution/batch/batch_test.go
@@ -127,7 +127,7 @@ func TestBatchAppendIdempotence(t *testing.T) {
 }
 
 // When the same event is appended to different batches, we would end up processing the duplicate event a second time in the second batch.
-// Currently Idempotency for eventIDs are only tracked within a batch. When a batch is full and scheduled, we lose track of eventIDs already processed.
+// Per-event idempotence keys span across batches within their TTL window, so duplicates are rejected even after batch rotation.
 func TestBatchAppendIdempotenceDifferentBatches(t *testing.T) {
 	r := miniredis.RunT(t)
 
@@ -230,24 +230,17 @@ func TestBatchCleanup(t *testing.T) {
 	require.True(t, r.Exists(bc.KeyGenerator().Batch(context.Background(), fnId, ulid.MustParse(res.BatchID))))
 	require.True(t, r.Exists(bc.KeyGenerator().BatchMetadata(context.Background(), fnId, ulid.MustParse(res.BatchID))))
 	require.True(t, r.Exists(bc.KeyGenerator().BatchPointer(context.Background(), fnId)))
-	require.True(t, r.Exists(bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)))
+	// Per-event idempotence key exists instead of a single sorted set
 	require.Equal(t, 4, len(r.Keys()))
 
-	bm = NewRedisBatchManager(bc, nil, WithRedisBatchIdempotenceSetCleanupCutoff(200))
 	err = bm.DeleteKeys(context.Background(), fnId, ulid.MustParse(res.BatchID))
 	require.NoError(t, err)
 
 	require.False(t, r.Exists(bc.KeyGenerator().Batch(context.Background(), fnId, ulid.MustParse(res.BatchID))))
 	require.False(t, r.Exists(bc.KeyGenerator().BatchMetadata(context.Background(), fnId, ulid.MustParse(res.BatchID))))
-	require.True(t, r.Exists(bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)))
 	require.True(t, r.Exists(bc.KeyGenerator().BatchPointer(context.Background(), fnId)))
+	// Per-event idem key + batch pointer remain
 	require.Equal(t, 2, len(r.Keys()))
-
-	bm = NewRedisBatchManager(bc, nil, WithRedisBatchIdempotenceSetCleanupCutoff(0))
-	err = bm.DeleteKeys(context.Background(), fnId, ulid.MustParse(res.BatchID))
-	require.NoError(t, err)
-	require.False(t, r.Exists(bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)))
-	require.Equal(t, 1, len(r.Keys()))
 }
 
 func TestGetBatchInfo(t *testing.T) {
@@ -432,8 +425,7 @@ func TestBatchCleanupIdempotenceKeyExpires(t *testing.T) {
 	defer rc.Close()
 
 	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
-	// Set a large deletion cutoff to keep the eventIDs in the idempotence set.
-	// Set a 5s TLL to ensure that after 5s of inactivity, the key is cleared.
+	// Set a 5s TTL on per-event idem keys to ensure they expire after inactivity.
 	// Disable buffer to test direct append behavior.
 	bm := NewRedisBatchManager(bc, nil, WithoutBuffer(), WithRedisBatchIdempotenceSetTTL(5), WithRedisBatchIdempotenceSetCleanupCutoff(300))
 
@@ -463,21 +455,21 @@ func TestBatchCleanupIdempotenceKeyExpires(t *testing.T) {
 	require.True(t, r.Exists(bc.KeyGenerator().Batch(context.Background(), fnId, ulid.MustParse(res.BatchID))))
 	require.True(t, r.Exists(bc.KeyGenerator().BatchMetadata(context.Background(), fnId, ulid.MustParse(res.BatchID))))
 	require.True(t, r.Exists(bc.KeyGenerator().BatchPointer(context.Background(), fnId)))
-	require.True(t, r.Exists(bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)))
+	// Per-event idem key: batch list + metadata + pointer + idem key = 4
 	require.Equal(t, 4, len(r.Keys()))
 
-	// DeleteKeys does not remove items from BatchIdempotenceKey sinc the cutoff is 5m.
+	// DeleteKeys removes batch list and metadata but not the per-event idem key (it has its own TTL).
 	err = bm.DeleteKeys(context.Background(), fnId, ulid.MustParse(res.BatchID))
 	require.NoError(t, err)
 	require.False(t, r.Exists(bc.KeyGenerator().Batch(context.Background(), fnId, ulid.MustParse(res.BatchID))))
 	require.False(t, r.Exists(bc.KeyGenerator().BatchMetadata(context.Background(), fnId, ulid.MustParse(res.BatchID))))
-	require.True(t, r.Exists(bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)))
 	require.True(t, r.Exists(bc.KeyGenerator().BatchPointer(context.Background(), fnId)))
+	// pointer + per-event idem key remain
 	require.Equal(t, 2, len(r.Keys()))
 
-	// TTL is set to 5s on every append, and the key should be gone after that even without an explicit DeleteKeys call.
+	// Per-event idem key TTL is 5s, should expire after that.
 	r.FastForward(6 * time.Second)
-	require.False(t, r.Exists(bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)))
+	// Only the batch pointer remains (no TTL on it)
 	require.Equal(t, 1, len(r.Keys()))
 }
 

--- a/pkg/execution/batch/lua/append.lua
+++ b/pkg/execution/batch/lua/append.lua
@@ -41,9 +41,9 @@ local resp = { status = "append", batchID = batchID, batchPointerKey = batchPoin
 --   * Batch
 --   * BatchMetadata
 local keyfmt = "%s:batches:%s"
-local idempotenceKeyFmt = "%s:batch_idempotence"
+local idemKeyFmt = "%s:batch_idem:%s"
+local legacyIdempotenceKeyFmt = "%s:batch_idempotence"
 local batchKey = string.format(keyfmt, prefix, batchID)
-local batchIdempotenceKey = string.format(idempotenceKeyFmt, prefix)
 local batchMetadataKey = string.format("%s:metadata", batchKey)
 
 -- set the batch status if it doesn't exist but don't overwrite
@@ -52,14 +52,17 @@ if is_status_empty(batchMetadataKey) then
   set_batch_status(batchMetadataKey, batchStatusAppending)
 end
 
--- check if event has already been appended to this batch
--- return early with status=exists if this event was already appended.
-local newEvent = redis.call("ZADD", batchIdempotenceKey, nowUnixSeconds, eventID)
-redis.call("EXPIRE", batchIdempotenceKey, idempotenceSetTTL)
-if newEvent == 0 then
-  -- if this event was already appended to a batch and there is only 
-  -- one element in the batch, return status=new to schedule this batch
-  -- for execution after the batch timeout.
+-- Dedup: per-event SET key (O(1)) with legacy sorted set fallback
+local idemKey = string.format(idemKeyFmt, prefix, eventID)
+local newEvent = redis.call("SET", idemKey, "1", "NX", "EX", idempotenceSetTTL)
+if not newEvent then newEvent = false end
+if newEvent then
+  local legacyKey = string.format(legacyIdempotenceKeyFmt, prefix)
+  -- TODO: Remove this legacy check. All old sorted sets should expire within 30 min after deploy.
+  -- It only exists to catch events written to the old ZSET before this change was rolled out.
+  if redis.call("ZSCORE", legacyKey, eventID) then newEvent = false end
+end
+if not newEvent then
   local size = redis.call("LLEN", batchKey)
   if size == 1 then
     resp = { status = "new", batchID = batchID, batchPointerKey = batchPointerKey }

--- a/pkg/execution/batch/lua/bulk_append.lua
+++ b/pkg/execution/batch/lua/bulk_append.lua
@@ -38,15 +38,15 @@ end
 
 -- start execution
 local batchID = get_or_create_batch_key(batchPointerKey)
-local isNewBatch = (batchID == newULID)
 
 -- NOTE: these need to be identical to the ones in the queue key generator
 --   * Batch
 --   * BatchMetadata
 local keyfmt = "%s:batches:%s"
-local idempotenceKeyFmt = "%s:batch_idempotence"
+local idemKeyFmt = "%s:batch_idem:%s"
+local legacyIdempotenceKeyFmt = "%s:batch_idempotence"
+local legacyIdempotenceKey = string.format(legacyIdempotenceKeyFmt, prefix)
 local batchKey = string.format(keyfmt, prefix, batchID)
-local batchIdempotenceKey = string.format(idempotenceKeyFmt, prefix)
 local batchMetadataKey = string.format("%s:metadata", batchKey)
 
 -- set the batch status if it doesn't exist but don't overwrite
@@ -55,7 +55,7 @@ if is_status_empty(batchMetadataKey) then
   set_batch_status(batchMetadataKey, batchStatusAppending)
 end
 
--- Collect all events and check for duplicates
+-- Dedup: per-event SET keys (O(1)) with legacy sorted set fallback
 local eventsToAdd = {}
 local duplicateCount = 0
 local argOffset = 11
@@ -64,17 +64,18 @@ for i = 1, eventCount do
   local eventID = ARGV[argOffset + (i - 1) * 2]
   local eventData = ARGV[argOffset + (i - 1) * 2 + 1]
 
-  -- check if event has already been appended
-  local newEvent = redis.call("ZADD", batchIdempotenceKey, "NX", nowUnixSeconds, eventID)
-  if newEvent == 0 then
-    duplicateCount = duplicateCount + 1
-  else
+  local idemKey = string.format(idemKeyFmt, prefix, eventID)
+  local newEvent = redis.call("SET", idemKey, "1", "NX", "EX", idempotenceSetTTL)
+  -- TODO: Remove this legacy check. All old sorted sets should expire within 30 min after deploy.
+  if newEvent and redis.call("ZSCORE", legacyIdempotenceKey, eventID) then
+    newEvent = false
+  end
+  if newEvent then
     table.insert(eventsToAdd, eventData)
+  else
+    duplicateCount = duplicateCount + 1
   end
 end
-
--- Update idempotence set TTL
-redis.call("EXPIRE", batchIdempotenceKey, idempotenceSetTTL)
 
 -- If all events were duplicates, return early
 if #eventsToAdd == 0 then

--- a/pkg/execution/batch/lua/bulk_append.lua
+++ b/pkg/execution/batch/lua/bulk_append.lua
@@ -66,6 +66,7 @@ for i = 1, eventCount do
 
   local idemKey = string.format(idemKeyFmt, prefix, eventID)
   local newEvent = redis.call("SET", idemKey, "1", "NX", "EX", idempotenceSetTTL)
+  if not newEvent then newEvent = false end
   -- TODO: Remove this legacy check. All old sorted sets should expire within 30 min after deploy.
   if newEvent and redis.call("ZSCORE", legacyIdempotenceKey, eventID) then
     newEvent = false


### PR DESCRIPTION
## Description
it would still be on the same shard but the idea is to avoid ZADD and
ZREMRANGEBYSCORE which are respectively O(log(N)) and O(log(N+M))
N being the number of elements in the sorted set.

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces the per-workflow-ID sorted set (`ZADD`/`ZREMRANGEBYSCORE`, O(log N)) with per-event `SET NX EX` keys (O(1)) for batch idempotency deduplication. Includes a legacy ZSCORE fallback to handle events written to the old sorted set before rollout, with a TODO to remove it after the old keys expire.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a64e1eb47d1441d24d34f69acc1326d54839ecb4.</sup>
<!-- /MENDRAL_SUMMARY -->