### PR TITLE
ci: add "docs" to allowed list

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -12,4 +12,4 @@ jobs:
         uses: ytanikin/pr-conventional-commits@639145d78959c53c43112365837e3abd21ed67c1 # 1.5.2
         with:
           # Keep this list aligned with cliff.toml.
-          task_types: '["feat","fix","doc","test","ci","refactor","perf","chore","revert","style","security","cloud","internal","noop"]'
+          task_types: '["feat","fix","doc","docs","test","ci","refactor","perf","chore","revert","style","security","cloud","internal","noop"]'


### PR DESCRIPTION
## Description

"docs" (plural) follows a more typical usage of conventional commits instead of "doc" (singular).

Sources that all use "docs":
- https://www.conventionalcommits.org/en/v1.0.0/
- https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/src/index.ts
- https://mcpmarket.com/tools/skills/conventional-commits-specialist
- https://www.bavaga.com/blog/2025/01/27/my-ultimate-conventional-commit-types-cheatsheet/

Note - the regex is still `^doc` so it can support singular as well.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds `"docs"` to the allowed conventional commit types list in `.github/workflows/commits.yml`, alongside the existing `"doc"`, to align with the standard conventional commits specification which uses the plural form.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit e175968338e48bd94f6536e24dd5bea0f4de7ee7.</sup>
<!-- /MENDRAL_SUMMARY -->