### PR TITLE
feat: promote api cli, add redirect message and beta tag

### DIFF
--- a/cmd/alpha.go
+++ b/cmd/alpha.go
@@ -14,7 +14,7 @@ func alpha() *cli.Command {
 		Hidden: true,
 		Usage:  "experimental CLI commands",
 		Commands: []*cli.Command{
-			apiv2cli.Command(),
+			apiv2cli.MovedCommand(),
 			conformance.Command(),
 			debug.Command(),
 			doctor.Command(),

--- a/cmd/apiv2cli/cmd.go
+++ b/cmd/apiv2cli/cmd.go
@@ -58,14 +58,28 @@ type endpoint struct {
 func Command() *cli.Command {
 	return &cli.Command{
 		Name:      "api",
-		Usage:     "Call Inngest REST API v2 endpoints",
-		UsageText: "inngest alpha api [target/auth flags] <endpoint> [endpoint flags]",
+		Usage:     "Call Inngest REST API v2 endpoints (beta)",
+		UsageText: "inngest api [target/auth flags] <endpoint> [endpoint flags]",
 		Description: strings.Join([]string{
+			"Beta: this command is under active development and may change.",
 			"By default, the command targets the local dev server.",
 			"Set --prod to target Inngest Cloud Production, or --api-host/--api-port to target a custom API server.",
 		}, "\n"),
 		Flags:    commonFlags(),
 		Commands: endpointCommands(),
+	}
+}
+
+func MovedCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "api",
+		Usage:       "Moved to inngest api",
+		UsageText:   "inngest alpha api",
+		Description: "The alpha api command has moved. Use `inngest api` instead.",
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			_, err := fmt.Fprintln(cmd.Root().Writer, "The alpha api command has moved. Use `inngest api` instead.")
+			return err
+		},
 	}
 }
 
@@ -150,7 +164,7 @@ func endpointUsageText(ep endpoint) string {
 	for _, name := range ep.pathParams {
 		fmt.Fprintf(&positional, " [<%s>]", kebab(name))
 	}
-	return fmt.Sprintf("inngest alpha api [target/auth flags] %s%s [endpoint flags]", ep.name, positional.String())
+	return fmt.Sprintf("inngest api [target/auth flags] %s%s [endpoint flags]", ep.name, positional.String())
 }
 
 func endpointArguments(ep endpoint) []cli.Argument {

--- a/cmd/apiv2cli/cmd_test.go
+++ b/cmd/apiv2cli/cmd_test.go
@@ -46,6 +46,36 @@ func TestEndpointCommandNameNormalizesReadVerbs(t *testing.T) {
 	require.Equal(t, "create-env", endpointCommandName("CreateEnv"))
 }
 
+func TestCommandHelpUsesTopLevelAPIAndBetaLabel(t *testing.T) {
+	cmd := Command()
+	out := bytes.Buffer{}
+	cmd.Writer = &out
+
+	err := cmd.Run(context.Background(), []string{
+		"api",
+		"--help",
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "inngest api [target/auth flags] <endpoint> [endpoint flags]")
+	require.Contains(t, out.String(), "Call Inngest REST API v2 endpoints (beta)")
+	require.Contains(t, out.String(), "Beta: this command is under active development and may change.")
+	require.NotContains(t, out.String(), "inngest alpha api [target/auth flags]")
+}
+
+func TestMovedCommandTellsUsersToUseTopLevelAPI(t *testing.T) {
+	cmd := MovedCommand()
+	out := bytes.Buffer{}
+	cmd.Writer = &out
+
+	err := cmd.Run(context.Background(), []string{
+		"api",
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "The alpha api command has moved. Use `inngest api` instead.")
+}
+
 func TestEndpointCommandsIncludeOperationAndInheritedFlagHelp(t *testing.T) {
 	var invoke *cli.Command
 	for _, cmd := range endpointCommands() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/inngest/inngest/cmd/apiv2cli"
 	"github.com/inngest/inngest/cmd/devserver"
 	"github.com/inngest/inngest/cmd/start"
 	"github.com/inngest/inngest/cmd/version"
@@ -93,6 +94,7 @@ func execute() {
 
 		Flags: globalFlags,
 		Commands: []*cli.Command{
+			apiv2cli.Command(),
 			devserver.Command(),
 			version.Command(),
 			start.Command(),


### PR DESCRIPTION
## Description

Take it out alpha, redirect any existing users who might try to use it on alpha:

```
NAME:
   inngest alpha api - Moved to inngest api

USAGE:
   inngest alpha api

DESCRIPTION:
   The alpha api command has moved. Use `inngest api` instead.
```

and mark it as beta:

```
NAME:
   inngest api - Call Inngest REST API v2 endpoints (beta)

USAGE:
   inngest api [target/auth flags] <endpoint> [endpoint flags]

DESCRIPTION:
   Beta: this command is under active development and may change.
   By default, the command targets the local dev server.
   Set --prod to target Inngest Cloud Production, or --api-host/--api-port to target a custom API server.
```

## Release note

The API CLI has moved out of alpha and is now available as a top-level beta command:

`npx inngest-cli@latest api --help`

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
