### PR TITLE
refactor: score name moves into the kind suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ gql: ## Generate GraphQL code
 .PHONY: tygo
 tygo: ## Generate TypeScript types from Go structs
 	go run github.com/gzuidhof/tygo@latest generate
-	cd ui && pnpx prettier@2.8.8 --write --no-config --single-quote "packages/components/src/generated/**/*.ts"
+	cd ui && pnpx prettier@2.8.8 --write --no-config --single-quote --print-width 100 "packages/components/src/generated/**/*.ts"
 
 .PHONY: constraintapi-snapshots
 constraintapi-snapshots: ## Regenerate constraint API Lua snapshots

--- a/pkg/api/apiv1/metadata_test.go
+++ b/pkg/api/apiv1/metadata_test.go
@@ -236,9 +236,9 @@ func TestAddRunMetadataAllowsScoreMetadata(t *testing.T) {
 	err = r.AddRunMetadata(ctx, auth, runID, &AddRunMetadataRequest{
 		Target: RunMetadataTarget{StepID: &stepID},
 		Metadata: []metadata.Update{{RawUpdate: metadata.RawUpdate{
-			Kind:   metadata.KindInngestScore,
+			Kind:   metadata.KindInngestScore + ".passed",
 			Op:     enums.MetadataOpcodeMerge,
-			Values: metadata.Values{"passed": json.RawMessage(`true`)},
+			Values: metadata.Values{"value": json.RawMessage(`true`)},
 		}}},
 	})
 	require.NoError(t, err)
@@ -269,9 +269,9 @@ func TestAddRunMetadataRejectsInvalidScoreMetadata(t *testing.T) {
 
 	err = r.AddRunMetadata(ctx, auth, runID, &AddRunMetadataRequest{
 		Metadata: []metadata.Update{{RawUpdate: metadata.RawUpdate{
-			Kind:   metadata.KindInngestScore,
+			Kind:   metadata.KindInngestScore + ".score",
 			Op:     enums.MetadataOpcodeMerge,
-			Values: metadata.Values{"score": json.RawMessage(`{"value":1}`)},
+			Values: metadata.Values{"value": json.RawMessage(`{"nested":1}`)},
 		}}},
 	})
 	require.ErrorIs(t, err, metadata.ErrScoreValueInvalid)
@@ -311,9 +311,9 @@ func TestAddRunMetadataAllowsRunScopedScoreMetadata(t *testing.T) {
 
 	err = r.AddRunMetadata(ctx, auth, runID, &AddRunMetadataRequest{
 		Metadata: []metadata.Update{{RawUpdate: metadata.RawUpdate{
-			Kind:   metadata.KindInngestScore,
+			Kind:   metadata.KindInngestScore + ".accuracy",
 			Op:     enums.MetadataOpcodeMerge,
-			Values: metadata.Values{"accuracy": json.RawMessage(`1`)},
+			Values: metadata.Values{"value": json.RawMessage(`1`)},
 		}}},
 	})
 	require.NoError(t, err)

--- a/pkg/tracing/metadata/kind.go
+++ b/pkg/tracing/metadata/kind.go
@@ -41,7 +41,9 @@ func (k Kind) Validate() error {
 
 // allowedInngestKinds is the set of inngest-prefixed metadata kinds that SDK
 // clients are permitted to set. Any inngest.* kind not in this set is rejected
-// to prevent spoofing of internal metadata.
+// to prevent spoofing of internal metadata. Score kinds carry a user-supplied
+// name in their suffix (KindInngestScore + "." + name) and are gated by
+// IsScoped below rather than this map.
 var allowedInngestKinds = map[Kind]bool{
 	"inngest.ai":               true,
 	"inngest.http":             true,
@@ -49,18 +51,32 @@ var allowedInngestKinds = map[Kind]bool{
 	"inngest.response_headers": true,
 	"inngest.warnings":         true,
 	"inngest.experiment":       true,
-	KindInngestScore:           true,
 }
 
 // ValidateAllowed checks that the kind is valid and, if it uses the inngest.*
 // prefix, that it belongs to the allowlist. Userland kinds pass without
-// restriction.
+// restriction. Score kinds (inngest.score.<name>) are accepted with any
+// non-empty suffix so the name appears as the outer Map key in storage,
+// mirroring how userland.<name> works.
 func (k Kind) ValidateAllowed() error {
 	if err := k.Validate(); err != nil {
 		return err
 	}
-	if k.IsInngest() && !allowedInngestKinds[k] {
-		return ErrKindNotAllowed
+	if !k.IsInngest() {
+		return nil
 	}
-	return nil
+	if allowedInngestKinds[k] {
+		return nil
+	}
+	if k.IsScoped(KindInngestScore) {
+		return nil
+	}
+	return ErrKindNotAllowed
+}
+
+// IsScoped reports whether k uses base + "." as a prefix and carries a
+// non-empty suffix (e.g. base="inngest.score", k="inngest.score.accuracy").
+func (k Kind) IsScoped(base Kind) bool {
+	prefix := string(base) + "."
+	return len(string(k)) > len(prefix) && strings.HasPrefix(string(k), prefix)
 }

--- a/pkg/tracing/metadata/kind.go
+++ b/pkg/tracing/metadata/kind.go
@@ -57,7 +57,8 @@ var allowedInngestKinds = map[Kind]bool{
 // prefix, that it belongs to the allowlist. Userland kinds pass without
 // restriction. Score kinds (inngest.score.<name>) are accepted with any
 // non-empty suffix so the name appears as the outer Map key in storage,
-// mirroring how userland.<name> works.
+// mirroring how userland.<name> works — except for characters that the cloud
+// variant aggregation would silently drop (see validateScoreName).
 func (k Kind) ValidateAllowed() error {
 	if err := k.Validate(); err != nil {
 		return err
@@ -69,7 +70,7 @@ func (k Kind) ValidateAllowed() error {
 		return nil
 	}
 	if k.IsScoped(KindInngestScore) {
-		return nil
+		return validateScoreName(string(k)[len(KindInngestScore)+1:])
 	}
 	return ErrKindNotAllowed
 }

--- a/pkg/tracing/metadata/kind_test.go
+++ b/pkg/tracing/metadata/kind_test.go
@@ -67,6 +67,41 @@ func TestKind_ValidateAllowed(t *testing.T) {
 			wantErr: ErrKindNotAllowed,
 		},
 		{
+			name:    "inngest.score.<name> with a single quote is rejected",
+			kind:    "inngest.score.it's-broken",
+			wantErr: ErrScoreNameInvalid,
+		},
+		{
+			name:    "inngest.score.<name> with a newline is rejected",
+			kind:    "inngest.score.foo\nbar",
+			wantErr: ErrScoreNameInvalid,
+		},
+		{
+			name:    "inngest.score.<name> with a tab is rejected",
+			kind:    "inngest.score.foo\tbar",
+			wantErr: ErrScoreNameInvalid,
+		},
+		{
+			name:    "inngest.score.<name> with DEL (0x7F) is rejected",
+			kind:    "inngest.score.foo\x7fbar",
+			wantErr: ErrScoreNameInvalid,
+		},
+		{
+			name:    "inngest.score.<name> with multi-byte UTF-8 is allowed",
+			kind:    "inngest.score.checkout-✓",
+			wantErr: nil,
+		},
+		{
+			name:    "inngest.score.<name> with a trailing backslash is allowed",
+			kind:    "inngest.score.trailing\\",
+			wantErr: nil,
+		},
+		{
+			name:    "inngest.score.<name> with a backtick is allowed",
+			kind:    "inngest.score.has`backtick",
+			wantErr: nil,
+		},
+		{
 			name:    "inngest.unknown is rejected",
 			kind:    "inngest.unknown",
 			wantErr: ErrKindNotAllowed,

--- a/pkg/tracing/metadata/kind_test.go
+++ b/pkg/tracing/metadata/kind_test.go
@@ -47,13 +47,33 @@ func TestKind_ValidateAllowed(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:    "inngest.score is allowed",
+			name:    "bare inngest.score is rejected (name must live in suffix)",
 			kind:    KindInngestScore,
+			wantErr: ErrKindNotAllowed,
+		},
+		{
+			name:    "inngest.score.<name> with simple suffix is allowed",
+			kind:    "inngest.score.accuracy",
 			wantErr: nil,
+		},
+		{
+			name:    "inngest.score.<name> with arbitrary characters is allowed",
+			kind:    "inngest.score.checkout success rate (variant A) %",
+			wantErr: nil,
+		},
+		{
+			name:    "inngest.score. with empty suffix is rejected",
+			kind:    "inngest.score.",
+			wantErr: ErrKindNotAllowed,
 		},
 		{
 			name:    "inngest.unknown is rejected",
 			kind:    "inngest.unknown",
+			wantErr: ErrKindNotAllowed,
+		},
+		{
+			name:    "inngest.ai.suffix is rejected (only score allows suffixes)",
+			kind:    "inngest.ai.gpt4",
 			wantErr: ErrKindNotAllowed,
 		},
 		{

--- a/pkg/tracing/metadata/metadata.go
+++ b/pkg/tracing/metadata/metadata.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"io"
 	"maps"
-	"math"
-	"regexp"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/inngest/inngest/pkg/enums"
@@ -17,11 +15,8 @@ import (
 var (
 	ErrMetadataSpanTooLarge    = errors.New("metadata span exceeds maximum size")
 	ErrRunMetadataSizeExceeded = errors.New("run cumulative metadata size exceeded")
-	ErrScoreNameInvalid        = errors.New("score name is invalid")
 	ErrScoreValueInvalid       = errors.New("score value must be a finite number or boolean")
 )
-
-var scoreNameRegex = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]{0,63}$`)
 
 type Opcode = enums.MetadataOpcode
 
@@ -162,8 +157,8 @@ func (m Update) ValidateAllowed() error {
 		return err
 	}
 
-	if m.Kind() == KindInngestScore {
-		return validateScoreValues(m.RawUpdate.Values)
+	if m.Kind().IsScoped(KindInngestScore) {
+		return validateNamedScoreValue(m.RawUpdate.Values)
 	}
 
 	return nil
@@ -175,32 +170,6 @@ func ValidateUpdatesAllowed(updates []Update) error {
 		if err := update.ValidateAllowed(); err != nil {
 			return err
 		}
-	}
-
-	return nil
-}
-
-func validateScoreValues(values Values) error {
-	for name, raw := range values {
-		if !scoreNameRegex.MatchString(name) {
-			return fmt.Errorf("invalid score name %q: %w", name, ErrScoreNameInvalid)
-		}
-
-		var value any
-		if err := json.Unmarshal(raw, &value); err != nil {
-			return fmt.Errorf("invalid score value for %q: %w", name, ErrScoreValueInvalid)
-		}
-
-		switch v := value.(type) {
-		case bool:
-			continue
-		case float64:
-			if !math.IsNaN(v) && !math.IsInf(v, 0) {
-				continue
-			}
-		}
-
-		return fmt.Errorf("invalid score value for %q: %w", name, ErrScoreValueInvalid)
 	}
 
 	return nil

--- a/pkg/tracing/metadata/metadata.go
+++ b/pkg/tracing/metadata/metadata.go
@@ -15,6 +15,7 @@ import (
 var (
 	ErrMetadataSpanTooLarge    = errors.New("metadata span exceeds maximum size")
 	ErrRunMetadataSizeExceeded = errors.New("run cumulative metadata size exceeded")
+	ErrScoreNameInvalid        = errors.New("score name contains invalid characters")
 	ErrScoreValueInvalid       = errors.New("score value must be a finite number or boolean")
 )
 

--- a/pkg/tracing/metadata/metadata.go
+++ b/pkg/tracing/metadata/metadata.go
@@ -158,7 +158,7 @@ func (m Update) ValidateAllowed() error {
 	}
 
 	if m.Kind().IsScoped(KindInngestScore) {
-		return validateNamedScoreValue(m.RawUpdate.Values)
+		return validateNamedScoreValue(m.Kind(), m.RawUpdate.Values)
 	}
 
 	return nil

--- a/pkg/tracing/metadata/metadata_test.go
+++ b/pkg/tracing/metadata/metadata_test.go
@@ -82,7 +82,7 @@ func TestValuesSizeNilMap(t *testing.T) {
 	}
 }
 
-func TestUpdateValidateAllowedScoreValues(t *testing.T) {
+func TestUpdateValidateAllowedNamedScoreValue(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -91,56 +91,74 @@ func TestUpdateValidateAllowedScoreValues(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "flat numeric score is valid",
+			name: "finite numeric value is valid",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   KindInngestScore,
+				Kind:   "inngest.score.accuracy",
 				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{"accuracy": json.RawMessage(`1`)},
+				Values: Values{"value": json.RawMessage(`0.95`)},
 			}},
 		},
 		{
-			name: "flat boolean score is valid",
+			name: "arbitrary name in kind is accepted",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   KindInngestScore,
+				Kind:   "inngest.score.click-through rate (variant A)",
 				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{"passed": json.RawMessage(`true`)},
+				Values: Values{"value": json.RawMessage(`0.23`)},
 			}},
 		},
 		{
-			name: "nested score object is invalid",
+			name: "missing value key is rejected",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   KindInngestScore,
+				Kind:   "inngest.score.accuracy",
 				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{"score": json.RawMessage(`{"value":1}`)},
+				Values: Values{"score": json.RawMessage(`1`)},
 			}},
 			wantErr: ErrScoreValueInvalid,
 		},
 		{
-			name: "null score is invalid",
+			name: "extra keys alongside value are rejected",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   KindInngestScore,
+				Kind:   "inngest.score.accuracy",
 				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{"score": json.RawMessage(`null`)},
+				Values: Values{"value": json.RawMessage(`1`), "extra": json.RawMessage(`2`)},
 			}},
 			wantErr: ErrScoreValueInvalid,
 		},
 		{
-			name: "string score is invalid",
+			name: "empty values map is rejected",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   KindInngestScore,
+				Kind:   "inngest.score.accuracy",
 				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{"accuracy": json.RawMessage(`"1"`)},
+				Values: Values{},
 			}},
 			wantErr: ErrScoreValueInvalid,
 		},
 		{
-			name: "invalid score name is rejected",
+			name: "null value is rejected",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   KindInngestScore,
+				Kind:   "inngest.score.accuracy",
 				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{"bad-name": json.RawMessage(`1`)},
+				Values: Values{"value": json.RawMessage(`null`)},
 			}},
-			wantErr: ErrScoreNameInvalid,
+			wantErr: ErrScoreValueInvalid,
+		},
+		{
+			name: "string value is rejected",
+			update: Update{RawUpdate: RawUpdate{
+				Kind:   "inngest.score.accuracy",
+				Op:     enums.MetadataOpcodeMerge,
+				Values: Values{"value": json.RawMessage(`"high"`)},
+			}},
+			wantErr: ErrScoreValueInvalid,
+		},
+		{
+			name: "object value is rejected",
+			update: Update{RawUpdate: RawUpdate{
+				Kind:   "inngest.score.accuracy",
+				Op:     enums.MetadataOpcodeMerge,
+				Values: Values{"value": json.RawMessage(`{"nested":1}`)},
+			}},
+			wantErr: ErrScoreValueInvalid,
 		},
 		{
 			name: "non-score metadata keeps generic shape",

--- a/pkg/tracing/metadata/score.go
+++ b/pkg/tracing/metadata/score.go
@@ -15,19 +15,19 @@ const (
 // inngest.score.<name> kind family. The user-supplied name lives in the kind
 // suffix (analogous to userland.<name>), so values carries exactly one entry
 // keyed "value" containing a finite number or boolean.
-func validateNamedScoreValue(values Values) error {
+func validateNamedScoreValue(kind Kind, values Values) error {
 	if len(values) != 1 {
-		return fmt.Errorf("score must have exactly one entry under \"value\": %w", ErrScoreValueInvalid)
+		return fmt.Errorf("score %q must have exactly one entry keyed \"value\": %w", kind, ErrScoreValueInvalid)
 	}
 
 	raw, ok := values["value"]
 	if !ok {
-		return fmt.Errorf("score value key must be \"value\": %w", ErrScoreValueInvalid)
+		return fmt.Errorf("score %q value key must be \"value\": %w", kind, ErrScoreValueInvalid)
 	}
 
 	var value any
 	if err := json.Unmarshal(raw, &value); err != nil {
-		return fmt.Errorf("invalid score value: %w", ErrScoreValueInvalid)
+		return fmt.Errorf("invalid score value for kind %q: %w", kind, ErrScoreValueInvalid)
 	}
 
 	switch v := value.(type) {
@@ -39,5 +39,5 @@ func validateNamedScoreValue(values Values) error {
 		}
 	}
 
-	return fmt.Errorf("invalid score value: %w", ErrScoreValueInvalid)
+	return fmt.Errorf("invalid score value for kind %q: %w", kind, ErrScoreValueInvalid)
 }

--- a/pkg/tracing/metadata/score.go
+++ b/pkg/tracing/metadata/score.go
@@ -1,6 +1,43 @@
 package metadata
 
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+)
+
 //tygo:generate
 const (
 	KindInngestScore Kind = "inngest.score"
 )
+
+// validateNamedScoreValue applies the value-shape rules for the
+// inngest.score.<name> kind family. The user-supplied name lives in the kind
+// suffix (analogous to userland.<name>), so values carries exactly one entry
+// keyed "value" containing a finite number or boolean.
+func validateNamedScoreValue(values Values) error {
+	if len(values) != 1 {
+		return fmt.Errorf("score must have exactly one entry under \"value\": %w", ErrScoreValueInvalid)
+	}
+
+	raw, ok := values["value"]
+	if !ok {
+		return fmt.Errorf("score value key must be \"value\": %w", ErrScoreValueInvalid)
+	}
+
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return fmt.Errorf("invalid score value: %w", ErrScoreValueInvalid)
+	}
+
+	switch v := value.(type) {
+	case bool:
+		return nil
+	case float64:
+		if !math.IsNaN(v) && !math.IsInf(v, 0) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("invalid score value: %w", ErrScoreValueInvalid)
+}

--- a/pkg/tracing/metadata/score.go
+++ b/pkg/tracing/metadata/score.go
@@ -11,6 +11,21 @@ const (
 	KindInngestScore Kind = "inngest.score"
 )
 
+// validateScoreName checks the user-supplied suffix of an inngest.score.<name>
+// kind for characters that downstream consumers can't safely round-trip.
+// Mirrors the SDK validation and the monorepo MetricKeyRegex: rejects control
+// characters (0x00-0x1F, 0x7F) and the single quote (which would silently
+// drop in cloud variant aggregation because MetricKeyRegex excludes it for
+// SQL-injection defense). Overall length is bounded by Kind.Validate.
+func validateScoreName(name string) error {
+	for _, r := range name {
+		if r < 0x20 || r == 0x7f || r == '\'' {
+			return fmt.Errorf("invalid score name %q: %w", name, ErrScoreNameInvalid)
+		}
+	}
+	return nil
+}
+
 // validateNamedScoreValue applies the value-shape rules for the
 // inngest.score.<name> kind family. The user-supplied name lives in the kind
 // suffix (analogous to userland.<name>), so values carries exactly one entry

--- a/tygo.yaml
+++ b/tygo.yaml
@@ -9,6 +9,10 @@ packages:
 
       // Span metadata kind types (derived from generated constants)
       export type SpanMetadataKindUserland = `userland.${string}`;
+      // Score kinds embed the user-supplied score name in the suffix
+      // (e.g. `inngest.score.accuracy`). The KindInngestScore constant is
+      // the base prefix, not a complete kind.
+      export type SpanMetadataKindInngestScore = `${typeof KindInngestScore}.${string}`;
       export type SpanMetadataKind =
         | typeof KindInngestAI
         | typeof KindInngestHTTP
@@ -17,7 +21,7 @@ packages:
         | typeof KindInngestTiming
         | typeof KindInngestExperiment
         | typeof KindInngestWarnings
-        | typeof KindInngestScore
+        | SpanMetadataKindInngestScore
         | SpanMetadataKindUserland;
     type_mappings:
       error: "string"

--- a/ui/packages/components/src/RunDetails/ScoresAttrs.tsx
+++ b/ui/packages/components/src/RunDetails/ScoresAttrs.tsx
@@ -1,6 +1,9 @@
 import { TimeElement } from '../DetailsCard/Element';
 
+const SCORE_KIND_PREFIX = 'inngest.score.';
+
 type ScoreMetadata = {
+  kind: string;
   updatedAt: string;
   values: Record<string, unknown>;
 };
@@ -12,13 +15,13 @@ type ScoreRow = {
 };
 
 type ScoreTrace = {
-  metadata?: Array<ScoreMetadata & { kind: string }>;
+  metadata?: ScoreMetadata[];
   childrenSpans?: ScoreTrace[];
 };
 
 export function collectScoreMetadata(trace?: ScoreTrace): ScoreMetadata[] {
   // Run views need child spans because scores attach where they are emitted.
-  const metadata = trace?.metadata?.filter((md) => md.kind === 'inngest.score') ?? [];
+  const metadata = trace?.metadata?.filter((md) => md.kind.startsWith(SCORE_KIND_PREFIX)) ?? [];
   const childMetadata = trace?.childrenSpans?.flatMap((child) => collectScoreMetadata(child)) ?? [];
 
   return [...metadata, ...childMetadata];
@@ -26,20 +29,17 @@ export function collectScoreMetadata(trace?: ScoreTrace): ScoreMetadata[] {
 
 function scoreRows(metadata: ScoreMetadata[]): ScoreRow[] {
   return metadata
-    .flatMap((md) =>
-      Object.entries(md.values)
-        .filter((entry): entry is [string, number | boolean] => {
-          const [, value] = entry;
-          return (
-            typeof value === 'boolean' || (typeof value === 'number' && Number.isFinite(value))
-          );
-        })
-        .map(([name, value]) => ({
-          name,
-          value,
-          updatedAt: md.updatedAt,
-        }))
-    )
+    .flatMap((md) => {
+      const name = md.kind.slice(SCORE_KIND_PREFIX.length);
+      if (!name) {
+        return [];
+      }
+      const value = md.values.value;
+      if (typeof value === 'boolean' || (typeof value === 'number' && Number.isFinite(value))) {
+        return [{ name, value, updatedAt: md.updatedAt }];
+      }
+      return [];
+    })
     .sort((a, b) => a.name.localeCompare(b.name) || a.updatedAt.localeCompare(b.updatedAt));
 }
 

--- a/ui/packages/components/src/RunDetailsV4/RunDetailsV4.tsx
+++ b/ui/packages/components/src/RunDetailsV4/RunDetailsV4.tsx
@@ -316,7 +316,7 @@ export const RunDetailsV4 = ({
                 ) : traceReady ? (
                   <TimelineV4Wrapper
                     runID={runID}
-                    trace={runData.trace}
+                    trace={runData.trace as unknown as Trace}
                     orgName={orgName}
                     functionSlug={runData.fn.slug}
                   />
@@ -361,7 +361,7 @@ export const RunDetailsV4 = ({
               getTrigger={getTrigger}
               runID={runID}
               result={resultData}
-              trace={runData?.trace}
+              trace={runData?.trace as unknown as Trace | undefined}
               isDurableEndpoint={runData?.isDurableEndpoint}
             />
           )}

--- a/ui/packages/components/src/RunDetailsV4/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/StepInfo.tsx
@@ -31,6 +31,7 @@ import { UserlandAttrs } from './UserlandAttrs';
 import { formatDuration, maybeBooleanToString, type StepInfoType } from './runDetailsUtils';
 import {
   isExperimentMetadata,
+  isScoreMetadata,
   isStepInfoInvoke,
   isStepInfoSignal,
   isStepInfoSleep,
@@ -248,12 +249,12 @@ export const StepInfo = ({
     ? trace.metadata?.filter(
         (md) =>
           md.kind !== 'inngest.response_headers' &&
-          md.kind !== 'inngest.score' &&
+          !isScoreMetadata(md) &&
           !isExperimentMetadata(md)
       ) ?? []
     : [];
 
-  const scoreMetadataList = trace.metadata?.filter((md) => md.kind === 'inngest.score') ?? [];
+  const scoreMetadataList = trace.metadata?.filter(isScoreMetadata) ?? [];
 
   const experimentMetadataList = metadataIsEnabled
     ? trace.metadata?.filter(isExperimentMetadata) ?? []
@@ -283,7 +284,7 @@ export const StepInfo = ({
 
   return (
     <div className="flex h-full flex-col justify-start gap-2">
-      <div className="flex min-h-11 w-full flex-row items-center justify-between border-none px-4">
+      <div className="min-h-11 flex w-full flex-row items-center justify-between border-none px-4">
         <div
           className="text-basis flex cursor-pointer items-center justify-start gap-2"
           onClick={() => setExpanded(!expanded)}

--- a/ui/packages/components/src/RunDetailsV4/TopInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/TopInfo.tsx
@@ -26,7 +26,7 @@ import { ErrorInfo } from './ErrorInfo';
 import { IO } from './IO';
 import { MetadataAttrs } from './MetadataAttrs';
 import { Tabs } from './Tabs';
-import type { Trace } from './types';
+import { isScoreMetadata, type Trace } from './types';
 
 type TopInfoProps = {
   slug?: string;
@@ -115,7 +115,7 @@ export const TopInfo = ({
 
   const metadataIsEnabled = true;
   const scoreMetadata = useMemo(() => collectScoreMetadata(trace), [trace]);
-  const nonScoreMetadata = trace?.metadata?.filter((md) => md.kind !== 'inngest.score') ?? [];
+  const nonScoreMetadata = trace?.metadata?.filter((md) => !isScoreMetadata(md)) ?? [];
   const hasMetadataTab = metadataIsEnabled && nonScoreMetadata.length > 0;
 
   const prettyPayload = useMemo(() => {

--- a/ui/packages/components/src/RunDetailsV4/types.ts
+++ b/ui/packages/components/src/RunDetailsV4/types.ts
@@ -1,5 +1,6 @@
 import type {
   SpanMetadataKind as GeneratedSpanMetadataKind,
+  SpanMetadataKindInngestScore as GeneratedSpanMetadataKindInngestScore,
   SpanMetadataKindUserland as GeneratedSpanMetadataKindUserland,
   Warnings,
 } from '../generated/index';
@@ -33,6 +34,8 @@ export type ResponseInfo = {
 };
 
 export type SpanMetadataKind = GeneratedSpanMetadataKind;
+
+export type SpanMetadataKindInngestScore = GeneratedSpanMetadataKindInngestScore;
 
 export type SpanMetadataKindUserland = GeneratedSpanMetadataKindUserland;
 
@@ -134,9 +137,9 @@ export type SpanMetadataInngestWarnings = {
 
 export type SpanMetadataInngestScore = {
   scope: SpanMetadataScope;
-  kind: 'inngest.score';
+  kind: SpanMetadataKindInngestScore;
   updatedAt: string;
-  values: Record<string, number | boolean>;
+  values: { value: number | boolean };
 };
 
 export type SpanMetadataUserland = {
@@ -236,4 +239,8 @@ export function isStepInfoSignal(stepInfo: Trace['stepInfo']): stepInfo is StepI
 
 export function isExperimentMetadata(md: SpanMetadata): md is SpanMetadataInngestExperiment {
   return md.kind === 'inngest.experiment';
+}
+
+export function isScoreMetadata(md: SpanMetadata): md is SpanMetadataInngestScore {
+  return md.kind.startsWith('inngest.score.');
 }

--- a/ui/packages/components/src/generated/index.ts
+++ b/ui/packages/components/src/generated/index.ts
@@ -4,6 +4,10 @@ type error = string;
 
 // Span metadata kind types (derived from generated constants)
 export type SpanMetadataKindUserland = `userland.${string}`;
+// Score kinds embed the user-supplied score name in the suffix
+// (e.g. `inngest.score.accuracy`). The KindInngestScore constant is
+// the base prefix, not a complete kind.
+export type SpanMetadataKindInngestScore = `${typeof KindInngestScore}.${string}`;
 export type SpanMetadataKind =
   | typeof KindInngestAI
   | typeof KindInngestHTTP
@@ -12,7 +16,7 @@ export type SpanMetadataKind =
   | typeof KindInngestTiming
   | typeof KindInngestExperiment
   | typeof KindInngestWarnings
-  | typeof KindInngestScore
+  | SpanMetadataKindInngestScore
   | SpanMetadataKindUserland;
 
 //////////


### PR DESCRIPTION
## Description

Score metadata used to be one kind (`inngest.score`) with the user-supplied name as a key inside the values map. The name had to match `^[a-zA-Z_][a-zA-Z0-9_]{0,63}$`, which rejected things like `click-through rate` or `accuracy-rate`.

Now scores follow the `userland.<name>` pattern: kind is `inngest.score.<name>`, values is `{value: <number|bool>}`. ClickHouse already strips the `inngest.` prefix at ingest, so the Map storage shape is unchanged.

Score-name regex is gone. Bare `inngest.score` is no longer accepted (feature not released yet, so no back-compat).

## Release note

None.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
