### PR TITLE
fix: Don't double count Vercel SDK AI spans (EXE-1837)

### DIFF
--- a/pkg/tracing/metadata/extractors/attributes.go
+++ b/pkg/tracing/metadata/extractors/attributes.go
@@ -3,6 +3,7 @@ package extractors
 import (
 	"cmp"
 	"encoding/json"
+	"regexp"
 	"slices"
 
 	"github.com/inngest/inngest/pkg/util"
@@ -292,7 +293,41 @@ func compareByRank(a, b parsedAttr) int {
 	)
 }
 
+// vercelProviderCallSegment matches the `.do<Op>` segment (e.g. `.doGenerate`,
+// `.doStream`, `.doEmbed`) that the Vercel AI SDK appends to the provider-call
+// (leaf) span's operationId. The framework rollup span lacks this segment.
+//
+// @see https://ai-sdk.dev/docs/ai-sdk-core/telemetry
+var vercelProviderCallSegment = regexp.MustCompile(`\.do[A-Z]`)
+
+// isVercelRollupSpan reports whether the span is a Vercel AI SDK framework
+// rollup (wrapper) span.
+//
+// The Vercel AI SDK emits a span *tree*: a framework rollup span
+// (`ai.generateText`) whose children are the provider-call (leaf) spans
+// (`ai.generateText.doGenerate`). Both carry overlapping usage data, so
+// extracting from both would double count. We choose to skip the rollup span.
+//
+// Only Vercel AI SDK spans carry `ai.operationId`; among them, the
+// provider-call leaf has a `.do*` segment and the rollup does not.
+func isVercelRollupSpan(attributes []*v1.KeyValue) bool {
+	for _, attr := range attributes {
+		if attr.Key != "ai.operationId" {
+			continue
+		}
+		op := attr.Value.GetStringValue()
+		return op != "" && !vercelProviderCallSegment.MatchString(op)
+	}
+	return false
+}
+
 func extractAIMetadataFromAttributes(attributes []*v1.KeyValue, md *AIMetadata) (foundAny bool) {
+	// The Vercel AI SDK's rollup span duplicates its provider-call child's
+	// usage; skip it to avoid double counting.
+	if isVercelRollupSpan(attributes) {
+		return false
+	}
+
 	potentialAttrs := map[string][]parsedAttr{}
 
 	// addAttr records a matched attribute as a candidate for its canonical field.

--- a/pkg/tracing/metadata/extractors/attributes_test.go
+++ b/pkg/tracing/metadata/extractors/attributes_test.go
@@ -116,3 +116,32 @@ func TestLangfusePrecedenceAndUsageExpansion(t *testing.T) {
 		}
 	}
 }
+
+// TestSkipsVercelRollupSpan verifies that the Vercel AI SDK's framework rollup
+// span (e.g. `ai.generateText`) extracts to nothing so its `ai.usage.*` isn't
+// double-counted against its provider-call child (`ai.generateText.doGenerate`),
+// which carries the same usage and the documented `.do*` segment.
+func TestSkipsVercelRollupSpan(t *testing.T) {
+	t.Parallel()
+
+	// The rollup span (no `.do*` segment) is skipped entirely.
+	rollup := []*v1.KeyValue{
+		strAttr("ai.operationId", "ai.generateText"),
+		strAttr("ai.model.id", "gpt-4.1-nano"),
+		intAttr("ai.usage.inputTokens", 17),
+	}
+	var rollupMd AIMetadata
+	assert.False(t, extractAIMetadataFromAttributes(rollup, &rollupMd))
+	assert.Equal(t, AIMetadata{}, rollupMd)
+
+	// The provider-call (leaf) span is still extracted normally.
+	leaf := []*v1.KeyValue{
+		strAttr("ai.operationId", "ai.generateText.doGenerate"),
+		strAttr("ai.model.id", "gpt-4.1-nano"),
+		intAttr("ai.usage.inputTokens", 17),
+	}
+	var leafMd AIMetadata
+	assert.True(t, extractAIMetadataFromAttributes(leaf, &leafMd))
+	assert.Equal(t, "gpt-4.1-nano", leafMd.Model)
+	assert.Equal(t, int64(17), leafMd.InputTokens)
+}

