### PR TITLE
feat(pauses): Move pause timeouts to system queue

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -524,6 +524,8 @@ type executor struct {
 	clock             clockwork.Clock
 
 	conditionalTracer itrace.ConditionalTracer
+
+	pauseTimeoutSystemQueue func(ctx context.Context, accountID, envID, functionID uuid.UUID) bool
 }
 
 func (e *executor) SetFinalizer(f execution.FinalizePublisher) {
@@ -3290,9 +3292,16 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 
 		// And dequeue the timeout job to remove unneeded work from the queue, etc.
 		if q, ok := e.queue.(queue.QueueManager); ok {
+			// Previously we enqueued pause timeouts to the user queue, never a system queue.
+			// We are changing this below, creating per-function timeout partitions.
+			var queueName *string
+			if e.pauseTimeoutSystemQueue != nil && e.pauseTimeoutSystemQueue(ctx, md.ID.Tenant.AccountID, md.ID.Tenant.EnvID, md.ID.FunctionID) {
+				queueName = util.StrPtr(fmt.Sprintf("%s:%s", queue.KindPause, md.ID.FunctionID))
+			}
+
 			// timeout jobs are enqueued to the workflow partition (see handleGeneratorWaitForEvent)
 			// this is _not_ a system partition and lives on the account shard, which we need to retrieve
-			shard, err := e.shards.Resolve(ctx, md.ID.Tenant.AccountID, nil)
+			shard, err := e.shards.Resolve(ctx, md.ID.Tenant.AccountID, queueName)
 			if err != nil {
 				return fmt.Errorf("could not find shard for pause timeout item for account %q: %w", md.ID.Tenant.AccountID, err)
 			}
@@ -4732,7 +4741,12 @@ func (e *executor) handleGeneratorWaitForSignal(ctx context.Context, runCtx exec
 		return fmt.Errorf("unable to parse signal expires: %w", err)
 	}
 
-	pauseID := inngest.DeterministicSha1UUID(runCtx.Metadata().ID.RunID.String() + gen.ID)
+	md := runCtx.Metadata()
+	accountID := md.ID.Tenant.AccountID
+	envID := md.ID.Tenant.EnvID
+	fnID := md.ID.FunctionID
+
+	pauseID := inngest.DeterministicSha1UUID(md.ID.RunID.String() + gen.ID)
 	opcode := gen.Op.String()
 	now := e.now()
 
@@ -4751,7 +4765,7 @@ func (e *executor) handleGeneratorWaitForSignal(ctx context.Context, runCtx exec
 
 	pause := state.Pause{
 		ID:                      pauseID,
-		WorkspaceID:             runCtx.Metadata().ID.Tenant.EnvID,
+		WorkspaceID:             envID,
 		Identifier:              sv2.NewPauseIdentifier(runCtx.Metadata().ID),
 		GroupID:                 runCtx.GroupID(),
 		Outgoing:                gen.ID,
@@ -4768,6 +4782,13 @@ func (e *executor) handleGeneratorWaitForSignal(ctx context.Context, runCtx exec
 		},
 		ParallelMode: gen.ParallelMode(),
 		CreatedAt:    now,
+	}
+
+	// Previously we enqueued pause timeouts to the user queue, never a system queue.
+	// We are changing this below, creating per-function timeout partitions.
+	var queueName *string
+	if e.pauseTimeoutSystemQueue != nil && e.pauseTimeoutSystemQueue(ctx, accountID, envID, fnID) {
+		queueName = util.StrPtr(fmt.Sprintf("%s:%s", queue.KindPause, fnID))
 	}
 
 	// Enqueue a job that will timeout the pause.
@@ -4787,6 +4808,7 @@ func (e *executor) handleGeneratorWaitForSignal(ctx context.Context, runCtx exec
 		},
 		Metadata:     make(map[string]any),
 		ParallelMode: gen.ParallelMode(),
+		QueueName:    queueName,
 	}
 
 	lifecycleItem := runCtx.LifecycleItem()

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -464,6 +464,13 @@ func WithConditionalTracer(tracer itrace.ConditionalTracer) ExecutorOpt {
 	}
 }
 
+func WithEnablePauseTimeoutSystemQueue(flag func(ctx context.Context, accountID, envID, fnID uuid.UUID) bool) ExecutorOpt {
+	return func(e execution.Executor) error {
+		e.(*executor).pauseTimeoutSystemQueue = flag
+		return nil
+	}
+}
+
 // executor represents a built-in executor for running workflows.
 type executor struct {
 	log logger.Logger

--- a/tests/execution/queue/system_queue_test.go
+++ b/tests/execution/queue/system_queue_test.go
@@ -126,6 +126,7 @@ func TestSystemQueueConfigs(t *testing.T) {
 		require.True(t, hasMember(t, r, kg.GlobalAccountIndex(), accountId.String()))
 	})
 
+	// TODO: Update this test once pause timeouts only go to system queue
 	t.Run("pause timeouts should belong to fn queue", func(t *testing.T) {
 		r.FlushAll()
 


### PR DESCRIPTION
## Description

> [!CAUTION]
> This breaks singletons. Some users want to maintain a singleton lock when the run is waiting for an event or signal, or invoking another function. Moving pause timeouts to the system queue means we won't use the same user level singleton lock on the account shard.

Upstream in https://github.com/inngest/monorepo/pull/7382

Going through all queue items, pause timeouts are enqueued to user queues and don't skip constraint checks, so use the Constraint API. This also means that in case of missing concurrency capacity, we will not run pause timeouts.

Pause timeouts only schedule the resume job as an `edge` item subject to constraint checks, so there's no reason why pause timeouts should not be a system queue like all other timeouts.

Here's a comprehensive table of all queue item types:

| Item Kind | Queue name | Is System? | Description |
| --- | --- | --- | --- |
| `internal-recovery` | `internal-recovery` | Yes | Replays |
| `schedule-batch` | `schedule-batch` | Yes | Batch timeouts |
| `pause-event` | `pause-event` | Yes | Pause events (not timeouts) |
| `debounce` | `debounce` | Yes | Debounce timeouts |
| `queue-migrate` | `queue-migrate` | Yes | Queue migrations (is this still used?) |
| `cancel` | `cancel` | Yes | Cancellation jobs |
| `fp` | `fp` | Yes | Function pausing jobs |
| `fup` | `fup` | Yes | Function unpausing jobs |
| `cron` | `cron` | Yes | Cron item |
| `cron-sync` | `cron-sync` | Yes | Cron sync |
| `jps` | `jps` | Yes | Job promotion |
| `pbf` | `pbf` | Yes | Pause block flush |
| `pause` | `pause` | No ⚠️ | Pause timeout job |

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
