### PR TITLE
fix(registration): nil-pointer panic on empty-function sync (/fn/register)

### DIFF
--- a/pkg/registration/process.go
+++ b/pkg/registration/process.go
@@ -72,9 +72,6 @@ func (r *ProcessResult) SetSemaphoreCapacity(ctx context.Context, sm constrainta
 // This is the single entry point for function registration logic shared between
 // devserver and cloud.
 func ProcessFunctions(ctx context.Context, req sdk.RegisterRequest, opts ProcessOpts) (*ProcessResult, error) {
-	if len(req.Functions) == 0 {
-		return nil, sdk.ErrNoFunctions
-	}
 
 	// Collect all errors for reporting.
 	var errs error
@@ -131,5 +128,8 @@ func ProcessFunctions(ctx context.Context, req sdk.RegisterRequest, opts Process
 		}
 	}
 
+	if len(req.Functions) == 0 {
+		return result, sdk.ErrNoFunctions
+	}
 	return result, nil
 }

--- a/pkg/registration/process.go
+++ b/pkg/registration/process.go
@@ -81,6 +81,10 @@ func ProcessFunctions(ctx context.Context, req sdk.RegisterRequest, opts Process
 		Functions: make([]inngest.DeployedFunction, 0, len(req.Functions)),
 	}
 
+	if len(req.Functions) == 0 {
+		return result, sdk.ErrNoFunctions
+	}
+
 	for _, sdkFn := range req.Functions {
 		fn, err := sdkFn.Function()
 		if err != nil {
@@ -128,8 +132,5 @@ func ProcessFunctions(ctx context.Context, req sdk.RegisterRequest, opts Process
 		}
 	}
 
-	if len(req.Functions) == 0 {
-		return result, sdk.ErrNoFunctions
-	}
 	return result, nil
 }

--- a/pkg/registration/process_test.go
+++ b/pkg/registration/process_test.go
@@ -132,3 +132,18 @@ func TestProcessFunctions(t *testing.T) {
 		})
 	}
 }
+
+// TestProcessFunctionsEmptyReturnsNonNilResult is a regression test ensuring
+// that ProcessFunctions returns a non-nil *ProcessResult alongside
+// sdk.ErrNoFunctions when the request contains no functions. Callers rely on
+// the result being non-nil (e.g. to access Functions) even on this error path.
+func TestProcessFunctionsEmptyReturnsNonNilResult(t *testing.T) {
+	req := sdk.RegisterRequest{Functions: []sdk.SDKFunction{}}
+
+	result, err := ProcessFunctions(context.Background(), req, ProcessOpts{})
+
+	require.ErrorIs(t, err, sdk.ErrNoFunctions)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Functions)
+	require.Len(t, result.Functions, 0)
+}


### PR DESCRIPTION
## Summary

`registration.ProcessFunctions` returned `nil, sdk.ErrNoFunctions` when the SDK posted an empty function list. The dev-server register handler (`pkg/devserver/api.go`) treats `sdk.ErrNoFunctions` as non-fatal and proceeds to use the result, which crashes on the first dereference:

```go
processed, err := registration.ProcessFunctions(ctx, r, registration.ProcessOpts{...})
if err != nil && err != sdk.ErrNoFunctions {
    return nil, publicerr.Wrap(err, 400, "At least one function is invalid")
}
// ...
seen := make(map[uuid.UUID]struct{}, len(processed.Functions))  // <- L401: panic
```

Stack trace:

```
server.go:3679: http: panic serving 192.168.107.1:59516: runtime error: invalid memory address or nil pointer dereference
goroutine 1164 [running]:
net/http.(*conn).serve.func1()
      /opt/hostedtoolcache/go/1.25.9/x64/src/net/http/server.go:1943 +0xb4
panic({0x28c77c0?, 0x5869a40?})
      /opt/hostedtoolcache/go/1.25.9/x64/src/runtime/panic.go:783 +0x120
github.com/inngest/inngest/pkg/devserver.devapi.register({{_, _}, _, _}, {_, _}, {{0x4000b882b0, 0x3}, {0x4001b5a200, 0x2c}, ...})
      /home/runner/work/inngest/inngest/pkg/devserver/api.go:391 +0x990
github.com/inngest/inngest/pkg/devserver.devapi.Register({{0x3ad7000?, 0x40006a86c0?}, 0x4000290388?, 0x88?}, {0x3a94ed0, 0x40008241e0}, 0x4000566140)
      /home/runner/work/inngest/inngest/pkg/devserver/api.go:228 +0x3a4
net/http.HandlerFunc.ServeHTTP(0x40014374c8?, {0x3a94ed0?, 0x40008241e0?}, 0x1?)
```

## Reproducing steps

1. `docker run -p 8288:8288 inngest/inngest:latest inngest dev --no-discovery -u http://localhost:4002/api/inngest`
2. Mount the JS SDK serve handler with no registered functions yet.
3. Trigger a sync — either dev-server poll or `curl -X PUT http://localhost:4002/api/inngest`.
4. Dev-server logs: nil-pointer panic per stack above.
5. SDK side: `ECONNRESET` on `/fn/register`. Dashboard: `internal_server_error` for the app.

## Fix

In `pkg/registration/process.go`, the empty-list short-circuit ran before the result struct was constructed, returning `nil` alongside `sdk.ErrNoFunctions`. Moved the check below the struct initialization so callers always receive a non-nil zero value when the sentinel is set.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [X] I've tested my own changes.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a nil-pointer panic in the dev-server register handler when an SDK syncs with zero functions. The early-return `return nil, sdk.ErrNoFunctions` was moved below the `result` struct initialization so callers always receive a non-nil `*ProcessResult` alongside the sentinel error.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 579eab921e1470dc655ebde62960a73aa60eb933.</sup>
<!-- /MENDRAL_SUMMARY -->