### PR TITLE
Support thread reply improvements

### DIFF
--- a/ui/apps/support/src/routes/_authed/case.$ticketId.tsx
+++ b/ui/apps/support/src/routes/_authed/case.$ticketId.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Link, createFileRoute, useRouter } from "@tanstack/react-router";
 import { useServerFn } from "@tanstack/react-start";
 import { useUser } from "@clerk/tanstack-react-start";
@@ -316,6 +316,15 @@ function ReplyForm({
     userEmail,
     onError: setError,
   });
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [message]);
+
   const hasContent =
     message.trim().length > 0 || uploadedAttachmentIds.length > 0;
 
@@ -359,11 +368,12 @@ function ReplyForm({
       <form onSubmit={handleSubmit}>
         <div className="border-muted bg-canvasBase flex flex-col gap-2 rounded-lg border px-4 py-3 shadow-sm">
           <textarea
+            ref={textareaRef}
             placeholder="Add new message"
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             rows={1}
-            className="text-basis placeholder:text-disabled min-h-[21px] w-full resize-none border-0 bg-transparent p-0 text-sm leading-5 outline-none focus:ring-0"
+            className="text-basis placeholder:text-disabled min-h-[21px] w-full resize-none overflow-hidden border-0 bg-transparent p-0 text-sm leading-5 outline-none focus:ring-0"
             disabled={isSubmitting}
           />
 

--- a/ui/apps/support/src/routes/_authed/case.$ticketId.tsx
+++ b/ui/apps/support/src/routes/_authed/case.$ticketId.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, createFileRoute, useRouter } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
 import { useUser } from "@clerk/tanstack-react-start";
 import {
@@ -45,10 +46,34 @@ export const Route = createFileRoute("/_authed/case/$ticketId")({
 });
 
 function TicketDetailPage() {
-  const { ticket, timelineEntries } = Route.useLoaderData();
-  const router = useRouter();
+  const { ticket, timelineEntries: initialTimelineEntries } =
+    Route.useLoaderData();
+  const params = Route.useParams();
   const { user } = useUser();
   const timelineEndRef = useRef<HTMLDivElement>(null);
+
+  const { data: serverEntries, refetch: refetchTimeline } = useQuery({
+    queryKey: ["timeline", params.ticketId],
+    queryFn: () =>
+      getTimelineEntriesForTicket({ data: { ticketId: params.ticketId } }),
+    initialData: initialTimelineEntries,
+    staleTime: 30_000,
+  });
+
+  const [pendingEntries, setPendingEntries] = useState<TimeLineEntryEdge[]>([]);
+
+  const timelineEntries = useMemo(() => {
+    const real = serverEntries ?? [];
+    const pending = pendingEntries.filter((pending) => {
+      const pendingTime = new Date(pending.node.timestamp.iso8601).getTime();
+      return !real.some(
+        (real) =>
+          real.node.actor.__typename === "CustomerActor" &&
+          new Date(real.node.timestamp.iso8601).getTime() >= pendingTime,
+      );
+    });
+    return [...real, ...pending];
+  }, [serverEntries, pendingEntries]);
 
   if (!ticket || !timelineEntries) {
     return <div>Error loading ticket</div>;
@@ -59,10 +84,9 @@ function TicketDetailPage() {
   const userEmail = user?.primaryEmailAddress?.emailAddress;
 
   const scrollToBottom = () => {
-    // Wait for the DOM to update after invalidation, then scroll
     setTimeout(() => {
       timelineEndRef.current?.scrollIntoView({ behavior: "smooth" });
-    }, 500);
+    }, 100);
   };
 
   // Find the first Slack message link for the "Reply in Slack" button
@@ -189,9 +213,41 @@ function TicketDetailPage() {
             <ReplyForm
               ticketId={ticket.id}
               userEmail={userEmail}
-              onSuccess={async () => {
-                await router.invalidate();
+              onSuccess={(sentMessage: string) => {
+                const now = new Date().toISOString();
+                const optimistic: TimeLineEntryEdge = {
+                  cursor: `pending-${Date.now()}`,
+                  node: {
+                    id: `pending-${Date.now()}`,
+                    timestamp: { __typename: "DateTime", iso8601: now },
+                    actor: {
+                      __typename: "CustomerActor",
+                      customer: {
+                        fullName: user?.fullName || userEmail || "You",
+                        avatarUrl: user?.imageUrl || "",
+                        email: { email: userEmail || "" },
+                      },
+                    },
+                    entry: {
+                      __typename: "EmailEntry",
+                      emailId: `pending-${Date.now()}`,
+                      subject: "",
+                      textContent: sentMessage,
+                      markdownContent: sentMessage,
+                      hasMoreMarkdownContent: false,
+                      fullMarkdownContent: sentMessage,
+                      sentAt: {
+                        unixTimestamp: String(Math.floor(Date.now() / 1000)),
+                        iso8601: now,
+                      },
+                      attachments: [],
+                    },
+                  },
+                };
+                setPendingEntries((prev) => [...prev, optimistic]);
                 scrollToBottom();
+                setTimeout(() => refetchTimeline(), 3000);
+                setTimeout(() => refetchTimeline(), 8000);
               }}
             />
           ) : null}
@@ -297,7 +353,7 @@ function ReplyForm({
 }: {
   ticketId: string;
   userEmail: string;
-  onSuccess: () => void;
+  onSuccess: (message: string) => void;
 }) {
   const [message, setMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -349,9 +405,10 @@ function ReplyForm({
       });
 
       if (result.success) {
+        const sentMessage = message.trim();
         setMessage("");
         clearAttachments();
-        onSuccess();
+        onSuccess(sentMessage);
       } else {
         setError(result.error || "Failed to send message");
       }


### PR DESCRIPTION
## Description

The support center form now automatically expands when text is multi-line. Also, replies are optimistically rendered and de-duped when refreshes happen to show live updates after a new message is added to a thread.

## Motivation
Feedback about poor UX.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds optimistic UI updates to the support ticket reply flow: pending entries are shown immediately after sending, de-duped against server data via timestamp comparison, and the server is re-fetched at 3s and 8s post-send. Also auto-resizes the reply textarea as the user types.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 47bb5e27862251b814940fb868aa026cf485312e.</sup>
<!-- /MENDRAL_SUMMARY -->