### PR TITLE
fix(cqrs/postgres): COALESCE finish columns in function-run LEFT JOINs (#4042)

### DIFF
--- a/pkg/cqrs/base_cqrs/sqlc/postgres/normalization.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/normalization.go
@@ -243,7 +243,14 @@ func (r *GetFunctionRunRow) ToSQLite() (*sqlc.GetFunctionRunRow, error) {
 		return nil, err
 	}
 
-	finish, err := r.FunctionFinish.ToSQLite()
+	pgFinish := FunctionFinish{
+		RunID:              r.FunctionRun.RunID,
+		Status:             r.FinishStatus,
+		Output:             r.FinishOutput,
+		CompletedStepCount: r.FinishCompletedStepCount,
+		CreatedAt:          r.FinishCreatedAt,
+	}
+	finish, err := pgFinish.ToSQLite()
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +267,14 @@ func (r *GetFunctionRunsTimeboundRow) ToSQLite() (*sqlc.GetFunctionRunsTimebound
 		return nil, err
 	}
 
-	finish, err := r.FunctionFinish.ToSQLite()
+	pgFinish := FunctionFinish{
+		RunID:              r.FunctionRun.RunID,
+		Status:             r.FinishStatus,
+		Output:             r.FinishOutput,
+		CompletedStepCount: r.FinishCompletedStepCount,
+		CreatedAt:          r.FinishCreatedAt,
+	}
+	finish, err := pgFinish.ToSQLite()
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +291,14 @@ func (r *GetFunctionRunsRow) ToSQLite() (*sqlc.GetFunctionRunsRow, error) {
 		return nil, err
 	}
 
-	finish, err := r.FunctionFinish.ToSQLite()
+	pgFinish := FunctionFinish{
+		RunID:              r.FunctionRun.RunID,
+		Status:             r.FinishStatus,
+		Output:             r.FinishOutput,
+		CompletedStepCount: r.FinishCompletedStepCount,
+		CreatedAt:          r.FinishCreatedAt,
+	}
+	finish, err := pgFinish.ToSQLite()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql
@@ -102,17 +102,31 @@ INSERT INTO function_finishes
     ($1, $2, $3, $4, $5);
 
 -- name: GetFunctionRun :one
-SELECT sqlc.embed(function_runs), sqlc.embed(function_finishes)
+SELECT sqlc.embed(function_runs),
+    COALESCE(function_finishes.status, '') AS finish_status,
+    COALESCE(function_finishes.output, '') AS finish_output,
+    COALESCE(function_finishes.completed_step_count, 0) AS finish_completed_step_count,
+    COALESCE(function_finishes.created_at, function_runs.run_started_at) AS finish_created_at
   FROM function_runs
   LEFT JOIN function_finishes ON function_finishes.run_id = function_runs.run_id
   WHERE function_runs.run_id = $1;
 
 -- name: GetFunctionRuns :many
-SELECT sqlc.embed(function_runs), sqlc.embed(function_finishes) FROM function_runs
+SELECT sqlc.embed(function_runs),
+    COALESCE(function_finishes.status, '') AS finish_status,
+    COALESCE(function_finishes.output, '') AS finish_output,
+    COALESCE(function_finishes.completed_step_count, 0) AS finish_completed_step_count,
+    COALESCE(function_finishes.created_at, function_runs.run_started_at) AS finish_created_at
+FROM function_runs
 LEFT JOIN function_finishes ON function_finishes.run_id = function_runs.run_id;
 
 -- name: GetFunctionRunsTimebound :many
-SELECT sqlc.embed(function_runs), sqlc.embed(function_finishes) FROM function_runs
+SELECT sqlc.embed(function_runs),
+    COALESCE(function_finishes.status, '') AS finish_status,
+    COALESCE(function_finishes.output, '') AS finish_output,
+    COALESCE(function_finishes.completed_step_count, 0) AS finish_completed_step_count,
+    COALESCE(function_finishes.created_at, function_runs.run_started_at) AS finish_created_at
+FROM function_runs
 LEFT JOIN function_finishes ON function_finishes.run_id = function_runs.run_id
 WHERE function_runs.run_started_at > $1 AND function_runs.run_started_at <= $2
 ORDER BY function_runs.run_started_at DESC

--- a/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql.go
+++ b/pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql.go
@@ -638,15 +638,22 @@ func (q *Queries) GetFunctionBySlug(ctx context.Context, slug string) (*Function
 }
 
 const getFunctionRun = `-- name: GetFunctionRun :one
-SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron, function_finishes.run_id, function_finishes.status, function_finishes.output, function_finishes.completed_step_count, function_finishes.created_at
+SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron,
+    COALESCE(function_finishes.status, '') AS finish_status,
+    COALESCE(function_finishes.output, '') AS finish_output,
+    COALESCE(function_finishes.completed_step_count, 0) AS finish_completed_step_count,
+    COALESCE(function_finishes.created_at, function_runs.run_started_at) AS finish_created_at
   FROM function_runs
   LEFT JOIN function_finishes ON function_finishes.run_id = function_runs.run_id
   WHERE function_runs.run_id = $1
 `
 
 type GetFunctionRunRow struct {
-	FunctionRun    FunctionRun
-	FunctionFinish FunctionFinish
+	FunctionRun              FunctionRun
+	FinishStatus             string
+	FinishOutput             string
+	FinishCompletedStepCount int32
+	FinishCreatedAt          time.Time
 }
 
 func (q *Queries) GetFunctionRun(ctx context.Context, runID ulid.ULID) (*GetFunctionRunRow, error) {
@@ -662,11 +669,10 @@ func (q *Queries) GetFunctionRun(ctx context.Context, runID ulid.ULID) (*GetFunc
 		&i.FunctionRun.BatchID,
 		&i.FunctionRun.OriginalRunID,
 		&i.FunctionRun.Cron,
-		&i.FunctionFinish.RunID,
-		&i.FunctionFinish.Status,
-		&i.FunctionFinish.Output,
-		&i.FunctionFinish.CompletedStepCount,
-		&i.FunctionFinish.CreatedAt,
+		&i.FinishStatus,
+		&i.FinishOutput,
+		&i.FinishCompletedStepCount,
+		&i.FinishCreatedAt,
 	)
 	return &i, err
 }
@@ -767,13 +773,21 @@ func (q *Queries) GetFunctionRunHistory(ctx context.Context, runID ulid.ULID) ([
 }
 
 const getFunctionRuns = `-- name: GetFunctionRuns :many
-SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron, function_finishes.run_id, function_finishes.status, function_finishes.output, function_finishes.completed_step_count, function_finishes.created_at FROM function_runs
+SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron,
+    COALESCE(function_finishes.status, '') AS finish_status,
+    COALESCE(function_finishes.output, '') AS finish_output,
+    COALESCE(function_finishes.completed_step_count, 0) AS finish_completed_step_count,
+    COALESCE(function_finishes.created_at, function_runs.run_started_at) AS finish_created_at
+FROM function_runs
 LEFT JOIN function_finishes ON function_finishes.run_id = function_runs.run_id
 `
 
 type GetFunctionRunsRow struct {
-	FunctionRun    FunctionRun
-	FunctionFinish FunctionFinish
+	FunctionRun              FunctionRun
+	FinishStatus             string
+	FinishOutput             string
+	FinishCompletedStepCount int32
+	FinishCreatedAt          time.Time
 }
 
 func (q *Queries) GetFunctionRuns(ctx context.Context) ([]*GetFunctionRunsRow, error) {
@@ -795,11 +809,10 @@ func (q *Queries) GetFunctionRuns(ctx context.Context) ([]*GetFunctionRunsRow, e
 			&i.FunctionRun.BatchID,
 			&i.FunctionRun.OriginalRunID,
 			&i.FunctionRun.Cron,
-			&i.FunctionFinish.RunID,
-			&i.FunctionFinish.Status,
-			&i.FunctionFinish.Output,
-			&i.FunctionFinish.CompletedStepCount,
-			&i.FunctionFinish.CreatedAt,
+			&i.FinishStatus,
+			&i.FinishOutput,
+			&i.FinishCompletedStepCount,
+			&i.FinishCreatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -871,7 +884,12 @@ func (q *Queries) GetFunctionRunsFromEvents(ctx context.Context, eventIds [][]by
 }
 
 const getFunctionRunsTimebound = `-- name: GetFunctionRunsTimebound :many
-SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron, function_finishes.run_id, function_finishes.status, function_finishes.output, function_finishes.completed_step_count, function_finishes.created_at FROM function_runs
+SELECT function_runs.run_id, function_runs.run_started_at, function_runs.function_id, function_runs.function_version, function_runs.trigger_type, function_runs.event_id, function_runs.batch_id, function_runs.original_run_id, function_runs.cron,
+    COALESCE(function_finishes.status, '') AS finish_status,
+    COALESCE(function_finishes.output, '') AS finish_output,
+    COALESCE(function_finishes.completed_step_count, 0) AS finish_completed_step_count,
+    COALESCE(function_finishes.created_at, function_runs.run_started_at) AS finish_created_at
+FROM function_runs
 LEFT JOIN function_finishes ON function_finishes.run_id = function_runs.run_id
 WHERE function_runs.run_started_at > $1 AND function_runs.run_started_at <= $2
 ORDER BY function_runs.run_started_at DESC
@@ -885,8 +903,11 @@ type GetFunctionRunsTimeboundParams struct {
 }
 
 type GetFunctionRunsTimeboundRow struct {
-	FunctionRun    FunctionRun
-	FunctionFinish FunctionFinish
+	FunctionRun              FunctionRun
+	FinishStatus             string
+	FinishOutput             string
+	FinishCompletedStepCount int32
+	FinishCreatedAt          time.Time
 }
 
 func (q *Queries) GetFunctionRunsTimebound(ctx context.Context, arg GetFunctionRunsTimeboundParams) ([]*GetFunctionRunsTimeboundRow, error) {
@@ -908,11 +929,10 @@ func (q *Queries) GetFunctionRunsTimebound(ctx context.Context, arg GetFunctionR
 			&i.FunctionRun.BatchID,
 			&i.FunctionRun.OriginalRunID,
 			&i.FunctionRun.Cron,
-			&i.FunctionFinish.RunID,
-			&i.FunctionFinish.Status,
-			&i.FunctionFinish.Output,
-			&i.FunctionFinish.CompletedStepCount,
-			&i.FunctionFinish.CreatedAt,
+			&i.FinishStatus,
+			&i.FinishOutput,
+			&i.FinishCompletedStepCount,
+			&i.FinishCreatedAt,
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/db/postgres/querier.go
+++ b/pkg/db/postgres/querier.go
@@ -309,7 +309,14 @@ func (pq *pgQuerier) GetFunctionRun(ctx context.Context, runID ulid.ULID) (*db.F
 	if err != nil {
 		return nil, err
 	}
-	return functionRunRowFromPG(&r.FunctionRun, &r.FunctionFinish), nil
+	finish := sqlc.FunctionFinish{
+		RunID:              r.FunctionRun.RunID,
+		Status:             r.FinishStatus,
+		Output:             r.FinishOutput,
+		CompletedStepCount: r.FinishCompletedStepCount,
+		CreatedAt:          r.FinishCreatedAt,
+	}
+	return functionRunRowFromPG(&r.FunctionRun, &finish), nil
 }
 
 func (pq *pgQuerier) GetFunctionRuns(ctx context.Context) ([]*db.FunctionRunRow, error) {
@@ -319,7 +326,14 @@ func (pq *pgQuerier) GetFunctionRuns(ctx context.Context) ([]*db.FunctionRunRow,
 	}
 	out := make([]*db.FunctionRunRow, len(rows))
 	for i, r := range rows {
-		out[i] = functionRunRowFromPG(&r.FunctionRun, &r.FunctionFinish)
+		finish := sqlc.FunctionFinish{
+			RunID:              r.FunctionRun.RunID,
+			Status:             r.FinishStatus,
+			Output:             r.FinishOutput,
+			CompletedStepCount: r.FinishCompletedStepCount,
+			CreatedAt:          r.FinishCreatedAt,
+		}
+		out[i] = functionRunRowFromPG(&r.FunctionRun, &finish)
 	}
 	return out, nil
 }
@@ -360,7 +374,14 @@ func (pq *pgQuerier) GetFunctionRunsTimebound(ctx context.Context, arg db.GetFun
 	}
 	out := make([]*db.FunctionRunRow, len(rows))
 	for i, r := range rows {
-		out[i] = functionRunRowFromPG(&r.FunctionRun, &r.FunctionFinish)
+		finish := sqlc.FunctionFinish{
+			RunID:              r.FunctionRun.RunID,
+			Status:             r.FinishStatus,
+			Output:             r.FinishOutput,
+			CompletedStepCount: r.FinishCompletedStepCount,
+			CreatedAt:          r.FinishCreatedAt,
+		}
+		out[i] = functionRunRowFromPG(&r.FunctionRun, &finish)
 	}
 	return out, nil
 }

--- a/pkg/db/regression_test.go
+++ b/pkg/db/regression_test.go
@@ -317,6 +317,64 @@ func TestFunctionRunRoundTrip(t *testing.T) {
 	assert.WithinDuration(t, finishedAt, got.FunctionFinish.CreatedAt.Time, time.Second)
 }
 
+// TestFunctionRunWithoutFinish guards the read path for a run that has been
+// inserted but has not completed yet. On Postgres, the generated
+// FunctionFinish struct uses bare non-nullable types (string, int32,
+// time.Time), so a LEFT JOIN with no matching finish row would cause
+// sql.Rows.Scan to fail ("converting NULL to string is unsupported") unless
+// the query COALESCEs the finish columns. Without the COALESCE guards,
+// GET /v1/runs/:runID returns 500 for every in-flight run.
+func TestFunctionRunWithoutFinish(t *testing.T) {
+	adapter, cleanup := newTestAdapter(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	q := adapter.Q()
+	runID := ulid.Make()
+	eventID := ulid.Make()
+	now := time.Now().UTC()
+
+	require.NoError(t, q.InsertFunctionRun(ctx, db.InsertFunctionRunParams{
+		RunID:           runID,
+		RunStartedAt:    now,
+		FunctionID:      uuid.New(),
+		FunctionVersion: 1,
+		TriggerType:     "event",
+		EventID:         eventID,
+		Cron:            sql.NullString{},
+		WorkspaceID:     uuid.New(),
+	}))
+
+	// Single-row read: the query that backs GET /v1/runs/:runID.
+	// Status/Output are the canonical "has finished" signals. The other
+	// finish columns (CompletedStepCount, CreatedAt) are coalesced to
+	// non-NULL defaults and their Valid flag is not a contract.
+	got, err := q.GetFunctionRun(ctx, runID)
+	require.NoError(t, err, "GetFunctionRun must not fail for an in-flight run")
+	assert.Equal(t, runID, got.FunctionRun.RunID)
+	assert.False(t, got.FunctionFinish.Status.Valid, "active run has no finish yet")
+	assert.False(t, got.FunctionFinish.Output.Valid)
+
+	// List reads follow the same LEFT JOIN shape and must also survive.
+	all, err := q.GetFunctionRuns(ctx)
+	require.NoError(t, err, "GetFunctionRuns must not fail when a run has no finish")
+	require.Len(t, all, 1)
+	assert.Equal(t, runID, all[0].FunctionRun.RunID)
+	assert.False(t, all[0].FunctionFinish.Status.Valid)
+	assert.False(t, all[0].FunctionFinish.Output.Valid)
+
+	tb, err := q.GetFunctionRunsTimebound(ctx, db.GetFunctionRunsTimeboundParams{
+		After:  now.Add(-time.Hour),
+		Before: now.Add(time.Hour),
+		Limit:  10,
+	})
+	require.NoError(t, err, "GetFunctionRunsTimebound must not fail when a run has no finish")
+	require.Len(t, tb, 1)
+	assert.Equal(t, runID, tb[0].FunctionRun.RunID)
+	assert.False(t, tb[0].FunctionFinish.Status.Valid)
+	assert.False(t, tb[0].FunctionFinish.Output.Valid)
+}
+
 func TestEventBatchRoundTrip(t *testing.T) {
 	adapter, cleanup := newTestAdapter(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Fixes #4042.

Three `sqlc` queries against the Postgres backend (`GetFunctionRun`, `GetFunctionRuns`, `GetFunctionRunsTimebound`) embed `function_finishes` via `LEFT JOIN` without `COALESCE`. The Postgres-side generated `FunctionFinish` struct uses bare non-nullable Go types, so `sql.Rows.Scan` fails on any run that hasn't written a `function_finishes` row yet:

```
sql: Scan error on column index 10, name "status": converting NULL to string is unsupported
```

The error bubbles up through `TraceReader.GetRun` into `pkg/api/apiv1/runs.go::GetFunctionRun`, which wraps every error as HTTP 500 — so `GET /v1/runs/{runID}` returns 500 for every in-flight run on a Postgres-backed self-hosted deploy.

This PR mirrors the existing pattern from `GetFunctionRunsFromEvents` (which already uses `COALESCE` and is unaffected):

```sql
COALESCE(function_finishes.status, '')                                  AS finish_status,
COALESCE(function_finishes.output, '')                                  AS finish_output,
COALESCE(function_finishes.completed_step_count, 0)                     AS finish_completed_step_count,
COALESCE(function_finishes.created_at, function_runs.run_started_at)    AS finish_created_at
```

## Changes

- `pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql` — add `COALESCE(...) AS finish_*` to the three broken queries.
- `pkg/cqrs/base_cqrs/sqlc/postgres/queries.sql.go` — regenerated via `sqlc generate` (sqlc v1.30.0, matches the version recorded in the existing generated files).
- `pkg/cqrs/base_cqrs/sqlc/postgres/normalization.go` — update `GetFunctionRunRow.ToSQLite` / `GetFunctionRunsRow.ToSQLite` / `GetFunctionRunsTimeboundRow.ToSQLite` to rebuild a `FunctionFinish` from the new flat `FinishStatus` / `FinishOutput` / `FinishCompletedStepCount` / `FinishCreatedAt` fields, matching the existing handling of `GetFunctionRunsFromEventsRow.ToSQLite`.
- `pkg/db/postgres/querier.go` — same shape change at the `db.FunctionRunRow` layer for `GetFunctionRun` / `GetFunctionRuns` / `GetFunctionRunsTimebound`.
- `pkg/db/regression_test.go` — adds `TestFunctionRunWithoutFinish` that inserts a `function_runs` row with no matching `function_finishes` and asserts the three queries return cleanly with `Status.Valid=false` / `Output.Valid=false`.

## Scope notes

- **Postgres only.** SQLite's generated `FunctionFinish` already uses `sql.NullString` / `sql.NullInt64` / `sql.NullTime`, so NULL scans cleanly and no SQL change is needed.
- **No handler change.** `pkg/api/apiv1/runs.go::GetFunctionRun` conflates "read error" and "not found" into HTTP 500, but once the underlying query stops erroring, the handler naturally returns a 200 with the in-flight status. A separate change could split 500 vs. 404, but that's out of scope here.

## Test plan

- [x] `go test ./pkg/db/...` under SQLite (default) — `TestFunctionRunWithoutFinish` passes.
- [x] `TEST_DATABASE=postgres go test ./pkg/db/...` — `TestFunctionRunWithoutFinish` passes after the fix; fails on `main` with the exact scan error quoted above.
- [x] `go test ./pkg/cqrs/base_cqrs/...` — green.
- [x] `go vet ./pkg/cqrs/base_cqrs/... ./pkg/db/postgres/...` — clean.
- [x] `sqlc generate` on the patched `queries.sql` produces the committed `queries.sql.go` with zero extra diff.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a production bug where `GET /v1/runs/{runID}` returns HTTP 500 for every in-flight run on Postgres-backed deployments. Three sqlc queries (`GetFunctionRun`, `GetFunctionRuns`, `GetFunctionRunsTimebound`) used `LEFT JOIN function_finishes` without `COALESCE`, causing `sql.Rows.Scan` to fail on NULL columns when no finish row exists. The fix mirrors the identical pattern already used by `GetFunctionRunsFromEvents`, updates the Go scan targets and normalization layer accordingly, and adds a regression test.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b5bab88d6d78ba72807f5fee610b9bec19f73a59.</sup>
<!-- /MENDRAL_SUMMARY -->