### PR TITLE
perf(batch): Split batch partition into function-scoped partitions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -166,7 +166,6 @@ jobs:
           TEST_MODE: true
           TEST_DATABASE: ${{ matrix.database }}
           EXPERIMENTAL_KEY_QUEUES_ENABLE: "${{ matrix.experimentalKeyQueues }}"
-          EXPERIMENTAL_SPLIT_BATCH_PARTITION_BY_WORKSPACE: "true"
 
       - name: Convert coverage for tooling
         run: |
@@ -187,6 +186,94 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: go-e2e,split-${{ matrix.index }},kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }}
+
+  batch:
+    name: "Batch / OS: (${{ matrix.os }}), key-queues: ${{ matrix.experimentalKeyQueues }}, db: ${{ matrix.database }}, split-batch-partition: ${{ matrix.splitBatchPartition }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        experimentalKeyQueues: [false, true]
+        database: [sqlite, postgres]
+        splitBatchPartition: [false, true]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+
+      - name: Start postgres container
+        if: matrix.database == 'postgres'
+        run: |
+          docker run -d --name inngest-test-postgres \
+            -e POSTGRES_USER=postgres \
+            -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_DB=inngest_test \
+            -p 5432:5432 \
+            postgres:17
+          # Wait for postgres to be ready
+          for i in $(seq 1 30); do
+            if docker exec inngest-test-postgres pg_isready -U postgres > /dev/null 2>&1; then
+              echo "Postgres is ready"
+              break
+            fi
+            if [ "$i" = "30" ]; then
+              echo "ERROR: Postgres failed to start"
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Build dev server
+        run: go build -cover -o ./inngest-bin ./cmd
+
+      - name: Run batch E2E tests
+        run: |
+          echo "Running dev server"
+          mkdir $GOCOVERDIR
+          if [ "${{ matrix.database }}" = "postgres" ]; then
+            nohup ./inngest-bin dev --no-discovery --no-poll --postgres-uri "postgres://postgres:postgres@localhost:5432/inngest_test?sslmode=disable" 2> /tmp/dev-output.txt &
+          else
+            nohup ./inngest-bin dev --no-discovery --no-poll 2> /tmp/dev-output.txt &
+          fi
+          echo "Ran dev server"
+          sleep 5
+          curl http://127.0.0.1:8288/dev > /dev/null 2> /dev/null
+
+          go test ./tests/batch/... -v -count=1
+        env:
+          API_URL: http://127.0.0.1:8288
+          INNGEST_EVENT_KEY: test
+          INNGEST_SIGNING_KEY: 7468697320697320612074657374206b6579
+          INNGEST_DEV: http://127.0.0.1:8288
+          TEST_MODE: true
+          TEST_DATABASE: ${{ matrix.database }}
+          EXPERIMENTAL_KEY_QUEUES_ENABLE: "${{ matrix.experimentalKeyQueues }}"
+          EXPERIMENTAL_SPLIT_BATCH_PARTITION_BY_WORKSPACE: "${{ matrix.splitBatchPartition }}"
+
+      - name: Convert coverage for tooling
+        run: |
+          ls -la $GOCOVERDIR
+          go tool covdata percent -i=$GOCOVERDIR | tee coverage.txt
+
+      - name: Upload devserver logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: devserver-logs-batch-kq-${{ matrix.experimentalKeyQueues }}-db-${{ matrix.database }}-split-${{ matrix.splitBatchPartition }}
+          path: /tmp/dev-output.txt
+          retention-days: 7
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: batch-e2e,kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }},split-${{ matrix.splitBatchPartition }}
 
   api:
     name: "API / OS: (${{ matrix.os }}), key-queues: ${{ matrix.experimentalKeyQueues }}, db: ${{ matrix.database }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -166,6 +166,7 @@ jobs:
           TEST_MODE: true
           TEST_DATABASE: ${{ matrix.database }}
           EXPERIMENTAL_KEY_QUEUES_ENABLE: "${{ matrix.experimentalKeyQueues }}"
+          EXPERIMENTAL_SPLIT_BATCH_PARTITION_BY_WORKSPACE: "true"
 
       - name: Convert coverage for tooling
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -254,7 +254,7 @@ jobs:
           TEST_MODE: true
           TEST_DATABASE: ${{ matrix.database }}
           EXPERIMENTAL_KEY_QUEUES_ENABLE: "${{ matrix.experimentalKeyQueues }}"
