### PR TITLE
fix: gracefully handle checkpoint dupes

### DIFF
--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -949,6 +949,33 @@ func TestCheckpointSyncSteps_RunComplete(t *testing.T) {
 	}
 }
 
+// On a duplicate save, the OnStepFinished metric must be suppressed —
+// otherwise the same step gets counted twice (once by whichever path
+// originally persisted it, once by this checkpoint).
+func TestCheckpointSyncSteps_DuplicateSaveSuppressesStepFinishedMetric(t *testing.T) {
+	ctx := context.Background()
+	require := require.New(t)
+
+	op := state.GeneratorOpcode{
+		ID:   "step-1",
+		Op:   enums.OpcodeStepRun,
+		Data: json.RawMessage(`{"result": "step 1 output"}`),
+		Name: "Step 1",
+	}
+
+	mocks, testData := setupSyncCheckpointTest(t, op)
+
+	expectedData := map[string]any{"data": json.RawMessage(op.Data)}
+	expectedOutputBytes, _ := json.Marshal(expectedData)
+	mocks.state.On("SaveStep", ctx, testData.metadata.ID, op.ID, expectedOutputBytes).
+		Return(false, state.ErrDuplicateResponse)
+
+	err := testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
+	require.NoError(err)
+
+	mocks.metrics.AssertNotCalled(t, "OnStepFinished")
+}
+
 //
 //
 // Testing utils.

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3717,10 +3717,12 @@ func (e *executor) handleGeneratorStep(ctx context.Context, runCtx execution.Run
 	}
 
 	hasPendingSteps, err := e.smv2.SaveStep(ctx, runCtx.Metadata().ID, gen.ID, []byte(output))
+	// A duplicate or idempotent save means the step was already persisted
+	// (typically via the checkpoint path). Keep the original output and
+	// continue so the run still advances.
 	if errors.Is(err, state.ErrDuplicateResponse) || errors.Is(err, state.ErrIdempotentResponse) {
-		// This is fine.
-		// XXX: we should totally attach a warning to the function run here.
-		return nil
+		e.log.Warn("step output already persisted; keeping existing output", "error", err, "run_id", runCtx.Metadata().ID.RunID, "step_id", gen.ID)
+		err = nil
 	}
 	if err != nil {
 		return err

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3717,9 +3717,11 @@ func (e *executor) handleGeneratorStep(ctx context.Context, runCtx execution.Run
 	}
 
 	hasPendingSteps, err := e.smv2.SaveStep(ctx, runCtx.Metadata().ID, gen.ID, []byte(output))
-	// A duplicate or idempotent save means the step was already persisted
-	// (typically via the checkpoint path). Keep the original output and
-	// continue so the run still advances.
+	// The step output was already persisted, typically by an earlier
+	// attempt that timed out or errored after succeeding. Clear the error so the
+	// discovery step still enqueues; otherwise the run stalls.
+	// XXX: hasPendingSteps can be stale on duplicate; worst case is
+	// redundant SDK invocations per in-flight parallel siblng.
 	if errors.Is(err, state.ErrDuplicateResponse) || errors.Is(err, state.ErrIdempotentResponse) {
 		e.log.Warn("step output already persisted; keeping existing output", "error", err, "run_id", runCtx.Metadata().ID.RunID, "step_id", gen.ID)
 		err = nil

--- a/pkg/execution/executor/handle_generator_step_test.go
+++ b/pkg/execution/executor/handle_generator_step_test.go
@@ -1,0 +1,66 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state"
+	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type stubRunService struct {
+	sv2.RunService
+	saveStepErr error
+}
+
+func (s *stubRunService) SaveStep(_ context.Context, _ sv2.ID, _ string, _ []byte) (bool, error) {
+	return false, s.saveStepErr
+}
+
+type stubQueue struct {
+	queue.Queue
+	enqueued []queue.Item
+}
+
+func (q *stubQueue) Enqueue(_ context.Context, item queue.Item, _ time.Time, _ queue.EnqueueOpts) error {
+	q.enqueued = append(q.enqueued, item)
+	return nil
+}
+
+// EXE-1625: when the SDK responds with a step that the checkpoint path
+// already saved with different bytes, SaveStep returns ErrDuplicateResponse.
+// The executor must still enqueue the next discovery edge or the run
+// strands with no in-flight queue items.
+func TestHandleGeneratorStepEnqueuesDiscoveryOnDuplicate(t *testing.T) {
+	q := &stubQueue{}
+	e := &executor{
+		smv2:           &stubRunService{saveStepErr: state.ErrDuplicateResponse},
+		queue:          q,
+		log:            logger.From(context.Background()),
+		tracerProvider: tracing.NewNoopTracerProvider(),
+	}
+
+	rc := &mockRunContext{md: sv2.Metadata{
+		ID:     sv2.ID{RunID: ulid.MustNew(ulid.Now(), nil), FunctionID: uuid.New()},
+		Config: *sv2.InitConfig(&sv2.Config{}),
+	}}
+
+	err := e.handleGeneratorStep(
+		context.Background(),
+		rc,
+		state.GeneratorOpcode{Op: enums.OpcodeStepRun, ID: "step", Data: json.RawMessage(`null`)},
+		queue.PayloadEdge{Edge: inngest.Edge{Incoming: "step"}},
+	)
+	require.NoError(t, err)
+	require.Len(t, q.enqueued, 1, "expected discovery enqueue despite duplicate save")
+}


### PR DESCRIPTION
## Description

Fix a bug where when the SDK reports a step that was already saved by a checkpoint, `handleGeneratorStep` was returning early on the dupe and skipping the discovery enqueue, which stranded the run. This lets it fall through so that the next step gets scheduled.

## Motivation

[EXE-1625: Hanging runs with checkpointing](https://linear.app/inngest/issue/EXE-1625/hanging-runs-with-checkpointing)

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a run-stranding bug where `handleGeneratorStep` returned `nil` early on `ErrDuplicateResponse`/`ErrIdempotentResponse` (step already persisted via the checkpoint path), skipping `maybeEnqueueDiscoveryStep`. The fix clears the error and falls through to the discovery enqueue, ensuring the run advances. Two targeted tests cover the broken path and the duplicate-metric suppression behavior in the checkpoint sync path.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 94f872b471a0bfd8a0bec7dac8dba96b62b4940b.</sup>
<!-- /MENDRAL_SUMMARY -->