### PR TITLE
feat: Insights AI: Allow non-user-specific requests

### DIFF
--- a/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
@@ -52,7 +52,7 @@ export const runInsightsAgent = inngest.createFunction(
       history,
     } = event.data as ChatEventData;
 
-    if (!userId || (!accountId && !requestId)) {
+    if (!userId && (!accountId || !requestId)) {
       throw new Error(
         'userId or accountId and requestId is required for agent chat execution',
       );

--- a/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
@@ -63,9 +63,9 @@ export const runInsightsAgent = inngest.createFunction(
     });
 
     const targetChannel = await step.run('generate-target-channel', () => {
-      return (
-        channelKey || `user:${userId}` || `request:${accountId}:${requestId}`
-      );
+      if (channelKey) return channelKey;
+      if (userId) return `user:${userId}`;
+      return `acct:${accountId}:${requestId}`;
     });
 
     // Extract client state from the user message

--- a/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
@@ -29,6 +29,8 @@ type ChatEventData = {
     systemPrompt?: string;
   };
   userId?: string;
+  accountId?: string;
+  requestId?: string;
   channelKey?: string;
   history?: Array<Record<string, unknown>>;
 };
@@ -44,12 +46,16 @@ export const runInsightsAgent = inngest.createFunction(
       threadId: providedThreadId,
       userMessage,
       userId,
+      accountId,
+      requestId,
       channelKey,
       history,
     } = event.data as ChatEventData;
 
-    if (!userId) {
-      throw new Error('userId is required for agent chat execution');
+    if (!userId || (!accountId && !requestId)) {
+      throw new Error(
+        'userId or accountId and requestId is required for agent chat execution',
+      );
     }
 
     const threadId = await step.run('generate-thread-id', () => {
@@ -57,7 +63,9 @@ export const runInsightsAgent = inngest.createFunction(
     });
 
     const targetChannel = await step.run('generate-target-channel', () => {
-      return channelKey || userId;
+      return (
+        channelKey || `user:${userId}` || `request:${accountId}:${requestId}`
+      );
     });
 
     // Extract client state from the user message

--- a/ui/apps/dashboard/src/lib/inngest/realtime.ts
+++ b/ui/apps/dashboard/src/lib/inngest/realtime.ts
@@ -14,7 +14,7 @@ const insightsRealtimeEventSchema = z.object({
 });
 
 export const insightsChannel = realtime.channel({
-  name: (userId: string) => `user:${userId}`,
+  name: (targetChannel: string) => targetChannel,
   topics: {
     agent_stream: { schema: insightsRealtimeEventSchema },
   },


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This allows non-user-specific Insights requests by accepting account/request id if user ID is not present. This is for the internal Insights API.

Previously the channel usually looked like `user:insights:<user id>` due to hardcoded wrapping of the provided channel key. Now it looks like one of `<channel key>`, `user:<user id>` or `request:<account id>-<request id>`

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
