### PR TITLE
chore: update semaphore manager to return idempotency info

### DIFF
--- a/pkg/connect/lifecycles/semaphore.go
+++ b/pkg/connect/lifecycles/semaphore.go
@@ -67,7 +67,8 @@ func (s *semaphoreLifecycles) OnSynced(ctx context.Context, conn *state.Connecti
 		idempotencyKey := fmt.Sprintf("connect-%s", conn.ConnectionId)
 
 		_, err := util.WithRetry(ctx, "adjust-semaphore-capacity-connect", func(ctx context.Context) (struct{}, error) {
-			return struct{}{}, s.sm.AdjustCapacity(ctx, conn.AccountID, semID, idempotencyKey, maxConcurrency)
+			_, err := s.sm.AdjustCapacity(ctx, conn.AccountID, semID, idempotencyKey, maxConcurrency)
+			return struct{}{}, err
 		}, util.NewRetryConf())
 		if err != nil {
 			l.Error("failed to adjust semaphore capacity on worker sync after retries",
@@ -104,7 +105,8 @@ func (s *semaphoreLifecycles) OnDisconnected(ctx context.Context, conn *state.Co
 		idempotencyKey := fmt.Sprintf("disconnect-%s", conn.ConnectionId)
 
 		_, err := util.WithRetry(ctx, "adjust-semaphore-capacity-disconnect", func(ctx context.Context) (struct{}, error) {
-			return struct{}{}, s.sm.AdjustCapacity(ctx, conn.AccountID, semID, idempotencyKey, -maxConcurrency)
+			_, err := s.sm.AdjustCapacity(ctx, conn.AccountID, semID, idempotencyKey, -maxConcurrency)
+			return struct{}{}, err
 		}, util.NewRetryConf())
 		if err != nil {
 			l.Error("failed to adjust semaphore capacity on worker disconnect after retries",

--- a/pkg/constraintapi/lua/semaphore_adjust_capacity.lua
+++ b/pkg/constraintapi/lua/semaphore_adjust_capacity.lua
@@ -2,6 +2,9 @@
 -- semaphore_adjust_capacity
 -- Idempotently adjusts capacity by delta.
 --
+-- Returns {capacity, applied} where applied is 1 when the delta was applied
+-- and 0 when this call was an idempotent replay of a previously-seen key.
+--
 
 local keyCapacity = KEYS[1]
 local keyIdempotency = KEYS[2]
@@ -12,7 +15,7 @@ local idempotencyTTL = tonumber(ARGV[2])
 -- Check idempotency
 local existing = redis.call("GET", keyIdempotency)
 if existing ~= nil and existing ~= false then
-	return existing
+	return {tonumber(existing), 0}
 end
 
 local newCapacity = redis.call("INCRBY", keyCapacity, delta)
@@ -22,4 +25,4 @@ if tonumber(newCapacity) < 0 then
 end
 redis.call("SET", keyIdempotency, tostring(newCapacity), "EX", tostring(idempotencyTTL))
 
-return newCapacity
+return {tonumber(newCapacity), 1}

--- a/pkg/constraintapi/lua/semaphore_set_capacity.lua
+++ b/pkg/constraintapi/lua/semaphore_set_capacity.lua
@@ -2,6 +2,9 @@
 -- semaphore_set_capacity
 -- Idempotently sets total capacity for a named semaphore.
 --
+-- Returns {capacity, applied} where applied is 1 when the capacity was set
+-- and 0 when this call was an idempotent replay of a previously-seen key.
+--
 
 local keyCapacity = KEYS[1]
 local keyIdempotency = KEYS[2]
@@ -12,10 +15,10 @@ local idempotencyTTL = tonumber(ARGV[2])
 -- Check idempotency
 local existing = redis.call("GET", keyIdempotency)
 if existing ~= nil and existing ~= false then
-	return existing
+	return {tonumber(existing), 0}
 end
 
 redis.call("SET", keyCapacity, capacity)
 redis.call("SET", keyIdempotency, capacity, "EX", tostring(idempotencyTTL))
 
-return capacity
+return {tonumber(capacity), 1}

--- a/pkg/constraintapi/semaphore_manager.go
+++ b/pkg/constraintapi/semaphore_manager.go
@@ -14,16 +14,32 @@ const (
 	semaphoreIdempotencyTTL = 60 * time.Second
 )
 
+// SetResult describes the outcome of SetCapacity. Applied is false when the
+// call was an idempotent replay of a previously-seen idempotency key; callers
+// emitting side effects (audit events) should gate on Applied. Capacity is the
+// resulting semaphore capacity.
+type SetResult struct {
+	Applied  bool
+	Capacity int64
+}
+
+// AdjustResult describes the outcome of AdjustCapacity. See SetResult for the
+// meaning of the fields.
+type AdjustResult struct {
+	Applied  bool
+	Capacity int64
+}
+
 // SemaphoreManager provides underlying internal APIs for managing semaphores.  these are required because,
 // unlike other constraints, semaphores can be manually adjusted:  the capacity must be adjusted when new
 // workers come online, and for fn concurrency Release is called manually.
 type SemaphoreManager interface {
 	// SetCapacity sets the total capacity for a named semaphore.
-	SetCapacity(ctx context.Context, accountID uuid.UUID, name, idempotencyKey string, capacity int64) error
+	SetCapacity(ctx context.Context, accountID uuid.UUID, name, idempotencyKey string, capacity int64) (SetResult, error)
 
 	// AdjustCapacity atomically adjusts capacity by delta (e.g., +N on worker connect, -N on disconnect).
 	// This upserts the semaphore if it does not exist.
-	AdjustCapacity(ctx context.Context, accountID uuid.UUID, name, idempotencyKey string, delta int64) error
+	AdjustCapacity(ctx context.Context, accountID uuid.UUID, name, idempotencyKey string, delta int64) (AdjustResult, error)
 
 	// GetCapacity returns current capacity and usage for a named semaphore.
 	GetCapacity(ctx context.Context, accountID uuid.UUID, name, usageValue string) (capacity int64, usage int64, err error)
@@ -53,7 +69,7 @@ func semaphoreIdempotencyKey(accountID uuid.UUID, op, idempotencyKey string) str
 	return fmt.Sprintf("{cs}:%s:sem:ik:%s:%s", accountScope(accountID), op, idempotencyKey)
 }
 
-func (m *redisSemaphoreManager) SetCapacity(ctx context.Context, accountID uuid.UUID, name, idempotencyKey string, capacity int64) error {
+func (m *redisSemaphoreManager) SetCapacity(ctx context.Context, accountID uuid.UUID, name, idempotencyKey string, capacity int64) (SetResult, error) {
 	start := time.Now()
 
 	keys := []string{
@@ -65,14 +81,17 @@ func (m *redisSemaphoreManager) SetCapacity(ctx context.Context, accountID uuid.
 		fmt.Sprintf("%d", int(semaphoreIdempotencyTTL.Seconds())),
 	}
 
-	err := scripts["semaphore_set_capacity"].Exec(ctx, m.client, keys, args).Error()
+	res, err := parseCapacityScriptResult(scripts["semaphore_set_capacity"].Exec(ctx, m.client, keys, args))
 
 	m.recordMetrics(ctx, "set_capacity", start, err)
 
-	return err
+	if err != nil {
+		return SetResult{}, err
+	}
+	return SetResult(res), nil
 }
 
-func (m *redisSemaphoreManager) AdjustCapacity(ctx context.Context, accountID uuid.UUID, name, idempotencyKey string, delta int64) error {
+func (m *redisSemaphoreManager) AdjustCapacity(ctx context.Context, accountID uuid.UUID, name, idempotencyKey string, delta int64) (AdjustResult, error) {
 	start := time.Now()
 
 	keys := []string{
@@ -84,11 +103,30 @@ func (m *redisSemaphoreManager) AdjustCapacity(ctx context.Context, accountID uu
 		fmt.Sprintf("%d", int(semaphoreIdempotencyTTL.Seconds())),
 	}
 
-	err := scripts["semaphore_adjust_capacity"].Exec(ctx, m.client, keys, args).Error()
+	res, err := parseCapacityScriptResult(scripts["semaphore_adjust_capacity"].Exec(ctx, m.client, keys, args))
 
 	m.recordMetrics(ctx, "adjust_capacity", start, err)
 
-	return err
+	if err != nil {
+		return AdjustResult{}, err
+	}
+	return AdjustResult(res), nil
+}
+
+// parseCapacityScriptResult decodes the {capacity, applied} array that
+// semaphore_set_capacity and semaphore_adjust_capacity return.
+func parseCapacityScriptResult(result rueidis.RedisResult) (AdjustResult, error) {
+	values, err := result.AsIntSlice()
+	if err != nil {
+		return AdjustResult{}, err
+	}
+	if len(values) != 2 {
+		return AdjustResult{}, fmt.Errorf("unexpected capacity script result length: %d", len(values))
+	}
+	return AdjustResult{
+		Capacity: values[0],
+		Applied:  values[1] == 1,
+	}, nil
 }
 
 func (m *redisSemaphoreManager) GetCapacity(ctx context.Context, accountID uuid.UUID, name, usageValue string) (int64, int64, error) {

--- a/pkg/constraintapi/semaphore_test.go
+++ b/pkg/constraintapi/semaphore_test.go
@@ -368,8 +368,10 @@ func TestSemaphoreManager(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("set and get capacity", func(t *testing.T) {
-		err := sm.SetCapacity(ctx, accountID, name, "set-1", 10)
+		res, err := sm.SetCapacity(ctx, accountID, name, "set-1", 10)
 		require.NoError(t, err)
+		require.True(t, res.Applied)
+		require.Equal(t, int64(10), res.Capacity)
 
 		cap, usage, err := sm.GetCapacity(ctx, accountID, name, "")
 		require.NoError(t, err)
@@ -378,11 +380,15 @@ func TestSemaphoreManager(t *testing.T) {
 	})
 
 	t.Run("set capacity idempotency", func(t *testing.T) {
-		err := sm.SetCapacity(ctx, accountID, name, "set-idem", 20)
+		res, err := sm.SetCapacity(ctx, accountID, name, "set-idem", 20)
 		require.NoError(t, err)
-		// Same idempotency key — should not change
-		err = sm.SetCapacity(ctx, accountID, name, "set-idem", 99)
+		require.True(t, res.Applied)
+		require.Equal(t, int64(20), res.Capacity)
+		// Same idempotency key — should not change, and Applied should be false
+		res, err = sm.SetCapacity(ctx, accountID, name, "set-idem", 99)
 		require.NoError(t, err)
+		require.False(t, res.Applied, "replay should not be applied")
+		require.Equal(t, int64(20), res.Capacity, "replay returns the cached capacity")
 
 		cap, _, err := sm.GetCapacity(ctx, accountID, name, "")
 		require.NoError(t, err)
@@ -391,11 +397,13 @@ func TestSemaphoreManager(t *testing.T) {
 
 	t.Run("adjust capacity", func(t *testing.T) {
 		name := fmt.Sprintf("app:%s", uuid.New())
-		err := sm.SetCapacity(ctx, accountID, name, "adj-set", 5)
+		_, err := sm.SetCapacity(ctx, accountID, name, "adj-set", 5)
 		require.NoError(t, err)
 
-		err = sm.AdjustCapacity(ctx, accountID, name, "adj-1", 3)
+		res, err := sm.AdjustCapacity(ctx, accountID, name, "adj-1", 3)
 		require.NoError(t, err)
+		require.True(t, res.Applied)
+		require.Equal(t, int64(8), res.Capacity)
 
 		cap, _, err := sm.GetCapacity(ctx, accountID, name, "")
 		require.NoError(t, err)
@@ -404,14 +412,18 @@ func TestSemaphoreManager(t *testing.T) {
 
 	t.Run("adjust capacity idempotency", func(t *testing.T) {
 		name := fmt.Sprintf("app:%s", uuid.New())
-		err := sm.SetCapacity(ctx, accountID, name, "adj-idem-set", 5)
+		_, err := sm.SetCapacity(ctx, accountID, name, "adj-idem-set", 5)
 		require.NoError(t, err)
 
-		err = sm.AdjustCapacity(ctx, accountID, name, "adj-idem-1", 3)
+		res, err := sm.AdjustCapacity(ctx, accountID, name, "adj-idem-1", 3)
 		require.NoError(t, err)
-		// Same idempotency key — should not double-add
-		err = sm.AdjustCapacity(ctx, accountID, name, "adj-idem-1", 3)
+		require.True(t, res.Applied)
+		require.Equal(t, int64(8), res.Capacity)
+		// Same idempotency key — should not double-add, and Applied should be false
+		res, err = sm.AdjustCapacity(ctx, accountID, name, "adj-idem-1", 3)
 		require.NoError(t, err)
+		require.False(t, res.Applied, "replay should not be applied")
+		require.Equal(t, int64(8), res.Capacity, "replay returns the cached capacity")
 
 		cap, _, err := sm.GetCapacity(ctx, accountID, name, "")
 		require.NoError(t, err)
@@ -657,12 +669,14 @@ func TestSemaphoreAdjustCapacityClampsToZero(t *testing.T) {
 	name := "app:" + uuid.New().String()
 
 	// Set capacity to 5
-	err = sm.SetCapacity(ctx, accountID, name, "set-1", 5)
+	_, err = sm.SetCapacity(ctx, accountID, name, "set-1", 5)
 	require.NoError(t, err)
 
 	// Adjust by -10, should clamp to 0
-	err = sm.AdjustCapacity(ctx, accountID, name, "adj-1", -10)
+	res, err := sm.AdjustCapacity(ctx, accountID, name, "adj-1", -10)
 	require.NoError(t, err)
+	require.True(t, res.Applied)
+	require.Equal(t, int64(0), res.Capacity, "clamped capacity should be reported in the result")
 
 	cap, _, err := sm.GetCapacity(ctx, accountID, name, "")
 	require.NoError(t, err)

--- a/pkg/constraintapi/testdata/snapshots/semaphore_adjust_capacity.lua
+++ b/pkg/constraintapi/testdata/snapshots/semaphore_adjust_capacity.lua
@@ -4,7 +4,7 @@ local delta = tonumber(ARGV[1])
 local idempotencyTTL = tonumber(ARGV[2])
 local existing = redis.call("GET", keyIdempotency)
 if existing ~= nil and existing ~= false then
-	return existing
+	return {tonumber(existing), 0}
 end
 local newCapacity = redis.call("INCRBY", keyCapacity, delta)
 if tonumber(newCapacity) < 0 then
@@ -12,4 +12,4 @@ if tonumber(newCapacity) < 0 then
 	newCapacity = 0
 end
 redis.call("SET", keyIdempotency, tostring(newCapacity), "EX", tostring(idempotencyTTL))
-return newCapacity
+return {tonumber(newCapacity), 1}

--- a/pkg/constraintapi/testdata/snapshots/semaphore_set_capacity.lua
+++ b/pkg/constraintapi/testdata/snapshots/semaphore_set_capacity.lua
@@ -4,8 +4,8 @@ local capacity = ARGV[1]
 local idempotencyTTL = tonumber(ARGV[2])
 local existing = redis.call("GET", keyIdempotency)
 if existing ~= nil and existing ~= false then
-	return existing
+	return {tonumber(existing), 0}
 end
 redis.call("SET", keyCapacity, capacity)
 redis.call("SET", keyIdempotency, capacity, "EX", tostring(idempotencyTTL))
-return capacity
+return {tonumber(capacity), 1}

--- a/pkg/devserver/api_test.go
+++ b/pkg/devserver/api_test.go
@@ -54,18 +54,18 @@ type capturingSemaphoreManager struct {
 	setCalls []semaphoreSetCall
 }
 
-func (c *capturingSemaphoreManager) SetCapacity(_ context.Context, accountID uuid.UUID, name, idempotencyKey string, capacity int64) error {
+func (c *capturingSemaphoreManager) SetCapacity(_ context.Context, accountID uuid.UUID, name, idempotencyKey string, capacity int64) (constraintapi.SetResult, error) {
 	c.setCalls = append(c.setCalls, semaphoreSetCall{
 		accountID:      accountID,
 		name:           name,
 		idempotencyKey: idempotencyKey,
 		capacity:       capacity,
 	})
-	return nil
+	return constraintapi.SetResult{Applied: true, Capacity: capacity}, nil
 }
 
-func (c *capturingSemaphoreManager) AdjustCapacity(context.Context, uuid.UUID, string, string, int64) error {
-	return nil
+func (c *capturingSemaphoreManager) AdjustCapacity(context.Context, uuid.UUID, string, string, int64) (constraintapi.AdjustResult, error) {
+	return constraintapi.AdjustResult{}, nil
 }
 
 func (c *capturingSemaphoreManager) GetCapacity(context.Context, uuid.UUID, string, string) (int64, int64, error) {

--- a/pkg/registration/process.go
+++ b/pkg/registration/process.go
@@ -63,7 +63,7 @@ func (r *ProcessResult) SetSemaphoreCapacity(ctx context.Context, sm constrainta
 			// add the idempotency key to the fn ID.  this resets after the semaphore idempotency period,
 			// eg 20 seconds, but ensures simultaneous deploys still update the sem.
 			ik := fmt.Sprintf("%s-%s", r.opts.IdempotencyKey, df.ID.String())
-			_ = sm.SetCapacity(ctx, df.AccountID, semID, ik, int64(fc.Limit))
+			_, _ = sm.SetCapacity(ctx, df.AccountID, semID, ik, int64(fc.Limit))
 		}
 	}
 }


### PR DESCRIPTION
## Description

Updates semaphore manager to return whether the txn was idempotent, and the new value.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Extends the `SemaphoreManager` interface so `SetCapacity` and `AdjustCapacity` return `{Capacity, Applied}` instead of a bare error. The Lua scripts are updated to return a 2-element array `{capacity, applied}`, a shared `parseCapacityScriptResult` helper decodes it via `rueidis`'s `AsIntSlice`, and callers are updated throughout.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 14d14c7f1530eb66143923846086f3459808b759.</sup>
<!-- /MENDRAL_SUMMARY -->