### PR TITLE
feat: Insights: Add stubs for new insights API endpoints

### DIFF
--- a/pkg/api/v2/endpoints.go
+++ b/pkg/api/v2/endpoints.go
@@ -280,3 +280,6 @@ func (s *Service) PatchEnv(ctx context.Context, req *apiv2.PatchEnvRequest) (*ap
 func (s *Service) SyncApp(ctx context.Context, req *apiv2.SyncAppRequest) (*apiv2.SyncAppResponse, error) {
 	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "App sync not implemented in OSS")
 }
+func (s *Service) QueryInsights(ctx context.Context, req *apiv2.QueryInsightsRequest) (*apiv2.QueryInsightsResponse, error) {
+	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Insights not implemented in OSS")
+}

--- a/pkg/api/v2/endpoints.go
+++ b/pkg/api/v2/endpoints.go
@@ -280,6 +280,10 @@ func (s *Service) PatchEnv(ctx context.Context, req *apiv2.PatchEnvRequest) (*ap
 func (s *Service) SyncApp(ctx context.Context, req *apiv2.SyncAppRequest) (*apiv2.SyncAppResponse, error) {
 	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "App sync not implemented in OSS")
 }
+func (s *Service) ListInsightsTables(ctx context.Context, req *apiv2.ListInsightsTablesRequest) (*apiv2.ListInsightsTablesResponse, error) {
+	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Insights not implemented in OSS")
+}
+
 func (s *Service) QueryInsights(ctx context.Context, req *apiv2.QueryInsightsRequest) (*apiv2.QueryInsightsResponse, error) {
 	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Insights not implemented in OSS")
 }

--- a/pkg/api/v2/endpoints.go
+++ b/pkg/api/v2/endpoints.go
@@ -284,6 +284,10 @@ func (s *Service) ListInsightsTables(ctx context.Context, req *apiv2.ListInsight
 	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Insights not implemented in OSS")
 }
 
+func (s *Service) QueryInsightsPrompt(ctx context.Context, req *apiv2.QueryInsightsPromptRequest) (*apiv2.QueryInsightsPromptResponse, error) {
+	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Insights not implemented in OSS")
+}
+
 func (s *Service) QueryInsights(ctx context.Context, req *apiv2.QueryInsightsRequest) (*apiv2.QueryInsightsResponse, error) {
 	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Insights not implemented in OSS")
 }

--- a/pkg/api/v2/endpoints.go
+++ b/pkg/api/v2/endpoints.go
@@ -280,6 +280,10 @@ func (s *Service) PatchEnv(ctx context.Context, req *apiv2.PatchEnvRequest) (*ap
 func (s *Service) SyncApp(ctx context.Context, req *apiv2.SyncAppRequest) (*apiv2.SyncAppResponse, error) {
 	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "App sync not implemented in OSS")
 }
+func (s *Service) ListInsightsEventSchemas(ctx context.Context, req *apiv2.ListInsightsEventSchemasRequest) (*apiv2.ListInsightsEventSchemasResponse, error) {
+	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Insights not implemented in OSS")
+}
+
 func (s *Service) ListInsightsTables(ctx context.Context, req *apiv2.ListInsightsTablesRequest) (*apiv2.ListInsightsTablesResponse, error) {
 	return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Insights not implemented in OSS")
 }

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -1210,6 +1210,68 @@ service V2 {
     };
   }
 
+  rpc ListInsightsTables(ListInsightsTablesRequest) returns (ListInsightsTablesResponse) {
+    option (google.api.http) = {
+      get: "/insights/tables"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List insights tables"
+      tags: "Insights"
+      tags: "Beta"
+      description: "Lists the available tables that can be queried via the Insights query endpoint."
+      security: {
+        security_requirement: {
+          key: "BearerAuth"
+          value: {}
+        }
+      }
+      responses: {
+        key: "200"
+        value: {
+          description: "List of available insights tables"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ListInsightsTablesResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "401"
+        value: {
+          description: "Unauthorized - authentication required"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "403"
+        value: {
+          description: "Forbidden - insufficient permissions"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "500"
+        value: {
+          description: "Internal Server Error"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+    };
+  }
+
   rpc QueryInsights(QueryInsightsRequest) returns (QueryInsightsResponse) {
     option (google.api.http) = {
       post: "/insights/query",
@@ -1850,20 +1912,20 @@ message QueryInsightsData {
   ];
 }
 
-message InsightsColumn {
+message InsightsOutputColumn {
   string name = 1 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Name of the column in the insights query result"
     }
   ];
-  InsightsColumnType type = 2 [
+  InsightsOutputColumnType type = 2 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Data type of the column (e.g., 'string', 'number', 'boolean')"
     }
   ];
 }
 
-enum InsightsColumnType {
+enum InsightsOutputColumnType {
   VALUE_TYPE_UNSPECIFIED = 0;
   STRING = 1;
   NUMBER = 2;
@@ -1924,6 +1986,56 @@ message InsightsDiagnosticPosition {
   string context = 3 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Snippet of the query string around the position to provide context for the diagnostic"
+    }
+  ];
+}
+
+message ListInsightsTablesRequest {
+  // Empty request message for listing available insights tables
+}
+
+message ListInsightsTablesResponse {
+  repeated InsightsTable data = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "List of available tables that can be queried via the Insights query endpoint"
+    }
+  ];
+  ResponseMetadata metadata = 2;
+}
+
+message InsightsTable {
+  string name = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Name of the table, used when writing queries"
+      example: "\"function_runs\""
+    }
+  ];
+  string description = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Human-readable description of the table and its contents"
+    }
+  ];
+  repeated InsightsTableColumn columns = 3 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Columns available in this table"
+    }
+  ];
+}
+
+message InsightsTableColumn {
+  string name = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Name of the column in the insights table"
+    }
+  ];
+  string description = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Human-readable description of the column and the data it contains"
+    }
+  ];
+  string type = 3 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Data type of the column (e.g., 'String', 'Int64', 'Array(String)', etc.)"
     }
   ];
 }

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -1272,6 +1272,91 @@ service V2 {
     };
   }
 
+  rpc QueryInsightsPrompt(QueryInsightsPromptRequest) returns (QueryInsightsPromptResponse) {
+    option (google.api.http) = {
+      post: "/insights/query/prompt",
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Generate insights query from prompt"
+      tags: "Insights"
+      tags: "Beta"
+      description: "Translates a natural language prompt into an Insights SQL query."
+      security: {
+        security_requirement: {
+          key: "BearerAuth"
+          value: {}
+        }
+      }
+      responses: {
+        key: "200"
+        value: {
+          description: "Query generated successfully"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2QueryInsightsPromptResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "400"
+        value: {
+          description: "Bad Request - invalid input data"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "401"
+        value: {
+          description: "Unauthorized - authentication required"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "403"
+        value: {
+          description: "Forbidden - insufficient permissions"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "422"
+        value: {
+          description: "Unprocessable Entity - prompt could not be translated into a valid query"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "500"
+        value: {
+          description: "Internal Server Error"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+    };
+  }
+
   rpc QueryInsights(QueryInsightsRequest) returns (QueryInsightsResponse) {
     option (google.api.http) = {
       post: "/insights/query",
@@ -2036,6 +2121,34 @@ message InsightsTableColumn {
   string type = 3 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Data type of the column (e.g., 'String', 'Int64', 'Array(String)', etc.)"
+    }
+  ];
+}
+
+message QueryInsightsPromptRequest {
+  string prompt = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Natural language description of the query to generate"
+      example: "\"Show me the top 10 functions by failure rate in the last 7 days\""
+    }
+  ];
+}
+
+message QueryInsightsPromptResponse {
+  QueryInsightsPromptData data = 1;
+  ResponseMetadata metadata = 2;
+}
+
+message QueryInsightsPromptData {
+  string query = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "The generated Insights SQL query"
+      example: "\"SELECT function_id, COUNT(*) AS total, countIf(status = 'Failed') AS failures, failures / total AS failure_rate FROM function_runs WHERE started_at >= now() - INTERVAL 7 DAY GROUP BY function_id ORDER BY failure_rate DESC LIMIT 10\""
+    }
+  ];
+  repeated InsightsDiagnostic diagnostics = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Any non-fatal diagnostics or warnings about the generated query"
     }
   ];
 }

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -1210,6 +1210,101 @@ service V2 {
     };
   }
 
+  rpc QueryInsights(QueryInsightsRequest) returns (QueryInsightsResponse) {
+    option (google.api.http) = {
+      post: "/insights/query",
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Query insights"
+      tags: "Insights"
+      tags: "Beta"
+      description: "Query Insights using the provided SQL query."
+      security: {
+        security_requirement: {
+          key: "BearerAuth"
+          value: {}
+        }
+      }
+      responses: {
+        key: "200"
+        value: {
+          description: "Query executed successfully"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2QueryInsightsResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "400"
+        value: {
+          description: "Bad Request - invalid input data"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "401"
+        value: {
+          description: "Unauthorized - authentication required"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "403"
+        value: {
+          description: "Forbidden - insufficient permissions"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "404"
+        value: {
+          description: "Not Found - environment not found"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "422"
+        value: {
+          description: "Unprocessable Entity - Query validation or execution failed."
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "500"
+        value: {
+          description: "Internal Server Error"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+    };
+  }
 }
 
 message HealthRequest {
@@ -1722,4 +1817,113 @@ message SyncAppData {
 message SyncAppError {
   string code = 1;
   string message = 2;
+}
+
+message QueryInsightsRequest {
+  string query = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "The insights query to execute, written in modified ClickHouse SQL"
+    }
+  ];
+}
+
+message QueryInsightsResponse {
+  QueryInsightsData data = 1;
+  ResponseMetadata metadata = 2;
+}
+
+message QueryInsightsData {
+  repeated InsightsOutputColumn columns = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Column metadata for the insights query result"
+    }
+  ];
+  repeated InsightsRow rows = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Rows of the insights query result, where each row contains a list of values corresponding to the columns"
+    }
+  ];
+  repeated InsightsDiagnostic diagnostics = 3 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Any non-fatal diagnostics related to the insights query execution"
+    }
+  ];
+}
+
+message InsightsColumn {
+  string name = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Name of the column in the insights query result"
+    }
+  ];
+  InsightsColumnType type = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Data type of the column (e.g., 'string', 'number', 'boolean')"
+    }
+  ];
+}
+
+enum InsightsColumnType {
+  VALUE_TYPE_UNSPECIFIED = 0;
+  STRING = 1;
+  NUMBER = 2;
+  BOOLEAN = 3;
+  DATETIME = 4;
+  COMPLEX = 5;
+}
+
+message InsightsRow {
+  repeated google.protobuf.Value values = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Values for a single row of the insights query result, where each value corresponds to a column. The value is represented as a JSON object to allow for flexible typing (e.g., string, number, boolean, etc.)"
+    }
+  ];
+}
+
+message InsightsDiagnostic {
+  InsightsDiagnosticSeverity severity = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Severity level of the diagnostic (e.g., 'error', 'warning', 'info')"
+    }
+  ];
+  string code = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Machine-readable code representing the type of diagnostic"
+    }
+  ];
+  string message = 3 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Human-readable message describing the diagnostic"
+    }
+  ];
+  optional InsightsDiagnosticPosition position = 4 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Optional position in the query string where the diagnostic applies, useful for pointing out syntax errors or other issues in the query"
+    }
+  ];
+}
+
+enum InsightsDiagnosticSeverity {
+  SEVERITY_UNSPECIFIED = 0;
+  ERROR = 1;
+  WARNING = 2;
+  INFO = 3;
+}
+
+message InsightsDiagnosticPosition {
+  int32 start = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Starting character index in the query string where the diagnostic applies"
+    }
+  ];
+  int32 end = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Ending character index in the query string where the diagnostic applies"
+    }
+  ];
+  string context = 3 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Snippet of the query string around the position to provide context for the diagnostic"
+    }
+  ];
 }

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -2225,11 +2225,6 @@ message QueryInsightsPromptData {
       example: "\"This query retrieves the top 10 functions with the highest failure rate over the past week, showing the total number of runs, number of failures, and calculated failure rate for each function.\""
     }
   ];
-  repeated InsightsDiagnostic diagnostics = 3 [
-    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Any non-fatal diagnostics or warnings about the generated query"
-    }
-  ];
 }
 
 message ListInsightsEventSchemasRequest {

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -2213,13 +2213,19 @@ message QueryInsightsPromptResponse {
 }
 
 message QueryInsightsPromptData {
-  string query = 1 [
+  string sql = 1 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "The generated Insights SQL query"
       example: "\"SELECT function_id, COUNT(*) AS total, countIf(status = 'Failed') AS failures, failures / total AS failure_rate FROM function_runs WHERE started_at >= now() - INTERVAL 7 DAY GROUP BY function_id ORDER BY failure_rate DESC LIMIT 10\""
     }
   ];
-  repeated InsightsDiagnostic diagnostics = 2 [
+  string summary = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "A natural language summary of the generated query, useful for explaining the query's intent to agents"
+      example: "\"This query retrieves the top 10 functions with the highest failure rate over the past week, showing the total number of runs, number of failures, and calculated failure rate for each function.\""
+    }
+  ];
+  repeated InsightsDiagnostic diagnostics = 3 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Any non-fatal diagnostics or warnings about the generated query"
     }

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -1272,6 +1272,79 @@ service V2 {
     };
   }
 
+  rpc ListInsightsEventSchemas(ListInsightsEventSchemasRequest) returns (ListInsightsEventSchemasResponse) {
+    option (google.api.http) = {
+      get: "/insights/events/schemas"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List event type schemas"
+      tags: "Insights"
+      tags: "Beta"
+      description: "Returns a paginated list of event type schemas, where each schema describes the shape of a specific event's data as nested JSON."
+      security: {
+        security_requirement: {
+          key: "BearerAuth"
+          value: {}
+        }
+      }
+      responses: {
+        key: "200"
+        value: {
+          description: "Paginated list of event type schemas"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ListInsightsEventSchemasResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "400"
+        value: {
+          description: "Bad Request - invalid query parameters"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "401"
+        value: {
+          description: "Unauthorized - authentication required"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "403"
+        value: {
+          description: "Forbidden - insufficient permissions"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+      responses: {
+        key: "500"
+        value: {
+          description: "Internal Server Error"
+          schema: {
+            json_schema: {
+              ref: "#/definitions/v2ErrorResponse"
+            }
+          }
+        }
+      }
+    };
+  }
+
   rpc QueryInsightsPrompt(QueryInsightsPromptRequest) returns (QueryInsightsPromptResponse) {
     option (google.api.http) = {
       post: "/insights/query/prompt",
@@ -2149,6 +2222,44 @@ message QueryInsightsPromptData {
   repeated InsightsDiagnostic diagnostics = 2 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Any non-fatal diagnostics or warnings about the generated query"
+    }
+  ];
+}
+
+message ListInsightsEventSchemasRequest {
+  optional string cursor = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Pagination cursor from previous response"
+    }
+  ];
+  optional int32 limit = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Number of event schemas to return per page (min: 1, max: 100)"
+      default: "20"
+    }
+  ];
+}
+
+message ListInsightsEventSchemasResponse {
+  repeated InsightsEventSchema data = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Paginated list of event type schemas"
+    }
+  ];
+  ResponseMetadata metadata = 2;
+  Page page = 3;
+}
+
+message InsightsEventSchema {
+  string name = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Event type name"
+      example: "\"orders/payment.created\""
+    }
+  ];
+  google.protobuf.Struct schema = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "JSON Schema describing the shape of this event's data, represented as a nested JSON object"
     }
   ];
 }

--- a/proto/gen/api/v2/apiv2connect/service.connect.go
+++ b/proto/gen/api/v2/apiv2connect/service.connect.go
@@ -67,6 +67,8 @@ const (
 	V2GetFunctionTraceProcedure = "/api.v2.V2/GetFunctionTrace"
 	// V2InvokeFunctionProcedure is the fully-qualified name of the V2's InvokeFunction RPC.
 	V2InvokeFunctionProcedure = "/api.v2.V2/InvokeFunction"
+	// V2QueryInsightsProcedure is the fully-qualified name of the V2's QueryInsights RPC.
+	V2QueryInsightsProcedure = "/api.v2.V2/QueryInsights"
 )
 
 // V2Client is a client for the api.v2.V2 service.
@@ -90,6 +92,7 @@ type V2Client interface {
 	SyncApp(context.Context, *connect.Request[v2.SyncAppRequest]) (*connect.Response[v2.SyncAppResponse], error)
 	GetFunctionTrace(context.Context, *connect.Request[v2.GetFunctionTraceRequest]) (*connect.Response[v2.GetFunctionTraceResponse], error)
 	InvokeFunction(context.Context, *connect.Request[v2.InvokeFunctionRequest]) (*connect.Response[v2.InvokeFunctionResponse], error)
+	QueryInsights(context.Context, *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error)
 }
 
 // NewV2Client constructs a client for the api.v2.V2 service. By default, it uses the Connect
@@ -199,6 +202,12 @@ func NewV2Client(httpClient connect.HTTPClient, baseURL string, opts ...connect.
 			connect.WithSchema(v2Methods.ByName("InvokeFunction")),
 			connect.WithClientOptions(opts...),
 		),
+		queryInsights: connect.NewClient[v2.QueryInsightsRequest, v2.QueryInsightsResponse](
+			httpClient,
+			baseURL+V2QueryInsightsProcedure,
+			connect.WithSchema(v2Methods.ByName("QueryInsights")),
+			connect.WithClientOptions(opts...),
+		),
 	}
 }
 
@@ -220,6 +229,7 @@ type v2Client struct {
 	syncApp                 *connect.Client[v2.SyncAppRequest, v2.SyncAppResponse]
 	getFunctionTrace        *connect.Client[v2.GetFunctionTraceRequest, v2.GetFunctionTraceResponse]
 	invokeFunction          *connect.Client[v2.InvokeFunctionRequest, v2.InvokeFunctionResponse]
+	queryInsights           *connect.Client[v2.QueryInsightsRequest, v2.QueryInsightsResponse]
 }
 
 // Health calls api.v2.V2.Health.
