### PR TITLE
Checkpointing: Log step name for duplicate/failed step saves

### DIFF
--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -83,6 +84,12 @@ type checkpointer struct {
 
 func (c checkpointer) Metrics() MetricsProvider {
 	return c.MetricsProvider
+}
+
+func sanitizeLogValue(v string) string {
+	v = strings.ReplaceAll(v, "\n", "")
+	v = strings.ReplaceAll(v, "\r", "")
+	return v
 }
 
 // CheckpointSyncSteps handles the checkpointing of new steps via sync, HTTP-based functions
@@ -162,14 +169,15 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 				// async.  Therefore, we onl want to save state if we don't have a complete opcode,
 				// as all complete functions will never re-enter.
 				_, err := c.State.SaveStep(ctx, input.Metadata.ID, op.ID, []byte(output))
+				stepName := sanitizeLogValue(op.UserDefinedName())
 				if errors.Is(err, state.ErrDuplicateResponse) || errors.Is(err, state.ErrIdempotentResponse) {
 					// Ignore.
-					l.Warn("duplicate checkpoint step", "id", input.Metadata.ID, "name", op.UserDefinedName())
+					l.Warn("duplicate checkpoint step", "id", input.Metadata.ID, "name", stepName)
 					continue
 				}
 				if err != nil {
-					l.Error("error saving checkpointed step state", "name", op.UserDefinedName(), "error", err)
-					return fmt.Errorf("failed to save step %s (%s): %w", op.ID, op.UserDefinedName(), err)
+					l.Error("error saving checkpointed step state", "name", stepName, "error", err)
+					return fmt.Errorf("failed to save step %s (%s): %w", op.ID, stepName, err)
 				}
 			}
 

--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -164,12 +164,12 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 				_, err := c.State.SaveStep(ctx, input.Metadata.ID, op.ID, []byte(output))
 				if errors.Is(err, state.ErrDuplicateResponse) || errors.Is(err, state.ErrIdempotentResponse) {
 					// Ignore.
-					l.Warn("duplicate checkpoint step", "id", input.Metadata.ID)
+					l.Warn("duplicate checkpoint step", "id", input.Metadata.ID, "name", op.UserDefinedName())
 					continue
 				}
 				if err != nil {
-					l.Error("error saving checkpointed step state", "error", err)
-					return fmt.Errorf("failed to save step %s: %w", op.ID, err)
+					l.Error("error saving checkpointed step state", "name", op.UserDefinedName(), "error", err)
+					return fmt.Errorf("failed to save step %s (%s): %w", op.ID, op.UserDefinedName(), err)
 				}
 			}
 


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

Add step name to checkpointing failure logging.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

We want to know which step was duplicated/failed specifically when we log checkpointing failures.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `op.UserDefinedName()` to structured log fields and the error message for duplicate/failed step saves in the checkpoint sync path. A follow-up commit (480c947) strips `\n`/`\r` from the step name before logging, addressing a CodeQL log-injection finding.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 480c94754f5ff4580a4ce1264e22b3fe11ff56d2.</sup>
<!-- /MENDRAL_SUMMARY -->