### PR TITLE
chore: add a concurrency safe marshal to state configs

### DIFF
--- a/pkg/execution/state/v2/state_metadata.go
+++ b/pkg/execution/state/v2/state_metadata.go
@@ -224,6 +224,14 @@ func (c *Config) initContext() {
 	}
 }
 
+// MarshalContextJSON returns the Context map serialized as a JSON string.
+func (c *Config) MarshalContextJSON() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	b, _ := json.Marshal(c.Context)
+	return string(b)
+}
+
 func (c *Config) SetCronSchedule(schedule string) {
 	defer c.mu.Unlock()
 	c.mu.Lock()


### PR DESCRIPTION
## Description
I need to use this for dual writing state store, marshalling the config
concurrently with any writers to it panics.


<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