@@ -302,6 +312,11 @@ func (c *v2Client) InvokeFunction(ctx context.Context, req *connect.Request[v2.I
 	return c.invokeFunction.CallUnary(ctx, req)
 }
 
+// QueryInsights calls api.v2.V2.QueryInsights.
+func (c *v2Client) QueryInsights(ctx context.Context, req *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error) {
+	return c.queryInsights.CallUnary(ctx, req)
+}
+
 // V2Handler is an implementation of the api.v2.V2 service.
 type V2Handler interface {
 	Health(context.Context, *connect.Request[v2.HealthRequest]) (*connect.Response[v2.HealthResponse], error)
@@ -323,6 +338,7 @@ type V2Handler interface {
 	SyncApp(context.Context, *connect.Request[v2.SyncAppRequest]) (*connect.Response[v2.SyncAppResponse], error)
 	GetFunctionTrace(context.Context, *connect.Request[v2.GetFunctionTraceRequest]) (*connect.Response[v2.GetFunctionTraceResponse], error)
 	InvokeFunction(context.Context, *connect.Request[v2.InvokeFunctionRequest]) (*connect.Response[v2.InvokeFunctionResponse], error)
+	QueryInsights(context.Context, *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error)
 }
 
 // NewV2Handler builds an HTTP handler from the service implementation. It returns the path on which
@@ -428,6 +444,12 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 		connect.WithSchema(v2Methods.ByName("InvokeFunction")),
 		connect.WithHandlerOptions(opts...),
 	)
+	v2QueryInsightsHandler := connect.NewUnaryHandler(
+		V2QueryInsightsProcedure,
+		svc.QueryInsights,
+		connect.WithSchema(v2Methods.ByName("QueryInsights")),
+		connect.WithHandlerOptions(opts...),
+	)
 	return "/api.v2.V2/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case V2HealthProcedure:
@@ -462,6 +484,8 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 			v2GetFunctionTraceHandler.ServeHTTP(w, r)
 		case V2InvokeFunctionProcedure:
 			v2InvokeFunctionHandler.ServeHTTP(w, r)
+		case V2QueryInsightsProcedure:
+			v2QueryInsightsHandler.ServeHTTP(w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -533,4 +557,8 @@ func (UnimplementedV2Handler) GetFunctionTrace(context.Context, *connect.Request
 
 func (UnimplementedV2Handler) InvokeFunction(context.Context, *connect.Request[v2.InvokeFunctionRequest]) (*connect.Response[v2.InvokeFunctionResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.InvokeFunction is not implemented"))
+}
+
+func (UnimplementedV2Handler) QueryInsights(context.Context, *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.QueryInsights is not implemented"))
 }

--- a/proto/gen/api/v2/apiv2connect/service.connect.go
+++ b/proto/gen/api/v2/apiv2connect/service.connect.go
@@ -69,6 +69,8 @@ const (
 	V2InvokeFunctionProcedure = "/api.v2.V2/InvokeFunction"
 	// V2ListInsightsTablesProcedure is the fully-qualified name of the V2's ListInsightsTables RPC.
 	V2ListInsightsTablesProcedure = "/api.v2.V2/ListInsightsTables"
+	// V2QueryInsightsPromptProcedure is the fully-qualified name of the V2's QueryInsightsPrompt RPC.
+	V2QueryInsightsPromptProcedure = "/api.v2.V2/QueryInsightsPrompt"
 	// V2QueryInsightsProcedure is the fully-qualified name of the V2's QueryInsights RPC.
 	V2QueryInsightsProcedure = "/api.v2.V2/QueryInsights"
 )
@@ -95,6 +97,7 @@ type V2Client interface {
 	GetFunctionTrace(context.Context, *connect.Request[v2.GetFunctionTraceRequest]) (*connect.Response[v2.GetFunctionTraceResponse], error)
 	InvokeFunction(context.Context, *connect.Request[v2.InvokeFunctionRequest]) (*connect.Response[v2.InvokeFunctionResponse], error)
 	ListInsightsTables(context.Context, *connect.Request[v2.ListInsightsTablesRequest]) (*connect.Response[v2.ListInsightsTablesResponse], error)
+	QueryInsightsPrompt(context.Context, *connect.Request[v2.QueryInsightsPromptRequest]) (*connect.Response[v2.QueryInsightsPromptResponse], error)
 	QueryInsights(context.Context, *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error)
 }
 
@@ -211,6 +214,12 @@ func NewV2Client(httpClient connect.HTTPClient, baseURL string, opts ...connect.
 			connect.WithSchema(v2Methods.ByName("ListInsightsTables")),
 			connect.WithClientOptions(opts...),
 		),
+		queryInsightsPrompt: connect.NewClient[v2.QueryInsightsPromptRequest, v2.QueryInsightsPromptResponse](
+			httpClient,
+			baseURL+V2QueryInsightsPromptProcedure,
+			connect.WithSchema(v2Methods.ByName("QueryInsightsPrompt")),
+			connect.WithClientOptions(opts...),
+		),
 		queryInsights: connect.NewClient[v2.QueryInsightsRequest, v2.QueryInsightsResponse](
 			httpClient,
 			baseURL+V2QueryInsightsProcedure,
@@ -239,6 +248,7 @@ type v2Client struct {
 	getFunctionTrace        *connect.Client[v2.GetFunctionTraceRequest, v2.GetFunctionTraceResponse]
 	invokeFunction          *connect.Client[v2.InvokeFunctionRequest, v2.InvokeFunctionResponse]
 	listInsightsTables      *connect.Client[v2.ListInsightsTablesRequest, v2.ListInsightsTablesResponse]
+	queryInsightsPrompt     *connect.Client[v2.QueryInsightsPromptRequest, v2.QueryInsightsPromptResponse]
 	queryInsights           *connect.Client[v2.QueryInsightsRequest, v2.QueryInsightsResponse]
 }
 
@@ -327,6 +337,11 @@ func (c *v2Client) ListInsightsTables(ctx context.Context, req *connect.Request[
 	return c.listInsightsTables.CallUnary(ctx, req)
 }
 
+// QueryInsightsPrompt calls api.v2.V2.QueryInsightsPrompt.
+func (c *v2Client) QueryInsightsPrompt(ctx context.Context, req *connect.Request[v2.QueryInsightsPromptRequest]) (*connect.Response[v2.QueryInsightsPromptResponse], error) {
+	return c.queryInsightsPrompt.CallUnary(ctx, req)
+}
+
 // QueryInsights calls api.v2.V2.QueryInsights.
 func (c *v2Client) QueryInsights(ctx context.Context, req *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error) {
 	return c.queryInsights.CallUnary(ctx, req)
@@ -354,6 +369,7 @@ type V2Handler interface {
 	GetFunctionTrace(context.Context, *connect.Request[v2.GetFunctionTraceRequest]) (*connect.Response[v2.GetFunctionTraceResponse], error)
 	InvokeFunction(context.Context, *connect.Request[v2.InvokeFunctionRequest]) (*connect.Response[v2.InvokeFunctionResponse], error)
 	ListInsightsTables(context.Context, *connect.Request[v2.ListInsightsTablesRequest]) (*connect.Response[v2.ListInsightsTablesResponse], error)
+	QueryInsightsPrompt(context.Context, *connect.Request[v2.QueryInsightsPromptRequest]) (*connect.Response[v2.QueryInsightsPromptResponse], error)
 	QueryInsights(context.Context, *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error)
 }
 
@@ -466,6 +482,12 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 		connect.WithSchema(v2Methods.ByName("ListInsightsTables")),
 		connect.WithHandlerOptions(opts...),
 	)
+	v2QueryInsightsPromptHandler := connect.NewUnaryHandler(
+		V2QueryInsightsPromptProcedure,
+		svc.QueryInsightsPrompt,
+		connect.WithSchema(v2Methods.ByName("QueryInsightsPrompt")),
+		connect.WithHandlerOptions(opts...),
+	)
 	v2QueryInsightsHandler := connect.NewUnaryHandler(
 		V2QueryInsightsProcedure,
 		svc.QueryInsights,
@@ -508,6 +530,8 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 			v2InvokeFunctionHandler.ServeHTTP(w, r)
 		case V2ListInsightsTablesProcedure:
 			v2ListInsightsTablesHandler.ServeHTTP(w, r)
+		case V2QueryInsightsPromptProcedure:
+			v2QueryInsightsPromptHandler.ServeHTTP(w, r)
 		case V2QueryInsightsProcedure:
 			v2QueryInsightsHandler.ServeHTTP(w, r)
 		default:
@@ -585,6 +609,10 @@ func (UnimplementedV2Handler) InvokeFunction(context.Context, *connect.Request[v
 
 func (UnimplementedV2Handler) ListInsightsTables(context.Context, *connect.Request[v2.ListInsightsTablesRequest]) (*connect.Response[v2.ListInsightsTablesResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.ListInsightsTables is not implemented"))
+}
+
+func (UnimplementedV2Handler) QueryInsightsPrompt(context.Context, *connect.Request[v2.QueryInsightsPromptRequest]) (*connect.Response[v2.QueryInsightsPromptResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.QueryInsightsPrompt is not implemented"))
 }
 
 func (UnimplementedV2Handler) QueryInsights(context.Context, *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error) {

--- a/proto/gen/api/v2/apiv2connect/service.connect.go
+++ b/proto/gen/api/v2/apiv2connect/service.connect.go
@@ -67,6 +67,8 @@ const (
 	V2GetFunctionTraceProcedure = "/api.v2.V2/GetFunctionTrace"
 	// V2InvokeFunctionProcedure is the fully-qualified name of the V2's InvokeFunction RPC.
 	V2InvokeFunctionProcedure = "/api.v2.V2/InvokeFunction"
+	// V2ListInsightsTablesProcedure is the fully-qualified name of the V2's ListInsightsTables RPC.
+	V2ListInsightsTablesProcedure = "/api.v2.V2/ListInsightsTables"
 	// V2QueryInsightsProcedure is the fully-qualified name of the V2's QueryInsights RPC.
 	V2QueryInsightsProcedure = "/api.v2.V2/QueryInsights"
 )
@@ -92,6 +94,7 @@ type V2Client interface {
 	SyncApp(context.Context, *connect.Request[v2.SyncAppRequest]) (*connect.Response[v2.SyncAppResponse], error)
 	GetFunctionTrace(context.Context, *connect.Request[v2.GetFunctionTraceRequest]) (*connect.Response[v2.GetFunctionTraceResponse], error)
 	InvokeFunction(context.Context, *connect.Request[v2.InvokeFunctionRequest]) (*connect.Response[v2.InvokeFunctionResponse], error)
+	ListInsightsTables(context.Context, *connect.Request[v2.ListInsightsTablesRequest]) (*connect.Response[v2.ListInsightsTablesResponse], error)
 	QueryInsights(context.Context, *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error)
 }
 
@@ -202,6 +205,12 @@ func NewV2Client(httpClient connect.HTTPClient, baseURL string, opts ...connect.
 			connect.WithSchema(v2Methods.ByName("InvokeFunction")),
 			connect.WithClientOptions(opts...),
 		),
+		listInsightsTables: connect.NewClient[v2.ListInsightsTablesRequest, v2.ListInsightsTablesResponse](
+			httpClient,
+			baseURL+V2ListInsightsTablesProcedure,
+			connect.WithSchema(v2Methods.ByName("ListInsightsTables")),
+			connect.WithClientOptions(opts...),
+		),
 		queryInsights: connect.NewClient[v2.QueryInsightsRequest, v2.QueryInsightsResponse](
 			httpClient,
 			baseURL+V2QueryInsightsProcedure,
@@ -229,6 +238,7 @@ type v2Client struct {
 	syncApp                 *connect.Client[v2.SyncAppRequest, v2.SyncAppResponse]
 	getFunctionTrace        *connect.Client[v2.GetFunctionTraceRequest, v2.GetFunctionTraceResponse]
 	invokeFunction          *connect.Client[v2.InvokeFunctionRequest, v2.InvokeFunctionResponse]
+	listInsightsTables      *connect.Client[v2.ListInsightsTablesRequest, v2.ListInsightsTablesResponse]
 	queryInsights           *connect.Client[v2.QueryInsightsRequest, v2.QueryInsightsResponse]
 }
 
@@ -312,6 +322,11 @@ func (c *v2Client) InvokeFunction(ctx context.Context, req *connect.Request[v2.I
 	return c.invokeFunction.CallUnary(ctx, req)
 }
 
+// ListInsightsTables calls api.v2.V2.ListInsightsTables.
+func (c *v2Client) ListInsightsTables(ctx context.Context, req *connect.Request[v2.ListInsightsTablesRequest]) (*connect.Response[v2.ListInsightsTablesResponse], error) {
+	return c.listInsightsTables.CallUnary(ctx, req)
+}
+
 // QueryInsights calls api.v2.V2.QueryInsights.
 func (c *v2Client) QueryInsights(ctx context.Context, req *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error) {
 	return c.queryInsights.CallUnary(ctx, req)
@@ -338,6 +353,7 @@ type V2Handler interface {
 	SyncApp(context.Context, *connect.Request[v2.SyncAppRequest]) (*connect.Response[v2.SyncAppResponse], error)
 	GetFunctionTrace(context.Context, *connect.Request[v2.GetFunctionTraceRequest]) (*connect.Response[v2.GetFunctionTraceResponse], error)
 	InvokeFunction(context.Context, *connect.Request[v2.InvokeFunctionRequest]) (*connect.Response[v2.InvokeFunctionResponse], error)
+	ListInsightsTables(context.Context, *connect.Request[v2.ListInsightsTablesRequest]) (*connect.Response[v2.ListInsightsTablesResponse], error)
 	QueryInsights(context.Context, *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error)
 }
 
@@ -444,6 +460,12 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 		connect.WithSchema(v2Methods.ByName("InvokeFunction")),
 		connect.WithHandlerOptions(opts...),
 	)
+	v2ListInsightsTablesHandler := connect.NewUnaryHandler(
+		V2ListInsightsTablesProcedure,
+		svc.ListInsightsTables,
+		connect.WithSchema(v2Methods.ByName("ListInsightsTables")),
+		connect.WithHandlerOptions(opts...),
+	)
 	v2QueryInsightsHandler := connect.NewUnaryHandler(
 		V2QueryInsightsProcedure,
 		svc.QueryInsights,
@@ -484,6 +506,8 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 			v2GetFunctionTraceHandler.ServeHTTP(w, r)
 		case V2InvokeFunctionProcedure:
 			v2InvokeFunctionHandler.ServeHTTP(w, r)
+		case V2ListInsightsTablesProcedure:
+			v2ListInsightsTablesHandler.ServeHTTP(w, r)
 		case V2QueryInsightsProcedure:
 			v2QueryInsightsHandler.ServeHTTP(w, r)
 		default:
@@ -557,6 +581,10 @@ func (UnimplementedV2Handler) GetFunctionTrace(context.Context, *connect.Request
 
 func (UnimplementedV2Handler) InvokeFunction(context.Context, *connect.Request[v2.InvokeFunctionRequest]) (*connect.Response[v2.InvokeFunctionResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.InvokeFunction is not implemented"))
+}
+
+func (UnimplementedV2Handler) ListInsightsTables(context.Context, *connect.Request[v2.ListInsightsTablesRequest]) (*connect.Response[v2.ListInsightsTablesResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.ListInsightsTables is not implemented"))
 }
 
 func (UnimplementedV2Handler) QueryInsights(context.Context, *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error) {

--- a/proto/gen/api/v2/apiv2connect/service.connect.go
+++ b/proto/gen/api/v2/apiv2connect/service.connect.go
@@ -69,6 +69,9 @@ const (
 	V2InvokeFunctionProcedure = "/api.v2.V2/InvokeFunction"
 	// V2ListInsightsTablesProcedure is the fully-qualified name of the V2's ListInsightsTables RPC.
 	V2ListInsightsTablesProcedure = "/api.v2.V2/ListInsightsTables"
+	// V2ListInsightsEventSchemasProcedure is the fully-qualified name of the V2's
+	// ListInsightsEventSchemas RPC.
+	V2ListInsightsEventSchemasProcedure = "/api.v2.V2/ListInsightsEventSchemas"
 	// V2QueryInsightsPromptProcedure is the fully-qualified name of the V2's QueryInsightsPrompt RPC.
 	V2QueryInsightsPromptProcedure = "/api.v2.V2/QueryInsightsPrompt"
 	// V2QueryInsightsProcedure is the fully-qualified name of the V2's QueryInsights RPC.
@@ -97,6 +100,7 @@ type V2Client interface {
 	GetFunctionTrace(context.Context, *connect.Request[v2.GetFunctionTraceRequest]) (*connect.Response[v2.GetFunctionTraceResponse], error)
 	InvokeFunction(context.Context, *connect.Request[v2.InvokeFunctionRequest]) (*connect.Response[v2.InvokeFunctionResponse], error)
 	ListInsightsTables(context.Context, *connect.Request[v2.ListInsightsTablesRequest]) (*connect.Response[v2.ListInsightsTablesResponse], error)
+	ListInsightsEventSchemas(context.Context, *connect.Request[v2.ListInsightsEventSchemasRequest]) (*connect.Response[v2.ListInsightsEventSchemasResponse], error)
 	QueryInsightsPrompt(context.Context, *connect.Request[v2.QueryInsightsPromptRequest]) (*connect.Response[v2.QueryInsightsPromptResponse], error)
 	QueryInsights(context.Context, *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error)
 }
@@ -214,6 +218,12 @@ func NewV2Client(httpClient connect.HTTPClient, baseURL string, opts ...connect.
 			connect.WithSchema(v2Methods.ByName("ListInsightsTables")),
 			connect.WithClientOptions(opts...),
 		),
+		listInsightsEventSchemas: connect.NewClient[v2.ListInsightsEventSchemasRequest, v2.ListInsightsEventSchemasResponse](
+			httpClient,
+			baseURL+V2ListInsightsEventSchemasProcedure,
+			connect.WithSchema(v2Methods.ByName("ListInsightsEventSchemas")),
+			connect.WithClientOptions(opts...),
+		),
 		queryInsightsPrompt: connect.NewClient[v2.QueryInsightsPromptRequest, v2.QueryInsightsPromptResponse](
 			httpClient,
 			baseURL+V2QueryInsightsPromptProcedure,
@@ -231,25 +241,26 @@ func NewV2Client(httpClient connect.HTTPClient, baseURL string, opts ...connect.
 
 // v2Client implements V2Client.
 type v2Client struct {
-	health                  *connect.Client[v2.HealthRequest, v2.HealthResponse]
-	xSchemaOnly             *connect.Client[v2.HealthRequest, v2.ErrorResponse]
-	createPartnerAccount    *connect.Client[v2.CreateAccountRequest, v2.CreateAccountResponse]
-	createEnv               *connect.Client[v2.CreateEnvRequest, v2.CreateEnvResponse]
-	fetchPartnerAccounts    *connect.Client[v2.FetchAccountsRequest, v2.FetchAccountsResponse]
-	fetchAccount            *connect.Client[v2.FetchAccountRequest, v2.FetchAccountResponse]
-	fetchAccountEnvs        *connect.Client[v2.FetchAccountEnvsRequest, v2.FetchAccountEnvsResponse]
-	fetchAccountEventKeys   *connect.Client[v2.FetchAccountEventKeysRequest, v2.FetchAccountEventKeysResponse]
-	fetchAccountSigningKeys *connect.Client[v2.FetchAccountSigningKeysRequest, v2.FetchAccountSigningKeysResponse]
-	createWebhook           *connect.Client[v2.CreateWebhookRequest, v2.CreateWebhookResponse]
-	listWebhooks            *connect.Client[v2.ListWebhooksRequest, v2.ListWebhooksResponse]
-	patchEnv                *connect.Client[v2.PatchEnvRequest, v2.PatchEnvsResponse]
-	getFunctionRun          *connect.Client[v2.GetFunctionRunRequest, v2.GetFunctionRunResponse]
-	syncApp                 *connect.Client[v2.SyncAppRequest, v2.SyncAppResponse]
-	getFunctionTrace        *connect.Client[v2.GetFunctionTraceRequest, v2.GetFunctionTraceResponse]
-	invokeFunction          *connect.Client[v2.InvokeFunctionRequest, v2.InvokeFunctionResponse]
-	listInsightsTables      *connect.Client[v2.ListInsightsTablesRequest, v2.ListInsightsTablesResponse]
-	queryInsightsPrompt     *connect.Client[v2.QueryInsightsPromptRequest, v2.QueryInsightsPromptResponse]
-	queryInsights           *connect.Client[v2.QueryInsightsRequest, v2.QueryInsightsResponse]
+	health                   *connect.Client[v2.HealthRequest, v2.HealthResponse]
+	xSchemaOnly              *connect.Client[v2.HealthRequest, v2.ErrorResponse]
+	createPartnerAccount     *connect.Client[v2.CreateAccountRequest, v2.CreateAccountResponse]
+	createEnv                *connect.Client[v2.CreateEnvRequest, v2.CreateEnvResponse]
+	fetchPartnerAccounts     *connect.Client[v2.FetchAccountsRequest, v2.FetchAccountsResponse]
+	fetchAccount             *connect.Client[v2.FetchAccountRequest, v2.FetchAccountResponse]
+	fetchAccountEnvs         *connect.Client[v2.FetchAccountEnvsRequest, v2.FetchAccountEnvsResponse]
+	fetchAccountEventKeys    *connect.Client[v2.FetchAccountEventKeysRequest, v2.FetchAccountEventKeysResponse]
+	fetchAccountSigningKeys  *connect.Client[v2.FetchAccountSigningKeysRequest, v2.FetchAccountSigningKeysResponse]
+	createWebhook            *connect.Client[v2.CreateWebhookRequest, v2.CreateWebhookResponse]
+	listWebhooks             *connect.Client[v2.ListWebhooksRequest, v2.ListWebhooksResponse]
+	patchEnv                 *connect.Client[v2.PatchEnvRequest, v2.PatchEnvsResponse]
+	getFunctionRun           *connect.Client[v2.GetFunctionRunRequest, v2.GetFunctionRunResponse]
+	syncApp                  *connect.Client[v2.SyncAppRequest, v2.SyncAppResponse]
+	getFunctionTrace         *connect.Client[v2.GetFunctionTraceRequest, v2.GetFunctionTraceResponse]
+	invokeFunction           *connect.Client[v2.InvokeFunctionRequest, v2.InvokeFunctionResponse]
+	listInsightsTables       *connect.Client[v2.ListInsightsTablesRequest, v2.ListInsightsTablesResponse]
+	listInsightsEventSchemas *connect.Client[v2.ListInsightsEventSchemasRequest, v2.ListInsightsEventSchemasResponse]
+	queryInsightsPrompt      *connect.Client[v2.QueryInsightsPromptRequest, v2.QueryInsightsPromptResponse]
+	queryInsights            *connect.Client[v2.QueryInsightsRequest, v2.QueryInsightsResponse]
 }
 
 // Health calls api.v2.V2.Health.
@@ -337,6 +348,11 @@ func (c *v2Client) ListInsightsTables(ctx context.Context, req *connect.Request[
 	return c.listInsightsTables.CallUnary(ctx, req)
 }
 
+// ListInsightsEventSchemas calls api.v2.V2.ListInsightsEventSchemas.
+func (c *v2Client) ListInsightsEventSchemas(ctx context.Context, req *connect.Request[v2.ListInsightsEventSchemasRequest]) (*connect.Response[v2.ListInsightsEventSchemasResponse], error) {
+	return c.listInsightsEventSchemas.CallUnary(ctx, req)
+}
+
 // QueryInsightsPrompt calls api.v2.V2.QueryInsightsPrompt.
 func (c *v2Client) QueryInsightsPrompt(ctx context.Context, req *connect.Request[v2.QueryInsightsPromptRequest]) (*connect.Response[v2.QueryInsightsPromptResponse], error) {
 	return c.queryInsightsPrompt.CallUnary(ctx, req)
@@ -369,6 +385,7 @@ type V2Handler interface {
 	GetFunctionTrace(context.Context, *connect.Request[v2.GetFunctionTraceRequest]) (*connect.Response[v2.GetFunctionTraceResponse], error)
 	InvokeFunction(context.Context, *connect.Request[v2.InvokeFunctionRequest]) (*connect.Response[v2.InvokeFunctionResponse], error)
 	ListInsightsTables(context.Context, *connect.Request[v2.ListInsightsTablesRequest]) (*connect.Response[v2.ListInsightsTablesResponse], error)
+	ListInsightsEventSchemas(context.Context, *connect.Request[v2.ListInsightsEventSchemasRequest]) (*connect.Response[v2.ListInsightsEventSchemasResponse], error)
 	QueryInsightsPrompt(context.Context, *connect.Request[v2.QueryInsightsPromptRequest]) (*connect.Response[v2.QueryInsightsPromptResponse], error)
 	QueryInsights(context.Context, *connect.Request[v2.QueryInsightsRequest]) (*connect.Response[v2.QueryInsightsResponse], error)
 }
@@ -482,6 +499,12 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 		connect.WithSchema(v2Methods.ByName("ListInsightsTables")),
 		connect.WithHandlerOptions(opts...),
 	)
+	v2ListInsightsEventSchemasHandler := connect.NewUnaryHandler(
+		V2ListInsightsEventSchemasProcedure,
+		svc.ListInsightsEventSchemas,
+		connect.WithSchema(v2Methods.ByName("ListInsightsEventSchemas")),
+		connect.WithHandlerOptions(opts...),
+	)
 	v2QueryInsightsPromptHandler := connect.NewUnaryHandler(
 		V2QueryInsightsPromptProcedure,
 		svc.QueryInsightsPrompt,
@@ -530,6 +553,8 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 			v2InvokeFunctionHandler.ServeHTTP(w, r)
 		case V2ListInsightsTablesProcedure:
 			v2ListInsightsTablesHandler.ServeHTTP(w, r)
+		case V2ListInsightsEventSchemasProcedure:
+			v2ListInsightsEventSchemasHandler.ServeHTTP(w, r)
 		case V2QueryInsightsPromptProcedure:
 			v2QueryInsightsPromptHandler.ServeHTTP(w, r)
 		case V2QueryInsightsProcedure:
@@ -609,6 +634,10 @@ func (UnimplementedV2Handler) InvokeFunction(context.Context, *connect.Request[v
 
 func (UnimplementedV2Handler) ListInsightsTables(context.Context, *connect.Request[v2.ListInsightsTablesRequest]) (*connect.Response[v2.ListInsightsTablesResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.ListInsightsTables is not implemented"))
+}
+
+func (UnimplementedV2Handler) ListInsightsEventSchemas(context.Context, *connect.Request[v2.ListInsightsEventSchemasRequest]) (*connect.Response[v2.ListInsightsEventSchemasResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.ListInsightsEventSchemas is not implemented"))
 }
 
 func (UnimplementedV2Handler) QueryInsightsPrompt(context.Context, *connect.Request[v2.QueryInsightsPromptRequest]) (*connect.Response[v2.QueryInsightsPromptResponse], error) {

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -4251,8 +4251,8 @@ func (x *QueryInsightsPromptResponse) GetMetadata() *ResponseMetadata {
 
 type QueryInsightsPromptData struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Query         string                 `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
-	Diagnostics   []*InsightsDiagnostic  `protobuf:"bytes,2,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
+	Sql           string                 `protobuf:"bytes,1,opt,name=sql,proto3" json:"sql,omitempty"`
+	Summary       string                 `protobuf:"bytes,2,opt,name=summary,proto3" json:"summary,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4287,18 +4287,18 @@ func (*QueryInsightsPromptData) Descriptor() ([]byte, []int) {
 	return file_api_v2_service_proto_rawDescGZIP(), []int{65}
 }
 
-func (x *QueryInsightsPromptData) GetQuery() string {
+func (x *QueryInsightsPromptData) GetSql() string {
 	if x != nil {
-		return x.Query
+		return x.Sql
 	}
 	return ""
 }
 
-func (x *QueryInsightsPromptData) GetDiagnostics() []*InsightsDiagnostic {
+func (x *QueryInsightsPromptData) GetSummary() string {
 	if x != nil {
-		return x.Diagnostics
+		return x.Summary
 	}
-	return nil
+	return ""
 }
 
 type ListInsightsEventSchemasRequest struct {
@@ -4785,10 +4785,10 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x06prompt\x18\x01 \x01(\tB}\x92Az25Natural language description of the query to generateJA\"Show me the top 10 functions by failure rate in the last 7 days\"R\x06prompt\"\x88\x01\n" +
 	"\x1bQueryInsightsPromptResponse\x123\n" +
 	"\x04data\x18\x01 \x01(\v2\x1f.api.v2.QueryInsightsPromptDataR\x04data\x124\n" +
-	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\xc9\x03\n" +
-	"\x17QueryInsightsPromptData\x12\xa8\x02\n" +
-	"\x05query\x18\x01 \x01(\tB\x91\x02\x92A\x8d\x022 The generated Insights SQL queryJ\xe8\x01\"SELECT function_id, COUNT(*) AS total, countIf(status = 'Failed') AS failures, failures / total AS failure_rate FROM function_runs WHERE started_at >= now() - INTERVAL 7 DAY GROUP BY function_id ORDER BY failure_rate DESC LIMIT 10\"R\x05query\x12\x82\x01\n" +
-	"\vdiagnostics\x18\x02 \x03(\v2\x1a.api.v2.InsightsDiagnosticBD\x92AA2?Any non-fatal diagnostics or warnings about the generated queryR\vdiagnostics\"\xe5\x01\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\x8e\x05\n" +
+	"\x17QueryInsightsPromptData\x12\xa4\x02\n" +
+	"\x03sql\x18\x01 \x01(\tB\x91\x02\x92A\x8d\x022 The generated Insights SQL queryJ\xe8\x01\"SELECT function_id, COUNT(*) AS total, countIf(status = 'Failed') AS failures, failures / total AS failure_rate FROM function_runs WHERE started_at >= now() - INTERVAL 7 DAY GROUP BY function_id ORDER BY failure_rate DESC LIMIT 10\"R\x03sql\x12\xcb\x02\n" +
+	"\asummary\x18\x02 \x01(\tB\xb0\x02\x92A\xac\x022eA natural language summary of the generated query, useful for explaining the query's intent to agentsJ\xc2\x01\"This query retrieves the top 10 functions with the highest failure rate over the past week, showing the total number of runs, number of failures, and calculated failure rate for each function.\"R\asummary\"\xe5\x01\n" +
 	"\x1fListInsightsEventSchemasRequest\x12J\n" +
 	"\x06cursor\x18\x01 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x00R\x06cursor\x88\x01\x01\x12a\n" +
 	"\x05limit\x18\x02 \x01(\x05BF\x92AC2=Number of event schemas to return per page (min: 1, max: 100):\x0220H\x01R\x05limit\x88\x01\x01B\t\n" +
@@ -5465,56 +5465,55 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	69,  // 87: api.v2.InsightsTable.columns:type_name -> api.v2.InsightsTableColumn
 	72,  // 88: api.v2.QueryInsightsPromptResponse.data:type_name -> api.v2.QueryInsightsPromptData
 	13,  // 89: api.v2.QueryInsightsPromptResponse.metadata:type_name -> api.v2.ResponseMetadata
-	64,  // 90: api.v2.QueryInsightsPromptData.diagnostics:type_name -> api.v2.InsightsDiagnostic
-	75,  // 91: api.v2.ListInsightsEventSchemasResponse.data:type_name -> api.v2.InsightsEventSchema
-	13,  // 92: api.v2.ListInsightsEventSchemasResponse.metadata:type_name -> api.v2.ResponseMetadata
-	35,  // 93: api.v2.ListInsightsEventSchemasResponse.page:type_name -> api.v2.Page
-	78,  // 94: api.v2.InsightsEventSchema.schema:type_name -> google.protobuf.Struct
-	7,   // 95: api.v2.V2.Health:input_type -> api.v2.HealthRequest
-	7,   // 96: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
-	25,  // 97: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
-	27,  // 98: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
-	31,  // 99: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
-	8,   // 100: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
-	39,  // 101: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
-	36,  // 102: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
-	41,  // 103: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
-	44,  // 104: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
-	47,  // 105: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
-	50,  // 106: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
-	18,  // 107: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
-	55,  // 108: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
-	23,  // 109: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
-	52,  // 110: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
-	66,  // 111: api.v2.V2.ListInsightsTables:input_type -> api.v2.ListInsightsTablesRequest
-	73,  // 112: api.v2.V2.ListInsightsEventSchemas:input_type -> api.v2.ListInsightsEventSchemasRequest
-	70,  // 113: api.v2.V2.QueryInsightsPrompt:input_type -> api.v2.QueryInsightsPromptRequest
-	59,  // 114: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
-	9,   // 115: api.v2.V2.Health:output_type -> api.v2.HealthResponse
-	12,  // 116: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
-	26,  // 117: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
-	28,  // 118: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
-	32,  // 119: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
-	33,  // 120: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
-	40,  // 121: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
-	37,  // 122: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
-	42,  // 123: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
-	45,  // 124: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
-	48,  // 125: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
-	51,  // 126: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
-	19,  // 127: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
-	56,  // 128: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
-	24,  // 129: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
-	53,  // 130: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
-	67,  // 131: api.v2.V2.ListInsightsTables:output_type -> api.v2.ListInsightsTablesResponse
-	74,  // 132: api.v2.V2.ListInsightsEventSchemas:output_type -> api.v2.ListInsightsEventSchemasResponse
-	71,  // 133: api.v2.V2.QueryInsightsPrompt:output_type -> api.v2.QueryInsightsPromptResponse
-	60,  // 134: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
-	115, // [115:135] is the sub-list for method output_type
-	95,  // [95:115] is the sub-list for method input_type
-	95,  // [95:95] is the sub-list for extension type_name
-	95,  // [95:95] is the sub-list for extension extendee
-	0,   // [0:95] is the sub-list for field type_name
+	75,  // 90: api.v2.ListInsightsEventSchemasResponse.data:type_name -> api.v2.InsightsEventSchema
+	13,  // 91: api.v2.ListInsightsEventSchemasResponse.metadata:type_name -> api.v2.ResponseMetadata
+	35,  // 92: api.v2.ListInsightsEventSchemasResponse.page:type_name -> api.v2.Page
+	78,  // 93: api.v2.InsightsEventSchema.schema:type_name -> google.protobuf.Struct
+	7,   // 94: api.v2.V2.Health:input_type -> api.v2.HealthRequest
+	7,   // 95: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
+	25,  // 96: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
+	27,  // 97: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
+	31,  // 98: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
+	8,   // 99: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
+	39,  // 100: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
+	36,  // 101: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
+	41,  // 102: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
+	44,  // 103: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
+	47,  // 104: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
+	50,  // 105: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
+	18,  // 106: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
+	55,  // 107: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
+	23,  // 108: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
+	52,  // 109: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
+	66,  // 110: api.v2.V2.ListInsightsTables:input_type -> api.v2.ListInsightsTablesRequest
+	73,  // 111: api.v2.V2.ListInsightsEventSchemas:input_type -> api.v2.ListInsightsEventSchemasRequest
+	70,  // 112: api.v2.V2.QueryInsightsPrompt:input_type -> api.v2.QueryInsightsPromptRequest
+	59,  // 113: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
+	9,   // 114: api.v2.V2.Health:output_type -> api.v2.HealthResponse
+	12,  // 115: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
+	26,  // 116: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
+	28,  // 117: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
+	32,  // 118: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
+	33,  // 119: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
+	40,  // 120: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
+	37,  // 121: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
+	42,  // 122: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
+	45,  // 123: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
+	48,  // 124: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
+	51,  // 125: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
+	19,  // 126: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
+	56,  // 127: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
+	24,  // 128: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
+	53,  // 129: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
+	67,  // 130: api.v2.V2.ListInsightsTables:output_type -> api.v2.ListInsightsTablesResponse
+	74,  // 131: api.v2.V2.ListInsightsEventSchemas:output_type -> api.v2.ListInsightsEventSchemasResponse
+	71,  // 132: api.v2.V2.QueryInsightsPrompt:output_type -> api.v2.QueryInsightsPromptResponse
+	60,  // 133: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
+	114, // [114:134] is the sub-list for method output_type
+	94,  // [94:114] is the sub-list for method input_type
+	94,  // [94:94] is the sub-list for extension type_name
+	94,  // [94:94] is the sub-list for extension extendee
+	0,   // [0:94] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_service_proto_init() }

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -4153,6 +4153,154 @@ func (x *InsightsTableColumn) GetType() string {
 	return ""
 }
 
+type QueryInsightsPromptRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Prompt        string                 `protobuf:"bytes,1,opt,name=prompt,proto3" json:"prompt,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QueryInsightsPromptRequest) Reset() {
+	*x = QueryInsightsPromptRequest{}
+	mi := &file_api_v2_service_proto_msgTypes[63]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QueryInsightsPromptRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QueryInsightsPromptRequest) ProtoMessage() {}
+
+func (x *QueryInsightsPromptRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[63]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QueryInsightsPromptRequest.ProtoReflect.Descriptor instead.
+func (*QueryInsightsPromptRequest) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{63}
+}
+
+func (x *QueryInsightsPromptRequest) GetPrompt() string {
+	if x != nil {
+		return x.Prompt
+	}
+	return ""
+}
+
+type QueryInsightsPromptResponse struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Data          *QueryInsightsPromptData `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	Metadata      *ResponseMetadata        `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QueryInsightsPromptResponse) Reset() {
+	*x = QueryInsightsPromptResponse{}
+	mi := &file_api_v2_service_proto_msgTypes[64]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QueryInsightsPromptResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QueryInsightsPromptResponse) ProtoMessage() {}
+
+func (x *QueryInsightsPromptResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[64]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QueryInsightsPromptResponse.ProtoReflect.Descriptor instead.
+func (*QueryInsightsPromptResponse) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{64}
+}
+
+func (x *QueryInsightsPromptResponse) GetData() *QueryInsightsPromptData {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+func (x *QueryInsightsPromptResponse) GetMetadata() *ResponseMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+type QueryInsightsPromptData struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Query         string                 `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
+	Diagnostics   []*InsightsDiagnostic  `protobuf:"bytes,2,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QueryInsightsPromptData) Reset() {
+	*x = QueryInsightsPromptData{}
+	mi := &file_api_v2_service_proto_msgTypes[65]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QueryInsightsPromptData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QueryInsightsPromptData) ProtoMessage() {}
+
+func (x *QueryInsightsPromptData) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[65]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QueryInsightsPromptData.ProtoReflect.Descriptor instead.
+func (*QueryInsightsPromptData) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{65}
+}
+
+func (x *QueryInsightsPromptData) GetQuery() string {
+	if x != nil {
+		return x.Query
+	}
+	return ""
+}
+
+func (x *QueryInsightsPromptData) GetDiagnostics() []*InsightsDiagnostic {
+	if x != nil {
+		return x.Diagnostics
+	}
+	return nil
+}
+
 var File_api_v2_service_proto protoreflect.FileDescriptor
 
 const file_api_v2_service_proto_rawDesc = "" +
@@ -4468,7 +4616,15 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x13InsightsTableColumn\x12A\n" +
 	"\x04name\x18\x01 \x01(\tB-\x92A*2(Name of the column in the insights tableR\x04name\x12h\n" +
 	"\vdescription\x18\x02 \x01(\tBF\x92AC2AHuman-readable description of the column and the data it containsR\vdescription\x12a\n" +
-	"\x04type\x18\x03 \x01(\tBM\x92AJ2HData type of the column (e.g., 'String', 'Int64', 'Array(String)', etc.)R\x04type*\xdf\x01\n" +
+	"\x04type\x18\x03 \x01(\tBM\x92AJ2HData type of the column (e.g., 'String', 'Int64', 'Array(String)', etc.)R\x04type\"\xb4\x01\n" +
+	"\x1aQueryInsightsPromptRequest\x12\x95\x01\n" +
+	"\x06prompt\x18\x01 \x01(\tB}\x92Az25Natural language description of the query to generateJA\"Show me the top 10 functions by failure rate in the last 7 days\"R\x06prompt\"\x88\x01\n" +
+	"\x1bQueryInsightsPromptResponse\x123\n" +
+	"\x04data\x18\x01 \x01(\v2\x1f.api.v2.QueryInsightsPromptDataR\x04data\x124\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\xc9\x03\n" +
+	"\x17QueryInsightsPromptData\x12\xa8\x02\n" +
+	"\x05query\x18\x01 \x01(\tB\x91\x02\x92A\x8d\x022 The generated Insights SQL queryJ\xe8\x01\"SELECT function_id, COUNT(*) AS total, countIf(status = 'Failed') AS failures, failures / total AS failure_rate FROM function_runs WHERE started_at >= now() - INTERVAL 7 DAY GROUP BY function_id ORDER BY failure_rate DESC LIMIT 10\"R\x05query\x12\x82\x01\n" +
+	"\vdiagnostics\x18\x02 \x03(\v2\x1a.api.v2.InsightsDiagnosticBD\x92AA2?Any non-fatal diagnostics or warnings about the generated queryR\vdiagnostics*\xdf\x01\n" +
 	"\x11FunctionRunStatus\x12#\n" +
 	"\x1fFUNCTION_RUN_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aFUNCTION_RUN_STATUS_QUEUED\x10\x01\x12\x1f\n" +
@@ -4516,7 +4672,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05ERROR\x10\x01\x12\v\n" +
 	"\aWARNING\x10\x02\x12\b\n" +
-	"\x04INFO\x10\x032\xd0]\n" +
+	"\x04INFO\x10\x032\xe7c\n" +
 	"\x02V2\x12\xbc\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\x82\x02\x92A\xef\x01\n" +
 	"\bInternal\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
@@ -4860,7 +5016,31 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x12\x12\x10/insights/tables\x12\x8e\x06\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x12\x12\x10/insights/tables\x12\x94\x06\n" +
+	"\x13QueryInsightsPrompt\x12\".api.v2.QueryInsightsPromptRequest\x1a#.api.v2.QueryInsightsPromptResponse\"\xb3\x05\x92A\x8e\x05\n" +
+	"\bInsights\n" +
+	"\x04Beta\x12#Generate insights query from prompt\x1a@Translates a natural language prompt into an Insights SQL query.JV\n" +
+	"\x03200\x12O\n" +
+	"\x1cQuery generated successfully\x12/\n" +
+	"-\x1a+#/definitions/v2QueryInsightsPromptResponseJL\n" +
+	"\x03400\x12E\n" +
+	" Bad Request - invalid input data\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJR\n" +
+	"\x03401\x12K\n" +
+	"&Unauthorized - authentication required\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJP\n" +
+	"\x03403\x12I\n" +
+	"$Forbidden - insufficient permissions\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJt\n" +
+	"\x03422\x12m\n" +
+	"HUnprocessable Entity - prompt could not be translated into a valid query\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJA\n" +
+	"\x03500\x12:\n" +
+	"\x15Internal Server Error\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
+	"\x0e\n" +
+	"\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x1b:\x01*\"\x16/insights/query/prompt\x12\x8e\x06\n" +
 	"\rQueryInsights\x12\x1c.api.v2.QueryInsightsRequest\x1a\x1d.api.v2.QueryInsightsResponse\"\xbf\x05\x92A\xa1\x05\n" +
 	"\bInsights\n" +
 	"\x04Beta\x12\x0eQuery insights\x1a,Query Insights using the provided SQL query.JO\n" +
@@ -4914,7 +5094,7 @@ func file_api_v2_service_proto_rawDescGZIP() []byte {
 }
 
 var file_api_v2_service_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 64)
+var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
 var file_api_v2_service_proto_goTypes = []any{
 	(FunctionRunStatus)(0),                  // 0: api.v2.FunctionRunStatus
 	(TraceSpanStatus)(0),                    // 1: api.v2.TraceSpanStatus
@@ -4986,36 +5166,39 @@ var file_api_v2_service_proto_goTypes = []any{
 	(*ListInsightsTablesResponse)(nil),      // 67: api.v2.ListInsightsTablesResponse
 	(*InsightsTable)(nil),                   // 68: api.v2.InsightsTable
 	(*InsightsTableColumn)(nil),             // 69: api.v2.InsightsTableColumn
-	nil,                                     // 70: api.v2.TraceSpanMetadata.ValuesEntry
-	(*timestamppb.Timestamp)(nil),           // 71: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                 // 72: google.protobuf.Struct
-	(*structpb.Value)(nil),                  // 73: google.protobuf.Value
+	(*QueryInsightsPromptRequest)(nil),      // 70: api.v2.QueryInsightsPromptRequest
+	(*QueryInsightsPromptResponse)(nil),     // 71: api.v2.QueryInsightsPromptResponse
+	(*QueryInsightsPromptData)(nil),         // 72: api.v2.QueryInsightsPromptData
+	nil,                                     // 73: api.v2.TraceSpanMetadata.ValuesEntry
+	(*timestamppb.Timestamp)(nil),           // 74: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                 // 75: google.protobuf.Struct
+	(*structpb.Value)(nil),                  // 76: google.protobuf.Value
 }
 var file_api_v2_service_proto_depIdxs = []int32{
 	10,  // 0: api.v2.HealthResponse.data:type_name -> api.v2.HealthData
 	13,  // 1: api.v2.HealthResponse.metadata:type_name -> api.v2.ResponseMetadata
 	11,  // 2: api.v2.ErrorResponse.errors:type_name -> api.v2.Error
-	71,  // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
-	71,  // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
+	74,  // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
+	74,  // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
 	14,  // 5: api.v2.FunctionRun.function:type_name -> api.v2.FunctionRef
 	15,  // 6: api.v2.FunctionRun.app:type_name -> api.v2.AppRef
 	0,   // 7: api.v2.FunctionRun.status:type_name -> api.v2.FunctionRunStatus
-	71,  // 8: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
-	71,  // 9: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
-	71,  // 10: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
+	74,  // 8: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
+	74,  // 9: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
+	74,  // 10: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
 	16,  // 11: api.v2.FunctionRun.trigger:type_name -> api.v2.RunTrigger
-	72,  // 12: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
+	75,  // 12: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
 	17,  // 13: api.v2.GetFunctionRunResponse.data:type_name -> api.v2.FunctionRun
 	13,  // 14: api.v2.GetFunctionRunResponse.metadata:type_name -> api.v2.ResponseMetadata
-	70,  // 15: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
-	71,  // 16: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
+	73,  // 15: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
+	74,  // 16: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
 	1,   // 17: api.v2.TraceSpan.status:type_name -> api.v2.TraceSpanStatus
 	2,   // 18: api.v2.TraceSpan.step_op:type_name -> api.v2.TraceStepOp
-	71,  // 19: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
-	71,  // 20: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
-	71,  // 21: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
-	72,  // 22: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
-	72,  // 23: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
+	74,  // 19: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
+	74,  // 20: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
+	74,  // 21: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
+	75,  // 22: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
+	75,  // 23: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
 	20,  // 24: api.v2.TraceSpan.metadata:type_name -> api.v2.TraceSpanMetadata
 	21,  // 25: api.v2.TraceSpan.children:type_name -> api.v2.TraceSpan
 	21,  // 26: api.v2.FunctionTrace.root_span:type_name -> api.v2.TraceSpan
@@ -5026,27 +5209,27 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	29,  // 31: api.v2.CreateEnvResponse.data:type_name -> api.v2.Env
 	13,  // 32: api.v2.CreateEnvResponse.metadata:type_name -> api.v2.ResponseMetadata
 	3,   // 33: api.v2.Env.type:type_name -> api.v2.EnvType
-	71,  // 34: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
-	71,  // 35: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
-	71,  // 36: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
+	74,  // 34: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
+	74,  // 35: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
+	74,  // 36: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
 	34,  // 37: api.v2.FetchAccountsResponse.data:type_name -> api.v2.Account
 	13,  // 38: api.v2.FetchAccountsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 39: api.v2.FetchAccountsResponse.page:type_name -> api.v2.Page
 	34,  // 40: api.v2.FetchAccountResponse.data:type_name -> api.v2.Account
 	13,  // 41: api.v2.FetchAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
-	71,  // 42: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
-	71,  // 43: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
+	74,  // 42: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
+	74,  // 43: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
 	38,  // 44: api.v2.FetchAccountEventKeysResponse.data:type_name -> api.v2.EventKey
 	13,  // 45: api.v2.FetchAccountEventKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 46: api.v2.FetchAccountEventKeysResponse.page:type_name -> api.v2.Page
-	71,  // 47: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
+	74,  // 47: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
 	29,  // 48: api.v2.FetchAccountEnvsResponse.data:type_name -> api.v2.Env
 	13,  // 49: api.v2.FetchAccountEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 50: api.v2.FetchAccountEnvsResponse.page:type_name -> api.v2.Page
 	43,  // 51: api.v2.FetchAccountSigningKeysResponse.data:type_name -> api.v2.SigningKey
 	13,  // 52: api.v2.FetchAccountSigningKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 53: api.v2.FetchAccountSigningKeysResponse.page:type_name -> api.v2.Page
-	71,  // 54: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
+	74,  // 54: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
 	46,  // 55: api.v2.CreateWebhookRequest.event_filter:type_name -> api.v2.EventFilter
 	49,  // 56: api.v2.CreateWebhookResponse.data:type_name -> api.v2.Webhook
 	13,  // 57: api.v2.CreateWebhookResponse.metadata:type_name -> api.v2.ResponseMetadata
@@ -5055,16 +5238,16 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	13,  // 60: api.v2.ListWebhooksResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 61: api.v2.ListWebhooksResponse.page:type_name -> api.v2.Page
 	46,  // 62: api.v2.Webhook.event_filter:type_name -> api.v2.EventFilter
-	71,  // 63: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
-	71,  // 64: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
+	74,  // 63: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
+	74,  // 64: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
 	29,  // 65: api.v2.PatchEnvsResponse.data:type_name -> api.v2.Env
 	13,  // 66: api.v2.PatchEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	72,  // 67: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
+	75,  // 67: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
 	54,  // 68: api.v2.InvokeFunctionResponse.data:type_name -> api.v2.InvokeFunctionData
 	13,  // 69: api.v2.InvokeFunctionResponse.metadata:type_name -> api.v2.ResponseMetadata
-	71,  // 70: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
-	71,  // 71: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
-	71,  // 72: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
+	74,  // 70: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
+	74,  // 71: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
+	74,  // 72: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
 	57,  // 73: api.v2.SyncAppResponse.data:type_name -> api.v2.SyncAppData
 	13,  // 74: api.v2.SyncAppResponse.metadata:type_name -> api.v2.ResponseMetadata
 	58,  // 75: api.v2.SyncAppData.error:type_name -> api.v2.SyncAppError
@@ -5074,53 +5257,58 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	63,  // 79: api.v2.QueryInsightsData.rows:type_name -> api.v2.InsightsRow
 	64,  // 80: api.v2.QueryInsightsData.diagnostics:type_name -> api.v2.InsightsDiagnostic
 	5,   // 81: api.v2.InsightsOutputColumn.type:type_name -> api.v2.InsightsOutputColumnType
-	73,  // 82: api.v2.InsightsRow.values:type_name -> google.protobuf.Value
+	76,  // 82: api.v2.InsightsRow.values:type_name -> google.protobuf.Value
 	6,   // 83: api.v2.InsightsDiagnostic.severity:type_name -> api.v2.InsightsDiagnosticSeverity
 	65,  // 84: api.v2.InsightsDiagnostic.position:type_name -> api.v2.InsightsDiagnosticPosition
 	68,  // 85: api.v2.ListInsightsTablesResponse.data:type_name -> api.v2.InsightsTable
 	13,  // 86: api.v2.ListInsightsTablesResponse.metadata:type_name -> api.v2.ResponseMetadata
 	69,  // 87: api.v2.InsightsTable.columns:type_name -> api.v2.InsightsTableColumn
-	7,   // 88: api.v2.V2.Health:input_type -> api.v2.HealthRequest
-	7,   // 89: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
-	25,  // 90: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
-	27,  // 91: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
-	31,  // 92: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
-	8,   // 93: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
-	39,  // 94: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
-	36,  // 95: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
-	41,  // 96: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
-	44,  // 97: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
-	47,  // 98: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
-	50,  // 99: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
-	18,  // 100: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
-	55,  // 101: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
-	23,  // 102: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
-	52,  // 103: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
-	66,  // 104: api.v2.V2.ListInsightsTables:input_type -> api.v2.ListInsightsTablesRequest
-	59,  // 105: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
-	9,   // 106: api.v2.V2.Health:output_type -> api.v2.HealthResponse
-	12,  // 107: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
-	26,  // 108: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
-	28,  // 109: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
-	32,  // 110: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
-	33,  // 111: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
-	40,  // 112: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
-	37,  // 113: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
-	42,  // 114: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
-	45,  // 115: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
-	48,  // 116: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
-	51,  // 117: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
-	19,  // 118: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
-	56,  // 119: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
-	24,  // 120: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
-	53,  // 121: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
-	67,  // 122: api.v2.V2.ListInsightsTables:output_type -> api.v2.ListInsightsTablesResponse
-	60,  // 123: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
-	106, // [106:124] is the sub-list for method output_type
-	88,  // [88:106] is the sub-list for method input_type
-	88,  // [88:88] is the sub-list for extension type_name
-	88,  // [88:88] is the sub-list for extension extendee
-	0,   // [0:88] is the sub-list for field type_name
+	72,  // 88: api.v2.QueryInsightsPromptResponse.data:type_name -> api.v2.QueryInsightsPromptData
+	13,  // 89: api.v2.QueryInsightsPromptResponse.metadata:type_name -> api.v2.ResponseMetadata
+	64,  // 90: api.v2.QueryInsightsPromptData.diagnostics:type_name -> api.v2.InsightsDiagnostic
+	7,   // 91: api.v2.V2.Health:input_type -> api.v2.HealthRequest
+	7,   // 92: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
+	25,  // 93: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
+	27,  // 94: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
+	31,  // 95: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
+	8,   // 96: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
+	39,  // 97: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
+	36,  // 98: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
+	41,  // 99: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
+	44,  // 100: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
+	47,  // 101: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
+	50,  // 102: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
+	18,  // 103: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
+	55,  // 104: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
+	23,  // 105: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
+	52,  // 106: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
+	66,  // 107: api.v2.V2.ListInsightsTables:input_type -> api.v2.ListInsightsTablesRequest
+	70,  // 108: api.v2.V2.QueryInsightsPrompt:input_type -> api.v2.QueryInsightsPromptRequest
+	59,  // 109: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
+	9,   // 110: api.v2.V2.Health:output_type -> api.v2.HealthResponse
+	12,  // 111: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
+	26,  // 112: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
+	28,  // 113: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
+	32,  // 114: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
+	33,  // 115: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
+	40,  // 116: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
+	37,  // 117: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
+	42,  // 118: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
+	45,  // 119: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
+	48,  // 120: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
+	51,  // 121: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
+	19,  // 122: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
+	56,  // 123: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
+	24,  // 124: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
+	53,  // 125: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
+	67,  // 126: api.v2.V2.ListInsightsTables:output_type -> api.v2.ListInsightsTablesResponse
+	71,  // 127: api.v2.V2.QueryInsightsPrompt:output_type -> api.v2.QueryInsightsPromptResponse
+	60,  // 128: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
+	110, // [110:129] is the sub-list for method output_type
+	91,  // [91:110] is the sub-list for method input_type
+	91,  // [91:91] is the sub-list for extension type_name
+	91,  // [91:91] is the sub-list for extension extendee
+	0,   // [0:91] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_service_proto_init() }
@@ -5155,7 +5343,7 @@ func file_api_v2_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v2_service_proto_rawDesc), len(file_api_v2_service_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   64,
+			NumMessages:   67,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -303,6 +303,116 @@ func (FilterType) EnumDescriptor() ([]byte, []int) {
 	return file_api_v2_service_proto_rawDescGZIP(), []int{4}
 }
 
+type InsightsColumnType int32
+
+const (
+	InsightsColumnType_VALUE_TYPE_UNSPECIFIED InsightsColumnType = 0
+	InsightsColumnType_STRING                 InsightsColumnType = 1
+	InsightsColumnType_NUMBER                 InsightsColumnType = 2
+	InsightsColumnType_BOOLEAN                InsightsColumnType = 3
+	InsightsColumnType_DATETIME               InsightsColumnType = 4
+	InsightsColumnType_COMPLEX                InsightsColumnType = 5
+)
+
+// Enum value maps for InsightsColumnType.
+var (
+	InsightsColumnType_name = map[int32]string{
+		0: "VALUE_TYPE_UNSPECIFIED",
+		1: "STRING",
+		2: "NUMBER",
+		3: "BOOLEAN",
+		4: "DATETIME",
+		5: "COMPLEX",
+	}
+	InsightsColumnType_value = map[string]int32{
+		"VALUE_TYPE_UNSPECIFIED": 0,
+		"STRING":                 1,
+		"NUMBER":                 2,
+		"BOOLEAN":                3,
+		"DATETIME":               4,
+		"COMPLEX":                5,
+	}
+)
+
+func (x InsightsColumnType) Enum() *InsightsColumnType {
+	p := new(InsightsColumnType)
+	*p = x
+	return p
+}
+
+func (x InsightsColumnType) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (InsightsColumnType) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_v2_service_proto_enumTypes[5].Descriptor()
+}
+
+func (InsightsColumnType) Type() protoreflect.EnumType {
+	return &file_api_v2_service_proto_enumTypes[5]
+}
+
+func (x InsightsColumnType) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use InsightsColumnType.Descriptor instead.
+func (InsightsColumnType) EnumDescriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{5}
+}
+
+type InsightsDiagnosticSeverity int32
+
+const (
+	InsightsDiagnosticSeverity_SEVERITY_UNSPECIFIED InsightsDiagnosticSeverity = 0
+	InsightsDiagnosticSeverity_ERROR                InsightsDiagnosticSeverity = 1
+	InsightsDiagnosticSeverity_WARNING              InsightsDiagnosticSeverity = 2
+	InsightsDiagnosticSeverity_INFO                 InsightsDiagnosticSeverity = 3
+)
+
+// Enum value maps for InsightsDiagnosticSeverity.
+var (
+	InsightsDiagnosticSeverity_name = map[int32]string{
+		0: "SEVERITY_UNSPECIFIED",
+		1: "ERROR",
+		2: "WARNING",
+		3: "INFO",
+	}
+	InsightsDiagnosticSeverity_value = map[string]int32{
+		"SEVERITY_UNSPECIFIED": 0,
+		"ERROR":                1,
+		"WARNING":              2,
+		"INFO":                 3,
+	}
+)
+
+func (x InsightsDiagnosticSeverity) Enum() *InsightsDiagnosticSeverity {
+	p := new(InsightsDiagnosticSeverity)
+	*p = x
+	return p
+}
+
+func (x InsightsDiagnosticSeverity) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (InsightsDiagnosticSeverity) Descriptor() protoreflect.EnumDescriptor {
+	return file_api_v2_service_proto_enumTypes[6].Descriptor()
+}
+
+func (InsightsDiagnosticSeverity) Type() protoreflect.EnumType {
+	return &file_api_v2_service_proto_enumTypes[6]
+}
+
+func (x InsightsDiagnosticSeverity) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use InsightsDiagnosticSeverity.Descriptor instead.
+func (InsightsDiagnosticSeverity) EnumDescriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{6}
+}
+
 type HealthRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
@@ -3455,6 +3565,334 @@ func (x *SyncAppError) GetMessage() string {
 	return ""
 }
 
+type QueryInsightsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Query         string                 `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QueryInsightsRequest) Reset() {
+	*x = QueryInsightsRequest{}
+	mi := &file_api_v2_service_proto_msgTypes[52]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QueryInsightsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QueryInsightsRequest) ProtoMessage() {}
+
+func (x *QueryInsightsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[52]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QueryInsightsRequest.ProtoReflect.Descriptor instead.
+func (*QueryInsightsRequest) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *QueryInsightsRequest) GetQuery() string {
+	if x != nil {
+		return x.Query
+	}
+	return ""
+}
+
+type QueryInsightsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Columns       []*InsightsColumn      `protobuf:"bytes,1,rep,name=columns,proto3" json:"columns,omitempty"`
+	Rows          []*InsightsRow         `protobuf:"bytes,2,rep,name=rows,proto3" json:"rows,omitempty"`
+	Diagnostics   []*InsightsDiagnostic  `protobuf:"bytes,3,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *QueryInsightsResponse) Reset() {
+	*x = QueryInsightsResponse{}
+	mi := &file_api_v2_service_proto_msgTypes[53]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *QueryInsightsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*QueryInsightsResponse) ProtoMessage() {}
+
+func (x *QueryInsightsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[53]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use QueryInsightsResponse.ProtoReflect.Descriptor instead.
+func (*QueryInsightsResponse) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{53}
+}
+
+func (x *QueryInsightsResponse) GetColumns() []*InsightsColumn {
+	if x != nil {
+		return x.Columns
+	}
+	return nil
+}
+
+func (x *QueryInsightsResponse) GetRows() []*InsightsRow {
+	if x != nil {
+		return x.Rows
+	}
+	return nil
+}
+
+func (x *QueryInsightsResponse) GetDiagnostics() []*InsightsDiagnostic {
+	if x != nil {
+		return x.Diagnostics
+	}
+	return nil
+}
+
+type InsightsColumn struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Type          InsightsColumnType     `protobuf:"varint,2,opt,name=type,proto3,enum=api.v2.InsightsColumnType" json:"type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InsightsColumn) Reset() {
+	*x = InsightsColumn{}
+	mi := &file_api_v2_service_proto_msgTypes[54]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InsightsColumn) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InsightsColumn) ProtoMessage() {}
+
+func (x *InsightsColumn) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[54]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InsightsColumn.ProtoReflect.Descriptor instead.
+func (*InsightsColumn) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{54}
+}
+
+func (x *InsightsColumn) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *InsightsColumn) GetType() InsightsColumnType {
+	if x != nil {
+		return x.Type
+	}
+	return InsightsColumnType_VALUE_TYPE_UNSPECIFIED
+}
+
+type InsightsRow struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Values        []*structpb.Value      `protobuf:"bytes,1,rep,name=values,proto3" json:"values,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InsightsRow) Reset() {
+	*x = InsightsRow{}
+	mi := &file_api_v2_service_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InsightsRow) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InsightsRow) ProtoMessage() {}
+
+func (x *InsightsRow) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InsightsRow.ProtoReflect.Descriptor instead.
+func (*InsightsRow) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *InsightsRow) GetValues() []*structpb.Value {
+	if x != nil {
+		return x.Values
+	}
+	return nil
+}
+
+type InsightsDiagnostic struct {
+	state         protoimpl.MessageState      `protogen:"open.v1"`
+	Severity      InsightsDiagnosticSeverity  `protobuf:"varint,1,opt,name=severity,proto3,enum=api.v2.InsightsDiagnosticSeverity" json:"severity,omitempty"`
+	Code          string                      `protobuf:"bytes,2,opt,name=code,proto3" json:"code,omitempty"`
+	Message       string                      `protobuf:"bytes,3,opt,name=message,proto3" json:"message,omitempty"`
+	Position      *InsightsDiagnosticPosition `protobuf:"bytes,4,opt,name=position,proto3,oneof" json:"position,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InsightsDiagnostic) Reset() {
+	*x = InsightsDiagnostic{}
+	mi := &file_api_v2_service_proto_msgTypes[56]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InsightsDiagnostic) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InsightsDiagnostic) ProtoMessage() {}
+
+func (x *InsightsDiagnostic) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[56]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InsightsDiagnostic.ProtoReflect.Descriptor instead.
+func (*InsightsDiagnostic) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{56}
+}
+
+func (x *InsightsDiagnostic) GetSeverity() InsightsDiagnosticSeverity {
+	if x != nil {
+		return x.Severity
+	}
+	return InsightsDiagnosticSeverity_SEVERITY_UNSPECIFIED
+}
+
+func (x *InsightsDiagnostic) GetCode() string {
+	if x != nil {
+		return x.Code
+	}
+	return ""
+}
+
+func (x *InsightsDiagnostic) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
+func (x *InsightsDiagnostic) GetPosition() *InsightsDiagnosticPosition {
+	if x != nil {
+		return x.Position
+	}
+	return nil
+}
+
+type InsightsDiagnosticPosition struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Start         int32                  `protobuf:"varint,1,opt,name=start,proto3" json:"start,omitempty"`
+	End           int32                  `protobuf:"varint,2,opt,name=end,proto3" json:"end,omitempty"`
+	Context       string                 `protobuf:"bytes,3,opt,name=context,proto3" json:"context,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InsightsDiagnosticPosition) Reset() {
+	*x = InsightsDiagnosticPosition{}
+	mi := &file_api_v2_service_proto_msgTypes[57]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InsightsDiagnosticPosition) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InsightsDiagnosticPosition) ProtoMessage() {}
+
+func (x *InsightsDiagnosticPosition) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[57]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InsightsDiagnosticPosition.ProtoReflect.Descriptor instead.
+func (*InsightsDiagnosticPosition) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{57}
+}
+
+func (x *InsightsDiagnosticPosition) GetStart() int32 {
+	if x != nil {
+		return x.Start
+	}
+	return 0
+}
+
+func (x *InsightsDiagnosticPosition) GetEnd() int32 {
+	if x != nil {
+		return x.End
+	}
+	return 0
+}
+
+func (x *InsightsDiagnosticPosition) GetContext() string {
+	if x != nil {
+		return x.Context
+	}
+	return ""
+}
+
 var File_api_v2_service_proto protoreflect.FileDescriptor
 
 const file_api_v2_service_proto_rawDesc = "" +
@@ -3734,7 +4172,28 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x06_error\"<\n" +
 	"\fSyncAppError\x12\x12\n" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x18\n" +
-	"\amessage\x18\x02 \x01(\tR\amessage*\xdf\x01\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"t\n" +
+	"\x14QueryInsightsRequest\x12\\\n" +
+	"\x05query\x18\x01 \x01(\tBF\x92AC2AThe insights query to execute, written in modified ClickHouse SQLR\x05query\"\x9d\x03\n" +
+	"\x15QueryInsightsResponse\x12d\n" +
+	"\acolumns\x18\x01 \x03(\v2\x16.api.v2.InsightsColumnB2\x92A/2-Column metadata for the insights query resultR\acolumns\x12\x96\x01\n" +
+	"\x04rows\x18\x02 \x03(\v2\x13.api.v2.InsightsRowBm\x92Aj2hRows of the insights query result, where each row contains a list of values corresponding to the columnsR\x04rows\x12\x84\x01\n" +
+	"\vdiagnostics\x18\x03 \x03(\v2\x1a.api.v2.InsightsDiagnosticBF\x92AC2AAny non-fatal diagnostics related to the insights query executionR\vdiagnostics\"\xce\x01\n" +
+	"\x0eInsightsColumn\x12H\n" +
+	"\x04name\x18\x01 \x01(\tB4\x92A12/Name of the column in the insights query resultR\x04name\x12r\n" +
+	"\x04type\x18\x02 \x01(\x0e2\x1a.api.v2.InsightsColumnTypeBB\x92A?2=Data type of the column (e.g., 'string', 'number', 'boolean')R\x04type\"\x94\x02\n" +
+	"\vInsightsRow\x12\x84\x02\n" +
+	"\x06values\x18\x01 \x03(\v2\x16.google.protobuf.ValueB\xd3\x01\x92A\xcf\x012\xcc\x01Values for a single row of the insights query result, where each value corresponds to a column. The value is represented as a JSON object to allow for flexible typing (e.g., string, number, boolean, etc.)R\x06values\"\xa7\x04\n" +
+	"\x12InsightsDiagnostic\x12\x88\x01\n" +
+	"\bseverity\x18\x01 \x01(\x0e2\".api.v2.InsightsDiagnosticSeverityBH\x92AE2CSeverity level of the diagnostic (e.g., 'error', 'warning', 'info')R\bseverity\x12R\n" +
+	"\x04code\x18\x02 \x01(\tB>\x92A;29Machine-readable code representing the type of diagnosticR\x04code\x12O\n" +
+	"\amessage\x18\x03 \x01(\tB5\x92A220Human-readable message describing the diagnosticR\amessage\x12\xd3\x01\n" +
+	"\bposition\x18\x04 \x01(\v2\".api.v2.InsightsDiagnosticPositionB\x8d\x01\x92A\x89\x012\x86\x01Optional position in the query string where the diagnostic applies, useful for pointing out syntax errors or other issues in the queryH\x00R\bposition\x88\x01\x01B\v\n" +
+	"\t_position\"\xd8\x02\n" +
+	"\x1aInsightsDiagnosticPosition\x12d\n" +
+	"\x05start\x18\x01 \x01(\x05BN\x92AK2IStarting character index in the query string where the diagnostic appliesR\x05start\x12^\n" +
+	"\x03end\x18\x02 \x01(\x05BL\x92AI2GEnding character index in the query string where the diagnostic appliesR\x03end\x12t\n" +
+	"\acontext\x18\x03 \x01(\tBZ\x92AW2USnippet of the query string around the position to provide context for the diagnosticR\acontext*\xdf\x01\n" +
 	"\x11FunctionRunStatus\x12#\n" +
 	"\x1fFUNCTION_RUN_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aFUNCTION_RUN_STATUS_QUEUED\x10\x01\x12\x1f\n" +
@@ -3768,7 +4227,21 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\n" +
 	"FilterType\x12\t\n" +
 	"\x05ALLOW\x10\x00\x12\b\n" +
-	"\x04DENY\x10\x012\xf4R\n" +
+	"\x04DENY\x10\x01*p\n" +
+	"\x12InsightsColumnType\x12\x1a\n" +
+	"\x16VALUE_TYPE_UNSPECIFIED\x10\x00\x12\n" +
+	"\n" +
+	"\x06STRING\x10\x01\x12\n" +
+	"\n" +
+	"\x06NUMBER\x10\x02\x12\v\n" +
+	"\aBOOLEAN\x10\x03\x12\f\n" +
+	"\bDATETIME\x10\x04\x12\v\n" +
+	"\aCOMPLEX\x10\x05*X\n" +
+	"\x1aInsightsDiagnosticSeverity\x12\x18\n" +
+	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\t\n" +
+	"\x05ERROR\x10\x01\x12\v\n" +
+	"\aWARNING\x10\x02\x12\b\n" +
+	"\x04INFO\x10\x032\x85Y\n" +
 	"\x02V2\x12\xbc\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\x82\x02\x92A\xef\x01\n" +
 	"\bInternal\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
@@ -4094,7 +4567,34 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x022:\x01*\"-/apps/{app_id}/functions/{function_id}/invokeB\xfc\x04\x92A\xc5\x04\x12\x9b\x01\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x022:\x01*\"-/apps/{app_id}/functions/{function_id}/invoke\x12\x8e\x06\n" +
+	"\rQueryInsights\x12\x1c.api.v2.QueryInsightsRequest\x1a\x1d.api.v2.QueryInsightsResponse\"\xbf\x05\x92A\xa1\x05\n" +
+	"\bInsights\n" +
+	"\x04Beta\x12\x0eQuery insights\x1a,Query Insights using the provided SQL query.JO\n" +
+	"\x03200\x12H\n" +
+	"\x1bQuery executed successfully\x12)\n" +
+	"'\x1a%#/definitions/v2QueryInsightsResponseJL\n" +
+	"\x03400\x12E\n" +
+	" Bad Request - invalid input data\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJR\n" +
+	"\x03401\x12K\n" +
+	"&Unauthorized - authentication required\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJP\n" +
+	"\x03403\x12I\n" +
+	"$Forbidden - insufficient permissions\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJM\n" +
+	"\x03404\x12F\n" +
+	"!Not Found - environment not found\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJh\n" +
+	"\x03422\x12a\n" +
+	"<Unprocessable Entity - Query validation or execution failed.\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJA\n" +
+	"\x03500\x12:\n" +
+	"\x15Internal Server Error\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
+	"\x0e\n" +
+	"\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x14:\x01*\"\x0f/insights/queryB\xfc\x04\x92A\xc5\x04\x12\x9b\x01\n" +
 	"\x13Inngest REST API v2\x12}The v2 API delivers a significantly improved developer experience with consistent design patterns and enhanced functionality.2\x052.0.0\x1a\x0fapi.inngest.com\"\x03/v2*\x01\x02ZX\n" +
 	"V\n" +
 	"\n" +
@@ -4120,184 +4620,202 @@ func file_api_v2_service_proto_rawDescGZIP() []byte {
 	return file_api_v2_service_proto_rawDescData
 }
 
-var file_api_v2_service_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
+var file_api_v2_service_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
+var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 59)
 var file_api_v2_service_proto_goTypes = []any{
 	(FunctionRunStatus)(0),                  // 0: api.v2.FunctionRunStatus
 	(TraceSpanStatus)(0),                    // 1: api.v2.TraceSpanStatus
 	(TraceStepOp)(0),                        // 2: api.v2.TraceStepOp
 	(EnvType)(0),                            // 3: api.v2.EnvType
 	(FilterType)(0),                         // 4: api.v2.FilterType
-	(*HealthRequest)(nil),                   // 5: api.v2.HealthRequest
-	(*FetchAccountRequest)(nil),             // 6: api.v2.FetchAccountRequest
-	(*HealthResponse)(nil),                  // 7: api.v2.HealthResponse
-	(*HealthData)(nil),                      // 8: api.v2.HealthData
-	(*Error)(nil),                           // 9: api.v2.Error
-	(*ErrorResponse)(nil),                   // 10: api.v2.ErrorResponse
-	(*ResponseMetadata)(nil),                // 11: api.v2.ResponseMetadata
-	(*FunctionRef)(nil),                     // 12: api.v2.FunctionRef
-	(*AppRef)(nil),                          // 13: api.v2.AppRef
-	(*RunTrigger)(nil),                      // 14: api.v2.RunTrigger
-	(*FunctionRun)(nil),                     // 15: api.v2.FunctionRun
-	(*GetFunctionRunRequest)(nil),           // 16: api.v2.GetFunctionRunRequest
-	(*GetFunctionRunResponse)(nil),          // 17: api.v2.GetFunctionRunResponse
-	(*TraceSpanMetadata)(nil),               // 18: api.v2.TraceSpanMetadata
-	(*TraceSpan)(nil),                       // 19: api.v2.TraceSpan
-	(*FunctionTrace)(nil),                   // 20: api.v2.FunctionTrace
-	(*GetFunctionTraceRequest)(nil),         // 21: api.v2.GetFunctionTraceRequest
-	(*GetFunctionTraceResponse)(nil),        // 22: api.v2.GetFunctionTraceResponse
-	(*CreateAccountRequest)(nil),            // 23: api.v2.CreateAccountRequest
-	(*CreateAccountResponse)(nil),           // 24: api.v2.CreateAccountResponse
-	(*CreateEnvRequest)(nil),                // 25: api.v2.CreateEnvRequest
-	(*CreateEnvResponse)(nil),               // 26: api.v2.CreateEnvResponse
-	(*Env)(nil),                             // 27: api.v2.Env
-	(*CreateAccountData)(nil),               // 28: api.v2.CreateAccountData
-	(*FetchAccountsRequest)(nil),            // 29: api.v2.FetchAccountsRequest
-	(*FetchAccountsResponse)(nil),           // 30: api.v2.FetchAccountsResponse
-	(*FetchAccountResponse)(nil),            // 31: api.v2.FetchAccountResponse
-	(*Account)(nil),                         // 32: api.v2.Account
-	(*Page)(nil),                            // 33: api.v2.Page
-	(*FetchAccountEventKeysRequest)(nil),    // 34: api.v2.FetchAccountEventKeysRequest
-	(*FetchAccountEventKeysResponse)(nil),   // 35: api.v2.FetchAccountEventKeysResponse
-	(*EventKey)(nil),                        // 36: api.v2.EventKey
-	(*FetchAccountEnvsRequest)(nil),         // 37: api.v2.FetchAccountEnvsRequest
-	(*FetchAccountEnvsResponse)(nil),        // 38: api.v2.FetchAccountEnvsResponse
-	(*FetchAccountSigningKeysRequest)(nil),  // 39: api.v2.FetchAccountSigningKeysRequest
-	(*FetchAccountSigningKeysResponse)(nil), // 40: api.v2.FetchAccountSigningKeysResponse
-	(*SigningKey)(nil),                      // 41: api.v2.SigningKey
-	(*CreateWebhookRequest)(nil),            // 42: api.v2.CreateWebhookRequest
-	(*CreateWebhookResponse)(nil),           // 43: api.v2.CreateWebhookResponse
-	(*EventFilter)(nil),                     // 44: api.v2.EventFilter
-	(*ListWebhooksRequest)(nil),             // 45: api.v2.ListWebhooksRequest
-	(*ListWebhooksResponse)(nil),            // 46: api.v2.ListWebhooksResponse
-	(*Webhook)(nil),                         // 47: api.v2.Webhook
-	(*PatchEnvRequest)(nil),                 // 48: api.v2.PatchEnvRequest
-	(*PatchEnvsResponse)(nil),               // 49: api.v2.PatchEnvsResponse
-	(*InvokeFunctionRequest)(nil),           // 50: api.v2.InvokeFunctionRequest
-	(*InvokeFunctionResponse)(nil),          // 51: api.v2.InvokeFunctionResponse
-	(*InvokeFunctionData)(nil),              // 52: api.v2.InvokeFunctionData
-	(*SyncAppRequest)(nil),                  // 53: api.v2.SyncAppRequest
-	(*SyncAppResponse)(nil),                 // 54: api.v2.SyncAppResponse
-	(*SyncAppData)(nil),                     // 55: api.v2.SyncAppData
-	(*SyncAppError)(nil),                    // 56: api.v2.SyncAppError
-	nil,                                     // 57: api.v2.TraceSpanMetadata.ValuesEntry
-	(*timestamppb.Timestamp)(nil),           // 58: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                 // 59: google.protobuf.Struct
+	(InsightsColumnType)(0),                 // 5: api.v2.InsightsColumnType
+	(InsightsDiagnosticSeverity)(0),         // 6: api.v2.InsightsDiagnosticSeverity
+	(*HealthRequest)(nil),                   // 7: api.v2.HealthRequest
+	(*FetchAccountRequest)(nil),             // 8: api.v2.FetchAccountRequest
+	(*HealthResponse)(nil),                  // 9: api.v2.HealthResponse
+	(*HealthData)(nil),                      // 10: api.v2.HealthData
+	(*Error)(nil),                           // 11: api.v2.Error
+	(*ErrorResponse)(nil),                   // 12: api.v2.ErrorResponse
+	(*ResponseMetadata)(nil),                // 13: api.v2.ResponseMetadata
+	(*FunctionRef)(nil),                     // 14: api.v2.FunctionRef
+	(*AppRef)(nil),                          // 15: api.v2.AppRef
+	(*RunTrigger)(nil),                      // 16: api.v2.RunTrigger
+	(*FunctionRun)(nil),                     // 17: api.v2.FunctionRun
+	(*GetFunctionRunRequest)(nil),           // 18: api.v2.GetFunctionRunRequest
+	(*GetFunctionRunResponse)(nil),          // 19: api.v2.GetFunctionRunResponse
+	(*TraceSpanMetadata)(nil),               // 20: api.v2.TraceSpanMetadata
+	(*TraceSpan)(nil),                       // 21: api.v2.TraceSpan
+	(*FunctionTrace)(nil),                   // 22: api.v2.FunctionTrace
+	(*GetFunctionTraceRequest)(nil),         // 23: api.v2.GetFunctionTraceRequest
+	(*GetFunctionTraceResponse)(nil),        // 24: api.v2.GetFunctionTraceResponse
+	(*CreateAccountRequest)(nil),            // 25: api.v2.CreateAccountRequest
+	(*CreateAccountResponse)(nil),           // 26: api.v2.CreateAccountResponse
+	(*CreateEnvRequest)(nil),                // 27: api.v2.CreateEnvRequest
+	(*CreateEnvResponse)(nil),               // 28: api.v2.CreateEnvResponse
+	(*Env)(nil),                             // 29: api.v2.Env
+	(*CreateAccountData)(nil),               // 30: api.v2.CreateAccountData
+	(*FetchAccountsRequest)(nil),            // 31: api.v2.FetchAccountsRequest
+	(*FetchAccountsResponse)(nil),           // 32: api.v2.FetchAccountsResponse
+	(*FetchAccountResponse)(nil),            // 33: api.v2.FetchAccountResponse
+	(*Account)(nil),                         // 34: api.v2.Account
+	(*Page)(nil),                            // 35: api.v2.Page
+	(*FetchAccountEventKeysRequest)(nil),    // 36: api.v2.FetchAccountEventKeysRequest
+	(*FetchAccountEventKeysResponse)(nil),   // 37: api.v2.FetchAccountEventKeysResponse
+	(*EventKey)(nil),                        // 38: api.v2.EventKey
+	(*FetchAccountEnvsRequest)(nil),         // 39: api.v2.FetchAccountEnvsRequest
+	(*FetchAccountEnvsResponse)(nil),        // 40: api.v2.FetchAccountEnvsResponse
+	(*FetchAccountSigningKeysRequest)(nil),  // 41: api.v2.FetchAccountSigningKeysRequest
+	(*FetchAccountSigningKeysResponse)(nil), // 42: api.v2.FetchAccountSigningKeysResponse
+	(*SigningKey)(nil),                      // 43: api.v2.SigningKey
+	(*CreateWebhookRequest)(nil),            // 44: api.v2.CreateWebhookRequest
+	(*CreateWebhookResponse)(nil),           // 45: api.v2.CreateWebhookResponse
+	(*EventFilter)(nil),                     // 46: api.v2.EventFilter
+	(*ListWebhooksRequest)(nil),             // 47: api.v2.ListWebhooksRequest
+	(*ListWebhooksResponse)(nil),            // 48: api.v2.ListWebhooksResponse
+	(*Webhook)(nil),                         // 49: api.v2.Webhook
+	(*PatchEnvRequest)(nil),                 // 50: api.v2.PatchEnvRequest
+	(*PatchEnvsResponse)(nil),               // 51: api.v2.PatchEnvsResponse
+	(*InvokeFunctionRequest)(nil),           // 52: api.v2.InvokeFunctionRequest
+	(*InvokeFunctionResponse)(nil),          // 53: api.v2.InvokeFunctionResponse
+	(*InvokeFunctionData)(nil),              // 54: api.v2.InvokeFunctionData
+	(*SyncAppRequest)(nil),                  // 55: api.v2.SyncAppRequest
+	(*SyncAppResponse)(nil),                 // 56: api.v2.SyncAppResponse
+	(*SyncAppData)(nil),                     // 57: api.v2.SyncAppData
+	(*SyncAppError)(nil),                    // 58: api.v2.SyncAppError
+	(*QueryInsightsRequest)(nil),            // 59: api.v2.QueryInsightsRequest
+	(*QueryInsightsResponse)(nil),           // 60: api.v2.QueryInsightsResponse
+	(*InsightsColumn)(nil),                  // 61: api.v2.InsightsColumn
+	(*InsightsRow)(nil),                     // 62: api.v2.InsightsRow
+	(*InsightsDiagnostic)(nil),              // 63: api.v2.InsightsDiagnostic
+	(*InsightsDiagnosticPosition)(nil),      // 64: api.v2.InsightsDiagnosticPosition
+	nil,                                     // 65: api.v2.TraceSpanMetadata.ValuesEntry
+	(*timestamppb.Timestamp)(nil),           // 66: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                 // 67: google.protobuf.Struct
+	(*structpb.Value)(nil),                  // 68: google.protobuf.Value
 }
 var file_api_v2_service_proto_depIdxs = []int32{
-	8,  // 0: api.v2.HealthResponse.data:type_name -> api.v2.HealthData
-	11, // 1: api.v2.HealthResponse.metadata:type_name -> api.v2.ResponseMetadata
-	9,  // 2: api.v2.ErrorResponse.errors:type_name -> api.v2.Error
-	58, // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
-	58, // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
-	12, // 5: api.v2.FunctionRun.function:type_name -> api.v2.FunctionRef
-	13, // 6: api.v2.FunctionRun.app:type_name -> api.v2.AppRef
-	0,  // 7: api.v2.FunctionRun.status:type_name -> api.v2.FunctionRunStatus
-	58, // 8: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
-	58, // 9: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
-	58, // 10: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
-	14, // 11: api.v2.FunctionRun.trigger:type_name -> api.v2.RunTrigger
-	59, // 12: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
-	15, // 13: api.v2.GetFunctionRunResponse.data:type_name -> api.v2.FunctionRun
-	11, // 14: api.v2.GetFunctionRunResponse.metadata:type_name -> api.v2.ResponseMetadata
-	57, // 15: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
-	58, // 16: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
-	1,  // 17: api.v2.TraceSpan.status:type_name -> api.v2.TraceSpanStatus
-	2,  // 18: api.v2.TraceSpan.step_op:type_name -> api.v2.TraceStepOp
-	58, // 19: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
-	58, // 20: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
-	58, // 21: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
-	59, // 22: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
-	59, // 23: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
-	18, // 24: api.v2.TraceSpan.metadata:type_name -> api.v2.TraceSpanMetadata
-	19, // 25: api.v2.TraceSpan.children:type_name -> api.v2.TraceSpan
-	19, // 26: api.v2.FunctionTrace.root_span:type_name -> api.v2.TraceSpan
-	20, // 27: api.v2.GetFunctionTraceResponse.data:type_name -> api.v2.FunctionTrace
-	11, // 28: api.v2.GetFunctionTraceResponse.metadata:type_name -> api.v2.ResponseMetadata
-	28, // 29: api.v2.CreateAccountResponse.data:type_name -> api.v2.CreateAccountData
-	11, // 30: api.v2.CreateAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
-	27, // 31: api.v2.CreateEnvResponse.data:type_name -> api.v2.Env
-	11, // 32: api.v2.CreateEnvResponse.metadata:type_name -> api.v2.ResponseMetadata
-	3,  // 33: api.v2.Env.type:type_name -> api.v2.EnvType
-	58, // 34: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
-	58, // 35: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
-	58, // 36: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
-	32, // 37: api.v2.FetchAccountsResponse.data:type_name -> api.v2.Account
-	11, // 38: api.v2.FetchAccountsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	33, // 39: api.v2.FetchAccountsResponse.page:type_name -> api.v2.Page
-	32, // 40: api.v2.FetchAccountResponse.data:type_name -> api.v2.Account
-	11, // 41: api.v2.FetchAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
-	58, // 42: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
-	58, // 43: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
-	36, // 44: api.v2.FetchAccountEventKeysResponse.data:type_name -> api.v2.EventKey
-	11, // 45: api.v2.FetchAccountEventKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
-	33, // 46: api.v2.FetchAccountEventKeysResponse.page:type_name -> api.v2.Page
-	58, // 47: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
-	27, // 48: api.v2.FetchAccountEnvsResponse.data:type_name -> api.v2.Env
-	11, // 49: api.v2.FetchAccountEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	33, // 50: api.v2.FetchAccountEnvsResponse.page:type_name -> api.v2.Page
-	41, // 51: api.v2.FetchAccountSigningKeysResponse.data:type_name -> api.v2.SigningKey
-	11, // 52: api.v2.FetchAccountSigningKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
-	33, // 53: api.v2.FetchAccountSigningKeysResponse.page:type_name -> api.v2.Page
-	58, // 54: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
-	44, // 55: api.v2.CreateWebhookRequest.event_filter:type_name -> api.v2.EventFilter
-	47, // 56: api.v2.CreateWebhookResponse.data:type_name -> api.v2.Webhook
-	11, // 57: api.v2.CreateWebhookResponse.metadata:type_name -> api.v2.ResponseMetadata
-	4,  // 58: api.v2.EventFilter.filter:type_name -> api.v2.FilterType
-	47, // 59: api.v2.ListWebhooksResponse.data:type_name -> api.v2.Webhook
-	11, // 60: api.v2.ListWebhooksResponse.metadata:type_name -> api.v2.ResponseMetadata
-	33, // 61: api.v2.ListWebhooksResponse.page:type_name -> api.v2.Page
-	44, // 62: api.v2.Webhook.event_filter:type_name -> api.v2.EventFilter
-	58, // 63: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
-	58, // 64: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
-	27, // 65: api.v2.PatchEnvsResponse.data:type_name -> api.v2.Env
-	11, // 66: api.v2.PatchEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	59, // 67: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
-	52, // 68: api.v2.InvokeFunctionResponse.data:type_name -> api.v2.InvokeFunctionData
-	11, // 69: api.v2.InvokeFunctionResponse.metadata:type_name -> api.v2.ResponseMetadata
-	58, // 70: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
-	58, // 71: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
-	58, // 72: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
-	55, // 73: api.v2.SyncAppResponse.data:type_name -> api.v2.SyncAppData
-	11, // 74: api.v2.SyncAppResponse.metadata:type_name -> api.v2.ResponseMetadata
-	56, // 75: api.v2.SyncAppData.error:type_name -> api.v2.SyncAppError
-	5,  // 76: api.v2.V2.Health:input_type -> api.v2.HealthRequest
-	5,  // 77: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
-	23, // 78: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
-	25, // 79: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
-	29, // 80: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
-	6,  // 81: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
-	37, // 82: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
-	34, // 83: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
-	39, // 84: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
-	42, // 85: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
-	45, // 86: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
-	48, // 87: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
-	16, // 88: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
-	53, // 89: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
-	21, // 90: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
-	50, // 91: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
-	7,  // 92: api.v2.V2.Health:output_type -> api.v2.HealthResponse
-	10, // 93: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
-	24, // 94: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
-	26, // 95: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
-	30, // 96: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
-	31, // 97: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
-	38, // 98: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
-	35, // 99: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
-	40, // 100: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
-	43, // 101: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
-	46, // 102: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
-	49, // 103: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
-	17, // 104: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
-	54, // 105: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
-	22, // 106: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
-	51, // 107: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
-	92, // [92:108] is the sub-list for method output_type
-	76, // [76:92] is the sub-list for method input_type
-	76, // [76:76] is the sub-list for extension type_name
-	76, // [76:76] is the sub-list for extension extendee
-	0,  // [0:76] is the sub-list for field type_name
+	10,  // 0: api.v2.HealthResponse.data:type_name -> api.v2.HealthData
+	13,  // 1: api.v2.HealthResponse.metadata:type_name -> api.v2.ResponseMetadata
+	11,  // 2: api.v2.ErrorResponse.errors:type_name -> api.v2.Error
+	66,  // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
+	66,  // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
+	14,  // 5: api.v2.FunctionRun.function:type_name -> api.v2.FunctionRef
+	15,  // 6: api.v2.FunctionRun.app:type_name -> api.v2.AppRef
+	0,   // 7: api.v2.FunctionRun.status:type_name -> api.v2.FunctionRunStatus
+	66,  // 8: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
+	66,  // 9: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
+	66,  // 10: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
+	16,  // 11: api.v2.FunctionRun.trigger:type_name -> api.v2.RunTrigger
+	67,  // 12: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
+	17,  // 13: api.v2.GetFunctionRunResponse.data:type_name -> api.v2.FunctionRun
+	13,  // 14: api.v2.GetFunctionRunResponse.metadata:type_name -> api.v2.ResponseMetadata
+	65,  // 15: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
+	66,  // 16: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
+	1,   // 17: api.v2.TraceSpan.status:type_name -> api.v2.TraceSpanStatus
+	2,   // 18: api.v2.TraceSpan.step_op:type_name -> api.v2.TraceStepOp
+	66,  // 19: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
+	66,  // 20: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
+	66,  // 21: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
+	67,  // 22: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
+	67,  // 23: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
+	20,  // 24: api.v2.TraceSpan.metadata:type_name -> api.v2.TraceSpanMetadata
+	21,  // 25: api.v2.TraceSpan.children:type_name -> api.v2.TraceSpan
+	21,  // 26: api.v2.FunctionTrace.root_span:type_name -> api.v2.TraceSpan
+	22,  // 27: api.v2.GetFunctionTraceResponse.data:type_name -> api.v2.FunctionTrace
+	13,  // 28: api.v2.GetFunctionTraceResponse.metadata:type_name -> api.v2.ResponseMetadata
+	30,  // 29: api.v2.CreateAccountResponse.data:type_name -> api.v2.CreateAccountData
+	13,  // 30: api.v2.CreateAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
+	29,  // 31: api.v2.CreateEnvResponse.data:type_name -> api.v2.Env
+	13,  // 32: api.v2.CreateEnvResponse.metadata:type_name -> api.v2.ResponseMetadata
+	3,   // 33: api.v2.Env.type:type_name -> api.v2.EnvType
+	66,  // 34: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
+	66,  // 35: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
+	66,  // 36: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
+	34,  // 37: api.v2.FetchAccountsResponse.data:type_name -> api.v2.Account
+	13,  // 38: api.v2.FetchAccountsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	35,  // 39: api.v2.FetchAccountsResponse.page:type_name -> api.v2.Page
+	34,  // 40: api.v2.FetchAccountResponse.data:type_name -> api.v2.Account
+	13,  // 41: api.v2.FetchAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
+	66,  // 42: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
+	66,  // 43: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
+	38,  // 44: api.v2.FetchAccountEventKeysResponse.data:type_name -> api.v2.EventKey
+	13,  // 45: api.v2.FetchAccountEventKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
+	35,  // 46: api.v2.FetchAccountEventKeysResponse.page:type_name -> api.v2.Page
+	66,  // 47: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
+	29,  // 48: api.v2.FetchAccountEnvsResponse.data:type_name -> api.v2.Env
+	13,  // 49: api.v2.FetchAccountEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	35,  // 50: api.v2.FetchAccountEnvsResponse.page:type_name -> api.v2.Page
+	43,  // 51: api.v2.FetchAccountSigningKeysResponse.data:type_name -> api.v2.SigningKey
+	13,  // 52: api.v2.FetchAccountSigningKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
+	35,  // 53: api.v2.FetchAccountSigningKeysResponse.page:type_name -> api.v2.Page
+	66,  // 54: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
+	46,  // 55: api.v2.CreateWebhookRequest.event_filter:type_name -> api.v2.EventFilter
+	49,  // 56: api.v2.CreateWebhookResponse.data:type_name -> api.v2.Webhook
+	13,  // 57: api.v2.CreateWebhookResponse.metadata:type_name -> api.v2.ResponseMetadata
+	4,   // 58: api.v2.EventFilter.filter:type_name -> api.v2.FilterType
+	49,  // 59: api.v2.ListWebhooksResponse.data:type_name -> api.v2.Webhook
+	13,  // 60: api.v2.ListWebhooksResponse.metadata:type_name -> api.v2.ResponseMetadata
+	35,  // 61: api.v2.ListWebhooksResponse.page:type_name -> api.v2.Page
+	46,  // 62: api.v2.Webhook.event_filter:type_name -> api.v2.EventFilter
+	66,  // 63: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
+	66,  // 64: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
+	29,  // 65: api.v2.PatchEnvsResponse.data:type_name -> api.v2.Env
+	13,  // 66: api.v2.PatchEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	67,  // 67: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
+	54,  // 68: api.v2.InvokeFunctionResponse.data:type_name -> api.v2.InvokeFunctionData
+	13,  // 69: api.v2.InvokeFunctionResponse.metadata:type_name -> api.v2.ResponseMetadata
+	66,  // 70: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
+	66,  // 71: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
+	66,  // 72: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
+	57,  // 73: api.v2.SyncAppResponse.data:type_name -> api.v2.SyncAppData
+	13,  // 74: api.v2.SyncAppResponse.metadata:type_name -> api.v2.ResponseMetadata
+	58,  // 75: api.v2.SyncAppData.error:type_name -> api.v2.SyncAppError
+	61,  // 76: api.v2.QueryInsightsResponse.columns:type_name -> api.v2.InsightsColumn
+	62,  // 77: api.v2.QueryInsightsResponse.rows:type_name -> api.v2.InsightsRow
+	63,  // 78: api.v2.QueryInsightsResponse.diagnostics:type_name -> api.v2.InsightsDiagnostic
+	5,   // 79: api.v2.InsightsColumn.type:type_name -> api.v2.InsightsColumnType
+	68,  // 80: api.v2.InsightsRow.values:type_name -> google.protobuf.Value
+	6,   // 81: api.v2.InsightsDiagnostic.severity:type_name -> api.v2.InsightsDiagnosticSeverity
+	64,  // 82: api.v2.InsightsDiagnostic.position:type_name -> api.v2.InsightsDiagnosticPosition
+	7,   // 83: api.v2.V2.Health:input_type -> api.v2.HealthRequest
+	7,   // 84: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
+	25,  // 85: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
+	27,  // 86: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
+	31,  // 87: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
+	8,   // 88: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
+	39,  // 89: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
+	36,  // 90: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
+	41,  // 91: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
+	44,  // 92: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
+	47,  // 93: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
+	50,  // 94: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
+	18,  // 95: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
+	55,  // 96: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
+	23,  // 97: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
+	52,  // 98: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
+	59,  // 99: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
+	9,   // 100: api.v2.V2.Health:output_type -> api.v2.HealthResponse
+	12,  // 101: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
+	26,  // 102: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
+	28,  // 103: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
+	32,  // 104: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
+	33,  // 105: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
+	40,  // 106: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
+	37,  // 107: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
+	42,  // 108: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
+	45,  // 109: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
+	48,  // 110: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
+	51,  // 111: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
+	19,  // 112: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
+	56,  // 113: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
+	24,  // 114: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
+	53,  // 115: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
+	60,  // 116: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
+	100, // [100:117] is the sub-list for method output_type
+	83,  // [83:100] is the sub-list for method input_type
+	83,  // [83:83] is the sub-list for extension type_name
+	83,  // [83:83] is the sub-list for extension extendee
+	0,   // [0:83] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_service_proto_init() }
@@ -4325,13 +4843,14 @@ func file_api_v2_service_proto_init() {
 	file_api_v2_service_proto_msgTypes[45].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[47].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[50].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[56].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v2_service_proto_rawDesc), len(file_api_v2_service_proto_rawDesc)),
-			NumEnums:      5,
-			NumMessages:   53,
+			NumEnums:      7,
+			NumMessages:   59,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -4301,6 +4301,170 @@ func (x *QueryInsightsPromptData) GetDiagnostics() []*InsightsDiagnostic {
 	return nil
 }
 
+type ListInsightsEventSchemasRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Cursor        *string                `protobuf:"bytes,1,opt,name=cursor,proto3,oneof" json:"cursor,omitempty"`
+	Limit         *int32                 `protobuf:"varint,2,opt,name=limit,proto3,oneof" json:"limit,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListInsightsEventSchemasRequest) Reset() {
+	*x = ListInsightsEventSchemasRequest{}
+	mi := &file_api_v2_service_proto_msgTypes[66]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListInsightsEventSchemasRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListInsightsEventSchemasRequest) ProtoMessage() {}
+
+func (x *ListInsightsEventSchemasRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[66]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListInsightsEventSchemasRequest.ProtoReflect.Descriptor instead.
+func (*ListInsightsEventSchemasRequest) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{66}
+}
+
+func (x *ListInsightsEventSchemasRequest) GetCursor() string {
+	if x != nil && x.Cursor != nil {
+		return *x.Cursor
+	}
+	return ""
+}
+
+func (x *ListInsightsEventSchemasRequest) GetLimit() int32 {
+	if x != nil && x.Limit != nil {
+		return *x.Limit
+	}
+	return 0
+}
+
+type ListInsightsEventSchemasResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Data          []*InsightsEventSchema `protobuf:"bytes,1,rep,name=data,proto3" json:"data,omitempty"`
+	Metadata      *ResponseMetadata      `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	Page          *Page                  `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListInsightsEventSchemasResponse) Reset() {
+	*x = ListInsightsEventSchemasResponse{}
+	mi := &file_api_v2_service_proto_msgTypes[67]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListInsightsEventSchemasResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListInsightsEventSchemasResponse) ProtoMessage() {}
+
+func (x *ListInsightsEventSchemasResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[67]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListInsightsEventSchemasResponse.ProtoReflect.Descriptor instead.
+func (*ListInsightsEventSchemasResponse) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{67}
+}
+
+func (x *ListInsightsEventSchemasResponse) GetData() []*InsightsEventSchema {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+func (x *ListInsightsEventSchemasResponse) GetMetadata() *ResponseMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *ListInsightsEventSchemasResponse) GetPage() *Page {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+type InsightsEventSchema struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Schema        *structpb.Struct       `protobuf:"bytes,2,opt,name=schema,proto3" json:"schema,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InsightsEventSchema) Reset() {
+	*x = InsightsEventSchema{}
+	mi := &file_api_v2_service_proto_msgTypes[68]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InsightsEventSchema) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InsightsEventSchema) ProtoMessage() {}
+
+func (x *InsightsEventSchema) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[68]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InsightsEventSchema.ProtoReflect.Descriptor instead.
+func (*InsightsEventSchema) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{68}
+}
+
+func (x *InsightsEventSchema) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *InsightsEventSchema) GetSchema() *structpb.Struct {
+	if x != nil {
+		return x.Schema
+	}
+	return nil
+}
+
 var File_api_v2_service_proto protoreflect.FileDescriptor
 
 const file_api_v2_service_proto_rawDesc = "" +
@@ -4624,7 +4788,19 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\xc9\x03\n" +
 	"\x17QueryInsightsPromptData\x12\xa8\x02\n" +
 	"\x05query\x18\x01 \x01(\tB\x91\x02\x92A\x8d\x022 The generated Insights SQL queryJ\xe8\x01\"SELECT function_id, COUNT(*) AS total, countIf(status = 'Failed') AS failures, failures / total AS failure_rate FROM function_runs WHERE started_at >= now() - INTERVAL 7 DAY GROUP BY function_id ORDER BY failure_rate DESC LIMIT 10\"R\x05query\x12\x82\x01\n" +
-	"\vdiagnostics\x18\x02 \x03(\v2\x1a.api.v2.InsightsDiagnosticBD\x92AA2?Any non-fatal diagnostics or warnings about the generated queryR\vdiagnostics*\xdf\x01\n" +
+	"\vdiagnostics\x18\x02 \x03(\v2\x1a.api.v2.InsightsDiagnosticBD\x92AA2?Any non-fatal diagnostics or warnings about the generated queryR\vdiagnostics\"\xe5\x01\n" +
+	"\x1fListInsightsEventSchemasRequest\x12J\n" +
+	"\x06cursor\x18\x01 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x00R\x06cursor\x88\x01\x01\x12a\n" +
+	"\x05limit\x18\x02 \x01(\x05BF\x92AC2=Number of event schemas to return per page (min: 1, max: 100):\x0220H\x01R\x05limit\x88\x01\x01B\t\n" +
+	"\a_cursorB\b\n" +
+	"\x06_limit\"\xd6\x01\n" +
+	" ListInsightsEventSchemasResponse\x12Z\n" +
+	"\x04data\x18\x01 \x03(\v2\x1b.api.v2.InsightsEventSchemaB)\x92A&2$Paginated list of event type schemasR\x04data\x124\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\x12 \n" +
+	"\x04page\x18\x03 \x01(\v2\f.api.v2.PageR\x04page\"\xec\x01\n" +
+	"\x13InsightsEventSchema\x12B\n" +
+	"\x04name\x18\x01 \x01(\tB.\x92A+2\x0fEvent type nameJ\x18\"orders/payment.created\"R\x04name\x12\x90\x01\n" +
+	"\x06schema\x18\x02 \x01(\v2\x17.google.protobuf.StructB_\x92A\\2ZJSON Schema describing the shape of this event's data, represented as a nested JSON objectR\x06schema*\xdf\x01\n" +
 	"\x11FunctionRunStatus\x12#\n" +
 	"\x1fFUNCTION_RUN_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aFUNCTION_RUN_STATUS_QUEUED\x10\x01\x12\x1f\n" +
@@ -4672,7 +4848,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05ERROR\x10\x01\x12\v\n" +
 	"\aWARNING\x10\x02\x12\b\n" +
-	"\x04INFO\x10\x032\xe7c\n" +
+	"\x04INFO\x10\x032\xdei\n" +
 	"\x02V2\x12\xbc\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\x82\x02\x92A\xef\x01\n" +
 	"\bInternal\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
@@ -5016,7 +5192,28 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x12\x12\x10/insights/tables\x12\x94\x06\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x12\x12\x10/insights/tables\x12\xf4\x05\n" +
+	"\x18ListInsightsEventSchemas\x12'.api.v2.ListInsightsEventSchemasRequest\x1a(.api.v2.ListInsightsEventSchemasResponse\"\x84\x05\x92A\xe0\x04\n" +
+	"\bInsights\n" +
+	"\x04Beta\x12\x17List event type schemas\x1a\x80\x01Returns a paginated list of event type schemas, where each schema describes the shape of a specific event's data as nested JSON.Jc\n" +
+	"\x03200\x12\\\n" +
+	"$Paginated list of event type schemas\x124\n" +
+	"2\x1a0#/definitions/v2ListInsightsEventSchemasResponseJR\n" +
+	"\x03400\x12K\n" +
+	"&Bad Request - invalid query parameters\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJR\n" +
+	"\x03401\x12K\n" +
+	"&Unauthorized - authentication required\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJP\n" +
+	"\x03403\x12I\n" +
+	"$Forbidden - insufficient permissions\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJA\n" +
+	"\x03500\x12:\n" +
+	"\x15Internal Server Error\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
+	"\x0e\n" +
+	"\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x1a\x12\x18/insights/events/schemas\x12\x94\x06\n" +
 	"\x13QueryInsightsPrompt\x12\".api.v2.QueryInsightsPromptRequest\x1a#.api.v2.QueryInsightsPromptResponse\"\xb3\x05\x92A\x8e\x05\n" +
 	"\bInsights\n" +
 	"\x04Beta\x12#Generate insights query from prompt\x1a@Translates a natural language prompt into an Insights SQL query.JV\n" +
@@ -5094,111 +5291,114 @@ func file_api_v2_service_proto_rawDescGZIP() []byte {
 }
 
 var file_api_v2_service_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 67)
+var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 70)
 var file_api_v2_service_proto_goTypes = []any{
-	(FunctionRunStatus)(0),                  // 0: api.v2.FunctionRunStatus
-	(TraceSpanStatus)(0),                    // 1: api.v2.TraceSpanStatus
-	(TraceStepOp)(0),                        // 2: api.v2.TraceStepOp
-	(EnvType)(0),                            // 3: api.v2.EnvType
-	(FilterType)(0),                         // 4: api.v2.FilterType
-	(InsightsOutputColumnType)(0),           // 5: api.v2.InsightsOutputColumnType
-	(InsightsDiagnosticSeverity)(0),         // 6: api.v2.InsightsDiagnosticSeverity
-	(*HealthRequest)(nil),                   // 7: api.v2.HealthRequest
-	(*FetchAccountRequest)(nil),             // 8: api.v2.FetchAccountRequest
-	(*HealthResponse)(nil),                  // 9: api.v2.HealthResponse
-	(*HealthData)(nil),                      // 10: api.v2.HealthData
-	(*Error)(nil),                           // 11: api.v2.Error
-	(*ErrorResponse)(nil),                   // 12: api.v2.ErrorResponse
-	(*ResponseMetadata)(nil),                // 13: api.v2.ResponseMetadata
-	(*FunctionRef)(nil),                     // 14: api.v2.FunctionRef
-	(*AppRef)(nil),                          // 15: api.v2.AppRef
-	(*RunTrigger)(nil),                      // 16: api.v2.RunTrigger
-	(*FunctionRun)(nil),                     // 17: api.v2.FunctionRun
-	(*GetFunctionRunRequest)(nil),           // 18: api.v2.GetFunctionRunRequest
-	(*GetFunctionRunResponse)(nil),          // 19: api.v2.GetFunctionRunResponse
-	(*TraceSpanMetadata)(nil),               // 20: api.v2.TraceSpanMetadata
-	(*TraceSpan)(nil),                       // 21: api.v2.TraceSpan
-	(*FunctionTrace)(nil),                   // 22: api.v2.FunctionTrace
-	(*GetFunctionTraceRequest)(nil),         // 23: api.v2.GetFunctionTraceRequest
-	(*GetFunctionTraceResponse)(nil),        // 24: api.v2.GetFunctionTraceResponse
-	(*CreateAccountRequest)(nil),            // 25: api.v2.CreateAccountRequest
-	(*CreateAccountResponse)(nil),           // 26: api.v2.CreateAccountResponse
-	(*CreateEnvRequest)(nil),                // 27: api.v2.CreateEnvRequest
-	(*CreateEnvResponse)(nil),               // 28: api.v2.CreateEnvResponse
-	(*Env)(nil),                             // 29: api.v2.Env
-	(*CreateAccountData)(nil),               // 30: api.v2.CreateAccountData
-	(*FetchAccountsRequest)(nil),            // 31: api.v2.FetchAccountsRequest
-	(*FetchAccountsResponse)(nil),           // 32: api.v2.FetchAccountsResponse
-	(*FetchAccountResponse)(nil),            // 33: api.v2.FetchAccountResponse
-	(*Account)(nil),                         // 34: api.v2.Account
-	(*Page)(nil),                            // 35: api.v2.Page
-	(*FetchAccountEventKeysRequest)(nil),    // 36: api.v2.FetchAccountEventKeysRequest
-	(*FetchAccountEventKeysResponse)(nil),   // 37: api.v2.FetchAccountEventKeysResponse
-	(*EventKey)(nil),                        // 38: api.v2.EventKey
-	(*FetchAccountEnvsRequest)(nil),         // 39: api.v2.FetchAccountEnvsRequest
-	(*FetchAccountEnvsResponse)(nil),        // 40: api.v2.FetchAccountEnvsResponse
-	(*FetchAccountSigningKeysRequest)(nil),  // 41: api.v2.FetchAccountSigningKeysRequest
-	(*FetchAccountSigningKeysResponse)(nil), // 42: api.v2.FetchAccountSigningKeysResponse
-	(*SigningKey)(nil),                      // 43: api.v2.SigningKey
-	(*CreateWebhookRequest)(nil),            // 44: api.v2.CreateWebhookRequest
-	(*CreateWebhookResponse)(nil),           // 45: api.v2.CreateWebhookResponse
-	(*EventFilter)(nil),                     // 46: api.v2.EventFilter
-	(*ListWebhooksRequest)(nil),             // 47: api.v2.ListWebhooksRequest
-	(*ListWebhooksResponse)(nil),            // 48: api.v2.ListWebhooksResponse
-	(*Webhook)(nil),                         // 49: api.v2.Webhook
-	(*PatchEnvRequest)(nil),                 // 50: api.v2.PatchEnvRequest
-	(*PatchEnvsResponse)(nil),               // 51: api.v2.PatchEnvsResponse
-	(*InvokeFunctionRequest)(nil),           // 52: api.v2.InvokeFunctionRequest
-	(*InvokeFunctionResponse)(nil),          // 53: api.v2.InvokeFunctionResponse
-	(*InvokeFunctionData)(nil),              // 54: api.v2.InvokeFunctionData
-	(*SyncAppRequest)(nil),                  // 55: api.v2.SyncAppRequest
-	(*SyncAppResponse)(nil),                 // 56: api.v2.SyncAppResponse
-	(*SyncAppData)(nil),                     // 57: api.v2.SyncAppData
-	(*SyncAppError)(nil),                    // 58: api.v2.SyncAppError
-	(*QueryInsightsRequest)(nil),            // 59: api.v2.QueryInsightsRequest
-	(*QueryInsightsResponse)(nil),           // 60: api.v2.QueryInsightsResponse
-	(*QueryInsightsData)(nil),               // 61: api.v2.QueryInsightsData
-	(*InsightsOutputColumn)(nil),            // 62: api.v2.InsightsOutputColumn
-	(*InsightsRow)(nil),                     // 63: api.v2.InsightsRow
-	(*InsightsDiagnostic)(nil),              // 64: api.v2.InsightsDiagnostic
-	(*InsightsDiagnosticPosition)(nil),      // 65: api.v2.InsightsDiagnosticPosition
-	(*ListInsightsTablesRequest)(nil),       // 66: api.v2.ListInsightsTablesRequest
-	(*ListInsightsTablesResponse)(nil),      // 67: api.v2.ListInsightsTablesResponse
-	(*InsightsTable)(nil),                   // 68: api.v2.InsightsTable
-	(*InsightsTableColumn)(nil),             // 69: api.v2.InsightsTableColumn
-	(*QueryInsightsPromptRequest)(nil),      // 70: api.v2.QueryInsightsPromptRequest
-	(*QueryInsightsPromptResponse)(nil),     // 71: api.v2.QueryInsightsPromptResponse
-	(*QueryInsightsPromptData)(nil),         // 72: api.v2.QueryInsightsPromptData
-	nil,                                     // 73: api.v2.TraceSpanMetadata.ValuesEntry
-	(*timestamppb.Timestamp)(nil),           // 74: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                 // 75: google.protobuf.Struct
-	(*structpb.Value)(nil),                  // 76: google.protobuf.Value
+	(FunctionRunStatus)(0),                   // 0: api.v2.FunctionRunStatus
+	(TraceSpanStatus)(0),                     // 1: api.v2.TraceSpanStatus
+	(TraceStepOp)(0),                         // 2: api.v2.TraceStepOp
+	(EnvType)(0),                             // 3: api.v2.EnvType
+	(FilterType)(0),                          // 4: api.v2.FilterType
+	(InsightsOutputColumnType)(0),            // 5: api.v2.InsightsOutputColumnType
+	(InsightsDiagnosticSeverity)(0),          // 6: api.v2.InsightsDiagnosticSeverity
+	(*HealthRequest)(nil),                    // 7: api.v2.HealthRequest
+	(*FetchAccountRequest)(nil),              // 8: api.v2.FetchAccountRequest
+	(*HealthResponse)(nil),                   // 9: api.v2.HealthResponse
+	(*HealthData)(nil),                       // 10: api.v2.HealthData
+	(*Error)(nil),                            // 11: api.v2.Error
+	(*ErrorResponse)(nil),                    // 12: api.v2.ErrorResponse
+	(*ResponseMetadata)(nil),                 // 13: api.v2.ResponseMetadata
+	(*FunctionRef)(nil),                      // 14: api.v2.FunctionRef
+	(*AppRef)(nil),                           // 15: api.v2.AppRef
+	(*RunTrigger)(nil),                       // 16: api.v2.RunTrigger
+	(*FunctionRun)(nil),                      // 17: api.v2.FunctionRun
+	(*GetFunctionRunRequest)(nil),            // 18: api.v2.GetFunctionRunRequest
+	(*GetFunctionRunResponse)(nil),           // 19: api.v2.GetFunctionRunResponse
+	(*TraceSpanMetadata)(nil),                // 20: api.v2.TraceSpanMetadata
+	(*TraceSpan)(nil),                        // 21: api.v2.TraceSpan
+	(*FunctionTrace)(nil),                    // 22: api.v2.FunctionTrace
+	(*GetFunctionTraceRequest)(nil),          // 23: api.v2.GetFunctionTraceRequest
+	(*GetFunctionTraceResponse)(nil),         // 24: api.v2.GetFunctionTraceResponse
+	(*CreateAccountRequest)(nil),             // 25: api.v2.CreateAccountRequest
+	(*CreateAccountResponse)(nil),            // 26: api.v2.CreateAccountResponse
+	(*CreateEnvRequest)(nil),                 // 27: api.v2.CreateEnvRequest
+	(*CreateEnvResponse)(nil),                // 28: api.v2.CreateEnvResponse
+	(*Env)(nil),                              // 29: api.v2.Env
+	(*CreateAccountData)(nil),                // 30: api.v2.CreateAccountData
+	(*FetchAccountsRequest)(nil),             // 31: api.v2.FetchAccountsRequest
+	(*FetchAccountsResponse)(nil),            // 32: api.v2.FetchAccountsResponse
+	(*FetchAccountResponse)(nil),             // 33: api.v2.FetchAccountResponse
+	(*Account)(nil),                          // 34: api.v2.Account
+	(*Page)(nil),                             // 35: api.v2.Page
+	(*FetchAccountEventKeysRequest)(nil),     // 36: api.v2.FetchAccountEventKeysRequest
+	(*FetchAccountEventKeysResponse)(nil),    // 37: api.v2.FetchAccountEventKeysResponse
+	(*EventKey)(nil),                         // 38: api.v2.EventKey
+	(*FetchAccountEnvsRequest)(nil),          // 39: api.v2.FetchAccountEnvsRequest
+	(*FetchAccountEnvsResponse)(nil),         // 40: api.v2.FetchAccountEnvsResponse
+	(*FetchAccountSigningKeysRequest)(nil),   // 41: api.v2.FetchAccountSigningKeysRequest
+	(*FetchAccountSigningKeysResponse)(nil),  // 42: api.v2.FetchAccountSigningKeysResponse
+	(*SigningKey)(nil),                       // 43: api.v2.SigningKey
+	(*CreateWebhookRequest)(nil),             // 44: api.v2.CreateWebhookRequest
+	(*CreateWebhookResponse)(nil),            // 45: api.v2.CreateWebhookResponse
+	(*EventFilter)(nil),                      // 46: api.v2.EventFilter
+	(*ListWebhooksRequest)(nil),              // 47: api.v2.ListWebhooksRequest
+	(*ListWebhooksResponse)(nil),             // 48: api.v2.ListWebhooksResponse
+	(*Webhook)(nil),                          // 49: api.v2.Webhook
+	(*PatchEnvRequest)(nil),                  // 50: api.v2.PatchEnvRequest
+	(*PatchEnvsResponse)(nil),                // 51: api.v2.PatchEnvsResponse
+	(*InvokeFunctionRequest)(nil),            // 52: api.v2.InvokeFunctionRequest
+	(*InvokeFunctionResponse)(nil),           // 53: api.v2.InvokeFunctionResponse
+	(*InvokeFunctionData)(nil),               // 54: api.v2.InvokeFunctionData
+	(*SyncAppRequest)(nil),                   // 55: api.v2.SyncAppRequest
+	(*SyncAppResponse)(nil),                  // 56: api.v2.SyncAppResponse
+	(*SyncAppData)(nil),                      // 57: api.v2.SyncAppData
+	(*SyncAppError)(nil),                     // 58: api.v2.SyncAppError
+	(*QueryInsightsRequest)(nil),             // 59: api.v2.QueryInsightsRequest
+	(*QueryInsightsResponse)(nil),            // 60: api.v2.QueryInsightsResponse
+	(*QueryInsightsData)(nil),                // 61: api.v2.QueryInsightsData
+	(*InsightsOutputColumn)(nil),             // 62: api.v2.InsightsOutputColumn
+	(*InsightsRow)(nil),                      // 63: api.v2.InsightsRow
+	(*InsightsDiagnostic)(nil),               // 64: api.v2.InsightsDiagnostic
+	(*InsightsDiagnosticPosition)(nil),       // 65: api.v2.InsightsDiagnosticPosition
+	(*ListInsightsTablesRequest)(nil),        // 66: api.v2.ListInsightsTablesRequest
+	(*ListInsightsTablesResponse)(nil),       // 67: api.v2.ListInsightsTablesResponse
+	(*InsightsTable)(nil),                    // 68: api.v2.InsightsTable
+	(*InsightsTableColumn)(nil),              // 69: api.v2.InsightsTableColumn
+	(*QueryInsightsPromptRequest)(nil),       // 70: api.v2.QueryInsightsPromptRequest
+	(*QueryInsightsPromptResponse)(nil),      // 71: api.v2.QueryInsightsPromptResponse
+	(*QueryInsightsPromptData)(nil),          // 72: api.v2.QueryInsightsPromptData
+	(*ListInsightsEventSchemasRequest)(nil),  // 73: api.v2.ListInsightsEventSchemasRequest
+	(*ListInsightsEventSchemasResponse)(nil), // 74: api.v2.ListInsightsEventSchemasResponse
+	(*InsightsEventSchema)(nil),              // 75: api.v2.InsightsEventSchema
+	nil,                                      // 76: api.v2.TraceSpanMetadata.ValuesEntry
+	(*timestamppb.Timestamp)(nil),            // 77: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                  // 78: google.protobuf.Struct
+	(*structpb.Value)(nil),                   // 79: google.protobuf.Value
 }
 var file_api_v2_service_proto_depIdxs = []int32{
 	10,  // 0: api.v2.HealthResponse.data:type_name -> api.v2.HealthData
 	13,  // 1: api.v2.HealthResponse.metadata:type_name -> api.v2.ResponseMetadata
 	11,  // 2: api.v2.ErrorResponse.errors:type_name -> api.v2.Error
-	74,  // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
-	74,  // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
+	77,  // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
+	77,  // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
 	14,  // 5: api.v2.FunctionRun.function:type_name -> api.v2.FunctionRef
 	15,  // 6: api.v2.FunctionRun.app:type_name -> api.v2.AppRef
 	0,   // 7: api.v2.FunctionRun.status:type_name -> api.v2.FunctionRunStatus
-	74,  // 8: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
-	74,  // 9: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
-	74,  // 10: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
+	77,  // 8: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
+	77,  // 9: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
+	77,  // 10: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
 	16,  // 11: api.v2.FunctionRun.trigger:type_name -> api.v2.RunTrigger
-	75,  // 12: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
+	78,  // 12: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
 	17,  // 13: api.v2.GetFunctionRunResponse.data:type_name -> api.v2.FunctionRun
 	13,  // 14: api.v2.GetFunctionRunResponse.metadata:type_name -> api.v2.ResponseMetadata
-	73,  // 15: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
-	74,  // 16: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
+	76,  // 15: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
+	77,  // 16: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
 	1,   // 17: api.v2.TraceSpan.status:type_name -> api.v2.TraceSpanStatus
 	2,   // 18: api.v2.TraceSpan.step_op:type_name -> api.v2.TraceStepOp
-	74,  // 19: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
-	74,  // 20: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
-	74,  // 21: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
-	75,  // 22: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
-	75,  // 23: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
+	77,  // 19: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
+	77,  // 20: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
+	77,  // 21: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
+	78,  // 22: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
+	78,  // 23: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
 	20,  // 24: api.v2.TraceSpan.metadata:type_name -> api.v2.TraceSpanMetadata
 	21,  // 25: api.v2.TraceSpan.children:type_name -> api.v2.TraceSpan
 	21,  // 26: api.v2.FunctionTrace.root_span:type_name -> api.v2.TraceSpan
@@ -5209,27 +5409,27 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	29,  // 31: api.v2.CreateEnvResponse.data:type_name -> api.v2.Env
 	13,  // 32: api.v2.CreateEnvResponse.metadata:type_name -> api.v2.ResponseMetadata
 	3,   // 33: api.v2.Env.type:type_name -> api.v2.EnvType
-	74,  // 34: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
-	74,  // 35: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
-	74,  // 36: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
+	77,  // 34: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
+	77,  // 35: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
+	77,  // 36: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
 	34,  // 37: api.v2.FetchAccountsResponse.data:type_name -> api.v2.Account
 	13,  // 38: api.v2.FetchAccountsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 39: api.v2.FetchAccountsResponse.page:type_name -> api.v2.Page
 	34,  // 40: api.v2.FetchAccountResponse.data:type_name -> api.v2.Account
 	13,  // 41: api.v2.FetchAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
-	74,  // 42: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
-	74,  // 43: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
+	77,  // 42: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
+	77,  // 43: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
 	38,  // 44: api.v2.FetchAccountEventKeysResponse.data:type_name -> api.v2.EventKey
 	13,  // 45: api.v2.FetchAccountEventKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 46: api.v2.FetchAccountEventKeysResponse.page:type_name -> api.v2.Page
-	74,  // 47: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
+	77,  // 47: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
 	29,  // 48: api.v2.FetchAccountEnvsResponse.data:type_name -> api.v2.Env
 	13,  // 49: api.v2.FetchAccountEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 50: api.v2.FetchAccountEnvsResponse.page:type_name -> api.v2.Page
 	43,  // 51: api.v2.FetchAccountSigningKeysResponse.data:type_name -> api.v2.SigningKey
 	13,  // 52: api.v2.FetchAccountSigningKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 53: api.v2.FetchAccountSigningKeysResponse.page:type_name -> api.v2.Page
-	74,  // 54: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
+	77,  // 54: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
 	46,  // 55: api.v2.CreateWebhookRequest.event_filter:type_name -> api.v2.EventFilter
 	49,  // 56: api.v2.CreateWebhookResponse.data:type_name -> api.v2.Webhook
 	13,  // 57: api.v2.CreateWebhookResponse.metadata:type_name -> api.v2.ResponseMetadata
@@ -5238,16 +5438,16 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	13,  // 60: api.v2.ListWebhooksResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 61: api.v2.ListWebhooksResponse.page:type_name -> api.v2.Page
 	46,  // 62: api.v2.Webhook.event_filter:type_name -> api.v2.EventFilter
-	74,  // 63: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
-	74,  // 64: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
+	77,  // 63: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
+	77,  // 64: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
 	29,  // 65: api.v2.PatchEnvsResponse.data:type_name -> api.v2.Env
 	13,  // 66: api.v2.PatchEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	75,  // 67: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
+	78,  // 67: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
 	54,  // 68: api.v2.InvokeFunctionResponse.data:type_name -> api.v2.InvokeFunctionData
 	13,  // 69: api.v2.InvokeFunctionResponse.metadata:type_name -> api.v2.ResponseMetadata
-	74,  // 70: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
-	74,  // 71: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
-	74,  // 72: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
+	77,  // 70: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
+	77,  // 71: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
+	77,  // 72: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
 	57,  // 73: api.v2.SyncAppResponse.data:type_name -> api.v2.SyncAppData
 	13,  // 74: api.v2.SyncAppResponse.metadata:type_name -> api.v2.ResponseMetadata
 	58,  // 75: api.v2.SyncAppData.error:type_name -> api.v2.SyncAppError
@@ -5257,7 +5457,7 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	63,  // 79: api.v2.QueryInsightsData.rows:type_name -> api.v2.InsightsRow
 	64,  // 80: api.v2.QueryInsightsData.diagnostics:type_name -> api.v2.InsightsDiagnostic
 	5,   // 81: api.v2.InsightsOutputColumn.type:type_name -> api.v2.InsightsOutputColumnType
-	76,  // 82: api.v2.InsightsRow.values:type_name -> google.protobuf.Value
+	79,  // 82: api.v2.InsightsRow.values:type_name -> google.protobuf.Value
 	6,   // 83: api.v2.InsightsDiagnostic.severity:type_name -> api.v2.InsightsDiagnosticSeverity
 	65,  // 84: api.v2.InsightsDiagnostic.position:type_name -> api.v2.InsightsDiagnosticPosition
 	68,  // 85: api.v2.ListInsightsTablesResponse.data:type_name -> api.v2.InsightsTable
@@ -5266,49 +5466,55 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	72,  // 88: api.v2.QueryInsightsPromptResponse.data:type_name -> api.v2.QueryInsightsPromptData
 	13,  // 89: api.v2.QueryInsightsPromptResponse.metadata:type_name -> api.v2.ResponseMetadata
 	64,  // 90: api.v2.QueryInsightsPromptData.diagnostics:type_name -> api.v2.InsightsDiagnostic
-	7,   // 91: api.v2.V2.Health:input_type -> api.v2.HealthRequest
-	7,   // 92: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
-	25,  // 93: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
-	27,  // 94: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
-	31,  // 95: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
-	8,   // 96: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
-	39,  // 97: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
-	36,  // 98: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
-	41,  // 99: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
-	44,  // 100: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
-	47,  // 101: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
-	50,  // 102: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
-	18,  // 103: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
-	55,  // 104: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
-	23,  // 105: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
-	52,  // 106: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
-	66,  // 107: api.v2.V2.ListInsightsTables:input_type -> api.v2.ListInsightsTablesRequest
-	70,  // 108: api.v2.V2.QueryInsightsPrompt:input_type -> api.v2.QueryInsightsPromptRequest
-	59,  // 109: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
-	9,   // 110: api.v2.V2.Health:output_type -> api.v2.HealthResponse
-	12,  // 111: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
-	26,  // 112: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
-	28,  // 113: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
-	32,  // 114: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
-	33,  // 115: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
-	40,  // 116: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
-	37,  // 117: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
-	42,  // 118: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
-	45,  // 119: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
-	48,  // 120: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
-	51,  // 121: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
-	19,  // 122: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
-	56,  // 123: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
-	24,  // 124: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
-	53,  // 125: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
-	67,  // 126: api.v2.V2.ListInsightsTables:output_type -> api.v2.ListInsightsTablesResponse
-	71,  // 127: api.v2.V2.QueryInsightsPrompt:output_type -> api.v2.QueryInsightsPromptResponse
-	60,  // 128: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
-	110, // [110:129] is the sub-list for method output_type
-	91,  // [91:110] is the sub-list for method input_type
-	91,  // [91:91] is the sub-list for extension type_name
-	91,  // [91:91] is the sub-list for extension extendee
-	0,   // [0:91] is the sub-list for field type_name
+	75,  // 91: api.v2.ListInsightsEventSchemasResponse.data:type_name -> api.v2.InsightsEventSchema
+	13,  // 92: api.v2.ListInsightsEventSchemasResponse.metadata:type_name -> api.v2.ResponseMetadata
+	35,  // 93: api.v2.ListInsightsEventSchemasResponse.page:type_name -> api.v2.Page
+	78,  // 94: api.v2.InsightsEventSchema.schema:type_name -> google.protobuf.Struct
+	7,   // 95: api.v2.V2.Health:input_type -> api.v2.HealthRequest
+	7,   // 96: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
+	25,  // 97: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
+	27,  // 98: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
+	31,  // 99: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
+	8,   // 100: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
+	39,  // 101: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
+	36,  // 102: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
+	41,  // 103: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
+	44,  // 104: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
+	47,  // 105: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
+	50,  // 106: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
+	18,  // 107: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
+	55,  // 108: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
+	23,  // 109: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
+	52,  // 110: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
+	66,  // 111: api.v2.V2.ListInsightsTables:input_type -> api.v2.ListInsightsTablesRequest
+	73,  // 112: api.v2.V2.ListInsightsEventSchemas:input_type -> api.v2.ListInsightsEventSchemasRequest
+	70,  // 113: api.v2.V2.QueryInsightsPrompt:input_type -> api.v2.QueryInsightsPromptRequest
+	59,  // 114: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
+	9,   // 115: api.v2.V2.Health:output_type -> api.v2.HealthResponse
+	12,  // 116: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
+	26,  // 117: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
+	28,  // 118: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
+	32,  // 119: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
+	33,  // 120: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
+	40,  // 121: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
+	37,  // 122: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
+	42,  // 123: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
+	45,  // 124: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
+	48,  // 125: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
+	51,  // 126: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
+	19,  // 127: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
+	56,  // 128: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
+	24,  // 129: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
+	53,  // 130: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
+	67,  // 131: api.v2.V2.ListInsightsTables:output_type -> api.v2.ListInsightsTablesResponse
+	74,  // 132: api.v2.V2.ListInsightsEventSchemas:output_type -> api.v2.ListInsightsEventSchemasResponse
+	71,  // 133: api.v2.V2.QueryInsightsPrompt:output_type -> api.v2.QueryInsightsPromptResponse
+	60,  // 134: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
+	115, // [115:135] is the sub-list for method output_type
+	95,  // [95:115] is the sub-list for method input_type
+	95,  // [95:95] is the sub-list for extension type_name
+	95,  // [95:95] is the sub-list for extension extendee
+	0,   // [0:95] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_service_proto_init() }
@@ -5337,13 +5543,14 @@ func file_api_v2_service_proto_init() {
 	file_api_v2_service_proto_msgTypes[47].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[50].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[57].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[66].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v2_service_proto_rawDesc), len(file_api_v2_service_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   67,
+			NumMessages:   70,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -303,20 +303,20 @@ func (FilterType) EnumDescriptor() ([]byte, []int) {
 	return file_api_v2_service_proto_rawDescGZIP(), []int{4}
 }
 
-type InsightsColumnType int32
+type InsightsOutputColumnType int32
 
 const (
-	InsightsColumnType_VALUE_TYPE_UNSPECIFIED InsightsColumnType = 0
-	InsightsColumnType_STRING                 InsightsColumnType = 1
-	InsightsColumnType_NUMBER                 InsightsColumnType = 2
-	InsightsColumnType_BOOLEAN                InsightsColumnType = 3
-	InsightsColumnType_DATETIME               InsightsColumnType = 4
-	InsightsColumnType_COMPLEX                InsightsColumnType = 5
+	InsightsOutputColumnType_VALUE_TYPE_UNSPECIFIED InsightsOutputColumnType = 0
+	InsightsOutputColumnType_STRING                 InsightsOutputColumnType = 1
+	InsightsOutputColumnType_NUMBER                 InsightsOutputColumnType = 2
+	InsightsOutputColumnType_BOOLEAN                InsightsOutputColumnType = 3
+	InsightsOutputColumnType_DATETIME               InsightsOutputColumnType = 4
+	InsightsOutputColumnType_COMPLEX                InsightsOutputColumnType = 5
 )
 
-// Enum value maps for InsightsColumnType.
+// Enum value maps for InsightsOutputColumnType.
 var (
-	InsightsColumnType_name = map[int32]string{
+	InsightsOutputColumnType_name = map[int32]string{
 		0: "VALUE_TYPE_UNSPECIFIED",
 		1: "STRING",
 		2: "NUMBER",
@@ -324,7 +324,7 @@ var (
 		4: "DATETIME",
 		5: "COMPLEX",
 	}
-	InsightsColumnType_value = map[string]int32{
+	InsightsOutputColumnType_value = map[string]int32{
 		"VALUE_TYPE_UNSPECIFIED": 0,
 		"STRING":                 1,
 		"NUMBER":                 2,
@@ -334,30 +334,30 @@ var (
 	}
 )
 
-func (x InsightsColumnType) Enum() *InsightsColumnType {
-	p := new(InsightsColumnType)
+func (x InsightsOutputColumnType) Enum() *InsightsOutputColumnType {
+	p := new(InsightsOutputColumnType)
 	*p = x
 	return p
 }
 
-func (x InsightsColumnType) String() string {
+func (x InsightsOutputColumnType) String() string {
 	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
 }
 
-func (InsightsColumnType) Descriptor() protoreflect.EnumDescriptor {
+func (InsightsOutputColumnType) Descriptor() protoreflect.EnumDescriptor {
 	return file_api_v2_service_proto_enumTypes[5].Descriptor()
 }
 
-func (InsightsColumnType) Type() protoreflect.EnumType {
+func (InsightsOutputColumnType) Type() protoreflect.EnumType {
 	return &file_api_v2_service_proto_enumTypes[5]
 }
 
-func (x InsightsColumnType) Number() protoreflect.EnumNumber {
+func (x InsightsOutputColumnType) Number() protoreflect.EnumNumber {
 	return protoreflect.EnumNumber(x)
 }
 
-// Deprecated: Use InsightsColumnType.Descriptor instead.
-func (InsightsColumnType) EnumDescriptor() ([]byte, []int) {
+// Deprecated: Use InsightsOutputColumnType.Descriptor instead.
+func (InsightsOutputColumnType) EnumDescriptor() ([]byte, []int) {
 	return file_api_v2_service_proto_rawDescGZIP(), []int{5}
 }
 
@@ -3611,9 +3611,8 @@ func (x *QueryInsightsRequest) GetQuery() string {
 
 type QueryInsightsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Columns       []*InsightsColumn      `protobuf:"bytes,1,rep,name=columns,proto3" json:"columns,omitempty"`
-	Rows          []*InsightsRow         `protobuf:"bytes,2,rep,name=rows,proto3" json:"rows,omitempty"`
-	Diagnostics   []*InsightsDiagnostic  `protobuf:"bytes,3,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
+	Data          *QueryInsightsData     `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	Metadata      *ResponseMetadata      `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3648,49 +3647,43 @@ func (*QueryInsightsResponse) Descriptor() ([]byte, []int) {
 	return file_api_v2_service_proto_rawDescGZIP(), []int{53}
 }
 
-func (x *QueryInsightsResponse) GetColumns() []*InsightsColumn {
+func (x *QueryInsightsResponse) GetData() *QueryInsightsData {
 	if x != nil {
-		return x.Columns
+		return x.Data
 	}
 	return nil
 }
 
-func (x *QueryInsightsResponse) GetRows() []*InsightsRow {
+func (x *QueryInsightsResponse) GetMetadata() *ResponseMetadata {
 	if x != nil {
-		return x.Rows
+		return x.Metadata
 	}
 	return nil
 }
 
-func (x *QueryInsightsResponse) GetDiagnostics() []*InsightsDiagnostic {
-	if x != nil {
-		return x.Diagnostics
-	}
-	return nil
-}
-
-type InsightsColumn struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Type          InsightsColumnType     `protobuf:"varint,2,opt,name=type,proto3,enum=api.v2.InsightsColumnType" json:"type,omitempty"`
+type QueryInsightsData struct {
+	state         protoimpl.MessageState  `protogen:"open.v1"`
+	Columns       []*InsightsOutputColumn `protobuf:"bytes,1,rep,name=columns,proto3" json:"columns,omitempty"`
+	Rows          []*InsightsRow          `protobuf:"bytes,2,rep,name=rows,proto3" json:"rows,omitempty"`
+	Diagnostics   []*InsightsDiagnostic   `protobuf:"bytes,3,rep,name=diagnostics,proto3" json:"diagnostics,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *InsightsColumn) Reset() {
-	*x = InsightsColumn{}
+func (x *QueryInsightsData) Reset() {
+	*x = QueryInsightsData{}
 	mi := &file_api_v2_service_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *InsightsColumn) String() string {
+func (x *QueryInsightsData) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*InsightsColumn) ProtoMessage() {}
+func (*QueryInsightsData) ProtoMessage() {}
 
-func (x *InsightsColumn) ProtoReflect() protoreflect.Message {
+func (x *QueryInsightsData) ProtoReflect() protoreflect.Message {
 	mi := &file_api_v2_service_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -3702,23 +3695,82 @@ func (x *InsightsColumn) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use InsightsColumn.ProtoReflect.Descriptor instead.
-func (*InsightsColumn) Descriptor() ([]byte, []int) {
+// Deprecated: Use QueryInsightsData.ProtoReflect.Descriptor instead.
+func (*QueryInsightsData) Descriptor() ([]byte, []int) {
 	return file_api_v2_service_proto_rawDescGZIP(), []int{54}
 }
 
-func (x *InsightsColumn) GetName() string {
+func (x *QueryInsightsData) GetColumns() []*InsightsOutputColumn {
+	if x != nil {
+		return x.Columns
+	}
+	return nil
+}
+
+func (x *QueryInsightsData) GetRows() []*InsightsRow {
+	if x != nil {
+		return x.Rows
+	}
+	return nil
+}
+
+func (x *QueryInsightsData) GetDiagnostics() []*InsightsDiagnostic {
+	if x != nil {
+		return x.Diagnostics
+	}
+	return nil
+}
+
+type InsightsOutputColumn struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Name          string                   `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Type          InsightsOutputColumnType `protobuf:"varint,2,opt,name=type,proto3,enum=api.v2.InsightsOutputColumnType" json:"type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InsightsOutputColumn) Reset() {
+	*x = InsightsOutputColumn{}
+	mi := &file_api_v2_service_proto_msgTypes[55]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InsightsOutputColumn) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InsightsOutputColumn) ProtoMessage() {}
+
+func (x *InsightsOutputColumn) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[55]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InsightsOutputColumn.ProtoReflect.Descriptor instead.
+func (*InsightsOutputColumn) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{55}
+}
+
+func (x *InsightsOutputColumn) GetName() string {
 	if x != nil {
 		return x.Name
 	}
 	return ""
 }
 
-func (x *InsightsColumn) GetType() InsightsColumnType {
+func (x *InsightsOutputColumn) GetType() InsightsOutputColumnType {
 	if x != nil {
 		return x.Type
 	}
-	return InsightsColumnType_VALUE_TYPE_UNSPECIFIED
+	return InsightsOutputColumnType_VALUE_TYPE_UNSPECIFIED
 }
 
 type InsightsRow struct {
@@ -3730,7 +3782,7 @@ type InsightsRow struct {
 
 func (x *InsightsRow) Reset() {
 	*x = InsightsRow{}
-	mi := &file_api_v2_service_proto_msgTypes[55]
+	mi := &file_api_v2_service_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3742,7 +3794,7 @@ func (x *InsightsRow) String() string {
 func (*InsightsRow) ProtoMessage() {}
 
 func (x *InsightsRow) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[55]
+	mi := &file_api_v2_service_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3755,7 +3807,7 @@ func (x *InsightsRow) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsightsRow.ProtoReflect.Descriptor instead.
 func (*InsightsRow) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{55}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *InsightsRow) GetValues() []*structpb.Value {
@@ -3777,7 +3829,7 @@ type InsightsDiagnostic struct {
 
 func (x *InsightsDiagnostic) Reset() {
 	*x = InsightsDiagnostic{}
-	mi := &file_api_v2_service_proto_msgTypes[56]
+	mi := &file_api_v2_service_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3789,7 +3841,7 @@ func (x *InsightsDiagnostic) String() string {
 func (*InsightsDiagnostic) ProtoMessage() {}
 
 func (x *InsightsDiagnostic) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[56]
+	mi := &file_api_v2_service_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3802,7 +3854,7 @@ func (x *InsightsDiagnostic) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsightsDiagnostic.ProtoReflect.Descriptor instead.
 func (*InsightsDiagnostic) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{56}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *InsightsDiagnostic) GetSeverity() InsightsDiagnosticSeverity {
@@ -3844,7 +3896,7 @@ type InsightsDiagnosticPosition struct {
 
 func (x *InsightsDiagnosticPosition) Reset() {
 	*x = InsightsDiagnosticPosition{}
-	mi := &file_api_v2_service_proto_msgTypes[57]
+	mi := &file_api_v2_service_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3856,7 +3908,7 @@ func (x *InsightsDiagnosticPosition) String() string {
 func (*InsightsDiagnosticPosition) ProtoMessage() {}
 
 func (x *InsightsDiagnosticPosition) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[57]
+	mi := &file_api_v2_service_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3869,7 +3921,7 @@ func (x *InsightsDiagnosticPosition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsightsDiagnosticPosition.ProtoReflect.Descriptor instead.
 func (*InsightsDiagnosticPosition) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{57}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *InsightsDiagnosticPosition) GetStart() int32 {
@@ -3889,6 +3941,214 @@ func (x *InsightsDiagnosticPosition) GetEnd() int32 {
 func (x *InsightsDiagnosticPosition) GetContext() string {
 	if x != nil {
 		return x.Context
+	}
+	return ""
+}
+
+type ListInsightsTablesRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListInsightsTablesRequest) Reset() {
+	*x = ListInsightsTablesRequest{}
+	mi := &file_api_v2_service_proto_msgTypes[59]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListInsightsTablesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListInsightsTablesRequest) ProtoMessage() {}
+
+func (x *ListInsightsTablesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[59]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListInsightsTablesRequest.ProtoReflect.Descriptor instead.
+func (*ListInsightsTablesRequest) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{59}
+}
+
+type ListInsightsTablesResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Data          []*InsightsTable       `protobuf:"bytes,1,rep,name=data,proto3" json:"data,omitempty"`
+	Metadata      *ResponseMetadata      `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListInsightsTablesResponse) Reset() {
+	*x = ListInsightsTablesResponse{}
+	mi := &file_api_v2_service_proto_msgTypes[60]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListInsightsTablesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListInsightsTablesResponse) ProtoMessage() {}
+
+func (x *ListInsightsTablesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[60]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListInsightsTablesResponse.ProtoReflect.Descriptor instead.
+func (*ListInsightsTablesResponse) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{60}
+}
+
+func (x *ListInsightsTablesResponse) GetData() []*InsightsTable {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+func (x *ListInsightsTablesResponse) GetMetadata() *ResponseMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+type InsightsTable struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Description   string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	Columns       []*InsightsTableColumn `protobuf:"bytes,3,rep,name=columns,proto3" json:"columns,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InsightsTable) Reset() {
+	*x = InsightsTable{}
+	mi := &file_api_v2_service_proto_msgTypes[61]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InsightsTable) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InsightsTable) ProtoMessage() {}
+
+func (x *InsightsTable) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[61]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InsightsTable.ProtoReflect.Descriptor instead.
+func (*InsightsTable) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{61}
+}
+
+func (x *InsightsTable) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *InsightsTable) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *InsightsTable) GetColumns() []*InsightsTableColumn {
+	if x != nil {
+		return x.Columns
+	}
+	return nil
+}
+
+type InsightsTableColumn struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Description   string                 `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	Type          string                 `protobuf:"bytes,3,opt,name=type,proto3" json:"type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InsightsTableColumn) Reset() {
+	*x = InsightsTableColumn{}
+	mi := &file_api_v2_service_proto_msgTypes[62]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InsightsTableColumn) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InsightsTableColumn) ProtoMessage() {}
+
+func (x *InsightsTableColumn) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[62]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InsightsTableColumn.ProtoReflect.Descriptor instead.
+func (*InsightsTableColumn) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{62}
+}
+
+func (x *InsightsTableColumn) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *InsightsTableColumn) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *InsightsTableColumn) GetType() string {
+	if x != nil {
+		return x.Type
 	}
 	return ""
 }
@@ -4174,14 +4434,17 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x04code\x18\x01 \x01(\tR\x04code\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\"t\n" +
 	"\x14QueryInsightsRequest\x12\\\n" +
-	"\x05query\x18\x01 \x01(\tBF\x92AC2AThe insights query to execute, written in modified ClickHouse SQLR\x05query\"\x9d\x03\n" +
-	"\x15QueryInsightsResponse\x12d\n" +
-	"\acolumns\x18\x01 \x03(\v2\x16.api.v2.InsightsColumnB2\x92A/2-Column metadata for the insights query resultR\acolumns\x12\x96\x01\n" +
+	"\x05query\x18\x01 \x01(\tBF\x92AC2AThe insights query to execute, written in modified ClickHouse SQLR\x05query\"|\n" +
+	"\x15QueryInsightsResponse\x12-\n" +
+	"\x04data\x18\x01 \x01(\v2\x19.api.v2.QueryInsightsDataR\x04data\x124\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\x9f\x03\n" +
+	"\x11QueryInsightsData\x12j\n" +
+	"\acolumns\x18\x01 \x03(\v2\x1c.api.v2.InsightsOutputColumnB2\x92A/2-Column metadata for the insights query resultR\acolumns\x12\x96\x01\n" +
 	"\x04rows\x18\x02 \x03(\v2\x13.api.v2.InsightsRowBm\x92Aj2hRows of the insights query result, where each row contains a list of values corresponding to the columnsR\x04rows\x12\x84\x01\n" +
-	"\vdiagnostics\x18\x03 \x03(\v2\x1a.api.v2.InsightsDiagnosticBF\x92AC2AAny non-fatal diagnostics related to the insights query executionR\vdiagnostics\"\xce\x01\n" +
-	"\x0eInsightsColumn\x12H\n" +
-	"\x04name\x18\x01 \x01(\tB4\x92A12/Name of the column in the insights query resultR\x04name\x12r\n" +
-	"\x04type\x18\x02 \x01(\x0e2\x1a.api.v2.InsightsColumnTypeBB\x92A?2=Data type of the column (e.g., 'string', 'number', 'boolean')R\x04type\"\x94\x02\n" +
+	"\vdiagnostics\x18\x03 \x03(\v2\x1a.api.v2.InsightsDiagnosticBF\x92AC2AAny non-fatal diagnostics related to the insights query executionR\vdiagnostics\"\xda\x01\n" +
+	"\x14InsightsOutputColumn\x12H\n" +
+	"\x04name\x18\x01 \x01(\tB4\x92A12/Name of the column in the insights query resultR\x04name\x12x\n" +
+	"\x04type\x18\x02 \x01(\x0e2 .api.v2.InsightsOutputColumnTypeBB\x92A?2=Data type of the column (e.g., 'string', 'number', 'boolean')R\x04type\"\x94\x02\n" +
 	"\vInsightsRow\x12\x84\x02\n" +
 	"\x06values\x18\x01 \x03(\v2\x16.google.protobuf.ValueB\xd3\x01\x92A\xcf\x012\xcc\x01Values for a single row of the insights query result, where each value corresponds to a column. The value is represented as a JSON object to allow for flexible typing (e.g., string, number, boolean, etc.)R\x06values\"\xa7\x04\n" +
 	"\x12InsightsDiagnostic\x12\x88\x01\n" +
@@ -4193,7 +4456,19 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1aInsightsDiagnosticPosition\x12d\n" +
 	"\x05start\x18\x01 \x01(\x05BN\x92AK2IStarting character index in the query string where the diagnostic appliesR\x05start\x12^\n" +
 	"\x03end\x18\x02 \x01(\x05BL\x92AI2GEnding character index in the query string where the diagnostic appliesR\x03end\x12t\n" +
-	"\acontext\x18\x03 \x01(\tBZ\x92AW2USnippet of the query string around the position to provide context for the diagnosticR\acontext*\xdf\x01\n" +
+	"\acontext\x18\x03 \x01(\tBZ\x92AW2USnippet of the query string around the position to provide context for the diagnosticR\acontext\"\x1b\n" +
+	"\x19ListInsightsTablesRequest\"\xd0\x01\n" +
+	"\x1aListInsightsTablesResponse\x12|\n" +
+	"\x04data\x18\x01 \x03(\v2\x15.api.v2.InsightsTableBQ\x92AN2LList of available tables that can be queried via the Insights query endpointR\x04data\x124\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\xa5\x02\n" +
+	"\rInsightsTable\x12V\n" +
+	"\x04name\x18\x01 \x01(\tBB\x92A?2,Name of the table, used when writing queriesJ\x0f\"function_runs\"R\x04name\x12_\n" +
+	"\vdescription\x18\x02 \x01(\tB=\x92A:28Human-readable description of the table and its contentsR\vdescription\x12[\n" +
+	"\acolumns\x18\x03 \x03(\v2\x1b.api.v2.InsightsTableColumnB$\x92A!2\x1fColumns available in this tableR\acolumns\"\xa5\x02\n" +
+	"\x13InsightsTableColumn\x12A\n" +
+	"\x04name\x18\x01 \x01(\tB-\x92A*2(Name of the column in the insights tableR\x04name\x12h\n" +
+	"\vdescription\x18\x02 \x01(\tBF\x92AC2AHuman-readable description of the column and the data it containsR\vdescription\x12a\n" +
+	"\x04type\x18\x03 \x01(\tBM\x92AJ2HData type of the column (e.g., 'String', 'Int64', 'Array(String)', etc.)R\x04type*\xdf\x01\n" +
 	"\x11FunctionRunStatus\x12#\n" +
 	"\x1fFUNCTION_RUN_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aFUNCTION_RUN_STATUS_QUEUED\x10\x01\x12\x1f\n" +
@@ -4227,8 +4502,8 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\n" +
 	"FilterType\x12\t\n" +
 	"\x05ALLOW\x10\x00\x12\b\n" +
-	"\x04DENY\x10\x01*p\n" +
-	"\x12InsightsColumnType\x12\x1a\n" +
+	"\x04DENY\x10\x01*v\n" +
+	"\x18InsightsOutputColumnType\x12\x1a\n" +
 	"\x16VALUE_TYPE_UNSPECIFIED\x10\x00\x12\n" +
 	"\n" +
 	"\x06STRING\x10\x01\x12\n" +
@@ -4241,7 +4516,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05ERROR\x10\x01\x12\v\n" +
 	"\aWARNING\x10\x02\x12\b\n" +
-	"\x04INFO\x10\x032\x85Y\n" +
+	"\x04INFO\x10\x032\xd0]\n" +
 	"\x02V2\x12\xbc\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\x82\x02\x92A\xef\x01\n" +
 	"\bInternal\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
@@ -4567,7 +4842,25 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x022:\x01*\"-/apps/{app_id}/functions/{function_id}/invoke\x12\x8e\x06\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x022:\x01*\"-/apps/{app_id}/functions/{function_id}/invoke\x12\xc8\x04\n" +
+	"\x12ListInsightsTables\x12!.api.v2.ListInsightsTablesRequest\x1a\".api.v2.ListInsightsTablesResponse\"\xea\x03\x92A\xce\x03\n" +
+	"\bInsights\n" +
+	"\x04Beta\x12\x14List insights tables\x1aOLists the available tables that can be queried via the Insights query endpoint.JZ\n" +
+	"\x03200\x12S\n" +
+	"!List of available insights tables\x12.\n" +
+	",\x1a*#/definitions/v2ListInsightsTablesResponseJR\n" +
+	"\x03401\x12K\n" +
+	"&Unauthorized - authentication required\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJP\n" +
+	"\x03403\x12I\n" +
+	"$Forbidden - insufficient permissions\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseJA\n" +
+	"\x03500\x12:\n" +
+	"\x15Internal Server Error\x12!\n" +
+	"\x1f\x1a\x1d#/definitions/v2ErrorResponseb\x10\n" +
+	"\x0e\n" +
+	"\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x12\x12\x10/insights/tables\x12\x8e\x06\n" +
 	"\rQueryInsights\x12\x1c.api.v2.QueryInsightsRequest\x1a\x1d.api.v2.QueryInsightsResponse\"\xbf\x05\x92A\xa1\x05\n" +
 	"\bInsights\n" +
 	"\x04Beta\x12\x0eQuery insights\x1a,Query Insights using the provided SQL query.JO\n" +
@@ -4621,14 +4914,14 @@ func file_api_v2_service_proto_rawDescGZIP() []byte {
 }
 
 var file_api_v2_service_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
-var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 59)
+var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 64)
 var file_api_v2_service_proto_goTypes = []any{
 	(FunctionRunStatus)(0),                  // 0: api.v2.FunctionRunStatus
 	(TraceSpanStatus)(0),                    // 1: api.v2.TraceSpanStatus
 	(TraceStepOp)(0),                        // 2: api.v2.TraceStepOp
 	(EnvType)(0),                            // 3: api.v2.EnvType
 	(FilterType)(0),                         // 4: api.v2.FilterType
-	(InsightsColumnType)(0),                 // 5: api.v2.InsightsColumnType
+	(InsightsOutputColumnType)(0),           // 5: api.v2.InsightsOutputColumnType
 	(InsightsDiagnosticSeverity)(0),         // 6: api.v2.InsightsDiagnosticSeverity
 	(*HealthRequest)(nil),                   // 7: api.v2.HealthRequest
 	(*FetchAccountRequest)(nil),             // 8: api.v2.FetchAccountRequest
@@ -4684,40 +4977,45 @@ var file_api_v2_service_proto_goTypes = []any{
 	(*SyncAppError)(nil),                    // 58: api.v2.SyncAppError
 	(*QueryInsightsRequest)(nil),            // 59: api.v2.QueryInsightsRequest
 	(*QueryInsightsResponse)(nil),           // 60: api.v2.QueryInsightsResponse
-	(*InsightsColumn)(nil),                  // 61: api.v2.InsightsColumn
-	(*InsightsRow)(nil),                     // 62: api.v2.InsightsRow
-	(*InsightsDiagnostic)(nil),              // 63: api.v2.InsightsDiagnostic
-	(*InsightsDiagnosticPosition)(nil),      // 64: api.v2.InsightsDiagnosticPosition
-	nil,                                     // 65: api.v2.TraceSpanMetadata.ValuesEntry
-	(*timestamppb.Timestamp)(nil),           // 66: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                 // 67: google.protobuf.Struct
-	(*structpb.Value)(nil),                  // 68: google.protobuf.Value
+	(*QueryInsightsData)(nil),               // 61: api.v2.QueryInsightsData
+	(*InsightsOutputColumn)(nil),            // 62: api.v2.InsightsOutputColumn
+	(*InsightsRow)(nil),                     // 63: api.v2.InsightsRow
+	(*InsightsDiagnostic)(nil),              // 64: api.v2.InsightsDiagnostic
+	(*InsightsDiagnosticPosition)(nil),      // 65: api.v2.InsightsDiagnosticPosition
+	(*ListInsightsTablesRequest)(nil),       // 66: api.v2.ListInsightsTablesRequest
+	(*ListInsightsTablesResponse)(nil),      // 67: api.v2.ListInsightsTablesResponse
+	(*InsightsTable)(nil),                   // 68: api.v2.InsightsTable
+	(*InsightsTableColumn)(nil),             // 69: api.v2.InsightsTableColumn
+	nil,                                     // 70: api.v2.TraceSpanMetadata.ValuesEntry
+	(*timestamppb.Timestamp)(nil),           // 71: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                 // 72: google.protobuf.Struct
+	(*structpb.Value)(nil),                  // 73: google.protobuf.Value
 }
 var file_api_v2_service_proto_depIdxs = []int32{
 	10,  // 0: api.v2.HealthResponse.data:type_name -> api.v2.HealthData
 	13,  // 1: api.v2.HealthResponse.metadata:type_name -> api.v2.ResponseMetadata
 	11,  // 2: api.v2.ErrorResponse.errors:type_name -> api.v2.Error
-	66,  // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
-	66,  // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
+	71,  // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
+	71,  // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
 	14,  // 5: api.v2.FunctionRun.function:type_name -> api.v2.FunctionRef
 	15,  // 6: api.v2.FunctionRun.app:type_name -> api.v2.AppRef
 	0,   // 7: api.v2.FunctionRun.status:type_name -> api.v2.FunctionRunStatus
-	66,  // 8: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
-	66,  // 9: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
-	66,  // 10: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
+	71,  // 8: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
+	71,  // 9: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
+	71,  // 10: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
 	16,  // 11: api.v2.FunctionRun.trigger:type_name -> api.v2.RunTrigger
-	67,  // 12: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
+	72,  // 12: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
 	17,  // 13: api.v2.GetFunctionRunResponse.data:type_name -> api.v2.FunctionRun
 	13,  // 14: api.v2.GetFunctionRunResponse.metadata:type_name -> api.v2.ResponseMetadata
-	65,  // 15: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
-	66,  // 16: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
+	70,  // 15: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
+	71,  // 16: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
 	1,   // 17: api.v2.TraceSpan.status:type_name -> api.v2.TraceSpanStatus
 	2,   // 18: api.v2.TraceSpan.step_op:type_name -> api.v2.TraceStepOp
-	66,  // 19: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
-	66,  // 20: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
-	66,  // 21: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
-	67,  // 22: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
-	67,  // 23: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
+	71,  // 19: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
+	71,  // 20: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
+	71,  // 21: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
+	72,  // 22: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
+	72,  // 23: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
 	20,  // 24: api.v2.TraceSpan.metadata:type_name -> api.v2.TraceSpanMetadata
 	21,  // 25: api.v2.TraceSpan.children:type_name -> api.v2.TraceSpan
 	21,  // 26: api.v2.FunctionTrace.root_span:type_name -> api.v2.TraceSpan
@@ -4728,27 +5026,27 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	29,  // 31: api.v2.CreateEnvResponse.data:type_name -> api.v2.Env
 	13,  // 32: api.v2.CreateEnvResponse.metadata:type_name -> api.v2.ResponseMetadata
 	3,   // 33: api.v2.Env.type:type_name -> api.v2.EnvType
-	66,  // 34: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
-	66,  // 35: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
-	66,  // 36: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
+	71,  // 34: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
+	71,  // 35: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
+	71,  // 36: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
 	34,  // 37: api.v2.FetchAccountsResponse.data:type_name -> api.v2.Account
 	13,  // 38: api.v2.FetchAccountsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 39: api.v2.FetchAccountsResponse.page:type_name -> api.v2.Page
 	34,  // 40: api.v2.FetchAccountResponse.data:type_name -> api.v2.Account
 	13,  // 41: api.v2.FetchAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
-	66,  // 42: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
-	66,  // 43: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
+	71,  // 42: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
+	71,  // 43: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
 	38,  // 44: api.v2.FetchAccountEventKeysResponse.data:type_name -> api.v2.EventKey
 	13,  // 45: api.v2.FetchAccountEventKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 46: api.v2.FetchAccountEventKeysResponse.page:type_name -> api.v2.Page
-	66,  // 47: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
+	71,  // 47: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
 	29,  // 48: api.v2.FetchAccountEnvsResponse.data:type_name -> api.v2.Env
 	13,  // 49: api.v2.FetchAccountEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 50: api.v2.FetchAccountEnvsResponse.page:type_name -> api.v2.Page
 	43,  // 51: api.v2.FetchAccountSigningKeysResponse.data:type_name -> api.v2.SigningKey
 	13,  // 52: api.v2.FetchAccountSigningKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 53: api.v2.FetchAccountSigningKeysResponse.page:type_name -> api.v2.Page
-	66,  // 54: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
+	71,  // 54: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
 	46,  // 55: api.v2.CreateWebhookRequest.event_filter:type_name -> api.v2.EventFilter
 	49,  // 56: api.v2.CreateWebhookResponse.data:type_name -> api.v2.Webhook
 	13,  // 57: api.v2.CreateWebhookResponse.metadata:type_name -> api.v2.ResponseMetadata
@@ -4757,65 +5055,72 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	13,  // 60: api.v2.ListWebhooksResponse.metadata:type_name -> api.v2.ResponseMetadata
 	35,  // 61: api.v2.ListWebhooksResponse.page:type_name -> api.v2.Page
 	46,  // 62: api.v2.Webhook.event_filter:type_name -> api.v2.EventFilter
-	66,  // 63: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
-	66,  // 64: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
+	71,  // 63: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
+	71,  // 64: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
 	29,  // 65: api.v2.PatchEnvsResponse.data:type_name -> api.v2.Env
 	13,  // 66: api.v2.PatchEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	67,  // 67: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
+	72,  // 67: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
 	54,  // 68: api.v2.InvokeFunctionResponse.data:type_name -> api.v2.InvokeFunctionData
 	13,  // 69: api.v2.InvokeFunctionResponse.metadata:type_name -> api.v2.ResponseMetadata
-	66,  // 70: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
-	66,  // 71: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
-	66,  // 72: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
+	71,  // 70: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
+	71,  // 71: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
+	71,  // 72: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
 	57,  // 73: api.v2.SyncAppResponse.data:type_name -> api.v2.SyncAppData
 	13,  // 74: api.v2.SyncAppResponse.metadata:type_name -> api.v2.ResponseMetadata
 	58,  // 75: api.v2.SyncAppData.error:type_name -> api.v2.SyncAppError
-	61,  // 76: api.v2.QueryInsightsResponse.columns:type_name -> api.v2.InsightsColumn
-	62,  // 77: api.v2.QueryInsightsResponse.rows:type_name -> api.v2.InsightsRow
-	63,  // 78: api.v2.QueryInsightsResponse.diagnostics:type_name -> api.v2.InsightsDiagnostic
-	5,   // 79: api.v2.InsightsColumn.type:type_name -> api.v2.InsightsColumnType
-	68,  // 80: api.v2.InsightsRow.values:type_name -> google.protobuf.Value
-	6,   // 81: api.v2.InsightsDiagnostic.severity:type_name -> api.v2.InsightsDiagnosticSeverity
-	64,  // 82: api.v2.InsightsDiagnostic.position:type_name -> api.v2.InsightsDiagnosticPosition
-	7,   // 83: api.v2.V2.Health:input_type -> api.v2.HealthRequest
-	7,   // 84: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
-	25,  // 85: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
-	27,  // 86: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
-	31,  // 87: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
-	8,   // 88: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
-	39,  // 89: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
-	36,  // 90: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
-	41,  // 91: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
-	44,  // 92: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
-	47,  // 93: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
-	50,  // 94: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
-	18,  // 95: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
-	55,  // 96: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
-	23,  // 97: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
-	52,  // 98: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
-	59,  // 99: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
-	9,   // 100: api.v2.V2.Health:output_type -> api.v2.HealthResponse
-	12,  // 101: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
-	26,  // 102: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
-	28,  // 103: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
-	32,  // 104: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
-	33,  // 105: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
-	40,  // 106: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
-	37,  // 107: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
-	42,  // 108: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
-	45,  // 109: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
-	48,  // 110: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
-	51,  // 111: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
-	19,  // 112: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
-	56,  // 113: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
-	24,  // 114: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
-	53,  // 115: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
-	60,  // 116: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
-	100, // [100:117] is the sub-list for method output_type
-	83,  // [83:100] is the sub-list for method input_type
-	83,  // [83:83] is the sub-list for extension type_name
-	83,  // [83:83] is the sub-list for extension extendee
-	0,   // [0:83] is the sub-list for field type_name
+	61,  // 76: api.v2.QueryInsightsResponse.data:type_name -> api.v2.QueryInsightsData
+	13,  // 77: api.v2.QueryInsightsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	62,  // 78: api.v2.QueryInsightsData.columns:type_name -> api.v2.InsightsOutputColumn
+	63,  // 79: api.v2.QueryInsightsData.rows:type_name -> api.v2.InsightsRow
+	64,  // 80: api.v2.QueryInsightsData.diagnostics:type_name -> api.v2.InsightsDiagnostic
+	5,   // 81: api.v2.InsightsOutputColumn.type:type_name -> api.v2.InsightsOutputColumnType
+	73,  // 82: api.v2.InsightsRow.values:type_name -> google.protobuf.Value
+	6,   // 83: api.v2.InsightsDiagnostic.severity:type_name -> api.v2.InsightsDiagnosticSeverity
+	65,  // 84: api.v2.InsightsDiagnostic.position:type_name -> api.v2.InsightsDiagnosticPosition
+	68,  // 85: api.v2.ListInsightsTablesResponse.data:type_name -> api.v2.InsightsTable
+	13,  // 86: api.v2.ListInsightsTablesResponse.metadata:type_name -> api.v2.ResponseMetadata
+	69,  // 87: api.v2.InsightsTable.columns:type_name -> api.v2.InsightsTableColumn
+	7,   // 88: api.v2.V2.Health:input_type -> api.v2.HealthRequest
+	7,   // 89: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
+	25,  // 90: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
+	27,  // 91: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
+	31,  // 92: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
+	8,   // 93: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
+	39,  // 94: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
+	36,  // 95: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
+	41,  // 96: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
+	44,  // 97: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
+	47,  // 98: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
+	50,  // 99: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
+	18,  // 100: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
+	55,  // 101: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
+	23,  // 102: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
+	52,  // 103: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
+	66,  // 104: api.v2.V2.ListInsightsTables:input_type -> api.v2.ListInsightsTablesRequest
+	59,  // 105: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
+	9,   // 106: api.v2.V2.Health:output_type -> api.v2.HealthResponse
+	12,  // 107: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
+	26,  // 108: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
+	28,  // 109: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
+	32,  // 110: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
+	33,  // 111: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
+	40,  // 112: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
+	37,  // 113: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
+	42,  // 114: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
+	45,  // 115: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
+	48,  // 116: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
+	51,  // 117: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
+	19,  // 118: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
+	56,  // 119: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
+	24,  // 120: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
+	53,  // 121: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
+	67,  // 122: api.v2.V2.ListInsightsTables:output_type -> api.v2.ListInsightsTablesResponse
+	60,  // 123: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
+	106, // [106:124] is the sub-list for method output_type
+	88,  // [88:106] is the sub-list for method input_type
+	88,  // [88:88] is the sub-list for extension type_name
+	88,  // [88:88] is the sub-list for extension extendee
+	0,   // [0:88] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_service_proto_init() }
@@ -4843,14 +5148,14 @@ func file_api_v2_service_proto_init() {
 	file_api_v2_service_proto_msgTypes[45].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[47].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[50].OneofWrappers = []any{}
-	file_api_v2_service_proto_msgTypes[56].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[57].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v2_service_proto_rawDesc), len(file_api_v2_service_proto_rawDesc)),
 			NumEnums:      7,
-			NumMessages:   59,
+			NumMessages:   64,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/gen/api/v2/service.pb.gw.go
+++ b/proto/gen/api/v2/service.pb.gw.go
@@ -611,6 +611,33 @@ func local_request_V2_InvokeFunction_0(ctx context.Context, marshaler runtime.Ma
 	return msg, metadata, err
 }
 
+func request_V2_QueryInsights_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq QueryInsightsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.QueryInsights(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_V2_QueryInsights_0(ctx context.Context, marshaler runtime.Marshaler, server V2Server, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq QueryInsightsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.QueryInsights(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 // RegisterV2HandlerServer registers the http handlers for service V2 to "mux".
 // UnaryRPC     :call V2Server directly.
 // StreamingRPC :currently unsupported pending https://github.com/grpc/grpc-go/issues/906.
@@ -937,6 +964,26 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		}
 		forward_V2_InvokeFunction_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_V2_QueryInsights_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/QueryInsights", runtime.WithHTTPPathPattern("/insights/query"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_V2_QueryInsights_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_QueryInsights_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 
 	return nil
 }
@@ -1249,6 +1296,23 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		}
 		forward_V2_InvokeFunction_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_V2_QueryInsights_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/QueryInsights", runtime.WithHTTPPathPattern("/insights/query"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_V2_QueryInsights_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_QueryInsights_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	return nil
 }
 
@@ -1269,6 +1333,7 @@ var (
 	pattern_V2_SyncApp_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"apps", "app_id", "syncs"}, ""))
 	pattern_V2_GetFunctionTrace_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"runs", "run_id", "trace"}, ""))
 	pattern_V2_InvokeFunction_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"apps", "app_id", "functions", "function_id", "invoke"}, ""))
+	pattern_V2_QueryInsights_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"insights", "query"}, ""))
 )
 
 var (
@@ -1288,4 +1353,5 @@ var (
 	forward_V2_SyncApp_0                 = runtime.ForwardResponseMessage
 	forward_V2_GetFunctionTrace_0        = runtime.ForwardResponseMessage
 	forward_V2_InvokeFunction_0          = runtime.ForwardResponseMessage
+	forward_V2_QueryInsights_0           = runtime.ForwardResponseMessage
 )

--- a/proto/gen/api/v2/service.pb.gw.go
+++ b/proto/gen/api/v2/service.pb.gw.go
@@ -632,6 +632,33 @@ func local_request_V2_ListInsightsTables_0(ctx context.Context, marshaler runtim
 	return msg, metadata, err
 }
 
+func request_V2_QueryInsightsPrompt_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq QueryInsightsPromptRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.QueryInsightsPrompt(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_V2_QueryInsightsPrompt_0(ctx context.Context, marshaler runtime.Marshaler, server V2Server, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq QueryInsightsPromptRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.QueryInsightsPrompt(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_V2_QueryInsights_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq QueryInsightsRequest
@@ -1005,6 +1032,26 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		}
 		forward_V2_ListInsightsTables_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_V2_QueryInsightsPrompt_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/QueryInsightsPrompt", runtime.WithHTTPPathPattern("/insights/query/prompt"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_V2_QueryInsightsPrompt_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_QueryInsightsPrompt_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_V2_QueryInsights_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -1354,6 +1401,23 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		}
 		forward_V2_ListInsightsTables_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_V2_QueryInsightsPrompt_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/QueryInsightsPrompt", runtime.WithHTTPPathPattern("/insights/query/prompt"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_V2_QueryInsightsPrompt_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_QueryInsightsPrompt_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_V2_QueryInsights_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -1392,6 +1456,7 @@ var (
 	pattern_V2_GetFunctionTrace_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"runs", "run_id", "trace"}, ""))
 	pattern_V2_InvokeFunction_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"apps", "app_id", "functions", "function_id", "invoke"}, ""))
 	pattern_V2_ListInsightsTables_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"insights", "tables"}, ""))
+	pattern_V2_QueryInsightsPrompt_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"insights", "query", "prompt"}, ""))
 	pattern_V2_QueryInsights_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"insights", "query"}, ""))
 )
 
@@ -1413,5 +1478,6 @@ var (
 	forward_V2_GetFunctionTrace_0        = runtime.ForwardResponseMessage
 	forward_V2_InvokeFunction_0          = runtime.ForwardResponseMessage
 	forward_V2_ListInsightsTables_0      = runtime.ForwardResponseMessage
+	forward_V2_QueryInsightsPrompt_0     = runtime.ForwardResponseMessage
 	forward_V2_QueryInsights_0           = runtime.ForwardResponseMessage
 )

--- a/proto/gen/api/v2/service.pb.gw.go
+++ b/proto/gen/api/v2/service.pb.gw.go
@@ -632,6 +632,41 @@ func local_request_V2_ListInsightsTables_0(ctx context.Context, marshaler runtim
 	return msg, metadata, err
 }
 
+var filter_V2_ListInsightsEventSchemas_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_V2_ListInsightsEventSchemas_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListInsightsEventSchemasRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_V2_ListInsightsEventSchemas_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.ListInsightsEventSchemas(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_V2_ListInsightsEventSchemas_0(ctx context.Context, marshaler runtime.Marshaler, server V2Server, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListInsightsEventSchemasRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_V2_ListInsightsEventSchemas_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ListInsightsEventSchemas(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_V2_QueryInsightsPrompt_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq QueryInsightsPromptRequest
@@ -1032,6 +1067,26 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		}
 		forward_V2_ListInsightsTables_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_V2_ListInsightsEventSchemas_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/ListInsightsEventSchemas", runtime.WithHTTPPathPattern("/insights/events/schemas"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_V2_ListInsightsEventSchemas_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_ListInsightsEventSchemas_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_V2_QueryInsightsPrompt_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -1401,6 +1456,23 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		}
 		forward_V2_ListInsightsTables_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_V2_ListInsightsEventSchemas_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/ListInsightsEventSchemas", runtime.WithHTTPPathPattern("/insights/events/schemas"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_V2_ListInsightsEventSchemas_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_ListInsightsEventSchemas_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_V2_QueryInsightsPrompt_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -1439,45 +1511,47 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 }
 
 var (
-	pattern_V2_Health_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"health"}, ""))
-	pattern_V2_XSchemaOnly_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"_internal", "schema-only"}, ""))
-	pattern_V2_CreatePartnerAccount_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"partner", "accounts"}, ""))
-	pattern_V2_CreateEnv_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"envs"}, ""))
-	pattern_V2_FetchPartnerAccounts_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"partner", "accounts"}, ""))
-	pattern_V2_FetchAccount_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"account"}, ""))
-	pattern_V2_FetchAccountEnvs_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"envs"}, ""))
-	pattern_V2_FetchAccountEventKeys_0   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"keys", "events"}, ""))
-	pattern_V2_FetchAccountSigningKeys_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"keys", "signing"}, ""))
-	pattern_V2_CreateWebhook_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"env", "webhooks"}, ""))
-	pattern_V2_ListWebhooks_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"env", "webhooks"}, ""))
-	pattern_V2_PatchEnv_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"envs", "id"}, ""))
-	pattern_V2_GetFunctionRun_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"runs", "run_id"}, ""))
-	pattern_V2_SyncApp_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"apps", "app_id", "syncs"}, ""))
-	pattern_V2_GetFunctionTrace_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"runs", "run_id", "trace"}, ""))
-	pattern_V2_InvokeFunction_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"apps", "app_id", "functions", "function_id", "invoke"}, ""))
-	pattern_V2_ListInsightsTables_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"insights", "tables"}, ""))
-	pattern_V2_QueryInsightsPrompt_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"insights", "query", "prompt"}, ""))
-	pattern_V2_QueryInsights_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"insights", "query"}, ""))
+	pattern_V2_Health_0                   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"health"}, ""))
+	pattern_V2_XSchemaOnly_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"_internal", "schema-only"}, ""))
+	pattern_V2_CreatePartnerAccount_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"partner", "accounts"}, ""))
+	pattern_V2_CreateEnv_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"envs"}, ""))
+	pattern_V2_FetchPartnerAccounts_0     = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"partner", "accounts"}, ""))
+	pattern_V2_FetchAccount_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"account"}, ""))
+	pattern_V2_FetchAccountEnvs_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"envs"}, ""))
+	pattern_V2_FetchAccountEventKeys_0    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"keys", "events"}, ""))
+	pattern_V2_FetchAccountSigningKeys_0  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"keys", "signing"}, ""))
+	pattern_V2_CreateWebhook_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"env", "webhooks"}, ""))
+	pattern_V2_ListWebhooks_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"env", "webhooks"}, ""))
+	pattern_V2_PatchEnv_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"envs", "id"}, ""))
+	pattern_V2_GetFunctionRun_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"runs", "run_id"}, ""))
+	pattern_V2_SyncApp_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"apps", "app_id", "syncs"}, ""))
+	pattern_V2_GetFunctionTrace_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"runs", "run_id", "trace"}, ""))
+	pattern_V2_InvokeFunction_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"apps", "app_id", "functions", "function_id", "invoke"}, ""))
+	pattern_V2_ListInsightsTables_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"insights", "tables"}, ""))
+	pattern_V2_ListInsightsEventSchemas_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"insights", "events", "schemas"}, ""))
+	pattern_V2_QueryInsightsPrompt_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"insights", "query", "prompt"}, ""))
+	pattern_V2_QueryInsights_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"insights", "query"}, ""))
 )
 
 var (
-	forward_V2_Health_0                  = runtime.ForwardResponseMessage
-	forward_V2_XSchemaOnly_0             = runtime.ForwardResponseMessage
-	forward_V2_CreatePartnerAccount_0    = runtime.ForwardResponseMessage
-	forward_V2_CreateEnv_0               = runtime.ForwardResponseMessage
-	forward_V2_FetchPartnerAccounts_0    = runtime.ForwardResponseMessage
-	forward_V2_FetchAccount_0            = runtime.ForwardResponseMessage
-	forward_V2_FetchAccountEnvs_0        = runtime.ForwardResponseMessage
-	forward_V2_FetchAccountEventKeys_0   = runtime.ForwardResponseMessage
-	forward_V2_FetchAccountSigningKeys_0 = runtime.ForwardResponseMessage
-	forward_V2_CreateWebhook_0           = runtime.ForwardResponseMessage
-	forward_V2_ListWebhooks_0            = runtime.ForwardResponseMessage
-	forward_V2_PatchEnv_0                = runtime.ForwardResponseMessage
-	forward_V2_GetFunctionRun_0          = runtime.ForwardResponseMessage
-	forward_V2_SyncApp_0                 = runtime.ForwardResponseMessage
-	forward_V2_GetFunctionTrace_0        = runtime.ForwardResponseMessage
-	forward_V2_InvokeFunction_0          = runtime.ForwardResponseMessage
-	forward_V2_ListInsightsTables_0      = runtime.ForwardResponseMessage
-	forward_V2_QueryInsightsPrompt_0     = runtime.ForwardResponseMessage
-	forward_V2_QueryInsights_0           = runtime.ForwardResponseMessage
+	forward_V2_Health_0                   = runtime.ForwardResponseMessage
+	forward_V2_XSchemaOnly_0              = runtime.ForwardResponseMessage
+	forward_V2_CreatePartnerAccount_0     = runtime.ForwardResponseMessage
+	forward_V2_CreateEnv_0                = runtime.ForwardResponseMessage
+	forward_V2_FetchPartnerAccounts_0     = runtime.ForwardResponseMessage
+	forward_V2_FetchAccount_0             = runtime.ForwardResponseMessage
+	forward_V2_FetchAccountEnvs_0         = runtime.ForwardResponseMessage
+	forward_V2_FetchAccountEventKeys_0    = runtime.ForwardResponseMessage
+	forward_V2_FetchAccountSigningKeys_0  = runtime.ForwardResponseMessage
+	forward_V2_CreateWebhook_0            = runtime.ForwardResponseMessage
+	forward_V2_ListWebhooks_0             = runtime.ForwardResponseMessage
+	forward_V2_PatchEnv_0                 = runtime.ForwardResponseMessage
+	forward_V2_GetFunctionRun_0           = runtime.ForwardResponseMessage
+	forward_V2_SyncApp_0                  = runtime.ForwardResponseMessage
+	forward_V2_GetFunctionTrace_0         = runtime.ForwardResponseMessage
+	forward_V2_InvokeFunction_0           = runtime.ForwardResponseMessage
+	forward_V2_ListInsightsTables_0       = runtime.ForwardResponseMessage
+	forward_V2_ListInsightsEventSchemas_0 = runtime.ForwardResponseMessage
+	forward_V2_QueryInsightsPrompt_0      = runtime.ForwardResponseMessage
+	forward_V2_QueryInsights_0            = runtime.ForwardResponseMessage
 )

