### PR TITLE
fix(connect): encode worker request ack policy

### DIFF
--- a/docs/plans/003-connect-gateway-lifecycle-controller.org
+++ b/docs/plans/003-connect-gateway-lifecycle-controller.org
@@ -570,10 +570,13 @@ Either way, a transient =getOrCreateGRPCClient= or =Ack= failure should not
 automatically close the worker websocket after the worker ACK was parsed and
 accepted.
 
+Decision: use Option A. A parsed =WORKER_REQUEST_ACK= completes local
+=Forward= delivery, and executor notification is best-effort.
+
 *** Implementation checklist
 
 - [X] Choose Option A or Option B.
-- [ ] Encode the chosen order in one helper.
+- [X] Encode the chosen order in one helper.
 - [X] Make unknown request ACKs non-fatal and clearly logged.
 - [X] Make executor ACK failures return request-level failure or warning,
   according to the chosen option.
@@ -582,11 +585,11 @@ accepted.
 
 *** Test checklist
 
-- [ ] gRPC client creation failure during =WORKER_REQUEST_ACK= does not close
+- [X] gRPC client creation failure during =WORKER_REQUEST_ACK= does not close
   the websocket unless chosen policy explicitly requires it;
 - [X] gRPC =Ack= RPC failure behavior matches chosen policy;
 - [X] =reply.Success=false= behavior matches chosen policy;
-- [ ] =Forward= result matches chosen policy.
+- [X] =Forward= result matches chosen policy.
 
 *** Validation checklist
 

--- a/pkg/connect/gateway_msg_request_ack.go
+++ b/pkg/connect/gateway_msg_request_ack.go
@@ -28,6 +28,15 @@ func (c *connectionHandler) handleWorkerRequestAck(msg *connectpb.ConnectMessage
 		}
 	}
 
