### PR TITLE
chore: update v2 /runs to use latest trace span structures

### DIFF
--- a/pkg/devserver/agentic_api_adapters_test.go
+++ b/pkg/devserver/agentic_api_adapters_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	apiv2 "github.com/inngest/inngest/pkg/api/v2"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 )
@@ -45,6 +48,36 @@ func TestNewFunctionProvider(t *testing.T) {
 	require.Equal(t, consts.DevServerEnvID, fn.EnvironmentID)
 	require.Equal(t, "Test function", fn.Function.Name)
 	require.Equal(t, "test-fn", fn.Function.Slug)
+}
+
+func TestNewFunctionProviderFindsArchivedFunctionByID(t *testing.T) {
+	ctx := context.Background()
+	fnID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	appID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	store := &fakeFunctionStore{
+		fnByID: map[uuid.UUID]*cqrs.Function{
+			fnID: {
+				ID:         fnID,
+				AppID:      appID,
+				Slug:       "app-cron-fn",
+				Config:     []byte(`{"name":"Cron function","slug":"cron-fn"}`),
+				ArchivedAt: time.Now().Add(-time.Minute),
+			},
+		},
+		app: &cqrs.App{
+			ID:   appID,
+			Name: "app",
+		},
+	}
+
+	fn, err := NewFunctionProvider(store).GetFunction(ctx, fnID.String())
+
+	require.NoError(t, err)
+	require.Equal(t, fnID, fn.ID)
+	require.Equal(t, "app-cron-fn", fn.Slug)
+	require.Equal(t, "app", fn.AppName)
+	require.Equal(t, "Cron function", fn.Function.Name)
+	require.Equal(t, "cron-fn", fn.Function.Slug)
 }
 
 func TestNewFunctionProviderErrors(t *testing.T) {
@@ -86,15 +119,38 @@ func TestNewFunctionProviderErrors(t *testing.T) {
 
 func TestFunctionRunReader(t *testing.T) {
 	runID := ulid.MustParse("01hp1zx8m3ng9vp6qn0xk7j4cy")
-	run := &cqrs.FunctionRun{RunID: runID}
-	reader := &fakeFunctionRunReader{run: run}
+	eventID := ulid.MustParse("01hp1zx8m3ng9vp6qn0xk7j4cz")
+	functionID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	startedAt := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	endedAt := startedAt.Add(500 * time.Millisecond)
+	status := enums.StepStatusCompleted
+	eventIDs := []string{eventID.String()}
+	root := &cqrs.OtelSpan{
+		RawOtelSpan: cqrs.RawOtelSpan{
+			Name:      meta.SpanNameRun,
+			StartTime: startedAt.Add(-100 * time.Millisecond),
+		},
+		RunID:      runID,
+		FunctionID: functionID,
+		Status:     status,
+		Attributes: &meta.ExtractedValues{
+			DynamicStatus: &status,
+			EventIDs:      &eventIDs,
+			StartedAt:     &startedAt,
+			EndedAt:       &endedAt,
+		},
+	}
+	reader := &fakeTraceReader{root: root}
 
 	result, err := NewFunctionRunReader(reader).GetFunctionRun(context.Background(), runID, apiv2.GetFunctionRunOpts{})
 
 	require.NoError(t, err)
-	require.Equal(t, run, result)
-	require.Equal(t, consts.DevServerAccountID, reader.accountID)
-	require.Equal(t, consts.DevServerEnvID, reader.workspaceID)
+	require.Equal(t, runID, result.RunID)
+	require.Equal(t, functionID, result.FunctionID)
+	require.Equal(t, eventID, result.EventID)
+	require.Equal(t, enums.RunStatusCompleted, result.Status)
+	require.Equal(t, startedAt, result.RunStartedAt)
+	require.Equal(t, &endedAt, result.EndedAt)
 	require.Equal(t, runID, reader.runID)
 }
 
@@ -118,13 +174,42 @@ func TestFunctionTraceReader(t *testing.T) {
 }
 
 type fakeFunctionStore struct {
-	fns []*cqrs.Function
-	app *cqrs.App
-	err error
+	fns    []*cqrs.Function
+	fnByID map[uuid.UUID]*cqrs.Function
+	app    *cqrs.App
+	err    error
 }
 
 func (f *fakeFunctionStore) GetFunctions(ctx context.Context) ([]*cqrs.Function, error) {
 	return f.fns, f.err
+}
+
+func (f *fakeFunctionStore) GetFunctionsByAppExternalID(ctx context.Context, workspaceID uuid.UUID, app string) ([]*cqrs.Function, error) {
+	return nil, nil
+}
+
+func (f *fakeFunctionStore) GetFunctionsByAppInternalID(ctx context.Context, appID uuid.UUID) ([]*cqrs.Function, error) {
+	return nil, nil
+}
+
+func (f *fakeFunctionStore) GetFunctionByExternalID(ctx context.Context, wsID uuid.UUID, appID string, functionID string) (*cqrs.Function, error) {
+	return nil, nil
+}
+
+func (f *fakeFunctionStore) GetFunctionByInternalUUID(ctx context.Context, fnID uuid.UUID) (*cqrs.Function, error) {
+	if fn, ok := f.fnByID[fnID]; ok {
+		return fn, nil
+	}
+	for _, fn := range f.fns {
+		if fn.ID == fnID {
+			return fn, nil
+		}
+	}
+	return nil, errors.New("function not found")
+}
+
+func (f *fakeFunctionStore) GetActiveFunctionByAppAndSlug(ctx context.Context, appName string, slug string) (*cqrs.Function, error) {
+	return nil, nil
 }
 
 func (f *fakeFunctionStore) GetApps(ctx context.Context, envID uuid.UUID, filter *cqrs.FilterAppParam) ([]*cqrs.App, error) {
@@ -152,24 +237,6 @@ func (f *fakeFunctionStore) GetAppByID(ctx context.Context, id uuid.UUID) (*cqrs
 		return nil, errors.New("app not found")
 	}
 	return f.app, nil
-}
-
-type fakeFunctionRunReader struct {
-	run         *cqrs.FunctionRun
-	accountID   uuid.UUID
-	workspaceID uuid.UUID
-	runID       ulid.ULID
-}
-
-func (f *fakeFunctionRunReader) GetFunctionRunsFromEvents(ctx context.Context, accountID uuid.UUID, workspaceID uuid.UUID, eventIDs []ulid.ULID) ([]*cqrs.FunctionRun, error) {
-	return nil, nil
-}
-
-func (f *fakeFunctionRunReader) GetFunctionRun(ctx context.Context, accountID uuid.UUID, workspaceID uuid.UUID, runID ulid.ULID) (*cqrs.FunctionRun, error) {
-	f.accountID = accountID
-	f.workspaceID = workspaceID
-	f.runID = runID
-	return f.run, nil
 }
 
 type fakeTraceReader struct {

--- a/pkg/devserver/function_provider.go
+++ b/pkg/devserver/function_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
 	apiv2 "github.com/inngest/inngest/pkg/api/v2"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/cqrs"
@@ -30,33 +31,45 @@ func NewFunctionProvider(reader cqrs.DevFunctionReader) apiv2.FunctionProvider {
 }
 
 func (p *cqrsFunctionProvider) GetFunction(ctx context.Context, identifier string) (inngest.DeployedFunction, error) {
+	if fnID, err := uuid.Parse(identifier); err == nil {
+		if reader, ok := p.reader.(cqrs.FunctionReader); ok {
+			if fn, err := reader.GetFunctionByInternalUUID(ctx, fnID); err == nil {
+				return p.toDeployedFunction(ctx, fn)
+			}
+		}
+	}
+
 	fns, err := p.reader.GetFunctions(ctx)
 	if err != nil {
 		return inngest.DeployedFunction{}, err
 	}
 	for _, fn := range fns {
 		if fn.Slug == identifier || fn.ID.String() == identifier {
-			inngestFn, err := fn.InngestFunction()
-			if err != nil {
-				return inngest.DeployedFunction{}, err
-			}
-			appName := ""
-			if p.apps != nil {
-				if app, err := p.apps.GetAppByID(ctx, fn.AppID); err == nil {
-					appName = app.Name
-				}
-			}
-
-			return inngest.DeployedFunction{
-				ID:            fn.ID,
-				Slug:          fn.Slug,
-				AppID:         fn.AppID,
-				AppName:       appName,
-				AccountID:     consts.DevServerAccountID,
-				EnvironmentID: consts.DevServerEnvID,
-				Function:      *inngestFn,
-			}, nil
+			return p.toDeployedFunction(ctx, fn)
 		}
 	}
 	return inngest.DeployedFunction{}, fmt.Errorf("function not found: %s", identifier)
+}
+
+func (p *cqrsFunctionProvider) toDeployedFunction(ctx context.Context, fn *cqrs.Function) (inngest.DeployedFunction, error) {
+	inngestFn, err := fn.InngestFunction()
+	if err != nil {
+		return inngest.DeployedFunction{}, err
+	}
+	appName := ""
+	if p.apps != nil {
+		if app, err := p.apps.GetAppByID(ctx, fn.AppID); err == nil {
+			appName = app.Name
+		}
+	}
+
+	return inngest.DeployedFunction{
+		ID:            fn.ID,
+		Slug:          fn.Slug,
+		AppID:         fn.AppID,
+		AppName:       appName,
+		AccountID:     consts.DevServerAccountID,
+		EnvironmentID: consts.DevServerEnvID,
+		Function:      *inngestFn,
+	}, nil
 }

--- a/pkg/devserver/function_run_reader.go
+++ b/pkg/devserver/function_run_reader.go
@@ -2,21 +2,89 @@ package devserver
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	apiv2 "github.com/inngest/inngest/pkg/api/v2"
-	"github.com/inngest/inngest/pkg/consts"
+	loader "github.com/inngest/inngest/pkg/coreapi/graph/loaders"
 	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/oklog/ulid/v2"
 )
 
-type cqrsFunctionRunReader struct {
-	reader cqrs.APIV1FunctionRunReader
+type spanFunctionRunReader struct {
+	reader spanRunReader
 }
 
-func NewFunctionRunReader(reader cqrs.APIV1FunctionRunReader) apiv2.FunctionRunReader {
-	return &cqrsFunctionRunReader{reader: reader}
+type spanRunReader interface {
+	GetSpansByRunID(ctx context.Context, runID ulid.ULID) (*cqrs.OtelSpan, error)
 }
 
-func (r *cqrsFunctionRunReader) GetFunctionRun(ctx context.Context, runID ulid.ULID, _ apiv2.GetFunctionRunOpts) (*cqrs.FunctionRun, error) {
-	return r.reader.GetFunctionRun(ctx, consts.DevServerAccountID, consts.DevServerEnvID, runID)
+func NewFunctionRunReader(reader spanRunReader) apiv2.FunctionRunReader {
+	return &spanFunctionRunReader{reader: reader}
+}
+
+func (r *spanFunctionRunReader) GetFunctionRun(ctx context.Context, runID ulid.ULID, _ apiv2.GetFunctionRunOpts) (*cqrs.FunctionRun, error) {
+	root, err := r.reader.GetSpansByRunID(ctx, runID)
+	if err != nil {
+		return nil, err
+	}
+	if root == nil {
+		return nil, errors.New("run not found")
+	}
+	if root.Attributes == nil {
+		root.Attributes = &meta.ExtractedValues{}
+	}
+
+	span, err := loader.ConvertRunSpan(ctx, root)
+	if err != nil {
+		return nil, fmt.Errorf("error converting run span: %w", err)
+	}
+
+	eventID, err := runEventID(root)
+	if err != nil {
+		return nil, err
+	}
+
+	startedAt := root.StartTime
+	if span.StartedAt != nil {
+		startedAt = *span.StartedAt
+	}
+
+	status := enums.RunStatusRunning
+	if root.Status != enums.StepStatusUnknown {
+		status = enums.StepStatusToRunStatus(root.Status)
+	}
+
+	run := &cqrs.FunctionRun{
+		RunID:        runID,
+		RunStartedAt: startedAt,
+		FunctionID:   root.GetFunctionID(),
+		EventID:      eventID,
+		Status:       status,
+		EndedAt:      span.EndedAt,
+	}
+
+	if root.Attributes.BatchID != nil {
+		run.BatchID = root.Attributes.BatchID
+	}
+	if root.Attributes.CronSchedule != nil {
+		run.Cron = root.Attributes.CronSchedule
+	}
+
+	return run, nil
+}
+
+func runEventID(root *cqrs.OtelSpan) (ulid.ULID, error) {
+	if root.Attributes == nil || root.Attributes.EventIDs == nil || len(*root.Attributes.EventIDs) == 0 {
+		return ulid.Zero, errors.New("run span missing event ID")
+	}
+
+	eventID, err := ulid.Parse((*root.Attributes.EventIDs)[0])
+	if err != nil {
+		return ulid.Zero, fmt.Errorf("invalid run event ID: %w", err)
+	}
+
+	return eventID, nil
 }


### PR DESCRIPTION
## Description

minor cleanup, v2 /runs was touching v1 trace stuff. this makes it use the latest.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
