### PR TITLE
fix(connect): keep worker messages alive on transient gateway errors

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -112,6 +112,8 @@ type connectionHandler struct {
 	// Forward blocks until the ACK arrives or times out.
 	pendingAcks sync.Map // requestID -> chan struct{}
 
+	consecutiveConnStatusUpdateFailures atomic.Int64
+
 	lastHeartbeatLock       sync.Mutex
 	lastHeartbeatReceivedAt time.Time
 

--- a/pkg/connect/gateway_msg_heartbeat.go
+++ b/pkg/connect/gateway_msg_heartbeat.go
@@ -28,8 +28,8 @@ func (c *connectionHandler) handleWorkerHeartbeat() *connecterrors.SocketError {
 		"conn_draining", c.draining.Load(),
 		"svc_draining", c.svc.isDraining.Load(),
 	)
-	if err != nil {
-		c.log.ReportError(err, "failed to update connection status after heartbeat")
+	if serr := c.handleConnStatusUpdateResult(err, "failed to update connection status after heartbeat"); serr != nil {
+		return serr
 	}
 
 	if c.conn.Data.InstanceId == "" {

--- a/pkg/connect/gateway_msg_heartbeat.go
+++ b/pkg/connect/gateway_msg_heartbeat.go
@@ -30,13 +30,6 @@ func (c *connectionHandler) handleWorkerHeartbeat() *connecterrors.SocketError {
 	)
 	if err != nil {
 		c.log.ReportError(err, "failed to update connection status after heartbeat")
-
-		// TODO Should we actually close the connection here?
-		return &connecterrors.SocketError{
-			SysCode:    syscode.CodeConnectInternal,
-			StatusCode: websocket.StatusInternalError,
-			Msg:        "could not update connection status",
-		}
 	}
 
 	if c.conn.Data.InstanceId == "" {

--- a/pkg/connect/gateway_msg_heartbeat_test.go
+++ b/pkg/connect/gateway_msg_heartbeat_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/websocket"
 	"github.com/inngest/inngest/pkg/connect/state"
+	"github.com/inngest/inngest/pkg/syscode"
 	connectpb "github.com/inngest/inngest/proto/gen/connect/v1"
 	"github.com/stretchr/testify/require"
 )
@@ -44,7 +46,7 @@ func TestHandleWorkerHeartbeatKeepsDrainingStatus(t *testing.T) {
 	})
 }
 
-func TestHandleWorkerHeartbeatStatusUpdateFailureWritesGatewayHeartbeat(t *testing.T) {
+func TestHandleWorkerHeartbeatStatusUpdateFailureWritesGatewayHeartbeatUntilThreshold(t *testing.T) {
 	res := createTestingGateway(t)
 	handshake(t, res)
 
@@ -53,7 +55,14 @@ func TestHandleWorkerHeartbeatStatusUpdateFailureWritesGatewayHeartbeat(t *testi
 		err:          errors.New("upsert connection failed"),
 	}
 
-	exchangeHeartbeat(t, res.ws, 2*time.Second)
+	for range maxConsecutiveConnStatusUpdateFailures - 1 {
+		exchangeHeartbeat(t, res.ws, 2*time.Second)
+	}
+
+	sendWorkerHeartbeatMessage(t, res.ws)
+	status, reason := awaitClosure(t, res.ws, 2*time.Second)
+	require.Equal(t, websocket.StatusInternalError, status)
+	require.Equal(t, syscode.CodeConnectInternal, reason)
 }
 
 func TestHandleWorkerHeartbeatMissingInstanceIDIsFatal(t *testing.T) {

--- a/pkg/connect/gateway_msg_heartbeat_test.go
+++ b/pkg/connect/gateway_msg_heartbeat_test.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -41,6 +42,18 @@ func TestHandleWorkerHeartbeatKeepsDrainingStatus(t *testing.T) {
 		onHeartbeatCount:     1,
 		onStartDrainingCount: 1,
 	})
+}
+
+func TestHandleWorkerHeartbeatStatusUpdateFailureWritesGatewayHeartbeat(t *testing.T) {
+	res := createTestingGateway(t)
+	handshake(t, res)
+
+	res.svc.stateManager = upsertConnectionErrorStateManager{
+		StateManager: res.svc.stateManager,
+		err:          errors.New("upsert connection failed"),
+	}
+
+	exchangeHeartbeat(t, res.ws, 2*time.Second)
 }
 
 func TestHandleWorkerHeartbeatMissingInstanceIDIsFatal(t *testing.T) {

--- a/pkg/connect/gateway_msg_ready.go
+++ b/pkg/connect/gateway_msg_ready.go
@@ -33,12 +33,8 @@ func (c *connectionHandler) handleWorkerReady() *connecterrors.SocketError {
 
 	err := c.updateConnStatus(connectpb.ConnectionStatus_READY, "worker ready message")
 	if err != nil {
-		// TODO Should we actually close the connection here?
-		return &connecterrors.SocketError{
-			SysCode:    syscode.CodeConnectInternal,
-			StatusCode: websocket.StatusInternalError,
-			Msg:        "could not update connection status",
-		}
+		c.log.ReportError(err, "failed to update connection status after worker ready")
+		return nil
 	}
 
 	if c.conn.Data.InstanceId == "" {

--- a/pkg/connect/gateway_msg_ready.go
+++ b/pkg/connect/gateway_msg_ready.go
@@ -32,9 +32,8 @@ func (c *connectionHandler) handleWorkerReady() *connecterrors.SocketError {
 	}
 
 	err := c.updateConnStatus(connectpb.ConnectionStatus_READY, "worker ready message")
-	if err != nil {
-		c.log.ReportError(err, "failed to update connection status after worker ready")
-		return nil
+	if serr := c.handleConnStatusUpdateResult(err, "failed to update connection status after worker ready"); serr != nil {
+		return serr
 	}
 
 	if c.conn.Data.InstanceId == "" {

--- a/pkg/connect/gateway_msg_ready_test.go
+++ b/pkg/connect/gateway_msg_ready_test.go
@@ -1,6 +1,7 @@
 package connect
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/inngest/inngest/pkg/connect/state"
@@ -49,6 +50,21 @@ func TestHandleWorkerReadyIgnoresDrainingConnection(t *testing.T) {
 	conn, err := res.stateManager.GetConnection(t.Context(), res.envID, res.connID)
 	require.NoError(t, err)
 	require.Equal(t, connectpb.ConnectionStatus_READY, conn.Status)
+}
+
+func TestHandleWorkerReadyStatusUpdateFailureIsNonFatal(t *testing.T) {
+	res := createTestingGateway(t)
+	handshake(t, res)
+
+	res.svc.stateManager = upsertConnectionErrorStateManager{
+		StateManager: res.svc.stateManager,
+		err:          errors.New("upsert connection failed"),
+	}
+
+	ch := newTestConnectionHandler(t, res)
+
+	serr := ch.handleWorkerReady()
+	require.Nil(t, serr)
 }
 
 func TestHandleWorkerReadyMissingInstanceIDIsFatal(t *testing.T) {

--- a/pkg/connect/gateway_msg_ready_test.go
+++ b/pkg/connect/gateway_msg_ready_test.go
@@ -52,7 +52,7 @@ func TestHandleWorkerReadyIgnoresDrainingConnection(t *testing.T) {
 	require.Equal(t, connectpb.ConnectionStatus_READY, conn.Status)
 }
 
-func TestHandleWorkerReadyStatusUpdateFailureIsNonFatal(t *testing.T) {
+func TestHandleWorkerReadyStatusUpdateFailureIsNonFatalUntilThreshold(t *testing.T) {
 	res := createTestingGateway(t)
 	handshake(t, res)
 
@@ -63,8 +63,15 @@ func TestHandleWorkerReadyStatusUpdateFailureIsNonFatal(t *testing.T) {
 
 	ch := newTestConnectionHandler(t, res)
 
+	for range maxConsecutiveConnStatusUpdateFailures - 1 {
+		serr := ch.handleWorkerReady()
+		require.Nil(t, serr)
+	}
+
 	serr := ch.handleWorkerReady()
-	require.Nil(t, serr)
+	require.NotNil(t, serr)
+	require.Equal(t, syscode.CodeConnectInternal, serr.SysCode)
+	require.Contains(t, serr.Msg, "could not update connection status")
 }
 
 func TestHandleWorkerReadyMissingInstanceIDIsFatal(t *testing.T) {

--- a/pkg/connect/gateway_msg_request_ack.go
+++ b/pkg/connect/gateway_msg_request_ack.go
@@ -2,14 +2,19 @@ package connect
 
 import (
 	"context"
+	"errors"
+	"time"
 
 	"github.com/coder/websocket"
 	connecterrors "github.com/inngest/inngest/pkg/connect/errors"
+	"github.com/inngest/inngest/pkg/connect/state"
 	"github.com/inngest/inngest/pkg/syscode"
 	connectpb "github.com/inngest/inngest/proto/gen/connect/v1"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+const workerRequestAckNotifyTimeout = 2 * time.Second
 
 func (c *connectionHandler) handleWorkerRequestAck(msg *connectpb.ConnectMessage) *connecterrors.SocketError {
 	var data connectpb.WorkerRequestAckData
@@ -34,41 +39,38 @@ func (c *connectionHandler) handleWorkerRequestAck(msg *connectpb.ConnectMessage
 		)
 	}
 
-	// This will be sent exactly once, as the router selected this gateway to
-	// handle the request. Even if the gateway is draining, we should ack the
-	// message; the SDK will buffer messages and use a new connection for
-	// results.
-	grpcClient, err := c.svc.getOrCreateGRPCClient(context.Background(), c.conn.EnvID, data.RequestId)
-	if err != nil {
-		return &connecterrors.SocketError{
-			SysCode:    syscode.CodeConnectInternal,
-			StatusCode: websocket.StatusInternalError,
-			Msg:        "could not create grpc client to ack",
-		}
-	}
+	notifyCtx, notifyCancel := context.WithTimeout(context.Background(), workerRequestAckNotifyTimeout)
+	defer notifyCancel()
 
-	reply, err := grpcClient.Ack(context.Background(), &connectpb.AckMessage{
-		RequestId: data.RequestId,
-		Ts:        timestamppb.Now(),
-	})
-	if err != nil {
-		// This should never happen: Failing the ack means we will redeliver
-		// the same request even though the worker already started processing it.
-		c.log.ReportError(err, "failed to ack message through gRPC")
-		return &connecterrors.SocketError{
-			SysCode:    syscode.CodeConnectInternal,
-			StatusCode: websocket.StatusInternalError,
-			Msg:        "could not ack message through gRPC",
-		}
-	}
-	if !reply.Success {
-		c.log.Warn("failed to ack, executor was likely done with the request")
-	}
-	c.log.Trace("worker acked message",
+	l := c.log.With(
 		"req_id", data.RequestId,
 		"run_id", data.RunId,
 		"transport", "grpc",
 	)
+
+	grpcClient, err := c.svc.getOrCreateGRPCClient(notifyCtx, c.conn.EnvID, data.RequestId)
+	switch {
+	case err == nil:
+	case errors.Is(err, state.ErrExecutorNotFound):
+		l.Debug("executor not found in lease, worker ack was likely picked up by polling")
+		return nil
+	default:
+		l.Warn("could not create grpc client to ack, executor will rely on timeout or polling", "err", err)
+		return nil
+	}
+
+	reply, err := grpcClient.Ack(notifyCtx, &connectpb.AckMessage{
+		RequestId: data.RequestId,
+		Ts:        timestamppb.Now(),
+	})
+	if err != nil {
+		l.Warn("could not ack message through gRPC, executor will rely on timeout or polling", "err", err)
+		return nil
+	}
+	if reply == nil || !reply.Success {
+		l.Warn("failed to ack, executor was likely done with the request")
+	}
+	l.Trace("worker acked message")
 
 	// TODO Should we send a reverse ack to the worker to start processing the request?
 	return nil

--- a/pkg/connect/gateway_msg_request_ack_test.go
+++ b/pkg/connect/gateway_msg_request_ack_test.go
@@ -31,7 +31,7 @@ func TestHandleWorkerRequestAckInvalidPayloadIsFatal(t *testing.T) {
 	require.Equal(t, syscode.CodeConnectWorkerRequestAckInvalidPayload, serr.SysCode)
 }
 
-func TestHandleWorkerRequestAckMissingExecutorLeaseIsFatalAfterPendingAck(t *testing.T) {
+func TestHandleWorkerRequestAckMissingExecutorLeaseIsNonFatalAfterPendingAck(t *testing.T) {
 	res := createTestingGateway(t)
 	handshake(t, res)
 
@@ -41,9 +41,7 @@ func TestHandleWorkerRequestAckMissingExecutorLeaseIsFatalAfterPendingAck(t *tes
 	ch.pendingAcks.Store(requestID, ackCh)
 
 	serr := ch.handleWorkerRequestAck(workerRequestAckMessage(t, res, requestID))
-	require.NotNil(t, serr)
-	require.Equal(t, syscode.CodeConnectInternal, serr.SysCode)
-	require.Contains(t, serr.Msg, "could not create grpc client to ack")
+	require.Nil(t, serr)
 
 	select {
 	case <-ackCh:
@@ -78,7 +76,7 @@ func TestHandleWorkerRequestAckNotifiesExecutor(t *testing.T) {
 	}
 }
 
-func TestHandleWorkerRequestAckRPCFailureIsFatal(t *testing.T) {
+func TestHandleWorkerRequestAckRPCFailureIsNonFatal(t *testing.T) {
 	res := createTestingGateway(t)
 	handshake(t, res)
 
@@ -95,9 +93,7 @@ func TestHandleWorkerRequestAckRPCFailureIsFatal(t *testing.T) {
 	ch := newTestConnectionHandler(t, res)
 
 	serr := ch.handleWorkerRequestAck(workerRequestAckMessage(t, res, requestID))
-	require.NotNil(t, serr)
-	require.Equal(t, syscode.CodeConnectInternal, serr.SysCode)
-	require.Contains(t, serr.Msg, "could not ack message through gRPC")
+	require.Nil(t, serr)
 }
 
 func TestHandleWorkerRequestAckExecutorDoneIsNonFatal(t *testing.T) {

--- a/pkg/connect/gateway_msg_status_update.go
+++ b/pkg/connect/gateway_msg_status_update.go
@@ -1,0 +1,32 @@
+package connect
+
+import (
+	"github.com/coder/websocket"
+	connecterrors "github.com/inngest/inngest/pkg/connect/errors"
+	"github.com/inngest/inngest/pkg/syscode"
+)
+
+const maxConsecutiveConnStatusUpdateFailures = 3
+
+func (c *connectionHandler) handleConnStatusUpdateResult(err error, reportMsg string) *connecterrors.SocketError {
+	if err == nil {
+		c.consecutiveConnStatusUpdateFailures.Store(0)
+		return nil
+	}
+
+	failures := c.consecutiveConnStatusUpdateFailures.Add(1)
+	c.log.With(
+		"consecutive_failures", failures,
+		"max_consecutive_failures", maxConsecutiveConnStatusUpdateFailures,
+	).ReportError(err, reportMsg)
+
+	if failures < maxConsecutiveConnStatusUpdateFailures {
+		return nil
+	}
+
+	return &connecterrors.SocketError{
+		SysCode:    syscode.CodeConnectInternal,
+		StatusCode: websocket.StatusInternalError,
+		Msg:        "could not update connection status",
+	}
+}

--- a/pkg/connect/gateway_msg_status_update_test.go
+++ b/pkg/connect/gateway_msg_status_update_test.go
@@ -1,0 +1,59 @@
+package connect
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/coder/websocket"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/syscode"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleConnStatusUpdateResultNilErrorResetsFailureCount(t *testing.T) {
+	ch := &connectionHandler{
+		log: logger.StdlibLogger(t.Context(), logger.WithLoggerLevel(logger.LevelEmergency)),
+	}
+	ch.consecutiveConnStatusUpdateFailures.Store(maxConsecutiveConnStatusUpdateFailures - 1)
+
+	serr := ch.handleConnStatusUpdateResult(nil, "status update")
+	require.Nil(t, serr)
+	require.Zero(t, ch.consecutiveConnStatusUpdateFailures.Load())
+}
+
+func TestHandleConnStatusUpdateResultFailsAfterThreshold(t *testing.T) {
+	ch := &connectionHandler{
+		log: logger.StdlibLogger(t.Context(), logger.WithLoggerLevel(logger.LevelEmergency)),
+	}
+
+	for range maxConsecutiveConnStatusUpdateFailures - 1 {
+		serr := ch.handleConnStatusUpdateResult(errors.New("upsert connection failed"), "status update")
+		require.Nil(t, serr)
+	}
+
+	serr := ch.handleConnStatusUpdateResult(errors.New("upsert connection failed"), "status update")
+	require.NotNil(t, serr)
+	require.Equal(t, syscode.CodeConnectInternal, serr.SysCode)
+	require.Equal(t, websocket.StatusInternalError, serr.StatusCode)
+	require.Contains(t, serr.Msg, "could not update connection status")
+	require.EqualValues(t, maxConsecutiveConnStatusUpdateFailures, ch.consecutiveConnStatusUpdateFailures.Load())
+}
+
+func TestHandleConnStatusUpdateResultSuccessBreaksFailureStreak(t *testing.T) {
+	ch := &connectionHandler{
+		log: logger.StdlibLogger(t.Context(), logger.WithLoggerLevel(logger.LevelEmergency)),
+	}
+
+	for range maxConsecutiveConnStatusUpdateFailures - 1 {
+		serr := ch.handleConnStatusUpdateResult(errors.New("upsert connection failed"), "status update")
+		require.Nil(t, serr)
+	}
+
+	serr := ch.handleConnStatusUpdateResult(nil, "status update")
+	require.Nil(t, serr)
+
+	for range maxConsecutiveConnStatusUpdateFailures - 1 {
+		serr = ch.handleConnStatusUpdateResult(errors.New("upsert connection failed"), "status update")
+		require.Nil(t, serr)
+	}
+}

--- a/pkg/connect/gateway_msg_test_helpers_test.go
+++ b/pkg/connect/gateway_msg_test_helpers_test.go
@@ -1,9 +1,12 @@
 package connect
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/inngest/inngest/pkg/connect/state"
+	connectpb "github.com/inngest/inngest/proto/gen/connect/v1"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,4 +35,13 @@ func newTestConnectionHandler(t *testing.T, res testingResources) *connectionHan
 		log:            res.svc.logger,
 		stopForwarding: make(chan struct{}),
 	}
+}
+
+type upsertConnectionErrorStateManager struct {
+	state.StateManager
+	err error
+}
+
+func (m upsertConnectionErrorStateManager) UpsertConnection(ctx context.Context, conn *state.Connection, status connectpb.ConnectionStatus, lastHeartbeatAt time.Time) error {
+	return m.err
 }


### PR DESCRIPTION
## Description

Fixes Connect gateway failure mode where transient gateway-side errors in worker message handling could close otherwise healthy worker WebSockets.

- Treat WORKER_REQUEST_ACK executor notification as best-effort after the gateway-local pending ack is closed.
- Use a bounded context for executor ACK notification and keep missing executor leases, gRPC client creation failures, ACK RPC failures, and Success=false replies nonfatal.
- Keep transient WORKER_READY and WORKER_HEARTBEAT status update failures nonfatal.
- Track connection-status update failures per connection and close with connect_internal_error after 3 consecutive failures, resetting the counter on the next successful status update.
- Preserve fatal handling for invalid worker payloads and missing instance IDs.

### Validation

- go test ./pkg/connect -run TestHandleConnStatusUpdateResult -count=1 -timeout=60s
- go test ./pkg/connect -run 'TestHandleWorkerRequestAckMissingExecutorLeaseIsNonFatalAfterPendingAck|TestHandleWorkerRequestAckRPCFailureIsNonFatal|TestHandleWorkerReadyStatusUpdateFailureIsNonFatal|TestHandleWorkerHeartbeatStatusUpdateFailureWritesGatewayHeartbeat' -count=1 -timeout=90s
- go test ./pkg/connect -run 'TestHandleWorkerReadyStatusUpdateFailureIsNonFatalUntilThreshold|TestHandleWorkerHeartbeatStatusUpdateFailureWritesGatewayHeartbeatUntilThreshold' -count=1 -timeout=90s
- go test ./pkg/connect -count=1 -timeout=120s
- make lint

## Release note

Fix Connect workers being disconnected by transient gateway/executor notification failures, while still closing workers after repeated connection-status persistence failures.

## Migration note

None.