### PR TITLE
Block affected sdk versions

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/inngest/inngest/pkg/headers"
 	"github.com/inngest/inngest/pkg/publicerr"
 	"github.com/inngest/inngestgo"
+	"golang.org/x/mod/semver"
 )
 
 var (
@@ -28,6 +29,7 @@ var (
 	DeployErrNoSigningKey        = fmt.Errorf("missing_signing_key")
 	DeployErrNoServerSigningKey  = fmt.Errorf("missing_server_signing_key")
 	DeployErrInvalidFunction     = fmt.Errorf("invalid_function")
+	DeployErrBlockedSDKVersion   = fmt.Errorf("sdk_version_denied")
 	DeployErrNoFunctions         = fmt.Errorf("no_functions")
 	DeployErrUnreachable         = fmt.Errorf("unreachable")
 	DeployErrUnsupportedProtocol = fmt.Errorf("unsupported_protocol")
@@ -125,6 +127,41 @@ func Ping(ctx context.Context, url string, serverKind string, signingKey string,
 		}
 	}
 	return pingResult{IsSDK: isSDK}
+}
+
+func HasBlockedSDKVersion(language, version string) bool {
+	if !isJavaScriptSDK(language) {
+		return false
+	}
+
+	version = normalizeSemver(version)
+	if !semver.IsValid(version) {
+		return false
+	}
+
+	return semver.Compare(version, "v3.22.0") >= 0 && semver.Compare(version, "v3.53.1") <= 0
+}
+
+func BlockedSDKVersionMessage() string {
+	return "App sync was blocked because this application is using an Inngest JavaScript SDK with a known security vulnerability. Please upgrade to v3.54.0 or later. See more information: https://www.inngest.com/blog/cve-2026-42047"
+}
+
+func isJavaScriptSDK(language string) bool {
+	language = strings.TrimPrefix(strings.TrimSpace(language), "inngest-")
+	return language == "js"
+}
+
+func normalizeSemver(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return ""
+	}
+
+	if !strings.HasPrefix(version, "v") {
+		return "v" + version
+	}
+
+	return version
 }
 
 func handlePingError(err error) error {

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -21,6 +21,7 @@ import (
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/cqrs/sync"
+	"github.com/inngest/inngest/pkg/deploy"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/cron"
 	"github.com/inngest/inngest/pkg/headers"
@@ -276,6 +277,46 @@ func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (*sync.Repl
 		}
 	}
 
+	method := enums.AppMethodServe
+	if r.IsConnect() {
+		method = enums.AppMethodConnect
+	}
+
+	appID := inngest.DeterministicAppUUID(r.AppName)
+	appParams := cqrs.UpsertAppParams{
+		// Use a deterministic ID for the app in dev.
+		ID:          appID,
+		Name:        r.AppName,
+		SdkLanguage: r.SDKLanguage(),
+		SdkVersion:  r.SDKVersion(),
+		Framework: sql.NullString{
+			String: r.Framework,
+			Valid:  r.Framework != "",
+		},
+		Url:        r.URL,
+		Checksum:   sum,
+		Method:     method.String(),
+		AppVersion: r.AppVersion,
+	}
+
+	if deploy.HasBlockedSDKVersion(r.SDKLanguage(), r.SDKVersion()) {
+		appParams.Error = sql.NullString{
+			String: deploy.DeployErrBlockedSDKVersion.Error(),
+			Valid:  true,
+		}
+
+		if _, err := a.devserver.Data.UpsertApp(ctx, appParams); err != nil {
+			return nil, publicerr.Wrap(err, 500, "Error updating app error")
+		}
+
+		return nil, publicerr.Error{
+			Code:    deploy.DeployErrBlockedSDKVersion.Error(),
+			Message: deploy.BlockedSDKVersionMessage(),
+			Status:  http.StatusBadRequest,
+			Err:     deploy.DeployErrBlockedSDKVersion,
+		}
+	}
+
 	if app, err := a.devserver.Data.GetAppByChecksum(ctx, consts.DevServerEnvID, sum); err == nil {
 		if !app.Error.Valid {
 			// Skip registration since the app was already successfully
@@ -303,35 +344,12 @@ func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (*sync.Repl
 	// setup a list of crons to be upserted into the queue for scheduling
 	var crons []cron.CronItem
 
-	appID := inngest.DeterministicAppUUID(r.AppName)
-
 	tx, err := a.devserver.Data.WithTx(ctx)
 	if err != nil {
 		return nil, publicerr.Wrap(err, 500, "Error starting registration tx")
 	}
 
 	defer func() {
-		method := enums.AppMethodServe
-		if r.IsConnect() {
-			method = enums.AppMethodConnect
-		}
-
-		appParams := cqrs.UpsertAppParams{
-			// Use a deterministic ID for the app in dev.
-			ID:          appID,
-			Name:        r.AppName,
-			SdkLanguage: r.SDKLanguage(),
-			SdkVersion:  r.SDKVersion(),
-			Framework: sql.NullString{
-				String: r.Framework,
-				Valid:  r.Framework != "",
-			},
-			Url:        r.URL,
-			Checksum:   sum,
-			Method:     method.String(),
-			AppVersion: r.AppVersion,
-		}
-
 		// We want to save an app at the end, after handling each error.
 		if err != nil {
 			appParams.Error = sql.NullString{

--- a/pkg/devserver/api_test.go
+++ b/pkg/devserver/api_test.go
@@ -17,10 +17,12 @@ import (
 	"github.com/inngest/inngest/pkg/cqrs/base_cqrs"
 	dbsqlite "github.com/inngest/inngest/pkg/db/sqlite"
 	"github.com/inngest/inngest/pkg/deploy"
+	"github.com/inngest/inngest/pkg/enums"
 	cronpkg "github.com/inngest/inngest/pkg/execution/cron"
 	"github.com/inngest/inngest/pkg/headers"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/publicerr"
 	"github.com/inngest/inngest/pkg/sdk"
 	"github.com/inngest/inngestgo"
 	"github.com/stretchr/testify/require"
@@ -269,6 +271,89 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 		require.Len(t, fnVersions, 1)
 		require.Contains(t, fnVersions, sdkFunction2.Name)
 		require.Equal(t, fnVersions[sdkFunction2.Name], 2)
+	})
+}
+
+func TestRegister_BlockedSDKVersion(t *testing.T) {
+	ctx := context.Background()
+
+	sdkFunction := sdk.SDKFunction{
+		Name: "Test Function",
+		Slug: "test-function",
+		Triggers: []inngest.Trigger{
+			{
+				EventTrigger: &inngest.EventTrigger{Event: "test/event"},
+			},
+		},
+		Steps: map[string]sdk.SDKStep{
+			"step-1": {
+				ID:   "step-1",
+				Name: "test step",
+				Runtime: map[string]any{
+					"url": "http://localhost:3000/api/inngest",
+				},
+			},
+		},
+	}
+
+	newRequest := func(version string) sdk.RegisterRequest {
+		return sdk.RegisterRequest{
+			URL:       "http://localhost:3000/api/inngest",
+			AppName:   "blocked-sdk-app",
+			SDK:       fmt.Sprintf("js:%s", version),
+			V:         "1",
+			Functions: []sdk.SDKFunction{sdkFunction},
+		}
+	}
+
+	t.Run("blocked versions are rejected and persisted as sync errors", func(t *testing.T) {
+		ds := newTestDevServer(t)
+		api := &devapi{devserver: ds}
+
+		_, err := api.register(ctx, newRequest("v3.35.0"))
+		require.Error(t, err)
+
+		var publicErr publicerr.Error
+		require.ErrorAs(t, err, &publicErr)
+		require.Contains(t, publicErr.Message, "known security vulnerability")
+
+		app, err := ds.Data.GetAppByName(ctx, consts.DevServerEnvID, "blocked-sdk-app")
+		require.NoError(t, err)
+		require.True(t, app.Error.Valid)
+		require.Equal(t, deploy.DeployErrBlockedSDKVersion.Error(), app.Error.String)
+		require.Equal(t, "v3.35.0", app.SdkVersion)
+	})
+
+	t.Run("blocked check runs before successful checksum short circuit", func(t *testing.T) {
+		ds := newTestDevServer(t)
+		api := &devapi{devserver: ds}
+		req := newRequest("v3.35.0")
+
+		sum, err := req.Checksum()
+		require.NoError(t, err)
+
+		_, err = ds.Data.UpsertApp(ctx, cqrs.UpsertAppParams{
+			ID:          inngest.DeterministicAppUUID(req.AppName),
+			Name:        req.AppName,
+			SdkLanguage: req.SDKLanguage(),
+			SdkVersion:  req.SDKVersion(),
+			Checksum:    sum,
+			Url:         req.URL,
+			Method:      enums.AppMethodServe.String(),
+		})
+		require.NoError(t, err)
+
+		_, err = api.register(ctx, req)
+		require.Error(t, err)
+
+		var publicErr publicerr.Error
+		require.ErrorAs(t, err, &publicErr)
+		require.Contains(t, publicErr.Message, "known security vulnerability")
+
+		app, err := ds.Data.GetAppByName(ctx, consts.DevServerEnvID, req.AppName)
+		require.NoError(t, err)
+		require.True(t, app.Error.Valid)
+		require.Equal(t, deploy.DeployErrBlockedSDKVersion.Error(), app.Error.String)
 	})
 }
 

--- a/ui/apps/dev-server-ui/src/components/App/AddAppModal.tsx
+++ b/ui/apps/dev-server-ui/src/components/App/AddAppModal.tsx
@@ -46,11 +46,11 @@ export default function AddAppModal({ isOpen, onClose }: AddAppModalProps) {
         input: {
           url: inputUrl,
         },
-      });
+      }).unwrap();
       toast.success('The app was successfully added.');
       console.log('Created app:', response);
     } catch (error) {
-      toast.error('The app could not be created: ${error}.');
+      toast.error('The app could not be created.');
       console.error('Error creating app:', error);
     }
     onClose();

--- a/ui/apps/dev-server-ui/src/components/App/AppCardContent.tsx
+++ b/ui/apps/dev-server-ui/src/components/App/AppCardContent.tsx
@@ -1,3 +1,4 @@
+import { Alert } from '@inngest/components/Alert/Alert';
 import { Link } from '@inngest/components/Link';
 import { type AppKind } from '@inngest/components/types/app';
 import { RiExternalLinkLine } from '@remixicon/react';
@@ -21,8 +22,12 @@ const getAppCardContent = ({ app }: { app: GetAppsQuery['apps'][number] }) => {
       ? 'No functions found'
       : null;
 
+  const isBlockedSDKVersion = app.error === 'sdk_version_denied';
+
   const footerHeaderTitle = !app.connected ? (
-    app.error === 'unreachable' ? (
+    isBlockedSDKVersion ? (
+      'App sync was blocked.'
+    ) : app.error === 'unreachable' ? (
       `The Inngest Server can't find your application.`
     ) : (
       `Error: ${app.error}`
@@ -44,14 +49,29 @@ const getAppCardContent = ({ app }: { app: GetAppsQuery['apps'][number] }) => {
     ) : null;
 
   const footerContent = !app.connected ? (
-    <>
-      <p className="text-subtle pb-4">
-        Ensure your full URL is correct, including the port. Inngest
-        automatically scans <span className="text-basis">multiple ports</span>{' '}
-        by default.
-      </p>
-      <UpdateApp app={app} />
-    </>
+    isBlockedSDKVersion ? (
+      <Alert severity="error">
+        App sync was blocked because this application is using an Inngest
+        JavaScript SDK with a known security vulnerability. Please upgrade to
+        v3.54.0 or later and review the advisory for more information.{' '}
+        <Alert.Link
+          href="https://www.inngest.com/blog/cve-2026-42047"
+          severity="error"
+          target="_blank"
+        >
+          See more information
+        </Alert.Link>
+      </Alert>
+    ) : (
+      <>
+        <p className="text-subtle pb-4">
+          Ensure your full URL is correct, including the port. Inngest
+          automatically scans <span className="text-basis">multiple ports</span>{' '}
+          by default.
+        </p>
+        <UpdateApp app={app} />
+      </>
+    )
   ) : app.functionCount === 0 ? (
     <>
       <p className="text-subtle pb-4">


### PR DESCRIPTION
## Description

Blocks SDK versions that are affected by CVE-2026-42047

<img width="1800" height="909" alt="Screenshot 2026-04-27 at 11 15 24 AM" src="https://github.com/user-attachments/assets/83642f03-3c7c-4573-a4eb-2b0619ef4713" />


## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Blocks JavaScript SDK versions v3.22.0–v3.53.1 (CVE-2026-42047) from syncing in the dev server. Adds `HasBlockedSDKVersion` to `pkg/deploy`, enforces the check early in the `register` handler before the checksum short-circuit, persists the error to the app record, and surfaces a UI alert with upgrade instructions.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 28fb4212a0c12297466d05ed96a4f65ab3786173.</sup>
<!-- /MENDRAL_SUMMARY -->