### PR TITLE
Add new "doctor" and "doctor healthcheck" commands

### DIFF
--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,4 +1,4 @@
 FROM --platform=$BUILDPLATFORM debian:stable-slim AS inngest
-RUN apt-get update && apt-get install -y ca-certificates tzdata curl && update-ca-certificates
+RUN apt-get update && apt-get upgrade -y && apt-get install -y ca-certificates tzdata && update-ca-certificates
 COPY inngest /bin/inngest
 CMD ["inngest"]

--- a/cmd/alpha.go
+++ b/cmd/alpha.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/inngest/inngest/cmd/conformance"
 	"github.com/inngest/inngest/cmd/debug"
+	"github.com/inngest/inngest/cmd/doctor"
 	"github.com/urfave/cli/v3"
 )
 
@@ -14,6 +15,7 @@ func alpha() *cli.Command {
 		Commands: []*cli.Command{
 			conformance.Command(),
 			debug.Command(),
+			doctor.Command(),
 		},
 	}
 }

--- a/cmd/devserver/cmd.go
+++ b/cmd/devserver/cmd.go
@@ -1,6 +1,7 @@
 package devserver
 
 import (
+	"github.com/inngest/inngest/pkg/api"
 	"github.com/inngest/inngest/pkg/devserver"
 	"github.com/urfave/cli/v3"
 )
@@ -36,10 +37,10 @@ func Command() *cli.Command {
 				Name:  "host",
 				Usage: "Inngest server host",
 			},
-			&cli.StringFlag{
+			&cli.IntFlag{
 				Name:    "port",
 				Aliases: []string{"p"},
-				Value:   "8288",
+				Value:   api.DefaultAPIPort,
 				Usage:   "Inngest server port",
 			},
 

--- a/cmd/devserver/devserver.go
+++ b/cmd/devserver/devserver.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 	"time"
 
 	localconfig "github.com/inngest/inngest/cmd/internal/config"
+	"github.com/inngest/inngest/pkg/api"
 	"github.com/inngest/inngest/pkg/config"
 	connectConfig "github.com/inngest/inngest/pkg/config/connect"
 	connectgrpc "github.com/inngest/inngest/pkg/connect/grpc"
@@ -45,12 +45,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		os.Exit(1)
 	}
 
-	portStr := localconfig.GetValue(cmd, "port", "8288")
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
+	port := localconfig.GetIntValue(cmd, "port", api.DefaultAPIPort)
 	conf.EventAPI.Port = port
 	conf.CoreAPI.Port = port
 

--- a/cmd/doctor/AGENTS.md
+++ b/cmd/doctor/AGENTS.md
@@ -1,0 +1,38 @@
+# `cmd/doctor` — agent guidance
+
+Diagnostic subcommand surface under `inngest alpha doctor`. Each subcommand is one "check"; bare `doctor` runs them all and prints a summary. Checks fall into two rough buckets:
+
+- **Probe checks** (e.g. `healthcheck`): cheap, fast, side-effect-free. Designed to be invoked repeatedly — often from a docker-compose `healthcheck:` directive.
+- **Diagnostic checks** (e.g. a future `configcheck`, `depscheck`): may load files, hit databases, or do real work. Designed for human/CI invocation, not loop polling.
+
+The first-class motivation for the surface was replacing `curl` in compose healthchecks so the published image can drop curl and eventually move to distroless. Don't let that history constrain checks whose purpose is diagnostic.
+
+## Adding a new check
+
+1. Create `cmd/doctor/<name>/cmd.go` exposing `func Command() *cli.Command`.
+2. Append `<name>.Command()` to the `Commands:` slice in `cmd/doctor/cmd.go`.
+
+That's it. Do **not** create a separate `[]Check{...}` registry. The `Commands:` slice **is** the registry — the parent's default `Action` (`runAllChecks`) iterates it.
+
+## Universal contract — every check must
+
+- Be **silent on success** (no stdout, no stderr).
+- On failure, print one line per problem to **stderr**, then return `cli.Exit("", 1)`. Do **not** return a plain `error` — `cmd/root.go` prints non-cli errors to stdout, which pollutes consumers (compose healthcheck logs, CI output).
+- Reuse existing `INNGEST_*` env vars (e.g. `INNGEST_HOST`, `INNGEST_PORT`, `INNGEST_CONNECT_GATEWAY_PORT`) via `Sources: cli.EnvVars(...)`. Do **not** introduce new env vars without explicit user approval.
+- Be non-interactive: no TTY prompts, no stdin reads.
+
+## Routing
+
+When a user runs `inngest alpha doctor <name>`, urfave/cli routes directly to that subcommand's `Action`; `runAllChecks` is not invoked. This is what preserves silent-on-success for the probe-check use case. When a user runs bare `inngest alpha doctor`, `runAllChecks` calls every subcommand's `Action` in turn and prints a human summary.
+
+## Tests
+
+Co-locate `cmd_test.go` next to each check. **Required** in any test file that exercises a check end-to-end:
+
+```go
+func init() {
+    cli.OsExiter = func(int) {} // cli.Exit otherwise calls os.Exit and kills the test process
+}
+```
+
+Drive the command with `cmd.Run(ctx, []string{"<name>", "--flag=value", ...})` and assert on the returned error. For HTTP probes, use `httptest.Server`.

