### PR TITLE
Add HTTP Basic Auth for self-hosted dashboard

### DIFF
--- a/cmd/internal/config/config.go
+++ b/cmd/internal/config/config.go
@@ -37,6 +37,10 @@ type Config struct {
 	SigningKey string   `koanf:"signing-key"`
 	EventKey   []string `koanf:"event-key"`
 
+	// Dashboard HTTP Basic Auth (self-hosted)
+	DashboardUsername string `koanf:"dashboard-username"`
+	DashboardPassword string `koanf:"dashboard-password"`
+
 	// Database configuration
 	RedisURI                string `koanf:"redis-uri"`
 	PostgresURI             string `koanf:"postgres-uri"`

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -120,6 +120,20 @@ func Command() *cli.Command {
 				Name:     "no-ui",
 				Usage:    "Disable the web UI and GraphQL API endpoint",
 			},
+
+			// Dashboard authentication flags. Env vars INNGEST_DASHBOARD_USERNAME
+			// and INNGEST_DASHBOARD_PASSWORD are picked up via the shared koanf
+			// loader.
+			&cli.StringFlag{
+				Category: "Dashboard Auth",
+				Name:     "dashboard-username",
+				Usage:    "Username required to access the dashboard via HTTP Basic Auth. Must be set together with --dashboard-password. When empty, no browser auth is required.",
+			},
+			&cli.StringFlag{
+				Category: "Dashboard Auth",
+				Name:     "dashboard-password",
+				Usage:    "Password required to access the dashboard via HTTP Basic Auth. Must be set together with --dashboard-username. When empty, no browser auth is required.",
+			},
 		},
 	}
 

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -122,10 +122,19 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	connectGatewayGRPCPort := localconfig.GetIntValue(cmd, "connect-gateway-grpc-port", devserver.DefaultConnectGatewayGRPCPort)
 	connectExecutorGRPCPort := localconfig.GetIntValue(cmd, "connect-executor-grpc-port", devserver.DefaultConnectExecutorGRPCPort)
 
