### PR TITLE
feat: add in-band syncs to self-hosted

### DIFF
--- a/cmd/devserver/devserver.go
+++ b/cmd/devserver/devserver.go
@@ -82,7 +82,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	conf.ServerKind = headers.ServerKindDev
 
 	opts := devserver.StartOpts{
-		AllowInsecureHTTP:  true, // `inngest dev` drives local SDKs over http://
+		// Dev Server always allows http://
+		AllowInsecureHTTP: true,
+
 		Autodiscover:       !noDiscovery,
 		Config:             *conf,
 		Poll:               !noPoll,

--- a/cmd/devserver/devserver.go
+++ b/cmd/devserver/devserver.go
@@ -82,6 +82,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	conf.ServerKind = headers.ServerKindDev
 
 	opts := devserver.StartOpts{
+		AllowInsecureHTTP:  true, // `inngest dev` drives local SDKs over http://
 		Autodiscover:       !noDiscovery,
 		Config:             *conf,
 		Poll:               !noPoll,

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -121,6 +121,11 @@ func Command() *cli.Command {
 				Name:     "no-ui",
 				Usage:    "Disable the web UI and GraphQL API endpoint",
 			},
+			&cli.BoolFlag{
+				Category: "Advanced",
+				Name:     "allow-insecure-http",
+				Usage:    "Permit app syncs against http:// SDK URLs (default: https only)",
+			},
 		},
 	}
 

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -118,6 +118,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	connectExecutorGRPCPort := localconfig.GetIntValue(cmd, "connect-executor-grpc-port", devserver.DefaultConnectExecutorGRPCPort)
 
 	opts := devserver.StartOpts{
+		AllowInsecureHTTP:       localconfig.GetBoolValue(cmd, "allow-insecure-http", false),
 		Config:                  *conf,
 		ConnectGatewayHost:      conf.CoreAPI.Addr,
 		ConnectGatewayPort:      connectGatewayPort,

--- a/docs/api-docs/public/api-specs/v2.json
+++ b/docs/api-docs/public/api-specs/v2.json
@@ -336,11 +336,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/v2SyncAppResponse"
+                  "$ref": "#/components/schemas/v2ErrorResponse"
                 }
               }
             },
