### PR TITLE
fix(cli): honor --json=false to force human-readable logs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/inngest/inngest/cmd/apiv2cli"
 	"github.com/inngest/inngest/cmd/devserver"
@@ -33,7 +34,7 @@ func init() {
 var globalFlags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:  "json",
-		Usage: "Output logs as JSON.  Set to true if stdout is not a TTY.",
+		Usage: "Output logs as JSON.  Defaults to true when stdout is not a TTY; set --json=false to force human-readable output.",
 	},
 	&cli.BoolFlag{
 		Name:  "verbose",
@@ -47,6 +48,46 @@ var globalFlags = []cli.Flag{
 	},
 }
 
+// resolveLogHandler determines the LOG_HANDLER value to apply from the --json
+// flag, whether stdout is a TTY, and the current LOG_HANDLER env value. It
+// returns "json" or "dev", or "" to leave the current LOG_HANDLER untouched.
+//
+// Priority:
+//  1. --json=true: always "json".
+//  2. --json=false: force the human-readable "dev" handler, but only when the
+//     current handler would otherwise produce JSON. An explicit non-JSON
+//     handler (e.g. LOG_HANDLER=text) is already what the user asked for, so it
+//     is preserved. This is what lets --json=false override the non-TTY JSON
+//     default (#4379).
+//  3. --json not set, non-TTY: default to "json" (machine-readable logs for
+//     pipes, Docker, turbo, etc.). Matches the previous default behavior, which
+//     forced JSON in non-TTY contexts regardless of any prior LOG_HANDLER.
+//  4. --json not set, TTY: leave unchanged so a configured LOG_HANDLER env var
+//     (or the default dev handler) applies.
+func resolveLogHandler(jsonSet, jsonValue, isTTY bool, current string) string {
+	if jsonSet {
+		if jsonValue {
+			return "json"
+		}
+		if isJSONHandler(current) {
+			return "dev"
+		}
+		// Already a human-readable handler (dev/text); honor the user's choice.
+		return ""
+	}
+	if !isTTY {
+		return "json"
+	}
+	return ""
+}
+
+// isJSONHandler reports whether a LOG_HANDLER value resolves to JSON output.
+// An empty/unset value resolves to the human-readable dev handler, so it is not
+// considered JSON here.
+func isJSONHandler(handler string) bool {
+	return strings.ToLower(strings.TrimSpace(handler)) == "json"
+}
+
 func execute() {
 	app := &cli.Command{
 		Name: "inngest",
@@ -58,10 +99,11 @@ func execute() {
 		)),
 		Version: inngestversion.Print(),
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			// Set LOG_HANDLER environment variable based on --json flag
-			// This ensures the logger respects the JSON output setting
-			if cmd.Bool("json") {
-				os.Setenv("LOG_HANDLER", "json")
+			// Resolve the log handler from the --json flag and TTY state. This
+			// runs after flags are parsed, so an explicit --json=false can
+			// override the non-TTY default of JSON output (see #4379).
+			if handler := resolveLogHandler(cmd.IsSet("json"), cmd.Bool("json"), isatty.IsTerminal(os.Stdout.Fd()), os.Getenv("LOG_HANDLER")); handler != "" {
+				os.Setenv("LOG_HANDLER", handler)
 			}
 
 			if os.Getenv("LOG_LEVEL") == "" {
@@ -98,11 +140,6 @@ func execute() {
 			start.Command(),
 			alpha(),
 		},
-	}
-
-	if !isatty.IsTerminal(os.Stdout.Fd()) {
-		// Always use JSON when not in a terminal
-		os.Setenv("LOG_HANDLER", "json")
 	}
 
 	if err := app.Run(context.Background(), os.Args); err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,116 @@
+package main
+
+import "testing"
+
+func TestResolveLogHandler(t *testing.T) {
+	tests := []struct {
+		name      string
+		jsonSet   bool
+		jsonValue bool
+		isTTY     bool
+		current   string
+		want      string
+	}{
+		{
+			name:      "explicit --json=false in a non-TTY forces human-readable output",
+			jsonSet:   true,
+			jsonValue: false,
+			isTTY:     false,
+			current:   "",
+			want:      "",
+		},
+		{
+			name:      "explicit --json=false overrides a json LOG_HANDLER env var",
+			jsonSet:   true,
+			jsonValue: false,
+			isTTY:     false,
+			current:   "json",
+			want:      "dev",
+		},
+		{
+			name:      "explicit --json=false preserves an explicit text LOG_HANDLER env var",
+			jsonSet:   true,
+			jsonValue: false,
+			isTTY:     false,
+			current:   "text",
+			want:      "",
+		},
+		{
+			name:      "explicit --json=false in a TTY stays human-readable",
+			jsonSet:   true,
+			jsonValue: false,
+			isTTY:     true,
+			current:   "",
+			want:      "",
+		},
+		{
+			name:      "explicit --json in a TTY forces JSON",
+			jsonSet:   true,
+			jsonValue: true,
+			isTTY:     true,
+			current:   "",
+			want:      "json",
+		},
+		{
+			name:      "explicit --json in a non-TTY stays JSON",
+			jsonSet:   true,
+			jsonValue: true,
+			isTTY:     false,
+			current:   "",
+			want:      "json",
+		},
+		{
+			name:    "no --json in a non-TTY defaults to JSON",
+			jsonSet: false,
+			isTTY:   false,
+			current: "",
+			want:    "json",
+		},
+		{
+			name:    "no --json in a TTY leaves the handler untouched",
+			jsonSet: false,
+			isTTY:   true,
+			current: "",
+			want:    "",
+		},
+		{
+			name:    "no --json in a TTY preserves an existing env handler",
+			jsonSet: false,
+			isTTY:   true,
+			current: "text",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveLogHandler(tt.jsonSet, tt.jsonValue, tt.isTTY, tt.current); got != tt.want {
+				t.Errorf("resolveLogHandler(jsonSet=%v, jsonValue=%v, isTTY=%v, current=%q) = %q, want %q",
+					tt.jsonSet, tt.jsonValue, tt.isTTY, tt.current, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsJSONHandler(t *testing.T) {
+	tests := []struct {
+		handler string
+		want    bool
+	}{
+		{handler: "json", want: true},
+		{handler: "JSON", want: true},
+		{handler: "  json  ", want: true},
+		{handler: "", want: false},
+		{handler: "dev", want: false},
+		{handler: "text", want: false},
+		{handler: "txt", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.handler, func(t *testing.T) {
+			if got := isJSONHandler(tt.handler); got != tt.want {
+				t.Errorf("isJSONHandler(%q) = %v, want %v", tt.handler, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #4379.

## Summary

The global `--json` flag could only *enable* JSON logs, never disable them. In `cmd/root.go`, when stdout wasn't a TTY, `execute()` set `LOG_HANDLER=json` before `app.Run()` (before flags were parsed), and the `Before` hook only handled `--json=true`. So `inngest --json=false dev` (piped — e.g. under turbo/Docker) had no effect.

This moves the decision into the `Before` hook via a pure `resolveLogHandler(jsonSet, jsonValue, isTTY, current)` helper. Priority:
- `--json=true` → json
- `--json=false` → dev, but only if the current handler is JSON (preserves an explicit `LOG_HANDLER=text`)
- no flag + non-TTY → json (unchanged default)
- no flag + TTY → leave as-is

## Tests

- Unit tests for `resolveLogHandler` (non-tautological — the old binary fails them) + updated flag help
- `go build ./cmd/...`, `go vet`, `go test ./cmd/ -race` all pass; `golangci-lint` (exact CI v2.11.4 + repo config) → 0 issues
- End-to-end verified 5 piped scenarios incl. env-var preservation; old binary reproduces the bug