### PR TITLE
fix: state leak when new state is created but ErrQueueItemExists is hit

### DIFF
--- a/pkg/execution/batch/redis.go
+++ b/pkg/execution/batch/redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -345,7 +346,7 @@ func (b *redisBatchManager) ScheduleExecution(ctx context.Context, opts Schedule
 		Payload:     opts.ScheduleBatchPayload,
 		QueueName:   &queueName,
 	}, opts.At, queue.EnqueueOpts{})
-	if err == queue.ErrQueueItemExists {
+	if errors.Is(err, queue.ErrQueueItemExists) {
 		b.log.Debug("queue item already exists for scheduled batch", "job_id", jobID, "function_id", opts.FunctionID)
 		return nil
 	}

--- a/pkg/execution/cancellation/redis.go
+++ b/pkg/execution/cancellation/redis.go
@@ -3,6 +3,7 @@ package cancellation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -93,7 +94,7 @@ func (r redisReadWriter) CreateCancellation(ctx context.Context, c cqrs.Cancella
 		Payload:     c,
 		QueueName:   &queueName,
 	}, time.Now(), queue.EnqueueOpts{})
-	if err == queue.ErrQueueItemExists {
+	if errors.Is(err, queue.ErrQueueItemExists) {
 		return nil
 	}
 	return err

--- a/pkg/execution/cron/manager.go
+++ b/pkg/execution/cron/manager.go
@@ -3,6 +3,7 @@ package cron
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"time"
 
@@ -189,11 +190,11 @@ func (c *manager) Sync(ctx context.Context, ci CronItem) error {
 		Payload:     ci,
 		QueueName:   &kind,
 	}, at, queue.EnqueueOpts{})
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		l.Debug("cron-sync enqueued", "jobID", jobID, "at", at)
 		return nil
-	case queue.ErrQueueItemExists, queue.ErrQueueItemSingletonExists:
+	case errors.Is(err, queue.ErrQueueItemExists) || errors.Is(err, queue.ErrQueueItemSingletonExists):
 		l.Debug("cron-sync item already exists", "jobID", jobID, "at", at)
 		return nil
 	default:
@@ -232,11 +233,11 @@ func (c *manager) EnqueueHealthCheck(ctx context.Context, ci CronItem) error {
 		QueueName:   &kind,
 	}, now, queue.EnqueueOpts{})
 
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		l.Debug("adhoc cron-health-check enqueued", "jobID", jobID)
 		return nil
-	case queue.ErrQueueItemExists, queue.ErrQueueItemSingletonExists:
+	case errors.Is(err, queue.ErrQueueItemExists) || errors.Is(err, queue.ErrQueueItemSingletonExists):
 		l.Debug("adhoc cron-health-check already exists", "jobID", jobID)
 		return nil
 	default:
@@ -268,11 +269,11 @@ func (c *manager) EnqueueNextHealthCheck(ctx context.Context) error {
 		QueueName: &kind,
 	}, nextCheck, queue.EnqueueOpts{})
 
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		l.Debug("cron-health-check enqueued")
 		return nil
-	case queue.ErrQueueItemExists, queue.ErrQueueItemSingletonExists:
+	case errors.Is(err, queue.ErrQueueItemExists) || errors.Is(err, queue.ErrQueueItemSingletonExists):
 		l.Debug("cron-health-check already exists")
 		return nil
 	default:
