### PR TITLE
EXE-1550: Entirely Synchronous Durable endpoints move to Completed Status

### DIFF
--- a/pkg/api/apiv1/checkpoint.go
+++ b/pkg/api/apiv1/checkpoint.go
@@ -420,7 +420,7 @@ func (a checkpointAPI) Output(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set(k, v)
 			}
 			w.WriteHeader(res.Data.StatusCode)
-			_, _ = w.Write(res.Data.Body)
+			_, _ = w.Write([]byte(res.Data.Body))
 			return
 		}
 

--- a/pkg/api/apiv1/checkpoint_test.go
+++ b/pkg/api/apiv1/checkpoint_test.go
@@ -42,7 +42,7 @@ func TestCheckpointAPI_Output(t *testing.T) {
 				"X-Custom-Header": "custom-value",
 				"Content-Type":    "text/plain",
 			},
-			Body: []byte("response body content"),
+			Body: "response body content",
 		}
 		wrappedOutput, err := json.Marshal(map[string]any{"data": apiRes})
 		require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestCheckpointAPI_Output(t *testing.T) {
 			Headers: map[string]string{
 				"Content-Type": "application/json",
 			},
-			Body: []byte(`{"error":"internal server error"}`),
+			Body: `{"error":"internal server error"}`,
 		}
 		wrappedOutput, err := json.Marshal(map[string]any{"data": apiRes})
 		require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestCheckpointAPI_Output(t *testing.T) {
 		apiRes := apiresult.APIResult{
 			StatusCode: 204,
 			Headers:    map[string]string{},
-			Body:       nil,
+			Body:       "",
 		}
 		wrappedOutput, err := json.Marshal(map[string]any{"data": apiRes})
 		require.NoError(t, err)

--- a/pkg/execution/apiresult/apiresult.go
+++ b/pkg/execution/apiresult/apiresult.go
@@ -1,16 +1,55 @@
 package apiresult
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
-// APIResult represents the final result of a sync-based API function call
+// APIResult represents the final result of a sync-based API function call.
+//
+// For SSE/streaming responses, the JS SDK cannot re-read the body and instead
+// posts a placeholder ("null"); the actual response bytes go directly to the
+// original HTTP caller.
+//
+// APIResult has custom JSON (un)marshaling to work with Body as a string in
+// JSON.
 type APIResult struct {
 	// StatusCode represents the status code for the API result
-	StatusCode int `json:"status_code"`
+	StatusCode int `json:"status"`
 	// Headers represents any response headers sent in the server response
 	Headers map[string]string `json:"headers"`
 	// Body represents the API response.  This may be nil by default.  It is only
 	// captured when you manually specify that you want to track the result.
-	Body []byte `json:"body,omitempty"`
+	Body []byte `json:"-"`
 	// Duration represents the overall time that it took for the API to execute.
-	Duration time.Duration `json:"duration"`
+	Duration time.Duration `json:"-"`
+}
+
+// apiResultWire is the on-the-wire representation.
+//
+// Notably, Body is a string (on-the-wire form) rather than []byte (internal
+// form).
+type apiResultWire struct {
+	StatusCode int               `json:"status"`
+	Headers    map[string]string `json:"headers,omitempty"`
+	Body       string            `json:"body,omitempty"`
+}
+
+func (a *APIResult) UnmarshalJSON(data []byte) error {
+	w := apiResultWire{}
+	if err := json.Unmarshal(data, &w); err != nil {
+		return err
+	}
+	a.StatusCode = w.StatusCode
+	a.Headers = w.Headers
+	a.Body = []byte(w.Body)
+	return nil
+}
+
+func (a APIResult) MarshalJSON() ([]byte, error) {
+	return json.Marshal(apiResultWire{
+		StatusCode: a.StatusCode,
+		Headers:    a.Headers,
+		Body:       string(a.Body),
+	})
 }

--- a/pkg/execution/apiresult/apiresult.go
+++ b/pkg/execution/apiresult/apiresult.go
@@ -1,55 +1,21 @@
 package apiresult
 
-import (
-	"encoding/json"
-	"time"
-)
+import "time"
 
 // APIResult represents the final result of a sync-based API function call.
 //
 // For SSE/streaming responses, the JS SDK cannot re-read the body and instead
 // posts a placeholder ("null"); the actual response bytes go directly to the
 // original HTTP caller.
-//
-// APIResult has custom JSON (un)marshaling to work with Body as a string in
-// JSON.
 type APIResult struct {
 	// StatusCode represents the status code for the API result
 	StatusCode int `json:"status"`
 	// Headers represents any response headers sent in the server response
-	Headers map[string]string `json:"headers"`
-	// Body represents the API response.  This may be nil by default.  It is only
-	// captured when you manually specify that you want to track the result.
-	Body []byte `json:"-"`
+	Headers map[string]string `json:"headers,omitempty"`
+	// Body represents the API response.  This may be empty by default.  It is
+	// only captured when you manually specify that you want to track the
+	// result.
+	Body string `json:"body,omitempty"`
 	// Duration represents the overall time that it took for the API to execute.
-	Duration time.Duration `json:"-"`
-}
-
-// apiResultWire is the on-the-wire representation.
-//
-// Notably, Body is a string (on-the-wire form) rather than []byte (internal
-// form).
-type apiResultWire struct {
-	StatusCode int               `json:"status"`
-	Headers    map[string]string `json:"headers,omitempty"`
-	Body       string            `json:"body,omitempty"`
-}
-
-func (a *APIResult) UnmarshalJSON(data []byte) error {
-	w := apiResultWire{}
-	if err := json.Unmarshal(data, &w); err != nil {
-		return err
-	}
-	a.StatusCode = w.StatusCode
-	a.Headers = w.Headers
-	a.Body = []byte(w.Body)
-	return nil
-}
-
-func (a APIResult) MarshalJSON() ([]byte, error) {
-	return json.Marshal(apiResultWire{
-		StatusCode: a.StatusCode,
-		Headers:    a.Headers,
-		Body:       string(a.Body),
-	})
+	Duration time.Duration `json:"duration"`
 }

--- a/pkg/execution/apiresult/apiresult_test.go
+++ b/pkg/execution/apiresult/apiresult_test.go
@@ -8,36 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAPIResult_MarshalJSON(t *testing.T) {
-	t.Run("body is encoded as a JSON string, not base64", func(t *testing.T) {
-		r := APIResult{
-			StatusCode: 200,
-			Headers:    map[string]string{"Content-Type": "application/json"},
-			Body:       []byte(`{"hello":"world"}`),
-		}
-
-		got, err := json.Marshal(r)
-		require.NoError(t, err)
-
-		// Decode into a generic map to inspect wire form.
-		var wire map[string]any
-		require.NoError(t, json.Unmarshal(got, &wire))
-
-		assert.Equal(t, float64(200), wire["status"])
-		assert.Equal(t, `{"hello":"world"}`, wire["body"])
-	})
-
-	t.Run("Duration is not serialized", func(t *testing.T) {
-		r := APIResult{StatusCode: 200, Duration: 12345}
-		got, err := json.Marshal(r)
-		require.NoError(t, err)
-		assert.NotContains(t, string(got), "duration")
-		assert.NotContains(t, string(got), "Duration")
-	})
-}
-
 func TestAPIResult_UnmarshalJSON(t *testing.T) {
-	t.Run("decodes body string into []byte", func(t *testing.T) {
+	t.Run("decodes body string", func(t *testing.T) {
 		raw := `{"status":201,"headers":{"X-Foo":"bar"},"body":"{\"a\":1}","version":2}`
 
 		var r APIResult
@@ -45,6 +17,27 @@ func TestAPIResult_UnmarshalJSON(t *testing.T) {
 
 		assert.Equal(t, 201, r.StatusCode)
 		assert.Equal(t, map[string]string{"X-Foo": "bar"}, r.Headers)
-		assert.Equal(t, []byte(`{"a":1}`), r.Body)
+		assert.Equal(t, `{"a":1}`, r.Body)
+	})
+
+	t.Run("absent body decodes to empty string", func(t *testing.T) {
+		// Streaming/SSE responses post no body — the wire form omits "body"
+		// entirely and we should land on the zero value rather than a
+		// silently-introduced placeholder.
+		raw := `{"status":200,"headers":{}}`
+
+		var r APIResult
+		require.NoError(t, json.Unmarshal([]byte(raw), &r))
+
+		assert.Equal(t, "", r.Body)
+	})
+
+	t.Run("explicit empty body string decodes to empty string", func(t *testing.T) {
+		raw := `{"status":200,"headers":{},"body":""}`
+
+		var r APIResult
+		require.NoError(t, json.Unmarshal([]byte(raw), &r))
+
+		assert.Equal(t, "", r.Body)
 	})
 }

--- a/pkg/execution/apiresult/apiresult_test.go
+++ b/pkg/execution/apiresult/apiresult_test.go
@@ -1,0 +1,50 @@
+package apiresult
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIResult_MarshalJSON(t *testing.T) {
+	t.Run("body is encoded as a JSON string, not base64", func(t *testing.T) {
+		r := APIResult{
+			StatusCode: 200,
+			Headers:    map[string]string{"Content-Type": "application/json"},
+			Body:       []byte(`{"hello":"world"}`),
+		}
+
+		got, err := json.Marshal(r)
+		require.NoError(t, err)
+
+		// Decode into a generic map to inspect wire form.
+		var wire map[string]any
+		require.NoError(t, json.Unmarshal(got, &wire))
+
+		assert.Equal(t, float64(200), wire["status"])
+		assert.Equal(t, `{"hello":"world"}`, wire["body"])
+	})
+
+	t.Run("Duration is not serialized", func(t *testing.T) {
+		r := APIResult{StatusCode: 200, Duration: 12345}
+		got, err := json.Marshal(r)
+		require.NoError(t, err)
+		assert.NotContains(t, string(got), "duration")
+		assert.NotContains(t, string(got), "Duration")
+	})
+}
+
+func TestAPIResult_UnmarshalJSON(t *testing.T) {
+	t.Run("decodes body string into []byte", func(t *testing.T) {
+		raw := `{"status":201,"headers":{"X-Foo":"bar"},"body":"{\"a\":1}","version":2}`
+
+		var r APIResult
+		require.NoError(t, json.Unmarshal([]byte(raw), &r))
+
+		assert.Equal(t, 201, r.StatusCode)
+		assert.Equal(t, map[string]string{"X-Foo": "bar"}, r.Headers)
+		assert.Equal(t, []byte(`{"a":1}`), r.Body)
+	})
+}

--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -22,6 +22,7 @@ import (
 	"github.com/inngest/inngest/pkg/execution/executor"
 	"github.com/inngest/inngest/pkg/execution/executor/queueref"
 	"github.com/inngest/inngest/pkg/execution/queue"
+	sv1 "github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/logger"
@@ -307,9 +308,7 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 			}
 
 		case enums.OpcodeRunComplete:
-			result := struct {
-				Data apiresult.APIResult `json:"data"`
-			}{}
+			result := apiresult.APIResult{}
 			if err := json.Unmarshal(op.Data, &result); err != nil {
 				l.Error("error unmarshalling api result from sync RunComplete op", "error", err)
 			}
@@ -322,9 +321,27 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 			}, enums.RunStatusCompleted)
 
 			// Call finalize and process the entire op.
-			if err := c.finalize(ctx, *input.Metadata, result.Data); err != nil {
+			if err := c.finalize(ctx, *input.Metadata, result); err != nil {
 				l.Error("error finalizing sync run", "error", err)
 			}
+
+			finishedResp := sv1.DriverResponse{
+				StatusCode: result.StatusCode,
+				Output:     result.Body,
+				Duration:   result.Duration,
+			}
+			if result.StatusCode < 200 || result.StatusCode > 299 {
+				errStr := fmt.Sprintf("invalid status code: %d", result.StatusCode)
+				finishedResp.Err = &errStr
+			}
+
+			c.Executor.RunFunctionFinishedLifecycle(
+				ctx,
+				*input.Metadata,
+				runCtx.LifecycleItem(),
+				runCtx.Events(),
+				finishedResp,
+			)
 
 		case enums.OpcodeDeferAdd:
 			if err := defers.SaveFromOp(ctx, c.State, l, input.Metadata.ID, op); err != nil {

--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution"
+	"github.com/inngest/inngest/pkg/execution/apiresult"
 	"github.com/inngest/inngest/pkg/execution/executor"
+	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
@@ -841,6 +843,108 @@ func TestSyncStepMetadata(t *testing.T) {
 	})
 }
 
+// TestCheckpointSyncSteps_RunComplete asserts that an OpcodeRunComplete op:
+//   - is forwarded to Executor.Finalize with the correct StatusCode/Headers/Body;
+//   - fires Executor.RunFunctionFinishedLifecycle with the same StatusCode so the
+//     legacy OTel pipeline emits a terminal status
+func TestCheckpointSyncSteps_RunComplete(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		wantErr    string
+	}{
+		{name: "success", statusCode: 200, wantErr: ""},
+		{name: "server error", statusCode: 500, wantErr: "invalid status code: 500"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			require := require.New(t)
+
+			body := json.RawMessage(`{"hello":"world"}`)
+			headers := map[string]string{"content-type": "application/json"}
+
+			wire, err := json.Marshal(apiresult.APIResult{
+				StatusCode: tc.statusCode,
+				Headers:    headers,
+				Body:       body,
+			})
+			require.NoError(err)
+
+			ops := []state.GeneratorOpcode{{
+				ID:   "run-complete-1",
+				Op:   enums.OpcodeRunComplete,
+				Data: wire,
+			}}
+
+			mocks, testData := setupSyncCheckpointTest(t, ops...)
+
+			// matchAPIResult validates the StatusCode/Headers/Body that the
+			// checkpoint path forwards into Finalize and the lifecycle. This
+			// is the assertion the original bug needed: without it, a
+			// zero-valued APIResult passes silently.
+			matchAPIResult := func(want apiresult.APIResult) func(apiresult.APIResult) bool {
+				return func(got apiresult.APIResult) bool {
+					return got.StatusCode == want.StatusCode &&
+						string(got.Body) == string(want.Body) &&
+						got.Headers["content-type"] == want.Headers["content-type"]
+				}
+			}
+			expected := apiresult.APIResult{
+				StatusCode: tc.statusCode,
+				Headers:    headers,
+				Body:       body,
+			}
+
+			mocks.executor.On("Finalize", ctx, mock.MatchedBy(func(opts execution.FinalizeOpts) bool {
+				return opts.Response.Type == execution.FinalizeResponseAPI &&
+					matchAPIResult(expected)(opts.Response.APIResponse)
+			})).Return(nil).Once()
+
+			mocks.executor.On(
+				"RunFunctionFinishedLifecycle",
+				ctx,
+				testData.metadata,
+				mock.AnythingOfType("queue.Item"),
+				mock.AnythingOfType("[]json.RawMessage"),
+				mock.MatchedBy(func(resp state.DriverResponse) bool {
+					if resp.StatusCode != tc.statusCode {
+						return false
+					}
+					out, ok := resp.Output.([]byte)
+					if !ok || string(out) != string(body) {
+						return false
+					}
+					if tc.wantErr == "" {
+						return resp.Err == nil
+					}
+					return resp.Err != nil && *resp.Err == tc.wantErr
+				}),
+			).Once()
+
+			mocks.metrics.On(
+				"OnFnFinished",
+				mock.Anything,
+				mock.AnythingOfType("checkpoint.MetricCardinality"),
+				enums.RunStatusCompleted,
+			).Once()
+
+			err = testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
+			require.NoError(err)
+
+			// Wait briefly for the goroutine that fires OnFnFinished — it's
+			// dispatched with `go` and otherwise races AssertExpectations.
+			require.Eventually(func() bool {
+				return mocks.metrics.AssertCalled(t, "OnFnFinished", mock.Anything, mock.Anything, enums.RunStatusCompleted)
+			}, time.Second, 10*time.Millisecond)
+
+			mocks.executor.AssertExpectations(t)
+			mocks.metrics.AssertExpectations(t)
+		})
+	}
+}
+
 //
 //
 // Testing utils.
