### PR TITLE
Disable constraint cache skips for older queue items

### DIFF
--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -273,11 +273,12 @@ func (q *queueProcessor) BacklogRefillConstraintCheck(
 		AccountID: *shadowPart.AccountID,
 		EnvID:     *shadowPart.EnvID,
 		// TODO: Make appID available to backlog
-		AppID:                appID,
-		IdempotencyKey:       operationIdempotencyKey,
-		FunctionID:           *shadowPart.FunctionID,
-		CurrentTime:          now,
-		RequestTime:          earliestEnqueuedAt(items),
+		AppID:          appID,
+		IdempotencyKey: operationIdempotencyKey,
+		FunctionID:     *shadowPart.FunctionID,
+		CurrentTime:    now,
+		// NOTE: We cannot skip caching for older queue items as this will massively increase load on the Constraint API, leading to latency spikes
+		// RequestTime:          earliestEnqueuedAt(items),
 		Duration:             QueueLeaseDuration,
 		Constraints:          constraintsToCheck,
 		Configuration:        ConstraintConfigFromConstraints(constraints),
@@ -471,9 +472,10 @@ func (q *queueProcessor) ItemLeaseConstraintCheck(
 		LeaseRunIDs: map[string]ulid.ULID{
 			idempotencyKey: item.Data.Identifier.RunID,
 		},
-		FunctionID:      *shadowPart.FunctionID,
-		CurrentTime:     now,
-		RequestTime:     enqueuedAtTime(item),
+		FunctionID:  *shadowPart.FunctionID,
+		CurrentTime: now,
+		// NOTE: We cannot skip caching for older queue items as this will massively increase load on the Constraint API, leading to latency spikes
+		// RequestTime:     enqueuedAtTime(item),
 		Duration:        QueueLeaseDuration,
 		Constraints:     constraintItems,
 		Configuration:   config,


### PR DESCRIPTION
## Description

This functionally reverts https://github.com/inngest/inngest/pull/4122

We are seeing massively increased throughput on the Constraint API since rolling this out. This is likely because the queue is now skipping the cache for lots of queue items that have been enqueued before the constraint was cached (this applies to an entire backlog).

We need to find a better way of ensuring idempotency.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Disables the constraint cache bypass for older queue items by commenting out `RequestTime` in both `BacklogRefillConstraintCheck` and `ItemLeaseConstraintCheck`. When `RequestTime` is set to the item's enqueue time, the in-process cache skips entries populated after that time — which is correct for retries but causes excessive Constraint API load when processing a backlog of older items. Omitting `RequestTime` (leaving it as zero) makes the cache treat requests as "unanchored" and always serve cached entries, trading correctness of cache bypass for load reduction.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 17957af1e444f7fccd0009cca36c6acbc1545c21.</sup>
<!-- /MENDRAL_SUMMARY -->