### PR TITLE
EXE-1687 Add callout on onboarding guide

### DIFF
--- a/ui/apps/dashboard/src/components/Onboarding/DeployApp.tsx
+++ b/ui/apps/dashboard/src/components/Onboarding/DeployApp.tsx
@@ -20,6 +20,7 @@ import useOnboardingStep from './useOnboardingStep';
 import { useOnboardingTracking } from './useOnboardingTracking';
 import { getNextStepName } from './utils';
 import { useVercelIntegration } from '@/queries/useVercelIntegration';
+import { Card } from '@inngest/components/Card';
 
 export default function DeployApp() {
   const currentStepName = OnboardingSteps.DeployApp;
@@ -362,6 +363,25 @@ export default function DeployApp() {
           />
         </TabCards.Content>
       </TabCards>
+      <Card className="mt-6">
+        <Card.Content className="text-sm">
+          <p className="font-semibold">
+            Before you go live, review security best practices.{' '}
+          </p>
+          <p>
+            Covers signing keys, end-to-end encryption, IP allowlisting, and
+            SAML for enterprise accounts.
+          </p>
+          <Link
+            size="small"
+            href="https://www.inngest.com/docs/learn/security?ref=app-onboarding"
+            className="block"
+            target="_blank"
+          >
+            Read security docs
+          </Link>
+        </Card.Content>
+      </Card>
     </div>
   );
 }

--- a/ui/apps/dashboard/src/components/Onboarding/DeployApp.tsx
+++ b/ui/apps/dashboard/src/components/Onboarding/DeployApp.tsx
@@ -366,7 +366,7 @@ export default function DeployApp() {
       <Card className="mt-6">
         <Card.Content className="text-sm">
           <p className="font-semibold">
-            Before you go live, review security best practices.{' '}
+            Before you go live, review security best practices.
           </p>
           <p>
             Covers signing keys, end-to-end encryption, IP allowlisting, and


### PR DESCRIPTION
## Description
Add callout in the deploy step of the onboarding guide


<img width="1135" height="641" alt="Screenshot 2026-04-27 at 18 06 03" src="https://github.com/user-attachments/assets/c8eb5157-16b6-424f-bc44-4aa476e96200" />

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a security callout card at the bottom of the DeployApp onboarding step, linking to Inngest's security documentation with UTM-style ref tracking.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6ffc0f07fe63f2c675e0116ff88cca0f27edba41.</sup>
<!-- /MENDRAL_SUMMARY -->