### PR TITLE
fix: EXE-1547 - Inngest sub-bar grows to fill parent on in-progress runs

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/Timeline.tsx
+++ b/ui/packages/components/src/RunDetailsV4/Timeline.tsx
@@ -219,13 +219,35 @@ function generatePhaseSegments<T extends { totalMs: number }>(
 }
 
 /**
+ * Resolve a bar's timing breakdown against `nowMs`. For completed spans the
+ * baked numbers are returned verbatim; for in-progress spans (executionMs ==
+ * null) we recompute executionMs against the live `nowMs` so the
+ * inngest/execution ratio can't drift from the parent bar's live width.
+ */
+function getLiveTimingForBar(
+  bar: TimelineBarData,
+  nowMs: number
+): { inngestMs: number; executionMs: number; totalMs: number } | null {
+  if (!bar.timingBreakdown) return null;
+  const { inngestMs, executionMs, totalMs } = bar.timingBreakdown;
+  if (executionMs != null && totalMs != null) {
+    return { inngestMs, executionMs, totalMs };
+  }
+  // In-progress: executionMs runs from startedAt (= startTime + delayMs) to now.
+  const startedAtMs = bar.startTime.getTime() + (bar.delayMs ?? 0);
+  const liveExec = Math.max(0, nowMs - startedAtMs);
+  return { inngestMs, executionMs: liveExec, totalMs: inngestMs + liveExec };
+}
+
+/**
  * Generate segments for a compound bar based on timing breakdown.
  * Uses gray delay bar for the queue portion (matching V3's visual distinction).
  */
