### PR TITLE
Add optional host authentication for self-hosted dashboard

### DIFF
--- a/docs/auth/README.md
+++ b/docs/auth/README.md
@@ -1,0 +1,112 @@
+# Host Authentication for Self-Hosted Inngest
+
+Optional password-based authentication for the Inngest self-hosted dashboard. When enabled, users must sign in before accessing the web UI or GraphQL API.
+
+![Login Screen](login-screenshot.png)
+
+## Quick Start
+
+Set two environment variables and restart the server:
+
+```bash
+export INNGEST_HOST_EMAIL="admin@yourcompany.com"
+export INNGEST_HOST_PASSWORD="your-secure-password"
+
+inngest start \
+  --signing-key=<your-signing-key> \
+  --event-key=<your-event-key> \
+  --sqlite-dir=/data/inngest
+```
+
+Visit `http://localhost:8288` and you'll be redirected to the login page.
+
+## How It Works
+
+- **Auth is optional** -- when `INNGEST_HOST_EMAIL` and `INNGEST_HOST_PASSWORD` are not set, the dashboard works as before with no login required.
+- **No signup/registration** -- the only valid credentials are the ones in the env vars.
+- **JWT in HTTP-only cookie** -- on successful login, a 24-hour JWT is stored in an `inngest_session` cookie (HttpOnly, SameSite=Lax).
+- **SDK endpoints are unaffected** -- event ingestion (`/e/{key}`), function registration (`/fn/register`), and other SDK endpoints continue to use signing key auth, independent of host auth.
+
+## Configuration
+
+| Environment Variable | Required | Description |
+|---|---|---|
+| `INNGEST_HOST_EMAIL` | Both must be set to enable auth | Email address for login |
+| `INNGEST_HOST_PASSWORD` | Both must be set to enable auth | Password for login |
+
+- Email comparison is **case-insensitive** (`Admin@Co.com` matches `admin@co.com`)
+- Password comparison is **case-sensitive** and uses constant-time comparison
+- Sessions expire after **24 hours** -- the user must re-login
+
+## Docker / Docker Compose
+
+```yaml
+services:
+  inngest:
+    image: inngest/inngest:latest
+    ports:
+      - "8288:8288"
+    environment:
+      - INNGEST_HOST_EMAIL=admin@yourcompany.com
+      - INNGEST_HOST_PASSWORD=your-secure-password
+    command: >
+      inngest start
+      --signing-key=<your-signing-key>
+      --event-key=<your-event-key>
+      --sqlite-dir=/data/inngest
+    volumes:
+      - inngest-data:/data/inngest
+
+volumes:
+  inngest-data:
+```
+
+## API Endpoints
+
+These endpoints are added when host auth is enabled:
+
+| Method | Path | Auth Required | Description |
+|---|---|---|---|
+| `GET` | `/auth/status` | No | Returns `{authRequired, authenticated}` |
+| `POST` | `/auth/login` | No | Accepts `{email, password}`, sets session cookie |
+| `POST` | `/auth/logout` | No | Clears session cookie |
+
+### Example: Check auth status
+
+```bash
+curl http://localhost:8288/auth/status
+# Auth disabled: {"authRequired":false,"authenticated":false}
+# Auth enabled, not logged in: {"authRequired":true,"authenticated":false}
+# Auth enabled, logged in: {"authRequired":true,"authenticated":true}
+```
+
+### Example: Login via API
+
+```bash
+curl -c cookies.txt -X POST http://localhost:8288/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"admin@yourcompany.com","password":"your-secure-password"}'
+
+# Use the cookie for authenticated requests
+curl -b cookies.txt http://localhost:8288/v0/gql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ apps { id name } }"}'
+```
+
+## What Is Protected
+
+| Resource | Protected by Host Auth? | Notes |
+|---|---|---|
+| Dashboard UI | Yes | Redirects to `/login` |
+| GraphQL API (`/v0/gql`) | Yes | Returns 401 without cookie |
+| Event ingestion (`/e/{key}`) | No | Uses signing key auth |
+| Function registration (`/fn/register`) | No | Uses signing key auth |
+| OTEL traces (`/dev/traces`) | No | SDK endpoint |
+| Static assets (`/assets/*`) | No | Needed for login page |
+
+## Security Notes
+
+- The JWT signing secret is derived from the password using HMAC-SHA256. Changing the password invalidates all existing sessions.
+- Cookies are set with `HttpOnly` and `SameSite=Lax` flags.
+- For production deployments behind HTTPS, consider using a reverse proxy (nginx, Traefik, Caddy) that terminates TLS.
+- The password is stored in an environment variable -- use your platform's secrets management (Docker secrets, Kubernetes secrets, etc.) rather than hardcoding it.

