### PR TITLE
refactor(queue): Remove duplicate item lookup method

### DIFF
--- a/pkg/debugapi/queue_item.go
+++ b/pkg/debugapi/queue_item.go
@@ -26,7 +26,7 @@ func (d *debugAPI) GetQueueItem(ctx context.Context, req *pb.QueueItemRequest) (
 	}
 
 	if itemID := req.GetItemId(); itemID != "" {
-		queueItem, err := d.queue.ItemByID(ctx, shard, itemID)
+		queueItem, err := d.queue.LoadQueueItem(ctx, shard.Name(), itemID)
 		if err != nil {
 			if errors.Is(err, queue.ErrQueueItemNotFound) {
 				return nil, status.Error(codes.NotFound, "no item found with id")

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -78,8 +78,8 @@ type QueueManager interface {
 	BacklogByID(ctx context.Context, queueShard QueueShard, backlogID string) (*QueueBacklog, error)
 	// PartitionByID retrieves the partition by the partition ID
 	PartitionByID(ctx context.Context, queueShard QueueShard, partitionID string) (*PartitionInspectionResult, error)
-	// ItemByID retrieves the queue item by the jobID
-	ItemByID(ctx context.Context, queueShard QueueShard, jobID string) (*QueueItem, error)
+	// LoadQueueItem retrieves the queue item by the item ID.
+	LoadQueueItem(ctx context.Context, shardName string, itemID string) (*QueueItem, error)
 
 	// ItemExists checks if an item with jobID exists in the queue
 	ItemExists(ctx context.Context, queueShard QueueShard, jobID string) (bool, error)
@@ -333,7 +333,6 @@ type ShardOperations interface {
 
 	DequeueByJobID(ctx context.Context, jobID string) error
 
-	ItemByID(ctx context.Context, jobID string) (*QueueItem, error)
 	ItemExists(ctx context.Context, jobID string) (bool, error)
 	ItemsByRunID(ctx context.Context, runID ulid.ULID) ([]*QueueItem, error)
 	PartitionBacklogSize(ctx context.Context, partitionID string) (int64, error)

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -223,11 +223,6 @@ func (q *queueProcessor) Dequeue(ctx context.Context, shard QueueShard, i QueueI
 	return shard.Dequeue(ctx, i, opts...)
 }
 
-// ItemByID implements QueueManager.
-func (q *queueProcessor) ItemByID(ctx context.Context, shard QueueShard, jobID string) (*QueueItem, error) {
-	return shard.ItemByID(ctx, jobID)
-}
-
 // ItemExists implements QueueManager.
 func (q *queueProcessor) ItemExists(ctx context.Context, shard QueueShard, jobID string) (bool, error) {
 	return shard.ItemExists(ctx, jobID)

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -336,10 +336,6 @@ func (m *mockShardForIterator) DequeueByJobID(ctx context.Context, jobID string)
 	return nil
 }
 
-func (m *mockShardForIterator) ItemByID(ctx context.Context, jobID string) (*QueueItem, error) {
-	return nil, nil
-}
-
 func (m *mockShardForIterator) ItemExists(ctx context.Context, jobID string) (bool, error) {
 	return false, nil
 }

--- a/pkg/execution/state/redis_state/queue_op.go
+++ b/pkg/execution/state/redis_state/queue_op.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (q *queue) DequeueByJobID(ctx context.Context, jobID string) error {
-	item, err := q.ItemByID(ctx, jobID)
+	item, err := q.LoadQueueItem(ctx, jobID)
 	switch err {
 	case nil:
 		// no-op

--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -554,26 +554,6 @@ func (q *queue) QueueIterator(ctx context.Context, opts QueueIteratorOpts) (part
 	return atomic.LoadInt64(&totalPartitions), atomic.LoadInt64(&totalQueueItems), nil
 }
 
-func (q *queue) ItemByID(ctx context.Context, jobID string) (*osqueue.QueueItem, error) {
-	rc := q.RedisClient.Client()
-	kg := q.RedisClient.kg
-
-	cmd := rc.B().Hget().Key(kg.QueueItem()).Field(jobID).Build()
-	byt, err := rc.Do(ctx, cmd).AsBytes()
-	if err != nil {
-		if rueidis.IsRedisNil(err) {
-			return nil, osqueue.ErrQueueItemNotFound
-		}
-	}
-
-	var item osqueue.QueueItem
-	if err := json.Unmarshal(byt, &item); err != nil {
-		return nil, fmt.Errorf("error unmarshalling queue item: %w", err)
-	}
-
-	return &item, nil
-}
-
 func (q *queue) ItemExists(ctx context.Context, jobID string) (bool, error) {
 	rc := q.RedisClient.Client()
 	kg := q.RedisClient.kg

--- a/pkg/execution/state/redis_state/reader_test.go
+++ b/pkg/execution/state/redis_state/reader_test.go
@@ -944,11 +944,11 @@ func TestItemsByBacklog(t *testing.T) {
 			expectedItems: 10,
 		},
 		{
-			name:          "with out of range interval",
-			num:           10,
-			from:          clock.Now(),
-			until:         clock.Now().Add(7 * time.Second).Truncate(time.Second),
-			interval:      time.Second,
+			name:     "with out of range interval",
+			num:      10,
+			from:     clock.Now(),
+			until:    clock.Now().Add(7 * time.Second).Truncate(time.Second),
+			interval: time.Second,
 			// 10 items enqueued at 0s–9s; the inclusive [from, until] window
 			// covers 0s–7s, so 8 items (at offsets 0–7) are returned.
 			expectedItems: 8,
@@ -1344,7 +1344,7 @@ func TestQueueIterator(t *testing.T) {
 	}
 }
 
-func TestItemByID(t *testing.T) {
+func TestLoadQueueItem(t *testing.T) {
 	_, rc := initRedis(t)
 	defer rc.Close()
 
@@ -1383,7 +1383,7 @@ func TestItemByID(t *testing.T) {
 		enqueued, err := enqueue(ctx, shard)
 		require.NoError(t, err)
 
-		res, err := q1.ItemByID(ctx, shard, enqueued.ID)
+		res, err := q1.LoadQueueItem(ctx, shard.Name(), enqueued.ID)
 		require.NoError(t, err)
 		require.NotNil(t, res)
 		require.Equal(t, enqueued.ID, res.ID)
@@ -1393,7 +1393,7 @@ func TestItemByID(t *testing.T) {
 		_, err := enqueue(ctx, shard)
 		require.NoError(t, err)
 
-		res, err := q1.ItemByID(ctx, shard, "random")
+		res, err := q1.LoadQueueItem(ctx, shard.Name(), "random")
 		require.ErrorIs(t, err, osqueue.ErrQueueItemNotFound)
 		require.Nil(t, res)
 	})

--- a/pkg/execution/state/redis_state/shadow_queue_test.go
+++ b/pkg/execution/state/redis_state/shadow_queue_test.go
@@ -1573,19 +1573,19 @@ func TestBacklogRefillSetCapacityLease(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, len(res.RefilledItems))
 
-	loaded, err := q.ItemByID(ctx, shard, item1.ID)
+	loaded, err := q.LoadQueueItem(ctx, shard.Name(), item1.ID)
 	require.NoError(t, err)
 	require.Equal(t, loaded.ID, item1.ID)
 	require.NotNil(t, loaded.CapacityLease)
 	require.Equal(t, capacityLeaseID, loaded.CapacityLease.LeaseID)
 
-	loaded, err = q.ItemByID(ctx, shard, item2.ID)
+	loaded, err = q.LoadQueueItem(ctx, shard.Name(), item2.ID)
 	require.NoError(t, err)
 	require.Equal(t, loaded.ID, item2.ID)
 	require.NotNil(t, loaded.CapacityLease)
 	require.Equal(t, capacityLeaseID2, loaded.CapacityLease.LeaseID)
 
-	loaded, err = q.ItemByID(ctx, shard, item3.ID)
+	loaded, err = q.LoadQueueItem(ctx, shard.Name(), item3.ID)
 	require.NoError(t, err)
 	require.Equal(t, loaded.ID, item3.ID)
 	require.NotNil(t, loaded.CapacityLease)

--- a/tests/execution/queue/lua_compatibility_test.go
+++ b/tests/execution/queue/lua_compatibility_test.go
@@ -400,7 +400,7 @@ func TestLuaCompatibility(t *testing.T) {
 				require.NotNil(t, res)
 				require.Equal(t, 1, len(res.RefilledItems))
 
-				refilled, err := q.ItemByID(ctx, shard, qi2.ID)
+				refilled, err := q.LoadQueueItem(ctx, shard.Name(), qi2.ID)
 				require.NoError(t, err)
 				require.NotNil(t, refilled.CapacityLease)
 				require.Equal(t, capacityLeaseID.String(), refilled.CapacityLease.LeaseID.String())


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes the duplicate `ItemByID` method from both the `ShardOperations` interface and `QueueManager` interface, consolidating all callers to use the existing `LoadQueueItem`. The `QueueManager` interface signature changes from taking a `QueueShard` struct to just `shardName string`, with the `queueProcessor` implementation resolving the shard via `q.shards.ByName(shardName)`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4a2eb696c3dbcce71471173e5b69cde574c52bdf.</sup>
<!-- /MENDRAL_SUMMARY -->