### PR TITLE
Standardize variant naming

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/StepInfo.tsx
@@ -266,7 +266,7 @@ export const StepInfo = ({
 
   return (
     <div className="flex h-full flex-col justify-start gap-2">
-      <div className="min-h-11 flex w-full flex-row items-center justify-between border-none px-4">
+      <div className="flex min-h-11 w-full flex-row items-center justify-between border-none px-4">
         <div
           className="text-basis flex cursor-pointer items-center justify-start gap-2"
           onClick={() => setExpanded(!expanded)}
@@ -358,7 +358,7 @@ export const StepInfo = ({
                 <TextElement>{experimentMetadata.values.experiment_name}</TextElement>
               </ElementWrapper>
               <ElementWrapper label="Variant">
-                <TextElement>{experimentMetadata.values.variant_selected}</TextElement>
+                <TextElement>{experimentMetadata.values.variant}</TextElement>
               </ElementWrapper>
             </>
           )}

--- a/ui/packages/components/src/RunDetailsV4/types.ts
+++ b/ui/packages/components/src/RunDetailsV4/types.ts
@@ -68,7 +68,7 @@ export type SpanMetadataInngestExperiment = {
   updatedAt: string;
   values: {
     experiment_name: string;
-    variant_selected: string;
+    variant: string;
     selection_strategy: string;
     available_variants?: string[];
     variant_weights?: Record<string, number>;

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
@@ -216,7 +216,7 @@ function traceToBarData(
   const experimentMetadata = experimentMd
     ? {
         experimentName: experimentMd.values.experiment_name,
-        variantSelected: experimentMd.values.variant_selected,
+        variantSelected: experimentMd.values.variant,
         availableVariants: experimentMd.values.available_variants,
         variantWeights: experimentMd.values.variant_weights,
         functionSlug,


### PR DESCRIPTION
## Description

Removes `variant_selected` in favor or using `variant` across experimentation steps

SDK PR: https://github.com/inngest/inngest-js/pull/1513
## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Renames the `variant_selected` field to `variant` in the `SpanMetadataInngestExperiment` type and all its usages across the UI components, aligning the frontend type with the backend API field name. Also includes a minor Tailwind class reordering.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 31902c6760c0536c6724ba45611a33b7b9c919b4.</sup>
<!-- /MENDRAL_SUMMARY -->