### PR TITLE
fix(executor): allow self-hosted crons to pass capacity-lease check (#4387)

### DIFF
--- a/pkg/execution/executor/cron_health_check_env_test.go
+++ b/pkg/execution/executor/cron_health_check_env_test.go
@@ -1,0 +1,66 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/constraintapi"
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCronHealthCheckEnvID covers the self-hosted cron scheduling regression in
+// issue #4387: self-hosted functions are stored without an env ID, so cqrs.Function.EnvID
+// is uuid.Nil. The cron health-check re-sync used that zero env ID directly as the cron
+// item's workspace ID, which the capacity-lease CheckConstraints validation rejects with
+// "missing envID", so self-hosted crons could never schedule and the health check looped
+// forever re-syncing them.
+func TestCronHealthCheckEnvID(t *testing.T) {
+	t.Run("falls back to DevServerEnvID for self-hosted functions with no env ID", func(t *testing.T) {
+		// Self-hosted function as returned by GetFunctions: EnvID is the zero UUID.
+		fn := &cqrs.Function{EnvID: uuid.Nil}
+
+		got := cronHealthCheckEnvID(fn)
+
+		require.Equal(t, consts.DevServerEnvID, got)
+		require.NotEqual(t, uuid.Nil, got, "resolved env ID must be non-nil so constraint validation passes")
+	})
+
+	t.Run("nil function falls back to DevServerEnvID", func(t *testing.T) {
+		require.Equal(t, consts.DevServerEnvID, cronHealthCheckEnvID(nil))
+	})
+
+	t.Run("preserves a real env ID when present (cloud/multi-tenant)", func(t *testing.T) {
+		real := uuid.New()
+		require.Equal(t, real, cronHealthCheckEnvID(&cqrs.Function{EnvID: real}))
+	})
+
+	// Regression guard: prove the resolved env ID actually passes the same constraint
+	// validation that was rejecting the request, and that the old zero env ID did not.
+	t.Run("resolved env ID passes capacity-lease validation while uuid.Nil fails", func(t *testing.T) {
+		fn := &cqrs.Function{EnvID: uuid.Nil}
+		resolved := cronHealthCheckEnvID(fn)
+
+		base := func(envID uuid.UUID) *constraintapi.CapacityCheckRequest {
+			return &constraintapi.CapacityCheckRequest{
+				AccountID: consts.DevServerAccountID,
+				EnvID:     envID,
+				Constraints: []constraintapi.ConstraintItem{
+					{Kind: constraintapi.ConstraintKindConcurrency},
+				},
+			}
+		}
+
+		// Before the fix: the raw zero env ID is rejected with "missing envID".
+		err := base(fn.EnvID).Valid()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "missing envID")
+
+		// After the fix: the resolved env ID is accepted (no "missing envID").
+		err = base(resolved).Valid()
+		if err != nil {
+			require.NotContains(t, err.Error(), "missing envID")
+		}
+	})
+}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -903,6 +903,19 @@ func (s *svc) handleEagerCancelBulkRun(ctx context.Context, c cqrs.Cancellation)
 	return nil
 }
 
+// cronHealthCheckEnvID resolves the env (workspace) ID used to health-check and
+// re-sync a self-hosted cron function. Self-hosted functions carry no env ID
+// (cqrsFn.EnvID is uuid.Nil), so we fall back to consts.DevServerEnvID — the same
+// non-zero env ID InitializeCrons stamps when it first enrolls the cron. This keeps
+// the health-check lookup and re-sync consistent with the original schedule and
+// avoids the capacity-lease "missing envID" rejection. See issue #4387.
+func cronHealthCheckEnvID(cqrsFn *cqrs.Function) uuid.UUID {
+	if cqrsFn == nil || cqrsFn.EnvID == uuid.Nil {
+		return consts.DevServerEnvID
+	}
+	return cqrsFn.EnvID
+}
+
 func (s *svc) handleCronHealthCheck(ctx context.Context, item queue.Item) error {
 	l := s.log.With("handler", "cron-health-check")
 
@@ -935,7 +948,14 @@ func (s *svc) handleCronHealthCheck(ctx context.Context, item queue.Item) error 
 		_ = json.Unmarshal([]byte(cqrsFn.Config), &fn)
 
 		accountID := consts.DevServerAccountID
-		envID := cqrsFn.EnvID
+		// Self-hosted functions are stored without an env ID, so cqrsFn.EnvID is the
+		// zero UUID. Using it here stamps an all-zero workspace ID on the cron item,
+		// which the capacity-lease CheckConstraints validation rejects with "missing
+		// envID" (uuid.Nil) — so the cron can never schedule and the health check
+		// re-syncs it forever. It also makes the HealthCheck lookup below miss the
+		// item enqueued by InitializeCrons under consts.DevServerEnvID. Resolve to the
+		// canonical self-hosted env ID, matching InitializeCrons. See issue #4387.
+		envID := cronHealthCheckEnvID(cqrsFn)
 		appID := cqrsFn.AppID
 
 		for _, cronExpr := range fn.ScheduleExpressions() {


### PR DESCRIPTION
## Problem

After upgrading self-hosted Inngest to v1.27.0, cron functions silently stop scheduling (event-triggered functions are unaffected). Every cron tick the executor calls `CheckConstraints` to acquire a capacity lease, and the request is rejected with `missing envID`.

Root cause is in the cron health-check path. Self-hosted functions are stored without an env ID, so `cqrs.Function.EnvID` is the zero UUID (`uuid.Nil`). `handleCronHealthCheck` used that value directly:

```go
envID := cqrsFn.EnvID // uuid.Nil for self-hosted functions
```

That zero env ID is then stamped as the cron item's `WorkspaceID`, propagated through `ScheduleNext` → `handleCron` → `Executor().Schedule`, and finally used as the capacity-lease `EnvID`. `CapacityCheckRequest.Valid()` rejects `EnvID == uuid.Nil` with `missing envID`, so the cron can never schedule. The same zero env ID also makes the `HealthCheck` lookup miss the item that `InitializeCrons` enqueued under `consts.DevServerEnvID`, so the health check reports the cron as unscheduled and re-syncs it forever under the same zero env ID — matching the `WorkspaceID:"00000000-0000-0000-0000-000000000000"` seen in the logged request in #4387.

`InitializeCrons` already stamps the non-zero `consts.DevServerEnvID`; the health-check re-sync was the one place using the raw zero value, so the two paths were inconsistent.

## Fix

Resolve the env ID to `consts.DevServerEnvID` when a function has no env ID, matching `InitializeCrons`. Real env IDs (cloud / multi-tenant) are preserved unchanged. This fixes both the capacity-lease rejection and the false-negative health-check lookup, so self-hosted crons schedule as they did on v1.26.0.

## Verified

- New focused test `TestCronHealthCheckEnvID` proves the resolved env ID is non-nil and passes the real `constraintapi` `CapacityCheckRequest.Valid()` validation, while the old zero env ID fails it with `missing envID`. Confirmed red→green: with the pre-fix behavior the test fails with the exact `missing envID` error from the issue; with the fix it passes.
- `go test ./pkg/execution/executor/` passes (one unrelated pre-existing failure, `TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion`, fails identically on a clean `main` — an embedded-Redis Lua script issue unrelated to this change). `pkg/execution/cron` passes; `constraintapi` validation tests pass.

Fixes #4387

— Charles ([Choreless](https://choreless.dev))
