### PR TITLE
feat: track GenerationID on QueueItem

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1521,7 +1521,8 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 		return nil, fmt.Errorf("no function loader specified running step")
 	}
 
-	requestID := ulid.MustNew(ulid.Timestamp(e.now()), rand.Reader).String()
+	seed := fmt.Appendf(nil, "%s:%d", id.RunID, queue.GenerationIDFromContext(ctx))
+	requestID := util.MustDeterministicULID(e.now(), seed).String()
 	jobID := queue.JobIDFromContext(ctx)
 	if item.JobID != nil {
 		jobID = *item.JobID

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -27,8 +27,9 @@ import (
 type jobIDValType struct{ int }
 
 var (
-	jobCtxVal   = jobIDValType{0}
-	shardCtxVal = jobIDValType{1}
+	jobCtxVal          = jobIDValType{0}
+	shardCtxVal        = jobIDValType{1}
+	generationIDCtxVal = jobIDValType{2}
 )
 
 // WithJobID returns a context that stores the given job ID inside.
@@ -41,6 +42,13 @@ func WithShardID(ctx context.Context, shardID string) context.Context {
 	return context.WithValue(ctx, shardCtxVal, shardID)
 }
 
+// WithGenerationID stores the queue item's monotonic dispatch generation. The
+// driver forwards this to the SDK so async checkpoint POSTs can be fenced
+// against requeues that supersede the original dispatch.
+func WithGenerationID(ctx context.Context, generationID int) context.Context {
+	return context.WithValue(ctx, generationIDCtxVal, generationID)
+}
+
 // JobIDFromContext returns the job ID given the current context, or an
 // empty string if there's no job ID.
 func JobIDFromContext(ctx context.Context) string {
@@ -51,6 +59,13 @@ func JobIDFromContext(ctx context.Context) string {
 func ShardIDFromContext(ctx context.Context) string {
 	str, _ := ctx.Value(shardCtxVal).(string)
 	return str
+}
+
+// GenerationIDFromContext returns the dispatch generation for the current job,
+// or 0 if not set.
+func GenerationIDFromContext(ctx context.Context) int {
+	v, _ := ctx.Value(generationIDCtxVal).(int)
+	return v
 }
 
 // QueueItem represents an individually queued work scheduled for some time in the
@@ -88,6 +103,9 @@ type QueueItem struct {
 	WorkspaceID uuid.UUID `json:"wsID"`
 	// LeaseID is a ULID which embeds a timestamp denoting when the lease expires.
 	LeaseID *ulid.ULID `json:"leaseID,omitempty"`
+	// GenerationID is a monotonic counter bumped by Requeue; mismatch fences
+	// a stale dispatch.
+	GenerationID int `json:"genID,omitempty"`
 	// Data represents the enqueued data, eg. the edge to process or the pause
 	// to resume.
 	Data Item `json:"data"`

--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -71,6 +71,7 @@ func (q *queueProcessor) ProcessItem(
 	// along the job ID as metadata to the SDK.  We also need to pass in shard information.
 	jobCtx = WithShardID(jobCtx, shard.Name())
 	jobCtx = WithJobID(jobCtx, qi.ID)
+	jobCtx = WithGenerationID(jobCtx, qi.GenerationID)
 	// Same with the group ID, if it exists.
 	if qi.Data.GroupID != "" {
 		jobCtx = state.WithGroupID(jobCtx, qi.Data.GroupID)

--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -495,7 +495,8 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 
 	// Assign the lease ID and pass this to be handled by the available worker.
 	// There should always be capacity on this queue as we track capacity via
-	// a semaphore.
+	// a semaphore. GenerationID was loaded from the queue hash on Peek and is
+	// preserved across Lease (the Lua script does not touch it).
 	item.LeaseID = leaseID
 
 	// increase success counter.

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -159,6 +159,12 @@ func (q *queue) EnqueueItem(ctx context.Context, i osqueue.QueueItem, at time.Ti
 		i.Data.JobID = &i.ID
 	}
 
+	// Start GenerationID at 1 so the very first dispatch carries a non-zero
+	// value to the SDK. The validator treats 0 as "no value sent"
+	if i.GenerationID == 0 {
+		i.GenerationID = 1
+	}
+
 	partitionTime := at
 	if at.Before(now) {
 		// We don't want to enqueue partitions (pointers to fns) before now.

--- a/pkg/execution/state/redis_state/queue_generation_id_test.go
+++ b/pkg/execution/state/redis_state/queue_generation_id_test.go
@@ -1,0 +1,115 @@
+package redis_state
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/jonboulle/clockwork"
+	"github.com/oklog/ulid/v2"
+	"github.com/redis/rueidis"
+	"github.com/stretchr/testify/require"
+
+	osqueue "github.com/inngest/inngest/pkg/execution/queue"
+)
+
+// TestQueueGenerationID asserts the GenerationID lifecycle: Enqueue starts at
+// 1 (so 0 is reserved as a "pre-rollout / no value sent" sentinel for the
+// validator), Lease and ExtendLease leave it untouched, Requeue bumps it
+// monotonically.
+func TestQueueGenerationID(t *testing.T) {
+	r := miniredis.RunT(t)
+
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	clock := clockwork.NewFakeClock()
+	_, shard := newQueue(t, rc, osqueue.WithClock(clock))
+
+	ctx := context.Background()
+
+	enqueueLeasedItem := func(t *testing.T) (osqueue.QueueItem, ulid.ULID) {
+		t.Helper()
+		fnID, accountID := uuid.New(), uuid.New()
+		runID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+		item, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
+			FunctionID: fnID,
+			Data: osqueue.Item{
+				Identifier: state.Identifier{
+					RunID:      runID,
+					WorkflowID: fnID,
+					AccountID:  accountID,
+				},
+			},
+		}, clock.Now(), osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+
+		require.Equal(t, 1, getQueueItem(t, r, item.ID).GenerationID,
+			"GenerationID should start at 1 so the first dispatch carries a non-zero value the validator can fence against")
+
+		leaseID, err := shard.Lease(ctx, item, time.Second, clock.Now())
+		require.NoError(t, err)
+		require.NotNil(t, leaseID)
+
+		return item, *leaseID
+	}
+
+	t.Run("Lease leaves GenerationID untouched", func(t *testing.T) {
+		item, _ := enqueueLeasedItem(t)
+
+		stored := getQueueItem(t, r, item.ID)
+		require.Equal(t, 1, stored.GenerationID,
+			"Lease must not touch GenerationID; the value carried into the dispatch is whatever was stamped on enqueue/last requeue")
+	})
+
+	t.Run("ExtendLease preserves GenerationID", func(t *testing.T) {
+		item, leaseID := enqueueLeasedItem(t)
+
+		before := getQueueItem(t, r, item.ID).GenerationID
+
+		clock.Advance(100 * time.Millisecond)
+		r.SetTime(clock.Now())
+
+		_, err := shard.ExtendLease(ctx, item, leaseID, time.Second)
+		require.NoError(t, err)
+
+		after := getQueueItem(t, r, item.ID).GenerationID
+		require.Equal(t, before, after,
+			"ExtendLease must not bump GenerationID; a single dispatch (lease + extensions) keeps one ID")
+	})
+
+	t.Run("Requeue bumps GenerationID monotonically", func(t *testing.T) {
+		item, _ := enqueueLeasedItem(t)
+
+		before := getQueueItem(t, r, item.ID).GenerationID
+
+		clock.Advance(100 * time.Millisecond)
+		r.SetTime(clock.Now())
+
+		require.NoError(t, shard.Requeue(ctx, item, clock.Now()))
+
+		after := getQueueItem(t, r, item.ID).GenerationID
+		require.Equal(t, before+1, after,
+			"Requeue must increment GenerationID so any in-flight SDK from the prior dispatch fails server-side validation")
+
+		// Bump again to confirm monotonicity holds across multiple requeues
+		// (e.g. transient errors that don't bump Data.Attempt still bump
+		// GenerationID).
+		updated := item
+		updated.GenerationID = after
+		clock.Advance(100 * time.Millisecond)
+		r.SetTime(clock.Now())
+		require.NoError(t, shard.Requeue(ctx, updated, clock.Now()))
+		require.Equal(t, after+1, getQueueItem(t, r, item.ID).GenerationID,
+			"successive Requeues must keep bumping GenerationID")
+	})
+}

--- a/pkg/execution/state/redis_state/queue_op.go
+++ b/pkg/execution/state/redis_state/queue_op.go
@@ -155,6 +155,8 @@ func (q *queue) Requeue(ctx context.Context, i osqueue.QueueItem, at time.Time, 
 
 	// Unset any lease ID as this is requeued.
 	i.LeaseID = nil
+	// Bump GenerationID so the next dispatch supersedes the previous one.
+	i.GenerationID++
 	// Update the At timestamp.
 	// NOTE: This does no priority factorization or FIFO for function ordering,
 	// eg. adjusting AtMS based off of function run time.

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -988,6 +988,7 @@ func TestQueuePeek(t *testing.T) {
 			ia.EnqueuedAt = items[0].EnqueuedAt
 			require.EqualValues(t, int64(1), items[0].ScavengeCount, "ScavengeCount should be 1 after first scavenge/requeue")
 			ia.ScavengeCount = 1
+			ia.GenerationID = items[0].GenerationID
 			require.EqualValues(t, []*osqueue.QueueItem{&ia, &ib, &ic, &id}, items)
 		})
 

--- a/pkg/util/ulid.go
+++ b/pkg/util/ulid.go
@@ -9,7 +9,6 @@ import (
 )
 
 // DeterministicULID creates a deterministic ULID given the seed.
-// new SeededID.
 func DeterministicULID(ts time.Time, seed []byte) (ulid.ULID, error) {
 	// ULID requires 10 bytes of entropy. If seed is shorter, pad it with zeros.
 	// If seed is longer, use all of it as the entropy source.

--- a/tests/execution/queue/queue_operation_test.go
+++ b/tests/execution/queue/queue_operation_test.go
@@ -178,8 +178,12 @@ func TestQueueOperations(t *testing.T) {
 	})
 
 	t.Run("Requeue", func(t *testing.T) {
+		preRequeue, err := shard.LoadQueueItem(ctx, item.ID)
+		require.NoError(t, err)
+		preGenerationID := preRequeue.GenerationID
+
 		requeueAt := clock.Now().Add(20 * time.Second)
-		err := shard.Requeue(ctx, *item, requeueAt)
+		err = shard.Requeue(ctx, *item, requeueAt)
 		require.NoError(t, err)
 
 		item.WallTimeMS = requeueAt.UnixMilli()
@@ -190,6 +194,9 @@ func TestQueueOperations(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Nil(t, loaded.LeaseID)
+		require.Equal(t, preGenerationID+1, loaded.GenerationID,
+			"Requeue must bump GenerationID to invalidate stale in-flight dispatches (EXE-1552)")
+		item.GenerationID = loaded.GenerationID
 		require.Equal(t, *item, *loaded)
 
 		t.Run("should find item in queue when peeking", func(t *testing.T) {


### PR DESCRIPTION
Adds a monotonic counter to QueueItem, initialized to 1 on enqueue and incremented on Requeue. Exposed via context so downstream callers can stamp the value on outbound dispatches.

Plumbing only: nothing reads the value yet. A follow-up wires it through the SDK request payload and the async-checkpoint API to fence stale dispatches whose lease was superseded by a Requeue.

---

This PR is a split from https://github.com/inngest/inngest/pull/4108

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a monotonic `GenerationID` counter to `QueueItem`: initialized to 1 on enqueue, incremented on `Requeue`, and threaded through context. The second commit replaces the random ULID entropy with a deterministic seed derived from `RunID + GenerationID`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 72a424ce1ef5b75165b51dc8f39a22cc1c16d665.</sup>
<!-- /MENDRAL_SUMMARY -->