@@ -382,10 +383,10 @@ func (c *manager) ScheduleNext(ctx context.Context, ci CronItem) (*CronItem, err
 
 	l = l.With("from", from, "next", next, "JobID", jobID, "enqueueAt", enqueueAt, "jitter", jitter)
 
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		l.Debug("cron ScheduleNext success")
-	case queue.ErrQueueItemExists, queue.ErrQueueItemSingletonExists:
+	case errors.Is(err, queue.ErrQueueItemExists) || errors.Is(err, queue.ErrQueueItemSingletonExists):
 		l.Debug("cron ScheduleNext already exists")
 	default:
 		l.ReportError(err, "error enqueueing cron for next schedule")

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1516,10 +1516,10 @@ func (e *executor) schedule(
 	err = e.queue.Enqueue(ctx, item, at, queue.EnqueueOpts{})
 	queueSpan.End()
 
-	switch err {
-	case nil:
+	switch {
+	case err == nil:
 		// no-op
-	case queue.ErrQueueItemExists:
+	case errors.Is(err, queue.ErrQueueItemExists):
 		// If the item already exists in the queue, we can safely ignore this
 		// entire schedule request; it's basically a retry and we should not
 		// persist this for the user.
@@ -1530,6 +1530,27 @@ func (e *executor) schedule(
 					"has_schedule_idempotency_key": req.IdempotencyKey != nil,
 				},
 			})
+
+			// Determine whether the duplicate item belongs to this same run.
+			// If it does, keep state. Otherwise delete it to avoid leaking state.
+			var existsErr queue.QueueItemExistsError
+			keepState := errors.As(err, &existsErr) && existsErr.RunID != nil && *existsErr.RunID == metadata.ID.RunID
+
+			var ownerRunID string
+			if existsErr.RunID != nil {
+				ownerRunID = existsErr.RunID.String()
+			}
+
+			if !keepState {
+				if deleteErr := e.smv2.Delete(ctx, sv2.IDFromV1(stv1ID)); deleteErr != nil {
+					l.Error("error deleting run state after queue duplicate, this has likely leaked state", deleteErr,
+						"run_id", metadata.ID.RunID.String(),
+						"account_id", req.AccountID.String(),
+						"workspace_id", req.WorkspaceID.String(),
+						"event_internal_id", req.Events[0].GetInternalID().String(),
+					)
+				}
+			}
 
 			var triggeringEventName string
 			if eventName != nil {
@@ -1570,14 +1591,16 @@ func (e *executor) schedule(
 				"run_mode", req.RunMode,
 				"queue_at", at,
 				"scheduled_at", scheduledAt,
+				"queue_duplicate_owner_run_id", ownerRunID,
+				"new_state_deleted", !keepState,
 			)
 		}
 		return &metadata.ID.RunID, nil, state.ErrIdentifierExists
 
-	case queue.ErrQueueItemSingletonExists:
-		err := e.smv2.Delete(ctx, sv2.IDFromV1(stv1ID))
-		if err != nil {
-			l.ReportError(err, "error deleting function state")
+	case errors.Is(err, queue.ErrQueueItemSingletonExists):
+		deleteErr := e.smv2.Delete(ctx, sv2.IDFromV1(stv1ID))
+		if deleteErr != nil {
+			l.ReportError(deleteErr, "error deleting function state, this has likely leaked state")
 		}
 		return nil, nil, ErrFunctionSkipped
 

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -646,7 +646,7 @@ func (s *svc) handleEagerCancelFinishTimeout(ctx context.Context, c cqrs.Cancell
 	item.JobID = &jobID
 	err = qm.Enqueue(ctx, item, requeueAt, queue.EnqueueOpts{})
 	// Ignore if the system job was already requeued.
-	if err != nil && err != queue.ErrQueueItemExists {
+	if err != nil && !errors.Is(err, queue.ErrQueueItemExists) {
 		return err
 	}
 	l.Info("re-enqueued eager cancellation of finish timeout", "requeueAt", requeueAt)
@@ -732,7 +732,7 @@ func (s *svc) handleEagerCancelStartTimeout(ctx context.Context, c cqrs.Cancella
 	item.JobID = &jobID
 	err = qm.Enqueue(ctx, item, requeueAt, queue.EnqueueOpts{})
 	// Ignore if the system job was already requeued.
-	if err != nil && err != queue.ErrQueueItemExists {
+	if err != nil && !errors.Is(err, queue.ErrQueueItemExists) {
 		return err
 	}
 	l.Info("re-enqueued eager cancellation of start timeout", "requeueAt", requeueAt)

--- a/pkg/execution/queue/enqueue.go
+++ b/pkg/execution/queue/enqueue.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -134,7 +135,7 @@ func (q *queueProcessor) Enqueue(ctx context.Context, item Item, at time.Time, o
 			ScheduledAt:  qi.AtMS,
 		},
 	}, promoteAt, EnqueueOpts{})
-	if err != nil && err != ErrQueueItemExists {
+	if err != nil && !errors.Is(err, ErrQueueItemExists) {
 		// This is best effort, and shouldn't fail the OG enqueue.
 		l.ReportError(err, "error scheduling promotion job")
 	}

--- a/pkg/execution/queue/errors.go
+++ b/pkg/execution/queue/errors.go
@@ -3,6 +3,8 @@ package queue
 import (
 	"errors"
 	"fmt"
+
+	"github.com/oklog/ulid/v2"
 )
 
 var ErrQueueItemThrottled = fmt.Errorf("queue item throttled")
@@ -36,6 +38,23 @@ func (k KeyError) Error() string {
 
 func (k KeyError) Unwrap() error {
 	return k.cause
+}
+
+// QueueItemExistsError is a wrapper for ErrQueueItemExists.
+// RunID is the owning run of the existing item, or nil
+// when the duplicate is a post-dequeue tombstone.
+type QueueItemExistsError struct {
+	JobID string
+	RunID *ulid.ULID
+}
+
+func (e QueueItemExistsError) Error() string { return ErrQueueItemExists.Error() }
+func (e QueueItemExistsError) Unwrap() error { return ErrQueueItemExists }
+
+// QueueItemExists returns a QueueItemExistsError. Pass nil runID when the
+// duplicate is a tombstone with no live runID.
+func QueueItemExists(jobID string, runID *ulid.ULID) error {
+	return QueueItemExistsError{JobID: jobID, RunID: runID}
 }
 
 var (

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -288,7 +288,14 @@ func (q *queue) EnqueueItem(ctx context.Context, i osqueue.QueueItem, at time.Ti
 	case 0:
 		return i, nil
 	case 1:
-		return i, osqueue.ErrQueueItemExists
+		var runID *ulid.ULID
+		if existing, loadErr := q.LoadQueueItem(ctx, i.ID); loadErr == nil {
+			id := existing.Data.Identifier.RunID
+			runID = &id
+		} else if loadErr != osqueue.ErrQueueItemNotFound {
+			return i, loadErr
+		}
+		return i, osqueue.QueueItemExists(i.ID, runID)
 	case 2:
 		return i, osqueue.ErrQueueItemSingletonExists
 	default:

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -610,7 +611,13 @@ func TestQueueEnqueueItemIdempotency(t *testing.T) {
 	start := time.Now().Truncate(time.Second)
 
 	t.Run("It enqueues an item only once", func(t *testing.T) {
-		i := osqueue.QueueItem{ID: "once"}
+		runID := ulid.MustNew(ulid.Timestamp(start), rand.Reader)
+		i := osqueue.QueueItem{
+			ID: "once",
+			Data: osqueue.Item{
+				Identifier: state.Identifier{RunID: runID},
+			},
+		}
 
 		item, err := shard.EnqueueItem(ctx, i, start, osqueue.EnqueueOpts{})
 
@@ -620,17 +627,21 @@ func TestQueueEnqueueItemIdempotency(t *testing.T) {
 		found := getQueueItem(t, r, item.ID)
 		require.Equal(t, item, found)
 
-		// Ensure we can't enqueue again.
 		_, err = shard.EnqueueItem(ctx, i, start, osqueue.EnqueueOpts{})
-		require.Equal(t, osqueue.ErrQueueItemExists, err)
+		require.ErrorIs(t, err, osqueue.ErrQueueItemExists)
+		var existsErr osqueue.QueueItemExistsError
+		require.True(t, errors.As(err, &existsErr))
+		require.NotNil(t, existsErr.RunID)
+		require.Equal(t, runID, *existsErr.RunID)
 
-		// Dequeue
 		err = shard.Dequeue(ctx, item)
 		require.NoError(t, err)
 
-		// Ensure we can't enqueue even after dequeue.
 		_, err = shard.EnqueueItem(ctx, i, start, osqueue.EnqueueOpts{})
-		require.Equal(t, osqueue.ErrQueueItemExists, err)
+		require.ErrorIs(t, err, osqueue.ErrQueueItemExists)
+		var tombstoneErr osqueue.QueueItemExistsError
+		require.True(t, errors.As(err, &tombstoneErr))
+		require.Nil(t, tombstoneErr.RunID)
 
 		// Wait for the idempotency TTL to expire
 		r.FastForward(dur)


### PR DESCRIPTION
## Description
Theoretically this codepath shouldn't be reached since idempotency keys
are atomic in Redis but turns out that we have a few thousands
occurrences of this every day. I confirmed that these run states are
leaked, they have no corresponding spans or queue items.

This happens when the same event id is sent after 24H of the first
occurrence which means the idempotency key TTL has expired and we allow
it to create new state but the first run's queue item is still in the
queue and an `ErrQueueItemExists` is returned on `Enqueue`.


<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