+	c.acceptWorkerRequestAck(&data)
+
+	// TODO Should we send a reverse ack to the worker to start processing the request?
+	return nil
+}
+
+func (c *connectionHandler) acceptWorkerRequestAck(data *connectpb.WorkerRequestAckData) {
+	// Option A: a parsed worker ACK means the gateway accepted local delivery.
+	// Executor notification happens afterwards and is best-effort.
 	if !c.completePendingAck(data.RequestId, nil) {
 		c.log.Warn(
 			"worker request ack received for unknown request ID",
@@ -37,6 +46,10 @@ func (c *connectionHandler) handleWorkerRequestAck(msg *connectpb.ConnectMessage
 		)
 	}
 
+	c.notifyExecutorWorkerRequestAck(data)
+}
+
+func (c *connectionHandler) notifyExecutorWorkerRequestAck(data *connectpb.WorkerRequestAckData) {
 	notifyCtx, notifyCancel := context.WithTimeout(context.Background(), workerRequestAckNotifyTimeout)
 	defer notifyCancel()
 
@@ -51,10 +64,10 @@ func (c *connectionHandler) handleWorkerRequestAck(msg *connectpb.ConnectMessage
 	case err == nil:
 	case errors.Is(err, state.ErrExecutorNotFound):
 		l.Debug("executor not found in lease, worker ack was likely picked up by polling")
-		return nil
+		return
 	default:
 		l.Warn("could not create grpc client to ack, executor will rely on timeout or polling", "err", err)
-		return nil
+		return
 	}
 
 	reply, err := grpcClient.Ack(notifyCtx, &connectpb.AckMessage{
@@ -63,13 +76,10 @@ func (c *connectionHandler) handleWorkerRequestAck(msg *connectpb.ConnectMessage
 	})
 	if err != nil {
 		l.Warn("could not ack message through gRPC, executor will rely on timeout or polling", "err", err)
-		return nil
+		return
 	}
 	if reply == nil || !reply.Success {
 		l.Warn("failed to ack, executor was likely done with the request")
 	}
 	l.Trace("worker acked message")
-
-	// TODO Should we send a reverse ack to the worker to start processing the request?
-	return nil
 }

--- a/pkg/connect/gateway_msg_request_ack_test.go
+++ b/pkg/connect/gateway_msg_request_ack_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/inngest/inngest/pkg/connect/wsproto"
 	"github.com/inngest/inngest/pkg/syscode"
 	connectpb "github.com/inngest/inngest/proto/gen/connect/v1"
 	"github.com/stretchr/testify/require"
@@ -97,6 +98,32 @@ func TestHandleWorkerRequestAckRPCFailureIsNonFatal(t *testing.T) {
 	require.Nil(t, serr)
 }
 
+func TestWorkerRequestAckGRPCClientCreationFailureDoesNotCloseWebSocket(t *testing.T) {
+	res := createTestingGateway(t, testingParameters{silent: true})
+	handshake(t, res)
+
+	executor := startAckExecutor(t, &ackExecutor{
+		pingReceived: make(chan struct{}, 1),
+		pingErr:      status.Error(codes.Unavailable, "ping unavailable"),
+	})
+	res.svc.grpcConfig.Executor.Port = executor.port
+
+	requestID := "test-worker-request-ack-client-creation-failure"
+	_, err := res.svc.stateManager.LeaseRequest(t.Context(), res.envID, requestID, 5*time.Second, testExecutorIP)
+	require.NoError(t, err)
+
+	err = wsproto.Write(t.Context(), res.ws, workerRequestAckMessage(t, res, requestID))
+	require.NoError(t, err)
+
+	select {
+	case <-executor.pingReceived:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for executor ping")
+	}
+
+	exchangeHeartbeat(t, res.ws, 2*time.Second)
+}
+
 func TestHandleWorkerRequestAckExecutorDoneIsNonFatal(t *testing.T) {
 	res := createTestingGateway(t)
 	handshake(t, res)
@@ -115,6 +142,59 @@ func TestHandleWorkerRequestAckExecutorDoneIsNonFatal(t *testing.T) {
 
 	serr := ch.handleWorkerRequestAck(workerRequestAckMessage(t, res, requestID))
 	require.Nil(t, serr)
+}
+
+func TestForwardSucceedsAfterWorkerRequestAckWhenExecutorAckFails(t *testing.T) {
+	res := createTestingGateway(t, testingParameters{silent: true})
+	handshake(t, res)
+
+	executor := startAckExecutor(t, &ackExecutor{
+		ackReceived: make(chan *connectpb.AckMessage, 1),
+		err:         status.Error(codes.Unavailable, "ack unavailable"),
+	})
+	res.svc.grpcConfig.Executor.Port = executor.port
+
+	requestID := "test-forward-success-after-worker-ack"
+	_, err := res.svc.stateManager.LeaseRequest(t.Context(), res.envID, requestID, 5*time.Second, testExecutorIP)
+	require.NoError(t, err)
+
+	forwardResult := make(chan *connectpb.ForwardResponse, 1)
+	forwardErr := make(chan error, 1)
+	go func() {
+		resp, err := res.svc.Forward(t.Context(), &connectpb.ForwardRequest{
+			ConnectionID: res.connID.String(),
+			Data:         testGatewayExecutorRequestData(res, requestID),
+		})
+		forwardResult <- resp
+		forwardErr <- err
+	}()
+
+	msg := awaitNextMessage(t, res.ws, 2*time.Second)
+	require.Equal(t, connectpb.GatewayMessageType_GATEWAY_EXECUTOR_REQUEST, msg.Kind)
+
+	err = wsproto.Write(t.Context(), res.ws, workerRequestAckMessage(t, res, requestID))
+	require.NoError(t, err)
+
+	select {
+	case err := <-forwardErr:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Forward error")
+	}
+
+	select {
+	case resp := <-forwardResult:
+		require.True(t, resp.GetSuccess())
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Forward response")
+	}
+
+	select {
+	case ack := <-executor.ackReceived:
+		require.Equal(t, requestID, ack.RequestId)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for executor ack")
+	}
 }
 
 func workerRequestAckMessage(t *testing.T, res testingResources, requestID string) *connectpb.ConnectMessage {
@@ -137,10 +217,12 @@ func workerRequestAckMessage(t *testing.T, res testingResources, requestID strin
 
 type ackExecutor struct {
 	connectpb.UnimplementedConnectExecutorServer
-	port        int
-	ackReceived chan *connectpb.AckMessage
-	success     *bool
-	err         error
+	port         int
+	ackReceived  chan *connectpb.AckMessage
+	success      *bool
+	err          error
+	pingReceived chan struct{}
+	pingErr      error
 }
 
 func startAckExecutor(t *testing.T, executor *ackExecutor) *ackExecutor {
@@ -182,6 +264,12 @@ func (s *ackExecutor) Ack(_ context.Context, msg *connectpb.AckMessage) (*connec
 }
 
 func (s *ackExecutor) Ping(_ context.Context, _ *connectpb.PingRequest) (*connectpb.PingResponse, error) {
+	if s.pingReceived != nil {
+		s.pingReceived <- struct{}{}
+	}
+	if s.pingErr != nil {
+		return nil, s.pingErr
+	}
 	return &connectpb.PingResponse{Message: "ok"}, nil
 }
 


### PR DESCRIPTION
## Description

Implements plan 003 phase 3 for Connect gateway lifecycle handling.

- Encodes Option A for WORKER_REQUEST_ACK: a parsed worker ACK completes local Forward delivery, while executor gRPC Ack notification is best-effort.
- Keeps executor client creation and Ack RPC failures non-fatal for the worker websocket after ACK acceptance.
- Adds regressions for gRPC client creation failure, executor Ack RPC failure, and Forward success semantics.
- Updates the phase 3 plan checklist and records the Option A decision.

Validation:

- go test ./pkg/connect -run 'Test.*Ack|Test.*Forward|Test.*Drain' -count=1
- go test ./pkg/connect -count=1
- scripts/check-plan-status.sh docs/plans/003-connect-gateway-lifecycle-controller.org

## Release note

None.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*