### PR TITLE
internal: use release token for release PRs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     paths-ignore:
       - "ui/**"
-  # Release PRs are updated by GITHUB_TOKEN, which does not fan out normal
-  # push/pull_request workflows. release-pr.yml dispatches this explicitly.
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,9 +10,6 @@ on:
   pull_request:
     paths-ignore:
       - "ui/**"
-  # Release PRs are updated by GITHUB_TOKEN, which does not fan out normal
-  # push/pull_request workflows. release-pr.yml dispatches this explicitly.
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,10 +13,12 @@ on:
   workflow_dispatch:
 
 permissions:
-  # Required for dispatching CI workflows after updating release/next.
-  actions: write
   contents: write
   pull-requests: write
+
+env:
+  # Use the release bot token so release/next pushes trigger normal CI fanout.
+  GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
 concurrency:
   group: release-pr-main
@@ -26,10 +28,18 @@ jobs:
   create-release-pr:
     runs-on: depot-ubuntu-22.04-4
     steps:
+      - name: Validate release token
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error title=Missing RELEASE_TOKEN::Configure the release bot token as the RELEASE_TOKEN repository secret."
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ env.GH_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -129,8 +139,6 @@ jobs:
 
       - name: Collect PR release notes
         if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           scripts/release/collect-pr-notes \
             --range "${{ steps.changes.outputs.release_range }}" \
@@ -149,8 +157,6 @@ jobs:
       - name: Find existing release PR
         if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false'
         id: existing-pr
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           pr_number="$(gh pr list \
             --base "${{ github.event.repository.default_branch }}" \
@@ -204,7 +210,6 @@ jobs:
       - name: Create release PR
         if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false' && steps.existing-pr.outputs.pr_number == ''
         env:
-          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.normalized-version.outputs.tag }}
         run: |
           gh pr create \
@@ -216,7 +221,6 @@ jobs:
       - name: Update existing release PR
         if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false' && steps.existing-pr.outputs.pr_number != ''
         env:
-          GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.normalized-version.outputs.tag }}
         run: |
           gh pr edit "${{ steps.existing-pr.outputs.pr_number }}" \

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -6,9 +6,6 @@ on:
   pull_request:
     paths-ignore:
       - "ui/**"
-  # Release PRs are updated by GITHUB_TOKEN, which does not fan out normal
-  # pull_request workflows. release-pr.yml dispatches this explicitly.
-  workflow_dispatch:
   schedule:
     - cron: "0 0 * * 0"
 


### PR DESCRIPTION
## Description

Change to use inngest release bot to handle release PRs instead so CI gets triggered properly

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Switches the release-pr workflow to use a dedicated bot token (`RELEASE_TOKEN`) instead of `GITHUB_TOKEN` when creating/updating release PRs, so that pushes to `release/next` trigger normal CI fanout. Removes the `workflow_dispatch` workaround from `e2e.yml`, `go.yaml`, and `security.yaml` now that it's no longer needed. Adds a token validation step and removes the `actions: write` permission that was previously required for the dispatch approach.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 643196933375aa2959b081c0a02e4909a58b8b67.</sup>
<!-- /MENDRAL_SUMMARY -->