### PR TITLE
fix: status, duration, output in v2 api event/runs

### DIFF
--- a/pkg/db/postgres/sqlc/queries.sql
+++ b/pkg/db/postgres/sqlc/queries.sql
@@ -236,7 +236,7 @@ LEFT JOIN LATERAL (
     AND output_spans.debug_run_id IS NULL
     AND output_spans.output IS NOT NULL
   ORDER BY
-    CASE WHEN COALESCE((output_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') = 'true' THEN 0 ELSE 1 END,
+    COALESCE((output_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') != 'true',
     output_spans.end_time DESC
   LIMIT 1
 ) run_output ON true

--- a/pkg/db/postgres/sqlc/queries.sql
+++ b/pkg/db/postgres/sqlc/queries.sql
@@ -198,10 +198,10 @@ SELECT
   spans.run_id,
   spans.function_id,
   spans.app_id,
-  spans.start_time,
-  spans.end_time,
-  COALESCE(spans.status, '') AS status,
-  COALESCE(spans.output::text, '') AS output,
+  COALESCE(run_start.start_time, spans.start_time) AS start_time,
+  COALESCE(run_status.end_time, spans.end_time) AS end_time,
+  COALESCE(run_status.status, spans.status, '') AS status,
+  COALESCE(run_output.output::text, spans.output::text, '') AS output,
   COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.slug', '') AS function_slug,
   COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.name', '') AS function_name,
   COALESCE(apps.name, '') AS app_name,
@@ -209,6 +209,37 @@ SELECT
   COALESCE((spans.attributes#>>'{}')::json->>'_inngest.cron.schedule', '') AS cron_schedule
 FROM spans
 LEFT JOIN apps ON apps.id::text = spans.app_id AND apps.archived_at IS NULL
+LEFT JOIN LATERAL (
+  SELECT start_time
+  FROM spans start_spans
+  WHERE start_spans.run_id = spans.run_id
+    AND start_spans.debug_run_id IS NULL
+    AND start_spans.parent_span_id IS NOT NULL
+    AND start_spans.parent_span_id <> ''
+    AND start_spans.parent_span_id <> '0000000000000000'
+  ORDER BY start_spans.start_time
+  LIMIT 1
+) run_start ON true
+LEFT JOIN LATERAL (
+  SELECT status, end_time
+  FROM spans status_spans
+  WHERE status_spans.run_id = spans.run_id
+    AND status_spans.debug_run_id IS NULL
+    AND status_spans.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
+  ORDER BY status_spans.end_time DESC
+  LIMIT 1
+) run_status ON true
+LEFT JOIN LATERAL (
+  SELECT output
+  FROM spans output_spans
+  WHERE output_spans.run_id = spans.run_id
+    AND output_spans.debug_run_id IS NULL
+    AND output_spans.output IS NOT NULL
+  ORDER BY
+    CASE WHEN COALESCE((output_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') = 'true' THEN 0 ELSE 1 END,
+    output_spans.end_time DESC
+  LIMIT 1
+) run_output ON true
 WHERE spans.name = sqlc.arg('name')
   AND spans.debug_run_id IS NULL
   AND spans.run_id > sqlc.arg('cursor_run_id')::TEXT

--- a/pkg/db/postgres/sqlc/queries.sql.go
+++ b/pkg/db/postgres/sqlc/queries.sql.go
@@ -1237,10 +1237,10 @@ SELECT
   spans.run_id,
   spans.function_id,
   spans.app_id,
-  spans.start_time,
-  spans.end_time,
-  COALESCE(spans.status, '') AS status,
-  COALESCE(spans.output::text, '') AS output,
+  COALESCE(run_start.start_time, spans.start_time) AS start_time,
+  COALESCE(run_status.end_time, spans.end_time) AS end_time,
+  COALESCE(run_status.status, spans.status, '') AS status,
+  COALESCE(run_output.output::text, spans.output::text, '') AS output,
   COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.slug', '') AS function_slug,
   COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.name', '') AS function_name,
   COALESCE(apps.name, '') AS app_name,
@@ -1248,6 +1248,37 @@ SELECT
   COALESCE((spans.attributes#>>'{}')::json->>'_inngest.cron.schedule', '') AS cron_schedule
 FROM spans
 LEFT JOIN apps ON apps.id::text = spans.app_id AND apps.archived_at IS NULL
+LEFT JOIN LATERAL (
+  SELECT start_time
+  FROM spans start_spans
+  WHERE start_spans.run_id = spans.run_id
+    AND start_spans.debug_run_id IS NULL
+    AND start_spans.parent_span_id IS NOT NULL
+    AND start_spans.parent_span_id <> ''
+    AND start_spans.parent_span_id <> '0000000000000000'
+  ORDER BY start_spans.start_time
+  LIMIT 1
+) run_start ON true
+LEFT JOIN LATERAL (
+  SELECT status, end_time
+  FROM spans status_spans
+  WHERE status_spans.run_id = spans.run_id
+    AND status_spans.debug_run_id IS NULL
+    AND status_spans.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
+  ORDER BY status_spans.end_time DESC
+  LIMIT 1
+) run_status ON true
+LEFT JOIN LATERAL (
+  SELECT output
+  FROM spans output_spans
+  WHERE output_spans.run_id = spans.run_id
+    AND output_spans.debug_run_id IS NULL
+    AND output_spans.output IS NOT NULL
+  ORDER BY
+    CASE WHEN COALESCE((output_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') = 'true' THEN 0 ELSE 1 END,
+    output_spans.end_time DESC
+  LIMIT 1
+) run_output ON true
 WHERE spans.name = $1
   AND spans.debug_run_id IS NULL
   AND spans.run_id > $2::TEXT

--- a/pkg/db/postgres/sqlc/queries.sql.go
+++ b/pkg/db/postgres/sqlc/queries.sql.go
@@ -1275,7 +1275,7 @@ LEFT JOIN LATERAL (
     AND output_spans.debug_run_id IS NULL
     AND output_spans.output IS NOT NULL
   ORDER BY
-    CASE WHEN COALESCE((output_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') = 'true' THEN 0 ELSE 1 END,
+    COALESCE((output_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') != 'true',
     output_spans.end_time DESC
   LIMIT 1
 ) run_output ON true

--- a/pkg/db/sqlite/querier.go
+++ b/pkg/db/sqlite/querier.go
@@ -390,11 +390,13 @@ func scanSpanRunListRows(rows []*sqlc.GetRunsRow, arg db.GetRunsParams) ([]*db.R
 		if arg.IncludeOutput && outputText != "" {
 			output = []byte(outputText)
 		}
+		startTime := toTime(r.StartTime)
+		endTime := toTime(r.EndTime)
 
 		out = append(out, &db.RunListItemRow{
 			FunctionRun: db.FunctionRun{
 				RunID:        parsedRunID,
-				RunStartedAt: r.StartTime,
+				RunStartedAt: startTime,
 				FunctionID:   parsedFunctionID,
 				TriggerType:  triggerType,
 				EventID:      arg.EventID,
@@ -405,7 +407,7 @@ func scanSpanRunListRows(rows []*sqlc.GetRunsRow, arg db.GetRunsParams) ([]*db.R
 				RunID:              parsedRunID,
 				Status:             sql.NullString{String: status.String(), Valid: statusText != ""},
 				CompletedStepCount: sql.NullInt64{Int64: 1, Valid: true},
-				CreatedAt:          sql.NullTime{Time: r.EndTime, Valid: enums.RunStatusEnded(status)},
+				CreatedAt:          sql.NullTime{Time: endTime, Valid: enums.RunStatusEnded(status)},
 			},
 			Output:         output,
 			FunctionSlug:   valueString(r.FunctionSlug),

--- a/pkg/db/sqlite/querier_runs_test.go
+++ b/pkg/db/sqlite/querier_runs_test.go
@@ -79,6 +79,77 @@ func TestQuerierGetRuns(t *testing.T) {
 	require.Empty(t, rows[0].Output)
 }
 
+func TestQuerierGetRunsUsesChildSpanSummary(t *testing.T) {
+	ctx := context.Background()
+	conn, err := Open(ctx, Options{ForTest: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	q := New(conn).Q()
+	runID := ulid.Make()
+	eventID := ulid.Make()
+	appID := uuid.New()
+	fnID := uuid.New()
+	startedAt := time.Now().UTC().Truncate(time.Millisecond)
+	childStartedAt := startedAt.Add(50 * time.Millisecond)
+	endedAt := startedAt.Add(time.Second)
+	_, err = q.UpsertApp(ctx, db.UpsertAppParams{
+		ID:          appID,
+		Name:        "event-runs-app",
+		SdkLanguage: "go",
+		SdkVersion:  "1.0.0",
+		Metadata:    "{}",
+		Status:      "active",
+		Checksum:    "checksum",
+		Url:         "https://example.com/inngest",
+		Method:      "POST",
+	})
+	require.NoError(t, err)
+	require.NoError(t, insertRunSpan(ctx, q, runSpan{
+		RunID:        runID,
+		EventIDs:     []ulid.ULID{eventID},
+		AppID:        appID,
+		FunctionID:   fnID,
+		FunctionSlug: "event-runs-function",
+		FunctionName: "Event Runs Function",
+		StartedAt:    startedAt,
+		EndedAt:      startedAt,
+		Status:       enums.StepStatusQueued.String(),
+	}))
+
+	attrs, err := json.Marshal(map[string]any{
+		meta.Attrs.IsFunctionOutput.Key(): true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
+		SpanID:       ulid.Make().String(),
+		TraceID:      "trace-" + runID.String(),
+		Name:         meta.SpanNameExecution,
+		ParentSpanID: sql.NullString{String: "run-span", Valid: true},
+		StartTime:    childStartedAt,
+		EndTime:      endedAt,
+		RunID:        runID.String(),
+		AccountID:    uuid.NewString(),
+		AppID:        appID.String(),
+		FunctionID:   fnID.String(),
+		EnvID:        uuid.NewString(),
+		Attributes:   attrs,
+		Links:        []byte(`[]`),
+		Output:       []byte(`{"data":{"body":"Hello, World!"}}`),
+		Status:       sql.NullString{String: enums.StepStatusCompleted.String(), Valid: true},
+		EventIds:     []byte(`[]`),
+	}))
+
+	rows, err := q.GetRuns(ctx, db.GetRunsParams{EventID: eventID, Limit: 1, IncludeOutput: true})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, childStartedAt, rows[0].FunctionRun.RunStartedAt)
+	require.Equal(t, "Completed", rows[0].FunctionFinish.Status.String)
+	require.True(t, rows[0].FunctionFinish.CreatedAt.Valid)
+	require.Equal(t, endedAt, rows[0].FunctionFinish.CreatedAt.Time)
+	require.JSONEq(t, `{"data":{"body":"Hello, World!"}}`, string(rows[0].Output))
+}
+
 func TestQuerierGetRunsError(t *testing.T) {
 	ctx := context.Background()
 	conn, err := Open(ctx, Options{ForTest: true})

--- a/pkg/db/sqlite/sqlc/queries.sql
+++ b/pkg/db/sqlite/sqlc/queries.sql
@@ -174,63 +174,80 @@ LEFT JOIN function_finishes ON function_finishes.run_id = function_runs.run_id
 WHERE function_runs.event_id IN (sqlc.slice('event_ids'));
 
 -- name: GetRuns :many
+WITH run_roots AS (
+  SELECT
+    spans.run_id,
+    spans.function_id,
+    spans.app_id,
+    CAST(COALESCE((
+      SELECT start_lookup.start_time
+      FROM spans start_lookup
+      WHERE start_lookup.run_id = spans.run_id
+        AND start_lookup.debug_run_id IS NULL
+        AND start_lookup.parent_span_id IS NOT NULL
+        AND start_lookup.parent_span_id <> ''
+        AND start_lookup.parent_span_id <> '0000000000000000'
+      ORDER BY start_lookup.start_time
+      LIMIT 1
+    ), spans.start_time) AS TEXT) AS start_time,
+    spans.end_time AS root_end_time,
+    spans.status AS root_status,
+    CAST(spans.output AS TEXT) AS root_output,
+    COALESCE(spans.attributes->>'$."_inngest.function.slug"', '') AS function_slug,
+    COALESCE(spans.attributes->>'$."_inngest.function.name"', '') AS function_name,
+    COALESCE(apps.name, '') AS app_name,
+    COALESCE(spans.attributes->>'$."_inngest.batch.id"', '') AS batch_id,
+    COALESCE(spans.attributes->>'$."_inngest.cron.schedule"', '') AS cron_schedule
+  FROM spans
+  LEFT JOIN apps ON apps.id = spans.app_id AND apps.archived_at IS NULL
+  WHERE spans.name = @name
+    AND spans.debug_run_id IS NULL
+    AND spans.run_id > @cursor_run_id
+    AND INSTR(CAST(spans.event_ids AS TEXT), @event_id) > 0
+  ORDER BY spans.run_id
+  LIMIT @limit_rows
+),
+run_status AS (
+  SELECT run_id, status, end_time
+  FROM (
+    SELECT
+      status_spans.run_id,
+      status_spans.status,
+      status_spans.end_time,
+      ROW_NUMBER() OVER (PARTITION BY status_spans.run_id ORDER BY status_spans.end_time DESC) AS rn
+    FROM spans status_spans
+    JOIN run_roots ON run_roots.run_id = status_spans.run_id
+    WHERE status_spans.debug_run_id IS NULL
+      AND status_spans.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
+  )
+  WHERE rn = 1
+)
 SELECT
-  spans.run_id,
-  spans.function_id,
-  spans.app_id,
-  CAST(COALESCE((
-    SELECT start_lookup.start_time
-    FROM spans start_lookup
-    WHERE start_lookup.run_id = spans.run_id
-      AND start_lookup.debug_run_id IS NULL
-      AND start_lookup.parent_span_id IS NOT NULL
-      AND start_lookup.parent_span_id <> ''
-      AND start_lookup.parent_span_id <> '0000000000000000'
-    ORDER BY start_lookup.start_time
-    LIMIT 1
-  ), spans.start_time) AS TEXT) AS start_time,
-  CAST(COALESCE((
-    SELECT status_lookup.end_time
-    FROM spans status_lookup
-    WHERE status_lookup.run_id = spans.run_id
-      AND status_lookup.debug_run_id IS NULL
-      AND status_lookup.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
-    ORDER BY status_lookup.end_time DESC
-    LIMIT 1
-  ), spans.end_time) AS TEXT) AS end_time,
-  COALESCE((
-    SELECT status_lookup.status
-    FROM spans status_lookup
-    WHERE status_lookup.run_id = spans.run_id
-      AND status_lookup.debug_run_id IS NULL
-      AND status_lookup.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
-    ORDER BY status_lookup.end_time DESC
-    LIMIT 1
-  ), spans.status, '') AS status,
+  run_roots.run_id,
+  run_roots.function_id,
+  run_roots.app_id,
+  run_roots.start_time,
+  CAST(COALESCE(run_status.end_time, run_roots.root_end_time) AS TEXT) AS end_time,
+  COALESCE(run_status.status, run_roots.root_status, '') AS status,
   COALESCE((
     SELECT CAST(output_lookup.output AS TEXT)
     FROM spans output_lookup
-    WHERE output_lookup.run_id = spans.run_id
+    WHERE output_lookup.run_id = run_roots.run_id
       AND output_lookup.output IS NOT NULL
       AND output_lookup.debug_run_id IS NULL
     ORDER BY
       CASE WHEN COALESCE(output_lookup.attributes->>'$."_inngest.is.function.output"', '') = 'true' THEN 0 ELSE 1 END,
       output_lookup.end_time DESC
     LIMIT 1
-  ), CAST(spans.output AS TEXT), '') AS output,
-  COALESCE(spans.attributes->>'$."_inngest.function.slug"', '') AS function_slug,
-  COALESCE(spans.attributes->>'$."_inngest.function.name"', '') AS function_name,
-  COALESCE(apps.name, '') AS app_name,
-  COALESCE(spans.attributes->>'$."_inngest.batch.id"', '') AS batch_id,
-  COALESCE(spans.attributes->>'$."_inngest.cron.schedule"', '') AS cron_schedule
-FROM spans
-LEFT JOIN apps ON apps.id = spans.app_id AND apps.archived_at IS NULL
-WHERE spans.name = @name
-  AND spans.debug_run_id IS NULL
-  AND spans.run_id > @cursor_run_id
-  AND INSTR(CAST(spans.event_ids AS TEXT), @event_id) > 0
-ORDER BY spans.run_id
-LIMIT @limit_rows;
+  ), run_roots.root_output, '') AS output,
+  run_roots.function_slug,
+  run_roots.function_name,
+  run_roots.app_name,
+  run_roots.batch_id,
+  run_roots.cron_schedule
+FROM run_roots
+LEFT JOIN run_status ON run_status.run_id = run_roots.run_id
+ORDER BY run_roots.run_id;
 
 -- name: GetFunctionRunFinishesByRunIDs :many
 SELECT * FROM function_finishes WHERE run_id IN (sqlc.slice('run_ids'));

--- a/pkg/db/sqlite/sqlc/queries.sql
+++ b/pkg/db/sqlite/sqlc/queries.sql
@@ -178,10 +178,46 @@ SELECT
   spans.run_id,
   spans.function_id,
   spans.app_id,
-  spans.start_time,
-  spans.end_time,
-  COALESCE(spans.status, '') AS status,
-  COALESCE(CAST(spans.output AS TEXT), '') AS output,
+  CAST(COALESCE((
+    SELECT start_lookup.start_time
+    FROM spans start_lookup
+    WHERE start_lookup.run_id = spans.run_id
+      AND start_lookup.debug_run_id IS NULL
+      AND start_lookup.parent_span_id IS NOT NULL
+      AND start_lookup.parent_span_id <> ''
+      AND start_lookup.parent_span_id <> '0000000000000000'
+    ORDER BY start_lookup.start_time
+    LIMIT 1
+  ), spans.start_time) AS TEXT) AS start_time,
+  CAST(COALESCE((
+    SELECT status_lookup.end_time
+    FROM spans status_lookup
+    WHERE status_lookup.run_id = spans.run_id
+      AND status_lookup.debug_run_id IS NULL
+      AND status_lookup.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
+    ORDER BY status_lookup.end_time DESC
+    LIMIT 1
+  ), spans.end_time) AS TEXT) AS end_time,
+  COALESCE((
+    SELECT status_lookup.status
+    FROM spans status_lookup
+    WHERE status_lookup.run_id = spans.run_id
+      AND status_lookup.debug_run_id IS NULL
+      AND status_lookup.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
+    ORDER BY status_lookup.end_time DESC
+    LIMIT 1
+  ), spans.status, '') AS status,
+  COALESCE((
+    SELECT CAST(output_lookup.output AS TEXT)
+    FROM spans output_lookup
+    WHERE output_lookup.run_id = spans.run_id
+      AND output_lookup.output IS NOT NULL
+      AND output_lookup.debug_run_id IS NULL
+    ORDER BY
+      CASE WHEN COALESCE(output_lookup.attributes->>'$."_inngest.is.function.output"', '') = 'true' THEN 0 ELSE 1 END,
+      output_lookup.end_time DESC
+    LIMIT 1
+  ), CAST(spans.output AS TEXT), '') AS output,
   COALESCE(spans.attributes->>'$."_inngest.function.slug"', '') AS function_slug,
   COALESCE(spans.attributes->>'$."_inngest.function.name"', '') AS function_name,
   COALESCE(apps.name, '') AS app_name,

--- a/pkg/db/sqlite/sqlc/queries.sql.go
+++ b/pkg/db/sqlite/sqlc/queries.sql.go
@@ -1256,10 +1256,46 @@ SELECT
   spans.run_id,
   spans.function_id,
   spans.app_id,
-  spans.start_time,
-  spans.end_time,
-  COALESCE(spans.status, '') AS status,
-  COALESCE(CAST(spans.output AS TEXT), '') AS output,
+  CAST(COALESCE((
+    SELECT start_lookup.start_time
+    FROM spans start_lookup
+    WHERE start_lookup.run_id = spans.run_id
+      AND start_lookup.debug_run_id IS NULL
+      AND start_lookup.parent_span_id IS NOT NULL
+      AND start_lookup.parent_span_id <> ''
+      AND start_lookup.parent_span_id <> '0000000000000000'
+    ORDER BY start_lookup.start_time
+    LIMIT 1
+  ), spans.start_time) AS TEXT) AS start_time,
+  CAST(COALESCE((
+    SELECT status_lookup.end_time
+    FROM spans status_lookup
+    WHERE status_lookup.run_id = spans.run_id
+      AND status_lookup.debug_run_id IS NULL
+      AND status_lookup.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
+    ORDER BY status_lookup.end_time DESC
+    LIMIT 1
+  ), spans.end_time) AS TEXT) AS end_time,
+  COALESCE((
+    SELECT status_lookup.status
+    FROM spans status_lookup
+    WHERE status_lookup.run_id = spans.run_id
+      AND status_lookup.debug_run_id IS NULL
+      AND status_lookup.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
+    ORDER BY status_lookup.end_time DESC
+    LIMIT 1
+  ), spans.status, '') AS status,
+  COALESCE((
+    SELECT CAST(output_lookup.output AS TEXT)
+    FROM spans output_lookup
+    WHERE output_lookup.run_id = spans.run_id
+      AND output_lookup.output IS NOT NULL
+      AND output_lookup.debug_run_id IS NULL
+    ORDER BY
+      CASE WHEN COALESCE(output_lookup.attributes->>'$."_inngest.is.function.output"', '') = 'true' THEN 0 ELSE 1 END,
+      output_lookup.end_time DESC
+    LIMIT 1
+  ), CAST(spans.output AS TEXT), '') AS output,
   COALESCE(spans.attributes->>'$."_inngest.function.slug"', '') AS function_slug,
   COALESCE(spans.attributes->>'$."_inngest.function.name"', '') AS function_name,
   COALESCE(apps.name, '') AS app_name,
@@ -1286,8 +1322,8 @@ type GetRunsRow struct {
 	RunID        string
 	FunctionID   string
 	AppID        string
-	StartTime    time.Time
-	EndTime      time.Time
+	StartTime    string
+	EndTime      string
 	Status       string
 	Output       interface{}
 	FunctionSlug interface{}

--- a/pkg/db/sqlite/sqlc/queries.sql.go
+++ b/pkg/db/sqlite/sqlc/queries.sql.go
@@ -1252,63 +1252,80 @@ func (q *Queries) GetRunSpanByRunID(ctx context.Context, arg GetRunSpanByRunIDPa
 }
 
 const getRuns = `-- name: GetRuns :many
+WITH run_roots AS (
+  SELECT
+    spans.run_id,
+    spans.function_id,
+    spans.app_id,
+    CAST(COALESCE((
+      SELECT start_lookup.start_time
+      FROM spans start_lookup
+      WHERE start_lookup.run_id = spans.run_id
+        AND start_lookup.debug_run_id IS NULL
+        AND start_lookup.parent_span_id IS NOT NULL
+        AND start_lookup.parent_span_id <> ''
+        AND start_lookup.parent_span_id <> '0000000000000000'
+      ORDER BY start_lookup.start_time
+      LIMIT 1
+    ), spans.start_time) AS TEXT) AS start_time,
+    spans.end_time AS root_end_time,
+    spans.status AS root_status,
+    CAST(spans.output AS TEXT) AS root_output,
+    COALESCE(spans.attributes->>'$."_inngest.function.slug"', '') AS function_slug,
+    COALESCE(spans.attributes->>'$."_inngest.function.name"', '') AS function_name,
+    COALESCE(apps.name, '') AS app_name,
+    COALESCE(spans.attributes->>'$."_inngest.batch.id"', '') AS batch_id,
+    COALESCE(spans.attributes->>'$."_inngest.cron.schedule"', '') AS cron_schedule
+  FROM spans
+  LEFT JOIN apps ON apps.id = spans.app_id AND apps.archived_at IS NULL
+  WHERE spans.name = ?1
+    AND spans.debug_run_id IS NULL
+    AND spans.run_id > ?2
+    AND INSTR(CAST(spans.event_ids AS TEXT), ?3) > 0
+  ORDER BY spans.run_id
+  LIMIT ?4
+),
+run_status AS (
+  SELECT run_id, status, end_time
+  FROM (
+    SELECT
+      status_spans.run_id,
+      status_spans.status,
+      status_spans.end_time,
+      ROW_NUMBER() OVER (PARTITION BY status_spans.run_id ORDER BY status_spans.end_time DESC) AS rn
+    FROM spans status_spans
+    JOIN run_roots ON run_roots.run_id = status_spans.run_id
+    WHERE status_spans.debug_run_id IS NULL
+      AND status_spans.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
+  )
+  WHERE rn = 1
+)
 SELECT
-  spans.run_id,
-  spans.function_id,
-  spans.app_id,
-  CAST(COALESCE((
-    SELECT start_lookup.start_time
-    FROM spans start_lookup
-    WHERE start_lookup.run_id = spans.run_id
-      AND start_lookup.debug_run_id IS NULL
-      AND start_lookup.parent_span_id IS NOT NULL
-      AND start_lookup.parent_span_id <> ''
-      AND start_lookup.parent_span_id <> '0000000000000000'
-    ORDER BY start_lookup.start_time
-    LIMIT 1
-  ), spans.start_time) AS TEXT) AS start_time,
-  CAST(COALESCE((
-    SELECT status_lookup.end_time
-    FROM spans status_lookup
-    WHERE status_lookup.run_id = spans.run_id
-      AND status_lookup.debug_run_id IS NULL
-      AND status_lookup.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
-    ORDER BY status_lookup.end_time DESC
-    LIMIT 1
-  ), spans.end_time) AS TEXT) AS end_time,
-  COALESCE((
-    SELECT status_lookup.status
-    FROM spans status_lookup
-    WHERE status_lookup.run_id = spans.run_id
-      AND status_lookup.debug_run_id IS NULL
-      AND status_lookup.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
-    ORDER BY status_lookup.end_time DESC
-    LIMIT 1
-  ), spans.status, '') AS status,
+  run_roots.run_id,
+  run_roots.function_id,
+  run_roots.app_id,
+  run_roots.start_time,
+  CAST(COALESCE(run_status.end_time, run_roots.root_end_time) AS TEXT) AS end_time,
+  COALESCE(run_status.status, run_roots.root_status, '') AS status,
   COALESCE((
     SELECT CAST(output_lookup.output AS TEXT)
     FROM spans output_lookup
-    WHERE output_lookup.run_id = spans.run_id
+    WHERE output_lookup.run_id = run_roots.run_id
       AND output_lookup.output IS NOT NULL
       AND output_lookup.debug_run_id IS NULL
     ORDER BY
       CASE WHEN COALESCE(output_lookup.attributes->>'$."_inngest.is.function.output"', '') = 'true' THEN 0 ELSE 1 END,
       output_lookup.end_time DESC
     LIMIT 1
-  ), CAST(spans.output AS TEXT), '') AS output,
-  COALESCE(spans.attributes->>'$."_inngest.function.slug"', '') AS function_slug,
-  COALESCE(spans.attributes->>'$."_inngest.function.name"', '') AS function_name,
-  COALESCE(apps.name, '') AS app_name,
-  COALESCE(spans.attributes->>'$."_inngest.batch.id"', '') AS batch_id,
-  COALESCE(spans.attributes->>'$."_inngest.cron.schedule"', '') AS cron_schedule
-FROM spans
-LEFT JOIN apps ON apps.id = spans.app_id AND apps.archived_at IS NULL
-WHERE spans.name = ?1
-  AND spans.debug_run_id IS NULL
-  AND spans.run_id > ?2
-  AND INSTR(CAST(spans.event_ids AS TEXT), ?3) > 0
-ORDER BY spans.run_id
-LIMIT ?4
+  ), run_roots.root_output, '') AS output,
+  run_roots.function_slug,
+  run_roots.function_name,
+  run_roots.app_name,
+  run_roots.batch_id,
+  run_roots.cron_schedule
+FROM run_roots
+LEFT JOIN run_status ON run_status.run_id = run_roots.run_id
+ORDER BY run_roots.run_id
 `
 
 type GetRunsParams struct {
@@ -1325,7 +1342,7 @@ type GetRunsRow struct {
 	StartTime    string
 	EndTime      string
 	Status       string
-	Output       interface{}
+	Output       string
 	FunctionSlug interface{}
 	FunctionName interface{}
 	AppName      string


### PR DESCRIPTION
## Description

I used the latest (v2) span structures for the new v2 event/runs but did not use all the associated gql rollup code so we lost some attributes. that code is not super easy to break apart and extract what we need to so I'm just grabbing the stuff we need directly in the sql to keep it simple.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
