### PR TITLE
vendor inngest/expr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/graph-gophers/dataloader v5.0.0+incompatible
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/inngest/expr v0.0.0-20260320151211-8abd2c0b8427
+	github.com/inngest/expr v0.0.0-20260504155224-a6e988c15b55
 	github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48
 	github.com/inngest/inngestgo v0.15.2-0.20260416001842-8bbfe3c34af0
 	github.com/jackc/pgx/v5 v5.9.1

--- a/go.sum
+++ b/go.sum
@@ -600,8 +600,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/inngest/expr v0.0.0-20260320151211-8abd2c0b8427 h1:JMWUk8lr4jVdxjo67TRT/bzIwGxlzvWbVYexH+8He1Y=
-github.com/inngest/expr v0.0.0-20260320151211-8abd2c0b8427/go.mod h1:fwLYQ2NlzdevRRQoldvMrMvCicAG6X3NaONAtxuiT8k=
+github.com/inngest/expr v0.0.0-20260504155224-a6e988c15b55 h1:Kf3x22dtq5nytZ7xLhYn7wXsFB3MUDNCJsE/DiQ2p3E=
+github.com/inngest/expr v0.0.0-20260504155224-a6e988c15b55/go.mod h1:fwLYQ2NlzdevRRQoldvMrMvCicAG6X3NaONAtxuiT8k=
 github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48 h1:8NwXUrQTQjWrfGj99JgesfTbCYujtnLHusePp7YyFU8=
 github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48/go.mod h1:7SNLkGaD+tiTey1IF9WUNDNurTfqNZqjbdPZo3CmLW4=
 github.com/inngest/inngestgo v0.15.2-0.20260416001842-8bbfe3c34af0 h1:c3/4VMegD1RLYStKt9Sj+v/s/4z6QG5yN9ZTRhVxXRQ=

--- a/vendor/github.com/inngest/expr/expr.go
+++ b/vendor/github.com/inngest/expr/expr.go
@@ -170,7 +170,11 @@ func NewAggregateEvaluator[T Evaluable](
 
 				return reflect.ValueOf(val).Elem().Interface().(T), err
 			},
-			FS: vfs.NewMem(),
+			// No FS specified: use in-memory storage with reduced settings since
+			// a block cache and bloom filters are pointless without disk reads.
+			FS:                 vfs.NewMem(),
+			BlockCacheSize:     8 << 20,
+			DisableBloomFilter: true,
 		}
 		// Attempt to unmarshal an empty byte slice, ensuring that we have
 		// a concrete type instead of an interface.

--- a/vendor/github.com/inngest/expr/kvdb.go
+++ b/vendor/github.com/inngest/expr/kvdb.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cockroachdb/pebble/v2"
+	"github.com/cockroachdb/pebble/v2/bloom"
 	"github.com/cockroachdb/pebble/v2/vfs"
 	"github.com/google/uuid"
 )
@@ -27,6 +28,11 @@ type KVOpts[T Evaluable] struct {
 	FS vfs.FS
 	// Dir is the direcorty to store the KV data within.
 	Dir string
+	// BlockCacheSize is the size of the pebble block cache in bytes.  Defaults to 512MB.
+	BlockCacheSize int64
+	// DisableBloomFilter disables the bloom filter on L0 SSTs.  The filter is
+	// pointless with an in-memory FS since there are no disk reads to avoid.
+	DisableBloomFilter bool
 }
 
 // New returns a new temporary EvalKV KV store written to disk.
@@ -38,15 +44,36 @@ func NewKV[T Evaluable](o KVOpts[T]) (KV[T], error) {
 		o.FS = vfs.Default
 	}
 
