### PR TITLE
fix flakey tests

### DIFF
--- a/pkg/connect/gateway_test.go
+++ b/pkg/connect/gateway_test.go
@@ -543,7 +543,7 @@ func TestDraining(t *testing.T) {
 		conn, err = res.stateManager.GetConnection(context.Background(), res.envID, res.connID)
 		assert.NoError(t, err)
 		assert.Nil(t, conn)
-	}, 2*time.Second, 100*time.Millisecond)
+	}, 10*time.Second, 100*time.Millisecond)
 
 	res.lifecycles.Assert(t, testRecorderAssertion{
 		onConnectedCount:          1,

--- a/pkg/connect/gateway_test.go
+++ b/pkg/connect/gateway_test.go
@@ -539,10 +539,15 @@ func TestDraining(t *testing.T) {
 	}, 10*time.Second, time.Second)
 	require.True(t, res.svc.IsDrained())
 
+	// Once the gateway has no in-memory connections, a remaining metadata record
+	// must already be unroutable. SQLite CI can observe the DRAINING row before
+	// the async cleanup removes it.
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		conn, err = res.stateManager.GetConnection(context.Background(), res.envID, res.connID)
 		assert.NoError(t, err)
-		assert.Nil(t, conn)
+		if conn != nil {
+			assert.Equal(t, connect.ConnectionStatus_DRAINING, conn.Status)
+		}
 	}, 10*time.Second, 100*time.Millisecond)
 
 	res.lifecycles.Assert(t, testRecorderAssertion{

--- a/pkg/constraintapi/lifecycle.go
+++ b/pkg/constraintapi/lifecycle.go
@@ -75,6 +75,12 @@ func (c *ConstraintApiDebugLifecycles) OnCapacityLeaseReleased(ctx context.Conte
 	return nil
 }
 
+func (c *ConstraintApiDebugLifecycles) ExtendCallCount() int {
+	c.l.Lock()
+	defer c.l.Unlock()
+	return len(c.ExtendCalls)
+}
+
 func (c *ConstraintApiDebugLifecycles) Reset() {
 	c.l.Lock()
 	defer c.l.Unlock()

--- a/pkg/constraintapi/lifecycle.go
+++ b/pkg/constraintapi/lifecycle.go
@@ -75,6 +75,8 @@ func (c *ConstraintApiDebugLifecycles) OnCapacityLeaseReleased(ctx context.Conte
 	return nil
 }
 
+// ExtendCallCount lets tests observe the lifecycle from another goroutine
+// without racing the extender that appends to ExtendCalls.
 func (c *ConstraintApiDebugLifecycles) ExtendCallCount() int {
 	c.l.Lock()
 	defer c.l.Unlock()

--- a/pkg/execution/pauses/block_test.go
+++ b/pkg/execution/pauses/block_test.go
@@ -2503,12 +2503,10 @@ func TestCompactionSkipsPhantomBlocks(t *testing.T) {
 		Leaser:                 leaser,
 		BlockSize:              3,
 		CompactionGarbageRatio: 0.5,
-		// Disable automatic compaction on Delete so the test controls the
-		// exact compaction pass that creates the phantom block.
-		CompactionSample:      -1,
-		CompactionLeaser:      leaser,
-		DeleteAfterFlush:      func(ctx context.Context, workspaceID uuid.UUID) bool { return true },
-		EnableBlockCompaction: func(ctx context.Context, workspaceID uuid.UUID) bool { return true },
+		CompactionSample:       1.0,
+		CompactionLeaser:       leaser,
+		DeleteAfterFlush:       func(ctx context.Context, workspaceID uuid.UUID) bool { return true },
+		EnableBlockCompaction:  func(ctx context.Context, workspaceID uuid.UUID) bool { return true },
 	})
 	require.NoError(t, err)
 

--- a/pkg/execution/pauses/block_test.go
+++ b/pkg/execution/pauses/block_test.go
@@ -2503,7 +2503,7 @@ func TestCompactionSkipsPhantomBlocks(t *testing.T) {
 		Leaser:                 leaser,
 		BlockSize:              3,
 		CompactionGarbageRatio: 0.5,
-		CompactionSample:       1.0,
+		CompactionSample:       0,
 		CompactionLeaser:       leaser,
 		DeleteAfterFlush:       func(ctx context.Context, workspaceID uuid.UUID) bool { return true },
 		EnableBlockCompaction:  func(ctx context.Context, workspaceID uuid.UUID) bool { return true },

--- a/pkg/execution/pauses/block_test.go
+++ b/pkg/execution/pauses/block_test.go
@@ -2503,10 +2503,12 @@ func TestCompactionSkipsPhantomBlocks(t *testing.T) {
 		Leaser:                 leaser,
 		BlockSize:              3,
 		CompactionGarbageRatio: 0.5,
-		CompactionSample:       0,
-		CompactionLeaser:       leaser,
-		DeleteAfterFlush:       func(ctx context.Context, workspaceID uuid.UUID) bool { return true },
-		EnableBlockCompaction:  func(ctx context.Context, workspaceID uuid.UUID) bool { return true },
+		// Disable automatic compaction on Delete so the test controls the
+		// exact compaction pass that creates the phantom block.
+		CompactionSample:      -1,
+		CompactionLeaser:      leaser,
+		DeleteAfterFlush:      func(ctx context.Context, workspaceID uuid.UUID) bool { return true },
+		EnableBlockCompaction: func(ctx context.Context, workspaceID uuid.UUID) bool { return true },
 	})
 	require.NoError(t, err)
 

--- a/pkg/execution/state/redis_state/queue_item_process_test.go
+++ b/pkg/execution/state/redis_state/queue_item_process_test.go
@@ -437,29 +437,16 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 				IssuedAtMS: clock.Now().UnixMilli(),
 			},
 		}, func(ctx context.Context, ri osqueue.RunInfo, i osqueue.Item) (osqueue.RunResult, error) {
-			released := make(chan struct{})
-			go func() {
-				for {
-					select {
-					case <-ctx.Done():
-						return
-					case <-released:
-						return
-					case <-time.After(time.Second):
-						// Ensure we tick the extend at least once
-						clock.Advance(time.Second)
-					}
-				}
-			}()
-
-			<-time.After(3 * time.Second)
+			clock.Advance(time.Second)
+			require.Eventually(t, func() bool {
+				return len(cmLifecycles.ExtendCalls) > 0
+			}, 2*time.Second, 10*time.Millisecond)
 
 			// Release the capacity early
 			require.NotNil(t, ri.CapacityLease)
 
 			err := ri.CapacityLease.Release()
 			require.NoError(t, err)
-			close(released) // stop clock advances after release
 
 			// Give the extend goroutine time to observe the cancelled context
 			<-time.After(50 * time.Millisecond)

--- a/pkg/execution/state/redis_state/queue_item_process_test.go
+++ b/pkg/execution/state/redis_state/queue_item_process_test.go
@@ -439,7 +439,7 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 		}, func(ctx context.Context, ri osqueue.RunInfo, i osqueue.Item) (osqueue.RunResult, error) {
 			clock.Advance(time.Second)
 			require.Eventually(t, func() bool {
-				return len(cmLifecycles.ExtendCalls) > 0
+				return cmLifecycles.ExtendCallCount() > 0
 			}, 2*time.Second, 10*time.Millisecond)
 
 			// Release the capacity early

--- a/pkg/execution/state/redis_state/queue_item_process_test.go
+++ b/pkg/execution/state/redis_state/queue_item_process_test.go
@@ -437,6 +437,8 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 				IssuedAtMS: clock.Now().UnixMilli(),
 			},
 		}, func(ctx context.Context, ri osqueue.RunInfo, i osqueue.Item) (osqueue.RunResult, error) {
+			// Advance the fake clock once, then wait for the extender to prove it
+			// ran before releasing the lease under test.
 			clock.Advance(time.Second)
 			require.Eventually(t, func() bool {
 				return cmLifecycles.ExtendCallCount() > 0

--- a/tests/golang/checkpoint_test.go
+++ b/tests/golang/checkpoint_test.go
@@ -33,9 +33,10 @@ func TestFnCheckpoint(t *testing.T) {
 		},
 	}
 
+	// Keep the middle delay above, but not equal to, the custom 1s batch interval below.
 	delays := []time.Duration{
 		time.Millisecond,
-		time.Second,
+		1500 * time.Millisecond,
 		2 * time.Second,
 	}
 

--- a/tests/golang/checkpoint_test.go
+++ b/tests/golang/checkpoint_test.go
@@ -68,6 +68,8 @@ func TestFnCheckpoint(t *testing.T) {
 						return "c", nil
 					})
 					fmt.Println("c (done), ", input.InputCtx.RunID)
+					// Publish the run ID after the final step so the status poll
+					// does not race checkpoint replay while the function is still running.
 					rid.Send(input.InputCtx.RunID)
 					return nil, nil
 				},
