### PR TITLE
make empty-state CTAs open replay/cancellation modals on the history pages

### DIFF
--- a/ui/apps/dashboard/src/components/Functions/CancellationTable.tsx
+++ b/ui/apps/dashboard/src/components/Functions/CancellationTable.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useState, type UIEventHandler } from 'react';
-import { useNavigate } from '@tanstack/react-router';
 import { Button } from '@inngest/components/Button';
 import {
   IDCell,
@@ -12,13 +11,13 @@ import {
   RiCloseCircleLine,
   RiDeleteBinLine,
   RiExternalLinkLine,
-  RiRefreshLine,
 } from '@remixicon/react';
 import { createColumnHelper } from '@tanstack/react-table';
 
+import { CancelFunctionModal } from './CancelFunction/CancelFunctionModal';
 import { DeleteCancellationModal } from './DeleteCancellationModal';
 import { useCancellations } from './useCancellations';
-import { pathCreator } from '@/utils/urls';
+import { useEnvironment } from '@/components/Environments/environment-context';
 
 type Cancellation = {
   createdAt: string;
@@ -41,8 +40,9 @@ type PendingDelete = {
 
 export function CancellationTable({ envSlug, fnSlug }: Props) {
   const [pendingDelete, setPendingDelete] = useState<PendingDelete>();
+  const [cancelOpen, setCancelOpen] = useState(false);
   const columns = useColumns({ setPendingDelete });
-  const navigate = useNavigate();
+  const env = useEnvironment();
 
   const {
     data: items,
@@ -80,20 +80,13 @@ export function CancellationTable({ envSlug, fnSlug }: Props) {
                 actions={
                   <>
                     <Button
-                      appearance="outlined"
-                      label="Refresh"
-                      onClick={() =>
-                        navigate({
-                          to: pathCreator.functionCancellations({
-                            envSlug,
-                            functionSlug: fnSlug,
-                          }),
-                        })
-                      }
-                      icon={<RiRefreshLine />}
+                      label="New cancellation"
+                      onClick={() => setCancelOpen(true)}
+                      icon={<RiCloseCircleLine />}
                       iconSide="left"
                     />
                     <Button
+                      appearance="outlined"
                       label="Go to docs"
                       href="https://www.inngest.com/docs/platform/manage/bulk-cancellation"
                       target="_blank"
@@ -114,6 +107,14 @@ export function CancellationTable({ envSlug, fnSlug }: Props) {
         onClose={() => setPendingDelete(undefined)}
         pendingDelete={pendingDelete}
       />
+      {cancelOpen && (
+        <CancelFunctionModal
+          envID={env.id}
+          functionSlug={fnSlug}
+          isOpen={cancelOpen}
+          onClose={() => setCancelOpen(false)}
+        />
+      )}
     </>
   );
 }

--- a/ui/apps/dashboard/src/components/Functions/ReplayList.tsx
+++ b/ui/apps/dashboard/src/components/Functions/ReplayList.tsx
@@ -17,7 +17,6 @@ import { createColumnHelper } from '@tanstack/react-table';
 import { useEnvironment } from '@/components/Environments/environment-context';
 import { useGetReplays } from '@/components/Replay/useGetReplay';
 import NewReplayModal from '@/components/Replay/NewReplayModal';
-import { useFunction } from '@/queries/functions';
 import { pathCreator } from '@/utils/urls';
 import { useNavigate } from '@tanstack/react-router';
 
@@ -98,18 +97,15 @@ const columns = [
 
 type Props = {
   functionSlug: string;
+  disableNewReplay?: boolean;
 };
 
-export function ReplayList({ functionSlug }: Props) {
+export function ReplayList({ functionSlug, disableNewReplay = false }: Props) {
   const environment = useEnvironment();
   const navigate = useNavigate();
   const [replayOpen, setReplayOpen] = useState(false);
 
   const { isLoading, error, data: replays } = useGetReplays(functionSlug);
-  const [{ data: fnData }] = useFunction({ functionSlug });
-  const fn = fnData?.workspace.workflow;
-  const isArchived = fn?.isArchived ?? false;
-  const isPaused = fn?.isPaused ?? false;
 
   if (error) {
     throw error;
@@ -139,7 +135,7 @@ export function ReplayList({ functionSlug }: Props) {
                 <Button
                   label="New replay"
                   onClick={() => setReplayOpen(true)}
-                  disabled={isArchived || isPaused}
+                  disabled={disableNewReplay}
                   icon={<IconReplay />}
                   iconSide="left"
                 />

--- a/ui/apps/dashboard/src/components/Functions/ReplayList.tsx
+++ b/ui/apps/dashboard/src/components/Functions/ReplayList.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Button } from '@inngest/components/Button';
 import {
   NumberCell,
@@ -10,11 +11,13 @@ import {
 import { IconReplay } from '@inngest/components/icons/Replay';
 import { ReplayStatus, type Replay } from '@inngest/components/types/replay';
 import { formatMilliseconds } from '@inngest/components/utils/date';
-import { RiExternalLinkLine, RiRefreshLine } from '@remixicon/react';
+import { RiExternalLinkLine } from '@remixicon/react';
 import { createColumnHelper } from '@tanstack/react-table';
 
 import { useEnvironment } from '@/components/Environments/environment-context';
 import { useGetReplays } from '@/components/Replay/useGetReplay';
+import NewReplayModal from '@/components/Replay/NewReplayModal';
+import { useFunction } from '@/queries/functions';
 import { pathCreator } from '@/utils/urls';
 import { useNavigate } from '@tanstack/react-router';
 
@@ -100,58 +103,66 @@ type Props = {
 export function ReplayList({ functionSlug }: Props) {
   const environment = useEnvironment();
   const navigate = useNavigate();
+  const [replayOpen, setReplayOpen] = useState(false);
 
   const { isLoading, error, data: replays } = useGetReplays(functionSlug);
+  const [{ data: fnData }] = useFunction({ functionSlug });
+  const fn = fnData?.workspace.workflow;
+  const isArchived = fn?.isArchived ?? false;
+  const isPaused = fn?.isPaused ?? false;
 
   if (error) {
     throw error;
   }
 
   return (
-    <Table
-      data={replays}
-      columns={columns}
-      isLoading={isLoading}
-      onRowClick={(row) =>
-        navigate({
-          to: pathCreator.functionReplay({
-            envSlug: environment.slug,
-            functionSlug,
-            replayID: row.original.id,
-          }),
-        })
-      }
-      blankState={
-        <TableBlankState
-          title="No replays found"
-          icon={<IconReplay />}
-          actions={
-            <>
-              <Button
-                appearance="outlined"
-                label="Refresh"
-                onClick={() =>
-                  navigate({
-                    to: pathCreator.functionReplays({
-                      envSlug: environment.slug,
-                      functionSlug,
-                    }),
-                  })
-                }
-                icon={<RiRefreshLine />}
-                iconSide="left"
-              />
-              <Button
-                label="Go to docs"
-                href="https://inngest.com/docs/platform/replay"
-                target="_blank"
-                icon={<RiExternalLinkLine />}
-                iconSide="left"
-              />
-            </>
-          }
+    <>
+      <Table
+        data={replays}
+        columns={columns}
+        isLoading={isLoading}
+        onRowClick={(row) =>
+          navigate({
+            to: pathCreator.functionReplay({
+              envSlug: environment.slug,
+              functionSlug,
+              replayID: row.original.id,
+            }),
+          })
+        }
+        blankState={
+          <TableBlankState
+            title="No replays found"
+            icon={<IconReplay />}
+            actions={
+              <>
+                <Button
+                  label="New replay"
+                  onClick={() => setReplayOpen(true)}
+                  disabled={isArchived || isPaused}
+                  icon={<IconReplay />}
+                  iconSide="left"
+                />
+                <Button
+                  appearance="outlined"
+                  label="Go to docs"
+                  href="https://inngest.com/docs/platform/replay"
+                  target="_blank"
+                  icon={<RiExternalLinkLine />}
+                  iconSide="left"
+                />
+              </>
+            }
+          />
+        }
+      />
+      {replayOpen && (
+        <NewReplayModal
+          isOpen={replayOpen}
+          functionSlug={functionSlug}
+          onClose={() => setReplayOpen(false)}
         />
-      }
-    />
+      )}
+    </>
   );
 }

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/functions/$slug/replays/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/functions/$slug/replays/index.tsx
@@ -44,7 +44,10 @@ function RouteComponent() {
         </div>
       )}
       <div className="h-full overflow-y-auto">
-        <ReplayList functionSlug={functionSlug} />
+        <ReplayList
+          functionSlug={functionSlug}
+          disableNewReplay={env.isArchived || functionIsPaused}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
## Description
Replace the low-signal "Refresh" button on the Replays and Cancellations history tabs with primary CTAs that open the existing NewReplayModal and CancelFunctionModal directly, so users can start the flow from the empty state instead of routing through the Actions menu. "Go to docs" becomes the secondary action.

Before
<img width="1698" height="935" alt="Screenshot 2026-04-16 at 22 54 56" src="https://github.com/user-attachments/assets/79389c90-f5dd-4c9d-9005-d20185f8b62f" />
<img width="1693" height="930" alt="Screenshot 2026-04-16 at 22 54 48" src="https://github.com/user-attachments/assets/f06effbe-41de-4e7c-9bd7-f4bca28df74d" />

After
<img width="1694" height="530" alt="Screenshot 2026-04-16 at 23 10 31" src="https://github.com/user-attachments/assets/9a50df94-731f-4128-8ef8-c5e499d1b520" />
<img width="1697" height="502" alt="Screenshot 2026-04-16 at 23 11 07" src="https://github.com/user-attachments/assets/7d4c5e4b-ae3a-4778-a8f0-a00bb10da922" />


## Motivation
QoL

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces the low-signal "Refresh" button on the Replays and Cancellations empty-state tables with primary CTAs that open the existing NewReplayModal and CancelFunctionModal directly. A follow-up commit lifts the archived/paused check to the route level, passing it as a `disableNewReplay` prop to avoid an extra `useFunction` query inside ReplayList.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 88c166916195995ffabe054999d8f6403864d8dc.</sup>
<!-- /MENDRAL_SUMMARY -->