### PR TITLE
Add security email

### DIFF
--- a/ui/apps/dashboard/src/gql/gql.ts
+++ b/ui/apps/dashboard/src/gql/gql.ts
@@ -155,6 +155,8 @@ type Documents = {
     "\n  query GetIngestKey($environmentID: ID!, $keyID: ID!) {\n    environment: workspace(id: $environmentID) {\n      ingestKey(id: $keyID) {\n        id\n        name\n        createdAt\n        presharedKey\n        url\n        filter {\n          type\n          ips\n          events\n        }\n        metadata\n        source\n      }\n    }\n  }\n": typeof types.GetIngestKeyDocument,
     "\n  mutation CreateWebhook($input: NewIngestKey!) {\n    key: createIngestKey(input: $input) {\n      id\n      url\n    }\n  }\n": typeof types.CreateWebhookDocument,
     "\n  mutation CompleteAWSMarketplaceSetup($input: AWSMarketplaceSetupInput!) {\n    completeAWSMarketplaceSetup(input: $input) {\n      message\n    }\n  }\n": typeof types.CompleteAwsMarketplaceSetupDocument,
+    "\n  query SecurityEmailSettings {\n    account {\n      securityEmail\n    }\n  }\n": typeof types.SecurityEmailSettingsDocument,
+    "\n  mutation UpdateSecurityEmail($input: UpdateAccount!) {\n    account: updateAccount(input: $input) {\n      securityEmail\n    }\n  }\n": typeof types.UpdateSecurityEmailDocument,
     "\n  query GetAccountSupportInfo {\n    account {\n      id\n      plan {\n        id\n        name\n        amount\n        features\n      }\n    }\n  }\n": typeof types.GetAccountSupportInfoDocument,
 };
 const documents: Documents = {
@@ -299,6 +301,8 @@ const documents: Documents = {
     "\n  query GetIngestKey($environmentID: ID!, $keyID: ID!) {\n    environment: workspace(id: $environmentID) {\n      ingestKey(id: $keyID) {\n        id\n        name\n        createdAt\n        presharedKey\n        url\n        filter {\n          type\n          ips\n          events\n        }\n        metadata\n        source\n      }\n    }\n  }\n": types.GetIngestKeyDocument,
     "\n  mutation CreateWebhook($input: NewIngestKey!) {\n    key: createIngestKey(input: $input) {\n      id\n      url\n    }\n  }\n": types.CreateWebhookDocument,
     "\n  mutation CompleteAWSMarketplaceSetup($input: AWSMarketplaceSetupInput!) {\n    completeAWSMarketplaceSetup(input: $input) {\n      message\n    }\n  }\n": types.CompleteAwsMarketplaceSetupDocument,
+    "\n  query SecurityEmailSettings {\n    account {\n      securityEmail\n    }\n  }\n": types.SecurityEmailSettingsDocument,
+    "\n  mutation UpdateSecurityEmail($input: UpdateAccount!) {\n    account: updateAccount(input: $input) {\n      securityEmail\n    }\n  }\n": types.UpdateSecurityEmailDocument,
     "\n  query GetAccountSupportInfo {\n    account {\n      id\n      plan {\n        id\n        name\n        amount\n        features\n      }\n    }\n  }\n": types.GetAccountSupportInfoDocument,
 };
 
@@ -880,6 +884,14 @@ export function graphql(source: "\n  mutation CreateWebhook($input: NewIngestKey
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "\n  mutation CompleteAWSMarketplaceSetup($input: AWSMarketplaceSetupInput!) {\n    completeAWSMarketplaceSetup(input: $input) {\n      message\n    }\n  }\n"): (typeof documents)["\n  mutation CompleteAWSMarketplaceSetup($input: AWSMarketplaceSetupInput!) {\n    completeAWSMarketplaceSetup(input: $input) {\n      message\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query SecurityEmailSettings {\n    account {\n      securityEmail\n    }\n  }\n"): (typeof documents)["\n  query SecurityEmailSettings {\n    account {\n      securityEmail\n    }\n  }\n"];
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  mutation UpdateSecurityEmail($input: UpdateAccount!) {\n    account: updateAccount(input: $input) {\n      securityEmail\n    }\n  }\n"): (typeof documents)["\n  mutation UpdateSecurityEmail($input: UpdateAccount!) {\n    account: updateAccount(input: $input) {\n      securityEmail\n    }\n  }\n"];
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/ui/apps/dashboard/src/gql/graphql.ts
+++ b/ui/apps/dashboard/src/gql/graphql.ts
@@ -51,7 +51,7 @@ export type Scalars = {
 export type ApiKey = {
   __typename?: 'APIKey';
   createdAt: Scalars['Time']['output'];
-  env?: Maybe<Workspace>;
+  env: Maybe<Workspace>;
   id: Scalars['UUID']['output'];
   maskedKey: Scalars['String']['output'];
   name: Scalars['String']['output'];
@@ -104,6 +104,7 @@ export type Account = {
   plan: Maybe<BillingPlan>;
   quickSearch: QuickSearchResults;
   search: SearchResults;
+  securityEmail: Maybe<Scalars['String']['output']>;
   status: Scalars['String']['output'];
   subscription: Maybe<BillingSubscription>;
   updatedAt: Scalars['Time']['output'];
@@ -2268,6 +2269,7 @@ export type UpdateApiKeyInput = {
 export type UpdateAccount = {
   billingEmail?: InputMaybe<Scalars['String']['input']>;
   name?: InputMaybe<Scalars['String']['input']>;
+  securityEmail?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type UpdateIngestKey = {
@@ -2688,7 +2690,7 @@ export type CreateApiKeyMutationVariables = Exact<{
 }>;
 
 
-export type CreateApiKeyMutation = { __typename?: 'Mutation', createAPIKey: { __typename?: 'APIKeyCreateResult', plaintextKey: string, apiKey: { __typename?: 'APIKey', id: string, name: string, createdAt: string, maskedKey: string, env?: { __typename?: 'Workspace', id: string, name: string } | null } } };
+export type CreateApiKeyMutation = { __typename?: 'Mutation', createAPIKey: { __typename?: 'APIKeyCreateResult', plaintextKey: string, apiKey: { __typename?: 'APIKey', id: string, name: string, createdAt: string, maskedKey: string, env: { __typename?: 'Workspace', id: string, name: string } | null } } };
 
 export type DeleteApiKeyMutationVariables = Exact<{
   id: Scalars['UUID']['input'];
@@ -2709,7 +2711,7 @@ export type GetApiKeysQueryVariables = Exact<{
 }>;
 
 
-export type GetApiKeysQuery = { __typename?: 'Query', account: { __typename?: 'Account', apiKeys: Array<{ __typename?: 'APIKey', id: string, name: string, createdAt: string, maskedKey: string, env?: { __typename?: 'Workspace', id: string, name: string, slug: string } | null }> } };
+export type GetApiKeysQuery = { __typename?: 'Query', account: { __typename?: 'Account', apiKeys: Array<{ __typename?: 'APIKey', id: string, name: string, createdAt: string, maskedKey: string, env: { __typename?: 'Workspace', id: string, name: string, slug: string } | null }> } };
 
 export type AchiveAppMutationVariables = Exact<{
   appID: Scalars['UUID']['input'];
@@ -3798,6 +3800,18 @@ export type CompleteAwsMarketplaceSetupMutationVariables = Exact<{
 
 export type CompleteAwsMarketplaceSetupMutation = { __typename?: 'Mutation', completeAWSMarketplaceSetup: { __typename?: 'AWSMarketplaceSetupResponse', message: string } | null };
 
+export type SecurityEmailSettingsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type SecurityEmailSettingsQuery = { __typename?: 'Query', account: { __typename?: 'Account', securityEmail: string | null } };
+
+export type UpdateSecurityEmailMutationVariables = Exact<{
+  input: UpdateAccount;
+}>;
+
+
+export type UpdateSecurityEmailMutation = { __typename?: 'Mutation', account: { __typename?: 'Account', securityEmail: string | null } };
+
 export type GetAccountSupportInfoQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -3944,4 +3958,6 @@ export const GetFunctionPauseStateDocument = {"kind":"Document","definitions":[{
 export const GetIngestKeyDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetIngestKey"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"environmentID"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"keyID"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"environment"},"name":{"kind":"Name","value":"workspace"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"environmentID"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"ingestKey"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"keyID"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"createdAt"}},{"kind":"Field","name":{"kind":"Name","value":"presharedKey"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"filter"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"type"}},{"kind":"Field","name":{"kind":"Name","value":"ips"}},{"kind":"Field","name":{"kind":"Name","value":"events"}}]}},{"kind":"Field","name":{"kind":"Name","value":"metadata"}},{"kind":"Field","name":{"kind":"Name","value":"source"}}]}}]}}]}}]} as unknown as DocumentNode<GetIngestKeyQuery, GetIngestKeyQueryVariables>;
 export const CreateWebhookDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CreateWebhook"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"NewIngestKey"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"key"},"name":{"kind":"Name","value":"createIngestKey"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"url"}}]}}]}}]} as unknown as DocumentNode<CreateWebhookMutation, CreateWebhookMutationVariables>;
 export const CompleteAwsMarketplaceSetupDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"CompleteAWSMarketplaceSetup"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"AWSMarketplaceSetupInput"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"completeAWSMarketplaceSetup"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"message"}}]}}]}}]} as unknown as DocumentNode<CompleteAwsMarketplaceSetupMutation, CompleteAwsMarketplaceSetupMutationVariables>;
+export const SecurityEmailSettingsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"SecurityEmailSettings"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"account"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"securityEmail"}}]}}]}}]} as unknown as DocumentNode<SecurityEmailSettingsQuery, SecurityEmailSettingsQueryVariables>;
+export const UpdateSecurityEmailDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"UpdateSecurityEmail"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"UpdateAccount"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","alias":{"kind":"Name","value":"account"},"name":{"kind":"Name","value":"updateAccount"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"securityEmail"}}]}}]}}]} as unknown as DocumentNode<UpdateSecurityEmailMutation, UpdateSecurityEmailMutationVariables>;
 export const GetAccountSupportInfoDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetAccountSupportInfo"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"account"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"plan"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"amount"}},{"kind":"Field","name":{"kind":"Name","value":"features"}}]}}]}}]}}]} as unknown as DocumentNode<GetAccountSupportInfoQuery, GetAccountSupportInfoQueryVariables>;

