### PR TITLE
internal: update release note parsing

### DIFF
--- a/docs/plans/004-automated-release-cycle.org
+++ b/docs/plans/004-automated-release-cycle.org
@@ -153,25 +153,31 @@ The release PR body should contain machine-owned and human-owned sections:
 
 #+begin_src markdown
 <!-- auto-release-pr -->
-## Release
-
 This PR prepares `vX.Y.Z`.
 
-## Additional Release Notes
+### Additional Release Notes
 <!-- release-note:manual-start -->
-None.
 <!-- release-note:manual-end -->
 
-## Additional Migration Notes
+### Additional Migration Notes
 <!-- migration-note:manual-start -->
-None.
 <!-- migration-note:manual-end -->
 
-## Notes Preview
+## Final Release Page Preview
+
+> This generated preview is the release notes body that will be published to
+> the GitHub Release page. It intentionally includes the additional notes above,
+> followed by collected PR notes and the changelog.
+
+<details open>
+<summary>Rendered release notes body</summary>
+
 <!-- release-note:preview-start -->
 Full generated release preview goes here, including release notes, migration
 notes, and generated changelog entries.
 <!-- release-note:preview-end -->
+
+</details>
 #+end_src
 
 When the workflow updates an existing release PR, it should preserve the manual

--- a/tools/release-notes/collect.go
+++ b/tools/release-notes/collect.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -49,8 +50,13 @@ func collectNotesCommand(inputPath, outputPath, cliffPath, commitRange, repo str
 		return err
 	}
 
