### PR TITLE
Prevent integration keys from being renamed

### DIFF
--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/manage/$ingestKeys/$keyID/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/manage/$ingestKeys/$keyID/index.tsx
@@ -127,12 +127,14 @@ function KeyComponent() {
                   />
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
-                  <DropdownMenuItem
-                    onSelect={() => setIsEditKeyNameModalVisible(true)}
-                  >
-                    <RiPencilLine className="h-4 w-4" />
-                    Edit name
-                  </DropdownMenuItem>
+                  {!isIntegration && (
+                    <DropdownMenuItem
+                      onSelect={() => setIsEditKeyNameModalVisible(true)}
+                    >
+                      <RiPencilLine className="h-4 w-4" />
+                      Edit name
+                    </DropdownMenuItem>
+                  )}
                   <DropdownMenuItem
                     onSelect={() => setIsDeleteKeyModalVisible(true)}
                     className="text-error"


### PR DESCRIPTION
## Description

Integration keys names should be read-only as they may follow a format that is required for other purposes like matching or deletion and the key should be consistent for debugging the system including support.

## Motivation
This is done now because the new Stripe Projects integration uses integration event keys.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Hides the "Edit name" dropdown item for integration keys by wrapping it in a `!isIntegration` conditional. `isIntegration` is derived from `key.source === 'integration'`, so the guard is server-driven and not bypassable client-side in a meaningful way.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f0618b858a77e45cb3f1a42df55d8d419de7f585.</sup>
<!-- /MENDRAL_SUMMARY -->