### PR TITLE
Remove per-Acquire constraintUsage from Lua

### DIFF
--- a/pkg/constraintapi/acquire.go
+++ b/pkg/constraintapi/acquire.go
@@ -166,36 +166,6 @@ type acquireScriptResponse struct {
 	RetryAt              int                       `json:"ra"`
 	Debug                flexibleStringArray       `json:"d"`
 	CacheHit             int                       `json:"ch"`
-	ConstraintUsage      []constraintUsageResponse `json:"cu"`
-}
-
-type constraintUsageResponse struct {
-	Limit int `json:"l"`
-	Usage int `json:"u"`
-}
-
-func buildConstraintUsage(
-	parsedUsage []constraintUsageResponse,
-	sortedConstraints []ConstraintItem,
-) ([]ConstraintUsage, error) {
-	if len(parsedUsage) == 0 {
-		return nil, nil
-	}
-
-	if len(parsedUsage) != len(sortedConstraints) {
-		return nil, fmt.Errorf("expected %d constraint usage entries, got %d", len(sortedConstraints), len(parsedUsage))
-	}
-
-	constraintUsage := make([]ConstraintUsage, 0, len(parsedUsage))
-	for i, v := range parsedUsage {
-		constraintUsage = append(constraintUsage, ConstraintUsage{
-			Constraint: sortedConstraints[i],
-			Limit:      v.Limit,
-			Used:       v.Usage,
-		})
-	}
-
-	return constraintUsage, nil
 }
 
 func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquireRequest) (*CapacityAcquireResponse, errs.InternalError) {
@@ -441,11 +411,6 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 		},
 	})
 
-	constraintUsage, err := buildConstraintUsage(parsedResponse.ConstraintUsage, sortedConstraints)
-	if err != nil {
-		return nil, errs.Wrap(0, false, "invalid constraint usage response: %w", err)
-	}
-
 	if len(r.lifecycles) > 0 {
 		for _, hook := range r.lifecycles {
 			err := hook.OnCapacityLeaseAcquired(ctx, OnCapacityLeaseAcquiredData{
@@ -463,7 +428,6 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 				Duration:             req.Duration,
 				Source:               req.Source,
 				GrantedLeases:        leases,
-				Usage:                constraintUsage,
 			})
 			if err != nil {
 				return nil, errs.Wrap(0, false, "acquire lifecycle failed: %w", err)
@@ -549,7 +513,6 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 			LimitingConstraints:  limitingConstraints,
 			ExhaustedConstraints: exhaustedConstraints,
 			FairnessReduction:    parsedResponse.FairnessReduction,
-			Usage:                constraintUsage,
 			RetryAfter:           retryAfter,
 			internalDebugState:   parsedResponse,
 		}, nil
@@ -569,7 +532,6 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 			ExhaustedConstraints: exhaustedConstraints,
 			RetryAfter:           retryAfter,
 			FairnessReduction:    parsedResponse.FairnessReduction,
-			Usage:                constraintUsage,
 			internalDebugState:   parsedResponse,
 		}, nil
 

--- a/pkg/constraintapi/acquire_test.go
+++ b/pkg/constraintapi/acquire_test.go
@@ -80,53 +80,6 @@ func makeAcquireRequest(accountID, envID, fnID uuid.UUID, clock clockwork.Clock,
 	}
 }
 