--- a/cmd/doctor/cmd.go
+++ b/cmd/doctor/cmd.go
@@ -26,7 +26,7 @@ func runAllChecks(ctx context.Context, cmd *cli.Command) error {
 	var failed []string
 	for _, sub := range cmd.Commands {
 		fmt.Printf("• %s ... ", sub.Name)
-		if err := sub.Action(ctx, sub); err != nil {
+		if err := runSubCheck(ctx, sub); err != nil {
 			fmt.Println("FAIL")
 			if msg := err.Error(); msg != "" {
 				fmt.Fprintf(os.Stderr, "  %s\n", msg)
@@ -40,4 +40,27 @@ func runAllChecks(ctx context.Context, cmd *cli.Command) error {
 		return cli.Exit(fmt.Sprintf("%d check(s) failed: %s", len(failed), strings.Join(failed, ", ")), 1)
 	}
 	return nil
+}
+
+// runSubCheck invokes a subcommand's Action with its flag values populated
+// from defaults and Sources (env vars, files). We can't go through sub.Run:
+// it routes ExitCoder errors (cli.Exit) through OsExiter = os.Exit, which
+// would kill the loop on the first failing check. Call Action directly, but
+// drive the same Pre/PostParse phases sub.Run would, so env-var Sources
+// resolve.
+func runSubCheck(ctx context.Context, sub *cli.Command) error {
+	if sub.Action == nil {
+		return nil
+	}
+	for _, f := range sub.Flags {
+		if err := f.PreParse(); err != nil {
+			return err
+		}
+	}
+	for _, f := range sub.Flags {
+		if err := f.PostParse(); err != nil {
+			return err
+		}
+	}
+	return sub.Action(ctx, sub)
 }

--- a/cmd/doctor/cmd.go
+++ b/cmd/doctor/cmd.go
@@ -25,6 +25,13 @@ func Command() *cli.Command {
 func runAllChecks(ctx context.Context, cmd *cli.Command) error {
 	var failed []string
 	for _, sub := range cmd.Commands {
+		// cli auto-injects a "help" subcommand into cmd.Commands during
+		// setupDefaults; it's not a health check, and invoking its Action
+		// (helpCommandAction) against an unparsed command panics in
+		// cmd.Args().First().
+		if sub.Name == "help" {
+			continue
+		}
 		fmt.Printf("• %s ... ", sub.Name)
 		if err := runSubCheck(ctx, sub); err != nil {
 			fmt.Println("FAIL")

--- a/cmd/doctor/cmd.go
+++ b/cmd/doctor/cmd.go
@@ -1,0 +1,43 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/inngest/inngest/cmd/doctor/healthcheck"
+	"github.com/urfave/cli/v3"
+)
+
+func Command() *cli.Command {
+	return &cli.Command{
+		Name:    "doctor",
+		Aliases: []string{"dr"},
+		Usage:   "Run diagnostics against the local inngest environment and server",
+		Commands: []*cli.Command{
+			healthcheck.Command(),
+		},
+		Action: runAllChecks,
+	}
+}
+
+func runAllChecks(ctx context.Context, cmd *cli.Command) error {
+	var failed []string
+	for _, sub := range cmd.Commands {
+		fmt.Printf("• %s ... ", sub.Name)
+		if err := sub.Action(ctx, sub); err != nil {
+			fmt.Println("FAIL")
+			if msg := err.Error(); msg != "" {
+				fmt.Fprintf(os.Stderr, "  %s\n", msg)
+			}
+			failed = append(failed, sub.Name)
+			continue
+		}
+		fmt.Println("OK")
+	}
+	if len(failed) > 0 {
+		return cli.Exit(fmt.Sprintf("%d check(s) failed: %s", len(failed), strings.Join(failed, ", ")), 1)
+	}
+	return nil
+}

--- a/cmd/doctor/cmd_test.go
+++ b/cmd/doctor/cmd_test.go
@@ -1,0 +1,72 @@
+package doctor
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/api"
+	"github.com/inngest/inngest/pkg/connect"
+	"github.com/urfave/cli/v3"
+)
+
+func init() {
+	cli.OsExiter = func(int) {}
+}
+
+// TestParentPath_EnvVarFallback verifies that env-var Sources on a
+// subcommand's flags resolve when the doctor parent runs all subchecks,
+// not only when the subcommand is invoked directly. Regression test for
+// runSubCheck driving PreParse/PostParse — without it, runAllChecks
+// invoked sub.Action with unparsed flags and Sources never resolved, so
+// healthcheck probed the static defaults (127.0.0.1:8288 / :8289)
+// instead of the env-var-pointed target.
+func TestParentPath_EnvVarFallback(t *testing.T) {
+	var probed atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case api.HealthPath, connect.ReadyPath:
+			probed.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	host, port := splitURL(t, srv.URL)
+	portStr := strconv.Itoa(port)
+	t.Setenv("INNGEST_HOST", host)
+	t.Setenv("INNGEST_PORT", portStr)
+	t.Setenv("INNGEST_CONNECT_GATEWAY_PORT", portStr)
+
+	cmd := Command()
+	if err := cmd.Run(context.Background(), []string{"doctor"}); err != nil {
+		t.Fatalf("doctor run returned error: %v", err)
+	}
+	if got := probed.Load(); got != 2 {
+		t.Fatalf("expected 2 probes against env-var target, got %d — env-var Sources not resolved through doctor parent", got)
+	}
+}
+
+func splitURL(t *testing.T, raw string) (string, int) {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("bad url %q: %v", raw, err)
+	}
+	host, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("bad host %q: %v", u.Host, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("bad port %q: %v", portStr, err)
+	}
+	return host, port
+}

--- a/cmd/doctor/healthcheck/cmd.go
+++ b/cmd/doctor/healthcheck/cmd.go
@@ -1,0 +1,144 @@
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/urfave/cli/v3"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	apiHealthPath     = "/health"
+	gatewayReadyPath  = "/ready"
+	defaultHost       = "127.0.0.1"
+	defaultAPIPort    = 8288
+	defaultGwPort     = 8289
+	defaultScheme     = "http"
+	defaultTimeout    = 5 * time.Second
+	verboseBodyLimit  = 200
+)
+
+func Command() *cli.Command {
+	return &cli.Command{
+		Name:  "healthcheck",
+		Usage: "Probe local inngest HTTP endpoints; exit non-zero on failure",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "host",
+				Value:   defaultHost,
+				Sources: cli.EnvVars("INNGEST_HOST"),
+				Usage:   "Host to probe",
+			},
+			&cli.IntFlag{
+				Name:    "api-port",
+				Value:   defaultAPIPort,
+				Sources: cli.EnvVars("INNGEST_PORT"),
+				Usage:   "Main API port",
+			},
+			&cli.IntFlag{
+				Name:    "connect-gateway-port",
+				Value:   defaultGwPort,
+				Sources: cli.EnvVars("INNGEST_CONNECT_GATEWAY_PORT"),
+				Usage:   "Connect Gateway port",
+			},
+			&cli.StringFlag{
+				Name:  "scheme",
+				Value: defaultScheme,
+				Usage: "URL scheme: http or https",
+			},
+			&cli.DurationFlag{
+				Name:  "timeout",
+				Value: defaultTimeout,
+				Usage: "Per-probe HTTP timeout",
+			},
+			&cli.BoolFlag{
+				Name:  "skip-connect-gateway",
+				Value: false,
+				Usage: "Skip the Connect Gateway probe",
+			},
+			&cli.BoolFlag{
+				Name:  "verbose",
+				Value: false,
+				Usage: "On failure, also print response status and a snippet of the body",
+			},
+		},
+		Action: run,
+	}
+}
+
+func run(ctx context.Context, cmd *cli.Command) error {
+	host := cmd.String("host")
+	scheme := cmd.String("scheme")
+	timeout := cmd.Duration("timeout")
+	verbose := cmd.Bool("verbose")
+
+	type probe struct {
+		component string
+		url       string
+	}
+
+	probes := []probe{
+		{
+			component: "api",
+			url:       fmt.Sprintf("%s://%s:%d%s", scheme, host, cmd.Int("api-port"), apiHealthPath),
+		},
+	}
+	if !cmd.Bool("skip-connect-gateway") {
+		probes = append(probes, probe{
+			component: "connect-gateway",
+			url:       fmt.Sprintf("%s://%s:%d%s", scheme, host, cmd.Int("connect-gateway-port"), gatewayReadyPath),
+		})
+	}
+
+	client := &http.Client{Timeout: timeout}
+	eg, egCtx := errgroup.WithContext(ctx)
+	errs := make([]error, len(probes))
+	for i, p := range probes {
+		eg.Go(func() error {
+			if err := probeOnce(egCtx, client, p.url, verbose); err != nil {
+				errs[i] = fmt.Errorf("healthcheck: %s %s: %w", p.component, p.url, err)
+			}
+			return nil
+		})
+	}
+	_ = eg.Wait()
+
+	var failed int
+	for _, err := range errs {
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			failed++
+		}
+	}
+	if failed > 0 {
+		return cli.Exit("", 1)
+	}
+	return nil
+}
+
+func probeOnce(ctx context.Context, client *http.Client, url string, verbose bool) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	if verbose {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, verboseBodyLimit))
+		return fmt.Errorf("status %d: %s", resp.StatusCode, string(body))
+	}
+	return fmt.Errorf("status %d", resp.StatusCode)
+}

