### PR TITLE
refactor(queue): Add Scope to more queue methods

### DIFF
--- a/cmd/debug/debugflags/scope.go
+++ b/cmd/debug/debugflags/scope.go
@@ -23,7 +23,7 @@ func AccountEnvFlags() []cli.Flag {
 func FunctionFlag() cli.Flag {
 	return &cli.StringFlag{
 		Name:  "function-id",
-		Usage: "Function UUID that owns the debounce",
+		Usage: "Function UUID for the scoped debug operation",
 	}
 }
 

--- a/cmd/debug/queue/item.go
+++ b/cmd/debug/queue/item.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/inngest/inngest/cmd/debug/debugflags"
 	"github.com/inngest/inngest/pkg/cli/output"
 	debugpkg "github.com/inngest/inngest/pkg/debug"
 	"github.com/inngest/inngest/pkg/execution/queue"
@@ -28,6 +29,15 @@ func ItemCommand() *cli.Command {
 				Name:  "run-id",
 				Usage: "run ID to reference (does not work with --id)",
 			},
+			&cli.StringFlag{
+				Name:  "account-id",
+				Usage: "Account UUID for run ID lookups",
+			},
+			&cli.StringFlag{
+				Name:  "env-id",
+				Usage: "Environment UUID for run ID lookups",
+			},
+			debugflags.FunctionFlag(),
 			&cli.StringFlag{
 				Name:    "queue-shard",
 				Aliases: []string{"qs"},
@@ -58,7 +68,19 @@ func ItemCommand() *cli.Command {
 			if itemID != "" {
 				req.ItemId = itemID
 			} else {
+				accountID, envID, err := debugflags.AccountEnv(cmd)
+				if err != nil {
+					return err
+				}
+				functionID, err := debugflags.RequiredUUID(cmd, "function-id")
+				if err != nil {
+					return err
+				}
+
 				req.RunId = runID
+				req.AccountId = accountID
+				req.EnvId = envID
+				req.FunctionId = functionID
 			}
 
 			resp, err := dbgCtx.Client.GetQueueItem(ctx, &req)

--- a/cmd/debug/queue/item.go
+++ b/cmd/debug/queue/item.go
@@ -104,7 +104,7 @@ func ItemCommand() *cli.Command {
 				return fmt.Errorf("error unmarshalling item: %w", err)
 			}
 
-			return output.TextQueueItem(&item)
+			return output.TextQueueItem(&item, resp.GetQueueShard())
 		},
 	}
 }

