### PR TITLE
fix(pauses): dedup evaluables fix upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/graph-gophers/dataloader v5.0.0+incompatible
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/inngest/expr v0.0.0-20260513185122-19a13103520a
+	github.com/inngest/expr v0.0.0-20260516032105-f2cf85864a0e
 	github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48
 	github.com/inngest/inngestgo v0.15.2-0.20260508201256-daaf24a3ed44
 	github.com/jackc/pgx/v5 v5.9.1

--- a/go.sum
+++ b/go.sum
@@ -600,8 +600,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/inngest/expr v0.0.0-20260513185122-19a13103520a h1:U9hCeCPX3ZwKsRD65p7o2Ph4YrVHd5v6B3DgataHCHQ=
-github.com/inngest/expr v0.0.0-20260513185122-19a13103520a/go.mod h1:fwLYQ2NlzdevRRQoldvMrMvCicAG6X3NaONAtxuiT8k=
+github.com/inngest/expr v0.0.0-20260516032105-f2cf85864a0e h1:zwuRYiHt8izk/iV4IiWKQV1kfaD8Fx/mZecAMZgkUWk=
+github.com/inngest/expr v0.0.0-20260516032105-f2cf85864a0e/go.mod h1:fwLYQ2NlzdevRRQoldvMrMvCicAG6X3NaONAtxuiT8k=
 github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48 h1:8NwXUrQTQjWrfGj99JgesfTbCYujtnLHusePp7YyFU8=
 github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48/go.mod h1:7SNLkGaD+tiTey1IF9WUNDNurTfqNZqjbdPZo3CmLW4=
 github.com/inngest/inngestgo v0.15.2-0.20260508201256-daaf24a3ed44 h1:5WhrkV16dtJzsBbOAu6eVDbUqck2hieIhJRKl4dxEJ0=

--- a/vendor/github.com/inngest/expr/expr.go
+++ b/vendor/github.com/inngest/expr/expr.go
@@ -514,6 +514,11 @@ func (a *aggregator[T]) Add(ctx context.Context, eval T) (float64, error) {
 		return -1, err
 	}
 
+	// deduplicate evaluables, as engines do not expect duplicates and will cause false positives
+	if _, err := a.kv.Get(parsed.EvaluableID); err == nil {
+		return 0, nil
+	}
+
 	if err := a.kv.Set(eval); err != nil {
 		return -1, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -780,7 +780,7 @@ github.com/hashicorp/hcl/hcl/token
 github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/inngest/expr v0.0.0-20260513185122-19a13103520a
+# github.com/inngest/expr v0.0.0-20260516032105-f2cf85864a0e
 ## explicit; go 1.24
 github.com/inngest/expr
 # github.com/inngest/go-httpstat v0.0.0-20250328150054-dfda91359d48


### PR DESCRIPTION
## Description
vendors https://github.com/inngest/expr/pull/51 which dedupes evaluables to avoid false positives returned by aggregators. This is not a correctness concern but a performance one since we have to evaluate more CEL expressions every time aggregators leak duplicates.

<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
