### PR TITLE
fix: Ensure canonical URL is set for all public auth pages

### DIFF
--- a/ui/apps/dashboard/public/robots.txt
+++ b/ui/apps/dashboard/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /sign-in
+Allow: /sign-up
+Disallow: /

--- a/ui/apps/dashboard/src/routes/(auth)/agent-deep-link.tsx
+++ b/ui/apps/dashboard/src/routes/(auth)/agent-deep-link.tsx
@@ -19,6 +19,7 @@ export const Route = createFileRoute('/(auth)/agent-deep-link')({
   validateSearch: validateAgentDeepLinkSearch,
   head: () => ({
     links: [canonicalLink('/agent-deep-link')],
+    meta: [{ name: 'robots', content: 'noindex' }],
   }),
 });
 

--- a/ui/apps/dashboard/src/routes/(auth)/agent-deep-link.tsx
+++ b/ui/apps/dashboard/src/routes/(auth)/agent-deep-link.tsx
@@ -4,6 +4,7 @@ import {
   stripDeepLinkParams,
   validateAgentDeepLinkSearch,
 } from '@/lib/deepLinkUtils';
+import { canonicalLink } from '@/utils/urls';
 import { useClerk, useSignIn } from '@clerk/tanstack-react-start';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useEffect, useRef, useState } from 'react';
