### PR TITLE
fix(apiv2): use camelCase for InvokeFunction params

### DIFF
--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -1010,7 +1010,7 @@ service V2 {
 
   rpc InvokeFunction(InvokeFunctionRequest) returns (InvokeFunctionResponse) {
     option (google.api.http) = {
-      post: "/apps/{app_id}/functions/{function_id}/invoke",
+      post: "/apps/{appId}/functions/{functionId}/invoke",
       body: "*"
     };
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
@@ -1437,7 +1437,7 @@ message PatchEnvsResponse {
 }
 
 message InvokeFunctionRequest {
-  string function_id = 1 [
+  string functionId = 1 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "The ID of the function to invoke"
       example: "\"my-app-hello-world\""
@@ -1449,13 +1449,13 @@ message InvokeFunctionRequest {
       example: "{\"message\": \"Hello, World!\"}"
     }
   ];
-  optional string idempotency_key = 3 [
+  optional string idempotencyKey = 3 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Optional idempotency key to handle duplicate requests within a given idempotency period."
       example: "\"user-action-123\""
     }
   ];
-  string app_id = 4 [
+  string appId = 4 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "The ID of the app containing the function"
       example: "\"my-app\""
@@ -1470,23 +1470,23 @@ message InvokeFunctionResponse {
 }
 
 message InvokeFunctionData {
-  string run_id = 1 [
+  string runId = 1 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Unique identifier for this function execution"
       example: "\"01hp1zx8m3ng9vp6qn0xk7j4cy\""
     }
   ];
-  google.protobuf.Timestamp queued_at = 2 [
+  google.protobuf.Timestamp queuedAt = 2 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Timestamp when the function execution was enqueued"
     }
   ];
-  optional google.protobuf.Timestamp started_at = 3 [
+  optional google.protobuf.Timestamp startedAt = 3 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Timestamp when the function execution started (if started)"
     }
   ];
-  optional google.protobuf.Timestamp completed_at = 4 [
+  optional google.protobuf.Timestamp completedAt = 4 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Timestamp when the function execution completed (if finished)"
     }

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -2090,10 +2090,10 @@ func (x *PatchEnvsResponse) GetMetadata() *ResponseMetadata {
 
 type InvokeFunctionRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
-	FunctionId     string                 `protobuf:"bytes,1,opt,name=function_id,json=functionId,proto3" json:"function_id,omitempty"`
+	FunctionId     string                 `protobuf:"bytes,1,opt,name=functionId,proto3" json:"functionId,omitempty"`
 	Data           *structpb.Struct       `protobuf:"bytes,2,opt,name=data,proto3" json:"data,omitempty"`
-	IdempotencyKey *string                `protobuf:"bytes,3,opt,name=idempotency_key,json=idempotencyKey,proto3,oneof" json:"idempotency_key,omitempty"`
-	AppId          string                 `protobuf:"bytes,4,opt,name=app_id,json=appId,proto3" json:"app_id,omitempty"`
+	IdempotencyKey *string                `protobuf:"bytes,3,opt,name=idempotencyKey,proto3,oneof" json:"idempotencyKey,omitempty"`
+	AppId          string                 `protobuf:"bytes,4,opt,name=appId,proto3" json:"appId,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -2210,10 +2210,10 @@ func (x *InvokeFunctionResponse) GetMetadata() *ResponseMetadata {
 
 type InvokeFunctionData struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	RunId         string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
-	QueuedAt      *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=queued_at,json=queuedAt,proto3" json:"queued_at,omitempty"`
-	StartedAt     *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=started_at,json=startedAt,proto3,oneof" json:"started_at,omitempty"`
-	CompletedAt   *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=completed_at,json=completedAt,proto3,oneof" json:"completed_at,omitempty"`
+	RunId         string                 `protobuf:"bytes,1,opt,name=runId,proto3" json:"runId,omitempty"`
+	QueuedAt      *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=queuedAt,proto3" json:"queuedAt,omitempty"`
+	StartedAt     *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=startedAt,proto3,oneof" json:"startedAt,omitempty"`
+	CompletedAt   *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=completedAt,proto3,oneof" json:"completedAt,omitempty"`
 	Result        *string                `protobuf:"bytes,5,opt,name=result,proto3,oneof" json:"result,omitempty"`
 	Error         *string                `protobuf:"bytes,6,opt,name=error,proto3,oneof" json:"error,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -2672,27 +2672,28 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\v_isArchived\"j\n" +
 	"\x11PatchEnvsResponse\x12\x1f\n" +
 	"\x04data\x18\x01 \x01(\v2\v.api.v2.EnvR\x04data\x124\n" +
-	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\x84\x04\n" +
-	"\x15InvokeFunctionRequest\x12\\\n" +
-	"\vfunction_id\x18\x01 \x01(\tB;\x92A82 The ID of the function to invokeJ\x14\"my-app-hello-world\"R\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\x80\x04\n" +
+	"\x15InvokeFunctionRequest\x12[\n" +
+	"\n" +
+	"functionId\x18\x01 \x01(\tB;\x92A82 The ID of the function to invokeJ\x14\"my-app-hello-world\"R\n" +
 	"functionId\x12\x86\x01\n" +
-	"\x04data\x18\x02 \x01(\v2\x17.google.protobuf.StructBY\x92AV26JSON object containing the input data for the functionJ\x1c{\"message\": \"Hello, World!\"}R\x04data\x12\x9e\x01\n" +
-	"\x0fidempotency_key\x18\x03 \x01(\tBp\x92Am2XOptional idempotency key to handle duplicate requests within a given idempotency period.J\x11\"user-action-123\"H\x00R\x0eidempotencyKey\x88\x01\x01\x12O\n" +
-	"\x06app_id\x18\x04 \x01(\tB8\x92A52)The ID of the app containing the functionJ\b\"my-app\"R\x05appIdB\x12\n" +
-	"\x10_idempotency_key\"~\n" +
+	"\x04data\x18\x02 \x01(\v2\x17.google.protobuf.StructBY\x92AV26JSON object containing the input data for the functionJ\x1c{\"message\": \"Hello, World!\"}R\x04data\x12\x9d\x01\n" +
+	"\x0eidempotencyKey\x18\x03 \x01(\tBp\x92Am2XOptional idempotency key to handle duplicate requests within a given idempotency period.J\x11\"user-action-123\"H\x00R\x0eidempotencyKey\x88\x01\x01\x12N\n" +
+	"\x05appId\x18\x04 \x01(\tB8\x92A52)The ID of the app containing the functionJ\b\"my-app\"R\x05appIdB\x11\n" +
+	"\x0f_idempotencyKey\"~\n" +
 	"\x16InvokeFunctionResponse\x12.\n" +
 	"\x04data\x18\x01 \x01(\v2\x1a.api.v2.InvokeFunctionDataR\x04data\x124\n" +
-	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\xba\x06\n" +
-	"\x12InvokeFunctionData\x12g\n" +
-	"\x06run_id\x18\x01 \x01(\tBP\x92AM2-Unique identifier for this function executionJ\x1c\"01hp1zx8m3ng9vp6qn0xk7j4cy\"R\x05runId\x12p\n" +
-	"\tqueued_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampB7\x92A422Timestamp when the function execution was enqueuedR\bqueuedAt\x12\x7f\n" +
-	"\n" +
-	"started_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampB?\x92A<2:Timestamp when the function execution started (if started)H\x00R\tstartedAt\x88\x01\x01\x12\x86\x01\n" +
-	"\fcompleted_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampBB\x92A?2=Timestamp when the function execution completed (if finished)H\x01R\vcompletedAt\x88\x01\x01\x12\xb9\x01\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\xb4\x06\n" +
+	"\x12InvokeFunctionData\x12f\n" +
+	"\x05runId\x18\x01 \x01(\tBP\x92AM2-Unique identifier for this function executionJ\x1c\"01hp1zx8m3ng9vp6qn0xk7j4cy\"R\x05runId\x12o\n" +
+	"\bqueuedAt\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampB7\x92A422Timestamp when the function execution was enqueuedR\bqueuedAt\x12~\n" +
+	"\tstartedAt\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampB?\x92A<2:Timestamp when the function execution started (if started)H\x00R\tstartedAt\x88\x01\x01\x12\x85\x01\n" +
+	"\vcompletedAt\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampBB\x92A?2=Timestamp when the function execution completed (if finished)H\x01R\vcompletedAt\x88\x01\x01\x12\xb9\x01\n" +
 	"\x06result\x18\x05 \x01(\tB\x9b\x01\x92A\x97\x012aJSON string containing the function result (only available for completed synchronous invocations)J2\"{\\\"success\\\": true, \\\"data\\\": \\\"Hello, World!\\\"}\"H\x02R\x06result\x88\x01\x01\x12N\n" +
-	"\x05error\x18\x06 \x01(\tB3\x92A02.Error message if the function execution failedH\x03R\x05error\x88\x01\x01B\r\n" +
-	"\v_started_atB\x0f\n" +
-	"\r_completed_atB\t\n" +
+	"\x05error\x18\x06 \x01(\tB3\x92A02.Error message if the function execution failedH\x03R\x05error\x88\x01\x01B\f\n" +
+	"\n" +
+	"_startedAtB\x0e\n" +
+	"\f_completedAtB\t\n" +
 	"\a_resultB\b\n" +
 	"\x06_error\"\xa1\x01\n" +
 	"\x0eSyncAppRequest\x12,\n" +
@@ -2719,7 +2720,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\n" +
 	"FilterType\x12\t\n" +
 	"\x05ALLOW\x10\x00\x12\b\n" +
-	"\x04DENY\x10\x012\x8dN\n" +
+	"\x04DENY\x10\x012\x8bN\n" +
 	"\x02V2\x12\xb2\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\xf8\x01\x92A\xe5\x01\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
 	"\x03401\x12K\n" +
@@ -2981,8 +2982,8 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x19:\x01*\"\x14/apps/{app_id}/syncs\x12\xf1\v\n" +
-	"\x0eInvokeFunction\x12\x1d.api.v2.InvokeFunctionRequest\x1a\x1e.api.v2.InvokeFunctionResponse\"\x9f\v\x92A\xe3\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x19:\x01*\"\x14/apps/{app_id}/syncs\x12\xef\v\n" +
+	"\x0eInvokeFunction\x12\x1d.api.v2.InvokeFunctionRequest\x1a\x1e.api.v2.InvokeFunctionResponse\"\x9d\v\x92A\xe3\n" +
 	"\x12\x0fInvoke function\x1a\x81\x01Invokes a function, executing the function either asynchronously or synchronously based on the mode parameter in the request bodyJn\n" +
 	"\x03200\x12g\n" +
 	"9Function invoked synchronously and has finished executing\x12*\n" +
@@ -3019,7 +3020,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x022:\x01*\"-/apps/{app_id}/functions/{function_id}/invokeB\xc8\x02\x92A\x91\x02\x12\x9b\x01\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x020:\x01*\"+/apps/{appId}/functions/{functionId}/invokeB\xc8\x02\x92A\x91\x02\x12\x9b\x01\n" +
 	"\x13Inngest REST API v2\x12}The v2 API delivers a significantly improved developer experience with consistent design patterns and enhanced functionality.2\x052.0.0\x1a\x0fapi.inngest.com\"\x03/v2*\x01\x02ZX\n" +
 	"V\n" +
 	"\n" +
@@ -3133,9 +3134,9 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	44, // 43: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
 	38, // 44: api.v2.InvokeFunctionResponse.data:type_name -> api.v2.InvokeFunctionData
 	8,  // 45: api.v2.InvokeFunctionResponse.metadata:type_name -> api.v2.ResponseMetadata
-	43, // 46: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
-	43, // 47: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
-	43, // 48: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
+	43, // 46: api.v2.InvokeFunctionData.queuedAt:type_name -> google.protobuf.Timestamp
+	43, // 47: api.v2.InvokeFunctionData.startedAt:type_name -> google.protobuf.Timestamp
+	43, // 48: api.v2.InvokeFunctionData.completedAt:type_name -> google.protobuf.Timestamp
 	41, // 49: api.v2.SyncAppResponse.data:type_name -> api.v2.SyncAppData
 	8,  // 50: api.v2.SyncAppResponse.metadata:type_name -> api.v2.ResponseMetadata
 	42, // 51: api.v2.SyncAppData.error:type_name -> api.v2.SyncAppError

--- a/proto/gen/api/v2/service.pb.gw.go
+++ b/proto/gen/api/v2/service.pb.gw.go
@@ -435,21 +435,21 @@ func request_V2_InvokeFunction_0(ctx context.Context, marshaler runtime.Marshale
 	if req.Body != nil {
 		_, _ = io.Copy(io.Discard, req.Body)
 	}
-	val, ok := pathParams["app_id"]
+	val, ok := pathParams["appId"]
 	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "app_id")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "appId")
 	}
 	protoReq.AppId, err = runtime.String(val)
 	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "app_id", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "appId", err)
 	}
-	val, ok = pathParams["function_id"]
+	val, ok = pathParams["functionId"]
 	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "function_id")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "functionId")
 	}
 	protoReq.FunctionId, err = runtime.String(val)
 	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "function_id", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "functionId", err)
 	}
 	msg, err := client.InvokeFunction(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
@@ -464,21 +464,21 @@ func local_request_V2_InvokeFunction_0(ctx context.Context, marshaler runtime.Ma
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
-	val, ok := pathParams["app_id"]
+	val, ok := pathParams["appId"]
 	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "app_id")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "appId")
 	}
 	protoReq.AppId, err = runtime.String(val)
 	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "app_id", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "appId", err)
 	}
-	val, ok = pathParams["function_id"]
+	val, ok = pathParams["functionId"]
 	if !ok {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "function_id")
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "functionId")
 	}
 	protoReq.FunctionId, err = runtime.String(val)
 	if err != nil {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "function_id", err)
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "functionId", err)
 	}
 	msg, err := server.InvokeFunction(ctx, &protoReq)
 	return msg, metadata, err
@@ -736,7 +736,7 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		var stream runtime.ServerTransportStream
 		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/InvokeFunction", runtime.WithHTTPPathPattern("/apps/{app_id}/functions/{function_id}/invoke"))
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/InvokeFunction", runtime.WithHTTPPathPattern("/apps/{appId}/functions/{functionId}/invoke"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -998,7 +998,7 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/InvokeFunction", runtime.WithHTTPPathPattern("/apps/{app_id}/functions/{function_id}/invoke"))
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/InvokeFunction", runtime.WithHTTPPathPattern("/apps/{appId}/functions/{functionId}/invoke"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -1027,7 +1027,7 @@ var (
 	pattern_V2_ListWebhooks_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"env", "webhooks"}, ""))
 	pattern_V2_PatchEnv_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"envs", "id"}, ""))
 	pattern_V2_SyncApp_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"apps", "app_id", "syncs"}, ""))
-	pattern_V2_InvokeFunction_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"apps", "app_id", "functions", "function_id", "invoke"}, ""))
+	pattern_V2_InvokeFunction_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"apps", "appId", "functions", "functionId", "invoke"}, ""))
 )
 
 var (

--- a/tests/api/v2_invoke_test.go
+++ b/tests/api/v2_invoke_test.go
@@ -128,7 +128,7 @@ func TestV2InvokeFunctionIdempotency(t *testing.T) {
 	// First invoke with idempotency key
 	resp1, err := postInvoke(ctx, appID, fnID, map[string]any{
 		"data":            map[string]any{"key": "value"},
-		"idempotency_key": "test-key-1",
+		"idempotencyKey": "test-key-1",
 	})
 	r.NoError(err)
 	defer resp1.Body.Close()
@@ -143,7 +143,7 @@ func TestV2InvokeFunctionIdempotency(t *testing.T) {
 	// Second invoke with same idempotency key → 409
 	resp2, err := postInvoke(ctx, appID, fnID, map[string]any{
 		"data":            map[string]any{"key": "value"},
-		"idempotency_key": "test-key-1",
+		"idempotencyKey": "test-key-1",
 	})
 	r.NoError(err)
 	defer resp2.Body.Close()
@@ -158,7 +158,7 @@ func TestV2InvokeFunctionIdempotency(t *testing.T) {
 	// Third invoke with different idempotency key → 200
 	resp3, err := postInvoke(ctx, appID, fnID, map[string]any{
 		"data":            map[string]any{"key": "value"},
-		"idempotency_key": "test-key-2",
+		"idempotencyKey": "test-key-2",
 	})
 	r.NoError(err)
 	defer resp3.Body.Close()


### PR DESCRIPTION
## Summary

The new REST API v2 invoke endpoint was using snake_case for its URL path placeholders and JSON body fields, breaking the v2 design principle of "camelCase everywhere" (per `pkg/api/v2/CLAUDE.md`). This PR aligns the invoke endpoint with the rest of the v2 API.

### Changes

- **InvokeFunctionRequest**: `function_id` → `functionId`, `idempotency_key` → `idempotencyKey`, `app_id` → `appId`
- **InvokeFunctionData**: `run_id` → `runId`, `queued_at` → `queuedAt`, `started_at` → `startedAt`, `completed_at` → `completedAt`
- **URL**: `/apps/{app_id}/functions/{function_id}/invoke` → `/apps/{appId}/functions/{functionId}/invoke`
- Regenerated `service.pb.go` and `service.pb.gw.go` via `buf generate`
- Updated `tests/api/v2_invoke_test.go` to send `idempotencyKey` instead of `idempotency_key`

The Go field names on the generated structs (e.g. `FunctionId`, `RunId`) are unchanged, so no downstream Go callers needed updates. Other v2 endpoints that still use snake_case (e.g. `SyncApp`) are intentionally left out of scope.

## Test plan

- [x] `go build ./pkg/api/v2/... ./proto/gen/api/v2/...` passes
- [x] `go test ./pkg/api/v2/...` passes
- [x] Generated OpenAPI spec shows `/apps/{appId}/functions/{functionId}/invoke` and camelCase request/response fields
- [ ] Run `tests/api/v2_invoke_test.go` against a dev server end-to-end

https://claude.ai/code/session_01EGPr8icZaNJixzJf6yBR31

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGPr8icZaNJixzJf6yBR31)_

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Renames proto fields in `InvokeFunctionRequest` and `InvokeFunctionData` from snake_case to camelCase to align the invoke endpoint with the v2 API design principle of "camelCase everywhere". Updates URL path placeholders, JSON field names, regenerated Go bindings, and integration tests accordingly.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 109e4676c4ff3b6e4d1509bdb49a5a8757dab95b.</sup>
<!-- /MENDRAL_SUMMARY -->