### PR TITLE
ci(release): restore tag-triggered publishing

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Validate release snapshot
         if: steps.command.outputs.matched == 'true' && steps.command.outputs.dry_run == 'true'
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: "~> v2"
           args: release --snapshot --skip=publish --clean --verbose

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -89,6 +90,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ steps.pr.outputs.head_sha }}
+          persist-credentials: false
 
       - name: Set up Go for PR head
         if: steps.command.outputs.matched == 'true'
@@ -181,7 +183,13 @@ jobs:
         env:
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           PRERELEASE_VERSION: ${{ steps.prerelease-version.outputs.version }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
+          if [ -z "${RELEASE_TOKEN}" ]; then
+            echo "::error title=Missing RELEASE_TOKEN::Configure the release bot token as the RELEASE_TOKEN repository secret."
+            exit 1
+          fi
+
           if ! printf '%s\n' "${HEAD_SHA}" | grep -Eq '^[0-9a-f]{40}$'; then
             echo "Prerelease head SHA output is invalid: ${HEAD_SHA}"
             exit 1
@@ -195,6 +203,7 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git tag "${PRERELEASE_VERSION}" "${HEAD_SHA}"
+          git remote set-url origin "https://x-access-token:${RELEASE_TOKEN}@github.com/${{ github.repository }}.git"
           git push origin "${PRERELEASE_VERSION}"
 
       - name: Comment publish result

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -164,9 +164,9 @@ jobs:
 
       - name: Validate release snapshot
         if: steps.command.outputs.matched == 'true' && steps.command.outputs.dry_run == 'true'
-        uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: "~> 2"
+          version: "~> v2"
           args: release --snapshot --skip=publish --clean --verbose
 
       - name: Comment dry-run result

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -11,6 +11,9 @@ on:
     # entry reflects the day the release PR is regenerated.
     - cron: "17 9 * * *"
   workflow_dispatch:
+  pull_request_target:
+    types:
+      - edited
 
 permissions:
   contents: write
@@ -26,6 +29,7 @@ concurrency:
 
 jobs:
   create-release-pr:
+    if: github.event_name != 'pull_request_target' || (github.event.pull_request.head.ref == 'release/next' && github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.state == 'open')
     runs-on: depot-ubuntu-22.04-4
     steps:
       - name: Validate release token
@@ -224,6 +228,14 @@ jobs:
         env:
           RELEASE_TAG: ${{ steps.normalized-version.outputs.tag }}
         run: |
+          current_title="$(gh pr view "${{ steps.existing-pr.outputs.pr_number }}" --json title --jq '.title')"
+          desired_title="chore(release): ${RELEASE_TAG}"
+
+          if [ "${current_title}" = "${desired_title}" ] && cmp -s /tmp/existing-release-pr-body.md /tmp/release-pr-body.md; then
+            echo "Release PR title and body are already up to date"
+            exit 0
+          fi
+
           gh pr edit "${{ steps.existing-pr.outputs.pr_number }}" \
-            --title "chore(release): ${RELEASE_TAG}" \
+            --title "${desired_title}" \
             --body-file /tmp/release-pr-body.md

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -145,15 +145,6 @@ jobs:
             --repo "${{ github.repository }}" \
             --output /tmp/release-pr-notes.json
 
-      - name: Build release notes preview
-        if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false'
-        run: |
-          scripts/release/build-release-notes \
-            --notes /tmp/release-pr-notes.json \
-            --changelog CHANGELOG.md \
-            --tag "${{ steps.normalized-version.outputs.tag }}" \
-            --output /tmp/release-notes-preview.md
-
       - name: Find existing release PR
         if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false'
         id: existing-pr
@@ -172,6 +163,16 @@ jobs:
           else
             : > /tmp/existing-release-pr-body.md
           fi
+
+      - name: Build release notes preview
+        if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false'
+        run: |
+          scripts/release/build-release-notes \
+            --notes /tmp/release-pr-notes.json \
+            --changelog CHANGELOG.md \
+            --tag "${{ steps.normalized-version.outputs.tag }}" \
+            --release-pr-body /tmp/existing-release-pr-body.md \
+            --output /tmp/release-notes-preview.md
 
       - name: Render release PR body
         if: steps.skip.outputs.skip == 'false' && steps.changes.outputs.ahead != '0' && steps.version-check.outputs.skip == 'false'

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+env:
+  # Use the release bot token so tag pushes trigger the Release workflow.
+  GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
 concurrency:
   group: release-tag-${{ github.event.pull_request.number }}
   cancel-in-progress: false
@@ -17,11 +21,19 @@ jobs:
     if: github.event.pull_request.merged == true && github.event.pull_request.head.ref == 'release/next' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
+      - name: Validate release token
+        run: |
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::error title=Missing RELEASE_TOKEN::Configure the release bot token as the RELEASE_TOKEN repository secret."
+            exit 1
+          fi
+
       - name: Checkout merged release commit
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+          token: ${{ env.GH_TOKEN }}
 
       - name: Determine release tag
         id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,9 +83,9 @@ jobs:
             echo "- Commit: \`$(git rev-parse HEAD)\`"
           } > /tmp/RELEASE_NOTES.md
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: "~> 2"
+          version: "~> v2"
           args: release --clean --verbose --release-notes=/tmp/RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,9 @@ jobs:
         run: |
           prerelease=$(echo ${{ github.ref_name }} | awk -F '-' '{print $2}' | awk -F '.' '{print $1}')
           echo "prerelease=$prerelease" >> $GITHUB_OUTPUT
