### PR TITLE
refactor(queue): remove duplicate global partition peek method

### DIFF
--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -266,12 +266,6 @@ type PeekOperations interface {
 		peekUntil time.Time,
 		sequential bool,
 	) ([]*QueuePartition, error)
-	PeekGlobalPartitions(
-		ctx context.Context,
-		peekLimit int64,
-		peekUntil time.Time,
-		sequential bool,
-	) ([]*QueuePartition, error)
 }
 
 // ShadowProcessingOperations is the per-shard surface for shadow partition,

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -232,10 +232,6 @@ func (m *mockShardForIterator) PeekAccountPartitions(ctx context.Context, accoun
 	return nil, nil
 }
 
-func (m *mockShardForIterator) PeekGlobalPartitions(ctx context.Context, peekLimit int64, peekUntil time.Time, sequential bool) ([]*QueuePartition, error) {
-	return nil, nil
-}
-
 func (m *mockShardForIterator) BacklogRefillConstraintCheck(ctx context.Context, shadowPart *QueueShadowPartition, backlog *QueueBacklog, constraints PartitionConstraintConfig, items []*QueueItem, operationIdempotencyKey string, now time.Time) (*BacklogRefillConstraintCheckResult, error) {
 	return nil, nil
 }

--- a/pkg/execution/queue/scan.go
+++ b/pkg/execution/queue/scan.go
@@ -226,7 +226,7 @@ func (q *queueProcessor) ScanAccountPartitions(ctx context.Context, accountID uu
 
 // ScanGlobalPartitions scans the partiton of partitions across all fns.
 func (q *queueProcessor) ScanGlobalPartitions(ctx context.Context, peekLimit int64, peekUntil time.Time, metricShardName string, reportPeekedPartitions *int64) error {
-	partitions, err := q.Shard().PeekGlobalPartitions(ctx, peekLimit, peekUntil, q.isSequential())
+	partitions, err := q.Shard().PartitionPeek(ctx, q.isSequential(), peekUntil, peekLimit)
 	if err != nil {
 		return fmt.Errorf("could not peek global partitions: %w", err)
 	}

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -1125,7 +1125,19 @@ func (q *queue) PartitionLease(
 // randomly, with higher priority partitions more likely to be selected.  This reduces
 // lease contention amongst multiple shared-nothing workers.
 func (q *queue) PartitionPeek(ctx context.Context, sequential bool, until time.Time, limit int64) ([]*osqueue.QueuePartition, error) {
-	return q.partitionPeek(ctx, q.RedisClient.kg.GlobalPartitionIndex(), sequential, until, limit, nil)
+	partitionKey := q.RedisClient.kg.GlobalPartitionIndex()
+
+	// Peek 1s into the future to pull jobs off ahead of time, minimizing 0 latency
+	partitions, err := osqueue.DurationWithTags(ctx, q.name, "partition_peek", q.Clock.Now(), func(ctx context.Context) ([]*osqueue.QueuePartition, error) {
+		return q.partitionPeek(ctx, partitionKey, sequential, until, limit, nil)
+	}, map[string]any{
+		"is_global_partition_peek": true,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return partitions, nil
 }
 
 func (q *queue) PartitionSize(ctx context.Context, partitionID string, until time.Time) (int64, error) {

--- a/pkg/execution/state/redis_state/queue_processor.go
+++ b/pkg/execution/state/redis_state/queue_processor.go
@@ -29,24 +29,3 @@ func (q *queue) PeekAccountPartitions(
 
 	return partitions, nil
 }
-
-func (q *queue) PeekGlobalPartitions(
-	ctx context.Context,
-	peekLimit int64,
-	peekUntil time.Time,
-	sequential bool,
-) ([]*osqueue.QueuePartition, error) {
-	partitionKey := q.RedisClient.kg.GlobalPartitionIndex()
-
-	// Peek 1s into the future to pull jobs off ahead of time, minimizing 0 latency
-	partitions, err := osqueue.DurationWithTags(ctx, q.name, "partition_peek", q.Clock.Now(), func(ctx context.Context) ([]*osqueue.QueuePartition, error) {
-		return q.partitionPeek(ctx, partitionKey, sequential, peekUntil, peekLimit, nil)
-	}, map[string]any{
-		"is_global_partition_peek": true,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return partitions, nil
-}

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -1606,7 +1606,7 @@ func TestQueueFunctionPause(t *testing.T) {
 
 	paused = true
 
-	peeked, err := shard.PeekGlobalPartitions(ctx, 100, now.Add(5*time.Minute), true)
+	peeked, err := shard.PartitionPeek(ctx, true, now.Add(5*time.Minute), 100)
 	require.NoError(t, err)
 	require.Len(t, peeked, 0)
 
@@ -1615,7 +1615,7 @@ func TestQueueFunctionPause(t *testing.T) {
 	err = q.UnpauseFunction(ctx, shard.Name(), uuid.Nil, uuid.Nil, idA)
 	require.NoError(t, err)
 
-	peeked, err = shard.PeekGlobalPartitions(ctx, 100, now.Add(5*time.Minute), true)
+	peeked, err = shard.PartitionPeek(ctx, true, now.Add(5*time.Minute), 100)
 	require.NoError(t, err)
 	require.Len(t, peeked, 1)
 	require.Equal(t, idA, *peeked[0].FunctionID)


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
