### PR TITLE
internal(release): pin release compare links to commit

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -3,42 +3,13 @@ name: PR Conventional Commit Validation
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
-  merge_group:
 
 jobs:
   validate-pr-title:
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
-        if: github.event_name == 'pull_request'
         uses: ytanikin/pr-conventional-commits@639145d78959c53c43112365837e3abd21ed67c1 # 1.5.2
         with:
           # Keep this list aligned with cliff.toml.
           task_types: '["feat","fix","doc","test","ci","refactor","perf","chore","revert","style","security","cloud","internal","noop"]'
-
-      - name: Merge Queue Conventional Commit Validation
-        if: github.event_name == 'merge_group'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
-        run: |
-          head_ref="${MERGE_GROUP_HEAD_REF:-${GITHUB_REF_NAME}}"
-          mapfile -t pr_numbers < <(printf '%s\n' "${head_ref}" | grep -Eo 'pr-[0-9]+' | sed 's/pr-//' | sort -u)
-
-          if [ "${#pr_numbers[@]}" -eq 0 ]; then
-            echo "::error title=Missing pull request number::Could not determine pull request number from merge queue ref: ${head_ref}"
-            exit 1
-          fi
-
-          allowed_types="feat|fix|doc|test|ci|refactor|perf|chore|revert|style|security|cloud|internal|noop"
-          title_regex="^(${allowed_types})(\([A-Za-z0-9._/-]+\))?!?: .+"
-
-          for pr_number in "${pr_numbers[@]}"; do
-            title="$(gh pr view "${pr_number}" --repo "${GITHUB_REPOSITORY}" --json title --jq '.title')"
-            echo "Validating PR #${pr_number}: ${title}"
-
-            if [[ ! "${title}" =~ ${title_regex} ]]; then
-              echo "::error title=Invalid conventional PR title::PR #${pr_number} title must use Conventional Commit format with an allowed type: ${title}"
-              exit 1
-            fi
-          done

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     paths-ignore:
       - "ui/**"
-  merge_group:
   # Release PRs are updated by GITHUB_TOKEN, which does not fan out normal
   # push/pull_request workflows. release-pr.yml dispatches this explicitly.
   workflow_dispatch:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -8,7 +8,6 @@ on:
   pull_request:
     paths-ignore:
       - "ui/**"
-  merge_group:
   # Release PRs are updated by GITHUB_TOKEN, which does not fan out normal
   # push/pull_request workflows. release-pr.yml dispatches this explicitly.
   workflow_dispatch:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -51,21 +51,26 @@ jobs:
         id: changes
         run: |
           latest_tag="$(git tag --list 'v*' --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)"
+          head_sha="$(git rev-parse HEAD)"
+          head_short_sha="$(git rev-parse --short HEAD)"
 
           if [ -n "${latest_tag}" ]; then
             ahead="$(git rev-list --count "${latest_tag}"..HEAD)"
             release_range="${latest_tag}..HEAD"
-            compare_url="${{ github.server_url }}/${{ github.repository }}/compare/${latest_tag}...${{ github.event.repository.default_branch }}"
+            compare_url="${{ github.server_url }}/${{ github.repository }}/compare/${latest_tag}...${head_sha}"
+            compare_label="${latest_tag}...${head_short_sha}"
           else
             ahead="$(git rev-list --count HEAD)"
             release_range="HEAD"
             compare_url=""
+            compare_label=""
           fi
 
           echo "latest_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
           echo "ahead=${ahead}" >> "$GITHUB_OUTPUT"
           echo "release_range=${release_range}" >> "$GITHUB_OUTPUT"
           echo "compare_url=${compare_url}" >> "$GITHUB_OUTPUT"
+          echo "compare_label=${compare_label}" >> "$GITHUB_OUTPUT"
 
           if [ "${ahead}" -eq 0 ]; then
             echo "No unreleased commits found"
@@ -168,6 +173,7 @@ jobs:
           scripts/release/render-release-pr-body \
             --tag "${{ steps.normalized-version.outputs.tag }}" \
             --compare-url "${{ steps.changes.outputs.compare_url }}" \
