### PR TITLE
chore: add missing metric on state store delete

### DIFF
--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -1109,7 +1109,9 @@ func (m shardedMgr) SavePending(ctx context.Context, i state.Identifier, pending
 // state store is queue-aware, it must delete queue items for the run also.  This may
 // not always be the case.
 func (m mgr) Delete(ctx context.Context, i state.Identifier) error {
-	err := m.shardedMgr.delete(ctx, ctx, i)
+	callCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
+	defer cancel()
+	err := m.shardedMgr.delete(ctx, callCtx, i)
 	if err != nil {
 		return err
 	}
@@ -1126,6 +1128,7 @@ func (m mgr) Delete(ctx context.Context, i state.Identifier) error {
 
 func (m shardedMgr) delete(ctx context.Context, callCtx context.Context, i state.Identifier) error {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "delete"), redis_telemetry.ScopeFnRunState)
+	callCtx = redis_telemetry.WithScope(redis_telemetry.WithOpName(callCtx, "delete"), redis_telemetry.ScopeFnRunState)
 
 	fnRunState := m.s.FunctionRunState()
 	r, isSharded := fnRunState.Client(ctx, i.AccountID, i.RunID)


### PR DESCRIPTION

## Description
Metrics for state store delete operation are borked this should fix it.
Also, deletes used to be non-cancellable and that regressed.

<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Fixes two issues in `mgr.Delete`: adds the missing `redis_telemetry.WithScope` enrichment to `callCtx` inside `shardedMgr.delete` so delete metrics are correctly recorded, and restores the non-cancellable delete behaviour using `context.WithoutCancel(ctx)` with a 20s timeout to prevent context cancellation from aborting in-flight deletes while preserving the parent trace context.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 590c2a42413225de1f5206d5e4dc73fbc8e58ca5.</sup>
<!-- /MENDRAL_SUMMARY -->