### PR TITLE
refactor(connect): gate gateway routing by connection phase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,3 +75,6 @@ compatible with the sections and placeholders described in
 - Prefer minimal, targeted changes with tests to verify their behavior
 - Commits should be in small logical chunks so each one is self reviewable
 - If operating with a plan, update the checklist items as you go if there are any
+- Add succinct comments when they clarify intent, lifecycle ordering, or
+  behavior-preservation constraints; avoid comments that merely restate the
+  code.

--- a/docs/plans/003-connect-gateway-lifecycle-controller.org
+++ b/docs/plans/003-connect-gateway-lifecycle-controller.org
@@ -512,31 +512,31 @@ Purpose: make routing and websocket writes consult connection phase.
 
 *** Implementation checklist
 
-- [ ] Add =canForward= and =canWrite= helpers.
-- [ ] Require =Ready= before accepting a new =Forward= into =messageChan=.
-- [ ] Require =Ready= before writing =GATEWAY_EXECUTOR_REQUEST=.
-- [ ] Allow =WORKER_REPLY_ACK= only for a message already read by the run loop,
+- [X] Add =canForward= and =canWrite= helpers.
+- [X] Require =Ready= before accepting a new =Forward= into =messageChan=.
+- [X] Require =Ready= before writing =GATEWAY_EXECUTOR_REQUEST=.
+- [X] Allow =WORKER_REPLY_ACK= only for a message already read by the run loop,
   and keep write failure non-fatal after persistence.
-- [ ] Allow heartbeat responses only when not draining/disconnecting.
-- [ ] Replace direct =draining.Load()= checks where a phase check is clearer.
-- [ ] Release =pendingAcks= explicitly when transitioning out of =Ready=.
+- [X] Allow heartbeat responses only when not draining/disconnecting.
+- [X] Replace direct =draining.Load()= checks where a phase check is clearer.
+- [X] Release =pendingAcks= explicitly when transitioning out of =Ready=.
 
 *** Test checklist
 
-- [ ] no new =Forward= succeeds outside =Ready=;
-- [ ] =GATEWAY_EXECUTOR_REQUEST= is not written outside =Ready=;
-- [ ] =pendingAcks= waiters are released when connection starts disconnecting;
-- [ ] heartbeat cannot revive a draining connection;
-- [ ] reply handling after persistence stays non-fatal.
+- [X] no new =Forward= succeeds outside =Ready=;
+- [X] =GATEWAY_EXECUTOR_REQUEST= is not written outside =Ready=;
+- [X] =pendingAcks= waiters are released when connection starts disconnecting;
+- [X] heartbeat cannot revive a draining connection;
+- [X] reply handling after persistence stays non-fatal.
 
 *** Validation checklist
 
-- [ ] =go test ./pkg/connect -count=1=
+- [X] =go test ./pkg/connect -count=1=
 
 *** Exit criteria
 
-- [ ] New router work cannot be sent to a draining or disconnecting websocket.
-- [ ] Pending ACK cleanup is lifecycle-driven, not only timeout-driven.
+- [X] New router work cannot be sent to a draining or disconnecting websocket.
+- [X] Pending ACK cleanup is lifecycle-driven, not only timeout-driven.
 
 ** Phase 3: Decide and encode =WORKER_REQUEST_ACK= semantics
 

--- a/docs/plans/003-connect-gateway-lifecycle-controller.org
+++ b/docs/plans/003-connect-gateway-lifecycle-controller.org
@@ -475,36 +475,36 @@ Purpose: make one gateway websocket handler's lifecycle observable.
 
 *** Implementation checklist
 
-- [ ] Add internal =gatewayConnPhase= values:
-  - [ ] =New=
-  - [ ] =Handshaking=
-  - [ ] =Ready=
-  - [ ] =Draining=
-  - [ ] =Disconnecting=
-  - [ ] =Closed=
-- [ ] Add concurrency-safe phase storage and transition logging.
-- [ ] Route existing state changes through phase helpers while preserving
+- [X] Add internal =gatewayConnPhase= values:
+  - [X] =New=
+  - [X] =Handshaking=
+  - [X] =Ready=
+  - [X] =Draining=
+  - [X] =Disconnecting=
+  - [X] =Closed=
+- [X] Add concurrency-safe phase storage and transition logging.
+- [X] Route existing state changes through phase helpers while preserving
   current behavior.
-- [ ] Keep =draining= temporarily if needed, but derive it from phase where
+- [X] Keep =draining= temporarily if needed, but derive it from phase where
   possible.
-- [ ] Add phase to useful connection logs.
+- [X] Add phase to useful connection logs.
 
 *** Test checklist
 
-- [ ] handshake moves =New -> Handshaking -> Ready=;
-- [ ] worker pause moves =Ready -> Draining=;
-- [ ] gateway drain moves =Ready -> Draining=;
-- [ ] read-loop exit moves to =Disconnecting= and then =Closed=;
-- [ ] repeated close/cleanup is idempotent.
+- [X] handshake moves =New -> Handshaking -> Ready=;
+- [X] worker pause moves =Ready -> Draining=;
+- [X] gateway drain moves =Ready -> Draining=;
+- [X] read-loop exit moves to =Disconnecting= and then =Closed=;
+- [X] repeated close/cleanup is idempotent.
 
 *** Validation checklist
 
-- [ ] =go test ./pkg/connect -count=1=
+- [X] =go test ./pkg/connect -count=1=
 
 *** Exit criteria
 
-- [ ] Every established gateway connection has an observable phase.
-- [ ] No intentional behavior change is introduced in this phase.
+- [X] Every established gateway connection has an observable phase.
+- [X] No intentional behavior change is introduced in this phase.
 
 ** Phase 2: Centralize write and forward eligibility
 

