### PR TITLE
Track queue item vest time

### DIFF
--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -147,7 +147,6 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 		Tags: map[string]any{
 			"kind":        item.Data.Kind,
 			"queue_shard": p.Queue.Shard().Name(),
-			"attempt":     item.Data.Attempt,
 		},
 	})
 

--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -141,7 +141,17 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 		span.SetAttributes(attribute.String("job_id", *item.Data.JobID))
 	}
 
-	if item.IsLeased(p.Queue.Clock().Now()) {
+	now := p.Queue.Clock().Now()
+	metrics.HistogramQueueItemVestDelay(ctx, now.Sub(time.UnixMilli(item.AtMS)), metrics.HistogramOpt{
+		PkgName: pkgName,
+		Tags: map[string]any{
+			"kind":        item.Data.Kind,
+			"queue_shard": p.Queue.Shard().Name(),
+			"attempt":     item.Data.Attempt,
+		},
+	})
+
+	if item.IsLeased(now) {
 		span.SetAttributes(attribute.String("skip_reason", "already_leased"))
 		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
 			PkgName: pkgName,

--- a/pkg/telemetry/metrics/histogram.go
+++ b/pkg/telemetry/metrics/histogram.go
@@ -154,6 +154,22 @@ func HistogramQueueOperationDelay(ctx context.Context, delay time.Duration, opts
 	})
 }
 
+// HistogramQueueItemVestDelay records how long after a queue item's scheduled
+// vest time (`At`) processing began. Negative values (items picked up via the
+// partition lookahead window) are clamped to 0; positive values indicate queue
+// lag past the scheduled run time.
+func HistogramQueueItemVestDelay(ctx context.Context, delay time.Duration, opts HistogramOpt) {
+	ms := max(delay.Milliseconds(), 0)
+	RecordIntHistogramMetric(ctx, ms, HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "queue_item_vest_delay",
+		Description: "Distribution of delay between a queue item's scheduled vest time and when processing begins",
+		Tags:        opts.Tags,
+		Unit:        "ms",
+		Boundaries:  DefaultBoundaries,
+	})
+}
+
 func HistogramRedisCommandDuration(ctx context.Context, value int64, opts HistogramOpt) {
 	RecordIntHistogramMetric(ctx, value, HistogramOpt{
 		PkgName:     opts.PkgName,


### PR DESCRIPTION
## Description

Track queue item vest time.

Queue Vest time is the time delay between the queue's vest time (`QueueItem.AtMS`) and the time it was actually picked up for processing. This is purely scan delay in the executor.

A few factors affect the quality of this metric:
- **Partition Lookahead time**: By default this is 1s, and we peek partitions and queue items ahead of their vest time, so in most cases, the delay would be negative. This is okay - we don't care about this scenario and just clamp the metric to 0. We care mostly about when we peek the account/partition/queue item past its vest time.
- **Time fudging**: For many reasons, we fudge the queue's vest time as it doubles as a "score" to compare items. This is also okay.  We only care about the delay between the queue item's vest score and time we pick it up. How we decide the queue score (fudged or not) is irrelevant for the purposes of this metric
- **Retries**: When a queue item is retried, we change the `QueueItem.AtMS` to include a backoff delay - so for retries, we will be using the new queue item score, which is the desirable behaviour for this metric.


## Motivation

Help accurately breakdown the delays in the queue and attribute it to the most accurate source of delay. This metric helps us identify if there is slowness in picking up items from the queue that are **not** attributable to the function's flow control settings.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
