### PR TITLE
fix: return consistent function ids across v2 endpoints

### DIFF
--- a/pkg/api/v2/endpoints_runs.go
+++ b/pkg/api/v2/endpoints_runs.go
@@ -269,11 +269,15 @@ func toAPIRunListItem(run *RunListItem) *apiv2.FunctionRun {
 }
 
 func functionRefID(fn inngest.DeployedFunction) string {
-	if fn.Function.Slug != "" {
+	if fn.Function.Slug != "" && fn.Function.Slug != fn.Slug {
 		return fn.Function.Slug
 	}
+
 	if fn.AppName != "" {
 		return strings.TrimPrefix(fn.Slug, fn.AppName+"-")
+	}
+	if fn.Function.Slug != "" {
+		return fn.Function.Slug
 	}
 	return fn.Slug
 }

--- a/pkg/api/v2/endpoints_runs_test.go
+++ b/pkg/api/v2/endpoints_runs_test.go
@@ -97,6 +97,26 @@ func TestFunctionRefID(t *testing.T) {
 		}))
 	})
 
+	t.Run("trims app prefix when configured slug matches deployed slug", func(t *testing.T) {
+		require.Equal(t, "function-slug", functionRefID(inngest.DeployedFunction{
+			Slug:    "app-function-slug",
+			AppName: "app",
+			Function: inngest.Function{
+				Slug: "app-function-slug",
+			},
+		}))
+	})
+
+	t.Run("does not trim bare configured slug that starts with app id", func(t *testing.T) {
+		require.Equal(t, "app-function-slug", functionRefID(inngest.DeployedFunction{
+			Slug:    "app-app-function-slug",
+			AppName: "app",
+			Function: inngest.Function{
+				Slug: "app-function-slug",
+			},
+		}))
+	})
+
 	t.Run("falls back to deployed slug", func(t *testing.T) {
 		require.Equal(t, "function-slug", functionRefID(inngest.DeployedFunction{
 			Slug: "function-slug",

--- a/pkg/devserver/agentic_api_adapters_test.go
+++ b/pkg/devserver/agentic_api_adapters_test.go
@@ -108,6 +108,41 @@ func TestNewFunctionProviderFindsFunctionWhenFunctionIDStartsWithAppID(t *testin
 	require.Equal(t, "app-test-fn", fn.Function.Slug)
 }
 
+func TestNewFunctionProviderPrefersExactPublicFunctionID(t *testing.T) {
+	ctx := context.Background()
+	legacyCompatibleFnID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	exactFnID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	appID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	store := &fakeFunctionStore{
+		fns: []*cqrs.Function{
+			{
+				ID:     legacyCompatibleFnID,
+				AppID:  appID,
+				Slug:   "app-test-fn",
+				Config: []byte(`{"name":"Test function","slug":"test-fn"}`),
+			},
+			{
+				ID:     exactFnID,
+				AppID:  appID,
+				Slug:   "app-app-test-fn",
+				Config: []byte(`{"name":"App test function","slug":"app-test-fn"}`),
+			},
+		},
+		app: &cqrs.App{
+			ID:   appID,
+			Name: "app",
+		},
+	}
+
+	fn, err := NewFunctionProvider(store).GetFunctionByApp(ctx, "app", "app-test-fn")
+
+	require.NoError(t, err)
+	require.Equal(t, exactFnID, fn.ID)
+	require.Equal(t, "app-app-test-fn", fn.Slug)
+	require.Equal(t, "App test function", fn.Function.Name)
+	require.Equal(t, "app-test-fn", fn.Function.Slug)
+}
+
 func TestNewFunctionProviderFindsArchivedFunctionByID(t *testing.T) {
 	ctx := context.Background()
 	fnID := uuid.MustParse("11111111-1111-1111-1111-111111111111")

--- a/pkg/devserver/function_provider.go
+++ b/pkg/devserver/function_provider.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	apiv2 "github.com/inngest/inngest/pkg/api/v2"
@@ -67,16 +68,46 @@ func (p *cqrsFunctionProvider) GetFunctionByApp(ctx context.Context, appID strin
 }
 
 func (p *cqrsFunctionProvider) findFunctionInApp(ctx context.Context, fns []*cqrs.Function, appID string, functionID string) (inngest.DeployedFunction, error) {
+	deployedFns := make([]inngest.DeployedFunction, 0, len(fns))
 	for _, fn := range fns {
 		deployed, err := p.toDeployedFunction(ctx, fn)
 		if err != nil {
 			return inngest.DeployedFunction{}, err
 		}
-		if functionIDsMatch(deployed, functionID, appID+"-"+functionID) {
-			return deployed, nil
+		deployedFns = append(deployedFns, deployed)
+	}
+
+	//
+	// Prefer the app-scoped ID before accepting legacy combined IDs; users can
+	// name a function with the app prefix, and that should still resolve exactly.
+	for _, fn := range deployedFns {
+		if publicDeployedFunctionID(appID, fn) == functionID {
+			return fn, nil
 		}
 	}
+
+	for _, fn := range deployedFns {
+		if functionIDsMatch(fn, functionID, appID+"-"+functionID) {
+			return fn, nil
+		}
+	}
+
 	return inngest.DeployedFunction{}, fmt.Errorf("%w: %s/%s", apiv2.ErrFunctionNotFound, appID, functionID)
+}
+
+func publicDeployedFunctionID(appID string, fn inngest.DeployedFunction) string {
+	if fn.Function.Slug != "" && fn.Function.Slug != fn.Slug {
+		return fn.Function.Slug
+	}
+
+	functionID := fn.Function.Slug
+	if functionID == "" {
+		functionID = fn.Slug
+	}
+	if appID != "" {
+		return strings.TrimPrefix(functionID, appID+"-")
+	}
+	return functionID
 }
 
 func functionIDsMatch(fn inngest.DeployedFunction, bareFunctionID string, prefixedFunctionID string) bool {

--- a/pkg/devserver/runs_reader.go
+++ b/pkg/devserver/runs_reader.go
@@ -51,14 +51,6 @@ func runListItemFromRow(row *db.RunListItemRow, includeOutput bool) *apiv2.RunLi
 	fn := inngest.Function{}
 	_ = json.Unmarshal([]byte(row.FunctionConfig), &fn)
 
-	functionID := fn.Slug
-	if functionID == "" && row.AppName != "" {
-		functionID = strings.TrimPrefix(row.FunctionSlug, row.AppName+"-")
-	}
-	if functionID == "" {
-		functionID = row.FunctionSlug
-	}
-
 	functionName := fn.Name
 	if functionName == "" {
 		functionName = row.FunctionName
@@ -73,7 +65,7 @@ func runListItemFromRow(row *db.RunListItemRow, includeOutput bool) *apiv2.RunLi
 		RunID:        row.FunctionRun.RunID,
 		RunStartedAt: row.FunctionRun.RunStartedAt,
 		EventID:      row.FunctionRun.EventID,
-		FunctionID:   functionID,
+		FunctionID:   publicRunListFunctionID(row.AppName, row.FunctionSlug, fn.Slug),
 		FunctionName: functionName,
 		AppID:        appID,
 	}
@@ -95,6 +87,21 @@ func runListItemFromRow(row *db.RunListItemRow, includeOutput bool) *apiv2.RunLi
 	}
 
 	return run
+}
+
+func publicRunListFunctionID(appID string, storedFunctionID string, configFunctionID string) string {
+	if configFunctionID != "" && configFunctionID != storedFunctionID {
+		return configFunctionID
+	}
+
+	functionID := configFunctionID
+	if functionID == "" {
+		functionID = storedFunctionID
+	}
+	if appID != "" {
+		return strings.TrimPrefix(functionID, appID+"-")
+	}
+	return functionID
 }
 
 func publicRunOutput(raw []byte) json.RawMessage {

--- a/pkg/devserver/runs_reader_test.go
+++ b/pkg/devserver/runs_reader_test.go
@@ -44,6 +44,37 @@ func TestRunListItemFromRowUsesTraceRunOutput(t *testing.T) {
 	require.True(t, output["ok"])
 }
 
+func TestRunListItemFromRowUsesBareFunctionID(t *testing.T) {
+	t.Run("uses distinct configured slug", func(t *testing.T) {
+		result := runListItemFromRow(&db.RunListItemRow{
+			FunctionSlug:   "app-app-test-fn",
+			FunctionConfig: `{"name":"Test function","slug":"app-test-fn"}`,
+			AppName:        "app",
+		}, false)
+
+		require.Equal(t, "app-test-fn", result.FunctionID)
+	})
+
+	t.Run("trims composite configured slug", func(t *testing.T) {
+		result := runListItemFromRow(&db.RunListItemRow{
+			FunctionSlug:   "app-test-fn",
+			FunctionConfig: `{"name":"Test function","slug":"app-test-fn"}`,
+			AppName:        "app",
+		}, false)
+
+		require.Equal(t, "test-fn", result.FunctionID)
+	})
+
+	t.Run("trims stored slug without configured slug", func(t *testing.T) {
+		result := runListItemFromRow(&db.RunListItemRow{
+			FunctionSlug: "app-test-fn",
+			AppName:      "app",
+		}, false)
+
+		require.Equal(t, "test-fn", result.FunctionID)
+	})
+}
+
 func TestRunListItemFromRowUnwrapsRunCompleteOpcodeOutput(t *testing.T) {
 	runID := ulid.Make()
 	eventID := ulid.Make()


### PR DESCRIPTION
## Description

we were previously being inconsistent and some were returning function id and some app id + function id as function id. since we are taking app id and function id separately on POST invoke and GET runs, etc. we should return that same shape. 

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
