### PR TITLE
fix: preserve debounce migration guard on cleanup failure

### DIFF
--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -738,17 +738,17 @@ func (d debouncer) prepareMigration(ctx context.Context, di DebounceItem, fn inn
 	}, nil
 }
 
-func (d debouncer) completePreparedMigration(ctx context.Context, di DebounceItem, fn inngest.Function, migration *preparedMigration) {
+func (d debouncer) completePreparedMigration(ctx context.Context, di DebounceItem, fn inngest.Function, migration *preparedMigration) error {
 	l := logger.StdlibLogger(ctx).With("debounce_id", migration.debounceID.String())
 
 	secondary, err := d.secondaryShard()
 	if err != nil {
-		l.Error("missing secondary debounce components while completing migration", "err", err)
-		return
+		return fmt.Errorf("missing secondary debounce components while completing migration: %w", err)
 	}
 
+	var cleanupErr error
 	if err := secondary.DebounceDeleteItems(ctx, scopeForDebounceItem(di), migration.debounceID); err != nil {
-		l.Error("unable to delete old debounce after migration", "err", err)
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("unable to delete old debounce after migration: %w", err))
 	}
 
 	queueItemID := queue.HashID(ctx, migration.debounceID.String())
@@ -758,20 +758,24 @@ func (d debouncer) completePreparedMigration(ctx context.Context, di DebounceIte
 		queue.KindDebounce,
 		queueItemID,
 	); err != nil {
-		l.Error("could not remove queue item", "item_id", queueItemID, "err", err)
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("could not remove queue item %s: %w", queueItemID, err))
 	} else {
 		l.Debug("deleted migrated debounce")
 	}
 
+	if cleanupErr != nil {
+		return fmt.Errorf("secondary debounce migration guard left in place because cleanup failed: %w", cleanupErr)
+	}
+
 	if err := secondary.DebounceDeleteMigratingFlag(ctx, scopeForDebounceItem(di), migration.debounceID); err != nil {
-		l.Error("unable to delete debounce migrating flag", "err", err)
+		return fmt.Errorf("unable to delete debounce migrating flag: %w", err)
 	}
 
 	key, err := d.debounceKey(ctx, di, fn)
 	if err != nil {
-		l.Error("unable to compute debounce key while completing migration", "err", err)
+		return fmt.Errorf("unable to compute debounce key while completing migration: %w", err)
 	} else if err := secondary.DebounceDeletePointer(ctx, scopeForDebounceItem(di), key); err != nil {
-		l.Error("unable to delete secondary debounce pointer", "err", err)
+		return fmt.Errorf("unable to delete secondary debounce pointer: %w", err)
 	}
 
 	metrics.IncrQueueDebounceOperationCounter(ctx, metrics.CounterOpt{
@@ -781,6 +785,8 @@ func (d debouncer) completePreparedMigration(ctx context.Context, di DebounceIte
 			"queue_shard": secondary.Name(),
 		},
 	})
+
+	return nil
 }
 
 func (d debouncer) cleanupPreparedMigrationPrimary(ctx context.Context, di DebounceItem, fn inngest.Function, migration *preparedMigration) error {
@@ -899,7 +905,9 @@ func (d debouncer) finalizePreparedMigration(ctx context.Context, di DebounceIte
 	}
 
 	if opErr == nil {
-		d.completePreparedMigration(ctx, di, fn, migration)
+		if err := d.completePreparedMigration(ctx, di, fn, migration); err != nil {
+			return err
+		}
 		return nil
 	}
 
@@ -920,7 +928,9 @@ func (d debouncer) finalizePreparedMigration(ctx context.Context, di DebounceIte
 			"debounce_id", migration.debounceID.String(),
 			"error", opErr,
 		)
-		d.completePreparedMigration(ctx, di, fn, migration)
+		if err := d.completePreparedMigration(ctx, di, fn, migration); err != nil {
+			return fmt.Errorf("primary debounce exists after migration error, but secondary cleanup failed: %w", err)
+		}
 		return nil
 	}
 

--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -53,6 +53,21 @@ func (s *setPointerFailingShard) DebounceDeleteMigratingFlag(ctx context.Context
 	return s.QueueShard.DebounceDeleteMigratingFlag(ctx, scope, debounceID)
 }
 
