### PR TITLE
SYS-839: Rename NewRedisCronManager to NewManager

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -404,7 +404,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	// batch.NewMigratingBatchManager.
 	batcher := batch.NewRedisBatchManager(shardedClient.Batch(), rq, batch.WithLogger(l))
 	debouncer := debounce.NewRedisDebouncer(unshardedClient.Debounce(), queueShard, rq)
-	croner := cron.NewRedisCronManager(queueShard, rq, l)
+	croner := cron.NewManager(queueShard, rq, l)
 
 	sn := singleton.New(ctx, shardRegistry)
 

--- a/pkg/execution/cron/cron_test.go
+++ b/pkg/execution/cron/cron_test.go
@@ -303,13 +303,13 @@ func TestNextScheduleCalculation(t *testing.T) {
 func TestCronSyncerInterface(t *testing.T) {
 	t.Run("CronManager implements CronSyncer", func(t *testing.T) {
 		// This test verifies that CronManager satisfies the CronSyncer interface
-		var _ CronSyncer = (*redisCronManager)(nil)
+		var _ CronSyncer = (*manager)(nil)
 
 		// Also verify through CronManager interface
-		var manager CronManager
+		var cm CronManager
 
 		// If this compiles, the interface embedding is working correctly
-		syncer := CronSyncer(manager)
+		syncer := CronSyncer(cm)
 		_ = syncer
 	})
 }

--- a/pkg/execution/cron/manager.go
+++ b/pkg/execution/cron/manager.go
@@ -26,9 +26,9 @@ const (
 	defaultHealthCheckInterval        = time.Minute
 )
 
-type RedisCronManagerOpt func(c *redisCronManagerOpt)
+type ManagerOpt func(c *managerOpt)
 
-type redisCronManagerOpt struct {
+type managerOpt struct {
 	// jitter range provides a min and max duration for the jitter to apply to schedules
 	// which will move the scheduling time a little earlier than the actual cron schedule.
 	//
@@ -40,21 +40,21 @@ type redisCronManagerOpt struct {
 	healthCheckInterval        time.Duration
 }
 
-func (opts *redisCronManagerOpt) validate() {
+func (opts *managerOpt) validate() {
 	if opts.healthCheckLeadTimeSeconds >= int(opts.healthCheckInterval.Seconds()) {
 		l := logger.StdlibLogger(context.Background())
 
 		opts.healthCheckLeadTimeSeconds = defaultHealthCheckLeadTimeSeconds
 
-		l.Warn("Invalid redisCronManagerOpt, health lead time cannot be >= health check interval", "leadTime_seconds", opts.healthCheckLeadTimeSeconds, "interval", opts.healthCheckInterval)
+		l.Warn("Invalid managerOpt, health lead time cannot be >= health check interval", "leadTime_seconds", opts.healthCheckLeadTimeSeconds, "interval", opts.healthCheckInterval)
 		l.Info("Resetting health check lead time", "leadTime", opts.healthCheckLeadTimeSeconds)
 	}
 }
 
-func WithJitterRange(min time.Duration, max time.Duration) RedisCronManagerOpt {
-	return func(c *redisCronManagerOpt) {
+func WithJitterRange(min time.Duration, max time.Duration) ManagerOpt {
+	return func(c *managerOpt) {
 		if min > max {
-			logger.StdlibLogger(context.Background()).Warn("rejecting invalid jitter range in redisCronManagerOpt", "min", min, "max", max)
+			logger.StdlibLogger(context.Background()).Warn("rejecting invalid jitter range in managerOpt", "min", min, "max", max)
 			return
 		}
 
@@ -63,33 +63,33 @@ func WithJitterRange(min time.Duration, max time.Duration) RedisCronManagerOpt {
 	}
 }
 
-func WithHealthCheckInterval(d time.Duration) RedisCronManagerOpt {
-	return func(c *redisCronManagerOpt) {
+func WithHealthCheckInterval(d time.Duration) ManagerOpt {
+	return func(c *managerOpt) {
 		if d < time.Minute {
-			logger.StdlibLogger(context.Background()).Warn("rejecting invalid health check interval in redisCronManagerOpt", "interval", d)
+			logger.StdlibLogger(context.Background()).Warn("rejecting invalid health check interval in managerOpt", "interval", d)
 			return
 		}
 		c.healthCheckInterval = d
 	}
 }
 
-func WithHealthCheckLeadTimeSeconds(leadTime int) RedisCronManagerOpt {
-	return func(c *redisCronManagerOpt) {
+func WithHealthCheckLeadTimeSeconds(leadTime int) ManagerOpt {
+	return func(c *managerOpt) {
 		if leadTime < 0 {
-			logger.StdlibLogger(context.Background()).Warn("rejecting invalid health check lead time in redisCronManagerOpt", "leadTime", leadTime)
+			logger.StdlibLogger(context.Background()).Warn("rejecting invalid health check lead time in managerOpt", "leadTime", leadTime)
 			return
 		}
 		c.healthCheckLeadTimeSeconds = leadTime
 	}
 }
 
-func NewRedisCronManager(
+func NewManager(
 	shard queue.QueueShard,
-	q queue.QueueManager,
+	q queue.Producer,
 	log logger.Logger,
-	opts ...RedisCronManagerOpt,
+	opts ...ManagerOpt,
 ) CronManager {
-	opt := redisCronManagerOpt{
+	opt := managerOpt{
 		jitterMin:                  defaultJitterMin,
 		jitterMax:                  defaultJitterMax,
 		healthCheckLeadTimeSeconds: defaultHealthCheckLeadTimeSeconds,
@@ -101,36 +101,34 @@ func NewRedisCronManager(
 
 	opt.validate()
 
-	manager := &redisCronManager{
+	return &manager{
 		shard: shard,
 		q:     q,
 		log:   log,
 		opt:   opt,
 	}
-
-	return manager
 }
 
-type redisCronManager struct {
+type manager struct {
 	shard queue.QueueShard
-	q     queue.QueueManager
+	q     queue.Producer
 
 	log logger.Logger
-	opt redisCronManagerOpt
+	opt managerOpt
 }
 
-func (c *redisCronManager) CronProcessJobID(schedule time.Time, expr string, fnID uuid.UUID, fnVersion int) string {
+func (c *manager) CronProcessJobID(schedule time.Time, expr string, fnID uuid.UUID, fnVersion int) string {
 	return fmt.Sprintf("{%s}:{%s}:{%s}:{%d}:cron:schedule", schedule, expr, fnID, fnVersion)
 }
 
-func (c *redisCronManager) CronHealthCheckJobID(at time.Time) string {
+func (c *manager) CronHealthCheckJobID(at time.Time) string {
 	return fmt.Sprintf("{%s}:cron:health-check", at)
 }
 
 // Sync enqueues a system job of kind "cron-sync" to the system queue.
-func (c *redisCronManager) Sync(ctx context.Context, ci CronItem) error {
+func (c *manager) Sync(ctx context.Context, ci CronItem) error {
 	kind := queue.KindCronSync
-	l := c.log.With("action", "redisCronManager.Sync", "queue", kind, "functionID", ci.FunctionID, "functionVersion", ci.FunctionVersion, "cronExpr", ci.Expression, "operation", ci.Op.String())
+	l := c.log.With("action", "cron.manager.Sync", "queue", kind, "functionID", ci.FunctionID, "functionVersion", ci.FunctionVersion, "cronExpr", ci.Expression, "operation", ci.Op.String())
 
 	switch ci.Op {
 	case enums.CronOpProcess, enums.CronHealthCheck:
@@ -171,7 +169,7 @@ func (c *redisCronManager) Sync(ctx context.Context, ci CronItem) error {
 	}
 }
 
-func (c *redisCronManager) nextHealthCheckTime(now time.Time) time.Time {
+func (c *manager) nextHealthCheckTime(now time.Time) time.Time {
 	base := now.Truncate(c.opt.healthCheckInterval)
 	next := base.Add(c.opt.healthCheckInterval).Add(time.Duration(-1*c.opt.healthCheckLeadTimeSeconds) * time.Second)
 	if !next.After(now) {
@@ -182,7 +180,7 @@ func (c *redisCronManager) nextHealthCheckTime(now time.Time) time.Time {
 
 // Enqueues an adhoc cron-health-check system job
 // This is triggered only from our internal dashboard inngest function
-func (c *redisCronManager) EnqueueHealthCheck(ctx context.Context, ci CronItem) error {
+func (c *manager) EnqueueHealthCheck(ctx context.Context, ci CronItem) error {
 	now := time.Now()
 
 	maxAttempts := consts.MaxRetries + 1
@@ -190,7 +188,7 @@ func (c *redisCronManager) EnqueueHealthCheck(ctx context.Context, ci CronItem) 
 
 	jobID := fmt.Sprintf("adhoc-%s", c.CronHealthCheckJobID(now))
 
-	l := c.log.With("action", "redisCronManager.EnqueueHealthCheck", "queue", kind, "ci", ci)
+	l := c.log.With("action", "cron.manager.EnqueueHealthCheck", "queue", kind, "ci", ci)
 
 	err := c.q.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
@@ -215,7 +213,7 @@ func (c *redisCronManager) EnqueueHealthCheck(ctx context.Context, ci CronItem) 
 }
 
 // enqueues a cronItem{op:healthcheck} of {kind:cron-health-check} into system queue.
-func (c *redisCronManager) EnqueueNextHealthCheck(ctx context.Context) error {
+func (c *manager) EnqueueNextHealthCheck(ctx context.Context) error {
 	now := time.Now()
 	nextCheck := c.nextHealthCheckTime(now)
 
@@ -223,7 +221,7 @@ func (c *redisCronManager) EnqueueNextHealthCheck(ctx context.Context) error {
 	kind := queue.KindCronHealthCheck
 	jobID := c.CronHealthCheckJobID(nextCheck)
 
-	l := c.log.With("action", "redisCronManager.EnqueueNextHealthCheck", "queue", kind, "now", now, "nextCheck", nextCheck)
+	l := c.log.With("action", "cron.manager.EnqueueNextHealthCheck", "queue", kind, "now", now, "nextCheck", nextCheck)
 
 	err := c.q.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
@@ -251,7 +249,7 @@ func (c *redisCronManager) EnqueueNextHealthCheck(ctx context.Context) error {
 }
 
 // HealthCheck checks if a "cron" queue item exists system queue for the next expected schedule time
-func (c *redisCronManager) HealthCheck(ctx context.Context, functionID uuid.UUID, expr string, fnVersion int) (CronHealthCheckStatus, error) {
+func (c *manager) HealthCheck(ctx context.Context, functionID uuid.UUID, expr string, fnVersion int) (CronHealthCheckStatus, error) {
 	from := time.Now()
 
 	// Get the next schedule time based on the cron expression
@@ -264,7 +262,7 @@ func (c *redisCronManager) HealthCheck(ctx context.Context, functionID uuid.UUID
 	jobID := queue.HashID(ctx, c.CronProcessJobID(next, expr, functionID, fnVersion))
 
 	// check if the jobID exists in the system queue.
-	exists, err := c.q.ItemExists(ctx, c.shard, jobID)
+	exists, err := c.shard.ItemExists(ctx, jobID)
 	if err != nil {
 		return CronHealthCheckStatus{}, fmt.Errorf("failed to check if item exits for health check: %w", err)
 	}
@@ -274,9 +272,9 @@ func (c *redisCronManager) HealthCheck(ctx context.Context, functionID uuid.UUID
 // ScheduleNext schedules the next "cron" job w.r.t the CronItem provided.
 // While CronItem.ID and CronItem.JobID encode the _actual_ timestamp of the next schedule, the CronItem is scheduled for a few milliseconds (jitterOpts) before the schedule to allow for some processing time to create the function run.
 // User-visible jitter is not applied here — it is computed in handleCron() from the live function config.
-func (c *redisCronManager) ScheduleNext(ctx context.Context, ci CronItem) (*CronItem, error) {
+func (c *manager) ScheduleNext(ctx context.Context, ci CronItem) (*CronItem, error) {
 	kind := queue.KindCron
-	l := c.log.With("action", "redisCronManager.ScheduleNext", "queue", kind, "functionID", ci.FunctionID, "functionVersion", ci.FunctionVersion, "cronExpr", ci.Expression, "operation", ci.Op)
+	l := c.log.With("action", "cron.manager.ScheduleNext", "queue", kind, "functionID", ci.FunctionID, "functionVersion", ci.FunctionVersion, "cronExpr", ci.Expression, "operation", ci.Op)
 
 	from := ci.ID.Timestamp()
 

--- a/pkg/execution/cron/manager.go
+++ b/pkg/execution/cron/manager.go
@@ -17,13 +17,13 @@ import (
 
 const (
 	// lead time for scheduling "cron" items.
-	defaultJitterMin = 5 * time.Second
-	defaultJitterMax = 15 * time.Second
+	defaultJitterMin = 0 * time.Millisecond
+	defaultJitterMax = 20 * time.Millisecond
 
 	// interval and lead time for scheduling "cron-health-check" items
-	// default: 50 seconds before the top of a minute
-	defaultHealthCheckLeadTimeSeconds = 50
-	defaultHealthCheckInterval        = 5 * time.Minute
+	// default: 20 seconds before the top of a minute
+	defaultHealthCheckLeadTimeSeconds = 20
+	defaultHealthCheckInterval        = time.Minute
 )
 
 type ManagerOpt func(c *managerOpt)

--- a/pkg/execution/cron/manager.go
+++ b/pkg/execution/cron/manager.go
@@ -17,13 +17,13 @@ import (
 
 const (
 	// lead time for scheduling "cron" items.
-	defaultJitterMin = 0 * time.Millisecond
-	defaultJitterMax = 20 * time.Millisecond
+	defaultJitterMin = 5 * time.Second
+	defaultJitterMax = 15 * time.Second
 
 	// interval and lead time for scheduling "cron-health-check" items
-	// default: 20 seconds before the top of a minute
-	defaultHealthCheckLeadTimeSeconds = 20
-	defaultHealthCheckInterval        = time.Minute
+	// default: 50 seconds before the top of a minute
+	defaultHealthCheckLeadTimeSeconds = 50
+	defaultHealthCheckInterval        = 5 * time.Minute
 )
 
 type ManagerOpt func(c *managerOpt)

--- a/pkg/execution/cron/manager_test.go
+++ b/pkg/execution/cron/manager_test.go
@@ -90,7 +90,7 @@ func TestGenerateJitter(t *testing.T) {
 
 func TestOptions(t *testing.T) {
 	t.Run("WithJitterRange sets jitter correctly", func(t *testing.T) {
-		opt := redisCronManagerOpt{}
+		opt := managerOpt{}
 		WithJitterRange(5*time.Millisecond, 15*time.Millisecond)(&opt)
 
 		assert.Equal(t, 5*time.Millisecond, opt.jitterMin)
@@ -98,7 +98,7 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("WithJitterRange ignores invalid range", func(t *testing.T) {
-		opt := redisCronManagerOpt{}
+		opt := managerOpt{}
 		WithJitterRange(15*time.Millisecond, 5*time.Millisecond)(&opt)
 
 		assert.Equal(t, time.Duration(0), opt.jitterMin)
@@ -106,28 +106,28 @@ func TestOptions(t *testing.T) {
 	})
 
 	t.Run("WithHealthCheckInterval sets interval correctly", func(t *testing.T) {
-		opt := redisCronManagerOpt{}
+		opt := managerOpt{}
 		WithHealthCheckInterval(5 * time.Minute)(&opt)
 
 		assert.Equal(t, 5*time.Minute, opt.healthCheckInterval)
 	})
 
 	t.Run("WithHealthCheckInterval ignores values < 1m", func(t *testing.T) {
-		opt := redisCronManagerOpt{}
+		opt := managerOpt{}
 		WithHealthCheckInterval(10 * time.Second)(&opt)
 
 		assert.Equal(t, time.Duration(0), opt.healthCheckInterval)
 	})
 
 	t.Run("WithHealthCheckLeadTimeSeconds sets lead time correctly", func(t *testing.T) {
-		opt := redisCronManagerOpt{}
+		opt := managerOpt{}
 		WithHealthCheckLeadTimeSeconds(20)(&opt)
 
 		assert.Equal(t, 20, opt.healthCheckLeadTimeSeconds)
 	})
 
 	t.Run("WithHealthCheckLeadTimeSeconds rejects negative values", func(t *testing.T) {
-		opt := redisCronManagerOpt{}
+		opt := managerOpt{}
 		WithHealthCheckLeadTimeSeconds(-20)(&opt)
 
 		assert.Equal(t, 0, opt.healthCheckLeadTimeSeconds)
@@ -135,7 +135,7 @@ func TestOptions(t *testing.T) {
 
 	t.Run("validate options", func(t *testing.T) {
 		t.Run("valid configuration should not modify values", func(t *testing.T) {
-			opt := redisCronManagerOpt{
+			opt := managerOpt{
 				healthCheckLeadTimeSeconds: 19,
 				healthCheckInterval:        time.Minute,
 			}
@@ -146,7 +146,7 @@ func TestOptions(t *testing.T) {
 		})
 
 		t.Run("lead time equal to interval should reset to default", func(t *testing.T) {
-			opt := redisCronManagerOpt{
+			opt := managerOpt{
 				healthCheckLeadTimeSeconds: 60,
 				healthCheckInterval:        time.Minute,
 			}
@@ -157,7 +157,7 @@ func TestOptions(t *testing.T) {
 		})
 
 		t.Run("lead time greater than interval should reset to default", func(t *testing.T) {
-			opt := redisCronManagerOpt{
+			opt := managerOpt{
 				healthCheckLeadTimeSeconds: 120,
 				healthCheckInterval:        time.Minute,
 			}
@@ -168,7 +168,7 @@ func TestOptions(t *testing.T) {
 		})
 
 		t.Run("lead time one second less than interval should be valid", func(t *testing.T) {
-			opt := redisCronManagerOpt{
+			opt := managerOpt{
 				healthCheckLeadTimeSeconds: 59,
 				healthCheckInterval:        time.Minute,
 			}
@@ -179,7 +179,7 @@ func TestOptions(t *testing.T) {
 		})
 
 		t.Run("zero lead time should be valid", func(t *testing.T) {
-			opt := redisCronManagerOpt{
+			opt := managerOpt{
 				healthCheckLeadTimeSeconds: 0,
 				healthCheckInterval:        time.Minute,
 			}
@@ -230,7 +230,7 @@ func TestOptions(t *testing.T) {
 
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
-					opt := redisCronManagerOpt{
+					opt := managerOpt{
 						healthCheckLeadTimeSeconds: tc.leadTimeSeconds,
 						healthCheckInterval:        tc.interval,
 					}
@@ -301,8 +301,8 @@ func TestNextHealthCheckTime(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("with default interval (1 minute) and default lead time (20 seconds)", func(t *testing.T) {
-		cm := NewRedisCronManager(shard, q, logger.StdlibLogger(ctx))
-		cmTyped := cm.(*redisCronManager)
+		cm := NewManager(shard, q, logger.StdlibLogger(ctx))
+		cmTyped := cm.(*manager)
 
 		testCases := []struct {
 			name           string
@@ -365,13 +365,13 @@ func TestNextHealthCheckTime(t *testing.T) {
 	})
 
 	t.Run("with 5 minute interval and 30 second lead time", func(t *testing.T) {
-		cm := NewRedisCronManager(
+		cm := NewManager(
 			shard, q,
 			logger.StdlibLogger(ctx),
 			WithHealthCheckInterval(5*time.Minute),
 			WithHealthCheckLeadTimeSeconds(30),
 		)
-		cmTyped := cm.(*redisCronManager)
+		cmTyped := cm.(*manager)
 
 		testCases := []struct {
 			name           string
@@ -428,13 +428,13 @@ func TestNextHealthCheckTime(t *testing.T) {
 	})
 
 	t.Run("with 1 hour interval and 5 minute lead time", func(t *testing.T) {
-		cm := NewRedisCronManager(
+		cm := NewManager(
 			shard, q,
 			logger.StdlibLogger(ctx),
 			WithHealthCheckInterval(1*time.Hour),
 			WithHealthCheckLeadTimeSeconds(300),
 		)
-		cmTyped := cm.(*redisCronManager)
+		cmTyped := cm.(*manager)
 
 		testCases := []struct {
 			name           string
@@ -477,8 +477,8 @@ func TestNextHealthCheckTime(t *testing.T) {
 	})
 
 	t.Run("consistency checks", func(t *testing.T) {
-		cm := NewRedisCronManager(shard, q, logger.StdlibLogger(ctx))
-		cmTyped := cm.(*redisCronManager)
+		cm := NewManager(shard, q, logger.StdlibLogger(ctx))
+		cmTyped := cm.(*manager)
 
 		t.Run("calling twice with same time should return same result", func(t *testing.T) {
 			inputTime := time.Date(2025, 10, 26, 14, 30, 45, 0, time.UTC)
@@ -544,8 +544,8 @@ func TestCronHealthCheckJobID(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	cm := NewRedisCronManager(shard, q, logger.StdlibLogger(ctx))
-	cmTyped := cm.(*redisCronManager)
+	cm := NewManager(shard, q, logger.StdlibLogger(ctx))
+	cmTyped := cm.(*manager)
 
 	t.Run("should generate consistent JobID for same time", func(t *testing.T) {
 		testTime := time.Date(2025, 10, 26, 14, 30, 41, 0, time.UTC)
@@ -634,7 +634,7 @@ func CronItemEquals(t *testing.T, expected, actual CronItem) {
 	assert.Equal(t, expected.Op, actual.Op)
 }
 
-func TestRedisCronManager(t *testing.T) {
+func TestManager(t *testing.T) {
 	r, rc := initRedis(t)
 	defer rc.Close()
 
@@ -670,7 +670,7 @@ func TestRedisCronManager(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	cm := NewRedisCronManager(
+	cm := NewManager(
 		shard,
 		q,
 		logger.StdlibLogger(ctx),


### PR DESCRIPTION
## Description

no-op rename. The cron manager stores no additional state in redis that does not already go via the queue shard interface.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Renames `redisCronManager` → `manager`, `RedisCronManagerOpt` → `ManagerOpt`, `NewRedisCronManager` → `NewManager`, and moves the file from `redis.go` to `manager.go`. Includes one functional change: `HealthCheck` now calls `c.shard.ItemExists(ctx, jobID)` directly instead of routing through `c.q.ItemExists(ctx, c.shard, jobID)`, and the `q` field type narrows from `QueueManager` to `Producer`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 88545ff9211b3a7d200323b8b649104ace062791.</sup>
<!-- /MENDRAL_SUMMARY -->