### PR TITLE
fix(devserver): wire SQL history reader, drop in-memory mirror

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -65,8 +65,6 @@ import (
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/expressions"
 	"github.com/inngest/inngest/pkg/expressions/expragg"
-	"github.com/inngest/inngest/pkg/history_drivers/memory_reader"
-	"github.com/inngest/inngest/pkg/history_drivers/memory_writer"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/metrics"
 	"github.com/inngest/inngest/pkg/pubsub"
@@ -484,8 +482,6 @@ func start(ctx context.Context, opts StartOpts) error {
 		return fmt.Errorf("failed to create publisher: %w", err)
 	}
 
-	hmw := memory_writer.NewWriter(ctx, memory_writer.WriterOptions{DumpToFile: false})
-
 	tp := tracing.NewSqlcTracerProvider(adapter.Q())
 
 	url := opts.Config.CoreAPI.Addr
@@ -517,7 +513,6 @@ func start(ctx context.Context, opts StartOpts) error {
 				history.NewLifecycleListener(
 					nil,
 					hd,
-					hmw,
 				),
 				Lifecycle{
 					Cqrs:       dbcqrs,
@@ -608,7 +603,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	)
 
 	// The devserver embeds the event API.
-	ds := NewService(opts, runner, dbcqrs, pb, stepLimitOverrides, stateSizeLimitOverrides, unshardedRc, hmw, nil)
+	ds := NewService(opts, runner, dbcqrs, pb, stepLimitOverrides, stateSizeLimitOverrides, unshardedRc, hd, nil)
 	ds.State = sm
 	ds.Queue = rq
 	ds.Executor = exec
@@ -631,7 +626,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		Queue:          ds.Queue,
 		EventHandler:   ds.HandleEvent,
 		Executor:       ds.Executor,
-		HistoryReader:  memory_reader.NewReader(),
+		HistoryReader:  base_cqrs.NewHistoryReader(adapter),
 		DisableGraphQL: &opts.NoUI,
 		ConnectOpts: connectv0.Opts{
 			GroupManager:               connectionManager,


### PR DESCRIPTION
Closes #3892 (or at least the dominant retention path of it).

## Description

The in-memory history mirror in `pkg/history_drivers/memory_store` grows unbounded under sustained load. `Singleton.Data` is never deleted: every run accumulates a `[]history.History` slice with full `Result.Output` strings retained for the entire process lifetime.

The mirror's only consumer is the GraphQL dashboard via `memory_reader.NewReader()`. The same data is already being durably written to Postgres/SQLite by the SQL history driver (`hd`, devserver.go:209), and `base_cqrs.NewHistoryReader` already implements the same `history_reader.Reader` interface — it just wasn't wired up.

This PR wires the GraphQL resolvers to the SQL reader and stops registering the in-memory writer.

## Why this is the right fix

Method-by-method, the SQL reader is at parity or strictly better than the memory reader:

| Method | `memory_reader` | `base_cqrs.reader` |
|---|---|---|
| `CountRuns` | `len(store.Data)` (only the mirror's view) | `q.HistoryCountRuns` (durable count) |
| `GetRun` / `GetFunctionRun` | map lookup | `q.GetFunctionRun` |
| `GetFunctionRunsFromEvents` | linear scan | indexed query |
| `GetRunHistory` | slice from `RunData.History` | `q.HistoryGetRunHistory` over `function_run_history` |
| `GetRunHistoryItemOutput` | linear scan | per-item query |
| `GetRuns` | **ignores `opts`, returns ALL runs** | respects filters |
| `GetRunsByEventID` | linear scan | indexed query |
| `GetSkippedRunsByEventID`, `GetUsage`, `GetReplayRuns`, `CountReplayRuns`, `GetActiveRunIDs`, `CountActiveRuns` | `not implemented` | `not implemented` (parity) |

The behavioural difference users will see: the dashboard's `GetRuns` now respects its `opts` filters instead of returning every cached run unfiltered. That's a correctness improvement, not a regression.

After this change `pkg/history_drivers/memory_{store,reader,writer}` have no remaining consumers in the codebase. They can be deleted in a follow-up PR (kept here for reviewability).

## Why now

Issue #3892 has been open since March with five+ users reporting the same shape, and an unofficial fork (`killfill/inngest`) shipping a FIFO cap as a workaround. Capping is a partial fix — it bounds count but not per-entry size, evicts in-flight runs by insertion order, and is only available as an unofficial Docker image. Removing the redundancy is the proper fix because the SQL store is already the source of truth for durable history; the mirror is just a stale, ever-growing copy.

## Test plan

- Existing `go.yaml` lint and unit tests should pass — no interface changes, no new code.
- Existing dashboard e2e (`e2e.yml`) should pass — same data, same shape.
- Manual: `inngest start` + Postgres, drive load, confirm dashboard `/runs` lists, drill-in, history, and step output panels still work.
- Manual: `inngest dev` with default SQLite, same checks.
- Soak: 24h workload comparable to #3892's repro, watch RSS — should plateau instead of growing linearly.

## Alternative if you'd rather keep the mirror

Happy to rework as either of:

1. Gate the in-memory wiring on `opts.NoUI` (or a new `--in-memory-history` flag), default to SQL — preserves the option for users who want the in-memory speedup.
2. Keep the mirror, FIFO-cap it (similar to https://github.com/killfill/inngest/commit/a0ebc222ab64952acdb73bcd842f45a47d7a1323) — partial fix but smaller behavioural change.

Drop the mirror feels like the architecturally correct choice given it's a redundant cache of data that's already durably stored, but I defer to maintainer preference.


## Results on our machine with high traffic.

So far so good, no climbing memory usage, and UI works fine. Around 10:00 we switched version.

<img width="1822" height="385" alt="image" src="https://github.com/user-attachments/assets/5a8de268-e852-4016-bf00-ffc1432aee81" />


## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the unbounded in-memory history mirror (`memory_writer`/`memory_reader`) from the dev server and wires the existing SQL-backed `base_cqrs.NewHistoryReader` and `hd` (`history.Driver`) in their place. The change is a 2-line addition / 7-line deletion with no new code paths.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 302afb96d39a9c1e48720655e14047855f7f650e.</sup>
<!-- /MENDRAL_SUMMARY -->