### PR TITLE
fix(release): mark prerelease tags as non-latest

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -93,3 +93,5 @@ release:
   github:
     owner: inngest
     name: inngest
+  prerelease: auto
+  make_latest: "{{ not .Prerelease }}"


### PR DESCRIPTION
## Description

GoReleaser was creating tags like v1.27.1-test.1 as normal GitHub releases because release.prerelease was not configured. The CLI update checker reads GitHub's /releases/latest endpoint, so the test release was treated as the latest production version and users saw update prompts for 1.27.1-test.1.

Set prerelease: auto so prerelease-style tags are published as GitHub prereleases, and set make_latest from .Prerelease so they cannot replace the stable latest release.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
Fixed github prerelease tagging

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