--- a/proto/gen/api/v2/service.pb.gw.go
+++ b/proto/gen/api/v2/service.pb.gw.go
@@ -611,6 +611,27 @@ func local_request_V2_InvokeFunction_0(ctx context.Context, marshaler runtime.Ma
 	return msg, metadata, err
 }
 
+func request_V2_ListInsightsTables_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListInsightsTablesRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.ListInsightsTables(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_V2_ListInsightsTables_0(ctx context.Context, marshaler runtime.Marshaler, server V2Server, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListInsightsTablesRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.ListInsightsTables(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_V2_QueryInsights_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq QueryInsightsRequest
@@ -964,6 +985,26 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		}
 		forward_V2_InvokeFunction_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_V2_ListInsightsTables_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/ListInsightsTables", runtime.WithHTTPPathPattern("/insights/tables"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_V2_ListInsightsTables_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_ListInsightsTables_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_V2_QueryInsights_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -1296,6 +1337,23 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		}
 		forward_V2_InvokeFunction_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_V2_ListInsightsTables_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/ListInsightsTables", runtime.WithHTTPPathPattern("/insights/tables"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_V2_ListInsightsTables_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_ListInsightsTables_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_V2_QueryInsights_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -1333,6 +1391,7 @@ var (
 	pattern_V2_SyncApp_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"apps", "app_id", "syncs"}, ""))
 	pattern_V2_GetFunctionTrace_0        = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"runs", "run_id", "trace"}, ""))
 	pattern_V2_InvokeFunction_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"apps", "app_id", "functions", "function_id", "invoke"}, ""))
