### PR TITLE
fix(queue): retry pre-lease constraint failures

### DIFF
--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -214,6 +214,9 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 	if err != nil {
 		span.RecordError(err)
 		l.ReportError(err, "could not check constraints to lease item")
+		if err := p.handlePreLeaseConstraintCheckError(ctx, item, err); err != nil {
+			return err
+		}
 		// Stop iterator but don't quit the queue
 		return ErrProcessStopIterator
 	}
@@ -514,6 +517,42 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 		ConditionalTraceCtx: context.WithoutCancel(ctx),
 	}
 	commitSemaphoreAcquire = true
+
+	return nil
+}
+
+func (p *ProcessorIterator) handlePreLeaseConstraintCheckError(ctx context.Context, item *QueueItem, err error) error {
+	shard := p.Queue.Shard()
+	l := logger.StdlibLogger(ctx).With("item", item, "cause", err)
+
+	if ShouldRetry(err, item.Data.Attempt, item.Data.GetMaxAttempts()) {
+		at := p.Queue.Options().backoffFunc(item.Data.Attempt)
+		// Match Process error handling: calculate backoff from the current attempt,
+		// then advance the stored attempt for the next dispatch.
+		if !IsAlwaysRetryable(err) {
+			item.Data.Attempt += 1
+		}
+
+		if err := shard.Requeue(context.WithoutCancel(ctx), *item, at); err != nil {
+			if errors.Is(err, ErrQueueItemNotFound) {
+				return nil
+			}
+
+			l.ReportError(err, "could not requeue item after pre-lease constraint check failure")
+			return fmt.Errorf("could not requeue item after pre-lease constraint check failure: %w", err)
+		}
+
+		return nil
+	}
+
+	if err := shard.Dequeue(context.WithoutCancel(ctx), *item); err != nil {
+		if errors.Is(err, ErrQueueItemNotFound) {
+			return nil
+		}
+
+		l.ReportError(err, "could not dequeue item after pre-lease constraint check failure")
+		return fmt.Errorf("could not dequeue item after pre-lease constraint check failure: %w", err)
+	}
 
 	return nil
 }

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"iter"
 	"sync"
 	"sync/atomic"
@@ -11,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/jonboulle/clockwork"
 	"github.com/oklog/ulid/v2"
@@ -28,6 +30,7 @@ type mockQueueProcessor struct {
 	shadowMu             sync.Mutex
 	shadowMap            map[string]ShadowContinuation
 	constraintResultFunc func() enums.QueueConstraint
+	constraintErr        error
 	leaseCount           int32
 }
 