--- a/pkg/authn/hostauth.go
+++ b/pkg/authn/hostauth.go
@@ -1,0 +1,78 @@
+package authn
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	hostAuthCookieName = "inngest_session"
+	hostAuthIssuer     = "inngest-host"
+	hostAuthExpiry     = 24 * time.Hour
+	hostAuthSalt       = "inngest-host-auth-v1"
+)
+
+type HostAuthConfig struct {
+	Email    string
+	Password string
+}
+
+func NewHostAuthConfig() *HostAuthConfig {
+	email := os.Getenv("INNGEST_HOST_EMAIL")
+	password := os.Getenv("INNGEST_HOST_PASSWORD")
+	if email == "" || password == "" {
+		return nil
+	}
+	return &HostAuthConfig{
+		Email:    email,
+		Password: password,
+	}
+}
+
+func (c *HostAuthConfig) IsEnabled() bool {
+	return c != nil && c.Email != "" && c.Password != ""
+}
+
+func (c *HostAuthConfig) ValidateCredentials(email, password string) bool {
+	if !c.IsEnabled() {
+		return false
+	}
+	emailMatch := strings.EqualFold(email, c.Email)
+	passwordMatch := subtle.ConstantTimeCompare([]byte(password), []byte(c.Password)) == 1
+	return emailMatch && passwordMatch
+}
+
+func (c *HostAuthConfig) JWTSecret() []byte {
+	mac := hmac.New(sha256.New, []byte(hostAuthSalt))
+	mac.Write([]byte(c.Password))
+	return mac.Sum(nil)
+}
+
+func (c *HostAuthConfig) CreateToken(email string) (string, error) {
+	now := time.Now()
+	claims := jwt.RegisteredClaims{
+		Subject:   email,
+		Issuer:    hostAuthIssuer,
+		ExpiresAt: jwt.NewNumericDate(now.Add(hostAuthExpiry)),
+		IssuedAt:  jwt.NewNumericDate(now),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(c.JWTSecret())
+}
+
+func (c *HostAuthConfig) ValidateToken(tokenString string) (*jwt.RegisteredClaims, error) {
+	claims := &jwt.RegisteredClaims{}
+	_, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+		return c.JWTSecret(), nil
+	}, jwt.WithIssuer(hostAuthIssuer), jwt.WithValidMethods([]string{"HS256"}))
+	if err != nil {
+		return nil, err
+	}
+	return claims, nil
+}

