### PR TITLE
Handle oversized Connect websocket messages as MESSAGE_TOO_LARGE

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -60,6 +60,14 @@ func isConnectionClosedErr(err error) bool {
 	return errors.As(err, &closeErr)
 }
 
+func isWebSocketReadLimitErr(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(err.Error(), "read limited at")
+}
+
 func (c *connectGatewaySvc) closeWithConnectError(ws *websocket.Conn, serr *connecterrors.SocketError) {
 	// reason must be limited to 125 bytes and should not be dynamic,
 	// so we restrict it to the known syscodes to prevent unintentional overflows
@@ -615,8 +623,9 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 
 					// Unfortunately, the websocket library does not expose a proper error when the size limit is reached,
 					// so we have to check the error message instead. This should rarely happen.
-					if strings.HasPrefix(err.Error(), "read limited at") {
+					if isWebSocketReadLimitErr(err) {
 						setCloseReason(connectpb.WorkerDisconnectReason_MESSAGE_TOO_LARGE.String())
+						ch.log.Warn("worker WebSocket message exceeded read limit", "max_bytes", consts.MaxSDKResponseBodySize, "err", err)
 						return nil
 					}
 

--- a/pkg/connect/gateway_test.go
+++ b/pkg/connect/gateway_test.go
@@ -433,6 +433,36 @@ func TestCloseConnectionOnConsecutiveHeartbeatFail(t *testing.T) {
 	require.Equal(t, connect.WorkerDisconnectReason_CONSECUTIVE_HEARTBEATS_MISSED.String(), res.lifecycles.onDisconnected[0].closeReason)
 }
 
+func TestCloseConnectionOnWorkerMessageTooLarge(t *testing.T) {
+	params := testingParameters{
+		consecutiveMissesBeforeClose: 10,
+		heartbeatInterval:            time.Second,
+	}
+	res := createTestingGateway(t, params)
+
+	handshake(t, res)
+
+	err := res.ws.Write(context.Background(), websocket.MessageBinary, make([]byte, consts.MaxSDKResponseBodySize+1))
+	require.NoError(t, err)
+
+	res.lifecycles.Assert(t, testRecorderAssertion{
+		onConnectedCount:          1,
+		onSyncedCount:             1,
+		onReadyCount:              1,
+		onHeartbeatCount:          0,
+		onStartDrainingCount:      0,
+		onStartDisconnectingCount: 1,
+		onDisconnectedCount:       1,
+	})
+
+	res.lifecycles.lock.Lock()
+	defer res.lifecycles.lock.Unlock()
+
+	require.Len(t, res.lifecycles.onDisconnected, 1)
+	require.Equal(t, res.connID, res.lifecycles.onDisconnected[0].conn.ConnectionId)
+	require.Equal(t, connect.WorkerDisconnectReason_MESSAGE_TOO_LARGE.String(), res.lifecycles.onDisconnected[0].closeReason)
+}
+
 func TestWorkerHeartbeats(t *testing.T) {
 	params := testingParameters{
 		consecutiveMissesBeforeClose: 10,


### PR DESCRIPTION
## Summary
- Detect wrapped websocket read-limit errors in the Connect gateway and classify them as `MESSAGE_TOO_LARGE` instead of falling back to `UNEXPECTED`.
- Add an explicit gateway warning when a worker message exceeds the read limit, including the configured max byte size.
- Cover the oversized-message path with a regression test that verifies the disconnect reason is recorded correctly.

## Testing
- `go test ./pkg/connect -count=1`
- Added a gateway test for an over-limit websocket message to confirm `MESSAGE_TOO_LARGE` is persisted in connection history.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Refactors the oversized WebSocket message detection into a dedicated `isWebSocketReadLimitErr` helper (using `strings.Contains` instead of the previous `strings.HasPrefix`), adds a warning log with the configured byte limit, and covers the path with a new gateway integration test.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 1c740970f76d4d7adb54c7438732215660764306.</sup>
<!-- /MENDRAL_SUMMARY -->