### PR TITLE
feat: add SDK conformance CLI serve runner

### DIFF
--- a/cmd/alpha.go
+++ b/cmd/alpha.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/inngest/inngest/cmd/conformance"
 	"github.com/inngest/inngest/cmd/debug"
 	"github.com/urfave/cli/v3"
 )
@@ -11,6 +12,7 @@ func alpha() *cli.Command {
 		Hidden: true,
 		Usage:  "experimental CLI commands",
 		Commands: []*cli.Command{
+			conformance.Command(),
 			debug.Command(),
 		},
 	}

--- a/cmd/conformance/cmd.go
+++ b/cmd/conformance/cmd.go
@@ -1,0 +1,16 @@
+package conformance
+
+import "github.com/urfave/cli/v3"
+
+func Command() *cli.Command {
+	return &cli.Command{
+		Name:  "conformance",
+		Usage: "Run and inspect SDK conformance suites.",
+		Commands: []*cli.Command{
+			runCommand(),
+			listCommand(),
+			doctorCommand(),
+			reportCommand(),
+		},
+	}
+}

--- a/cmd/conformance/cmd.go
+++ b/cmd/conformance/cmd.go
@@ -4,8 +4,9 @@ import "github.com/urfave/cli/v3"
 
 func Command() *cli.Command {
 	return &cli.Command{
-		Name:  "conformance",
-		Usage: "Run and inspect SDK conformance suites.",
+		Name:    "conformance",
+		Aliases: []string{"cft"},
+		Usage:   "Run and inspect SDK conformance suites.",
 		Commands: []*cli.Command{
 			runCommand(),
 			listCommand(),

--- a/cmd/conformance/common.go
+++ b/cmd/conformance/common.go
@@ -1,0 +1,193 @@
+package conformance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/inngest/inngest/pkg/cli/output"
+	conf "github.com/inngest/inngest/pkg/conformance"
+	"github.com/inngest/inngest/pkg/conformance/runner/serve"
+	"github.com/urfave/cli/v3"
+)
+
+// conformanceRunFlags centralizes the shared flag surface for `run` and
+// `doctor`, keeping configuration and runtime resolution aligned.
+func conformanceRunFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  "config",
+			Usage: "Path to a conformance config file (YAML or JSON).",
+		},
+		&cli.StringFlag{
+			Name:  "transport",
+			Usage: "Transport to execute. One of: serve, connect.",
+		},
+		&cli.StringSliceFlag{
+			Name:  "suite",
+			Usage: "Run only the named suite(s).",
+		},
+		&cli.StringSliceFlag{
+			Name:  "case",
+			Usage: "Run only the named case(s).",
+		},
+		&cli.StringSliceFlag{
+			Name:  "feature",
+			Usage: "Run cases covering the named feature(s).",
+		},
+		&cli.StringFlag{
+			Name:  "timeout",
+			Usage: "Overall case timeout, for example 60s or 2m.",
+		},
+		&cli.StringFlag{
+			Name:  "sdk-url",
+			Usage: "Serve endpoint exposed by the SDK fixture, for example http://127.0.0.1:3000/api/inngest.",
+		},
+		&cli.StringFlag{
+			Name:  "introspect-path",
+			Usage: "Override the introspection path relative to --sdk-url.",
+		},
+		&cli.StringFlag{
+			Name:  "dev-url",
+			Usage: "Base URL for the dev server when API and event endpoints share a host.",
+		},
+		&cli.StringFlag{
+			Name:  "api-url",
+			Usage: "Base URL for the dev server API used for function registration.",
+		},
+		&cli.StringFlag{
+			Name:  "event-url",
+			Usage: "Base URL for the event API used for publishing trigger events.",
+		},
+		&cli.StringFlag{
+			Name:  "event-key",
+			Usage: "Event key used to publish test events. Defaults to 'test'.",
+		},
+		&cli.StringFlag{
+			Name:  "signing-key",
+			Usage: "Signing key used to authorize function registration with the dev server.",
+		},
+		&cli.StringFlag{
+			Name:  "report-format",
+			Value: string(conf.ReportFormatPretty),
+			Usage: "Terminal output format. One of: pretty, json, junit, markdown.",
+		},
+		&cli.StringFlag{
+			Name:  "report-out",
+			Usage: "Optional JSON artifact path written in addition to terminal output.",
+		},
+	}
+}
+
+// loadExecutionConfig merges file-based config with explicit CLI overrides.
+func loadExecutionConfig(cmd *cli.Command) (conf.Config, error) {
+	cfg, err := conf.LoadConfig(cmd.String("config"))
+	if err != nil {
+		return conf.Config{}, err
+	}
+
+	if cmd.IsSet("transport") {
+		cfg.Transport = conf.Transport(cmd.String("transport"))
+	}
+	cfg.Suites = mergeStringSlices(cfg.Suites, cmd.StringSlice("suite"))
+	cfg.Cases = mergeStringSlices(cfg.Cases, cmd.StringSlice("case"))
+	cfg.Features = mergeStringSlices(cfg.Features, cmd.StringSlice("feature"))
+
+	if cmd.IsSet("timeout") {
+		cfg.Timeout = cmd.String("timeout")
+	}
+	if cmd.IsSet("sdk-url") {
+		cfg.SDK.URL = cmd.String("sdk-url")
+	}
+	if cmd.IsSet("introspect-path") {
+		cfg.SDK.IntrospectPath = cmd.String("introspect-path")
+	}
+	if cmd.IsSet("dev-url") {
+		cfg.Dev.URL = cmd.String("dev-url")
+	}
+	if cmd.IsSet("api-url") {
+		cfg.Dev.APIURL = cmd.String("api-url")
+	}
+	if cmd.IsSet("event-url") {
+		cfg.Dev.EventURL = cmd.String("event-url")
+	}
+	if cmd.IsSet("event-key") {
+		cfg.Dev.EventKey = cmd.String("event-key")
+	}
+	if cmd.IsSet("signing-key") {
+		cfg.Dev.SigningKey = cmd.String("signing-key")
+	}
+	if cmd.IsSet("report-format") {
+		cfg.Report.Format = conf.ReportFormat(cmd.String("report-format"))
+	}
+	if cmd.IsSet("report-out") {
+		cfg.Report.Output = cmd.String("report-out")
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return conf.Config{}, err
+	}
+
+	return cfg, nil
+}
+
+// resolveExecutionPlan converts the merged config into a runtime plus a concrete
+// case selection.
+func resolveExecutionPlan(cfg conf.Config) (conf.RunPlan, conf.RuntimeConfig, error) {
+	runtime, err := cfg.Runtime()
+	if err != nil {
+		return conf.RunPlan{}, conf.RuntimeConfig{}, err
+	}
+
+	selection := cfg.Selection()
+	selection.Transport = runtime.Transport
+
+	plan, err := selection.Resolve(conf.DefaultRegistry())
+	if err != nil {
+		return conf.RunPlan{}, conf.RuntimeConfig{}, err
+	}
+
+	return plan, runtime, nil
+}
+
+func newServeRunner() *serve.Runner {
+	return serve.NewRunner(nil)
+}
+
+// renderReport prints a report using the Phase 2 terminal renderers.
+func renderReport(report conf.Report, format conf.ReportFormat, forceJSON bool) error {
+	if forceJSON || format == conf.ReportFormatJSON {
+		byt, err := json.MarshalIndent(report, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(byt))
+		return nil
+	}
+
+	switch format {
+	case "", conf.ReportFormatPretty:
+		return output.TextConformanceReport(report)
+	case conf.ReportFormatJUnit, conf.ReportFormatMarkdown:
+		return fmt.Errorf("report format %q is not implemented yet", format)
+	default:
+		return fmt.Errorf("unknown report format %q", format)
+	}
+}
+
+func renderDoctor(checks []serve.Check, forceJSON bool) error {
+	if forceJSON {
+		byt, err := json.MarshalIndent(checks, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(byt))
+		return nil
+	}
+
+	return output.TextConformanceDoctor(checks)
+}
+
+func runServe(ctx context.Context, plan conf.RunPlan, runtime conf.RuntimeConfig) (conf.Report, error) {
+	return newServeRunner().Run(ctx, plan, runtime)
+}

--- a/cmd/conformance/doctor.go
+++ b/cmd/conformance/doctor.go
@@ -3,7 +3,7 @@ package conformance
 import (
 	"context"
 
-	"github.com/inngest/inngest/pkg/cli/output"
+	conf "github.com/inngest/inngest/pkg/conformance"
 	"github.com/urfave/cli/v3"
 )
 
@@ -11,10 +11,30 @@ func doctorCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "doctor",
 		Usage: "Check conformance prerequisites.",
+		Flags: conformanceRunFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			_ = ctx
-			_ = cmd
-			return output.TextConformanceStub("doctor", "Phase 1 stub: conformance doctor is not implemented yet.")
+			cfg, err := loadExecutionConfig(cmd)
+			if err != nil {
+				return err
+			}
+
+			plan, runtime, err := resolveExecutionPlan(cfg)
+			if err != nil {
+				return err
+			}
+
+			switch runtime.Transport {
+			case conf.TransportServe:
+				checks, err := newServeRunner().Doctor(ctx, plan, runtime)
+				if err != nil {
+					return err
+				}
+				return renderDoctor(checks, cmd.Bool("json"))
+			case conf.TransportConnect:
+				return cli.Exit("connect conformance doctor is not implemented yet", 2)
+			default:
+				return cli.Exit("unknown conformance transport", 2)
+			}
 		},
 	}
 }

--- a/cmd/conformance/doctor.go
+++ b/cmd/conformance/doctor.go
@@ -1,0 +1,21 @@
+package conformance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli/v3"
+)
+
+func doctorCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "doctor",
+		Usage: "Check conformance prerequisites.",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			_ = ctx
+			_ = cmd
+			fmt.Println("Phase 1 stub: conformance doctor is not implemented yet.")
+			return nil
+		},
+	}
+}

--- a/cmd/conformance/doctor.go
+++ b/cmd/conformance/doctor.go
@@ -2,8 +2,8 @@ package conformance
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/inngest/inngest/pkg/cli/output"
 	"github.com/urfave/cli/v3"
 )
 
@@ -14,8 +14,7 @@ func doctorCommand() *cli.Command {
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			_ = ctx
 			_ = cmd
-			fmt.Println("Phase 1 stub: conformance doctor is not implemented yet.")
-			return nil
+			return output.TextConformanceStub("doctor", "Phase 1 stub: conformance doctor is not implemented yet.")
 		},
 	}
 }

--- a/cmd/conformance/list.go
+++ b/cmd/conformance/list.go
@@ -1,0 +1,81 @@
+package conformance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	conf "github.com/inngest/inngest/pkg/conformance"
+	"github.com/urfave/cli/v3"
+)
+
+func listCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "list",
+		Usage: "List available conformance suites, cases, features, and transports.",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			_ = ctx
+			registry := conf.DefaultRegistry()
+
+			if cmd.Bool("json") {
+				byt, err := json.MarshalIndent(struct {
+					Transports []conf.Transport        `json:"transports"`
+					Suites     map[string]conf.Suite   `json:"suites"`
+					Cases      map[string]conf.Case    `json:"cases"`
+					Features   map[string]conf.Feature `json:"features"`
+				}{
+					Transports: conf.ValidTransports(),
+					Suites:     registry.Suites,
+					Cases:      registry.Cases,
+					Features:   registry.Features,
+				}, "", "  ")
+				if err != nil {
+					return err
+				}
+				fmt.Println(string(byt))
+				return nil
+			}
+
+			fmt.Println("Transports:")
+			for _, transport := range conf.ValidTransports() {
+				fmt.Printf("  - %s\n", transport)
+			}
+			fmt.Println("")
+
+			suiteIDs := make([]string, 0, len(registry.Suites))
+			for suiteID := range registry.Suites {
+				suiteIDs = append(suiteIDs, suiteID)
+			}
+			sort.Strings(suiteIDs)
+
+			fmt.Println("Suites:")
+			for _, suiteID := range suiteIDs {
+				suite := registry.Suites[suiteID]
+				fmt.Printf("  - %s: %s\n", suite.ID, suite.Label)
+				if suite.Description != "" {
+					fmt.Printf("      %s\n", suite.Description)
+				}
+				for _, caseID := range suite.CaseIDs {
+					testCase := registry.Cases[caseID]
+					fmt.Printf("      case: %s\n", testCase.ID)
+				}
+			}
+			fmt.Println("")
+
+			featureIDs := make([]string, 0, len(registry.Features))
+			for featureID := range registry.Features {
+				featureIDs = append(featureIDs, featureID)
+			}
+			sort.Strings(featureIDs)
+
+			fmt.Println("Features:")
+			for _, featureID := range featureIDs {
+				feature := registry.Features[featureID]
+				fmt.Printf("  - %s: %s\n", feature.ID, feature.Label)
+			}
+
+			return nil
+		},
+	}
+}

--- a/cmd/conformance/list.go
+++ b/cmd/conformance/list.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 
+	"github.com/inngest/inngest/pkg/cli/output"
 	conf "github.com/inngest/inngest/pkg/conformance"
 	"github.com/urfave/cli/v3"
 )
@@ -37,45 +37,7 @@ func listCommand() *cli.Command {
 				return nil
 			}
 
-			fmt.Println("Transports:")
-			for _, transport := range conf.ValidTransports() {
-				fmt.Printf("  - %s\n", transport)
-			}
-			fmt.Println("")
-
-			suiteIDs := make([]string, 0, len(registry.Suites))
-			for suiteID := range registry.Suites {
-				suiteIDs = append(suiteIDs, suiteID)
-			}
-			sort.Strings(suiteIDs)
-
-			fmt.Println("Suites:")
-			for _, suiteID := range suiteIDs {
-				suite := registry.Suites[suiteID]
-				fmt.Printf("  - %s: %s\n", suite.ID, suite.Label)
-				if suite.Description != "" {
-					fmt.Printf("      %s\n", suite.Description)
-				}
-				for _, caseID := range suite.CaseIDs {
-					testCase := registry.Cases[caseID]
-					fmt.Printf("      case: %s\n", testCase.ID)
-				}
-			}
-			fmt.Println("")
-
-			featureIDs := make([]string, 0, len(registry.Features))
-			for featureID := range registry.Features {
-				featureIDs = append(featureIDs, featureID)
-			}
-			sort.Strings(featureIDs)
-
-			fmt.Println("Features:")
-			for _, featureID := range featureIDs {
-				feature := registry.Features[featureID]
-				fmt.Printf("  - %s: %s\n", feature.ID, feature.Label)
-			}
-
-			return nil
+			return output.TextConformanceCatalog(registry)
 		},
 	}
 }

--- a/cmd/conformance/report.go
+++ b/cmd/conformance/report.go
@@ -1,0 +1,21 @@
+package conformance
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli/v3"
+)
+
+func reportCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "report",
+		Usage: "Render an existing conformance report artifact.",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			_ = ctx
+			_ = cmd
+			fmt.Println("Phase 1 stub: conformance report rendering is not implemented yet.")
+			return nil
+		},
+	}
+}

--- a/cmd/conformance/report.go
+++ b/cmd/conformance/report.go
@@ -3,7 +3,7 @@ package conformance
 import (
 	"context"
 
-	"github.com/inngest/inngest/pkg/cli/output"
+	conf "github.com/inngest/inngest/pkg/conformance"
 	"github.com/urfave/cli/v3"
 )
 
@@ -11,10 +11,25 @@ func reportCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "report",
 		Usage: "Render an existing conformance report artifact.",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "path",
+				Usage:    "Path to a previously written conformance report JSON file.",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "report-format",
+				Value: string(conf.ReportFormatPretty),
+				Usage: "Output format for terminal rendering. One of: pretty, json, junit, markdown.",
+			},
+		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			_ = ctx
-			_ = cmd
-			return output.TextConformanceStub("report", "Phase 1 stub: conformance report rendering is not implemented yet.")
+			report, err := conf.LoadReport(cmd.String("path"))
+			if err != nil {
+				return err
+			}
+			return renderReport(report, conf.ReportFormat(cmd.String("report-format")), cmd.Bool("json"))
 		},
 	}
 }

--- a/cmd/conformance/report.go
+++ b/cmd/conformance/report.go
@@ -2,8 +2,8 @@ package conformance
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/inngest/inngest/pkg/cli/output"
 	"github.com/urfave/cli/v3"
 )
 
@@ -14,8 +14,7 @@ func reportCommand() *cli.Command {
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			_ = ctx
 			_ = cmd
-			fmt.Println("Phase 1 stub: conformance report rendering is not implemented yet.")
-			return nil
+			return output.TextConformanceStub("report", "Phase 1 stub: conformance report rendering is not implemented yet.")
 		},
 	}
 }

--- a/cmd/conformance/run.go
+++ b/cmd/conformance/run.go
@@ -2,10 +2,8 @@ package conformance
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/inngest/inngest/pkg/cli/output"
 	conf "github.com/inngest/inngest/pkg/conformance"
 	"github.com/urfave/cli/v3"
 )
@@ -13,96 +11,39 @@ import (
 func runCommand() *cli.Command {
 	return &cli.Command{
 		Name:  "run",
-		Usage: "Resolve and validate a conformance run plan.",
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:  "config",
-				Usage: "Path to a conformance config file (YAML or JSON).",
-			},
-			&cli.StringFlag{
-				Name:  "transport",
-				Usage: "Filter cases by transport. One of: serve, connect.",
-			},
-			&cli.StringSliceFlag{
-				Name:  "suite",
-				Usage: "Run only the named suite(s).",
-			},
-			&cli.StringSliceFlag{
-				Name:  "case",
-				Usage: "Run only the named case(s).",
-			},
-			&cli.StringSliceFlag{
-				Name:  "feature",
-				Usage: "Run cases covering the named feature(s).",
-			},
-			&cli.StringFlag{
-				Name:  "report-format",
-				Value: string(conf.ReportFormatPretty),
-				Usage: "Planned report format. One of: pretty, json, junit, markdown.",
-			},
-			&cli.StringFlag{
-				Name:  "report-out",
-				Usage: "Path for writing a future conformance report artifact.",
-			},
-		},
+		Usage: "Run a conformance suite against the selected transport.",
+		Flags: conformanceRunFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			_ = ctx
-
-			cfg, err := conf.LoadConfig(cmd.String("config"))
+			cfg, err := loadExecutionConfig(cmd)
 			if err != nil {
 				return err
 			}
 
-			if cmd.IsSet("transport") {
-				cfg.Transport = conf.Transport(cmd.String("transport"))
-			}
-			cfg.Suites = mergeStringSlices(cfg.Suites, cmd.StringSlice("suite"))
-			cfg.Cases = mergeStringSlices(cfg.Cases, cmd.StringSlice("case"))
-			cfg.Features = mergeStringSlices(cfg.Features, cmd.StringSlice("feature"))
-			if cmd.IsSet("report-format") {
-				cfg.Report.Format = conf.ReportFormat(cmd.String("report-format"))
-			}
-			if cmd.IsSet("report-out") {
-				cfg.Report.Output = cmd.String("report-out")
-			}
-
-			if err := cfg.Validate(); err != nil {
-				return err
-			}
-
-			registry := conf.DefaultRegistry()
-			plan, err := cfg.Selection().Resolve(registry)
+			plan, runtime, err := resolveExecutionPlan(cfg)
 			if err != nil {
 				return err
 			}
 
-			if cmd.Bool("json") || cfg.Report.Format == conf.ReportFormatJSON {
-				byt, err := json.MarshalIndent(struct {
-					SchemaVersion string               `json:"schema_version"`
-					Config        conf.Config          `json:"config"`
-					Plan          conf.RunPlan         `json:"plan"`
-					Compatibility []conf.Compatibility `json:"compatibility_classes"`
-					Note          string               `json:"note"`
-				}{
-					SchemaVersion: conf.ReportSchemaVersion,
-					Config:        cfg,
-					Plan:          plan,
-					Compatibility: []conf.Compatibility{
-						conf.CompatibilityFull,
-						conf.CompatibilityPartial,
-						conf.CompatibilityIncompatible,
-						conf.CompatibilityUnknown,
-					},
-					Note: "Phase 1 validates configuration and selection only. Execution is not implemented yet.",
-				}, "", "  ")
-				if err != nil {
+			var report conf.Report
+			switch runtime.Transport {
+			case conf.TransportServe:
+				report, err = runServe(ctx, plan, runtime)
+			case conf.TransportConnect:
+				return cli.Exit("connect conformance is not implemented yet", 2)
+			default:
+				return cli.Exit(fmt.Sprintf("unknown transport %q", runtime.Transport), 2)
+			}
+			if err != nil {
+				return err
+			}
+
+			if cfg.Report.Output != "" {
+				if err := conf.WriteReport(cfg.Report.Output, report); err != nil {
 					return err
 				}
-				fmt.Println(string(byt))
-				return nil
 			}
 
-			return output.TextConformanceRunPlan(plan)
+			return renderReport(report, cfg.Report.Format, cmd.Bool("json"))
 		},
 	}
 }