+            --compare-label "${{ steps.changes.outputs.compare_label }}" \
             --latest-tag "${{ steps.changes.outputs.latest_tag }}" \
             --base "${{ github.event.repository.default_branch }}" \
             --head "release/next" \

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -89,7 +89,8 @@ scripts/release/build-release-notes \
 
 scripts/release/render-release-pr-body \
   --tag v1.2.3 \
-  --compare-url "https://github.com/inngest/inngest/compare/v1.2.2...main" \
+  --compare-url "https://github.com/inngest/inngest/compare/v1.2.2...abc1234" \
+  --compare-label "v1.2.2...abc1234" \
   --latest-tag v1.2.2 \
   --preview /tmp/RELEASE_NOTES.md \
   --output /tmp/release-pr-body.md

--- a/tools/release-notes/parse.go
+++ b/tools/release-notes/parse.go
@@ -62,9 +62,13 @@ func parseHeading(line string) (string, bool) {
 	}
 }
 
-var htmlCommentPattern = regexp.MustCompile(`(?s)<!--.*?-->`)
+var (
+	htmlCommentPattern    = regexp.MustCompile(`(?s)<!--.*?-->`)
+	mendralSummaryPattern = regexp.MustCompile(`(?s)<!--\s*MENDRAL_SUMMARY\s*-->.*?<!--\s*/MENDRAL_SUMMARY\s*-->`)
+)
 
 func CleanMarkdownSection(value string) string {
+	value = mendralSummaryPattern.ReplaceAllString(value, "")
 	value = htmlCommentPattern.ReplaceAllString(value, "")
 	return NormalizeWhitespace(value)
 }

--- a/tools/release-notes/parse_test.go
+++ b/tools/release-notes/parse_test.go
@@ -118,3 +118,24 @@ func TestNormalizeNotePlaceholders(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePRBodyDropsMendralSummary(t *testing.T) {
+	body := `## Migration note
+
+None.
+
+<!-- MENDRAL_SUMMARY -->
+---
+
+> [!NOTE]
+> AI-generated summary.
+>
+> <sup>Written by [Mendral](https://mendral.com).</sup>
+<!-- /MENDRAL_SUMMARY -->
+`
+
+	sections := ParsePRBody(body)
+	if got := NormalizeNote(sections["migration note"]); got != "" {
+		t.Fatalf("migration note = %q, want empty", got)
+	}
+}

--- a/tools/release-notes/pr_body.go
+++ b/tools/release-notes/pr_body.go
@@ -17,6 +17,7 @@ func prBodyCommand() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "tag", Usage: "Release tag.", Required: true},
 			&cli.StringFlag{Name: "compare-url", Usage: "GitHub compare URL since previous release."},
+			&cli.StringFlag{Name: "compare-label", Usage: "Display label for the GitHub compare URL."},
 			&cli.StringFlag{Name: "base", Value: "main", Usage: "Base branch."},
 			&cli.StringFlag{Name: "head", Value: "release/next", Usage: "Release branch."},
 			&cli.StringFlag{Name: "latest-tag", Usage: "Previous release tag."},
