### PR TITLE
Link invoked run's runID to invoking step span while in progress

### DIFF
--- a/pkg/cqrs/base_cqrs/cqrs.go
+++ b/pkg/cqrs/base_cqrs/cqrs.go
@@ -234,6 +234,29 @@ type spanRollupInfo struct {
 	otelToDynamic map[string]string
 }
 
+// fragmentAttributesJSON returns the attributes field of a span fragment as
+// JSON bytes. The aggregation queries differ between backends: sqlite's
+// json_object embeds JSON columns as quoted strings while postgres'
+// json_build_object embeds jsonb as nested objects, so the decoded fragment
+// can land here as either a string or a map[string]any.
+func fragmentAttributesJSON(raw any) ([]byte, bool) {
+	switch v := raw.(type) {
+	case string:
+		if v == "" {
+			return nil, false
+		}
+		return []byte(v), true
+	case map[string]any:
+		byt, err := json.Marshal(v)
+		if err != nil {
+			return nil, false
+		}
+		return byt, true
+	default:
+		return nil, false
+	}
+}
+
 func mapSpanFromRow[T normalizedSpan](ctx context.Context, span T, info *spanRollupInfo) (*cqrs.OtelSpan, error) {
 	// Use interface methods to get the fields directly
 	traceID := span.GetTraceID()
@@ -347,9 +370,9 @@ fragmentLoop:
 			}
 		}
 
