### PR TITLE
Fix race error in jitter tests

### DIFF
--- a/tests/golang/cron_test.go
+++ b/tests/golang/cron_test.go
@@ -299,7 +299,9 @@ func TestCronJitter(t *testing.T) {
 	})
 
 	t.Run("trace run should have appropriate data", func(t *testing.T) {
-		runID := runIDVal.Load().(string)
+		val := runIDVal.Load()
+		require.NotNil(t, val, "runID should have been captured by the handler")
+		runID := val.(string)
 		run := c.WaitForRunTraces(ctx, t, &runID, client.WaitForRunTracesOptions{Status: models.FunctionStatusCompleted})
 
 		r.NotNil(run.CronSchedule)
@@ -387,7 +389,9 @@ func TestCronJitterRemovalAppliesToCurrentOccurrence(t *testing.T) {
 		return atomic.LoadInt32(&counter) == 1
 	}, 121*time.Second, 5*time.Second)
 
-	runID := runIDVal.Load().(string)
+	val := runIDVal.Load()
+	r.NotNil(val, "runID should have been captured by the handler")
+	runID := val.(string)
 	run := c.WaitForRunTraces(ctx, t, &runID, client.WaitForRunTracesOptions{Status: models.FunctionStatusCompleted})
 	r.NotNil(run.CronSchedule)
 	r.Equal("* * * * *", *run.CronSchedule)

--- a/tests/golang/cron_test.go
+++ b/tests/golang/cron_test.go
@@ -273,7 +273,7 @@ func TestCronJitter(t *testing.T) {
 
 	var (
 		counter    int32
-		runID      string
+		runIDVal   atomic.Value
 		executedAt atomic.Value
 	)
 
@@ -283,9 +283,7 @@ func TestCronJitter(t *testing.T) {
 		inngestgo.FunctionOpts{ID: "cron-jitter-test"},
 		inngestgo.CronTriggerWithJitter("* * * * *", jitterDuration),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
-			if runID == "" {
-				runID = input.InputCtx.RunID
-			}
+			runIDVal.CompareAndSwap(nil, input.InputCtx.RunID)
 			executedAt.Store(time.Now().UTC())
 			atomic.AddInt32(&counter, 1)
 			return "schedule done", nil
@@ -301,6 +299,7 @@ func TestCronJitter(t *testing.T) {
 	})
 
 	t.Run("trace run should have appropriate data", func(t *testing.T) {
+		runID := runIDVal.Load().(string)
 		run := c.WaitForRunTraces(ctx, t, &runID, client.WaitForRunTracesOptions{Status: models.FunctionStatusCompleted})
 
 		r.NotNil(run.CronSchedule)
@@ -348,7 +347,7 @@ func TestCronJitterRemovalAppliesToCurrentOccurrence(t *testing.T) {
 
 	var (
 		counter    int32
-		runID      string
+		runIDVal   atomic.Value
 		executedAt atomic.Value
 	)
 
@@ -358,9 +357,7 @@ func TestCronJitterRemovalAppliesToCurrentOccurrence(t *testing.T) {
 		inngestgo.FunctionOpts{ID: "cron-jitter-test"},
 		inngestgo.CronTriggerWithJitter("* * * * *", 50*time.Second),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
-			if runID == "" {
-				runID = input.InputCtx.RunID
-			}
+			runIDVal.CompareAndSwap(nil, input.InputCtx.RunID)
 			executedAt.Store(time.Now().UTC())
 			atomic.AddInt32(&counter, 1)
 			return "schedule done", nil
@@ -377,9 +374,7 @@ func TestCronJitterRemovalAppliesToCurrentOccurrence(t *testing.T) {
 		inngestgo.FunctionOpts{ID: "cron-jitter-test"},
 		inngestgo.CronTrigger("* * * * *"),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
-			if runID == "" {
-				runID = input.InputCtx.RunID
-			}
+			runIDVal.CompareAndSwap(nil, input.InputCtx.RunID)
 			executedAt.Store(time.Now().UTC())
 			atomic.AddInt32(&counter, 1)
 			return "schedule done", nil
@@ -392,6 +387,7 @@ func TestCronJitterRemovalAppliesToCurrentOccurrence(t *testing.T) {
 		return atomic.LoadInt32(&counter) == 1
 	}, 121*time.Second, 5*time.Second)
 
+	runID := runIDVal.Load().(string)
 	run := c.WaitForRunTraces(ctx, t, &runID, client.WaitForRunTracesOptions{Status: models.FunctionStatusCompleted})
 	r.NotNil(run.CronSchedule)
 	r.Equal("* * * * *", *run.CronSchedule)


### PR DESCRIPTION
## Description

Replace unsynchronized string variable with atomic.Value for runID in TestCronJitter and TestCronJitterRemovalAppliesToCurrentOccurrence. The handler goroutine writes runID while the test goroutine reads it.   

Problem found by mendral in monorepo, propagating the fix back in inngest.

## Motivation
Found by mendral when running race condition tests in monorepo
 
## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces unsynchronized `string` variables with `atomic.Value` to fix data races in `TestCronJitter` and `TestCronJitterRemovalAppliesToCurrentOccurrence`. The follow-up commit adds nil guards (`require.NotNil` / `r.NotNil`) before the type assertions to prevent panics if the handler never fires.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f250d15dc5ca3b1f458da6e0bef3d6a1ad4a2a58.</sup>
<!-- /MENDRAL_SUMMARY -->