### PR TITLE
feat: Add update notifier to select commands

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/inngest/inngest/cmd/devserver"
@@ -11,9 +12,21 @@ import (
 	"github.com/inngest/inngest/pkg/api/tel"
 	inncli "github.com/inngest/inngest/pkg/cli"
 	inngestversion "github.com/inngest/inngest/pkg/inngest/version"
+	"github.com/inngest/inngest/pkg/update"
 	isatty "github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v3"
 )
+
+func init() {
+	// Wrap urfave/cli's default help printer so help output is followed by an
+	// update notice (when applicable). Covers `inngest help`, bare `inngest`,
+	// and `inngest <subcmd> --help`.
+	defaultHelp := cli.HelpPrinter
+	cli.HelpPrinter = func(w io.Writer, templ string, data interface{}) {
+		defaultHelp(w, templ, data)
+		update.Notify(os.Stderr, inngestversion.Version)
+	}
+}
 
 // globalFlags are the flags that should be available on all commands
 var globalFlags = []cli.Flag{
@@ -64,6 +77,12 @@ func execute() {
 			m := tel.NewMetadata(ctx)
 			m.SetCliContext(cmd)
 			tel.SendMetadata(ctx, m)
+
+			// Best-effort background refresh of the cached "latest version"
+			// record. Dedup'd by the cache TTL, so cheap on every invocation.
+			// Check honors the same opt-out gates as Notify.
+			go update.Check(context.Background(), inngestversion.Version)
+
 			return ctx, nil
 		},
 		After: func(ctx context.Context, cmd *cli.Command) error {

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -3,8 +3,10 @@ package version
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/inngest/inngest/pkg/inngest/version"
+	"github.com/inngest/inngest/pkg/update"
 	"github.com/urfave/cli/v3"
 )
 
@@ -17,6 +19,9 @@ func Command() *cli.Command {
 		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			fmt.Println(version.Print())
+			// Notice on stderr so stdout (the version string) stays clean
+			// for `inngest version | xargs ...` style usage.
+			update.Notify(os.Stderr, version.Version)
 			return nil
 		},
 	}

