### PR TITLE
feat(queue): Enable shard ForEach using feature flag

### DIFF
--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -36,6 +36,10 @@ type QueueOpt func(q *QueueOptions)
 
 type QueueProcessorOpt func(q *queueProcessor)
 
+// AccountShardIterationEnabled controls whether account-scoped queue reads
+// should fan out across every shard instead of resolving the account's shard.
+type AccountShardIterationEnabled func(ctx context.Context, accountID uuid.UUID) bool
+
 func WithName(name string) QueueProcessorOpt {
 	return func(q *queueProcessor) {
 		q.name = name
@@ -70,6 +74,14 @@ func WithAccountExists(f AccountExists) QueueOpt {
 	return func(q *QueueOptions) {
 		if f != nil {
 			q.AccountExists = f
+		}
+	}
+}
+
+func WithAccountShardIterationEnabled(f AccountShardIterationEnabled) QueueOpt {
+	return func(q *QueueOptions) {
+		if f != nil {
+			q.AccountShardIterationEnabled = f
 		}
 	}
 }
@@ -341,10 +353,11 @@ type QueueRunMode struct {
 }
 
 type QueueOptions struct {
-	PartitionPriorityFinder PartitionPriorityFinder
-	AccountPriorityFinder   AccountPriorityFinder
-	AccountExists           AccountExists
-	PartitionPausedGetter   PartitionPausedGetter
+	PartitionPriorityFinder      PartitionPriorityFinder
+	AccountPriorityFinder        AccountPriorityFinder
+	AccountExists                AccountExists
+	PartitionPausedGetter        PartitionPausedGetter
+	AccountShardIterationEnabled AccountShardIterationEnabled
 
 	lifecycles QueueLifecycleListeners
 
@@ -709,6 +722,9 @@ func NewQueueOptions(
 		},
 		AccountExists: func(_ context.Context, _ uuid.UUID) (bool, error) {
 			return true, nil
+		},
+		AccountShardIterationEnabled: func(context.Context, uuid.UUID) bool {
+			return false
 		},
 		PartitionPausedGetter: func(ctx context.Context, fnID uuid.UUID) PartitionPausedInfo {
 			return PartitionPausedInfo{}

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/VividCortex/ewma"
+	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/jonboulle/clockwork"
@@ -238,11 +239,23 @@ func (q *queueProcessor) LoadQueueItem(ctx context.Context, shardName string, it
 	return shard.LoadQueueItem(ctx, itemID)
 }
 
+func (q *queueProcessor) forAccountShards(ctx context.Context, accountID uuid.UUID, fn func(context.Context, QueueShard) error) error {
+	if q.AccountShardIterationEnabled != nil && q.AccountShardIterationEnabled(ctx, accountID) {
+		return q.shards.ForEach(ctx, fn)
+	}
+
+	shard, err := q.shards.Resolve(ctx, accountID, nil)
+	if err != nil {
+		return fmt.Errorf("could not resolve account shard: %w", err)
+	}
+	return fn(ctx, shard)
+}
+
 // PartitionBacklogSize implements QueueManager.
 func (q *queueProcessor) PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error) {
 	var totalCount int64
 
-	err := q.shards.ForEach(ctx, func(ctx context.Context, shard QueueShard) error {
+	err := q.forAccountShards(ctx, scope.AccountID, func(ctx context.Context, shard QueueShard) error {
 		backlogSize, err := shard.PartitionBacklogSize(ctx, scope, partitionID)
 		if err != nil {
 			return fmt.Errorf("could not load partition backlog size: %w", err)
@@ -292,7 +305,7 @@ func (q *queueProcessor) TotalSystemQueueDepth(ctx context.Context, shard QueueS
 func (q *queueProcessor) OutstandingJobCount(ctx context.Context, scope Scope, runID ulid.ULID) (int, error) {
 	var totalCount int64
 
-	err := q.shards.ForEach(ctx, func(ctx context.Context, shard QueueShard) error {
+	err := q.forAccountShards(ctx, scope.AccountID, func(ctx context.Context, shard QueueShard) error {
 		outstanding, err := shard.OutstandingJobCount(ctx, scope, runID)
 		if err != nil {
 			return fmt.Errorf("could not load outstanding job count: %w", err)
@@ -320,7 +333,7 @@ func (q *queueProcessor) RunJobs(ctx context.Context, shardName string, scope Sc
 func (q *queueProcessor) RunningCount(ctx context.Context, scope Scope) (int64, error) {
 	var totalCount int64
 
-	err := q.shards.ForEach(ctx, func(ctx context.Context, shard QueueShard) error {
+	err := q.forAccountShards(ctx, scope.AccountID, func(ctx context.Context, shard QueueShard) error {
 		running, err := shard.RunningCount(ctx, scope)
 		if err != nil {
 			return fmt.Errorf("could not load running count: %w", err)
@@ -338,7 +351,7 @@ func (q *queueProcessor) RunningCount(ctx context.Context, scope Scope) (int64, 
 func (q *queueProcessor) StatusCount(ctx context.Context, scope Scope, status string) (int64, error) {
 	var totalCount int64
 
-	err := q.shards.ForEach(ctx, func(ctx context.Context, shard QueueShard) error {
+	err := q.forAccountShards(ctx, scope.AccountID, func(ctx context.Context, shard QueueShard) error {
 		running, err := shard.StatusCount(ctx, scope, status)
 		if err != nil {
 			return fmt.Errorf("could not load status count: %w", err)

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -240,6 +240,8 @@ func (q *queueProcessor) LoadQueueItem(ctx context.Context, shardName string, it
 }
 
 func (q *queueProcessor) forAccountShards(ctx context.Context, accountID uuid.UUID, fn func(context.Context, QueueShard) error) error {
+	// Fan-out is feature-flagged because querying every shard increases
+	// latency and makes a single shard failure affect the whole read.
 	if q.AccountShardIterationEnabled != nil && q.AccountShardIterationEnabled(ctx, accountID) {
 		return q.shards.ForEach(ctx, fn)
 	}

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -59,6 +59,14 @@ type mockShardForIterator struct {
 	partitionRequeueCount   int32
 	partitionRequeueAt      time.Time
 	partitionRequeueForceAt bool
+	partitionBacklogSize    int64
+	partitionBacklogCalls   int32
+	outstandingJobCount     int
+	outstandingJobCalls     int32
+	runningCount            int64
+	runningCountCalls       int32
+	statusCount             int64
+	statusCountCalls        int32
 }
 
 func (m *mockShardForIterator) Name() string {
@@ -352,7 +360,8 @@ func (m *mockShardForIterator) ItemsByRunID(ctx context.Context, scope Scope, ru
 }
 
 func (m *mockShardForIterator) PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error) {
-	return 0, nil
+	atomic.AddInt32(&m.partitionBacklogCalls, 1)
+	return m.partitionBacklogSize, nil
 }
 
 func (m *mockShardForIterator) PartitionByID(ctx context.Context, scope Scope, partitionID string) (*PartitionInspectionResult, error) {
@@ -364,15 +373,18 @@ func (m *mockShardForIterator) UnpauseFunction(ctx context.Context, scope Scope)
 }
 
 func (m *mockShardForIterator) OutstandingJobCount(ctx context.Context, scope Scope, runID ulid.ULID) (int, error) {
-	return 0, nil
+	atomic.AddInt32(&m.outstandingJobCalls, 1)
+	return m.outstandingJobCount, nil
 }
 
 func (m *mockShardForIterator) RunningCount(ctx context.Context, scope Scope) (int64, error) {
-	return 0, nil
+	atomic.AddInt32(&m.runningCountCalls, 1)
+	return m.runningCount, nil
 }
 
 func (m *mockShardForIterator) StatusCount(ctx context.Context, scope Scope, status string) (int64, error) {
-	return 0, nil
+	atomic.AddInt32(&m.statusCountCalls, 1)
+	return m.statusCount, nil
 }
 
 func (m *mockShardForIterator) RunJobs(ctx context.Context, scope Scope, runID ulid.ULID, limit, offset int64) ([]JobResponse, error) {

--- a/pkg/execution/queue/processor_test.go
+++ b/pkg/execution/queue/processor_test.go
@@ -1,0 +1,135 @@
+package queue
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessorAccountShardReadsResolveByDefault(t *testing.T) {
+	ctx := context.Background()
+	accountID := uuid.New()
+	shardA := &mockShardForIterator{
+		name:                 "shard-a",
+		partitionBacklogSize: 1,
+		outstandingJobCount:  2,
+		runningCount:         3,
+		statusCount:          4,
+	}
+	shardB := &mockShardForIterator{
+		name:                 "shard-b",
+		partitionBacklogSize: 10,
+		outstandingJobCount:  20,
+		runningCount:         30,
+		statusCount:          40,
+	}
+	registry, err := NewShardRegistry(
+		map[string]QueueShard{
+			shardA.Name(): shardA,
+			shardB.Name(): shardB,
+		},
+		WithPrimary(shardA),
+		WithShardSelector(func(_ context.Context, id uuid.UUID, _ *string) (QueueShard, error) {
+			require.Equal(t, accountID, id)
+			return shardB, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	q, err := New(ctx, "test", registry)
+	require.NoError(t, err)
+
+	scope := Scope{AccountID: accountID, EnvID: uuid.New(), FunctionID: uuid.New()}
+
+	backlogSize, err := q.PartitionBacklogSize(ctx, scope, "partition")
+	require.NoError(t, err)
+	require.Equal(t, int64(10), backlogSize)
+
+	outstanding, err := q.OutstandingJobCount(ctx, scope, ulid.Make())
+	require.NoError(t, err)
+	require.Equal(t, 20, outstanding)
+
+	running, err := q.RunningCount(ctx, scope)
+	require.NoError(t, err)
+	require.Equal(t, int64(30), running)
+
+	status, err := q.StatusCount(ctx, scope, "status")
+	require.NoError(t, err)
+	require.Equal(t, int64(40), status)
+
+	require.Equal(t, int32(0), atomic.LoadInt32(&shardA.partitionBacklogCalls))
+	require.Equal(t, int32(0), atomic.LoadInt32(&shardA.outstandingJobCalls))
+	require.Equal(t, int32(0), atomic.LoadInt32(&shardA.runningCountCalls))
+	require.Equal(t, int32(0), atomic.LoadInt32(&shardA.statusCountCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shardB.partitionBacklogCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shardB.outstandingJobCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shardB.runningCountCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shardB.statusCountCalls))
+}
+
+func TestProcessorAccountShardReadsForEachWhenEnabled(t *testing.T) {
+	ctx := context.Background()
+	accountID := uuid.New()
+	shardA := &mockShardForIterator{
+		name:                 "shard-a",
+		partitionBacklogSize: 1,
+		outstandingJobCount:  2,
+		runningCount:         3,
+		statusCount:          4,
+	}
+	shardB := &mockShardForIterator{
+		name:                 "shard-b",
+		partitionBacklogSize: 10,
+		outstandingJobCount:  20,
+		runningCount:         30,
+		statusCount:          40,
+	}
+	registry, err := NewShardRegistry(
+		map[string]QueueShard{
+			shardA.Name(): shardA,
+			shardB.Name(): shardB,
+		},
+		WithPrimary(shardA),
+		WithShardSelector(func(context.Context, uuid.UUID, *string) (QueueShard, error) {
+			return shardB, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	q, err := New(ctx, "test", registry, WithAccountShardIterationEnabled(func(_ context.Context, id uuid.UUID) bool {
+		require.Equal(t, accountID, id)
+		return true
+	}))
+	require.NoError(t, err)
+
+	scope := Scope{AccountID: accountID, EnvID: uuid.New(), FunctionID: uuid.New()}
+
+	backlogSize, err := q.PartitionBacklogSize(ctx, scope, "partition")
+	require.NoError(t, err)
+	require.Equal(t, int64(11), backlogSize)
+
+	outstanding, err := q.OutstandingJobCount(ctx, scope, ulid.Make())
+	require.NoError(t, err)
+	require.Equal(t, 22, outstanding)
+
+	running, err := q.RunningCount(ctx, scope)
+	require.NoError(t, err)
+	require.Equal(t, int64(33), running)
+
+	status, err := q.StatusCount(ctx, scope, "status")
+	require.NoError(t, err)
+	require.Equal(t, int64(44), status)
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&shardA.partitionBacklogCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shardA.outstandingJobCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shardA.runningCountCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shardA.statusCountCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shardB.partitionBacklogCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shardB.outstandingJobCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shardB.runningCountCalls))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shardB.statusCountCalls))
+}

--- a/pkg/execution/state/redis_state/backlog_test.go
+++ b/pkg/execution/state/redis_state/backlog_test.go
@@ -1293,6 +1293,9 @@ func TestPartitionBacklogSize(t *testing.T) {
 		osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 			return true
 		}),
+		osqueue.WithAccountShardIterationEnabled(func(context.Context, uuid.UUID) bool {
+			return true
+		}),
 		osqueue.WithClock(clock),
 	}
 


### PR DESCRIPTION
## Description

SYS-916

We currently have a couple queue operations iterating over all shards. This was needed during queue migrations, as it's possible for queue items to reside on two shards for a short time.

Iterating over all shards becomes a problem for large numbers of shards, as any slow or faulty shard can increase tail latency and failure rates. We want to reduce the blast radius by default, so we'll resolve the account shard and use that unless a feature flag is enabled. This is the sane default we should be using. 

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