@@ -59,6 +62,12 @@ type mockShardForIterator struct {
 	partitionRequeueCount   int32
 	partitionRequeueAt      time.Time
 	partitionRequeueForceAt bool
+	itemOpMu                sync.Mutex
+	requeueCount            int
+	requeuedItem            *QueueItem
+	requeueAt               time.Time
+	dequeueCount            int
+	dequeuedItem            *QueueItem
 }
 
 func (m *mockShardForIterator) Name() string {
@@ -94,6 +103,12 @@ func (m *mockShardForIterator) Lease(ctx context.Context, item QueueItem, durati
 }
 
 func (m *mockShardForIterator) Requeue(ctx context.Context, i QueueItem, at time.Time, opts ...RequeueOptionFn) error {
+	m.itemOpMu.Lock()
+	defer m.itemOpMu.Unlock()
+
+	m.requeueCount++
+	m.requeuedItem = &i
+	m.requeueAt = at
 	return nil
 }
 
@@ -119,6 +134,11 @@ func (m *mockShardForIterator) RequeueByJobID(ctx context.Context, jobID string,
 }
 
 func (m *mockShardForIterator) Dequeue(ctx context.Context, i QueueItem, opts ...DequeueOptionFn) error {
+	m.itemOpMu.Lock()
+	defer m.itemOpMu.Unlock()
+
+	m.dequeueCount++
+	m.dequeuedItem = &i
 	return nil
 }
 
@@ -385,6 +405,10 @@ func (m *mockQueueProcessor) ItemLeaseConstraintCheck(ctx context.Context, shado
 	// Add some delay to increase chance of race
 	time.Sleep(time.Microsecond * 50)
 
+	if m.constraintErr != nil {
+		return ItemLeaseConstraintCheckResult{}, m.constraintErr
+	}
+
 	var constraint enums.QueueConstraint
 	if m.constraintResultFunc != nil {
 		constraint = m.constraintResultFunc()
@@ -395,6 +419,140 @@ func (m *mockQueueProcessor) ItemLeaseConstraintCheck(ctx context.Context, shado
 	return ItemLeaseConstraintCheckResult{
 		LimitingConstraint: constraint,
 	}, nil
+}
+
+func TestProcessorIteratorConstraintCheckErrorRequeuesWithAttempt(t *testing.T) {
+	ctx := logger.WithStdlib(context.Background(), logger.VoidLogger())
+
+	accountID := uuid.New()
+	fnID := uuid.New()
+	envID := uuid.New()
+	runID := ulid.Make()
+	maxAttempts := 3
+	nextAttemptAt := time.Now().Add(time.Minute)
+
+	shard := &mockShardForIterator{name: "test-shard"}
+	opts := NewQueueOptions()
+	opts.backoffFunc = func(attempt int) time.Time {
+		require.Equal(t, 1, attempt)
+		return nextAttemptAt
+	}
+
+	mockProc := &mockQueueProcessor{
+		shard:         shard,
+		clock:         clockwork.NewRealClock(),
+		sem:           util.NewTrackingSemaphore(1),
+		workers:       make(chan ProcessItem, 1),
+		shadowMap:     make(map[string]ShadowContinuation),
+		opts:          opts,
+		constraintErr: errors.New("missing constraint config workflow version"),
+	}
+
+	item := &QueueItem{
+		ID:          ulid.Make().String(),
+		FunctionID:  fnID,
+		WorkspaceID: envID,
+		AtMS:        time.Now().UnixMilli(),
+		Data: Item{
+			Kind:        KindEdge,
+			Attempt:     1,
+			MaxAttempts: &maxAttempts,
+			Identifier: state.Identifier{
+				AccountID:   accountID,
+				WorkspaceID: envID,
+				WorkflowID:  fnID,
+				RunID:       runID,
+			},
+		},
+	}
+
+	iter := ProcessorIterator{
+		Partition: &QueuePartition{
+			ID:         fnID.String(),
+			AccountID:  accountID,
+			EnvID:      &envID,
+			FunctionID: &fnID,
+		},
+		Items:      []*QueueItem{item},
+		Queue:      mockProc,
+		StaticTime: time.Now(),
+	}
+
+	err := iter.Iterate(ctx)
+	require.NoError(t, err)
+
+	shard.itemOpMu.Lock()
+	defer shard.itemOpMu.Unlock()
+
+	require.Equal(t, 1, shard.requeueCount)
+	require.Equal(t, 0, shard.dequeueCount)
+	require.NotNil(t, shard.requeuedItem)
+	require.Equal(t, 2, shard.requeuedItem.Data.Attempt)
+	require.Equal(t, nextAttemptAt, shard.requeueAt)
+	require.Empty(t, mockProc.workers)
+}
+
+func TestProcessorIteratorConstraintCheckErrorDequeuesAtMaxAttempts(t *testing.T) {
+	ctx := logger.WithStdlib(context.Background(), logger.VoidLogger())
+
+	accountID := uuid.New()
+	fnID := uuid.New()
+	envID := uuid.New()
+	runID := ulid.Make()
+	maxAttempts := 3
+
+	shard := &mockShardForIterator{name: "test-shard"}
+	mockProc := &mockQueueProcessor{
+		shard:         shard,
+		clock:         clockwork.NewRealClock(),
+		sem:           util.NewTrackingSemaphore(1),
+		workers:       make(chan ProcessItem, 1),
+		shadowMap:     make(map[string]ShadowContinuation),
+		opts:          NewQueueOptions(),
+		constraintErr: errors.New("missing constraint config workflow version"),
+	}
+
+	item := &QueueItem{
+		ID:          ulid.Make().String(),
+		FunctionID:  fnID,
+		WorkspaceID: envID,
+		AtMS:        time.Now().UnixMilli(),
+		Data: Item{
+			Kind:        KindEdge,
+			Attempt:     2,
+			MaxAttempts: &maxAttempts,
+			Identifier: state.Identifier{
+				AccountID:   accountID,
+				WorkspaceID: envID,
+				WorkflowID:  fnID,
+				RunID:       runID,
+			},
+		},
+	}
+
+	iter := ProcessorIterator{
+		Partition: &QueuePartition{
+			ID:         fnID.String(),
+			AccountID:  accountID,
+			EnvID:      &envID,
+			FunctionID: &fnID,
+		},
+		Items:      []*QueueItem{item},
+		Queue:      mockProc,
+		StaticTime: time.Now(),
+	}
+
+	err := iter.Iterate(ctx)
+	require.NoError(t, err)
+
+	shard.itemOpMu.Lock()
+	defer shard.itemOpMu.Unlock()
+
+	require.Equal(t, 0, shard.requeueCount)
+	require.Equal(t, 1, shard.dequeueCount)
+	require.NotNil(t, shard.dequeuedItem)
+	require.Equal(t, 2, shard.dequeuedItem.Data.Attempt)
+	require.Empty(t, mockProc.workers)
 }
 
 // TestProcessorIteratorCounterRaceCondition tests for race conditions when


### PR DESCRIPTION
## Description

Fixes #4060.

Queue items can fail `ItemLeaseConstraintCheck` before the item is leased, for example when legacy/orphaned items contain a constraint configuration with `FunctionVersion == 0`. Previously that error stopped the iterator without mutating the item, so the same ready item could be picked immediately again with the same attempt count.

This treats pre-lease constraint-check failures like other queue item failures:

- requeue with the normal queue backoff while attempts remain
- increment the item attempt before requeueing, except for always-retryable errors
- dequeue the item once its max attempts are exhausted
- ignore `ErrQueueItemNotFound` in case a concurrent cancellation already removed it

Local validation:

- `git diff --check`
- `golangci-lint run --verbose`
- `go test ./pkg/execution/queue -run 'TestProcessorIteratorConstraintCheckError|TestShouldRetry' -count=1`
- `TEST_MODE=true EXPERIMENTAL_KEY_QUEUES_ENABLE=<false|true> ENABLE_CONSTRAINT_API=<false|true> TEST_DATABASE=<sqlite|postgres> go test -v ./pkg/execution/queue -race -count=1` across all 8 combinations

## Release note

Fixes a queue retry loop where pre-lease constraint validation failures could repeatedly retry the same item without advancing attempts.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*