### PR TITLE
fix: get outputs working again with v2 runs

### DIFF
--- a/pkg/api/v2/endpoints_runs.go
+++ b/pkg/api/v2/endpoints_runs.go
@@ -33,7 +33,10 @@ func (s *Service) GetFunctionRun(ctx context.Context, req *apiv2.GetFunctionRunR
 		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, "Run ID must be a valid ULID")
 	}
 
-	run, err := s.runs.GetFunctionRun(ctx, runID)
+	includeOutput := req.GetIncludeOutput()
+	run, err := s.runs.GetFunctionRun(ctx, runID, GetFunctionRunOpts{
+		IncludeOutput: includeOutput,
+	})
 	if err != nil {
 		return nil, s.base.NewError(http.StatusNotFound, apiv2base.ErrorNotFound, "Run not found")
 	}
@@ -44,7 +47,7 @@ func (s *Service) GetFunctionRun(ctx context.Context, req *apiv2.GetFunctionRunR
 	}
 
 	data := toFunctionRun(run, fn)
-	if req.GetIncludeOutput() {
+	if includeOutput {
 		data.Output = s.traceRunOutput(ctx, runID)
 	}
 

--- a/pkg/api/v2/endpoints_runs.go
+++ b/pkg/api/v2/endpoints_runs.go
@@ -43,8 +43,13 @@ func (s *Service) GetFunctionRun(ctx context.Context, req *apiv2.GetFunctionRunR
 		return nil, s.base.NewError(http.StatusNotFound, apiv2base.ErrorNotFound, "Function not found")
 	}
 
+	data := toFunctionRun(run, fn)
+	if req.GetIncludeOutput() {
+		data.Output = s.functionRunOutput(ctx, runID, run.Output)
+	}
+
 	return &apiv2.GetFunctionRunResponse{
-		Data:     toFunctionRun(run, fn, req.GetIncludeOutput()),
+		Data:     data,
 		Metadata: &apiv2.ResponseMetadata{FetchedAt: timestamppb.Now()},
 	}, nil
 }
@@ -79,7 +84,7 @@ func (s *Service) GetFunctionTrace(ctx context.Context, req *apiv2.GetFunctionTr
 	}, nil
 }
 
-func toFunctionRun(run *cqrs.FunctionRun, fn inngest.DeployedFunction, includeOutput bool) *apiv2.FunctionRun {
+func toFunctionRun(run *cqrs.FunctionRun, fn inngest.DeployedFunction) *apiv2.FunctionRun {
 	queuedAt := timestamppb.New(ulid.Time(run.RunID.Time()))
 	startedAt := timestamppb.New(run.RunStartedAt)
 
@@ -113,10 +118,6 @@ func toFunctionRun(run *cqrs.FunctionRun, fn inngest.DeployedFunction, includeOu
 		result.EndedAt = timestamppb.New(*run.EndedAt)
 		duration := uint64(run.EndedAt.Sub(run.RunStartedAt) / time.Millisecond)
 		result.DurationMs = &duration
-	}
-
-	if includeOutput {
-		result.Output = jsonToStruct(run.Output)
 	}
 
 	return result
@@ -159,17 +160,30 @@ func jsonToStruct(raw json.RawMessage) *structpb.Struct {
 		return nil
 	}
 
-	var value map[string]any
+	var value any
 	if err := json.Unmarshal(raw, &value); err != nil {
 		return nil
 	}
 
-	result, err := structpb.NewStruct(value)
+	if object, ok := value.(map[string]any); ok {
+		result, err := structpb.NewStruct(object)
+		if err != nil {
+			return nil
+		}
+
+		return result
+	}
+
+	wrapped, err := structpb.NewValue(value)
 	if err != nil {
 		return nil
 	}
 
-	return result
+	return &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"data": wrapped,
+		},
+	}
 }
 
 func optionalString(value string) *string {
@@ -354,4 +368,35 @@ func loadTraceOutput(ctx context.Context, reader FunctionTraceReader, encodedID 
 		input:  jsonToStruct(json.RawMessage(data.Input)),
 		output: jsonToStruct(json.RawMessage(data.Data)),
 	}, nil
+}
+
+func (s *Service) functionRunOutput(ctx context.Context, runID ulid.ULID, fallback json.RawMessage) *structpb.Struct {
+	if output := s.traceRunOutput(ctx, runID); output != nil {
+		return output
+	}
+
+	return jsonToStruct(fallback)
+}
+
+func (s *Service) traceRunOutput(ctx context.Context, runID ulid.ULID) *structpb.Struct {
+	if s.traces == nil {
+		return nil
+	}
+
+	root, err := s.traces.GetSpansByRunID(ctx, runID)
+	if err != nil || root == nil {
+		return nil
+	}
+
+	outputID := root.GetOutputID()
+	if outputID == nil {
+		return nil
+	}
+
+	output, err := loadTraceOutput(ctx, s.traces, *outputID)
+	if err != nil || output == nil {
+		return nil
+	}
+
+	return output.output
 }

