### PR TITLE
remove old zset idempotency key for batches

### DIFF
--- a/pkg/execution/batch/batch_test.go
+++ b/pkg/execution/batch/batch_test.go
@@ -479,55 +479,6 @@ func TestPerEventIdempotenceKeys(t *testing.T) {
 	require.Equal(t, enums.BatchAppend, res.Status)
 }
 
-// TestPerEventIdempotenceLegacyFallback verifies that events written to the legacy
-// sorted set before migration are still deduped via the ZSCORE fallback.
-func TestPerEventIdempotenceLegacyFallback(t *testing.T) {
-	r := miniredis.RunT(t)
-
-	rc, err := rueidis.NewClient(rueidis.ClientOption{
-		InitAddress:  []string{r.Addr()},
-		DisableCache: true,
-	})
-	require.NoError(t, err)
-	defer rc.Close()
-
-	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
-	bm := NewRedisBatchManager(bc, nil, WithoutBuffer())
-
-	fnId := uuid.New()
-	fn := inngest.Function{
-		ID: fnId,
-		EventBatch: &inngest.EventBatchConfig{
-			MaxSize: 100,
-			Timeout: "60s",
-		},
-	}
-
-	eventID := ulid.MustNew(ulid.Now(), rand.Reader)
-	bi := BatchItem{
-		AccountID:  uuid.New(),
-		FunctionID: fnId,
-		EventID:    eventID,
-		Event:      event.Event{ID: "test"},
-	}
-
-	// Simulate a legacy event by writing directly to the old sorted set
-	legacyKey := bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)
-	r.ZAdd(legacyKey, float64(time.Now().Unix()), eventID.String())
-
-	// Append the same event — should be rejected via legacy fallback
-	res, err := bm.Append(context.Background(), bi, fn)
-	require.NoError(t, err)
-	require.Equal(t, enums.BatchItemExists, res.Status)
-
-	// A different event should go through fine
-	bi2 := bi
-	bi2.EventID = ulid.MustNew(ulid.Now(), rand.Reader)
-	res, err = bm.Append(context.Background(), bi2, fn)
-	require.NoError(t, err)
-	require.Equal(t, enums.BatchNew, res.Status)
-}
-
 // TestPerEventIdempotenceBulkAppend verifies per-event dedup works in the bulk append path.
 func TestPerEventIdempotenceBulkAppend(t *testing.T) {
 	r := miniredis.RunT(t)
@@ -587,49 +538,6 @@ func TestPerEventIdempotenceBulkAppend(t *testing.T) {
 	require.Equal(t, 1, res.Duplicates)
 }
 
-// TestPerEventIdempotenceBulkAppendLegacyFallback verifies the legacy ZSCORE fallback
-// works in the bulk append path.
-func TestPerEventIdempotenceBulkAppendLegacyFallback(t *testing.T) {
-	r := miniredis.RunT(t)
-
-	rc, err := rueidis.NewClient(rueidis.ClientOption{
-		InitAddress:  []string{r.Addr()},
-		DisableCache: true,
-	})
-	require.NoError(t, err)
-	defer rc.Close()
-
-	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
-	mgr := NewRedisBatchManager(bc, nil, WithoutBuffer())
-	bm := mgr.(*redisBatchManager)
-
-	fnId := uuid.New()
-	fn := inngest.Function{
-		ID: fnId,
-		EventBatch: &inngest.EventBatchConfig{
-			MaxSize: 100,
-			Timeout: "60s",
-		},
-	}
-
-	legacyEventID := ulid.MustNew(ulid.Now(), rand.Reader)
-	newEventID := ulid.MustNew(ulid.Now(), rand.Reader)
-
-	// Simulate legacy event in the old sorted set
-	legacyKey := bc.KeyGenerator().BatchIdempotenceKey(context.Background(), fnId)
-	r.ZAdd(legacyKey, float64(time.Now().Unix()), legacyEventID.String())
-
-	items := []BatchItem{
-		{AccountID: uuid.New(), FunctionID: fnId, EventID: legacyEventID, Event: event.Event{ID: "legacy"}},
-		{AccountID: uuid.New(), FunctionID: fnId, EventID: newEventID, Event: event.Event{ID: "new"}},
-	}
-
-	res, err := bm.BulkAppend(context.Background(), items, fn)
-	require.NoError(t, err)
-	require.Equal(t, 1, res.Committed)
-	require.Equal(t, 1, res.Duplicates)
-}
-
 func TestBatchCleanupIdempotenceKeyExpires(t *testing.T) {
 	r := miniredis.RunT(t)
 
@@ -643,7 +551,7 @@ func TestBatchCleanupIdempotenceKeyExpires(t *testing.T) {
 	bc := redis_state.NewBatchClient(rc, redis_state.QueueDefaultKey)
 	// Set a 5s TTL on per-event idem keys to ensure they expire after inactivity.
 	// Disable buffer to test direct append behavior.
-	bm := NewRedisBatchManager(bc, nil, WithoutBuffer(), WithRedisBatchIdempotenceSetTTL(5), WithRedisBatchIdempotenceSetCleanupCutoff(300))
+	bm := NewRedisBatchManager(bc, nil, WithoutBuffer(), WithRedisBatchIdempotenceSetTTL(5))
 
 	accountId := uuid.New()
 	fnId := uuid.New()

--- a/pkg/execution/batch/lua/append.lua
+++ b/pkg/execution/batch/lua/append.lua
@@ -42,7 +42,6 @@ local resp = { status = "append", batchID = batchID, batchPointerKey = batchPoin
 --   * BatchMetadata
 local keyfmt = "%s:batches:%s"
 local idemKeyFmt = "%s:batch_idem:%s"
-local legacyIdempotenceKeyFmt = "%s:batch_idempotence"
 local batchKey = string.format(keyfmt, prefix, batchID)
 local batchMetadataKey = string.format("%s:metadata", batchKey)
 
@@ -52,16 +51,10 @@ if is_status_empty(batchMetadataKey) then
   set_batch_status(batchMetadataKey, batchStatusAppending)
 end
 
--- Dedup: per-event SET key (O(1)) with legacy sorted set fallback
+-- Dedup: per-event SET key (O(1))
 local idemKey = string.format(idemKeyFmt, prefix, eventID)
 local newEvent = redis.call("SET", idemKey, "1", "NX", "EX", idempotenceSetTTL)
 if not newEvent then newEvent = false end
-if newEvent then
-  local legacyKey = string.format(legacyIdempotenceKeyFmt, prefix)
-  -- TODO: Remove this legacy check. All old sorted sets should expire within 30 min after deploy.
-  -- It only exists to catch events written to the old ZSET before this change was rolled out.
-  if redis.call("ZSCORE", legacyKey, eventID) then newEvent = false end
-end
 if not newEvent then
   local size = redis.call("LLEN", batchKey)
   if size == 1 then

--- a/pkg/execution/batch/lua/bulk_append.lua
+++ b/pkg/execution/batch/lua/bulk_append.lua
@@ -44,8 +44,6 @@ local batchID = get_or_create_batch_key(batchPointerKey)
 --   * BatchMetadata
 local keyfmt = "%s:batches:%s"
 local idemKeyFmt = "%s:batch_idem:%s"
-local legacyIdempotenceKeyFmt = "%s:batch_idempotence"
-local legacyIdempotenceKey = string.format(legacyIdempotenceKeyFmt, prefix)
 local batchKey = string.format(keyfmt, prefix, batchID)
 local batchMetadataKey = string.format("%s:metadata", batchKey)
 
@@ -55,7 +53,7 @@ if is_status_empty(batchMetadataKey) then
   set_batch_status(batchMetadataKey, batchStatusAppending)
 end
 
--- Dedup: per-event SET keys (O(1)) with legacy sorted set fallback
+-- Dedup: per-event SET keys (O(1))
 local eventsToAdd = {}
 local duplicateCount = 0
 local argOffset = 11
@@ -67,10 +65,6 @@ for i = 1, eventCount do
   local idemKey = string.format(idemKeyFmt, prefix, eventID)
   local newEvent = redis.call("SET", idemKey, "1", "NX", "EX", idempotenceSetTTL)
   if not newEvent then newEvent = false end
-  -- TODO: Remove this legacy check. All old sorted sets should expire within 30 min after deploy.
-  if newEvent and redis.call("ZSCORE", legacyIdempotenceKey, eventID) then
-    newEvent = false
-  end
   if newEvent then
     table.insert(eventsToAdd, eventData)
   else

--- a/pkg/execution/batch/lua/drop_keys.lua
+++ b/pkg/execution/batch/lua/drop_keys.lua
@@ -2,11 +2,6 @@
 --- Deletes the provided keys
 ---
 
-local batchIdempotenceKey = ARGV[1] -- This key contains all event IDs that were appended for this function
-local maxScoreToDrop = ARGV[2] -- This key denotes max score to drop from the idempotence set
-
-redis.call("ZREMRANGEBYSCORE", batchIdempotenceKey, "-inf", maxScoreToDrop)
-
 for i, key in ipairs(KEYS) do
   if i > 0 then
     redis.call("DEL", key)

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -22,9 +22,8 @@ import (
 )
 
 const (
-	defaultBatchSizeLimit                = 10 * 1024 * 1024 // 10MiB
-	defaultEventIdempotenceCleanupCutOff = 120              // 120 seconds
-	defaultEventIdempotenceSetTTL        = 1800             // 30 minutes
+	defaultBatchSizeLimit         = 10 * 1024 * 1024 // 10MiB
+	defaultEventIdempotenceSetTTL = 1800             // 30 minutes
 )
 
 type RedisBatchManagerOpt func(m *redisBatchManager)
@@ -32,12 +31,6 @@ type RedisBatchManagerOpt func(m *redisBatchManager)
 func WithRedisBatchSizeLimit(l int) RedisBatchManagerOpt {
 	return func(m *redisBatchManager) {
 		m.sizeLimit = l
-	}
-}
-
-func WithRedisBatchIdempotenceSetCleanupCutoff(l int64) RedisBatchManagerOpt {
-	return func(m *redisBatchManager) {
-		m.idempotenceSetCleanupCutoffSeconds = l
 	}
 }
 
@@ -89,11 +82,10 @@ func WithoutBuffer() RedisBatchManagerOpt {
 // or [WithoutBuffer].
 func NewRedisBatchManager(b *redis_state.BatchClient, q queue.QueueManager, opts ...RedisBatchManagerOpt) BatchManager {
 	manager := &redisBatchManager{
-		b:                                  b,
-		q:                                  q,
-		sizeLimit:                          defaultBatchSizeLimit,
-		idempotenceSetCleanupCutoffSeconds: defaultEventIdempotenceCleanupCutOff,
-		idempotenceSetTTL:                  defaultEventIdempotenceSetTTL,
+		b:                 b,
+		q:                 q,
+		sizeLimit:         defaultBatchSizeLimit,
+		idempotenceSetTTL: defaultEventIdempotenceSetTTL,
 		log:                                logger.StdlibLogger(context.Background()),
 	}
 
@@ -113,10 +105,7 @@ type redisBatchManager struct {
 
 	// sizeLimit is the size limit that a batch can have
 	sizeLimit int
-	// All event IDs appended to a batch are tracked in a set to ensure idempotence to guard against processsing of duplicate eventIDs.
-	// This cutoff denotes the last X seconds of eventsIDs to keep active in the idempotence set.
-	idempotenceSetCleanupCutoffSeconds int64
-	// Every append call sets the TTL to this value to ensure that after this amount of inactivity, this set gets cleared.
+	// idempotenceSetTTL is the TTL in seconds for per-event idempotence keys.
 	idempotenceSetTTL int64
 	log               logger.Logger
 
@@ -347,21 +336,12 @@ func (b *redisBatchManager) DeleteKeys(ctx context.Context, functionId uuid.UUID
 		b.b.KeyGenerator().Batch(ctx, functionId, batchID),
 		b.b.KeyGenerator().BatchMetadata(ctx, functionId, batchID),
 	}
-	nowUnixSeconds := time.Now().Unix()
 
-	args, err := redis_state.StrSlice([]any{
-		b.b.KeyGenerator().BatchIdempotenceKey(ctx, functionId),
-		nowUnixSeconds - b.idempotenceSetCleanupCutoffSeconds,
-	})
-	if err != nil {
-		return fmt.Errorf("error constructing batch deletion: %w", err)
-	}
-
-	if _, err = retriableScripts["drop_keys"].Exec(
+	if _, err := retriableScripts["drop_keys"].Exec(
 		ctx,
 		b.b.Client(),
 		keys,
-		args,
+		[]string{},
 	).AsInt64(); err != nil {
 		return fmt.Errorf("failed to delete batch '%s' related keys: %v", batchID, err)
 	}


### PR DESCRIPTION
## Description

followup for the new batch idempotency key: https://github.com/inngest/inngest/pull/4001

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the legacy zset idempotency fallback that was introduced as a migration bridge in PR #4001. Cleans up the ZSCORE check in both `append.lua` and `bulk_append.lua`, removes the `ZREMRANGEBYSCORE` cleanup from `drop_keys.lua`, and deletes the now-unused `idempotenceSetCleanupCutoffSeconds` field and its option function from `redis.go`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit a89d666d0d726914f6b24472a1b822ab27d69791.</sup>
<!-- /MENDRAL_SUMMARY -->