### PR TITLE
fix(grpc): handle unimplemented error for `LoadDefersMeta` for backwards compatibility

### DIFF
--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -14,6 +14,8 @@ import (
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/util/errs"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
 )
 
 // DriverV2 represents a driver that makes requests to SDKs to re-enter and execute
@@ -129,7 +131,14 @@ func MarshalV1(
 	// read the input data.
 	defers, err := sl.LoadDefersMeta(ctx, md.ID)
 	if err != nil {
-		return nil, fmt.Errorf("error loading defers in driver marshaller: %w", err)
+		// Older state-service deployments may not yet expose LoadDefersMeta.
+		// Treat that as an empty set rather than failing the whole request, so
+		// a rolling upgrade doesn't break in-flight executions.
+		if st, ok := grpcStatus.FromError(err); ok && st.Code() == codes.Unimplemented {
+			defers = map[string]sv2.DeferMeta{}
+		} else {
+			return nil, fmt.Errorf("error loading defers in driver marshaller: %w", err)
+		}
 	}
 
 	deferEntries := make(map[string]SDKDeferEntry, len(defers))


### PR DESCRIPTION
## Description

<!--- Please edit this to include a summary of the change (what). -->
<!--- Include screenshots if you modify the UI. -->
When LoadDefersMeta is called on a gRPC state-service deployment that was compiled before the RPC was added to the proto (state.v2.RunService), the server returns codes.Unimplemented and the entire execution request fails with:


error loading defers in driver marshaller: non-retriable error: rpc error: code = Unimplemented desc = unknown method LoadDefersMeta for service state.v2.RunService
The fix detects the codes.Unimplemented gRPC status in MarshalV1 and falls back to an empty defers map, so executions continue normally on older state-service deployments instead of failing.

## Motivation
<!--- Please edit this to include the reason why we are making this change. -->
LoadDefersMeta was added to the StateLoader interface and called in driver.MarshalV1 in the same release that added the DeferAdd/DeferCancel opcodes. The corresponding gRPC RPC was added to the proto in a separate commit (22559d61f). Any state-service gRPC server deployed before that proto update doesn't know about LoadDefersMeta, causing all function executions routed through it to fail with a non-retriable error.

The fallback is safe because: prior to this feature, defers were never sent to the SDK at all — an empty map is exactly what older deployments would have sent.
## Type of change (choose one)
- [ ] Chore (refactors, upgrades, etc.)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist
- [ ] I've linked any associated issues to this PR.
- [x] I've tested my own changes.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds backwards-compatible fallback in `MarshalV1` when the gRPC state-service returns `codes.Unimplemented` for `LoadDefersMeta`, treating it as an empty defers map to prevent execution failures during rolling upgrades.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 233336b6cc986deaab40f12d517587c05ed2ee0e.</sup>
<!-- /MENDRAL_SUMMARY -->