### PR TITLE
Update Debian packages to patch known vulnerabilities

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
 FROM --platform=$BUILDPLATFORM debian:stable-slim AS inngest
-RUN apt-get update && apt-get install -y ca-certificates tzdata curl && update-ca-certificates
+RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates tzdata && update-ca-certificates
 COPY inngest /bin/inngest
 CMD ["inngest"]


### PR DESCRIPTION
## Description

Update the base image packages to address vulnerabilities in Debian packages.

This also removes curl from image due to unfixed debian dependency (libnghttp2-14, libcurl4t64)

## Motivation
Addressing vulnerabilities in the `inngest/inngest` image.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Patches Debian package vulnerabilities in the production Docker image by running `apt-get upgrade -y` during the build and removing `curl` (which has unfixed transitive vulnerabilities via `libnghttp2-14` and `libcurl4t64`).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit dc06c56b23a7ba42246d6c008f6ec64b78a8a495.</sup>
<!-- /MENDRAL_SUMMARY -->