### PR TITLE
fix(pauses): Retry enqueueing edge after consuming pause

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3225,9 +3225,13 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 				e.log.Debug("error creating span for next step after resume", "error", err)
 			}
 
-			err = e.queue.Enqueue(ctx, nextItem, e.now(), queue.EnqueueOpts{})
+			_, err = util.WithRetry(ctx, "executor.resume.enqueue", func(ctx context.Context) (any, error) {
+				return nil, e.queue.Enqueue(ctx, nextItem, e.now(), queue.EnqueueOpts{})
+			}, util.NewRetryConf(util.WithRetryConfRetryableErrors(func(err error) bool {
+				return !errors.Is(err, queue.ErrQueueItemExists)
+			})))
 			if err != nil {
-				if err == queue.ErrQueueItemExists {
+				if errors.Is(err, queue.ErrQueueItemExists) {
 					nextStepSpan.Drop()
 				} else {
 					_ = nextStepSpan.Send()

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3225,6 +3225,11 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 				e.log.Debug("error creating span for next step after resume", "error", err)
 			}
 
+			// Retry the Enqueue inline to avoid transient errors causing
+			// this pause job to fail. We can't rely on retrying the pause
+			// job itself: the pause has already been consumed above, and
+			// it may also be consumed by a timeout job, so future attempts
+			// of this pause job would skip the Enqueue entirely.
 			_, err = util.WithRetry(ctx, "executor.resume.enqueue", func(ctx context.Context) (any, error) {
 				return nil, e.queue.Enqueue(ctx, nextItem, e.now(), queue.EnqueueOpts{})
 			}, util.NewRetryConf(util.WithRetryConfRetryableErrors(func(err error) bool {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3225,11 +3225,13 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 				e.log.Debug("error creating span for next step after resume", "error", err)
 			}
 
-			// Retry the Enqueue inline to avoid transient errors causing
-			// this pause job to fail. We can't rely on retrying the pause
-			// job itself: the pause has already been consumed above, and
-			// it may also be consumed by a timeout job, so future attempts
-			// of this pause job would skip the Enqueue entirely.
+			// The Enqueue is retried inline here to avoid transient errors causing
+			// this pause job to fail. If the Enqueue fails after consuming the pause
+			// above, retries of this pause job will notice that the pause has been
+			// consumed and skip the subsequent Enqueue.
+			// It is possible for the pause to be consumed by a timeout job as well,
+			//  so we cannot just retry the Enqueue on future attempts of this pause job
+			// without knowing if the pause was consumed by an event or by the timeout.
 			_, err = util.WithRetry(ctx, "executor.resume.enqueue", func(ctx context.Context) (any, error) {
 				return nil, e.queue.Enqueue(ctx, nextItem, e.now(), queue.EnqueueOpts{})
 			}, util.NewRetryConf(util.WithRetryConfRetryableErrors(func(err error) bool {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3220,18 +3220,20 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 			}
 
 			err = e.queue.Enqueue(ctx, nextItem, e.now(), queue.EnqueueOpts{})
-			if err != nil {
-				if err == queue.ErrQueueItemExists {
-					nextStepSpan.Drop()
-				} else {
-					_ = nextStepSpan.Send()
-					return fmt.Errorf("error enqueueing after pause: %w", err)
-				}
+			// if we did not consume the pause, it implies another handler raced to consume
+			// the pause first. Drop the span and exit and let the other handler write spans.
+			if !consumeResult.DidConsume {
+				nextStepSpan.Drop()
+				return nil
 			}
 
+			if err != nil && err != queue.ErrQueueItemExists {
+				nextStepSpan.Drop()
+				return fmt.Errorf("error enqueueing after pause: %w", err)
+			}
+			// on successful enqueue, send the span
 			_ = nextStepSpan.Send()
-		}
-
+		
 		// Only run lifecycles if we consumed the pause and enqueued next step.
 		switch pause.GetOpcode() {
 		case enums.OpcodeInvokeFunction:

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3225,13 +3225,6 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 				e.log.Debug("error creating span for next step after resume", "error", err)
 			}
 
-			// The Enqueue is retried inline here to avoid transient errors causing
-			// this pause job to fail. If the Enqueue fails after consuming the pause
-			// above, retries of this pause job will notice that the pause has been
-			// consumed and skip the subsequent Enqueue.
-			// It is possible for the pause to be consumed by a timeout job as well,
-			//  so we cannot just retry the Enqueue on future attempts of this pause job
-			// without knowing if the pause was consumed by an event or by the timeout.
 			_, err = util.WithRetry(ctx, "executor.resume.enqueue", func(ctx context.Context) (any, error) {
 				return nil, e.queue.Enqueue(ctx, nextItem, e.now(), queue.EnqueueOpts{})
 			}, util.NewRetryConf(util.WithRetryConfRetryableErrors(func(err error) bool {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3233,7 +3233,8 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 			}
 			// on successful enqueue, send the span
 			_ = nextStepSpan.Send()
-		
+		}
+
 		// Only run lifecycles if we consumed the pause and enqueued next step.
 		switch pause.GetOpcode() {
 		case enums.OpcodeInvokeFunction:

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3225,13 +3225,9 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 				e.log.Debug("error creating span for next step after resume", "error", err)
 			}
 
-			_, err = util.WithRetry(ctx, "executor.resume.enqueue", func(ctx context.Context) (any, error) {
-				return nil, e.queue.Enqueue(ctx, nextItem, e.now(), queue.EnqueueOpts{})
-			}, util.NewRetryConf(util.WithRetryConfRetryableErrors(func(err error) bool {
-				return !errors.Is(err, queue.ErrQueueItemExists)
-			})))
+			err = e.queue.Enqueue(ctx, nextItem, e.now(), queue.EnqueueOpts{})
 			if err != nil {
-				if errors.Is(err, queue.ErrQueueItemExists) {
+				if err == queue.ErrQueueItemExists {
 					nextStepSpan.Drop()
 				} else {
 					_ = nextStepSpan.Send()

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3158,12 +3158,6 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 			"consumed", consumeResult,
 		)
 
-		if !consumeResult.DidConsume {
-			// We don't need to do anything here.  This could be a dupe;  consuming a pause
-			// is transactional / atomic, so ignore this.
-			return nil
-		}
-
 		status := enums.StepStatusCompleted
 		if r.IsTimeout {
 			status = enums.StepStatusTimedOut


### PR DESCRIPTION
## Description

Improves pause resume reliability by adding retry logic around enqueueing the next queue item after a pause is consumed.

In this [ticket](https://app.plain.com/workspace/w_01H5R1F69XQ35G4P7THFQGN5KB/thread/th_01KQSD1WR8FNAADPVEZD2QV8CR),  we see that a pause was consumed successfully, but the subsequent Enqueue of next step failed. 

When the pause job was retried, since the pause was already consumed, we early exit and declare success. Since the next step was not enqueued the user fn run continued to hang indefinitely.


## Release note

None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