-		if attrs, ok := fragment["attributes"].(string); ok {
+		if attrs, ok := fragmentAttributesJSON(fragment["attributes"]); ok {
 			fragmentAttr := map[string]any{}
-			if err := json.Unmarshal([]byte(attrs), &fragmentAttr); err != nil {
+			if err := json.Unmarshal(attrs, &fragmentAttr); err != nil {
 				logger.StdlibLogger(ctx).Error("error unmarshalling span attributes", "error", err)
 				return nil, err
 			}
@@ -578,7 +601,7 @@ func rollupSpanMetadataFromFragments(ctx context.Context, fragments []map[string
 	}
 
 	for _, fragment := range fragments {
-		attrs, ok := fragment["attributes"].(string)
+		attrs, ok := fragmentAttributesJSON(fragment["attributes"])
 		if !ok {
 			logger.StdlibLogger(ctx).Error("error unmarshalling metadata span kind, no attributes")
 			continue
@@ -590,7 +613,7 @@ func rollupSpanMetadataFromFragments(ctx context.Context, fragments []map[string
 			Op     *metadata.Opcode `json:"_inngest.metadata.op"`
 			Values *string          `json:"_inngest.metadata.values"`
 		}
-		if err := json.Unmarshal([]byte(attrs), &fragmentAttr); err != nil {
+		if err := json.Unmarshal(attrs, &fragmentAttr); err != nil {
 			logger.StdlibLogger(ctx).Error("error unmarshalling metadata span attributes", "error", err)
 			return nil, err
 		}

--- a/pkg/cqrs/base_cqrs/cqrs_test.go
+++ b/pkg/cqrs/base_cqrs/cqrs_test.go
@@ -1789,6 +1789,32 @@ func TestSpanWithAttributesAndOutput(t *testing.T) {
 	assert.NotNil(t, result)
 }
 
+// TestSpanAttributesRoundTrip exercises the read path for stored span
+// attributes. Postgres' jsonb embeds as a nested object inside json_build_object
+// while sqlite's JSON returns a quoted string, so this regression-tests that the
+// reader handles both shapes — when broken, the entire attribute map is silently
+// empty under postgres and every downstream consumer (StepOp, RunID, etc.) sees
+// zero values.
+func TestSpanAttributesRoundTrip(t *testing.T) {
+	cm, cleanup := initCQRS(t)
+	defer cleanup()
+
+	runULID := ulid.MustNew(ulid.Now(), rand.Reader)
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runULID.String(),
+		DynamicSpanID: "dyn-attrs",
+		Name:          "executor.run",
+		Attributes:    []byte(`{"sdk.language":"go","sdk.version":"0.1.0","_inngest.run.id":"` + runULID.String() + `"}`),
+	})
+
+	result, err := cm.GetSpansByRunID(t.Context(), runULID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "go", result.RawOtelSpan.Attributes["sdk.language"])
+	assert.Equal(t, "0.1.0", result.RawOtelSpan.Attributes["sdk.version"])
+}
+
 // TestSpanOutputReadBack verifies that span output stored as []byte can be
 // read back via GetSpanOutput without corruption. This is a regression test
 // for double-encoding where json.Marshal(stringValue) would wrap the JSON

--- a/pkg/event/invoke.go
+++ b/pkg/event/invoke.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/consts"
 	itrace "github.com/inngest/inngest/pkg/telemetry/trace"
+	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -63,19 +64,22 @@ type InngestMetadata struct {
 	// InvokeType represents the invoke type, eg. "step", "api", and so on.
 	// This allows us to differentiate function invocations and handle things
 	// specifically.
-	InvokeType           string               `json:"type,omitempty"`
-	InvokeIdempotencyKey string               `json:"invoke_idempotency,omitempty"`
-	SourceAppID          string               `json:"source_app_id"`
-	SourceFnID           string               `json:"source_fn_id"`
-	SourceFnVersion      int                  `json:"source_fn_v"`
-	InvokeFnID           string               `json:"fn_id"`
-	InvokeCorrelationId  string               `json:"correlation_id,omitempty"`
-	InvokeTraceCarrier   *itrace.TraceCarrier `json:"tc,omitempty"`
-	InvokeExpiresAt      int64                `json:"expire"`
-	InvokeGroupID        string               `json:"gid"`
-	InvokeDisplayName    string               `json:"name"`
-	DebugSessionID       *ulid.ULID           `json:"debug_session_id,omitempty"`
-	DebugRunID           *ulid.ULID           `json:"debug_run_id,omitempty"`
+	InvokeType           string `json:"type,omitempty"`
+	InvokeIdempotencyKey string `json:"invoke_idempotency,omitempty"`
+	SourceAppID          string `json:"source_app_id"`
+	SourceFnID           string `json:"source_fn_id"`
+	SourceFnVersion      int    `json:"source_fn_v"`
+	InvokeFnID           string `json:"fn_id"`
+	InvokeCorrelationId  string `json:"correlation_id,omitempty"`
+	// InvokeTraceCarrier is for v1 traces and InvokeSpanRef is for v2
+	// Used for linking invoked runIDs to the caller
+	InvokeTraceCarrier *itrace.TraceCarrier `json:"tc,omitempty"`
+	InvokeSpanRef      *meta.SpanReference  `json:"isr,omitempty"`
+	InvokeExpiresAt    int64                `json:"expire"`
+	InvokeGroupID      string               `json:"gid"`
+	InvokeDisplayName  string               `json:"name"`
+	DebugSessionID     *ulid.ULID           `json:"debug_session_id,omitempty"`
+	DebugRunID         *ulid.ULID           `json:"debug_run_id,omitempty"`
 }
 
 func (m *InngestMetadata) Decode(data any) error {
@@ -99,6 +103,24 @@ func (m *InngestMetadata) RunID() *ulid.ULID {
 		return &id
 	}
 	return nil
+}
+
+// SetInvokeSpanRef sets InvokeSpanRef on the InngestMetadata stored in this event's data bag.
+// Returns false if the event has no inngest metadata (not an invocation event).
+func (e *Event) SetInvokeSpanRef(ref *meta.SpanReference) bool {
+	if e.Data == nil {
+		return false
+	}
+	// The metadata sits under an `any` slot in Event.Data, so
+	// we can't mutate one of its fields in place - we have to type assert it out,
+	// modify the copy, and put it back.
+	md, ok := e.Data[consts.InngestEventDataPrefix].(InngestMetadata)
+	if !ok {
+		return false
+	}
+	md.InvokeSpanRef = ref
+	e.Data[consts.InngestEventDataPrefix] = md
+	return true
 }
 
 func (e Event) InngestMetadata() (*InngestMetadata, error) {

--- a/pkg/event/invoke_test.go
+++ b/pkg/event/invoke_test.go
@@ -1,0 +1,33 @@
+package event
+
+import (
+	"testing"
+
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvent_SetInvokeSpanRef(t *testing.T) {
+	ref := &meta.SpanReference{TraceParent: "00-00112233445566778899aabbccddeeff-0011223344556677-01"}
+	evt := Event{
+		Name: InvokeFnName,
+		Data: map[string]any{
+			consts.InngestEventDataPrefix: InngestMetadata{InvokeFnID: "app-fn"},
+		},
+	}
+
+	require.True(t, evt.SetInvokeSpanRef(ref))
+
+	md := evt.Data[consts.InngestEventDataPrefix].(InngestMetadata)
+	require.Equal(t, ref, md.InvokeSpanRef)
+	require.Equal(t, "app-fn", md.InvokeFnID, "unrelated fields must be preserved")
+}
+
+func TestEvent_SetInvokeSpanRef_ReturnsFalseWhenNoMetadata(t *testing.T) {
+	evt := Event{Name: "user/thing.happened", Data: map[string]any{"foo": "bar"}}
+	require.False(t, evt.SetInvokeSpanRef(&meta.SpanReference{}))
+
+	nilData := Event{Name: "user/thing.happened"}
+	require.False(t, nilData.SetInvokeSpanRef(&meta.SpanReference{}))
+}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1459,6 +1459,10 @@ func (e *executor) schedule(
 		}
 	}
 
+	// If this run was triggered by an invoke, write the invoked run's ID back
+	// onto the invoking function's invoke span so the in-progress trace shows it.
+	e.updateInvokeSpanWithInvokedRunID(ctx, l, req.Events, metadata.ID.RunID)
+
 	// If this is run mode sync, we do NOT need to create a queue item, as the
 	// Inngest SDK is checkpointing and the execution is happening in a single
 	// external API request.
@@ -1499,6 +1503,49 @@ func (e *executor) schedule(
 	}
 
 	return &metadata.ID.RunID, &metadata, nil
+}
+
+func (e *executor) updateInvokeSpanWithInvokedRunID(ctx context.Context, l logger.Logger, events []event.TrackedEvent, invokedRunID ulid.ULID) {
+	// We should only have one Invoke event at most, but this technically handles a batch of invoke events
+	if len(events) == 0 || events[0].GetEvent().Name != consts.FnInvokeName {
+		return
+	}
+	for _, trackedEvent := range events {
+		invocationEvtID := trackedEvent.GetInternalID()
+		raw, ok := trackedEvent.GetEvent().Data[consts.InngestEventDataPrefix]
+		if !ok {
+			l.Debug("invocation event missing inngest metadata; skipping invoke span update", "invocation_evt_id", invocationEvtID)
+			continue
+		}
+		invocationMeta := event.InngestMetadata{}
+		if err := invocationMeta.Decode(raw); err != nil {
+			l.Debug("failed to decode invocation metadata; skipping invoke span update", "invocation_evt_id", invocationEvtID, "error", err)
+			continue
+		}
+		if invocationMeta.InvokeSpanRef == nil {
+			l.Debug("invocation event missing invoke span ref; skipping invoke span update", "invocation_evt_id", invocationEvtID)
+			continue
+		}
+		sourceRunID := invocationMeta.RunID()
+		if sourceRunID == nil {
+			l.Debug("invocation event has unparseable correlation id; skipping invoke span update", "invocation_evt_id", invocationEvtID, "correlation_id", invocationMeta.InvokeCorrelationId)
+			continue
+		}
+		sourceAccountID := trackedEvent.GetAccountID()
+		sourceEnvID := trackedEvent.GetWorkspaceID()
+		if err := e.tracerProvider.UpdateSpan(ctx, &tracing.UpdateSpanOptions{
+			Debug:      &tracing.SpanDebugData{Location: "executor.Schedule.invokeRunID"},
+			TargetSpan: invocationMeta.InvokeSpanRef,
+			Attributes: meta.NewAttrSet(
+				meta.Attr(meta.Attrs.StepInvokeRunID, &invokedRunID),
+				meta.Attr(meta.Attrs.RunID, sourceRunID),
+				meta.Attr(meta.Attrs.AccountID, &sourceAccountID),
+				meta.Attr(meta.Attrs.EnvID, &sourceEnvID),
+			),
+		}); err != nil {
+			l.Debug("error updating invoke span with invoked runID", "error", err)
+		}
+	}
 }
 
 func (e *executor) handleFunctionSkipped(ctx context.Context, req execution.ScheduleRequest, metadata sv2.Metadata, evts []json.RawMessage, reason enums.SkipReason) (*ulid.ULID, *sv2.Metadata, error) {
@@ -4940,6 +4987,13 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx exe
 
 	if span != nil {
 		_ = span.Send()
+	}
+
+	// Attach the v2 invoke span ref to the invocation event so the invoked
+	// function's Schedule can call UpdateSpan to write its runID onto this
+	// invoke span while the invoke is still in progress.
+	if span != nil && span.Ref != nil {
+		evt.Event.SetInvokeSpanRef(span.Ref)
 	}
 
 	// Send the event.

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1531,6 +1531,16 @@ func (e *executor) updateInvokeSpanWithInvokedRunID(ctx context.Context, l logge
 			l.Debug("invocation event has unparseable correlation id; skipping invoke span update", "invocation_evt_id", invocationEvtID, "correlation_id", invocationMeta.InvokeCorrelationId)
 			continue
 		}
+		sourceFnID, err := uuid.Parse(invocationMeta.SourceFnID)
+		if err != nil {
+			l.Debug("invocation event has unparseable source fn id; skipping invoke span update", "invocation_evt_id", invocationEvtID, "source_fn_id", invocationMeta.SourceFnID, "error", err)
+			continue
+		}
+		sourceAppID, err := uuid.Parse(invocationMeta.SourceAppID)
+		if err != nil {
+			l.Debug("invocation event has unparseable source app id; skipping invoke span update", "invocation_evt_id", invocationEvtID, "source_app_id", invocationMeta.SourceAppID, "error", err)
+			continue
+		}
 		sourceAccountID := trackedEvent.GetAccountID()
 		sourceEnvID := trackedEvent.GetWorkspaceID()
 		if err := e.tracerProvider.UpdateSpan(ctx, &tracing.UpdateSpanOptions{
@@ -1541,6 +1551,8 @@ func (e *executor) updateInvokeSpanWithInvokedRunID(ctx context.Context, l logge
 				meta.Attr(meta.Attrs.RunID, sourceRunID),
 				meta.Attr(meta.Attrs.AccountID, &sourceAccountID),
 				meta.Attr(meta.Attrs.EnvID, &sourceEnvID),
+				meta.Attr(meta.Attrs.FunctionID, &sourceFnID),
+				meta.Attr(meta.Attrs.AppID, &sourceAppID),
 			),
 		}); err != nil {
 			l.Debug("error updating invoke span with invoked runID", "error", err)

--- a/pkg/execution/executor/invoke_span_runid_test.go
+++ b/pkg/execution/executor/invoke_span_runid_test.go
@@ -44,6 +44,12 @@ func newSpanRef() *meta.SpanReference {
 func invocationEvent(t *testing.T, accountID, envID uuid.UUID, sourceRunID ulid.ULID, md event.InngestMetadata) event.InternalEvent {
 	t.Helper()
 	md.InvokeCorrelationId = sourceRunID.String() + ".step-1"
+	if md.SourceFnID == "" {
+		md.SourceFnID = uuid.NewString()
+	}
+	if md.SourceAppID == "" {
+		md.SourceAppID = uuid.NewString()
+	}
 	id := ulid.MustNew(ulid.Now(), nil)
 	return event.InternalEvent{
 		ID:          id,

--- a/pkg/execution/executor/invoke_span_runid_test.go
+++ b/pkg/execution/executor/invoke_span_runid_test.go
@@ -1,0 +1,181 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingTracerProvider captures UpdateSpan calls so tests can inspect them.
+type recordingTracerProvider struct {
+	tracing.TracerProvider
+	updateCalls []*tracing.UpdateSpanOptions
+	updateErr   error
+}
+
+func (r *recordingTracerProvider) UpdateSpan(_ context.Context, opts *tracing.UpdateSpanOptions) error {
+	r.updateCalls = append(r.updateCalls, opts)
+	return r.updateErr
+}
+
+func newRecordingTracerProvider() *recordingTracerProvider {
+	return &recordingTracerProvider{TracerProvider: tracing.NewNoopTracerProvider()}
+}
+
+func newSpanRef() *meta.SpanReference {
+	return &meta.SpanReference{
+		TraceParent: "00-00112233445566778899aabbccddeeff-0011223344556677-01",
+	}
+}
+
+// invocationEvent builds an InternalEvent shaped like a function.invoked event
+// with the supplied InngestMetadata. The InvokeCorrelationId is set so that
+// (*InngestMetadata).RunID() returns sourceRunID.
+func invocationEvent(t *testing.T, accountID, envID uuid.UUID, sourceRunID ulid.ULID, md event.InngestMetadata) event.InternalEvent {
+	t.Helper()
+	md.InvokeCorrelationId = sourceRunID.String() + ".step-1"
+	id := ulid.MustNew(ulid.Now(), nil)
+	return event.InternalEvent{
+		ID:          id,
+		AccountID:   accountID,
+		WorkspaceID: envID,
+		Event: event.Event{
+			ID:        id.String(),
+			Name:      consts.FnInvokeName,
+			Timestamp: time.Now().UnixMilli(),
+			Data: map[string]any{
+				consts.InngestEventDataPrefix: md,
+			},
+		},
+	}
+}
+
+func TestUpdateInvokeSpanWithInvokedRunID_WritesAttributesToInvokeSpan(t *testing.T) {
+	rec := newRecordingTracerProvider()
+	e := &executor{
+		log:            logger.From(context.Background()),
+		tracerProvider: rec,
+	}
+
+	accountID := uuid.New()
+	envID := uuid.New()
+	sourceRunID := ulid.MustNew(ulid.Now(), nil)
+	invokedRunID := ulid.MustNew(ulid.Now(), nil)
+	spanRef := newSpanRef()
+
+	evt := invocationEvent(t, accountID, envID, sourceRunID, event.InngestMetadata{
+		InvokeFnID:    "app-fn",
+		InvokeSpanRef: spanRef,
+	})
+
+	e.updateInvokeSpanWithInvokedRunID(context.Background(), e.log, []event.TrackedEvent{evt}, invokedRunID)
+
+	require.Len(t, rec.updateCalls, 1)
+	call := rec.updateCalls[0]
+	require.NotNil(t, call.TargetSpan)
+	require.Equal(t, spanRef.TraceParent, call.TargetSpan.TraceParent,
+		"target span must be the caller's invoke span (round-tripped through the invocation event)")
+	require.NotNil(t, call.Debug)
+	require.Equal(t, "executor.Schedule.invokeRunID", call.Debug.Location)
+
+	gotInvokedRunID, ok := call.Attributes.Get(meta.Attrs.StepInvokeRunID.Key()).(*ulid.ULID)
+	require.True(t, ok, "step.invoke.run.id must be set as *ulid.ULID")
+	require.Equal(t, invokedRunID, *gotInvokedRunID)
+
+	gotSourceRunID, ok := call.Attributes.Get(meta.Attrs.RunID.Key()).(*ulid.ULID)
+	require.True(t, ok, "caller run id must be set to scope the target span")
+	require.Equal(t, sourceRunID, *gotSourceRunID)
+
+	gotAccountID, ok := call.Attributes.Get(meta.Attrs.AccountID.Key()).(*uuid.UUID)
+	require.True(t, ok)
+	require.Equal(t, accountID, *gotAccountID)
+
+	gotEnvID, ok := call.Attributes.Get(meta.Attrs.EnvID.Key()).(*uuid.UUID)
+	require.True(t, ok)
+	require.Equal(t, envID, *gotEnvID)
+}
+
+func TestUpdateInvokeSpanWithInvokedRunID_NoCallsWhenNotInvoke(t *testing.T) {
+	rec := newRecordingTracerProvider()
+	e := &executor{
+		log:            logger.From(context.Background()),
+		tracerProvider: rec,
+	}
+	invokedRunID := ulid.MustNew(ulid.Now(), nil)
+
+	// Same metadata shape, but the event name is not FnInvokeName — this run
+	// was not triggered by an invoke step, so nothing should be written.
+	evt := event.InternalEvent{
+		ID: ulid.MustNew(ulid.Now(), nil),
+		Event: event.Event{
+			Name: "user/cron.triggered",
+			Data: map[string]any{
+				consts.InngestEventDataPrefix: event.InngestMetadata{
+					InvokeSpanRef: newSpanRef(),
+				},
+			},
+		},
+	}
+
+	e.updateInvokeSpanWithInvokedRunID(context.Background(), e.log, []event.TrackedEvent{evt}, invokedRunID)
+	require.Empty(t, rec.updateCalls, "non-invoke events must not produce UpdateSpan calls")
+}
+
+func TestUpdateInvokeSpanWithInvokedRunID_SkipsEventsMissingSpanRef(t *testing.T) {
+	rec := newRecordingTracerProvider()
+	e := &executor{
+		log:            logger.From(context.Background()),
+		tracerProvider: rec,
+	}
+
+	accountID := uuid.New()
+	envID := uuid.New()
+	sourceRunID := ulid.MustNew(ulid.Now(), nil)
+	invokedRunID := ulid.MustNew(ulid.Now(), nil)
+
+	// First event has no span ref (older invocations that predate the field);
+	// second event has the span ref — only the second should produce an update.
+	noRef := invocationEvent(t, accountID, envID, sourceRunID, event.InngestMetadata{
+		InvokeFnID: "app-fn",
+	})
+	withRef := invocationEvent(t, accountID, envID, sourceRunID, event.InngestMetadata{
+		InvokeFnID:    "app-fn",
+		InvokeSpanRef: newSpanRef(),
+	})
+
+	e.updateInvokeSpanWithInvokedRunID(context.Background(), e.log, []event.TrackedEvent{noRef, withRef}, invokedRunID)
+	require.Len(t, rec.updateCalls, 1, "only the event carrying an invoke span ref produces an UpdateSpan call")
+}
+
+func TestUpdateInvokeSpanWithInvokedRunID_SwallowsTracerError(t *testing.T) {
+	rec := newRecordingTracerProvider()
+	rec.updateErr = errors.New("tracer offline")
+	e := &executor{
+		log:            logger.From(context.Background()),
+		tracerProvider: rec,
+	}
+
+	evt := invocationEvent(t, uuid.New(), uuid.New(), ulid.MustNew(ulid.Now(), nil), event.InngestMetadata{
+		InvokeFnID:    "app-fn",
+		InvokeSpanRef: newSpanRef(),
+	})
+
+	// The Schedule path must not abort if the tracer fails — the invoke span
+	// update is best-effort (the invoking function's invoke step still
+	// completes when the invoked run finishes), so a tracer error is logged
+	// and swallowed.
+	require.NotPanics(t, func() {
+		e.updateInvokeSpanWithInvokedRunID(context.Background(), e.log, []event.TrackedEvent{evt}, ulid.MustNew(ulid.Now(), nil))
+	})
+	require.Len(t, rec.updateCalls, 1)
+}

--- a/tests/golang/invoke_test.go
+++ b/tests/golang/invoke_test.go
@@ -438,3 +438,100 @@ func TestInvokeRateLimit(t *testing.T) {
 	secondRunID := secondRID.Wait(t)
 	c.WaitForRunStatus(ctx, t, "FAILED", secondRunID)
 }
+
+func TestInvokeInProgressRunID(t *testing.T) {
+	ctx := context.Background()
+	r := require.New(t)
+	c := client.New(t)
+
+	appID := "InvokeInProgressRunID-" + ulid.MustNew(ulid.Now(), nil).String()
+	inngestClient, server, registerFuncs := NewSDKHandler(t, appID)
+	defer server.Close()
+
+	mainRID := NewRunID()
+	invokedRID := NewRunID()
+
+	// Invoked function: capture its runID, then sleep long enough that we can
+	// observe the invoking function mid-flight.
+	invokedFnName := "invoked-fn"
+	_, err := inngestgo.CreateFunction(
+		inngestClient,
+		inngestgo.FunctionOpts{
+			ID:      invokedFnName,
+			Retries: inngestgo.IntPtr(0),
+		},
+		inngestgo.EventTrigger("none", nil),
+		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
+			invokedRID.Send(input.InputCtx.RunID)
+			step.Sleep(ctx, "hold", 20*time.Second)
+			return "invoked!", nil
+		},
+	)
+	r.NoError(err)
+
+	evtName := "invoke-in-progress"
+	_, err = inngestgo.CreateFunction(
+		inngestClient,
+		inngestgo.FunctionOpts{
+			ID:      "main-fn",
+			Retries: inngestgo.IntPtr(0),
+		},
+		inngestgo.EventTrigger(evtName, nil),
+		func(ctx context.Context, input inngestgo.Input[DebounceEvent]) (any, error) {
+			mainRID.Send(input.InputCtx.RunID)
+			_, err := step.Invoke[any](
+				ctx,
+				"invoke",
+				step.InvokeOpts{FunctionId: appID + "-" + invokedFnName},
+			)
+			return nil, err
+		},
+	)
+	r.NoError(err)
+	registerFuncs()
+
+	_, err = inngestClient.Send(ctx, &event.Event{Name: evtName})
+	r.NoError(err)
+
+	// Both runs must have started before we query mid-flight.
+	mainRunID := mainRID.Wait(t)
+	invokedRunID := invokedRID.Wait(t)
+
+	// Poll the v2 trace until the invoke step span has the invoked runID.
+	var observedRunID string
+	invokeOp := models.StepOpInvoke.String()
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		run, err := c.RunTraces(ctx, mainRunID, true)
+		require.NoError(ct, err)
+		require.NotNil(ct, run)
+		require.NotNil(ct, run.Trace)
+		require.Equal(ct, models.FunctionStatusRunning.String(), run.Status,
+			"main fn finished before we could observe the in-progress invoke")
+
+		var invokeStepInfo any
+		var invokeStatus string
+		found := false
+		for i := range run.Trace.ChildSpans {
+			s := &run.Trace.ChildSpans[i]
+			if s.StepOp == invokeOp {
+				invokeStepInfo = s.StepInfo
+				invokeStatus = s.Status
+				found = true
+				break
+			}
+		}
+		require.True(ct, found, "invoke step span not yet present in trace")
+		require.Equal(ct, models.RunTraceSpanStatusRunning.String(), invokeStatus,
+			"invoke span must still be running")
+
+		var stepInfo models.InvokeStepInfo
+		byt, err := json.Marshal(invokeStepInfo)
+		require.NoError(ct, err)
+		require.NoError(ct, json.Unmarshal(byt, &stepInfo))
+		require.NotNil(ct, stepInfo.RunID, "InvokeStepInfo.RunID must be populated while invoke is in-progress")
+		observedRunID = stepInfo.RunID.String()
+	}, 15*time.Second, 500*time.Millisecond)
+
+	r.Equal(invokedRunID, observedRunID,
+		"InvokeStepInfo.RunID must match the invoked function's runID")
+}


### PR DESCRIPTION
## Description

This is a regression from v1 traces which had this behavior. v2 currently only links this runID when the invoke completes in ResumeAttrs

We need to use InvokeSpanRef as a carrier instead of the existing TraceCarrier because the v2 UpdateSpan requires this to link to the dynamic span

## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Restores v1 trace behavior: links an invoked run's ID to the calling function's invoke step span while still in-progress. Adds `InvokeSpanRef` (`isr`) to `InngestMetadata` as a v2-compatible carrier; `handleGeneratorInvokeFunction` attaches the span ref before dispatching; `schedule` reads it back via `updateInvokeSpanWithInvokedRunID` and calls `UpdateSpan`. Also fixes a sqlite/postgres JSON attribute deserialization divergence (`fragmentAttributesJSON`) and adds regression tests. The final commit populates `SourceFnID`/`SourceAppID` in the `UpdateSpan` call and updates the test helper.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 18804747ec3ae0803f16e4e614e2b4c1b13f896c.</sup>
<!-- /MENDRAL_SUMMARY -->