+	pattern_V2_ListInsightsTables_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"insights", "tables"}, ""))
 	pattern_V2_QueryInsights_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"insights", "query"}, ""))
 )
 
@@ -1353,5 +1412,6 @@ var (
 	forward_V2_SyncApp_0                 = runtime.ForwardResponseMessage
 	forward_V2_GetFunctionTrace_0        = runtime.ForwardResponseMessage
 	forward_V2_InvokeFunction_0          = runtime.ForwardResponseMessage
+	forward_V2_ListInsightsTables_0      = runtime.ForwardResponseMessage
 	forward_V2_QueryInsights_0           = runtime.ForwardResponseMessage
 )

--- a/proto/gen/api/v2/service_grpc.pb.go
+++ b/proto/gen/api/v2/service_grpc.pb.go
@@ -35,6 +35,7 @@ const (
 	V2_SyncApp_FullMethodName                 = "/api.v2.V2/SyncApp"
 	V2_GetFunctionTrace_FullMethodName        = "/api.v2.V2/GetFunctionTrace"
 	V2_InvokeFunction_FullMethodName          = "/api.v2.V2/InvokeFunction"
+	V2_QueryInsights_FullMethodName           = "/api.v2.V2/QueryInsights"
 )
 
 // V2Client is the client API for V2 service.