--- a/pkg/authn/hostauth_handlers.go
+++ b/pkg/authn/hostauth_handlers.go
@@ -1,0 +1,92 @@
+package authn
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type loginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type authStatusResponse struct {
+	AuthRequired  bool `json:"authRequired"`
+	Authenticated bool `json:"authenticated"`
+}
+
+func HostAuthLoginHandler(config *HostAuthConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if config == nil || !config.IsEnabled() {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "authentication not enabled"})
+			return
+		}
+
+		var req loginRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+			return
+		}
+
+		if !config.ValidateCredentials(req.Email, req.Password) {
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid credentials"})
+			return
+		}
+
+		token, err := config.CreateToken(req.Email)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create session"})
+			return
+		}
+
+		http.SetCookie(w, &http.Cookie{
+			Name:     hostAuthCookieName,
+			Value:    token,
+			Path:     "/",
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   int(hostAuthExpiry.Seconds()),
+		})
+
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	}
+}
+
+func HostAuthLogoutHandler(config *HostAuthConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		http.SetCookie(w, &http.Cookie{
+			Name:     hostAuthCookieName,
+			Value:    "",
+			Path:     "/",
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   -1,
+		})
+		writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+	}
+}
+
+func HostAuthStatusHandler(config *HostAuthConfig) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		resp := authStatusResponse{
+			AuthRequired:  config != nil && config.IsEnabled(),
+			Authenticated: false,
+		}
+
+		if resp.AuthRequired {
+			if cookie, err := r.Cookie(hostAuthCookieName); err == nil {
+				if _, err := config.ValidateToken(cookie.Value); err == nil {
+					resp.Authenticated = true
+				}
+			}
+		}
+
+		writeJSON(w, http.StatusOK, resp)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}