--- a/pkg/tracing/metadata/extractors/testdata/openai_vercel_aisdk/basic_responses.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_vercel_aisdk/basic_responses.otlp.json.out
@@ -14,16 +14,4 @@ SPAN ai.generateText.doGenerate
 }
 
 SPAN ai.generateText
-{
-  "model": "gpt-5.4-nano",
-  "system": "openai.responses",
-  "operation_name": "",
-  "response_model": "",
-  "response_id": "",
-  "finish_reasons": [
-    "stop"
-  ],
-  "input_tokens": 17,
-  "output_tokens": 40,
-  "total_tokens": 57
-}
+no AI metadata extracted

--- a/pkg/tracing/metadata/extractors/testdata/openai_vercel_aisdk/embeddings.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_vercel_aisdk/embeddings.otlp.json.out
@@ -12,14 +12,4 @@ SPAN ai.embed.doEmbed
 }
 
 SPAN ai.embed
-{
-  "model": "text-embedding-3-small",
-  "system": "openai.embedding",
-  "operation_name": "",
-  "response_model": "",
-  "response_id": "",
-  "finish_reasons": null,
-  "input_tokens": 10,
-  "output_tokens": 0,
-  "total_tokens": 10
-}
+no AI metadata extracted

--- a/pkg/tracing/metadata/extractors/testdata/openai_vercel_aisdk/params_chat.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_vercel_aisdk/params_chat.otlp.json.out
@@ -14,16 +14,4 @@ SPAN ai.generateText.doGenerate
 }
 
 SPAN ai.generateText
-{
-  "model": "gpt-4.1-nano",
-  "system": "openai.chat",
-  "operation_name": "",
-  "response_model": "",
-  "response_id": "",
-  "finish_reasons": [
-    "stop"
-  ],
-  "input_tokens": 22,
-  "output_tokens": 6,
-  "total_tokens": 28
-}
+no AI metadata extracted

--- a/pkg/tracing/metadata/extractors/testdata/openai_vercel_aisdk/reasoning_responses.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_vercel_aisdk/reasoning_responses.otlp.json.out
@@ -14,16 +14,4 @@ SPAN ai.generateText.doGenerate
 }
 
 SPAN ai.generateText
-{
-  "model": "gpt-5.4-nano",
-  "system": "openai.responses",
-  "operation_name": "",
-  "response_model": "",
-  "response_id": "",
-  "finish_reasons": [
-    "stop"
-  ],
-  "input_tokens": 42,
-  "output_tokens": 195,
-  "total_tokens": 237
-}
+no AI metadata extracted

--- a/pkg/tracing/metadata/extractors/testdata/openai_vercel_aisdk/stream_chat.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_vercel_aisdk/stream_chat.otlp.json.out
@@ -14,16 +14,4 @@ SPAN ai.streamText.doStream
 }
 
 SPAN ai.streamText
-{
-  "model": "gpt-4.1-nano",
-  "system": "openai.chat",
-  "operation_name": "",
-  "response_model": "",
-  "response_id": "",
-  "finish_reasons": [
-    "stop"
-  ],
-  "input_tokens": 11,
-  "output_tokens": 10,
-  "total_tokens": 21
-}
+no AI metadata extracted

--- a/pkg/tracing/metadata/extractors/testdata/openai_vercel_aisdk/tools_chat.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_vercel_aisdk/tools_chat.otlp.json.out
@@ -14,16 +14,4 @@ SPAN ai.generateText.doGenerate
 }
 
 SPAN ai.generateText
-{
-  "model": "gpt-4.1-nano",
-  "system": "openai.chat",
-  "operation_name": "",
-  "response_model": "",
-  "response_id": "",
-  "finish_reasons": [
-    "tool-calls"
-  ],
-  "input_tokens": 56,
-  "output_tokens": 14,
-  "total_tokens": 70
-}
+no AI metadata extracted


### PR DESCRIPTION
## Description

- The Vercel SDK AI emits multiple spans per LLM call
- The parent is a roll up that has aggregated data about the LLM call(s)
- We perform our own aggregation, so parsing both leads to double counting. Let's ignore the roll up span until we want to extract data only found there and not in the children.
- This mirrors https://github.com/inngest/inngest-js/pull/1571

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