@@ -16,6 +17,9 @@ const consumedTickets = new Set<string>();
 export const Route = createFileRoute('/(auth)/agent-deep-link')({
   component: AgentDeepLink,
   validateSearch: validateAgentDeepLinkSearch,
+  head: () => ({
+    links: [canonicalLink('/agent-deep-link')],
+  }),
 });
 
 function AgentDeepLink() {

--- a/ui/apps/dashboard/src/routes/(auth)/organization-list.$.tsx
+++ b/ui/apps/dashboard/src/routes/(auth)/organization-list.$.tsx
@@ -1,6 +1,7 @@
 import LoadingIcon from '@/components/Icons/LoadingIcon';
 import SplitView from '@/components/SignIn/SplitView';
 import { validateRedirectUrlSearch } from '@/lib/deepLinkUtils';
+import { canonicalLink } from '@/utils/urls';
 import { OrganizationList, useAuth } from '@clerk/tanstack-react-start';
 import { createFileRoute, useLocation } from '@tanstack/react-router';
 import logoImageUrl from '@inngest/components/icons/logos/inngest-logo-black.png';
@@ -8,6 +9,9 @@ import logoImageUrl from '@inngest/components/icons/logos/inngest-logo-black.png
 export const Route = createFileRoute('/(auth)/organization-list/$')({
   component: RouteComponent,
   validateSearch: validateRedirectUrlSearch,
+  head: () => ({
+    links: [canonicalLink('/organization-list')],
+  }),
 });
 
 function RouteComponent() {

--- a/ui/apps/dashboard/src/routes/(auth)/organization-list.$.tsx
+++ b/ui/apps/dashboard/src/routes/(auth)/organization-list.$.tsx
@@ -11,6 +11,7 @@ export const Route = createFileRoute('/(auth)/organization-list/$')({
   validateSearch: validateRedirectUrlSearch,
   head: () => ({
     links: [canonicalLink('/organization-list')],
+    meta: [{ name: 'robots', content: 'noindex' }],
   }),
 });
 

--- a/ui/apps/dashboard/src/routes/(auth)/organization-setup.tsx
+++ b/ui/apps/dashboard/src/routes/(auth)/organization-setup.tsx
@@ -1,7 +1,7 @@
 import ReloadClerkAndRedirect from '@/components/Clerk/ReloadClerkAndRedirect';
 import { graphql } from '@/gql';
 import graphqlAPI from '@/queries/graphqlAPI';
-import { pathCreator } from '@/utils/urls';
+import { canonicalLink, pathCreator } from '@/utils/urls';
 import { createFileRoute } from '@tanstack/react-router';
 import { createServerFn } from '@tanstack/react-start';
 
@@ -21,6 +21,9 @@ const setUpAccount = createServerFn({ method: 'GET' }).handler(() =>
 
 export const Route = createFileRoute('/(auth)/organization-setup')({
   component: OrganizationSetupComponent,
+  head: () => ({
+    links: [canonicalLink('/organization-setup')],
+  }),
   beforeLoad: async () => {
     await setUpAccount();
   },

--- a/ui/apps/dashboard/src/routes/(auth)/organization-setup.tsx
+++ b/ui/apps/dashboard/src/routes/(auth)/organization-setup.tsx
@@ -23,6 +23,7 @@ export const Route = createFileRoute('/(auth)/organization-setup')({
   component: OrganizationSetupComponent,
   head: () => ({
     links: [canonicalLink('/organization-setup')],
+    meta: [{ name: 'robots', content: 'noindex' }],
   }),
   beforeLoad: async () => {
     await setUpAccount();

--- a/ui/apps/dashboard/src/routes/(auth)/sign-in.$.tsx
+++ b/ui/apps/dashboard/src/routes/(auth)/sign-in.$.tsx
@@ -4,6 +4,7 @@ import SignInRedirectErrors, {
 } from '@/components/SignIn/Errors';
 import SplitView from '@/components/SignIn/SplitView';
 import { validateRedirectUrlSearch } from '@/lib/deepLinkUtils';
+import { canonicalLink } from '@/utils/urls';
 import { SignIn } from '@clerk/tanstack-react-start';
 import { Alert } from '@inngest/components/Alert';
 import { createFileRoute, useLocation } from '@tanstack/react-router';
@@ -15,6 +16,9 @@ type SignInSearchParams = ReturnType<typeof validateRedirectUrlSearch> & {
 
 export const Route = createFileRoute('/(auth)/sign-in/$')({
   component: RouteComponent,
+  head: () => ({
+    links: [canonicalLink('/sign-in')],
+  }),
   validateSearch: (search: Record<string, unknown>): SignInSearchParams => {
     return {
       ...validateRedirectUrlSearch(search),

--- a/ui/apps/dashboard/src/routes/(auth)/sign-out.tsx
+++ b/ui/apps/dashboard/src/routes/(auth)/sign-out.tsx
@@ -1,5 +1,6 @@
 import { SignOutButton } from '@/components/Auth/SignOutButton';
 import SplitView from '@/components/SignIn/SplitView';
+import { canonicalLink } from '@/utils/urls';
 import { useAuth } from '@clerk/tanstack-react-start';
 
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
@@ -7,6 +8,9 @@ import { useEffect } from 'react';
 
 export const Route = createFileRoute('/(auth)/sign-out')({
   component: RouteComponent,
+  head: () => ({
+    links: [canonicalLink('/sign-out')],
+  }),
 });
 
 function RouteComponent() {

--- a/ui/apps/dashboard/src/routes/(auth)/sign-out.tsx
+++ b/ui/apps/dashboard/src/routes/(auth)/sign-out.tsx
@@ -10,6 +10,7 @@ export const Route = createFileRoute('/(auth)/sign-out')({
   component: RouteComponent,
   head: () => ({
     links: [canonicalLink('/sign-out')],
+    meta: [{ name: 'robots', content: 'noindex' }],
   }),
 });
 

--- a/ui/apps/dashboard/src/routes/(auth)/sign-up.$.tsx
+++ b/ui/apps/dashboard/src/routes/(auth)/sign-up.$.tsx
@@ -1,4 +1,5 @@
 import SplitView from '@/components/SignIn/SplitView';
+import { canonicalLink } from '@/utils/urls';
 import { SignUp } from '@clerk/tanstack-react-start';
 import { createFileRoute } from '@tanstack/react-router';
 import logoImageUrl from '@inngest/components/icons/logos/inngest-logo-black.png';
@@ -17,6 +18,9 @@ const getAnonymousId = () => {
 
 export const Route = createFileRoute('/(auth)/sign-up/$')({
   component: RouteComponent,
+  head: () => ({
+    links: [canonicalLink('/sign-up')],
+  }),
 });
 
 function RouteComponent() {

--- a/ui/apps/dashboard/src/routes/(auth)/switch-organization.tsx
+++ b/ui/apps/dashboard/src/routes/(auth)/switch-organization.tsx
@@ -11,6 +11,7 @@ export const Route = createFileRoute('/(auth)/switch-organization')({
   validateSearch: validateSwitchOrganizationSearch,
   head: () => ({
     links: [canonicalLink('/switch-organization')],
+    meta: [{ name: 'robots', content: 'noindex' }],
   }),
 });
 

--- a/ui/apps/dashboard/src/routes/(auth)/switch-organization.tsx
+++ b/ui/apps/dashboard/src/routes/(auth)/switch-organization.tsx
@@ -1,6 +1,7 @@
 import LoadingIcon from '@/components/Icons/LoadingIcon';
 import SplitView from '@/components/SignIn/SplitView';
 import { validateSwitchOrganizationSearch } from '@/lib/deepLinkUtils';
+import { canonicalLink } from '@/utils/urls';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useClerk } from '@clerk/tanstack-react-start';
 import { useEffect } from 'react';
@@ -8,6 +9,9 @@ import { useEffect } from 'react';
 export const Route = createFileRoute('/(auth)/switch-organization')({
   component: RouteComponent,
   validateSearch: validateSwitchOrganizationSearch,
+  head: () => ({
+    links: [canonicalLink('/switch-organization')],
+  }),
 });
 
 function RouteComponent() {

--- a/ui/apps/dashboard/src/utils/urls.ts
+++ b/ui/apps/dashboard/src/utils/urls.ts
@@ -24,6 +24,18 @@ export function setSkipCacheSearchParam(url: string): string {
   return url;
 }
 
+/**
+ * Builds an absolute `<link rel="canonical">` descriptor for a route's `head`
+ * option. Splat routes (e.g. Clerk's /sign-in/factor-one) should pass their
+ * base path so all sub-paths collapse to one canonical URL.
+ */
+export function canonicalLink(path: string) {
+  return {
+    rel: 'canonical',
+    href: new URL(path, import.meta.env.VITE_APP_URL).toString(),
+  };
+}
+
 export function getManageKey(pathname: string) {
   const regex = /\/manage\/(\w+)/;
   const match = pathname.match(regex);


### PR DESCRIPTION


## Description

We need to de-duplicate any pages crawled by google to avoid indexing issues

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
