### PR TITLE
chore: measure non-atomic state idempotency claim races

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1269,13 +1269,15 @@ func (e *executor) schedule(
 	}
 
 	// Create run state if not skipped
+	var stateCreated bool
 	if skipReason == enums.SkipReasonNone {
 		ctx, span := e.conditionalTracer.NewSpan(ctx, "executor.CreateState", req.AccountID, req.WorkspaceID, req.Function.ID)
 		st, err := e.smv2.Create(ctx, newState)
 		span.End()
 
 		switch {
-		case err == nil: // no-op
+		case err == nil:
+			stateCreated = true
 		case errors.Is(err, state.ErrIdentifierExists): // no-op
 		case errors.Is(err, state.ErrIdentifierTombstone):
 			tombstoneRunID := st.Metadata.ID.RunID
@@ -1521,6 +1523,14 @@ func (e *executor) schedule(
 		// If the item already exists in the queue, we can safely ignore this
 		// entire schedule request; it's basically a retry and we should not
 		// persist this for the user.
+		if stateCreated {
+			metrics.IncrScheduleFreshStateQueueDuplicateCounter(ctx, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags: map[string]any{
+					"is_invoke": req.IdempotencyKey != nil,
+				},
+			})
+		}
 		return &metadata.ID.RunID, nil, state.ErrIdentifierExists
 
 	case queue.ErrQueueItemSingletonExists:

--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -148,6 +148,18 @@ func IncrExecutorScheduleCount(ctx context.Context, opts CounterOpt) {
 	})
 }
 
+func IncrScheduleFreshStateQueueDuplicateCounter(ctx context.Context, opts CounterOpt) {
+	// This should not happen for Redis state: run-level idempotency is claimed
+	// atomically before state creation, so a duplicate should adopt the
+	// existing run ID instead of creating fresh state.
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "schedule_fresh_state_queue_duplicate_total",
+		Description: "Fresh run states created before queue idempotency rejected the schedule",
+		Tags:        opts.Tags,
+	})
+}
+
 func IncrBatchScheduledCounter(ctx context.Context, opts CounterOpt) {
 	RecordCounterMetric(ctx, 1, CounterOpt{
 		PkgName:     opts.PkgName,


### PR DESCRIPTION
## Description
Adds a metric for schedules that create a new run state but then
loses at the queue idempotency boundary. This verifies whether
atomic run idempotency is currently preventing that shape of
issues and gives us data before adding cleanup for orphaned loser
state with non atomic idempotency key claims (other storage backend)


<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
