### PR TITLE
Improve Connect gateway lifecycle logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/inngest/expr v0.0.0-20260504155224-a6e988c15b55
 	github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48
-	github.com/inngest/inngestgo v0.15.2-0.20260506200124-23193cd96953
+	github.com/inngest/inngestgo v0.15.2-0.20260507002849-c26cf7119dbf
 	github.com/jackc/pgx/v5 v5.9.1
 	github.com/jinzhu/copier v0.3.5
 	github.com/jonboulle/clockwork v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -604,8 +604,8 @@ github.com/inngest/expr v0.0.0-20260504155224-a6e988c15b55 h1:Kf3x22dtq5nytZ7xLh
 github.com/inngest/expr v0.0.0-20260504155224-a6e988c15b55/go.mod h1:fwLYQ2NlzdevRRQoldvMrMvCicAG6X3NaONAtxuiT8k=
 github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48 h1:8NwXUrQTQjWrfGj99JgesfTbCYujtnLHusePp7YyFU8=
 github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48/go.mod h1:7SNLkGaD+tiTey1IF9WUNDNurTfqNZqjbdPZo3CmLW4=
-github.com/inngest/inngestgo v0.15.2-0.20260506200124-23193cd96953 h1:cxeC7CTfSevJzc8TJEONiDUQnplpLk1FNcAWq7F5qtk=
-github.com/inngest/inngestgo v0.15.2-0.20260506200124-23193cd96953/go.mod h1:rQX+C3i4IfdJqRRf6sYZ7axIP+mTg4etX84aFmvaFlg=
+github.com/inngest/inngestgo v0.15.2-0.20260507002849-c26cf7119dbf h1:i9jQfYxl6l90R99guIQFr9D8jx2Y/iQOToG7ewBsHVw=
+github.com/inngest/inngestgo v0.15.2-0.20260507002849-c26cf7119dbf/go.mod h1:rQX+C3i4IfdJqRRf6sYZ7axIP+mTg4etX84aFmvaFlg=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -109,6 +110,9 @@ type connectionHandler struct {
 
 	lastStatusLock       sync.Mutex
 	lastStatusReceivedAt time.Time
+
+	connectionStatus   connectpb.ConnectionStatus
+	connectionStatusOK bool
 }
 
 func (c *connectionHandler) setLastHeartbeat(time time.Time) {
@@ -133,6 +137,89 @@ func (c *connectionHandler) getLastStatus() time.Time {
 	c.lastStatusLock.Lock()
 	defer c.lastStatusLock.Unlock()
 	return c.lastStatusReceivedAt
+}
+
+func (c *connectionHandler) bindConnectionLogger(conn *state.Connection) {
+	c.log = c.log.With(connectionLogAttrs(conn)...)
+}
+
+func connectionLogAttrs(conn *state.Connection) []any {
+	if conn == nil {
+		return nil
+	}
+
+	attrs := []any{
+		"account_id", conn.AccountID.String(),
+		"env_id", conn.EnvID.String(),
+		"conn_id", conn.ConnectionId.String(),
+		"connection_id", conn.ConnectionId.String(),
+		"worker_ip", util.SanitizeLogField(conn.WorkerIP),
+	}
+
+	if conn.Data != nil {
+		attrs = append(attrs,
+			"instance_id", util.SanitizeLogField(conn.Data.GetInstanceId()),
+			"sdk_language", conn.Data.GetSdkLanguage(),
+			"sdk_version", conn.Data.GetSdkVersion(),
+			"sdk_platform", conn.Data.GetPlatform(),
+			"sdk_framework", conn.Data.GetFramework(),
+			"worker_environment", conn.Data.GetEnvironment(),
+			"worker_manual_readiness_ack", conn.Data.GetWorkerManualReadinessAck(),
+			"max_worker_concurrency", conn.Data.GetMaxWorkerConcurrency(),
+			"app_names", conn.AppNames(),
+			"app_count", len(conn.Data.GetApps()),
+		)
+
+		system := conn.Data.GetSystemAttributes()
+		attrs = append(attrs,
+			"worker_cpu_cores", system.GetCpuCores(),
+			"worker_mem_bytes", system.GetMemBytes(),
+			"worker_os", system.GetOs(),
+		)
+	}
+
+	groupHashes := make([]string, 0, len(conn.Groups))
+	for groupHash := range conn.Groups {
+		groupHashes = append(groupHashes, groupHash)
+	}
+	sort.Strings(groupHashes)
+
+	attrs = append(attrs, "worker_group_hashes", groupHashes)
+
+	return attrs
+}
+
+func (c *connectionHandler) logConnStatus(status connectpb.ConnectionStatus, reason string, attrs ...any) {
+	c.updateLock.Lock()
+	defer c.updateLock.Unlock()
+
+	c.logConnStatusLocked(status, reason, attrs...)
+}
+
+func (c *connectionHandler) logConnStatusLocked(status connectpb.ConnectionStatus, reason string, attrs ...any) {
+	previous := c.connectionStatus
+	previousOK := c.connectionStatusOK
+	c.connectionStatus = status
+	c.connectionStatusOK = true
+
+	from := ""
+	if previousOK {
+		from = previous.String()
+	}
+
+	logAttrs := []any{
+		"from", from,
+		"to", status.String(),
+		"reason", reason,
+	}
+	logAttrs = append(logAttrs, attrs...)
+
+	if !previousOK || previous != status {
+		c.log.Debug("worker connection status transition", logAttrs...)
+		return
+	}
+
+	c.log.Trace("worker connection status refreshed", logAttrs...)
 }
 
 var ErrDraining = connecterrors.SocketError{
@@ -271,17 +358,6 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 			return
 		}
 
-		instanceId := ""
-		if conn.Data != nil {
-			instanceId = conn.Data.InstanceId
-		}
-		ch.log = ch.log.With(
-			"account_id", conn.AccountID,
-			"env_id", conn.EnvID,
-			"conn_id", conn.ConnectionId,
-			"instance_id", util.SanitizeLogField(instanceId),
-			"worker_ip", util.SanitizeLogField(conn.WorkerIP))
-
 		workerDrainedCtx, notifyWorkerDrained := context.WithCancel(context.Background())
 		defer notifyWorkerDrained()
 
@@ -297,7 +373,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 			}
 
 			// If gateway is shutting down, we must immediately start the draining process
