### PR TITLE
fix(executor): initialize synthetic cancel metadata config

### DIFF
--- a/pkg/execution/executor/cancel_test.go
+++ b/pkg/execution/executor/cancel_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -20,50 +21,72 @@ import (
 )
 
 func TestCancelForceLifecycleHookFinalizesWhenMetadataMissing(t *testing.T) {
-	runID := ulid.Make()
-	id := sv2.ID{
-		RunID:      runID,
-		FunctionID: uuid.New(),
-		Tenant: sv2.Tenant{
-			AccountID: uuid.New(),
-			AppID:     uuid.New(),
-			EnvID:     uuid.New(),
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "metadata not found",
+			err:  sv2.ErrMetadataNotFound,
 		},
-	}
+		{
+			name: "run not found",
+			err:  state.ErrRunNotFound,
+		},
+		{
+			name: "wrapped run not found",
+			err:  fmt.Errorf("load metadata: %w", state.ErrRunNotFound),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runID := ulid.Make()
+			id := sv2.ID{
+				RunID:      runID,
+				FunctionID: uuid.New(),
+				Tenant: sv2.Tenant{
+					AccountID: uuid.New(),
+					AppID:     uuid.New(),
+					EnvID:     uuid.New(),
+				},
+			}
 
-	runState := &missingMetadataRunService{}
-	lifecycle := &recordingCancelLifecycle{
-		cancelled: make(chan sv2.Metadata, 1),
-	}
-	e := &executor{
-		log:            logger.VoidLogger(),
-		smv2:           runState,
-		shards:         missingShardRegistry{},
-		tracerProvider: tracing.NewNoopTracerProvider(),
-		lifecycles:     []execution.LifecycleListener{lifecycle},
-	}
+			runState := &missingMetadataRunService{err: tc.err}
+			lifecycle := &recordingCancelLifecycle{
+				cancelled: make(chan sv2.Metadata, 1),
+			}
+			e := &executor{
+				log:            logger.VoidLogger(),
+				smv2:           runState,
+				shards:         missingShardRegistry{},
+				tracerProvider: tracing.NewOtelTracerProvider(nil, time.Millisecond),
+				lifecycles:     []execution.LifecycleListener{lifecycle},
+			}
 
-	err := e.Cancel(context.Background(), id, execution.CancelRequest{
-		ForceLifecycleHook: true,
-	})
-	require.NoError(t, err)
-	require.True(t, runState.deleted.Load())
+			err := e.Cancel(context.Background(), id, execution.CancelRequest{
+				ForceLifecycleHook: true,
+			})
+			require.NoError(t, err)
+			require.True(t, runState.deleted.Load())
 
-	select {
-	case md := <-lifecycle.cancelled:
-		require.Equal(t, id, md.ID)
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for cancellation lifecycle")
+			select {
+			case md := <-lifecycle.cancelled:
+				require.Equal(t, id, md.ID)
+				require.Nil(t, md.Config.DebugRunID())
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for cancellation lifecycle")
+			}
+		})
 	}
 }
 
 type missingMetadataRunService struct {
 	sv2.RunService
 	deleted atomic.Bool
+	err     error
 }
 
 func (m *missingMetadataRunService) LoadMetadata(context.Context, sv2.ID) (sv2.Metadata, error) {
-	return sv2.Metadata{}, sv2.ErrMetadataNotFound
+	return sv2.Metadata{}, m.err
 }
 
 func (m *missingMetadataRunService) LoadEvents(context.Context, sv2.ID) ([]json.RawMessage, error) {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2888,7 +2888,7 @@ func (e *executor) Cancel(ctx context.Context, id sv2.ID, r execution.CancelRequ
 				"cancellation_id", r.CancellationID,
 			)
 
-			md := sv2.Metadata{ID: id}
+			md := sv2.Metadata{ID: id, Config: *sv2.InitConfig(&sv2.Config{})}
 			if err := e.Finalize(ctx, execution.FinalizeOpts{
 				Metadata: md,
 				Response: execution.FinalizeResponse{


### PR DESCRIPTION
## Description

Bulk cancellation can force lifecycle hooks for runs whose metadata is already missing from the state store. PR #4255 added a synthetic `Finalize` path for that case, but the synthetic `sv2.Metadata` used a zero-value `Config`. In production tracing, `Finalize` calls `UpdateSpan`, which starts an OTEL extension span and reads debug IDs from `Metadata.Config`; the zero-value config has no mutex and can panic while calling `DebugRunID` or `DebugSessionID`.

This initializes the synthetic metadata config with `sv2.InitConfig` before finalization. The regression test now uses the real OTEL tracer path and covers `sv2.ErrMetadataNotFound`, `state.ErrRunNotFound`, and wrapped `state.ErrRunNotFound`.

Validated with:

```sh
go test ./pkg/execution/executor -run TestCancelForceLifecycleHookFinalizesWhenMetadataMissing -count=1
go test ./pkg/execution/executor -count=1
```

## Release note

None.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*