--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -322,6 +322,8 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 		defer func() {
 			// This is deferred so we always update the semaphore
 			defer c.connectionCount.Done()
+			// markClosed is paired with the outer connection lifetime so every
+			// accepted websocket has a terminal phase, including handshake failures.
 			defer ch.markClosed("connection cleanup complete", "close_reason", *closeReasonPtr.Load())
 			ch.log.Debug("Closing WebSocket connection", "reason", *closeReasonPtr.Load())
 			c.logger.Trace("worker disconnected")
@@ -461,6 +463,8 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 		// regardless of whether it's permanent or temporary
 		defer func() {
 			// Ensure receiveRouterMessagesFromGRPC exits on any disconnect.
+			// This marks the local handler as disconnecting before the external
+			// metadata is removed so logs show cleanup intent even if Redis fails.
 			ch.beginDisconnect("connection cleanup", "close_reason", *closeReasonPtr.Load())
 			ch.stopForwardingOnce.Do(func() { close(ch.stopForwarding) })
 			ch.logConnStatus(connectpb.ConnectionStatus_DISCONNECTED, "connection cleanup", "close_reason", *closeReasonPtr.Load())

--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -105,7 +105,8 @@ type connectionHandler struct {
 
 	// draining is set to true when a WORKER_PAUSE message is received.
 	// Once set, heartbeats must not reset the connection status to READY.
-	draining atomic.Bool
+	draining  atomic.Bool
+	connPhase atomic.Int32
 
 	// messageChan receives forwarded requests from the router.
 	messageChan chan forwardMessage
@@ -227,6 +228,7 @@ func (c *connectionHandler) logConnStatusLocked(status connectpb.ConnectionStatu
 		"from", from,
 		"to", status.String(),
 		"reason", reason,
+		"phase", c.phase().String(),
 	}
 	logAttrs = append(logAttrs, attrs...)
 
@@ -304,6 +306,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 			controlCh:      make(chan *connectpb.ConnectMessage, 10),
 			dataCh:         make(chan *connectpb.ConnectMessage, 50),
 		}
+		ch.markHandshaking("websocket accepted")
 
 		closeReason := connectpb.WorkerDisconnectReason_UNEXPECTED.String()
 		var closeReasonPtr atomic.Pointer[string]
@@ -319,6 +322,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 		defer func() {
 			// This is deferred so we always update the semaphore
 			defer c.connectionCount.Done()
+			defer ch.markClosed("connection cleanup complete", "close_reason", *closeReasonPtr.Load())
 			ch.log.Debug("Closing WebSocket connection", "reason", *closeReasonPtr.Load())
 			c.logger.Trace("worker disconnected")
 
@@ -397,7 +401,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 			// heartbeats from marking it as ready, but do NOT update Redis
 			// yet, the connection stays READY for routing to give the worker
 			// enough time to reconnect to a different gateway.
-			ch.draining.Store(true)
+			ch.beginDrain("gateway drain started", "active_connections", c.connectionCount.Count())
 
 			setCloseReason(connectpb.WorkerDisconnectReason_GATEWAY_DRAINING.String())
 
@@ -457,6 +461,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 		// regardless of whether it's permanent or temporary
 		defer func() {
 			// Ensure receiveRouterMessagesFromGRPC exits on any disconnect.
+			ch.beginDisconnect("connection cleanup", "close_reason", *closeReasonPtr.Load())
 			ch.stopForwardingOnce.Do(func() { close(ch.stopForwarding) })
 			ch.logConnStatus(connectpb.ConnectionStatus_DISCONNECTED, "connection cleanup", "close_reason", *closeReasonPtr.Load())
 
@@ -582,6 +587,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 				err := wsproto.Read(runLoopCtx, ws, &msg)
 				if err != nil {
 					// immediately stop routing messages to this connection
+					ch.beginDisconnect("websocket read loop ended", "err", err)
 					if err := ch.updateConnStatus(connectpb.ConnectionStatus_DISCONNECTING, "websocket read loop ended", "err", err); err != nil {
 						ch.log.ReportError(err, "could not update connection status after read error")
 					}
@@ -781,6 +787,7 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 
 				return
 			}
+			ch.markReady("automatic readiness")
 
 			for _, l := range c.lifecycles {
 				go l.OnReady(context.Background(), conn)
@@ -901,6 +908,7 @@ func (c *connectionHandler) receiveRouterMessagesFromGRPC(ctx context.Context, o
 				"step_id", data.StepId,
 				"run_id", data.RunId,
 				"transport", "grpc",
+				"phase", c.phase().String(),
 			)
 
 			// Block forwards while draining — wait for the new connection

--- a/pkg/connect/gateway.go
+++ b/pkg/connect/gateway.go
@@ -118,8 +118,9 @@ type connectionHandler struct {
 	stopForwardingOnce sync.Once
 
 	// pendingAcks tracks request IDs waiting for WORKER_REQUEST_ACK.
-	// Forward blocks until the ACK arrives or times out.
-	pendingAcks sync.Map // requestID -> chan struct{}
+	// Forward blocks until the ACK arrives, the connection leaves Ready, or
+	// the request times out.
+	pendingAcks sync.Map // requestID -> chan error
 
 	consecutiveConnStatusUpdateFailures atomic.Int64
 
@@ -131,6 +132,25 @@ type connectionHandler struct {
 
 	connectionStatus   connectpb.ConnectionStatus
 	connectionStatusOK bool
+}
+
+func (c *connectionHandler) completePendingAck(requestID string, err error) bool {
+	ackCh, ok := c.pendingAcks.LoadAndDelete(requestID)
+	if !ok {
+		return false
+	}
+
+	ackCh.(chan error) <- err
+	return true
+}
+
+func (c *connectionHandler) releasePendingAcks(err error) {
+	c.pendingAcks.Range(func(key, value any) bool {
+		if c.pendingAcks.CompareAndDelete(key, value) {
+			value.(chan error) <- err
+		}
+		return true
+	})
 }
 
 func (c *connectionHandler) setLastHeartbeat(time time.Time) {
@@ -416,6 +436,10 @@ func (c *connectGatewaySvc) Handler() http.Handler {
 			drainStart := time.Now()
 			closingWriteCtx, closingWriteCancel := context.WithTimeout(context.Background(), wsWriteTimeout)
 			defer closingWriteCancel()
+			if !ch.canWrite(connectpb.GatewayMessageType_GATEWAY_CLOSING) {
+				ch.log.Debug("skipping gateway closing message because connection phase cannot write", "phase", ch.phase().String())
+				return
+			}
 			err := wsproto.Write(closingWriteCtx, ws, &connectpb.ConnectMessage{
 				Kind: connectpb.GatewayMessageType_GATEWAY_CLOSING,
 			})
@@ -917,7 +941,12 @@ func (c *connectionHandler) receiveRouterMessagesFromGRPC(ctx context.Context, o
 
 			// Block forwards while draining — wait for the new connection
 			// to be READY before failing so the proxy re-route succeeds.
-			if c.draining.Load() {
+			if !c.canForward() {
+				if c.phase() != gatewayConnPhaseDraining {
+					msg.Result <- fmt.Errorf("connection is not ready: phase=%s", c.phase().String())
+					continue
+				}
+
 				<-c.stopForwarding
 				log.Debug("rejecting forward, connection finished draining")
 				msg.Result <- fmt.Errorf("connection is draining")
@@ -940,7 +969,7 @@ func (c *connectionHandler) receiveRouterMessagesFromGRPC(ctx context.Context, o
 			// block the message loop from processing other requests.
 			// IMPORTANT: Store before writing to the WebSocket to avoid a race
 			// condition.
-			ackCh := make(chan struct{})
+			ackCh := make(chan error, 1)
 			c.pendingAcks.Store(data.RequestId, ackCh)
 
 			// Use a fresh context instead of the connection ctx. During a
@@ -953,6 +982,13 @@ func (c *connectionHandler) receiveRouterMessagesFromGRPC(ctx context.Context, o
 				context.Background(),
 				5*time.Second,
 			)
+			if !c.canWrite(connectpb.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST) {
+				writeCancel()
+				c.pendingAcks.Delete(data.RequestId)
+				msg.Result <- fmt.Errorf("connection cannot write executor request: phase=%s", c.phase().String())
+				continue
+			}
+
 			err = wsproto.Write(writeCtx, c.ws, &connectpb.ConnectMessage{
 				Kind:    connectpb.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST,
 				Payload: rawBytes,
@@ -970,12 +1006,15 @@ func (c *connectionHandler) receiveRouterMessagesFromGRPC(ctx context.Context, o
 
 			go func() {
 				select {
-				case <-ackCh:
-					msg.Result <- nil
+				case err := <-ackCh:
+					msg.Result <- err
 				case <-time.After(consts.ConnectWorkerRequestLeaseDuration + consts.ConnectWorkerRequestGracePeriod):
-					c.pendingAcks.Delete(data.RequestId)
-					msg.Result <- fmt.Errorf("worker did not ACK request %s", data.RequestId)
-					log.Warn("worker did not ACK request in time", "req_id", data.RequestId)
+					if c.pendingAcks.CompareAndDelete(data.RequestId, ackCh) {
+						msg.Result <- fmt.Errorf("worker did not ACK request %s", data.RequestId)
+						log.Warn("worker did not ACK request in time", "req_id", data.RequestId)
+					} else {
+						msg.Result <- <-ackCh
+					}
 				}
 			}()
 		}
@@ -1276,6 +1315,10 @@ func (c *connectionHandler) handleSdkReply(ctx context.Context, msg *connectpb.C
 
 	writeCtx, writeCancel := context.WithTimeout(context.Background(), wsWriteTimeout)
 	defer writeCancel()
+	if !c.canWrite(connectpb.GatewayMessageType_WORKER_REPLY_ACK) {
+		l.Warn("skipping worker reply ack because connection phase cannot write", "phase", c.phase().String())
+		return nil
+	}
 	if err := wsproto.Write(writeCtx, c.ws, &connectpb.ConnectMessage{
 		Kind:    connectpb.GatewayMessageType_WORKER_REPLY_ACK,
 		Payload: replyAck,

--- a/pkg/connect/gateway_drain_test.go
+++ b/pkg/connect/gateway_drain_test.go
@@ -218,6 +218,10 @@ func TestHeartbeatDuringGatewayDrain_StatusRemainsDraining(t *testing.T) {
 	// Worker sends a heartbeat during drain
 	sendWorkerHeartbeatMessage(t, res.ws)
 
+	// Expect GATEWAY_HEARTBEAT response (heartbeats are still processed)
+	msg = awaitNextMessage(t, res.ws, 3*time.Second)
+	require.Equal(t, connectpb.GatewayMessageType_GATEWAY_HEARTBEAT, msg.Kind)
+
 	// Verify connection status in Redis is DRAINING (not reset to READY)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		conn, err := res.stateManager.GetConnection(ctx, res.envID, res.connID)
@@ -588,14 +592,9 @@ func TestLeaseExtensionDuringGatewayDrain_IsProcessed(t *testing.T) {
 	require.WithinDuration(t, time.Now().Add(consts.ConnectWorkerRequestLeaseDuration), ulid.Time(parsed.Time()), 2*time.Second,
 		"new lease should have a future expiry")
 
-	// Verify the connection is still alive enough to process another inbound
-	// heartbeat. Draining connections no longer receive heartbeat responses.
+	// Verify connection is still alive by exchanging a heartbeat
 	sendWorkerHeartbeatMessage(t, res.ws)
-	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		res.lifecycles.lock.Lock()
-		defer res.lifecycles.lock.Unlock()
-
-		assert.GreaterOrEqual(ct, len(res.lifecycles.onHeartbeat), 1,
-			"connection should process heartbeat after lease extension during drain")
-	}, 2*time.Second, 100*time.Millisecond)
+	msg = awaitNextMessage(t, res.ws, 3*time.Second)
+	require.Equal(t, connectpb.GatewayMessageType_GATEWAY_HEARTBEAT, msg.Kind,
+		"connection should still be alive after lease extension during drain")
 }

--- a/pkg/connect/gateway_drain_test.go
+++ b/pkg/connect/gateway_drain_test.go
@@ -202,7 +202,7 @@ func TestHeartbeatDuringGatewayDrain_StatusRemainsDraining(t *testing.T) {
 	res := createTestingGateway(t, testingParameters{
 		consecutiveMissesBeforeClose: 10,
 		heartbeatInterval:            1 * time.Second,
-		drainAckTimeout:              500 * time.Millisecond,
+		drainAckTimeout:              2 * time.Second,
 		silent:                       true,
 	})
 	handshake(t, res)
@@ -218,16 +218,15 @@ func TestHeartbeatDuringGatewayDrain_StatusRemainsDraining(t *testing.T) {
 	// Worker sends a heartbeat during drain
 	sendWorkerHeartbeatMessage(t, res.ws)
 
-	// Expect GATEWAY_HEARTBEAT response (heartbeats are still processed)
-	msg = awaitNextMessage(t, res.ws, 3*time.Second)
-	require.Equal(t, connectpb.GatewayMessageType_GATEWAY_HEARTBEAT, msg.Kind)
-
 	// Verify connection status in Redis is DRAINING (not reset to READY)
-	conn, err := res.stateManager.GetConnection(ctx, res.envID, res.connID)
-	require.NoError(t, err)
-	require.NotNil(t, conn)
-	require.Equal(t, connectpb.ConnectionStatus_DRAINING, conn.Status,
-		"heartbeat during drain should keep status as DRAINING, not reset to READY")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		conn, err := res.stateManager.GetConnection(ctx, res.envID, res.connID)
+		assert.NoError(ct, err)
+		if conn != nil {
+			assert.Equal(ct, connectpb.ConnectionStatus_DRAINING, conn.Status,
+				"heartbeat during drain should keep status as DRAINING, not reset to READY")
+		}
+	}, 2*time.Second, 100*time.Millisecond)
 
 	// Verify lifecycle: heartbeat was recorded and draining started
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
@@ -589,9 +588,14 @@ func TestLeaseExtensionDuringGatewayDrain_IsProcessed(t *testing.T) {
 	require.WithinDuration(t, time.Now().Add(consts.ConnectWorkerRequestLeaseDuration), ulid.Time(parsed.Time()), 2*time.Second,
 		"new lease should have a future expiry")
 
-	// Verify connection is still alive by exchanging a heartbeat
+	// Verify the connection is still alive enough to process another inbound
+	// heartbeat. Draining connections no longer receive heartbeat responses.
 	sendWorkerHeartbeatMessage(t, res.ws)
-	msg = awaitNextMessage(t, res.ws, 3*time.Second)
-	require.Equal(t, connectpb.GatewayMessageType_GATEWAY_HEARTBEAT, msg.Kind,
-		"connection should still be alive after lease extension during drain")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		res.lifecycles.lock.Lock()
+		defer res.lifecycles.lock.Unlock()
+
+		assert.GreaterOrEqual(ct, len(res.lifecycles.onHeartbeat), 1,
+			"connection should process heartbeat after lease extension during drain")
+	}, 2*time.Second, 100*time.Millisecond)
 }

--- a/pkg/connect/gateway_msg.go
+++ b/pkg/connect/gateway_msg.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (c *connectionHandler) handleIncomingWebSocketMessage(msg *connectpb.ConnectMessage) *connecterrors.SocketError {
-	c.log.Trace("received WebSocket message", "kind", msg.Kind.String())
+	c.log.Trace("received WebSocket message", "kind", msg.Kind.String(), "phase", c.phase().String())
 
 	switch msg.Kind {
 	case connectpb.GatewayMessageType_WORKER_READY:

--- a/pkg/connect/gateway_msg_extend_lease.go
+++ b/pkg/connect/gateway_msg_extend_lease.go
@@ -119,6 +119,10 @@ func (c *connectionHandler) writeWorkerRequestExtendLeaseAck(data *connectpb.Wor
 
 	ackWriteCtx, ackWriteCancel := context.WithTimeout(context.Background(), wsWriteTimeout)
 	defer ackWriteCancel()
+	if !c.canWrite(connectpb.GatewayMessageType_WORKER_REQUEST_EXTEND_LEASE_ACK) {
+		c.log.Trace("skipping worker request extend lease ack because connection phase cannot write", "phase", c.phase().String())
+		return nil
+	}
 	if err := wsproto.Write(ackWriteCtx, c.ws, &connectpb.ConnectMessage{
 		Kind:    connectpb.GatewayMessageType_WORKER_REQUEST_EXTEND_LEASE_ACK,
 		Payload: ackPayload,

--- a/pkg/connect/gateway_msg_heartbeat.go
+++ b/pkg/connect/gateway_msg_heartbeat.go
@@ -14,7 +14,10 @@ import (
 )
 
 func (c *connectionHandler) handleWorkerHeartbeat() *connecterrors.SocketError {
-	status := connectpb.ConnectionStatus_READY
+	status := connectpb.ConnectionStatus_CONNECTED
+	if c.phase() == gatewayConnPhaseReady {
+		status = connectpb.ConnectionStatus_READY
+	}
 	if c.svc.isDraining.Load() || c.phase() == gatewayConnPhaseDraining {
 		status = connectpb.ConnectionStatus_DRAINING
 

--- a/pkg/connect/gateway_msg_heartbeat.go
+++ b/pkg/connect/gateway_msg_heartbeat.go
@@ -15,17 +15,17 @@ import (
 
 func (c *connectionHandler) handleWorkerHeartbeat() *connecterrors.SocketError {
 	status := connectpb.ConnectionStatus_READY
-	if c.svc.isDraining.Load() || c.draining.Load() {
+	if c.svc.isDraining.Load() || c.phase() == gatewayConnPhaseDraining {
 		status = connectpb.ConnectionStatus_DRAINING
 
 		c.log.Warn("worker heartbeat received during draining sequence",
-			"conn_draining", c.draining.Load(),
+			"phase", c.phase().String(),
 			"svc_draining", c.svc.isDraining.Load(),
 		)
 	}
 
 	err := c.updateConnStatus(status, "worker heartbeat",
-		"conn_draining", c.draining.Load(),
+		"phase", c.phase().String(),
 		"svc_draining", c.svc.isDraining.Load(),
 	)
 	if serr := c.handleConnStatusUpdateResult(err, "failed to update connection status after heartbeat"); serr != nil {
@@ -55,6 +55,12 @@ func (c *connectionHandler) handleWorkerHeartbeat() *connecterrors.SocketError {
 		go l.OnHeartbeat(context.Background(), c.conn)
 	}
 
+	c.setLastHeartbeat(time.Now())
+	if !c.canWrite(connectpb.GatewayMessageType_GATEWAY_HEARTBEAT) {
+		c.log.Trace("worker heartbeat response skipped", "status", status.String(), "phase", c.phase().String())
+		return nil
+	}
+
 	writeCtx, writeCancel := context.WithTimeout(context.Background(), wsWriteTimeout)
 	defer writeCancel()
 	if err := wsproto.Write(writeCtx, c.ws, &connectpb.ConnectMessage{
@@ -64,7 +70,6 @@ func (c *connectionHandler) handleWorkerHeartbeat() *connecterrors.SocketError {
 		return nil
 	}
 
-	c.setLastHeartbeat(time.Now())
 	c.log.Trace("worker heartbeat processed", "status", status.String())
 
 	return nil

--- a/pkg/connect/gateway_msg_heartbeat_test.go
+++ b/pkg/connect/gateway_msg_heartbeat_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/inngest/inngest/pkg/connect/state"
 	"github.com/inngest/inngest/pkg/syscode"
 	connectpb "github.com/inngest/inngest/proto/gen/connect/v1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,11 +32,15 @@ func TestHandleWorkerHeartbeatKeepsDrainingStatus(t *testing.T) {
 	handshake(t, res)
 
 	sendWorkerPauseMessage(t, res.ws)
-	exchangeHeartbeat(t, res.ws, 2*time.Second)
+	sendWorkerHeartbeatMessage(t, res.ws)
 
-	conn, err := res.stateManager.GetConnection(t.Context(), res.envID, res.connID)
-	require.NoError(t, err)
-	require.Equal(t, connectpb.ConnectionStatus_DRAINING, conn.Status)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		conn, err := res.stateManager.GetConnection(t.Context(), res.envID, res.connID)
+		assert.NoError(ct, err)
+		if conn != nil {
+			assert.Equal(ct, connectpb.ConnectionStatus_DRAINING, conn.Status)
+		}
+	}, 2*time.Second, 100*time.Millisecond)
 
 	res.lifecycles.Assert(t, testRecorderAssertion{
 		onConnectedCount:     1,

--- a/pkg/connect/gateway_msg_heartbeat_test.go
+++ b/pkg/connect/gateway_msg_heartbeat_test.go
@@ -51,6 +51,52 @@ func TestHandleWorkerHeartbeatKeepsDrainingStatus(t *testing.T) {
 	})
 }
 
+func TestHandleWorkerHeartbeatKeepsManualReadinessConnectionConnected(t *testing.T) {
+	res := createTestingGateway(t)
+
+	msg := awaitNextMessage(t, res.ws, 2*time.Second)
+	require.Equal(t, connectpb.GatewayMessageType_GATEWAY_HELLO, msg.Kind)
+
+	res.reqData.WorkerManualReadinessAck = true
+	sendWorkerConnectMessage(t, res)
+
+	msg = awaitNextMessage(t, res.ws, 5*time.Second)
+	require.Equal(t, connectpb.GatewayMessageType_GATEWAY_CONNECTION_READY, msg.Kind)
+
+	handler := awaitConnectionHandler(t, res)
+	require.Equal(t, gatewayConnPhaseHandshaking, handler.phase())
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		conn, err := res.stateManager.GetConnection(t.Context(), res.envID, res.connID)
+		assert.NoError(ct, err)
+		if conn != nil {
+			assert.Equal(ct, connectpb.ConnectionStatus_CONNECTED, conn.Status)
+		}
+	}, 2*time.Second, 100*time.Millisecond)
+
+	sendWorkerHeartbeatMessage(t, res.ws)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		res.lifecycles.lock.Lock()
+		defer res.lifecycles.lock.Unlock()
+
+		assert.Equal(ct, 1, len(res.lifecycles.onHeartbeat))
+	}, 2*time.Second, 100*time.Millisecond)
+
+	require.Equal(t, gatewayConnPhaseHandshaking, handler.phase())
+
+	conn, err := res.stateManager.GetConnection(t.Context(), res.envID, res.connID)
+	require.NoError(t, err)
+	require.Equal(t, connectpb.ConnectionStatus_CONNECTED, conn.Status)
+
+	res.lifecycles.Assert(t, testRecorderAssertion{
+		onConnectedCount: 1,
+		onSyncedCount:    1,
+		onReadyCount:     0,
+		onHeartbeatCount: 1,
+	})
+}
+
 func TestHandleWorkerHeartbeatStatusUpdateFailureWritesGatewayHeartbeatUntilThreshold(t *testing.T) {
 	res := createTestingGateway(t)
 	handshake(t, res)

--- a/pkg/connect/gateway_msg_pause.go
+++ b/pkg/connect/gateway_msg_pause.go
@@ -15,7 +15,7 @@ func (c *connectionHandler) handleWorkerPause() *connecterrors.SocketError {
 		c.log.Warn("worker pause signal received during draining sequence")
 	}
 
-	c.draining.Store(true)
+	c.beginDrain("worker pause message", "svc_draining", c.svc.isDraining.Load())
 
 	err := c.updateConnStatus(connectpb.ConnectionStatus_DRAINING, "worker pause message", "svc_draining", c.svc.isDraining.Load())
 	if err != nil {

--- a/pkg/connect/gateway_msg_ready.go
+++ b/pkg/connect/gateway_msg_ready.go
@@ -35,6 +35,7 @@ func (c *connectionHandler) handleWorkerReady() *connecterrors.SocketError {
 	if serr := c.handleConnStatusUpdateResult(err, "failed to update connection status after worker ready"); serr != nil {
 		return serr
 	}
+	c.markReady("worker ready message")
 
 	if c.conn.Data.InstanceId == "" {
 		return &connecterrors.SocketError{

--- a/pkg/connect/gateway_msg_ready.go
+++ b/pkg/connect/gateway_msg_ready.go
@@ -20,14 +20,14 @@ func (c *connectionHandler) handleWorkerReady() *connecterrors.SocketError {
 			"account_id", c.conn.AccountID.String(),
 			"gateway_id", c.conn.GatewayId.String(),
 			"connection_id", c.conn.ConnectionId.String(),
-			"conn_draining", c.draining.Load(),
+			"phase", c.phase().String(),
 		)
 
 		return &ErrDraining
 	}
 
-	if c.draining.Load() {
-		c.log.Warn("ignoring worker ready as connection is marked as draining")
+	if !c.canForward() && c.phase() != gatewayConnPhaseHandshaking {
+		c.log.Warn("ignoring worker ready as connection is not routable", "phase", c.phase().String())
 		return nil
 	}
 

--- a/pkg/connect/gateway_msg_ready_test.go
+++ b/pkg/connect/gateway_msg_ready_test.go
@@ -42,7 +42,7 @@ func TestHandleWorkerReadyIgnoresDrainingConnection(t *testing.T) {
 	handshake(t, res)
 
 	ch := newTestConnectionHandler(t, res)
-	ch.draining.Store(true)
+	ch.beginDrain("test drain")
 
 	serr := ch.handleWorkerReady()
 	require.Nil(t, serr)

--- a/pkg/connect/gateway_msg_request_ack.go
+++ b/pkg/connect/gateway_msg_request_ack.go
@@ -28,9 +28,7 @@ func (c *connectionHandler) handleWorkerRequestAck(msg *connectpb.ConnectMessage
 		}
 	}
 
-	if ackCh, ok := c.pendingAcks.LoadAndDelete(data.RequestId); ok {
-		close(ackCh.(chan struct{}))
-	} else {
+	if !c.completePendingAck(data.RequestId, nil) {
 		c.log.Warn(
 			"worker request ack received for unknown request ID",
 			"conn_id", c.conn.ConnectionId.String(),

--- a/pkg/connect/gateway_msg_request_ack_test.go
+++ b/pkg/connect/gateway_msg_request_ack_test.go
@@ -37,16 +37,17 @@ func TestHandleWorkerRequestAckMissingExecutorLeaseIsNonFatalAfterPendingAck(t *
 
 	ch := newTestConnectionHandler(t, res)
 	requestID := "test-missing-executor-lease"
-	ackCh := make(chan struct{})
+	ackCh := make(chan error, 1)
 	ch.pendingAcks.Store(requestID, ackCh)
 
 	serr := ch.handleWorkerRequestAck(workerRequestAckMessage(t, res, requestID))
 	require.Nil(t, serr)
 
 	select {
-	case <-ackCh:
+	case err := <-ackCh:
+		require.NoError(t, err)
 	case <-time.After(time.Second):
-		t.Fatal("pending ack channel should be closed before executor notification")
+		t.Fatal("pending ack channel should succeed before executor notification")
 	}
 }
 

--- a/pkg/connect/gateway_msg_test_helpers_test.go
+++ b/pkg/connect/gateway_msg_test_helpers_test.go
@@ -28,13 +28,15 @@ func newTestConnectionHandler(t *testing.T, res testingResources) *connectionHan
 		GatewayId: res.svc.gatewayId,
 	}
 
-	return &connectionHandler{
+	ch := &connectionHandler{
 		svc:            res.svc,
 		conn:           conn,
 		ws:             res.ws,
 		log:            res.svc.logger,
 		stopForwarding: make(chan struct{}),
 	}
+	ch.markReady("test connection handler")
+	return ch
 }
 
 type upsertConnectionErrorStateManager struct {

--- a/pkg/connect/gateway_phase.go
+++ b/pkg/connect/gateway_phase.go
@@ -75,23 +75,31 @@ func (c *connectionHandler) canWrite(kind connectpb.GatewayMessageType) bool {
 // transition records phase movement. Most external side effects still live at
 // existing call sites so phase checks can be introduced without collapsing the
 // Redis, lifecycle listener, and transport-close responsibilities together.
-func (c *connectionHandler) transition(to gatewayConnPhase, reason string, attrs ...any) gatewayConnPhase {
-	from := gatewayConnPhase(c.connPhase.Swap(int32(to)))
+func (c *connectionHandler) transition(to gatewayConnPhase, reason string, attrs ...any) (gatewayConnPhase, bool) {
+	for {
+		from := c.phase()
+		logAttrs := []any{
+			"from_phase", from.String(),
+			"to_phase", to.String(),
+			"reason", reason,
+		}
+		logAttrs = append(logAttrs, attrs...)
 
-	logAttrs := []any{
-		"from_phase", from.String(),
-		"to_phase", to.String(),
-		"reason", reason,
+		if from > to {
+			c.log.Trace("worker connection phase transition ignored", logAttrs...)
+			return from, false
+		}
+
+		if c.connPhase.CompareAndSwap(int32(from), int32(to)) {
+			if from == to {
+				c.log.Trace("worker connection phase refreshed", logAttrs...)
+				return from, true
+			}
+
+			c.log.Debug("worker connection phase transition", logAttrs...)
+			return from, true
+		}
 	}
-	logAttrs = append(logAttrs, attrs...)
-
-	if from == to {
-		c.log.Trace("worker connection phase refreshed", logAttrs...)
-		return from
-	}
-
-	c.log.Debug("worker connection phase transition", logAttrs...)
-	return from
 }
 
 func (c *connectionHandler) markHandshaking(reason string, attrs ...any) {
@@ -101,48 +109,43 @@ func (c *connectionHandler) markHandshaking(reason string, attrs ...any) {
 func (c *connectionHandler) markReady(reason string, attrs ...any) {
 	// Keep the legacy draining flag in sync while it remains part of the
 	// handler state observed by tests and drain cleanup.
-	c.draining.Store(false)
-	c.transition(gatewayConnPhaseReady, reason, attrs...)
+	if _, ok := c.transition(gatewayConnPhaseReady, reason, attrs...); ok {
+		c.draining.Store(false)
+	}
 }
 
 func (c *connectionHandler) beginDrain(reason string, attrs ...any) {
-	from := c.phase()
-	switch from {
-	case gatewayConnPhaseDisconnecting, gatewayConnPhaseClosed:
-		// Drain is a routing concern. Once disconnect cleanup has started, do not
-		// move the observable phase backward or revive legacy drain behavior.
-		c.log.Trace("worker connection phase not moved to draining after disconnect started",
-			append([]any{"phase", c.phase().String(), "reason", reason}, attrs...)...)
+	from, ok := c.transition(gatewayConnPhaseDraining, reason, attrs...)
+	if !ok {
 		return
-	default:
-		// Keep c.draining synchronized with the phase for compatibility with
-		// existing drain state observers.
-		c.draining.Store(true)
-		c.transition(gatewayConnPhaseDraining, reason, attrs...)
-		if from == gatewayConnPhaseReady {
-			c.releasePendingAcks(fmt.Errorf("connection entered drain: %s", reason))
-		}
+	}
+
+	// Keep c.draining synchronized with the phase for compatibility with
+	// existing drain state observers.
+	c.draining.Store(true)
+	if from == gatewayConnPhaseReady {
+		c.releasePendingAcks(fmt.Errorf("connection entered drain: %s", reason))
 	}
 }
 
 func (c *connectionHandler) beginDisconnect(reason string, attrs ...any) {
-	if c.phase() == gatewayConnPhaseClosed {
-		// Cleanup can be reached from several defers. Preserve idempotence and
-		// keep Closed as the terminal observable phase.
-		c.log.Trace("worker connection phase already closed",
-			append([]any{"reason", reason}, attrs...)...)
+	from, ok := c.transition(gatewayConnPhaseDisconnecting, reason, attrs...)
+	if !ok {
 		return
 	}
 
-	if c.phase() == gatewayConnPhaseReady {
+	if from == gatewayConnPhaseReady {
 		c.releasePendingAcks(fmt.Errorf("connection started disconnecting: %s", reason))
 	}
-	c.transition(gatewayConnPhaseDisconnecting, reason, attrs...)
 }
 
 func (c *connectionHandler) markClosed(reason string, attrs ...any) {
-	if c.phase() == gatewayConnPhaseReady {
+	from, ok := c.transition(gatewayConnPhaseClosed, reason, attrs...)
+	if !ok {
+		return
+	}
+
+	if from == gatewayConnPhaseReady {
 		c.releasePendingAcks(fmt.Errorf("connection closed: %s", reason))
 	}
-	c.transition(gatewayConnPhaseClosed, reason, attrs...)
 }

--- a/pkg/connect/gateway_phase.go
+++ b/pkg/connect/gateway_phase.go
@@ -1,0 +1,89 @@
+package connect
+
+type gatewayConnPhase int32
+
+const (
+	gatewayConnPhaseNew gatewayConnPhase = iota
+	gatewayConnPhaseHandshaking
+	gatewayConnPhaseReady
+	gatewayConnPhaseDraining
+	gatewayConnPhaseDisconnecting
+	gatewayConnPhaseClosed
+)
+
+func (p gatewayConnPhase) String() string {
+	switch p {
+	case gatewayConnPhaseNew:
+		return "New"
+	case gatewayConnPhaseHandshaking:
+		return "Handshaking"
+	case gatewayConnPhaseReady:
+		return "Ready"
+	case gatewayConnPhaseDraining:
+		return "Draining"
+	case gatewayConnPhaseDisconnecting:
+		return "Disconnecting"
+	case gatewayConnPhaseClosed:
+		return "Closed"
+	default:
+		return "Unknown"
+	}
+}
+
+func (c *connectionHandler) phase() gatewayConnPhase {
+	return gatewayConnPhase(c.connPhase.Load())
+}
+
+func (c *connectionHandler) transition(to gatewayConnPhase, reason string, attrs ...any) gatewayConnPhase {
+	from := gatewayConnPhase(c.connPhase.Swap(int32(to)))
+
+	logAttrs := []any{
+		"from_phase", from.String(),
+		"to_phase", to.String(),
+		"reason", reason,
+	}
+	logAttrs = append(logAttrs, attrs...)
+
+	if from == to {
+		c.log.Trace("worker connection phase refreshed", logAttrs...)
+		return from
+	}
+
+	c.log.Debug("worker connection phase transition", logAttrs...)
+	return from
+}
+
+func (c *connectionHandler) markHandshaking(reason string, attrs ...any) {
+	c.transition(gatewayConnPhaseHandshaking, reason, attrs...)
+}
+
+func (c *connectionHandler) markReady(reason string, attrs ...any) {
+	c.draining.Store(false)
+	c.transition(gatewayConnPhaseReady, reason, attrs...)
+}
+
+func (c *connectionHandler) beginDrain(reason string, attrs ...any) {
+	switch c.phase() {
+	case gatewayConnPhaseDisconnecting, gatewayConnPhaseClosed:
+		c.log.Trace("worker connection phase not moved to draining after disconnect started",
+			append([]any{"phase", c.phase().String(), "reason", reason}, attrs...)...)
+		return
+	default:
+		c.draining.Store(true)
+		c.transition(gatewayConnPhaseDraining, reason, attrs...)
+	}
+}
+
+func (c *connectionHandler) beginDisconnect(reason string, attrs ...any) {
+	if c.phase() == gatewayConnPhaseClosed {
+		c.log.Trace("worker connection phase already closed",
+			append([]any{"reason", reason}, attrs...)...)
+		return
+	}
+
+	c.transition(gatewayConnPhaseDisconnecting, reason, attrs...)
+}
+
+func (c *connectionHandler) markClosed(reason string, attrs ...any) {
+	c.transition(gatewayConnPhaseClosed, reason, attrs...)
+}

--- a/pkg/connect/gateway_phase.go
+++ b/pkg/connect/gateway_phase.go
@@ -1,5 +1,11 @@
 package connect
 
+import (
+	"fmt"
+
+	connectpb "github.com/inngest/inngest/proto/gen/connect/v1"
+)
+
 // gatewayConnPhase tracks the in-memory lifecycle of a single websocket
 // handler. It is intentionally separate from Redis connection status: Redis is
 // router-visible state, while this phase answers what the local handler may do.
@@ -37,9 +43,38 @@ func (c *connectionHandler) phase() gatewayConnPhase {
 	return gatewayConnPhase(c.connPhase.Load())
 }
 
-// transition records phase movement without owning external side effects yet.
-// Phase 1 keeps behavior unchanged, so Redis writes, lifecycle callbacks, and
-// transport closes still happen at their existing call sites.
+func (c *connectionHandler) canForward() bool {
+	return c.phase() == gatewayConnPhaseReady
+}
+
+func (c *connectionHandler) canWrite(kind connectpb.GatewayMessageType) bool {
+	phase := c.phase()
+
+	switch kind {
+	case connectpb.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST:
+		return phase == gatewayConnPhaseReady
+	case connectpb.GatewayMessageType_GATEWAY_HEARTBEAT:
+		return phase == gatewayConnPhaseReady
+	case connectpb.GatewayMessageType_WORKER_REPLY_ACK:
+		// Replies are only handled after the run loop has read a worker message.
+		// Allow the ACK while cleanup is starting, but never after final close.
+		return phase == gatewayConnPhaseReady ||
+			phase == gatewayConnPhaseDraining ||
+			phase == gatewayConnPhaseDisconnecting
+	case connectpb.GatewayMessageType_WORKER_REQUEST_EXTEND_LEASE_ACK:
+		return phase == gatewayConnPhaseReady ||
+			phase == gatewayConnPhaseDraining
+	case connectpb.GatewayMessageType_GATEWAY_CLOSING:
+		return phase == gatewayConnPhaseReady ||
+			phase == gatewayConnPhaseDraining
+	default:
+		return phase != gatewayConnPhaseClosed
+	}
+}
+
+// transition records phase movement. Most external side effects still live at
+// existing call sites so phase checks can be introduced without collapsing the
+// Redis, lifecycle listener, and transport-close responsibilities together.
 func (c *connectionHandler) transition(to gatewayConnPhase, reason string, attrs ...any) gatewayConnPhase {
 	from := gatewayConnPhase(c.connPhase.Swap(int32(to)))
 
@@ -64,14 +99,15 @@ func (c *connectionHandler) markHandshaking(reason string, attrs ...any) {
 }
 
 func (c *connectionHandler) markReady(reason string, attrs ...any) {
-	// Keep the legacy draining flag in sync until routing/write eligibility can
-	// move fully to phase checks in a later plan phase.
+	// Keep the legacy draining flag in sync while it remains part of the
+	// handler state observed by tests and drain cleanup.
 	c.draining.Store(false)
 	c.transition(gatewayConnPhaseReady, reason, attrs...)
 }
 
 func (c *connectionHandler) beginDrain(reason string, attrs ...any) {
-	switch c.phase() {
+	from := c.phase()
+	switch from {
 	case gatewayConnPhaseDisconnecting, gatewayConnPhaseClosed:
 		// Drain is a routing concern. Once disconnect cleanup has started, do not
 		// move the observable phase backward or revive legacy drain behavior.
@@ -79,10 +115,13 @@ func (c *connectionHandler) beginDrain(reason string, attrs ...any) {
 			append([]any{"phase", c.phase().String(), "reason", reason}, attrs...)...)
 		return
 	default:
-		// During Phase 1 the existing Forward and heartbeat paths still read
-		// c.draining, so set it as part of entering the drain phase.
+		// Keep c.draining synchronized with the phase for compatibility with
+		// existing drain state observers.
 		c.draining.Store(true)
 		c.transition(gatewayConnPhaseDraining, reason, attrs...)
+		if from == gatewayConnPhaseReady {
+			c.releasePendingAcks(fmt.Errorf("connection entered drain: %s", reason))
+		}
 	}
 }
 
@@ -95,9 +134,15 @@ func (c *connectionHandler) beginDisconnect(reason string, attrs ...any) {
 		return
 	}
 
+	if c.phase() == gatewayConnPhaseReady {
+		c.releasePendingAcks(fmt.Errorf("connection started disconnecting: %s", reason))
+	}
 	c.transition(gatewayConnPhaseDisconnecting, reason, attrs...)
 }
 
 func (c *connectionHandler) markClosed(reason string, attrs ...any) {
+	if c.phase() == gatewayConnPhaseReady {
+		c.releasePendingAcks(fmt.Errorf("connection closed: %s", reason))
+	}
 	c.transition(gatewayConnPhaseClosed, reason, attrs...)
 }

--- a/pkg/connect/gateway_phase.go
+++ b/pkg/connect/gateway_phase.go
@@ -54,7 +54,8 @@ func (c *connectionHandler) canWrite(kind connectpb.GatewayMessageType) bool {
 	case connectpb.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST:
 		return phase == gatewayConnPhaseReady
 	case connectpb.GatewayMessageType_GATEWAY_HEARTBEAT:
-		return phase == gatewayConnPhaseReady
+		return phase == gatewayConnPhaseReady ||
+			phase == gatewayConnPhaseDraining
 	case connectpb.GatewayMessageType_WORKER_REPLY_ACK:
 		// Replies are only handled after the run loop has read a worker message.
 		// Allow the ACK while cleanup is starting, but never after final close.

--- a/pkg/connect/gateway_phase.go
+++ b/pkg/connect/gateway_phase.go
@@ -1,5 +1,8 @@
 package connect
 
+// gatewayConnPhase tracks the in-memory lifecycle of a single websocket
+// handler. It is intentionally separate from Redis connection status: Redis is
+// router-visible state, while this phase answers what the local handler may do.
 type gatewayConnPhase int32
 
 const (
@@ -34,6 +37,9 @@ func (c *connectionHandler) phase() gatewayConnPhase {
 	return gatewayConnPhase(c.connPhase.Load())
 }
 
+// transition records phase movement without owning external side effects yet.
+// Phase 1 keeps behavior unchanged, so Redis writes, lifecycle callbacks, and
+// transport closes still happen at their existing call sites.
 func (c *connectionHandler) transition(to gatewayConnPhase, reason string, attrs ...any) gatewayConnPhase {
 	from := gatewayConnPhase(c.connPhase.Swap(int32(to)))
 
@@ -58,6 +64,8 @@ func (c *connectionHandler) markHandshaking(reason string, attrs ...any) {
 }
 
 func (c *connectionHandler) markReady(reason string, attrs ...any) {
+	// Keep the legacy draining flag in sync until routing/write eligibility can
+	// move fully to phase checks in a later plan phase.
 	c.draining.Store(false)
 	c.transition(gatewayConnPhaseReady, reason, attrs...)
 }
@@ -65,10 +73,14 @@ func (c *connectionHandler) markReady(reason string, attrs ...any) {
 func (c *connectionHandler) beginDrain(reason string, attrs ...any) {
 	switch c.phase() {
 	case gatewayConnPhaseDisconnecting, gatewayConnPhaseClosed:
+		// Drain is a routing concern. Once disconnect cleanup has started, do not
+		// move the observable phase backward or revive legacy drain behavior.
 		c.log.Trace("worker connection phase not moved to draining after disconnect started",
 			append([]any{"phase", c.phase().String(), "reason", reason}, attrs...)...)
 		return
 	default:
+		// During Phase 1 the existing Forward and heartbeat paths still read
+		// c.draining, so set it as part of entering the drain phase.
 		c.draining.Store(true)
 		c.transition(gatewayConnPhaseDraining, reason, attrs...)
 	}
@@ -76,6 +88,8 @@ func (c *connectionHandler) beginDrain(reason string, attrs ...any) {
 
 func (c *connectionHandler) beginDisconnect(reason string, attrs ...any) {
 	if c.phase() == gatewayConnPhaseClosed {
+		// Cleanup can be reached from several defers. Preserve idempotence and
+		// keep Closed as the terminal observable phase.
 		c.log.Trace("worker connection phase already closed",
 			append([]any{"reason", reason}, attrs...)...)
 		return

--- a/pkg/connect/gateway_phase_test.go
+++ b/pkg/connect/gateway_phase_test.go
@@ -1,0 +1,120 @@
+package connect
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/inngest/inngest/pkg/logger"
+	connectpb "github.com/inngest/inngest/proto/gen/connect/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnectionHandlerPhaseHelpers(t *testing.T) {
+	ch := &connectionHandler{
+		log: logger.StdlibLogger(context.Background(), logger.WithLoggerLevel(logger.LevelEmergency)),
+	}
+
+	require.Equal(t, gatewayConnPhaseNew, ch.phase())
+
+	ch.markHandshaking("test handshake")
+	require.Equal(t, gatewayConnPhaseHandshaking, ch.phase())
+
+	ch.markReady("test ready")
+	require.Equal(t, gatewayConnPhaseReady, ch.phase())
+	require.False(t, ch.draining.Load())
+
+	ch.beginDrain("test drain")
+	require.Equal(t, gatewayConnPhaseDraining, ch.phase())
+	require.True(t, ch.draining.Load())
+
+	ch.beginDisconnect("test disconnect")
+	require.Equal(t, gatewayConnPhaseDisconnecting, ch.phase())
+
+	ch.markClosed("test closed")
+	require.Equal(t, gatewayConnPhaseClosed, ch.phase())
+
+	ch.markClosed("test closed again")
+	require.Equal(t, gatewayConnPhaseClosed, ch.phase())
+
+	ch.beginDrain("late drain")
+	require.Equal(t, gatewayConnPhaseClosed, ch.phase())
+}
+
+func TestGatewayConnectionPhaseHandshakeReady(t *testing.T) {
+	res := createTestingGateway(t, testingParameters{silent: true})
+	handshake(t, res)
+
+	handler := awaitConnectionHandler(t, res)
+	require.Equal(t, gatewayConnPhaseReady, handler.phase())
+}
+
+func TestGatewayConnectionPhaseWorkerPauseDraining(t *testing.T) {
+	res := createTestingGateway(t, testingParameters{silent: true})
+	handshake(t, res)
+
+	handler := awaitConnectionHandler(t, res)
+	require.Equal(t, gatewayConnPhaseReady, handler.phase())
+
+	sendWorkerPauseMessage(t, res.ws)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.Equal(ct, gatewayConnPhaseDraining, handler.phase())
+		assert.True(ct, handler.draining.Load())
+	}, 2*time.Second, 100*time.Millisecond)
+}
+
+func TestGatewayConnectionPhaseGatewayDrainDraining(t *testing.T) {
+	res := createTestingGateway(t, testingParameters{
+		drainAckTimeout: 2 * time.Second,
+		silent:          true,
+	})
+	handshake(t, res)
+
+	handler := awaitConnectionHandler(t, res)
+	require.Equal(t, gatewayConnPhaseReady, handler.phase())
+
+	require.NoError(t, res.svc.DrainGateway())
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.Equal(ct, gatewayConnPhaseDraining, handler.phase())
+		assert.True(ct, handler.draining.Load())
+	}, 2*time.Second, 100*time.Millisecond)
+
+	msg := awaitNextMessage(t, res.ws, 3*time.Second)
+	require.Equal(t, connectpb.GatewayMessageType_GATEWAY_CLOSING, msg.Kind)
+}
+
+func TestGatewayConnectionPhaseReadLoopExitClosed(t *testing.T) {
+	res := createTestingGateway(t, testingParameters{silent: true})
+	handshake(t, res)
+
+	handler := awaitConnectionHandler(t, res)
+	require.Equal(t, gatewayConnPhaseReady, handler.phase())
+
+	require.NoError(t, res.ws.Close(websocket.StatusNormalClosure, connectpb.WorkerDisconnectReason_WORKER_SHUTDOWN.String()))
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.Equal(ct, gatewayConnPhaseClosed, handler.phase())
+	}, 3*time.Second, 100*time.Millisecond)
+}
+
+func awaitConnectionHandler(t *testing.T, res testingResources) *connectionHandler {
+	t.Helper()
+
+	var handler *connectionHandler
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		val, ok := res.svc.wsConnections.Load(res.connID.String())
+		if !assert.True(ct, ok) {
+			return
+		}
+
+		var typeOK bool
+		handler, typeOK = val.(*connectionHandler)
+		assert.True(ct, typeOK)
+	}, 2*time.Second, 100*time.Millisecond)
+
+	return handler
+}

--- a/pkg/connect/gateway_phase_test.go
+++ b/pkg/connect/gateway_phase_test.go
@@ -72,7 +72,7 @@ func TestConnectionHandlerPhaseEligibility(t *testing.T) {
 	ch.beginDrain("test drain")
 	require.False(t, ch.canForward())
 	require.False(t, ch.canWrite(connectpb.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST))
-	require.False(t, ch.canWrite(connectpb.GatewayMessageType_GATEWAY_HEARTBEAT))
+	require.True(t, ch.canWrite(connectpb.GatewayMessageType_GATEWAY_HEARTBEAT))
 	require.True(t, ch.canWrite(connectpb.GatewayMessageType_WORKER_REPLY_ACK))
 	require.True(t, ch.canWrite(connectpb.GatewayMessageType_WORKER_REQUEST_EXTEND_LEASE_ACK))
 

--- a/pkg/connect/gateway_phase_test.go
+++ b/pkg/connect/gateway_phase_test.go
@@ -43,6 +43,58 @@ func TestConnectionHandlerPhaseHelpers(t *testing.T) {
 	require.Equal(t, gatewayConnPhaseClosed, ch.phase())
 }
 
+func TestConnectionHandlerPhaseEligibility(t *testing.T) {
+	ch := &connectionHandler{
+		log: logger.StdlibLogger(context.Background(), logger.WithLoggerLevel(logger.LevelEmergency)),
+	}
+
+	require.False(t, ch.canForward())
+	require.False(t, ch.canWrite(connectpb.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST))
+
+	ch.markReady("test ready")
+	require.True(t, ch.canForward())
+	require.True(t, ch.canWrite(connectpb.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST))
+	require.True(t, ch.canWrite(connectpb.GatewayMessageType_GATEWAY_HEARTBEAT))
+
+	ch.beginDrain("test drain")
+	require.False(t, ch.canForward())
+	require.False(t, ch.canWrite(connectpb.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST))
+	require.False(t, ch.canWrite(connectpb.GatewayMessageType_GATEWAY_HEARTBEAT))
+	require.True(t, ch.canWrite(connectpb.GatewayMessageType_WORKER_REPLY_ACK))
+	require.True(t, ch.canWrite(connectpb.GatewayMessageType_WORKER_REQUEST_EXTEND_LEASE_ACK))
+
+	ch.beginDisconnect("test disconnect")
+	require.False(t, ch.canForward())
+	require.True(t, ch.canWrite(connectpb.GatewayMessageType_WORKER_REPLY_ACK))
+	require.False(t, ch.canWrite(connectpb.GatewayMessageType_WORKER_REQUEST_EXTEND_LEASE_ACK))
+
+	ch.markClosed("test closed")
+	require.False(t, ch.canForward())
+	require.False(t, ch.canWrite(connectpb.GatewayMessageType_WORKER_REPLY_ACK))
+}
+
+func TestConnectionHandlerPhaseReleasesPendingAcks(t *testing.T) {
+	ch := &connectionHandler{
+		log: logger.StdlibLogger(context.Background(), logger.WithLoggerLevel(logger.LevelEmergency)),
+	}
+	ch.markReady("test ready")
+
+	ackCh := make(chan error, 1)
+	ch.pendingAcks.Store("req-1", ackCh)
+
+	ch.beginDisconnect("test disconnect")
+
+	select {
+	case err := <-ackCh:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("pending ack should be released when leaving Ready")
+	}
+
+	_, ok := ch.pendingAcks.Load("req-1")
+	require.False(t, ok)
+}
+
 func TestGatewayConnectionPhaseHandshakeReady(t *testing.T) {
 	res := createTestingGateway(t, testingParameters{silent: true})
 	handshake(t, res)
@@ -101,6 +153,44 @@ func TestGatewayConnectionPhaseReadLoopExitClosed(t *testing.T) {
 	}, 3*time.Second, 100*time.Millisecond)
 }
 
+func TestForwardRejectsConnectionOutsideReady(t *testing.T) {
+	res := createTestingGateway(t, testingParameters{silent: true})
+	handshake(t, res)
+
+	handler := awaitConnectionHandler(t, res)
+	handler.beginDisconnect("test disconnect")
+
+	resp, err := res.svc.Forward(context.Background(), &connectpb.ForwardRequest{
+		ConnectionID: res.connID.String(),
+		Data:         testGatewayExecutorRequestData(res, "test-forward-not-ready"),
+	})
+	require.NoError(t, err)
+	require.False(t, resp.Success)
+}
+
+func TestGatewayExecutorRequestNotWrittenOutsideReady(t *testing.T) {
+	res := createTestingGateway(t, testingParameters{silent: true})
+	handshake(t, res)
+
+	handler := awaitConnectionHandler(t, res)
+	handler.beginDisconnect("test disconnect")
+
+	resultCh := make(chan error, 1)
+	handler.messageChan <- forwardMessage{
+		Data:   testGatewayExecutorRequestData(res, "test-write-not-ready"),
+		Result: resultCh,
+	}
+
+	select {
+	case err := <-resultCh:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("forward should fail when connection is not Ready")
+	}
+
+	assertNoMessage(t, res.ws, 200*time.Millisecond)
+}
+
 func awaitConnectionHandler(t *testing.T, res testingResources) *connectionHandler {
 	t.Helper()
 
@@ -117,4 +207,18 @@ func awaitConnectionHandler(t *testing.T, res testingResources) *connectionHandl
 	}, 2*time.Second, 100*time.Millisecond)
 
 	return handler
+}
+
+func testGatewayExecutorRequestData(res testingResources, requestID string) *connectpb.GatewayExecutorRequestData {
+	return &connectpb.GatewayExecutorRequestData{
+		RequestId:      requestID,
+		AccountId:      res.accountID.String(),
+		EnvId:          res.envID.String(),
+		AppId:          res.appID.String(),
+		AppName:        res.appName,
+		FunctionId:     res.fnID.String(),
+		FunctionSlug:   res.fnSlug,
+		RequestPayload: []byte("test payload"),
+		RunId:          res.runID.String(),
+	}
 }

--- a/pkg/connect/gateway_phase_test.go
+++ b/pkg/connect/gateway_phase_test.go
@@ -43,6 +43,19 @@ func TestConnectionHandlerPhaseHelpers(t *testing.T) {
 	require.Equal(t, gatewayConnPhaseClosed, ch.phase())
 }
 
+func TestConnectionHandlerTransitionDoesNotMovePhaseBackward(t *testing.T) {
+	ch := &connectionHandler{
+		log: logger.StdlibLogger(context.Background(), logger.WithLoggerLevel(logger.LevelEmergency)),
+	}
+
+	ch.markReady("test ready")
+	ch.beginDisconnect("test disconnect")
+
+	ch.transition(gatewayConnPhaseDraining, "stale drain transition")
+
+	require.Equal(t, gatewayConnPhaseDisconnecting, ch.phase())
+}
+
 func TestConnectionHandlerPhaseEligibility(t *testing.T) {
 	ch := &connectionHandler{
 		log: logger.StdlibLogger(context.Background(), logger.WithLoggerLevel(logger.LevelEmergency)),

--- a/pkg/connect/gateway_test.go
+++ b/pkg/connect/gateway_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -1181,7 +1182,10 @@ func assertNoMessage(t *testing.T, ws *websocket.Conn, timeout time.Duration) {
 
 	parsed := connect.ConnectMessage{}
 	err := wsproto.Read(ctx, ws, &parsed)
-	require.ErrorIs(t, err, context.DeadlineExceeded)
+	if errors.Is(err, context.DeadlineExceeded) || isConnectionClosedErr(err) {
+		return
+	}
+	require.Error(t, err)
 }
 
 func awaitClosure(t *testing.T, ws *websocket.Conn, timeout time.Duration) (websocket.StatusCode, string) {

--- a/pkg/connect/gateway_test.go
+++ b/pkg/connect/gateway_test.go
@@ -1173,6 +1173,17 @@ func awaitNextMessage(t *testing.T, ws *websocket.Conn, timeout time.Duration) *
 	return &parsed
 }
 
+func assertNoMessage(t *testing.T, ws *websocket.Conn, timeout time.Duration) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	parsed := connect.ConnectMessage{}
+	err := wsproto.Read(ctx, ws, &parsed)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
 func awaitClosure(t *testing.T, ws *websocket.Conn, timeout time.Duration) (websocket.StatusCode, string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -1717,11 +1728,10 @@ func TestDrainingConnectionNotKilledByHeartbeatDetector(t *testing.T) {
 	}, 2*time.Second, 50*time.Millisecond)
 
 	// Keep sending heartbeats well past the miss threshold (3 * 200ms = 600ms).
-	// Use exchangeHeartbeat to verify the gateway responds with GATEWAY_HEARTBEAT
-	// even while draining. Without a response, the SDK would consider the
-	// connection dead and stop extending leases for in-flight work.
+	// Phase-driven write eligibility skips heartbeat responses during drain, but
+	// the inbound heartbeat still refreshes the detector.
 	for range 10 {
-		exchangeHeartbeat(t, res.ws, 2*time.Second)
+		sendWorkerHeartbeatMessage(t, res.ws)
 		time.Sleep(params.heartbeatInterval)
 	}
 

--- a/pkg/connect/gateway_test.go
+++ b/pkg/connect/gateway_test.go
@@ -1732,10 +1732,10 @@ func TestDrainingConnectionNotKilledByHeartbeatDetector(t *testing.T) {
 	}, 2*time.Second, 50*time.Millisecond)
 
 	// Keep sending heartbeats well past the miss threshold (3 * 200ms = 600ms).
-	// Phase-driven write eligibility skips heartbeat responses during drain, but
-	// the inbound heartbeat still refreshes the detector.
+	// Keep exchanging heartbeat ACKs so the SDK-side pending heartbeat counter
+	// would not treat the draining connection as dead.
 	for range 10 {
-		sendWorkerHeartbeatMessage(t, res.ws)
+		exchangeHeartbeat(t, res.ws, 2*time.Second)
 		time.Sleep(params.heartbeatInterval)
 	}
 

--- a/pkg/connect/rpc.go
+++ b/pkg/connect/rpc.go
@@ -36,6 +36,7 @@ func (c *connectGatewaySvc) Forward(ctx context.Context, req *pb.ForwardRequest)
 				"conn_id", req.ConnectionID,
 				"req_id", req.Data.RequestId,
 				"run_id", req.Data.RunId,
+				"phase", handler.phase().String(),
 			)
 			select {
 			case <-handler.stopForwarding:
@@ -46,11 +47,12 @@ func (c *connectGatewaySvc) Forward(ctx context.Context, req *pb.ForwardRequest)
 				"conn_id", req.ConnectionID,
 				"req_id", req.Data.RequestId,
 				"run_id", req.Data.RunId,
+				"phase", handler.phase().String(),
 			)
 			return &pb.ForwardResponse{Success: false}, nil
 		}
 
-		l.Trace("found ws connection by connectionID")
+		l.Trace("found ws connection by connectionID", "phase", handler.phase().String())
 		msgChan := handler.messageChan
 
 		resultCh := make(chan error, 1)

--- a/pkg/connect/rpc.go
+++ b/pkg/connect/rpc.go
@@ -26,29 +26,33 @@ func (c *connectGatewaySvc) Forward(ctx context.Context, req *pb.ForwardRequest)
 	if val, ok := c.wsConnections.Load(req.ConnectionID); ok {
 		handler := val.(*connectionHandler)
 
-		if handler.draining.Load() {
+		if !handler.canForward() {
 			// Block until DRAINING is written to Redis, so the proxy
 			// re-route finds the new connection as READY.
 
 			accID, _ := uuid.Parse(req.Data.AccountId)
 
-			l.Optional(accID, "connect").Debug("forward blocked, connection draining",
+			l.Optional(accID, "connect").Debug("forward rejected, connection not ready",
 				"conn_id", req.ConnectionID,
 				"req_id", req.Data.RequestId,
 				"run_id", req.Data.RunId,
 				"phase", handler.phase().String(),
 			)
-			select {
-			case <-handler.stopForwarding:
-			case <-ctx.Done():
-				return nil, ctx.Err()
+
+			if handler.phase() == gatewayConnPhaseDraining {
+				select {
+				case <-handler.stopForwarding:
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+				l.Optional(accID, "connect").Debug("forward released after drain complete",
+					"conn_id", req.ConnectionID,
+					"req_id", req.Data.RequestId,
+					"run_id", req.Data.RunId,
+					"phase", handler.phase().String(),
+				)
 			}
-			l.Optional(accID, "connect").Debug("forward released after drain complete",
-				"conn_id", req.ConnectionID,
-				"req_id", req.Data.RequestId,
-				"run_id", req.Data.RunId,
-				"phase", handler.phase().String(),
-			)
+
 			return &pb.ForwardResponse{Success: false}, nil
 		}
 


### PR DESCRIPTION
## Description

Implements phases 1 and 2 of the Connect gateway lifecycle controller.

- Adds an internal `gatewayConnPhase` model for one websocket handler: New, Handshaking, Ready, Draining, Disconnecting, and Closed.
- Records phase transitions in logs while keeping Redis connection status, lifecycle callbacks, and websocket transport cleanup separate.
- Adds `canForward` and `canWrite` helpers so new router work and `GATEWAY_EXECUTOR_REQUEST` writes require `Ready`.
- Releases pending request ACK waiters when a connection leaves `Ready`, instead of relying only on timeout cleanup.
- Keeps post-persistence reply ACK behavior non-fatal and preserves drain-time lease extension handling for in-flight work.
- Makes phase transitions monotonic so stale drain paths cannot move a handler backward from `Disconnecting` to `Draining`.
- Adds regression coverage for phase transitions, routing/write eligibility, pending ACK release, heartbeat/drain behavior, and non-fatal reply handling.
- Updates the plan checklist and agent guidance for intent-focused comments.

## Release note

None

## Migration note

None

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*