### PR TITLE
fix: prevent non-admin users from changing plan in UI and give helper text

### DIFF
--- a/ui/apps/dashboard/src/components/Billing/Plans/UpgradeButton.tsx
+++ b/ui/apps/dashboard/src/components/Billing/Plans/UpgradeButton.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
-import { useRouter } from '@tanstack/react-router';
+import { useOrganization } from '@clerk/tanstack-react-start';
 import { Button } from '@inngest/components/Button';
+import { useRouter } from '@tanstack/react-router';
 import { toast } from 'sonner';
 
 import CheckoutModal, {
@@ -32,6 +33,8 @@ export default function UpgradeButton({
   label?: string;
 }) {
   const router = useRouter();
+  const { isLoaded: orgLoaded, membership } = useOrganization();
+  const canChangePlan = orgLoaded && membership?.role === 'org:admin';
   const [checkoutData, setCheckoutData] = useState<{
     action: 'upgrade' | 'downgrade' | 'cancel';
     items: CheckoutItem[];
@@ -110,14 +113,14 @@ export default function UpgradeButton({
       <Button
         className="w-full"
         label={buttonLabel}
-        disabled={isActive}
+        disabled={isActive || !canChangePlan}
         href={
-          isEnterpriseCard && !isActive
+          isEnterpriseCard && !isActive && canChangePlan
             ? pathCreator.support({ ref: 'app-billing-plans-enterprise' })
             : undefined
         }
         onClick={() => {
-          if (isActive || isEnterpriseCard) return;
+          if (isActive || isEnterpriseCard || !canChangePlan) return;
           onClickChangePlan({
             action: isFreeCard
               ? 'cancel'

--- a/ui/apps/dashboard/src/routes/_authed/billing/plans/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/billing/plans/index.tsx
@@ -1,3 +1,5 @@
+import { useOrganization } from '@clerk/tanstack-react-start';
+import { Alert } from '@inngest/components/Alert';
 import { Link } from '@inngest/components/Link';
 import { createFileRoute } from '@tanstack/react-router';
 
@@ -24,6 +26,8 @@ export const Route = createFileRoute('/_authed/billing/plans/')({
 
 function BillingPlansPage() {
   const { currentPlan } = Route.useLoaderData();
+  const { isLoaded: orgLoaded, membership } = useOrganization();
+  const isAdmin = membership?.role === 'org:admin';
 
   const refetchCurrentPlan = async () => {
     return await getCurrentPlan();
@@ -78,6 +82,12 @@ function BillingPlansPage() {
 
   return (
     <>
+      {orgLoaded && !isAdmin && (
+        <Alert severity="info" showIcon className="mb-8">
+          Only organization admins can change your plan. Ask an admin to upgrade
+          your account.
+        </Alert>
+      )}
       {currentPlan.isLegacy && (
         <div className="mb-8">
           <HorizontalPlanCard


### PR DESCRIPTION
## Description

On plan page, disable buttons and add banner for non-admin users.
<img width="1780" height="1196" alt="image" src="https://github.com/user-attachments/assets/cfed841e-a51f-41f3-81b3-ffac4517d4b1" />

## Release note

None.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
