### PR TITLE
fix: keep completed runs from being reported as reverted

### DIFF
--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -1613,6 +1613,90 @@ func TestCQRSInsertTraceRun_PreservesTerminalStateAgainstStaleNonTerminalWrite(t
 	assert.Equal(t, enums.RunStatusCompleted, got.Status)
 }
 
+// Invariant from TLA RunStateProjection ("terminal states are monotonic"):
+// once a terminal status has been written for a run_id, no subsequent read
+// returns a non-terminal status, regardless of the order writes arrive in.
+func TestCQRSInsertTraceRun_TerminalMonotonicityUnderAllOrderings(t *testing.T) {
+	base := []enums.RunStatus{
+		enums.RunStatusScheduled,
+		enums.RunStatusRunning,
+		enums.RunStatusCompleted,
+		enums.RunStatusCancelled,
+	}
+
+	var perms [][]enums.RunStatus
+	var permute func([]enums.RunStatus, int)
+	permute = func(arr []enums.RunStatus, k int) {
+		if k == len(arr)-1 {
+			cpy := make([]enums.RunStatus, len(arr))
+			copy(cpy, arr)
+			perms = append(perms, cpy)
+			return
+		}
+		for i := k; i < len(arr); i++ {
+			arr[k], arr[i] = arr[i], arr[k]
+			permute(arr, k+1)
+			arr[k], arr[i] = arr[i], arr[k]
+		}
+	}
+	arr := make([]enums.RunStatus, len(base))
+	copy(arr, base)
+	permute(arr, 0)
+
+	for _, perm := range perms {
+		name := ""
+		for i, s := range perm {
+			if i > 0 {
+				name += "-"
+			}
+			name += s.String()
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			appID := uuid.New()
+			cm, cleanup := initCQRS(t, withInitCQRSOptApp(appID))
+			defer cleanup()
+
+			accountID := uuid.New()
+			workspaceID := uuid.New()
+			functionID := uuid.New()
+			runID := ulid.MustNew(ulid.Now(), rand.Reader)
+			now := time.Now().UTC().Truncate(time.Second)
+
+			sawTerminal := false
+			for i, s := range perm {
+				tr := &cqrs.TraceRun{
+					AccountID:   accountID,
+					WorkspaceID: workspaceID,
+					AppID:       appID,
+					FunctionID:  functionID,
+					TraceID:     fmt.Sprintf("trace-%d-%s", i, runID.String()),
+					RunID:       runID.String(),
+					QueuedAt:    now,
+					StartedAt:   now,
+					EndedAt:     now,
+					SourceID:    "test-source",
+					TriggerIDs:  []string{"evt-test"},
+					Status:      s,
+				}
+				require.NoError(t, cm.InsertTraceRun(ctx, tr))
+
+				got, err := cm.GetTraceRun(ctx, cqrs.TraceRunIdentifier{RunID: runID})
+				require.NoError(t, err)
+
+				if enums.RunStatusEnded(s) {
+					sawTerminal = true
+				}
+				if sawTerminal {
+					assert.True(t, enums.RunStatusEnded(got.Status),
+						"step %d (write %s): after observing terminal, got %s",
+						i, s, got.Status)
+				}
+			}
+		})
+	}
+}
+
 func TestCQRSGetTraceRunsPagination(t *testing.T) {
 	// This test verifies that cursor-based pagination works correctly for the GetSpanRuns
 	ctx := context.Background()

--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -1552,6 +1552,67 @@ func TestCQRSGetTraceRunsByTriggerID(t *testing.T) {
 	})
 }
 
