### PR TITLE
Add Linear releases to CI for CLI release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,8 @@ jobs:
 
   linear-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,6 +94,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # We block on goreleaser to not track any failed releases
+    needs: [check-release-type, goreleaser]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,3 +89,17 @@ jobs:
           else
             npm publish --tag ${{ needs.check-release-type.outputs.prerelease }} --access public
           fi
+
+  linear-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # required for commit history
+
+      - uses: linear/linear-release-action@v0
+        if: needs.check-release-type.outputs.prerelease == ''
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY_INNGEST }}
+          version: ${{ github.ref_name }}
+          command: complete


### PR DESCRIPTION
## Description

Adds [Linear releases](https://linear.app/docs/releases) to CI for releasing the CLI. I am not a 100% sure this is configured correctly, but this is my best take referencing their docs.

https://github.com/marketplace/actions/linear-release

## Motivation
This should allow us to track changes that are merged to main, but not yet released to customers yet.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `linear-release` job to the release workflow that calls the Linear release action to mark issues as released when a non-prerelease tag is pushed. Follow-up commits added `needs: [check-release-type, goreleaser]` and `permissions: contents: read`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 45c864c94587760dad0ab6f6dbed11c23f4b4748.</sup>
<!-- /MENDRAL_SUMMARY -->