### PR TITLE
fix: Opcode Gateway -> StepTypeFetch

### DIFF
--- a/pkg/execution/state/opcode.go
+++ b/pkg/execution/state/opcode.go
@@ -230,6 +230,8 @@ func (g GeneratorOpcode) StepType() enums.StepType {
 		return enums.StepTypeWaitForSignal
 	case enums.OpcodeInvokeFunction:
 		return enums.StepTypeInvoke
+	case enums.OpcodeGateway:
+		return enums.StepTypeFetch
 	case enums.OpcodeAIGateway:
 		return enums.StepTypeAiInfer
 	default:

--- a/pkg/execution/state/opcode_test.go
+++ b/pkg/execution/state/opcode_test.go
@@ -59,6 +59,7 @@ func TestGeneratorOpcode_StepType(t *testing.T) {
 			{enums.OpcodeWaitForEvent, enums.StepTypeWaitForEvent},
 			{enums.OpcodeWaitForSignal, enums.StepTypeWaitForSignal},
 			{enums.OpcodeInvokeFunction, enums.StepTypeInvoke},
+			{enums.OpcodeGateway, enums.StepTypeFetch},
 			{enums.OpcodeAIGateway, enums.StepTypeAiInfer},
 		}
 		for _, tc := range cases {


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This fixes a missing case in the population of the `_inngest.step.type` attribute for the Gateway opcode

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds the missing `OpcodeGateway → StepTypeFetch` case to the `StepType()` switch in `opcode.go`, preventing the gateway opcode from falling through to the default (`StepTypeNoop`) and incorrectly setting the `_inngest.step.type` attribute. A corresponding table-driven test case is added.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7fd0252e89fbb221fbc04cc6226a1b546833be92.</sup>
<!-- /MENDRAL_SUMMARY -->