### PR TITLE
fix(devserver): Reapply postgres connection pool settings

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -92,9 +92,10 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		os.Exit(1)
 	}
 
-	// Validate PostgreSQL connection pool settings
-	postgresMaxIdleConns := cmd.Int("postgres-max-idle-conns")
-	postgresMaxOpenConns := cmd.Int("postgres-max-open-conns")
+	// Validate PostgreSQL connection pool settings. Read through localconfig so
+	// env vars (INNGEST_POSTGRES_*) and config files are honored, not just flags.
+	postgresMaxIdleConns := localconfig.GetIntValue(cmd, "postgres-max-idle-conns", 10)
+	postgresMaxOpenConns := localconfig.GetIntValue(cmd, "postgres-max-open-conns", 100)
 	if postgresMaxOpenConns <= 1 {
 		fmt.Printf("Error: postgres-max-open-conns (%d) must be greater than 1\n", postgresMaxOpenConns)
 		os.Exit(1)
@@ -125,8 +126,8 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		NoUI:                    localconfig.GetBoolValue(cmd, "no-ui", false),
 		Persist:                 true,
 		PollInterval:            localconfig.GetIntValue(cmd, "poll-interval", devserver.DefaultPollInterval),
-		PostgresConnMaxIdleTime: cmd.Int("postgres-conn-max-idle-time"),
-		PostgresConnMaxLifetime: cmd.Int("postgres-conn-max-lifetime"),
+		PostgresConnMaxIdleTime: localconfig.GetIntValue(cmd, "postgres-conn-max-idle-time", 5),
+		PostgresConnMaxLifetime: localconfig.GetIntValue(cmd, "postgres-conn-max-lifetime", 30),
 		PostgresMaxIdleConns:    postgresMaxIdleConns,
 		PostgresMaxOpenConns:    postgresMaxOpenConns,
 		PostgresURI:             postgresURI,

--- a/pkg/db/postgres/migrations.go
+++ b/pkg/db/postgres/migrations.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/inngest/inngest/pkg/logger"
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -30,6 +31,26 @@ type Options struct {
 	// purposes. By default database handlers are singletons, but when this flag
 	// is enabled, each call creates a new connection.
 	ForTest bool
+
+	// MaxIdleConns sets the number of idle connections retained in the pool.
+	//
+	// Zero leaves the database/sql default.
+	MaxIdleConns int
+
+	// MaxOpenConns bounds the total connections the pool may open.
+	//
+	// Zero leaves the database/sql default.
+	MaxOpenConns int
+
+	// ConnMaxIdleTime sets how long an idle connection is retained.
+	//
+	// Zero leaves the database/sql default.
+	ConnMaxIdleTime time.Duration
+
+	// ConnMaxLifetime sets the maximum lifetime of a connection.
+	//
+	// Zero leaves the database/sql default.
+	ConnMaxLifetime time.Duration
 }
 
 func Open(ctx context.Context, opts Options) (*sql.DB, error) {
@@ -61,6 +82,8 @@ func Open(ctx context.Context, opts Options) (*sql.DB, error) {
 		return nil, err
 	}
 
+	configurePool(conn, opts)
+
 	if err := conn.Ping(); err != nil {
 		return nil, err
 	}
@@ -71,6 +94,23 @@ func Open(ctx context.Context, opts Options) (*sql.DB, error) {
 	l.Info("ran database migrations")
 
 	return conn, nil
+}
+
+// configurePool applies any non-zero pool options, leaving database/sql
+// defaults otherwise.
+func configurePool(conn *sql.DB, opts Options) {
+	if opts.MaxIdleConns > 0 {
+		conn.SetMaxIdleConns(opts.MaxIdleConns)
+	}
+	if opts.MaxOpenConns > 0 {
+		conn.SetMaxOpenConns(opts.MaxOpenConns)
+	}
+	if opts.ConnMaxIdleTime > 0 {
+		conn.SetConnMaxIdleTime(opts.ConnMaxIdleTime)
+	}
+	if opts.ConnMaxLifetime > 0 {
+		conn.SetConnMaxLifetime(opts.ConnMaxLifetime)
+	}
 }
 
 func Migrate(ctx context.Context, conn *sql.DB) error {

--- a/pkg/db/postgres/migrations_test.go
+++ b/pkg/db/postgres/migrations_test.go
@@ -1,0 +1,37 @@
+package postgres
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigurePool(t *testing.T) {
+	// sql.Open is lazy, so no live server is needed to assert pool settings.
+	open := func(t *testing.T) *sql.DB {
+		conn, err := sql.Open("pgx", "postgres://user:pass@localhost:5432/inngest")
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, conn.Close()) })
+		return conn
+	}
+
+	t.Run("zero options leave driver defaults", func(t *testing.T) {
+		conn := open(t)
+		configurePool(conn, Options{})
+		// database/sql reports 0 for an unbounded pool.
+		require.Equal(t, 0, conn.Stats().MaxOpenConnections)
+	})
+
+	t.Run("applies explicit options", func(t *testing.T) {
+		conn := open(t)
+		configurePool(conn, Options{
+			MaxIdleConns:    3,
+			MaxOpenConns:    7,
+			ConnMaxIdleTime: time.Minute,
+			ConnMaxLifetime: time.Hour,
+		})
+		require.Equal(t, 7, conn.Stats().MaxOpenConnections)
+	})
+}

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -195,7 +195,14 @@ func start(ctx context.Context, opts StartOpts) error {
 		Helpers() driverhelp.DialectHelpers
 	}
 	if opts.PostgresURI != "" {
-		db, err := dbpostgres.Open(ctx, dbpostgres.Options{URI: opts.PostgresURI})
+		// Pool settings are in minutes, mirroring the postgres-conn-max-* flags.
+		db, err := dbpostgres.Open(ctx, dbpostgres.Options{
+			URI:             opts.PostgresURI,
+			MaxIdleConns:    opts.PostgresMaxIdleConns,
+			MaxOpenConns:    opts.PostgresMaxOpenConns,
+			ConnMaxIdleTime: time.Duration(opts.PostgresConnMaxIdleTime) * time.Minute,
+			ConnMaxLifetime: time.Duration(opts.PostgresConnMaxLifetime) * time.Minute,
+		})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

- Mendral identified that one of our top CI flakes is [this one](https://app.mendral.com/insights/01KMP8EJV264SNJFKJ9KEGE22Q) where we're hitting test timeouts. In particular, "Postgres variants are worst".
- Investigated and identified that we're not properly passing Postgres configurations, in addition to other contributors.
- We regressed in #3894 during some rewiring
- Rewire and add a test for regressions
- Also wire up ENV VAR support for these pieces of config for self-hosted Inngest

## Release note

Fixed a bug where we were improperly configuring Postgres connection pool settings for the dev server and self-hosted Inngest.

Fixed a bug ignoring non-flag Postgres connection pool configuration methods (such as env vars and config files) for self-hosted Inngest.

## Migration note

For users with Postgres, the dev server and self-hosted Inngest will move its connection pooling settings from from 

    2 max idle connections
    unlimited max open connections
    unlimited  connection max idle time
    unlimited connection max lifetime 

to the configured settings. 

These settings can be configured via flags, which have always been supported, or environment variables and config files, which were not previously supported before for self-hosted Inngest.

When a setting is not specified, it will use the default. The default settings are 

      10 max idle connections
      100 max open connections
      5m connection max idle time
      30m connection max lifetime

