### PR TITLE
fix: request ID collisions in parallel requests

### DIFF
--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -743,10 +743,18 @@ func (c checkpointer) validateAsyncDispatch(ctx context.Context, input AsyncChec
 	}
 
 	// Compare only the entropy: it's the deterministic part bound to
-	// (runID, generationID). The ULID timestamp is incidental (it just
-	// gives RequestIDs chronological sort order) and isn't part of the
-	// fence.
-	if !bytes.Equal(parsed.Entropy(), driver.DispatchRequestIDEntropy(input.RunID, item.GenerationID)) {
+	// (runID, queue item, generationID). The ULID timestamp is incidental
+	// (it just gives RequestIDs chronological sort order) and isn't part of
+	// the fence.
+	//
+	// Also, check the legacy request ID (from before it included QueueItemRef).
+	// We can delete this a day or so after updating the Executor's request ID
+	// generation logic to include queueItemRef. Just long enough to ensure
+	// there are no more in-flight requests (which shouldn't be longer than 2
+	// hours).
+	entropy := parsed.Entropy()
+	if !bytes.Equal(entropy, driver.DispatchRequestIDEntropy(input.RunID, input.QueueItemRef, item.GenerationID)) &&
+		!bytes.Equal(entropy, driver.LegacyDispatchRequestIDEntropy(input.RunID, item.GenerationID)) {
 		return fmt.Errorf("%w: request id %s does not match queue item generation %d", ErrStaleDispatch, input.RequestID, item.GenerationID)
 	}
 

--- a/pkg/execution/checkpoint/checkpoint_async_test.go
+++ b/pkg/execution/checkpoint/checkpoint_async_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func requestIDForGeneration(runID ulid.ULID, generationID int) string {
-	return driver.DispatchRequestID(time.Now(), runID, generationID).String()
+func requestIDForGeneration(runID ulid.ULID, queueItemRef string, generationID int) string {
+	return driver.DispatchRequestID(time.Now(), runID, queueItemRef, generationID).String()
 }
 
 func TestCheckpointAsyncSteps(t *testing.T) {
@@ -467,7 +467,7 @@ func TestCheckpointAsyncSteps_RequestStartedAtGate(t *testing.T) {
 			}
 			mocks, testData := setupAsyncCheckpointTest(t, op)
 
-			testData.asyncCheckpoint.RequestID = requestIDForGeneration(testData.asyncCheckpoint.RunID, 4)
+			testData.asyncCheckpoint.RequestID = requestIDForGeneration(testData.asyncCheckpoint.RunID, testData.asyncCheckpoint.QueueItemRef, 4)
 			testData.asyncCheckpoint.RequestStartedAt = time.Now().Add(tc.ageOffset).UnixMilli()
 
 			if tc.expectLoad {
@@ -527,7 +527,7 @@ func TestCheckpointAsyncSteps_ValidationDisabledBypassesGate(t *testing.T) {
 	}
 	mocks, testData := setupAsyncCheckpointTestWithValidation(t, false, op)
 
-	testData.asyncCheckpoint.RequestID = requestIDForGeneration(testData.asyncCheckpoint.RunID, 1)
+	testData.asyncCheckpoint.RequestID = requestIDForGeneration(testData.asyncCheckpoint.RunID, testData.asyncCheckpoint.QueueItemRef, 1)
 	testData.asyncCheckpoint.RequestStartedAt = time.Now().Add(-time.Hour).UnixMilli()
 
 	expectedData, err := json.Marshal(map[string]any{
@@ -561,7 +561,7 @@ func TestCheckpointAsyncSteps_QueueItemNotFoundFailsBeforeSave(t *testing.T) {
 	}
 	mocks, testData := setupAsyncCheckpointTest(t, op)
 
-	testData.asyncCheckpoint.RequestID = requestIDForGeneration(testData.asyncCheckpoint.RunID, 1)
+	testData.asyncCheckpoint.RequestID = requestIDForGeneration(testData.asyncCheckpoint.RunID, testData.asyncCheckpoint.QueueItemRef, 1)
 	// Nil-from-HGET means the dispatch the SDK is serving no longer exists,
 	// which is exactly the stale case.
 	mocks.queue.On("LoadQueueItem", ctx, "shard-1", "job-123").Return(nil, queue.ErrQueueItemNotFound)

--- a/pkg/execution/driver/request.go
+++ b/pkg/execution/driver/request.go
@@ -18,14 +18,39 @@ type sdkJobIDCtxKey struct{}
 // DispatchRequestID is the single source of truth for the request ID the
 // executor (producer) stamps on outbound SDK requests and the checkpoint
 // validator (consumer) recomputes when fencing stale dispatches.
-func DispatchRequestID(ts time.Time, runID ulid.ULID, generationID int) ulid.ULID {
-	return util.MustDeterministicULID(ts, fmt.Appendf(nil, "%s:%d", runID, generationID))
+func DispatchRequestID(
+	ts time.Time,
+	runID ulid.ULID,
+	queueItemRef string,
+	generationID int,
+) ulid.ULID {
+	return util.MustDeterministicULID(
+		ts,
+		dispatchRequestIDSeed(runID, queueItemRef, generationID),
+	)
 }
 
 // DispatchRequestIDEntropy returns the entropy portion of the dispatch
 // RequestID; the timestamp doesn't participate in fencing.
-func DispatchRequestIDEntropy(runID ulid.ULID, generationID int) []byte {
-	return DispatchRequestID(time.Unix(0, 0), runID, generationID).Entropy()
+func DispatchRequestIDEntropy(
+	runID ulid.ULID,
+	queueItemRef string,
+	generationID int,
+) []byte {
+	return DispatchRequestID(
+		time.Unix(0, 0), runID, queueItemRef, generationID,
+	).Entropy()
+}
+
+// LegacyDispatchRequestIDEntropy returns the v1.24.0 request ID entropy that
+// omitted the queue item ref. Keep accepting this during rolling upgrades so
+// already-dispatched SDK work can checkpoint successfully.
+func LegacyDispatchRequestIDEntropy(runID ulid.ULID, generationID int) []byte {
+	return util.MustDeterministicULID(time.Unix(0, 0), fmt.Appendf(nil, "%s:%d", runID, generationID)).Entropy()
+}
+
+func dispatchRequestIDSeed(runID ulid.ULID, queueItemRef string, generationID int) []byte {
+	return fmt.Appendf(nil, "%s:%s:%d", runID, queueItemRef, generationID)
 }
 
 // WithRequestIDs stores the per-outbound request ID and stable job ID for SDK

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1617,7 +1617,12 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 	conditionalTraceCtx, conditionalSpan := e.conditionalTracer.NewSpan(ctx, "executor.Execute", id.AccountID, id.WorkspaceID, id.WorkflowID)
 	defer conditionalSpan.End()
 
-	requestID := driver.DispatchRequestID(e.now(), id.RunID, queue.GenerationIDFromContext(ctx)).String()
+	requestID := driver.DispatchRequestID(
+		e.now(),
+		id.RunID,
+		queueref.StringFromCtx(ctx),
+		queue.GenerationIDFromContext(ctx),
+	).String()
 
 	jobID := queue.JobIDFromContext(ctx)
 	if item.JobID != nil {


### PR DESCRIPTION
> ⚠️ This PR cannot be merged as-is. See the migration note.

## Description
Fix request ID collisions in parallel requests. This happens when 2 parallel requests' request IDs are created at the same millisecond.

The solution involved adding the queue item ref to the request ID entropy.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

This needs to be broken up into multiple releases, ensuring that our checkpointing endpoint is able to handle both the new and legacy request IDs. Once that's released (and we're confident we won't roll it back), we can make the Executor start generating the new request IDs.