--- a/ui/apps/dashboard/src/routes/_authed/settings/organization/$.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/settings/organization/$.tsx
@@ -1,5 +1,32 @@
-import { OrganizationProfile } from '@clerk/tanstack-react-start';
+import { useEffect, useState, type FormEvent } from 'react';
+import {
+  OrganizationProfile,
+  useOrganization,
+} from '@clerk/tanstack-react-start';
+import { Alert } from '@inngest/components/Alert';
+import { Button } from '@inngest/components/Button';
+import { Input } from '@inngest/components/Forms/Input';
 import { createFileRoute, useLocation } from '@tanstack/react-router';
+import { toast } from 'sonner';
+import { useMutation, useQuery } from 'urql';
+
+import { graphql } from '@/gql';
+
+const SecurityEmailSettingsDocument = graphql(`
+  query SecurityEmailSettings {
+    account {
+      securityEmail
+    }
+  }
+`);
+
+const UpdateSecurityEmailDocument = graphql(`
+  mutation UpdateSecurityEmail($input: UpdateAccount!) {
+    account: updateAccount(input: $input) {
+      securityEmail
+    }
+  }
+`);
 
 export const Route = createFileRoute('/_authed/settings/organization/$')({
   component: OrganizationSettingsPage,
@@ -7,6 +34,9 @@ export const Route = createFileRoute('/_authed/settings/organization/$')({
 
 function OrganizationSettingsPage() {
   const location = useLocation();
+  const isBaseOrganizationPage =
+    location.pathname === '/settings/organization' ||
+    location.pathname === '/settings/organization/';
 
   return (
     <div className="flex w-full flex-col justify-start">
@@ -25,6 +55,96 @@ function OrganizationSettingsPage() {
           },
         }}
       />
+      {isBaseOrganizationPage && <SecurityEmailSettings />}
+    </div>
+  );
+}
+
+function SecurityEmailSettings() {
+  const [{ data, error, fetching }, refetch] = useQuery({
+    query: SecurityEmailSettingsDocument,
+  });
+  const [{ fetching: isSaving }, updateSecurityEmail] = useMutation(
+    UpdateSecurityEmailDocument,
+  );
+  const { isLoaded: orgLoaded, membership } = useOrganization();
+  const isAdmin = membership?.role === 'org:admin';
+  const currentSecurityEmail = data?.account.securityEmail ?? '';
+  const [securityEmail, setSecurityEmail] = useState(currentSecurityEmail);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSecurityEmail(currentSecurityEmail);
+  }, [currentSecurityEmail]);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!isAdmin) return;
+
+    const trimmedSecurityEmail = securityEmail.trim();
+    setSaveError(null);
+
+    const res = await updateSecurityEmail(
+      { input: { securityEmail: trimmedSecurityEmail } },
+      { additionalTypenames: ['Account'] },
+    );
+    if (res.error) {
+      setSaveError(res.error.message.replace('[GraphQL] ', ''));
+      return;
+    }
+
+    setSecurityEmail(res.data?.account.securityEmail ?? '');
+    refetch({ requestPolicy: 'network-only' });
+    toast.success('Security email updated');
+  }
+
+  const canEdit = orgLoaded && isAdmin;
+  const trimmedSecurityEmail = securityEmail.trim();
+  const isDirty = trimmedSecurityEmail !== currentSecurityEmail;
+
+  return (
+    <div className="mx-auto mb-8 w-fit max-w-[1200px] px-6">
+      <div className="w-fit bg-canvasBase shadow-none md:min-w-[880px]">
+        <div className="px-2 pt-6">
+          <section className="border-subtle bg-canvasBase w-full rounded-md border p-6 md:w-[784px]">
+            <div className="mb-6 flex flex-col gap-1">
+              <h2 className="text-muted text-lg">Security email</h2>
+              <p className="text-muted text-sm">
+                This account-level email receives security notifications for
+                your organization.
+              </p>
+            </div>
+            <form className="flex flex-col gap-4" onSubmit={submit}>
+              {error && <Alert severity="error">{error.message}</Alert>}
+              {saveError && <Alert severity="error">{saveError}</Alert>}
+              <Input
+                label="Email address"
+                name="security-email"
+                type="email"
+                value={securityEmail}
+                placeholder="security@example.com"
+                onChange={(event) => setSecurityEmail(event.target.value)}
+                readOnly={!canEdit || fetching || isSaving}
+              />
+              {!canEdit && orgLoaded && (
+                <p className="text-subtle text-sm">
+                  Only organization admins can update the security email.
+                </p>
+              )}
+              <div className="flex justify-end">
+                <Button
+                  appearance="outlined"
+                  kind="primary"
+                  label="Save"
+                  type="submit"
+                  loading={isSaving}
+                  disabled={!canEdit || fetching || isSaving || !isDirty}
+                />
+              </div>
+            </form>
+          </section>
+        </div>
+      </div>
     </div>
   );
 }