-func TestBuildConstraintUsage(t *testing.T) {
-	constraints := []ConstraintItem{
-		{
-			Kind: ConstraintKindConcurrency,
-			Concurrency: &ConcurrencyConstraint{
-				Scope: enums.ConcurrencyScopeAccount,
-				Mode:  enums.ConcurrencyModeStep,
-			},
-		},
-		{
-			Kind: ConstraintKindConcurrency,
-			Concurrency: &ConcurrencyConstraint{
-				Scope: enums.ConcurrencyScopeFn,
-				Mode:  enums.ConcurrencyModeStep,
-			},
-		},
-	}
-
-	t.Run("maps usage entries when lengths match", func(t *testing.T) {
-		parsedUsage := []constraintUsageResponse{
-			{Limit: 10, Usage: 4},
-			{Limit: 5, Usage: 1},
-		}
-
-		got, err := buildConstraintUsage(parsedUsage, constraints)
-		require.NoError(t, err)
-		require.Len(t, got, 2)
-		require.Equal(t, constraints[0], got[0].Constraint)
-		require.Equal(t, 10, got[0].Limit)
-		require.Equal(t, 4, got[0].Used)
-		require.Equal(t, constraints[1], got[1].Constraint)
-		require.Equal(t, 5, got[1].Limit)
-		require.Equal(t, 1, got[1].Used)
-	})
-
-	t.Run("returns error on length mismatch", func(t *testing.T) {
-		parsedUsage := []constraintUsageResponse{
-			{Limit: 10, Usage: 4},
-			{Limit: 5, Usage: 1},
-			{Limit: 2, Usage: 2},
-		}
-
-		_, err := buildConstraintUsage(parsedUsage, constraints)
-		require.ErrorContains(t, err, "expected 2 constraint usage entries, got 3")
-	})
-}
-
 func TestAcquireCachePreExistingKey(t *testing.T) {
 	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
 	cm, r, clock, ctx := newTestSetup(t, enableAllCache())

--- a/pkg/constraintapi/capacity_manager.go
+++ b/pkg/constraintapi/capacity_manager.go
@@ -195,12 +195,6 @@ type CapacityAcquireResponse struct {
 	// FairnessReduction specifies the capacity that was reserved for fairness reasons.
 	FairnessReduction int
 
-	// Usage contains per-constraint capacity usage after this acquire operation.
-	// Each entry corresponds to a constraint in sorted execution order (not
-	// necessarily the caller's original slice order, as constraints are sorted
-	// before evaluation).
-	Usage []ConstraintUsage
-
 	RetryAfter time.Time
 
 	internalDebugState acquireScriptResponse

--- a/pkg/constraintapi/convert.go
+++ b/pkg/constraintapi/convert.go
@@ -909,21 +909,12 @@ func CapacityAcquireResponseToProto(resp *CapacityAcquireResponse) *pb.CapacityA
 		exhaustedConstraints[i] = ConstraintItemToProto(constraint)
 	}
 
-	var usage []*pb.ConstraintUsage
-	if len(resp.Usage) > 0 {
-		usage = make([]*pb.ConstraintUsage, len(resp.Usage))
-		for i, u := range resp.Usage {
-			usage[i] = ConstraintUsageToProto(u)
-		}
-	}
-
 	return &pb.CapacityAcquireResponse{
 		Leases:               leases,
 		LimitingConstraints:  limitingConstraints,
 		ExhaustedConstraints: exhaustedConstraints,
 		RetryAfter:           timestamppb.New(resp.RetryAfter),
 		FairnessReduction:    int32(resp.FairnessReduction),
-		Usage:                usage,
 	}
 }
 
@@ -956,21 +947,12 @@ func CapacityAcquireResponseFromProto(pbResp *pb.CapacityAcquireResponse) (*Capa
 		retryAfter = pbResp.RetryAfter.AsTime()
 	}
 
-	var usage []ConstraintUsage
-	if len(pbResp.Usage) > 0 {
-		usage = make([]ConstraintUsage, len(pbResp.Usage))
-		for i, u := range pbResp.Usage {
-			usage[i] = ConstraintUsageFromProto(u)
-		}
-	}
-
 	return &CapacityAcquireResponse{
 		Leases:               leases,
 		LimitingConstraints:  limitingConstraints,
 		ExhaustedConstraints: exhaustedConstraints,
 		RetryAfter:           retryAfter,
 		FairnessReduction:    int(pbResp.FairnessReduction),
-		Usage:                usage,
 	}, nil
 }
 