-	db, err := pebble.Open(o.Dir, &pebble.Options{
-		FS: o.FS,
-		// cockroachdb defaults that should slightly help with faster writes
-		// https://github.com/cockroachdb/cockroach/blob/5a1f5da5bb3b2d962d8737848a4fca69f915dacb/pkg/storage/pebble.go#L668-L673
-		L0CompactionThreshold:       2,
+	cacheSize := o.BlockCacheSize
+	if cacheSize == 0 {
+		cacheSize = 512 << 20
+	}
+	blockCache := pebble.NewCache(cacheSize)
+
+	// closely following some of cockroachdb defaults
+	// https://github.com/cockroachdb/cockroach/blob/5a1f5da5bb3b2d962d8737848a4fca69f915dacb/pkg/storage/pebble.go#L668-L673
+	opts := &pebble.Options{
+		FS:                          o.FS,
+		Cache:                       blockCache,
+		DisableWAL:                  true,
+		L0CompactionThreshold:       8,
 		L0StopWritesThreshold:       1000,
 		MemTableSize:                64 << 20, // 64 MB
 		MemTableStopWritesThreshold: 4,
-	})
+		CompactionConcurrencyRange:  func() (int, int) { return 1, 4 },
+	}
+	l0 := pebble.LevelOptions{
+		BlockSize:      32 << 10,
+		IndexBlockSize: 256 << 10,
+	}
+	if !o.DisableBloomFilter {
+		l0.FilterPolicy = bloom.FilterPolicy(10)
+		l0.FilterType = pebble.TableFilter
+	}
+	opts.Levels[0] = l0
+	opts.Levels[0].EnsureL0Defaults()
+
+	db, err := pebble.Open(o.Dir, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/inngest/expr/lift.go
+++ b/vendor/github.com/inngest/expr/lift.go
@@ -12,18 +12,16 @@ const (
 	VarPrefix = "vars"
 )
 
-var (
-	// replace is truly hack city.  these are 20 variable names for values that are
-	// lifted out of expressions via liftLiterals.
-	replace = []string{
-		"a", "b", "c", "d", "e",
-		"f", "g", "h", "i", "j",
-		"k", "l", "m", "n", "o",
-		"p", "q", "r", "s", "t",
-		"u", "v", "w", "x", "y",
-		"z",
-	}
-)
+// replace is truly hack city.  these are 20 variable names for values that are
+// lifted out of expressions via liftLiterals.
+var replace = []string{
+	"a", "b", "c", "d", "e",
+	"f", "g", "h", "i", "j",
+	"k", "l", "m", "n", "o",
+	"p", "q", "r", "s", "t",
+	"u", "v", "w", "x", "y",
+	"z",
+}
 
 // LiftedArgs represents a set of variables that have been lifted from expressions and
 // replaced with identifiers, eg `id == "foo"` becomes `id == vars.a`, with "foo" lifted
@@ -304,8 +302,9 @@ func (l *liftParser) consumeString(quoteChar byte) argMapValue {
 	for l.idx < len(l.expr) {
 		char := l.expr[l.idx]
 
-		if char == '\\' && l.peek() == quoteChar {
-			// If we're escaping the quote character, ignore it.
+		if char == '\\' && l.idx+1 < len(l.expr) {
+			// Escape sequence: skip the backslash and whatever follows it.
+			// This correctly handles \\, \", \', \n, \t, etc.
 			l.idx += 2
 			length += 2
 			continue
@@ -325,11 +324,17 @@ func (l *liftParser) consumeString(quoteChar byte) argMapValue {
 		length++
 	}
 
-	// Should never happen:  we should always find the ending string quote, as the
-	// expression should have already been validated.
-	panic(fmt.Sprintf("unable to parse quoted string: `%s` (offset %d)", l.expr, offset))
+	// this is a grossly invalid expr, eg: `event.data.id == "foo\"`
+	// in this case, we can never parse this string.  we always fix this by treating the last backslash
+	// as a \ literal, innit bruv
+	if length > 0 && offset+length <= len(l.expr) && l.expr[offset+length-1] == quoteChar {
+		length--
+	}
+
+	return argMapValue{offset: offset, length: length}
 }
 
+// nolint:unused
 func (l *liftParser) peek() byte {
 	if (l.idx + 1) >= len(l.expr) {
 		return 0x0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -780,7 +780,7 @@ github.com/hashicorp/hcl/hcl/token
 github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/inngest/expr v0.0.0-20260320151211-8abd2c0b8427
+# github.com/inngest/expr v0.0.0-20260504155224-a6e988c15b55
 ## explicit; go 1.24
 github.com/inngest/expr
 # github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48


### PR DESCRIPTION
## Description
Vendors newer version of the expr dependency for consistency, the main changes are specific to Cloud

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Vendors a newer version of `github.com/inngest/expr`, picking up pebble tuning changes: an explicit block cache, WAL disabled for in-memory use, bloom filter opt-out, and a fix for malformed escape sequences in `consumeString`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 43d782342d2cb32717bd99a322a1a061176d71dc.</sup>
<!-- /MENDRAL_SUMMARY -->