### PR TITLE
fix(queue): handle renewed item lease during processing

### DIFF
--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -457,14 +457,14 @@ func (q *queueProcessor) ProcessItem(
 			}
 
 			qi.AtMS = at.UnixMilli()
-			qi = itemWithCurrentLease(qi)
-			if err := shard.Requeue(context.WithoutCancel(ctx), qi, at); err != nil {
+			requeueItem := itemWithCurrentLease(qi)
+			if err := shard.Requeue(context.WithoutCancel(ctx), requeueItem, at); err != nil {
 				if err == ErrQueueItemNotFound {
 					// Safe. The executor may have dequeued.
 					return nil
 				}
 
-				l.Error("error requeuing job", "error", err, "item", qi)
+				l.Error("error requeuing job", "error", err, "item", requeueItem)
 				return err
 			}
 			if _, ok := err.(QuitError); ok {
@@ -476,8 +476,7 @@ func (q *queueProcessor) ProcessItem(
 
 		// Dequeue this entirely, as this permanently failed.
 		// XXX: Increase permanently failed counter here.
-		qi = itemWithCurrentLease(qi)
-		if err := shard.Dequeue(context.WithoutCancel(ctx), qi); err != nil {
+		if err := shard.Dequeue(context.WithoutCancel(ctx), itemWithCurrentLease(qi)); err != nil {
 			if err == ErrQueueItemNotFound {
 				// Safe. The executor may have dequeued.
 				return nil
@@ -492,8 +491,7 @@ func (q *queueProcessor) ProcessItem(
 		}
 	case <-jobCtx.Done():
 		stopItemLeaseRenewal()
-		qi = itemWithCurrentLease(qi)
-		if err := shard.Dequeue(context.WithoutCancel(ctx), qi); err != nil {
+		if err := shard.Dequeue(context.WithoutCancel(ctx), itemWithCurrentLease(qi)); err != nil {
 			if err == ErrQueueItemNotFound {
 				// Safe. The executor may have dequeued.
 				return nil

--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"sync"
 	"time"
 
 	"github.com/inngest/inngest/pkg/constraintapi"
@@ -13,6 +14,7 @@ import (
 	"github.com/inngest/inngest/pkg/service"
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"github.com/jonboulle/clockwork"
+	"github.com/oklog/ulid/v2"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -50,8 +52,29 @@ func (q *queueProcessor) ProcessItem(
 	p := i.P
 	continuationCtr := i.PCtr
 
-	var err error
 	leaseID := qi.LeaseID
+	leaseMu := sync.RWMutex{}
+
+	currentLeaseID := func() *ulid.ULID {
+		leaseMu.RLock()
+		defer leaseMu.RUnlock()
+		if leaseID == nil {
+			return nil
+		}
+		current := *leaseID
+		return &current
+	}
+
+	setLeaseID := func(next *ulid.ULID) {
+		leaseMu.Lock()
+		defer leaseMu.Unlock()
+		leaseID = next
+	}
+
+	itemWithCurrentLease := func(item QueueItem) QueueItem {
+		item.LeaseID = currentLeaseID()
+		return item
+	}
 
 	// Allow the main runner to block until this work is done
 	q.wg.Add(1)
@@ -80,7 +103,10 @@ func (q *queueProcessor) ProcessItem(
 	// Continually extend lease in the background while we're working on this job
 	extendLeaseTick := q.Clock().NewTicker(QueueLeaseDuration / 2)
 	defer extendLeaseTick.Stop()
+	leaseRenewalDone := make(chan struct{})
 	go func() {
+		defer close(leaseRenewalDone)
+
 		for {
 			select {
 			case <-jobCtx.Done():
@@ -91,7 +117,8 @@ func (q *queueProcessor) ProcessItem(
 					return
 				}
 
-				if leaseID == nil {
+				current := currentLeaseID()
+				if current == nil {
 					l.Error("cannot extend lease since lease ID is nil", "qi", qi, "partition", p)
 					// Don't extend lease since one doesn't exist
 					errCh <- fmt.Errorf("cannot extend lease since lease ID is nil")
@@ -99,10 +126,10 @@ func (q *queueProcessor) ProcessItem(
 				}
 
 				// Once a job has started, use a BG context to always renew.
-				leaseID, err = shard.ExtendLease(
+				nextLeaseID, err := shard.ExtendLease(
 					context.Background(),
 					qi,
-					*leaseID,
+					*current,
 					QueueLeaseDuration,
 				)
 				if err != nil {
@@ -116,9 +143,16 @@ func (q *queueProcessor) ProcessItem(
 					errCh <- fmt.Errorf("error extending lease while processing: %w", err)
 					return
 				}
+				setLeaseID(nextLeaseID)
 			}
 		}
 	}()
+	stopItemLeaseRenewal := func() {
+		jobDone()
+		// Ensure cleanup observes any lease renewal that won the race with job
+		// completion before passing a lease token to Requeue or Dequeue.
+		<-leaseRenewalDone
+	}
 
 	// If a capacity lease is set on the item, continue extending it and cancel execution if lease expires
 	capacityLeaseID := newCapacityLease(i.CapacityLease)
@@ -407,7 +441,7 @@ func (q *queueProcessor) ProcessItem(
 	case err := <-errCh:
 		// Job errored or extending lease errored.  Signal that the job is done to
 		// stop everything.
-		jobDone()
+		stopItemLeaseRenewal()
 
 		if ShouldRetry(err, qi.Data.Attempt, qi.Data.GetMaxAttempts()) {
 			at := q.backoffFunc(qi.Data.Attempt)
@@ -423,6 +457,7 @@ func (q *queueProcessor) ProcessItem(
 			}
 
 			qi.AtMS = at.UnixMilli()
+			qi = itemWithCurrentLease(qi)
 			if err := shard.Requeue(context.WithoutCancel(ctx), qi, at); err != nil {
 				if err == ErrQueueItemNotFound {
 					// Safe. The executor may have dequeued.
@@ -441,6 +476,7 @@ func (q *queueProcessor) ProcessItem(
 
 		// Dequeue this entirely, as this permanently failed.
 		// XXX: Increase permanently failed counter here.
+		qi = itemWithCurrentLease(qi)
 		if err := shard.Dequeue(context.WithoutCancel(ctx), qi); err != nil {
 			if err == ErrQueueItemNotFound {
 				// Safe. The executor may have dequeued.
@@ -455,6 +491,8 @@ func (q *queueProcessor) ProcessItem(
 			return err
 		}
 	case <-jobCtx.Done():
+		stopItemLeaseRenewal()
+		qi = itemWithCurrentLease(qi)
 		if err := shard.Dequeue(context.WithoutCancel(ctx), qi); err != nil {
 			if err == ErrQueueItemNotFound {
 				// Safe. The executor may have dequeued.

--- a/pkg/execution/state/redis_state/queue_item_process_test.go
+++ b/pkg/execution/state/redis_state/queue_item_process_test.go
@@ -5,8 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -488,86 +486,19 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 	})
 }
 
-type leaseTrackingShard struct {
-	osqueue.QueueShard
-
-	mu          sync.Mutex
-	current     ulid.ULID
-	extended    chan struct{}
-	extendOnce  sync.Once
-	cleanup     chan struct{}
-	cleanupOnce sync.Once
-	cleanupKind string
-}
-
-func newLeaseTrackingShard(inner osqueue.QueueShard, initial ulid.ULID) *leaseTrackingShard {
-	return &leaseTrackingShard{
-		QueueShard: inner,
-		current:    initial,
-		extended:   make(chan struct{}),
-		cleanup:    make(chan struct{}),
-	}
-}
-
-func (s *leaseTrackingShard) ExtendLease(ctx context.Context, i osqueue.QueueItem, leaseID ulid.ULID, duration time.Duration, opts ...osqueue.ExtendLeaseOptionFn) (*ulid.ULID, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if leaseID != s.current {
-		return nil, fmt.Errorf("extended stale lease: got %s want %s", leaseID, s.current)
-	}
-
-	next := ulid.MustNew(ulid.Timestamp(leaseID.Timestamp().Add(duration)), rand.Reader)
-	s.current = next
-	s.extendOnce.Do(func() {
-		close(s.extended)
-	})
-
-	return &next, nil
-}
-
-func (s *leaseTrackingShard) Dequeue(ctx context.Context, i osqueue.QueueItem, opts ...osqueue.DequeueOptionFn) error {
-	return s.recordCleanup("dequeue", i)
-}
-
-func (s *leaseTrackingShard) Requeue(ctx context.Context, i osqueue.QueueItem, at time.Time, opts ...osqueue.RequeueOptionFn) error {
-	return s.recordCleanup("requeue", i)
-}
-
-func (s *leaseTrackingShard) recordCleanup(kind string, i osqueue.QueueItem) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	defer s.cleanupOnce.Do(func() {
-		close(s.cleanup)
-	})
-
-	if i.LeaseID == nil {
-		return fmt.Errorf("%s used nil lease; want %s", kind, s.current)
-	}
-
-	if *i.LeaseID != s.current {
-		return fmt.Errorf("%s used stale lease: got %s want %s", kind, *i.LeaseID, s.current)
-	}
-
-	s.cleanupKind = kind
-	return nil
-}
-
 func TestQueueItemProcessCleanupUsesRenewedLease(t *testing.T) {
 	tests := []struct {
-		name     string
-		runErr   error
-		expected string
+		name    string
+		runErr  error
+		requeue bool
 	}{
 		{
-			name:     "dequeue on success",
-			expected: "dequeue",
+			name: "dequeue on success",
 		},
 		{
-			name:     "requeue on retryable error",
-			runErr:   errors.New("retryable"),
-			expected: "requeue",
+			name:    "requeue on retryable error",
+			runErr:  errors.New("retryable"),
+			requeue: true,
 		},
 	}
 
@@ -584,28 +515,22 @@ func TestQueueItemProcessCleanupUsesRenewedLease(t *testing.T) {
 			require.NoError(t, err)
 			defer rc.Close()
 
-			queueClient := NewQueueClient(rc, QueueDefaultKey)
-			inner := NewQueueShard("test", queueClient, osqueue.WithClock(clock))
-
-			initialLease := ulid.MustNew(ulid.Timestamp(clock.Now().Add(osqueue.QueueLeaseDuration)), rand.Reader)
-			shard := newLeaseTrackingShard(inner, initialLease)
-			shardRegistry, err := osqueue.NewSingleShardRegistry(shard)
-			require.NoError(t, err)
-
-			q, err := osqueue.New(ctx, "test", shardRegistry, osqueue.WithClock(clock))
-			require.NoError(t, err)
+			q, shard := newQueue(
+				t,
+				rc,
+				osqueue.WithClock(clock),
+				osqueue.WithBackoffFunc(func(int) time.Time {
+					return clock.Now().Add(time.Minute)
+				}),
+			)
 
 			accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
 			runID := ulid.MustNew(ulid.Timestamp(clock.Now()), rand.Reader)
 			jobID := "lease-cleanup-" + tc.name
-			item := osqueue.QueueItem{
+			item, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
 				ID:          jobID,
 				FunctionID:  fnID,
 				WorkspaceID: envID,
-				LeaseID:     &initialLease,
-				AtMS:        clock.Now().UnixMilli(),
-				WallTimeMS:  clock.Now().UnixMilli(),
-				EnqueuedAt:  clock.Now().UnixMilli(),
 				Data: osqueue.Item{
 					JobID:       &jobID,
 					WorkspaceID: envID,
@@ -617,7 +542,14 @@ func TestQueueItemProcessCleanupUsesRenewedLease(t *testing.T) {
 						RunID:       runID,
 					},
 				},
-			}
+			}, clock.Now(), osqueue.EnqueueOpts{})
+			require.NoError(t, err)
+
+			leaseID, err := shard.Lease(ctx, item, osqueue.QueueLeaseDuration, clock.Now())
+			require.NoError(t, err)
+			item.LeaseID = leaseID
+			initialLease := *leaseID
+			initialGeneration := item.GenerationID
 
 			started := make(chan struct{})
 			done := make(chan error, 1)
@@ -627,12 +559,24 @@ func TestQueueItemProcessCleanupUsesRenewedLease(t *testing.T) {
 					I: item,
 				}, func(ctx context.Context, ri osqueue.RunInfo, i osqueue.Item) (osqueue.RunResult, error) {
 					close(started)
-					select {
-					case <-shard.extended:
-					case <-ctx.Done():
-						return osqueue.RunResult{}, ctx.Err()
+					deadline := time.After(time.Second)
+					ticker := time.NewTicker(10 * time.Millisecond)
+					defer ticker.Stop()
+
+					for {
+						loaded, err := shard.LoadQueueItem(ctx, item.ID)
+						if err == nil && loaded.LeaseID != nil && *loaded.LeaseID != initialLease {
+							return osqueue.RunResult{}, tc.runErr
+						}
+
+						select {
+						case <-deadline:
+							return osqueue.RunResult{}, errors.New("timed out waiting for lease renewal")
+						case <-ticker.C:
+						case <-ctx.Done():
+							return osqueue.RunResult{}, ctx.Err()
+						}
 					}
-					return osqueue.RunResult{}, tc.runErr
 				})
 			}()
 
@@ -646,6 +590,7 @@ func TestQueueItemProcessCleanupUsesRenewedLease(t *testing.T) {
 			}, time.Second, 10*time.Millisecond)
 
 			clock.Advance(osqueue.QueueLeaseDuration / 2)
+			r.SetTime(clock.Now())
 
 			select {
 			case err := <-done:
@@ -654,16 +599,17 @@ func TestQueueItemProcessCleanupUsesRenewedLease(t *testing.T) {
 				t.Fatal("timed out waiting for ProcessItem to finish")
 			}
 
-			select {
-			case <-shard.cleanup:
-			default:
-				t.Fatal("expected cleanup to run")
+			loaded, err := shard.LoadQueueItem(ctx, item.ID)
+			if !tc.requeue {
+				require.ErrorIs(t, err, osqueue.ErrQueueItemNotFound)
+				require.Nil(t, loaded)
+				return
 			}
 
-			shard.mu.Lock()
-			cleanupKind := shard.cleanupKind
-			shard.mu.Unlock()
-			require.Equal(t, tc.expected, cleanupKind)
+			require.NoError(t, err)
+			require.Nil(t, loaded.LeaseID)
+			require.Equal(t, initialGeneration+1, loaded.GenerationID)
+			require.Equal(t, 1, loaded.Data.Attempt)
 		})
 	}
 }

--- a/pkg/execution/state/redis_state/queue_item_process_test.go
+++ b/pkg/execution/state/redis_state/queue_item_process_test.go
@@ -2,7 +2,11 @@ package redis_state
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -18,6 +22,7 @@ import (
 	"github.com/inngest/inngest/pkg/service"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/jonboulle/clockwork"
+	"github.com/oklog/ulid/v2"
 	"github.com/redis/rueidis"
 	"github.com/stretchr/testify/require"
 )
@@ -481,6 +486,186 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 		// Expect exactly 2 release calls
 		require.Equal(t, 2, len(cmLifecycles.ReleaseCalls))
 	})
+}
+
+type leaseTrackingShard struct {
+	osqueue.QueueShard
+
+	mu          sync.Mutex
+	current     ulid.ULID
+	extended    chan struct{}
+	extendOnce  sync.Once
+	cleanup     chan struct{}
+	cleanupOnce sync.Once
+	cleanupKind string
+}
+
+func newLeaseTrackingShard(inner osqueue.QueueShard, initial ulid.ULID) *leaseTrackingShard {
+	return &leaseTrackingShard{
+		QueueShard: inner,
+		current:    initial,
+		extended:   make(chan struct{}),
+		cleanup:    make(chan struct{}),
+	}
+}
+
+func (s *leaseTrackingShard) ExtendLease(ctx context.Context, i osqueue.QueueItem, leaseID ulid.ULID, duration time.Duration, opts ...osqueue.ExtendLeaseOptionFn) (*ulid.ULID, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if leaseID != s.current {
+		return nil, fmt.Errorf("extended stale lease: got %s want %s", leaseID, s.current)
+	}
+
+	next := ulid.MustNew(ulid.Timestamp(leaseID.Timestamp().Add(duration)), rand.Reader)
+	s.current = next
+	s.extendOnce.Do(func() {
+		close(s.extended)
+	})
+
+	return &next, nil
+}
+
+func (s *leaseTrackingShard) Dequeue(ctx context.Context, i osqueue.QueueItem, opts ...osqueue.DequeueOptionFn) error {
+	return s.recordCleanup("dequeue", i)
+}
+
+func (s *leaseTrackingShard) Requeue(ctx context.Context, i osqueue.QueueItem, at time.Time, opts ...osqueue.RequeueOptionFn) error {
+	return s.recordCleanup("requeue", i)
+}
+
+func (s *leaseTrackingShard) recordCleanup(kind string, i osqueue.QueueItem) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	defer s.cleanupOnce.Do(func() {
+		close(s.cleanup)
+	})
+
+	if i.LeaseID == nil {
+		return fmt.Errorf("%s used nil lease; want %s", kind, s.current)
+	}
+
+	if *i.LeaseID != s.current {
+		return fmt.Errorf("%s used stale lease: got %s want %s", kind, *i.LeaseID, s.current)
+	}
+
+	s.cleanupKind = kind
+	return nil
+}
+
+func TestQueueItemProcessCleanupUsesRenewedLease(t *testing.T) {
+	tests := []struct {
+		name     string
+		runErr   error
+		expected string
+	}{
+		{
+			name:     "dequeue on success",
+			expected: "dequeue",
+		},
+		{
+			name:     "requeue on retryable error",
+			runErr:   errors.New("retryable"),
+			expected: "requeue",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			clock := clockwork.NewFakeClock()
+
+			r := miniredis.RunT(t)
+			rc, err := rueidis.NewClient(rueidis.ClientOption{
+				InitAddress:  []string{r.Addr()},
+				DisableCache: true,
+			})
+			require.NoError(t, err)
+			defer rc.Close()
+
+			queueClient := NewQueueClient(rc, QueueDefaultKey)
+			inner := NewQueueShard("test", queueClient, osqueue.WithClock(clock))
+
+			initialLease := ulid.MustNew(ulid.Timestamp(clock.Now().Add(osqueue.QueueLeaseDuration)), rand.Reader)
+			shard := newLeaseTrackingShard(inner, initialLease)
+			shardRegistry, err := osqueue.NewSingleShardRegistry(shard)
+			require.NoError(t, err)
+
+			q, err := osqueue.New(ctx, "test", shardRegistry, osqueue.WithClock(clock))
+			require.NoError(t, err)
+
+			accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+			runID := ulid.MustNew(ulid.Timestamp(clock.Now()), rand.Reader)
+			jobID := "lease-cleanup-" + tc.name
+			item := osqueue.QueueItem{
+				ID:          jobID,
+				FunctionID:  fnID,
+				WorkspaceID: envID,
+				LeaseID:     &initialLease,
+				AtMS:        clock.Now().UnixMilli(),
+				WallTimeMS:  clock.Now().UnixMilli(),
+				EnqueuedAt:  clock.Now().UnixMilli(),
+				Data: osqueue.Item{
+					JobID:       &jobID,
+					WorkspaceID: envID,
+					Kind:        osqueue.KindStart,
+					Identifier: state.Identifier{
+						AccountID:   accountID,
+						WorkspaceID: envID,
+						WorkflowID:  fnID,
+						RunID:       runID,
+					},
+				},
+			}
+
+			started := make(chan struct{})
+			done := make(chan error, 1)
+			go func() {
+				done <- q.ProcessItem(ctx, osqueue.ProcessItem{
+					P: osqueue.ItemPartition(ctx, item),
+					I: item,
+				}, func(ctx context.Context, ri osqueue.RunInfo, i osqueue.Item) (osqueue.RunResult, error) {
+					close(started)
+					select {
+					case <-shard.extended:
+					case <-ctx.Done():
+						return osqueue.RunResult{}, ctx.Err()
+					}
+					return osqueue.RunResult{}, tc.runErr
+				})
+			}()
+
+			require.Eventually(t, func() bool {
+				select {
+				case <-started:
+					return true
+				default:
+					return false
+				}
+			}, time.Second, 10*time.Millisecond)
+
+			clock.Advance(osqueue.QueueLeaseDuration / 2)
+
+			select {
+			case err := <-done:
+				require.NoError(t, err)
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for ProcessItem to finish")
+			}
+
+			select {
+			case <-shard.cleanup:
+			default:
+				t.Fatal("expected cleanup to run")
+			}
+
+			shard.mu.Lock()
+			cleanupKind := shard.cleanupKind
+			shard.mu.Unlock()
+			require.Equal(t, tc.expected, cleanupKind)
+		})
+	}
 }
 
 func TestQueueProcessorPreLeaseWithConstraintAPI(t *testing.T) {


### PR DESCRIPTION
## Description

Fixes queue item processing so background item lease renewals are synchronized with terminal cleanup. When a processing lease is extended while the run function is still executing, `ProcessItem` now tracks the latest lease ID and waits for the renewal goroutine to stop before calling `Requeue` or `Dequeue`.

Adds a Redis-backed regression test in `pkg/execution/state/redis_state/queue_item_process_test.go` that leases a real queue item, waits for `ProcessItem` to renew that lease, and then verifies successful cleanup on both completion and retryable error paths.

## Release note

None

## Migration note

None

## Validation

- `go test -count=1 -run TestQueueItemProcessCleanupUsesRenewedLease ./pkg/execution/state/redis_state`
- `go test -race -count=1 -run TestQueueItemProcessCleanupUsesRenewedLease ./pkg/execution/state/redis_state`
- `go test -count=1 -run TestQueueItemProcess ./pkg/execution/state/redis_state`