### PR TITLE
fix: v2 api event/runs statuses

### DIFF
--- a/pkg/db/adapter_integration_test.go
+++ b/pkg/db/adapter_integration_test.go
@@ -279,7 +279,7 @@ func TestGetRuns(t *testing.T) {
 	}
 }
 
-func TestGetRunsTreatsNumericFunctionOutputAttributeAsFinal(t *testing.T) {
+func TestGetRunsPrefersFunctionOutputSpan(t *testing.T) {
 	adapter, cleanup := newTestAdapter(t)
 	defer cleanup()
 
@@ -290,13 +290,15 @@ func TestGetRunsTreatsNumericFunctionOutputAttributeAsFinal(t *testing.T) {
 	fnID := uuid.New()
 	eventID := ulid.Make()
 	runID := ulid.Make()
+	rootSpanID := "root-" + ulid.Make().String()
 	startedAt := time.Now().UTC().Truncate(time.Millisecond)
 	childStartedAt := startedAt.Add(50 * time.Millisecond)
 	finalEndedAt := startedAt.Add(time.Second)
 	laterEndedAt := finalEndedAt.Add(time.Second)
+	endedAt := laterEndedAt.Add(time.Second)
 	_, err := q.UpsertApp(ctx, db.UpsertAppParams{
 		ID:          appID,
-		Name:        "numeric-output-app",
+		Name:        "function-output-app",
 		SdkLanguage: "go",
 		SdkVersion:  "1.0.0",
 		Metadata:    "{}",
@@ -306,27 +308,30 @@ func TestGetRunsTreatsNumericFunctionOutputAttributeAsFinal(t *testing.T) {
 		Method:      "POST",
 	})
 	require.NoError(t, err)
-	require.NoError(t, insertRunListSpan(ctx, q, runListSpan{
+	root := runListSpan{
+		SpanID:       rootSpanID,
 		RunID:        runID,
 		EventIDs:     []ulid.ULID{eventID},
 		AppID:        appID,
 		FunctionID:   fnID,
-		FunctionSlug: "numeric-output-function",
-		FunctionName: "Numeric Output Function",
+		FunctionSlug: "function-output-function",
+		FunctionName: "Function Output Function",
 		StartedAt:    startedAt,
 		EndedAt:      startedAt,
 		Status:       enums.StepStatusQueued.String(),
-	}))
+	}
+	require.NoError(t, insertRunListSpan(ctx, q, root))
+	require.NoError(t, extendSpan(ctx, q, root, rootSpanID, endedAt, enums.StepStatusCompleted.String()))
 
 	finalAttrs, err := json.Marshal(map[string]any{
-		meta.Attrs.IsFunctionOutput.Key(): 1,
+		meta.Attrs.IsFunctionOutput.Key(): true,
 	})
 	require.NoError(t, err)
 	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
 		SpanID:       ulid.Make().String(),
 		TraceID:      "trace-" + runID.String(),
 		Name:         meta.SpanNameExecution,
-		ParentSpanID: sql.NullString{String: "run-span", Valid: true},
+		ParentSpanID: sql.NullString{String: rootSpanID, Valid: true},
 		StartTime:    childStartedAt,
 		EndTime:      finalEndedAt,
 		RunID:        runID.String(),
@@ -340,11 +345,14 @@ func TestGetRunsTreatsNumericFunctionOutputAttributeAsFinal(t *testing.T) {
 		Status:       sql.NullString{String: enums.StepStatusCompleted.String(), Valid: true},
 		EventIds:     []byte(`[]`),
 	}))
+
+	//
+	// a later step output without the function-output marker must not win
 	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
 		SpanID:       ulid.Make().String(),
 		TraceID:      "trace-" + runID.String(),
 		Name:         meta.SpanNameExecution,
-		ParentSpanID: sql.NullString{String: "run-span", Valid: true},
+		ParentSpanID: sql.NullString{String: rootSpanID, Valid: true},
 		StartTime:    childStartedAt,
 		EndTime:      laterEndedAt,
 		RunID:        runID.String(),
@@ -369,11 +377,11 @@ func TestGetRunsTreatsNumericFunctionOutputAttributeAsFinal(t *testing.T) {
 	assert.Equal(t, runID, rows[0].FunctionRun.RunID)
 	assert.Equal(t, "Completed", rows[0].FunctionFinish.Status.String)
 	assert.True(t, rows[0].FunctionFinish.CreatedAt.Valid)
-	assert.WithinDuration(t, finalEndedAt, rows[0].FunctionFinish.CreatedAt.Time, time.Millisecond)
+	assert.WithinDuration(t, endedAt, rows[0].FunctionFinish.CreatedAt.Time, time.Millisecond)
 	assert.JSONEq(t, `{"data":{"body":"final"}}`, string(rows[0].Output))
 }
 
-func TestGetRunsUsesRootDynamicTerminalStatus(t *testing.T) {
+func TestGetRunsUsesRootDynamicSpanStatus(t *testing.T) {
 	adapter, cleanup := newTestAdapter(t)
 	defer cleanup()
 
@@ -385,10 +393,10 @@ func TestGetRunsUsesRootDynamicTerminalStatus(t *testing.T) {
 	eventID := ulid.Make()
 	runID := ulid.Make()
 	rootSpanID := "root-" + ulid.Make().String()
-	childSpanID := "child-" + ulid.Make().String()
+	stepSpanID := "step-" + ulid.Make().String()
 	startedAt := time.Now().UTC().Truncate(time.Millisecond)
 	cancelledAt := startedAt.Add(3 * time.Minute)
-	childCompletedAt := cancelledAt.Add(7 * time.Minute)
+	stepCompletedAt := cancelledAt.Add(7 * time.Minute)
 	_, err := q.UpsertApp(ctx, db.UpsertAppParams{
 		ID:          appID,
 		Name:        "dynamic-status-app",
@@ -401,7 +409,7 @@ func TestGetRunsUsesRootDynamicTerminalStatus(t *testing.T) {
 		Method:      "POST",
 	})
 	require.NoError(t, err)
-	require.NoError(t, insertRunListSpan(ctx, q, runListSpan{
+	root := runListSpan{
 		SpanID:       rootSpanID,
 		RunID:        runID,
 		EventIDs:     []ulid.ULID{eventID},
@@ -412,54 +420,15 @@ func TestGetRunsUsesRootDynamicTerminalStatus(t *testing.T) {
 		StartedAt:    startedAt,
 		EndedAt:      startedAt,
 		Status:       enums.StepStatusQueued.String(),
-	}))
+	}
+	require.NoError(t, insertRunListSpan(ctx, q, root))
+	require.NoError(t, extendSpan(ctx, q, root, rootSpanID, startedAt.Add(time.Second), enums.StepStatusRunning.String()))
+	require.NoError(t, extendSpan(ctx, q, root, rootSpanID, cancelledAt, enums.StepStatusCancelled.String()))
 
-	rootAttrs, err := json.Marshal(map[string]any{
-		meta.Attrs.DynamicSpanID.Key(): rootSpanID,
-		meta.Attrs.DynamicStatus.Key(): enums.StepStatusCancelled.String(),
-	})
-	require.NoError(t, err)
-	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
-		SpanID:       ulid.Make().String(),
-		TraceID:      "trace-" + runID.String(),
-		Name:         meta.SpanNameDynamicExtension,
-		ParentSpanID: sql.NullString{String: "0000000000000000", Valid: true},
-		StartTime:    cancelledAt,
-		EndTime:      cancelledAt,
-		RunID:        runID.String(),
-		AccountID:    uuid.NewString(),
-		AppID:        appID.String(),
-		FunctionID:   fnID.String(),
-		EnvID:        uuid.NewString(),
-		Attributes:   rootAttrs,
-		Links:        []byte(`[]`),
-		Status:       sql.NullString{String: enums.StepStatusCancelled.String(), Valid: true},
-		EventIds:     []byte(`[]`),
-	}))
-
-	childAttrs, err := json.Marshal(map[string]any{
-		meta.Attrs.DynamicSpanID.Key(): childSpanID,
-		meta.Attrs.DynamicStatus.Key(): enums.StepStatusCompleted.String(),
-	})
-	require.NoError(t, err)
-	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
-		SpanID:       ulid.Make().String(),
-		TraceID:      "trace-" + runID.String(),
-		Name:         meta.SpanNameDynamicExtension,
-		ParentSpanID: sql.NullString{String: rootSpanID, Valid: true},
-		StartTime:    childCompletedAt,
-		EndTime:      childCompletedAt,
-		RunID:        runID.String(),
-		AccountID:    uuid.NewString(),
-		AppID:        appID.String(),
-		FunctionID:   fnID.String(),
-		EnvID:        uuid.NewString(),
-		Attributes:   childAttrs,
-		Links:        []byte(`[]`),
-		Output:       []byte(`{"data":"child completed after cancellation"}`),
-		Status:       sql.NullString{String: enums.StepStatusCompleted.String(), Valid: true},
-		EventIds:     []byte(`[]`),
-	}))
+	//
+	// a step's own dynamic span finishing later must not override the run
+	// root group's terminal status
+	require.NoError(t, extendSpan(ctx, q, root, stepSpanID, stepCompletedAt, enums.StepStatusCompleted.String()))
 
 	rows, err := q.GetRuns(ctx, db.GetRunsParams{
 		EventID: eventID,
@@ -473,7 +442,7 @@ func TestGetRunsUsesRootDynamicTerminalStatus(t *testing.T) {
 	assert.WithinDuration(t, cancelledAt, rows[0].FunctionFinish.CreatedAt.Time, time.Millisecond)
 }
 
-func TestGetRunsIgnoresRetryableFunctionOutputStatus(t *testing.T) {
+func TestGetRunsIgnoresStepFailureStatus(t *testing.T) {
 	adapter, cleanup := newTestAdapter(t)
 	defer cleanup()
 
@@ -484,12 +453,13 @@ func TestGetRunsIgnoresRetryableFunctionOutputStatus(t *testing.T) {
 	fnID := uuid.New()
 	eventID := ulid.Make()
 	runID := ulid.Make()
+	rootSpanID := "root-" + ulid.Make().String()
+	stepSpanID := "step-" + ulid.Make().String()
 	startedAt := time.Now().UTC().Truncate(time.Millisecond)
-	childStartedAt := startedAt.Add(50 * time.Millisecond)
 	failedAt := startedAt.Add(time.Second)
 	_, err := q.UpsertApp(ctx, db.UpsertAppParams{
 		ID:          appID,
-		Name:        "retryable-output-app",
+		Name:        "step-failure-app",
 		SdkLanguage: "go",
 		SdkVersion:  "1.0.0",
 		Metadata:    "{}",
@@ -499,42 +469,25 @@ func TestGetRunsIgnoresRetryableFunctionOutputStatus(t *testing.T) {
 		Method:      "POST",
 	})
 	require.NoError(t, err)
-	require.NoError(t, insertRunListSpan(ctx, q, runListSpan{
+	root := runListSpan{
+		SpanID:       rootSpanID,
 		RunID:        runID,
 		EventIDs:     []ulid.ULID{eventID},
 		AppID:        appID,
 		FunctionID:   fnID,
-		FunctionSlug: "retryable-output-function",
-		FunctionName: "Retryable Output Function",
+		FunctionSlug: "step-failure-function",
+		FunctionName: "Step Failure Function",
 		StartedAt:    startedAt,
 		EndedAt:      startedAt,
 		Status:       enums.StepStatusQueued.String(),
-	}))
+	}
+	require.NoError(t, insertRunListSpan(ctx, q, root))
+	require.NoError(t, extendSpan(ctx, q, root, rootSpanID, startedAt.Add(time.Millisecond), enums.StepStatusRunning.String()))
 
-	attrs, err := json.Marshal(map[string]any{
-		meta.Attrs.DynamicStatus.Key():    enums.StepStatusFailed.String(),
-		meta.Attrs.IsFunctionOutput.Key(): true,
-		meta.Attrs.Retryable.Key():        true,
-	})
-	require.NoError(t, err)
-	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
-		SpanID:       ulid.Make().String(),
-		TraceID:      "trace-" + runID.String(),
-		Name:         meta.SpanNameDynamicExtension,
-		ParentSpanID: sql.NullString{String: "child-span", Valid: true},
-		StartTime:    childStartedAt,
-		EndTime:      failedAt,
-		RunID:        runID.String(),
-		AccountID:    uuid.NewString(),
-		AppID:        appID.String(),
-		FunctionID:   fnID.String(),
-		EnvID:        uuid.NewString(),
-		Attributes:   attrs,
-		Links:        []byte(`[]`),
-		Output:       []byte(`{"error":{"message":"retry me"}}`),
-		Status:       sql.NullString{String: enums.StepStatusFailed.String(), Valid: true},
-		EventIds:     []byte(`[]`),
-	}))
+	//
+	// a retryable step failure only extends the step's dynamic span; the run
+	// root group keeps the run in flight
+	require.NoError(t, extendSpan(ctx, q, root, stepSpanID, failedAt, enums.StepStatusErrored.String()))
 
 	rows, err := q.GetRuns(ctx, db.GetRunsParams{
 		EventID: eventID,
@@ -563,6 +516,8 @@ type runListSpan struct {
 	Status       string
 }
 
+// the exporter stores the run root as an executor.run row whose
+// dynamic_span_id doubles as the grouping key for later EXTEND rows
 func insertRunListSpan(ctx context.Context, q db.Querier, span runListSpan) error {
 	spanID := span.SpanID
 	if spanID == "" {
@@ -588,21 +543,44 @@ func insertRunListSpan(ctx context.Context, q db.Querier, span runListSpan) erro
 	eventIDBytes, _ := json.Marshal(eventIDs)
 
 	return q.InsertSpan(ctx, db.InsertSpanParams{
-		SpanID:     spanID,
-		TraceID:    "trace-" + span.RunID.String(),
-		Name:       meta.SpanNameRun,
-		StartTime:  span.StartedAt,
-		EndTime:    span.EndedAt,
-		RunID:      span.RunID.String(),
-		AccountID:  uuid.NewString(),
-		AppID:      span.AppID.String(),
-		FunctionID: span.FunctionID.String(),
-		EnvID:      uuid.NewString(),
-		Attributes: attrBytes,
-		Links:      []byte(`[]`),
-		Output:     span.Output,
-		Status:     sql.NullString{String: span.Status, Valid: span.Status != ""},
-		EventIds:   eventIDBytes,
+		SpanID:        spanID,
+		TraceID:       "trace-" + span.RunID.String(),
+		Name:          meta.SpanNameRun,
+		StartTime:     span.StartedAt,
+		EndTime:       span.EndedAt,
+		RunID:         span.RunID.String(),
+		AccountID:     uuid.NewString(),
+		AppID:         span.AppID.String(),
+		FunctionID:    span.FunctionID.String(),
+		EnvID:         uuid.NewString(),
+		DynamicSpanID: sql.NullString{String: spanID, Valid: true},
+		Attributes:    attrBytes,
+		Links:         []byte(`[]`),
+		Output:        span.Output,
+		Status:        sql.NullString{String: span.Status, Valid: span.Status != ""},
+		EventIds:      eventIDBytes,
+	})
+}
+
+// status transitions arrive as EXTEND rows sharing the target span's
+// dynamic_span_id
+func extendSpan(ctx context.Context, q db.Querier, span runListSpan, dynamicSpanID string, at time.Time, status string) error {
+	return q.InsertSpan(ctx, db.InsertSpanParams{
+		SpanID:        ulid.Make().String(),
+		TraceID:       "trace-" + span.RunID.String(),
+		Name:          meta.SpanNameDynamicExtension,
+		StartTime:     at,
+		EndTime:       at,
+		RunID:         span.RunID.String(),
+		AccountID:     uuid.NewString(),
+		AppID:         span.AppID.String(),
+		FunctionID:    span.FunctionID.String(),
+		EnvID:         uuid.NewString(),
+		DynamicSpanID: sql.NullString{String: dynamicSpanID, Valid: true},
+		Attributes:    []byte(`{}`),
+		Links:         []byte(`[]`),
+		Status:        sql.NullString{String: status, Valid: status != ""},
+		EventIds:      []byte(`[]`),
 	})
 }
 

--- a/pkg/db/adapter_integration_test.go
+++ b/pkg/db/adapter_integration_test.go
@@ -279,7 +279,276 @@ func TestGetRuns(t *testing.T) {
 	}
 }
 
+func TestGetRunsTreatsNumericFunctionOutputAttributeAsFinal(t *testing.T) {
+	adapter, cleanup := newTestAdapter(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	q := adapter.Q()
+
+	appID := uuid.New()
+	fnID := uuid.New()
+	eventID := ulid.Make()
+	runID := ulid.Make()
+	startedAt := time.Now().UTC().Truncate(time.Millisecond)
+	childStartedAt := startedAt.Add(50 * time.Millisecond)
+	finalEndedAt := startedAt.Add(time.Second)
+	laterEndedAt := finalEndedAt.Add(time.Second)
+	_, err := q.UpsertApp(ctx, db.UpsertAppParams{
+		ID:          appID,
+		Name:        "numeric-output-app",
+		SdkLanguage: "go",
+		SdkVersion:  "1.0.0",
+		Metadata:    "{}",
+		Status:      "active",
+		Checksum:    "checksum",
+		Url:         "https://example.com/inngest",
+		Method:      "POST",
+	})
+	require.NoError(t, err)
+	require.NoError(t, insertRunListSpan(ctx, q, runListSpan{
+		RunID:        runID,
+		EventIDs:     []ulid.ULID{eventID},
+		AppID:        appID,
+		FunctionID:   fnID,
+		FunctionSlug: "numeric-output-function",
+		FunctionName: "Numeric Output Function",
+		StartedAt:    startedAt,
+		EndedAt:      startedAt,
+		Status:       enums.StepStatusQueued.String(),
+	}))
+
+	finalAttrs, err := json.Marshal(map[string]any{
+		meta.Attrs.IsFunctionOutput.Key(): 1,
+	})
+	require.NoError(t, err)
+	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
+		SpanID:       ulid.Make().String(),
+		TraceID:      "trace-" + runID.String(),
+		Name:         meta.SpanNameExecution,
+		ParentSpanID: sql.NullString{String: "run-span", Valid: true},
+		StartTime:    childStartedAt,
+		EndTime:      finalEndedAt,
+		RunID:        runID.String(),
+		AccountID:    uuid.NewString(),
+		AppID:        appID.String(),
+		FunctionID:   fnID.String(),
+		EnvID:        uuid.NewString(),
+		Attributes:   finalAttrs,
+		Links:        []byte(`[]`),
+		Output:       []byte(`{"data":{"body":"final"}}`),
+		Status:       sql.NullString{String: enums.StepStatusCompleted.String(), Valid: true},
+		EventIds:     []byte(`[]`),
+	}))
+	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
+		SpanID:       ulid.Make().String(),
+		TraceID:      "trace-" + runID.String(),
+		Name:         meta.SpanNameExecution,
+		ParentSpanID: sql.NullString{String: "run-span", Valid: true},
+		StartTime:    childStartedAt,
+		EndTime:      laterEndedAt,
+		RunID:        runID.String(),
+		AccountID:    uuid.NewString(),
+		AppID:        appID.String(),
+		FunctionID:   fnID.String(),
+		EnvID:        uuid.NewString(),
+		Attributes:   []byte(`{}`),
+		Links:        []byte(`[]`),
+		Output:       []byte(`{"data":{"body":"step"}}`),
+		Status:       sql.NullString{String: enums.StepStatusCompleted.String(), Valid: true},
+		EventIds:     []byte(`[]`),
+	}))
+
+	rows, err := q.GetRuns(ctx, db.GetRunsParams{
+		EventID:       eventID,
+		Limit:         1,
+		IncludeOutput: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, runID, rows[0].FunctionRun.RunID)
+	assert.Equal(t, "Completed", rows[0].FunctionFinish.Status.String)
+	assert.True(t, rows[0].FunctionFinish.CreatedAt.Valid)
+	assert.WithinDuration(t, finalEndedAt, rows[0].FunctionFinish.CreatedAt.Time, time.Millisecond)
+	assert.JSONEq(t, `{"data":{"body":"final"}}`, string(rows[0].Output))
+}
+
+func TestGetRunsUsesRootDynamicTerminalStatus(t *testing.T) {
+	adapter, cleanup := newTestAdapter(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	q := adapter.Q()
+
+	appID := uuid.New()
+	fnID := uuid.New()
+	eventID := ulid.Make()
+	runID := ulid.Make()
+	rootSpanID := "root-" + ulid.Make().String()
+	childSpanID := "child-" + ulid.Make().String()
+	startedAt := time.Now().UTC().Truncate(time.Millisecond)
+	cancelledAt := startedAt.Add(3 * time.Minute)
+	childCompletedAt := cancelledAt.Add(7 * time.Minute)
+	_, err := q.UpsertApp(ctx, db.UpsertAppParams{
+		ID:          appID,
+		Name:        "dynamic-status-app",
+		SdkLanguage: "go",
+		SdkVersion:  "1.0.0",
+		Metadata:    "{}",
+		Status:      "active",
+		Checksum:    "checksum",
+		Url:         "https://example.com/inngest",
+		Method:      "POST",
+	})
+	require.NoError(t, err)
+	require.NoError(t, insertRunListSpan(ctx, q, runListSpan{
+		SpanID:       rootSpanID,
+		RunID:        runID,
+		EventIDs:     []ulid.ULID{eventID},
+		AppID:        appID,
+		FunctionID:   fnID,
+		FunctionSlug: "dynamic-status-function",
+		FunctionName: "Dynamic Status Function",
+		StartedAt:    startedAt,
+		EndedAt:      startedAt,
+		Status:       enums.StepStatusQueued.String(),
+	}))
+
+	rootAttrs, err := json.Marshal(map[string]any{
+		meta.Attrs.DynamicSpanID.Key(): rootSpanID,
+		meta.Attrs.DynamicStatus.Key(): enums.StepStatusCancelled.String(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
+		SpanID:       ulid.Make().String(),
+		TraceID:      "trace-" + runID.String(),
+		Name:         meta.SpanNameDynamicExtension,
+		ParentSpanID: sql.NullString{String: "0000000000000000", Valid: true},
+		StartTime:    cancelledAt,
+		EndTime:      cancelledAt,
+		RunID:        runID.String(),
+		AccountID:    uuid.NewString(),
+		AppID:        appID.String(),
+		FunctionID:   fnID.String(),
+		EnvID:        uuid.NewString(),
+		Attributes:   rootAttrs,
+		Links:        []byte(`[]`),
+		Status:       sql.NullString{String: enums.StepStatusCancelled.String(), Valid: true},
+		EventIds:     []byte(`[]`),
+	}))
+
+	childAttrs, err := json.Marshal(map[string]any{
+		meta.Attrs.DynamicSpanID.Key(): childSpanID,
+		meta.Attrs.DynamicStatus.Key(): enums.StepStatusCompleted.String(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
+		SpanID:       ulid.Make().String(),
+		TraceID:      "trace-" + runID.String(),
+		Name:         meta.SpanNameDynamicExtension,
+		ParentSpanID: sql.NullString{String: rootSpanID, Valid: true},
+		StartTime:    childCompletedAt,
+		EndTime:      childCompletedAt,
+		RunID:        runID.String(),
+		AccountID:    uuid.NewString(),
+		AppID:        appID.String(),
+		FunctionID:   fnID.String(),
+		EnvID:        uuid.NewString(),
+		Attributes:   childAttrs,
+		Links:        []byte(`[]`),
+		Output:       []byte(`{"data":"child completed after cancellation"}`),
+		Status:       sql.NullString{String: enums.StepStatusCompleted.String(), Valid: true},
+		EventIds:     []byte(`[]`),
+	}))
+
+	rows, err := q.GetRuns(ctx, db.GetRunsParams{
+		EventID: eventID,
+		Limit:   1,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, runID, rows[0].FunctionRun.RunID)
+	assert.Equal(t, "Cancelled", rows[0].FunctionFinish.Status.String)
+	assert.True(t, rows[0].FunctionFinish.CreatedAt.Valid)
+	assert.WithinDuration(t, cancelledAt, rows[0].FunctionFinish.CreatedAt.Time, time.Millisecond)
+}
+
+func TestGetRunsIgnoresRetryableFunctionOutputStatus(t *testing.T) {
+	adapter, cleanup := newTestAdapter(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	q := adapter.Q()
+
+	appID := uuid.New()
+	fnID := uuid.New()
+	eventID := ulid.Make()
+	runID := ulid.Make()
+	startedAt := time.Now().UTC().Truncate(time.Millisecond)
+	childStartedAt := startedAt.Add(50 * time.Millisecond)
+	failedAt := startedAt.Add(time.Second)
+	_, err := q.UpsertApp(ctx, db.UpsertAppParams{
+		ID:          appID,
+		Name:        "retryable-output-app",
+		SdkLanguage: "go",
+		SdkVersion:  "1.0.0",
+		Metadata:    "{}",
+		Status:      "active",
+		Checksum:    "checksum",
+		Url:         "https://example.com/inngest",
+		Method:      "POST",
+	})
+	require.NoError(t, err)
+	require.NoError(t, insertRunListSpan(ctx, q, runListSpan{
+		RunID:        runID,
+		EventIDs:     []ulid.ULID{eventID},
+		AppID:        appID,
+		FunctionID:   fnID,
+		FunctionSlug: "retryable-output-function",
+		FunctionName: "Retryable Output Function",
+		StartedAt:    startedAt,
+		EndedAt:      startedAt,
+		Status:       enums.StepStatusQueued.String(),
+	}))
+
+	attrs, err := json.Marshal(map[string]any{
+		meta.Attrs.DynamicStatus.Key():    enums.StepStatusFailed.String(),
+		meta.Attrs.IsFunctionOutput.Key(): true,
+		meta.Attrs.Retryable.Key():        true,
+	})
+	require.NoError(t, err)
+	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
+		SpanID:       ulid.Make().String(),
+		TraceID:      "trace-" + runID.String(),
+		Name:         meta.SpanNameDynamicExtension,
+		ParentSpanID: sql.NullString{String: "child-span", Valid: true},
+		StartTime:    childStartedAt,
+		EndTime:      failedAt,
+		RunID:        runID.String(),
+		AccountID:    uuid.NewString(),
+		AppID:        appID.String(),
+		FunctionID:   fnID.String(),
+		EnvID:        uuid.NewString(),
+		Attributes:   attrs,
+		Links:        []byte(`[]`),
+		Output:       []byte(`{"error":{"message":"retry me"}}`),
+		Status:       sql.NullString{String: enums.StepStatusFailed.String(), Valid: true},
+		EventIds:     []byte(`[]`),
+	}))
+
+	rows, err := q.GetRuns(ctx, db.GetRunsParams{
+		EventID: eventID,
+		Limit:   1,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, runID, rows[0].FunctionRun.RunID)
+	assert.Equal(t, "Running", rows[0].FunctionFinish.Status.String)
+	assert.False(t, rows[0].FunctionFinish.CreatedAt.Valid)
+}
+
 type runListSpan struct {
+	SpanID       string
 	RunID        ulid.ULID
 	EventIDs     []ulid.ULID
 	BatchID      ulid.ULID
@@ -295,6 +564,11 @@ type runListSpan struct {
 }
 
 func insertRunListSpan(ctx context.Context, q db.Querier, span runListSpan) error {
+	spanID := span.SpanID
+	if spanID == "" {
+		spanID = ulid.Make().String()
+	}
+
 	attrs := map[string]any{
 		meta.Attrs.FunctionSlug.Key(): span.FunctionSlug,
 		meta.Attrs.FunctionName.Key(): span.FunctionName,
@@ -314,7 +588,7 @@ func insertRunListSpan(ctx context.Context, q db.Querier, span runListSpan) erro
 	eventIDBytes, _ := json.Marshal(eventIDs)
 
 	return q.InsertSpan(ctx, db.InsertSpanParams{
-		SpanID:     ulid.Make().String(),
+		SpanID:     spanID,
 		TraceID:    "trace-" + span.RunID.String(),
 		Name:       meta.SpanNameRun,
 		StartTime:  span.StartedAt,

--- a/pkg/db/postgres/querier.go
+++ b/pkg/db/postgres/querier.go
@@ -429,13 +429,8 @@ func scanSpanRunListRows(rows []*sqlc.GetRunsRow, arg db.GetRunsParams) ([]*db.R
 			return nil, err
 		}
 
-		status := enums.RunStatusRunning
 		statusText := r.Status
-		if statusText != "" {
-			if stepStatus, err := enums.StepStatusString(statusText); err == nil && stepStatus != enums.StepStatusUnknown {
-				status = enums.StepStatusToRunStatus(stepStatus)
-			}
-		}
+		status := db.RunStatusFromSpanStatus(statusText)
 
 		batchIDText := valueString(r.BatchID)
 		var batchID ulid.ULID

--- a/pkg/db/postgres/sqlc/queries.sql
+++ b/pkg/db/postgres/sqlc/queries.sql
@@ -223,7 +223,12 @@ LEFT JOIN LATERAL (
 ) run_start ON true
 LEFT JOIN LATERAL (
   SELECT
-    COALESCE((status_spans.attributes#>>'{}')::json->>'sys.function.status.code', status_spans.status, '')::TEXT AS status,
+    COALESCE(
+      (status_spans.attributes#>>'{}')::json->>'sys.function.status.code',
+      (status_spans.attributes#>>'{}')::json->>'_inngest.dynamic.status',
+      status_spans.status,
+      ''
+    )::TEXT AS status,
     end_time
   FROM spans status_spans
   WHERE status_spans.run_id = spans.run_id
@@ -233,7 +238,15 @@ LEFT JOIN LATERAL (
     -- run status.
     AND (
       COALESCE((status_spans.attributes#>>'{}')::json->>'sys.function.status.code', '') <> ''
-      OR COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') = 'true'
+      OR (
+        COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') IN ('true', '1')
+        AND COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.retryable', '') NOT IN ('true', '1')
+      )
+      -- Terminal runs may only update the root dynamic status.
+      OR (
+        COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.dynamic.span.id', '') = spans.span_id
+        AND COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.dynamic.status', status_spans.status, '') IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut', 'Skipped')
+      )
     )
   ORDER BY status_spans.end_time DESC
   LIMIT 1
@@ -245,7 +258,7 @@ LEFT JOIN LATERAL (
     AND output_spans.debug_run_id IS NULL
     AND output_spans.output IS NOT NULL
   ORDER BY
-    COALESCE((output_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') != 'true',
+    COALESCE((output_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') NOT IN ('true', '1'),
     output_spans.end_time DESC
   LIMIT 1
 ) run_output ON true

--- a/pkg/db/postgres/sqlc/queries.sql
+++ b/pkg/db/postgres/sqlc/queries.sql
@@ -194,84 +194,82 @@ LEFT JOIN function_finishes ON function_finishes.run_id = function_runs.run_id
 WHERE function_runs.event_id IN (SELECT UNNEST(sqlc.slice('event_ids')::BYTEA[]));
 
 -- name: GetRuns :many
-SELECT
-  spans.run_id,
-  spans.function_id,
-  spans.app_id,
-  COALESCE(run_start.start_time, spans.start_time) AS start_time,
-  COALESCE(run_status.end_time, spans.end_time) AS end_time,
-  -- Child spans mean user code has started even if the root run span still says queued.
-  COALESCE(run_status.status, CASE WHEN run_start.start_time IS NOT NULL THEN 'Running' END, spans.status, '') AS status,
-  COALESCE(run_output.output::text, spans.output::text, '') AS output,
-  COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.slug', '') AS function_slug,
-  COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.name', '') AS function_name,
-  COALESCE(apps.name, '') AS app_name,
-  COALESCE((spans.attributes#>>'{}')::json->>'_inngest.batch.id', '') AS batch_id,
-  COALESCE((spans.attributes#>>'{}')::json->>'_inngest.cron.schedule', '') AS cron_schedule
-FROM spans
-LEFT JOIN apps ON apps.id::text = spans.app_id AND apps.archived_at IS NULL
-LEFT JOIN LATERAL (
-  SELECT start_time
-  FROM spans start_spans
-  WHERE start_spans.run_id = spans.run_id
-    AND start_spans.debug_run_id IS NULL
-    AND start_spans.parent_span_id IS NOT NULL
-    AND start_spans.parent_span_id <> ''
-    AND start_spans.parent_span_id <> '0000000000000000'
-  ORDER BY start_spans.start_time
-  LIMIT 1
-) run_start ON true
-LEFT JOIN LATERAL (
+-- Mirrors the span-runs grouping the GraphQL runs list uses (GetSpanRuns): a
+-- run is its executor.run root row plus extension rows sharing the root's
+-- dynamic_span_id, and the latest row in that group carries the run's current
+-- status. Child/step spans never decide run status.
+WITH run_roots AS (
   SELECT
-    COALESCE(
-      (status_spans.attributes#>>'{}')::json->>'sys.function.status.code',
-      (status_spans.attributes#>>'{}')::json->>'_inngest.dynamic.status',
-      status_spans.status,
-      ''
-    )::TEXT AS status,
-    end_time
-  FROM spans status_spans
-  WHERE status_spans.run_id = spans.run_id
-    AND status_spans.debug_run_id IS NULL
-    -- Step spans can finish while the run is still active; only function
-    -- status code spans or final function-output spans should decide terminal
-    -- run status.
-    AND (
-      COALESCE((status_spans.attributes#>>'{}')::json->>'sys.function.status.code', '') <> ''
-      OR (
-        COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') IN ('true', '1')
-        AND COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.retryable', '') NOT IN ('true', '1')
-      )
-      -- Terminal runs may only update the root dynamic status.
-      OR (
-        COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.dynamic.span.id', '') = spans.span_id
-        AND COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.dynamic.status', status_spans.status, '') IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut', 'Skipped')
-      )
+    spans.run_id,
+    spans.dynamic_span_id,
+    spans.function_id,
+    spans.app_id,
+    spans.start_time AS root_start_time,
+    spans.end_time AS root_end_time,
+    CAST(spans.output AS TEXT) AS root_output,
+    COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.slug', '') AS function_slug,
+    COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.name', '') AS function_name,
+    COALESCE(apps.name, '') AS app_name,
+    COALESCE((spans.attributes#>>'{}')::json->>'_inngest.batch.id', '') AS batch_id,
+    COALESCE((spans.attributes#>>'{}')::json->>'_inngest.cron.schedule', '') AS cron_schedule
+  FROM spans
+  LEFT JOIN apps ON apps.id::text = spans.app_id AND apps.archived_at IS NULL
+  WHERE spans.name = sqlc.arg('name')
+    AND spans.debug_run_id IS NULL
+    AND spans.run_id > sqlc.arg('cursor_run_id')::TEXT
+    AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements_text(NULLIF(spans.event_ids#>>'{}', '')::jsonb) AS eid(event_id)
+      WHERE eid.event_id = sqlc.arg('event_id')::TEXT
     )
-  ORDER BY status_spans.end_time DESC
-  LIMIT 1
-) run_status ON true
-LEFT JOIN LATERAL (
-  SELECT output
-  FROM spans output_spans
-  WHERE output_spans.run_id = spans.run_id
-    AND output_spans.debug_run_id IS NULL
-    AND output_spans.output IS NOT NULL
-  ORDER BY
-    COALESCE((output_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') NOT IN ('true', '1'),
-    output_spans.end_time DESC
-  LIMIT 1
-) run_output ON true
-WHERE spans.name = sqlc.arg('name')
-  AND spans.debug_run_id IS NULL
-  AND spans.run_id > sqlc.arg('cursor_run_id')::TEXT
-  AND EXISTS (
-    SELECT 1
-    FROM jsonb_array_elements_text(NULLIF(spans.event_ids#>>'{}', '')::jsonb) AS eid(event_id)
-    WHERE eid.event_id = sqlc.arg('event_id')::TEXT
-  )
-ORDER BY spans.run_id
-LIMIT @limit_rows;
+  ORDER BY spans.run_id
+  LIMIT @limit_rows
+)
+SELECT
+  run_roots.run_id,
+  run_roots.function_id,
+  run_roots.app_id,
+  CAST(COALESCE((
+    SELECT MIN(group_spans.start_time)
+    FROM spans group_spans
+    WHERE group_spans.run_id = run_roots.run_id
+      AND group_spans.dynamic_span_id = run_roots.dynamic_span_id
+      AND group_spans.debug_run_id IS NULL
+  ), run_roots.root_start_time) AS TIMESTAMPTZ) AS start_time,
+  CAST(COALESCE((
+    SELECT MAX(group_spans.end_time)
+    FROM spans group_spans
+    WHERE group_spans.run_id = run_roots.run_id
+      AND group_spans.dynamic_span_id = run_roots.dynamic_span_id
+      AND group_spans.debug_run_id IS NULL
+  ), run_roots.root_end_time) AS TIMESTAMPTZ) AS end_time,
+  CAST(COALESCE((
+    SELECT status_spans.status
+    FROM spans status_spans
+    WHERE status_spans.run_id = run_roots.run_id
+      AND status_spans.dynamic_span_id = run_roots.dynamic_span_id
+      AND status_spans.debug_run_id IS NULL
+    ORDER BY status_spans.end_time DESC
+    LIMIT 1
+  ), '') AS TEXT) AS status,
+  COALESCE((
+    SELECT CAST(output_lookup.output AS TEXT)
+    FROM spans output_lookup
+    WHERE output_lookup.run_id = run_roots.run_id
+      AND output_lookup.output IS NOT NULL
+      AND output_lookup.debug_run_id IS NULL
+    ORDER BY
+      CASE WHEN COALESCE((output_lookup.attributes#>>'{}')::json->>'_inngest.is.function.output', '') IN ('true', '1') THEN 0 ELSE 1 END,
+      output_lookup.end_time DESC
+    LIMIT 1
+  ), run_roots.root_output, '') AS output,
+  run_roots.function_slug,
+  run_roots.function_name,
+  run_roots.app_name,
+  run_roots.batch_id,
+  run_roots.cron_schedule
+FROM run_roots
+ORDER BY run_roots.run_id;
 
 -- name: GetFunctionRunFinishesByRunIDs :many
 SELECT * FROM function_finishes WHERE run_id = ANY($1::BYTEA[]);

--- a/pkg/db/postgres/sqlc/queries.sql
+++ b/pkg/db/postgres/sqlc/queries.sql
@@ -200,7 +200,8 @@ SELECT
   spans.app_id,
   COALESCE(run_start.start_time, spans.start_time) AS start_time,
   COALESCE(run_status.end_time, spans.end_time) AS end_time,
-  COALESCE(run_status.status, spans.status, '') AS status,
+  -- Child spans mean user code has started even if the root run span still says queued.
+  COALESCE(run_status.status, CASE WHEN run_start.start_time IS NOT NULL THEN 'Running' END, spans.status, '') AS status,
   COALESCE(run_output.output::text, spans.output::text, '') AS output,
   COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.slug', '') AS function_slug,
   COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.name', '') AS function_name,
@@ -221,11 +222,19 @@ LEFT JOIN LATERAL (
   LIMIT 1
 ) run_start ON true
 LEFT JOIN LATERAL (
-  SELECT status, end_time
+  SELECT
+    COALESCE((status_spans.attributes#>>'{}')::json->>'sys.function.status.code', status_spans.status, '')::TEXT AS status,
+    end_time
   FROM spans status_spans
   WHERE status_spans.run_id = spans.run_id
     AND status_spans.debug_run_id IS NULL
-    AND status_spans.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
+    -- Step spans can finish while the run is still active; only function
+    -- status code spans or final function-output spans should decide terminal
+    -- run status.
+    AND (
+      COALESCE((status_spans.attributes#>>'{}')::json->>'sys.function.status.code', '') <> ''
+      OR COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') = 'true'
+    )
   ORDER BY status_spans.end_time DESC
   LIMIT 1
 ) run_status ON true

--- a/pkg/db/postgres/sqlc/queries.sql.go
+++ b/pkg/db/postgres/sqlc/queries.sql.go
@@ -1233,83 +1233,78 @@ func (q *Queries) GetRunSpanByRunID(ctx context.Context, arg GetRunSpanByRunIDPa
 }
 
 const getRuns = `-- name: GetRuns :many
-SELECT
-  spans.run_id,
-  spans.function_id,
-  spans.app_id,
-  COALESCE(run_start.start_time, spans.start_time) AS start_time,
-  COALESCE(run_status.end_time, spans.end_time) AS end_time,
-  -- Child spans mean user code has started even if the root run span still says queued.
-  COALESCE(run_status.status, CASE WHEN run_start.start_time IS NOT NULL THEN 'Running' END, spans.status, '') AS status,
-  COALESCE(run_output.output::text, spans.output::text, '') AS output,
-  COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.slug', '') AS function_slug,
-  COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.name', '') AS function_name,
-  COALESCE(apps.name, '') AS app_name,
-  COALESCE((spans.attributes#>>'{}')::json->>'_inngest.batch.id', '') AS batch_id,
-  COALESCE((spans.attributes#>>'{}')::json->>'_inngest.cron.schedule', '') AS cron_schedule
-FROM spans
-LEFT JOIN apps ON apps.id::text = spans.app_id AND apps.archived_at IS NULL
-LEFT JOIN LATERAL (
-  SELECT start_time
-  FROM spans start_spans
-  WHERE start_spans.run_id = spans.run_id
-    AND start_spans.debug_run_id IS NULL
-    AND start_spans.parent_span_id IS NOT NULL
-    AND start_spans.parent_span_id <> ''
-    AND start_spans.parent_span_id <> '0000000000000000'
-  ORDER BY start_spans.start_time
-  LIMIT 1
-) run_start ON true
-LEFT JOIN LATERAL (
+WITH run_roots AS (
   SELECT
-    COALESCE(
-      (status_spans.attributes#>>'{}')::json->>'sys.function.status.code',
-      (status_spans.attributes#>>'{}')::json->>'_inngest.dynamic.status',
-      status_spans.status,
-      ''
-    )::TEXT AS status,
-    end_time
-  FROM spans status_spans
-  WHERE status_spans.run_id = spans.run_id
-    AND status_spans.debug_run_id IS NULL
-    -- Step spans can finish while the run is still active; only function
-    -- status code spans or final function-output spans should decide terminal
-    -- run status.
-    AND (
-      COALESCE((status_spans.attributes#>>'{}')::json->>'sys.function.status.code', '') <> ''
-      OR (
-        COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') IN ('true', '1')
-        AND COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.retryable', '') NOT IN ('true', '1')
-      )
-      OR (
-        COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.dynamic.span.id', '') = spans.span_id
-        AND COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.dynamic.status', status_spans.status, '') IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut', 'Skipped')
-      )
+    spans.run_id,
+    spans.dynamic_span_id,
+    spans.function_id,
+    spans.app_id,
+    spans.start_time AS root_start_time,
+    spans.end_time AS root_end_time,
+    CAST(spans.output AS TEXT) AS root_output,
+    COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.slug', '') AS function_slug,
+    COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.name', '') AS function_name,
+    COALESCE(apps.name, '') AS app_name,
+    COALESCE((spans.attributes#>>'{}')::json->>'_inngest.batch.id', '') AS batch_id,
+    COALESCE((spans.attributes#>>'{}')::json->>'_inngest.cron.schedule', '') AS cron_schedule
+  FROM spans
+  LEFT JOIN apps ON apps.id::text = spans.app_id AND apps.archived_at IS NULL
+  WHERE spans.name = $1
+    AND spans.debug_run_id IS NULL
+    AND spans.run_id > $2::TEXT
+    AND EXISTS (
+      SELECT 1
+      FROM jsonb_array_elements_text(NULLIF(spans.event_ids#>>'{}', '')::jsonb) AS eid(event_id)
+      WHERE eid.event_id = $3::TEXT
     )
-  ORDER BY status_spans.end_time DESC
-  LIMIT 1
-) run_status ON true
-LEFT JOIN LATERAL (
-  SELECT output
-  FROM spans output_spans
-  WHERE output_spans.run_id = spans.run_id
-    AND output_spans.debug_run_id IS NULL
-    AND output_spans.output IS NOT NULL
-  ORDER BY
-    COALESCE((output_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') NOT IN ('true', '1'),
-    output_spans.end_time DESC
-  LIMIT 1
-) run_output ON true
-WHERE spans.name = $1
-  AND spans.debug_run_id IS NULL
-  AND spans.run_id > $2::TEXT
-  AND EXISTS (
-    SELECT 1
-    FROM jsonb_array_elements_text(NULLIF(spans.event_ids#>>'{}', '')::jsonb) AS eid(event_id)
-    WHERE eid.event_id = $3::TEXT
-  )
-ORDER BY spans.run_id
-LIMIT $4
+  ORDER BY spans.run_id
+  LIMIT $4
+)
+SELECT
+  run_roots.run_id,
+  run_roots.function_id,
+  run_roots.app_id,
+  CAST(COALESCE((
+    SELECT MIN(group_spans.start_time)
+    FROM spans group_spans
+    WHERE group_spans.run_id = run_roots.run_id
+      AND group_spans.dynamic_span_id = run_roots.dynamic_span_id
+      AND group_spans.debug_run_id IS NULL
+  ), run_roots.root_start_time) AS TIMESTAMPTZ) AS start_time,
+  CAST(COALESCE((
+    SELECT MAX(group_spans.end_time)
+    FROM spans group_spans
+    WHERE group_spans.run_id = run_roots.run_id
+      AND group_spans.dynamic_span_id = run_roots.dynamic_span_id
+      AND group_spans.debug_run_id IS NULL
+  ), run_roots.root_end_time) AS TIMESTAMPTZ) AS end_time,
+  CAST(COALESCE((
+    SELECT status_spans.status
+    FROM spans status_spans
+    WHERE status_spans.run_id = run_roots.run_id
+      AND status_spans.dynamic_span_id = run_roots.dynamic_span_id
+      AND status_spans.debug_run_id IS NULL
+    ORDER BY status_spans.end_time DESC
+    LIMIT 1
+  ), '') AS TEXT) AS status,
+  COALESCE((
+    SELECT CAST(output_lookup.output AS TEXT)
+    FROM spans output_lookup
+    WHERE output_lookup.run_id = run_roots.run_id
+      AND output_lookup.output IS NOT NULL
+      AND output_lookup.debug_run_id IS NULL
+    ORDER BY
+      CASE WHEN COALESCE((output_lookup.attributes#>>'{}')::json->>'_inngest.is.function.output', '') IN ('true', '1') THEN 0 ELSE 1 END,
+      output_lookup.end_time DESC
+    LIMIT 1
+  ), run_roots.root_output, '') AS output,
+  run_roots.function_slug,
+  run_roots.function_name,
+  run_roots.app_name,
+  run_roots.batch_id,
+  run_roots.cron_schedule
+FROM run_roots
+ORDER BY run_roots.run_id
 `
 
 type GetRunsParams struct {
@@ -1326,7 +1321,7 @@ type GetRunsRow struct {
 	StartTime    time.Time
 	EndTime      time.Time
 	Status       string
-	Output       interface{}
+	Output       string
 	FunctionSlug interface{}
 	FunctionName interface{}
 	AppName      string
@@ -1334,6 +1329,10 @@ type GetRunsRow struct {
 	CronSchedule interface{}
 }
 
+// Mirrors the span-runs grouping the GraphQL runs list uses (GetSpanRuns): a
+// run is its executor.run root row plus extension rows sharing the root's
+// dynamic_span_id, and the latest row in that group carries the run's current
+// status. Child/step spans never decide run status.
 func (q *Queries) GetRuns(ctx context.Context, arg GetRunsParams) ([]*GetRunsRow, error) {
 	rows, err := q.db.QueryContext(ctx, getRuns,
 		arg.Name,

--- a/pkg/db/postgres/sqlc/queries.sql.go
+++ b/pkg/db/postgres/sqlc/queries.sql.go
@@ -1262,7 +1262,12 @@ LEFT JOIN LATERAL (
 ) run_start ON true
 LEFT JOIN LATERAL (
   SELECT
-    COALESCE((status_spans.attributes#>>'{}')::json->>'sys.function.status.code', status_spans.status, '')::TEXT AS status,
+    COALESCE(
+      (status_spans.attributes#>>'{}')::json->>'sys.function.status.code',
+      (status_spans.attributes#>>'{}')::json->>'_inngest.dynamic.status',
+      status_spans.status,
+      ''
+    )::TEXT AS status,
     end_time
   FROM spans status_spans
   WHERE status_spans.run_id = spans.run_id
@@ -1272,7 +1277,14 @@ LEFT JOIN LATERAL (
     -- run status.
     AND (
       COALESCE((status_spans.attributes#>>'{}')::json->>'sys.function.status.code', '') <> ''
-      OR COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') = 'true'
+      OR (
+        COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') IN ('true', '1')
+        AND COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.retryable', '') NOT IN ('true', '1')
+      )
+      OR (
+        COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.dynamic.span.id', '') = spans.span_id
+        AND COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.dynamic.status', status_spans.status, '') IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut', 'Skipped')
+      )
     )
   ORDER BY status_spans.end_time DESC
   LIMIT 1
@@ -1284,7 +1296,7 @@ LEFT JOIN LATERAL (
     AND output_spans.debug_run_id IS NULL
     AND output_spans.output IS NOT NULL
   ORDER BY
-    COALESCE((output_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') != 'true',
+    COALESCE((output_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') NOT IN ('true', '1'),
     output_spans.end_time DESC
   LIMIT 1
 ) run_output ON true

--- a/pkg/db/postgres/sqlc/queries.sql.go
+++ b/pkg/db/postgres/sqlc/queries.sql.go
@@ -1239,7 +1239,8 @@ SELECT
   spans.app_id,
   COALESCE(run_start.start_time, spans.start_time) AS start_time,
   COALESCE(run_status.end_time, spans.end_time) AS end_time,
-  COALESCE(run_status.status, spans.status, '') AS status,
+  -- Child spans mean user code has started even if the root run span still says queued.
+  COALESCE(run_status.status, CASE WHEN run_start.start_time IS NOT NULL THEN 'Running' END, spans.status, '') AS status,
   COALESCE(run_output.output::text, spans.output::text, '') AS output,
   COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.slug', '') AS function_slug,
   COALESCE((spans.attributes#>>'{}')::json->>'_inngest.function.name', '') AS function_name,
@@ -1260,11 +1261,19 @@ LEFT JOIN LATERAL (
   LIMIT 1
 ) run_start ON true
 LEFT JOIN LATERAL (
-  SELECT status, end_time
+  SELECT
+    COALESCE((status_spans.attributes#>>'{}')::json->>'sys.function.status.code', status_spans.status, '')::TEXT AS status,
+    end_time
   FROM spans status_spans
   WHERE status_spans.run_id = spans.run_id
     AND status_spans.debug_run_id IS NULL
-    AND status_spans.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
+    -- Step spans can finish while the run is still active; only function
+    -- status code spans or final function-output spans should decide terminal
+    -- run status.
+    AND (
+      COALESCE((status_spans.attributes#>>'{}')::json->>'sys.function.status.code', '') <> ''
+      OR COALESCE((status_spans.attributes#>>'{}')::json->>'_inngest.is.function.output', '') = 'true'
+    )
   ORDER BY status_spans.end_time DESC
   LIMIT 1
 ) run_status ON true

--- a/pkg/db/run_status.go
+++ b/pkg/db/run_status.go
@@ -1,0 +1,21 @@
+package db
+
+import (
+	"strconv"
+
+	"github.com/inngest/inngest/pkg/enums"
+)
+
+func RunStatusFromSpanStatus(statusText string) enums.RunStatus {
+	if code, err := strconv.ParseInt(statusText, 10, 64); err == nil {
+		if status := enums.RunCodeToStatus(code); status != enums.RunStatusUnknown {
+			return status
+		}
+	}
+
+	if stepStatus, err := enums.StepStatusString(statusText); err == nil && stepStatus != enums.StepStatusUnknown {
+		return enums.StepStatusToRunStatus(stepStatus)
+	}
+
+	return enums.RunStatusRunning
+}

--- a/pkg/db/run_status.go
+++ b/pkg/db/run_status.go
@@ -1,18 +1,13 @@
 package db
 
 import (
-	"strconv"
-
 	"github.com/inngest/inngest/pkg/enums"
 )
 
+// span statuses are StepStatus strings stamped onto run-root extension rows;
+// an absent or unknown status means the run is still in flight, matching the
+// GraphQL runs list behavior
 func RunStatusFromSpanStatus(statusText string) enums.RunStatus {
-	if code, err := strconv.ParseInt(statusText, 10, 64); err == nil {
-		if status := enums.RunCodeToStatus(code); status != enums.RunStatusUnknown {
-			return status
-		}
-	}
-
 	if stepStatus, err := enums.StepStatusString(statusText); err == nil && stepStatus != enums.StepStatusUnknown {
 		return enums.StepStatusToRunStatus(stepStatus)
 	}

--- a/pkg/db/sqlite/querier.go
+++ b/pkg/db/sqlite/querier.go
@@ -366,13 +366,8 @@ func scanSpanRunListRows(rows []*sqlc.GetRunsRow, arg db.GetRunsParams) ([]*db.R
 			return nil, err
 		}
 
-		status := enums.RunStatusRunning
 		statusText := r.Status
-		if statusText != "" {
-			if stepStatus, err := enums.StepStatusString(statusText); err == nil && stepStatus != enums.StepStatusUnknown {
-				status = enums.StepStatusToRunStatus(stepStatus)
-			}
-		}
+		status := db.RunStatusFromSpanStatus(statusText)
 
 		batchIDText := valueString(r.BatchID)
 		var batchID ulid.ULID

--- a/pkg/db/sqlite/querier_runs_test.go
+++ b/pkg/db/sqlite/querier_runs_test.go
@@ -150,6 +150,139 @@ func TestQuerierGetRunsUsesChildSpanSummary(t *testing.T) {
 	require.JSONEq(t, `{"data":{"body":"Hello, World!"}}`, string(rows[0].Output))
 }
 
+func TestQuerierGetRunsIgnoresCompletedNonOutputChildStatus(t *testing.T) {
+	ctx := context.Background()
+	conn, err := Open(ctx, Options{ForTest: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	q := New(conn).Q()
+	runID := ulid.Make()
+	eventID := ulid.Make()
+	appID := uuid.New()
+	fnID := uuid.New()
+	startedAt := time.Now().UTC().Truncate(time.Millisecond)
+	childStartedAt := startedAt.Add(50 * time.Millisecond)
+	childEndedAt := startedAt.Add(time.Second)
+	_, err = q.UpsertApp(ctx, db.UpsertAppParams{
+		ID:          appID,
+		Name:        "event-runs-app",
+		SdkLanguage: "go",
+		SdkVersion:  "1.0.0",
+		Metadata:    "{}",
+		Status:      "active",
+		Checksum:    "checksum",
+		Url:         "https://example.com/inngest",
+		Method:      "POST",
+	})
+	require.NoError(t, err)
+	require.NoError(t, insertRunSpan(ctx, q, runSpan{
+		RunID:        runID,
+		EventIDs:     []ulid.ULID{eventID},
+		AppID:        appID,
+		FunctionID:   fnID,
+		FunctionSlug: "event-runs-function",
+		FunctionName: "Event Runs Function",
+		StartedAt:    startedAt,
+		EndedAt:      startedAt,
+		Status:       enums.StepStatusQueued.String(),
+	}))
+
+	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
+		SpanID:       ulid.Make().String(),
+		TraceID:      "trace-" + runID.String(),
+		Name:         meta.SpanNameExecution,
+		ParentSpanID: sql.NullString{String: "run-span", Valid: true},
+		StartTime:    childStartedAt,
+		EndTime:      childEndedAt,
+		RunID:        runID.String(),
+		AccountID:    uuid.NewString(),
+		AppID:        appID.String(),
+		FunctionID:   fnID.String(),
+		EnvID:        uuid.NewString(),
+		Attributes:   []byte(`{}`),
+		Links:        []byte(`[]`),
+		Output:       []byte(`{"data":{"step":"done"}}`),
+		Status:       sql.NullString{String: enums.StepStatusCompleted.String(), Valid: true},
+		EventIds:     []byte(`[]`),
+	}))
+
+	rows, err := q.GetRuns(ctx, db.GetRunsParams{EventID: eventID, Limit: 1, IncludeOutput: true})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, childStartedAt, rows[0].FunctionRun.RunStartedAt)
+	require.Equal(t, "Running", rows[0].FunctionFinish.Status.String)
+	require.False(t, rows[0].FunctionFinish.CreatedAt.Valid)
+	require.JSONEq(t, `{"data":{"step":"done"}}`, string(rows[0].Output))
+}
+
+func TestQuerierGetRunsUsesFunctionStatusCodeForCancellation(t *testing.T) {
+	ctx := context.Background()
+	conn, err := Open(ctx, Options{ForTest: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	q := New(conn).Q()
+	runID := ulid.Make()
+	eventID := ulid.Make()
+	appID := uuid.New()
+	fnID := uuid.New()
+	startedAt := time.Now().UTC().Truncate(time.Millisecond)
+	cancelledAt := startedAt.Add(time.Second)
+	_, err = q.UpsertApp(ctx, db.UpsertAppParams{
+		ID:          appID,
+		Name:        "event-runs-app",
+		SdkLanguage: "go",
+		SdkVersion:  "1.0.0",
+		Metadata:    "{}",
+		Status:      "active",
+		Checksum:    "checksum",
+		Url:         "https://example.com/inngest",
+		Method:      "POST",
+	})
+	require.NoError(t, err)
+	require.NoError(t, insertRunSpan(ctx, q, runSpan{
+		RunID:        runID,
+		EventIDs:     []ulid.ULID{eventID},
+		AppID:        appID,
+		FunctionID:   fnID,
+		FunctionSlug: "event-runs-function",
+		FunctionName: "Event Runs Function",
+		StartedAt:    startedAt,
+		EndedAt:      startedAt,
+		Status:       enums.StepStatusQueued.String(),
+	}))
+
+	attrs, err := json.Marshal(map[string]any{
+		"sys.function.status.code": enums.RunStatusCancelled.ToCode(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
+		SpanID:       ulid.Make().String(),
+		TraceID:      "trace-" + runID.String(),
+		Name:         "long-running",
+		ParentSpanID: sql.NullString{String: "run-span", Valid: true},
+		StartTime:    startedAt,
+		EndTime:      cancelledAt,
+		RunID:        runID.String(),
+		AccountID:    uuid.NewString(),
+		AppID:        appID.String(),
+		FunctionID:   fnID.String(),
+		EnvID:        uuid.NewString(),
+		Attributes:   attrs,
+		Links:        []byte(`[]`),
+		Status:       sql.NullString{},
+		EventIds:     []byte(`[]`),
+	}))
+
+	rows, err := q.GetRuns(ctx, db.GetRunsParams{EventID: eventID, Limit: 1})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	require.Equal(t, "Cancelled", rows[0].FunctionFinish.Status.String)
+	require.True(t, rows[0].FunctionFinish.CreatedAt.Valid)
+	require.Equal(t, cancelledAt, rows[0].FunctionFinish.CreatedAt.Time)
+}
+
 func TestQuerierGetRunsError(t *testing.T) {
 	ctx := context.Background()
 	conn, err := Open(ctx, Options{ForTest: true})

--- a/pkg/db/sqlite/querier_runs_test.go
+++ b/pkg/db/sqlite/querier_runs_test.go
@@ -29,19 +29,10 @@ func TestQuerierGetRuns(t *testing.T) {
 	appID := uuid.New()
 	fnID := uuid.New()
 	startedAt := time.Now().UTC().Truncate(time.Millisecond)
-	_, err = q.UpsertApp(ctx, db.UpsertAppParams{
-		ID:          appID,
-		Name:        "event-runs-app",
-		SdkLanguage: "go",
-		SdkVersion:  "1.0.0",
-		Metadata:    "{}",
-		Status:      "active",
-		Checksum:    "checksum",
-		Url:         "https://example.com/inngest",
-		Method:      "POST",
-	})
-	require.NoError(t, err)
-	require.NoError(t, insertRunSpan(ctx, q, runSpan{
+	endedAt := startedAt.Add(time.Second)
+	upsertTestApp(ctx, t, q, appID)
+
+	root := runSpan{
 		RunID:        runID,
 		EventIDs:     []ulid.ULID{eventID, batchEventID},
 		BatchID:      batchID,
@@ -52,9 +43,11 @@ func TestQuerierGetRuns(t *testing.T) {
 		Output:       []byte(`{"data":{"ok":true}}`),
 		Cron:         "*/5 * * * *",
 		StartedAt:    startedAt,
-		EndedAt:      startedAt.Add(time.Second),
-		Status:       enums.StepStatusCompleted.String(),
-	}))
+		EndedAt:      startedAt,
+		Status:       enums.StepStatusQueued.String(),
+	}
+	require.NoError(t, insertRunSpan(ctx, q, root))
+	require.NoError(t, extendRunSpan(ctx, q, root, endedAt, enums.StepStatusCompleted.String()))
 
 	rows, err := q.GetRuns(ctx, db.GetRunsParams{EventID: eventID, Limit: 1, IncludeOutput: true})
 	require.NoError(t, err)
@@ -64,8 +57,10 @@ func TestQuerierGetRuns(t *testing.T) {
 	require.Equal(t, batchID, rows[0].FunctionRun.BatchID)
 	require.Equal(t, "cron", rows[0].FunctionRun.TriggerType)
 	require.Equal(t, "*/5 * * * *", rows[0].FunctionRun.Cron.String)
+	require.Equal(t, startedAt, rows[0].FunctionRun.RunStartedAt)
 	require.Equal(t, "Completed", rows[0].FunctionFinish.Status.String)
 	require.True(t, rows[0].FunctionFinish.CreatedAt.Valid)
+	require.Equal(t, endedAt, rows[0].FunctionFinish.CreatedAt.Time)
 	require.Equal(t, "event-runs-app", rows[0].AppName)
 	require.Equal(t, "event-runs-function", rows[0].FunctionSlug)
 	require.Equal(t, "Event Runs Function", rows[0].FunctionName)
@@ -79,7 +74,7 @@ func TestQuerierGetRuns(t *testing.T) {
 	require.Empty(t, rows[0].Output)
 }
 
-func TestQuerierGetRunsUsesChildSpanSummary(t *testing.T) {
+func TestQuerierGetRunsPrefersFunctionOutputSpan(t *testing.T) {
 	ctx := context.Background()
 	conn, err := Open(ctx, Options{ForTest: true})
 	require.NoError(t, err)
@@ -93,19 +88,9 @@ func TestQuerierGetRunsUsesChildSpanSummary(t *testing.T) {
 	startedAt := time.Now().UTC().Truncate(time.Millisecond)
 	childStartedAt := startedAt.Add(50 * time.Millisecond)
 	endedAt := startedAt.Add(time.Second)
-	_, err = q.UpsertApp(ctx, db.UpsertAppParams{
-		ID:          appID,
-		Name:        "event-runs-app",
-		SdkLanguage: "go",
-		SdkVersion:  "1.0.0",
-		Metadata:    "{}",
-		Status:      "active",
-		Checksum:    "checksum",
-		Url:         "https://example.com/inngest",
-		Method:      "POST",
-	})
-	require.NoError(t, err)
-	require.NoError(t, insertRunSpan(ctx, q, runSpan{
+	upsertTestApp(ctx, t, q, appID)
+
+	root := runSpan{
 		RunID:        runID,
 		EventIDs:     []ulid.ULID{eventID},
 		AppID:        appID,
@@ -115,7 +100,9 @@ func TestQuerierGetRunsUsesChildSpanSummary(t *testing.T) {
 		StartedAt:    startedAt,
 		EndedAt:      startedAt,
 		Status:       enums.StepStatusQueued.String(),
-	}))
+	}
+	require.NoError(t, insertRunSpan(ctx, q, root))
+	require.NoError(t, extendRunSpan(ctx, q, root, endedAt, enums.StepStatusCompleted.String()))
 
 	attrs, err := json.Marshal(map[string]any{
 		meta.Attrs.IsFunctionOutput.Key(): true,
@@ -127,7 +114,7 @@ func TestQuerierGetRunsUsesChildSpanSummary(t *testing.T) {
 		Name:         meta.SpanNameExecution,
 		ParentSpanID: sql.NullString{String: "run-span", Valid: true},
 		StartTime:    childStartedAt,
-		EndTime:      endedAt,
+		EndTime:      endedAt.Add(-100 * time.Millisecond),
 		RunID:        runID.String(),
 		AccountID:    uuid.NewString(),
 		AppID:        appID.String(),
@@ -140,17 +127,38 @@ func TestQuerierGetRunsUsesChildSpanSummary(t *testing.T) {
 		EventIds:     []byte(`[]`),
 	}))
 
+	//
+	// a later step output without the function-output marker must not win
+	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
+		SpanID:       ulid.Make().String(),
+		TraceID:      "trace-" + runID.String(),
+		Name:         meta.SpanNameExecution,
+		ParentSpanID: sql.NullString{String: "run-span", Valid: true},
+		StartTime:    childStartedAt,
+		EndTime:      endedAt.Add(-50 * time.Millisecond),
+		RunID:        runID.String(),
+		AccountID:    uuid.NewString(),
+		AppID:        appID.String(),
+		FunctionID:   fnID.String(),
+		EnvID:        uuid.NewString(),
+		Attributes:   []byte(`{}`),
+		Links:        []byte(`[]`),
+		Output:       []byte(`{"data":{"step":"intermediate"}}`),
+		Status:       sql.NullString{String: enums.StepStatusCompleted.String(), Valid: true},
+		EventIds:     []byte(`[]`),
+	}))
+
 	rows, err := q.GetRuns(ctx, db.GetRunsParams{EventID: eventID, Limit: 1, IncludeOutput: true})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	require.Equal(t, childStartedAt, rows[0].FunctionRun.RunStartedAt)
+	require.Equal(t, startedAt, rows[0].FunctionRun.RunStartedAt)
 	require.Equal(t, "Completed", rows[0].FunctionFinish.Status.String)
 	require.True(t, rows[0].FunctionFinish.CreatedAt.Valid)
 	require.Equal(t, endedAt, rows[0].FunctionFinish.CreatedAt.Time)
 	require.JSONEq(t, `{"data":{"body":"Hello, World!"}}`, string(rows[0].Output))
 }
 
-func TestQuerierGetRunsIgnoresCompletedNonOutputChildStatus(t *testing.T) {
+func TestQuerierGetRunsIgnoresChildSpanStatus(t *testing.T) {
 	ctx := context.Background()
 	conn, err := Open(ctx, Options{ForTest: true})
 	require.NoError(t, err)
@@ -164,19 +172,9 @@ func TestQuerierGetRunsIgnoresCompletedNonOutputChildStatus(t *testing.T) {
 	startedAt := time.Now().UTC().Truncate(time.Millisecond)
 	childStartedAt := startedAt.Add(50 * time.Millisecond)
 	childEndedAt := startedAt.Add(time.Second)
-	_, err = q.UpsertApp(ctx, db.UpsertAppParams{
-		ID:          appID,
-		Name:        "event-runs-app",
-		SdkLanguage: "go",
-		SdkVersion:  "1.0.0",
-		Metadata:    "{}",
-		Status:      "active",
-		Checksum:    "checksum",
-		Url:         "https://example.com/inngest",
-		Method:      "POST",
-	})
-	require.NoError(t, err)
-	require.NoError(t, insertRunSpan(ctx, q, runSpan{
+	upsertTestApp(ctx, t, q, appID)
+
+	root := runSpan{
 		RunID:        runID,
 		EventIDs:     []ulid.ULID{eventID},
 		AppID:        appID,
@@ -186,8 +184,12 @@ func TestQuerierGetRunsIgnoresCompletedNonOutputChildStatus(t *testing.T) {
 		StartedAt:    startedAt,
 		EndedAt:      startedAt,
 		Status:       enums.StepStatusQueued.String(),
-	}))
+	}
+	require.NoError(t, insertRunSpan(ctx, q, root))
+	require.NoError(t, extendRunSpan(ctx, q, root, startedAt.Add(25*time.Millisecond), enums.StepStatusRunning.String()))
 
+	//
+	// a completed step span must not mark the whole run completed
 	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
 		SpanID:       ulid.Make().String(),
 		TraceID:      "trace-" + runID.String(),
@@ -210,13 +212,12 @@ func TestQuerierGetRunsIgnoresCompletedNonOutputChildStatus(t *testing.T) {
 	rows, err := q.GetRuns(ctx, db.GetRunsParams{EventID: eventID, Limit: 1, IncludeOutput: true})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	require.Equal(t, childStartedAt, rows[0].FunctionRun.RunStartedAt)
 	require.Equal(t, "Running", rows[0].FunctionFinish.Status.String)
 	require.False(t, rows[0].FunctionFinish.CreatedAt.Valid)
 	require.JSONEq(t, `{"data":{"step":"done"}}`, string(rows[0].Output))
 }
 
-func TestQuerierGetRunsUsesFunctionStatusCodeForCancellation(t *testing.T) {
+func TestQuerierGetRunsUsesLatestRootExtensionStatus(t *testing.T) {
 	ctx := context.Background()
 	conn, err := Open(ctx, Options{ForTest: true})
 	require.NoError(t, err)
@@ -229,19 +230,9 @@ func TestQuerierGetRunsUsesFunctionStatusCodeForCancellation(t *testing.T) {
 	fnID := uuid.New()
 	startedAt := time.Now().UTC().Truncate(time.Millisecond)
 	cancelledAt := startedAt.Add(time.Second)
-	_, err = q.UpsertApp(ctx, db.UpsertAppParams{
-		ID:          appID,
-		Name:        "event-runs-app",
-		SdkLanguage: "go",
-		SdkVersion:  "1.0.0",
-		Metadata:    "{}",
-		Status:      "active",
-		Checksum:    "checksum",
-		Url:         "https://example.com/inngest",
-		Method:      "POST",
-	})
-	require.NoError(t, err)
-	require.NoError(t, insertRunSpan(ctx, q, runSpan{
+	upsertTestApp(ctx, t, q, appID)
+
+	root := runSpan{
 		RunID:        runID,
 		EventIDs:     []ulid.ULID{eventID},
 		AppID:        appID,
@@ -251,29 +242,10 @@ func TestQuerierGetRunsUsesFunctionStatusCodeForCancellation(t *testing.T) {
 		StartedAt:    startedAt,
 		EndedAt:      startedAt,
 		Status:       enums.StepStatusQueued.String(),
-	}))
-
-	attrs, err := json.Marshal(map[string]any{
-		"sys.function.status.code": enums.RunStatusCancelled.ToCode(),
-	})
-	require.NoError(t, err)
-	require.NoError(t, q.InsertSpan(ctx, db.InsertSpanParams{
-		SpanID:       ulid.Make().String(),
-		TraceID:      "trace-" + runID.String(),
-		Name:         "long-running",
-		ParentSpanID: sql.NullString{String: "run-span", Valid: true},
-		StartTime:    startedAt,
-		EndTime:      cancelledAt,
-		RunID:        runID.String(),
-		AccountID:    uuid.NewString(),
-		AppID:        appID.String(),
-		FunctionID:   fnID.String(),
-		EnvID:        uuid.NewString(),
-		Attributes:   attrs,
-		Links:        []byte(`[]`),
-		Status:       sql.NullString{},
-		EventIds:     []byte(`[]`),
-	}))
+	}
+	require.NoError(t, insertRunSpan(ctx, q, root))
+	require.NoError(t, extendRunSpan(ctx, q, root, startedAt.Add(10*time.Millisecond), enums.StepStatusRunning.String()))
+	require.NoError(t, extendRunSpan(ctx, q, root, cancelledAt, enums.StepStatusCancelled.String()))
 
 	rows, err := q.GetRuns(ctx, db.GetRunsParams{EventID: eventID, Limit: 1})
 	require.NoError(t, err)
@@ -296,6 +268,22 @@ func TestQuerierGetRunsError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func upsertTestApp(ctx context.Context, t *testing.T, q db.Querier, appID uuid.UUID) {
+	t.Helper()
+	_, err := q.UpsertApp(ctx, db.UpsertAppParams{
+		ID:          appID,
+		Name:        "event-runs-app",
+		SdkLanguage: "go",
+		SdkVersion:  "1.0.0",
+		Metadata:    "{}",
+		Status:      "active",
+		Checksum:    "checksum",
+		Url:         "https://example.com/inngest",
+		Method:      "POST",
+	})
+	require.NoError(t, err)
+}
+
 type runSpan struct {
 	RunID        ulid.ULID
 	EventIDs     []ulid.ULID
@@ -311,6 +299,8 @@ type runSpan struct {
 	Status       string
 }
 
+// the exporter stores the run root as an executor.run row whose
+// dynamic_span_id doubles as the grouping key for later EXTEND rows
 func insertRunSpan(ctx context.Context, q db.Querier, span runSpan) error {
 	attrs := map[string]any{
 		meta.Attrs.FunctionSlug.Key(): span.FunctionSlug,
@@ -331,20 +321,46 @@ func insertRunSpan(ctx context.Context, q db.Querier, span runSpan) error {
 	eventIDBytes, _ := json.Marshal(eventIDs)
 
 	return q.InsertSpan(ctx, db.InsertSpanParams{
-		SpanID:     ulid.Make().String(),
-		TraceID:    "trace-" + span.RunID.String(),
-		Name:       meta.SpanNameRun,
-		StartTime:  span.StartedAt,
-		EndTime:    span.EndedAt,
-		RunID:      span.RunID.String(),
-		AccountID:  uuid.NewString(),
-		AppID:      span.AppID.String(),
-		FunctionID: span.FunctionID.String(),
-		EnvID:      uuid.NewString(),
-		Attributes: attrBytes,
-		Links:      []byte(`[]`),
-		Output:     span.Output,
-		Status:     sql.NullString{String: span.Status, Valid: span.Status != ""},
-		EventIds:   eventIDBytes,
+		SpanID:        runRootSpanID(span.RunID),
+		TraceID:       "trace-" + span.RunID.String(),
+		Name:          meta.SpanNameRun,
+		StartTime:     span.StartedAt,
+		EndTime:       span.EndedAt,
+		RunID:         span.RunID.String(),
+		AccountID:     uuid.NewString(),
+		AppID:         span.AppID.String(),
+		FunctionID:    span.FunctionID.String(),
+		EnvID:         uuid.NewString(),
+		DynamicSpanID: sql.NullString{String: runRootSpanID(span.RunID), Valid: true},
+		Attributes:    attrBytes,
+		Links:         []byte(`[]`),
+		Output:        span.Output,
+		Status:        sql.NullString{String: span.Status, Valid: span.Status != ""},
+		EventIds:      eventIDBytes,
 	})
+}
+
+// status transitions arrive as EXTEND rows sharing the root's dynamic_span_id
+func extendRunSpan(ctx context.Context, q db.Querier, span runSpan, at time.Time, status string) error {
+	return q.InsertSpan(ctx, db.InsertSpanParams{
+		SpanID:        ulid.Make().String(),
+		TraceID:       "trace-" + span.RunID.String(),
+		Name:          meta.SpanNameDynamicExtension,
+		StartTime:     at,
+		EndTime:       at,
+		RunID:         span.RunID.String(),
+		AccountID:     uuid.NewString(),
+		AppID:         span.AppID.String(),
+		FunctionID:    span.FunctionID.String(),
+		EnvID:         uuid.NewString(),
+		DynamicSpanID: sql.NullString{String: runRootSpanID(span.RunID), Valid: true},
+		Attributes:    []byte(`{}`),
+		Links:         []byte(`[]`),
+		Status:        sql.NullString{String: status, Valid: status != ""},
+		EventIds:      []byte(`[]`),
+	})
+}
+
+func runRootSpanID(runID ulid.ULID) string {
+	return "run-span-" + runID.String()
 }

--- a/pkg/db/sqlite/sqlc/querier.go
+++ b/pkg/db/sqlite/sqlc/querier.go
@@ -55,6 +55,10 @@ type Querier interface {
 	//
 	GetQueueSnapshotChunks(ctx context.Context, snapshotID interface{}) ([]*GetQueueSnapshotChunksRow, error)
 	GetRunSpanByRunID(ctx context.Context, arg GetRunSpanByRunIDParams) (*GetRunSpanByRunIDRow, error)
+	// Mirrors the span-runs grouping the GraphQL runs list uses (GetSpanRuns): a
+	// run is its executor.run root row plus extension rows sharing the root's
+	// dynamic_span_id, and the latest row in that group carries the run's current
+	// status. Child/step spans never decide run status.
 	GetRuns(ctx context.Context, arg GetRunsParams) ([]*GetRunsRow, error)
 	GetSpanBySpanID(ctx context.Context, arg GetSpanBySpanIDParams) (*GetSpanBySpanIDRow, error)
 	GetSpanOutput(ctx context.Context, ids []string) ([]*GetSpanOutputRow, error)

--- a/pkg/db/sqlite/sqlc/queries.sql
+++ b/pkg/db/sqlite/sqlc/queries.sql
@@ -174,35 +174,18 @@ LEFT JOIN function_finishes ON function_finishes.run_id = function_runs.run_id
 WHERE function_runs.event_id IN (sqlc.slice('event_ids'));
 
 -- name: GetRuns :many
+-- Mirrors the span-runs grouping the GraphQL runs list uses (GetSpanRuns): a
+-- run is its executor.run root row plus extension rows sharing the root's
+-- dynamic_span_id, and the latest row in that group carries the run's current
+-- status. Child/step spans never decide run status.
 WITH run_roots AS (
   SELECT
     spans.run_id,
-    spans.span_id AS root_span_id,
+    spans.dynamic_span_id,
     spans.function_id,
     spans.app_id,
-    -- Child spans mean user code has started even if the root run span still says queued.
-    EXISTS (
-      SELECT 1
-      FROM spans start_lookup
-      WHERE start_lookup.run_id = spans.run_id
-        AND start_lookup.debug_run_id IS NULL
-        AND start_lookup.parent_span_id IS NOT NULL
-        AND start_lookup.parent_span_id <> ''
-        AND start_lookup.parent_span_id <> '0000000000000000'
-    ) AS has_started,
-    CAST(COALESCE((
-      SELECT start_lookup.start_time
-      FROM spans start_lookup
-      WHERE start_lookup.run_id = spans.run_id
-        AND start_lookup.debug_run_id IS NULL
-        AND start_lookup.parent_span_id IS NOT NULL
-        AND start_lookup.parent_span_id <> ''
-        AND start_lookup.parent_span_id <> '0000000000000000'
-      ORDER BY start_lookup.start_time
-      LIMIT 1
-    ), spans.start_time) AS TEXT) AS start_time,
+    spans.start_time AS root_start_time,
     spans.end_time AS root_end_time,
-    spans.status AS root_status,
     CAST(spans.output AS TEXT) AS root_output,
     COALESCE(spans.attributes->>'$."_inngest.function.slug"', '') AS function_slug,
     COALESCE(spans.attributes->>'$."_inngest.function.name"', '') AS function_name,
@@ -217,48 +200,34 @@ WITH run_roots AS (
     AND INSTR(CAST(spans.event_ids AS TEXT), @event_id) > 0
   ORDER BY spans.run_id
   LIMIT @limit_rows
-),
-run_status AS (
-  SELECT run_id, status, end_time
-  FROM (
-    SELECT
-      status_spans.run_id,
-      COALESCE(
-        CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT),
-        CAST(status_spans.attributes->>'$."_inngest.dynamic.status"' AS TEXT),
-        status_spans.status,
-        ''
-      ) AS status,
-      status_spans.end_time,
-      ROW_NUMBER() OVER (PARTITION BY status_spans.run_id ORDER BY status_spans.end_time DESC) AS rn
-    FROM spans status_spans
-    JOIN run_roots ON run_roots.run_id = status_spans.run_id
-    WHERE status_spans.debug_run_id IS NULL
-      -- Step spans can finish while the run is still active; only function
-      -- status code spans or final function-output spans should decide terminal
-      -- run status.
-      AND (
-        COALESCE(CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT), '') <> ''
-        OR (
-          COALESCE(CAST(status_spans.attributes->>'$."_inngest.is.function.output"' AS TEXT), '') IN ('true', '1')
-          AND COALESCE(CAST(status_spans.attributes->>'$."_inngest.retryable"' AS TEXT), '') NOT IN ('true', '1')
-        )
-        -- Terminal runs may only update the root dynamic status.
-        OR (
-          COALESCE(CAST(status_spans.attributes->>'$."_inngest.dynamic.span.id"' AS TEXT), '') = run_roots.root_span_id
-          AND COALESCE(CAST(status_spans.attributes->>'$."_inngest.dynamic.status"' AS TEXT), status_spans.status, '') IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut', 'Skipped')
-        )
-      )
-  )
-  WHERE rn = 1
 )
 SELECT
   run_roots.run_id,
   run_roots.function_id,
   run_roots.app_id,
-  run_roots.start_time,
-  CAST(COALESCE(run_status.end_time, run_roots.root_end_time) AS TEXT) AS end_time,
-  COALESCE(run_status.status, CASE WHEN run_roots.has_started THEN 'Running' END, run_roots.root_status, '') AS status,
+  CAST(COALESCE((
+    SELECT MIN(group_spans.start_time)
+    FROM spans group_spans
+    WHERE group_spans.run_id = run_roots.run_id
+      AND group_spans.dynamic_span_id = run_roots.dynamic_span_id
+      AND group_spans.debug_run_id IS NULL
+  ), run_roots.root_start_time) AS TEXT) AS start_time,
+  CAST(COALESCE((
+    SELECT MAX(group_spans.end_time)
+    FROM spans group_spans
+    WHERE group_spans.run_id = run_roots.run_id
+      AND group_spans.dynamic_span_id = run_roots.dynamic_span_id
+      AND group_spans.debug_run_id IS NULL
+  ), run_roots.root_end_time) AS TEXT) AS end_time,
+  CAST(COALESCE((
+    SELECT status_spans.status
+    FROM spans status_spans
+    WHERE status_spans.run_id = run_roots.run_id
+      AND status_spans.dynamic_span_id = run_roots.dynamic_span_id
+      AND status_spans.debug_run_id IS NULL
+    ORDER BY status_spans.end_time DESC
+    LIMIT 1
+  ), '') AS TEXT) AS status,
   COALESCE((
     SELECT CAST(output_lookup.output AS TEXT)
     FROM spans output_lookup
@@ -276,7 +245,6 @@ SELECT
   run_roots.batch_id,
   run_roots.cron_schedule
 FROM run_roots
-LEFT JOIN run_status ON run_status.run_id = run_roots.run_id
 ORDER BY run_roots.run_id;
 
 -- name: GetFunctionRunFinishesByRunIDs :many

--- a/pkg/db/sqlite/sqlc/queries.sql
+++ b/pkg/db/sqlite/sqlc/queries.sql
@@ -177,6 +177,7 @@ WHERE function_runs.event_id IN (sqlc.slice('event_ids'));
 WITH run_roots AS (
   SELECT
     spans.run_id,
+    spans.span_id AS root_span_id,
     spans.function_id,
     spans.app_id,
     -- Child spans mean user code has started even if the root run span still says queued.
@@ -222,7 +223,12 @@ run_status AS (
   FROM (
     SELECT
       status_spans.run_id,
-      COALESCE(CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT), status_spans.status, '') AS status,
+      COALESCE(
+        CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT),
+        CAST(status_spans.attributes->>'$."_inngest.dynamic.status"' AS TEXT),
+        status_spans.status,
+        ''
+      ) AS status,
       status_spans.end_time,
       ROW_NUMBER() OVER (PARTITION BY status_spans.run_id ORDER BY status_spans.end_time DESC) AS rn
     FROM spans status_spans
@@ -233,7 +239,15 @@ run_status AS (
       -- run status.
       AND (
         COALESCE(CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT), '') <> ''
-        OR COALESCE(CAST(status_spans.attributes->>'$."_inngest.is.function.output"' AS TEXT), '') IN ('true', '1')
+        OR (
+          COALESCE(CAST(status_spans.attributes->>'$."_inngest.is.function.output"' AS TEXT), '') IN ('true', '1')
+          AND COALESCE(CAST(status_spans.attributes->>'$."_inngest.retryable"' AS TEXT), '') NOT IN ('true', '1')
+        )
+        -- Terminal runs may only update the root dynamic status.
+        OR (
+          COALESCE(CAST(status_spans.attributes->>'$."_inngest.dynamic.span.id"' AS TEXT), '') = run_roots.root_span_id
+          AND COALESCE(CAST(status_spans.attributes->>'$."_inngest.dynamic.status"' AS TEXT), status_spans.status, '') IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut', 'Skipped')
+        )
       )
   )
   WHERE rn = 1

--- a/pkg/db/sqlite/sqlc/queries.sql
+++ b/pkg/db/sqlite/sqlc/queries.sql
@@ -179,6 +179,16 @@ WITH run_roots AS (
     spans.run_id,
     spans.function_id,
     spans.app_id,
+    -- Child spans mean user code has started even if the root run span still says queued.
+    EXISTS (
+      SELECT 1
+      FROM spans start_lookup
+      WHERE start_lookup.run_id = spans.run_id
+        AND start_lookup.debug_run_id IS NULL
+        AND start_lookup.parent_span_id IS NOT NULL
+        AND start_lookup.parent_span_id <> ''
+        AND start_lookup.parent_span_id <> '0000000000000000'
+    ) AS has_started,
     CAST(COALESCE((
       SELECT start_lookup.start_time
       FROM spans start_lookup
@@ -212,13 +222,19 @@ run_status AS (
   FROM (
     SELECT
       status_spans.run_id,
-      status_spans.status,
+      COALESCE(CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT), status_spans.status, '') AS status,
       status_spans.end_time,
       ROW_NUMBER() OVER (PARTITION BY status_spans.run_id ORDER BY status_spans.end_time DESC) AS rn
     FROM spans status_spans
     JOIN run_roots ON run_roots.run_id = status_spans.run_id
     WHERE status_spans.debug_run_id IS NULL
-      AND status_spans.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
+      -- Step spans can finish while the run is still active; only function
+      -- status code spans or final function-output spans should decide terminal
+      -- run status.
+      AND (
+        COALESCE(CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT), '') <> ''
+        OR COALESCE(CAST(status_spans.attributes->>'$."_inngest.is.function.output"' AS TEXT), '') IN ('true', '1')
+      )
   )
   WHERE rn = 1
 )
@@ -228,7 +244,7 @@ SELECT
   run_roots.app_id,
   run_roots.start_time,
   CAST(COALESCE(run_status.end_time, run_roots.root_end_time) AS TEXT) AS end_time,
-  COALESCE(run_status.status, run_roots.root_status, '') AS status,
+  COALESCE(run_status.status, CASE WHEN run_roots.has_started THEN 'Running' END, run_roots.root_status, '') AS status,
   COALESCE((
     SELECT CAST(output_lookup.output AS TEXT)
     FROM spans output_lookup
@@ -236,7 +252,7 @@ SELECT
       AND output_lookup.output IS NOT NULL
       AND output_lookup.debug_run_id IS NULL
     ORDER BY
-      CASE WHEN COALESCE(output_lookup.attributes->>'$."_inngest.is.function.output"', '') = 'true' THEN 0 ELSE 1 END,
+      CASE WHEN COALESCE(CAST(output_lookup.attributes->>'$."_inngest.is.function.output"' AS TEXT), '') IN ('true', '1') THEN 0 ELSE 1 END,
       output_lookup.end_time DESC
     LIMIT 1
   ), run_roots.root_output, '') AS output,

--- a/pkg/db/sqlite/sqlc/queries.sql.go
+++ b/pkg/db/sqlite/sqlc/queries.sql.go
@@ -1255,32 +1255,11 @@ const getRuns = `-- name: GetRuns :many
 WITH run_roots AS (
   SELECT
     spans.run_id,
-    spans.span_id AS root_span_id,
+    spans.dynamic_span_id,
     spans.function_id,
     spans.app_id,
-    -- Child spans mean user code has started even if the root run span still says queued.
-    EXISTS (
-      SELECT 1
-      FROM spans start_lookup
-      WHERE start_lookup.run_id = spans.run_id
-        AND start_lookup.debug_run_id IS NULL
-        AND start_lookup.parent_span_id IS NOT NULL
-        AND start_lookup.parent_span_id <> ''
-        AND start_lookup.parent_span_id <> '0000000000000000'
-    ) AS has_started,
-    CAST(COALESCE((
-      SELECT start_lookup.start_time
-      FROM spans start_lookup
-      WHERE start_lookup.run_id = spans.run_id
-        AND start_lookup.debug_run_id IS NULL
-        AND start_lookup.parent_span_id IS NOT NULL
-        AND start_lookup.parent_span_id <> ''
-        AND start_lookup.parent_span_id <> '0000000000000000'
-      ORDER BY start_lookup.start_time
-      LIMIT 1
-    ), spans.start_time) AS TEXT) AS start_time,
+    spans.start_time AS root_start_time,
     spans.end_time AS root_end_time,
-    spans.status AS root_status,
     CAST(spans.output AS TEXT) AS root_output,
     COALESCE(spans.attributes->>'$."_inngest.function.slug"', '') AS function_slug,
     COALESCE(spans.attributes->>'$."_inngest.function.name"', '') AS function_name,
@@ -1295,47 +1274,34 @@ WITH run_roots AS (
     AND INSTR(CAST(spans.event_ids AS TEXT), ?3) > 0
   ORDER BY spans.run_id
   LIMIT ?4
-),
-run_status AS (
-  SELECT run_id, status, end_time
-  FROM (
-    SELECT
-      status_spans.run_id,
-      COALESCE(
-        CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT),
-        CAST(status_spans.attributes->>'$."_inngest.dynamic.status"' AS TEXT),
-        status_spans.status,
-        ''
-      ) AS status,
-      status_spans.end_time,
-      ROW_NUMBER() OVER (PARTITION BY status_spans.run_id ORDER BY status_spans.end_time DESC) AS rn
-    FROM spans status_spans
-    JOIN run_roots ON run_roots.run_id = status_spans.run_id
-    WHERE status_spans.debug_run_id IS NULL
-      -- Step spans can finish while the run is still active; only function
-      -- status code spans or final function-output spans should decide terminal
-      -- run status.
-      AND (
-        COALESCE(CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT), '') <> ''
-        OR (
-          COALESCE(CAST(status_spans.attributes->>'$."_inngest.is.function.output"' AS TEXT), '') IN ('true', '1')
-          AND COALESCE(CAST(status_spans.attributes->>'$."_inngest.retryable"' AS TEXT), '') NOT IN ('true', '1')
-        )
-        OR (
-          COALESCE(CAST(status_spans.attributes->>'$."_inngest.dynamic.span.id"' AS TEXT), '') = run_roots.root_span_id
-          AND COALESCE(CAST(status_spans.attributes->>'$."_inngest.dynamic.status"' AS TEXT), status_spans.status, '') IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut', 'Skipped')
-        )
-      )
-  )
-  WHERE rn = 1
 )
 SELECT
   run_roots.run_id,
   run_roots.function_id,
   run_roots.app_id,
-  run_roots.start_time,
-  CAST(COALESCE(run_status.end_time, run_roots.root_end_time) AS TEXT) AS end_time,
-  COALESCE(run_status.status, CASE WHEN run_roots.has_started THEN 'Running' END, run_roots.root_status, '') AS status,
+  CAST(COALESCE((
+    SELECT MIN(group_spans.start_time)
+    FROM spans group_spans
+    WHERE group_spans.run_id = run_roots.run_id
+      AND group_spans.dynamic_span_id = run_roots.dynamic_span_id
+      AND group_spans.debug_run_id IS NULL
+  ), run_roots.root_start_time) AS TEXT) AS start_time,
+  CAST(COALESCE((
+    SELECT MAX(group_spans.end_time)
+    FROM spans group_spans
+    WHERE group_spans.run_id = run_roots.run_id
+      AND group_spans.dynamic_span_id = run_roots.dynamic_span_id
+      AND group_spans.debug_run_id IS NULL
+  ), run_roots.root_end_time) AS TEXT) AS end_time,
+  CAST(COALESCE((
+    SELECT status_spans.status
+    FROM spans status_spans
+    WHERE status_spans.run_id = run_roots.run_id
+      AND status_spans.dynamic_span_id = run_roots.dynamic_span_id
+      AND status_spans.debug_run_id IS NULL
+    ORDER BY status_spans.end_time DESC
+    LIMIT 1
+  ), '') AS TEXT) AS status,
   COALESCE((
     SELECT CAST(output_lookup.output AS TEXT)
     FROM spans output_lookup
@@ -1353,7 +1319,6 @@ SELECT
   run_roots.batch_id,
   run_roots.cron_schedule
 FROM run_roots
-LEFT JOIN run_status ON run_status.run_id = run_roots.run_id
 ORDER BY run_roots.run_id
 `
 
@@ -1379,6 +1344,10 @@ type GetRunsRow struct {
 	CronSchedule interface{}
 }
 
+// Mirrors the span-runs grouping the GraphQL runs list uses (GetSpanRuns): a
+// run is its executor.run root row plus extension rows sharing the root's
+// dynamic_span_id, and the latest row in that group carries the run's current
+// status. Child/step spans never decide run status.
 func (q *Queries) GetRuns(ctx context.Context, arg GetRunsParams) ([]*GetRunsRow, error) {
 	rows, err := q.db.QueryContext(ctx, getRuns,
 		arg.Name,

--- a/pkg/db/sqlite/sqlc/queries.sql.go
+++ b/pkg/db/sqlite/sqlc/queries.sql.go
@@ -1257,6 +1257,16 @@ WITH run_roots AS (
     spans.run_id,
     spans.function_id,
     spans.app_id,
+    -- Child spans mean user code has started even if the root run span still says queued.
+    EXISTS (
+      SELECT 1
+      FROM spans start_lookup
+      WHERE start_lookup.run_id = spans.run_id
+        AND start_lookup.debug_run_id IS NULL
+        AND start_lookup.parent_span_id IS NOT NULL
+        AND start_lookup.parent_span_id <> ''
+        AND start_lookup.parent_span_id <> '0000000000000000'
+    ) AS has_started,
     CAST(COALESCE((
       SELECT start_lookup.start_time
       FROM spans start_lookup
@@ -1290,13 +1300,19 @@ run_status AS (
   FROM (
     SELECT
       status_spans.run_id,
-      status_spans.status,
+      COALESCE(CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT), status_spans.status, '') AS status,
       status_spans.end_time,
       ROW_NUMBER() OVER (PARTITION BY status_spans.run_id ORDER BY status_spans.end_time DESC) AS rn
     FROM spans status_spans
     JOIN run_roots ON run_roots.run_id = status_spans.run_id
     WHERE status_spans.debug_run_id IS NULL
-      AND status_spans.status IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut')
+      -- Step spans can finish while the run is still active; only function
+      -- status code spans or final function-output spans should decide terminal
+      -- run status.
+      AND (
+        COALESCE(CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT), '') <> ''
+        OR COALESCE(CAST(status_spans.attributes->>'$."_inngest.is.function.output"' AS TEXT), '') IN ('true', '1')
+      )
   )
   WHERE rn = 1
 )
@@ -1306,7 +1322,7 @@ SELECT
   run_roots.app_id,
   run_roots.start_time,
   CAST(COALESCE(run_status.end_time, run_roots.root_end_time) AS TEXT) AS end_time,
-  COALESCE(run_status.status, run_roots.root_status, '') AS status,
+  COALESCE(run_status.status, CASE WHEN run_roots.has_started THEN 'Running' END, run_roots.root_status, '') AS status,
   COALESCE((
     SELECT CAST(output_lookup.output AS TEXT)
     FROM spans output_lookup
@@ -1314,7 +1330,7 @@ SELECT
       AND output_lookup.output IS NOT NULL
       AND output_lookup.debug_run_id IS NULL
     ORDER BY
-      CASE WHEN COALESCE(output_lookup.attributes->>'$."_inngest.is.function.output"', '') = 'true' THEN 0 ELSE 1 END,
+      CASE WHEN COALESCE(CAST(output_lookup.attributes->>'$."_inngest.is.function.output"' AS TEXT), '') IN ('true', '1') THEN 0 ELSE 1 END,
       output_lookup.end_time DESC
     LIMIT 1
   ), run_roots.root_output, '') AS output,

--- a/pkg/db/sqlite/sqlc/queries.sql.go
+++ b/pkg/db/sqlite/sqlc/queries.sql.go
@@ -1255,6 +1255,7 @@ const getRuns = `-- name: GetRuns :many
 WITH run_roots AS (
   SELECT
     spans.run_id,
+    spans.span_id AS root_span_id,
     spans.function_id,
     spans.app_id,
     -- Child spans mean user code has started even if the root run span still says queued.
@@ -1300,7 +1301,12 @@ run_status AS (
   FROM (
     SELECT
       status_spans.run_id,
-      COALESCE(CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT), status_spans.status, '') AS status,
+      COALESCE(
+        CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT),
+        CAST(status_spans.attributes->>'$."_inngest.dynamic.status"' AS TEXT),
+        status_spans.status,
+        ''
+      ) AS status,
       status_spans.end_time,
       ROW_NUMBER() OVER (PARTITION BY status_spans.run_id ORDER BY status_spans.end_time DESC) AS rn
     FROM spans status_spans
@@ -1311,7 +1317,14 @@ run_status AS (
       -- run status.
       AND (
         COALESCE(CAST(status_spans.attributes->>'$."sys.function.status.code"' AS TEXT), '') <> ''
-        OR COALESCE(CAST(status_spans.attributes->>'$."_inngest.is.function.output"' AS TEXT), '') IN ('true', '1')
+        OR (
+          COALESCE(CAST(status_spans.attributes->>'$."_inngest.is.function.output"' AS TEXT), '') IN ('true', '1')
+          AND COALESCE(CAST(status_spans.attributes->>'$."_inngest.retryable"' AS TEXT), '') NOT IN ('true', '1')
+        )
+        OR (
+          COALESCE(CAST(status_spans.attributes->>'$."_inngest.dynamic.span.id"' AS TEXT), '') = run_roots.root_span_id
+          AND COALESCE(CAST(status_spans.attributes->>'$."_inngest.dynamic.status"' AS TEXT), status_spans.status, '') IN ('Completed', 'Failed', 'Errored', 'Cancelled', 'TimedOut', 'Skipped')
+        )
       )
   )
   WHERE rn = 1


### PR DESCRIPTION
## Description

Addresses some incorrect status issues reported by our early adopters. This hoists the main status check out of the sql (shared by multiple queries). It also better handles intermediate run span states so we accurately reflect state as we move from qeueud to running and running to completed. 

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
