### PR TITLE
Support shared throttle scopes

### DIFF
--- a/docs/SDK_SPEC.md
+++ b/docs/SDK_SPEC.md
@@ -743,6 +743,13 @@ A Sync’s payload MUST be the following JSON object:
       key?: string;
 
       /**
+       * An optional scope for the throttle bucket. By default, throttle limits are
+       * scoped to functions. Use "env" to share the bucket across functions in the
+       * same environment, or "account" to share it across environments in the account.
+       */
+      scope?: "fn" | "env" | "account";
+
+      /**
        * The maximum number of runs to allow per the given `period`.
        */
       limit: number;

--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -563,6 +563,7 @@ type ComplexityRoot struct {
 		Key    func(childComplexity int) int
 		Limit  func(childComplexity int) int
 		Period func(childComplexity int) int
+		Scope  func(childComplexity int) int
 	}
 
 	UserlandSpan struct {
@@ -3198,6 +3199,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ThrottleConfiguration.Period(childComplexity), true
 
+	case "ThrottleConfiguration.scope":
+		if e.complexity.ThrottleConfiguration.Scope == nil {
+			break
+		}
+
+		return e.complexity.ThrottleConfiguration.Scope(childComplexity), true
+
 	case "UserlandSpan.resourceAttrs":
 		if e.complexity.UserlandSpan.ResourceAttrs == nil {
 			break
@@ -3865,6 +3873,13 @@ type ThrottleConfiguration {
   key: String
   limit: Int!
   period: String!
+  scope: ThrottleScope!
+}
+
+enum ThrottleScope {
+  ACCOUNT
+  ENVIRONMENT
+  FUNCTION
 }
 
 type SingletonConfiguration {
@@ -10452,6 +10467,8 @@ func (ec *executionContext) fieldContext_FunctionConfiguration_throttle(ctx cont
 				return ec.fieldContext_ThrottleConfiguration_limit(ctx, field)
 			case "period":
 				return ec.fieldContext_ThrottleConfiguration_period(ctx, field)
+			case "scope":
+				return ec.fieldContext_ThrottleConfiguration_scope(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ThrottleConfiguration", field.Name)
 		},
@@ -21430,6 +21447,50 @@ func (ec *executionContext) fieldContext_ThrottleConfiguration_period(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _ThrottleConfiguration_scope(ctx context.Context, field graphql.CollectedField, obj *models.ThrottleConfiguration) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ThrottleConfiguration_scope(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Scope, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(models.ThrottleScope)
+	fc.Result = res
+	return ec.marshalNThrottleScope2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐThrottleScope(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ThrottleConfiguration_scope(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ThrottleConfiguration",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ThrottleScope does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UserlandSpan_spanName(ctx context.Context, field graphql.CollectedField, obj *models.UserlandSpan) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_UserlandSpan_spanName(ctx, field)
 	if err != nil {
@@ -28616,6 +28677,13 @@ func (ec *executionContext) _ThrottleConfiguration(ctx context.Context, sel ast.
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "scope":
+
+			out.Values[i] = ec._ThrottleConfiguration_scope(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -30431,6 +30499,16 @@ func (ec *executionContext) marshalNString2string(ctx context.Context, sel ast.S
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) unmarshalNThrottleScope2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐThrottleScope(ctx context.Context, v interface{}) (models.ThrottleScope, error) {
+	var res models.ThrottleScope
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNThrottleScope2githubᚗcomᚋinngestᚋinngestᚋpkgᚋcoreapiᚋgraphᚋmodelsᚐThrottleScope(ctx context.Context, sel ast.SelectionSet, v models.ThrottleScope) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) unmarshalNTime2timeᚐTime(ctx context.Context, v interface{}) (time.Time, error) {

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -292,6 +292,13 @@ type ThrottleConfiguration {
   key: String
   limit: Int!
   period: String!
+  scope: ThrottleScope!
+}
+
+enum ThrottleScope {
+  ACCOUNT
+  ENVIRONMENT
+  FUNCTION
 }
 
 type SingletonConfiguration {

--- a/pkg/coreapi/graph/models/function_configuration_serializer.go
+++ b/pkg/coreapi/graph/models/function_configuration_serializer.go
@@ -51,6 +51,7 @@ func ToFunctionConfiguration(fn *inngest.Function, planConcurrencyLimit int) *Fu
 			Burst: int(fn.Throttle.Burst),
 			Key:   fn.Throttle.Key,
 			Limit: int(fn.Throttle.Limit),
+			Scope: mapThrottleScope(fn.Throttle.Scope),
 
 			// TODO: We need a custom "time.Duration to string" function that
 			// formats it more closely to what we want. For example,
@@ -139,6 +140,19 @@ func mapScope(internalEnum enums.ConcurrencyScope) ConcurrencyScope {
 		return gqlEnum
 	}
 	return ConcurrencyScopeFunction
+}
+
+func mapThrottleScope(internalEnum enums.ThrottleScope) ThrottleScope {
+	var enumMapping = map[enums.ThrottleScope]ThrottleScope{
+		enums.ThrottleScopeFn:      ThrottleScopeFunction,
+		enums.ThrottleScopeEnv:     ThrottleScopeEnvironment,
+		enums.ThrottleScopeAccount: ThrottleScopeAccount,
+	}
+
+	if gqlEnum, ok := enumMapping[internalEnum]; ok {
+		return gqlEnum
+	}
+	return ThrottleScopeFunction
 }
 
 func mapSingletonMode(internalEnum enums.SingletonMode) SingletonMode {

--- a/pkg/coreapi/graph/models/function_configuration_serializer_test.go
+++ b/pkg/coreapi/graph/models/function_configuration_serializer_test.go
@@ -225,6 +225,27 @@ func TestToFunctionConfiguration(t *testing.T) {
 					Period: "30m0s",
 					Burst:  3,
 					Key:    util.StrPtr("event.data.customer_id"),
+					Scope:  ThrottleScopeFunction,
+				},
+			}),
+		},
+		{
+			name: "account scoped throttle",
+			fn: mergeWithDefaultFunction(&inngest.Function{
+				Throttle: &inngest.Throttle{
+					Limit:  10,
+					Period: 30 * time.Minute,
+					Burst:  3,
+					Scope:  enums.ThrottleScopeAccount,
+				},
+			}),
+			planConcurrencyLimit: UnknownPlanConcurrencyLimit,
+			expected: mergeWithDefaultFunctionConfiguration(&FunctionConfiguration{
+				Throttle: &ThrottleConfiguration{
+					Limit:  10,
+					Period: "30m0s",
+					Burst:  3,
+					Scope:  ThrottleScopeAccount,
 				},
 			}),
 		},

--- a/pkg/coreapi/graph/models/models_gen.go
+++ b/pkg/coreapi/graph/models/models_gen.go
@@ -472,10 +472,11 @@ type StreamQuery struct {
 }
 
 type ThrottleConfiguration struct {
-	Burst  int     `json:"burst"`
-	Key    *string `json:"key,omitempty"`
-	Limit  int     `json:"limit"`
-	Period string  `json:"period"`
+	Burst  int           `json:"burst"`
+	Key    *string       `json:"key,omitempty"`
+	Limit  int           `json:"limit"`
+	Period string        `json:"period"`
+	Scope  ThrottleScope `json:"scope"`
 }
 
 type UpdateAppInput struct {
@@ -1273,5 +1274,48 @@ func (e *StreamType) UnmarshalGQL(v interface{}) error {
 }
 
 func (e StreamType) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
+}
+
+type ThrottleScope string
+
+const (
+	ThrottleScopeAccount     ThrottleScope = "ACCOUNT"
+	ThrottleScopeEnvironment ThrottleScope = "ENVIRONMENT"
+	ThrottleScopeFunction    ThrottleScope = "FUNCTION"
+)
+
+var AllThrottleScope = []ThrottleScope{
+	ThrottleScopeAccount,
+	ThrottleScopeEnvironment,
+	ThrottleScopeFunction,
+}
+
+func (e ThrottleScope) IsValid() bool {
+	switch e {
+	case ThrottleScopeAccount, ThrottleScopeEnvironment, ThrottleScopeFunction:
+		return true
+	}
+	return false
+}
+
+func (e ThrottleScope) String() string {
+	return string(e)
+}
+
+func (e *ThrottleScope) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = ThrottleScope(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid ThrottleScope", str)
+	}
+	return nil
+}
+
+func (e ThrottleScope) MarshalGQL(w io.Writer) {
 	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -955,7 +955,7 @@ func NormalizeThrottle(smv2 sv2.StateLoader, dbcqrs cqrs.Manager) queue.RefreshI
 
 		evtMap := evt0.Map()
 
-		return queue.GetThrottleConfig(ctx, id.FunctionID, fn.Throttle, evtMap), nil
+		return queue.GetThrottleConfig(ctx, id, fn.Throttle, evtMap), nil
 	}
 }
 
@@ -1025,6 +1025,7 @@ func PartitionConstraintConfigGetter(dbcqrs cqrs.Manager) queue.PartitionConstra
 				Limit:                     int(fn.Throttle.Limit),
 				Burst:                     int(fn.Throttle.Burst),
 				Period:                    int(fn.Throttle.Period.Seconds()),
+				Scope:                     fn.Throttle.Scope,
 			}
 		}
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1143,7 +1143,7 @@ func (e *executor) schedule(
 	//
 	// Create throttle information prior to creating state.  This is used in the queue.
 	//
-	throttle := queue.GetThrottleConfig(ctx, req.Function.ID, req.Function.Throttle, evtMap)
+	throttle := queue.GetThrottleConfig(ctx, metadata.ID, req.Function.Throttle, evtMap)
 
 	// Track skip reason and context for span attributes
 	var skipReason enums.SkipReason

--- a/pkg/execution/queue/backlog.go
+++ b/pkg/execution/queue/backlog.go
@@ -41,6 +41,9 @@ type BacklogConcurrencyKey struct {
 }
 
 type BacklogThrottle struct {
+	// Scope controls whether this throttle applies to the function, environment, or account.
+	Scope enums.ThrottleScope `json:"s,omitempty"`
+
 	// ThrottleKey is the hashed evaluated throttle key (e.g. hash("customer1")) or function ID (e.g. hash(fnID))
 	ThrottleKey string `json:"tk,omitempty"`
 
@@ -91,6 +94,11 @@ func (b QueueBacklog) IsOutdated(constraints PartitionConstraintConfig) enums.Qu
 	// Throttle removed - move items back to default backlog
 	if b.Throttle != nil && constraints.Throttle == nil {
 		return enums.QueueNormalizeReasonThrottleRemoved
+	}
+
+	// Throttle scope changed - move from old throttle key backlogs to the new throttle scope backlogs
+	if b.Throttle != nil && constraints.Throttle != nil && b.Throttle.Scope != constraints.Throttle.Scope {
+		return enums.QueueNormalizeReasonThrottleKeyChanged
 	}
 
 	// Throttle key changed - move from old throttle key backlogs to the new throttle key backlogs
@@ -201,6 +209,7 @@ func ItemBacklog(ctx context.Context, i QueueItem) QueueBacklog {
 		// This is always specified, even if no key was configured in the function definition.
 		// In that case, the Throttle Key is the hashed function ID. See Schedule() for more details.
 		b.Throttle = &BacklogThrottle{
+			Scope:                     i.Data.Throttle.Scope,
 			ThrottleKey:               i.Data.Throttle.Key,
 			ThrottleKeyExpressionHash: i.Data.Throttle.KeyExpressionHash,
 		}
@@ -278,6 +287,12 @@ type ThrottleKeyInput struct {
 	// EvaluatedValue is the evaluated value of the expression (e.g. "customer1").
 	// Only used when Expression is non-empty.
 	EvaluatedValue string
+
+	// Scope is the throttle scope (function, env, or account).
+	Scope enums.ThrottleScope
+
+	// ScopeID is the UUID of the entity (function, env, or account) that the throttle applies to.
+	ScopeID uuid.UUID
 }
 
 // BuildBacklogID constructs a backlog ID from its component parts, matching the format
@@ -296,8 +311,13 @@ func BuildBacklogID(functionID uuid.UUID, start bool, throttle *ThrottleKeyInput
 	if throttle != nil && start {
 		exprHash := util.XXHash(throttle.Expression)
 
-		// Throttle key: hashID(fnID) or hashID(fnID)-hashID(evaluatedValue)
-		throttleKey := HashID(context.Background(), functionID.String())
+		scopeID := throttle.ScopeID
+		if scopeID == uuid.Nil {
+			scopeID = functionID
+		}
+
+		// Throttle key: hashID(scopeID) or hashID(scopeID)-hashID(evaluatedValue).
+		throttleKey := HashID(context.Background(), throttleScopeKey(throttle.Scope, scopeID))
 		if throttle.Expression != "" {
 			throttleKey = throttleKey + "-" + HashID(context.Background(), throttle.EvaluatedValue)
 		}

--- a/pkg/execution/queue/backlog_test.go
+++ b/pkg/execution/queue/backlog_test.go
@@ -96,6 +96,34 @@ func TestBuildBacklogID_StartWithThrottleCustomExpression(t *testing.T) {
 	require.Equal(t, expected.BacklogID, got)
 }
 
+func TestBuildBacklogID_StartWithEnvThrottleCustomExpression(t *testing.T) {
+	fnID := uuid.New()
+	envID := uuid.New()
+
+	got := BuildBacklogID(fnID, true, &ThrottleKeyInput{
+		Expression:     "event.data.customerId",
+		EvaluatedValue: "customer-123",
+		Scope:          enums.ThrottleScopeEnv,
+		ScopeID:        envID,
+	}, nil)
+
+	throttleKey := HashID(context.Background(), "env:"+envID.String()) + "-" + HashID(context.Background(), "customer-123")
+	item := QueueItem{
+		FunctionID: fnID,
+		Data: Item{
+			Kind: KindStart,
+			Throttle: &Throttle{
+				Key:               throttleKey,
+				KeyExpressionHash: util.XXHash("event.data.customerId"),
+				Scope:             enums.ThrottleScopeEnv,
+			},
+		},
+	}
+	expected := ItemBacklog(context.Background(), item)
+
+	require.Equal(t, expected.BacklogID, got)
+}
+
 func TestBuildBacklogID_ThrottleIgnoredForNonStart(t *testing.T) {
 	fnID := uuid.New()
 

--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -34,6 +34,9 @@ type CustomConcurrencyLimit struct {
 }
 
 type PartitionThrottle struct {
+	// Scope controls whether this throttle applies to the function, environment, or account.
+	Scope enums.ThrottleScope `json:"s,omitempty"`
+
 	// ThrottleKeyExpressionHash is the hashed throttle key expression, if set.
 	ThrottleKeyExpressionHash string `json:"tkh,omitempty"`
 
@@ -170,6 +173,7 @@ func ConstraintConfigFromConstraints(
 
 	if constraints.Throttle != nil {
 		config.Throttle = append(config.Throttle, constraintapi.ThrottleConfig{
+			Scope:             constraints.Throttle.Scope,
 			Limit:             constraints.Throttle.Limit,
 			Burst:             constraints.Throttle.Burst,
 			Period:            constraints.Throttle.Period,
@@ -528,10 +532,14 @@ func constraintItemsFromBacklog(backlog *QueueBacklog, latestConstraints Partiti
 		)
 	}
 
-	if backlog.Throttle != nil && latestConstraints.Throttle != nil && backlog.Throttle.ThrottleKeyExpressionHash == latestConstraints.Throttle.ThrottleKeyExpressionHash {
+	if backlog.Throttle != nil &&
+		latestConstraints.Throttle != nil &&
+		backlog.Throttle.Scope == latestConstraints.Throttle.Scope &&
+		backlog.Throttle.ThrottleKeyExpressionHash == latestConstraints.Throttle.ThrottleKeyExpressionHash {
 		constraints = append(constraints, constraintapi.ConstraintItem{
 			Kind: constraintapi.ConstraintKindThrottle,
 			Throttle: &constraintapi.ThrottleConstraint{
+				Scope:             backlog.Throttle.Scope,
 				KeyExpressionHash: backlog.Throttle.ThrottleKeyExpressionHash,
 				EvaluatedKeyHash:  backlog.Throttle.ThrottleKey,
 			},

--- a/pkg/execution/queue/constraints_test.go
+++ b/pkg/execution/queue/constraints_test.go
@@ -175,6 +175,37 @@ func TestConstraintConfigFromConstraints(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "with account scoped throttle",
+			constraints: PartitionConstraintConfig{
+				FunctionVersion: 4,
+				Throttle: &PartitionThrottle{
+					Scope:                     enums.ThrottleScopeAccount,
+					Limit:                     10,
+					Burst:                     5,
+					Period:                    60,
+					ThrottleKeyExpressionHash: "account-throttle-hash",
+				},
+			},
+			expected: constraintapi.ConstraintConfig{
+				FunctionVersion: 4,
+				Concurrency: constraintapi.ConcurrencyConfig{
+					AccountConcurrency:     0,
+					FunctionConcurrency:    0,
+					AccountRunConcurrency:  0,
+					FunctionRunConcurrency: 0,
+				},
+				Throttle: []constraintapi.ThrottleConfig{
+					{
+						Scope:             enums.ThrottleScopeAccount,
+						Limit:             10,
+						Burst:             5,
+						Period:            60,
+						KeyExpressionHash: "account-throttle-hash",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -318,6 +349,94 @@ func TestConstraintItemsFromBacklog(t *testing.T) {
 					Burst:                     5,
 					Period:                    60,
 					ThrottleKeyExpressionHash: "new-throttle-expr-hash",
+				},
+			},
+			expected: []constraintapi.ConstraintItem{
+				{
+					Kind: constraintapi.ConstraintKindConcurrency,
+					Concurrency: &constraintapi.ConcurrencyConstraint{
+						Mode:  enums.ConcurrencyModeStep,
+						Scope: enums.ConcurrencyScopeAccount,
+					},
+				},
+				{
+					Kind: constraintapi.ConstraintKindConcurrency,
+					Concurrency: &constraintapi.ConcurrencyConstraint{
+						Mode:  enums.ConcurrencyModeStep,
+						Scope: enums.ConcurrencyScopeFn,
+					},
+				},
+			},
+		},
+		{
+			name: "with environment scoped throttle",
+			backlog: &QueueBacklog{
+				Throttle: &BacklogThrottle{
+					Scope:                     enums.ThrottleScopeEnv,
+					ThrottleKeyExpressionHash: "env-throttle-expr-hash",
+					ThrottleKey:               "env-throttle-key-value",
+				},
+			},
+			sp: &QueueShadowPartition{
+				PartitionID: fnID.String(),
+				AccountID:   &accountID,
+				FunctionID:  &fnID,
+			},
+			constraints: PartitionConstraintConfig{
+				Throttle: &PartitionThrottle{
+					Scope:                     enums.ThrottleScopeEnv,
+					Limit:                     10,
+					Burst:                     5,
+					Period:                    60,
+					ThrottleKeyExpressionHash: "env-throttle-expr-hash",
+				},
+			},
+			expected: []constraintapi.ConstraintItem{
+				{
+					Kind: constraintapi.ConstraintKindConcurrency,
+					Concurrency: &constraintapi.ConcurrencyConstraint{
+						Mode:  enums.ConcurrencyModeStep,
+						Scope: enums.ConcurrencyScopeAccount,
+					},
+				},
+				{
+					Kind: constraintapi.ConstraintKindConcurrency,
+					Concurrency: &constraintapi.ConcurrencyConstraint{
+						Mode:  enums.ConcurrencyModeStep,
+						Scope: enums.ConcurrencyScopeFn,
+					},
+				},
+				{
+					Kind: constraintapi.ConstraintKindThrottle,
+					Throttle: &constraintapi.ThrottleConstraint{
+						Scope:             enums.ThrottleScopeEnv,
+						KeyExpressionHash: "env-throttle-expr-hash",
+						EvaluatedKeyHash:  "env-throttle-key-value",
+					},
+				},
+			},
+		},
+		{
+			name: "throttle in backlog ignored when config has different scope",
+			backlog: &QueueBacklog{
+				Throttle: &BacklogThrottle{
+					Scope:                     enums.ThrottleScopeEnv,
+					ThrottleKeyExpressionHash: "throttle-expr-hash",
+					ThrottleKey:               "throttle-key-value",
+				},
+			},
+			sp: &QueueShadowPartition{
+				PartitionID: fnID.String(),
+				AccountID:   &accountID,
+				FunctionID:  &fnID,
+			},
+			constraints: PartitionConstraintConfig{
+				Throttle: &PartitionThrottle{
+					Scope:                     enums.ThrottleScopeAccount,
+					Limit:                     10,
+					Burst:                     5,
+					Period:                    60,
+					ThrottleKeyExpressionHash: "throttle-expr-hash",
 				},
 			},
 			expected: []constraintapi.ConstraintItem{

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/inngest/inngest/pkg/constraintapi"
@@ -379,6 +380,9 @@ type Throttle struct {
 	// Period is the rate limit period, in seconds
 	Period int `json:"p"`
 
+	// Scope controls whether this throttle applies to the function, environment, or account.
+	Scope enums.ThrottleScope `json:"s,omitempty"`
+
 	// UnhashedThrottleKey is the raw value returned after evaluating the key expression, if configured.
 	// Otherwise, this is the function ID. In the case of evaluated keys, this may be large and should be truncated before usage.
 	UnhashedThrottleKey string `json:"-"`
@@ -633,12 +637,33 @@ func HashID(_ context.Context, id string) string {
 	return strconv.FormatUint(ui, 36)
 }
 
-func GetThrottleConfig(ctx context.Context, fnID uuid.UUID, throttle *inngest.Throttle, evtMap map[string]any) *Throttle {
+func throttleScopeID(id sv2.ID, scope enums.ThrottleScope) uuid.UUID {
+	switch scope {
+	case enums.ThrottleScopeAccount:
+		return id.Tenant.AccountID
+	case enums.ThrottleScopeEnv:
+		return id.Tenant.EnvID
+	default:
+		return id.FunctionID
+	}
+}
+
+func throttleScopeKey(scope enums.ThrottleScope, scopeID uuid.UUID) string {
+	if scope == enums.ThrottleScopeFn {
+		return scopeID.String()
+	}
+
+	return fmt.Sprintf("%s:%s", strings.ToLower(scope.String()), scopeID)
+}
+
+func GetThrottleConfig(ctx context.Context, id sv2.ID, throttle *inngest.Throttle, evtMap map[string]any) *Throttle {
 	if throttle == nil {
 		return nil
 	}
 
-	unhashedThrottleKey := fnID.String()
+	scope := throttle.Scope
+	scopeID := throttleScopeID(id, scope)
+	unhashedThrottleKey := throttleScopeKey(scope, scopeID)
 	throttleKey := HashID(ctx, unhashedThrottleKey)
 	var throttleExpr string
 	if throttle.Key != nil {
@@ -655,6 +680,7 @@ func GetThrottleConfig(ctx context.Context, fnID uuid.UUID, throttle *inngest.Th
 		Limit:               int(throttle.Limit),
 		Burst:               int(throttle.Burst),
 		Period:              int(throttle.Period.Seconds()),
+		Scope:               scope,
 		UnhashedThrottleKey: unhashedThrottleKey,
 		KeyExpressionHash:   util.XXHash(throttleExpr),
 	}
@@ -753,7 +779,7 @@ func ConvertToConstraintConfiguration(accountConcurrency int, fn inngest.Functio
 			Limit:             int(fn.Throttle.Limit),
 			Burst:             int(fn.Throttle.Burst),
 			Period:            int(fn.Throttle.Period.Seconds()),
-			Scope:             enums.ThrottleScopeFn,
+			Scope:             fn.Throttle.Scope,
 			KeyExpressionHash: util.XXHash(throttleKey),
 		})
 	}

--- a/pkg/execution/queue/item_test.go
+++ b/pkg/execution/queue/item_test.go
@@ -1,11 +1,14 @@
 package queue
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/constraintapi"
 	"github.com/inngest/inngest/pkg/enums"
+	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/stretchr/testify/assert"
@@ -171,6 +174,89 @@ func TestDelay(t *testing.T) {
 			require.Equal(t, test.expectedLeaseDelay, test.qi.LeaseDelay(test.now))
 		})
 	}
+}
+
+func TestGetThrottleConfig(t *testing.T) {
+	ctx := context.Background()
+	fnID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	envID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	accountID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	id := sv2.ID{
+		FunctionID: fnID,
+		Tenant: sv2.Tenant{
+			EnvID:     envID,
+			AccountID: accountID,
+		},
+	}
+
+	t.Run("function scope preserves legacy key format", func(t *testing.T) {
+		key := "event.data.customer_id"
+		got := GetThrottleConfig(ctx, id, &inngest.Throttle{
+			Limit:  10,
+			Burst:  2,
+			Period: time.Minute,
+			Key:    &key,
+		}, map[string]any{
+			"data": map[string]any{
+				"customer_id": "cust_123",
+			},
+		})
+
+		require.NotNil(t, got)
+		require.Equal(t, enums.ThrottleScopeFn, got.Scope)
+		require.Equal(t, HashID(ctx, fnID.String())+"-"+HashID(ctx, "cust_123"), got.Key)
+		require.Equal(t, "cust_123", got.UnhashedThrottleKey)
+		require.Equal(t, util.XXHash(key), got.KeyExpressionHash)
+	})
+
+	t.Run("environment scope shares across function ids", func(t *testing.T) {
+		throttle := &inngest.Throttle{
+			Limit:  10,
+			Burst:  2,
+			Period: time.Minute,
+			Scope:  enums.ThrottleScopeEnv,
+		}
+		otherFunctionID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+		otherID := id
+		otherID.FunctionID = otherFunctionID
+
+		got := GetThrottleConfig(ctx, id, throttle, nil)
+		other := GetThrottleConfig(ctx, otherID, throttle, nil)
+
+		require.NotNil(t, got)
+		require.Equal(t, enums.ThrottleScopeEnv, got.Scope)
+		require.Equal(t, HashID(ctx, "env:"+envID.String()), got.Key)
+		require.Equal(t, got.Key, other.Key)
+	})
+
+	t.Run("account scope shares across environments", func(t *testing.T) {
+		key := "event.data.customer_id"
+		throttle := &inngest.Throttle{
+			Limit:  10,
+			Burst:  2,
+			Period: time.Minute,
+			Key:    &key,
+			Scope:  enums.ThrottleScopeAccount,
+		}
+		otherEnvID := uuid.MustParse("55555555-5555-5555-5555-555555555555")
+		otherID := id
+		otherID.Tenant.EnvID = otherEnvID
+		otherID.FunctionID = uuid.MustParse("66666666-6666-6666-6666-666666666666")
+
+		evt := map[string]any{
+			"data": map[string]any{
+				"customer_id": "cust_123",
+			},
+		}
+		got := GetThrottleConfig(ctx, id, throttle, evt)
+		other := GetThrottleConfig(ctx, otherID, throttle, evt)
+
+		require.NotNil(t, got)
+		require.Equal(t, enums.ThrottleScopeAccount, got.Scope)
+		require.Equal(t, HashID(ctx, "account:"+accountID.String())+"-"+HashID(ctx, "cust_123"), got.Key)
+		require.Equal(t, got.Key, other.Key)
+		require.Equal(t, util.XXHash(key), got.KeyExpressionHash)
+	})
 }
 
 func TestConvertToConstraintConfiguration(t *testing.T) {
@@ -477,6 +563,37 @@ func TestConvertToConstraintConfiguration(t *testing.T) {
 					CustomConcurrencyKeys: nil,
 				},
 				Throttle: nil,
+			},
+		},
+		{
+			name:               "function with environment scoped throttle",
+			accountConcurrency: 100,
+			fn: inngest.Function{
+				FunctionVersion: 9,
+				Throttle: &inngest.Throttle{
+					Limit:  20,
+					Burst:  5,
+					Period: 60 * time.Second,
+					Scope:  enums.ThrottleScopeEnv,
+				},
+			},
+			expected: constraintapi.ConstraintConfig{
+				FunctionVersion: 9,
+				RateLimit:       nil,
+				Concurrency: constraintapi.ConcurrencyConfig{
+					AccountConcurrency:    100,
+					FunctionConcurrency:   0,
+					CustomConcurrencyKeys: nil,
+				},
+				Throttle: []constraintapi.ThrottleConfig{
+					{
+						Limit:             20,
+						Burst:             5,
+						Period:            60,
+						Scope:             enums.ThrottleScopeEnv,
+						KeyExpressionHash: util.XXHash(""),
+					},
+				},
 			},
 		},
 	}

--- a/pkg/execution/queue/throttle.go
+++ b/pkg/execution/queue/throttle.go
@@ -28,6 +28,10 @@ func (q PartitionConstraintConfig) HasOutdatedThrottle(qi QueueItem) enums.Outda
 			return enums.OutdatedThrottleReasonMissingKeyExpressionHash
 		}
 
+		if itemThrottle.Scope != constraintThrottle.Scope {
+			return enums.OutdatedThrottleReasonKeyExpressionMismatch
+		}
+
 		// The key expression hash was set on both sides and changed: Throttle key expression was updated
 		if itemThrottle.KeyExpressionHash != constraintThrottle.ThrottleKeyExpressionHash {
 			return enums.OutdatedThrottleReasonKeyExpressionMismatch

--- a/pkg/execution/state/redis_state/backlog_test.go
+++ b/pkg/execution/state/redis_state/backlog_test.go
@@ -1020,6 +1020,25 @@ func TestBacklogIsOutdated(t *testing.T) {
 		require.Equal(t, enums.QueueNormalizeReasonUnchanged, backlog.IsOutdated(constraints))
 	})
 
+	t.Run("changing throttle scope should mark as outdated", func(t *testing.T) {
+		keyHash := util.XXHash("event.data.orgID")
+
+		constraints := osqueue.PartitionConstraintConfig{
+			Throttle: &osqueue.PartitionThrottle{
+				Scope:                     enums.ThrottleScopeAccount,
+				ThrottleKeyExpressionHash: keyHash,
+			},
+		}
+		backlog := &osqueue.QueueBacklog{
+			Throttle: &osqueue.BacklogThrottle{
+				Scope:                     enums.ThrottleScopeEnv,
+				ThrottleKeyExpressionHash: keyHash,
+			},
+		}
+
+		require.Equal(t, enums.QueueNormalizeReasonThrottleKeyChanged, backlog.IsOutdated(constraints))
+	})
+
 	t.Run("removing throttle key should mark as outdated", func(t *testing.T) {
 		keyHashOld := util.XXHash("event.data.customerID")
 

--- a/pkg/execution/state/redis_state/throttle_test.go
+++ b/pkg/execution/state/redis_state/throttle_test.go
@@ -79,6 +79,25 @@ func TestOutdatedThrottle(t *testing.T) {
 			},
 			expected: enums.OutdatedThrottleReasonKeyExpressionMismatch,
 		},
+		{
+			name: "changed throttle scope",
+			constraint: &osqueue.PartitionThrottle{
+				Scope:                     enums.ThrottleScopeAccount,
+				ThrottleKeyExpressionHash: util.XXHash("event.data.customerID"),
+				Limit:                     10,
+				Burst:                     1,
+				Period:                    60,
+			},
+			item: &osqueue.Throttle{
+				Scope:             enums.ThrottleScopeEnv,
+				Key:               util.XXHash("user1"),
+				KeyExpressionHash: util.XXHash("event.data.customerID"),
+				Limit:             10,
+				Burst:             1,
+				Period:            60,
+			},
+			expected: enums.OutdatedThrottleReasonKeyExpressionMismatch,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/inngest/function.go
+++ b/pkg/inngest/function.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	petname "github.com/dustinkirkland/golang-petname"
-	"github.com/fatih/structs"
 	"github.com/google/uuid"
 	"github.com/gosimple/slug"
 	multierror "github.com/hashicorp/go-multierror"
@@ -220,6 +219,9 @@ type Throttle struct {
 	// ID in an event you can use the following key: "{{ event.user.id }}".  This ensures
 	// that we throttle functions for each user independently.
 	Key *string `json:"key,omitempty"`
+	// Scope controls whether this throttle is isolated to the function or shared
+	// across the environment or account. Defaults to function scope.
+	Scope enums.ThrottleScope `json:"scope,omitempty"`
 }
 
 func (t *Throttle) UnmarshalJSON(in []byte) error {
@@ -229,10 +231,11 @@ func (t *Throttle) UnmarshalJSON(in []byte) error {
 
 	var err error
 	input := struct {
-		Limit  uint    `json:"limit"`
-		Period string  `json:"period"`
-		Burst  uint    `json:"burst"`
-		Key    *string `json:"key,omitempty"`
+		Limit  uint                `json:"limit"`
+		Period string              `json:"period"`
+		Burst  uint                `json:"burst"`
+		Key    *string             `json:"key,omitempty"`
+		Scope  enums.ThrottleScope `json:"scope,omitempty"`
 	}{}
 	if err = json.Unmarshal(in, &input); err != nil {
 		return err
@@ -241,6 +244,7 @@ func (t *Throttle) UnmarshalJSON(in []byte) error {
 	t.Limit = input.Limit
 	t.Burst = input.Burst
 	t.Key = input.Key
+	t.Scope = input.Scope
 	t.Period, err = str2duration.ParseDuration(input.Period)
 
 	// Normalization
@@ -255,12 +259,39 @@ func (t *Throttle) UnmarshalJSON(in []byte) error {
 }
 
 func (t Throttle) MarshalJSON() ([]byte, error) {
-	s := structs.New(t)
-	s.TagName = "json"
-	val := s.Map()
-	// convert period to a string.
-	val["period"] = str2duration.String(t.Period)
-	return json.Marshal(val)
+	output := struct {
+		Limit  uint    `json:"limit"`
+		Period string  `json:"period"`
+		Burst  uint    `json:"burst"`
+		Key    *string `json:"key,omitempty"`
+		Scope  *string `json:"scope,omitempty"`
+	}{
+		Limit:  t.Limit,
+		Period: str2duration.String(t.Period),
+		Burst:  t.Burst,
+		Key:    t.Key,
+	}
+
+	if t.Scope != enums.ThrottleScopeFn {
+		scope := strings.ToLower(t.Scope.String())
+		output.Scope = &scope
+	}
+
+	return json.Marshal(output)
+}
+
+func (t Throttle) Validate(ctx context.Context) error {
+	if !t.Scope.IsAThrottleScope() {
+		return fmt.Errorf("Invalid throttle scope: %s", t.Scope)
+	}
+
+	if t.Key != nil {
+		if _, err := expressions.NewExpressionEvaluator(ctx, *t.Key); err != nil {
+			return fmt.Errorf("Invalid throttle key '%s': %w", *t.Key, err)
+		}
+	}
+
+	return nil
 }
 
 // Timeouts represents timeouts for the function. If any of the timeouts are hit, the function
@@ -421,6 +452,12 @@ func (f Function) Validate(ctx context.Context) error {
 	if f.Concurrency != nil {
 		if cerr := f.Concurrency.Validate(ctx); cerr != nil {
 			err = multierror.Append(err, cerr)
+		}
+	}
+
+	if f.Throttle != nil {
+		if terr := f.Throttle.Validate(ctx); terr != nil {
+			err = multierror.Append(err, terr)
 		}
 	}
 

--- a/pkg/inngest/function_test.go
+++ b/pkg/inngest/function_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/enums"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,6 +45,36 @@ func TestURI(t *testing.T) {
 
 	actual := fn.URI()
 	require.EqualValues(t, *expected, *actual)
+}
+
+func TestThrottleJSONScope(t *testing.T) {
+	t.Run("defaults to function scope", func(t *testing.T) {
+		throttle := &Throttle{}
+		err := json.Unmarshal([]byte(`{"limit":2,"period":"1m","burst":1}`), throttle)
+		require.NoError(t, err)
+		require.Equal(t, enums.ThrottleScopeFn, throttle.Scope)
+
+		byt, err := json.Marshal(throttle)
+		require.NoError(t, err)
+		require.NotContains(t, string(byt), `"scope"`)
+	})
+
+	t.Run("accepts and marshals shared scopes", func(t *testing.T) {
+		throttle := &Throttle{}
+		err := json.Unmarshal([]byte(`{"limit":2,"period":"1m","burst":1,"scope":"env"}`), throttle)
+		require.NoError(t, err)
+		require.Equal(t, enums.ThrottleScopeEnv, throttle.Scope)
+
+		byt, err := json.Marshal(throttle)
+		require.NoError(t, err)
+		require.Contains(t, string(byt), `"scope":"env"`)
+	})
+
+	t.Run("rejects unknown scopes", func(t *testing.T) {
+		throttle := &Throttle{}
+		err := json.Unmarshal([]byte(`{"limit":2,"period":"1m","burst":1,"scope":"global"}`), throttle)
+		require.Error(t, err)
+	})
 }
 
 func TestValidate(t *testing.T) {
@@ -119,6 +150,35 @@ func TestValidate(t *testing.T) {
 			err := f.Validate(context.Background())
 			require.NotNil(t, err)
 			require.Contains(t, err.Error(), "Functions must contain one step")
+		})
+
+		t.Run("With an invalid throttle key", func(t *testing.T) {
+			f := Function{
+				Name: "hi",
+				Triggers: []Trigger{
+					{
+						EventTrigger: &EventTrigger{
+							Event: "fail",
+						},
+					},
+				},
+				Throttle: &Throttle{
+					Limit:  1,
+					Period: time.Minute,
+					Key:    strptr("invalid because not a string"),
+				},
+				Steps: []Step{
+					{
+						ID:   "step",
+						Name: "Function body",
+						URI:  "http://lol/what.xml.api",
+					},
+				},
+			}
+
+			err := f.Validate(context.Background())
+			require.NotNil(t, err)
+			require.Contains(t, err.Error(), "Invalid throttle key")
 		})
 	})
 }


### PR DESCRIPTION
## Description

Adds throttle scope plumbing so synced throttle configs can share buckets by function, environment, or account while preserving function scope as the default behavior.

This updates the server-side throttle configuration path, queue constraint generation, backlog normalization, GraphQL display model, and SDK spec documentation.

## Motivation

Closes #3701.

This lets users apply throttle limits across multiple functions or environments without every function receiving its own isolated throttle bucket.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

## Testing

- `go test ./pkg/inngest`
- `go test ./pkg/execution/queue -run 'Test(GetThrottleConfig|ConvertToConstraintConfiguration|BuildBacklogID|ConstraintConfigFromConstraints|ConstraintItemsFromBacklog|ConstraintItemsBacklogToLimitingConstraintRoundTrip)'`
- `go test ./pkg/execution/state/redis_state -run 'Test(OutdatedThrottle|BacklogIsOutdated)'`
- `go test ./pkg/coreapi/graph/models`
- `make gql`

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds throttle scope support so functions can share throttle buckets at the function (default), environment, or account level. The change threads `enums.ThrottleScope` through the queue item, backlog, constraint config, and GraphQL model layers. Backward compatibility is preserved: `ThrottleScopeFn = 0` is the zero value and is omitted from JSON serialization, so existing persisted queue items deserialize with function scope by default.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 854d652f0e190e27490efa6b9dedc69d576178a4.</sup>
<!-- /MENDRAL_SUMMARY -->