### PR TITLE
fix(queue): quarantine deleted account partitions

### DIFF
--- a/pkg/execution/queue/account_exists.go
+++ b/pkg/execution/queue/account_exists.go
@@ -1,0 +1,61 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/telemetry/metrics"
+)
+
+const (
+	deletedAccountPartitionActionFound           = "found"
+	deletedAccountPartitionActionQuarantined     = "quarantined"
+	deletedAccountPartitionActionCheckError      = "check_error"
+	deletedAccountPartitionActionQuarantineError = "quarantine_error"
+)
+
+func (q *queueProcessor) accountExists(ctx context.Context, accountID uuid.UUID) (bool, error) {
+	if accountID == uuid.Nil {
+		return true, nil
+	}
+
+	if q.AccountExists == nil {
+		return true, nil
+	}
+
+	return q.AccountExists(ctx, accountID)
+}
+
+func (q *queueProcessor) requeueDeletedAccountPartition(ctx context.Context, shard QueueShard, p *QueuePartition) error {
+	requeueAt := q.Clock().Now().Add(PartitionDeletedAccountRequeueExtension)
+	if err := shard.PartitionRequeue(ctx, p, requeueAt, true); err != nil {
+		metrics.IncrQueueDeletedAccountPartitionCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags: map[string]any{
+				"queue_shard": shard.Name(),
+				"action":      deletedAccountPartitionActionQuarantineError,
+			},
+		})
+		return fmt.Errorf("error requeueing deleted account partition: %w", err)
+	}
+
+	metrics.IncrQueueDeletedAccountPartitionCounter(ctx, metrics.CounterOpt{
+		PkgName: pkgName,
+		Tags: map[string]any{
+			"queue_shard": shard.Name(),
+			"action":      deletedAccountPartitionActionQuarantined,
+		},
+	})
+
+	logger.StdlibLogger(ctx).Warn(
+		"requeued partition for deleted account",
+		"account_id", p.AccountID.String(),
+		"partition_id", p.ID,
+		"queue_shard", shard.Name(),
+		"requeue_at", requeueAt,
+	)
+
+	return nil
+}

