### PR TITLE
Fix dropped sleep trace attempts

### DIFF
--- a/pkg/coreapi/graph/loaders/loader.go
+++ b/pkg/coreapi/graph/loaders/loader.go
@@ -79,8 +79,10 @@ func LoadMany[T interface{}](
 ) ([]T, error) {
 	thunkMany := loader.LoadMany(ctx, keys)
 	results, errs := thunkMany()
-	if len(errs) > 0 {
-		return []T{}, errs[1]
+	for _, err := range errs {
+		if err != nil {
+			return []T{}, err
+		}
 	}
 
 	output := make([]T, len(keys))

--- a/pkg/coreapi/graph/loaders/loader_test.go
+++ b/pkg/coreapi/graph/loaders/loader_test.go
@@ -1,0 +1,52 @@
+package loader
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/graph-gophers/dataloader"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadManyReturnsSingleError(t *testing.T) {
+	expectedErr := errors.New("batch failed")
+	keyCount := 0
+	loader := dataloader.NewBatchedLoader(func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
+		keyCount = len(keys)
+
+		return []*dataloader.Result{
+			{Error: expectedErr},
+		}
+	})
+
+	results, err := LoadMany[string](
+		context.Background(),
+		loader,
+		dataloader.NewKeysFromStrings([]string{"run"}),
+	)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, results)
+	assert.Equal(t, 1, keyCount)
+}
+
+func TestLoadManyReturnsFirstNonNilError(t *testing.T) {
+	expectedErr := errors.New("second key failed")
+	loader := dataloader.NewBatchedLoader(func(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
+		return []*dataloader.Result{
+			{Data: "ok"},
+			{Error: expectedErr},
+		}
+	})
+
+	results, err := LoadMany[string](
+		context.Background(),
+		loader,
+		dataloader.NewKeysFromStrings([]string{"ok", "failed"}),
+	)
+
+	require.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, results)
+}

--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -399,9 +399,11 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 				continue
 			}
 
-			if !cs.MarkedAsDropped {
-				showSpan = true
+			if cs.MarkedAsDropped {
+				continue
 			}
+
+			showSpan = true
 
 			// Transfer any accumulated metadata from preceding omitted
 			// step discovery spans to this visible step sibling. Each

--- a/pkg/coreapi/graph/loaders/trace_test.go
+++ b/pkg/coreapi/graph/loaders/trace_test.go
@@ -72,8 +72,8 @@ func TestRunTraceEnded(t *testing.T) {
 	}
 }
 
-func boolPtr(b bool) *bool     { return &b }
-func strPtr(s string) *string  { return &s }
+func boolPtr(b bool) *bool    { return &b }
+func strPtr(s string) *string { return &s }
 
 func TestConvertRunSpanToGQL_UserlandCollapse(t *testing.T) {
 	tr := &traceReader{}
@@ -163,6 +163,108 @@ func TestConvertRunSpanToGQL_UserlandCollapse(t *testing.T) {
 		require.Len(t, result.ChildrenSpans[0].ChildrenSpans, 1, "should preserve children")
 		assert.Equal(t, "child-span", result.ChildrenSpans[0].ChildrenSpans[0].Name)
 	})
