### PR TITLE
Remove candidate connection limit in routing selection

### DIFF
--- a/pkg/connect/routing/router.go
+++ b/pkg/connect/routing/router.go
@@ -310,15 +310,12 @@ func sortByGroupCreatedAt(candidates []connWithGroup) {
 }
 
 func pickConnection(candidates []connWithGroup, rnd *util.FrandRNG) (*connectpb.ConnMetadata, error) {
-	// First, sort candidate connections by CreatedAt timestamp (newest first)
+	// Sort by group CreatedAt (oldest first) so getVersionTimeDistribution can
+	// read the oldest/newest versions from the ends. All candidates remain
+	// eligible; the weighted sampler distributes uniformly among connections
+	// within a group while biasing selection toward newer groups.
 	sortByGroupCreatedAt(candidates)
 
-	// Clamp candidates
-	if len(candidates) > 5 {
-		candidates = candidates[:5]
-	}
-
-	// Get range of versions
 	versionTimeDistribution := getVersionTimeDistribution(candidates)
 
 	weights := make([]float64, len(candidates))


### PR DESCRIPTION
## Description

Removed the 5-connection candidate limit in `pickConnection()` to allow the weighted sampler to consider all eligible connections when selecting routes. Updated the sorting comment to clarify that candidates are sorted by group CreatedAt (oldest first) to support proper version time distribution calculation, while the weighted sampler handles uniform distribution within groups and bias toward newer groups.

## Motivation

The previous hard limit of 5 candidates was unnecessarily restrictive and prevented the routing algorithm from considering all available connections. By removing this constraint, the weighted sampling mechanism can now fairly evaluate all eligible candidates, improving connection selection quality and distribution.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

https://claude.ai/code/session_01TvpSUSdf24DibbeSa63Mja

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the hard 5-candidate clamp in `pickConnection` that was restricting weighted sampling to the first (oldest) five connections. With the clamp gone, all healthy candidates participate in the weighted sampler, which already biases toward newer groups and distributes uniformly within a group. The sort comment is updated to clarify the oldest-first ordering required by `getVersionTimeDistribution`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6e4786ab61dfb6a87797de986ee88499f385a0e1.</sup>
<!-- /MENDRAL_SUMMARY -->