### PR TITLE
perf(pauses): evaluations containing string comparisons

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/graph-gophers/dataloader v5.0.0+incompatible
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/inngest/expr v0.0.0-20260504155224-a6e988c15b55
+	github.com/inngest/expr v0.0.0-20260513185122-19a13103520a
 	github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48
 	github.com/inngest/inngestgo v0.15.2-0.20260508201256-daaf24a3ed44
 	github.com/jackc/pgx/v5 v5.9.1

--- a/go.sum
+++ b/go.sum
@@ -600,8 +600,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/inngest/expr v0.0.0-20260504155224-a6e988c15b55 h1:Kf3x22dtq5nytZ7xLhYn7wXsFB3MUDNCJsE/DiQ2p3E=
-github.com/inngest/expr v0.0.0-20260504155224-a6e988c15b55/go.mod h1:fwLYQ2NlzdevRRQoldvMrMvCicAG6X3NaONAtxuiT8k=
+github.com/inngest/expr v0.0.0-20260513185122-19a13103520a h1:U9hCeCPX3ZwKsRD65p7o2Ph4YrVHd5v6B3DgataHCHQ=
+github.com/inngest/expr v0.0.0-20260513185122-19a13103520a/go.mod h1:fwLYQ2NlzdevRRQoldvMrMvCicAG6X3NaONAtxuiT8k=
 github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48 h1:8NwXUrQTQjWrfGj99JgesfTbCYujtnLHusePp7YyFU8=
 github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48/go.mod h1:7SNLkGaD+tiTey1IF9WUNDNurTfqNZqjbdPZo3CmLW4=
 github.com/inngest/inngestgo v0.15.2-0.20260508201256-daaf24a3ed44 h1:5WhrkV16dtJzsBbOAu6eVDbUqck2hieIhJRKl4dxEJ0=

--- a/pkg/expressions/cel.go
+++ b/pkg/expressions/cel.go
@@ -17,8 +17,37 @@ type celProgram struct {
 	cel.Program
 }
 