--- a/pkg/cli/output/text.go
+++ b/pkg/cli/output/text.go
@@ -22,7 +22,7 @@ func valueToStringImpl(value any, jsonFallback bool, indent int) string {
 	// Check for nil interfaces and pointers before type switching
 	rv := reflect.ValueOf(value)
 	switch rv.Kind() {
-	case reflect.Interface, reflect.Ptr:
+	case reflect.Interface, reflect.Pointer:
 		if rv.IsNil() {
 			return nilString
 		}

--- a/pkg/cli/styles.go
+++ b/pkg/cli/styles.go
@@ -18,6 +18,11 @@ var (
 	FeintStyle   = TextStyle.Copy().Foreground(Feint)
 	BoldStyle    = TextStyle.Copy().Bold(true)
 	WarningStyle = TextStyle.Copy().Foreground(Orange)
+
+	UpdateNoticeStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(Orange).
+				Padding(0, 1)
 )
 
 // RenderError returns a formatted error string.

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -179,7 +178,7 @@ func handlePingError(err error) error {
 func GetDeployError(resp *http.Response) error {
 	if resp.StatusCode == http.StatusBadRequest {
 		// 400s usually contain SDK error messages that we want to pass through
-		byt, _ := ioutil.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
+		byt, _ := io.ReadAll(io.LimitReader(resp.Body, 10*1024*1024))
 		type result struct {
 			Message string `json:"message"`
 		}

--- a/pkg/devserver/service.go
+++ b/pkg/devserver/service.go
@@ -30,10 +30,12 @@ import (
 	"github.com/inngest/inngest/pkg/execution/runner"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/inngest"
+	inngestversion "github.com/inngest/inngest/pkg/inngest/version"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/pubsub"
 	"github.com/inngest/inngest/pkg/sdk"
 	"github.com/inngest/inngest/pkg/service"
+	"github.com/inngest/inngest/pkg/update"
 	"github.com/inngest/inngest/pkg/util"
 	itrace "github.com/inngest/inngest/pkg/telemetry/trace"
 	"github.com/mattn/go-isatty"
@@ -222,6 +224,8 @@ func (d *devserver) Run(ctx context.Context) error {
 					fmt.Println(cli.WarningStyle.Render("\tWARNING: No event keys provided. Events will not be accepted.\n\t\t Add event keys with a flag, environment variable, or config file.\n"))
 				}
 			}
+
+			update.Notify(os.Stderr, inngestversion.Version)
 		}()
 	}
 

--- a/pkg/expressions/unknown.go
+++ b/pkg/expressions/unknown.go
@@ -239,7 +239,7 @@ func maybeWrapLogicalOp(i interpreter.Interpretable, act interpreter.PartialActi
 	//       terms []interpreter.Interpretable
 	//   }
 	v := reflect.ValueOf(i)
-	if v.Kind() == reflect.Ptr {
+	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
 	termsField := v.FieldByName("terms")

--- a/pkg/inngest/client/gql.go
+++ b/pkg/inngest/client/gql.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -33,7 +32,7 @@ func (c httpClient) DoGQL(ctx context.Context, input Params) (*Response, error) 
 
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("invalid status code %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/pkg/inngest/clistate/clistate.go
+++ b/pkg/inngest/clistate/clistate.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 
 	"github.com/google/uuid"
@@ -106,7 +105,7 @@ func (s State) Persist(ctx context.Context) error {
 		return fmt.Errorf("error reading ~/.config/inngest")
 	}
 
-	return ioutil.WriteFile(path, byt, 0600)
+	return os.WriteFile(path, byt, 0600)
 }
 
 // Client returns an API client, attempting to use authentication from

--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -1,0 +1,176 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mitchellh/go-homedir"
+	"golang.org/x/mod/semver"
+)
+
+const (
+	releasesURL  = "https://api.github.com/repos/inngest/inngest/releases/latest"
+	cacheTTL     = 24 * time.Hour
+	checkTimeout = 3 * time.Second
+)
+
+type cacheFile struct {
+	CheckedAt     time.Time `json:"checked_at"`
+	LatestVersion string    `json:"latest_version"`
+	LatestURL     string    `json:"latest_url"`
+}
+
+var (
+	cacheMu      sync.Mutex
+	httpClient   = &http.Client{Timeout: checkTimeout}
+	cachePathFn  = defaultCachePath
+	releasesAddr = releasesURL
+)
+
+// Check refreshes the cached "latest version" record if the cache is stale.
+// Network and I/O errors are swallowed silently — this is a best-effort
+// background helper. Safe to call from a goroutine.
+//
+// Honors the same opt-out gates as Notify (env vars, TTY, dev builds) so
+// disabling the notifier also suppresses the background network request.
+func Check(ctx context.Context, currentVersion string) {
+	if disabled(currentVersion) {
+		return
+	}
+	if !shouldFetch() {
+		return
+	}
+	latest, url, err := fetchLatest(ctx)
+	if err != nil || latest == "" {
+		return
+	}
+	_ = writeCache(cacheFile{
+		CheckedAt:     time.Now().UTC(),
+		LatestVersion: latest,
+		LatestURL:     url,
+	})
+}
+
+// Latest returns the most recently cached "latest version" tuple, or empty
+// strings if no fresh-enough cache exists.
+func Latest() (version, url string) {
+	c, err := readCache()
+	if err != nil {
+		return "", ""
+	}
+	return c.LatestVersion, c.LatestURL
+}
+
+func shouldFetch() bool {
+	c, err := readCache()
+	if err != nil {
+		return true
+	}
+	return time.Since(c.CheckedAt) > cacheTTL
+}
+
+func fetchLatest(ctx context.Context) (string, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releasesAddr, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "inngest-cli")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("releases: status %d", resp.StatusCode)
+	}
+	var body struct {
+		TagName string `json:"tag_name"`
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err != nil {
+		return "", "", err
+	}
+	return strings.TrimPrefix(body.TagName, "v"), body.HTMLURL, nil
+}
+
+func defaultCachePath() (string, error) {
+	dir, err := homedir.Expand("~/.config/inngest")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "update-check.json"), nil
+}
+
+func readCache() (cacheFile, error) {
+	var c cacheFile
+	p, err := cachePathFn()
+	if err != nil {
+		return c, err
+	}
+	byt, err := os.ReadFile(p)
+	if errors.Is(err, fs.ErrNotExist) {
+		return c, err
+	}
+	if err != nil {
+		return c, err
+	}
+	if err := json.Unmarshal(byt, &c); err != nil {
+		return c, err
+	}
+	return c, nil
+}
+
+func writeCache(c cacheFile) error {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+
+	p, err := cachePathFn()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	byt, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, byt, 0o600)
+}
+
+// IsNewer reports whether `latest` is strictly newer than `current`.
+// Accepts versions with or without a leading "v". Empty strings, "dev", or
+// unparseable inputs return false.
+func IsNewer(current, latest string) bool {
+	cv := normalizeSemver(current)
+	lv := normalizeSemver(latest)
+	if cv == "" || lv == "" {
+		return false
+	}
+	return semver.Compare(lv, cv) > 0
+}
+
+func normalizeSemver(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" || v == "dev" {
+		return ""
+	}
+	if !strings.HasPrefix(v, "v") {
+		v = "v" + v
+	}
+	if semver.IsValid(v) {
+		return semver.Canonical(v)
+	}
+	return ""
+}