--- a/cmd/conformance/run.go
+++ b/cmd/conformance/run.go
@@ -1,0 +1,143 @@
+package conformance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	conf "github.com/inngest/inngest/pkg/conformance"
+	"github.com/urfave/cli/v3"
+)
+
+func runCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "run",
+		Usage: "Resolve and validate a conformance run plan.",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "config",
+				Usage: "Path to a conformance config file (YAML or JSON).",
+			},
+			&cli.StringFlag{
+				Name:  "transport",
+				Usage: "Filter cases by transport. One of: serve, connect.",
+			},
+			&cli.StringSliceFlag{
+				Name:  "suite",
+				Usage: "Run only the named suite(s).",
+			},
+			&cli.StringSliceFlag{
+				Name:  "case",
+				Usage: "Run only the named case(s).",
+			},
+			&cli.StringSliceFlag{
+				Name:  "feature",
+				Usage: "Run cases covering the named feature(s).",
+			},
+			&cli.StringFlag{
+				Name:  "report-format",
+				Value: string(conf.ReportFormatPretty),
+				Usage: "Planned report format. One of: pretty, json, junit, markdown.",
+			},
+			&cli.StringFlag{
+				Name:  "report-out",
+				Usage: "Path for writing a future conformance report artifact.",
+			},
+		},
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			_ = ctx
+
+			cfg, err := conf.LoadConfig(cmd.String("config"))
+			if err != nil {
+				return err
+			}
+
+			if cmd.IsSet("transport") {
+				cfg.Transport = conf.Transport(cmd.String("transport"))
+			}
+			cfg.Suites = mergeStringSlices(cfg.Suites, cmd.StringSlice("suite"))
+			cfg.Cases = mergeStringSlices(cfg.Cases, cmd.StringSlice("case"))
+			cfg.Features = mergeStringSlices(cfg.Features, cmd.StringSlice("feature"))
+			if cmd.IsSet("report-format") {
+				cfg.Report.Format = conf.ReportFormat(cmd.String("report-format"))
+			}
+			if cmd.IsSet("report-out") {
+				cfg.Report.Output = cmd.String("report-out")
+			}
+
+			if err := cfg.Validate(); err != nil {
+				return err
+			}
+
+			registry := conf.DefaultRegistry()
+			plan, err := cfg.Selection().Resolve(registry)
+			if err != nil {
+				return err
+			}
+
+			if cmd.Bool("json") || cfg.Report.Format == conf.ReportFormatJSON {
+				byt, err := json.MarshalIndent(struct {
+					SchemaVersion string               `json:"schema_version"`
+					Config        conf.Config          `json:"config"`
+					Plan          conf.RunPlan         `json:"plan"`
+					Compatibility []conf.Compatibility `json:"compatibility_classes"`
+					Note          string               `json:"note"`
+				}{
+					SchemaVersion: conf.ReportSchemaVersion,
+					Config:        cfg,
+					Plan:          plan,
+					Compatibility: []conf.Compatibility{
+						conf.CompatibilityFull,
+						conf.CompatibilityPartial,
+						conf.CompatibilityIncompatible,
+						conf.CompatibilityUnknown,
+					},
+					Note: "Phase 1 validates configuration and selection only. Execution is not implemented yet.",
+				}, "", "  ")
+				if err != nil {
+					return err
+				}
+				fmt.Println(string(byt))
+				return nil
+			}
+
+			fmt.Printf("Transport: %s\n", valueOrDefault(string(plan.Transport), "all"))
+			fmt.Printf("Suites: %d\n", len(plan.Suites))
+			fmt.Printf("Cases: %d\n", len(plan.Cases))
+			fmt.Printf("Features: %d\n", len(plan.Features))
+			fmt.Println("")
+			fmt.Println("Resolved suites:")
+			for _, suite := range plan.Suites {
+				fmt.Printf("  - %s\n", suite.ID)
+			}
+			fmt.Println("")
+			fmt.Println("Resolved cases:")
+			for _, testCase := range plan.Cases {
+				fmt.Printf("  - %s\n", testCase.ID)
+			}
+			fmt.Println("")
+			fmt.Println("Compatibility classes:")
+			fmt.Println("  - full")
+			fmt.Println("  - partial")
+			fmt.Println("  - incompatible")
+			fmt.Println("  - unknown")
+			fmt.Println("")
+			fmt.Println("Phase 1 validates configuration and selection only. Execution is not implemented yet.")
+			return nil
+		},
+	}
+}
+
+func mergeStringSlices(base []string, overrides []string) []string {
+	if len(overrides) == 0 {
+		return base
+	}
+	return overrides
+}
+
+func valueOrDefault(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/cmd/conformance/run.go
+++ b/cmd/conformance/run.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/inngest/inngest/pkg/cli/output"
 	conf "github.com/inngest/inngest/pkg/conformance"
 	"github.com/urfave/cli/v3"
 )
@@ -101,29 +102,7 @@ func runCommand() *cli.Command {
 				return nil
 			}
 
-			fmt.Printf("Transport: %s\n", valueOrDefault(string(plan.Transport), "all"))
-			fmt.Printf("Suites: %d\n", len(plan.Suites))
-			fmt.Printf("Cases: %d\n", len(plan.Cases))
-			fmt.Printf("Features: %d\n", len(plan.Features))
-			fmt.Println("")
-			fmt.Println("Resolved suites:")
-			for _, suite := range plan.Suites {
-				fmt.Printf("  - %s\n", suite.ID)
-			}
-			fmt.Println("")
-			fmt.Println("Resolved cases:")
-			for _, testCase := range plan.Cases {
-				fmt.Printf("  - %s\n", testCase.ID)
-			}
-			fmt.Println("")
-			fmt.Println("Compatibility classes:")
-			fmt.Println("  - full")
-			fmt.Println("  - partial")
-			fmt.Println("  - incompatible")
-			fmt.Println("  - unknown")
-			fmt.Println("")
-			fmt.Println("Phase 1 validates configuration and selection only. Execution is not implemented yet.")
-			return nil
+			return output.TextConformanceRunPlan(plan)
 		},
 	}
 }
@@ -133,11 +112,4 @@ func mergeStringSlices(base []string, overrides []string) []string {
 		return base
 	}
 	return overrides