-function generateBarSegments(bar: TimelineBarData): BarSegment[] | undefined {
-  if (!bar.timingBreakdown) return undefined;
+function generateBarSegments(bar: TimelineBarData, nowMs: number): BarSegment[] | undefined {
+  const live = getLiveTimingForBar(bar, nowMs);
+  if (!live) return undefined;
 
-  const { inngestMs, executionMs, totalMs } = bar.timingBreakdown;
+  const { inngestMs, executionMs, totalMs } = live;
 
   if (totalMs <= 0) return undefined;
 
@@ -396,11 +418,15 @@ function buildTimingDetails(bar: TimelineBarData): TimingDetail[] | undefined {
     details.push(...detailsFromPhases(RUN_INNGEST_PHASES, bar.runInngestBreakdown));
   }
 
-  // Timing breakdown (queue + execution) — no matching phase array
+  // Timing breakdown (queue + execution) — no matching phase array.
+  // For in-progress spans `executionMs` is null; the live value is computed
+  // by the renderer, so we just skip it here (the row's own duration label
+  // shows wall-clock progress).
   if (bar.timingBreakdown) {
     const b = bar.timingBreakdown;
     if (b.inngestMs > 0) details.push({ label: 'Inngest', durationMs: b.inngestMs });
-    if (b.executionMs > 0) details.push({ label: 'Your server', durationMs: b.executionMs });
+    if (b.executionMs != null && b.executionMs > 0)
+      details.push({ label: 'Your server', durationMs: b.executionMs });
   }
 
   // HTTP timing breakdown
@@ -455,6 +481,9 @@ type TimelineBarRendererProps = {
   depth: number;
   minTime: Date;
   maxTime: Date;
+  /** Live `Date.now()` snapshot for this render; used to compute in-progress
+   *  executionMs so it stays in sync with the parent bar's live width. */
+  nowMs: number;
   leftWidth: number;
   orgName?: string;
   expandedBars: Set<string>;
@@ -479,6 +508,7 @@ function TimelineBarRenderer({
   depth,
   minTime,
   maxTime,
+  nowMs,
   leftWidth,
   orgName,
   expandedBars,
@@ -512,7 +542,7 @@ function TimelineBarRenderer({
 
   // Generate segments for compound bar visualization
   // Bars with timingBreakdown use queue+execution segments; others fall back to delay+execution
-  const segments = generateBarSegments(bar) ?? generateDelaySegments(bar);
+  const segments = generateBarSegments(bar, nowMs) ?? generateDelaySegments(bar);
 
   // Pre-compute timing sub-bar positions from the parent bar's position.
   // This ensures sub-bars visually align with the parent's compound segments.
@@ -520,9 +550,12 @@ function TimelineBarRenderer({
   // For the Inngest portion: prefer timingBreakdown.inngestMs (from metadata),
   // but fall back to inngestBreakdown.totalMs (from timestamps) so we still
   // show the Inngest bar even when metadata is missing or reports 0.
+  //
+  // `executionMs` is live for in-progress spans — see getLiveTimingForBar.
   const timingPositions = (() => {
-    const breakdownInngestMs = bar.timingBreakdown?.inngestMs ?? 0;
-    const executionMs = bar.timingBreakdown?.executionMs ?? 0;
+    const live = getLiveTimingForBar(bar, nowMs);
+    const breakdownInngestMs = live?.inngestMs ?? 0;
+    const executionMs = live?.executionMs ?? 0;
     const inngestMs =
       breakdownInngestMs > 0 ? breakdownInngestMs : bar.inngestBreakdown?.totalMs ?? 0;
     const totalMs = inngestMs + executionMs;
@@ -707,6 +740,7 @@ function TimelineBarRenderer({
                 depth={depth + 2}
                 minTime={minTime}
                 maxTime={maxTime}
+                nowMs={nowMs}
                 leftWidth={leftWidth}
                 orgName={orgName}
                 expandedBars={expandedBars}
@@ -823,6 +857,7 @@ function TimelineBarRenderer({
             depth={depth + 1}
             minTime={minTime}
             maxTime={maxTime}
+            nowMs={nowMs}
             leftWidth={leftWidth}
             orgName={orgName}
             expandedBars={expandedBars}
@@ -853,7 +888,13 @@ function TimelineBarRenderer({
  * - Column resize handling (planned)
  */
 export function Timeline({ data, onSelectStep }: Props): JSX.Element {
-  const { minTime, maxTime, bars, leftWidth, orgName } = data;
+  const { minTime, maxTime: bakedMaxTime, bars, leftWidth, orgName } = data;
+  // Substitute a live `Date.now()` for in-progress runs (where maxTime is
+  // null). This is computed once per render and shared with TimelineHeader
+  // and every TimelineBarRenderer so the timeline's right edge stays in
+  // sync with the executionMs we compute for in-progress sub-bars.
+  const nowMs = Date.now();
+  const maxTime = bakedMaxTime ?? new Date(nowMs);
 
   const rootBarIds = useMemo(() => bars.filter((bar) => bar.isRoot).map((bar) => bar.id), [bars]);
 
@@ -950,6 +991,7 @@ export function Timeline({ data, onSelectStep }: Props): JSX.Element {
           depth={0}
           minTime={minTime}
           maxTime={maxTime}
+          nowMs={nowMs}
           leftWidth={leftWidth}
           orgName={orgName}
           expandedBars={expandedBars}

--- a/ui/packages/components/src/RunDetailsV4/TimelineBar.types.ts
+++ b/ui/packages/components/src/RunDetailsV4/TimelineBar.types.ts
@@ -244,9 +244,11 @@ export interface TimingDetail {
  * Complete timeline data for rendering.
  */
 export interface TimelineData {
-  /** Overall timeline bounds */
+  /** Overall timeline bounds. `maxTime` is null while the run is in
+   *  progress — Timeline substitutes a live `Date.now()` each render so the
+   *  right edge stays in sync with sub-bar timing computations. */
   minTime: Date;
-  maxTime: Date;
+  maxTime: Date | null;
 
   /** Root-level bars (steps) */
   bars: TimelineBarData[];
@@ -321,11 +323,13 @@ export interface TimingBreakdownData {
   /** Total Inngest-side overhead (queue delay + system latency) */
   inngestMs: number;
 
-  /** Execution time (SERVER) */
-  executionMs: number;
+  /** Execution time (SERVER). `null` while the span is in progress —
+   *  consumers should recompute live from `bar.startTime + bar.delayMs` to
+   *  `Date.now()` so the value can't be frozen by a memoization boundary. */
+  executionMs: number | null;
 
-  /** Total duration */
-  totalMs: number;
+  /** Total duration. `null` while the span is in progress — see executionMs. */
+  totalMs: number | null;
 }
 
 /**

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
@@ -3,7 +3,7 @@
  * Feature: 001-composable-timeline-bar
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { Trace } from '../types';
 import { traceToTimelineData } from './traceConversion';
@@ -94,7 +94,11 @@ describe('traceConversion', () => {
       expect(result.maxTime).toEqual(new Date('2024-01-01T00:00:20Z'));
     });
 
-    it('handles trace with null endedAt (in progress)', () => {
+    it('leaves maxTime null for in-progress runs so renderer substitutes live now', () => {
+      // For in-progress runs we deliberately don't bake `Date.now()` here.
+      // Doing so would freeze inside the upstream useMemo and let the
+      // Inngest sub-bar grow with the parent. The Timeline component is
+      // responsible for substituting a fresh `Date.now()` each render.
       const trace = createTrace({
         isRoot: true,
         endedAt: null,
@@ -102,9 +106,127 @@ describe('traceConversion', () => {
 
       const result = traceToTimelineData(trace, { runID: 'run-1' });
 
-      // maxTime should be roughly "now" - just check it's a valid date
-      expect(result.maxTime).toBeInstanceOf(Date);
-      expect(result.maxTime.getTime()).toBeGreaterThan(result.minTime.getTime());
+      expect(result.maxTime).toBeNull();
+    });
+
+    it('leaves maxTime null when any child is still in-progress', () => {
+      const trace = createTrace({
+        isRoot: true,
+        endedAt: '2024-01-01T00:00:30Z',
+        childrenSpans: [
+          createTrace({
+            spanID: 'child-1',
+            stepOp: 'RUN',
+            endedAt: '2024-01-01T00:00:05Z',
+          }),
+          createTrace({
+            spanID: 'child-2',
+            stepOp: 'RUN',
+            endedAt: null,
+          }),
+        ],
+      });
+
+      const result = traceToTimelineData(trace, { runID: 'run-1' });
+
+      expect(result.maxTime).toBeNull();
+    });
+  });
+
+  describe('in-progress timing breakdown', () => {
+    it('still bakes executionMs/totalMs for fully completed step.run spans', () => {
+      const trace = createTrace({
+        isRoot: true,
+        endedAt: '2024-01-01T00:00:10Z',
+        childrenSpans: [
+          createTrace({
+            spanID: 'done-step',
+            stepOp: 'RUN',
+            queuedAt: '2024-01-01T00:00:00Z',
+            startedAt: '2024-01-01T00:00:02Z',
+            endedAt: '2024-01-01T00:00:07Z',
+          }),
+        ],
+      });
+
+      const result = traceToTimelineData(trace, { runID: 'run-1' });
+      const child = result.bars[0]?.children?.[0];
+
+      expect(child?.timingBreakdown?.inngestMs).toBe(2000);
+      expect(child?.timingBreakdown?.executionMs).toBe(5000);
+      expect(child?.timingBreakdown?.totalMs).toBe(7000);
+    });
+
+    it('produces identical in-progress output regardless of system time', async () => {
+      // If `calculateTimingBreakdown` accidentally re-introduces a Date.now()
+      // capture, this test fails: the two results would differ.
+      const trace = createTrace({
+        isRoot: true,
+        endedAt: null,
+        childrenSpans: [
+          createTrace({
+            spanID: 'in-progress-step',
+            stepOp: 'RUN',
+            queuedAt: '2024-01-01T00:00:00Z',
+            startedAt: '2024-01-01T00:00:00.050Z',
+            endedAt: null,
+          }),
+        ],
+      });
+
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2024-01-01T00:00:01Z'));
+        const early = traceToTimelineData(trace, { runID: 'run-1' });
+
+        vi.setSystemTime(new Date('2024-01-01T00:05:00Z'));
+        const late = traceToTimelineData(trace, { runID: 'run-1' });
+
+        const earlyChild = early.bars[0]?.children?.[0]?.timingBreakdown;
+        const lateChild = late.bars[0]?.children?.[0]?.timingBreakdown;
+
+        expect(earlyChild).toEqual(lateChild);
+        expect(earlyChild?.executionMs).toBeNull();
+        expect(earlyChild?.totalMs).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('skips the root timingBreakdown roll-up when any child is in-progress', () => {
+      // The root roll-up at traceToTimelineData sums child execution times to
+      // derive root inngest/execution; with an in-progress child that sum
+      // would be partly Date.now()-dependent. We refuse to bake it.
+      // The real root span has stepOp: null (it's not a step.run itself), so
+      // its own calculateTimingBreakdown returns undefined, leaving any value
+      // on rootBar.timingBreakdown attributable to the roll-up.
+      const trace = createTrace({
+        isRoot: true,
+        stepOp: null,
+        endedAt: null,
+        childrenSpans: [
+          createTrace({
+            spanID: 'done',
+            stepOp: 'RUN',
+            queuedAt: '2024-01-01T00:00:00Z',
+            startedAt: '2024-01-01T00:00:00.010Z',
+            endedAt: '2024-01-01T00:00:05Z',
+          }),
+          createTrace({
+            spanID: 'in-progress',
+            stepOp: 'RUN',
+            queuedAt: '2024-01-01T00:00:05Z',
+            startedAt: '2024-01-01T00:00:05.010Z',
+            endedAt: null,
+          }),
+        ],
+      });
+
+      const result = traceToTimelineData(trace, { runID: 'run-1' });
+      const root = result.bars[0];
+
+      // No frozen executionMs/totalMs on the root either.
+      expect(root?.timingBreakdown).toBeUndefined();
     });
   });
 

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
@@ -70,25 +70,33 @@ function getStyleForTrace(trace: Trace): BarStyleKey {
 }
 
 /**
- * Calculate timing breakdown for a step.run span
+ * Calculate timing breakdown for a step.run span.
+ *
+ * For in-progress spans (no `endedAt`), `executionMs`/`totalMs` are returned
+ * as `null`. The render path must recompute them live against `Date.now()`
+ * — baking a `Date.now()` snapshot here would freeze inside the upstream
+ * `useMemo` and visually misallocate width to the Inngest segment.
  */
 function calculateTimingBreakdown(
   trace: Trace
-): { inngestMs: number; executionMs: number; totalMs: number } | undefined {
+): { inngestMs: number; executionMs: number | null; totalMs: number | null } | undefined {
   if (!trace.queuedAt) return undefined;
 
   const queuedAt = new Date(trace.queuedAt).getTime();
   const startedAt = trace.startedAt ? new Date(trace.startedAt).getTime() : null;
-  const endedAt = trace.endedAt ? new Date(trace.endedAt).getTime() : Date.now();
+  const endedAt = trace.endedAt ? new Date(trace.endedAt).getTime() : null;
 
-  // Calculate durations
-  const inngestMs = startedAt
-    ? Math.max(0, startedAt - queuedAt)
-    : Math.max(0, Date.now() - queuedAt);
-  const executionMs = startedAt ? Math.max(0, endedAt - startedAt) : 0;
-  const totalMs = startedAt ? inngestMs + executionMs : Date.now() - queuedAt;
+  // Inngest-side overhead is fixed once `startedAt` exists; without `startedAt`
+  // we cannot bake a value (would drift with Date.now), so leave it as 0 and
+  // let the render path treat the whole bar as in-progress.
+  const inngestMs = startedAt != null ? Math.max(0, startedAt - queuedAt) : 0;
 
-  return { inngestMs, executionMs, totalMs };
+  if (endedAt == null) {
+    return { inngestMs, executionMs: null, totalMs: null };
+  }
+
+  const executionMs = startedAt != null ? Math.max(0, endedAt - startedAt) : 0;
+  return { inngestMs, executionMs, totalMs: inngestMs + executionMs };
 }
 
 /**
@@ -98,7 +106,7 @@ function calculateTimingBreakdown(
 function getTimingFromMetadata(
   trace: Trace,
   metadata?: SpanMetadata[]
-): { inngestMs: number; executionMs: number; totalMs: number } | null {
+): { inngestMs: number; executionMs: number | null; totalMs: number | null } | null {
   if (!metadata) return null;
 
   const timing = metadata.find((m): m is SpanMetadataInngestTiming => m.kind === 'inngest.timing');
@@ -107,14 +115,17 @@ function getTimingFromMetadata(
 
   const inngestMs = timing.values.total_inngest_ms ?? 0;
 
-  // Execution time is still derived from span timestamps since the metadata
-  // captures Inngest-side overhead, not SDK execution duration.
+  // Execution time is derived from span timestamps. For in-progress spans
+  // we return null so the render path computes it live against Date.now().
   const startedAt = trace.startedAt ? new Date(trace.startedAt).getTime() : null;
-  const endedAt = trace.endedAt ? new Date(trace.endedAt).getTime() : Date.now();
-  const executionMs = startedAt ? Math.max(0, endedAt - startedAt) : 0;
-  const totalMs = inngestMs + executionMs;
+  const endedAt = trace.endedAt ? new Date(trace.endedAt).getTime() : null;
 
-  return { inngestMs, executionMs, totalMs };
+  if (endedAt == null) {
+    return { inngestMs, executionMs: null, totalMs: null };
+  }
+
+  const executionMs = startedAt != null ? Math.max(0, endedAt - startedAt) : 0;
+  return { inngestMs, executionMs, totalMs: inngestMs + executionMs };
 }
 
 /**
@@ -257,17 +268,26 @@ export function traceToTimelineData(
 ): TimelineData {
   const { orgName, leftWidth = TIMELINE_CONSTANTS.DEFAULT_LEFT_WIDTH, functionSlug } = options;
 
-  // Calculate min/max time from the entire trace tree
+  // Calculate min/max time from the entire trace tree. `maxTime` stays null
+  // while the run is in progress so callers substitute a live `Date.now()`
+  // — baking a snapshot here would freeze inside the upstream useMemo.
   let minTime = new Date(trace.queuedAt);
-  let maxTime = trace.endedAt ? new Date(trace.endedAt) : new Date();
+  let maxTime: Date | null = trace.endedAt ? new Date(trace.endedAt) : null;
+  let anyInProgress = !trace.endedAt;
 
   traceWalk(trace, (t) => {
     minTime = min([minTime, new Date(t.queuedAt)]);
     const endedAt = t.endedAt ? new Date(t.endedAt) : null;
     if (endedAt) {
-      maxTime = max([endedAt, maxTime]);
+      maxTime = maxTime ? max([endedAt, maxTime]) : endedAt;
+    } else {
+      anyInProgress = true;
     }
   });
+
+  if (anyInProgress) {
+    maxTime = null;
+  }
 
   // Run startedAt timestamp for computing per-step discovery time
   const runStartedAtMs = trace.startedAt ? new Date(trace.startedAt).getTime() : null;
@@ -287,12 +307,16 @@ export function traceToTimelineData(
   // Sum execution time from all step children, and attribute the rest to Inngest overhead.
   // For children without a timingBreakdown (sleep, waitForEvent, invoke, etc.),
   // use their wall-clock duration as execution time so it isn't misattributed as overhead.
-  if (rootBar.endTime) {
+  // Only roll up the root bar's timingBreakdown for fully-completed runs.
+  // While any child is in-progress, both the run duration and child execution
+  // sums are live (Date.now()-dependent); baking them here would freeze
+  // inside useMemo. The renderer handles the in-progress root via segments.
+  if (rootBar.endTime && !anyInProgress) {
     const runDurationMs = rootBar.endTime.getTime() - rootBar.startTime.getTime();
     if (runDurationMs > 0) {
       let totalExecutionMs = 0;
       for (const child of rootBar.children ?? []) {
-        if (child.timingBreakdown) {
+        if (child.timingBreakdown?.executionMs != null) {
           totalExecutionMs += child.timingBreakdown.executionMs;
         } else if (child.endTime) {
           totalExecutionMs += Math.max(0, child.endTime.getTime() - child.startTime.getTime());


### PR DESCRIPTION
## Description

  - Problem: We're in the process of reporting in progress steps during checkpointing, however they're looking funky. On the run timeline in the dashboard, the "Inngest" bar grows to fill the parent bar while a run was in progress, crowding out the "Your server" bar.
 
<img width="803" height="397" alt="Screenshot 2026-05-19 at 4 11 10 PM" src="https://github.com/user-attachments/assets/886265e5-057d-4d0b-b46a-de6f42de497d" />


  - Root cause: Two Date.now() clocks rendered in the same frame disagreed.  calculateTimingBreakdown baked executionMs in Date.now(), while calculateBarPosition read live Date.now()
  - To fix, we avoid baking in Date.now and instead pass nulls and a live nowMs.

After

<img width="803" height="88" alt="image" src="https://github.com/user-attachments/assets/7530b62f-652e-44f2-9768-d53777ba3897" />

- I produced this with https://github.com/inngest/inngest-js/pull/1530 which will be merged after this PR

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
- Improves the rendering of in progress steps when checkpointing is active

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