+}
+
+func TestConvertRunSpanToGQL_DroppedDiscoveryExecutionDoesNotCreateSleepAttempts(t *testing.T) {
+	tr := &traceReader{}
+	ctx := context.Background()
+
+	status := enums.StepStatusCompleted
+	stepOp := enums.OpcodeSleep
+	sleepDuration := time.Second
+	queuedAt := time.Date(2026, 5, 8, 15, 34, 39, 0, time.UTC)
+	endedAt := queuedAt.Add(sleepDuration)
+	stepID := "b101b7cef051778f3c4378e92fad02d5f90a527d"
+	stepName := "wait-a-moment"
+
+	result, err := tr.convertRunSpanToGQL(ctx, &cqrs.OtelSpan{
+		RawOtelSpan: cqrs.RawOtelSpan{
+			Name:      meta.SpanNameRun,
+			SpanID:    "run",
+			TraceID:   "trace",
+			StartTime: queuedAt,
+			EndTime:   endedAt,
+		},
+		Attributes: &meta.ExtractedValues{
+			DynamicStatus: &status,
+			QueuedAt:      &queuedAt,
+			StartedAt:     &queuedAt,
+			EndedAt:       &endedAt,
+		},
+		Children: []*cqrs.OtelSpan{
+			{
+				RawOtelSpan: cqrs.RawOtelSpan{
+					Name:      meta.SpanNameStepDiscovery,
+					SpanID:    "discovery",
+					TraceID:   "trace",
+					StartTime: queuedAt,
+					EndTime:   endedAt,
+				},
+				Attributes: &meta.ExtractedValues{
+					QueuedAt:  &queuedAt,
+					StartedAt: &queuedAt,
+					EndedAt:   &endedAt,
+				},
+				Children: []*cqrs.OtelSpan{
+					{
+						RawOtelSpan: cqrs.RawOtelSpan{
+							Name:      meta.SpanNameExecution,
+							SpanID:    "discovery-execution",
+							TraceID:   "trace",
+							StartTime: queuedAt,
+							EndTime:   queuedAt,
+						},
+						Attributes: &meta.ExtractedValues{
+							DynamicStatus:     &status,
+							StepOp:            &stepOp,
+							StepID:            &stepID,
+							StepName:          &stepName,
+							StepSleepDuration: &sleepDuration,
+							QueuedAt:          &queuedAt,
+							StartedAt:         &queuedAt,
+							EndedAt:           &queuedAt,
+						},
+						MarkedAsDropped: true,
+					},
+					{
+						RawOtelSpan: cqrs.RawOtelSpan{
+							Name:      meta.SpanNameStep,
+							SpanID:    "sleep",
+							TraceID:   "trace",
+							StartTime: queuedAt,
+							EndTime:   endedAt,
+						},
+						Attributes: &meta.ExtractedValues{
+							DynamicStatus:     &status,
+							StepOp:            &stepOp,
+							StepID:            &stepID,
+							StepName:          &stepName,
+							StepSleepDuration: &sleepDuration,
+							QueuedAt:          &queuedAt,
+							StartedAt:         &queuedAt,
+							EndedAt:           &endedAt,
+						},
+					},
+				},
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.ChildrenSpans, 1)
+
+	sleep := result.ChildrenSpans[0]
+	assert.Equal(t, stepName, sleep.Name)
+	assert.Equal(t, models.RunTraceSpanStatusCompleted, sleep.Status)
+	assert.Empty(t, sleep.ChildrenSpans)
+	require.NotNil(t, sleep.StepOp)
+	assert.Equal(t, models.StepOpSleep, *sleep.StepOp)
+	require.NotNil(t, sleep.StepID)
+	assert.Equal(t, stepID, *sleep.StepID)
+
+	info, ok := sleep.StepInfo.(*models.SleepStepInfo)
+	require.True(t, ok)
+	assert.Equal(t, endedAt, info.SleepUntil)
 }
 
 func TestConvertRunSpanToGQL_MetadataPromotion(t *testing.T) {


### PR DESCRIPTION
## Description

Agentic api testing revealed that we shipped extra internal spans to the ui that the ui was hiding. Properly hiding them here as the agentic api is sharing this mapping code so we have the same traces. 


## Motivation
Cleaner traces for the agentic api. 

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes two bugs: (1) dropped execution spans (`MarkedAsDropped=true`) were still processed due to missing `continue`, causing spurious sleep attempt children in trace output; (2) `LoadMany` was indexing `errs[1]` instead of iterating for the first non-nil error, silently dropping the first error and panicking on single-result batches. Both fixes include regression tests.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit cf5c9d3c7f7a9a34d014737b5b580203e1fd1d4e.</sup>
<!-- /MENDRAL_SUMMARY -->