--- a/pkg/authn/hostauth_middleware.go
+++ b/pkg/authn/hostauth_middleware.go
@@ -1,0 +1,25 @@
+package authn
+
+import (
+	"net/http"
+)
+
+func HostAuthMiddleware(config *HostAuthConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if config == nil || !config.IsEnabled() {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cookie, err := r.Cookie(hostAuthCookieName)
+			if err != nil {
+				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+				return
+			}
+			if _, err := config.ValidateToken(cookie.Value); err != nil {
+				writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/coreapi/coreapi.go
+++ b/pkg/coreapi/coreapi.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/inngest/inngest/pkg/api"
 	"github.com/inngest/inngest/pkg/api/tel"
+	"github.com/inngest/inngest/pkg/authn"
 	"github.com/inngest/inngest/pkg/config"
 	connectv0 "github.com/inngest/inngest/pkg/connect/rest/v0"
 	"github.com/inngest/inngest/pkg/consts"
@@ -35,6 +36,7 @@ type Options struct {
 	Data cqrs.Manager
 
 	AuthMiddleware func(http.Handler) http.Handler
+	HostAuthConfig *authn.HostAuthConfig
 	Config         config.Config
 	Logger         logger.Logger
 	Runner         runner.Runner
@@ -84,7 +86,7 @@ func NewCoreApi(o Options) (*CoreAPI, error) {
 		AllowOriginFunc:  func(r *http.Request, origin string) bool { return true },
 		AllowedMethods:   []string{"GET", "POST", "OPTIONS"},
 		AllowedHeaders:   []string{"*"},
-		AllowCredentials: false,
+		AllowCredentials: true,
 	})
 	a.Use(
 		cors.Handler,
@@ -110,7 +112,7 @@ func NewCoreApi(o Options) (*CoreAPI, error) {
 
 		// TODO - Add option for enabling GraphQL Playground
 		a.Handle("/", playground.Handler("GraphQL playground", "/v0/gql"))
-		a.Handle("/gql", srv)
+		a.With(authn.HostAuthMiddleware(o.HostAuthConfig)).Handle("/gql", srv)
 	}
 
 	// V0 APIs

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/api/tel"
+	"github.com/inngest/inngest/pkg/authn"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/cqrs/sync"
@@ -50,6 +51,7 @@ type devapi struct {
 type DevAPIOptions struct {
 	disableUI      bool
 	AuthMiddleware func(http.Handler) http.Handler
+	HostAuthConfig *authn.HostAuthConfig
 }
 
 func NewDevAPI(d *devserver, o DevAPIOptions) chi.Router {
@@ -59,11 +61,11 @@ func NewDevAPI(d *devserver, o DevAPIOptions) chi.Router {
 		devserver: d,
 		disableUI: o.disableUI,
 	}
-	api.addRoutes(o.AuthMiddleware)
+	api.addRoutes(o.AuthMiddleware, o.HostAuthConfig)
 	return api
 }
 
-func (a *devapi) addRoutes(AuthMiddleware func(http.Handler) http.Handler) {
+func (a *devapi) addRoutes(AuthMiddleware func(http.Handler) http.Handler, hostAuthConfig *authn.HostAuthConfig) {
 	a.Use(func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
 			l := a.devserver.log.With("caller", a.devserver.Name())
@@ -73,6 +75,13 @@ func (a *devapi) addRoutes(AuthMiddleware func(http.Handler) http.Handler) {
 		return http.HandlerFunc(fn)
 	})
 	a.Use(headers.StaticHeadersMiddleware(a.devserver.Opts.Config.GetServerKind()))
+
+	// Host auth endpoints - always accessible (no auth required)
+	a.Get("/auth/status", authn.HostAuthStatusHandler(hostAuthConfig))
+	if hostAuthConfig != nil && hostAuthConfig.IsEnabled() {
+		a.Post("/auth/login", authn.HostAuthLoginHandler(hostAuthConfig))
+		a.Post("/auth/logout", authn.HostAuthLogoutHandler(hostAuthConfig))
+	}
 
 	a.Post("/dev/traces", a.OTLPTrace) // Intentionally outside the AuthMiddleware
 

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -607,12 +607,19 @@ func start(ctx context.Context, opts StartOpts) error {
 	// start the API
 	// Create a new API endpoint which hosts SDK-related functionality for
 	// registering functions.
-	devAPI := NewDevAPI(ds, DevAPIOptions{AuthMiddleware: authn.SigningKeyMiddleware(opts.SigningKey), disableUI: opts.NoUI})
+	hostAuthConfig := authn.NewHostAuthConfig()
+
+	devAPI := NewDevAPI(ds, DevAPIOptions{
+		AuthMiddleware: authn.SigningKeyMiddleware(opts.SigningKey),
+		disableUI:      opts.NoUI,
+		HostAuthConfig: hostAuthConfig,
+	})
 
 	// Add MCP server route
 	AddMCPRoute(devAPI, ds.HandleEvent, ds.Data, opts.Tick)
 	core, err := coreapi.NewCoreApi(coreapi.Options{
 		AuthMiddleware: authn.SigningKeyMiddleware(opts.SigningKey),
+		HostAuthConfig: hostAuthConfig,
 		Data:           ds.Data,
 		Config:         ds.Opts.Config,
 		Logger:         l,

--- a/ui/apps/dev-server-ui/src/components/Navigation/ProfileMenu.tsx
+++ b/ui/apps/dev-server-ui/src/components/Navigation/ProfileMenu.tsx
@@ -1,7 +1,18 @@
 import { Listbox } from '@headlessui/react';
 import ModeSwitch from '@inngest/components/ThemeMode/ModeSwitch';
+import { RiLogoutBoxRLine } from '@remixicon/react';
+
+import { useAuthStatusQuery, useLogoutMutation } from '@/store/authApi';
 
 export const ProfileMenu = ({ children }: React.PropsWithChildren) => {
+  const { data: authStatus } = useAuthStatusQuery();
+  const [logout] = useLogoutMutation();
+
+  const handleLogout = async () => {
+    await logout().unwrap();
+    window.location.href = '/login';
+  };
+
   return (
     <Listbox>
       <Listbox.Button className="w-full cursor-pointer ring-0">
@@ -18,6 +29,16 @@ export const ProfileMenu = ({ children }: React.PropsWithChildren) => {
               <div>Theme</div>
               <ModeSwitch />
             </Listbox.Option>
+            {authStatus?.authRequired && (
+              <Listbox.Option
+                value="logout"
+                className="text-muted mx-2 mb-2 flex h-8 cursor-pointer items-center gap-2 rounded px-2 text-[13px] hover:bg-canvasSubtle"
+                onClick={handleLogout}
+              >
+                <RiLogoutBoxRLine className="h-4 w-4" />
+                <div>Sign out</div>
+              </Listbox.Option>
+            )}
           </>
         </Listbox.Options>
       </div>

--- a/ui/apps/dev-server-ui/src/routeTree.gen.ts
+++ b/ui/apps/dev-server-ui/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as LoginRouteImport } from './routes/login'
 import { Route as DashboardRouteImport } from './routes/_dashboard'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as DashboardFunctionsRouteRouteImport } from './routes/_dashboard/functions/route'
@@ -25,6 +26,11 @@ import { Route as DashboardAppsAppIndexRouteImport } from './routes/_dashboard/a
 import { Route as DashboardAppsOnboardingChooseTemplateRouteImport } from './routes/_dashboard/apps/_onboarding/choose-template'
 import { Route as DashboardAppsOnboardingChooseFrameworkRouteImport } from './routes/_dashboard/apps/_onboarding/choose-framework'
 
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DashboardRoute = DashboardRouteImport.update({
   id: '/_dashboard',
   getParentRoute: () => rootRouteImport,
@@ -107,6 +113,7 @@ const DashboardAppsOnboardingChooseFrameworkRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
   '/functions': typeof DashboardFunctionsRouteRouteWithChildren
   '/apps': typeof DashboardAppsOnboardingRouteRouteWithChildren
   '/apps/': typeof DashboardAppsIndexRoute
@@ -123,6 +130,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
   '/functions': typeof DashboardFunctionsRouteRouteWithChildren
   '/apps': typeof DashboardAppsIndexRoute
   '/event': typeof DashboardEventIndexRoute
@@ -140,6 +148,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_dashboard': typeof DashboardRouteWithChildren
+  '/login': typeof LoginRoute
   '/_dashboard/functions': typeof DashboardFunctionsRouteRouteWithChildren
   '/_dashboard/apps/_onboarding': typeof DashboardAppsOnboardingRouteRouteWithChildren
   '/_dashboard/apps/': typeof DashboardAppsIndexRoute
@@ -158,6 +167,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/login'
     | '/functions'
     | '/apps'
     | '/apps/'
@@ -174,6 +184,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/login'
     | '/functions'
     | '/apps'
     | '/event'
@@ -190,6 +201,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/_dashboard'
+    | '/login'
     | '/_dashboard/functions'
     | '/_dashboard/apps/_onboarding'
     | '/_dashboard/apps/'
@@ -208,10 +220,18 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   DashboardRoute: typeof DashboardRouteWithChildren
+  LoginRoute: typeof LoginRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_dashboard': {
       id: '/_dashboard'
       path: ''
@@ -386,6 +406,7 @@ const DashboardRouteWithChildren = DashboardRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   DashboardRoute: DashboardRouteWithChildren,
+  LoginRoute: LoginRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/ui/apps/dev-server-ui/src/routes/__root.tsx
+++ b/ui/apps/dev-server-ui/src/routes/__root.tsx
@@ -9,11 +9,14 @@ import {
   Outlet,
   Scripts,
   createRootRoute,
+  useNavigate,
+  useRouterState,
 } from '@tanstack/react-router';
 
 import globalsCss from '@inngest/components/AppRoot/globals.css?url';
 import fontsCss from '@inngest/components/AppRoot/fonts.css?url';
 import StoreProvider from '@/components/StoreProvider';
+import { useAuthStatusQuery } from '@/store/authApi';
 
 export const Route = createRootRoute({
   head: () => ({
@@ -53,12 +56,53 @@ export const Route = createRootRoute({
   component: RootComponent,
 });
 
+function AuthGate({ children }: { children: React.ReactNode }) {
+  const { data: authStatus, isLoading } = useAuthStatusQuery();
+  const navigate = useNavigate();
+  const routerState = useRouterState();
+  const pathname = routerState.location.pathname;
+
+  React.useEffect(() => {
+    if (isLoading || !authStatus) return;
+    if (
+      authStatus.authRequired &&
+      !authStatus.authenticated &&
+      pathname !== '/login'
+    ) {
+      navigate({ to: '/login' });
+    }
+    if (authStatus.authenticated && pathname === '/login') {
+      navigate({ to: '/' });
+    }
+  }, [authStatus, isLoading, pathname, navigate]);
+
+  if (isLoading) {
+    return (
+      <div className="bg-canvasBase flex h-screen w-full items-center justify-center">
+        <div className="text-muted text-sm">Loading...</div>
+      </div>
+    );
+  }
+
+  if (
+    authStatus?.authRequired &&
+    !authStatus.authenticated &&
+    pathname !== '/login'
+  ) {
+    return null;
+  }
+
+  return <>{children}</>;
+}
+
 function RootComponent() {
   return (
     <RootDocument>
       <StoreProvider>
         <ThemeProvider attribute="class" defaultTheme="system">
-          <Outlet />
+          <AuthGate>
+            <Outlet />
+          </AuthGate>
           <Toaster
             toastOptions={{
               className: 'drop-shadow-lg',

--- a/ui/apps/dev-server-ui/src/routes/login.tsx
+++ b/ui/apps/dev-server-ui/src/routes/login.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { InngestLogo } from '@inngest/components/icons/logos/InngestLogo';
+import { createFileRoute } from '@tanstack/react-router';
+
+import { useLoginMutation } from '@/store/authApi';
+
+export const Route = createFileRoute('/login')({
+  component: LoginPage,
+});
+
+function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [login, { isLoading }] = useLoginMutation();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await login({ email, password }).unwrap();
+      window.location.href = '/';
+    } catch {
+      setError('Invalid email or password');
+    }
+  };
+
+  return (
+    <div className="bg-canvasBase flex h-screen w-full items-center justify-center">
+      <div className="border-subtle bg-canvasBase w-full max-w-sm rounded-lg border p-8 shadow-lg">
+        <div className="mb-8 flex flex-col items-center">
+          <InngestLogo className="text-basis mb-2" width={120} />
+          <p className="text-muted text-sm">Sign in to your server</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          {error && (
+            <div className="bg-error/10 text-error rounded px-3 py-2 text-sm">
+              {error}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="email" className="text-muted text-sm">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="border-subtle bg-canvasSubtle text-basis focus:border-primary-moderate rounded border px-3 py-2 text-sm outline-none"
+              placeholder="you@example.com"
+              autoComplete="email"
+              autoFocus
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor="password" className="text-muted text-sm">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="border-subtle bg-canvasSubtle text-basis focus:border-primary-moderate rounded border px-3 py-2 text-sm outline-none"
+              placeholder="Enter your password"
+              autoComplete="current-password"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="bg-primary-moderate text-onContrast hover:bg-primary-intense mt-2 rounded px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50"
+          >
+            {isLoading ? 'Signing in...' : 'Sign in'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/ui/apps/dev-server-ui/src/store/authApi.ts
+++ b/ui/apps/dev-server-ui/src/store/authApi.ts
@@ -1,0 +1,44 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+const baseURL = import.meta.env.VITE_PUBLIC_API_BASE_URL
+  ? new URL('/', import.meta.env.VITE_PUBLIC_API_BASE_URL)
+  : '/';
+
+export interface AuthStatus {
+  authRequired: boolean;
+  authenticated: boolean;
+}
+
+interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export const authApi = createApi({
+  reducerPath: 'authApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: baseURL.toString(),
+    credentials: 'include',
+  }),
+  endpoints: (builder) => ({
+    authStatus: builder.query<AuthStatus, void>({
+      query: () => '/auth/status',
+    }),
+    login: builder.mutation<{ ok: boolean }, LoginRequest>({
+      query: (body) => ({
+        url: '/auth/login',
+        method: 'POST',
+        body,
+      }),
+    }),
+    logout: builder.mutation<{ ok: boolean }, void>({
+      query: () => ({
+        url: '/auth/logout',
+        method: 'POST',
+      }),
+    }),
+  }),
+});
+
+export const { useAuthStatusQuery, useLoginMutation, useLogoutMutation } =
+  authApi;

--- a/ui/apps/dev-server-ui/src/store/baseApi.ts
+++ b/ui/apps/dev-server-ui/src/store/baseApi.ts
@@ -1,4 +1,5 @@
 import { createApi } from '@reduxjs/toolkit/query/react';
+import type { BaseQueryFn } from '@reduxjs/toolkit/query';
 import { graphqlRequestBaseQuery } from '@rtk-query/graphql-request-base-query';
 import { GraphQLClient } from 'graphql-request';
 
@@ -6,12 +7,28 @@ const graphQLEndpoint = import.meta.env.VITE_PUBLIC_API_BASE_URL
   ? new URL('/v0/gql', import.meta.env.VITE_PUBLIC_API_BASE_URL)
   : '/v0/gql';
 
-export const client = new GraphQLClient(graphQLEndpoint.toString());
+export const client = new GraphQLClient(graphQLEndpoint.toString(), {
+  credentials: 'include',
+});
+
+const rawBaseQuery = graphqlRequestBaseQuery({
+  // @ts-expect-error
+  client,
+});
+
+const baseQueryWithReauth: BaseQueryFn = async (args, api, extraOptions) => {
+  const result = await rawBaseQuery(args, api, extraOptions);
+  if (
+    result.error &&
+    'originalStatus' in (result.error as any) &&
+    (result.error as any).originalStatus === 401
+  ) {
+    window.location.href = '/login';
+  }
+  return result;
+};
 
 export const api = createApi({
-  baseQuery: graphqlRequestBaseQuery({
-    // @ts-expect-error
-    client,
-  }),
+  baseQuery: baseQueryWithReauth,
   endpoints: () => ({}),
 });

--- a/ui/apps/dev-server-ui/src/store/devApi.ts
+++ b/ui/apps/dev-server-ui/src/store/devApi.ts
@@ -28,7 +28,10 @@ export interface ServerInfo extends z.output<typeof serverInfoSchema> {
 
 export const devApi = createApi({
   reducerPath: 'devApi',
-  baseQuery: fetchBaseQuery({ baseUrl: baseURL.toString() }),
+  baseQuery: fetchBaseQuery({
+    baseUrl: baseURL.toString(),
+    credentials: 'include',
+  }),
   endpoints: (builder) => ({
     info: builder.query<ServerInfo, void>({
       query() {

--- a/ui/apps/dev-server-ui/src/store/store.ts
+++ b/ui/apps/dev-server-ui/src/store/store.ts
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
+import { authApi } from './authApi';
 import devApi from './devApi';
 import { api } from './generated';
 
@@ -6,6 +7,7 @@ export const store = configureStore({
   reducer: {
     [api.reducerPath]: api.reducer,
     [devApi.reducerPath]: devApi.reducer,
+    [authApi.reducerPath]: authApi.reducer,
   },
   middleware: (getDefaultMiddleware) => {
     const defaults = getDefaultMiddleware();
@@ -18,7 +20,11 @@ export const store = configureStore({
         : m,
     );
 
-    return fixedDefaults.concat(api.middleware, devApi.middleware);
+    return fixedDefaults.concat(
+      api.middleware,
+      devApi.middleware,
+      authApi.middleware,
+    );
   },
 });
 


### PR DESCRIPTION
Adds env-var based authentication (INNGEST_HOST_EMAIL, INNGEST_HOST_PASSWORD) that protects the web dashboard and GraphQL API when set. Auth is fully optional — when env vars are absent, everything works as before.

Backend: JWT in HTTP-only cookie, login/logout/status endpoints, middleware on GraphQL. SDK endpoints (event ingestion, function registration) are unaffected.

Frontend: Login page, auth gate in root component, logout in profile menu, credentials included on all API requests.

## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds optional env-var-based authentication (INNGEST_HOST_EMAIL/INNGEST_HOST_PASSWORD) for the self-hosted dashboard. When enabled, a JWT stored in an HTTP-only cookie gates the GraphQL API and dashboard UI. SDK endpoints remain unprotected by design. Includes backend handlers, middleware, and a React login page with auth gate.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e11655ab1292d320067ce827c0d36e33181bb333.</sup>
<!-- /MENDRAL_SUMMARY -->