### PR TITLE
Fix constraint cache silently dropping retries on exhaustion

### DIFF
--- a/pkg/constraintapi/cache.go
+++ b/pkg/constraintapi/cache.go
@@ -44,8 +44,9 @@ type constraintCacheItem struct {
 	retryAfter time.Time
 	// addedAt records the wall-clock time at which this cache entry was created.
 	// Callers can pass CapacityAcquireRequest.RequestTime to bypass entries that
-	// were added after the underlying work was originally received, which prevents
-	// silent drops on retries of work that predates a cached "exhausted" decision.
+	// were added after the underlying work was originally received, allowing the
+	// capacity manager's idempotency handling to take effect even when the
+	// in-process cache is deployed.
 	addedAt time.Time
 }
 
@@ -138,10 +139,10 @@ func (l *constraintCache) Acquire(ctx context.Context, req *CapacityAcquireReque
 		val := item.Value()
 
 		// Skip the cache when the caller's request was originally received before
-		// this cache entry was added. This is the silent-drop-on-retry guard: a
-		// retry of work received at T0 should not be denied by a cache entry that
-		// was populated at T1 > T0. We fall through to the underlying manager so
-		// the actual constraint state is checked.
+		// this cache entry was added. This lets the capacity manager's idempotency
+		// handling take effect even when the in-process cache is deployed: a retry
+		// of work received at T0 falls through to the manager rather than being
+		// answered by a cache entry populated at T1 > T0.
 		if !req.RequestTime.IsZero() && val.addedAt.After(req.RequestTime) {
 			tags := map[string]any{
 				"op":              "skipped_stale",

--- a/pkg/constraintapi/cache.go
+++ b/pkg/constraintapi/cache.go
@@ -42,6 +42,11 @@ type constraintCache struct {
 type constraintCacheItem struct {
 	constraint ConstraintItem
 	retryAfter time.Time
+	// addedAt records the wall-clock time at which this cache entry was created.
+	// Callers can pass CapacityAcquireRequest.RequestTime to bypass entries that
+	// were added after the underlying work was originally received, which prevents
+	// silent drops on retries of work that predates a cached "exhausted" decision.
+	addedAt time.Time
 }
 
 type ConstraintCacheOption func(c *constraintCache)
@@ -131,6 +136,28 @@ func (l *constraintCache) Acquire(ctx context.Context, req *CapacityAcquireReque
 
 		// Cache hit - this constraint is exhausted
 		val := item.Value()
+
+		// Skip the cache when the caller's request was originally received before
+		// this cache entry was added. This is the silent-drop-on-retry guard: a
+		// retry of work received at T0 should not be denied by a cache entry that
+		// was populated at T1 > T0. We fall through to the underlying manager so
+		// the actual constraint state is checked.
+		if !req.RequestTime.IsZero() && val.addedAt.After(req.RequestTime) {
+			tags := map[string]any{
+				"op":              "skipped_stale",
+				"source_location": req.Source.Location.String(),
+				"source_service":  req.Source.Service.String(),
+				"constraint":      ci.MetricsIdentifier(),
+			}
+			if l.enableHighCardinalityInstrumentation != nil && l.enableHighCardinalityInstrumentation(ctx, req.AccountID, req.EnvID, req.FunctionID) {
+				tags["function_id"] = req.FunctionID
+			}
+			metrics.HistogramConstraintAPILimitingConstraintCacheTTL(ctx, item.TTL(), metrics.HistogramOpt{
+				PkgName: pkgName,
+				Tags:    tags,
+			})
+			continue
+		}
 
 		recentlyLimited = append(recentlyLimited, ci)
 		if val.retryAfter.After(retryAfter) {
@@ -223,6 +250,7 @@ func (l *constraintCache) Acquire(ctx context.Context, req *CapacityAcquireReque
 			&constraintCacheItem{
 				retryAfter: res.RetryAfter,
 				constraint: ci,
+				addedAt:    l.clock.Now(),
 			},
 			cacheTTL,
 		)

--- a/pkg/constraintapi/cache_test.go
+++ b/pkg/constraintapi/cache_test.go
@@ -1141,6 +1141,118 @@ func TestCache(t *testing.T) {
 				require.LessOrEqual(t, smallCache.cache.ItemCount(), 3, "cache should not exceed max size")
 			},
 		},
+		{
+			name: "should bypass cache when RequestTime predates addedAt, hit it otherwise",
+			run: func(ctx context.Context, t *testing.T, deps deps) {
+				accountConcurrency := ConstraintItem{
+					Kind: ConstraintKindConcurrency,
+					Concurrency: &ConcurrencyConstraint{
+						Scope: enums.ConcurrencyScopeAccount,
+					},
+				}
+
+				config := ConstraintConfig{
+					FunctionVersion: 1,
+					Concurrency: ConcurrencyConfig{
+						AccountConcurrency: 1,
+					},
+				}
+
+				// T0: prime the cache. The first Acquire takes the only slot
+				// and exhausts the constraint - the cache wrapper records the
+				// item with addedAt = clock.Now() = T0.
+				cachePopulationTime := deps.clock.Now()
+				res, err := deps.cache.Acquire(ctx, &CapacityAcquireRequest{
+					AccountID:            accountID,
+					EnvID:                envID,
+					FunctionID:           fnID,
+					Source:               LeaseSource{Service: ServiceAPI, Location: CallerLocationItemLease, RunProcessingMode: RunProcessingModeBackground},
+					IdempotencyKey:       "acq-prime",
+					Configuration:        config,
+					Constraints:          []ConstraintItem{accountConcurrency},
+					Amount:               1,
+					LeaseIdempotencyKeys: []string{"item-prime"},
+					CurrentTime:          cachePopulationTime,
+					Duration:             3 * time.Second,
+					MaximumLifetime:      time.Minute,
+				})
+				require.NoError(t, err)
+				require.Len(t, res.Leases, 1)
+				require.Len(t, res.ExhaustedConstraints, 1)
+				require.NotNil(t, deps.cache.cache.Get(accountConcurrency.CacheKey(accountID, envID, fnID)),
+					"sanity: cache must be populated after exhausting the constraint")
+				require.Equal(t, 1, len(deps.lifecycles.AcquireCalls), "sanity: priming Acquire should hit the manager once")
+
+				// Case 1: RequestTime < addedAt
+				// Models a retry of work that was originally received before
+				// the cache entry was added. The cache must be bypassed and
+				// the underlying manager re-consulted.
+				_, err = deps.cache.Acquire(ctx, &CapacityAcquireRequest{
+					AccountID:            accountID,
+					EnvID:                envID,
+					FunctionID:           fnID,
+					Source:               LeaseSource{Service: ServiceAPI, Location: CallerLocationItemLease, RunProcessingMode: RunProcessingModeBackground},
+					IdempotencyKey:       "acq-stale",
+					Configuration:        config,
+					Constraints:          []ConstraintItem{accountConcurrency},
+					Amount:               1,
+					LeaseIdempotencyKeys: []string{"item-stale"},
+					CurrentTime:          deps.clock.Now(),
+					RequestTime:          cachePopulationTime.Add(-time.Second), // before addedAt
+					Duration:             3 * time.Second,
+					MaximumLifetime:      time.Minute,
+				})
+				require.NoError(t, err)
+				require.Equal(t, 2, len(deps.lifecycles.AcquireCalls),
+					"RequestTime < addedAt must bypass the cache (manager called again)")
+
+				// Case 2: RequestTime >= addedAt
+				// Models a fresh request that arrived after the rate limit
+				// decision was cached. The cache should answer.
+				callsBefore := len(deps.lifecycles.AcquireCalls)
+				_, err = deps.cache.Acquire(ctx, &CapacityAcquireRequest{
+					AccountID:            accountID,
+					EnvID:                envID,
+					FunctionID:           fnID,
+					Source:               LeaseSource{Service: ServiceAPI, Location: CallerLocationItemLease, RunProcessingMode: RunProcessingModeBackground},
+					IdempotencyKey:       "acq-fresh",
+					Configuration:        config,
+					Constraints:          []ConstraintItem{accountConcurrency},
+					Amount:               1,
+					LeaseIdempotencyKeys: []string{"item-fresh"},
+					CurrentTime:          deps.clock.Now(),
+					RequestTime:          cachePopulationTime.Add(time.Millisecond), // after addedAt
+					Duration:             3 * time.Second,
+					MaximumLifetime:      time.Minute,
+				})
+				require.NoError(t, err)
+				require.Equal(t, callsBefore, len(deps.lifecycles.AcquireCalls),
+					"RequestTime >= addedAt must use the cache (manager not called)")
+
+				// Case 3: RequestTime == zero time
+				// Callers that don't anchor a request time should get the
+				// pre-existing behavior: the cache answers when populated.
+				callsBefore = len(deps.lifecycles.AcquireCalls)
+				_, err = deps.cache.Acquire(ctx, &CapacityAcquireRequest{
+					AccountID:            accountID,
+					EnvID:                envID,
+					FunctionID:           fnID,
+					Source:               LeaseSource{Service: ServiceAPI, Location: CallerLocationItemLease, RunProcessingMode: RunProcessingModeBackground},
+					IdempotencyKey:       "acq-zero",
+					Configuration:        config,
+					Constraints:          []ConstraintItem{accountConcurrency},
+					Amount:               1,
+					LeaseIdempotencyKeys: []string{"item-zero"},
+					CurrentTime:          deps.clock.Now(),
+					// RequestTime intentionally left zero.
+					Duration:        3 * time.Second,
+					MaximumLifetime: time.Minute,
+				})
+				require.NoError(t, err)
+				require.Equal(t, callsBefore, len(deps.lifecycles.AcquireCalls),
+					"RequestTime == zero must use the cache (manager not called)")
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/constraintapi/capacity_manager.go
+++ b/pkg/constraintapi/capacity_manager.go
@@ -150,6 +150,19 @@ type CapacityAcquireRequest struct {
 	// RequestAttempt is the current request attempt. For retries, this should be > 0.
 	// This is mainly used for instrumentation.
 	RequestAttempt int
+
+	// RequestTime is the time at which the underlying work was originally received
+	// (e.g. the event ReceivedAt for run scheduling). Unlike CurrentTime, it is
+	// stable across retries of the same work item.
+	//
+	// The in-process constraint cache uses RequestTime to bypass cache entries that
+	// were populated after the work was received: if a retry of an event predates
+	// a cached "exhausted" decision, the cache is skipped so the actual constraint
+	// state is re-checked rather than silently denying the request.
+	//
+	// May be zero, in which case the cache treats the request as unanchored and
+	// honors any non-expired entry.
+	RequestTime time.Time
 }
 
 // CapacityLease represents the tuple of LeaseID <-> IdempotencyKey which identifies the leased resource (event, queue item, etc.).

--- a/pkg/constraintapi/capacity_manager.go
+++ b/pkg/constraintapi/capacity_manager.go
@@ -155,10 +155,9 @@ type CapacityAcquireRequest struct {
 	// (e.g. the event ReceivedAt for run scheduling). Unlike CurrentTime, it is
 	// stable across retries of the same work item.
 	//
-	// The in-process constraint cache uses RequestTime to bypass cache entries that
-	// were populated after the work was received: if a retry of an event predates
-	// a cached "exhausted" decision, the cache is skipped so the actual constraint
-	// state is re-checked rather than silently denying the request.
+	// The in-process constraint cache uses RequestTime to bypass entries that
+	// were populated after the work was received, allowing the capacity manager's
+	// idempotency handling to take effect even when the cache is deployed.
 	//
 	// May be zero, in which case the cache treats the request as unanchored and
 	// honors any non-expired entry.

--- a/pkg/constraintapi/convert.go
+++ b/pkg/constraintapi/convert.go
@@ -797,6 +797,7 @@ func CapacityAcquireRequestToProto(req *CapacityAcquireRequest) *pb.CapacityAcqu
 		BlockingThreshold:    durationpb.New(req.BlockingThreshold),
 		Source:               LeaseSourceToProto(req.Source),
 		RequestAttempt:       uint32(req.RequestAttempt),
+		RequestTime:          timestamppb.New(req.RequestTime),
 	}
 }
 
@@ -836,6 +837,11 @@ func CapacityAcquireRequestFromProto(pbReq *pb.CapacityAcquireRequest) (*Capacit
 	var currentTime time.Time
 	if pbReq.CurrentTime != nil {
 		currentTime = pbReq.CurrentTime.AsTime()
+	}
+
+	var requestTime time.Time
+	if pbReq.RequestTime != nil {
+		requestTime = pbReq.RequestTime.AsTime()
 	}
 
 	var duration time.Duration
@@ -879,6 +885,7 @@ func CapacityAcquireRequestFromProto(pbReq *pb.CapacityAcquireRequest) (*Capacit
 		BlockingThreshold:    blockingThreshold,
 		Source:               LeaseSourceFromProto(pbReq.Source),
 		RequestAttempt:       int(pbReq.RequestAttempt),
+		RequestTime:          requestTime,
 	}, nil
 }
 

--- a/pkg/constraintapi/convert_test.go
+++ b/pkg/constraintapi/convert_test.go
@@ -1478,6 +1478,7 @@ func TestCapacityAcquireRequestConversion(t *testing.T) {
 					Location:          pb.ConstraintApiCallerLocation_CONSTRAINT_API_CALLER_LOCATION_ITEM_LEASE,
 					RunProcessingMode: pb.ConstraintApiRunProcessingMode_CONSTRAINT_API_RUN_PROCESSING_MODE_BACKGROUND,
 				},
+				RequestTime: timestamppb.New(time.Time{}),
 			},
 		},
 		{
@@ -1525,6 +1526,7 @@ func TestCapacityAcquireRequestConversion(t *testing.T) {
 					Location:          pb.ConstraintApiCallerLocation_CONSTRAINT_API_CALLER_LOCATION_UNSPECIFIED,
 					RunProcessingMode: pb.ConstraintApiRunProcessingMode_CONSTRAINT_API_RUN_PROCESSING_MODE_BACKGROUND,
 				},
+				RequestTime: timestamppb.New(time.Time{}),
 			},
 		},
 		{

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -343,6 +343,16 @@ func start(ctx context.Context, opts StartOpts) error {
 		return fmt.Errorf("could not create constraint API: %w", err)
 	}
 
+	// Wrap the manager in the in-process constraint cache so the dev server
+	// matches production shape. Min TTL 1s, max TTL 3min.
+	cachedCM := constraintapi.NewConstraintCache(
+		constraintapi.WithConstraintCacheClock(clockwork.NewRealClock()),
+		constraintapi.WithConstraintCacheManager(cm),
+		constraintapi.WithConstraintCacheEnable(func(ctx context.Context, accountID, envID, functionID uuid.UUID) (enable bool, minTTL, maxTTL time.Duration) {
+			return true, time.Second, 3 * time.Minute
+		}),
+	)
+
 	queueOpts := []queue.QueueOpt{
 		queue.WithRunMode(runMode),
 		queue.WithIdempotencyTTL(time.Hour),
@@ -372,9 +382,9 @@ func start(ctx context.Context, opts StartOpts) error {
 			return queue.PartitionPausedInfo{}
 		}),
 		queue.WithConditionalTracer(conditionalQueueTracer),
-		queue.WithCapacityManager(cm),
+		queue.WithCapacityManager(cachedCM),
 		queue.WithAcquireCapacityLeaseOnBacklogRefill(true),
-		queue.WithCapacityManager(cm),
+		queue.WithCapacityManager(cachedCM),
 		queue.WithAcquireCapacityLeaseOnBacklogRefill(true),
 	}
 
@@ -550,7 +560,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		executor.WithAllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
 			return enableStepMetadata
 		}),
-		executor.WithCapacityManager(cm),
+		executor.WithCapacityManager(cachedCM),
 		executor.WithSemaphoreManager(semaphores),
 		executor.WithUseConstraintAPI(func(ctx context.Context, accountID uuid.UUID) (enable bool) {
 			return true
@@ -785,7 +795,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			ShardSelector:   shardSelector,
 			Port:            ds.Opts.DebugAPIPort,
 			PauseManager:    pauseMgr,
-			CapacityManager: cm,
+			CapacityManager: cachedCM,
 			// Dependencies for batching, singleton, and debounce insights
 			BatchManager:   batcher,
 			SingletonStore: sn,

--- a/pkg/execution/executor/constraints.go
+++ b/pkg/execution/executor/constraints.go
@@ -35,6 +35,7 @@ const (
 func WithConstraints[T any](
 	ctx context.Context,
 	now time.Time,
+	requestTime time.Time,
 	capacityManager constraintapi.CapacityManager,
 	useConstraintAPI constraintapi.UseConstraintAPIFn,
 	req execution.ScheduleRequest,
@@ -106,6 +107,7 @@ func WithConstraints[T any](
 	checkResult, err := CheckConstraints(
 		ctx,
 		now,
+		requestTime,
 		capacityManager,
 		useConstraintAPI,
 		req,
@@ -369,6 +371,7 @@ func getScheduleConstraints(ctx context.Context, req execution.ScheduleRequest) 
 func CheckConstraints(
 	ctx context.Context,
 	now time.Time,
+	requestTime time.Time,
 	capacityManager constraintapi.CapacityManager,
 	useConstraintAPI constraintapi.UseConstraintAPIFn,
 	req execution.ScheduleRequest,
@@ -419,6 +422,7 @@ func CheckConstraints(
 		Constraints:       constraints,
 		Amount:            1,
 		CurrentTime:       now,
+		RequestTime:       requestTime,
 		Duration:          ScheduleLeaseDuration,
 		MaximumLifetime:   5 * time.Minute, // This lease should be short!
 		Source:            source,

--- a/pkg/execution/executor/constraints_test.go
+++ b/pkg/execution/executor/constraints_test.go
@@ -2,10 +2,10 @@ package executor
 
 import (
 	"context"
-	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/constraintapi"
 	"github.com/inngest/inngest/pkg/event"
@@ -14,9 +14,9 @@ import (
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/telemetry/trace"
 	"github.com/inngest/inngest/pkg/util"
-	"github.com/inngest/inngest/pkg/util/errs"
 	"github.com/jonboulle/clockwork"
 	"github.com/oklog/ulid/v2"
+	"github.com/redis/rueidis"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,102 +84,82 @@ func TestRateLimitKeyExpressionHashConsistency(t *testing.T) {
 	}
 }
 
-// scriptedCapacityManager is a CapacityManager whose Acquire response is
-// scripted per-call. All other operations no-op or fail.
-type scriptedCapacityManager struct {
-	calls     atomic.Int64
-	responses []*constraintapi.CapacityAcquireResponse
-}
-
-func (s *scriptedCapacityManager) Acquire(ctx context.Context, req *constraintapi.CapacityAcquireRequest) (*constraintapi.CapacityAcquireResponse, errs.InternalError) {
-	idx := int(s.calls.Add(1)) - 1
-	if idx >= len(s.responses) {
-		return nil, errs.Wrap(0, false, "scriptedCapacityManager: unexpected call %d", idx)
-	}
-	return s.responses[idx], nil
-}
-
-func (s *scriptedCapacityManager) Check(context.Context, *constraintapi.CapacityCheckRequest) (*constraintapi.CapacityCheckResponse, errs.UserError, errs.InternalError) {
-	return nil, nil, errs.Wrap(0, false, "not implemented")
-}
-
-func (s *scriptedCapacityManager) ExtendLease(context.Context, *constraintapi.CapacityExtendLeaseRequest) (*constraintapi.CapacityExtendLeaseResponse, errs.InternalError) {
-	// Return a fresh lease so the background extension goroutine can run without
-	// thrashing or canceling the schedule context.
-	id := ulid.MustNew(ulid.Now(), nil)
-	return &constraintapi.CapacityExtendLeaseResponse{LeaseID: &id}, nil
-}
-
-func (s *scriptedCapacityManager) Release(context.Context, *constraintapi.CapacityReleaseRequest) (*constraintapi.CapacityReleaseResponse, errs.InternalError) {
-	return &constraintapi.CapacityReleaseResponse{}, nil
-}
-
 // TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion exercises the
 // silent-drop-on-retry case (SYS-820): when a Schedule attempt is rate
 // limited, the in-process constraint cache stores the "exhausted" decision.
 // On retry of the same event the cache must not silently deny the request -
-// the original event ReceivedAt predates the cache entry, so the cache should
+// the original event ReceivedAt predates the cache entry, so the cache must
 // be bypassed and the actual constraint state re-checked.
+//
+// This uses a real redisCapacityManager backed by miniredis (matching
+// production), wrapped in the in-process constraintCache. The rate limit
+// period is short (1s) so the GCRA window is past the rate limit by the time
+// we retry; without the fix the cache would still deny the request and the
+// event would be silently dropped.
 func TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion(t *testing.T) {
 	ctx := context.Background()
+
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(rc.Close)
+
 	clock := clockwork.NewFakeClockAt(time.Now().Truncate(time.Minute))
+
+	// Production-shaped capacity manager: real Lua-driven Redis logic, fake
+	// clock so we can advance past the rate-limit window deterministically.
+	// Idempotency TTLs are set to the minimum (1s, the floor for Redis EX);
+	// we expire them between attempts via miniredis.FastForward so the second
+	// Acquire actually re-runs GCRA instead of replaying a cached response.
+	cm, err := constraintapi.NewRedisCapacityManager(
+		constraintapi.WithClient(rc),
+		constraintapi.WithShardName("test"),
+		constraintapi.WithClock(clock),
+		constraintapi.WithOperationIdempotencyTTL(time.Second),
+		constraintapi.WithConstraintCheckIdempotencyTTL(time.Second),
+		constraintapi.WithCheckIdempotencyTTL(time.Second),
+	)
+	require.NoError(t, err)
+
+	// In-process cache wrapping the real manager. Min TTL 1s, max TTL 1m -
+	// matching production constants and the request's instructions.
+	cache := constraintapi.NewConstraintCache(
+		constraintapi.WithConstraintCacheClock(clock),
+		constraintapi.WithConstraintCacheManager(cm),
+		constraintapi.WithConstraintCacheEnable(func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) (bool, time.Duration, time.Duration) {
+			return true, time.Second, time.Minute
+		}),
+	)
+
+	useConstraintAPI := func(context.Context, uuid.UUID) bool { return true }
 
 	accountID := uuid.New()
 	envID := uuid.New()
 	appID := uuid.New()
 	fnID := uuid.New()
 
-	rateLimit := constraintapi.ConstraintItem{
-		Kind: constraintapi.ConstraintKindRateLimit,
-		RateLimit: &constraintapi.RateLimitConstraint{
-			Scope: 0, // RateLimitScopeFn (default)
-		},
-	}
-
-	// First Acquire: rate limit exhausted, no leases. Cache will be populated.
-	// Subsequent Acquires: capacity restored (e.g. window moved on), single
-	// lease granted. The bug surfaces when the cache prevents the second call
-	// from ever reaching the manager.
-	leaseID := ulid.MustNew(ulid.Timestamp(clock.Now().Add(time.Minute)), nil)
-	manager := &scriptedCapacityManager{
-		responses: []*constraintapi.CapacityAcquireResponse{
-			{
-				RequestID:            ulid.MustNew(ulid.Now(), nil),
-				Leases:               nil,
-				ExhaustedConstraints: []constraintapi.ConstraintItem{rateLimit},
-				LimitingConstraints:  []constraintapi.ConstraintItem{rateLimit},
-				RetryAfter:           clock.Now().Add(30 * time.Second),
-			},
-			{
-				RequestID: ulid.MustNew(ulid.Now(), nil),
-				Leases: []constraintapi.CapacityLease{
-					{LeaseID: leaseID, IdempotencyKey: "lease-key"},
-				},
-			},
-		},
-	}
-
-	cache := constraintapi.NewConstraintCache(
-		constraintapi.WithConstraintCacheClock(clock),
-		constraintapi.WithConstraintCacheManager(manager),
-		constraintapi.WithConstraintCacheEnable(func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) (bool, time.Duration, time.Duration) {
-			return true, constraintapi.MinCacheTTL, constraintapi.MaxCacheTTL
-		}),
-	)
-
-	useConstraintAPI := func(context.Context, uuid.UUID) bool { return true }
-
-	receivedAt := clock.Now() // T0: when the event was received
-	clock.Advance(time.Second)
-	firstAttemptNow := clock.Now() // T1 = T0 + 1s
-
+	// Rate limit of 1 per second. With period=1s, advancing the clock by >1s
+	// puts us past the GCRA window so the underlying manager will allow a
+	// retry - if the cache lets us reach it.
 	fn := inngest.Function{
-		ID: fnID,
+		ID:              fnID,
+		FunctionVersion: 1,
 		RateLimit: &inngest.RateLimit{
 			Limit:  1,
-			Period: "1m",
+			Period: "1s",
 		},
 	}
+
+	receivedAt := clock.Now() // T0: when the event was received
+
+	// Advance the clock so the first attempt's wall-clock is strictly after
+	// receivedAt - this is what makes addedAt > requestTime on the cache
+	// entry populated by the first attempt.
+	clock.Advance(100 * time.Millisecond)
+	firstAttemptNow := clock.Now() // T0 + 100ms
 
 	evt := event.InternalEvent{
 		ID:          ulid.MustNew(ulid.Now(), nil),
@@ -203,13 +183,16 @@ func TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion(t *testing.T) {
 	idempotencyKey := "schedule-idempotency"
 	tracer := trace.NoopConditionalTracer()
 
-	called := func() (any, error) { return nil, nil }
+	scheduleCalls := 0
 	scheduleFn := func(ctx context.Context, performChecks bool) (any, error) {
-		return called()
+		scheduleCalls++
+		return nil, nil
 	}
 
-	// First attempt: rate limit hit. Cache is populated with addedAt = T1.
-	_, err := WithConstraints(
+	// First attempt: consumes the only allowed call in the rate-limit
+	// window, exhausts the constraint, and populates the in-process cache
+	// with addedAt = T0 + 100ms.
+	_, err = WithConstraints(
 		ctx,
 		firstAttemptNow,
 		receivedAt,
@@ -220,16 +203,23 @@ func TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion(t *testing.T) {
 		idempotencyKey,
 		scheduleFn,
 	)
-	require.ErrorIs(t, err, ErrFunctionRateLimited, "first attempt should be rate limited")
-	require.Equal(t, int64(1), manager.calls.Load(), "first attempt should call Acquire once")
+	require.NoError(t, err, "first attempt should pass (lease granted, capacity then exhausted)")
+	require.Equal(t, 1, scheduleCalls, "first attempt should run the schedule fn once")
 
-	// Retry: same event, same idempotency key. RequestTime stays at the
-	// original ReceivedAt (T0), which is before the cache entry's addedAt
-	// (T1). The cache must be bypassed so the underlying manager is consulted
-	// again - otherwise the retry is silently dropped.
-	clock.Advance(time.Second)
-	retryNow := clock.Now() // T2 = T0 + 2s
+	// Advance past the rate-limit window in the manager's fake clock; also
+	// FastForward miniredis so the Lua-script idempotency keys (EX 1s) have
+	// expired and the second Acquire actually re-runs GCRA. The in-process
+	// cache entry is still alive: ccache uses real wall-clock time and only
+	// milliseconds have elapsed in real time.
+	clock.Advance(2 * time.Second)
+	r.FastForward(2 * time.Second)
+	retryNow := clock.Now() // T0 + 2.1s
 
+	// Retry: same event, same idempotency key, RequestTime unchanged at T0.
+	// Because RequestTime (T0) < addedAt (T0 + 100ms), the cache must be
+	// bypassed so the underlying manager grants a fresh lease. Without the
+	// fix this hits the cached "exhausted" entry and silently drops the
+	// event with ErrFunctionRateLimited.
 	_, err = WithConstraints(
 		ctx,
 		retryNow,
@@ -241,6 +231,6 @@ func TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion(t *testing.T) {
 		idempotencyKey,
 		scheduleFn,
 	)
-	require.NoError(t, err, "retry should not be silently rate limited from cache")
-	require.Equal(t, int64(2), manager.calls.Load(), "retry must reach the underlying capacity manager (cache must be bypassed)")
+	require.NoError(t, err, "retry must not be silently rate limited from a stale cache entry")
+	require.Equal(t, 2, scheduleCalls, "retry should run the schedule fn (cache bypassed, manager re-consulted)")
 }

--- a/pkg/execution/executor/constraints_test.go
+++ b/pkg/execution/executor/constraints_test.go
@@ -2,14 +2,21 @@ package executor
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/constraintapi"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/telemetry/trace"
 	"github.com/inngest/inngest/pkg/util"
+	"github.com/inngest/inngest/pkg/util/errs"
+	"github.com/jonboulle/clockwork"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -75,4 +82,165 @@ func TestRateLimitKeyExpressionHashConsistency(t *testing.T) {
 			require.Equal(t, configHash, constraintHash, "config and constraint KeyExpressionHash must be equal")
 		})
 	}
+}
+
+// scriptedCapacityManager is a CapacityManager whose Acquire response is
+// scripted per-call. All other operations no-op or fail.
+type scriptedCapacityManager struct {
+	calls     atomic.Int64
+	responses []*constraintapi.CapacityAcquireResponse
+}
+
+func (s *scriptedCapacityManager) Acquire(ctx context.Context, req *constraintapi.CapacityAcquireRequest) (*constraintapi.CapacityAcquireResponse, errs.InternalError) {
+	idx := int(s.calls.Add(1)) - 1
+	if idx >= len(s.responses) {
+		return nil, errs.Wrap(0, false, "scriptedCapacityManager: unexpected call %d", idx)
+	}
+	return s.responses[idx], nil
+}
+
+func (s *scriptedCapacityManager) Check(context.Context, *constraintapi.CapacityCheckRequest) (*constraintapi.CapacityCheckResponse, errs.UserError, errs.InternalError) {
+	return nil, nil, errs.Wrap(0, false, "not implemented")
+}
+
+func (s *scriptedCapacityManager) ExtendLease(context.Context, *constraintapi.CapacityExtendLeaseRequest) (*constraintapi.CapacityExtendLeaseResponse, errs.InternalError) {
+	// Return a fresh lease so the background extension goroutine can run without
+	// thrashing or canceling the schedule context.
+	id := ulid.MustNew(ulid.Now(), nil)
+	return &constraintapi.CapacityExtendLeaseResponse{LeaseID: &id}, nil
+}
+
+func (s *scriptedCapacityManager) Release(context.Context, *constraintapi.CapacityReleaseRequest) (*constraintapi.CapacityReleaseResponse, errs.InternalError) {
+	return &constraintapi.CapacityReleaseResponse{}, nil
+}
+
+// TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion exercises the
+// silent-drop-on-retry case (SYS-820): when a Schedule attempt is rate
+// limited, the in-process constraint cache stores the "exhausted" decision.
+// On retry of the same event the cache must not silently deny the request -
+// the original event ReceivedAt predates the cache entry, so the cache should
+// be bypassed and the actual constraint state re-checked.
+func TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClockAt(time.Now().Truncate(time.Minute))
+
+	accountID := uuid.New()
+	envID := uuid.New()
+	appID := uuid.New()
+	fnID := uuid.New()
+
+	rateLimit := constraintapi.ConstraintItem{
+		Kind: constraintapi.ConstraintKindRateLimit,
+		RateLimit: &constraintapi.RateLimitConstraint{
+			Scope: 0, // RateLimitScopeFn (default)
+		},
+	}
+
+	// First Acquire: rate limit exhausted, no leases. Cache will be populated.
+	// Subsequent Acquires: capacity restored (e.g. window moved on), single
+	// lease granted. The bug surfaces when the cache prevents the second call
+	// from ever reaching the manager.
+	leaseID := ulid.MustNew(ulid.Timestamp(clock.Now().Add(time.Minute)), nil)
+	manager := &scriptedCapacityManager{
+		responses: []*constraintapi.CapacityAcquireResponse{
+			{
+				RequestID:            ulid.MustNew(ulid.Now(), nil),
+				Leases:               nil,
+				ExhaustedConstraints: []constraintapi.ConstraintItem{rateLimit},
+				LimitingConstraints:  []constraintapi.ConstraintItem{rateLimit},
+				RetryAfter:           clock.Now().Add(30 * time.Second),
+			},
+			{
+				RequestID: ulid.MustNew(ulid.Now(), nil),
+				Leases: []constraintapi.CapacityLease{
+					{LeaseID: leaseID, IdempotencyKey: "lease-key"},
+				},
+			},
+		},
+	}
+
+	cache := constraintapi.NewConstraintCache(
+		constraintapi.WithConstraintCacheClock(clock),
+		constraintapi.WithConstraintCacheManager(manager),
+		constraintapi.WithConstraintCacheEnable(func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) (bool, time.Duration, time.Duration) {
+			return true, constraintapi.MinCacheTTL, constraintapi.MaxCacheTTL
+		}),
+	)
+
+	useConstraintAPI := func(context.Context, uuid.UUID) bool { return true }
+
+	receivedAt := clock.Now() // T0: when the event was received
+	clock.Advance(time.Second)
+	firstAttemptNow := clock.Now() // T1 = T0 + 1s
+
+	fn := inngest.Function{
+		ID: fnID,
+		RateLimit: &inngest.RateLimit{
+			Limit:  1,
+			Period: "1m",
+		},
+	}
+
+	evt := event.InternalEvent{
+		ID:          ulid.MustNew(ulid.Now(), nil),
+		AccountID:   accountID,
+		WorkspaceID: envID,
+		Event: event.Event{
+			Name: "test",
+			Data: map[string]any{},
+		},
+		ReceivedAt: receivedAt,
+	}
+
+	req := execution.ScheduleRequest{
+		Function:    fn,
+		AccountID:   accountID,
+		WorkspaceID: envID,
+		AppID:       appID,
+		Events:      []event.TrackedEvent{evt},
+	}
+
+	idempotencyKey := "schedule-idempotency"
+	tracer := trace.NoopConditionalTracer()
+
+	called := func() (any, error) { return nil, nil }
+	scheduleFn := func(ctx context.Context, performChecks bool) (any, error) {
+		return called()
+	}
+
+	// First attempt: rate limit hit. Cache is populated with addedAt = T1.
+	_, err := WithConstraints(
+		ctx,
+		firstAttemptNow,
+		receivedAt,
+		cache,
+		useConstraintAPI,
+		req,
+		tracer,
+		idempotencyKey,
+		scheduleFn,
+	)
+	require.ErrorIs(t, err, ErrFunctionRateLimited, "first attempt should be rate limited")
+	require.Equal(t, int64(1), manager.calls.Load(), "first attempt should call Acquire once")
+
+	// Retry: same event, same idempotency key. RequestTime stays at the
+	// original ReceivedAt (T0), which is before the cache entry's addedAt
+	// (T1). The cache must be bypassed so the underlying manager is consulted
+	// again - otherwise the retry is silently dropped.
+	clock.Advance(time.Second)
+	retryNow := clock.Now() // T2 = T0 + 2s
+
+	_, err = WithConstraints(
+		ctx,
+		retryNow,
+		receivedAt, // unchanged across retries
+		cache,
+		useConstraintAPI,
+		req,
+		tracer,
+		idempotencyKey,
+		scheduleFn,
+	)
+	require.NoError(t, err, "retry should not be silently rate limited from cache")
+	require.Equal(t, int64(2), manager.calls.Load(), "retry must reach the underlying capacity manager (cache must be bypassed)")
 }

--- a/pkg/execution/executor/constraints_test.go
+++ b/pkg/execution/executor/constraints_test.go
@@ -109,6 +109,12 @@ func TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion(t *testing.T) {
 
 	clock := clockwork.NewFakeClockAt(time.Now().Truncate(time.Minute))
 
+	// Lifecycle hooks let us count how many times the underlying manager's
+	// Acquire actually ran - useful to distinguish "cache hit" (no manager
+	// call) from "cache bypass + manager limited" (manager call returns no
+	// leases).
+	lifecycles := constraintapi.NewConstraintAPIDebugLifecycles()
+
 	// Production-shaped capacity manager: real Lua-driven Redis logic, fake
 	// clock so we can advance past the rate-limit window deterministically.
 	// Idempotency TTLs are set to the minimum (1s, the floor for Redis EX);
@@ -121,6 +127,7 @@ func TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion(t *testing.T) {
 		constraintapi.WithOperationIdempotencyTTL(time.Second),
 		constraintapi.WithConstraintCheckIdempotencyTTL(time.Second),
 		constraintapi.WithCheckIdempotencyTTL(time.Second),
+		constraintapi.WithLifecycles(lifecycles),
 	)
 	require.NoError(t, err)
 
@@ -180,7 +187,6 @@ func TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion(t *testing.T) {
 		Events:      []event.TrackedEvent{evt},
 	}
 
-	idempotencyKey := "schedule-idempotency"
 	tracer := trace.NoopConditionalTracer()
 
 	scheduleCalls := 0
@@ -189,48 +195,74 @@ func TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion(t *testing.T) {
 		return nil, nil
 	}
 
-	// First attempt: consumes the only allowed call in the rate-limit
+	runAttempt := func(now, requestTime time.Time, idempotencyKey string) error {
+		_, err := WithConstraints(
+			ctx,
+			now,
+			requestTime,
+			cache,
+			useConstraintAPI,
+			req,
+			tracer,
+			idempotencyKey,
+			scheduleFn,
+		)
+		return err
+	}
+
+	// Attempt 1 - warmup. Consumes the only allowed call in the rate-limit
 	// window, exhausts the constraint, and populates the in-process cache
 	// with addedAt = T0 + 100ms.
-	_, err = WithConstraints(
-		ctx,
-		firstAttemptNow,
-		receivedAt,
-		cache,
-		useConstraintAPI,
-		req,
-		tracer,
-		idempotencyKey,
-		scheduleFn,
-	)
-	require.NoError(t, err, "first attempt should pass (lease granted, capacity then exhausted)")
-	require.Equal(t, 1, scheduleCalls, "first attempt should run the schedule fn once")
+	require.NoError(t, runAttempt(firstAttemptNow, receivedAt, "warmup-key"),
+		"warmup attempt should pass (lease granted, capacity then exhausted)")
+	require.Equal(t, 1, scheduleCalls, "warmup attempt should run the schedule fn once")
+	require.Equal(t, 1, len(lifecycles.AcquireCalls), "warmup must reach the manager")
 
-	// Advance past the rate-limit window in the manager's fake clock; also
-	// FastForward miniredis so the Lua-script idempotency keys (EX 1s) have
-	// expired and the second Acquire actually re-runs GCRA. The in-process
-	// cache entry is still alive: ccache uses real wall-clock time and only
-	// milliseconds have elapsed in real time.
+	// Attempt 2 - old event (RequestTime predates addedAt) with a fresh
+	// idempotency key. The cache is bypassed because RequestTime < addedAt,
+	// but the rate-limit window is still active in Redis: GCRA inside the
+	// capacity manager rejects the request, so the schedule is denied.
+	// This verifies the manager's per-request handling kicks in once the
+	// cache has stepped aside.
+	require.ErrorIs(t,
+		runAttempt(clock.Now(), receivedAt, "fresh-key"),
+		ErrFunctionRateLimited,
+		"old event with different idempotency key must be limited by the capacity manager (GCRA window active)",
+	)
+	require.Equal(t, 1, scheduleCalls, "manager-limited attempt must not run the schedule fn")
+	require.Equal(t, 2, len(lifecycles.AcquireCalls),
+		"old event with different idempotency key must reach the manager (cache bypassed)")
+
+	// Attempt 3 - new event whose RequestTime is later than the cache
+	// entry's addedAt. The cache must answer here without consulting the
+	// manager: the AcquireCalls counter does not advance.
+	newRequestTime := firstAttemptNow.Add(50 * time.Millisecond)
+	require.ErrorIs(t,
+		runAttempt(clock.Now(), newRequestTime, "new-event-key"),
+		ErrFunctionRateLimited,
+		"new event (RequestTime > addedAt) must be limited by the in-process cache",
+	)
+	require.Equal(t, 1, scheduleCalls, "cache-limited attempt must not run the schedule fn")
+	require.Equal(t, 2, len(lifecycles.AcquireCalls),
+		"new event must NOT reach the manager (cache hit)")
+
+	// Attempt 4 - retry of the original event after the rate-limit window
+	// has elapsed. Advance past the rate-limit window in the manager's fake
+	// clock; FastForward miniredis so the Lua-script idempotency keys
+	// (EX 1s) have expired and the second Acquire actually re-runs GCRA.
+	// The in-process cache entry is still alive: ccache uses real
+	// wall-clock time and only milliseconds have elapsed in real time.
+	//
+	// Because RequestTime (T0) < addedAt (T0 + 100ms), the cache is
+	// bypassed and the underlying manager grants a fresh lease. Without
+	// the fix this hits the cached "exhausted" entry and silently drops
+	// the event with ErrFunctionRateLimited.
 	clock.Advance(2 * time.Second)
 	r.FastForward(2 * time.Second)
-	retryNow := clock.Now() // T0 + 2.1s
-
-	// Retry: same event, same idempotency key, RequestTime unchanged at T0.
-	// Because RequestTime (T0) < addedAt (T0 + 100ms), the cache must be
-	// bypassed so the underlying manager grants a fresh lease. Without the
-	// fix this hits the cached "exhausted" entry and silently drops the
-	// event with ErrFunctionRateLimited.
-	_, err = WithConstraints(
-		ctx,
-		retryNow,
-		receivedAt, // unchanged across retries
-		cache,
-		useConstraintAPI,
-		req,
-		tracer,
-		idempotencyKey,
-		scheduleFn,
+	require.NoError(t,
+		runAttempt(clock.Now(), receivedAt, "warmup-key"),
+		"retry must not be silently rate limited from a stale cache entry",
 	)
-	require.NoError(t, err, "retry must not be silently rate limited from a stale cache entry")
 	require.Equal(t, 2, scheduleCalls, "retry should run the schedule fn (cache bypassed, manager re-consulted)")
+	require.Equal(t, 3, len(lifecycles.AcquireCalls), "retry must reach the manager")
 }

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -830,8 +830,9 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 	l.Optional(req.AccountID, "schedule").Debug("hitting constraint API")
 
 	// requestTime is the original event ReceivedAt. It stays constant across
-	// retries of the same event so the constraint cache can bypass entries that
-	// were populated after the event was received (avoiding silent drops).
+	// retries of the same event, which lets the constraint API's idempotency
+	// handling kick in by bypassing in-process cache entries that were
+	// populated after the event was received.
 	var requestTime time.Time
 	if len(req.Events) > 0 {
 		requestTime = req.Events[0].GetReceivedAt()

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -829,10 +829,19 @@ func (e *executor) Schedule(ctx context.Context, req execution.ScheduleRequest) 
 
 	l.Optional(req.AccountID, "schedule").Debug("hitting constraint API")
 
+	// requestTime is the original event ReceivedAt. It stays constant across
+	// retries of the same event so the constraint cache can bypass entries that
+	// were populated after the event was received (avoiding silent drops).
+	var requestTime time.Time
+	if len(req.Events) > 0 {
+		requestTime = req.Events[0].GetReceivedAt()
+	}
+
 	// Check constraints and acquire lease
 	md, err := WithConstraints(
 		ctx,
 		e.now(),
+		requestTime,
 		e.capacityManager,
 		e.useConstraintAPI,
 		req,

--- a/proto/constraintapi/v1/service.proto
+++ b/proto/constraintapi/v1/service.proto
@@ -207,6 +207,7 @@ message CapacityAcquireRequest {
   google.protobuf.Duration blocking_threshold = 13;
   LeaseSource source = 14;
   uint32 request_attempt = 15;
+  google.protobuf.Timestamp request_time = 17;
 }
 
 message CapacityAcquireResponse {

--- a/proto/gen/constraintapi/v1/service.pb.go
+++ b/proto/gen/constraintapi/v1/service.pb.go
@@ -1615,6 +1615,7 @@ type CapacityAcquireRequest struct {
 	BlockingThreshold    *durationpb.Duration   `protobuf:"bytes,13,opt,name=blocking_threshold,json=blockingThreshold,proto3" json:"blocking_threshold,omitempty"`
 	Source               *LeaseSource           `protobuf:"bytes,14,opt,name=source,proto3" json:"source,omitempty"`
 	RequestAttempt       uint32                 `protobuf:"varint,15,opt,name=request_attempt,json=requestAttempt,proto3" json:"request_attempt,omitempty"`
+	RequestTime          *timestamppb.Timestamp `protobuf:"bytes,17,opt,name=request_time,json=requestTime,proto3" json:"request_time,omitempty"`
 	unknownFields        protoimpl.UnknownFields
 	sizeCache            protoimpl.SizeCache
 }
@@ -1759,6 +1760,13 @@ func (x *CapacityAcquireRequest) GetRequestAttempt() uint32 {
 		return x.RequestAttempt
 	}
 	return 0
+}
+
+func (x *CapacityAcquireRequest) GetRequestTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.RequestTime
+	}
+	return nil
 }
 
 type CapacityAcquireResponse struct {
@@ -2562,7 +2570,7 @@ const file_constraintapi_v1_service_proto_rawDesc = "" +
 	"\x12fairness_reduction\x18\x04 \x01(\x05R\x11fairnessReduction\x12;\n" +
 	"\vretry_after\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
 	"retryAfter\x12U\n" +
-	"\x15exhausted_constraints\x18\x06 \x03(\v2 .constraintapi.v1.ConstraintItemR\x14exhaustedConstraints\"\x90\a\n" +
+	"\x15exhausted_constraints\x18\x06 \x03(\v2 .constraintapi.v1.ConstraintItemR\x14exhaustedConstraints\"\xcf\a\n" +
 	"\x16CapacityAcquireRequest\x12'\n" +
 	"\x0fidempotency_key\x18\x01 \x01(\tR\x0eidempotencyKey\x12\x1d\n" +
 	"\n" +
@@ -2582,7 +2590,8 @@ const file_constraintapi_v1_service_proto_rawDesc = "" +
 	"\x10maximum_lifetime\x18\f \x01(\v2\x19.google.protobuf.DurationR\x0fmaximumLifetime\x12H\n" +
 	"\x12blocking_threshold\x18\r \x01(\v2\x19.google.protobuf.DurationR\x11blockingThreshold\x125\n" +
 	"\x06source\x18\x0e \x01(\v2\x1d.constraintapi.v1.LeaseSourceR\x06source\x12'\n" +
-	"\x0frequest_attempt\x18\x0f \x01(\rR\x0erequestAttempt\x1a>\n" +
+	"\x0frequest_attempt\x18\x0f \x01(\rR\x0erequestAttempt\x12=\n" +
+	"\frequest_time\x18\x11 \x01(\v2\x1a.google.protobuf.TimestampR\vrequestTime\x1a>\n" +
 	"\x10LeaseRunIdsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xa3\x03\n" +
@@ -2796,37 +2805,38 @@ var file_constraintapi_v1_service_proto_depIdxs = []int32{
 	39, // 35: constraintapi.v1.CapacityAcquireRequest.maximum_lifetime:type_name -> google.protobuf.Duration
 	39, // 36: constraintapi.v1.CapacityAcquireRequest.blocking_threshold:type_name -> google.protobuf.Duration
 	22, // 37: constraintapi.v1.CapacityAcquireRequest.source:type_name -> constraintapi.v1.LeaseSource
-	21, // 38: constraintapi.v1.CapacityAcquireResponse.leases:type_name -> constraintapi.v1.CapacityLease
-	19, // 39: constraintapi.v1.CapacityAcquireResponse.limiting_constraints:type_name -> constraintapi.v1.ConstraintItem
-	38, // 40: constraintapi.v1.CapacityAcquireResponse.retry_after:type_name -> google.protobuf.Timestamp
-	19, // 41: constraintapi.v1.CapacityAcquireResponse.exhausted_constraints:type_name -> constraintapi.v1.ConstraintItem
-	20, // 42: constraintapi.v1.CapacityAcquireResponse.usage:type_name -> constraintapi.v1.ConstraintUsage
-	39, // 43: constraintapi.v1.CapacityExtendLeaseRequest.duration:type_name -> google.protobuf.Duration
-	22, // 44: constraintapi.v1.CapacityExtendLeaseRequest.source:type_name -> constraintapi.v1.LeaseSource
-	38, // 45: constraintapi.v1.CapacityExtendLeaseRequest.lease_issued_at:type_name -> google.protobuf.Timestamp
-	22, // 46: constraintapi.v1.CapacityReleaseRequest.source:type_name -> constraintapi.v1.LeaseSource
-	38, // 47: constraintapi.v1.CapacityReleaseRequest.lease_issued_at:type_name -> google.protobuf.Timestamp
-	23, // 48: constraintapi.v1.ConstraintAPI.Check:input_type -> constraintapi.v1.CapacityCheckRequest
-	25, // 49: constraintapi.v1.ConstraintAPI.Acquire:input_type -> constraintapi.v1.CapacityAcquireRequest
-	27, // 50: constraintapi.v1.ConstraintAPI.ExtendLease:input_type -> constraintapi.v1.CapacityExtendLeaseRequest
-	29, // 51: constraintapi.v1.ConstraintAPI.Release:input_type -> constraintapi.v1.CapacityReleaseRequest
-	31, // 52: constraintapi.v1.ConstraintAPI.SetSemaphoreCapacity:input_type -> constraintapi.v1.SemaphoreSetCapacityRequest
-	32, // 53: constraintapi.v1.ConstraintAPI.AdjustSemaphoreCapacity:input_type -> constraintapi.v1.SemaphoreAdjustCapacityRequest
-	33, // 54: constraintapi.v1.ConstraintAPI.GetSemaphoreCapacity:input_type -> constraintapi.v1.SemaphoreGetCapacityRequest
-	35, // 55: constraintapi.v1.ConstraintAPI.ReleaseSemaphore:input_type -> constraintapi.v1.SemaphoreReleaseRequest
-	24, // 56: constraintapi.v1.ConstraintAPI.Check:output_type -> constraintapi.v1.CapacityCheckResponse
-	26, // 57: constraintapi.v1.ConstraintAPI.Acquire:output_type -> constraintapi.v1.CapacityAcquireResponse
-	28, // 58: constraintapi.v1.ConstraintAPI.ExtendLease:output_type -> constraintapi.v1.CapacityExtendLeaseResponse
-	30, // 59: constraintapi.v1.ConstraintAPI.Release:output_type -> constraintapi.v1.CapacityReleaseResponse
-	36, // 60: constraintapi.v1.ConstraintAPI.SetSemaphoreCapacity:output_type -> constraintapi.v1.SemaphoreResponse
-	36, // 61: constraintapi.v1.ConstraintAPI.AdjustSemaphoreCapacity:output_type -> constraintapi.v1.SemaphoreResponse
-	34, // 62: constraintapi.v1.ConstraintAPI.GetSemaphoreCapacity:output_type -> constraintapi.v1.SemaphoreGetCapacityResponse
-	36, // 63: constraintapi.v1.ConstraintAPI.ReleaseSemaphore:output_type -> constraintapi.v1.SemaphoreResponse
-	56, // [56:64] is the sub-list for method output_type
-	48, // [48:56] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	38, // 38: constraintapi.v1.CapacityAcquireRequest.request_time:type_name -> google.protobuf.Timestamp
+	21, // 39: constraintapi.v1.CapacityAcquireResponse.leases:type_name -> constraintapi.v1.CapacityLease
+	19, // 40: constraintapi.v1.CapacityAcquireResponse.limiting_constraints:type_name -> constraintapi.v1.ConstraintItem
+	38, // 41: constraintapi.v1.CapacityAcquireResponse.retry_after:type_name -> google.protobuf.Timestamp
+	19, // 42: constraintapi.v1.CapacityAcquireResponse.exhausted_constraints:type_name -> constraintapi.v1.ConstraintItem
+	20, // 43: constraintapi.v1.CapacityAcquireResponse.usage:type_name -> constraintapi.v1.ConstraintUsage
+	39, // 44: constraintapi.v1.CapacityExtendLeaseRequest.duration:type_name -> google.protobuf.Duration
+	22, // 45: constraintapi.v1.CapacityExtendLeaseRequest.source:type_name -> constraintapi.v1.LeaseSource
+	38, // 46: constraintapi.v1.CapacityExtendLeaseRequest.lease_issued_at:type_name -> google.protobuf.Timestamp
+	22, // 47: constraintapi.v1.CapacityReleaseRequest.source:type_name -> constraintapi.v1.LeaseSource
+	38, // 48: constraintapi.v1.CapacityReleaseRequest.lease_issued_at:type_name -> google.protobuf.Timestamp
+	23, // 49: constraintapi.v1.ConstraintAPI.Check:input_type -> constraintapi.v1.CapacityCheckRequest
+	25, // 50: constraintapi.v1.ConstraintAPI.Acquire:input_type -> constraintapi.v1.CapacityAcquireRequest
+	27, // 51: constraintapi.v1.ConstraintAPI.ExtendLease:input_type -> constraintapi.v1.CapacityExtendLeaseRequest
+	29, // 52: constraintapi.v1.ConstraintAPI.Release:input_type -> constraintapi.v1.CapacityReleaseRequest
+	31, // 53: constraintapi.v1.ConstraintAPI.SetSemaphoreCapacity:input_type -> constraintapi.v1.SemaphoreSetCapacityRequest
+	32, // 54: constraintapi.v1.ConstraintAPI.AdjustSemaphoreCapacity:input_type -> constraintapi.v1.SemaphoreAdjustCapacityRequest
+	33, // 55: constraintapi.v1.ConstraintAPI.GetSemaphoreCapacity:input_type -> constraintapi.v1.SemaphoreGetCapacityRequest
+	35, // 56: constraintapi.v1.ConstraintAPI.ReleaseSemaphore:input_type -> constraintapi.v1.SemaphoreReleaseRequest
+	24, // 57: constraintapi.v1.ConstraintAPI.Check:output_type -> constraintapi.v1.CapacityCheckResponse
+	26, // 58: constraintapi.v1.ConstraintAPI.Acquire:output_type -> constraintapi.v1.CapacityAcquireResponse
+	28, // 59: constraintapi.v1.ConstraintAPI.ExtendLease:output_type -> constraintapi.v1.CapacityExtendLeaseResponse
+	30, // 60: constraintapi.v1.ConstraintAPI.Release:output_type -> constraintapi.v1.CapacityReleaseResponse
+	36, // 61: constraintapi.v1.ConstraintAPI.SetSemaphoreCapacity:output_type -> constraintapi.v1.SemaphoreResponse
+	36, // 62: constraintapi.v1.ConstraintAPI.AdjustSemaphoreCapacity:output_type -> constraintapi.v1.SemaphoreResponse
+	34, // 63: constraintapi.v1.ConstraintAPI.GetSemaphoreCapacity:output_type -> constraintapi.v1.SemaphoreGetCapacityResponse
+	36, // 64: constraintapi.v1.ConstraintAPI.ReleaseSemaphore:output_type -> constraintapi.v1.SemaphoreResponse
+	57, // [57:65] is the sub-list for method output_type
+	49, // [49:57] is the sub-list for method input_type
+	49, // [49:49] is the sub-list for extension type_name
+	49, // [49:49] is the sub-list for extension extendee
+	0,  // [0:49] is the sub-list for field type_name
 }
 
 func init() { file_constraintapi_v1_service_proto_init() }


### PR DESCRIPTION
## Description

Fixes a bug (SYS-820) where the in-process constraint cache would silently drop retries of rate-limited events. When a Schedule attempt was rate limited, the cache would store an "exhausted" decision. On retry of the same event, the cache would deny the request without re-checking the actual constraint state, causing the retry to be silently dropped.

The fix adds a `RequestTime` field to `CapacityAcquireRequest` that tracks when the underlying work was originally received (e.g., event `ReceivedAt`). The constraint cache now bypasses stale entries—those added after the work was received—forcing a re-check of the actual constraint state rather than silently denying retries.

## Changes

- **Proto**: Added `request_time` field to `CapacityAcquireRequest` to track original work receipt time
- **Constraint Cache**: Added `addedAt` timestamp to cache entries and logic to skip entries that postdate the request time
- **Capacity Manager**: Added `RequestTime` field to `CapacityAcquireRequest` struct with documentation
- **Executor**: Pass event `ReceivedAt` as `RequestTime` when calling `WithConstraints`
- **Conversion**: Updated proto conversion functions to handle the new `RequestTime` field
- **Tests**: Added comprehensive test `TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion` that exercises the fix with a scripted capacity manager

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] I've linked any associated issues to this PR (SYS-820).
- [x] I've tested my own changes (added unit test covering the bug scenario).

https://claude.ai/code/session_018RRAjSa6wpJUW5S4PABKUv

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a silent-drop-on-retry bug (SYS-820) in the in-process constraint cache. When a Schedule attempt was rate-limited, the cache stored an "exhausted" decision. Retries of the same event hit that cache entry and were denied without re-checking the actual constraint state. The fix adds `RequestTime` (event `ReceivedAt`) to `CapacityAcquireRequest` and an `addedAt` timestamp to each cache entry; if `addedAt > RequestTime`, the cache is bypassed and the underlying manager is consulted. The final commit wraps the dev server's capacity manager in the constraint cache to match production shape.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4cab0e52f26c4c0074c75c209678de707a7dd7af.</sup>
<!-- /MENDRAL_SUMMARY -->