### PR TITLE
ci: remove merge queue requirement for tests for now

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     paths-ignore:
       - "ui/**"
-  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -8,7 +8,6 @@ on:
   pull_request:
     paths-ignore:
       - "ui/**"
-  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Tests already run on CI, so waiting for them again is a little too much.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