+
   goreleaser:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-4
     needs: [check-release-type]
     steps:
       - name: Login to Docker Hub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,11 +67,32 @@ jobs:
             --output /tmp/release-pr-notes.json
       - name: Build release notes
         if: needs.check-release-type.outputs.prerelease == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          pr_number="$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state merged \
+            --search "${GITHUB_REF_NAME} type:pr in:title" \
+            --json number,title,mergeCommit \
+            --jq "map(select(.title == \"chore(release): ${GITHUB_REF_NAME}\" and .mergeCommit.oid == \"${GITHUB_SHA}\")) | .[0].number // empty")"
+
+          release_pr_body_arg=()
+          if [ -n "${pr_number}" ]; then
+            gh pr view "${pr_number}" \
+              --repo "${{ github.repository }}" \
+              --json body \
+              --jq '.body // ""' > /tmp/release-pr-body.md
+            release_pr_body_arg=(--release-pr-body /tmp/release-pr-body.md)
+          else
+            echo "No merged release PR found for ${GITHUB_REF_NAME} at ${GITHUB_SHA}; building release notes without manual release PR blocks."
+          fi
+
           scripts/release/build-release-notes \
             --notes /tmp/release-pr-notes.json \
             --changelog CHANGELOG.md \
             --tag "${GITHUB_REF_NAME}" \
+            "${release_pr_body_arg[@]}" \
             --output /tmp/RELEASE_NOTES.md
       - name: Build prerelease notes
         if: needs.check-release-type.outputs.prerelease != ''

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -67,7 +69,8 @@ docker_manifests:
 archives:
   - format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - LICENSE.md
 
@@ -75,7 +78,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ incpatch .Tag }}-next"
+  version_template: "{{ incpatch .Tag }}-next"
 
 changelog:
   sort: asc

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ schema-dump: ## Dump SQLite and Postgres schema files from migrations
 
 .PHONY: snapshot
 snapshot: ## Build release snapshot
-	goreleaser release --snapshot --skip publish --clean
+	goreleaser release --snapshot --skip=publish --clean
 
 .PHONY: build-ui
 build-ui: ## Build dev server UI

--- a/tools/release-notes/build_test.go
+++ b/tools/release-notes/build_test.go
@@ -178,6 +178,45 @@ N/A
 	}
 }
 
+func TestBuildReleaseNotesDoesNotDuplicateManualNotesFromPreview(t *testing.T) {
+	releasePRBody := `### Additional Release Notes
+<!-- release-note:manual-start -->
+Manual release note.
+<!-- release-note:manual-end -->
+
+### Additional Migration Notes
+<!-- migration-note:manual-start -->
+Manual migration note.
+<!-- migration-note:manual-end -->
+
+## Final Release Page Preview
+<!-- release-note:preview-start -->
+## Release Notes
+
+Manual release note.
+
+## Migration Notes
+
+Manual migration note.
+
+## Changelog
+
+- Old entry
+<!-- release-note:preview-end -->`
+
+	got, err := BuildReleaseNotes(NotesFile{}, "### Bug Fixes\n\n- Fix thing", releasePRBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if count := strings.Count(got, "Manual release note."); count != 1 {
+		t.Fatalf("manual release note count = %d, want 1:\n%s", count, got)
+	}
+	if count := strings.Count(got, "Manual migration note."); count != 1 {
+		t.Fatalf("manual migration note count = %d, want 1:\n%s", count, got)
+	}
+}
+
 func TestBuildCommandWritesOutput(t *testing.T) {
 	dir := t.TempDir()
 	notesPath := filepath.Join(dir, "notes.json")


### PR DESCRIPTION
## Description

Release automation was creating tags from GitHub Actions with the default `GITHUB_TOKEN`, which does not trigger the downstream tag `push` workflow that creates GitHub Releases and publishes artifacts. The stable release workflow also built the final GitHub Release body without passing the merged release PR body, so manual release and migration note blocks were omitted from `v1.19.3`.

This PR updates the release flow to:

- push stable release tags with `secrets.RELEASE_TOKEN` so `release.yml` runs after `release/next` merges
- push prerelease tags with `secrets.RELEASE_TOKEN`, scoped only to the tag publish step
- avoid persisting checkout credentials in the prerelease workflow before PR code is checked out
- include manual release and migration note blocks from the release PR in the published GitHub Release body
- include existing manual release PR blocks in the rendered release PR preview
- refresh the release PR preview when the `release/next` PR body is edited
- avoid update loops by skipping PR edits when the rendered title/body is unchanged
- cover the manual-note re-render path with a regression test to ensure final release notes do not duplicate manual entries from the preview
- update GoReleaser usage/configuration for v2 and validate the config with `goreleaser check`
- run the GoReleaser job on the Depot Ubuntu runner

## Release note

None.

## Migration note

None.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Restores tag-triggered publishing by switching release and prerelease tag pushes to `secrets.RELEASE_TOKEN` (which triggers downstream workflows, unlike `GITHUB_TOKEN`). Also fixes the release notes build to include manual note blocks from the merged release PR body, refreshes the release PR preview on `pull_request_target` edits, adds an idempotency check to skip no-op PR updates, and upgrades GoReleaser configuration to v2.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 1ce38e1597b9ba403695f80aa61f145de05f7467.</sup>
<!-- /MENDRAL_SUMMARY -->