### PR TITLE
fix(connect): case where connect worker abruptly dies & request hangs

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -1313,6 +1313,10 @@ func (c *connectionHandler) receiveRouterMessagesFromGRPC(ctx context.Context, o
 				select {
 				case <-ackCh:
 					msg.Result <- nil
+				case <-c.stopForwarding:
+					c.pendingAcks.Delete(data.RequestId)
+					msg.Result <- fmt.Errorf("connection closed before worker ACK for request %s", data.RequestId)
+					log.Warn("connection closed before worker ACK, re-routing", "req_id", data.RequestId)
 				case <-time.After(consts.ConnectWorkerRequestLeaseDuration + consts.ConnectWorkerRequestGracePeriod):
 					c.pendingAcks.Delete(data.RequestId)
 					msg.Result <- fmt.Errorf("worker did not ACK request %s", data.RequestId)

--- a/pkg/connect/gateway_test.go
+++ b/pkg/connect/gateway_test.go
@@ -409,6 +409,54 @@ func TestExecutorMessageForwardingGRPC(t *testing.T) {
 	require.True(t, proto.Equal(expectedPayload, payload))
 }
 
+func TestExecutorMessageForwardingGRPC_StopForwardingBeforeWorkerACK(t *testing.T) {
+	params := testingParameters{
+		consecutiveMissesBeforeClose: 10,
+		heartbeatInterval:            1 * time.Second,
+		shouldUseGRPC:                true,
+	}
+	res := createTestingGateway(t, params)
+	handshake(t, res)
+
+	payload := &connect.GatewayExecutorRequestData{
+		RequestId:      "test-req-stop",
+		AccountId:      res.accountID.String(),
+		EnvId:          res.envID.String(),
+		AppId:          res.appID.String(),
+		AppName:        res.appName,
+		FunctionId:     res.fnID.String(),
+		FunctionSlug:   res.fnSlug,
+		StepId:         ptr.String("step"),
+		RequestPayload: []byte("hello world"),
+		RunId:          res.runID.String(),
+		LeaseId:        "lease-test",
+	}
+
+	handler, ok := res.svc.wsConnections.Load(res.connID.String())
+	require.True(t, ok)
+	ch := handler.(*connectionHandler)
+
+	resultCh := make(chan error, 1)
+	go func() {
+		ch.messageChan <- forwardMessage{Data: payload, Result: resultCh}
+	}()
+
+	// Wait for the WS message to be forwarded to the worker, then close the connection.
+	awaitNextMessage(t, res.ws, 2*time.Second)
+
+	close(ch.stopForwarding)
+
+	select {
+	case err := <-resultCh:
+		require.ErrorContains(t, err, "connection closed before worker ACK")
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Result after stopForwarding")
+	}
+
+	_, stillPresent := ch.pendingAcks.Load(payload.RequestId)
+	require.False(t, stillPresent, "pendingAcks should be cleaned up after stopForwarding")
+}
+
 func TestCloseConnectionOnConsecutiveHeartbeatFail(t *testing.T) {
 	params := testingParameters{
 		consecutiveMissesBeforeClose: 5,


### PR DESCRIPTION
## Description

When a worker exists closing the websocket connection abruptly,
forwarded requests that did not receive an ACK should not be keep
waiting for the lease timeout to happen to return to executor. Instead
it should return asap to get rerouted to a different worker.


<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
Fixes "Worker stopped responding" Connect error that happens on abrupb websocket disconnects.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a `stopForwarding` channel case to the ACK-wait select in `receiveRouterMessagesFromGRPC` so that in-flight requests fail fast (instead of waiting for the full lease timeout) when a worker disconnects abruptly. Includes a new test exercising this path.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d196a290805895c1ab8231dea2309bf630660b10.</sup>
<!-- /MENDRAL_SUMMARY -->