### PR TITLE
test(connect): forward regression test

### DIFF
--- a/docs/plans/003-connect-gateway-lifecycle-controller.org
+++ b/docs/plans/003-connect-gateway-lifecycle-controller.org
@@ -426,20 +426,37 @@ changes.
 
 Purpose: capture the behavior we rely on before moving lifecycle code.
 
+Intentionally preserved baseline behavior:
+
+- =WORKER_REQUEST_ACK= uses Option A: a parsed worker ACK releases
+  =pendingAcks= before best-effort executor gRPC =Ack= notification.
+- Unknown request ACKs and post-worker-ACK executor notification failures are
+  non-fatal to the worker websocket.
+- =WORKER_REPLY= persistence is the durable boundary. After
+  =SaveResponse= succeeds, executor gRPC =Reply= failure and
+  =WORKER_REPLY_ACK= write failure are non-fatal because the executor can poll
+  the buffered response.
+- Worker heartbeats during drain still receive =GATEWAY_HEARTBEAT=, but Redis
+  connection status remains =DRAINING=.
+- =WORKER_PAUSE= during gateway drain is accepted and removes the connection
+  from in-memory routing.
+- New =Forward= calls during gateway drain block or reject with
+  =Success=false= instead of writing a new =GATEWAY_EXECUTOR_REQUEST=.
+
 *** Implementation checklist
 
-- [ ] Keep the SYS-856 =handleSdkReply= regressions:
-  - [ ] persisted response plus gRPC =Reply= failure is non-fatal;
+- [X] Keep the SYS-856 =handleSdkReply= regressions:
+  - [X] persisted response plus gRPC =Reply= failure is non-fatal;
   - [X] persisted response plus =WORKER_REPLY_ACK= write failure is non-fatal.
 - [X] Add coverage for =WORKER_REQUEST_ACK= ordering:
   - [X] worker ACK received for a known request;
   - [X] =pendingAcks= waiter behavior is explicit;
   - [X] executor gRPC =Ack= failure behavior is explicit.
-- [ ] Add coverage for drain and forwarding:
-  - [ ] gateway drain blocks or rejects new =Forward= calls;
+- [X] Add coverage for drain and forwarding:
+  - [X] gateway drain blocks or rejects new =Forward= calls;
   - [X] worker pause removes =wsConnections= and stops forwarding;
   - [X] heartbeat during drain cannot mark connection =READY=.
-- [ ] Document any behavior that is intentionally preserved even if awkward.
+- [X] Document any behavior that is intentionally preserved even if awkward.
 
 *** Validation checklist
 
@@ -447,9 +464,9 @@ Purpose: capture the behavior we rely on before moving lifecycle code.
 
 *** Exit criteria
 
-- [ ] Tests fail for the current ambiguous =WORKER_REQUEST_ACK= behavior if the
+- [X] Tests fail for the current ambiguous =WORKER_REQUEST_ACK= behavior if the
   chosen policy is not implemented.
-- [ ] Drain and reply behavior can be refactored without relying on real socket
+- [X] Drain and reply behavior can be refactored without relying on real socket
   races.
 
 ** Phase 1: Add gateway connection phases without behavior changes

--- a/docs/plans/003-connect-gateway-lifecycle-controller.org
+++ b/docs/plans/003-connect-gateway-lifecycle-controller.org
@@ -1,7 +1,7 @@
 #+TITLE: Connect Gateway Lifecycle Controller
 #+AUTHOR: Darwin D. Wu
 #+DATE: 2026-05-08
-#+STATUS: Draft
+#+STATUS: Active
 #+STARTUP: showall
 
 * Overview
@@ -264,6 +264,11 @@ is intentional, executor ACK failures should likely be downgraded from
 =connect_internal_error=. If it is not intentional, the ordering should be fixed
 and covered by tests.
 
+Current decision: use Option A. A parsed =WORKER_REQUEST_ACK= for a known
+request accepts worker delivery and releases the local =pendingAcks= waiter
+before best-effort executor gRPC =Ack= notification. Executor notification
+failures are request-level warnings and must not close the worker websocket.
+
 ** Option A: worker ACK acceptance is enough
 
 #+BEGIN_SRC mermaid
@@ -425,20 +430,20 @@ Purpose: capture the behavior we rely on before moving lifecycle code.
 
 - [ ] Keep the SYS-856 =handleSdkReply= regressions:
   - [ ] persisted response plus gRPC =Reply= failure is non-fatal;
-  - [ ] persisted response plus =WORKER_REPLY_ACK= write failure is non-fatal.
-- [ ] Add coverage for =WORKER_REQUEST_ACK= ordering:
-  - [ ] worker ACK received for a known request;
-  - [ ] =pendingAcks= waiter behavior is explicit;
-  - [ ] executor gRPC =Ack= failure behavior is explicit.
+  - [X] persisted response plus =WORKER_REPLY_ACK= write failure is non-fatal.
+- [X] Add coverage for =WORKER_REQUEST_ACK= ordering:
+  - [X] worker ACK received for a known request;
+  - [X] =pendingAcks= waiter behavior is explicit;
+  - [X] executor gRPC =Ack= failure behavior is explicit.
 - [ ] Add coverage for drain and forwarding:
   - [ ] gateway drain blocks or rejects new =Forward= calls;