--- a/cmd/doctor/healthcheck/cmd.go
+++ b/cmd/doctor/healthcheck/cmd.go
@@ -8,19 +8,17 @@ import (
 	"os"
 	"time"
 
+	"github.com/inngest/inngest/pkg/api"
+	"github.com/inngest/inngest/pkg/connect"
 	"github.com/urfave/cli/v3"
 	"golang.org/x/sync/errgroup"
 )
 
 const (
-	apiHealthPath     = "/health"
-	gatewayReadyPath  = "/ready"
-	defaultHost       = "127.0.0.1"
-	defaultAPIPort    = 8288
-	defaultGwPort     = 8289
-	defaultScheme     = "http"
-	defaultTimeout    = 5 * time.Second
-	verboseBodyLimit  = 200
+	defaultHost      = "127.0.0.1"
+	defaultScheme    = "http"
+	defaultTimeout   = 5 * time.Second
+	verboseBodyLimit = 200
 )
 
 func Command() *cli.Command {
@@ -32,17 +30,17 @@ func Command() *cli.Command {
 				Name:    "host",
 				Value:   defaultHost,
 				Sources: cli.EnvVars("INNGEST_HOST"),
-				Usage:   "Host to probe",
+				Usage:   "Inngest server host",
 			},
 			&cli.IntFlag{
-				Name:    "api-port",
-				Value:   defaultAPIPort,
+				Name:    "port",
+				Value:   api.DefaultAPIPort,
 				Sources: cli.EnvVars("INNGEST_PORT"),
-				Usage:   "Main API port",
+				Usage:   "Inngest server port",
 			},
 			&cli.IntFlag{
 				Name:    "connect-gateway-port",
-				Value:   defaultGwPort,
+				Value:   connect.DefaultGatewayPort,
 				Sources: cli.EnvVars("INNGEST_CONNECT_GATEWAY_PORT"),
 				Usage:   "Connect Gateway port",
 			},
@@ -85,13 +83,13 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	probes := []probe{
 		{
 			component: "api",
-			url:       fmt.Sprintf("%s://%s:%d%s", scheme, host, cmd.Int("api-port"), apiHealthPath),
+			url:       fmt.Sprintf("%s://%s:%d%s", scheme, host, cmd.Int("port"), api.HealthPath),
 		},
 	}
 	if !cmd.Bool("skip-connect-gateway") {
 		probes = append(probes, probe{
 			component: "connect-gateway",
-			url:       fmt.Sprintf("%s://%s:%d%s", scheme, host, cmd.Int("connect-gateway-port"), gatewayReadyPath),
+			url:       fmt.Sprintf("%s://%s:%d%s", scheme, host, cmd.Int("connect-gateway-port"), connect.ReadyPath),
 		})
 	}
 

--- a/cmd/doctor/healthcheck/cmd.go
+++ b/cmd/doctor/healthcheck/cmd.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"time"
 
 	"github.com/inngest/inngest/pkg/api"
@@ -107,9 +106,10 @@ func run(ctx context.Context, cmd *cli.Command) error {
 	_ = eg.Wait()
 
 	var failed int
+	errOut := cmd.Root().ErrWriter
 	for _, err := range errs {
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
+			fmt.Fprintln(errOut, err.Error())
 			failed++
 		}
 	}

--- a/cmd/doctor/healthcheck/cmd_test.go
+++ b/cmd/doctor/healthcheck/cmd_test.go
@@ -1,6 +1,7 @@
 package healthcheck
 
 import (
+	"bytes"
 	"context"
 	"net"
 	"net/http"
@@ -162,6 +163,11 @@ func TestRun_SchemeOverride(t *testing.T) {
 
 	host, port := splitURL(t, srv.URL)
 	cmd := Command()
+	// Capture per-probe error context; cmd.Run returns cli.Exit("", 1)
+	// regardless of failure mode, so the returned err alone can't tell us
+	// whether the scheme flag was honored.
+	var stderr bytes.Buffer
+	cmd.ErrWriter = &stderr
 	err := cmd.Run(context.Background(), []string{
 		"healthcheck",
 		"--host=" + host,
@@ -170,14 +176,15 @@ func TestRun_SchemeOverride(t *testing.T) {
 		"--scheme=https",
 		"--timeout=2s",
 	})
-	// httptest's TLS uses a self-signed cert, so the probe will fail TLS verification.
-	// We're only validating that the scheme flag is honored (request goes out as HTTPS,
-	// not HTTP, which would otherwise return 400).
 	if err == nil {
-		t.Fatal("expected TLS verification error, got nil")
+		t.Fatal("expected error, got nil")
 	}
-	if !strings.Contains(err.Error(), "") { // err is non-nil; cli.Exit("", 1) has empty msg
-		t.Fatalf("unexpected error shape: %v", err)
+	// httptest's TLS uses a self-signed cert. If scheme=https was honored,
+	// the probe fails TLS verification on the client side; if it was ignored
+	// and the request went out as HTTP to the TLS port, we'd see a 400 or
+	// "malformed HTTP response" instead.
+	if got := stderr.String(); !strings.Contains(got, "tls") {
+		t.Fatalf("expected TLS verification error in probe output, got:\n%s", got)
 	}
 }
 

--- a/cmd/doctor/healthcheck/cmd_test.go
+++ b/cmd/doctor/healthcheck/cmd_test.go
@@ -1,0 +1,197 @@
+package healthcheck
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/urfave/cli/v3"
+)
+
+func init() {
+	// Prevent cli.Exit from terminating the test process. The framework
+	// calls HandleExitCoder → OsExiter, which defaults to os.Exit.
+	cli.OsExiter = func(int) {}
+}
+
+func TestRun(t *testing.T) {
+	apiOK := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != apiHealthPath {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiOK.Close()
+
+	gwOK := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != gatewayReadyPath {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer gwOK.Close()
+
+	apiBad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer apiBad.Close()
+
+	apiSlow := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer apiSlow.Close()
+
+	tests := []struct {
+		name           string
+		apiURL         string
+		gwURL          string
+		timeout        time.Duration
+		skipGw         bool
+		wantErr        bool
+	}{
+		{
+			name:    "both healthy",
+			apiURL:  apiOK.URL,
+			gwURL:   gwOK.URL,
+			timeout: 2 * time.Second,
+			wantErr: false,
+		},
+		{
+			name:    "api 500 fails",
+			apiURL:  apiBad.URL,
+			gwURL:   gwOK.URL,
+			timeout: 2 * time.Second,
+			wantErr: true,
+		},
+		{
+			name:    "gateway down fails",
+			apiURL:  apiOK.URL,
+			gwURL:   "http://127.0.0.1:1", // unreachable
+			timeout: 500 * time.Millisecond,
+			wantErr: true,
+		},
+		{
+			name:    "skip gateway when down",
+			apiURL:  apiOK.URL,
+			gwURL:   "http://127.0.0.1:1",
+			timeout: 500 * time.Millisecond,
+			skipGw:  true,
+			wantErr: false,
+		},
+		{
+			name:    "timeout fails",
+			apiURL:  apiSlow.URL,
+			gwURL:   gwOK.URL,
+			timeout: 50 * time.Millisecond,
+			wantErr: true,
+		},
+		{
+			name:    "connection refused fails",
+			apiURL:  "http://127.0.0.1:1",
+			gwURL:   gwOK.URL,
+			timeout: 500 * time.Millisecond,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, apiPort := splitURL(t, tt.apiURL)
+			_, gwPort := splitURL(t, tt.gwURL)
+
+			cmd := Command()
+			args := []string{
+				"healthcheck",
+				"--host=" + host,
+				"--api-port=" + strconv.Itoa(apiPort),
+				"--connect-gateway-port=" + strconv.Itoa(gwPort),
+				"--timeout=" + tt.timeout.String(),
+			}
+			if tt.skipGw {
+				args = append(args, "--skip-connect-gateway")
+			}
+
+			err := cmd.Run(context.Background(), args)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestRun_EnvVarFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	host, port := splitURL(t, srv.URL)
+	t.Setenv("INNGEST_HOST", host)
+	t.Setenv("INNGEST_PORT", strconv.Itoa(port))
+
+	cmd := Command()
+	err := cmd.Run(context.Background(), []string{
+		"healthcheck",
+		"--connect-gateway-port=" + strconv.Itoa(port),
+		"--timeout=2s",
+	})
+	if err != nil {
+		t.Fatalf("env-var fallback failed: %v", err)
+	}
+}
+
+func TestRun_SchemeOverride(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	host, port := splitURL(t, srv.URL)
+	cmd := Command()
+	err := cmd.Run(context.Background(), []string{
+		"healthcheck",
+		"--host=" + host,
+		"--api-port=" + strconv.Itoa(port),
+		"--connect-gateway-port=" + strconv.Itoa(port),
+		"--scheme=https",
+		"--timeout=2s",
+	})
+	// httptest's TLS uses a self-signed cert, so the probe will fail TLS verification.
+	// We're only validating that the scheme flag is honored (request goes out as HTTPS,
+	// not HTTP, which would otherwise return 400).
+	if err == nil {
+		t.Fatal("expected TLS verification error, got nil")
+	}
+	if !strings.Contains(err.Error(), "") { // err is non-nil; cli.Exit("", 1) has empty msg
+		t.Fatalf("unexpected error shape: %v", err)
+	}
+}
+
+func splitURL(t *testing.T, raw string) (string, int) {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("bad url %q: %v", raw, err)
+	}
+	host, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("bad host %q: %v", u.Host, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("bad port %q: %v", portStr, err)
+	}
+	return host, port
+}

--- a/cmd/doctor/healthcheck/cmd_test.go
+++ b/cmd/doctor/healthcheck/cmd_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/inngest/inngest/pkg/api"
+	"github.com/inngest/inngest/pkg/connect"
 	"github.com/urfave/cli/v3"
 )
 
@@ -22,7 +24,7 @@ func init() {
 
 func TestRun(t *testing.T) {
 	apiOK := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != apiHealthPath {
+		if r.URL.Path != api.HealthPath {
 			http.NotFound(w, r)
 			return
 		}
@@ -31,7 +33,7 @@ func TestRun(t *testing.T) {
 	defer apiOK.Close()
 
 	gwOK := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != gatewayReadyPath {
+		if r.URL.Path != connect.ReadyPath {
 			http.NotFound(w, r)
 			return
 		}
@@ -51,12 +53,12 @@ func TestRun(t *testing.T) {
 	defer apiSlow.Close()
 
 	tests := []struct {
-		name           string
-		apiURL         string
-		gwURL          string
-		timeout        time.Duration
-		skipGw         bool
-		wantErr        bool
+		name    string
+		apiURL  string
+		gwURL   string
+		timeout time.Duration
+		skipGw  bool
+		wantErr bool
 	}{
 		{
 			name:    "both healthy",
@@ -112,7 +114,7 @@ func TestRun(t *testing.T) {
 			args := []string{
 				"healthcheck",
 				"--host=" + host,
-				"--api-port=" + strconv.Itoa(apiPort),
+				"--port=" + strconv.Itoa(apiPort),
 				"--connect-gateway-port=" + strconv.Itoa(gwPort),
 				"--timeout=" + tt.timeout.String(),
 			}
@@ -163,7 +165,7 @@ func TestRun_SchemeOverride(t *testing.T) {
 	err := cmd.Run(context.Background(), []string{
 		"healthcheck",
 		"--host=" + host,
-		"--api-port=" + strconv.Itoa(port),
+		"--port=" + strconv.Itoa(port),
 		"--connect-gateway-port=" + strconv.Itoa(port),
 		"--scheme=https",
 		"--timeout=2s",

--- a/cmd/start/cmd.go
+++ b/cmd/start/cmd.go
@@ -1,6 +1,7 @@
 package start
 
 import (
+	"github.com/inngest/inngest/pkg/api"
 	"github.com/inngest/inngest/pkg/devserver"
 	"github.com/urfave/cli/v3"
 )
@@ -8,7 +9,7 @@ import (
 func Command() *cli.Command {
 	cmd := &cli.Command{
 		Name:        "start",
-		Usage:       "[Beta] Run Inngest as a single-node service.",
+		Usage:       "Run the Inngest server with external persistence.",
 		UsageText:   "inngest start [options]",
 		Description: "Example: inngest start",
 		Action:      action,
@@ -23,10 +24,10 @@ func Command() *cli.Command {
 				Name:  "host",
 				Usage: "Inngest server hostname",
 			},
-			&cli.StringFlag{
+			&cli.IntFlag{
 				Name:    "port",
 				Aliases: []string{"p"},
-				Value:   "8288",
+				Value:   api.DefaultAPIPort,
 				Usage:   "Inngest server port",
 			},
 			&cli.StringSliceFlag{

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"time"
 
 	localconfig "github.com/inngest/inngest/cmd/internal/config"
+	"github.com/inngest/inngest/pkg/api"
 	"github.com/inngest/inngest/pkg/authn"
 	"github.com/inngest/inngest/pkg/config"
 	connectConfig "github.com/inngest/inngest/pkg/config/connect"
@@ -31,12 +31,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		os.Exit(1)
 	}
 
-	portStr := localconfig.GetValue(cmd, "port", "8288")
-	port, err := strconv.Atoi(portStr)
-	if err != nil {
-		fmt.Println(err.Error())
-		os.Exit(1)
-	}
+	port := localconfig.GetIntValue(cmd, "port", api.DefaultAPIPort)
 	conf.EventAPI.Port = port
 	conf.CoreAPI.Port = port
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -24,6 +24,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// Constants set here are leveraged by start, dev, and, healthcheck commands
+const (
+	DefaultAPIPort = 8288
+	HealthPath     = "/health"
+)
+
 type EventHandler func(context.Context, *event.Event, *event.SeededID) (string, error)
 
 type Options struct {
@@ -67,7 +73,7 @@ func NewAPI(o Options) (chi.Router, error) {
 	api.Use(cors.Handler)
 	api.Use(headers.StaticHeadersMiddleware(o.Config.GetServerKind()))
 
-	api.Get("/health", api.HealthCheck)
+	api.Get(HealthPath, api.HealthCheck)
 	api.Post("/e/{key}", api.ReceiveEvent)
 	api.Post("/invoke/{slug}", api.Invoke)
 

--- a/pkg/connect/maintenance.go
+++ b/pkg/connect/maintenance.go
@@ -42,7 +42,7 @@ func (m *maintenanceApi) setup() {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("."))
 		})
-		r.Get("/ready", func(w http.ResponseWriter, req *http.Request) {
+		r.Get(ReadyPath, func(w http.ResponseWriter, req *http.Request) {
 			if m.GatewayMaintenance.IsDraining() {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				return

--- a/pkg/connect/service.go
+++ b/pkg/connect/service.go
@@ -31,6 +31,14 @@ import (
 const (
 	GatewayInstrumentInterval = 20 * time.Second
 	GatewayGCInterval         = 30 * time.Minute
+
+	// DefaultGatewayPort is the default HTTP port the connect gateway binds to.
+	DefaultGatewayPort = 8289
+
+	// ReadyPath is the URL path of the gateway's readiness endpoint. Exported
+	// so callers (notably cmd/doctor/healthcheck) can probe the same path the
+	// gateway registers without the two drifting apart.
+	ReadyPath = "/ready"
 )
 
 // WorkerStatusIntervalFunc returns the status reporting interval for a given
@@ -280,11 +288,11 @@ func NewConnectGatewayService(opts ...gatewayOpt) *connectGatewaySvc {
 		r.Mount("/v0", v0Router)
 
 		// Readiness must be served to traffic port for load balancer health checks
-		r.Get("/ready", readinessHandler)
+		r.Get(ReadyPath, readinessHandler)
 	})
 
 	gateway.maintenanceApi = newMaintenanceApi(gateway)
-	gateway.maintenanceApi.Get("/ready", readinessHandler)
+	gateway.maintenanceApi.Get(ReadyPath, readinessHandler)
 
 	// Optionally mount maintenance API on the gateway public routes
 	if os.Getenv("INTERNAL_CONNECT_MAINTENANCE") == "1" {

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -90,7 +90,7 @@ const (
 	DefaultPollInterval = 5
 	DefaultQueueWorkers = 100
 
-	DefaultConnectGatewayPort      = 8289
+	DefaultConnectGatewayPort      = connect.DefaultGatewayPort
 	DefaultConnectGatewayGRPCPort  = 50052
 	DefaultConnectExecutorGRPCPort = 50053
 


### PR DESCRIPTION
## Description

This command will be an umbrella for system and configuration checks that folks can run in their environment against their server. The first check is a healthcheck command which allows us to drop the curl requirement in the base image (see #4134).

```
inngest alpha doctor healthcheck
```

## Motivation
We can drop curl from the base image (see: #4134). This enables us to reduce the packages footprint for security purposes. This then allows folks running Inngest server with Docker Compose or other systems to run a healthcheck with zero other dependencies.

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `inngest alpha doctor` as an umbrella diagnostic command with `healthcheck` as the first subcommand, probing `/health` and `/ready` in parallel to replace `curl` in the base Docker image. Follow-up commits fix env-var Sources resolution through the parent command path, add a regression test with a `help`-skip to prevent a production panic, and strengthen the `TestRun_SchemeOverride` assertion by capturing probe errors via `ErrWriter` and checking for `"tls"` in the output.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit af3491d554f4539a1de717b698ce1a317175aec2.</sup>
<!-- /MENDRAL_SUMMARY -->