### PR TITLE
Make AppID available to Acquire

### DIFF
--- a/pkg/constraintapi/acquire.go
+++ b/pkg/constraintapi/acquire.go
@@ -160,12 +160,12 @@ type acquireScriptResponse struct {
 		LeaseID             ulid.ULID `json:"lid"`
 		LeaseIdempotencyKey string    `json:"lik"`
 	} `json:"l"`
-	LimitingConstraints  flexibleIntArray    `json:"lc"`
-	ExhaustedConstraints flexibleIntArray    `json:"ec"`
-	FairnessReduction    int                 `json:"fr"`
-	RetryAt              int                 `json:"ra"`
-	Debug                flexibleStringArray `json:"d"`
-	CacheHit             int                 `json:"ch"`
+	LimitingConstraints  flexibleIntArray          `json:"lc"`
+	ExhaustedConstraints flexibleIntArray          `json:"ec"`
+	FairnessReduction    int                       `json:"fr"`
+	RetryAt              int                       `json:"ra"`
+	Debug                flexibleStringArray       `json:"d"`
+	CacheHit             int                       `json:"ch"`
 	ConstraintUsage      []constraintUsageResponse `json:"cu"`
 }
 
@@ -451,6 +451,7 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 			err := hook.OnCapacityLeaseAcquired(ctx, OnCapacityLeaseAcquiredData{
 				AccountID:            req.AccountID,
 				EnvID:                req.EnvID,
+				AppID:                req.AppID,
 				FunctionID:           req.FunctionID,
 				Configuration:        req.Configuration,
 				Constraints:          req.Constraints,

--- a/pkg/constraintapi/capacity_manager.go
+++ b/pkg/constraintapi/capacity_manager.go
@@ -84,6 +84,9 @@ type CapacityAcquireRequest struct {
 	// FunctionID is used for identifying the function.
 	FunctionID uuid.UUID
 
+	// AppID is included for lifecycle reporting.
+	AppID uuid.UUID
+
 	// Configuration represents the latest known constraint configuration (a subset of the function config).
 	//
 	// The server _may_ reject calls if it has recently seen a newer configuration. This is expected for a short

--- a/pkg/constraintapi/convert.go
+++ b/pkg/constraintapi/convert.go
@@ -495,7 +495,7 @@ func SemaphoreFromProto(pbSem *pb.Semaphore) Semaphore {
 		ID:         pbSem.Id,
 		UsageValue: pbSem.UsageValue,
 		Weight:     pbSem.Weight,
-		Release: SemaphoreReleaseModeFromProto(pbSem.Release),
+		Release:    SemaphoreReleaseModeFromProto(pbSem.Release),
 	}
 }
 
@@ -516,7 +516,7 @@ func SemaphoreConstraintFromProto(pbConstraint *pb.SemaphoreConstraint) Semaphor
 		ID:         pbConstraint.Id,
 		UsageValue: pbConstraint.UsageValue,
 		Weight:     pbConstraint.Weight,
-		Release: SemaphoreReleaseModeFromProto(pbConstraint.Release),
+		Release:    SemaphoreReleaseModeFromProto(pbConstraint.Release),
 	}
 }
 
@@ -784,6 +784,7 @@ func CapacityAcquireRequestToProto(req *CapacityAcquireRequest) *pb.CapacityAcqu
 		IdempotencyKey:       req.IdempotencyKey,
 		AccountId:            req.AccountID.String(),
 		EnvId:                req.EnvID.String(),
+		AppId:                req.AppID.String(),
 		FunctionId:           req.FunctionID.String(),
 		Configuration:        ConstraintConfigToProto(req.Configuration),
 		Constraints:          constraints,