@@ -29,6 +30,7 @@ func prBodyCommand() *cli.Command {
 			return prBodyCommandAction(
 				cmd.String("tag"),
 				cmd.String("compare-url"),
+				cmd.String("compare-label"),
 				cmd.String("base"),
 				cmd.String("head"),
 				cmd.String("latest-tag"),
@@ -40,7 +42,7 @@ func prBodyCommand() *cli.Command {
 	}
 }
 
-func prBodyCommandAction(tag, compareURL, base, head, latestTag, previewPath, existingBodyPath, outputPath string) error {
+func prBodyCommandAction(tag, compareURL, compareLabel, base, head, latestTag, previewPath, existingBodyPath, outputPath string) error {
 	if tag == "" {
 		return errors.New("--tag is required")
 	}
@@ -65,6 +67,7 @@ func prBodyCommandAction(tag, compareURL, base, head, latestTag, previewPath, ex
 	rendered, err := RenderReleasePRBody(ReleasePRBodyInput{
 		Tag:          tag,
 		CompareURL:   compareURL,
+		CompareLabel: compareLabel,
 		Base:         base,
 		Head:         head,
 		LatestTag:    latestTag,
@@ -85,6 +88,7 @@ func prBodyCommandAction(tag, compareURL, base, head, latestTag, previewPath, ex
 type ReleasePRBodyInput struct {
 	Tag          string
 	CompareURL   string
+	CompareLabel string
 	Base         string
 	Head         string
 	LatestTag    string
@@ -126,10 +130,11 @@ func RenderReleasePRBody(input ReleasePRBodyInput) (string, error) {
 	b.WriteString("## Release\n\n")
 	fmt.Fprintf(&b, "This PR prepares `%s`.\n\n", tag)
 	if input.CompareURL != "" {
-		compareLabel := strings.TrimSpace(input.LatestTag)
-		if compareLabel != "" {
-			compareLabel = fmt.Sprintf("%s...%s", compareLabel, base)
-		} else {
+		compareLabel := strings.TrimSpace(input.CompareLabel)
+		if compareLabel == "" && strings.TrimSpace(input.LatestTag) != "" {
+			compareLabel = fmt.Sprintf("%s...%s", strings.TrimSpace(input.LatestTag), base)
+		}
+		if compareLabel == "" {
 			compareLabel = "Compare changes"
 		}
 		fmt.Fprintf(&b, "- Code difference since last tag: [%s](%s)\n", compareLabel, input.CompareURL)

--- a/tools/release-notes/pr_body.go
+++ b/tools/release-notes/pr_body.go
@@ -117,13 +117,7 @@ func RenderReleasePRBody(input ReleasePRBodyInput) (string, error) {
 	}
 
 	manualRelease := NormalizeNote(ExtractMarkerBlock(input.ExistingBody, "release-note:manual-start", "release-note:manual-end"))
-	if manualRelease == "" {
-		manualRelease = "None."
-	}
 	manualMigration := NormalizeNote(ExtractMarkerBlock(input.ExistingBody, "migration-note:manual-start", "migration-note:manual-end"))
-	if manualMigration == "" {
-		manualMigration = "None."
-	}
 
 	var b strings.Builder
 	b.WriteString("<!-- auto-release-pr -->\n")
@@ -147,13 +141,19 @@ func RenderReleasePRBody(input ReleasePRBodyInput) (string, error) {
 
 	b.WriteString("## Additional Release Notes\n")
 	b.WriteString("<!-- release-note:manual-start -->\n")
-	b.WriteString(manualRelease)
-	b.WriteString("\n<!-- release-note:manual-end -->\n\n")
+	if manualRelease != "" {
+		b.WriteString(manualRelease)
+		b.WriteString("\n")
+	}
+	b.WriteString("<!-- release-note:manual-end -->\n\n")
 
 	b.WriteString("## Additional Migration Notes\n")
 	b.WriteString("<!-- migration-note:manual-start -->\n")
-	b.WriteString(manualMigration)
-	b.WriteString("\n<!-- migration-note:manual-end -->\n\n")
+	if manualMigration != "" {
+		b.WriteString(manualMigration)
+		b.WriteString("\n")
+	}
+	b.WriteString("<!-- migration-note:manual-end -->\n\n")
 
 	b.WriteString("## Notes Preview\n")
 	b.WriteString("<!-- release-note:preview-start -->\n")

--- a/tools/release-notes/pr_body_test.go
+++ b/tools/release-notes/pr_body_test.go
@@ -55,7 +55,7 @@ Old preview.
 	}
 }
 
-func TestRenderReleasePRBodyDefaultsManualBlocks(t *testing.T) {
+func TestRenderReleasePRBodyRendersEmptyEditableManualBlocks(t *testing.T) {
 	got, err := RenderReleasePRBody(ReleasePRBodyInput{
 		Tag:     "v1.2.3",
 		Preview: "## Changelog\n\n- Entry",
@@ -64,10 +64,38 @@ func TestRenderReleasePRBodyDefaultsManualBlocks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assertContains(t, got, "<!-- release-note:manual-start -->\nNone.\n<!-- release-note:manual-end -->")
-	assertContains(t, got, "<!-- migration-note:manual-start -->\nNone.\n<!-- migration-note:manual-end -->")
+	assertContains(t, got, "## Additional Release Notes")
+	assertContains(t, got, "<!-- release-note:manual-start -->\n<!-- release-note:manual-end -->")
+	assertContains(t, got, "## Additional Migration Notes")
+	assertContains(t, got, "<!-- migration-note:manual-start -->\n<!-- migration-note:manual-end -->")
+	assertNotContains(t, got, "None.")
+	assertNotContains(t, got, "N/A")
 	assertContains(t, got, "- Source branch: `release/next`")
 	assertContains(t, got, "- Base branch: `main`")
+}
+
+func TestRenderReleasePRBodyOmitsPlaceholderManualText(t *testing.T) {
+	got, err := RenderReleasePRBody(ReleasePRBodyInput{
+		Tag: "v1.2.3",
+		ExistingBody: `## Additional Release Notes
+<!-- release-note:manual-start -->
+None.
+<!-- release-note:manual-end -->
+
+## Additional Migration Notes
+<!-- migration-note:manual-start -->
+N/A
+<!-- migration-note:manual-end -->`,
+		Preview: "## Changelog\n\n- Entry",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertContains(t, got, "## Additional Release Notes")
+	assertContains(t, got, "## Additional Migration Notes")
+	assertNotContains(t, got, "None.")
+	assertNotContains(t, got, "N/A")
 }
 
 func TestPRBodyCommandWritesOutput(t *testing.T) {

--- a/tools/release-notes/pr_body_test.go
+++ b/tools/release-notes/pr_body_test.go
@@ -31,7 +31,8 @@ Old preview.
 
 	got, err := RenderReleasePRBody(ReleasePRBodyInput{
 		Tag:          "v1.2.3",
-		CompareURL:   "https://github.com/inngest/inngest/compare/v1.2.2...main",
+		CompareURL:   "https://github.com/inngest/inngest/compare/v1.2.2...abc1234",
+		CompareLabel: "v1.2.2...abc1234",
 		Base:         "main",
 		Head:         "release/next",
 		LatestTag:    "v1.2.2",
@@ -43,7 +44,7 @@ Old preview.
 	}
 
 	assertContains(t, got, "This PR prepares `v1.2.3`.")
-	assertContains(t, got, "- Code difference since last tag: [v1.2.2...main](https://github.com/inngest/inngest/compare/v1.2.2...main)")
+	assertContains(t, got, "- Code difference since last tag: [v1.2.2...abc1234](https://github.com/inngest/inngest/compare/v1.2.2...abc1234)")
 	assertContains(t, got, "- Previous tag: `v1.2.2`")
 	assertContains(t, got, "Keep this release context.")
 	assertContains(t, got, "Keep this migration context.")
@@ -87,7 +88,8 @@ Manual context.
 	err := run([]string{
 		"pr-body",
 		"--tag", "v1.2.3",
-		"--compare-url", "https://github.com/inngest/inngest/compare/v1.2.2...main",
+		"--compare-url", "https://github.com/inngest/inngest/compare/v1.2.2...abc1234",
+		"--compare-label", "v1.2.2...abc1234",
 		"--preview", previewPath,
 		"--existing-body", existingPath,
 		"--output", outputPath,

--- a/tools/release-notes/test_helpers_test.go
+++ b/tools/release-notes/test_helpers_test.go
@@ -11,3 +11,10 @@ func assertContains(t *testing.T, haystack, needle string) {
 		t.Fatalf("expected output to contain %q:\n%s", needle, haystack)
 	}
 }
+
+func assertNotContains(t *testing.T, haystack, needle string) {
+	t.Helper()
+	if strings.Contains(haystack, needle) {
+		t.Fatalf("expected output not to contain %q:\n%s", needle, haystack)
+	}
+}


### PR DESCRIPTION
## Description

Update release notes with diffs from last tag to HEAD at point in time.

Also make sure notes that are empty not being posted onto the release body.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR updates the release automation in two ways: (1) pins the "compare since last tag" link in release PRs to the exact HEAD commit SHA at workflow run time (rather than the mutable default branch ref), and (2) strips AI-generated Mendral summary blocks from PR body sections before including them in release notes. It also removes merge queue support from CI workflows.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e67a4b537408a1def2973833af09972c4fb35e22.</sup>
<!-- /MENDRAL_SUMMARY -->