### PR TITLE
add defers proto rpcs

### DIFF
--- a/proto/gen/state/v2/state.pb.go
+++ b/proto/gen/state/v2/state.pb.go
@@ -23,6 +23,62 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// DeferStatus mirrors enums.DeferStatus
+type DeferStatus int32
+
+const (
+	DeferStatus_DEFER_STATUS_UNKNOWN   DeferStatus = 0
+	DeferStatus_DEFER_STATUS_SCHEDULED DeferStatus = 1
+	DeferStatus_DEFER_STATUS_AFTER_RUN DeferStatus = 2
+	DeferStatus_DEFER_STATUS_ABORTED   DeferStatus = 3
+	DeferStatus_DEFER_STATUS_REJECTED  DeferStatus = 4
+)
+
+// Enum value maps for DeferStatus.
+var (
+	DeferStatus_name = map[int32]string{
+		0: "DEFER_STATUS_UNKNOWN",
+		1: "DEFER_STATUS_SCHEDULED",
+		2: "DEFER_STATUS_AFTER_RUN",
+		3: "DEFER_STATUS_ABORTED",
+		4: "DEFER_STATUS_REJECTED",
+	}
+	DeferStatus_value = map[string]int32{
+		"DEFER_STATUS_UNKNOWN":   0,
+		"DEFER_STATUS_SCHEDULED": 1,
+		"DEFER_STATUS_AFTER_RUN": 2,
+		"DEFER_STATUS_ABORTED":   3,
+		"DEFER_STATUS_REJECTED":  4,
+	}
+)
+
+func (x DeferStatus) Enum() *DeferStatus {
+	p := new(DeferStatus)
+	*p = x
+	return p
+}
+
+func (x DeferStatus) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (DeferStatus) Descriptor() protoreflect.EnumDescriptor {
+	return file_state_v2_state_proto_enumTypes[0].Descriptor()
+}
+
+func (DeferStatus) Type() protoreflect.EnumType {
+	return &file_state_v2_state_proto_enumTypes[0]
+}
+
+func (x DeferStatus) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use DeferStatus.Descriptor instead.
+func (DeferStatus) EnumDescriptor() ([]byte, []int) {
+	return file_state_v2_state_proto_rawDescGZIP(), []int{0}
+}
+
 type Metadata struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Id            *ID                    `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
@@ -1475,6 +1531,590 @@ func (x *LoadStateResponse) GetSteps() map[string][]byte {
 	return nil
 }
 
+type Defer struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	FnSlug         string                 `protobuf:"bytes,1,opt,name=fn_slug,json=fnSlug,proto3" json:"fn_slug,omitempty"`
+	HashedId       string                 `protobuf:"bytes,2,opt,name=hashed_id,json=hashedId,proto3" json:"hashed_id,omitempty"`
+	ScheduleStatus DeferStatus            `protobuf:"varint,3,opt,name=schedule_status,json=scheduleStatus,proto3,enum=state.v2.DeferStatus" json:"schedule_status,omitempty"`
+	Input          []byte                 `protobuf:"bytes,4,opt,name=input,proto3" json:"input,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *Defer) Reset() {
+	*x = Defer{}
+	mi := &file_state_v2_state_proto_msgTypes[26]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Defer) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Defer) ProtoMessage() {}
+
+func (x *Defer) ProtoReflect() protoreflect.Message {
+	mi := &file_state_v2_state_proto_msgTypes[26]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Defer.ProtoReflect.Descriptor instead.
+func (*Defer) Descriptor() ([]byte, []int) {
+	return file_state_v2_state_proto_rawDescGZIP(), []int{26}
+}
+
+func (x *Defer) GetFnSlug() string {
+	if x != nil {
+		return x.FnSlug
+	}
+	return ""
+}
+
+func (x *Defer) GetHashedId() string {
+	if x != nil {
+		return x.HashedId
+	}
+	return ""
+}
+
+func (x *Defer) GetScheduleStatus() DeferStatus {
+	if x != nil {
+		return x.ScheduleStatus
+	}
+	return DeferStatus_DEFER_STATUS_UNKNOWN
+}
+
+func (x *Defer) GetInput() []byte {
+	if x != nil {
+		return x.Input
+	}
+	return nil
+}
+
+type DeferMeta struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	FnSlug         string                 `protobuf:"bytes,1,opt,name=fn_slug,json=fnSlug,proto3" json:"fn_slug,omitempty"`
+	HashedId       string                 `protobuf:"bytes,2,opt,name=hashed_id,json=hashedId,proto3" json:"hashed_id,omitempty"`
+	ScheduleStatus DeferStatus            `protobuf:"varint,3,opt,name=schedule_status,json=scheduleStatus,proto3,enum=state.v2.DeferStatus" json:"schedule_status,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *DeferMeta) Reset() {
+	*x = DeferMeta{}
+	mi := &file_state_v2_state_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeferMeta) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeferMeta) ProtoMessage() {}
+
+func (x *DeferMeta) ProtoReflect() protoreflect.Message {
+	mi := &file_state_v2_state_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeferMeta.ProtoReflect.Descriptor instead.
+func (*DeferMeta) Descriptor() ([]byte, []int) {
+	return file_state_v2_state_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *DeferMeta) GetFnSlug() string {
+	if x != nil {
+		return x.FnSlug
+	}
+	return ""
+}
+
+func (x *DeferMeta) GetHashedId() string {
+	if x != nil {
+		return x.HashedId
+	}
+	return ""
+}
+
+func (x *DeferMeta) GetScheduleStatus() DeferStatus {
+	if x != nil {
+		return x.ScheduleStatus
+	}
+	return DeferStatus_DEFER_STATUS_UNKNOWN
+}
+
+type SaveDeferRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            *ID                    `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Defer         *Defer                 `protobuf:"bytes,2,opt,name=defer,proto3" json:"defer,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SaveDeferRequest) Reset() {
+	*x = SaveDeferRequest{}
+	mi := &file_state_v2_state_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SaveDeferRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SaveDeferRequest) ProtoMessage() {}
+
+func (x *SaveDeferRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_state_v2_state_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SaveDeferRequest.ProtoReflect.Descriptor instead.
+func (*SaveDeferRequest) Descriptor() ([]byte, []int) {
+	return file_state_v2_state_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *SaveDeferRequest) GetId() *ID {
+	if x != nil {
+		return x.Id
+	}
+	return nil
+}
+
+func (x *SaveDeferRequest) GetDefer() *Defer {
+	if x != nil {
+		return x.Defer
+	}
+	return nil
+}
+
+type SaveDeferResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SaveDeferResponse) Reset() {
+	*x = SaveDeferResponse{}
+	mi := &file_state_v2_state_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SaveDeferResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SaveDeferResponse) ProtoMessage() {}
+
+func (x *SaveDeferResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_state_v2_state_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SaveDeferResponse.ProtoReflect.Descriptor instead.
+func (*SaveDeferResponse) Descriptor() ([]byte, []int) {
+	return file_state_v2_state_proto_rawDescGZIP(), []int{29}
+}
+
+type SetDeferStatusRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            *ID                    `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	HashedId      string                 `protobuf:"bytes,2,opt,name=hashed_id,json=hashedId,proto3" json:"hashed_id,omitempty"`
+	Status        DeferStatus            `protobuf:"varint,3,opt,name=status,proto3,enum=state.v2.DeferStatus" json:"status,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetDeferStatusRequest) Reset() {
+	*x = SetDeferStatusRequest{}
+	mi := &file_state_v2_state_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetDeferStatusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetDeferStatusRequest) ProtoMessage() {}
+
+func (x *SetDeferStatusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_state_v2_state_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetDeferStatusRequest.ProtoReflect.Descriptor instead.
+func (*SetDeferStatusRequest) Descriptor() ([]byte, []int) {
+	return file_state_v2_state_proto_rawDescGZIP(), []int{30}
+}
+
+func (x *SetDeferStatusRequest) GetId() *ID {
+	if x != nil {
+		return x.Id
+	}
+	return nil
+}
+
+func (x *SetDeferStatusRequest) GetHashedId() string {
+	if x != nil {
+		return x.HashedId
+	}
+	return ""
+}
+
+func (x *SetDeferStatusRequest) GetStatus() DeferStatus {
+	if x != nil {
+		return x.Status
+	}
+	return DeferStatus_DEFER_STATUS_UNKNOWN
+}
+
+type SetDeferStatusResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SetDeferStatusResponse) Reset() {
+	*x = SetDeferStatusResponse{}
+	mi := &file_state_v2_state_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SetDeferStatusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SetDeferStatusResponse) ProtoMessage() {}
+
+func (x *SetDeferStatusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_state_v2_state_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SetDeferStatusResponse.ProtoReflect.Descriptor instead.
+func (*SetDeferStatusResponse) Descriptor() ([]byte, []int) {
+	return file_state_v2_state_proto_rawDescGZIP(), []int{31}
+}
+
+type SaveRejectedDeferRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            *ID                    `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	FnSlug        string                 `protobuf:"bytes,2,opt,name=fn_slug,json=fnSlug,proto3" json:"fn_slug,omitempty"`
+	HashedId      string                 `protobuf:"bytes,3,opt,name=hashed_id,json=hashedId,proto3" json:"hashed_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SaveRejectedDeferRequest) Reset() {
+	*x = SaveRejectedDeferRequest{}
+	mi := &file_state_v2_state_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SaveRejectedDeferRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SaveRejectedDeferRequest) ProtoMessage() {}
+
+func (x *SaveRejectedDeferRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_state_v2_state_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SaveRejectedDeferRequest.ProtoReflect.Descriptor instead.
+func (*SaveRejectedDeferRequest) Descriptor() ([]byte, []int) {
+	return file_state_v2_state_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *SaveRejectedDeferRequest) GetId() *ID {
+	if x != nil {
+		return x.Id
+	}
+	return nil
+}
+
+func (x *SaveRejectedDeferRequest) GetFnSlug() string {
+	if x != nil {
+		return x.FnSlug
+	}
+	return ""
+}
+
+func (x *SaveRejectedDeferRequest) GetHashedId() string {
+	if x != nil {
+		return x.HashedId
+	}
+	return ""
+}
+
+type SaveRejectedDeferResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SaveRejectedDeferResponse) Reset() {
+	*x = SaveRejectedDeferResponse{}
+	mi := &file_state_v2_state_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SaveRejectedDeferResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SaveRejectedDeferResponse) ProtoMessage() {}
+
+func (x *SaveRejectedDeferResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_state_v2_state_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SaveRejectedDeferResponse.ProtoReflect.Descriptor instead.
+func (*SaveRejectedDeferResponse) Descriptor() ([]byte, []int) {
+	return file_state_v2_state_proto_rawDescGZIP(), []int{33}
+}
+
+type LoadDefersRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            *ID                    `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LoadDefersRequest) Reset() {
+	*x = LoadDefersRequest{}
+	mi := &file_state_v2_state_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LoadDefersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LoadDefersRequest) ProtoMessage() {}
+
+func (x *LoadDefersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_state_v2_state_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LoadDefersRequest.ProtoReflect.Descriptor instead.
+func (*LoadDefersRequest) Descriptor() ([]byte, []int) {
+	return file_state_v2_state_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *LoadDefersRequest) GetId() *ID {
+	if x != nil {
+		return x.Id
+	}
+	return nil
+}
+
+type LoadDefersResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Defers        map[string]*Defer      `protobuf:"bytes,1,rep,name=defers,proto3" json:"defers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LoadDefersResponse) Reset() {
+	*x = LoadDefersResponse{}
+	mi := &file_state_v2_state_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LoadDefersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LoadDefersResponse) ProtoMessage() {}
+
+func (x *LoadDefersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_state_v2_state_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LoadDefersResponse.ProtoReflect.Descriptor instead.
+func (*LoadDefersResponse) Descriptor() ([]byte, []int) {
+	return file_state_v2_state_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *LoadDefersResponse) GetDefers() map[string]*Defer {
+	if x != nil {
+		return x.Defers
+	}
+	return nil
+}
+
+type LoadDefersMetaRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            *ID                    `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LoadDefersMetaRequest) Reset() {
+	*x = LoadDefersMetaRequest{}
+	mi := &file_state_v2_state_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LoadDefersMetaRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LoadDefersMetaRequest) ProtoMessage() {}
+
+func (x *LoadDefersMetaRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_state_v2_state_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LoadDefersMetaRequest.ProtoReflect.Descriptor instead.
+func (*LoadDefersMetaRequest) Descriptor() ([]byte, []int) {
+	return file_state_v2_state_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *LoadDefersMetaRequest) GetId() *ID {
+	if x != nil {
+		return x.Id
+	}
+	return nil
+}
+
+type LoadDefersMetaResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Defers        map[string]*DeferMeta  `protobuf:"bytes,1,rep,name=defers,proto3" json:"defers,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LoadDefersMetaResponse) Reset() {
+	*x = LoadDefersMetaResponse{}
+	mi := &file_state_v2_state_proto_msgTypes[37]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LoadDefersMetaResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LoadDefersMetaResponse) ProtoMessage() {}
+
+func (x *LoadDefersMetaResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_state_v2_state_proto_msgTypes[37]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LoadDefersMetaResponse.ProtoReflect.Descriptor instead.
+func (*LoadDefersMetaResponse) Descriptor() ([]byte, []int) {
+	return file_state_v2_state_proto_rawDescGZIP(), []int{37}
+}
+
+func (x *LoadDefersMetaResponse) GetDefers() map[string]*DeferMeta {
+	if x != nil {
+		return x.Defers
+	}
+	return nil
+}
+
 type PauseIdentifier struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	RunId         string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
@@ -1486,7 +2126,7 @@ type PauseIdentifier struct {
 
 func (x *PauseIdentifier) Reset() {
 	*x = PauseIdentifier{}
-	mi := &file_state_v2_state_proto_msgTypes[26]
+	mi := &file_state_v2_state_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1498,7 +2138,7 @@ func (x *PauseIdentifier) String() string {
 func (*PauseIdentifier) ProtoMessage() {}
 
 func (x *PauseIdentifier) ProtoReflect() protoreflect.Message {
-	mi := &file_state_v2_state_proto_msgTypes[26]
+	mi := &file_state_v2_state_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1511,7 +2151,7 @@ func (x *PauseIdentifier) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PauseIdentifier.ProtoReflect.Descriptor instead.
 func (*PauseIdentifier) Descriptor() ([]byte, []int) {
-	return file_state_v2_state_proto_rawDescGZIP(), []int{26}
+	return file_state_v2_state_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *PauseIdentifier) GetRunId() string {
@@ -1549,7 +2189,7 @@ type Pause struct {
 
 func (x *Pause) Reset() {
 	*x = Pause{}
-	mi := &file_state_v2_state_proto_msgTypes[27]
+	mi := &file_state_v2_state_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1561,7 +2201,7 @@ func (x *Pause) String() string {
 func (*Pause) ProtoMessage() {}
 
 func (x *Pause) ProtoReflect() protoreflect.Message {
-	mi := &file_state_v2_state_proto_msgTypes[27]
+	mi := &file_state_v2_state_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1574,7 +2214,7 @@ func (x *Pause) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Pause.ProtoReflect.Descriptor instead.
 func (*Pause) Descriptor() ([]byte, []int) {
-	return file_state_v2_state_proto_rawDescGZIP(), []int{27}
+	return file_state_v2_state_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *Pause) GetId() string {
@@ -1614,7 +2254,7 @@ type ConsumePauseOpts struct {
 
 func (x *ConsumePauseOpts) Reset() {
 	*x = ConsumePauseOpts{}
-	mi := &file_state_v2_state_proto_msgTypes[28]
+	mi := &file_state_v2_state_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1626,7 +2266,7 @@ func (x *ConsumePauseOpts) String() string {
 func (*ConsumePauseOpts) ProtoMessage() {}
 
 func (x *ConsumePauseOpts) ProtoReflect() protoreflect.Message {
-	mi := &file_state_v2_state_proto_msgTypes[28]
+	mi := &file_state_v2_state_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1639,7 +2279,7 @@ func (x *ConsumePauseOpts) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConsumePauseOpts.ProtoReflect.Descriptor instead.
 func (*ConsumePauseOpts) Descriptor() ([]byte, []int) {
-	return file_state_v2_state_proto_rawDescGZIP(), []int{28}
+	return file_state_v2_state_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ConsumePauseOpts) GetData() []byte {
@@ -1659,7 +2299,7 @@ type ConsumePauseResult struct {
 
 func (x *ConsumePauseResult) Reset() {
 	*x = ConsumePauseResult{}
-	mi := &file_state_v2_state_proto_msgTypes[29]
+	mi := &file_state_v2_state_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1671,7 +2311,7 @@ func (x *ConsumePauseResult) String() string {
 func (*ConsumePauseResult) ProtoMessage() {}
 
 func (x *ConsumePauseResult) ProtoReflect() protoreflect.Message {
-	mi := &file_state_v2_state_proto_msgTypes[29]
+	mi := &file_state_v2_state_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1684,7 +2324,7 @@ func (x *ConsumePauseResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConsumePauseResult.ProtoReflect.Descriptor instead.
 func (*ConsumePauseResult) Descriptor() ([]byte, []int) {
-	return file_state_v2_state_proto_rawDescGZIP(), []int{29}
+	return file_state_v2_state_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ConsumePauseResult) GetDidConsume() bool {
@@ -1711,7 +2351,7 @@ type ConsumePauseRequest struct {
 
 func (x *ConsumePauseRequest) Reset() {
 	*x = ConsumePauseRequest{}
-	mi := &file_state_v2_state_proto_msgTypes[30]
+	mi := &file_state_v2_state_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1723,7 +2363,7 @@ func (x *ConsumePauseRequest) String() string {
 func (*ConsumePauseRequest) ProtoMessage() {}
 
 func (x *ConsumePauseRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_state_v2_state_proto_msgTypes[30]
+	mi := &file_state_v2_state_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1736,7 +2376,7 @@ func (x *ConsumePauseRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConsumePauseRequest.ProtoReflect.Descriptor instead.
 func (*ConsumePauseRequest) Descriptor() ([]byte, []int) {
-	return file_state_v2_state_proto_rawDescGZIP(), []int{30}
+	return file_state_v2_state_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *ConsumePauseRequest) GetPause() *Pause {
@@ -1762,7 +2402,7 @@ type ConsumePauseResponse struct {
 
 func (x *ConsumePauseResponse) Reset() {
 	*x = ConsumePauseResponse{}
-	mi := &file_state_v2_state_proto_msgTypes[31]
+	mi := &file_state_v2_state_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1774,7 +2414,7 @@ func (x *ConsumePauseResponse) String() string {
 func (*ConsumePauseResponse) ProtoMessage() {}
 
 func (x *ConsumePauseResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_state_v2_state_proto_msgTypes[31]
+	mi := &file_state_v2_state_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1787,7 +2427,7 @@ func (x *ConsumePauseResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConsumePauseResponse.ProtoReflect.Descriptor instead.
 func (*ConsumePauseResponse) Descriptor() ([]byte, []int) {
-	return file_state_v2_state_proto_rawDescGZIP(), []int{31}
+	return file_state_v2_state_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ConsumePauseResponse) GetResult() *ConsumePauseResult {
@@ -1916,7 +2556,44 @@ const file_state_v2_state_proto_rawDesc = "" +
 	"\n" +
 	"StepsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"h\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"\x93\x01\n" +
+	"\x05Defer\x12\x17\n" +
+	"\afn_slug\x18\x01 \x01(\tR\x06fnSlug\x12\x1b\n" +
+	"\thashed_id\x18\x02 \x01(\tR\bhashedId\x12>\n" +
+	"\x0fschedule_status\x18\x03 \x01(\x0e2\x15.state.v2.DeferStatusR\x0escheduleStatus\x12\x14\n" +
+	"\x05input\x18\x04 \x01(\fR\x05input\"\x81\x01\n" +
+	"\tDeferMeta\x12\x17\n" +
+	"\afn_slug\x18\x01 \x01(\tR\x06fnSlug\x12\x1b\n" +
+	"\thashed_id\x18\x02 \x01(\tR\bhashedId\x12>\n" +
+	"\x0fschedule_status\x18\x03 \x01(\x0e2\x15.state.v2.DeferStatusR\x0escheduleStatus\"W\n" +
+	"\x10SaveDeferRequest\x12\x1c\n" +
+	"\x02id\x18\x01 \x01(\v2\f.state.v2.IDR\x02id\x12%\n" +
+	"\x05defer\x18\x02 \x01(\v2\x0f.state.v2.DeferR\x05defer\"\x13\n" +
+	"\x11SaveDeferResponse\"\x81\x01\n" +
+	"\x15SetDeferStatusRequest\x12\x1c\n" +
+	"\x02id\x18\x01 \x01(\v2\f.state.v2.IDR\x02id\x12\x1b\n" +
+	"\thashed_id\x18\x02 \x01(\tR\bhashedId\x12-\n" +
+	"\x06status\x18\x03 \x01(\x0e2\x15.state.v2.DeferStatusR\x06status\"\x18\n" +
+	"\x16SetDeferStatusResponse\"n\n" +
+	"\x18SaveRejectedDeferRequest\x12\x1c\n" +
+	"\x02id\x18\x01 \x01(\v2\f.state.v2.IDR\x02id\x12\x17\n" +
+	"\afn_slug\x18\x02 \x01(\tR\x06fnSlug\x12\x1b\n" +
+	"\thashed_id\x18\x03 \x01(\tR\bhashedId\"\x1b\n" +
+	"\x19SaveRejectedDeferResponse\"1\n" +
+	"\x11LoadDefersRequest\x12\x1c\n" +
+	"\x02id\x18\x01 \x01(\v2\f.state.v2.IDR\x02id\"\xa2\x01\n" +
+	"\x12LoadDefersResponse\x12@\n" +
+	"\x06defers\x18\x01 \x03(\v2(.state.v2.LoadDefersResponse.DefersEntryR\x06defers\x1aJ\n" +
+	"\vDefersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12%\n" +
+	"\x05value\x18\x02 \x01(\v2\x0f.state.v2.DeferR\x05value:\x028\x01\"5\n" +
+	"\x15LoadDefersMetaRequest\x12\x1c\n" +
+	"\x02id\x18\x01 \x01(\v2\f.state.v2.IDR\x02id\"\xae\x01\n" +
+	"\x16LoadDefersMetaResponse\x12D\n" +
+	"\x06defers\x18\x01 \x03(\v2,.state.v2.LoadDefersMetaResponse.DefersEntryR\x06defers\x1aN\n" +
+	"\vDefersEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12)\n" +
+	"\x05value\x18\x02 \x01(\v2\x13.state.v2.DeferMetaR\x05value:\x028\x01\"h\n" +
 	"\x0fPauseIdentifier\x12\x15\n" +
 	"\x06run_id\x18\x01 \x01(\tR\x05runId\x12\x1f\n" +
 	"\vfunction_id\x18\x02 \x01(\tR\n" +
@@ -1940,7 +2617,13 @@ const file_state_v2_state_proto_rawDesc = "" +
 	"\x05pause\x18\x01 \x01(\v2\x0f.state.v2.PauseR\x05pause\x12.\n" +
 	"\x04opts\x18\x02 \x01(\v2\x1a.state.v2.ConsumePauseOptsR\x04opts\"L\n" +
 	"\x14ConsumePauseResponse\x124\n" +
-	"\x06result\x18\x01 \x01(\v2\x1c.state.v2.ConsumePauseResultR\x06result2\xc4\x06\n" +
+	"\x06result\x18\x01 \x01(\v2\x1c.state.v2.ConsumePauseResultR\x06result*\x94\x01\n" +
+	"\vDeferStatus\x12\x18\n" +
+	"\x14DEFER_STATUS_UNKNOWN\x10\x00\x12\x1a\n" +
+	"\x16DEFER_STATUS_SCHEDULED\x10\x01\x12\x1a\n" +
+	"\x16DEFER_STATUS_AFTER_RUN\x10\x02\x12\x18\n" +
+	"\x14DEFER_STATUS_ABORTED\x10\x03\x12\x19\n" +
+	"\x15DEFER_STATUS_REJECTED\x10\x042\xe5\t\n" +
 	"\n" +
 	"RunService\x12G\n" +
 	"\x06Create\x12\x1c.state.v2.CreateStateRequest\x1a\x1d.state.v2.CreateStateResponse\"\x00\x12G\n" +
@@ -1949,12 +2632,18 @@ const file_state_v2_state_proto_rawDesc = "" +
 	"\x0eUpdateMetadata\x12\x1f.state.v2.UpdateMetadataRequest\x1a .state.v2.UpdateMetadataResponse\"\x00\x12C\n" +
 	"\bSaveStep\x12\x19.state.v2.SaveStepRequest\x1a\x1a.state.v2.SaveStepResponse\"\x00\x12L\n" +
 	"\vSavePending\x12\x1c.state.v2.SavePendingRequest\x1a\x1d.state.v2.SavePendingResponse\"\x00\x12O\n" +
-	"\fConsumePause\x12\x1d.state.v2.ConsumePauseRequest\x1a\x1e.state.v2.ConsumePauseResponse\"\x00\x12O\n" +
+	"\fConsumePause\x12\x1d.state.v2.ConsumePauseRequest\x1a\x1e.state.v2.ConsumePauseResponse\"\x00\x12F\n" +
+	"\tSaveDefer\x12\x1a.state.v2.SaveDeferRequest\x1a\x1b.state.v2.SaveDeferResponse\"\x00\x12U\n" +
+	"\x0eSetDeferStatus\x12\x1f.state.v2.SetDeferStatusRequest\x1a .state.v2.SetDeferStatusResponse\"\x00\x12^\n" +
+	"\x11SaveRejectedDefer\x12\".state.v2.SaveRejectedDeferRequest\x1a#.state.v2.SaveRejectedDeferResponse\"\x00\x12O\n" +
 	"\fLoadMetadata\x12\x1d.state.v2.LoadMetadataRequest\x1a\x1e.state.v2.LoadMetadataResponse\"\x00\x12I\n" +
 	"\n" +
 	"LoadEvents\x12\x1b.state.v2.LoadEventsRequest\x1a\x1c.state.v2.LoadEventsResponse\"\x00\x12F\n" +
 	"\tLoadSteps\x12\x1a.state.v2.LoadStepsRequest\x1a\x1b.state.v2.LoadStepsResponse\"\x00\x12F\n" +
-	"\tLoadState\x12\x1a.state.v2.LoadStateRequest\x1a\x1b.state.v2.LoadStateResponse\"\x00B7Z5github.com/inngest/inngest/proto/gen/state/v2;statev2b\x06proto3"
+	"\tLoadState\x12\x1a.state.v2.LoadStateRequest\x1a\x1b.state.v2.LoadStateResponse\"\x00\x12I\n" +
+	"\n" +
+	"LoadDefers\x12\x1b.state.v2.LoadDefersRequest\x1a\x1c.state.v2.LoadDefersResponse\"\x00\x12U\n" +
+	"\x0eLoadDefersMeta\x12\x1f.state.v2.LoadDefersMetaRequest\x1a .state.v2.LoadDefersMetaResponse\"\x00B7Z5github.com/inngest/inngest/proto/gen/state/v2;statev2b\x06proto3"
 
 var (
 	file_state_v2_state_proto_rawDescOnce sync.Once
@@ -1968,102 +2657,141 @@ func file_state_v2_state_proto_rawDescGZIP() []byte {
 	return file_state_v2_state_proto_rawDescData
 }
 
-var file_state_v2_state_proto_msgTypes = make([]protoimpl.MessageInfo, 35)
+var file_state_v2_state_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_state_v2_state_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
 var file_state_v2_state_proto_goTypes = []any{
-	(*Metadata)(nil),               // 0: state.v2.Metadata
-	(*ID)(nil),                     // 1: state.v2.ID
-	(*Config)(nil),                 // 2: state.v2.Config
-	(*ConcurrencyKey)(nil),         // 3: state.v2.ConcurrencyKey
-	(*RunMetrics)(nil),             // 4: state.v2.RunMetrics
-	(*Tenant)(nil),                 // 5: state.v2.Tenant
-	(*CreateStateRequest)(nil),     // 6: state.v2.CreateStateRequest
-	(*CreateStateResponse)(nil),    // 7: state.v2.CreateStateResponse
-	(*DeleteStateRequest)(nil),     // 8: state.v2.DeleteStateRequest
-	(*DeleteStateResponse)(nil),    // 9: state.v2.DeleteStateResponse
-	(*LoadMetadataRequest)(nil),    // 10: state.v2.LoadMetadataRequest
-	(*LoadMetadataResponse)(nil),   // 11: state.v2.LoadMetadataResponse
-	(*UpdateMetadataRequest)(nil),  // 12: state.v2.UpdateMetadataRequest
-	(*UpdateMetadataResponse)(nil), // 13: state.v2.UpdateMetadataResponse
-	(*SaveStepRequest)(nil),        // 14: state.v2.SaveStepRequest
-	(*SaveStepResponse)(nil),       // 15: state.v2.SaveStepResponse
-	(*SavePendingRequest)(nil),     // 16: state.v2.SavePendingRequest
-	(*SavePendingResponse)(nil),    // 17: state.v2.SavePendingResponse
-	(*ExistsRequest)(nil),          // 18: state.v2.ExistsRequest
-	(*ExistsResponse)(nil),         // 19: state.v2.ExistsResponse
-	(*LoadEventsRequest)(nil),      // 20: state.v2.LoadEventsRequest
-	(*LoadEventsResponse)(nil),     // 21: state.v2.LoadEventsResponse
-	(*LoadStepsRequest)(nil),       // 22: state.v2.LoadStepsRequest
-	(*LoadStepsResponse)(nil),      // 23: state.v2.LoadStepsResponse
-	(*LoadStateRequest)(nil),       // 24: state.v2.LoadStateRequest
-	(*LoadStateResponse)(nil),      // 25: state.v2.LoadStateResponse
-	(*PauseIdentifier)(nil),        // 26: state.v2.PauseIdentifier
-	(*Pause)(nil),                  // 27: state.v2.Pause
-	(*ConsumePauseOpts)(nil),       // 28: state.v2.ConsumePauseOpts
-	(*ConsumePauseResult)(nil),     // 29: state.v2.ConsumePauseResult
-	(*ConsumePauseRequest)(nil),    // 30: state.v2.ConsumePauseRequest
-	(*ConsumePauseResponse)(nil),   // 31: state.v2.ConsumePauseResponse
-	nil,                            // 32: state.v2.CreateStateResponse.StepsEntry
-	nil,                            // 33: state.v2.LoadStepsResponse.StepsEntry
-	nil,                            // 34: state.v2.LoadStateResponse.StepsEntry
-	(*timestamppb.Timestamp)(nil),  // 35: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),        // 36: google.protobuf.Struct
+	(DeferStatus)(0),                  // 0: state.v2.DeferStatus
+	(*Metadata)(nil),                  // 1: state.v2.Metadata
+	(*ID)(nil),                        // 2: state.v2.ID
+	(*Config)(nil),                    // 3: state.v2.Config
+	(*ConcurrencyKey)(nil),            // 4: state.v2.ConcurrencyKey
+	(*RunMetrics)(nil),                // 5: state.v2.RunMetrics
+	(*Tenant)(nil),                    // 6: state.v2.Tenant
+	(*CreateStateRequest)(nil),        // 7: state.v2.CreateStateRequest
+	(*CreateStateResponse)(nil),       // 8: state.v2.CreateStateResponse
+	(*DeleteStateRequest)(nil),        // 9: state.v2.DeleteStateRequest
+	(*DeleteStateResponse)(nil),       // 10: state.v2.DeleteStateResponse
+	(*LoadMetadataRequest)(nil),       // 11: state.v2.LoadMetadataRequest
+	(*LoadMetadataResponse)(nil),      // 12: state.v2.LoadMetadataResponse
+	(*UpdateMetadataRequest)(nil),     // 13: state.v2.UpdateMetadataRequest
+	(*UpdateMetadataResponse)(nil),    // 14: state.v2.UpdateMetadataResponse
+	(*SaveStepRequest)(nil),           // 15: state.v2.SaveStepRequest
+	(*SaveStepResponse)(nil),          // 16: state.v2.SaveStepResponse
+	(*SavePendingRequest)(nil),        // 17: state.v2.SavePendingRequest
+	(*SavePendingResponse)(nil),       // 18: state.v2.SavePendingResponse
+	(*ExistsRequest)(nil),             // 19: state.v2.ExistsRequest
+	(*ExistsResponse)(nil),            // 20: state.v2.ExistsResponse
+	(*LoadEventsRequest)(nil),         // 21: state.v2.LoadEventsRequest
+	(*LoadEventsResponse)(nil),        // 22: state.v2.LoadEventsResponse
+	(*LoadStepsRequest)(nil),          // 23: state.v2.LoadStepsRequest
+	(*LoadStepsResponse)(nil),         // 24: state.v2.LoadStepsResponse
+	(*LoadStateRequest)(nil),          // 25: state.v2.LoadStateRequest
+	(*LoadStateResponse)(nil),         // 26: state.v2.LoadStateResponse
+	(*Defer)(nil),                     // 27: state.v2.Defer
+	(*DeferMeta)(nil),                 // 28: state.v2.DeferMeta
+	(*SaveDeferRequest)(nil),          // 29: state.v2.SaveDeferRequest
+	(*SaveDeferResponse)(nil),         // 30: state.v2.SaveDeferResponse
+	(*SetDeferStatusRequest)(nil),     // 31: state.v2.SetDeferStatusRequest
+	(*SetDeferStatusResponse)(nil),    // 32: state.v2.SetDeferStatusResponse
+	(*SaveRejectedDeferRequest)(nil),  // 33: state.v2.SaveRejectedDeferRequest
+	(*SaveRejectedDeferResponse)(nil), // 34: state.v2.SaveRejectedDeferResponse
+	(*LoadDefersRequest)(nil),         // 35: state.v2.LoadDefersRequest
+	(*LoadDefersResponse)(nil),        // 36: state.v2.LoadDefersResponse
+	(*LoadDefersMetaRequest)(nil),     // 37: state.v2.LoadDefersMetaRequest
+	(*LoadDefersMetaResponse)(nil),    // 38: state.v2.LoadDefersMetaResponse
+	(*PauseIdentifier)(nil),           // 39: state.v2.PauseIdentifier
+	(*Pause)(nil),                     // 40: state.v2.Pause
+	(*ConsumePauseOpts)(nil),          // 41: state.v2.ConsumePauseOpts
+	(*ConsumePauseResult)(nil),        // 42: state.v2.ConsumePauseResult
+	(*ConsumePauseRequest)(nil),       // 43: state.v2.ConsumePauseRequest
+	(*ConsumePauseResponse)(nil),      // 44: state.v2.ConsumePauseResponse
+	nil,                               // 45: state.v2.CreateStateResponse.StepsEntry
+	nil,                               // 46: state.v2.LoadStepsResponse.StepsEntry
+	nil,                               // 47: state.v2.LoadStateResponse.StepsEntry
+	nil,                               // 48: state.v2.LoadDefersResponse.DefersEntry
+	nil,                               // 49: state.v2.LoadDefersMetaResponse.DefersEntry
+	(*timestamppb.Timestamp)(nil),     // 50: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),           // 51: google.protobuf.Struct
 }
 var file_state_v2_state_proto_depIdxs = []int32{
-	1,  // 0: state.v2.Metadata.id:type_name -> state.v2.ID
-	2,  // 1: state.v2.Metadata.config:type_name -> state.v2.Config
-	4,  // 2: state.v2.Metadata.metrics:type_name -> state.v2.RunMetrics
-	5,  // 3: state.v2.ID.tenant:type_name -> state.v2.Tenant
-	35, // 4: state.v2.Config.started_at:type_name -> google.protobuf.Timestamp
-	3,  // 5: state.v2.Config.concurrency_keys:type_name -> state.v2.ConcurrencyKey
-	36, // 6: state.v2.Config.context:type_name -> google.protobuf.Struct
-	0,  // 7: state.v2.CreateStateRequest.metadata:type_name -> state.v2.Metadata
-	0,  // 8: state.v2.CreateStateResponse.metadata:type_name -> state.v2.Metadata
-	32, // 9: state.v2.CreateStateResponse.steps:type_name -> state.v2.CreateStateResponse.StepsEntry
-	1,  // 10: state.v2.DeleteStateRequest.id:type_name -> state.v2.ID
-	1,  // 11: state.v2.LoadMetadataRequest.id:type_name -> state.v2.ID
-	0,  // 12: state.v2.LoadMetadataResponse.metadata:type_name -> state.v2.Metadata
-	1,  // 13: state.v2.UpdateMetadataRequest.id:type_name -> state.v2.ID
-	35, // 14: state.v2.UpdateMetadataRequest.started_at:type_name -> google.protobuf.Timestamp
-	1,  // 15: state.v2.SaveStepRequest.id:type_name -> state.v2.ID
-	1,  // 16: state.v2.SavePendingRequest.id:type_name -> state.v2.ID
-	1,  // 17: state.v2.ExistsRequest.id:type_name -> state.v2.ID
-	1,  // 18: state.v2.LoadEventsRequest.id:type_name -> state.v2.ID
-	1,  // 19: state.v2.LoadStepsRequest.id:type_name -> state.v2.ID
-	33, // 20: state.v2.LoadStepsResponse.steps:type_name -> state.v2.LoadStepsResponse.StepsEntry
-	1,  // 21: state.v2.LoadStateRequest.id:type_name -> state.v2.ID
-	0,  // 22: state.v2.LoadStateResponse.metadata:type_name -> state.v2.Metadata
-	34, // 23: state.v2.LoadStateResponse.steps:type_name -> state.v2.LoadStateResponse.StepsEntry
-	26, // 24: state.v2.Pause.identifier:type_name -> state.v2.PauseIdentifier
-	27, // 25: state.v2.ConsumePauseRequest.pause:type_name -> state.v2.Pause
-	28, // 26: state.v2.ConsumePauseRequest.opts:type_name -> state.v2.ConsumePauseOpts
-	29, // 27: state.v2.ConsumePauseResponse.result:type_name -> state.v2.ConsumePauseResult
-	6,  // 28: state.v2.RunService.Create:input_type -> state.v2.CreateStateRequest
-	8,  // 29: state.v2.RunService.Delete:input_type -> state.v2.DeleteStateRequest
-	18, // 30: state.v2.RunService.Exists:input_type -> state.v2.ExistsRequest
-	12, // 31: state.v2.RunService.UpdateMetadata:input_type -> state.v2.UpdateMetadataRequest
-	14, // 32: state.v2.RunService.SaveStep:input_type -> state.v2.SaveStepRequest
-	16, // 33: state.v2.RunService.SavePending:input_type -> state.v2.SavePendingRequest
-	30, // 34: state.v2.RunService.ConsumePause:input_type -> state.v2.ConsumePauseRequest
-	10, // 35: state.v2.RunService.LoadMetadata:input_type -> state.v2.LoadMetadataRequest
-	20, // 36: state.v2.RunService.LoadEvents:input_type -> state.v2.LoadEventsRequest
-	22, // 37: state.v2.RunService.LoadSteps:input_type -> state.v2.LoadStepsRequest
-	24, // 38: state.v2.RunService.LoadState:input_type -> state.v2.LoadStateRequest
-	7,  // 39: state.v2.RunService.Create:output_type -> state.v2.CreateStateResponse
-	9,  // 40: state.v2.RunService.Delete:output_type -> state.v2.DeleteStateResponse
-	19, // 41: state.v2.RunService.Exists:output_type -> state.v2.ExistsResponse
-	13, // 42: state.v2.RunService.UpdateMetadata:output_type -> state.v2.UpdateMetadataResponse
-	15, // 43: state.v2.RunService.SaveStep:output_type -> state.v2.SaveStepResponse
-	17, // 44: state.v2.RunService.SavePending:output_type -> state.v2.SavePendingResponse
-	31, // 45: state.v2.RunService.ConsumePause:output_type -> state.v2.ConsumePauseResponse
-	11, // 46: state.v2.RunService.LoadMetadata:output_type -> state.v2.LoadMetadataResponse
-	21, // 47: state.v2.RunService.LoadEvents:output_type -> state.v2.LoadEventsResponse
-	23, // 48: state.v2.RunService.LoadSteps:output_type -> state.v2.LoadStepsResponse
-	25, // 49: state.v2.RunService.LoadState:output_type -> state.v2.LoadStateResponse
-	39, // [39:50] is the sub-list for method output_type
-	28, // [28:39] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	2,  // 0: state.v2.Metadata.id:type_name -> state.v2.ID
+	3,  // 1: state.v2.Metadata.config:type_name -> state.v2.Config
+	5,  // 2: state.v2.Metadata.metrics:type_name -> state.v2.RunMetrics
+	6,  // 3: state.v2.ID.tenant:type_name -> state.v2.Tenant
+	50, // 4: state.v2.Config.started_at:type_name -> google.protobuf.Timestamp
+	4,  // 5: state.v2.Config.concurrency_keys:type_name -> state.v2.ConcurrencyKey
+	51, // 6: state.v2.Config.context:type_name -> google.protobuf.Struct
+	1,  // 7: state.v2.CreateStateRequest.metadata:type_name -> state.v2.Metadata
+	1,  // 8: state.v2.CreateStateResponse.metadata:type_name -> state.v2.Metadata
+	45, // 9: state.v2.CreateStateResponse.steps:type_name -> state.v2.CreateStateResponse.StepsEntry
+	2,  // 10: state.v2.DeleteStateRequest.id:type_name -> state.v2.ID
+	2,  // 11: state.v2.LoadMetadataRequest.id:type_name -> state.v2.ID
+	1,  // 12: state.v2.LoadMetadataResponse.metadata:type_name -> state.v2.Metadata
+	2,  // 13: state.v2.UpdateMetadataRequest.id:type_name -> state.v2.ID
+	50, // 14: state.v2.UpdateMetadataRequest.started_at:type_name -> google.protobuf.Timestamp
+	2,  // 15: state.v2.SaveStepRequest.id:type_name -> state.v2.ID
+	2,  // 16: state.v2.SavePendingRequest.id:type_name -> state.v2.ID
+	2,  // 17: state.v2.ExistsRequest.id:type_name -> state.v2.ID
+	2,  // 18: state.v2.LoadEventsRequest.id:type_name -> state.v2.ID
+	2,  // 19: state.v2.LoadStepsRequest.id:type_name -> state.v2.ID
+	46, // 20: state.v2.LoadStepsResponse.steps:type_name -> state.v2.LoadStepsResponse.StepsEntry
+	2,  // 21: state.v2.LoadStateRequest.id:type_name -> state.v2.ID
+	1,  // 22: state.v2.LoadStateResponse.metadata:type_name -> state.v2.Metadata
+	47, // 23: state.v2.LoadStateResponse.steps:type_name -> state.v2.LoadStateResponse.StepsEntry
+	0,  // 24: state.v2.Defer.schedule_status:type_name -> state.v2.DeferStatus
+	0,  // 25: state.v2.DeferMeta.schedule_status:type_name -> state.v2.DeferStatus
+	2,  // 26: state.v2.SaveDeferRequest.id:type_name -> state.v2.ID
+	27, // 27: state.v2.SaveDeferRequest.defer:type_name -> state.v2.Defer
+	2,  // 28: state.v2.SetDeferStatusRequest.id:type_name -> state.v2.ID
+	0,  // 29: state.v2.SetDeferStatusRequest.status:type_name -> state.v2.DeferStatus
+	2,  // 30: state.v2.SaveRejectedDeferRequest.id:type_name -> state.v2.ID
+	2,  // 31: state.v2.LoadDefersRequest.id:type_name -> state.v2.ID
+	48, // 32: state.v2.LoadDefersResponse.defers:type_name -> state.v2.LoadDefersResponse.DefersEntry
+	2,  // 33: state.v2.LoadDefersMetaRequest.id:type_name -> state.v2.ID
+	49, // 34: state.v2.LoadDefersMetaResponse.defers:type_name -> state.v2.LoadDefersMetaResponse.DefersEntry
+	39, // 35: state.v2.Pause.identifier:type_name -> state.v2.PauseIdentifier
+	40, // 36: state.v2.ConsumePauseRequest.pause:type_name -> state.v2.Pause
+	41, // 37: state.v2.ConsumePauseRequest.opts:type_name -> state.v2.ConsumePauseOpts
+	42, // 38: state.v2.ConsumePauseResponse.result:type_name -> state.v2.ConsumePauseResult
+	27, // 39: state.v2.LoadDefersResponse.DefersEntry.value:type_name -> state.v2.Defer
+	28, // 40: state.v2.LoadDefersMetaResponse.DefersEntry.value:type_name -> state.v2.DeferMeta
+	7,  // 41: state.v2.RunService.Create:input_type -> state.v2.CreateStateRequest
+	9,  // 42: state.v2.RunService.Delete:input_type -> state.v2.DeleteStateRequest
+	19, // 43: state.v2.RunService.Exists:input_type -> state.v2.ExistsRequest
+	13, // 44: state.v2.RunService.UpdateMetadata:input_type -> state.v2.UpdateMetadataRequest
+	15, // 45: state.v2.RunService.SaveStep:input_type -> state.v2.SaveStepRequest
+	17, // 46: state.v2.RunService.SavePending:input_type -> state.v2.SavePendingRequest
+	43, // 47: state.v2.RunService.ConsumePause:input_type -> state.v2.ConsumePauseRequest
+	29, // 48: state.v2.RunService.SaveDefer:input_type -> state.v2.SaveDeferRequest
+	31, // 49: state.v2.RunService.SetDeferStatus:input_type -> state.v2.SetDeferStatusRequest
+	33, // 50: state.v2.RunService.SaveRejectedDefer:input_type -> state.v2.SaveRejectedDeferRequest
+	11, // 51: state.v2.RunService.LoadMetadata:input_type -> state.v2.LoadMetadataRequest
+	21, // 52: state.v2.RunService.LoadEvents:input_type -> state.v2.LoadEventsRequest
+	23, // 53: state.v2.RunService.LoadSteps:input_type -> state.v2.LoadStepsRequest
+	25, // 54: state.v2.RunService.LoadState:input_type -> state.v2.LoadStateRequest
+	35, // 55: state.v2.RunService.LoadDefers:input_type -> state.v2.LoadDefersRequest
+	37, // 56: state.v2.RunService.LoadDefersMeta:input_type -> state.v2.LoadDefersMetaRequest
+	8,  // 57: state.v2.RunService.Create:output_type -> state.v2.CreateStateResponse
+	10, // 58: state.v2.RunService.Delete:output_type -> state.v2.DeleteStateResponse
+	20, // 59: state.v2.RunService.Exists:output_type -> state.v2.ExistsResponse
+	14, // 60: state.v2.RunService.UpdateMetadata:output_type -> state.v2.UpdateMetadataResponse
+	16, // 61: state.v2.RunService.SaveStep:output_type -> state.v2.SaveStepResponse
+	18, // 62: state.v2.RunService.SavePending:output_type -> state.v2.SavePendingResponse
+	44, // 63: state.v2.RunService.ConsumePause:output_type -> state.v2.ConsumePauseResponse
+	30, // 64: state.v2.RunService.SaveDefer:output_type -> state.v2.SaveDeferResponse
+	32, // 65: state.v2.RunService.SetDeferStatus:output_type -> state.v2.SetDeferStatusResponse
+	34, // 66: state.v2.RunService.SaveRejectedDefer:output_type -> state.v2.SaveRejectedDeferResponse
+	12, // 67: state.v2.RunService.LoadMetadata:output_type -> state.v2.LoadMetadataResponse
+	22, // 68: state.v2.RunService.LoadEvents:output_type -> state.v2.LoadEventsResponse
+	24, // 69: state.v2.RunService.LoadSteps:output_type -> state.v2.LoadStepsResponse
+	26, // 70: state.v2.RunService.LoadState:output_type -> state.v2.LoadStateResponse
+	36, // 71: state.v2.RunService.LoadDefers:output_type -> state.v2.LoadDefersResponse
+	38, // 72: state.v2.RunService.LoadDefersMeta:output_type -> state.v2.LoadDefersMetaResponse
+	57, // [57:73] is the sub-list for method output_type
+	41, // [41:57] is the sub-list for method input_type
+	41, // [41:41] is the sub-list for extension type_name
+	41, // [41:41] is the sub-list for extension extendee
+	0,  // [0:41] is the sub-list for field type_name
 }
 
 func init() { file_state_v2_state_proto_init() }
@@ -2077,13 +2805,14 @@ func file_state_v2_state_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_state_v2_state_proto_rawDesc), len(file_state_v2_state_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   35,
+			NumEnums:      1,
+			NumMessages:   49,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_state_v2_state_proto_goTypes,
 		DependencyIndexes: file_state_v2_state_proto_depIdxs,
+		EnumInfos:         file_state_v2_state_proto_enumTypes,
 		MessageInfos:      file_state_v2_state_proto_msgTypes,
 	}.Build()
 	File_state_v2_state_proto = out.File

--- a/proto/gen/state/v2/state_grpc.pb.go
+++ b/proto/gen/state/v2/state_grpc.pb.go
@@ -19,17 +19,22 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	RunService_Create_FullMethodName         = "/state.v2.RunService/Create"
-	RunService_Delete_FullMethodName         = "/state.v2.RunService/Delete"
-	RunService_Exists_FullMethodName         = "/state.v2.RunService/Exists"
-	RunService_UpdateMetadata_FullMethodName = "/state.v2.RunService/UpdateMetadata"
-	RunService_SaveStep_FullMethodName       = "/state.v2.RunService/SaveStep"
-	RunService_SavePending_FullMethodName    = "/state.v2.RunService/SavePending"
-	RunService_ConsumePause_FullMethodName   = "/state.v2.RunService/ConsumePause"
-	RunService_LoadMetadata_FullMethodName   = "/state.v2.RunService/LoadMetadata"
-	RunService_LoadEvents_FullMethodName     = "/state.v2.RunService/LoadEvents"
-	RunService_LoadSteps_FullMethodName      = "/state.v2.RunService/LoadSteps"
-	RunService_LoadState_FullMethodName      = "/state.v2.RunService/LoadState"
+	RunService_Create_FullMethodName            = "/state.v2.RunService/Create"
+	RunService_Delete_FullMethodName            = "/state.v2.RunService/Delete"
+	RunService_Exists_FullMethodName            = "/state.v2.RunService/Exists"
+	RunService_UpdateMetadata_FullMethodName    = "/state.v2.RunService/UpdateMetadata"
+	RunService_SaveStep_FullMethodName          = "/state.v2.RunService/SaveStep"
+	RunService_SavePending_FullMethodName       = "/state.v2.RunService/SavePending"
+	RunService_ConsumePause_FullMethodName      = "/state.v2.RunService/ConsumePause"
+	RunService_SaveDefer_FullMethodName         = "/state.v2.RunService/SaveDefer"
+	RunService_SetDeferStatus_FullMethodName    = "/state.v2.RunService/SetDeferStatus"
+	RunService_SaveRejectedDefer_FullMethodName = "/state.v2.RunService/SaveRejectedDefer"
+	RunService_LoadMetadata_FullMethodName      = "/state.v2.RunService/LoadMetadata"
+	RunService_LoadEvents_FullMethodName        = "/state.v2.RunService/LoadEvents"
+	RunService_LoadSteps_FullMethodName         = "/state.v2.RunService/LoadSteps"
+	RunService_LoadState_FullMethodName         = "/state.v2.RunService/LoadState"
+	RunService_LoadDefers_FullMethodName        = "/state.v2.RunService/LoadDefers"
+	RunService_LoadDefersMeta_FullMethodName    = "/state.v2.RunService/LoadDefersMeta"
 )
 
 // RunServiceClient is the client API for RunService service.
@@ -43,10 +48,15 @@ type RunServiceClient interface {
 	SaveStep(ctx context.Context, in *SaveStepRequest, opts ...grpc.CallOption) (*SaveStepResponse, error)
 	SavePending(ctx context.Context, in *SavePendingRequest, opts ...grpc.CallOption) (*SavePendingResponse, error)
 	ConsumePause(ctx context.Context, in *ConsumePauseRequest, opts ...grpc.CallOption) (*ConsumePauseResponse, error)
+	SaveDefer(ctx context.Context, in *SaveDeferRequest, opts ...grpc.CallOption) (*SaveDeferResponse, error)
+	SetDeferStatus(ctx context.Context, in *SetDeferStatusRequest, opts ...grpc.CallOption) (*SetDeferStatusResponse, error)
+	SaveRejectedDefer(ctx context.Context, in *SaveRejectedDeferRequest, opts ...grpc.CallOption) (*SaveRejectedDeferResponse, error)
 	LoadMetadata(ctx context.Context, in *LoadMetadataRequest, opts ...grpc.CallOption) (*LoadMetadataResponse, error)
 	LoadEvents(ctx context.Context, in *LoadEventsRequest, opts ...grpc.CallOption) (*LoadEventsResponse, error)
 	LoadSteps(ctx context.Context, in *LoadStepsRequest, opts ...grpc.CallOption) (*LoadStepsResponse, error)
 	LoadState(ctx context.Context, in *LoadStateRequest, opts ...grpc.CallOption) (*LoadStateResponse, error)
+	LoadDefers(ctx context.Context, in *LoadDefersRequest, opts ...grpc.CallOption) (*LoadDefersResponse, error)
+	LoadDefersMeta(ctx context.Context, in *LoadDefersMetaRequest, opts ...grpc.CallOption) (*LoadDefersMetaResponse, error)
 }
 
 type runServiceClient struct {
@@ -127,6 +137,36 @@ func (c *runServiceClient) ConsumePause(ctx context.Context, in *ConsumePauseReq
 	return out, nil
 }
 
+func (c *runServiceClient) SaveDefer(ctx context.Context, in *SaveDeferRequest, opts ...grpc.CallOption) (*SaveDeferResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SaveDeferResponse)
+	err := c.cc.Invoke(ctx, RunService_SaveDefer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *runServiceClient) SetDeferStatus(ctx context.Context, in *SetDeferStatusRequest, opts ...grpc.CallOption) (*SetDeferStatusResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SetDeferStatusResponse)
+	err := c.cc.Invoke(ctx, RunService_SetDeferStatus_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *runServiceClient) SaveRejectedDefer(ctx context.Context, in *SaveRejectedDeferRequest, opts ...grpc.CallOption) (*SaveRejectedDeferResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(SaveRejectedDeferResponse)
+	err := c.cc.Invoke(ctx, RunService_SaveRejectedDefer_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *runServiceClient) LoadMetadata(ctx context.Context, in *LoadMetadataRequest, opts ...grpc.CallOption) (*LoadMetadataResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(LoadMetadataResponse)
@@ -167,6 +207,26 @@ func (c *runServiceClient) LoadState(ctx context.Context, in *LoadStateRequest, 
 	return out, nil
 }
 
+func (c *runServiceClient) LoadDefers(ctx context.Context, in *LoadDefersRequest, opts ...grpc.CallOption) (*LoadDefersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(LoadDefersResponse)
+	err := c.cc.Invoke(ctx, RunService_LoadDefers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *runServiceClient) LoadDefersMeta(ctx context.Context, in *LoadDefersMetaRequest, opts ...grpc.CallOption) (*LoadDefersMetaResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(LoadDefersMetaResponse)
+	err := c.cc.Invoke(ctx, RunService_LoadDefersMeta_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // RunServiceServer is the server API for RunService service.
 // All implementations must embed UnimplementedRunServiceServer
 // for forward compatibility.
@@ -178,10 +238,15 @@ type RunServiceServer interface {
 	SaveStep(context.Context, *SaveStepRequest) (*SaveStepResponse, error)
 	SavePending(context.Context, *SavePendingRequest) (*SavePendingResponse, error)
 	ConsumePause(context.Context, *ConsumePauseRequest) (*ConsumePauseResponse, error)
+	SaveDefer(context.Context, *SaveDeferRequest) (*SaveDeferResponse, error)
+	SetDeferStatus(context.Context, *SetDeferStatusRequest) (*SetDeferStatusResponse, error)
+	SaveRejectedDefer(context.Context, *SaveRejectedDeferRequest) (*SaveRejectedDeferResponse, error)
 	LoadMetadata(context.Context, *LoadMetadataRequest) (*LoadMetadataResponse, error)
 	LoadEvents(context.Context, *LoadEventsRequest) (*LoadEventsResponse, error)
 	LoadSteps(context.Context, *LoadStepsRequest) (*LoadStepsResponse, error)
 	LoadState(context.Context, *LoadStateRequest) (*LoadStateResponse, error)
+	LoadDefers(context.Context, *LoadDefersRequest) (*LoadDefersResponse, error)
+	LoadDefersMeta(context.Context, *LoadDefersMetaRequest) (*LoadDefersMetaResponse, error)
 	mustEmbedUnimplementedRunServiceServer()
 }
 
@@ -213,6 +278,15 @@ func (UnimplementedRunServiceServer) SavePending(context.Context, *SavePendingRe
 func (UnimplementedRunServiceServer) ConsumePause(context.Context, *ConsumePauseRequest) (*ConsumePauseResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ConsumePause not implemented")
 }
+func (UnimplementedRunServiceServer) SaveDefer(context.Context, *SaveDeferRequest) (*SaveDeferResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SaveDefer not implemented")
+}
+func (UnimplementedRunServiceServer) SetDeferStatus(context.Context, *SetDeferStatusRequest) (*SetDeferStatusResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SetDeferStatus not implemented")
+}
+func (UnimplementedRunServiceServer) SaveRejectedDefer(context.Context, *SaveRejectedDeferRequest) (*SaveRejectedDeferResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method SaveRejectedDefer not implemented")
+}
 func (UnimplementedRunServiceServer) LoadMetadata(context.Context, *LoadMetadataRequest) (*LoadMetadataResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method LoadMetadata not implemented")
 }
@@ -224,6 +298,12 @@ func (UnimplementedRunServiceServer) LoadSteps(context.Context, *LoadStepsReques
 }
 func (UnimplementedRunServiceServer) LoadState(context.Context, *LoadStateRequest) (*LoadStateResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method LoadState not implemented")
+}
+func (UnimplementedRunServiceServer) LoadDefers(context.Context, *LoadDefersRequest) (*LoadDefersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method LoadDefers not implemented")
+}
+func (UnimplementedRunServiceServer) LoadDefersMeta(context.Context, *LoadDefersMetaRequest) (*LoadDefersMetaResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method LoadDefersMeta not implemented")
 }
 func (UnimplementedRunServiceServer) mustEmbedUnimplementedRunServiceServer() {}
 func (UnimplementedRunServiceServer) testEmbeddedByValue()                    {}
@@ -372,6 +452,60 @@ func _RunService_ConsumePause_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _RunService_SaveDefer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SaveDeferRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RunServiceServer).SaveDefer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RunService_SaveDefer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RunServiceServer).SaveDefer(ctx, req.(*SaveDeferRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RunService_SetDeferStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetDeferStatusRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RunServiceServer).SetDeferStatus(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RunService_SetDeferStatus_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RunServiceServer).SetDeferStatus(ctx, req.(*SetDeferStatusRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RunService_SaveRejectedDefer_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SaveRejectedDeferRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RunServiceServer).SaveRejectedDefer(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RunService_SaveRejectedDefer_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RunServiceServer).SaveRejectedDefer(ctx, req.(*SaveRejectedDeferRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _RunService_LoadMetadata_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(LoadMetadataRequest)
 	if err := dec(in); err != nil {
@@ -444,6 +578,42 @@ func _RunService_LoadState_Handler(srv interface{}, ctx context.Context, dec fun
 	return interceptor(ctx, in, info, handler)
 }
 
+func _RunService_LoadDefers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(LoadDefersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RunServiceServer).LoadDefers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RunService_LoadDefers_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RunServiceServer).LoadDefers(ctx, req.(*LoadDefersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _RunService_LoadDefersMeta_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(LoadDefersMetaRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RunServiceServer).LoadDefersMeta(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RunService_LoadDefersMeta_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RunServiceServer).LoadDefersMeta(ctx, req.(*LoadDefersMetaRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // RunService_ServiceDesc is the grpc.ServiceDesc for RunService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -480,6 +650,18 @@ var RunService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _RunService_ConsumePause_Handler,
 		},
 		{
+			MethodName: "SaveDefer",
+			Handler:    _RunService_SaveDefer_Handler,
+		},
+		{
+			MethodName: "SetDeferStatus",
+			Handler:    _RunService_SetDeferStatus_Handler,
+		},
+		{
+			MethodName: "SaveRejectedDefer",
+			Handler:    _RunService_SaveRejectedDefer_Handler,
+		},
+		{
 			MethodName: "LoadMetadata",
 			Handler:    _RunService_LoadMetadata_Handler,
 		},
@@ -494,6 +676,14 @@ var RunService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "LoadState",
 			Handler:    _RunService_LoadState_Handler,
+		},
+		{
+			MethodName: "LoadDefers",
+			Handler:    _RunService_LoadDefers_Handler,
+		},
+		{
+			MethodName: "LoadDefersMeta",
+			Handler:    _RunService_LoadDefersMeta_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/gen/state/v2/statev2connect/state.connect.go
+++ b/proto/gen/state/v2/statev2connect/state.connect.go
@@ -48,6 +48,14 @@ const (
 	RunServiceSavePendingProcedure = "/state.v2.RunService/SavePending"
 	// RunServiceConsumePauseProcedure is the fully-qualified name of the RunService's ConsumePause RPC.
 	RunServiceConsumePauseProcedure = "/state.v2.RunService/ConsumePause"
+	// RunServiceSaveDeferProcedure is the fully-qualified name of the RunService's SaveDefer RPC.
+	RunServiceSaveDeferProcedure = "/state.v2.RunService/SaveDefer"
+	// RunServiceSetDeferStatusProcedure is the fully-qualified name of the RunService's SetDeferStatus
+	// RPC.
+	RunServiceSetDeferStatusProcedure = "/state.v2.RunService/SetDeferStatus"
+	// RunServiceSaveRejectedDeferProcedure is the fully-qualified name of the RunService's
+	// SaveRejectedDefer RPC.
+	RunServiceSaveRejectedDeferProcedure = "/state.v2.RunService/SaveRejectedDefer"
 	// RunServiceLoadMetadataProcedure is the fully-qualified name of the RunService's LoadMetadata RPC.
 	RunServiceLoadMetadataProcedure = "/state.v2.RunService/LoadMetadata"
 	// RunServiceLoadEventsProcedure is the fully-qualified name of the RunService's LoadEvents RPC.
@@ -56,6 +64,11 @@ const (
 	RunServiceLoadStepsProcedure = "/state.v2.RunService/LoadSteps"
 	// RunServiceLoadStateProcedure is the fully-qualified name of the RunService's LoadState RPC.
 	RunServiceLoadStateProcedure = "/state.v2.RunService/LoadState"
+	// RunServiceLoadDefersProcedure is the fully-qualified name of the RunService's LoadDefers RPC.
+	RunServiceLoadDefersProcedure = "/state.v2.RunService/LoadDefers"
+	// RunServiceLoadDefersMetaProcedure is the fully-qualified name of the RunService's LoadDefersMeta
+	// RPC.
+	RunServiceLoadDefersMetaProcedure = "/state.v2.RunService/LoadDefersMeta"
 )
 
 // RunServiceClient is a client for the state.v2.RunService service.
@@ -67,10 +80,15 @@ type RunServiceClient interface {
 	SaveStep(context.Context, *connect.Request[v2.SaveStepRequest]) (*connect.Response[v2.SaveStepResponse], error)
 	SavePending(context.Context, *connect.Request[v2.SavePendingRequest]) (*connect.Response[v2.SavePendingResponse], error)
 	ConsumePause(context.Context, *connect.Request[v2.ConsumePauseRequest]) (*connect.Response[v2.ConsumePauseResponse], error)
+	SaveDefer(context.Context, *connect.Request[v2.SaveDeferRequest]) (*connect.Response[v2.SaveDeferResponse], error)
+	SetDeferStatus(context.Context, *connect.Request[v2.SetDeferStatusRequest]) (*connect.Response[v2.SetDeferStatusResponse], error)
+	SaveRejectedDefer(context.Context, *connect.Request[v2.SaveRejectedDeferRequest]) (*connect.Response[v2.SaveRejectedDeferResponse], error)
 	LoadMetadata(context.Context, *connect.Request[v2.LoadMetadataRequest]) (*connect.Response[v2.LoadMetadataResponse], error)
 	LoadEvents(context.Context, *connect.Request[v2.LoadEventsRequest]) (*connect.Response[v2.LoadEventsResponse], error)
 	LoadSteps(context.Context, *connect.Request[v2.LoadStepsRequest]) (*connect.Response[v2.LoadStepsResponse], error)
 	LoadState(context.Context, *connect.Request[v2.LoadStateRequest]) (*connect.Response[v2.LoadStateResponse], error)
+	LoadDefers(context.Context, *connect.Request[v2.LoadDefersRequest]) (*connect.Response[v2.LoadDefersResponse], error)
+	LoadDefersMeta(context.Context, *connect.Request[v2.LoadDefersMetaRequest]) (*connect.Response[v2.LoadDefersMetaResponse], error)
 }
 
 // NewRunServiceClient constructs a client for the state.v2.RunService service. By default, it uses
@@ -126,6 +144,24 @@ func NewRunServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...
 			connect.WithSchema(runServiceMethods.ByName("ConsumePause")),
 			connect.WithClientOptions(opts...),
 		),
+		saveDefer: connect.NewClient[v2.SaveDeferRequest, v2.SaveDeferResponse](
+			httpClient,
+			baseURL+RunServiceSaveDeferProcedure,
+			connect.WithSchema(runServiceMethods.ByName("SaveDefer")),
+			connect.WithClientOptions(opts...),
+		),
+		setDeferStatus: connect.NewClient[v2.SetDeferStatusRequest, v2.SetDeferStatusResponse](
+			httpClient,
+			baseURL+RunServiceSetDeferStatusProcedure,
+			connect.WithSchema(runServiceMethods.ByName("SetDeferStatus")),
+			connect.WithClientOptions(opts...),
+		),
+		saveRejectedDefer: connect.NewClient[v2.SaveRejectedDeferRequest, v2.SaveRejectedDeferResponse](
+			httpClient,
+			baseURL+RunServiceSaveRejectedDeferProcedure,
+			connect.WithSchema(runServiceMethods.ByName("SaveRejectedDefer")),
+			connect.WithClientOptions(opts...),
+		),
 		loadMetadata: connect.NewClient[v2.LoadMetadataRequest, v2.LoadMetadataResponse](
 			httpClient,
 			baseURL+RunServiceLoadMetadataProcedure,
@@ -150,22 +186,39 @@ func NewRunServiceClient(httpClient connect.HTTPClient, baseURL string, opts ...
 			connect.WithSchema(runServiceMethods.ByName("LoadState")),
 			connect.WithClientOptions(opts...),
 		),
+		loadDefers: connect.NewClient[v2.LoadDefersRequest, v2.LoadDefersResponse](
+			httpClient,
+			baseURL+RunServiceLoadDefersProcedure,
+			connect.WithSchema(runServiceMethods.ByName("LoadDefers")),
+			connect.WithClientOptions(opts...),
+		),
+		loadDefersMeta: connect.NewClient[v2.LoadDefersMetaRequest, v2.LoadDefersMetaResponse](
+			httpClient,
+			baseURL+RunServiceLoadDefersMetaProcedure,
+			connect.WithSchema(runServiceMethods.ByName("LoadDefersMeta")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
 // runServiceClient implements RunServiceClient.
 type runServiceClient struct {
-	create         *connect.Client[v2.CreateStateRequest, v2.CreateStateResponse]
-	delete         *connect.Client[v2.DeleteStateRequest, v2.DeleteStateResponse]
-	exists         *connect.Client[v2.ExistsRequest, v2.ExistsResponse]
-	updateMetadata *connect.Client[v2.UpdateMetadataRequest, v2.UpdateMetadataResponse]
-	saveStep       *connect.Client[v2.SaveStepRequest, v2.SaveStepResponse]
-	savePending    *connect.Client[v2.SavePendingRequest, v2.SavePendingResponse]
-	consumePause   *connect.Client[v2.ConsumePauseRequest, v2.ConsumePauseResponse]
-	loadMetadata   *connect.Client[v2.LoadMetadataRequest, v2.LoadMetadataResponse]
-	loadEvents     *connect.Client[v2.LoadEventsRequest, v2.LoadEventsResponse]
-	loadSteps      *connect.Client[v2.LoadStepsRequest, v2.LoadStepsResponse]
-	loadState      *connect.Client[v2.LoadStateRequest, v2.LoadStateResponse]
+	create            *connect.Client[v2.CreateStateRequest, v2.CreateStateResponse]
+	delete            *connect.Client[v2.DeleteStateRequest, v2.DeleteStateResponse]
+	exists            *connect.Client[v2.ExistsRequest, v2.ExistsResponse]
+	updateMetadata    *connect.Client[v2.UpdateMetadataRequest, v2.UpdateMetadataResponse]
+	saveStep          *connect.Client[v2.SaveStepRequest, v2.SaveStepResponse]
+	savePending       *connect.Client[v2.SavePendingRequest, v2.SavePendingResponse]
+	consumePause      *connect.Client[v2.ConsumePauseRequest, v2.ConsumePauseResponse]
+	saveDefer         *connect.Client[v2.SaveDeferRequest, v2.SaveDeferResponse]
+	setDeferStatus    *connect.Client[v2.SetDeferStatusRequest, v2.SetDeferStatusResponse]
+	saveRejectedDefer *connect.Client[v2.SaveRejectedDeferRequest, v2.SaveRejectedDeferResponse]
+	loadMetadata      *connect.Client[v2.LoadMetadataRequest, v2.LoadMetadataResponse]
+	loadEvents        *connect.Client[v2.LoadEventsRequest, v2.LoadEventsResponse]
+	loadSteps         *connect.Client[v2.LoadStepsRequest, v2.LoadStepsResponse]
+	loadState         *connect.Client[v2.LoadStateRequest, v2.LoadStateResponse]
+	loadDefers        *connect.Client[v2.LoadDefersRequest, v2.LoadDefersResponse]
+	loadDefersMeta    *connect.Client[v2.LoadDefersMetaRequest, v2.LoadDefersMetaResponse]
 }
 
 // Create calls state.v2.RunService.Create.
@@ -203,6 +256,21 @@ func (c *runServiceClient) ConsumePause(ctx context.Context, req *connect.Reques
 	return c.consumePause.CallUnary(ctx, req)
 }
 
+// SaveDefer calls state.v2.RunService.SaveDefer.
+func (c *runServiceClient) SaveDefer(ctx context.Context, req *connect.Request[v2.SaveDeferRequest]) (*connect.Response[v2.SaveDeferResponse], error) {
+	return c.saveDefer.CallUnary(ctx, req)
+}
+
+// SetDeferStatus calls state.v2.RunService.SetDeferStatus.
+func (c *runServiceClient) SetDeferStatus(ctx context.Context, req *connect.Request[v2.SetDeferStatusRequest]) (*connect.Response[v2.SetDeferStatusResponse], error) {
+	return c.setDeferStatus.CallUnary(ctx, req)
+}
+
+// SaveRejectedDefer calls state.v2.RunService.SaveRejectedDefer.
+func (c *runServiceClient) SaveRejectedDefer(ctx context.Context, req *connect.Request[v2.SaveRejectedDeferRequest]) (*connect.Response[v2.SaveRejectedDeferResponse], error) {
+	return c.saveRejectedDefer.CallUnary(ctx, req)
+}
+
 // LoadMetadata calls state.v2.RunService.LoadMetadata.
 func (c *runServiceClient) LoadMetadata(ctx context.Context, req *connect.Request[v2.LoadMetadataRequest]) (*connect.Response[v2.LoadMetadataResponse], error) {
 	return c.loadMetadata.CallUnary(ctx, req)
@@ -223,6 +291,16 @@ func (c *runServiceClient) LoadState(ctx context.Context, req *connect.Request[v
 	return c.loadState.CallUnary(ctx, req)
 }
 
+// LoadDefers calls state.v2.RunService.LoadDefers.
+func (c *runServiceClient) LoadDefers(ctx context.Context, req *connect.Request[v2.LoadDefersRequest]) (*connect.Response[v2.LoadDefersResponse], error) {
+	return c.loadDefers.CallUnary(ctx, req)
+}
+
+// LoadDefersMeta calls state.v2.RunService.LoadDefersMeta.
+func (c *runServiceClient) LoadDefersMeta(ctx context.Context, req *connect.Request[v2.LoadDefersMetaRequest]) (*connect.Response[v2.LoadDefersMetaResponse], error) {
+	return c.loadDefersMeta.CallUnary(ctx, req)
+}
+
 // RunServiceHandler is an implementation of the state.v2.RunService service.
 type RunServiceHandler interface {
 	Create(context.Context, *connect.Request[v2.CreateStateRequest]) (*connect.Response[v2.CreateStateResponse], error)
@@ -232,10 +310,15 @@ type RunServiceHandler interface {
 	SaveStep(context.Context, *connect.Request[v2.SaveStepRequest]) (*connect.Response[v2.SaveStepResponse], error)
 	SavePending(context.Context, *connect.Request[v2.SavePendingRequest]) (*connect.Response[v2.SavePendingResponse], error)
 	ConsumePause(context.Context, *connect.Request[v2.ConsumePauseRequest]) (*connect.Response[v2.ConsumePauseResponse], error)
+	SaveDefer(context.Context, *connect.Request[v2.SaveDeferRequest]) (*connect.Response[v2.SaveDeferResponse], error)
+	SetDeferStatus(context.Context, *connect.Request[v2.SetDeferStatusRequest]) (*connect.Response[v2.SetDeferStatusResponse], error)
+	SaveRejectedDefer(context.Context, *connect.Request[v2.SaveRejectedDeferRequest]) (*connect.Response[v2.SaveRejectedDeferResponse], error)
 	LoadMetadata(context.Context, *connect.Request[v2.LoadMetadataRequest]) (*connect.Response[v2.LoadMetadataResponse], error)
 	LoadEvents(context.Context, *connect.Request[v2.LoadEventsRequest]) (*connect.Response[v2.LoadEventsResponse], error)
 	LoadSteps(context.Context, *connect.Request[v2.LoadStepsRequest]) (*connect.Response[v2.LoadStepsResponse], error)
 	LoadState(context.Context, *connect.Request[v2.LoadStateRequest]) (*connect.Response[v2.LoadStateResponse], error)
+	LoadDefers(context.Context, *connect.Request[v2.LoadDefersRequest]) (*connect.Response[v2.LoadDefersResponse], error)
+	LoadDefersMeta(context.Context, *connect.Request[v2.LoadDefersMetaRequest]) (*connect.Response[v2.LoadDefersMetaResponse], error)
 }
 
 // NewRunServiceHandler builds an HTTP handler from the service implementation. It returns the path
@@ -287,6 +370,24 @@ func NewRunServiceHandler(svc RunServiceHandler, opts ...connect.HandlerOption) 
 		connect.WithSchema(runServiceMethods.ByName("ConsumePause")),
 		connect.WithHandlerOptions(opts...),
 	)
+	runServiceSaveDeferHandler := connect.NewUnaryHandler(
+		RunServiceSaveDeferProcedure,
+		svc.SaveDefer,
+		connect.WithSchema(runServiceMethods.ByName("SaveDefer")),
+		connect.WithHandlerOptions(opts...),
+	)
+	runServiceSetDeferStatusHandler := connect.NewUnaryHandler(
+		RunServiceSetDeferStatusProcedure,
+		svc.SetDeferStatus,
+		connect.WithSchema(runServiceMethods.ByName("SetDeferStatus")),
+		connect.WithHandlerOptions(opts...),
+	)
+	runServiceSaveRejectedDeferHandler := connect.NewUnaryHandler(
+		RunServiceSaveRejectedDeferProcedure,
+		svc.SaveRejectedDefer,
+		connect.WithSchema(runServiceMethods.ByName("SaveRejectedDefer")),
+		connect.WithHandlerOptions(opts...),
+	)
 	runServiceLoadMetadataHandler := connect.NewUnaryHandler(
 		RunServiceLoadMetadataProcedure,
 		svc.LoadMetadata,
@@ -311,6 +412,18 @@ func NewRunServiceHandler(svc RunServiceHandler, opts ...connect.HandlerOption) 
 		connect.WithSchema(runServiceMethods.ByName("LoadState")),
 		connect.WithHandlerOptions(opts...),
 	)
+	runServiceLoadDefersHandler := connect.NewUnaryHandler(
+		RunServiceLoadDefersProcedure,
+		svc.LoadDefers,
+		connect.WithSchema(runServiceMethods.ByName("LoadDefers")),
+		connect.WithHandlerOptions(opts...),
+	)
+	runServiceLoadDefersMetaHandler := connect.NewUnaryHandler(
+		RunServiceLoadDefersMetaProcedure,
+		svc.LoadDefersMeta,
+		connect.WithSchema(runServiceMethods.ByName("LoadDefersMeta")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/state.v2.RunService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case RunServiceCreateProcedure:
@@ -327,6 +440,12 @@ func NewRunServiceHandler(svc RunServiceHandler, opts ...connect.HandlerOption) 
 			runServiceSavePendingHandler.ServeHTTP(w, r)
 		case RunServiceConsumePauseProcedure:
 			runServiceConsumePauseHandler.ServeHTTP(w, r)
+		case RunServiceSaveDeferProcedure:
+			runServiceSaveDeferHandler.ServeHTTP(w, r)
+		case RunServiceSetDeferStatusProcedure:
+			runServiceSetDeferStatusHandler.ServeHTTP(w, r)
+		case RunServiceSaveRejectedDeferProcedure:
+			runServiceSaveRejectedDeferHandler.ServeHTTP(w, r)
 		case RunServiceLoadMetadataProcedure:
 			runServiceLoadMetadataHandler.ServeHTTP(w, r)
 		case RunServiceLoadEventsProcedure:
@@ -335,6 +454,10 @@ func NewRunServiceHandler(svc RunServiceHandler, opts ...connect.HandlerOption) 
 			runServiceLoadStepsHandler.ServeHTTP(w, r)
 		case RunServiceLoadStateProcedure:
 			runServiceLoadStateHandler.ServeHTTP(w, r)
+		case RunServiceLoadDefersProcedure:
+			runServiceLoadDefersHandler.ServeHTTP(w, r)
+		case RunServiceLoadDefersMetaProcedure:
+			runServiceLoadDefersMetaHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -372,6 +495,18 @@ func (UnimplementedRunServiceHandler) ConsumePause(context.Context, *connect.Req
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("state.v2.RunService.ConsumePause is not implemented"))
 }
 
+func (UnimplementedRunServiceHandler) SaveDefer(context.Context, *connect.Request[v2.SaveDeferRequest]) (*connect.Response[v2.SaveDeferResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("state.v2.RunService.SaveDefer is not implemented"))
+}
+
+func (UnimplementedRunServiceHandler) SetDeferStatus(context.Context, *connect.Request[v2.SetDeferStatusRequest]) (*connect.Response[v2.SetDeferStatusResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("state.v2.RunService.SetDeferStatus is not implemented"))
+}
+
+func (UnimplementedRunServiceHandler) SaveRejectedDefer(context.Context, *connect.Request[v2.SaveRejectedDeferRequest]) (*connect.Response[v2.SaveRejectedDeferResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("state.v2.RunService.SaveRejectedDefer is not implemented"))
+}
+
 func (UnimplementedRunServiceHandler) LoadMetadata(context.Context, *connect.Request[v2.LoadMetadataRequest]) (*connect.Response[v2.LoadMetadataResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("state.v2.RunService.LoadMetadata is not implemented"))
 }
@@ -386,4 +521,12 @@ func (UnimplementedRunServiceHandler) LoadSteps(context.Context, *connect.Reques
 
 func (UnimplementedRunServiceHandler) LoadState(context.Context, *connect.Request[v2.LoadStateRequest]) (*connect.Response[v2.LoadStateResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("state.v2.RunService.LoadState is not implemented"))
+}
+
+func (UnimplementedRunServiceHandler) LoadDefers(context.Context, *connect.Request[v2.LoadDefersRequest]) (*connect.Response[v2.LoadDefersResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("state.v2.RunService.LoadDefers is not implemented"))
+}
+
+func (UnimplementedRunServiceHandler) LoadDefersMeta(context.Context, *connect.Request[v2.LoadDefersMetaRequest]) (*connect.Response[v2.LoadDefersMetaResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("state.v2.RunService.LoadDefersMeta is not implemented"))
 }

--- a/proto/state/v2/state.proto
+++ b/proto/state/v2/state.proto
@@ -152,6 +152,67 @@ message LoadStateResponse {
   map<string, bytes> steps    = 3;
 }
 
+// DeferStatus mirrors enums.DeferStatus
+enum DeferStatus {
+  DEFER_STATUS_UNKNOWN   = 0;
+  DEFER_STATUS_SCHEDULED = 1;
+  DEFER_STATUS_AFTER_RUN = 2;
+  DEFER_STATUS_ABORTED   = 3;
+  DEFER_STATUS_REJECTED  = 4;
+}
+
+message Defer {
+  string      fn_slug         = 1;
+  string      hashed_id       = 2;
+  DeferStatus schedule_status = 3;
+  bytes       input           = 4;
+}
+
+message DeferMeta {
+  string      fn_slug         = 1;
+  string      hashed_id       = 2;
+  DeferStatus schedule_status = 3;
+}
+
+message SaveDeferRequest {
+  ID    id    = 1;
+  Defer defer = 2;
+}
+
+message SaveDeferResponse {}
+
+message SetDeferStatusRequest {
+  ID          id        = 1;
+  string      hashed_id = 2;
+  DeferStatus status    = 3;
+}
+
+message SetDeferStatusResponse {}
+
+message SaveRejectedDeferRequest {
+  ID     id        = 1;
+  string fn_slug   = 2;
+  string hashed_id = 3;
+}
+
+message SaveRejectedDeferResponse {}
+
+message LoadDefersRequest {
+  ID id = 1;
+}
+
+message LoadDefersResponse {
+  map<string, Defer> defers = 1;
+}
+
+message LoadDefersMetaRequest {
+  ID id = 1;
+}
+
+message LoadDefersMetaResponse {
+  map<string, DeferMeta> defers = 1;
+}
+
 message PauseIdentifier {
   string run_id      = 1;
   string function_id = 2;
@@ -195,8 +256,14 @@ service RunService {
   rpc SavePending(SavePendingRequest) returns (SavePendingResponse) {}
   rpc ConsumePause(ConsumePauseRequest) returns (ConsumePauseResponse) {}
 
+  rpc SaveDefer(SaveDeferRequest) returns (SaveDeferResponse) {}
+  rpc SetDeferStatus(SetDeferStatusRequest) returns (SetDeferStatusResponse) {}
+  rpc SaveRejectedDefer(SaveRejectedDeferRequest) returns (SaveRejectedDeferResponse) {}
+
   rpc LoadMetadata(LoadMetadataRequest) returns (LoadMetadataResponse) {}
   rpc LoadEvents(LoadEventsRequest) returns (LoadEventsResponse) {}
   rpc LoadSteps(LoadStepsRequest) returns (LoadStepsResponse) {}
   rpc LoadState(LoadStateRequest) returns (LoadStateResponse) {}
+  rpc LoadDefers(LoadDefersRequest) returns (LoadDefersResponse) {}
+  rpc LoadDefersMeta(LoadDefersMetaRequest) returns (LoadDefersMetaResponse) {}
 }


### PR DESCRIPTION
## Description
Needed to implement defer operations as state proxy operations in Cloud.

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds 5 new RPC methods to the `RunService` proto for defer operations: `SaveDefer`, `SetDeferStatus`, `SaveRejectedDefer`, `LoadDefers`, and `LoadDefersMeta`. The PR includes the proto source definition, the generated Go protobuf message types (`state.pb.go`), the generated gRPC server/client stubs (`state_grpc.pb.go`), and the generated Connect RPC handler (`statev2connect/state.connect.go`). The `DeferStatus` enum values (0–4) correctly mirror `enums.DeferStatus` iota values.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8f9a1383c5fa7a3e5c642a2a3a753c73b26503f3.</sup>
<!-- /MENDRAL_SUMMARY -->