### PR TITLE
refactor: Refactor tel package to remove noise

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,9 +75,7 @@ func execute() {
 				}
 			}
 
-			m := tel.NewMetadata(ctx)
-			m.SetCliContext(cmd)
-			tel.SendMetadata(ctx, m)
+			tel.SendCmdExecutedEvent(ctx, cmd)
 
 			// Best-effort background refresh of the cached "latest version"
 			// record. Dedup'd by the cache TTL, so cheap on every invocation.

--- a/pkg/api/tel/tel.go
+++ b/pkg/api/tel/tel.go
@@ -14,8 +14,8 @@ import (
 )
 
 const (
-	EventName   = "cli/command.executed"
-	CIEventName = "cli/ci.command.executed"
+	CommandExecutedEventName   = "cli/command.executed"
+	CICommandExecutedEventName = "cli/ci.command.executed"
 )
 
 var (
@@ -69,20 +69,16 @@ func NewMetadata(ctx context.Context) *Metadata {
 	}
 }
 
-func (m *Metadata) SetCliContext(cmd *cli.Command) {
+func FormatCommand(cmd *cli.Command) string {
 	// Build command path similar to cobra's CommandPath()
 	cmdPath := "inngest"
 	if cmd != nil && cmd.Args().Len() > 0 {
 		cmdPath += " " + cmd.Args().Get(0)
 	}
-	m.Cmd = cmdPath
+	return cmdPath
 }
 
-func (m *Metadata) Event() inngestgo.Event {
-	name := EventName
-	if isCI() {
-		name = CIEventName
-	}
+func (m *Metadata) Event(name string) inngestgo.Event {
 	return inngestgo.Event{
 		Name: name,
 		Data: map[string]any{
@@ -98,16 +94,26 @@ func (m *Metadata) Event() inngestgo.Event {
 	}
 }
 
-func SendMetadata(ctx context.Context, m *Metadata) {
-	Send(ctx, m.Event())
-}
 func SendEvent(ctx context.Context, name string, m *Metadata) {
 	if isCI() {
 		return
 	}
-	evt := m.Event()
-	evt.Name = name
+	evt := m.Event(name)
 	Send(ctx, evt)
+}
+
+func SendCmdExecutedEvent(ctx context.Context, cmd *cli.Command) {
+	cmdString := FormatCommand(cmd)
+	if cmdString == "" {
+		return
+	}
+	m := NewMetadata(ctx)
+	m.Cmd = cmdString
+	name := CommandExecutedEventName
+	if isCI() {
+		name = CICommandExecutedEventName
+	}
+	Send(ctx, m.Event(name))
 }
 
 func Send(ctx context.Context, e inngestgo.Event) {

--- a/pkg/api/tel/tel.go
+++ b/pkg/api/tel/tel.go
@@ -103,12 +103,8 @@ func SendEvent(ctx context.Context, name string, m *Metadata) {
 }
 
 func SendCmdExecutedEvent(ctx context.Context, cmd *cli.Command) {
-	cmdString := FormatCommand(cmd)
-	if cmdString == "" {
-		return
-	}
 	m := NewMetadata(ctx)
-	m.Cmd = cmdString
+	m.Cmd = FormatCommand(cmd)
 	name := CommandExecutedEventName
 	if isCI() {
 		name = CICommandExecutedEventName

--- a/pkg/coreapi/coreapi.go
+++ b/pkg/coreapi/coreapi.go
@@ -200,8 +200,6 @@ func (a CoreAPI) TrackEvent(w http.ResponseWriter, r *http.Request) {
 	eventName, ok := requestBody["eventName"].(string)
 	if ok {
 		tel.SendEvent(ctx, eventName, metadata)
-	} else {
-		tel.SendMetadata(ctx, metadata)
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/pkg/devserver/api.go
+++ b/pkg/devserver/api.go
@@ -131,7 +131,6 @@ func (a devapi) UI(w http.ResponseWriter, r *http.Request) {
 
 	m := tel.NewMetadata(r.Context())
 	tel.SendEvent(r.Context(), "cli/dev_ui.loaded", m)
-	tel.SendMetadata(r.Context(), m)
 
 	byt := serve(r.Context(), r.URL.Path)
 	_, _ = w.Write(byt)


### PR DESCRIPTION


## Description

Simplify the use of telemetry to avoid sending empty metadata events. This ensures there are no empty "cmd" events which lead to lots of noise.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
