### PR TITLE
fix(debounce): Preserve TTL from DebounceUpdate

### DIFF
--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -795,8 +795,14 @@ func (d debouncer) updateDebounce(ctx context.Context, di DebounceItem, fn innge
 		// The queue item is not found with the debounceID
 		// enqueue a new item
 		qi := d.queueItem(ctx, di, debounceID)
+		// Some queue shards can preserve the debounce's max-timeout cap even
+		// when the timeout job is missing, and return the capped TTL here.
+		actualTTL := ttl
+		if newTTL > 0 {
+			actualTTL = time.Second * time.Duration(newTTL)
+		}
 
-		return d.queue.Enqueue(ctx, qi, now.Add(ttl).Add(buffer).Add(time.Second), queue.EnqueueOpts{
+		return d.queue.Enqueue(ctx, qi, now.Add(actualTTL).Add(buffer).Add(time.Second), queue.EnqueueOpts{
 			// Debounce timeout items must live on the same Redis instance as the state.
 			ForceQueueShardName: queueShard.Name(),
 		})

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -181,7 +181,8 @@ const (
 	// the debounce; the caller should drop the update.
 	DebounceUpdateOutOfOrder
 	// DebounceUpdateNotFound indicates the timeout queue item is missing;
-	// the caller should enqueue a fresh timeout job.
+	// the caller should enqueue a fresh timeout job. Implementations may
+	// return ttlSeconds when they can preserve the debounce's capped timeout.
 	DebounceUpdateNotFound
 )
 


### PR DESCRIPTION
## Description

This PR extends updateDebounce to preserve the TTL returned in the item not found case. This works as the debounce item may still exist and store the TTL.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