--- a/pkg/update/check_test.go
+++ b/pkg/update/check_test.go
@@ -1,0 +1,285 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func withTempCache(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "update-check.json")
+	old := cachePathFn
+	cachePathFn = func() (string, error) { return path, nil }
+	t.Cleanup(func() { cachePathFn = old })
+	return path
+}
+
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		current, latest string
+		want            bool
+	}{
+		{"0.35.0", "0.36.0", true},
+		{"0.35.0", "0.35.1", true},
+		{"v0.35.0", "0.36.0", true},
+		{"0.35.0", "v0.35.0", false},
+		{"0.36.0", "0.35.0", false},
+		{"dev", "0.36.0", false},
+		{"", "0.36.0", false},
+		{"0.35.0", "", false},
+		{"not-a-version", "0.36.0", false},
+		{"0.35.0", "0.36.0-rc.1", true},
+		{"0.35.0-rc.1", "0.35.0", true},
+	}
+	for _, tc := range cases {
+		if got := IsNewer(tc.current, tc.latest); got != tc.want {
+			t.Errorf("IsNewer(%q,%q) = %v, want %v", tc.current, tc.latest, got, tc.want)
+		}
+	}
+}
+
+func TestCacheRoundTrip(t *testing.T) {
+	withTempCache(t)
+
+	if _, _, _ = "x", "x", 0; true {
+		// Empty cache — Latest returns empty.
+		if v, u := Latest(); v != "" || u != "" {
+			t.Fatalf("Latest() on empty cache = (%q,%q), want empty", v, u)
+		}
+	}
+
+	want := cacheFile{
+		CheckedAt:     time.Now().UTC().Truncate(time.Second),
+		LatestVersion: "0.36.0",
+		LatestURL:     "https://example.test/v0.36.0",
+	}
+	if err := writeCache(want); err != nil {
+		t.Fatalf("writeCache: %v", err)
+	}
+	got, err := readCache()
+	if err != nil {
+		t.Fatalf("readCache: %v", err)
+	}
+	if !got.CheckedAt.Equal(want.CheckedAt) || got.LatestVersion != want.LatestVersion || got.LatestURL != want.LatestURL {
+		t.Errorf("round-trip mismatch: got %+v want %+v", got, want)
+	}
+	if v, u := Latest(); v != want.LatestVersion || u != want.LatestURL {
+		t.Errorf("Latest() = (%q,%q), want (%q,%q)", v, u, want.LatestVersion, want.LatestURL)
+	}
+}
+
+func TestShouldFetch(t *testing.T) {
+	withTempCache(t)
+
+	// No file — should fetch.
+	if !shouldFetch() {
+		t.Error("shouldFetch with no cache = false, want true")
+	}
+
+	// Fresh cache — should NOT fetch.
+	if err := writeCache(cacheFile{CheckedAt: time.Now().UTC(), LatestVersion: "0.36.0"}); err != nil {
+		t.Fatal(err)
+	}
+	if shouldFetch() {
+		t.Error("shouldFetch with fresh cache = true, want false")
+	}
+
+	// Stale cache — should fetch.
+	if err := writeCache(cacheFile{CheckedAt: time.Now().Add(-2 * cacheTTL).UTC(), LatestVersion: "0.36.0"}); err != nil {
+		t.Fatal(err)
+	}
+	if !shouldFetch() {
+		t.Error("shouldFetch with stale cache = false, want true")
+	}
+}
+
+func TestCheckFetchesAndCaches(t *testing.T) {
+	withTempCache(t)
+	// Force the env-var gate off so the test doesn't depend on host env.
+	for _, k := range []string{"INNGEST_NO_UPDATE_NOTIFIER", "NO_UPDATE_NOTIFIER", "DO_NOT_TRACK", "CI"} {
+		t.Setenv(k, "")
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"tag_name": "v0.36.0",
+			"html_url": "https://example.test/releases/v0.36.0",
+		})
+	}))
+	defer srv.Close()
+
+	oldAddr := releasesAddr
+	releasesAddr = srv.URL
+	t.Cleanup(func() { releasesAddr = oldAddr })
+
+	// Bypass the TTY gate inside disabled() — the fetch logic itself does
+	// not require a TTY, only the shared opt-out helper does. We test that
+	// helper separately; here we exercise the network path by calling the
+	// internals directly.
+	if !shouldFetch() {
+		t.Fatal("shouldFetch returned false with empty cache")
+	}
+	latest, url, err := fetchLatest(context.Background())
+	if err != nil {
+		t.Fatalf("fetchLatest: %v", err)
+	}
+	if err := writeCache(cacheFile{CheckedAt: time.Now().UTC(), LatestVersion: latest, LatestURL: url}); err != nil {
+		t.Fatal(err)
+	}
+
+	v, u := Latest()
+	if v != "0.36.0" {
+		t.Errorf("Latest version = %q, want %q", v, "0.36.0")
+	}
+	if u != "https://example.test/releases/v0.36.0" {
+		t.Errorf("Latest url = %q", u)
+	}
+}
+
+func TestCheckSilentOnHTTPError(t *testing.T) {
+	withTempCache(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	oldAddr := releasesAddr
+	releasesAddr = srv.URL
+	t.Cleanup(func() { releasesAddr = oldAddr })
+
+	// Even calling the fetch directly, an HTTP error must not write cache.
+	if _, _, err := fetchLatest(context.Background()); err == nil {
+		t.Fatal("fetchLatest succeeded on 500, want error")
+	}
+	if v, _ := Latest(); v != "" {
+		t.Errorf("Latest() = %q after failed fetch, want empty", v)
+	}
+}
+
+func TestCheckSkipsWhenDisabled(t *testing.T) {
+	withTempCache(t)
+
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": "v0.36.0"})
+	}))
+	defer srv.Close()
+
+	oldAddr := releasesAddr
+	releasesAddr = srv.URL
+	t.Cleanup(func() { releasesAddr = oldAddr })
+
+	for _, tc := range []struct {
+		name           string
+		envKey, envVal string
+		currentVer     string
+	}{
+		{name: "INNGEST_NO_UPDATE_NOTIFIER", envKey: "INNGEST_NO_UPDATE_NOTIFIER", envVal: "1", currentVer: "0.35.0"},
+		{name: "NO_UPDATE_NOTIFIER", envKey: "NO_UPDATE_NOTIFIER", envVal: "1", currentVer: "0.35.0"},
+		{name: "DO_NOT_TRACK", envKey: "DO_NOT_TRACK", envVal: "1", currentVer: "0.35.0"},
+		{name: "CI", envKey: "CI", envVal: "true", currentVer: "0.35.0"},
+		{name: "dev build", currentVer: "dev"},
+		{name: "empty version", currentVer: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.envKey != "" {
+				t.Setenv(tc.envKey, tc.envVal)
+			}
+			before := hits
+			Check(context.Background(), tc.currentVer)
+			if hits != before {
+				t.Errorf("Check made %d new HTTP request(s) with %s set; expected 0", hits-before, tc.name)
+			}
+		})
+	}
+}
+
+func TestNotifySkipsWithoutCache(t *testing.T) {
+	withTempCache(t)
+	t.Setenv("INNGEST_NO_UPDATE_NOTIFIER", "")
+	t.Setenv("NO_UPDATE_NOTIFIER", "")
+
+	// Even if all gates pass, no cache means no output.
+	var buf testWriter
+	Notify(&buf, "0.35.0")
+	if buf.n > 0 {
+		t.Errorf("Notify wrote %d bytes with no cache, want 0", buf.n)
+	}
+}
+
+func TestNotifySkipsForDevBuild(t *testing.T) {
+	withTempCache(t)
+	if err := writeCache(cacheFile{CheckedAt: time.Now().UTC(), LatestVersion: "99.0.0"}); err != nil {
+		t.Fatal(err)
+	}
+	var buf testWriter
+	Notify(&buf, "dev")
+	if buf.n > 0 {
+		t.Errorf("Notify wrote %d bytes for dev build, want 0", buf.n)
+	}
+}
+
+func TestNotifyRespectsOptOut(t *testing.T) {
+	withTempCache(t)
+	if err := writeCache(cacheFile{CheckedAt: time.Now().UTC(), LatestVersion: "99.0.0"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"INNGEST_NO_UPDATE_NOTIFIER", "NO_UPDATE_NOTIFIER", "DO_NOT_TRACK", "CI"} {
+		t.Run(k, func(t *testing.T) {
+			t.Setenv(k, "1")
+			var buf testWriter
+			Notify(&buf, "0.35.0")
+			if buf.n > 0 {
+				t.Errorf("Notify wrote %d bytes with %s set, want 0", buf.n, k)
+			}
+		})
+	}
+}
+
+func TestEnabledFor(t *testing.T) {
+	cases := map[string]bool{
+		"dev":     true,
+		"help":    true,
+		"version": true,
+		"":        true,
+		"start":   false,
+		"doctor":  false,
+		"alpha":   false,
+		"random":  false,
+	}
+	for name, want := range cases {
+		if got := EnabledFor(name); got != want {
+			t.Errorf("EnabledFor(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestDefaultCachePathLocation(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	p, err := defaultCachePath()
+	if err != nil {
+		t.Fatalf("defaultCachePath: %v", err)
+	}
+	// On any platform the path should be under the configured home dir.
+	if !filepath.IsAbs(p) {
+		t.Errorf("defaultCachePath returned non-absolute path: %q", p)
+	}
+	_ = os.Setenv // silence import if unused on a platform
+}
+
+// testWriter is a minimal io.Writer that only tracks total bytes written.
+type testWriter struct{ n int }
+
+func (w *testWriter) Write(p []byte) (int, error) {
+	w.n += len(p)
+	return len(p), nil
+}

--- a/pkg/update/detect.go
+++ b/pkg/update/detect.go
@@ -79,4 +79,5 @@ func UpgradeCommand(m Method) string {
 	default:
 		return "curl -fsSL https://cli.inngest.com/install.sh | sh"
 	}
+	return "curl -fsSL https://cli.inngest.com/install.sh | sh"
 }

--- a/pkg/update/detect.go
+++ b/pkg/update/detect.go
@@ -1,0 +1,82 @@
+package update
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Method identifies how the running CLI was installed.
+type Method string
+
+const (
+	MethodNPM      Method = "npm"
+	MethodHomebrew Method = "homebrew"
+	MethodBash     Method = "bash"
+	MethodBinary   Method = "binary"
+)
+
+// EnvInstallMethod lets installers declare the channel explicitly,
+// bypassing path-based heuristics. Homebrew formula and install.sh set this.
+const EnvInstallMethod = "INNGEST_INSTALL_METHOD"
+
+// Detect returns the install method, preferring the env override and
+// falling back to a path heuristic on os.Executable().
+func Detect() Method {
+	if m := normalize(os.Getenv(EnvInstallMethod)); m != "" {
+		return m
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return MethodBinary
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return classifyPath(exe)
+}
+
+func normalize(v string) Method {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "npm", "npx":
+		return MethodNPM
+	case "homebrew", "brew":
+		return MethodHomebrew
+	case "bash", "sh", "install.sh", "curl":
+		return MethodBash
+	case "binary":
+		return MethodBinary
+	}
+	return ""
+}
+
+func classifyPath(p string) Method {
+	p = filepath.ToSlash(p)
+	switch {
+	case strings.Contains(p, "/node_modules/"),
+		strings.Contains(p, "/_npx/"):
+		return MethodNPM
+	case strings.Contains(p, "/Cellar/"),
+		strings.HasPrefix(p, "/opt/homebrew/"),
+		strings.HasPrefix(p, "/home/linuxbrew/"):
+		return MethodHomebrew
+	case p == "/usr/local/bin/inngest", p == "/usr/bin/inngest":
+		return MethodBash
+	}
+	return MethodBinary
+}
+
+// UpgradeCommand returns the recommended upgrade command for the method.
+func UpgradeCommand(m Method) string {
+	switch m {
+	case MethodNPM:
+		return "npm install -g inngest-cli@latest"
+	case MethodHomebrew:
+		return "brew upgrade inngest"
+		// The default is the bash command. The user will always see a link
+		// to the GitHub releases page if they want to download the binary manually
+	case MethodBash:
+	default:
+		return "curl -fsSL https://cli.inngest.com/install.sh | sh"
+	}
+}

--- a/pkg/update/detect_test.go
+++ b/pkg/update/detect_test.go
@@ -1,0 +1,72 @@
+package update
+
+import "testing"
+
+func TestClassifyPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want Method
+	}{
+		{"/Users/alice/proj/node_modules/inngest-cli/bin/inngest", MethodNPM},
+		{"/Users/alice/.npm/_npx/abc/node_modules/.bin/inngest", MethodNPM},
+		{"/opt/homebrew/bin/inngest", MethodHomebrew},
+		{"/opt/homebrew/Cellar/inngest/0.35.0/bin/inngest", MethodHomebrew},
+		{"/usr/local/Cellar/inngest/0.35.0/bin/inngest", MethodHomebrew},
+		{"/home/linuxbrew/.linuxbrew/bin/inngest", MethodHomebrew},
+		{"/usr/local/bin/inngest", MethodBash},
+		{"/usr/bin/inngest", MethodBash},
+		{"/Users/alice/Downloads/inngest", MethodBinary},
+		{"/tmp/inngest", MethodBinary},
+	}
+	for _, tc := range cases {
+		if got := classifyPath(tc.path); got != tc.want {
+			t.Errorf("classifyPath(%q) = %q, want %q", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeMethod(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Method
+	}{
+		{"npm", MethodNPM},
+		{"NPX", MethodNPM},
+		{" Homebrew ", MethodHomebrew},
+		{"brew", MethodHomebrew},
+		{"bash", MethodBash},
+		{"install.sh", MethodBash},
+		{"binary", MethodBinary},
+		{"", Method("")},
+		{"unknown", Method("")},
+	}
+	for _, tc := range cases {
+		if got := normalize(tc.in); got != tc.want {
+			t.Errorf("normalize(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestUpgradeCommand(t *testing.T) {
+	cases := []struct {
+		m    Method
+		want string
+	}{
+		{MethodNPM, "npm install -g inngest-cli@latest"},
+		{MethodHomebrew, "brew upgrade inngest"},
+		{MethodBash, "curl -fsSL https://cli.inngest.com/install.sh | sh"},
+		{MethodBinary, "https://github.com/inngest/inngest/releases/latest"},
+	}
+	for _, tc := range cases {
+		if got := UpgradeCommand(tc.m); got != tc.want {
+			t.Errorf("UpgradeCommand(%q) = %q, want %q", tc.m, got, tc.want)
+		}
+	}
+}
+
+func TestDetectEnvOverride(t *testing.T) {
+	t.Setenv(EnvInstallMethod, "homebrew")
+	if got := Detect(); got != MethodHomebrew {
+		t.Errorf("Detect() with INNGEST_INSTALL_METHOD=homebrew = %q, want %q", got, MethodHomebrew)
+	}
+}

--- a/pkg/update/detect_test.go
+++ b/pkg/update/detect_test.go
@@ -55,7 +55,7 @@ func TestUpgradeCommand(t *testing.T) {
 		{MethodNPM, "npm install -g inngest-cli@latest"},
 		{MethodHomebrew, "brew upgrade inngest"},
 		{MethodBash, "curl -fsSL https://cli.inngest.com/install.sh | sh"},
-		{MethodBinary, "https://github.com/inngest/inngest/releases/latest"},
+		{MethodBinary, "curl -fsSL https://cli.inngest.com/install.sh | sh"},
 	}
 	for _, tc := range cases {
 		if got := UpgradeCommand(tc.m); got != tc.want {

--- a/pkg/update/notify.go
+++ b/pkg/update/notify.go
@@ -1,0 +1,75 @@
+package update
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/charmbracelet/lipgloss"
+	inncli "github.com/inngest/inngest/pkg/cli"
+	isatty "github.com/mattn/go-isatty"
+)
+
+// EnabledFor reports whether the update notifier should run for the named
+// subcommand. To enable the notifier for a new command, add it here.
+func EnabledFor(name string) bool {
+	switch name {
+	case "dev", "help", "version", "":
+		return true
+	}
+	return false
+}
+
+// Notify renders the update notice to w (typically os.Stderr) if a newer
+// version is cached and every skip-gate passes. Always safe to call.
+func Notify(w io.Writer, currentVersion string) {
+	if disabled(currentVersion) {
+		return
+	}
+	latest, url := Latest()
+	if !IsNewer(currentVersion, latest) {
+		return
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, render(currentVersion, latest, url, Detect()))
+	fmt.Fprintln(w)
+}
+
+// disabled reports whether the update notifier is suppressed by env, TTY,
+// or dev-build state. Shared by Check and Notify so opting out also
+// silences the background network request — not just the rendering.
+func disabled(currentVersion string) bool {
+	if currentVersion == "" || currentVersion == "dev" {
+		return true
+	}
+	for _, k := range []string{
+		"INNGEST_NO_UPDATE_NOTIFIER",
+		"NO_UPDATE_NOTIFIER",
+		"DO_NOT_TRACK",
+		"CI",
+	} {
+		if os.Getenv(k) != "" {
+			return true
+		}
+	}
+	// Stderr-only output — skip when stderr isn't a terminal so we don't
+	// pollute redirected error logs (and so we never fetch when we'd never
+	// render).
+	return !isatty.IsTerminal(os.Stderr.Fd())
+}
+
+func render(current, latest, url string, m Method) string {
+	header := lipgloss.NewStyle().Bold(true).Foreground(inncli.Orange).
+		Render("Update available")
+	arrow := lipgloss.NewStyle().Foreground(inncli.Feint).Render("→")
+	versions := fmt.Sprintf("%s %s %s", current, arrow, latest)
+
+	runLabel := lipgloss.NewStyle().Foreground(inncli.Feint).Render("Run:")
+	cmd := lipgloss.NewStyle().Bold(true).Render(UpgradeCommand(m))
+
+	body := fmt.Sprintf("%s  %s\n%s %s", header, versions, runLabel, cmd)
+	if url != "" {
+		body += "\n" + lipgloss.NewStyle().Foreground(inncli.Feint).Render(url)
+	}
+	return inncli.UpdateNoticeStyle.Render(body)
+}


### PR DESCRIPTION
## Description

The CLI now automatically checks for updates available to recommend the user to upgrade their CLI through their installed method. It can be disabled by setting:

```
INNGEST_NO_UPDATE_NOTIFIER=1
NO_UPDATE_NOTIFIER=1
DO_NOT_TRACK=1
CI=1
```

<img width="756" height="613" alt="Screen Shot 2026-05-14 at 9 00 04 AM" src="https://github.com/user-attachments/assets/666d691a-c45d-4b22-b9e1-d97121fbe71e" />



## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
The CLI now automatically checks and notifies the user when there is an updated version available. The check will not run if any of the following environment variables are set to a truthy value (e.g. `=1`): `INNGEST_NO_UPDATE_NOTIFIER`, `NO_UPDATE_NOTIFIER`, `DO_NOT_TRACK`, `CI`. The update does not print when using the `start` or `doctor` commands or when using a non TTY input.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds an update notifier to select CLI commands (`dev`, `help`, `version`). A background goroutine fetches the latest release from the GitHub API and caches it in `~/.config/inngest/update-check.json` (24h TTL). On subsequent invocations, `Notify` reads the cache and renders an upgrade hint to stderr when a newer version exists. The notifier is suppressed by opt-out env vars, dev builds, and non-TTY stderr. Install method is auto-detected via path heuristics or `INNGEST_INSTALL_METHOD`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 62753ea28170e3cb210a4274029ef1e7ffee2818.</sup>
<!-- /MENDRAL_SUMMARY -->