### PR TITLE
internal: enable PR write

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   validate-pr-title:


### PR DESCRIPTION
## Description

allow PR update permissions

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Changes `pull-requests` permission in `.github/workflows/commits.yml` from `read` to `write`, enabling the `ytanikin/pr-conventional-commits` action to add labels to PRs (`add_label: true` is configured).
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3bd9eb3d531986292fc36e17744e5f7ad71eb55c.</sup>
<!-- /MENDRAL_SUMMARY -->