### PR TITLE
Fix package dependancies

### DIFF
--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -49,6 +49,7 @@
     "@stripe/stripe-js": "^1.52.1",
     "@tanstack/eslint-config": "^0.3.0",
     "@tanstack/nitro-v2-vite-plugin": "^1.154.7",
+    "@tanstack/query-core": "5.90.2",
     "@tanstack/react-query": "^5.66.5",
     "@tanstack/react-query-devtools": "^5.84.2",
     "@tanstack/react-router": "^1.158.1",

--- a/ui/apps/dev-server-ui/package.json
+++ b/ui/apps/dev-server-ui/package.json
@@ -32,6 +32,7 @@
     "@reduxjs/toolkit": "^1.9.0",
     "@remixicon/react": "^4.2.0",
     "@rtk-query/graphql-request-base-query": "^2.2.0",
+    "@tanstack/query-core": "5.90.2",
     "@tanstack/react-query": "^5.66.5",
     "@tanstack/react-query-devtools": "^5.84.2",
     "@tanstack/react-router": "^1.158.1",

--- a/ui/apps/support/package.json
+++ b/ui/apps/support/package.json
@@ -17,6 +17,7 @@
     "@headlessui/react": "^2.2.9",
     "@launchdarkly/node-server-sdk": "^9.0.3",
     "@remixicon/react": "^4.7.0",
+    "@tanstack/query-core": "5.90.2",
     "@tanstack/react-query": "^5.66.5",
     "@tanstack/react-query-devtools": "^5.84.2",
     "@tanstack/react-router": "1.134.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -83,7 +83,9 @@
       "minimatch@<5.0.0": ">=5.0.0",
       "nodemon": ">=3.0.0",
       "nodemon>minimatch": "3.1.2",
-      "nodemon>brace-expansion": "1.1.11"
+      "nodemon>brace-expansion": "1.1.11",
+      "@clerk/shared@<3.47.4": "3.47.4",
+      "protobufjs@<7.5.5": "7.5.5"
     },
     "onlyBuiltDependencies": [
       "@sentry/cli",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -60,6 +60,8 @@ overrides:
   nodemon: '>=3.0.0'
   nodemon>minimatch: 3.1.2
   nodemon>brace-expansion: 1.1.11
+  '@clerk/shared@<3.47.4': 3.47.4
+  protobufjs@<7.5.5: 7.5.5
 
 importers:
 
@@ -137,6 +139,9 @@ importers:
       '@tanstack/nitro-v2-vite-plugin':
         specifier: ^1.154.7
         version: 1.154.7(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.0))
+      '@tanstack/query-core':
+        specifier: 5.90.2
+        version: 5.90.2
       '@tanstack/react-query':
         specifier: ^5.66.5
         version: 5.90.2(react@18.2.0)
@@ -363,6 +368,9 @@ importers:
       '@rtk-query/graphql-request-base-query':
         specifier: ^2.2.0
         version: 2.2.0(@reduxjs/toolkit@1.9.0(react-redux@8.0.5(@types/react-dom@18.2.4)(@types/react@18.2.11)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(redux@4.2.1))(react@18.2.0))(graphql@16.8.1)
+      '@tanstack/query-core':
+        specifier: 5.90.2
+        version: 5.90.2
       '@tanstack/react-query':
         specifier: ^5.66.5
         version: 5.90.2(react@18.2.0)
@@ -526,6 +534,9 @@ importers:
       '@remixicon/react':
         specifier: ^4.7.0
         version: 4.7.0(react@18.2.0)
+      '@tanstack/query-core':
+        specifier: 5.90.2
+        version: 5.90.2
       '@tanstack/react-query':
         specifier: ^5.66.5
         version: 5.90.2(react@18.2.0)
@@ -1976,20 +1987,8 @@ packages:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
       react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
 
-  '@clerk/shared@3.36.0':
-    resolution: {integrity: sha512-Yp4tL/x/iVft40DnxBjT/g/kQilZ+i9mYrqC1Lk6fUnfZV8t7E54GX19JtJSSONzjHsH6sCv3BmJaF1f7Eomkw==}
-    engines: {node: '>=18.17.0'}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0 || ^19.0.0-0
-      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
-  '@clerk/shared@3.44.0':
-    resolution: {integrity: sha512-kH+chNeZwqml3IDpWLgebWECfOZifyUQO4OISd/96w1EuCY1Bzw6cBq/ZbpsoO8jyG8/6bGr/MGXLhDzTrpPfA==}
+  '@clerk/shared@3.47.4':
+    resolution: {integrity: sha512-0O5/zgB5SO26PKarAIw7uj4j+4JsnT2/uiJ7SPI3LQMb62sM+AjDlVadcXuYc+4sY6w1szrAIVepI5Bkv57hnQ==}
     engines: {node: '>=18.17.0'}
     peerDependencies:
       react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
