### PR TITLE
internal: run go.yaml jobs on Depot runners

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [depot-ubuntu-22.04-8]
+        os: [depot-ubuntu-22.04-4]
         experimentalKeyQueues: [false, true]
         enableConstraintAPI: [false, true]
         database: [sqlite, postgres]

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Lint
     strategy:
       matrix:
-        os: [depot-ubuntu-22.04-4]
+        os: [depot-ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [depot-ubuntu-22.04-8]
+        os: [depot-ubuntu-22.04]
         experimentalKeyQueues: [false, true]
         enableConstraintAPI: [false, true]
         database: [sqlite, postgres]

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Lint
     strategy:
       matrix:
-        os: [depot-ubuntu-22.04-8]
+        os: [depot-ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
 
   gen:
     name: 'git state after "make gen protobuf"'
-    runs-on: depot-ubuntu-22.04-8
+    runs-on: depot-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Lint
     strategy:
       matrix:
-        os: [depot-ubuntu-22.04]
+        os: [depot-ubuntu-22.04-4]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Lint
     strategy:
       matrix:
-        os: [depot-ubuntu-22.04]
+        os: [depot-ubuntu-22.04-4]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
 
   gen:
     name: 'git state after "make gen protobuf"'
-    runs-on: depot-ubuntu-22.04
+    runs-on: depot-ubuntu-22.04-4
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [depot-ubuntu-22.04]
+        os: [depot-ubuntu-22.04-4]
         experimentalKeyQueues: [false, true]
         enableConstraintAPI: [false, true]
         database: [sqlite, postgres]

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Lint
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [depot-ubuntu-22.04-4]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
 
   gen:
     name: 'git state after "make gen protobuf"'
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [depot-ubuntu-22.04-8]
         experimentalKeyQueues: [false, true]
         enableConstraintAPI: [false, true]
         database: [sqlite, postgres]

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Lint
     strategy:
       matrix:
-        os: [depot-ubuntu-22.04-4]
+        os: [depot-ubuntu-22.04-8]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +38,7 @@ jobs:
 
   gen:
     name: 'git state after "make gen protobuf"'
-    runs-on: depot-ubuntu-22.04-4
+    runs-on: depot-ubuntu-22.04-8
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [depot-ubuntu-22.04-4]
+        os: [depot-ubuntu-22.04-8]
         experimentalKeyQueues: [false, true]
         enableConstraintAPI: [false, true]
         database: [sqlite, postgres]


### PR DESCRIPTION
- Let's test if running certain CPU intensive tests is faster on Depot GHA runners

- test-linux-race -> depot-ubuntu-22.04-8 (the CPU-bound `go test -race` matrix is ~94% test execution and the workflow's critical path; the 8-vCPU runner is where the win is)
- Lint -> depot-ubuntu-22.04-4
- gen -> depot-ubuntu-22.04 (also validates Nix on Depot)



## Description

<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
