### PR TITLE
refactor(queue): Make Producer configurable in Queue

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -604,7 +604,6 @@ func start(ctx context.Context, opts StartOpts) error {
 		runner.WithExecutionManager(dbcqrs),
 		runner.WithPauseManager(pauseMgr),
 		runner.WithStateManager(sm),
-		runner.WithRunnerQueue(rq),
 		runner.WithBatchManager(batcher),
 		runner.WithCronManager(croner),
 		runner.WithPublisher(pb),
@@ -614,7 +613,6 @@ func start(ctx context.Context, opts StartOpts) error {
 	// The devserver embeds the event API.
 	ds := NewService(opts, runner, dbcqrs, pb, stepLimitOverrides, stateSizeLimitOverrides, unshardedRc, hd, nil)
 	ds.State = sm
-	ds.Queue = rq
 	ds.Executor = exec
 	ds.SemaphoreManager = semaphores
 	ds.CronSyncer = croner
@@ -632,7 +630,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		Logger:         l,
 		Runner:         ds.Runner,
 		State:          ds.State,
-		Queue:          ds.Queue,
+		Queue:          rq,
 		EventHandler:   ds.HandleEvent,
 		Executor:       ds.Executor,
 		HistoryReader:  cqrsmanager.NewHistoryReader(adapter),
@@ -663,7 +661,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			AuthMiddleware:    authn.SigningKeyMiddleware(opts.SigningKey),
 			CachingMiddleware: caching,
 			FunctionReader:    ds.Data,
-			JobQueueReader:    ds.Queue.(queue.JobQueueReader),
+			JobQueueReader:    rq,
 			Executor:          ds.Executor,
 			Queue:             rq,
 			QueueShards:       shardRegistry,

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -26,7 +26,6 @@ import (
 	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/cron"
 	"github.com/inngest/inngest/pkg/execution/history"
-	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/runner"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/inngest"
@@ -35,9 +34,9 @@ import (
 	"github.com/inngest/inngest/pkg/pubsub"
 	"github.com/inngest/inngest/pkg/sdk"
 	"github.com/inngest/inngest/pkg/service"
+	itrace "github.com/inngest/inngest/pkg/telemetry/trace"
 	"github.com/inngest/inngest/pkg/update"
 	"github.com/inngest/inngest/pkg/util"
-	itrace "github.com/inngest/inngest/pkg/telemetry/trace"
 	"github.com/mattn/go-isatty"
 	"github.com/redis/rueidis"
 	"go.opentelemetry.io/otel/propagation"
@@ -89,7 +88,6 @@ type devserver struct {
 	// Runner stores the Runner
 	Runner           runner.Runner
 	State            state.Manager
-	Queue            queue.Queue
 	Executor         execution.Executor
 	SemaphoreManager constraintapi.SemaphoreManager
 	publisher        pubsub.Publisher

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -94,10 +94,10 @@ func WithSplitBatchPartitionByFunction(fn func(ctx context.Context, accountID uu
 // Note that this buffers in-memory using the defaults via [DefaultMaxBufferDuration] and
 // [DefaultMaxBufferSize].  to change these or disable buffering, use [WithBufferSettings]
 // or [WithoutBuffer].
-func NewRedisBatchManager(b *redis_state.BatchClient, q queue.QueueManager, opts ...RedisBatchManagerOpt) BatchManager {
+func NewRedisBatchManager(b *redis_state.BatchClient, producer queue.Producer, opts ...RedisBatchManagerOpt) BatchManager {
 	manager := &redisBatchManager{
 		b:                 b,
-		q:                 q,
+		producer:          producer,
 		sizeLimit:         defaultBatchSizeLimit,
 		idempotenceSetTTL: defaultEventIdempotenceSetTTL,
 		log:               logger.StdlibLogger(context.Background()),
@@ -114,8 +114,8 @@ func NewRedisBatchManager(b *redis_state.BatchClient, q queue.QueueManager, opts
 }
 
 type redisBatchManager struct {
-	b *redis_state.BatchClient
-	q queue.QueueManager
+	b        *redis_state.BatchClient
+	producer queue.Producer
 
 	// sizeLimit is the size limit that a batch can have
 	sizeLimit int
@@ -316,8 +316,8 @@ func (b *redisBatchManager) StartExecution(ctx context.Context, functionId uuid.
 
 // ScheduleExecution enqueues a job to run the batch job after the specified duration.
 func (b *redisBatchManager) ScheduleExecution(ctx context.Context, opts ScheduleBatchOpts) error {
-	if b.q == nil {
-		// No queue manager configured, skip scheduling (useful for tests)
+	if b.producer == nil {
+		// No queue producer configured, skip scheduling (useful for tests)
 		return nil
 	}
 
@@ -328,7 +328,7 @@ func (b *redisBatchManager) ScheduleExecution(ctx context.Context, opts Schedule
 	if b.splitBatchPartitionByFunction != nil && b.splitBatchPartitionByFunction(ctx, opts.AccountID) {
 		queueName = fmt.Sprintf("%s:%s", queue.KindScheduleBatch, opts.FunctionID)
 	}
-	err := b.q.Enqueue(ctx, queue.Item{
+	err := b.producer.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
 		GroupID:     uuid.New().String(),
 		WorkspaceID: opts.WorkspaceID,

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -94,10 +94,10 @@ func WithSplitBatchPartitionByFunction(fn func(ctx context.Context, accountID uu
 // Note that this buffers in-memory using the defaults via [DefaultMaxBufferDuration] and
 // [DefaultMaxBufferSize].  to change these or disable buffering, use [WithBufferSettings]
 // or [WithoutBuffer].
-func NewRedisBatchManager(b *redis_state.BatchClient, producer queue.Producer, opts ...RedisBatchManagerOpt) BatchManager {
+func NewRedisBatchManager(b *redis_state.BatchClient, q queue.Producer, opts ...RedisBatchManagerOpt) BatchManager {
 	manager := &redisBatchManager{
 		b:                 b,
-		producer:          producer,
+		q:                 q,
 		sizeLimit:         defaultBatchSizeLimit,
 		idempotenceSetTTL: defaultEventIdempotenceSetTTL,
 		log:               logger.StdlibLogger(context.Background()),
@@ -114,8 +114,8 @@ func NewRedisBatchManager(b *redis_state.BatchClient, producer queue.Producer, o
 }
 
 type redisBatchManager struct {
-	b        *redis_state.BatchClient
-	producer queue.Producer
+	b *redis_state.BatchClient
+	q queue.Producer
 
 	// sizeLimit is the size limit that a batch can have
 	sizeLimit int
@@ -316,7 +316,7 @@ func (b *redisBatchManager) StartExecution(ctx context.Context, functionId uuid.
 
 // ScheduleExecution enqueues a job to run the batch job after the specified duration.
 func (b *redisBatchManager) ScheduleExecution(ctx context.Context, opts ScheduleBatchOpts) error {
-	if b.producer == nil {
+	if b.q == nil {
 		// No queue producer configured, skip scheduling (useful for tests)
 		return nil
 	}
@@ -328,7 +328,7 @@ func (b *redisBatchManager) ScheduleExecution(ctx context.Context, opts Schedule
 	if b.splitBatchPartitionByFunction != nil && b.splitBatchPartitionByFunction(ctx, opts.AccountID) {
 		queueName = fmt.Sprintf("%s:%s", queue.KindScheduleBatch, opts.FunctionID)
 	}
-	err := b.producer.Enqueue(ctx, queue.Item{
+	err := b.q.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
 		GroupID:     uuid.New().String(),
 		WorkspaceID: opts.WorkspaceID,

--- a/pkg/execution/cron/manager.go
+++ b/pkg/execution/cron/manager.go
@@ -137,7 +137,7 @@ func NewManager(
 
 	return &manager{
 		shard: shard,
-		q:     q,
+		queue: q,
 		log:   log,
 		opt:   opt,
 	}
@@ -145,7 +145,7 @@ func NewManager(
 
 type manager struct {
 	shard queue.QueueShard
-	q     queue.Producer
+	queue queue.Producer
 
 	log logger.Logger
 	opt managerOpt
@@ -174,7 +174,7 @@ func (c *manager) Sync(ctx context.Context, ci CronItem) error {
 	at := time.Now()
 	jobID := ci.SyncID()
 
-	err := c.q.Enqueue(ctx, queue.Item{
+	err := c.queue.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
 		GroupID:     uuid.New().String(),
 		WorkspaceID: ci.WorkspaceID,
@@ -224,7 +224,7 @@ func (c *manager) EnqueueHealthCheck(ctx context.Context, ci CronItem) error {
 
 	l := c.log.With("action", "cron.manager.EnqueueHealthCheck", "queue", kind, "ci", ci)
 
-	err := c.q.Enqueue(ctx, queue.Item{
+	err := c.queue.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
 		GroupID:     uuid.New().String(),
 		Kind:        kind,
@@ -257,7 +257,7 @@ func (c *manager) EnqueueNextHealthCheck(ctx context.Context) error {
 
 	l := c.log.With("action", "cron.manager.EnqueueNextHealthCheck", "queue", kind, "now", now, "nextCheck", nextCheck)
 
-	err := c.q.Enqueue(ctx, queue.Item{
+	err := c.queue.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
 		GroupID:     uuid.New().String(),
 		Kind:        kind,
@@ -364,7 +364,7 @@ func (c *manager) ScheduleNext(ctx context.Context, ci CronItem) (*CronItem, err
 		queueName = fmt.Sprintf("%s:%s", queue.KindCron, ci.WorkspaceID)
 	}
 
-	err = c.q.Enqueue(ctx, queue.Item{
+	err = c.queue.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
 		GroupID:     uuid.New().String(),
 		WorkspaceID: ci.WorkspaceID,

--- a/pkg/execution/cron/manager.go
+++ b/pkg/execution/cron/manager.go
@@ -137,7 +137,7 @@ func NewManager(
 
 	return &manager{
 		shard: shard,
-		queue: q,
+		q:     q,
 		log:   log,
 		opt:   opt,
 	}
@@ -145,7 +145,7 @@ func NewManager(
 
 type manager struct {
 	shard queue.QueueShard
-	queue queue.Producer
+	q     queue.Producer
 
 	log logger.Logger
 	opt managerOpt
@@ -174,7 +174,7 @@ func (c *manager) Sync(ctx context.Context, ci CronItem) error {
 	at := time.Now()
 	jobID := ci.SyncID()
 
-	err := c.queue.Enqueue(ctx, queue.Item{
+	err := c.q.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
 		GroupID:     uuid.New().String(),
 		WorkspaceID: ci.WorkspaceID,
@@ -224,7 +224,7 @@ func (c *manager) EnqueueHealthCheck(ctx context.Context, ci CronItem) error {
 
 	l := c.log.With("action", "cron.manager.EnqueueHealthCheck", "queue", kind, "ci", ci)
 
-	err := c.queue.Enqueue(ctx, queue.Item{
+	err := c.q.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
 		GroupID:     uuid.New().String(),
 		Kind:        kind,
@@ -257,7 +257,7 @@ func (c *manager) EnqueueNextHealthCheck(ctx context.Context) error {
 
 	l := c.log.With("action", "cron.manager.EnqueueNextHealthCheck", "queue", kind, "now", now, "nextCheck", nextCheck)
 
-	err := c.queue.Enqueue(ctx, queue.Item{
+	err := c.q.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
 		GroupID:     uuid.New().String(),
 		Kind:        kind,
@@ -364,7 +364,7 @@ func (c *manager) ScheduleNext(ctx context.Context, ci CronItem) (*CronItem, err
 		queueName = fmt.Sprintf("%s:%s", queue.KindCron, ci.WorkspaceID)
 	}
 
-	err = c.queue.Enqueue(ctx, queue.Item{
+	err = c.q.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
 		GroupID:     uuid.New().String(),
 		WorkspaceID: ci.WorkspaceID,

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -629,11 +629,6 @@ func (s *svc) handleEagerCancelFinishTimeout(ctx context.Context, c cqrs.Cancell
 	}
 
 	// timeout was extended, requeue eager cancellation.
-	qm, ok := s.queue.(queue.QueueManager)
-	if !ok {
-		l.Error("queue does not conform to queue manager")
-		return nil
-	}
 	requeueAt := jobStarteddAt.Add(*timeout)
 	// Enqueue a new job in the future for when the timeout expires to reprocess the eager cancellation.
 	jobID := ""
@@ -644,7 +639,7 @@ func (s *svc) handleEagerCancelFinishTimeout(ctx context.Context, c cqrs.Cancell
 	}
 	jobID = fmt.Sprintf("%s:%s", "finish-timeout-extended", jobID)
 	item.JobID = &jobID
-	err = qm.Enqueue(ctx, item, requeueAt, queue.EnqueueOpts{})
+	err = s.queue.Enqueue(ctx, item, requeueAt, queue.EnqueueOpts{})
 	// Ignore if the system job was already requeued.
 	if err != nil && !errors.Is(err, queue.ErrQueueItemExists) {
 		return err
@@ -715,11 +710,6 @@ func (s *svc) handleEagerCancelStartTimeout(ctx context.Context, c cqrs.Cancella
 		})
 	}
 	// timeout was extended, requeue eager cancellation.
-	qm, ok := s.queue.(queue.QueueManager)
-	if !ok {
-		l.Error("queue does not conform to queue manager")
-		return nil
-	}
 	requeueAt := jobEnqueuedAt.Add(*timeout)
 	// Enqueue a new job in the future for when the timeout expires to reprocess the eager cancellation.
 	jobID := ""
@@ -730,7 +720,7 @@ func (s *svc) handleEagerCancelStartTimeout(ctx context.Context, c cqrs.Cancella
 	}
 	jobID = fmt.Sprintf("%s:%s", "start-timeout-extended", jobID)
 	item.JobID = &jobID
-	err = qm.Enqueue(ctx, item, requeueAt, queue.EnqueueOpts{})
+	err = s.queue.Enqueue(ctx, item, requeueAt, queue.EnqueueOpts{})
 	// Ignore if the system job was already requeued.
 	if err != nil && !errors.Is(err, queue.ErrQueueItemExists) {
 		return err
@@ -846,17 +836,12 @@ func (s *svc) handleEagerCancelBulkRun(ctx context.Context, c cqrs.Cancellation)
 		from = *c.StartedAfter
 	}
 
-	qm, ok := s.queue.(queue.QueueManager)
-	if !ok {
-		return fmt.Errorf("expected queue manager for cancellation")
-	}
-
 	shard, err := s.shards.Resolve(ctx, c.AccountID, c.QueueName)
 	if err != nil {
 		return fmt.Errorf("error selecting shard for cancellation: %w", err)
 	}
 
-	items, err := qm.ItemsByPartition(ctx, shard, queue.Scope{
+	items, err := shard.ItemsByPartition(ctx, queue.Scope{
 		AccountID:  c.AccountID,
 		EnvID:      c.WorkspaceID,
 		FunctionID: c.FunctionID,

--- a/pkg/execution/queue/enqueue.go
+++ b/pkg/execution/queue/enqueue.go
@@ -19,7 +19,7 @@ const (
 // Enqueue adds an item to the queue to be processed at the given time.
 // TODO: Lift this function and the queue interface to a higher level, so that it's disconnected from the
 // concrete Redis implementation.
-func (q *queueProcessor) Enqueue(ctx context.Context, item Item, at time.Time, opts EnqueueOpts) error {
+func (q *QueueProducer) Enqueue(ctx context.Context, item Item, at time.Time, opts EnqueueOpts) error {
 	l := logger.StdlibLogger(ctx)
 
 	// propagate

--- a/pkg/execution/queue/enqueue.go
+++ b/pkg/execution/queue/enqueue.go
@@ -19,7 +19,7 @@ const (
 // Enqueue adds an item to the queue to be processed at the given time.
 // TODO: Lift this function and the queue interface to a higher level, so that it's disconnected from the
 // concrete Redis implementation.
-func (q *QueueProducer) Enqueue(ctx context.Context, item Item, at time.Time, opts EnqueueOpts) error {
+func (q *queueProducer) Enqueue(ctx context.Context, item Item, at time.Time, opts EnqueueOpts) error {
 	l := logger.StdlibLogger(ctx)
 
 	// propagate
@@ -75,7 +75,7 @@ func (q *QueueProducer) Enqueue(ctx context.Context, item Item, at time.Time, op
 		qi.AtMS -= factor
 	}
 
-	ctx, span := q.ConditionalTracer.NewSpan(ctx, "queue.Enqueue.select_shard", TraceScopeFromQueueItem(qi, opts.ForceQueueShardName))
+	ctx, span := q.conditionalTracer.NewSpan(ctx, "queue.Enqueue.select_shard", TraceScopeFromQueueItem(qi, opts.ForceQueueShardName))
 	shard, err := q.selectShard(ctx, opts.ForceQueueShardName, qi)
 	span.End()
 	if err != nil {

--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -446,6 +446,7 @@ type QueueOptions struct {
 	PeekEWMALen int
 	// queueKindMapping stores a map of job kind => queue names
 	queueKindMapping        map[string]string
+	queueProducer           Producer
 	disableFifoForFunctions map[string]struct{}
 	disableFifoForAccounts  map[string]struct{}
 	peekSizeForFunctions    map[string]int64
@@ -599,6 +600,12 @@ func WithInstrumentInterval(t time.Duration) QueueOpt {
 func WithEnableJobPromotion(enable bool) QueueOpt {
 	return func(q *QueueOptions) {
 		q.enableJobPromotion = enable
+	}
+}
+
+func WithQueueProducer(producer Producer) QueueOpt {
+	return func(q *QueueOptions) {
+		q.queueProducer = producer
 	}
 }
 

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -68,12 +68,13 @@ func New(
 		quit:         make(chan error, o.numWorkers),
 
 		shards: shards,
-		queueProducer: NewProducer(shards, ProducerOpts{
-			clock:              o.Clock,
-			queueKindMapping:   o.queueKindMapping,
-			enableJobPromotion: o.enableJobPromotion,
-			conditionalTracer:  o.ConditionalTracer,
-		}),
+		queueProducer: NewProducer(
+			shards,
+			WithProducerClock(o.Clock),
+			WithProducerKindToQueueMapping(o.queueKindMapping),
+			WithProducerJobPromotion(o.enableJobPromotion),
+			WithProducerConditionalTracer(o.ConditionalTracer),
+		),
 
 		peekSizeCache: ccache.New(ccache.Configure[int64]().MaxSize(50_000)),
 
@@ -168,10 +169,6 @@ func (q *queueProcessor) GetShadowContinuations() map[string]ShadowContinuation 
 	defer q.shadowContinuesLock.Unlock()
 
 	return q.shadowContinues
-}
-
-func (q *queueProcessor) QueueProducer() Producer {
-	return q.queueProducer
 }
 
 func (q *queueProcessor) ClearShadowContinuations() {

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -68,6 +68,12 @@ func New(
 		quit:         make(chan error, o.numWorkers),
 
 		shards: shards,
+		queueProducer: NewProducer(shards, ProducerOpts{
+			clock:              o.Clock,
+			queueKindMapping:   o.queueKindMapping,
+			enableJobPromotion: o.enableJobPromotion,
+			conditionalTracer:  o.ConditionalTracer,
+		}),
 
 		peekSizeCache: ccache.New(ccache.Configure[int64]().MaxSize(50_000)),
 
@@ -86,6 +92,9 @@ func New(
 			return nil, fmt.Errorf("No shards found for configured shard group: %s", o.runMode.ShardGroup)
 		}
 	}
+	if o.queueProducer != nil {
+		qp.queueProducer = o.queueProducer
+	}
 
 	qp.configureQueueRoles()
 
@@ -101,6 +110,8 @@ type queueProcessor struct {
 	// shards owns the {shards map, selector, primary} trio. Topology can be
 	// mutated at runtime via shards.SetPrimary.
 	shards QueueShardRegistry
+
+	queueProducer Producer
 
 	// quit is a channel that any method can send on to trigger termination
 	// of the Run loop.  This typically accepts an error, but a nil error
@@ -296,6 +307,11 @@ func (q *queueProcessor) Requeue(ctx context.Context, shard QueueShard, i QueueI
 // RequeueByJobID implements QueueManager.
 func (q *queueProcessor) RequeueByJobID(ctx context.Context, shard QueueShard, jobID string, at time.Time) error {
 	return shard.RequeueByJobID(ctx, jobID, at)
+}
+
+// Enqueue implements QueueManager.
+func (q *queueProcessor) Enqueue(ctx context.Context, item Item, at time.Time, opts EnqueueOpts) error {
+	return q.queueProducer.Enqueue(ctx, item, at, opts)
 }
 
 // TotalSystemQueueDepth implements QueueManager.

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -170,6 +170,10 @@ func (q *queueProcessor) GetShadowContinuations() map[string]ShadowContinuation 
 	return q.shadowContinues
 }
 
+func (q *queueProcessor) QueueProducer() Producer {
+	return q.queueProducer
+}
+
 func (q *queueProcessor) ClearShadowContinuations() {
 	q.shadowContinuesLock.Lock()
 	defer q.shadowContinuesLock.Unlock()

--- a/pkg/execution/queue/processor_test.go
+++ b/pkg/execution/queue/processor_test.go
@@ -4,11 +4,36 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 )
+
+type mockProducer struct {
+	called atomic.Bool
+}
+
+func (m *mockProducer) Enqueue(context.Context, Item, time.Time, EnqueueOpts) error {
+	m.called.Store(true)
+	return nil
+}
+
+func TestProcessorWithQueueProducerOverridesDefaultProducer(t *testing.T) {
+	ctx := context.Background()
+	shard := &mockShardForIterator{name: "shard-a"}
+	registry, err := NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+
+	producer := &mockProducer{}
+	q, err := New(ctx, "test", registry, WithQueueProducer(producer))
+	require.NoError(t, err)
+
+	err = q.Enqueue(ctx, Item{}, time.Now(), EnqueueOpts{})
+	require.NoError(t, err)
+	require.True(t, producer.called.Load())
+}
 
 func TestProcessorAccountShardReadsResolveByDefault(t *testing.T) {
 	ctx := context.Background()

--- a/pkg/execution/queue/producer.go
+++ b/pkg/execution/queue/producer.go
@@ -1,0 +1,41 @@
+package queue
+
+import (
+	"github.com/inngest/inngest/pkg/telemetry/trace"
+	"github.com/jonboulle/clockwork"
+)
+
+type ProducerOpts struct {
+	clock              clockwork.Clock
+	queueKindMapping   map[string]string
+	enableJobPromotion bool
+	conditionalTracer  trace.ConditionalTracer
+}
+
+// QueueProducer implements the Producer interface, providing the ability to enqueue
+// and requeue items.
+type QueueProducer struct {
+	clock              clockwork.Clock
+	queueKindMapping   map[string]string
+	enableJobPromotion bool
+	ConditionalTracer  trace.ConditionalTracer
+
+	shards ShardRegistry
+}
+
+func NewProducer(
+	shards ShardRegistry,
+	opts ProducerOpts,
+) *QueueProducer {
+	return &QueueProducer{
+		clock:              opts.clock,
+		queueKindMapping:   opts.queueKindMapping,
+		enableJobPromotion: opts.enableJobPromotion,
+		ConditionalTracer:  opts.conditionalTracer,
+		shards:             shards,
+	}
+}
+
+func (q *QueueProducer) Clock() clockwork.Clock {
+	return q.clock
+}

--- a/pkg/execution/queue/producer.go
+++ b/pkg/execution/queue/producer.go
@@ -5,37 +5,59 @@ import (
 	"github.com/jonboulle/clockwork"
 )
 
-type ProducerOpts struct {
+// queueProducer implements the Producer interface, providing the ability to enqueue
+// and requeue items.
+type queueProducer struct {
 	clock              clockwork.Clock
 	queueKindMapping   map[string]string
 	enableJobPromotion bool
 	conditionalTracer  trace.ConditionalTracer
-}
-
-// QueueProducer implements the Producer interface, providing the ability to enqueue
-// and requeue items.
-type QueueProducer struct {
-	clock              clockwork.Clock
-	queueKindMapping   map[string]string
-	enableJobPromotion bool
-	ConditionalTracer  trace.ConditionalTracer
 
 	shards ShardRegistry
 }
 
-func NewProducer(
-	shards ShardRegistry,
-	opts ProducerOpts,
-) *QueueProducer {
-	return &QueueProducer{
-		clock:              opts.clock,
-		queueKindMapping:   opts.queueKindMapping,
-		enableJobPromotion: opts.enableJobPromotion,
-		ConditionalTracer:  opts.conditionalTracer,
-		shards:             shards,
+type ProducerOpt func(*queueProducer)
+
+func WithProducerClock(clock clockwork.Clock) ProducerOpt {
+	return func(q *queueProducer) {
+		q.clock = clock
 	}
 }
 
-func (q *QueueProducer) Clock() clockwork.Clock {
+func WithProducerKindToQueueMapping(mapping map[string]string) ProducerOpt {
+	return func(q *queueProducer) {
+		q.queueKindMapping = mapping
+	}
+}
+
+func WithProducerJobPromotion(enable bool) ProducerOpt {
+	return func(q *queueProducer) {
+		q.enableJobPromotion = enable
+	}
+}
+
+func WithProducerConditionalTracer(tracer trace.ConditionalTracer) ProducerOpt {
+	return func(q *queueProducer) {
+		q.conditionalTracer = tracer
+	}
+}
+
+func NewProducer(
+	shards ShardRegistry,
+	opts ...ProducerOpt,
+) Producer {
+	q := &queueProducer{
+		clock:             clockwork.NewRealClock(),
+		conditionalTracer: trace.NoopConditionalTracer(),
+		shards:            shards,
+	}
+	for _, opt := range opts {
+		opt(q)
+	}
+
+	return q
+}
+
+func (q *queueProducer) Clock() clockwork.Clock {
 	return q.clock
 }

--- a/pkg/execution/queue/shard.go
+++ b/pkg/execution/queue/shard.go
@@ -21,7 +21,7 @@ type QueueShard interface {
 	ShardAssignmentConfig() ShardAssignmentConfig
 }
 
-func (q *queueProcessor) defaultQueueNameForItemKind(kind string) *string {
+func (q *QueueProducer) defaultQueueNameForItemKind(kind string) *string {
 	var queueName *string
 	if name, ok := q.queueKindMapping[kind]; ok {
 		queueName = &name
@@ -29,14 +29,14 @@ func (q *queueProcessor) defaultQueueNameForItemKind(kind string) *string {
 	return queueName
 }
 
-func (q *queueProcessor) selectShard(ctx context.Context, shardName string, qi QueueItem) (QueueShard, error) {
+func (q *QueueProducer) selectShard(ctx context.Context, shardName string, qi QueueItem) (QueueShard, error) {
 	l := logger.StdlibLogger(ctx)
 
 	// If the caller wants us to enqueue the job to a specific queue shard, use that.
 	if shardName != "" {
 		shard, err := q.shards.ByName(shardName)
 		if err != nil {
-			return q.Shard(), fmt.Errorf("tried to force invalid queue shard %q", shardName)
+			return nil, fmt.Errorf("tried to force invalid queue shard %q", shardName)
 		}
 		return shard, nil
 	}
@@ -49,7 +49,7 @@ func (q *queueProcessor) selectShard(ctx context.Context, shardName string, qi Q
 	selected, err := q.shards.Resolve(ctx, qi.Data.Identifier.AccountID, queueItemKind)
 	if err != nil {
 		l.Error("error selecting shard", "error", err, "item", qi)
-		return q.Shard(), fmt.Errorf("could not select shard: %w", err)
+		return nil, fmt.Errorf("could not select shard: %w", err)
 	}
 	return selected, nil
 }

--- a/pkg/execution/queue/shard.go
+++ b/pkg/execution/queue/shard.go
@@ -21,7 +21,7 @@ type QueueShard interface {
 	ShardAssignmentConfig() ShardAssignmentConfig
 }
 
-func (q *QueueProducer) defaultQueueNameForItemKind(kind string) *string {
+func (q *queueProducer) defaultQueueNameForItemKind(kind string) *string {
 	var queueName *string
 	if name, ok := q.queueKindMapping[kind]; ok {
 		queueName = &name
@@ -29,7 +29,7 @@ func (q *QueueProducer) defaultQueueNameForItemKind(kind string) *string {
 	return queueName
 }
 
-func (q *QueueProducer) selectShard(ctx context.Context, shardName string, qi QueueItem) (QueueShard, error) {
+func (q *queueProducer) selectShard(ctx context.Context, shardName string, qi QueueItem) (QueueShard, error) {
 	l := logger.StdlibLogger(ctx)
 
 	// If the caller wants us to enqueue the job to a specific queue shard, use that.

--- a/pkg/execution/queue/shard.go
+++ b/pkg/execution/queue/shard.go
@@ -36,7 +36,7 @@ func (q *queueProducer) selectShard(ctx context.Context, shardName string, qi Qu
 	if shardName != "" {
 		shard, err := q.shards.ByName(shardName)
 		if err != nil {
-			return nil, fmt.Errorf("tried to force invalid queue shard %q", shardName)
+			return q.shards.Primary(), fmt.Errorf("tried to force invalid queue shard %q", shardName)
 		}
 		return shard, nil
 	}
@@ -49,7 +49,7 @@ func (q *queueProducer) selectShard(ctx context.Context, shardName string, qi Qu
 	selected, err := q.shards.Resolve(ctx, qi.Data.Identifier.AccountID, queueItemKind)
 	if err != nil {
 		l.Error("error selecting shard", "error", err, "item", qi)
-		return nil, fmt.Errorf("could not select shard: %w", err)
+		return q.shards.Primary(), nil
 	}
 	return selected, nil
 }

--- a/pkg/execution/queue/shard.go
+++ b/pkg/execution/queue/shard.go
@@ -36,7 +36,7 @@ func (q *queueProducer) selectShard(ctx context.Context, shardName string, qi Qu
 	if shardName != "" {
 		shard, err := q.shards.ByName(shardName)
 		if err != nil {
-			return q.shards.Primary(), fmt.Errorf("tried to force invalid queue shard %q", shardName)
+			return nil, fmt.Errorf("tried to force invalid queue shard %q", shardName)
 		}
 		return shard, nil
 	}
@@ -49,7 +49,7 @@ func (q *queueProducer) selectShard(ctx context.Context, shardName string, qi Qu
 	selected, err := q.shards.Resolve(ctx, qi.Data.Identifier.AccountID, queueItemKind)
 	if err != nil {
 		l.Error("error selecting shard", "error", err, "item", qi)
-		return q.shards.Primary(), nil
+		return nil, fmt.Errorf("could not select shard: %w", err)
 	}
 	return selected, nil
 }

--- a/pkg/execution/runner/runner.go
+++ b/pkg/execution/runner/runner.go
@@ -23,7 +23,6 @@ import (
 	"github.com/inngest/inngest/pkg/execution/cron"
 	"github.com/inngest/inngest/pkg/execution/executor"
 	"github.com/inngest/inngest/pkg/execution/pauses"
-	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/expressions"
@@ -86,12 +85,6 @@ func WithStateManager(sm state.Manager) func(s *svc) {
 	}
 }
 
-func WithRunnerQueue(q queue.Queue) func(s *svc) {
-	return func(s *svc) {
-		s.queue = q
-	}
-}
-
 func WithBatchManager(b batch.BatchManager) func(s *svc) {
 	return func(s *svc) {
 		s.batcher = b
@@ -140,8 +133,6 @@ type svc struct {
 	state state.Manager
 	// pauses allows management of pauses, used to resume function runs on matching events.
 	pm pauses.Manager
-	// queue allows the scheduling of new functions.
-	queue queue.Queue
 	// batcher handles batch operations
 	batcher batch.BatchManager
 	// croner handles cron operations
@@ -165,13 +156,6 @@ func (s *svc) Pre(ctx context.Context) error {
 
 	if s.state == nil {
 		s.state, err = s.config.State.Service.Concrete.SingleClusterManager(ctx, nil)
-		if err != nil {
-			return err
-		}
-	}
-
-	if s.queue == nil {
-		s.queue, err = s.config.Queue.Service.Concrete.Queue()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

Make Producer configurable in Queue.

A producer can be provided to the Queue as an option to override the default producer.

## Motivation

Will be used in Cloud to pass a different producer implementation exposed over a grpc proxy.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
