### PR TITLE
revert enabling contraint cache on devserver

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -343,16 +343,6 @@ func start(ctx context.Context, opts StartOpts) error {
 		return fmt.Errorf("could not create constraint API: %w", err)
 	}
 
-	// Wrap the manager in the in-process constraint cache so the dev server
-	// matches production shape. Min TTL 1s, max TTL 3min.
-	cachedCM := constraintapi.NewConstraintCache(
-		constraintapi.WithConstraintCacheClock(clockwork.NewRealClock()),
-		constraintapi.WithConstraintCacheManager(cm),
-		constraintapi.WithConstraintCacheEnable(func(ctx context.Context, accountID, envID, functionID uuid.UUID) (enable bool, minTTL, maxTTL time.Duration) {
-			return true, time.Second, 3 * time.Minute
-		}),
-	)
-
 	queueOpts := []queue.QueueOpt{
 		queue.WithRunMode(runMode),
 		queue.WithIdempotencyTTL(time.Hour),
@@ -382,9 +372,9 @@ func start(ctx context.Context, opts StartOpts) error {
 			return queue.PartitionPausedInfo{}
 		}),
 		queue.WithConditionalTracer(conditionalQueueTracer),
-		queue.WithCapacityManager(cachedCM),
+		queue.WithCapacityManager(cm),
 		queue.WithAcquireCapacityLeaseOnBacklogRefill(true),
-		queue.WithCapacityManager(cachedCM),
+		queue.WithCapacityManager(cm),
 		queue.WithAcquireCapacityLeaseOnBacklogRefill(true),
 	}
 
@@ -560,7 +550,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		executor.WithAllowStepMetadata(func(ctx context.Context, acctID uuid.UUID) bool {
 			return enableStepMetadata
 		}),
-		executor.WithCapacityManager(cachedCM),
+		executor.WithCapacityManager(cm),
 		executor.WithSemaphoreManager(semaphores),
 		executor.WithUseConstraintAPI(func(ctx context.Context, accountID uuid.UUID) (enable bool) {
 			return true
@@ -795,7 +785,7 @@ func start(ctx context.Context, opts StartOpts) error {
 			ShardSelector:   shardSelector,
 			Port:            ds.Opts.DebugAPIPort,
 			PauseManager:    pauseMgr,
-			CapacityManager: cachedCM,
+			CapacityManager: cm,
 			// Dependencies for batching, singleton, and debounce insights
 			BatchManager:   batcher,
 			SingletonStore: sn,


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Reverts the constraint cache wrapper (`constraintapi.NewConstraintCache`) that was previously enabled on the dev server. All four `cachedCM` references in `devserver.go` are replaced with the direct `cm` manager, and the cache construction block is removed.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f54ccc0e71e00ee8bc933fd0fdc498e02bd76ff2.</sup>
<!-- /MENDRAL_SUMMARY -->