--- a/ui/apps/dashboard/src/routes/_authed/settings/user/$.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/settings/user/$.tsx
@@ -1,5 +1,29 @@
-import { UserProfile } from '@clerk/tanstack-react-start';
+import { useEffect, useState, type FormEvent } from 'react';
+import { useOrganization, UserProfile } from '@clerk/tanstack-react-start';
+import { Alert } from '@inngest/components/Alert';
+import { Button } from '@inngest/components/Button';
+import { Input } from '@inngest/components/Forms/Input';
 import { createFileRoute, redirect } from '@tanstack/react-router';
+import { toast } from 'sonner';
+import { useMutation, useQuery } from 'urql';
+
+import { graphql } from '@/gql';
+
+const SecurityEmailSettingsDocument = graphql(`
+  query SecurityEmailSettings {
+    account {
+      securityEmail
+    }
+  }
+`);
+
+const UpdateSecurityEmailDocument = graphql(`
+  mutation UpdateSecurityEmail($input: UpdateAccount!) {
+    account: updateAccount(input: $input) {
+      securityEmail
+    }
+  }
+`);
 
 export const Route = createFileRoute('/_authed/settings/user/$')({
   gcTime: 0,
@@ -39,23 +63,115 @@ function UserSettingsPage() {
         </UserProfile>
       )}
       {_splat === 'security' && (
-        <UserProfile
-          routing="path"
-          path="/settings/user/security"
-          appearance={{
-            layout: {
-              logoPlacement: 'none',
-            },
-            elements: {
-              navbar: 'hidden',
-              scrollBox: 'bg-canvasBase shadow-none',
-              pageScrollBox: 'pt-0 px-2',
-            },
-          }}
-        >
-          <UserProfile.Page label="account" />
-        </UserProfile>
+        <>
+          <UserProfile
+            routing="path"
+            path="/settings/user/security"
+            appearance={{
+              layout: {
+                logoPlacement: 'none',
+              },
+              elements: {
+                navbar: 'hidden',
+                scrollBox: 'bg-canvasBase shadow-none',
+                pageScrollBox: 'pt-6 px-2',
+              },
+            }}
+          >
+            <UserProfile.Page label="account" />
+          </UserProfile>
+          <SecurityEmailSettings />
+        </>
       )}
+    </div>
+  );
+}
+
+function SecurityEmailSettings() {
+  const [{ data, error, fetching }, refetch] = useQuery({
+    query: SecurityEmailSettingsDocument,
+  });
+  const [{ fetching: isSaving }, updateSecurityEmail] = useMutation(
+    UpdateSecurityEmailDocument,
+  );
+  const { isLoaded: orgLoaded, membership } = useOrganization();
+  const isAdmin = membership?.role === 'org:admin';
+  const currentSecurityEmail = data?.account.securityEmail ?? '';
+  const [securityEmail, setSecurityEmail] = useState(currentSecurityEmail);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSecurityEmail(currentSecurityEmail);
+  }, [currentSecurityEmail]);
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!isAdmin) return;
+
+    const trimmedSecurityEmail = securityEmail.trim();
+    setSaveError(null);
+
+    const res = await updateSecurityEmail(
+      { input: { securityEmail: trimmedSecurityEmail } },
+      { additionalTypenames: ['Account'] },
+    );
+    if (res.error) {
+      setSaveError(res.error.message.replace('[GraphQL] ', ''));
+      return;
+    }
+
+    setSecurityEmail(res.data?.account.securityEmail ?? '');
+    refetch({ requestPolicy: 'network-only' });
+    toast.success('Security email updated');
+  }
+
+  const canEdit = orgLoaded && isAdmin;
+  const trimmedSecurityEmail = securityEmail.trim();
+  const isDirty = trimmedSecurityEmail !== currentSecurityEmail;
+
+  return (
+    <div className="mx-auto mb-8 w-fit max-w-[1200px] px-6">
+      <div className="w-fit bg-canvasBase shadow-none md:min-w-[880px]">
+        <div className="px-2 pt-6">
+          <section className="border-subtle bg-canvasBase w-full rounded-md border p-6 md:w-[770px]">
+            <div className="mb-6 flex flex-col gap-1">
+              <h2 className="text-muted text-lg">Security email</h2>
+              <p className="text-muted text-sm">
+                This account-level email receives security notifications for
+                your organization.
+              </p>
+            </div>
+            <form className="flex flex-col gap-4" onSubmit={submit}>
+              {error && <Alert severity="error">{error.message}</Alert>}
+              {saveError && <Alert severity="error">{saveError}</Alert>}
+              <Input
+                label="Email address"
+                name="security-email"
+                type="email"
+                value={securityEmail}
+                placeholder="security@example.com"
+                onChange={(event) => setSecurityEmail(event.target.value)}
+                readOnly={!canEdit || fetching || isSaving}
+              />
+              {!canEdit && orgLoaded && (
+                <p className="text-subtle text-sm">
+                  Only organization admins can update the security email.
+                </p>
+              )}
+              <div className="flex justify-end">
+                <Button
+                  appearance="outlined"
+                  kind="primary"
+                  label="Save"
+                  type="submit"
+                  loading={isSaving}
+                  disabled={!canEdit || fetching || isSaving || !isDirty}
+                />
+              </div>
+            </form>
+          </section>
+        </div>
+      </div>
     </div>
   );
 }

