### PR TITLE
fix: add authentication to GraphQL endpoint

### DIFF
--- a/pkg/coreapi/coreapi.go
+++ b/pkg/coreapi/coreapi.go
@@ -108,9 +108,8 @@ func NewCoreApi(o Options) (*CoreAPI, error) {
 		}
 		srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: a.resolver}))
 
-		// TODO - Add option for enabling GraphQL Playground
-		a.Handle("/", playground.Handler("GraphQL playground", "/v0/gql"))
-		a.Handle("/gql", srv)
+		a.With(o.AuthMiddleware).Handle("/", playground.Handler("GraphQL playground", "/v0/gql"))
+		a.With(o.AuthMiddleware).Handle("/gql", srv)
 	}
 
 	// V0 APIs


### PR DESCRIPTION
## Summary

The GraphQL handler (`/v0/gql`) and playground (`/v0/`) were registered without the `AuthMiddleware` that protects adjacent REST endpoints on the same router. In `inngest start` with a signing key configured, REST endpoints like `DELETE /runs/{runID}` correctly return 401 for unauthenticated requests, but GraphQL queries succeed without credentials.

This wraps both handlers with `o.AuthMiddleware`, matching the pattern used by the REST endpoints.

## Reproduction

```bash
inngest start --signing-key "<hex-key>" --event-key "my-key"

# Correctly rejected (401):
curl -X DELETE http://localhost:8288/v0/runs/01HTESTID

# Returns full schema (200) — should be rejected:
curl -X POST -H "Content-Type: application/json" \
  -d '{"query":"{ __schema { types { name } } }"}' \
  http://localhost:8288/v0/gql
```

## Test plan

- [x] `inngest start` with signing key: `POST /v0/gql` without auth returns 401
- [x] `inngest start` with signing key: `POST /v0/gql` with valid signing key returns schema
- [x] `inngest dev` (no keys): GraphQL continues to work without auth
- [x] Existing REST endpoints unaffected

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> The GraphQL handler (`/v0/gql`) and playground (`/v0/`) were registered without `AuthMiddleware`, allowing unauthenticated access to the full GraphQL schema even when a signing key was configured. This PR wraps both handlers with `o.AuthMiddleware`, matching the pattern already used by all REST endpoints on the same router.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit c142f1da8d1e7ecc9c0e68b2aa86455b4292bb72.</sup>
<!-- /MENDRAL_SUMMARY -->