### PR TITLE
feat: EXE-1918: Parse total tokens from AI Metadata

### DIFF
--- a/pkg/tracing/metadata/extractors/ai_test.go
+++ b/pkg/tracing/metadata/extractors/ai_test.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
+	"github.com/inngest/inngest/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	v1 "go.opentelemetry.io/proto/otlp/common/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
@@ -133,6 +135,57 @@ func TestAIMetadataExtractor_NonAISpan(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Empty(t, metadata, "Non-AI span should not produce metadata")
+}
+
+func TestExtractAIMetadata_TotalTokens(t *testing.T) {
+	t.Parallel()
+
+	e := NewAIMetadataExtractor()
+
+	cases := []struct {
+		name  string
+		attrs []*v1.KeyValue
+		want  *int64
+	}{
+		{
+			// We should be using the provider's total, even if it differs from our calcs
+			name: "provider total preserved when it differs from sum",
+			attrs: []*v1.KeyValue{
+				intAttr("gen_ai.usage.input_tokens", 17),
+				intAttr("gen_ai.usage.output_tokens", 44),
+				// 100 != 17 + 44
+				intAttr("gen_ai.usage.total_tokens", 100),
+			},
+			want: util.ToPtr[int64](100),
+		},
+		{
+			name: "computed from input only when total absent",
+			attrs: []*v1.KeyValue{
+				intAttr("gen_ai.usage.input_tokens", 10),
+			},
+			want: util.ToPtr[int64](10),
+		},
+		{
+			name: "computed from input+output when total absent",
+			attrs: []*v1.KeyValue{
+				intAttr("gen_ai.usage.input_tokens", 56),
+				intAttr("gen_ai.usage.output_tokens", 30),
+			},
+			want: util.ToPtr[int64](86),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			span := &tracev1.Span{Attributes: tc.attrs}
+			md, ok := e.extractAIMetadata(span)
+
+			assert.True(t, ok)
+			assert.Equal(t, tc.want, md.TotalTokens)
+		})
+	}
 }
 
 func TestExtractAIOutputMetadata_VercelAISDK(t *testing.T) {

--- a/pkg/tracing/metadata/extractors/ai_test.go
+++ b/pkg/tracing/metadata/extractors/ai_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
-	v1 "go.opentelemetry.io/proto/otlp/common/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 )
 
@@ -144,13 +143,13 @@ func TestExtractAIMetadata_TotalTokens(t *testing.T) {
 
 	cases := []struct {
 		name  string
-		attrs []*v1.KeyValue
+		attrs []*commonv1.KeyValue
 		want  *int64
 	}{
 		{
 			// We should be using the provider's total, even if it differs from our calcs
 			name: "provider total preserved when it differs from sum",
-			attrs: []*v1.KeyValue{
+			attrs: []*commonv1.KeyValue{
 				intAttr("gen_ai.usage.input_tokens", 17),
 				intAttr("gen_ai.usage.output_tokens", 44),
 				// 100 != 17 + 44
@@ -160,14 +159,14 @@ func TestExtractAIMetadata_TotalTokens(t *testing.T) {
 		},
 		{
 			name: "computed from input only when total absent",
-			attrs: []*v1.KeyValue{
+			attrs: []*commonv1.KeyValue{
 				intAttr("gen_ai.usage.input_tokens", 10),
 			},
 			want: util.ToPtr[int64](10),
 		},
 		{
 			name: "computed from input+output when total absent",
-			attrs: []*v1.KeyValue{
+			attrs: []*commonv1.KeyValue{
 				intAttr("gen_ai.usage.input_tokens", 56),
 				intAttr("gen_ai.usage.output_tokens", 30),
 			},

--- a/pkg/tracing/metadata/extractors/aimetadata.go
+++ b/pkg/tracing/metadata/extractors/aimetadata.go
@@ -35,8 +35,8 @@ func (e *AIMetadataExtractor) extractAIMetadata(span *tracev1.Span) (md AIMetada
 		md.LatencyMs = &latencyMs
 	}
 
-	// calculate total tokens
-	if md.InputTokens > 0 || md.OutputTokens > 0 {
+	// calculate total tokens if a provider value wasn't supplied
+	if md.TotalTokens == nil && (md.InputTokens > 0 || md.OutputTokens > 0) {
 		totalTokens := md.InputTokens + md.OutputTokens
 		md.TotalTokens = &totalTokens
 	}

--- a/pkg/tracing/metadata/extractors/attributes.go
+++ b/pkg/tracing/metadata/extractors/attributes.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"slices"
 
+	"github.com/inngest/inngest/pkg/util"
 	v1 "go.opentelemetry.io/proto/otlp/common/v1"
 )
 
@@ -38,6 +39,10 @@ var keyFieldMap = map[string]attrMapping{
 		field:      "outputTokens",
 		convention: semconv,
 	},
+	"gen_ai.usage.total_tokens": {
+		field:      "totalTokens",
+		convention: semconv,
+	},
 	"gen_ai.request.model": {
 		field:      "model",
 		convention: semconv,
@@ -69,6 +74,10 @@ var keyFieldMap = map[string]attrMapping{
 		field:      "outputTokens",
 		convention: openinference,
 	},
+	"llm.token_count.total": {
+		field:      "totalTokens",
+		convention: openinference,
+	},
 	"llm.model_name": {
 		field:      "model",
 		convention: openinference,
@@ -87,6 +96,9 @@ var metadataFieldSetters = map[string]func(v *v1.AnyValue, md *AIMetadata){
 	},
 	"outputTokens": func(v *v1.AnyValue, md *AIMetadata) {
 		md.OutputTokens = v.GetIntValue()
+	},
+	"totalTokens": func(v *v1.AnyValue, md *AIMetadata) {
+		md.TotalTokens = util.ToPtr(v.GetIntValue())
 	},
 	"model": func(v *v1.AnyValue, md *AIMetadata) {
 		md.Model = v.GetStringValue()

--- a/pkg/tracing/metadata/extractors/attributes_test.go
+++ b/pkg/tracing/metadata/extractors/attributes_test.go
@@ -3,6 +3,7 @@ package extractors
 import (
 	"testing"
 
+	"github.com/inngest/inngest/pkg/util"
 	"github.com/stretchr/testify/assert"
 	v1 "go.opentelemetry.io/proto/otlp/common/v1"
 )
@@ -97,6 +98,7 @@ func TestExtractAIMetadataFromAttributes_RealSpans(t *testing.T) {
 			want: AIMetadata{
 				InputTokens:   17,
 				OutputTokens:  44,
+				TotalTokens:   util.ToPtr[int64](61),
 				Model:         "gpt-5.4-nano",
 				System:        "openai",
 				OperationName: "chat",
@@ -129,6 +131,7 @@ func TestExtractAIMetadataFromAttributes_RealSpans(t *testing.T) {
 			want: AIMetadata{
 				InputTokens:  17,
 				OutputTokens: 35,
+				TotalTokens:  util.ToPtr[int64](52),
 				Model:        "gpt-5.4-nano-2026-03-17",
 				System:       "openai",
 				// No gen_ai.operation.name equivalent, so OperationName stays empty.
@@ -155,6 +158,7 @@ func TestExtractAIMetadataFromAttributes_RealSpans(t *testing.T) {
 			want: AIMetadata{
 				InputTokens:   56,
 				OutputTokens:  30,
+				TotalTokens:   util.ToPtr[int64](86),
 				Model:         "gpt-4.1-nano",
 				System:        "openai",
 				OperationName: "chat",
@@ -211,6 +215,7 @@ func TestExtractAIMetadataFromAttributes_RealSpans(t *testing.T) {
 			want: AIMetadata{
 				InputTokens:   56,
 				OutputTokens:  14,
+				TotalTokens:   util.ToPtr[int64](70),
 				Model:         "gpt-4.1-nano-2025-04-14",
 				System:        "openai",
 				OperationName: "",


### PR DESCRIPTION
## Description

- Let's parse the total tokens from otel attributes into AI metadata
- Previously, we calculated this ourselves. Let's conditionally calculate it ourselves

## Release note

Step AI metadata sources total tokens from span attributes when provided

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
