### PR TITLE
fix: Adding A Check For Minimum Number of Apps Per Connection

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -1442,6 +1442,14 @@ func (c *connectionHandler) establishConnection(ctx context.Context) (*state.Con
 			limit = authResp.Entitlements.AppsPerConnection
 		}
 
+		if len(initialMessageData.Apps) == 0 {
+			return nil, &connecterrors.SocketError{
+				SysCode:    syscode.CodeConnectWorkerHelloInvalidPayload,
+				StatusCode: websocket.StatusPolicyViolation,
+				Msg:        "Missing apps in SDK connect message",
+			}
+		}
+
 		if len(initialMessageData.Apps) > limit {
 			return nil, &connecterrors.SocketError{
 				SysCode:    syscode.CodeConnectTooManyAppsPerConnection,

--- a/pkg/connect/gateway_test.go
+++ b/pkg/connect/gateway_test.go
@@ -1747,6 +1747,46 @@ func TestEstablishConnectionMissingInstanceId(t *testing.T) {
 	require.Equal(t, syscode.CodeConnectWorkerHelloInvalidPayload, reason)
 }
 
+// TestEstablishConnectionMissingApps tests missing app configurations.
+func TestEstablishConnectionMissingApps(t *testing.T) {
+	res := createTestingGateway(t, testingParameters{
+		noConnect: true,
+	})
+
+	ws, _, err := websocket.Dial(context.Background(), res.websocketUrl, &websocket.DialOptions{
+		Subprotocols: []string{types.GatewaySubProtocol},
+	})
+	require.NoError(t, err)
+	defer func() { _ = ws.CloseNow() }()
+
+	// Wait for hello message
+	msg := awaitNextMessage(t, ws, 2*time.Second)
+	require.Equal(t, connect.GatewayMessageType_GATEWAY_HELLO, msg.Kind)
+
+	connID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	reqData := proto.Clone(res.reqData).(*connect.WorkerConnectRequestData)
+	reqData.ConnectionId = connID.String()
+	reqData.Apps = nil
+
+	connectMsg, err := proto.Marshal(reqData)
+	require.NoError(t, err)
+
+	err = wsproto.Write(context.Background(), ws, &connect.ConnectMessage{
+		Kind:    connect.GatewayMessageType_WORKER_CONNECT,
+		Payload: connectMsg,
+	})
+	require.NoError(t, err)
+
+	status, reason := awaitClosure(t, ws, 2*time.Second)
+	require.Equal(t, websocket.StatusPolicyViolation, status)
+	require.Equal(t, syscode.CodeConnectWorkerHelloInvalidPayload, reason)
+
+	conn, err := res.stateManager.GetConnection(context.Background(), res.envID, connID)
+	require.NoError(t, err)
+	require.Nil(t, conn)
+}
+
 // TestCloseWithConnectError tests the closeWithConnectError function
 func TestCloseWithConnectError(t *testing.T) {
 	res := createTestingGateway(t, testingParameters{

--- a/pkg/connect/lifecycles/semaphore.go
+++ b/pkg/connect/lifecycles/semaphore.go
@@ -64,7 +64,7 @@ func (s *semaphoreLifecycles) OnSynced(ctx context.Context, conn *state.Connecti
 		}
 
 		semID := constraintapi.SemaphoreIDApp(*group.AppID)
-		idempotencyKey := fmt.Sprintf("connect-%s", conn.ConnectionId)
+		idempotencyKey := fmt.Sprintf("connect-%s-%s", conn.ConnectionId, semID)
 
 		_, err := util.WithRetry(ctx, "adjust-semaphore-capacity-connect", func(ctx context.Context) (struct{}, error) {
 			_, err := s.sm.AdjustCapacity(ctx, conn.AccountID, semID, idempotencyKey, maxConcurrency)
@@ -102,7 +102,7 @@ func (s *semaphoreLifecycles) OnDisconnected(ctx context.Context, conn *state.Co
 
 		semID := constraintapi.SemaphoreIDApp(*group.AppID)
 		// Different idempotency key from connect so both operations can execute
-		idempotencyKey := fmt.Sprintf("disconnect-%s", conn.ConnectionId)
+		idempotencyKey := fmt.Sprintf("disconnect-%s-%s", conn.ConnectionId, semID)
 
 		_, err := util.WithRetry(ctx, "adjust-semaphore-capacity-disconnect", func(ctx context.Context) (struct{}, error) {
 			_, err := s.sm.AdjustCapacity(ctx, conn.AccountID, semID, idempotencyKey, -maxConcurrency)

--- a/pkg/connect/lifecycles/semaphore_test.go
+++ b/pkg/connect/lifecycles/semaphore_test.go
@@ -1,0 +1,133 @@
+package lifecycles
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/connect/state"
+	"github.com/inngest/inngest/pkg/constraintapi"
+	connectpb "github.com/inngest/inngest/proto/gen/connect/v1"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type semaphoreAdjustCall struct {
+	accountID      uuid.UUID
+	name           string
+	idempotencyKey string
+	delta          int64
+}
+
+type recordingSemaphoreManager struct {
+	mu    sync.Mutex
+	calls []semaphoreAdjustCall
+}
+
+func (m *recordingSemaphoreManager) SetCapacity(context.Context, uuid.UUID, string, string, int64) (constraintapi.SetResult, error) {
+	panic("not implemented")
+}
+
+func (m *recordingSemaphoreManager) AdjustCapacity(_ context.Context, accountID uuid.UUID, name, idempotencyKey string, delta int64) (constraintapi.AdjustResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls = append(m.calls, semaphoreAdjustCall{
+		accountID:      accountID,
+		name:           name,
+		idempotencyKey: idempotencyKey,
+		delta:          delta,
+	})
+
+	return constraintapi.AdjustResult{Applied: true, Capacity: delta}, nil
+}
+
+func (m *recordingSemaphoreManager) GetCapacity(context.Context, uuid.UUID, string, string) (int64, int64, error) {
+	panic("not implemented")
+}
+
+func (m *recordingSemaphoreManager) ReleaseSemaphore(context.Context, uuid.UUID, string, string, string, int64) error {
+	panic("not implemented")
+}
+
+func (m *recordingSemaphoreManager) recordedCalls() []semaphoreAdjustCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	calls := make([]semaphoreAdjustCall, len(m.calls))
+	copy(calls, m.calls)
+	return calls
+}
+
+func (m *recordingSemaphoreManager) reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls = nil
+}
+
+func TestSemaphoreLifecycleUsesUniqueIdempotencyKeysPerApp(t *testing.T) {
+	ctx := context.Background()
+	accountID := uuid.New()
+	appID1 := uuid.New()
+	appID2 := uuid.New()
+	connID := ulid.Make()
+	maxConcurrency := int64(7)
+
+	conn := &state.Connection{
+		AccountID:    accountID,
+		ConnectionId: connID,
+		Data: &connectpb.WorkerConnectRequestData{
+			MaxWorkerConcurrency: &maxConcurrency,
+		},
+		Groups: map[string]*state.WorkerGroup{
+			"group-1": {AppID: &appID1},
+			"group-2": {AppID: &appID2},
+		},
+	}
+
+	sm := &recordingSemaphoreManager{}
+	lifecycle := NewSemaphoreLifecycleListener(sm, time.Time{})
+
+	lifecycle.OnSynced(ctx, conn)
+
+	connectCalls := sm.recordedCalls()
+	require.Len(t, connectCalls, 2)
+	require.ElementsMatch(t, []string{
+		constraintapi.SemaphoreIDApp(appID1),
+		constraintapi.SemaphoreIDApp(appID2),
+	}, []string{connectCalls[0].name, connectCalls[1].name})
+
+	connectKeys := map[string]struct{}{}
+	for _, call := range connectCalls {
+		require.Equal(t, accountID, call.accountID)
+		require.Equal(t, maxConcurrency, call.delta)
+		require.Contains(t, call.idempotencyKey, "connect-"+connID.String()+"-")
+		require.Contains(t, call.idempotencyKey, call.name)
+		connectKeys[call.idempotencyKey] = struct{}{}
+	}
+	require.Len(t, connectKeys, 2)
+
+	sm.reset()
+	lifecycle.OnDisconnected(ctx, conn, "test close")
+
+	disconnectCalls := sm.recordedCalls()
+	require.Len(t, disconnectCalls, 2)
+	require.ElementsMatch(t, []string{
+		constraintapi.SemaphoreIDApp(appID1),
+		constraintapi.SemaphoreIDApp(appID2),
+	}, []string{disconnectCalls[0].name, disconnectCalls[1].name})
+
+	disconnectKeys := map[string]struct{}{}
+	for _, call := range disconnectCalls {
+		require.Equal(t, accountID, call.accountID)
+		require.Equal(t, -maxConcurrency, call.delta)
+		require.Contains(t, call.idempotencyKey, "disconnect-"+connID.String()+"-")
+		require.Contains(t, call.idempotencyKey, call.name)
+		require.NotContains(t, connectKeys, call.idempotencyKey)
+		disconnectKeys[call.idempotencyKey] = struct{}{}
+	}
+	require.Len(t, disconnectKeys, 2)
+}


### PR DESCRIPTION
## Description

Adding a lower bound check on number of apps

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds a lower-bound validation rejecting worker connect messages with zero apps (`CodeConnectWorkerHelloInvalidPayload` / `StatusPolicyViolation`), and fixes a semaphore idempotency key bug where all apps in a multi-app connection shared the same key (`connect-{connID}`), causing only the first app's capacity adjustment to take effect. The semaphore fix appends the semaphore ID to the key, making it unique per app per connection for both connect and disconnect operations.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 7df8c779ecdeff7db827b6c1a8a164a960401f75.</sup>
<!-- /MENDRAL_SUMMARY -->