-			ch.log.Debug("context done, starting draining process")
+			ch.log.Debug("context done, starting draining process", "active_connections", c.connectionCount.Count())
 
 			// Mark connection as draining in-memory to prevent subsequent
 			// heartbeats from marking it as ready, but do NOT update Redis
@@ -321,7 +397,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 			})
 			if err != nil {
 				// Can't tell the worker so we mark as DRAINING immediately.
-				if statusErr := ch.updateConnStatus(connectpb.ConnectionStatus_DRAINING); statusErr != nil {
+				if statusErr := ch.updateConnStatus(connectpb.ConnectionStatus_DRAINING, "gateway drain started after failed closing write", "err", err); statusErr != nil {
 					ch.log.ReportError(statusErr, "could not update connection status after context done")
 				}
 				ch.stopForwardingOnce.Do(func() { close(ch.stopForwarding) })
@@ -340,7 +416,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 				ch.log.Debug("timed out waiting for drain ack, marking connection as draining")
 			}
 
-			if statusErr := ch.updateConnStatus(connectpb.ConnectionStatus_DRAINING); statusErr != nil {
+			if statusErr := ch.updateConnStatus(connectpb.ConnectionStatus_DRAINING, "gateway drain completed or timed out", "drain_ack_wait_ms", time.Since(drainStart).Milliseconds()); statusErr != nil {
 				ch.log.ReportError(statusErr, "could not update connection status after drain ack")
 			}
 			ch.stopForwardingOnce.Do(func() { close(ch.stopForwarding) })
@@ -364,6 +440,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 		defer func() {
 			// Ensure receiveRouterMessagesFromGRPC exits on any disconnect.
 			ch.stopForwardingOnce.Do(func() { close(ch.stopForwarding) })
+			ch.logConnStatus(connectpb.ConnectionStatus_DISCONNECTED, "connection cleanup", "close_reason", *closeReasonPtr.Load())
 
 			// This is a transactional operation, it should always complete regardless of context cancellation
 			err := c.stateManager.DeleteConnection(context.Background(), conn.EnvID, conn.ConnectionId)
@@ -431,7 +508,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 			}
 
 			// upsert connection to update WorkerGroups map
-			if err := c.stateManager.UpsertConnection(context.Background(), conn, connectpb.ConnectionStatus_CONNECTED, time.Now()); err != nil {
+			if err := ch.updateConnStatus(connectpb.ConnectionStatus_CONNECTED, "worker groups synced"); err != nil {
 				ch.log.ReportError(err, "updating connection state after sync failed")
 				c.closeWithConnectError(ws, &connecterrors.SocketError{
 					SysCode:    syscode.CodeConnectInternal,
@@ -485,7 +562,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 				err := wsproto.Read(runLoopCtx, ws, &msg)
 				if err != nil {
 					// immediately stop routing messages to this connection
-					if err := ch.updateConnStatus(connectpb.ConnectionStatus_DISCONNECTING); err != nil {
+					if err := ch.updateConnStatus(connectpb.ConnectionStatus_DISCONNECTING, "websocket read loop ended", "err", err); err != nil {
 						ch.log.ReportError(err, "could not update connection status after read error")
 					}
 
@@ -621,7 +698,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 			}
 
 			// Mark connection as ready to receive traffic unless we require manual client ready signal (optional)
-			err = c.stateManager.UpsertConnection(ctx, conn, connectpb.ConnectionStatus_READY, time.Now())
+			err = ch.updateConnStatus(connectpb.ConnectionStatus_READY, "automatic readiness")
 			if err != nil {
 				if ctx.Err() != nil {
 					c.closeDraining(ws)
@@ -729,7 +806,7 @@ func (c *connectionHandler) handleIncomingWebSocketMessage(msg *connectpb.Connec
 			return nil
 		}
 
-		err := c.updateConnStatus(connectpb.ConnectionStatus_READY)
+		err := c.updateConnStatus(connectpb.ConnectionStatus_READY, "worker ready message")
 		if err != nil {
 			// TODO Should we actually close the connection here?
 			return &connecterrors.SocketError{
@@ -783,7 +860,10 @@ func (c *connectionHandler) handleIncomingWebSocketMessage(msg *connectpb.Connec
 			)
 		}
 
-		err := c.updateConnStatus(status)
+		err := c.updateConnStatus(status, "worker heartbeat",
+			"conn_draining", c.draining.Load(),
+			"svc_draining", c.svc.isDraining.Load(),
+		)
 		if err != nil {
 
 			c.log.ReportError(err, "failed to update connection status after heartbeat")
@@ -834,6 +914,7 @@ func (c *connectionHandler) handleIncomingWebSocketMessage(msg *connectpb.Connec
 		}
 
 		c.setLastHeartbeat(time.Now())
+		c.log.Trace("worker heartbeat processed", "status", status.String())
 
 		return nil
 	case connectpb.GatewayMessageType_WORKER_STATUS:
@@ -871,7 +952,7 @@ func (c *connectionHandler) handleIncomingWebSocketMessage(msg *connectpb.Connec
 
 		// Update the Redis status to DRAINING so the router stops selecting
 		// this connection for new requests.
-		err := c.updateConnStatus(connectpb.ConnectionStatus_DRAINING)
+		err := c.updateConnStatus(connectpb.ConnectionStatus_DRAINING, "worker pause message", "svc_draining", c.svc.isDraining.Load())
 		if err != nil {
 			c.log.Error("could not update connection status to DRAINING on WORKER_PAUSE",
 				"err", err,
@@ -1366,6 +1447,7 @@ func (c *connectionHandler) establishConnection(ctx context.Context) (*state.Con
 		"account_id", authResp.AccountID,
 		"env_id", authResp.EnvID,
 		"conn_id", connectionId.String(),
+		"connection_id", connectionId.String(),
 		"instance_id", util.SanitizeLogField(initialMessageData.InstanceId),
 		"worker_ip", util.SanitizeLogField(c.remoteAddr))
 
@@ -1420,13 +1502,15 @@ func (c *connectionHandler) establishConnection(ctx context.Context) (*state.Con
 		// Used for routing messages to the correct gateway
 		GatewayId: c.svc.gatewayId,
 	}
+	c.conn = &conn
+	c.bindConnectionLogger(&conn)
 
 	{
 		// This is a transactional operation, it should always complete regardless of context cancellation
 
 		// Connection should always be upserted, we don't want inconsistent state
-		if err := c.svc.stateManager.UpsertConnection(context.Background(), &conn, connectpb.ConnectionStatus_CONNECTED, time.Now()); err != nil {
-			log.ReportError(err, "adding connection state failed")
+		if err := c.updateConnStatus(connectpb.ConnectionStatus_CONNECTED, "worker authenticated"); err != nil {
+			c.log.ReportError(err, "adding connection state failed")
 			return nil, &connecterrors.SocketError{
 				SysCode:    syscode.CodeConnectInternal,
 				StatusCode: websocket.StatusInternalError,
@@ -1450,7 +1534,7 @@ func (c *connectionHandler) establishConnection(ctx context.Context) (*state.Con
 			maxConcurrency = *initialMessageData.MaxWorkerConcurrency
 		}
 		if err := c.svc.stateManager.SetWorkerTotalCapacity(context.Background(), authResp.EnvID, initialMessageData.InstanceId, maxConcurrency); err != nil {
-			log.ReportError(err, "failed to set worker capacity")
+			c.log.ReportError(err, "failed to set worker capacity")
 			return nil, &connecterrors.SocketError{
 				SysCode:    syscode.CodeConnectInternal,
 				StatusCode: websocket.StatusInternalError,
@@ -1458,15 +1542,13 @@ func (c *connectionHandler) establishConnection(ctx context.Context) (*state.Con
 			}
 		}
 
-		log.Trace("worker capacity set", "account_id", authResp.AccountID, "env_id", authResp.EnvID, "instance_id", initialMessageData.InstanceId, "max_concurrency", maxConcurrency)
+		c.log.Trace("worker capacity set", "max_concurrency", maxConcurrency)
 
 		// TODO Connection should not be marked as ready to receive traffic until the read loop is set up, sync is handled, and the client optionally sent a ready signal
 		for _, l := range c.svc.lifecycles {
 			go l.OnConnected(context.Background(), &conn)
 		}
 	}
-
-	c.conn = &conn
 
 	return &conn, nil
 }
@@ -1530,10 +1612,16 @@ func (c *connectionHandler) handleSdkReply(ctx context.Context, msg *connectpb.C
 	return nil
 }
 
-func (c *connectionHandler) updateConnStatus(status connectpb.ConnectionStatus) error {
+func (c *connectionHandler) updateConnStatus(status connectpb.ConnectionStatus, reason string, attrs ...any) error {
 	c.updateLock.Lock()
 	defer c.updateLock.Unlock()
 
 	// Always update the connection status, do not use context cancellation
-	return c.svc.stateManager.UpsertConnection(context.Background(), c.conn, status, time.Now())
+	err := c.svc.stateManager.UpsertConnection(context.Background(), c.conn, status, time.Now())
+	if err != nil {
+		return err
+	}
+
+	c.logConnStatusLocked(status, reason, attrs...)
+	return nil
 }

--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -151,7 +151,6 @@ func connectionLogAttrs(conn *state.Connection) []any {
 	attrs := []any{
 		"account_id", conn.AccountID.String(),
 		"env_id", conn.EnvID.String(),
-		"conn_id", conn.ConnectionId.String(),
 		"connection_id", conn.ConnectionId.String(),
 		"worker_ip", util.SanitizeLogField(conn.WorkerIP),
 	}
@@ -1446,7 +1445,6 @@ func (c *connectionHandler) establishConnection(ctx context.Context) (*state.Con
 	log := c.log.With(
 		"account_id", authResp.AccountID,
 		"env_id", authResp.EnvID,
-		"conn_id", connectionId.String(),
 		"connection_id", connectionId.String(),
 		"instance_id", util.SanitizeLogField(initialMessageData.InstanceId),
 		"worker_ip", util.SanitizeLogField(c.remoteAddr))

--- a/pkg/connect/service.go
+++ b/pkg/connect/service.go
@@ -110,6 +110,8 @@ type connectGatewaySvc struct {
 	connectionCount connectionCounter
 	drainListener   *drainListener
 	stateUpdateLock sync.Mutex
+	gatewayStatus   state.GatewayStatus
+	gatewayStatusOK bool
 
 	grpcClientManager *grpc.GRPCClientManager[pb.ConnectExecutorClient]
 }
@@ -239,9 +241,9 @@ func NewConnectGatewayService(opts ...gatewayOpt) *connectGatewaySvc {
 			grpc.DefaultConnectGRPCIP, grpc.DefaultConnectExecutorGRPCPort,
 		),
 
-		workerHeartbeatInterval:                               consts.ConnectWorkerHeartbeatInterval,
-		workerRequestExtendLeaseInterval:                      consts.ConnectWorkerRequestExtendLeaseInterval,
-		workerRequestLeaseDuration:                            consts.ConnectWorkerRequestLeaseDuration,
+		workerHeartbeatInterval:          consts.ConnectWorkerHeartbeatInterval,
+		workerRequestExtendLeaseInterval: consts.ConnectWorkerRequestExtendLeaseInterval,
+		workerRequestLeaseDuration:       consts.ConnectWorkerRequestLeaseDuration,
 		workerStatusInterval: func(_ context.Context, _ uuid.UUID, _ uuid.UUID) time.Duration {
 			return consts.ConnectWorkerStatusInterval
 		},
@@ -315,8 +317,13 @@ func (c *connectGatewaySvc) Pre(ctx context.Context) error {
 	c.hostname = hostname
 
 	c.ipAddress = c.grpcConfig.Gateway.IP
+	c.logger = c.logger.With(
+		"gateway_group", c.groupName,
+		"gateway_hostname", c.hostname,
+		"gateway_ip", c.ipAddress.String(),
+	)
 
-	if err := c.updateGatewayState(state.GatewayStatusStarting); err != nil {
+	if err := c.updateGatewayState(state.GatewayStatusStarting, "gateway service starting"); err != nil {
 		return fmt.Errorf("could not set initial gateway state: %w", err)
 	}
 
@@ -341,7 +348,7 @@ func (c *connectGatewaySvc) heartbeat(ctx context.Context) {
 				status = state.GatewayStatusDraining
 			}
 
-			err := c.updateGatewayState(status)
+			err := c.updateGatewayState(status, "gateway heartbeat")
 			if err != nil {
 				c.logger.Error(fmt.Sprintf("could not update gateway state: %v", err))
 			}
@@ -482,7 +489,7 @@ func (c *connectGatewaySvc) Run(ctx context.Context) error {
 	})
 
 	if !c.isDraining.Load() {
-		err := c.updateGatewayState(state.GatewayStatusActive)
+		err := c.updateGatewayState(state.GatewayStatusActive, "gateway server started")
 		if err != nil {
 			return fmt.Errorf("could not update gateway state: %w", err)
 		}
@@ -500,9 +507,12 @@ func (c *connectGatewaySvc) Run(ctx context.Context) error {
 	return eg.Wait()
 }
 
-func (c *connectGatewaySvc) updateGatewayState(status state.GatewayStatus) error {
+func (c *connectGatewaySvc) updateGatewayState(status state.GatewayStatus, reason string) error {
 	c.stateUpdateLock.Lock()
 	defer c.stateUpdateLock.Unlock()
+
+	previous := c.gatewayStatus
+	previousOK := c.gatewayStatusOK
 
 	err := c.stateManager.UpsertGateway(context.Background(), &state.Gateway{
 		Id:                c.gatewayId,
@@ -512,9 +522,26 @@ func (c *connectGatewaySvc) updateGatewayState(status state.GatewayStatus) error
 		IPAddress:         c.ipAddress,
 	})
 	if err != nil {
-		c.logger.Error("failed to update gateway status in state", "status", status, "error", err)
+		c.logger.Error("failed to update gateway status in state", "status", status, "reason", reason, "error", err)
 
 		return fmt.Errorf("could not upsert gateway: %w", err)
+	}
+
+	c.gatewayStatus = status
+	c.gatewayStatusOK = true
+
+	if !previousOK || previous != status {
+		from := ""
+		if previousOK {
+			from = string(previous)
+		}
+		c.logger.Info("gateway status transition",
+			"from", from,
+			"to", status,
+			"reason", reason,
+			"active_connections", c.connectionCount.Count(),
+			"is_draining", c.isDraining.Load(),
+		)
 	}
 
 	return nil
@@ -563,21 +590,25 @@ func (c *connectGatewaySvc) GetState() (*state.Gateway, error) {
 }
 
 func (c *connectGatewaySvc) DrainGateway() error {
-	err := c.updateGatewayState(state.GatewayStatusDraining)
+	c.logger.Info("gateway drain requested", "active_connections", c.connectionCount.Count())
+	err := c.updateGatewayState(state.GatewayStatusDraining, "gateway drain requested")
 	if err != nil {
 		return fmt.Errorf("could not update gateway state: %w", err)
 	}
 	c.isDraining.Store(true)
 	c.drainListener.Notify()
+	c.logger.Info("gateway drain notification sent", "active_connections", c.connectionCount.Count())
 	return nil
 }
 
 func (c *connectGatewaySvc) ActivateGateway() error {
-	err := c.updateGatewayState(state.GatewayStatusActive)
+	c.logger.Info("gateway activation requested", "active_connections", c.connectionCount.Count())
+	err := c.updateGatewayState(state.GatewayStatusActive, "gateway activation requested")
 	if err != nil {
 		return fmt.Errorf("could not update gateway state: %w", err)
 	}
 	c.isDraining.Store(false)
+	c.logger.Info("gateway activated", "active_connections", c.connectionCount.Count())
 	return nil
 }
 

--- a/vendor/github.com/inngest/inngestgo/client.go
+++ b/vendor/github.com/inngest/inngestgo/client.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/inngest/inngestgo/internal/logger"
 	"github.com/inngest/inngestgo/internal/middleware"
 	"github.com/inngest/inngestgo/pkg/checkpoint"
 	"github.com/inngest/inngestgo/pkg/env"
@@ -138,7 +139,7 @@ func NewClient(opts ClientOpts) (Client, error) {
 	}
 
 	if opts.Logger == nil {
-		opts.Logger = slog.Default()
+		opts.Logger = logger.Default()
 	}
 
 	// Add the default log middleware as the first middleware.

--- a/vendor/github.com/inngest/inngestgo/connect/connection.go
+++ b/vendor/github.com/inngest/inngestgo/connect/connection.go
@@ -53,7 +53,7 @@ func (h *connectHandler) connect(ctx context.Context, data connectionEstablishDa
 	// Set up connection (including connect handshake protocol)
 	preparedConn, err := h.prepareConnection(ctx, data, o.excludeGateways)
 	if err != nil {
-		h.logger.Error("could not establish connection", "err", err)
+		h.logger.Error("could not establish connection", "err", err, "reconnect", shouldReconnect(err))
 
 		h.notifyConnectDoneChan <- connectReport{
 			reconnect: shouldReconnect(err),
@@ -61,6 +61,9 @@ func (h *connectHandler) connect(ctx context.Context, data connectionEstablishDa
 		}
 		return
 	}
+
+	l := h.logger.With(preparedConn.logAttrs()...)
+	l.Debug("connection established")
 
 	// Notify that the connection was established
 	h.notifyConnectedChan <- struct{}{}
@@ -74,7 +77,7 @@ func (h *connectHandler) connect(ctx context.Context, data connectionEstablishDa
 	// Set up connection lifecycle logic (receiving messages, handling requests, etc.)
 	err = h.handleConnection(h.workerCtx, data, preparedConn)
 	if err != nil {
-		h.logger.Error("could not handle connection", "err", err)
+		l.Error("could not handle connection", "err", err, "reconnect", shouldReconnect(err))
 
 		if errors.Is(err, errGatewayDraining) {
 			// if the gateway is draining, the original connection was closed, and we already reconnected inside handleConnection
@@ -103,10 +106,19 @@ type connectionEstablishData struct {
 type connection struct {
 	ws               *websocket.Conn
 	gatewayGroupName string
+	gatewayEndpoint  string
 	connectionId     string
 
 	heartbeatInterval   time.Duration
 	extendLeaseInterval time.Duration
+}
+
+func (c *connection) logAttrs() []any {
+	return []any{
+		"connection_id", c.connectionId,
+		"gateway_group", c.gatewayGroupName,
+		"gateway_endpoint", c.gatewayEndpoint,
+	}
 }
 
 func (h *connectHandler) prepareConnection(ctx context.Context, data connectionEstablishData, excludeGateways []string) (*connection, error) {
@@ -179,6 +191,7 @@ func (h *connectHandler) prepareConnection(ctx context.Context, data connectionE
 	return &connection{
 		ws:                  ws,
 		gatewayGroupName:    startRes.GetGatewayGroup(),
+		gatewayEndpoint:     gatewayHost.String(),
 		connectionId:        connectionId.String(),
 		heartbeatInterval:   heartbeatInterval,
 		extendLeaseInterval: extendLeaseInterval,
@@ -188,6 +201,8 @@ func (h *connectHandler) prepareConnection(ctx context.Context, data connectionE
 func (h *connectHandler) handleConnection(ctx context.Context, data connectionEstablishData, preparedConn *connection) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	l := h.logger.With(preparedConn.logAttrs()...)
 
 	defer func() {
 		// This is a fallback safeguard to always close the WebSocket connection at the end of the function
@@ -215,9 +230,9 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 					Kind: connectproto.GatewayMessageType_WORKER_HEARTBEAT,
 				})
 				if err != nil {
-					h.logger.Error("failed to send worker heartbeat", "err", err)
+					l.Error("failed to send worker heartbeat", "err", err, "heartbeat_interval", preparedConn.heartbeatInterval.String())
 				}
-				h.logger.Debug("sent worker heartbeat")
+				l.Debug("sent worker heartbeat", "heartbeat_interval", preparedConn.heartbeatInterval.String())
 			}
 
 		}
@@ -252,7 +267,7 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 				heartbeatReplyTimer.Reset(heartbeatTimeout)
 			case <-heartbeatReplyTimer.C:
 				// No heartbeat received in time!
-				h.logger.Error("did not receive gateway heartbeat in time")
+				l.Error("did not receive gateway heartbeat in time", "heartbeat_interval", preparedConn.heartbeatInterval.String(), "heartbeat_timeout", heartbeatTimeout.String())
 				cancelReaderLifetimeContext()
 				return
 			}
@@ -269,18 +284,19 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 			// - Gateway heartbeat was missed (unexpected connection loss)
 			err := wsproto.Read(readerLifetimeContext, preparedConn.ws, &msg)
 			if err != nil {
-				h.logger.Error("failed to read message", "err", err)
+				l.Error("failed to read message", "err", err, "reader_context_error", readerLifetimeContext.Err())
 
 				// The connection may still be active, but for some reason we couldn't read the message
 				return err
 			}
 
-			h.logger.Debug("received gateway request", "kind", msg.Kind.String())
+			l.Debug("received gateway request", "kind", msg.Kind.String())
 
 			switch msg.Kind {
 			case connectproto.GatewayMessageType_GATEWAY_CLOSING:
 				// Stop the read loop: We will not receive any further messages and should establish a new connection
 				// We can still use the old connection to send replies to the gateway
+				l.Info("gateway requested connection drain")
 				return errGatewayDraining
 			case connectproto.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST:
 				// Handle invoke in a non-blocking way to allow for other messages to be processed
@@ -301,34 +317,22 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 				}
 			case connectproto.GatewayMessageType_WORKER_REPLY_ACK:
 				if err := h.handleMessageReplyAck(&msg); err != nil {
-					h.logger.Error("could not handle message reply ack", "err", err)
+					l.Error("could not handle message reply ack", "err", err)
 					continue
 				}
 			case connectproto.GatewayMessageType_WORKER_REQUEST_EXTEND_LEASE_ACK:
-				{
-					var payload connectproto.WorkerRequestExtendLeaseAckData
-					if err := proto.Unmarshal(msg.Payload, &payload); err != nil {
-						h.logger.Error("could not parse extend lease ack", "err", err)
-						continue
-					}
-
-					h.workerPool.inProgressLeasesLock.Lock()
-					if payload.NewLeaseId != nil {
-						h.workerPool.inProgressLeases[payload.RequestId] = *payload.NewLeaseId
-					} else {
-						// remove local request lease to stop extending
-						delete(h.workerPool.inProgressLeases, payload.RequestId)
-					}
-					h.workerPool.inProgressLeasesLock.Unlock()
+				if err := h.handleWorkerRequestExtendLeaseAck(&msg); err != nil {
+					l.Error("could not handle extend lease ack", "err", err)
+					continue
 				}
 			default:
-				h.logger.Debug("got unknown gateway request", "err", err)
+				l.Debug("got unknown gateway request", "err", err)
 				continue
 			}
 		}
 	})
 
-	h.logger.Debug("waiting for read loop to end")
+	l.Debug("waiting for read loop to end")
 
 	// If read loop ends, this can be for two reasons
 	// - Connection loss (io.EOF), read loop terminated intentionally (CloseError), other error (unexpected), missed heartbeat (readerLifetimeContext canceled)
@@ -353,7 +357,7 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 			// Wait until the new connection is established before closing the old one
 			<-waitUntilConnected.Done()
 			if errors.Is(waitUntilConnected.Err(), context.DeadlineExceeded) {
-				h.logger.Error("timed out waiting for new connection to be established")
+				l.Error("timed out waiting for new connection to be established")
 			}
 
 			// Send a proper close frame
@@ -362,12 +366,12 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 			return errGatewayDraining
 		}
 
-		h.logger.Debug("read loop ended with error", "err", err)
+		l.Debug("read loop ended with error", "err", err)
 
 		// In case the gateway intentionally closed the connection, we'll receive a close error
 		cerr := websocket.CloseError{}
 		if errors.As(err, &cerr) {
-			h.logger.Error("connection closed with reason", "reason", cerr.Reason)
+			l.Error("connection closed with reason", "reason", cerr.Reason)
 
 			// Reconnect!
 			return newReconnectErr(fmt.Errorf("connection closed with reason %q: %w", cerr.Reason, cerr))
@@ -375,7 +379,7 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 
 		// connection closed without reason
 		if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) {
-			h.logger.Error("failed to read message from gateway, lost connection unexpectedly", "err", err)
+			l.Error("failed to read message from gateway, lost connection unexpectedly", "err", err)
 			return newReconnectErr(fmt.Errorf("connection closed unexpectedly: %w", cerr))
 		}
 
@@ -392,17 +396,17 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 
 	// Signal gateway that we won't process additional messages!
 	{
-		h.logger.Debug("sending worker pause message")
+		l.Debug("sending worker pause message")
 		err := wsproto.Write(context.Background(), preparedConn.ws, &connectproto.ConnectMessage{
 			Kind: connectproto.GatewayMessageType_WORKER_PAUSE,
 		})
 		if err != nil {
 			// We should not exit here, as we're already in the shutdown routine
-			h.logger.Error("failed to serialize worker pause msg", "err", err)
+			l.Error("failed to serialize worker pause msg", "err", err)
 		}
 	}
 
-	h.logger.Debug("waiting for in-progress requests to finish")
+	l.Debug("waiting for in-progress requests to finish")
 
 	// Wait until all in-progress requests are completed
 	h.workerPool.Wait()
@@ -414,11 +418,11 @@ func (h *connectHandler) handleConnection(ctx context.Context, data connectionEs
 	if h.messageBuffer.hasMessages() {
 		err := h.messageBuffer.flush(data.hashedSigningKey)
 		if err != nil {
-			h.logger.Error("could not send buffered messages", "err", err)
+			l.Error("could not send buffered messages", "err", err)
 		}
 	}
 
-	h.logger.Debug("connection done")
+	l.Debug("connection done")
 
 	return nil
 }
@@ -430,6 +434,28 @@ func (h *connectHandler) handleMessageReplyAck(msg *connectproto.ConnectMessage)
 	}
 
 	h.messageBuffer.acknowledge(payload.RequestId)
+
+	return nil
+}
+
+func (h *connectHandler) handleWorkerRequestExtendLeaseAck(msg *connectproto.ConnectMessage) error {
+	var payload connectproto.WorkerRequestExtendLeaseAckData
+	if err := proto.Unmarshal(msg.Payload, &payload); err != nil {
+		return fmt.Errorf("could not unmarshal extend lease ack data: %w", err)
+	}
+
+	h.workerPool.inProgressLeasesLock.Lock()
+	defer h.workerPool.inProgressLeasesLock.Unlock()
+
+	if payload.NewLeaseId != nil {
+		if _, ok := h.workerPool.inProgressLeases[payload.RequestId]; !ok {
+			return nil
+		}
+		h.workerPool.inProgressLeases[payload.RequestId] = *payload.NewLeaseId
+	} else {
+		// remove local request lease to stop extending
+		delete(h.workerPool.inProgressLeases, payload.RequestId)
+	}
 
 	return nil
 }

--- a/vendor/github.com/inngest/inngestgo/connect/handler.go
+++ b/vendor/github.com/inngest/inngestgo/connect/handler.go
@@ -58,8 +58,10 @@ func Connect(ctx context.Context, opts Opts, invokers map[string]FunctionInvoker
 	// Once the worker is running, it can only be stopped by calling Close()
 	doneCtx, cancelDone := context.WithCancel(context.Background())
 
+	l := logger.With("mode", "connect")
+
 	ch := &connectHandler{
-		logger:                 logger,
+		logger:                 l,
 		invokers:               invokers,
 		opts:                   opts,
 		notifyConnectDoneChan:  make(chan connectReport),
@@ -84,6 +86,7 @@ func Connect(ctx context.Context, opts Opts, invokers map[string]FunctionInvoker
 
 	conn, err := ch.Connect(ctx)
 	if err != nil {
+		l.Error("could not establish connection", "error", err)
 		return nil, fmt.Errorf("could not establish connection: %w", err)
 	}
 
@@ -176,6 +179,8 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 	startCtx, cancelStart := context.WithTimeout(ctx, time.Second*30)
 	defer cancelStart()
 
+	l := h.logger
+
 	signingKey := h.opts.HashedSigningKey
 	if len(signingKey) == 0 && !h.opts.IsDev {
 		return nil, fmt.Errorf("hashed signing key is required")
@@ -214,7 +219,7 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 		}
 	}
 
-	h.logger.Debug("using provided functions", "slugs", appSlugs)
+	l.Debug("using provided functions", "slugs", appSlugs)
 
 	marshaledCapabilities, err := json.Marshal(h.opts.Capabilities)
 	if err != nil {
@@ -240,21 +245,25 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 
 			// Reset attempts when connection succeeded
 			case <-h.notifyConnectedChan:
-				h.logger.Debug("connected")
+				l.Debug("connected")
 				if isInitialConnection {
 					isInitialConnection = false
 					initialConnectionDone <- nil
 				}
-				h.setState(ConnectionStateActive)
+				h.setState(ConnectionStateActive, "connection established", "attempt", attempts)
 				attempts = 0
 				continue
 
 			// Handle connection done events
 			case msg := <-h.notifyConnectDoneChan:
-				h.logger.Error("connect failed", "err", err, "reconnect", msg.reconnect)
+				if msg.err != nil {
+					l.Error("connection ended with error", "err", msg.err, "reconnect", msg.reconnect)
+				} else {
+					l.Debug("connection ended", "reconnect", msg.reconnect)
+				}
 
 				if !msg.reconnect {
-					h.setState(ConnectionStateClosed)
+					h.setState(ConnectionStateClosed, "connection ended without reconnect", "err", msg.err)
 
 					if isInitialConnection {
 						isInitialConnection = false
@@ -264,7 +273,7 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 					return err
 				}
 
-				h.setState(ConnectionStateReconnecting)
+				h.setState(ConnectionStateReconnecting, "connection ended with reconnect", "err", msg.err, "attempt", attempts)
 
 				// Some errors should be handled differently (e.g. auth failed)
 				if msg.err != nil {
@@ -332,14 +341,14 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 				if h.messageBuffer.hasMessages() {
 					err := h.messageBuffer.flush(h.auth.hashedSigningKey)
 					if err != nil {
-						h.logger.Error("could not send buffered messages", "err", err)
+						l.Error("could not send buffered messages", "err", err)
 					}
 				}
 
 				// continue to reconnect logic
 				delay := expBackoff(attempts)
 
-				h.logger.Debug("reconnecting", "delay", delay.String(), "attempts", attempts)
+				l.Debug("reconnecting", "delay", delay.String(), "attempts", attempts)
 
 				select {
 				case <-time.After(delay):
@@ -350,7 +359,7 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 						initialConnectionDone <- nil
 					}
 
-					h.logger.Info("canceled context while waiting to reconnect")
+					l.Info("canceled context while waiting to reconnect")
 					return nil
 				}
 
@@ -391,18 +400,18 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 		// Wait for run loop to complete (maximum attempts reached, context canceled)
 		runLoopErr := runLoop.Wait()
 		if runLoopErr != nil {
-			h.logger.Error("could not connect", "err", runLoopErr)
+			l.Error("could not connect", "err", runLoopErr)
 		}
 
-		h.logger.Debug("run loop ended")
+		l.Debug("run loop ended")
 
 		// Wait until current connection is fully terminated
 		select {
 		case <-ctx.Done():
 		case <-time.After(5 * time.Second):
-			h.logger.Warn("shutting down without final signal")
+			l.Warn("shutting down without final signal")
 		case <-h.notifyConnectDoneChan:
-			h.logger.Debug("got connection done signal")
+			l.Debug("got connection done signal")
 		}
 
 		// Always send out buffered messages using API
@@ -410,13 +419,13 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 			// Send buffered messages
 			err := h.messageBuffer.flush(h.auth.hashedSigningKey)
 			if err != nil {
-				h.logger.Error("could not send buffered messages", "err", err)
+				l.Error("could not send buffered messages", "err", err)
 			}
 
 			// TODO Push remaining messages to another destination for processing?
 		}
 
-		h.logger.Debug("connect handler done")
+		l.Debug("connect handler done")
 		return nil
 	})
 
@@ -441,13 +450,17 @@ func (h *connectHandler) Connect(ctx context.Context) (WorkerConnection, error) 
 func (h *connectHandler) Close() error {
 	// If connection was already closed, this is a no-op.
 	if h.closed.Swap(true) {
+		h.logger.Debug("close ignored; connection already closed", "state", h.State())
 		return nil
 	}
 
 	if h.cancelWorkerCtx == nil {
-		return fmt.Errorf("connection was not fully set up")
+		err := fmt.Errorf("connection was not fully set up")
+		h.logger.Error("could not close connection", "err", err, "state", h.State())
+		return err
 	}
 
+	h.setState(ConnectionStateClosing, "close requested")
 	h.cancelWorkerCtx()
 
 	// Wait until connection loop finishes
@@ -456,7 +469,7 @@ func (h *connectHandler) Close() error {
 		return fmt.Errorf("failed to connect: %w", err)
 	}
 
-	h.setState(ConnectionStateClosed)
+	h.setState(ConnectionStateClosed, "close complete")
 
 	return nil
 }
@@ -467,10 +480,19 @@ func (h *connectHandler) State() ConnectionState {
 	return h.state
 }
 
-func (h *connectHandler) setState(state ConnectionState) {
+func (h *connectHandler) setState(state ConnectionState, reason string, attrs ...any) {
 	h.stateLock.Lock()
-	defer h.stateLock.Unlock()
+	previous := h.state
 	h.state = state
+	h.stateLock.Unlock()
+
+	logAttrs := []any{
+		"from", previous,
+		"to", state,
+		"reason", reason,
+	}
+	logAttrs = append(logAttrs, attrs...)
+	h.logger.Debug("worker connection state transition", logAttrs...)
 }
 
 var errGatewayDraining = errors.New("gateway is draining")

--- a/vendor/github.com/inngest/inngestgo/handler.go
+++ b/vendor/github.com/inngest/inngestgo/handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/inngest/inngestgo/internal"
 	"github.com/inngest/inngestgo/internal/event"
 	"github.com/inngest/inngestgo/internal/fn"
+	"github.com/inngest/inngestgo/internal/logger"
 	"github.com/inngest/inngestgo/internal/middleware"
 	"github.com/inngest/inngestgo/internal/sdkrequest"
 	"github.com/inngest/inngestgo/internal/types"
@@ -248,12 +249,14 @@ func (h handlerOpts) isDev() bool {
 // newHandler returns a new Handler for serving Inngest functions.
 func newHandler(c Client, opts handlerOpts) *handler {
 	if opts.Logger == nil {
-		opts.Logger = slog.Default()
+		opts.Logger = logger.Default()
 	}
 
 	if opts.MaxBodySize == 0 {
 		opts.MaxBodySize = DefaultMaxBodySize
 	}
+
+	opts.Logger = opts.Logger.With("mode", "serve")
 
 	return &handler{
 		handlerOpts: opts,
@@ -292,7 +295,7 @@ func (h *handler) SetOptions(opts handlerOpts) *handler {
 		opts.MaxBodySize = DefaultMaxBodySize
 	}
 	if opts.Logger == nil {
-		opts.Logger = slog.Default()
+		opts.Logger = logger.Default()
 	}
 
 	return h

--- a/vendor/github.com/inngest/inngestgo/internal/logger/logger.go
+++ b/vendor/github.com/inngest/inngestgo/internal/logger/logger.go
@@ -1,0 +1,84 @@
+package logger
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/lmittmann/tint"
+)
+
+const (
+	// LevelTrace matches the common slog convention of placing trace below debug.
+	LevelTrace slog.Level = -8
+)
+
+// Default returns the SDK's default slog logger, configured from environment
+// variables.
+func Default() *slog.Logger {
+	return New(os.Stderr)
+}
+
+// New returns a slog logger configured from environment variables and writing
+// to w. It is exported for tests and internal packages that need custom writers.
+func New(w io.Writer) *slog.Logger {
+	handlerOpts := &slog.HandlerOptions{
+		Level: parseLevel(os.Getenv("LOG_LEVEL")),
+	}
+
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("LOG_HANDLER"))) {
+	case "json":
+		return slog.New(slog.NewJSONHandler(w, handlerOpts))
+	case "txt", "text":
+		return slog.New(slog.NewTextHandler(w, handlerOpts))
+	case "dev", "":
+		return slog.New(devHandler(w, handlerOpts.Level))
+	default:
+		return slog.New(devHandler(w, handlerOpts.Level))
+	}
+}
+
+func devHandler(w io.Writer, level slog.Leveler) slog.Handler {
+	return tint.NewHandler(w, &tint.Options{
+		Level:      level,
+		TimeFormat: "[15:04:05.000]",
+		ReplaceAttr: func(groups []string, attr slog.Attr) slog.Attr {
+			if attr.Key == slog.LevelKey && len(groups) == 0 {
+				lvl, ok := attr.Value.Any().(slog.Level)
+				if ok {
+					switch lvl {
+					case LevelTrace:
+						return tint.Attr(13, slog.String(attr.Key, "TRC"))
+					case slog.LevelDebug:
+						return tint.Attr(3, slog.String(attr.Key, "DBG"))
+					case slog.LevelInfo:
+						return tint.Attr(14, slog.String(attr.Key, "INF"))
+					}
+				}
+			}
+			return attr
+		},
+	})
+}
+
+func parseLevel(value string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "trace":
+		return LevelTrace
+	case "debug":
+		return slog.LevelDebug
+	case "info", "":
+		return slog.LevelInfo
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		if n, err := strconv.Atoi(value); err == nil {
+			return slog.Level(n)
+		}
+		return slog.LevelInfo
+	}
+}

--- a/vendor/github.com/inngest/inngestgo/internal/middleware/log.go
+++ b/vendor/github.com/inngest/inngestgo/internal/middleware/log.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"sync/atomic"
+
+	"github.com/inngest/inngestgo/internal/logger"
 )
 
 type logContextKeyType struct{}
@@ -15,13 +17,13 @@ func LoggerFromContext(ctx context.Context) *slog.Logger {
 	value := ctx.Value(logContextKey)
 	if value == nil {
 		// Unreachable if the middleware is used correctly.
-		return slog.Default()
+		return logger.Default()
 	}
 
 	l, ok := value.(*slog.Logger)
 	if !ok {
 		// Unreachable if the middleware is used correctly.
-		return slog.Default()
+		return logger.Default()
 	}
 
 	return l

--- a/vendor/github.com/inngest/inngestgo/internal/sdkrequest/manager.go
+++ b/vendor/github.com/inngest/inngestgo/internal/sdkrequest/manager.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"slices"
 	"sync"
 	"time"
@@ -15,6 +14,7 @@ import (
 	"github.com/inngest/inngestgo/experimental"
 	"github.com/inngest/inngestgo/internal/checkpoint"
 	"github.com/inngest/inngestgo/internal/fn"
+	"github.com/inngest/inngestgo/internal/logger"
 	"github.com/inngest/inngestgo/internal/middleware"
 	"github.com/inngest/inngestgo/internal/opcode"
 	"github.com/inngest/inngestgo/internal/util"
@@ -304,7 +304,7 @@ func (r *requestCtxManager) AppendOp(ctx context.Context, op GeneratorOpcode) {
 				}
 				return
 			}
-			slog.Default().Warn("error checkpointing state, falling back to async response", "error", err)
+			logger.Default().Warn("error checkpointing state, falling back to async response", "error", err)
 		})
 	default:
 		// Do nothing else.

--- a/vendor/github.com/inngest/inngestgo/signature.go
+++ b/vendor/github.com/inngest/inngestgo/signature.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"log/slog"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -14,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gowebpki/jcs"
+	"github.com/inngest/inngestgo/internal/logger"
 )
 
 var (
@@ -33,7 +33,7 @@ func Sign(ctx context.Context, at time.Time, key, body []byte) (string, error) {
 	if len(body) > 0 {
 		body, err = jcs.Transform(body)
 		if err != nil {
-			slog.Default().Warn("failed to canonicalize body", "error", err)
+			logger.Default().Warn("failed to canonicalize body", "error", err)
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -786,7 +786,7 @@ github.com/inngest/expr
 # github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48
 ## explicit; go 1.23.2
 github.com/inngest/go-httpstat
-# github.com/inngest/inngestgo v0.15.2-0.20260506200124-23193cd96953
+# github.com/inngest/inngestgo v0.15.2-0.20260507002849-c26cf7119dbf
 ## explicit; go 1.25.9
 github.com/inngest/inngestgo
 github.com/inngest/inngestgo/connect
@@ -797,6 +797,7 @@ github.com/inngest/inngestgo/internal
 github.com/inngest/inngestgo/internal/checkpoint
 github.com/inngest/inngestgo/internal/event
 github.com/inngest/inngestgo/internal/fn
+github.com/inngest/inngestgo/internal/logger
 github.com/inngest/inngestgo/internal/middleware
 github.com/inngest/inngestgo/internal/opcode
 github.com/inngest/inngestgo/internal/sdkrequest


### PR DESCRIPTION
## Description

Adds a clearer log trail for Connect gateway and worker connection lifecycle state changes, complementing the SDK-side logging added in inngestgo#217.

This is split into two reviewable commits:

- `Log connect gateway status transitions`: logs gateway status changes with previous state, next state, reason, active connection count, and gateway metadata.
- `Log connect worker lifecycle transitions`: adds connection-scoped metadata to gateway logs and logs worker connection status transitions with reasons across handshake, sync, readiness, heartbeat, drain, disconnecting, and cleanup paths.

## Motivation

When investigating incidents around a specific time window, we need to correlate both sides of Connect lifecycle behavior: SDK worker transitions and gateway-side state changes. These logs make it easier to reconstruct when a gateway starts draining, when a worker connection moves through `CONNECTED`, `READY`, `DRAINING`, `DISCONNECTING`, and `DISCONNECTED`, and which connection/worker metadata was involved.

## Note

Might want to consider moving this to a proper state machine so it's easier to track transitions instead of the current procedural/event based changes, which any state can become any other state.

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Testing

- [x] `go test ./pkg/connect/...`

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds structured lifecycle logging to the Connect gateway and worker connection state machine. Gateway status transitions now log `from`/`to`/`reason` with active connection count and gateway metadata. Worker connection status transitions use the same pattern via `logConnStatusLocked`, called under `updateLock`. The vendored inngestgo SDK is bumped to pick up matching worker-side logging.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0a8a979a7d0e4211d1de92444007fbdce71f9a97.</sup>
<!-- /MENDRAL_SUMMARY -->