+type removeQueueItemFailingShard struct {
+	queue.QueueShard
+	err                  error
+	deleteMigratingCalls int
+}
+
+func (s *removeQueueItemFailingShard) RemoveQueueItem(ctx context.Context, scope queue.Scope, partitionID string, itemID string) error {
+	return s.err
+}
+
+func (s *removeQueueItemFailingShard) DebounceDeleteMigratingFlag(ctx context.Context, scope queue.Scope, debounceID ulid.ULID) error {
+	s.deleteMigratingCalls++
+	return s.QueueShard.DebounceDeleteMigratingFlag(ctx, scope, debounceID)
+}
+
 // migrationShardSelector routes system queue items (queueName != nil) to the
 // new system shard and everything else to the default shard.
 func migrationShardSelector(defaultShard, newSystemShard queue.QueueShard) func(ctx context.Context, accountID uuid.UUID, queueName *string) (queue.QueueShard, error) {
@@ -2026,6 +2041,122 @@ func TestFinalizePreparedMigrationCommitsWhenPrimaryReadyAfterError(t *testing.T
 	require.Equal(t, debounceID.String(), primaryPointer)
 	require.NotEmpty(t, primaryCluster.HGet(primaryDebounceClient.KeyGenerator().Debounce(ctx), debounceID.String()))
 	require.NotEmpty(t, primaryCluster.HGet(primaryClient.Queue().KeyGenerator().QueueItem(), queue.HashID(ctx, debounceID.String())))
+}
+
+func TestCompletePreparedMigrationKeepsMigratingFlagWhenSecondaryCleanupFails(t *testing.T) {
+	secondaryCluster := miniredis.RunT(t)
+	primaryCluster := miniredis.RunT(t)
+
+	secondaryRc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{secondaryCluster.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer secondaryRc.Close()
+
+	primaryRc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{primaryCluster.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer primaryRc.Close()
+
+	secondaryClient := redis_state.NewUnshardedClient(secondaryRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
+	primaryClient := redis_state.NewUnshardedClient(primaryRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
+	secondaryDebounceClient := secondaryClient.Debounce()
+
+	fakeClock := clockwork.NewFakeClock()
+	opts := []queue.QueueOpt{
+		queue.WithKindToQueueMapping(map[string]string{
+			queue.KindDebounce: queue.KindDebounce,
+		}),
+		queue.WithClock(fakeClock),
+	}
+
+	secondaryShard := redis_state.NewQueueShard(consts.DefaultQueueShardName, secondaryClient.Queue(), opts...)
+	failingSecondary := &removeQueueItemFailingShard{
+		QueueShard: secondaryShard,
+		err:        errors.New("remove queue item failed"),
+	}
+	primaryShard := redis_state.NewQueueShard("new-system", primaryClient.Queue(), opts...)
+
+	shards, err := queue.NewShardRegistry(
+		migrationShardMap(failingSecondary, primaryShard),
+		queue.WithShardSelector(migrationShardSelector(failingSecondary, primaryShard)),
+		queue.WithPrimary(primaryShard),
+	)
+	require.NoError(t, err)
+
+	q, err := queue.New(context.Background(), "new-queue", shards, opts...)
+	require.NoError(t, err)
+
+	redisDebouncer := debouncer{
+		shards:             shards,
+		primaryShardName:   primaryShard.Name(),
+		secondaryShardName: failingSecondary.Name(),
+		queue:              q,
+		c:                  fakeClock,
+	}
+
+	ctx := context.Background()
+	accountID, workspaceID, appID, functionID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	scope := testScope(accountID, workspaceID, functionID)
+	fn := inngest.Function{
+		ID: functionID,
+		Debounce: &inngest.Debounce{
+			Period:  "10s",
+			Timeout: util.StrPtr("60s"),
+		},
+	}
+	key := functionID.String()
+	debounceID := ulid.MustNew(ulid.Now(), rand.Reader)
+	fakeDebounceID := ulid.MustNew(ulid.Now()+1, rand.Reader)
+	initialTime := fakeClock.Now()
+	di := DebounceItem{
+		AccountID:   accountID,
+		WorkspaceID: workspaceID,
+		AppID:       appID,
+		FunctionID:  functionID,
+		EventID:     ulid.MustNew(ulid.Timestamp(initialTime), rand.Reader),
+		Event: event.Event{
+			Name:      "initial",
+			ID:        "initial-event",
+			Timestamp: initialTime.UnixMilli(),
+		},
+		Timeout: initialTime.Add(time.Minute).UnixMilli(),
+	}
+	item, err := json.Marshal(di)
+	require.NoError(t, err)
+
+	existingID, err := secondaryShard.DebounceCreate(ctx, scope, key, debounceID, item, 10*time.Second)
+	require.NoError(t, err)
+	require.Nil(t, existingID)
+
+	queueItem := redisDebouncer.queueItem(ctx, di, debounceID)
+	err = q.Enqueue(ctx, queueItem, initialTime.Add(10*time.Second), queue.EnqueueOpts{ForceQueueShardName: secondaryShard.Name()})
+	require.NoError(t, err)
+
+	preparedID, timeoutUnixMillis, pointerTTL, err := secondaryShard.DebouncePrepareMigration(ctx, scope, key, fakeDebounceID)
+	require.NoError(t, err)
+	require.NotNil(t, preparedID)
+	require.Equal(t, debounceID, *preparedID)
+
+	createdID, err := redisDebouncer.newDebounce(ctx, di, fn, pointerTTL, true, debounceID)
+	require.NoError(t, err)
+	require.NotNil(t, createdID)
+
+	err = redisDebouncer.finalizePreparedMigration(ctx, di, fn, &preparedMigration{
+		debounceID:       debounceID,
+		timeoutUnixMilli: timeoutUnixMillis,
+		pointerTTL:       pointerTTL,
+	}, nil)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "secondary debounce migration guard left in place")
+	require.Equal(t, 0, failingSecondary.deleteMigratingCalls)
+
+	migratingIDs, err := secondaryCluster.HKeys(secondaryDebounceClient.KeyGenerator().DebounceMigrating(ctx))
+	require.NoError(t, err)
+	require.Contains(t, migratingIDs, debounceID.String())
 }
 
 func TestDebounceMigrationFailurePreservesExistingDebounce(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes a debounce migration cleanup edge case where completion could clear the secondary migration guard even if stale secondary cleanup failed.

- make completePreparedMigration return cleanup errors
- only clear the secondary migrating flag after the old debounce item and timeout queue item are removed
- surface cleanup failure to callers so the guard remains and stale timeout jobs keep aborting
- add a regression test for failed secondary queue-item cleanup preserving the migrating flag

## Testing

- go test ./pkg/execution/debounce -run 'TestCompletePreparedMigrationKeepsMigratingFlagWhenSecondaryCleanupFails|TestFinalizePreparedMigrationCommitsWhenPrimaryReadyAfterError|TestRollbackPreparedMigrationKeepsMigratingFlagWhenPointerRestoreFails' -count=1
- go test ./pkg/execution/debounce -count=1