### PR TITLE
Investigate adding Code Cov Test Analytics for Flaky Tests

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@6ba3fdeec616fb91fd6a389b788a2366835a0fa2 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./junit.xml

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -92,8 +92,9 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@6ba3fdeec616fb91fd6a389b788a2366835a0fa2 # v1.2.1
+        uses: codecov/codecov-action@aa56896cf108bd10b5eb883cd1d24196da57f695 # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./junit.xml
           flags: unit,kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }}
+          report_type: test_results

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -70,9 +70,14 @@ jobs:
         with:
           go-version-file: ./go.mod
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.12.0
+
       - name: Test
         run: |
-          go test -v $(find . -iname "*_test.go" | xargs -I {} dirname {} | uniq | grep -v "./tests") -race -count=1 -coverprofile=coverage.txt
+          gotestsum --junitfile=junit.xml --format=standard-verbose -- \
+            $(find . -iname "*_test.go" | xargs -I {} dirname {} | uniq | grep -v "./tests") \
+            -race -count=1 -coverprofile=coverage.txt
         env:
           TEST_MODE: true
           EXPERIMENTAL_KEY_QUEUES_ENABLE: "${{ matrix.experimentalKeyQueues }}"
@@ -83,4 +88,12 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit,kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./junit.xml
           flags: unit,kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }}

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -71,7 +71,7 @@ jobs:
           go-version-file: ./go.mod
 
       - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.12.0
+        run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Test
         run: |


### PR DESCRIPTION
## Description

- We have many flaky tests
- To figure out how bad the situation is and whether fixes are effective, we can measure flakiness
- In this repo, we hook up CodeCov's test analytics to start analyzing. We're already on CodeCov's pro plan.
- We hook this up against a small subset of tests. If it works, we could expand to more.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Integrates Codecov Test Analytics to track flaky test rates. Replaces the deprecated `test-results-action` with `codecov-action@v5` using `report_type: test_results`, switches from `go test` to `gotestsum` to generate JUnit XML output, and pins the action to a specific commit SHA.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0ba6435fb150eabca756ddbcd85e6b426e635786.</sup>
<!-- /MENDRAL_SUMMARY -->