### PR TITLE
perf(connect): split heartbeats into a high priority goroutine

### DIFF
--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -27,6 +27,7 @@ import (
 	"github.com/inngest/inngest/pkg/util"
 	connectpb "github.com/inngest/inngest/proto/gen/connect/v1"
 	"github.com/oklog/ulid/v2"
+	"github.com/sourcegraph/conc/pool"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 )
@@ -94,6 +95,13 @@ type connectionHandler struct {
 	log        logger.Logger
 
 	remoteAddr string
+
+	// controlCh carries high-priority messages (heartbeats, pause, ready).
+	// dataCh carries data messages (replies, acks, lease extensions).
+	// Separate consumer goroutines service each channel so control messages
+	// are never queued behind slow data handlers.
+	controlCh chan *connectpb.ConnectMessage
+	dataCh    chan *connectpb.ConnectMessage
 
 	// draining is set to true when a WORKER_PAUSE message is received.
 	// Once set, heartbeats must not reset the connection status to READY.
@@ -293,6 +301,8 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 			updateLock:     sync.Mutex{},
 			remoteAddr:     remoteAddr,
 			stopForwarding: make(chan struct{}),
+			controlCh:      make(chan *connectpb.ConnectMessage, 10),
+			dataCh:         make(chan *connectpb.ConnectMessage, 50),
 		}
 
 		closeReason := connectpb.WorkerDisconnectReason_UNEXPECTED.String()
@@ -562,6 +572,8 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 
 		eg := errgroup.Group{}
 		eg.Go(func() error {
+			// Unblock consumer goroutines as soon as this is over
+			defer cancelRunLoopContext()
 			for {
 				// We already handle context cancellations in a goroutine above.
 				// If we timed out the read loop, the connection would be closed. This is bad because
@@ -648,10 +660,56 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 					Tags:    tags,
 				})
 
-				serr := ch.handleIncomingWebSocketMessage(&msg)
-				if serr != nil {
-					c.closeWithConnectError(ws, serr)
-					return serr
+				switch msg.Kind {
+				case connectpb.GatewayMessageType_WORKER_HEARTBEAT,
+					connectpb.GatewayMessageType_WORKER_PAUSE,
+					connectpb.GatewayMessageType_WORKER_READY:
+					select {
+					case ch.controlCh <- &msg:
+					case <-runLoopCtx.Done():
+						return nil
+					}
+				default:
+					select {
+					case ch.dataCh <- &msg:
+					case <-runLoopCtx.Done():
+						return nil
+					}
+				}
+			}
+		})
+
+		// dedicated goroutine for heartbeats, pause, and ready
+		eg.Go(func() error {
+			for {
+				select {
+				case <-runLoopCtx.Done():
+					return nil
+				case msg := <-ch.controlCh:
+					if serr := ch.handleIncomingWebSocketMessage(msg); serr != nil {
+						c.closeWithConnectError(ws, serr)
+						cancelRunLoopContext()
+						return serr
+					}
+				}
+			}
+		})
+
+		eg.Go(func() error {
+			p := pool.New().WithErrors().WithFirstError().WithMaxGoroutines(5)
+			for {
+				select {
+				case <-runLoopCtx.Done():
+					return p.Wait()
+				case msg := <-ch.dataCh:
+					p.Go(func() error {
+						if serr := ch.handleIncomingWebSocketMessage(msg); serr != nil {
+							c.closeWithConnectError(ws, serr)
+							cancelRunLoopContext()
+							return serr
+						}
+						return nil
+					})
 				}
 			}
 		})


### PR DESCRIPTION
## Description
Also adds a concurrency of 5 goroutines for handling incoming websocket
messages. From what I checked, all handlers are safe to run concurrently.

Without the concurrency, I had to increase the buffered channel size to
2k elements just to keep heartbeat latency under 1s, which is not ideal
memory-wise if those queued message are all replies containing large
payloads.

Worker under full load
```
time=2026-05-19T02:29:20.531+01:00 level=DEBUG msg=heartbeat
mode=connect connection_id=01KRYX7JFBW8T5B764YFK1PZFR gateway_group=gw1
gateway_endpoint=ws://localhost:8100/v0/connect ack_latency=4ms
time=2026-05-19T02:29:30.530+01:00 level=DEBUG msg=heartbeat
mode=connect connection_id=01KRYX7JFBW8T5B764YFK1PZFR gateway_group=gw1
gateway_endpoint=ws://localhost:8100/v0/connect ack_latency=4ms
time=2026-05-19T02:29:40.529+01:00 level=DEBUG msg=heartbeat
mode=connect connection_id=01KRYX7JFBW8T5B764YFK1PZFR gateway_group=gw1
gateway_endpoint=ws://localhost:8100/v0/connect ack_latency=2ms
time=2026-05-19T02:29:50.530+01:00 level=DEBUG msg=heartbeat
mode=connect connection_id=01KRYX7JFBW8T5B764YFK1PZFR gateway_group=gw1
gateway_endpoint=ws://localhost:8100/v0/connect ack_latency=3ms
time=2026-05-19T02:30:00.528+01:00 level=DEBUG msg=heartbeat
mode=connect connection_id=01KRYX7JFBW8T5B764YFK1PZFR gateway_group=gw1
gateway_endpoint=ws://localhost:8100/v0/connect ack_latency=1ms
time=2026-05-19T02:30:10.529+01:00 level=DEBUG msg=heartbeat
mode=connect connection_id=01KRYX7JFBW8T5B764YFK1PZFR gateway_group=gw1
gateway_endpoint=ws://localhost:8100/v0/connect ack_latency=2ms
time=2026-05-19T02:30:20.529+01:00 level=DEBUG msg=heartbeat
mode=connect connection_id=01KRYX7JFBW8T5B764YFK1PZFR gateway_group=gw1
gateway_endpoint=ws://localhost:8100/v0/connect ack_latency=2ms
time=2026-05-19T02:30:30.530+01:00 level=DEBUG msg=heartbeat
mode=connect connection_id=01KRYX7JFBW8T5B764YFK1PZFR gateway_group=gw1
gateway_endpoint=ws://localhost:8100/v0/connect ack_latency=2ms
```


<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
Improves Connect's gateway message handling performance

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