+	templateBody, err := readPullRequestTemplate(".github/pull_request_template.md")
+	if err != nil {
+		return err
+	}
+
 	for i := range prs {
-		sections := ParsePRBody(prs[i].Body)
+		sections := ParsePRBodyWithTemplate(prs[i].Body, templateBody)
 		prs[i].Description = sections["description"]
 		prs[i].ReleaseNote = NormalizeNote(sections["release note"])
 		prs[i].MigrationNote = NormalizeNote(sections["migration note"])
@@ -68,6 +74,29 @@ func collectNotesCommand(inputPath, outputPath, cliffPath, commitRange, repo str
 		return err
 	}
 	return os.WriteFile(outputPath, out, 0o644)
+}
+
+func readPullRequestTemplate(path string) (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		data, err := os.ReadFile(filepath.Join(dir, path))
+		if err == nil {
+			return string(data), nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", nil
+		}
+		dir = parent
+	}
 }
 
 func readPRInput(path string) ([]PullRequest, error) {

--- a/tools/release-notes/collect_test.go
+++ b/tools/release-notes/collect_test.go
@@ -17,7 +17,7 @@ func TestCollectCommandFromInput(t *testing.T) {
 		{
 			Number: 1,
 			Title:  "feat: add thing",
-			Body:   "## Description\n\nAdds a thing.\n\n## Release note\n\nThing is available.\n\n## Migration note\n\nNone.\n",
+			Body:   "## Description\n\nAdds a thing.\n\n## Release note\n\nThing is available.\n\n## Migration note\n\nNone.\n\n*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*\n",
 			Files:  []string{"pkg/execution/run.go"},
 		},
 	}

--- a/tools/release-notes/parse.go
+++ b/tools/release-notes/parse.go
@@ -6,6 +6,26 @@ import (
 )
 
 func ParsePRBody(body string) map[string]string {
+	return ParsePRBodyWithTemplate(body, "")
+}
+
+func ParsePRBodyWithTemplate(body, template string) map[string]string {
+	sections := parsePRBodySections(body)
+	if template == "" {
+		return sections
+	}
+
+	templateSections := parsePRBodySections(template)
+	for section, templateValue := range templateSections {
+		if sections[section] == "" {
+			continue
+		}
+		sections[section] = RemoveTemplateText(sections[section], templateValue)
+	}
+	return sections
+}
+
+func parsePRBodySections(body string) map[string]string {
 	sections := map[string]string{}
 	var current string
 	var lines []string
@@ -65,14 +85,38 @@ func parseHeading(line string) (string, bool) {
 var (
 	htmlCommentPattern    = regexp.MustCompile(`(?s)<!--.*?-->`)
 	mendralSummaryPattern = regexp.MustCompile(`(?s)<!--\s*MENDRAL_SUMMARY\s*-->.*?<!--\s*/MENDRAL_SUMMARY\s*-->`)
-	prGuidelinesPattern   = regexp.MustCompile(`(?m)^\*\[Check our Pull Request Guidelines\]\(https://github\.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES\.md\)\*\s*$`)
 )
 
 func CleanMarkdownSection(value string) string {
 	value = mendralSummaryPattern.ReplaceAllString(value, "")
 	value = htmlCommentPattern.ReplaceAllString(value, "")
-	value = prGuidelinesPattern.ReplaceAllString(value, "")
 	return NormalizeWhitespace(value)
+}
+
+func RemoveTemplateText(value, templateValue string) string {
+	value = NormalizeWhitespace(value)
+	templateValue = NormalizeWhitespace(templateValue)
+	if value == "" || templateValue == "" {
+		return value
+	}
+
+	templateLines := map[string]struct{}{}
+	for _, line := range strings.Split(templateValue, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			templateLines[line] = struct{}{}
+		}
+	}
+
+	lines := strings.Split(value, "\n")
+	kept := lines[:0]
+	for _, line := range lines {
+		if _, ok := templateLines[strings.TrimSpace(line)]; ok {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return NormalizeWhitespace(strings.Join(kept, "\n"))
 }
 
 func NormalizeNote(value string) string {

--- a/tools/release-notes/parse.go
+++ b/tools/release-notes/parse.go
@@ -65,11 +65,13 @@ func parseHeading(line string) (string, bool) {
 var (
 	htmlCommentPattern    = regexp.MustCompile(`(?s)<!--.*?-->`)
 	mendralSummaryPattern = regexp.MustCompile(`(?s)<!--\s*MENDRAL_SUMMARY\s*-->.*?<!--\s*/MENDRAL_SUMMARY\s*-->`)
+	prGuidelinesPattern   = regexp.MustCompile(`(?m)^\*\[Check our Pull Request Guidelines\]\(https://github\.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES\.md\)\*\s*$`)
 )
 
 func CleanMarkdownSection(value string) string {
 	value = mendralSummaryPattern.ReplaceAllString(value, "")
 	value = htmlCommentPattern.ReplaceAllString(value, "")
+	value = prGuidelinesPattern.ReplaceAllString(value, "")
 	return NormalizeWhitespace(value)
 }
 

--- a/tools/release-notes/parse_test.go
+++ b/tools/release-notes/parse_test.go
@@ -124,8 +124,6 @@ func TestParsePRBodyDropsMendralSummary(t *testing.T) {
 
 None.
 
-*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
-
 <!-- MENDRAL_SUMMARY -->
 ---
 
@@ -139,5 +137,53 @@ None.
 	sections := ParsePRBody(body)
 	if got := NormalizeNote(sections["migration note"]); got != "" {
 		t.Fatalf("migration note = %q, want empty", got)
+	}
+}
+
+func TestParsePRBodyWithTemplateDropsUnmodifiedTemplateText(t *testing.T) {
+	template := `## Description
+
+<!-- What changed? Include screenshots if you modify the UI. -->
+
+## Release note
+
+<!-- User-facing release note. Use "None" if this does not need release notes. -->
+None.
+
+## Migration note
+
+<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
+None.
+
+*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
+`
+
+	body := `## Description
+
+<!-- What changed? Include screenshots if you modify the UI. -->
+Fixes a thing.
+
+## Release note
+
+<!-- User-facing release note. Use "None" if this does not need release notes. -->
+None.
+
+## Migration note
+
+<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
+Set the new flag before rollout.
+
+*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
+`
+
+	sections := ParsePRBodyWithTemplate(body, template)
+	if got := NormalizeNote(sections["description"]); got != "Fixes a thing." {
+		t.Fatalf("description = %q", got)
+	}
+	if got := NormalizeNote(sections["release note"]); got != "" {
+		t.Fatalf("release note = %q, want empty", got)
+	}
+	if got := NormalizeNote(sections["migration note"]); got != "Set the new flag before rollout." {
+		t.Fatalf("migration note = %q", got)
 	}
 }

--- a/tools/release-notes/parse_test.go
+++ b/tools/release-notes/parse_test.go
@@ -124,6 +124,8 @@ func TestParsePRBodyDropsMendralSummary(t *testing.T) {
 
 None.
 
+*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
+
 <!-- MENDRAL_SUMMARY -->
 ---
 

--- a/tools/release-notes/pr_body.go
+++ b/tools/release-notes/pr_body.go
@@ -121,7 +121,6 @@ func RenderReleasePRBody(input ReleasePRBodyInput) (string, error) {
 
 	var b strings.Builder
 	b.WriteString("<!-- auto-release-pr -->\n")
-	b.WriteString("## Release\n\n")
 	fmt.Fprintf(&b, "This PR prepares `%s`.\n\n", tag)
 	if input.CompareURL != "" {
 		compareLabel := strings.TrimSpace(input.CompareLabel)
@@ -134,12 +133,12 @@ func RenderReleasePRBody(input ReleasePRBodyInput) (string, error) {
 		fmt.Fprintf(&b, "- Code difference since last tag: [%s](%s)\n", compareLabel, input.CompareURL)
 	}
 	if input.LatestTag != "" {
-		fmt.Fprintf(&b, "- Previous tag: `%s`\n", input.LatestTag)
+		fmt.Fprintf(&b, "- Previous tag: `%s`\n", input.LatestTag) // TODO make this a link of previous tag
 	}
 	fmt.Fprintf(&b, "- Source branch: `%s`\n", head)
 	fmt.Fprintf(&b, "- Base branch: `%s`\n\n", base)
 
-	b.WriteString("## Additional Release Notes\n")
+	b.WriteString("### Additional Release Notes\n")
 	b.WriteString("<!-- release-note:manual-start -->\n")
 	if manualRelease != "" {
 		b.WriteString(manualRelease)
@@ -147,7 +146,7 @@ func RenderReleasePRBody(input ReleasePRBodyInput) (string, error) {
 	}
 	b.WriteString("<!-- release-note:manual-end -->\n\n")
 
-	b.WriteString("## Additional Migration Notes\n")
+	b.WriteString("### Additional Migration Notes\n")
 	b.WriteString("<!-- migration-note:manual-start -->\n")
 	if manualMigration != "" {
 		b.WriteString(manualMigration)
@@ -155,10 +154,14 @@ func RenderReleasePRBody(input ReleasePRBodyInput) (string, error) {
 	}
 	b.WriteString("<!-- migration-note:manual-end -->\n\n")
 
-	b.WriteString("## Notes Preview\n")
+	b.WriteString("## Final Release Page Preview\n\n")
+	b.WriteString("> This generated preview is the release notes body that will be published to the GitHub Release page. It intentionally includes the additional notes above, followed by collected PR notes and the changelog.\n\n")
+	b.WriteString("<details open>\n")
+	b.WriteString("<summary>Rendered release notes body</summary>\n\n")
 	b.WriteString("<!-- release-note:preview-start -->\n")
 	b.WriteString(preview)
-	b.WriteString("\n<!-- release-note:preview-end -->\n")
+	b.WriteString("\n<!-- release-note:preview-end -->\n\n")
+	b.WriteString("</details>\n")
 
 	return b.String(), nil
 }

--- a/tools/release-notes/pr_body_test.go
+++ b/tools/release-notes/pr_body_test.go
@@ -48,6 +48,9 @@ Old preview.
 	assertContains(t, got, "- Previous tag: `v1.2.2`")
 	assertContains(t, got, "Keep this release context.")
 	assertContains(t, got, "Keep this migration context.")
+	assertContains(t, got, "## Final Release Page Preview")
+	assertContains(t, got, "release notes body that will be published to the GitHub Release page")
+	assertContains(t, got, "<summary>Rendered release notes body</summary>")
 	assertContains(t, got, "New preview.")
 
 	if strings.Contains(got, "Old preview.") {
@@ -64,14 +67,17 @@ func TestRenderReleasePRBodyRendersEmptyEditableManualBlocks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assertContains(t, got, "## Additional Release Notes")
+	assertContains(t, got, "### Additional Release Notes")
 	assertContains(t, got, "<!-- release-note:manual-start -->\n<!-- release-note:manual-end -->")
-	assertContains(t, got, "## Additional Migration Notes")
+	assertContains(t, got, "### Additional Migration Notes")
 	assertContains(t, got, "<!-- migration-note:manual-start -->\n<!-- migration-note:manual-end -->")
 	assertNotContains(t, got, "None.")
 	assertNotContains(t, got, "N/A")
 	assertContains(t, got, "- Source branch: `release/next`")
 	assertContains(t, got, "- Base branch: `main`")
+	assertContains(t, got, "<details open>")
+	assertContains(t, got, "<!-- release-note:preview-start -->\n## Changelog")
+	assertContains(t, got, "<!-- release-note:preview-end -->\n\n</details>")
 }
 
 func TestRenderReleasePRBodyOmitsPlaceholderManualText(t *testing.T) {
@@ -92,8 +98,8 @@ N/A
 		t.Fatal(err)
 	}
 
-	assertContains(t, got, "## Additional Release Notes")
-	assertContains(t, got, "## Additional Migration Notes")
+	assertContains(t, got, "### Additional Release Notes")
+	assertContains(t, got, "### Additional Migration Notes")
 	assertNotContains(t, got, "None.")
 	assertNotContains(t, got, "N/A")
 }


### PR DESCRIPTION
## Description

Update PR migration note gathering to exclude text from the PR template.

Also update release notes to be more clear.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds template-aware PR body parsing to the release note collection tool so that boilerplate text copied unchanged from `.github/pull_request_template.md` is excluded from release/migration notes. Also updates the release PR body renderer to use `###` headings for the manual note sections and wraps the preview in a `<details>` block.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 5a93602e54e2578a0b1269a346c383fcac8cb5d2.</sup>
<!-- /MENDRAL_SUMMARY -->