+	dashboardUsername := localconfig.GetValue(cmd, "dashboard-username", "")
+	dashboardPassword := localconfig.GetValue(cmd, "dashboard-password", "")
+	if (dashboardUsername == "") != (dashboardPassword == "") {
+		fmt.Println("Error: dashboard-username and dashboard-password must both be set to enable dashboard auth")
+		os.Exit(1)
+	}
+
 	opts := devserver.StartOpts{
 		Config:                  *conf,
 		ConnectGatewayHost:      conf.CoreAPI.Addr,
 		ConnectGatewayPort:      connectGatewayPort,
+		DashboardUsername:       dashboardUsername,
+		DashboardPassword:       dashboardPassword,
 		EventKeys:               eventKeys,
 		NoUI:                    localconfig.GetBoolValue(cmd, "no-ui", false),
 		Persist:                 true,

--- a/pkg/authn/basic_auth.go
+++ b/pkg/authn/basic_auth.go
@@ -1,0 +1,37 @@
+// StrategyBasicAuth provides HTTP Basic Authentication for protecting the
+// self-hosted dashboard in a browser.
+package authn
+
+import (
+	"crypto/subtle"
+	"net/http"
+)
+
+// BasicAuthMiddleware returns middleware that challenges the browser with
+// HTTP Basic Auth. If either username or password is empty, the middleware
+// is a no-op so self-hosted deployments without credentials configured are
+// unaffected.
+func BasicAuthMiddleware(username, password, realm string) func(http.Handler) http.Handler {
+	if realm == "" {
+		realm = "Inngest"
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if username == "" || password == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			u, p, ok := r.BasicAuth()
+			userMatch := subtle.ConstantTimeCompare([]byte(u), []byte(username)) == 1
+			passMatch := subtle.ConstantTimeCompare([]byte(p), []byte(password)) == 1
+			if !ok || !userMatch || !passMatch {
+				w.Header().Set("WWW-Authenticate", `Basic realm="`+realm+`", charset="UTF-8"`)
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/authn/basic_auth_test.go
+++ b/pkg/authn/basic_auth_test.go
@@ -1,0 +1,100 @@
+package authn
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBasicAuthMiddleware(t *testing.T) {
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	t.Run("no-op when credentials are not configured", func(t *testing.T) {
+		mw := BasicAuthMiddleware("", "", "")
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		mw(okHandler).ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("no-op when only username is set", func(t *testing.T) {
+		mw := BasicAuthMiddleware("admin", "", "")
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		mw(okHandler).ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200 when password empty, got %d", rec.Code)
+		}
+	})
+
+	t.Run("challenges request without credentials", func(t *testing.T) {
+		mw := BasicAuthMiddleware("admin", "secret", "Inngest Dashboard")
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		mw(okHandler).ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401, got %d", rec.Code)
+		}
+		auth := rec.Header().Get("WWW-Authenticate")
+		if !strings.Contains(auth, `realm="Inngest Dashboard"`) {
+			t.Fatalf("expected WWW-Authenticate to include realm, got %q", auth)
+		}
+	})
+
+	t.Run("rejects invalid credentials", func(t *testing.T) {
+		mw := BasicAuthMiddleware("admin", "secret", "")
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("admin", "wrong")
+		mw(okHandler).ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401 for invalid password, got %d", rec.Code)
+		}
+	})
+
+	t.Run("rejects wrong username", func(t *testing.T) {
+		mw := BasicAuthMiddleware("admin", "secret", "")
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("wrong", "secret")
+		mw(okHandler).ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("expected 401 for invalid user, got %d", rec.Code)
+		}
+	})
+
+	t.Run("passes valid credentials", func(t *testing.T) {
+		mw := BasicAuthMiddleware("admin", "secret", "")
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.SetBasicAuth("admin", "secret")
+		mw(okHandler).ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rec.Code)
+		}
+	})
+
+	t.Run("defaults realm when not provided", func(t *testing.T) {
+		mw := BasicAuthMiddleware("admin", "secret", "")
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		mw(okHandler).ServeHTTP(rec, req)
+
+		auth := rec.Header().Get("WWW-Authenticate")
+		if !strings.Contains(auth, `realm="Inngest"`) {
+			t.Fatalf("expected default realm, got %q", auth)
+		}
+	})
+}

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -49,6 +49,11 @@ type devapi struct {
 type DevAPIOptions struct {
 	disableUI      bool
 	AuthMiddleware func(http.Handler) http.Handler
+	// DashboardAuthMiddleware is applied to the browser-facing dashboard
+	// routes (SPA + static assets) so self-hosted deployments can require
+	// HTTP Basic Auth for dashboard access without impacting SDK-facing
+	// endpoints.
+	DashboardAuthMiddleware func(http.Handler) http.Handler
 }
 
 func NewDevAPI(d *devserver, o DevAPIOptions) chi.Router {
@@ -58,11 +63,11 @@ func NewDevAPI(d *devserver, o DevAPIOptions) chi.Router {
 		devserver: d,
 		disableUI: o.disableUI,
 	}
-	api.addRoutes(o.AuthMiddleware)
+	api.addRoutes(o.AuthMiddleware, o.DashboardAuthMiddleware)
 	return api
 }
 
-func (a *devapi) addRoutes(AuthMiddleware func(http.Handler) http.Handler) {
+func (a *devapi) addRoutes(AuthMiddleware func(http.Handler) http.Handler, DashboardAuthMiddleware func(http.Handler) http.Handler) {
 	a.Use(func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			l := a.devserver.log.With("caller", a.devserver.Name())
@@ -96,15 +101,29 @@ func (a *devapi) addRoutes(AuthMiddleware func(http.Handler) http.Handler) {
 		//
 		// Create filesystem rooted at static/client for Tanstack assets
 		staticFS, _ := fs.Sub(static, "static/client")
-		a.Get("/images/*", http.FileServer(http.FS(staticFS)).ServeHTTP)
-		a.Get("/assets/*", http.FileServer(http.FS(staticFS)).ServeHTTP)
-		a.Get("/{file}.txt", http.FileServer(http.FS(staticFS)).ServeHTTP)
-		a.Get("/{file}.svg", http.FileServer(http.FS(staticFS)).ServeHTTP)
-		a.Get("/{file}.jpg", http.FileServer(http.FS(staticFS)).ServeHTTP)
-		a.Get("/{file}.png", http.FileServer(http.FS(staticFS)).ServeHTTP)
+		staticHandler := http.FileServer(http.FS(staticFS))
+		uiHandler := http.HandlerFunc(a.UI)
+
+		// When a dashboard auth middleware is configured (HTTP Basic Auth for
+		// self-hosted deployments), wrap the browser-facing routes so users
+		// cannot load the dashboard without valid credentials. The middleware
+		// is a no-op when credentials are not configured.
+		var staticServe http.Handler = staticHandler
+		var uiServe http.Handler = uiHandler
+		if DashboardAuthMiddleware != nil {
+			staticServe = DashboardAuthMiddleware(staticHandler)
+			uiServe = DashboardAuthMiddleware(uiHandler)
+		}
+
+		a.Get("/images/*", staticServe.ServeHTTP)
+		a.Get("/assets/*", staticServe.ServeHTTP)
+		a.Get("/{file}.txt", staticServe.ServeHTTP)
+		a.Get("/{file}.svg", staticServe.ServeHTTP)
+		a.Get("/{file}.jpg", staticServe.ServeHTTP)
+		a.Get("/{file}.png", staticServe.ServeHTTP)
 		//
 		// Everything else loads the UI (SPA fallback)
-		a.NotFound(a.UI)
+		a.NotFound(uiServe.ServeHTTP)
 	}
 }
 

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -137,6 +137,12 @@ type StartOpts struct {
 
 	NoUI bool
 
+	// DashboardUsername and DashboardPassword enable HTTP Basic Auth for the
+	// self-hosted dashboard (UI + static assets). When either is empty, no
+	// browser auth is enforced. SDK-facing endpoints are unaffected.
+	DashboardUsername string `json:"-"`
+	DashboardPassword string `json:"-"`
+
 	// Persist controls whether to persist data in between restarts.  If false,
 	// the dev server will use in-memory databases.
 	Persist bool `json:"persist"`
@@ -605,7 +611,12 @@ func start(ctx context.Context, opts StartOpts) error {
 	// start the API
 	// Create a new API endpoint which hosts SDK-related functionality for
 	// registering functions.
-	devAPI := NewDevAPI(ds, DevAPIOptions{AuthMiddleware: authn.SigningKeyMiddleware(opts.SigningKey), disableUI: opts.NoUI})
+	dashboardAuth := authn.BasicAuthMiddleware(opts.DashboardUsername, opts.DashboardPassword, "Inngest Dashboard")
+	devAPI := NewDevAPI(ds, DevAPIOptions{
+		AuthMiddleware:          authn.SigningKeyMiddleware(opts.SigningKey),
+		DashboardAuthMiddleware: dashboardAuth,
+		disableUI:               opts.NoUI,
+	})
 
 	// Add MCP server route
 	AddMCPRoute(devAPI, ds.HandleEvent, ds.Data, opts.Tick)


### PR DESCRIPTION
## Description

Adds HTTP Basic Authentication support for the self-hosted dashboard (UI and static assets) without affecting SDK-facing endpoints. This allows self-hosted deployments to require credentials for browser access while keeping the API open for SDK clients.

The implementation includes:
- New `BasicAuthMiddleware` in `pkg/authn/basic_auth.go` that validates HTTP Basic Auth credentials
- Configuration flags `--dashboard-username` and `--dashboard-password` for the `inngest start` command
- Separate `DashboardAuthMiddleware` option in `DevAPIOptions` to apply auth only to browser-facing routes
- Validation to ensure both username and password are set together

The middleware is a no-op when credentials are not configured, ensuring existing deployments are unaffected.

## Motivation

Self-hosted deployments need a way to protect the dashboard from unauthorized browser access in shared or public environments, while maintaining open access to SDK-facing endpoints for function registration and event handling.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I've tested my own changes.
- [x] Added comprehensive unit tests for `BasicAuthMiddleware` covering all scenarios (no credentials, invalid credentials, valid credentials, realm handling)

https://claude.ai/code/session_01LHS7Ddnd5hFWnmBPjSsKy6

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds HTTP Basic Auth for the self-hosted dashboard UI and static assets via new `--dashboard-username` / `--dashboard-password` flags on `inngest start`. SDK-facing endpoints are unaffected. A new `BasicAuthMiddleware` in `pkg/authn` uses `subtle.ConstantTimeCompare` and is wired as a separate `DashboardAuthMiddleware` in `DevAPIOptions`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c4adf5a8c74b35941cb7d6787a5bcd1ce3ad2a18.</sup>
<!-- /MENDRAL_SUMMARY -->