### PR TITLE
fix: panic in bulk cancel

### DIFF
--- a/pkg/execution/executor/cancel_test.go
+++ b/pkg/execution/executor/cancel_test.go
@@ -39,7 +39,7 @@ func TestCancelForceLifecycleHookFinalizesWhenMetadataMissing(t *testing.T) {
 		log:            logger.VoidLogger(),
 		smv2:           runState,
 		shards:         missingShardRegistry{},
-		tracerProvider: tracing.NewNoopTracerProvider(),
+		tracerProvider: tracing.NewOtelTracerProvider(nil, time.Millisecond),
 		lifecycles:     []execution.LifecycleListener{lifecycle},
 	}
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2888,7 +2888,10 @@ func (e *executor) Cancel(ctx context.Context, id sv2.ID, r execution.CancelRequ
 				"cancellation_id", r.CancellationID,
 			)
 
-			md := sv2.Metadata{ID: id}
+			md := sv2.Metadata{
+				ID:     id,
+				Config: *sv2.InitConfig(&sv2.Config{}),
+			}
 			if err := e.Finalize(ctx, execution.FinalizeOpts{
 				Metadata: md,
 				Response: execution.FinalizeResponse{


### PR DESCRIPTION
## Description

Fix panic caused by our metadata config stub we used to get bulk cancels working for runs without metadata.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