--- a/pkg/execution/queue/consts.go
+++ b/pkg/execution/queue/consts.go
@@ -33,10 +33,11 @@ const (
 	// NOTE: This must be greater than PartitionLookahead
 	// NOTE: This is the maximum latency introduced into concurrnecy limited partitions in the
 	//       worst case.
-	PartitionConcurrencyLimitRequeueExtension  = 5 * time.Second
+	PartitionConcurrencyLimitRequeueExtension = 5 * time.Second
 	PartitionSemaphoreLimitRequeueExtension   = 1 * time.Second
 	PartitionThrottleLimitRequeueExtension    = 1 * time.Second
 	PartitionPausedRequeueExtension           = 5 * time.Minute
+	PartitionDeletedAccountRequeueExtension   = 7 * 24 * time.Hour
 	PartitionLookahead                        = time.Second
 
 	ShadowPartitionLeaseDuration  = 4 * time.Second // same as PartitionLeaseDuration

--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -23,6 +23,9 @@ type PartitionPriorityFinder func(ctx context.Context, part QueuePartition) uint
 // AccountPriorityFinder returns the priority for a given account.
 type AccountPriorityFinder func(ctx context.Context, accountId uuid.UUID) uint
 
+// AccountExists reports whether an account can still process queue partitions.
+type AccountExists func(ctx context.Context, accountID uuid.UUID) (bool, error)
+
 type PartitionPausedInfo struct {
 	Stale  bool
 	Paused bool
@@ -60,6 +63,14 @@ func WithPartitionPausedGetter(partitionPausedGetter PartitionPausedGetter) Queu
 func WithAccountPriorityFinder(apf AccountPriorityFinder) QueueOpt {
 	return func(q *QueueOptions) {
 		q.AccountPriorityFinder = apf
+	}
+}
+
+func WithAccountExists(f AccountExists) QueueOpt {
+	return func(q *QueueOptions) {
+		if f != nil {
+			q.AccountExists = f
+		}
 	}
 }
 
@@ -326,6 +337,7 @@ type QueueRunMode struct {
 type QueueOptions struct {
 	PartitionPriorityFinder PartitionPriorityFinder
 	AccountPriorityFinder   AccountPriorityFinder
+	AccountExists           AccountExists
 	PartitionPausedGetter   PartitionPausedGetter
 
 	lifecycles QueueLifecycleListeners
@@ -686,6 +698,9 @@ func NewQueueOptions(
 		},
 		AccountPriorityFinder: func(_ context.Context, _ uuid.UUID) uint {
 			return PriorityDefault
+		},
+		AccountExists: func(_ context.Context, _ uuid.UUID) (bool, error) {
+			return true, nil
 		},
 		PartitionPausedGetter: func(ctx context.Context, fnID uuid.UUID) PartitionPausedInfo {
 			return PartitionPausedInfo{}

--- a/pkg/execution/queue/process_partition.go
+++ b/pkg/execution/queue/process_partition.go
@@ -84,6 +84,30 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 		return fmt.Errorf("error leasing partition: %w", err)
 	}
 
+	if !p.IsSystem() {
+		accountExists, err := q.accountExists(ctx, p.AccountID)
+		if err != nil {
+			metrics.IncrQueueDeletedAccountPartitionCounter(ctx, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags: map[string]any{
+					"queue_shard": shard.Name(),
+					"action":      deletedAccountPartitionActionCheckError,
+				},
+			})
+			l.Warn("error checking account existence for partition", "error", err, "account_id", p.AccountID.String(), "partition_id", p.ID)
+		} else if !accountExists {
+			metrics.IncrQueueDeletedAccountPartitionCounter(ctx, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags: map[string]any{
+					"queue_shard": shard.Name(),
+					"action":      deletedAccountPartitionActionFound,
+				},
+			})
+			span.SetAttributes(attribute.String("status", "deleted_account"))
+			return q.requeueDeletedAccountPartition(ctx, shard, p)
+		}
+	}
+
 	begin := q.Clock().Now()
 	defer func() {
 		metrics.HistogramProcessPartitionDuration(ctx, q.Clock().Since(begin).Milliseconds(), metrics.HistogramOpt{

--- a/pkg/execution/queue/process_partition_deleted_account_test.go
+++ b/pkg/execution/queue/process_partition_deleted_account_test.go
@@ -1,0 +1,48 @@
+package queue
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessPartitionRequeuesDeletedAccount(t *testing.T) {
+	ctx := context.Background()
+	now := clockwork.NewFakeClock()
+	accountID := uuid.New()
+	fnID := uuid.New()
+
+	shard := &mockShardForIterator{name: "test-shard"}
+	registry, err := NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+
+	var checks int32
+	q, err := New(
+		ctx,
+		"test",
+		registry,
+		WithClock(now),
+		WithAccountExists(func(context.Context, uuid.UUID) (bool, error) {
+			atomic.AddInt32(&checks, 1)
+			return false, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	err = q.ProcessPartition(ctx, &QueuePartition{
+		ID:         fnID.String(),
+		FunctionID: &fnID,
+		AccountID:  accountID,
+	}, 0, false)
+	require.NoError(t, err)
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&checks))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shard.partitionLeaseCount))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shard.partitionRequeueCount))
+	require.True(t, shard.partitionRequeueForceAt)
+	require.Equal(t, now.Now().Add(PartitionDeletedAccountRequeueExtension), shard.partitionRequeueAt)
+}

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -56,7 +56,11 @@ func (m *mockQueueProcessor) ClearShadowContinuations() {
 
 // mockShardForIterator implements the minimal QueueShard interface methods used by ProcessorIterator
 type mockShardForIterator struct {
-	name string
+	name                    string
+	partitionLeaseCount     int32
+	partitionRequeueCount   int32
+	partitionRequeueAt      time.Time
+	partitionRequeueForceAt bool
 }
 
 func (m *mockShardForIterator) Name() string {
@@ -125,10 +129,15 @@ func (m *mockShardForIterator) PartitionPeek(ctx context.Context, sequential boo
 }
 
 func (m *mockShardForIterator) PartitionLease(ctx context.Context, p *QueuePartition, duration time.Duration, opts ...PartitionLeaseOpt) (*ulid.ULID, error) {
-	return nil, nil
+	atomic.AddInt32(&m.partitionLeaseCount, 1)
+	id := ulid.Make()
+	return &id, nil
 }
 
 func (m *mockShardForIterator) PartitionRequeue(ctx context.Context, p *QueuePartition, at time.Time, forceAt bool) error {
+	atomic.AddInt32(&m.partitionRequeueCount, 1)
+	m.partitionRequeueAt = at
+	m.partitionRequeueForceAt = forceAt
 	return nil
 }
 

--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -94,6 +94,15 @@ func IncrQueuePartitionProcessedCounter(ctx context.Context, opts CounterOpt) {
 	})
 }
 
+func IncrQueueDeletedAccountPartitionCounter(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "queue_deleted_account_partition_total",
+		Description: "The total number of queue partitions found for deleted accounts",
+		Tags:        opts.Tags,
+	})
+}
+
 func IncrPartitionGoneCounter(ctx context.Context, opts CounterOpt) {
 	RecordCounterMetric(ctx, 1, CounterOpt{
 		PkgName:     opts.PkgName,


### PR DESCRIPTION
Description
- Add an optional queue AccountExists hook with a default that preserves existing behavior.
- Check account existence after partition lease and before item peeking for non-system partitions.
- Requeue deleted-account partitions 7 days out and emit queue_deleted_account_partition_total metrics.

Release note
None

Migration note
None

Tests
- go test -count=1 ./pkg/execution/queue