### PR TITLE
chore: tweak copy support

### DIFF
--- a/ui/apps/dashboard/src/routes/support/index.tsx
+++ b/ui/apps/dashboard/src/routes/support/index.tsx
@@ -175,7 +175,7 @@ function SupportComponent() {
 
           <SupportChannel title="Community">
             <p>
-              Chat with other developers and the Inngest team in our{' '}
+              Chat with other developers in our{' '}
               <Link
                 target="_blank"
                 href="https://www.inngest.com/discord"
@@ -191,7 +191,7 @@ function SupportComponent() {
                 target="_blank"
                 size="medium"
               >
-                #help-forum
+                #ask-the-community
               </Link>{' '}
               channel or submit your own question.
             </p>

--- a/ui/apps/support/src/components/Support/CommunityChannels.tsx
+++ b/ui/apps/support/src/components/Support/CommunityChannels.tsx
@@ -7,7 +7,7 @@ export function CommunityChannels() {
     <div className="mt-8 p-4 border rounded flex flex-col gap-4 max-w-xl">
       <h2 className="text-basis text-lg font-bold">Community</h2>
       <p>
-        Chat with other developers and the Inngest team in our{" "}
+        Chat with other developers in our{" "}
         <Link
           target="_blank"
           href="https://www.inngest.com/discord"
@@ -23,7 +23,7 @@ export function CommunityChannels() {
           target="_blank"
           size="medium"
         >
-          #help-forum
+          #ask-the-community
         </Link>{" "}
         channel or submit your own question.
       </p>


### PR DESCRIPTION
## Description
Adjust copy on support page to reflect the change in one of our discord channels.

## Release note
None.

## Migration note
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Copy-only update to the support page: removes "and the Inngest team" from the Discord community blurb and renames the channel reference from `#help-forum` to `#ask-the-community` in both the dashboard and support app components.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7272a959a67be25674062f041f0b75e2fb860b6c.</sup>
<!-- /MENDRAL_SUMMARY -->