-            "description": "Unprocessable Entity - sync failed. The response body is still SyncAppResponse and includes the persisted deploy plus a coded error under data.latestSync.error."
+            "description": "Unprocessable Entity - sync failed."
           },
           "500": {
             "content": {

--- a/pkg/api/v2/endpoints.go
+++ b/pkg/api/v2/endpoints.go
@@ -305,6 +305,17 @@ func (s *Service) SyncApp(
 			"app_id is required",
 		)
 	}
+
+	// Sync drives an outbound HTTP request to a caller-supplied URL; rate-limit
+	// before any work to bound SSRF / DoS amplification per signing key.
+	if result := s.rateLimiter.CheckRateLimit(ctx, apiv2.V2_SyncApp_FullMethodName); result.Limited {
+		return nil, s.base.NewError(
+			http.StatusTooManyRequests,
+			apiv2base.ErrorRateLimited,
+			"API rate limit exceeded. The request was rejected and no app was synced.",
+		)
+	}
+
 	if s.appSyncer == nil {
 		return nil, s.base.NewError(
 			http.StatusNotImplemented,

--- a/pkg/api/v2/endpoints.go
+++ b/pkg/api/v2/endpoints.go
@@ -334,7 +334,7 @@ func (s *Service) SyncApp(
 		return nil, s.base.NewError(
 			http.StatusInternalServerError,
 			apiv2base.ErrorInternalError,
-			err.Error(),
+			"internal error during sync",
 		)
 	}
 	if syscodeErr != nil {

--- a/pkg/api/v2/endpoints.go
+++ b/pkg/api/v2/endpoints.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/inngest/inngest/pkg/api/v2/apiv2base"
@@ -291,14 +292,16 @@ func (s *Service) SyncApp(
 ) (*apiv2.SyncAppResponse, error) {
 	ctx = logger.WithStdlib(ctx, logger.From(ctx).With("handler", "SyncApp"))
 
-	if req.Url == "" {
+	appURL := strings.TrimSpace(req.GetUrl())
+	if appURL == "" {
 		return nil, s.base.NewError(
 			http.StatusBadRequest,
 			apiv2base.ErrorMissingField,
 			"url is required",
 		)
 	}
-	if req.AppId == "" {
+	appID := strings.TrimSpace(req.GetAppId())
+	if appID == "" {
 		return nil, s.base.NewError(
 			http.StatusBadRequest,
 			apiv2base.ErrorMissingField,
@@ -331,16 +334,16 @@ func (s *Service) SyncApp(
 
 	syncResp, syscodeErr, err := appsync.Sync(ctx, appsync.Opts{
 		AllowInsecureHTTP: s.appSyncAllowInsecure,
-		ExpectedAppID:     req.AppId,
+		ExpectedAppID:     appID,
 		ServerKind:        s.serverKind,
 		SigningKey:        signingKey,
-		URL:               req.Url,
+		URL:               appURL,
 	})
 	if err != nil {
 		logger.From(ctx).Error(
 			"system error during sync",
 			"error", err,
-			"url", req.Url,
+			"url", appURL,
 		)
 		return nil, s.base.NewError(
 			http.StatusInternalServerError,
@@ -353,7 +356,7 @@ func (s *Service) SyncApp(
 			"sync failed",
 			"code", syscodeErr.Code,
 			"message", syscodeErr.Message,
-			"url", req.Url,
+			"url", appURL,
 		)
 		return nil, s.base.NewError(
 			httpStatusForSyncSyscode(syscodeErr.Code),
@@ -375,7 +378,7 @@ func (s *Service) SyncApp(
 
 	return &apiv2.SyncAppResponse{
 		Data: &apiv2.SyncAppData{
-			AppId:  req.AppId,
+			AppId:  appID,
 			Id:     syncID,
 			Status: syncStatusSuccess,
 		},

--- a/pkg/api/v2/endpoints.go
+++ b/pkg/api/v2/endpoints.go
@@ -2,11 +2,16 @@ package apiv2
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
 	"github.com/inngest/inngest/pkg/api/v2/apiv2base"
+	"github.com/inngest/inngest/pkg/appsync"
 	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/publicerr"
+	"github.com/inngest/inngest/pkg/syscode"
 	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -277,8 +282,174 @@ func (s *Service) PatchEnv(ctx context.Context, req *apiv2.PatchEnvRequest) (*ap
 	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Environments not implemented in OSS")
 }
 
-func (s *Service) SyncApp(ctx context.Context, req *apiv2.SyncAppRequest) (*apiv2.SyncAppResponse, error) {
-	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "App sync not implemented in OSS")
+const syncStatusSuccess = "SUCCESS"
+
+// SyncApp performs an app sync against the SDK at the provided URL.
+func (s *Service) SyncApp(
+	ctx context.Context,
+	req *apiv2.SyncAppRequest,
+) (*apiv2.SyncAppResponse, error) {
+	ctx = logger.WithStdlib(ctx, logger.From(ctx).With("handler", "SyncApp"))
+
+	if req.Url == "" {
+		return nil, s.base.NewError(
+			http.StatusBadRequest,
+			apiv2base.ErrorMissingField,
+			"url is required",
+		)
+	}
+	if req.AppId == "" {
+		return nil, s.base.NewError(
+			http.StatusBadRequest,
+			apiv2base.ErrorMissingField,
+			"app_id is required",
+		)
+	}
+	if s.appSyncer == nil {
+		return nil, s.base.NewError(
+			http.StatusNotImplemented,
+			apiv2base.ErrorNotImplemented,
+			"App sync not implemented",
+		)
+	}
+
+	signingKey, err := s.firstSigningKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	syncResp, syscodeErr, err := appsync.Sync(ctx, appsync.Opts{
+		AllowInsecureHTTP: s.appSyncAllowInsecure,
+		ExpectedAppID:     req.AppId,
+		ServerKind:        s.serverKind,
+		SigningKey:        signingKey,
+		URL:               req.Url,
+	})
+	if err != nil {
+		logger.From(ctx).Error(
+			"system error during sync",
+			"error", err,
+			"url", req.Url,
+		)
+		return nil, s.base.NewError(
+			http.StatusInternalServerError,
+			apiv2base.ErrorInternalError,
+			err.Error(),
+		)
+	}
+	if syscodeErr != nil {
+		logger.From(ctx).Warn(
+			"sync failed",
+			"code", syscodeErr.Code,
+			"message", syscodeErr.Message,
+			"url", req.Url,
+		)
+		return nil, s.base.NewError(
+			httpStatusForSyncSyscode(syscodeErr.Code),
+			syscodeErr.Code,
+			syscodeErr.Message,
+		)
+	}
+
+	reply, err := s.appSyncer.ProcessSync(ctx, *syncResp.ToRegisterRequest())
+	if err != nil {
+		logger.From(ctx).Error("error processing sync", "error", err)
+		return nil, s.processSyncErr(err)
+	}
+
+	syncID := ""
+	if reply != nil && reply.SyncID != nil {
+		syncID = reply.SyncID.String()
+	}
+
+	return &apiv2.SyncAppResponse{
+		Data: &apiv2.SyncAppData{
+			AppId:  req.AppId,
+			Id:     syncID,
+			Status: syncStatusSuccess,
+		},
+		Metadata: &apiv2.ResponseMetadata{
+			FetchedAt: timestamppb.Now(),
+		},
+	}, nil
+}
+
+// firstSigningKey returns the configured key, or a generic 501 if anything
+// is misconfigured. All failure modes log a reason but never surface it, so
+// the response can't be used to probe key configuration.
+func (s *Service) firstSigningKey(ctx context.Context) (string, error) {
+	notImpl := s.base.NewError(
+		http.StatusNotImplemented,
+		apiv2base.ErrorNotImplemented,
+		"App sync not implemented",
+	)
+
+	if s.signingKeys == nil {
+		logger.From(ctx).Error("no signing keys provider")
+		return "", notImpl
+	}
+	keys, err := s.signingKeys.GetSigningKeys(ctx)
+	if err != nil {
+		logger.From(ctx).Error("failed to load signing keys", "error", err)
+		return "", notImpl
+	}
+	if len(keys) == 0 || keys[0].Key == "" {
+		logger.From(ctx).Error("no signing key")
+		return "", notImpl
+	}
+	if len(keys) > 1 {
+		logger.From(ctx).Warn("multiple signing keys")
+	}
+	return keys[0].Key, nil
+}
+
+// processSyncErr maps an AppSyncer error to a v2 response. Known types
+// (publicerr.Error, *syscode.Error) propagate status/code/message; others
+// collapse to 500 with no internal detail. Caller logs the raw err.
+func (s *Service) processSyncErr(err error) error {
+	var perr publicerr.Error
+	if errors.As(err, &perr) {
+		code := perr.Code
+		if code == "" {
+			code = apiv2base.ErrorAppSyncFailed
+		}
+		msg := perr.Message
+		if msg == "" {
+			msg = http.StatusText(perr.Status)
+		}
+		status := perr.Status
+		if status == 0 {
+			status = http.StatusInternalServerError
+		}
+		return s.base.NewError(status, code, msg)
+	}
+
+	var syserr *syscode.Error
+	if errors.As(err, &syserr) {
+		return s.base.NewError(
+			http.StatusUnprocessableEntity,
+			syserr.Code,
+			syserr.Message,
+		)
+	}
+
+	return s.base.NewError(
+		http.StatusInternalServerError,
+		apiv2base.ErrorInternalError,
+		"failed to process sync",
+	)
+}
+
+// httpStatusForSyncSyscode maps an appsync.Sync syscode to an HTTP status.
+// Caller-input violations are 400; everything else is a 422 (the SDK side of
+// the protocol exchange failed).
+func httpStatusForSyncSyscode(code string) int {
+	switch code {
+	case syscode.CodeURLSchemeDenied:
+		return http.StatusBadRequest
+	default:
+		return http.StatusUnprocessableEntity
+	}
 }
 func (s *Service) ListInsightsEventSchemas(ctx context.Context, req *apiv2.ListInsightsEventSchemasRequest) (*apiv2.ListInsightsEventSchemasResponse, error) {
 	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Insights not implemented in OSS")

--- a/pkg/api/v2/interfaces.go
+++ b/pkg/api/v2/interfaces.go
@@ -6,11 +6,13 @@ import (
 	"time"
 
 	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/cqrs/sync"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/execution"
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/sdk"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -77,4 +79,9 @@ type RunsReader interface {
 type FunctionTraceReader interface {
 	GetSpansByRunID(ctx context.Context, runID ulid.ULID) (*cqrs.OtelSpan, error)
 	GetSpanOutput(ctx context.Context, id cqrs.SpanIdentifier) (*cqrs.SpanOutput, error)
+}
+
+// AppSyncer persists an in-band sync result. Dev server and cloud differ.
+type AppSyncer interface {
+	ProcessSync(ctx context.Context, req sdk.RegisterRequest) (*sync.Reply, error)
 }

--- a/pkg/api/v2/service.go
+++ b/pkg/api/v2/service.go
@@ -19,16 +19,19 @@ import (
 // Service implements the V2 API service for gRPC with grpc-gateway
 type Service struct {
 	apiv2.UnimplementedV2Server
-	signingKeys    SigningKeysProvider
-	eventKeys      EventKeysProvider
-	functions      FunctionProvider
-	runs           FunctionRunReader
-	runList        RunsReader
-	traces         FunctionTraceReader
-	executor       FunctionScheduler
-	eventPublisher EventPublisher
-	rateLimiter    RateLimitProvider
-	base           *apiv2base.Base
+	signingKeys          SigningKeysProvider
+	eventKeys            EventKeysProvider
+	functions            FunctionProvider
+	runs                 FunctionRunReader
+	runList              RunsReader
+	traces               FunctionTraceReader
+	executor             FunctionScheduler
+	eventPublisher       EventPublisher
+	rateLimiter          RateLimitProvider
+	appSyncer            AppSyncer
+	serverKind           string
+	appSyncAllowInsecure bool
+	base                 *apiv2base.Base
 }
 
 // ServiceOptions contains configuration for the V2 service
@@ -42,6 +45,11 @@ type ServiceOptions struct {
 	Executor            FunctionScheduler
 	EventPublisher      EventPublisher
 	RateLimitProvider   RateLimitProvider
+	AppSyncer           AppSyncer
+	ServerKind          string
+
+	// AppSyncAllowInsecureHTTP permits in-band sync to use http:// URLs.
+	AppSyncAllowInsecureHTTP bool
 }
 
 func NewService(opts ServiceOptions) *Service {
@@ -50,16 +58,19 @@ func NewService(opts ServiceOptions) *Service {
 		rateLimiter = noopRateLimitProvider{}
 	}
 	return &Service{
-		signingKeys:    opts.SigningKeysProvider,
-		eventKeys:      opts.EventKeysProvider,
-		functions:      opts.Functions,
-		runs:           opts.FunctionRuns,
-		runList:        opts.RunList,
-		traces:         opts.FunctionTraces,
-		executor:       opts.Executor,
-		eventPublisher: opts.EventPublisher,
-		rateLimiter:    rateLimiter,
-		base:           apiv2base.NewBase(),
+		signingKeys:          opts.SigningKeysProvider,
+		eventKeys:            opts.EventKeysProvider,
+		functions:            opts.Functions,
+		runs:                 opts.FunctionRuns,
+		runList:              opts.RunList,
+		traces:               opts.FunctionTraces,
+		executor:             opts.Executor,
+		eventPublisher:       opts.EventPublisher,
+		rateLimiter:          rateLimiter,
+		appSyncer:            opts.AppSyncer,
+		serverKind:           opts.ServerKind,
+		appSyncAllowInsecure: opts.AppSyncAllowInsecureHTTP,
+		base:                 apiv2base.NewBase(),
 	}
 }
 

--- a/pkg/api/v2/sync_app_test.go
+++ b/pkg/api/v2/sync_app_test.go
@@ -2,26 +2,22 @@ package apiv2
 
 import (
 	"context"
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/api/v2/apiv2base"
-	"github.com/inngest/inngest/pkg/appsync"
 	"github.com/inngest/inngest/pkg/cqrs/sync"
 	"github.com/inngest/inngest/pkg/headers"
 	"github.com/inngest/inngest/pkg/publicerr"
 	"github.com/inngest/inngest/pkg/sdk"
 	"github.com/inngest/inngest/pkg/syscode"
+	"github.com/inngest/inngestgo"
 	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -31,15 +27,23 @@ import (
 
 const testSigningKey = "signkey-test-deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 
-// signResponse mirrors inngestgo's signWithoutJCS for response signing.
-func signResponse(t *testing.T, body []byte, key string) string {
+// realSDKHandler returns an httptest.Server backed by a real inngestgo
+// handler with in-band sync enabled. Drives Sync's success path through the
+// production response-signing code, so the test fails if either side's
+// signing logic drifts.
+func realSDKHandler(t *testing.T) *httptest.Server {
 	t.Helper()
-	keyBytes := regexp.MustCompile(`^signkey-\w+-`).ReplaceAll([]byte(key), nil)
-	ts := time.Now().Unix()
-	mac := hmac.New(sha256.New, keyBytes)
-	_, _ = mac.Write(body)
-	_, _ = fmt.Fprintf(mac, "%d", ts)
-	return fmt.Sprintf("t=%d&s=%s", ts, hex.EncodeToString(mac.Sum(nil)))
+	allow := true
+	dev := false
+	sk := testSigningKey
+	client, err := inngestgo.NewClient(inngestgo.ClientOpts{
+		AppID:           "my-app",
+		SigningKey:      &sk,
+		AllowInBandSync: &allow,
+		Dev:             &dev,
+	})
+	require.NoError(t, err)
+	return httptest.NewServer(client.Serve())
 }
 
 type fakeSigningKeyProvider struct {
@@ -69,38 +73,6 @@ func (r *recordingAppSyncer) ProcessSync(ctx context.Context, req sdk.RegisterRe
 	return r.reply, r.returnErr
 }
 
-// inBandHandler returns a fake SDK server. customize runs after defaults so
-// it can also override (including with empty values).
-func inBandHandler(t *testing.T, customize func(w http.ResponseWriter, body *[]byte)) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		body := sampleResponseBody(t)
-		w.Header().Set(headers.HeaderKeySignature, signResponse(t, body, testSigningKey))
-		w.Header().Set(headers.HeaderKeySDK, "go:0.7.0")
-		if customize != nil {
-			customize(w, &body)
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(body)
-	}))
-}
-
-func sampleResponseBody(t *testing.T) []byte {
-	t.Helper()
-	r := require.New(t)
-	resp := appsync.Response{
-		AppID:       "my-app",
-		SDKAuthor:   "inngest",
-		SDKLanguage: "go",
-		SDKVersion:  "0.7.0",
-		URL:         "http://placeholder/api/inngest",
-		Functions:   []sdk.SDKFunction{},
-	}
-	byt, err := json.Marshal(resp)
-	r.NoError(err)
-	return byt
-}
-
 // requireErrorWithCode asserts the gRPC status and the first embedded ErrorItem code.
 func requireErrorWithCode(t *testing.T, err error, wantStatus codes.Code, wantCode string) {
 	t.Helper()
@@ -119,7 +91,7 @@ func requireErrorWithCode(t *testing.T, err error, wantStatus codes.Code, wantCo
 func TestSyncApp(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		r := require.New(t)
-		srv := inBandHandler(t, nil)
+		srv := realSDKHandler(t)
 		defer srv.Close()
 
 		syncID := uuid.New()
@@ -146,14 +118,21 @@ func TestSyncApp(t *testing.T) {
 		r.Nil(resp.Data.Error)
 		r.True(syncer.called)
 		r.Equal("my-app", syncer.gotReq.AppName)
-		r.Equal("go:0.7.0", syncer.gotReq.SDK)
+		r.Equal(inngestgo.SDKLanguage+":"+inngestgo.SDKVersion, syncer.gotReq.SDK)
 	})
 
-	t.Run("SDK returns bad signature returns 422", func(t *testing.T) {
+	// Stands in for the entire family of appsync.Sync syscode failures
+	// (unreachable, app_id mismatch, etc.). At this layer the assertion is
+	// the same: syscode propagates as the gRPC error code, status maps to
+	// 422, and ProcessSync is not invoked. Per-syscode behavior is covered
+	// in pkg/appsync.
+	t.Run("syncs that fail in appsync return 422 and skip ProcessSync", func(t *testing.T) {
 		r := require.New(t)
-		srv := inBandHandler(t, func(w http.ResponseWriter, _ *[]byte) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set(headers.HeaderKeySignature, fmt.Sprintf("t=%d&s=cafebabe", time.Now().Unix()))
-		})
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"app_id":"my-app"}`))
+		}))
 		defer srv.Close()
 
 		syncer := &recordingAppSyncer{}
@@ -172,53 +151,9 @@ func TestSyncApp(t *testing.T) {
 		r.False(syncer.called, "processor should not be invoked on protocol failure")
 	})
 
-	t.Run("unreachable returns 422", func(t *testing.T) {
-		// Closed server triggers a dial failure.
-		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
-		url := srv.URL
-		srv.Close()
-
-		syncer := &recordingAppSyncer{}
-		service := NewService(ServiceOptions{
-			SigningKeysProvider:      fakeSigningKeyProvider{key: testSigningKey},
-			AppSyncer:                syncer,
-			ServerKind:               headers.ServerKindDev,
-			AppSyncAllowInsecureHTTP: true,
-		})
-
-		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
-			AppId: "my-app",
-			Url:   url,
-		})
-		requireErrorWithCode(t, err, codes.FailedPrecondition, syscode.CodeHTTPUnreachable)
-	})
-
-	t.Run("app_id mismatch fails sync", func(t *testing.T) {
-		r := require.New(t)
-		// SDK reports app_id "my-app" (sampleResponseBody default); caller asks
-		// to sync "other-app". Sync must fail before ProcessSync runs.
-		srv := inBandHandler(t, nil)
-		defer srv.Close()
-
-		syncer := &recordingAppSyncer{}
-		service := NewService(ServiceOptions{
-			SigningKeysProvider:      fakeSigningKeyProvider{key: testSigningKey},
-			AppSyncer:                syncer,
-			ServerKind:               headers.ServerKindDev,
-			AppSyncAllowInsecureHTTP: true,
-		})
-
-		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
-			AppId: "other-app",
-			Url:   srv.URL,
-		})
-		requireErrorWithCode(t, err, codes.FailedPrecondition, syscode.CodeAppIDMismatch)
-		r.False(syncer.called, "processor should not run on app_id mismatch")
-	})
-
 	t.Run("URL scheme rejection returns 400", func(t *testing.T) {
-		// Service has AllowInsecureHTTP=false, so http:// is rejected by
-		// appsync.checkScheme as CodeURLSchemeDenied. Should map to 400, not 422.
+		// CodeURLSchemeDenied is the one syscode that maps to 400 instead of
+		// 422; covers the special case in httpStatusForSyncSyscode.
 		service := NewService(ServiceOptions{
 			SigningKeysProvider: fakeSigningKeyProvider{key: testSigningKey},
 			AppSyncer:           &recordingAppSyncer{},
@@ -298,7 +233,7 @@ func TestSyncApp(t *testing.T) {
 
 	t.Run("processor unknown error sanitized to 500", func(t *testing.T) {
 		r := require.New(t)
-		srv := inBandHandler(t, nil)
+		srv := realSDKHandler(t)
 		defer srv.Close()
 
 		syncer := &recordingAppSyncer{returnErr: errors.New("db down: connection refused at 10.0.0.5")}
@@ -324,7 +259,7 @@ func TestSyncApp(t *testing.T) {
 
 	t.Run("processor publicerr propagates status and message", func(t *testing.T) {
 		r := require.New(t)
-		srv := inBandHandler(t, nil)
+		srv := realSDKHandler(t)
 		defer srv.Close()
 
 		syncer := &recordingAppSyncer{returnErr: publicerr.Error{
@@ -351,7 +286,7 @@ func TestSyncApp(t *testing.T) {
 	})
 
 	t.Run("processor publicerr without code falls back to app_sync_failed", func(t *testing.T) {
-		srv := inBandHandler(t, nil)
+		srv := realSDKHandler(t)
 		defer srv.Close()
 
 		syncer := &recordingAppSyncer{returnErr: publicerr.Wrap(
@@ -372,7 +307,7 @@ func TestSyncApp(t *testing.T) {
 	})
 
 	t.Run("processor syscode error maps to 422", func(t *testing.T) {
-		srv := inBandHandler(t, nil)
+		srv := realSDKHandler(t)
 		defer srv.Close()
 
 		syncer := &recordingAppSyncer{returnErr: &syscode.Error{

--- a/pkg/api/v2/sync_app_test.go
+++ b/pkg/api/v2/sync_app_test.go
@@ -1,0 +1,395 @@
+package apiv2
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/api/v2/apiv2base"
+	"github.com/inngest/inngest/pkg/appsync"
+	"github.com/inngest/inngest/pkg/cqrs/sync"
+	"github.com/inngest/inngest/pkg/headers"
+	"github.com/inngest/inngest/pkg/publicerr"
+	"github.com/inngest/inngest/pkg/sdk"
+	"github.com/inngest/inngest/pkg/syscode"
+	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const testSigningKey = "signkey-test-deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+// signResponse mirrors inngestgo's signWithoutJCS for response signing.
+func signResponse(t *testing.T, body []byte, key string) string {
+	t.Helper()
+	keyBytes := regexp.MustCompile(`^signkey-\w+-`).ReplaceAll([]byte(key), nil)
+	ts := time.Now().Unix()
+	mac := hmac.New(sha256.New, keyBytes)
+	_, _ = mac.Write(body)
+	_, _ = fmt.Fprintf(mac, "%d", ts)
+	return fmt.Sprintf("t=%d&s=%s", ts, hex.EncodeToString(mac.Sum(nil)))
+}
+
+type fakeSigningKeyProvider struct {
+	key string
+}
+
+func (f fakeSigningKeyProvider) GetSigningKeys(ctx context.Context) ([]*apiv2.SigningKey, error) {
+	if f.key == "" {
+		return nil, nil
+	}
+	return []*apiv2.SigningKey{{
+		Key:       f.key,
+		CreatedAt: timestamppb.Now(),
+	}}, nil
+}
+
+type recordingAppSyncer struct {
+	called    bool
+	gotReq    sdk.RegisterRequest
+	reply     *sync.Reply
+	returnErr error
+}
+
+func (r *recordingAppSyncer) ProcessSync(ctx context.Context, req sdk.RegisterRequest) (*sync.Reply, error) {
+	r.called = true
+	r.gotReq = req
+	return r.reply, r.returnErr
+}
+
+// inBandHandler returns a fake SDK server. customize runs after defaults so
+// it can also override (including with empty values).
+func inBandHandler(t *testing.T, customize func(w http.ResponseWriter, body *[]byte)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		body := sampleResponseBody(t)
+		w.Header().Set(headers.HeaderKeySignature, signResponse(t, body, testSigningKey))
+		w.Header().Set(headers.HeaderKeySDK, "go:0.7.0")
+		if customize != nil {
+			customize(w, &body)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+}
+
+func sampleResponseBody(t *testing.T) []byte {
+	t.Helper()
+	r := require.New(t)
+	resp := appsync.Response{
+		AppID:       "my-app",
+		SDKAuthor:   "inngest",
+		SDKLanguage: "go",
+		SDKVersion:  "0.7.0",
+		URL:         "http://placeholder/api/inngest",
+		Functions:   []sdk.SDKFunction{},
+	}
+	byt, err := json.Marshal(resp)
+	r.NoError(err)
+	return byt
+}
+
+// requireErrorWithCode asserts the gRPC status and the first embedded ErrorItem code.
+func requireErrorWithCode(t *testing.T, err error, wantStatus codes.Code, wantCode string) {
+	t.Helper()
+	r := require.New(t)
+	r.Error(err)
+	st, ok := status.FromError(err)
+	r.True(ok, "expected gRPC status, got %T", err)
+	r.Equal(wantStatus, st.Code(), "grpc code mismatch (msg=%q)", st.Message())
+
+	var resp apiv2base.ErrorResponse
+	r.NoError(json.Unmarshal([]byte(st.Message()), &resp), "message=%q", st.Message())
+	r.NotEmpty(resp.Errors)
+	r.Equal(wantCode, resp.Errors[0].Code)
+}
+
+func TestSyncApp(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		r := require.New(t)
+		srv := inBandHandler(t, nil)
+		defer srv.Close()
+
+		syncID := uuid.New()
+		appID := uuid.New()
+		syncer := &recordingAppSyncer{
+			reply: &sync.Reply{OK: true, AppID: &appID, SyncID: &syncID},
+		}
+		service := NewService(ServiceOptions{
+			SigningKeysProvider:      fakeSigningKeyProvider{key: testSigningKey},
+			AppSyncer:                syncer,
+			ServerKind:               headers.ServerKindDev,
+			AppSyncAllowInsecureHTTP: true,
+		})
+
+		resp, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "my-app",
+			Url:   srv.URL,
+		})
+		r.NoError(err)
+		r.NotNil(resp)
+		r.Equal(syncStatusSuccess, resp.Data.Status)
+		r.Equal("my-app", resp.Data.AppId)
+		r.Equal(syncID.String(), resp.Data.Id)
+		r.Nil(resp.Data.Error)
+		r.True(syncer.called)
+		r.Equal("my-app", syncer.gotReq.AppName)
+		r.Equal("go:0.7.0", syncer.gotReq.SDK)
+	})
+
+	t.Run("SDK returns bad signature returns 422", func(t *testing.T) {
+		r := require.New(t)
+		srv := inBandHandler(t, func(w http.ResponseWriter, _ *[]byte) {
+			w.Header().Set(headers.HeaderKeySignature, fmt.Sprintf("t=%d&s=cafebabe", time.Now().Unix()))
+		})
+		defer srv.Close()
+
+		syncer := &recordingAppSyncer{}
+		service := NewService(ServiceOptions{
+			SigningKeysProvider:      fakeSigningKeyProvider{key: testSigningKey},
+			AppSyncer:                syncer,
+			ServerKind:               headers.ServerKindDev,
+			AppSyncAllowInsecureHTTP: true,
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "my-app",
+			Url:   srv.URL,
+		})
+		requireErrorWithCode(t, err, codes.FailedPrecondition, syscode.CodeSigVerificationFailed)
+		r.False(syncer.called, "processor should not be invoked on protocol failure")
+	})
+
+	t.Run("unreachable returns 422", func(t *testing.T) {
+		// Closed server triggers a dial failure.
+		srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+		url := srv.URL
+		srv.Close()
+
+		syncer := &recordingAppSyncer{}
+		service := NewService(ServiceOptions{
+			SigningKeysProvider:      fakeSigningKeyProvider{key: testSigningKey},
+			AppSyncer:                syncer,
+			ServerKind:               headers.ServerKindDev,
+			AppSyncAllowInsecureHTTP: true,
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "my-app",
+			Url:   url,
+		})
+		requireErrorWithCode(t, err, codes.FailedPrecondition, syscode.CodeHTTPUnreachable)
+	})
+
+	t.Run("app_id mismatch fails sync", func(t *testing.T) {
+		r := require.New(t)
+		// SDK reports app_id "my-app" (sampleResponseBody default); caller asks
+		// to sync "other-app". Sync must fail before ProcessSync runs.
+		srv := inBandHandler(t, nil)
+		defer srv.Close()
+
+		syncer := &recordingAppSyncer{}
+		service := NewService(ServiceOptions{
+			SigningKeysProvider:      fakeSigningKeyProvider{key: testSigningKey},
+			AppSyncer:                syncer,
+			ServerKind:               headers.ServerKindDev,
+			AppSyncAllowInsecureHTTP: true,
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "other-app",
+			Url:   srv.URL,
+		})
+		requireErrorWithCode(t, err, codes.FailedPrecondition, syscode.CodeAppIDMismatch)
+		r.False(syncer.called, "processor should not run on app_id mismatch")
+	})
+
+	t.Run("URL scheme rejection returns 400", func(t *testing.T) {
+		// Service has AllowInsecureHTTP=false, so http:// is rejected by
+		// appsync.checkScheme as CodeURLSchemeDenied. Should map to 400, not 422.
+		service := NewService(ServiceOptions{
+			SigningKeysProvider: fakeSigningKeyProvider{key: testSigningKey},
+			AppSyncer:           &recordingAppSyncer{},
+			ServerKind:          headers.ServerKindDev,
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "my-app",
+			Url:   "http://example.com/api/inngest",
+		})
+		requireErrorWithCode(t, err, codes.InvalidArgument, syscode.CodeURLSchemeDenied)
+	})
+
+	t.Run("requires URL", func(t *testing.T) {
+		r := require.New(t)
+		service := NewService(ServiceOptions{
+			SigningKeysProvider: fakeSigningKeyProvider{key: testSigningKey},
+			AppSyncer:           &recordingAppSyncer{},
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "my-app",
+		})
+		r.Error(err)
+	})
+
+	t.Run("requires app ID", func(t *testing.T) {
+		r := require.New(t)
+		service := NewService(ServiceOptions{
+			SigningKeysProvider: fakeSigningKeyProvider{key: testSigningKey},
+			AppSyncer:           &recordingAppSyncer{},
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			Url: "http://example.com",
+		})
+		r.Error(err)
+	})
+
+	t.Run("no app syncer wired", func(t *testing.T) {
+		r := require.New(t)
+		service := NewService(ServiceOptions{
+			SigningKeysProvider: fakeSigningKeyProvider{key: testSigningKey},
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "my-app",
+			Url:   "http://example.com",
+		})
+		r.Error(err)
+	})
+
+	t.Run("no signing key returns not implemented", func(t *testing.T) {
+		service := NewService(ServiceOptions{
+			SigningKeysProvider: fakeSigningKeyProvider{},
+			AppSyncer:           &recordingAppSyncer{},
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "my-app",
+			Url:   "http://example.com",
+		})
+		requireErrorWithCode(t, err, codes.Unimplemented, apiv2base.ErrorNotImplemented)
+	})
+
+	t.Run("no signing keys provider returns not implemented", func(t *testing.T) {
+		service := NewService(ServiceOptions{
+			AppSyncer: &recordingAppSyncer{},
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "my-app",
+			Url:   "http://example.com",
+		})
+		requireErrorWithCode(t, err, codes.Unimplemented, apiv2base.ErrorNotImplemented)
+	})
+
+	t.Run("processor unknown error sanitized to 500", func(t *testing.T) {
+		r := require.New(t)
+		srv := inBandHandler(t, nil)
+		defer srv.Close()
+
+		syncer := &recordingAppSyncer{returnErr: errors.New("db down: connection refused at 10.0.0.5")}
+		service := NewService(ServiceOptions{
+			SigningKeysProvider:      fakeSigningKeyProvider{key: testSigningKey},
+			AppSyncer:                syncer,
+			ServerKind:               headers.ServerKindDev,
+			AppSyncAllowInsecureHTTP: true,
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "my-app",
+			Url:   srv.URL,
+		})
+		requireErrorWithCode(t, err, codes.Internal, apiv2base.ErrorInternalError)
+
+		// The internal error text must NOT leak to the caller.
+		st, _ := status.FromError(err)
+		r.NotContains(st.Message(), "db down")
+		r.NotContains(st.Message(), "10.0.0.5")
+		r.Contains(st.Message(), "failed to process sync")
+	})
+
+	t.Run("processor publicerr propagates status and message", func(t *testing.T) {
+		r := require.New(t)
+		srv := inBandHandler(t, nil)
+		defer srv.Close()
+
+		syncer := &recordingAppSyncer{returnErr: publicerr.Error{
+			Code:    "function_invalid",
+			Message: "Function 'foo' is invalid",
+			Status:  http.StatusBadRequest,
+			Err:     errors.New("internal cause: should not leak"),
+		}}
+		service := NewService(ServiceOptions{
+			SigningKeysProvider:      fakeSigningKeyProvider{key: testSigningKey},
+			AppSyncer:                syncer,
+			ServerKind:               headers.ServerKindDev,
+			AppSyncAllowInsecureHTTP: true,
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "my-app",
+			Url:   srv.URL,
+		})
+		requireErrorWithCode(t, err, codes.InvalidArgument, "function_invalid")
+		st, _ := status.FromError(err)
+		r.Contains(st.Message(), "Function 'foo' is invalid")
+		r.NotContains(st.Message(), "internal cause")
+	})
+
+	t.Run("processor publicerr without code falls back to app_sync_failed", func(t *testing.T) {
+		srv := inBandHandler(t, nil)
+		defer srv.Close()
+
+		syncer := &recordingAppSyncer{returnErr: publicerr.Wrap(
+			errors.New("inner"), http.StatusBadRequest, "Invalid request",
+		)}
+		service := NewService(ServiceOptions{
+			SigningKeysProvider:      fakeSigningKeyProvider{key: testSigningKey},
+			AppSyncer:                syncer,
+			ServerKind:               headers.ServerKindDev,
+			AppSyncAllowInsecureHTTP: true,
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "my-app",
+			Url:   srv.URL,
+		})
+		requireErrorWithCode(t, err, codes.InvalidArgument, apiv2base.ErrorAppSyncFailed)
+	})
+
+	t.Run("processor syscode error maps to 422", func(t *testing.T) {
+		srv := inBandHandler(t, nil)
+		defer srv.Close()
+
+		syncer := &recordingAppSyncer{returnErr: &syscode.Error{
+			Code:    "function_count_invalid",
+			Message: "too many functions",
+		}}
+		service := NewService(ServiceOptions{
+			SigningKeysProvider:      fakeSigningKeyProvider{key: testSigningKey},
+			AppSyncer:                syncer,
+			ServerKind:               headers.ServerKindDev,
+			AppSyncAllowInsecureHTTP: true,
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "my-app",
+			Url:   srv.URL,
+		})
+		requireErrorWithCode(t, err, codes.FailedPrecondition, "function_count_invalid")
+	})
+}

--- a/pkg/api/v2/sync_app_test.go
+++ b/pkg/api/v2/sync_app_test.go
@@ -392,4 +392,31 @@ func TestSyncApp(t *testing.T) {
 		})
 		requireErrorWithCode(t, err, codes.FailedPrecondition, "function_count_invalid")
 	})
+
+	t.Run("rate limited", func(t *testing.T) {
+		r := require.New(t)
+		syncer := &recordingAppSyncer{}
+		service := NewService(ServiceOptions{
+			SigningKeysProvider:      fakeSigningKeyProvider{key: testSigningKey},
+			AppSyncer:                syncer,
+			ServerKind:               headers.ServerKindDev,
+			AppSyncAllowInsecureHTTP: true,
+			RateLimitProvider:        stubRateLimitProvider{limited: true},
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "my-app",
+			Url:   "http://example.com",
+		})
+		requireErrorWithCode(t, err, codes.ResourceExhausted, apiv2base.ErrorRateLimited)
+		r.False(syncer.called, "no outbound work when rate limited")
+	})
+}
+
+type stubRateLimitProvider struct {
+	limited bool
+}
+
+func (s stubRateLimitProvider) CheckRateLimit(context.Context, string) RateLimitResult {
+	return RateLimitResult{Limited: s.limited}
 }

--- a/pkg/api/v2/sync_app_test.go
+++ b/pkg/api/v2/sync_app_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/inngest/inngest/pkg/publicerr"
 	"github.com/inngest/inngest/pkg/sdk"
 	"github.com/inngest/inngest/pkg/syscode"
-	"github.com/inngest/inngestgo"
 	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
+	"github.com/inngest/inngestgo"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -121,8 +121,31 @@ func TestSyncApp(t *testing.T) {
 		r.Equal(inngestgo.SDKLanguage+":"+inngestgo.SDKVersion, syncer.gotReq.SDK)
 	})
 
+	t.Run("app mismatch returns monorepo error contract", func(t *testing.T) {
+		r := require.New(t)
+		srv := realSDKHandler(t)
+		defer srv.Close()
+
+		syncer := &recordingAppSyncer{}
+		service := NewService(ServiceOptions{
+			SigningKeysProvider:      fakeSigningKeyProvider{key: testSigningKey},
+			AppSyncer:                syncer,
+			ServerKind:               headers.ServerKindDev,
+			AppSyncAllowInsecureHTTP: true,
+		})
+
+		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
+			AppId: "wrong-app",
+			Url:   srv.URL,
+		})
+		requireErrorWithCode(t, err, codes.FailedPrecondition, syscode.CodeAppMismatch)
+		st, _ := status.FromError(err)
+		r.Contains(st.Message(), "expected app ID wrong-app, got my-app")
+		r.False(syncer.called)
+	})
+
 	// Stands in for the entire family of appsync.Sync syscode failures
-	// (unreachable, app_id mismatch, etc.). At this layer the assertion is
+	// (unreachable, app mismatch, etc.). At this layer the assertion is
 	// the same: syscode propagates as the gRPC error code, status maps to
 	// 422, and ProcessSync is not invoked. Per-syscode behavior is covered
 	// in pkg/appsync.
@@ -168,7 +191,6 @@ func TestSyncApp(t *testing.T) {
 	})
 
 	t.Run("requires URL", func(t *testing.T) {
-		r := require.New(t)
 		service := NewService(ServiceOptions{
 			SigningKeysProvider: fakeSigningKeyProvider{key: testSigningKey},
 			AppSyncer:           &recordingAppSyncer{},
@@ -176,21 +198,22 @@ func TestSyncApp(t *testing.T) {
 
 		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
 			AppId: "my-app",
+			Url:   "   ",
 		})
-		r.Error(err)
+		requireErrorWithCode(t, err, codes.InvalidArgument, apiv2base.ErrorMissingField)
 	})
 
 	t.Run("requires app ID", func(t *testing.T) {
-		r := require.New(t)
 		service := NewService(ServiceOptions{
 			SigningKeysProvider: fakeSigningKeyProvider{key: testSigningKey},
 			AppSyncer:           &recordingAppSyncer{},
 		})
 
 		_, err := service.SyncApp(context.Background(), &apiv2.SyncAppRequest{
-			Url: "http://example.com",
+			AppId: "   ",
+			Url:   "http://example.com",
 		})
-		r.Error(err)
+		requireErrorWithCode(t, err, codes.InvalidArgument, apiv2base.ErrorMissingField)
 	})
 
 	t.Run("no app syncer wired", func(t *testing.T) {

--- a/pkg/appsync/AGENTS.md
+++ b/pkg/appsync/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent guide: pkg/appsync
+
+Read [ARCHITECTURE.md](./ARCHITECTURE.md) before changing code in this
+package. It covers what the package does, the security model (opt-in flags
+for private networks and `http://`), and what is intentionally out of scope.

--- a/pkg/appsync/ARCHITECTURE.md
+++ b/pkg/appsync/ARCHITECTURE.md
@@ -1,0 +1,49 @@
+# Architecture: pkg/appsync
+
+## Purpose
+
+In-band sync is server-initiated: the Inngest server makes a signed `PUT` to
+the SDK's app URL and parses the signed register payload from the response
+in one round-trip. Compare to `/fn/register`, which is SDK-initiated.
+
+This package owns the HTTP exchange and signature handling. It does not
+persist the result and does not decide what to do with it.
+
+## Sync return contract
+
+`Sync(ctx, opts) (*Response, *syscode.Error, error)`. Exactly one is non-nil.
+
+- **`*Response`**: Success, body validated against signature.
+- **`*syscode.Error`**: "Userland" error. This indicates something out of our control failed in the sync (wrong signing key, unreachable SDK, etc.).
+- **`error`**: "System" error. This indicates a bug in our code (bad opts, marshaling).
+
+## Security model
+
+Does not trust the caller-supplied URL, even though it was probably authenticated at the API layer. This package is defensive.
+
+### Signed both ways
+
+Request and response both carry `X-Inngest-Signature` over the body using
+the configured signing key. The response signature is validated *before*
+parsing the body. Pre-validation bytes are untrusted.
+
+### Network policy
+
+- **Private networks**: always allowed. Self-hosted setups commonly run the
+  SDK on the same box as Inngest, so blocking loopback/RFC1918 isn't useful.
+- **Insecure HTTP**: opt-in via `Opts.AllowInsecureHTTP` (default `false`).
+  `inngest dev` always passes `true`; `inngest start` exposes it via the
+  `--allow-insecure-http` flag (default `false`).
+- **Redirects**: refused outright (see below).
+
+### Other safety properties
+
+- **Body cap**: 10 MiB, checked before signature validation, bounds memory under a malicious endpoint.
+- **Error messages**: Never echo upstream body bytes or Go's dial errors in `syscode.Error.Message`. Pre-signature bytes are attacker-controlled, and dial errors leak resolved IPs. Sanitize; keep raw bytes in logs.
+- **Why redirects are refused**: the SDK URL is canonical. Following redirects would add a header-forwarding surface (the request carries a signed body) and another code path to maintain for negligible benefit.
+
+## Out of scope
+
+- **Persistence and downstream effects**: Caller's job.
+- **Signing key selection**: `Opts.SigningKey` is taken as given.
+- **HTTP status mapping**: This package categorizes failures via `syscode.Error.Code`; status translation is the caller's choice.

--- a/pkg/appsync/ARCHITECTURE.md
+++ b/pkg/appsync/ARCHITECTURE.md
@@ -2,12 +2,9 @@
 
 ## Purpose
 
-In-band sync is server-initiated: the Inngest server makes a signed `PUT` to
-the SDK's app URL and parses the signed register payload from the response
-in one round-trip. Compare to `/fn/register`, which is SDK-initiated.
+In-band sync is server-initiated: the Inngest server makes a signed `PUT` to the SDK's app URL and parses the signed register payload from the response in one round-trip. Compare to `/fn/register`, which is SDK-initiated.
 
-This package owns the HTTP exchange and signature handling. It does not
-persist the result and does not decide what to do with it.
+This package owns the HTTP exchange and signature handling. It does not persist the result and does not decide what to do with it.
 
 ## Sync return contract
 
@@ -23,24 +20,19 @@ Does not trust the caller-supplied URL, even though it was probably authenticate
 
 ### Signed both ways
 
-Request and response both carry `X-Inngest-Signature` over the body using
-the configured signing key. The response signature is validated *before*
-parsing the body. Pre-validation bytes are untrusted.
+Request and response both carry `X-Inngest-Signature` over the body using the configured signing key. The response signature is validated *before* parsing the body. Pre-validation bytes are untrusted.
 
 ### Network policy
 
-- **Private networks**: always allowed. Self-hosted setups commonly run the
-  SDK on the same box as Inngest, so blocking loopback/RFC1918 isn't useful.
-- **Insecure HTTP**: opt-in via `Opts.AllowInsecureHTTP` (default `false`).
-  `inngest dev` always passes `true`; `inngest start` exposes it via the
-  `--allow-insecure-http` flag (default `false`).
-- **Redirects**: refused outright (see below).
+- **Private networks**: always allowed. Self-hosted setups commonly run the SDK on the same box as Inngest, so blocking loopback/RFC1918 isn't useful. "Private" here is everything `exechttp.SecureDialer` treats as private when `AllowPrivate=true`, which is broader than RFC1918: loopback, RFC1918, **link-local (`169.254.0.0/16`, `fe80::/10`), including cloud-metadata IPs like `169.254.169.254`,**, IPv6 ULA (`fc00::/7`), and multicast. Operators self-hosting on AWS/GCP/Azure should know that an authenticated v2 caller can probe internal networks via SyncApp; the outbound request body and response body are not reflected to the caller, but reachability and HTTP status are. The v2 endpoint is rate-limited to bound abuse.
+- **Insecure HTTP**: opt-in via `Opts.AllowInsecureHTTP` (default `false`). `inngest dev` always passes `true`; `inngest start` exposes it via the `--allow-insecure-http` flag (default `false`).
+- **Redirects**: refused outright. The SDK URL is canonical. Following redirects would add a header-forwarding surface (the request carries a signed body) and another code path to maintain for negligible benefit.
+- **`Opts.HTTPClient` escape hatch**: when set, replaces the built-in client entirely. **The scheme check still runs, but the SecureDialer (private network policy), redirect refusal, and the 10s request timeout do not.** Intended for tests; production callers should leave it nil.
 
 ### Other safety properties
 
 - **Body cap**: 10 MiB, checked before signature validation, bounds memory under a malicious endpoint.
 - **Error messages**: Never echo upstream body bytes or Go's dial errors in `syscode.Error.Message`. Pre-signature bytes are attacker-controlled, and dial errors leak resolved IPs. Sanitize; keep raw bytes in logs.
-- **Why redirects are refused**: the SDK URL is canonical. Following redirects would add a header-forwarding surface (the request carries a signed body) and another code path to maintain for negligible benefit.
 
 ## Out of scope
 

--- a/pkg/appsync/CLAUDE.md
+++ b/pkg/appsync/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/pkg/appsync/appsync.go
+++ b/pkg/appsync/appsync.go
@@ -1,0 +1,325 @@
+// Package appsync performs an in-band sync: signed PUT to an SDK URL, signed
+// response parsed into sdk.RegisterRequest. Persistence is the caller's job.
+package appsync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/inngest/inngest/pkg/execution/exechttp"
+	"github.com/inngest/inngest/pkg/headers"
+	"github.com/inngest/inngest/pkg/sdk"
+	"github.com/inngest/inngest/pkg/syscode"
+	"github.com/inngest/inngestgo"
+)
+
+var (
+	ErrMissingURL           = errors.New("url is required")
+	ErrMissingSigningKey    = errors.New("signing key is required")
+	ErrMissingExpectedAppID = errors.New("expected app id is required")
+)
+
+// 10 MiB clears any realistic register payload while bounding a misbehaving
+// endpoint. Matches pkg/deploy.
+const maxResponseBytes = 10 * 1024 * 1024
+
+// Caps total request duration, independent of any per-stage transport timeouts.
+const requestTimeout = 10 * time.Second
+
+// Opts configures a Sync call.
+type Opts struct {
+	// AllowInsecureHTTP permits http:// URLs.
+	AllowInsecureHTTP bool
+
+	// ExpectedAppID, when non-empty, requires the SDK's reported app_id to
+	// match. Mismatch fails the sync.
+	ExpectedAppID string
+
+	// HTTPClient overrides the built-in client; scheme check still runs.
+	HTTPClient *http.Client
+
+	// ServerKind sets X-Inngest-Server-Kind. Defaults to ServerKindCloud.
+	ServerKind string
+
+	SigningKey string
+
+	URL string
+}
+
+func (o *Opts) Validate() error {
+	if o.ExpectedAppID == "" {
+		return ErrMissingExpectedAppID
+	}
+	if o.SigningKey == "" {
+		return ErrMissingSigningKey
+	}
+	if o.URL == "" {
+		return ErrMissingURL
+	}
+	return nil
+}
+
+// Response mirrors the SDK's in-band sync handler body.
+type Response struct {
+	AppID       string            `json:"app_id"`
+	Env         *string           `json:"env"`
+	Framework   *string           `json:"framework"`
+	Functions   []sdk.SDKFunction `json:"functions"`
+	Inspection  map[string]any    `json:"inspection"`
+	Platform    *string           `json:"platform"`
+	SDKAuthor   string            `json:"sdk_author"`
+	SDKLanguage string            `json:"sdk_language"`
+	SDKVersion  string            `json:"sdk_version"`
+	URL         string            `json:"url"`
+}
+
+// ToRegisterRequest returns a normalized RegisterRequest so checksums match
+// the /fn/register pipeline.
+func (r *Response) ToRegisterRequest() *sdk.RegisterRequest {
+	req := &sdk.RegisterRequest{
+		AppName:      r.AppID,
+		Capabilities: r.capabilities(),
+		Framework:    deref(r.Framework),
+		Functions:    r.Functions,
+		Headers: sdk.Headers{
+			Env:      deref(r.Env),
+			Platform: deref(r.Platform),
+		},
+		SDK: fmt.Sprintf("%s:%s", r.SDKLanguage, r.SDKVersion),
+		URL: r.URL,
+	}
+	_ = req.Normalize(false)
+	return req
+}
+
+// capabilities is best-effort: zero value when absent or malformed.
+func (r *Response) capabilities() sdk.Capabilities {
+	raw, ok := r.Inspection["capabilities"]
+	if !ok {
+		return sdk.Capabilities{}
+	}
+	byt, err := json.Marshal(raw)
+	if err != nil {
+		return sdk.Capabilities{}
+	}
+	var caps sdk.Capabilities
+	_ = json.Unmarshal(byt, &caps)
+	return caps
+}
+
+// Sync performs an in-band sync. Exactly one return is non-nil:
+//   - *Response: success, signature-validated.
+//   - *syscode.Error: protocol-level failure (signature, non-2xx, unreachable,
+//     Cloudflare, policy). Switch on Code.
+//   - error: bug on our side (bad opts, marshaling).
+func Sync(ctx context.Context, opts Opts) (*Response, *syscode.Error, error) {
+	if err := opts.Validate(); err != nil {
+		return nil, nil, err
+	}
+	if syscodeErr := checkScheme(opts.URL, opts.AllowInsecureHTTP); syscodeErr != nil {
+		return nil, syscodeErr, nil
+	}
+
+	serverKind := opts.ServerKind
+	if serverKind == "" {
+		serverKind = headers.ServerKindCloud
+	}
+
+	client := opts.HTTPClient
+	if client == nil {
+		client = newClient(opts)
+	}
+
+	reqByt, err := json.Marshal(map[string]string{"url": opts.URL})
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPut,
+		opts.URL,
+		bytes.NewReader(reqByt),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set(headers.HeaderContentType, "application/json")
+	req.Header.Set(headers.HeaderKeyServerKind, serverKind)
+	req.Header.Set(inngestgo.HeaderKeySyncKind, inngestgo.SyncKindInBand)
+
+	sig, err := inngestgo.Sign(ctx, time.Now(), []byte(opts.SigningKey), reqByt)
+	if err != nil {
+		return nil, nil, fmt.Errorf("sign request: %w", err)
+	}
+	req.Header.Set(headers.HeaderKeySignature, sig)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		if errors.Is(err, errRedirectDenied) {
+			return nil, &syscode.Error{
+				Code:    syscode.CodeRedirectDenied,
+				Message: "redirects are not permitted",
+			}, nil
+		}
+		// Go's dial errors include the resolved IP and lookup failure mode;
+		// don't reflect them to API callers.
+		return nil, &syscode.Error{
+			Code:    syscode.CodeHTTPUnreachable,
+			Message: "unable to reach SDK URL",
+		}, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.Header.Get("Cf-Mitigated") != "" {
+		return nil, &syscode.Error{
+			Code:    syscode.CodeCloudflareMitigated,
+			Message: "request was mitigated by cloudflare",
+			Data: syscode.DataHTTPErr{
+				Headers:    resp.Header,
+				StatusCode: resp.StatusCode,
+			}.ToMap(),
+		}, nil
+	}
+
+	// +1 distinguishes "at limit" from "over limit".
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
+	if err != nil {
+		return nil, &syscode.Error{
+			Code:    syscode.CodeHTTPUnreachable,
+			Message: "failed to read SDK response body",
+		}, nil
+	}
+	if len(body) > maxResponseBytes {
+		return nil, &syscode.Error{
+			Code: syscode.CodeOutputTooLarge,
+			Message: fmt.Sprintf(
+				"response body exceeds %d bytes", maxResponseBytes,
+			),
+		}, nil
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Body is pre-signature-validation and may be attacker-controlled. Do
+		// not echo it into Message; callers reflect Message to API responses.
+		return nil, &syscode.Error{
+			Code:    syscode.CodeHTTPNotOK,
+			Message: fmt.Sprintf("SDK returned non-2xx response: status=%d", resp.StatusCode),
+			Data: syscode.DataHTTPErr{
+				Headers:    resp.Header,
+				StatusCode: resp.StatusCode,
+			}.ToMap(),
+		}, nil
+	}
+
+	respSig := resp.Header.Get(headers.HeaderKeySignature)
+	if respSig == "" {
+		return nil, &syscode.Error{
+			Code: syscode.CodeHTTPMissingHeader,
+			Message: fmt.Sprintf(
+				"missing %s response header", headers.HeaderKeySignature,
+			),
+		}, nil
+	}
+
+	valid, sigErr := inngestgo.ValidateResponseSignature(
+		ctx,
+		respSig,
+		[]byte(opts.SigningKey),
+		body,
+	)
+	if sigErr != nil || !valid {
+		msg := "invalid response signature"
+		if sigErr != nil {
+			msg = sigErr.Error()
+		}
+		return nil, &syscode.Error{
+			Code:    syscode.CodeSigVerificationFailed,
+			Message: msg,
+		}, nil
+	}
+
+	var out Response
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, &syscode.Error{
+			Code:    syscode.CodeMalformedResponse,
+			Message: err.Error(),
+		}, nil
+	}
+
+	if out.AppID != opts.ExpectedAppID {
+		return nil, &syscode.Error{
+			Code:    syscode.CodeAppIDMismatch,
+			Message: fmt.Sprintf("app_id mismatch: expected %q, SDK reported %q", opts.ExpectedAppID, out.AppID),
+		}, nil
+	}
+
+	return &out, nil, nil
+}
+
+// checkScheme rejects unsupported schemes and gates http:// behind the flag.
+func checkScheme(rawURL string, allowInsecureHTTP bool) *syscode.Error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return &syscode.Error{
+			Code:    syscode.CodeURLSchemeDenied,
+			Message: fmt.Sprintf("invalid url: %s", err.Error()),
+		}
+	}
+	switch u.Scheme {
+	case "https":
+		return nil
+	case "http":
+		if !allowInsecureHTTP {
+			return &syscode.Error{
+				Code:    syscode.CodeURLSchemeDenied,
+				Message: "insecure http:// scheme not permitted",
+			}
+		}
+		return nil
+	default:
+		return &syscode.Error{
+			Code:    syscode.CodeURLSchemeDenied,
+			Message: fmt.Sprintf("unsupported url scheme %q", u.Scheme),
+		}
+	}
+}
+
+// newClient builds an HTTP client that allows private networks (single-host
+// self-hosted setups commonly run the SDK on the same box as Inngest) and
+// refuses redirects.
+func newClient(opts Opts) *http.Client {
+	transport := exechttp.Transport(exechttp.SecureDialerOpts{
+		AllowPrivate:    true,
+		AllowHostDocker: true,
+	})
+	return &http.Client{
+		Timeout:       requestTimeout,
+		Transport:     transport,
+		CheckRedirect: refuseRedirects,
+	}
+}
+
+// errRedirectDenied is returned by refuseRedirects so callers can distinguish
+// our redirect refusal from generic dial failures via errors.Is.
+var errRedirectDenied = errors.New("redirects are not permitted")
+
+// refuseRedirects: the SDK URL is canonical, and the request carries a signed
+// body we don't want forwarded cross-origin.
+func refuseRedirects(_ *http.Request, _ []*http.Request) error {
+	return errRedirectDenied
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/pkg/appsync/appsync.go
+++ b/pkg/appsync/appsync.go
@@ -236,21 +236,21 @@ func Sync(ctx context.Context, opts Opts) (*Response, *syscode.Error, error) {
 		body,
 	)
 	if sigErr != nil || !valid {
-		msg := "invalid response signature"
-		if sigErr != nil {
-			msg = sigErr.Error()
-		}
+		// Don't reflect sigErr.Error(); it distinguishes expired/invalid/bad-ts
+		// to the API caller, which is a small probe oracle on key state.
 		return nil, &syscode.Error{
 			Code:    syscode.CodeSigVerificationFailed,
-			Message: msg,
+			Message: "invalid response signature",
 		}, nil
 	}
 
 	var out Response
 	if err := json.Unmarshal(body, &out); err != nil {
+		// json error strings can include byte offsets and raw token bytes from
+		// the body; keep them out of the public message.
 		return nil, &syscode.Error{
 			Code:    syscode.CodeMalformedResponse,
-			Message: err.Error(),
+			Message: "failed to parse SDK response",
 		}, nil
 	}
 

--- a/pkg/appsync/appsync.go
+++ b/pkg/appsync/appsync.go
@@ -86,9 +86,9 @@ func (r *Response) Validate(expectedAppID string) *syscode.Error {
 	}
 	if r.AppID != expectedAppID {
 		return &syscode.Error{
-			Code: syscode.CodeAppIDMismatch,
+			Code: syscode.CodeAppMismatch,
 			Message: fmt.Sprintf(
-				"app_id mismatch: expected %q, SDK reported %q",
+				"expected app ID %s, got %s",
 				expectedAppID,
 				r.AppID,
 			),

--- a/pkg/appsync/appsync.go
+++ b/pkg/appsync/appsync.go
@@ -80,6 +80,33 @@ type Response struct {
 	URL         string            `json:"url"`
 }
 
+func (r *Response) Validate(expectedAppID string) *syscode.Error {
+	if r.AppID == "" {
+		return malformedResponse("missing app_id")
+	}
+	if r.AppID != expectedAppID {
+		return &syscode.Error{
+			Code: syscode.CodeAppIDMismatch,
+			Message: fmt.Sprintf(
+				"app_id mismatch: expected %q, SDK reported %q",
+				expectedAppID,
+				r.AppID,
+			),
+		}
+	}
+	if r.URL == "" {
+		return malformedResponse("missing url")
+	}
+	parsedURL, err := url.Parse(r.URL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return malformedResponse("invalid url")
+	}
+	if r.Functions == nil {
+		return malformedResponse("missing functions")
+	}
+	return nil
+}
+
 // ToRegisterRequest returns a normalized RegisterRequest so checksums match
 // the /fn/register pipeline.
 func (r *Response) ToRegisterRequest() *sdk.RegisterRequest {
@@ -254,14 +281,18 @@ func Sync(ctx context.Context, opts Opts) (*Response, *syscode.Error, error) {
 		}, nil
 	}
 
-	if out.AppID != opts.ExpectedAppID {
-		return nil, &syscode.Error{
-			Code:    syscode.CodeAppIDMismatch,
-			Message: fmt.Sprintf("app_id mismatch: expected %q, SDK reported %q", opts.ExpectedAppID, out.AppID),
-		}, nil
+	if syscodeErr := out.Validate(opts.ExpectedAppID); syscodeErr != nil {
+		return nil, syscodeErr, nil
 	}
 
 	return &out, nil, nil
+}
+
+func malformedResponse(message string) *syscode.Error {
+	return &syscode.Error{
+		Code:    syscode.CodeMalformedResponse,
+		Message: message,
+	}
 }
 
 // checkScheme rejects unsupported schemes and gates http:// behind the flag.

--- a/pkg/appsync/appsync_test.go
+++ b/pkg/appsync/appsync_test.go
@@ -23,8 +23,30 @@ import (
 
 const testSigningKey = "signkey-test-deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 
-// signResponse mirrors the SDK's signWithoutJCS.
-func signResponse(t *testing.T, body []byte, key string) string {
+// realSDKHandler returns an httptest.Server backed by a real inngestgo
+// handler with in-band sync enabled. The handler signs responses with the
+// production code path, so the success-path tests exercise actual signing
+// rather than a hand-rolled HMAC.
+func realSDKHandler(t *testing.T) *httptest.Server {
+	t.Helper()
+	allow := true
+	dev := false
+	sk := testSigningKey
+	client, err := inngestgo.NewClient(inngestgo.ClientOpts{
+		AppID:           "my-app",
+		SigningKey:      &sk,
+		AllowInBandSync: &allow,
+		Dev:             &dev,
+	})
+	require.NoError(t, err)
+	return httptest.NewServer(client.Serve())
+}
+
+// hmacSignResponse mirrors inngestgo's signWithoutJCS. Used only by tests
+// that intentionally produce a signature outside the production code path:
+// signing with a different key, or signing a deliberately malformed body
+// (where JCS would refuse). Other tests should drive realSDKHandler.
+func hmacSignResponse(t *testing.T, body []byte, key string) string {
 	t.Helper()
 	keyBytes := regexp.MustCompile(`^signkey-\w+-`).ReplaceAll([]byte(key), nil)
 	ts := time.Now().Unix()
@@ -32,50 +54,6 @@ func signResponse(t *testing.T, body []byte, key string) string {
 	_, _ = mac.Write(body)
 	_, _ = fmt.Fprintf(mac, "%d", ts)
 	return fmt.Sprintf("t=%d&s=%s", ts, hex.EncodeToString(mac.Sum(nil)))
-}
-
-func sampleResponseBody(t *testing.T) []byte {
-	t.Helper()
-	env := "production"
-	platform := "vercel"
-	resp := Response{
-		AppID:       "my-app",
-		Env:         &env,
-		Platform:    &platform,
-		SDKAuthor:   "inngest",
-		SDKLanguage: "go",
-		SDKVersion:  "0.7.0",
-		URL:         "https://example.com/api/inngest",
-		Functions:   []sdk.SDKFunction{},
-		Inspection: map[string]any{
-			"capabilities": map[string]any{
-				"in_band_sync": "v1",
-				"trust_probe":  "v1",
-				"connect":      "v1",
-			},
-		},
-	}
-	byt, err := json.Marshal(resp)
-	require.NoError(t, err, "marshal sample response")
-	return byt
-}
-
-// inBandHandler returns a fake SDK server. customize runs after defaults are
-// set, so it can also override (including with empty values).
-func inBandHandler(t *testing.T, customize func(w http.ResponseWriter, body *[]byte)) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodPut, r.Method)
-		body := sampleResponseBody(t)
-		w.Header().Set(headers.HeaderKeySignature, signResponse(t, body, testSigningKey))
-		w.Header().Set(inngestgo.HeaderKeySyncKind, inngestgo.SyncKindInBand)
-		w.Header().Set(headers.HeaderKeySDK, "go:0.7.0")
-		if customize != nil {
-			customize(w, &body)
-		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(body)
-	}))
 }
 
 func assertSyscode(t *testing.T, syscodeErr *syscode.Error, err error, wantCode string) {
@@ -88,7 +66,7 @@ func assertSyscode(t *testing.T, syscodeErr *syscode.Error, err error, wantCode 
 func TestSync(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		r := require.New(t)
-		srv := inBandHandler(t, nil)
+		srv := realSDKHandler(t)
 		defer srv.Close()
 
 		resp, syscodeErr, err := Sync(context.Background(), Opts{
@@ -102,11 +80,15 @@ func TestSync(t *testing.T) {
 		r.Nil(syscodeErr)
 		r.NotNil(resp)
 		r.Equal("my-app", resp.AppID)
-		r.Equal("go", resp.SDKLanguage)
-		r.Equal("0.7.0", resp.SDKVersion)
+		r.Equal(inngestgo.SDKLanguage, resp.SDKLanguage)
+		r.Equal(inngestgo.SDKVersion, resp.SDKVersion)
 	})
 
 	t.Run("sends required request headers", func(t *testing.T) {
+		// Capture the request headers/body the handler receives. We don't
+		// need a real signed response — Sync's request-side behavior is what
+		// we're verifying, so a minimal handler that doesn't return a body
+		// is enough; we ignore Sync's resulting error.
 		r := require.New(t)
 		var got struct {
 			serverKind string
@@ -119,24 +101,17 @@ func TestSync(t *testing.T) {
 			got.syncKind = req.Header.Get(inngestgo.HeaderKeySyncKind)
 			got.signature = req.Header.Get(headers.HeaderKeySignature)
 			got.body, _ = io.ReadAll(req.Body)
-
-			body := sampleResponseBody(t)
-			w.Header().Set(headers.HeaderKeySignature, signResponse(t, body, testSigningKey))
-			w.Header().Set(inngestgo.HeaderKeySyncKind, inngestgo.SyncKindInBand)
-			w.Header().Set(headers.HeaderKeySDK, "go:0.7.0")
-			_, _ = w.Write(body)
+			w.WriteHeader(http.StatusOK)
 		}))
 		defer srv.Close()
 
-		_, syscodeErr, err := Sync(context.Background(), Opts{
+		_, _, _ = Sync(context.Background(), Opts{
 			URL:               srv.URL,
 			SigningKey:        testSigningKey,
 			ExpectedAppID:     "my-app",
 			AllowInsecureHTTP: true,
 			HTTPClient:        srv.Client(),
 		})
-		r.NoError(err)
-		r.Nil(syscodeErr)
 
 		r.Equal(headers.ServerKindCloud, got.serverKind)
 		r.Equal(inngestgo.SyncKindInBand, got.syncKind)
@@ -152,14 +127,11 @@ func TestSync(t *testing.T) {
 		var got string
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			got = req.Header.Get(headers.HeaderKeyServerKind)
-			body := sampleResponseBody(t)
-			w.Header().Set(headers.HeaderKeySignature, signResponse(t, body, testSigningKey))
-			w.Header().Set(inngestgo.HeaderKeySyncKind, inngestgo.SyncKindInBand)
-			_, _ = w.Write(body)
+			w.WriteHeader(http.StatusOK)
 		}))
 		defer srv.Close()
 
-		_, syscodeErr, err := Sync(context.Background(), Opts{
+		_, _, _ = Sync(context.Background(), Opts{
 			URL:               srv.URL,
 			SigningKey:        testSigningKey,
 			ServerKind:        headers.ServerKindDev,
@@ -167,15 +139,14 @@ func TestSync(t *testing.T) {
 			AllowInsecureHTTP: true,
 			HTTPClient:        srv.Client(),
 		})
-		r.NoError(err)
-		r.Nil(syscodeErr)
 		r.Equal(headers.ServerKindDev, got)
 	})
 
 	t.Run("missing response signature", func(t *testing.T) {
-		srv := inBandHandler(t, func(w http.ResponseWriter, _ *[]byte) {
-			w.Header().Set(headers.HeaderKeySignature, "")
-		})
+		// Real handler would set the sig; strip it on the way out via a
+		// proxying handler that lets the request hit the SDK but rewrites
+		// the response.
+		srv := stripResponseSig(t, realSDKHandler(t))
 		defer srv.Close()
 
 		_, syscodeErr, err := Sync(context.Background(), Opts{
@@ -189,9 +160,7 @@ func TestSync(t *testing.T) {
 	})
 
 	t.Run("invalid response signature", func(t *testing.T) {
-		srv := inBandHandler(t, func(w http.ResponseWriter, _ *[]byte) {
-			w.Header().Set(headers.HeaderKeySignature, fmt.Sprintf("t=%d&s=cafebabe", time.Now().Unix()))
-		})
+		srv := overrideResponseSig(t, realSDKHandler(t), fmt.Sprintf("t=%d&s=cafebabe", time.Now().Unix()))
 		defer srv.Close()
 
 		_, syscodeErr, err := Sync(context.Background(), Opts{
@@ -205,10 +174,15 @@ func TestSync(t *testing.T) {
 	})
 
 	t.Run("response signature with different key", func(t *testing.T) {
+		// Hand-rolled HMAC: by definition we want a sig produced under a
+		// different key than the validator uses.
 		otherKey := "signkey-test-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-		srv := inBandHandler(t, func(w http.ResponseWriter, body *[]byte) {
-			w.Header().Set(headers.HeaderKeySignature, signResponse(t, *body, otherKey))
-		})
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			body := []byte(`{"app_id":"my-app","sdk_language":"go","sdk_version":"0.0.0","url":"http://x/api/inngest","functions":[]}`)
+			w.Header().Set(headers.HeaderKeySignature, hmacSignResponse(t, body, otherKey))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
 		defer srv.Close()
 
 		_, syscodeErr, err := Sync(context.Background(), Opts{
@@ -265,9 +239,11 @@ func TestSync(t *testing.T) {
 	})
 
 	t.Run("malformed body", func(t *testing.T) {
+		// Hand-rolled HMAC: invalid JSON can't go through inngestgo.Sign
+		// because JCS canonicalization would refuse to parse it.
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			body := []byte(`{not valid json`)
-			w.Header().Set(headers.HeaderKeySignature, signResponse(t, body, testSigningKey))
+			w.Header().Set(headers.HeaderKeySignature, hmacSignResponse(t, body, testSigningKey))
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(body)
 		}))
@@ -285,7 +261,6 @@ func TestSync(t *testing.T) {
 
 	t.Run("body too large", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set(inngestgo.HeaderKeySyncKind, inngestgo.SyncKindInBand)
 			w.Header().Set(headers.HeaderKeySignature, "t=0&s=00")
 			w.WriteHeader(http.StatusOK)
 			// Size check runs before signature/parse, so content isn't validated.
@@ -380,7 +355,7 @@ func TestSync(t *testing.T) {
 
 	t.Run("succeeds against loopback (built-in client)", func(t *testing.T) {
 		r := require.New(t)
-		srv := inBandHandler(t, nil)
+		srv := realSDKHandler(t)
 		defer srv.Close()
 
 		resp, syscodeErr, err := Sync(context.Background(), Opts{
@@ -414,8 +389,8 @@ func TestSync(t *testing.T) {
 
 	t.Run("ExpectedAppID mismatch", func(t *testing.T) {
 		r := require.New(t)
-		// sampleResponseBody reports AppID "my-app"; expect "other-app".
-		srv := inBandHandler(t, nil)
+		// Real SDK handler reports AppID "my-app"; expect "other-app".
+		srv := realSDKHandler(t)
 		defer srv.Close()
 
 		_, syscodeErr, err := Sync(context.Background(), Opts{
@@ -430,6 +405,74 @@ func TestSync(t *testing.T) {
 		r.Contains(syscodeErr.Message, "my-app")
 	})
 
+}
+
+// stripResponseSig wraps an httptest.Server in a proxy that forwards the
+// request to the inner server but removes the X-Inngest-Signature response
+// header before writing it to the caller.
+func stripResponseSig(t *testing.T, inner *httptest.Server) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyTo(t, inner, w, r, func(h http.Header) {
+			h.Del(headers.HeaderKeySignature)
+		})
+	}))
+}
+
+// overrideResponseSig wraps an httptest.Server in a proxy that forwards the
+// request to the inner server and replaces the X-Inngest-Signature response
+// header with the given value.
+func overrideResponseSig(t *testing.T, inner *httptest.Server, sig string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxyTo(t, inner, w, r, func(h http.Header) {
+			h.Set(headers.HeaderKeySignature, sig)
+		})
+	}))
+}
+
+func proxyTo(t *testing.T, inner *httptest.Server, w http.ResponseWriter, r *http.Request, mutateHeaders func(http.Header)) {
+	t.Helper()
+	body, _ := io.ReadAll(r.Body)
+	req, err := http.NewRequest(r.Method, inner.URL+r.URL.Path, bytesReader(body))
+	require.NoError(t, err)
+	for k, vs := range r.Header {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	resp, err := inner.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	mutateHeaders(w.Header())
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+func bytesReader(b []byte) io.Reader {
+	if len(b) == 0 {
+		return http.NoBody
+	}
+	return &readCloserBytes{b: b}
+}
+
+type readCloserBytes struct {
+	b []byte
+	i int
+}
+
+func (r *readCloserBytes) Read(p []byte) (int, error) {
+	if r.i >= len(r.b) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.b[r.i:])
+	r.i += n
+	return n, nil
 }
 
 func TestResponse(t *testing.T) {
@@ -485,7 +528,7 @@ func TestResponse(t *testing.T) {
 
 	t.Run("ToRegisterRequest normalizes URLs", func(t *testing.T) {
 		r := require.New(t)
-		// 127.0.0.1 → localhost, :80 stripped, step URLs same.
+		// 127.0.0.1 to localhost, :80 stripped, step URLs same.
 		resp := &Response{
 			AppID:       "app-1",
 			SDKLanguage: "go",

--- a/pkg/appsync/appsync_test.go
+++ b/pkg/appsync/appsync_test.go
@@ -1,0 +1,523 @@
+package appsync
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/headers"
+	"github.com/inngest/inngest/pkg/sdk"
+	"github.com/inngest/inngest/pkg/syscode"
+	"github.com/inngest/inngestgo"
+	"github.com/stretchr/testify/require"
+)
+
+const testSigningKey = "signkey-test-deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+// signResponse mirrors the SDK's signWithoutJCS.
+func signResponse(t *testing.T, body []byte, key string) string {
+	t.Helper()
+	keyBytes := regexp.MustCompile(`^signkey-\w+-`).ReplaceAll([]byte(key), nil)
+	ts := time.Now().Unix()
+	mac := hmac.New(sha256.New, keyBytes)
+	_, _ = mac.Write(body)
+	_, _ = fmt.Fprintf(mac, "%d", ts)
+	return fmt.Sprintf("t=%d&s=%s", ts, hex.EncodeToString(mac.Sum(nil)))
+}
+
+func sampleResponseBody(t *testing.T) []byte {
+	t.Helper()
+	env := "production"
+	platform := "vercel"
+	resp := Response{
+		AppID:       "my-app",
+		Env:         &env,
+		Platform:    &platform,
+		SDKAuthor:   "inngest",
+		SDKLanguage: "go",
+		SDKVersion:  "0.7.0",
+		URL:         "https://example.com/api/inngest",
+		Functions:   []sdk.SDKFunction{},
+		Inspection: map[string]any{
+			"capabilities": map[string]any{
+				"in_band_sync": "v1",
+				"trust_probe":  "v1",
+				"connect":      "v1",
+			},
+		},
+	}
+	byt, err := json.Marshal(resp)
+	require.NoError(t, err, "marshal sample response")
+	return byt
+}
+
+// inBandHandler returns a fake SDK server. customize runs after defaults are
+// set, so it can also override (including with empty values).
+func inBandHandler(t *testing.T, customize func(w http.ResponseWriter, body *[]byte)) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPut, r.Method)
+		body := sampleResponseBody(t)
+		w.Header().Set(headers.HeaderKeySignature, signResponse(t, body, testSigningKey))
+		w.Header().Set(inngestgo.HeaderKeySyncKind, inngestgo.SyncKindInBand)
+		w.Header().Set(headers.HeaderKeySDK, "go:0.7.0")
+		if customize != nil {
+			customize(w, &body)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+}
+
+func assertSyscode(t *testing.T, syscodeErr *syscode.Error, err error, wantCode string) {
+	t.Helper()
+	require.NoError(t, err, "unexpected system error")
+	require.NotNil(t, syscodeErr, "expected syscode.Error with code %q, got nil", wantCode)
+	require.Equal(t, wantCode, syscodeErr.Code, "syscode mismatch (msg=%q)", syscodeErr.Message)
+}
+
+func TestSync(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		r := require.New(t)
+		srv := inBandHandler(t, nil)
+		defer srv.Close()
+
+		resp, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+			HTTPClient:        srv.Client(),
+		})
+		r.NoError(err)
+		r.Nil(syscodeErr)
+		r.NotNil(resp)
+		r.Equal("my-app", resp.AppID)
+		r.Equal("go", resp.SDKLanguage)
+		r.Equal("0.7.0", resp.SDKVersion)
+	})
+
+	t.Run("sends required request headers", func(t *testing.T) {
+		r := require.New(t)
+		var got struct {
+			serverKind string
+			syncKind   string
+			signature  string
+			body       []byte
+		}
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			got.serverKind = req.Header.Get(headers.HeaderKeyServerKind)
+			got.syncKind = req.Header.Get(inngestgo.HeaderKeySyncKind)
+			got.signature = req.Header.Get(headers.HeaderKeySignature)
+			got.body, _ = io.ReadAll(req.Body)
+
+			body := sampleResponseBody(t)
+			w.Header().Set(headers.HeaderKeySignature, signResponse(t, body, testSigningKey))
+			w.Header().Set(inngestgo.HeaderKeySyncKind, inngestgo.SyncKindInBand)
+			w.Header().Set(headers.HeaderKeySDK, "go:0.7.0")
+			_, _ = w.Write(body)
+		}))
+		defer srv.Close()
+
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+			HTTPClient:        srv.Client(),
+		})
+		r.NoError(err)
+		r.Nil(syscodeErr)
+
+		r.Equal(headers.ServerKindCloud, got.serverKind)
+		r.Equal(inngestgo.SyncKindInBand, got.syncKind)
+		r.NotEmpty(got.signature, "expected signed request")
+
+		var bodyParsed map[string]string
+		r.NoError(json.Unmarshal(got.body, &bodyParsed))
+		r.Equal(srv.URL, bodyParsed["url"])
+	})
+
+	t.Run("respects ServerKind opt", func(t *testing.T) {
+		r := require.New(t)
+		var got string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			got = req.Header.Get(headers.HeaderKeyServerKind)
+			body := sampleResponseBody(t)
+			w.Header().Set(headers.HeaderKeySignature, signResponse(t, body, testSigningKey))
+			w.Header().Set(inngestgo.HeaderKeySyncKind, inngestgo.SyncKindInBand)
+			_, _ = w.Write(body)
+		}))
+		defer srv.Close()
+
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ServerKind:        headers.ServerKindDev,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+			HTTPClient:        srv.Client(),
+		})
+		r.NoError(err)
+		r.Nil(syscodeErr)
+		r.Equal(headers.ServerKindDev, got)
+	})
+
+	t.Run("missing response signature", func(t *testing.T) {
+		srv := inBandHandler(t, func(w http.ResponseWriter, _ *[]byte) {
+			w.Header().Set(headers.HeaderKeySignature, "")
+		})
+		defer srv.Close()
+
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+			HTTPClient:        srv.Client(),
+		})
+		assertSyscode(t, syscodeErr, err, syscode.CodeHTTPMissingHeader)
+	})
+
+	t.Run("invalid response signature", func(t *testing.T) {
+		srv := inBandHandler(t, func(w http.ResponseWriter, _ *[]byte) {
+			w.Header().Set(headers.HeaderKeySignature, fmt.Sprintf("t=%d&s=cafebabe", time.Now().Unix()))
+		})
+		defer srv.Close()
+
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+			HTTPClient:        srv.Client(),
+		})
+		assertSyscode(t, syscodeErr, err, syscode.CodeSigVerificationFailed)
+	})
+
+	t.Run("response signature with different key", func(t *testing.T) {
+		otherKey := "signkey-test-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		srv := inBandHandler(t, func(w http.ResponseWriter, body *[]byte) {
+			w.Header().Set(headers.HeaderKeySignature, signResponse(t, *body, otherKey))
+		})
+		defer srv.Close()
+
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+			HTTPClient:        srv.Client(),
+		})
+		assertSyscode(t, syscodeErr, err, syscode.CodeSigVerificationFailed)
+	})
+
+	t.Run("non-2xx response", func(t *testing.T) {
+		r := require.New(t)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"secret":"do-not-leak"}`))
+		}))
+		defer srv.Close()
+
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+			HTTPClient:        srv.Client(),
+		})
+		assertSyscode(t, syscodeErr, err, syscode.CodeHTTPNotOK)
+
+		// Upstream body must not leak into Message (callers reflect Message
+		// to API responses).
+		r.Equal("SDK returned non-2xx response: status=500", syscodeErr.Message)
+
+		data, ok := syscodeErr.Data.(map[string]any)
+		r.True(ok, "Data = %T, want map[string]any", syscodeErr.Data)
+		r.Equal(500, data["status_code"])
+	})
+
+	t.Run("Cf-Mitigated", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Cf-Mitigated", "challenge")
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer srv.Close()
+
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+			HTTPClient:        srv.Client(),
+		})
+		assertSyscode(t, syscodeErr, err, syscode.CodeCloudflareMitigated)
+	})
+
+	t.Run("malformed body", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			body := []byte(`{not valid json`)
+			w.Header().Set(headers.HeaderKeySignature, signResponse(t, body, testSigningKey))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer srv.Close()
+
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+			HTTPClient:        srv.Client(),
+		})
+		assertSyscode(t, syscodeErr, err, syscode.CodeMalformedResponse)
+	})
+
+	t.Run("body too large", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set(inngestgo.HeaderKeySyncKind, inngestgo.SyncKindInBand)
+			w.Header().Set(headers.HeaderKeySignature, "t=0&s=00")
+			w.WriteHeader(http.StatusOK)
+			// Size check runs before signature/parse, so content isn't validated.
+			buf := make([]byte, 1024*1024)
+			for i := 0; i < (maxResponseBytes/len(buf))+2; i++ {
+				if _, err := w.Write(buf); err != nil {
+					return
+				}
+			}
+		}))
+		defer srv.Close()
+
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+			HTTPClient:        srv.Client(),
+		})
+		assertSyscode(t, syscodeErr, err, syscode.CodeOutputTooLarge)
+	})
+
+	t.Run("unreachable", func(t *testing.T) {
+		r := require.New(t)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+		url := srv.URL
+		srv.Close() // shut it down so the dial fails
+
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               url,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+		})
+		assertSyscode(t, syscodeErr, err, syscode.CodeHTTPUnreachable)
+		r.Equal("unable to reach SDK URL", syscodeErr.Message)
+	})
+
+	t.Run("requires expected app ID", func(t *testing.T) {
+		r := require.New(t)
+		resp, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:        "https://example.com",
+			SigningKey: testSigningKey,
+		})
+		r.Nil(resp)
+		r.Nil(syscodeErr)
+		r.ErrorIs(err, ErrMissingExpectedAppID)
+	})
+
+	t.Run("requires URL", func(t *testing.T) {
+		r := require.New(t)
+		resp, syscodeErr, err := Sync(context.Background(), Opts{
+			SigningKey:    testSigningKey,
+			ExpectedAppID: "my-app",
+		})
+		r.Nil(resp)
+		r.Nil(syscodeErr)
+		r.ErrorIs(err, ErrMissingURL)
+	})
+
+	t.Run("requires signing key", func(t *testing.T) {
+		r := require.New(t)
+		resp, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:           "https://example.com",
+			ExpectedAppID: "my-app",
+		})
+		r.Nil(resp)
+		r.Nil(syscodeErr)
+		r.ErrorIs(err, ErrMissingSigningKey)
+	})
+
+	t.Run("rejects insecure HTTP by default", func(t *testing.T) {
+		r := require.New(t)
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:           "http://example.com",
+			SigningKey:    testSigningKey,
+			ExpectedAppID: "my-app",
+		})
+		assertSyscode(t, syscodeErr, err, syscode.CodeURLSchemeDenied)
+		r.Equal("insecure http:// scheme not permitted", syscodeErr.Message)
+	})
+
+	t.Run("rejects unsupported scheme", func(t *testing.T) {
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               "ftp://example.com",
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true, // ftp is rejected regardless
+		})
+		assertSyscode(t, syscodeErr, err, syscode.CodeURLSchemeDenied)
+	})
+
+	t.Run("succeeds against loopback (built-in client)", func(t *testing.T) {
+		r := require.New(t)
+		srv := inBandHandler(t, nil)
+		defer srv.Close()
+
+		resp, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+		})
+		r.NoError(err)
+		r.Nil(syscodeErr)
+		r.NotNil(resp)
+		r.Equal("my-app", resp.AppID)
+	})
+
+	t.Run("refuses redirects", func(t *testing.T) {
+		r := require.New(t)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Redirect(w, &http.Request{}, "https://example.com/elsewhere", http.StatusFound)
+		}))
+		defer srv.Close()
+
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+		})
+		assertSyscode(t, syscodeErr, err, syscode.CodeRedirectDenied)
+		r.Equal("redirects are not permitted", syscodeErr.Message)
+	})
+
+	t.Run("ExpectedAppID mismatch", func(t *testing.T) {
+		r := require.New(t)
+		// sampleResponseBody reports AppID "my-app"; expect "other-app".
+		srv := inBandHandler(t, nil)
+		defer srv.Close()
+
+		_, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "other-app",
+			AllowInsecureHTTP: true,
+			HTTPClient:        srv.Client(),
+		})
+		assertSyscode(t, syscodeErr, err, syscode.CodeAppIDMismatch)
+		r.Contains(syscodeErr.Message, "other-app")
+		r.Contains(syscodeErr.Message, "my-app")
+	})
+
+}
+
+func TestResponse(t *testing.T) {
+	t.Run("ToRegisterRequest", func(t *testing.T) {
+		r := require.New(t)
+		env := "staging"
+		framework := "express"
+		platform := "fly"
+		resp := &Response{
+			AppID:       "app-1",
+			Env:         &env,
+			Framework:   &framework,
+			Platform:    &platform,
+			SDKLanguage: "go",
+			SDKVersion:  "1.2.3",
+			URL:         "https://example.com/api/inngest",
+			Functions:   []sdk.SDKFunction{{Name: "fn"}},
+			Inspection: map[string]any{
+				"capabilities": map[string]any{
+					"in_band_sync": "v1",
+					"trust_probe":  "v1",
+					"connect":      "v1",
+				},
+			},
+		}
+
+		req := resp.ToRegisterRequest()
+		r.Equal("app-1", req.AppName)
+		r.Equal("go:1.2.3", req.SDK)
+		r.Equal(env, req.Headers.Env)
+		r.Equal(platform, req.Headers.Platform)
+		r.Equal(framework, req.Framework)
+		r.Equal(resp.URL, req.URL)
+		r.Len(req.Functions, 1)
+		r.Equal("fn", req.Functions[0].Name)
+		r.Equal(sdk.Capabilities{InBandSync: "v1", TrustProbe: "v1", Connect: "v1"}, req.Capabilities)
+	})
+
+	t.Run("ToRegisterRequest with nil optionals", func(t *testing.T) {
+		r := require.New(t)
+		resp := &Response{
+			AppID:       "app-1",
+			SDKLanguage: "go",
+			SDKVersion:  "1.0.0",
+			URL:         "https://example.com",
+		}
+		req := resp.ToRegisterRequest()
+		r.Empty(req.Headers.Env)
+		r.Empty(req.Headers.Platform)
+		r.Empty(req.Framework)
+		r.Equal(sdk.Capabilities{}, req.Capabilities)
+	})
+
+	t.Run("ToRegisterRequest normalizes URLs", func(t *testing.T) {
+		r := require.New(t)
+		// 127.0.0.1 → localhost, :80 stripped, step URLs same.
+		resp := &Response{
+			AppID:       "app-1",
+			SDKLanguage: "go",
+			SDKVersion:  "1.0.0",
+			URL:         "http://127.0.0.1:80/api/inngest",
+			Functions: []sdk.SDKFunction{{
+				Name: "fn",
+				Steps: map[string]sdk.SDKStep{
+					"step": {Runtime: map[string]any{"url": "http://127.0.0.1:80/api/inngest?fnId=1"}},
+				},
+			}},
+		}
+		req := resp.ToRegisterRequest()
+		r.Equal("http://localhost/api/inngest", req.URL)
+		stepURL, _ := req.Functions[0].Steps["step"].Runtime["url"].(string)
+		r.Equal("http://localhost/api/inngest?fnId=1", stepURL)
+	})
+
+	t.Run("capabilities absent or malformed", func(t *testing.T) {
+		cases := []struct {
+			name string
+			insp map[string]any
+		}{
+			{"nil inspection", nil},
+			{"missing capabilities", map[string]any{"other": 1}},
+			{"non-object capabilities", map[string]any{"capabilities": "nope"}},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				resp := &Response{Inspection: tc.insp}
+				require.Equal(t, sdk.Capabilities{}, resp.capabilities())
+			})
+		}
+	})
+}

--- a/pkg/appsync/appsync_test.go
+++ b/pkg/appsync/appsync_test.go
@@ -259,6 +259,62 @@ func TestSync(t *testing.T) {
 		assertSyscode(t, syscodeErr, err, syscode.CodeMalformedResponse)
 	})
 
+	t.Run("signed response missing required fields", func(t *testing.T) {
+		r := require.New(t)
+		// A valid signature proves authenticity, but the signed response still
+		// needs schema validation before it can become a RegisterRequest.
+		body := []byte(`{"app_id":"my-app"}`)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set(headers.HeaderKeySignature, hmacSignResponse(t, body, testSigningKey))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer srv.Close()
+
+		resp, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+			HTTPClient:        srv.Client(),
+		})
+		r.Nil(resp)
+		assertSyscode(t, syscodeErr, err, syscode.CodeMalformedResponse)
+		r.Equal("missing url", syscodeErr.Message)
+	})
+
+	t.Run("signed response allows explicit empty functions", func(t *testing.T) {
+		r := require.New(t)
+		var srv *httptest.Server
+		srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			body, err := json.Marshal(Response{
+				AppID:       "my-app",
+				Functions:   []sdk.SDKFunction{},
+				SDKAuthor:   "inngest",
+				SDKLanguage: "go",
+				SDKVersion:  "1.0.0",
+				URL:         srv.URL,
+			})
+			require.NoError(t, err)
+			w.Header().Set(headers.HeaderKeySignature, hmacSignResponse(t, body, testSigningKey))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(body)
+		}))
+		defer srv.Close()
+
+		resp, syscodeErr, err := Sync(context.Background(), Opts{
+			URL:               srv.URL,
+			SigningKey:        testSigningKey,
+			ExpectedAppID:     "my-app",
+			AllowInsecureHTTP: true,
+			HTTPClient:        srv.Client(),
+		})
+		r.NoError(err)
+		r.Nil(syscodeErr)
+		r.NotNil(resp)
+		r.Empty(resp.Functions)
+	})
+
 	t.Run("body too large", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set(headers.HeaderKeySignature, "t=0&s=00")

--- a/pkg/appsync/appsync_test.go
+++ b/pkg/appsync/appsync_test.go
@@ -456,9 +456,8 @@ func TestSync(t *testing.T) {
 			AllowInsecureHTTP: true,
 			HTTPClient:        srv.Client(),
 		})
-		assertSyscode(t, syscodeErr, err, syscode.CodeAppIDMismatch)
-		r.Contains(syscodeErr.Message, "other-app")
-		r.Contains(syscodeErr.Message, "my-app")
+		assertSyscode(t, syscodeErr, err, syscode.CodeAppMismatch)
+		r.Equal("expected app ID other-app, got my-app", syscodeErr.Message)
 	})
 
 }

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -207,13 +207,6 @@ func (a devapi) Register(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	ctx := r.Context()
 
-	// SDK-initiated sync is dev-only. `inngest start` uses the v2 SyncApp
-	// endpoint (server-initiated, in-band).
-	if a.devserver.Opts.Config.GetServerKind() == headers.ServerKindCloud {
-		_ = publicerr.WriteHTTP(w, publicerr.HTTPErr(http.StatusNotFound))
-		return
-	}
-
 	l := a.devserver.log
 	l.Debug("received register request")
 

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -207,6 +207,13 @@ func (a devapi) Register(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	ctx := r.Context()
 
+	// SDK-initiated sync is dev-only. `inngest start` uses the v2 SyncApp
+	// endpoint (server-initiated, in-band).
+	if a.devserver.Opts.Config.GetServerKind() == headers.ServerKindCloud {
+		_ = publicerr.WriteHTTP(w, publicerr.HTTPErr(http.StatusNotFound))
+		return
+	}
+
 	l := a.devserver.log
 	l.Debug("received register request")
 
@@ -216,9 +223,6 @@ func (a devapi) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	a.devserver.handlerLock.Lock()
-	defer a.devserver.handlerLock.Unlock()
-
 	req, err := sdk.FromReadCloser(r.Body, sdk.FromReadCloserOpts{})
 	if err != nil {
 		l.Warn("Invalid request", "error", err)
@@ -226,7 +230,7 @@ func (a devapi) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	reply, err := a.register(ctx, req)
+	reply, err := a.devserver.ProcessSync(ctx, req)
 	if err != nil {
 		l.Warn("error registering functions", "error", err)
 		_ = publicerr.WriteHTTP(w, err)
@@ -242,13 +246,16 @@ func (a devapi) Register(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(resp)
 }
 
-func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (*sync.Reply, error) {
+func (d *devserver) ProcessSync(ctx context.Context, r sdk.RegisterRequest) (*sync.Reply, error) {
+	d.handlerLock.Lock()
+	defer d.handlerLock.Unlock()
+
 	sum, err := r.Checksum()
 	if err != nil {
 		return nil, publicerr.Wrap(err, 400, "Invalid request")
 	}
 
-	l := a.devserver.log
+	l := d.log
 
 	// TODO Retrieve same syncID for connect, if r.IdempotencyKey is the same
 	syncID := uuid.New()
@@ -307,7 +314,7 @@ func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (*sync.Repl
 	// Iterate all apps rather than using GetAppByURL because that query
 	// returns LIMIT 1 and may find the real (named) app instead when both
 	// share the same URL.
-	allApps, err := a.devserver.Data.GetAllApps(ctx, consts.DevServerEnvID)
+	allApps, err := d.Data.GetAllApps(ctx, consts.DevServerEnvID)
 	if err != nil {
 		l.Error("error loading existing apps", err)
 	}
@@ -317,18 +324,18 @@ func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (*sync.Repl
 			if app.Name != "" || util.NormalizeAppURL(app.Url, false) != normalizedURL {
 				continue
 			}
-			fns, fnsErr := a.devserver.Data.GetFunctionsByAppInternalID(ctx, app.ID)
+			fns, fnsErr := d.Data.GetFunctionsByAppInternalID(ctx, app.ID)
 			if fnsErr == nil && len(fns) > 0 {
 				// Legacy row with attached functions — adopt the row by id
 				// rather than deleting and starting over.
 				adopt := appParams
 				adopt.ID = app.ID
-				if _, err := a.devserver.Data.UpsertApp(ctx, adopt); err != nil {
+				if _, err := d.Data.UpsertApp(ctx, adopt); err != nil {
 					l.Error("error adopting URL-keyed legacy app row", "appID", app.ID, "error", err)
 				}
 				continue
 			}
-			if err := a.devserver.Data.DeleteApp(ctx, app.ID); err != nil {
+			if err := d.Data.DeleteApp(ctx, app.ID); err != nil {
 				l.Error("error deleting app", "error", err)
 			}
 		}
@@ -340,7 +347,7 @@ func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (*sync.Repl
 			Valid:  true,
 		}
 
-		if _, err := a.devserver.Data.UpsertAppByName(ctx, appParams); err != nil {
+		if _, err := d.Data.UpsertAppByName(ctx, appParams); err != nil {
 			return nil, publicerr.Wrap(err, 500, "Error updating app error")
 		}
 
@@ -352,7 +359,7 @@ func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (*sync.Repl
 		}
 	}
 
-	if app, err := a.devserver.Data.GetAppByChecksum(ctx, consts.DevServerEnvID, sum); err == nil {
+	if app, err := d.Data.GetAppByChecksum(ctx, consts.DevServerEnvID, sum); err == nil {
 		if !app.Error.Valid {
 			// Skip registration since the app was already successfully
 			// registered.
@@ -364,7 +371,7 @@ func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (*sync.Repl
 		}
 
 		// Clear app error.
-		_, err = a.devserver.Data.UpdateAppError(
+		_, err = d.Data.UpdateAppError(
 			ctx,
 			cqrs.UpdateAppErrorParams{
 				ID:    app.ID,
@@ -379,7 +386,7 @@ func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (*sync.Repl
 	// setup a list of crons to be upserted into the queue for scheduling
 	var crons []cron.CronItem
 
-	tx, err := a.devserver.Data.WithTx(ctx)
+	tx, err := d.Data.WithTx(ctx)
 	if err != nil {
 		return nil, publicerr.Wrap(err, 500, "Error starting registration tx")
 	}
@@ -415,7 +422,7 @@ func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (*sync.Repl
 
 		// handle cron sync to system queue
 		for _, ci := range crons {
-			if err := a.devserver.CronSyncer.Sync(ctx, ci); err != nil {
+			if err := d.CronSyncer.Sync(ctx, ci); err != nil {
 				l.Error("error on triggering cron-sync", "functionID", ci.FunctionID, "cronExpr", ci.Expression, "functionVersion", ci.FunctionVersion, "error", err)
 			}
 		}
@@ -561,7 +568,7 @@ func (a devapi) register(ctx context.Context, r sdk.RegisterRequest) (*sync.Repl
 	}
 
 	// Set semaphore capacity for all fn-scoped concurrency limits after DB storage.
-	processed.SetSemaphoreCapacity(ctx, a.devserver.SemaphoreManager)
+	processed.SetSemaphoreCapacity(ctx, d.SemaphoreManager)
 
 	reply := &sync.Reply{
 		OK:       true,

--- a/pkg/devserver/api_test.go
+++ b/pkg/devserver/api_test.go
@@ -1028,23 +1028,3 @@ func TestDevEndpoint_Returns404InCloudMode(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, w.Code)
 }
 
-func TestRegisterEndpoint_Returns404InCloudMode(t *testing.T) {
-	ds := newTestDevServer(t)
-	ds.Opts = StartOpts{
-		Config: config.Config{
-			ServerKind: headers.ServerKindCloud,
-		},
-	}
-
-	noAuthMiddleware := func(next http.Handler) http.Handler { return next }
-	api := NewDevAPI(ds, DevAPIOptions{AuthMiddleware: noAuthMiddleware})
-
-	req := httptest.NewRequest("POST", "/fn/register", nil)
-	w := httptest.NewRecorder()
-	api.ServeHTTP(w, req)
-
-	require.Equal(t, http.StatusNotFound, w.Code)
-	var body map[string]any
-	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
-	require.Equal(t, float64(http.StatusNotFound), body["status"])
-}

--- a/pkg/devserver/api_test.go
+++ b/pkg/devserver/api_test.go
@@ -1027,4 +1027,3 @@ func TestDevEndpoint_Returns404InCloudMode(t *testing.T) {
 	// Should return 404
 	require.Equal(t, http.StatusNotFound, w.Code)
 }
-

--- a/pkg/devserver/api_test.go
+++ b/pkg/devserver/api_test.go
@@ -118,12 +118,8 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 	t.Run("new function starts with version 1", func(t *testing.T) {
 		// Create a test devserver with in-memory data store
 		ds := newTestDevServer(t)
-		api := &devapi{
-			devserver: ds,
-		}
-
 		// Register the app with one function
-		_, err := api.register(ctx, req)
+		_, err := ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		// Verify the function was created with version 1
@@ -137,12 +133,8 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 	t.Run("re-registering same app config does not increment version", func(t *testing.T) {
 		// Create a test devserver with in-memory data store
 		ds := newTestDevServer(t)
-		api := &devapi{
-			devserver: ds,
-		}
-
 		// Register the app with one function
-		_, err := api.register(ctx, req)
+		_, err := ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		// Verify the function was created with version 1
@@ -153,7 +145,7 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 		}
 
 		// Register the same app again
-		_, err = api.register(ctx, req)
+		_, err = ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		// Get the updated version — same config means no increment
@@ -166,10 +158,6 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 
 	t.Run("multiple re-registrations increment version correctly", func(t *testing.T) {
 		ds := newTestDevServer(t)
-		api := &devapi{
-			devserver: ds,
-		}
-
 		expectedVersions := []int{1, 2, 3, 4, 5}
 
 		// Register the function multiple times with different config
@@ -182,7 +170,7 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 			req.Functions[0] = sdkFunction1
 
 			// Re-register the app
-			_, err := api.register(ctx, req)
+			_, err := ds.ProcessSync(ctx, req)
 			require.NoError(t, err, "registration %d failed", i)
 
 			// Verify the version is incremented
@@ -196,12 +184,8 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 
 	t.Run("different functions have independent versions", func(t *testing.T) {
 		ds := newTestDevServer(t)
-		api := &devapi{
-			devserver: ds,
-		}
-
 		// First registration with a single function has version=1
-		_, err := api.register(ctx, req)
+		_, err := ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		fnVersions := getFunctionIDandVersion(t, ds, req.AppName)
@@ -214,7 +198,7 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 		// existing function bumped up to version 2
 		// new function set to version 1
 		req.Functions = []sdk.SDKFunction{sdkFunction1, sdkFunction2}
-		_, err = api.register(ctx, req)
+		_, err = ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		fnVersions = getFunctionIDandVersion(t, ds, req.AppName)
@@ -226,7 +210,7 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 
 		// Now register only function1 again, removing function2
 		req.Functions = []sdk.SDKFunction{sdkFunction1}
-		_, err = api.register(ctx, req)
+		_, err = ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		// Function1 should bumped up to version 3, function2 should be removed.
@@ -239,14 +223,10 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 	// When one function's config changes, all functions get their versions updated, even those that don't have any change in config.
 	t.Run("all function versions incremented on app sync", func(t *testing.T) {
 		ds := newTestDevServer(t)
-		api := &devapi{
-			devserver: ds,
-		}
-
 		req.Functions = []sdk.SDKFunction{sdkFunction1, sdkFunction2}
 
 		// Register the app
-		_, err := api.register(ctx, req)
+		_, err := ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		// Verify the functions were created with version 1
@@ -263,7 +243,7 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 		req.Functions[0] = sdkFunction1
 
 		// Re-Register the app
-		_, err = api.register(ctx, req)
+		_, err = ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		// Verify both functions had versions incremented even though function2 had no change in config.
@@ -276,14 +256,10 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 
 	t.Run("removing function increments versions of other functions on app sync", func(t *testing.T) {
 		ds := newTestDevServer(t)
-		api := &devapi{
-			devserver: ds,
-		}
-
 		req.Functions = []sdk.SDKFunction{sdkFunction1, sdkFunction2}
 
 		// Register the app
-		_, err := api.register(ctx, req)
+		_, err := ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		// Verify the functions were created with version 1
@@ -299,7 +275,7 @@ func TestRegister_FunctionVersionIncrement(t *testing.T) {
 		}
 
 		// Re-Register the app
-		_, err = api.register(ctx, req)
+		_, err = ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		// Verify function1 is gone and function2 is now on version=2
@@ -344,9 +320,8 @@ func TestRegister_BlockedSDKVersion(t *testing.T) {
 
 	t.Run("blocked versions are rejected and persisted as sync errors", func(t *testing.T) {
 		ds := newTestDevServer(t)
-		api := &devapi{devserver: ds}
 
-		_, err := api.register(ctx, newRequest("v3.35.0"))
+		_, err := ds.ProcessSync(ctx, newRequest("v3.35.0"))
 		require.Error(t, err)
 
 		var publicErr publicerr.Error
@@ -362,7 +337,6 @@ func TestRegister_BlockedSDKVersion(t *testing.T) {
 
 	t.Run("blocked check runs before successful checksum short circuit", func(t *testing.T) {
 		ds := newTestDevServer(t)
-		api := &devapi{devserver: ds}
 		req := newRequest("v3.35.0")
 
 		sum, err := req.Checksum()
@@ -379,7 +353,7 @@ func TestRegister_BlockedSDKVersion(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = api.register(ctx, req)
+		_, err = ds.ProcessSync(ctx, req)
 		require.Error(t, err)
 
 		var publicErr publicerr.Error
@@ -431,10 +405,9 @@ func TestRegister_CronJitterPropagation(t *testing.T) {
 	ds := newTestDevServer(t)
 	syncer := &capturingCronSyncer{}
 	ds.CronSyncer = syncer
-	api := &devapi{devserver: ds}
 
 	// register the app with a cron function that has jitter configured
-	_, err := api.register(ctx, req)
+	_, err := ds.ProcessSync(ctx, req)
 	require.NoError(t, err)
 
 	// Verify the cron item was synced
@@ -452,7 +425,7 @@ func TestRegister_CronJitterPropagation(t *testing.T) {
 	sdkFunction.Triggers[0].CronTrigger.Jitter = &updatedJitter
 	req.Functions[0] = sdkFunction
 
-	_, err = api.register(ctx, req)
+	_, err = ds.ProcessSync(ctx, req)
 	require.NoError(t, err)
 
 	// Verify the cron item was synced a second time again with the updated jitter
@@ -578,12 +551,8 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 		// 4. BUG: Two apps exist — the real one and the zombie placeholder
 
 		ds := newTestDevServer(t)
-		api := &devapi{
-			devserver: ds,
-		}
-
 		// Step 1: SDK registers the app normally
-		_, err := api.register(ctx, req)
+		_, err := ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		// Verify: one app exists
@@ -613,7 +582,7 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 
 		// Step 3: SDK re-registers with the same request (same checksum).
 		// This triggers the checksum early-return path in register().
-		_, err = api.register(ctx, req)
+		_, err = ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		// Step 4: Assert that the placeholder was cleaned up.
@@ -631,10 +600,6 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 		// placeholder should be cleaned up.
 
 		ds := newTestDevServer(t)
-		api := &devapi{
-			devserver: ds,
-		}
-
 		// Step 1: Simulate the `-u` flag creating a placeholder (pollSDKs initial loop)
 		placeholderID := inngest.DeterministicAppUUID(req.URL)
 		_, err := ds.Data.UpsertApp(ctx, cqrs.UpsertAppParams{
@@ -648,7 +613,7 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 		require.NoError(t, err)
 
 		// Step 2: SDK registers (first time — placeholder has no name, so cleanup works)
-		_, err = api.register(ctx, req)
+		_, err = ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		// Verify: one app, placeholder was cleaned up
@@ -675,7 +640,7 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 		require.Len(t, apps, 2)
 
 		// Step 4: SDK re-registers with the same checksum
-		_, err = api.register(ctx, req)
+		_, err = ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		// Step 5: Assert that the placeholder was cleaned up
@@ -695,10 +660,6 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 		// the placeholder even on the first registration.
 
 		ds := newTestDevServer(t)
-		api := &devapi{
-			devserver: ds,
-		}
-
 		// Step 1: User adds "http://myhost/api/inngest" via UI (no port).
 		// This creates a placeholder with ID based on the URL without port.
 		uiURL := "http://myhost/api/inngest"
@@ -721,7 +682,7 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 			V:         "1",
 			Functions: []sdk.SDKFunction{sdkFunction},
 		}
-		_, err = api.register(ctx, sdkReq)
+		_, err = ds.ProcessSync(ctx, sdkReq)
 		require.NoError(t, err)
 
 		// There should be exactly one app. The placeholder should have been
@@ -737,10 +698,6 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 		// should result in only one app (the last one wins).
 
 		ds := newTestDevServer(t)
-		api := &devapi{
-			devserver: ds,
-		}
-
 		// Register from URL1
 		req1 := sdk.RegisterRequest{
 			URL:       "http://localhost:3000/api/inngest",
@@ -748,7 +705,7 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 			V:         "1",
 			Functions: []sdk.SDKFunction{sdkFunction},
 		}
-		_, err := api.register(ctx, req1)
+		_, err := ds.ProcessSync(ctx, req1)
 		require.NoError(t, err)
 
 		// Register from URL2 with the same app name
@@ -758,7 +715,7 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 			V:         "1",
 			Functions: []sdk.SDKFunction{sdkFunction},
 		}
-		_, err = api.register(ctx, req2)
+		_, err = ds.ProcessSync(ctx, req2)
 		require.NoError(t, err)
 
 		// Should only have one app
@@ -772,10 +729,6 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 		ds := newTestDevServer(t)
 		sm := &capturingSemaphoreManager{}
 		ds.SemaphoreManager = sm
-		api := &devapi{
-			devserver: ds,
-		}
-
 		fn := sdkFunction
 		fn.Concurrency = &inngest.ConcurrencyLimits{
 			Fn: []inngest.FnConcurrency{
@@ -791,7 +744,7 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 			V:         "1",
 			Functions: []sdk.SDKFunction{fn},
 		}
-		_, err := api.register(ctx, req1)
+		_, err := ds.ProcessSync(ctx, req1)
 		require.NoError(t, err)
 
 		funcs, err := ds.Data.GetFunctionsByAppInternalID(ctx, inngest.DeterministicAppUUID("my-app"))
@@ -818,7 +771,7 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 			V:         "1",
 			Functions: []sdk.SDKFunction{rotatedFn},
 		}
-		_, err = api.register(ctx, req2)
+		_, err = ds.ProcessSync(ctx, req2)
 		require.NoError(t, err)
 
 		funcs, err = ds.Data.GetFunctionsByAppInternalID(ctx, inngest.DeterministicAppUUID("my-app"))
@@ -840,8 +793,6 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 		// pre-existing functions. This test pre-populates the v1.13 state and
 		// asserts adoption: legacy id is reused, function uuid is unchanged.
 		ds := newTestDevServer(t)
-		api := &devapi{devserver: ds}
-
 		legacyAppID := inngest.DeterministicAppUUID(util.NormalizeAppURL(req.URL, false))
 		nameAppID := inngest.DeterministicAppUUID(req.AppName)
 		require.NotEqual(t, legacyAppID, nameAppID, "fixture must reproduce the seed mismatch")
@@ -873,7 +824,7 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = api.register(ctx, req)
+		_, err = ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		apps, err := ds.Data.GetAllApps(ctx, consts.DevServerEnvID)
@@ -925,9 +876,8 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 
 	t.Run("fresh install with no legacy row uses name-derived ID", func(t *testing.T) {
 		ds := newTestDevServer(t)
-		api := &devapi{devserver: ds}
 
-		_, err := api.register(ctx, req)
+		_, err := ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		apps, err := ds.Data.GetAllApps(ctx, consts.DevServerEnvID)
@@ -956,7 +906,6 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 		// The fix adopts the row by id (renaming '' → r.AppName) when it
 		// has attached functions; UpsertAppByName then resolves it by name.
 		ds := newTestDevServer(t)
-		api := &devapi{devserver: ds}
 
 		legacyAppID := inngest.DeterministicAppUUID(util.NormalizeAppURL(req.URL, false))
 
@@ -987,7 +936,7 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = api.register(ctx, req)
+		_, err = ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		apps, err := ds.Data.GetAllApps(ctx, consts.DevServerEnvID)
@@ -1020,11 +969,10 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 		// UpsertAppByName must revive the archived row in place: same id,
 		// archived_at cleared, function uuid unchanged.
 		ds := newTestDevServer(t)
-		api := &devapi{devserver: ds}
 
 		// First sync to create the app + a function. The deterministic
 		// candidate id IS the row's id since this is a fresh install.
-		_, err := api.register(ctx, req)
+		_, err := ds.ProcessSync(ctx, req)
 		require.NoError(t, err)
 
 		appID := inngest.DeterministicAppUUID(req.AppName)
@@ -1040,7 +988,7 @@ func TestRegister_DuplicateAppCleanup(t *testing.T) {
 		require.Empty(t, apps, "archived row must drop out of the active listing")
 
 		// Resync with the same payload. The archived row should revive.
-		_, err = api.register(ctx, req)
+		_, err = ds.ProcessSync(ctx, req)
 		require.NoError(t, err, "resync after archive must not collide on PK")
 
 		apps, err = ds.Data.GetAllApps(ctx, consts.DevServerEnvID)
@@ -1078,4 +1026,25 @@ func TestDevEndpoint_Returns404InCloudMode(t *testing.T) {
 
 	// Should return 404
 	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestRegisterEndpoint_Returns404InCloudMode(t *testing.T) {
+	ds := newTestDevServer(t)
+	ds.Opts = StartOpts{
+		Config: config.Config{
+			ServerKind: headers.ServerKindCloud,
+		},
+	}
+
+	noAuthMiddleware := func(next http.Handler) http.Handler { return next }
+	api := NewDevAPI(ds, DevAPIOptions{AuthMiddleware: noAuthMiddleware})
+
+	req := httptest.NewRequest("POST", "/fn/register", nil)
+	w := httptest.NewRecorder()
+	api.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Equal(t, float64(http.StatusNotFound), body["status"])
 }

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -122,6 +122,11 @@ type StartOpts struct {
 	// validate responses where applicable, modelling cloud behaviour.
 	SigningKey *string `json:"-"`
 
+	// AllowInsecureHTTP permits in-band sync against http:// SDK URLs.
+	// `inngest dev` always sets this true; `inngest start` exposes it via
+	// --allow-insecure-http.
+	AllowInsecureHTTP bool `json:"-"`
+
 	// EventKey is used to authorize incoming events, ensuring they match the
 	// given key.
 	EventKeys []string `json:"-"`
@@ -717,16 +722,18 @@ func start(ctx context.Context, opts StartOpts) error {
 		return err
 	}
 
-	// Create the API v2 service handler
 	serviceOpts := apiv2.ServiceOptions{
-		SigningKeysProvider: apiv2.NewSigningKeysProvider(opts.SigningKey),
-		EventKeysProvider:   apiv2.NewEventKeysProvider(opts.EventKeys),
-		Functions:           NewFunctionProvider(dbcqrs),
-		FunctionRuns:        NewFunctionRunReader(dbcqrs),
-		RunList:             NewRunsReader(adapter.Q()),
-		FunctionTraces:      NewFunctionTraceReader(dbcqrs),
-		Executor:            exec,
-		EventPublisher:      runner,
+		SigningKeysProvider:      apiv2.NewSigningKeysProvider(opts.SigningKey),
+		EventKeysProvider:        apiv2.NewEventKeysProvider(opts.EventKeys),
+		Functions:                NewFunctionProvider(dbcqrs),
+		FunctionRuns:             NewFunctionRunReader(dbcqrs),
+		RunList:                  NewRunsReader(adapter.Q()),
+		FunctionTraces:           NewFunctionTraceReader(dbcqrs),
+		Executor:                 exec,
+		EventPublisher:           runner,
+		AppSyncer:                ds,
+		ServerKind:               opts.Config.GetServerKind(),
+		AppSyncAllowInsecureHTTP: opts.AllowInsecureHTTP,
 	}
 
 	apiv2Base := apiv2base.NewBase()

--- a/pkg/sdk/sdk.go
+++ b/pkg/sdk/sdk.go
@@ -40,7 +40,7 @@ func FromReadCloser(r io.ReadCloser, opts FromReadCloserOpts) (RegisterRequest, 
 	fr.Headers.Env = opts.Env
 	fr.Headers.Platform = opts.Platform
 
-	err = fr.normalize(opts.ForceHTTPS)
+	err = fr.Normalize(opts.ForceHTTPS)
 	if err != nil {
 		return fr, err
 	}
@@ -142,7 +142,9 @@ func (f RegisterRequest) IsConnect() bool {
 }
 
 
-func (f *RegisterRequest) normalize(forceHTTPS bool) error {
+// Normalize canonicalizes URLs so checksums match across registration entry
+// points. forceHTTPS rewrites http(s)/ws(s) to the secure variant.
+func (f *RegisterRequest) Normalize(forceHTTPS bool) error {
 	f.URL = util.NormalizeAppURL(f.URL, forceHTTPS)
 
 	for _, fn := range f.Functions {

--- a/pkg/syscode/codes.go
+++ b/pkg/syscode/codes.go
@@ -1,10 +1,12 @@
 package syscode
 
 const (
+	CodeAppIDMismatch             = "app_id_mismatch"
 	CodeBatchIfExpressionInvalid  = "batch_if_expression_invalid"
 	CodeBatchKeyExpressionInvalid = "batch_key_expression_invalid"
 	CodeBatchSizeInvalid          = "batch_size_invalid"
 	CodeBatchTimeoutInvalid       = "batch_timeout_invalid"
+	CodeCloudflareMitigated       = "cloudflare_mitigated"
 	CodeComboUnsupported          = "combo_unsupported"
 	CodeConcurrencyLimitInvalid   = "concurrency_limit_invalid"
 	CodeConfigInvalid             = "config_invalid"
@@ -13,12 +15,15 @@ const (
 	CodeHTTPMissingHeader         = "http_missing_header"
 	CodeHTTPNotOK                 = "http_not_ok"
 	CodeHTTPUnreachable           = "http_unreachable"
+	CodeMalformedResponse         = "malformed_response"
 	CodeNotSDK                    = "not_sdk"
 	CodeOutputTooLarge            = "output_too_large"
 	CodePlanUpgradeRequired       = "plan_upgrade_required"
+	CodeRedirectDenied            = "redirect_denied"
 	CodeRequestTooLong            = "request_duration_too_long"
 	CodeSigVerificationFailed     = "sig_verification_failed"
 	CodeSyncAlreadyPending        = "sync_already_pending"
+	CodeURLSchemeDenied           = "url_scheme_denied"
 	CodeUnknown                   = "unknown"
 
 	// Connect

--- a/pkg/syscode/codes.go
+++ b/pkg/syscode/codes.go
@@ -1,7 +1,7 @@
 package syscode
 
 const (
-	CodeAppIDMismatch             = "app_id_mismatch"
+	CodeAppMismatch               = "app_mismatch"
 	CodeBatchIfExpressionInvalid  = "batch_if_expression_invalid"
 	CodeBatchKeyExpressionInvalid = "batch_key_expression_invalid"
 	CodeBatchSizeInvalid          = "batch_size_invalid"

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -1049,10 +1049,10 @@ service V2 {
       responses: {
         key: "422"
         value: {
-          description: "Unprocessable Entity - sync failed. The response body is still SyncAppResponse and includes the persisted deploy plus a coded error under data.latestSync.error."
+          description: "Unprocessable Entity - sync failed."
           schema: {
             json_schema: {
-              ref: "#/definitions/v2SyncAppResponse"
+              ref: "#/definitions/v2ErrorResponse"
             }
           }
         }

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -4988,7 +4988,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05ERROR\x10\x01\x12\v\n" +
 	"\aWARNING\x10\x02\x12\b\n" +
-	"\x04INFO\x10\x032\xd8k\n" +
+	"\x04INFO\x10\x032\xd6j\n" +
 	"\x02V2\x12\xbc\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\x82\x02\x92A\xef\x01\n" +
 	"\bInternal\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
@@ -5248,8 +5248,8 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x04Beta\x12\x0eGet event runs\x1a1Lists function runs triggered by a specific eventb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x19\x12\x17/events/{event_id}/runs\x12\xca\x06\n" +
-	"\aSyncApp\x12\x16.api.v2.SyncAppRequest\x1a\x17.api.v2.SyncAppResponse\"\x8d\x06\x92A\xea\x05\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x19\x12\x17/events/{event_id}/runs\x12\xc8\x05\n" +
+	"\aSyncApp\x12\x16.api.v2.SyncAppRequest\x1a\x17.api.v2.SyncAppResponse\"\x8b\x05\x92A\xe8\x04\n" +
 	"\x04Apps\n" +
 	"\x04Beta\x12\bSync app\x1a Sync an app at the provided URL.JE\n" +
 	"\x03200\x12>\n" +
@@ -5266,10 +5266,10 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJM\n" +
 	"\x03404\x12F\n" +
 	"!Not Found - environment not found\x12!\n" +
-	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJ\xd0\x01\n" +
-	"\x03422\x12\xc8\x01\n" +
-	"\xa0\x01Unprocessable Entity - sync failed. The response body is still SyncAppResponse and includes the persisted deploy plus a coded error under data.latestSync.error.\x12#\n" +
-	"!\x1a\x1f#/definitions/v2SyncAppResponseJA\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJO\n" +
+	"\x03422\x12H\n" +
+	"#Unprocessable Entity - sync failed.\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJA\n" +
 	"\x03500\x12:\n" +
 	"\x15Internal Server Error\x12!\n" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,63 @@
+# In-Band Sync
+
+In-band sync is a synchronous request/response sync: the server sends one
+signed `PUT` to the SDK and receives the full register payload in the same
+response. Both directions are signed.
+
+Reference implementation: `monorepo/pkg/applogic/sdkhandlers/{api,registration,synchronization}.go`.
+
+## Wire protocol
+
+### Request (server → SDK)
+
+- `PUT <appURL>` with body `{"url": "<appURL>"}`.
+- Required headers:
+  - `content-type: application/json`
+  - `x-inngest-server-kind: cloud` (or `dev`)
+  - `x-inngest-sync-kind: in_band` (`inngestgo.SyncKindInBand`)
+  - `x-inngest-signature: <inngestgo.Sign(skey, body)>`
+
+A signing key is required.
+
+### Response (SDK → server)
+
+A response is accepted iff it is 2xx, has a valid `x-inngest-signature`, and
+parses as the body shape below. The response sync-kind header is not checked.
+
+- Required headers:
+  - `x-inngest-signature: <hmac of body with skey>`
+- Body (JSON), per the inngestgo handler:
+  ```
+  {
+    "app_id":       string,
+    "env":          *string,
+    "framework":    *string,
+    "platform":     *string,
+    "sdk_author":   string,
+    "sdk_language": string,
+    "sdk_version":  string,
+    "url":          string,
+    "functions":    []sdk.SDKFunction,
+    "inspection":   object   // polymorphic; capabilities live at inspection.capabilities
+  }
+  ```
+
+## Package: `pkg/appsync`
+
+Sends the request and parses the response. Does **not** process the resulting
+register payload. The caller does that (this repo and the cloud monorepo
+process differently).
+
+Behavior:
+1. Validate `x-inngest-signature` against the body via
+   `inngestgo.ValidateResponseSignature(skey, body)`. Invalid → fail.
+2. Unmarshal into the in-band response struct.
+3. Convert to `*sdk.RegisterRequest` (mapping: `app_id` → `AppName`,
+   capabilities pulled from `inspection.capabilities`,
+   `SDK = "<sdk_language>:<sdk_version>"`).
+
+## Errors
+
+- Missing or invalid response signature → fail.
+- Cloudflare interstitial (`Cf-Mitigated` header) → fail.
+- Non-2xx status → fail with the body surfaced.


### PR DESCRIPTION
## Description

Add in-band syncs to Self-Hosted. Also 404 the `/fn/register` endpoint (used for out-of-band syncs).

Does not add in-band syncs to Dev Server.

See `pkg/appsync/ARCHITECTURE.md` for detailed info. The PR description is intentionally sparse because I want to ensure the docs are good 😄

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Implements in-band (server-initiated) app syncs for `inngest start`. The server makes a signed PUT to the SDK URL, validates the signed response, and persists the result via a new `AppSyncer` interface. Adds `--allow-insecure-http` CLI flag, rate limiting on the sync endpoint, and comprehensive unit tests covering error sanitization, syscode propagation, and the full success path against a real `inngestgo` handler.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7bd8b6e5d558f1de95b464558e29a901350a2e97.</sup>
<!-- /MENDRAL_SUMMARY -->