@@ -7039,13 +7038,13 @@ packages:
     resolution: {integrity: sha512-4LuWrg7EKWgQaMJfnN+wcmbAW+VSsCmqGohftWjuct47bv8uE4n/nPpq4XjJPsxgq00GGG5J8dvBczp8uxScew==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: '>=4.5.11'
+      vite: '>=5.4.16'
 
   '@vitejs/plugin-react@5.1.3':
     resolution: {integrity: sha512-NVUnA6gQCl8jfoYqKqQU5Clv0aPw14KkZYCsX6T9Lfu9slI0LOU10OTwFHS/WmptsMMpshNd/1tuWsHQ2Uk+cg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: '>=4.5.11'
+      vite: '>=5.4.16'
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
@@ -7057,7 +7056,7 @@ packages:
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: '>=5.4.16'
+      vite: '>=6.2.7'
     peerDependenciesMeta:
       msw:
         optional: true
@@ -13577,7 +13576,7 @@ packages:
   vite-tsconfig-paths@6.0.5:
     resolution: {integrity: sha512-f/WvY6ekHykUF1rWJUAbCU7iS/5QYDIugwpqJA+ttwKbxSbzNlqlE8vZSrsnxNQciUW+z6lvhlXMaEyZn9MSig==}
     peerDependencies:
-      vite: '>=4.5.11'
+      vite: '>=5.4.16'
 
   vite@7.1.12:
     resolution: {integrity: sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==}
@@ -13662,7 +13661,7 @@ packages:
   vitefu@1.1.1:
     resolution: {integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==}
     peerDependencies:
-      vite: '>=4.5.11'
+      vite: '>=5.4.16'
     peerDependenciesMeta:
       vite:
         optional: true
@@ -15633,7 +15632,7 @@ snapshots:
 
   '@clerk/backend@2.24.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@clerk/shared': 3.36.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/shared': 3.47.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@clerk/types': 4.101.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       cookie: 1.0.2
       standardwebhooks: 1.0.0
@@ -15644,7 +15643,7 @@ snapshots:
 
   '@clerk/backend@2.30.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@clerk/shared': 3.44.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/shared': 3.47.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@clerk/types': 4.101.14(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       standardwebhooks: 1.0.0
       tslib: 2.8.1
@@ -15654,31 +15653,19 @@ snapshots:
 
   '@clerk/clerk-react@5.57.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@clerk/shared': 3.36.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/shared': 3.47.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.8.1
 
   '@clerk/clerk-react@5.60.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@clerk/shared': 3.44.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/shared': 3.47.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       tslib: 2.8.1
 
-  '@clerk/shared@3.36.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
-    dependencies:
-      csstype: 3.1.3
-      dequal: 2.0.3
-      glob-to-regexp: 0.4.1
-      js-cookie: 3.0.5
-      std-env: 3.10.0
-      swr: 2.3.4(react@18.2.0)
-    optionalDependencies:
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-
-  '@clerk/shared@3.44.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@clerk/shared@3.47.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       csstype: 3.1.3
       dequal: 2.0.3
@@ -15694,7 +15681,7 @@ snapshots:
     dependencies:
       '@clerk/backend': 2.24.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@clerk/clerk-react': 5.57.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@clerk/shared': 3.36.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/shared': 3.47.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@clerk/types': 4.101.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tanstack/react-router': 1.134.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tanstack/react-start': 1.134.6(crossws@0.4.1(srvx@0.11.13))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@7.1.12(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.0))(webpack@5.99.9)
@@ -15706,7 +15693,7 @@ snapshots:
     dependencies:
       '@clerk/backend': 2.30.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@clerk/clerk-react': 5.60.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@clerk/shared': 3.44.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/shared': 3.47.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@clerk/types': 4.101.14(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tanstack/react-router': 1.158.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tanstack/react-start': 1.158.1(crossws@0.4.1(srvx@0.11.13))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.39.0)(tsx@4.20.6)(yaml@2.8.0))(webpack@5.99.9)
@@ -15716,14 +15703,14 @@ snapshots:
 
   '@clerk/types@4.101.14(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@clerk/shared': 3.44.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/shared': 3.47.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - react
       - react-dom
 
   '@clerk/types@4.101.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@clerk/shared': 3.36.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@clerk/shared': 3.47.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
       - react
       - react-dom


### PR DESCRIPTION
## Description

Fixes packages dependancies

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Pins `@tanstack/query-core` as an explicit direct dependency across three apps to eliminate the duplicate `5.51.9`/`5.90.2` instance in the lockfile. Adds pnpm overrides to force `@clerk/shared>=3.47.4` and `protobufjs>=7.5.5` across the monorepo, and updates vite peer-dep lower bounds in the lockfile snapshots.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit dcf4912cc95a2617df9c2ac79d0b9224406fddf4.</sup>
<!-- /MENDRAL_SUMMARY -->