### PR TITLE
feat: EXE-1547: Process leading and trailing OpCodes for showing in-progress steps

### DIFF
--- a/pkg/execution/checkpoint/util.go
+++ b/pkg/execution/checkpoint/util.go
@@ -16,6 +16,8 @@ func stepDynamicSeed(op state.GeneratorOpcode, attempt int) []byte {
 	return fmt.Appendf(nil, "%s:%d", op.ID, attempt)
 }
 
+const PairedTrailingKey = "_paired_trailing"
+
 // isPairedTrailingStepRun reports whether this StepRun is the trailing arm
 // of a paired StepPlanned + StepRun emitted by an SDK in checkpointing mode
 // for an in-progress step.
@@ -27,7 +29,7 @@ func isPairedTrailingStepRun(op state.GeneratorOpcode) bool {
 	if !ok {
 		return false
 	}
-	v, ok := opts["_paired_trailing"].(bool)
+	v, ok := opts[PairedTrailingKey].(bool)
 	return ok && v
 }
 

--- a/pkg/execution/checkpoint/util.go
+++ b/pkg/execution/checkpoint/util.go
@@ -16,18 +16,47 @@ func stepDynamicSeed(op state.GeneratorOpcode, attempt int) []byte {
 	return fmt.Appendf(nil, "%s:%d", op.ID, attempt)
 }
 