--- a/pkg/api/apiv1/runs.go
+++ b/pkg/api/apiv1/runs.go
@@ -118,8 +118,11 @@ func (a router) GetFunctionRunJobs(w http.ResponseWriter, r *http.Request) {
 
 	jobs, err := shard.RunJobs(
 		ctx,
-		auth.WorkspaceID(),
-		fr.FunctionID,
+		queue.Scope{
+			AccountID:  auth.AccountID(),
+			EnvID:      auth.WorkspaceID(),
+			FunctionID: fr.FunctionID,
+		},
 		runID,
 		10,
 		0,

--- a/pkg/cli/output/partition.go
+++ b/pkg/cli/output/partition.go
@@ -101,7 +101,7 @@ func TextPartition(pt *pb.PartitionResponse, pts *pb.PartitionStatusResponse) er
 	return w.Flush()
 }
 
-func TextQueueItem(item *queue.QueueItem) error {
+func TextQueueItem(item *queue.QueueItem, shardName ...string) error {
 	if item == nil {
 		fmt.Println("no item found")
 		return nil
@@ -111,11 +111,11 @@ func TextQueueItem(item *queue.QueueItem) error {
 
 	data := item.Data
 
-	if err := w.WriteOrdered(OrderedData(
+	fields := []any{
 		"ID", item.ID,
 		"EarliestPeekTime", item.EarliestPeekTime,
 		"At", time.UnixMilli(item.AtMS).Format(time.RFC3339),
-		"WallTime", time.Duration(item.WallTimeMS)*time.Millisecond,
+		"WallTime", time.Duration(item.WallTimeMS) * time.Millisecond,
 		"WorkspaceID", item.WorkspaceID,
 		"FunctionID", item.FunctionID,
 		"LeaseID", item.LeaseID,
@@ -147,7 +147,12 @@ func TextQueueItem(item *queue.QueueItem) error {
 			"Metadata", data.Metadata,
 			"ParallelMode", data.ParallelMode,
 		),
-	), WithTextOptLeadSpace(true)); err != nil {
+	}
+	if len(shardName) > 0 && shardName[0] != "" {
+		fields = append([]any{"QueueShard", shardName[0]}, fields...)
+	}
+
+	if err := w.WriteOrdered(OrderedData(fields...), WithTextOptLeadSpace(true)); err != nil {
 		return err
 	}
 

--- a/pkg/coreapi/graph/resolvers/function_run.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run.resolver.go
@@ -15,6 +15,7 @@ import (
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/executor"
+	"github.com/inngest/inngest/pkg/execution/queue"
 	statev1 "github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/history_reader"
@@ -42,8 +43,11 @@ func (r *functionRunResolver) PendingSteps(ctx context.Context, obj *models.Func
 	}
 	pending, _ := r.Queue.OutstandingJobCount(
 		ctx,
-		md.Identifier.WorkspaceID,
-		md.Identifier.WorkflowID,
+		queue.Scope{
+			AccountID:  md.Identifier.AccountID,
+			EnvID:      md.Identifier.WorkspaceID,
+			FunctionID: md.Identifier.WorkflowID,
+		},
 		md.Identifier.RunID,
 	)
 	return &pending, nil

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -3,6 +3,7 @@ package debugapi
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/inngest/inngest/pkg/execution/batch"
 	"github.com/inngest/inngest/pkg/execution/debounce"
 	"github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/pkg/execution/state/redis_state"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/util"
@@ -101,6 +103,76 @@ func setupDebouncer(t *testing.T, rc rueidis.Client) debounce.Debouncer {
 	deb, err := debounce.NewDebouncer(shardRegistry, shard.Name(), q)
 	require.NoError(t, err)
 	return deb
+}
+
+func TestGetQueueItemByRunIDResolvesShardFromScope(t *testing.T) {
+	defaultRC, _ := setupTestRedis(t)
+	accountRC, _ := setupTestRedis(t)
+	ctx := context.Background()
+
+	defaultShard := redis_state.NewQueueShard(
+		consts.DefaultQueueShardName,
+		redis_state.NewUnshardedClient(defaultRC, redis_state.StateDefaultKey, redis_state.QueueDefaultKey).Queue(),
+	)
+	accountShard := redis_state.NewQueueShard(
+		"account-shard",
+		redis_state.NewUnshardedClient(accountRC, redis_state.StateDefaultKey, redis_state.QueueDefaultKey).Queue(),
+	)
+
+	accountID := uuid.New()
+	envID := uuid.New()
+	functionID := uuid.New()
+	runID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	shardRegistry, err := queue.NewShardRegistry(
+		map[string]queue.QueueShard{
+			defaultShard.Name(): defaultShard,
+			accountShard.Name(): accountShard,
+		},
+		queue.WithPrimary(defaultShard),
+		queue.WithShardSelector(func(ctx context.Context, id uuid.UUID, queueName *string) (queue.QueueShard, error) {
+			if id == accountID {
+				return accountShard, nil
+			}
+			return defaultShard, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	q, err := queue.New(ctx, "debug-queue-item-test", shardRegistry)
+	require.NoError(t, err)
+
+	jobID := "run-item"
+	err = q.Enqueue(ctx, queue.Item{
+		JobID:       &jobID,
+		WorkspaceID: envID,
+		Kind:        queue.KindEdge,
+		Identifier: state.Identifier{
+			AccountID:   accountID,
+			WorkspaceID: envID,
+			WorkflowID:  functionID,
+			RunID:       runID,
+		},
+	}, time.Now(), queue.EnqueueOpts{})
+	require.NoError(t, err)
+
+	d := &debugAPI{
+		queue:  q,
+		shards: shardRegistry,
+	}
+
+	resp, err := d.GetQueueItem(ctx, &pb.QueueItemRequest{
+		RunId:      runID.String(),
+		AccountId:  accountID.String(),
+		EnvId:      envID.String(),
+		FunctionId: functionID.String(),
+	})
+	require.NoError(t, err)
+
+	var item queue.QueueItem
+	require.NoError(t, json.Unmarshal(resp.GetData(), &item))
+	require.Equal(t, runID, item.Data.Identifier.RunID)
+	require.Equal(t, functionID, item.FunctionID)
 }
 
 // TestGetBatchInfoHandler tests the debug API handler for batch info.

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -168,6 +168,7 @@ func TestGetQueueItemByRunIDResolvesShardFromScope(t *testing.T) {
 		FunctionId: functionID.String(),
 	})
 	require.NoError(t, err)
+	require.Equal(t, accountShard.Name(), resp.GetQueueShard())
 
 	var item queue.QueueItem
 	require.NoError(t, json.Unmarshal(resp.GetData(), &item))

--- a/pkg/debugapi/key_queue.go
+++ b/pkg/debugapi/key_queue.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	pb "github.com/inngest/inngest/proto/gen/debug/v1"
@@ -19,7 +20,14 @@ func (d *debugAPI) GetShadowPartition(ctx context.Context, req *pb.ShadowPartiti
 		return nil, fmt.Errorf("error finding shard: %w", err)
 	}
 
-	pt, err := d.queue.PartitionByID(ctx, shard, req.GetPartitionId())
+	scope := queue.Scope{
+		AccountID: consts.DevServerAccountID,
+		EnvID:     consts.DevServerEnvID,
+	}
+	if fnID, parseErr := uuid.Parse(req.GetPartitionId()); parseErr == nil {
+		scope.FunctionID = fnID
+	}
+	pt, err := d.queue.PartitionByID(ctx, shard, scope, req.GetPartitionId())
 	if err != nil {
 		if errors.Is(err, queue.ErrPartitionNotFound) {
 			return nil, status.Error(codes.NotFound, queue.ErrPartitionNotFound.Error())

--- a/pkg/debugapi/queue_item.go
+++ b/pkg/debugapi/queue_item.go
@@ -15,17 +15,17 @@ import (
 )
 
 func (d *debugAPI) GetQueueItem(ctx context.Context, req *pb.QueueItemRequest) (*pb.QueueItemResponse, error) {
-	shardName := consts.DefaultQueueShardName
-	if req.QueueShard != "" {
-		shardName = req.QueueShard
-	}
-
-	shard, err := d.shards.ByName(shardName)
-	if err != nil {
-		return nil, fmt.Errorf("could not find queue shard %q", shardName)
-	}
-
 	if itemID := req.GetItemId(); itemID != "" {
+		shardName := consts.DefaultQueueShardName
+		if req.QueueShard != "" {
+			shardName = req.QueueShard
+		}
+
+		shard, err := d.shards.ByName(shardName)
+		if err != nil {
+			return nil, fmt.Errorf("could not find queue shard %q", shardName)
+		}
+
 		queueItem, err := d.queue.LoadQueueItem(ctx, shard.Name(), itemID)
 		if err != nil {
 			if errors.Is(err, queue.ErrQueueItemNotFound) {
@@ -55,6 +55,19 @@ func (d *debugAPI) GetQueueItem(ctx context.Context, req *pb.QueueItemRequest) (
 	scope, err := debugScope(req.GetFunctionId(), req.GetAccountId(), req.GetEnvId())
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	var shard queue.QueueShard
+	if req.QueueShard != "" {
+		shard, err = d.shards.ByName(req.QueueShard)
+		if err != nil {
+			return nil, fmt.Errorf("could not find queue shard %q", req.QueueShard)
+		}
+	} else {
+		shard, err = d.shards.Resolve(ctx, scope.AccountID, nil)
+		if err != nil {
+			return nil, fmt.Errorf("could not resolve queue shard for account %q: %w", scope.AccountID, err)
+		}
 	}
 
 	items, err := d.queue.ItemsByRunID(ctx, shard, scope, runID)

--- a/pkg/debugapi/queue_item.go
+++ b/pkg/debugapi/queue_item.go
@@ -51,10 +51,13 @@ func (d *debugAPI) GetQueueItem(ctx context.Context, req *pb.QueueItemRequest) (
 		}
 		runID = id
 	}
-	items, err := d.queue.ItemsByRunID(ctx, shard, queue.Scope{
-		AccountID: consts.DevServerAccountID,
-		EnvID:     consts.DevServerEnvID,
-	}, runID)
+
+	scope, err := debugScope(req.GetFunctionId(), req.GetAccountId(), req.GetEnvId())
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	items, err := d.queue.ItemsByRunID(ctx, shard, scope, runID)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Errorf("error retrieving queue items by runID: %w", err).Error())
 	}

--- a/pkg/debugapi/queue_item.go
+++ b/pkg/debugapi/queue_item.go
@@ -51,7 +51,10 @@ func (d *debugAPI) GetQueueItem(ctx context.Context, req *pb.QueueItemRequest) (
 		}
 		runID = id
 	}
-	items, err := d.queue.ItemsByRunID(ctx, shard, runID)
+	items, err := d.queue.ItemsByRunID(ctx, shard, queue.Scope{
+		AccountID: consts.DevServerAccountID,
+		EnvID:     consts.DevServerEnvID,
+	}, runID)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Errorf("error retrieving queue items by runID: %w", err).Error())
 	}

--- a/pkg/debugapi/queue_item.go
+++ b/pkg/debugapi/queue_item.go
@@ -39,7 +39,10 @@ func (d *debugAPI) GetQueueItem(ctx context.Context, req *pb.QueueItemRequest) (
 			return nil, status.Error(codes.Internal, fmt.Errorf("error marshalling queue item: %w", err).Error())
 		}
 
-		return &pb.QueueItemResponse{Data: byt}, nil
+		return &pb.QueueItemResponse{
+			Data:       byt,
+			QueueShard: shard.Name(),
+		}, nil
 	}
 
 	// use runID
@@ -86,6 +89,7 @@ func (d *debugAPI) GetQueueItem(ctx context.Context, req *pb.QueueItemRequest) (
 	}
 
 	return &pb.QueueItemResponse{
-		Data: byt,
+		Data:       byt,
+		QueueShard: shard.Name(),
 	}, nil
 }

--- a/pkg/debugapi/queue_partition.go
+++ b/pkg/debugapi/queue_partition.go
@@ -47,7 +47,7 @@ func (d *debugAPI) GetPartition(ctx context.Context, req *pb.PartitionRequest) (
 
 	var cronSchedules []*pb.CronSchedule
 	for _, cronExpr := range conf.ScheduleExpressions() {
-		if healthCheckStatus, err := d.croner.HealthCheck(ctx, fn.ID, cronExpr, conf.FunctionVersion); err == nil {
+		if healthCheckStatus, err := d.croner.HealthCheck(ctx, consts.DevServerAccountID, consts.DevServerEnvID, fn.ID, cronExpr, conf.FunctionVersion); err == nil {
 			cronSchedules = append(cronSchedules, &pb.CronSchedule{
 				Next:      timestamppb.New(healthCheckStatus.Next),
 				JobId:     healthCheckStatus.JobID,
@@ -85,7 +85,14 @@ func (d *debugAPI) GetPartitionStatus(ctx context.Context, req *pb.PartitionRequ
 		return nil, fmt.Errorf("error finding shard for GetPartition: %w", err)
 	}
 
-	pt, err := d.queue.PartitionByID(ctx, shard, req.GetId())
+	scope := queue.Scope{
+		AccountID: consts.DevServerAccountID,
+		EnvID:     consts.DevServerEnvID,
+	}
+	if fnID, parseErr := uuid.Parse(req.GetId()); parseErr == nil {
+		scope.FunctionID = fnID
+	}
+	pt, err := d.queue.PartitionByID(ctx, shard, scope, req.GetId())
 	if err != nil {
 		if errors.Is(err, queue.ErrPartitionNotFound) {
 			return nil, status.Error(codes.NotFound, queue.ErrPartitionNotFound.Error())

--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -611,7 +611,11 @@ func (c checkpointer) checkpointAsyncSteps(ctx context.Context, input AsyncCheck
 		return nil
 	}
 
-	if err := c.Queue.ResetAttemptsByJobID(ctx, ref.ShardID(), ref.JobID()); err != nil {
+	if err := c.Queue.ResetAttemptsByJobID(ctx, ref.ShardID(), queue.Scope{
+		AccountID:  md.ID.Tenant.AccountID,
+		EnvID:      md.ID.Tenant.EnvID,
+		FunctionID: md.ID.FunctionID,
+	}, ref.JobID()); err != nil {
 		l.Error("error resetting queue item attempts", "error", err)
 		return err
 	}

--- a/pkg/execution/checkpoint/checkpoint_async_test.go
+++ b/pkg/execution/checkpoint/checkpoint_async_test.go
@@ -72,7 +72,7 @@ func TestCheckpointAsyncSteps(t *testing.T) {
 		// Expect queue reset to be called with the job ID and shard info.
 		// Without this, a failed queue item that becomes successful will
 		// have an attempt count > 0 on the next retry.
-		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", "job-123").Return(nil)
+		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", testData.scope, "job-123").Return(nil)
 
 		err := testData.checkpointer.CheckpointAsyncSteps(ctx, testData.asyncCheckpoint)
 		require.NoError(err)
@@ -91,7 +91,7 @@ func TestCheckpointAsyncSteps(t *testing.T) {
 			require.EqualValues("Completed", capture.attributes.Get(meta.Attrs.DynamicStatus.Key()).(*enums.StepStatus).String())
 		}
 
-		mocks.queue.AssertCalled(t, "ResetAttemptsByJobID", ctx, "shard-1", "job-123")
+		mocks.queue.AssertCalled(t, "ResetAttemptsByJobID", ctx, "shard-1", testData.scope, "job-123")
 
 		mocks.state.AssertExpectations(t)
 		mocks.tracer.AssertExpectations(t)
@@ -176,7 +176,7 @@ func TestCheckpointAsyncSteps(t *testing.T) {
 			On("CreateSpan", mock.Anything, mock.Anything, mock.AnythingOfType("*tracing.CreateSpanOptions")).
 			Return(&meta.SpanReference{}, nil)
 
-		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", "job-123").Return(nil)
+		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", testData.scope, "job-123").Return(nil)
 
 		err := testData.checkpointer.CheckpointAsyncSteps(ctx, testData.asyncCheckpoint)
 		require.NoError(err)
@@ -223,7 +223,7 @@ func TestCheckpointAsyncSteps(t *testing.T) {
 			On("CreateSpan", mock.Anything, meta.SpanNameStep, mock.AnythingOfType("*tracing.CreateSpanOptions")).
 			Return(&meta.SpanReference{}, nil).
 			Twice()
-		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", "job-123").Return(nil)
+		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", testData.scope, "job-123").Return(nil)
 
 		err := testData.checkpointer.CheckpointAsyncSteps(ctx, testData.asyncCheckpoint)
 		require.NoError(err)
@@ -266,7 +266,7 @@ func TestCheckpointAsyncSteps(t *testing.T) {
 			On("CreateSpan", mock.Anything, meta.SpanNameStep, mock.AnythingOfType("*tracing.CreateSpanOptions")).
 			Return(&meta.SpanReference{}, fmt.Errorf("simulated tracer outage")).
 			Once()
-		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", "job-123").Return(nil)
+		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", testData.scope, "job-123").Return(nil)
 
 		err := testData.checkpointer.CheckpointAsyncSteps(ctx, testData.asyncCheckpoint)
 		require.NoError(err, "best-effort: tracer failure must not surface to caller")
@@ -306,7 +306,7 @@ func TestCheckpointAsyncSteps(t *testing.T) {
 				d.ScheduleStatus == enums.DeferStatusAfterRun &&
 				string(d.Input) == `{"user_id":"u_123"}`
 		})).Return(nil)
-		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", "job-123").Return(nil)
+		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", testData.scope, "job-123").Return(nil)
 
 		err := testData.checkpointer.CheckpointAsyncSteps(ctx, testData.asyncCheckpoint)
 		require.NoError(err)
@@ -334,7 +334,7 @@ func TestCheckpointAsyncSteps(t *testing.T) {
 		mocks, testData := setupAsyncCheckpointTest(t, op)
 
 		mocks.state.On("SetDeferStatus", ctx, testData.metadata.ID, "step-defer", enums.DeferStatusAborted).Return(nil)
-		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", "job-123").Return(nil)
+		mocks.queue.On("ResetAttemptsByJobID", ctx, "shard-1", testData.scope, "job-123").Return(nil)
 
 		err := testData.checkpointer.CheckpointAsyncSteps(ctx, testData.asyncCheckpoint)
 		require.NoError(err)
@@ -453,6 +453,11 @@ func setupAsyncCheckpointTest(t *testing.T, ops ...state.GeneratorOpcode) (*test
 	appID := uuid.New()
 
 	// Create test metadata
+	scope := queue.Scope{
+		AccountID:  accountID,
+		EnvID:      envID,
+		FunctionID: fnID,
+	}
 	testMetadata := state.Metadata{
 		ID: state.ID{
 			RunID:      runID,
@@ -489,6 +494,7 @@ func setupAsyncCheckpointTest(t *testing.T, ops ...state.GeneratorOpcode) (*test
 
 	return mocks, &testData{
 		metadata:        testMetadata,
+		scope:           scope,
 		stepOpcodes:     ops,
 		asyncCheckpoint: asyncCheckpoint,
 		checkpointer:    checkpointer,
@@ -613,8 +619,8 @@ type mockQueue struct {
 	mock.Mock
 }
 
-func (m *mockQueue) ResetAttemptsByJobID(ctx context.Context, shardID, jobID string) error {
-	args := m.Called(ctx, shardID, jobID)
+func (m *mockQueue) ResetAttemptsByJobID(ctx context.Context, shardID string, scope queue.Scope, jobID string) error {
+	args := m.Called(ctx, shardID, scope, jobID)
 	return args.Error(0)
 }
 
@@ -651,6 +657,7 @@ type testMocks struct {
 
 type testData struct {
 	metadata        state.Metadata
+	scope           queue.Scope
 	stepOpcodes     []state.GeneratorOpcode
 	asyncCheckpoint AsyncCheckpoint
 	checkpointer    Checkpointer

--- a/pkg/execution/cron/cron.go
+++ b/pkg/execution/cron/cron.go
@@ -34,7 +34,7 @@ type CronSyncer interface {
 
 type CronHealthChecker interface {
 	// HealthCheck checks if a "cron" queue item exists in the system queue for the next expected schedule time
-	HealthCheck(ctx context.Context, functionID uuid.UUID, expr string, fnVersion int) (CronHealthCheckStatus, error)
+	HealthCheck(ctx context.Context, accountID, envID, functionID uuid.UUID, expr string, fnVersion int) (CronHealthCheckStatus, error)
 
 	// Enqueues the next periodic global cron-health-check system job
 	EnqueueNextHealthCheck(ctx context.Context) error

--- a/pkg/execution/cron/manager.go
+++ b/pkg/execution/cron/manager.go
@@ -249,7 +249,7 @@ func (c *manager) EnqueueNextHealthCheck(ctx context.Context) error {
 }
 
 // HealthCheck checks if a "cron" queue item exists system queue for the next expected schedule time
-func (c *manager) HealthCheck(ctx context.Context, functionID uuid.UUID, expr string, fnVersion int) (CronHealthCheckStatus, error) {
+func (c *manager) HealthCheck(ctx context.Context, accountID, envID, functionID uuid.UUID, expr string, fnVersion int) (CronHealthCheckStatus, error) {
 	from := time.Now()
 
 	// Get the next schedule time based on the cron expression
@@ -262,7 +262,11 @@ func (c *manager) HealthCheck(ctx context.Context, functionID uuid.UUID, expr st
 	jobID := queue.HashID(ctx, c.CronProcessJobID(next, expr, functionID, fnVersion))
 
 	// check if the jobID exists in the system queue.
-	exists, err := c.shard.ItemExists(ctx, jobID)
+	exists, err := c.shard.ItemExists(ctx, queue.Scope{
+		AccountID:  accountID,
+		EnvID:      envID,
+		FunctionID: functionID,
+	}, jobID)
 	if err != nil {
 		return CronHealthCheckStatus{}, fmt.Errorf("failed to check if item exits for health check: %w", err)
 	}

--- a/pkg/execution/cron/manager_test.go
+++ b/pkg/execution/cron/manager_test.go
@@ -1058,12 +1058,16 @@ func TestManager(t *testing.T) {
 	t.Run("HealthCheck", func(t *testing.T) {
 		r.FlushAll()
 
+		healthCheck := func(functionID uuid.UUID, expr string, fnVersion int) (CronHealthCheckStatus, error) {
+			return cm.HealthCheck(ctx, consts.DevServerAccountID, consts.DevServerEnvID, functionID, expr, fnVersion)
+		}
+
 		t.Run("should return next scheduled item with valid inputs", func(t *testing.T) {
 			functionID := uuid.New()
 			expr := "0 * * * *" // Every hour
 			fnVersion := 1
 
-			hc, err := cm.HealthCheck(ctx, functionID, expr, fnVersion)
+			hc, err := healthCheck(functionID, expr, fnVersion)
 			require.NoError(t, err)
 
 			// Verify Next time is set and is after now
@@ -1081,7 +1085,7 @@ func TestManager(t *testing.T) {
 			fnVersion := 1
 
 			beforeCall := time.Now()
-			hc, err := cm.HealthCheck(ctx, functionID, expr, fnVersion)
+			hc, err := healthCheck(functionID, expr, fnVersion)
 			require.NoError(t, err)
 
 			nextTime := hc.Next
@@ -1171,7 +1175,7 @@ func TestManager(t *testing.T) {
 					functionID := uuid.New()
 					fnVersion := 1
 
-					hc, err := cm.HealthCheck(ctx, functionID, tc.expression, fnVersion)
+					hc, err := healthCheck(functionID, tc.expression, fnVersion)
 					require.NoError(t, err)
 
 					nextTime := hc.Next
@@ -1202,7 +1206,7 @@ func TestManager(t *testing.T) {
 					functionID := uuid.New()
 					fnVersion := 1
 
-					hc, err := cm.HealthCheck(ctx, functionID, tc.expression, fnVersion)
+					hc, err := healthCheck(functionID, tc.expression, fnVersion)
 					assert.Error(t, err)
 					assert.Equal(t, CronHealthCheckStatus{}, hc)
 					assert.Contains(t, err.Error(), "failed to get next schedule time for health check")
@@ -1217,7 +1221,7 @@ func TestManager(t *testing.T) {
 			versions := []int{1, 2, 5, 10, 100}
 			for _, version := range versions {
 				t.Run(fmt.Sprintf("version %d", version), func(t *testing.T) {
-					hc, err := cm.HealthCheck(ctx, functionID, expr, version)
+					hc, err := healthCheck(functionID, expr, version)
 					require.NoError(t, err)
 					assert.False(t, hc.Next.IsZero())
 				})
@@ -1231,10 +1235,10 @@ func TestManager(t *testing.T) {
 			functionID1 := uuid.New()
 			functionID2 := uuid.New()
 
-			hc1, err := cm.HealthCheck(ctx, functionID1, expr, fnVersion)
+			hc1, err := healthCheck(functionID1, expr, fnVersion)
 			require.NoError(t, err)
 
-			hc2, err := cm.HealthCheck(ctx, functionID2, expr, fnVersion)
+			hc2, err := healthCheck(functionID2, expr, fnVersion)
 			require.NoError(t, err)
 
 			// Different function IDs should generate different job IDs
@@ -1245,10 +1249,10 @@ func TestManager(t *testing.T) {
 			functionID := uuid.New()
 			fnVersion := 1
 
-			hc1, err := cm.HealthCheck(ctx, functionID, "0 * * * *", fnVersion)
+			hc1, err := healthCheck(functionID, "0 * * * *", fnVersion)
 			require.NoError(t, err)
 
-			hc2, err := cm.HealthCheck(ctx, functionID, "0 0 * * *", fnVersion)
+			hc2, err := healthCheck(functionID, "0 0 * * *", fnVersion)
 			require.NoError(t, err)
 
 			// Different expressions should generate different job IDs
@@ -1260,7 +1264,7 @@ func TestManager(t *testing.T) {
 			expr := "0 * * * *"
 			fnVersion := 1
 
-			hc, err := cm.HealthCheck(ctx, functionID, expr, fnVersion)
+			hc, err := healthCheck(functionID, expr, fnVersion)
 			require.NoError(t, err)
 			// JobID should still be generated even with zero UUID
 			assert.NotEmpty(t, hc.JobID)
@@ -1272,7 +1276,7 @@ func TestManager(t *testing.T) {
 			expr := "0 * * * *"
 			fnVersion := 0
 
-			hc, err := cm.HealthCheck(ctx, functionID, expr, fnVersion)
+			hc, err := healthCheck(functionID, expr, fnVersion)
 			require.NoError(t, err)
 			// Version 0 should still work
 			assert.NotEmpty(t, hc.JobID)
@@ -1284,7 +1288,7 @@ func TestManager(t *testing.T) {
 			expr := "0 * * * *"
 			fnVersion := -1
 
-			hc, err := cm.HealthCheck(ctx, functionID, expr, fnVersion)
+			hc, err := healthCheck(functionID, expr, fnVersion)
 			require.NoError(t, err)
 			// Negative version should still work
 			assert.NotEmpty(t, hc.JobID)
@@ -1296,7 +1300,7 @@ func TestManager(t *testing.T) {
 			expr := "0 * * * *"
 			fnVersion := 1
 
-			hc, err := cm.HealthCheck(ctx, functionID, expr, fnVersion)
+			hc, err := healthCheck(functionID, expr, fnVersion)
 			require.NoError(t, err)
 
 			// Verify Next time is valid and in the future
@@ -1310,7 +1314,7 @@ func TestManager(t *testing.T) {
 			fnVersion := 1
 
 			// First check should show not scheduled
-			hc1, err := cm.HealthCheck(ctx, functionID, expr, fnVersion)
+			hc1, err := healthCheck(functionID, expr, fnVersion)
 			require.NoError(t, err)
 			assert.False(t, hc1.Scheduled)
 
@@ -1326,7 +1330,7 @@ func TestManager(t *testing.T) {
 			require.NoError(t, err)
 
 			// Now the health check should show it as scheduled
-			hc2, err := cm.HealthCheck(ctx, functionID, expr, fnVersion)
+			hc2, err := healthCheck(functionID, expr, fnVersion)
 			require.NoError(t, err)
 			assert.True(t, hc2.Scheduled)
 		})

--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -569,7 +569,7 @@ func (d debouncer) debounce(ctx context.Context, di DebounceItem, fn inngest.Fun
 
 			// Delete debounce timeout from old cluster
 			queueItemId := queue.HashID(ctx, debounceID.String())
-			if err := secondary.RemoveQueueItem(ctx, queue.KindDebounce, queueItemId); err != nil {
+			if err := secondary.RemoveQueueItem(ctx, scopeForDebounceItem(di), queue.KindDebounce, queueItemId); err != nil {
 				l.Error("could not remove queue item", "item_id", queueItemId)
 			} else {
 				l.Debug("deleted migrated debounce")
@@ -945,7 +945,7 @@ func (d debouncer) DeleteDebounce(ctx context.Context, scope queue.Scope, deboun
 
 	// Try to remove the queue item (best effort)
 	queueItemId := queue.HashID(ctx, debounceID.String())
-	_ = queueShard.RemoveQueueItem(ctx, queue.KindDebounce, queueItemId)
+	_ = queueShard.RemoveQueueItem(ctx, scope, queue.KindDebounce, queueItemId)
 
 	return &DeleteDebounceResult{
 		Deleted:    true,
@@ -976,7 +976,7 @@ func (d debouncer) DeleteDebounceByID(ctx context.Context, scope queue.Scope, de
 	// Best-effort remove timeout queue items
 	for _, id := range debounceIDs {
 		queueItemId := queue.HashID(ctx, id.String())
-		_ = queueShard.RemoveQueueItem(ctx, queue.KindDebounce, queueItemId)
+		_ = queueShard.RemoveQueueItem(ctx, scope, queue.KindDebounce, queueItemId)
 	}
 
 	return nil

--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -2308,7 +2308,7 @@ func TestDeleteDebounceByID(t *testing.T) {
 
 		// Manually remove the timeout queue item first
 		queueItemId := queue.HashID(ctx, debounceID.String())
-		err := shard.RemoveQueueItem(ctx, queue.KindDebounce, queueItemId)
+		err := shard.RemoveQueueItem(ctx, scope, queue.KindDebounce, queueItemId)
 		require.NoError(t, err)
 
 		// Verify timeout is gone

--- a/pkg/execution/deletion/delete.go
+++ b/pkg/execution/deletion/delete.go
@@ -117,7 +117,7 @@ func (d *deleteManager) DeleteQueueItem(ctx context.Context, shard queue.QueueSh
 		partition = *item.QueueName
 	}
 
-	err := shard.RemoveQueueItem(ctx, partition, item.ID)
+	err := shard.RemoveQueueItem(ctx, queue.ScopeFromQueueItem(*item), partition, item.ID)
 	if err != nil {
 		return fmt.Errorf("could not remove queue item: %w", err)
 	}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -761,7 +761,11 @@ func (e *executor) checkBacklogSizeLimit(ctx context.Context, req execution.Sche
 		return enums.SkipReasonNone, nil
 	}
 
-	scheduledSteps, err := e.queue.StatusCount(ctx, req.Function.ID, "start")
+	scheduledSteps, err := e.queue.StatusCount(ctx, queue.Scope{
+		AccountID:  req.AccountID,
+		EnvID:      req.WorkspaceID,
+		FunctionID: req.Function.ID,
+	}, "start")
 	if err != nil {
 		return enums.SkipReasonNone, fmt.Errorf("could not get scheduled step count: %w", err)
 	}

--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -312,8 +312,11 @@ func (e *executor) finalizeRemoveJobs(ctx context.Context, opts execution.Finali
 	// Find all items for the current function run.
 	jobs, err := shard.RunJobs(
 		ctx,
-		opts.Metadata.ID.Tenant.EnvID,
-		opts.Metadata.ID.FunctionID,
+		queue.Scope{
+			AccountID:  opts.Metadata.ID.Tenant.AccountID,
+			EnvID:      opts.Metadata.ID.Tenant.EnvID,
+			FunctionID: opts.Metadata.ID.FunctionID,
+		},
 		opts.Metadata.ID.RunID,
 		1000,
 		0,

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -855,7 +855,11 @@ func (s *svc) handleEagerCancelBulkRun(ctx context.Context, c cqrs.Cancellation)
 		return fmt.Errorf("error selecting shard for cancellation: %w", err)
 	}
 
-	items, err := qm.ItemsByPartition(ctx, shard, c.FunctionID.String(), from, c.StartedBefore)
+	items, err := qm.ItemsByPartition(ctx, shard, queue.Scope{
+		AccountID:  c.AccountID,
+		EnvID:      c.WorkspaceID,
+		FunctionID: c.FunctionID,
+	}, c.FunctionID.String(), from, c.StartedBefore)
 	if err != nil {
 		return fmt.Errorf("error retrieving partition items: %w", err)
 	}
@@ -929,18 +933,21 @@ func (s *svc) handleCronHealthCheck(ctx context.Context, item queue.Item) error 
 		fn := inngest.Function{}
 		_ = json.Unmarshal([]byte(cqrsFn.Config), &fn)
 
-		// Get AppID
+		accountID := consts.DevServerAccountID
+		envID := cqrsFn.EnvID
 		appID := cqrsFn.AppID
 
 		for _, cronExpr := range fn.ScheduleExpressions() {
 			fn := fn
+			accountID := accountID
+			envID := envID
 			appID := appID
 			cronExpr := cronExpr
 
 			eg.Go(func() error {
 				l := s.log.With("fnID", fn.ID, "cronExpr", cronExpr, "fnVersion", fn.FunctionVersion)
 
-				status, err := s.croner.HealthCheck(ctx, fn.ID, cronExpr, fn.FunctionVersion)
+				status, err := s.croner.HealthCheck(ctx, accountID, envID, fn.ID, cronExpr, fn.FunctionVersion)
 				if err != nil {
 					atomic.AddInt64(&errored, 1)
 					l.Error("health check failed", "err", err)
@@ -951,8 +958,8 @@ func (s *svc) handleCronHealthCheck(ctx context.Context, item queue.Item) error 
 					l.Warn("cron health check failed, re-syncing")
 					err = s.croner.Sync(ctx, cron.CronItem{
 						ID:              ulid.MustNew(ulid.Now(), rand.Reader),
-						AccountID:       consts.DevServerAccountID,
-						WorkspaceID:     consts.DevServerEnvID,
+						AccountID:       accountID,
+						WorkspaceID:     envID,
 						AppID:           appID,
 						FunctionID:      fn.ID,
 						FunctionVersion: fn.FunctionVersion,

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -64,10 +64,10 @@ type QueueManager interface {
 
 	// ResetAttemptsByJobID sets retries to zero given a single job ID.  This is important for
 	// checkpointing;  a single job becomes shared amongst many  steps.
-	ResetAttemptsByJobID(ctx context.Context, shard string, jobID string) error
+	ResetAttemptsByJobID(ctx context.Context, shard string, scope Scope, jobID string) error
 
 	// ItemsByPartition returns a queue item iterator for a function within a specific time range
-	ItemsByPartition(ctx context.Context, queueShard QueueShard, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
+	ItemsByPartition(ctx context.Context, queueShard QueueShard, scope Scope, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
 	// ItemsByBacklog returns a queue item iterator for a backlog within a specific time range
 	ItemsByBacklog(ctx context.Context, queueShard QueueShard, backlogID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
 	// BacklogsByPartition returns an iterator for the partition's backlogs
@@ -77,21 +77,21 @@ type QueueManager interface {
 	// BacklogByID retrieves a single backlog by its ID
 	BacklogByID(ctx context.Context, queueShard QueueShard, backlogID string) (*QueueBacklog, error)
 	// PartitionByID retrieves the partition by the partition ID
-	PartitionByID(ctx context.Context, queueShard QueueShard, partitionID string) (*PartitionInspectionResult, error)
+	PartitionByID(ctx context.Context, queueShard QueueShard, scope Scope, partitionID string) (*PartitionInspectionResult, error)
 	// LoadQueueItem retrieves the queue item by the item ID.
 	LoadQueueItem(ctx context.Context, shardName string, itemID string) (*QueueItem, error)
 
 	// ItemExists checks if an item with jobID exists in the queue
-	ItemExists(ctx context.Context, queueShard QueueShard, jobID string) (bool, error)
+	ItemExists(ctx context.Context, queueShard QueueShard, scope Scope, jobID string) (bool, error)
 	// ItemsByRunID retrieves all queue items via runID
 	//
 	// NOTE
 	// The queue technically shouldn't know about runIDs, so we should make this more generic with certain type of indices in the future
-	ItemsByRunID(ctx context.Context, queueShard QueueShard, runID ulid.ULID) ([]*QueueItem, error)
+	ItemsByRunID(ctx context.Context, queueShard QueueShard, scope Scope, runID ulid.ULID) ([]*QueueItem, error)
 
 	// PartitionBacklogSize returns the point in time backlog size of the partition.
 	// This will sum the size of all backlogs in that partition
-	PartitionBacklogSize(ctx context.Context, partitionID string) (int64, error)
+	PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error)
 
 	// Total queue depth of all partitions including backlog and ready state items
 	TotalSystemQueueDepth(ctx context.Context, queueShard QueueShard) (int64, error)

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -157,14 +157,6 @@ type QueueProcessor interface {
 	) (ItemLeaseConstraintCheckResult, error)
 }
 
-// Scope identifies the tenant/function namespace for queue-owned state.
-type Scope struct {
-	IsSystem   bool
-	AccountID  uuid.UUID
-	EnvID      uuid.UUID
-	FunctionID uuid.UUID
-}
-
 // SingletonOperations is the per-shard surface for singleton lock state.
 // Construct singleton clients against a shard resolved through ShardRegistry.
 type SingletonOperations interface {

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -306,15 +306,16 @@ type ShadowProcessingOperations interface {
 // InsightsOperations is the per-shard surface for queue inspection and metrics.
 type InsightsOperations interface {
 	Instrument(ctx context.Context) error
-	ItemsByPartition(ctx context.Context, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
+	ItemsByPartition(ctx context.Context, scope Scope, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
 
 	// Total queue depth of all partitions including backlog and ready state items
 	TotalSystemQueueDepth(ctx context.Context) (int64, error)
 
-	PartitionBacklogSize(ctx context.Context, partitionID string) (int64, error)
-	OutstandingJobCount(ctx context.Context, workspaceID, workflowID uuid.UUID, runID ulid.ULID) (int, error)
-	RunningCount(ctx context.Context, functionID uuid.UUID) (int64, error)
-	StatusCount(ctx context.Context, workflowID uuid.UUID, status string) (int64, error)
+	PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error)
+	OutstandingJobCount(ctx context.Context, scope Scope, runID ulid.ULID) (int, error)
+	RunningCount(ctx context.Context, scope Scope) (int64, error)
+	StatusCount(ctx context.Context, scope Scope, status string) (int64, error)
+	RunJobs(ctx context.Context, scope Scope, runID ulid.ULID, limit, offset int64) ([]JobResponse, error)
 }
 
 type ShardOperations interface {
@@ -340,12 +341,12 @@ type ShardOperations interface {
 
 	Scavenge(ctx context.Context, limit int) (int, error)
 
-	RemoveQueueItem(ctx context.Context, partitionID string, itemID string) error
+	RemoveQueueItem(ctx context.Context, scope Scope, partitionID string, itemID string) error
 
-	SetFunctionMigrate(ctx context.Context, fnID uuid.UUID, migrateLockUntil *time.Time) error
-	ResetAttemptsByJobID(ctx context.Context, jobID string) error
+	SetFunctionMigrate(ctx context.Context, scope Scope, migrateLockUntil *time.Time) error
+	ResetAttemptsByJobID(ctx context.Context, scope Scope, jobID string) error
 
-	PartitionSize(ctx context.Context, partitionID string, until time.Time) (int64, error)
+	PartitionSize(ctx context.Context, scope Scope, partitionID string, until time.Time) (int64, error)
 
 	ConfigLease(ctx context.Context, key string, duration time.Duration, existingLeaseID ...*ulid.ULID) (*ulid.ULID, error)
 	ShardLease(ctx context.Context, key string, duration time.Duration, maxLeases int, existingLeaseID ...*ulid.ULID) (*ulid.ULID, error)
@@ -353,15 +354,13 @@ type ShardOperations interface {
 
 	LoadQueueItem(ctx context.Context, itemID string) (*QueueItem, error)
 
-	IsMigrationLocked(ctx context.Context, fnID uuid.UUID) (*time.Time, error)
+	IsMigrationLocked(ctx context.Context, scope Scope) (*time.Time, error)
 
-	ItemExists(ctx context.Context, jobID string) (bool, error)
-	ItemsByRunID(ctx context.Context, runID ulid.ULID) ([]*QueueItem, error)
-	PartitionByID(ctx context.Context, partitionID string) (*PartitionInspectionResult, error)
+	ItemExists(ctx context.Context, scope Scope, jobID string) (bool, error)
+	ItemsByRunID(ctx context.Context, scope Scope, runID ulid.ULID) ([]*QueueItem, error)
+	PartitionByID(ctx context.Context, scope Scope, partitionID string) (*PartitionInspectionResult, error)
 
-	UnpauseFunction(ctx context.Context, acctID, envID, fnID uuid.UUID) error
-
-	RunJobs(ctx context.Context, workspaceID, workflowID uuid.UUID, runID ulid.ULID, limit, offset int64) ([]JobResponse, error)
+	UnpauseFunction(ctx context.Context, scope Scope) error
 }
 
 type BacklogRefillOptions struct {

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -68,18 +68,6 @@ func GenerationIDFromContext(ctx context.Context) int {
 	return v
 }
 
-func ScopeFromQueueItem(i QueueItem) Scope {
-	scope := Scope{
-		AccountID:  i.Data.Identifier.AccountID,
-		EnvID:      i.Data.Identifier.WorkspaceID,
-		FunctionID: i.FunctionID,
-	}
-	if i.QueueName != nil {
-		scope.IsSystem = true
-	}
-	return scope
-}
-
 // QueueItem represents an individually queued work scheduled for some time in the
 // future.
 type QueueItem struct {

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -68,6 +68,18 @@ func GenerationIDFromContext(ctx context.Context) int {
 	return v
 }
 
+func ScopeFromQueueItem(i QueueItem) Scope {
+	scope := Scope{
+		AccountID:  i.Data.Identifier.AccountID,
+		EnvID:      i.Data.Identifier.WorkspaceID,
+		FunctionID: i.FunctionID,
+	}
+	if i.QueueName != nil {
+		scope.IsSystem = true
+	}
+	return scope
+}
+
 // QueueItem represents an individually queued work scheduled for some time in the
 // future.
 type QueueItem struct {

--- a/pkg/execution/queue/migrate.go
+++ b/pkg/execution/queue/migrate.go
@@ -7,14 +7,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/telemetry/redis_telemetry"
 	"github.com/redis/rueidis"
 	"golang.org/x/sync/errgroup"
 )
 
-func (q *queueProcessor) Migrate(ctx context.Context, sourceShardName string, fnID uuid.UUID, limit int64, concurrency int, handler QueueMigrationHandler) (int64, error) {
+func (q *queueProcessor) Migrate(ctx context.Context, sourceShardName string, scope Scope, limit int64, concurrency int, handler QueueMigrationHandler) (int64, error) {
 	l := logger.StdlibLogger(ctx)
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "MigrationPeek"), redis_telemetry.ScopeQueue)
 
@@ -26,7 +25,7 @@ func (q *queueProcessor) Migrate(ctx context.Context, sourceShardName string, fn
 	from := time.Time{}
 	// setting it to 5 years ahead should be enough to cover all queue items in the partition
 	until := q.Clock().Now().Add(24 * time.Hour * 365 * 5)
-	items, err := shard.ItemsByPartition(ctx, fnID.String(), from, until,
+	items, err := shard.ItemsByPartition(ctx, scope, scope.FunctionID.String(), from, until,
 		WithQueueItemIterBatchSize(limit),
 	)
 	if err != nil {

--- a/pkg/execution/queue/peek_size.go
+++ b/pkg/execution/queue/peek_size.go
@@ -82,7 +82,11 @@ func (q *queueProcessor) ewmaPeekSize(ctx context.Context, p *QueuePartition) in
 	}
 
 	dur := time.Hour * 24
-	qsize, _ := shard.PartitionSize(ctx, p.ID, q.Clock().Now().Add(dur))
+	qsize, _ := shard.PartitionSize(ctx, Scope{
+		AccountID:  p.AccountID,
+		EnvID:      *p.EnvID,
+		FunctionID: *p.FunctionID,
+	}, p.ID, q.Clock().Now().Add(dur))
 	if qsize > size {
 		size = qsize
 	}

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/VividCortex/ewma"
-	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/jonboulle/clockwork"
@@ -224,8 +223,8 @@ func (q *queueProcessor) Dequeue(ctx context.Context, shard QueueShard, i QueueI
 }
 
 // ItemExists implements QueueManager.
-func (q *queueProcessor) ItemExists(ctx context.Context, shard QueueShard, jobID string) (bool, error) {
-	return shard.ItemExists(ctx, jobID)
+func (q *queueProcessor) ItemExists(ctx context.Context, shard QueueShard, scope Scope, jobID string) (bool, error) {
+	return shard.ItemExists(ctx, scope, jobID)
 }
 
 // ItemsByBacklog implements QueueManager.
@@ -234,13 +233,13 @@ func (q *queueProcessor) ItemsByBacklog(ctx context.Context, shard QueueShard, b
 }
 
 // ItemsByPartition implements QueueManager.
-func (q *queueProcessor) ItemsByPartition(ctx context.Context, shard QueueShard, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error) {
-	return shard.ItemsByPartition(ctx, partitionID, from, until, opts...)
+func (q *queueProcessor) ItemsByPartition(ctx context.Context, shard QueueShard, scope Scope, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error) {
+	return shard.ItemsByPartition(ctx, scope, partitionID, from, until, opts...)
 }
 
 // ItemsByRunID implements QueueManager.
-func (q *queueProcessor) ItemsByRunID(ctx context.Context, shard QueueShard, runID ulid.ULID) ([]*QueueItem, error) {
-	return shard.ItemsByRunID(ctx, runID)
+func (q *queueProcessor) ItemsByRunID(ctx context.Context, shard QueueShard, scope Scope, runID ulid.ULID) ([]*QueueItem, error) {
+	return shard.ItemsByRunID(ctx, scope, runID)
 }
 
 // LoadQueueItem implements QueueManager.
@@ -254,11 +253,11 @@ func (q *queueProcessor) LoadQueueItem(ctx context.Context, shardName string, it
 }
 
 // PartitionBacklogSize implements QueueManager.
-func (q *queueProcessor) PartitionBacklogSize(ctx context.Context, partitionID string) (int64, error) {
+func (q *queueProcessor) PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error) {
 	var totalCount int64
 
 	err := q.shards.ForEach(ctx, func(ctx context.Context, shard QueueShard) error {
-		backlogSize, err := shard.PartitionBacklogSize(ctx, partitionID)
+		backlogSize, err := shard.PartitionBacklogSize(ctx, scope, partitionID)
 		if err != nil {
 			return fmt.Errorf("could not load partition backlog size: %w", err)
 		}
@@ -274,18 +273,18 @@ func (q *queueProcessor) PartitionBacklogSize(ctx context.Context, partitionID s
 }
 
 // PartitionByID implements QueueManager.
-func (q *queueProcessor) PartitionByID(ctx context.Context, shard QueueShard, partitionID string) (*PartitionInspectionResult, error) {
-	return shard.PartitionByID(ctx, partitionID)
+func (q *queueProcessor) PartitionByID(ctx context.Context, shard QueueShard, scope Scope, partitionID string) (*PartitionInspectionResult, error) {
+	return shard.PartitionByID(ctx, scope, partitionID)
 }
 
 // RemoveQueueItem implements QueueManager.
-func (q *queueProcessor) RemoveQueueItem(ctx context.Context, shardName string, partitionID string, itemID string) error {
+func (q *queueProcessor) RemoveQueueItem(ctx context.Context, shardName string, scope Scope, partitionID string, itemID string) error {
 	shard, err := q.shards.ByName(shardName)
 	if err != nil {
 		return err
 	}
 
-	return shard.RemoveQueueItem(ctx, partitionID, itemID)
+	return shard.RemoveQueueItem(ctx, scope, partitionID, itemID)
 }
 
 // Requeue implements QueueManager.
@@ -304,11 +303,11 @@ func (q *queueProcessor) TotalSystemQueueDepth(ctx context.Context, shard QueueS
 }
 
 // OutstandingJobCount implements Queue.
-func (q *queueProcessor) OutstandingJobCount(ctx context.Context, envID uuid.UUID, fnID uuid.UUID, runID ulid.ULID) (int, error) {
+func (q *queueProcessor) OutstandingJobCount(ctx context.Context, scope Scope, runID ulid.ULID) (int, error) {
 	var totalCount int64
 
 	err := q.shards.ForEach(ctx, func(ctx context.Context, shard QueueShard) error {
-		outstanding, err := shard.OutstandingJobCount(ctx, envID, fnID, runID)
+		outstanding, err := shard.OutstandingJobCount(ctx, scope, runID)
 		if err != nil {
 			return fmt.Errorf("could not load outstanding job count: %w", err)
 		}
@@ -322,21 +321,21 @@ func (q *queueProcessor) OutstandingJobCount(ctx context.Context, envID uuid.UUI
 }
 
 // RunJobs implements Queue.
-func (q *queueProcessor) RunJobs(ctx context.Context, shardName string, workspaceID uuid.UUID, workflowID uuid.UUID, runID ulid.ULID, limit int64, offset int64) ([]JobResponse, error) {
+func (q *queueProcessor) RunJobs(ctx context.Context, shardName string, scope Scope, runID ulid.ULID, limit int64, offset int64) ([]JobResponse, error) {
 	shard, err := q.shards.ByName(shardName)
 	if err != nil {
 		return nil, err
 	}
 
-	return shard.RunJobs(ctx, workspaceID, workflowID, runID, limit, offset)
+	return shard.RunJobs(ctx, scope, runID, limit, offset)
 }
 
 // RunningCount implements Queue.
-func (q *queueProcessor) RunningCount(ctx context.Context, workflowID uuid.UUID) (int64, error) {
+func (q *queueProcessor) RunningCount(ctx context.Context, scope Scope) (int64, error) {
 	var totalCount int64
 
 	err := q.shards.ForEach(ctx, func(ctx context.Context, shard QueueShard) error {
-		running, err := shard.RunningCount(ctx, workflowID)
+		running, err := shard.RunningCount(ctx, scope)
 		if err != nil {
 			return fmt.Errorf("could not load running count: %w", err)
 		}
@@ -350,11 +349,11 @@ func (q *queueProcessor) RunningCount(ctx context.Context, workflowID uuid.UUID)
 }
 
 // StatusCount implements Queue.
-func (q *queueProcessor) StatusCount(ctx context.Context, workflowID uuid.UUID, status string) (int64, error) {
+func (q *queueProcessor) StatusCount(ctx context.Context, scope Scope, status string) (int64, error) {
 	var totalCount int64
 
 	err := q.shards.ForEach(ctx, func(ctx context.Context, shard QueueShard) error {
-		running, err := shard.StatusCount(ctx, workflowID, status)
+		running, err := shard.StatusCount(ctx, scope, status)
 		if err != nil {
 			return fmt.Errorf("could not load status count: %w", err)
 		}
@@ -368,13 +367,13 @@ func (q *queueProcessor) StatusCount(ctx context.Context, workflowID uuid.UUID, 
 }
 
 // ResetAttemptsByJobID implements Queue.
-func (q *queueProcessor) ResetAttemptsByJobID(ctx context.Context, shardName string, jobID string) error {
+func (q *queueProcessor) ResetAttemptsByJobID(ctx context.Context, shardName string, scope Scope, jobID string) error {
 	shard, err := q.shards.ByName(shardName)
 	if err != nil {
 		return err
 	}
 
-	return shard.ResetAttemptsByJobID(ctx, jobID)
+	return shard.ResetAttemptsByJobID(ctx, scope, jobID)
 }
 
 func (q *queueProcessor) Run(ctx context.Context, f RunFunc) error {
@@ -425,22 +424,22 @@ func (q *queueProcessor) Run(ctx context.Context, f RunFunc) error {
 }
 
 // SetFunctionMigrate implements Queue.
-func (q *queueProcessor) SetFunctionMigrate(ctx context.Context, sourceShard string, fnID uuid.UUID, migrateLockUntil *time.Time) error {
+func (q *queueProcessor) SetFunctionMigrate(ctx context.Context, sourceShard string, scope Scope, migrateLockUntil *time.Time) error {
 	shard, err := q.shards.ByName(sourceShard)
 	if err != nil {
 		return fmt.Errorf("could not find shard %q", sourceShard)
 	}
 
-	return shard.SetFunctionMigrate(ctx, fnID, migrateLockUntil)
+	return shard.SetFunctionMigrate(ctx, scope, migrateLockUntil)
 }
 
 // UnpauseFunction implements Queue.
-func (q *queueProcessor) UnpauseFunction(ctx context.Context, shardName string, acctID uuid.UUID, envID, fnID uuid.UUID) error {
+func (q *queueProcessor) UnpauseFunction(ctx context.Context, shardName string, scope Scope) error {
 	shard, err := q.shards.ByName(shardName)
 	if err != nil {
 		return err
 	}
-	return shard.UnpauseFunction(ctx, acctID, envID, fnID)
+	return shard.UnpauseFunction(ctx, scope)
 }
 
 func (q *queueProcessor) capacity() int64 {

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -140,7 +140,7 @@ func (m *mockShardForIterator) Instrument(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockShardForIterator) ItemsByPartition(ctx context.Context, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error) {
+func (m *mockShardForIterator) ItemsByPartition(ctx context.Context, scope Scope, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error) {
 	return nil, nil
 }
 
@@ -148,11 +148,11 @@ func (m *mockShardForIterator) ItemsByBacklog(ctx context.Context, backlogID str
 	return nil, nil
 }
 
-func (m *mockShardForIterator) SetFunctionMigrate(ctx context.Context, fnID uuid.UUID, migrateLockUntil *time.Time) error {
+func (m *mockShardForIterator) SetFunctionMigrate(ctx context.Context, scope Scope, migrateLockUntil *time.Time) error {
 	return nil
 }
 
-func (m *mockShardForIterator) ResetAttemptsByJobID(ctx context.Context, jobID string) error {
+func (m *mockShardForIterator) ResetAttemptsByJobID(ctx context.Context, scope Scope, jobID string) error {
 	return nil
 }
 
@@ -164,7 +164,7 @@ func (m *mockShardForIterator) SetPeekEWMA(ctx context.Context, fnID *uuid.UUID,
 	return nil
 }
 
-func (m *mockShardForIterator) PartitionSize(ctx context.Context, partitionID string, until time.Time) (int64, error) {
+func (m *mockShardForIterator) PartitionSize(ctx context.Context, scope Scope, partitionID string, until time.Time) (int64, error) {
 	return 0, nil
 }
 
@@ -236,7 +236,7 @@ func (m *mockShardForIterator) BacklogRefillConstraintCheck(ctx context.Context,
 	return nil, nil
 }
 
-func (m *mockShardForIterator) RemoveQueueItem(ctx context.Context, partitionID string, itemID string) error {
+func (m *mockShardForIterator) RemoveQueueItem(ctx context.Context, scope Scope, partitionID string, itemID string) error {
 	return nil
 }
 
@@ -320,7 +320,7 @@ func (m *mockShardForIterator) PeekShadowPartitions(ctx context.Context, account
 	return nil, nil
 }
 
-func (m *mockShardForIterator) IsMigrationLocked(ctx context.Context, fnID uuid.UUID) (*time.Time, error) {
+func (m *mockShardForIterator) IsMigrationLocked(ctx context.Context, scope Scope) (*time.Time, error) {
 	return nil, nil
 }
 
@@ -332,39 +332,39 @@ func (m *mockShardForIterator) DequeueByJobID(ctx context.Context, jobID string)
 	return nil
 }
 
-func (m *mockShardForIterator) ItemExists(ctx context.Context, jobID string) (bool, error) {
+func (m *mockShardForIterator) ItemExists(ctx context.Context, scope Scope, jobID string) (bool, error) {
 	return false, nil
 }
 
-func (m *mockShardForIterator) ItemsByRunID(ctx context.Context, runID ulid.ULID) ([]*QueueItem, error) {
+func (m *mockShardForIterator) ItemsByRunID(ctx context.Context, scope Scope, runID ulid.ULID) ([]*QueueItem, error) {
 	return nil, nil
 }
 
-func (m *mockShardForIterator) PartitionBacklogSize(ctx context.Context, partitionID string) (int64, error) {
+func (m *mockShardForIterator) PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error) {
 	return 0, nil
 }
 
-func (m *mockShardForIterator) PartitionByID(ctx context.Context, partitionID string) (*PartitionInspectionResult, error) {
+func (m *mockShardForIterator) PartitionByID(ctx context.Context, scope Scope, partitionID string) (*PartitionInspectionResult, error) {
 	return nil, nil
 }
 
-func (m *mockShardForIterator) UnpauseFunction(ctx context.Context, acctID, envID, fnID uuid.UUID) error {
+func (m *mockShardForIterator) UnpauseFunction(ctx context.Context, scope Scope) error {
 	return nil
 }
 
-func (m *mockShardForIterator) OutstandingJobCount(ctx context.Context, workspaceID, workflowID uuid.UUID, runID ulid.ULID) (int, error) {
+func (m *mockShardForIterator) OutstandingJobCount(ctx context.Context, scope Scope, runID ulid.ULID) (int, error) {
 	return 0, nil
 }
 
-func (m *mockShardForIterator) RunningCount(ctx context.Context, functionID uuid.UUID) (int64, error) {
+func (m *mockShardForIterator) RunningCount(ctx context.Context, scope Scope) (int64, error) {
 	return 0, nil
 }
 
-func (m *mockShardForIterator) StatusCount(ctx context.Context, workflowID uuid.UUID, status string) (int64, error) {
+func (m *mockShardForIterator) StatusCount(ctx context.Context, scope Scope, status string) (int64, error) {
 	return 0, nil
 }
 
-func (m *mockShardForIterator) RunJobs(ctx context.Context, workspaceID, workflowID uuid.UUID, runID ulid.ULID, limit, offset int64) ([]JobResponse, error) {
+func (m *mockShardForIterator) RunJobs(ctx context.Context, scope Scope, runID ulid.ULID, limit, offset int64) ([]JobResponse, error) {
 	return nil, nil
 }
 

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -243,6 +243,7 @@ type JobQueueReader interface {
 // MigratePayload stores the information to be used when migrating a queue shard to another one
 type MigratePayload struct {
 	AccountID  uuid.UUID
+	EnvID      uuid.UUID
 	FunctionID uuid.UUID
 
 	// Source is the source queue where the migration will occur on
@@ -256,4 +257,12 @@ type MigratePayload struct {
 
 	// Concurrency optionally specifies the concurrency for running the migrate handler over each batch of queue items.
 	Concurrency int
+}
+
+func (p MigratePayload) Scope() Scope {
+	return Scope{
+		AccountID:  p.AccountID,
+		EnvID:      p.EnvID,
+		FunctionID: p.FunctionID,
+	}
 }

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -85,19 +85,19 @@ type QueueMigrationHandler func(ctx context.Context, qi *QueueItem) error
 type Migrator interface {
 	// SetFunctionMigrate updates the function metadata to signal it's being migrated to
 	// another queue shard
-	SetFunctionMigrate(ctx context.Context, sourceShard string, fnID uuid.UUID, migrateLockUntil *time.Time) error
+	SetFunctionMigrate(ctx context.Context, sourceShard string, scope Scope, migrateLockUntil *time.Time) error
 	// Migration does a peek operation like the normal peek, but ignores leases and other conditions a normal peek cares about.
 	// The sore goal is to grab things and migrate them to somewhere else
-	Migrate(ctx context.Context, shard string, fnID uuid.UUID, limit int64, concurrency int, handler QueueMigrationHandler) (int64, error)
+	Migrate(ctx context.Context, shard string, scope Scope, limit int64, concurrency int, handler QueueMigrationHandler) (int64, error)
 }
 
 type Unpauser interface {
-	UnpauseFunction(ctx context.Context, shard string, acctID, envID, fnID uuid.UUID) error
+	UnpauseFunction(ctx context.Context, shard string, scope Scope) error
 }
 
 // AttemptResetter resets queue item attempts after a successful checkpoint.
 type AttemptResetter interface {
-	ResetAttemptsByJobID(ctx context.Context, shard string, jobID string) error
+	ResetAttemptsByJobID(ctx context.Context, shard string, scope Scope, jobID string) error
 }
 
 // QuitError is an error that, when returned, quits the queue.  This always retries
@@ -227,17 +227,17 @@ type JobResponse struct {
 type JobQueueReader interface {
 	// OutstandingJobCount returns the number of jobs in progress
 	// or scheduled for a given run.
-	OutstandingJobCount(ctx context.Context, envID uuid.UUID, fnID uuid.UUID, runID ulid.ULID) (int, error)
+	OutstandingJobCount(ctx context.Context, scope Scope, runID ulid.ULID) (int, error)
 
 	// RunningCount returns the number of running (in-progress) jobs for a given function
-	RunningCount(ctx context.Context, workflowID uuid.UUID) (int64, error)
+	RunningCount(ctx context.Context, scope Scope) (int64, error)
 
 	// StatusCount returns the total number of items in the function
 	// status queue.
-	StatusCount(ctx context.Context, workflowID uuid.UUID, status string) (int64, error)
+	StatusCount(ctx context.Context, scope Scope, status string) (int64, error)
 
 	// RunJobs reads items in the queue for a specific run.
-	RunJobs(ctx context.Context, queueShardName string, workspaceID uuid.UUID, workflowID uuid.UUID, runID ulid.ULID, limit, offset int64) ([]JobResponse, error)
+	RunJobs(ctx context.Context, queueShardName string, scope Scope, runID ulid.ULID, limit, offset int64) ([]JobResponse, error)
 }
 
 // MigratePayload stores the information to be used when migrating a queue shard to another one

--- a/pkg/execution/queue/queue_test.go
+++ b/pkg/execution/queue/queue_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -76,4 +77,19 @@ func TestAsRetryAt(t *testing.T) {
 	require.NotNil(t, AsRetryAtError(base))
 	require.NotNil(t, AsRetryAtError(wrapped))
 	require.Nil(t, AsRetryAtError(fmt.Errorf("no")))
+}
+
+func TestMigratePayloadScope(t *testing.T) {
+	payload := MigratePayload{
+		AccountID:  uuid.New(),
+		EnvID:      uuid.New(),
+		FunctionID: uuid.New(),
+	}
+
+	require.Equal(t, Scope{
+		AccountID:  payload.AccountID,
+		EnvID:      payload.EnvID,
+		FunctionID: payload.FunctionID,
+	}, payload.Scope())
+	require.NoError(t, payload.Scope().Validate())
 }

--- a/pkg/execution/queue/scope.go
+++ b/pkg/execution/queue/scope.go
@@ -6,6 +6,14 @@ import (
 	"github.com/google/uuid"
 )
 
+// Scope identifies the tenant/function namespace for queue-owned state.
+type Scope struct {
+	IsSystem   bool
+	AccountID  uuid.UUID
+	EnvID      uuid.UUID
+	FunctionID uuid.UUID
+}
+
 func (s Scope) Validate() error {
 	if s.IsSystem {
 		return nil
@@ -20,4 +28,30 @@ func (s Scope) Validate() error {
 		return fmt.Errorf("missing function ID")
 	}
 	return nil
+}
+
+func ScopeFromQueueItem(i QueueItem) Scope {
+	scope := Scope{
+		AccountID:  i.Data.Identifier.AccountID,
+		EnvID:      i.Data.Identifier.WorkspaceID,
+		FunctionID: i.FunctionID,
+	}
+	if i.QueueName != nil {
+		scope.IsSystem = true
+	}
+	return scope
+}
+
+func ScopeFromQueuePartition(partition *QueuePartition) Scope {
+	scope := Scope{AccountID: partition.AccountID}
+	if partition.EnvID != nil {
+		scope.EnvID = *partition.EnvID
+	}
+	if partition.FunctionID != nil {
+		scope.FunctionID = *partition.FunctionID
+	}
+	if partition.QueueName != nil {
+		scope.IsSystem = true
+	}
+	return scope
 }

--- a/pkg/execution/queue/shadow_process.go
+++ b/pkg/execution/queue/shadow_process.go
@@ -33,8 +33,12 @@ func (q *queueProcessor) ProcessShadowPartition(ctx context.Context, shadowPart 
 	defer metrics.ActiveShadowScannerCount(ctx, -1, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": shard.Name()}})
 
 	// Check if shadow partition cannot be processed (paused/refill disabled, etc.)
-	if shadowPart.FunctionID != nil {
-		lockedUntil, err := shard.IsMigrationLocked(ctx, *shadowPart.FunctionID)
+	if shadowPart.FunctionID != nil && shadowPart.AccountID != nil && shadowPart.EnvID != nil {
+		lockedUntil, err := shard.IsMigrationLocked(ctx, Scope{
+			AccountID:  *shadowPart.AccountID,
+			EnvID:      *shadowPart.EnvID,
+			FunctionID: *shadowPart.FunctionID,
+		})
 		if err != nil {
 			return fmt.Errorf("could not check for migration lock: %w", err)
 		}

--- a/pkg/execution/state/redis_state/backlog.go
+++ b/pkg/execution/state/redis_state/backlog.go
@@ -455,7 +455,7 @@ func (q *queue) BacklogsByPartition(ctx context.Context, partitionID string, fro
 	}, nil
 }
 
-func (q *queue) PartitionBacklogSize(ctx context.Context, partitionID string) (int64, error) {
+func (q *queue) PartitionBacklogSize(ctx context.Context, scope osqueue.Scope, partitionID string) (int64, error) {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "partitionBacklogSize"), redis_telemetry.ScopeQueue)
 
 	l := logger.StdlibLogger(ctx).With(

--- a/pkg/execution/state/redis_state/backlog_test.go
+++ b/pkg/execution/state/redis_state/backlog_test.go
@@ -1301,6 +1301,7 @@ func TestPartitionBacklogSize(t *testing.T) {
 	queueShards := mapFromShards(shard1, shard2)
 
 	acctId, fnID, wsID := uuid.New(), uuid.New(), uuid.New()
+	scope := osqueue.Scope{AccountID: acctId, EnvID: wsID, FunctionID: fnID}
 
 	testcases := []struct {
 		name   string
@@ -1384,11 +1385,11 @@ func TestPartitionBacklogSize(t *testing.T) {
 			}
 
 			// NOTE: should return the same result regardless of which shard initiated the instrumentation
-			size1, err := q1.PartitionBacklogSize(ctx, fnID.String())
+			size1, err := q1.PartitionBacklogSize(ctx, scope, fnID.String())
 			require.NoError(t, err)
 			require.EqualValues(t, int64(tc.num), size1)
 
-			size2, err := q2.PartitionBacklogSize(ctx, fnID.String())
+			size2, err := q2.PartitionBacklogSize(ctx, scope, fnID.String())
 			require.NoError(t, err)
 			require.EqualValues(t, int64(tc.num), size2)
 		})

--- a/pkg/execution/state/redis_state/debug.go
+++ b/pkg/execution/state/redis_state/debug.go
@@ -11,7 +11,7 @@ import (
 	osqueue "github.com/inngest/inngest/pkg/execution/queue"
 )
 
-func (q *queue) PartitionByID(ctx context.Context, partitionID string) (*osqueue.PartitionInspectionResult, error) {
+func (q *queue) PartitionByID(ctx context.Context, scope osqueue.Scope, partitionID string) (*osqueue.PartitionInspectionResult, error) {
 	var (
 		result osqueue.PartitionInspectionResult
 		qp     osqueue.QueuePartition
@@ -90,11 +90,15 @@ func (q *queue) PartitionByID(ctx context.Context, partitionID string) (*osqueue
 	}
 
 	// Fetch paused + migrating state
-	if qp.FunctionID != nil {
+	if qp.FunctionID != nil && qp.EnvID != nil {
 		paused := q.PartitionPausedGetter(ctx, *qp.FunctionID)
 		result.Paused = paused.Paused
 
-		locked, err := q.IsMigrationLocked(ctx, *qp.FunctionID)
+		locked, err := q.IsMigrationLocked(ctx, osqueue.Scope{
+			AccountID:  qp.AccountID,
+			EnvID:      *qp.EnvID,
+			FunctionID: *qp.FunctionID,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("could not get locked state: %w", err)
 		}

--- a/pkg/execution/state/redis_state/debug_test.go
+++ b/pkg/execution/state/redis_state/debug_test.go
@@ -100,7 +100,11 @@ func TestPartitionByID(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			res, err := q.PartitionByID(ctx, shard, fnID.String())
+			res, err := q.PartitionByID(ctx, shard, osqueue.Scope{
+				AccountID:  acctId,
+				EnvID:      wsID,
+				FunctionID: fnID,
+			}, fnID.String())
 			require.NoError(t, err)
 
 			// fmt.Printf("RESULT: %#v\n", res)

--- a/pkg/execution/state/redis_state/pause.go
+++ b/pkg/execution/state/redis_state/pause.go
@@ -5,19 +5,18 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/uuid"
 	osqueue "github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/logger"
 )
 
-func (q *queue) UnpauseFunction(ctx context.Context, acctID, envID, fnID uuid.UUID) error {
+func (q *queue) UnpauseFunction(ctx context.Context, scope osqueue.Scope) error {
 	l := logger.StdlibLogger(ctx)
 
 	part := &osqueue.QueuePartition{
-		ID:         fnID.String(),
-		FunctionID: &fnID,
-		AccountID:  acctID,
-		EnvID:      &envID,
+		ID:         scope.FunctionID.String(),
+		FunctionID: &scope.FunctionID,
+		AccountID:  scope.AccountID,
+		EnvID:      &scope.EnvID,
 	}
 
 	err := q.PartitionRequeue(ctx, part, q.Clock.Now(), false)
@@ -27,11 +26,11 @@ func (q *queue) UnpauseFunction(ctx context.Context, acctID, envID, fnID uuid.UU
 	}
 
 	// Also unpause shadow partition if key queues enabled
-	if q.AllowKeyQueues(ctx, acctID, envID, fnID) {
+	if q.AllowKeyQueues(ctx, scope.AccountID, scope.EnvID, scope.FunctionID) {
 		shadowPart := &osqueue.QueueShadowPartition{
-			PartitionID: fnID.String(),
-			FunctionID:  &fnID,
-			AccountID:   &acctID,
+			PartitionID: scope.FunctionID.String(),
+			FunctionID:  &scope.FunctionID,
+			AccountID:   &scope.AccountID,
 		}
 		// requeue to earliest item
 		err = q.ShadowPartitionRequeue(ctx, shadowPart, nil)

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -461,6 +461,7 @@ func (q *queue) Peek(ctx context.Context, partition *osqueue.QueuePartition, unt
 			Until:        until,
 			PartitionKey: partitionKey,
 			PartitionID:  partition.ID,
+			Scope:        scopeFromPartition(partition),
 		},
 	)
 	return result.Items, err
@@ -490,15 +491,31 @@ func (q *queue) PeekRandom(ctx context.Context, partition *osqueue.QueuePartitio
 			Until:        until,
 			PartitionKey: partitionKey,
 			PartitionID:  partition.ID,
+			Scope:        scopeFromPartition(partition),
 			Random:       true,
 		},
 	)
 	return result.Items, err
 }
 
+func scopeFromPartition(partition *osqueue.QueuePartition) osqueue.Scope {
+	scope := osqueue.Scope{AccountID: partition.AccountID}
+	if partition.EnvID != nil {
+		scope.EnvID = *partition.EnvID
+	}
+	if partition.FunctionID != nil {
+		scope.FunctionID = *partition.FunctionID
+	}
+	if partition.QueueName != nil {
+		scope.IsSystem = true
+	}
+	return scope
+}
+
 type peekOpts struct {
 	PartitionID  string
 	PartitionKey string
+	Scope        osqueue.Scope
 	Random       bool
 	From         *time.Time
 	Until        time.Time
@@ -629,7 +646,7 @@ func (q *queue) peek(ctx context.Context, opts peekOpts) (peekResult, error) {
 		for _, missingItemId := range missingQueueItems {
 			id := missingItemId
 			eg.Go(func() error {
-				return q.RemoveQueueItem(ctx, opts.PartitionID, id)
+				return q.RemoveQueueItem(ctx, opts.Scope, opts.PartitionID, id)
 			})
 		}
 

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -461,7 +461,7 @@ func (q *queue) Peek(ctx context.Context, partition *osqueue.QueuePartition, unt
 			Until:        until,
 			PartitionKey: partitionKey,
 			PartitionID:  partition.ID,
-			Scope:        scopeFromPartition(partition),
+			Scope:        osqueue.ScopeFromQueuePartition(partition),
 		},
 	)
 	return result.Items, err
@@ -491,25 +491,11 @@ func (q *queue) PeekRandom(ctx context.Context, partition *osqueue.QueuePartitio
 			Until:        until,
 			PartitionKey: partitionKey,
 			PartitionID:  partition.ID,
-			Scope:        scopeFromPartition(partition),
+			Scope:        osqueue.ScopeFromQueuePartition(partition),
 			Random:       true,
 		},
 	)
 	return result.Items, err
-}
-
-func scopeFromPartition(partition *osqueue.QueuePartition) osqueue.Scope {
-	scope := osqueue.Scope{AccountID: partition.AccountID}
-	if partition.EnvID != nil {
-		scope.EnvID = *partition.EnvID
-	}
-	if partition.FunctionID != nil {
-		scope.FunctionID = *partition.FunctionID
-	}
-	if partition.QueueName != nil {
-		scope.IsSystem = true
-	}
-	return scope
 }
 
 type peekOpts struct {

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -327,12 +327,12 @@ func (q *queue) dropPartitionPointerIfEmpty(ctx context.Context, keyIndex, keyPa
 	}
 }
 
-func (q *queue) SetFunctionMigrate(ctx context.Context, fnID uuid.UUID, migrateLockUntil *time.Time) error {
+func (q *queue) SetFunctionMigrate(ctx context.Context, scope osqueue.Scope, migrateLockUntil *time.Time) error {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "SetFunctionMigrate"), redis_telemetry.ScopeQueue)
 	client := q.RedisClient.Client()
 	kg := q.RedisClient.KeyGenerator()
 
-	key := kg.QueueMigrationLock(fnID)
+	key := kg.QueueMigrationLock(scope.FunctionID)
 	if migrateLockUntil == nil {
 		cmd := client.B().Del().Key(key).Build()
 		err := client.Do(ctx, cmd).Error()
@@ -357,7 +357,7 @@ func (q *queue) SetFunctionMigrate(ctx context.Context, fnID uuid.UUID, migrateL
 
 // removeQueueItem attempts to remove a specific item in the target queue shard
 // and also remove it from the queue item hash as well
-func (q *queue) RemoveQueueItem(ctx context.Context, partitionID string, itemID string) error {
+func (q *queue) RemoveQueueItem(ctx context.Context, scope osqueue.Scope, partitionID string, itemID string) error {
 	l := logger.StdlibLogger(ctx)
 
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "removeQueueItem"), redis_telemetry.ScopeQueue)
@@ -687,7 +687,7 @@ func (q *queue) peek(ctx context.Context, opts peekOpts) (peekResult, error) {
 	}, nil
 }
 
-func (q *queue) ResetAttemptsByJobID(ctx context.Context, jobID string) error {
+func (q *queue) ResetAttemptsByJobID(ctx context.Context, scope osqueue.Scope, jobID string) error {
 	l := logger.StdlibLogger(ctx)
 
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "ResetAttemptsByJobID"), redis_telemetry.ScopeQueue)
@@ -1146,7 +1146,7 @@ func (q *queue) PartitionPeek(ctx context.Context, sequential bool, until time.T
 	return partitions, nil
 }
 
-func (q *queue) PartitionSize(ctx context.Context, partitionID string, until time.Time) (int64, error) {
+func (q *queue) PartitionSize(ctx context.Context, scope osqueue.Scope, partitionID string, until time.Time) (int64, error) {
 	return q.partitionSize(ctx, q.RedisClient.kg.PartitionQueueSet(enums.PartitionTypeDefault, partitionID, ""), until)
 }
 

--- a/pkg/execution/state/redis_state/queue_dequeue_test.go
+++ b/pkg/execution/state/redis_state/queue_dequeue_test.go
@@ -232,15 +232,20 @@ func TestQueueDequeue(t *testing.T) {
 
 		start := time.Now()
 
+		acctID := uuid.New()
+		envID := uuid.New()
 		fnID := uuid.New()
 		runID := ulid.MustNew(ulid.Now(), rand.Reader)
+		scope := osqueue.Scope{AccountID: acctID, EnvID: envID, FunctionID: fnID}
 
 		item, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
 			FunctionID: fnID,
 			Data: osqueue.Item{
 				Identifier: state.Identifier{
-					RunID:      runID,
-					WorkflowID: fnID,
+					AccountID:   acctID,
+					WorkspaceID: envID,
+					RunID:       runID,
+					WorkflowID:  fnID,
 				},
 			},
 		}, start, osqueue.EnqueueOpts{})
@@ -252,7 +257,7 @@ func TestQueueDequeue(t *testing.T) {
 		require.NoError(t, err)
 
 		t.Run("The lease exists in the partition queue", func(t *testing.T) {
-			count, err := shard.RunningCount(ctx, *p.FunctionID)
+			count, err := shard.RunningCount(ctx, scope)
 			require.NoError(t, err)
 			require.EqualValues(t, 1, count, r.Dump())
 		})
@@ -278,7 +283,7 @@ func TestQueueDequeue(t *testing.T) {
 		})
 
 		t.Run("It should remove the item from the concurrency partition's queue", func(t *testing.T) {
-			count, err := shard.RunningCount(ctx, *p.FunctionID)
+			count, err := shard.RunningCount(ctx, scope)
 			require.NoError(t, err)
 			require.EqualValues(t, 0, count)
 		})

--- a/pkg/execution/state/redis_state/queue_lease_test.go
+++ b/pkg/execution/state/redis_state/queue_lease_test.go
@@ -44,16 +44,18 @@ func TestQueueLease(t *testing.T) {
 	start := clock.Now().Truncate(time.Second)
 
 	t.Run("It leases an item", func(t *testing.T) {
-		fnID, accountID := uuid.New(), uuid.New()
+		fnID, accountID, envID := uuid.New(), uuid.New(), uuid.New()
 		runID := ulid.MustNew(ulid.Now(), rand.Reader)
+		scope := osqueue.Scope{AccountID: accountID, EnvID: envID, FunctionID: fnID}
 
 		item, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
 			FunctionID: fnID,
 			Data: osqueue.Item{
 				Identifier: state.Identifier{
-					RunID:      runID,
-					WorkflowID: fnID,
-					AccountID:  accountID,
+					RunID:       runID,
+					WorkflowID:  fnID,
+					AccountID:   accountID,
+					WorkspaceID: envID,
 				},
 			},
 		}, start, osqueue.EnqueueOpts{})
@@ -65,6 +67,7 @@ func TestQueueLease(t *testing.T) {
 		p := osqueue.QueuePartition{
 			ID:         fnID.String(),
 			FunctionID: &fnID,
+			EnvID:      &envID,
 			AccountID:  accountID,
 		} // Default workflow ID etc
 
@@ -90,7 +93,7 @@ func TestQueueLease(t *testing.T) {
 		})
 
 		t.Run("It should add the item to the function's in-progress concurrency queue", func(t *testing.T) {
-			count, err := shard.RunningCount(ctx, fnID)
+			count, err := shard.RunningCount(ctx, scope)
 			require.NoError(t, err)
 			require.EqualValues(t, 1, count, r.Dump())
 		})
@@ -126,7 +129,7 @@ func TestQueueLease(t *testing.T) {
 
 			// Now expired
 			t.Run("After expiry, no items should be in progress", func(t *testing.T) {
-				count, err := shard.RunningCount(ctx, *p.FunctionID)
+				count, err := shard.RunningCount(ctx, scope)
 				require.NoError(t, err)
 				require.EqualValues(t, 0, count)
 			})
@@ -141,7 +144,7 @@ func TestQueueLease(t *testing.T) {
 			require.WithinDuration(t, now.Add(5*time.Second), ulid.Time(item.LeaseID.Time()), 20*time.Millisecond)
 
 			t.Run("Leasing an expired key has one in-progress", func(t *testing.T) {
-				count, err := shard.RunningCount(ctx, *p.FunctionID)
+				count, err := shard.RunningCount(ctx, scope)
 				require.NoError(t, err)
 				require.EqualValues(t, 1, count)
 			})

--- a/pkg/execution/state/redis_state/queue_requeue_test.go
+++ b/pkg/execution/state/redis_state/queue_requeue_test.go
@@ -42,14 +42,19 @@ func TestQueueRequeue(t *testing.T) {
 		now := time.Now()
 
 		fnID := uuid.New()
+		acctID := uuid.New()
+		envID := uuid.New()
+		scope := osqueue.Scope{AccountID: acctID, EnvID: envID, FunctionID: fnID}
 		runID := ulid.MustNew(ulid.Now(), rand.Reader)
 
 		item, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
 			FunctionID: fnID,
 			Data: osqueue.Item{
 				Identifier: state.Identifier{
-					RunID:      runID,
-					WorkflowID: fnID,
+					AccountID:   acctID,
+					WorkspaceID: envID,
+					RunID:       runID,
+					WorkflowID:  fnID,
 				},
 			},
 		}, now, osqueue.EnqueueOpts{})
@@ -62,7 +67,7 @@ func TestQueueRequeue(t *testing.T) {
 		pi := osqueue.QueuePartition{FunctionID: &item.FunctionID}
 		requirePartitionScoreEquals(t, r, pi.FunctionID, now.Truncate(time.Second))
 
-		requirePartitionInProgress(t, shard, item.FunctionID, 1)
+		requirePartitionInProgress(t, shard, scope, 1)
 
 		next := now.Add(time.Hour)
 		err = shard.Requeue(ctx, item, next)
@@ -78,7 +83,7 @@ func TestQueueRequeue(t *testing.T) {
 		})
 
 		t.Run("It should decrease the in-progress count", func(t *testing.T) {
-			requirePartitionInProgress(t, shard, item.FunctionID, 0)
+			requirePartitionInProgress(t, shard, scope, 0)
 		})
 
 		t.Run("It should update the partition's earliest time, if earliest", func(t *testing.T) {

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -2270,9 +2270,9 @@ func getQueueItem(t *testing.T, r *miniredis.Miniredis, id string) osqueue.Queue
 	return i
 }
 
-func requirePartitionInProgress(t *testing.T, q RedisQueueShard, workflowID uuid.UUID, count int) {
+func requirePartitionInProgress(t *testing.T, q RedisQueueShard, scope osqueue.Scope, count int) {
 	t.Helper()
-	actual, err := q.RunningCount(context.Background(), workflowID)
+	actual, err := q.RunningCount(context.Background(), scope)
 	require.NoError(t, err)
 	require.EqualValues(t, count, actual)
 }
@@ -3335,6 +3335,8 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 	ctx := context.Background()
 	fnID := uuid.New()
 	acctID := uuid.New()
+	envID := uuid.New()
+	scope := osqueue.Scope{AccountID: acctID, EnvID: envID, FunctionID: fnID}
 	start := time.Now().Truncate(time.Second)
 
 	t.Run("removes start status index", func(t *testing.T) {
@@ -3345,22 +3347,24 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 			Data: osqueue.Item{
 				Kind: osqueue.KindStart,
 				Identifier: state.Identifier{
-					AccountID: acctID,
+					AccountID:   acctID,
+					WorkspaceID: envID,
+					WorkflowID:  fnID,
 				},
 			},
 		}, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
 		// Verify the status index was created by enqueue.
-		count, err := shard.StatusCount(ctx, fnID, "start")
+		count, err := shard.StatusCount(ctx, scope, "start")
 		require.NoError(t, err)
 		require.EqualValues(t, 1, count, "status:start index should have 1 member after enqueue")
 
 		// RemoveQueueItem should clean up the status index.
-		err = shard.RemoveQueueItem(ctx, fnID.String(), item.ID)
+		err = shard.RemoveQueueItem(ctx, scope, fnID.String(), item.ID)
 		require.NoError(t, err)
 
-		count, err = shard.StatusCount(ctx, fnID, "start")
+		count, err = shard.StatusCount(ctx, scope, "start")
 		require.NoError(t, err)
 		require.EqualValues(t, 0, count, "status:start index should be empty after remove")
 	})
@@ -3373,20 +3377,22 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 			Data: osqueue.Item{
 				Kind: osqueue.KindEdge,
 				Identifier: state.Identifier{
-					AccountID: acctID,
+					AccountID:   acctID,
+					WorkspaceID: envID,
+					WorkflowID:  fnID,
 				},
 			},
 		}, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		count, err := shard.StatusCount(ctx, fnID, "in-progress")
+		count, err := shard.StatusCount(ctx, scope, "in-progress")
 		require.NoError(t, err)
 		require.EqualValues(t, 1, count, "status:in-progress index should have 1 member after enqueue")
 
-		err = shard.RemoveQueueItem(ctx, fnID.String(), item.ID)
+		err = shard.RemoveQueueItem(ctx, scope, fnID.String(), item.ID)
 		require.NoError(t, err)
 
-		count, err = shard.StatusCount(ctx, fnID, "in-progress")
+		count, err = shard.StatusCount(ctx, scope, "in-progress")
 		require.NoError(t, err)
 		require.EqualValues(t, 0, count, "status:in-progress index should be empty after remove")
 	})
@@ -3399,20 +3405,22 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 			Data: osqueue.Item{
 				Kind: osqueue.KindSleep,
 				Identifier: state.Identifier{
-					AccountID: acctID,
+					AccountID:   acctID,
+					WorkspaceID: envID,
+					WorkflowID:  fnID,
 				},
 			},
 		}, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		count, err := shard.StatusCount(ctx, fnID, "sleep")
+		count, err := shard.StatusCount(ctx, scope, "sleep")
 		require.NoError(t, err)
 		require.EqualValues(t, 1, count, "status:sleep index should have 1 member after enqueue")
 
-		err = shard.RemoveQueueItem(ctx, fnID.String(), item.ID)
+		err = shard.RemoveQueueItem(ctx, scope, fnID.String(), item.ID)
 		require.NoError(t, err)
 
-		count, err = shard.StatusCount(ctx, fnID, "sleep")
+		count, err = shard.StatusCount(ctx, scope, "sleep")
 		require.NoError(t, err)
 		require.EqualValues(t, 0, count, "status:sleep index should be empty after remove")
 	})
@@ -3425,7 +3433,9 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 			Data: osqueue.Item{
 				Kind: osqueue.KindStart,
 				Identifier: state.Identifier{
-					AccountID: acctID,
+					AccountID:   acctID,
+					WorkspaceID: envID,
+					WorkflowID:  fnID,
 				},
 			},
 		}, start, osqueue.EnqueueOpts{})
@@ -3436,21 +3446,23 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 			Data: osqueue.Item{
 				Kind: osqueue.KindStart,
 				Identifier: state.Identifier{
-					AccountID: acctID,
+					AccountID:   acctID,
+					WorkspaceID: envID,
+					WorkflowID:  fnID,
 				},
 			},
 		}, start.Add(time.Second), osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		count, err := shard.StatusCount(ctx, fnID, "start")
+		count, err := shard.StatusCount(ctx, scope, "start")
 		require.NoError(t, err)
 		require.EqualValues(t, 2, count)
 
 		// Remove only itemA.
-		err = shard.RemoveQueueItem(ctx, fnID.String(), itemA.ID)
+		err = shard.RemoveQueueItem(ctx, scope, fnID.String(), itemA.ID)
 		require.NoError(t, err)
 
-		count, err = shard.StatusCount(ctx, fnID, "start")
+		count, err = shard.StatusCount(ctx, scope, "start")
 		require.NoError(t, err)
 		require.EqualValues(t, 1, count)
 	})
@@ -3464,23 +3476,25 @@ func TestRemoveQueueItemCleansStatusIndexes(t *testing.T) {
 			Data: osqueue.Item{
 				Kind: osqueue.KindStart,
 				Identifier: state.Identifier{
-					AccountID: acctID,
+					AccountID:   acctID,
+					WorkspaceID: envID,
+					WorkflowID:  fnID,
 				},
 			},
 		}, start, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
-		count, err := shard.StatusCount(ctx, fnID, "start")
+		count, err := shard.StatusCount(ctx, scope, "start")
 		require.NoError(t, err)
 		require.EqualValues(t, 1, count)
 
 		// Calling with a non-UUID partition should not error, but also won't
 		// clean up status indexes (no function ID to derive keys from).
-		err = shard.RemoveQueueItem(ctx, "not-a-uuid", item.ID)
+		err = shard.RemoveQueueItem(ctx, scope, "not-a-uuid", item.ID)
 		require.NoError(t, err)
 
 		// Status index should still contain the item since we used the wrong partition.
-		count, err = shard.StatusCount(ctx, fnID, "start")
+		count, err = shard.StatusCount(ctx, scope, "start")
 		require.NoError(t, err)
 		require.EqualValues(t, 1, count)
 	})

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -1214,7 +1214,11 @@ func TestQueuePartitionPeek(t *testing.T) {
 
 		// After unpausing A, it should be included in the peek:
 		paused[idA] = false
-		require.NoError(t, q.UnpauseFunction(ctx, shard.Name(), accountId, uuid.Nil, idA))
+		require.NoError(t, q.UnpauseFunction(ctx, shard.Name(), osqueue.Scope{
+			AccountID:  accountId,
+			EnvID:      uuid.New(),
+			FunctionID: idA,
+		}))
 
 		require.NoError(t, err)
 		items, err = shard.PartitionPeek(ctx, true, now.Add(time.Hour), osqueue.PartitionPeekMax)
@@ -1613,7 +1617,11 @@ func TestQueueFunctionPause(t *testing.T) {
 
 	paused = false
 
-	err = q.UnpauseFunction(ctx, shard.Name(), uuid.Nil, uuid.Nil, idA)
+	err = q.UnpauseFunction(ctx, shard.Name(), osqueue.Scope{
+		AccountID:  uuid.New(),
+		EnvID:      uuid.New(),
+		FunctionID: idA,
+	})
 	require.NoError(t, err)
 
 	peeked, err = shard.PartitionPeek(ctx, true, now.Add(5*time.Minute), 100)
@@ -1642,14 +1650,16 @@ func TestQueueSetFunctionMigrate(t *testing.T) {
 		ctx := context.Background()
 
 		acctID := uuid.New()
+		envID := uuid.New()
 		now := time.Now().Truncate(time.Second)
 		fnID := uuid.New()
-		id := state.Identifier{AccountID: acctID, WorkflowID: fnID}
+		scope := osqueue.Scope{AccountID: acctID, EnvID: envID, FunctionID: fnID}
+		id := state.Identifier{AccountID: acctID, WorkspaceID: envID, WorkflowID: fnID}
 		_, err = shard.EnqueueItem(ctx, osqueue.QueueItem{FunctionID: fnID, Data: osqueue.Item{Identifier: id}}, now, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
 		lockUntil := now.Add(10 * time.Minute)
-		err = q.SetFunctionMigrate(ctx, "default", fnID, &lockUntil)
+		err = q.SetFunctionMigrate(ctx, "default", scope, &lockUntil)
 		require.NoError(t, err)
 
 		require.True(t, r.Exists(kg.QueueMigrationLock(fnID)))
@@ -1658,7 +1668,7 @@ func TestQueueSetFunctionMigrate(t *testing.T) {
 		require.Equal(t, lockUntil, ulid.MustParse(lockValue).Timestamp())
 
 		// disable migration flag
-		err = q.SetFunctionMigrate(ctx, "default", fnID, nil)
+		err = q.SetFunctionMigrate(ctx, "default", scope, nil)
 		require.NoError(t, err)
 
 		require.False(t, r.Exists(kg.QueueMigrationLock(fnID)))
@@ -1678,9 +1688,11 @@ func TestQueueSetFunctionMigrate(t *testing.T) {
 		ctx := context.Background()
 
 		acctID := uuid.New()
+		envID := uuid.New()
 		now := time.Now().Truncate(time.Second)
 		fnID := uuid.New()
-		id := state.Identifier{AccountID: acctID, WorkflowID: fnID}
+		scope := osqueue.Scope{AccountID: acctID, EnvID: envID, FunctionID: fnID}
+		id := state.Identifier{AccountID: acctID, WorkspaceID: envID, WorkflowID: fnID}
 		_, err = shard.EnqueueItem(ctx, osqueue.QueueItem{FunctionID: fnID, Data: osqueue.Item{Identifier: id}}, now, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
@@ -1697,24 +1709,24 @@ func TestQueueSetFunctionMigrate(t *testing.T) {
 		sp := getShadowPartition()
 		require.Equal(t, fnID.String(), sp.PartitionID)
 
-		lockedUntil, err := shard.IsMigrationLocked(ctx, fnID)
+		lockedUntil, err := shard.IsMigrationLocked(ctx, scope)
 		require.NoError(t, err)
 		require.Nil(t, lockedUntil)
 
 		lockUntil := now.Add(10 * time.Minute)
-		err = q.SetFunctionMigrate(ctx, "default", fnID, &lockUntil)
+		err = q.SetFunctionMigrate(ctx, "default", scope, &lockUntil)
 		require.NoError(t, err)
 
-		lockedUntil, err = shard.IsMigrationLocked(ctx, fnID)
+		lockedUntil, err = shard.IsMigrationLocked(ctx, scope)
 		require.NoError(t, err)
 		require.NotNil(t, lockedUntil)
 		require.Equal(t, lockUntil, *lockedUntil)
 
 		// disable migration flag
-		err = q.SetFunctionMigrate(ctx, "default", fnID, nil)
+		err = q.SetFunctionMigrate(ctx, "default", scope, nil)
 		require.NoError(t, err)
 
-		lockedUntil, err = shard.IsMigrationLocked(ctx, fnID)
+		lockedUntil, err = shard.IsMigrationLocked(ctx, scope)
 		require.NoError(t, err)
 		require.Nil(t, lockedUntil)
 	})
@@ -1741,23 +1753,25 @@ func TestQueueSetFunctionMigrate(t *testing.T) {
 
 		ctx := context.Background()
 		acctID := uuid.New()
+		envID := uuid.New()
 		now := time.Now().Truncate(time.Second)
 		fnID := uuid.New()
-		id := state.Identifier{AccountID: acctID, WorkflowID: fnID}
+		scope := osqueue.Scope{AccountID: acctID, EnvID: envID, FunctionID: fnID}
+		id := state.Identifier{AccountID: acctID, WorkspaceID: envID, WorkflowID: fnID}
 		_, err = yoloShard.EnqueueItem(ctx, osqueue.QueueItem{FunctionID: fnID, Data: osqueue.Item{Identifier: id}}, now, osqueue.EnqueueOpts{})
 		require.NoError(t, err)
 
 		lockUntil := now.Add(10 * time.Minute)
-		err = q.SetFunctionMigrate(ctx, "yolo", fnID, &lockUntil)
+		err = q.SetFunctionMigrate(ctx, "yolo", scope, &lockUntil)
 		require.NoError(t, err)
 
 		// should not find it in the default shard
-		lockedUntil, err := defaultShard.IsMigrationLocked(ctx, fnID)
+		lockedUntil, err := defaultShard.IsMigrationLocked(ctx, scope)
 		require.NoError(t, err)
 		require.Nil(t, lockedUntil)
 
 		// should find metadata in the other shard
-		lockedUntil, err = yoloShard.IsMigrationLocked(ctx, fnID)
+		lockedUntil, err = yoloShard.IsMigrationLocked(ctx, scope)
 		require.NoError(t, err)
 		require.Equal(t, lockUntil, *lockedUntil)
 	})
@@ -2162,12 +2176,21 @@ func TestMigrate(t *testing.T) {
 			)
 			require.NoError(t, err)
 
+			acctID := uuid.New()
+			envID := uuid.New()
+			fnID := uuid.New()
+			scope := osqueue.Scope{
+				AccountID:  acctID,
+				EnvID:      envID,
+				FunctionID: fnID,
+			}
+
 			expectItemCountForPartition := func(ctx context.Context, shard RedisQueueShard, partitionID uuid.UUID, expected int) {
 				var count int
 
 				from := time.Time{}
 				until := clock.Now().Add(24 * time.Hour * 365)
-				items, err := shard.ItemsByPartition(ctx, partitionID.String(), from, until)
+				items, err := shard.ItemsByPartition(ctx, scope, partitionID.String(), from, until)
 				require.NoError(t, err)
 
 				for range items {
@@ -2176,12 +2199,9 @@ func TestMigrate(t *testing.T) {
 				require.Equal(t, expected, count)
 			}
 
-			acctID := uuid.New()
-			fnID := uuid.New()
-
 			// Enqueue to shard 1
 			for range 5 {
-				id := state.Identifier{AccountID: acctID, WorkflowID: fnID, EventID: ulid.MustNew(ulid.Now(), rand.Reader), RunID: ulid.MustNew(ulid.Now(), rand.Reader)}
+				id := state.Identifier{AccountID: acctID, WorkspaceID: envID, WorkflowID: fnID, EventID: ulid.MustNew(ulid.Now(), rand.Reader), RunID: ulid.MustNew(ulid.Now(), rand.Reader)}
 				err := q1.Enqueue(ctx, osqueue.Item{Identifier: id}, clock.Now(), osqueue.EnqueueOpts{})
 				require.NoError(t, err)
 			}
@@ -2191,14 +2211,14 @@ func TestMigrate(t *testing.T) {
 
 			// Don't really need it since there are no executors to process the enqueued items
 			lockUntil := clock.Now().Add(10 * time.Minute)
-			err = q1.SetFunctionMigrate(ctx, shard1.Name(), fnID, &lockUntil)
+			err = q1.SetFunctionMigrate(ctx, shard1.Name(), scope, &lockUntil)
 			require.NoError(t, err)
 
 			// Verify that there are expected number of items in it
 			expectItemCountForPartition(ctx, shard1, fnID, 5)
 
 			// Attempt to migrate from shard1 to shard2
-			processed, err := q1.Migrate(ctx, shard1.Name(), fnID, 10, 0, func(ctx context.Context, qi *osqueue.QueueItem) error {
+			processed, err := q1.Migrate(ctx, shard1.Name(), scope, 10, 0, func(ctx context.Context, qi *osqueue.QueueItem) error {
 				return q2.Enqueue(ctx, qi.Data, time.UnixMilli(qi.AtMS), osqueue.EnqueueOpts{PassthroughJobId: true})
 			})
 			require.NoError(t, err)
@@ -2217,7 +2237,7 @@ func TestMigrate(t *testing.T) {
 			require.Equal(t, time.Duration(0), remainingTTL, remainingTTL.String())
 
 			// Now, move everything back to queue 1
-			returned, err := q2.Migrate(ctx, shard2.Name(), fnID, 10, 0, func(ctx context.Context, qi *osqueue.QueueItem) error {
+			returned, err := q2.Migrate(ctx, shard2.Name(), scope, 10, 0, func(ctx context.Context, qi *osqueue.QueueItem) error {
 				return q1.Enqueue(ctx, qi.Data, time.UnixMilli(qi.AtMS), osqueue.EnqueueOpts{PassthroughJobId: true})
 			})
 			require.NoError(t, err, "r1", r1.Dump())

--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/enums"
 	osqueue "github.com/inngest/inngest/pkg/execution/queue"
@@ -188,6 +187,7 @@ func (q *queue) ItemsByPartition(ctx context.Context, scope osqueue.Scope, parti
 				Limit:        opt.BatchSize,
 				PartitionID:  partitionID,
 				PartitionKey: partitionZsetKey(pt, q.RedisClient.kg),
+				Scope:        scope,
 			})
 			if err != nil {
 				if !errors.Is(err, context.Canceled) {

--- a/pkg/execution/state/redis_state/reader.go
+++ b/pkg/execution/state/redis_state/reader.go
@@ -21,7 +21,7 @@ import (
 )
 
 // RunJobs returns a list of jobs that are due to run for a given run ID.
-func (q *queue) RunJobs(ctx context.Context, workspaceID, workflowID uuid.UUID, runID ulid.ULID, limit, offset int64) ([]osqueue.JobResponse, error) {
+func (q *queue) RunJobs(ctx context.Context, scope osqueue.Scope, runID ulid.ULID, limit, offset int64) ([]osqueue.JobResponse, error) {
 	if limit > 1000 || limit <= 0 {
 		limit = 1000
 	}
@@ -60,11 +60,11 @@ func (q *queue) RunJobs(ctx context.Context, workspaceID, workflowID uuid.UUID, 
 		if err := json.Unmarshal([]byte(str), qi); err != nil {
 			return nil, fmt.Errorf("error unmarshalling queue item: %w", err)
 		}
-		if qi.Data.Identifier.WorkspaceID != workspaceID {
+		if qi.Data.Identifier.WorkspaceID != scope.EnvID {
 			continue
 		}
 		// TODO Do we need to check backlogs here?
-		cmd := q.RedisClient.unshardedRc.B().Zrank().Key(q.RedisClient.kg.FnQueueSet(workflowID.String())).Member(qi.ID).Build()
+		cmd := q.RedisClient.unshardedRc.B().Zrank().Key(q.RedisClient.kg.FnQueueSet(scope.FunctionID.String())).Member(qi.ID).Build()
 		pos, err := q.RedisClient.unshardedRc.Do(ctx, cmd).AsInt64()
 		if !rueidis.IsRedisNil(err) && err != nil {
 			return nil, fmt.Errorf("error reading queue position: %w", err)
@@ -82,7 +82,7 @@ func (q *queue) RunJobs(ctx context.Context, workspaceID, workflowID uuid.UUID, 
 	return resp, nil
 }
 
-func (q *queue) OutstandingJobCount(ctx context.Context, workspaceID, workflowID uuid.UUID, runID ulid.ULID) (int, error) {
+func (q *queue) OutstandingJobCount(ctx context.Context, scope osqueue.Scope, runID ulid.ULID) (int, error) {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "OutstandingJobCount"), redis_telemetry.ScopeQueue)
 
 	cmd := q.RedisClient.unshardedRc.B().Zcard().Key(q.RedisClient.kg.RunIndex(runID)).Build()
@@ -93,10 +93,10 @@ func (q *queue) OutstandingJobCount(ctx context.Context, workspaceID, workflowID
 	return int(count), nil
 }
 
-func (q *queue) StatusCount(ctx context.Context, workflowID uuid.UUID, status string) (int64, error) {
+func (q *queue) StatusCount(ctx context.Context, scope osqueue.Scope, status string) (int64, error) {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "StatusCount"), redis_telemetry.ScopeQueue)
 
-	key := q.RedisClient.kg.Status(status, workflowID)
+	key := q.RedisClient.kg.Status(status, scope.FunctionID)
 	cmd := q.RedisClient.unshardedRc.B().Zcard().Key(key).Build()
 	count, err := q.RedisClient.unshardedRc.Do(ctx, cmd).AsInt64()
 	if err != nil {
@@ -106,7 +106,7 @@ func (q *queue) StatusCount(ctx context.Context, workflowID uuid.UUID, status st
 	return count, nil
 }
 
-func (q *queue) RunningCount(ctx context.Context, functionID uuid.UUID) (int64, error) {
+func (q *queue) RunningCount(ctx context.Context, scope osqueue.Scope) (int64, error) {
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "RunningCount"), redis_telemetry.ScopeQueue)
 
 	rc := q.RedisClient.unshardedRc
@@ -116,7 +116,7 @@ func (q *queue) RunningCount(ctx context.Context, functionID uuid.UUID) (int64, 
 	// NOTE: We previously used the concurrency ZSET, which will no longer be populated by Lease in case
 	// a valid capacity lease was acquired using the Constraint API. This is to prevent double-counting
 	// concurrency. For this reason, we need to track in progress queue items in a partition using a new index.
-	key := q.RedisClient.kg.PartitionScavengerIndex(functionID.String())
+	key := q.RedisClient.kg.PartitionScavengerIndex(scope.FunctionID.String())
 
 	// Only consider items in the future (do not count expired jobs which will be scavenged)
 	from := fmt.Sprintf("%d", q.Clock.Now().UnixMilli())
@@ -134,7 +134,7 @@ func (q *queue) RunningCount(ctx context.Context, functionID uuid.UUID) (int64, 
 	return count, nil
 }
 
-func (q *queue) ItemsByPartition(ctx context.Context, partitionID string, from time.Time, until time.Time, opts ...osqueue.QueueIterOpt) (iter.Seq[*osqueue.QueueItem], error) {
+func (q *queue) ItemsByPartition(ctx context.Context, scope osqueue.Scope, partitionID string, from time.Time, until time.Time, opts ...osqueue.QueueIterOpt) (iter.Seq[*osqueue.QueueItem], error) {
 	l := logger.StdlibLogger(ctx)
 
 	opt := osqueue.QueueIterOptions{
@@ -554,7 +554,7 @@ func (q *queue) QueueIterator(ctx context.Context, opts QueueIteratorOpts) (part
 	return atomic.LoadInt64(&totalPartitions), atomic.LoadInt64(&totalQueueItems), nil
 }
 
-func (q *queue) ItemExists(ctx context.Context, jobID string) (bool, error) {
+func (q *queue) ItemExists(ctx context.Context, scope osqueue.Scope, jobID string) (bool, error) {
 	rc := q.RedisClient.Client()
 	kg := q.RedisClient.kg
 
@@ -570,7 +570,7 @@ func (q *queue) ItemExists(ctx context.Context, jobID string) (bool, error) {
 	return exists, nil
 }
 
-func (q *queue) ItemsByRunID(ctx context.Context, runID ulid.ULID) ([]*osqueue.QueueItem, error) {
+func (q *queue) ItemsByRunID(ctx context.Context, scope osqueue.Scope, runID ulid.ULID) ([]*osqueue.QueueItem, error) {
 	rc := q.RedisClient.Client()
 	kg := q.RedisClient.KeyGenerator()
 

--- a/pkg/execution/state/redis_state/reader_test.go
+++ b/pkg/execution/state/redis_state/reader_test.go
@@ -37,7 +37,11 @@ func TestItemsByPartitionOnEmptyPartition(t *testing.T) {
 			osqueue.WithClock(clock),
 		)
 
-		_, err := q.ItemsByPartition(ctx, shard, "i-dont-exist", time.Time{}, clock.Now().Add(time.Minute),
+		_, err := q.ItemsByPartition(ctx, shard, osqueue.Scope{
+			AccountID:  uuid.New(),
+			EnvID:      uuid.New(),
+			FunctionID: uuid.New(),
+		}, "i-dont-exist", time.Time{}, clock.Now().Add(time.Minute),
 			osqueue.WithQueueItemIterBatchSize(150),
 		)
 		require.Error(t, err)
@@ -53,6 +57,7 @@ func TestItemsByPartition(t *testing.T) {
 	clock := clockwork.NewFakeClockAt(time.Now().Truncate(time.Minute))
 
 	acctId, fnID, wsID := uuid.New(), uuid.New(), uuid.New()
+	scope := osqueue.Scope{AccountID: acctId, EnvID: wsID, FunctionID: fnID}
 
 	testcases := []struct {
 		name             string
@@ -174,7 +179,7 @@ func TestItemsByPartition(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			items, err := q.ItemsByPartition(ctx, shard, fnID.String(), tc.from, tc.until,
+			items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), tc.from, tc.until,
 				osqueue.WithQueueItemIterBatchSize(tc.batchSize),
 			)
 			require.NoError(t, err)
@@ -197,6 +202,7 @@ func TestItemsByPartitionWithSystemQueue(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	acctID, wsID := uuid.New(), uuid.New()
+	systemScope := osqueue.Scope{IsSystem: true, AccountID: acctID, EnvID: wsID}
 
 	q, shard := newQueue(
 		t, rc,
@@ -233,7 +239,7 @@ func TestItemsByPartitionWithSystemQueue(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	items, err := q.ItemsByPartition(ctx, shard, systemQueueName, time.Time{}, clock.Now().Add(1*time.Hour),
+	items, err := q.ItemsByPartition(ctx, shard, systemScope, systemQueueName, time.Time{}, clock.Now().Add(1*time.Hour),
 		osqueue.WithQueueItemIterBatchSize(100),
 		osqueue.WithQueueItemIterEnableBacklog(false),
 	)
@@ -286,6 +292,7 @@ func TestItemsByPartitionLeasedItems(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	acctId, fnID, wsID := uuid.New(), uuid.New(), uuid.New()
+	scope := osqueue.Scope{AccountID: acctId, EnvID: wsID, FunctionID: fnID}
 
 	enqueueItems := func(t *testing.T, shard RedisQueueShard, n int, prefix string, atFn func(i int) time.Time) []string {
 		t.Helper()
@@ -344,7 +351,7 @@ func TestItemsByPartitionLeasedItems(t *testing.T) {
 			leaseQueueItem(t, rc, kg, id, leaseExpiry)
 		}
 
-		items, err := q.ItemsByPartition(ctx, shard, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
+		items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
 			osqueue.WithQueueItemIterBatchSize(100),
 			osqueue.WithQueueItemIterEnableBacklog(false),
 		)
@@ -384,7 +391,7 @@ func TestItemsByPartitionLeasedItems(t *testing.T) {
 			leaseQueueItem(t, rc, kg, id, leaseExpiry)
 		}
 
-		items, err := q.ItemsByPartition(ctx, shard, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
+		items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
 			osqueue.WithQueueItemIterBatchSize(batchSize),
 			osqueue.WithQueueItemIterEnableBacklog(false),
 		)
@@ -421,7 +428,7 @@ func TestItemsByPartitionLeasedItems(t *testing.T) {
 		leaseQueueItem(t, rc, kg, ids[2], leaseExpiry)
 		leaseQueueItem(t, rc, kg, ids[3], leaseExpiry)
 
-		items, err := q.ItemsByPartition(ctx, shard, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
+		items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
 			osqueue.WithQueueItemIterBatchSize(batchSize),
 			osqueue.WithQueueItemIterEnableBacklog(false),
 		)
@@ -455,6 +462,7 @@ func TestItemsByPartitionMissingHashItems(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	acctId, fnID, wsID := uuid.New(), uuid.New(), uuid.New()
+	scope := osqueue.Scope{AccountID: acctId, EnvID: wsID, FunctionID: fnID}
 
 	enqueueItems := func(t *testing.T, shard RedisQueueShard, n int, prefix string, atFn func(i int) time.Time) []string {
 		t.Helper()
@@ -517,7 +525,7 @@ func TestItemsByPartitionMissingHashItems(t *testing.T) {
 			deleteQueueItemFromHash(t, rc, kg, id)
 		}
 
-		items, err := q.ItemsByPartition(ctx, shard, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
+		items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
 			osqueue.WithQueueItemIterBatchSize(batchSize),
 			osqueue.WithQueueItemIterEnableBacklog(false),
 		)
@@ -553,7 +561,7 @@ func TestItemsByPartitionMissingHashItems(t *testing.T) {
 			deleteQueueItemFromHash(t, rc, kg, id)
 		}
 
-		items, err := q.ItemsByPartition(ctx, shard, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
+		items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
 			osqueue.WithQueueItemIterBatchSize(100),
 			osqueue.WithQueueItemIterEnableBacklog(false),
 		)
@@ -575,6 +583,7 @@ func TestItemsByPartitionScoreParsing(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	acctId, fnID, wsID := uuid.New(), uuid.New(), uuid.New()
+	scope := osqueue.Scope{AccountID: acctId, EnvID: wsID, FunctionID: fnID}
 
 	enqueueItems := func(t *testing.T, shard RedisQueueShard, n int, prefix string, atFn func(i int) time.Time) []string {
 		t.Helper()
@@ -649,7 +658,7 @@ func TestItemsByPartitionScoreParsing(t *testing.T) {
 		// Use a channel + timeout to detect an infinite loop.
 		done := make(chan int, 1)
 		go func() {
-			items, err := q.ItemsByPartition(ctx, shard, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
+			items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
 				osqueue.WithQueueItemIterBatchSize(batchSize),
 				osqueue.WithQueueItemIterEnableBacklog(false),
 			)
@@ -704,7 +713,7 @@ func TestItemsByPartitionScoreParsing(t *testing.T) {
 
 		done := make(chan int, 1)
 		go func() {
-			items, err := q.ItemsByPartition(ctx, shard, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
+			items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
 				osqueue.WithQueueItemIterBatchSize(100),
 				osqueue.WithQueueItemIterEnableBacklog(false),
 			)
@@ -762,6 +771,7 @@ func TestItemsByPartitionAtMSDivergence(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	acctId, fnID, wsID := uuid.New(), uuid.New(), uuid.New()
+	scope := osqueue.Scope{AccountID: acctId, EnvID: wsID, FunctionID: fnID}
 
 	enqueueItems := func(t *testing.T, shard RedisQueueShard, n int, prefix string, atFn func(i int) time.Time) []string {
 		t.Helper()
@@ -830,7 +840,7 @@ func TestItemsByPartitionAtMSDivergence(t *testing.T) {
 
 		done := make(chan int, 1)
 		go func() {
-			items, err := q.ItemsByPartition(ctx, shard, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
+			items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
 				osqueue.WithQueueItemIterBatchSize(batchSize),
 				osqueue.WithQueueItemIterEnableBacklog(false),
 			)
@@ -880,7 +890,7 @@ func TestItemsByPartitionAtMSDivergence(t *testing.T) {
 
 		done := make(chan int, 1)
 		go func() {
-			items, err := q.ItemsByPartition(ctx, shard, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
+			items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
 				osqueue.WithQueueItemIterBatchSize(batchSize),
 				osqueue.WithQueueItemIterEnableBacklog(false),
 			)
@@ -1189,6 +1199,7 @@ func TestItemsByPartitionBacklogZeroCursor(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	acctId, fnID, wsID := uuid.New(), uuid.New(), uuid.New()
+	scope := osqueue.Scope{AccountID: acctId, EnvID: wsID, FunctionID: fnID}
 
 	q, shard := newQueue(
 		t, rc,
@@ -1240,7 +1251,7 @@ func TestItemsByPartitionBacklogZeroCursor(t *testing.T) {
 
 		done := make(chan int, 1)
 		go func() {
-			items, err := q.ItemsByPartition(ctx, shard, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
+			items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
 				osqueue.WithQueueItemIterBatchSize(100),
 				osqueue.WithQueueItemIterEnableBacklog(true),
 			)
@@ -1406,6 +1417,7 @@ func TestItemExists(t *testing.T) {
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 	acctId, fnID, wsID := uuid.New(), uuid.New(), uuid.New()
+	scope := osqueue.Scope{AccountID: acctId, EnvID: wsID, FunctionID: fnID}
 
 	q, shard := newQueue(
 		t, rc,
@@ -1441,7 +1453,7 @@ func TestItemExists(t *testing.T) {
 		enqueued, err := enqueue(ctx, shard, jobID)
 		require.NoError(t, err)
 
-		exists, err := q.ItemExists(ctx, shard, enqueued.ID)
+		exists, err := q.ItemExists(ctx, shard, scope, enqueued.ID)
 		require.NoError(t, err)
 		require.True(t, exists, "item should exist")
 	})
@@ -1451,7 +1463,7 @@ func TestItemExists(t *testing.T) {
 
 		nonExistentJobID := ulid.MustNew(ulid.Now(), rand.Reader).String()
 
-		exists, err := q.ItemExists(ctx, shard, nonExistentJobID)
+		exists, err := q.ItemExists(ctx, shard, scope, nonExistentJobID)
 		require.NoError(t, err)
 		require.False(t, exists, "item should not exist")
 	})
@@ -1464,7 +1476,7 @@ func TestItemExists(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify it exists
-		exists, err := q.ItemExists(ctx, shard, enqueued.ID)
+		exists, err := q.ItemExists(ctx, shard, scope, enqueued.ID)
 		require.NoError(t, err)
 		require.True(t, exists)
 
@@ -1473,7 +1485,7 @@ func TestItemExists(t *testing.T) {
 		require.NoError(t, err)
 
 		// Should no longer exist
-		exists, err = q.ItemExists(ctx, shard, enqueued.ID)
+		exists, err = q.ItemExists(ctx, shard, scope, enqueued.ID)
 		require.NoError(t, err)
 		require.False(t, exists, "dequeued item should not exist")
 	})

--- a/pkg/execution/state/redis_state/shadow_queue.go
+++ b/pkg/execution/state/redis_state/shadow_queue.go
@@ -17,10 +17,10 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-func (q *queue) IsMigrationLocked(ctx context.Context, fnID uuid.UUID) (*time.Time, error) {
+func (q *queue) IsMigrationLocked(ctx context.Context, scope osqueue.Scope) (*time.Time, error) {
 	client := q.RedisClient.Client()
 	kg := q.RedisClient.KeyGenerator()
-	cmd := client.B().Get().Key(kg.QueueMigrationLock(fnID)).Build()
+	cmd := client.B().Get().Key(kg.QueueMigrationLock(scope.FunctionID)).Build()
 	exists, err := client.Do(ctx, cmd).ToString()
 	if err != nil {
 		if rueidis.IsRedisNil(err) {

--- a/pkg/testapi/api.go
+++ b/pkg/testapi/api.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
@@ -23,13 +24,13 @@ type TestAPI struct {
 }
 
 type Options struct {
-	QueueShards        queue.ShardRegistry
-	Queue              queue.Queue
-	Executor           execution.Executor
-	StateManager       statev2.RunService
-	ResetAll           func()
-	PauseFunction      func(id uuid.UUID)
-	UnpauseFunction    func(id uuid.UUID)
+	QueueShards     queue.ShardRegistry
+	Queue           queue.Queue
+	Executor        execution.Executor
+	StateManager    statev2.RunService
+	ResetAll        func()
+	PauseFunction   func(id uuid.UUID)
+	UnpauseFunction func(id uuid.UUID)
 }
 
 func ShouldEnable() bool {
@@ -89,7 +90,11 @@ func (t *TestAPI) GetQueueSize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	count, err := shard.PartitionSize(ctx, parsedFnId.String(), time.Now().Add(2*365*24*time.Hour))
+	count, err := shard.PartitionSize(ctx, queue.Scope{
+		AccountID:  parsedAccountId,
+		EnvID:      consts.DevServerEnvID,
+		FunctionID: parsedFnId,
+	}, parsedFnId.String(), time.Now().Add(2*365*24*time.Hour))
 	if err != nil {
 		w.WriteHeader(500)
 		_, _ = w.Write([]byte("Internal server error"))

--- a/proto/debug/v1/queue.proto
+++ b/proto/debug/v1/queue.proto
@@ -59,6 +59,9 @@ message QueueItemRequest {
   string item_id = 1;
   string run_id = 2;
   string queue_shard = 3;
+  string account_id = 4;
+  string env_id = 5;
+  string function_id = 6;
 }
 
 message QueueItemResponse { bytes data = 1; }

--- a/proto/debug/v1/queue.proto
+++ b/proto/debug/v1/queue.proto
@@ -64,7 +64,10 @@ message QueueItemRequest {
   string function_id = 6;
 }
 
-message QueueItemResponse { bytes data = 1; }
+message QueueItemResponse {
+  bytes data = 1;
+  string queue_shard = 2;
+}
 
 //
 // Shadow Partition / Backlog (Key Queues)

--- a/proto/gen/debug/v1/queue.pb.go
+++ b/proto/gen/debug/v1/queue.pb.go
@@ -535,6 +535,7 @@ func (x *QueueItemRequest) GetFunctionId() string {
 type QueueItemResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Data          []byte                 `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	QueueShard    string                 `protobuf:"bytes,2,opt,name=queue_shard,json=queueShard,proto3" json:"queue_shard,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -574,6 +575,13 @@ func (x *QueueItemResponse) GetData() []byte {
 		return x.Data
 	}
 	return nil
+}
+
+func (x *QueueItemResponse) GetQueueShard() string {
+	if x != nil {
+		return x.QueueShard
+	}
+	return ""
 }
 
 // Shadow Partition / Backlog (Key Queues)
@@ -1224,9 +1232,11 @@ const file_debug_v1_queue_proto_rawDesc = "" +
 	"account_id\x18\x04 \x01(\tR\taccountId\x12\x15\n" +
 	"\x06env_id\x18\x05 \x01(\tR\x05envId\x12\x1f\n" +
 	"\vfunction_id\x18\x06 \x01(\tR\n" +
-	"functionId\"'\n" +
+	"functionId\"H\n" +
 	"\x11QueueItemResponse\x12\x12\n" +
-	"\x04data\x18\x01 \x01(\fR\x04data\";\n" +
+	"\x04data\x18\x01 \x01(\fR\x04data\x12\x1f\n" +
+	"\vqueue_shard\x18\x02 \x01(\tR\n" +
+	"queueShard\";\n" +
 	"\x16ShadowPartitionRequest\x12!\n" +
 	"\fpartition_id\x18\x01 \x01(\tR\vpartitionId\"\xaa\x02\n" +
 	"\x17ShadowPartitionResponse\x12!\n" +

--- a/proto/gen/debug/v1/queue.pb.go
+++ b/proto/gen/debug/v1/queue.pb.go
@@ -453,6 +453,9 @@ type QueueItemRequest struct {
 	ItemId        string                 `protobuf:"bytes,1,opt,name=item_id,json=itemId,proto3" json:"item_id,omitempty"`
 	RunId         string                 `protobuf:"bytes,2,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
 	QueueShard    string                 `protobuf:"bytes,3,opt,name=queue_shard,json=queueShard,proto3" json:"queue_shard,omitempty"`
+	AccountId     string                 `protobuf:"bytes,4,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	EnvId         string                 `protobuf:"bytes,5,opt,name=env_id,json=envId,proto3" json:"env_id,omitempty"`
+	FunctionId    string                 `protobuf:"bytes,6,opt,name=function_id,json=functionId,proto3" json:"function_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -504,6 +507,27 @@ func (x *QueueItemRequest) GetRunId() string {
 func (x *QueueItemRequest) GetQueueShard() string {
 	if x != nil {
 		return x.QueueShard
+	}
+	return ""
+}
+
+func (x *QueueItemRequest) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *QueueItemRequest) GetEnvId() string {
+	if x != nil {
+		return x.EnvId
+	}
+	return ""
+}
+
+func (x *QueueItemRequest) GetFunctionId() string {
+	if x != nil {
+		return x.FunctionId
 	}
 	return ""
 }
@@ -1190,12 +1214,17 @@ const file_debug_v1_queue_proto_rawDesc = "" +
 	"\x04next\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x04next\x12\x15\n" +
 	"\x06job_id\x18\x02 \x01(\tR\x05jobId\x12\x12\n" +
 	"\x04expr\x18\x03 \x01(\tR\x04expr\x12\x1c\n" +
-	"\tscheduled\x18\x04 \x01(\bR\tscheduled\"c\n" +
+	"\tscheduled\x18\x04 \x01(\bR\tscheduled\"\xba\x01\n" +
 	"\x10QueueItemRequest\x12\x17\n" +
 	"\aitem_id\x18\x01 \x01(\tR\x06itemId\x12\x15\n" +
 	"\x06run_id\x18\x02 \x01(\tR\x05runId\x12\x1f\n" +
 	"\vqueue_shard\x18\x03 \x01(\tR\n" +
-	"queueShard\"'\n" +
+	"queueShard\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x04 \x01(\tR\taccountId\x12\x15\n" +
+	"\x06env_id\x18\x05 \x01(\tR\x05envId\x12\x1f\n" +
+	"\vfunction_id\x18\x06 \x01(\tR\n" +
+	"functionId\"'\n" +
 	"\x11QueueItemResponse\x12\x12\n" +
 	"\x04data\x18\x01 \x01(\fR\x04data\";\n" +
 	"\x16ShadowPartitionRequest\x12!\n" +

--- a/tests/execution/executor/executor_test.go
+++ b/tests/execution/executor/executor_test.go
@@ -600,8 +600,11 @@ func TestFinalize(t *testing.T) {
 	jobs1, err := rq.RunJobs(
 		ctx,
 		queueShard.Name(),
-		run1.ID.Tenant.EnvID,
-		run1.ID.FunctionID,
+		queue.Scope{
+			AccountID:  run1.ID.Tenant.AccountID,
+			EnvID:      run1.ID.Tenant.EnvID,
+			FunctionID: run1.ID.FunctionID,
+		},
 		run1.ID.RunID,
 		1000,
 		0,
@@ -635,8 +638,11 @@ func TestFinalize(t *testing.T) {
 	jobs2, err := rq.RunJobs(
 		ctx,
 		queueShard.Name(),
-		run2.ID.Tenant.EnvID,
-		run2.ID.FunctionID,
+		queue.Scope{
+			AccountID:  run2.ID.Tenant.AccountID,
+			EnvID:      run2.ID.Tenant.EnvID,
+			FunctionID: run2.ID.FunctionID,
+		},
 		run2.ID.RunID,
 		1000,
 		0,
@@ -1060,8 +1066,11 @@ func TestExecutorReturnsResponseWhenNonRetriableError(t *testing.T) {
 	jobsAfterSchedule, err := rq.RunJobs(
 		ctx,
 		queueShard.Name(),
-		run.ID.Tenant.EnvID,
-		run.ID.FunctionID,
+		queue.Scope{
+			AccountID:  run.ID.Tenant.AccountID,
+			EnvID:      run.ID.Tenant.EnvID,
+			FunctionID: run.ID.FunctionID,
+		},
 		run.ID.RunID,
 		1000,
 		0,
@@ -1242,8 +1251,11 @@ func TestCapacityErrorRetriesWhenAttemptsExhausted(t *testing.T) {
 	jobsAfterSchedule, err := rq.RunJobs(
 		ctx,
 		queueShard.Name(),
-		run.ID.Tenant.EnvID,
-		run.ID.FunctionID,
+		queue.Scope{
+			AccountID:  run.ID.Tenant.AccountID,
+			EnvID:      run.ID.Tenant.EnvID,
+			FunctionID: run.ID.FunctionID,
+		},
 		run.ID.RunID,
 		1000,
 		0,
@@ -1429,8 +1441,11 @@ func TestExecutorScheduleRateLimit(t *testing.T) {
 	jobsAfterSchedule, err := rq.RunJobs(
 		ctx,
 		queueShard.Name(),
-		run.ID.Tenant.EnvID,
-		run.ID.FunctionID,
+		queue.Scope{
+			AccountID:  run.ID.Tenant.AccountID,
+			EnvID:      run.ID.Tenant.EnvID,
+			FunctionID: run.ID.FunctionID,
+		},
 		run.ID.RunID,
 		1000,
 		0,
@@ -1630,8 +1645,11 @@ func TestExecutorScheduleBacklogSizeLimit(t *testing.T) {
 	jobsAfterSchedule, err := rq.RunJobs(
 		ctx,
 		queueShard.Name(),
-		run.ID.Tenant.EnvID,
-		run.ID.FunctionID,
+		queue.Scope{
+			AccountID:  run.ID.Tenant.AccountID,
+			EnvID:      run.ID.Tenant.EnvID,
+			FunctionID: run.ID.FunctionID,
+		},
 		run.ID.RunID,
 		1000,
 		0,

--- a/tests/execution/executor/parallel_invoke_coalesce_test.go
+++ b/tests/execution/executor/parallel_invoke_coalesce_test.go
@@ -226,8 +226,11 @@ func TestParallelPauseBackedOpsCoalesceDiscovery(t *testing.T) {
 	jobsAfterSchedule, err := rq.RunJobs(
 		ctx,
 		queueShard.Name(),
-		run.ID.Tenant.EnvID,
-		run.ID.FunctionID,
+		queue.Scope{
+			AccountID:  run.ID.Tenant.AccountID,
+			EnvID:      run.ID.Tenant.EnvID,
+			FunctionID: run.ID.FunctionID,
+		},
 		run.ID.RunID,
 		1000,
 		0,

--- a/tests/execution/queue/queue_operation_test.go
+++ b/tests/execution/queue/queue_operation_test.go
@@ -40,6 +40,7 @@ func TestQueueOperations(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+	scope := queue.Scope{AccountID: accountID, EnvID: envID, FunctionID: fnID}
 	runID := ulid.MustNew(ulid.Timestamp(clock.Now()), rand.Reader)
 
 	options := []queue.QueueOpt{
@@ -122,7 +123,7 @@ func TestQueueOperations(t *testing.T) {
 		partition.LeaseID = leaseID
 		partition.Last = clock.Now().UnixMilli()
 
-		res, err := shard.PartitionByID(ctx, partition.ID)
+		res, err := shard.PartitionByID(ctx, scope, partition.ID)
 		require.NoError(t, err)
 		require.Equal(t, partition, res.QueuePartition)
 	})


### PR DESCRIPTION
## Description

Threads `queue.Scope` through the queue manager/reader APIs added around `c938782421a206cfe07910b91b47f30616d6769b` and updates callers/tests to pass account, environment, and function IDs where available.

Notable updates:

- Adds `ScopeFromQueueItem` in `pkg/execution/queue/item.go` for deriving queue scope from persisted queue items.
- Updates Redis queue method signatures to accept scope while preserving the existing Redis shard behavior.
- Updates cron `HealthCheck` to accept account ID, environment ID, and function ID, then uses that scope when checking for the scheduled queue item.
- Updates cron health-check callers, including the debug API and executor health-check flow, to supply account/env/function IDs.
- Keeps the debug API on dev-server account/env constants for now; cloud-specific ID resolution can be handled by the cloud implementation.

Validation:

- `go test ./pkg/execution/cron`
- `go test ./pkg/execution/queue`
- `go test -run '^$' ./pkg/execution/state/redis_state ./tests/execution/executor ./tests/execution/queue`
- `go test -run '^$' ./...` compiles the changed packages; the top-level `tests` package still requires `SDK_URL` during init.

## Release note

None.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*