### PR TITLE
Fix GetSpanOutput missing run ID filter

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -428,7 +428,7 @@ fragmentLoop:
 
 	// If this span has finished, set a preliminary output ID.
 	if (outputSpanID != nil && *outputSpanID != "") || (inputSpanID != nil && *inputSpanID != "") {
-		newSpan.OutputID, err = encodeSpanOutputID(outputSpanID, inputSpanID)
+		newSpan.OutputID, err = encodeSpanOutputID(newSpan.RunID.String(), outputSpanID, inputSpanID)
 		if err != nil {
 			logger.StdlibLogger(ctx).Error("error encoding span identifier", "error", err)
 			return nil, err
@@ -511,7 +511,7 @@ func mapRootSpansFromRows[T normalizedSpan](ctx context.Context, spans []T) (*cq
 			if targetSpanID, ok := outputDynamicRefs[*spanRefStr]; ok {
 				// We've found the span ID that we need to target for
 				// this span. So let's use it!
-				span.OutputID, err = encodeSpanOutputID(targetSpanID, nil)
+				span.OutputID, err = encodeSpanOutputID(span.RunID.String(), targetSpanID, nil)
 				if err != nil {
 					logger.StdlibLogger(ctx).Error("error encoding span output ID", "error", err)
 					return nil, err
@@ -691,7 +691,7 @@ func walkMetadataSize(span *cqrs.OtelSpan, total *int) {
 	}
 }
 
-func encodeSpanOutputID(outputSpanID *string, inputSpanID *string) (*string, error) {
+func encodeSpanOutputID(runID string, outputSpanID *string, inputSpanID *string) (*string, error) {
 	p := true
 	osid := ""
 	if outputSpanID != nil {
@@ -699,6 +699,7 @@ func encodeSpanOutputID(outputSpanID *string, inputSpanID *string) (*string, err
 	}
 
 	id := &cqrs.SpanIdentifier{
+		RunID:       runID,
 		SpanID:      osid,
 		InputSpanID: inputSpanID,
 		Preview:     &p,
@@ -1910,7 +1911,11 @@ func (w wrapper) GetSpanOutput(ctx context.Context, opts cqrs.SpanIdentifier) (*
 		return nil, fmt.Errorf("span ID or input span ID is required to retrieve output")
 	}
 
-	rows, err := w.q.GetSpanOutput(ctx, ids)
+	if opts.RunID == "" {
+		return nil, fmt.Errorf("run ID is required to retrieve span output")
+	}
+
+	rows, err := w.q.GetSpanOutput(ctx, opts.RunID, ids)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving span output: %w", err)
 	}

--- a/pkg/cqrs/base_cqrs/cqrs_test.go
+++ b/pkg/cqrs/base_cqrs/cqrs_test.go
@@ -1785,7 +1785,7 @@ func TestSpanOutputReadBack(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	out, err := cm.GetSpanOutput(t.Context(), cqrs.SpanIdentifier{SpanID: spanID})
+	out, err := cm.GetSpanOutput(t.Context(), cqrs.SpanIdentifier{RunID: runID, SpanID: spanID})
 	require.NoError(t, err)
 	require.NotNil(t, out)
 	// After the data/error unwrapping in GetSpanOutput, "data" key is extracted

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/db_normalization.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/db_normalization.go
@@ -840,8 +840,11 @@ func (q NormalizedQueries) GetSpanBySpanID(ctx context.Context, args sqlc_sqlite
 	return row.ToSQLite()
 }
 
-func (q NormalizedQueries) GetSpanOutput(ctx context.Context, spanIds []string) ([]*sqlc_sqlite.GetSpanOutputRow, error) {
-	rows, err := q.db.GetSpanOutput(ctx, spanIds)
+func (q NormalizedQueries) GetSpanOutput(ctx context.Context, arg sqlc_sqlite.GetSpanOutputParams) ([]*sqlc_sqlite.GetSpanOutputRow, error) {
+	rows, err := q.db.GetSpanOutput(ctx, GetSpanOutputParams{
+		RunID: arg.RunID,
+		Ids:   arg.Ids,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
@@ -447,7 +447,7 @@ SELECT
   input,
   output
 FROM spans
-WHERE span_id IN (SELECT UNNEST(sqlc.slice('ids')::TEXT[]))
+WHERE run_id = sqlc.arg(run_id)::CHAR(26) AND span_id IN (SELECT UNNEST(sqlc.slice('ids')::TEXT[]))
 LIMIT 2;
 
 -- name: GetRunSpanByRunID :one

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql.go
@@ -1247,17 +1247,22 @@ SELECT
   input,
   output
 FROM spans
-WHERE span_id IN (SELECT UNNEST($1::TEXT[]))
+WHERE run_id = $1::CHAR(26) AND span_id IN (SELECT UNNEST($2::TEXT[]))
 LIMIT 2
 `
+
+type GetSpanOutputParams struct {
+	RunID string
+	Ids   []string
+}
 
 type GetSpanOutputRow struct {
 	Input  pqtype.NullRawMessage
 	Output pqtype.NullRawMessage
 }
 
-func (q *Queries) GetSpanOutput(ctx context.Context, ids []string) ([]*GetSpanOutputRow, error) {
-	rows, err := q.db.QueryContext(ctx, getSpanOutput, pq.Array(ids))
+func (q *Queries) GetSpanOutput(ctx context.Context, arg GetSpanOutputParams) ([]*GetSpanOutputRow, error) {
+	rows, err := q.db.QueryContext(ctx, getSpanOutput, arg.RunID, pq.Array(arg.Ids))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/querier.go
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/querier.go
@@ -50,7 +50,7 @@ type Querier interface {
 	GetQueueSnapshotChunks(ctx context.Context, snapshotID interface{}) ([]*GetQueueSnapshotChunksRow, error)
 	GetRunSpanByRunID(ctx context.Context, arg GetRunSpanByRunIDParams) (*GetRunSpanByRunIDRow, error)
 	GetSpanBySpanID(ctx context.Context, arg GetSpanBySpanIDParams) (*GetSpanBySpanIDRow, error)
-	GetSpanOutput(ctx context.Context, ids []string) ([]*GetSpanOutputRow, error)
+	GetSpanOutput(ctx context.Context, arg GetSpanOutputParams) ([]*GetSpanOutputRow, error)
 	GetSpansByDebugRunID(ctx context.Context, debugRunID sql.NullString) ([]*GetSpansByDebugRunIDRow, error)
 	GetSpansByDebugSessionID(ctx context.Context, debugSessionID sql.NullString) ([]*GetSpansByDebugSessionIDRow, error)
 	GetSpansByRunID(ctx context.Context, runID string) ([]*GetSpansByRunIDRow, error)

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql
@@ -420,7 +420,7 @@ SELECT
   input,
   output
 FROM spans
-WHERE span_id IN (sqlc.slice('ids'))
+WHERE run_id = sqlc.arg(run_id) AND span_id IN (sqlc.slice('ids'))
 LIMIT 2;
 
 -- name: GetRunSpanByRunID :one

--- a/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql.go
+++ b/pkg/cqrs/base_cqrs/sqlc/sqlite/queries.sql.go
@@ -1276,23 +1276,29 @@ SELECT
   input,
   output
 FROM spans
-WHERE span_id IN (/*SLICE:ids*/?)
+WHERE run_id = ? AND span_id IN (/*SLICE:ids*/?)
 LIMIT 2
 `
+
+type GetSpanOutputParams struct {
+	RunID string
+	Ids   []string
+}
 
 type GetSpanOutputRow struct {
 	Input  interface{}
 	Output interface{}
 }
 
-func (q *Queries) GetSpanOutput(ctx context.Context, ids []string) ([]*GetSpanOutputRow, error) {
+func (q *Queries) GetSpanOutput(ctx context.Context, arg GetSpanOutputParams) ([]*GetSpanOutputRow, error) {
 	query := getSpanOutput
 	var queryParams []interface{}
-	if len(ids) > 0 {
-		for _, v := range ids {
+	queryParams = append(queryParams, arg.RunID)
+	if len(arg.Ids) > 0 {
+		for _, v := range arg.Ids {
 			queryParams = append(queryParams, v)
 		}
-		query = strings.Replace(query, "/*SLICE:ids*/?", strings.Repeat(",?", len(ids))[1:], 1)
+		query = strings.Replace(query, "/*SLICE:ids*/?", strings.Repeat(",?", len(arg.Ids))[1:], 1)
 	} else {
 		query = strings.Replace(query, "/*SLICE:ids*/?", "NULL", 1)
 	}

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -516,6 +516,11 @@ type SpanIdentifier struct {
 	TraceID     string    `json:"tid"`
 	SpanID      string    `json:"sid"`
 
+	// RunID scopes preview-path output lookups (GetSpanOutput). Required for
+	// the preview path because span_id can collide across runs when the
+	// checkpoint-deterministic seed produces the same OTEL span ID.
+	RunID string `json:"rid,omitempty,omitzero"`
+
 	// Whether the output should direct to the tracing preview stores
 	Preview *bool `json:"preview,omitempty,omitzero"`
 

--- a/pkg/db/adapter_integration_test.go
+++ b/pkg/db/adapter_integration_test.go
@@ -272,7 +272,7 @@ func TestQuerierSpanRoundTrip(t *testing.T) {
 	require.Len(t, spans, 1)
 
 	// Verify output is readable (not double-encoded)
-	outputs, err := q.GetSpanOutput(ctx, []string{spanID})
+	outputs, err := q.GetSpanOutput(ctx, runID, []string{spanID})
 	require.NoError(t, err)
 	require.Len(t, outputs, 1)
 

--- a/pkg/db/postgres/querier.go
+++ b/pkg/db/postgres/querier.go
@@ -546,8 +546,8 @@ func (pq *pgQuerier) GetStepSpanByStepID(ctx context.Context, arg db.GetStepSpan
 	}, nil
 }
 
-func (pq *pgQuerier) GetSpanOutput(ctx context.Context, ids []string) ([]*db.SpanOutputRow, error) {
-	rows, err := pq.q.GetSpanOutput(ctx, ids)
+func (pq *pgQuerier) GetSpanOutput(ctx context.Context, runID string, ids []string) ([]*db.SpanOutputRow, error) {
+	rows, err := pq.q.GetSpanOutput(ctx, sqlc.GetSpanOutputParams{RunID: runID, Ids: ids})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/db/querier.go
+++ b/pkg/db/querier.go
@@ -78,7 +78,7 @@ type Querier interface {
 	GetRunSpanByRunID(ctx context.Context, arg GetRunSpanByRunIDParams) (*SpanRow, error)
 	GetSpanBySpanID(ctx context.Context, arg GetSpanBySpanIDParams) (*SpanRow, error)
 	GetStepSpanByStepID(ctx context.Context, arg GetStepSpanByStepIDParams) (*SpanRow, error)
-	GetSpanOutput(ctx context.Context, ids []string) ([]*SpanOutputRow, error)
+	GetSpanOutput(ctx context.Context, runID string, ids []string) ([]*SpanOutputRow, error)
 	GetExecutionSpanByStepIDAndAttempt(ctx context.Context, arg GetExecutionSpanByStepIDAndAttemptParams) (*SpanRow, error)
 	GetLatestExecutionSpanByStepID(ctx context.Context, arg GetLatestExecutionSpanByStepIDParams) (*SpanRow, error)
 

--- a/pkg/db/sqlite/querier.go
+++ b/pkg/db/sqlite/querier.go
@@ -497,8 +497,8 @@ func (sq *sqliteQuerier) GetStepSpanByStepID(ctx context.Context, arg db.GetStep
 	}, nil
 }
 
-func (sq *sqliteQuerier) GetSpanOutput(ctx context.Context, ids []string) ([]*db.SpanOutputRow, error) {
-	rows, err := sq.q.GetSpanOutput(ctx, ids)
+func (sq *sqliteQuerier) GetSpanOutput(ctx context.Context, runID string, ids []string) ([]*db.SpanOutputRow, error) {
+	rows, err := sq.q.GetSpanOutput(ctx, sqlc.GetSpanOutputParams{RunID: runID, Ids: ids})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Fix `GetSpanOutput` missing run ID filter. Before this PR, changing step output between runs would still show only step output in the new runs. For example, if step `a` in run 1 returned `"foo"` and then returned `"bar"` in run 2, then run 2 showed `"foo"` in the UI

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a bug where `GetSpanOutput` was missing a `run_id` filter, causing step output from a previous run to bleed into subsequent runs when the OTEL span ID was deterministically identical across runs. The fix threads `RunID` through `SpanIdentifier`, encodes it into the output ID, and adds it as a SQL filter in both SQLite and Postgres queries.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b2ea02d062c1914d477a065b0d37a9fabe0e2f1a.</sup>
<!-- /MENDRAL_SUMMARY -->