### PR TITLE
chore: Run prettier after generating files

### DIFF
--- a/ui/apps/dev-server-ui/codegen.ts
+++ b/ui/apps/dev-server-ui/codegen.ts
@@ -21,6 +21,9 @@ const codegenConfig: CodegenConfig = {
   overwrite: true,
   schema: '../../../pkg/coreapi/**/*.graphql',
   documents: 'src/**/*',
+  hooks: {
+    afterOneFileWrite: ['prettier --write'],
+  },
   generates: {
     //
     // a type-only version without the rtk-query dep so the cross-app


### PR DESCRIPTION
## Description

- Sometimes I'll see a file hanging around after running the dev server with formatting changes
- Run prettier after generating the file to get it to match its committed state

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