-  - [ ] worker pause removes =wsConnections= and stops forwarding;
-  - [ ] heartbeat during drain cannot mark connection =READY=.
+  - [X] worker pause removes =wsConnections= and stops forwarding;
+  - [X] heartbeat during drain cannot mark connection =READY=.
 - [ ] Document any behavior that is intentionally preserved even if awkward.
 
 *** Validation checklist
 
-- [ ] =go test ./pkg/connect -count=1=
+- [X] =go test ./pkg/connect -count=1=
 
 *** Exit criteria
 
@@ -550,30 +555,30 @@ accepted.
 
 *** Implementation checklist
 
-- [ ] Choose Option A or Option B.
+- [X] Choose Option A or Option B.
 - [ ] Encode the chosen order in one helper.
-- [ ] Make unknown request ACKs non-fatal and clearly logged.
-- [ ] Make executor ACK failures return request-level failure or warning,
+- [X] Make unknown request ACKs non-fatal and clearly logged.
+- [X] Make executor ACK failures return request-level failure or warning,
   according to the chosen option.
-- [ ] Remove the direct =connect_internal_error= close for post-worker-ACK
+- [X] Remove the direct =connect_internal_error= close for post-worker-ACK
   executor notification failures unless tests prove it is required.
 
 *** Test checklist
 
 - [ ] gRPC client creation failure during =WORKER_REQUEST_ACK= does not close
   the websocket unless chosen policy explicitly requires it;
-- [ ] gRPC =Ack= RPC failure behavior matches chosen policy;
-- [ ] =reply.Success=false= behavior matches chosen policy;
+- [X] gRPC =Ack= RPC failure behavior matches chosen policy;
+- [X] =reply.Success=false= behavior matches chosen policy;
 - [ ] =Forward= result matches chosen policy.
 
 *** Validation checklist
 
-- [ ] =go test ./pkg/connect -run 'Test.*Ack|Test.*Forward|Test.*Drain' -count=1=
-- [ ] =go test ./pkg/connect -count=1=
+- [X] =go test ./pkg/connect -run 'Test.*Ack|Test.*Forward|Test.*Drain' -count=1=
+- [X] =go test ./pkg/connect -count=1=
 
 *** Exit criteria
 
-- [ ] =WORKER_REQUEST_ACK= can no longer unexpectedly close the worker
+- [X] =WORKER_REQUEST_ACK= can no longer unexpectedly close the worker
   websocket for an executor notification failure after the worker ACK has been
   accepted.
 

--- a/pkg/connect/gateway_drain_test.go
+++ b/pkg/connect/gateway_drain_test.go
@@ -286,6 +286,46 @@ func TestNoNewConnectionsDuringDrain(t *testing.T) {
 	require.Equal(t, 0, readyCount, "no onReady events should fire")
 }
 
+func TestForwardDuringGatewayDrainReturnsFalse(t *testing.T) {
+	ctx := context.Background()
+	res := createTestingGateway(t, testingParameters{
+		consecutiveMissesBeforeClose: 10,
+		heartbeatInterval:            1 * time.Second,
+		drainAckTimeout:              100 * time.Millisecond,
+		silent:                       true,
+	})
+	handshake(t, res)
+
+	err := res.svc.DrainGateway()
+	require.NoError(t, err)
+
+	msg := awaitNextMessage(t, res.ws, 3*time.Second)
+	require.Equal(t, connectpb.GatewayMessageType_GATEWAY_CLOSING, msg.Kind)
+
+	forwardCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	resp, err := res.svc.Forward(forwardCtx, &connectpb.ForwardRequest{
+		ConnectionID: res.connID.String(),
+		Data: &connectpb.GatewayExecutorRequestData{
+			RequestId:      "test-forward-during-drain",
+			AccountId:      res.accountID.String(),
+			EnvId:          res.envID.String(),
+			AppId:          res.appID.String(),
+			AppName:        res.appName,
+			FunctionId:     res.fnID.String(),
+			FunctionSlug:   res.fnSlug,
+			StepId:         ptr.String("step"),
+			RequestPayload: []byte("should not be delivered while draining"),
+			RunId:          res.runID.String(),
+			LeaseId:        "test-lease",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.False(t, resp.Success)
+}
+
 // TestWorkerReplyDuringGatewayDrain_IsProcessed verifies that worker replies
 // are accepted, saved to Redis, and acknowledged during drain.
 func TestWorkerReplyDuringGatewayDrain_IsProcessed(t *testing.T) {


### PR DESCRIPTION
## Description

Completes Phase 0 of the Connect gateway lifecycle controller plan by locking in the current baseline behavior before lifecycle refactoring:

- Documents the preserved request ACK, reply, heartbeat, pause, and drain forwarding behavior in plan 003.
- Records Option A for WORKER_REQUEST_ACK semantics: worker ACK acceptance releases pendingAcks before best-effort executor gRPC Ack notification.
- Adds regression coverage that new Forward calls during gateway drain return Success=false instead of delivering a new GATEWAY_EXECUTOR_REQUEST.

Validation:

- go test ./pkg/connect -count=1
- scripts/check-plan-status.sh

## Release note

None.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*