### PR TITLE
feat: Add Group ID & Request ID attributes to most execution spans

### DIFF
--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -480,6 +480,7 @@ type ComplexityRoot struct {
 		Duration          func(childComplexity int) int
 		EndedAt           func(childComplexity int) int
 		FunctionID        func(childComplexity int) int
+		GroupID           func(childComplexity int) int
 		IsRoot            func(childComplexity int) int
 		IsUserland        func(childComplexity int) int
 		Metadata          func(childComplexity int) int
@@ -2843,6 +2844,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.RunTraceSpan.FunctionID(childComplexity), true
 
+	case "RunTraceSpan.groupID":
+		if e.complexity.RunTraceSpan.GroupID == nil {
+			break
+		}
+
+		return e.complexity.RunTraceSpan.GroupID(childComplexity), true
+
 	case "RunTraceSpan.isRoot":
 		if e.complexity.RunTraceSpan.IsRoot == nil {
 			break
@@ -4319,6 +4327,7 @@ type RunTraceSpan {
   # Internal
   spanID: String! # internal span ID, or a virtual span ID
   traceID: String! # the internal ID of the trace this span belongs to
+  groupID: String # the group ID of this span, used for grouping spans together in the UI, e.g. retries
   # Required
   name: String! # the name of the span
   status: RunTraceSpanStatus! # the status of the span
@@ -7736,6 +7745,8 @@ func (ec *executionContext) fieldContext_DebugRun_debugTraces(ctx context.Contex
 				return ec.fieldContext_RunTraceSpan_spanID(ctx, field)
 			case "traceID":
 				return ec.fieldContext_RunTraceSpan_traceID(ctx, field)
+			case "groupID":
+				return ec.fieldContext_RunTraceSpan_groupID(ctx, field)
 			case "name":
 				return ec.fieldContext_RunTraceSpan_name(ctx, field)
 			case "status":
@@ -12647,6 +12658,8 @@ func (ec *executionContext) fieldContext_FunctionRunV2_trace(ctx context.Context
 				return ec.fieldContext_RunTraceSpan_spanID(ctx, field)
 			case "traceID":
 				return ec.fieldContext_RunTraceSpan_traceID(ctx, field)
+			case "groupID":
+				return ec.fieldContext_RunTraceSpan_groupID(ctx, field)
 			case "name":
 				return ec.fieldContext_RunTraceSpan_name(ctx, field)
 			case "status":
@@ -15627,6 +15640,8 @@ func (ec *executionContext) fieldContext_Query_runTrace(ctx context.Context, fie
 				return ec.fieldContext_RunTraceSpan_spanID(ctx, field)
 			case "traceID":
 				return ec.fieldContext_RunTraceSpan_traceID(ctx, field)
+			case "groupID":
+				return ec.fieldContext_RunTraceSpan_groupID(ctx, field)
 			case "name":
 				return ec.fieldContext_RunTraceSpan_name(ctx, field)
 			case "status":
@@ -19072,6 +19087,47 @@ func (ec *executionContext) fieldContext_RunTraceSpan_traceID(ctx context.Contex
 	return fc, nil
 }
 
+func (ec *executionContext) _RunTraceSpan_groupID(ctx context.Context, field graphql.CollectedField, obj *models.RunTraceSpan) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RunTraceSpan_groupID(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.GroupID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RunTraceSpan_groupID(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RunTraceSpan",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _RunTraceSpan_name(ctx context.Context, field graphql.CollectedField, obj *models.RunTraceSpan) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_RunTraceSpan_name(ctx, field)
 	if err != nil {
@@ -19460,6 +19516,8 @@ func (ec *executionContext) fieldContext_RunTraceSpan_childrenSpans(ctx context.
 				return ec.fieldContext_RunTraceSpan_spanID(ctx, field)
 			case "traceID":
 				return ec.fieldContext_RunTraceSpan_traceID(ctx, field)
+			case "groupID":
+				return ec.fieldContext_RunTraceSpan_groupID(ctx, field)
 			case "name":
 				return ec.fieldContext_RunTraceSpan_name(ctx, field)
 			case "status":
@@ -19817,6 +19875,8 @@ func (ec *executionContext) fieldContext_RunTraceSpan_parentSpan(ctx context.Con
 				return ec.fieldContext_RunTraceSpan_spanID(ctx, field)
 			case "traceID":
 				return ec.fieldContext_RunTraceSpan_traceID(ctx, field)
+			case "groupID":
+				return ec.fieldContext_RunTraceSpan_groupID(ctx, field)
 			case "name":
 				return ec.fieldContext_RunTraceSpan_name(ctx, field)
 			case "status":
@@ -29156,6 +29216,10 @@ func (ec *executionContext) _RunTraceSpan(ctx context.Context, sel ast.Selection
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "groupID":
+
+			out.Values[i] = ec._RunTraceSpan_groupID(ctx, field, obj)
+
 		case "name":
 
 			out.Values[i] = ec._RunTraceSpan_name(ctx, field, obj)

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -613,6 +613,7 @@ type RunTraceSpan {
   # Internal
   spanID: String! # internal span ID, or a virtual span ID
   traceID: String! # the internal ID of the trace this span belongs to
+  groupID: String # the group ID of this span, used for grouping spans together in the UI, e.g. retries
   # Required
   name: String! # the name of the span
   status: RunTraceSpanStatus! # the status of the span

--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -229,6 +229,7 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 	gqlSpan := &models.RunTraceSpan{
 		AppID:          span.GetAppID(),
 		Attempts:       &attempts,
+		GroupID:        span.Attributes.GroupID,
 		EndedAt:        span.GetEndedAtTime(),
 		FunctionID:     span.GetFunctionID(),
 		IsRoot:         span.GetIsRoot(),

--- a/pkg/coreapi/graph/models/augmented.go
+++ b/pkg/coreapi/graph/models/augmented.go
@@ -32,6 +32,7 @@ type RunTraceSpan struct {
 	Run               *FunctionRun              `json:"run"`
 	SpanID            string                    `json:"spanID"`
 	TraceID           string                    `json:"traceID"`
+	GroupID           *string                   `json:"groupID,omitempty"`
 	Name              string                    `json:"name"`
 	Status            RunTraceSpanStatus        `json:"status"`
 	Attempts          *int                      `json:"attempts,omitempty"`

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1598,23 +1598,28 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 	conditionalTraceCtx, conditionalSpan := e.conditionalTracer.NewSpan(ctx, "executor.Execute", id.AccountID, id.WorkspaceID, id.WorkflowID)
 	defer conditionalSpan.End()
 
+	requestID := driver.DispatchRequestID(e.now(), id.RunID, queue.GenerationIDFromContext(ctx)).String()
+
+	jobID := queue.JobIDFromContext(ctx)
+	if item.JobID != nil {
+		jobID = *item.JobID
+	}
+
 	// Immediately store execution context for tracing.
 	ctx = tracing.WithExecutionContext(ctx, tracing.ExecutionContext{
 		Identifier:  sv2.IDFromV1(id),
 		Attempt:     item.Attempt,
 		MaxAttempts: item.MaxAttempts,
 		QueueKind:   item.Kind,
+		RequestID:   inngestgo.Ptr(requestID),
+		GroupID:     inngestgo.Ptr(item.GroupID),
+		JobID:       inngestgo.Ptr(jobID),
 	})
 
 	if e.fl == nil {
 		return nil, fmt.Errorf("no function loader specified running step")
 	}
 
-	requestID := driver.DispatchRequestID(e.now(), id.RunID, queue.GenerationIDFromContext(ctx)).String()
-	jobID := queue.JobIDFromContext(ctx)
-	if item.JobID != nil {
-		jobID = *item.JobID
-	}
 	ctx = driver.WithRequestIDs(ctx, requestID, jobID)
 
 	l := e.log.With(
@@ -1868,8 +1873,6 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 
 	// This span will be updated with output as soon as execution finishes.
 	execAttrs := tracing.FunctionAttrs(&instance.f)
-	meta.AddAttr(execAttrs, meta.Attrs.RequestID, &instance.requestID)
-	meta.AddAttr(execAttrs, meta.Attrs.JobID, &instance.jobID)
 
 	instance.execSpan, err = e.tracerProvider.CreateSpan(
 		ctx,
@@ -1906,8 +1909,6 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 		// XX: This is going to drop any sleep requests, because DriverResponseAttrs
 		// forces the drop field if resp.IsDiscoveryResponse() is true.
 		responseAttrs := tracing.DriverResponseAttrs(resp, nil)
-		meta.AddAttr(responseAttrs, meta.Attrs.RequestID, &instance.requestID)
-		meta.AddAttr(responseAttrs, meta.Attrs.JobID, &instance.jobID)
 
 		updateOpts := &tracing.UpdateSpanOptions{
 			Debug:      &tracing.SpanDebugData{Location: "executor.ExecutePost"},

--- a/pkg/tracing/execution_processor.go
+++ b/pkg/tracing/execution_processor.go
@@ -22,6 +22,10 @@ type ExecutionContext struct {
 	MaxAttempts *int
 	// QueueKind is the queue kind string, eg. "sleep" - the type of job enqueued in our system.
 	QueueKind string
+
+	RequestID *string
+	GroupID   *string
+	JobID     *string
 }
 
 // WithExecutionContext stores data for spans in context.
@@ -76,11 +80,19 @@ func (p *executionProcessor) OnStart(parent context.Context, s sdktrace.ReadWrit
 	ec := getExecutionContext(parent)
 
 	if ec != nil {
-		meta.AddAttr(rawAttrs, meta.Attrs.RunID, &ec.Identifier.RunID)
-		meta.AddAttr(rawAttrs, meta.Attrs.FunctionID, &ec.Identifier.FunctionID)
-		meta.AddAttr(rawAttrs, meta.Attrs.AccountID, &ec.Identifier.Tenant.AccountID)
-		meta.AddAttr(rawAttrs, meta.Attrs.EnvID, &ec.Identifier.Tenant.EnvID)
-		meta.AddAttr(rawAttrs, meta.Attrs.AppID, &ec.Identifier.Tenant.AppID)
+		AddMetadataTenantAttrs(rawAttrs, ec.Identifier)
+
+		if ec.RequestID != nil {
+			meta.AddAttr(rawAttrs, meta.Attrs.RequestID, ec.RequestID)
+		}
+
+		if ec.GroupID != nil {
+			meta.AddAttr(rawAttrs, meta.Attrs.GroupID, ec.GroupID)
+		}
+
+		if ec.JobID != nil {
+			meta.AddAttr(rawAttrs, meta.Attrs.JobID, ec.JobID)
+		}
 	}
 
 	// Do not set extra contextual data on extension spans
@@ -130,8 +142,6 @@ func (p *executionProcessor) OnStart(parent context.Context, s sdktrace.ReadWrit
 
 	case meta.SpanNameStep:
 		{
-			meta.AddAttrIfUnset(rawAttrs, meta.Attrs.QueuedAt, &now)
-
 			if ec != nil {
 				meta.AddAttr(rawAttrs, meta.Attrs.StepMaxAttempts, ec.MaxAttempts)
 				meta.AddAttr(rawAttrs, meta.Attrs.StepAttempt, &ec.Attempt)

--- a/pkg/tracing/meta/attributes.go
+++ b/pkg/tracing/meta/attributes.go
@@ -136,6 +136,7 @@ var Attrs = struct {
 	// HTTP (serve) attributes
 	RequestID          attr[*string]
 	JobID              attr[*string]
+	GroupID            attr[*string]
 	RequestURL         attr[*string]
 	ResponseHeaders    attr[*headers.Compact]
 	ResponseStatusCode attr[*int]
@@ -201,6 +202,7 @@ var Attrs = struct {
 	QueuedAt:                           TimeAttr("queued_at"),
 	RequestID:                          StringAttr("request.id"),
 	JobID:                              StringAttr("job.id"),
+	GroupID:                            StringAttr("job.group.id"),
 	RequestURL:                         StringAttr("request.url"),
 	ResponseHeaders:                    JsonAttr[headers.Compact]("response.headers"),
 	ResponseOutputSize:                 IntAttr("response.output_size"),

--- a/pkg/tracing/meta/consts.go
+++ b/pkg/tracing/meta/consts.go
@@ -20,6 +20,7 @@ const (
 	SpanNameDynamicExtension = "EXTEND"
 	SpanNameUserland         = "userland"
 	SpanNameMetadata         = "metadata"
+	SpanNameNonStep          = "executor.nonstep" // TODO: better name
 
 	// SDKExecutionSpanName is the name of the execution wrapper span
 	// created by SDKs (e.g., "inngest.execution"). This span houses

--- a/pkg/tracing/meta/extracted_values_gen.go
+++ b/pkg/tracing/meta/extracted_values_gen.go
@@ -84,6 +84,7 @@ type ExtractedValues struct {
 	StepGatewayResponseOutputSizeBytes *int
 	RequestID *string
 	JobID *string
+	GroupID *string
 	RequestURL *string
 	ResponseHeaders *headers.Compact
 	ResponseStatusCode *int


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This adds group/request ID attributes to most spans emitted by the executor to better be able to group spans (especially for non-SDK failed attempts). Currently we do this kinda contextually/based on the discovery span parent, but going forward, step spans aren't going to be parented to the discovery span for better similarity with checkpointed step spans, so this strategy will stop working. 

NOTE: the group ID is just a random UUID we generate for sets of queue items, so exposing it in GQL should be OK

This also simplifies the execution processor tenant ID attribute emission slightly

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
