### PR TITLE
fix: re-enable parallel processing for crons

### DIFF
--- a/pkg/execution/queue/process_partition.go
+++ b/pkg/execution/queue/process_partition.go
@@ -255,6 +255,10 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 	if strings.HasPrefix(p.Queue(), KindScheduleBatch) {
 		isSystemFn = true
 	}
+	// All cron queue partitions get parallel processing.
+	if strings.HasPrefix(p.Queue(), KindCron) {
+		isSystemFn = true
+	}
 	_, parallelFn := q.disableFifoForFunctions[p.Queue()]
 	_, parallelAccount := q.disableFifoForAccounts[p.AccountID.String()]
 


### PR DESCRIPTION
## Description

fix: re-enable parallel processing for crons

In https://github.com/inngest/inngest/pull/4356 I changed the queue names for crons, but forgot to explicitly mark these queues are eligible for parallel processing. Fixing that here.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
