### PR TITLE
fix(realtime): websocket memory leak

### DIFF
--- a/pkg/execution/realtime/api.go
+++ b/pkg/execution/realtime/api.go
@@ -333,6 +333,11 @@ func (a *api) GetWebsocketUpgrade(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 
+	// Cleanup subscription
+	if err := a.opts.Broadcaster.CloseSubscription(ctx, sub.ID()); err != nil {
+		logger.StdlibLogger(ctx).Warn("error closing websocket subscription", "error", err, "sub_id", sub.ID())
+	}
+
 	logger.StdlibLogger(ctx).Debug("closing websocket conn", "sub_id", sub.ID())
 	_ = ws.CloseNow()
 }

--- a/pkg/execution/realtime/api_websocket_test.go
+++ b/pkg/execution/realtime/api_websocket_test.go
@@ -340,11 +340,9 @@ func TestAPI_GetWebsocketUpgrade(t *testing.T) {
 
 		// Check if subscription was cleaned up
 		// Note: With websockets using context.Background() for Poll, cleanup may not happen immediately on context cancellation
-		finalSubCount := subCount(bc)
-
 		// Allow for either immediate cleanup or eventual cleanup
-		if finalSubCount > 0 {
-			t.Logf("Subscription still active after context timeout (expected for websocket implementation)")
-		}
+		require.Eventually(t, func() bool {
+			return subCount(bc) == 0
+		}, 2*time.Second, 10*time.Millisecond, "topic goroutines should be stopped")
 	})
 }

--- a/pkg/execution/realtime/broadcaster.go
+++ b/pkg/execution/realtime/broadcaster.go
@@ -330,7 +330,7 @@ func (b *broadcaster) CloseSubscription(ctx context.Context, subscriptionID uuid
 	}
 
 	if err := as.Close(); err != nil {
-		return fmt.Errorf("error closing subscription: %w", err)
+		logger.StdlibLogger(ctx).Warn("error closing subscription", "error", err, "sub_id", subscriptionID)
 	}
 
 	// Delete all subscriptions from the topic lookup


### PR DESCRIPTION
## Description

Previously the websocket handler never called `CloseSubscription` on disconnect, and `CloseSubscription` bailed out when `as.Close()` errored (which it does on abrupt disconnects), which led to things not being cleaned up correctly.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
Fix memory leak in realtime websocket connections.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