@@ -60,6 +61,7 @@ type V2Client interface {
 	SyncApp(ctx context.Context, in *SyncAppRequest, opts ...grpc.CallOption) (*SyncAppResponse, error)
 	GetFunctionTrace(ctx context.Context, in *GetFunctionTraceRequest, opts ...grpc.CallOption) (*GetFunctionTraceResponse, error)
 	InvokeFunction(ctx context.Context, in *InvokeFunctionRequest, opts ...grpc.CallOption) (*InvokeFunctionResponse, error)
+	QueryInsights(ctx context.Context, in *QueryInsightsRequest, opts ...grpc.CallOption) (*QueryInsightsResponse, error)
 }
 
 type v2Client struct {
@@ -230,6 +232,16 @@ func (c *v2Client) InvokeFunction(ctx context.Context, in *InvokeFunctionRequest
 	return out, nil
 }
 
+func (c *v2Client) QueryInsights(ctx context.Context, in *QueryInsightsRequest, opts ...grpc.CallOption) (*QueryInsightsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(QueryInsightsResponse)
+	err := c.cc.Invoke(ctx, V2_QueryInsights_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // V2Server is the server API for V2 service.
 // All implementations must embed UnimplementedV2Server
 // for forward compatibility.
@@ -253,6 +265,7 @@ type V2Server interface {
 	SyncApp(context.Context, *SyncAppRequest) (*SyncAppResponse, error)
 	GetFunctionTrace(context.Context, *GetFunctionTraceRequest) (*GetFunctionTraceResponse, error)
 	InvokeFunction(context.Context, *InvokeFunctionRequest) (*InvokeFunctionResponse, error)
+	QueryInsights(context.Context, *QueryInsightsRequest) (*QueryInsightsResponse, error)
 	mustEmbedUnimplementedV2Server()
 }
 
@@ -310,6 +323,9 @@ func (UnimplementedV2Server) GetFunctionTrace(context.Context, *GetFunctionTrace
 }
 func (UnimplementedV2Server) InvokeFunction(context.Context, *InvokeFunctionRequest) (*InvokeFunctionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method InvokeFunction not implemented")
+}
+func (UnimplementedV2Server) QueryInsights(context.Context, *QueryInsightsRequest) (*QueryInsightsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method QueryInsights not implemented")
 }
 func (UnimplementedV2Server) mustEmbedUnimplementedV2Server() {}
 func (UnimplementedV2Server) testEmbeddedByValue()            {}
@@ -620,6 +636,24 @@ func _V2_InvokeFunction_Handler(srv interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 
+func _V2_QueryInsights_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryInsightsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(V2Server).QueryInsights(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: V2_QueryInsights_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(V2Server).QueryInsights(ctx, req.(*QueryInsightsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // V2_ServiceDesc is the grpc.ServiceDesc for V2 service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -690,6 +724,10 @@ var V2_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "InvokeFunction",
 			Handler:    _V2_InvokeFunction_Handler,
+		},
+		{
+			MethodName: "QueryInsights",
+			Handler:    _V2_QueryInsights_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/gen/api/v2/service_grpc.pb.go
+++ b/proto/gen/api/v2/service_grpc.pb.go
@@ -19,25 +19,26 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	V2_Health_FullMethodName                  = "/api.v2.V2/Health"
-	V2_XSchemaOnly_FullMethodName             = "/api.v2.V2/_SchemaOnly"
-	V2_CreatePartnerAccount_FullMethodName    = "/api.v2.V2/CreatePartnerAccount"
-	V2_CreateEnv_FullMethodName               = "/api.v2.V2/CreateEnv"
-	V2_FetchPartnerAccounts_FullMethodName    = "/api.v2.V2/FetchPartnerAccounts"
-	V2_FetchAccount_FullMethodName            = "/api.v2.V2/FetchAccount"
-	V2_FetchAccountEnvs_FullMethodName        = "/api.v2.V2/FetchAccountEnvs"
-	V2_FetchAccountEventKeys_FullMethodName   = "/api.v2.V2/FetchAccountEventKeys"
-	V2_FetchAccountSigningKeys_FullMethodName = "/api.v2.V2/FetchAccountSigningKeys"
-	V2_CreateWebhook_FullMethodName           = "/api.v2.V2/CreateWebhook"
-	V2_ListWebhooks_FullMethodName            = "/api.v2.V2/ListWebhooks"
-	V2_PatchEnv_FullMethodName                = "/api.v2.V2/PatchEnv"
-	V2_GetFunctionRun_FullMethodName          = "/api.v2.V2/GetFunctionRun"
-	V2_SyncApp_FullMethodName                 = "/api.v2.V2/SyncApp"
-	V2_GetFunctionTrace_FullMethodName        = "/api.v2.V2/GetFunctionTrace"
-	V2_InvokeFunction_FullMethodName          = "/api.v2.V2/InvokeFunction"
-	V2_ListInsightsTables_FullMethodName      = "/api.v2.V2/ListInsightsTables"
-	V2_QueryInsightsPrompt_FullMethodName     = "/api.v2.V2/QueryInsightsPrompt"
-	V2_QueryInsights_FullMethodName           = "/api.v2.V2/QueryInsights"
+	V2_Health_FullMethodName                   = "/api.v2.V2/Health"
+	V2_XSchemaOnly_FullMethodName              = "/api.v2.V2/_SchemaOnly"
+	V2_CreatePartnerAccount_FullMethodName     = "/api.v2.V2/CreatePartnerAccount"
+	V2_CreateEnv_FullMethodName                = "/api.v2.V2/CreateEnv"
+	V2_FetchPartnerAccounts_FullMethodName     = "/api.v2.V2/FetchPartnerAccounts"
+	V2_FetchAccount_FullMethodName             = "/api.v2.V2/FetchAccount"
+	V2_FetchAccountEnvs_FullMethodName         = "/api.v2.V2/FetchAccountEnvs"
+	V2_FetchAccountEventKeys_FullMethodName    = "/api.v2.V2/FetchAccountEventKeys"
+	V2_FetchAccountSigningKeys_FullMethodName  = "/api.v2.V2/FetchAccountSigningKeys"
+	V2_CreateWebhook_FullMethodName            = "/api.v2.V2/CreateWebhook"
+	V2_ListWebhooks_FullMethodName             = "/api.v2.V2/ListWebhooks"
+	V2_PatchEnv_FullMethodName                 = "/api.v2.V2/PatchEnv"
+	V2_GetFunctionRun_FullMethodName           = "/api.v2.V2/GetFunctionRun"
+	V2_SyncApp_FullMethodName                  = "/api.v2.V2/SyncApp"
+	V2_GetFunctionTrace_FullMethodName         = "/api.v2.V2/GetFunctionTrace"
+	V2_InvokeFunction_FullMethodName           = "/api.v2.V2/InvokeFunction"
+	V2_ListInsightsTables_FullMethodName       = "/api.v2.V2/ListInsightsTables"
+	V2_ListInsightsEventSchemas_FullMethodName = "/api.v2.V2/ListInsightsEventSchemas"
+	V2_QueryInsightsPrompt_FullMethodName      = "/api.v2.V2/QueryInsightsPrompt"
+	V2_QueryInsights_FullMethodName            = "/api.v2.V2/QueryInsights"
 )
 
 // V2Client is the client API for V2 service.
@@ -64,6 +65,7 @@ type V2Client interface {
 	GetFunctionTrace(ctx context.Context, in *GetFunctionTraceRequest, opts ...grpc.CallOption) (*GetFunctionTraceResponse, error)
 	InvokeFunction(ctx context.Context, in *InvokeFunctionRequest, opts ...grpc.CallOption) (*InvokeFunctionResponse, error)
 	ListInsightsTables(ctx context.Context, in *ListInsightsTablesRequest, opts ...grpc.CallOption) (*ListInsightsTablesResponse, error)
+	ListInsightsEventSchemas(ctx context.Context, in *ListInsightsEventSchemasRequest, opts ...grpc.CallOption) (*ListInsightsEventSchemasResponse, error)
 	QueryInsightsPrompt(ctx context.Context, in *QueryInsightsPromptRequest, opts ...grpc.CallOption) (*QueryInsightsPromptResponse, error)
 	QueryInsights(ctx context.Context, in *QueryInsightsRequest, opts ...grpc.CallOption) (*QueryInsightsResponse, error)
 }
@@ -246,6 +248,16 @@ func (c *v2Client) ListInsightsTables(ctx context.Context, in *ListInsightsTable
 	return out, nil
 }
 
+func (c *v2Client) ListInsightsEventSchemas(ctx context.Context, in *ListInsightsEventSchemasRequest, opts ...grpc.CallOption) (*ListInsightsEventSchemasResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListInsightsEventSchemasResponse)
+	err := c.cc.Invoke(ctx, V2_ListInsightsEventSchemas_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *v2Client) QueryInsightsPrompt(ctx context.Context, in *QueryInsightsPromptRequest, opts ...grpc.CallOption) (*QueryInsightsPromptResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(QueryInsightsPromptResponse)
@@ -290,6 +302,7 @@ type V2Server interface {
 	GetFunctionTrace(context.Context, *GetFunctionTraceRequest) (*GetFunctionTraceResponse, error)
 	InvokeFunction(context.Context, *InvokeFunctionRequest) (*InvokeFunctionResponse, error)
 	ListInsightsTables(context.Context, *ListInsightsTablesRequest) (*ListInsightsTablesResponse, error)
+	ListInsightsEventSchemas(context.Context, *ListInsightsEventSchemasRequest) (*ListInsightsEventSchemasResponse, error)
 	QueryInsightsPrompt(context.Context, *QueryInsightsPromptRequest) (*QueryInsightsPromptResponse, error)
 	QueryInsights(context.Context, *QueryInsightsRequest) (*QueryInsightsResponse, error)
 	mustEmbedUnimplementedV2Server()
@@ -352,6 +365,9 @@ func (UnimplementedV2Server) InvokeFunction(context.Context, *InvokeFunctionRequ
 }
 func (UnimplementedV2Server) ListInsightsTables(context.Context, *ListInsightsTablesRequest) (*ListInsightsTablesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListInsightsTables not implemented")
+}
+func (UnimplementedV2Server) ListInsightsEventSchemas(context.Context, *ListInsightsEventSchemasRequest) (*ListInsightsEventSchemasResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListInsightsEventSchemas not implemented")
 }
 func (UnimplementedV2Server) QueryInsightsPrompt(context.Context, *QueryInsightsPromptRequest) (*QueryInsightsPromptResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method QueryInsightsPrompt not implemented")
@@ -686,6 +702,24 @@ func _V2_ListInsightsTables_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _V2_ListInsightsEventSchemas_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListInsightsEventSchemasRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(V2Server).ListInsightsEventSchemas(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: V2_ListInsightsEventSchemas_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(V2Server).ListInsightsEventSchemas(ctx, req.(*ListInsightsEventSchemasRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _V2_QueryInsightsPrompt_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(QueryInsightsPromptRequest)
 	if err := dec(in); err != nil {
@@ -796,6 +830,10 @@ var V2_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListInsightsTables",
 			Handler:    _V2_ListInsightsTables_Handler,
+		},
+		{
+			MethodName: "ListInsightsEventSchemas",
+			Handler:    _V2_ListInsightsEventSchemas_Handler,
 		},
 		{
 			MethodName: "QueryInsightsPrompt",

--- a/proto/gen/api/v2/service_grpc.pb.go
+++ b/proto/gen/api/v2/service_grpc.pb.go
@@ -36,6 +36,7 @@ const (
 	V2_GetFunctionTrace_FullMethodName        = "/api.v2.V2/GetFunctionTrace"
 	V2_InvokeFunction_FullMethodName          = "/api.v2.V2/InvokeFunction"
 	V2_ListInsightsTables_FullMethodName      = "/api.v2.V2/ListInsightsTables"
+	V2_QueryInsightsPrompt_FullMethodName     = "/api.v2.V2/QueryInsightsPrompt"
 	V2_QueryInsights_FullMethodName           = "/api.v2.V2/QueryInsights"
 )
 
@@ -63,6 +64,7 @@ type V2Client interface {
 	GetFunctionTrace(ctx context.Context, in *GetFunctionTraceRequest, opts ...grpc.CallOption) (*GetFunctionTraceResponse, error)
 	InvokeFunction(ctx context.Context, in *InvokeFunctionRequest, opts ...grpc.CallOption) (*InvokeFunctionResponse, error)
 	ListInsightsTables(ctx context.Context, in *ListInsightsTablesRequest, opts ...grpc.CallOption) (*ListInsightsTablesResponse, error)
+	QueryInsightsPrompt(ctx context.Context, in *QueryInsightsPromptRequest, opts ...grpc.CallOption) (*QueryInsightsPromptResponse, error)
 	QueryInsights(ctx context.Context, in *QueryInsightsRequest, opts ...grpc.CallOption) (*QueryInsightsResponse, error)
 }
 
@@ -244,6 +246,16 @@ func (c *v2Client) ListInsightsTables(ctx context.Context, in *ListInsightsTable
 	return out, nil
 }
 
+func (c *v2Client) QueryInsightsPrompt(ctx context.Context, in *QueryInsightsPromptRequest, opts ...grpc.CallOption) (*QueryInsightsPromptResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(QueryInsightsPromptResponse)
+	err := c.cc.Invoke(ctx, V2_QueryInsightsPrompt_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *v2Client) QueryInsights(ctx context.Context, in *QueryInsightsRequest, opts ...grpc.CallOption) (*QueryInsightsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(QueryInsightsResponse)
@@ -278,6 +290,7 @@ type V2Server interface {
 	GetFunctionTrace(context.Context, *GetFunctionTraceRequest) (*GetFunctionTraceResponse, error)
 	InvokeFunction(context.Context, *InvokeFunctionRequest) (*InvokeFunctionResponse, error)
 	ListInsightsTables(context.Context, *ListInsightsTablesRequest) (*ListInsightsTablesResponse, error)
+	QueryInsightsPrompt(context.Context, *QueryInsightsPromptRequest) (*QueryInsightsPromptResponse, error)
 	QueryInsights(context.Context, *QueryInsightsRequest) (*QueryInsightsResponse, error)
 	mustEmbedUnimplementedV2Server()
 }
@@ -339,6 +352,9 @@ func (UnimplementedV2Server) InvokeFunction(context.Context, *InvokeFunctionRequ
 }
 func (UnimplementedV2Server) ListInsightsTables(context.Context, *ListInsightsTablesRequest) (*ListInsightsTablesResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListInsightsTables not implemented")
+}
+func (UnimplementedV2Server) QueryInsightsPrompt(context.Context, *QueryInsightsPromptRequest) (*QueryInsightsPromptResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method QueryInsightsPrompt not implemented")
 }
 func (UnimplementedV2Server) QueryInsights(context.Context, *QueryInsightsRequest) (*QueryInsightsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method QueryInsights not implemented")
@@ -670,6 +686,24 @@ func _V2_ListInsightsTables_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _V2_QueryInsightsPrompt_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryInsightsPromptRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(V2Server).QueryInsightsPrompt(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: V2_QueryInsightsPrompt_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(V2Server).QueryInsightsPrompt(ctx, req.(*QueryInsightsPromptRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _V2_QueryInsights_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(QueryInsightsRequest)
 	if err := dec(in); err != nil {
@@ -762,6 +796,10 @@ var V2_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListInsightsTables",
 			Handler:    _V2_ListInsightsTables_Handler,
+		},
+		{
+			MethodName: "QueryInsightsPrompt",
+			Handler:    _V2_QueryInsightsPrompt_Handler,
 		},
 		{
 			MethodName: "QueryInsights",

--- a/proto/gen/api/v2/service_grpc.pb.go
+++ b/proto/gen/api/v2/service_grpc.pb.go
@@ -35,6 +35,7 @@ const (
 	V2_SyncApp_FullMethodName                 = "/api.v2.V2/SyncApp"
 	V2_GetFunctionTrace_FullMethodName        = "/api.v2.V2/GetFunctionTrace"
 	V2_InvokeFunction_FullMethodName          = "/api.v2.V2/InvokeFunction"
+	V2_ListInsightsTables_FullMethodName      = "/api.v2.V2/ListInsightsTables"
 	V2_QueryInsights_FullMethodName           = "/api.v2.V2/QueryInsights"
 )
 
@@ -61,6 +62,7 @@ type V2Client interface {
 	SyncApp(ctx context.Context, in *SyncAppRequest, opts ...grpc.CallOption) (*SyncAppResponse, error)
 	GetFunctionTrace(ctx context.Context, in *GetFunctionTraceRequest, opts ...grpc.CallOption) (*GetFunctionTraceResponse, error)
 	InvokeFunction(ctx context.Context, in *InvokeFunctionRequest, opts ...grpc.CallOption) (*InvokeFunctionResponse, error)
+	ListInsightsTables(ctx context.Context, in *ListInsightsTablesRequest, opts ...grpc.CallOption) (*ListInsightsTablesResponse, error)
 	QueryInsights(ctx context.Context, in *QueryInsightsRequest, opts ...grpc.CallOption) (*QueryInsightsResponse, error)
 }
 
@@ -232,6 +234,16 @@ func (c *v2Client) InvokeFunction(ctx context.Context, in *InvokeFunctionRequest
 	return out, nil
 }
 
+func (c *v2Client) ListInsightsTables(ctx context.Context, in *ListInsightsTablesRequest, opts ...grpc.CallOption) (*ListInsightsTablesResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListInsightsTablesResponse)
+	err := c.cc.Invoke(ctx, V2_ListInsightsTables_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *v2Client) QueryInsights(ctx context.Context, in *QueryInsightsRequest, opts ...grpc.CallOption) (*QueryInsightsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(QueryInsightsResponse)
@@ -265,6 +277,7 @@ type V2Server interface {
 	SyncApp(context.Context, *SyncAppRequest) (*SyncAppResponse, error)
 	GetFunctionTrace(context.Context, *GetFunctionTraceRequest) (*GetFunctionTraceResponse, error)
 	InvokeFunction(context.Context, *InvokeFunctionRequest) (*InvokeFunctionResponse, error)
+	ListInsightsTables(context.Context, *ListInsightsTablesRequest) (*ListInsightsTablesResponse, error)
 	QueryInsights(context.Context, *QueryInsightsRequest) (*QueryInsightsResponse, error)
 	mustEmbedUnimplementedV2Server()
 }
@@ -323,6 +336,9 @@ func (UnimplementedV2Server) GetFunctionTrace(context.Context, *GetFunctionTrace
 }
 func (UnimplementedV2Server) InvokeFunction(context.Context, *InvokeFunctionRequest) (*InvokeFunctionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method InvokeFunction not implemented")
+}
+func (UnimplementedV2Server) ListInsightsTables(context.Context, *ListInsightsTablesRequest) (*ListInsightsTablesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListInsightsTables not implemented")
 }
 func (UnimplementedV2Server) QueryInsights(context.Context, *QueryInsightsRequest) (*QueryInsightsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method QueryInsights not implemented")
@@ -636,6 +652,24 @@ func _V2_InvokeFunction_Handler(srv interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 
+func _V2_ListInsightsTables_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListInsightsTablesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(V2Server).ListInsightsTables(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: V2_ListInsightsTables_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(V2Server).ListInsightsTables(ctx, req.(*ListInsightsTablesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _V2_QueryInsights_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(QueryInsightsRequest)
 	if err := dec(in); err != nil {
@@ -724,6 +758,10 @@ var V2_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "InvokeFunction",
 			Handler:    _V2_InvokeFunction_Handler,
+		},
+		{
+			MethodName: "ListInsightsTables",
+			Handler:    _V2_ListInsightsTables_Handler,
 		},
 		{
 			MethodName: "QueryInsights",


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This adds stubs for new Insights API endpoints. The OSS implementation just returns not implemented. These are all tagged as beta endpoints as they are still subject to change.
* `/insights/query` -- executes and returns query results
* `/insights/query/prompt` -- turns a natural language user prompt into a query
* `/insights/tables` -- list table schemas
* `/insights/events/schemas` -- lists event type schemas

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds stubs for a new `/insights/query` API endpoint: proto definition for `QueryInsights` RPC with request/response messages (columns, rows, diagnostics), generated connect-go client+handler wiring, and an OSS implementation that returns `StatusNotImplemented`. The "fix schema" follow-up commits corrected the `.proto` source file but did not regenerate the derived Go files.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 3eb9856c5be68063c515044267e088ac0076cf66.</sup>
<!-- /MENDRAL_SUMMARY -->