### PR TITLE
fix: preserve debounce on migration failure

### DIFF
--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -259,6 +259,12 @@ type debouncer struct {
 	shouldMigrate func(ctx context.Context, accountID uuid.UUID) bool
 }
 
+type preparedMigration struct {
+	debounceID       ulid.ULID
+	timeoutUnixMilli int64
+	pointerTTL       time.Duration
+}
+
 func (d debouncer) hasSecondary() bool {
 	return d.secondaryShardName != ""
 }
@@ -513,6 +519,8 @@ func (d debouncer) Debounce(ctx context.Context, di DebounceItem, fn inngest.Fun
 func (d debouncer) debounce(ctx context.Context, di DebounceItem, fn inngest.Function, ttl time.Duration, n int, shouldMigrate bool) error {
 	newDebounceID := ulid.MustNew(ulid.Timestamp(d.c.Now()), rand.Reader)
 	var foundDebounce bool
+	var migration *preparedMigration
+	var err error
 
 	l := logger.StdlibLogger(ctx).With(
 		"fn_id", di.FunctionID.String(),
@@ -542,50 +550,24 @@ func (d debouncer) debounce(ctx context.Context, di DebounceItem, fn inngest.Fun
 			return fmt.Errorf("could not resolve secondary shard: %w", err)
 		}
 
-		debounceID, debounceTimeout, err := d.prepareMigration(ctx, di, fn, secondary)
+		migration, err = d.prepareMigration(ctx, di, fn, secondary)
 		if err != nil {
 			return fmt.Errorf("could not prepare debounce migration: %w", err)
 		}
 
-		if debounceID != nil {
+		if migration != nil {
 			l = l.With(
-				"debounce_id", *debounceID,
-				"timeout", time.UnixMilli(debounceTimeout).String(),
+				"debounce_id", migration.debounceID,
+				"timeout", time.UnixMilli(migration.timeoutUnixMilli).String(),
 			)
 
 			l.Debug("found debounce to migrate")
 
 			foundDebounce = true
-			newDebounceID = *debounceID
+			newDebounceID = migration.debounceID
 
 			// Preserve previous timeout
-			di.Timeout = debounceTimeout
-
-			// Delete debounce state from old cluster
-			if err := secondary.DebounceDeleteItems(ctx, scopeForDebounceItem(di), newDebounceID); err != nil {
-				l.Error("unable to delete old debounce after migration", "err", err)
-				return nil
-			}
-
-			// Delete debounce timeout from old cluster
-			queueItemId := queue.HashID(ctx, debounceID.String())
-			if err := secondary.RemoveQueueItem(ctx, scopeForDebounceItem(di), queue.KindDebounce, queueItemId); err != nil {
-				l.Error("could not remove queue item", "item_id", queueItemId)
-			} else {
-				l.Debug("deleted migrated debounce")
-			}
-
-			if err := secondary.DebounceDeleteMigratingFlag(ctx, scopeForDebounceItem(di), newDebounceID); err != nil {
-				l.Error("unable to delete debounce migrating flag", "err", err)
-			}
-
-			metrics.IncrQueueDebounceOperationCounter(ctx, metrics.CounterOpt{
-				PkgName: pkgName,
-				Tags: map[string]any{
-					"op":          "migration_prepared",
-					"queue_shard": secondary.Name(),
-				},
-			})
+			di.Timeout = migration.timeoutUnixMilli
 		}
 	}
 
@@ -594,7 +576,7 @@ func (d debouncer) debounce(ctx context.Context, di DebounceItem, fn inngest.Fun
 	// is atomic, and two individual threads/workers cannot create debounces simultaneously.
 	existingDebounceID, err := d.newDebounce(ctx, di, fn, ttl, shouldMigrate, newDebounceID)
 	if err == nil {
-		return nil
+		return d.finalizePreparedMigration(ctx, di, fn, migration, nil)
 	}
 	if err != ErrDebounceExists {
 		if shouldMigrate && foundDebounce {
@@ -602,23 +584,23 @@ func (d debouncer) debounce(ctx context.Context, di DebounceItem, fn inngest.Fun
 		}
 
 		// There was an unkown error creating the debounce.
-		return err
+		return d.finalizePreparedMigration(ctx, di, fn, migration, err)
 	}
 	if existingDebounceID == nil {
 		if shouldMigrate && foundDebounce {
 			l.Error("unexpected missing existing debounce ID after creating on primary cluster", "err", err)
 		}
 
-		return fmt.Errorf("expected debounce ID when debounce exists")
+		return d.finalizePreparedMigration(ctx, di, fn, migration, fmt.Errorf("expected debounce ID when debounce exists"))
 	}
 
 	// A debounce must already exist for this fn.  Update it.
 	err = d.updateDebounce(ctx, di, fn, ttl, *existingDebounceID, shouldMigrate)
-	if err == context.DeadlineExceeded || err == ErrDebounceInProgress || err == ErrDebounceNotFound {
+	if migration == nil && (err == context.DeadlineExceeded || err == ErrDebounceInProgress || err == ErrDebounceNotFound) {
 		if n == 5 {
 			l.Error("unable to update debounce", "error", err)
 			// Only recurse 5 times.
-			return fmt.Errorf("unable to update debounce: %w", err)
+			return d.finalizePreparedMigration(ctx, di, fn, migration, fmt.Errorf("unable to update debounce: %w", err))
 		}
 		// Re-invoke this to see if we need to extend the debounce or continue.
 		// Wait 50 milliseconds for the current lock and job to have evaluated.
@@ -629,7 +611,7 @@ func (d debouncer) debounce(ctx context.Context, di DebounceItem, fn inngest.Fun
 		return d.debounce(ctx, di, fn, ttl, n+1, shouldMigrate)
 	}
 
-	return err
+	return d.finalizePreparedMigration(ctx, di, fn, migration, err)
 }
 
 func (d debouncer) queueItem(ctx context.Context, di DebounceItem, debounceID ulid.ULID) queue.Item {
@@ -728,17 +710,223 @@ func (d debouncer) newDebounce(ctx context.Context, di DebounceItem, fn inngest.
 	return existingID, ErrDebounceExists
 }
 
-func (d debouncer) prepareMigration(ctx context.Context, di DebounceItem, fn inngest.Function, secondary queue.QueueShard) (*ulid.ULID, int64, error) {
+func (d debouncer) prepareMigration(ctx context.Context, di DebounceItem, fn inngest.Function, secondary queue.QueueShard) (*preparedMigration, error) {
 	// Replace existing debounce pointer with fake debounce ID so timeout jobs don't
 	now := d.c.Now()
 	fakeDebounceID := ulid.MustNew(ulid.Timestamp(now), rand.Reader)
 
 	key, err := d.debounceKey(ctx, di, fn)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
-	return secondary.DebouncePrepareMigration(ctx, scopeForDebounceItem(di), key, fakeDebounceID)
+	existingID, timeoutUnixMillis, pointerTTL, err := secondary.DebouncePrepareMigration(ctx, scopeForDebounceItem(di), key, fakeDebounceID)
+	if err != nil {
+		return nil, err
+	}
+
+	if existingID == nil {
+		return nil, nil
+	}
+
+	return &preparedMigration{
+		debounceID:       *existingID,
+		timeoutUnixMilli: timeoutUnixMillis,
+		pointerTTL:       pointerTTL,
+	}, nil
+}
+
+func (d debouncer) completePreparedMigration(ctx context.Context, di DebounceItem, fn inngest.Function, migration *preparedMigration) {
+	l := logger.StdlibLogger(ctx).With("debounce_id", migration.debounceID.String())
+
+	secondary, err := d.secondaryShard()
+	if err != nil {
+		l.Error("missing secondary debounce components while completing migration", "err", err)
+		return
+	}
+
+	if err := secondary.DebounceDeleteItems(ctx, scopeForDebounceItem(di), migration.debounceID); err != nil {
+		l.Error("unable to delete old debounce after migration", "err", err)
+	}
+
+	queueItemID := queue.HashID(ctx, migration.debounceID.String())
+	if err := secondary.RemoveQueueItem(
+		ctx,
+		scopeForDebounceItem(di),
+		queue.KindDebounce,
+		queueItemID,
+	); err != nil {
+		l.Error("could not remove queue item", "item_id", queueItemID, "err", err)
+	} else {
+		l.Debug("deleted migrated debounce")
+	}
+
+	if err := secondary.DebounceDeleteMigratingFlag(ctx, scopeForDebounceItem(di), migration.debounceID); err != nil {
+		l.Error("unable to delete debounce migrating flag", "err", err)
+	}
+
+	key, err := d.debounceKey(ctx, di, fn)
+	if err != nil {
+		l.Error("unable to compute debounce key while completing migration", "err", err)
+	} else if err := secondary.DebounceDeletePointer(ctx, scopeForDebounceItem(di), key); err != nil {
+		l.Error("unable to delete secondary debounce pointer", "err", err)
+	}
+
+	metrics.IncrQueueDebounceOperationCounter(ctx, metrics.CounterOpt{
+		PkgName: pkgName,
+		Tags: map[string]any{
+			"op":          "migration_prepared",
+			"queue_shard": secondary.Name(),
+		},
+	})
+}
+
+func (d debouncer) cleanupPreparedMigrationPrimary(ctx context.Context, di DebounceItem, fn inngest.Function, migration *preparedMigration) error {
+	primary, err := d.primaryShard()
+	if err != nil {
+		return fmt.Errorf("could not resolve primary shard: %w", err)
+	}
+
+	var cleanupErr error
+	key, err := d.debounceKey(ctx, di, fn)
+	if err != nil {
+		cleanupErr = errors.Join(cleanupErr, err)
+	} else {
+		pointedID, err := primary.DebounceGetPointer(ctx, scopeForDebounceItem(di), key)
+		switch {
+		case err == nil:
+			if pointedID == migration.debounceID.String() {
+				if err := primary.DebounceDeletePointer(ctx, scopeForDebounceItem(di), key); err != nil {
+					cleanupErr = errors.Join(cleanupErr, fmt.Errorf("failed to delete primary debounce pointer: %w", err))
+				}
+			}
+		case !errors.Is(err, ErrDebounceNotFound):
+			cleanupErr = errors.Join(cleanupErr, fmt.Errorf("failed to inspect primary debounce pointer: %w", err))
+		}
+	}
+
+	if err := primary.DebounceDeleteItems(ctx, scopeForDebounceItem(di), migration.debounceID); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("failed to delete primary debounce state: %w", err))
+	}
+
+	queueItemID := queue.HashID(ctx, migration.debounceID.String())
+	if err := primary.RemoveQueueItem(ctx, scopeForDebounceItem(di), queue.KindDebounce, queueItemID); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("failed to delete primary debounce queue item: %w", err))
+	}
+
+	return cleanupErr
+}
+
+func (d debouncer) rollbackPreparedMigration(ctx context.Context, di DebounceItem, fn inngest.Function, migration *preparedMigration) error {
+	secondary, err := d.secondaryShard()
+	if err != nil {
+		return fmt.Errorf("could not resolve secondary shard: %w", err)
+	}
+
+	var rollbackErr error
+	if err := d.cleanupPreparedMigrationPrimary(ctx, di, fn, migration); err != nil {
+		rollbackErr = errors.Join(rollbackErr, err)
+	}
+
+	key, err := d.debounceKey(ctx, di, fn)
+	pointerRestored := false
+	if err != nil {
+		rollbackErr = errors.Join(rollbackErr, err)
+	} else if err := secondary.DebounceSetPointer(ctx, scopeForDebounceItem(di), key, migration.debounceID, migration.pointerTTL); err != nil {
+		rollbackErr = errors.Join(rollbackErr, fmt.Errorf("failed to restore secondary debounce pointer: %w", err))
+	} else {
+		pointerRestored = true
+	}
+
+	if pointerRestored {
+		if err := secondary.DebounceDeleteMigratingFlag(ctx, scopeForDebounceItem(di), migration.debounceID); err != nil {
+			rollbackErr = errors.Join(rollbackErr, err)
+		}
+	} else {
+		rollbackErr = errors.Join(rollbackErr, fmt.Errorf("secondary debounce migration flag left in place because pointer restore failed"))
+	}
+
+	return rollbackErr
+}
+
+func (d debouncer) primaryDebounceReady(ctx context.Context, di DebounceItem, fn inngest.Function) (bool, error) {
+	primary, err := d.primaryShard()
+	if err != nil {
+		return false, fmt.Errorf("could not resolve primary shard: %w", err)
+	}
+
+	key, err := d.debounceKey(ctx, di, fn)
+	if err != nil {
+		return false, err
+	}
+
+	debounceIDStr, err := primary.DebounceGetPointer(ctx, scopeForDebounceItem(di), key)
+	if errors.Is(err, ErrDebounceNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to read primary debounce pointer: %w", err)
+	}
+
+	debounceID, err := ulid.Parse(debounceIDStr)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse primary debounce pointer %q: %w", debounceIDStr, err)
+	}
+
+	if _, err := primary.DebounceGetItem(ctx, scopeForDebounceItem(di), debounceID); err != nil {
+		if errors.Is(err, ErrDebounceNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to read primary debounce state: %w", err)
+	}
+
+	exists, err := primary.ItemExists(ctx, scopeForDebounceItem(di), debounceID.String())
+	if err != nil {
+		return false, fmt.Errorf("failed to inspect primary debounce queue item: %w", err)
+	}
+	if !exists {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (d debouncer) finalizePreparedMigration(ctx context.Context, di DebounceItem, fn inngest.Function, migration *preparedMigration, opErr error) error {
+	if migration == nil {
+		return opErr
+	}
+
+	if opErr == nil {
+		d.completePreparedMigration(ctx, di, fn, migration)
+		return nil
+	}
+
+	ready, err := d.primaryDebounceReady(ctx, di, fn)
+	if err != nil {
+		logger.StdlibLogger(ctx).Warn("failed to inspect primary debounce after migration error; attempting rollback",
+			"debounce_id", migration.debounceID.String(),
+			"error", err,
+		)
+		if rollbackErr := d.rollbackPreparedMigration(ctx, di, fn, migration); rollbackErr != nil {
+			return fmt.Errorf("%w: additionally failed to inspect primary debounce (%v) and rollback prepared migration: %v", opErr, err, rollbackErr)
+		}
+		return opErr
+	}
+
+	if ready {
+		logger.StdlibLogger(ctx).Warn("primary debounce exists after migration error; cleaning up secondary state",
+			"debounce_id", migration.debounceID.String(),
+			"error", opErr,
+		)
+		d.completePreparedMigration(ctx, di, fn, migration)
+		return nil
+	}
+
+	if err := d.rollbackPreparedMigration(ctx, di, fn, migration); err != nil {
+		return fmt.Errorf("%w: additionally failed to rollback prepared migration: %v", opErr, err)
+	}
+
+	return opErr
 }
 
 // updateDebounce updates the currently pending debounce to point to the new event ID.  It pushes

--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -880,7 +880,7 @@ func (d debouncer) primaryDebounceReady(ctx context.Context, di DebounceItem, fn
 		return false, fmt.Errorf("failed to read primary debounce state: %w", err)
 	}
 
-	exists, err := primary.ItemExists(ctx, scopeForDebounceItem(di), debounceID.String())
+	exists, err := primary.ItemExists(ctx, scopeForDebounceItem(di), queue.HashID(ctx, debounceID.String()))
 	if err != nil {
 		return false, fmt.Errorf("failed to inspect primary debounce queue item: %w", err)
 	}

--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -35,6 +36,21 @@ func testScope(accountID, workspaceID, functionID uuid.UUID) queue.Scope {
 		EnvID:      workspaceID,
 		FunctionID: functionID,
 	}
+}
+
+type setPointerFailingShard struct {
+	queue.QueueShard
+	err                  error
+	deleteMigratingCalls int
+}
+
+func (s *setPointerFailingShard) DebounceSetPointer(ctx context.Context, scope queue.Scope, key string, debounceID ulid.ULID, ttl time.Duration) error {
+	return s.err
+}
+
+func (s *setPointerFailingShard) DebounceDeleteMigratingFlag(ctx context.Context, scope queue.Scope, debounceID ulid.ULID) error {
+	s.deleteMigratingCalls++
+	return s.QueueShard.DebounceDeleteMigratingFlag(ctx, scope, debounceID)
 }
 
 // migrationShardSelector routes system queue items (queueName != nil) to the
@@ -1557,7 +1573,7 @@ func TestDebounceExecutionDuringMigrationWorks(t *testing.T) {
 
 		// A racing prepareMigration call must not be able to find the debounce
 		fakeID := ulid.MustNew(ulid.Now(), rand.Reader)
-		existingID, _, err := defaultQueueShard.DebouncePrepareMigration(ctx, testScope(accountId, workspaceId, fn.ID), fn.ID.String(), fakeID)
+		existingID, _, _, err := defaultQueueShard.DebouncePrepareMigration(ctx, testScope(accountId, workspaceId, fn.ID), fn.ID.String(), fakeID)
 		require.NoError(t, err)
 		require.Nil(t, existingID)
 
@@ -1748,7 +1764,7 @@ func TestDebounceExecutionShouldNotRaceMigration(t *testing.T) {
 
 		// If prepareMigration is called first, it must lock the execution from running the debounce item
 		fakeID := ulid.MustNew(ulid.Now(), rand.Reader)
-		existingID, _, err := defaultQueueShard.DebouncePrepareMigration(ctx, testScope(accountId, workspaceId, fn.ID), fn.ID.String(), fakeID)
+		existingID, _, _, err := defaultQueueShard.DebouncePrepareMigration(ctx, testScope(accountId, workspaceId, fn.ID), fn.ID.String(), fakeID)
 		require.NoError(t, err)
 		require.NotNil(t, existingID)
 		require.Equal(t, debounceId, *existingID)
@@ -1782,6 +1798,259 @@ func TestDebounceExecutionShouldNotRaceMigration(t *testing.T) {
 		// Lock must be gone
 		require.False(t, unshardedCluster.Exists(unshardedDebounceClient.KeyGenerator().DebounceMigrating(ctx)))
 	})
+}
+
+func TestRollbackPreparedMigrationKeepsMigratingFlagWhenPointerRestoreFails(t *testing.T) {
+	secondaryCluster := miniredis.RunT(t)
+	primaryCluster := miniredis.RunT(t)
+
+	secondaryRc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{secondaryCluster.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer secondaryRc.Close()
+
+	primaryRc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{primaryCluster.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer primaryRc.Close()
+
+	secondaryClient := redis_state.NewUnshardedClient(secondaryRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
+	primaryClient := redis_state.NewUnshardedClient(primaryRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
+	secondaryDebounceClient := secondaryClient.Debounce()
+
+	secondaryShard := redis_state.NewQueueShard(consts.DefaultQueueShardName, secondaryClient.Queue())
+	primaryShard := redis_state.NewQueueShard("new-system", primaryClient.Queue())
+	failingSecondary := &setPointerFailingShard{
+		QueueShard: secondaryShard,
+		err:        errors.New("set pointer failed"),
+	}
+
+	shards, err := queue.NewShardRegistry(
+		migrationShardMap(failingSecondary, primaryShard),
+		queue.WithShardSelector(migrationShardSelector(failingSecondary, primaryShard)),
+		queue.WithPrimary(primaryShard),
+	)
+	require.NoError(t, err)
+
+	redisDebouncer := debouncer{
+		shards:             shards,
+		primaryShardName:   primaryShard.Name(),
+		secondaryShardName: failingSecondary.Name(),
+	}
+
+	ctx := context.Background()
+	accountID, workspaceID, appID, functionID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	scope := testScope(accountID, workspaceID, functionID)
+	fn := inngest.Function{
+		ID: functionID,
+		Debounce: &inngest.Debounce{
+			Period:  "10s",
+			Timeout: util.StrPtr("60s"),
+		},
+	}
+	key := functionID.String()
+	debounceID := ulid.MustNew(ulid.Now(), rand.Reader)
+	fakeDebounceID := ulid.MustNew(ulid.Now()+1, rand.Reader)
+	di := DebounceItem{
+		AccountID:   accountID,
+		WorkspaceID: workspaceID,
+		AppID:       appID,
+		FunctionID:  functionID,
+		EventID:     ulid.MustNew(ulid.Now()+2, rand.Reader),
+		Event: event.Event{
+			Name: "initial",
+			ID:   "initial-event",
+		},
+		Timeout: time.Now().Add(time.Minute).UnixMilli(),
+	}
+	item, err := json.Marshal(di)
+	require.NoError(t, err)
+
+	existingID, err := secondaryShard.DebounceCreate(ctx, scope, key, debounceID, item, 10*time.Second)
+	require.NoError(t, err)
+	require.Nil(t, existingID)
+
+	preparedID, _, pointerTTL, err := secondaryShard.DebouncePrepareMigration(ctx, scope, key, fakeDebounceID)
+	require.NoError(t, err)
+	require.NotNil(t, preparedID)
+	require.Equal(t, debounceID, *preparedID)
+
+	err = redisDebouncer.rollbackPreparedMigration(ctx, di, fn, &preparedMigration{
+		debounceID:       debounceID,
+		timeoutUnixMilli: di.Timeout,
+		pointerTTL:       pointerTTL,
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "failed to restore secondary debounce pointer")
+	require.ErrorContains(t, err, "migration flag left in place")
+	require.Equal(t, 0, failingSecondary.deleteMigratingCalls)
+
+	pointerVal, err := secondaryCluster.Get(secondaryDebounceClient.KeyGenerator().DebouncePointer(ctx, functionID, key))
+	require.NoError(t, err)
+	require.Equal(t, fakeDebounceID.String(), pointerVal)
+
+	migratingIDs, err := secondaryCluster.HKeys(secondaryDebounceClient.KeyGenerator().DebounceMigrating(ctx))
+	require.NoError(t, err)
+	require.Contains(t, migratingIDs, debounceID.String())
+	require.NotEmpty(t, secondaryCluster.HGet(secondaryDebounceClient.KeyGenerator().Debounce(ctx), debounceID.String()))
+}
+
+func TestDebounceMigrationFailurePreservesExistingDebounce(t *testing.T) {
+	unshardedCluster := miniredis.RunT(t)
+	newSystemCluster := miniredis.RunT(t)
+
+	unshardedRc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{unshardedCluster.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer unshardedRc.Close()
+
+	newSystemRc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{newSystemCluster.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+
+	unshardedClient := redis_state.NewUnshardedClient(unshardedRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
+	newSystemClient := redis_state.NewUnshardedClient(newSystemRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
+
+	unshardedDebounceClient := unshardedClient.Debounce()
+	newSystemDebounceClient := newSystemClient.Debounce()
+
+	fakeClock := clockwork.NewFakeClock()
+
+	opts := []queue.QueueOpt{
+		queue.WithKindToQueueMapping(map[string]string{
+			queue.KindDebounce: queue.KindDebounce,
+		}),
+		queue.WithClock(fakeClock),
+	}
+
+	defaultQueueShard := redis_state.NewQueueShard(consts.DefaultQueueShardName, unshardedClient.Queue(), opts...)
+	newSystemShard := redis_state.NewQueueShard("new-system", newSystemClient.Queue(), opts...)
+
+	oldShardRegistry, err := queue.NewSingleShardRegistry(defaultQueueShard)
+	require.NoError(t, err)
+	oldQueue, err := queue.New(context.Background(), "old-queue", oldShardRegistry, opts...)
+	require.NoError(t, err)
+
+	newShardRegistry, err := queue.NewShardRegistry(
+		migrationShardMap(defaultQueueShard, newSystemShard),
+		queue.WithShardSelector(migrationShardSelector(defaultQueueShard, newSystemShard)),
+		queue.WithPrimary(newSystemShard),
+	)
+	require.NoError(t, err)
+
+	newQueue, err := queue.New(context.Background(), "new-queue", newShardRegistry, opts...)
+	require.NoError(t, err)
+
+	oldDeb, err := NewDebouncerWithMigration(DebouncerOpts{
+		Shards:           oldShardRegistry,
+		PrimaryShardName: defaultQueueShard.Name(),
+		Queue:            oldQueue,
+		Clock:            fakeClock,
+	})
+	require.NoError(t, err)
+	oldRedisDebouncer := oldDeb.(debouncer)
+
+	newDeb, err := NewDebouncerWithMigration(DebouncerOpts{
+		Shards:             newShardRegistry,
+		PrimaryShardName:   newSystemShard.Name(),
+		SecondaryShardName: defaultQueueShard.Name(),
+		Queue:              newQueue,
+		ShouldMigrate: func(ctx context.Context, accountID uuid.UUID) bool {
+			return true
+		},
+		Clock: fakeClock,
+	})
+	require.NoError(t, err)
+	newRedisDebouncer := newDeb.(debouncer)
+
+	ctx := context.Background()
+	accountID, workspaceID, appID, functionID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+
+	fn := inngest.Function{
+		ID: functionID,
+		Debounce: &inngest.Debounce{
+			Period:  "10s",
+			Timeout: util.StrPtr("60s"),
+		},
+	}
+
+	firstEventTime := fakeClock.Now()
+	firstEventID := ulid.MustNew(ulid.Timestamp(firstEventTime), rand.Reader)
+
+	err = oldRedisDebouncer.Debounce(ctx, DebounceItem{
+		AccountID:   accountID,
+		WorkspaceID: workspaceID,
+		AppID:       appID,
+		FunctionID:  functionID,
+		EventID:     firstEventID,
+		Event: event.Event{
+			Name:      "initial",
+			ID:        firstEventID.String(),
+			Timestamp: firstEventTime.UnixMilli(),
+		},
+	}, fn)
+	require.NoError(t, err)
+
+	debounceIDs, err := unshardedCluster.HKeys(unshardedDebounceClient.KeyGenerator().Debounce(ctx))
+	require.NoError(t, err)
+	require.Len(t, debounceIDs, 1)
+	originalDebounceID := debounceIDs[0]
+
+	queueItemIDs, err := unshardedCluster.HKeys(defaultQueueShard.Client().KeyGenerator().QueueItem())
+	require.NoError(t, err)
+	require.Len(t, queueItemIDs, 1)
+	require.Equal(t, queue.HashID(ctx, originalDebounceID), queueItemIDs[0])
+
+	// Force the primary path to fail after prepareMigration() has already
+	// locked the old debounce for migration.
+	newSystemRc.Close()
+
+	fakeClock.Advance(5 * time.Second)
+	secondEventTime := fakeClock.Now()
+	secondEventID := ulid.MustNew(ulid.Timestamp(secondEventTime), rand.Reader)
+
+	err = newRedisDebouncer.Debounce(ctx, DebounceItem{
+		AccountID:   accountID,
+		WorkspaceID: workspaceID,
+		AppID:       appID,
+		FunctionID:  functionID,
+		EventID:     secondEventID,
+		Event: event.Event{
+			Name:      "migrate",
+			ID:        secondEventID.String(),
+			Timestamp: secondEventTime.UnixMilli(),
+		},
+	}, fn)
+	require.Error(t, err)
+
+	// If the new primary debounce is never created, the old debounce must remain
+	// runnable on the secondary cluster.
+	require.NotEmpty(t, unshardedCluster.HGet(unshardedDebounceClient.KeyGenerator().Debounce(ctx), originalDebounceID))
+
+	pointerVal, err := unshardedCluster.Get(unshardedDebounceClient.KeyGenerator().DebouncePointer(ctx, functionID, functionID.String()))
+	require.NoError(t, err)
+	require.NotEmpty(t, pointerVal)
+	require.Equal(t, originalDebounceID, pointerVal)
+
+	_, err = unshardedCluster.HKeys(unshardedDebounceClient.KeyGenerator().DebounceMigrating(ctx))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no such key")
+
+	queueItemIDs, err = unshardedCluster.HKeys(defaultQueueShard.Client().KeyGenerator().QueueItem())
+	require.NoError(t, err)
+	require.Len(t, queueItemIDs, 1)
+	require.Equal(t, queue.HashID(ctx, originalDebounceID), queueItemIDs[0])
+
+	require.False(t, newSystemCluster.Exists(newSystemDebounceClient.KeyGenerator().DebouncePointer(ctx, functionID, functionID.String())))
+	require.False(t, newSystemCluster.Exists(newSystemDebounceClient.KeyGenerator().Debounce(ctx)))
 }
 
 func TestGetDebounceInfo(t *testing.T) {

--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -1899,6 +1899,135 @@ func TestRollbackPreparedMigrationKeepsMigratingFlagWhenPointerRestoreFails(t *t
 	require.NotEmpty(t, secondaryCluster.HGet(secondaryDebounceClient.KeyGenerator().Debounce(ctx), debounceID.String()))
 }
 
+func TestFinalizePreparedMigrationCommitsWhenPrimaryReadyAfterError(t *testing.T) {
+	secondaryCluster := miniredis.RunT(t)
+	primaryCluster := miniredis.RunT(t)
+
+	secondaryRc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{secondaryCluster.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer secondaryRc.Close()
+
+	primaryRc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{primaryCluster.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer primaryRc.Close()
+
+	secondaryClient := redis_state.NewUnshardedClient(secondaryRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
+	primaryClient := redis_state.NewUnshardedClient(primaryRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
+	secondaryDebounceClient := secondaryClient.Debounce()
+	primaryDebounceClient := primaryClient.Debounce()
+
+	fakeClock := clockwork.NewFakeClock()
+	opts := []queue.QueueOpt{
+		queue.WithKindToQueueMapping(map[string]string{
+			queue.KindDebounce: queue.KindDebounce,
+		}),
+		queue.WithClock(fakeClock),
+	}
+
+	secondaryShard := redis_state.NewQueueShard(consts.DefaultQueueShardName, secondaryClient.Queue(), opts...)
+	primaryShard := redis_state.NewQueueShard("new-system", primaryClient.Queue(), opts...)
+
+	shards, err := queue.NewShardRegistry(
+		migrationShardMap(secondaryShard, primaryShard),
+		queue.WithShardSelector(migrationShardSelector(secondaryShard, primaryShard)),
+		queue.WithPrimary(primaryShard),
+	)
+	require.NoError(t, err)
+
+	q, err := queue.New(context.Background(), "new-queue", shards, opts...)
+	require.NoError(t, err)
+
+	redisDebouncer := debouncer{
+		shards:             shards,
+		primaryShardName:   primaryShard.Name(),
+		secondaryShardName: secondaryShard.Name(),
+		queue:              q,
+		c:                  fakeClock,
+	}
+
+	ctx := context.Background()
+	accountID, workspaceID, appID, functionID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	scope := testScope(accountID, workspaceID, functionID)
+	fn := inngest.Function{
+		ID: functionID,
+		Debounce: &inngest.Debounce{
+			Period:  "10s",
+			Timeout: util.StrPtr("60s"),
+		},
+	}
+	key := functionID.String()
+	debounceID := ulid.MustNew(ulid.Now(), rand.Reader)
+	fakeDebounceID := ulid.MustNew(ulid.Now()+1, rand.Reader)
+	initialTime := fakeClock.Now()
+	di := DebounceItem{
+		AccountID:   accountID,
+		WorkspaceID: workspaceID,
+		AppID:       appID,
+		FunctionID:  functionID,
+		EventID:     ulid.MustNew(ulid.Timestamp(initialTime), rand.Reader),
+		Event: event.Event{
+			Name:      "initial",
+			ID:        "initial-event",
+			Timestamp: initialTime.UnixMilli(),
+		},
+		Timeout: initialTime.Add(time.Minute).UnixMilli(),
+	}
+	item, err := json.Marshal(di)
+	require.NoError(t, err)
+
+	existingID, err := secondaryShard.DebounceCreate(ctx, scope, key, debounceID, item, 10*time.Second)
+	require.NoError(t, err)
+	require.Nil(t, existingID)
+
+	queueItem := redisDebouncer.queueItem(ctx, di, debounceID)
+	err = q.Enqueue(ctx, queueItem, initialTime.Add(10*time.Second), queue.EnqueueOpts{ForceQueueShardName: secondaryShard.Name()})
+	require.NoError(t, err)
+
+	preparedID, timeoutUnixMillis, pointerTTL, err := secondaryShard.DebouncePrepareMigration(ctx, scope, key, fakeDebounceID)
+	require.NoError(t, err)
+	require.NotNil(t, preparedID)
+	require.Equal(t, debounceID, *preparedID)
+	require.Equal(t, di.Timeout, timeoutUnixMillis)
+
+	// This fills the coverage gap where the primary debounce is already fully
+	// ready, but a later migration operation returns an error. In that case we
+	// must commit cleanup of the secondary instead of rolling back and leaving
+	// duplicate runnable debounce state on both shards.
+	createdID, err := redisDebouncer.newDebounce(ctx, di, fn, pointerTTL, true, debounceID)
+	require.NoError(t, err)
+	require.NotNil(t, createdID)
+	require.Equal(t, debounceID, *createdID)
+
+	err = redisDebouncer.finalizePreparedMigration(ctx, di, fn, &preparedMigration{
+		debounceID:       debounceID,
+		timeoutUnixMilli: timeoutUnixMillis,
+		pointerTTL:       pointerTTL,
+	}, errors.New("post-primary migration error"))
+	require.NoError(t, err)
+
+	_, err = secondaryCluster.Get(secondaryDebounceClient.KeyGenerator().DebouncePointer(ctx, functionID, key))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no such key")
+
+	_, err = secondaryCluster.HKeys(secondaryDebounceClient.KeyGenerator().DebounceMigrating(ctx))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "no such key")
+	require.Empty(t, secondaryCluster.HGet(secondaryDebounceClient.KeyGenerator().Debounce(ctx), debounceID.String()))
+	require.Empty(t, secondaryCluster.HGet(secondaryClient.Queue().KeyGenerator().QueueItem(), queue.HashID(ctx, debounceID.String())))
+
+	primaryPointer, err := primaryCluster.Get(primaryDebounceClient.KeyGenerator().DebouncePointer(ctx, functionID, key))
+	require.NoError(t, err)
+	require.Equal(t, debounceID.String(), primaryPointer)
+	require.NotEmpty(t, primaryCluster.HGet(primaryDebounceClient.KeyGenerator().Debounce(ctx), debounceID.String()))
+	require.NotEmpty(t, primaryCluster.HGet(primaryClient.Queue().KeyGenerator().QueueItem(), queue.HashID(ctx, debounceID.String())))
+}
+
 func TestDebounceMigrationFailurePreservesExistingDebounce(t *testing.T) {
 	unshardedCluster := miniredis.RunT(t)
 	newSystemCluster := miniredis.RunT(t)

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -217,10 +217,10 @@ type DebounceOperations interface {
 
 	// DebouncePrepareMigration atomically replaces the debounce pointer
 	// with fakeDebounceID to disable execution on this shard, returning
-	// the existing debounce ID and timeout (millis) so the caller can
-	// re-create the debounce on another shard. Returns (nil, 0, nil)
-	// when no debounce exists.
-	DebouncePrepareMigration(ctx context.Context, scope Scope, key string, fakeDebounceID ulid.ULID) (existingID *ulid.ULID, timeoutMillis int64, err error)
+	// the existing debounce ID, timeout (millis), and pointer TTL so the
+	// caller can re-create or restore the debounce on another shard.
+	// Returns (nil, 0, 0, nil) when no debounce exists.
+	DebouncePrepareMigration(ctx context.Context, scope Scope, key string, fakeDebounceID ulid.ULID) (existingID *ulid.ULID, timeoutMillis int64, pointerTTL time.Duration, err error)
 
 	// DebounceGetItem retrieves the serialized debounce item from the
 	// hash. Returns ErrDebounceNotFound when absent.
@@ -237,6 +237,10 @@ type DebounceOperations interface {
 	// DebounceGetPointer reads the current debounce ID for scope/key.
 	// Returns ErrDebounceNotFound when no debounce is active.
 	DebounceGetPointer(ctx context.Context, scope Scope, key string) (string, error)
+
+	// DebounceSetPointer sets the pointer for scope/key, optionally
+	// preserving the previous TTL when ttl is greater than zero.
+	DebounceSetPointer(ctx context.Context, scope Scope, key string, debounceID ulid.ULID, ttl time.Duration) error
 
 	// DebounceDeletePointer removes the pointer for scope/key.
 	DebounceDeletePointer(ctx context.Context, scope Scope, key string) error

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -203,8 +203,8 @@ func (m *mockShardForIterator) DebounceStartExecution(ctx context.Context, scope
 	return DebounceStartStarted, nil
 }
 
-func (m *mockShardForIterator) DebouncePrepareMigration(ctx context.Context, scope Scope, key string, fakeDebounceID ulid.ULID) (*ulid.ULID, int64, error) {
-	return nil, 0, nil
+func (m *mockShardForIterator) DebouncePrepareMigration(ctx context.Context, scope Scope, key string, fakeDebounceID ulid.ULID) (*ulid.ULID, int64, time.Duration, error) {
+	return nil, 0, 0, nil
 }
 
 func (m *mockShardForIterator) DebounceGetItem(ctx context.Context, scope Scope, debounceID ulid.ULID) ([]byte, error) {
@@ -221,6 +221,10 @@ func (m *mockShardForIterator) DebounceDeleteMigratingFlag(ctx context.Context, 
 
 func (m *mockShardForIterator) DebounceGetPointer(ctx context.Context, scope Scope, key string) (string, error) {
 	return "", nil
+}
+
+func (m *mockShardForIterator) DebounceSetPointer(ctx context.Context, scope Scope, key string, debounceID ulid.ULID, ttl time.Duration) error {
+	return nil
 }
 
 func (m *mockShardForIterator) DebounceDeletePointer(ctx context.Context, scope Scope, key string) error {

--- a/pkg/execution/state/redis_state/debounce.go
+++ b/pkg/execution/state/redis_state/debounce.go
@@ -117,7 +117,7 @@ func (q *queue) DebounceStartExecution(ctx context.Context, scope osqueue.Scope,
 }
 
 // DebouncePrepareMigration implements queue.DebounceOperations.
-func (q *queue) DebouncePrepareMigration(ctx context.Context, scope osqueue.Scope, key string, fakeDebounceID ulid.ULID) (*ulid.ULID, int64, error) {
+func (q *queue) DebouncePrepareMigration(ctx context.Context, scope osqueue.Scope, key string, fakeDebounceID ulid.ULID) (*ulid.ULID, int64, time.Duration, error) {
 	client := q.RedisClient.Client()
 	kg := q.RedisClient.DebounceKeyGenerator()
 
@@ -132,49 +132,60 @@ func (q *queue) DebouncePrepareMigration(ctx context.Context, scope osqueue.Scop
 		[]string{fakeDebounceID.String()},
 	).ToAny()
 	if err != nil {
-		return nil, 0, fmt.Errorf("error running prepareMigration script: %w", err)
+		return nil, 0, 0, fmt.Errorf("error running prepareMigration script: %w", err)
 	}
 
 	returnedSet, ok := out.([]any)
 	if !ok {
-		return nil, 0, fmt.Errorf("expected to receive one or more set items")
+		return nil, 0, 0, fmt.Errorf("expected to receive one or more set items")
 	}
 	if len(returnedSet) < 1 {
-		return nil, 0, fmt.Errorf("expected at least one item")
+		return nil, 0, 0, fmt.Errorf("expected at least one item")
 	}
 
 	status, ok := returnedSet[0].(int64)
 	if !ok {
-		return nil, 0, fmt.Errorf("unexpected return value, expected status int")
+		return nil, 0, 0, fmt.Errorf("unexpected return value, expected status int")
 	}
 
 	if status == 0 {
-		return nil, 0, nil
+		return nil, 0, 0, nil
 	}
 
 	if status != 1 || len(returnedSet) < 2 {
-		return nil, 0, fmt.Errorf("expected status 1 with at least two return items")
+		return nil, 0, 0, fmt.Errorf("expected status 1 with at least two return items")
 	}
 
 	debounceIdStr, ok := returnedSet[1].(string)
 	if !ok {
-		return nil, 0, fmt.Errorf("expected debounceID as second item")
+		return nil, 0, 0, fmt.Errorf("expected debounceID as second item")
 	}
 
 	existingID, err := ulid.Parse(debounceIdStr)
 	if err != nil {
-		return nil, 0, fmt.Errorf("unknown debounce ID return value: %s", debounceIdStr)
+		return nil, 0, 0, fmt.Errorf("unknown debounce ID return value: %s", debounceIdStr)
 	}
 
 	var timeoutMillis int64
-	if len(returnedSet) == 3 {
+	if len(returnedSet) >= 3 {
 		timeoutMillis, ok = returnedSet[2].(int64)
 		if !ok {
-			return nil, 0, fmt.Errorf("expected timeout int")
+			return nil, 0, 0, fmt.Errorf("expected timeout int")
 		}
 	}
 
-	return &existingID, timeoutMillis, nil
+	var pointerTTL time.Duration
+	if len(returnedSet) >= 4 {
+		pointerTTLMillis, ok := returnedSet[3].(int64)
+		if !ok {
+			return nil, 0, 0, fmt.Errorf("expected pointer ttl int")
+		}
+		if pointerTTLMillis > 0 {
+			pointerTTL = time.Duration(pointerTTLMillis) * time.Millisecond
+		}
+	}
+
+	return &existingID, timeoutMillis, pointerTTL, nil
 }
 
 // DebounceGetItem implements queue.DebounceOperations.
@@ -245,6 +256,25 @@ func (q *queue) DebounceGetPointer(ctx context.Context, scope osqueue.Scope, key
 		return "", err
 	}
 	return val, nil
+}
+
+// DebounceSetPointer implements queue.DebounceOperations.
+func (q *queue) DebounceSetPointer(ctx context.Context, scope osqueue.Scope, key string, debounceID ulid.ULID, ttl time.Duration) error {
+	client := q.RedisClient.Client()
+	kg := q.RedisClient.DebounceKeyGenerator()
+
+	builder := client.B().Set().Key(kg.DebouncePointer(ctx, scope.FunctionID, key)).Value(debounceID.String())
+	var cmd rueidis.Completed
+	if ttl > 0 {
+		cmd = builder.Ex(ttl).Build()
+	} else {
+		cmd = builder.Build()
+	}
+
+	if err := client.Do(ctx, cmd).Error(); err != nil {
+		return fmt.Errorf("error setting debounce pointer: %w", err)
+	}
+	return nil
 }
 
 // DebounceDeletePointer implements queue.DebounceOperations.

--- a/pkg/execution/state/redis_state/lua/debounce/prepareMigration.lua
+++ b/pkg/execution/state/redis_state/lua/debounce/prepareMigration.lua
@@ -14,7 +14,6 @@ local keyDbc = KEYS[2] -- debounce info key
 local keyDebounceMigrating = KEYS[3]
 
 local newDebounceID = ARGV[1]
-local currentTime 	= tonumber(ARGV[2]) -- in ms
 
 local existingDebounceID = redis.call("GET", keyPtr)
 if existingDebounceID == nil or existingDebounceID == false then
@@ -29,11 +28,16 @@ if existingDebounceItemStr == false then
 end
 
 local debounceItem = cjson.decode(existingDebounceItemStr)
+local pointerTTL = redis.call("PTTL", keyPtr)
 
 -- Prevent the next prepareMigration() call from finding the same debounce again. It will immediately
 -- create/update a debounce on the primary.
 -- Note: This does not prevent the debounce from running on the secondary cluster on timeout.
-redis.call("SET", keyPtr, newDebounceID)
+if pointerTTL ~= nil and tonumber(pointerTTL) > 0 then
+	redis.call("SET", keyPtr, newDebounceID, "PX", pointerTTL)
+else
+	redis.call("SET", keyPtr, newDebounceID)
+end
 
 -- Prevent the timeout job from running, in case we are racing with StartExecution().
 -- We drop the debounce state and timeout item immediately after prepareMigration(), this is just a protection against data races.
@@ -41,8 +45,8 @@ redis.call("HSET", keyDebounceMigrating, existingDebounceID, 1)
 
 -- If timeout is not provided, only return debounce ID
 if debounceItem.t == nil or debounceItem.t <= 0 then
-	return { 1, existingDebounceID }
+	return { 1, existingDebounceID, 0, pointerTTL }
 end
 
 -- Return debounce ID and current timeout (carried over from first event)
-return { 1, existingDebounceID, debounceItem.t }
+return { 1, existingDebounceID, debounceItem.t, pointerTTL }


### PR DESCRIPTION
## Summary

This fixes a debounce migration bug where we could delete the old debounce on the secondary cluster before we had actually proven that the new debounce existed on the primary cluster.

In plain English: a migration attempt could cut over too early. If primary debounce creation failed in that window, the debounce was gone instead of still being runnable on the old cluster.

Put another way, before this PR, migration looked roughly like:

1. Lock the existing debounce on the secondary cluster.
2. Delete the old debounce state and timeout queue item from the secondary cluster.
3. Create the debounce on the primary cluster.

The bug was if step 2 permanently removed the old debounce before step 3 had successfully created the replacement on the primary cluster.

If primary creation failed:

- old debounce already deleted
- new debounce never created
- work disappeared

The debounce was effectively lost.

## Root Cause

The old flow did this:

1. `prepareMigration()` swapped the secondary pointer to a fake ID and set the migrating lock.
2. `debounce()` immediately deleted the old secondary debounce state and old timeout queue item.
3. Only after that did it try to create the new primary debounce.

If step 3 failed, there was nothing left to run.

## What Changed

The migration flow is now treated as a prepare / commit / rollback sequence:

- `prepareMigration.lua` preserves the old secondary pointer TTL when it swaps in the fake pointer.
- `prepareMigration()` now returns the existing debounce ID, carried timeout, and pointer TTL.
- Moved Redis debounce operations behind the queue shard adapter (`DebounceOperations`) so migration code can operate on primary and secondary shards uniformly instead of reaching directly into Redis clients/Lua.
- `debounce()` no longer deletes the old secondary debounce during prepare.
- After the primary create/update path runs, we verify whether the primary debounce is actually ready:
  - if yes, we clean up the old secondary debounce and timeout item
  - if no, we roll back the migration lock, restore the original secondary pointer, and remove any partial primary artifacts
- `primaryDebounceReady()` now checks the hashed debounce timeout job ID, matching how debounce timeout jobs are stored.

This keeps the old debounce runnable unless the new one is actually in place.

## Repro

The bug is reproducible:

1. Create a debounce on the old / secondary cluster.
2. Turn on migration.
3. Trigger another debounce event so migration starts.
4. Make primary debounce creation fail after `prepareMigration()` has already run.

Before this change, the old debounce disappeared.
After this change, the old debounce still exists on the secondary cluster with its pointer and timeout queue item intact.

## Tests

The main regression test is:

- `TestDebounceMigrationFailurePreservesExistingDebounce`

That test forces primary creation to fail after `prepareMigration()` has already locked the old debounce, then asserts:

- the original secondary debounce state still exists
- the secondary pointer still points at the original debounce
- the original secondary timeout queue item still exists
- no primary debounce was created

Additional migration coverage added / kept:

- `TestFinalizePreparedMigrationCommitsWhenPrimaryReadyAfterError`: fills the opposite finalize gap. If primary debounce state and its timeout job are already ready, but a later migration operation reports an error, finalization must commit secondary cleanup instead of rolling back into duplicate runnable debounce state. This also caught the hashed queue-item ID mismatch in `primaryDebounceReady()`.
- `TestRollbackPreparedMigrationKeepsMigratingFlagWhenPointerRestoreFails`: covers rollback partial failure. If pointer restore fails, the migrating guard must remain so the secondary debounce is not stranded behind the fake pointer with no guard.
- `TestDebounceExecutionDuringMigrationWorks`: covers timeout execution winning before migration prepares.
- `TestDebounceExecutionShouldNotRaceMigration`: covers migration prepare winning before timeout execution.
- `TestJITDebounceMigration`: covers the normal JIT migration path.

## Validation

- `go test ./pkg/execution/debounce -run '^(TestFinalizePreparedMigrationCommitsWhenPrimaryReadyAfterError|TestDebounceMigrationFailurePreservesExistingDebounce|TestRollbackPreparedMigrationKeepsMigratingFlagWhenPointerRestoreFails|TestJITDebounceMigration|TestDebounceExecutionShouldNotRaceMigration)$' -count=1`
- `go test ./pkg/execution/debounce -count=1`

## Scope

This PR is intentionally narrow. It fixes the Redis debounce migration work-loss bug and the primary-readiness check used by that migration finalizer.

Known gaps left outside this PR:

- Crash-after-prepare recovery / scavenger behavior if the process dies after the pointer is swapped to the fake ID.
- Full rollout sequencing with old and new executors plus the future-timestamp feature flag.
- FDB-specific debounce semantics, which are covered separately by the FDB debounce PR.
- The broader atomic debounce upsert prototype work.
