### PR TITLE
refactor: use Item.Kind for shard selection instead of Item.QueueName

### DIFF
--- a/pkg/execution/queue/enqueue.go
+++ b/pkg/execution/queue/enqueue.go
@@ -32,10 +32,8 @@ func (q *queueProcessor) Enqueue(ctx context.Context, item Item, at time.Time, o
 	}
 
 	if item.QueueName == nil {
-		// Check if we have a kind mapping.
-		if name, ok := q.queueKindMapping[item.Kind]; ok {
-			item.QueueName = &name
-		}
+		// Check if we have a kind => queuename mapping.
+		item.QueueName = q.defaultQueueNameForItemKind(item.Kind)
 	}
 
 	qi := QueueItem{

--- a/pkg/execution/queue/shard.go
+++ b/pkg/execution/queue/shard.go
@@ -21,6 +21,14 @@ type QueueShard interface {
 	ShardAssignmentConfig() ShardAssignmentConfig
 }
 
+func (q *queueProcessor) defaultQueueNameForItemKind(kind string) *string {
+	var queueName *string
+	if name, ok := q.queueKindMapping[kind]; ok {
+		queueName = &name
+	}
+	return queueName
+}
+
 func (q *queueProcessor) selectShard(ctx context.Context, shardName string, qi QueueItem) (QueueShard, error) {
 	l := logger.StdlibLogger(ctx)
 
@@ -33,14 +41,12 @@ func (q *queueProcessor) selectShard(ctx context.Context, shardName string, qi Q
 		return shard, nil
 	}
 
-	// QueueName should be consistently specified on both levels. This safeguard ensures
-	// we'll check for both places, just in case.
-	qn := qi.Data.QueueName
-	if qn == nil {
-		qn = qi.QueueName
+	var queueItemKind *string
+	if q.defaultQueueNameForItemKind(qi.Data.Kind) != nil {
+		queueItemKind = &qi.Data.Kind
 	}
 
-	selected, err := q.shards.Resolve(ctx, qi.Data.Identifier.AccountID, qn)
+	selected, err := q.shards.Resolve(ctx, qi.Data.Identifier.AccountID, queueItemKind)
 	if err != nil {
 		l.Error("error selecting shard", "error", err, "item", qi)
 		return q.Shard(), fmt.Errorf("could not select shard: %w", err)

--- a/pkg/execution/queue/shard_registry.go
+++ b/pkg/execution/queue/shard_registry.go
@@ -36,7 +36,7 @@ type ShardRegistry interface {
 
 	// Resolve picks a shard for a given enqueue, applying the registry's
 	// shard selector. Resolve errors if no selector has been configured.
-	Resolve(ctx context.Context, accountID uuid.UUID, queueName *string) (QueueShard, error)
+	Resolve(ctx context.Context, accountID uuid.UUID, queueItemKind *string) (QueueShard, error)
 
 	// ForEach runs fn against every active shard concurrently, returning
 	// the first error encountered. The shard set is snapshotted at call
@@ -176,8 +176,8 @@ func (r *shardRegistry) ByGroup(groupName string) []QueueShard {
 	return out
 }
 
-func (r *shardRegistry) Resolve(ctx context.Context, accountID uuid.UUID, queueName *string) (QueueShard, error) {
-	return r.selector(ctx, accountID, queueName)
+func (r *shardRegistry) Resolve(ctx context.Context, accountID uuid.UUID, queueItemKind *string) (QueueShard, error) {
+	return r.selector(ctx, accountID, queueItemKind)
 }
 
 func (r *shardRegistry) ForEach(ctx context.Context, fn func(context.Context, QueueShard) error) error {


### PR DESCRIPTION
## Description
This PR changes the shard selector to take the item's kind as input, so that Cloud can use the item kind (which is a discrete set of values) to perform system shard selection.

Currently, we use `queue.Item.QueueName` for system shard selection. 
- QueueName is the partition name that item should be written to after a shard has been selected.
- This works as an input to shard selector in OSS because there is only one shard and the queueName passed to shard selector is unused.
- This works as an input to shard selector in Cloud for essentially the same reason - there is only one system shard and no matter what queue name you use for shard selection, it always returns the single system queue shard.

QueueNames are arbitrary (and a non-exhaustive list) names formed from the ItemKind plus some kind of tenancy identifier. For the purposes of shard selection, ItemKind (if it is present in QueueKindMapping) is a better attribute to select the appropriate queue shard.




## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