@@ -812,6 +813,14 @@ func CapacityAcquireRequestFromProto(pbReq *pb.CapacityAcquireRequest) (*Capacit
 	envID, err := uuid.Parse(pbReq.EnvId)
 	if err != nil {
 		return nil, fmt.Errorf("invalid env ID: %w", err)
+	}
+
+	var appID uuid.UUID
+	if pbReq.AppId != "" {
+		appID, err = uuid.Parse(pbReq.AppId)
+		if err != nil {
+			return nil, fmt.Errorf("invalid app ID: %w", err)
+		}
 	}
 
 	functionID, err := uuid.Parse(pbReq.FunctionId)
@@ -857,6 +866,7 @@ func CapacityAcquireRequestFromProto(pbReq *pb.CapacityAcquireRequest) (*Capacit
 		IdempotencyKey:       pbReq.IdempotencyKey,
 		AccountID:            accountID,
 		EnvID:                envID,
+		AppID:                appID,
 		FunctionID:           functionID,
 		Configuration:        ConstraintConfigFromProto(pbReq.Configuration),
 		Constraints:          constraints,

--- a/pkg/constraintapi/convert_test.go
+++ b/pkg/constraintapi/convert_test.go
@@ -1389,6 +1389,7 @@ func TestCapacityCheckResponseConversion(t *testing.T) {
 func TestCapacityAcquireRequestConversion(t *testing.T) {
 	accountID := uuid.New()
 	envID := uuid.New()
+	appID := uuid.New()
 	functionID := uuid.New()
 	currentTime := time.Date(2023, 10, 15, 12, 30, 45, 0, time.UTC)
 	kindConcurrency := ConstraintKindConcurrency
@@ -1404,6 +1405,7 @@ func TestCapacityAcquireRequestConversion(t *testing.T) {
 				IdempotencyKey: "test-key-123",
 				AccountID:      accountID,
 				EnvID:          envID,
+				AppID:          appID,
 				FunctionID:     functionID,
 				Configuration: ConstraintConfig{
 					FunctionVersion: 1,
@@ -1442,6 +1444,7 @@ func TestCapacityAcquireRequestConversion(t *testing.T) {
 				IdempotencyKey: "test-key-123",
 				AccountId:      accountID.String(),
 				EnvId:          envID.String(),
+				AppId:          appID.String(),
 				FunctionId:     functionID.String(),
 				Configuration: &pb.ConstraintConfig{
 					FunctionVersion: 1,
@@ -1483,6 +1486,7 @@ func TestCapacityAcquireRequestConversion(t *testing.T) {
 				IdempotencyKey: "minimal",
 				AccountID:      accountID,
 				EnvID:          envID,
+				AppID:          appID,
 				FunctionID:     functionID,
 				Configuration: ConstraintConfig{
 					RateLimit: []RateLimitConfig{},
@@ -1499,6 +1503,7 @@ func TestCapacityAcquireRequestConversion(t *testing.T) {
 				IdempotencyKey: "minimal",
 				AccountId:      accountID.String(),
 				EnvId:          envID.String(),
+				AppId:          appID.String(),
 				FunctionId:     functionID.String(),
 				Configuration: &pb.ConstraintConfig{
 					FunctionVersion: 0,

--- a/pkg/constraintapi/lifecycle.go
+++ b/pkg/constraintapi/lifecycle.go
@@ -12,6 +12,7 @@ import (
 type OnCapacityLeaseAcquiredData struct {
 	AccountID  uuid.UUID
 	EnvID      uuid.UUID
+	AppID      uuid.UUID
 	FunctionID uuid.UUID
 
 	Configuration ConstraintConfig

--- a/pkg/execution/executor/constraints.go
+++ b/pkg/execution/executor/constraints.go
@@ -12,8 +12,8 @@ import (
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/queue"
-	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/execution/ratelimit"
+	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/expressions"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/logger"
@@ -413,6 +413,7 @@ func CheckConstraints(
 		// the create state call within schedule().
 		// LeaseRunIDs: []ulid.ULID,
 		EnvID:             req.WorkspaceID,
+		AppID:             req.AppID,
 		FunctionID:        req.Function.ID,
 		Configuration:     configuration,
 		Constraints:       constraints,

--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/constraintapi"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/enums"
@@ -232,9 +233,16 @@ func (q *queueProcessor) BacklogRefillConstraintCheck(
 		}, nil
 	}
 
+	var appID uuid.UUID
+	if len(items) > 0 {
+		appID = items[0].Data.Identifier.AppID
+	}
+
 	res, err := q.CapacityManager.Acquire(ctx, &constraintapi.CapacityAcquireRequest{
-		AccountID:            *shadowPart.AccountID,
-		EnvID:                *shadowPart.EnvID,
+		AccountID: *shadowPart.AccountID,
+		EnvID:     *shadowPart.EnvID,
+		// TODO: Make appID available to backlog
+		AppID:                appID,
 		IdempotencyKey:       operationIdempotencyKey,
 		FunctionID:           *shadowPart.FunctionID,
 		CurrentTime:          now,
@@ -422,6 +430,7 @@ func (q *queueProcessor) ItemLeaseConstraintCheck(
 	res, err := q.CapacityManager.Acquire(ctx, &constraintapi.CapacityAcquireRequest{
 		AccountID: *shadowPart.AccountID,
 		EnvID:     *shadowPart.EnvID,
+		AppID:     item.Data.Identifier.AppID,
 		// TODO: Double check if the item ID works for idempotency:
 		// - Consistent across the same attempt
 		// - Do we need to re-evaluate per retry?

--- a/proto/constraintapi/v1/service.proto
+++ b/proto/constraintapi/v1/service.proto
@@ -194,6 +194,7 @@ message CapacityAcquireRequest {
   string idempotency_key = 1;
   string account_id = 2;
   string env_id = 3;
+  string app_id = 16;
   string function_id = 4;
   ConstraintConfig configuration = 5;
   repeated ConstraintItem constraints = 6;

--- a/proto/gen/constraintapi/v1/service.pb.go
+++ b/proto/gen/constraintapi/v1/service.pb.go
@@ -1602,6 +1602,7 @@ type CapacityAcquireRequest struct {
 	IdempotencyKey       string                 `protobuf:"bytes,1,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
 	AccountId            string                 `protobuf:"bytes,2,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
 	EnvId                string                 `protobuf:"bytes,3,opt,name=env_id,json=envId,proto3" json:"env_id,omitempty"`
+	AppId                string                 `protobuf:"bytes,16,opt,name=app_id,json=appId,proto3" json:"app_id,omitempty"`
 	FunctionId           string                 `protobuf:"bytes,4,opt,name=function_id,json=functionId,proto3" json:"function_id,omitempty"`
 	Configuration        *ConstraintConfig      `protobuf:"bytes,5,opt,name=configuration,proto3" json:"configuration,omitempty"`
 	Constraints          []*ConstraintItem      `protobuf:"bytes,6,rep,name=constraints,proto3" json:"constraints,omitempty"`
@@ -1665,6 +1666,13 @@ func (x *CapacityAcquireRequest) GetAccountId() string {
 func (x *CapacityAcquireRequest) GetEnvId() string {
 	if x != nil {
 		return x.EnvId
+	}
+	return ""
+}
+
+func (x *CapacityAcquireRequest) GetAppId() string {
+	if x != nil {
+		return x.AppId
 	}
 	return ""
 }
@@ -2554,12 +2562,13 @@ const file_constraintapi_v1_service_proto_rawDesc = "" +
 	"\x12fairness_reduction\x18\x04 \x01(\x05R\x11fairnessReduction\x12;\n" +
 	"\vretry_after\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"retryAfter\x12U\n" +
-	"\x15exhausted_constraints\x18\x06 \x03(\v2 .constraintapi.v1.ConstraintItemR\x14exhaustedConstraints\"\xf9\x06\n" +
+	"\x15exhausted_constraints\x18\x06 \x03(\v2 .constraintapi.v1.ConstraintItemR\x14exhaustedConstraints\"\x90\a\n" +
 	"\x16CapacityAcquireRequest\x12'\n" +
 	"\x0fidempotency_key\x18\x01 \x01(\tR\x0eidempotencyKey\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x02 \x01(\tR\taccountId\x12\x15\n" +
-	"\x06env_id\x18\x03 \x01(\tR\x05envId\x12\x1f\n" +
+	"\x06env_id\x18\x03 \x01(\tR\x05envId\x12\x15\n" +
+	"\x06app_id\x18\x10 \x01(\tR\x05appId\x12\x1f\n" +
 	"\vfunction_id\x18\x04 \x01(\tR\n" +
 	"functionId\x12H\n" +
 	"\rconfiguration\x18\x05 \x01(\v2\".constraintapi.v1.ConstraintConfigR\rconfiguration\x12B\n" +


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Propagates `AppID` through the capacity acquire path — added to `CapacityAcquireRequest`, the proto definition (`field 16`), `CapacityAcquireRequestToProto`/`FromProto`, `OnCapacityLeaseAcquiredData`, and both `BacklogRefillConstraintCheck` and `ItemLeaseConstraintCheck` call sites. The second commit fills in the missing `AppID` in the conversion tests.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c5a0850680fe6c5e18b66c79708852eea976d114.</sup>
<!-- /MENDRAL_SUMMARY -->