-          EXPERIMENTAL_SPLIT_BATCH_PARTITION_BY_WORKSPACE: "${{ matrix.splitBatchPartition }}"
+          EXPERIMENTAL_SPLIT_BATCH_PARTITION_BY_FUNCTION: "${{ matrix.splitBatchPartition }}"
 
       - name: Convert coverage for tooling
         run: |

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -408,14 +408,14 @@ func start(ctx context.Context, opts StartOpts) error {
 	// to enable zero-downtime migration between Redis clusters via
 	// batch.NewMigratingBatchManager.
 	//
-	// EXPERIMENTAL_SPLIT_BATCH_PARTITION_BY_WORKSPACE controls the
+	// EXPERIMENTAL_SPLIT_BATCH_PARTITION_BY_FUNCTION controls the
 	// schedule-batch routing experiment: when "true", schedule-batch jobs go to
-	// a workspace-scoped system partition; otherwise they share the global
+	// a function-scoped system partition; otherwise they share the global
 	// schedule-batch partition.
-	splitBatchPartitionByWorkspace := os.Getenv("EXPERIMENTAL_SPLIT_BATCH_PARTITION_BY_WORKSPACE") == "true"
+	splitBatchPartitionByFunction := os.Getenv("EXPERIMENTAL_SPLIT_BATCH_PARTITION_BY_FUNCTION") == "true"
 	batchOpts := []batch.RedisBatchManagerOpt{batch.WithLogger(l)}
-	if splitBatchPartitionByWorkspace {
-		batchOpts = append(batchOpts, batch.WithSplitBatchPartitionByWorkspace(func(_ context.Context, _ uuid.UUID) bool {
+	if splitBatchPartitionByFunction {
+		batchOpts = append(batchOpts, batch.WithSplitBatchPartitionByFunction(func(_ context.Context, _ uuid.UUID) bool {
 			return true
 		}))
 	}

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -407,7 +407,19 @@ func start(ctx context.Context, opts StartOpts) error {
 	// Create the batch manager. In production, a second BatchClient can be provided
 	// to enable zero-downtime migration between Redis clusters via
 	// batch.NewMigratingBatchManager.
-	batcher := batch.NewRedisBatchManager(shardedClient.Batch(), rq, batch.WithLogger(l))
+	//
+	// EXPERIMENTAL_SPLIT_BATCH_PARTITION_BY_WORKSPACE controls the
+	// schedule-batch routing experiment: when "true", schedule-batch jobs go to
+	// a workspace-scoped system partition; otherwise they share the global
+	// schedule-batch partition.
+	splitBatchPartitionByWorkspace := os.Getenv("EXPERIMENTAL_SPLIT_BATCH_PARTITION_BY_WORKSPACE") == "true"
+	batchOpts := []batch.RedisBatchManagerOpt{batch.WithLogger(l)}
+	if splitBatchPartitionByWorkspace {
+		batchOpts = append(batchOpts, batch.WithSplitBatchPartitionByWorkspace(func(_ context.Context, _ uuid.UUID) bool {
+			return true
+		}))
+	}
+	batcher := batch.NewRedisBatchManager(shardedClient.Batch(), rq, batchOpts...)
 	debouncer, err := debounce.NewDebouncer(shardRegistry, queueShard.Name(), rq)
 	if err != nil {
 		return fmt.Errorf("could not create debounce manager: %w", err)

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -76,6 +76,18 @@ func WithoutBuffer() RedisBatchManagerOpt {
 	}
 }
 
+// WithSplitBatchPartitionByWorkspace registers a gate that controls whether
+// scheduled batch jobs are enqueued to a workspace-scoped system partition
+// (queue.KindScheduleBatch:<workspaceID>) instead of the single shared
+// schedule-batch partition. When the gate returns true for an accountID, that
+// account's workspaces each get their own batch schedule partition, avoiding
+// cross-workspace head-of-line blocking on the shared system queue.
+func WithSplitBatchPartitionByWorkspace(fn func(ctx context.Context, accountID uuid.UUID) (enable bool)) RedisBatchManagerOpt {
+	return func(m *redisBatchManager) {
+		m.splitBatchPartitionByWorkspace = fn
+	}
+}
+
 // NewRedisBatchManager creates a new redis batch manager, using Redis as the backing manager.
 //
 // Note that this buffers in-memory using the defaults via [DefaultMaxBufferDuration] and
@@ -114,6 +126,12 @@ type redisBatchManager struct {
 	// When nil, appends go directly to Redis. When set, appends are buffered
 	// and flushed periodically or when the buffer is full.
 	buffer *appendBuffer
+
+	// splitBatchPartitionByWorkspace, when non-nil and returning true for a
+	// given accountID, causes ScheduleExecution to enqueue the batch-scheduling
+	// job to a workspace-scoped system partition rather than the shared
+	// schedule-batch partition.
+	splitBatchPartitionByWorkspace func(ctx context.Context, accountID uuid.UUID) (enable bool)
 }
 
 func (b *redisBatchManager) batchKey(ctx context.Context, evt event.Event, fn inngest.Function) (string, error) {
@@ -305,7 +323,10 @@ func (b *redisBatchManager) ScheduleExecution(ctx context.Context, opts Schedule
 	jobID := opts.JobID()
 	maxAttempts := consts.MaxRetries + 1
 
-	queueName := fmt.Sprintf("%s:%s", queue.KindScheduleBatch, opts.WorkspaceID)
+	queueName := queue.KindScheduleBatch
+	if b.splitBatchPartitionByWorkspace != nil && b.splitBatchPartitionByWorkspace(ctx, opts.AccountID) {
+		queueName = fmt.Sprintf("%s:%s", queue.KindScheduleBatch, opts.WorkspaceID)
+	}
 	err := b.q.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
 		GroupID:     uuid.New().String(),

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -76,15 +76,15 @@ func WithoutBuffer() RedisBatchManagerOpt {
 	}
 }
 
-// WithSplitBatchPartitionByWorkspace registers a gate that controls whether
-// scheduled batch jobs are enqueued to a workspace-scoped system partition
-// (queue.KindScheduleBatch:<workspaceID>) instead of the single shared
+// WithSplitBatchPartitionByFunction registers a gate that controls whether
+// scheduled batch jobs are enqueued to a function-scoped system partition
+// (queue.KindScheduleBatch:<functionID>) instead of the single shared
 // schedule-batch partition. When the gate returns true for an accountID, that
-// account's workspaces each get their own batch schedule partition, avoiding
-// cross-workspace head-of-line blocking on the shared system queue.
-func WithSplitBatchPartitionByWorkspace(fn func(ctx context.Context, accountID uuid.UUID) (enable bool)) RedisBatchManagerOpt {
+// account's functions each get their own batch schedule partition, avoiding
+// cross-function head-of-line blocking on the shared system queue.
+func WithSplitBatchPartitionByFunction(fn func(ctx context.Context, accountID uuid.UUID) (enable bool)) RedisBatchManagerOpt {
 	return func(m *redisBatchManager) {
-		m.splitBatchPartitionByWorkspace = fn
+		m.splitBatchPartitionByFunction = fn
 	}
 }
 
@@ -127,11 +127,11 @@ type redisBatchManager struct {
 	// and flushed periodically or when the buffer is full.
 	buffer *appendBuffer
 
-	// splitBatchPartitionByWorkspace, when non-nil and returning true for a
+	// splitBatchPartitionByFunction, when non-nil and returning true for a
 	// given accountID, causes ScheduleExecution to enqueue the batch-scheduling
-	// job to a workspace-scoped system partition rather than the shared
+	// job to a function-scoped system partition rather than the shared
 	// schedule-batch partition.
-	splitBatchPartitionByWorkspace func(ctx context.Context, accountID uuid.UUID) (enable bool)
+	splitBatchPartitionByFunction func(ctx context.Context, accountID uuid.UUID) (enable bool)
 }
 
 func (b *redisBatchManager) batchKey(ctx context.Context, evt event.Event, fn inngest.Function) (string, error) {
@@ -324,8 +324,8 @@ func (b *redisBatchManager) ScheduleExecution(ctx context.Context, opts Schedule
 	maxAttempts := consts.MaxRetries + 1
 
 	queueName := queue.KindScheduleBatch
-	if b.splitBatchPartitionByWorkspace != nil && b.splitBatchPartitionByWorkspace(ctx, opts.AccountID) {
-		queueName = fmt.Sprintf("%s:%s", queue.KindScheduleBatch, opts.WorkspaceID)
+	if b.splitBatchPartitionByFunction != nil && b.splitBatchPartitionByFunction(ctx, opts.AccountID) {
+		queueName = fmt.Sprintf("%s:%s", queue.KindScheduleBatch, opts.FunctionID)
 	}
 	err := b.q.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -305,7 +305,7 @@ func (b *redisBatchManager) ScheduleExecution(ctx context.Context, opts Schedule
 	jobID := opts.JobID()
 	maxAttempts := consts.MaxRetries + 1
 
-	queueName := queue.KindScheduleBatch
+	queueName := fmt.Sprintf("%s:%s", queue.KindScheduleBatch, opts.WorkspaceID)
 	err := b.q.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
 		GroupID:     uuid.New().String(),

--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -19,6 +19,7 @@ import (
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/oklog/ulid/v2"
 	"github.com/redis/rueidis"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -86,7 +87,7 @@ func NewRedisBatchManager(b *redis_state.BatchClient, q queue.QueueManager, opts
 		q:                 q,
 		sizeLimit:         defaultBatchSizeLimit,
 		idempotenceSetTTL: defaultEventIdempotenceSetTTL,
-		log:                                logger.StdlibLogger(context.Background()),
+		log:               logger.StdlibLogger(context.Background()),
 	}
 
 	// add default buffer
@@ -228,8 +229,6 @@ func (b *redisBatchManager) Append(ctx context.Context, bi BatchItem, fn inngest
 
 // RetrieveItems retrieve the data associated with the specified batch.
 func (b *redisBatchManager) RetrieveItems(ctx context.Context, functionId uuid.UUID, batchID ulid.ULID) ([]BatchItem, error) {
-	empty := make([]BatchItem, 0)
-
 	itemStrList, err := retriableScripts["retrieve"].Exec(
 		ctx,
 		b.b.Client(),
@@ -237,16 +236,22 @@ func (b *redisBatchManager) RetrieveItems(ctx context.Context, functionId uuid.U
 		[]string{},
 	).AsStrSlice()
 	if err != nil {
-		return empty, fmt.Errorf("failed to retrieve list of events for batch '%s': %v", batchID, err)
+		return nil, fmt.Errorf("failed to retrieve list of events for batch '%s': %v", batchID, err)
 	}
 
-	items := []BatchItem{}
-	for _, str := range itemStrList {
-		item := &BatchItem{}
-		if err := json.Unmarshal([]byte(str), &item); err != nil {
-			return empty, fmt.Errorf("failed to decode item for batch '%s': %v", batchID, err)
-		}
-		items = append(items, *item)
+	items := make([]BatchItem, len(itemStrList))
+	var eg errgroup.Group
+	eg.SetLimit(20)
+	for i, str := range itemStrList {
+		eg.Go(func() error {
+			if err := json.Unmarshal([]byte(str), &items[i]); err != nil {
+				return fmt.Errorf("failed to decode item for batch '%s': %v", batchID, err)
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 
 	return items, nil

--- a/pkg/execution/queue/process_partition.go
+++ b/pkg/execution/queue/process_partition.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/inngest/inngest/pkg/logger"
@@ -224,6 +225,12 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 	// parallel all queue names with internal mappings for now.
 	// XXX: Allow parallel partitions for all functions except for fns opting into FIFO
 	_, isSystemFn := q.queueKindMapping[p.Queue()]
+	// Workspace-scoped batch partitions ("schedule-batch:<wsID>") still get
+	// parallel within-partition processing even though the suffixed name is
+	// not in queueKindMapping.
+	if strings.HasPrefix(p.Queue(), KindScheduleBatch+":") {
+		isSystemFn = true
+	}
 	_, parallelFn := q.disableFifoForFunctions[p.Queue()]
 	_, parallelAccount := q.disableFifoForAccounts[p.AccountID.String()]
 

--- a/pkg/execution/queue/process_partition.go
+++ b/pkg/execution/queue/process_partition.go
@@ -228,7 +228,7 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 	// Workspace-scoped batch partitions ("schedule-batch:<wsID>") still get
 	// parallel within-partition processing even though the suffixed name is
 	// not in queueKindMapping.
-	if strings.HasPrefix(p.Queue(), KindScheduleBatch+":") {
+	if strings.HasPrefix(p.Queue(), KindScheduleBatch) {
 		isSystemFn = true
 	}
 	_, parallelFn := q.disableFifoForFunctions[p.Queue()]

--- a/pkg/execution/queue/process_partition.go
+++ b/pkg/execution/queue/process_partition.go
@@ -225,7 +225,7 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 	// parallel all queue names with internal mappings for now.
 	// XXX: Allow parallel partitions for all functions except for fns opting into FIFO
 	_, isSystemFn := q.queueKindMapping[p.Queue()]
-	// Workspace-scoped batch partitions ("schedule-batch:<wsID>") still get
+	// Function-scoped batch partitions ("schedule-batch:<fnID>") still get
 	// parallel within-partition processing even though the suffixed name is
 	// not in queueKindMapping.
 	if strings.HasPrefix(p.Queue(), KindScheduleBatch) {

--- a/tests/batch/batch_test.go
+++ b/tests/batch/batch_test.go
@@ -1,4 +1,4 @@
-package golang
+package batch
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/tests/client"
+	testgolang "github.com/inngest/inngest/tests/golang"
 	"github.com/inngest/inngestgo"
 	"github.com/inngest/inngestgo/step"
 	"github.com/oklog/ulid/v2"
@@ -30,7 +31,7 @@ type BatchEvent = inngestgo.GenericEvent[BatchEventData]
 func TestBatchEvents(t *testing.T) {
 	ctx := context.Background()
 	c := client.New(t)
-	inngestClient, server, registerFuncs := NewSDKHandler(t, "batch")
+	inngestClient, server, registerFuncs := testgolang.NewSDKHandler(t, "batch")
 	defer server.Close()
 
 	var (
@@ -110,7 +111,7 @@ func TestBatchEvents(t *testing.T) {
 
 func TestMunsonRepro(t *testing.T) {
 	ctx := context.Background()
-	inngestClient, server, registerFuncs := NewSDKHandler(t, "batch")
+	inngestClient, server, registerFuncs := testgolang.NewSDKHandler(t, "batch")
 	defer server.Close()
 
 	var (
@@ -168,7 +169,7 @@ func TestMunsonRepro(t *testing.T) {
 
 func TestBatchWithConditionalTrigger(t *testing.T) {
 	ctx := context.Background()
-	inngestClient, server, registerFuncs := NewSDKHandler(t, "batch")
+	inngestClient, server, registerFuncs := testgolang.NewSDKHandler(t, "batch")
 	defer server.Close()
 
 	var (
@@ -211,7 +212,7 @@ func TestBatchWithConditionalTrigger(t *testing.T) {
 
 func TestConditionalBatching(t *testing.T) {
 	ctx := context.Background()
-	inngestClient, server, registerFuncs := NewSDKHandler(t, "batch")
+	inngestClient, server, registerFuncs := testgolang.NewSDKHandler(t, "batch")
 	defer server.Close()
 
 	var (
@@ -257,7 +258,7 @@ func TestConditionalBatching(t *testing.T) {
 
 func TestConditionalBatchingWithEventTriggerCondition(t *testing.T) {
 	ctx := context.Background()
-	inngestClient, server, registerFuncs := NewSDKHandler(t, "batch")
+	inngestClient, server, registerFuncs := testgolang.NewSDKHandler(t, "batch")
 	defer server.Close()
 
 	var (
@@ -305,7 +306,7 @@ func TestConditionalBatchingWithEventTriggerCondition(t *testing.T) {
 
 func TestBatchInvoke(t *testing.T) {
 	ctx := context.Background()
-	inngestClient, server, registerFuncs := NewSDKHandler(t, "batchinvoke")
+	inngestClient, server, registerFuncs := testgolang.NewSDKHandler(t, "batchinvoke")
 	defer server.Close()
 
 	var (
@@ -400,7 +401,7 @@ func TestBatchKeyEvents(t *testing.T) {
 	type BatchEventWithKey = inngestgo.GenericEvent[BatchEventDataWithUserId]
 
 	ctx := context.Background()
-	inngestClient, server, registerFuncs := NewSDKHandler(t, "user-notifications")
+	inngestClient, server, registerFuncs := testgolang.NewSDKHandler(t, "user-notifications")
 	defer server.Close()
 
 	var totalEvents int32


### PR DESCRIPTION
## Description

**Split batch partition into workspace-scoped partitions.**
  - This can be flag gated by account and defaults to false. 
  - The flag gate is fully forward and backward compatible. 
  - When enabled, any existing batch queue item in the global `schedule-batch` partition will continue to drain. New batches will be scheduled in the workspace scoped partition.

**Parallelize json unmarshal in batch.RetrieveItems**
In `batch.RetrieveItems`, cpu profiles show a bug chunk of time spent unmarshalling bytes into json objects. Parallelize that loop 
<img width="1720" height="983" alt="Screenshot 2026-05-20 at 2 19 04 PM" src="https://github.com/user-attachments/assets/37a3229c-dafb-401e-9599-1a3cacdfcb39" />


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
