### PR TITLE
chore(insights): Add "Open in Insights" button on Failed Functions chart on the Metrics page

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/hooks/useInsightsSQLEditorOnMountCallback.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/hooks/useInsightsSQLEditorOnMountCallback.ts
@@ -11,7 +11,6 @@ import { bindEditorShortcuts } from '../actions/handleShortcuts';
 import { markTemplateVars } from '../actions/markTemplateVars';
 import { getCanRunQuery } from '../utils';
 import { useLatest, useLatestCallback } from './useLatestCallback';
-import { clickhouse, formatDialect } from 'sql-formatter';
 
 type UseInsightsSQLEditorOnMountCallbackReturn = {
   onMount: SQLEditorMountCallback;
@@ -59,17 +58,6 @@ export function useInsightsSQLEditorOnMountCallback(): UseInsightsSQLEditorOnMou
           handler: tabManagerActions.createNewTab,
         },
       ]);
-
-      monaco.languages.registerDocumentFormattingEditProvider('sql', {
-        provideDocumentFormattingEdits: (model) => {
-          return [
-            {
-              range: model.getFullModelRange(),
-              text: formatDialect(model.getValue(), { dialect: clickhouse }),
-            },
-          ];
-        },
-      });
 
       const markersDisposable = markTemplateVars(editor, monaco);
 