--- a/pkg/api/v2/endpoints_runs.go
+++ b/pkg/api/v2/endpoints_runs.go
@@ -45,7 +45,7 @@ func (s *Service) GetFunctionRun(ctx context.Context, req *apiv2.GetFunctionRunR
 
 	data := toFunctionRun(run, fn)
 	if req.GetIncludeOutput() {
-		data.Output = s.functionRunOutput(ctx, runID, run.Output)
+		data.Output = s.traceRunOutput(ctx, runID)
 	}
 
 	return &apiv2.GetFunctionRunResponse{
@@ -368,14 +368,6 @@ func loadTraceOutput(ctx context.Context, reader FunctionTraceReader, encodedID 
 		input:  jsonToStruct(json.RawMessage(data.Input)),
 		output: jsonToStruct(json.RawMessage(data.Data)),
 	}, nil
-}
-
-func (s *Service) functionRunOutput(ctx context.Context, runID ulid.ULID, fallback json.RawMessage) *structpb.Struct {
-	if output := s.traceRunOutput(ctx, runID); output != nil {
-		return output
-	}
-
-	return jsonToStruct(fallback)
 }
 
 func (s *Service) traceRunOutput(ctx context.Context, runID ulid.ULID) *structpb.Struct {

--- a/pkg/api/v2/endpoints_runs_test.go
+++ b/pkg/api/v2/endpoints_runs_test.go
@@ -39,7 +39,6 @@ func TestToFunctionRun(t *testing.T) {
 		Cron:         &cron,
 		Status:       enums.RunStatusCompleted,
 		EndedAt:      &endedAt,
-		Output:       json.RawMessage(`{"ok":true}`),
 	}, inngest.DeployedFunction{
 		AppID:   appID,
 		AppName: "agent-app",
@@ -48,7 +47,7 @@ func TestToFunctionRun(t *testing.T) {
 			Name: "Summarize",
 			Slug: "summary",
 		},
-	}, true)
+	})
 
 	require.Equal(t, runID.String(), result.Id)
 	require.Equal(t, "summary", result.Function.Id)
@@ -63,18 +62,17 @@ func TestToFunctionRun(t *testing.T) {
 	require.True(t, result.Trigger.IsBatch)
 	require.Equal(t, batchID.String(), *result.Trigger.BatchId)
 	require.Equal(t, cron, *result.Trigger.CronSchedule)
-	require.True(t, result.Output.Fields["ok"].GetBoolValue())
+	require.Nil(t, result.Output)
 }
 
-func TestToFunctionRunOmitsOutputWhenNotRequested(t *testing.T) {
+func TestToFunctionRunOmitsOptionalFields(t *testing.T) {
 	runID := ulid.MustParse("01hp1zx8m3ng9vp6qn0xk7j4cy")
 
 	result := toFunctionRun(&cqrs.FunctionRun{
 		RunID:        runID,
 		RunStartedAt: time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC),
 		EventID:      runID,
-		Output:       json.RawMessage(`{"ok":true}`),
-	}, inngest.DeployedFunction{}, false)
+	}, inngest.DeployedFunction{})
 
 	require.Nil(t, result.Output)
 	require.Nil(t, result.DurationMs)
@@ -147,10 +145,28 @@ func TestJSONToStruct(t *testing.T) {
 		require.Equal(t, float64(2), result.Fields["count"].GetNumberValue())
 	})
 
+	t.Run("wraps non-object JSON values", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			raw  json.RawMessage
+		}{
+			{name: "string", raw: json.RawMessage(`"hello"`)},
+			{name: "array", raw: json.RawMessage(`[1,2,3]`)},
+			{name: "number", raw: json.RawMessage(`42`)},
+			{name: "boolean", raw: json.RawMessage(`true`)},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				result := jsonToStruct(tc.raw)
+
+				require.NotNil(t, result)
+				require.Contains(t, result.Fields, "data")
+			})
+		}
+	})
+
 	t.Run("returns nil for empty or invalid JSON", func(t *testing.T) {
 		require.Nil(t, jsonToStruct(nil))
 		require.Nil(t, jsonToStruct(json.RawMessage(`not-json`)))
-		require.Nil(t, jsonToStruct(json.RawMessage(`[]`)))
 	})
 }
 