-// program takes a compiled AST, a cel.Env, and the data that's used in the expression and
-// returns a program and partial that's used as input to evaluate the expression.
+// buildProgram creates a reusable cel.Program from the AST.  It is data-independent:
+// when evalUnknowns is true the unknownDecorator is attached (as a stateless wrapper),
+// making the program safe to cache for the lifetime of the expression.
+//
+// evalUnknowns controls whether unknowns are treated as nulls (true, event matching)
+// or left in the eval state (false, residual/interpolation via ResidualAst).
+func buildProgram(ast *cel.Ast, env *cel.Env, evalUnknowns bool) (*celProgram, error) {
+	var opts []cel.ProgramOption
+	if evalUnknowns {
+		// Event-matching path: OptTrackState/OptExhaustiveEval only needed for ResidualAst.
+		opts = []cel.ProgramOption{
+			cel.EvalOptions(cel.OptPartialEval),
+			cel.CustomDecorator(unknownDecorator()),
+		}
+	} else {
+		// Residual/interpolation path: OptTrackState for ResidualAst, OptExhaustiveEval so
+		// unknowns in both branches of &&/|| are recorded.
+		opts = []cel.ProgramOption{
+			cel.EvalOptions(cel.OptExhaustiveEval, cel.OptTrackState, cel.OptPartialEval),
+		}
+	}
+	prog, err := env.Program(ast, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &celProgram{Program: prog}, nil
+}
+
+// program builds a one-shot program+activation pair.  Used by the residual/interpolation
+// path (evalUnknowns=false) where the program is not cached and unknowns must survive into
+// the eval state so that ResidualAst can reduce the expression.
 func program(
 	ctx context.Context,
 	ast *cel.Ast,
@@ -29,7 +58,7 @@ func program(
 	// trying to evaluate unknowns: we're trying to leave them in so that we can compute
 	// the interpolated expression.
 	//
-	// However, when we're ACTAULLY matching events, we want to evaluate any unknows as if
+	// However, when we're ACTUALLY matching events, we want to evaluate any unknowns as if
 	// the value was `null`.  Setting this to true forces the evaluation of unknown vars in
 	// the program.
 	evalUnknowns bool,
@@ -48,21 +77,11 @@ func program(
 		return nil, nil, err
 	}
 
-	opts := []cel.ProgramOption{
-		cel.EvalOptions(cel.OptExhaustiveEval, cel.OptTrackState, cel.OptPartialEval), // Exhaustive, always, right now.
+	prog, err := buildProgram(ast, env, evalUnknowns)
+	if err != nil {
+		return nil, nil, err
 	}
-
-	if evalUnknowns {
-		opts = append(opts, cel.CustomDecorator(unknownDecorator(act)))
-	}
-
-	// Create the program, refusing to short circuit if a match is found.
-	//
-	// This will add all functions from functions.StandardOverloads as we
-	// created the environment with our custom library.
-	prog, err := env.Program(ast, opts...)
-
-	return &celProgram{Program: prog}, act, err
+	return prog, act, nil
 }
 
 func eval(program *celProgram, activation interpreter.PartialActivation) (interface{}, error) {

--- a/pkg/expressions/data.go
+++ b/pkg/expressions/data.go
@@ -9,6 +9,23 @@ import (
 	"github.com/google/cel-go/interpreter"
 )
 
+// precomputePatterns builds the full path list and the corresponding
+// AttributePattern chain for every path in attrs, both keyed by index.
+// These are expression-specific and never change, so the caller should
+// compute them once and reuse them across evaluations.
+func precomputePatterns(attrs *UsedAttributes) ([][]string, []*interpreter.AttributePattern) {
+	paths := attrs.FullPaths()
+	pats := make([]*interpreter.AttributePattern, len(paths))
+	for i, path := range paths {
+		pat := cel.AttributePattern(path[0])
+		for _, piece := range path[1:] {
+			pat = pat.QualString(piece)
+		}
+		pats[i] = pat
+	}
+	return paths, pats
+}
+
 // NewData returns data ready for use within an evaluation.  This formats all
 // values of the incoming map correctly for evaluation.
 func NewData(data map[string]interface{}) *Data {
@@ -80,6 +97,23 @@ func (d *Data) Partial(ctx context.Context, attrs UsedAttributes) (interpreter.P
 	// Add the mapped data and the "patterns" which allow us to use empty data
 	// within CEL.
 	return interpreter.NewPartialActivation(d.data, patterns...)
+}
+
+// partialWithPatterns is the fast-path variant of Partial that uses pre-computed
+// paths and patterns (both indexed together) rather than rebuilding them from
+// UsedAttributes on every call.  fullPaths[i] and allPatterns[i] must correspond
+// to the same attribute path.
+func (d *Data) partialWithPatterns(ctx context.Context, fullPaths [][]string, allPatterns []*interpreter.AttributePattern) (interpreter.PartialActivation, error) {
+	var selected []*interpreter.AttributePattern
+	for i, path := range fullPaths {
+		if !d.PathExists(ctx, path) {
+			if selected == nil {
+				selected = make([]*interpreter.AttributePattern, 0, len(allPatterns))
+			}
+			selected = append(selected, allPatterns[i])
+		}
+	}
+	return interpreter.NewPartialActivation(d.data, selected...)
 }
 
 // Get returns the data from the given path, with a boolean indicating

--- a/pkg/expressions/exprenv/overloads.go
+++ b/pkg/expressions/exprenv/overloads.go
@@ -162,11 +162,9 @@ func GetBindings(name string, existing functions.BinaryOp) functions.BinaryOp {
 
 // ProgramOptions returns function implementations for the standard CEL functions.
 func (customLibrary) ProgramOptions() []cel.ProgramOption {
-	return []cel.ProgramOption{
-		// Add our custom function implementations (overloads) into the fn.
-		cel.Functions(CELOverloads()...),
-		cel.EvalOptions(cel.OptExhaustiveEval, cel.OptTrackState, cel.OptPartialEval),
-	}
+	// Eval options (OptExhaustiveEval, OptTrackState, OptPartialEval) are set per-program
+	// in buildProgram() so the event-matching path can skip OptTrackState/OptExhaustiveEval.
+	return []cel.ProgramOption{cel.Functions(CELOverloads()...)}
 }
 
 // newFunctioEnvOption creates a new *decls.FunctionDecl and wraps this within

--- a/pkg/expressions/expressions.go
+++ b/pkg/expressions/expressions.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/interpreter"
 	"github.com/inngest/expr"
 	"github.com/inngest/inngest/pkg/expressions/exprenv"
 	"github.com/karlseguin/ccache/v2"
@@ -251,6 +252,11 @@ type expressionEvaluator struct {
 	// prog is the compiled, data-independent cel.Program built once and reused across
 	// all evaluations of this expression.  Safe for concurrent use.
 	prog *celProgram
+
+	// fullPaths and patterns are pre-computed from attrs once and reused on every
+	// Evaluate call.  fullPaths[i] and patterns[i] refer to the same attribute path.
+	fullPaths [][]string
+	patterns  []*interpreter.AttributePattern
 }
 
 // Evaluate evaluates the cached expression against the provided data.
@@ -267,7 +273,7 @@ func (e *expressionEvaluator) Evaluate(ctx context.Context, data *Data) (interfa
 		})
 	}
 
-	act, err := data.Partial(ctx, *e.attrs)
+	act, err := data.partialWithPatterns(ctx, e.fullPaths, e.patterns)
 	if err != nil {
 		return nil, err
 	}
@@ -290,7 +296,7 @@ func (e *expressionEvaluator) FilteredAttributes(ctx context.Context, d *Data) *
 	filtered := map[string]interface{}{}
 
 	current := filtered
-	stack := e.attrs.FullPaths()
+	stack := e.fullPaths
 	for len(stack) > 0 {
 		path := stack[0]
 		stack = stack[1:]
@@ -334,5 +340,6 @@ func (e *expressionEvaluator) parseAttributes(ctx context.Context) error {
 		return err
 	}
 	e.attrs = attrs
+	e.fullPaths, e.patterns = precomputePatterns(attrs)
 	return nil
 }

--- a/pkg/expressions/expressions.go
+++ b/pkg/expressions/expressions.go
@@ -137,6 +137,14 @@ func NewExpressionEvaluator(ctx context.Context, expression string) (Evaluator, 
 	// Use the lifting expression parser in order to compile our env,
 	// if it's not nil.
 	if exprCompiler != nil {
+		// Cache the full evaluator (including compiled program) so that repeated
+		// calls with the same expression string reuse the same cel.Program.
+		cacheKey := "lifted:" + expression
+		if cached := cache.Get(cacheKey); cached != nil {
+			cached.Extend(CacheExtendTime)
+			return cached.Value().(*expressionEvaluator), nil
+		}
+
 		ast, issues, vars := exprCompiler.Parse(expression)
 		if issues != nil {
 			return nil, NewCompileError(issues.Err())
@@ -158,6 +166,12 @@ func NewExpressionEvaluator(ctx context.Context, expression string) (Evaluator, 
 		if err := eval.parseAttributes(ctx); err != nil {
 			return nil, err
 		}
+		prog, err := buildProgram(ast, e, true)
+		if err != nil {
+			return nil, err
+		}
+		eval.prog = prog
+		cache.Set(cacheKey, eval, CacheTTL)
 		return eval, nil
 	}
 
@@ -186,11 +200,14 @@ func cachedCompile(ctx context.Context, expression string) (*expressionEvaluator
 		env:        e,
 		expression: expression,
 	}
-
 	if err := eval.parseAttributes(ctx); err != nil {
 		return nil, err
 	}
-
+	prog, err := buildProgram(ast, e, true)
+	if err != nil {
+		return nil, err
+	}
+	eval.prog = prog
 	cache.Set("eval:"+expression, eval, CacheTTL)
 	return eval, nil
 }
@@ -217,10 +234,6 @@ func (b booleanEvaluator) Evaluate(ctx context.Context, data *Data) (bool, error
 }
 
 type expressionEvaluator struct {
-	// TODO: Refactor unknownEval to remove the need tor attr.Eval(activation),
-	// and make dateRefs thread safe.  We can then place a cel.Program on the
-	// evaluator as it's thread safe.  Without these changes, Programs are bound
-	// to specific expression & data combinations.
 	ast *cel.Ast
 	env *cel.Env
 
@@ -231,15 +244,16 @@ type expressionEvaluator struct {
 	// parser.
 	liftedVars map[string]any
 
-	// attrs is allows us to determine which attributes are used within an expression.
-	// This is needed to create partial activations, and is also used to optimistically
-	// load only necessary attributes.
+	// attrs determines which attributes are referenced within the expression.
+	// Used to build PartialActivations and to optimistically load only necessary data.
 	attrs *UsedAttributes
+
+	// prog is the compiled, data-independent cel.Program built once and reused across
+	// all evaluations of this expression.  Safe for concurrent use.
+	prog *celProgram
 }
 
-// Evaluate compiles an expression string against a set of variables, returning whether the
-// expression evaluates to true, the next earliest time to re-test the evaluation (if dates are
-// compared), and any errors.
+// Evaluate evaluates the cached expression against the provided data.
 func (e *expressionEvaluator) Evaluate(ctx context.Context, data *Data) (interface{}, error) {
 	if data == nil {
 		return false, nil
@@ -253,12 +267,12 @@ func (e *expressionEvaluator) Evaluate(ctx context.Context, data *Data) (interfa
 		})
 	}
 
-	program, act, err := program(ctx, e.ast, e.env, data, true, e.attrs)
+	act, err := data.Partial(ctx, *e.attrs)
 	if err != nil {
 		return nil, err
 	}
 
-	return eval(program, act)
+	return eval(e.prog, act)
 }
 
 // UsedAttributes returns the attributes used within the expression.

--- a/pkg/expressions/unknown.go
+++ b/pkg/expressions/unknown.go
@@ -285,6 +285,7 @@ func (e *evalTruthyLogical) Eval(ctx interpreter.Activation) ref.Val {
 	}
 
 	// Apply JS-like truthy coercion.
+	n := len(e.terms)
 	if e.isOr {
 		// Return the first truthy value, or the last value.
 		for i := 0; i < n; i++ {
@@ -292,7 +293,7 @@ func (e *evalTruthyLogical) Eval(ctx interpreter.Activation) ref.Val {
 				return vals[i]
 			}
 		}
-		return vals[len(vals)-1]
+		return vals[n-1]
 	}
 
 	// AND: return the first falsy value, or the last value.
@@ -301,7 +302,7 @@ func (e *evalTruthyLogical) Eval(ctx interpreter.Activation) ref.Val {
 			return vals[i]
 		}
 	}
-	return vals[len(vals)-1]
+	return vals[n-1]
 }
 
 // isTruthy returns whether a CEL value is "truthy" using JS-like semantics.

--- a/pkg/expressions/unknown.go
+++ b/pkg/expressions/unknown.go
@@ -53,10 +53,10 @@ func (r *runtimeUnknownCall) Eval(act interpreter.Activation) ref.Val {
 		fnVal = r.Function()
 	}
 
-	argTypes := &argColl{}
+	var argTypes argColl
 	args := r.Args()
 	for _, arg := range args {
-		argTypes.Add(arg.Eval(act))
+		argTypes.add(arg.Eval(act))
 	}
 
 	if argTypes.TypeLen() == 1 && !argTypes.Exists(types.ErrType) && !argTypes.Exists(types.UnknownType) {
@@ -98,10 +98,12 @@ func (r *runtimeUnknownCall) Eval(act interpreter.Activation) ref.Val {
 		//    variable.  This error contains "no such attribute", and this is a usual
 		//    part of runing macros.  XXX: Figure out why Eval() on macro variables fails:
 		//    this is actually _not_ an error.
-		for _, val := range argTypes.OfType(types.ErrType) {
-			if strings.HasPrefix(val.(error).Error(), "no such attribute") {
-				// This must be a macro call;  handle as usual
-				return r.InterpretableCall.Eval(act)
+		for i := 0; i < argTypes.n && i < 2; i++ {
+			if argTypes.a[i] != nil && argTypes.a[i].Type() == types.ErrType {
+				if strings.HasPrefix(argTypes.a[i].(error).Error(), "no such attribute") {
+					// This must be a macro call;  handle as usual
+					return r.InterpretableCall.Eval(act)
+				}
 			}
 		}
 		// This is an unknown type.  Dependent on the function being called return
@@ -131,7 +133,7 @@ func (r *runtimeUnknownCall) Eval(act interpreter.Activation) ref.Val {
 		//
 		// We must create a new zero type in place of the null argument,
 		// then fetch the overload from the standard dispatcher and run the function.
-		zeroArgs, err := argTypes.ZeroValArgs()
+		zeroArgs, err := argTypes.zeroValArgs()
 		if err != nil {
 			return r.InterpretableCall.Eval(act)
 		}
@@ -152,15 +154,15 @@ func (r *runtimeUnknownCall) Eval(act interpreter.Activation) ref.Val {
 //
 // This functionality adds custom logic for each overload to return a static ref.Val
 // which is used in place of unknown.
-func handleUnknownCall(i interpreter.InterpretableCall, args *argColl) (interpreter.Interpretable, error) {
+func handleUnknownCall(i interpreter.InterpretableCall, args argColl) (interpreter.Interpretable, error) {
 	switch i.Function() {
 	case operators.Add:
 		// Find the non-unknown type and return that
-		for _, arg := range args.arguments {
-			if types.IsUnknown(arg) {
+		for j := 0; j < args.n && j < 2; j++ {
+			if types.IsUnknown(args.a[j]) {
 				continue
 			}
-			return staticCall{result: arg, InterpretableCall: i}, nil
+			return staticCall{result: args.a[j], InterpretableCall: i}, nil
 		}
 		return staticCall{result: types.False, InterpretableCall: i}, nil
 	case operators.Equals:
@@ -182,14 +184,14 @@ func handleUnknownCall(i interpreter.InterpretableCall, args *argColl) (interpre
 
 	case operators.Less, operators.LessEquals:
 		// Unknown is less than anything.
-		if args.arguments[0].Type() == types.UnknownType || args.arguments[0].Type() == types.ErrType {
+		if args.a[0].Type() == types.UnknownType || args.a[0].Type() == types.ErrType {
 			return staticCall{result: types.True, InterpretableCall: i}, nil
 		}
 		return staticCall{result: types.False, InterpretableCall: i}, nil
 
 	case operators.Greater, operators.GreaterEquals:
-		// If the first arg is unkown, return false:  unknown is not greater.
-		if args.arguments[0].Type() == types.UnknownType || args.arguments[0].Type() == types.ErrType {
+		// If the first arg is unknown, return false:  unknown is not greater.
+		if args.a[0].Type() == types.UnknownType || args.a[0].Type() == types.ErrType {
 			return staticCall{result: types.False, InterpretableCall: i}, nil
 		}
 		return staticCall{result: types.True, InterpretableCall: i}, nil
@@ -205,9 +207,6 @@ func handleUnknownCall(i interpreter.InterpretableCall, args *argColl) (interpre
 		// Size on unknowns should always return zero to avoid type errors.
 		return staticCall{result: types.IntZero, InterpretableCall: i}, nil
 	default:
-
-		// By default, return false, for eaxmple: "_<_", "@in", "@not_strictly_false"
-		// return staticCall{result: types.False, InterpretableCall: call}, nil
 		return staticCall{result: types.False, InterpretableCall: i}, nil
 	}
 }
@@ -268,12 +267,14 @@ func (e *evalTruthyLogical) ID() int64 {
 }
 
 func (e *evalTruthyLogical) Eval(ctx interpreter.Activation) ref.Val {
-	// Evaluate all terms to check their types.
-	vals := make([]ref.Val, len(e.terms))
+	// CEL's || and && produce nested binary AST nodes by default; evalExhaustiveOr/And
+	// inherits that 2-element terms slice.  This breaks if the env ever enables
+	// cel.variadicLogicalOperatorASTs() which is not even exported can break this assumption.
+	var vals [2]ref.Val
 	allBool := true
-	for idx, term := range e.terms {
-		vals[idx] = term.Eval(ctx)
-		if vals[idx] == nil || vals[idx].Type() != types.BoolType {
+	for i, term := range e.terms {
+		vals[i] = term.Eval(ctx)
+		if vals[i] == nil || vals[i].Type() != types.BoolType {
 			allBool = false
 		}
 	}
@@ -286,18 +287,18 @@ func (e *evalTruthyLogical) Eval(ctx interpreter.Activation) ref.Val {
 	// Apply JS-like truthy coercion.
 	if e.isOr {
 		// Return the first truthy value, or the last value.
-		for _, val := range vals {
-			if isTruthy(val) {
-				return val
+		for i := 0; i < n; i++ {
+			if isTruthy(vals[i]) {
+				return vals[i]
 			}
 		}
 		return vals[len(vals)-1]
 	}
 
 	// AND: return the first falsy value, or the last value.
-	for _, val := range vals {
-		if !isTruthy(val) {
-			return val
+	for i := 0; i < n; i++ {
+		if !isTruthy(vals[i]) {
+			return vals[i]
 		}
 	}
 	return vals[len(vals)-1]
@@ -338,92 +339,68 @@ func (u staticCall) Eval(ctx interpreter.Activation) ref.Val {
 	return u.result
 }
 
-// argColl inspects all of the types available within a function call in
-// CEL, storing their type information.
+// argColl tracks the argument values and distinct types for a binary operator call.
+// CEL operators are always binary (2 args), so fixed-size arrays are used throughout
+// to avoid any heap allocation.
 type argColl struct {
-	// types represents a map of types to their values used within the
-	// function.
-	types map[ref.Type][]ref.Val
-
-	// arguments represents the function arguments, in order.
-	arguments []ref.Val
+	a      [2]ref.Val // arguments in order
+	n      int        // number of arguments added (0–2)
+	t0, t1 ref.Type  // distinct types seen; t0 is set first
+	nt     int        // number of distinct types (0–2)
 }
 
-// Add adds a new value to the type collection, storing its type in the map.
-func (t *argColl) Add(vals ...ref.Val) {
-	if t.types == nil {
-		t.types = map[ref.Type][]ref.Val{}
+func (t *argColl) add(val ref.Val) {
+	if t.n < 2 {
+		t.a[t.n] = val
 	}
-
-	for _, val := range vals {
-		// Store the arguments in order (left and right hand side of operators)
-		t.arguments = append(t.arguments, val)
-
-		if val == nil {
-			// XXX: We should probably handle this differently
-			continue
+	t.n++
+	if val == nil {
+		return
+	}
+	typ := val.Type()
+	switch t.nt {
+	case 0:
+		t.t0 = typ
+		t.nt = 1
+	case 1:
+		if t.t0 != typ {
+			t.t1 = typ
+			t.nt = 2
 		}
-
-		typ := val.Type()
-		coll, ok := t.types[typ]
-		if !ok {
-			t.types[typ] = []ref.Val{val}
-			return
-		}
-		t.types[typ] = append(coll, val)
 	}
 }
 
-func (t *argColl) TypeLen() int {
-	return len(t.types)
-}
-
-func (t *argColl) ArgLen() int {
-	return len(t.arguments)
-}
+func (t *argColl) TypeLen() int { return t.nt }
+func (t *argColl) ArgLen() int  { return t.n }
 
 func (t *argColl) Exists(typ ref.Type) bool {
-	_, ok := t.types[typ]
-	return ok
+	return (t.nt >= 1 && t.t0 == typ) || (t.nt >= 2 && t.t1 == typ)
 }
 
-// OfType returns all arguments of the given type.
-func (t *argColl) OfType(typ ref.Type) []ref.Val {
-	coll, ok := t.types[typ]
-	if !ok {
-		return nil
+// zeroValArgs returns the two args with any null replaced by the zero value of the
+// other type.  Returns an error if there isn't exactly one non-null type present.
+func (t *argColl) zeroValArgs() ([2]ref.Val, error) {
+	var nonNull ref.Type
+	nn := 0
+	if t.nt >= 1 && t.t0 != types.NullType {
+		nonNull = t.t0
+		nn++
 	}
-	return coll
-}
-
-// NonNull returns all non-null types as a slice.
-func (t *argColl) NonNull() []ref.Type {
-	coll := []ref.Type{}
-	for typ := range t.types {
-		if typ == types.NullType {
-			continue
-		}
-		coll = append(coll, typ)
+	if t.nt >= 2 && t.t1 != types.NullType {
+		nonNull = t.t1
+		nn++
 	}
-	return coll
-}
-
-// ZeroValArgs returns all args with null types replaced as zero values
-func (t *argColl) ZeroValArgs() ([]ref.Val, error) {
-	typ := t.NonNull()
-	if len(typ) != 1 {
-		return t.arguments, fmt.Errorf("not exactly one other non-null type present")
+	if nn != 1 {
+		return t.a, fmt.Errorf("not exactly one other non-null type present")
 	}
-
-	coll := make([]ref.Val, len(t.arguments))
-	for n, arg := range t.arguments {
-		coll[n] = arg
-		if arg.Type() == types.NullType {
-			coll[n] = zeroVal(typ[0])
+	result := t.a
+	zero := zeroVal(nonNull)
+	for i := 0; i < t.n && i < 2; i++ {
+		if t.a[i] != nil && t.a[i].Type() == types.NullType {
+			result[i] = zero
 		}
 	}
-
-	return coll, nil
+	return result, nil
 }
 
 // zeroVal returns a zero value for common cel datatypes.  This helps us

--- a/pkg/expressions/unknown.go
+++ b/pkg/expressions/unknown.go
@@ -14,18 +14,11 @@ import (
 	"github.com/inngest/inngest/pkg/expressions/exprenv"
 )
 
-// unknownDecorator returns a decorator for inspecting and handling unknowns at runtime.  This
-// decorator is called before _any_ attribute or function is evaluated in CEL, allowing us to
-// intercept and return our own values.
-//
-// For example, natively in CEL `size(null)` returns a "no such overload" error.  We intercept
-// the evalutation of `size(null)` and return a new type (0) instead of the error.
-func unknownDecorator(act interpreter.PartialActivation) interpreter.InterpretableDecorator {
-	// Create a new dispatcher with all functions added
-	dispatcher := interpreter.NewDispatcher()
-	overloads := exprenv.CELOverloads()
-	_ = dispatcher.Add(overloads...)
-
+// unknownDecorator returns a data-independent decorator that wraps every InterpretableCall
+// in a runtimeUnknownCall.  The actual type-dispatch logic (unknown/null/coercion handling)
+// runs at eval time instead of plan time, which means the cel.Program can be built once and
+// cached for the lifetime of the expression rather than rebuilt on every evaluation.
+func unknownDecorator() interpreter.InterpretableDecorator {
 	return func(i interpreter.Interpretable) (interpreter.Interpretable, error) {
 		// Handle logical OR/AND nodes.  CEL represents || and && as special
 		// evalOr/evalAnd (or evalExhaustiveOr/evalExhaustiveAnd) structs that
@@ -33,7 +26,7 @@ func unknownDecorator(act interpreter.PartialActivation) interpreter.Interpretab
 		// commonly write "event.data.a || event.data.b" expecting JS-like truthy
 		// coercion.  We detect these nodes via reflection and wrap them to
 		// implement truthy coercion when operands are non-boolean.
-		if wrapped, ok := maybeWrapLogicalOp(i, act); ok {
+		if wrapped, ok := maybeWrapLogicalOp(i); ok {
 			return wrapped, nil
 		}
 
@@ -43,111 +36,115 @@ func unknownDecorator(act interpreter.PartialActivation) interpreter.Interpretab
 			return i, nil
 		}
 
-		fnVal := call.OverloadID()
-		if fnVal == "" {
-			fnVal = call.Function()
-		}
-
-		argTypes := &argColl{}
-
-		args := call.Args()
-		for _, arg := range args {
-			// We want both attributes (variables) & consts to check for coercion.
-			argTypes.Add(arg.Eval(act))
-		}
-
-		if argTypes.TypeLen() == 1 && !argTypes.Exists(types.ErrType) && !argTypes.Exists(types.UnknownType) {
-			// A single type used within the function with no error and unknown is
-			// safe to call as usual.
-			return i, nil
-		}
-
-		// For each function that we wnat to be heterogeneous, check the types here.
-		//
-		// Only run this in the case in which we have known types;  unknowns are handled
-		// below.
-		if argTypes.TypeLen() == 2 && !argTypes.Exists(types.UnknownType) {
-			// Check if the original function is a success.
-			val := call.Eval(act)
-			if !types.IsError(val) && !types.IsUnknown(val) {
-				// Memoize this result and return it.
-				return staticCall{result: val, InterpretableCall: call}, nil
-			}
-
-			switch fnVal {
-			case operators.Add:
-				//
-				// This allows concatenation of distinct types, eg string + number.
-				//
-				str := types.String(fmt.Sprintf("%v%v", args[0].Eval(act).Value(), args[1].Eval(act).Value()))
-				return staticCall{result: str, InterpretableCall: call}, nil
-			}
-		}
-
-		if argTypes.Exists(types.ErrType) || argTypes.Exists(types.UnknownType) {
-			// We work with unknown and error types, handling both as non-existent
-			// types.
-			//
-			// Errors can appear when calling macros on unknowns (eg:
-			// event.data.nonexistent.subkey.contains("something")).
-			//
-			// This could be because:
-			//
-			// 1. we're calling a macro on an unknown value. This happens before we can intercept
-			// the InterpretableCall and will always happen.  That's fine, and this produces the
-			// error "no such key".  These are the errors we want to intercept.
-			//
-			// 2. we're inside a macro and we're using the __result__ or lambda
-			//    variable.  This error contains "no such attribute", and this is a usual
-			//    part of runing macros.  XXX: Figure out why Eval() on macro variables fails:
-			//    this is actually _not_ an error.
-			for _, val := range argTypes.OfType(types.ErrType) {
-				if strings.HasPrefix(val.(error).Error(), "no such attribute") {
-					// This must be a macro call;  handle as usual
-					return i, nil
-				}
-			}
-			// This is an unknown type.  Dependent on the function being called return
-			// a concrete true or false value by default.
-			return handleUnknownCall(call, argTypes)
-		}
-
-		// Here we have multiple types called together.  If these are coercible, we'll
-		// attempt to coerce them (eg. ints and floats).
-		//
-		// We can't create a custom null type, because Compare may run on String, Int, Double,
-		// etc:  we'd have to wrap every type and add null checking.  This is a maintenance
-		// en and could be bug-prone.
-		//
-		// Therefore, we have to evaluate this here within a decorator.
-		if argTypes.Exists(types.NullType) && argTypes.ArgLen() == 2 {
-			switch call.Function() {
-			case operators.Equals:
-				return staticCall{result: types.False, InterpretableCall: call}, nil
-			case operators.NotEquals:
-				return staticCall{result: types.True, InterpretableCall: call}, nil
-			}
-
-			// Other operators, such as >, <=, depend on the argument order to evaluate
-			// correctly.
-			//
-			// We must create a new zero type in place of the null argument,
-			// then fetch the overload from the standard dispatcher and run the function.
-			args, err := argTypes.ZeroValArgs()
-			if err != nil {
-				return i, nil
-			}
-
-			// Get the actual implementation which we've copied into overloads.go.
-			fn := exprenv.GetBindings(call.Function(), nil)
-			if fn == nil {
-				return i, nil
-			}
-			return staticCall{result: fn(args[0], args[1]), InterpretableCall: call}, nil
-		}
-
-		return i, nil
+		return &runtimeUnknownCall{InterpretableCall: call}, nil
 	}
+}
+
+// runtimeUnknownCall wraps an InterpretableCall and applies the same unknown/null/coercion
+// handling logic as the old plan-time unknownDecorator, but at eval time using the live
+// activation.  This is what allows cel.Program to be safely cached across evaluations.
+type runtimeUnknownCall struct {
+	interpreter.InterpretableCall
+}
+
+func (r *runtimeUnknownCall) Eval(act interpreter.Activation) ref.Val {
+	fnVal := r.OverloadID()
+	if fnVal == "" {
+		fnVal = r.Function()
+	}
+
+	argTypes := &argColl{}
+	args := r.Args()
+	for _, arg := range args {
+		argTypes.Add(arg.Eval(act))
+	}
+
+	if argTypes.TypeLen() == 1 && !argTypes.Exists(types.ErrType) && !argTypes.Exists(types.UnknownType) {
+		// A single type used within the function with no error and unknown is
+		// safe to call as usual.
+		return r.InterpretableCall.Eval(act)
+	}
+
+	// For each function that we want to be heterogeneous, check the types here.
+	//
+	// Only run this in the case in which we have known types;  unknowns are handled
+	// below.
+	if argTypes.TypeLen() == 2 && !argTypes.Exists(types.UnknownType) {
+		val := r.InterpretableCall.Eval(act)
+		if !types.IsError(val) && !types.IsUnknown(val) {
+			return val
+		}
+
+		if fnVal == operators.Add {
+			// This allows concatenation of distinct types, eg string + number.
+			return types.String(fmt.Sprintf("%v%v", args[0].Eval(act).Value(), args[1].Eval(act).Value()))
+		}
+	}
+
+	if argTypes.Exists(types.ErrType) || argTypes.Exists(types.UnknownType) {
+		// We work with unknown and error types, handling both as non-existent
+		// types.
+		//
+		// Errors can appear when calling macros on unknowns (eg:
+		// event.data.nonexistent.subkey.contains("something")).
+		//
+		// This could be because:
+		//
+		// 1. we're calling a macro on an unknown value. This happens before we can intercept
+		// the InterpretableCall and will always happen.  That's fine, and this produces the
+		// error "no such key".  These are the errors we want to intercept.
+		//
+		// 2. we're inside a macro and we're using the __result__ or lambda
+		//    variable.  This error contains "no such attribute", and this is a usual
+		//    part of runing macros.  XXX: Figure out why Eval() on macro variables fails:
+		//    this is actually _not_ an error.
+		for _, val := range argTypes.OfType(types.ErrType) {
+			if strings.HasPrefix(val.(error).Error(), "no such attribute") {
+				// This must be a macro call;  handle as usual
+				return r.InterpretableCall.Eval(act)
+			}
+		}
+		// This is an unknown type.  Dependent on the function being called return
+		// a concrete true or false value by default.
+		result, _ := handleUnknownCall(r.InterpretableCall, argTypes)
+		return result.Eval(act)
+	}
+
+	// Here we have multiple types called together.  If these are coercible, we'll
+	// attempt to coerce them (eg. ints and floats).
+	//
+	// We can't create a custom null type, because Compare may run on String, Int, Double,
+	// etc:  we'd have to wrap every type and add null checking.  This is a maintenance
+	// burden and could be bug-prone.
+	//
+	// Therefore, we have to evaluate this here within a decorator.
+	if argTypes.Exists(types.NullType) && argTypes.ArgLen() == 2 {
+		switch r.Function() {
+		case operators.Equals:
+			return types.False
+		case operators.NotEquals:
+			return types.True
+		}
+
+		// Other operators, such as >, <=, depend on the argument order to evaluate
+		// correctly.
+		//
+		// We must create a new zero type in place of the null argument,
+		// then fetch the overload from the standard dispatcher and run the function.
+		zeroArgs, err := argTypes.ZeroValArgs()
+		if err != nil {
+			return r.InterpretableCall.Eval(act)
+		}
+
+		// Get the actual implementation which we've copied into overloads.go.
+		fn := exprenv.GetBindings(r.Function(), nil)
+		if fn == nil {
+			return r.InterpretableCall.Eval(act)
+		}
+		return fn(zeroArgs[0], zeroArgs[1])
+	}
+
+	return r.InterpretableCall.Eval(act)
 }
 
 // By default, CEL tracks unknowns as a separate value.  This is fantastic, but when
@@ -219,7 +216,7 @@ func handleUnknownCall(i interpreter.InterpretableCall, args *argColl) (interpre
 // variants) via reflection and wraps them to implement JS-like truthy coercion
 // when operands are non-boolean.  Returns (wrapped, true) if the node was wrapped,
 // or (nil, false) if the node is not a logical operator.
-func maybeWrapLogicalOp(i interpreter.Interpretable, act interpreter.PartialActivation) (interpreter.Interpretable, bool) {
+func maybeWrapLogicalOp(i interpreter.Interpretable) (interpreter.Interpretable, bool) {
 	typeName := reflect.TypeOf(i).String()
 
 	var isOr bool

--- a/pkg/expressions/unknown_test.go
+++ b/pkg/expressions/unknown_test.go
@@ -1,0 +1,662 @@
+package expressions
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestHandleUnknownCall tests handleUnknownCall — the path taken when one or more
+// operands are unknown (missing from activation) or error type.
+func TestHandleUnknownCall(t *testing.T) {
+	ctx := context.Background()
+
+	noData := map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{}}}
+
+	tests := []struct {
+		name     string
+		expr     string
+		data     map[string]interface{}
+		expected interface{}
+	}{
+		// ── Equals ────────────────────────────────────────────────────────────────
+		{
+			name:     "unknown == string → false",
+			expr:     `event.data.missing == "foo"`,
+			data:     noData,
+			expected: false,
+		},
+		{
+			name:     "unknown == null → true (unknown treated as null)",
+			expr:     `event.data.missing == null`,
+			data:     noData,
+			expected: true,
+		},
+		{
+			name:     "unknown == 0 → false (unknown is not null literal)",
+			expr:     `event.data.missing == 0`,
+			data:     noData,
+			expected: false,
+		},
+		{
+			name:     "unknown == unknown → false (neither is null literal)",
+			expr:     `event.data.a == event.data.b`,
+			data:     noData,
+			expected: false,
+		},
+
+		// ── NotEquals ─────────────────────────────────────────────────────────────
+		{
+			name:     "unknown != string → true",
+			expr:     `event.data.missing != "foo"`,
+			data:     noData,
+			expected: true,
+		},
+		{
+			name:     "unknown != null → false (unknown is null)",
+			expr:     `event.data.missing != null`,
+			data:     noData,
+			expected: false,
+		},
+		{
+			name:     "unknown != 0 → true (zero value does not equal unknown)",
+			expr:     `event.data.missing != 0`,
+			data:     noData,
+			expected: true,
+		},
+		{
+			name:     `unknown != "" → true`,
+			expr:     `event.data.missing != ""`,
+			data:     noData,
+			expected: true,
+		},
+
+		// ── Less / LessEquals — direction matters ─────────────────────────────────
+		// handleUnknownCall: if args[0] is unknown → true, else false
+		{
+			name:     "unknown LHS: unknown < 5 → true",
+			expr:     `event.data.missing < 5`,
+			data:     noData,
+			expected: true,
+		},
+		{
+			name:     "unknown LHS: unknown <= 5 → true",
+			expr:     `event.data.missing <= 5`,
+			data:     noData,
+			expected: true,
+		},
+		{
+			name:     "known LHS: 5 < unknown → false",
+			expr:     `5 < event.data.missing`,
+			data:     noData,
+			expected: false,
+		},
+		{
+			name:     "known LHS: 5 <= unknown → false",
+			expr:     `5 <= event.data.missing`,
+			data:     noData,
+			expected: false,
+		},
+		{
+			name: "known field > unknown → true",
+			expr: `event.data.n > event.data.missing`,
+			data: map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"n": 2}}},
+			// args[0] = int(2), not unknown → Greater returns true
+			expected: true,
+		},
+
+		// ── Greater / GreaterEquals — direction matters ───────────────────────────
+		// handleUnknownCall: if args[0] is unknown → false, else true
+		{
+			name:     "unknown LHS: unknown > 5 → false",
+			expr:     `event.data.missing > 5`,
+			data:     noData,
+			expected: false,
+		},
+		{
+			name:     "unknown LHS: unknown >= 5 → false",
+			expr:     `event.data.missing >= 5`,
+			data:     noData,
+			expected: false,
+		},
+		{
+			name:     "known LHS: 5 > unknown → true",
+			expr:     `5 > event.data.missing`,
+			data:     noData,
+			expected: true,
+		},
+		{
+			name:     "known LHS: 5 >= unknown → true",
+			expr:     `5 >= event.data.missing`,
+			data:     noData,
+			expected: true,
+		},
+
+		// ── Add with unknown ──────────────────────────────────────────────────────
+		// handleUnknownCall Add: returns the first non-unknown arg in argument order
+		{
+			name:     "known + unknown → known (lhs preserved)",
+			expr:     `event.data.name + event.data.missing`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"name": "hello"}}},
+			expected: "hello",
+		},
+		{
+			name:     "unknown + known → known (rhs preserved when lhs missing)",
+			expr:     `event.data.missing + event.data.name`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"name": "hello"}}},
+			expected: "hello",
+		},
+		{
+			// Both args unknown → no non-unknown found → returns false
+			name:     "unknown + unknown → false",
+			expr:     `event.data.a + event.data.b`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{}}},
+			expected: false,
+		},
+
+		// ── size on unknown ───────────────────────────────────────────────────────
+		{
+			name:     "size(unknown) returns 0",
+			expr:     `size(event.data.missing)`,
+			data:     noData,
+			expected: int64(0),
+		},
+		{
+			name:     "size(unknown) > 0 → false",
+			expr:     `size(event.data.missing) > 0`,
+			data:     noData,
+			expected: false,
+		},
+		{
+			name:     "size(unknown) == 0 → true",
+			expr:     `size(event.data.missing) == 0`,
+			data:     noData,
+			expected: true,
+		},
+
+		// ── @in with unknown (default branch) ─────────────────────────────────────
+		{
+			name:     "unknown in list → false",
+			expr:     `event.data.missing in ["a", "b", "c"]`,
+			data:     noData,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Evaluate(ctx, tt.expr, tt.data)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestNullTypeHandling tests the NullType path in unknownDecorator
+// (argTypes.Exists(types.NullType) && argTypes.ArgLen() == 2),
+// which coerces null to a zero value for ordered comparisons.
+func TestNullTypeHandling(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		expr     string
+		data     map[string]interface{}
+		expected interface{}
+	}{
+		// ── Equals with explicit null ─────────────────────────────────────────────
+		{
+			name:     "null == string → false",
+			expr:     `null == "foo"`,
+			data:     map[string]interface{}{},
+			expected: false,
+		},
+		{
+			name:     "string == null → false",
+			expr:     `"foo" == null`,
+			data:     map[string]interface{}{},
+			expected: false,
+		},
+
+		// ── NotEquals with explicit null ──────────────────────────────────────────
+		{
+			name:     "null != string → true",
+			expr:     `null != "foo"`,
+			data:     map[string]interface{}{},
+			expected: true,
+		},
+		{
+			name:     "string != null → true",
+			expr:     `"foo" != null`,
+			data:     map[string]interface{}{},
+			expected: true,
+		},
+
+		// ── null < "string" — ZeroValArgs with string zero value ────────────────────
+		{
+			// ZeroValArgs replaces null with String("") → "" < "foo" = true
+			name:     `null < "foo" → true (null coerced to empty string)`,
+			expr:     `null < "foo"`,
+			data:     map[string]interface{}{},
+			expected: true,
+		},
+		{
+			// "" < "aardvark" is false since "" < "a" is true actually... wait, "" < "foo" is true
+			// ZeroValArgs: null → String("") → "foo" < "" = false
+			name:     `"foo" < null → false (null coerced to empty string)`,
+			expr:     `"foo" < null`,
+			data:     map[string]interface{}{},
+			expected: false,
+		},
+		// ── null compared with uint — zeroVal "uint" branch ─────────────────────────
+		{
+			// null < uint(5): ZeroValArgs → Uint(0) < Uint(5) = true
+			name:     "null < uint(5) → true (null coerced to uint 0)",
+			expr:     `null < uint(5)`,
+			data:     map[string]interface{}{},
+			expected: true,
+		},
+		// ── Less/Greater with null literal — ZeroValArgs replaces null with 0 ─────
+		{
+			// null < 5: ZeroValArgs → int(0) < int(5) = true
+			name:     "null < 5 → true (null coerced to 0)",
+			expr:     `null < 5`,
+			data:     map[string]interface{}{},
+			expected: true,
+		},
+		{
+			// 5 < null: ZeroValArgs → int(5) < int(0) = false
+			name:     "5 < null → false (null coerced to 0)",
+			expr:     `5 < null`,
+			data:     map[string]interface{}{},
+			expected: false,
+		},
+		{
+			// null > 0: ZeroValArgs → int(0) > int(0) = false
+			name:     "null > 0 → false (null coerced to 0)",
+			expr:     `null > 0`,
+			data:     map[string]interface{}{},
+			expected: false,
+		},
+		{
+			// 5 > null: ZeroValArgs → int(5) > int(0) = true
+			name:     "5 > null → true (null coerced to 0)",
+			expr:     `5 > null`,
+			data:     map[string]interface{}{},
+			expected: true,
+		},
+		{
+			// null <= 0: ZeroValArgs → int(0) <= int(0) = true
+			name:     "null <= 0 → true (null coerced to 0)",
+			expr:     `null <= 0`,
+			data:     map[string]interface{}{},
+			expected: true,
+		},
+		{
+			// null >= 1: ZeroValArgs → int(0) >= int(1) = false
+			name:     "null >= 1 → false (null coerced to 0)",
+			expr:     `null >= 1`,
+			data:     map[string]interface{}{},
+			expected: false,
+		},
+		{
+			// null < 0.5: NonNull is DoubleType → Double(0) < 0.5 = true
+			name:     "null < 0.5 → true (null coerced to 0.0)",
+			expr:     `null < 0.5`,
+			data:     map[string]interface{}{},
+			expected: true,
+		},
+		// ── Null field values from activation ─────────────────────────────────────
+		{
+			name:     "float field > null → true",
+			expr:     `event.data.float > null`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"float": 3.141}}},
+			expected: true,
+		},
+		{
+			name:     "int field > null → true",
+			expr:     `event.data.n > null`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"n": 8}}},
+			expected: true,
+		},
+		{
+			name:     "float field <= null → false",
+			expr:     `event.data.float <= null`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"float": 3.141}}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Evaluate(ctx, tt.expr, tt.data)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestTruthyLogicalCoercion tests the evalTruthyLogical wrapper which handles ||
+// and && with non-boolean operands using JS-like truthy coercion.
+func TestTruthyLogicalCoercion(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		expr     string
+		data     map[string]interface{}
+		expected interface{}
+	}{
+		// ── Logical OR: returns first truthy, or last value if all falsy ───────────
+		{
+			name:     "OR both truthy strings → returns first",
+			expr:     `event.data.a || event.data.b`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"a": "first", "b": "second"}}},
+			expected: "first",
+		},
+		{
+			name:     "OR empty string (falsy) || truthy string → returns second",
+			expr:     `event.data.a || event.data.b`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"a": "", "b": "second"}}},
+			expected: "second",
+		},
+		{
+			name:     "OR missing || truthy → returns truthy",
+			expr:     `event.data.missing || event.data.b`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"b": "found"}}},
+			expected: "found",
+		},
+		{
+			name:     "OR truthy || missing → returns truthy (lhs short-circuits)",
+			expr:     `event.data.a || event.data.missing`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"a": "found"}}},
+			expected: "found",
+		},
+		{
+			name:     "OR both missing → false (last unknown is falsy)",
+			expr:     `event.data.a || event.data.b`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{}}},
+			expected: false,
+		},
+		{
+			name:     "OR int 0 (falsy) || string → returns string",
+			expr:     `event.data.zero || event.data.name`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"zero": 0, "name": "hi"}}},
+			expected: "hi",
+		},
+		// isTruthy for non-standard types in OR
+		{
+			// null is falsy → falls through to rhs
+			name:     "OR null (falsy) || string → returns string",
+			expr:     `null || event.data.b`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"b": "fallback"}}},
+			expected: "fallback",
+		},
+		{
+			// double 3.14 is truthy
+			name:     "OR double 3.14 (truthy) || false → returns 3.14",
+			expr:     `event.data.f || false`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"f": 3.14}}},
+			expected: float64(3.14),
+		},
+		{
+			// double 0.0 is falsy → falls through to rhs
+			name:     "OR double 0.0 (falsy) || string → returns string",
+			expr:     `event.data.f || event.data.b`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"f": 0.0, "b": "yes"}}},
+			expected: "yes",
+		},
+		{
+			// A non-empty list hits isTruthy default branch → truthy → OR returns
+			// the list instead of false.
+			name:     "OR non-empty list (truthy default branch) || false → returns list",
+			expr:     `false || event.data.list`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"list": []string{"a"}}}},
+			expected: []string{"a"},
+		},
+		{
+			// uint(5) hits isTruthy UintType branch → non-zero → truthy
+			name:     "OR uint(5) (truthy) || false → returns uint 5",
+			expr:     `uint(5) || false`,
+			data:     map[string]interface{}{},
+			expected: uint64(5),
+		},
+		{
+			// uint(0) hits isTruthy UintType branch → zero → falsy → falls through
+			name:     "OR uint(0) (falsy) || string → returns string",
+			expr:     `uint(0) || event.data.b`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"b": "yes"}}},
+			expected: "yes",
+		},
+		// Boolean operands delegate to native CEL
+		{
+			name:     "OR bool false || bool true → true",
+			expr:     `event.data.flagA || event.data.flagB`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"flagA": false, "flagB": true}}},
+			expected: true,
+		},
+		{
+			name:     "OR bool false || bool false → false",
+			expr:     `event.data.flagA || event.data.flagB`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"flagA": false, "flagB": false}}},
+			expected: false,
+		},
+		{
+			name:     "OR bool true || bool false → true",
+			expr:     `event.data.flagA || event.data.flagB`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"flagA": true, "flagB": false}}},
+			expected: true,
+		},
+
+		// ── Logical AND: returns first falsy, or last value if all truthy ──────────
+		{
+			name:     "AND both truthy strings → returns last",
+			expr:     `event.data.a && event.data.b`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"a": "first", "b": "second"}}},
+			expected: "second",
+		},
+		{
+			name:     "AND empty string (falsy) && truthy → returns empty string",
+			expr:     `event.data.a && event.data.b`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"a": "", "b": "second"}}},
+			expected: "",
+		},
+		{
+			name:     "AND truthy && empty string → returns empty string",
+			expr:     `event.data.a && event.data.b`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"a": "first", "b": ""}}},
+			expected: "",
+		},
+		{
+			name:     "AND missing (falsy) && truthy → returns false",
+			expr:     `event.data.missing && event.data.b`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"b": "second"}}},
+			expected: false,
+		},
+		// Boolean operands delegate to native CEL
+		{
+			name:     "AND bool true && bool false → false",
+			expr:     `event.data.flagA && event.data.flagB`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"flagA": true, "flagB": false}}},
+			expected: false,
+		},
+		{
+			name:     "AND bool true && bool true → true",
+			expr:     `event.data.flagA && event.data.flagB`,
+			data:     map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"flagA": true, "flagB": true}}},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Evaluate(ctx, tt.expr, tt.data)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestMacrosWithUnknowns tests that macros (exists, all) handle unknowns correctly.
+// The key invariant: lambda variables produce "no such attribute" errors which must
+// pass through the decorator unchanged, not be treated as unknown call failures.
+func TestMacrosWithUnknowns(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name     string
+		expr     string
+		data     map[string]interface{}
+		expected interface{}
+	}{
+		{
+			name: "exists on real list with matching element → true",
+			expr: `event.data.tags.exists(x, x == "a")`,
+			data: map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"tags": []string{"a", "b", "c"}}}},
+			expected: true,
+		},
+		{
+			name: "exists on real list with no matching element → false",
+			expr: `event.data.tags.exists(x, x == "z")`,
+			data: map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"tags": []string{"a", "b", "c"}}}},
+			expected: false,
+		},
+		{
+			name: "exists on real list with OR inside lambda → true",
+			expr: `event.data.tags.exists(x, x == "d" || x == "a")`,
+			data: map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"tags": []string{"a", "b", "c"}}}},
+			expected: true,
+		},
+		{
+			name: "exists on unknown field → false",
+			expr: `event.nonexistent.exists(x, x == "a")`,
+			data: map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{}}},
+			expected: false,
+		},
+		{
+			name: "all on real list all matching → true",
+			expr: `event.data.nums.all(x, x > 0)`,
+			data: map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"nums": []int{1, 2, 3}}}},
+			expected: true,
+		},
+		{
+			name: "all on real list not all matching → false",
+			expr: `event.data.nums.all(x, x > 1)`,
+			data: map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"nums": []int{1, 2, 3}}}},
+			expected: false,
+		},
+		{
+			name: "contains on unknown nested field → false",
+			expr: `event.data.some.unknown.contains("x")`,
+			data: map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{}}},
+			expected: false,
+		},
+		{
+			name: "in operator with unknown field → false",
+			expr: `event.data.nonexistent in ["LOL", "Issue", "Epic"]`,
+			data: map[string]interface{}{"event": map[string]interface{}{"data": map[string]interface{}{"issue": "Bug"}}},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := Evaluate(ctx, tt.expr, tt.data)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestUnknownDecoratorConcurrentSafety verifies that the same compiled expression
+// can be evaluated concurrently with different data without data races or errors.
+func TestUnknownDecoratorConcurrentSafety(t *testing.T) {
+	ctx := context.Background()
+	// Use an expression that exercises unknown, null, and truthy paths together.
+	expression := `event.data.missing < 5 && event.data.name != "" && (event.data.tag || event.data.fallback)`
+
+	const goroutines = 100
+	errs := make(chan error, goroutines)
+	var wg sync.WaitGroup
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			data := map[string]interface{}{
+				"event": map[string]interface{}{
+					"data": map[string]interface{}{
+						"name":     fmt.Sprintf("user-%d", n),
+						"fallback": fmt.Sprintf("tag-%d", n),
+					},
+				},
+			}
+			_, err := Evaluate(ctx, expression, data)
+			if err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+func TestEvalTruthyLogical_NaryOR(t *testing.T) {
+	ctx := context.Background()
+
+	// name == "alice" AND role == "admin" AND plan == "pro" AND (feature_a OR feature_b OR feature_c)
+	expr := `event.data.user.name == "alice" && event.data.user.role == "admin" && event.data.user.plan == "pro" && (event.data.features.a || event.data.features.b || event.data.features.c)`
+
+	eval := func(name, role, plan string, features map[string]interface{}) (interface{}, error) {
+		return Evaluate(ctx, expr, map[string]interface{}{
+			"event": map[string]interface{}{
+				"data": map[string]interface{}{
+					"user":     map[string]interface{}{"name": name, "role": role, "plan": plan},
+					"features": features,
+				},
+			},
+		})
+	}
+
+	// all ANDs satisfied, 3rd OR branch decides
+	result, err := eval("alice", "admin", "pro", map[string]interface{}{"c": "on"})
+	require.NoError(t, err)
+	require.NotEqual(t, false, result)
+
+	// all ANDs satisfied, 1st OR branch
+	result, err = eval("alice", "admin", "pro", map[string]interface{}{"a": "on"})
+	require.NoError(t, err)
+	require.NotEqual(t, false, result)
+
+	// all ANDs satisfied, 2nd OR branch
+	result, err = eval("alice", "admin", "pro", map[string]interface{}{"b": "on"})
+	require.NoError(t, err)
+	require.NotEqual(t, false, result)
+
+	// wrong name
+	result, err = eval("bob", "admin", "pro", map[string]interface{}{"a": "on", "b": "on", "c": "on"})
+	require.NoError(t, err)
+	require.Equal(t, false, result)
+
+	// wrong role
+	result, err = eval("alice", "user", "pro", map[string]interface{}{"a": "on", "b": "on", "c": "on"})
+	require.NoError(t, err)
+	require.Equal(t, false, result)
+
+	// wrong plan
+	result, err = eval("alice", "admin", "free", map[string]interface{}{"a": "on", "b": "on", "c": "on"})
+	require.NoError(t, err)
+	require.Equal(t, false, result)
+
+	// no features
+	result, err = eval("alice", "admin", "pro", map[string]interface{}{})
+	require.NoError(t, err)
+	require.Equal(t, false, result)
+}

--- a/vendor/github.com/inngest/expr/engine.go
+++ b/vendor/github.com/inngest/expr/engine.go
@@ -16,6 +16,7 @@ const (
 	EngineTypeStringHash
 	EngineTypeNullMatch
 	EngineTypeBTree
+	EngineTypeStringBTree
 	// EngineTypeART
 )
 

--- a/vendor/github.com/inngest/expr/engine_stringbtree.go
+++ b/vendor/github.com/inngest/expr/engine_stringbtree.go
@@ -1,0 +1,194 @@
+package expr
+
+import (
+	"context"
+	"sync"
+
+	"github.com/google/cel-go/common/operators"
+	"github.com/ohler55/ojg/jp"
+	"github.com/tidwall/btree"
+	"slices"
+)
+
+func newStringBTreeMatcher() MatchingEngine {
+	return &stringBTree{
+		lock:  &sync.RWMutex{},
+		paths: map[string]int{},
+		tree:  btree.NewMap[string, rangeNode](64),
+	}
+}
+
+// rangeNode holds the three predicate slices for a single threshold key.
+// All three live in the same btree node so one cache-line fetch covers them all.
+type rangeNode struct {
+	exact []*StoredExpressionPart // >= and <= (equality case)
+	gt    []*StoredExpressionPart // > and >=
+	lt    []*StoredExpressionPart // < and <=
+}
+
+// stringBTree matches string range predicates (<, >, <=, >=) using a single B-tree.
+//
+// For a stored threshold t and incoming event value v:
+//   - exact fires when v == t  (covers the equality case of >= and <=)
+//   - gt    fires when v > t   (gt scan stops at first threshold >= v)
+//   - lt    fires when v < t   (lt reverse scan stops at first threshold <= v)
+//
+// A >= expression is stored in both exact and gt; a > expression only in gt.
+// This prevents double-counting: exact fires on equality, gt's stop condition
+// (threshold >= v) means it never fires on equality.
+type stringBTree struct {
+	lock  *sync.RWMutex
+	paths map[string]int // ident -> count of stored ExpressionParts; deleted when 0
+	tree  *btree.Map[string, rangeNode]
+}
+
+func (s *stringBTree) Type() EngineType { return EngineTypeStringBTree }
+
+func (s *stringBTree) Match(ctx context.Context, input map[string]any, result *MatchResult) error {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	for path := range s.paths {
+		x, err := jp.ParseString(path)
+		if err != nil {
+			return err
+		}
+		res := x.Get(input)
+		if len(res) == 0 {
+			continue
+		}
+		val, ok := res[0].(string)
+		if !ok {
+			continue
+		}
+		s.search(path, val, result)
+	}
+	return nil
+}
+
+func (s *stringBTree) Search(ctx context.Context, variable string, input any, result *MatchResult) {
+	val, ok := input.(string)
+	if !ok {
+		return
+	}
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	s.search(variable, val, result)
+}
+
+// search is the lock-free inner implementation; callers must hold s.lock.RLock.
+func (s *stringBTree) search(variable string, val string, result *MatchResult) {
+	if node, ok := s.tree.Get(val); ok {
+		for _, m := range node.exact {
+			if m.Ident != nil && *m.Ident != variable {
+				continue
+			}
+			result.AddExprs(m)
+		}
+	}
+
+	s.tree.Scan(func(threshold string, node rangeNode) bool {
+		if threshold >= val {
+			return false
+		}
+		for _, m := range node.gt {
+			if m.Ident != nil && *m.Ident != variable {
+				continue
+			}
+			result.AddExprs(m)
+		}
+		return true
+	})
+
+	s.tree.Reverse(func(threshold string, node rangeNode) bool {
+		if threshold <= val {
+			return false
+		}
+		for _, m := range node.lt {
+			if m.Ident != nil && *m.Ident != variable {
+				continue
+			}
+			result.AddExprs(m)
+		}
+		return true
+	})
+}
+
+func (s *stringBTree) Add(ctx context.Context, p ExpressionPart) error {
+	val := p.Predicate.LiteralAsString()
+	stored := p.ToStored()
+
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	s.paths[p.Predicate.Ident]++
+
+	node, _ := s.tree.Get(val)
+	if p.Predicate.Operator == operators.GreaterEquals || p.Predicate.Operator == operators.LessEquals {
+		node.exact = append(node.exact, stored)
+	}
+	switch p.Predicate.Operator {
+	case operators.Greater, operators.GreaterEquals:
+		node.gt = append(node.gt, stored)
+	case operators.Less, operators.LessEquals:
+		node.lt = append(node.lt, stored)
+	}
+	s.tree.Set(val, node)
+	return nil
+}
+
+func (s *stringBTree) Remove(ctx context.Context, parts []ExpressionPart) (int, error) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	removeFrom := func(slice []*StoredExpressionPart, p ExpressionPart) ([]*StoredExpressionPart, bool) {
+		for i, eval := range slice {
+			if p.EqualsStored(eval) {
+				return slices.Delete(slice, i, i+1), true
+			}
+		}
+		return slice, false
+	}
+
+	processedCount := 0
+	for _, p := range parts {
+		if ctx.Err() != nil {
+			return processedCount, ctx.Err()
+		}
+		val := p.Predicate.LiteralAsString()
+		node, ok := s.tree.Get(val)
+		if !ok {
+			processedCount++
+			continue
+		}
+		var removed bool
+		if p.Predicate.Operator == operators.GreaterEquals || p.Predicate.Operator == operators.LessEquals {
+			var ok bool
+			node.exact, ok = removeFrom(node.exact, p)
+			removed = removed || ok
+		}
+		switch p.Predicate.Operator {
+		case operators.Greater, operators.GreaterEquals:
+			var ok bool
+			node.gt, ok = removeFrom(node.gt, p)
+			removed = removed || ok
+		case operators.Less, operators.LessEquals:
+			var ok bool
+			node.lt, ok = removeFrom(node.lt, p)
+			removed = removed || ok
+		}
+		if len(node.exact) == 0 && len(node.gt) == 0 && len(node.lt) == 0 {
+			s.tree.Delete(val)
+		} else {
+			s.tree.Set(val, node)
+		}
+		if removed {
+			s.paths[p.Predicate.Ident]--
+			if s.paths[p.Predicate.Ident] == 0 {
+				delete(s.paths, p.Predicate.Ident)
+			}
+		}
+		processedCount++
+	}
+	return processedCount, nil
+}

--- a/vendor/github.com/inngest/expr/expr.go
+++ b/vendor/github.com/inngest/expr/expr.go
@@ -192,9 +192,10 @@ func NewAggregateEvaluator[T Evaluable](
 		eval:   opts.Eval,
 		parser: opts.Parser,
 		engines: map[EngineType]MatchingEngine{
-			EngineTypeStringHash: newStringEqualityMatcher(),
-			EngineTypeNullMatch:  newNullMatcher(),
-			EngineTypeBTree:      newNumberMatcher(),
+			EngineTypeStringHash:  newStringEqualityMatcher(),
+			EngineTypeNullMatch:   newNullMatcher(),
+			EngineTypeBTree:       newNumberMatcher(),
+			EngineTypeStringBTree: newStringBTreeMatcher(),
 		},
 		lock:            &sync.RWMutex{},
 		constants:       map[uuid.UUID]struct{}{},
@@ -698,7 +699,7 @@ func (a *aggregator[T]) GC(ctx context.Context) bool {
 	parseDuration := time.Since(parseStart)
 
 	// Remove null and number engine parts first (small and fast, no timeout needed)
-	for _, et := range []EngineType{EngineTypeNullMatch, EngineTypeBTree} {
+	for _, et := range []EngineType{EngineTypeNullMatch, EngineTypeBTree, EngineTypeStringBTree} {
 		if parts := partsByEngine[et]; len(parts) > 0 {
 			if engine, ok := a.engines[et]; ok {
 				count, err := engine.Remove(context.Background(), parts)
@@ -1002,8 +1003,11 @@ func engineType(p Predicate) EngineType {
 		// NOTE: operators.In acts as operators.Equals, but iterates over the given
 		// array to check each item.
 		if p.Operator == operators.In || p.Operator == operators.Equals || p.Operator == operators.NotEquals {
-			// StringHash is only used for matching on in/equality.
 			return EngineTypeStringHash
+		}
+		if p.Operator == operators.Greater || p.Operator == operators.GreaterEquals ||
+			p.Operator == operators.Less || p.Operator == operators.LessEquals {
+			return EngineTypeStringBTree
 		}
 	case nil:
 		// Only allow this if we're not comparing two idents.each element of the array and

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -780,7 +780,7 @@ github.com/hashicorp/hcl/hcl/token
 github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/inngest/expr v0.0.0-20260504155224-a6e988c15b55
+# github.com/inngest/expr v0.0.0-20260513185122-19a13103520a
 ## explicit; go 1.24
 github.com/inngest/expr
 # github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48


### PR DESCRIPTION
## Description

- **cache mixed expressions cel programs**
- **eliminate per-eval allocations in CEL expression evaluation**
- **cache attribute paths and CEL patterns per expression**
- **implement btree engine for aggregating string comparisons**: https://github.com/inngest/expr/pull/50

```
go test -run=^$ -bench=BenchmarkPauseMixed ./pkg/expressions/expragg/ -benchtime=10000x -benchmem

goos: darwin
goarch: arm64
pkg: github.com/inngest/inngest/pkg/expressions/expragg
cpu: Apple M4 Max
BenchmarkPauseMixed-14    	   10000	     60536 ns/op	   50062 B/op	     802 allocs/op
--- BENCH: BenchmarkPauseMixed-14
    pause_benchmark_test.go:176: Adding 1 expressions (useSameVersion=false, useMixedExpression=true)...
    pause_benchmark_test.go:205: Aggregate evaluator has 1 total evaluables (Fast: 1, Mixed: 0, Slow: 0)
    pause_benchmark_test.go:176: Adding 10000 expressions (useSameVersion=false, useMixedExpression=true)...
    pause_benchmark_test.go:205: Aggregate evaluator has 10000 total evaluables (Fast: 10000, Mixed: 0, Slow: 0)
PASS
ok  	github.com/inngest/inngest/pkg/expressions/expragg	1.174s
```
while before
```
go test -run=^$ -bench=BenchmarkPauseMixed ./pkg/expressions/expragg/ -benchtime=10000x -benchmem

goos: darwin
goarch: arm64
pkg: github.com/inngest/inngest/pkg/expressions/expragg
cpu: Apple M4 Max
BenchmarkPauseMixed-14             10000           5030243 ns/op        24819610 B/op     504199 allocs/op
--- BENCH: BenchmarkPauseMixed-14
    pause_benchmark_test.go:70: Adding 1 expressions (useSameVersion=false, useMixedExpression=true)...
    pause_benchmark_test.go:99: Aggregate evaluator has 1 total evaluables (Fast: 0, Mixed: 1, Slow: 0)
    pause_benchmark_test.go:70: Adding 10000 expressions (useSameVersion=false, useMixedExpression=true)...
    pause_benchmark_test.go:99: Aggregate evaluator has 10000 total evaluables (Fast: 0, Mixed: 10000, Slow: 0)
PASS
ok      github.com/inngest/inngest/pkg/expressions/expragg      50.790s
```

## Type of change (choose one)
- [x] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR optimizes CEL expression evaluation for pause matching via three strategies: (1) caching compiled `cel.Program` instances per expression string, (2) pre-computing attribute paths and `AttributePattern` slices at parse time to avoid per-evaluation allocations, and (3) refactoring `unknownDecorator` from plan-time to eval-time via the new `runtimeUnknownCall` struct. It also bumps `github.com/inngest/expr` to pick up a btree engine for string comparison aggregation, yielding an ~83× throughput improvement on the mixed-expression benchmark.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b99fe80568018d90c5f0b6445e4d6db3d042e63d.</sup>
<!-- /MENDRAL_SUMMARY -->