### PR TITLE
feat: Add support for parsing span attribute data from Langfuse (EXE-1914)

### DIFF
--- a/pkg/tracing/metadata/extractors/aimetadata_test.go
+++ b/pkg/tracing/metadata/extractors/aimetadata_test.go
@@ -361,6 +361,70 @@ func TestAIMetadataExtractor_CapturedFixtures(t *testing.T) {
 				TotalTokens:   util.ToPtr[int64](57),
 			},
 		},
+
+		// Langfuse (@langfuse/openai + LangfuseSpanProcessor)
+		//
+		// Langfuse spans carry NO gen_ai.*/llm.* — extraction relies entirely on
+		// the langfuse.* mappings. Model is the dated response model (from
+		// langfuse.observation.model.name); tokens come from the usage_details
+		// JSON blob (input/output/total), exploded into scalar fields.
+		//
+		// Documented gaps (no Langfuse key emits them): System, OperationName,
+		// ResponseModel, ResponseID, FinishReasons are all empty.
+		{
+			fixture: "openai_langfuse_observe/basic_responses.otlp.json",
+			expected: extractors.AIMetadata{
+				Model:        "gpt-5.4-nano-2026-03-17",
+				InputTokens:  17,
+				OutputTokens: 36,
+				TotalTokens:  util.ToPtr[int64](53),
+			},
+		},
+		{
+			fixture: "openai_langfuse_observe/params_chat.otlp.json",
+			expected: extractors.AIMetadata{
+				Model:        "gpt-4.1-nano-2025-04-14",
+				InputTokens:  22,
+				OutputTokens: 6,
+				TotalTokens:  util.ToPtr[int64](28),
+			},
+		},
+		{
+			fixture: "openai_langfuse_observe/tools_chat.otlp.json",
+			expected: extractors.AIMetadata{
+				Model:        "gpt-4.1-nano-2025-04-14",
+				InputTokens:  56,
+				OutputTokens: 30,
+				TotalTokens:  util.ToPtr[int64](86),
+			},
+		},
+		{
+			fixture: "openai_langfuse_observe/stream_chat.otlp.json",
+			expected: extractors.AIMetadata{
+				Model:        "gpt-4.1-nano",
+				InputTokens:  11,
+				OutputTokens: 10,
+				TotalTokens:  util.ToPtr[int64](21),
+			},
+		},
+		{
+			fixture: "openai_langfuse_observe/reasoning_responses.otlp.json",
+			expected: extractors.AIMetadata{
+				Model:        "gpt-5.4-nano-2026-03-17",
+				InputTokens:  17,
+				OutputTokens: 13,
+				TotalTokens:  util.ToPtr[int64](30),
+			},
+		},
+		{
+			// Embeddings emit no usage_details, so token counts stay zero and
+			// TotalTokens is not derived (nil) — a documented gap, like the OI
+			// embeddings case.
+			fixture: "openai_langfuse_observe/embeddings.otlp.json",
+			expected: extractors.AIMetadata{
+				Model: "text-embedding-3-small",
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/tracing/metadata/extractors/attributes.go
+++ b/pkg/tracing/metadata/extractors/attributes.go
@@ -2,6 +2,7 @@ package extractors
 
 import (
 	"cmp"
+	"encoding/json"
 	"slices"
 
 	"github.com/inngest/inngest/pkg/util"
@@ -14,18 +15,32 @@ import (
 type convention int
 
 const (
-	semconv       convention = 1
-	openinference convention = 2
-	vercel        convention = 3
+	// langfuse ranks first: Langfuse states its langfuse.* keys always
+	// take precedence over the generic conventions on spans it instrumented.
+	langfuse      convention = 1
+	semconv       convention = 2
+	openinference convention = 3
+	vercel        convention = 4
 )
+
+// langfuseUsagePrefix namespaces the synthetic scalar keys that
+// expandLangfuseUsageDetails emits from the langfuse.observation.usage_details
+// JSON blob. The double underscore marks them as derived, not wire attributes.
+const langfuseUsagePrefix = "__langfuse.usage_details."
 
 // attrMapping records the canonical field a source attribute key maps to, the
 // convention it belongs to, and a keyRank tiebreak used to order keys within
 // the same convention (lower wins; 0 = default).
+//
+// A mapping is either scalar (field set, expand nil) or composite (expand set,
+// field empty): a composite mapping carries no value of its own — its expand
+// func explodes the attribute into synthetic child KeyValues that are matched
+// back through keyFieldMap like any other attribute.
 type attrMapping struct {
 	field      string
 	convention convention
 	keyRank    int
+	expand     func(v *v1.AnyValue) []*v1.KeyValue
 }
 
 var keyFieldMap = map[string]attrMapping{
@@ -160,6 +175,63 @@ var keyFieldMap = map[string]attrMapping{
 		field:      "finishReasons",
 		convention: vercel,
 	},
+
+	// ---------------------------------------------------------------------------
+	// Langfuse (`langfuse.*`, via @langfuse/openai + LangfuseSpanProcessor)
+	// ---------------------------------------------------------------------------
+	"langfuse.observation.model.name": {
+		field:      "model",
+		convention: langfuse,
+	},
+	// usage_details is a single JSON blob ({"input":N,"output":N,"total":N,...}).
+	// It carries no value of its own: expand explodes it into synthetic scalar
+	// children, which are matched back through keyFieldMap below.
+	"langfuse.observation.usage_details": {
+		convention: langfuse,
+		expand:     expandLangfuseUsageDetails,
+	},
+	langfuseUsagePrefix + "input": {
+		field:      "inputTokens",
+		convention: langfuse,
+	},
+	langfuseUsagePrefix + "output": {
+		field:      "outputTokens",
+		convention: langfuse,
+	},
+	langfuseUsagePrefix + "total": {
+		field:      "totalTokens",
+		convention: langfuse,
+	},
+}
+
+// expandLangfuseUsageDetails parses the langfuse.observation.usage_details JSON
+// blob and emits one synthetic scalar KeyValue per integer entry, keyed under
+// langfuseUsagePrefix. keyFieldMap does further processing on the keys emitted.
+// matching does.
+func expandLangfuseUsageDetails(v *v1.AnyValue) []*v1.KeyValue {
+	raw := v.GetStringValue()
+	if raw == "" {
+		return nil
+	}
+
+	var counts map[string]json.Number
+	if err := json.Unmarshal([]byte(raw), &counts); err != nil {
+		return nil
+	}
+
+	out := make([]*v1.KeyValue, 0, len(counts))
+	for k, num := range counts {
+		n, err := num.Int64()
+		if err != nil {
+			// non-integer entry (shouldn't happen for token counts); skip.
+			continue
+		}
+		out = append(out, &v1.KeyValue{
+			Key:   langfuseUsagePrefix + k,
+			Value: &v1.AnyValue{Value: &v1.AnyValue_IntValue{IntValue: n}},
+		})
+	}
+	return out
 }
 
 var metadataFieldSetters = map[string]func(v *v1.AnyValue, md *AIMetadata){
@@ -223,17 +295,38 @@ func compareByRank(a, b parsedAttr) int {
 func extractAIMetadataFromAttributes(attributes []*v1.KeyValue, md *AIMetadata) (foundAny bool) {
 	potentialAttrs := map[string][]parsedAttr{}
 
+	// addAttr records a matched attribute as a candidate for its canonical field.
+	addAttr := func(m attrMapping, value *v1.AnyValue) {
+		potentialAttrs[m.field] = append(
+			potentialAttrs[m.field],
+			parsedAttr{
+				value:      value,
+				convention: m.convention,
+				keyRank:    m.keyRank,
+			},
+		)
+	}
+
 	for _, attr := range attributes {
-		if mapping, ok := keyFieldMap[attr.Key]; ok {
-			potentialAttrs[mapping.field] = append(
-				potentialAttrs[mapping.field],
-				parsedAttr{
-					value:      attr.Value,
-					convention: mapping.convention,
-					keyRank:    mapping.keyRank,
-				},
-			)
+		mapping, ok := keyFieldMap[attr.Key]
+		if !ok {
+			continue
 		}
+
+		// Composite mapping: explode the attribute into synthetic children and
+		// match each back through keyFieldMap, so they flow through the same
+		// per-field precedence as everything else. Children carry their own
+		// mapping's convention/keyRank, and unmapped children are ignored.
+		if mapping.expand != nil {
+			for _, child := range mapping.expand(attr.Value) {
+				if childMapping, ok := keyFieldMap[child.Key]; ok {
+					addAttr(childMapping, child.Value)
+				}
+			}
+			continue
+		}
+
+		addAttr(mapping, attr.Value)
 	}
 
 	if len(potentialAttrs) == 0 {

--- a/pkg/tracing/metadata/extractors/attributes_test.go
+++ b/pkg/tracing/metadata/extractors/attributes_test.go
@@ -23,11 +23,20 @@ func intAttr(key string, value int64) *v1.KeyValue {
 
 // TestCanonicalKeysHaveFieldSetters guards against drift between
 // canonicalKeyMapping and metadataFieldSetters: every canonical key referenced
-// by a mapping must have a setter, otherwise the attribute is silently dropped.
+// by a scalar mapping must have a setter, otherwise the attribute is silently
+// dropped. Composite mappings (expand != nil) carry no field of their own — they
+// explode into synthetic children that are matched back through keyFieldMap, so
+// those children are covered by their own scalar entries in this same loop.
 func TestCanonicalKeysHaveFieldSetters(t *testing.T) {
 	t.Parallel()
 
 	for sourceKey, mapping := range keyFieldMap {
+		if mapping.expand != nil {
+			assert.Emptyf(t, mapping.field,
+				"composite mapping %q must not also set a scalar field", sourceKey)
+			continue
+		}
+
 		_, ok := metadataFieldSetters[mapping.field]
 		assert.Truef(t, ok,
 			"field %q (mapped from %q) has no entry in metadataFieldSetters",
@@ -53,5 +62,46 @@ func TestRankingPrefersProviderNameOverDeprecatedSystem(t *testing.T) {
 		assert.True(t, foundAny)
 		assert.Equal(t, "anthropic", md.System,
 			"gen_ai.provider.name should win over deprecated gen_ai.system")
+	}
+}
+
+// TestLangfusePrecedenceAndUsageExpansion verifies two things no captured
+// fixture exercises (real Langfuse spans carry no gen_ai.*): on a span carrying
+// both namespaces, langfuse.* wins (it ranks first), and the usage_details JSON
+// blob expands into input/output/total while unmapped sub-keys are ignored.
+func TestLangfusePrecedenceAndUsageExpansion(t *testing.T) {
+	t.Parallel()
+
+	orders := [][]*v1.KeyValue{
+		{
+			strAttr("gen_ai.request.model", "gpt-4.1-nano"),
+			intAttr("gen_ai.usage.input_tokens", 100),
+			strAttr("langfuse.observation.model.name", "gpt-4.1-nano-2025-04-14"),
+			strAttr("langfuse.observation.usage_details",
+				`{"input":22,"output":6,"total":28,"input_cached_tokens":5}`),
+		},
+		// reversed, to prove order-independence
+		{
+			strAttr("langfuse.observation.usage_details",
+				`{"input":22,"output":6,"total":28,"input_cached_tokens":5}`),
+			strAttr("langfuse.observation.model.name", "gpt-4.1-nano-2025-04-14"),
+			intAttr("gen_ai.usage.input_tokens", 100),
+			strAttr("gen_ai.request.model", "gpt-4.1-nano"),
+		},
+	}
+
+	for _, attrs := range orders {
+		var md AIMetadata
+		foundAny := extractAIMetadataFromAttributes(attrs, &md)
+		assert.True(t, foundAny)
+		// langfuse ranks first, so its values win over the co-present gen_ai.*.
+		assert.Equal(t, "gpt-4.1-nano-2025-04-14", md.Model)
+		assert.Equal(t, int64(22), md.InputTokens)
+		assert.Equal(t, int64(6), md.OutputTokens)
+		// usage_details supplies the total; input_cached_tokens is unmapped and
+		// dropped, not summed.
+		if assert.NotNil(t, md.TotalTokens) {
+			assert.Equal(t, int64(28), *md.TotalTokens)
+		}
 	}
 }

--- a/pkg/tracing/metadata/extractors/attributes_test.go
+++ b/pkg/tracing/metadata/extractors/attributes_test.go
@@ -44,6 +44,17 @@ func TestCanonicalKeysHaveFieldSetters(t *testing.T) {
 	}
 }
 
+func TestAttrMappings_FieldAndExpandAreExclusive(t *testing.T) {
+	t.Parallel()
+	for key, mapping := range keyFieldMap {
+		assert.Truef(
+			t,
+			(mapping.field != "") != (mapping.expand != nil),
+			"key %s cannot have both field and expand set", key,
+		)
+	}
+}
+
 // TestRankingPrefersProviderNameOverDeprecatedSystem verifies that when both
 // the deprecated gen_ai.system and its replacement gen_ai.provider.name are
 // present, the deprecated key's keyRank demotes it so the replacement wins,

--- a/pkg/tracing/metadata/extractors/testdata/openai_langfuse_observe/basic_responses.otlp.json
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langfuse_observe/basic_responses.otlp.json
@@ -1,0 +1,234 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "Mac.localdomain"
+            }
+          },
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "host.id",
+            "value": {
+              "stringValue": "C5C64DB3-DCD6-588B-81A1-B56AA61D0585"
+            }
+          },
+          {
+            "key": "process.pid",
+            "value": {
+              "intValue": 90049
+            }
+          },
+          {
+            "key": "process.executable.name",
+            "value": {
+              "stringValue": "node"
+            }
+          },
+          {
+            "key": "process.executable.path",
+            "value": {
+              "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+            }
+          },
+          {
+            "key": "process.command_args",
+            "value": {
+              "arrayValue": {
+                "values": [
+                  {
+                    "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+                  },
+                  {
+                    "stringValue": "--require"
+                  },
+                  {
+                    "stringValue": "./capture-instrumentation-otlp.cjs"
+                  },
+                  {
+                    "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "key": "process.runtime.version",
+            "value": {
+              "stringValue": "24.13.1"
+            }
+          },
+          {
+            "key": "process.runtime.name",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "process.runtime.description",
+            "value": {
+              "stringValue": "Node.js"
+            }
+          },
+          {
+            "key": "process.command",
+            "value": {
+              "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+            }
+          },
+          {
+            "key": "process.owner",
+            "value": {
+              "stringValue": "scott"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.1.0"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langfuse-sdk",
+            "version": "5.4.1"
+          },
+          "spans": [
+            {
+              "traceId": "112f0ac11a707ae86e5beeca4e69c274",
+              "spanId": "0eff81027f19c6cc",
+              "name": "OpenAI.responses",
+              "kind": 1,
+              "startTimeUnixNano": "1780441264063000000",
+              "endTimeUnixNano": "1780441264969987000",
+              "attributes": [
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "capture-user"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "capture-session-basic_responses"
+                  }
+                },
+                {
+                  "key": "langfuse.trace.name",
+                  "value": {
+                    "stringValue": "capture-basic_responses"
+                  }
+                },
+                {
+                  "key": "langfuse.internal.is_app_root",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "langfuse.observation.type",
+                  "value": {
+                    "stringValue": "generation"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.input",
+                  "value": {
+                    "stringValue": "Write a one-sentence bedtime story about a unicorn."
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.name",
+                  "value": {
+                    "stringValue": "gpt-5.4-nano-2026-03-17"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.parameters",
+                  "value": {
+                    "stringValue": "{\"parallel_tool_calls\":true,\"store\":true,\"temperature\":1,\"tool_choice\":\"auto\",\"top_p\":0.98,\"truncation\":\"disabled\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.output",
+                  "value": {
+                    "stringValue": "Once upon a moonlit night, a gentle unicorn tucked in the stars with its shimmering horn, humming lullabies until the whole sky drifted off to sleep."
+                  }
+                },
+                {
+                  "key": "langfuse.observation.usage_details",
+                  "value": {
+                    "stringValue": "{\"input\":17,\"output\":36,\"total\":53,\"input_cached_tokens\":0,\"output_reasoning_tokens\":0}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.reasoning",
+                  "value": {
+                    "stringValue": "{\"context\":\"current_turn\",\"effort\":\"none\",\"summary\":null}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.tools",
+                  "value": {
+                    "stringValue": "[]"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.metadata",
+                  "value": {
+                    "stringValue": "{}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.status",
+                  "value": {
+                    "stringValue": "completed"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tracing/metadata/extractors/testdata/openai_langfuse_observe/embeddings.otlp.json
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langfuse_observe/embeddings.otlp.json
@@ -1,0 +1,204 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "Mac.localdomain"
+            }
+          },
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "host.id",
+            "value": {
+              "stringValue": "C5C64DB3-DCD6-588B-81A1-B56AA61D0585"
+            }
+          },
+          {
+            "key": "process.pid",
+            "value": {
+              "intValue": 90049
+            }
+          },
+          {
+            "key": "process.executable.name",
+            "value": {
+              "stringValue": "node"
+            }
+          },
+          {
+            "key": "process.executable.path",
+            "value": {
+              "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+            }
+          },
+          {
+            "key": "process.command_args",
+            "value": {
+              "arrayValue": {
+                "values": [
+                  {
+                    "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+                  },
+                  {
+                    "stringValue": "--require"
+                  },
+                  {
+                    "stringValue": "./capture-instrumentation-otlp.cjs"
+                  },
+                  {
+                    "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "key": "process.runtime.version",
+            "value": {
+              "stringValue": "24.13.1"
+            }
+          },
+          {
+            "key": "process.runtime.name",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "process.runtime.description",
+            "value": {
+              "stringValue": "Node.js"
+            }
+          },
+          {
+            "key": "process.command",
+            "value": {
+              "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+            }
+          },
+          {
+            "key": "process.owner",
+            "value": {
+              "stringValue": "scott"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.1.0"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langfuse-sdk",
+            "version": "5.4.1"
+          },
+          "spans": [
+            {
+              "traceId": "f4d5f632e8f3495b35a51c53d4f43013",
+              "spanId": "5c584938b1fcf355",
+              "name": "OpenAI.embeddings",
+              "kind": 1,
+              "startTimeUnixNano": "1780441267558000000",
+              "endTimeUnixNano": "1780441267694131209",
+              "attributes": [
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "capture-user"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "capture-session-embeddings"
+                  }
+                },
+                {
+                  "key": "langfuse.trace.name",
+                  "value": {
+                    "stringValue": "capture-embeddings"
+                  }
+                },
+                {
+                  "key": "langfuse.internal.is_app_root",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "langfuse.observation.type",
+                  "value": {
+                    "stringValue": "generation"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.input",
+                  "value": {
+                    "stringValue": "The quick brown fox jumps over the lazy dog."
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.name",
+                  "value": {
+                    "stringValue": "text-embedding-3-small"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.parameters",
+                  "value": {
+                    "stringValue": "{\"response_format\":\"\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.output",
+                  "value": {
+                    "stringValue": ""
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tracing/metadata/extractors/testdata/openai_langfuse_observe/params_chat.otlp.json
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langfuse_observe/params_chat.otlp.json
@@ -1,0 +1,210 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "Mac.localdomain"
+            }
+          },
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "host.id",
+            "value": {
+              "stringValue": "C5C64DB3-DCD6-588B-81A1-B56AA61D0585"
+            }
+          },
+          {
+            "key": "process.pid",
+            "value": {
+              "intValue": 90049
+            }
+          },
+          {
+            "key": "process.executable.name",
+            "value": {
+              "stringValue": "node"
+            }
+          },
+          {
+            "key": "process.executable.path",
+            "value": {
+              "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+            }
+          },
+          {
+            "key": "process.command_args",
+            "value": {
+              "arrayValue": {
+                "values": [
+                  {
+                    "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+                  },
+                  {
+                    "stringValue": "--require"
+                  },
+                  {
+                    "stringValue": "./capture-instrumentation-otlp.cjs"
+                  },
+                  {
+                    "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "key": "process.runtime.version",
+            "value": {
+              "stringValue": "24.13.1"
+            }
+          },
+          {
+            "key": "process.runtime.name",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "process.runtime.description",
+            "value": {
+              "stringValue": "Node.js"
+            }
+          },
+          {
+            "key": "process.command",
+            "value": {
+              "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+            }
+          },
+          {
+            "key": "process.owner",
+            "value": {
+              "stringValue": "scott"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.1.0"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langfuse-sdk",
+            "version": "5.4.1"
+          },
+          "spans": [
+            {
+              "traceId": "d0508b44b19758f0c1b11f40a51495aa",
+              "spanId": "6bf40ce119b0664e",
+              "name": "OpenAI.chat",
+              "kind": 1,
+              "startTimeUnixNano": "1780441264971000000",
+              "endTimeUnixNano": "1780441265261486167",
+              "attributes": [
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "capture-user"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "capture-session-params_chat"
+                  }
+                },
+                {
+                  "key": "langfuse.trace.name",
+                  "value": {
+                    "stringValue": "capture-params_chat"
+                  }
+                },
+                {
+                  "key": "langfuse.internal.is_app_root",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "langfuse.observation.type",
+                  "value": {
+                    "stringValue": "generation"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.input",
+                  "value": {
+                    "stringValue": "{\"messages\":[{\"role\":\"system\",\"content\":\"You are a terse assistant.\"},{\"role\":\"user\",\"content\":\"Name three primary colors.\"}]}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.name",
+                  "value": {
+                    "stringValue": "gpt-4.1-nano-2025-04-14"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.parameters",
+                  "value": {
+                    "stringValue": "{\"frequency_penalty\":0.2,\"max_tokens\":64,\"presence_penalty\":0.1,\"seed\":42,\"stop\":[\"\\n\\n\"],\"temperature\":0.7,\"top_p\":0.9,\"response_format\":\"\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.output",
+                  "value": {
+                    "stringValue": "{\"role\":\"assistant\",\"content\":\"Red, blue, yellow.\",\"refusal\":null,\"annotations\":[]}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.usage_details",
+                  "value": {
+                    "stringValue": "{\"input\":22,\"output\":6,\"total\":28,\"input_cached_tokens\":0,\"input_audio_tokens\":0,\"output_reasoning_tokens\":0,\"output_audio_tokens\":0,\"output_accepted_prediction_tokens\":0,\"output_rejected_prediction_tokens\":0}"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tracing/metadata/extractors/testdata/openai_langfuse_observe/reasoning_responses.otlp.json
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langfuse_observe/reasoning_responses.otlp.json
@@ -1,0 +1,234 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "Mac.localdomain"
+            }
+          },
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "host.id",
+            "value": {
+              "stringValue": "C5C64DB3-DCD6-588B-81A1-B56AA61D0585"
+            }
+          },
+          {
+            "key": "process.pid",
+            "value": {
+              "intValue": 90049
+            }
+          },
+          {
+            "key": "process.executable.name",
+            "value": {
+              "stringValue": "node"
+            }
+          },
+          {
+            "key": "process.executable.path",
+            "value": {
+              "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+            }
+          },
+          {
+            "key": "process.command_args",
+            "value": {
+              "arrayValue": {
+                "values": [
+                  {
+                    "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+                  },
+                  {
+                    "stringValue": "--require"
+                  },
+                  {
+                    "stringValue": "./capture-instrumentation-otlp.cjs"
+                  },
+                  {
+                    "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "key": "process.runtime.version",
+            "value": {
+              "stringValue": "24.13.1"
+            }
+          },
+          {
+            "key": "process.runtime.name",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "process.runtime.description",
+            "value": {
+              "stringValue": "Node.js"
+            }
+          },
+          {
+            "key": "process.command",
+            "value": {
+              "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+            }
+          },
+          {
+            "key": "process.owner",
+            "value": {
+              "stringValue": "scott"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.1.0"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langfuse-sdk",
+            "version": "5.4.1"
+          },
+          "spans": [
+            {
+              "traceId": "a82f012672983aa393d7309287721ecc",
+              "spanId": "b02f67378b40e2bd",
+              "name": "OpenAI.responses",
+              "kind": 1,
+              "startTimeUnixNano": "1780441266710000000",
+              "endTimeUnixNano": "1780441267555921458",
+              "attributes": [
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "capture-user"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "capture-session-reasoning_responses"
+                  }
+                },
+                {
+                  "key": "langfuse.trace.name",
+                  "value": {
+                    "stringValue": "capture-reasoning_responses"
+                  }
+                },
+                {
+                  "key": "langfuse.internal.is_app_root",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "langfuse.observation.type",
+                  "value": {
+                    "stringValue": "generation"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.input",
+                  "value": {
+                    "stringValue": "What is 17 * 24? Think briefly."
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.name",
+                  "value": {
+                    "stringValue": "gpt-5.4-nano-2026-03-17"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.parameters",
+                  "value": {
+                    "stringValue": "{\"parallel_tool_calls\":true,\"store\":true,\"temperature\":1,\"tool_choice\":\"auto\",\"top_p\":0.98,\"truncation\":\"disabled\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.output",
+                  "value": {
+                    "stringValue": "17 × 24 = **408**."
+                  }
+                },
+                {
+                  "key": "langfuse.observation.usage_details",
+                  "value": {
+                    "stringValue": "{\"input\":17,\"output\":13,\"total\":30,\"input_cached_tokens\":0,\"output_reasoning_tokens\":0}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.reasoning",
+                  "value": {
+                    "stringValue": "{\"context\":\"current_turn\",\"effort\":\"low\",\"summary\":null}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.tools",
+                  "value": {
+                    "stringValue": "[]"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.metadata",
+                  "value": {
+                    "stringValue": "{}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.metadata.status",
+                  "value": {
+                    "stringValue": "completed"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tracing/metadata/extractors/testdata/openai_langfuse_observe/stream_chat.otlp.json
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langfuse_observe/stream_chat.otlp.json
@@ -1,0 +1,216 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "Mac.localdomain"
+            }
+          },
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "host.id",
+            "value": {
+              "stringValue": "C5C64DB3-DCD6-588B-81A1-B56AA61D0585"
+            }
+          },
+          {
+            "key": "process.pid",
+            "value": {
+              "intValue": 90049
+            }
+          },
+          {
+            "key": "process.executable.name",
+            "value": {
+              "stringValue": "node"
+            }
+          },
+          {
+            "key": "process.executable.path",
+            "value": {
+              "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+            }
+          },
+          {
+            "key": "process.command_args",
+            "value": {
+              "arrayValue": {
+                "values": [
+                  {
+                    "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+                  },
+                  {
+                    "stringValue": "--require"
+                  },
+                  {
+                    "stringValue": "./capture-instrumentation-otlp.cjs"
+                  },
+                  {
+                    "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "key": "process.runtime.version",
+            "value": {
+              "stringValue": "24.13.1"
+            }
+          },
+          {
+            "key": "process.runtime.name",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "process.runtime.description",
+            "value": {
+              "stringValue": "Node.js"
+            }
+          },
+          {
+            "key": "process.command",
+            "value": {
+              "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+            }
+          },
+          {
+            "key": "process.owner",
+            "value": {
+              "stringValue": "scott"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.1.0"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langfuse-sdk",
+            "version": "5.4.1"
+          },
+          "spans": [
+            {
+              "traceId": "86a472475f9372999ad6aa874e12df16",
+              "spanId": "30aed59495f699d5",
+              "name": "OpenAI.chat",
+              "kind": 1,
+              "startTimeUnixNano": "1780441266156000000",
+              "endTimeUnixNano": "1780441266709381625",
+              "attributes": [
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "capture-user"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "capture-session-stream_chat"
+                  }
+                },
+                {
+                  "key": "langfuse.trace.name",
+                  "value": {
+                    "stringValue": "capture-stream_chat"
+                  }
+                },
+                {
+                  "key": "langfuse.internal.is_app_root",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "langfuse.observation.type",
+                  "value": {
+                    "stringValue": "generation"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.input",
+                  "value": {
+                    "stringValue": "{\"messages\":[{\"role\":\"user\",\"content\":\"Count to five.\"}]}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.name",
+                  "value": {
+                    "stringValue": "gpt-4.1-nano"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.parameters",
+                  "value": {
+                    "stringValue": "{\"stream\":true,\"response_format\":\"\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.output",
+                  "value": {
+                    "stringValue": "One, two, three, four, five."
+                  }
+                },
+                {
+                  "key": "langfuse.observation.usage_details",
+                  "value": {
+                    "stringValue": "{\"input\":11,\"output\":10,\"total\":21,\"input_cached_tokens\":0,\"input_audio_tokens\":0,\"output_reasoning_tokens\":0,\"output_audio_tokens\":0,\"output_accepted_prediction_tokens\":0,\"output_rejected_prediction_tokens\":0}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.completion_start_time",
+                  "value": {
+                    "stringValue": "\"2026-06-02T23:01:06.474Z\""
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tracing/metadata/extractors/testdata/openai_langfuse_observe/tools_chat.otlp.json
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langfuse_observe/tools_chat.otlp.json
@@ -1,0 +1,210 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "Mac.localdomain"
+            }
+          },
+          {
+            "key": "host.arch",
+            "value": {
+              "stringValue": "arm64"
+            }
+          },
+          {
+            "key": "host.id",
+            "value": {
+              "stringValue": "C5C64DB3-DCD6-588B-81A1-B56AA61D0585"
+            }
+          },
+          {
+            "key": "process.pid",
+            "value": {
+              "intValue": 90049
+            }
+          },
+          {
+            "key": "process.executable.name",
+            "value": {
+              "stringValue": "node"
+            }
+          },
+          {
+            "key": "process.executable.path",
+            "value": {
+              "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+            }
+          },
+          {
+            "key": "process.command_args",
+            "value": {
+              "arrayValue": {
+                "values": [
+                  {
+                    "stringValue": "/nix/store/0rb3g0249h5y7bzzcavsjj7s6hhpabdy-nodejs-24.13.1/bin/node"
+                  },
+                  {
+                    "stringValue": "--require"
+                  },
+                  {
+                    "stringValue": "./capture-instrumentation-otlp.cjs"
+                  },
+                  {
+                    "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "key": "process.runtime.version",
+            "value": {
+              "stringValue": "24.13.1"
+            }
+          },
+          {
+            "key": "process.runtime.name",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "process.runtime.description",
+            "value": {
+              "stringValue": "Node.js"
+            }
+          },
+          {
+            "key": "process.command",
+            "value": {
+              "stringValue": "/Users/scott/src/ai-sdk-metadata/langfuse-openai/capture.cjs"
+            }
+          },
+          {
+            "key": "process.owner",
+            "value": {
+              "stringValue": "scott"
+            }
+          },
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.1.0"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langfuse-sdk",
+            "version": "5.4.1"
+          },
+          "spans": [
+            {
+              "traceId": "02bd7e7b957101fa67a5abe0b53c568f",
+              "spanId": "55c7c54a6af87ed5",
+              "name": "OpenAI.chat",
+              "kind": 1,
+              "startTimeUnixNano": "1780441265262000000",
+              "endTimeUnixNano": "1780441266153239417",
+              "attributes": [
+                {
+                  "key": "user.id",
+                  "value": {
+                    "stringValue": "capture-user"
+                  }
+                },
+                {
+                  "key": "session.id",
+                  "value": {
+                    "stringValue": "capture-session-tools_chat"
+                  }
+                },
+                {
+                  "key": "langfuse.trace.name",
+                  "value": {
+                    "stringValue": "capture-tools_chat"
+                  }
+                },
+                {
+                  "key": "langfuse.internal.is_app_root",
+                  "value": {
+                    "boolValue": true
+                  }
+                },
+                {
+                  "key": "langfuse.observation.type",
+                  "value": {
+                    "stringValue": "generation"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.input",
+                  "value": {
+                    "stringValue": "{\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris? Use the tool.\"}],\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get the current weather for a city\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}}],\"tool_choice\":\"auto\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.name",
+                  "value": {
+                    "stringValue": "gpt-4.1-nano-2025-04-14"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.model.parameters",
+                  "value": {
+                    "stringValue": "{\"response_format\":\"\"}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.output",
+                  "value": {
+                    "stringValue": "{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"id\":\"call_xHygFhB4GwfnVFJ0Xf2E9gxP\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\": \\\"Paris\\\"}\"}}],\"refusal\":null,\"annotations\":[]}"
+                  }
+                },
+                {
+                  "key": "langfuse.observation.usage_details",
+                  "value": {
+                    "stringValue": "{\"input\":56,\"output\":30,\"total\":86,\"input_cached_tokens\":0,\"input_audio_tokens\":0,\"output_reasoning_tokens\":0,\"output_audio_tokens\":0,\"output_accepted_prediction_tokens\":0,\"output_rejected_prediction_tokens\":0}"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

- Add support for parsing span attribute data from Langfuse

## Release note

Add support for parsing span attribute data from Langfuse

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
