### PR TITLE
feat(metadata): Use deterministic step span IDs

### DIFF
--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -195,18 +195,15 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 
 	default:
 		scope = enums.MetadataScopeExtendedTrace
-		// TODO: require that this is an extended trace span
-		span, err := a.opts.TraceReader.GetSpanBySpanID(ctx, runID, *req.Target.SpanID, auth.AccountID(), auth.WorkspaceID())
-		switch {
-		case err != nil:
-			return publicerr.Wrap(err, 404, "Unable to find metadata target")
-		case span == nil:
-			return publicerr.Errorf(404, "Unable to find metadata target")
-		}
+		// The TraceID is the same for all spans in the run and is derived
+		// deterministically from the runID. The span itself is referenced by
+		// the caller-supplied SpanID, so no ClickHouse lookup is needed.
+		traceID := tracing.DeterministicSpanConfig(runID[:]).TraceID.String()
+		spanID := *req.Target.SpanID
 		parentSpanRef = &meta.SpanReference{
-			TraceParent:            fmt.Sprintf("00-%s-%s-00", span.TraceID, span.SpanID),
-			DynamicSpanID:          span.SpanID,
-			DynamicSpanTraceParent: fmt.Sprintf("00-%s-%s-00", span.TraceID, span.SpanID),
+			TraceParent:            fmt.Sprintf("00-%s-%s-00", traceID, spanID),
+			DynamicSpanID:          spanID,
+			DynamicSpanTraceParent: fmt.Sprintf("00-%s-%s-00", traceID, spanID),
 		}
 	}
 

--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -337,6 +337,8 @@ func (a router) addRunMetadataLegacy(ctx context.Context, auth apiv1auth.V1Auth,
 		}
 	}
 
+	// Missing state uses a request-local fallback so this write still enforces
+	// the cumulative size limit within the request.
 	if stateMetadata == nil {
 		stateMetadata = &statev2.Metadata{ID: stateID}
 	}
@@ -373,6 +375,9 @@ func (a router) addRunMetadataLegacy(ctx context.Context, auth apiv1auth.V1Auth,
 		}
 	}
 
