### PR TITLE
fix: env switcher bug

### DIFF
--- a/ui/apps/dashboard/src/components/Navigation/Environments.tsx
+++ b/ui/apps/dashboard/src/components/Navigation/Environments.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-
 import { Listbox } from '@headlessui/react';
 import { OptionalTooltip } from '@inngest/components/Tooltip/OptionalTooltip';
 import {
@@ -130,15 +128,9 @@ export default function EnvironmentSelectMenu({
 }: EnvironmentSelectMenuProps) {
   const navigate = useNavigate();
   type ListboxValue = Environment | null | 'view_all' | 'sync_branch';
-  const [selected, setSelected] = useState<ListboxValue>(null);
+  const selected: ListboxValue = activeEnv ?? null;
   const nextPathname = useSwitchablePathname();
   const [{ data: envs = [], error }] = useEnvironments();
-
-  //
-  // Sync selected state with activeEnv from route
-  useEffect(() => {
-    setSelected(activeEnv || null);
-  }, [activeEnv]);
 
   if (error) {
     console.error('error fetching envs', error);

--- a/ui/apps/dashboard/src/routes/_authed.tsx
+++ b/ui/apps/dashboard/src/routes/_authed.tsx
@@ -1,10 +1,14 @@
 import { fetchClerkAuth, jwtAuth } from '@/lib/auth';
 import { sanitizeRedirectUrl } from '@/lib/deepLinkUtils';
-import { createFileRoute, notFound, Outlet } from '@tanstack/react-router';
+import {
+  createFileRoute,
+  notFound,
+  Outlet,
+  useMatch,
+} from '@tanstack/react-router';
 
 import Layout from '@/components/Layout/Layout';
 import { navCollapsed } from '@/lib/nav';
-import { getEnvironment } from '@/queries/server/getEnvironment';
 import { getProfileDisplay } from '@/queries/server/profile';
 import NotFound from '@/components/Error/NotFound';
 
@@ -34,15 +38,7 @@ export const Route = createFileRoute('/_authed')({
     };
   },
 
-  loader: async ({ params }: { params: { envSlug?: string } }) => {
-    const env = params.envSlug
-      ? await getEnvironment({ data: { environmentSlug: params.envSlug } })
-      : undefined;
-
-    if (params.envSlug && !env) {
-      throw notFound({ data: { error: 'Environment not found' } });
-    }
-
+  loader: async () => {
     const profile = await getProfileDisplay();
 
     if (!profile) {
@@ -50,7 +46,6 @@ export const Route = createFileRoute('/_authed')({
     }
 
     return {
-      env,
       profile,
       navCollapsed: await navCollapsed(),
     };
@@ -58,10 +53,15 @@ export const Route = createFileRoute('/_authed')({
 });
 
 function Authed() {
-  const { env, navCollapsed, profile } = Route.useLoaderData();
+  const { navCollapsed, profile } = Route.useLoaderData();
+  const activeEnv = useMatch({
+    from: '/_authed/env/$envSlug',
+    shouldThrow: false,
+    select: (match) => match.loaderData?.env,
+  });
 
   return (
-    <Layout collapsed={navCollapsed} activeEnv={env} profile={profile}>
+    <Layout collapsed={navCollapsed} activeEnv={activeEnv} profile={profile}>
       <Outlet />
     </Layout>
   );

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/manage/$ingestKeys/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/manage/$ingestKeys/index.tsx
@@ -1,7 +1,7 @@
 import useManagePageTerminology from '@/components/Manage/useManagePageTerminology';
+import { useEnvironment } from '@/components/Environments/environment-context';
 import { EnvironmentType } from '@/utils/environments';
 import { createFileRoute } from '@tanstack/react-router';
-import { Route as OrgActiveRoute } from '@/routes/_authed';
 import { Alert } from '@inngest/components/Alert';
 
 export const Route = createFileRoute(
@@ -12,7 +12,7 @@ export const Route = createFileRoute(
 
 function KeysComponent() {
   const currentContent = useManagePageTerminology();
-  const { env } = OrgActiveRoute?.useLoaderData() ?? {};
+  const env = useEnvironment();
 
   const shouldShowAlert =
     currentContent?.param === 'keys' &&

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/manage/route.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/manage/route.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 
-import { Route as OrgActiveRoute } from '@/routes/_authed';
+import { useEnvironment } from '@/components/Environments/environment-context';
 import ChildEmptyState from '@/components/Manage/ChildEmptyState';
 import { ManageHeader } from '@/components/Manage/Header';
 
@@ -9,7 +9,7 @@ export const Route = createFileRoute('/_authed/env/$envSlug/manage')({
 });
 
 function ManageLayoutComponent() {
-  const { env } = OrgActiveRoute?.useLoaderData() ?? {};
+  const env = useEnvironment();
 
   if (env?.hasParent) {
     return <ChildEmptyState />;


### PR DESCRIPTION
## Description
switching envs using the env selector works but the old env is still reflected in the component until you hard refresh the page, see:
<img width="501" height="155" alt="Screenshot 2026-06-02 at 10 54 25 AM" src="https://github.com/user-attachments/assets/5091a159-3d70-4175-8b0a-55ad0e3ce802" />

this fixes it by simplifying env handling, removing intermediate state and tanstack router indirection.

## Release note

Fix environment switcher ux component.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
