### PR TITLE
feat(queue): Track earliest peek time before Constraint API

### DIFF
--- a/pkg/execution/queue/consts.go
+++ b/pkg/execution/queue/consts.go
@@ -52,13 +52,14 @@ const (
 	DefaultQueuePeekMax  int64 = 750
 	AbsoluteQueuePeekMax int64 = 5000
 
-	QueuePeekCurrMultiplier int64 = 4 // threshold 25%
-	QueuePeekEWMALen        int   = 10
-	QueueLeaseDuration            = 30 * time.Second
-	RoleLeaseDuration             = 10 * time.Second
-	RoleLeaseMax                  = 20 * time.Second
-	ShardLeaseDuration            = 10 * time.Second
-	ShardLeaseMax                 = 20 * time.Second
+	QueuePeekCurrMultiplier      int64 = 4 // threshold 25%
+	QueuePeekEWMALen             int   = 10
+	QueueLeaseDuration                 = 30 * time.Second
+	QueueItemEarliestPeekTimeTTL       = 7 * 24 * time.Hour
+	RoleLeaseDuration                  = 10 * time.Second
+	RoleLeaseMax                       = 20 * time.Second
+	ShardLeaseDuration                 = 10 * time.Second
+	ShardLeaseMax                      = 20 * time.Second
 
 	PriorityMax     uint = 0
 	PriorityDefault uint = 5

--- a/pkg/execution/queue/errors.go
+++ b/pkg/execution/queue/errors.go
@@ -108,8 +108,9 @@ var (
 )
 
 var (
-	ErrProcessNoCapacity   = fmt.Errorf("no capacity")
-	ErrProcessStopIterator = fmt.Errorf("stop iterator")
+	ErrProcessNoCapacity               = fmt.Errorf("no capacity")
+	ErrProcessStopIterator             = fmt.Errorf("stop iterator")
+	ErrProcessNoUserConstraintCapacity = fmt.Errorf("no user constraint capacity: %w", ErrProcessStopIterator)
 )
 
 var (

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -323,6 +323,8 @@ type ShardOperations interface {
 
 	EnqueueItem(ctx context.Context, i QueueItem, at time.Time, opts EnqueueOpts) (QueueItem, error)
 
+	SetEarliestPeekTime(ctx context.Context, item QueueItem, at time.Time) (time.Time, error)
+
 	Lease(ctx context.Context, item QueueItem, leaseDuration time.Duration, now time.Time, options ...LeaseOptionFn) (*ulid.ULID, error)
 	ExtendLease(ctx context.Context, i QueueItem, leaseID ulid.ULID, duration time.Duration, opts ...ExtendLeaseOptionFn) (*ulid.ULID, error)
 

--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -43,6 +43,7 @@ type AccountShardIterationEnabled func(ctx context.Context, accountID uuid.UUID)
 // DisableSemaphoreConstraintChecks controls whether semaphore constraints should
 // be ignored for an account while semaphores are rolled out.
 type DisableSemaphoreConstraintChecks func(ctx context.Context, accountID uuid.UUID) bool
+
 // QueueItemEarliestPeekTimeConfig controls earliest-peek-time side-key stamping.
 // Items already visited by the iterator are stamped individually when Enabled is
 // true. BulkStampLimit is only the additional tail budget used if the iterator

--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -43,6 +43,19 @@ type AccountShardIterationEnabled func(ctx context.Context, accountID uuid.UUID)
 // DisableSemaphoreConstraintChecks controls whether semaphore constraints should
 // be ignored for an account while semaphores are rolled out.
 type DisableSemaphoreConstraintChecks func(ctx context.Context, accountID uuid.UUID) bool
+// QueueItemEarliestPeekTimeConfig controls earliest-peek-time side-key stamping.
+// Items already visited by the iterator are stamped individually when Enabled is
+// true. BulkStampLimit is only the additional tail budget used if the iterator
+// stops early after hitting account or function concurrency, and is ignored
+// unless Enabled is true.
+type QueueItemEarliestPeekTimeConfig struct {
+	Enabled        bool
+	BulkStampLimit int
+}
+
+// QueueItemEarliestPeekTimeEnabled returns the earliest-peek-time side-key
+// stamping config for a queue item scope.
+type QueueItemEarliestPeekTimeEnabled func(ctx context.Context, shardName string, acctID, envID, fnID uuid.UUID) QueueItemEarliestPeekTimeConfig
 
 func WithName(name string) QueueProcessorOpt {
 	return func(q *queueProcessor) {
@@ -88,6 +101,33 @@ func WithAccountShardIterationEnabled(f AccountShardIterationEnabled) QueueOpt {
 			q.AccountShardIterationEnabled = f
 		}
 	}
+}
+
+func WithQueueItemEarliestPeekTimeEnabled(f QueueItemEarliestPeekTimeEnabled) QueueOpt {
+	return func(q *QueueOptions) {
+		if f != nil {
+			q.QueueItemEarliestPeekTimeEnabled = f
+		}
+	}
+}
+
+func (o QueueOptions) ItemEarliestPeekTimeConfig(ctx context.Context, shardName string, item QueueItem) QueueItemEarliestPeekTimeConfig {
+	if o.QueueItemEarliestPeekTimeEnabled == nil {
+		return QueueItemEarliestPeekTimeConfig{}
+	}
+
+	config := o.QueueItemEarliestPeekTimeEnabled(
+		ctx,
+		shardName,
+		item.Data.Identifier.AccountID,
+		item.Data.Identifier.WorkspaceID,
+		item.FunctionID,
+	)
+	if config.BulkStampLimit < 0 {
+		config.BulkStampLimit = 0
+	}
+
+	return config
 }
 
 func WithIdempotencyTTL(t time.Duration) QueueOpt {
@@ -357,11 +397,12 @@ type QueueRunMode struct {
 }
 
 type QueueOptions struct {
-	PartitionPriorityFinder      PartitionPriorityFinder
-	AccountPriorityFinder        AccountPriorityFinder
-	AccountExists                AccountExists
-	PartitionPausedGetter        PartitionPausedGetter
-	AccountShardIterationEnabled AccountShardIterationEnabled
+	PartitionPriorityFinder          PartitionPriorityFinder
+	AccountPriorityFinder            AccountPriorityFinder
+	AccountExists                    AccountExists
+	PartitionPausedGetter            PartitionPausedGetter
+	AccountShardIterationEnabled     AccountShardIterationEnabled
+	QueueItemEarliestPeekTimeEnabled QueueItemEarliestPeekTimeEnabled
 
 	lifecycles QueueLifecycleListeners
 
@@ -782,6 +823,9 @@ func NewQueueOptions(
 		},
 		AllowKeyQueues: func(ctx context.Context, acctID, envID, fnID uuid.UUID) bool {
 			return false
+		},
+		QueueItemEarliestPeekTimeEnabled: func(ctx context.Context, shardName string, acctID, envID, fnID uuid.UUID) QueueItemEarliestPeekTimeConfig {
+			return QueueItemEarliestPeekTimeConfig{}
 		},
 		shadowPartitionProcessCount: func(ctx context.Context, acctID uuid.UUID) int {
 			return 5

--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -146,6 +146,21 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 	item.Data.At = time.UnixMilli(item.AtMS)
 	item.Data.EnqueuedAt = time.UnixMilli(item.EnqueuedAt)
 
+	if item.EarliestPeekTime == 0 && p.Queue.Options().ItemEarliestPeekTimeConfig(ctx, p.Queue.Shard().Name(), *item).Enabled {
+		peekTime := p.StaticTime
+		if peekTime.IsZero() {
+			peekTime = p.Queue.Clock().Now()
+		}
+
+		earliestPeekTime, err := p.Queue.Shard().SetEarliestPeekTime(ctx, *item, peekTime)
+		if err != nil {
+			span.RecordError(err)
+			l.Warn("could not set earliest peek time", "error", err)
+		} else {
+			item.EarliestPeekTime = earliestPeekTime.UnixMilli()
+		}
+	}
+
 	if item.IsLeased(p.Queue.Clock().Now()) {
 		span.SetAttributes(attribute.String("skip_reason", "already_leased"))
 		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{

--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -98,9 +98,15 @@ func (p *ProcessorIterator) Iterate(ctx context.Context) error {
 			if errors.Is(err, ErrQueueItemNotFound) {
 				continue
 			}
+
+			// If item processing was terminated early due to user constraints,
+			// set the earliest peek time for the remaining items.
+			// This ensures accurate tracking of peeked items waiting for
+			// user constraint capacity to become available (user latency).
 			if errors.Is(err, ErrProcessNoUserConstraintCapacity) {
 				config := p.Queue.Options().ItemEarliestPeekTimeConfig(ctx, p.Queue.Shard().Name(), *i)
 				if config.Enabled {
+					// Stamp remaining items from next item on (idx+1)
 					p.stampRemainingEarliestPeekTimes(ctx, idx+1, config.BulkStampLimit)
 				}
 			}
@@ -133,6 +139,7 @@ func (p *ProcessorIterator) Iterate(ctx context.Context) error {
 	return err
 }
 
+// stampRemainingEarliestPeekTimes iterates over a slice of items starting from start and up to limit.
 func (p *ProcessorIterator) stampRemainingEarliestPeekTimes(ctx context.Context, start, limit int) {
 	if limit <= 0 || start >= len(p.Items) {
 		return
@@ -183,21 +190,6 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 	item.Data.At = time.UnixMilli(item.AtMS)
 	item.Data.EnqueuedAt = time.UnixMilli(item.EnqueuedAt)
 
-	if item.EarliestPeekTime == 0 && p.Queue.Options().ItemEarliestPeekTimeConfig(ctx, p.Queue.Shard().Name(), *item).Enabled {
-		peekTime := p.StaticTime
-		if peekTime.IsZero() {
-			peekTime = p.Queue.Clock().Now()
-		}
-
-		earliestPeekTime, err := p.Queue.Shard().SetEarliestPeekTime(ctx, *item, peekTime)
-		if err != nil {
-			span.RecordError(err)
-			l.Warn("could not set earliest peek time", "error", err)
-		} else {
-			item.EarliestPeekTime = earliestPeekTime.UnixMilli()
-		}
-	}
-
 	if item.IsLeased(p.Queue.Clock().Now()) {
 		span.SetAttributes(attribute.String("skip_reason", "already_leased"))
 		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{
@@ -236,6 +228,25 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 
 		release()
 	}()
+
+	// In case the item has no earliest peek time set and stamping is enabled,
+	// call SetEarliestPeekTime before verifying and user constraints.
+	// This is intentionally called AFTER queue worker capacity; unlike user constraints,
+	// worker capacity counts towards system latency, not user latency.
+	if item.EarliestPeekTime == 0 && p.Queue.Options().ItemEarliestPeekTimeConfig(ctx, p.Queue.Shard().Name(), *item).Enabled {
+		peekTime := p.StaticTime
+		if peekTime.IsZero() {
+			peekTime = p.Queue.Clock().Now()
+		}
+
+		earliestPeekTime, err := p.Queue.Shard().SetEarliestPeekTime(ctx, *item, peekTime)
+		if err != nil {
+			span.RecordError(err)
+			l.Warn("could not set earliest peek time", "error", err)
+		} else {
+			item.EarliestPeekTime = earliestPeekTime.UnixMilli()
+		}
+	}
 
 	//
 	// Before we can do any work on the queue item, we need to check if all the constraints have capacity.

--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -70,7 +70,7 @@ func (p *ProcessorIterator) Iterate(ctx context.Context) error {
 	p.IsSemaphoreLimitOnly.Store(true)
 
 	eg := errgroup.Group{}
-	for _, i := range p.Items {
+	for idx, i := range p.Items {
 		if i == nil {
 			// THIS SHOULD NEVER HAPPEN. Skip gracefully and log error
 			logger.StdlibLogger(ctx).Error("nil queue item in partition", "partition", p.Partition)
@@ -97,6 +97,12 @@ func (p *ProcessorIterator) Iterate(ctx context.Context) error {
 			// NOTE: ignore if the queue item is not found
 			if errors.Is(err, ErrQueueItemNotFound) {
 				continue
+			}
+			if errors.Is(err, ErrProcessNoUserConstraintCapacity) {
+				config := p.Queue.Options().ItemEarliestPeekTimeConfig(ctx, p.Queue.Shard().Name(), *i)
+				if config.Enabled {
+					p.stampRemainingEarliestPeekTimes(ctx, idx+1, config.BulkStampLimit)
+				}
 			}
 			// always break on the first error;  if processing returns an error we
 			// always assume that we stop iterating.
@@ -125,6 +131,37 @@ func (p *ProcessorIterator) Iterate(ctx context.Context) error {
 
 	// someting went wrong.  report the error.
 	return err
+}
+
+func (p *ProcessorIterator) stampRemainingEarliestPeekTimes(ctx context.Context, start, limit int) {
+	if limit <= 0 || start >= len(p.Items) {
+		return
+	}
+
+	peekTime := p.StaticTime
+	if peekTime.IsZero() {
+		peekTime = p.Queue.Clock().Now()
+	}
+
+	l := logger.StdlibLogger(ctx).With("partition", p.Partition)
+	attempts := 0
+	for _, item := range p.Items[start:] {
+		if attempts >= limit {
+			return
+		}
+		if item == nil || item.EarliestPeekTime != 0 {
+			continue
+		}
+
+		attempts++
+		earliestPeekTime, err := p.Queue.Shard().SetEarliestPeekTime(ctx, *item, peekTime)
+		if err != nil {
+			l.Warn("could not set earliest peek time for remaining item", "item", item, "error", err)
+			continue
+		}
+
+		item.EarliestPeekTime = earliestPeekTime.UnixMilli()
+	}
 }
 
 func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error {
@@ -437,7 +474,7 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 			})
 		}
 
-		return fmt.Errorf("concurrency hit: %w", ErrProcessStopIterator)
+		return fmt.Errorf("concurrency hit: %w", ErrProcessNoUserConstraintCapacity)
 	case ErrConcurrencyLimitCustomKey:
 		p.IsSemaphoreLimitOnly.Store(false)
 		p.CtrConcurrency.Add(1)

--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -361,7 +361,7 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 	//
 	// Anyway, here we set the first peek item to the item's start time if there was a
 	// peek since the job was added.
-	if p.Partition.Last > 0 && p.Partition.Last > item.AtMS {
+	if item.EarliestPeekTime == 0 && p.Partition.Last > 0 && p.Partition.Last > item.AtMS {
 		// Fudge the earliest peek time because we know this wasn't peeked and so
 		// the peek time wasn't set;  but, as we were still processing jobs after
 		// the job was added this item was concurrency-limited.

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"iter"
 	"sync"
 	"sync/atomic"
@@ -67,6 +68,9 @@ type mockShardForIterator struct {
 	runningCountCalls       int32
 	statusCount             int64
 	statusCountCalls        int32
+	earliestPeekTimes       sync.Map
+	earliestPeekTimeCalls   int32
+	earliestPeekTimeErr     error
 }
 
 func (m *mockShardForIterator) Name() string {
@@ -99,6 +103,15 @@ func (m *mockShardForIterator) ItemLeaseConstraintCheck(
 func (m *mockShardForIterator) Lease(ctx context.Context, item QueueItem, duration time.Duration, now time.Time, options ...LeaseOptionFn) (*ulid.ULID, error) {
 	id := ulid.Make()
 	return &id, nil
+}
+
+func (m *mockShardForIterator) SetEarliestPeekTime(ctx context.Context, item QueueItem, at time.Time) (time.Time, error) {
+	atomic.AddInt32(&m.earliestPeekTimeCalls, 1)
+	if m.earliestPeekTimeErr != nil {
+		return time.Time{}, m.earliestPeekTimeErr
+	}
+	actual, _ := m.earliestPeekTimes.LoadOrStore(item.ID, at)
+	return actual.(time.Time), nil
 }
 
 func (m *mockShardForIterator) Requeue(ctx context.Context, i QueueItem, at time.Time, opts ...RequeueOptionFn) error {
@@ -728,4 +741,195 @@ func TestProcessorIteratorIsCustomKeyLimitOnlyRace(t *testing.T) {
 	// With atomic operations, this should now be deterministic
 	require.False(t, isCustomKeyLimitOnly,
 		"IsCustomKeyLimitOnly should be false when function concurrency limits are hit")
+}
+
+func TestProcessorIteratorUsesPartitionLastEarliestPeekFallbackWhenFlagDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	accountID := uuid.New()
+	fnID := uuid.New()
+	envID := uuid.New()
+	at := time.Now().Add(-time.Minute).Truncate(time.Millisecond)
+
+	shard := &mockShardForIterator{
+		name: "test-shard",
+	}
+	mockProc := &mockQueueProcessor{
+		shard:     shard,
+		clock:     clockwork.NewRealClock(),
+		sem:       util.NewTrackingSemaphore(1),
+		workers:   make(chan ProcessItem, 1),
+		shadowMap: make(map[string]ShadowContinuation),
+		opts:      NewQueueOptions(),
+		constraintResultFunc: func() enums.QueueConstraint {
+			return enums.QueueConstraintFunctionConcurrency
+		},
+	}
+
+	partition := &QueuePartition{
+		ID:         fnID.String(),
+		AccountID:  accountID,
+		EnvID:      &envID,
+		FunctionID: &fnID,
+		Last:       at.Add(time.Second).UnixMilli(),
+	}
+	item := &QueueItem{
+		ID:          ulid.Make().String(),
+		FunctionID:  fnID,
+		WorkspaceID: envID,
+		AtMS:        at.UnixMilli(),
+		Data: Item{
+			Kind: KindEdge,
+			Identifier: state.Identifier{
+				AccountID:   accountID,
+				WorkspaceID: envID,
+				WorkflowID:  fnID,
+				RunID:       ulid.Make(),
+			},
+		},
+	}
+
+	iter := ProcessorIterator{
+		Partition:  partition,
+		Items:      []*QueueItem{item},
+		Queue:      mockProc,
+		StaticTime: at.Add(2 * time.Second),
+	}
+
+	err := iter.Process(ctx, item)
+	require.ErrorIs(t, err, ErrProcessStopIterator)
+	require.Equal(t, item.AtMS, item.EarliestPeekTime)
+	require.Equal(t, int32(0), atomic.LoadInt32(&shard.earliestPeekTimeCalls))
+}
+
+func TestProcessorIteratorStampsProcessedItemWhenBulkLimitZero(t *testing.T) {
+	ctx := context.Background()
+
+	accountID := uuid.New()
+	fnID := uuid.New()
+	envID := uuid.New()
+	at := time.Now().Add(-time.Minute).Truncate(time.Millisecond)
+	peekTime := at.Add(2 * time.Second)
+
+	shard := &mockShardForIterator{
+		name: "test-shard",
+	}
+	opts := NewQueueOptions()
+	WithQueueItemEarliestPeekTimeEnabled(func(ctx context.Context, shardName string, acctID, gotEnvID, gotFnID uuid.UUID) QueueItemEarliestPeekTimeConfig {
+		return QueueItemEarliestPeekTimeConfig{
+			Enabled:        true,
+			BulkStampLimit: 0,
+		}
+	})(opts)
+
+	mockProc := &mockQueueProcessor{
+		shard:     shard,
+		clock:     clockwork.NewRealClock(),
+		sem:       util.NewTrackingSemaphore(1),
+		workers:   make(chan ProcessItem, 1),
+		shadowMap: make(map[string]ShadowContinuation),
+		opts:      opts,
+	}
+
+	require.NoError(t, mockProc.sem.Acquire(ctx, 1))
+
+	partition := &QueuePartition{
+		ID:         fnID.String(),
+		AccountID:  accountID,
+		EnvID:      &envID,
+		FunctionID: &fnID,
+		Last:       at.Add(time.Second).UnixMilli(),
+	}
+	item := &QueueItem{
+		ID:          ulid.Make().String(),
+		FunctionID:  fnID,
+		WorkspaceID: envID,
+		AtMS:        at.UnixMilli(),
+		Data: Item{
+			Kind: KindEdge,
+			Identifier: state.Identifier{
+				AccountID:   accountID,
+				WorkspaceID: envID,
+				WorkflowID:  fnID,
+				RunID:       ulid.Make(),
+			},
+		},
+	}
+
+	iter := ProcessorIterator{
+		Partition:  partition,
+		Items:      []*QueueItem{item},
+		Queue:      mockProc,
+		StaticTime: peekTime,
+	}
+
+	err := iter.Process(ctx, item)
+	require.ErrorIs(t, err, ErrProcessNoCapacity)
+	require.Equal(t, peekTime.UnixMilli(), item.EarliestPeekTime)
+	require.Equal(t, int32(1), atomic.LoadInt32(&shard.earliestPeekTimeCalls))
+}
+
+func TestProcessorIteratorContinuesWhenEarliestPeekTimeStampFails(t *testing.T) {
+	ctx := context.Background()
+
+	accountID := uuid.New()
+	fnID := uuid.New()
+	envID := uuid.New()
+	at := time.Now().Add(-time.Minute).Truncate(time.Millisecond)
+
+	shard := &mockShardForIterator{
+		name:                "test-shard",
+		earliestPeekTimeErr: errors.New("redis unavailable"),
+	}
+	opts := NewQueueOptions()
+	WithQueueItemEarliestPeekTimeEnabled(func(ctx context.Context, shardName string, acctID, gotEnvID, gotFnID uuid.UUID) QueueItemEarliestPeekTimeConfig {
+		return QueueItemEarliestPeekTimeConfig{
+			Enabled: true,
+		}
+	})(opts)
+
+	workers := make(chan ProcessItem, 1)
+	mockProc := &mockQueueProcessor{
+		shard:     shard,
+		clock:     clockwork.NewRealClock(),
+		sem:       util.NewTrackingSemaphore(1),
+		workers:   workers,
+		shadowMap: make(map[string]ShadowContinuation),
+		opts:      opts,
+	}
+
+	partition := &QueuePartition{
+		ID:         fnID.String(),
+		AccountID:  accountID,
+		EnvID:      &envID,
+		FunctionID: &fnID,
+	}
+	item := &QueueItem{
+		ID:          ulid.Make().String(),
+		FunctionID:  fnID,
+		WorkspaceID: envID,
+		AtMS:        at.UnixMilli(),
+		Data: Item{
+			Kind: KindEdge,
+			Identifier: state.Identifier{
+				AccountID:   accountID,
+				WorkspaceID: envID,
+				WorkflowID:  fnID,
+				RunID:       ulid.Make(),
+			},
+		},
+	}
+
+	iter := ProcessorIterator{
+		Partition:  partition,
+		Items:      []*QueueItem{item},
+		Queue:      mockProc,
+		StaticTime: at.Add(2 * time.Second),
+	}
+
+	err := iter.Process(ctx, item)
+	require.NoError(t, err)
+	require.Zero(t, item.EarliestPeekTime)
+	require.Equal(t, int32(1), atomic.LoadInt32(&shard.earliestPeekTimeCalls))
+	require.Len(t, workers, 1)
 }

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -797,6 +797,7 @@ func TestProcessorIteratorUsesPartitionLastEarliestPeekFallbackWhenFlagDisabled(
 	}
 
 	err := iter.Process(ctx, item)
+	require.ErrorIs(t, err, ErrProcessNoUserConstraintCapacity)
 	require.ErrorIs(t, err, ErrProcessStopIterator)
 	require.Equal(t, item.AtMS, item.EarliestPeekTime)
 	require.Equal(t, int32(0), atomic.LoadInt32(&shard.earliestPeekTimeCalls))

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -803,7 +803,7 @@ func TestProcessorIteratorUsesPartitionLastEarliestPeekFallbackWhenFlagDisabled(
 	require.Equal(t, int32(0), atomic.LoadInt32(&shard.earliestPeekTimeCalls))
 }
 
-func TestProcessorIteratorStampsProcessedItemWhenBulkLimitZero(t *testing.T) {
+func TestProcessorIteratorSkipsEarliestPeekTimeWhenNoWorkerCapacity(t *testing.T) {
 	ctx := context.Background()
 
 	accountID := uuid.New()
@@ -866,8 +866,8 @@ func TestProcessorIteratorStampsProcessedItemWhenBulkLimitZero(t *testing.T) {
 
 	err := iter.Process(ctx, item)
 	require.ErrorIs(t, err, ErrProcessNoCapacity)
-	require.Equal(t, peekTime.UnixMilli(), item.EarliestPeekTime)
-	require.Equal(t, int32(1), atomic.LoadInt32(&shard.earliestPeekTimeCalls))
+	require.Zero(t, item.EarliestPeekTime)
+	require.Equal(t, int32(0), atomic.LoadInt32(&shard.earliestPeekTimeCalls))
 }
 
 func TestProcessorIteratorContinuesWhenEarliestPeekTimeStampFails(t *testing.T) {

--- a/pkg/execution/state/redis_state/key_generator.go
+++ b/pkg/execution/state/redis_state/key_generator.go
@@ -125,6 +125,9 @@ type QueueKeyGenerator interface {
 	// QueueItem returns the key for the hash containing all items within a
 	// queue for a function.
 	QueueItem() string
+	// QueueItemEarliestPeekTime returns the key storing the first time a queue
+	// item was observed by the processor iterator.
+	QueueItemEarliestPeekTime(itemID string) string
 
 	//
 	// Partition keys
@@ -637,4 +640,8 @@ type queueItemKeyGenerator struct {
 
 func (u queueItemKeyGenerator) QueueItem() string {
 	return fmt.Sprintf("{%s}:queue:item", u.queueDefaultKey)
+}
+
+func (u queueItemKeyGenerator) QueueItemEarliestPeekTime(itemID string) string {
+	return fmt.Sprintf("{%s}:queue:item:peek:%s", u.queueDefaultKey, itemID)
 }

--- a/pkg/execution/state/redis_state/lua/queue/dequeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/dequeue.lua
@@ -31,8 +31,10 @@ local singletonRunKey          = KEYS[17]
 
 local keyPartitionScavengerIndex  = KEYS[18]
 
-local keyItemIndexA            = KEYS[19]   -- custom item index 1
-local keyItemIndexB            = KEYS[20]  -- custom item index 2
+local keyEarliestPeekTime      = KEYS[19]
+
+local keyItemIndexA            = KEYS[20]   -- custom item index 1
+local keyItemIndexB            = KEYS[21]  -- custom item index 2
 
 local queueID        = ARGV[1]
 local partitionID    = ARGV[2]
@@ -56,6 +58,7 @@ if item == nil then
 end
 
 redis.call("HDEL", keyQueueMap, queueID)
+redis.call("DEL", keyEarliestPeekTime)
 
 -- TODO Are these calls safe? Should we check for present keys?
 redis.call("ZREM", keyReadyQueue, queueID)

--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -17,7 +17,8 @@ local queueID = ARGV[1]
 local partitionID = ARGV[2]
 local newLeaseID = ARGV[3]
 local currentTime = tonumber(ARGV[4]) -- in ms
-local setLegacyPeekTime = tonumber(ARGV[5])
+local setEarliestPeekTime = tonumber(ARGV[5])
+local itemEarliestPeekTime = tonumber(ARGV[6])
 
 -- Use our custom Go preprocessor to inject the file from ./includes/
 -- $include(decode_ulid_time.lua)
@@ -42,7 +43,12 @@ if item.leaseID ~= nil and item.leaseID ~= cjson.null and decode_ulid_time(item.
 	return -2
 end
 
-if setLegacyPeekTime == 1 then
+if setEarliestPeekTime == 1 and itemEarliestPeekTime ~= nil and itemEarliestPeekTime > 0 then
+	-- The processor may have stamped earliest peek time through the side-key
+	-- path before leasing. Persist that value on the item once leased so later
+	-- calls can compute latency from the queue item alone.
+	item = set_item_peek_time(keyQueueMap, queueID, item, itemEarliestPeekTime)
+else
 	-- Track the earliest time this job was attempted in the queue. This is the
 	-- legacy path used before earliest peek time moved to a side key.
 	item = set_item_peek_time(keyQueueMap, queueID, item, currentTime)

--- a/pkg/execution/state/redis_state/lua/queue/lease.lua
+++ b/pkg/execution/state/redis_state/lua/queue/lease.lua
@@ -17,6 +17,7 @@ local queueID = ARGV[1]
 local partitionID = ARGV[2]
 local newLeaseID = ARGV[3]
 local currentTime = tonumber(ARGV[4]) -- in ms
+local setLegacyPeekTime = tonumber(ARGV[5])
 
 -- Use our custom Go preprocessor to inject the file from ./includes/
 -- $include(decode_ulid_time.lua)
@@ -41,8 +42,11 @@ if item.leaseID ~= nil and item.leaseID ~= cjson.null and decode_ulid_time(item.
 	return -2
 end
 
--- Track the earliest time this job was attempted in the queue.
-item = set_item_peek_time(keyQueueMap, queueID, item, currentTime)
+if setLegacyPeekTime == 1 then
+	-- Track the earliest time this job was attempted in the queue. This is the
+	-- legacy path used before earliest peek time moved to a side key.
+	item = set_item_peek_time(keyQueueMap, queueID, item, currentTime)
+end
 
 -- Update the item's lease key.
 item.leaseID = newLeaseID

--- a/pkg/execution/state/redis_state/lua/queue/removeItem.lua
+++ b/pkg/execution/state/redis_state/lua/queue/removeItem.lua
@@ -7,14 +7,16 @@
 
 local queueKey     = KEYS[1]
 local queueItemKey = KEYS[2]
+local keyEarliestPeekTime = KEYS[3]
 
 local itemID = ARGV[1]
 
 redis.call("ZREM", queueKey, itemID)
 redis.call("HDEL", queueItemKey, itemID)
+redis.call("DEL", keyEarliestPeekTime)
 
 -- Clean up any additional index keys (e.g. status indexes) passed by the caller.
-for i = 3, #KEYS do
+for i = 4, #KEYS do
     if KEYS[i] ~= "" then
         redis.call("ZREM", KEYS[i], itemID)
     end

--- a/pkg/execution/state/redis_state/lua/queue/requeue.lua
+++ b/pkg/execution/state/redis_state/lua/queue/requeue.lua
@@ -28,8 +28,10 @@ local keyAccountShadowPartitionSet       = KEYS[14]
 
 local keyPartitionScavengerIndex  = KEYS[15]
 
-local keyItemIndexA           = KEYS[16]          -- custom item index 1
-local keyItemIndexB           = KEYS[17]          -- custom item index 2
+local keyEarliestPeekTime     = KEYS[16]
+
+local keyItemIndexA           = KEYS[17]          -- custom item index 1
+local keyItemIndexB           = KEYS[18]          -- custom item index 2
 
 local queueID             = ARGV[1]           -- id
 local queueItem           = ARGV[2]
@@ -60,6 +62,7 @@ end
 
 -- Update the queue item with a nil lease, at, atMS, etc.
 redis.call("HSET", queueKey, queueID, queueItem)
+redis.call("DEL", keyEarliestPeekTime)
 
 -- Remove item from ready queue
 redis.call("ZREM", keyReadyQueue, item.id)

--- a/pkg/execution/state/redis_state/lua/queue/requeueByID.lua
+++ b/pkg/execution/state/redis_state/lua/queue/requeueByID.lua
@@ -21,6 +21,7 @@ local keyGlobalAccountPointer = KEYS[4] -- accounts:sorted - zset
 local keyAccountPartitions    = KEYS[5] -- accounts:$accountId:partition:sorted
 
 local keyPartitionFn    = KEYS[6] -- queue:sorted:$workflowID - zset
+local keyEarliestPeekTime = KEYS[7]
 
 local jobID            = ARGV[1]           -- queue item ID
 local jobScore         = tonumber(ARGV[2]) -- enqueue at, in milliseconds
@@ -52,7 +53,9 @@ end
 -- Update the "at" time of the job
 item.at = jobScore
 item.wt = jobScore
+item.pt = nil
 redis.call("HSET", keyQueueHash, jobID, cjson.encode(item))
+redis.call("DEL", keyEarliestPeekTime)
 
 requeue_to_partition(keyPartitionFn, partitionID, partitionItem, keyPartitionMap, keyGlobalPointer, keyGlobalAccountPointer, keyAccountPartitions, jobScore, jobID, nowMS, accountID)
 

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -912,9 +912,9 @@ func (q *queue) Lease(
 		kg.PartitionScavengerIndex(o.ShadowPartition.PartitionID),
 	}
 
-	setLegacyPeekTime := "1"
+	setEarliestPeekTime := "0"
 	if q.ItemEarliestPeekTimeConfig(ctx, q.Name(), item).Enabled {
-		setLegacyPeekTime = "0"
+		setEarliestPeekTime = "1"
 	}
 
 	args, err := StrSlice([]any{
@@ -922,7 +922,8 @@ func (q *queue) Lease(
 		o.ShadowPartition.PartitionID,
 		leaseID.String(),
 		now.UnixMilli(),
-		setLegacyPeekTime,
+		setEarliestPeekTime,
+		item.EarliestPeekTime,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -372,6 +372,7 @@ func (q *queue) RemoveQueueItem(ctx context.Context, scope osqueue.Scope, partit
 	keys := []string{
 		q.RedisClient.kg.PartitionQueueSet(enums.PartitionTypeDefault, partitionID, ""),
 		q.RedisClient.kg.QueueItem(),
+		q.RedisClient.kg.QueueItemEarliestPeekTime(itemID),
 	}
 
 	// If partitionID is a valid function UUID, append status index keys so the
@@ -427,6 +428,42 @@ func (q *queue) LoadQueueItem(ctx context.Context, itemID string) (*osqueue.Queu
 	qi.Data.JobID = &qi.ID
 
 	return qi, nil
+}
+
+func (q *queue) SetEarliestPeekTime(ctx context.Context, item osqueue.QueueItem, at time.Time) (time.Time, error) {
+	if item.ID == "" {
+		return time.Time{}, fmt.Errorf("cannot set earliest peek time for queue item with empty ID")
+	}
+
+	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "SetEarliestPeekTime"), redis_telemetry.ScopeQueue)
+
+	at = time.UnixMilli(at.UnixMilli())
+	client := q.RedisClient.Client()
+	key := q.RedisClient.kg.QueueItemEarliestPeekTime(item.ID)
+	value := strconv.FormatInt(at.UnixMilli(), 10)
+
+	prev, err := client.Do(ctx, client.B().
+		Set().
+		Key(key).
+		Value(value).
+		Nx().
+		Get().
+		Ex(osqueue.QueueItemEarliestPeekTimeTTL).
+		Build(),
+	).ToString()
+	if err == rueidis.Nil {
+		return at, nil
+	}
+	if err != nil {
+		return time.Time{}, fmt.Errorf("could not set earliest peek time: %w", err)
+	}
+
+	ms, err := strconv.ParseInt(prev, 10, 64)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("could not parse earliest peek time %q: %w", prev, err)
+	}
+
+	return time.UnixMilli(ms), nil
 }
 
 // Peek takes n items from a queue, up until QueuePeekMax.  For peeking workflow/
@@ -774,6 +811,7 @@ func (q *queue) RequeueByJobID(ctx context.Context, jobID string, at time.Time) 
 		q.RedisClient.kg.AccountPartitionIndex(i.Data.Identifier.AccountID),
 
 		partitionZsetKey(fnPartition, q.RedisClient.kg),
+		q.RedisClient.kg.QueueItemEarliestPeekTime(jobID),
 	}
 
 	args, err := StrSlice([]any{
@@ -874,11 +912,17 @@ func (q *queue) Lease(
 		kg.PartitionScavengerIndex(o.ShadowPartition.PartitionID),
 	}
 
+	setLegacyPeekTime := "1"
+	if q.ItemEarliestPeekTimeConfig(ctx, q.Name(), item).Enabled {
+		setLegacyPeekTime = "0"
+	}
+
 	args, err := StrSlice([]any{
 		item.ID,
 		o.ShadowPartition.PartitionID,
 		leaseID.String(),
 		now.UnixMilli(),
+		setLegacyPeekTime,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/execution/state/redis_state/queue_op.go
+++ b/pkg/execution/state/redis_state/queue_op.go
@@ -81,6 +81,7 @@ func (q *queue) Dequeue(ctx context.Context, i osqueue.QueueItem, options ...osq
 		kg.SingletonRunKey(i.Data.Identifier.RunID.String()),
 
 		kg.PartitionScavengerIndex(partition.PartitionID),
+		kg.QueueItemEarliestPeekTime(i.ID),
 	}
 
 	// Append indexes
@@ -170,6 +171,7 @@ func (q *queue) Requeue(ctx context.Context, i osqueue.QueueItem, at time.Time, 
 
 	// Reset enqueuedAt (used for latency calculation)
 	i.EnqueuedAt = now.UnixMilli()
+	i.EarliestPeekTime = 0
 
 	fnPartition := osqueue.ItemPartition(ctx, i)
 	shadowPartition := osqueue.ItemShadowPartition(ctx, i)
@@ -237,6 +239,7 @@ func (q *queue) Requeue(ctx context.Context, i osqueue.QueueItem, at time.Time, 
 		kg.AccountShadowPartitions(i.Data.Identifier.AccountID), // empty for system partitions
 
 		kg.PartitionScavengerIndex(shadowPartition.PartitionID),
+		kg.QueueItemEarliestPeekTime(i.ID),
 	}
 	// Append indexes
 	for _, idx := range q.itemIndexer(ctx, i, q.RedisClient.kg) {

--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -31,6 +31,15 @@ func IncrQueueItemProcessedCounter(ctx context.Context, opts CounterOpt) {
 	})
 }
 
+func IncrQueueItemEarliestPeekTimeCounter(ctx context.Context, count int64, opts CounterOpt) {
+	RecordCounterMetric(ctx, count, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "queue_item_earliest_peek_time_total",
+		Description: "Total number of queue items considered for earliest peek time stamping",
+		Tags:        opts.Tags,
+	})
+}
+
 func IncrQueuePartitionLeaseContentionCounter(ctx context.Context, opts CounterOpt) {
 	RecordCounterMetric(ctx, 1, CounterOpt{
 		PkgName:     opts.PkgName,

--- a/tests/execution/queue/earliest_peek_time_test.go
+++ b/tests/execution/queue/earliest_peek_time_test.go
@@ -125,14 +125,83 @@ func TestProcessorIteratorSetsEarliestPeekTimeBeforeConstraintLimit(t *testing.T
 
 	loaded, err := shard.LoadQueueItem(ctx, qi1.ID)
 	require.NoError(t, err)
-	require.Zero(t, loaded.EarliestPeekTime, "earliest peek time should live in the side key, not the queue item hash")
+	require.Equal(t, peekTime.UnixMilli(), loaded.EarliestPeekTime, "leased item should persist stamped earliest peek time")
 
 	loaded, err = shard.LoadQueueItem(ctx, qi2.ID)
 	require.NoError(t, err)
-	require.Zero(t, loaded.EarliestPeekTime, "earliest peek time should live in the side key, not the queue item hash")
+	require.Zero(t, loaded.EarliestPeekTime, "unleased stamped item should still live in the side key only")
 }
 
-func TestLeaseSetsLegacyEarliestPeekTimeWhenFeatureFlagDisabled(t *testing.T) {
+func TestLeasePersistsStampedEarliestPeekTimeWhenFeatureFlagEnabled(t *testing.T) {
+	ctx := context.Background()
+
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC))
+	r.SetTime(clock.Now())
+
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+
+	queueClient := redis_state.NewQueueClient(rc, redis_state.QueueDefaultKey)
+	shard := redis_state.NewQueueShard(
+		"test",
+		queueClient,
+		osqueue.WithClock(clock),
+		osqueue.WithQueueItemEarliestPeekTimeEnabled(func(ctx context.Context, shardName string, acctID, gotEnvID, gotFnID uuid.UUID) osqueue.QueueItemEarliestPeekTimeConfig {
+			if shardName == "test" && acctID == accountID && gotEnvID == envID && gotFnID == fnID {
+				return osqueue.QueueItemEarliestPeekTimeConfig{Enabled: true}
+			}
+			return osqueue.QueueItemEarliestPeekTimeConfig{}
+		}),
+	)
+
+	qi, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
+		FunctionID:  fnID,
+		WorkspaceID: envID,
+		Data: osqueue.Item{
+			Kind: osqueue.KindStart,
+			Identifier: state.Identifier{
+				AccountID:   accountID,
+				WorkspaceID: envID,
+				WorkflowID:  fnID,
+				RunID:       ulid.MustNew(ulid.Timestamp(clock.Now()), rand.Reader),
+			},
+			WorkspaceID: envID,
+		},
+	}, clock.Now(), osqueue.EnqueueOpts{})
+	require.NoError(t, err)
+	require.Zero(t, qi.EarliestPeekTime)
+
+	peekTime := clock.Now().Add(250 * time.Millisecond)
+	stampedAt, err := shard.SetEarliestPeekTime(ctx, qi, peekTime)
+	require.NoError(t, err)
+	require.Equal(t, peekTime.UnixMilli(), stampedAt.UnixMilli())
+
+	loaded, err := shard.LoadQueueItem(ctx, qi.ID)
+	require.NoError(t, err)
+	require.Zero(t, loaded.EarliestPeekTime)
+
+	qi.EarliestPeekTime = stampedAt.UnixMilli()
+	_, err = shard.Lease(ctx, qi, osqueue.QueueLeaseDuration, clock.Now().Add(time.Second))
+	require.NoError(t, err)
+
+	loaded, err = shard.LoadQueueItem(ctx, qi.ID)
+	require.NoError(t, err)
+	require.Equal(t, peekTime.UnixMilli(), loaded.EarliestPeekTime)
+
+	key := queueClient.KeyGenerator().QueueItemEarliestPeekTime(qi.ID)
+	val, err := r.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, strconv.FormatInt(peekTime.UnixMilli(), 10), val)
+}
+
+func TestLeaseIgnoresStampedEarliestPeekTimeWhenFeatureFlagDisabled(t *testing.T) {
 	ctx := context.Background()
 
 	r := miniredis.RunT(t)
@@ -167,6 +236,9 @@ func TestLeaseSetsLegacyEarliestPeekTimeWhenFeatureFlagDisabled(t *testing.T) {
 	}, clock.Now(), osqueue.EnqueueOpts{})
 	require.NoError(t, err)
 
+	stampedPeekTime := clock.Now().Add(-time.Minute)
+	qi.EarliestPeekTime = stampedPeekTime.UnixMilli()
+
 	leaseTime := clock.Now().Add(250 * time.Millisecond)
 	_, err = shard.Lease(ctx, qi, osqueue.QueueLeaseDuration, leaseTime)
 	require.NoError(t, err)
@@ -174,6 +246,7 @@ func TestLeaseSetsLegacyEarliestPeekTimeWhenFeatureFlagDisabled(t *testing.T) {
 	loaded, err := shard.LoadQueueItem(ctx, qi.ID)
 	require.NoError(t, err)
 	require.Equal(t, leaseTime.UnixMilli(), loaded.EarliestPeekTime)
+	require.NotEqual(t, stampedPeekTime.UnixMilli(), loaded.EarliestPeekTime)
 
 	key := queueClient.KeyGenerator().QueueItemEarliestPeekTime(qi.ID)
 	require.False(t, r.Exists(key), "legacy path should not create the side key")

--- a/tests/execution/queue/earliest_peek_time_test.go
+++ b/tests/execution/queue/earliest_peek_time_test.go
@@ -278,7 +278,10 @@ func TestProcessorIteratorSetsEarliestPeekTimeForProcessedItemsBeforeConcurrency
 	require.Len(t, cmLifecycles.AcquireCalls[1].GrantedLeases, 0)
 	require.Len(t, cmLifecycles.AcquireCalls[1].LimitingConstraints, 1)
 
-	stampedItems := len(cmLifecycles.AcquireCalls)
+	stampedItems := len(cmLifecycles.AcquireCalls) + bulkStampLimit
+	if stampedItems > len(items) {
+		stampedItems = len(items)
+	}
 	for i, qi := range items {
 		key := queueClient.KeyGenerator().QueueItemEarliestPeekTime(qi.ID)
 		if i < stampedItems {

--- a/tests/execution/queue/earliest_peek_time_test.go
+++ b/tests/execution/queue/earliest_peek_time_test.go
@@ -297,6 +297,244 @@ func TestProcessorIteratorSetsEarliestPeekTimeForProcessedItemsBeforeConcurrency
 	}
 }
 
+func TestProcessorIteratorDoesNotStampRemainingItemsWhenDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2026, 6, 11, 10, 0, 0, 123_000_000, time.UTC))
+	r.SetTime(clock.Now())
+
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+
+	cmLifecycles := constraintapi.NewConstraintAPIDebugLifecycles()
+	cm, err := constraintapi.NewRedisCapacityManager(
+		constraintapi.WithClient(rc),
+		constraintapi.WithShardName("test"),
+		constraintapi.WithClock(clock),
+		constraintapi.WithLifecycles(cmLifecycles),
+	)
+	require.NoError(t, err)
+
+	const bulkStampLimit = 5
+	options := []osqueue.QueueOpt{
+		osqueue.WithClock(clock),
+		osqueue.WithCapacityManager(cm),
+		osqueue.WithAcquireCapacityLeaseOnBacklogRefill(true),
+		osqueue.WithQueueItemEarliestPeekTimeEnabled(func(ctx context.Context, shardName string, acctID, gotEnvID, gotFnID uuid.UUID) osqueue.QueueItemEarliestPeekTimeConfig {
+			if shardName == "test" && acctID == accountID && gotEnvID == envID && gotFnID == fnID {
+				return osqueue.QueueItemEarliestPeekTimeConfig{
+					Enabled:        false,
+					BulkStampLimit: bulkStampLimit,
+				}
+			}
+			return osqueue.QueueItemEarliestPeekTimeConfig{}
+		}),
+		osqueue.WithPartitionConstraintConfigGetter(func(ctx context.Context, p osqueue.PartitionIdentifier) osqueue.PartitionConstraintConfig {
+			return osqueue.PartitionConstraintConfig{
+				FunctionVersion: 1,
+				Concurrency: osqueue.PartitionConcurrency{
+					AccountConcurrency:  1,
+					FunctionConcurrency: 1,
+				},
+			}
+		}),
+	}
+
+	queueClient := redis_state.NewQueueClient(rc, redis_state.QueueDefaultKey)
+	shard := redis_state.NewQueueShard("test", queueClient, options...)
+
+	shardRegistry, err := osqueue.NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+	q, err := osqueue.New(ctx, "test", shardRegistry, options...)
+	require.NoError(t, err)
+
+	makeItem := func() osqueue.QueueItem {
+		return osqueue.QueueItem{
+			FunctionID:  fnID,
+			WorkspaceID: envID,
+			Data: osqueue.Item{
+				Kind: osqueue.KindStart,
+				Identifier: state.Identifier{
+					AccountID:   accountID,
+					WorkspaceID: envID,
+					WorkflowID:  fnID,
+					RunID:       ulid.MustNew(ulid.Timestamp(clock.Now()), rand.Reader),
+				},
+				WorkspaceID: envID,
+			},
+		}
+	}
+
+	items := make([]*osqueue.QueueItem, 10)
+	for i := range items {
+		qi, err := shard.EnqueueItem(ctx, makeItem(), clock.Now(), osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+		items[i] = &qi
+	}
+
+	partition := osqueue.ItemPartition(ctx, *items[0])
+	iter := osqueue.ProcessorIterator{
+		Partition:  &partition,
+		Items:      items,
+		Queue:      q,
+		StaticTime: clock.Now().Add(250 * time.Millisecond),
+	}
+
+	err = iter.Iterate(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, cmLifecycles.AcquireCalls, 2)
+	require.Len(t, cmLifecycles.AcquireCalls[0].GrantedLeases, 1)
+	require.Len(t, cmLifecycles.AcquireCalls[1].GrantedLeases, 0)
+
+	for i, qi := range items {
+		key := queueClient.KeyGenerator().QueueItemEarliestPeekTime(qi.ID)
+		require.False(t, r.Exists(key), "item %d should not have a side key", i)
+	}
+}
+
+func TestQueueLatencySeparatesSystemAndUserLatencyAfterEarliestPeekStamp(t *testing.T) {
+	ctx := context.Background()
+
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	enqueuedAt := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
+	clock := clockwork.NewFakeClockAt(enqueuedAt)
+	r.SetTime(clock.Now())
+
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+
+	cm, err := constraintapi.NewRedisCapacityManager(
+		constraintapi.WithClient(rc),
+		constraintapi.WithShardName("test"),
+		constraintapi.WithClock(clock),
+	)
+	require.NoError(t, err)
+
+	functionVersion := 1
+	concurrencyLimit := 1
+	options := []osqueue.QueueOpt{
+		osqueue.WithClock(clock),
+		osqueue.WithCapacityManager(cm),
+		osqueue.WithAcquireCapacityLeaseOnBacklogRefill(true),
+		osqueue.WithQueueItemEarliestPeekTimeEnabled(func(ctx context.Context, shardName string, acctID, gotEnvID, gotFnID uuid.UUID) osqueue.QueueItemEarliestPeekTimeConfig {
+			if shardName == "test" && acctID == accountID && gotEnvID == envID && gotFnID == fnID {
+				return osqueue.QueueItemEarliestPeekTimeConfig{
+					Enabled:        true,
+					BulkStampLimit: 10,
+				}
+			}
+			return osqueue.QueueItemEarliestPeekTimeConfig{}
+		}),
+		osqueue.WithPartitionConstraintConfigGetter(func(ctx context.Context, p osqueue.PartitionIdentifier) osqueue.PartitionConstraintConfig {
+			return osqueue.PartitionConstraintConfig{
+				FunctionVersion: functionVersion,
+				Concurrency: osqueue.PartitionConcurrency{
+					AccountConcurrency:  concurrencyLimit,
+					FunctionConcurrency: concurrencyLimit,
+				},
+			}
+		}),
+	}
+
+	queueClient := redis_state.NewQueueClient(rc, redis_state.QueueDefaultKey)
+	shard := redis_state.NewQueueShard("test", queueClient, options...)
+
+	shardRegistry, err := osqueue.NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+	q, err := osqueue.New(ctx, "test", shardRegistry, options...)
+	require.NoError(t, err)
+
+	makeItem := func() osqueue.QueueItem {
+		return osqueue.QueueItem{
+			FunctionID:  fnID,
+			WorkspaceID: envID,
+			Data: osqueue.Item{
+				Kind: osqueue.KindStart,
+				Identifier: state.Identifier{
+					AccountID:   accountID,
+					WorkspaceID: envID,
+					WorkflowID:  fnID,
+					RunID:       ulid.MustNew(ulid.Timestamp(clock.Now()), rand.Reader),
+				},
+				WorkspaceID: envID,
+			},
+		}
+	}
+
+	qi1, err := shard.EnqueueItem(ctx, makeItem(), enqueuedAt, osqueue.EnqueueOpts{})
+	require.NoError(t, err)
+	qi2, err := shard.EnqueueItem(ctx, makeItem(), enqueuedAt, osqueue.EnqueueOpts{})
+	require.NoError(t, err)
+
+	partition := osqueue.ItemPartition(ctx, qi1)
+	peekTime := enqueuedAt.Add(5 * time.Second)
+	iter := osqueue.ProcessorIterator{
+		Partition:  &partition,
+		Items:      []*osqueue.QueueItem{&qi1, &qi2},
+		Queue:      q,
+		StaticTime: peekTime,
+	}
+
+	err = iter.Iterate(ctx)
+	require.NoError(t, err)
+	require.Equal(t, peekTime.UnixMilli(), qi2.EarliestPeekTime)
+
+	firstWork := <-q.Workers()
+	err = q.ProcessItem(ctx, firstWork, func(ctx context.Context, info osqueue.RunInfo, item osqueue.Item) (osqueue.RunResult, error) {
+		return osqueue.RunResult{}, nil
+	})
+	require.NoError(t, err)
+	q.Semaphore().Release(1)
+	require.NotNil(t, firstWork.CapacityLease)
+	require.NoError(t, firstWork.CapacityLease.Release())
+
+	functionVersion = 2
+	concurrencyLimit = 2
+
+	processTime := peekTime.Add(7 * time.Second)
+	clock.Advance(processTime.Sub(clock.Now()))
+	r.SetTime(clock.Now())
+
+	iter = osqueue.ProcessorIterator{
+		Partition:  &partition,
+		Items:      []*osqueue.QueueItem{&qi2},
+		Queue:      q,
+		StaticTime: processTime,
+	}
+	err = iter.Iterate(ctx)
+	require.NoError(t, err)
+	require.Len(t, q.Workers(), 1)
+
+	infoCh := make(chan osqueue.RunInfo, 1)
+	secondWork := <-q.Workers()
+	err = q.ProcessItem(ctx, secondWork, func(ctx context.Context, info osqueue.RunInfo, item osqueue.Item) (osqueue.RunResult, error) {
+		infoCh <- info
+		return osqueue.RunResult{}, nil
+	})
+	require.NoError(t, err)
+	q.Semaphore().Release(1)
+	require.NotNil(t, secondWork.CapacityLease)
+	require.NoError(t, secondWork.CapacityLease.Release())
+
+	info := <-infoCh
+	require.Equal(t, peekTime.Sub(enqueuedAt), info.Latency)
+	require.Equal(t, processTime.Sub(peekTime), info.SojournDelay)
+}
+
 func TestSetEarliestPeekTimeOnlyStoresFirstTimestamp(t *testing.T) {
 	ctx := context.Background()
 

--- a/tests/execution/queue/earliest_peek_time_test.go
+++ b/tests/execution/queue/earliest_peek_time_test.go
@@ -1,0 +1,379 @@
+package queue
+
+import (
+	"context"
+	"crypto/rand"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/constraintapi"
+	osqueue "github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/execution/state/redis_state"
+	"github.com/jonboulle/clockwork"
+	"github.com/oklog/ulid/v2"
+	"github.com/redis/rueidis"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProcessorIteratorSetsEarliestPeekTimeBeforeConstraintLimit(t *testing.T) {
+	ctx := context.Background()
+
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2026, 6, 11, 10, 0, 0, 123_000_000, time.UTC))
+	r.SetTime(clock.Now())
+
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+
+	cmLifecycles := constraintapi.NewConstraintAPIDebugLifecycles()
+	cm, err := constraintapi.NewRedisCapacityManager(
+		constraintapi.WithClient(rc),
+		constraintapi.WithShardName("test"),
+		constraintapi.WithClock(clock),
+		constraintapi.WithLifecycles(cmLifecycles),
+	)
+	require.NoError(t, err)
+
+	options := []osqueue.QueueOpt{
+		osqueue.WithClock(clock),
+		osqueue.WithCapacityManager(cm),
+		osqueue.WithAcquireCapacityLeaseOnBacklogRefill(true),
+		osqueue.WithQueueItemEarliestPeekTimeEnabled(func(ctx context.Context, shardName string, acctID, gotEnvID, gotFnID uuid.UUID) osqueue.QueueItemEarliestPeekTimeConfig {
+			if shardName == "test" && acctID == accountID && gotEnvID == envID && gotFnID == fnID {
+				return osqueue.QueueItemEarliestPeekTimeConfig{
+					Enabled:        true,
+					BulkStampLimit: 100,
+				}
+			}
+			return osqueue.QueueItemEarliestPeekTimeConfig{}
+		}),
+		osqueue.WithPartitionConstraintConfigGetter(func(ctx context.Context, p osqueue.PartitionIdentifier) osqueue.PartitionConstraintConfig {
+			return osqueue.PartitionConstraintConfig{
+				FunctionVersion: 1,
+				Concurrency: osqueue.PartitionConcurrency{
+					AccountConcurrency:  1,
+					FunctionConcurrency: 1,
+				},
+			}
+		}),
+	}
+
+	queueClient := redis_state.NewQueueClient(rc, redis_state.QueueDefaultKey)
+	shard := redis_state.NewQueueShard("test", queueClient, options...)
+
+	shardRegistry, err := osqueue.NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+	q, err := osqueue.New(ctx, "test", shardRegistry, options...)
+	require.NoError(t, err)
+
+	makeItem := func() osqueue.QueueItem {
+		return osqueue.QueueItem{
+			FunctionID:  fnID,
+			WorkspaceID: envID,
+			Data: osqueue.Item{
+				Kind: osqueue.KindStart,
+				Identifier: state.Identifier{
+					AccountID:   accountID,
+					WorkspaceID: envID,
+					WorkflowID:  fnID,
+					RunID:       ulid.MustNew(ulid.Timestamp(clock.Now()), rand.Reader),
+				},
+				WorkspaceID: envID,
+			},
+		}
+	}
+
+	qi1, err := shard.EnqueueItem(ctx, makeItem(), clock.Now(), osqueue.EnqueueOpts{})
+	require.NoError(t, err)
+	qi2, err := shard.EnqueueItem(ctx, makeItem(), clock.Now(), osqueue.EnqueueOpts{})
+	require.NoError(t, err)
+
+	partition := osqueue.ItemPartition(ctx, qi1)
+	peekTime := clock.Now().Add(250 * time.Millisecond)
+	iter := osqueue.ProcessorIterator{
+		Partition:  &partition,
+		Items:      []*osqueue.QueueItem{&qi1, &qi2},
+		Queue:      q,
+		StaticTime: peekTime,
+	}
+
+	err = iter.Iterate(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, cmLifecycles.AcquireCalls, 2)
+	require.Len(t, cmLifecycles.AcquireCalls[0].GrantedLeases, 1)
+	require.Len(t, cmLifecycles.AcquireCalls[1].GrantedLeases, 0)
+	require.Len(t, cmLifecycles.AcquireCalls[1].LimitingConstraints, 1)
+
+	require.Equal(t, peekTime.UnixMilli(), qi1.EarliestPeekTime)
+	require.Equal(t, peekTime.UnixMilli(), qi2.EarliestPeekTime)
+
+	key := queueClient.KeyGenerator().QueueItemEarliestPeekTime(qi2.ID)
+	val, err := r.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, strconv.FormatInt(peekTime.UnixMilli(), 10), val)
+
+	loaded, err := shard.LoadQueueItem(ctx, qi1.ID)
+	require.NoError(t, err)
+	require.Zero(t, loaded.EarliestPeekTime, "earliest peek time should live in the side key, not the queue item hash")
+
+	loaded, err = shard.LoadQueueItem(ctx, qi2.ID)
+	require.NoError(t, err)
+	require.Zero(t, loaded.EarliestPeekTime, "earliest peek time should live in the side key, not the queue item hash")
+}
+
+func TestLeaseSetsLegacyEarliestPeekTimeWhenFeatureFlagDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC))
+	r.SetTime(clock.Now())
+
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+
+	queueClient := redis_state.NewQueueClient(rc, redis_state.QueueDefaultKey)
+	shard := redis_state.NewQueueShard("test", queueClient, osqueue.WithClock(clock))
+
+	qi, err := shard.EnqueueItem(ctx, osqueue.QueueItem{
+		FunctionID:  fnID,
+		WorkspaceID: envID,
+		Data: osqueue.Item{
+			Kind: osqueue.KindStart,
+			Identifier: state.Identifier{
+				AccountID:   accountID,
+				WorkspaceID: envID,
+				WorkflowID:  fnID,
+				RunID:       ulid.MustNew(ulid.Timestamp(clock.Now()), rand.Reader),
+			},
+			WorkspaceID: envID,
+		},
+	}, clock.Now(), osqueue.EnqueueOpts{})
+	require.NoError(t, err)
+
+	leaseTime := clock.Now().Add(250 * time.Millisecond)
+	_, err = shard.Lease(ctx, qi, osqueue.QueueLeaseDuration, leaseTime)
+	require.NoError(t, err)
+
+	loaded, err := shard.LoadQueueItem(ctx, qi.ID)
+	require.NoError(t, err)
+	require.Equal(t, leaseTime.UnixMilli(), loaded.EarliestPeekTime)
+
+	key := queueClient.KeyGenerator().QueueItemEarliestPeekTime(qi.ID)
+	require.False(t, r.Exists(key), "legacy path should not create the side key")
+}
+
+func TestProcessorIteratorSetsEarliestPeekTimeForProcessedItemsBeforeConcurrencyStop(t *testing.T) {
+	ctx := context.Background()
+
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2026, 6, 11, 10, 0, 0, 123_000_000, time.UTC))
+	r.SetTime(clock.Now())
+
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+
+	cmLifecycles := constraintapi.NewConstraintAPIDebugLifecycles()
+	cm, err := constraintapi.NewRedisCapacityManager(
+		constraintapi.WithClient(rc),
+		constraintapi.WithShardName("test"),
+		constraintapi.WithClock(clock),
+		constraintapi.WithLifecycles(cmLifecycles),
+	)
+	require.NoError(t, err)
+
+	const bulkStampLimit = 5
+	options := []osqueue.QueueOpt{
+		osqueue.WithClock(clock),
+		osqueue.WithCapacityManager(cm),
+		osqueue.WithAcquireCapacityLeaseOnBacklogRefill(true),
+		osqueue.WithQueueItemEarliestPeekTimeEnabled(func(ctx context.Context, shardName string, acctID, gotEnvID, gotFnID uuid.UUID) osqueue.QueueItemEarliestPeekTimeConfig {
+			if shardName == "test" && acctID == accountID && gotEnvID == envID && gotFnID == fnID {
+				return osqueue.QueueItemEarliestPeekTimeConfig{
+					Enabled:        true,
+					BulkStampLimit: bulkStampLimit,
+				}
+			}
+			return osqueue.QueueItemEarliestPeekTimeConfig{}
+		}),
+		osqueue.WithPartitionConstraintConfigGetter(func(ctx context.Context, p osqueue.PartitionIdentifier) osqueue.PartitionConstraintConfig {
+			return osqueue.PartitionConstraintConfig{
+				FunctionVersion: 1,
+				Concurrency: osqueue.PartitionConcurrency{
+					AccountConcurrency:  1,
+					FunctionConcurrency: 1,
+				},
+			}
+		}),
+	}
+
+	queueClient := redis_state.NewQueueClient(rc, redis_state.QueueDefaultKey)
+	shard := redis_state.NewQueueShard("test", queueClient, options...)
+
+	shardRegistry, err := osqueue.NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+	q, err := osqueue.New(ctx, "test", shardRegistry, options...)
+	require.NoError(t, err)
+
+	makeItem := func() osqueue.QueueItem {
+		return osqueue.QueueItem{
+			FunctionID:  fnID,
+			WorkspaceID: envID,
+			Data: osqueue.Item{
+				Kind: osqueue.KindStart,
+				Identifier: state.Identifier{
+					AccountID:   accountID,
+					WorkspaceID: envID,
+					WorkflowID:  fnID,
+					RunID:       ulid.MustNew(ulid.Timestamp(clock.Now()), rand.Reader),
+				},
+				WorkspaceID: envID,
+			},
+		}
+	}
+
+	items := make([]*osqueue.QueueItem, 10)
+	for i := range items {
+		qi, err := shard.EnqueueItem(ctx, makeItem(), clock.Now(), osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+		items[i] = &qi
+	}
+
+	partition := osqueue.ItemPartition(ctx, *items[0])
+	peekTime := clock.Now().Add(250 * time.Millisecond)
+	iter := osqueue.ProcessorIterator{
+		Partition:  &partition,
+		Items:      items,
+		Queue:      q,
+		StaticTime: peekTime,
+	}
+
+	err = iter.Iterate(ctx)
+	require.NoError(t, err)
+
+	require.Len(t, cmLifecycles.AcquireCalls, 2)
+	require.Len(t, cmLifecycles.AcquireCalls[0].GrantedLeases, 1)
+	require.Len(t, cmLifecycles.AcquireCalls[1].GrantedLeases, 0)
+	require.Len(t, cmLifecycles.AcquireCalls[1].LimitingConstraints, 1)
+
+	stampedItems := len(cmLifecycles.AcquireCalls)
+	for i, qi := range items {
+		key := queueClient.KeyGenerator().QueueItemEarliestPeekTime(qi.ID)
+		if i < stampedItems {
+			require.Equal(t, peekTime.UnixMilli(), qi.EarliestPeekTime, "item %d should be stamped", i)
+			val, err := r.Get(key)
+			require.NoError(t, err)
+			require.Equal(t, strconv.FormatInt(peekTime.UnixMilli(), 10), val)
+			continue
+		}
+
+		require.Zero(t, qi.EarliestPeekTime, "item %d should be beyond the cutoff", i)
+		require.False(t, r.Exists(key), "item %d should not have a side key", i)
+	}
+}
+
+func TestSetEarliestPeekTimeOnlyStoresFirstTimestamp(t *testing.T) {
+	ctx := context.Background()
+
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC))
+	r.SetTime(clock.Now())
+
+	queueClient := redis_state.NewQueueClient(rc, redis_state.QueueDefaultKey)
+	shard := redis_state.NewQueueShard("test", queueClient, osqueue.WithClock(clock))
+
+	qi, err := shard.EnqueueItem(ctx, osqueue.QueueItem{}, clock.Now(), osqueue.EnqueueOpts{})
+	require.NoError(t, err)
+
+	first := clock.Now()
+	second := first.Add(time.Hour)
+
+	got, err := shard.SetEarliestPeekTime(ctx, qi, first)
+	require.NoError(t, err)
+	require.Equal(t, first.UnixMilli(), got.UnixMilli())
+
+	got, err = shard.SetEarliestPeekTime(ctx, qi, second)
+	require.NoError(t, err)
+	require.Equal(t, first.UnixMilli(), got.UnixMilli())
+
+	key := queueClient.KeyGenerator().QueueItemEarliestPeekTime(qi.ID)
+	val, err := r.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, strconv.FormatInt(first.UnixMilli(), 10), val)
+
+	ttl := r.TTL(key)
+	require.Greater(t, ttl, time.Duration(0))
+	require.LessOrEqual(t, ttl, osqueue.QueueItemEarliestPeekTimeTTL)
+}
+
+func TestEarliestPeekTimeKeyDeletedOnRequeueAndDequeue(t *testing.T) {
+	ctx := context.Background()
+
+	r := miniredis.RunT(t)
+	rc, err := rueidis.NewClient(rueidis.ClientOption{
+		InitAddress:  []string{r.Addr()},
+		DisableCache: true,
+	})
+	require.NoError(t, err)
+	defer rc.Close()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC))
+	r.SetTime(clock.Now())
+
+	queueClient := redis_state.NewQueueClient(rc, redis_state.QueueDefaultKey)
+	shard := redis_state.NewQueueShard("test", queueClient, osqueue.WithClock(clock))
+
+	qi, err := shard.EnqueueItem(ctx, osqueue.QueueItem{}, clock.Now(), osqueue.EnqueueOpts{})
+	require.NoError(t, err)
+
+	key := queueClient.KeyGenerator().QueueItemEarliestPeekTime(qi.ID)
+	_, err = shard.SetEarliestPeekTime(ctx, qi, clock.Now())
+	require.NoError(t, err)
+	require.True(t, r.Exists(key))
+
+	qi.EarliestPeekTime = clock.Now().UnixMilli()
+	err = shard.Requeue(ctx, qi, clock.Now().Add(time.Minute))
+	require.NoError(t, err)
+	require.False(t, r.Exists(key))
+
+	loaded, err := shard.LoadQueueItem(ctx, qi.ID)
+	require.NoError(t, err)
+	require.Zero(t, loaded.EarliestPeekTime)
+
+	_, err = shard.SetEarliestPeekTime(ctx, *loaded, clock.Now().Add(time.Second))
+	require.NoError(t, err)
+	require.True(t, r.Exists(key))
+
+	err = shard.Dequeue(ctx, *loaded)
+	require.NoError(t, err)
+	require.False(t, r.Exists(key))
+}

--- a/tests/execution/queue/queue_semaphore_test.go
+++ b/tests/execution/queue/queue_semaphore_test.go
@@ -565,6 +565,7 @@ func TestQueueSemaphore(t *testing.T) {
 
 				err = iter.Process(ctx, &qi2)
 				require.Error(t, err)
+				require.ErrorIs(t, err, queue.ErrProcessNoUserConstraintCapacity)
 				require.ErrorIs(t, err, queue.ErrProcessStopIterator)
 				require.ErrorContains(t, err, "concurrency hit")
 				require.Equal(t, int32(1), iter.CtrConcurrency.Load())
@@ -683,6 +684,7 @@ func TestQueueSemaphore(t *testing.T) {
 
 				err = iter.Process(ctx, &qi2)
 				require.Error(t, err)
+				require.ErrorIs(t, err, queue.ErrProcessNoUserConstraintCapacity)
 				require.ErrorIs(t, err, queue.ErrProcessStopIterator)
 				require.ErrorContains(t, err, "concurrency hit")
 				require.Equal(t, int32(1), iter.CtrConcurrency.Load())


### PR DESCRIPTION
### Description

This PR introduces a new way to track earliest lease time, correcting latency metrics.

<img width="4356" height="1530" alt="image" src="https://github.com/user-attachments/assets/f00711a7-aec5-4085-bcd4-67e8a5694e36" />



#### Why?

- We need a good latency indicator for queue performance
- Latency can have different reasons, so it should be split into system vs user latency
- System latency measures the time to job discovery, which is the earliest peek time - desired time to run the job
- User latency measures the time between job discovery and leasing the item, after acquiring the required capacity
- Ideally, system latency is close to 0, this means the item is picked up as close to the desired run time as possible
- Ideally, user latency is close to 0, this means capacity is acquired as close to job discovery as possible

#### How?
- Currently, earliest peek time is set during Lease. When there's no capacity (i.e. Acquire does not return a valid capacity lease), we will skip Lease, so earliest peek time is never set
- Whenever we peek an item, we need to set the earliest peek time before running constraint checks.
- Of course, if there's no capacity, the iterator will potentially stop and requeue the partition before hitting all items, so earliest peek time will be in the future as well, even if the item was returned in the initial peek set.
- This is fixed by iterating over all remaining items and setting earliest peek time, in case of the early exit
- In case of large peek sizes, iterating over every item might get expensive, which is why we cap the maximum number using an option

This PR introduces a new lightweight earliest peek time key that is set during processor iteration if doesn't already exist. We then use that value to set the earliest peek time on the item which is used for metrics.

<details><summary>What does partition.Last do?</summary>
<p>

 partition.Last is the millisecond timestamp of the last
  successful partition lease.

  The authoritative update happens in Redis during PartitionLease:

  - partitionLease.lua reads the existing value into existingTime
  - then sets existing.last = currentTime
  - stores the updated partition JSON back into the partition hash

  See pkg/execution/state/redis_state/lua/queue/
  partitionLease.lua:37.

  Subtle part: the Lua script returns the previous existing.last,
  not the new currentTime. Go then only copies that returned
  previous value onto the in-memory p.Last:

  pkg/execution/state/redis_state/queue.go:1158

  So in the current ProcessPartition call, p.Last is effectively
  “the previous time this partition was leased before this lease.”
  The current lease time is persisted to Redis and will be visible
  when the partition is peeked again later.

  Other paths mostly preserve it:

  - Enqueue creates the partition if missing, with Last defaulting
    to 0.

  - Requeue updates lease/score/force metadata but does not change
    last.

  - Partition peek just reads the persisted partition JSON, so it
    sees whatever the last successful lease wrote.

</p>
</details> 

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
