### PR TITLE
fix: make v2 api path match mono/docs & improve host/port handling

### DIFF
--- a/cmd/apiv2cli/cmd.go
+++ b/cmd/apiv2cli/cmd.go
@@ -105,7 +105,7 @@ func commonFlags() []cli.Flag {
 		&cli.StringFlag{
 			Category: "Target",
 			Name:     "api-host",
-			Usage:    "Custom API host or origin",
+			Usage:    "Custom API host or origin; may include /api/v2 or /v2",
 		},
 		&cli.IntFlag{
 			Category:    "Target",
@@ -299,7 +299,7 @@ func endpointDescription(ep endpoint) string {
 		"",
 		"Target, auth, and output flags are inherited from `inngest alpha api`:",
 		"  --prod                  Target Inngest Cloud Production",
-		"  --api-host, --api-port  Target a custom API server",
+		"  --api-host, --api-port  Target a custom API server; host may include /api/v2 or /v2",
 		"  --api-key               API key, or INNGEST_API_KEY",
 		"  --signing-key           Signing key, or INNGEST_SIGNING_KEY",
 		"  --env                   Environment name, or INNGEST_ENV",
@@ -494,7 +494,7 @@ func resolveBaseURL(ctx context.Context, cmd *cli.Command) (string, error) {
 
 	apiPort := localconfig.GetIntValue(cmd, "api-port", 0)
 	if apiHost := localconfig.GetValue(cmd, "api-host", ""); apiHost != "" {
-		if apiPort == 0 {
+		if apiPort == 0 && !looksLikeURL(apiHost) {
 			apiPort = api.DefaultAPIPort
 		}
 		return normalizeAPIHostTarget(apiHost, apiPort)
@@ -513,7 +513,7 @@ func resolveBaseURL(ctx context.Context, cmd *cli.Command) (string, error) {
 
 func normalizeAPIHostTarget(rawHost string, port int) (string, error) {
 	if looksLikeURL(rawHost) {
-		return normalizeAPIURL(rawHost)
+		return normalizeAPIURLWithPort(rawHost, port)
 	}
 
 	host := rawHost
@@ -532,6 +532,21 @@ func normalizeAPIHostTarget(rawHost string, port int) (string, error) {
 	}
 
 	return normalizeAPIURL(fmt.Sprintf("%s://%s", scheme, rawHost))
+}
+
+func normalizeAPIURLWithPort(rawURL string, port int) (string, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", fmt.Errorf("api host must include scheme and host")
+	}
+	if port != 0 && parsed.Port() == "" {
+		parsed.Host = net.JoinHostPort(parsed.Hostname(), strconv.Itoa(port))
+	}
+
+	return normalizeAPIURL(parsed.String())
 }
 
 func normalizeAPIURL(rawURL string) (string, error) {

--- a/cmd/apiv2cli/cmd_test.go
+++ b/cmd/apiv2cli/cmd_test.go
@@ -61,6 +61,7 @@ func TestEndpointCommandsIncludeOperationAndInheritedFlagHelp(t *testing.T) {
 	require.Contains(t, invoke.Description, "--prod")
 	require.Contains(t, invoke.Description, "INNGEST_API_KEY")
 	require.Contains(t, invoke.Description, "INNGEST_ENV")
+	require.Contains(t, invoke.Description, "/v2")
 }
 
 func TestEndpointFlagsUseProtoFieldDescriptions(t *testing.T) {
@@ -381,6 +382,55 @@ func TestResolveBaseURLCustomTargetOverridesProd(t *testing.T) {
 	require.Equal(t, "http://localhost:1/api/v2", baseURL)
 }
 
+func TestResolveBaseURLAppliesAPIPortToURLHostWithoutPort(t *testing.T) {
+	var baseURL string
+	cmd := Command()
+	cmd.Commands = []*cli.Command{
+		{
+			Name: "capture",
+			Action: func(ctx context.Context, cmd *cli.Command) error {
+				var err error
+				baseURL, err = resolveBaseURL(ctx, cmd)
+				return err
+			},
+		},
+	}
+
+	err := cmd.Run(context.Background(), []string{
+		"api",
+		"--api-host", "http://127.0.0.1",
+		"--api-port", "8090",
+		"capture",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "http://127.0.0.1:8090/api/v2", baseURL)
+}
+
+func TestResolveBaseURLDoesNotApplyDefaultPortToURLHost(t *testing.T) {
+	var baseURL string
+	cmd := Command()
+	cmd.Commands = []*cli.Command{
+		{
+			Name: "capture",
+			Action: func(ctx context.Context, cmd *cli.Command) error {
+				var err error
+				baseURL, err = resolveBaseURL(ctx, cmd)
+				return err
+			},
+		},
+	}
+
+	err := cmd.Run(context.Background(), []string{
+		"api",
+		"--api-host", "https://inngest.example.com",
+		"capture",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "https://inngest.example.com/api/v2", baseURL)
+}
+
 func TestResolveBaseURLAPIPortOverridesProd(t *testing.T) {
 	var baseURL string
 	cmd := Command()
@@ -486,6 +536,11 @@ func TestNormalizeAPIURL(t *testing.T) {
 			expected: "https://inngest.example.com/v2",
 		},
 		{
+			name:     "existing api v2 path is preserved",
+			rawURL:   "https://inngest.example.com/api/v2",
+			expected: "https://inngest.example.com/api/v2",
+		},
+		{
 			name:     "existing api path is completed",
 			rawURL:   "https://inngest.example.com/api",
 			expected: "https://inngest.example.com/api/v2",
@@ -531,6 +586,18 @@ func TestNormalizeAPIHostTarget(t *testing.T) {
 			rawURL:   "http://127.0.0.1:9999",
 			port:     8288,
 			expected: "http://127.0.0.1:9999/api/v2",
+		},
+		{
+			name:     "url host without port uses api port",
+			rawURL:   "http://127.0.0.1",
+			port:     8090,
+			expected: "http://127.0.0.1:8090/api/v2",
+		},
+		{
+			name:     "url host with explicit path and missing port uses api port",
+			rawURL:   "http://127.0.0.1/v2",
+			port:     8090,
+			expected: "http://127.0.0.1:8090/v2",
 		},
 	}
 

--- a/pkg/api/v2/http_test.go
+++ b/pkg/api/v2/http_test.go
@@ -325,6 +325,15 @@ func TestHTTPGateway_Routing(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, rec.Code)
 	})
 
+	t.Run("invalid endpoints under /v2 return 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v2/invalid", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
 	t.Run("root path returns 404", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()

--- a/pkg/api/v2/service.go
+++ b/pkg/api/v2/service.go
@@ -153,9 +153,11 @@ func NewHTTPHandler(ctx context.Context, serviceOpts ServiceOptions, httpOpts HT
 	}
 
 	r.Mount("/", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		// Strip /api/v2 prefix and forward to gateway
+		// Strip supported v2 prefixes and forward to gateway
 		originalPath := req.URL.Path
 		if after, ok := strings.CutPrefix(req.URL.Path, "/api/v2"); ok {
+			req.URL.Path = after
+		} else if after, ok := strings.CutPrefix(req.URL.Path, "/v2"); ok {
 			req.URL.Path = after
 		}
 

--- a/pkg/api/v2/service_test.go
+++ b/pkg/api/v2/service_test.go
@@ -138,6 +138,21 @@ func TestNewHTTPHandler(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, rec.Code)
 	})
+
+	t.Run("strips /v2 prefix correctly", func(t *testing.T) {
+		opts := HTTPHandlerOptions{}
+		handler, err := newTestHTTPHandler(ctx, ServiceOptions{}, opts)
+
+		require.NoError(t, err)
+		require.NotNil(t, handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/v2/health", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code)
+	})
 }
 
 func TestService_HealthResponse_Structure(t *testing.T) {

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -747,6 +747,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		{At: "/", Router: devAPI},
 		{At: "/v0", Router: core.Router},
 		{At: "/api/v2", Handler: apiv2Handler},
+		{At: "/v2", Handler: apiv2Handler},
 		{At: "/debug", Handler: middleware.Profiler()},
 		{At: "/metrics", Router: metricsAPI.Router},
 	}


### PR DESCRIPTION
## Description

We launched the v2 rest api on a different path /api/v2 than the docs and mono. This is tripping people up when they switch from v1 to v2. This adds support for both. 

This also makes the api wrapper cli handle ports/host args with more flexibility. Those were tripping up agents when they tried to customize. `--api-host http://127.0.0.1 --api-port 8090` now targets the intended port, explicit /v2 or /api/v2 paths are preserved, and full URL hosts no longer get an implicit dev port.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
