### PR TITLE
Insights: Add tables to schema explorer

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/SchemaExplorer/SchemaExplorer.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/SchemaExplorer/SchemaExplorer.tsx
@@ -6,6 +6,7 @@ import { SchemaViewer } from '@inngest/components/SchemaViewer/SchemaViewer';
 import { SchemaExplorerSwitcher } from './SchemaExplorerSwitcher';
 import { useSchemas } from './SchemasContext/SchemasContext';
 import { useSchemasInUse } from './useSchemasInUse';
+import { tableEntries } from './tableSchemas';
 
 export function SchemaExplorer() {
   const [search, setSearch] = useState('');
@@ -34,6 +35,14 @@ export function SchemaExplorer() {
       ref={containerRef}
     >
       <>
+        <div className="text-light text-xs font-medium uppercase">
+          Available Tables
+        </div>
+        <div className="flex flex-col gap-1">
+          {tableEntries.map((tableEntry) => (
+            <SchemaViewer key={tableEntry.key} node={tableEntry.node} />
+          ))}
+        </div>
         {schemasInUse.length > 0 && (
           <div className="mb-3 flex flex-col gap-2">
             <div className="text-light text-xs font-medium uppercase">
@@ -45,7 +54,7 @@ export function SchemaExplorer() {
           </div>
         )}
         <div className="text-light text-xs font-medium uppercase">
-          All Schemas
+          Event Schemas
         </div>
         <Search
           inngestSize="base"

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/SchemaExplorer/tableSchemas.ts
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/SchemaExplorer/tableSchemas.ts
@@ -1,0 +1,394 @@
+import type { SchemaNode } from '@inngest/components/SchemaViewer/types';
+import type { SchemaEntry } from './SchemasContext/types';
+
+const metadataNode = (table: string, column: string): SchemaNode => ({
+  kind: 'object',
+  name: column,
+  path: `${table}.${column}`,
+  type: 'JSON',
+  children: [
+    {
+      kind: 'object',
+      name: '<kind>',
+      path: `${table}.${column}.<kind>`,
+      type: 'String',
+      children: [
+        {
+          kind: 'value',
+          name: 'updated_at',
+          path: `${table}.${column}.<kind>.updated_at`,
+          type: 'DateTime',
+        },
+        {
+          kind: 'value',
+          name: 'values',
+          path: `${table}.${column}.<kind>.values`,
+          type: 'JSON',
+        },
+      ],
+    },
+  ],
+});
+
+const attributesNode = (table: string, column: string): SchemaNode => ({
+  kind: 'object',
+  name: column,
+  path: `${table}.${column}`,
+  type: 'JSON',
+  children: [
+    {
+      kind: 'value',
+      name: '<key>',
+      path: `${table}.${column}.<attr>`,
+      type: 'String',
+    },
+  ],
+});
+
+const stepsTable = (table: string): SchemaEntry => ({
+  key: table,
+  node: {
+    kind: 'table',
+    name: table,
+    path: table,
+    children: [
+      {
+        kind: 'value',
+        name: 'run_id',
+        path: `${table}.run_id`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'app_id',
+        path: `${table}.app_id`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'function_id',
+        path: `${table}.function_id`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'type',
+        path: `${table}.type`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'name',
+        path: `${table}.name`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'id',
+        path: `${table}.id`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'loop_index',
+        path: `${table}.loop_index`,
+        type: 'Integer',
+      },
+      {
+        kind: 'value',
+        name: 'attempt',
+        path: `${table}.attempt`,
+        type: 'Integer',
+      },
+      {
+        kind: 'value',
+        name: 'status',
+        path: `${table}.status`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'queued_at',
+        path: `${table}.queued_at`,
+        type: 'DateTime',
+      },
+      {
+        kind: 'value',
+        name: 'started_at',
+        path: `${table}.started_at`,
+        type: 'DateTime',
+      },
+      {
+        kind: 'value',
+        name: 'ended_at',
+        path: `${table}.ended_at`,
+        type: 'DateTime',
+      },
+      {
+        kind: 'value',
+        name: 'output',
+        path: `${table}.output`,
+        type: 'JSON',
+      },
+      {
+        kind: 'value',
+        name: 'error',
+        path: `${table}.error`,
+        type: 'JSON',
+      },
+      attributesNode(table, 'attributes'),
+      metadataNode(table, 'inngest'),
+      metadataNode(table, 'metadata'),
+    ],
+  },
+});
+
+const extendedTraceSpansTable = (table: string): SchemaEntry => ({
+  key: table,
+  node: {
+    kind: 'table',
+    name: table,
+    path: table,
+    children: [
+      {
+        kind: 'value',
+        name: 'run_id',
+        path: `${table}.run_id`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'app_id',
+        path: `${table}.app_id`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'function_id',
+        path: `${table}.function_id`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'step_id',
+        path: `${table}.step_id`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'step_index',
+        path: `${table}.step_index`,
+        type: 'Integer',
+      },
+      {
+        kind: 'value',
+        name: 'step_attempt',
+        path: `${table}.step_attempt`,
+        type: 'Integer',
+      },
+      {
+        kind: 'value',
+        name: 'span_id',
+        path: `${table}.span_id`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'parent_span_id',
+        path: `${table}.parent_span_id`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'start_time',
+        path: `${table}.start_time`,
+        type: 'DateTime',
+      },
+      {
+        kind: 'value',
+        name: 'end_time',
+        path: `${table}.end_time`,
+        type: 'DateTime',
+      },
+      {
+        kind: 'value',
+        name: 'name',
+        path: `${table}.name`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'kind',
+        path: `${table}.kind`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'scope_name',
+        path: `${table}.scope_name`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'scope_version',
+        path: `${table}.scope_version`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'service_name',
+        path: `${table}.service_name`,
+        type: 'String',
+      },
+      {
+        kind: 'value',
+        name: 'output',
+        path: `${table}.output`,
+        type: 'JSON',
+      },
+      {
+        kind: 'value',
+        name: 'error',
+        path: `${table}.error`,
+        type: 'JSON',
+      },
+      attributesNode(table, 'attributes'),
+      metadataNode(table, 'inngest'),
+      metadataNode(table, 'metadata'),
+    ],
+  },
+});
+
+export const tableEntries: SchemaEntry[] = [
+  {
+    key: 'events',
+    node: {
+      kind: 'table',
+      name: 'events',
+      path: 'events',
+      children: [
+        {
+          kind: 'value',
+          name: 'name',
+          path: 'events.name',
+          type: 'String',
+        },
+        {
+          kind: 'value',
+          name: 'id',
+          path: 'events.id',
+          type: 'String',
+        },
+        {
+          kind: 'value',
+          name: 'data',
+          path: 'events.data',
+          type: 'JSON',
+        },
+        {
+          kind: 'value',
+          name: 'ts',
+          path: 'events.ts',
+          type: 'Integer',
+        },
+        {
+          kind: 'value',
+          name: 'ts_dt',
+          path: 'events.ts_dt',
+          type: 'DateTime',
+        },
+        {
+          kind: 'value',
+          name: 'received_at',
+          path: 'events.received_at',
+          type: 'Integer',
+        },
+        {
+          kind: 'value',
+          name: 'received_at_dt',
+          path: 'events.received_at_dt',
+          type: 'DateTime',
+        },
+      ],
+    },
+  },
+  {
+    key: 'runs',
+    node: {
+      kind: 'table',
+      name: 'runs',
+      path: 'runs',
+      children: [
+        {
+          kind: 'value',
+          name: 'id',
+          path: 'runs.id',
+          type: 'String',
+        },
+        {
+          kind: 'value',
+          name: 'app_id',
+          path: 'runs.app_id',
+          type: 'String',
+        },
+        {
+          kind: 'value',
+          name: 'function_id',
+          path: 'runs.function_id',
+          type: 'String',
+        },
+        {
+          kind: 'value',
+          name: 'triggering_event_name',
+          path: 'runs.triggering_event_name',
+          type: 'String',
+        },
+        {
+          kind: 'value',
+          name: 'queued_at',
+          path: 'runs.queued_at',
+          type: 'DateTime',
+        },
+        {
+          kind: 'value',
+          name: 'started_at',
+          path: 'runs.started_at',
+          type: 'DateTime',
+        },
+        {
+          kind: 'value',
+          name: 'ended_at',
+          path: 'runs.ended_at',
+          type: 'DateTime',
+        },
+        {
+          kind: 'value',
+          name: 'inputs',
+          path: 'runs.inputs',
+          type: 'Array(JSON)',
+        },
+        {
+          kind: 'value',
+          name: 'input',
+          path: 'runs.input',
+          type: 'JSON',
+        },
+        {
+          kind: 'value',
+          name: 'output',
+          path: 'runs.output',
+          type: 'JSON',
+        },
+        {
+          kind: 'value',
+          name: 'error',
+          path: 'runs.error',
+          type: 'JSON',
+        },
+      ],
+    },
+  },
+  stepsTable('steps'),
+  stepsTable('step_attempts'),
+  extendedTraceSpansTable('extended_trace_spans'),
+];

--- a/ui/packages/components/src/SchemaViewer/AdornmentContext.tsx
+++ b/ui/packages/components/src/SchemaViewer/AdornmentContext.tsx
@@ -1,8 +1,8 @@
 import { createContext, useContext } from 'react';
 
-import type { ValueNode } from './types';
+import type { TypedNode } from './types';
 
-export type RenderAdornmentFn = (node: ValueNode, typeLabel: string) => React.ReactNode;
+export type RenderAdornmentFn = (node: TypedNode, typeLabel: string) => React.ReactNode;
 
 const defaultRenderAdornment: RenderAdornmentFn = () => null;
 

--- a/ui/packages/components/src/SchemaViewer/TypeContext.tsx
+++ b/ui/packages/components/src/SchemaViewer/TypeContext.tsx
@@ -1,8 +1,8 @@
 import { createContext, useContext } from 'react';
 
-import type { ValueNode } from './types';
+import type { TypedNode } from './types';
 
-export type ComputeTypeFn = (node: ValueNode, baseLabel: string) => string;
+export type ComputeTypeFn = (node: TypedNode, baseLabel: string) => string;
 
 const defaultComputeType: ComputeTypeFn = (_node, baseLabel) => baseLabel;
 

--- a/ui/packages/components/src/SchemaViewer/rows/ArrayRow/variants/ArrayRowVariantNested.tsx
+++ b/ui/packages/components/src/SchemaViewer/rows/ArrayRow/variants/ArrayRowVariantNested.tsx
@@ -1,5 +1,12 @@
 import { makeValueTypeLabel, repeatArrayBrackets } from '../../../typeUtil';
-import type { ArrayNode, ObjectNode, SchemaNode, TupleNode, ValueNode } from '../../../types';
+import type {
+  ArrayNode,
+  ObjectNode,
+  SchemaNode,
+  TableNode,
+  TupleNode,
+  ValueNode,
+} from '../../../types';
 import { ObjectRow } from '../../ObjectRow';
 import { TupleRow } from '../../TupleRow';
 import { ValueRow } from '../../ValueRow';
@@ -47,7 +54,7 @@ export function ArrayRowVariantNested({ node }: { node: ArrayNode }): React.Reac
 // Identifies the first non-array schema node.
 function computeNestedTerminal(element: SchemaNode): {
   bracketLayers: number;
-  terminal: ObjectNode | TupleNode | ValueNode | null;
+  terminal: ObjectNode | TupleNode | ValueNode | TableNode | null;
 } {
   let bracketLayers = 1;
   let cursor: SchemaNode | undefined = element;
@@ -69,7 +76,13 @@ function labelForNestedValue(bracketLayers: number, value: ValueNode): string {
 }
 
 function mkObjectNode(node: ArrayNode, terminal: ObjectNode): ObjectNode {
-  return { kind: 'object', name: node.name, path: node.path, children: terminal.children };
+  return {
+    kind: 'object',
+    name: node.name,
+    path: node.path,
+    type: terminal.type,
+    children: terminal.children,
+  };
 }
 
 function mkTupleNode(node: ArrayNode, terminal: TupleNode): TupleNode {

--- a/ui/packages/components/src/SchemaViewer/rows/Row.tsx
+++ b/ui/packages/components/src/SchemaViewer/rows/Row.tsx
@@ -1,6 +1,7 @@
 import type { SchemaNode } from '../types';
 import { ArrayRow } from './ArrayRow/ArrayRow';
 import { ObjectRow } from './ObjectRow';
+import { TableRow } from './TableRow';
 import { TupleRow } from './TupleRow';
 import { ValueRow } from './ValueRow';
 
@@ -16,6 +17,8 @@ export function Row({ node }: RowProps): React.ReactElement | null {
       return <TupleRow node={node} />;
     case 'value':
       return <ValueRow node={node} />;
+    case 'table':
+      return <TableRow node={node} />;
     default:
       return null;
   }

--- a/ui/packages/components/src/SchemaViewer/rows/TableRow.tsx
+++ b/ui/packages/components/src/SchemaViewer/rows/TableRow.tsx
@@ -1,17 +1,23 @@
-import { RiFileCopyLine } from '@remixicon/react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@inngest/components/Tooltip';
+import { RiInformationLine } from '@remixicon/react';
 
 import { cn } from '../../utils/classNames';
 import { useRenderAdornment } from '../AdornmentContext';
 import { useExpansion } from '../ExpansionContext';
 import { useComputeType } from '../TypeContext';
-import type { ObjectNode } from '../types';
+import type { SchemaNode, TableNode } from '../types';
 import { CollapsibleRowWidget } from './CollapsibleRowWidget';
 import { Row } from './Row';
-import { collectAllExpandablePaths, getTypeLabel, handleCopyValue } from './utils';
+import { getTypeLabel } from './utils';
 
-export type ObjectRowProps = { node: ObjectNode; typeLabelOverride?: string };
+export type TableRowProps = { node: TableNode; typeLabelOverride?: string };
 
-export function ObjectRow({ node }: ObjectRowProps): React.ReactElement {
+export function TableRow({ node }: TableRowProps): React.ReactElement {
   const computeType = useComputeType();
   const renderAdornment = useRenderAdornment();
   const { isExpanded, toggleRecursive } = useExpansion();
@@ -36,16 +42,19 @@ export function ObjectRow({ node }: ObjectRowProps): React.ReactElement {
         <span className={'text-subtle overflow-hidden text-ellipsis whitespace-nowrap text-sm'}>
           {node.name}
         </span>
-        <button
-          className={cn(
-            'hover:bg-canvasBase min-w-sm rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100'
-          )}
-          onClick={handleCopyValue(node)}
-          type="button"
-          aria-label="Copy value"
-        >
-          <RiFileCopyLine className="text-subtle h-3 w-3" />
-        </button>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger>
+              <RiInformationLine
+                className={
+                  'hover:bg-canvasBase min-w-sm rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100'
+                }
+                size={16}
+              />
+            </TooltipTrigger>
+            <TooltipContent>Query {node.name} table</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         <div className="ml-auto flex items-baseline gap-1.5">
           <span className="text-muted min-w-0 whitespace-nowrap font-mono text-xs capitalize">
             {typeText}
@@ -74,4 +83,28 @@ export function ObjectRow({ node }: ObjectRowProps): React.ReactElement {
       )}
     </div>
   );
+}
+
+function collectAllExpandablePaths(node: SchemaNode): string[] {
+  const paths: string[] = [];
+
+  function traverse(n: SchemaNode) {
+    if (n.kind === 'object') {
+      paths.push(n.path);
+      n.children.forEach(traverse);
+    } else if (n.kind === 'array') {
+      paths.push(n.path);
+      traverse(n.element);
+    } else if (n.kind === 'tuple') {
+      paths.push(n.path);
+      n.elements.forEach(traverse);
+    }
+  }
+
+  // Start with children to avoid adding the current node's path
+  if (node.kind === 'object') {
+    node.children.forEach(traverse);
+  }
+
+  return paths;
 }

--- a/ui/packages/components/src/SchemaViewer/rows/TableRow.tsx
+++ b/ui/packages/components/src/SchemaViewer/rows/TableRow.tsx
@@ -42,19 +42,6 @@ export function TableRow({ node }: TableRowProps): React.ReactElement {
         <span className={'text-subtle overflow-hidden text-ellipsis whitespace-nowrap text-sm'}>
           {node.name}
         </span>
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger>
-              <RiInformationLine
-                className={
-                  'hover:bg-canvasBase min-w-sm rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100'
-                }
-                size={16}
-              />
-            </TooltipTrigger>
-            <TooltipContent>Query {node.name} table</TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
         <div className="ml-auto flex items-baseline gap-1.5">
           <span className="text-muted min-w-0 whitespace-nowrap font-mono text-xs capitalize">
             {typeText}

--- a/ui/packages/components/src/SchemaViewer/rows/TableRow.tsx
+++ b/ui/packages/components/src/SchemaViewer/rows/TableRow.tsx
@@ -1,11 +1,3 @@
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@inngest/components/Tooltip';
-import { RiInformationLine } from '@remixicon/react';
-
 import { cn } from '../../utils/classNames';
 import { useRenderAdornment } from '../AdornmentContext';
 import { useExpansion } from '../ExpansionContext';

--- a/ui/packages/components/src/SchemaViewer/rows/ValueRow.tsx
+++ b/ui/packages/components/src/SchemaViewer/rows/ValueRow.tsx
@@ -1,18 +1,19 @@
+import type { ReactElement } from 'react';
 import { Pill } from '@inngest/components/Pill/Pill';
-import { STANDARD_EVENT_FIELDS } from '@inngest/components/constants';
 import { RiFileCopyLine } from '@remixicon/react';
-import { toast } from 'sonner';
 
 import { cn } from '../../utils/classNames';
 import { useRenderAdornment } from '../AdornmentContext';
 import { useComputeType } from '../TypeContext';
 import type { ValueNode } from '../types';
+import { getTypeLabel, handleCopyValue } from './utils';
 
 export type ValueRowProps = {
   boldName?: boolean;
   node: ValueNode;
   typeLabelOverride?: string;
   typePillOverride?: string;
+  btn?: ReactElement;
 };
 
 export function ValueRow({
@@ -28,57 +29,31 @@ export function ValueRow({
   const computed = computeType(node, baseLabel);
   const typeText = typeLabelOverride !== undefined ? typeLabelOverride : computed;
 
-  const handleCopyValue = async (e: React.MouseEvent) => {
-    e.stopPropagation();
-    try {
-      // The path is formatted as "eventName.field.subfield..."
-      // We need to remove the event name prefix (which can contain dots)
-      // We do this by finding the first occurrence of a standard field after the event name
-      // Strategy: The path after the event name will always start with a dot followed by a field
-      let relativePath = node.path;
-
-      for (const field of STANDARD_EVENT_FIELDS) {
-        const pattern = `.${field}`;
-        const index = node.path.indexOf(pattern);
-        if (index !== -1) {
-          // Found a standard field, extract from this point (excluding the leading dot)
-          relativePath = node.path.substring(index + 1);
-          break;
-        }
-      }
-
-      await navigator.clipboard.writeText(relativePath);
-      toast.success('Path copied to clipboard');
-    } catch (err) {
-      console.error('Failed to copy:', err);
-      toast.error('Failed to copy to clipboard');
-    }
-  };
-
   return (
-    <div className="group flex items-baseline justify-between gap-2 rounded px-1 py-0.5">
-      <div className="flex items-center gap-1">
-        <span
-          className={cn(
-            'text-sm',
-            boldName ? 'text-basis font-semibold' : 'text-subtle',
-            'whitespace-nowrap'
-          )}
-        >
-          {node.name}
-        </span>
-        <button
-          className="hover:bg-canvasBase flex items-center rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100"
-          onClick={handleCopyValue}
-          type="button"
-          aria-label="Copy value"
-        >
-          <RiFileCopyLine className="text-subtle h-3 w-3" />
-        </button>
-      </div>
-      <div className="flex items-baseline gap-1.5">
+    <div className="group flex items-center justify-between gap-2 rounded px-1 py-0.5">
+      <span
+        className={cn(
+          'overflow-hidden text-ellipsis',
+          'text-sm',
+          boldName ? 'text-basis font-semibold' : 'text-subtle',
+          'whitespace-nowrap'
+        )}
+      >
+        {node.name}
+      </span>
+      <button
+        className={cn(
+          'hover:bg-canvasBase min-w-sm rounded p-0.5 opacity-0 transition-opacity group-hover:opacity-100'
+        )}
+        onClick={handleCopyValue(node)}
+        type="button"
+        aria-label="Copy value"
+      >
+        <RiFileCopyLine className="text-subtle h-3 w-3" />
+      </button>
+      <div className="ml-auto flex items-baseline gap-1.5">
         {Boolean(typeText) && (
-          <span className="text-muted whitespace-nowrap font-mono text-xs capitalize">
+          <span className="text-muted min-w-0 whitespace-nowrap font-mono text-xs capitalize">
             {typeText}
           </span>
         )}
@@ -97,8 +72,4 @@ export function ValueRow({
       </div>
     </div>
   );
-}
-
-function getTypeLabel(node: ValueNode, override?: string): string {
-  return override ?? (Array.isArray(node.type) ? node.type.join(' | ') : node.type);
 }

--- a/ui/packages/components/src/SchemaViewer/rows/utils.ts
+++ b/ui/packages/components/src/SchemaViewer/rows/utils.ts
@@ -1,0 +1,62 @@
+import { STANDARD_EVENT_FIELDS } from '@inngest/components/constants';
+import { toast } from 'sonner';
+
+import type { SchemaNode, TypedNode } from '../types';
+
+export function collectAllExpandablePaths(node: SchemaNode): string[] {
+  const paths: string[] = [];
+
+  function traverse(n: SchemaNode) {
+    if (n.kind === 'object') {
+      paths.push(n.path);
+      n.children.forEach(traverse);
+    } else if (n.kind === 'array') {
+      paths.push(n.path);
+      traverse(n.element);
+    } else if (n.kind === 'tuple') {
+      paths.push(n.path);
+      n.elements.forEach(traverse);
+    }
+  }
+
+  // Start with children to avoid adding the current node's path
+  if (node.kind === 'object') {
+    node.children.forEach(traverse);
+  }
+
+  return paths;
+}
+
+export function getTypeLabel(node: TypedNode, override?: string): string {
+  const type = node.type ?? '';
+  return override ?? (Array.isArray(type) ? type.join(' | ') : type);
+}
+
+export const handleCopyValue = (node: SchemaNode) => {
+  return async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      // The path is formatted as "eventName.field.subfield..."
+      // We need to remove the event name prefix (which can contain dots)
+      // We do this by finding the first occurrence of a standard field after the event name
+      // Strategy: The path after the event name will always start with a dot followed by a field
+      let relativePath = node.path;
+
+      for (const field of STANDARD_EVENT_FIELDS) {
+        const pattern = `.${field}`;
+        const index = node.path.indexOf(pattern);
+        if (index !== -1) {
+          // Found a standard field, extract from this point (excluding the leading dot)
+          relativePath = node.path.substring(index + 1);
+          break;
+        }
+      }
+
+      await navigator.clipboard.writeText(relativePath);
+      toast.success('Path copied to clipboard');
+    } catch (err) {
+      console.error('Failed to copy:', err);
+      toast.error('Failed to copy to clipboard');
+    }
+  };
+};

--- a/ui/packages/components/src/SchemaViewer/types.ts
+++ b/ui/packages/components/src/SchemaViewer/types.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema7TypeName as JSONSchemaTypeName } from 'json-schema';
 
-export type SchemaNodeKind = 'array' | 'object' | 'tuple' | 'value';
+export type SchemaNodeKind = 'array' | 'object' | 'tuple' | 'value' | 'table';
 
 export interface BaseNode {
   kind: SchemaNodeKind;
@@ -15,6 +15,12 @@ export interface ArrayNode extends BaseNode {
 
 export interface ObjectNode extends BaseNode {
   kind: 'object';
+  type?: JSONSchemaTypeName | 'unknown' | string;
+  children: SchemaNode[];
+}
+
+export interface TableNode extends BaseNode {
+  kind: 'table';
   children: SchemaNode[];
 }
 
@@ -25,10 +31,14 @@ export interface TupleNode extends BaseNode {
 
 export interface ValueNode extends BaseNode {
   kind: 'value';
-  type: JSONSchemaTypeName | JSONSchemaTypeName[] | 'unknown';
+  type: JSONSchemaTypeName | JSONSchemaTypeName[] | 'unknown' | string;
 }
 
-export type SchemaNode = ArrayNode | ObjectNode | TupleNode | ValueNode;
+export interface TypedNode extends BaseNode {
+  type?: JSONSchemaTypeName | JSONSchemaTypeName[] | 'unknown' | string;
+}
+
+export type SchemaNode = ArrayNode | ObjectNode | TupleNode | ValueNode | TableNode;
 
 export type {
   JSONSchema7 as JSONSchema,


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

Add a Table Schemas section to the schema explorer to show table schemas.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

We have a bunch of new insights tables and their schemas are not very discoverable currently

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a static "Available Tables" section to the schema explorer with hardcoded schemas for `events`, `runs`, `steps`, `step_attempts`, and `extended_trace_spans`. Introduces a new `TableRow` component, refactors `ObjectRow` and `ValueRow` to share copy/type utilities via a new `utils.ts`, and widens `AdornmentContext`/`TypeContext` callback types from `ValueNode` to `TypedNode`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 56afc03b06117b7aeb1379fbe3a427896284515a.</sup>
<!-- /MENDRAL_SUMMARY -->