@@ -948,6 +1052,24 @@ func (m *mockExecutor) HandleGenerator(ctx context.Context, runCtx execution.Run
 func (m *mockExecutor) Finalize(ctx context.Context, opts execution.FinalizeOpts) error {
 	args := m.Called(ctx, opts)
 	return args.Error(0)
+}
+
+func (m *mockExecutor) RunFunctionFinishedLifecycle(
+	ctx context.Context,
+	md state.Metadata,
+	item queue.Item,
+	evts []json.RawMessage,
+	resp state.DriverResponse,
+) {
+	// Only record if a test has registered an expectation; otherwise no-op.
+	// This keeps existing tests (which don't exercise OpcodeRunComplete) from
+	// having to declare the call.
+	for _, c := range m.ExpectedCalls {
+		if c.Method == "RunFunctionFinishedLifecycle" {
+			m.Called(ctx, md, item, evts, resp)
+			return
+		}
+	}
 }
 
 // mockFnReader mocks the function reader interface

--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -862,7 +862,7 @@ func TestCheckpointSyncSteps_RunComplete(t *testing.T) {
 			ctx := context.Background()
 			require := require.New(t)
 
-			body := json.RawMessage(`{"hello":"world"}`)
+			body := `{"hello":"world"}`
 			headers := map[string]string{"content-type": "application/json"}
 
 			wire, err := json.Marshal(apiresult.APIResult{
@@ -887,7 +887,7 @@ func TestCheckpointSyncSteps_RunComplete(t *testing.T) {
 			matchAPIResult := func(want apiresult.APIResult) func(apiresult.APIResult) bool {
 				return func(got apiresult.APIResult) bool {
 					return got.StatusCode == want.StatusCode &&
-						string(got.Body) == string(want.Body) &&
+						got.Body == want.Body &&
 						got.Headers["content-type"] == want.Headers["content-type"]
 				}
 			}
@@ -912,8 +912,8 @@ func TestCheckpointSyncSteps_RunComplete(t *testing.T) {
 					if resp.StatusCode != tc.statusCode {
 						return false
 					}
-					out, ok := resp.Output.([]byte)
-					if !ok || string(out) != string(body) {
+					out, ok := resp.Output.(string)
+					if !ok || out != body {
 						return false
 					}
 					if tc.wantErr == "" {

--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -923,21 +923,25 @@ func TestCheckpointSyncSteps_RunComplete(t *testing.T) {
 				}),
 			).Once()
 
+			// OnFnFinished is dispatched in a goroutine; signal via a channel
+			fnFinished := make(chan struct{}, 1)
 			mocks.metrics.On(
 				"OnFnFinished",
 				mock.Anything,
 				mock.AnythingOfType("checkpoint.MetricCardinality"),
 				enums.RunStatusCompleted,
-			).Once()
+			).Run(func(args mock.Arguments) {
+				fnFinished <- struct{}{}
+			}).Once()
 
 			err = testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
 			require.NoError(err)
 
-			// Wait briefly for the goroutine that fires OnFnFinished — it's
-			// dispatched with `go` and otherwise races AssertExpectations.
-			require.Eventually(func() bool {
-				return mocks.metrics.AssertCalled(t, "OnFnFinished", mock.Anything, mock.Anything, enums.RunStatusCompleted)
-			}, time.Second, 10*time.Millisecond)
+			select {
+			case <-fnFinished:
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for OnFnFinished")
+			}
 
 			mocks.executor.AssertExpectations(t)
 			mocks.metrics.AssertExpectations(t)

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -117,6 +117,10 @@ type Executor interface {
 
 	Finalize(ctx context.Context, opts FinalizeOpts) error
 
+	// RunFunctionFinishedLifecycle fans OnFunctionFinished out to every
+	// registered LifecycleListener.
+	RunFunctionFinishedLifecycle(ctx context.Context, md sv2.Metadata, item queue.Item, evts []json.RawMessage, resp state.DriverResponse)
+
 	// AddLifecycleListener adds a lifecycle listener to run on hooks.  This must
 	// always add to a list of listeners vs replace listeners.
 	AddLifecycleListener(l LifecycleListener)

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -548,6 +548,18 @@ func (e *executor) AddLifecycleListener(l execution.LifecycleListener) {
 	e.lifecycles = append(e.lifecycles, l)
 }
 
+func (e *executor) RunFunctionFinishedLifecycle(
+	ctx context.Context,
+	md sv2.Metadata,
+	item queue.Item,
+	evts []json.RawMessage,
+	resp state.DriverResponse,
+) {
+	for _, l := range e.lifecycles {
+		go l.OnFunctionFinished(context.WithoutCancel(ctx), md, item, evts, resp)
+	}
+}
+
 func (e *executor) CloseLifecycleListeners(ctx context.Context) {
 	var eg errgroup.Group
 

--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -508,7 +508,7 @@ func apiAttributes(res apiresult.APIResult) *meta.SerializableAttrs {
 	meta.AddAttr(rawAttrs, meta.Attrs.ResponseStatusCode, &res.StatusCode)
 	meta.AddAttr(rawAttrs, meta.Attrs.ResponseOutputSize, inngestgo.Ptr(len(res.Body)))
 	// XXX: We always wrap trace output with {"data":T} or {"error":T} for consistency with steps.
-	meta.AddAttr(rawAttrs, meta.Attrs.StepOutput, inngestgo.Ptr(util.DataWrap(res.Body)))
+	meta.AddAttr(rawAttrs, meta.Attrs.StepOutput, inngestgo.Ptr(util.DataWrap([]byte(res.Body))))
 
 	return rawAttrs
 }


### PR DESCRIPTION
## Description

- We observed a bug where entirely sync durable endpoint runs were stuck in queued viewed in their pop out window (though were completed in the main views).
- We determined that this was caused by missing calls to OnFunctionFinished hooks, which would run `traceLifecycle.OnFunctionFinished` and set `OtelSysFunctionStatusCode` to `RunStatusCompleted`. The pops view exposed this data, while other views utilized different data.
- While fixing, we identified and fixed APIResult's JSON format vs the reality on the wire.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [x] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes two bugs in the sync durable endpoint path: (1) corrects `APIResult` JSON field names to match the JS SDK wire format (`status` instead of `status_code`, `Body` as `string` instead of base64 `[]byte`), and (2) adds the missing `RunFunctionFinishedLifecycle` call so OTel lifecycle hooks fire on sync run completion, which was causing runs to appear stuck in RUNNING in the pop-out view.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8156393779a276f6bac7ca264e4715a086f34ce7.</sup>
<!-- /MENDRAL_SUMMARY -->