### PR TITLE
feat: Use queue item timestamps for traces

### DIFF
--- a/pkg/coreapi/generated/generated.go
+++ b/pkg/coreapi/generated/generated.go
@@ -492,6 +492,7 @@ type ComplexityRoot struct {
 		Response          func(childComplexity int) int
 		Run               func(childComplexity int) int
 		RunID             func(childComplexity int) int
+		ScheduledAt       func(childComplexity int) int
 		SkipExistingRunID func(childComplexity int) int
 		SkipReason        func(childComplexity int) int
 		SpanID            func(childComplexity int) int
@@ -2928,6 +2929,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.RunTraceSpan.RunID(childComplexity), true
 
+	case "RunTraceSpan.scheduledAt":
+		if e.complexity.RunTraceSpan.ScheduledAt == nil {
+			break
+		}
+
+		return e.complexity.RunTraceSpan.ScheduledAt(childComplexity), true
+
 	case "RunTraceSpan.skipExistingRunID":
 		if e.complexity.RunTraceSpan.SkipExistingRunID == nil {
 			break
@@ -4338,6 +4346,7 @@ type RunTraceSpan {
   duration: Int # the duration of the span in milliseconds (calculated), if null, it's still running
   outputID: String
   queuedAt: Time!
+  scheduledAt: Time # the time this span was scheduled to run
   startedAt: Time # the start time of the span
   endedAt: Time # the end time of the span, only present if it's ended
   childrenSpans: [RunTraceSpan!]! # the children spans of this span - invoke
@@ -7759,6 +7768,8 @@ func (ec *executionContext) fieldContext_DebugRun_debugTraces(ctx context.Contex
 				return ec.fieldContext_RunTraceSpan_outputID(ctx, field)
 			case "queuedAt":
 				return ec.fieldContext_RunTraceSpan_queuedAt(ctx, field)
+			case "scheduledAt":
+				return ec.fieldContext_RunTraceSpan_scheduledAt(ctx, field)
 			case "startedAt":
 				return ec.fieldContext_RunTraceSpan_startedAt(ctx, field)
 			case "endedAt":
@@ -12672,6 +12683,8 @@ func (ec *executionContext) fieldContext_FunctionRunV2_trace(ctx context.Context
 				return ec.fieldContext_RunTraceSpan_outputID(ctx, field)
 			case "queuedAt":
 				return ec.fieldContext_RunTraceSpan_queuedAt(ctx, field)
+			case "scheduledAt":
+				return ec.fieldContext_RunTraceSpan_scheduledAt(ctx, field)
 			case "startedAt":
 				return ec.fieldContext_RunTraceSpan_startedAt(ctx, field)
 			case "endedAt":
@@ -15654,6 +15667,8 @@ func (ec *executionContext) fieldContext_Query_runTrace(ctx context.Context, fie
 				return ec.fieldContext_RunTraceSpan_outputID(ctx, field)
 			case "queuedAt":
 				return ec.fieldContext_RunTraceSpan_queuedAt(ctx, field)
+			case "scheduledAt":
+				return ec.fieldContext_RunTraceSpan_scheduledAt(ctx, field)
 			case "startedAt":
 				return ec.fieldContext_RunTraceSpan_startedAt(ctx, field)
 			case "endedAt":
@@ -19383,6 +19398,47 @@ func (ec *executionContext) fieldContext_RunTraceSpan_queuedAt(ctx context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _RunTraceSpan_scheduledAt(ctx context.Context, field graphql.CollectedField, obj *models.RunTraceSpan) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RunTraceSpan_scheduledAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ScheduledAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*time.Time)
+	fc.Result = res
+	return ec.marshalOTime2ᚖtimeᚐTime(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RunTraceSpan_scheduledAt(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RunTraceSpan",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _RunTraceSpan_startedAt(ctx context.Context, field graphql.CollectedField, obj *models.RunTraceSpan) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_RunTraceSpan_startedAt(ctx, field)
 	if err != nil {
@@ -19530,6 +19586,8 @@ func (ec *executionContext) fieldContext_RunTraceSpan_childrenSpans(ctx context.
 				return ec.fieldContext_RunTraceSpan_outputID(ctx, field)
 			case "queuedAt":
 				return ec.fieldContext_RunTraceSpan_queuedAt(ctx, field)
+			case "scheduledAt":
+				return ec.fieldContext_RunTraceSpan_scheduledAt(ctx, field)
 			case "startedAt":
 				return ec.fieldContext_RunTraceSpan_startedAt(ctx, field)
 			case "endedAt":
@@ -19889,6 +19947,8 @@ func (ec *executionContext) fieldContext_RunTraceSpan_parentSpan(ctx context.Con
 				return ec.fieldContext_RunTraceSpan_outputID(ctx, field)
 			case "queuedAt":
 				return ec.fieldContext_RunTraceSpan_queuedAt(ctx, field)
+			case "scheduledAt":
+				return ec.fieldContext_RunTraceSpan_scheduledAt(ctx, field)
 			case "startedAt":
 				return ec.fieldContext_RunTraceSpan_startedAt(ctx, field)
 			case "endedAt":
@@ -29253,6 +29313,10 @@ func (ec *executionContext) _RunTraceSpan(ctx context.Context, sel ast.Selection
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "scheduledAt":
+
+			out.Values[i] = ec._RunTraceSpan_scheduledAt(ctx, field, obj)
+
 		case "startedAt":
 
 			out.Values[i] = ec._RunTraceSpan_startedAt(ctx, field, obj)

--- a/pkg/coreapi/gql.schema.graphql
+++ b/pkg/coreapi/gql.schema.graphql
@@ -624,6 +624,7 @@ type RunTraceSpan {
   duration: Int # the duration of the span in milliseconds (calculated), if null, it's still running
   outputID: String
   queuedAt: Time!
+  scheduledAt: Time # the time this span was scheduled to run
   startedAt: Time # the start time of the span
   endedAt: Time # the end time of the span, only present if it's ended
   childrenSpans: [RunTraceSpan!]! # the children spans of this span - invoke

--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -240,6 +240,7 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 		RunID:          span.GetRunID(),
 		SpanID:         span.GetSpanID(),
 		StartedAt:      span.GetStartedAtTime(),
+		ScheduledAt:    span.GetScheduledAtTime(),
 		Status:         status,
 		TraceID:        span.GetTraceID(),
 		DebugRunID:     debugRunID,

--- a/pkg/coreapi/graph/models/augmented.go
+++ b/pkg/coreapi/graph/models/augmented.go
@@ -39,6 +39,7 @@ type RunTraceSpan struct {
 	Duration          *int                      `json:"duration,omitempty"`
 	OutputID          *string                   `json:"outputID,omitempty"`
 	QueuedAt          time.Time                 `json:"queuedAt"`
+	ScheduledAt       *time.Time                `json:"scheduledAt,omitempty"`
 	StartedAt         *time.Time                `json:"startedAt,omitempty"`
 	EndedAt           *time.Time                `json:"endedAt,omitempty"`
 	ChildrenSpans     []*RunTraceSpan           `json:"childrenSpans"`

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -148,6 +148,13 @@ func (s *OtelSpan) GetQueuedAtTime() time.Time {
 	return s.StartTime
 }
 
+func (s *OtelSpan) GetScheduledAtTime() *time.Time {
+	if s.Attributes != nil && s.Attributes.ScheduledAt != nil {
+		return s.Attributes.ScheduledAt
+	}
+	return nil
+}
+
 // GetStartedAtTime gets the time that the span started. Note that this is not necessarily
 // when the span created, as it may be dynamic.
 func (s *OtelSpan) GetStartedAtTime() *time.Time {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/url"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1309,6 +1310,22 @@ func (e *executor) schedule(
 		}
 	}
 
+	at := e.now()
+	if req.BatchID == nil {
+		evtTs := time.UnixMilli(req.Events[0].GetEvent().Timestamp)
+		if evtTs.After(at) {
+			// Schedule functions in the future if there's a future
+			// event `ts` field.
+			at = evtTs
+		}
+	}
+	if req.At != nil {
+		at = *req.At
+	}
+
+	// Fudge the timestamp slightly so that scheduledAt >= queuedAt
+	scheduledAt := slices.MaxFunc([]time.Time{at, runID.Timestamp()}, time.Time.Compare)
+
 	runTimestamp := runID.Timestamp()
 	var scheduleTypePtr *enums.ScheduleType
 	if req.ScheduleType != enums.ScheduleTypeUnknown {
@@ -1326,6 +1343,7 @@ func (e *executor) schedule(
 			meta.Attr(meta.Attrs.EventsInput, &strEvts),
 			meta.Attr(meta.Attrs.TriggeringEventName, eventName),
 			meta.Attr(meta.Attrs.QueuedAt, &runTimestamp),
+			meta.Attr(meta.Attrs.ScheduledAt, &scheduledAt),
 			meta.Attr(meta.Attrs.ReplayOriginalRunID, req.OriginalRunID),
 			meta.Attr(meta.Attrs.RunScheduleType, scheduleTypePtr),
 			meta.Attr(meta.Attrs.AppName, &appName),
@@ -1414,19 +1432,6 @@ func (e *executor) schedule(
 				return &metadata.ID.RunID, &metadata, err
 			}
 		}
-	}
-
-	at := e.now()
-	if req.BatchID == nil {
-		evtTs := time.UnixMilli(req.Events[0].GetEvent().Timestamp)
-		if evtTs.After(at) {
-			// Schedule functions in the future if there's a future
-			// event `ts` field.
-			at = evtTs
-		}
-	}
-	if req.At != nil {
-		at = *req.At
 	}
 
 	// Prefix the workflow to the job ID so that no invocation can accidentally
@@ -1880,6 +1885,10 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 
 	// This span will be updated with output as soon as execution finishes.
 	execAttrs := tracing.FunctionAttrs(&instance.f)
+	meta.AddAttr(execAttrs, meta.Attrs.StartedAt, &start)
+	runningStatus := enums.StepStatusRunning
+	meta.AddAttr(execAttrs, meta.Attrs.DynamicStatus, &runningStatus)
+	tracing.AddQueueTimestampAttrs(execAttrs, item)
 
 	instance.execSpan, err = e.tracerProvider.CreateSpan(
 		ctx,
@@ -3816,6 +3825,7 @@ func (e *executor) handleGeneratorStep(ctx context.Context, runCtx execution.Run
 						meta.Attr(meta.Attrs.StepName, inngestgo.Ptr(gen.UserDefinedName())),
 						meta.Attr(meta.Attrs.RunID, &runCtx.Metadata().ID.RunID),
 						meta.Attr(meta.Attrs.QueuedAt, inngestgo.Ptr(gen.Timing.Start())),
+						meta.Attr(meta.Attrs.ScheduledAt, inngestgo.Ptr(gen.Timing.Start())),
 						meta.Attr(meta.Attrs.StartedAt, inngestgo.Ptr(gen.Timing.Start())),
 						meta.Attr(meta.Attrs.EndedAt, inngestgo.Ptr(gen.Timing.End())),
 						meta.Attr(meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusCompleted)),
@@ -4130,6 +4140,8 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, runCtx execut
 
 	parent := tracing.RunSpanRefFromMetadata(runCtx.Metadata())
 	attrs := tracing.GeneratorAttrs(&gen)
+	meta.AddAttr(attrs, meta.Attrs.QueuedAt, &now)
+	meta.AddAttr(attrs, meta.Attrs.ScheduledAt, &now)
 
 	lifecycleItem := runCtx.LifecycleItem()
 	span, err := e.tracerProvider.CreateDroppableSpan(
@@ -4207,6 +4219,8 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, runCtx execution.Ru
 
 	lifecycleItem := runCtx.LifecycleItem()
 	metadata := runCtx.Metadata()
+	attrs := tracing.GeneratorAttrs(&gen)
+	tracing.AddQueueTimestampAttrs(attrs, runCtx.LifecycleItem())
 
 	// Create a new span that we'll use to record the sleep as complete.
 	// This is going to be attached to the same parent (the discovery step that started this sleep).
@@ -4220,7 +4234,7 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, runCtx execution.Ru
 			Metadata:    metadata,
 			QueueItem:   &nextItem,
 			Parent:      runCtx.ParentSpan(),
-			Attributes:  tracing.GeneratorAttrs(&gen),
+			Attributes:  attrs,
 		},
 	)
 	if err != nil {
@@ -4794,6 +4808,9 @@ func (e *executor) handleGeneratorWaitForSignal(ctx context.Context, runCtx exec
 	}
 
 	lifecycleItem := runCtx.LifecycleItem()
+	attrs := tracing.GeneratorAttrs(&gen)
+	tracing.AddQueueTimestampAttrs(attrs, lifecycleItem)
+
 	span, err := e.tracerProvider.CreateDroppableSpan(
 		ctx,
 		meta.SpanNameStep,
@@ -4804,7 +4821,7 @@ func (e *executor) handleGeneratorWaitForSignal(ctx context.Context, runCtx exec
 			Metadata:    runCtx.Metadata(),
 			QueueItem:   &nextItem,
 			Parent:      tracing.RunSpanRefFromMetadata(runCtx.Metadata()),
-			Attributes:  tracing.GeneratorAttrs(&gen),
+			Attributes:  attrs,
 			StartTime:   now,
 		},
 	)
@@ -4990,6 +5007,10 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx exe
 		Metadata:     make(map[string]any),
 		ParallelMode: gen.ParallelMode(),
 	}
+	attrs := tracing.GeneratorAttrs(&gen)
+	tracing.AddQueueTimestampAttrs(attrs, runCtx.LifecycleItem())
+	// Always correlate the triggering event ID with the invoked step.
+	meta.AddAttr(attrs, meta.Attrs.StepInvokeTriggerEventID, &evt.ID)
 
 	lifecycleItem := runCtx.LifecycleItem()
 	span, err := e.tracerProvider.CreateDroppableSpan(
@@ -5003,10 +5024,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx exe
 			Metadata:    runCtx.Metadata(),
 			QueueItem:   &nextItem,
 			Parent:      tracing.RunSpanRefFromMetadata(runCtx.Metadata()),
-			Attributes: tracing.GeneratorAttrs(&gen).Merge(
-				// Always correlate the triggering event ID with the invoked step.
-				meta.NewAttrSet(meta.Attr(meta.Attrs.StepInvokeTriggerEventID, &evt.ID)),
-			),
+			Attributes:  attrs,
 		},
 	)
 	if err != nil {
@@ -5213,6 +5231,8 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, runCtx execu
 		Metadata:     make(map[string]any),
 		ParallelMode: gen.ParallelMode(),
 	}
+	attrs := tracing.GeneratorAttrs(&gen)
+	tracing.AddQueueTimestampAttrs(attrs, runCtx.LifecycleItem())
 
 	lifecycleItem := runCtx.LifecycleItem()
 	span, err := e.tracerProvider.CreateDroppableSpan(
@@ -5225,7 +5245,7 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, runCtx execu
 			Metadata:    runCtx.Metadata(),
 			QueueItem:   &nextItem,
 			Parent:      tracing.RunSpanRefFromMetadata(runCtx.Metadata()),
-			Attributes:  tracing.GeneratorAttrs(&gen),
+			Attributes:  attrs,
 		},
 	)
 	if err != nil {

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -377,6 +377,11 @@ type Item struct {
 	// Only present on start jobs for function concurrency, or on all items
 	// for worker concurrency (app-scoped semaphores).
 	Semaphores []constraintapi.Semaphore `json:"sem,omitempty"`
+
+	// EnqueuedAt is the time this item was enqueued, populated from the outer queue item's EnqueuedAt field
+	EnqueuedAt time.Time `json:"-"`
+	// At is the time that this item is scheduled to run, populated from the outer queue item's At field.
+	At time.Time `json:"-"`
 }
 
 func (i Item) GetMaxAttempts() int {

--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -141,6 +141,11 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 		span.SetAttributes(attribute.String("job_id", *item.Data.JobID))
 	}
 
+	// Copy queue timestamps into the inner item for easier access during processing.
+	// We convert these to time.Time here so that we don't have to convert them multiple times during processing.
+	item.Data.At = time.UnixMilli(item.AtMS)
+	item.Data.EnqueuedAt = time.UnixMilli(item.EnqueuedAt)
+
 	if item.IsLeased(p.Queue.Clock().Now()) {
 		span.SetAttributes(attribute.String("skip_reason", "already_leased"))
 		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{

--- a/pkg/tracing/execution_processor.go
+++ b/pkg/tracing/execution_processor.go
@@ -2,6 +2,7 @@ package tracing
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	"github.com/inngest/inngest/pkg/enums"
@@ -57,6 +58,21 @@ func AddMetadataTenantAttrs(rawAttrs *meta.SerializableAttrs, id statev2.ID) {
 	meta.AddAttr(rawAttrs, meta.Attrs.AccountID, &id.Tenant.AccountID)
 	meta.AddAttr(rawAttrs, meta.Attrs.EnvID, &id.Tenant.EnvID)
 	meta.AddAttr(rawAttrs, meta.Attrs.AppID, &id.Tenant.AppID)
+}
+
+func AddQueueTimestampAttrs(rawAttrs *meta.SerializableAttrs, item queue.Item) {
+	if !item.EnqueuedAt.IsZero() {
+		meta.AddAttr(rawAttrs, meta.Attrs.QueuedAt, &item.EnqueuedAt)
+	}
+
+	if !item.At.IsZero() {
+		// Fudge the timestamp slightly in the case that At < EnqueuedAt
+		// which happens when a job is scheduled to run immediately
+		// (ie. At is now at the time of Enqueue(), but EnqueuedAt is created after that).
+		// This ensures that the ScheduledAt time is always >= QueuedAt time.
+		scheduledAt := slices.MaxFunc([]time.Time{item.EnqueuedAt, item.At}, time.Time.Compare)
+		meta.AddAttr(rawAttrs, meta.Attrs.ScheduledAt, &scheduledAt)
+	}
 }
 
 func getExecutionContext(ctx context.Context) *ExecutionContext {

--- a/pkg/tracing/execution_processor_test.go
+++ b/pkg/tracing/execution_processor_test.go
@@ -1,0 +1,93 @@
+package tracing
+
+import (
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddQueueTimestampAttrs(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	later := now.Add(5 * time.Second)
+	earlier := now.Add(-5 * time.Second)
+
+	t.Run("both zero: no attributes set", func(t *testing.T) {
+		attrs := meta.NewAttrSet()
+		item := queue.Item{}
+		AddQueueTimestampAttrs(attrs, item)
+
+		_, hasQueuedAt := meta.GetAttr(attrs, meta.Attrs.QueuedAt)
+		_, hasScheduledAt := meta.GetAttr(attrs, meta.Attrs.ScheduledAt)
+		assert.False(t, hasQueuedAt)
+		assert.False(t, hasScheduledAt)
+	})
+
+	t.Run("only EnqueuedAt set: QueuedAt set, ScheduledAt absent", func(t *testing.T) {
+		attrs := meta.NewAttrSet()
+		item := queue.Item{EnqueuedAt: now}
+		AddQueueTimestampAttrs(attrs, item)
+
+		queuedAt, hasQueuedAt := meta.GetAttr(attrs, meta.Attrs.QueuedAt)
+		_, hasScheduledAt := meta.GetAttr(attrs, meta.Attrs.ScheduledAt)
+		require.True(t, hasQueuedAt)
+		assert.Equal(t, now, *queuedAt)
+		assert.False(t, hasScheduledAt)
+	})
+
+	t.Run("only At set: ScheduledAt equals At, QueuedAt absent", func(t *testing.T) {
+		attrs := meta.NewAttrSet()
+		item := queue.Item{At: now}
+		AddQueueTimestampAttrs(attrs, item)
+
+		_, hasQueuedAt := meta.GetAttr(attrs, meta.Attrs.QueuedAt)
+		scheduledAt, hasScheduledAt := meta.GetAttr(attrs, meta.Attrs.ScheduledAt)
+		assert.False(t, hasQueuedAt)
+		require.True(t, hasScheduledAt)
+		assert.Equal(t, now, *scheduledAt)
+	})
+
+	t.Run("At after EnqueuedAt: ScheduledAt equals At", func(t *testing.T) {
+		attrs := meta.NewAttrSet()
+		item := queue.Item{EnqueuedAt: now, At: later}
+		AddQueueTimestampAttrs(attrs, item)
+
+		queuedAt, hasQueuedAt := meta.GetAttr(attrs, meta.Attrs.QueuedAt)
+		scheduledAt, hasScheduledAt := meta.GetAttr(attrs, meta.Attrs.ScheduledAt)
+		require.True(t, hasQueuedAt)
+		require.True(t, hasScheduledAt)
+		assert.Equal(t, now, *queuedAt)
+		assert.Equal(t, later, *scheduledAt)
+	})
+
+	t.Run("At before EnqueuedAt: EnqueuedAt fudged to ScheduledAt", func(t *testing.T) {
+		attrs := meta.NewAttrSet()
+		item := queue.Item{EnqueuedAt: now, At: earlier}
+		AddQueueTimestampAttrs(attrs, item)
+
+		queuedAt, hasQueuedAt := meta.GetAttr(attrs, meta.Attrs.QueuedAt)
+		scheduledAt, hasScheduledAt := meta.GetAttr(attrs, meta.Attrs.ScheduledAt)
+		require.True(t, hasQueuedAt)
+		require.True(t, hasScheduledAt)
+		assert.Equal(t, now, *queuedAt)
+		// ScheduledAt must never be before QueuedAt
+		assert.Equal(t, now, *scheduledAt)
+		assert.False(t, scheduledAt.Before(*queuedAt))
+	})
+
+	t.Run("At equals EnqueuedAt: ScheduledAt equals both", func(t *testing.T) {
+		attrs := meta.NewAttrSet()
+		item := queue.Item{EnqueuedAt: now, At: now}
+		AddQueueTimestampAttrs(attrs, item)
+
+		queuedAt, hasQueuedAt := meta.GetAttr(attrs, meta.Attrs.QueuedAt)
+		scheduledAt, hasScheduledAt := meta.GetAttr(attrs, meta.Attrs.ScheduledAt)
+		require.True(t, hasQueuedAt)
+		require.True(t, hasScheduledAt)
+		assert.Equal(t, now, *queuedAt)
+		assert.Equal(t, now, *scheduledAt)
+	})
+}

--- a/pkg/tracing/meta/attributes.go
+++ b/pkg/tracing/meta/attributes.go
@@ -13,9 +13,10 @@ import (
 
 var Attrs = struct {
 	// Timings
-	StartedAt attr[*time.Time]
-	QueuedAt  attr[*time.Time]
-	EndedAt   attr[*time.Time]
+	QueuedAt    attr[*time.Time]
+	ScheduledAt attr[*time.Time]
+	StartedAt   attr[*time.Time]
+	EndedAt     attr[*time.Time]
 
 	// Run attributes
 	AccountID           attr[*uuid.UUID]
@@ -220,6 +221,7 @@ var Attrs = struct {
 	SkipReason:                         TextAttr[enums.SkipReason]("run.skip_reason"),
 	SkipExistingRunID:                  StringAttr("run.skip_existing_run_id"),
 	StartedAt:                          TimeAttr("started_at"),
+	ScheduledAt:                        TimeAttr("scheduled_at"),
 	StepAttempt:                        IntAttr("step.attempt"),
 	StepCodeLocation:                   StringAttr("step.code_location"),
 	StepGatewayResponseOutputSizeBytes: IntAttr("step.gateway.response.output_size_bytes"),

--- a/pkg/tracing/meta/extracted_values_gen.go
+++ b/pkg/tracing/meta/extracted_values_gen.go
@@ -16,8 +16,9 @@ import (
 // ExtractedValues mirrors the Attrs struct but with actual pointer types
 // instead of attr wrappers. This allows for type-safe access to deserialized values.
 type ExtractedValues struct {
-	StartedAt *time.Time
 	QueuedAt *time.Time
+	ScheduledAt *time.Time
+	StartedAt *time.Time
 	EndedAt *time.Time
 	AccountID *uuid.UUID
 	AppID *uuid.UUID

--- a/pkg/tracing/meta/serializers.go
+++ b/pkg/tracing/meta/serializers.go
@@ -80,8 +80,8 @@ func GetAttr[T any](r *SerializableAttrs, attr attr[*T]) (*T, bool) {
 	// iterate in reverse order.
 	for i := len(r.Attrs) - 1; i >= 0; i-- {
 		if r.Attrs[i].key == attr.Key() {
-			if val, ok := r.Attrs[i].value.(T); ok {
-				return &val, true
+			if val, ok := r.Attrs[i].value.(*T); ok {
+				return val, true
 			}
 
 			return nil, false


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This uses the timestamps on queue items to populate span attributes. This reduces the amount of rollup we need for discovery spans for instance. Also adds a scheduledAt attribute because that is also present on the queue item.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