+// isPairedTrailingStepRun reports whether this StepRun is the trailing arm
+// of a paired StepPlanned + StepRun emitted by an SDK in checkpointing mode
+// for an in-progress step.
+func isPairedTrailingStepRun(op state.GeneratorOpcode) bool {
+	if op.Op != enums.OpcodeStepRun {
+		return false
+	}
+	opts, ok := op.Opts.(map[string]any)
+	if !ok {
+		return false
+	}
+	v, ok := opts["_paired_trailing"].(bool)
+	return ok && v
+}
+
 func stepRunAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, runID ulid.ULID) *meta.SerializableAttrs {
-	return attrs.Merge(
+	attrs = attrs.Merge(
 		meta.NewAttrSet(
-			meta.Attr(meta.Attrs.StepName, inngestgo.Ptr(op.UserDefinedName())),
-			meta.Attr(meta.Attrs.RunID, &runID),
-			meta.Attr(meta.Attrs.QueuedAt, inngestgo.Ptr(op.Timing.Start())),
-			meta.Attr(meta.Attrs.StartedAt, inngestgo.Ptr(op.Timing.Start())),
 			meta.Attr(meta.Attrs.EndedAt, inngestgo.Ptr(op.Timing.End())),
 			meta.Attr(meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusCompleted)),
 			meta.Attr(meta.Attrs.IsCheckpoint, inngestgo.Ptr(true)),
+			meta.Attr(meta.Attrs.StepName, inngestgo.Ptr(op.UserDefinedName())),
+			meta.Attr(meta.Attrs.RunID, &runID),
 		),
 	)
+
+	if isPairedTrailingStepRun(op) {
+		attrs = attrs.Merge(meta.NewAttrSet(
+			// Omit QueuedAt and StartedAt, as the trailing edge has different values
+			// and would override the leading edge's values.
+			//
+			// Mark this span, so that we don't add QueuedAt and StartedAt later.
+			meta.Attr(meta.Attrs.IsPairedTrailing, inngestgo.Ptr(true)),
+		))
+	} else {
+		attrs = attrs.Merge(meta.NewAttrSet(
+			meta.Attr(meta.Attrs.QueuedAt, inngestgo.Ptr(op.Timing.Start())),
+			meta.Attr(meta.Attrs.StartedAt, inngestgo.Ptr(op.Timing.Start())),
+		))
+	}
+	return attrs
 }
 
 func stepPlannedAttrs(attrs *meta.SerializableAttrs, op state.GeneratorOpcode, runID ulid.ULID) *meta.SerializableAttrs {

--- a/pkg/execution/checkpoint/util_test.go
+++ b/pkg/execution/checkpoint/util_test.go
@@ -1,0 +1,95 @@
+package checkpoint
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsPairedTrailingStepRun(t *testing.T) {
+	tests := []struct {
+		name string
+		op   state.GeneratorOpcode
+		want bool
+	}{
+		{
+			name: "non-StepRun opcode is never paired-trailing",
+			op: state.GeneratorOpcode{
+				Op:   enums.OpcodeStepPlanned,
+				Opts: map[string]any{"_paired_trailing": true},
+			},
+			want: false,
+		},
+		{
+			name: "StepRun with nil opts",
+			op:   state.GeneratorOpcode{Op: enums.OpcodeStepRun},
+			want: false,
+		},
+		{
+			name: "StepRun with non-map opts",
+			op: state.GeneratorOpcode{
+				Op:   enums.OpcodeStepRun,
+				Opts: "not-a-map",
+			},
+			want: false,
+		},
+		{
+			name: "StepRun with map opts missing the flag",
+			op: state.GeneratorOpcode{
+				Op:   enums.OpcodeStepRun,
+				Opts: map[string]any{"other": true},
+			},
+			want: false,
+		},
+		{
+			name: "StepRun with flag set to false",
+			op: state.GeneratorOpcode{
+				Op:   enums.OpcodeStepRun,
+				Opts: map[string]any{"_paired_trailing": false},
+			},
+			want: false,
+		},
+		{
+			name: "StepRun with flag as a string is the wrong type",
+			op: state.GeneratorOpcode{
+				Op:   enums.OpcodeStepRun,
+				Opts: map[string]any{"_paired_trailing": "true"},
+			},
+			want: false,
+		},
+		{
+			name: "StepRun with flag set to true",
+			op: state.GeneratorOpcode{
+				Op:   enums.OpcodeStepRun,
+				Opts: map[string]any{"_paired_trailing": true},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isPairedTrailingStepRun(tc.op))
+		})
+	}
+}
+
+// TestIsPairedTrailingStepRun_WireShape guards the realistic path: when the
+// opcode is decoded from the JSON an SDK actually sends, the opts object
+// decodes to map[string]any and the flag decodes to a Go bool. If either shape
+// drifts, the type assertions in isPairedTrailingStepRun silently return false
+// and the flag is never honored.
+func TestIsPairedTrailingStepRun_WireShape(t *testing.T) {
+	var op state.GeneratorOpcode
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"op": "StepRun",
+		"id": "step-id",
+		"opts": {"_paired_trailing": true}
+	}`), &op))
+
+	require.Equal(t, enums.OpcodeStepRun, op.Op)
+	require.True(t, isPairedTrailingStepRun(op))
+}

--- a/pkg/execution/checkpoint/util_test.go
+++ b/pkg/execution/checkpoint/util_test.go
@@ -23,7 +23,7 @@ func TestIsPairedTrailingStepRun(t *testing.T) {
 			name: "non-StepRun opcode is never paired-trailing",
 			op: state.GeneratorOpcode{
 				Op:   enums.OpcodeStepPlanned,
-				Opts: map[string]any{"_paired_trailing": true},
+				Opts: map[string]any{PairedTrailingKey: true},
 			},
 			want: false,
 		},
@@ -52,7 +52,7 @@ func TestIsPairedTrailingStepRun(t *testing.T) {
 			name: "StepRun with flag set to false",
 			op: state.GeneratorOpcode{
 				Op:   enums.OpcodeStepRun,
-				Opts: map[string]any{"_paired_trailing": false},
+				Opts: map[string]any{PairedTrailingKey: false},
 			},
 			want: false,
 		},
@@ -60,7 +60,7 @@ func TestIsPairedTrailingStepRun(t *testing.T) {
 			name: "StepRun with flag as a string is the wrong type",
 			op: state.GeneratorOpcode{
 				Op:   enums.OpcodeStepRun,
-				Opts: map[string]any{"_paired_trailing": "true"},
+				Opts: map[string]any{PairedTrailingKey: "true"},
 			},
 			want: false,
 		},
@@ -68,7 +68,7 @@ func TestIsPairedTrailingStepRun(t *testing.T) {
 			name: "StepRun with flag set to true",
 			op: state.GeneratorOpcode{
 				Op:   enums.OpcodeStepRun,
-				Opts: map[string]any{"_paired_trailing": true},
+				Opts: map[string]any{PairedTrailingKey: true},
 			},
 			want: true,
 		},
@@ -136,7 +136,7 @@ func TestStepRunAttrs(t *testing.T) {
 
 	t.Run("paired-trailing StepRun omits QueuedAt and StartedAt", func(t *testing.T) {
 		op := baseOp()
-		op.Opts = map[string]any{"_paired_trailing": true}
+		op.Opts = map[string]any{PairedTrailingKey: true}
 		attrs := stepRunAttrs(meta.NewAttrSet(), op, runID)
 
 		val, ok := meta.GetBoolFlag(attrs, meta.Attrs.IsPairedTrailing)

--- a/pkg/execution/checkpoint/util_test.go
+++ b/pkg/execution/checkpoint/util_test.go
@@ -3,9 +3,13 @@ package checkpoint
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/inngest/inngest/pkg/util/interval"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -92,4 +96,63 @@ func TestIsPairedTrailingStepRun_WireShape(t *testing.T) {
 
 	require.Equal(t, enums.OpcodeStepRun, op.Op)
 	require.True(t, isPairedTrailingStepRun(op))
+}
+
+func TestStepRunAttrs(t *testing.T) {
+	runID := ulid.Make()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	timing := interval.Interval{A: start.UnixNano(), B: int64(5 * time.Second)}
+	name := "my-step"
+
+	baseOp := func() state.GeneratorOpcode {
+		return state.GeneratorOpcode{
+			Op:          enums.OpcodeStepRun,
+			ID:          "step-id",
+			DisplayName: &name,
+			Timing:      timing,
+		}
+	}
+
+	t.Run("plain StepRun sets QueuedAt and StartedAt and is not paired-trailing", func(t *testing.T) {
+		op := baseOp()
+		attrs := stepRunAttrs(meta.NewAttrSet(), op, runID)
+
+		_, isPaired := meta.GetBoolFlag(attrs, meta.Attrs.IsPairedTrailing)
+		require.False(t, isPaired, "plain StepRun must not be flagged paired-trailing")
+
+		qa, ok := attrs.Get(meta.Attrs.QueuedAt.Key()).(*time.Time)
+		require.True(t, ok, "QueuedAt must be set for a plain StepRun")
+		require.Equal(t, op.Timing.Start().UnixNano(), qa.UnixNano())
+
+		sa, ok := attrs.Get(meta.Attrs.StartedAt.Key()).(*time.Time)
+		require.True(t, ok, "StartedAt must be set for a plain StepRun")
+		require.Equal(t, op.Timing.Start().UnixNano(), sa.UnixNano())
+
+		// The common attributes are merged regardless of the paired-trailing branch.
+		sn, ok := attrs.Get(meta.Attrs.StepName.Key()).(*string)
+		require.True(t, ok)
+		require.Equal(t, name, *sn)
+	})
+
+	t.Run("paired-trailing StepRun omits QueuedAt and StartedAt", func(t *testing.T) {
+		op := baseOp()
+		op.Opts = map[string]any{"_paired_trailing": true}
+		attrs := stepRunAttrs(meta.NewAttrSet(), op, runID)
+
+		val, ok := meta.GetBoolFlag(attrs, meta.Attrs.IsPairedTrailing)
+		require.True(t, ok)
+		require.True(t, val)
+
+		// Omitting these is the whole point: the trailing arm must not clobber
+		// the timing the leading StepPlanned already wrote to the shared span.
+		require.Nil(t, attrs.Get(meta.Attrs.QueuedAt.Key()),
+			"QueuedAt must be omitted so the leading arm's value survives")
+		require.Nil(t, attrs.Get(meta.Attrs.StartedAt.Key()),
+			"StartedAt must be omitted so the leading arm's value survives")
+
+		// The common attributes are still merged.
+		sn, ok := attrs.Get(meta.Attrs.StepName.Key()).(*string)
+		require.True(t, ok)
+		require.Equal(t, name, *sn)
+	})
 }

--- a/pkg/tracing/meta/attributes.go
+++ b/pkg/tracing/meta/attributes.go
@@ -148,6 +148,11 @@ var Attrs = struct {
 
 	IsCheckpoint attr[*bool]
 
+	// IsPairedTrailing marks a span as the trailing arm of a StepPlanned +
+	// StepRun pair, so that downstream processing skips StartedAt and
+	// QueuedAt attributes that would overwrite the leading arm's values.
+	IsPairedTrailing attr[*bool]
+
 	// Userland attributes
 	IsUserland                 attr[*bool]
 	UserlandSpanID             attr[*string]
@@ -253,6 +258,7 @@ var Attrs = struct {
 	StepWaitForEventName:               StringAttr("step.wait_for_event.name"),
 	UserlandSpanID:                     StringAttr("userland.span.id"),
 	IsCheckpoint:                       BoolAttr("checkpoint"),
+	IsPairedTrailing:                   BoolAttr("step.paired_trailing"),
 	IsUserland:                         BoolAttr("userland"),
 	UserlandKind:                       StringAttr("userland.kind"),
 	UserlandServiceName:                StringAttr("userland.service.name"),

--- a/pkg/tracing/meta/extracted_values_gen.go
+++ b/pkg/tracing/meta/extracted_values_gen.go
@@ -94,6 +94,7 @@ type ExtractedValues struct {
 	ResponseOutputSize *int
 	ResponseSteps *ResponseOps
 	IsCheckpoint *bool
+	IsPairedTrailing *bool
 	IsUserland *bool
 	UserlandSpanID *string
 	UserlandName *string

--- a/pkg/tracing/meta/serializers.go
+++ b/pkg/tracing/meta/serializers.go
@@ -75,6 +75,23 @@ func AddAttrIfUnset[T any](r *SerializableAttrs, attr attr[T], value T) {
 	r.Attrs = append(r.Attrs, newAttr)
 }
 
+// GetBoolFlag returns a bool flag and its presence.
+func GetBoolFlag(r *SerializableAttrs, a attr[*bool]) (val bool, ok bool) {
+	if r == nil {
+		return false, false
+	}
+	idx, ok := r.keyMap[a.key]
+	if !ok {
+		return false, false
+	}
+	v, ok := r.Attrs[idx].value.(*bool)
+	if !ok || v == nil {
+		return false, false
+	}
+
+	return *v, true
+}
+
 func GetAttr[T any](r *SerializableAttrs, attr attr[*T]) (*T, bool) {
 	// Attributes that are applied later will override earlier ones, so we
 	// iterate in reverse order.

--- a/pkg/tracing/meta/serializers_test.go
+++ b/pkg/tracing/meta/serializers_test.go
@@ -829,6 +829,58 @@ func TestExtractTypedValues(t *testing.T) {
 	})
 }
 
+func TestGetBoolFlag(t *testing.T) {
+	tr, fl := true, false
+
+	t.Run("nil receiver", func(t *testing.T) {
+		val, ok := GetBoolFlag(nil, Attrs.IsPairedTrailing)
+		require.False(t, ok)
+		require.False(t, val)
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		attrs := NewAttrSet(Attr(Attrs.IsCheckpoint, &tr))
+		val, ok := GetBoolFlag(attrs, Attrs.IsPairedTrailing)
+		require.False(t, ok)
+		require.False(t, val)
+	})
+
+	t.Run("present and true", func(t *testing.T) {
+		attrs := NewAttrSet(Attr(Attrs.IsPairedTrailing, &tr))
+		val, ok := GetBoolFlag(attrs, Attrs.IsPairedTrailing)
+		require.True(t, ok)
+		require.True(t, val)
+	})
+
+	t.Run("present and false reports presence", func(t *testing.T) {
+		// The ok return must distinguish "set to false" from "absent" — the
+		// consumer in tracer.go branches on (ok && val).
+		attrs := NewAttrSet(Attr(Attrs.IsPairedTrailing, &fl))
+		val, ok := GetBoolFlag(attrs, Attrs.IsPairedTrailing)
+		require.True(t, ok)
+		require.False(t, val)
+	})
+
+	t.Run("present but nil pointer", func(t *testing.T) {
+		attrs := NewAttrSet(Attr(Attrs.IsPairedTrailing, (*bool)(nil)))
+		val, ok := GetBoolFlag(attrs, Attrs.IsPairedTrailing)
+		require.False(t, ok)
+		require.False(t, val)
+	})
+
+	t.Run("present but wrong stored type", func(t *testing.T) {
+		// Simulate the key mapping to a non-*bool value (e.g. a key collision
+		// with an attribute of another type).
+		attrs := &SerializableAttrs{
+			Attrs:  []SerializableAttr{{key: Attrs.IsPairedTrailing.key, value: "not-a-bool"}},
+			keyMap: map[string]int{Attrs.IsPairedTrailing.key: 0},
+		}
+		val, ok := GetBoolFlag(attrs, Attrs.IsPairedTrailing)
+		require.False(t, ok)
+		require.False(t, val)
+	})
+}
+
 type hexInt int64
 
 func (t hexInt) MarshalText() ([]byte, error) {

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -158,8 +158,6 @@ func (tp *otelTracerProvider) CreateDroppableSpan(
 	st := opts.StartTime
 	if st.IsZero() {
 		st = time.Now()
-	} else if !(isPairedTrailing) {
-		meta.AddAttr(attrs, meta.Attrs.StartedAt, &st)
 	}
 
 	if opts.Parent != nil {

--- a/pkg/tracing/tracer.go
+++ b/pkg/tracing/tracer.go
@@ -151,10 +151,14 @@ func (tp *otelTracerProvider) CreateDroppableSpan(
 		attrs = meta.NewAttrSet()
 	}
 
+	// The StepRun of a (StepPlanned, StepRun) pair omits StartedAt so the
+	// StepPlanned's value survives.
+	isPairedTrailing, _ := meta.GetBoolFlag(attrs, meta.Attrs.IsPairedTrailing)
+
 	st := opts.StartTime
 	if st.IsZero() {
 		st = time.Now()
-	} else {
+	} else if !(isPairedTrailing) {
 		meta.AddAttr(attrs, meta.Attrs.StartedAt, &st)
 	}
 
@@ -181,7 +185,7 @@ func (tp *otelTracerProvider) CreateDroppableSpan(
 			meta.AddAttr(attrs, meta.Attrs.InternalLocation, &opts.Debug.Location)
 		}
 	}
-	if !opts.StartTime.IsZero() {
+	if !opts.StartTime.IsZero() && !(isPairedTrailing) {
 		meta.AddAttr(attrs, meta.Attrs.StartedAt, &opts.StartTime)
 	}
 	if !opts.EndTime.IsZero() {

--- a/pkg/tracing/tracer_test.go
+++ b/pkg/tracing/tracer_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/inngest/inngest/pkg/util"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
 func TestDeterministicTraceID(t *testing.T) {
@@ -127,4 +130,45 @@ func TestSeededSpanThenReuseContext(t *testing.T) {
 	require.NotEmpty(t, newTraceID)
 	require.NotEmpty(t, newDynamicSpanID)
 	require.NotEmpty(t, newTraceParent)
+}
+
+// TestCreateDroppableSpanPairedTrailingOmitsStartedAt verifies that the
+// consume-site honors the paired-trailing flag: a paired-trailing span must
+// not record StartedAt (so the leading StepPlanned arm's value survives on the
+// shared dynamic span), while an otherwise-identical plain span records it.
+func TestCreateDroppableSpanPairedTrailingOmitsStartedAt(t *testing.T) {
+	ctx := t.Context()
+	startedAtKey := meta.Attrs.StartedAt.Key()
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	hasStartedAtAttr := func(t *testing.T, ds *DroppableSpan) bool {
+		span, ok := ds.span.(sdktrace.ReadOnlySpan)
+		require.True(t, ok, "span must be a ReadOnlySpan to inspect attributes")
+		for _, kv := range span.Attributes() {
+			if string(kv.Key) == startedAtKey {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("plain span with a StartTime records StartedAt", func(t *testing.T) {
+		traceProvider := NewOtelTracerProvider(nil, time.Millisecond)
+		droppableSpan, err := traceProvider.CreateDroppableSpan(ctx, "step", &CreateSpanOptions{
+			StartTime: start,
+		})
+		require.NoError(t, err)
+		require.True(t, hasStartedAtAttr(t, droppableSpan), "StartedAt must be recorded when not paired-trailing")
+	})
+
+	t.Run("paired-trailing span omits StartedAt", func(t *testing.T) {
+		traceProvider := NewOtelTracerProvider(nil, time.Millisecond)
+		droppableSPan, err := traceProvider.CreateDroppableSpan(ctx, "step", &CreateSpanOptions{
+			StartTime:  start,
+			Attributes: meta.NewAttrSet(meta.Attr(meta.Attrs.IsPairedTrailing, util.ToPtr(true))),
+		})
+		require.NoError(t, err)
+		require.False(t, hasStartedAtAttr(t, droppableSPan),
+			"StartedAt must be omitted for the paired-trailing arm so the leading arm's value survives")
+	})
 }

--- a/pkg/tracing/util.go
+++ b/pkg/tracing/util.go
@@ -19,6 +19,7 @@ import (
 	"github.com/inngest/inngest/pkg/util/aigateway"
 	"github.com/inngest/inngestgo"
 	"github.com/oklog/ulid/v2"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -448,4 +449,14 @@ func spanContextFromMetadata(m *meta.SpanReference) trace.SpanContext {
 	sc := trace.SpanContextFromContext(ctx)
 
 	return sc
+}
+
+func isPairedTrailing(attrs []attribute.KeyValue) bool {
+	for _, attr := range attrs {
+		if string(attr.Key) == meta.Attrs.IsPairedTrailing.Key() &&
+			attr.Value.Type() == attribute.BOOL && attr.Value.AsBool() {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/tracing/util_test.go
+++ b/pkg/tracing/util_test.go
@@ -1,0 +1,54 @@
+package tracing
+
+import (
+	"testing"
+
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+func TestIsPairedTrailing(t *testing.T) {
+	key := meta.Attrs.IsPairedTrailing.Key()
+
+	tests := []struct {
+		name  string
+		attrs []attribute.KeyValue
+		want  bool
+	}{
+		{
+			name:  "empty",
+			attrs: nil,
+			want:  false,
+		},
+		{
+			name:  "flag present and true",
+			attrs: []attribute.KeyValue{attribute.Bool(key, true)},
+			want:  true,
+		},
+		{
+			name:  "flag present and false",
+			attrs: []attribute.KeyValue{attribute.Bool(key, false)},
+			want:  false,
+		},
+		{
+			name:  "flag key present but wrong type",
+			attrs: []attribute.KeyValue{attribute.String(key, "true")},
+			want:  false,
+		},
+		{
+			name: "only unrelated keys",
+			attrs: []attribute.KeyValue{
+				attribute.Bool("some.other.flag", true),
+				attribute.String(key+".suffix", "true"),
+			},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isPairedTrailing(tc.attrs))
+		})
+	}
+}

--- a/pkg/tracing/util_test.go
+++ b/pkg/tracing/util_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/inngest/inngest/pkg/util"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -49,6 +50,42 @@ func TestIsPairedTrailing(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.want, isPairedTrailing(tc.attrs))
+		})
+	}
+}
+
+// TestIsPairedTrailingSerializeRoundTrip guards the writer→reader contract
+// across representations. The flag is written into a SerializableAttrs (as the
+// checkpoint layer does via meta), but isPairedTrailing reads it from the
+// []attribute.KeyValue produced by Serialize() — what OnStart actually sees. A
+// key or serializer drift between the two would pass every isolated test yet
+// break this round-trip.
+func TestIsPairedTrailingSerializeRoundTrip(t *testing.T) {
+	tests := []struct {
+		name  string
+		attrs *meta.SerializableAttrs
+		want  bool
+	}{
+		{
+			name:  "flag true survives serialization",
+			attrs: meta.NewAttrSet(meta.Attr(meta.Attrs.IsPairedTrailing, util.ToPtr(true))),
+			want:  true,
+		},
+		{
+			name:  "flag false survives serialization",
+			attrs: meta.NewAttrSet(meta.Attr(meta.Attrs.IsPairedTrailing, util.ToPtr(false))),
+			want:  false,
+		},
+		{
+			name:  "absent flag",
+			attrs: meta.NewAttrSet(),
+			want:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isPairedTrailing(tc.attrs.Serialize()))
 		})
 	}
 }


### PR DESCRIPTION
## Description

- In https://github.com/inngest/inngest-js/pull/1550, we begin sending two OpCodes for long running steps
- In this PR, we update the executor to process these opcodes and emit spans, with special care not to add started at or queued at on the trailing span. 
  - We use the later start time of the trailing span so that our status:completed overrides the leading span's status:running. This override mechanism means that we must also omit the startedAt and queuedAt attributes from the trailing to avoid overwriting the lead span's attributes.

I detail the flow in:

<img width="8708" height="2858" alt="image" src="https://github.com/user-attachments/assets/9ffe86cf-44be-461b-8490-6abc9b43c89f" />

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
