### PR TITLE
Persist AppID in constraint API request state

### DIFF
--- a/pkg/constraintapi/acquire.go
+++ b/pkg/constraintapi/acquire.go
@@ -33,6 +33,7 @@ type redisRequestState struct {
 	OperationIdempotencyKey string    `json:"k,omitempty"`
 	EnvID                   uuid.UUID `json:"e,omitempty"`
 	FunctionID              uuid.UUID `json:"f,omitempty"`
+	AppID                   uuid.UUID `json:"ai,omitempty"`
 
 	// SortedConstraints represents the list of constraints
 	// included in the request sorted to execute in the expected
@@ -76,6 +77,7 @@ func buildRequestState(req *CapacityAcquireRequest) (
 		OperationIdempotencyKey: req.IdempotencyKey,
 		EnvID:                   req.EnvID,
 		FunctionID:              req.FunctionID,
+		AppID:                   req.AppID,
 		RequestedAmount:         req.Amount,
 		MaximumLifetimeMillis:   req.MaximumLifetime.Milliseconds(),
 		ConfigVersion:           req.Configuration.FunctionVersion,

--- a/pkg/constraintapi/redis_test.go
+++ b/pkg/constraintapi/redis_test.go
@@ -69,6 +69,7 @@ func TestRedisCapacityManager_RateLimit(t *testing.T) {
 		AccountID:            accountID,
 		EnvID:                envID,
 		FunctionID:           fnID,
+		AppID:                uuid.New(),
 		Amount:               1,
 		LeaseIdempotencyKeys: []string{leaseIdempotencyKey},
 		IdempotencyKey:       "event1",
@@ -237,6 +238,26 @@ func TestRedisCapacityManager_RateLimit(t *testing.T) {
 		require.Contains(t, keys, cm.keyOperationIdempotency(accountID, "rel", "release-test"))
 		require.Contains(t, keys, cm.keyOperationIdempotency(accountID, "chk", checkHash))
 	})
+}
+
+func TestRedisRequestState_AppIDRoundTrip(t *testing.T) {
+	appID := uuid.New()
+
+	state := redisRequestState{
+		AppID: appID,
+	}
+
+	body, err := json.Marshal(state)
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"ai":`)
+
+	var decoded redisRequestState
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	require.Equal(t, appID, decoded.AppID)
+
+	var knownGood redisRequestState
+	require.NoError(t, json.Unmarshal([]byte(`{"ai":"`+appID.String()+`"}`), &knownGood))
+	require.Equal(t, appID, knownGood.AppID)
 }
 
 func TestRedisCapacityManager_Concurrency(t *testing.T) {


### PR DESCRIPTION
## Description

Adds AppID (json:"ai") to redisRequestState so the steps_running background [poller](https://github.com/inngest/monorepo/pull/6989) can read it back and emit app_id in gauge tags. Without this commit, the poller can't include app_id (it has no way to know the AppID), so dashboards that filter by app_id would silently lose data for any account that switched over to the poller. 

Companion [PR](https://github.com/inngest/monorepo/pull/6989): "Add background steps_running poller"

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [X] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `AppID` (JSON key `"ai"`) to `redisRequestState` so the background `steps_running` poller can read it back and include `app_id` in gauge metric tags. Without this, dashboards filtering by `app_id` would silently lose data for accounts using the poller.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4b8b4d5688701ff4df6face052007ecbe53a8708.</sup>
<!-- /MENDRAL_SUMMARY -->