### PR TITLE
feat: session server parse + emit

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -123,6 +123,18 @@ const (
 	// MaxEvents is the maximum number of events we can parse in a single batch.
 	MaxEvents = 5_000
 
+	// MaxEventSessions is the maximum number of sessions on a single event.
+	MaxEventSessions = 5
+	// MaxRunSessions is the maximum number of sessions on a single run. A run
+	// aggregates the sessions of every event that triggered it (eg. when
+	// batching), so its bound is larger than MaxEventSessions. It keeps the
+	// run's session label a small fraction of the span metadata budget.
+	MaxRunSessions = 25
+	// MaxEventSessionKeyLength is the maximum number of bytes in a session key.
+	MaxEventSessionKeyLength = 128
+	// MaxEventSessionIDLength is the maximum number of bytes in a session ID.
+	MaxEventSessionIDLength = 512
+
 	InngestEventDataPrefix = "_inngest"
 	// InvokeSlugKey is the data key used to store the fn name when invoking a function
 	// via an RPC-like call, abstracting event-driven fanout.

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -64,8 +62,8 @@ type Event struct {
 	Timestamp int64  `json:"ts,omitempty"`
 	Version   string `json:"v,omitempty"`
 
-	// Sessions groups runs triggered by this event.
-	Sessions Sessions `json:"sessions,omitempty"`
+	// Meta carries event meta shared across runs triggered by this event.
+	Meta EventMeta `json:"meta,omitempty,omitzero"`
 
 	// User represents user-specific information for the event.
 	//
@@ -75,60 +73,6 @@ type Event struct {
 	// size represents the size of the event in bytes, set during
 	// the UnmarshalJSON call.
 	size int
-}
-
-// Sessions maps a session key to a session ID.
-type Sessions map[string]string
-
-func (s *Sessions) UnmarshalJSON(data []byte) error {
-	if string(data) == "null" {
-		*s = nil
-		return nil
-	}
-
-	raw := map[string]any{}
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-
-	out := Sessions{}
-	for name, value := range raw {
-		switch v := value.(type) {
-		case string:
-			out[name] = v
-		case float64:
-			out[name] = strconv.FormatFloat(v, 'f', -1, 64)
-		default:
-			// Booleans are intentionally rejected: a boolean is only ever two
-			// values, i.e. a low-cardinality label, not a session ID.
-			return fmt.Errorf("event session %q must be a string or number", name)
-		}
-	}
-
-	*s = out
-	return nil
-}
-
-// Validate checks session keys and IDs against size limits.
-func (s Sessions) Validate() error {
-	if len(s) > consts.MaxEventSessions {
-		return fmt.Errorf("event sessions can include at most %d entries", consts.MaxEventSessions)
-	}
-	for name, id := range s {
-		if name == "" {
-			return errors.New("event session keys cannot be empty")
-		}
-		if len(name) > consts.MaxEventSessionKeyLength {
-			return fmt.Errorf("event session key %q exceeds %d bytes", name, consts.MaxEventSessionKeyLength)
-		}
-		if id == "" {
-			return fmt.Errorf("event session %q cannot have an empty ID", name)
-		}
-		if len(id) > consts.MaxEventSessionIDLength {
-			return fmt.Errorf("event session %q exceeds %d bytes", name, consts.MaxEventSessionIDLength)
-		}
-	}
-	return nil
 }
 
 func (e *Event) UnmarshalJSON(data []byte) error {
@@ -184,8 +128,10 @@ func (e Event) Map() map[string]any {
 	if e.Version != "" {
 		data["v"] = e.Version
 	}
-	if len(e.Sessions) > 0 {
-		data["sessions"] = e.Sessions
+	if len(e.Meta.Sessions) > 0 {
+		data["meta"] = map[string]any{
+			"sessions": e.Meta.Sessions,
+		}
 	}
 
 	return data
@@ -207,7 +153,7 @@ func (e Event) Validate(ctx context.Context) error {
 		}
 	}
 
-	if err := e.Sessions.Validate(); err != nil {
+	if err := e.Meta.Sessions.Validate(); err != nil {
 		return err
 	}
 

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -62,6 +64,9 @@ type Event struct {
 	Timestamp int64  `json:"ts,omitempty"`
 	Version   string `json:"v,omitempty"`
 
+	// Sessions groups runs triggered by this event.
+	Sessions Sessions `json:"sessions,omitempty"`
+
 	// User represents user-specific information for the event.
 	//
 	// Deprecated:  this will be removed in favour of storing everything within data.
@@ -70,6 +75,60 @@ type Event struct {
 	// size represents the size of the event in bytes, set during
 	// the UnmarshalJSON call.
 	size int
+}
+
+// Sessions maps a session key to a session ID.
+type Sessions map[string]string
+
+func (s *Sessions) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*s = nil
+		return nil
+	}
+
+	raw := map[string]any{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	out := Sessions{}
+	for name, value := range raw {
+		switch v := value.(type) {
+		case string:
+			out[name] = v
+		case float64:
+			out[name] = strconv.FormatFloat(v, 'f', -1, 64)
+		default:
+			// Booleans are intentionally rejected: a boolean is only ever two
+			// values, i.e. a low-cardinality label, not a session ID.
+			return fmt.Errorf("event session %q must be a string or number", name)
+		}
+	}
+
+	*s = out
+	return nil
+}
+
+// Validate checks session keys and IDs against size limits.
+func (s Sessions) Validate() error {
+	if len(s) > consts.MaxEventSessions {
+		return fmt.Errorf("event sessions can include at most %d entries", consts.MaxEventSessions)
+	}
+	for name, id := range s {
+		if name == "" {
+			return errors.New("event session keys cannot be empty")
+		}
+		if len(name) > consts.MaxEventSessionKeyLength {
+			return fmt.Errorf("event session key %q exceeds %d bytes", name, consts.MaxEventSessionKeyLength)
+		}
+		if id == "" {
+			return fmt.Errorf("event session %q cannot have an empty ID", name)
+		}
+		if len(id) > consts.MaxEventSessionIDLength {
+			return fmt.Errorf("event session %q exceeds %d bytes", name, consts.MaxEventSessionIDLength)
+		}
+	}
+	return nil
 }
 
 func (e *Event) UnmarshalJSON(data []byte) error {
@@ -125,6 +184,9 @@ func (e Event) Map() map[string]any {
 	if e.Version != "" {
 		data["v"] = e.Version
 	}
+	if len(e.Sessions) > 0 {
+		data["sessions"] = e.Sessions
+	}
 
 	return data
 }
@@ -143,6 +205,10 @@ func (e Event) Validate(ctx context.Context) error {
 		if t.After(endTimestamp) {
 			return errors.New("timestamp is after Jan 1, 2100")
 		}
+	}
+
+	if err := e.Sessions.Validate(); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -11,7 +11,7 @@ func TestUnmarshalJSON(t *testing.T) {
 	t.Run("sets all fields", func(t *testing.T) {
 		r := require.New(t)
 
-		input := `{"id":"evt-1","name":"test/event","data":{"key":"val"},"ts":1700000000000,"v":"2024-01-01","sessions":{"conversation_id":"conversation_1234","priority":1},"user":{"email":"a@b.com"}}`
+		input := `{"id":"evt-1","name":"test/event","data":{"key":"val"},"ts":1700000000000,"v":"2024-01-01","meta":{"sessions":{"conversation_id":"conversation_1234","priority":1}},"user":{"email":"a@b.com"}}`
 
 		var evt Event
 		err := json.Unmarshal([]byte(input), &evt)
@@ -22,8 +22,18 @@ func TestUnmarshalJSON(t *testing.T) {
 		r.Equal(map[string]any{"key": "val"}, evt.Data)
 		r.Equal(int64(1700000000000), evt.Timestamp)
 		r.Equal("2024-01-01", evt.Version)
-		r.Equal(Sessions{"conversation_id": "conversation_1234", "priority": "1"}, evt.Sessions)
+		r.Equal(Sessions{"conversation_id": "conversation_1234", "priority": "1"}, evt.Meta.Sessions)
 		r.Equal(map[string]any{"email": "a@b.com"}, evt.User)
+	})
+
+	t.Run("ignores top-level sessions", func(t *testing.T) {
+		r := require.New(t)
+
+		var evt Event
+		err := json.Unmarshal([]byte(`{"name":"test/event","data":{},"sessions":{"conversation_id":"conversation_1234"}}`), &evt)
+		r.NoError(err)
+
+		r.Empty(evt.Meta.Sessions)
 	})
 
 	t.Run("sets size to byte length of input", func(t *testing.T) {
@@ -50,7 +60,7 @@ func TestUnmarshalJSON(t *testing.T) {
 		r := require.New(t)
 
 		var evt Event
-		err := json.Unmarshal([]byte(`{"name":"test/event","data":{},"sessions":{"conversation_id":null}}`), &evt)
+		err := json.Unmarshal([]byte(`{"name":"test/event","data":{},"meta":{"sessions":{"conversation_id":null}}}`), &evt)
 		r.EqualError(err, `event session "conversation_id" must be a string or number`)
 	})
 
@@ -58,8 +68,17 @@ func TestUnmarshalJSON(t *testing.T) {
 		r := require.New(t)
 
 		var evt Event
-		err := json.Unmarshal([]byte(`{"name":"test/event","data":{},"sessions":{"active":true}}`), &evt)
+		err := json.Unmarshal([]byte(`{"name":"test/event","data":{},"meta":{"sessions":{"active":true}}}`), &evt)
 		r.EqualError(err, `event session "active" must be a string or number`)
+	})
+
+	t.Run("omits empty meta when marshalled", func(t *testing.T) {
+		r := require.New(t)
+
+		byt, err := json.Marshal(Event{Name: "test/event", Data: map[string]any{}})
+		r.NoError(err)
+
+		r.NotContains(string(byt), `"meta"`)
 	})
 
 	t.Run("Size falls back to marshal when not unmarshalled", func(t *testing.T) {
@@ -79,8 +98,10 @@ func TestUnmarshalJSON(t *testing.T) {
 func TestEventValidateSessions(t *testing.T) {
 	t.Run("allows valid sessions", func(t *testing.T) {
 		evt := Event{
-			Name:     "test/event",
-			Sessions: Sessions{"conversation_id": "conversation_1234"},
+			Name: "test/event",
+			Meta: EventMeta{
+				Sessions: Sessions{"conversation_id": "conversation_1234"},
+			},
 		}
 
 		require.NoError(t, evt.Validate(t.Context()))
@@ -89,13 +110,15 @@ func TestEventValidateSessions(t *testing.T) {
 	t.Run("rejects too many sessions", func(t *testing.T) {
 		evt := Event{
 			Name: "test/event",
-			Sessions: Sessions{
-				"a": "1",
-				"b": "2",
-				"c": "3",
-				"d": "4",
-				"e": "5",
-				"f": "6",
+			Meta: EventMeta{
+				Sessions: Sessions{
+					"a": "1",
+					"b": "2",
+					"c": "3",
+					"d": "4",
+					"e": "5",
+					"f": "6",
+				},
 			},
 		}
 
@@ -104,8 +127,10 @@ func TestEventValidateSessions(t *testing.T) {
 
 	t.Run("rejects empty session key", func(t *testing.T) {
 		evt := Event{
-			Name:     "test/event",
-			Sessions: Sessions{"": "conversation_1234"},
+			Name: "test/event",
+			Meta: EventMeta{
+				Sessions: Sessions{"": "conversation_1234"},
+			},
 		}
 
 		require.EqualError(t, evt.Validate(t.Context()), "event session keys cannot be empty")

--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -11,7 +11,7 @@ func TestUnmarshalJSON(t *testing.T) {
 	t.Run("sets all fields", func(t *testing.T) {
 		r := require.New(t)
 
-		input := `{"id":"evt-1","name":"test/event","data":{"key":"val"},"ts":1700000000000,"v":"2024-01-01","user":{"email":"a@b.com"}}`
+		input := `{"id":"evt-1","name":"test/event","data":{"key":"val"},"ts":1700000000000,"v":"2024-01-01","sessions":{"conversation_id":"conversation_1234","priority":1},"user":{"email":"a@b.com"}}`
 
 		var evt Event
 		err := json.Unmarshal([]byte(input), &evt)
@@ -22,6 +22,7 @@ func TestUnmarshalJSON(t *testing.T) {
 		r.Equal(map[string]any{"key": "val"}, evt.Data)
 		r.Equal(int64(1700000000000), evt.Timestamp)
 		r.Equal("2024-01-01", evt.Version)
+		r.Equal(Sessions{"conversation_id": "conversation_1234", "priority": "1"}, evt.Sessions)
 		r.Equal(map[string]any{"email": "a@b.com"}, evt.User)
 	})
 
@@ -45,6 +46,22 @@ func TestUnmarshalJSON(t *testing.T) {
 		r.Error(err)
 	})
 
+	t.Run("invalid session value type returns error", func(t *testing.T) {
+		r := require.New(t)
+
+		var evt Event
+		err := json.Unmarshal([]byte(`{"name":"test/event","data":{},"sessions":{"conversation_id":null}}`), &evt)
+		r.EqualError(err, `event session "conversation_id" must be a string or number`)
+	})
+
+	t.Run("boolean session value returns error", func(t *testing.T) {
+		r := require.New(t)
+
+		var evt Event
+		err := json.Unmarshal([]byte(`{"name":"test/event","data":{},"sessions":{"active":true}}`), &evt)
+		r.EqualError(err, `event session "active" must be a string or number`)
+	})
+
 	t.Run("Size falls back to marshal when not unmarshalled", func(t *testing.T) {
 		r := require.New(t)
 
@@ -56,5 +73,41 @@ func TestUnmarshalJSON(t *testing.T) {
 		byt, err := json.Marshal(evt)
 		r.NoError(err)
 		r.Equal(len(byt), evt.Size())
+	})
+}
+
+func TestEventValidateSessions(t *testing.T) {
+	t.Run("allows valid sessions", func(t *testing.T) {
+		evt := Event{
+			Name:     "test/event",
+			Sessions: Sessions{"conversation_id": "conversation_1234"},
+		}
+
+		require.NoError(t, evt.Validate(t.Context()))
+	})
+
+	t.Run("rejects too many sessions", func(t *testing.T) {
+		evt := Event{
+			Name: "test/event",
+			Sessions: Sessions{
+				"a": "1",
+				"b": "2",
+				"c": "3",
+				"d": "4",
+				"e": "5",
+				"f": "6",
+			},
+		}
+
+		require.EqualError(t, evt.Validate(t.Context()), "event sessions can include at most 5 entries")
+	})
+
+	t.Run("rejects empty session key", func(t *testing.T) {
+		evt := Event{
+			Name:     "test/event",
+			Sessions: Sessions{"": "conversation_1234"},
+		}
+
+		require.EqualError(t, evt.Validate(t.Context()), "event session keys cannot be empty")
 	})
 }

--- a/pkg/event/sessions.go
+++ b/pkg/event/sessions.go
@@ -1,0 +1,74 @@
+package event
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/inngest/inngest/pkg/consts"
+)
+
+// EventMeta carries event meta shared across runs triggered by this event.
+type EventMeta struct {
+	// Sessions groups runs triggered by this event.
+	Sessions Sessions `json:"sessions,omitempty"`
+}
+
+func (m EventMeta) IsZero() bool {
+	return len(m.Sessions) == 0
+}
+
+// Sessions maps a session key to a session ID.
+type Sessions map[string]string
+
+func (s *Sessions) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*s = nil
+		return nil
+	}
+
+	raw := map[string]any{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	out := Sessions{}
+	for name, value := range raw {
+		switch v := value.(type) {
+		case string:
+			out[name] = v
+		case float64:
+			out[name] = strconv.FormatFloat(v, 'f', -1, 64)
+		default:
+			// Booleans are intentionally rejected: a boolean is only ever two
+			// values, i.e. a low-cardinality label, not a session ID.
+			return fmt.Errorf("event session %q must be a string or number", name)
+		}
+	}
+
+	*s = out
+	return nil
+}
+
+// Validate checks session keys and IDs against size limits.
+func (s Sessions) Validate() error {
+	if len(s) > consts.MaxEventSessions {
+		return fmt.Errorf("event sessions can include at most %d entries", consts.MaxEventSessions)
+	}
+	for name, id := range s {
+		if name == "" {
+			return errors.New("event session keys cannot be empty")
+		}
+		if len(name) > consts.MaxEventSessionKeyLength {
+			return fmt.Errorf("event session key %q exceeds %d bytes", name, consts.MaxEventSessionKeyLength)
+		}
+		if id == "" {
+			return fmt.Errorf("event session %q cannot have an empty ID", name)
+		}
+		if len(id) > consts.MaxEventSessionIDLength {
+			return fmt.Errorf("event session %q exceeds %d bytes", name, consts.MaxEventSessionIDLength)
+		}
+	}
+	return nil
+}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/rand"
 	"encoding/json"
@@ -1023,11 +1024,16 @@ func (e *executor) schedule(
 	var eventName *string
 
 	evts := make([]json.RawMessage, len(req.Events))
+	sessions := meta.EventSessions{}
 	for n, item := range req.Events {
 		evt := item.GetEvent()
 		if eventName == nil {
 			name := evt.Name
 			eventName = &name
+		}
+
+		for name, id := range evt.Sessions {
+			sessions = append(sessions, meta.EventSession{Key: name, ID: id})
 		}
 
 		// serialize this data to the span at the same time
@@ -1036,6 +1042,17 @@ func (e *executor) schedule(
 			return nil, nil, fmt.Errorf("error marshalling event: %w", err)
 		}
 		evts[n] = byt
+	}
+
+	var droppedSessions int
+	sessions, droppedSessions = normalizeRunSessions(sessions)
+	if droppedSessions > 0 {
+		logger.StdlibLogger(ctx).Warn(
+			"dropping sessions over per-run limit",
+			"dropped", droppedSessions,
+			"limit", consts.MaxRunSessions,
+			"function_id", req.Function.ID,
+		)
 	}
 
 	// Evaluate the run priority based off of the input event data.
@@ -1358,6 +1375,9 @@ func (e *executor) schedule(
 			meta.Attr(meta.Attrs.FunctionSlug, &functionSlug),
 		),
 		Seed: []byte(metadata.ID.RunID[:]),
+	}
+	if len(sessions) > 0 {
+		meta.AddAttr(runSpanOpts.Attributes, meta.Attrs.Sessions, &sessions)
 	}
 	if req.RunMode == enums.RunModeSync {
 		// XXX: If this is a sync run, always add the start time to the span. We do this
@@ -6077,4 +6097,30 @@ func updateDeferSpans(
 			&parentFnSlug,
 		)
 	}
+}
+
+// normalizeRunSessions dedupes, sorts, and caps the session pairs collected
+// from a run's triggering events. Sorting makes the run's session label
+// deterministic across retries, since map and batch iteration order are not.
+// Returns the number of pairs dropped by the cap.
+func normalizeRunSessions(pairs meta.EventSessions) (meta.EventSessions, int) {
+	if len(pairs) == 0 {
+		return nil, 0
+	}
+
+	slices.SortFunc(pairs, func(a, b meta.EventSession) int {
+		if c := cmp.Compare(a.Key, b.Key); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.ID, b.ID)
+	})
+	pairs = slices.Compact(pairs)
+
+	dropped := 0
+	if len(pairs) > consts.MaxRunSessions {
+		dropped = len(pairs) - consts.MaxRunSessions
+		pairs = pairs[:consts.MaxRunSessions]
+	}
+
+	return pairs, dropped
 }

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1032,7 +1032,7 @@ func (e *executor) schedule(
 			eventName = &name
 		}
 
-		for name, id := range evt.Sessions {
+		for name, id := range evt.Meta.Sessions {
 			sessions = append(sessions, meta.EventSession{Key: name, ID: id})
 		}
 

--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -457,12 +457,15 @@ func (e *executor) finalizeEvents(ctx context.Context, opts execution.FinalizeOp
 			"status": opts.Status(),
 		}
 
-		// Add an `inngest/function.finished` event.
+		// Add an `inngest/function.finished` event.  Lifecycle events carry
+		// the sessions of the event they report on, so that runs triggered by
+		// them (eg. onFailure handlers) stay in the same sessions.
 		freshEvents = append(freshEvents, event.Event{
 			ID:        ulid.MustNew(uint64(now.UnixMilli()), rand.Reader).String(),
 			Name:      event.FnFinishedName,
 			Timestamp: now.UnixMilli(),
 			Data:      data,
+			Sessions:  runEvt.Sessions,
 		})
 
 		switch opts.Status() {
@@ -472,6 +475,7 @@ func (e *executor) finalizeEvents(ctx context.Context, opts execution.FinalizeOp
 				Name:      event.FnCancelledName,
 				Timestamp: now.UnixMilli(),
 				Data:      data,
+				Sessions:  runEvt.Sessions,
 			})
 		case enums.StepStatusFailed:
 			// Legacy - send inngest/function.failed, except for when the function has been cancelled.
@@ -480,6 +484,7 @@ func (e *executor) finalizeEvents(ctx context.Context, opts execution.FinalizeOp
 				Name:      event.FnFailedName,
 				Timestamp: now.UnixMilli(),
 				Data:      data,
+				Sessions:  runEvt.Sessions,
 			})
 		}
 	}

--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -465,7 +465,7 @@ func (e *executor) finalizeEvents(ctx context.Context, opts execution.FinalizeOp
 			Name:      event.FnFinishedName,
 			Timestamp: now.UnixMilli(),
 			Data:      data,
-			Sessions:  runEvt.Sessions,
+			Meta:      runEvt.Meta,
 		})
 
 		switch opts.Status() {
@@ -475,7 +475,7 @@ func (e *executor) finalizeEvents(ctx context.Context, opts execution.FinalizeOp
 				Name:      event.FnCancelledName,
 				Timestamp: now.UnixMilli(),
 				Data:      data,
-				Sessions:  runEvt.Sessions,
+				Meta:      runEvt.Meta,
 			})
 		case enums.StepStatusFailed:
 			// Legacy - send inngest/function.failed, except for when the function has been cancelled.
@@ -484,7 +484,7 @@ func (e *executor) finalizeEvents(ctx context.Context, opts execution.FinalizeOp
 				Name:      event.FnFailedName,
 				Timestamp: now.UnixMilli(),
 				Data:      data,
-				Sessions:  runEvt.Sessions,
+				Meta:      runEvt.Meta,
 			})
 		}
 	}

--- a/pkg/execution/executor/run_sessions_test.go
+++ b/pkg/execution/executor/run_sessions_test.go
@@ -1,0 +1,68 @@
+package executor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeRunSessions(t *testing.T) {
+	t.Run("returns nil for no pairs", func(t *testing.T) {
+		sessions, dropped := normalizeRunSessions(meta.EventSessions{})
+		require.Nil(t, sessions)
+		require.Zero(t, dropped)
+	})
+
+	t.Run("dedupes identical pairs across events", func(t *testing.T) {
+		sessions, dropped := normalizeRunSessions(meta.EventSessions{
+			{Key: "conversation_id", ID: "conv_a"},
+			{Key: "conversation_id", ID: "conv_a"},
+		})
+		require.Equal(t, meta.EventSessions{
+			{Key: "conversation_id", ID: "conv_a"},
+		}, sessions)
+		require.Zero(t, dropped)
+	})
+
+	t.Run("keeps two IDs under the same key", func(t *testing.T) {
+		sessions, dropped := normalizeRunSessions(meta.EventSessions{
+			{Key: "conversation_id", ID: "conv_b"},
+			{Key: "conversation_id", ID: "conv_a"},
+		})
+		require.Equal(t, meta.EventSessions{
+			{Key: "conversation_id", ID: "conv_a"},
+			{Key: "conversation_id", ID: "conv_b"},
+		}, sessions)
+		require.Zero(t, dropped)
+	})
+
+	t.Run("sorts deterministically by key then ID", func(t *testing.T) {
+		sessions, _ := normalizeRunSessions(meta.EventSessions{
+			{Key: "tenant", ID: "t_1"},
+			{Key: "conversation_id", ID: "conv_a"},
+			{Key: "workflow_id", ID: "wf_1"},
+		})
+		require.Equal(t, meta.EventSessions{
+			{Key: "conversation_id", ID: "conv_a"},
+			{Key: "tenant", ID: "t_1"},
+			{Key: "workflow_id", ID: "wf_1"},
+		}, sessions)
+	})
+
+	t.Run("caps at the per-run limit and reports dropped", func(t *testing.T) {
+		pairs := meta.EventSessions{}
+		for i := 0; i < consts.MaxRunSessions+3; i++ {
+			pairs = append(pairs, meta.EventSession{
+				Key: "conversation_id",
+				ID:  fmt.Sprintf("conv_%03d", i),
+			})
+		}
+
+		sessions, dropped := normalizeRunSessions(pairs)
+		require.Len(t, sessions, consts.MaxRunSessions)
+		require.Equal(t, 3, dropped)
+	})
+}

--- a/pkg/execution/state/opcode.go
+++ b/pkg/execution/state/opcode.go
@@ -349,13 +349,22 @@ func (g GeneratorOpcode) InvokeFunctionOpts() (*InvokeFunctionOpts, error) {
 	if err := opts.UnmarshalAny(g.Opts); err != nil {
 		return nil, err
 	}
-	return opts, nil
+	return opts, opts.Validate()
 }
 
 type InvokeFunctionOpts struct {
 	FunctionID string       `json:"function_id"`
 	Payload    *event.Event `json:"payload,omitempty"`
 	Timeout    string       `json:"timeout"`
+}
+
+func (i *InvokeFunctionOpts) Validate() error {
+	if i.Payload == nil {
+		return nil
+	}
+	// Mirrors the session checks in Event.Validate() at API ingest; invocation
+	// events are constructed by the executor and never pass through the API.
+	return i.Payload.Sessions.Validate()
 }
 
 func (i *InvokeFunctionOpts) UnmarshalAny(a any) error {

--- a/pkg/execution/state/opcode.go
+++ b/pkg/execution/state/opcode.go
@@ -364,7 +364,7 @@ func (i *InvokeFunctionOpts) Validate() error {
 	}
 	// Mirrors the session checks in Event.Validate() at API ingest; invocation
 	// events are constructed by the executor and never pass through the API.
-	return i.Payload.Sessions.Validate()
+	return i.Payload.Meta.Sessions.Validate()
 }
 
 func (i *InvokeFunctionOpts) UnmarshalAny(a any) error {

--- a/pkg/execution/state/opcode_test.go
+++ b/pkg/execution/state/opcode_test.go
@@ -157,7 +157,9 @@ func TestInvokeFunctionOpts_Validate(t *testing.T) {
 	t.Run("accepts valid payload sessions", func(t *testing.T) {
 		opts := InvokeFunctionOpts{
 			Payload: &event.Event{
-				Sessions: event.Sessions{"conversation_id": "conversation_1234"},
+				Meta: event.EventMeta{
+					Sessions: event.Sessions{"conversation_id": "conversation_1234"},
+				},
 			},
 		}
 		require.NoError(t, opts.Validate())
@@ -166,7 +168,9 @@ func TestInvokeFunctionOpts_Validate(t *testing.T) {
 	t.Run("rejects too many payload sessions", func(t *testing.T) {
 		opts := InvokeFunctionOpts{
 			Payload: &event.Event{
-				Sessions: event.Sessions{"a": "1", "b": "2", "c": "3", "d": "4", "e": "5", "f": "6"},
+				Meta: event.EventMeta{
+					Sessions: event.Sessions{"a": "1", "b": "2", "c": "3", "d": "4", "e": "5", "f": "6"},
+				},
 			},
 		}
 		require.EqualError(t, opts.Validate(), "event sessions can include at most 5 entries")

--- a/pkg/execution/state/opcode_test.go
+++ b/pkg/execution/state/opcode_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/event"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -144,6 +145,31 @@ func TestInvokeFunctionOpts_Expires(t *testing.T) {
 		got, err := opts.Expires()
 		require.NoError(t, err)
 		assert.WithinDuration(t, now.AddDate(1, 0, 0), got, time.Second)
+	})
+}
+
+func TestInvokeFunctionOpts_Validate(t *testing.T) {
+	t.Run("accepts nil payload", func(t *testing.T) {
+		opts := InvokeFunctionOpts{}
+		require.NoError(t, opts.Validate())
+	})
+
+	t.Run("accepts valid payload sessions", func(t *testing.T) {
+		opts := InvokeFunctionOpts{
+			Payload: &event.Event{
+				Sessions: event.Sessions{"conversation_id": "conversation_1234"},
+			},
+		}
+		require.NoError(t, opts.Validate())
+	})
+
+	t.Run("rejects too many payload sessions", func(t *testing.T) {
+		opts := InvokeFunctionOpts{
+			Payload: &event.Event{
+				Sessions: event.Sessions{"a": "1", "b": "2", "c": "3", "d": "4", "e": "5", "f": "6"},
+			},
+		}
+		require.EqualError(t, opts.Validate(), "event sessions can include at most 5 entries")
 	})
 }
 

--- a/pkg/tracing/meta/attributes.go
+++ b/pkg/tracing/meta/attributes.go
@@ -29,6 +29,7 @@ var Attrs = struct {
 	EnvID               attr[*uuid.UUID]
 	EventIDs            attr[*[]string]
 	EventsInput         attr[*string]
+	Sessions            attr[*EventSessions]
 	TriggeringEventName attr[*string]
 	FunctionID          attr[*uuid.UUID]
 	FunctionName        attr[*string]
@@ -197,6 +198,7 @@ var Attrs = struct {
 	EnvID:                              UUIDAttr("env.id"),
 	EventIDs:                           StringSliceAttr("event.ids"),
 	EventsInput:                        StringAttr("events.input"),
+	Sessions:                           JsonAttr[EventSessions]("event.sessions"),
 	TriggeringEventName:                StringAttr("event.trigger.name"),
 	FunctionID:                         UUIDAttr("function.id"),
 	FunctionName:                       StringAttr("function.name"),
@@ -270,6 +272,19 @@ var Attrs = struct {
 	MetadataOp:    TextAttr[enums.MetadataOpcode]("metadata.op"),
 	MetadataScope: TextAttr[enums.MetadataScope]("metadata.scope"),
 }
+
+// EventSession is a single session membership pair on a run. The run-level
+// label is a list of pairs rather than a map so that a run triggered by
+// multiple events (eg. a batch) can belong to several sessions sharing the
+// same key.
+type EventSession struct {
+	Key string `json:"key"`
+	ID  string `json:"id"`
+}
+
+// EventSessions is the run-level form of event.Sessions, which cannot be
+// imported here because pkg/event depends on this package.
+type EventSessions []EventSession
 
 type ResponseOps []ResponseOp
 

--- a/pkg/tracing/meta/attributes.go
+++ b/pkg/tracing/meta/attributes.go
@@ -282,7 +282,7 @@ type EventSession struct {
 	ID  string `json:"id"`
 }
 
-// EventSessions is the run-level form of event.Sessions, which cannot be
+// EventSessions is the run-level form of event.EventMeta.Sessions, which cannot be
 // imported here because pkg/event depends on this package.
 type EventSessions []EventSession
 

--- a/pkg/tracing/meta/extracted_values_gen.go
+++ b/pkg/tracing/meta/extracted_values_gen.go
@@ -30,6 +30,7 @@ type ExtractedValues struct {
 	EnvID *uuid.UUID
 	EventIDs *[]string
 	EventsInput *string
+	Sessions *EventSessions
 	TriggeringEventName *string
 	FunctionID *uuid.UUID
 	FunctionName *string


### PR DESCRIPTION
## Description

server-side sessions: parse `sessions` off event payloads and emit the run's sessions on the root span attr so related runs can be grouped

the read path is in the cloud pr, the send surface is the sdk pr (inngest/inngest-js#1547), and the dashboard ui is #4403. doesn't add anything to the ingest path, it's a span attr insights already captures


- a run's sessions = the union of its triggering events' sessions (batched runs union all of them). kept as `(key, id)` pairs, not a map, so a run can be in multiple sessions under the same key
- `normalizeRunSessions` sorts (deterministic across retries) + dedupes + caps. over the cap we drop + warn, never error
- two caps: 5 per event (at ingest), 25 per run (the post-batch union)
- booleans rejected, numbers coerced to strings

convo [here](https://inngest.slack.com/archives/C05QSAYPEG0/p1781721674384799?thread_ts=1781717694.974469&cid=C05QSAYPEG0) about top level `meta` changes
## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*