### PR TITLE
Add `alpha` cmd as a home for experimental CLI commands

### DIFF
--- a/cmd/alpha.go
+++ b/cmd/alpha.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/inngest/inngest/cmd/debug"
+	"github.com/urfave/cli/v3"
+)
+
+func alpha() *cli.Command {
+	return &cli.Command{
+		Name:  "alpha",
+		Usage: "experimental CLI commands",
+		Commands: []*cli.Command{
+			debug.Command(),
+		},
+	}
+}

--- a/cmd/alpha.go
+++ b/cmd/alpha.go
@@ -7,8 +7,9 @@ import (
 
 func alpha() *cli.Command {
 	return &cli.Command{
-		Name:  "alpha",
-		Usage: "experimental CLI commands",
+		Name:   "alpha",
+		Hidden: true,
+		Usage:  "experimental CLI commands",
 		Commands: []*cli.Command{
 			debug.Command(),
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/inngest/inngest/cmd/debug"
 	"github.com/inngest/inngest/cmd/devserver"
 	"github.com/inngest/inngest/cmd/start"
 	"github.com/inngest/inngest/cmd/version"
@@ -78,7 +77,7 @@ func execute() {
 			devserver.Command(),
 			version.Command(),
 			start.Command(),
-			debug.Command(),
+			alpha(),
 		},
 	}
 


### PR DESCRIPTION
## Description

We want to keep our exposed CLI commands to a list that are well used or have documents or examples showcasing their usage.

New experimental commands should live under the `alpha` cmd. This is inspired by `kubectl` on how it keeps unstable APIs.

The `debug` cmd now lives under `alpha` until we have a more usage samples of it.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Introduces an `alpha` hidden CLI command as a namespace for experimental/unstable commands, inspired by `kubectl alpha`. The `debug` command is moved under `alpha` instead of being a top-level command, keeping the public CLI surface clean.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit bfc29f96d77ddcc1d5ce76802ae6dc65e65ad94d.</sup>
<!-- /MENDRAL_SUMMARY -->