### PR TITLE
internal: wrap getParentSpan in a retry

### DIFF
--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -17,6 +18,7 @@ import (
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/publicerr"
+	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"github.com/inngest/inngest/pkg/tracing"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
@@ -118,10 +120,43 @@ type AddRunMetadataRequest struct {
 }
 
 func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID ulid.ULID, req *AddRunMetadataRequest) error {
-	parentSpan, scope, err := a.getParentSpan(ctx, auth, runID, &req.Target)
+	var parentSpan *cqrs.OtelSpan
+	var scope metadata.Scope
+	var err error
+	var attempts int
+	start := time.Now()
+
+	// This retry only exists because of eventual consistency in ClickHouse
+	// data. There's a race condition where the parent span may not be queryable
+	// when the metadata update arrives.
+	//
+	// There's also a related race where a successful retry span isn't queryable
+	// yet, which causes us to mistakenly update metadata on a prior failed
+	// attempt.
+	//
+	// TODO: We should replace this hack with a proper fix. But a proper fix
+	// likely requires changes in our ClickHouse trace schema.
+	_, err = util.WithRetry(
+		ctx,
+		"apiv1.AddRunMetadata.getParentSpan",
+		func(ctx context.Context) (any, error) {
+			attempts++
+			parentSpan, scope, err = a.getParentSpan(ctx, auth, runID, &req.Target)
+			return nil, err
+		},
+		util.NewRetryConf(),
+	)
 	if err != nil {
 		return err
 	}
+	metrics.HistogramMetadataGetParentSpanDuration(
+		ctx,
+		time.Since(start),
+		attempts,
+		metrics.HistogramOpt{
+			PkgName: pkgName,
+		},
+	)
 
 	// Load run metadata to enforce the per-run cumulative size limit against
 	// metadata that already exists in the run, not just this request.

--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -147,6 +147,14 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 		util.NewRetryConf(),
 	)
 	if err != nil {
+		logger.StdlibLogger(ctx).ErrorSample(
+			1,
+			"failed to get parent span for metadata",
+			"error", err,
+			"attempts", attempts,
+			"run_id", runID,
+			"target", req.Target,
+		)
 		return err
 	}
 	metrics.HistogramMetadataGetParentSpanDuration(

--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -134,6 +134,10 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 	// yet, which causes us to mistakenly update metadata on a prior failed
 	// attempt.
 	//
+	// The retry config is sized so that the cumulative backoff covers roughly
+	// one minute, which gives the Kafka→ClickHouse pipeline time to land the
+	// span.
+	//
 	// TODO: We should replace this hack with a proper fix. But a proper fix
 	// likely requires changes in our ClickHouse trace schema.
 	_, err = util.WithRetry(
@@ -144,11 +148,15 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 			parentSpan, scope, err = a.getParentSpan(ctx, auth, runID, &req.Target)
 			return nil, err
 		},
-		util.NewRetryConf(),
+		// 2s → 4s → 8s → 15s → 15s → 15s
+		util.NewRetryConf(
+			util.WithRetryConfMaxAttempts(7),
+			util.WithRetryConfInitialBackoff(2*time.Second),
+			util.WithRetryConfMaxBackoff(15*time.Second),
+		),
 	)
 	if err != nil {
-		logger.StdlibLogger(ctx).ErrorSample(
-			1,
+		logger.StdlibLogger(ctx).Error(
 			"failed to get parent span for metadata",
 			"error", err,
 			"attempts", attempts,
@@ -293,6 +301,9 @@ func (a router) getParentSpan(ctx context.Context, auth apiv1auth.V1Auth, runID 
 	// TODO: specific err cases
 	case err != nil:
 		return nil, 0, publicerr.Wrap(err, 404, "Unable to find metadata target")
+	case span == nil:
+		// Cloud's GetRunSpanByRunID implementation can return `(nil, nil)`
+		return nil, 0, publicerr.Errorf(404, "Unable to find metadata target")
 	}
 
 	return span, scope, nil

--- a/pkg/logger/stdlib.go
+++ b/pkg/logger/stdlib.go
@@ -87,11 +87,6 @@ type Logger interface {
 	// Non-sampled logs are logged as a trace.
 	DebugSample(percent int, msg string, args ...any)
 
-	// ErrorSample samples a % of time to produce an error log, between 0-100.
-	// Non-sampled logs are dropped. Use for expected, high-volume errors where
-	// a metric is the primary signal and a log is only useful occasionally.
-	ErrorSample(percent int, msg string, args ...any)
-
 	// ReportError is a wrapper over Error, and will also submit a report to the error report tool
 	ReportError(err error, msg string, opts ...ReportErrorOpt)
 }
@@ -285,14 +280,6 @@ type logger struct {
 func (l *logger) DebugSample(percent int, msg string, args ...any) {
 	if rand.Intn(100) < percent {
 		l.Debug(msg, args...)
-		return
-	}
-	l.Trace(msg, args...)
-}
-
-func (l *logger) ErrorSample(percent int, msg string, args ...any) {
-	if rand.Intn(100) < percent {
-		l.Error(msg, args...)
 		return
 	}
 	l.Trace(msg, args...)

--- a/pkg/logger/stdlib.go
+++ b/pkg/logger/stdlib.go
@@ -87,6 +87,11 @@ type Logger interface {
 	// Non-sampled logs are logged as a trace.
 	DebugSample(percent int, msg string, args ...any)
 
+	// ErrorSample samples a % of time to produce an error log, between 0-100.
+	// Non-sampled logs are dropped. Use for expected, high-volume errors where
+	// a metric is the primary signal and a log is only useful occasionally.
+	ErrorSample(percent int, msg string, args ...any)
+
 	// ReportError is a wrapper over Error, and will also submit a report to the error report tool
 	ReportError(err error, msg string, opts ...ReportErrorOpt)
 }
@@ -280,6 +285,14 @@ type logger struct {
 func (l *logger) DebugSample(percent int, msg string, args ...any) {
 	if rand.Intn(100) < percent {
 		l.Debug(msg, args...)
+		return
+	}
+	l.Trace(msg, args...)
+}
+
+func (l *logger) ErrorSample(percent int, msg string, args ...any) {
+	if rand.Intn(100) < percent {
+		l.Error(msg, args...)
 		return
 	}
 	l.Trace(msg, args...)

--- a/pkg/telemetry/metrics/histogram.go
+++ b/pkg/telemetry/metrics/histogram.go
@@ -655,3 +655,29 @@ func HistogramDefersPerRun(ctx context.Context, count int64, opts HistogramOpt) 
 		Boundaries:  []float64{1, 2, 5, 10, 15, 20},
 	})
 }
+
+func HistogramMetadataGetParentSpanDuration(
+	ctx context.Context,
+	dur time.Duration,
+	attempts int,
+	opts HistogramOpt,
+) {
+	if opts.Tags == nil {
+		opts.Tags = map[string]any{}
+	}
+
+	// Always be true, but we'll add this check to protect cardinality just in
+	// case
+	if attempts < 10 {
+		opts.Tags["attempts"] = attempts
+	}
+
+	RecordIntHistogramMetric(ctx, dur.Milliseconds(), HistogramOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "metadata_get_parent_span_duration",
+		Description: "Distribution of latency when getting parent span in metadata endpoint",
+		Tags:        opts.Tags,
+		Unit:        "ms",
+		Boundaries:  []float64{10, 50, 100, 200, 500, 1000, 2000, 5000, 10000, 30000, 60000, 120_000},
+	})
+}


### PR DESCRIPTION
## Description
Wrap `getParentSpan()` call with a retry in the metadata update API endpoint. This is a short term fix to handle eventual consistency in ClickHouse.

Also include a histogram metric and sampled error logging