+	// Persist the cumulative metadata size delta back to the state store.
+	// Only persist when we successfully loaded from state; the fallback
+	// Metadata is request-local and has no backing store to update.
 	if loadedFromState {
 		if delta := stateMetadata.Metrics.SwapMetadataSizeDelta(); delta > 0 {
 			if err := statev2.TryIncrementMetadataSize(ctx, a.opts.State, stateID, delta); err != nil {

--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -26,6 +26,11 @@ import (
 	"github.com/oklog/ulid/v2"
 )
 
+// deterministicSpanIDCutoff is the earliest run-creation time for which the
+// deterministic span ID scheme is guaranteed to be in use. Runs created before
+// this point are served by the legacy ClickHouse query path.
+var deterministicSpanIDCutoff = time.Date(2026, time.June, 10, 21, 29, 25, 0, time.UTC)
+
 type MetadataOpts struct {
 	Flag AllowMetadataFlag
 
@@ -113,6 +118,145 @@ type AddRunMetadataRequest struct {
 }
 
 func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID ulid.ULID, req *AddRunMetadataRequest) error {
+	if err := metadata.ValidateUpdatesAllowed(req.Metadata); err != nil {
+		return publicerr.Wrap(err, 400, "Invalid metadata")
+	}
+
+	// Runs created before the deterministic span ID scheme was deployed use
+	// the legacy ClickHouse query path to locate the parent span.
+	if ulid.Time(runID.Time()).Before(deterministicSpanIDCutoff) {
+		return a.addRunMetadataLegacy(ctx, auth, runID, req)
+	}
+
+	// Load run metadata from the state store. The lookup uses only AccountID
+	// and RunID; FunctionID and AppID are populated from the stored state.
+	// The state store is immediately consistent, so no retry is needed here.
+	partialID := statev2.ID{
+		RunID: runID,
+		Tenant: statev2.Tenant{
+			EnvID:     auth.WorkspaceID(),
+			AccountID: auth.AccountID(),
+		},
+	}
+
+	var stateMetadata *statev2.Metadata
+	loadedFromState := false
+	if a.opts.State != nil {
+		md, err := a.opts.State.LoadMetadata(ctx, partialID)
+		if errors.Is(err, statev2.ErrRunNotFound) || errors.Is(err, statev2.ErrMetadataNotFound) {
+			logger.StdlibLogger(ctx).Warn("failed to load run metadata for size limit check, falling back to request-local limit",
+				"error", err,
+				"run_id", runID.String(),
+			)
+		} else if err != nil {
+			return publicerr.Wrap(err, 500, "Unable to load run metadata")
+		} else {
+			stateMetadata = &md
+			loadedFromState = true
+		}
+	}
+
+	// Missing state uses a request-local fallback so this write still enforces
+	// the cumulative size limit within the request.
+	if stateMetadata == nil {
+		stateMetadata = &statev2.Metadata{ID: partialID}
+	}
+	statev2.InitConfig(&stateMetadata.Config)
+
+	// Build the parent span reference and determine scope. For run-scoped and
+	// step-scoped metadata the span reference is computed deterministically from
+	// the run/step IDs, removing any dependency on ClickHouse. The
+	// extended-trace case still looks up the user-created span by its ID.
+	var parentSpanRef *meta.SpanReference
+	var scope metadata.Scope
+
+	switch {
+	case req.Target.StepID == nil:
+		scope = enums.MetadataScopeRun
+		parentSpanRef = tracing.RunSpanRefFromMetadata(stateMetadata)
+
+	case req.Target.StepAttempt == nil || req.Target.SpanID == nil:
+		scope = enums.MetadataScopeStep
+
+		var hashedStepID string
+		if req.Target.StepIndex == nil || *req.Target.StepIndex == 0 {
+			sum := sha1.Sum([]byte(*req.Target.StepID))
+			hashedStepID = hex.EncodeToString(sum[:])
+		} else {
+			sum := sha1.Sum(fmt.Appendf(nil, "%s:%d", *req.Target.StepID, *req.Target.StepIndex))
+			hashedStepID = hex.EncodeToString(sum[:])
+		}
+
+		if req.Target.StepAttempt == nil || *req.Target.StepAttempt < 0 {
+			parentSpanRef = tracing.FinalizedStepSpanRefFromMetadataAndStepID(stateMetadata, hashedStepID)
+		} else {
+			parentSpanRef = tracing.RetryStepSpanRefFromMetadataAndStepID(stateMetadata, hashedStepID, *req.Target.StepAttempt)
+		}
+
+	default:
+		scope = enums.MetadataScopeExtendedTrace
+		// TODO: require that this is an extended trace span
+		span, err := a.opts.TraceReader.GetSpanBySpanID(ctx, runID, *req.Target.SpanID, auth.AccountID(), auth.WorkspaceID())
+		switch {
+		case err != nil:
+			return publicerr.Wrap(err, 404, "Unable to find metadata target")
+		case span == nil:
+			return publicerr.Errorf(404, "Unable to find metadata target")
+		}
+		parentSpanRef = &meta.SpanReference{
+			TraceParent:            fmt.Sprintf("00-%s-%s-00", span.TraceID, span.SpanID),
+			DynamicSpanID:          span.SpanID,
+			DynamicSpanTraceParent: fmt.Sprintf("00-%s-%s-00", span.TraceID, span.SpanID),
+		}
+	}
+
+	addTenantIDs := func(cfg *tracing.MetadataSpanConfig) {
+		meta.AddAttr(cfg.Attrs, meta.Attrs.AccountID, util.ToPtr(auth.AccountID()))
+		meta.AddAttr(cfg.Attrs, meta.Attrs.EnvID, util.ToPtr(auth.WorkspaceID()))
+		meta.AddAttr(cfg.Attrs, meta.Attrs.FunctionID, &stateMetadata.ID.FunctionID)
+		meta.AddAttr(cfg.Attrs, meta.Attrs.RunID, &stateMetadata.ID.RunID)
+		meta.AddAttr(cfg.Attrs, meta.Attrs.AppID, &stateMetadata.ID.Tenant.AppID)
+	}
+
+	for _, md := range req.Metadata {
+		_, err := tracing.CreateMetadataSpan(
+			ctx,
+			a.opts.TracerProvider,
+			parentSpanRef,
+			"router.AddRunMetadata",
+			pkgName,
+			stateMetadata,
+			md,
+			scope,
+			addTenantIDs,
+		)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Persist the cumulative metadata size delta back to the state store.
+	// Only persist when we successfully loaded from state; the fallback
+	// Metadata is request-local and has no backing store to update.
+	if loadedFromState {
+		if delta := stateMetadata.Metrics.SwapMetadataSizeDelta(); delta > 0 {
+			if err := statev2.TryIncrementMetadataSize(ctx, a.opts.State, stateMetadata.ID, delta); err != nil {
+				logger.StdlibLogger(ctx).Error("failed to persist metadata size delta",
+					"error", err,
+					"run_id", runID.String(),
+					"delta", delta,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+// addRunMetadataLegacy is the original implementation for runs created before
+// deterministicSpanIDCutoff. It queries ClickHouse to locate the parent span
+// with a retry loop to absorb Kafka→ClickHouse propagation latency.
+func (a router) addRunMetadataLegacy(ctx context.Context, auth apiv1auth.V1Auth, runID ulid.ULID, req *AddRunMetadataRequest) error {
 	var parentSpan *cqrs.OtelSpan
 	var scope metadata.Scope
 	var err error
@@ -130,9 +274,6 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 	// The retry config is sized so that the cumulative backoff covers roughly
 	// one minute, which gives the Kafka→ClickHouse pipeline time to land the
 	// span.
-	//
-	// TODO: We should replace this hack with a proper fix. But a proper fix
-	// likely requires changes in our ClickHouse trace schema.
 	_, err = util.WithRetry(
 		ctx,
 		"apiv1.AddRunMetadata.getParentSpan",
@@ -167,10 +308,6 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 		},
 	)
 
-	if err := metadata.ValidateUpdatesAllowed(req.Metadata); err != nil {
-		return publicerr.Wrap(err, 400, "Invalid metadata")
-	}
-
 	// Load run metadata to enforce the per-run cumulative size limit against
 	// metadata that already exists in the run, not just this request.
 	stateID := statev2.ID{
@@ -200,8 +337,6 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 		}
 	}
 
-	// Missing state uses a request-local fallback so this write still enforces
-	// the cumulative size limit within the request.
 	if stateMetadata == nil {
 		stateMetadata = &statev2.Metadata{ID: stateID}
 	}
@@ -238,9 +373,6 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 		}
 	}
 
-	// Persist the cumulative metadata size delta back to the state store.
-	// Only persist when we successfully loaded from state; the fallback
-	// Metadata is request-local and has no backing store to update.
 	if loadedFromState {
 		if delta := stateMetadata.Metrics.SwapMetadataSizeDelta(); delta > 0 {
 			if err := statev2.TryIncrementMetadataSize(ctx, a.opts.State, stateID, delta); err != nil {
@@ -271,7 +403,6 @@ func (a router) getParentSpan(ctx context.Context, auth apiv1auth.V1Auth, runID 
 			sum := sha1.Sum([]byte(*target.StepID))
 			stepID = hex.EncodeToString(sum[:])
 		} else {
-
 			sum := sha1.Sum(fmt.Appendf(nil, "%s:%d", *target.StepID, *target.StepIndex))
 			stepID = hex.EncodeToString(sum[:])
 		}
@@ -290,7 +421,6 @@ func (a router) getParentSpan(ctx context.Context, auth apiv1auth.V1Auth, runID 
 	}
 
 	switch {
-	// TODO: specific err cases
 	case err != nil:
 		return nil, 0, publicerr.Wrap(err, 404, "Unable to find metadata target")
 	case span == nil:

--- a/pkg/api/apiv1/metadata_test.go
+++ b/pkg/api/apiv1/metadata_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/api/apiv1/apiv1auth"
@@ -19,20 +21,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type metadataFallbackTraceReader struct {
+// metadataTraceReader stubs the trace reader for legacy-path tests.
+type metadataTraceReader struct {
 	cqrs.TraceReader
 	span *cqrs.OtelSpan
 }
 
-func (r metadataFallbackTraceReader) GetRunSpanByRunID(context.Context, ulid.ULID, uuid.UUID, uuid.UUID) (*cqrs.OtelSpan, error) {
+func (r metadataTraceReader) GetRunSpanByRunID(context.Context, ulid.ULID, uuid.UUID, uuid.UUID) (*cqrs.OtelSpan, error) {
 	return r.span, nil
 }
 
-func (r metadataFallbackTraceReader) GetLatestExecutionSpanByStepID(context.Context, ulid.ULID, string, uuid.UUID, uuid.UUID) (*cqrs.OtelSpan, error) {
+func (r metadataTraceReader) GetLatestExecutionSpanByStepID(context.Context, ulid.ULID, string, uuid.UUID, uuid.UUID) (*cqrs.OtelSpan, error) {
 	return r.span, nil
 }
 
-type metadataFallbackTracerProvider struct {
+type metadataTracerProvider struct {
 	t      *testing.T
 	wantID statev2.ID
 	called bool
@@ -47,11 +50,10 @@ func (s metadataStateLoader) LoadMetadata(ctx context.Context, id statev2.ID) (s
 	if s.loadMetadata != nil {
 		return s.loadMetadata(ctx, id)
 	}
-
 	return statev2.Metadata{}, errors.New("unexpected LoadMetadata call")
 }
 
-func (p *metadataFallbackTracerProvider) CreateSpan(_ context.Context, _ string, opts *tracing.CreateSpanOptions) (*meta.SpanReference, error) {
+func (p *metadataTracerProvider) CreateSpan(_ context.Context, _ string, opts *tracing.CreateSpanOptions) (*meta.SpanReference, error) {
 	p.called = true
 
 	require.NotNil(p.t, opts.Metadata)
@@ -64,20 +66,34 @@ func (p *metadataFallbackTracerProvider) CreateSpan(_ context.Context, _ string,
 	return &meta.SpanReference{}, nil
 }
 
-func (p *metadataFallbackTracerProvider) CreateDroppableSpan(context.Context, string, *tracing.CreateSpanOptions) (*tracing.DroppableSpan, error) {
+func (p *metadataTracerProvider) CreateDroppableSpan(context.Context, string, *tracing.CreateSpanOptions) (*tracing.DroppableSpan, error) {
 	return nil, errors.New("unexpected CreateDroppableSpan call")
 }
 
-func (p *metadataFallbackTracerProvider) UpdateSpan(context.Context, *tracing.UpdateSpanOptions) error {
+func (p *metadataTracerProvider) UpdateSpan(context.Context, *tracing.UpdateSpanOptions) error {
 	return errors.New("unexpected UpdateSpan call")
 }
 
-func TestAddRunMetadataFallbackInitializesStateMetadata(t *testing.T) {
+// newRunID returns a ULID with the current time (new path).
+func newRunID() ulid.ULID {
+	return ulid.Make()
+}
+
+// preDeterministicSpanIDRunID returns a ULID timestamped before deterministicSpanIDCutoff (legacy path).
+func preDeterministicSpanIDRunID() ulid.ULID {
+	ts := ulid.Timestamp(deterministicSpanIDCutoff.Add(-time.Hour))
+	return ulid.MustNew(ts, rand.New(rand.NewSource(0)))
+}
+
+// TestAddRunMetadataNewPathUsesStateForTenantIDs verifies that on the new path
+// the FunctionID and AppID attached to the metadata span come from the state
+// store, not from a ClickHouse span query.
+func TestAddRunMetadataNewPathUsesStateForTenantIDs(t *testing.T) {
 	ctx := t.Context()
 	auth, err := apiv1auth.NilAuthFinder(ctx)
 	require.NoError(t, err)
 
-	runID := ulid.Make()
+	runID := newRunID()
 	functionID := uuid.New()
 	appID := uuid.New()
 	wantID := statev2.ID{
@@ -90,16 +106,10 @@ func TestAddRunMetadataFallbackInitializesStateMetadata(t *testing.T) {
 		},
 	}
 
-	tp := &metadataFallbackTracerProvider{t: t, wantID: wantID}
+	tp := &metadataTracerProvider{t: t, wantID: wantID}
 	r := router{API: &API{opts: Opts{
-		TraceReader: metadataFallbackTraceReader{span: &cqrs.OtelSpan{
-			RawOtelSpan: cqrs.RawOtelSpan{
-				TraceID: "00000000000000000000000000000001",
-				SpanID:  "0000000000000001",
-			},
-			RunID:      runID,
-			FunctionID: functionID,
-			AppID:      appID,
+		State: metadataStateLoader{loadMetadata: func(_ context.Context, _ statev2.ID) (statev2.Metadata, error) {
+			return statev2.Metadata{ID: wantID}, nil
 		}},
 		TracerProvider: tp,
 	}}}
@@ -115,39 +125,29 @@ func TestAddRunMetadataFallbackInitializesStateMetadata(t *testing.T) {
 	require.True(t, tp.called)
 }
 
-func TestAddRunMetadataFallbackInitializesMissingStateMetadata(t *testing.T) {
+// TestAddRunMetadataNewPathFallbackToPartialIDWhenStateMissing verifies that
+// when the state store has no record for the run, the metadata span is still
+// created using the partial ID (zero FunctionID/AppID).
+func TestAddRunMetadataNewPathFallbackToPartialIDWhenStateMissing(t *testing.T) {
 	ctx := t.Context()
 	auth, err := apiv1auth.NilAuthFinder(ctx)
 	require.NoError(t, err)
 
-	runID := ulid.Make()
-	functionID := uuid.New()
-	appID := uuid.New()
+	runID := newRunID()
 	wantID := statev2.ID{
-		RunID:      runID,
-		FunctionID: functionID,
+		RunID: runID,
 		Tenant: statev2.Tenant{
-			AppID:     appID,
 			EnvID:     auth.WorkspaceID(),
 			AccountID: auth.AccountID(),
 		},
 	}
 
-	tp := &metadataFallbackTracerProvider{t: t, wantID: wantID}
+	tp := &metadataTracerProvider{t: t, wantID: wantID}
 	r := router{API: &API{opts: Opts{
-		TraceReader: metadataFallbackTraceReader{span: &cqrs.OtelSpan{
-			RawOtelSpan: cqrs.RawOtelSpan{
-				TraceID: "00000000000000000000000000000001",
-				SpanID:  "0000000000000001",
-			},
-			RunID:      runID,
-			FunctionID: functionID,
-			AppID:      appID,
-		}},
-		TracerProvider: tp,
 		State: metadataStateLoader{loadMetadata: func(context.Context, statev2.ID) (statev2.Metadata, error) {
 			return statev2.Metadata{}, statev2.ErrMetadataNotFound
 		}},
+		TracerProvider: tp,
 	}}}
 
 	err = r.AddRunMetadata(ctx, auth, runID, &AddRunMetadataRequest{
@@ -166,19 +166,10 @@ func TestAddRunMetadataReturnsTransientStateLoadError(t *testing.T) {
 	auth, err := apiv1auth.NilAuthFinder(ctx)
 	require.NoError(t, err)
 
-	runID := ulid.Make()
+	runID := newRunID()
 	loadErr := errors.New("temporary state load failure")
-	tp := &metadataFallbackTracerProvider{t: t}
+	tp := &metadataTracerProvider{t: t}
 	r := router{API: &API{opts: Opts{
-		TraceReader: metadataFallbackTraceReader{span: &cqrs.OtelSpan{
-			RawOtelSpan: cqrs.RawOtelSpan{
-				TraceID: "00000000000000000000000000000001",
-				SpanID:  "0000000000000001",
-			},
-			RunID:      runID,
-			FunctionID: uuid.New(),
-			AppID:      uuid.New(),
-		}},
 		TracerProvider: tp,
 		State: metadataStateLoader{loadMetadata: func(context.Context, statev2.ID) (statev2.Metadata, error) {
 			return statev2.Metadata{}, loadErr
@@ -205,7 +196,7 @@ func TestAddRunMetadataAllowsScoreMetadata(t *testing.T) {
 	auth, err := apiv1auth.NilAuthFinder(ctx)
 	require.NoError(t, err)
 
-	runID := ulid.Make()
+	runID := newRunID()
 	functionID := uuid.New()
 	appID := uuid.New()
 	stepID := "score-step"
@@ -219,16 +210,10 @@ func TestAddRunMetadataAllowsScoreMetadata(t *testing.T) {
 		},
 	}
 
-	tp := &metadataFallbackTracerProvider{t: t, wantID: wantID}
+	tp := &metadataTracerProvider{t: t, wantID: wantID}
 	r := router{API: &API{opts: Opts{
-		TraceReader: metadataFallbackTraceReader{span: &cqrs.OtelSpan{
-			RawOtelSpan: cqrs.RawOtelSpan{
-				TraceID: "00000000000000000000000000000001",
-				SpanID:  "0000000000000001",
-			},
-			RunID:      runID,
-			FunctionID: functionID,
-			AppID:      appID,
+		State: metadataStateLoader{loadMetadata: func(_ context.Context, _ statev2.ID) (statev2.Metadata, error) {
+			return statev2.Metadata{ID: wantID}, nil
 		}},
 		TracerProvider: tp,
 	}}}
@@ -250,17 +235,8 @@ func TestAddRunMetadataRejectsInvalidScoreMetadata(t *testing.T) {
 	auth, err := apiv1auth.NilAuthFinder(ctx)
 	require.NoError(t, err)
 
-	runID := ulid.Make()
+	runID := newRunID()
 	r := router{API: &API{opts: Opts{
-		TraceReader: metadataFallbackTraceReader{span: &cqrs.OtelSpan{
-			RawOtelSpan: cqrs.RawOtelSpan{
-				TraceID: "00000000000000000000000000000001",
-				SpanID:  "0000000000000001",
-			},
-			RunID:      runID,
-			FunctionID: uuid.New(),
-			AppID:      uuid.New(),
-		}},
 		State: metadataStateLoader{loadMetadata: func(context.Context, statev2.ID) (statev2.Metadata, error) {
 			require.Fail(t, "LoadMetadata should not be called for invalid metadata")
 			return statev2.Metadata{}, nil
@@ -282,7 +258,7 @@ func TestAddRunMetadataAllowsRunScopedScoreMetadata(t *testing.T) {
 	auth, err := apiv1auth.NilAuthFinder(ctx)
 	require.NoError(t, err)
 
-	runID := ulid.Make()
+	runID := newRunID()
 	functionID := uuid.New()
 	appID := uuid.New()
 	wantID := statev2.ID{
@@ -295,16 +271,10 @@ func TestAddRunMetadataAllowsRunScopedScoreMetadata(t *testing.T) {
 		},
 	}
 
-	tp := &metadataFallbackTracerProvider{t: t, wantID: wantID}
+	tp := &metadataTracerProvider{t: t, wantID: wantID}
 	r := router{API: &API{opts: Opts{
-		TraceReader: metadataFallbackTraceReader{span: &cqrs.OtelSpan{
-			RawOtelSpan: cqrs.RawOtelSpan{
-				TraceID: "00000000000000000000000000000001",
-				SpanID:  "0000000000000001",
-			},
-			RunID:      runID,
-			FunctionID: functionID,
-			AppID:      appID,
+		State: metadataStateLoader{loadMetadata: func(_ context.Context, _ statev2.ID) (statev2.Metadata, error) {
+			return statev2.Metadata{ID: wantID}, nil
 		}},
 		TracerProvider: tp,
 	}}}
@@ -325,18 +295,8 @@ func TestAddRunMetadataRejectsDisallowedInngestKind(t *testing.T) {
 	auth, err := apiv1auth.NilAuthFinder(ctx)
 	require.NoError(t, err)
 
-	runID := ulid.Make()
-	r := router{API: &API{opts: Opts{
-		TraceReader: metadataFallbackTraceReader{span: &cqrs.OtelSpan{
-			RawOtelSpan: cqrs.RawOtelSpan{
-				TraceID: "00000000000000000000000000000001",
-				SpanID:  "0000000000000001",
-			},
-			RunID:      runID,
-			FunctionID: uuid.New(),
-			AppID:      uuid.New(),
-		}},
-	}}}
+	runID := newRunID()
+	r := router{API: &API{opts: Opts{}}}
 
 	err = r.AddRunMetadata(ctx, auth, runID, &AddRunMetadataRequest{
 		Metadata: []metadata.Update{{RawUpdate: metadata.RawUpdate{
@@ -346,4 +306,50 @@ func TestAddRunMetadataRejectsDisallowedInngestKind(t *testing.T) {
 		}}},
 	})
 	require.ErrorIs(t, err, metadata.ErrKindNotAllowed)
+}
+
+// TestAddRunMetadataLegacyPathForOldRuns verifies that run IDs created before
+// deterministicSpanIDCutoff are routed through the legacy ClickHouse query
+// path (getParentSpan with retry).
+func TestAddRunMetadataLegacyPathForOldRuns(t *testing.T) {
+	ctx := t.Context()
+	auth, err := apiv1auth.NilAuthFinder(ctx)
+	require.NoError(t, err)
+
+	runID := preDeterministicSpanIDRunID()
+	functionID := uuid.New()
+	appID := uuid.New()
+	wantID := statev2.ID{
+		RunID:      runID,
+		FunctionID: functionID,
+		Tenant: statev2.Tenant{
+			AppID:     appID,
+			EnvID:     auth.WorkspaceID(),
+			AccountID: auth.AccountID(),
+		},
+	}
+
+	tp := &metadataTracerProvider{t: t, wantID: wantID}
+	r := router{API: &API{opts: Opts{
+		TraceReader: metadataTraceReader{span: &cqrs.OtelSpan{
+			RawOtelSpan: cqrs.RawOtelSpan{
+				TraceID: "00000000000000000000000000000001",
+				SpanID:  "0000000000000001",
+			},
+			RunID:      runID,
+			FunctionID: functionID,
+			AppID:      appID,
+		}},
+		TracerProvider: tp,
+	}}}
+
+	err = r.AddRunMetadata(ctx, auth, runID, &AddRunMetadataRequest{
+		Metadata: []metadata.Update{{RawUpdate: metadata.RawUpdate{
+			Kind:   "userland.scores",
+			Op:     enums.MetadataOpcodeMerge,
+			Values: metadata.Values{"score": json.RawMessage(`{"value":1}`)},
+		}}},
+	})
+	require.NoError(t, err)
+	require.True(t, tp.called)
 }


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This changes the metadata API to use deterministic span IDs for span attribution for new runs.

We still use CH for older runs

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
