### PR TITLE
EXE-1595: Consistently accept date for timeout fields

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -51,10 +51,10 @@ import (
 	"github.com/inngest/inngest/pkg/tracing/metadata/extractors"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/inngest/inngest/pkg/util/gateway"
+	"github.com/inngest/inngest/pkg/util/strtimeout"
 	"github.com/inngest/inngestgo"
 	"github.com/jonboulle/clockwork"
 	"github.com/oklog/ulid/v2"
-	"github.com/xhit/go-str2duration/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
@@ -593,11 +593,11 @@ func (e *executor) createCancellationPauses(ctx context.Context, l logger.Logger
 	for _, c := range req.Function.Cancel {
 		expires := e.now().Add(consts.CancelTimeout)
 		if c.Timeout != nil {
-			dur, err := str2duration.ParseDuration(*c.Timeout)
+			parsedExpires, err := strtimeout.ParseTimeout(*c.Timeout, e.now)
 			if err != nil {
-				return fmt.Errorf("error parsing cancel duration: %w", err)
+				return fmt.Errorf("error parsing cancel timeout: %w", err)
 			}
-			expires = e.now().Add(dur)
+			expires = parsedExpires
 		}
 
 		// The triggering event ID should be the first ID in the batch.

--- a/pkg/execution/state/opcode.go
+++ b/pkg/execution/state/opcode.go
@@ -293,11 +293,7 @@ func (s SignalOpts) Expires() (time.Time, error) {
 		return time.Now().AddDate(1, 0, 0), nil
 	}
 
-	dur, err := str2duration.ParseDuration(s.Timeout)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return time.Now().Add(dur), nil
+	return strtimeout.ParseTimeout(s.Timeout, time.Now)
 }
 
 func (g GeneratorOpcode) InvokeFunctionOpts() (*InvokeFunctionOpts, error) {
@@ -339,11 +335,7 @@ func (i InvokeFunctionOpts) Expires() (time.Time, error) {
 		return time.Now().AddDate(1, 0, 0), nil
 	}
 
-	dur, err := str2duration.ParseDuration(i.Timeout)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return time.Now().Add(dur), nil
+	return strtimeout.ParseTimeout(i.Timeout, time.Now)
 }
 
 type SleepOpts struct {

--- a/pkg/execution/state/opcode_test.go
+++ b/pkg/execution/state/opcode_test.go
@@ -24,3 +24,57 @@ func TestWaitForEventOpts_Expires(t *testing.T) {
 		assert.WithinDuration(t, time.Now(), got, time.Second)
 	})
 }
+
+func TestSignalOpts_Expires(t *testing.T) {
+	t.Run("accepts duration", func(t *testing.T) {
+		opts := SignalOpts{Timeout: "3d"}
+		now := time.Now()
+		got, err := opts.Expires()
+		require.NoError(t, err)
+		assert.WithinDuration(t, now.Add(3*24*time.Hour), got, time.Second)
+	})
+
+	t.Run("accepts RFC 3339", func(t *testing.T) {
+		opts := SignalOpts{Timeout: "2030-01-02T03:04:05Z"}
+		want, err := time.Parse(time.RFC3339, "2030-01-02T03:04:05Z")
+		require.NoError(t, err)
+		got, err := opts.Expires()
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("empty defaults to ~1 year", func(t *testing.T) {
+		opts := SignalOpts{}
+		now := time.Now()
+		got, err := opts.Expires()
+		require.NoError(t, err)
+		assert.WithinDuration(t, now.AddDate(1, 0, 0), got, time.Second)
+	})
+}
+
+func TestInvokeFunctionOpts_Expires(t *testing.T) {
+	t.Run("accepts duration", func(t *testing.T) {
+		opts := InvokeFunctionOpts{Timeout: "3d"}
+		now := time.Now()
+		got, err := opts.Expires()
+		require.NoError(t, err)
+		assert.WithinDuration(t, now.Add(3*24*time.Hour), got, time.Second)
+	})
+
+	t.Run("accepts RFC 3339", func(t *testing.T) {
+		opts := InvokeFunctionOpts{Timeout: "2030-01-02T03:04:05Z"}
+		want, err := time.Parse(time.RFC3339, "2030-01-02T03:04:05Z")
+		require.NoError(t, err)
+		got, err := opts.Expires()
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("empty defaults to ~1 year", func(t *testing.T) {
+		opts := InvokeFunctionOpts{}
+		now := time.Now()
+		got, err := opts.Expires()
+		require.NoError(t, err)
+		assert.WithinDuration(t, now.AddDate(1, 0, 0), got, time.Second)
+	})
+}


### PR DESCRIPTION
## Description

- Previously, we began accepting RFC 3339 times for waitForEvent's timeout: https://github.com/inngest/inngest/pull/4048
- In this PR, we consistently accept RFC 3339 times across our other uses of timeout: step.waitForSignal, step.invoke, and cancelOn[]

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Extracts the `parseTimeout` helper into `pkg/util/strtimeout` as `ParseTimeout`, then migrates all timeout parsing call sites (`SignalOpts.Expires`, `InvokeFunctionOpts.Expires`, `createCancellationPauses`) to use it, enabling RFC 3339 date strings alongside duration strings. Adds tests for the two newly migrated paths.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e342ffefcdd5203c9e21a16d8e6c21310f0d3130.</sup>
<!-- /MENDRAL_SUMMARY -->