### PR TITLE
Add minimum cron jitter of 1s

### DIFF
--- a/pkg/execution/cron/cron.go
+++ b/pkg/execution/cron/cron.go
@@ -85,17 +85,18 @@ func (i CronItem) SyncID() string {
 	return fmt.Sprintf("%s:sync", i.ID)
 }
 
-// DeterministicJitter returns a stable jitter duration in (0, max] derived from
+// DeterministicJitter returns a stable jitter duration in [min, max) derived from
 // the given seed string using xxhash. The same seed always produces the same result.
-// The result is always at least 1ns so that jittered times are strictly after the
-// canonical boundary.
-func DeterministicJitter(seed string, max time.Duration) time.Duration {
-	if max <= 0 {
-		return 0
+func DeterministicJitter(seed string, min, max time.Duration) time.Duration {
+	if max <= 0 || max <= min {
+		return min
 	}
 
-	rangeNs := uint64(max / time.Nanosecond)
-	return time.Duration(xxhash.Sum64String(seed)%rangeNs) + 1
+	rangeNs := uint64((max - min) / time.Nanosecond)
+	if rangeNs == 0 {
+		return min
+	}
+	return min + time.Duration(xxhash.Sum64String(seed)%rangeNs)
 }
 
 type CronHealthCheckStatus struct {

--- a/pkg/execution/cron/cron_test.go
+++ b/pkg/execution/cron/cron_test.go
@@ -12,17 +12,23 @@ import (
 )
 
 func TestDeterministicJitter(t *testing.T) {
-	t.Run("returns zero for non-positive max", func(t *testing.T) {
-		assert.Zero(t, DeterministicJitter("seed", 0))
+	t.Run("returns min when max is non-positive", func(t *testing.T) {
+		assert.Equal(t, time.Second, DeterministicJitter("seed", time.Second, 0))
 	})
 
-	t.Run("is stable for the same seed and bounded by max", func(t *testing.T) {
-		j1 := DeterministicJitter("same-seed", 5*time.Minute)
-		j2 := DeterministicJitter("same-seed", 5*time.Minute)
+	t.Run("returns min when max equals min", func(t *testing.T) {
+		assert.Equal(t, time.Second, DeterministicJitter("seed", time.Second, time.Second))
+	})
+
+	t.Run("is stable for the same seed and bounded by [min, max)", func(t *testing.T) {
+		min := time.Second
+		max := 5 * time.Minute
+		j1 := DeterministicJitter("same-seed", min, max)
+		j2 := DeterministicJitter("same-seed", min, max)
 
 		assert.Equal(t, j1, j2)
-		assert.Greater(t, j1, time.Duration(0))
-		assert.LessOrEqual(t, j1, 5*time.Minute)
+		assert.GreaterOrEqual(t, j1, min)
+		assert.Less(t, j1, max)
 	})
 }
 

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -1061,7 +1061,7 @@ func (s *svc) handleCron(ctx context.Context, item queue.Item) error {
 			l.Error("CronItem.JobID is empty, using fallback seed for jitter")
 			jobID = fmt.Sprintf("%s:%s:%d", ci.FunctionID, ci.Expression, scheduledAt.UnixMilli())
 		}
-		fireAt = scheduledAt.Add(cron.DeterministicJitter(jobID, jitter))
+		fireAt = scheduledAt.Add(cron.DeterministicJitter(jobID, inngest.MinCronJitter, jitter))
 	}
 
 	l = l.With("jitter", jitter, "fireAt", fireAt)

--- a/pkg/inngest/function_test.go
+++ b/pkg/inngest/function_test.go
@@ -498,6 +498,13 @@ func TestCronTriggerValidate(t *testing.T) {
 		require.ErrorContains(t, err, "greater than or equal to zero")
 	})
 
+	t.Run("rejects jitter below minimum", func(t *testing.T) {
+		jitter := "500ms"
+		err := (CronTrigger{Cron: "0 9 * * *", Jitter: &jitter}).Validate(ctx)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "at least")
+	})
+
 	t.Run("rejects jitter above hard cap", func(t *testing.T) {
 		jitter := "25h"
 		err := (CronTrigger{Cron: "0 9 * * *", Jitter: &jitter}).Validate(ctx)

--- a/pkg/inngest/trigger.go
+++ b/pkg/inngest/trigger.go
@@ -20,6 +20,8 @@ import (
 const (
 	MaxCronLength      = 255
 	MaxEventNameLength = 255
+	// MinCronJitter ensures jitter is large enough to be visible at second precision (RFC3339).
+	MinCronJitter = 1 * time.Second
 	// MaxCronJitter is intentionally conservative for v1. Can be raised based on user feedback.
 	MaxCronJitter = 5 * time.Minute
 )
@@ -220,6 +222,9 @@ func (c CronTrigger) Validate(ctx context.Context) error {
 	}
 	if jitter < 0 {
 		return fmt.Errorf("cron jitter must be greater than or equal to zero")
+	}
+	if jitter > 0 && jitter < MinCronJitter {
+		return fmt.Errorf("cron jitter must be at least %s", MinCronJitter)
 	}
 	if jitter > MaxCronJitter {
 		return fmt.Errorf("cron jitter must be less than or equal to %s", MaxCronJitter)

--- a/tests/golang/cron_test.go
+++ b/tests/golang/cron_test.go
@@ -321,7 +321,7 @@ func TestCronJitter(t *testing.T) {
 			// assert that scheduledAt < fireAt <= scheduledAt + jitterDuration,
 			// and that the function actually executes no later than fireAt + tolerance
 			assert.True(t, fireAt.After(scheduledAt), "fireAt %s should be after scheduledAt %s (jitter should be applied)", fireAt, scheduledAt)
-			assert.True(t, !fireAt.After(scheduledAt.Add(jitterDuration)), "fireAt %s should be within %s jitter of scheduledAt %s", fireAt, jitterDuration, scheduledAt)
+			assert.True(t, fireAt.Before(scheduledAt.Add(jitterDuration)), "fireAt %s should be within %s jitter of scheduledAt %s", fireAt, jitterDuration, scheduledAt)
 			assert.True(t, !executedAtTime.Before(scheduledAt), "executedAt %s should not be before scheduledAt %s", executedAtTime, scheduledAt)
 			tolerance := 10 * time.Second
 			assert.True(t, !executedAtTime.After(fireAt.Add(tolerance)), "executedAt %s should not be too much after fireAt %s (tolerance %s)", executedAtTime, fireAt, tolerance)


### PR DESCRIPTION
## Description

Enforce MinCronJitter at validation to ensure jitter is visible at second precision (RFC3339). DeterministicJitter now returns values in [min, max) instead of [0, max).

## Motivation

The Mendral PR (#4011) suggested switching to RFC3339Nano timestamps to fix a flaky test. Its more straightforward to clamp minimum jitter to 1 second and keep timestamps at second precision.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Enforces a 1-second minimum cron jitter at validation time (`MinCronJitter = 1s`) so that jitter is always visible at RFC3339 second precision. `DeterministicJitter` is updated to accept an explicit `min` parameter and now returns values in `[min, max)` instead of `(0, max]`. The integration test assertion is tightened from `!fireAt.After(...)` (≤) to `fireAt.Before(...)` (<) to match the new exclusive-upper-bound contract.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 06482402f79eb811e36fc355fdda94b0f37dedad.</sup>
<!-- /MENDRAL_SUMMARY -->