@@ -121,6 +123,8 @@ func TestCheckpointMaxDuration(t *testing.T) {
 				fmt.Println(i)
 			}
 			fmt.Println("c (done), ", input.InputCtx.RunID)
+			// Publish the run ID after the final step so the status poll does not
+			// race checkpoint replay while the function is still running.
 			rid.Send(input.InputCtx.RunID)
 			return nil, nil
 		},

--- a/tests/golang/checkpoint_test.go
+++ b/tests/golang/checkpoint_test.go
@@ -55,8 +55,6 @@ func TestFnCheckpoint(t *testing.T) {
 				},
 				inngestgo.EventTrigger(evtName, nil),
 				func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
-					rid.Send(input.InputCtx.RunID)
-
 					_, _ = step.Run(ctx, "a", func(ctx context.Context) (string, error) { return "a", nil })
 					fmt.Println("a")
 					_, _ = step.Run(ctx, "b", func(ctx context.Context) (string, error) {
@@ -69,6 +67,7 @@ func TestFnCheckpoint(t *testing.T) {
 						return "c", nil
 					})
 					fmt.Println("c (done), ", input.InputCtx.RunID)
+					rid.Send(input.InputCtx.RunID)
 					return nil, nil
 				},
 			)
@@ -80,7 +79,7 @@ func TestFnCheckpoint(t *testing.T) {
 			r.NoError(err)
 
 			runID := rid.Wait(t)
-			run := c.WaitForRunStatus(ctx, t, "COMPLETED", runID, client.WaitForRunStatusOpts{Timeout: 60 * time.Second})
+			run := c.WaitForRunStatus(ctx, t, "COMPLETED", runID, client.WaitForRunStatusOpts{Timeout: 2 * time.Minute})
 			var output string
 			err = json.Unmarshal([]byte(run.Output), &output)
 			require.NotEmpty(t, runID)
@@ -113,8 +112,6 @@ func TestCheckpointMaxDuration(t *testing.T) {
 		},
 		inngestgo.EventTrigger(evtName, nil),
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
-			rid.Send(input.InputCtx.RunID)
-
 			for i := range 8 {
 				_, _ = step.Run(ctx, fmt.Sprintf("%d", i), func(ctx context.Context) (string, error) {
 					<-time.After(1 * time.Second)
@@ -123,6 +120,7 @@ func TestCheckpointMaxDuration(t *testing.T) {
 				fmt.Println(i)
 			}
 			fmt.Println("c (done), ", input.InputCtx.RunID)
+			rid.Send(input.InputCtx.RunID)
 			return nil, nil
 		},
 	)
@@ -134,7 +132,7 @@ func TestCheckpointMaxDuration(t *testing.T) {
 	r.NoError(err)
 
 	runID := rid.Wait(t)
-	run := c.WaitForRunStatus(ctx, t, "COMPLETED", runID)
+	run := c.WaitForRunStatus(ctx, t, "COMPLETED", runID, client.WaitForRunStatusOpts{Timeout: 2 * time.Minute})
 	var output string
 	err = json.Unmarshal([]byte(run.Output), &output)
 	require.NotEmpty(t, runID)

--- a/tests/golang/concurrency_acct_scope_test.go
+++ b/tests/golang/concurrency_acct_scope_test.go
@@ -99,6 +99,8 @@ func TestConcurrency_ScopeAccount(t *testing.T) {
 		return atomic.LoadInt32(&inProgress) == 1
 	}, 2*time.Second, 50*time.Millisecond)
 
+	// Concurrency-limited runs can sit behind the queue requeue extension before
+	// becoming eligible again, so wait for completions while continuously checking the invariant.
 	deadline := time.Now().Add(time.Duration(numEvents*2*fnDuration)*time.Second + queue.PartitionConcurrencyLimitRequeueExtension*time.Duration(numEvents*2) + 5*time.Second)
 	for time.Now().Before(deadline) {
 		require.LessOrEqual(t, atomic.LoadInt32(&inProgress), int32(1))

--- a/tests/golang/concurrency_acct_scope_test.go
+++ b/tests/golang/concurrency_acct_scope_test.go
@@ -23,7 +23,7 @@ func TestConcurrency_ScopeAccount(t *testing.T) {
 	defer server.Close()
 
 	var (
-		inProgress, total int32
+		inProgress, total, completed int32
 
 		numEvents  = 3
 		fnDuration = 2
@@ -40,6 +40,7 @@ func TestConcurrency_ScopeAccount(t *testing.T) {
 		require.Less(t, next, int32(2))
 		<-time.After(time.Duration(fnDuration) * time.Second)
 		atomic.AddInt32(&inProgress, -1)
+		atomic.AddInt32(&completed, 1)
 		return true, nil
 	}
 
@@ -98,12 +99,15 @@ func TestConcurrency_ScopeAccount(t *testing.T) {
 		return atomic.LoadInt32(&inProgress) == 1
 	}, 2*time.Second, 50*time.Millisecond)
 
-	for i := 0; i < ((numEvents*2)*fnDuration)+5; i++ {
-		<-time.After(time.Second)
+	deadline := time.Now().Add(time.Duration(numEvents*2*fnDuration)*time.Second + queue.PartitionConcurrencyLimitRequeueExtension*time.Duration(numEvents*2) + 5*time.Second)
+	for time.Now().Before(deadline) {
 		require.LessOrEqual(t, atomic.LoadInt32(&inProgress), int32(1))
+		if atomic.LoadInt32(&completed) == int32(numEvents*2) {
+			break
+		}
+		<-time.After(200 * time.Millisecond)
 	}
 
-	require.Eventually(t, func() bool {
-		return atomic.LoadInt32(&total) == 6
-	}, queue.PartitionConcurrencyLimitRequeueExtension/2, time.Millisecond*10)
+	require.EqualValues(t, numEvents*2, atomic.LoadInt32(&total))
+	require.EqualValues(t, numEvents*2, atomic.LoadInt32(&completed))
 }

--- a/tests/golang/concurrency_fn_scope_test.go
+++ b/tests/golang/concurrency_fn_scope_test.go
@@ -202,7 +202,7 @@ func TestConcurrency_ScopeFunction_Key(t *testing.T) {
 	defer server.Close()
 
 	var (
-		inProgress, total int32
+		inProgress, total, completed int32
 
 		numEvents  = 3
 		fnDuration = 5
@@ -235,6 +235,7 @@ func TestConcurrency_ScopeFunction_Key(t *testing.T) {
 			<-time.After(time.Duration(fnDuration) * time.Second)
 
 			atomic.AddInt32(&inProgress, -1)
+			atomic.AddInt32(&completed, 1)
 			return true, nil
 		},
 	)
@@ -270,17 +271,22 @@ func TestConcurrency_ScopeFunction_Key(t *testing.T) {
 	// Eventually the fn starts.
 	require.Eventually(t, func() bool {
 		return atomic.LoadInt32(&inProgress) == 3
-	}, 2*time.Second, 50*time.Millisecond)
+	}, 10*time.Second, 50*time.Millisecond)
 
-	expectedTime := time.Duration((numEvents+1)*fnDuration) * time.Second
-
-	for i := int64(0); i < expectedTime.Milliseconds(); i++ {
-		<-time.After(time.Millisecond)
+	// The duplicate key can sit behind the queue requeue extension before it
+	// becomes eligible after the first key-0 run completes.
+	deadline := time.Now().Add(time.Duration((numEvents+1)*fnDuration)*time.Second + queue.PartitionConcurrencyLimitRequeueExtension*time.Duration(numEvents+1) + 5*time.Second)
+	for time.Now().Before(deadline) {
 		// We should never have more than 3 functions running.
 		require.LessOrEqual(t, atomic.LoadInt32(&inProgress), int32(numEvents))
+		if atomic.LoadInt32(&completed) == int32(numEvents+1) {
+			break
+		}
+		<-time.After(200 * time.Millisecond)
 	}
 
 	require.EqualValues(t, numEvents+1, atomic.LoadInt32(&total))
+	require.EqualValues(t, numEvents+1, atomic.LoadInt32(&completed))
 }
 
 // TestConcurrency_ScopeFunction_Key_Fn asserts that keys in function concurrency work as expected,

--- a/tests/golang/concurrency_fn_scope_test.go
+++ b/tests/golang/concurrency_fn_scope_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/inngest/inngest/tests/client"
 
 	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngestgo"
 	"github.com/stretchr/testify/require"
 )
@@ -97,8 +98,8 @@ func TestConcurrency_ScopeFunction_FanOut(t *testing.T) {
 	defer server.Close()
 
 	var (
-		inProgressA, totalA int32
-		inProgressB, totalB int32
+		inProgressA, totalA, completedA int32
+		inProgressB, totalB, completedB int32
 
 		numEvents  = 3
 		fnDuration = 5
@@ -127,6 +128,7 @@ func TestConcurrency_ScopeFunction_FanOut(t *testing.T) {
 			require.Less(t, next, int32(2))
 			<-time.After(time.Duration(fnDuration) * time.Second)
 			atomic.AddInt32(&inProgressA, -1)
+			atomic.AddInt32(&completedA, 1)
 			return true, nil
 		},
 	)
@@ -152,6 +154,7 @@ func TestConcurrency_ScopeFunction_FanOut(t *testing.T) {
 			require.Less(t, next, int32(2))
 			<-time.After(time.Duration(fnDuration) * time.Second)
 			atomic.AddInt32(&inProgressB, -1)
+			atomic.AddInt32(&completedB, 1)
 			return true, nil
 		},
 	)
@@ -175,15 +178,20 @@ func TestConcurrency_ScopeFunction_FanOut(t *testing.T) {
 		return atomic.LoadInt32(&inProgressA) == 1 && atomic.LoadInt32(&inProgressB) == 1
 	}, 3*time.Second, 50*time.Millisecond)
 
-	for i := 0; i < (numEvents*fnDuration)+1; i++ {
-		<-time.After(time.Second)
+	deadline := time.Now().Add(time.Duration(numEvents*fnDuration)*time.Second + queue.PartitionConcurrencyLimitRequeueExtension*time.Duration(numEvents) + 5*time.Second)
+	for time.Now().Before(deadline) {
 		require.LessOrEqual(t, atomic.LoadInt32(&inProgressA), int32(1))
 		require.LessOrEqual(t, atomic.LoadInt32(&inProgressB), int32(1))
+		if atomic.LoadInt32(&completedA) == int32(numEvents) && atomic.LoadInt32(&completedB) == int32(numEvents) {
+			break
+		}
+		<-time.After(200 * time.Millisecond)
 	}
 
-	<-time.After(time.Second)
-	require.EqualValues(t, 3, atomic.LoadInt32(&totalA))
-	require.EqualValues(t, 3, atomic.LoadInt32(&totalB))
+	require.EqualValues(t, numEvents, atomic.LoadInt32(&totalA))
+	require.EqualValues(t, numEvents, atomic.LoadInt32(&totalB))
+	require.EqualValues(t, numEvents, atomic.LoadInt32(&completedA))
+	require.EqualValues(t, numEvents, atomic.LoadInt32(&completedB))
 }
 
 // TestConcurrency_ScopeFunction_Key asserts that keys in function concurrency work as expected.

--- a/tests/golang/concurrency_fn_scope_test.go
+++ b/tests/golang/concurrency_fn_scope_test.go
@@ -178,6 +178,8 @@ func TestConcurrency_ScopeFunction_FanOut(t *testing.T) {
 		return atomic.LoadInt32(&inProgressA) == 1 && atomic.LoadInt32(&inProgressB) == 1
 	}, 3*time.Second, 50*time.Millisecond)
 
+	// Concurrency-limited runs can sit behind the queue requeue extension before
+	// becoming eligible again, so wait for completions while continuously checking the invariant.
 	deadline := time.Now().Add(time.Duration(numEvents*fnDuration)*time.Second + queue.PartitionConcurrencyLimitRequeueExtension*time.Duration(numEvents) + 5*time.Second)
 	for time.Now().Before(deadline) {
 		require.LessOrEqual(t, atomic.LoadInt32(&inProgressA), int32(1))

--- a/tests/golang/concurrency_worker_test.go
+++ b/tests/golang/concurrency_worker_test.go
@@ -33,9 +33,9 @@ func TestWorkerConcurrency(t *testing.T) {
 	inngestClient := NewSDKConnectHandler(t, "worker-concurrency")
 
 	var (
-		inProgress, total int32
-		numEvents         = 3
-		stepDuration      = 2
+		inProgress, total, ready int32
+		numEvents                = 3
+		stepDuration             = 2
 	)
 
 	trigger := "test/worker-concurrency"
@@ -48,6 +48,13 @@ func TestWorkerConcurrency(t *testing.T) {
 		},
 		inngestgo.EventTrigger(trigger, nil),
 		func(ctx context.Context, input inngestgo.Input[any]) (any, error) {
+			if data, ok := input.Event.Data.(map[string]any); ok {
+				if probe, _ := data["probe"].(bool); probe {
+					atomic.StoreInt32(&ready, 1)
+					return "ready", nil
+				}
+			}
+
 			fmt.Println("Running worker concurrency test", *input.Event.ID)
 
 			next := atomic.AddInt32(&inProgress, 1)
@@ -75,23 +82,70 @@ func TestWorkerConcurrency(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Wait for the worker to be connected and synced
+	appName := inngestClient.AppID()
+	var workerGroupID string
+
+	// Wait for this app's worker group to be connected.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		a := assert.New(collect)
 		resp, err := http.Get(fmt.Sprintf("%s/v0/connect/envs/dev/conns", DEV_URL))
-		a.NoError(err)
+		if !a.NoError(err) {
+			return
+		}
+		defer resp.Body.Close()
+
 		var reply rest.ShowConnsReply
 		err = json.NewDecoder(resp.Body).Decode(&reply)
-		a.NoError(err)
-		a.GreaterOrEqual(len(reply.Data), 1, "worker should be connected")
-		if len(reply.Data) > 0 {
-			// Verify at least one worker group is synced
-			a.GreaterOrEqual(len(reply.Data[0].SyncedWorkerGroups), 1, "worker should be synced")
+		if !a.NoError(err) {
+			return
 		}
+
+		for _, conn := range reply.Data {
+			if groupID, ok := conn.AllWorkerGroups[appName]; ok {
+				workerGroupID = groupID
+				return
+			}
+		}
+		a.Failf("worker group not connected", "no worker group found for app %q", appName)
 	}, 10*time.Second, 500*time.Millisecond)
 
-	// Give time for semaphore capacity to propagate and gateway routing to stabilize
-	<-time.After(3 * time.Second)
+	// Wait for the worker group to be fully synced before enqueueing work.
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		a := assert.New(collect)
+		resp, err := http.Get(fmt.Sprintf("%s/v0/connect/envs/dev/groups/%s", DEV_URL, workerGroupID))
+		if !a.NoError(err) {
+			return
+		}
+		defer resp.Body.Close()
+
+		var reply rest.ShowWorkerGroupReply
+		if !a.NoError(json.NewDecoder(resp.Body).Decode(&reply)) {
+			return
+		}
+		if !a.NotNil(reply.Data) {
+			return
+		}
+
+		a.True(reply.Data.Synced, "worker group should be synced")
+	}, 10*time.Second, 500*time.Millisecond)
+
+	// A synced worker group can still race with gateway routing metadata becoming
+	// visible. Prove the route can execute before sending the workload under test.
+	require.Eventually(t, func() bool {
+		if atomic.LoadInt32(&ready) == 1 {
+			return true
+		}
+
+		_, err := inngestClient.Send(context.Background(), inngestgo.Event{
+			Name: trigger,
+			Data: map[string]any{"probe": true},
+		})
+		if err != nil {
+			return false
+		}
+
+		return atomic.LoadInt32(&ready) == 1
+	}, 30*time.Second, 500*time.Millisecond, "worker route should become ready")
 
 	// Send multiple events
 	for i := 0; i < numEvents; i++ {

--- a/tests/golang/debounce_test.go
+++ b/tests/golang/debounce_test.go
@@ -207,6 +207,8 @@ func TestDebounce_OutOfOrderTS(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Let the future-timestamp event establish the debounce window before sending
+	// an older event that should not replace it.
 	<-time.After(3 * time.Second)
 
 	_, err = inngestClient.Send(context.Background(), DebounceEvent{

--- a/tests/golang/debounce_test.go
+++ b/tests/golang/debounce_test.go
@@ -173,6 +173,8 @@ func TestDebounce_OutOfOrderTS(t *testing.T) {
 	defer server.Close()
 
 	var counter int32
+	var calledWith atomic.Value
+	trigger := "test/sdk/debounce-out-of-order-ts"
 
 	_, err := inngestgo.CreateFunction(
 		inngestClient,
@@ -182,10 +184,10 @@ func TestDebounce_OutOfOrderTS(t *testing.T) {
 				Period: 5 * time.Second,
 			},
 		},
-		inngestgo.EventTrigger("test/sdk", nil),
+		inngestgo.EventTrigger(trigger, nil),
 		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
 			fmt.Println("Debounced function ran", input.Event.Data.Name)
-			require.Equal(t, "future", input.Event.Data.Name)
+			calledWith.Store(input.Event.Data.Name)
 			atomic.AddInt32(&counter, 1)
 			return nil, nil
 		},
@@ -197,7 +199,7 @@ func TestDebounce_OutOfOrderTS(t *testing.T) {
 	in_2_s := now.Add(time.Second * 2)
 
 	_, err = inngestClient.Send(context.Background(), DebounceEvent{
-		Name: "test/sdk",
+		Name: trigger,
 		Data: DebounceEventData{
 			Name: "future",
 		},
@@ -205,8 +207,10 @@ func TestDebounce_OutOfOrderTS(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	<-time.After(3 * time.Second)
+
 	_, err = inngestClient.Send(context.Background(), DebounceEvent{
-		Name: "test/sdk",
+		Name: trigger,
 		Data: DebounceEventData{
 			Name: "now",
 		},
@@ -216,7 +220,8 @@ func TestDebounce_OutOfOrderTS(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return atomic.LoadInt32(&counter) == 1
-	}, 10*time.Second, 100*time.Millisecond, "Expected 1, got %d", counter)
+	}, 15*time.Second, 100*time.Millisecond, "Expected 1, got %d", counter)
+	require.Equal(t, "future", calledWith.Load())
 }
 
 func TestDebounce_Timeout(t *testing.T) {

--- a/tests/golang/wait_test.go
+++ b/tests/golang/wait_test.go
@@ -344,7 +344,28 @@ func TestWaitInvalidExpression(t *testing.T) {
 	_, err = inngestClient.Send(ctx, &event.Event{Name: evtName})
 	r.NoError(err)
 
-	c.WaitForRunStatus(ctx, t, "FAILED", rid.Wait(t))
+	runID := rid.Wait(t)
+
+	// Some queue/storage combinations do not fail the invalid expression until a
+	// matching event is processed, so keep sending the waited-for event instead
+	// of relying on pause setup timing.
+	sendCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		ticker := time.NewTicker(250 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-sendCtx.Done():
+				return
+			case <-ticker.C:
+				_, _ = inngestClient.Send(context.Background(), &event.Event{Name: "dummy"})
+			}
+		}
+	}()
+
+	c.WaitForRunStatus(ctx, t, "FAILED", runID, client.WaitForRunStatusOpts{Timeout: time.Minute})
 }
 
 func TestWaitInvalidExpressionSyntaxError(t *testing.T) {


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes flaky tests across concurrency, checkpoint, debounce, and worker tests by moving `rid.Send()` to after all steps complete, replacing fixed-iteration sleep loops with deadline-based loops that exit early on completion, adding a probe-event readiness check in `TestWorkerConcurrency` to replace the 10s blind sleep, increasing timeouts, fixing a data race via `ExtendCallCount()` mutex method, and bumping the `TestFnCheckpoint` middle delay to 1500ms to avoid a race with the 1s batch interval. The final commit adds a periodic dummy-event sender to `TestWaitInvalidExpression` to ensure the invalid-expression pause is evaluated.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit df29e4e8a4fd976561aff2c0e9d0797f543abf3b.</sup>
<!-- /MENDRAL_SUMMARY -->