### PR TITLE
Run span query changes

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -2997,9 +2997,23 @@ func (w wrapper) GetSpanRuns(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*c
 	}
 
 	allFilters := append(builder.filter, celFilters...)
+	// The inner subquery is bounded by Until (an executor.run always precedes
+	// any EXTEND sharing its dynamic_span_id). For start_time-based windows we
+	// also apply the From floor so the inner scan stops growing O(total
+	// executor.run history) as the system ages — at the cost of excluding runs
+	// whose root started before From but had EXTEND activity inside the
+	// window. For end_time-based windows we skip the floor: a run that ended
+	// in-window can legitimately have started arbitrarily earlier.
+	innerPreds := []sq.Expression{
+		sq.C("name").Eq(meta.SpanNameRun),
+		sq.C("start_time").Lt(opt.Filter.Until.UTC()),
+	}
+	if opt.Filter.TimeField != enums.TraceRunTimeEndedAt {
+		innerPreds = append(innerPreds, sq.C("start_time").Gte(opt.Filter.From.UTC()))
+	}
 	q = q.Select(selectCols...).
 		Where(sq.L("spans.dynamic_span_id").In(
-			sq.Dialect(h.GoquDialect()).Select("dynamic_span_id").Distinct().From("spans").Where(sq.C("name").Eq(meta.SpanNameRun)),
+			sq.Dialect(h.GoquDialect()).Select("dynamic_span_id").From("spans").Where(innerPreds...),
 		)).
 		Where(allFilters...).
 		GroupBy(groupByCols...).

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/schema.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 16.11
--- Dumped by pg_dump version 16.11
+-- Dumped from database version 16.13
+-- Dumped by pg_dump version 16.13
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/schema.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 16.13
--- Dumped by pg_dump version 16.13
+-- Dumped from database version 16.11
+-- Dumped by pg_dump version 16.11
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -417,6 +417,18 @@ CREATE INDEX idx_history_run_id_created ON public.history USING btree (run_id, c
 --
 
 CREATE INDEX idx_spans_account_status_time ON public.spans USING btree (account_id, status, start_time);
+
+--
+-- Name: idx_spans_active_start_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_spans_active_start_time ON public.spans USING btree (start_time) WHERE ((debug_run_id IS NULL) AND ((status IS NULL) OR (status <> 'Skipped'::text)));
+
+--
+-- Name: idx_spans_name_start_time_dynamic_span_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_spans_name_start_time_dynamic_span_id ON public.spans USING btree (name, start_time, dynamic_span_id);
 
 --
 -- Name: idx_spans_run_id; Type: INDEX; Schema: public; Owner: -

--- a/pkg/db/postgres/migrations/000002_add_spans_name_start_time_index.sql
+++ b/pkg/db/postgres/migrations/000002_add_spans_name_start_time_index.sql
@@ -10,14 +10,5 @@
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_spans_name_start_time_dynamic_span_id
   ON spans (name, start_time, dynamic_span_id);
 
--- Supports the outer scan used by the run list. The partial predicate mirrors
--- the query's active-run filter so the index stays narrow and the planner
--- picks it over a parallel seq scan for typical 1-7 day windows.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_spans_active_start_time
-  ON spans (start_time)
-  WHERE debug_run_id IS NULL
-    AND (status IS NULL OR status <> 'Skipped');
-
 -- +goose Down
-DROP INDEX CONCURRENTLY IF EXISTS idx_spans_active_start_time;
 DROP INDEX CONCURRENTLY IF EXISTS idx_spans_name_start_time_dynamic_span_id;

--- a/pkg/db/postgres/migrations/000002_spans_trace_view_indexes.sql
+++ b/pkg/db/postgres/migrations/000002_spans_trace_view_indexes.sql
@@ -1,0 +1,23 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+-- Supports the inner subquery used by the run list (GetSpanRuns):
+--   SELECT dynamic_span_id FROM spans
+--   WHERE name = 'executor.run' AND start_time >= $from AND start_time < $until
+-- With all three columns in the index the planner can use an index-only scan
+-- instead of a bitmap heap scan + re-check, and the subquery stops scanning
+-- historical executor.run rows as the deployment ages.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_spans_name_start_time_dynamic_span_id
+  ON spans (name, start_time, dynamic_span_id);
+
+-- Supports the outer scan used by the run list. The partial predicate mirrors
+-- the query's active-run filter so the index stays narrow and the planner
+-- picks it over a parallel seq scan for typical 1-7 day windows.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_spans_active_start_time
+  ON spans (start_time)
+  WHERE debug_run_id IS NULL
+    AND (status IS NULL OR status <> 'Skipped');
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_spans_active_start_time;
+DROP INDEX CONCURRENTLY IF EXISTS idx_spans_name_start_time_dynamic_span_id;

--- a/pkg/db/postgres/migrations/000003_add_spans_active_start_time_index.sql
+++ b/pkg/db/postgres/migrations/000003_add_spans_active_start_time_index.sql
@@ -1,0 +1,13 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+
+-- Supports the outer scan used by the run list. The partial predicate mirrors
+-- the query's active-run filter so the index stays narrow and the planner
+-- picks it over a parallel seq scan for typical 1-7 day windows.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_spans_active_start_time
+  ON spans (start_time)
+  WHERE debug_run_id IS NULL
+    AND (status IS NULL OR status <> 'Skipped');
+
+-- +goose Down
+DROP INDEX CONCURRENTLY IF EXISTS idx_spans_active_start_time;

--- a/pkg/db/postgres/schema.sql
+++ b/pkg/db/postgres/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 16.11
--- Dumped by pg_dump version 16.11
+-- Dumped from database version 16.13
+-- Dumped by pg_dump version 16.13
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;

--- a/pkg/db/postgres/schema.sql
+++ b/pkg/db/postgres/schema.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 16.13
--- Dumped by pg_dump version 16.13
+-- Dumped from database version 16.11
+-- Dumped by pg_dump version 16.11
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -417,6 +417,18 @@ CREATE INDEX idx_history_run_id_created ON public.history USING btree (run_id, c
 --
 
 CREATE INDEX idx_spans_account_status_time ON public.spans USING btree (account_id, status, start_time);
+
+--
+-- Name: idx_spans_active_start_time; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_spans_active_start_time ON public.spans USING btree (start_time) WHERE ((debug_run_id IS NULL) AND ((status IS NULL) OR (status <> 'Skipped'::text)));
+
+--
+-- Name: idx_spans_name_start_time_dynamic_span_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_spans_name_start_time_dynamic_span_id ON public.spans USING btree (name, start_time, dynamic_span_id);
 
 --
 -- Name: idx_spans_run_id; Type: INDEX; Schema: public; Owner: -

--- a/ui/apps/dev-server-ui/src/routes/_dashboard/runs/index.tsx
+++ b/ui/apps/dev-server-ui/src/routes/_dashboard/runs/index.tsx
@@ -1,6 +1,7 @@
 import SendEventButton from '@/components/Event/SendEventButton';
 import { useGetTrigger } from '@/hooks/useGetTrigger';
 import { client } from '@/store/baseApi';
+import { useInfoQuery } from '@/store/devApi';
 import {
   useGetAppsQuery,
   GetRunsQuery,
@@ -31,13 +32,22 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { useState, useEffect, useCallback, useMemo } from 'react';
 
-const pollInterval = 400;
+// Dev mode polls aggressively so iterations feel instant; serve (single-node
+// production) polls every 10s to keep query load off Postgres.
+const DEV_POLL_INTERVAL = 400;
+const SERVE_POLL_INTERVAL = 10_000;
 
 export const Route = createFileRoute('/_dashboard/runs/')({
   component: RunsComponent,
 });
 
 function RunsComponent() {
+  const { data: info } = useInfoQuery();
+  // While info is loading, default to the safer (slower) interval so we don't
+  // hammer a serve-mode deployment before we know which mode we're in.
+  const isDevMode = info !== undefined && !info.isSingleNodeService;
+  const pollInterval = isDevMode ? DEV_POLL_INTERVAL : SERVE_POLL_INTERVAL;
+
   const { booleanFlag } = useBooleanFlag();
   const { value: pollingDisabled, isReady: pollingFlagReady } = booleanFlag(
     'polling-disabled',

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -271,21 +271,25 @@ export function RunsPage({
       <div className="bg-canvasBase sticky top-0 z-10 flex flex-col">
         <div className="flex h-11 items-center justify-between gap-1.5 px-3">
           <div className="flex items-center gap-1.5">
-            <Button
-              icon={<RiSearchLine />}
-              size="small"
-              kind="secondary"
-              iconSide="left"
-              appearance="outlined"
-              label={showSearch ? 'Hide search' : 'Show search'}
-              onClick={() => setShowSearch((prev) => !prev)}
-              className={cn(
-                search
-                  ? 'after:bg-secondary-moderate after:mb-3 after:ml-0.5 after:h-2 after:w-2 after:rounded'
-                  : '',
-                'h-[26px] w-[103px] rounded'
-              )}
-            />
+            {/* CEL search scans the returned run set and gets prohibitively slow on large pages,
+                so only offer it when the total is small or the user already has a query applied. */}
+            {(totalCount === undefined || totalCount < 1000 || !!search) && (
+              <Button
+                icon={<RiSearchLine />}
+                size="small"
+                kind="secondary"
+                iconSide="left"
+                appearance="outlined"
+                label={showSearch ? 'Hide search' : 'Show search'}
+                onClick={() => setShowSearch((prev) => !prev)}
+                className={cn(
+                  search
+                    ? 'after:bg-secondary-moderate after:mb-3 after:ml-0.5 after:h-2 after:w-2 after:rounded'
+                    : '',
+                  'h-[26px] w-[103px] rounded'
+                )}
+              />
+            )}
             <SelectGroup>
               <TimeFieldFilter
                 selectedTimeField={timeField}

--- a/ui/packages/components/src/hooks/useCalculatedStartTime.ts
+++ b/ui/packages/components/src/hooks/useCalculatedStartTime.ts
@@ -7,7 +7,7 @@ type CalculatedStartTimeProps = {
   defaultTime?: string;
 };
 
-export const DEFAULT_TIME = '3d';
+export const DEFAULT_TIME = '1d';
 
 export const useCalculatedStartTime = ({
   lastDays,


### PR DESCRIPTION
Perf updates for run spans.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Performance improvements for the run spans query: adds a time-bounded inner subquery to avoid full `executor.run` history scans, two new Postgres indexes (`idx_spans_name_start_time_dynamic_span_id` and `idx_spans_active_start_time`) to support it, a dynamic poll interval in the dev-server UI (400ms dev / 10s serve-mode), hides the CEL search button when `totalCount >= 1000`, and shrinks the default time window from 3d to 1d.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7a4a15b787923f63f72faaca4a9bb4e265aecc2d.</sup>
<!-- /MENDRAL_SUMMARY -->