### PR TITLE
fix: EXE-1547: Tolerate out of order Opcodes in OSS

### DIFF
--- a/pkg/cqrs/manager/cqrs.go
+++ b/pkg/cqrs/manager/cqrs.go
@@ -267,6 +267,27 @@ func fragmentAttributesJSON(raw any) ([]byte, bool) {
 	}
 }
 
+// fragmentEndTime extracts the end_time field from a decoded span fragment.
+//
+// Missing or unparseable values return the zero time so fragments without
+// end_time sort before any real value.
+func fragmentEndTime(fragment map[string]any) time.Time {
+	raw, ok := fragment["end_time"].(string)
+	if !ok || raw == "" {
+		return time.Time{}
+	}
+	s := strings.Split(raw, " m=")[0]
+	for _, layout := range []string{
+		"2006-01-02 15:04:05.999999999 -0700 MST",
+		time.RFC3339Nano,
+	} {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
 func mapSpanFromRow[T normalizedSpan](ctx context.Context, span T, info *spanRollupInfo) (*cqrs.OtelSpan, error) {
 	// Use interface methods to get the fields directly
 	traceID := span.GetTraceID()
@@ -361,6 +382,16 @@ func mapSpanFromRow[T normalizedSpan](ctx context.Context, span T, info *spanRol
 	}
 
 	_ = json.Unmarshal(spanFragmentsBytes, &fragments)
+
+	// Sort fragments by end_time ascending so the maps.Copy merge below
+	// resolves status deterministically by causal order rather than row
+	// insertion order.
+	//
+	// We sort these fragments in Go rather than sql, as sqlc's SQL parser
+	// doesn't accept `ORDER BY end_time` inside `json_group_array(...)`.
+	sort.SliceStable(fragments, func(i, j int) bool {
+		return fragmentEndTime(fragments[i]).Before(fragmentEndTime(fragments[j]))
+	})
 
 fragmentLoop:
 	for _, fragment := range fragments {

--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +17,9 @@ import (
 	dbpostgres "github.com/inngest/inngest/pkg/db/postgres"
 	dbsqlite "github.com/inngest/inngest/pkg/db/sqlite"
 	"github.com/inngest/inngest/pkg/enums"
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/tests/testutil"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
@@ -1763,6 +1767,108 @@ func TestCQRSGetSpan(t *testing.T) {
 	})
 }
 
+// TestCQRSTracerWritesEndTimeFromOpts verifies that the
+// tracer's CreateSpan stamps the stored end_time from caller-supplied
+// timing rather than wall-clock-at-processing.
+//
+// This test exercises the actual tracer write path (CreateSpan ->
+// dbExporter -> InsertSpan) end-to-end, then reads the on-disk rows to
+// confirm the late RUNNING row's end_time matches its caller-supplied
+// start_time, not the (much later) moment we invoked CreateSpan.
+func TestCQRSTracerWritesEndTimeFromOpts(t *testing.T) {
+	cm, cleanup := initCQRS(t)
+	defer cleanup()
+
+	// Build the real sqlc-backed tracer against the same DB the manager
+	// reads from.
+	q := cm.(wrapper).q
+	tp := tracing.NewSqlcTracerProvider(q)
+
+	runIDULID := ulid.MustNew(ulid.Now(), rand.Reader)
+	runID := runIDULID.String()
+	const dynID = "dyn-step-race"
+	t0 := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	t1 := t0.Add(10 * time.Millisecond) // step body finishes
+
+	mkExecCtx := func() context.Context {
+		return tracing.WithExecutionContext(t.Context(), tracing.ExecutionContext{
+			Identifier: statev2.ID{RunID: runIDULID},
+		})
+	}
+
+	// COMPLETED step span — arrives first, caller supplies both timings.
+	_, err := tp.CreateSpan(mkExecCtx(), meta.SpanNameStep, &tracing.CreateSpanOptions{
+		DynamicSpanIDOverride: dynID,
+		StartTime:             t0,
+		EndTime:               t1,
+		Attributes: meta.NewAttrSet(
+			meta.Attr(meta.Attrs.RunID, &runIDULID),
+		),
+	})
+	require.NoError(t, err)
+
+	// Simulate the executor handling the late leading-edge POST well after
+	// the step body has finished. The SDK-supplied StartTime is still t0
+	// (captured before the step body ran); EndTime is intentionally omitted
+	// because the leading-edge POST represents a span that hasn't ended.
+	//
+	// Sleep so wall-clock now is decisively past t1: if the tracer ever
+	// regresses back to stamping wall-clock, the row's end_time will exceed
+	// t1 and the assertion below catches it.
+	time.Sleep(20 * time.Millisecond)
+	_, err = tp.CreateSpan(mkExecCtx(), meta.SpanNameStep, &tracing.CreateSpanOptions{
+		DynamicSpanIDOverride: dynID,
+		StartTime:             t0,
+		// no EndTime — this is the leading-edge OpcodeStepPlanned shape.
+		Attributes: meta.NewAttrSet(
+			meta.Attr(meta.Attrs.RunID, &runIDULID),
+		),
+	})
+	require.NoError(t, err)
+
+	// Read the raw on-disk rows for this dynamic_span_id. We expect two
+	// rows (no upsert): one with end_time=t1, one with end_time=t0.
+	rawRows, err := q.GetSpansByRunID(t.Context(), runID)
+	require.NoError(t, err)
+	require.NotEmpty(t, rawRows, "expected the tracer to have written rows for this run")
+
+	// GetSpansByRunID groups by dynamic_span_id and aggregates end_time with
+	// MAX. Find the row for our dynamic span; its MAX(end_time) must not
+	// exceed t1 — if it does, the tracer regressed to stamping wall-clock.
+	var maxEnd time.Time
+	for _, r := range rawRows {
+		if !r.DynamicSpanID.Valid || r.DynamicSpanID.String != dynID {
+			continue
+		}
+		parsed, parseErr := parseRowEndTime(r.EndTime)
+		require.NoError(t, parseErr)
+		if parsed.After(maxEnd) {
+			maxEnd = parsed
+		}
+	}
+	require.False(t, maxEnd.IsZero(), "no rows matched dynamic_span_id=%s", dynID)
+
+	// Tolerance: t1 is the completion timestamp, the largest legitimate
+	// end_time. A regression would push past wall-clock (>> t1 + 20ms).
+	assert.False(t, maxEnd.After(t1),
+		"tracer must stamp end_time from caller timing: MAX(end_time)=%s, expected <= %s (sleep + late POST should not bleed into end_time)",
+		maxEnd, t1)
+}
+
+// parseRowEndTime handles the time/string column shapes the sqlite driver
+// hands back (see mapSpanFromRow for the read-path equivalent).
+func parseRowEndTime(v any) (time.Time, error) {
+	switch x := v.(type) {
+	case time.Time:
+		return x, nil
+	case string:
+		s := strings.Split(x, " m=")[0]
+		return time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", s)
+	default:
+		return time.Time{}, fmt.Errorf("unexpected end_time type %T", v)
+	}
+}
+
 // TestSpanWithAttributesAndOutput is a regression test ensuring that spans
 // with JSON attributes and output can be inserted and queried without
 // "JSON cannot hold BLOB values" errors. This catches the bug where []byte
@@ -1855,6 +1961,7 @@ func TestSpanOutputReadBack(t *testing.T) {
 
 type testSpanFields struct {
 	RunID          string    // required
+	TraceID        string    // optional; default: fresh ULID per call
 	DynamicSpanID  string    // required for GROUP BY tests
 	ParentSpanID   string    // for child spans (references parent's DynamicSpanID)
 	DebugRunID     string    // for debug run tests
@@ -1862,6 +1969,7 @@ type testSpanFields struct {
 	Name           string    // default: "test-span"
 	Status         string    // default: "" (NULL)
 	StartTime      time.Time // default: time.Now()
+	EndTime        time.Time // default: StartTime + 100ms
 	AccountID      string    // default: "acct"
 	AppID          string    // default: "app"
 	FunctionID     string    // default: "fn"
@@ -1876,7 +1984,10 @@ func insertTestSpan(t *testing.T, cm cqrs.Manager, spanFields testSpanFields) {
 	t.Helper()
 
 	spanID := ulid.MustNew(ulid.Now(), rand.Reader).String()
-	traceID := ulid.MustNew(ulid.Now(), rand.Reader).String()
+	traceID := spanFields.TraceID
+	if traceID == "" {
+		traceID = ulid.MustNew(ulid.Now(), rand.Reader).String()
+	}
 
 	// Apply defaults
 	if spanFields.Name == "" {
@@ -1897,6 +2008,10 @@ func insertTestSpan(t *testing.T, cm cqrs.Manager, spanFields testSpanFields) {
 	if spanFields.EnvID == "" {
 		spanFields.EnvID = "env"
 	}
+	endTime := spanFields.EndTime
+	if endTime.IsZero() {
+		endTime = spanFields.StartTime.Add(100 * time.Millisecond)
+	}
 
 	// TODO: ideally we should not have to do this type assertion to wrapper to write a span
 	q := cm.(wrapper).q
@@ -1907,7 +2022,7 @@ func insertTestSpan(t *testing.T, cm cqrs.Manager, spanFields testSpanFields) {
 		Name:           spanFields.Name,
 		Status:         sql.NullString{String: spanFields.Status, Valid: spanFields.Status != ""},
 		StartTime:      spanFields.StartTime,
-		EndTime:        spanFields.StartTime.Add(100 * time.Millisecond),
+		EndTime:        endTime,
 		RunID:          spanFields.RunID,
 		AccountID:      spanFields.AccountID,
 		AppID:          spanFields.AppID,

--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -1869,6 +1869,76 @@ func parseRowEndTime(v any) (time.Time, error) {
 	}
 }
 
+// TestCQRSGetSpansByRunID_OrdersFragmentsByEndTime verifies that
+// GetSpansByRunID orders fragments inside its json_group_array by end_time
+// so the read-path merge in mapSpanFromRow (which is last-write-wins via
+// maps.Copy) deterministically resolves status by causal order, mirroring
+// the property the monorepo's CH AggregatingMergeTree gets for free.
+//
+// The simulated on-disk state is what TestCQRSTracerWritesEndTimeFromOpts
+// already proved the tracer produces: a RUNNING fragment with
+// end_time = start_time = T0, a COMPLETED fragment with end_time = T1 > T0.
+// Critically, the RUNNING row is inserted LAST — i.e. its rowid is larger,
+// which is the order json_group_array would emit without an ORDER BY. The
+// fix exists only if the read path actively re-sorts by end_time.
+func TestCQRSGetSpansByRunID_OrdersFragmentsByEndTime(t *testing.T) {
+	cm, cleanup := initCQRS(t)
+	defer cleanup()
+
+	runID := ulid.MustNew(ulid.Now(), rand.Reader).String()
+	traceID := ulid.MustNew(ulid.Now(), rand.Reader).String()
+	const dynID = "dyn-step-race"
+	t0 := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	t1 := t0.Add(10 * time.Millisecond)
+
+	// Root run span.
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runID,
+		TraceID:       traceID,
+		DynamicSpanID: "dyn-run-" + runID,
+		Name:          meta.SpanNameRun,
+		StartTime:     t0,
+		EndTime:       t0.Add(time.Millisecond),
+		Attributes:    []byte(fmt.Sprintf(`{"_inngest.run.id":%q}`, runID)),
+	})
+
+	// COMPLETED fragment FIRST — earlier insertion order.
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runID,
+		TraceID:       traceID,
+		DynamicSpanID: dynID,
+		ParentSpanID:  "dyn-run-" + runID,
+		Name:          meta.SpanNameStep,
+		StartTime:     t0,
+		EndTime:       t1,
+		Attributes:    []byte(`{"_inngest.dynamic.status":"Completed"}`),
+	})
+
+	// Late RUNNING fragment LAST — larger rowid, smaller end_time. Without
+	// ORDER BY end_time inside json_group_array, this fragment comes last
+	// in the JSON array and maps.Copy lets its DynamicStatus override.
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runID,
+		TraceID:       traceID,
+		DynamicSpanID: dynID,
+		ParentSpanID:  "dyn-run-" + runID,
+		Name:          meta.SpanNameStep,
+		StartTime:     t0,
+		EndTime:       t0, // tracer-fix shape: RUNNING ends at start.
+		Attributes:    []byte(`{"_inngest.dynamic.status":"Running"}`),
+	})
+
+	root, err := cm.GetSpansByRunID(t.Context(), ulid.MustParse(runID))
+	require.NoError(t, err)
+	require.NotNil(t, root)
+	require.Len(t, root.Children, 1, "expected one merged step span as a child of the run")
+
+	step := root.Children[0]
+	assert.Equal(t, dynID, step.SpanID)
+	assert.Equal(t, enums.StepStatusCompleted, step.Status,
+		"GetSpansByRunID must order fragments by end_time so the merged status is the causally-latest one")
+}
+
 // TestSpanWithAttributesAndOutput is a regression test ensuring that spans
 // with JSON attributes and output can be inserted and queried without
 // "JSON cannot hold BLOB values" errors. This catches the bug where []byte

--- a/pkg/db/postgres/sqlc/queries.sql
+++ b/pkg/db/postgres/sqlc/queries.sql
@@ -455,7 +455,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST($1 AS CHAR(26))
@@ -477,7 +478,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE debug_run_id = CAST($1 AS CHAR(26))
@@ -499,7 +501,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE debug_session_id = CAST($1 AS CHAR(26))
@@ -529,7 +532,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND account_id = sqlc.arg(account_id) AND (parent_span_id IS NULL OR parent_span_id = '0000000000000000')
@@ -552,7 +556,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE span_id IN (
@@ -584,7 +589,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND account_id = sqlc.arg(account_id) AND name != 'userland'
@@ -610,7 +616,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND account_id = sqlc.arg(account_id) AND name != 'userland'
@@ -638,7 +645,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans b
 WHERE b.run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND b.account_id = sqlc.arg(account_id) AND b.name != 'userland'
@@ -664,7 +672,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST(sqlc.arg(run_id) AS CHAR(26)) AND span_id = sqlc.arg(span_id) AND account_id = sqlc.arg(account_id)

--- a/pkg/db/postgres/sqlc/queries.sql.go
+++ b/pkg/db/postgres/sqlc/queries.sql.go
@@ -546,7 +546,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST($1 AS CHAR(26)) AND account_id = $2 AND name != 'userland'
@@ -1059,7 +1060,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans b
 WHERE b.run_id = CAST($1 AS CHAR(26)) AND b.account_id = $2 AND b.name != 'userland'
@@ -1192,7 +1194,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST($1 AS CHAR(26)) AND account_id = $2 AND (parent_span_id IS NULL OR parent_span_id = '0000000000000000')
@@ -1246,7 +1249,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST($1 AS CHAR(26)) AND span_id = $2 AND account_id = $3
@@ -1338,7 +1342,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE debug_run_id = CAST($1 AS CHAR(26))
@@ -1404,7 +1409,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE debug_session_id = CAST($1 AS CHAR(26))
@@ -1469,7 +1475,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST($1 AS CHAR(26))
@@ -1532,7 +1539,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE span_id IN (
@@ -1564,7 +1572,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = CAST($1 AS CHAR(26)) AND account_id = $2 AND name != 'userland'

--- a/pkg/db/sqlite/sqlc/queries.sql
+++ b/pkg/db/sqlite/sqlc/queries.sql
@@ -436,7 +436,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = ?
@@ -458,7 +459,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE debug_run_id = ?
@@ -480,7 +482,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE debug_session_id = ?
@@ -509,7 +512,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = ? AND account_id = ? AND (parent_span_id IS NULL OR parent_span_id == '0000000000000000')
@@ -532,7 +536,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE span_id IN (
@@ -564,7 +569,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = sqlc.arg(run_id) AND account_id = sqlc.arg(account_id) AND name != 'userland'
@@ -590,7 +596,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = ? AND account_id = ? AND name != 'userland'
@@ -618,7 +625,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans b
 WHERE b.run_id = sqlc.arg(run_id) AND b.account_id = sqlc.arg(account_id) AND b.name != 'userland'
@@ -644,7 +652,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = ? AND span_id = ? AND account_id = ?

--- a/pkg/db/sqlite/sqlc/queries.sql.go
+++ b/pkg/db/sqlite/sqlc/queries.sql.go
@@ -569,7 +569,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = ? AND account_id = ? AND name != 'userland'
@@ -1079,7 +1080,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans b
 WHERE b.run_id = ?1 AND b.account_id = ?2 AND b.name != 'userland'
@@ -1211,7 +1213,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = ? AND account_id = ? AND (parent_span_id IS NULL OR parent_span_id == '0000000000000000')
@@ -1265,7 +1268,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = ? AND span_id = ? AND account_id = ?
@@ -1367,7 +1371,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE debug_run_id = ?
@@ -1433,7 +1438,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE debug_session_id = ?
@@ -1498,7 +1504,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = ?
@@ -1561,7 +1568,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE span_id IN (
@@ -1593,7 +1601,8 @@ SELECT
     'attributes', attributes,
     'links', links,
     'output_span_id', CASE WHEN output IS NOT NULL THEN span_id ELSE NULL END,
-    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END
+    'input_span_id', CASE WHEN input IS NOT NULL THEN span_id ELSE NULL END,
+    'end_time', end_time
   )) AS span_fragments
 FROM spans
 WHERE run_id = ?1 AND account_id = ?2 AND name != 'userland'

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -131,12 +131,32 @@ func (tp *otelTracerProvider) CreateSpan(
 		return nil, fmt.Errorf("failed to CreateSpan: %w", err)
 	}
 
-	err = ds.Send()
-	if err != nil {
-		return nil, fmt.Errorf("failed to send span during creation: %w", err)
-	}
+	// CreateSpan records a span for an event with caller-known timing, so
+	// the stored end_time must reflect that timing — not wall-clock at
+	// processing. Without WithTimestamp, OTel defaults End() to time.Now(),
+	// which lets a late leading-edge RUNNING POST land with a larger
+	// end_time than the COMPLETED row it raced against and break
+	// MAX(end_time) / argmax(status, end_time) on read.
+	ds.span.End(trace.WithTimestamp(resolveSpanEndTime(opts)))
 
 	return ds.Ref, nil
+}
+
+// resolveSpanEndTime returns the timestamp to stamp on the OTel span when
+// CreateSpan finalizes it. Prefer the caller-supplied EndTime; fall back to
+// StartTime for not-yet-ended events (e.g. leading-edge RUNNING from
+// OpcodeStepPlanned) so the row lands with end_time == start_time instead of
+// processing-time-now; only synthesize a wall-clock value when the caller
+// supplied neither.
+func resolveSpanEndTime(opts *CreateSpanOptions) time.Time {
+	switch {
+	case !opts.EndTime.IsZero():
+		return opts.EndTime
+	case !opts.StartTime.IsZero():
+		return opts.StartTime
+	default:
+		return time.Now()
+	}
 }
 
 // CreateDroppableSpan creates a span that can be dropped and relies on us

--- a/pkg/tracing/tracer_test.go
+++ b/pkg/tracing/tracer_test.go
@@ -1,11 +1,41 @@
 package tracing
 
 import (
+	"context"
+	"sync"
 	"testing"
 	"time"
 
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// captureExporter records every span passed to ExportSpans. SimpleSpanProcessor
+// invokes the exporter synchronously on End(), so by the time CreateSpan
+// returns, the captured slice has the finalized span with its EndTime set.
+type captureExporter struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (c *captureExporter) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.spans = append(c.spans, spans...)
+	return nil
+}
+
+func (c *captureExporter) Shutdown(_ context.Context) error { return nil }
+
+func (c *captureExporter) only(t *testing.T) sdktrace.ReadOnlySpan {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	require.Len(t, c.spans, 1, "expected exactly one captured span")
+	return c.spans[0]
+}
 
 func TestDeterministicTraceID(t *testing.T) {
 	ctx := t.Context()
@@ -85,6 +115,112 @@ func TestRandomSpanIDGeneration(t *testing.T) {
 	require.Len(t, traceIDs, 10)
 	require.Len(t, dynamicSpanIDs, 10)
 	require.Len(t, traceParents, 10)
+}
+
+// TestCreateSpanEndTime documents the invariant that the OTel span's stored
+// end_time reflects caller-supplied timing rather than wall-clock at
+// processing.
+func TestCreateSpanEndTime(t *testing.T) {
+	t.Run("uses caller-supplied EndTime when set", func(t *testing.T) {
+		exp := &captureExporter{}
+		tp := NewOtelTracerProvider(exp, time.Millisecond)
+
+		start := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+		end := start.Add(250 * time.Millisecond)
+
+		_, err := tp.CreateSpan(t.Context(), "completed-step", &CreateSpanOptions{
+			StartTime: start,
+			EndTime:   end,
+		})
+		require.NoError(t, err)
+
+		span := exp.only(t)
+		assert.Equal(t, start, span.StartTime())
+		assert.Equal(t, end, span.EndTime())
+	})
+
+	t.Run("falls back to StartTime when EndTime is zero", func(t *testing.T) {
+		// Models the leading-edge OpcodeStepPlanned case: the executor
+		// supplies start_time = op.Timing.Start() but no EndTime, because
+		// the step hasn't ended. Without this fallback, OTel would stamp
+		// end_time = time.Now() at processing.
+		exp := &captureExporter{}
+		tp := NewOtelTracerProvider(exp, time.Millisecond)
+
+		start := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+		_, err := tp.CreateSpan(t.Context(), "leading-edge-step", &CreateSpanOptions{
+			StartTime: start,
+			// no EndTime
+		})
+		require.NoError(t, err)
+
+		span := exp.only(t)
+		assert.Equal(t, start, span.StartTime())
+		assert.Equal(t, start, span.EndTime(),
+			"a span with no caller-supplied EndTime must land with end_time = start_time, not wall-clock-now")
+	})
+
+	t.Run("uses wall-clock now when neither is set", func(t *testing.T) {
+		exp := &captureExporter{}
+		tp := NewOtelTracerProvider(exp, time.Millisecond)
+
+		before := time.Now()
+		_, err := tp.CreateSpan(t.Context(), "instant-span", &CreateSpanOptions{})
+		require.NoError(t, err)
+		after := time.Now()
+
+		span := exp.only(t)
+		// Both start and end should be in the [before, after] window and
+		// equal to each other (resolveSpanEndTime returns the same value
+		// CreateDroppableSpan computed for st).
+		assert.False(t, span.StartTime().Before(before))
+		assert.False(t, span.EndTime().After(after))
+	})
+}
+
+func TestResolveSpanEndTime(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	start := now.Add(10 * time.Millisecond)
+	end := now.Add(20 * time.Millisecond)
+
+	cases := []struct {
+		name   string
+		opts   *CreateSpanOptions
+		want   func(time.Time) bool // nil => exact compare against `expect`
+		expect time.Time
+	}{
+		{
+			name:   "EndTime wins when both set",
+			opts:   &CreateSpanOptions{StartTime: start, EndTime: end},
+			expect: end,
+		},
+		{
+			name:   "falls back to StartTime when EndTime zero",
+			opts:   &CreateSpanOptions{StartTime: start},
+			expect: start,
+		},
+		{
+			name: "falls back to time.Now when both zero",
+			opts: &CreateSpanOptions{},
+			want: func(got time.Time) bool {
+				return !got.IsZero()
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveSpanEndTime(tc.opts)
+			if tc.want != nil {
+				assert.True(t, tc.want(got), "got %v", got)
+				return
+			}
+			assert.Equal(t, tc.expect, got)
+		})
+	}
+
+	_ = now
 }
 
 func TestSeededSpanThenReuseContext(t *testing.T) {


### PR DESCRIPTION
## Description

- In https://github.com/inngest/inngest-js/pull/1530, we introduce sending a StepPlanned opcode before executing a step. This sometimes leads to races, and the server may receive the StepCompleted before the StepPlanned. OSS will sometimes aggregate this and have the RUNNING status win rather than the COMPLETED status.
- We adjust oss to behave more like cloud with ClickHouse
- Instead of writing time.Now to end when end is unspecified, we fallack to the user-provided start. `null` would be most similar, but would require extensive typing changes
- When aggregating, we order by end time instead of random

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
Better tolerate Opcodes that are delivered out of order.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
