### PR TITLE
internal: Verify span AI attribute parsing from LangSmith (EXE-1916)

### DIFF
--- a/pkg/tracing/metadata/extractors/aimetadata_test.go
+++ b/pkg/tracing/metadata/extractors/aimetadata_test.go
@@ -425,6 +425,77 @@ func TestAIMetadataExtractor_CapturedFixtures(t *testing.T) {
 				Model: "text-embedding-3-small",
 			},
 		},
+
+		// LangSmith (langsmith wrapOpenAI + OTel mode)
+		//
+		// Unlike Langfuse, LangSmith spans carry a standard gen_ai.* set alongside
+		// its langsmith.* keys, so extraction works through the semconv mappings
+		// with no LangSmith-specific convention. Model is the requested alias
+		// (gen_ai.request.model); the dated model lands in ResponseModel.
+		//
+		// gen_ai.response.finish_reasons arrives as a scalar string (not the
+		// semconv array); the setter's scalar fallback wraps it.
+		//
+		// Missing variants (documented gaps in the capture app): wrapOpenAI wraps
+		// neither embeddings.create nor streaming chat completions (langsmith
+		// 0.7.3), so there are no embeddings/stream_chat fixtures. The Responses
+		// API variants (basic/reasoning) omit finish_reasons entirely.
+		{
+			fixture: "openai_langsmith_otel/basic_responses.otlp.json",
+			expected: extractors.AIMetadata{
+				Model:         "gpt-5.4-nano",
+				System:        "openai",
+				OperationName: "chat",
+				ResponseModel: "gpt-5.4-nano-2026-03-17",
+				ResponseID:    "resp_076af25434275e80006a1f60fe34c081989e65e074eb0213b3",
+				FinishReasons: nil,
+				InputTokens:   17,
+				OutputTokens:  35,
+				TotalTokens:   util.ToPtr[int64](52),
+			},
+		},
+		{
+			fixture: "openai_langsmith_otel/params_chat.otlp.json",
+			expected: extractors.AIMetadata{
+				Model:         "gpt-4.1-nano",
+				System:        "openai",
+				OperationName: "chat",
+				ResponseModel: "gpt-4.1-nano-2025-04-14",
+				ResponseID:    "chatcmpl-DmSPnK1FqD0W1V6k55vnLKTyNV9cH",
+				FinishReasons: []string{"stop"},
+				InputTokens:   22,
+				OutputTokens:  6,
+				TotalTokens:   util.ToPtr[int64](28),
+			},
+		},
+		{
+			fixture: "openai_langsmith_otel/tools_chat.otlp.json",
+			expected: extractors.AIMetadata{
+				Model:         "gpt-4.1-nano",
+				System:        "openai",
+				OperationName: "chat",
+				ResponseModel: "gpt-4.1-nano-2025-04-14",
+				ResponseID:    "chatcmpl-DmSPog8FUcyXw3C6bUGF0WZZDZw1k",
+				FinishReasons: []string{"tool_calls"},
+				InputTokens:   56,
+				OutputTokens:  30,
+				TotalTokens:   util.ToPtr[int64](86),
+			},
+		},
+		{
+			fixture: "openai_langsmith_otel/reasoning_responses.otlp.json",
+			expected: extractors.AIMetadata{
+				Model:         "gpt-5.4-nano",
+				System:        "openai",
+				OperationName: "chat",
+				ResponseModel: "gpt-5.4-nano-2026-03-17",
+				ResponseID:    "resp_0c58250a28f29e7f006a1f61028f248199962f6ae9f6dcec2f",
+				FinishReasons: nil,
+				InputTokens:   17,
+				OutputTokens:  12,
+				TotalTokens:   util.ToPtr[int64](29),
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/basic_responses.otlp.json
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/basic_responses.otlp.json
@@ -1,0 +1,220 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.7.1"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langsmith",
+            "version": "0.7.3"
+          },
+          "spans": [
+            {
+              "traceId": "06a138a3871df73327665d4d136f6b66",
+              "spanId": "4f2424ce1858dadc",
+              "name": "ChatOpenAI",
+              "kind": 1,
+              "startTimeUnixNano": "1780441342111000000",
+              "endTimeUnixNano": "1780441343233000000",
+              "attributes": [
+                {
+                  "key": "langsmith.traceable",
+                  "value": {
+                    "stringValue": "true"
+                  }
+                },
+                {
+                  "key": "langsmith.span.kind",
+                  "value": {
+                    "stringValue": "llm"
+                  }
+                },
+                {
+                  "key": "gen_ai.operation.name",
+                  "value": {
+                    "stringValue": "chat"
+                  }
+                },
+                {
+                  "key": "langsmith.trace.name",
+                  "value": {
+                    "stringValue": "ChatOpenAI"
+                  }
+                },
+                {
+                  "key": "langsmith.trace.session_name",
+                  "value": {
+                    "stringValue": "langsmith-openai-fixtures"
+                  }
+                },
+                {
+                  "key": "gen_ai.system",
+                  "value": {
+                    "stringValue": "openai"
+                  }
+                },
+                {
+                  "key": "gen_ai.request.model",
+                  "value": {
+                    "stringValue": "gpt-5.4-nano"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.LANGSMITH_TRACING",
+                  "value": {
+                    "stringValue": "true"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.LANGSMITH_OTEL_ENABLED",
+                  "value": {
+                    "stringValue": "true"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_provider",
+                  "value": {
+                    "stringValue": "openai"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_model_type",
+                  "value": {
+                    "stringValue": "chat"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_model_name",
+                  "value": {
+                    "stringValue": "gpt-5.4-nano"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_invocation_params",
+                  "value": {
+                    "stringValue": "{\"use_responses_api\":true}"
+                  }
+                },
+                {
+                  "key": "langsmith.span.tags",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "gen_ai.prompt",
+                  "value": {
+                    "stringValue": "{\"model\":\"gpt-5.4-nano\",\"input\":\"Write a one-sentence bedtime story about a unicorn.\"}"
+                  }
+                },
+                {
+                  "key": "langsmith.usage_metadata",
+                  "value": {
+                    "stringValue": "{\"input_tokens\":17,\"output_tokens\":35,\"total_tokens\":52,\"input_token_details\":{\"cache_read\":0},\"output_token_details\":{\"reasoning\":0}}"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.usage_metadata",
+                  "value": {
+                    "stringValue": "{\"input_tokens\":17,\"output_tokens\":35,\"total_tokens\":52,\"input_token_details\":{\"cache_read\":0},\"output_token_details\":{\"reasoning\":0}}"
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.input_tokens",
+                  "value": {
+                    "intValue": 17
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.output_tokens",
+                  "value": {
+                    "intValue": 35
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.total_tokens",
+                  "value": {
+                    "intValue": 52
+                  }
+                },
+                {
+                  "key": "gen_ai.response.model",
+                  "value": {
+                    "stringValue": "gpt-5.4-nano-2026-03-17"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.id",
+                  "value": {
+                    "stringValue": "resp_076af25434275e80006a1f60fe34c081989e65e074eb0213b3"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.service_tier",
+                  "value": {
+                    "stringValue": "default"
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.input_token_details",
+                  "value": {
+                    "stringValue": "{\"cache_read\":0}"
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.output_token_details",
+                  "value": {
+                    "stringValue": "{\"reasoning\":0}"
+                  }
+                },
+                {
+                  "key": "gen_ai.completion",
+                  "value": {
+                    "stringValue": "{\"id\":\"resp_076af25434275e80006a1f60fe34c081989e65e074eb0213b3\",\"object\":\"response\",\"created_at\":1780441342,\"status\":\"completed\",\"background\":false,\"billing\":{\"payer\":\"developer\"},\"completed_at\":1780441343,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-nano-2026-03-17\",\"moderation\":null,\"output\":[{\"id\":\"msg_076af25434275e80006a1f60fea038819884f1d36b93ad64af\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"In a moonlit meadow, a gentle unicorn tucked in the stars one by one, humming a lullaby until the whole night felt safe enough to sleep.\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"none\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"user\":null,\"metadata\":{},\"output_text\":\"In a moonlit meadow, a gentle unicorn tucked in the stars one by one, humming a lullaby until the whole night felt safe enough to sleep.\",\"usage_metadata\":{\"input_tokens\":17,\"output_tokens\":35,\"total_tokens\":52,\"input_token_details\":{\"cache_read\":0},\"output_token_details\":{\"reasoning\":0}}}"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 1
+              },
+              "links": [],
+              "droppedLinksCount": 0,
+              "flags": 257
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/params_chat.otlp.json
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/params_chat.otlp.json
@@ -1,0 +1,250 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.7.1"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langsmith",
+            "version": "0.7.3"
+          },
+          "spans": [
+            {
+              "traceId": "71cf19bb84453e7d515b8f49aa00e6fe",
+              "spanId": "6759083dcb25cf8d",
+              "name": "ChatOpenAI",
+              "kind": 1,
+              "startTimeUnixNano": "1780441343487000000",
+              "endTimeUnixNano": "1780441344024000000",
+              "attributes": [
+                {
+                  "key": "langsmith.traceable",
+                  "value": {
+                    "stringValue": "true"
+                  }
+                },
+                {
+                  "key": "langsmith.span.kind",
+                  "value": {
+                    "stringValue": "llm"
+                  }
+                },
+                {
+                  "key": "gen_ai.operation.name",
+                  "value": {
+                    "stringValue": "chat"
+                  }
+                },
+                {
+                  "key": "langsmith.trace.name",
+                  "value": {
+                    "stringValue": "ChatOpenAI"
+                  }
+                },
+                {
+                  "key": "langsmith.trace.session_name",
+                  "value": {
+                    "stringValue": "langsmith-openai-fixtures"
+                  }
+                },
+                {
+                  "key": "gen_ai.system",
+                  "value": {
+                    "stringValue": "openai"
+                  }
+                },
+                {
+                  "key": "gen_ai.request.model",
+                  "value": {
+                    "stringValue": "gpt-4.1-nano"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.LANGSMITH_TRACING",
+                  "value": {
+                    "stringValue": "true"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.LANGSMITH_OTEL_ENABLED",
+                  "value": {
+                    "stringValue": "true"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_provider",
+                  "value": {
+                    "stringValue": "openai"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_model_type",
+                  "value": {
+                    "stringValue": "chat"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_model_name",
+                  "value": {
+                    "stringValue": "gpt-4.1-nano"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_max_tokens",
+                  "value": {
+                    "stringValue": "64"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_temperature",
+                  "value": {
+                    "stringValue": "0.7"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_stop",
+                  "value": {
+                    "stringValue": "[\"\\n\\n\"]"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_invocation_params",
+                  "value": {
+                    "stringValue": "{\"top_p\":0.9,\"frequency_penalty\":0.2,\"presence_penalty\":0.1,\"seed\":42}"
+                  }
+                },
+                {
+                  "key": "langsmith.span.tags",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "gen_ai.prompt",
+                  "value": {
+                    "stringValue": "{\"model\":\"gpt-4.1-nano\",\"messages\":[{\"role\":\"system\",\"content\":\"You are a terse assistant.\"},{\"role\":\"user\",\"content\":\"Name three primary colors.\"}],\"temperature\":0.7,\"top_p\":0.9,\"max_tokens\":64,\"frequency_penalty\":0.2,\"presence_penalty\":0.1,\"stop\":[\"\\n\\n\"],\"seed\":42}"
+                  }
+                },
+                {
+                  "key": "langsmith.usage_metadata",
+                  "value": {
+                    "stringValue": "{\"input_tokens\":22,\"output_tokens\":6,\"total_tokens\":28,\"input_token_details\":{\"audio\":0,\"cache_read\":0},\"output_token_details\":{\"audio\":0,\"reasoning\":0}}"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.usage_metadata",
+                  "value": {
+                    "stringValue": "{\"input_tokens\":22,\"output_tokens\":6,\"total_tokens\":28,\"input_token_details\":{\"audio\":0,\"cache_read\":0},\"output_token_details\":{\"audio\":0,\"reasoning\":0}}"
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.input_tokens",
+                  "value": {
+                    "intValue": 22
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.output_tokens",
+                  "value": {
+                    "intValue": 6
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.total_tokens",
+                  "value": {
+                    "intValue": 28
+                  }
+                },
+                {
+                  "key": "gen_ai.response.model",
+                  "value": {
+                    "stringValue": "gpt-4.1-nano-2025-04-14"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.id",
+                  "value": {
+                    "stringValue": "chatcmpl-DmSPnK1FqD0W1V6k55vnLKTyNV9cH"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.finish_reasons",
+                  "value": {
+                    "stringValue": "stop"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.service_tier",
+                  "value": {
+                    "stringValue": "default"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.system_fingerprint",
+                  "value": {
+                    "stringValue": "fp_97e92d7018"
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.input_token_details",
+                  "value": {
+                    "stringValue": "{\"audio\":0,\"cache_read\":0}"
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.output_token_details",
+                  "value": {
+                    "stringValue": "{\"audio\":0,\"reasoning\":0}"
+                  }
+                },
+                {
+                  "key": "gen_ai.completion",
+                  "value": {
+                    "stringValue": "{\"id\":\"chatcmpl-DmSPnK1FqD0W1V6k55vnLKTyNV9cH\",\"object\":\"chat.completion\",\"created\":1780441343,\"model\":\"gpt-4.1-nano-2025-04-14\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"Red, blue, yellow.\",\"refusal\":null,\"annotations\":[]},\"logprobs\":null,\"finish_reason\":\"stop\"}],\"service_tier\":\"default\",\"system_fingerprint\":\"fp_97e92d7018\",\"usage_metadata\":{\"input_tokens\":22,\"output_tokens\":6,\"total_tokens\":28,\"input_token_details\":{\"audio\":0,\"cache_read\":0},\"output_token_details\":{\"audio\":0,\"reasoning\":0}}}"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 1
+              },
+              "links": [],
+              "droppedLinksCount": 0,
+              "flags": 257
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/reasoning_responses.otlp.json
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/reasoning_responses.otlp.json
@@ -1,0 +1,220 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.7.1"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langsmith",
+            "version": "0.7.3"
+          },
+          "spans": [
+            {
+              "traceId": "abfdcffdc9d58d4907c632cb5ebde721",
+              "spanId": "93d60525c6f42e2f",
+              "name": "ChatOpenAI",
+              "kind": 1,
+              "startTimeUnixNano": "1780441346513000000",
+              "endTimeUnixNano": "1780441347995000000",
+              "attributes": [
+                {
+                  "key": "langsmith.traceable",
+                  "value": {
+                    "stringValue": "true"
+                  }
+                },
+                {
+                  "key": "langsmith.span.kind",
+                  "value": {
+                    "stringValue": "llm"
+                  }
+                },
+                {
+                  "key": "gen_ai.operation.name",
+                  "value": {
+                    "stringValue": "chat"
+                  }
+                },
+                {
+                  "key": "langsmith.trace.name",
+                  "value": {
+                    "stringValue": "ChatOpenAI"
+                  }
+                },
+                {
+                  "key": "langsmith.trace.session_name",
+                  "value": {
+                    "stringValue": "langsmith-openai-fixtures"
+                  }
+                },
+                {
+                  "key": "gen_ai.system",
+                  "value": {
+                    "stringValue": "openai"
+                  }
+                },
+                {
+                  "key": "gen_ai.request.model",
+                  "value": {
+                    "stringValue": "gpt-5.4-nano"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.LANGSMITH_TRACING",
+                  "value": {
+                    "stringValue": "true"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.LANGSMITH_OTEL_ENABLED",
+                  "value": {
+                    "stringValue": "true"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_provider",
+                  "value": {
+                    "stringValue": "openai"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_model_type",
+                  "value": {
+                    "stringValue": "chat"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_model_name",
+                  "value": {
+                    "stringValue": "gpt-5.4-nano"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_invocation_params",
+                  "value": {
+                    "stringValue": "{\"reasoning\":{\"effort\":\"low\"},\"use_responses_api\":true}"
+                  }
+                },
+                {
+                  "key": "langsmith.span.tags",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "gen_ai.prompt",
+                  "value": {
+                    "stringValue": "{\"model\":\"gpt-5.4-nano\",\"input\":\"What is 17 * 24? Think briefly.\",\"reasoning\":{\"effort\":\"low\"}}"
+                  }
+                },
+                {
+                  "key": "langsmith.usage_metadata",
+                  "value": {
+                    "stringValue": "{\"input_tokens\":17,\"output_tokens\":12,\"total_tokens\":29,\"input_token_details\":{\"cache_read\":0},\"output_token_details\":{\"reasoning\":0}}"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.usage_metadata",
+                  "value": {
+                    "stringValue": "{\"input_tokens\":17,\"output_tokens\":12,\"total_tokens\":29,\"input_token_details\":{\"cache_read\":0},\"output_token_details\":{\"reasoning\":0}}"
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.input_tokens",
+                  "value": {
+                    "intValue": 17
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.output_tokens",
+                  "value": {
+                    "intValue": 12
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.total_tokens",
+                  "value": {
+                    "intValue": 29
+                  }
+                },
+                {
+                  "key": "gen_ai.response.model",
+                  "value": {
+                    "stringValue": "gpt-5.4-nano-2026-03-17"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.id",
+                  "value": {
+                    "stringValue": "resp_0c58250a28f29e7f006a1f61028f248199962f6ae9f6dcec2f"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.service_tier",
+                  "value": {
+                    "stringValue": "default"
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.input_token_details",
+                  "value": {
+                    "stringValue": "{\"cache_read\":0}"
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.output_token_details",
+                  "value": {
+                    "stringValue": "{\"reasoning\":0}"
+                  }
+                },
+                {
+                  "key": "gen_ai.completion",
+                  "value": {
+                    "stringValue": "{\"id\":\"resp_0c58250a28f29e7f006a1f61028f248199962f6ae9f6dcec2f\",\"object\":\"response\",\"created_at\":1780441346,\"status\":\"completed\",\"background\":false,\"billing\":{\"payer\":\"developer\"},\"completed_at\":1780441347,\"error\":null,\"frequency_penalty\":0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-nano-2026-03-17\",\"moderation\":null,\"output\":[{\"id\":\"msg_0c58250a28f29e7f006a1f6102e5508199b723d69648100b8a\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"17 × 24 = 408.\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"low\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"user\":null,\"metadata\":{},\"output_text\":\"17 × 24 = 408.\",\"usage_metadata\":{\"input_tokens\":17,\"output_tokens\":12,\"total_tokens\":29,\"input_token_details\":{\"cache_read\":0},\"output_token_details\":{\"reasoning\":0}}}"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 1
+              },
+              "links": [],
+              "droppedLinksCount": 0,
+              "flags": 257
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/tools_chat.otlp.json
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/tools_chat.otlp.json
@@ -1,0 +1,232 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.7.1"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "langsmith",
+            "version": "0.7.3"
+          },
+          "spans": [
+            {
+              "traceId": "fc930536ff567e3c06eb0c0aa4ff78ba",
+              "spanId": "7a4cb1a61dc110c9",
+              "name": "ChatOpenAI",
+              "kind": 1,
+              "startTimeUnixNano": "1780441344277000000",
+              "endTimeUnixNano": "1780441345103000000",
+              "attributes": [
+                {
+                  "key": "langsmith.traceable",
+                  "value": {
+                    "stringValue": "true"
+                  }
+                },
+                {
+                  "key": "langsmith.span.kind",
+                  "value": {
+                    "stringValue": "llm"
+                  }
+                },
+                {
+                  "key": "gen_ai.operation.name",
+                  "value": {
+                    "stringValue": "chat"
+                  }
+                },
+                {
+                  "key": "langsmith.trace.name",
+                  "value": {
+                    "stringValue": "ChatOpenAI"
+                  }
+                },
+                {
+                  "key": "langsmith.trace.session_name",
+                  "value": {
+                    "stringValue": "langsmith-openai-fixtures"
+                  }
+                },
+                {
+                  "key": "gen_ai.system",
+                  "value": {
+                    "stringValue": "openai"
+                  }
+                },
+                {
+                  "key": "gen_ai.request.model",
+                  "value": {
+                    "stringValue": "gpt-4.1-nano"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.LANGSMITH_TRACING",
+                  "value": {
+                    "stringValue": "true"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.LANGSMITH_OTEL_ENABLED",
+                  "value": {
+                    "stringValue": "true"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_provider",
+                  "value": {
+                    "stringValue": "openai"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_model_type",
+                  "value": {
+                    "stringValue": "chat"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_model_name",
+                  "value": {
+                    "stringValue": "gpt-4.1-nano"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.ls_invocation_params",
+                  "value": {
+                    "stringValue": "{}"
+                  }
+                },
+                {
+                  "key": "langsmith.span.tags",
+                  "value": {
+                    "stringValue": ""
+                  }
+                },
+                {
+                  "key": "gen_ai.prompt",
+                  "value": {
+                    "stringValue": "{\"model\":\"gpt-4.1-nano\",\"messages\":[{\"role\":\"user\",\"content\":\"What is the weather in Paris? Use the tool.\"}],\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"description\":\"Get the current weather for a city\",\"parameters\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}}],\"tool_choice\":\"auto\"}"
+                  }
+                },
+                {
+                  "key": "langsmith.usage_metadata",
+                  "value": {
+                    "stringValue": "{\"input_tokens\":56,\"output_tokens\":30,\"total_tokens\":86,\"input_token_details\":{\"audio\":0,\"cache_read\":0},\"output_token_details\":{\"audio\":0,\"reasoning\":0}}"
+                  }
+                },
+                {
+                  "key": "langsmith.metadata.usage_metadata",
+                  "value": {
+                    "stringValue": "{\"input_tokens\":56,\"output_tokens\":30,\"total_tokens\":86,\"input_token_details\":{\"audio\":0,\"cache_read\":0},\"output_token_details\":{\"audio\":0,\"reasoning\":0}}"
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.input_tokens",
+                  "value": {
+                    "intValue": 56
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.output_tokens",
+                  "value": {
+                    "intValue": 30
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.total_tokens",
+                  "value": {
+                    "intValue": 86
+                  }
+                },
+                {
+                  "key": "gen_ai.response.model",
+                  "value": {
+                    "stringValue": "gpt-4.1-nano-2025-04-14"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.id",
+                  "value": {
+                    "stringValue": "chatcmpl-DmSPog8FUcyXw3C6bUGF0WZZDZw1k"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.finish_reasons",
+                  "value": {
+                    "stringValue": "tool_calls"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.service_tier",
+                  "value": {
+                    "stringValue": "default"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.system_fingerprint",
+                  "value": {
+                    "stringValue": "fp_327b48687d"
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.input_token_details",
+                  "value": {
+                    "stringValue": "{\"audio\":0,\"cache_read\":0}"
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.output_token_details",
+                  "value": {
+                    "stringValue": "{\"audio\":0,\"reasoning\":0}"
+                  }
+                },
+                {
+                  "key": "gen_ai.completion",
+                  "value": {
+                    "stringValue": "{\"id\":\"chatcmpl-DmSPog8FUcyXw3C6bUGF0WZZDZw1k\",\"object\":\"chat.completion\",\"created\":1780441344,\"model\":\"gpt-4.1-nano-2025-04-14\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":null,\"tool_calls\":[{\"id\":\"call_ykiS5AwsG1Y6jUpN1fytEmux\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\": \\\"Paris\\\"}\"}}],\"refusal\":null,\"annotations\":[]},\"logprobs\":null,\"finish_reason\":\"tool_calls\"}],\"service_tier\":\"default\",\"system_fingerprint\":\"fp_327b48687d\",\"usage_metadata\":{\"input_tokens\":56,\"output_tokens\":30,\"total_tokens\":86,\"input_token_details\":{\"audio\":0,\"cache_read\":0},\"output_token_details\":{\"audio\":0,\"reasoning\":0}}}"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 1
+              },
+              "links": [],
+              "droppedLinksCount": 0,
+              "flags": 257
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

- Add test data for a LangSmith app that calls OpenAI 
- Verifies that we are correctly parsing LangSmith attributes, which follow otel sem conventions

## Release note

None.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*