### PR TITLE
fix: add app name to run spans

### DIFF
--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -54,6 +54,8 @@ type DebounceItem struct {
 	WorkspaceID uuid.UUID `json:"wsID"`
 	// AppID represents the app for the debounce item
 	AppID uuid.UUID `json:"appID"`
+	// AppName represents the app ID defined in user code.
+	AppName string `json:"appName,omitempty"`
 	// FunctionID represents the function ID that this debounce is for.
 	FunctionID uuid.UUID `json:"fnID"`
 	// FunctionVersion represents the version of the function that was debounced.

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -239,6 +239,8 @@ type ScheduleRequest struct {
 	WorkspaceID uuid.UUID
 	// AppID is the app that this request belongs to.
 	AppID uuid.UUID
+	// AppName is the app ID defined in user code.
+	AppName string
 	// RunID allows specifying a run ID for the scheduled run.  This is entirely
 	// optional, and allows clients to choose a run ID when scheduling.  We need this
 	// for run IDs with API-based checkpointing.
@@ -314,6 +316,7 @@ func NewScheduleRequest(f inngest.DeployedFunction) ScheduleRequest {
 		AccountID:   f.AccountID,
 		WorkspaceID: f.EnvironmentID,
 		AppID:       f.AppID,
+		AppName:     f.AppName,
 	}
 	if !f.PausedAt.IsZero() {
 		req.FunctionPausedAt = &f.PausedAt

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -992,6 +992,7 @@ func (e *executor) schedule(
 			AccountID:        req.AccountID,
 			WorkspaceID:      req.WorkspaceID,
 			AppID:            req.AppID,
+			AppName:          req.AppName,
 			FunctionID:       req.Function.ID,
 			FunctionVersion:  req.Function.FunctionVersion,
 			EventID:          req.Events[0].GetInternalID(),

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1315,6 +1315,7 @@ func (e *executor) schedule(
 	}
 	functionName := req.Function.Name
 	functionSlug := req.Function.GetSlug()
+	appName := req.AppName
 	runSpanOpts := &tracing.CreateSpanOptions{
 		Debug:    &tracing.SpanDebugData{Location: "executor.Schedule"},
 		Metadata: &metadata,
@@ -1326,6 +1327,7 @@ func (e *executor) schedule(
 			meta.Attr(meta.Attrs.QueuedAt, &runTimestamp),
 			meta.Attr(meta.Attrs.ReplayOriginalRunID, req.OriginalRunID),
 			meta.Attr(meta.Attrs.RunScheduleType, scheduleTypePtr),
+			meta.Attr(meta.Attrs.AppName, &appName),
 			meta.Attr(meta.Attrs.FunctionName, &functionName),
 			meta.Attr(meta.Attrs.FunctionSlug, &functionSlug),
 		),

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -496,6 +496,7 @@ func (s *svc) handleDebounce(ctx context.Context, item queue.Item) error {
 				AccountID:        di.AccountID,
 				WorkspaceID:      di.WorkspaceID,
 				AppID:            di.AppID,
+				AppName:          di.AppName,
 				Events:           []event.TrackedEvent{di},
 				PreventDebounce:  true,
 				PreventRateLimit: true, // Rate limit was already enforced for this

--- a/pkg/tracing/meta/attributes.go
+++ b/pkg/tracing/meta/attributes.go
@@ -20,6 +20,7 @@ var Attrs = struct {
 	// Run attributes
 	AccountID           attr[*uuid.UUID]
 	AppID               attr[*uuid.UUID]
+	AppName             attr[*string]
 	BatchID             attr[*ulid.ULID]
 	BatchTimestamp      attr[*time.Time]
 	CronSchedule        attr[*string]
@@ -175,6 +176,7 @@ var Attrs = struct {
 	AIResponseMetadata:                 JsonAttr[aigateway.ParsedInferenceResponse]("ai.response"),
 	AccountID:                          UUIDAttr("account.id"),
 	AppID:                              UUIDAttr("app.id"),
+	AppName:                            StringAttr("app.name"),
 	BatchID:                            ULIDAttr("batch.id"),
 	BatchTimestamp:                     TimeAttr("batch.ts"),
 	CronSchedule:                       StringAttr("cron.schedule"),

--- a/pkg/tracing/meta/extracted_values_gen.go
+++ b/pkg/tracing/meta/extracted_values_gen.go
@@ -21,6 +21,7 @@ type ExtractedValues struct {
 	EndedAt *time.Time
 	AccountID *uuid.UUID
 	AppID *uuid.UUID
+	AppName *string
 	BatchID *ulid.ULID
 	BatchTimestamp *time.Time
 	CronSchedule *string


### PR DESCRIPTION
## Description

Add app name to run spans for v2 api fetches.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
