### PR TITLE
internal: restore provenance and move to github hosted runner for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   npm:
-    runs-on: depot-ubuntu-22.04
+    runs-on: ubuntu-22.04
     needs: [goreleaser, check-release-type]
     permissions:
       contents: read
@@ -142,9 +142,9 @@ jobs:
           npm version ${{ github.ref_name }}
 
           if [ -z "${{ needs.check-release-type.outputs.prerelease }}" ]; then
-            npm publish --access public --provenance=false
+            npm publish --access public --provenance
           else
-            npm publish --tag ${{ needs.check-release-type.outputs.prerelease }} --access public --provenance=false
+            npm publish --tag ${{ needs.check-release-type.outputs.prerelease }} --access public --provenance
           fi
 
   linear-release:


### PR DESCRIPTION
## Description

Attempts to unbreak npm cli release with provenance by using a github-hosted runner. 

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
