### PR TITLE
feat: EXE-1547 - Accept StepPlanned upon beginning to run a step

### DIFF
--- a/pkg/enums/opcode.go
+++ b/pkg/enums/opcode.go
@@ -35,6 +35,7 @@ const (
 var opcodeSyncMap = map[Opcode]struct{}{
 	OpcodeStep:            {},
 	OpcodeStepRun:         {},
+	OpcodeStepPlanned:     {},
 	OpcodeRunComplete:     {},
 	OpcodeSyncRunComplete: {},
 	OpcodeStepFailed:      {},

--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -216,7 +216,7 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 				meta.SpanNameStep,
 				&tracing.CreateSpanOptions{
 					Debug:      &tracing.SpanDebugData{Location: "checkpoint.SyncStep"},
-					Seed:       []byte(fmt.Sprintf("%s:%d", op.ID, runCtx.AttemptCount())),
+					Seed:       stepDynamicSeed(op, runCtx.AttemptCount()),
 					Parent:     tracing.RunSpanRefFromMetadata(input.Metadata),
 					StartTime:  op.Timing.Start(),
 					EndTime:    op.Timing.End(),
@@ -254,7 +254,7 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 				meta.SpanNameStep,
 				&tracing.CreateSpanOptions{
 					Debug:      &tracing.SpanDebugData{Location: "checkpoint.SyncErr"},
-					Seed:       []byte(fmt.Sprintf("%s:%d", op.ID, runCtx.AttemptCount())),
+					Seed:       stepDynamicSeed(op, runCtx.AttemptCount()),
 					Parent:     tracing.RunSpanRefFromMetadata(input.Metadata),
 					StartTime:  op.Timing.Start(),
 					EndTime:    op.Timing.End(),
@@ -494,7 +494,7 @@ func (c checkpointer) checkpointAsyncSteps(ctx context.Context, input AsyncCheck
 				meta.SpanNameStep,
 				&tracing.CreateSpanOptions{
 					Debug:      &tracing.SpanDebugData{Location: "checkpoint.AsyncStep"},
-					Seed:       []byte(fmt.Sprintf("%s:%d", op.ID, 0)),
+					Seed:       stepDynamicSeed(op, 0),
 					Parent:     tracing.RunSpanRefFromMetadata(&md),
 					StartTime:  op.Timing.Start(),
 					EndTime:    op.Timing.End(),

--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -508,6 +508,33 @@ func (c checkpointer) checkpointAsyncSteps(ctx context.Context, input AsyncCheck
 
 			c.processMetadata(ctx, l, input.AccountID, &md, stepSpanRef, op, "checkpoint.AsyncStep.metadata")
 
+		case enums.OpcodeStepPlanned:
+			// When the SDK announces a step is about to run, we open a Running
+			// executor.step span to show progress to the user.
+			_, err := c.TracerProvider.CreateSpan(
+				tracing.WithExecutionContext(ctx, tracing.ExecutionContext{
+					Identifier: md.ID,
+					Attempt:    0,
+				}),
+				meta.SpanNameStep,
+				&tracing.CreateSpanOptions{
+					Debug: &tracing.SpanDebugData{Location: "checkpoint.AsyncStepPlanned"},
+
+					// Set the same dynamic span ID as the eventual completion arm.
+					// We use DynamicSpanIDOverride instead of Seed to avoid setting the same
+					// span ID.
+					DynamicSpanIDOverride: tracing.DeterministicSpanConfig(stepDynamicSeed(op, 0)).SpanID.String(),
+					Parent:                tracing.RunSpanRefFromMetadata(&md),
+					StartTime:             op.Timing.Start(),
+					Attributes:            stepPlannedAttrs(attrs, op, input.RunID),
+				},
+			)
+			if err != nil {
+				// Processing the leading-edge is best effort both in the executor and SDK.
+				// We'll eventually get the completion arm even if this fails.
+				l.Warn("error saving leading-edge span for StepPlanned", "error", err, "step_id", op.ID)
+			}
+
 		case enums.OpcodeDeferAdd:
 			if err := defers.SaveFromOp(ctx, c.State, l, md.ID, op); err != nil {
 				// Log without returning the error: a bad defer must

--- a/pkg/execution/checkpoint/checkpoint_async_test.go
+++ b/pkg/execution/checkpoint/checkpoint_async_test.go
@@ -192,6 +192,87 @@ func TestCheckpointAsyncSteps(t *testing.T) {
 		require.True(hasMetadata, "Expected a metadata span")
 	})
 
+	t.Run("StepPlanned then StepRun share the same span seed", func(t *testing.T) {
+		ctx := context.Background()
+		require := require.New(t)
+
+		now := time.Now()
+		planned := state.GeneratorOpcode{
+			ID:     "step-1",
+			Op:     enums.OpcodeStepPlanned,
+			Name:   "work",
+			Timing: interval.New(now, time.Time{}),
+		}
+		run := state.GeneratorOpcode{
+			ID:     "step-1",
+			Op:     enums.OpcodeStepRun,
+			Data:   json.RawMessage(`{"result":"ok"}`),
+			Name:   "work",
+			Timing: interval.New(now, now.Add(time.Second)),
+		}
+
+		mocks, testData := setupAsyncCheckpointTest(t, planned, run)
+
+		expectedData := map[string]any{"data": json.RawMessage(run.Data)}
+		expectedOutputBytes, _ := json.Marshal(expectedData)
+		mocks.state.On("SaveStep", ctx, testData.metadata.ID, "step-1", expectedOutputBytes).Return(false, nil)
+		mocks.tracer.
+			On("CreateSpan", mock.Anything, meta.SpanNameStep, mock.AnythingOfType("*tracing.CreateSpanOptions")).
+			Return(&meta.SpanReference{}, nil).
+			Twice()
+		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", "job-123").Return(nil)
+
+		err := testData.checkpointer.CheckpointAsyncSteps(ctx, testData.asyncCheckpoint)
+		require.NoError(err)
+
+		require.Len(mocks.tracer.createdSpans, 2)
+		leadingEdgeSpan := mocks.tracer.createdSpans[0]
+		completionArmSpan := mocks.tracer.createdSpans[1]
+
+		completionSeed := completionArmSpan.options.Seed
+		require.NotEmpty(completionSeed, "completion arm should still use Seed")
+		expectedDynID := tracing.DeterministicSpanConfig(completionSeed).SpanID.String()
+
+		require.Empty(leadingEdgeSpan.options.Seed, "leading edge should still not use Seed")
+		require.Equal(expectedDynID, leadingEdgeSpan.options.DynamicSpanIDOverride,
+			"leading-edge DynamicSpanIDOverride must equal DeterministicSpanConfig(completion.Seed).SpanID")
+
+		require.EqualValues("Running",
+			leadingEdgeSpan.attributes.Get(meta.Attrs.DynamicStatus.Key()).(*enums.StepStatus).String())
+		require.Nil(leadingEdgeSpan.attributes.Get(meta.Attrs.EndedAt.Key()))
+
+		require.EqualValues("Completed",
+			completionArmSpan.attributes.Get(meta.Attrs.DynamicStatus.Key()).(*enums.StepStatus).String())
+		require.NotNil(completionArmSpan.attributes.Get(meta.Attrs.EndedAt.Key()))
+	})
+
+	t.Run("StepPlanned span creation failure does not fail the request", func(t *testing.T) {
+		ctx := context.Background()
+		require := require.New(t)
+
+		op := state.GeneratorOpcode{
+			ID:     "step-flaky",
+			Op:     enums.OpcodeStepPlanned,
+			Name:   "work",
+			Timing: interval.New(time.Now(), time.Time{}),
+		}
+
+		mocks, testData := setupAsyncCheckpointTest(t, op)
+
+		mocks.tracer.
+			On("CreateSpan", mock.Anything, meta.SpanNameStep, mock.AnythingOfType("*tracing.CreateSpanOptions")).
+			Return(&meta.SpanReference{}, fmt.Errorf("simulated tracer outage")).
+			Once()
+		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", "job-123").Return(nil)
+
+		err := testData.checkpointer.CheckpointAsyncSteps(ctx, testData.asyncCheckpoint)
+		require.NoError(err, "best-effort: tracer failure must not surface to caller")
+
+		mocks.state.AssertNotCalled(t, "SaveStep")
+		mocks.tracer.AssertExpectations(t)
+		mocks.queue.AssertExpectations(t)
+	})
+
 	t.Run("defer add", func(t *testing.T) {
 		// Async path handles OpcodeDeferAdd the same way the sync path
 		// does: persist a Defer record. SDK-side memoization is carried

--- a/pkg/execution/checkpoint/util.go
+++ b/pkg/execution/checkpoint/util.go
@@ -1,12 +1,20 @@
 package checkpoint
 
 import (
+	"fmt"
+
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngestgo"
 	"github.com/oklog/ulid/v2"
 )
+
+// stepDynamicSeed returns the deterministic seed used to derive an
+// executor.step row's dynamic_span_id.
+func stepDynamicSeed(op state.GeneratorOpcode, attempt int) []byte {
+	return fmt.Appendf(nil, "%s:%d", op.ID, attempt)
+}
 
 func stepRunAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, runID ulid.ULID) *meta.SerializableAttrs {
 	return attrs.Merge(

--- a/pkg/execution/checkpoint/util.go
+++ b/pkg/execution/checkpoint/util.go
@@ -30,6 +30,18 @@ func stepRunAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, runID
 	)
 }
 
+func stepPlannedAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, runID ulid.ULID) *meta.SerializableAttrs {
+	return attrs.Merge(
+		meta.NewAttrSet(
+			meta.Attr(meta.Attrs.StepName, inngestgo.Ptr(op.UserDefinedName())),
+			meta.Attr(meta.Attrs.RunID, &runID),
+			meta.Attr(meta.Attrs.QueuedAt, inngestgo.Ptr(op.Timing.Start())),
+			meta.Attr(meta.Attrs.StartedAt, inngestgo.Ptr(op.Timing.Start())),
+			meta.Attr(meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusRunning)),
+		),
+	)
+}
+
 func stepErrorAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, runID ulid.ULID, status enums.StepStatus) *meta.SerializableAttrs {
 	return attrs.Merge(
 		meta.NewAttrSet(

--- a/pkg/execution/checkpoint/util.go
+++ b/pkg/execution/checkpoint/util.go
@@ -33,8 +33,6 @@ func stepRunAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, runID
 func stepPlannedAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, runID ulid.ULID) *meta.SerializableAttrs {
 	return attrs.Merge(
 		meta.NewAttrSet(
-			meta.Attr(meta.Attrs.StepName, inngestgo.Ptr(op.UserDefinedName())),
-			meta.Attr(meta.Attrs.RunID, &runID),
 			meta.Attr(meta.Attrs.QueuedAt, inngestgo.Ptr(op.Timing.Start())),
 			meta.Attr(meta.Attrs.StartedAt, inngestgo.Ptr(op.Timing.Start())),
 			meta.Attr(meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusRunning)),

--- a/pkg/execution/state/opcode.go
+++ b/pkg/execution/state/opcode.go
@@ -200,6 +200,8 @@ func (g GeneratorOpcode) RunType() string {
 // This does not map 1-1 to Opcode. For example, many different SDK operations map to OpcodeStepRun.
 func (g GeneratorOpcode) StepType() enums.StepType {
 	switch g.RunType() {
+	case "step.run":
+		return enums.StepTypeRun
 	case "step.sendEvent":
 		return enums.StepTypeSendEvent
 	case "step.sendSignal":

--- a/pkg/tracing/metadata.go
+++ b/pkg/tracing/metadata.go
@@ -77,7 +77,9 @@ func CreateMetadataSpanFromValues(ctx context.Context, tracerProvider TracerProv
 			Metadata:   stateMetadata,
 			Attributes: cfg.Attrs,
 
-			DynamicSeed: MetadataSpanIDSeed(parent.DynamicSpanID, kind),
+			// Set the dynamic_span_id from (parent, kind) so every
+			// metadata emission of this kind under this parent aggregates together.
+			DynamicSpanIDOverride: DeterministicSpanID(MetadataSpanIDSeed(parent.DynamicSpanID, kind)).String(),
 		},
 	)
 	if err != nil {

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -60,10 +60,13 @@ type CreateSpanOptions struct {
 	Seed   []byte
 	SpanID trace.SpanID
 
-	// DynamicSeed is optional and used for CreateOrUpdate operations
-	// This differs from Seed in that seed creates a deterministic trace and span ID while
-	// dynamic seed only creates a deterministic dynamic span ID while leaving the concrete span ID random.
-	DynamicSeed []byte
+	// DynamicSpanIDOverride, if non-empty, sets the persisted DynamicSpanID
+	// attribute to exactly this value, leaving the concrete OTel span_id
+	// random.
+	//
+	// Use this when multiple physical span rows must share one
+	// logical identity but have have unique span_ids.
+	DynamicSpanIDOverride string
 }
 
 type UpdateSpanOptions struct {
@@ -232,8 +235,8 @@ func (tp *otelTracerProvider) CreateDroppableSpan(
 	}
 
 	spanRef.DynamicSpanID = span.SpanContext().SpanID().String()
-	if opts.DynamicSeed != nil {
-		spanRef.DynamicSpanID = DeterministicSpanID(opts.DynamicSeed).String()
+	if opts.DynamicSpanIDOverride != "" {
+		spanRef.DynamicSpanID = opts.DynamicSpanIDOverride
 	}
 
 	if opts.Parent != nil {


### PR DESCRIPTION
## Description
* Users running checkpointing sometimes have long running steps. Currently in the dashboard, it is difficult to determine that the step is in progress rather than hanging.
* We do have the Execution > Attempt 0 row in the execution viewer, but this is separated from where on-going step will eventually live, especially in longer and more complex workflows. Additionally, this eventually disappears once the run finishes
* We would like to show users that we are working on their step
* On the SDK side, we https://github.com/inngest/inngest-js/pull/1530
* In the executor in this PR,  upon receiving this `StepPlanned` opcode, we persist a `Running` span with the step name and start time. Critically, we will set the dynamic span ID to match the incoming `StepRun` opcode that will conclude the step.


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
