### PR TITLE
fix: Properly calculate discover step

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/TimelineBar.types.ts
+++ b/ui/packages/components/src/RunDetailsV4/TimelineBar.types.ts
@@ -333,7 +333,7 @@ export interface TimingBreakdownData {
  * Per-step-attempt breakdown combining metadata and timestamp-derived phases.
  */
 export interface InngestBreakdownData {
-  /** Discovery time: SDK executing user code until it discovers this step (run.startedAt → step.queuedAt) */
+  /** Discovery time: SDK executing user code until it discovers this step (previous step end → step.queuedAt) */
   discoveryMs: number;
 
   /** Sojourn delay from concurrency limits, throttle, or other constraints (from metadata) */

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
@@ -378,6 +378,34 @@ describe('traceConversion', () => {
       expect(childBar?.inngestBreakdown?.totalMs).toBe(3000);
     });
 
+    it('calculates discovery from the previous completed sibling instead of run start', () => {
+      const trace = createTrace({
+        isRoot: true,
+        startedAt: '2024-01-01T00:00:00Z',
+        childrenSpans: [
+          createTrace({
+            spanID: 'slow-step',
+            stepOp: 'RUN',
+            queuedAt: '2024-01-01T00:00:00Z',
+            startedAt: '2024-01-01T00:00:00Z',
+            endedAt: '2024-01-01T00:00:08Z',
+          }),
+          createTrace({
+            spanID: 'quick-step',
+            stepOp: 'RUN',
+            queuedAt: '2024-01-01T00:00:08.100Z',
+            startedAt: '2024-01-01T00:00:08.100Z',
+            endedAt: '2024-01-01T00:00:08.350Z',
+          }),
+        ],
+      });
+      const result = traceToTimelineData(trace, { runID: 'run-1' });
+
+      const quickStep = result.bars[0]?.children?.[1];
+      expect(quickStep?.inngestBreakdown?.discoveryMs).toBe(100);
+      expect(quickStep?.inngestBreakdown?.totalMs).toBe(100);
+    });
+
     it('returns no inngestBreakdown without metadata timing', () => {
       const trace = createTrace({
         isRoot: true,

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
@@ -124,13 +124,14 @@ function getTimingFromMetadata(
  */
 function getInngestBreakdown(
   trace: Trace,
-  runStartedAtMs: number | null
+  discoveryStartAtMs: number | null
 ): InngestBreakdownData | null {
   if (!trace.queuedAt) return null;
 
-  // Discovery: time from when the run started executing to when this step was queued
+  // Discovery: time from the previous completed sibling to when this step was queued.
   const stepQueuedAt = new Date(trace.queuedAt).getTime();
-  const discoveryMs = runStartedAtMs !== null ? Math.max(0, stepQueuedAt - runStartedAtMs) : 0;
+  const discoveryMs =
+    discoveryStartAtMs !== null ? Math.max(0, stepQueuedAt - discoveryStartAtMs) : 0;
 
   // Concurrency delay + system latency from metadata
   let queueDelayMs = 0;
@@ -148,6 +149,40 @@ function getInngestBreakdown(
   if (totalMs <= 0) return null;
 
   return { discoveryMs, queueDelayMs, systemLatencyMs, totalMs };
+}
+
+function tracesToBarData(
+  traces: Trace[] | undefined,
+  orgName?: string,
+  rootStatus?: string,
+  initialDiscoveryStartAtMs?: number | null,
+  functionSlug?: string
+): TimelineBarData[] | undefined {
+  if (!traces) return undefined;
+
+  let latestCompletedSiblingEndMs = initialDiscoveryStartAtMs ?? null;
+  const bars: TimelineBarData[] = [];
+  for (const trace of traces) {
+    const bar = traceToBarData(
+      trace,
+      orgName,
+      rootStatus,
+      latestCompletedSiblingEndMs,
+      functionSlug
+    );
+
+    if (bar.endTime) {
+      const endMs = bar.endTime.getTime();
+      latestCompletedSiblingEndMs =
+        latestCompletedSiblingEndMs === null
+          ? endMs
+          : Math.max(latestCompletedSiblingEndMs, endMs);
+    }
+
+    bars.push(bar);
+  }
+
+  return bars;
 }
 
 /**
@@ -180,7 +215,7 @@ function traceToBarData(
   trace: Trace,
   orgName?: string,
   rootStatus?: string,
-  runStartedAtMs?: number | null,
+  discoveryStartAtMs?: number | null,
   functionSlug?: string
 ): TimelineBarData {
   const isStepRun = isStepRunSpan(trace) && !trace.isUserland;
@@ -205,8 +240,14 @@ function traceToBarData(
 
   // Per-step Inngest overhead breakdown (discovery + metadata timing)
   const inngestBreakdown = isStepRun
-    ? getInngestBreakdown(trace, runStartedAtMs ?? null) ?? undefined
+    ? getInngestBreakdown(trace, discoveryStartAtMs ?? null) ?? undefined
     : undefined;
+
+  const traceStartedAtMs = trace.startedAt ? new Date(trace.startedAt).getTime() : null;
+  const traceQueuedAtMs = trace.queuedAt ? new Date(trace.queuedAt).getTime() : null;
+  const childDiscoveryStartAtMs = trace.isRoot
+    ? (traceStartedAtMs ?? discoveryStartAtMs)
+    : (traceStartedAtMs ?? traceQueuedAtMs ?? discoveryStartAtMs);
 
   // Check if this step has experiment metadata
   const hasExperiment = trace.metadata?.some((m) => m.kind === KindInngestExperiment) ?? false;
@@ -229,8 +270,12 @@ function traceToBarData(
     startTime: new Date(trace.queuedAt),
     endTime: trace.endedAt ? new Date(trace.endedAt) : null,
     style: getStyleForTrace(trace),
-    children: trace.childrenSpans?.map((child) =>
-      traceToBarData(child, orgName, rootStatus, runStartedAtMs, functionSlug)
+    children: tracesToBarData(
+      trace.childrenSpans,
+      orgName,
+      rootStatus,
+      childDiscoveryStartAtMs,
+      functionSlug
     ),
     timingBreakdown,
     httpTimingBreakdown,


### PR DESCRIPTION
## Description

Previously, we would calculate discovery time from the start of the run to queued at

This makes discovery timing calculation based on the previous completed step