### PR TITLE
perf(cron): split cron partitions by workspace

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -425,7 +425,9 @@ func start(ctx context.Context, opts StartOpts) error {
 	if err != nil {
 		return fmt.Errorf("could not create debounce manager: %w", err)
 	}
-	croner := cron.NewManager(queueShard, rq, l)
+	croner := cron.NewManager(queueShard, rq, l, cron.WithSplitCronPartitionByWorkspace(func(_ context.Context, _ uuid.UUID) bool {
+		return true
+	}))
 
 	sn := singleton.New(ctx, shardRegistry)
 

--- a/pkg/execution/cron/cron.go
+++ b/pkg/execution/cron/cron.go
@@ -68,6 +68,8 @@ type CronItem struct {
 	AppID           uuid.UUID `json:"appID"`
 	FunctionID      uuid.UUID `json:"fnID"`
 	FunctionVersion int       `json:"fnV"`
+	// IsProductionWorkspace indicates whether this cron belongs to a production workspace.
+	IsProductionWorkspace bool `json:"prodWs,omitempty"`
 	// Expression is the actual cron expression being used
 	Expression string `json:"expr"`
 	// JobID stores queue item ID that's supposed to be handling this cron item.

--- a/pkg/execution/cron/manager.go
+++ b/pkg/execution/cron/manager.go
@@ -36,8 +36,19 @@ type managerOpt struct {
 	jitterMin time.Duration
 	jitterMax time.Duration
 
+	// productionWorkspaceJitter range is used for production workspace cron
+	// items. If unset, it defaults to the standard jitter range.
+	productionWorkspaceJitterMin time.Duration
+	productionWorkspaceJitterMax time.Duration
+	productionWorkspaceJitterSet bool
+
 	healthCheckLeadTimeSeconds int
 	healthCheckInterval        time.Duration
+
+	// splitCronPartitionByWorkspace, when non-nil and returning true for a
+	// given accountID, causes ScheduleNext to enqueue cron jobs to a
+	// workspace-scoped system partition rather than the shared cron partition.
+	splitCronPartitionByWorkspace func(ctx context.Context, accountID uuid.UUID) (enable bool)
 }
 
 func (opts *managerOpt) validate() {
@@ -63,6 +74,19 @@ func WithJitterRange(min time.Duration, max time.Duration) ManagerOpt {
 	}
 }
 
+func WithProductionWorkspaceJitterRange(min time.Duration, max time.Duration) ManagerOpt {
+	return func(c *managerOpt) {
+		if min > max {
+			logger.StdlibLogger(context.Background()).Warn("rejecting invalid production workspace jitter range in managerOpt", "min", min, "max", max)
+			return
+		}
+
+		c.productionWorkspaceJitterMin = min
+		c.productionWorkspaceJitterMax = max
+		c.productionWorkspaceJitterSet = true
+	}
+}
+
 func WithHealthCheckInterval(d time.Duration) ManagerOpt {
 	return func(c *managerOpt) {
 		if d < time.Minute {
@@ -80,6 +104,15 @@ func WithHealthCheckLeadTimeSeconds(leadTime int) ManagerOpt {
 			return
 		}
 		c.healthCheckLeadTimeSeconds = leadTime
+	}
+}
+
+// WithSplitCronPartitionByWorkspace registers a gate that controls whether
+// cron jobs are enqueued to a workspace-scoped system partition
+// (queue.KindCron:<workspaceID>) instead of the single shared cron partition.
+func WithSplitCronPartitionByWorkspace(fn func(ctx context.Context, accountID uuid.UUID) (enable bool)) ManagerOpt {
+	return func(c *managerOpt) {
+		c.splitCronPartitionByWorkspace = fn
 	}
 }
 
@@ -298,25 +331,37 @@ func (c *manager) ScheduleNext(ctx context.Context, ci CronItem) (*CronItem, err
 	// We want only one cron loop to exist for a {FnID, FnVersion, CronExpr} combination. This jobID helps achieve that idempotency.
 	jobID := queue.HashID(ctx, c.CronProcessJobID(next, ci.Expression, ci.FunctionID, ci.FunctionVersion))
 
-	// Add jitter to schedule execution slightly earlier
-	// This ensures execution starts around the desired time
-	jitter := generateJitter(c.opt.jitterMin, c.opt.jitterMax)
+	jitterMin := c.opt.jitterMin
+	jitterMax := c.opt.jitterMax
+	if ci.IsProductionWorkspace && c.opt.productionWorkspaceJitterSet {
+		jitterMin = c.opt.productionWorkspaceJitterMin
+		jitterMax = c.opt.productionWorkspaceJitterMax
+	}
+
+	// Add jitter to schedule execution slightly earlier.
+	// This ensures execution starts around the desired time.
+	jitter := generateJitter(jitterMin, jitterMax)
 	enqueueAt := next.Add(-jitter)
 
 	nextItem := CronItem{
-		ID:              ulid.MustNew(uint64(next.UnixMilli()), rand.Reader),
-		AccountID:       ci.AccountID,
-		WorkspaceID:     ci.WorkspaceID,
-		AppID:           ci.AppID,
-		FunctionID:      ci.FunctionID,
-		FunctionVersion: ci.FunctionVersion,
-		Expression:      ci.Expression,
-		JobID:           jobID,
-		Op:              enums.CronOpProcess,
+		ID:                    ulid.MustNew(uint64(next.UnixMilli()), rand.Reader),
+		AccountID:             ci.AccountID,
+		WorkspaceID:           ci.WorkspaceID,
+		AppID:                 ci.AppID,
+		FunctionID:            ci.FunctionID,
+		FunctionVersion:       ci.FunctionVersion,
+		IsProductionWorkspace: ci.IsProductionWorkspace,
+		Expression:            ci.Expression,
+		JobID:                 jobID,
+		Op:                    enums.CronOpProcess,
 	}
 
 	// enqueue new schedule
 	maxAttempts := consts.MaxRetries + 1
+	queueName := kind
+	if c.opt.splitCronPartitionByWorkspace != nil && c.opt.splitCronPartitionByWorkspace(ctx, ci.AccountID) {
+		queueName = fmt.Sprintf("%s:%s", queue.KindCron, ci.WorkspaceID)
+	}
 
 	err = c.q.Enqueue(ctx, queue.Item{
 		JobID:       &jobID,
@@ -330,7 +375,7 @@ func (c *manager) ScheduleNext(ctx context.Context, ci CronItem) (*CronItem, err
 			WorkflowVersion: ci.FunctionVersion,
 		},
 		Kind:        kind,
-		QueueName:   &kind,
+		QueueName:   &queueName,
 		MaxAttempts: &maxAttempts,
 		Payload:     nextItem,
 	}, enqueueAt, queue.EnqueueOpts{PassthroughJobId: true})

--- a/pkg/execution/cron/manager_test.go
+++ b/pkg/execution/cron/manager_test.go
@@ -105,6 +105,24 @@ func TestOptions(t *testing.T) {
 		assert.Equal(t, time.Duration(0), opt.jitterMax)
 	})
 
+	t.Run("WithProductionWorkspaceJitterRange sets jitter correctly", func(t *testing.T) {
+		opt := managerOpt{}
+		WithProductionWorkspaceJitterRange(10*time.Millisecond, 30*time.Millisecond)(&opt)
+
+		assert.Equal(t, 10*time.Millisecond, opt.productionWorkspaceJitterMin)
+		assert.Equal(t, 30*time.Millisecond, opt.productionWorkspaceJitterMax)
+		assert.True(t, opt.productionWorkspaceJitterSet)
+	})
+
+	t.Run("WithProductionWorkspaceJitterRange ignores invalid range", func(t *testing.T) {
+		opt := managerOpt{}
+		WithProductionWorkspaceJitterRange(30*time.Millisecond, 10*time.Millisecond)(&opt)
+
+		assert.Equal(t, time.Duration(0), opt.productionWorkspaceJitterMin)
+		assert.Equal(t, time.Duration(0), opt.productionWorkspaceJitterMax)
+		assert.False(t, opt.productionWorkspaceJitterSet)
+	})
+
 	t.Run("WithHealthCheckInterval sets interval correctly", func(t *testing.T) {
 		opt := managerOpt{}
 		WithHealthCheckInterval(5 * time.Minute)(&opt)
@@ -131,6 +149,15 @@ func TestOptions(t *testing.T) {
 		WithHealthCheckLeadTimeSeconds(-20)(&opt)
 
 		assert.Equal(t, 0, opt.healthCheckLeadTimeSeconds)
+	})
+
+	t.Run("WithSplitCronPartitionByWorkspace sets callback", func(t *testing.T) {
+		opt := managerOpt{}
+		WithSplitCronPartitionByWorkspace(func(context.Context, uuid.UUID) bool {
+			return true
+		})(&opt)
+
+		require.NotNil(t, opt.splitCronPartitionByWorkspace)
 	})
 
 	t.Run("validate options", func(t *testing.T) {
@@ -622,6 +649,7 @@ func CronItemEqualsIgnoreIDAndOp(t *testing.T, expected, actual CronItem) {
 	assert.Equal(t, expected.AppID, actual.AppID)
 	assert.Equal(t, expected.FunctionID, actual.FunctionID)
 	assert.Equal(t, expected.FunctionVersion, actual.FunctionVersion)
+	assert.Equal(t, expected.IsProductionWorkspace, actual.IsProductionWorkspace)
 	assert.Equal(t, expected.Expression, actual.Expression)
 }
 
@@ -632,6 +660,146 @@ func CronItemEquals(t *testing.T, expected, actual CronItem) {
 	assert.True(t, expected.ID.Timestamp().Equal(actual.ID.Timestamp()))
 	assert.Equal(t, expected.JobID, actual.JobID)
 	assert.Equal(t, expected.Op, actual.Op)
+}
+
+type captureProducer struct {
+	item queue.Item
+	at   time.Time
+	opts queue.EnqueueOpts
+}
+
+func (p *captureProducer) Enqueue(_ context.Context, item queue.Item, at time.Time, opts queue.EnqueueOpts) error {
+	p.item = item
+	p.at = at
+	p.opts = opts
+	return nil
+}
+
+func TestScheduleNextQueueName(t *testing.T) {
+	ctx := context.Background()
+	accountID := uuid.New()
+	workspaceID := uuid.New()
+	appID := uuid.New()
+	functionID := uuid.New()
+
+	tests := []struct {
+		name      string
+		gate      func(context.Context, uuid.UUID) bool
+		queueName string
+	}{
+		{
+			name:      "flag gate unset",
+			queueName: queue.KindCron,
+		}, {
+			name:      "flag gate nil",
+			gate:      nil,
+			queueName: queue.KindCron,
+		},
+		{
+			name: "workspace scoped cron partition disabled",
+			gate: func(_ context.Context, acctID uuid.UUID) bool {
+				return false
+			},
+			queueName: queue.KindCron,
+		},
+		{
+			name: "workspace scoped cron partition enabled",
+			gate: func(_ context.Context, acctID uuid.UUID) bool {
+				return true
+			},
+			queueName: queue.KindCron + ":" + workspaceID.String(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			producer := &captureProducer{}
+			opts := []ManagerOpt{
+				WithJitterRange(0, 0),
+			}
+			if tt.gate != nil {
+				opts = append(opts, WithSplitCronPartitionByWorkspace(tt.gate))
+			}
+			mgr := NewManager(nil, producer, logger.StdlibLogger(ctx), opts...)
+
+			_, err := mgr.ScheduleNext(ctx, CronItem{
+				ID:              ulid.Make(),
+				AccountID:       accountID,
+				WorkspaceID:     workspaceID,
+				AppID:           appID,
+				FunctionID:      functionID,
+				FunctionVersion: 1,
+				Expression:      "* * * * *",
+				Op:              enums.CronOpProcess,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, producer.item.QueueName)
+			require.Equal(t, tt.queueName, *producer.item.QueueName)
+			require.Equal(t, queue.KindCron, producer.item.Kind)
+		})
+	}
+}
+
+func TestScheduleNextProductionWorkspaceJitter(t *testing.T) {
+	ctx := context.Background()
+
+	// Manager with both standard and production-workspace jitter ranges.
+	producer := &captureProducer{}
+	mgr := NewManager(
+		nil,
+		producer,
+		logger.StdlibLogger(ctx),
+		WithJitterRange(10*time.Second, 10*time.Second),
+		WithProductionWorkspaceJitterRange(30*time.Second, 30*time.Second),
+	)
+
+	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	item := CronItem{
+		ID:              ulid.MustNew(ulid.Timestamp(from), ulid.DefaultEntropy()),
+		AccountID:       uuid.New(),
+		WorkspaceID:     uuid.New(),
+		AppID:           uuid.New(),
+		FunctionID:      uuid.New(),
+		FunctionVersion: 1,
+		Expression:      "* * * * *",
+		Op:              enums.CronOpProcess,
+	}
+
+	// The first schedule below uses the standard range because the item is not a
+	// production workspace cron.
+	nextItem, err := mgr.ScheduleNext(ctx, item)
+	require.NoError(t, err)
+	require.NotNil(t, nextItem)
+	require.False(t, nextItem.IsProductionWorkspace)
+	require.True(t, producer.at.Equal(from.Add(time.Minute).Add(-10*time.Second)))
+
+	// Production workspace item should use the production-specific range.
+	item.IsProductionWorkspace = true
+	nextItem, err = mgr.ScheduleNext(ctx, item)
+	require.NoError(t, err)
+	require.NotNil(t, nextItem)
+	require.True(t, nextItem.IsProductionWorkspace)
+	require.True(t, producer.at.Equal(from.Add(time.Minute).Add(-30*time.Second)))
+
+	payload, ok := producer.item.Payload.(CronItem)
+	require.True(t, ok)
+	require.True(t, payload.IsProductionWorkspace)
+
+	// Manager with only the standard jitter range. Production workspace items
+	// should fall back to the standard range when no production range is set.
+	producer = &captureProducer{}
+	mgr = NewManager(
+		nil,
+		producer,
+		logger.StdlibLogger(ctx),
+		WithJitterRange(10*time.Second, 10*time.Second),
+	)
+
+	nextItem, err = mgr.ScheduleNext(ctx, item)
+	require.NoError(t, err)
+	require.NotNil(t, nextItem)
+	require.True(t, nextItem.IsProductionWorkspace)
+	require.True(t, producer.at.Equal(from.Add(time.Minute).Add(-10*time.Second)))
 }
 
 func TestManager(t *testing.T) {


### PR DESCRIPTION
## Description

Cron Performance Improvements:
- split cron partitions by workspace (enabled by default in devserver)
- prioritize production workspaces ahead of other workspaces (disabled by default in devserver)

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
