### PR TITLE
refactor run search

### DIFF
--- a/ui/apps/dev-server-ui/src/routes/_dashboard/runs/index.tsx
+++ b/ui/apps/dev-server-ui/src/routes/_dashboard/runs/index.tsx
@@ -250,6 +250,7 @@ function RunsComponent() {
         scope="env"
         totalCount={totalCount}
         searchError={searchError}
+        searchLimit={1000}
         infiniteScrollTrigger={(containerRef) => (
           <InfiniteScrollTrigger
             onIntersect={fetchNextPage}

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -286,7 +286,7 @@ export function RunsPage({
             <OptionalTooltip
               tooltip={
                 !!searchLimit && totalCount !== undefined && totalCount >= searchLimit && !search
-                  ? 'Search is unavailable for large result sets'
+                  ? `Search is limited to ${searchLimit} results`
                   : undefined
               }
             >

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -5,6 +5,7 @@ import { TimeFilter } from '@inngest/components/Filter/TimeFilter';
 import { Pill } from '@inngest/components/Pill';
 import { SelectGroup, type Option } from '@inngest/components/Select/Select';
 import { TableFilter } from '@inngest/components/Table';
+import { OptionalTooltip } from '@inngest/components/Tooltip/OptionalTooltip';
 import { DEFAULT_TIME } from '@inngest/components/hooks/useCalculatedStartTime';
 import {
   FunctionRunTimeField,
@@ -279,19 +280,25 @@ export function RunsPage({
         <div className="flex h-11 items-center justify-between gap-1.5 px-3">
           <div className="flex items-center gap-1.5">
             {/* CEL search scans the returned run set and gets prohibitively slow on large pages.
-                Callers can pass `searchLimit` to hide the button above that count; if `searchLimit`
-                is unset (cloud), the button always renders. An active query also keeps the button
-                visible so users are never stranded without a "Hide search" toggle. */}
-            {(searchLimit === undefined ||
-              totalCount === undefined ||
-              totalCount < searchLimit ||
-              !!search) && (
+                Callers can pass `searchLimit` to disable the button above that count. An active
+                query keeps the button enabled so users are never stranded without a "Hide search"
+                toggle. */}
+            <OptionalTooltip
+              tooltip={
+                !!searchLimit && totalCount !== undefined && totalCount > searchLimit && !search
+                  ? 'Search is unavailable for large result sets'
+                  : undefined
+              }
+            >
               <Button
                 icon={<RiSearchLine />}
                 size="small"
                 kind="secondary"
                 iconSide="left"
                 appearance="outlined"
+                disabled={
+                  !!searchLimit && totalCount !== undefined && totalCount > searchLimit && !search
+                }
                 label={showSearch ? 'Hide search' : 'Show search'}
                 onClick={() => setShowSearch((prev) => !prev)}
                 className={cn(
@@ -301,7 +308,7 @@ export function RunsPage({
                   'h-[26px] w-[103px] rounded'
                 )}
               />
-            )}
+            </OptionalTooltip>
             <SelectGroup>
               <TimeFieldFilter
                 selectedTimeField={timeField}

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -55,6 +55,12 @@ type Props = {
   searchError?: Error;
   error?: Error | null;
   infiniteScrollTrigger?: (containerRef: HTMLDivElement | null) => React.ReactNode;
+  // When set, the CEL search button is hidden once `totalCount` reaches this
+  // threshold (unless the user already has an active query, so they're not
+  // stranded without a "Hide search" toggle). Used by self-hosted deployments
+  // where CEL search against large result sets is prohibitively slow. Leave
+  // undefined to always show the button (cloud default).
+  searchLimit?: number;
 };
 
 export function RunsPage({
@@ -76,6 +82,7 @@ export function RunsPage({
   searchError,
   error,
   infiniteScrollTrigger,
+  searchLimit,
 }: Props) {
   const containerRef = useRef<HTMLDivElement>(null);
   const columns = useScopedColumns(scope);
@@ -271,9 +278,14 @@ export function RunsPage({
       <div className="bg-canvasBase sticky top-0 z-10 flex flex-col">
         <div className="flex h-11 items-center justify-between gap-1.5 px-3">
           <div className="flex items-center gap-1.5">
-            {/* CEL search scans the returned run set and gets prohibitively slow on large pages,
-                so only offer it when the total is small or the user already has a query applied. */}
-            {(totalCount === undefined || totalCount < 1000 || !!search) && (
+            {/* CEL search scans the returned run set and gets prohibitively slow on large pages.
+                Callers can pass `searchLimit` to hide the button above that count; if `searchLimit`
+                is unset (cloud), the button always renders. An active query also keeps the button
+                visible so users are never stranded without a "Hide search" toggle. */}
+            {(searchLimit === undefined ||
+              totalCount === undefined ||
+              totalCount < searchLimit ||
+              !!search) && (
               <Button
                 icon={<RiSearchLine />}
                 size="small"

--- a/ui/packages/components/src/RunsPage/RunsPage.tsx
+++ b/ui/packages/components/src/RunsPage/RunsPage.tsx
@@ -285,7 +285,7 @@ export function RunsPage({
                 toggle. */}
             <OptionalTooltip
               tooltip={
-                !!searchLimit && totalCount !== undefined && totalCount > searchLimit && !search
+                !!searchLimit && totalCount !== undefined && totalCount >= searchLimit && !search
                   ? 'Search is unavailable for large result sets'
                   : undefined
               }
@@ -297,7 +297,7 @@ export function RunsPage({
                 iconSide="left"
                 appearance="outlined"
                 disabled={
-                  !!searchLimit && totalCount !== undefined && totalCount > searchLimit && !search
+                  !!searchLimit && totalCount !== undefined && totalCount >= searchLimit && !search
                 }
                 label={showSearch ? 'Hide search' : 'Show search'}
                 onClick={() => setShowSearch((prev) => !prev)}


### PR DESCRIPTION

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Refactors the CEL search button visibility logic: instead of conditionally rendering the button, it's always rendered but disabled (with a tooltip) when `totalCount` exceeds the new `searchLimit` prop. The `searchLimit` is hardcoded to 1000 in the dev-server UI.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4933fdf88ccb1b13089ae4250f57d26cfa273660.</sup>
<!-- /MENDRAL_SUMMARY -->