### PR TITLE
fix: Fudge planned step span times slightly to prevent rollup race condition

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -4051,7 +4051,9 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, runCtx execut
 
 	// Re-enqueue the exact same edge to run now.
 	jobID := fmt.Sprintf("%s-%s", runCtx.Metadata().IdempotencyKey(), gen.ID+"-plan")
-	now := e.now()
+	// NOTE: we fudge the time to be slightly in the past so that ultra-low-latency step executions don't return
+	// with the same timestamp as the discovery step, which can cause issues with span ordering for rollup.
+	now := e.now().Add(-1 * time.Millisecond)
 	nextItem := queue.Item{
 		JobID:                 &jobID,
 		GroupID:               groupID, // Ensure we correlate future jobs with this group ID, eg. started/failed.
@@ -4081,6 +4083,7 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, runCtx execut
 			Metadata:    md,
 			FollowsFrom: tracing.SpanRefFromQueueItem(&lifecycleItem),
 			Parent:      runCtx.RootSpan(),
+			StartTime:   now,
 			QueueItem:   &nextItem,
 		},
 	)
@@ -4100,6 +4103,7 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, runCtx execut
 			Metadata:              runCtx.Metadata(),
 			QueueItem:             &nextItem,
 			Parent:                runCtx.RootSpan(),
+			StartTime:             now,
 			Attributes:            attrs,
 		},
 	)

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -4052,8 +4052,8 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, runCtx execut
 	// Re-enqueue the exact same edge to run now.
 	jobID := fmt.Sprintf("%s-%s", runCtx.Metadata().IdempotencyKey(), gen.ID+"-plan")
 	// NOTE: we fudge the time to be slightly in the past so that ultra-low-latency step executions don't return
-	// with the same timestamp as the discovery step, which can cause issues with span ordering for rollup.
-	now := e.now().Add(-1 * time.Millisecond)
+	// with the same timestamp as the step, which can cause issues with span ordering for rollup.
+	adjustedStartTime := e.now().Add(-1 * time.Millisecond)
 	nextItem := queue.Item{
 		JobID:                 &jobID,
 		GroupID:               groupID, // Ensure we correlate future jobs with this group ID, eg. started/failed.
@@ -4083,7 +4083,7 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, runCtx execut
 			Metadata:    md,
 			FollowsFrom: tracing.SpanRefFromQueueItem(&lifecycleItem),
 			Parent:      runCtx.RootSpan(),
-			StartTime:   now,
+			StartTime:   adjustedStartTime,
 			QueueItem:   &nextItem,
 		},
 	)
@@ -4103,7 +4103,7 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, runCtx execut
 			Metadata:              runCtx.Metadata(),
 			QueueItem:             &nextItem,
 			Parent:                runCtx.RootSpan(),
-			StartTime:             now,
+			StartTime:             adjustedStartTime,
 			Attributes:            attrs,
 		},
 	)
@@ -4113,7 +4113,7 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, runCtx execut
 		e.log.Debug("error creating span for next step after StepPlanned", "error", err)
 	}
 
-	err = e.queue.Enqueue(ctx, nextItem, now, queue.EnqueueOpts{})
+	err = e.queue.Enqueue(ctx, nextItem, adjustedStartTime, queue.EnqueueOpts{})
 	if err == queue.ErrQueueItemExists {
 		span.Drop()
 		return nil


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

Currently if the StepPlanned and actual step spans for parallel execution are emitted the same millisecond timestamp, they roll up incorrectly. This fudges the step span start_time (not the attribute timestamps) to prevent this from happening. This really only happens with no-op steps in the integration tests as otherwise there's almost always at least 1ms of latency.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
