### PR TITLE
Fix AI metadata detail fields

### DIFF
--- a/ui/packages/components/src/AI/AITrace.test.tsx
+++ b/ui/packages/components/src/AI/AITrace.test.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AITrace } from './AITrace';
+
+vi.mock('../DetailsCard/Element', () => ({
+  ElementWrapper: ({ label, children }: { label: string; children: ReactNode }) => (
+    <div>
+      <span>{label}</span>
+      <div>{children}</div>
+    </div>
+  ),
+  TextElement: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+describe('AITrace', () => {
+  it('renders canonical AI metadata labels', () => {
+    render(
+      <AITrace
+        aiInfo={{
+          model: 'gpt-4o-mini-2024-07-18',
+          inputTokens: 16,
+          outputTokens: 19,
+          totalTokens: 35,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Model')).toBeTruthy();
+    expect(screen.getByText('Input Tokens')).toBeTruthy();
+    expect(screen.getByText('Output Tokens')).toBeTruthy();
+    expect(screen.getByText('Total Tokens')).toBeTruthy();
+    expect(screen.queryByText('Prompt Tokens')).toBeNull();
+    expect(screen.queryByText('Completion Tokens')).toBeNull();
+  });
+});

--- a/ui/packages/components/src/AI/AITrace.tsx
+++ b/ui/packages/components/src/AI/AITrace.tsx
@@ -1,15 +1,12 @@
 import { ElementWrapper, TextElement } from '../DetailsCard/Element';
-import { getAIInfo, type ExperimentalAI } from './utils';
+import type { AIInfo } from './utils';
 
-export const AITrace = ({ aiOutput }: { aiOutput?: ExperimentalAI }) => {
-  if (!aiOutput) {
+export const AITrace = ({ aiInfo }: { aiInfo?: AIInfo }) => {
+  if (!aiInfo) {
     return null;
   }
-  const { promptTokens, completionTokens, totalTokens, model } = getAIInfo(aiOutput);
+  const { inputTokens, outputTokens, totalTokens, model } = aiInfo;
 
-  //
-  // upstream parsing is quite forgiving,
-  // only show ai metadata it actually exists
   return (
     <>
       {model && (
@@ -17,14 +14,14 @@ export const AITrace = ({ aiOutput }: { aiOutput?: ExperimentalAI }) => {
           <TextElement>{model}</TextElement>
         </ElementWrapper>
       )}
-      {typeof promptTokens === 'number' && (
-        <ElementWrapper label="Prompt Tokens">
-          <TextElement>{promptTokens}</TextElement>
+      {typeof inputTokens === 'number' && (
+        <ElementWrapper label="Input Tokens">
+          <TextElement>{inputTokens}</TextElement>
         </ElementWrapper>
       )}
-      {typeof completionTokens === 'number' && (
-        <ElementWrapper label="Completion Tokens">
-          <TextElement>{completionTokens}</TextElement>
+      {typeof outputTokens === 'number' && (
+        <ElementWrapper label="Output Tokens">
+          <TextElement>{outputTokens}</TextElement>
         </ElementWrapper>
       )}
       {typeof totalTokens === 'number' && (

--- a/ui/packages/components/src/AI/utils.test.ts
+++ b/ui/packages/components/src/AI/utils.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { describe, it } from 'vitest';
 
-import { getAIInfo, type OpenAIOutput } from './utils';
+import { getAIInfo, getAIInfoFromMetadata, type OpenAIOutput } from './utils';
 
 const googleOutput = {
   body: {
@@ -377,8 +377,8 @@ describe('parseAIOutput', (t) => {
 
     assert.deepStrictEqual(aiInfo, {
       model: 'gpt-4o-mini-2024-07-18',
-      promptTokens: 16,
-      completionTokens: 18,
+      inputTokens: 16,
+      outputTokens: 18,
       totalTokens: 34,
     });
   });
@@ -387,10 +387,10 @@ describe('parseAIOutput', (t) => {
     const aiInfo = getAIInfo(vercelOutput);
 
     assert.deepStrictEqual(aiInfo, {
-      completionTokens: 19,
-      promptTokens: 16,
-      totalTokens: 35,
       model: 'gpt-4o-mini-2024-07-18',
+      inputTokens: 16,
+      outputTokens: 19,
+      totalTokens: 35,
     });
   });
 
@@ -398,10 +398,10 @@ describe('parseAIOutput', (t) => {
     const aiInfo = getAIInfo(anthropicOutput);
 
     assert.deepStrictEqual(aiInfo, {
-      completionTokens: 35,
-      promptTokens: 17,
-      totalTokens: 52,
       model: 'claude-3-5-sonnet-20241022',
+      inputTokens: 17,
+      outputTokens: 35,
+      totalTokens: 52,
     });
   });
 
@@ -409,10 +409,95 @@ describe('parseAIOutput', (t) => {
     const aiInfo = getAIInfo(googleOutput);
 
     assert.deepStrictEqual(aiInfo, {
-      completionTokens: 17,
-      promptTokens: 9,
-      totalTokens: 26,
       model: 'gemini-1.5-flash-001',
+      inputTokens: 9,
+      outputTokens: 17,
+      totalTokens: 26,
+    });
+  });
+
+  it('ignores nested cost fields when direct usage tokens exist', () => {
+    const aiInfo = getAIInfo({
+      model: 'claude-opus-4-1',
+      usage: {
+        cacheRead: 0,
+        cacheWrite: 3258,
+        cost: {
+          cacheread: 0,
+          cachewrite: 0.061087,
+          input: 0.000045,
+          output: 0.00765,
+          total: 0.0687825,
+        },
+        input: 3,
+        output: 102,
+        totaltokens: 3363,
+      },
+    });
+
+    assert.deepStrictEqual(aiInfo, {
+      model: 'claude-opus-4-1',
+      inputTokens: 3,
+      outputTokens: 102,
+      totalTokens: 3363,
+    });
+  });
+});
+
+describe('getAIInfoFromMetadata', () => {
+  it('prefers step_attempt metadata and returns canonical fields', () => {
+    const aiInfo = getAIInfoFromMetadata([
+      {
+        kind: 'inngest.ai',
+        scope: 'extended_trace',
+        updatedAt: '2026-01-01T00:00:00Z',
+        values: {
+          input_tokens: 8,
+          output_tokens: 13,
+          total_tokens: 21,
+          model: 'old-model',
+        },
+      },
+      {
+        kind: 'inngest.ai',
+        scope: 'step_attempt',
+        updatedAt: '2026-01-01T00:00:01Z',
+        values: {
+          input_tokens: 16,
+          output_tokens: 19,
+          total_tokens: 35,
+          model: 'gpt-4o-mini-2024-07-18',
+        },
+      },
+    ]);
+
+    assert.deepStrictEqual(aiInfo, {
+      model: 'gpt-4o-mini-2024-07-18',
+      inputTokens: 16,
+      outputTokens: 19,
+      totalTokens: 35,
+    });
+  });
+
+  it('computes total tokens when canonical metadata omits it', () => {
+    const aiInfo = getAIInfoFromMetadata([
+      {
+        kind: 'inngest.ai',
+        scope: 'step_attempt',
+        updatedAt: '2026-01-01T00:00:01Z',
+        values: {
+          input_tokens: 7,
+          output_tokens: 5,
+          model: 'claude-sonnet-4-5',
+        },
+      },
+    ]);
+
+    assert.deepStrictEqual(aiInfo, {
+      model: 'claude-sonnet-4-5',
+      inputTokens: 7,
+      outputTokens: 5,
+      totalTokens: 12,
     });
   });
 });

--- a/ui/packages/components/src/AI/utils.ts
+++ b/ui/packages/components/src/AI/utils.ts
@@ -20,6 +20,170 @@ export type GoogleAIOutput = {
 
 export type ExperimentalAI = OpenAIOutput | VercelAIOutput | GoogleAIOutput;
 
+export type AIInfo = {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+  model?: string;
+};
+
+type MetadataLike = {
+  kind?: string | null;
+  scope?: string | null;
+  updatedAt?: string | null;
+  values?: Record<string, unknown> | null;
+};
+
+type Value = string | number | boolean | null;
+type Object = { [key: string]: Value | Object | Array<Value | Object> };
+
+const AI_METADATA_KIND = 'inngest.ai';
+const preferredMetadataScopes = ['step_attempt', 'extended_trace'] as const;
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const asNumber = (value: unknown): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.length > 0 ? value : undefined;
+
+const withComputedTotalTokens = (info: AIInfo): AIInfo => {
+  if (
+    typeof info.totalTokens !== 'number' &&
+    typeof info.inputTokens === 'number' &&
+    typeof info.outputTokens === 'number'
+  ) {
+    return {
+      ...info,
+      totalTokens: info.inputTokens + info.outputTokens,
+    };
+  }
+
+  return info;
+};
+
+const hasAIInfo = (info: AIInfo | undefined): info is AIInfo =>
+  Boolean(
+    info &&
+      (typeof info.inputTokens === 'number' ||
+        typeof info.outputTokens === 'number' ||
+        typeof info.totalTokens === 'number' ||
+        info.model)
+  );
+
+const getModelFromStep = (step: unknown): string | undefined => {
+  if (!isObject(step)) {
+    return undefined;
+  }
+
+  const response = isObject(step.response) ? step.response : undefined;
+  if (response) {
+    const responseModel = asString(response.modelId);
+    if (responseModel) {
+      return responseModel;
+    }
+  }
+
+  const request = isObject(step.request) ? step.request : undefined;
+  const body = request && isObject(request.body) ? request.body : undefined;
+  return body ? asString(body.model) : undefined;
+};
+
+const getUsageInfo = (usage: unknown): AIInfo | undefined => {
+  if (!isObject(usage)) {
+    return undefined;
+  }
+
+  const candidates: AIInfo[] = [
+    {
+      inputTokens: asNumber(usage.prompt_tokens),
+      outputTokens: asNumber(usage.completion_tokens),
+      totalTokens: asNumber(usage.total_tokens),
+    },
+    {
+      inputTokens: asNumber(usage.input_tokens),
+      outputTokens: asNumber(usage.output_tokens),
+      totalTokens: asNumber(usage.total_tokens),
+    },
+    {
+      inputTokens: asNumber(usage.promptTokens),
+      outputTokens: asNumber(usage.completionTokens),
+      totalTokens: asNumber(usage.totalTokens),
+    },
+    {
+      inputTokens: asNumber(usage.inputTokens),
+      outputTokens: asNumber(usage.outputTokens),
+      totalTokens: asNumber(usage.totalTokens),
+    },
+    {
+      inputTokens: asNumber(usage.input),
+      outputTokens: asNumber(usage.output),
+      totalTokens: asNumber(usage.totaltokens),
+    },
+  ];
+
+  return candidates.map(withComputedTotalTokens).find(hasAIInfo);
+};
+
+const getGoogleAIInfo = (obj: Object): AIInfo | undefined => {
+  const response = isObject(obj.response) ? obj.response : undefined;
+  const usageMetadata =
+    response && isObject(response.usageMetadata) ? response.usageMetadata : undefined;
+
+  if (!response || !usageMetadata) {
+    return undefined;
+  }
+
+  return withComputedTotalTokens({
+    model: asString(response.modelVersion),
+    inputTokens: asNumber(usageMetadata.promptTokenCount),
+    outputTokens: asNumber(usageMetadata.candidatesTokenCount),
+    totalTokens: asNumber(usageMetadata.totalTokenCount),
+  });
+};
+
+const isLikelyVercelOutput = (obj: Object): boolean => {
+  const response = isObject(obj.response) ? obj.response : undefined;
+
+  return Boolean(
+    obj.experimental_providerMetadata ||
+      obj.totalUsage ||
+      obj.rawResponse ||
+      (Array.isArray(obj.steps) && obj.steps.length > 0) ||
+      (response && response.modelId)
+  );
+};
+
+const getVercelAIInfo = (obj: Object): AIInfo | undefined => {
+  if (!isLikelyVercelOutput(obj)) {
+    return undefined;
+  }
+
+  const totalUsageInfo = getUsageInfo(obj.totalUsage);
+  const topLevelUsageInfo = getUsageInfo(obj.usage);
+
+  const steps = Array.isArray(obj.steps) ? obj.steps : [];
+  const firstStep = steps.find((step): step is Object => isObject(step));
+  const stepUsageInfo = firstStep ? getUsageInfo(firstStep.usage) : undefined;
+
+  const model =
+    asString(obj.modelId) ??
+    (isObject(obj.response) ? asString(obj.response.modelId) : undefined) ??
+    (firstStep ? getModelFromStep(firstStep) : undefined);
+
+  const usageInfo = totalUsageInfo ?? topLevelUsageInfo ?? stepUsageInfo;
+  if (!usageInfo && !model) {
+    return undefined;
+  }
+
+  return withComputedTotalTokens({
+    ...(usageInfo ?? {}),
+    model,
+  });
+};
+
 export const parseAIOutput = (output: string): ExperimentalAI | undefined => {
   try {
     const data = JSON.parse(output);
@@ -48,78 +212,62 @@ export const parseAIOutput = (output: string): ExperimentalAI | undefined => {
   }
 };
 
-//
-// regex pattern to match the key pieces of ai information in outputs:
-// promptTokens, completionTokens, totalTokens, model and common variations
-// such as promptTokens, prompt_tokens, modelId, model, etc.
-const pattern =
-  /\b(?:prompt|input|completion|output|total|model)[ _]?(?:id|version|tokens?|TokenCount)?\b|\b(?:prompt|candidates|total)[ _]?(?:tokens?|TokenCount)\b/i;
-
-export type Value = string | number | boolean | null;
-type Object = { [key: string]: Value | Object | Array<Value | Object> };
-
-type ResultType = {
-  promptTokens?: Value;
-  completionTokens?: Value;
-  totalTokens?: Value;
-  model?: Value;
-};
-
-/*
- * recursively search through the object to find any of the key pieces of ai information
- * we care about. For now just take the first match we find for each and stop there.
- */
-export const getAIInfo = (obj: Object): ResultType => {
-  const info = Object.keys(obj).reduce<ResultType>((acc, key) => {
-    if (acc.promptTokens && acc.completionTokens && acc.totalTokens && acc.model) {
-      return acc;
-    }
-
-    const value = obj[key];
-
-    //
-    // Handle arrays by reducing each element into a combined result
-    if (Array.isArray(value)) {
-      const arrayResult = value.reduce<ResultType>((arrayAcc, item) => {
-        if (typeof item === 'object' && item !== null) {
-          return { ...arrayAcc, ...getAIInfo(item) };
-        }
-        return arrayAcc;
-      }, {});
-      return { ...acc, ...arrayResult };
-    }
-
-    if (typeof value === 'object' && value !== null) {
-      return { ...acc, ...getAIInfo(value) };
-    }
-
-    const match = pattern.exec(key);
-
-    if (match) {
-      if (!acc.promptTokens && (/prompt/.test(key) || /input/.test(key))) {
-        acc.promptTokens = value;
-      } else if (
-        !acc.completionTokens &&
-        (/completion/.test(key) || /output/.test(key) || /candidatesTokenCount/.test(key))
-      ) {
-        acc.completionTokens = value;
-      } else if (!acc.totalTokens && /total/.test(key)) {
-        acc.totalTokens = value;
-      } else if (!acc.model && /model/.test(key)) {
-        acc.model = value;
-      }
-    }
-
-    return acc;
-  }, {});
-
-  if (
-    !info.totalTokens &&
-    typeof info.promptTokens === 'number' &&
-    typeof info.completionTokens === 'number'
-  ) {
-    info.totalTokens = info.promptTokens + info.completionTokens;
+export const getAIInfo = (obj: Object): AIInfo => {
+  if (isObject(obj.body)) {
+    return getAIInfo(obj.body as Object);
   }
 
-  return info;
+  if (isObject(obj.data)) {
+    return getAIInfo(obj.data as Object);
+  }
+
+  const directUsageInfo = getUsageInfo(obj.usage);
+  const directInfo = withComputedTotalTokens({
+    model: asString(obj.model),
+    ...(directUsageInfo ?? {}),
+  });
+
+  const info = getGoogleAIInfo(obj) ?? getVercelAIInfo(obj) ?? directInfo;
+
+  return hasAIInfo(info) ? info : {};
+};
+
+export const getAIInfoFromMetadata = (metadata?: MetadataLike[] | null): AIInfo | undefined => {
+  if (!metadata?.length) {
+    return undefined;
+  }
+
+  for (const scope of preferredMetadataScopes) {
+    const match = metadata
+      .filter((entry): entry is MetadataLike =>
+        Boolean(
+          entry &&
+            entry.kind === AI_METADATA_KIND &&
+            entry.scope === scope &&
+            isObject(entry.values)
+        )
+      )
+      .sort((a, b) => {
+        const aTime = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+        const bTime = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+        return bTime - aTime;
+      })[0];
+
+    if (!match || !match.values) {
+      continue;
+    }
+
+    const info = withComputedTotalTokens({
+      inputTokens: asNumber(match.values.input_tokens),
+      outputTokens: asNumber(match.values.output_tokens),
+      totalTokens: asNumber(match.values.total_tokens),
+      model: asString(match.values.model),
+    });
+
+    if (hasAIInfo(info)) {
+      return info;
+    }
+  }
+
+  return undefined;
 };

--- a/ui/packages/components/src/RunDetailsV3/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/RunInfo.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { RiArrowRightSLine } from '@remixicon/react';
 
 import { AITrace } from '../AI/AITrace';
-import { parseAIOutput } from '../AI/utils';
+import { getAIInfo, parseAIOutput } from '../AI/utils';
 import {
   ElementWrapper,
   IDElement,
@@ -58,6 +58,7 @@ export const RunInfo = ({ initialRunData, run, runID, standalone, result }: Prop
   const [expanded, setExpanded] = useState(true);
   const allowCancel = isLazyDone(run) && !Boolean(run.trace.endedAt);
   const aiOutput = result?.data ? parseAIOutput(result.data) : undefined;
+  const aiInfo = aiOutput ? getAIInfo(aiOutput) : undefined;
   const { pathCreator } = usePathCreator();
 
   return (
@@ -200,7 +201,7 @@ export const RunInfo = ({ initialRunData, run, runID, standalone, result }: Prop
               return <TimeElement date={endedAt} />;
             }}
           </OptimisticElementWrapper>
-          {aiOutput && <AITrace aiOutput={aiOutput} />}
+          {aiInfo && <AITrace aiInfo={aiInfo} />}
         </div>
       )}
     </div>

--- a/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV3/StepInfo.tsx
@@ -4,7 +4,7 @@ import { Button } from '@inngest/components/Button/Button';
 import { RiArrowRightSLine } from '@remixicon/react';
 
 import { AITrace } from '../AI/AITrace';
-import { parseAIOutput } from '../AI/utils';
+import { getAIInfo, getAIInfoFromMetadata, parseAIOutput } from '../AI/utils';
 import {
   CodeElement,
   ElementWrapper,
@@ -172,6 +172,8 @@ export const StepInfo = ({
   });
 
   const aiOutput = result?.data ? parseAIOutput(result.data) : undefined;
+  const aiInfo =
+    getAIInfoFromMetadata(trace.metadata) ?? (aiOutput ? getAIInfo(aiOutput) : undefined);
   const prettyInput = usePrettyJson(result?.input ?? '') || (result?.input ?? '');
   const prettyOutput = usePrettyJson(result?.data ?? '') || (result?.data ?? '');
   const prettyErrorBody = usePrettyErrorBody(result?.error);
@@ -278,7 +280,7 @@ export const StepInfo = ({
 
           {stepKindInfo}
 
-          {aiOutput && <AITrace aiOutput={aiOutput} />}
+          {aiInfo && <AITrace aiInfo={aiInfo} />}
         </div>
       )}
 

--- a/ui/packages/components/src/RunDetailsV4/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/RunInfo.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { RiArrowRightSLine } from '@remixicon/react';
 
 import { AITrace } from '../AI/AITrace';
-import { parseAIOutput } from '../AI/utils';
+import { getAIInfo, parseAIOutput } from '../AI/utils';
 import {
   ElementWrapper,
   IDElement,
@@ -66,6 +66,7 @@ export const RunInfo = ({
   const [expanded, setExpanded] = useState(true);
   const allowCancel = isLazyDone(run) && !Boolean(run.trace.endedAt);
   const aiOutput = result?.data ? parseAIOutput(result.data) : undefined;
+  const aiInfo = aiOutput ? getAIInfo(aiOutput) : undefined;
   const { pathCreator } = usePathCreator();
 
   return (
@@ -209,7 +210,7 @@ export const RunInfo = ({
               return <TimeElement date={endedAt} />;
             }}
           </OptimisticElementWrapper>
-          {aiOutput && <AITrace aiOutput={aiOutput} />}
+          {aiInfo && <AITrace aiInfo={aiInfo} />}
         </div>
       )}
     </div>

--- a/ui/packages/components/src/RunDetailsV4/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/StepInfo.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { RiArrowRightSLine } from '@remixicon/react';
 
 import { AITrace } from '../AI/AITrace';
-import { parseAIOutput } from '../AI/utils';
+import { getAIInfo, getAIInfoFromMetadata, parseAIOutput } from '../AI/utils';
 import { Button } from '../Button/Button';
 import {
   CodeElement,
@@ -209,6 +209,8 @@ export const StepInfo = ({
   });
 
   const aiOutput = result?.data ? parseAIOutput(result.data) : undefined;
+  const aiInfo =
+    getAIInfoFromMetadata(trace.metadata) ?? (aiOutput ? getAIInfo(aiOutput) : undefined);
   const prettyInput = usePrettyJson(result?.input ?? '') || (result?.input ?? '');
   const prettyOutput = usePrettyJson(result?.data ?? '') || (result?.data ?? '');
   const prettyErrorBody = usePrettyErrorBody(result?.error);
@@ -369,7 +371,7 @@ export const StepInfo = ({
             </ElementWrapper>
           )}
 
-          {aiOutput && <AITrace aiOutput={aiOutput} />}
+          {aiInfo && <AITrace aiInfo={aiInfo} />}
         </div>
       )}
 


### PR DESCRIPTION
## Description

https://inngest.slack.com/archives/C069Q14GKC5/p1777600992044119

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Refactors AI metadata parsing to use canonical `inputTokens`/`outputTokens` field names (replacing `promptTokens`/`completionTokens`), introduces a new `getAIInfoFromMetadata` function that reads from structured trace metadata with scope priority (`step_attempt` > `extended_trace`), and updates `AITrace` to accept the normalized `AIInfo` type directly instead of raw output.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4d364c50fcb203062e15acd43e0af9dbc81f101f.</sup>
<!-- /MENDRAL_SUMMARY -->