### PR TITLE
EXE-1484: Gracefully handle long userland attributes

### DIFF
--- a/ui/packages/components/src/RunDetailsV3/UserlandAttrs.tsx
+++ b/ui/packages/components/src/RunDetailsV3/UserlandAttrs.tsx
@@ -14,9 +14,9 @@ export const UserlandAttrs = ({ userlandSpan }: { userlandSpan: UserlandSpanType
   return attrs ? (
     <div className="h-full overflow-y-auto">
       <div className="mb-4 mt-2 flex max-h-full flex-col gap-2">
-        <div className="text-muted bg-canvasSubtle sticky top-0 flex flex-row px-4 py-2 text-sm font-medium leading-tight">
-          <div className="w-72">Key</div>
-          <div className="">Value</div>
+        <div className="text-muted bg-canvasSubtle sticky top-0 grid grid-cols-[18rem_1fr] px-4 py-2 text-sm font-medium leading-tight">
+          <div>Key</div>
+          <div>Value</div>
         </div>
         {Object.entries(attrs)
           .filter(([key]) => !internalPrevixes.some((prefix) => key.startsWith(prefix)))
@@ -24,10 +24,10 @@ export const UserlandAttrs = ({ userlandSpan }: { userlandSpan: UserlandSpanType
             return (
               <div
                 key={`userland-span-attr-${key}`}
-                className="border-canvasSubtle flex flex-row items-center border-b px-4 pb-2"
+                className="border-canvasSubtle grid grid-cols-[18rem_1fr] items-center border-b px-4 pb-2"
               >
-                <div className="text-muted w-72 text-sm font-normal leading-tight">{key}</div>
-                <div className="text-basis truncate text-sm font-normal leading-tight">
+                <div className="text-muted text-sm font-normal leading-tight">{key}</div>
+                <div className="text-basis min-w-0 truncate text-sm font-normal leading-tight">
                   {String(value) || '--'}
                 </div>
               </div>

--- a/ui/packages/components/src/RunDetailsV3/UserlandAttrs.tsx
+++ b/ui/packages/components/src/RunDetailsV3/UserlandAttrs.tsx
@@ -26,7 +26,9 @@ export const UserlandAttrs = ({ userlandSpan }: { userlandSpan: UserlandSpanType
                 key={`userland-span-attr-${key}`}
                 className="border-canvasSubtle grid grid-cols-[18rem_1fr] items-center border-b px-4 pb-2"
               >
-                <div className="text-muted text-sm font-normal leading-tight">{key}</div>
+                <div className="text-muted min-w-0 truncate text-sm font-normal leading-tight">
+                  {key}
+                </div>
                 <div className="text-basis min-w-0 truncate text-sm font-normal leading-tight">
                   {String(value) || '--'}
                 </div>

--- a/ui/packages/components/src/RunDetailsV4/UserlandAttrs.tsx
+++ b/ui/packages/components/src/RunDetailsV4/UserlandAttrs.tsx
@@ -30,17 +30,17 @@ function AttrTable({
   if (entries.length === 0) return null;
   return (
     <div data-testid={testId} className="mb-4 mt-2 flex max-h-full flex-col gap-2">
-      <div className="text-muted bg-canvasSubtle sticky top-0 flex flex-row px-4 py-2 text-sm font-medium leading-tight">
-        <div className="w-72">Key</div>
-        <div className="">Value</div>
+      <div className="text-muted bg-canvasSubtle sticky top-0 grid grid-cols-[18rem_1fr] px-4 py-2 text-sm font-medium leading-tight">
+        <div>Key</div>
+        <div>Value</div>
       </div>
       {entries.map(([key, value]) => (
         <div
           key={`${keyPrefix}-${key}`}
-          className="border-canvasSubtle flex flex-row items-center border-b px-4 pb-2"
+          className="border-canvasSubtle grid grid-cols-[18rem_1fr] items-center border-b px-4 pb-2"
         >
-          <div className="text-muted w-72 text-sm font-normal leading-tight">{key}</div>
-          <div className="text-basis truncate text-sm font-normal leading-tight">
+          <div className="text-muted text-sm font-normal leading-tight">{key}</div>
+          <div className="text-basis min-w-0 truncate text-sm font-normal leading-tight">
             {String(value) || '--'}
           </div>
         </div>

--- a/ui/packages/components/src/RunDetailsV4/UserlandAttrs.tsx
+++ b/ui/packages/components/src/RunDetailsV4/UserlandAttrs.tsx
@@ -39,7 +39,7 @@ function AttrTable({
           key={`${keyPrefix}-${key}`}
           className="border-canvasSubtle grid grid-cols-[18rem_1fr] items-center border-b px-4 pb-2"
         >
-          <div className="text-muted text-sm font-normal leading-tight">{key}</div>
+          <div className="text-muted min-w-0 truncate text-sm font-normal leading-tight">{key}</div>
           <div className="text-basis min-w-0 truncate text-sm font-normal leading-tight">
             {String(value) || '--'}
           </div>


### PR DESCRIPTION
## Description

- Previously, we did not gracefully handle very long keys or values for userland span attributes

Before:
<img width="50%" height="1489" alt="before" src="https://github.com/user-attachments/assets/9e8eae6c-1f62-4c67-95d2-e93ed9a78e83" />

- We now gracefully truncate keys and values
- For keys (which tend to be short), users can copy the entire value out
- For values, users can copy the value out or adjust the width of the entire panel to see more.

After:
<img width="50%" height="1489" alt="after" src="https://github.com/user-attachments/assets/4ba6c02a-1620-44d3-989e-e8623c6e0c39" />

- We utilize grid to be explicit about our intent to present a grid
- We add min-w-0 to correctly resolve how the spacing and truncation resolves
- I considered adding hovering to reveal a hint with the entire value, but I think this is too low discoverability and can still present a poor viewing experience for very long strings


<!--- Include screenshots if you modify the UI. -->

## Motivation

- Gracefully handle long keys and values for userland span attributes

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes overflow of long userland span attribute keys and values by switching from fixed-width flex to CSS grid with `min-w-0 truncate`. The new commits also add `title={key}` tooltips on key cells in both V3 and V4 so users can hover to see full key text.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ef45df5560f2f7b245bcf49f5a097ac0183d23b8.</sup>
<!-- /MENDRAL_SUMMARY -->