### PR TITLE
disable logging for fallbacking different partition keys on spans

### DIFF
--- a/pkg/telemetry/exporters/kafka.go
+++ b/pkg/telemetry/exporters/kafka.go
@@ -199,12 +199,25 @@ func (e *kafkaSpanExporter) ExportSpans(ctx context.Context, spans []trace.ReadO
 				rec.Key = []byte(id.GetRunId())
 			case id.GetFunctionId() != "":
 				l.Warn("missing run_id, falling back to function_id", "span", sp)
+				metrics.IncrSpanExportMissingRunID(ctx, metrics.CounterOpt{
+					PkgName: pkgName,
+					Tags:    map[string]any{"fallback": "function_id"},
+				})
 				rec.Key = []byte(id.GetFunctionId())
 			case id.GetEnvId() != "":
-				l.Warn("missing run_id, falling back to env_id", "span", sp)
+				// No logging as it's expected to happen with some of the v1 traces
+				// not having run ids.
+				metrics.IncrSpanExportMissingRunID(ctx, metrics.CounterOpt{
+					PkgName: pkgName,
+					Tags:    map[string]any{"fallback": "env_id"},
+				})
 				rec.Key = []byte(id.GetEnvId())
 			case id.GetAccountId() != "":
 				l.Warn("missing run_id, falling back to acct_id", "span", sp)
+				metrics.IncrSpanExportMissingRunID(ctx, metrics.CounterOpt{
+					PkgName: pkgName,
+					Tags:    map[string]any{"fallback": "acct_id"},
+				})
 				rec.Key = []byte(id.GetAccountId())
 			default:
 				l.Error("missing run_id, no other identifier to fallback to", "span", sp)

--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -184,6 +184,15 @@ func IncrSpanExportDataLoss(ctx context.Context, opts CounterOpt) {
 	})
 }
 
+func IncrSpanExportMissingRunID(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "span_export_missing_run_id_total",
+		Description: "Total number of spans exported without a run_id, keyed by fallback identifier",
+		Tags:        opts.Tags,
+	})
+}
+
 func IncrSpanBatchProcessorEnqueuedCounter(ctx context.Context, opts CounterOpt) {
 	RecordCounterMetric(ctx, 1, CounterOpt{
 		PkgName:     opts.PkgName,


### PR DESCRIPTION
## Description
I'm switching v1 traces to use run IDs as partition keys to avoid hot
spots and this will overwhelm logs with expected warnings so I removed
the log statement and added a fallback counter.


<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Replaces the `l.Warn` log for the `env_id` fallback path in the Kafka span exporter with a metrics counter, and adds `IncrSpanExportMissingRunID` counters to all three fallback cases (`function_id`, `env_id`, `acct_id`). The motivation is that switching v1 traces to use run IDs as partition keys will make the `env_id` fallback expected/frequent, so logging it would flood logs.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 667e878fc3a6d0d1e3f8bcfa9fd84fa0dbb5de8a.</sup>
<!-- /MENDRAL_SUMMARY -->