### PR TITLE
Add RequestTime to constraint checks using EnqueuedAt

### DIFF
--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -74,6 +74,37 @@ type BacklogRefillConstraintCheckResult struct {
 	RetryAfter time.Time
 }
 
+// enqueuedAtTime returns the wall-clock enqueue time for a queue item, or the
+// zero value when the item predates the EnqueuedAt schema field. Returning
+// zero is important: the constraint cache treats a zero RequestTime as
+// unanchored and falls back to its default behavior, so legacy items behave
+// the same as before.
+func enqueuedAtTime(item *QueueItem) time.Time {
+	if item == nil || item.EnqueuedAt == 0 {
+		return time.Time{}
+	}
+	return time.UnixMilli(item.EnqueuedAt)
+}
+
+// earliestEnqueuedAt returns the oldest EnqueuedAt across the items, used as
+// RequestTime on batched Acquire calls. Items already waiting in the queue
+// when the constraint cache populated an "exhausted" entry must bypass that
+// stale entry once capacity is freed; the cache compares cache addedAt
+// against RequestTime and only bypasses when RequestTime is older.
+func earliestEnqueuedAt(items []*QueueItem) time.Time {
+	var earliest time.Time
+	for _, item := range items {
+		t := enqueuedAtTime(item)
+		if t.IsZero() {
+			continue
+		}
+		if earliest.IsZero() || t.Before(earliest) {
+			earliest = t
+		}
+	}
+	return earliest
+}
+
 func ConvertLimitingConstraint(
 	constraints PartitionConstraintConfig,
 	limitingConstraints []constraintapi.ConstraintItem,
@@ -246,6 +277,7 @@ func (q *queueProcessor) BacklogRefillConstraintCheck(
 		IdempotencyKey:       operationIdempotencyKey,
 		FunctionID:           *shadowPart.FunctionID,
 		CurrentTime:          now,
+		RequestTime:          earliestEnqueuedAt(items),
 		Duration:             QueueLeaseDuration,
 		Constraints:          constraintsToCheck,
 		Configuration:        ConstraintConfigFromConstraints(constraints),
@@ -441,6 +473,7 @@ func (q *queueProcessor) ItemLeaseConstraintCheck(
 		},
 		FunctionID:      *shadowPart.FunctionID,
 		CurrentTime:     now,
+		RequestTime:     enqueuedAtTime(item),
 		Duration:        QueueLeaseDuration,
 		Constraints:     constraintItems,
 		Configuration:   config,

--- a/pkg/execution/queue/constraints_test.go
+++ b/pkg/execution/queue/constraints_test.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/constraintapi"
@@ -1064,4 +1065,45 @@ func TestConstraintItemsBacklogToLimitingConstraintRoundTrip(t *testing.T) {
 			assert.True(t, hasFunctionConcurrency, "Should always include function concurrency constraint")
 		})
 	}
+}
+
+func TestEnqueuedAtTime(t *testing.T) {
+	t.Run("zero EnqueuedAt returns zero time", func(t *testing.T) {
+		got := enqueuedAtTime(&QueueItem{})
+		assert.True(t, got.IsZero())
+	})
+
+	t.Run("nil item returns zero time", func(t *testing.T) {
+		got := enqueuedAtTime(nil)
+		assert.True(t, got.IsZero())
+	})
+
+	t.Run("populated EnqueuedAt converts from millis", func(t *testing.T) {
+		ts := time.Unix(1_700_000_000, 0)
+		got := enqueuedAtTime(&QueueItem{EnqueuedAt: ts.UnixMilli()})
+		assert.Equal(t, ts.UnixMilli(), got.UnixMilli())
+	})
+}
+
+func TestEarliestEnqueuedAt(t *testing.T) {
+	t.Run("empty slice returns zero time", func(t *testing.T) {
+		got := earliestEnqueuedAt(nil)
+		assert.True(t, got.IsZero())
+	})
+
+	t.Run("all-zero EnqueuedAt returns zero time", func(t *testing.T) {
+		got := earliestEnqueuedAt([]*QueueItem{{}, {}})
+		assert.True(t, got.IsZero())
+	})
+
+	t.Run("mixed legacy and populated items skips zeros and returns earliest", func(t *testing.T) {
+		newer := time.Unix(1_700_000_010, 0)
+		older := time.Unix(1_700_000_000, 0)
+		got := earliestEnqueuedAt([]*QueueItem{
+			{},
+			{EnqueuedAt: newer.UnixMilli()},
+			{EnqueuedAt: older.UnixMilli()},
+		})
+		assert.Equal(t, older.UnixMilli(), got.UnixMilli())
+	})
 }


### PR DESCRIPTION
## Description

This change adds support for tracking when queue items were enqueued and uses that timestamp as the `RequestTime` parameter in constraint cache checks. Two new helper functions are introduced:

- `enqueuedAtTime()`: Converts a queue item's `EnqueuedAt` field (stored in milliseconds) to a `time.Time`, returning zero for nil items or legacy items without the field set
- `earliestEnqueuedAt()`: Finds the oldest enqueue time across a batch of items, used for batched constraint checks

The `RequestTime` is now populated in both:
1. `BacklogRefillConstraintCheck()`: Uses the earliest enqueued time across all items in the batch
2. `ItemLeaseConstraintCheck()`: Uses the enqueue time of the individual item

This allows the constraint cache to properly handle stale "exhausted" entries by comparing the cache's `addedAt` timestamp against the `RequestTime`. Items that were already waiting in the queue when a constraint became exhausted can now bypass that stale cache entry once capacity is freed.

## Motivation

The constraint cache needs to distinguish between requests that arrived before vs. after it marked a constraint as exhausted. By anchoring requests to their actual enqueue time rather than the current time, the cache can correctly invalidate stale exhausted entries and allow queued items to proceed when capacity becomes available.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I've tested my own changes.

https://claude.ai/code/session_01MJAyvufmW2gMPJnJumyThD

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Passes `EnqueuedAt` as `RequestTime` in both `BacklogRefillConstraintCheck` and `ItemLeaseConstraintCheck` so that queue items already waiting when a constraint cache entry was populated can bypass that stale "exhausted" entry. Two small helpers (`enqueuedAtTime`, `earliestEnqueuedAt`) handle the millisecond-to-`time.Time` conversion and zero-value fallback for legacy items.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit cb8017d05b2551bd66838ca47f2d7797bd907097.</sup>
<!-- /MENDRAL_SUMMARY -->