### PR TITLE
fix: emit valid MCP input schemas

### DIFF
--- a/pkg/devserver/mcp.go
+++ b/pkg/devserver/mcp.go
@@ -260,6 +260,17 @@ func (h *MCPHandler) addCompatibilityTools(server *mcp.Server) {
 		Name:        "send_event",
 		Title:       "Send event (deprecated)",
 		Description: "Deprecated compatibility tool retained for existing dev server integrations. Send an event to the Inngest dev server and return the event ID and any run IDs it creates. Parameters: name (required string - the event name like 'test/hello.world'), data (optional - the event data, must be a JSON object or will be wrapped in {\"value\": data}), user (optional JSON object - user context), eventIdSeed (optional string for deterministic event IDs)",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"name":        map[string]any{"type": "string"},
+				"data":        map[string]any{},
+				"user":        map[string]any{},
+				"eventIdSeed": map[string]any{"type": "string"},
+			},
+			"required":             []string{"name"},
+			"additionalProperties": false,
+		},
 	}, h.sendEvent)
 
 	mcp.AddTool(server, &mcp.Tool{
@@ -278,6 +289,17 @@ func (h *MCPHandler) addCompatibilityTools(server *mcp.Server) {
 		Name:        "invoke_function_sync",
 		Title:       "Invoke function synchronously (deprecated)",
 		Description: "Deprecated compatibility tool retained for existing dev server integrations. Use invoke_function for the shared asynchronous Cloud and dev server contract. This tool waits for completion and returns the function output. Parameters: functionId (required string - function slug, ID, or name), data (optional - function input data, must be a JSON object or will be wrapped in {\"value\": data}), user (optional JSON object - user context), timeout (optional int - seconds to wait, default 30)",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"functionId": map[string]any{"type": "string"},
+				"data":       map[string]any{},
+				"user":       map[string]any{},
+				"timeout":    map[string]any{"type": "integer"},
+			},
+			"required":             []string{"functionId"},
+			"additionalProperties": false,
+		},
 	}, h.invokeFunction)
 }
 
@@ -333,16 +355,16 @@ func (h *MCPHandler) executeV2(ctx context.Context, endpoint apiv2endpoint.Endpo
 // SendEventArgs represents the arguments for sending an event
 type SendEventArgs struct {
 	Name        string `json:"name"`
-	Data        any    `json:"data,omitempty" jsonschema:"true"`
-	User        any    `json:"user,omitempty" jsonschema:"true"`
+	Data        any    `json:"data,omitempty"`
+	User        any    `json:"user,omitempty"`
 	EventIDSeed string `json:"eventIdSeed,omitempty"`
 }
 
 // InvokeFunctionArgs represents the arguments for invoking a function
 type InvokeFunctionArgs struct {
 	FunctionID string `json:"functionId"`
-	Data       any    `json:"data,omitempty" jsonschema:"true"`
-	User       any    `json:"user,omitempty" jsonschema:"true"`
+	Data       any    `json:"data,omitempty"`
+	User       any    `json:"user,omitempty"`
 	Timeout    int    `json:"timeout,omitempty"`
 }
 

--- a/pkg/devserver/mcp_test.go
+++ b/pkg/devserver/mcp_test.go
@@ -205,3 +205,49 @@ func listMCPTools(t *testing.T, handler http.Handler) []listedMCPTool {
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
 	return response.Result.Tools
 }
+
+func TestMCPToolInputSchemasDoNotUseBooleanProperties(t *testing.T) {
+	ctx := context.Background()
+	server := (&MCPHandler{}).createMCPServer()
+
+	serverTransport, clientTransport := mcp.NewInMemoryTransports()
+	if _, err := server.Connect(ctx, serverTransport, nil); err != nil {
+		t.Fatalf("connect server: %v", err)
+	}
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("connect client: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := session.Close(); err != nil {
+			t.Fatalf("close session: %v", err)
+		}
+	})
+
+	result, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("list tools: %v", err)
+	}
+
+	for _, tool := range result.Tools {
+		var inputSchema struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		}
+		schemaJSON, err := json.Marshal(tool.InputSchema)
+		if err != nil {
+			t.Fatalf("marshal %s input schema: %v", tool.Name, err)
+		}
+		if err := json.Unmarshal(schemaJSON, &inputSchema); err != nil {
+			t.Fatalf("unmarshal %s input schema: %v", tool.Name, err)
+		}
+
+		for name, propertySchema := range inputSchema.Properties {
+			var isBoolean bool
+			if err := json.Unmarshal(propertySchema, &isBoolean); err == nil {
+				t.Fatalf("%s.%s input schema is boolean: %s", tool.Name, name, propertySchema)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description

Fixes #3305.

The MCP `tools/list` metadata for `send_event` and `invoke_function` currently derives boolean property schemas for flexible `data` and `user` arguments. Some MCP clients validate tool input schemas as object-shaped JSON Schema property entries, so those boolean entries can fail before a tool call is made.

This sets explicit `InputSchema` metadata for both tools and keeps `data` / `user` as permissive object-valued schemas. It also adds a focused regression test that connects to the in-memory MCP server, lists tools, and fails if any tool property schema is emitted as a JSON boolean.

This is a narrow refresh of the same issue covered by #3664 and #3489, which are both closed and unmerged.

## Release note

Fix MCP dev server tool metadata so clients can validate `send_event` and `invoke_function` input schemas.

## Migration note

None.

## Validation

```bash
go test -count=1 ./pkg/devserver
```
