### PR TITLE
fix: enforce step state limit & total state size for checkpointing

### DIFF
--- a/pkg/api/apiv1/checkpoint.go
+++ b/pkg/api/apiv1/checkpoint.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"errors"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/api/apiv1/apiv1auth"
@@ -22,6 +23,7 @@ import (
 	"github.com/inngest/inngest/pkg/execution/executor"
 	"github.com/inngest/inngest/pkg/execution/realtime"
 	"github.com/inngest/inngest/pkg/execution/realtime/streamingtypes"
+
 	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/publicerr"
@@ -325,7 +327,16 @@ func (a checkpointAPI) CheckpointSteps(w http.ResponseWriter, r *http.Request) {
 		Steps:     input.Steps,
 	})
 	if err != nil {
-		logger.StdlibLogger(ctx).Error("error checkpointing sync steps", "error", err)
+		if errors.Is(err, state.ErrStepOutputTooLarge) || errors.Is(err, state.ErrStateOverflowed) {
+			logger.StdlibLogger(ctx).Error("sync checkpoint skipped: step output too large",
+				"run_id", input.RunID,
+				"fn_id", input.FnID,
+				"step_count", len(input.Steps),
+				"error", err,
+			)
+		} else {
+			logger.StdlibLogger(ctx).Error("error checkpointing sync steps", "error", err)
+		}
 	}
 }
 
@@ -365,13 +376,24 @@ func (a checkpointAPI) CheckpointAsyncSteps(w http.ResponseWriter, r *http.Reque
 		EnvID:        auth.WorkspaceID(),
 	})
 	if err != nil {
-		logger.StdlibLogger(ctx).Error("error checkpointing async steps", "error", err)
+		status := http.StatusBadRequest
+		if errors.Is(err, state.ErrStepOutputTooLarge) || errors.Is(err, state.ErrStateOverflowed) {
+			logger.StdlibLogger(ctx).Error("async checkpoint rejected",
+				"run_id", input.RunID,
+				"fn_id", input.FnID,
+				"step_count", len(input.Steps),
+				"error", err,
+			)
+			status = http.StatusRequestEntityTooLarge
+		} else {
+			logger.StdlibLogger(ctx).Error("error checkpointing async steps", "error", err)
+		}
 		_ = publicerr.WriteHTTP(w, publicerr.Error{
-			Message: "Failed to checkpoint steps",
+			Message: err.Error(),
 			Data: map[string]any{
 				"run_id": input.RunID,
 			},
-			Status: 400,
+			Status: status,
 		})
 	}
 }

--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/backoff"
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution"
@@ -173,6 +174,12 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 		}
 	}
 
