### PR TITLE
fix(queue): fix Semaphore Key Queues edge case

### DIFF
--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -400,7 +400,7 @@ func (q *queueProcessor) ItemLeaseConstraintCheck(
 			},
 		})
 
-		if len(item.Data.Semaphores) == 0 {
+		if len(item.Data.Semaphores) == 0 || q.semaphoreConstraintChecksDisabled(ctx, *shadowPart.AccountID) {
 			// backlog lease covers everything, no semaphores — skip Acquire entirely.
 			span.SetAttributes(attribute.Bool("valid_lease", true))
 			return ItemLeaseConstraintCheckResult{
@@ -532,6 +532,14 @@ func (q *queueProcessor) ItemLeaseConstraintCheck(
 
 func hasValidCapacityLease(item *QueueItem, now time.Time) bool {
 	return item.CapacityLease != nil && item.CapacityLease.LeaseID.Timestamp().After(now.Add(2*time.Second))
+}
+
+func (q *queueProcessor) semaphoreConstraintChecksDisabled(ctx context.Context, accountID uuid.UUID) bool {
+	if q.DisableSemaphoreConstraintChecks == nil {
+		return false
+	}
+
+	return q.DisableSemaphoreConstraintChecks(ctx, accountID)
 }
 
 func constraintItemsFromBacklog(backlog *QueueBacklog, latestConstraints PartitionConstraintConfig) []constraintapi.ConstraintItem {

--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -40,6 +40,10 @@ type QueueProcessorOpt func(q *queueProcessor)
 // should fan out across every shard instead of resolving the account's shard.
 type AccountShardIterationEnabled func(ctx context.Context, accountID uuid.UUID) bool
 
+// DisableSemaphoreConstraintChecks controls whether semaphore constraints should
+// be ignored for an account while semaphores are rolled out.
+type DisableSemaphoreConstraintChecks func(ctx context.Context, accountID uuid.UUID) bool
+
 func WithName(name string) QueueProcessorOpt {
 	return func(q *queueProcessor) {
 		q.name = name
@@ -451,6 +455,7 @@ type QueueOptions struct {
 	EnableCapacityLeaseInstrumentation  constraintapi.EnableHighCardinalityInstrumentation
 	CapacityLeaseExtendInterval         time.Duration
 	AcquireCapacityLeaseOnBacklogRefill bool
+	DisableSemaphoreConstraintChecks    DisableSemaphoreConstraintChecks
 
 	ConditionalTracer trace.ConditionalTracer
 
@@ -576,6 +581,12 @@ func WithCapacityLeaseInstrumentation(enable constraintapi.EnableHighCardinality
 func WithAcquireCapacityLeaseOnBacklogRefill(acquire bool) QueueOpt {
 	return func(q *QueueOptions) {
 		q.AcquireCapacityLeaseOnBacklogRefill = acquire
+	}
+}
+
+func WithDisableSemaphoreConstraintChecks(f DisableSemaphoreConstraintChecks) QueueOpt {
+	return func(q *QueueOptions) {
+		q.DisableSemaphoreConstraintChecks = f
 	}
 }
 

--- a/tests/execution/queue/queue_semaphore_test.go
+++ b/tests/execution/queue/queue_semaphore_test.go
@@ -145,6 +145,144 @@ func TestQueueSemaphoreWithConstraintAPI(t *testing.T) {
 	require.Equal(t, int64(1), q.Semaphore().Count())
 }
 
+func TestQueueSemaphoreDisableFlagSkipsSemaphoreOnlyValidCapacityLeaseAcquire(t *testing.T) {
+	ctx := context.Background()
+
+	accountID, envID, appID, fnID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	runID := ulid.MustNew(ulid.Now(), rand.Reader)
+	sem := constraintapi.Semaphore{
+		ID:      constraintapi.SemaphoreIDApp(appID),
+		Weight:  1,
+		Release: constraintapi.SemaphoreReleaseAuto,
+	}
+
+	testCases := []struct {
+		name                      string
+		disableSemaphoreChecks    bool
+		expectedAcquireCalls      int
+		expectedFilteredEmptyCall bool
+	}{
+		{
+			name:                      "disabled flag off documents downstream empty acquire",
+			expectedAcquireCalls:      1,
+			expectedFilteredEmptyCall: true,
+		},
+		{
+			name:                   "disabled flag on skips semaphore-only acquire with valid lease",
+			disableSemaphoreChecks: true,
+			expectedAcquireCalls:   0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := miniredis.RunT(t)
+			rc, err := rueidis.NewClient(rueidis.ClientOption{
+				InitAddress:  []string{r.Addr()},
+				DisableCache: true,
+			})
+			require.NoError(t, err)
+			defer rc.Close()
+
+			clock := clockwork.NewFakeClock()
+			cm := &semaphoreFilteringCapacityManager{}
+			constraints := queue.PartitionConstraintConfig{
+				FunctionVersion: 1,
+				Concurrency: queue.PartitionConcurrency{
+					AccountConcurrency:  1,
+					FunctionConcurrency: 1,
+				},
+			}
+
+			var flagAccountID uuid.UUID
+			options := []queue.QueueOpt{
+				queue.WithClock(clock),
+				queue.WithCapacityManager(cm),
+				queue.WithDisableSemaphoreConstraintChecks(func(_ context.Context, accountID uuid.UUID) bool {
+					flagAccountID = accountID
+					return tc.disableSemaphoreChecks
+				}),
+				queue.WithAllowKeyQueues(func(ctx context.Context, acctID, envID, fnID uuid.UUID) bool {
+					return true
+				}),
+				queue.WithPartitionConstraintConfigGetter(func(ctx context.Context, p queue.PartitionIdentifier) queue.PartitionConstraintConfig {
+					return constraints
+				}),
+			}
+
+			shard := redis_state.NewQueueShard("test", redis_state.NewQueueClient(rc, redis_state.QueueDefaultKey), options...)
+			shardRegistry, err := queue.NewSingleShardRegistry(shard)
+			require.NoError(t, err)
+			q, err := queue.New(ctx, "test", shardRegistry, options...)
+			require.NoError(t, err)
+
+			qi, err := shard.EnqueueItem(ctx, queue.QueueItem{
+				Data: queue.Item{
+					Kind: queue.KindStart,
+					Identifier: state.Identifier{
+						AccountID:   accountID,
+						WorkspaceID: envID,
+						AppID:       appID,
+						WorkflowID:  fnID,
+						RunID:       runID,
+					},
+					WorkspaceID: envID,
+					Semaphores:  []constraintapi.Semaphore{sem},
+				},
+				WorkspaceID: envID,
+				FunctionID:  fnID,
+			}, clock.Now(), queue.EnqueueOpts{})
+			require.NoError(t, err)
+
+			backlog := queue.ItemBacklog(ctx, qi)
+			shadowPart := queue.ItemShadowPartition(ctx, qi)
+			capacityLeaseID := ulid.MustNew(ulid.Timestamp(clock.Now().Add(queue.QueueLeaseDuration)), rand.Reader)
+			refillUntil := clock.Now().Add(time.Minute)
+			refillItems, err := getItemIDsFromBacklog(ctx, shard, &backlog, refillUntil, 1)
+			require.NoError(t, err)
+			require.Equal(t, []string{qi.ID}, refillItems)
+			refillResult, err := shard.BacklogRefill(
+				ctx,
+				&backlog,
+				&shadowPart,
+				refillUntil,
+				refillItems,
+				queue.WithBacklogRefillItemCapacityLeases([]queue.CapacityLease{{
+					LeaseID:    capacityLeaseID,
+					IssuedAtMS: clock.Now().UnixMilli(),
+				}}),
+			)
+			require.NoError(t, err)
+			require.Equal(t, []string{qi.ID}, refillResult.RefilledItems)
+
+			refilled, err := q.LoadQueueItem(ctx, shard.Name(), qi.ID)
+			require.NoError(t, err)
+			require.NotNil(t, refilled.CapacityLease)
+			require.Equal(t, capacityLeaseID, refilled.CapacityLease.LeaseID)
+			require.Len(t, refilled.Data.Semaphores, 1)
+
+			res, err := q.ItemLeaseConstraintCheck(ctx, &shadowPart, &backlog, constraints, refilled, clock.Now())
+			if tc.expectedFilteredEmptyCall {
+				require.Error(t, err)
+				require.ErrorContains(t, err, "must provide constraints")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, res.CapacityLease)
+				require.Equal(t, capacityLeaseID, res.CapacityLease.LeaseID)
+			}
+
+			require.Equal(t, accountID, flagAccountID)
+			require.Len(t, cm.acquireCalls, tc.expectedAcquireCalls)
+			require.Len(t, cm.filteredAcquireCalls, tc.expectedAcquireCalls)
+			if tc.expectedFilteredEmptyCall {
+				require.Len(t, cm.acquireCalls[0].Constraints, 1)
+				require.Equal(t, constraintapi.ConstraintKindSemaphore, cm.acquireCalls[0].Constraints[0].Kind)
+				require.Empty(t, cm.filteredAcquireCalls[0].Constraints)
+			}
+		})
+	}
+}
+
 func TestQueueSemaphore(t *testing.T) {
 	ctx := context.Background()
 
@@ -659,4 +797,47 @@ func newFailingCapacityManager(acquireCallCounter *int64) constraintapi.Capacity
 	return &failingCapacityManagerImpl{
 		acquireCalls: acquireCallCounter,
 	}
+}
+
+type semaphoreFilteringCapacityManager struct {
+	acquireCalls         []*constraintapi.CapacityAcquireRequest
+	filteredAcquireCalls []*constraintapi.CapacityAcquireRequest
+}
+
+func (f *semaphoreFilteringCapacityManager) Acquire(ctx context.Context, req *constraintapi.CapacityAcquireRequest) (*constraintapi.CapacityAcquireResponse, errs.InternalError) {
+	f.acquireCalls = append(f.acquireCalls, req)
+
+	filteredReq := *req
+	filteredReq.Constraints = make([]constraintapi.ConstraintItem, 0, len(req.Constraints))
+	for _, item := range req.Constraints {
+		if item.Kind == constraintapi.ConstraintKindSemaphore {
+			continue
+		}
+		filteredReq.Constraints = append(filteredReq.Constraints, item)
+	}
+	f.filteredAcquireCalls = append(f.filteredAcquireCalls, &filteredReq)
+
+	if len(filteredReq.Constraints) == 0 {
+		return nil, errs.Wrap(0, false, "invalid request: 1 error occurred:\n\t* must provide constraints")
+	}
+
+	leaseID := ulid.MustNew(ulid.Timestamp(req.CurrentTime.Add(req.Duration)), rand.Reader)
+	return &constraintapi.CapacityAcquireResponse{
+		Leases: []constraintapi.CapacityLease{{
+			LeaseID:        leaseID,
+			IdempotencyKey: req.LeaseIdempotencyKeys[0],
+		}},
+	}, nil
+}
+
+func (f *semaphoreFilteringCapacityManager) Check(ctx context.Context, req *constraintapi.CapacityCheckRequest) (*constraintapi.CapacityCheckResponse, errs.UserError, errs.InternalError) {
+	return nil, nil, errs.Wrap(0, false, "not implemented")
+}
+
+func (f *semaphoreFilteringCapacityManager) ExtendLease(ctx context.Context, req *constraintapi.CapacityExtendLeaseRequest) (*constraintapi.CapacityExtendLeaseResponse, errs.InternalError) {
+	return nil, errs.Wrap(0, false, "not implemented")
+}
+
+func (f *semaphoreFilteringCapacityManager) Release(ctx context.Context, req *constraintapi.CapacityReleaseRequest) (*constraintapi.CapacityReleaseResponse, errs.InternalError) {
+	return nil, errs.Wrap(0, false, "not implemented")
 }


### PR DESCRIPTION
## Description

Semaphores are currently disabled downstream via a feature flag and filtered out before sending the Acquire request to the Constraint API.

When a function uses both semaphores CONFIGURED but DISABLED _and_ has key queues enabled, we were running into an edge case:
- Constraints would be checked before BacklogRefill
- Items would be refilled with a valid capacity lease
- We would only check semaphores before item Lease
- We would filter out all semaphores
- The Constraint API returns an error because no constraints are provided

This can be fixed by exiting early if a valid capacity lease is present _and_ semaphores are disabled. This guarantees that all constraints have been checked.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