--- a/pkg/constraintapi/convert_test.go
+++ b/pkg/constraintapi/convert_test.go
@@ -1689,57 +1689,6 @@ func TestCapacityAcquireResponseConversion(t *testing.T) {
 			},
 		},
 		{
-			name: "response with usage",
-			input: &CapacityAcquireResponse{
-				Leases: []CapacityLease{
-					{
-						LeaseID:        leaseID1,
-						IdempotencyKey: "lease-key-1",
-					},
-				},
-				LimitingConstraints:  []ConstraintItem{},
-				ExhaustedConstraints: []ConstraintItem{},
-				RetryAfter:           time.Time{},
-				Usage: []ConstraintUsage{
-					{
-						Constraint: ConstraintItem{
-							Kind: ConstraintKindConcurrency,
-							Concurrency: &ConcurrencyConstraint{
-								Mode:  enums.ConcurrencyModeStep,
-								Scope: enums.ConcurrencyScopeFn,
-							},
-						},
-						Used:  5,
-						Limit: 10,
-					},
-				},
-			},
-			expected: &pb.CapacityAcquireResponse{
-				Leases: []*pb.CapacityLease{
-					{
-						LeaseId:        leaseID1.String(),
-						IdempotencyKey: "lease-key-1",
-					},
-				},
-				LimitingConstraints:  []*pb.ConstraintItem{},
-				ExhaustedConstraints: []*pb.ConstraintItem{},
-				RetryAfter:           timestamppb.New(time.Time{}),
-				Usage: []*pb.ConstraintUsage{
-					{
-						Constraint: &pb.ConstraintItem{
-							Kind: pb.ConstraintApiConstraintKind_CONSTRAINT_API_CONSTRAINT_KIND_CONCURRENCY,
-							Concurrency: &pb.ConcurrencyConstraint{
-								Mode:  pb.ConstraintApiConcurrencyMode_CONSTRAINT_API_CONCURRENCY_MODE_STEP,
-								Scope: pb.ConstraintApiConcurrencyScope_CONSTRAINT_API_CONCURRENCY_SCOPE_FUNCTION,
-							},
-						},
-						Used:  5,
-						Limit: 10,
-					},
-				},
-			},
-		},
-		{
 			name:     "nil response",
 			input:    nil,
 			expected: nil,

--- a/pkg/constraintapi/lifecycle.go
+++ b/pkg/constraintapi/lifecycle.go
@@ -27,9 +27,6 @@ type OnCapacityLeaseAcquiredData struct {
 	ExhaustedConstraints []ConstraintItem
 	FairnessReduction    int
 	RetryAfter           time.Time
-
-	// Usage contains per-constraint capacity usage after this acquire operation.
-	Usage []ConstraintUsage
 }
 
 type OnCapacityLeaseExtendedData struct {

--- a/pkg/constraintapi/lua/acquire.lua
+++ b/pkg/constraintapi/lua/acquire.lua
@@ -323,9 +323,6 @@ local keyPrefixConstraintCheck = scopedKeyPrefix .. ":ik:cc:"
 -- Again, this ONLY includes retry times for exhausted constraints.
 retryAt = 0
 
--- Track per-constraint usage after granting (mirrors check.lua pattern)
-local constraintUsage = {}
-
 -- Update constraint state
 for i, value in ipairs(constraints) do
 	local constraintRetryAt = 0
@@ -376,34 +373,6 @@ for i, value in ipairs(constraints) do
 			constraintCapacity = math.floor(remaining / weight)
 		end
 	end
-
-	-- Collect post-grant usage per constraint (mirrors check.lua pattern)
-	local usage = {}
-	if value.k == 1 then
-		-- rate limit: use actual usage from GCRA result
-		usage["l"] = value.r.l
-		local rlCheck = rateLimit(value.r.k, nowNS, value.r.p, value.r.l, value.r.b, 0)
-		usage["u"] = rlCheck["u"]
-	elseif value.k == 2 then
-		-- concurrency
-		usage["l"] = value.c.l
-		usage["u"] = math.max(math.min(value.c.l - constraintCapacity, value.c.l or 0), 0)
-	elseif value.k == 3 then
-		-- throttle: read actual state to avoid bogus values on skipGCRA path
-		usage["l"] = value.t.l
-		local maxBurst = (value.t.l or 0) + (value.t.b or 0) - 1
-		local throttleCheck = throttle(value.t.k, nowMS, value.t.p, value.t.l, maxBurst, 0)
-		local throttleRemaining = throttleCheck["remaining"] or 0
-		usage["u"] = math.max(math.min(value.t.l - throttleRemaining, value.t.l or 0), 0)
-	elseif value.k == 4 then
-		-- semaphore: read actual usage counter directly (not derived from slot count,
-		-- which has a unit mismatch for weight > 1)
-		local currentUsage = tonumber(call("GET", value.sem.k)) or 0
-		local capacity = tonumber(call("GET", value.sem.ck)) or 0
-		usage["l"] = capacity
-		usage["u"] = math.max(math.min(currentUsage, capacity), 0)
-	end
-	table.insert(constraintUsage, usage)
 
 	-- If we used up capacity after the update,
 	-- add constraint to exhausted constraints
@@ -485,7 +454,7 @@ end
 
 -- Construct result
 
----@type { s: integer, lc: integer[], ec: integer[], fr: integer, r: integer, g: integer, l: { lid: string, lik: string }[], cu: {}[] }
+---@type { s: integer, lc: integer[], ec: integer[], fr: integer, r: integer, g: integer, l: { lid: string, lik: string }[] }
 local result = {}
 
 result["s"] = 3
@@ -498,7 +467,6 @@ result["ra"] = retryAt -- include retryAt to hint when next capacity is availabl
 result["d"] = debugLogs
 result["fr"] = fairnessReduction
 result["ch"] = 0
-result["cu"] = constraintUsage
 
 local encoded = cjson.encode(result)
 

--- a/pkg/constraintapi/redis_test.go
+++ b/pkg/constraintapi/redis_test.go
@@ -110,11 +110,6 @@ func TestRedisCapacityManager_RateLimit(t *testing.T) {
 		require.Nil(t, resp.LimitingConstraints)
 		require.Empty(t, resp.ExhaustedConstraints)
 
-		// Usage should reflect post-acquire state
-		require.NotEmpty(t, resp.Usage, "Acquire response should include per-constraint usage")
-		require.Equal(t, 120, resp.Usage[0].Limit, "Rate limit constraint limit should be 120")
-		require.Equal(t, 1, resp.Usage[0].Used, "Rate limit usage should be 1 after acquiring 1 lease")
-
 		// RetryAfter should not be set
 		require.Zero(t, resp.RetryAfter)
 

--- a/pkg/constraintapi/testdata/snapshots/acquire.lua
+++ b/pkg/constraintapi/testdata/snapshots/acquire.lua
@@ -325,7 +325,6 @@ local accountLeasesArgs = {}
 local keyPrefixLeaseDetails = scopedKeyPrefix .. ":ld:"
 local keyPrefixConstraintCheck = scopedKeyPrefix .. ":ik:cc:"
 retryAt = 0
-local constraintUsage = {}
 for i, value in ipairs(constraints) do
 	local constraintRetryAt = 0
 	local constraintCapacity = 0
@@ -364,27 +363,6 @@ for i, value in ipairs(constraints) do
 			constraintCapacity = math.floor(remaining / weight)
 		end
 	end
-	local usage = {}
-	if value.k == 1 then
-		usage["l"] = value.r.l
-		local rlCheck = rateLimit(value.r.k, nowNS, value.r.p, value.r.l, value.r.b, 0)
-		usage["u"] = rlCheck["u"]
-	elseif value.k == 2 then
-		usage["l"] = value.c.l
-		usage["u"] = math.max(math.min(value.c.l - constraintCapacity, value.c.l or 0), 0)
-	elseif value.k == 3 then
-		usage["l"] = value.t.l
-		local maxBurst = (value.t.l or 0) + (value.t.b or 0) - 1
-		local throttleCheck = throttle(value.t.k, nowMS, value.t.p, value.t.l, maxBurst, 0)
-		local throttleRemaining = throttleCheck["remaining"] or 0
-		usage["u"] = math.max(math.min(value.t.l - throttleRemaining, value.t.l or 0), 0)
-	elseif value.k == 4 then
-		local currentUsage = tonumber(call("GET", value.sem.k)) or 0
-		local capacity = tonumber(call("GET", value.sem.ck)) or 0
-		usage["l"] = capacity
-		usage["u"] = math.max(math.min(currentUsage, capacity), 0)
-	end
-	table.insert(constraintUsage, usage)
 	if constraintCapacity <= 0 then
 		if not exhaustedSet[i] then
 			exhaustedSet[i] = true
@@ -442,7 +420,6 @@ result["ra"] = retryAt
 result["d"] = debugLogs
 result["fr"] = fairnessReduction
 result["ch"] = 0
-result["cu"] = constraintUsage
 local encoded = cjson.encode(result)
 call("SET", keyOperationIdempotency, encoded, "EX", tostring(operationIdempotencyTTL))
 return encoded


### PR DESCRIPTION
## Summary

This removes the per-Acquire `constraintUsage` path from the `inngest` constraint API implementation:

- removes the `Usage` field from the Acquire response path
- deletes the Lua `cu` collection and the related request-state plumbing
- removes the Go-side conversion and lifecycle hooks for that data
- updates the related tests and snapshot

## Why

The per-Acquire usage tracking is no longer needed now that the account concurrency signal comes from the poller path.

## Testing

- `go test ./pkg/constraintapi -run ^`

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the per-Acquire `constraintUsage` (`cu`) tracking from the Lua script, Go response structs, proto conversion, lifecycle hooks, and all associated tests. The feature is no longer needed since account concurrency signals now come from the poller path.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7985dca6f2e5f99a30b5b995114030a88c78dc85.</sup>
<!-- /MENDRAL_SUMMARY -->