+func TestCQRSInsertTraceRun_PreservesTerminalStateAgainstStaleNonTerminalWrite(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+
+	cm, cleanup := initCQRS(t, withInitCQRSOptApp(appID))
+	defer cleanup()
+
+	accountID := uuid.New()
+	workspaceID := uuid.New()
+	functionID := uuid.New()
+	runID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	terminalOutput := []byte(`{"status":"done"}`)
+
+	terminal := &cqrs.TraceRun{
+		AccountID:   accountID,
+		WorkspaceID: workspaceID,
+		AppID:       appID,
+		FunctionID:  functionID,
+		TraceID:     "trace-terminal-" + runID.String(),
+		RunID:       runID.String(),
+		QueuedAt:    now.Add(-2 * time.Minute),
+		StartedAt:   now.Add(-1 * time.Minute),
+		EndedAt:     now,
+		SourceID:    "terminal-source",
+		TriggerIDs:  []string{"evt-terminal"},
+		Output:      terminalOutput,
+		Status:      enums.RunStatusCompleted,
+	}
+
+	stale := &cqrs.TraceRun{
+		AccountID:   accountID,
+		WorkspaceID: workspaceID,
+		AppID:       appID,
+		FunctionID:  functionID,
+		TraceID:     "trace-stale-" + runID.String(),
+		RunID:       runID.String(),
+		QueuedAt:    now.Add(-3 * time.Minute),
+		StartedAt:   now.Add(-2 * time.Minute),
+		SourceID:    "stale-source",
+		TriggerIDs:  []string{"evt-stale"},
+		Status:      enums.RunStatusRunning,
+	}
+
+	require.NoError(t, cm.InsertTraceRun(ctx, terminal))
+	require.NoError(t, cm.InsertTraceRun(ctx, stale))
+
+	got, err := cm.GetTraceRun(ctx, cqrs.TraceRunIdentifier{RunID: runID})
+	require.NoError(t, err)
+
+	assert.Equal(t, terminal.TraceID, got.TraceID)
+	assert.Equal(t, terminal.QueuedAt.UnixMilli(), got.QueuedAt.UnixMilli())
+	assert.Equal(t, terminal.StartedAt.UnixMilli(), got.StartedAt.UnixMilli())
+	assert.Equal(t, terminal.EndedAt.UnixMilli(), got.EndedAt.UnixMilli())
+	assert.Equal(t, terminal.SourceID, got.SourceID)
+	assert.Equal(t, terminal.TriggerIDs, got.TriggerIDs)
+	assert.Equal(t, terminalOutput, got.Output)
+	assert.Equal(t, enums.RunStatusCompleted, got.Status)
+}
+
 func TestCQRSGetTraceRunsPagination(t *testing.T) {
 	// This test verifies that cursor-based pagination works correctly for the GetSpanRuns
 	ctx := context.Background()

--- a/pkg/db/postgres/sqlc/queries.sql
+++ b/pkg/db/postgres/sqlc/queries.sql
@@ -383,6 +383,8 @@ ON CONFLICT (run_id) DO UPDATE SET
                 WHEN trace_runs.has_ai = TRUE THEN TRUE
                 ELSE excluded.has_ai
              END
+-- Terminal status codes (matches enums.runStatusCode in pkg/enums/run_status.go):
+--   50=Overflowed, 300=Completed, 400=Failed, 500=Cancelled, 600=Skipped.
 WHERE NOT (
     trace_runs.status IN (50, 300, 400, 500, 600)
     AND excluded.status NOT IN (50, 300, 400, 500, 600)

--- a/pkg/db/postgres/sqlc/queries.sql
+++ b/pkg/db/postgres/sqlc/queries.sql
@@ -382,7 +382,11 @@ ON CONFLICT (run_id) DO UPDATE SET
     has_ai = CASE
                 WHEN trace_runs.has_ai = TRUE THEN TRUE
                 ELSE excluded.has_ai
-             END;
+             END
+WHERE NOT (
+    trace_runs.status IN (50, 300, 400, 500, 600)
+    AND excluded.status NOT IN (50, 300, 400, 500, 600)
+);
 
 -- name: GetTraceRun :one
 SELECT * FROM trace_runs WHERE run_id = sqlc.arg('run_id')::CHAR(26);

--- a/pkg/db/postgres/sqlc/queries.sql.go
+++ b/pkg/db/postgres/sqlc/queries.sql.go
@@ -2484,6 +2484,10 @@ ON CONFLICT (run_id) DO UPDATE SET
                 WHEN trace_runs.has_ai = TRUE THEN TRUE
                 ELSE excluded.has_ai
              END
+WHERE NOT (
+    trace_runs.status IN (50, 300, 400, 500, 600)
+    AND excluded.status NOT IN (50, 300, 400, 500, 600)
+)
 `
 
 type InsertTraceRunParams struct {

--- a/pkg/db/postgres/sqlc/queries.sql.go
+++ b/pkg/db/postgres/sqlc/queries.sql.go
@@ -2484,8 +2484,6 @@ ON CONFLICT (run_id) DO UPDATE SET
                 WHEN trace_runs.has_ai = TRUE THEN TRUE
                 ELSE excluded.has_ai
              END
--- Terminal status codes (matches enums.runStatusCode in pkg/enums/run_status.go):
---   50=Overflowed, 300=Completed, 400=Failed, 500=Cancelled, 600=Skipped.
 WHERE NOT (
     trace_runs.status IN (50, 300, 400, 500, 600)
     AND excluded.status NOT IN (50, 300, 400, 500, 600)
@@ -2512,6 +2510,9 @@ type InsertTraceRunParams struct {
 	HasAi        bool
 }
 
+// Terminal status codes (matches enums.runStatusCode in pkg/enums/run_status.go):
+//
+//	50=Overflowed, 300=Completed, 400=Failed, 500=Cancelled, 600=Skipped.
 func (q *Queries) InsertTraceRun(ctx context.Context, arg InsertTraceRunParams) error {
 	_, err := q.db.ExecContext(ctx, insertTraceRun,
 		arg.AccountID,

--- a/pkg/db/postgres/sqlc/queries.sql.go
+++ b/pkg/db/postgres/sqlc/queries.sql.go
@@ -2484,6 +2484,8 @@ ON CONFLICT (run_id) DO UPDATE SET
                 WHEN trace_runs.has_ai = TRUE THEN TRUE
                 ELSE excluded.has_ai
              END
+-- Terminal status codes (matches enums.runStatusCode in pkg/enums/run_status.go):
+--   50=Overflowed, 300=Completed, 400=Failed, 500=Cancelled, 600=Skipped.
 WHERE NOT (
     trace_runs.status IN (50, 300, 400, 500, 600)
     AND excluded.status NOT IN (50, 300, 400, 500, 600)

--- a/pkg/db/sqlite/sqlc/querier.go
+++ b/pkg/db/sqlite/sqlc/querier.go
@@ -99,6 +99,8 @@ type Querier interface {
 	// Traces
 	//
 	InsertTrace(ctx context.Context, arg InsertTraceParams) error
+	// Terminal status codes (matches enums.runStatusCode in pkg/enums/run_status.go):
+	//   50=Overflowed, 300=Completed, 400=Failed, 500=Cancelled, 600=Skipped.
 	InsertTraceRun(ctx context.Context, arg InsertTraceRunParams) error
 	//
 	// Worker Connections

--- a/pkg/db/sqlite/sqlc/queries.sql
+++ b/pkg/db/sqlite/sqlc/queries.sql
@@ -364,7 +364,11 @@ DO UPDATE SET
     has_ai = CASE
                  WHEN trace_runs.has_ai = 1 THEN 1
                  ELSE excluded.has_ai
-             END;
+             END
+WHERE NOT (
+    trace_runs.status IN (50, 300, 400, 500, 600)
+    AND excluded.status NOT IN (50, 300, 400, 500, 600)
+);
 
 -- name: GetTraceRun :one
 SELECT * FROM trace_runs WHERE run_id = @run_id;

--- a/pkg/db/sqlite/sqlc/queries.sql
+++ b/pkg/db/sqlite/sqlc/queries.sql
@@ -365,6 +365,8 @@ DO UPDATE SET
                  WHEN trace_runs.has_ai = 1 THEN 1
                  ELSE excluded.has_ai
              END
+-- Terminal status codes (matches enums.runStatusCode in pkg/enums/run_status.go):
+--   50=Overflowed, 300=Completed, 400=Failed, 500=Cancelled, 600=Skipped.
 WHERE NOT (
     trace_runs.status IN (50, 300, 400, 500, 600)
     AND excluded.status NOT IN (50, 300, 400, 500, 600)

--- a/pkg/db/sqlite/sqlc/queries.sql.go
+++ b/pkg/db/sqlite/sqlc/queries.sql.go
@@ -2545,8 +2545,6 @@ DO UPDATE SET
                  WHEN trace_runs.has_ai = 1 THEN 1
                  ELSE excluded.has_ai
              END
--- Terminal status codes (matches enums.runStatusCode in pkg/enums/run_status.go):
---   50=Overflowed, 300=Completed, 400=Failed, 500=Cancelled, 600=Skipped.
 WHERE NOT (
     trace_runs.status IN (50, 300, 400, 500, 600)
     AND excluded.status NOT IN (50, 300, 400, 500, 600)
@@ -2573,6 +2571,9 @@ type InsertTraceRunParams struct {
 	HasAi        bool
 }
 
+// Terminal status codes (matches enums.runStatusCode in pkg/enums/run_status.go):
+//
+//	50=Overflowed, 300=Completed, 400=Failed, 500=Cancelled, 600=Skipped.
 func (q *Queries) InsertTraceRun(ctx context.Context, arg InsertTraceRunParams) error {
 	_, err := q.db.ExecContext(ctx, insertTraceRun,
 		arg.RunID,

--- a/pkg/db/sqlite/sqlc/queries.sql.go
+++ b/pkg/db/sqlite/sqlc/queries.sql.go
@@ -2545,6 +2545,10 @@ DO UPDATE SET
                  WHEN trace_runs.has_ai = 1 THEN 1
                  ELSE excluded.has_ai
              END
+WHERE NOT (
+    trace_runs.status IN (50, 300, 400, 500, 600)
+    AND excluded.status NOT IN (50, 300, 400, 500, 600)
+)
 `
 
 type InsertTraceRunParams struct {

--- a/pkg/db/sqlite/sqlc/queries.sql.go
+++ b/pkg/db/sqlite/sqlc/queries.sql.go
@@ -2545,6 +2545,8 @@ DO UPDATE SET
                  WHEN trace_runs.has_ai = 1 THEN 1
                  ELSE excluded.has_ai
              END
+-- Terminal status codes (matches enums.runStatusCode in pkg/enums/run_status.go):
+--   50=Overflowed, 300=Completed, 400=Failed, 500=Cancelled, 600=Skipped.
 WHERE NOT (
     trace_runs.status IN (50, 300, 400, 500, 600)
     AND excluded.status NOT IN (50, 300, 400, 500, 600)


### PR DESCRIPTION
## Summary

This fixes a `trace_runs` bug where a stale non-terminal write could overwrite a newer terminal row.

In plain English: a run could already be marked `COMPLETED` or `FAILED`, and then a later stale `RUNNING` write for the same `run_id` could move the read model backward again.

## Root Cause

The `trace_runs` upsert was plain last-write-wins.

That meant this sequence was possible:

1. insert a terminal `trace_runs` row for a run
2. later receive a stale non-terminal write for the same run
3. the upsert overwrites the terminal row with the stale non-terminal state

That can regress not just `status`, but also terminal fields like `ended_at` and `output`.

## What Changed

The upsert now refuses to apply a non-terminal update on top of an already-terminal row.

Concretely:

If the existing row is terminal (`COMPLETED`, `FAILED`, `CANCELLED`, `OVERFLOWED`, or `SKIPPED`) and the incoming write is non-terminal then the conflict update is skipped. This keeps terminal trace run rows monotonic instead of allowing them to move backward.

The rule was added for both SQLite and Postgres in the checked-in query sources and generated query files.

## Repro

The repro is encoded directly in the new regression test:

1. insert a terminal `trace_runs` row for one `run_id`
2. insert a stale `RUNNING` row for the same `run_id`
3. read the row back through the normal CQRS path

Before this change, the row could regress. After this change, it stays terminal and preserves terminal metadata.

## Tests

The main regression test is:

- `TestCQRSInsertTraceRun_PreservesTerminalStateAgainstStaleNonTerminalWrite`

That test proves:

- the stale-write pattern is reproducible
- `COMPLETED` is preserved
- `ended_at` is preserved
- `output` is preserved
- the stale non-terminal row does not move the projection backward

Plus a property-style test that enumerates all 24 orderings of `[Scheduled, Running, Completed, Cancelled]` and asserts the TLA `RunStateProjection` invariant "terminal states are monotonic" holds after each write:

- `TestCQRSInsertTraceRun_TerminalMonotonicityUnderAllOrderings`

## Validation

- `go test ./pkg/cqrs/base_cqrs -run '^TestCQRSInsertTraceRun_PreservesTerminalStateAgainstStaleNonTerminalWrite$' -count=1`
- `go test ./pkg/cqrs/manager -run '^TestCQRSInsertTraceRun_TerminalMonotonicityUnderAllOrderings$' -count=1`
- `go test ./pkg/cqrs/base_cqrs -count=1`

