### PR TITLE
Fix: Update Events List and docs in v1/events endpoint to limit to 51 and return 400 if limit is greater than 51

### DIFF
--- a/docs/api-docs/public/api-specs/v1.json
+++ b/docs/api-docs/public/api-specs/v1.json
@@ -55,7 +55,7 @@
             "schema": {
               "type": "number",
               "minimum": 1,
-              "maximum": 100
+              "maximum": 51
             },
             "in": "query",
             "name": "limit",

--- a/docs/api-docs/public/api-specs/v1.yaml
+++ b/docs/api-docs/public/api-specs/v1.yaml
@@ -57,7 +57,7 @@ paths:
         - schema:
             type: number
             minimum: 1
-            maximum: 100
+            maximum: 51
           in: query
           name: limit
           description: The number of events to list

--- a/docs/openapi/v3/api/v1/spec.yaml
+++ b/docs/openapi/v3/api/v1/spec.yaml
@@ -54,7 +54,7 @@ paths:
         - schema:
             type: number
             minimum: 1
-            maximum: 100
+            maximum: 51
           in: query
           name: limit
           description: The number of events to list

--- a/pkg/api/apiv1/events.go
+++ b/pkg/api/apiv1/events.go
@@ -13,7 +13,6 @@ import (
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/publicerr"
-	"github.com/inngest/inngest/pkg/util"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -55,7 +54,11 @@ func (a router) getEvents(w http.ResponseWriter, r *http.Request) {
 	if limit == 0 {
 		limit = DefaultEvents
 	}
-	opts.Limit = util.Bound(limit, 1, cqrs.MaxEvents)
+	if limit < 1 || limit > cqrs.MaxEvents {
+		_ = publicerr.WriteHTTP(w, publicerr.Errorf(400, "Invalid limit query parameter: must be between 1 and %d", cqrs.MaxEvents))
+		return
+	}
+	opts.Limit = limit
 
 	if cursor := r.FormValue("cursor"); cursor != "" {
 		parsed, err := ulid.Parse(cursor)

--- a/tests/golang/event_list_test.go
+++ b/tests/golang/event_list_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"slices"
 	"testing"
 	"time"
 
+	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/coreapi/graph/models"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/tests/client"
@@ -669,6 +671,50 @@ func TestEventList(t *testing.T) {
 			return e.Node.Name == eventName
 		}))
 
+	})
+
+	t.Run("limit exceeds max returns 400", func(t *testing.T) {
+		r := require.New(t)
+		c := client.New(t)
+
+		for _, limit := range []int{cqrs.MaxEvents + 1, 1000, -1} {
+			req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/events?limit=%d", limit), nil)
+			r.NoError(err)
+
+			resp, err := c.Do(req)
+			r.NoError(err)
+			defer resp.Body.Close()
+
+			var body struct {
+				Error  string `json:"error"`
+				Status int    `json:"status"`
+			}
+			r.NoError(json.NewDecoder(resp.Body).Decode(&body))
+			r.Equal(http.StatusBadRequest, body.Status, "limit=%d should return 400, got %d: %s", limit, body.Status, body.Error)
+			r.NotEmpty(body.Error)
+		}
+	})
+
+	t.Run("limit within max returns 200", func(t *testing.T) {
+		r := require.New(t)
+		c := client.New(t)
+
+		for _, limit := range []int{1, 25, cqrs.MaxEvents} {
+			req, err := c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/events?limit=%d", limit), nil)
+			r.NoError(err)
+
+			resp, err := c.Do(req)
+			r.NoError(err)
+			defer resp.Body.Close()
+
+			var body struct {
+				Data     json.RawMessage `json:"data"`
+				Metadata json.RawMessage `json:"metadata"`
+			}
+			r.NoError(json.NewDecoder(resp.Body).Decode(&body))
+			r.NotNil(body.Data, "limit=%d should return data", limit)
+			r.NotNil(body.Metadata, "limit=%d should return metadata", limit)
+		}
 	})
 
 }


### PR DESCRIPTION
## Description

Our v1 Rest API only returns 51 records although our api spec docs have maximum set to 100. Change is updating the docs to show 51 and returning 400 if a request send limits over 51

## Release note

  The /v1/events endpoint now returns a 400 Bad Request when the limit query parameter is 
  less than 1 or greater than 51. Previously, out-of-range values were silently clamped to
   the nearest valid value, which could cause callers to receive fewer events than        
  expected without any indication. The API documentation has also been updated to reflect 
  the correct maximum of 51.



## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
