### PR TITLE
feat: EXE-1837: Add a few Open Inference attributes to Metadata

### DIFF
--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -2,7 +2,6 @@ package extractors
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"math"
 	"net/http"
@@ -14,7 +13,6 @@ import (
 	"github.com/inngest/inngest/pkg/tracing/metadata"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/inngest/inngest/pkg/util/aigateway"
-	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
 //tygo:generate
@@ -51,73 +49,6 @@ func (ms AIMetadata) Serialize() (metadata.Values, error) {
 	}
 
 	return rawMetadata, nil
-}
-
-type AIMetadataExtractor struct{}
-
-func NewAIMetadataExtractor() *AIMetadataExtractor {
-	return &AIMetadataExtractor{}
-}
-
-func (e *AIMetadataExtractor) ExtractSpanMetadata(ctx context.Context, span *tracev1.Span) ([]metadata.Structured, error) {
-	if !e.isLikelyAISpan(span) {
-		return nil, nil // TODO: should this be an explicit "nah, didn't find any" return?
-	}
-
-	aiMetadata := e.extractAIMetadata(span)
-	return []metadata.Structured{aiMetadata}, nil
-}
-
-var aiAttributeKeys = map[string]bool{
-	"gen_ai.usage.input_tokens":  true,
-	"gen_ai.usage.output_tokens": true,
-	"gen_ai.request.model":       true,
-	"gen_ai.system":              true,
-	"gen_ai.operation.name":      true,
-}
-
-func (e *AIMetadataExtractor) isLikelyAISpan(span *tracev1.Span) bool {
-	for _, attr := range span.Attributes {
-		if aiAttributeKeys[attr.Key] {
-			return true
-		}
-	}
-	return false
-}
-
-func (e *AIMetadataExtractor) extractAIMetadata(span *tracev1.Span) AIMetadata {
-	var md AIMetadata
-
-	for _, attr := range span.Attributes {
-		switch attr.Key {
-		case "gen_ai.usage.input_tokens":
-			md.InputTokens = attr.Value.GetIntValue()
-		case "gen_ai.usage.output_tokens":
-			md.OutputTokens = attr.Value.GetIntValue()
-		case "gen_ai.request.model":
-			md.Model = attr.Value.GetStringValue()
-		case "gen_ai.system":
-			md.System = attr.Value.GetStringValue()
-		case "gen_ai.operation.name":
-			md.OperationName = attr.Value.GetStringValue()
-		}
-	}
-
-	// calculate latency from span duration
-	if span.EndTimeUnixNano > span.StartTimeUnixNano {
-		latencyMs := int64((span.EndTimeUnixNano - span.StartTimeUnixNano) / 1_000_000)
-		md.LatencyMs = &latencyMs
-	}
-
-	// calculate total tokens
-	if md.InputTokens > 0 || md.OutputTokens > 0 {
-		totalTokens := md.InputTokens + md.OutputTokens
-		md.TotalTokens = &totalTokens
-	}
-
-	md.EstimatedCost = EstimateCost(md.Model, md.InputTokens, md.OutputTokens)
-
-	return md
 }
 
 func ExtractAIGatewayMetadata(req aigateway.Request, respStatus int, resp []byte, serverProcessingMs int64) ([]metadata.Structured, error) {

--- a/pkg/tracing/metadata/extractors/ai_test.go
+++ b/pkg/tracing/metadata/extractors/ai_test.go
@@ -132,7 +132,7 @@ func TestAIMetadataExtractor_NonAISpan(t *testing.T) {
 
 	require.NoError(t, err)
 
-	assert.Nil(t, metadata, "Non-AI span should not produce metadata")
+	assert.Empty(t, metadata, "Non-AI span should not produce metadata")
 }
 
 func TestExtractAIOutputMetadata_VercelAISDK(t *testing.T) {

--- a/pkg/tracing/metadata/extractors/aimetadata.go
+++ b/pkg/tracing/metadata/extractors/aimetadata.go
@@ -1,0 +1,47 @@
+package extractors
+
+import (
+	"context"
+
+	"github.com/inngest/inngest/pkg/tracing/metadata"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+type AIMetadataExtractor struct{}
+
+func NewAIMetadataExtractor() *AIMetadataExtractor {
+	return &AIMetadataExtractor{}
+}
+
+func (e *AIMetadataExtractor) ExtractSpanMetadata(ctx context.Context, span *tracev1.Span) ([]metadata.Structured, error) {
+	aiMetadata, ok := e.extractAIMetadata(span)
+	if !ok {
+		return nil, nil // TODO: should this be an explicit "nah, didn't find any" return?
+	}
+	return []metadata.Structured{aiMetadata}, nil
+}
+
+// extractAIMetadata populates AIMetadata and returns ok=false when no AI
+// attributes are recognized.
+func (e *AIMetadataExtractor) extractAIMetadata(span *tracev1.Span) (md AIMetadata, ok bool) {
+	foundAny := extractAIMetadataFromAttributes(span.Attributes, &md)
+	if !foundAny {
+		return md, false
+	}
+
+	// calculate latency from span duration
+	if span.EndTimeUnixNano > span.StartTimeUnixNano {
+		latencyMs := int64((span.EndTimeUnixNano - span.StartTimeUnixNano) / 1_000_000)
+		md.LatencyMs = &latencyMs
+	}
+
+	// calculate total tokens
+	if md.InputTokens > 0 || md.OutputTokens > 0 {
+		totalTokens := md.InputTokens + md.OutputTokens
+		md.TotalTokens = &totalTokens
+	}
+
+	md.EstimatedCost = EstimateCost(md.Model, md.InputTokens, md.OutputTokens)
+
+	return md, true
+}

--- a/pkg/tracing/metadata/extractors/aimetadata.go
+++ b/pkg/tracing/metadata/extractors/aimetadata.go
@@ -16,7 +16,7 @@ func NewAIMetadataExtractor() *AIMetadataExtractor {
 func (e *AIMetadataExtractor) ExtractSpanMetadata(ctx context.Context, span *tracev1.Span) ([]metadata.Structured, error) {
 	aiMetadata, ok := e.extractAIMetadata(span)
 	if !ok {
-		return nil, nil // TODO: should this be an explicit "nah, didn't find any" return?
+		return []metadata.Structured{}, nil
 	}
 	return []metadata.Structured{aiMetadata}, nil
 }

--- a/pkg/tracing/metadata/extractors/attributes.go
+++ b/pkg/tracing/metadata/extractors/attributes.go
@@ -141,14 +141,8 @@ func extractAIMetadataFromAttributes(attributes []*v1.KeyValue, md *AIMetadata) 
 			continue
 		}
 
-		var chosenAttr parsedAttr
-
-		if len(attrs) == 1 {
-			chosenAttr = attrs[0]
-		} else {
-			// Reduce our list of attrs to the highest-priority one.
-			chosenAttr = slices.MinFunc(attrs, compareByRank)
-		}
+		// Reduce our list of attrs to the highest-priority one.
+		chosenAttr := slices.MinFunc(attrs, compareByRank)
 
 		metadataFieldSetter, ok := metadataFieldSetters[field]
 		if !ok {

--- a/pkg/tracing/metadata/extractors/attributes.go
+++ b/pkg/tracing/metadata/extractors/attributes.go
@@ -117,7 +117,7 @@ func compareByRank(a, b parsedAttr) int {
 }
 
 func extractAIMetadataFromAttributes(attributes []*v1.KeyValue, md *AIMetadata) (foundAny bool) {
-	var potentialAttrs map[string][]parsedAttr = map[string][]parsedAttr{}
+	potentialAttrs := map[string][]parsedAttr{}
 
 	for _, attr := range attributes {
 		if mapping, ok := keyFieldMap[attr.Key]; ok {

--- a/pkg/tracing/metadata/extractors/attributes.go
+++ b/pkg/tracing/metadata/extractors/attributes.go
@@ -108,7 +108,7 @@ type parsedAttr struct {
 }
 
 // compareByRank computes the overall ordering of two parsedAttrs.
-// We order first by convention and berak ties with keyRank.
+// We order first by convention and break ties with keyRank.
 func compareByRank(a, b parsedAttr) int {
 	return cmp.Or(
 		cmp.Compare(a.convention, b.convention),

--- a/pkg/tracing/metadata/extractors/attributes.go
+++ b/pkg/tracing/metadata/extractors/attributes.go
@@ -1,0 +1,164 @@
+package extractors
+
+import (
+	"cmp"
+	"slices"
+
+	v1 "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+// convention identifies a namespace of attributes and orders which should win
+// when multiple namespaces are present. Lower numbers will override higher
+// numbers.
+type convention int
+
+const (
+	semconv       convention = 1
+	openinference convention = 2
+)
+
+// attrMapping records the canonical field a source attribute key maps to, the
+// convention it belongs to, and a keyRank tiebreak used to order keys within
+// the same convention (lower wins; 0 = default).
+type attrMapping struct {
+	field      string
+	convention convention
+	keyRank    int
+}
+
+var keyFieldMap = map[string]attrMapping{
+	// ---------------------------------------------------------------------------
+	// Open Telementry Semantic Conventions
+	// ---------------------------------------------------------------------------
+	"gen_ai.usage.input_tokens": {
+		field:      "inputTokens",
+		convention: semconv,
+	},
+	"gen_ai.usage.output_tokens": {
+		field:      "outputTokens",
+		convention: semconv,
+	},
+	"gen_ai.request.model": {
+		field:      "model",
+		convention: semconv,
+	},
+	"gen_ai.provider.name": {
+		field:      "providerName",
+		convention: semconv,
+	},
+	"gen_ai.system": {
+		// deprecated in semconv in favor of gen_ai.provider.name; both are
+		// semconv, so this keyRank places it behind its replacement.
+		field:      "providerName",
+		convention: semconv,
+		keyRank:    1,
+	},
+	"gen_ai.operation.name": {
+		field:      "operationName",
+		convention: semconv,
+	},
+
+	// ---------------------------------------------------------------------------
+	// Open Inference
+	// ---------------------------------------------------------------------------
+	"llm.token_count.prompt": {
+		field:      "inputTokens",
+		convention: openinference,
+	},
+	"llm.token_count.completion": {
+		field:      "outputTokens",
+		convention: openinference,
+	},
+	"llm.model_name": {
+		field:      "model",
+		convention: openinference,
+	},
+	// llm.system identifies the AI product/vendor (openai, anthropic, ...),
+	// matching the semantics of the deprecated semconv gen_ai.system.
+	"llm.system": {
+		field:      "providerName",
+		convention: openinference,
+	},
+}
+
+var metadataFieldSetters = map[string]func(v *v1.AnyValue, md *AIMetadata){
+	"inputTokens": func(v *v1.AnyValue, md *AIMetadata) {
+		md.InputTokens = v.GetIntValue()
+	},
+	"outputTokens": func(v *v1.AnyValue, md *AIMetadata) {
+		md.OutputTokens = v.GetIntValue()
+	},
+	"model": func(v *v1.AnyValue, md *AIMetadata) {
+		md.Model = v.GetStringValue()
+	},
+	"providerName": func(v *v1.AnyValue, md *AIMetadata) {
+		md.System = v.GetStringValue()
+	},
+	"operationName": func(v *v1.AnyValue, md *AIMetadata) {
+		md.OperationName = v.GetStringValue()
+	},
+}
+
+// parsedAttr records a key, value, the convention it came from, and its
+// keyRank tiebreak within that convention.
+type parsedAttr struct {
+	value      *v1.AnyValue
+	convention convention
+	keyRank    int
+}
+
+// compareByRank computes the overall ordering of two parsedAttrs.
+// We order first by convention and berak ties with keyRank.
+func compareByRank(a, b parsedAttr) int {
+	return cmp.Or(
+		cmp.Compare(a.convention, b.convention),
+		cmp.Compare(a.keyRank, b.keyRank),
+	)
+}
+
+func extractAIMetadataFromAttributes(attributes []*v1.KeyValue, md *AIMetadata) (foundAny bool) {
+	var potentialAttrs map[string][]parsedAttr = map[string][]parsedAttr{}
+
+	for _, attr := range attributes {
+		if mapping, ok := keyFieldMap[attr.Key]; ok {
+			potentialAttrs[mapping.field] = append(
+				potentialAttrs[mapping.field],
+				parsedAttr{
+					value:      attr.Value,
+					convention: mapping.convention,
+					keyRank:    mapping.keyRank,
+				},
+			)
+		}
+	}
+
+	if len(potentialAttrs) == 0 {
+		return false
+	}
+
+	for field, attrs := range potentialAttrs {
+		if len(attrs) == 0 {
+			continue
+		}
+
+		var chosenAttr parsedAttr
+
+		if len(attrs) == 1 {
+			chosenAttr = attrs[0]
+		} else {
+			// Reduce our list of attrs to the highest-priority one.
+			chosenAttr = slices.MinFunc(attrs, compareByRank)
+		}
+
+		metadataFieldSetter, ok := metadataFieldSetters[field]
+		if !ok {
+			// log an error for the unexpected field
+			continue
+		}
+
+		metadataFieldSetter(chosenAttr.value, md)
+		foundAny = true
+	}
+
+	return foundAny
+}

--- a/pkg/tracing/metadata/extractors/attributes_test.go
+++ b/pkg/tracing/metadata/extractors/attributes_test.go
@@ -1,0 +1,140 @@
+package extractors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+func strAttr(key, value string) *v1.KeyValue {
+	return &v1.KeyValue{
+		Key:   key,
+		Value: &v1.AnyValue{Value: &v1.AnyValue_StringValue{StringValue: value}},
+	}
+}
+
+func intAttr(key string, value int64) *v1.KeyValue {
+	return &v1.KeyValue{
+		Key:   key,
+		Value: &v1.AnyValue{Value: &v1.AnyValue_IntValue{IntValue: value}},
+	}
+}
+
+// TestCanonicalKeysHaveFieldSetters guards against drift between
+// canonicalKeyMapping and metadataFieldSetters: every canonical key referenced
+// by a mapping must have a setter, otherwise the attribute is silently dropped.
+func TestCanonicalKeysHaveFieldSetters(t *testing.T) {
+	t.Parallel()
+
+	for sourceKey, mapping := range keyFieldMap {
+		_, ok := metadataFieldSetters[mapping.field]
+		assert.Truef(t, ok,
+			"field %q (mapped from %q) has no entry in metadataFieldSetters",
+			mapping.field, sourceKey)
+	}
+}
+
+// TestRankingPrefersProviderNameOverDeprecatedSystem verifies that when both
+// the deprecated gen_ai.system and its replacement gen_ai.provider.name are
+// present, the deprecated key's keyRank demotes it so the replacement wins,
+// regardless of attribute order.
+func TestRankingPrefersProviderNameOverDeprecatedSystem(t *testing.T) {
+	t.Parallel()
+
+	orders := [][]*v1.KeyValue{
+		{strAttr("gen_ai.system", "openai"), strAttr("gen_ai.provider.name", "anthropic")},
+		{strAttr("gen_ai.provider.name", "anthropic"), strAttr("gen_ai.system", "openai")},
+	}
+
+	for _, attrs := range orders {
+		var md AIMetadata
+		foundAny := extractAIMetadataFromAttributes(attrs, &md)
+		assert.True(t, foundAny)
+		assert.Equal(t, "anthropic", md.System,
+			"gen_ai.provider.name should win over deprecated gen_ai.system")
+	}
+}
+
+// TestExtractAIMetadataFromAttributes_RealSpans feeds the full instrumentation
+// attribute set captured from real runs of test apps and asserts the
+// extractor pulls the correct values for the fields it parses.
+func TestExtractAIMetadataFromAttributes_RealSpans(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		attrs []*v1.KeyValue
+		want  AIMetadata
+	}{
+		{
+			// @traceloop/instrumentation-openai (gen_ai.* semconv).
+			name: "semconv (traceloop)",
+			attrs: []*v1.KeyValue{
+				strAttr("gen_ai.input.messages", `[{"role":"user","parts":[{"type":"text","content":"Write a one-sentence bedtime story about a unicorn."}]}]`),
+				strAttr("gen_ai.operation.name", "chat"),
+				strAttr("gen_ai.output.messages", `[{"role":"assistant","finish_reason":"stop","parts":[{"type":"text","content":"Under a moonlit sky, a gentle unicorn tiptoed through a sleepy meadow, sprinkling stardust on every leaf until the whole forest drifted into the softest, dreamiest quiet."}]}]`),
+				strAttr("gen_ai.provider.name", "openai"),
+				strAttr("gen_ai.request.model", "gpt-5.4-nano"),
+				strAttr("gen_ai.response.finish_reasons", ""),
+				strAttr("gen_ai.response.id", "resp_0a6244b051b4439d006a1dfd4611e0819a9ff1b38c811bc714"),
+				strAttr("gen_ai.response.model", "gpt-5.4-nano-2026-03-17"),
+				intAttr("gen_ai.usage.input_tokens", 17),
+				intAttr("gen_ai.usage.output_tokens", 44),
+				intAttr("gen_ai.usage.total_tokens", 61),
+			},
+			want: AIMetadata{
+				InputTokens:   17,
+				OutputTokens:  44,
+				Model:         "gpt-5.4-nano",
+				System:        "openai",
+				OperationName: "chat",
+			},
+		},
+		{
+			// @arizeai/openinference-instrumentation-openai (llm.*/openinference.*).
+			name: "openinference (arizeai)",
+			attrs: []*v1.KeyValue{
+				strAttr("input.mime_type", "application/json"),
+				strAttr("input.value", `{"model":"gpt-5.4-nano","input":"Write a one-sentence bedtime story about a unicorn."}`),
+				strAttr("llm.input_messages.0.message.content", "Write a one-sentence bedtime story about a unicorn."),
+				strAttr("llm.input_messages.0.message.role", "user"),
+				strAttr("llm.invocation_parameters", `{"model":"gpt-5.4-nano"}`),
+				strAttr("llm.model_name", "gpt-5.4-nano-2026-03-17"),
+				strAttr("llm.output_messages.0.message.contents.0.message_content.text", "On a moonlit night, a gentle unicorn tucked the stars into the corners of the sky and drifted off to sleep with a sigh of silver dreams."),
+				strAttr("llm.output_messages.0.message.contents.0.message_content.type", "output_text"),
+				strAttr("llm.output_messages.0.message.role", "assistant"),
+				strAttr("llm.provider", "openai"),
+				strAttr("llm.system", "openai"),
+				intAttr("llm.token_count.completion", 35),
+				intAttr("llm.token_count.completion_details.reasoning", 0),
+				intAttr("llm.token_count.prompt", 17),
+				intAttr("llm.token_count.prompt_details.cache_read", 0),
+				intAttr("llm.token_count.total", 52),
+				strAttr("openinference.span.kind", "LLM"),
+				strAttr("output.mime_type", "application/json"),
+				strAttr("output.value", `{"id":"resp_0f3cf5bafdfbe25c006a1dfb297544819aa73f0d05c13d5bd2","object":"response","created_at":1780349737,"status":"completed","model":"gpt-5.4-nano-2026-03-17","output":[{"type":"message","status":"completed","content":[{"type":"output_text","text":"On a moonlit night, a gentle unicorn tucked the stars into the corners of the sky and drifted off to sleep with a sigh of silver dreams."}],"role":"assistant"}],"usage":{"input_tokens":17,"output_tokens":35,"total_tokens":52},"output_text":"On a moonlit night, a gentle unicorn tucked the stars into the corners of the sky and drifted off to sleep with a sigh of silver dreams."}`),
+			},
+			want: AIMetadata{
+				InputTokens:  17,
+				OutputTokens: 35,
+				Model:        "gpt-5.4-nano-2026-03-17",
+				System:       "openai",
+				// No gen_ai.operation.name equivalent, so OperationName stays empty.
+				OperationName: "",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var md AIMetadata
+			foundAny := extractAIMetadataFromAttributes(tc.attrs, &md)
+
+			assert.True(t, foundAny)
+			assert.Equal(t, tc.want, md)
+		})
+	}
+}


### PR DESCRIPTION
## Description

- Currently we support parsing AI metadata for a handful of OTel Semantic Conventions attributes
- In EXE-1837, we would like to expand to support many more conventions across many more attributes
- In this PR, we add support for a handful of Open Inference attributes and introduce a new structure to support many conventions and resolve conflicts. We will add more conventions and more attributes in future PRs.

## Release note

Adds support for processing a handful of Open Inference attributes into step metadata

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