--- a/pkg/api/v2/http_test.go
+++ b/pkg/api/v2/http_test.go
@@ -124,7 +124,7 @@ func TestHTTPGateway_RunEnumsUseShortJSONNames(t *testing.T) {
 	functions := &mockFunctionProvider{}
 	functions.On("GetFunction", mock.Anything, functionID.String()).Return(fn, nil).Once()
 	runs := &mockFunctionRunReader{}
-	runs.On("GetFunctionRun", mock.Anything, runID).Return(functionRun, nil).Once()
+	runs.On("GetFunctionRun", mock.Anything, runID, GetFunctionRunOpts{}).Return(functionRun, nil).Once()
 
 	handler, err := newTestHTTPHandler(ctx, ServiceOptions{
 		Functions:    functions,

--- a/pkg/api/v2/interfaces.go
+++ b/pkg/api/v2/interfaces.go
@@ -32,8 +32,12 @@ type EventPublisher interface {
 	Publish(ctx context.Context, event event.TrackedEvent) error
 }
 
+type GetFunctionRunOpts struct {
+	IncludeOutput bool
+}
+
 type FunctionRunReader interface {
-	GetFunctionRun(ctx context.Context, runID ulid.ULID) (*cqrs.FunctionRun, error)
+	GetFunctionRun(ctx context.Context, runID ulid.ULID, opts GetFunctionRunOpts) (*cqrs.FunctionRun, error)
 }
 
 type FunctionTraceReader interface {

--- a/pkg/api/v2/service_test.go
+++ b/pkg/api/v2/service_test.go
@@ -359,6 +359,58 @@ func TestService_GetFunctionRun(t *testing.T) {
 		require.Nil(t, resp)
 		require.ErrorContains(t, err, "Function not found")
 	})
+
+	t.Run("uses root trace output when requested", func(t *testing.T) {
+		inputSpanID := "input-span"
+		outputIdentifier := cqrs.SpanIdentifier{
+			SpanID:      "output-span",
+			InputSpanID: &inputSpanID,
+			Preview:     boolPtr(true),
+		}
+		outputID, err := outputIdentifier.Encode()
+		require.NoError(t, err)
+
+		runs := &mockFunctionRunReader{}
+		runs.On("GetFunctionRun", mock.Anything, runID).Return(&cqrs.FunctionRun{
+			RunID:        runID,
+			RunStartedAt: startedAt,
+			FunctionID:   functionID,
+			EventID:      runID,
+			Status:       enums.RunStatusCompleted,
+			EndedAt:      &endedAt,
+			Output:       json.RawMessage(`""`),
+		}, nil).Once()
+		functions := &mockFunctionProvider{}
+		functions.On("GetFunction", mock.Anything, functionID.String()).Return(fn, nil).Once()
+		traces := &mockFunctionTraceReader{}
+		traces.On("GetSpansByRunID", mock.Anything, runID).Return(&cqrs.OtelSpan{
+			RunID:    runID,
+			OutputID: &outputID,
+		}, nil).Once()
+		traces.On("GetSpanOutput", mock.Anything, outputIdentifier).Return(&cqrs.SpanOutput{
+			Data: []byte(`{"body":"Hello, World!"}`),
+		}, nil).Once()
+		t.Cleanup(func() {
+			runs.AssertExpectations(t)
+			functions.AssertExpectations(t)
+			traces.AssertExpectations(t)
+		})
+
+		service := NewService(ServiceOptions{
+			Functions:      functions,
+			FunctionRuns:   runs,
+			FunctionTraces: traces,
+		})
+
+		resp, err := service.GetFunctionRun(context.Background(), &apiv2.GetFunctionRunRequest{
+			RunId:         runID.String(),
+			IncludeOutput: boolPtr(true),
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp.Data.Output)
+		require.Equal(t, "Hello, World!", resp.Data.Output.Fields["body"].GetStringValue())
+	})
 }
 
 func TestToTraceSpanStatus(t *testing.T) {

--- a/pkg/api/v2/service_test.go
+++ b/pkg/api/v2/service_test.go
@@ -246,9 +246,6 @@ func TestService_GetFunctionRun(t *testing.T) {
 	appID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
 	startedAt := time.Date(2026, 4, 9, 12, 0, 0, 0, time.UTC)
 	endedAt := startedAt.Add(2 * time.Second)
-	output, err := json.Marshal(map[string]any{"ok": true})
-	require.NoError(t, err)
-
 	fn := inngest.DeployedFunction{
 		ID:      functionID,
 		Slug:    "my-app-test-fn",
@@ -266,7 +263,6 @@ func TestService_GetFunctionRun(t *testing.T) {
 		EventID:      runID,
 		Status:       enums.RunStatusCompleted,
 		EndedAt:      &endedAt,
-		Output:       output,
 	}
 	functions := &mockFunctionProvider{}
 	functions.On("GetFunction", mock.Anything, functionID.String()).Return(fn, nil).Once()
@@ -295,8 +291,7 @@ func TestService_GetFunctionRun(t *testing.T) {
 		require.Equal(t, "test-fn", resp.Data.Function.Id)
 		require.Equal(t, "Test function", resp.Data.Function.Name)
 		require.Equal(t, "my-app", resp.Data.App.Id)
-		require.NotNil(t, resp.Data.Output)
-		require.Equal(t, true, resp.Data.Output.Fields["ok"].GetBoolValue())
+		require.Nil(t, resp.Data.Output)
 		require.NotNil(t, resp.Data.DurationMs)
 		require.Equal(t, uint64(2000), *resp.Data.DurationMs)
 	})
@@ -410,6 +405,38 @@ func TestService_GetFunctionRun(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp.Data.Output)
 		require.Equal(t, "Hello, World!", resp.Data.Output.Fields["body"].GetStringValue())
+	})
+
+	t.Run("does not fall back to run output", func(t *testing.T) {
+		runs := &mockFunctionRunReader{}
+		runs.On("GetFunctionRun", mock.Anything, runID).Return(&cqrs.FunctionRun{
+			RunID:        runID,
+			RunStartedAt: startedAt,
+			FunctionID:   functionID,
+			EventID:      runID,
+			Status:       enums.RunStatusCompleted,
+			EndedAt:      &endedAt,
+			Output:       json.RawMessage(`{"old":true}`),
+		}, nil).Once()
+		functions := &mockFunctionProvider{}
+		functions.On("GetFunction", mock.Anything, functionID.String()).Return(fn, nil).Once()
+		t.Cleanup(func() {
+			runs.AssertExpectations(t)
+			functions.AssertExpectations(t)
+		})
+
+		service := NewService(ServiceOptions{
+			Functions:    functions,
+			FunctionRuns: runs,
+		})
+
+		resp, err := service.GetFunctionRun(context.Background(), &apiv2.GetFunctionRunRequest{
+			RunId:         runID.String(),
+			IncludeOutput: boolPtr(true),
+		})
+
+		require.NoError(t, err)
+		require.Nil(t, resp.Data.Output)
 	})
 }
 

--- a/pkg/api/v2/service_test.go
+++ b/pkg/api/v2/service_test.go
@@ -267,7 +267,7 @@ func TestService_GetFunctionRun(t *testing.T) {
 	functions := &mockFunctionProvider{}
 	functions.On("GetFunction", mock.Anything, functionID.String()).Return(fn, nil).Once()
 	runs := &mockFunctionRunReader{}
-	runs.On("GetFunctionRun", mock.Anything, runID).Return(run, nil).Once()
+	runs.On("GetFunctionRun", mock.Anything, runID, GetFunctionRunOpts{IncludeOutput: true}).Return(run, nil).Once()
 
 	service := NewService(ServiceOptions{
 		Functions:    functions,
@@ -314,7 +314,7 @@ func TestService_GetFunctionRun(t *testing.T) {
 
 	t.Run("returns not found when run is missing", func(t *testing.T) {
 		runs := &mockFunctionRunReader{}
-		runs.On("GetFunctionRun", mock.Anything, runID).Return(nil, errors.New("missing")).Once()
+		runs.On("GetFunctionRun", mock.Anything, runID, GetFunctionRunOpts{}).Return(nil, errors.New("missing")).Once()
 		t.Cleanup(func() {
 			runs.AssertExpectations(t)
 		})
@@ -334,7 +334,7 @@ func TestService_GetFunctionRun(t *testing.T) {
 
 	t.Run("returns not found when function is missing", func(t *testing.T) {
 		runs := &mockFunctionRunReader{}
-		runs.On("GetFunctionRun", mock.Anything, runID).Return(run, nil).Once()
+		runs.On("GetFunctionRun", mock.Anything, runID, GetFunctionRunOpts{}).Return(run, nil).Once()
 		functions := &mockFunctionProvider{}
 		functions.On("GetFunction", mock.Anything, functionID.String()).Return(inngest.DeployedFunction{}, errors.New("missing")).Once()
 		t.Cleanup(func() {
@@ -366,7 +366,7 @@ func TestService_GetFunctionRun(t *testing.T) {
 		require.NoError(t, err)
 
 		runs := &mockFunctionRunReader{}
-		runs.On("GetFunctionRun", mock.Anything, runID).Return(&cqrs.FunctionRun{
+		runs.On("GetFunctionRun", mock.Anything, runID, GetFunctionRunOpts{IncludeOutput: true}).Return(&cqrs.FunctionRun{
 			RunID:        runID,
 			RunStartedAt: startedAt,
 			FunctionID:   functionID,
@@ -409,7 +409,7 @@ func TestService_GetFunctionRun(t *testing.T) {
 
 	t.Run("does not fall back to run output", func(t *testing.T) {
 		runs := &mockFunctionRunReader{}
-		runs.On("GetFunctionRun", mock.Anything, runID).Return(&cqrs.FunctionRun{
+		runs.On("GetFunctionRun", mock.Anything, runID, GetFunctionRunOpts{IncludeOutput: true}).Return(&cqrs.FunctionRun{
 			RunID:        runID,
 			RunStartedAt: startedAt,
 			FunctionID:   functionID,

--- a/pkg/api/v2/test_mocks_test.go
+++ b/pkg/api/v2/test_mocks_test.go
@@ -27,8 +27,8 @@ type mockFunctionRunReader struct {
 	mock.Mock
 }
 
-func (m *mockFunctionRunReader) GetFunctionRun(ctx context.Context, runID ulid.ULID) (*cqrs.FunctionRun, error) {
-	args := m.Called(ctx, runID)
+func (m *mockFunctionRunReader) GetFunctionRun(ctx context.Context, runID ulid.ULID, opts GetFunctionRunOpts) (*cqrs.FunctionRun, error) {
+	args := m.Called(ctx, runID, opts)
 	run, _ := args.Get(0).(*cqrs.FunctionRun)
 	return run, args.Error(1)
 }

--- a/pkg/devserver/agentic_api_adapters_test.go
+++ b/pkg/devserver/agentic_api_adapters_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	apiv2 "github.com/inngest/inngest/pkg/api/v2"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/oklog/ulid/v2"
@@ -88,7 +89,7 @@ func TestFunctionRunReader(t *testing.T) {
 	run := &cqrs.FunctionRun{RunID: runID}
 	reader := &fakeFunctionRunReader{run: run}
 
-	result, err := NewFunctionRunReader(reader).GetFunctionRun(context.Background(), runID)
+	result, err := NewFunctionRunReader(reader).GetFunctionRun(context.Background(), runID, apiv2.GetFunctionRunOpts{})
 
 	require.NoError(t, err)
 	require.Equal(t, run, result)

--- a/pkg/devserver/function_run_reader.go
+++ b/pkg/devserver/function_run_reader.go
@@ -17,6 +17,6 @@ func NewFunctionRunReader(reader cqrs.APIV1FunctionRunReader) apiv2.FunctionRunR
 	return &cqrsFunctionRunReader{reader: reader}
 }
 
-func (r *cqrsFunctionRunReader) GetFunctionRun(ctx context.Context, runID ulid.ULID) (*cqrs.FunctionRun, error) {
+func (r *cqrsFunctionRunReader) GetFunctionRun(ctx context.Context, runID ulid.ULID, _ apiv2.GetFunctionRunOpts) (*cqrs.FunctionRun, error) {
 	return r.reader.GetFunctionRun(ctx, consts.DevServerAccountID, consts.DevServerEnvID, runID)
 }


### PR DESCRIPTION
## Description

Outputs stopped working between when v2 runs was released in oss (https://github.com/inngest/inngest/pull/3985) and now, so maybe related to a v1 -> v2 change. Run output is now read from the root trace span output instead of the legacy run output field and drops support for old trace fallbacks.

Adds include_output to the internal FunctionRunReader API so implementations can avoid loading output unless the public rest request explicitly asks for it, which is good for monorepo clickhouse performance. 

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
