### PR TITLE
fix: add authentication to /invoke/{slug} endpoint

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -311,7 +312,38 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 
 // Invoke creates an event to invoke a specific function.
 func (a API) Invoke(w http.ResponseWriter, r *http.Request) {
-	// XXX: In OSS self hosting, check signing keys here.
+	if a.requireKeys && len(a.localEventKeys) == 0 {
+		a.log.Error("rejecting invoke; event keys are required to invoke functions securely")
+		w.Header().Add("Content-Type", "application/json")
+		a.writeResponse(w, apiResponse{
+			StatusCode: http.StatusServiceUnavailable,
+			Error:      "Event keys are required to invoke functions securely",
+		})
+		return
+	}
+
+	if len(a.localEventKeys) > 0 {
+		key := r.Header.Get("Authorization")
+		if len(key) > 7 && strings.ToUpper(key[0:6]) == "BEARER" {
+			key = key[7:]
+		}
+
+		var found bool
+		for _, k := range a.localEventKeys {
+			if k == key {
+				found = true
+				break
+			}
+		}
+		if !found {
+			w.Header().Add("Content-Type", "application/json")
+			a.writeResponse(w, apiResponse{
+				StatusCode: http.StatusUnauthorized,
+				Error:      "Unauthorized",
+			})
+			return
+		}
+	}
 
 	// Get the function slug from the route parameter.   This is the function
 	// we'll invoke.  Any request is passed as the event data to the function.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -324,7 +324,7 @@ func (a API) Invoke(w http.ResponseWriter, r *http.Request) {
 
 	if len(a.localEventKeys) > 0 {
 		key := r.Header.Get("Authorization")
-		if len(key) > 7 && strings.ToUpper(key[0:6]) == "BEARER" {
+		if len(key) > 7 && strings.ToUpper(key[0:7]) == "BEARER " {
 			key = key[7:]
 		}
 


### PR DESCRIPTION
## Summary

The `POST /invoke/{slug}` endpoint was missing event key validation, allowing unauthenticated function invocation in self-hosted deployments running `inngest start` with signing keys and event keys configured.

The adjacent `POST /e/{key}` endpoint correctly validates event keys and returns 401 for invalid keys. This PR adds the same validation to the invoke endpoint, which accepts the event key via the `Authorization: Bearer <key>` header.

## Reproduction

```bash
inngest start --signing-key "<hex-key>" --event-key "my-key"

# Rejected (401):
curl -X POST -H "Content-Type: application/json" \
  -d '{"name":"test","data":{}}' \
  http://localhost:8288/e/wrong-key

# Accepted (200) — should be rejected:
curl -X POST -H "Content-Type: application/json" \
  -d '{"name":"test","data":{}}' \
  http://localhost:8288/invoke/any-slug
```

## Test plan

- [x] `inngest start` with event key: `POST /invoke/{slug}` without auth returns 401
- [x] `inngest start` with event key: `POST /invoke/{slug}` with valid `Authorization: Bearer <event-key>` returns 200
- [x] `inngest dev` (no keys): `POST /invoke/{slug}` continues to work without auth
- [x] Existing event ingestion via `POST /e/{key}` is unaffected

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds event key authentication to the `POST /invoke/{slug}` endpoint, which previously allowed unauthenticated function invocation in self-hosted deployments. The fix mirrors the key validation already present in `ReceiveEvent`, adapted for `Authorization: Bearer` header delivery. A follow-up commit addressed the off-by-one in the Bearer prefix check flagged in the previous review.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7a29a6d3ad98f3fbbbf2afb0e09488c247abf362.</sup>
<!-- /MENDRAL_SUMMARY -->