### PR TITLE
fix(cqrs): correct run EndedAt when a CEL event filter is active

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ pkg/execution/state/redis_state/testdata
 .specify/
 specs/**
 .retrospeced/**
+.codegraph/

--- a/pkg/cqrs/manager/cqrs.go
+++ b/pkg/cqrs/manager/cqrs.go
@@ -2994,9 +2994,12 @@ func (w wrapper) GetSpanRuns(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*c
 
 	builder := newSpanRunsQueryBuilder(ctx, opt)
 
-	// Parse CEL expressions using adapter's converter
-	var celFilters []sq.Expression
-	var useJoin bool
+	// Parse CEL expressions using adapter's converter.
+	// Event filters and output filters must be kept separate: event filters reference the
+	// events table (via a join) while output filters reference spans.output directly.
+	// Mixing them in the main span aggregation join corrupts MAX(end_time) — see fix below.
+	var eventCELFilters []sq.Expression
+	var outputCELFilters []sq.Expression
 	if opt.Filter.CEL != "" {
 		expHandler, err := run.NewExpressionHandler(ctx,
 			run.WithExpressionHandlerBlob(opt.Filter.CEL, "\n"),
@@ -3005,12 +3008,17 @@ func (w wrapper) GetSpanRuns(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*c
 		if err != nil {
 			return nil, err
 		}
-		if expHandler.HasFilters() {
-			celFilters, err = expHandler.ToSQLFilters(ctx)
+		if expHandler.HasEventFilters() {
+			eventCELFilters, err = expHandler.ToEventSQLFilters(ctx)
 			if err != nil {
 				return nil, err
 			}
-			useJoin = needsEventJoin(opt.Filter.CEL)
+		}
+		if expHandler.HasOutputFilters() {
+			outputCELFilters, err = expHandler.ToOutputSQLFilters(ctx)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -3072,13 +3080,46 @@ func (w wrapper) GetSpanRuns(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*c
 	orderExprs = append(orderExprs, sq.C("run_id").Asc())
 
 	q := sq.Dialect(h.GoquDialect()).From("spans")
-	if useJoin {
-		// database specific join syntax needed because event_ids is an array of ids to the events table,
-		// so we need to unpack that and perform the join before the spans are grouped back together by run_id
-		q = h.BuildEventJoin(q)
+	// NOTE: the event join (BuildEventJoin) is intentionally NOT applied to the main query here.
+	//
+	// The join uses INNER JOIN on spans.event_ids, which excludes EXTEND spans (they carry no
+	// event_ids). Those spans are required for MAX(spans.end_time) to reflect the true run end
+	// time. Joining events into the main aggregation query therefore causes the "Ended At" column
+	// to show the root executor.run span's end_time instead of the last EXTEND span's end_time
+	// (i.e. the wrong, earlier timestamp reported in issue #4268).
+	//
+	// Instead, event-field CEL predicates are applied via a run_id correlated subquery so that
+	// all spans for a matched run participate in the GROUP BY aggregation.
+
+	allFilters := make([]sq.Expression, len(builder.filter))
+	copy(allFilters, builder.filter)
+
+	if len(eventCELFilters) > 0 {
+		// Identify run_ids whose events satisfy the CEL predicate using a correlated subquery.
+		// The subquery is the only place the event join lives, so EXTEND spans in the outer
+		// query are never dropped and MAX(end_time) remains correct.
+		eventSub := sq.Dialect(h.GoquDialect()).
+			Select(sq.L("spans.run_id")).
+			Distinct().
+			From("spans")
+		eventSub = h.BuildEventJoin(eventSub)
+		for _, f := range eventCELFilters {
+			eventSub = eventSub.Where(f)
+		}
+		allFilters = append(allFilters, sq.L("spans.run_id").In(eventSub))
 	}
 
-	allFilters := append(builder.filter, celFilters...)
+	if len(outputCELFilters) > 0 {
+		// Output/error predicates reference spans.output which is present on individual span rows;
+		// apply them directly.  A run_id subquery is used here too so that the main aggregation
+		// sees all spans for matched runs, not just the spans where output happens to be set.
+		outputSub := sq.Dialect(h.GoquDialect()).
+			Select(sq.L("spans.run_id")).
+			Distinct().
+			From("spans").
+			Where(outputCELFilters...)
+		allFilters = append(allFilters, sq.L("spans.run_id").In(outputSub))
+	}
 	if opt.Filter.IsDeferred != nil {
 		// is_deferred uses TRUE/NULL encoding, so a non-deferred filter must
 		// check IS NULL. Anchor on the executor.run row because EXTEND rows

--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -1849,6 +1849,134 @@ func TestSpanOutputReadBack(t *testing.T) {
 	assert.Contains(t, string(out.Data), `"num":42`, "output should contain raw JSON, not double-encoded")
 }
 
+// TestGetSpanRunsCELEventFilterPreservesEndedAt is the regression test for issue #4268.
+//
+// Root cause: GetSpanRuns used INNER JOIN on spans.event_ids when a CEL event.* filter was
+// present. Only the root executor.run span carries event_ids; EXTEND spans have NULL
+// event_ids and are excluded by the INNER JOIN. MAX(spans.end_time) was therefore computed
+// only from the root span, producing an earlier (wrong) EndedAt.
+//
+// Fix: event CEL predicates are evaluated via a correlated run_id subquery so that ALL spans
+// for matched runs participate in the GROUP BY aggregation.
+func TestGetSpanRunsCELEventFilterPreservesEndedAt(t *testing.T) {
+	ctx := context.Background()
+	appID := uuid.New()
+	cm, cleanup := initCQRS(t, withInitCQRSOptApp(appID))
+	defer cleanup()
+
+	accountID := uuid.New()
+	workspaceID := uuid.New()
+	functionID := uuid.New()
+
+	// Insert an event the CEL filter will match on.
+	eventID := uuid.New().String()
+	q := cm.(wrapper).q
+	err := q.InsertEvent(ctx, dbpkg.InsertEventParams{
+		InternalID: ulid.MustNew(ulid.Now(), rand.Reader),
+		ReceivedAt: time.Now(),
+		EventID:    eventID,
+		EventName:  "user/created",
+		EventData:  `{"plan":"pro"}`,
+		EventUser:  `{}`,
+		EventTs:    time.Now(),
+	})
+	require.NoError(t, err)
+
+	// event_ids encoded as a JSON array — the events join reads it with json_each (SQLite)
+	// or jsonb_array_elements_text (Postgres).
+	eventIDsJSON, err := json.Marshal([]string{eventID})
+	require.NoError(t, err)
+
+	runID := ulid.MustNew(ulid.Now(), rand.Reader).String()
+	// Spans in the same run share a single trace_id so they collapse into one GROUP BY group.
+	traceID := ulid.MustNew(ulid.Now(), rand.Reader).String()
+	baseTime := time.Now().UTC().Truncate(time.Millisecond)
+	dynSpanID := "dyn-root"
+
+	// Root span (executor.run): has event_ids, short duration.
+	rootEnd := baseTime.Add(200 * time.Millisecond)
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runID,
+		TraceID:       traceID,
+		DynamicSpanID: dynSpanID,
+		Name:          "executor.run",
+		StartTime:     baseTime,
+		EndTime:       rootEnd,
+		AccountID:     accountID.String(),
+		AppID:         appID.String(),
+		FunctionID:    functionID.String(),
+		EnvID:         workspaceID.String(),
+		EventIds:      eventIDsJSON,
+	})
+
+	// EXTEND span: same run/trace/dynSpanID, no event_ids, ends 5 s after root.
+	// This is the true run end time and must survive the CEL event filter.
+	trueEndTime := baseTime.Add(5 * time.Second)
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runID,
+		TraceID:       traceID,
+		DynamicSpanID: dynSpanID,
+		Name:          "executor.run:EXTEND",
+		StartTime:     rootEnd,
+		EndTime:       trueEndTime,
+		AccountID:     accountID.String(),
+		AppID:         appID.String(),
+		FunctionID:    functionID.String(),
+		EnvID:         workspaceID.String(),
+		// EventIds intentionally omitted — EXTEND spans do not carry event_ids
+	})
+
+	baseFilter := cqrs.GetTraceRunFilter{
+		AccountID:   accountID,
+		WorkspaceID: workspaceID,
+		FunctionID:  []uuid.UUID{functionID},
+		TimeField:   enums.TraceRunTimeStartedAt,
+		From:        baseTime.Add(-time.Hour),
+		Until:       baseTime.Add(time.Hour),
+	}
+	order := []cqrs.GetTraceRunOrder{
+		{Field: enums.TraceRunTimeStartedAt, Direction: enums.TraceRunOrderDesc},
+	}
+
+	t.Run("without CEL: EndedAt reflects the last EXTEND span's end_time", func(t *testing.T) {
+		runs, err := cm.GetTraceRuns(ctx, cqrs.GetTraceRunOpt{
+			Filter:  baseFilter,
+			Order:   order,
+			Preview: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, runs, 1)
+		assert.Equal(t, trueEndTime.UnixMilli(), runs[0].EndedAt.UnixMilli(),
+			"without CEL, EndedAt must equal the last EXTEND span's end_time")
+	})
+
+	t.Run("with event CEL filter: EndedAt must still equal the true run end_time (regression #4268)", func(t *testing.T) {
+		filter := baseFilter
+		filter.CEL = `event.name == "user/created"`
+		runs, err := cm.GetTraceRuns(ctx, cqrs.GetTraceRunOpt{
+			Filter:  filter,
+			Order:   order,
+			Preview: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, runs, 1, "run must appear in CEL-filtered results")
+		assert.Equal(t, trueEndTime.UnixMilli(), runs[0].EndedAt.UnixMilli(),
+			"with event CEL, EndedAt must still equal the EXTEND span's end_time, not the root span's")
+	})
+
+	t.Run("non-matching event CEL filter: run must be excluded", func(t *testing.T) {
+		filter := baseFilter
+		filter.CEL = `event.name == "other/event"`
+		runs, err := cm.GetTraceRuns(ctx, cqrs.GetTraceRunOpt{
+			Filter:  filter,
+			Order:   order,
+			Preview: true,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, runs, "CEL filter for non-matching event name must return no runs")
+	})
+}
+
 //
 // Helpers
 //
@@ -1856,18 +1984,21 @@ func TestSpanOutputReadBack(t *testing.T) {
 type testSpanFields struct {
 	RunID          string    // required
 	DynamicSpanID  string    // required for GROUP BY tests
+	TraceID        string    // shared across spans in the same run (generated if empty)
 	ParentSpanID   string    // for child spans (references parent's DynamicSpanID)
 	DebugRunID     string    // for debug run tests
 	DebugSessionID string    // for debug session tests
 	Name           string    // default: "test-span"
 	Status         string    // default: "" (NULL)
 	StartTime      time.Time // default: time.Now()
+	EndTime        time.Time // default: StartTime + 100ms
 	AccountID      string    // default: "acct"
 	AppID          string    // default: "app"
 	FunctionID     string    // default: "fn"
 	EnvID          string    // default: "env"
 	Attributes     []byte    // JSON attributes (optional)
 	Output         []byte    // JSON output (optional)
+	EventIds       []byte    // JSON-encoded event ID array, e.g. ["uuid1"] (optional)
 }
 
 // There aren't any functions exposed on cqrs.Manager that write to the new spans table
@@ -1876,7 +2007,10 @@ func insertTestSpan(t *testing.T, cm cqrs.Manager, spanFields testSpanFields) {
 	t.Helper()
 
 	spanID := ulid.MustNew(ulid.Now(), rand.Reader).String()
-	traceID := ulid.MustNew(ulid.Now(), rand.Reader).String()
+	traceID := spanFields.TraceID
+	if traceID == "" {
+		traceID = ulid.MustNew(ulid.Now(), rand.Reader).String()
+	}
 
 	// Apply defaults
 	if spanFields.Name == "" {
@@ -1898,6 +2032,11 @@ func insertTestSpan(t *testing.T, cm cqrs.Manager, spanFields testSpanFields) {
 		spanFields.EnvID = "env"
 	}
 
+	endTime := spanFields.EndTime
+	if endTime.IsZero() {
+		endTime = spanFields.StartTime.Add(100 * time.Millisecond)
+	}
+
 	// TODO: ideally we should not have to do this type assertion to wrapper to write a span
 	q := cm.(wrapper).q
 	err := q.InsertSpan(t.Context(), dbpkg.InsertSpanParams{
@@ -1907,7 +2046,7 @@ func insertTestSpan(t *testing.T, cm cqrs.Manager, spanFields testSpanFields) {
 		Name:           spanFields.Name,
 		Status:         sql.NullString{String: spanFields.Status, Valid: spanFields.Status != ""},
 		StartTime:      spanFields.StartTime,
-		EndTime:        spanFields.StartTime.Add(100 * time.Millisecond),
+		EndTime:        endTime,
 		RunID:          spanFields.RunID,
 		AccountID:      spanFields.AccountID,
 		AppID:          spanFields.AppID,
@@ -1918,6 +2057,7 @@ func insertTestSpan(t *testing.T, cm cqrs.Manager, spanFields testSpanFields) {
 		DebugSessionID: sql.NullString{String: spanFields.DebugSessionID, Valid: spanFields.DebugSessionID != ""},
 		Attributes:     spanFields.Attributes,
 		Output:         spanFields.Output,
+		EventIds:       spanFields.EventIds,
 	})
 	require.NoError(t, err)
 }

--- a/pkg/run/cel.go
+++ b/pkg/run/cel.go
@@ -176,29 +176,46 @@ func (h *ExpressionHandler) HasOutputFilters() bool {
 }
 
 func (h *ExpressionHandler) ToSQLFilters(ctx context.Context) ([]sq.Expression, error) {
+	eventFilters, err := h.ToEventSQLFilters(ctx)
+	if err != nil {
+		return nil, err
+	}
+	outputFilters, err := h.ToOutputSQLFilters(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return append(eventFilters, outputFilters...), nil
+}
+
+// ToEventSQLFilters returns SQL filter expressions derived only from event.* CEL predicates.
+// Callers that join the events table (for span-level aggregation queries) must use this
+// instead of ToSQLFilters so that output/error predicates are not inadvertently mixed in.
+func (h *ExpressionHandler) ToEventSQLFilters(ctx context.Context) ([]sq.Expression, error) {
+	return h.exprListToSQL(ctx, h.EventExprList)
+}
+
+// ToOutputSQLFilters returns SQL filter expressions derived only from output.*/error.* CEL
+// predicates (both map to the spans.output column).
+func (h *ExpressionHandler) ToOutputSQLFilters(ctx context.Context) ([]sq.Expression, error) {
+	return h.exprListToSQL(ctx, h.OutputExprList)
+}
+
+// exprListToSQL converts a deduplicated slice of raw CEL strings to goqu SQL expressions
+// using this handler's configured SQLConverter.
+func (h *ExpressionHandler) exprListToSQL(ctx context.Context, cel []string) ([]sq.Expression, error) {
 	filters := []sq.Expression{}
 	parser := expressions.ParserSingleton()
 
-	// used to dedup in case there's an expression that is included in both list
-	dedup := map[string]bool{}
-	exprs := []string{}
-	for _, e := range h.EventExprList {
-		if _, ok := dedup[e]; !ok {
-			dedup[e] = true
-			exprs = append(exprs, e)
+	seen := map[string]bool{}
+	for _, exp := range cel {
+		if seen[exp] {
+			continue
 		}
-	}
-	for _, e := range h.OutputExprList {
-		if _, ok := dedup[e]; !ok {
-			dedup[e] = true
-			exprs = append(exprs, e)
-		}
-	}
+		seen[exp] = true
 
-	for _, exp := range exprs {
 		tree, err := parser.Parse(ctx, expr.StringExpression(exp))
 		if err != nil {
-			return nil, fmt.Errorf("error evaluating event expression '%s': %w", exp, err)
+			return nil, fmt.Errorf("error evaluating expression '%s': %w", exp, err)
 		}
 
 		expFilter, err := h.toSQLFilters(ctx, []*expr.Node{&tree.Root})

--- a/pkg/run/cel_test.go
+++ b/pkg/run/cel_test.go
@@ -328,3 +328,118 @@ func TestToSQLFiltersWithPostgresConverter(t *testing.T) {
 		})
 	}
 }
+
+// TestExpressionHandlerSeparateSQLFilters verifies the ToEventSQLFilters / ToOutputSQLFilters
+// split introduced to fix issue #4268 (wrong EndedAt when CEL event filter is active).
+//
+// Previously ToSQLFilters returned a single flat list; the GetSpanRuns aggregation query
+// then joined the events table in-line, which excluded EXTEND spans and corrupted MAX(end_time).
+// The fix exposes separate accessors so event filters can be moved to a subquery.
+func TestExpressionHandlerSeparateSQLFilters(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("event-only CEL populates only event filters", func(t *testing.T) {
+		h, err := NewExpressionHandler(ctx,
+			WithExpressionHandlerBlob(`event.name == "user/created"`, "\n"),
+			WithExpressionSQLConverter(SpanEventSQLiteConverter),
+		)
+		require.NoError(t, err)
+
+		eventFilters, err := h.ToEventSQLFilters(ctx)
+		require.NoError(t, err)
+		assert.NotEmpty(t, eventFilters, "event CEL must produce event SQL filters")
+
+		outputFilters, err := h.ToOutputSQLFilters(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, outputFilters, "event-only CEL must produce no output SQL filters")
+	})
+
+	t.Run("output-only CEL populates only output filters", func(t *testing.T) {
+		h, err := NewExpressionHandler(ctx,
+			WithExpressionHandlerBlob(`output.status == "ok"`, "\n"),
+			WithExpressionSQLConverter(SpanEventSQLiteConverter),
+		)
+		require.NoError(t, err)
+
+		eventFilters, err := h.ToEventSQLFilters(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, eventFilters, "output-only CEL must produce no event SQL filters")
+
+		outputFilters, err := h.ToOutputSQLFilters(ctx)
+		require.NoError(t, err)
+		assert.NotEmpty(t, outputFilters, "output CEL must produce output SQL filters")
+	})
+
+	t.Run("error-only CEL populates only output filters", func(t *testing.T) {
+		h, err := NewExpressionHandler(ctx,
+			WithExpressionHandlerBlob(`error.message == "timeout"`, "\n"),
+			WithExpressionSQLConverter(SpanEventSQLiteConverter),
+		)
+		require.NoError(t, err)
+
+		eventFilters, err := h.ToEventSQLFilters(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, eventFilters)
+
+		outputFilters, err := h.ToOutputSQLFilters(ctx)
+		require.NoError(t, err)
+		assert.NotEmpty(t, outputFilters, "error.* maps to output filters (spans.output column)")
+	})
+
+	t.Run("mixed CEL populates both filter sets", func(t *testing.T) {
+		h, err := NewExpressionHandler(ctx,
+			WithExpressionHandlerBlob(`event.name == "user/created"`, "\n"),
+			WithExpressionHandlerBlob(`output.status == "ok"`, "\n"),
+			WithExpressionSQLConverter(SpanEventSQLiteConverter),
+		)
+		require.NoError(t, err)
+
+		eventFilters, err := h.ToEventSQLFilters(ctx)
+		require.NoError(t, err)
+		assert.NotEmpty(t, eventFilters)
+
+		outputFilters, err := h.ToOutputSQLFilters(ctx)
+		require.NoError(t, err)
+		assert.NotEmpty(t, outputFilters)
+	})
+
+	t.Run("ToSQLFilters is the union of event and output filters", func(t *testing.T) {
+		h, err := NewExpressionHandler(ctx,
+			WithExpressionHandlerBlob(`event.name == "user/created"`, "\n"),
+			WithExpressionHandlerBlob(`output.status == "ok"`, "\n"),
+			WithExpressionSQLConverter(SpanEventSQLiteConverter),
+		)
+		require.NoError(t, err)
+
+		all, err := h.ToSQLFilters(ctx)
+		require.NoError(t, err)
+
+		evtF, err := h.ToEventSQLFilters(ctx)
+		require.NoError(t, err)
+
+		outF, err := h.ToOutputSQLFilters(ctx)
+		require.NoError(t, err)
+
+		assert.Equal(t, len(evtF)+len(outF), len(all),
+			"ToSQLFilters count must equal ToEventSQLFilters + ToOutputSQLFilters")
+	})
+
+	t.Run("empty handler produces no filters from any accessor", func(t *testing.T) {
+		h, err := NewExpressionHandler(ctx,
+			WithExpressionSQLConverter(SpanEventSQLiteConverter),
+		)
+		require.NoError(t, err)
+
+		evtF, err := h.ToEventSQLFilters(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, evtF)
+
+		outF, err := h.ToOutputSQLFilters(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, outF)
+
+		all, err := h.ToSQLFilters(ctx)
+		require.NoError(t, err)
+		assert.Empty(t, all)
+	})
+}


### PR DESCRIPTION
## Description

Fixes #4268 — the `Ended At` column in the runs list showing an earlier (wrong) timestamp whenever a CEL query filter was active. The non-filtered view was correct; apply literally any CEL expression and the end time would quietly slip back by a few seconds. Classic.

### Root cause

`GetSpanRuns` builds an aggregated query over the `spans` table, grouping all spans for a run to compute `MAX(spans.end_time)` as the run's end time. When a CEL `event.*` filter was present, the query joined the `events` table inline via an `INNER JOIN` on `spans.event_ids`:

```sql
FROM spans
INNER JOIN json_each(spans.event_ids) …
INNER JOIN events ON … WHERE events.event_name = 'user/created'
GROUP BY spans.run_id, spans.dynamic_span_id, …
SELECT MAX(spans.end_time) -- 🙂 only root span survived
```

The problem: only the root `executor.run` span carries `event_ids`. Every subsequent `EXTEND` span has `NULL`/empty `event_ids` and is silently dropped by the `INNER JOIN` before the `GROUP BY` even runs. So `MAX(end_time)` was computed from the root span alone — producing the earlier timestamp the user observed. The actual last span's end time never made it into the result.

### Fix

Moved event-field CEL predicates out of the main aggregation query and into a correlated `run_id` subquery:

```sql
FROM spans
WHERE spans.run_id IN (
    SELECT DISTINCT spans.run_id
    FROM spans
    INNER JOIN events ON …      -- join lives here now, safely isolated
    WHERE events.event_name = 'user/created'
)
GROUP BY spans.run_id, spans.dynamic_span_id, …
SELECT MAX(spans.end_time)      -- ✅ all spans participate
```

All spans for a matched run now participate in the `GROUP BY`, so `MAX(end_time)` correctly reflects the last `EXTEND` span's end time. The same subquery pattern is applied to `output.*`/`error.*` CEL predicates for the same reason.

**`ExpressionHandler` changes (`pkg/run/cel.go`):**
- Extracted `ToEventSQLFilters(ctx)` — SQL predicates for `event.*` CEL expressions
- Extracted `ToOutputSQLFilters(ctx)` — SQL predicates for `output.*`/`error.*` CEL expressions
- Refactored `ToSQLFilters(ctx)` to be their union — zero behaviour change for existing callers

**`GetSpanRuns` changes (`pkg/cqrs/manager/cqrs.go`):**
- Removed `BuildEventJoin` from the main span aggregation query
- Event filters → correlated `run_id IN (SELECT … INNER JOIN events …)` subquery
- Output/error filters → same subquery pattern anchored on `spans.output`

**Tests:**
- `TestExpressionHandlerSeparateSQLFilters` (6 subtests) — unit coverage for the new filter accessors
- `TestGetSpanRunsCELEventFilterPreservesEndedAt` (3 subtests) — integration regression that directly reproduces the bug: inserts a root + EXTEND span pair, verifies `EndedAt` equals the EXTEND span's end time both with and without a CEL event filter

## Release note

Fixed a bug where the `Ended At` time shown for a function run was incorrect when a CEL query filter was applied. The displayed time was taken from the root span rather than the actual last step, causing it to appear earlier than the real end time.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
