### PR TITLE
refactor(queue): scope debounce and singleton operations

### DIFF
--- a/cmd/debug/debounce/delete.go
+++ b/cmd/debug/debounce/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/inngest/inngest/cmd/debug/debugflags"
 	debugpkg "github.com/inngest/inngest/pkg/debug"
 	dbgpb "github.com/inngest/inngest/proto/gen/debug/v1"
 	"github.com/urfave/cli/v3"
@@ -15,14 +16,14 @@ func DeleteCommand() *cli.Command {
 		Aliases:   []string{"d", "rm"},
 		Usage:     "Delete a debounce for a function",
 		ArgsUsage: "<function-uuid>",
-		Flags: []cli.Flag{
+		Flags: append(debugflags.AccountEnvFlags(),
 			&cli.StringFlag{
 				Name:    "key",
 				Aliases: []string{"k"},
 				Value:   "",
 				Usage:   "Debounce key (optional, for keyed debounces)",
 			},
-		},
+		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.NArg() == 0 {
 				return fmt.Errorf("function UUID is required")
@@ -30,6 +31,10 @@ func DeleteCommand() *cli.Command {
 
 			functionID := cmd.Args().Get(0)
 			debounceKey := cmd.String("key")
+			accountID, envID, err := debugflags.AccountEnv(cmd)
+			if err != nil {
+				return err
+			}
 
 			debugCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
 			if !ok {
@@ -39,6 +44,8 @@ func DeleteCommand() *cli.Command {
 			req := &dbgpb.DeleteDebounceRequest{
 				FunctionId:  functionID,
 				DebounceKey: debounceKey,
+				AccountId:   accountID,
+				EnvId:       envID,
 			}
 
 			resp, err := debugCtx.Client.DeleteDebounce(ctx, req)

--- a/cmd/debug/debounce/delete_by_id.go
+++ b/cmd/debug/debounce/delete_by_id.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/inngest/inngest/cmd/debug/debugflags"
 	debugpkg "github.com/inngest/inngest/pkg/debug"
 	dbgpb "github.com/inngest/inngest/proto/gen/debug/v1"
 	"github.com/urfave/cli/v3"
@@ -16,6 +17,10 @@ func DeleteByIDCommand() *cli.Command {
 		Aliases:   []string{"rmid"},
 		Usage:     "Delete debounces directly by their IDs",
 		ArgsUsage: "<debounce-id> [debounce-id...]",
+		Flags: append(
+			debugflags.AccountEnvFlags(),
+			debugflags.FunctionFlag(),
+		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.NArg() == 0 {
 				return fmt.Errorf("at least one debounce ID is required")
@@ -26,6 +31,16 @@ func DeleteByIDCommand() *cli.Command {
 				ids[i] = cmd.Args().Get(i)
 			}
 
+			accountID, envID, err := debugflags.AccountEnv(cmd)
+			if err != nil {
+				return err
+			}
+
+			functionID, err := debugflags.RequiredUUID(cmd, "function-id")
+			if err != nil {
+				return err
+			}
+
 			debugCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
 			if !ok {
 				return fmt.Errorf("debug context not found")
@@ -33,6 +48,9 @@ func DeleteByIDCommand() *cli.Command {
 
 			req := &dbgpb.DeleteDebounceByIDRequest{
 				DebounceIds: ids,
+				AccountId:   accountID,
+				EnvId:       envID,
+				FunctionId:  functionID,
 			}
 
 			resp, err := debugCtx.Client.DeleteDebounceByID(ctx, req)

--- a/cmd/debug/debounce/info.go
+++ b/cmd/debug/debounce/info.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/inngest/inngest/cmd/debug/debugflags"
 	debugpkg "github.com/inngest/inngest/pkg/debug"
 	dbgpb "github.com/inngest/inngest/proto/gen/debug/v1"
 	"github.com/urfave/cli/v3"
@@ -16,14 +17,14 @@ func InfoCommand() *cli.Command {
 		Aliases:   []string{"i"},
 		Usage:     "Get debounce information for a function",
 		ArgsUsage: "<function-uuid>",
-		Flags: []cli.Flag{
+		Flags: append(debugflags.AccountEnvFlags(),
 			&cli.StringFlag{
 				Name:    "key",
 				Aliases: []string{"k"},
 				Value:   "",
 				Usage:   "Debounce key (optional, for keyed debounces)",
 			},
-		},
+		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.NArg() == 0 {
 				return fmt.Errorf("function UUID is required")
@@ -31,6 +32,10 @@ func InfoCommand() *cli.Command {
 
 			functionID := cmd.Args().Get(0)
 			debounceKey := cmd.String("key")
+			accountID, envID, err := debugflags.AccountEnv(cmd)
+			if err != nil {
+				return err
+			}
 
 			debugCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
 			if !ok {
@@ -40,6 +45,8 @@ func InfoCommand() *cli.Command {
 			req := &dbgpb.DebounceInfoRequest{
 				FunctionId:  functionID,
 				DebounceKey: debounceKey,
+				AccountId:   accountID,
+				EnvId:       envID,
 			}
 
 			resp, err := debugCtx.Client.GetDebounceInfo(ctx, req)

--- a/cmd/debug/debounce/run.go
+++ b/cmd/debug/debounce/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/inngest/inngest/cmd/debug/debugflags"
 	debugpkg "github.com/inngest/inngest/pkg/debug"
 	dbgpb "github.com/inngest/inngest/proto/gen/debug/v1"
 	"github.com/urfave/cli/v3"
@@ -15,14 +16,14 @@ func RunCommand() *cli.Command {
 		Aliases:   []string{"r"},
 		Usage:     "Execute a pending debounce immediately",
 		ArgsUsage: "<function-uuid>",
-		Flags: []cli.Flag{
+		Flags: append(debugflags.AccountEnvFlags(),
 			&cli.StringFlag{
 				Name:    "key",
 				Aliases: []string{"k"},
 				Value:   "",
 				Usage:   "Debounce key (optional, for keyed debounces)",
 			},
-		},
+		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.NArg() == 0 {
 				return fmt.Errorf("function UUID is required")
@@ -30,6 +31,10 @@ func RunCommand() *cli.Command {
 
 			functionID := cmd.Args().Get(0)
 			debounceKey := cmd.String("key")
+			accountID, envID, err := debugflags.AccountEnv(cmd)
+			if err != nil {
+				return err
+			}
 
 			debugCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
 			if !ok {
@@ -39,6 +44,8 @@ func RunCommand() *cli.Command {
 			req := &dbgpb.RunDebounceRequest{
 				FunctionId:  functionID,
 				DebounceKey: debounceKey,
+				AccountId:   accountID,
+				EnvId:       envID,
 			}
 
 			resp, err := debugCtx.Client.RunDebounce(ctx, req)

--- a/cmd/debug/debugflags/scope.go
+++ b/cmd/debug/debugflags/scope.go
@@ -1,0 +1,53 @@
+package debugflags
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/urfave/cli/v3"
+)
+
+func AccountEnvFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  "account-id",
+			Usage: "Account UUID that owns the function",
+		},
+		&cli.StringFlag{
+			Name:  "env-id",
+			Usage: "Environment UUID that owns the function",
+		},
+	}
+}
+
+func FunctionFlag() cli.Flag {
+	return &cli.StringFlag{
+		Name:  "function-id",
+		Usage: "Function UUID that owns the debounce",
+	}
+}
+
+func AccountEnv(cmd *cli.Command) (string, string, error) {
+	accountID, err := RequiredUUID(cmd, "account-id")
+	if err != nil {
+		return "", "", err
+	}
+
+	envID, err := RequiredUUID(cmd, "env-id")
+	if err != nil {
+		return "", "", err
+	}
+
+	return accountID, envID, nil
+}
+
+func RequiredUUID(cmd *cli.Command, name string) (string, error) {
+	val := cmd.String(name)
+	if val == "" {
+		return "", fmt.Errorf("%s is required", name)
+	}
+	if _, err := uuid.Parse(val); err != nil {
+		return "", fmt.Errorf("invalid %s: %w", name, err)
+	}
+	return val, nil
+}

--- a/cmd/debug/singleton/delete.go
+++ b/cmd/debug/singleton/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/inngest/inngest/cmd/debug/debugflags"
 	debugpkg "github.com/inngest/inngest/pkg/debug"
 	dbgpb "github.com/inngest/inngest/proto/gen/debug/v1"
 	"github.com/urfave/cli/v3"
@@ -15,14 +16,14 @@ func DeleteCommand() *cli.Command {
 		Aliases:   []string{"d", "rm"},
 		Usage:     "Delete a singleton lock for a function",
 		ArgsUsage: "<function-uuid>",
-		Flags: []cli.Flag{
+		Flags: append(debugflags.AccountEnvFlags(),
 			&cli.StringFlag{
 				Name:    "key",
 				Aliases: []string{"k"},
 				Value:   "",
 				Usage:   "Singleton key suffix (optional, for keyed singletons)",
 			},
-		},
+		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.NArg() == 0 {
 				return fmt.Errorf("function UUID is required")
@@ -30,6 +31,10 @@ func DeleteCommand() *cli.Command {
 
 			functionID := cmd.Args().Get(0)
 			singletonKey := cmd.String("key")
+			accountID, envID, err := debugflags.AccountEnv(cmd)
+			if err != nil {
+				return err
+			}
 
 			debugCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
 			if !ok {
@@ -39,6 +44,8 @@ func DeleteCommand() *cli.Command {
 			req := &dbgpb.DeleteSingletonLockRequest{
 				FunctionId:   functionID,
 				SingletonKey: singletonKey,
+				AccountId:    accountID,
+				EnvId:        envID,
 			}
 
 			resp, err := debugCtx.Client.DeleteSingletonLock(ctx, req)

--- a/cmd/debug/singleton/info.go
+++ b/cmd/debug/singleton/info.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/inngest/inngest/cmd/debug/debugflags"
 	debugpkg "github.com/inngest/inngest/pkg/debug"
 	dbgpb "github.com/inngest/inngest/proto/gen/debug/v1"
 	"github.com/urfave/cli/v3"
@@ -15,14 +16,14 @@ func InfoCommand() *cli.Command {
 		Aliases:   []string{"i"},
 		Usage:     "Get singleton lock information for a function",
 		ArgsUsage: "<function-uuid>",
-		Flags: []cli.Flag{
+		Flags: append(debugflags.AccountEnvFlags(),
 			&cli.StringFlag{
 				Name:    "key",
 				Aliases: []string{"k"},
 				Value:   "",
 				Usage:   "Singleton key suffix (optional, for keyed singletons)",
 			},
-		},
+		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.NArg() == 0 {
 				return fmt.Errorf("function UUID is required")
@@ -30,6 +31,10 @@ func InfoCommand() *cli.Command {
 
 			functionID := cmd.Args().Get(0)
 			singletonKey := cmd.String("key")
+			accountID, envID, err := debugflags.AccountEnv(cmd)
+			if err != nil {
+				return err
+			}
 
 			debugCtx, ok := ctx.Value(debugpkg.CtxKey).(*debugpkg.Context)
 			if !ok {
@@ -39,6 +44,8 @@ func InfoCommand() *cli.Command {
 			req := &dbgpb.SingletonInfoRequest{
 				FunctionId:   functionID,
 				SingletonKey: singletonKey,
+				AccountId:    accountID,
+				EnvId:        envID,
 			}
 
 			resp, err := debugCtx.Client.GetSingletonInfo(ctx, req)

--- a/pkg/debugapi/debounce.go
+++ b/pkg/debugapi/debounce.go
@@ -8,8 +8,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/execution/debounce"
-	"github.com/oklog/ulid/v2"
+	"github.com/inngest/inngest/pkg/execution/queue"
 	pb "github.com/inngest/inngest/proto/gen/debug/v1"
+	"github.com/oklog/ulid/v2"
 )
 
 // GetDebounceInfo retrieves the currently debounced event for a function and debounce key.
@@ -23,8 +24,14 @@ func (d *debugAPI) GetDebounceInfo(ctx context.Context, req *pb.DebounceInfoRequ
 		return nil, fmt.Errorf("invalid function_id: %w", err)
 	}
 
+	scope := queue.Scope{
+		AccountID:  consts.DevServerAccountID,
+		EnvID:      consts.DevServerEnvID,
+		FunctionID: fnID,
+	}
+
 	// Use the debouncer to get debounce info
-	info, err := d.debouncer.GetDebounceInfo(ctx, fnID, req.GetDebounceKey())
+	info, err := d.debouncer.GetDebounceInfo(ctx, scope, req.GetDebounceKey())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get debounce info: %w", err)
 	}
@@ -66,7 +73,11 @@ func (d *debugAPI) DeleteDebounce(ctx context.Context, req *pb.DeleteDebounceReq
 		return nil, fmt.Errorf("invalid function_id: %w", err)
 	}
 
-	result, err := d.debouncer.DeleteDebounce(ctx, fnID, req.GetDebounceKey())
+	result, err := d.debouncer.DeleteDebounce(ctx, queue.Scope{
+		AccountID:  consts.DevServerAccountID,
+		EnvID:      consts.DevServerEnvID,
+		FunctionID: fnID,
+	}, req.GetDebounceKey())
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete debounce: %w", err)
 	}
@@ -101,7 +112,10 @@ func (d *debugAPI) DeleteDebounceByID(ctx context.Context, req *pb.DeleteDebounc
 		parsed[i] = u
 	}
 
-	err := d.debouncer.DeleteDebounceByID(ctx, parsed...)
+	err := d.debouncer.DeleteDebounceByID(ctx, queue.Scope{
+		AccountID: consts.DevServerAccountID,
+		EnvID:     consts.DevServerEnvID,
+	}, parsed...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete debounce by ID: %w", err)
 	}
@@ -126,6 +140,7 @@ func (d *debugAPI) RunDebounce(ctx context.Context, req *pb.RunDebounceRequest) 
 		FunctionID:  fnID,
 		DebounceKey: req.GetDebounceKey(),
 		AccountID:   consts.DevServerAccountID,
+		EnvID:       consts.DevServerEnvID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to run debounce: %w", err)

--- a/pkg/debugapi/debounce.go
+++ b/pkg/debugapi/debounce.go
@@ -5,10 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/google/uuid"
-	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/execution/debounce"
-	"github.com/inngest/inngest/pkg/execution/queue"
 	pb "github.com/inngest/inngest/proto/gen/debug/v1"
 	"github.com/oklog/ulid/v2"
 )
@@ -19,15 +16,9 @@ func (d *debugAPI) GetDebounceInfo(ctx context.Context, req *pb.DebounceInfoRequ
 		return nil, fmt.Errorf("debouncer not configured")
 	}
 
-	fnID, err := uuid.Parse(req.GetFunctionId())
+	scope, err := debugScope(req.GetFunctionId(), req.GetAccountId(), req.GetEnvId())
 	if err != nil {
-		return nil, fmt.Errorf("invalid function_id: %w", err)
-	}
-
-	scope := queue.Scope{
-		AccountID:  consts.DevServerAccountID,
-		EnvID:      consts.DevServerEnvID,
-		FunctionID: fnID,
+		return nil, err
 	}
 
 	// Use the debouncer to get debounce info
@@ -68,16 +59,12 @@ func (d *debugAPI) DeleteDebounce(ctx context.Context, req *pb.DeleteDebounceReq
 		return nil, fmt.Errorf("debouncer not configured")
 	}
 
-	fnID, err := uuid.Parse(req.GetFunctionId())
+	scope, err := debugScope(req.GetFunctionId(), req.GetAccountId(), req.GetEnvId())
 	if err != nil {
-		return nil, fmt.Errorf("invalid function_id: %w", err)
+		return nil, err
 	}
 
-	result, err := d.debouncer.DeleteDebounce(ctx, queue.Scope{
-		AccountID:  consts.DevServerAccountID,
-		EnvID:      consts.DevServerEnvID,
-		FunctionID: fnID,
-	}, req.GetDebounceKey())
+	result, err := d.debouncer.DeleteDebounce(ctx, scope, req.GetDebounceKey())
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete debounce: %w", err)
 	}
@@ -112,10 +99,12 @@ func (d *debugAPI) DeleteDebounceByID(ctx context.Context, req *pb.DeleteDebounc
 		parsed[i] = u
 	}
 
-	err := d.debouncer.DeleteDebounceByID(ctx, queue.Scope{
-		AccountID: consts.DevServerAccountID,
-		EnvID:     consts.DevServerEnvID,
-	}, parsed...)
+	scope, err := debugScope(req.GetFunctionId(), req.GetAccountId(), req.GetEnvId())
+	if err != nil {
+		return nil, err
+	}
+
+	err = d.debouncer.DeleteDebounceByID(ctx, scope, parsed...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete debounce by ID: %w", err)
 	}
@@ -131,16 +120,16 @@ func (d *debugAPI) RunDebounce(ctx context.Context, req *pb.RunDebounceRequest) 
 		return nil, fmt.Errorf("debouncer not configured")
 	}
 
-	fnID, err := uuid.Parse(req.GetFunctionId())
+	scope, err := debugScope(req.GetFunctionId(), req.GetAccountId(), req.GetEnvId())
 	if err != nil {
-		return nil, fmt.Errorf("invalid function_id: %w", err)
+		return nil, err
 	}
 
 	result, err := d.debouncer.RunDebounce(ctx, debounce.RunDebounceOpts{
-		FunctionID:  fnID,
+		FunctionID:  scope.FunctionID,
 		DebounceKey: req.GetDebounceKey(),
-		AccountID:   consts.DevServerAccountID,
-		EnvID:       consts.DevServerEnvID,
+		AccountID:   scope.AccountID,
+		EnvID:       scope.EnvID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to run debounce: %w", err)

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -170,6 +170,8 @@ func TestGetSingletonInfoHandler(t *testing.T) {
 	d := &debugAPI{shards: shardRegistry}
 
 	functionID := uuid.New()
+	accountID := uuid.New()
+	envID := uuid.New()
 	singletonKey := functionID.String()
 	runID := ulid.MustNew(ulid.Now(), rand.Reader)
 
@@ -181,6 +183,8 @@ func TestGetSingletonInfoHandler(t *testing.T) {
 	// Test handler correctly converts store response to protobuf
 	resp, err := d.GetSingletonInfo(ctx, &pb.SingletonInfoRequest{
 		FunctionId: functionID.String(),
+		AccountId:  accountID.String(),
+		EnvId:      envID.String(),
 	})
 	require.NoError(t, err)
 	require.True(t, resp.HasLock)
@@ -234,6 +238,8 @@ func TestGetDebounceInfoHandler(t *testing.T) {
 	resp, err := d.GetDebounceInfo(ctx, &pb.DebounceInfoRequest{
 		FunctionId:  functionID.String(),
 		DebounceKey: functionID.String(),
+		AccountId:   accountID.String(),
+		EnvId:       workspaceID.String(),
 	})
 	require.NoError(t, err)
 	require.True(t, resp.HasDebounce)
@@ -450,6 +456,8 @@ func TestDeleteSingletonLockHandler(t *testing.T) {
 	d := &debugAPI{shards: shardRegistry}
 
 	functionID := uuid.New()
+	accountID := uuid.New()
+	envID := uuid.New()
 	singletonKey := functionID.String()
 	runID := ulid.MustNew(ulid.Now(), rand.Reader)
 
@@ -461,6 +469,8 @@ func TestDeleteSingletonLockHandler(t *testing.T) {
 	// Test handler correctly deletes the lock
 	resp, err := d.DeleteSingletonLock(ctx, &pb.DeleteSingletonLockRequest{
 		FunctionId: functionID.String(),
+		AccountId:  accountID.String(),
+		EnvId:      envID.String(),
 	})
 	require.NoError(t, err)
 	require.True(t, resp.Deleted)
@@ -469,6 +479,8 @@ func TestDeleteSingletonLockHandler(t *testing.T) {
 	// Verify lock no longer exists
 	infoResp, err := d.GetSingletonInfo(ctx, &pb.SingletonInfoRequest{
 		FunctionId: functionID.String(),
+		AccountId:  accountID.String(),
+		EnvId:      envID.String(),
 	})
 	require.NoError(t, err)
 	require.False(t, infoResp.HasLock)
@@ -595,6 +607,8 @@ func TestDeleteDebounceHandler(t *testing.T) {
 	resp, err := d.DeleteDebounce(ctx, &pb.DeleteDebounceRequest{
 		FunctionId:  functionID.String(),
 		DebounceKey: functionID.String(),
+		AccountId:   accountID.String(),
+		EnvId:       workspaceID.String(),
 	})
 	require.NoError(t, err)
 	require.True(t, resp.Deleted)
@@ -605,6 +619,8 @@ func TestDeleteDebounceHandler(t *testing.T) {
 	infoResp, err := d.GetDebounceInfo(ctx, &pb.DebounceInfoRequest{
 		FunctionId:  functionID.String(),
 		DebounceKey: functionID.String(),
+		AccountId:   accountID.String(),
+		EnvId:       workspaceID.String(),
 	})
 	require.NoError(t, err)
 	require.False(t, infoResp.HasDebounce)
@@ -656,11 +672,72 @@ func TestRunDebounceHandler(t *testing.T) {
 	resp, err := d.RunDebounce(ctx, &pb.RunDebounceRequest{
 		FunctionId:  functionID.String(),
 		DebounceKey: functionID.String(),
+		AccountId:   accountID.String(),
+		EnvId:       workspaceID.String(),
 	})
 	require.NoError(t, err)
 	require.True(t, resp.Scheduled)
 	require.NotEmpty(t, resp.DebounceId)
 	require.Equal(t, eventID.String(), resp.EventId)
+}
+
+func TestDeleteDebounceByIDHandler(t *testing.T) {
+	rc, _ := setupTestRedis(t)
+	ctx := context.Background()
+
+	redisDebouncer := setupDebouncer(t, rc)
+	d := &debugAPI{debouncer: redisDebouncer}
+
+	accountID := uuid.New()
+	workspaceID := uuid.New()
+	appID := uuid.New()
+	functionID := uuid.New()
+	eventID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	di := debounce.DebounceItem{
+		AccountID:       accountID,
+		WorkspaceID:     workspaceID,
+		AppID:           appID,
+		FunctionID:      functionID,
+		FunctionVersion: 1,
+		EventID:         eventID,
+		Event: event.Event{
+			Name:      "test/debounce-event",
+			ID:        eventID.String(),
+			Timestamp: time.Now().UnixMilli(),
+			Data:      map[string]any{"key": "value"},
+		},
+	}
+
+	fn := inngest.Function{
+		ID: functionID,
+		Debounce: &inngest.Debounce{
+			Key:     nil,
+			Period:  "10s",
+			Timeout: util.StrPtr("60s"),
+		},
+	}
+
+	err := redisDebouncer.Debounce(ctx, di, fn)
+	require.NoError(t, err)
+
+	infoResp, err := d.GetDebounceInfo(ctx, &pb.DebounceInfoRequest{
+		FunctionId:  functionID.String(),
+		DebounceKey: functionID.String(),
+		AccountId:   accountID.String(),
+		EnvId:       workspaceID.String(),
+	})
+	require.NoError(t, err)
+	require.True(t, infoResp.HasDebounce)
+
+	resp, err := d.DeleteDebounceByID(ctx, &pb.DeleteDebounceByIDRequest{
+		DebounceIds: []string{infoResp.DebounceId},
+		AccountId:   accountID.String(),
+		EnvId:       workspaceID.String(),
+		FunctionId:  functionID.String(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{infoResp.DebounceId}, resp.DeletedIds)
 }
 
 func TestDeleteDebounceNilDebouncer(t *testing.T) {

--- a/pkg/debugapi/scope.go
+++ b/pkg/debugapi/scope.go
@@ -1,0 +1,36 @@
+package debugapi
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/execution/queue"
+)
+
+func debugScope(functionID, accountID, envID string) (queue.Scope, error) {
+	fnID, err := uuid.Parse(functionID)
+	if err != nil {
+		return queue.Scope{}, fmt.Errorf("invalid function_id: %w", err)
+	}
+
+	acctID, err := uuid.Parse(accountID)
+	if err != nil {
+		return queue.Scope{}, fmt.Errorf("invalid account_id: %w", err)
+	}
+
+	environmentID, err := uuid.Parse(envID)
+	if err != nil {
+		return queue.Scope{}, fmt.Errorf("invalid env_id: %w", err)
+	}
+
+	scope := queue.Scope{
+		AccountID:  acctID,
+		EnvID:      environmentID,
+		FunctionID: fnID,
+	}
+	if err := scope.Validate(); err != nil {
+		return queue.Scope{}, err
+	}
+
+	return scope, nil
+}

--- a/pkg/debugapi/singleton.go
+++ b/pkg/debugapi/singleton.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/execution/queue"
 	pb "github.com/inngest/inngest/proto/gen/debug/v1"
 )
 
@@ -27,7 +28,11 @@ func (d *debugAPI) GetSingletonInfo(ctx context.Context, req *pb.SingletonInfoRe
 		return nil, fmt.Errorf("failed to resolve shard: %w", err)
 	}
 
-	runID, err := shard.SingletonGetRunID(ctx, singletonKey)
+	runID, err := shard.SingletonGetRunID(ctx, queue.Scope{
+		AccountID:  consts.DevServerAccountID,
+		EnvID:      consts.DevServerEnvID,
+		FunctionID: fnID,
+	}, singletonKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get singleton info: %w", err)
 	}
@@ -63,7 +68,11 @@ func (d *debugAPI) DeleteSingletonLock(ctx context.Context, req *pb.DeleteSingle
 		return nil, fmt.Errorf("failed to resolve shard: %w", err)
 	}
 
-	runID, err := shard.SingletonReleaseRunID(ctx, singletonKey)
+	runID, err := shard.SingletonReleaseRunID(ctx, queue.Scope{
+		AccountID:  consts.DevServerAccountID,
+		EnvID:      consts.DevServerEnvID,
+		FunctionID: fnID,
+	}, singletonKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete singleton lock: %w", err)
 	}

--- a/pkg/debugapi/singleton.go
+++ b/pkg/debugapi/singleton.go
@@ -4,35 +4,28 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/uuid"
-	"github.com/inngest/inngest/pkg/consts"
-	"github.com/inngest/inngest/pkg/execution/queue"
 	pb "github.com/inngest/inngest/proto/gen/debug/v1"
 )
 
 // GetSingletonInfo retrieves the current singleton lock status for a given key.
 func (d *debugAPI) GetSingletonInfo(ctx context.Context, req *pb.SingletonInfoRequest) (*pb.SingletonInfoResponse, error) {
-	fnID, err := uuid.Parse(req.GetFunctionId())
+	scope, err := debugScope(req.GetFunctionId(), req.GetAccountId(), req.GetEnvId())
 	if err != nil {
-		return nil, fmt.Errorf("invalid function_id: %w", err)
+		return nil, err
 	}
 
 	// Build singleton key: function_id or function_id-suffix
-	singletonKey := fnID.String()
+	singletonKey := scope.FunctionID.String()
 	if req.GetSingletonKey() != "" {
-		singletonKey = fnID.String() + "-" + req.GetSingletonKey()
+		singletonKey = scope.FunctionID.String() + "-" + req.GetSingletonKey()
 	}
 
-	shard, err := d.shards.Resolve(ctx, consts.DevServerAccountID, nil)
+	shard, err := d.shards.Resolve(ctx, scope.AccountID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve shard: %w", err)
 	}
 
-	runID, err := shard.SingletonGetRunID(ctx, queue.Scope{
-		AccountID:  consts.DevServerAccountID,
-		EnvID:      consts.DevServerEnvID,
-		FunctionID: fnID,
-	}, singletonKey)
+	runID, err := shard.SingletonGetRunID(ctx, scope, singletonKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get singleton info: %w", err)
 	}
@@ -52,27 +45,23 @@ func (d *debugAPI) GetSingletonInfo(ctx context.Context, req *pb.SingletonInfoRe
 
 // DeleteSingletonLock removes an existing singleton lock.
 func (d *debugAPI) DeleteSingletonLock(ctx context.Context, req *pb.DeleteSingletonLockRequest) (*pb.DeleteSingletonLockResponse, error) {
-	fnID, err := uuid.Parse(req.GetFunctionId())
+	scope, err := debugScope(req.GetFunctionId(), req.GetAccountId(), req.GetEnvId())
 	if err != nil {
-		return nil, fmt.Errorf("invalid function_id: %w", err)
+		return nil, err
 	}
 
 	// Build singleton key: function_id or function_id-suffix
-	singletonKey := fnID.String()
+	singletonKey := scope.FunctionID.String()
 	if req.GetSingletonKey() != "" {
-		singletonKey = fnID.String() + "-" + req.GetSingletonKey()
+		singletonKey = scope.FunctionID.String() + "-" + req.GetSingletonKey()
 	}
 
-	shard, err := d.shards.Resolve(ctx, consts.DevServerAccountID, nil)
+	shard, err := d.shards.Resolve(ctx, scope.AccountID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve shard: %w", err)
 	}
 
-	runID, err := shard.SingletonReleaseRunID(ctx, queue.Scope{
-		AccountID:  consts.DevServerAccountID,
-		EnvID:      consts.DevServerEnvID,
-		FunctionID: fnID,
-	}, singletonKey)
+	runID, err := shard.SingletonReleaseRunID(ctx, scope, singletonKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to delete singleton lock: %w", err)
 	}

--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -323,6 +323,10 @@ func scopeForDebounceItem(di DebounceItem) queue.Scope {
 
 // DeleteDebounceItem removes a debounce from the map.
 func (d debouncer) DeleteDebounceItem(ctx context.Context, scope queue.Scope, debounceID ulid.ULID, di DebounceItem) error {
+	if err := scope.Validate(); err != nil {
+		return err
+	}
+
 	// Determine the flag value once and pass down to prevent inconsistent values mid-deletion
 	shouldMigrate := d.shouldMigrate(ctx, scope.AccountID)
 
@@ -357,6 +361,10 @@ func (d debouncer) DeleteDebounceItem(ctx context.Context, scope queue.Scope, de
 
 // GetDebounceItem returns a DebounceItem given a debounce ID.
 func (d debouncer) GetDebounceItem(ctx context.Context, scope queue.Scope, debounceID ulid.ULID) (*DebounceItem, error) {
+	if err := scope.Validate(); err != nil {
+		return nil, err
+	}
+
 	shouldMigrate := d.shouldMigrate(ctx, scope.AccountID)
 
 	// Determine the flag value once and pass down to prevent inconsistent values mid-retrieval
@@ -416,6 +424,10 @@ func getDebounceItem(ctx context.Context, shard queue.QueueShard, scope queue.Sc
 
 // StartExecution swaps out the underlying pointer of the debounce
 func (d debouncer) StartExecution(ctx context.Context, di DebounceItem, fn inngest.Function, debounceID ulid.ULID) error {
+	if err := scopeForDebounceItem(di).Validate(); err != nil {
+		return err
+	}
+
 	dkey, err := d.debounceKey(ctx, di, fn)
 	if err != nil {
 		return err
@@ -483,6 +495,9 @@ func (d debouncer) Migrate(ctx context.Context, debounceId ulid.ULID, di Debounc
 func (d debouncer) Debounce(ctx context.Context, di DebounceItem, fn inngest.Function) error {
 	if fn.Debounce == nil {
 		return fmt.Errorf("fn has no debounce config")
+	}
+	if err := scopeForDebounceItem(di).Validate(); err != nil {
+		return err
 	}
 	ttl, err := str2duration.ParseDuration(fn.Debounce.Period)
 	if err != nil {
@@ -839,6 +854,10 @@ func (d debouncer) debounceKey(ctx context.Context, evt event.TrackedEvent, fn i
 
 // GetDebounceInfo retrieves information about the current debounce for a function and debounce key.
 func (d debouncer) GetDebounceInfo(ctx context.Context, scope queue.Scope, debounceKey string) (*DebounceInfo, error) {
+	if err := scope.Validate(); err != nil {
+		return nil, err
+	}
+
 	// Use function ID as debounce key if not specified
 	if debounceKey == "" {
 		debounceKey = scope.FunctionID.String()
@@ -887,6 +906,10 @@ func (d debouncer) GetDebounceInfo(ctx context.Context, scope queue.Scope, debou
 
 // DeleteDebounce deletes the current debounce for a function and debounce key.
 func (d debouncer) DeleteDebounce(ctx context.Context, scope queue.Scope, debounceKey string) (*DeleteDebounceResult, error) {
+	if err := scope.Validate(); err != nil {
+		return nil, err
+	}
+
 	// Get the debounce info first
 	info, err := d.GetDebounceInfo(ctx, scope, debounceKey)
 	if err != nil {
@@ -933,6 +956,10 @@ func (d debouncer) DeleteDebounce(ctx context.Context, scope queue.Scope, deboun
 
 // DeleteDebounceByID deletes debounces directly by their IDs.
 func (d debouncer) DeleteDebounceByID(ctx context.Context, scope queue.Scope, debounceIDs ...ulid.ULID) error {
+	if err := scope.Validate(); err != nil {
+		return err
+	}
+
 	if len(debounceIDs) == 0 {
 		return nil
 	}
@@ -963,6 +990,10 @@ func (d debouncer) RunDebounce(ctx context.Context, opts RunDebounceOpts) (*RunD
 		EnvID:      opts.EnvID,
 		FunctionID: opts.FunctionID,
 	}
+	if err := scope.Validate(); err != nil {
+		return nil, err
+	}
+
 	info, err := d.GetDebounceInfo(ctx, scope, opts.DebounceKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get debounce info: %w", err)

--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -129,19 +129,19 @@ type DebounceMigrator interface {
 // until a specific time period passes when no more events matching a key are received.
 type Debouncer interface {
 	Debounce(ctx context.Context, d DebounceItem, fn inngest.Function) error
-	GetDebounceItem(ctx context.Context, debounceID ulid.ULID, accountID uuid.UUID) (*DebounceItem, error)
-	DeleteDebounceItem(ctx context.Context, debounceID ulid.ULID, d DebounceItem, accountID uuid.UUID) error
+	GetDebounceItem(ctx context.Context, scope queue.Scope, debounceID ulid.ULID) (*DebounceItem, error)
+	DeleteDebounceItem(ctx context.Context, scope queue.Scope, debounceID ulid.ULID, d DebounceItem) error
 	StartExecution(ctx context.Context, d DebounceItem, fn inngest.Function, debounceID ulid.ULID) error
 	// GetDebounceInfo retrieves information about the current debounce for a function and debounce key.
 	// This is used for debugging and introspection.
-	GetDebounceInfo(ctx context.Context, functionID uuid.UUID, debounceKey string) (*DebounceInfo, error)
+	GetDebounceInfo(ctx context.Context, scope queue.Scope, debounceKey string) (*DebounceInfo, error)
 	// DeleteDebounce deletes the current debounce for a function and debounce key.
 	// Returns information about the deleted debounce.
-	DeleteDebounce(ctx context.Context, functionID uuid.UUID, debounceKey string) (*DeleteDebounceResult, error)
+	DeleteDebounce(ctx context.Context, scope queue.Scope, debounceKey string) (*DeleteDebounceResult, error)
 	// DeleteDebounceByID deletes debounces directly by their IDs.
 	// Unlike DeleteDebounce, this does not require function_id or debounce_key.
 	// It removes the debounce items from the hash and (best effort) removes the timeout queue items.
-	DeleteDebounceByID(ctx context.Context, debounceIDs ...ulid.ULID) error
+	DeleteDebounceByID(ctx context.Context, scope queue.Scope, debounceIDs ...ulid.ULID) error
 	// RunDebounce schedules immediate execution of a debounce by creating a timeout job that runs in one second.
 	RunDebounce(ctx context.Context, opts RunDebounceOpts) (*RunDebounceResult, error)
 }
@@ -169,6 +169,7 @@ type RunDebounceOpts struct {
 	FunctionID  uuid.UUID
 	DebounceKey string
 	AccountID   uuid.UUID
+	EnvID       uuid.UUID
 }
 
 // RunDebounceResult contains information about a scheduled debounce execution.
@@ -312,10 +313,18 @@ func (d debouncer) secondaryShard() (queue.QueueShard, error) {
 	return d.shards.ByName(d.secondaryShardName)
 }
 
+func scopeForDebounceItem(di DebounceItem) queue.Scope {
+	return queue.Scope{
+		AccountID:  di.AccountID,
+		EnvID:      di.WorkspaceID,
+		FunctionID: di.FunctionID,
+	}
+}
+
 // DeleteDebounceItem removes a debounce from the map.
-func (d debouncer) DeleteDebounceItem(ctx context.Context, debounceID ulid.ULID, di DebounceItem, accountID uuid.UUID) error {
+func (d debouncer) DeleteDebounceItem(ctx context.Context, scope queue.Scope, debounceID ulid.ULID, di DebounceItem) error {
 	// Determine the flag value once and pass down to prevent inconsistent values mid-deletion
-	shouldMigrate := d.shouldMigrate(ctx, accountID)
+	shouldMigrate := d.shouldMigrate(ctx, scope.AccountID)
 
 	// If the new primary is set up and the secondary is draining, for some time old debounces
 	// will still exist on the secondary. If a debounce item times out before being migrated,
@@ -338,7 +347,7 @@ func (d debouncer) DeleteDebounceItem(ctx context.Context, debounceID ulid.ULID,
 		})
 	}()
 
-	if err := queueShard.DebounceDeleteItems(ctx, debounceID); err != nil {
+	if err := queueShard.DebounceDeleteItems(ctx, scope, debounceID); err != nil {
 		return fmt.Errorf("could not delete debounce item: %w", err)
 	}
 
@@ -347,8 +356,8 @@ func (d debouncer) DeleteDebounceItem(ctx context.Context, debounceID ulid.ULID,
 }
 
 // GetDebounceItem returns a DebounceItem given a debounce ID.
-func (d debouncer) GetDebounceItem(ctx context.Context, debounceID ulid.ULID, accountID uuid.UUID) (*DebounceItem, error) {
-	shouldMigrate := d.shouldMigrate(ctx, accountID)
+func (d debouncer) GetDebounceItem(ctx context.Context, scope queue.Scope, debounceID ulid.ULID) (*DebounceItem, error) {
+	shouldMigrate := d.shouldMigrate(ctx, scope.AccountID)
 
 	// Determine the flag value once and pass down to prevent inconsistent values mid-retrieval
 	queueShard, err := d.shard(shouldMigrate)
@@ -356,7 +365,7 @@ func (d debouncer) GetDebounceItem(ctx context.Context, debounceID ulid.ULID, ac
 		return nil, fmt.Errorf("could not resolve shard: %w", err)
 	}
 
-	di, err := getDebounceItem(ctx, queueShard, debounceID)
+	di, err := getDebounceItem(ctx, queueShard, scope, debounceID)
 	if err != nil && !errors.Is(err, ErrDebounceNotFound) {
 		return nil, err
 	}
@@ -380,7 +389,7 @@ func (d debouncer) GetDebounceItem(ctx context.Context, debounceID ulid.ULID, ac
 		if err != nil {
 			return nil, fmt.Errorf("could not resolve secondary shard: %w", err)
 		}
-		di, err := getDebounceItem(ctx, secondary, debounceID)
+		di, err := getDebounceItem(ctx, secondary, scope, debounceID)
 
 		// Mark DebounceItem as being retrieved from the secondary cluster. This is important
 		// for StartExecution() and DeleteDebounceItem() to use the correct cluster.
@@ -393,8 +402,8 @@ func (d debouncer) GetDebounceItem(ctx context.Context, debounceID ulid.ULID, ac
 	return di, nil
 }
 
-func getDebounceItem(ctx context.Context, shard queue.QueueShard, debounceID ulid.ULID) (*DebounceItem, error) {
-	byt, err := shard.DebounceGetItem(ctx, debounceID)
+func getDebounceItem(ctx context.Context, shard queue.QueueShard, scope queue.Scope, debounceID ulid.ULID) (*DebounceItem, error) {
+	byt, err := shard.DebounceGetItem(ctx, scope, debounceID)
 	if err != nil {
 		return nil, err
 	}
@@ -434,7 +443,7 @@ func (d debouncer) StartExecution(ctx context.Context, di DebounceItem, fn innge
 		})
 	}()
 
-	res, err := queueShard.DebounceStartExecution(ctx, fn.ID, dkey, newDebounceID, debounceID)
+	res, err := queueShard.DebounceStartExecution(ctx, scopeForDebounceItem(di), dkey, newDebounceID, debounceID)
 	if err != nil {
 		status = "error"
 		return err
@@ -538,7 +547,7 @@ func (d debouncer) debounce(ctx context.Context, di DebounceItem, fn inngest.Fun
 			di.Timeout = debounceTimeout
 
 			// Delete debounce state from old cluster
-			if err := secondary.DebounceDeleteItems(ctx, newDebounceID); err != nil {
+			if err := secondary.DebounceDeleteItems(ctx, scopeForDebounceItem(di), newDebounceID); err != nil {
 				l.Error("unable to delete old debounce after migration", "err", err)
 				return nil
 			}
@@ -551,7 +560,7 @@ func (d debouncer) debounce(ctx context.Context, di DebounceItem, fn inngest.Fun
 				l.Debug("deleted migrated debounce")
 			}
 
-			if err := secondary.DebounceDeleteMigratingFlag(ctx, newDebounceID); err != nil {
+			if err := secondary.DebounceDeleteMigratingFlag(ctx, scopeForDebounceItem(di), newDebounceID); err != nil {
 				l.Error("unable to delete debounce migrating flag", "err", err)
 			}
 
@@ -670,7 +679,7 @@ func (d debouncer) newDebounce(ctx context.Context, di DebounceItem, fn inngest.
 		return nil, fmt.Errorf("error marshalling debounce: %w", err)
 	}
 
-	existingID, err := queueShard.DebounceCreate(ctx, fn.ID, key, newDebounceID, byt, ttl)
+	existingID, err := queueShard.DebounceCreate(ctx, scopeForDebounceItem(di), key, newDebounceID, byt, ttl)
 	if err != nil {
 		return nil, fmt.Errorf("error creating debounce: %w", err)
 	}
@@ -714,7 +723,7 @@ func (d debouncer) prepareMigration(ctx context.Context, di DebounceItem, fn inn
 		return nil, 0, err
 	}
 
-	return secondary.DebouncePrepareMigration(ctx, fn.ID, key, fakeDebounceID)
+	return secondary.DebouncePrepareMigration(ctx, scopeForDebounceItem(di), key, fakeDebounceID)
 }
 
 // updateDebounce updates the currently pending debounce to point to the new event ID.  It pushes
@@ -745,7 +754,7 @@ func (d debouncer) updateDebounce(ctx context.Context, di DebounceItem, fn innge
 
 	newTTL, status, err := queueShard.DebounceUpdate(
 		ctx,
-		fn.ID,
+		scopeForDebounceItem(di),
 		key,
 		debounceID,
 		byt,
@@ -829,10 +838,10 @@ func (d debouncer) debounceKey(ctx context.Context, evt event.TrackedEvent, fn i
 }
 
 // GetDebounceInfo retrieves information about the current debounce for a function and debounce key.
-func (d debouncer) GetDebounceInfo(ctx context.Context, functionID uuid.UUID, debounceKey string) (*DebounceInfo, error) {
+func (d debouncer) GetDebounceInfo(ctx context.Context, scope queue.Scope, debounceKey string) (*DebounceInfo, error) {
 	// Use function ID as debounce key if not specified
 	if debounceKey == "" {
-		debounceKey = functionID.String()
+		debounceKey = scope.FunctionID.String()
 	}
 
 	// Always use the primary shard for debugging - this is read-only
@@ -842,7 +851,7 @@ func (d debouncer) GetDebounceInfo(ctx context.Context, functionID uuid.UUID, de
 	}
 
 	// Read the debounce ID from the pointer
-	debounceIDStr, err := queueShard.DebounceGetPointer(ctx, functionID, debounceKey)
+	debounceIDStr, err := queueShard.DebounceGetPointer(ctx, scope, debounceKey)
 	if errors.Is(err, ErrDebounceNotFound) {
 		// No active debounce
 		return &DebounceInfo{}, nil
@@ -856,7 +865,7 @@ func (d debouncer) GetDebounceInfo(ctx context.Context, functionID uuid.UUID, de
 		return nil, fmt.Errorf("invalid debounce id %q in pointer: %w", debounceIDStr, err)
 	}
 
-	itemBytes, err := queueShard.DebounceGetItem(ctx, debounceID)
+	itemBytes, err := queueShard.DebounceGetItem(ctx, scope, debounceID)
 	if errors.Is(err, ErrDebounceNotFound) {
 		// Debounce ID exists in pointer but item not found in hash
 		return &DebounceInfo{DebounceID: debounceIDStr}, nil
@@ -877,9 +886,9 @@ func (d debouncer) GetDebounceInfo(ctx context.Context, functionID uuid.UUID, de
 }
 
 // DeleteDebounce deletes the current debounce for a function and debounce key.
-func (d debouncer) DeleteDebounce(ctx context.Context, functionID uuid.UUID, debounceKey string) (*DeleteDebounceResult, error) {
+func (d debouncer) DeleteDebounce(ctx context.Context, scope queue.Scope, debounceKey string) (*DeleteDebounceResult, error) {
 	// Get the debounce info first
-	info, err := d.GetDebounceInfo(ctx, functionID, debounceKey)
+	info, err := d.GetDebounceInfo(ctx, scope, debounceKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get debounce info: %w", err)
 	}
@@ -896,7 +905,7 @@ func (d debouncer) DeleteDebounce(ctx context.Context, functionID uuid.UUID, deb
 
 	// Use function ID as debounce key if not specified (same as GetDebounceInfo)
 	if debounceKey == "" {
-		debounceKey = functionID.String()
+		debounceKey = scope.FunctionID.String()
 	}
 
 	queueShard, err := d.primaryShard()
@@ -904,10 +913,10 @@ func (d debouncer) DeleteDebounce(ctx context.Context, functionID uuid.UUID, deb
 		return nil, fmt.Errorf("could not resolve primary shard: %w", err)
 	}
 
-	if err := queueShard.DebounceDeleteItems(ctx, debounceID); err != nil {
+	if err := queueShard.DebounceDeleteItems(ctx, scope, debounceID); err != nil {
 		return nil, fmt.Errorf("failed to delete debounce item: %w", err)
 	}
-	if err := queueShard.DebounceDeletePointer(ctx, functionID, debounceKey); err != nil {
+	if err := queueShard.DebounceDeletePointer(ctx, scope, debounceKey); err != nil {
 		return nil, fmt.Errorf("failed to delete debounce pointer: %w", err)
 	}
 
@@ -923,7 +932,7 @@ func (d debouncer) DeleteDebounce(ctx context.Context, functionID uuid.UUID, deb
 }
 
 // DeleteDebounceByID deletes debounces directly by their IDs.
-func (d debouncer) DeleteDebounceByID(ctx context.Context, debounceIDs ...ulid.ULID) error {
+func (d debouncer) DeleteDebounceByID(ctx context.Context, scope queue.Scope, debounceIDs ...ulid.ULID) error {
 	if len(debounceIDs) == 0 {
 		return nil
 	}
@@ -933,7 +942,7 @@ func (d debouncer) DeleteDebounceByID(ctx context.Context, debounceIDs ...ulid.U
 		return fmt.Errorf("could not resolve primary shard: %w", err)
 	}
 
-	if err := queueShard.DebounceDeleteItems(ctx, debounceIDs...); err != nil {
+	if err := queueShard.DebounceDeleteItems(ctx, scope, debounceIDs...); err != nil {
 		return fmt.Errorf("failed to delete debounce items: %w", err)
 	}
 
@@ -949,7 +958,12 @@ func (d debouncer) DeleteDebounceByID(ctx context.Context, debounceIDs ...ulid.U
 // RunDebounce schedules immediate execution of a debounce by creating a timeout job that runs in one second.
 func (d debouncer) RunDebounce(ctx context.Context, opts RunDebounceOpts) (*RunDebounceResult, error) {
 	// Get the debounce info first
-	info, err := d.GetDebounceInfo(ctx, opts.FunctionID, opts.DebounceKey)
+	scope := queue.Scope{
+		AccountID:  opts.AccountID,
+		EnvID:      opts.EnvID,
+		FunctionID: opts.FunctionID,
+	}
+	info, err := d.GetDebounceInfo(ctx, scope, opts.DebounceKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get debounce info: %w", err)
 	}

--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -29,6 +29,14 @@ func migrationShardMap(defaultShard, newSystemShard queue.QueueShard) map[string
 	}
 }
 
+func testScope(accountID, workspaceID, functionID uuid.UUID) queue.Scope {
+	return queue.Scope{
+		AccountID:  accountID,
+		EnvID:      workspaceID,
+		FunctionID: functionID,
+	}
+}
+
 // migrationShardSelector routes system queue items (queueName != nil) to the
 // new system shard and everything else to the default shard.
 func migrationShardSelector(defaultShard, newSystemShard queue.QueueShard) func(ctx context.Context, accountID uuid.UUID, queueName *string) (queue.QueueShard, error) {
@@ -265,7 +273,7 @@ func TestDebounce(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, debounceId.String(), val)
 
-		di, err := redisDebouncer.GetDebounceItem(ctx, debounceId, accountId)
+		di, err := redisDebouncer.GetDebounceItem(ctx, testScope(accountId, workspaceId, functionId), debounceId)
 		require.NoError(t, err)
 
 		err = redisDebouncer.StartExecution(ctx, *di, fn, debounceId)
@@ -287,7 +295,7 @@ func TestDebounce(t *testing.T) {
 		err = json.Unmarshal([]byte(unshardedCluster.HGet(debounceClient.KeyGenerator().Debounce(ctx), debounceIds[0])), &di)
 		require.NoError(t, err)
 
-		err = redisDebouncer.DeleteDebounceItem(ctx, debounceId, di, accountId)
+		err = redisDebouncer.DeleteDebounceItem(ctx, testScope(accountId, workspaceId, functionId), debounceId, di)
 		require.NoError(t, err)
 
 		_, err = unshardedCluster.HKeys(debounceClient.KeyGenerator().Debounce(ctx))
@@ -1526,7 +1534,7 @@ func TestDebounceExecutionDuringMigrationWorks(t *testing.T) {
 
 		debounceId := ulid.MustParse(debounceIds[0])
 
-		di, err := newRedisDebouncer.GetDebounceItem(ctx, debounceId, accountId)
+		di, err := newRedisDebouncer.GetDebounceItem(ctx, testScope(accountId, workspaceId, functionId), debounceId)
 		require.NoError(t, err)
 
 		// Must retrieve from secondary cluster
@@ -1549,11 +1557,11 @@ func TestDebounceExecutionDuringMigrationWorks(t *testing.T) {
 
 		// A racing prepareMigration call must not be able to find the debounce
 		fakeID := ulid.MustNew(ulid.Now(), rand.Reader)
-		existingID, _, err := defaultQueueShard.DebouncePrepareMigration(ctx, fn.ID, fn.ID.String(), fakeID)
+		existingID, _, err := defaultQueueShard.DebouncePrepareMigration(ctx, testScope(accountId, workspaceId, fn.ID), fn.ID.String(), fakeID)
 		require.NoError(t, err)
 		require.Nil(t, existingID)
 
-		err = newRedisDebouncer.DeleteDebounceItem(ctx, debounceId, *di, accountId)
+		err = newRedisDebouncer.DeleteDebounceItem(ctx, testScope(accountId, workspaceId, functionId), debounceId, *di)
 		require.NoError(t, err)
 
 		// Debounce should be dropped
@@ -1732,7 +1740,7 @@ func TestDebounceExecutionShouldNotRaceMigration(t *testing.T) {
 
 		debounceId := ulid.MustParse(debounceIds[0])
 
-		di, err := newRedisDebouncer.GetDebounceItem(ctx, debounceId, accountId)
+		di, err := newRedisDebouncer.GetDebounceItem(ctx, testScope(accountId, workspaceId, functionId), debounceId)
 		require.NoError(t, err)
 
 		// Must retrieve from secondary cluster
@@ -1740,7 +1748,7 @@ func TestDebounceExecutionShouldNotRaceMigration(t *testing.T) {
 
 		// If prepareMigration is called first, it must lock the execution from running the debounce item
 		fakeID := ulid.MustNew(ulid.Now(), rand.Reader)
-		existingID, _, err := defaultQueueShard.DebouncePrepareMigration(ctx, fn.ID, fn.ID.String(), fakeID)
+		existingID, _, err := defaultQueueShard.DebouncePrepareMigration(ctx, testScope(accountId, workspaceId, fn.ID), fn.ID.String(), fakeID)
 		require.NoError(t, err)
 		require.NotNil(t, existingID)
 		require.Equal(t, debounceId, *existingID)
@@ -1768,7 +1776,7 @@ func TestDebounceExecutionShouldNotRaceMigration(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorIs(t, err, ErrDebounceMigrating)
 
-		err = defaultQueueShard.DebounceDeleteMigratingFlag(ctx, debounceId)
+		err = defaultQueueShard.DebounceDeleteMigratingFlag(ctx, testScope(accountId, workspaceId, functionId), debounceId)
 		require.NoError(t, err)
 
 		// Lock must be gone
@@ -1808,7 +1816,7 @@ func TestGetDebounceInfo(t *testing.T) {
 	accountId, workspaceId, appId, functionId := uuid.New(), uuid.New(), uuid.New(), uuid.New()
 
 	t.Run("no debounce exists returns empty info", func(t *testing.T) {
-		info, err := redisDebouncer.GetDebounceInfo(ctx, functionId, functionId.String())
+		info, err := redisDebouncer.GetDebounceInfo(ctx, testScope(accountId, workspaceId, functionId), functionId.String())
 		require.NoError(t, err)
 		require.Equal(t, "", info.DebounceID)
 		require.Nil(t, info.Item)
@@ -1844,7 +1852,7 @@ func TestGetDebounceInfo(t *testing.T) {
 		require.NoError(t, err)
 
 		// Query with function ID as debounce key (default)
-		info, err := redisDebouncer.GetDebounceInfo(ctx, functionId, functionId.String())
+		info, err := redisDebouncer.GetDebounceInfo(ctx, testScope(accountId, workspaceId, functionId), functionId.String())
 		require.NoError(t, err)
 		require.NotEmpty(t, info.DebounceID)
 		require.NotNil(t, info.Item)
@@ -1887,14 +1895,14 @@ func TestGetDebounceInfo(t *testing.T) {
 		require.NoError(t, err)
 
 		// Query with the custom key
-		info, err := redisDebouncer.GetDebounceInfo(ctx, customFnId, customKey)
+		info, err := redisDebouncer.GetDebounceInfo(ctx, testScope(accountId, workspaceId, customFnId), customKey)
 		require.NoError(t, err)
 		require.NotEmpty(t, info.DebounceID)
 		require.NotNil(t, info.Item)
 		require.Equal(t, eventId, info.Item.EventID)
 
 		// Query with wrong key should return empty
-		info2, err := redisDebouncer.GetDebounceInfo(ctx, customFnId, "wrong-key")
+		info2, err := redisDebouncer.GetDebounceInfo(ctx, testScope(accountId, workspaceId, customFnId), "wrong-key")
 		require.NoError(t, err)
 		require.Equal(t, "", info2.DebounceID)
 		require.Nil(t, info2.Item)
@@ -1951,7 +1959,7 @@ func TestGetDebounceInfo(t *testing.T) {
 		require.NoError(t, err)
 
 		// Query should return the latest event
-		info, err := redisDebouncer.GetDebounceInfo(ctx, updateFnId, updateFnId.String())
+		info, err := redisDebouncer.GetDebounceInfo(ctx, testScope(accountId, workspaceId, updateFnId), updateFnId.String())
 		require.NoError(t, err)
 		require.NotEmpty(t, info.DebounceID)
 		require.NotNil(t, info.Item)
@@ -1960,7 +1968,7 @@ func TestGetDebounceInfo(t *testing.T) {
 
 	t.Run("non-existent function returns empty", func(t *testing.T) {
 		nonExistentFnId := uuid.New()
-		info, err := redisDebouncer.GetDebounceInfo(ctx, nonExistentFnId, nonExistentFnId.String())
+		info, err := redisDebouncer.GetDebounceInfo(ctx, testScope(accountId, workspaceId, nonExistentFnId), nonExistentFnId.String())
 		require.NoError(t, err)
 		require.Equal(t, "", info.DebounceID)
 		require.Nil(t, info.Item)
@@ -2000,7 +2008,7 @@ func TestDeleteDebounce(t *testing.T) {
 
 	t.Run("delete non-existent debounce returns deleted=false", func(t *testing.T) {
 		nonExistentFnId := uuid.New()
-		result, err := redisDebouncer.DeleteDebounce(ctx, nonExistentFnId, nonExistentFnId.String())
+		result, err := redisDebouncer.DeleteDebounce(ctx, testScope(accountId, workspaceId, nonExistentFnId), nonExistentFnId.String())
 		require.NoError(t, err)
 		require.False(t, result.Deleted)
 		require.Equal(t, "", result.DebounceID)
@@ -2038,21 +2046,21 @@ func TestDeleteDebounce(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify debounce exists
-		info, err := redisDebouncer.GetDebounceInfo(ctx, functionId, functionId.String())
+		info, err := redisDebouncer.GetDebounceInfo(ctx, testScope(accountId, workspaceId, functionId), functionId.String())
 		require.NoError(t, err)
 		require.NotEmpty(t, info.DebounceID)
 		require.NotNil(t, info.Item)
 		debounceID := info.DebounceID
 
 		// Delete the debounce
-		result, err := redisDebouncer.DeleteDebounce(ctx, functionId, functionId.String())
+		result, err := redisDebouncer.DeleteDebounce(ctx, testScope(accountId, workspaceId, functionId), functionId.String())
 		require.NoError(t, err)
 		require.True(t, result.Deleted)
 		require.Equal(t, debounceID, result.DebounceID)
 		require.Equal(t, eventId.String(), result.EventID)
 
 		// Verify debounce no longer exists
-		infoAfter, err := redisDebouncer.GetDebounceInfo(ctx, functionId, functionId.String())
+		infoAfter, err := redisDebouncer.GetDebounceInfo(ctx, testScope(accountId, workspaceId, functionId), functionId.String())
 		require.NoError(t, err)
 		require.Equal(t, "", infoAfter.DebounceID)
 		require.Nil(t, infoAfter.Item)
@@ -2096,6 +2104,7 @@ func TestRunDebounce(t *testing.T) {
 			FunctionID:  nonExistentFnId,
 			DebounceKey: nonExistentFnId.String(),
 			AccountID:   accountId,
+			EnvID:       workspaceId,
 		})
 		require.NoError(t, err)
 		require.False(t, result.Scheduled)
@@ -2134,7 +2143,7 @@ func TestRunDebounce(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify debounce exists
-		info, err := redisDebouncer.GetDebounceInfo(ctx, functionId, functionId.String())
+		info, err := redisDebouncer.GetDebounceInfo(ctx, testScope(accountId, workspaceId, functionId), functionId.String())
 		require.NoError(t, err)
 		require.NotEmpty(t, info.DebounceID)
 		debounceID := info.DebounceID
@@ -2144,6 +2153,7 @@ func TestRunDebounce(t *testing.T) {
 			FunctionID:  functionId,
 			DebounceKey: functionId.String(),
 			AccountID:   accountId,
+			EnvID:       workspaceId,
 		})
 		require.NoError(t, err)
 		require.True(t, result.Scheduled)
@@ -2184,10 +2194,9 @@ func TestDeleteDebounceByID(t *testing.T) {
 	ctx := context.Background()
 	accountId, workspaceId, appId := uuid.New(), uuid.New(), uuid.New()
 
-	// helper to create a debounce and return its ULID
-	createDebounce := func(t *testing.T) (uuid.UUID, ulid.ULID) {
+	// helper to create a debounce and return its scope and ULID
+	createDebounce := func(t *testing.T, functionId uuid.UUID) (queue.Scope, ulid.ULID) {
 		t.Helper()
-		functionId := uuid.New()
 		fn := inngest.Function{
 			ID: functionId,
 			Debounce: &inngest.Debounce{
@@ -2216,12 +2225,13 @@ func TestDeleteDebounceByID(t *testing.T) {
 		err := redisDebouncer.Debounce(ctx, di, fn)
 		require.NoError(t, err)
 
-		info, err := redisDebouncer.GetDebounceInfo(ctx, functionId, functionId.String())
+		scope := testScope(accountId, workspaceId, functionId)
+		info, err := redisDebouncer.GetDebounceInfo(ctx, scope, functionId.String())
 		require.NoError(t, err)
 		require.NotEmpty(t, info.DebounceID)
 
 		debounceID := ulid.MustParse(info.DebounceID)
-		return functionId, debounceID
+		return scope, debounceID
 	}
 
 	// hashFieldExists checks if a field exists in a Redis hash using miniredis.
@@ -2232,12 +2242,13 @@ func TestDeleteDebounceByID(t *testing.T) {
 
 	t.Run("no debounce exists should succeed", func(t *testing.T) {
 		fakeID := ulid.MustNew(ulid.Now(), rand.Reader)
-		err := redisDebouncer.DeleteDebounceByID(ctx, fakeID)
+		err := redisDebouncer.DeleteDebounceByID(ctx, testScope(accountId, workspaceId, uuid.New()), fakeID)
 		require.NoError(t, err)
 	})
 
 	t.Run("delete current debounce by ID", func(t *testing.T) {
-		functionId, debounceID := createDebounce(t)
+		functionId := uuid.New()
+		scope, debounceID := createDebounce(t, functionId)
 
 		// Verify the debounce item exists in the hash
 		debounceKey := debounceClient.KeyGenerator().Debounce(ctx)
@@ -2249,7 +2260,7 @@ func TestDeleteDebounceByID(t *testing.T) {
 		require.NoError(t, err, "timeout queue item should exist")
 
 		// Delete by ID
-		err = redisDebouncer.DeleteDebounceByID(ctx, debounceID)
+		err = redisDebouncer.DeleteDebounceByID(ctx, scope, debounceID)
 		require.NoError(t, err)
 
 		// Verify the debounce item is gone from the hash
@@ -2261,13 +2272,13 @@ func TestDeleteDebounceByID(t *testing.T) {
 
 		// The pointer key may still exist (DeleteDebounceByID does not clean it up),
 		// but GetDebounceInfo should handle this gracefully.
-		info, err := redisDebouncer.GetDebounceInfo(ctx, functionId, functionId.String())
+		info, err := redisDebouncer.GetDebounceInfo(ctx, scope, functionId.String())
 		require.NoError(t, err)
 		require.Nil(t, info.Item, "debounce item should not be found via pointer")
 	})
 
 	t.Run("delete debounce after pointer is dropped", func(t *testing.T) {
-		_, debounceID := createDebounce(t)
+		scope, debounceID := createDebounce(t, uuid.New())
 
 		debounceKey := debounceClient.KeyGenerator().Debounce(ctx)
 		require.True(t, hashFieldExists(debounceKey, debounceID.String()), "debounce item should exist in hash before deletion")
@@ -2278,7 +2289,7 @@ func TestDeleteDebounceByID(t *testing.T) {
 		require.NoError(t, err, "timeout queue item should exist")
 
 		// Delete by ID (pointer is gone, but item + timeout still exist)
-		err = redisDebouncer.DeleteDebounceByID(ctx, debounceID)
+		err = redisDebouncer.DeleteDebounceByID(ctx, scope, debounceID)
 		require.NoError(t, err)
 
 		// Verify item is gone from hash
@@ -2290,7 +2301,7 @@ func TestDeleteDebounceByID(t *testing.T) {
 	})
 
 	t.Run("delete debounce when timeout already removed", func(t *testing.T) {
-		_, debounceID := createDebounce(t)
+		scope, debounceID := createDebounce(t, uuid.New())
 
 		debounceKey := debounceClient.KeyGenerator().Debounce(ctx)
 		require.True(t, hashFieldExists(debounceKey, debounceID.String()), "debounce item should exist in hash")
@@ -2305,7 +2316,7 @@ func TestDeleteDebounceByID(t *testing.T) {
 		require.ErrorIs(t, err, queue.ErrQueueItemNotFound, "timeout should already be gone")
 
 		// Delete by ID should still succeed (timeout removal is best-effort)
-		err = redisDebouncer.DeleteDebounceByID(ctx, debounceID)
+		err = redisDebouncer.DeleteDebounceByID(ctx, scope, debounceID)
 		require.NoError(t, err)
 
 		// Verify item is gone from hash
@@ -2313,7 +2324,7 @@ func TestDeleteDebounceByID(t *testing.T) {
 	})
 
 	t.Run("missing item but existing timeout job should clean up timeout", func(t *testing.T) {
-		_, debounceID := createDebounce(t)
+		scope, debounceID := createDebounce(t, uuid.New())
 
 		debounceKey := debounceClient.KeyGenerator().Debounce(ctx)
 
@@ -2327,7 +2338,7 @@ func TestDeleteDebounceByID(t *testing.T) {
 		require.NoError(t, err, "timeout queue item should still exist")
 
 		// Delete by ID — HDEL on missing item is a no-op, but timeout should be cleaned up
-		err = redisDebouncer.DeleteDebounceByID(ctx, debounceID)
+		err = redisDebouncer.DeleteDebounceByID(ctx, scope, debounceID)
 		require.NoError(t, err)
 
 		// Verify timeout queue item is now gone
@@ -2336,8 +2347,8 @@ func TestDeleteDebounceByID(t *testing.T) {
 	})
 
 	t.Run("batch delete multiple debounce IDs", func(t *testing.T) {
-		_, debounceID1 := createDebounce(t)
-		_, debounceID2 := createDebounce(t)
+		scope, debounceID1 := createDebounce(t, uuid.New())
+		_, debounceID2 := createDebounce(t, uuid.New())
 
 		debounceKey := debounceClient.KeyGenerator().Debounce(ctx)
 
@@ -2354,7 +2365,7 @@ func TestDeleteDebounceByID(t *testing.T) {
 		require.NoError(t, err)
 
 		// Batch delete both
-		err = redisDebouncer.DeleteDebounceByID(ctx, debounceID1, debounceID2)
+		err = redisDebouncer.DeleteDebounceByID(ctx, scope, debounceID1, debounceID2)
 		require.NoError(t, err)
 
 		// Both items should be gone from hash
@@ -2369,7 +2380,7 @@ func TestDeleteDebounceByID(t *testing.T) {
 	})
 
 	t.Run("empty ID list is a no-op", func(t *testing.T) {
-		err := redisDebouncer.DeleteDebounceByID(ctx)
+		err := redisDebouncer.DeleteDebounceByID(ctx, testScope(accountId, workspaceId, uuid.New()))
 		require.NoError(t, err)
 	})
 }

--- a/pkg/execution/deletion/delete.go
+++ b/pkg/execution/deletion/delete.go
@@ -62,7 +62,12 @@ func (d *deleteManager) DeleteQueueItem(ctx context.Context, shard queue.QueueSh
 			break
 		}
 
-		di, err := d.deb.GetDebounceItem(ctx, payload.DebounceID, payload.AccountID)
+		scope := queue.Scope{
+			AccountID:  payload.AccountID,
+			EnvID:      payload.WorkspaceID,
+			FunctionID: payload.FunctionID,
+		}
+		di, err := d.deb.GetDebounceItem(ctx, scope, payload.DebounceID)
 		if err != nil {
 			return fmt.Errorf("could not get debounce item: %w", err)
 		}
@@ -71,7 +76,7 @@ func (d *deleteManager) DeleteQueueItem(ctx context.Context, shard queue.QueueSh
 			break
 		}
 
-		err = d.deb.DeleteDebounceItem(ctx, payload.DebounceID, *di, di.AccountID)
+		err = d.deb.DeleteDebounceItem(ctx, scope, payload.DebounceID, *di)
 		if err != nil {
 			return fmt.Errorf("could not delete debounce item: %w", err)
 		}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1188,7 +1188,11 @@ func (e *executor) schedule(
 			// the lock becomes available to any competing run. If a faster run acquires it before
 			// this one tries to, it will fail to acquire the lock and be skipped; Effectively
 			// behaving as if the singleton mode were set to skip.
-			singletonRunID, err := e.singletonMgr.HandleSingleton(ctx, singletonKey, *req.Function.Singleton, req.AccountID)
+			singletonRunID, err := e.singletonMgr.HandleSingleton(ctx, queue.Scope{
+				AccountID:  req.AccountID,
+				EnvID:      req.WorkspaceID,
+				FunctionID: req.Function.ID,
+			}, singletonKey, *req.Function.Singleton)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -139,7 +139,7 @@ type svc struct {
 	// queue allows us to enqueue next steps.
 	queue queue.Queue
 	// exec runs the specific actions.
-	exec          execution.Executor
+	exec      execution.Executor
 	debouncer debounce.Debouncer
 	batcher   batch.BatchManager
 	croner    cron.CronManager
@@ -445,7 +445,12 @@ func (s *svc) handleDebounce(ctx context.Context, item queue.Item) error {
 
 	for _, f := range all {
 		if f.ID == d.FunctionID {
-			di, err := s.debouncer.GetDebounceItem(ctx, d.DebounceID, d.AccountID)
+			scope := queue.Scope{
+				AccountID:  d.AccountID,
+				EnvID:      d.WorkspaceID,
+				FunctionID: d.FunctionID,
+			}
+			di, err := s.debouncer.GetDebounceItem(ctx, scope, d.DebounceID)
 			if err != nil {
 				if errors.Is(err, debounce.ErrDebounceNotFound) {
 					// This is expected after migrating items to a new primary cluster
@@ -512,7 +517,7 @@ func (s *svc) handleDebounce(ctx context.Context, item queue.Item) error {
 				if errors.Is(err, state.ErrIdentifierExists) ||
 					errors.Is(err, ErrFunctionSkipped) ||
 					errors.Is(err, ErrFunctionSkippedIdempotency) {
-					if err := s.debouncer.DeleteDebounceItem(ctx, d.DebounceID, *di, d.AccountID); err != nil {
+					if err := s.debouncer.DeleteDebounceItem(ctx, scope, d.DebounceID, *di); err != nil {
 						logger.StdlibLogger(ctx).ReportError(err, "error deleting debounce item")
 					}
 
@@ -525,7 +530,7 @@ func (s *svc) handleDebounce(ctx context.Context, item queue.Item) error {
 				span.SetAttributes(attribute.String(consts.OtelAttrSDKRunID, md.ID.RunID.String()))
 			}
 
-			if err := s.debouncer.DeleteDebounceItem(ctx, d.DebounceID, *di, d.AccountID); err != nil {
+			if err := s.debouncer.DeleteDebounceItem(ctx, scope, d.DebounceID, *di); err != nil {
 				logger.StdlibLogger(ctx).ReportError(err, "error deleting debounce item")
 			}
 		}

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -243,42 +243,14 @@ type DebounceOperations interface {
 	DebounceDeletePointer(ctx context.Context, fnID uuid.UUID, key string) error
 }
 
-type ShardOperations interface {
-	SingletonOperations
-	DebounceOperations
-
-	EnqueueItem(ctx context.Context, i QueueItem, at time.Time, opts EnqueueOpts) (QueueItem, error)
+// PeekOperations is the per-shard surface for queue peeking.
+type PeekOperations interface {
 	Peek(ctx context.Context, partition *QueuePartition, until time.Time, limit int64) ([]*QueueItem, error)
 	PeekRandom(ctx context.Context, partition *QueuePartition, until time.Time, limit int64) ([]*QueueItem, error)
-	Lease(ctx context.Context, item QueueItem, leaseDuration time.Duration, now time.Time, options ...LeaseOptionFn) (*ulid.ULID, error)
-	ExtendLease(ctx context.Context, i QueueItem, leaseID ulid.ULID, duration time.Duration, opts ...ExtendLeaseOptionFn) (*ulid.ULID, error)
-	Requeue(ctx context.Context, i QueueItem, at time.Time, opts ...RequeueOptionFn) error
-	RequeueByJobID(ctx context.Context, jobID string, at time.Time) error
-	Dequeue(ctx context.Context, i QueueItem, opts ...DequeueOptionFn) error
-
 	PartitionPeek(ctx context.Context, sequential bool, until time.Time, limit int64) ([]*QueuePartition, error)
-	PartitionLease(ctx context.Context, p *QueuePartition, duration time.Duration, opts ...PartitionLeaseOpt) (*ulid.ULID, error)
-	PartitionRequeue(ctx context.Context, p *QueuePartition, at time.Time, forceAt bool) error
-
-	Scavenge(ctx context.Context, limit int) (int, error)
-	Instrument(ctx context.Context) error
-
-	ItemsByPartition(ctx context.Context, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
-	ItemsByBacklog(ctx context.Context, backlogID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
-
-	SetFunctionMigrate(ctx context.Context, fnID uuid.UUID, migrateLockUntil *time.Time) error
-	ResetAttemptsByJobID(ctx context.Context, jobID string) error
-
 	PeekEWMA(ctx context.Context, fnID uuid.UUID) (int64, error)
 	SetPeekEWMA(ctx context.Context, fnID *uuid.UUID, val int64) error
-	PartitionSize(ctx context.Context, partitionID string, until time.Time) (int64, error)
-
-	ConfigLease(ctx context.Context, key string, duration time.Duration, existingLeaseID ...*ulid.ULID) (*ulid.ULID, error)
-	ShardLease(ctx context.Context, key string, duration time.Duration, maxLeases int, existingLeaseID ...*ulid.ULID) (*ulid.ULID, error)
-	ReleaseShardLease(ctx context.Context, key string, existingLeaseID ulid.ULID) error
-
 	AccountPeek(ctx context.Context, sequential bool, until time.Time, limit int64) ([]uuid.UUID, error)
-
 	PeekAccountPartitions(
 		ctx context.Context,
 		accountID uuid.UUID,
@@ -286,31 +258,25 @@ type ShardOperations interface {
 		peekUntil time.Time,
 		sequential bool,
 	) ([]*QueuePartition, error)
-
 	PeekGlobalPartitions(
 		ctx context.Context,
 		peekLimit int64,
 		peekUntil time.Time,
 		sequential bool,
 	) ([]*QueuePartition, error)
+}
 
-	RemoveQueueItem(ctx context.Context, partitionID string, itemID string) error
-	LoadQueueItem(ctx context.Context, itemID string) (*QueueItem, error)
-
+// ShadowProcessingOperations is the per-shard surface for shadow partition,
+// backlog, and backlog normalization processing.
+type ShadowProcessingOperations interface {
 	LeaseBacklogForNormalization(ctx context.Context, bl *QueueBacklog) error
 	ExtendBacklogNormalizationLease(ctx context.Context, now time.Time, bl *QueueBacklog) error
-	ShadowPartitionPeekNormalizeBacklogs(ctx context.Context, sp *QueueShadowPartition, limit int64) ([]*QueueBacklog, error)
-	BacklogNormalizePeek(ctx context.Context, b *QueueBacklog, limit int64) (*PeekResult[QueueItem], error)
-	PeekGlobalNormalizeAccounts(ctx context.Context, until time.Time, limit int64) ([]uuid.UUID, error)
-
-	PeekGlobalShadowPartitionAccounts(ctx context.Context, sequential bool, until time.Time, limit int64) ([]uuid.UUID, error)
 
 	ShadowPartitionRequeue(ctx context.Context, sp *QueueShadowPartition, requeueAt *time.Time) error
 	ShadowPartitionLease(ctx context.Context, sp *QueueShadowPartition, duration time.Duration) (*ulid.ULID, error)
 	ShadowPartitionExtendLease(ctx context.Context, sp *QueueShadowPartition, leaseID ulid.ULID, duration time.Duration) (*ulid.ULID, error)
-	ShadowPartitionPeek(ctx context.Context, sp *QueueShadowPartition, sequential bool, until time.Time, limit int64, opts ...PeekOpt) ([]*QueueBacklog, int, error)
+
 	BacklogPrepareNormalize(ctx context.Context, b *QueueBacklog, sp *QueueShadowPartition) error
-	BacklogPeek(ctx context.Context, b *QueueBacklog, from time.Time, until time.Time, limit int64, opts ...PeekOpt) (*BacklogPeekResult, error)
 	BacklogRefill(
 		ctx context.Context,
 		b *QueueBacklog,
@@ -324,25 +290,75 @@ type ShardOperations interface {
 	BacklogSize(ctx context.Context, backlogID string) (int64, error)
 	BacklogByID(ctx context.Context, backlogID string) (*QueueBacklog, error)
 
-	PeekShadowPartitions(ctx context.Context, accountID *uuid.UUID, sequential bool, peekLimit int64, until time.Time) ([]*QueueShadowPartition, error)
+	ItemsByBacklog(ctx context.Context, backlogID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
 
-	IsMigrationLocked(ctx context.Context, fnID uuid.UUID) (*time.Time, error)
+	ShadowPartitionPeekNormalizeBacklogs(ctx context.Context, sp *QueueShadowPartition, limit int64) ([]*QueueBacklog, error)
+	BacklogNormalizePeek(ctx context.Context, b *QueueBacklog, limit int64) (*PeekResult[QueueItem], error)
+	PeekGlobalNormalizeAccounts(ctx context.Context, until time.Time, limit int64) ([]uuid.UUID, error)
+	PeekGlobalShadowPartitionAccounts(ctx context.Context, sequential bool, until time.Time, limit int64) ([]uuid.UUID, error)
+	ShadowPartitionPeek(ctx context.Context, sp *QueueShadowPartition, sequential bool, until time.Time, limit int64, opts ...PeekOpt) ([]*QueueBacklog, int, error)
+	PeekShadowPartitions(ctx context.Context, accountID *uuid.UUID, sequential bool, peekLimit int64, until time.Time) ([]*QueueShadowPartition, error)
+	BacklogPeek(ctx context.Context, b *QueueBacklog, from time.Time, until time.Time, limit int64, opts ...PeekOpt) (*BacklogPeekResult, error)
+}
+
+// InsightsOperations is the per-shard surface for queue inspection and metrics.
+type InsightsOperations interface {
+	Instrument(ctx context.Context) error
+	ItemsByPartition(ctx context.Context, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
 
 	// Total queue depth of all partitions including backlog and ready state items
 	TotalSystemQueueDepth(ctx context.Context) (int64, error)
 
+	PartitionBacklogSize(ctx context.Context, partitionID string) (int64, error)
+	OutstandingJobCount(ctx context.Context, workspaceID, workflowID uuid.UUID, runID ulid.ULID) (int, error)
+	RunningCount(ctx context.Context, functionID uuid.UUID) (int64, error)
+	StatusCount(ctx context.Context, workflowID uuid.UUID, status string) (int64, error)
+}
+
+type ShardOperations interface {
+	SingletonOperations
+	DebounceOperations
+	PeekOperations
+	ShadowProcessingOperations
+	InsightsOperations
+
+	EnqueueItem(ctx context.Context, i QueueItem, at time.Time, opts EnqueueOpts) (QueueItem, error)
+
+	Lease(ctx context.Context, item QueueItem, leaseDuration time.Duration, now time.Time, options ...LeaseOptionFn) (*ulid.ULID, error)
+	ExtendLease(ctx context.Context, i QueueItem, leaseID ulid.ULID, duration time.Duration, opts ...ExtendLeaseOptionFn) (*ulid.ULID, error)
+
+	Requeue(ctx context.Context, i QueueItem, at time.Time, opts ...RequeueOptionFn) error
+	RequeueByJobID(ctx context.Context, jobID string, at time.Time) error
+
+	Dequeue(ctx context.Context, i QueueItem, opts ...DequeueOptionFn) error
 	DequeueByJobID(ctx context.Context, jobID string) error
+
+	PartitionLease(ctx context.Context, p *QueuePartition, duration time.Duration, opts ...PartitionLeaseOpt) (*ulid.ULID, error)
+	PartitionRequeue(ctx context.Context, p *QueuePartition, at time.Time, forceAt bool) error
+
+	Scavenge(ctx context.Context, limit int) (int, error)
+
+	RemoveQueueItem(ctx context.Context, partitionID string, itemID string) error
+
+	SetFunctionMigrate(ctx context.Context, fnID uuid.UUID, migrateLockUntil *time.Time) error
+	ResetAttemptsByJobID(ctx context.Context, jobID string) error
+
+	PartitionSize(ctx context.Context, partitionID string, until time.Time) (int64, error)
+
+	ConfigLease(ctx context.Context, key string, duration time.Duration, existingLeaseID ...*ulid.ULID) (*ulid.ULID, error)
+	ShardLease(ctx context.Context, key string, duration time.Duration, maxLeases int, existingLeaseID ...*ulid.ULID) (*ulid.ULID, error)
+	ReleaseShardLease(ctx context.Context, key string, existingLeaseID ulid.ULID) error
+
+	LoadQueueItem(ctx context.Context, itemID string) (*QueueItem, error)
+
+	IsMigrationLocked(ctx context.Context, fnID uuid.UUID) (*time.Time, error)
 
 	ItemExists(ctx context.Context, jobID string) (bool, error)
 	ItemsByRunID(ctx context.Context, runID ulid.ULID) ([]*QueueItem, error)
-	PartitionBacklogSize(ctx context.Context, partitionID string) (int64, error)
 	PartitionByID(ctx context.Context, partitionID string) (*PartitionInspectionResult, error)
 
 	UnpauseFunction(ctx context.Context, acctID, envID, fnID uuid.UUID) error
 
-	OutstandingJobCount(ctx context.Context, workspaceID, workflowID uuid.UUID, runID ulid.ULID) (int, error)
-	RunningCount(ctx context.Context, functionID uuid.UUID) (int64, error)
-	StatusCount(ctx context.Context, workflowID uuid.UUID, status string) (int64, error)
 	RunJobs(ctx context.Context, workspaceID, workflowID uuid.UUID, runID ulid.ULID, limit, offset int64) ([]JobResponse, error)
 }
 

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -157,15 +157,23 @@ type QueueProcessor interface {
 	) (ItemLeaseConstraintCheckResult, error)
 }
 
+// Scope identifies the tenant/function namespace for queue-owned state.
+type Scope struct {
+	IsSystem   bool
+	AccountID  uuid.UUID
+	EnvID      uuid.UUID
+	FunctionID uuid.UUID
+}
+
 // SingletonOperations is the per-shard surface for singleton lock state.
 // Construct singleton clients against a shard resolved through ShardRegistry.
 type SingletonOperations interface {
 	// SingletonGetRunID returns the run ID currently holding the singleton
 	// lock for key, or nil if no lock is held.
-	SingletonGetRunID(ctx context.Context, key string) (*ulid.ULID, error)
+	SingletonGetRunID(ctx context.Context, scope Scope, key string) (*ulid.ULID, error)
 	// SingletonReleaseRunID atomically gets and deletes the singleton lock
 	// for key, returning the released run ID or nil if no lock was held.
-	SingletonReleaseRunID(ctx context.Context, key string) (*ulid.ULID, error)
+	SingletonReleaseRunID(ctx context.Context, scope Scope, key string) (*ulid.ULID, error)
 }
 
 // DebounceUpdateStatus describes the outcome of DebounceUpdate.
@@ -201,46 +209,46 @@ const (
 // debounce lives on a single shard alongside its timeout queue item; route
 // to the right shard via ShardRegistry before invoking these.
 type DebounceOperations interface {
-	// DebounceCreate atomically creates a new debounce for fnID/key. If a
+	// DebounceCreate atomically creates a new debounce for scope/key. If a
 	// debounce already exists, it returns the existing debounce ID and
 	// no error.
-	DebounceCreate(ctx context.Context, fnID uuid.UUID, key string, debounceID ulid.ULID, item []byte, ttl time.Duration) (existingID *ulid.ULID, err error)
+	DebounceCreate(ctx context.Context, scope Scope, key string, debounceID ulid.ULID, item []byte, ttl time.Duration) (existingID *ulid.ULID, err error)
 
 	// DebounceUpdate atomically updates the currently pending debounce.
 	// On status DebounceUpdateOK, ttlSeconds is the new TTL to requeue
 	// against. Other statuses describe special outcomes; ttlSeconds is
 	// undefined for those.
-	DebounceUpdate(ctx context.Context, fnID uuid.UUID, key string, debounceID ulid.ULID, item []byte, ttl time.Duration, jobID string, now time.Time, eventTimestamp int64) (ttlSeconds int64, status DebounceUpdateStatus, err error)
+	DebounceUpdate(ctx context.Context, scope Scope, key string, debounceID ulid.ULID, item []byte, ttl time.Duration, jobID string, now time.Time, eventTimestamp int64) (ttlSeconds int64, status DebounceUpdateStatus, err error)
 
 	// DebounceStartExecution atomically begins execution of a debounce,
 	// rotating the pointer to newDebounceID.
-	DebounceStartExecution(ctx context.Context, fnID uuid.UUID, key string, newDebounceID, debounceID ulid.ULID) (DebounceStartStatus, error)
+	DebounceStartExecution(ctx context.Context, scope Scope, key string, newDebounceID, debounceID ulid.ULID) (DebounceStartStatus, error)
 
 	// DebouncePrepareMigration atomically replaces the debounce pointer
 	// with fakeDebounceID to disable execution on this shard, returning
 	// the existing debounce ID and timeout (millis) so the caller can
 	// re-create the debounce on another shard. Returns (nil, 0, nil)
 	// when no debounce exists.
-	DebouncePrepareMigration(ctx context.Context, fnID uuid.UUID, key string, fakeDebounceID ulid.ULID) (existingID *ulid.ULID, timeoutMillis int64, err error)
+	DebouncePrepareMigration(ctx context.Context, scope Scope, key string, fakeDebounceID ulid.ULID) (existingID *ulid.ULID, timeoutMillis int64, err error)
 
 	// DebounceGetItem retrieves the serialized debounce item from the
 	// hash. Returns ErrDebounceNotFound when absent.
-	DebounceGetItem(ctx context.Context, debounceID ulid.ULID) ([]byte, error)
+	DebounceGetItem(ctx context.Context, scope Scope, debounceID ulid.ULID) ([]byte, error)
 
 	// DebounceDeleteItems removes one or more debounce items from the
 	// hash. A no-op on an empty list.
-	DebounceDeleteItems(ctx context.Context, debounceIDs ...ulid.ULID) error
+	DebounceDeleteItems(ctx context.Context, scope Scope, debounceIDs ...ulid.ULID) error
 
 	// DebounceDeleteMigratingFlag clears the in-progress migration flag
 	// for debounceID.
-	DebounceDeleteMigratingFlag(ctx context.Context, debounceID ulid.ULID) error
+	DebounceDeleteMigratingFlag(ctx context.Context, scope Scope, debounceID ulid.ULID) error
 
-	// DebounceGetPointer reads the current debounce ID for fnID/key.
+	// DebounceGetPointer reads the current debounce ID for scope/key.
 	// Returns ErrDebounceNotFound when no debounce is active.
-	DebounceGetPointer(ctx context.Context, fnID uuid.UUID, key string) (string, error)
+	DebounceGetPointer(ctx context.Context, scope Scope, key string) (string, error)
 
-	// DebounceDeletePointer removes the pointer for fnID/key.
-	DebounceDeletePointer(ctx context.Context, fnID uuid.UUID, key string) error
+	// DebounceDeletePointer removes the pointer for scope/key.
+	DebounceDeletePointer(ctx context.Context, scope Scope, key string) error
 }
 
 // PeekOperations is the per-shard surface for queue peeking.

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -176,47 +176,47 @@ func (m *mockShardForIterator) ShardLease(ctx context.Context, key string, durat
 	return nil, nil
 }
 
-func (m *mockShardForIterator) SingletonGetRunID(ctx context.Context, key string) (*ulid.ULID, error) {
+func (m *mockShardForIterator) SingletonGetRunID(ctx context.Context, scope Scope, key string) (*ulid.ULID, error) {
 	return nil, nil
 }
 
-func (m *mockShardForIterator) SingletonReleaseRunID(ctx context.Context, key string) (*ulid.ULID, error) {
+func (m *mockShardForIterator) SingletonReleaseRunID(ctx context.Context, scope Scope, key string) (*ulid.ULID, error) {
 	return nil, nil
 }
 
-func (m *mockShardForIterator) DebounceCreate(ctx context.Context, fnID uuid.UUID, key string, debounceID ulid.ULID, item []byte, ttl time.Duration) (*ulid.ULID, error) {
+func (m *mockShardForIterator) DebounceCreate(ctx context.Context, scope Scope, key string, debounceID ulid.ULID, item []byte, ttl time.Duration) (*ulid.ULID, error) {
 	return nil, nil
 }
 
-func (m *mockShardForIterator) DebounceUpdate(ctx context.Context, fnID uuid.UUID, key string, debounceID ulid.ULID, item []byte, ttl time.Duration, jobID string, now time.Time, eventTimestamp int64) (int64, DebounceUpdateStatus, error) {
+func (m *mockShardForIterator) DebounceUpdate(ctx context.Context, scope Scope, key string, debounceID ulid.ULID, item []byte, ttl time.Duration, jobID string, now time.Time, eventTimestamp int64) (int64, DebounceUpdateStatus, error) {
 	return 0, DebounceUpdateOK, nil
 }
 
-func (m *mockShardForIterator) DebounceStartExecution(ctx context.Context, fnID uuid.UUID, key string, newDebounceID, debounceID ulid.ULID) (DebounceStartStatus, error) {
+func (m *mockShardForIterator) DebounceStartExecution(ctx context.Context, scope Scope, key string, newDebounceID, debounceID ulid.ULID) (DebounceStartStatus, error) {
 	return DebounceStartStarted, nil
 }
 
-func (m *mockShardForIterator) DebouncePrepareMigration(ctx context.Context, fnID uuid.UUID, key string, fakeDebounceID ulid.ULID) (*ulid.ULID, int64, error) {
+func (m *mockShardForIterator) DebouncePrepareMigration(ctx context.Context, scope Scope, key string, fakeDebounceID ulid.ULID) (*ulid.ULID, int64, error) {
 	return nil, 0, nil
 }
 
-func (m *mockShardForIterator) DebounceGetItem(ctx context.Context, debounceID ulid.ULID) ([]byte, error) {
+func (m *mockShardForIterator) DebounceGetItem(ctx context.Context, scope Scope, debounceID ulid.ULID) ([]byte, error) {
 	return nil, nil
 }
 
-func (m *mockShardForIterator) DebounceDeleteItems(ctx context.Context, debounceIDs ...ulid.ULID) error {
+func (m *mockShardForIterator) DebounceDeleteItems(ctx context.Context, scope Scope, debounceIDs ...ulid.ULID) error {
 	return nil
 }
 
-func (m *mockShardForIterator) DebounceDeleteMigratingFlag(ctx context.Context, debounceID ulid.ULID) error {
+func (m *mockShardForIterator) DebounceDeleteMigratingFlag(ctx context.Context, scope Scope, debounceID ulid.ULID) error {
 	return nil
 }
 
-func (m *mockShardForIterator) DebounceGetPointer(ctx context.Context, fnID uuid.UUID, key string) (string, error) {
+func (m *mockShardForIterator) DebounceGetPointer(ctx context.Context, scope Scope, key string) (string, error) {
 	return "", nil
 }
 
-func (m *mockShardForIterator) DebounceDeletePointer(ctx context.Context, fnID uuid.UUID, key string) error {
+func (m *mockShardForIterator) DebounceDeletePointer(ctx context.Context, scope Scope, key string) error {
 	return nil
 }
 

--- a/pkg/execution/queue/scope.go
+++ b/pkg/execution/queue/scope.go
@@ -1,0 +1,23 @@
+package queue
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+func (s Scope) Validate() error {
+	if s.IsSystem {
+		return nil
+	}
+	if s.AccountID == uuid.Nil {
+		return fmt.Errorf("missing account ID")
+	}
+	if s.EnvID == uuid.Nil {
+		return fmt.Errorf("missing env ID")
+	}
+	if s.FunctionID == uuid.Nil {
+		return fmt.Errorf("missing function ID")
+	}
+	return nil
+}

--- a/pkg/execution/singleton/singleton.go
+++ b/pkg/execution/singleton/singleton.go
@@ -19,7 +19,7 @@ var (
 )
 
 type Singleton interface {
-	HandleSingleton(ctx context.Context, key string, c inngest.Singleton, accountID uuid.UUID) (*ulid.ULID, error)
+	HandleSingleton(ctx context.Context, scope queue.Scope, key string, c inngest.Singleton) (*ulid.ULID, error)
 }
 
 func New(ctx context.Context, shards queue.ShardRegistry) Singleton {
@@ -30,8 +30,8 @@ type store struct {
 	shards queue.ShardRegistry
 }
 
-func (s *store) HandleSingleton(ctx context.Context, key string, cfg inngest.Singleton, accountID uuid.UUID) (*ulid.ULID, error) {
-	return singleton(ctx, s.shards, key, cfg, accountID)
+func (s *store) HandleSingleton(ctx context.Context, scope queue.Scope, key string, cfg inngest.Singleton) (*ulid.ULID, error) {
+	return singleton(ctx, s.shards, scope, key, cfg)
 }
 
 // SingletonKey returns the singleton key given a function ID, singleton config,
@@ -65,16 +65,16 @@ func hash(res any, id uuid.UUID) string {
 // - If the mode is SingletonModeSkip, it returns the currently held run ID without modifying the lock.
 //
 // - If the mode is SingletonModeCancel, it attempts to release the lock and returns the run ID that was released.
-func singleton(ctx context.Context, shards queue.ShardRegistry, key string, s inngest.Singleton, accountID uuid.UUID) (*ulid.ULID, error) {
-	shard, err := shards.Resolve(ctx, accountID, nil)
+func singleton(ctx context.Context, shards queue.ShardRegistry, scope queue.Scope, key string, s inngest.Singleton) (*ulid.ULID, error) {
+	shard, err := shards.Resolve(ctx, scope.AccountID, nil)
 	if err != nil {
 		return nil, err
 	}
 	switch s.Mode {
 	case enums.SingletonModeSkip:
-		return shard.SingletonGetRunID(ctx, key)
+		return shard.SingletonGetRunID(ctx, scope, key)
 	case enums.SingletonModeCancel:
-		return shard.SingletonReleaseRunID(ctx, key)
+		return shard.SingletonReleaseRunID(ctx, scope, key)
 	default:
 		return nil, fmt.Errorf("singleton mode %d not implemented", s.Mode)
 	}

--- a/pkg/execution/singleton/singleton.go
+++ b/pkg/execution/singleton/singleton.go
@@ -31,6 +31,10 @@ type store struct {
 }
 
 func (s *store) HandleSingleton(ctx context.Context, scope queue.Scope, key string, cfg inngest.Singleton) (*ulid.ULID, error) {
+	if err := scope.Validate(); err != nil {
+		return nil, err
+	}
+
 	return singleton(ctx, s.shards, scope, key, cfg)
 }
 

--- a/pkg/execution/state/redis_state/debounce.go
+++ b/pkg/execution/state/redis_state/debounce.go
@@ -6,21 +6,20 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/uuid"
 	osqueue "github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/oklog/ulid/v2"
 	"github.com/redis/rueidis"
 )
 
 // DebounceCreate implements queue.DebounceOperations.
-func (q *queue) DebounceCreate(ctx context.Context, fnID uuid.UUID, key string, debounceID ulid.ULID, item []byte, ttl time.Duration) (*ulid.ULID, error) {
+func (q *queue) DebounceCreate(ctx context.Context, scope osqueue.Scope, key string, debounceID ulid.ULID, item []byte, ttl time.Duration) (*ulid.ULID, error) {
 	client := q.RedisClient.Client()
 	kg := q.RedisClient.DebounceKeyGenerator()
 
 	out, err := scripts["debounce/newDebounce"].Exec(
 		ctx,
 		client,
-		[]string{kg.DebouncePointer(ctx, fnID, key), kg.Debounce(ctx)},
+		[]string{kg.DebouncePointer(ctx, scope.FunctionID, key), kg.Debounce(ctx)},
 		[]string{debounceID.String(), string(item), strconv.Itoa(int(ttl.Seconds()))},
 	).ToString()
 	if err != nil {
@@ -41,7 +40,7 @@ func (q *queue) DebounceCreate(ctx context.Context, fnID uuid.UUID, key string, 
 // DebounceUpdate implements queue.DebounceOperations.
 func (q *queue) DebounceUpdate(
 	ctx context.Context,
-	fnID uuid.UUID,
+	scope osqueue.Scope,
 	key string,
 	debounceID ulid.ULID,
 	item []byte,
@@ -57,7 +56,7 @@ func (q *queue) DebounceUpdate(
 		ctx,
 		client,
 		[]string{
-			kg.DebouncePointer(ctx, fnID, key),
+			kg.DebouncePointer(ctx, scope.FunctionID, key),
 			kg.Debounce(ctx),
 			kg.QueueItem(),
 		},
@@ -87,7 +86,7 @@ func (q *queue) DebounceUpdate(
 }
 
 // DebounceStartExecution implements queue.DebounceOperations.
-func (q *queue) DebounceStartExecution(ctx context.Context, fnID uuid.UUID, key string, newDebounceID, debounceID ulid.ULID) (osqueue.DebounceStartStatus, error) {
+func (q *queue) DebounceStartExecution(ctx context.Context, scope osqueue.Scope, key string, newDebounceID, debounceID ulid.ULID) (osqueue.DebounceStartStatus, error) {
 	client := q.RedisClient.Client()
 	kg := q.RedisClient.DebounceKeyGenerator()
 
@@ -95,7 +94,7 @@ func (q *queue) DebounceStartExecution(ctx context.Context, fnID uuid.UUID, key 
 		ctx,
 		client,
 		[]string{
-			kg.DebouncePointer(ctx, fnID, key),
+			kg.DebouncePointer(ctx, scope.FunctionID, key),
 			kg.DebounceMigrating(ctx),
 		},
 		[]string{
@@ -118,7 +117,7 @@ func (q *queue) DebounceStartExecution(ctx context.Context, fnID uuid.UUID, key 
 }
 
 // DebouncePrepareMigration implements queue.DebounceOperations.
-func (q *queue) DebouncePrepareMigration(ctx context.Context, fnID uuid.UUID, key string, fakeDebounceID ulid.ULID) (*ulid.ULID, int64, error) {
+func (q *queue) DebouncePrepareMigration(ctx context.Context, scope osqueue.Scope, key string, fakeDebounceID ulid.ULID) (*ulid.ULID, int64, error) {
 	client := q.RedisClient.Client()
 	kg := q.RedisClient.DebounceKeyGenerator()
 
@@ -126,7 +125,7 @@ func (q *queue) DebouncePrepareMigration(ctx context.Context, fnID uuid.UUID, ke
 		ctx,
 		client,
 		[]string{
-			kg.DebouncePointer(ctx, fnID, key),
+			kg.DebouncePointer(ctx, scope.FunctionID, key),
 			kg.Debounce(ctx),
 			kg.DebounceMigrating(ctx),
 		},
@@ -179,7 +178,7 @@ func (q *queue) DebouncePrepareMigration(ctx context.Context, fnID uuid.UUID, ke
 }
 
 // DebounceGetItem implements queue.DebounceOperations.
-func (q *queue) DebounceGetItem(ctx context.Context, debounceID ulid.ULID) ([]byte, error) {
+func (q *queue) DebounceGetItem(ctx context.Context, scope osqueue.Scope, debounceID ulid.ULID) ([]byte, error) {
 	client := q.RedisClient.Client()
 	kg := q.RedisClient.DebounceKeyGenerator()
 
@@ -195,7 +194,7 @@ func (q *queue) DebounceGetItem(ctx context.Context, debounceID ulid.ULID) ([]by
 }
 
 // DebounceDeleteItems implements queue.DebounceOperations.
-func (q *queue) DebounceDeleteItems(ctx context.Context, debounceIDs ...ulid.ULID) error {
+func (q *queue) DebounceDeleteItems(ctx context.Context, scope osqueue.Scope, debounceIDs ...ulid.ULID) error {
 	if len(debounceIDs) == 0 {
 		return nil
 	}
@@ -218,7 +217,7 @@ func (q *queue) DebounceDeleteItems(ctx context.Context, debounceIDs ...ulid.ULI
 }
 
 // DebounceDeleteMigratingFlag implements queue.DebounceOperations.
-func (q *queue) DebounceDeleteMigratingFlag(ctx context.Context, debounceID ulid.ULID) error {
+func (q *queue) DebounceDeleteMigratingFlag(ctx context.Context, scope osqueue.Scope, debounceID ulid.ULID) error {
 	client := q.RedisClient.Client()
 	kg := q.RedisClient.DebounceKeyGenerator()
 
@@ -234,11 +233,11 @@ func (q *queue) DebounceDeleteMigratingFlag(ctx context.Context, debounceID ulid
 }
 
 // DebounceGetPointer implements queue.DebounceOperations.
-func (q *queue) DebounceGetPointer(ctx context.Context, fnID uuid.UUID, key string) (string, error) {
+func (q *queue) DebounceGetPointer(ctx context.Context, scope osqueue.Scope, key string) (string, error) {
 	client := q.RedisClient.Client()
 	kg := q.RedisClient.DebounceKeyGenerator()
 
-	val, err := client.Do(ctx, client.B().Get().Key(kg.DebouncePointer(ctx, fnID, key)).Build()).ToString()
+	val, err := client.Do(ctx, client.B().Get().Key(kg.DebouncePointer(ctx, scope.FunctionID, key)).Build()).ToString()
 	if rueidis.IsRedisNil(err) {
 		return "", osqueue.ErrDebounceNotFound
 	}
@@ -249,11 +248,11 @@ func (q *queue) DebounceGetPointer(ctx context.Context, fnID uuid.UUID, key stri
 }
 
 // DebounceDeletePointer implements queue.DebounceOperations.
-func (q *queue) DebounceDeletePointer(ctx context.Context, fnID uuid.UUID, key string) error {
+func (q *queue) DebounceDeletePointer(ctx context.Context, scope osqueue.Scope, key string) error {
 	client := q.RedisClient.Client()
 	kg := q.RedisClient.DebounceKeyGenerator()
 
-	err := client.Do(ctx, client.B().Del().Key(kg.DebouncePointer(ctx, fnID, key)).Build()).Error()
+	err := client.Do(ctx, client.B().Del().Key(kg.DebouncePointer(ctx, scope.FunctionID, key)).Build()).Error()
 	if err != nil && !rueidis.IsRedisNil(err) {
 		return fmt.Errorf("error deleting debounce pointer: %w", err)
 	}

--- a/pkg/execution/state/redis_state/singleton.go
+++ b/pkg/execution/state/redis_state/singleton.go
@@ -20,7 +20,7 @@ return v
 var getAndDeleteScript = rueidis.NewLuaScript(getAndDeleteLua)
 
 // SingletonGetRunID implements queue.ShardOperations.
-func (q *queue) SingletonGetRunID(ctx context.Context, key string) (*ulid.ULID, error) {
+func (q *queue) SingletonGetRunID(ctx context.Context, scope osqueue.Scope, key string) (*ulid.ULID, error) {
 	client := q.RedisClient.Client()
 	redisKey := q.RedisClient.KeyGenerator().SingletonKey(&osqueue.Singleton{Key: key})
 
@@ -29,7 +29,7 @@ func (q *queue) SingletonGetRunID(ctx context.Context, key string) (*ulid.ULID, 
 }
 
 // SingletonReleaseRunID implements queue.ShardOperations.
-func (q *queue) SingletonReleaseRunID(ctx context.Context, key string) (*ulid.ULID, error) {
+func (q *queue) SingletonReleaseRunID(ctx context.Context, scope osqueue.Scope, key string) (*ulid.ULID, error) {
 	client := q.RedisClient.Client()
 	redisKey := q.RedisClient.KeyGenerator().SingletonKey(&osqueue.Singleton{Key: key})
 

--- a/proto/debug/v1/debounce.proto
+++ b/proto/debug/v1/debounce.proto
@@ -12,6 +12,10 @@ message DebounceInfoRequest {
   // debounce_key is the optional evaluated debounce key suffix (from the key expression).
   // If empty, uses the function_id as the debounce key.
   string debounce_key = 2;
+  // account_id is the UUID of the account that owns the function.
+  string account_id = 3;
+  // env_id is the UUID of the environment that owns the function.
+  string env_id = 4;
 }
 
 // DebounceInfoResponse contains information about the current debounce.
@@ -41,6 +45,10 @@ message DeleteDebounceRequest {
   // debounce_key is the optional evaluated debounce key suffix (from the key expression).
   // If empty, uses the function_id as the debounce key.
   string debounce_key = 2;
+  // account_id is the UUID of the account that owns the function.
+  string account_id = 3;
+  // env_id is the UUID of the environment that owns the function.
+  string env_id = 4;
 }
 
 // DeleteDebounceResponse contains information about the deleted debounce.
@@ -60,6 +68,10 @@ message RunDebounceRequest {
   // debounce_key is the optional evaluated debounce key suffix (from the key expression).
   // If empty, uses the function_id as the debounce key.
   string debounce_key = 2;
+  // account_id is the UUID of the account that owns the function.
+  string account_id = 3;
+  // env_id is the UUID of the environment that owns the function.
+  string env_id = 4;
 }
 
 // RunDebounceResponse contains information about the scheduled debounce execution.
@@ -76,6 +88,12 @@ message RunDebounceResponse {
 message DeleteDebounceByIDRequest {
   // debounce_ids are the ULIDs of the debounces to delete. Max 20.
   repeated string debounce_ids = 1;
+  // account_id is the UUID of the account that owns the function.
+  string account_id = 2;
+  // env_id is the UUID of the environment that owns the function.
+  string env_id = 3;
+  // function_id is the UUID of the function.
+  string function_id = 4;
 }
 
 // DeleteDebounceByIDResponse contains information about the deleted debounces.

--- a/proto/debug/v1/singleton.proto
+++ b/proto/debug/v1/singleton.proto
@@ -10,6 +10,10 @@ message SingletonInfoRequest {
   // singleton_key is the optional evaluated singleton key suffix (hash part).
   // If empty, uses the function_id as the singleton key.
   string singleton_key = 2;
+  // account_id is the UUID of the account that owns the function.
+  string account_id = 3;
+  // env_id is the UUID of the environment that owns the function.
+  string env_id = 4;
 }
 
 // SingletonInfoResponse contains information about the current singleton lock.
@@ -27,6 +31,10 @@ message DeleteSingletonLockRequest {
   // singleton_key is the optional evaluated singleton key suffix (hash part).
   // If empty, uses the function_id as the singleton key.
   string singleton_key = 2;
+  // account_id is the UUID of the account that owns the function.
+  string account_id = 3;
+  // env_id is the UUID of the environment that owns the function.
+  string env_id = 4;
 }
 
 // DeleteSingletonLockResponse contains information about the deleted lock.

--- a/proto/gen/debug/v1/debounce.pb.go
+++ b/proto/gen/debug/v1/debounce.pb.go
@@ -29,7 +29,11 @@ type DebounceInfoRequest struct {
 	FunctionId string `protobuf:"bytes,1,opt,name=function_id,json=functionId,proto3" json:"function_id,omitempty"`
 	// debounce_key is the optional evaluated debounce key suffix (from the key expression).
 	// If empty, uses the function_id as the debounce key.
-	DebounceKey   string `protobuf:"bytes,2,opt,name=debounce_key,json=debounceKey,proto3" json:"debounce_key,omitempty"`
+	DebounceKey string `protobuf:"bytes,2,opt,name=debounce_key,json=debounceKey,proto3" json:"debounce_key,omitempty"`
+	// account_id is the UUID of the account that owns the function.
+	AccountId string `protobuf:"bytes,3,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	// env_id is the UUID of the environment that owns the function.
+	EnvId         string `protobuf:"bytes,4,opt,name=env_id,json=envId,proto3" json:"env_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -74,6 +78,20 @@ func (x *DebounceInfoRequest) GetFunctionId() string {
 func (x *DebounceInfoRequest) GetDebounceKey() string {
 	if x != nil {
 		return x.DebounceKey
+	}
+	return ""
+}
+
+func (x *DebounceInfoRequest) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *DebounceInfoRequest) GetEnvId() string {
+	if x != nil {
+		return x.EnvId
 	}
 	return ""
 }
@@ -194,7 +212,11 @@ type DeleteDebounceRequest struct {
 	FunctionId string `protobuf:"bytes,1,opt,name=function_id,json=functionId,proto3" json:"function_id,omitempty"`
 	// debounce_key is the optional evaluated debounce key suffix (from the key expression).
 	// If empty, uses the function_id as the debounce key.
-	DebounceKey   string `protobuf:"bytes,2,opt,name=debounce_key,json=debounceKey,proto3" json:"debounce_key,omitempty"`
+	DebounceKey string `protobuf:"bytes,2,opt,name=debounce_key,json=debounceKey,proto3" json:"debounce_key,omitempty"`
+	// account_id is the UUID of the account that owns the function.
+	AccountId string `protobuf:"bytes,3,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	// env_id is the UUID of the environment that owns the function.
+	EnvId         string `protobuf:"bytes,4,opt,name=env_id,json=envId,proto3" json:"env_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -239,6 +261,20 @@ func (x *DeleteDebounceRequest) GetFunctionId() string {
 func (x *DeleteDebounceRequest) GetDebounceKey() string {
 	if x != nil {
 		return x.DebounceKey
+	}
+	return ""
+}
+
+func (x *DeleteDebounceRequest) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *DeleteDebounceRequest) GetEnvId() string {
+	if x != nil {
+		return x.EnvId
 	}
 	return ""
 }
@@ -314,7 +350,11 @@ type RunDebounceRequest struct {
 	FunctionId string `protobuf:"bytes,1,opt,name=function_id,json=functionId,proto3" json:"function_id,omitempty"`
 	// debounce_key is the optional evaluated debounce key suffix (from the key expression).
 	// If empty, uses the function_id as the debounce key.
-	DebounceKey   string `protobuf:"bytes,2,opt,name=debounce_key,json=debounceKey,proto3" json:"debounce_key,omitempty"`
+	DebounceKey string `protobuf:"bytes,2,opt,name=debounce_key,json=debounceKey,proto3" json:"debounce_key,omitempty"`
+	// account_id is the UUID of the account that owns the function.
+	AccountId string `protobuf:"bytes,3,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	// env_id is the UUID of the environment that owns the function.
+	EnvId         string `protobuf:"bytes,4,opt,name=env_id,json=envId,proto3" json:"env_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -359,6 +399,20 @@ func (x *RunDebounceRequest) GetFunctionId() string {
 func (x *RunDebounceRequest) GetDebounceKey() string {
 	if x != nil {
 		return x.DebounceKey
+	}
+	return ""
+}
+
+func (x *RunDebounceRequest) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *RunDebounceRequest) GetEnvId() string {
+	if x != nil {
+		return x.EnvId
 	}
 	return ""
 }
@@ -431,7 +485,13 @@ func (x *RunDebounceResponse) GetEventId() string {
 type DeleteDebounceByIDRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// debounce_ids are the ULIDs of the debounces to delete. Max 20.
-	DebounceIds   []string `protobuf:"bytes,1,rep,name=debounce_ids,json=debounceIds,proto3" json:"debounce_ids,omitempty"`
+	DebounceIds []string `protobuf:"bytes,1,rep,name=debounce_ids,json=debounceIds,proto3" json:"debounce_ids,omitempty"`
+	// account_id is the UUID of the account that owns the function.
+	AccountId string `protobuf:"bytes,2,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	// env_id is the UUID of the environment that owns the function.
+	EnvId string `protobuf:"bytes,3,opt,name=env_id,json=envId,proto3" json:"env_id,omitempty"`
+	// function_id is the UUID of the function.
+	FunctionId    string `protobuf:"bytes,4,opt,name=function_id,json=functionId,proto3" json:"function_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -471,6 +531,27 @@ func (x *DeleteDebounceByIDRequest) GetDebounceIds() []string {
 		return x.DebounceIds
 	}
 	return nil
+}
+
+func (x *DeleteDebounceByIDRequest) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *DeleteDebounceByIDRequest) GetEnvId() string {
+	if x != nil {
+		return x.EnvId
+	}
+	return ""
+}
+
+func (x *DeleteDebounceByIDRequest) GetFunctionId() string {
+	if x != nil {
+		return x.FunctionId
+	}
+	return ""
 }
 
 // DeleteDebounceByIDResponse contains information about the deleted debounces.
@@ -523,11 +604,14 @@ var File_debug_v1_debounce_proto protoreflect.FileDescriptor
 
 const file_debug_v1_debounce_proto_rawDesc = "" +
 	"\n" +
-	"\x17debug/v1/debounce.proto\x12\bdebug.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"Y\n" +
+	"\x17debug/v1/debounce.proto\x12\bdebug.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x8f\x01\n" +
 	"\x13DebounceInfoRequest\x12\x1f\n" +
 	"\vfunction_id\x18\x01 \x01(\tR\n" +
 	"functionId\x12!\n" +
-	"\fdebounce_key\x18\x02 \x01(\tR\vdebounceKey\"\x91\x02\n" +
+	"\fdebounce_key\x18\x02 \x01(\tR\vdebounceKey\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x03 \x01(\tR\taccountId\x12\x15\n" +
+	"\x06env_id\x18\x04 \x01(\tR\x05envId\"\x91\x02\n" +
 	"\x14DebounceInfoResponse\x12!\n" +
 	"\fhas_debounce\x18\x01 \x01(\bR\vhasDebounce\x12\x1f\n" +
 	"\vdebounce_id\x18\x02 \x01(\tR\n" +
@@ -540,27 +624,38 @@ const file_debug_v1_debounce_proto_rawDesc = "" +
 	"account_id\x18\x06 \x01(\tR\taccountId\x12!\n" +
 	"\fworkspace_id\x18\a \x01(\tR\vworkspaceId\x12\x1f\n" +
 	"\vfunction_id\x18\b \x01(\tR\n" +
-	"functionId\"[\n" +
+	"functionId\"\x91\x01\n" +
 	"\x15DeleteDebounceRequest\x12\x1f\n" +
 	"\vfunction_id\x18\x01 \x01(\tR\n" +
 	"functionId\x12!\n" +
-	"\fdebounce_key\x18\x02 \x01(\tR\vdebounceKey\"n\n" +
+	"\fdebounce_key\x18\x02 \x01(\tR\vdebounceKey\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x03 \x01(\tR\taccountId\x12\x15\n" +
+	"\x06env_id\x18\x04 \x01(\tR\x05envId\"n\n" +
 	"\x16DeleteDebounceResponse\x12\x18\n" +
 	"\adeleted\x18\x01 \x01(\bR\adeleted\x12\x1f\n" +
 	"\vdebounce_id\x18\x02 \x01(\tR\n" +
 	"debounceId\x12\x19\n" +
-	"\bevent_id\x18\x03 \x01(\tR\aeventId\"X\n" +
+	"\bevent_id\x18\x03 \x01(\tR\aeventId\"\x8e\x01\n" +
 	"\x12RunDebounceRequest\x12\x1f\n" +
 	"\vfunction_id\x18\x01 \x01(\tR\n" +
 	"functionId\x12!\n" +
-	"\fdebounce_key\x18\x02 \x01(\tR\vdebounceKey\"o\n" +
+	"\fdebounce_key\x18\x02 \x01(\tR\vdebounceKey\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x03 \x01(\tR\taccountId\x12\x15\n" +
+	"\x06env_id\x18\x04 \x01(\tR\x05envId\"o\n" +
 	"\x13RunDebounceResponse\x12\x1c\n" +
 	"\tscheduled\x18\x01 \x01(\bR\tscheduled\x12\x1f\n" +
 	"\vdebounce_id\x18\x02 \x01(\tR\n" +
 	"debounceId\x12\x19\n" +
-	"\bevent_id\x18\x03 \x01(\tR\aeventId\">\n" +
+	"\bevent_id\x18\x03 \x01(\tR\aeventId\"\x95\x01\n" +
 	"\x19DeleteDebounceByIDRequest\x12!\n" +
-	"\fdebounce_ids\x18\x01 \x03(\tR\vdebounceIds\"=\n" +
+	"\fdebounce_ids\x18\x01 \x03(\tR\vdebounceIds\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x02 \x01(\tR\taccountId\x12\x15\n" +
+	"\x06env_id\x18\x03 \x01(\tR\x05envId\x12\x1f\n" +
+	"\vfunction_id\x18\x04 \x01(\tR\n" +
+	"functionId\"=\n" +
 	"\x1aDeleteDebounceByIDResponse\x12\x1f\n" +
 	"\vdeleted_ids\x18\x01 \x03(\tR\n" +
 	"deletedIdsB5Z3github.com/inngest/inngest/proto/gen/debug/v1;debugb\x06proto3"

--- a/proto/gen/debug/v1/singleton.pb.go
+++ b/proto/gen/debug/v1/singleton.pb.go
@@ -28,7 +28,11 @@ type SingletonInfoRequest struct {
 	FunctionId string `protobuf:"bytes,1,opt,name=function_id,json=functionId,proto3" json:"function_id,omitempty"`
 	// singleton_key is the optional evaluated singleton key suffix (hash part).
 	// If empty, uses the function_id as the singleton key.
-	SingletonKey  string `protobuf:"bytes,2,opt,name=singleton_key,json=singletonKey,proto3" json:"singleton_key,omitempty"`
+	SingletonKey string `protobuf:"bytes,2,opt,name=singleton_key,json=singletonKey,proto3" json:"singleton_key,omitempty"`
+	// account_id is the UUID of the account that owns the function.
+	AccountId string `protobuf:"bytes,3,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	// env_id is the UUID of the environment that owns the function.
+	EnvId         string `protobuf:"bytes,4,opt,name=env_id,json=envId,proto3" json:"env_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -73,6 +77,20 @@ func (x *SingletonInfoRequest) GetFunctionId() string {
 func (x *SingletonInfoRequest) GetSingletonKey() string {
 	if x != nil {
 		return x.SingletonKey
+	}
+	return ""
+}
+
+func (x *SingletonInfoRequest) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *SingletonInfoRequest) GetEnvId() string {
+	if x != nil {
+		return x.EnvId
 	}
 	return ""
 }
@@ -139,7 +157,11 @@ type DeleteSingletonLockRequest struct {
 	FunctionId string `protobuf:"bytes,1,opt,name=function_id,json=functionId,proto3" json:"function_id,omitempty"`
 	// singleton_key is the optional evaluated singleton key suffix (hash part).
 	// If empty, uses the function_id as the singleton key.
-	SingletonKey  string `protobuf:"bytes,2,opt,name=singleton_key,json=singletonKey,proto3" json:"singleton_key,omitempty"`
+	SingletonKey string `protobuf:"bytes,2,opt,name=singleton_key,json=singletonKey,proto3" json:"singleton_key,omitempty"`
+	// account_id is the UUID of the account that owns the function.
+	AccountId string `protobuf:"bytes,3,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	// env_id is the UUID of the environment that owns the function.
+	EnvId         string `protobuf:"bytes,4,opt,name=env_id,json=envId,proto3" json:"env_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -184,6 +206,20 @@ func (x *DeleteSingletonLockRequest) GetFunctionId() string {
 func (x *DeleteSingletonLockRequest) GetSingletonKey() string {
 	if x != nil {
 		return x.SingletonKey
+	}
+	return ""
+}
+
+func (x *DeleteSingletonLockRequest) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *DeleteSingletonLockRequest) GetEnvId() string {
+	if x != nil {
+		return x.EnvId
 	}
 	return ""
 }
@@ -247,18 +283,24 @@ var File_debug_v1_singleton_proto protoreflect.FileDescriptor
 
 const file_debug_v1_singleton_proto_rawDesc = "" +
 	"\n" +
-	"\x18debug/v1/singleton.proto\x12\bdebug.v1\"\\\n" +
+	"\x18debug/v1/singleton.proto\x12\bdebug.v1\"\x92\x01\n" +
 	"\x14SingletonInfoRequest\x12\x1f\n" +
 	"\vfunction_id\x18\x01 \x01(\tR\n" +
 	"functionId\x12#\n" +
-	"\rsingleton_key\x18\x02 \x01(\tR\fsingletonKey\"X\n" +
+	"\rsingleton_key\x18\x02 \x01(\tR\fsingletonKey\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x03 \x01(\tR\taccountId\x12\x15\n" +
+	"\x06env_id\x18\x04 \x01(\tR\x05envId\"X\n" +
 	"\x15SingletonInfoResponse\x12\x19\n" +
 	"\bhas_lock\x18\x01 \x01(\bR\ahasLock\x12$\n" +
-	"\x0ecurrent_run_id\x18\x02 \x01(\tR\fcurrentRunId\"b\n" +
+	"\x0ecurrent_run_id\x18\x02 \x01(\tR\fcurrentRunId\"\x98\x01\n" +
 	"\x1aDeleteSingletonLockRequest\x12\x1f\n" +
 	"\vfunction_id\x18\x01 \x01(\tR\n" +
 	"functionId\x12#\n" +
-	"\rsingleton_key\x18\x02 \x01(\tR\fsingletonKey\"N\n" +
+	"\rsingleton_key\x18\x02 \x01(\tR\fsingletonKey\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x03 \x01(\tR\taccountId\x12\x15\n" +
+	"\x06env_id\x18\x04 \x01(\tR\x05envId\"N\n" +
 	"\x1bDeleteSingletonLockResponse\x12\x18\n" +
 	"\adeleted\x18\x01 \x01(\bR\adeleted\x12\x15\n" +
 	"\x06run_id\x18\x02 \x01(\tR\x05runIdB5Z3github.com/inngest/inngest/proto/gen/debug/v1;debugb\x06proto3"


### PR DESCRIPTION
## Description

Adds an explicit queue `Scope` for debounce and singleton storage operations. The scope carries system state plus account, environment, and function IDs so future queue storage implementations can namespace debounce/singleton content under the tenant and function it belongs to.

This updates the debounce and singleton operation interfaces, Redis-backed implementations, callers, CLI debug commands, and tests to pass scope through without changing the current Redis key layout. It also updates the debug API protobufs so clients provide account/environment/function scope instead of the server assuming devserver IDs.

## Release note

Debug API debounce and singleton requests now include account and environment IDs so scoped queue storage can target the correct tenant/function namespace.

## Migration note

Debug API clients for debounce and singleton operations must send `account_id`, `env_id`, and `function_id` on scoped requests. The debug CLI now requires account/environment flags for these commands. Existing Redis storage behavior is unchanged.

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds an explicit `queue.Scope` (account, env, function IDs) to debounce and singleton debug operations. The new `debugflags/scope.go` centralises flag definitions and UUID validation for the debug CLI, and `pkg/debugapi/scope.go` provides a `debugScope()` helper used by all debug API handlers. Proto requests now require account/environment/function IDs instead of the server assuming dev-server constants.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit fefee22dfbf78686a740c94c42b333f2cd544706.</sup>
<!-- /MENDRAL_SUMMARY -->