### PR TITLE
Fix modal overflow and adjust CopyButton styling

### DIFF
--- a/ui/apps/dashboard/src/components/APIKeys/CreateAPIKeyModal.tsx
+++ b/ui/apps/dashboard/src/components/APIKeys/CreateAPIKeyModal.tsx
@@ -133,7 +133,11 @@ export function CreateAPIKeyModal({ isOpen, onClose }: Props) {
   const inRevealStep = plaintextKey !== null;
 
   return (
-    <Modal className="w-full max-w-xl" isOpen={isOpen} onClose={close}>
+    <Modal
+      className="w-full max-w-xl overflow-visible"
+      isOpen={isOpen}
+      onClose={close}
+    >
       <Modal.Header>
         {inRevealStep ? 'Copy your API key' : 'Create API key'}
       </Modal.Header>

--- a/ui/apps/dashboard/src/components/Secret/CopyButton.tsx
+++ b/ui/apps/dashboard/src/components/Secret/CopyButton.tsx
@@ -25,7 +25,7 @@ export function CopyButton({ value }: Props) {
       <TooltipTrigger asChild>
         <button
           aria-label={label}
-          className="bg-canvasBase flex items-center justify-center px-2"
+          className="flex items-center justify-center px-2"
           onClick={() => handleCopyClick(value)}
         >
           <Icon className="h-6" />

--- a/ui/packages/components/src/Modal/Modal.tsx
+++ b/ui/packages/components/src/Modal/Modal.tsx
@@ -74,8 +74,8 @@ export function Modal({
               >
                 <Dialog.Content
                   className={cn(
-                    className,
-                    'bg-modalBase shadow-tooltip border-subtle max-h-full overflow-y-auto overflow-x-hidden rounded-md border shadow-2xl'
+                    'bg-modalBase shadow-tooltip border-subtle max-h-full overflow-y-auto overflow-x-hidden rounded-md border shadow-2xl',
+                    className
                   )}
                 >
                   {(title || description) && <Header description={description}>{title}</Header>}


### PR DESCRIPTION
## Description

- env select in api key manager pops over modal (instead of inside it)
<img width="598" height="536" alt="image" src="https://github.com/user-attachments/assets/cd6d3aa7-0a15-4d9e-82e9-5e1034cbe81d" />

- fix bg color on copy icon
<img width="612" height="373" alt="image" src="https://github.com/user-attachments/assets/a4f9e2e3-06db-40bc-bfd9-a74492743c75" />

## Motivation

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes two UI bugs: a dropdown/select in the API key modal that was clipping inside the modal instead of overflowing above it, and a background color mismatch on the CopyButton icon. The Modal fix reorders `cn()` arguments so the caller's `className` overrides base styles, and adds `overflow-visible` at the call site. The CopyButton fix removes the `bg-canvasBase` class.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 2fa306ae01ba855168c0dea3fb386eb57328a147.</sup>
<!-- /MENDRAL_SUMMARY -->