### PR TITLE
perf: Add state metadata option to skip fetching stack & step metadata

### DIFF
--- a/pkg/api/apiv1/metadata_test.go
+++ b/pkg/api/apiv1/metadata_test.go
@@ -46,7 +46,7 @@ type metadataStateLoader struct {
 	loadMetadata func(context.Context, statev2.ID) (statev2.Metadata, error)
 }
 
-func (s metadataStateLoader) LoadMetadata(ctx context.Context, id statev2.ID) (statev2.Metadata, error) {
+func (s metadataStateLoader) LoadMetadata(ctx context.Context, id statev2.ID, _ ...statev2.LoadMetadataOption) (statev2.Metadata, error) {
 	if s.loadMetadata != nil {
 		return s.loadMetadata(ctx, id)
 	}

--- a/pkg/execution/checkpoint/checkpoint_async_test.go
+++ b/pkg/execution/checkpoint/checkpoint_async_test.go
@@ -810,7 +810,7 @@ type mockRunService struct {
 	mock.Mock
 }
 
-func (m *mockRunService) LoadMetadata(ctx context.Context, id state.ID) (state.Metadata, error) {
+func (m *mockRunService) LoadMetadata(ctx context.Context, id state.ID, _ ...state.LoadMetadataOption) (state.Metadata, error) {
 	args := m.Called(ctx, id)
 	return args.Get(0).(state.Metadata), args.Error(1)
 }

--- a/pkg/execution/driver/httpv2/httpv2_test.go
+++ b/pkg/execution/driver/httpv2/httpv2_test.go
@@ -584,7 +584,7 @@ type mockStateLoader struct {
 	err    error
 }
 
-func (m *mockStateLoader) LoadMetadata(ctx context.Context, id sv2.ID) (sv2.Metadata, error) {
+func (m *mockStateLoader) LoadMetadata(ctx context.Context, id sv2.ID, _ ...sv2.LoadMetadataOption) (sv2.Metadata, error) {
 	return sv2.Metadata{}, nil
 }
 

--- a/pkg/execution/executor/cancel_test.go
+++ b/pkg/execution/executor/cancel_test.go
@@ -85,7 +85,7 @@ type missingMetadataRunService struct {
 	err     error
 }
 
-func (m *missingMetadataRunService) LoadMetadata(context.Context, sv2.ID) (sv2.Metadata, error) {
+func (m *missingMetadataRunService) LoadMetadata(context.Context, sv2.ID, ...sv2.LoadMetadataOption) (sv2.Metadata, error) {
 	return sv2.Metadata{}, m.err
 }
 

--- a/pkg/execution/pauses/manager_test.go
+++ b/pkg/execution/pauses/manager_test.go
@@ -376,7 +376,7 @@ func (m *mockRunService) SavePending(ctx context.Context, id statev2.ID, pending
 	return nil
 }
 
-func (m *mockRunService) LoadMetadata(ctx context.Context, id statev2.ID) (statev2.Metadata, error) {
+func (m *mockRunService) LoadMetadata(ctx context.Context, id statev2.ID, _ ...statev2.LoadMetadataOption) (statev2.Metadata, error) {
 	return statev2.Metadata{}, nil
 }
 

--- a/pkg/execution/state/redis_state/v2_adapter.go
+++ b/pkg/execution/state/redis_state/v2_adapter.go
@@ -333,7 +333,7 @@ func (v v2) SaveRejectedDefer(ctx context.Context, id state.ID, fnSlug string, h
 }
 
 // Metadata returns metadata for a given run
-func (v v2) LoadMetadata(ctx context.Context, id state.ID) (state.Metadata, error) {
+func (v v2) LoadMetadata(ctx context.Context, id state.ID, _ ...state.LoadMetadataOption) (state.Metadata, error) {
 	md, err := v.mgr.metadata(ctx, id.Tenant.AccountID, id.RunID)
 	if err != nil {
 		return state.Metadata{}, err

--- a/pkg/execution/state/v2/interfaces.go
+++ b/pkg/execution/state/v2/interfaces.go
@@ -132,10 +132,31 @@ func TryIncrementMetadataSize(ctx context.Context, svc RunService, id ID, delta 
 	return nil
 }
 
+type LoadMetadataOpts struct {
+	OmitStackAndStepMetrics bool
+}
+
+type LoadMetadataOption func(*LoadMetadataOpts)
+
+// OmitStackAndStepMetrics skips loading Stack and step-derived metrics
+// (StateSize, StepCount), avoiding an extra round trip. Those fields are
+// zero-valued in the returned Metadata.
+func OmitStackAndStepMetrics() LoadMetadataOption {
+	return func(o *LoadMetadataOpts) { o.OmitStackAndStepMetrics = true }
+}
+
+func ApplyLoadMetadataOpts(opts []LoadMetadataOption) LoadMetadataOpts {
+	var o LoadMetadataOpts
+	for _, fn := range opts {
+		fn(&o)
+	}
+	return o
+}
+
 // Staeloader defines an interface for loading the entire run state from the state store.
 type StateLoader interface {
 	// Metadata returns metadata for a given run
-	LoadMetadata(ctx context.Context, id ID) (Metadata, error)
+	LoadMetadata(ctx context.Context, id ID, opts ...LoadMetadataOption) (Metadata, error)
 	// LoadEvents loads the triggering events for the given run.
 	LoadEvents(ctx context.Context, id ID) ([]json.RawMessage, error)
 	// LoadState returns all steps for a run.

--- a/proto/gen/state/v2/state.pb.go
+++ b/proto/gen/state/v2/state.pb.go
@@ -772,10 +772,13 @@ func (x *DeleteStateResponse) GetDeleted() bool {
 }
 
 type LoadMetadataRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            *ID                    `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Id    *ID                    `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Skip loading stack and step-derived metrics (state_size, step_count)
+	// when the caller doesn't need them, avoiding an extra round trip.
+	OmitStackAndStepMetrics bool `protobuf:"varint,2,opt,name=omit_stack_and_step_metrics,json=omitStackAndStepMetrics,proto3" json:"omit_stack_and_step_metrics,omitempty"`
+	unknownFields           protoimpl.UnknownFields
+	sizeCache               protoimpl.SizeCache
 }
 
 func (x *LoadMetadataRequest) Reset() {
@@ -813,6 +816,13 @@ func (x *LoadMetadataRequest) GetId() *ID {
 		return x.Id
 	}
 	return nil
+}
+
+func (x *LoadMetadataRequest) GetOmitStackAndStepMetrics() bool {
+	if x != nil {
+		return x.OmitStackAndStepMetrics
+	}
+	return false
 }
 
 type LoadMetadataResponse struct {
@@ -2508,9 +2518,10 @@ const file_state_v2_state_proto_rawDesc = "" +
 	"\x12DeleteStateRequest\x12\x1c\n" +
 	"\x02id\x18\x01 \x01(\v2\f.state.v2.IDR\x02id\"/\n" +
 	"\x13DeleteStateResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\bR\adeleted\"3\n" +
+	"\adeleted\x18\x01 \x01(\bR\adeleted\"q\n" +
 	"\x13LoadMetadataRequest\x12\x1c\n" +
-	"\x02id\x18\x01 \x01(\v2\f.state.v2.IDR\x02id\"F\n" +
+	"\x02id\x18\x01 \x01(\v2\f.state.v2.IDR\x02id\x12<\n" +
+	"\x1bomit_stack_and_step_metrics\x18\x02 \x01(\bR\x17omitStackAndStepMetrics\"F\n" +
 	"\x14LoadMetadataResponse\x12.\n" +
 	"\bmetadata\x18\x01 \x01(\v2\x12.state.v2.MetadataR\bmetadata\"\xc1\x01\n" +
 	"\x15UpdateMetadataRequest\x12\x1c\n" +

--- a/proto/state/v2/state.proto
+++ b/proto/state/v2/state.proto
@@ -83,7 +83,10 @@ message DeleteStateResponse {
 }
 
 message LoadMetadataRequest {
-  ID id = 1;
+  ID   id                          = 1;
+  // Skip loading stack and step-derived metrics (state_size, step_count)
+  // when the caller doesn't need them, avoiding an extra round trip.
+  bool omit_stack_and_step_metrics = 2;
 }
 
 message LoadMetadataResponse {


### PR DESCRIPTION
## Description
The idea is that about half of the LoadMetadata call sites don't require step metadata. Right now it's cheap to fetch anyway from Redis since most of it consists of accumulated counters updated atomically via Lua scripts, but that's not true for our next state-store storage engine.

Step metadata is derived from steps, so loading it requires scanning all steps and adds an extra RTT. To avoid that overhead, this change adds an opt-out parameter for callers that don't need it.

It's opt-out rather than opt-in to make rollout backwards compatible (older clients talking to newer State Proxy versions that understand the parameter) and to avoid making the API easy to misuse by accidentally returning incomplete metadata. A complete refactor into separate methods was also considered but requires much more effort to go though each current Metadata usage.

The new option is a no-op for the redis implementation.


<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