--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/utils.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/utils.ts
@@ -1,4 +1,4 @@
-import { format } from 'sql-formatter';
+import { clickhouse, formatDialect } from 'sql-formatter';
 
 export function getCanRunQuery(query: string, isRunning: boolean): boolean {
   return query.trim() !== '' && !isRunning;
@@ -6,10 +6,9 @@ export function getCanRunQuery(query: string, isRunning: boolean): boolean {
 
 export function formatSQL(sql: string): string {
   try {
-    return format(sql, {
-      language: 'sql',
+    return formatDialect(sql, {
+      dialect: clickhouse,
       tabWidth: 2,
-      keywordCase: 'upper',
       linesBetweenQueries: 2,
     });
   } catch (error) {

--- a/ui/apps/dashboard/src/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext.tsx
@@ -1,4 +1,11 @@
-import { createContext, useCallback, useContext, type ReactNode } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { useStoredQueries } from '../QueryHelperPanel/StoredQueriesContext';
@@ -22,21 +29,25 @@ const InsightsStateMachineContext =
 
 type InsightsStateMachineContextProviderProps = {
   children: ReactNode;
+  onAutoRunConsumed?: () => void;
   onQueryChange: (query: string) => void;
   onQueryNameChange: (name: string) => void;
   query: string;
   queryName: string;
   renderChildren: boolean;
+  runOnMount?: boolean;
   tabId: string;
 };
 
 export function InsightsStateMachineContextProvider({
   children,
+  onAutoRunConsumed,
   onQueryChange,
   onQueryNameChange,
   query,
   queryName,
   renderChildren,
+  runOnMount,
   tabId,
 }: InsightsStateMachineContextProviderProps) {
   const { fetchInsights } = useFetchInsights();
@@ -58,6 +69,20 @@ export function InsightsStateMachineContextProvider({
   const runQuery = useCallback(() => {
     refetch();
   }, [refetch]);
+
+  // Fire refetch() once per tab when a tab is created with a seeded query
+  // that should execute automatically (e.g. the Failed Functions "Open in
+  // Insights" deep link). Gated on `renderChildren` so inactive tabs don't
+  // run, and on a ref so toggling the tab in/out of focus can't refire it.
+  const hasAutoRunRef = useRef(false);
+  useEffect(() => {
+    if (hasAutoRunRef.current) return;
+    if (!runOnMount || !renderChildren) return;
+
+    hasAutoRunRef.current = true;
+    refetch();
+    onAutoRunConsumed?.();
+  }, [runOnMount, renderChildren, refetch, onAutoRunConsumed]);
 
   return (
     <InsightsStateMachineContext.Provider

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
@@ -69,12 +69,19 @@ function saveTabsToStorage(tabs: Tab[], activeTabId: string) {
   } catch {}
 }
 
+export interface CreateTabFromQueryOptions {
+  // Auto-run the seeded query after the new tab mounts. Used by deep-link
+  // entry points (e.g. the Failed Functions "Open in Insights" button).
+  runOnMount?: boolean;
+}
+
 export interface TabManagerActions {
   breakQueryAssociation: (savedQueryId: string) => void;
   closeTab: (id: string) => void;
   createNewTab: () => void;
   createTabFromQuery: (
     query: InsightsQueryStatement | QuerySnapshot | QueryTemplate,
+    options?: CreateTabFromQueryOptions,
   ) => void;
   focusTab: (id: string) => void;
   openTemplatesTab: () => void;
@@ -205,18 +212,26 @@ export function useInsightsTabManager(
       },
       createTabFromQuery: (
         query: InsightsQueryStatement | QuerySnapshot | QueryTemplate,
+        options?: CreateTabFromQueryOptions,
       ) => {
+        const runOnMount = options?.runOnMount ? true : undefined;
+
         if (isQueryTemplate(query)) {
           createTabBase({
             ...makeEmptyUnsavedTab(),
             query: query.query,
             name: query.name,
+            runOnMount,
           });
           return;
         }
 
         if (isQuerySnapshot(query)) {
-          createTabBase({ ...makeEmptyUnsavedTab(), query: query.query });
+          createTabBase({
+            ...makeEmptyUnsavedTab(),
+            query: query.query,
+            runOnMount,
+          });
           return;
         }
 
@@ -233,6 +248,7 @@ export function useInsightsTabManager(
           name: query.name,
           query: query.sql,
           savedQueryId: query.id,
+          runOnMount,
         });
       },
       focusTab: setActiveTabId,
@@ -318,11 +334,15 @@ function SingleTabRenderer({
   return (
     <InsightsStateMachineContextProvider
       key={tab.id}
+      onAutoRunConsumed={() =>
+        actions.updateTab(tab.id, { runOnMount: undefined })
+      }
       onQueryChange={(query) => actions.updateTab(tab.id, { query })}
       onQueryNameChange={(name) => actions.updateTab(tab.id, { name })}
       query={tab.query}
       queryName={tab.name}
       renderChildren={isActive}
+      runOnMount={tab.runOnMount}
       tabId={tab.id}
     >
       <CellDetailProvider onOpenPanel={handleOpenCellDetailPanel}>

--- a/ui/apps/dashboard/src/components/Insights/types.ts
+++ b/ui/apps/dashboard/src/components/Insights/types.ts
@@ -15,4 +15,8 @@ export interface Tab {
   name: string;
   query: string;
   savedQueryId?: string;
+  // Set transiently when a tab is created with a seeded query that should
+  // execute automatically on first mount. Cleared by the state machine
+  // provider after firing.
+  runOnMount?: boolean;
 }

--- a/ui/apps/dashboard/src/components/Insights/useDeepLinkHandler.ts
+++ b/ui/apps/dashboard/src/components/Insights/useDeepLinkHandler.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 import { ulid } from 'ulid';
 
+import { formatSQL } from '@/components/Insights/InsightsSQLEditor/utils';
 import type { TabManagerActions } from '@/components/Insights/InsightsTabManager/InsightsTabManager';
 import { useStoredQueries } from '@/components/Insights/QueryHelperPanel/StoredQueriesContext';
 import type { QueryTemplate } from '@/components/Insights/types';
@@ -82,16 +83,13 @@ export function useDeepLinkHandler({
 
       // Synthesize a QueryTemplate so the tab manager's template branch picks
       // it up and honors the name (the snapshot branch ignores name and falls
-      // back to the "untitled" label).
-      //
-      // Pass the SQL through unchanged: the deep-link caller already owns the
-      // formatting, and running it through sql-formatter mangles ClickHouse
-      // function calls (e.g. `toUnixTimestamp64Milli(...)` becomes
-      // `toUnixTimestamp64Milli (...)` with a space before the paren).
+      // back to the "untitled" label). formatSQL now uses the ClickHouse
+      // dialect, so formatting the incoming SQL no longer mangles function
+      // calls like `toUnixTimestamp64Milli(...)`.
       const template: QueryTemplate = {
         id: `deeplink-${ulid()}`,
         name: nameFromUrl ?? DEEP_LINK_DEFAULT_NAME,
-        query: sqlFromUrl,
+        query: formatSQL(sqlFromUrl),
         explanation: '',
         templateKind: 'time',
       };

--- a/ui/apps/dashboard/src/components/Insights/useDeepLinkHandler.ts
+++ b/ui/apps/dashboard/src/components/Insights/useDeepLinkHandler.ts
@@ -95,7 +95,7 @@ export function useDeepLinkHandler({
         explanation: '',
         templateKind: 'time',
       };
-      actions.createTabFromQuery(template);
+      actions.createTabFromQuery(template, { runOnMount: true });
 
       // Clear the deep-link params from the URL so refresh/bookmark doesn't
       // respawn duplicate tabs.

--- a/ui/apps/dashboard/src/components/Insights/useDeepLinkHandler.ts
+++ b/ui/apps/dashboard/src/components/Insights/useDeepLinkHandler.ts
@@ -5,7 +5,9 @@ import { ulid } from 'ulid';
 import { formatSQL } from '@/components/Insights/InsightsSQLEditor/utils';
 import type { TabManagerActions } from '@/components/Insights/InsightsTabManager/InsightsTabManager';
 import { useStoredQueries } from '@/components/Insights/QueryHelperPanel/StoredQueriesContext';
-import type { QuerySnapshot } from '@/components/Insights/types';
+import type { QueryTemplate } from '@/components/Insights/types';
+
+const DEEP_LINK_DEFAULT_NAME = 'Untitled query';
 
 interface UseDeepLinkHandlerParams {
   actions: TabManagerActions;
@@ -67,23 +69,37 @@ export function useDeepLinkHandler({
       return;
     }
 
-    // If there's a sql param (and no query_id), open a new tab with that SQL
+    // If there's a sql param (and no query_id), open a new tab with that SQL.
+    // The tab name comes from the optional `name` param so callers (e.g. the
+    // Failed Functions "Open in Insights" button) can label the tab without
+    // depending on a built-in Insights template existing.
     if (sqlFromUrl) {
       hasProcessedInitialDeepLink.current = true;
 
-      const snapshot: QuerySnapshot = {
-        id: ulid(),
-        isSnapshot: true,
-        name: 'Experiment Query',
-        query: formatSQL(sqlFromUrl),
-      };
-      actions.createTabFromQuery(snapshot);
+      const nameFromUrl =
+        typeof search.name === 'string' && search.name.length > 0
+          ? search.name
+          : undefined;
 
-      // Clear the sql param from the URL to avoid re-opening on refresh
+      // Synthesize a QueryTemplate so the tab manager's template branch picks
+      // it up and honors the name (the snapshot branch ignores name and falls
+      // back to the "untitled" label).
+      const template: QueryTemplate = {
+        id: `deeplink-${ulid()}`,
+        name: nameFromUrl ?? DEEP_LINK_DEFAULT_NAME,
+        query: formatSQL(sqlFromUrl),
+        explanation: '',
+        templateKind: 'time',
+      };
+      actions.createTabFromQuery(template);
+
+      // Clear the deep-link params from the URL so refresh/bookmark doesn't
+      // respawn duplicate tabs.
       navigate({
         search: (prev: Record<string, unknown>) => {
           const next = { ...prev };
           delete next.sql;
+          delete next.name;
           return next;
         },
         replace: true,

--- a/ui/apps/dashboard/src/components/Insights/useDeepLinkHandler.ts
+++ b/ui/apps/dashboard/src/components/Insights/useDeepLinkHandler.ts
@@ -2,7 +2,6 @@ import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 import { ulid } from 'ulid';
 
-import { formatSQL } from '@/components/Insights/InsightsSQLEditor/utils';
 import type { TabManagerActions } from '@/components/Insights/InsightsTabManager/InsightsTabManager';
 import { useStoredQueries } from '@/components/Insights/QueryHelperPanel/StoredQueriesContext';
 import type { QueryTemplate } from '@/components/Insights/types';
@@ -84,10 +83,15 @@ export function useDeepLinkHandler({
       // Synthesize a QueryTemplate so the tab manager's template branch picks
       // it up and honors the name (the snapshot branch ignores name and falls
       // back to the "untitled" label).
+      //
+      // Pass the SQL through unchanged: the deep-link caller already owns the
+      // formatting, and running it through sql-formatter mangles ClickHouse
+      // function calls (e.g. `toUnixTimestamp64Milli(...)` becomes
+      // `toUnixTimestamp64Milli (...)` with a space before the paren).
       const template: QueryTemplate = {
         id: `deeplink-${ulid()}`,
         name: nameFromUrl ?? DEEP_LINK_DEFAULT_NAME,
-        query: formatSQL(sqlFromUrl),
+        query: sqlFromUrl,
         explanation: '',
         templateKind: 'time',
       };

--- a/ui/apps/dashboard/src/components/Metrics/FailedFunctions.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/FailedFunctions.tsx
@@ -3,10 +3,10 @@ import { Chart } from '@inngest/components/Chart/Chart';
 import { Info } from '@inngest/components/Info/Info';
 import { Link } from '@inngest/components/Link/Link';
 import { RiArrowRightUpLine } from '@remixicon/react';
+import { useNavigate } from '@tanstack/react-router';
 
 import { useEnvironment } from '@/components/Environments/environment-context';
 import type { FunctionStatusMetricsQuery } from '@/gql/graphql';
-import { pathCreator } from '@/utils/urls';
 import type { EntityLookup } from './Dashboard';
 import { FailedRate } from './FailedRate';
 import { getLineChartOptions, mapEntityLines, sum } from './utils';
@@ -57,6 +57,7 @@ export const FailedFunctions = ({
   functions: EntityLookup;
 }) => {
   const env = useEnvironment();
+  const navigate = useNavigate();
 
   const metrics = workspace && mapFailed(workspace, entities);
 
@@ -85,19 +86,23 @@ export const FailedFunctions = ({
           icon={<RiArrowRightUpLine />}
           iconSide="left"
           label="Open in Insights"
-          // Use `href` (plain anchor) rather than `to` (TanStack Link).
-          // Passing `?sql=...` inside `to` causes TanStack's path resolver to
-          // treat the query string as part of the pathname; the SQL's `%0A`
-          // is then percent-decoded into raw `\n`, which @tanstack/history's
-          // sanitizePath strips out (along with all ASCII control chars).
-          // The result is SQL that lands in the editor on a single line.
-          // With a plain href the URL is delivered verbatim to the browser
-          // and parsed correctly on the receiving side.
-          href={`${pathCreator.insights({
-            envSlug: env.slug,
-          })}?sql=${encodeURIComponent(
-            INSIGHTS_QUERY,
-          )}&name=${encodeURIComponent(INSIGHTS_QUERY_NAME)}`}
+          // Programmatic client-side navigation rather than a Link `to` with
+          // an embedded query string. Passing `search` as an object lets
+          // TanStack route it through `stringifySearch`, which preserves
+          // newlines (`\n` -> `%0A`). Embedding `?sql=...` inside a string
+          // `to` makes the path resolver treat the query as part of the
+          // pathname, and @tanstack/history's sanitizePath then strips out
+          // all ASCII control chars — including the SQL's newlines.
+          onClick={() =>
+            navigate({
+              to: '/env/$envSlug/insights',
+              params: { envSlug: env.slug },
+              search: {
+                sql: INSIGHTS_QUERY,
+                name: INSIGHTS_QUERY_NAME,
+              },
+            })
+          }
         />
       </div>
       <div className="flex h-full flex-row items-center">

--- a/ui/apps/dashboard/src/components/Metrics/FailedFunctions.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/FailedFunctions.tsx
@@ -10,7 +10,6 @@ import { pathCreator } from '@/utils/urls';
 import type { EntityLookup } from './Dashboard';
 import { FailedRate } from './FailedRate';
 import { getLineChartOptions, mapEntityLines, sum } from './utils';
-import type { FileRouteTypes } from '@tanstack/react-router';
 
 export type CompletedType =
   FunctionStatusMetricsQuery['workspace']['completed'];
@@ -86,15 +85,19 @@ export const FailedFunctions = ({
           icon={<RiArrowRightUpLine />}
           iconSide="left"
           label="Open in Insights"
-          to={
-            `${pathCreator.insights({
-              envSlug: env.slug,
-            })}?sql=${encodeURIComponent(
-              INSIGHTS_QUERY,
-            )}&name=${encodeURIComponent(
-              INSIGHTS_QUERY_NAME,
-            )}` as FileRouteTypes['to']
-          }
+          // Use `href` (plain anchor) rather than `to` (TanStack Link).
+          // Passing `?sql=...` inside `to` causes TanStack's path resolver to
+          // treat the query string as part of the pathname; the SQL's `%0A`
+          // is then percent-decoded into raw `\n`, which @tanstack/history's
+          // sanitizePath strips out (along with all ASCII control chars).
+          // The result is SQL that lands in the editor on a single line.
+          // With a plain href the URL is delivered verbatim to the browser
+          // and parsed correctly on the receiving side.
+          href={`${pathCreator.insights({
+            envSlug: env.slug,
+          })}?sql=${encodeURIComponent(
+            INSIGHTS_QUERY,
+          )}&name=${encodeURIComponent(INSIGHTS_QUERY_NAME)}`}
         />
       </div>
       <div className="flex h-full flex-row items-center">

--- a/ui/apps/dashboard/src/components/Metrics/FailedFunctions.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/FailedFunctions.tsx
@@ -31,6 +31,23 @@ const mapFailed = (
   return mapEntityLines(failed, entities);
 };
 
+// SQL carried by the "Open in Insights" deep link. Kept local so the chart
+// doesn't depend on a matching entry inside the Insights templates module —
+// renaming or removing a built-in template can't silently break this button.
+const INSIGHTS_QUERY = `SELECT
+    data.function_id AS function_id,
+    COUNT(*) as failed_count
+FROM
+    events
+WHERE
+    name = 'inngest/function.failed'
+    AND ts > toUnixTimestamp64Milli(subtractDays(now64(), 1))
+GROUP BY
+    function_id
+ORDER BY
+    failed_count DESC`;
+const INSIGHTS_QUERY_NAME = 'Failed function runs (24h)';
+
 export const FailedFunctions = ({
   workspace,
   entities,
@@ -68,11 +85,15 @@ export const FailedFunctions = ({
           appearance="outlined"
           icon={<RiArrowRightUpLine />}
           iconSide="left"
-          label="View all"
+          label="Open in Insights"
           to={
-            `${pathCreator.runs({
+            `${pathCreator.insights({
               envSlug: env.slug,
-            })}?filterStatus=%5B"FAILED"%5D` as FileRouteTypes['to']
+            })}?sql=${encodeURIComponent(
+              INSIGHTS_QUERY,
+            )}&name=${encodeURIComponent(
+              INSIGHTS_QUERY_NAME,
+            )}` as FileRouteTypes['to']
           }
         />
       </div>

--- a/ui/apps/dashboard/src/components/Metrics/FailedFunctions.tsx
+++ b/ui/apps/dashboard/src/components/Metrics/FailedFunctions.tsx
@@ -7,6 +7,7 @@ import { useNavigate } from '@tanstack/react-router';
 
 import { useEnvironment } from '@/components/Environments/environment-context';
 import type { FunctionStatusMetricsQuery } from '@/gql/graphql';
+import { pathCreator } from '@/utils/urls';
 import type { EntityLookup } from './Dashboard';
 import { FailedRate } from './FailedRate';
 import { getLineChartOptions, mapEntityLines, sum } from './utils';
@@ -95,8 +96,7 @@ export const FailedFunctions = ({
           // all ASCII control chars — including the SQL's newlines.
           onClick={() =>
             navigate({
-              to: '/env/$envSlug/insights',
-              params: { envSlug: env.slug },
+              to: pathCreator.insights({ envSlug: env.slug }),
               search: {
                 sql: INSIGHTS_QUERY,
                 name: INSIGHTS_QUERY_NAME,

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/insights/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/insights/index.tsx
@@ -21,6 +21,7 @@ import { useDeepLinkHandler } from '@/components/Insights/useDeepLinkHandler';
 export type InsightsSearchParams = {
   query_id?: string;
   sql?: string;
+  name?: string;
 };
 
 export const Route = createFileRoute('/_authed/env/$envSlug/insights/')({
@@ -29,6 +30,7 @@ export const Route = createFileRoute('/_authed/env/$envSlug/insights/')({
     query_id:
       typeof search?.query_id === 'string' ? search.query_id : undefined,
     sql: typeof search?.sql === 'string' ? search.sql : undefined,
+    name: typeof search?.name === 'string' ? search.name : undefined,
   }),
 });
 

--- a/ui/lint-staged.config.js
+++ b/ui/lint-staged.config.js
@@ -1,5 +1,15 @@
 const path = require('path');
 
+// Single-quote a path for bash so shell metacharacters (e.g. `$` in
+// TanStack Router's `$envSlug` filenames) aren't expanded. The outer
+// command string is wrapped in double quotes, which lint-staged's
+// command parser (string-argv) handles correctly.
+const shellQuote = (p) => `'${p.replace(/'/g, `'\\''`)}'`;
+
+// lint-staged v15 runs command strings via execa without a shell, so
+// `&&` and single-quoted filenames need an explicit shell invocation.
+const wrapInShell = (command) => `bash -c "${command}"`;
+
 const ESLintTask = (fileNames) => {
   const filesByWorkspace = {};
 
@@ -20,18 +30,24 @@ const ESLintTask = (fileNames) => {
     }
   }
 
-  return Object.entries(filesByWorkspace).map(
-    ([workspace, files]) => `cd ${workspace} && eslint --fix ${files.join(' ')}`
+  return Object.entries(filesByWorkspace).map(([workspace, files]) =>
+    wrapInShell(`cd ${shellQuote(workspace)} && eslint --fix ${files.map(shellQuote).join(' ')}`)
   );
 };
+
+const PrettierTask = (fileNames) =>
+  wrapInShell(`prettier --write ${fileNames.map(shellQuote).join(' ')}`);
+
+const PrettierIgnoreUnknownTask = (fileNames) =>
+  wrapInShell(`prettier --ignore-unknown --write ${fileNames.map(shellQuote).join(' ')}`);
 
 module.exports = {
   //
   // Run ESLint and Prettier for TypeScript files in apps and packages
-  './{apps,packages}/*/{src,test}/**/*.{tsx,ts}': [ESLintTask, 'prettier --write'],
+  './{apps,packages}/*/{src,test}/**/*.{tsx,ts}': [ESLintTask, PrettierTask],
 
   //
   // Run Prettier for non-TypeScript files, excluding config files
   '!(./{src,test}/**/*.{tsx,ts}|**/.prettierrc*|**/.eslintrc*|**/eslint.config.*|**/.prettierignore)':
-    'prettier --ignore-unknown --write',
+    PrettierIgnoreUnknownTask,
 };

--- a/ui/packages/components/src/SQLEditor/hooks/useSQLFormatter.ts
+++ b/ui/packages/components/src/SQLEditor/hooks/useSQLFormatter.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useMonaco } from '@monaco-editor/react';
 import type { languages } from 'monaco-editor';
-import { format } from 'sql-formatter';
+import { clickhouse, formatDialect } from 'sql-formatter';
 
 export function useSQLFormatter() {
   const monaco = useMonaco();
@@ -15,10 +15,9 @@ export function useSQLFormatter() {
         const text = model.getValue();
 
         try {
-          const formatted = format(text, {
-            language: 'sql',
+          const formatted = formatDialect(text, {
+            dialect: clickhouse,
             tabWidth: 2,
-            keywordCase: 'upper',
             linesBetweenQueries: 2,
           });
 


### PR DESCRIPTION
## Description

Replace the "View all" button on the Failed Functions metrics chart with an "Open in Insights" button that deep-links to the Insights SQL editor and seeds a new tab with the existing "recent-function-failures" template. Drives Insights adoption from an existing, relevant surface.

- Add template_id search param to the Insights route
- Extend useDeepLinkHandler to open a tab from a built-in template when template_id is present, then strip the param so reload/bookmark does not respawn duplicate tabs
- Point the Failed Functions chart button at /env/:envSlug/insights?template_id=recent-function-failures
- Fix ui/lint-staged.config.js so hooks work for files containing shell metacharacters (e.g. TanStack Router's $envSlug segments): wrap commands in bash -c for && support and single-quote paths so $vars are not expanded

<img width="1014" height="377" alt="Screenshot 2026-04-23 at 17 09 58" src="https://github.com/user-attachments/assets/4d7eaa07-2c3e-49ac-8508-17c741c6dcad" />

<img width="478" height="565" alt="Screenshot 2026-04-23 at 17 10 06" src="https://github.com/user-attachments/assets/9b1f2567-f6f7-4761-bd32-e272b7db908a" />


## Motivation
Small PR for insights Adoption 

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces the "View all" button on the Failed Functions metrics chart with an "Open in Insights" button that deep-links to the Insights SQL editor, seeding a new tab from the `recent-function-failures` built-in template and auto-executing the query on mount. Also fixes `lint-staged.config.js` to handle shell metacharacters in TanStack Router filenames.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 29164e18465f5daaad61dba53ad2b9fdaf6e96dc.</sup>
<!-- /MENDRAL_SUMMARY -->