### PR TITLE
Make Run ID clickable in Runs Info

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/RunInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/RunInfo.tsx
@@ -12,6 +12,7 @@ import {
   TextElement,
   TimeElement,
 } from '../DetailsCard/Element';
+import { Link } from '../Link';
 import type { Run as InitialRunData } from '../RunsPage/types';
 import type { TraceResult } from '../SharedContext/useGetTraceResult';
 import { usePathCreator } from '../SharedContext/usePathCreator';
@@ -106,7 +107,13 @@ export const RunInfo = ({
       {expanded && (
         <div className="flex flex-row flex-wrap items-center justify-start gap-x-10 gap-y-4">
           <ElementWrapper label="Run ID">
-            <IDElement>{runID}</IDElement>
+            {standalone ? (
+              <IDElement>{runID}</IDElement>
+            ) : (
+              <Link href={pathCreator.runPopout({ runID })} className="font-mono">
+                {runID}
+              </Link>
+            )}
           </ElementWrapper>
 
           <OptimisticElementWrapper


### PR DESCRIPTION
## Description

Updated the RunInfo component to display the Run ID as a clickable link when the component is not in standalone mode. When `standalone` is true, the Run ID displays as plain text (IDElement). When false, it renders as a Link that navigates to the run popout view.

<img width="493" height="170" alt="image" src="https://github.com/user-attachments/assets/05607969-cdf7-4902-a46e-44ea3384efee" />


## Motivation

This improves navigation within the UI by allowing users to quickly access the popout view of a run directly from the Run ID in the details panel, reducing the number of clicks needed to navigate between related views.

## Type of change

- [ ] Chore (refactors, upgrades, etc.)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Security fix (non-breaking change that fixes a potential vulnerability)
- [ ] Docs
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist

- [ ] I've linked any associated issues to this PR.
- [ ] I've tested my own changes.

https://claude.ai/code/session_0133QaZJ4R8mpK9zzmEmr6ry

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Makes the Run ID in the RunInfo details panel a clickable link to the run popout view when the component is not in standalone mode. When `standalone` is true, the existing plain `IDElement` renders as before.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 696bc7a238903a71f227deb1711e743b22552cbe.</sup>
<!-- /MENDRAL_SUMMARY -->