### PR TITLE
Adds sync failure status handling in UI

### DIFF
--- a/ui/apps/dashboard/src/components/Apps/AppCardContent.tsx
+++ b/ui/apps/dashboard/src/components/Apps/AppCardContent.tsx
@@ -4,6 +4,7 @@ import { HorizontalPillList } from '@inngest/components/Pill/HorizontalPillList'
 import { methodTypes, type AppKind } from '@inngest/components/types/app';
 import { RiExternalLinkLine } from '@remixicon/react';
 
+import { SyncErrorMessage } from '@/components/Apps/SyncErrorMessage';
 import { syncKind, syncStatusText } from '@/components/Apps/SyncStatusPill';
 import { pathCreator } from '@/utils/urls';
 import type { FlattenedApp } from './useApps';
@@ -26,9 +27,14 @@ const getAppCardContent = ({
   const status = app.isArchived
     ? 'Archived'
     : syncStatusText[statusKey] ?? null;
-
   const footerHeaderTitle = app.error ? (
-    `Error: ${app.error}`
+    <>
+      Error:{' '}
+      <SyncErrorMessage
+        error={app.error}
+        onLinkClick={(event) => event.stopPropagation()}
+      />
+    </>
   ) : app.functionCount === 0 ? (
     'There are currently no functions registered at this URL.'
   ) : (

--- a/ui/apps/dashboard/src/components/Apps/SyncErrorMessage.tsx
+++ b/ui/apps/dashboard/src/components/Apps/SyncErrorMessage.tsx
@@ -1,5 +1,7 @@
 import type { MouseEventHandler } from 'react';
 
+import { isSafeCTAURL } from '@/components/ActiveBanners/safeUrl';
+
 const advisoryMarker = 'See more information:';
 
 export function parseSyncErrorMessage(error: string) {
@@ -11,7 +13,7 @@ export function parseSyncErrorMessage(error: string) {
   const advisoryURL = error.slice(markerIndex + advisoryMarker.length).trim();
   return {
     message: error.slice(0, markerIndex).trim(),
-    advisoryURL: advisoryURL || null,
+    advisoryURL: advisoryURL && isSafeCTAURL(advisoryURL) ? advisoryURL : null,
   };
 }
 

--- a/ui/apps/dashboard/src/components/Apps/SyncErrorMessage.tsx
+++ b/ui/apps/dashboard/src/components/Apps/SyncErrorMessage.tsx
@@ -1,0 +1,46 @@
+import type { MouseEventHandler } from 'react';
+
+const advisoryMarker = 'See more information:';
+
+export function parseSyncErrorMessage(error: string) {
+  const markerIndex = error.indexOf(advisoryMarker);
+  if (markerIndex === -1) {
+    return { message: error, advisoryURL: null };
+  }
+
+  const advisoryURL = error.slice(markerIndex + advisoryMarker.length).trim();
+  return {
+    message: error.slice(0, markerIndex).trim(),
+    advisoryURL: advisoryURL || null,
+  };
+}
+
+export function SyncErrorMessage({
+  error,
+  onLinkClick,
+}: {
+  error: string;
+  onLinkClick?: MouseEventHandler<HTMLAnchorElement>;
+}) {
+  const { advisoryURL, message } = parseSyncErrorMessage(error);
+
+  return (
+    <>
+      {message}
+      {advisoryURL && (
+        <>
+          {' '}
+          <a
+            className="text-error decoration-error hover:text-tertiary-2xIntense hover:decoration-tertiary-2xIntense inline underline underline-offset-2"
+            href={advisoryURL}
+            onClick={onLinkClick}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            View advisory
+          </a>
+        </>
+      )}
+    </>
+  );
+}

--- a/ui/apps/dashboard/src/components/Apps/Syncs/Sync.tsx
+++ b/ui/apps/dashboard/src/components/Apps/Syncs/Sync.tsx
@@ -3,6 +3,7 @@ import { RiErrorWarningLine } from '@remixicon/react';
 
 import { AppGitCard } from '@/components/Apps/AppGitCard/AppGitCard';
 import { AppInfoCard } from '@/components/Apps/AppInfoCard/AppInfoCard';
+import { SyncErrorMessage } from '@/components/Apps/SyncErrorMessage';
 import { useEnvironment } from '@/components/Environments/environment-context';
 import { useSync } from './useSync';
 
@@ -48,7 +49,7 @@ export const Sync = ({ externalAppID, syncID }: Props) => {
       <div className="mx-auto w-full max-w-[1200px] p-4">
         {sync.error && (
           <Alert className="mb-4" severity="error">
-            {sync.error}
+            <SyncErrorMessage error={sync.error} />
           </Alert>
         )}
 

--- a/ui/apps/dashboard/src/components/SyncFailure/utils.ts
+++ b/ui/apps/dashboard/src/components/SyncFailure/utils.ts
@@ -38,6 +38,8 @@ const messages = {
     'Signature verification failed. Is your app using the correct signing key?',
   signing_key_invalid: "The app's signing key is invalid.",
   signing_key_unspecified: 'The app is not using a signing key.',
+  sdk_version_denied:
+    'App sync was blocked because this app is using an SDK version with a known vulnerability. Upgrade the SDK and try again.',
   too_many_pings: 'Too many requests to register in a short time window.',
   unauthorized: 'Unauthorized response from URL.',
   unreachable: 'The URL is unreachable.',
@@ -47,6 +49,10 @@ const messages = {
 } as const satisfies { [key in Exclude<ErrorCode, 'unknown'>]: string };
 
 export function getMessage(error: CodedError) {
+  if (error.code === 'sdk_version_denied' && error.message) {
+    return error.message;
+  }
+
   if (isErrorCode(error.code) && error.code !== 'unknown') {
     return messages[error.code];
   }

--- a/ui/apps/dashboard/src/components/UnattachedSyncs/Sync.tsx
+++ b/ui/apps/dashboard/src/components/UnattachedSyncs/Sync.tsx
@@ -3,6 +3,7 @@ import { RiErrorWarningLine } from '@remixicon/react';
 
 import { AppGitCard } from '@/components/Apps/AppGitCard/AppGitCard';
 import { AppInfoCard } from '@/components/Apps/AppInfoCard/AppInfoCard';
+import { SyncErrorMessage } from '@/components/Apps/SyncErrorMessage';
 import { useSync } from './useSync';
 
 type Props = {
@@ -45,7 +46,7 @@ export const Sync = ({ syncID }: Props) => {
       <div className="mx-auto w-full max-w-[1200px] p-4">
         {sync.error && (
           <Alert className="mb-4" severity="error">
-            {sync.error}
+            <SyncErrorMessage error={sync.error} />
           </Alert>
         )}
 

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/apps/$externalID/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/apps/$externalID/index.tsx
@@ -9,6 +9,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router';
 
 import { AppGitCard } from '@/components/Apps/AppGitCard/AppGitCard';
 import { AppInfoCard } from '@/components/Apps/AppInfoCard/AppInfoCard';
+import { SyncErrorMessage } from '@/components/Apps/SyncErrorMessage';
 import { useApp } from '@/components/Apps/useApp';
 import { useEnvironment } from '@/components/Environments/environment-context';
 import WorkersSection from '@/components/Workers/WorkersSection';
@@ -78,7 +79,7 @@ function AppPage() {
 
         {appRes.data.latestSync?.error && (
           <Alert className="mb-4" severity="error">
-            {appRes.data.latestSync.error}
+            <SyncErrorMessage error={appRes.data.latestSync.error} />
           </Alert>
         )}
 

--- a/ui/apps/dashboard/src/utils/codedError.ts
+++ b/ui/apps/dashboard/src/utils/codedError.ts
@@ -27,6 +27,7 @@ const codes = [
   'sig_verification_failed',
   'signing_key_invalid',
   'signing_key_unspecified',
+  'sdk_version_denied',
   'too_many_pings',
   'unknown',
   'url_invalid',


### PR DESCRIPTION
## Description

Adds dashboard support for sdk_version_denied sync failures, rendering backend-provided messages and optional advisory links across app cards, app details, and sync views

EXE-1674

Before:
<img width="1544" height="1251" alt="Screenshot 2026-04-27 at 11 05 22 AM" src="https://github.com/user-attachments/assets/531a9a79-ec42-4827-b72d-f394b73544c1" />

After:
<img width="3616" height="1818" alt="image" src="https://github.com/user-attachments/assets/35b71930-a016-4d00-9233-a02f01880303" />


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `sdk_version_denied` error code handling and a new `SyncErrorMessage` component that parses a backend-provided error string for an optional advisory URL, rendering it as a clickable link across app cards, app detail pages, and sync views.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit cd93cd144047f91902ce76d8a7e101191ca1680b.</sup>
<!-- /MENDRAL_SUMMARY -->