### PR TITLE
fix(httpdriver): preserve large integer precision in ParseResponse

### DIFF
--- a/pkg/execution/driver/httpdriver/parse.go
+++ b/pkg/execution/driver/httpdriver/parse.go
@@ -173,8 +173,7 @@ func ParseResponse(byt []byte) any {
 	if byt[0] == '{' {
 		// Is the response valid JSON?  If so, ensure that we don't re-marshal the
 		// JSON string.
-		respjson := map[string]interface{}{}
-		if err := json.Unmarshal(byt, &respjson); err == nil {
+		if respjson, err := unmarshalObject(byt); err == nil {
 			return respjson
 		}
 	}
@@ -194,8 +193,7 @@ func ParseResponse(byt []byte) any {
 			// Treat this as raw text.
 			return string(byt)
 		}
-		respjson := map[string]interface{}{}
-		if err := json.Unmarshal([]byte(respstr), &respjson); err == nil {
+		if respjson, err := unmarshalObject([]byte(respstr)); err == nil {
 			return respjson
 		}
 	}
@@ -206,4 +204,25 @@ func ParseResponse(byt []byte) any {
 	}
 
 	return string(byt)
+}
+
+// unmarshalObject decodes a JSON object into a map, decoding numbers as
+// json.Number rather than float64.  This preserves the precision of large
+// integers (e.g. snowflake IDs) that would otherwise be rounded by float64's
+// 53-bit mantissa when the output is later re-marshalled.
+func unmarshalObject(byt []byte) (map[string]interface{}, error) {
+	respjson := map[string]interface{}{}
+	dec := json.NewDecoder(bytes.NewReader(byt))
+	dec.UseNumber()
+	if err := dec.Decode(&respjson); err != nil {
+		return nil, err
+	}
+	// json.Unmarshal rejects trailing data after a single JSON value; mirror
+	// that here so a malformed payload such as `{...}garbage` still falls
+	// through to the raw-text handling below rather than being silently
+	// accepted as an object.
+	if dec.More() {
+		return nil, fmt.Errorf("unexpected trailing data after JSON object")
+	}
+	return respjson, nil
 }

--- a/pkg/execution/driver/httpdriver/parse_test.go
+++ b/pkg/execution/driver/httpdriver/parse_test.go
@@ -47,6 +47,40 @@ func TestParseResponse(t *testing.T) {
 		map[string]any{"nested": map[string]any{"deep": "hi"}},
 		ParseResponse([]byte(`"{\"nested\": {\"deep\": \"hi\"}}"`)),
 	)
+
+	// Trailing data after an object is rejected, matching json.Unmarshal, so
+	// the raw payload falls through to the text handling.
+	r.Equal(string(`{"a":1}garbage`), ParseResponse([]byte(`{"a":1}garbage`)))
+}
+
+// TestParseResponsePreservesLargeIntegers guards against precision loss for
+// large integers (e.g. snowflake IDs) inside object responses. Decoding into a
+// map[string]interface{} via json.Unmarshal would store the value as a float64,
+// whose 53-bit mantissa cannot represent integers beyond 2^53 exactly, so
+// re-marshalling the output would silently round the value.
+func TestParseResponsePreservesLargeIntegers(t *testing.T) {
+	r := require.New(t)
+
+	const snowflake = "616581622363398142"
+
+	assertPreserved := func(input []byte) {
+		out := ParseResponse(input)
+		m, ok := out.(map[string]any)
+		r.True(ok, "expected object response to decode into a map, got %T", out)
+		r.Equal(json.Number(snowflake), m["id"])
+
+		// The value must survive a marshal round-trip without rounding, since
+		// the output is later re-serialised before being stored and returned.
+		byt, err := json.Marshal(m)
+		r.NoError(err)
+		r.JSONEq(`{"id":`+snowflake+`}`, string(byt))
+	}
+
+	// Plain object response.
+	assertPreserved([]byte(`{"id":` + snowflake + `}`))
+
+	// Double-encoded object response.
+	assertPreserved([]byte(`"{\"id\":` + snowflake + `}"`))
 }
 
 func TestParseGeneratorAllowsExplicitEmptyArray(t *testing.T) {


### PR DESCRIPTION
Closes #4058.

`ParseResponse()` (`pkg/execution/driver/httpdriver/parse.go`) decoded object responses into `map[string]interface{}` via `json.Unmarshal`, which stores JSON numbers as `float64` (53-bit mantissa) — so large integers like Snowflake IDs lose precision (`616581622363398142` → `616581622363398100`) when passed between events/steps.

This adds an `unmarshalObject()` helper that decodes with a `json.Decoder` + `UseNumber()` (keeping numbers as lossless `json.Number`) plus a trailing-data guard (`dec.More()`), and routes both object-decode sites through it. The return type is unchanged.

Red-green proven: the new `TestParseResponsePreservesLargeIntegers` fails on the original code (`6.165816223633981e+17` vs `616581622363398142`) and passes with the fix; the reporter symptom `{"id":616581622363398142}` now round-trips exactly. CI-parity: `go build` / `go vet` / `gofmt` / `go test -race` on the changed + consumer packages (`state`, `executor`), and `golangci-lint v2.11.4` with the repo config → 0 issues.