+	if !complete {
+		if input.Metadata.Metrics.StateSize+stepOutputSize(ordered) > consts.DefaultMaxStateSizeLimit {
+			return fmt.Errorf("run state size limit exceeded: %w", sv1.ErrStateOverflowed)
+		}
+	}
+
 	for _, op := range ordered {
 		attrs := tracing.GeneratorAttrs(&op)
 		tracing.AddMetadataTenantAttrs(attrs, input.Metadata.ID)
@@ -185,6 +192,10 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 			output, err := op.Output()
 			if err != nil {
 				l.Error("error fetching checkpoint step output", "error", err)
+			}
+
+			if len(output) > consts.MaxStepOutputSize {
+				return fmt.Errorf("step %s output too large: %w", op.ID, sv1.ErrStepOutputTooLarge)
 			}
 
 			if !complete {
@@ -461,6 +472,10 @@ func (c checkpointer) checkpointAsyncSteps(ctx context.Context, input AsyncCheck
 		return fmt.Errorf("cannot checkpoint async steps")
 	}
 
+	if md.Metrics.StateSize+stepOutputSize(input.Steps) > consts.DefaultMaxStateSizeLimit {
+		return fmt.Errorf("run state size limit exceeded: %w", sv1.ErrStateOverflowed)
+	}
+
 	for _, op := range input.Steps {
 		attrs := tracing.GeneratorAttrs(&op)
 		tracing.AddMetadataTenantAttrs(attrs, md.ID)
@@ -472,6 +487,10 @@ func (c checkpointer) checkpointAsyncSteps(ctx context.Context, input AsyncCheck
 			output, err := op.Output()
 			if err != nil {
 				l.Error("error fetching checkpoint step output", "error", err)
+			}
+
+			if len(output) > consts.MaxStepOutputSize {
+				return fmt.Errorf("step %s output too large: %w", op.ID, sv1.ErrStepOutputTooLarge)
 			}
 
 			_, err = c.State.SaveStep(ctx, md.ID, op.ID, []byte(output))
@@ -561,6 +580,19 @@ func (c checkpointer) checkpointAsyncSteps(ctx context.Context, input AsyncCheck
 	}
 
 	return nil
+}
+
+// stepOutputSize returns the total byte size of all StepRun/Step outputs in ops.
+func stepOutputSize(ops []state.GeneratorOpcode) int {
+	total := 0
+	for _, op := range ops {
+		if op.Op == enums.OpcodeStepRun || op.Op == enums.OpcodeStep {
+			if out, err := op.Output(); err == nil {
+				total += len(out)
+			}
+		}
+	}
+	return total
 }
 
 func (c checkpointer) runContext(md state.Metadata, fn *inngest.Function) execution.RunContext {

--- a/pkg/execution/checkpoint/checkpoint_async_test.go
+++ b/pkg/execution/checkpoint/checkpoint_async_test.go
@@ -4,14 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/executor"
 	"github.com/inngest/inngest/pkg/execution/executor/queueref"
 	"github.com/inngest/inngest/pkg/execution/queue"
+	sv1 "github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/tracing"
 	"github.com/inngest/inngest/pkg/tracing/meta"
@@ -258,6 +261,88 @@ func TestCheckpointAsyncSteps(t *testing.T) {
 		mocks.state.AssertExpectations(t)
 		mocks.tracer.AssertExpectations(t)
 		mocks.queue.AssertExpectations(t)
+	})
+
+	t.Run("step output too large", func(t *testing.T) {
+		// A single step whose output exceeds MaxStepOutputSize causes
+		// CheckpointAsyncSteps to return ErrStepOutputTooLarge without
+		// attempting to save state.
+		ctx := context.Background()
+		require := require.New(t)
+
+		// A JSON string of MaxStepOutputSize 'x' characters: when wrapped in
+		// {"data": ...} the total output exceeds the 4 MiB per-step limit.
+		largeData := json.RawMessage(`"` + strings.Repeat("x", consts.MaxStepOutputSize) + `"`)
+		op := state.GeneratorOpcode{
+			ID:   "big-step",
+			Op:   enums.OpcodeStepRun,
+			Data: largeData,
+			Name: "Big Step",
+		}
+
+		_, testData := setupAsyncCheckpointTest(t, op)
+
+		err := testData.checkpointer.CheckpointAsyncSteps(ctx, testData.asyncCheckpoint)
+		require.ErrorIs(err, sv1.ErrStepOutputTooLarge)
+	})
+
+	t.Run("cumulative state overflow", func(t *testing.T) {
+		// When accumulated state already equals the 32 MiB limit, any
+		// additional step output causes CheckpointAsyncSteps to return
+		// ErrStateOverflowed before saving state.
+		ctx := context.Background()
+		require := require.New(t)
+
+		runID := ulid.MustNew(ulid.Now(), nil)
+		fnID := uuid.New()
+		accountID := uuid.New()
+		envID := uuid.New()
+
+		md := state.Metadata{
+			ID: state.ID{
+				RunID:      runID,
+				FunctionID: fnID,
+				Tenant: state.Tenant{
+					AccountID: accountID,
+					EnvID:     envID,
+				},
+			},
+			Metrics: state.RunMetrics{
+				StateSize: consts.DefaultMaxStateSizeLimit,
+			},
+		}
+
+		op := state.GeneratorOpcode{
+			ID:   "step-1",
+			Op:   enums.OpcodeStepRun,
+			Data: json.RawMessage(`"small"`),
+			Name: "Step 1",
+		}
+
+		qRef := queueref.QueueRef{"job-x", "shard-x"}
+		asyncCheckpoint := AsyncCheckpoint{
+			RunID:        runID,
+			FnID:         fnID,
+			Steps:        []state.GeneratorOpcode{op},
+			QueueItemRef: qRef.String(),
+			AccountID:    accountID,
+			EnvID:        envID,
+		}
+
+		stateMock := &mockRunService{}
+		stateMock.On("LoadMetadata", ctx, asyncCheckpoint.ID()).Return(md, nil)
+
+		checkpointer := New(Opts{
+			State:           stateMock,
+			TracerProvider:  &mockTracerProvider{},
+			Queue:           &mockQueue{},
+			MetricsProvider: &mockMetricsProvider{},
+		})
+
+		err := checkpointer.CheckpointAsyncSteps(ctx, asyncCheckpoint)
+		require.ErrorIs(err, sv1.ErrStateOverflowed)
+
+		stateMock.AssertNotCalled(t, "SaveStep")
 	})
 }
 

--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -9,12 +9,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/apiresult"
 	"github.com/inngest/inngest/pkg/execution/executor"
 	"github.com/inngest/inngest/pkg/execution/queue"
+	sv1 "github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
@@ -451,6 +453,50 @@ func TestCheckpointSyncSteps(t *testing.T) {
 		mocks.tracer.AssertExpectations(t)
 		mocks.queue.AssertExpectations(t)
 		mocks.executor.AssertExpectations(t)
+	})
+
+	t.Run("step output too large", func(t *testing.T) {
+		// A single step whose output exceeds MaxStepOutputSize causes
+		// CheckpointSyncSteps to return ErrStepOutputTooLarge without
+		// attempting to save state.
+		ctx := context.Background()
+		require := require.New(t)
+
+		// A JSON string of MaxStepOutputSize 'x' characters: when wrapped in
+		// {"data": ...} the total output exceeds the 4 MiB per-step limit.
+		largeData := json.RawMessage(`"` + strings.Repeat("x", consts.MaxStepOutputSize) + `"`)
+		op := state.GeneratorOpcode{
+			ID:   "big-step",
+			Op:   enums.OpcodeStepRun,
+			Data: largeData,
+			Name: "Big Step",
+		}
+
+		_, testData := setupSyncCheckpointTest(t, op)
+
+		err := testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
+		require.ErrorIs(err, sv1.ErrStepOutputTooLarge)
+	})
+
+	t.Run("cumulative state overflow", func(t *testing.T) {
+		// When accumulated state already equals the 32 MiB limit, any
+		// additional step output causes CheckpointSyncSteps to return
+		// ErrStateOverflowed before saving state.
+		ctx := context.Background()
+		require := require.New(t)
+
+		op := state.GeneratorOpcode{
+			ID:   "step-1",
+			Op:   enums.OpcodeStepRun,
+			Data: json.RawMessage(`"small"`),
+			Name: "Step 1",
+		}
+
+		_, testData := setupSyncCheckpointTest(t, op)
+		testData.syncCheckpoint.Metadata.Metrics.StateSize = consts.DefaultMaxStateSizeLimit
+
+		err := testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
+		require.ErrorIs(err, sv1.ErrStateOverflowed)
 	})
 }
 


### PR DESCRIPTION
## Description
App wasn't enforcing the state limits on checkpointing and it was only
working fine because the of the state proxy fallback mechanism which i'm
getting rid of next so we need to handle this correctly now.

Normal checkpointing now returns an HTTP error
StatusRequestEntityTooLarge, SDK might retry a few times and we might
want to to remove the retry in this case but eventually it'll go into
normal mode which will catch the same error again and force finalize the
run.

For Durable endpoints we currently swallow the error and log, it
won't break or fail runs but these step outputs will fail to be
persisted on our end.


<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
Fixed a bug where checkpointing wasn't enforcing state size limits

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
