### PR TITLE
chore: fix PR release job

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -10,7 +10,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
+        if: github.event_name == 'pull_request'
         uses: ytanikin/pr-conventional-commits@639145d78959c53c43112365837e3abd21ed67c1 # 1.5.2
         with:
           # Keep this list aligned with cliff.toml.
           task_types: '["feat","fix","doc","test","ci","refactor","perf","chore","revert","style","security","cloud","internal","noop"]'
+
+      - name: Merge Queue Conventional Commit Validation
+        if: github.event_name == 'merge_group'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          head_ref="${MERGE_GROUP_HEAD_REF:-${GITHUB_REF_NAME}}"
+          mapfile -t pr_numbers < <(printf '%s\n' "${head_ref}" | grep -Eo 'pr-[0-9]+' | sed 's/pr-//' | sort -u)
+
+          if [ "${#pr_numbers[@]}" -eq 0 ]; then
+            echo "::error title=Missing pull request number::Could not determine pull request number from merge queue ref: ${head_ref}"
+            exit 1
+          fi
+
+          allowed_types="feat|fix|doc|test|ci|refactor|perf|chore|revert|style|security|cloud|internal|noop"
+          title_regex="^(${allowed_types})(\([A-Za-z0-9._/-]+\))?!?: .+"
+
+          for pr_number in "${pr_numbers[@]}"; do
+            title="$(gh pr view "${pr_number}" --repo "${GITHUB_REPOSITORY}" --json title --jq '.title')"
+            echo "Validating PR #${pr_number}: ${title}"
+
+            if [[ ! "${title}" =~ ${title_regex} ]]; then
+              echo "::error title=Invalid conventional PR title::PR #${pr_number} title must use Conventional Commit format with an allowed type: ${title}"
+              exit 1
+            fi
+          done

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -119,6 +119,8 @@ jobs:
 
       - name: Collect PR release notes
         if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           scripts/release/collect-pr-notes \
             --range "${{ steps.changes.outputs.release_range }}" \

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   create-release-pr:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-4
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description

The release job misses the GH token needed. 
https://github.com/inngest/inngest/actions/runs/25702576601/job/75465721111

Adding it and also changing the runner to a 4 CPU node so the changelog processing is faster.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes two gaps in the CI/release pipeline: adds `GH_TOKEN` to the "Collect PR release notes" step in `release-pr.yml` (required for `gh` CLI calls), switches the release job runner to a 4-CPU Depot node, and adds a `merge_group` path to `commits.yml` that validates conventional commit format by extracting the PR number from the merge queue ref and fetching the PR title via `gh pr view`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 9596e703d4cdf173ddf704eec3b13f34fc303611.</sup>
<!-- /MENDRAL_SUMMARY -->