### PR TITLE
SYS-816: Change env var population to use 1passwd instead of Vercel

### DIFF
--- a/ui/apps/dashboard/README.md
+++ b/ui/apps/dashboard/README.md
@@ -12,7 +12,7 @@ Before being able to run the app for the first time, you need to follow the step
 
 - Set up the [Cloud monorepo](https://github.com/inngest/monorepo) and have all backend services running locally
 - [Node.js](https://nodejs.org/en/download/)
-- Join the company's Vercel account
+- Install 1Password Desktop App
 
 ### Instructions
 
@@ -21,9 +21,7 @@ Before being able to run the app for the first time, you need to follow the step
    [Corepack](https://nodejs.org/docs/latest-v18.x/api/corepack.html) by running
    `corepack enable; corepack prepare`
 3. Install dependencies by running `pnpm install`
-4. Link local project to our `ui` Vercel project by running `pnpm vercel link -p ui`
-   - Make sure the command prints out `Linked to inngest/ui` and not a `ui` project in your personal scope
-5. Download environment variables by running `pnpm env:pull`
+4. Setup local environment variables following [this guide](https://www.notion.so/inngest/Setup-env-local-for-development-351b64753bbd8068bceed9825558ec33?source=copy_link)
 
 ## Developing
 
@@ -83,32 +81,6 @@ $ pnpm format
 Staged files are automatically formatted when committing.
 
 We recommend using an [editor integration for Prettier](https://prettier.io/docs/en/editors.html).
-
-### Environment Variables
-
-Environment variables are managed with the [Vercel CLI](https://vercel.com/docs/cli/env). Use the
-following commands to manage them:
-
-```sh
-# Link the project on Vercel
-$ pnpm vercel link -p ui # and follow the steps
-
-# Download development environment variables for running the app locally
-$ pnpm env:pull
-
-# Add a new environment variable
-$ pnpm env:add
-
-# Remove an environment variable
-$ pnpm env:rm
-```
-
-Check the [Tanstack Start Documentation](https://tanstack.com/start/latest/docs/framework/react/overview)
-for more information.
-
-You should **never commit environment variables** to the repository. If you need to add a new
-environment variable, add it with the `pnpm env:add` command and then download it with the
-`pnpm env:pull` command.
 
 ### Sign In
 

--- a/ui/apps/dashboard/package.json
+++ b/ui/apps/dashboard/package.json
@@ -28,10 +28,7 @@
     "lint": "eslint src --report-unused-disable-directives --max-warnings 0",
     "test": "vitest run",
     "type-check": "tsc --noEmit",
-    "preinstall": "npx only-allow pnpm",
-    "env:pull": "npx vercel env pull",
-    "env:add": "npx vercel env add",
-    "env:rm": "npx vercel env rm"
+    "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {
     "@clerk/tanstack-react-start": "^0.29.1",


### PR DESCRIPTION
## Description

It makes no sense for us needing to have to

1. Create a Vercel account
2. Link it

in order to download local development env vars.

It's more reasonable to utilize 1Password to handle this considering that's an app everyone will have regardless of role.

Ref: https://1password.com/blog/1password-environments-env-files-public-beta

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Migrates local development environment variable setup from Vercel CLI to 1Password, removing the `env:*` npm scripts and updating the README to reference a Notion guide instead of inline Vercel instructions.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4b09da38e7e6524801eab98f6657d3dde259a91a.</sup>
<!-- /MENDRAL_SUMMARY -->