--- a/ui/apps/dashboard/src/routes/_authed/settings/user/$.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/settings/user/$.tsx
@@ -1,29 +1,5 @@
-import { useEffect, useState, type FormEvent } from 'react';
-import { useOrganization, UserProfile } from '@clerk/tanstack-react-start';
-import { Alert } from '@inngest/components/Alert';
-import { Button } from '@inngest/components/Button';
-import { Input } from '@inngest/components/Forms/Input';
+import { UserProfile } from '@clerk/tanstack-react-start';
 import { createFileRoute, redirect } from '@tanstack/react-router';
-import { toast } from 'sonner';
-import { useMutation, useQuery } from 'urql';
-
-import { graphql } from '@/gql';
-
-const SecurityEmailSettingsDocument = graphql(`
-  query SecurityEmailSettings {
-    account {
-      securityEmail
-    }
-  }
-`);
-
-const UpdateSecurityEmailDocument = graphql(`
-  mutation UpdateSecurityEmail($input: UpdateAccount!) {
-    account: updateAccount(input: $input) {
-      securityEmail
-    }
-  }
-`);
 
 export const Route = createFileRoute('/_authed/settings/user/$')({
   gcTime: 0,
@@ -63,115 +39,23 @@ function UserSettingsPage() {
         </UserProfile>
       )}
       {_splat === 'security' && (
-        <>
-          <UserProfile
-            routing="path"
-            path="/settings/user/security"
-            appearance={{
-              layout: {
-                logoPlacement: 'none',
-              },
-              elements: {
-                navbar: 'hidden',
-                scrollBox: 'bg-canvasBase shadow-none',
-                pageScrollBox: 'pt-6 px-2',
-              },
-            }}
-          >
-            <UserProfile.Page label="account" />
-          </UserProfile>
-          <SecurityEmailSettings />
-        </>
+        <UserProfile
+          routing="path"
+          path="/settings/user/security"
+          appearance={{
+            layout: {
+              logoPlacement: 'none',
+            },
+            elements: {
+              navbar: 'hidden',
+              scrollBox: 'bg-canvasBase shadow-none',
+              pageScrollBox: 'pt-6 px-2',
+            },
+          }}
+        >
+          <UserProfile.Page label="account" />
+        </UserProfile>
       )}
-    </div>
-  );
-}
-
-function SecurityEmailSettings() {
-  const [{ data, error, fetching }, refetch] = useQuery({
-    query: SecurityEmailSettingsDocument,
-  });
-  const [{ fetching: isSaving }, updateSecurityEmail] = useMutation(
-    UpdateSecurityEmailDocument,
-  );
-  const { isLoaded: orgLoaded, membership } = useOrganization();
-  const isAdmin = membership?.role === 'org:admin';
-  const currentSecurityEmail = data?.account.securityEmail ?? '';
-  const [securityEmail, setSecurityEmail] = useState(currentSecurityEmail);
-  const [saveError, setSaveError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setSecurityEmail(currentSecurityEmail);
-  }, [currentSecurityEmail]);
-
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    if (!isAdmin) return;
-
-    const trimmedSecurityEmail = securityEmail.trim();
-    setSaveError(null);
-
-    const res = await updateSecurityEmail(
-      { input: { securityEmail: trimmedSecurityEmail } },
-      { additionalTypenames: ['Account'] },
-    );
-    if (res.error) {
-      setSaveError(res.error.message.replace('[GraphQL] ', ''));
-      return;
-    }
-
-    setSecurityEmail(res.data?.account.securityEmail ?? '');
-    refetch({ requestPolicy: 'network-only' });
-    toast.success('Security email updated');
-  }
-
-  const canEdit = orgLoaded && isAdmin;
-  const trimmedSecurityEmail = securityEmail.trim();
-  const isDirty = trimmedSecurityEmail !== currentSecurityEmail;
-
-  return (
-    <div className="mx-auto mb-8 w-fit max-w-[1200px] px-6">
-      <div className="w-fit bg-canvasBase shadow-none md:min-w-[880px]">
-        <div className="px-2 pt-6">
-          <section className="border-subtle bg-canvasBase w-full rounded-md border p-6 md:w-[770px]">
-            <div className="mb-6 flex flex-col gap-1">
-              <h2 className="text-muted text-lg">Security email</h2>
-              <p className="text-muted text-sm">
-                This account-level email receives security notifications for
-                your organization.
-              </p>
-            </div>
-            <form className="flex flex-col gap-4" onSubmit={submit}>
-              {error && <Alert severity="error">{error.message}</Alert>}
-              {saveError && <Alert severity="error">{saveError}</Alert>}
-              <Input
-                label="Email address"
-                name="security-email"
-                type="email"
-                value={securityEmail}
-                placeholder="security@example.com"
-                onChange={(event) => setSecurityEmail(event.target.value)}
-                readOnly={!canEdit || fetching || isSaving}
-              />
-              {!canEdit && orgLoaded && (
-                <p className="text-subtle text-sm">
-                  Only organization admins can update the security email.
-                </p>
-              )}
-              <div className="flex justify-end">
-                <Button
-                  appearance="outlined"
-                  kind="primary"
-                  label="Save"
-                  type="submit"
-                  loading={isSaving}
-                  disabled={!canEdit || fetching || isSaving || !isDirty}
-                />
-              </div>
-            </form>
-          </section>
-        </div>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Description

Frontend to add security email to dashbaord

<img width="5098" height="2672" alt="image" src="https://github.com/user-attachments/assets/61f51d4c-3fa6-4e86-b491-573969476546" />


Monorepo PR: https://github.com/inngest/monorepo/pull/6982

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a security email field to the organization settings page, allowing org admins to set an account-level email for security notifications. Includes GraphQL query/mutation for fetching and updating the value, with frontend admin-only enforcement. The second commit moved the component from the user settings page to the organization settings page.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7aa74019a48c307d266d9d001f50dbd4881489c3.</sup>
<!-- /MENDRAL_SUMMARY -->