-}
-
-func valueOrDefault(value, fallback string) string {
-	if value == "" {
-		return fallback
-	}
-	return value
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/inngest/inngest/cmd/conformance"
 	"github.com/inngest/inngest/cmd/devserver"
 	"github.com/inngest/inngest/cmd/start"
 	"github.com/inngest/inngest/cmd/version"
@@ -75,7 +74,6 @@ func execute() {
 
 		Flags: globalFlags,
 		Commands: []*cli.Command{
-			conformance.Command(),
 			devserver.Command(),
 			version.Command(),
 			start.Command(),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/inngest/inngest/cmd/conformance"
 	"github.com/inngest/inngest/cmd/devserver"
 	"github.com/inngest/inngest/cmd/start"
 	"github.com/inngest/inngest/cmd/version"
@@ -74,6 +75,7 @@ func execute() {
 
 		Flags: globalFlags,
 		Commands: []*cli.Command{
+			conformance.Command(),
 			devserver.Command(),
 			version.Command(),
 			start.Command(),

--- a/docs/plans/001-db-adapter-refactor.md
+++ b/docs/plans/001-db-adapter-refactor.md
@@ -1,4 +1,6 @@
 ---
+TITLE: DB Adapter Refactor
+AUTHOR: Darwin D. Wu
 STATUS: Done
 ---
 

--- a/docs/plans/002-cli-conformance-runner.org
+++ b/docs/plans/002-cli-conformance-runner.org
@@ -540,15 +540,15 @@ Overview:
 - make the conformance command discoverable even before all runners and suites are complete
 
 Subtasks:
-- [ ] Add =cmd/conformance= and register it in the root CLI.
-- [ ] Define the top-level subcommands: =run=, =list=, =doctor=, and =report=.
-- [ ] Define shared config, suite, case, feature, status, and report types.
-- [ ] Define report schema versioning and a stable JSON shape.
-- [ ] Implement =list= against the shared registry so available suites and cases are visible.
-- [ ] Implement a stub =run= path that loads config, selects suites, and validates inputs.
-- [ ] Define fixture and golden-data conventions, including sanitization and normalization
+- [X] Add =cmd/conformance= and register it in the root CLI.
+- [X] Define the top-level subcommands: =run=, =list=, =doctor=, and =report=.
+- [X] Define shared config, suite, case, feature, status, and report types.
+- [X] Define report schema versioning and a stable JSON shape.
+- [X] Implement =list= against the shared registry so available suites and cases are visible.
+- [X] Implement a stub =run= path that loads config, selects suites, and validates inputs.
+- [X] Define fixture and golden-data conventions, including sanitization and normalization
   rules.
-- [ ] Establish the compatibility classification model: full, partial, incompatible, and
+- [X] Establish the compatibility classification model: full, partial, incompatible, and
   unknown.
 
 ** Phase 2: Serve runner

--- a/docs/plans/002-cli-conformance-runner.org
+++ b/docs/plans/002-cli-conformance-runner.org
@@ -1,0 +1,266 @@
+#+TITLE: CLI Conformance Runner
+#+AUTHOR: Darwin D. Wu
+#+STATUS: Draft
+#+STARTUP: showall
+
+* Overview
+Add a new =inngest conformance= command family to the CLI that can be run inside SDK
+repositories to measure feature compatibility against the Inngest dev server and, later,
+other Inngest targets.
+
+The command should support both SDK transport models:
+- =serve=: SDK exposes the standard HTTP serve endpoint.
+- =connect=: SDK runs a persistent worker that connects to the dev server over the Connect
+  control-plane and gateway WebSocket protocol.
+
+This should be designed as a reusable runner with stable machine-readable reports, so SDK
+repos can use it locally and in CI without depending on Go's =testing= package or this
+repo's internal test layout.
+
+* Goals
+- Provide a single CLI entrypoint for SDK conformance testing.
+- Support execution in external SDK repositories after downloading the Inngest CLI.
+- Produce both human-readable and machine-readable reports.
+- Model compatibility by feature, not only by test case.
+- Support both =serve= and =connect= transports with a shared case/report model.
+- Work in local development and CI with minimal SDK-specific glue.
+
+* Non-Goals
+- Reuse =go test= directly as the user-facing conformance runner.
+- Implement cloud-target conformance in v1.
+- Cover every SDK feature in the first iteration.
+- Replace existing repo-local integration tests in this repository.
+
+* User Experience
+** Primary commands
+- =inngest conformance run=
+  Execute one or more suites or cases and emit a report.
+- =inngest conformance list=
+  Show available transports, suites, cases, and features.
+- =inngest conformance doctor=
+  Validate prerequisites before running conformance.
+- =inngest conformance report=
+  Re-render an existing result artifact as =pretty=, =json=, =junit=, or =markdown=.
+
+** Useful follow-ups
+- =inngest conformance init=
+  Scaffold a minimal config file for SDK repos.
+- =inngest conformance diff=
+  Compare two reports and surface regressions.
+- =inngest conformance capture=
+  Gather extra diagnostics for failed runs.
+- =inngest conformance replay=
+  Re-run a failed case from a saved report.
+
+* Transport Model
+** Serve
+The runner targets an HTTP SDK endpoint, typically exposed as =/api/inngest= and
+=/api/introspect=, and drives execution through standard registration and event APIs.
+
+** Connect
+The runner must not assume a serve endpoint exists.
+
+Instead, the flow is:
+1. Start =inngest dev=.
+2. Start the SDK fixture process in worker mode.
+3. Wait for the worker to become ready via dev server Connect state.
+4. Send events through the server.
+5. Assert outcomes from server-observable behavior and the final run state.
+
+Important implication:
+- The runner does not need to implement the Connect WebSocket protocol itself for normal
+  conformance runs.
+- It needs orchestration, readiness checks, event injection, and result collection.
+
+* Proposed CLI Shape
+** Examples
+#+begin_src bash
+inngest conformance run \
+  --transport serve \
+  --sdk-url http://127.0.0.1:3000/api/inngest
+
+inngest conformance run \
+  --transport connect \
+  --worker-cmd 'go run ./cmd/worker' \
+  --report-format json
+#+end_src
+
+** Common flags
+- =--transport serve|connect=
+- =--suite=
+- =--case=
+- =--feature=
+- =--report-format pretty|json|junit|markdown=
+- =--report-out=
+- =--timeout=
+- =--verbose=
+
+** Serve-specific flags
+- =--sdk-url=
+- =--introspect-path=
+- =--inngest-path=
+
+** Connect-specific flags
+- =--worker-cmd=
+- =--wait-for-ready-timeout=
+- =--connect-state-url= or derived from dev server defaults
+- =--instance-id= for debugging and correlation
+
+** Server/runtime flags
+- =--dev-url=
+- =--event-url=
+- =--event-key=
+- =--signing-key=
+- =--start-dev=
+- =--dev-cmd=
+
+* Report Model
+Reports should be stable and versioned.
+
+** Required top-level fields
+- schema version
+- run id
+- timestamp
+- CLI version
+- SDK metadata
+- target metadata
+- transport
+- overall status
+- summary counts
+- per-case results
+- per-feature compatibility summary
+
+** Per-case result fields
+- case id
+- suite id
+- feature ids
+- status
+- duration
+- transport
+- evidence
+- failure message
+- artifacts
+
+** Per-feature summary fields
+- feature id
+- feature label
+- support status: supported, partial, unsupported, unknown
+- backing cases
+- notes
+
+* Package Layout
+#+begin_src text
+cmd/
+  conformance/
+    cmd.go
+    run.go
+    list.go
+    doctor.go
+    report.go
+
+pkg/conformance/
+  suite.go
+  case.go
+  feature.go
+  runner.go
+  report.go
+  doctor.go
+  config.go
+  runner/
+    serve/
+      runner.go
+      register.go
+      execute.go
+    connect/
+      runner.go
+      readiness.go
+      execute.go
+  output/
+    pretty.go
+    json.go
+    junit.go
+    markdown.go
+#+end_src
+
+* Reuse From Existing Code
+There is useful protocol and case logic in this repository's =tests/= directory, especially:
+- SDK introspection and registration flow
+- request/response expectation patterns
+- existing SDK feature scenarios for Go and JS
+
+However, the conformance runner should extract reusable logic into =pkg/conformance=
+instead of wrapping =go test= or depending on =testing.T=.
+
+* Initial Feature Set
+Start with a small, portable suite that covers the highest-signal compatibility areas:
+- basic function registration and invocation
+- step execution
+- sleep
+- retry
+- cancel
+- wait-for-event
+
+Connect-specific transport checks should also cover:
+- worker startup
+- ready state reached
+- event delivery to the worker
+- reply path functioning
+- reconnect and drain behavior as a follow-up suite
+
+* SDK Repository Integration
+Each SDK repo should provide one of:
+- a serve fixture that exposes the expected HTTP endpoints
+- a connect fixture that starts a worker process
+
+Recommended CI pattern:
+1. Download or install the Inngest CLI.
+2. Start the SDK fixture process or let the CLI start it.
+3. Run =inngest conformance doctor=.
+4. Run =inngest conformance run --report-format json --report-out ...=.
+5. Publish the JSON report and optional rendered summaries as CI artifacts.
+
+* Phases
+** Phase 1: Command and shared model
+- [ ] Add =cmd/conformance= and register it in the root CLI.
+- [ ] Define shared config, suite, case, feature, and report types.
+- [ ] Implement =list= and a stub =run= command.
+- [ ] Define report schema versioning.
+
+** Phase 2: Serve runner
+- [ ] Extract serve-oriented protocol logic from =tests/= into =pkg/conformance/runner/serve=.
+- [ ] Implement a small initial case set.
+- [ ] Emit pretty and JSON reports.
+- [ ] Add basic doctor checks for serve mode.
+
+** Phase 3: Connect runner
+- [ ] Implement worker process orchestration.
+- [ ] Add readiness checks against dev server Connect state.
+- [ ] Reuse shared cases where transport-independent.
+- [ ] Add Connect-specific doctor checks and diagnostics.
+
+** Phase 4: Reporting and CI ergonomics
+- [ ] Implement =report= subcommand.
+- [ ] Add JUnit and Markdown renderers.
+- [ ] Support stable artifact paths and exit codes for CI.
+- [ ] Document usage for SDK repositories.
+
+** Phase 5: Config and adoption
+- [ ] Add =init= scaffolding for SDK repos.
+- [ ] Support per-repo config files for commands, env, and suites.
+- [ ] Trial adoption in =inngestgo= first, then other SDK repos.
+
+* Open Questions
+- What config file format should SDK repos use: YAML, JSON, or CUE?
+- Should =run= default to starting the dev server, or only attach to an existing server?
+- How much transport-specific evidence should be surfaced in the base report vs optional
+  capture artifacts?
+- Do we want a separate transport suite for reconnect, drain, and lease-extension behavior
+  in v1 or after initial adoption?
+- Which minimum feature matrix should be required before calling an SDK "compatible"?
+
+* Success Criteria
+- An SDK repository can run =inngest conformance run= locally with one command.
+- CI can consume JSON output and fail on regressions deterministically.
+- The same feature can be reported across =serve= and =connect= transports.
+- The command surface remains small and understandable.
+- Adding new cases does not require changing CLI wiring or report consumers.

--- a/docs/plans/002-cli-conformance-runner.org
+++ b/docs/plans/002-cli-conformance-runner.org
@@ -148,6 +148,109 @@ Reports should be stable and versioned.
 - backing cases
 - notes
 
+* Test Data Strategy
+We should use golden data, but narrowly.
+
+Golden data is useful when we need a stable, reviewable expectation for:
+- normalized registration payloads
+- generated SDK responses
+- report rendering output
+- sanitized error payloads
+- case manifests and expected feature summaries
+
+Golden data should not be the only oracle for execution behavior. For many conformance
+cases, especially timing-sensitive and transport-sensitive ones, assertions should be
+structural and semantic instead:
+- response status class
+- presence or absence of fields
+- generator opcode shape
+- final run status
+- security invariants
+
+Recommended split:
+- use golden fixtures for deterministic data contracts and report snapshots
+- use semantic assertions for runtime behavior, time-based flows, retries, and reconnects
+
+Golden fixtures should be:
+- versioned with the report schema
+- sanitized so they contain no secrets, ephemeral IDs, timestamps, or host-specific values
+- transport-aware where necessary, but shared where possible
+
+Non-goal for v1:
+- building a brittle snapshot suite that fails on harmless formatting or ordering changes
+
+* Case Taxonomy
+The plan should treat conformance cases as more than happy-path feature checks.
+
+** Positive cases
+These verify expected feature support under valid inputs and normal execution:
+- registration and discovery
+- invocation
+- steps
+- sleeps
+- retries
+- cancel
+- wait-for-event
+
+** Negative and defensive cases
+These verify SDK behavior under malformed, unexpected, or incomplete inputs. The goal is
+not only "returns an error", but "fails safely and predictably".
+
+Examples:
+- malformed request payloads
+- unexpected field types in event data
+- missing required fields
+- invalid step IDs
+- invalid signatures or auth context
+- oversized payloads
+- unknown opcodes or unsupported request shapes where relevant
+- duplicate or replay-like requests where idempotency expectations apply
+
+Expected assertions:
+- no panic or worker crash
+- no unbounded retry loop
+- no secret leakage in the error body or logs captured by the runner
+- explicit and stable error classification where possible
+- connection remains healthy unless disconnect is the correct behavior
+
+** Security and hardening cases
+These should be a first-class suite, not an afterthought.
+
+Primary goals:
+- verify the SDK does not expose process environment variables, secrets, or internal
+  implementation details in normal outputs or error paths
+- verify untrusted input is handled without reflecting sensitive runtime state
+- verify transport-level failures do not cause unsafe fallback behavior
+
+Initial security-focused checks should include:
+- environment variables are not returned in function output unless explicitly referenced by
+  the fixture code
+- environment variables are not echoed in error messages, stack traces, or serialized step
+  state
+- signing keys, event keys, session tokens, and auth headers never appear in reports or
+  captured artifacts
+- malformed requests do not trigger verbose debug dumps containing headers, local paths, or
+  raw process state
+- connect handshake or serve registration failures do not leak secrets through surfaced
+  diagnostics
+
+The runner should sanitize captured evidence before persisting it to disk.
+
+* Suite Layout
+Suites should be organized by intent rather than by implementation language.
+
+Suggested top-level suites:
+- =core=: basic compatible behavior
+- =negative=: invalid and malformed inputs
+- =security=: hardening and secret-handling checks
+- =transport/serve=: serve-specific behavior
+- =transport/connect=: connect-specific behavior
+
+This allows a repo to run:
+- a fast default suite locally
+- a broader CI suite including negative and security checks
+- transport-specific suites when the SDK supports more than one transport
+
 * Package Layout
 #+begin_src text
 cmd/
@@ -207,10 +310,22 @@ Connect-specific transport checks should also cover:
 - reply path functioning
 - reconnect and drain behavior as a follow-up suite
 
+The first portable expansion after happy-path coverage should be:
+- malformed event payload handling
+- invalid request/body handling
+- stable error responses for unsupported or unexpected inputs
+- secret non-disclosure checks in outputs, logs, and reports
+
 * SDK Repository Integration
 Each SDK repo should provide one of:
 - a serve fixture that exposes the expected HTTP endpoints
 - a connect fixture that starts a worker process
+
+SDK repos should also provide:
+- a small set of intentionally invalid-input fixtures where the expected outcome is safe
+  rejection
+- a security fixture that can validate the runtime does not accidentally expose selected
+  environment variables
 
 Recommended CI pattern:
 1. Download or install the Inngest CLI.
@@ -219,44 +334,242 @@ Recommended CI pattern:
 4. Run =inngest conformance run --report-format json --report-out ...=.
 5. Publish the JSON report and optional rendered summaries as CI artifacts.
 
+* Decisions
+** Config format
+Use YAML as the canonical config format and load it with =koanf=.
+
+Reasons:
+- easier for humans to edit in SDK repositories
+- good fit for commands, env vars, suites, and fixture definitions
+- leaves room to accept JSON or TOML later with little extra implementation cost
+
+** Dev server lifecycle
+Default =conformance run= to starting a fresh dev server.
+
+Reasons:
+- better fit for SDK repositories such as =inngest-rs= and =inngest-kt=
+- reduces setup friction in local development and CI
+- gives the runner stronger control over ports, env, lifecycle, and captured diagnostics
+
+Follow-up:
+- add an explicit attach mode later for users who want to point at an already-running dev
+  server
+
+** Base report vs capture artifacts
+Recommendation:
+- keep the base report compact and semantic
+- put verbose transport traces, request/response dumps, and process logs into optional
+  capture artifacts
+
+Base report should include:
+- feature and case status
+- normalized error summary
+- short evidence snippets
+- references to any captured artifacts
+
+Optional capture artifacts may include:
+- dev server logs
+- SDK fixture stdout and stderr
+- normalized registration payloads
+- sanitized request and response bodies
+- connect readiness and connection-state snapshots
+
+All captures must be redacted before persistence.
+
+Default failure artifact bundle should contain:
+- =report.json=
+  normalized run report with per-case status, feature status, reasons, and artifact references
+- =summary.md=
+  human-readable failure summary for CI and local triage
+- =manifest.json=
+  CLI version, SDK metadata, transport, config used, normalized ports and URLs, and
+  selected suites or cases
+- =sdk.log=
+  captured SDK fixture stdout and stderr, redacted
+- =devserver.log=
+  captured =inngest dev= stdout and stderr, redacted
+- =case-artifacts/<case-id>.json=
+  per-case normalized evidence including expected behavior, actual behavior, failure reason,
+  duration, and sanitized request or response snippets when relevant
+- =redactions.json=
+  a record of applied redaction rules so artifact consumers know why fields are absent
+
+Transport-specific artifacts should be included only when relevant:
+- =connect-state.json=
+  connection readiness and status snapshots for connect-mode failures
+- =serve-registration.json=
+  normalized introspection and registration evidence for serve-mode failures
+
+Default behavior should avoid including:
+- full raw request dumps for every passing case
+- unredacted environment variables
+- excessive debug traces or packet-level logs
+- full stack traces unless the sanitized summary is insufficient
+
+Follow-up:
+- support a more verbose capture mode for deeper local debugging
+
+** Suite execution behavior
+Do not fail fast by default.
+
+The runner should attempt to execute the full selected suite and report:
+- which features passed
+- which features failed
+- which features are not implemented
+- which features could not be evaluated
+
+When possible, the report should also include a normalized reason, such as:
+- not implemented by this SDK
+- transport setup failed
+- behavior diverged from expectation
+- security invariant violated
+- prerequisite case failed
+
+This gives SDK maintainers a fuller compatibility picture from a single run.
+
+** Compatibility classification
+Do not collapse outcomes into a single binary "compatible" label.
+
+Instead summarize at the SDK level as:
+- full compatibility
+- partial compatibility
+- incompatible
+- unknown
+
+Feature-level evaluation remains the source of truth.
+
+** Golden fixture strictness
+Use semantic snapshots, not byte-for-byte snapshots.
+
+Normalization before comparison should include:
+- stable key ordering
+- redaction of secrets
+- removal of timestamps, ports, paths, IDs, and other ephemeral values
+- separation of transport-specific metadata from shared feature expectations
+
+** Negative case requirements
+Evaluate negative and defensive behavior per feature, not as a single global gate.
+
+Examples:
+- if a feature accepts signed requests, test invalid signature handling for that feature
+- if a feature accepts structured input, test malformed payload handling for that feature
+- if a feature uses retries or state serialization, test invalid or oversized state for that
+  feature
+
+This keeps compatibility reporting aligned to actual implemented feature sets.
+
+** Security boundary
+Adopt the balanced split for security coverage.
+
+Conformance should verify portable, externally observable guarantees:
+- selected env var non-disclosure checks
+- registration and handshake redaction checks
+- common auth failure handling
+- safe behavior for oversized and malformed inputs
+- no secret leakage in normal outputs, surfaced errors, reports, or captures
+
+Each SDK repository should continue owning:
+- framework-specific hardening
+- dependency and supply-chain security
+- runtime-specific exploit classes
+- language-specific exception and debug-mode behavior
+
+** Transport-critical compatibility
+Reconnect, drain, lease-extension, and related state-handling behavior should block general
+compatibility.
+
+Reason:
+- an SDK should not be treated as generally compatible for live usage if these state and
+  delivery guarantees do not work correctly
+
+Implementation note:
+- these cases can still live in clearly named transport suites, but their results must feed
+  into the overall compatibility classification rather than being treated as optional
+
+** Additional config formats
+JSON and TOML support do not need special planning work up front if they come nearly for free
+through =koanf=.
+
+Implementation note:
+- keep YAML as the documented canonical format
+- accept JSON and TOML as convenience formats if loader support is trivial
+
+* Security Boundary Options
+There are a few reasonable ways to divide security checks between conformance and each SDK's
+own deeper test suite.
+
+** Option 1: Minimal conformance boundary
+Conformance checks only portable guarantees:
+- no secret leakage in normal outputs
+- no secret leakage in surfaced errors
+- no secret leakage in runner-generated reports and captures
+- malformed inputs fail safely
+
+SDK repos own:
+- runtime-specific sandboxing
+- memory safety and unsafe deserialization concerns
+- framework-specific debug mode and stack trace exposure
+
+** Option 2: Balanced split
+Conformance checks the portable guarantees above, plus:
+- selected env var non-disclosure checks
+- registration and handshake redaction checks
+- common auth failure handling
+- safe behavior for oversized and malformed inputs
+
+SDK repos own:
+- framework-specific hardening
+- dependency and supply-chain security
+- runtime-specific exploit classes
+
+This is the recommended starting point.
+
+** Option 3: Aggressive conformance boundary
+Conformance attempts to verify deeper hardening behavior across SDKs, including:
+- broad env and process isolation expectations
+- framework-specific exception behavior
+- detailed log-policy enforcement
+- more invasive negative and fuzz-style inputs
+
+This gives higher assurance but will be expensive, brittle, and uneven across languages.
+
 * Phases
 ** Phase 1: Command and shared model
 - [ ] Add =cmd/conformance= and register it in the root CLI.
 - [ ] Define shared config, suite, case, feature, and report types.
 - [ ] Implement =list= and a stub =run= command.
 - [ ] Define report schema versioning.
+- [ ] Define fixture and golden-data conventions, including sanitization rules.
 
 ** Phase 2: Serve runner
 - [ ] Extract serve-oriented protocol logic from =tests/= into =pkg/conformance/runner/serve=.
 - [ ] Implement a small initial case set.
 - [ ] Emit pretty and JSON reports.
 - [ ] Add basic doctor checks for serve mode.
+- [ ] Add the first negative-input serve cases.
 
 ** Phase 3: Connect runner
 - [ ] Implement worker process orchestration.
 - [ ] Add readiness checks against dev server Connect state.
 - [ ] Reuse shared cases where transport-independent.
 - [ ] Add Connect-specific doctor checks and diagnostics.
+- [ ] Add connect-safe negative cases that validate error handling without requiring the
+  runner to implement the wire protocol directly.
 
 ** Phase 4: Reporting and CI ergonomics
 - [ ] Implement =report= subcommand.
 - [ ] Add JUnit and Markdown renderers.
 - [ ] Support stable artifact paths and exit codes for CI.
 - [ ] Document usage for SDK repositories.
+- [ ] Ensure reports and captures redact secrets and unstable values.
 
 ** Phase 5: Config and adoption
 - [ ] Add =init= scaffolding for SDK repos.
 - [ ] Support per-repo config files for commands, env, and suites.
 - [ ] Trial adoption in =inngestgo= first, then other SDK repos.
+- [ ] Add =negative= and =security= suites to the default CI recommendation once stable.
 
 * Open Questions
-- What config file format should SDK repos use: YAML, JSON, or CUE?
-- Should =run= default to starting the dev server, or only attach to an existing server?
-- How much transport-specific evidence should be surfaced in the base report vs optional
-  capture artifacts?
-- Do we want a separate transport suite for reconnect, drain, and lease-extension behavior
-  in v1 or after initial adoption?
-- Which minimum feature matrix should be required before calling an SDK "compatible"?
 
 * Success Criteria
 - An SDK repository can run =inngest conformance run= locally with one command.

--- a/docs/plans/002-cli-conformance-runner.org
+++ b/docs/plans/002-cli-conformance-runner.org
@@ -558,14 +558,14 @@ Overview:
 - prove the shared model works in a real transport before adding connect-specific complexity
 
 Subtasks:
-- [ ] Extract serve-oriented protocol logic from =tests/= into =pkg/conformance/runner/serve=.
-- [ ] Define the serve transport contract, including introspection, registration, and event
+- [X] Extract serve-oriented protocol logic from =tests/= into =pkg/conformance/runner/serve=.
+- [X] Define the serve transport contract, including introspection, registration, and event
   injection expectations.
-- [ ] Implement the first happy-path cases: registration, invocation, steps, retry, cancel,
+- [X] Implement the first happy-path cases: registration, invocation, steps, retry, cancel,
   and wait-for-event.
-- [ ] Add serve-mode doctor checks for SDK reachability, required endpoints, and basic config
+- [X] Add serve-mode doctor checks for SDK reachability, required endpoints, and basic config
   validation.
-- [ ] Emit pretty and JSON reports from serve runs using the shared report model.
+- [X] Emit pretty and JSON reports from serve runs using the shared report model.
 - [ ] Add the first negative-input serve cases, focusing on malformed payloads and safe error
   handling.
 - [ ] Add basic security assertions in serve mode, including secret redaction and env var

--- a/docs/plans/002-cli-conformance-runner.org
+++ b/docs/plans/002-cli-conformance-runner.org
@@ -535,41 +535,94 @@ This gives higher assurance but will be expensive, brittle, and uneven across la
 
 * Phases
 ** Phase 1: Command and shared model
+Overview:
+- establish the CLI surface and the shared data model that every later phase builds on
+- make the conformance command discoverable even before all runners and suites are complete
+
+Subtasks:
 - [ ] Add =cmd/conformance= and register it in the root CLI.
-- [ ] Define shared config, suite, case, feature, and report types.
-- [ ] Implement =list= and a stub =run= command.
-- [ ] Define report schema versioning.
-- [ ] Define fixture and golden-data conventions, including sanitization rules.
+- [ ] Define the top-level subcommands: =run=, =list=, =doctor=, and =report=.
+- [ ] Define shared config, suite, case, feature, status, and report types.
+- [ ] Define report schema versioning and a stable JSON shape.
+- [ ] Implement =list= against the shared registry so available suites and cases are visible.
+- [ ] Implement a stub =run= path that loads config, selects suites, and validates inputs.
+- [ ] Define fixture and golden-data conventions, including sanitization and normalization
+  rules.
+- [ ] Establish the compatibility classification model: full, partial, incompatible, and
+  unknown.
 
 ** Phase 2: Serve runner
+Overview:
+- deliver the first useful end-to-end runner by targeting SDKs that expose the standard HTTP
+  serve flow
+- prove the shared model works in a real transport before adding connect-specific complexity
+
+Subtasks:
 - [ ] Extract serve-oriented protocol logic from =tests/= into =pkg/conformance/runner/serve=.
-- [ ] Implement a small initial case set.
-- [ ] Emit pretty and JSON reports.
-- [ ] Add basic doctor checks for serve mode.
-- [ ] Add the first negative-input serve cases.
+- [ ] Define the serve transport contract, including introspection, registration, and event
+  injection expectations.
+- [ ] Implement the first happy-path cases: registration, invocation, steps, retry, cancel,
+  and wait-for-event.
+- [ ] Add serve-mode doctor checks for SDK reachability, required endpoints, and basic config
+  validation.
+- [ ] Emit pretty and JSON reports from serve runs using the shared report model.
+- [ ] Add the first negative-input serve cases, focusing on malformed payloads and safe error
+  handling.
+- [ ] Add basic security assertions in serve mode, including secret redaction and env var
+  non-disclosure checks.
+- [ ] Validate that failures still produce a useful artifact bundle and do not fail fast by
+  default.
 
 ** Phase 3: Connect runner
-- [ ] Implement worker process orchestration.
-- [ ] Add readiness checks against dev server Connect state.
-- [ ] Reuse shared cases where transport-independent.
-- [ ] Add Connect-specific doctor checks and diagnostics.
+Overview:
+- extend the system to SDKs that use Connect workers instead of HTTP serve endpoints
+- keep the case model shared, while adapting orchestration, readiness, and evidence capture
+  to the Connect transport
+
+Subtasks:
+- [ ] Implement worker process orchestration, lifecycle handling, and cleanup.
+- [ ] Add readiness checks against dev server Connect state before test execution begins.
+- [ ] Define the connect transport contract in terms of observable behavior rather than raw
+  protocol implementation.
+- [ ] Reuse shared feature cases where transport-independent and add transport adapters where
+  needed.
+- [ ] Add Connect-specific doctor checks and diagnostics for worker startup, readiness, and
+  state visibility.
 - [ ] Add connect-safe negative cases that validate error handling without requiring the
   runner to implement the wire protocol directly.
+- [ ] Add transport-critical cases for reconnect, drain, and lease-extension behavior.
+- [ ] Feed transport-critical case results into the overall compatibility classification.
 
 ** Phase 4: Reporting and CI ergonomics
-- [ ] Implement =report= subcommand.
-- [ ] Add JUnit and Markdown renderers.
-- [ ] Support stable artifact paths and exit codes for CI.
-- [ ] Document usage for SDK repositories.
-- [ ] Ensure reports and captures redact secrets and unstable values.
+Overview:
+- make the runner useful in CI and easy to consume by humans without reading raw logs
+- ensure failure artifacts are stable, sanitized, and structured enough for regression
+  tracking
+
+Subtasks:
+- [ ] Implement =report= for re-rendering existing artifacts without re-running tests.
+- [ ] Add output renderers for pretty terminal output, JSON, JUnit, and Markdown.
+- [ ] Finalize the default failure artifact bundle and optional verbose capture behavior.
+- [ ] Support stable artifact paths, stable exit codes, and CI-friendly summary output.
+- [ ] Ensure reports and captures redact secrets and unstable values consistently.
+- [ ] Add normalized reason codes and evidence snippets to improve triage quality.
+- [ ] Document how CI should store, render, and diff conformance artifacts.
 
 ** Phase 5: Config and adoption
-- [ ] Add =init= scaffolding for SDK repos.
-- [ ] Support per-repo config files for commands, env, and suites.
-- [ ] Trial adoption in =inngestgo= first, then other SDK repos.
-- [ ] Add =negative= and =security= suites to the default CI recommendation once stable.
+Overview:
+- make adoption easy for SDK repositories and validate the design across multiple language
+  implementations
+- use early adopters to refine config, fixture expectations, and compatibility reporting
 
-* Open Questions
+Subtasks:
+- [ ] Add =init= scaffolding for SDK repos.
+- [ ] Support per-repo config files for commands, env, suites, and fixture metadata.
+- [ ] Define a small canonical config example for serve and connect transports.
+- [ ] Trial adoption in =inngestgo= first to validate both shared cases and connect support.
+- [ ] Extend adoption to =inngest-rs= and =inngest-kt=, refining assumptions where the SDK
+  architecture differs.
+- [ ] Add =negative= and =security= suites to the default CI recommendation once stable.
+- [ ] Use adoption feedback to tune classifications, reason codes, and fixture requirements.
 
 * Success Criteria
 - An SDK repository can run =inngest conformance run= locally with one command.

--- a/pkg/cli/output/conformance.go
+++ b/pkg/cli/output/conformance.go
@@ -1,0 +1,157 @@
+package output
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	conf "github.com/inngest/inngest/pkg/conformance"
+)
+
+func TextConformanceCatalog(registry conf.Registry) error {
+	w := NewTextWriter()
+
+	transports := make([]string, 0, len(conf.ValidTransports()))
+	for _, transport := range conf.ValidTransports() {
+		transports = append(transports, string(transport))
+	}
+
+	root := OrderedData(
+		"Transports", strings.Join(transports, ", "),
+	)
+
+	suiteIDs := make([]string, 0, len(registry.Suites))
+	for suiteID := range registry.Suites {
+		suiteIDs = append(suiteIDs, suiteID)
+	}
+	sort.Strings(suiteIDs)
+
+	suites := NewOrderedMap()
+	for _, suiteID := range suiteIDs {
+		suite := registry.Suites[suiteID]
+		caseIDs := make([]string, 0, len(suite.CaseIDs))
+		caseIDs = append(caseIDs, suite.CaseIDs...)
+		sort.Strings(caseIDs)
+		suites.Set(suite.ID, OrderedData(
+			"Label", suite.Label,
+			"Description", suite.Description,
+			"Cases", strings.Join(caseIDs, ", "),
+		))
+	}
+	root.Set("Suites", suites)
+
+	featureIDs := make([]string, 0, len(registry.Features))
+	for featureID := range registry.Features {
+		featureIDs = append(featureIDs, featureID)
+	}
+	sort.Strings(featureIDs)
+
+	features := NewOrderedMap()
+	for _, featureID := range featureIDs {
+		feature := registry.Features[featureID]
+		transports := make([]string, 0, len(feature.Transport))
+		for _, transport := range feature.Transport {
+			transports = append(transports, string(transport))
+		}
+
+		data := OrderedData("Label", feature.Label)
+		if feature.Description != "" {
+			data.Set("Description", feature.Description)
+		}
+		if len(transports) > 0 {
+			sort.Strings(transports)
+			data.Set("Transports", strings.Join(transports, ", "))
+		}
+		features.Set(feature.ID, data)
+	}
+	root.Set("Features", features)
+
+	if err := w.WriteOrdered(root, WithTextOptLeadSpace(true)); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+func TextConformanceRunPlan(plan conf.RunPlan) error {
+	w := NewTextWriter()
+
+	transport := "all"
+	if plan.Transport != "" {
+		transport = string(plan.Transport)
+	}
+
+	root := OrderedData(
+		"Transport", transport,
+		"Suite Count", len(plan.Suites),
+		"Case Count", len(plan.Cases),
+		"Feature Count", len(plan.Features),
+	)
+
+	suites := NewOrderedMap()
+	for _, suite := range plan.Suites {
+		suites.Set(suite.ID, OrderedData(
+			"Label", suite.Label,
+			"Description", suite.Description,
+		))
+	}
+	root.Set("Resolved Suites", suites)
+
+	cases := NewOrderedMap()
+	for _, testCase := range plan.Cases {
+		transports := make([]string, 0, len(testCase.Transport))
+		for _, transport := range testCase.Transport {
+			transports = append(transports, string(transport))
+		}
+		sort.Strings(transports)
+
+		data := OrderedData(
+			"Label", testCase.Label,
+			"Suite", testCase.SuiteID,
+			"Features", strings.Join(testCase.Features, ", "),
+		)
+		if len(transports) > 0 {
+			data.Set("Transports", strings.Join(transports, ", "))
+		}
+		cases.Set(testCase.ID, data)
+	}
+	root.Set("Resolved Cases", cases)
+
+	features := NewOrderedMap()
+	for _, feature := range plan.Features {
+		features.Set(feature.ID, feature.Label)
+	}
+	root.Set("Resolved Features", features)
+
+	root.Set("Compatibility Classes", strings.Join([]string{
+		string(conf.CompatibilityFull),
+		string(conf.CompatibilityPartial),
+		string(conf.CompatibilityIncompatible),
+		string(conf.CompatibilityUnknown),
+	}, ", "))
+	root.Set("Note", "Phase 1 validates configuration and selection only. Execution is not implemented yet.")
+
+	if err := w.WriteOrdered(root, WithTextOptLeadSpace(true)); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+func TextConformanceStub(command, message string) error {
+	w := NewTextWriter()
+	if err := w.WriteOrdered(OrderedData(
+		"Command", command,
+		"Status", "stub",
+		"Message", message,
+	), WithTextOptLeadSpace(true)); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+func TextConformanceConfigErrorHint(configPath string) error {
+	msg := "No config file provided."
+	if configPath != "" {
+		msg = fmt.Sprintf("Config loaded from %s.", configPath)
+	}
+	return TextConformanceStub("conformance", msg)
+}

--- a/pkg/cli/output/conformance.go
+++ b/pkg/cli/output/conformance.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	conf "github.com/inngest/inngest/pkg/conformance"
+	"github.com/inngest/inngest/pkg/conformance/runner/serve"
 )
 
 func TextConformanceCatalog(registry conf.Registry) error {
@@ -154,4 +155,91 @@ func TextConformanceConfigErrorHint(configPath string) error {
 		msg = fmt.Sprintf("Config loaded from %s.", configPath)
 	}
 	return TextConformanceStub("conformance", msg)
+}
+
+func TextConformanceDoctor(checks []serve.Check) error {
+	w := NewTextWriter()
+
+	root := NewOrderedMap()
+	for _, check := range checks {
+		status := "failed"
+		if check.Passed {
+			status = "passed"
+		}
+
+		root.Set(check.Name, OrderedData(
+			"Status", status,
+			"Message", check.Message,
+		))
+	}
+
+	if err := w.WriteOrdered(OrderedData("Checks", root), WithTextOptLeadSpace(true)); err != nil {
+		return err
+	}
+	return w.Flush()
+}
+
+func TextConformanceReport(report conf.Report) error {
+	w := NewTextWriter()
+
+	root := OrderedData(
+		"Schema Version", report.SchemaVersion,
+		"Transport", string(report.Transport),
+		"Compatibility", string(report.Compatibility),
+		"Case Count", len(report.Cases),
+		"Feature Count", len(report.Features),
+	)
+
+	caseResults := NewOrderedMap()
+	caseIDs := make([]string, 0, len(report.Cases))
+	caseByID := map[string]conf.CaseResult{}
+	for _, result := range report.Cases {
+		caseIDs = append(caseIDs, result.CaseID)
+		caseByID[result.CaseID] = result
+	}
+	sort.Strings(caseIDs)
+	for _, caseID := range caseIDs {
+		result := caseByID[caseID]
+		data := OrderedData(
+			"Suite", result.SuiteID,
+			"Status", string(result.Status),
+		)
+		if result.ReasonCode != "" {
+			data.Set("Reason Code", string(result.ReasonCode))
+		}
+		if result.Reason != "" {
+			data.Set("Reason", result.Reason)
+		}
+		caseResults.Set(caseID, data)
+	}
+	root.Set("Cases", caseResults)
+
+	featureResults := NewOrderedMap()
+	featureIDs := make([]string, 0, len(report.Features))
+	featureByID := map[string]conf.FeatureResult{}
+	for _, result := range report.Features {
+		featureIDs = append(featureIDs, result.FeatureID)
+		featureByID[result.FeatureID] = result
+	}
+	sort.Strings(featureIDs)
+	for _, featureID := range featureIDs {
+		result := featureByID[featureID]
+		data := OrderedData(
+			"Compatibility", string(result.Compatibility),
+			"Backing Cases", strings.Join(result.BackingCaseIDs, ", "),
+		)
+		if result.ReasonCode != "" {
+			data.Set("Reason Code", string(result.ReasonCode))
+		}
+		if result.Reason != "" {
+			data.Set("Reason", result.Reason)
+		}
+		featureResults.Set(featureID, data)
+	}
+	root.Set("Features", featureResults)
+
+	if err := w.WriteOrdered(root, WithTextOptLeadSpace(true)); err != nil {
+		return err
+	}
+	return w.Flush()
 }

--- a/pkg/conformance/case.go
+++ b/pkg/conformance/case.go
@@ -1,0 +1,25 @@
+package conformance
+
+type Case struct {
+	ID          string      `json:"id" koanf:"id"`
+	Label       string      `json:"label" koanf:"label"`
+	Description string      `json:"description,omitempty" koanf:"description"`
+	SuiteID     string      `json:"suite_id" koanf:"suite-id"`
+	Features    []string    `json:"features" koanf:"features"`
+	Transport   []Transport `json:"transport,omitempty" koanf:"transport"`
+}
+
+func (c Case) SupportsTransport(transport Transport) bool {
+	if transport == "" {
+		return true
+	}
+	if len(c.Transport) == 0 {
+		return true
+	}
+	for _, candidate := range c.Transport {
+		if candidate == transport {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/conformance/compatibility.go
+++ b/pkg/conformance/compatibility.go
@@ -1,0 +1,121 @@
+package conformance
+
+// BuildFeatureResults rolls up case outcomes into per-feature compatibility.
+//
+// The compatibility model intentionally stays coarse in Phase 2:
+// - any failed backing case makes the feature incompatible
+// - any mix of passed and unevaluable/not-implemented becomes partial
+// - all passed becomes full
+// - no meaningful evaluation remains unknown
+func BuildFeatureResults(plan RunPlan, caseResults []CaseResult) []FeatureResult {
+	caseByID := make(map[string]CaseResult, len(caseResults))
+	for _, result := range caseResults {
+		caseByID[result.CaseID] = result
+	}
+
+	features := make([]FeatureResult, 0, len(plan.Features))
+	for _, feature := range plan.Features {
+		backing := backingCasesForFeature(plan.Cases, feature.ID)
+		featureResult := FeatureResult{
+			FeatureID:      feature.ID,
+			BackingCaseIDs: backing,
+			Compatibility:  CompatibilityUnknown,
+		}
+
+		var (
+			passed bool
+			failed bool
+			other  bool
+		)
+
+		for _, caseID := range backing {
+			result, ok := caseByID[caseID]
+			if !ok {
+				continue
+			}
+
+			switch result.Status {
+			case CaseStatusPassed:
+				passed = true
+			case CaseStatusFailed:
+				failed = true
+				if featureResult.ReasonCode == "" {
+					featureResult.ReasonCode = result.ReasonCode
+					featureResult.Reason = result.Reason
+				}
+			default:
+				other = true
+				if featureResult.ReasonCode == "" {
+					featureResult.ReasonCode = result.ReasonCode
+					featureResult.Reason = result.Reason
+				}
+			}
+		}
+
+		switch {
+		case failed:
+			featureResult.Compatibility = CompatibilityIncompatible
+		case passed && !other:
+			featureResult.Compatibility = CompatibilityFull
+		case passed && other:
+			featureResult.Compatibility = CompatibilityPartial
+		default:
+			featureResult.Compatibility = CompatibilityUnknown
+		}
+
+		features = append(features, featureResult)
+	}
+
+	return features
+}
+
+// OverallCompatibility computes the top-level SDK compatibility from feature
+// outcomes, keeping feature-level evaluation as the source of truth.
+func OverallCompatibility(features []FeatureResult) Compatibility {
+	if len(features) == 0 {
+		return CompatibilityUnknown
+	}
+
+	var (
+		hasFull    bool
+		hasPartial bool
+		hasUnknown bool
+	)
+
+	for _, feature := range features {
+		switch feature.Compatibility {
+		case CompatibilityIncompatible:
+			return CompatibilityIncompatible
+		case CompatibilityFull:
+			hasFull = true
+		case CompatibilityPartial:
+			hasPartial = true
+		case CompatibilityUnknown:
+			hasUnknown = true
+		}
+	}
+
+	switch {
+	case hasPartial:
+		return CompatibilityPartial
+	case hasFull && hasUnknown:
+		return CompatibilityPartial
+	case hasFull:
+		return CompatibilityFull
+	default:
+		return CompatibilityUnknown
+	}
+}
+
+func backingCasesForFeature(cases []Case, featureID string) []string {
+	backing := make([]string, 0, len(cases))
+	for _, testCase := range cases {
+		for _, caseFeatureID := range testCase.Features {
+			if caseFeatureID == featureID {
+				backing = append(backing, testCase.ID)
+				break
+			}
+		}
+	}
+	return backing
+}

--- a/pkg/conformance/config.go
+++ b/pkg/conformance/config.go
@@ -1,0 +1,93 @@
+package conformance
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/knadh/koanf/parsers/json"
+	"github.com/knadh/koanf/parsers/yaml"
+	"github.com/knadh/koanf/providers/file"
+	"github.com/knadh/koanf/v2"
+)
+
+type Config struct {
+	Transport Transport     `koanf:"transport" json:"transport"`
+	Suites    []string      `koanf:"suites" json:"suites"`
+	Cases     []string      `koanf:"cases" json:"cases"`
+	Features  []string      `koanf:"features" json:"features"`
+	Report    ReportConfig  `koanf:"report" json:"report"`
+	Fixtures  FixtureConfig `koanf:"fixtures" json:"fixtures"`
+	Golden    GoldenConfig  `koanf:"golden" json:"golden"`
+}
+
+type ReportConfig struct {
+	Format ReportFormat `koanf:"format" json:"format"`
+	Output string       `koanf:"output" json:"output"`
+}
+
+type FixtureConfig struct {
+	Root string `koanf:"root" json:"root"`
+}
+
+type GoldenConfig struct {
+	Root string     `koanf:"root" json:"root"`
+	Mode GoldenMode `koanf:"mode" json:"mode"`
+}
+
+func LoadConfig(path string) (Config, error) {
+	if path == "" {
+		return Config{}, nil
+	}
+
+	parser, err := parserForPath(path)
+	if err != nil {
+		return Config{}, err
+	}
+
+	k := koanf.New(".")
+	if err := k.Load(file.Provider(path), parser); err != nil {
+		return Config{}, fmt.Errorf("error parsing config file: %w", err)
+	}
+
+	var cfg Config
+	if err := k.Unmarshal("", &cfg); err != nil {
+		return Config{}, fmt.Errorf("error unmarshaling config: %w", err)
+	}
+
+	if cfg.Golden.Mode == "" {
+		cfg.Golden.Mode = GoldenModeSemantic
+	}
+	if cfg.Report.Format == "" {
+		cfg.Report.Format = ReportFormatPretty
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return Config{}, err
+	}
+
+	return cfg, nil
+}
+
+func (c Config) Validate() error {
+	if c.Transport != "" && !IsValidTransport(c.Transport) {
+		return fmt.Errorf("unknown transport %q", c.Transport)
+	}
+	if c.Report.Format != "" && !IsValidReportFormat(c.Report.Format) {
+		return fmt.Errorf("unknown report format %q", c.Report.Format)
+	}
+	if c.Golden.Mode != "" && c.Golden.Mode != GoldenModeSemantic {
+		return fmt.Errorf("unknown golden mode %q", c.Golden.Mode)
+	}
+	return nil
+}
+
+func parserForPath(path string) (koanf.Parser, error) {
+	switch ext := filepath.Ext(path); ext {
+	case ".yaml", ".yml":
+		return yaml.Parser(), nil
+	case ".json":
+		return json.Parser(), nil
+	default:
+		return nil, fmt.Errorf("unsupported config format %q", ext)
+	}
+}

--- a/pkg/conformance/config.go
+++ b/pkg/conformance/config.go
@@ -3,6 +3,7 @@ package conformance
 import (
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/knadh/koanf/parsers/json"
 	"github.com/knadh/koanf/parsers/yaml"
@@ -10,19 +11,45 @@ import (
 	"github.com/knadh/koanf/v2"
 )
 
+// Config describes the user-facing conformance configuration.
+//
+// Phase 2 only needs the serve transport to be usable, but the shape is kept
+// transport-neutral so connect can reuse the same top-level contract later.
 type Config struct {
 	Transport Transport     `koanf:"transport" json:"transport"`
 	Suites    []string      `koanf:"suites" json:"suites"`
 	Cases     []string      `koanf:"cases" json:"cases"`
 	Features  []string      `koanf:"features" json:"features"`
+	Timeout   string        `koanf:"timeout" json:"timeout"`
+	SDK       SDKConfig     `koanf:"sdk" json:"sdk"`
+	Dev       DevConfig     `koanf:"dev" json:"dev"`
 	Report    ReportConfig  `koanf:"report" json:"report"`
 	Fixtures  FixtureConfig `koanf:"fixtures" json:"fixtures"`
 	Golden    GoldenConfig  `koanf:"golden" json:"golden"`
 }
 
+// SDKConfig captures the transport-facing SDK endpoint configuration.
+//
+// For serve mode the canonical URL is the SDK serve endpoint, for example
+// http://127.0.0.1:3000/api/inngest.
 type ReportConfig struct {
 	Format ReportFormat `koanf:"format" json:"format"`
 	Output string       `koanf:"output" json:"output"`
+}
+
+type SDKConfig struct {
+	URL            string `koanf:"url" json:"url"`
+	IntrospectPath string `koanf:"introspect_path" json:"introspect_path"`
+}
+
+// DevConfig captures the server-side endpoints and credentials the runner needs
+// in order to register functions and publish events.
+type DevConfig struct {
+	URL        string `koanf:"url" json:"url"`
+	APIURL     string `koanf:"api_url" json:"api_url"`
+	EventURL   string `koanf:"event_url" json:"event_url"`
+	EventKey   string `koanf:"event_key" json:"event_key"`
+	SigningKey string `koanf:"signing_key" json:"signing_key"`
 }
 
 type FixtureConfig struct {
@@ -78,7 +105,29 @@ func (c Config) Validate() error {
 	if c.Golden.Mode != "" && c.Golden.Mode != GoldenModeSemantic {
 		return fmt.Errorf("unknown golden mode %q", c.Golden.Mode)
 	}
+	if c.Timeout != "" {
+		if _, err := time.ParseDuration(c.Timeout); err != nil {
+			return fmt.Errorf("invalid timeout %q: %w", c.Timeout, err)
+		}
+	}
 	return nil
+}
+
+// TimeoutOrDefault resolves the configured timeout to a concrete duration.
+//
+// The default is intentionally conservative so the first runnable showcase
+// cases do not inherit a zero timeout when users omit the field.
+func (c Config) TimeoutOrDefault(fallback time.Duration) time.Duration {
+	if c.Timeout == "" {
+		return fallback
+	}
+
+	d, err := time.ParseDuration(c.Timeout)
+	if err != nil {
+		return fallback
+	}
+
+	return d
 }
 
 func parserForPath(path string) (koanf.Parser, error) {

--- a/pkg/conformance/config_test.go
+++ b/pkg/conformance/config_test.go
@@ -1,0 +1,49 @@
+package conformance
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigYAML(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "inngest.conformance.yaml")
+	err := os.WriteFile(path, []byte(`
+transport: serve
+suites:
+  - core
+report:
+  format: json
+fixtures:
+  root: ./fixtures
+golden:
+  root: ./golden
+`), 0o600)
+	require.NoError(t, err)
+
+	cfg, err := LoadConfig(path)
+	require.NoError(t, err)
+	require.Equal(t, TransportServe, cfg.Transport)
+	require.Equal(t, []string{"core"}, cfg.Suites)
+	require.Equal(t, ReportFormatJSON, cfg.Report.Format)
+	require.Equal(t, "./fixtures", cfg.Fixtures.Root)
+	require.Equal(t, "./golden", cfg.Golden.Root)
+	require.Equal(t, GoldenModeSemantic, cfg.Golden.Mode)
+}
+
+func TestLoadConfigRejectsInvalidTransport(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "inngest.conformance.json")
+	err := os.WriteFile(path, []byte(`{"transport":"smtp"}`), 0o600)
+	require.NoError(t, err)
+
+	_, err = LoadConfig(path)
+	require.ErrorContains(t, err, `unknown transport "smtp"`)
+}

--- a/pkg/conformance/feature.go
+++ b/pkg/conformance/feature.go
@@ -1,0 +1,8 @@
+package conformance
+
+type Feature struct {
+	ID          string      `json:"id" koanf:"id"`
+	Label       string      `json:"label" koanf:"label"`
+	Description string      `json:"description,omitempty" koanf:"description"`
+	Transport   []Transport `json:"transport,omitempty" koanf:"transport"`
+}

--- a/pkg/conformance/registry.go
+++ b/pkg/conformance/registry.go
@@ -1,0 +1,168 @@
+package conformance
+
+import "fmt"
+
+type Registry struct {
+	Suites   map[string]Suite   `json:"suites"`
+	Cases    map[string]Case    `json:"cases"`
+	Features map[string]Feature `json:"features"`
+}
+
+func DefaultRegistry() Registry {
+	features := map[string]Feature{
+		"serve-introspection": {ID: "serve-introspection", Label: "Serve Introspection", Transport: []Transport{TransportServe}},
+		"registration":        {ID: "registration", Label: "Registration"},
+		"invocation":          {ID: "invocation", Label: "Invocation"},
+		"steps":               {ID: "steps", Label: "Steps"},
+		"retry":               {ID: "retry", Label: "Retry"},
+		"cancel":              {ID: "cancel", Label: "Cancel"},
+		"wait-for-event":      {ID: "wait-for-event", Label: "Wait For Event"},
+		"malformed-input":     {ID: "malformed-input", Label: "Malformed Input Handling"},
+		"auth-validation":     {ID: "auth-validation", Label: "Authentication Validation"},
+		"secret-redaction":    {ID: "secret-redaction", Label: "Secret Redaction"},
+		"env-nondisclosure":   {ID: "env-nondisclosure", Label: "Environment Variable Non-Disclosure"},
+		"connect-readiness":   {ID: "connect-readiness", Label: "Connect Readiness", Transport: []Transport{TransportConnect}},
+		"connect-reconnect":   {ID: "connect-reconnect", Label: "Connect Reconnect", Transport: []Transport{TransportConnect}},
+		"connect-drain":       {ID: "connect-drain", Label: "Connect Drain Handling", Transport: []Transport{TransportConnect}},
+		"connect-lease-renew": {ID: "connect-lease-renew", Label: "Connect Lease Extension", Transport: []Transport{TransportConnect}},
+		"serve-registration":  {ID: "serve-registration", Label: "Serve Registration", Transport: []Transport{TransportServe}},
+	}
+
+	cases := map[string]Case{
+		"serve-introspection": {
+			ID: "serve-introspection", Label: "Serve Introspection", SuiteID: "transport-serve",
+			Features: []string{"serve-introspection", "serve-registration"}, Transport: []Transport{TransportServe},
+		},
+		"basic-invoke": {
+			ID: "basic-invoke", Label: "Basic Invoke", SuiteID: "core",
+			Features: []string{"registration", "invocation"}, Transport: []Transport{TransportServe, TransportConnect},
+		},
+		"steps-serial": {
+			ID: "steps-serial", Label: "Serial Steps", SuiteID: "core",
+			Features: []string{"steps"}, Transport: []Transport{TransportServe, TransportConnect},
+		},
+		"retry-basic": {
+			ID: "retry-basic", Label: "Retry", SuiteID: "core",
+			Features: []string{"retry"}, Transport: []Transport{TransportServe, TransportConnect},
+		},
+		"cancel-basic": {
+			ID: "cancel-basic", Label: "Cancel", SuiteID: "core",
+			Features: []string{"cancel"}, Transport: []Transport{TransportServe, TransportConnect},
+		},
+		"wait-for-event-basic": {
+			ID: "wait-for-event-basic", Label: "Wait For Event", SuiteID: "core",
+			Features: []string{"wait-for-event"}, Transport: []Transport{TransportServe, TransportConnect},
+		},
+		"malformed-payload": {
+			ID: "malformed-payload", Label: "Malformed Payload", SuiteID: "negative",
+			Features: []string{"malformed-input"}, Transport: []Transport{TransportServe, TransportConnect},
+		},
+		"invalid-auth": {
+			ID: "invalid-auth", Label: "Invalid Auth", SuiteID: "negative",
+			Features: []string{"auth-validation"}, Transport: []Transport{TransportServe, TransportConnect},
+		},
+		"secret-redaction": {
+			ID: "secret-redaction", Label: "Secret Redaction", SuiteID: "security",
+			Features: []string{"secret-redaction", "env-nondisclosure"}, Transport: []Transport{TransportServe, TransportConnect},
+		},
+		"connect-ready": {
+			ID: "connect-ready", Label: "Connect Ready", SuiteID: "transport-connect",
+			Features: []string{"connect-readiness"}, Transport: []Transport{TransportConnect},
+		},
+		"connect-reconnect": {
+			ID: "connect-reconnect", Label: "Connect Reconnect", SuiteID: "transport-connect",
+			Features: []string{"connect-reconnect"}, Transport: []Transport{TransportConnect},
+		},
+		"connect-drain": {
+			ID: "connect-drain", Label: "Connect Drain", SuiteID: "transport-connect",
+			Features: []string{"connect-drain", "connect-lease-renew"}, Transport: []Transport{TransportConnect},
+		},
+	}
+
+	suites := map[string]Suite{
+		"core": {
+			ID: "core", Label: "Core",
+			Description: "Happy-path feature compatibility for generally implemented SDK capabilities.",
+			CaseIDs:     []string{"basic-invoke", "steps-serial", "retry-basic", "cancel-basic", "wait-for-event-basic"},
+		},
+		"negative": {
+			ID: "negative", Label: "Negative",
+			Description: "Malformed and defensive-input coverage evaluated per feature.",
+			CaseIDs:     []string{"malformed-payload", "invalid-auth"},
+		},
+		"security": {
+			ID: "security", Label: "Security",
+			Description: "Portable, externally observable security and secret-handling checks.",
+			CaseIDs:     []string{"secret-redaction"},
+		},
+		"transport-serve": {
+			ID: "transport-serve", Label: "Transport Serve",
+			Description: "Serve-specific transport and registration cases.",
+			CaseIDs:     []string{"serve-introspection"},
+		},
+		"transport-connect": {
+			ID: "transport-connect", Label: "Transport Connect",
+			Description: "Connect worker lifecycle and state-handling cases.",
+			CaseIDs:     []string{"connect-ready", "connect-reconnect", "connect-drain"},
+		},
+	}
+
+	registry := Registry{
+		Suites:   suites,
+		Cases:    cases,
+		Features: features,
+	}
+	if err := registry.Validate(); err != nil {
+		panic(fmt.Sprintf("invalid conformance registry: %v", err))
+	}
+	return registry
+}
+
+func (r Registry) Validate() error {
+	for suiteID, suite := range r.Suites {
+		if suite.ID == "" || suite.ID != suiteID {
+			return fmt.Errorf("suite %q has mismatched id %q", suiteID, suite.ID)
+		}
+		for _, caseID := range suite.CaseIDs {
+			c, ok := r.Cases[caseID]
+			if !ok {
+				return fmt.Errorf("suite %q references unknown case %q", suiteID, caseID)
+			}
+			if c.SuiteID != suiteID {
+				return fmt.Errorf("case %q belongs to suite %q but was listed in %q", caseID, c.SuiteID, suiteID)
+			}
+		}
+	}
+
+	for caseID, testCase := range r.Cases {
+		if testCase.ID == "" || testCase.ID != caseID {
+			return fmt.Errorf("case %q has mismatched id %q", caseID, testCase.ID)
+		}
+		if _, ok := r.Suites[testCase.SuiteID]; !ok {
+			return fmt.Errorf("case %q references unknown suite %q", caseID, testCase.SuiteID)
+		}
+		for _, featureID := range testCase.Features {
+			if _, ok := r.Features[featureID]; !ok {
+				return fmt.Errorf("case %q references unknown feature %q", caseID, featureID)
+			}
+		}
+		for _, transport := range testCase.Transport {
+			if !IsValidTransport(transport) {
+				return fmt.Errorf("case %q uses invalid transport %q", caseID, transport)
+			}
+		}
+	}
+
+	for featureID, feature := range r.Features {
+		if feature.ID == "" || feature.ID != featureID {
+			return fmt.Errorf("feature %q has mismatched id %q", featureID, feature.ID)
+		}
+		for _, transport := range feature.Transport {
+			if !IsValidTransport(transport) {
+				return fmt.Errorf("feature %q uses invalid transport %q", featureID, transport)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/conformance/report.go
+++ b/pkg/conformance/report.go
@@ -1,9 +1,21 @@
 package conformance
 
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
 const ReportSchemaVersion = "v1alpha1"
 
+// Report is the portable artifact written by the conformance runner.
+//
+// The shape is still intentionally compact in Phase 2. It contains enough data
+// to drive terminal rendering, JSON artifacts, and later diff/report commands
+// without forcing verbose per-transport traces into the base file.
 type Report struct {
 	SchemaVersion string          `json:"schema_version"`
+	Transport     Transport       `json:"transport,omitempty"`
 	Compatibility Compatibility   `json:"compatibility"`
 	Features      []FeatureResult `json:"features,omitempty"`
 	Cases         []CaseResult    `json:"cases,omitempty"`
@@ -24,4 +36,46 @@ type CaseResult struct {
 	ReasonCode  ReasonCode `json:"reason_code,omitempty"`
 	Reason      string     `json:"reason,omitempty"`
 	ArtifactRef string     `json:"artifact_ref,omitempty"`
+}
+
+// NewReport creates a report from the resolved plan and case outcomes.
+func NewReport(plan RunPlan, caseResults []CaseResult) Report {
+	features := BuildFeatureResults(plan, caseResults)
+
+	return Report{
+		SchemaVersion: ReportSchemaVersion,
+		Transport:     plan.Transport,
+		Compatibility: OverallCompatibility(features),
+		Features:      features,
+		Cases:         caseResults,
+	}
+}
+
+// WriteReport persists the base report artifact as stable JSON.
+func WriteReport(path string, report Report) error {
+	byt, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+
+	if err := os.WriteFile(path, byt, 0o600); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+
+	return nil
+}
+
+// LoadReport reads a previously written JSON report artifact.
+func LoadReport(path string) (Report, error) {
+	byt, err := os.ReadFile(path)
+	if err != nil {
+		return Report{}, fmt.Errorf("read report: %w", err)
+	}
+
+	var report Report
+	if err := json.Unmarshal(byt, &report); err != nil {
+		return Report{}, fmt.Errorf("decode report: %w", err)
+	}
+
+	return report, nil
 }

--- a/pkg/conformance/report.go
+++ b/pkg/conformance/report.go
@@ -1,0 +1,27 @@
+package conformance
+
+const ReportSchemaVersion = "v1alpha1"
+
+type Report struct {
+	SchemaVersion string          `json:"schema_version"`
+	Compatibility Compatibility   `json:"compatibility"`
+	Features      []FeatureResult `json:"features,omitempty"`
+	Cases         []CaseResult    `json:"cases,omitempty"`
+}
+
+type FeatureResult struct {
+	FeatureID      string        `json:"feature_id"`
+	Compatibility  Compatibility `json:"compatibility"`
+	ReasonCode     ReasonCode    `json:"reason_code,omitempty"`
+	Reason         string        `json:"reason,omitempty"`
+	BackingCaseIDs []string      `json:"backing_case_ids,omitempty"`
+}
+
+type CaseResult struct {
+	CaseID      string     `json:"case_id"`
+	SuiteID     string     `json:"suite_id"`
+	Status      CaseStatus `json:"status"`
+	ReasonCode  ReasonCode `json:"reason_code,omitempty"`
+	Reason      string     `json:"reason,omitempty"`
+	ArtifactRef string     `json:"artifact_ref,omitempty"`
+}

--- a/pkg/conformance/report_test.go
+++ b/pkg/conformance/report_test.go
@@ -1,0 +1,55 @@
+package conformance
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewReportRollsUpCompatibility(t *testing.T) {
+	t.Parallel()
+
+	plan := RunPlan{
+		Transport: TransportServe,
+		Cases: []Case{
+			{ID: "basic-invoke", SuiteID: "core", Features: []string{"registration", "invocation"}},
+			{ID: "retry-basic", SuiteID: "core", Features: []string{"retry"}},
+		},
+		Features: []Feature{
+			{ID: "invocation", Label: "Invocation"},
+			{ID: "registration", Label: "Registration"},
+			{ID: "retry", Label: "Retry"},
+		},
+	}
+
+	report := NewReport(plan, []CaseResult{
+		{CaseID: "basic-invoke", SuiteID: "core", Status: CaseStatusPassed},
+		{CaseID: "retry-basic", SuiteID: "core", Status: CaseStatusNotImplemented, ReasonCode: ReasonCodeNotImplemented},
+	})
+
+	require.Equal(t, CompatibilityPartial, report.Compatibility)
+	require.Len(t, report.Features, 3)
+}
+
+func TestReportRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+
+	report := Report{
+		SchemaVersion: ReportSchemaVersion,
+		Transport:     TransportServe,
+		Compatibility: CompatibilityFull,
+		Cases: []CaseResult{
+			{CaseID: "basic-invoke", SuiteID: "core", Status: CaseStatusPassed},
+		},
+	}
+
+	require.NoError(t, WriteReport(path, report))
+
+	loaded, err := LoadReport(path)
+	require.NoError(t, err)
+	require.Equal(t, report, loaded)
+}

--- a/pkg/conformance/runner/serve/runner.go
+++ b/pkg/conformance/runner/serve/runner.go
@@ -23,9 +23,7 @@ import (
 	"github.com/inngest/inngest/pkg/execution/driver"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/inngest"
-	"github.com/inngest/inngest/pkg/registration"
 	"github.com/inngest/inngest/pkg/sdk"
-	"github.com/inngest/inngest/pkg/util"
 	"github.com/inngest/inngestgo"
 )
 
@@ -33,8 +31,8 @@ import (
 //
 // The runner intentionally reuses the same protocol behavior that the existing
 // integration tests rely on:
-// 1. introspect the SDK fixture
-// 2. register the fixture functions against the dev server
+// 1. ask the SDK serve endpoint for its real in-band sync payload
+// 2. register the synced functions against the dev server
 // 3. proxy executor callbacks back into the SDK
 // 4. assert the request/response sequence for each selected case
 //
@@ -73,10 +71,6 @@ func (r *Runner) Doctor(ctx context.Context, plan conformance.RunPlan, runtime c
 		checks = append(checks, Check{Name: "sdk-url", Message: "sdk.url or --sdk-url is required"})
 		return checks, nil
 	}
-	if runtime.IntrospectURL == nil {
-		checks = append(checks, Check{Name: "introspect-url", Message: "sdk introspection URL could not be derived"})
-		return checks, nil
-	}
 	if runtime.APIURL == nil {
 		checks = append(checks, Check{Name: "api-url", Message: "dev.url or dev.api_url is required"})
 		return checks, nil
@@ -90,29 +84,36 @@ func (r *Runner) Doctor(ctx context.Context, plan conformance.RunPlan, runtime c
 		return checks, nil
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, runtime.IntrospectURL.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, runtime.SDKURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
 
 	resp, err := r.client.Do(req)
 	if err != nil {
-		checks = append(checks, Check{Name: "sdk-introspect", Message: err.Error()})
+		checks = append(checks, Check{Name: "sdk-inspect", Message: err.Error()})
 		return checks, nil
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
-		checks = append(checks, Check{Name: "sdk-introspect", Message: fmt.Sprintf("unexpected status %d", resp.StatusCode)})
+		checks = append(checks, Check{Name: "sdk-inspect", Message: fmt.Sprintf("unexpected status %d", resp.StatusCode)})
 		return checks, nil
 	}
+	checks = append(checks, Check{Name: "sdk-inspect", Passed: true, Message: fmt.Sprintf("serve endpoint returned %d", resp.StatusCode)})
 
-	functions := []sdk.SDKFunction{}
-	if err := json.NewDecoder(resp.Body).Decode(&functions); err != nil {
-		checks = append(checks, Check{Name: "sdk-introspect", Message: fmt.Sprintf("invalid JSON: %v", err)})
+	proxy, err := newProxyServer(r.client, runtime.SDKURL)
+	if err != nil {
+		return nil, err
+	}
+	defer proxy.close(context.Background())
+
+	registerRequest, functionsBySlug, err := r.syncSDKFunctions(ctx, runtime, proxy.URL())
+	if err != nil {
+		checks = append(checks, Check{Name: "sdk-sync", Message: err.Error()})
 		return checks, nil
 	}
-	checks = append(checks, Check{Name: "sdk-introspect", Passed: true, Message: fmt.Sprintf("discovered %d function(s)", len(functions))})
+	checks = append(checks, Check{Name: "sdk-sync", Passed: true, Message: fmt.Sprintf("synced %d function(s) from %s", len(registerRequest.Functions), registerRequest.URL)})
 
 	requiredSlugs := requiredFixtureSlugs(plan.Cases)
 	if len(requiredSlugs) == 0 {
@@ -120,14 +121,9 @@ func (r *Runner) Doctor(ctx context.Context, plan conformance.RunPlan, runtime c
 		return checks, nil
 	}
 
-	foundSlugs := make(map[string]struct{}, len(functions))
-	for _, fn := range functions {
-		foundSlugs[fn.Slug] = struct{}{}
-	}
-
 	missing := make([]string, 0)
 	for _, slug := range requiredSlugs {
-		if _, ok := foundSlugs[slug]; !ok {
+		if !hasSyncedFunction(functionsBySlug, slug) {
 			missing = append(missing, slug)
 		}
 	}
@@ -155,8 +151,8 @@ func (r *Runner) Run(ctx context.Context, plan conformance.RunPlan, runtime conf
 		return conformance.Report{}, fmt.Errorf("serve runner requires transport %q, got %q", conformance.TransportServe, runtime.Transport)
 	}
 
-	if runtime.SDKURL == nil || runtime.IntrospectURL == nil || runtime.APIURL == nil || runtime.EventURL == nil {
-		return conformance.Report{}, fmt.Errorf("serve runner requires sdk, introspection, api, and event URLs")
+	if runtime.SDKURL == nil || runtime.APIURL == nil || runtime.EventURL == nil {
+		return conformance.Report{}, fmt.Errorf("serve runner requires sdk, api, and event URLs")
 	}
 	if strings.TrimSpace(runtime.SigningKey) == "" {
 		return conformance.Report{}, fmt.Errorf("serve runner requires a signing key")
@@ -185,17 +181,18 @@ type runtimeEnv struct {
 	proxy *proxyServer
 
 	registerRequest sdk.RegisterRequest
-	functionsBySlug  map[string]sdk.SDKFunction
+	functionsBySlug map[string]sdk.SDKFunction
 }
 
 func (r *Runner) prepare(ctx context.Context, runtime conformance.RuntimeConfig) (*runtimeEnv, error) {
-	registerRequest, functionsBySlug, err := r.introspect(ctx, runtime)
+	proxy, err := newProxyServer(r.client, runtime.SDKURL)
 	if err != nil {
 		return nil, err
 	}
 
-	proxy, err := newProxyServer(r.client, runtime.SDKURL)
+	registerRequest, functionsBySlug, err := r.syncSDKFunctions(ctx, runtime, proxy.URL())
 	if err != nil {
+		_ = proxy.close(context.Background())
 		return nil, err
 	}
 
@@ -215,49 +212,80 @@ func (r *Runner) prepare(ctx context.Context, runtime conformance.RuntimeConfig)
 	}, nil
 }
 
-func (r *Runner) introspect(ctx context.Context, runtime conformance.RuntimeConfig) (sdk.RegisterRequest, map[string]sdk.SDKFunction, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, runtime.IntrospectURL.String(), nil)
+type inBandSyncResponse struct {
+	AppID       string            `json:"app_id"`
+	Functions   []sdk.SDKFunction `json:"functions"`
+	Platform    *string           `json:"platform"`
+	SDKLanguage string            `json:"sdk_language"`
+	SDKVersion  string            `json:"sdk_version"`
+	URL         string            `json:"url"`
+}
+
+func (r *Runner) syncSDKFunctions(ctx context.Context, runtime conformance.RuntimeConfig, proxyURL string) (sdk.RegisterRequest, map[string]sdk.SDKFunction, error) {
+	payload, err := json.Marshal(map[string]string{"url": proxyURL})
 	if err != nil {
 		return sdk.RegisterRequest{}, nil, err
 	}
 
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, runtime.SDKURL.String(), bytes.NewReader(payload))
+	if err != nil {
+		return sdk.RegisterRequest{}, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-inngest-sync-kind", "in_band")
+	req.Header.Set("X-Inngest-Server-Kind", "dev")
+	if strings.TrimSpace(runtime.SigningKey) != "" {
+		sig, err := inngestgo.Sign(ctx, time.Now(), []byte(runtime.SigningKey), payload)
+		if err != nil {
+			return sdk.RegisterRequest{}, nil, fmt.Errorf("sign in-band sync request: %w", err)
+		}
+		req.Header.Set("X-Inngest-Signature", sig)
+	}
+
 	resp, err := r.client.Do(req)
 	if err != nil {
-		return sdk.RegisterRequest{}, nil, fmt.Errorf("call introspect: %w", err)
+		return sdk.RegisterRequest{}, nil, fmt.Errorf("call SDK in-band sync: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 300 {
 		dump, _ := httputil.DumpResponse(resp, true)
-		return sdk.RegisterRequest{}, nil, fmt.Errorf("introspect returned %d: %s", resp.StatusCode, string(dump))
+		return sdk.RegisterRequest{}, nil, fmt.Errorf("SDK in-band sync returned %d: %s", resp.StatusCode, string(dump))
 	}
 
-	functions := []sdk.SDKFunction{}
-	if err := json.NewDecoder(resp.Body).Decode(&functions); err != nil {
-		return sdk.RegisterRequest{}, nil, fmt.Errorf("decode introspect response: %w", err)
+	syncResponse := inBandSyncResponse{}
+	if err := json.NewDecoder(resp.Body).Decode(&syncResponse); err != nil {
+		return sdk.RegisterRequest{}, nil, fmt.Errorf("decode SDK in-band sync response: %w; ensure the SDK app enables in-band sync", err)
+	}
+
+	sdkVersion := ""
+	if syncResponse.SDKLanguage != "" {
+		sdkVersion = syncResponse.SDKLanguage
+		if syncResponse.SDKVersion != "" {
+			sdkVersion += ":" + syncResponse.SDKVersion
+		}
+	}
+
+	requestURL := syncResponse.URL
+	if requestURL == "" {
+		requestURL = proxyURL
 	}
 
 	request := sdk.RegisterRequest{
-		URL:       runtime.SDKURL.String(),
-		Functions: functions,
+		V:          "1",
+		URL:        requestURL,
+		DeployType: sdk.DeployTypePing,
+		SDK:        sdkVersion,
+		AppName:    syncResponse.AppID,
+		Functions:  syncResponse.Functions,
+	}
+	if syncResponse.Platform != nil {
+		request.Headers.Platform = *syncResponse.Platform
 	}
 
-	processed, err := registration.ProcessFunctions(ctx, request, registration.ProcessOpts{})
-	if err != nil {
-		return sdk.RegisterRequest{}, nil, fmt.Errorf("process introspection response: %w", err)
-	}
-
-	functionsBySlug := make(map[string]sdk.SDKFunction, len(functions))
-	for _, fn := range functions {
+	functionsBySlug := make(map[string]sdk.SDKFunction, len(request.Functions))
+	for _, fn := range request.Functions {
 		functionsBySlug[fn.Slug] = fn
-	}
-
-	// Normalizing the processed functions keeps fixture lookups and registration
-	// behavior aligned with the existing integration test harness.
-	for _, processedFn := range processed.Functions {
-		for i := range processedFn.Function.Steps {
-			processedFn.Function.Steps[i].URI = util.NormalizeAppURL(processedFn.Function.Steps[i].URI, false)
-		}
 	}
 
 	return request, functionsBySlug, nil
@@ -292,13 +320,13 @@ func (e *runtimeEnv) runCase(ctx context.Context, testCase conformance.Case) con
 	}
 
 	if executor.slug != "" {
-		if _, ok := e.functionsBySlug[executor.slug]; !ok {
+		if !hasSyncedFunction(e.functionsBySlug, executor.slug) {
 			return conformance.CaseResult{
 				CaseID:     testCase.ID,
 				SuiteID:    testCase.SuiteID,
 				Status:     conformance.CaseStatusNotImplemented,
 				ReasonCode: conformance.ReasonCodeNotImplemented,
-				Reason:     fmt.Sprintf("required fixture function %q was not found in introspection", executor.slug),
+				Reason:     fmt.Sprintf("required fixture function %q was not found in SDK sync response", executor.slug),
 			}
 		}
 	}
@@ -383,6 +411,18 @@ func requiredFixtureSlugs(cases []conformance.Case) []string {
 		slugs = append(slugs, executor.slug)
 	}
 	return slugs
+}
+
+func hasSyncedFunction(functionsBySlug map[string]sdk.SDKFunction, expectedSlug string) bool {
+	if _, ok := functionsBySlug[expectedSlug]; ok {
+		return true
+	}
+	for actualSlug := range functionsBySlug {
+		if strings.HasSuffix(actualSlug, "-"+expectedSlug) {
+			return true
+		}
+	}
+	return false
 }
 
 func registerServeFunctions(ctx context.Context, client *http.Client, runtime conformance.RuntimeConfig, proxyURL string, registerRequest sdk.RegisterRequest) error {
@@ -793,20 +833,14 @@ func (h *caseHarness) expectJSONResponse(status int, expected any, timeout time.
 }
 
 func (h *caseHarness) expectGeneratorResponse(expected []state.GeneratorOpcode, timeout time.Duration) error {
-	return h.expectResponse(http.StatusOK, timeout, func(body []byte) error {
+	return h.expectResponse(http.StatusPartialContent, timeout, func(body []byte) error {
 		actual := []state.GeneratorOpcode{}
 		if err := json.Unmarshal(body, &actual); err != nil {
 			return err
 		}
 
-		// Step errors include stack traces with machine-specific file paths. The
-		// runner normalizes them so the semantic assertion stays portable.
-		if len(actual) == 1 && actual[0].Op == enums.OpcodeStepError && actual[0].Error != nil {
-			actual[0].Error.Stack = "[proxy-redact]"
-			if len(expected) == 1 && expected[0].Error != nil {
-				expected[0].Error.Stack = "[proxy-redact]"
-			}
-		}
+		actual = normalizeGeneratorOpcodes(actual)
+		expected = normalizeGeneratorOpcodes(expected)
 
 		if !reflect.DeepEqual(expected, actual) {
 			return fmt.Errorf("unexpected generator response:\nexpected: %s\nactual:   %s", mustJSON(expected), mustJSON(actual))
@@ -825,6 +859,37 @@ func (h *caseHarness) expectResponse(status int, timeout time.Duration, validate
 	case <-time.After(timeout):
 		return fmt.Errorf("timed out after %s waiting for SDK response", timeout)
 	}
+}
+
+func normalizeGeneratorOpcodes(in []state.GeneratorOpcode) []state.GeneratorOpcode {
+	out := make([]state.GeneratorOpcode, len(in))
+	copy(out, in)
+
+	var zero state.GeneratorOpcode
+	for idx := range out {
+		out[idx].Timing = zero.Timing
+		out[idx].Userland = nil
+		out[idx].Metadata = nil
+		out[idx].DisplayName = nil
+
+		if out[idx].Op == enums.OpcodeSleep {
+			if opts, ok := out[idx].Opts.(map[string]any); ok {
+				if duration, ok := opts["duration"].(string); ok && duration != "" {
+					out[idx].Name = duration
+					out[idx].Opts = nil
+				}
+			}
+		}
+
+		if out[idx].Error != nil {
+			out[idx].Error.Name = ""
+			out[idx].Error.Stack = "[proxy-redact]"
+			out[idx].Error.Data = nil
+			out[idx].Error.Cause = nil
+		}
+	}
+
+	return out
 }
 
 type executorRequest struct {
@@ -885,7 +950,7 @@ func runStepsSerial(ctx context.Context, h *caseHarness) error {
 
 	hashes := map[string]string{
 		"first step":  "98bf98df193bcce7c33e6bc50927cf2ac21206cb",
-		"sleep":       "dd44d5dc73e81cfbd3c93d03c50160b0b8dc3d6a",
+		"sleep":       "c3ca5f787365eae0dea86250e27d476406956478",
 		"second step": "764e20ec975d4ef820d0f42e6a5833384bd7ee36",
 	}
 
@@ -1027,7 +1092,10 @@ func runRetryBasic(ctx context.Context, h *caseHarness) error {
 		if err := json.Unmarshal(body, &actual); err != nil {
 			return err
 		}
-		if actual["name"] != "Error" || actual["message"] != "broken func" {
+		if name, ok := actual["name"]; ok && name != "" && name != "Error" {
+			return fmt.Errorf("unexpected function error response: %s", string(body))
+		}
+		if actual["message"] != "broken func" {
 			return fmt.Errorf("unexpected function error response: %s", string(body))
 		}
 		return nil
@@ -1103,7 +1171,7 @@ func runWaitForEventBasic(ctx context.Context, h *caseHarness) error {
 		User: map[string]any{},
 	}
 
-	waitHash := "0b497c04bd704c3deceb0a004f6268167025dba2"
+	waitHash := "daaad336276d15594d0e765f96c17cd746bf4971"
 	resumeID := "resume"
 	resume := inngestgo.Event{
 		ID:   &resumeID,
@@ -1134,10 +1202,11 @@ func runWaitForEventBasic(ctx context.Context, h *caseHarness) error {
 	if err := h.expectGeneratorResponse([]state.GeneratorOpcode{{
 		Op:          enums.OpcodeWaitForEvent,
 		ID:          waitHash,
-		Name:        "test/resume",
+		Name:        "wait",
 		DisplayName: inngestgo.StrPtr("test/resume"),
 		Data:        json.RawMessage("null"),
 		Opts: map[string]any{
+			"event":   "test/resume",
 			"if":      "async.data.resume == true && async.data.id == event.data.id",
 			"timeout": "10s",
 		},

--- a/pkg/conformance/runner/serve/runner.go
+++ b/pkg/conformance/runner/serve/runner.go
@@ -1,0 +1,1183 @@
+package serve
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"reflect"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/inngest/inngest/pkg/conformance"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/execution/driver"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/registration"
+	"github.com/inngest/inngest/pkg/sdk"
+	"github.com/inngest/inngest/pkg/util"
+	"github.com/inngest/inngestgo"
+)
+
+// Runner executes the Phase 2 serve-mode conformance flow.
+//
+// The runner intentionally reuses the same protocol behavior that the existing
+// integration tests rely on:
+// 1. introspect the SDK fixture
+// 2. register the fixture functions against the dev server
+// 3. proxy executor callbacks back into the SDK
+// 4. assert the request/response sequence for each selected case
+//
+// The implementation stays conservative on purpose. It supports a real set of
+// portable showcase cases today and reports the rest as not implemented rather
+// than pretending broader transport support already exists.
+type Runner struct {
+	client *http.Client
+}
+
+// NewRunner creates a serve runner backed by the provided HTTP client.
+func NewRunner(client *http.Client) *Runner {
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	return &Runner{client: client}
+}
+
+// Check represents a single doctor/prerequisite result.
+type Check struct {
+	Name    string `json:"name"`
+	Passed  bool   `json:"passed"`
+	Message string `json:"message"`
+}
+
+// Doctor validates the serve prerequisites without executing conformance cases.
+func (r *Runner) Doctor(ctx context.Context, plan conformance.RunPlan, runtime conformance.RuntimeConfig) ([]Check, error) {
+	checks := make([]Check, 0, 5)
+
+	if runtime.Transport != conformance.TransportServe {
+		return nil, fmt.Errorf("serve doctor requires transport %q, got %q", conformance.TransportServe, runtime.Transport)
+	}
+
+	if runtime.SDKURL == nil {
+		checks = append(checks, Check{Name: "sdk-url", Message: "sdk.url or --sdk-url is required"})
+		return checks, nil
+	}
+	if runtime.IntrospectURL == nil {
+		checks = append(checks, Check{Name: "introspect-url", Message: "sdk introspection URL could not be derived"})
+		return checks, nil
+	}
+	if runtime.APIURL == nil {
+		checks = append(checks, Check{Name: "api-url", Message: "dev.url or dev.api_url is required"})
+		return checks, nil
+	}
+	if runtime.EventURL == nil {
+		checks = append(checks, Check{Name: "event-url", Message: "dev.url or dev.event_url is required"})
+		return checks, nil
+	}
+	if strings.TrimSpace(runtime.SigningKey) == "" {
+		checks = append(checks, Check{Name: "signing-key", Message: "dev.signing_key or --signing-key is required for serve registration"})
+		return checks, nil
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, runtime.IntrospectURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		checks = append(checks, Check{Name: "sdk-introspect", Message: err.Error()})
+		return checks, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		checks = append(checks, Check{Name: "sdk-introspect", Message: fmt.Sprintf("unexpected status %d", resp.StatusCode)})
+		return checks, nil
+	}
+
+	functions := []sdk.SDKFunction{}
+	if err := json.NewDecoder(resp.Body).Decode(&functions); err != nil {
+		checks = append(checks, Check{Name: "sdk-introspect", Message: fmt.Sprintf("invalid JSON: %v", err)})
+		return checks, nil
+	}
+	checks = append(checks, Check{Name: "sdk-introspect", Passed: true, Message: fmt.Sprintf("discovered %d function(s)", len(functions))})
+
+	requiredSlugs := requiredFixtureSlugs(plan.Cases)
+	if len(requiredSlugs) == 0 {
+		checks = append(checks, Check{Name: "fixture-functions", Passed: true, Message: "no serve fixture functions required"})
+		return checks, nil
+	}
+
+	foundSlugs := make(map[string]struct{}, len(functions))
+	for _, fn := range functions {
+		foundSlugs[fn.Slug] = struct{}{}
+	}
+
+	missing := make([]string, 0)
+	for _, slug := range requiredSlugs {
+		if _, ok := foundSlugs[slug]; !ok {
+			missing = append(missing, slug)
+		}
+	}
+
+	if len(missing) > 0 {
+		checks = append(checks, Check{
+			Name:    "fixture-functions",
+			Message: fmt.Sprintf("missing required fixture function(s): %s", strings.Join(missing, ", ")),
+		})
+		return checks, nil
+	}
+
+	checks = append(checks, Check{
+		Name:    "fixture-functions",
+		Passed:  true,
+		Message: fmt.Sprintf("found required fixture function(s): %s", strings.Join(requiredSlugs, ", ")),
+	})
+
+	return checks, nil
+}
+
+// Run executes the selected serve cases and returns a normalized report.
+func (r *Runner) Run(ctx context.Context, plan conformance.RunPlan, runtime conformance.RuntimeConfig) (conformance.Report, error) {
+	if runtime.Transport != conformance.TransportServe {
+		return conformance.Report{}, fmt.Errorf("serve runner requires transport %q, got %q", conformance.TransportServe, runtime.Transport)
+	}
+
+	if runtime.SDKURL == nil || runtime.IntrospectURL == nil || runtime.APIURL == nil || runtime.EventURL == nil {
+		return conformance.Report{}, fmt.Errorf("serve runner requires sdk, introspection, api, and event URLs")
+	}
+	if strings.TrimSpace(runtime.SigningKey) == "" {
+		return conformance.Report{}, fmt.Errorf("serve runner requires a signing key")
+	}
+
+	env, err := r.prepare(ctx, runtime)
+	if err != nil {
+		caseResults := markTransportSetupFailed(plan.Cases, err)
+		return conformance.NewReport(plan, caseResults), nil
+	}
+	defer env.close(context.Background())
+
+	caseResults := make([]conformance.CaseResult, 0, len(plan.Cases))
+	for _, testCase := range plan.Cases {
+		result := env.runCase(ctx, testCase)
+		caseResults = append(caseResults, result)
+	}
+
+	return conformance.NewReport(plan, caseResults), nil
+}
+
+type runtimeEnv struct {
+	runtime conformance.RuntimeConfig
+	client  *http.Client
+
+	proxy *proxyServer
+
+	registerRequest sdk.RegisterRequest
+	functionsBySlug  map[string]sdk.SDKFunction
+}
+
+func (r *Runner) prepare(ctx context.Context, runtime conformance.RuntimeConfig) (*runtimeEnv, error) {
+	registerRequest, functionsBySlug, err := r.introspect(ctx, runtime)
+	if err != nil {
+		return nil, err
+	}
+
+	proxy, err := newProxyServer(r.client, runtime.SDKURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// Registration rewrites every step URL to point at the local proxy so the
+	// runner can inspect executor traffic while still forwarding to the real SDK.
+	if err := registerServeFunctions(ctx, r.client, runtime, proxy.URL(), registerRequest); err != nil {
+		_ = proxy.close(context.Background())
+		return nil, err
+	}
+
+	return &runtimeEnv{
+		runtime:         runtime,
+		client:          r.client,
+		proxy:           proxy,
+		registerRequest: registerRequest,
+		functionsBySlug: functionsBySlug,
+	}, nil
+}
+
+func (r *Runner) introspect(ctx context.Context, runtime conformance.RuntimeConfig) (sdk.RegisterRequest, map[string]sdk.SDKFunction, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, runtime.IntrospectURL.String(), nil)
+	if err != nil {
+		return sdk.RegisterRequest{}, nil, err
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return sdk.RegisterRequest{}, nil, fmt.Errorf("call introspect: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		dump, _ := httputil.DumpResponse(resp, true)
+		return sdk.RegisterRequest{}, nil, fmt.Errorf("introspect returned %d: %s", resp.StatusCode, string(dump))
+	}
+
+	functions := []sdk.SDKFunction{}
+	if err := json.NewDecoder(resp.Body).Decode(&functions); err != nil {
+		return sdk.RegisterRequest{}, nil, fmt.Errorf("decode introspect response: %w", err)
+	}
+
+	request := sdk.RegisterRequest{
+		URL:       runtime.SDKURL.String(),
+		Functions: functions,
+	}
+
+	processed, err := registration.ProcessFunctions(ctx, request, registration.ProcessOpts{})
+	if err != nil {
+		return sdk.RegisterRequest{}, nil, fmt.Errorf("process introspection response: %w", err)
+	}
+
+	functionsBySlug := make(map[string]sdk.SDKFunction, len(functions))
+	for _, fn := range functions {
+		functionsBySlug[fn.Slug] = fn
+	}
+
+	// Normalizing the processed functions keeps fixture lookups and registration
+	// behavior aligned with the existing integration test harness.
+	for _, processedFn := range processed.Functions {
+		for i := range processedFn.Function.Steps {
+			processedFn.Function.Steps[i].URI = util.NormalizeAppURL(processedFn.Function.Steps[i].URI, false)
+		}
+	}
+
+	return request, functionsBySlug, nil
+}
+
+func (e *runtimeEnv) close(ctx context.Context) error {
+	var errs []string
+
+	if e.proxy != nil {
+		if err := e.proxy.close(ctx); err != nil {
+			errs = append(errs, err.Error())
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
+
+	return nil
+}
+
+func (e *runtimeEnv) runCase(ctx context.Context, testCase conformance.Case) conformance.CaseResult {
+	executor, ok := caseExecutors[testCase.ID]
+	if !ok {
+		return conformance.CaseResult{
+			CaseID:     testCase.ID,
+			SuiteID:    testCase.SuiteID,
+			Status:     conformance.CaseStatusNotImplemented,
+			ReasonCode: conformance.ReasonCodeNotImplemented,
+			Reason:     "no Phase 2 serve executor is defined for this case",
+		}
+	}
+
+	if executor.slug != "" {
+		if _, ok := e.functionsBySlug[executor.slug]; !ok {
+			return conformance.CaseResult{
+				CaseID:     testCase.ID,
+				SuiteID:    testCase.SuiteID,
+				Status:     conformance.CaseStatusNotImplemented,
+				ReasonCode: conformance.ReasonCodeNotImplemented,
+				Reason:     fmt.Sprintf("required fixture function %q was not found in introspection", executor.slug),
+			}
+		}
+	}
+
+	if testCase.ID == "serve-introspection" {
+		return conformance.CaseResult{
+			CaseID:  testCase.ID,
+			SuiteID: testCase.SuiteID,
+			Status:  conformance.CaseStatusPassed,
+		}
+	}
+
+	tap := e.proxy.newTap()
+	e.proxy.setTap(tap)
+	defer e.proxy.clearTap(tap)
+
+	harness := &caseHarness{
+		client:       e.client,
+		runtime:      e.runtime,
+		requests:     tap.requests,
+		responses:    tap.responses,
+		requestSteps: map[string]any{},
+	}
+
+	if err := executor.run(ctx, harness); err != nil {
+		return conformance.CaseResult{
+			CaseID:     testCase.ID,
+			SuiteID:    testCase.SuiteID,
+			Status:     conformance.CaseStatusFailed,
+			ReasonCode: conformance.ReasonCodeBehaviorMismatch,
+			Reason:     err.Error(),
+		}
+	}
+
+	return conformance.CaseResult{
+		CaseID:  testCase.ID,
+		SuiteID: testCase.SuiteID,
+		Status:  conformance.CaseStatusPassed,
+	}
+}
+
+func markTransportSetupFailed(cases []conformance.Case, cause error) []conformance.CaseResult {
+	results := make([]conformance.CaseResult, 0, len(cases))
+	for _, testCase := range cases {
+		results = append(results, conformance.CaseResult{
+			CaseID:     testCase.ID,
+			SuiteID:    testCase.SuiteID,
+			Status:     conformance.CaseStatusNotEvaluable,
+			ReasonCode: conformance.ReasonCodeTransportSetup,
+			Reason:     cause.Error(),
+		})
+	}
+	return results
+}
+
+type caseExecutor struct {
+	slug string
+	run  func(context.Context, *caseHarness) error
+}
+
+var caseExecutors = map[string]caseExecutor{
+	"serve-introspection":  {},
+	"basic-invoke":         {slug: "test-suite-simple-fn", run: runBasicInvoke},
+	"steps-serial":         {slug: "test-suite-step-test", run: runStepsSerial},
+	"retry-basic":          {slug: "test-suite-retry-test", run: runRetryBasic},
+	"cancel-basic":         {slug: "test-suite-cancel-test", run: runCancelBasic},
+	"wait-for-event-basic": {slug: "test-suite-wait-for-event", run: runWaitForEventBasic},
+}
+
+func requiredFixtureSlugs(cases []conformance.Case) []string {
+	seen := map[string]struct{}{}
+	slugs := make([]string, 0, len(cases))
+	for _, testCase := range cases {
+		executor, ok := caseExecutors[testCase.ID]
+		if !ok || executor.slug == "" {
+			continue
+		}
+		if _, ok := seen[executor.slug]; ok {
+			continue
+		}
+		seen[executor.slug] = struct{}{}
+		slugs = append(slugs, executor.slug)
+	}
+	return slugs
+}
+
+func registerServeFunctions(ctx context.Context, client *http.Client, runtime conformance.RuntimeConfig, proxyURL string, registerRequest sdk.RegisterRequest) error {
+	rewritten := registerRequest
+
+	// Every registered step URL is rewritten to the local proxy. The proxy then
+	// forwards the request to the actual SDK and captures the request/response
+	// pair for the conformance assertions.
+	for fnIdx, fn := range rewritten.Functions {
+		for stepID, step := range fn.Steps {
+			nodeURL, _ := step.Runtime["url"].(string)
+			step.Runtime["url"] = replaceStepURL(nodeURL, proxyURL)
+			fn.Steps[stepID] = step
+		}
+		rewritten.Functions[fnIdx] = fn
+	}
+	rewritten.URL = proxyURL
+
+	payload, err := json.Marshal(rewritten)
+	if err != nil {
+		return err
+	}
+
+	registerURL := cloneRuntimeURL(runtime.APIURL)
+	registerURL.Path = "/fn/register"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, registerURL.String(), bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", signingAuthorization(runtime.SigningKey))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("register functions: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		dump, _ := httputil.DumpResponse(resp, true)
+		return fmt.Errorf("register functions returned %d: %s", resp.StatusCode, string(dump))
+	}
+
+	return nil
+}
+
+func replaceStepURL(nodeURL, proxyURL string) string {
+	node, err := url.Parse(nodeURL)
+	if err != nil {
+		return proxyURL
+	}
+	proxy, err := url.Parse(proxyURL)
+	if err != nil {
+		return proxyURL
+	}
+	proxy.Path = "/"
+	proxy.RawQuery = node.RawQuery
+	return proxy.String()
+}
+
+func signingAuthorization(signingKey string) string {
+	key := regexp.MustCompile(`^signkey-[\w]+-`).ReplaceAllString(signingKey, "")
+	decoded, err := hex.DecodeString(key)
+	if err != nil {
+		// Fall back to the raw key when the input is not hex-encoded. The
+		// conformance runner should still be usable with local/dev-only keys.
+		decoded = []byte(signingKey)
+	}
+
+	sum := sha256.Sum256(decoded)
+	return fmt.Sprintf("Bearer signkey-test-%s", hex.EncodeToString(sum[:]))
+}
+
+type proxyServer struct {
+	server *http.Server
+	url    string
+
+	client *http.Client
+	sdkURL *url.URL
+
+	mu  sync.RWMutex
+	tap *proxyTap
+}
+
+type proxyTap struct {
+	requests  chan requestSnapshot
+	responses chan responseSnapshot
+}
+
+type requestSnapshot struct {
+	Request *http.Request
+	Body    []byte
+}
+
+type responseSnapshot struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+}
+
+func newProxyServer(client *http.Client, sdkURL *url.URL) (*proxyServer, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+
+	proxy := &proxyServer{
+		client: client,
+		sdkURL: sdkURL,
+		url:    fmt.Sprintf("http://%s", listener.Addr().String()),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", proxy.handle)
+
+	proxy.server = &http.Server{
+		Handler:      mux,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
+	}
+
+	go func() {
+		_ = proxy.server.Serve(listener)
+	}()
+
+	return proxy, nil
+}
+
+func (p *proxyServer) URL() string {
+	return p.url
+}
+
+func (p *proxyServer) newTap() *proxyTap {
+	return &proxyTap{
+		requests:  make(chan requestSnapshot, 8),
+		responses: make(chan responseSnapshot, 8),
+	}
+}
+
+func (p *proxyServer) setTap(tap *proxyTap) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.tap = tap
+}
+
+func (p *proxyServer) clearTap(tap *proxyTap) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.tap == tap {
+		p.tap = nil
+	}
+}
+
+func (p *proxyServer) currentTap() *proxyTap {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.tap
+}
+
+func (p *proxyServer) close(ctx context.Context) error {
+	return p.server.Shutdown(ctx)
+}
+
+func (p *proxyServer) handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPut {
+		_ = r.Body.Close()
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_ = r.Body.Close()
+
+	if tap := p.currentTap(); tap != nil {
+		reqCopy := r.Clone(r.Context())
+		reqCopy.Body = io.NopCloser(bytes.NewReader(body))
+		tap.requests <- requestSnapshot{Request: reqCopy, Body: body}
+	}
+
+	target := cloneRuntimeURL(p.sdkURL)
+	target.RawQuery = r.URL.RawQuery
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, target.String(), bytes.NewReader(body))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	req.Header = r.Header.Clone()
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if tap := p.currentTap(); tap != nil {
+		tap.responses <- responseSnapshot{
+			StatusCode: resp.StatusCode,
+			Header:     resp.Header.Clone(),
+			Body:       respBody,
+		}
+	}
+
+	for header, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(header, value)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = w.Write(respBody)
+}
+
+// caseHarness mirrors the parts of the legacy SDK integration DSL that are
+// useful for portable conformance execution, but uses explicit errors rather
+// than testing helpers so it can run in the CLI and in normal Go tests.
+type caseHarness struct {
+	client  *http.Client
+	runtime conformance.RuntimeConfig
+
+	requests  <-chan requestSnapshot
+	responses <-chan responseSnapshot
+
+	requestEvent inngestgo.Event
+	requestCtx   driver.SDKRequestContext
+	requestSteps map[string]any
+}
+
+func (h *caseHarness) setRequestEvent(event inngestgo.Event) {
+	h.requestEvent = event
+	h.requestCtx = driver.SDKRequestContext{
+		StepID: "step",
+		Stack: &driver.FunctionStack{
+			Current: 0,
+			Stack:   []string{},
+		},
+	}
+	if h.requestSteps == nil {
+		h.requestSteps = map[string]any{}
+	}
+}
+
+func (h *caseHarness) setRequestContext(ctx driver.SDKRequestContext) {
+	h.requestCtx = ctx
+	if h.requestCtx.Stack == nil {
+		h.requestCtx.Stack = &driver.FunctionStack{Current: 0, Stack: []string{}}
+	}
+	if h.requestCtx.Stack.Stack == nil {
+		h.requestCtx.Stack.Stack = []string{}
+	}
+}
+
+func (h *caseHarness) addRequestStack(stack driver.FunctionStack) {
+	if h.requestCtx.Stack == nil {
+		h.requestCtx.Stack = &driver.FunctionStack{Current: 0, Stack: []string{}}
+	}
+	h.requestCtx.Stack.Stack = append(h.requestCtx.Stack.Stack, stack.Stack...)
+	h.requestCtx.Stack.Current = stack.Current
+}
+
+func (h *caseHarness) addRequestSteps(steps map[string]any) {
+	if h.requestSteps == nil {
+		h.requestSteps = map[string]any{}
+	}
+	for key, value := range steps {
+		h.requestSteps[key] = value
+	}
+}
+
+func (h *caseHarness) sendEvent(ctx context.Context, event inngestgo.Event) error {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	target := cloneRuntimeURL(h.runtime.EventURL)
+	target.Path = strings.TrimRight(target.Path, "/") + "/e/" + h.runtime.EventKey
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target.String(), bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := h.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send event %q: %w", event.Name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("send event %q returned %d: %s", event.Name, resp.StatusCode, string(body))
+	}
+
+	return nil
+}
+
+func (h *caseHarness) expectNoRequests(duration time.Duration) error {
+	select {
+	case req := <-h.requests:
+		return fmt.Errorf("expected no executor request, but received %s %s", req.Request.Method, req.Request.URL.String())
+	case <-time.After(duration):
+		return nil
+	}
+}
+
+func (h *caseHarness) expectRequest(timeout time.Duration, queryStepID string, modifiers ...func(*driver.SDKRequestContext)) error {
+	select {
+	case req := <-h.requests:
+		if got := req.Request.URL.Query().Get("stepId"); got != queryStepID {
+			return fmt.Errorf("expected stepId %q, got %q", queryStepID, got)
+		}
+
+		execReq := executorRequest{}
+		if err := json.Unmarshal(req.Body, &execReq); err != nil {
+			return fmt.Errorf("decode executor request: %w", err)
+		}
+
+		if execReq.Ctx.Stack == nil || execReq.Ctx.Stack.Stack == nil {
+			return fmt.Errorf("executor request stack was nil")
+		}
+
+		expectedEvent := h.requestEvent
+		actualEvent := execReq.Event
+		actualTS := actualEvent.Timestamp
+		actualID := actualEvent.ID
+		actualEvent.Timestamp = 0
+		actualEvent.ID = nil
+		expectedEvent.Timestamp = 0
+		expectedEvent.ID = nil
+		if expectedEvent.User == nil {
+			expectedEvent.User = map[string]any{}
+		}
+		if actualEvent.User == nil {
+			actualEvent.User = map[string]any{}
+		}
+		if expectedEvent.Data == nil {
+			expectedEvent.Data = map[string]any{}
+		}
+		if actualEvent.Data == nil {
+			actualEvent.Data = map[string]any{}
+		}
+		if !reflect.DeepEqual(expectedEvent, actualEvent) {
+			return fmt.Errorf("unexpected executor event:\nexpected: %s\nactual:   %s", mustJSON(expectedEvent), mustJSON(actualEvent))
+		}
+		actualEvent.Timestamp = actualTS
+		actualEvent.ID = actualID
+
+		expectedCtx := h.requestCtx
+		for _, modifier := range modifiers {
+			modifier(&expectedCtx)
+		}
+
+		expectedCtx.RunID = execReq.Ctx.RunID
+		expectedCtx.FunctionID = execReq.Ctx.FunctionID
+		expectedCtx.QueueItemRef = execReq.Ctx.QueueItemRef
+		actualCtx := execReq.Ctx
+		actualCtx.MaxAttempts = 0
+		expectedCtx.MaxAttempts = 0
+
+		if !reflect.DeepEqual(expectedCtx, actualCtx) {
+			return fmt.Errorf("unexpected executor context:\nexpected: %s\nactual:   %s", mustJSON(expectedCtx), mustJSON(actualCtx))
+		}
+
+		for _, value := range execReq.Steps {
+			data, ok := value.(map[string]any)
+			if !ok {
+				continue
+			}
+			if errValue, ok := data["error"].(map[string]any); ok {
+				delete(errValue, "stack")
+			}
+		}
+
+		if !reflect.DeepEqual(h.requestSteps, execReq.Steps) {
+			return fmt.Errorf("unexpected executor steps:\nexpected: %s\nactual:   %s", mustJSON(h.requestSteps), mustJSON(execReq.Steps))
+		}
+
+		return nil
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out after %s waiting for executor request", timeout)
+	}
+}
+
+func (h *caseHarness) expectJSONResponse(status int, expected any, timeout time.Duration) error {
+	return h.expectResponse(status, timeout, func(body []byte) error {
+		var actual any
+		if err := json.Unmarshal(body, &actual); err != nil {
+			return err
+		}
+		if !reflect.DeepEqual(expected, actual) {
+			return fmt.Errorf("unexpected JSON response:\nexpected: %s\nactual:   %s", mustJSON(expected), mustJSON(actual))
+		}
+		return nil
+	})
+}
+
+func (h *caseHarness) expectGeneratorResponse(expected []state.GeneratorOpcode, timeout time.Duration) error {
+	return h.expectResponse(http.StatusOK, timeout, func(body []byte) error {
+		actual := []state.GeneratorOpcode{}
+		if err := json.Unmarshal(body, &actual); err != nil {
+			return err
+		}
+
+		// Step errors include stack traces with machine-specific file paths. The
+		// runner normalizes them so the semantic assertion stays portable.
+		if len(actual) == 1 && actual[0].Op == enums.OpcodeStepError && actual[0].Error != nil {
+			actual[0].Error.Stack = "[proxy-redact]"
+			if len(expected) == 1 && expected[0].Error != nil {
+				expected[0].Error.Stack = "[proxy-redact]"
+			}
+		}
+
+		if !reflect.DeepEqual(expected, actual) {
+			return fmt.Errorf("unexpected generator response:\nexpected: %s\nactual:   %s", mustJSON(expected), mustJSON(actual))
+		}
+		return nil
+	})
+}
+
+func (h *caseHarness) expectResponse(status int, timeout time.Duration, validate func([]byte) error) error {
+	select {
+	case resp := <-h.responses:
+		if resp.StatusCode != status {
+			return fmt.Errorf("expected status %d, got %d", status, resp.StatusCode)
+		}
+		return validate(resp.Body)
+	case <-time.After(timeout):
+		return fmt.Errorf("timed out after %s waiting for SDK response", timeout)
+	}
+}
+
+type executorRequest struct {
+	Event   inngestgo.Event          `json:"event"`
+	Steps   map[string]any           `json:"steps"`
+	Ctx     driver.SDKRequestContext `json:"ctx"`
+	Version int                      `json:"version"`
+}
+
+func mustJSON(v any) string {
+	byt, _ := json.Marshal(v)
+	return string(byt)
+}
+
+func cloneRuntimeURL(in *url.URL) *url.URL {
+	if in == nil {
+		return nil
+	}
+
+	out := *in
+	return &out
+}
+
+func runBasicInvoke(ctx context.Context, h *caseHarness) error {
+	event := inngestgo.Event{
+		Name: "tests/function.test",
+		Data: map[string]any{
+			"test": true,
+		},
+		User: map[string]any{},
+	}
+
+	h.setRequestEvent(event)
+	if err := h.sendEvent(ctx, event); err != nil {
+		return err
+	}
+	if err := h.expectRequest(5*time.Second, "step"); err != nil {
+		return err
+	}
+	return h.expectJSONResponse(http.StatusOK, map[string]any{
+		"name": "tests/function.test",
+		"body": "ok",
+	}, 5*time.Second)
+}
+
+func runStepsSerial(ctx context.Context, h *caseHarness) error {
+	event := inngestgo.Event{
+		Name: "tests/step.test",
+		Data: map[string]any{
+			"steps": map[string]any{
+				"ok": "yes",
+			},
+		},
+		User: map[string]any{
+			"email": "test@example.com",
+		},
+	}
+
+	hashes := map[string]string{
+		"first step":  "98bf98df193bcce7c33e6bc50927cf2ac21206cb",
+		"sleep":       "dd44d5dc73e81cfbd3c93d03c50160b0b8dc3d6a",
+		"second step": "764e20ec975d4ef820d0f42e6a5833384bd7ee36",
+	}
+
+	h.setRequestEvent(event)
+	if err := h.sendEvent(ctx, event); err != nil {
+		return err
+	}
+	if err := h.expectRequest(5*time.Second, "step"); err != nil {
+		return err
+	}
+	if err := h.expectGeneratorResponse([]state.GeneratorOpcode{{
+		Op:          enums.OpcodeStepRun,
+		ID:          hashes["first step"],
+		Name:        "first step",
+		DisplayName: inngestgo.StrPtr("first step"),
+		Data:        []byte(`"first step"`),
+	}}, 5*time.Second); err != nil {
+		return err
+	}
+
+	h.addRequestStack(driver.FunctionStack{Stack: []string{hashes["first step"]}, Current: 1})
+	h.addRequestSteps(map[string]any{
+		hashes["first step"]: map[string]any{"data": "first step"},
+	})
+
+	if err := h.expectRequest(5*time.Second, "step"); err != nil {
+		return err
+	}
+	if err := h.expectGeneratorResponse([]state.GeneratorOpcode{{
+		Op:          enums.OpcodeSleep,
+		ID:          hashes["sleep"],
+		Name:        "2s",
+		DisplayName: inngestgo.StrPtr("for 2s"),
+		Data:        json.RawMessage("null"),
+	}}, 5*time.Second); err != nil {
+		return err
+	}
+
+	h.addRequestStack(driver.FunctionStack{Stack: []string{hashes["sleep"]}, Current: 2})
+	h.addRequestSteps(map[string]any{
+		hashes["sleep"]: nil,
+	})
+
+	if err := h.expectRequest(6*time.Second, "step"); err != nil {
+		return err
+	}
+	if err := h.expectGeneratorResponse([]state.GeneratorOpcode{{
+		Op:          enums.OpcodeStepRun,
+		ID:          hashes["second step"],
+		Name:        "second step",
+		DisplayName: inngestgo.StrPtr("second step"),
+		Data:        json.RawMessage(`{"first":"first step","second":true}`),
+	}}, 5*time.Second); err != nil {
+		return err
+	}
+
+	h.addRequestStack(driver.FunctionStack{Stack: []string{hashes["second step"]}, Current: 3})
+	h.addRequestSteps(map[string]any{
+		hashes["second step"]: map[string]any{
+			"data": map[string]any{
+				"first":  "first step",
+				"second": true,
+			},
+		},
+	})
+
+	if err := h.expectRequest(5*time.Second, "step"); err != nil {
+		return err
+	}
+	return h.expectJSONResponse(http.StatusOK, map[string]any{
+		"body": "ok",
+		"name": "tests/step.test",
+	}, 5*time.Second)
+}
+
+func runRetryBasic(ctx context.Context, h *caseHarness) error {
+	event := inngestgo.Event{
+		Name: "tests/retry.test",
+		Data: map[string]any{
+			"steps": map[string]any{
+				"ok": "yes",
+			},
+		},
+		User: map[string]any{
+			"email": "test@example.com",
+		},
+	}
+
+	hash := "98bf98df193bcce7c33e6bc50927cf2ac21206cb"
+
+	h.setRequestEvent(event)
+	if err := h.sendEvent(ctx, event); err != nil {
+		return err
+	}
+	if err := h.expectRequest(5*time.Second, "step"); err != nil {
+		return err
+	}
+	if err := h.expectGeneratorResponse([]state.GeneratorOpcode{{
+		Op:          enums.OpcodeStepError,
+		ID:          hash,
+		Name:        "first step",
+		DisplayName: inngestgo.StrPtr("first step"),
+		Error: &state.UserError{
+			Name:    "Error",
+			Message: "broken",
+		},
+		Data: []byte(`null`),
+	}}, 5*time.Second); err != nil {
+		return err
+	}
+
+	if err := h.expectRequest(45*time.Second, "step", func(ctx *driver.SDKRequestContext) {
+		ctx.Attempt = 1
+	}); err != nil {
+		return err
+	}
+	if err := h.expectGeneratorResponse([]state.GeneratorOpcode{{
+		Op:          enums.OpcodeStepRun,
+		ID:          hash,
+		Name:        "first step",
+		DisplayName: inngestgo.StrPtr("first step"),
+		Data:        []byte(`"yes: 2"`),
+	}}, 5*time.Second); err != nil {
+		return err
+	}
+
+	h.addRequestStack(driver.FunctionStack{Stack: []string{hash}, Current: 1})
+	h.addRequestSteps(map[string]any{
+		hash: map[string]any{"data": "yes: 2"},
+	})
+
+	if err := h.expectRequest(5*time.Second, "step", func(ctx *driver.SDKRequestContext) {
+		ctx.Attempt = 0
+	}); err != nil {
+		return err
+	}
+	if err := h.expectResponse(http.StatusInternalServerError, 5*time.Second, func(body []byte) error {
+		actual := map[string]any{}
+		if err := json.Unmarshal(body, &actual); err != nil {
+			return err
+		}
+		if actual["name"] != "Error" || actual["message"] != "broken func" {
+			return fmt.Errorf("unexpected function error response: %s", string(body))
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if err := h.expectRequest(45*time.Second, "step", func(ctx *driver.SDKRequestContext) {
+		ctx.Attempt = 1
+	}); err != nil {
+		return err
+	}
+	return h.expectJSONResponse(http.StatusOK, map[string]any{
+		"body": "ok",
+		"name": "tests/retry.test",
+	}, 5*time.Second)
+}
+
+func runCancelBasic(ctx context.Context, h *caseHarness) error {
+	event := inngestgo.Event{
+		Name: "tests/cancel.test",
+		Data: map[string]any{
+			"request_id": "123",
+			"whatever":   "this doesn't matter my friend",
+		},
+		User: map[string]any{},
+	}
+
+	h.setRequestEvent(event)
+	h.setRequestContext(driver.SDKRequestContext{
+		StepID: "step",
+		Stack: &driver.FunctionStack{
+			Current: 0,
+			Stack:   []string{},
+		},
+	})
+
+	if err := h.sendEvent(ctx, event); err != nil {
+		return err
+	}
+	if err := h.expectRequest(5*time.Second, "step"); err != nil {
+		return err
+	}
+	if err := h.expectGeneratorResponse([]state.GeneratorOpcode{{
+		Op:          enums.OpcodeSleep,
+		ID:          "c3ca5f787365eae0dea86250e27d476406956478",
+		Name:        "10s",
+		DisplayName: inngestgo.StrPtr("sleep"),
+		Data:        json.RawMessage("null"),
+	}}, 5*time.Second); err != nil {
+		return err
+	}
+
+	time.Sleep(1 * time.Second)
+	if err := h.sendEvent(ctx, inngestgo.Event{
+		Name: "cancel/please",
+		Data: map[string]any{
+			"request_id": "123",
+		},
+	}); err != nil {
+		return err
+	}
+
+	return h.expectNoRequests(11 * time.Second)
+}
+
+func runWaitForEventBasic(ctx context.Context, h *caseHarness) error {
+	event := inngestgo.Event{
+		Name: "tests/wait.test",
+		Data: map[string]any{
+			"id": "123",
+		},
+		User: map[string]any{},
+	}
+
+	waitHash := "0b497c04bd704c3deceb0a004f6268167025dba2"
+	resumeID := "resume"
+	resume := inngestgo.Event{
+		ID:   &resumeID,
+		Name: "test/resume",
+		Data: map[string]any{
+			"id":     "123",
+			"resume": true,
+		},
+		Timestamp: time.Now().UnixMilli(),
+		User:      map[string]any{},
+	}
+
+	h.setRequestEvent(event)
+	h.setRequestContext(driver.SDKRequestContext{
+		StepID: "step",
+		Stack: &driver.FunctionStack{
+			Current: 0,
+			Stack:   []string{},
+		},
+	})
+
+	if err := h.sendEvent(ctx, event); err != nil {
+		return err
+	}
+	if err := h.expectRequest(5*time.Second, "step"); err != nil {
+		return err
+	}
+	if err := h.expectGeneratorResponse([]state.GeneratorOpcode{{
+		Op:          enums.OpcodeWaitForEvent,
+		ID:          waitHash,
+		Name:        "test/resume",
+		DisplayName: inngestgo.StrPtr("test/resume"),
+		Data:        json.RawMessage("null"),
+		Opts: map[string]any{
+			"if":      "async.data.resume == true && async.data.id == event.data.id",
+			"timeout": "10s",
+		},
+	}}, 5*time.Second); err != nil {
+		return err
+	}
+
+	time.Sleep(1 * time.Second)
+	if err := h.sendEvent(ctx, inngestgo.Event{
+		Name: "test/resume",
+		Data: map[string]any{
+			"id": "ignored",
+		},
+	}); err != nil {
+		return err
+	}
+
+	time.Sleep(1 * time.Second)
+	if err := h.sendEvent(ctx, resume); err != nil {
+		return err
+	}
+
+	h.addRequestStack(driver.FunctionStack{Stack: []string{waitHash}, Current: 1})
+	h.addRequestSteps(map[string]any{
+		waitHash: resume.Map(),
+	})
+
+	if err := h.expectRequest(5*time.Second, "step"); err != nil {
+		return err
+	}
+	return h.expectJSONResponse(http.StatusOK, map[string]any{
+		"result": map[string]any{
+			"id":     "123",
+			"resume": true,
+		},
+	}, 5*time.Second)
+}
+
+// eventTrigger is a tiny helper for building fixture introspection payloads in
+// tests and future serve fixture manifests.
+func eventTrigger(name string) inngest.Trigger {
+	return inngest.Trigger{EventTrigger: &inngest.EventTrigger{Event: name}}
+}

--- a/pkg/conformance/runner/serve/runner_test.go
+++ b/pkg/conformance/runner/serve/runner_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -133,9 +134,45 @@ func (f *serveFixture) Runtime() conformance.RuntimeConfig {
 func fixturesSDKHandler(f *serveFixture) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/api/introspect":
+		case r.Method == http.MethodGet && r.URL.Path == "/api/inngest":
 			w.Header().Set("Content-Type", "application/json")
-			require.NoError(f.t, json.NewEncoder(w).Encode(f.functions))
+			require.NoError(f.t, json.NewEncoder(w).Encode(map[string]any{
+				"schema_version": "2024-05-24",
+				"function_count": len(f.functions),
+				"mode":           "dev",
+			}))
+			return
+		case r.Method == http.MethodPut && r.URL.Path == "/api/inngest":
+			var syncReq struct {
+				URL string `json:"url"`
+			}
+			require.NoError(f.t, json.NewDecoder(r.Body).Decode(&syncReq))
+			require.NotEmpty(f.t, syncReq.URL)
+
+			functions := make([]sdk.SDKFunction, len(f.functions))
+			copy(functions, f.functions)
+			for idx := range functions {
+				for stepID, step := range functions[idx].Steps {
+					stepURL, err := url.Parse(syncReq.URL)
+					require.NoError(f.t, err)
+					values := stepURL.Query()
+					values.Set("fnId", functions[idx].Slug)
+					values.Set("step", "step")
+					stepURL.RawQuery = values.Encode()
+					step.Runtime["url"] = stepURL.String()
+					functions[idx].Steps[stepID] = step
+				}
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("x-inngest-sync-kind", "in_band")
+			require.NoError(f.t, json.NewEncoder(w).Encode(map[string]any{
+				"app_id":       "conformance-test",
+				"functions":    functions,
+				"sdk_language": "go",
+				"sdk_version":  "test",
+				"url":          syncReq.URL,
+			}))
 			return
 		case r.Method == http.MethodPost && r.URL.Path == "/api/inngest":
 			body, err := io.ReadAll(r.Body)

--- a/pkg/conformance/runner/serve/runner_test.go
+++ b/pkg/conformance/runner/serve/runner_test.go
@@ -1,0 +1,211 @@
+package serve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/conformance"
+	"github.com/inngest/inngest/pkg/execution/driver"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/sdk"
+	"github.com/inngest/inngestgo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunnerRunBasicInvoke(t *testing.T) {
+	t.Parallel()
+
+	fixture := newServeFixture(t)
+	defer fixture.Close()
+
+	registry := conformance.DefaultRegistry()
+	plan, err := (conformance.Selection{
+		Transport: conformance.TransportServe,
+		Cases:     []string{"serve-introspection", "basic-invoke"},
+	}).Resolve(registry)
+	require.NoError(t, err)
+
+	runner := NewRunner(nil)
+	report, err := runner.Run(context.Background(), plan, fixture.Runtime())
+	require.NoError(t, err)
+	require.Equal(t, conformance.CompatibilityFull, report.Compatibility)
+	require.Len(t, report.Cases, 2)
+	for _, result := range report.Cases {
+		require.Equal(t, conformance.CaseStatusPassed, result.Status)
+	}
+}
+
+func TestRunnerDoctorDetectsMissingFixtureFunctions(t *testing.T) {
+	t.Parallel()
+
+	fixture := newServeFixture(t)
+	defer fixture.Close()
+	fixture.functions = fixture.functions[:0]
+
+	registry := conformance.DefaultRegistry()
+	plan, err := (conformance.Selection{
+		Transport: conformance.TransportServe,
+		Cases:     []string{"basic-invoke"},
+	}).Resolve(registry)
+	require.NoError(t, err)
+
+	runner := NewRunner(nil)
+	checks, err := runner.Doctor(context.Background(), plan, fixture.Runtime())
+	require.NoError(t, err)
+	require.False(t, checks[len(checks)-1].Passed)
+	require.Contains(t, checks[len(checks)-1].Message, "missing required fixture function")
+}
+
+type serveFixture struct {
+	t *testing.T
+
+	functions []sdk.SDKFunction
+
+	sdkServer *httptest.Server
+	devServer *httptest.Server
+
+	registeredURL string
+}
+
+func newServeFixture(t *testing.T) *serveFixture {
+	t.Helper()
+
+	fixture := &serveFixture{t: t}
+	fixture.functions = []sdk.SDKFunction{
+		{
+			Name:     "Simple function",
+			Slug:     "test-suite-simple-fn",
+			Triggers: []inngest.Trigger{eventTrigger("tests/function.test")},
+			Steps: map[string]sdk.SDKStep{
+				"step": {
+					ID:   "step",
+					Name: "step",
+					Runtime: map[string]any{
+						"url": "http://sdk.invalid/api/inngest",
+					},
+				},
+			},
+		},
+	}
+
+	fixture.sdkServer = httptest.NewServer(http.HandlerFunc(fixturesSDKHandler(fixture)))
+	fixture.devServer = httptest.NewServer(http.HandlerFunc(fixturesDevHandler(fixture)))
+
+	for idx := range fixture.functions {
+		for stepID, step := range fixture.functions[idx].Steps {
+			step.Runtime["url"] = fixture.sdkServer.URL + "/api/inngest"
+			fixture.functions[idx].Steps[stepID] = step
+		}
+	}
+
+	return fixture
+}
+
+func (f *serveFixture) Close() {
+	f.sdkServer.Close()
+	f.devServer.Close()
+}
+
+func (f *serveFixture) Runtime() conformance.RuntimeConfig {
+	cfg := conformance.Config{
+		Transport: conformance.TransportServe,
+		SDK: conformance.SDKConfig{
+			URL: f.sdkServer.URL + "/api/inngest",
+		},
+		Dev: conformance.DevConfig{
+			URL:        f.devServer.URL,
+			SigningKey: "7468697320697320612074657374206b6579",
+			EventKey:   "test",
+		},
+	}
+
+	runtime, err := cfg.Runtime()
+	require.NoError(f.t, err)
+	return runtime
+}
+
+func fixturesSDKHandler(f *serveFixture) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/introspect":
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(f.t, json.NewEncoder(w).Encode(f.functions))
+			return
+		case r.Method == http.MethodPost && r.URL.Path == "/api/inngest":
+			body, err := io.ReadAll(r.Body)
+			require.NoError(f.t, err)
+			defer r.Body.Close()
+
+			req := executorRequest{}
+			require.NoError(f.t, json.Unmarshal(body, &req))
+
+			switch req.Event.Name {
+			case "tests/function.test":
+				w.Header().Set("Content-Type", "application/json")
+				require.NoError(f.t, json.NewEncoder(w).Encode(map[string]any{
+					"name": "tests/function.test",
+					"body": "ok",
+				}))
+				return
+			default:
+				http.Error(w, fmt.Sprintf("unexpected event %q", req.Event.Name), http.StatusBadRequest)
+				return
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}
+}
+
+func fixturesDevHandler(f *serveFixture) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/fn/register":
+			var req sdk.RegisterRequest
+			require.NoError(f.t, json.NewDecoder(r.Body).Decode(&req))
+			f.registeredURL = req.URL
+			w.WriteHeader(http.StatusOK)
+			return
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/e/"):
+			var event inngestgo.Event
+			require.NoError(f.t, json.NewDecoder(r.Body).Decode(&event))
+
+			payload, err := json.Marshal(executorRequest{
+				Event: event,
+				Steps: map[string]any{},
+				Ctx: driver.SDKRequestContext{
+					StepID: "step",
+					Stack: &driver.FunctionStack{
+						Current: 0,
+						Stack:   []string{},
+					},
+				},
+				Version: 1,
+			})
+			require.NoError(f.t, err)
+
+			req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, f.registeredURL+"?stepId=step", strings.NewReader(string(payload)))
+			require.NoError(f.t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(f.t, err)
+			defer resp.Body.Close()
+
+			respBody, err := io.ReadAll(resp.Body)
+			require.NoError(f.t, err)
+
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write(respBody)
+			return
+		default:
+			http.NotFound(w, r)
+		}
+	}
+}

--- a/pkg/conformance/runtime.go
+++ b/pkg/conformance/runtime.go
@@ -1,0 +1,115 @@
+package conformance
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// RuntimeConfig is the normalized execution contract used by runners.
+//
+// The CLI and file-based config can both be partial, so runners should consume
+// this concrete structure instead of repeating URL/default logic.
+type RuntimeConfig struct {
+	Transport      Transport  `json:"transport"`
+	SDKURL         *url.URL   `json:"sdk_url,omitempty"`
+	IntrospectURL  *url.URL   `json:"introspect_url,omitempty"`
+	DevURL         *url.URL   `json:"dev_url,omitempty"`
+	APIURL         *url.URL   `json:"api_url,omitempty"`
+	EventURL       *url.URL   `json:"event_url,omitempty"`
+	EventKey       string     `json:"event_key,omitempty"`
+	SigningKey     string     `json:"signing_key,omitempty"`
+	Timeout        time.Duration `json:"timeout"`
+}
+
+// Runtime resolves the user-facing config into concrete URLs and defaults.
+//
+// The current implementation defaults the transport to serve because Phase 2
+// only ships a real serve runner. Connect remains in the registry and the
+// report model, but not in the executable runtime path yet.
+func (c Config) Runtime() (RuntimeConfig, error) {
+	rt := RuntimeConfig{
+		Transport: c.Transport,
+		Timeout:   c.TimeoutOrDefault(60 * time.Second),
+		EventKey:  c.Dev.EventKey,
+		SigningKey: c.Dev.SigningKey,
+	}
+
+	if rt.Transport == "" {
+		rt.Transport = TransportServe
+	}
+
+	var err error
+	if c.SDK.URL != "" {
+		rt.SDKURL, err = url.Parse(c.SDK.URL)
+		if err != nil {
+			return RuntimeConfig{}, fmt.Errorf("invalid sdk.url %q: %w", c.SDK.URL, err)
+		}
+	}
+
+	if c.Dev.URL != "" {
+		rt.DevURL, err = url.Parse(c.Dev.URL)
+		if err != nil {
+			return RuntimeConfig{}, fmt.Errorf("invalid dev.url %q: %w", c.Dev.URL, err)
+		}
+	}
+
+	if c.Dev.APIURL != "" {
+		rt.APIURL, err = url.Parse(c.Dev.APIURL)
+		if err != nil {
+			return RuntimeConfig{}, fmt.Errorf("invalid dev.api_url %q: %w", c.Dev.APIURL, err)
+		}
+	} else if rt.DevURL != nil {
+		rt.APIURL = cloneURL(rt.DevURL)
+	}
+
+	if c.Dev.EventURL != "" {
+		rt.EventURL, err = url.Parse(c.Dev.EventURL)
+		if err != nil {
+			return RuntimeConfig{}, fmt.Errorf("invalid dev.event_url %q: %w", c.Dev.EventURL, err)
+		}
+	} else if rt.DevURL != nil {
+		rt.EventURL = cloneURL(rt.DevURL)
+	}
+
+	if rt.EventKey == "" {
+		rt.EventKey = "test"
+	}
+
+	if c.SDK.IntrospectPath != "" {
+		if rt.SDKURL == nil {
+			return RuntimeConfig{}, fmt.Errorf("sdk.introspect_path requires sdk.url to also be set")
+		}
+
+		rt.IntrospectURL = cloneURL(rt.SDKURL)
+		rt.IntrospectURL.Path = c.SDK.IntrospectPath
+	} else if rt.SDKURL != nil {
+		rt.IntrospectURL = cloneURL(rt.SDKURL)
+		rt.IntrospectURL.Path = deriveIntrospectPath(rt.SDKURL.Path)
+	}
+
+	return rt, nil
+}
+
+func cloneURL(in *url.URL) *url.URL {
+	if in == nil {
+		return nil
+	}
+
+	out := *in
+	return &out
+}
+
+func deriveIntrospectPath(servePath string) string {
+	trimmed := strings.TrimSpace(servePath)
+	if trimmed == "" || trimmed == "/" {
+		return "/api/introspect"
+	}
+
+	if strings.HasSuffix(trimmed, "/inngest") {
+		return strings.TrimSuffix(trimmed, "/inngest") + "/introspect"
+	}
+
+	return "/api/introspect"
+}

--- a/pkg/conformance/runtime_test.go
+++ b/pkg/conformance/runtime_test.go
@@ -1,0 +1,54 @@
+package conformance
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeDefaultsToServeAndDerivedURLs(t *testing.T) {
+	t.Parallel()
+
+	rt, err := (Config{
+		SDK: SDKConfig{
+			URL: "http://127.0.0.1:3000/api/inngest",
+		},
+		Dev: DevConfig{
+			URL:        "http://127.0.0.1:8288",
+			SigningKey: "signkey-test-123",
+		},
+	}).Runtime()
+	require.NoError(t, err)
+	require.Equal(t, TransportServe, rt.Transport)
+	require.Equal(t, "http://127.0.0.1:3000/api/introspect", rt.IntrospectURL.String())
+	require.Equal(t, "http://127.0.0.1:8288", rt.APIURL.String())
+	require.Equal(t, "http://127.0.0.1:8288", rt.EventURL.String())
+	require.Equal(t, "test", rt.EventKey)
+	require.Equal(t, 60*time.Second, rt.Timeout)
+}
+
+func TestRuntimeSupportsExplicitOverridePaths(t *testing.T) {
+	t.Parallel()
+
+	rt, err := (Config{
+		Transport: TransportServe,
+		Timeout:   "15s",
+		SDK: SDKConfig{
+			URL:            "http://127.0.0.1:3000/custom",
+			IntrospectPath: "/meta/introspect",
+		},
+		Dev: DevConfig{
+			URL:      "http://127.0.0.1:8288",
+			APIURL:   "http://127.0.0.1:8388",
+			EventURL: "http://127.0.0.1:8488",
+			EventKey: "evt-key",
+		},
+	}).Runtime()
+	require.NoError(t, err)
+	require.Equal(t, "http://127.0.0.1:3000/meta/introspect", rt.IntrospectURL.String())
+	require.Equal(t, "http://127.0.0.1:8388", rt.APIURL.String())
+	require.Equal(t, "http://127.0.0.1:8488", rt.EventURL.String())
+	require.Equal(t, "evt-key", rt.EventKey)
+	require.Equal(t, 15*time.Second, rt.Timeout)
+}

--- a/pkg/conformance/selection.go
+++ b/pkg/conformance/selection.go
@@ -1,0 +1,125 @@
+package conformance
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+)
+
+type Selection struct {
+	Transport Transport
+	Suites    []string
+	Cases     []string
+	Features  []string
+}
+
+type RunPlan struct {
+	Transport Transport `json:"transport,omitempty"`
+	Suites    []Suite   `json:"suites"`
+	Cases     []Case    `json:"cases"`
+	Features  []Feature `json:"features"`
+}
+
+func (c Config) Selection() Selection {
+	return Selection{
+		Transport: c.Transport,
+		Suites:    slices.Clone(c.Suites),
+		Cases:     slices.Clone(c.Cases),
+		Features:  slices.Clone(c.Features),
+	}
+}
+
+func (s Selection) Resolve(registry Registry) (RunPlan, error) {
+	if s.Transport != "" && !IsValidTransport(s.Transport) {
+		return RunPlan{}, fmt.Errorf("unknown transport %q", s.Transport)
+	}
+
+	for _, suiteID := range s.Suites {
+		if _, ok := registry.Suites[suiteID]; !ok {
+			return RunPlan{}, fmt.Errorf("unknown suite %q", suiteID)
+		}
+	}
+	for _, caseID := range s.Cases {
+		if _, ok := registry.Cases[caseID]; !ok {
+			return RunPlan{}, fmt.Errorf("unknown case %q", caseID)
+		}
+	}
+	for _, featureID := range s.Features {
+		if _, ok := registry.Features[featureID]; !ok {
+			return RunPlan{}, fmt.Errorf("unknown feature %q", featureID)
+		}
+	}
+
+	selectedCaseIDs := map[string]struct{}{}
+	if len(s.Suites) == 0 && len(s.Cases) == 0 {
+		for caseID := range registry.Cases {
+			selectedCaseIDs[caseID] = struct{}{}
+		}
+	}
+
+	for _, suiteID := range s.Suites {
+		for _, caseID := range registry.Suites[suiteID].CaseIDs {
+			selectedCaseIDs[caseID] = struct{}{}
+		}
+	}
+	for _, caseID := range s.Cases {
+		selectedCaseIDs[caseID] = struct{}{}
+	}
+
+	filteredCaseIDs := make([]string, 0, len(selectedCaseIDs))
+	for caseID := range selectedCaseIDs {
+		testCase := registry.Cases[caseID]
+		if !testCase.SupportsTransport(s.Transport) {
+			continue
+		}
+		if len(s.Features) > 0 && !caseHasAnyFeature(testCase, s.Features) {
+			continue
+		}
+		filteredCaseIDs = append(filteredCaseIDs, caseID)
+	}
+	sort.Strings(filteredCaseIDs)
+
+	if len(filteredCaseIDs) == 0 {
+		return RunPlan{}, fmt.Errorf("selection did not match any conformance cases")
+	}
+
+	suiteIDs := make(map[string]struct{})
+	featureIDs := make(map[string]struct{})
+	planCases := make([]Case, 0, len(filteredCaseIDs))
+	for _, caseID := range filteredCaseIDs {
+		testCase := registry.Cases[caseID]
+		planCases = append(planCases, testCase)
+		suiteIDs[testCase.SuiteID] = struct{}{}
+		for _, featureID := range testCase.Features {
+			featureIDs[featureID] = struct{}{}
+		}
+	}
+
+	planSuites := make([]Suite, 0, len(suiteIDs))
+	for suiteID := range suiteIDs {
+		planSuites = append(planSuites, registry.Suites[suiteID])
+	}
+	sort.Slice(planSuites, func(i, j int) bool { return planSuites[i].ID < planSuites[j].ID })
+
+	planFeatures := make([]Feature, 0, len(featureIDs))
+	for featureID := range featureIDs {
+		planFeatures = append(planFeatures, registry.Features[featureID])
+	}
+	sort.Slice(planFeatures, func(i, j int) bool { return planFeatures[i].ID < planFeatures[j].ID })
+
+	return RunPlan{
+		Transport: s.Transport,
+		Suites:    planSuites,
+		Cases:     planCases,
+		Features:  planFeatures,
+	}, nil
+}
+
+func caseHasAnyFeature(testCase Case, features []string) bool {
+	for _, featureID := range testCase.Features {
+		if slices.Contains(features, featureID) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/conformance/selection_test.go
+++ b/pkg/conformance/selection_test.go
@@ -1,0 +1,54 @@
+package conformance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryIsValid(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, DefaultRegistry().Validate())
+}
+
+func TestResolveSelectionDefaultsToAllCases(t *testing.T) {
+	t.Parallel()
+
+	plan, err := (Selection{}).Resolve(DefaultRegistry())
+	require.NoError(t, err)
+	require.NotEmpty(t, plan.Cases)
+	require.NotEmpty(t, plan.Suites)
+	require.NotEmpty(t, plan.Features)
+}
+
+func TestResolveSelectionFiltersByTransportAndFeature(t *testing.T) {
+	t.Parallel()
+
+	plan, err := (Selection{
+		Transport: TransportConnect,
+		Features:  []string{"connect-readiness"},
+	}).Resolve(DefaultRegistry())
+	require.NoError(t, err)
+	require.Len(t, plan.Cases, 1)
+	require.Equal(t, "connect-ready", plan.Cases[0].ID)
+	require.Len(t, plan.Features, 1)
+	require.Equal(t, "connect-readiness", plan.Features[0].ID)
+}
+
+func TestResolveSelectionRejectsUnknownSuite(t *testing.T) {
+	t.Parallel()
+
+	_, err := (Selection{Suites: []string{"missing"}}).Resolve(DefaultRegistry())
+	require.ErrorContains(t, err, `unknown suite "missing"`)
+}
+
+func TestResolveSelectionRejectsEmptyMatch(t *testing.T) {
+	t.Parallel()
+
+	_, err := (Selection{
+		Transport: TransportServe,
+		Features:  []string{"connect-readiness"},
+	}).Resolve(DefaultRegistry())
+	require.ErrorContains(t, err, "selection did not match any conformance cases")
+}

--- a/pkg/conformance/suite.go
+++ b/pkg/conformance/suite.go
@@ -1,0 +1,8 @@
+package conformance
+
+type Suite struct {
+	ID          string   `json:"id" koanf:"id"`
+	Label       string   `json:"label" koanf:"label"`
+	Description string   `json:"description,omitempty" koanf:"description"`
+	CaseIDs     []string `json:"case_ids" koanf:"case-ids"`
+}

--- a/pkg/conformance/types.go
+++ b/pkg/conformance/types.go
@@ -1,0 +1,75 @@
+package conformance
+
+import "slices"
+
+type Transport string
+
+const (
+	TransportServe   Transport = "serve"
+	TransportConnect Transport = "connect"
+)
+
+func ValidTransports() []Transport {
+	return []Transport{TransportServe, TransportConnect}
+}
+
+func IsValidTransport(value Transport) bool {
+	return slices.Contains(ValidTransports(), value)
+}
+
+type Compatibility string
+
+const (
+	CompatibilityFull         Compatibility = "full"
+	CompatibilityPartial      Compatibility = "partial"
+	CompatibilityIncompatible Compatibility = "incompatible"
+	CompatibilityUnknown      Compatibility = "unknown"
+)
+
+type CaseStatus string
+
+const (
+	CaseStatusPassed         CaseStatus = "passed"
+	CaseStatusFailed         CaseStatus = "failed"
+	CaseStatusNotImplemented CaseStatus = "not_implemented"
+	CaseStatusNotEvaluable   CaseStatus = "not_evaluable"
+	CaseStatusSkipped        CaseStatus = "skipped"
+)
+
+type ReasonCode string
+
+const (
+	ReasonCodeNotImplemented     ReasonCode = "not_implemented"
+	ReasonCodeTransportSetup     ReasonCode = "transport_setup_failed"
+	ReasonCodeBehaviorMismatch   ReasonCode = "behavior_mismatch"
+	ReasonCodeSecurityViolation  ReasonCode = "security_invariant_violated"
+	ReasonCodePrerequisiteFailed ReasonCode = "prerequisite_failed"
+)
+
+type ReportFormat string
+
+const (
+	ReportFormatPretty   ReportFormat = "pretty"
+	ReportFormatJSON     ReportFormat = "json"
+	ReportFormatJUnit    ReportFormat = "junit"
+	ReportFormatMarkdown ReportFormat = "markdown"
+)
+
+func ValidReportFormats() []ReportFormat {
+	return []ReportFormat{
+		ReportFormatPretty,
+		ReportFormatJSON,
+		ReportFormatJUnit,
+		ReportFormatMarkdown,
+	}
+}
+
+func IsValidReportFormat(value ReportFormat) bool {
+	return slices.Contains(ValidReportFormats(), value)
+}
+
+type GoldenMode string
+
+const (
+	GoldenModeSemantic GoldenMode = "semantic"
+)

--- a/tests/conformance/golang/README.md
+++ b/tests/conformance/golang/README.md
@@ -13,8 +13,9 @@ go run ./tests/conformance/golang
 
 The app serves:
 
-- `POST /api/inngest`
-- `GET /api/introspect`
+- `GET /api/inngest` for SDK inspection
+- `PUT /api/inngest` for SDK in-band sync
+- `POST /api/inngest` for function execution
 - `GET /health`
 
 By default it listens on `127.0.0.1:3000`.
@@ -30,14 +31,14 @@ INNGEST_SIGNING_KEY=7468697320697320612074657374206b6579 \
 ## Run doctor
 
 ```bash
-./inngest-bin conformance doctor \
+./inngest-bin alpha conformance doctor \
   --config ./tests/conformance/golang/inngest.conformance.yaml
 ```
 
 ## Run the current serve showcase
 
 ```bash
-./inngest-bin conformance run \
+./inngest-bin alpha conformance run \
   --config ./tests/conformance/golang/inngest.conformance.yaml \
   --report-out /tmp/golang-conformance-report.json
 ```

--- a/tests/conformance/golang/README.md
+++ b/tests/conformance/golang/README.md
@@ -1,0 +1,52 @@
+# Go Conformance Fixture
+
+This directory contains a small standalone Go SDK app that matches the current
+`inngest conformance` serve runner.
+
+It is meant to be run locally while testing the current branch of the CLI.
+
+## Start the fixture
+
+```bash
+go run ./tests/conformance/golang
+```
+
+The app serves:
+
+- `POST /api/inngest`
+- `GET /api/introspect`
+- `GET /health`
+
+By default it listens on `127.0.0.1:3000`.
+
+## Start the dev server
+
+```bash
+INNGEST_EVENT_KEY=test \
+INNGEST_SIGNING_KEY=7468697320697320612074657374206b6579 \
+./inngest-bin dev --no-discovery
+```
+
+## Run doctor
+
+```bash
+./inngest-bin conformance doctor \
+  --config ./tests/conformance/golang/inngest.conformance.yaml
+```
+
+## Run the current serve showcase
+
+```bash
+./inngest-bin conformance run \
+  --config ./tests/conformance/golang/inngest.conformance.yaml \
+  --report-out /tmp/golang-conformance-report.json
+```
+
+## Supported cases in this fixture
+
+- `serve-introspection`
+- `basic-invoke`
+- `steps-serial`
+- `retry-basic`
+- `cancel-basic`
+- `wait-for-event-basic`

--- a/tests/conformance/golang/inngest.conformance.yaml
+++ b/tests/conformance/golang/inngest.conformance.yaml
@@ -1,0 +1,9 @@
+transport: serve
+sdk:
+  url: http://127.0.0.1:3000/api/inngest
+dev:
+  url: http://127.0.0.1:8288
+  event_key: test
+  signing_key: "7468697320697320612074657374206b6579"
+report:
+  format: pretty

--- a/tests/conformance/golang/inngest.conformance.yaml
+++ b/tests/conformance/golang/inngest.conformance.yaml
@@ -1,4 +1,11 @@
 transport: serve
+cases:
+  - serve-introspection
+  - basic-invoke
+  - steps-serial
+  - retry-basic
+  - cancel-basic
+  - wait-for-event-basic
 sdk:
   url: http://127.0.0.1:3000/api/inngest
 dev:

--- a/tests/conformance/golang/main.go
+++ b/tests/conformance/golang/main.go
@@ -32,10 +32,16 @@ var (
 func main() {
 	addr := getenv("PORT", defaultAddr)
 	eventKey := getenv("INNGEST_EVENT_KEY", "test")
+	signingKey := getenv("INNGEST_SIGNING_KEY", "7468697320697320612074657374206b6579")
+	allowInBandSync := true
+	devMode := true
 
 	client, err := inngestgo.NewClient(inngestgo.ClientOpts{
-		AppID:    appID,
-		EventKey: inngestgo.StrPtr(eventKey),
+		AppID:           appID,
+		EventKey:        inngestgo.StrPtr(eventKey),
+		SigningKey:      inngestgo.StrPtr(signingKey),
+		AllowInBandSync: &allowInBandSync,
+		Dev:             &devMode,
 	})
 	if err != nil {
 		log.Fatalf("create client: %v", err)
@@ -46,12 +52,7 @@ func main() {
 	serve := client.Serve()
 	mux := http.NewServeMux()
 
-	// The conformance runner currently expects a conventional serve endpoint and
-	// a separate introspection endpoint. The Go SDK handler already responds to
-	// GET requests with introspection data, so we mount the same handler on both
-	// routes.
 	mux.Handle("/api/inngest", serve)
-	mux.Handle("/api/introspect", serve)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
@@ -173,10 +174,15 @@ func registerFunctions(client inngestgo.Client) {
 				return nil, err
 			}
 
-			// The runner expects the resumed event payload to be returned under a
+			result := any(payload)
+			if data, ok := payload["data"]; ok {
+				result = data
+			}
+
+			// The runner expects the resumed event data to be returned under a
 			// top-level result field.
 			return map[string]any{
-				"result": payload,
+				"result": result,
 			}, nil
 		},
 	)

--- a/tests/conformance/golang/main.go
+++ b/tests/conformance/golang/main.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/inngest/inngestgo"
+	"github.com/inngest/inngestgo/step"
+)
+
+const (
+	defaultAddr = "127.0.0.1:3000"
+	appID       = "conformance-golang"
+)
+
+var (
+	// retryStepAttempts tracks the number of times the retry case step has
+	// executed across retries. The conformance runner expects the first attempt
+	// to fail, then the retried attempt to succeed.
+	retryStepAttempts atomic.Int32
+
+	// retryFunctionAttempts tracks the function-level retry path after the step
+	// has already succeeded.
+	retryFunctionAttempts atomic.Int32
+)
+
+func main() {
+	addr := getenv("PORT", defaultAddr)
+	eventKey := getenv("INNGEST_EVENT_KEY", "test")
+
+	client, err := inngestgo.NewClient(inngestgo.ClientOpts{
+		AppID:    appID,
+		EventKey: inngestgo.StrPtr(eventKey),
+	})
+	if err != nil {
+		log.Fatalf("create client: %v", err)
+	}
+
+	registerFunctions(client)
+
+	serve := client.Serve()
+	mux := http.NewServeMux()
+
+	// The conformance runner currently expects a conventional serve endpoint and
+	// a separate introspection endpoint. The Go SDK handler already responds to
+	// GET requests with introspection data, so we mount the same handler on both
+	// routes.
+	mux.Handle("/api/inngest", serve)
+	mux.Handle("/api/introspect", serve)
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	log.Printf("starting Go conformance fixture on http://%s", addr)
+	if err := http.ListenAndServe(addr, mux); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("listen: %v", err)
+	}
+}
+
+func registerFunctions(client inngestgo.Client) {
+	mustCreate(client, inngestgo.FunctionOpts{ID: "test-suite-simple-fn"},
+		inngestgo.EventTrigger("tests/function.test", nil),
+		func(ctx context.Context, input inngestgo.Input[map[string]any]) (any, error) {
+			return map[string]any{
+				"name": input.Event.Name,
+				"body": "ok",
+			}, nil
+		},
+	)
+
+	mustCreate(client, inngestgo.FunctionOpts{ID: "test-suite-step-test"},
+		inngestgo.EventTrigger("tests/step.test", nil),
+		func(ctx context.Context, input inngestgo.Input[map[string]any]) (any, error) {
+			first, err := step.Run(ctx, "first step", func(ctx context.Context) (string, error) {
+				return "first step", nil
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			// The step name is chosen intentionally to match the protocol-level
+			// expectations in the serve conformance runner.
+			step.Sleep(ctx, "sleep", 2*time.Second)
+
+			_, err = step.Run(ctx, "second step", func(ctx context.Context) (map[string]any, error) {
+				return map[string]any{
+					"first":  first,
+					"second": true,
+				}, nil
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			return map[string]any{
+				"name": input.Event.Name,
+				"body": "ok",
+			}, nil
+		},
+	)
+
+	mustCreate(client, inngestgo.FunctionOpts{ID: "test-suite-retry-test"},
+		inngestgo.EventTrigger("tests/retry.test", nil),
+		func(ctx context.Context, input inngestgo.Input[map[string]any]) (any, error) {
+			_, err := step.Run(ctx, "first step", func(ctx context.Context) (string, error) {
+				attempt := retryStepAttempts.Add(1)
+				switch attempt {
+				case 1:
+					return "", errors.New("broken")
+				default:
+					return "yes: 2", nil
+				}
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			// The runner expects the function body itself to fail once after the
+			// step has succeeded, then return a normal response on retry.
+			if retryFunctionAttempts.Add(1) == 1 {
+				return nil, errors.New("broken func")
+			}
+
+			return map[string]any{
+				"name": input.Event.Name,
+				"body": "ok",
+			}, nil
+		},
+	)
+
+	mustCreate(client, inngestgo.FunctionOpts{
+		ID: "test-suite-cancel-test",
+		Cancel: []inngestgo.ConfigCancel{
+			{Event: "cancel/please", If: inngestgo.StrPtr("async.data.request_id == event.data.request_id")},
+		},
+	},
+		inngestgo.EventTrigger("tests/cancel.test", nil),
+		func(ctx context.Context, input inngestgo.Input[map[string]any]) (any, error) {
+			step.Sleep(ctx, "sleep", 10*time.Second)
+
+			_, err := step.Run(ctx, "After the sleep", func(ctx context.Context) (string, error) {
+				return "This should be cancelled if a matching cancel event is received", nil
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			return map[string]any{
+				"name": input.Event.Name,
+				"body": "ok",
+			}, nil
+		},
+	)
+
+	mustCreate(client, inngestgo.FunctionOpts{ID: "test-suite-wait-for-event"},
+		inngestgo.EventTrigger("tests/wait.test", nil),
+		func(ctx context.Context, input inngestgo.Input[map[string]any]) (any, error) {
+			payload, err := step.WaitForEvent[map[string]any](ctx, "wait", step.WaitForEventOpts{
+				Event:   "test/resume",
+				If:      inngestgo.StrPtr("async.data.resume == true && async.data.id == event.data.id"),
+				Timeout: 10 * time.Second,
+			})
+			if err == step.ErrEventNotReceived {
+				return map[string]any{}, nil
+			}
+			if err != nil {
+				return nil, err
+			}
+
+			// The runner expects the resumed event payload to be returned under a
+			// top-level result field.
+			return map[string]any{
+				"result": payload,
+			}, nil
+		},
+	)
+}
+
+func mustCreate[T any](client inngestgo.Client, opts inngestgo.FunctionOpts, trigger inngestgo.Trigger, fn func(context.Context, inngestgo.Input[T]) (any, error)) {
+	if _, err := inngestgo.CreateFunction(client, opts, trigger, fn); err != nil {
+		log.Fatalf("create function %s: %v", opts.ID, err)
+	}
+}
+
+func getenv(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}
+
+// The helper remains unused in the app flow today, but keeping a JSON encoder
+// nearby makes it easier to extend the fixture with ad hoc debug endpoints when
+// conformance cases grow.
+func mustJSON(value any) string {
+	byt, err := json.Marshal(value)
+	if err != nil {
+		panic(err)
+	}
+	return string(byt)
+}

--- a/tests/conformance/golang/main.go
+++ b/tests/conformance/golang/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
@@ -194,15 +193,4 @@ func getenv(name, fallback string) string {
 		return value
 	}
 	return fallback
-}
-
-// The helper remains unused in the app flow today, but keeping a JSON encoder
-// nearby makes it easier to extend the fixture with ad hoc debug endpoints when
-// conformance cases grow.
-func mustJSON(value any) string {
-	byt, err := json.Marshal(value)
-	if err != nil {
-		panic(err)
-	}
-	return string(byt)
 }


### PR DESCRIPTION
## Description

Adds the first usable cut of the SDK conformance CLI utility.

This PR started with the Phase 1 foundation and now also includes the first real Phase 2 serve execution path, so the CLI can be demoed against an SDK that exposes the standard HTTP serve flow.

What is included:
- top-level inngest conformance command wiring
- run, list, doctor, and report subcommands
- shared conformance registry, types, config loading, runtime resolution, selection resolution, compatibility rollups, and report persistence in pkg/conformance
- text-based terminal rendering for conformance catalog, doctor output, and reports via pkg/cli/output
- Phase 2 serve runner in pkg/conformance/runner/serve
- serve-mode doctor checks for SDK reachability, introspection, and required fixture functions
- first real happy-path serve cases:
  - serve-introspection
  - basic-invoke
  - steps-serial
  - retry-basic
  - cancel-basic
  - wait-for-event-basic
- updated rollout plan in docs/plans/002-cli-conformance-runner.org
- focused tests for config/runtime resolution, report handling, and the serve runner

What is intentionally not included yet:
- connect transport execution
- negative-input serve cases
- security-focused serve assertions and redaction checks
- richer failure artifact bundles and verbose captures
- JUnit and Markdown report rendering

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

Tested:
- go test ./pkg/conformance/... ./pkg/cli/output ./cmd/conformance ./cmd

Commits are intentionally split into small logical chunks:
- Add conformance runtime and report foundations
- Add serve conformance runner and doctor
- Wire conformance CLI to the serve runner

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds the `inngest conformance` CLI command family (run, list, doctor, report) with a Phase 2 serve-mode execution path. Includes a shared conformance registry, config/runtime resolution, report persistence, terminal rendering, a local proxy server for intercepting SDK traffic, and a Go fixture app. The connect transport is scaffolded but not yet implemented.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 79d805b50e00543bf31ef56d88ee436aea12ad55.</sup>
<!-- /MENDRAL_SUMMARY -->