### PR TITLE
feat: postgres backed experiments

### DIFF
--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -277,6 +277,7 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 			}
 
 			c.processMetadata(ctx, l, input.AccountID, input.Metadata, stepSpanRef, op, "checkpoint.SyncStep.metadata")
+			c.processExperiment(ctx, input.Metadata, op)
 
 			go c.MetricsProvider.OnStepFinished(ctx, MetricCardinality{
 				AccountID: input.AccountID,
@@ -315,6 +316,7 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 			}
 
 			c.processMetadata(ctx, l, input.AccountID, input.Metadata, stepSpanRef, op, "checkpoint.SyncErr.metadata")
+			c.processExperiment(ctx, input.Metadata, op)
 
 			err = c.Executor.HandleGenerator(ctx, runCtx, op)
 			if errors.Is(err, executor.ErrHandledStepError) {
@@ -571,6 +573,7 @@ func (c checkpointer) checkpointAsyncSteps(ctx context.Context, input AsyncCheck
 			}
 
 			c.processMetadata(ctx, l, input.AccountID, &md, stepSpanRef, op, "checkpoint.AsyncStep.metadata")
+			c.processExperiment(ctx, &md, op)
 
 		case enums.OpcodeStepPlanned:
 			// When the SDK announces a step is about to run, we open a Running
@@ -795,6 +798,16 @@ func (c checkpointer) fn(ctx context.Context, fnID uuid.UUID) (*inngest.Function
 		return nil, fmt.Errorf("error loading function: %w", err)
 	}
 	return cfn.InngestFunction()
+}
+
+// Deliberately not behind the AllowStepMetadata gate (unlike processMetadata):
+// experiment observation must fire regardless of the trace-metadata flag.
+func (c checkpointer) processExperiment(ctx context.Context, md *state.Metadata, op state.GeneratorOpcode) {
+	expMd, err := extractors.ExtractExperimentOptsMetadata(op.Opts)
+	if err != nil || expMd == nil {
+		return
+	}
+	c.Executor.RunStepExperimentLifecycle(ctx, *md, op)
 }
 
 func (c checkpointer) processMetadata(

--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -1163,6 +1163,19 @@ func (m *mockExecutor) RunFunctionFinishedLifecycle(
 	}
 }
 
+func (m *mockExecutor) RunStepExperimentLifecycle(
+	ctx context.Context,
+	md state.Metadata,
+	op state.GeneratorOpcode,
+) {
+	for _, c := range m.ExpectedCalls {
+		if c.Method == "RunStepExperimentLifecycle" {
+			m.Called(ctx, md, op)
+			return
+		}
+	}
+}
+
 // mockFnReader mocks the function reader interface
 type mockFnReader struct {
 	cqrs.FunctionReader

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -121,6 +121,11 @@ type Executor interface {
 	// registered LifecycleListener.
 	RunFunctionFinishedLifecycle(ctx context.Context, md sv2.Metadata, item queue.Item, evts []json.RawMessage, resp state.DriverResponse)
 
+	// RunStepExperimentLifecycle fans OnStepExperiment out to every registered
+	// LifecycleListener. Called from both the v1 step handler and the
+	// checkpointer when an opcode carries group.experiment() variant context.
+	RunStepExperimentLifecycle(ctx context.Context, md sv2.Metadata, op state.GeneratorOpcode)
+
 	// AddLifecycleListener adds a lifecycle listener to run on hooks.  This must
 	// always add to a list of listeners vs replace listeners.
 	AddLifecycleListener(l LifecycleListener)

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -561,6 +561,16 @@ func (e *executor) RunFunctionFinishedLifecycle(
 	}
 }
 
+func (e *executor) RunStepExperimentLifecycle(
+	ctx context.Context,
+	md sv2.Metadata,
+	op state.GeneratorOpcode,
+) {
+	for _, l := range e.lifecycles {
+		go l.OnStepExperiment(context.WithoutCancel(ctx), md, op)
+	}
+}
+
 func (e *executor) CloseLifecycleListeners(ctx context.Context) {
 	var eg errgroup.Group
 
@@ -5675,6 +5685,8 @@ func (e *executor) emitExperimentMetadataFromOpts(ctx context.Context, runCtx ex
 	); err != nil {
 		e.log.Warn("error creating experiment metadata span", "error", err)
 	}
+
+	e.RunStepExperimentLifecycle(ctx, *runCtx.Metadata(), *gen)
 }
 
 func (e *executor) createMetadataSpan(ctx context.Context, runCtx execution.RunContext, location string, md metadata.Structured, scope metadata.Scope, op *state.GeneratorOpcode) (*meta.SpanReference, error) {

--- a/pkg/execution/history/lifecycle.go
+++ b/pkg/execution/history/lifecycle.go
@@ -358,6 +358,10 @@ func (l lifecycle) OnStepStarted(
 	}
 }
 
+// OnStepExperiment captures group.experiment() selections; a no-op here since
+// that is handled by a dedicated listener, not recorded in run history.
+func (l lifecycle) OnStepExperiment(context.Context, sv2.Metadata, state.GeneratorOpcode) {}
+
 func (l lifecycle) OnStepFinished(
 	ctx context.Context,
 	md sv2.Metadata,

--- a/pkg/execution/lifecycle.go
+++ b/pkg/execution/lifecycle.go
@@ -117,6 +117,15 @@ type LifecycleListener interface {
 		error,
 	)
 
+	// OnStepExperiment is called when a step's opcode carries group.experiment()
+	// variant context. Fires in both v1 and checkpointing execution, independent
+	// of the step-metadata gate, so listeners see every experiment selection.
+	OnStepExperiment(
+		context.Context,
+		statev2.Metadata,
+		statev1.GeneratorOpcode,
+	)
+
 	// OnGatewayRequestFinished is called when a step's offloaded request finishes.
 	// The offloaded request may be a success or error; it does not matter.
 	OnStepGatewayRequestFinished(
@@ -299,6 +308,13 @@ func (NoopLifecyceListener) OnStepFinished(
 	inngest.Edge,
 	*statev1.DriverResponse,
 	error,
+) {
+}
+
+func (NoopLifecyceListener) OnStepExperiment(
+	context.Context,
+	statev2.Metadata,
+	statev1.GeneratorOpcode,
 ) {
 }
 


### PR DESCRIPTION
## Description

Adds an `OnStepExperiment` lifecycle hook so we can observe experiment selections
consistently across both non-checkpointed and checkpointing paths.

No behavior change for existing listeners (the default is a noop). Consumed by
the cloud monorepo to persist experiments to Postgres.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
