### PR TITLE
Fix metadata fallback

### DIFF
--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -156,8 +156,9 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 	// limit within this request. This prevents unbounded metadata writes to
 	// old runs.
 	if stateMetadata == nil {
-		stateMetadata = &statev2.Metadata{}
+		stateMetadata = &statev2.Metadata{ID: stateID}
 	}
+	statev2.InitConfig(&stateMetadata.Config)
 
 	parentSpanRef := &meta.SpanReference{
 		TraceParent:            fmt.Sprintf("00-%s-%s-00", parentSpan.TraceID, parentSpan.SpanID),

--- a/pkg/api/apiv1/metadata_test.go
+++ b/pkg/api/apiv1/metadata_test.go
@@ -1,0 +1,98 @@
+package apiv1
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/api/apiv1/apiv1auth"
+	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/enums"
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type metadataFallbackTraceReader struct {
+	cqrs.TraceReader
+	span *cqrs.OtelSpan
+}
+
+func (r metadataFallbackTraceReader) GetRunSpanByRunID(context.Context, ulid.ULID, uuid.UUID, uuid.UUID) (*cqrs.OtelSpan, error) {
+	return r.span, nil
+}
+
+type metadataFallbackTracerProvider struct {
+	t      *testing.T
+	wantID statev2.ID
+	called bool
+}
+
+func (p *metadataFallbackTracerProvider) CreateSpan(_ context.Context, _ string, opts *tracing.CreateSpanOptions) (*meta.SpanReference, error) {
+	p.called = true
+
+	require.NotNil(p.t, opts.Metadata)
+	require.Equal(p.t, p.wantID, opts.Metadata.ID)
+	require.NotPanics(p.t, func() {
+		_ = opts.Metadata.Config.DebugRunID()
+		_ = opts.Metadata.Config.DebugSessionID()
+	})
+
+	return &meta.SpanReference{}, nil
+}
+
+func (p *metadataFallbackTracerProvider) CreateDroppableSpan(context.Context, string, *tracing.CreateSpanOptions) (*tracing.DroppableSpan, error) {
+	return nil, errors.New("unexpected CreateDroppableSpan call")
+}
+
+func (p *metadataFallbackTracerProvider) UpdateSpan(context.Context, *tracing.UpdateSpanOptions) error {
+	return errors.New("unexpected UpdateSpan call")
+}
+
+func TestAddRunMetadataFallbackInitializesStateMetadata(t *testing.T) {
+	ctx := t.Context()
+	auth, err := apiv1auth.NilAuthFinder(ctx)
+	require.NoError(t, err)
+
+	runID := ulid.Make()
+	functionID := uuid.New()
+	appID := uuid.New()
+	wantID := statev2.ID{
+		RunID:      runID,
+		FunctionID: functionID,
+		Tenant: statev2.Tenant{
+			AppID:     appID,
+			EnvID:     auth.WorkspaceID(),
+			AccountID: auth.AccountID(),
+		},
+	}
+
+	tp := &metadataFallbackTracerProvider{t: t, wantID: wantID}
+	r := router{API: &API{opts: Opts{
+		TraceReader: metadataFallbackTraceReader{span: &cqrs.OtelSpan{
+			RawOtelSpan: cqrs.RawOtelSpan{
+				TraceID: "00000000000000000000000000000001",
+				SpanID:  "0000000000000001",
+			},
+			RunID:      runID,
+			FunctionID: functionID,
+			AppID:      appID,
+		}},
+		TracerProvider: tp,
+	}}}
+
+	err = r.AddRunMetadata(ctx, auth, runID, &AddRunMetadataRequest{
+		Metadata: []metadata.Update{{RawUpdate: metadata.RawUpdate{
+			Kind:   "userland.scores",
+			Op:     enums.MetadataOpcodeMerge,
+			Values: metadata.Values{"score": json.RawMessage(`{"value":1}`)},
+		}}},
+	})
+	require.NoError(t, err)
+	require.True(t, tp.called)
+}


### PR DESCRIPTION
## Description

Fixes metadata fallback on defer path

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes a nil-pointer panic on the defer path when `stateMetadata` is nil: initializes the `Metadata` struct with the correct `stateID` and calls `InitConfig` to set up the `Config.mu` mutex before use. Adds a unit test covering the fallback path.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit f78a1e2dd50c49728feb7c2234a9b68b5d9793ff.</sup>
<!-- /MENDRAL_SUMMARY -->