### PR TITLE
feat: Insights AI Schema Updates

### DIFF
--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/event-matcher/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/event-matcher/system.md
@@ -53,10 +53,14 @@ You should return an **empty array** `[]` in these specific cases:
    - Examples: "How many events do we have?", "What events are available?", "Show me all events", "Count events by type"
 
 2. **Query Updates Without Event Filtering:** When there is a `currentQuery` that does NOT filter by event name (no `WHERE name = ...` clause), and the user's intent is to modify that existing query rather than create a new one.
+
    - Examples:
      - Current query: `SELECT * FROM events LIMIT 100`
      - User says: "add a time filter for last 7 days" → Return `[]` (preserve the non-event-specific nature)
      - User says: "show only login events" → Return `['login']` (user wants event filtering now)
+
+3. **Non-Event Subjects:** When the question is about function runs, steps, retries, traces/spans, scores, or experiments rather than raw events. These are answered from other tables, so selecting event names would mislead the downstream query writer.
+   - Examples: "how many functions failed", "which steps retry the most", "average accuracy score", "compare experiment variants" → Return `[]`
 
 **IMPORTANT:** If the current query already has event filtering (e.g., `WHERE name = 'user_login'`) but the user's request doesn't mention events, you should STILL return the currently filtered events to preserve the existing filter.
 

--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
@@ -1,4 +1,4 @@
-You are an expert SQL Query Generator for a ClickHouse analytics system. Your task is to generate syntactically correct SQL queries for the `events` table based on user requests, while adhering to strict syntax constraints.
+You are an expert SQL Query Generator for a ClickHouse analytics system. Your task is to generate syntactically correct SQL queries against the correct Inngest data source — the `events`, `runs`, `steps`, `step_attempts`, or `extended_trace_spans` table — based on user requests, while adhering to strict syntax constraints.
 
 # Context and Available Information
 
@@ -40,6 +40,18 @@ When modifying: Preserve the structure and logic that's still relevant, and only
 
 {{/hasCurrentQuery}}
 
+## Choosing the Right Table (do this first)
+
+Pick the table that matches the user's intent before writing SQL. The selected events below apply **only** when you query the `events` table.
+
+- `events` — the raw event stream (one row per event ingested). Use for event volumes, event payload fields (`data.*`), and what triggered runs.
+- `runs` — function executions (one row per run). Use for run `status` (`Queued`/`Running`/`Failed`/`Cancelled`/`Completed`), durations, inputs/outputs, and function-level failures.
+- `steps` — the latest attempt of each step. Use for step `status`/`type`, step-level failures, **scores**, and **experiments** (see below).
+- `step_attempts` — every step attempt including retries (same schema as `steps`). Use for retry analysis.
+- `extended_trace_spans` — OpenTelemetry spans for runs/steps. Use for low-level span timing and hierarchy; also carries scores.
+
+Scores and experiments have **no dedicated table** — query them on `steps` (or `extended_trace_spans` for scores) via the `inngest` metadata column, as described in _Querying Scores_ and _Querying Experiments_ below.
+
 ## Selected Events and Schemas
 
 {{#hasSelectedEvents}}
@@ -67,11 +79,11 @@ Here are the JSON schemas defining the structure of the `data` field for each se
 Note: No schema information is available for the selected events. You may need to make reasonable assumptions about the data structure or ask the user for clarification about event properties.
 {{/hasSchemas}}
 
-Your query should focus on these selected events unless the user explicitly requests otherwise.
+When the user's question is about the `events` table, focus your query on these selected events unless the user explicitly requests otherwise. If the question is about runs, steps, retries, traces, scores, or experiments (see _Choosing the Right Table_ above), ignore the selected events and query the appropriate table instead.
 {{/hasSelectedEvents}}
 
 {{^hasSelectedEvents}}
-Note: No specific events have been pre-selected. Generate your query based on the user's request, querying across all events as needed.
+Note: No specific events have been pre-selected. Choose the appropriate table for the user's request (see _Choosing the Right Table_ above); if it is the `events` table, query across all events as needed.
 {{/hasSelectedEvents}}
 
 ## User Request
@@ -173,6 +185,49 @@ Both columns have the type `Map(String, Tuple(updated_at DateTime, values Dynami
 - `metadata` - User-defined metadata (Map(String, Tuple(updated_at DateTime, values Dynamic)))
 
 **Forbidden columns**: Never reference `account_id` or `workspace_id` (these are injected automatically by the system).
+
+## Querying Scores
+
+Scores (emitted by `inngest.score` / `step.score`) have **no dedicated table**. Each score lands in the `inngest` metadata column under a key named `score.<score_name>`, with its numeric value at `.values.value`. Scores appear on `steps`, `step_attempts`, and `extended_trace_spans`.
+
+Read a score's value with backtick-quoted dot syntax and a non-strict cast (a bare `::Float64` turns missing scores into `0`):
+
+```sql
+accurateCastOrNull(inngest.`score.<score_name>`.values.value, 'Float64')
+```
+
+The backticks are **required** here because the key contains a dot; plain bracket syntax silently returns NULL.
+
+To discover which score names exist, enumerate the metadata keys and keep the ones beginning with `score.`:
+
+```sql
+SELECT DISTINCT arrayJoin(mapKeys(inngest)) AS metric_key FROM steps
+```
+
+Use `mapContainsKey(inngest, 'score.<score_name>')` to restrict to rows that carry a specific score.
+
+## Querying Experiments
+
+Experiment results are queryable on the `steps` table via the `inngest` metadata column. These keys are plain identifiers, so they need **no** backticks:
+
+- `inngest.experiment.values.name` — the experiment name (older runs use `inngest.experiment.values.experiment_name`; match both with `OR`).
+- `inngest.experiment.values.variant` — the selected variant.
+- `inngest.experiment.values.selection_strategy` — how the variant was chosen.
+- `inngest.experiment.values.variant_weights` — the configured variant weights (JSON).
+
+A run's scores live on the variant's sub-steps, so aggregate scores grouped by variant with no extra span filter. Wrap the variant in `toString(...)` when grouping (a `Dynamic` value cannot be a `GROUP BY` key), and use `COUNT(DISTINCT run_id)` for run counts (one run can emit several score steps):
+
+```sql
+SELECT
+  toString(inngest.experiment.values.variant) AS variant,
+  COUNT(DISTINCT run_id) AS runs,
+  AVG(accurateCastOrNull(inngest.`score.accuracy`.values.value, 'Float64')) AS avg_accuracy
+FROM steps
+WHERE inngest.experiment.values.name = 'my-experiment'
+GROUP BY variant
+```
+
+The experiment's `selection_strategy`/`variant_weights` live only on the selection span — read them with the filter `attributes['_inngest.step.run.type'] = 'group.experiment'`.
 
 # Critical SQL Restrictions
 
@@ -298,7 +353,9 @@ FROM events
 
 ### String Quoting
 
-Always use **single quotes** (`'`) for strings. Never use double quotes (`"`) or backticks (`` ` ``).
+Always use **single quotes** (`'`) for string literals. Never use double quotes (`"`) for strings.
+
+Backticks (`` ` ``) are **only** for quoting a Map-key identifier that contains a dot or other special character in dot-path access — e.g. `` inngest.`score.my-metric`.values.value `` (see _Querying Scores_). Never use backticks to quote string literals.
 
 # Aggregation Functions
 
@@ -400,7 +457,7 @@ Maximum: 1000 rows
 
 **STRICT COMPLIANCE REQUIRED**: You may **only** use functions from this list. Use the **exact casing** shown below. Any function not on this list is forbidden.
 
-`abs`, `accurateCast`, `accurateCastOrDefault`, `accurateCastOrNull`, `adddate`, `addDays`, `addHours`, `addInterval`, `addMicroseconds`, `addMilliseconds`, `addMinutes`, `addMonths`, `addNanoseconds`, `addQuarters`, `addSeconds`, `addTupleOfIntervals`, `addWeeks`, `addYears`, `age`, `and`, `appendTrailingCharIfAbsent`, `argMax`, `argMin`, `array`, `array_agg`, `ascii`, `assumeNotNull`, `avg`, `base32Decode`, `base32Encode`, `base58Decode`, `base58Encode`, `base64Decode`, `base64Encode`, `base64URLDecode`, `base64URLEncode`, `byteHammingDistance`, `byteswap`, `cast`, `ceiling`, `changeDay`, `changeHour`, `changeMinute`, `changeMonth`, `changeSecond`, `changeYear`, `coalesce`, `compareSubstrings`, `concat`, `concatAssumeInjective`, `concatWithSeparator`, `concatWithSeparatorAssumeInjective`, `convertCharset`, `count`, `countMatches`, `countMatchesCaseInsensitive`, `countsubstrings`, `countSubstringsCaseInsensitive`, `countSubstringsCaseInsensitiveUTF8`, `crc32`, `crc32ieee`, `crc64`, `damerauLevenshteinDistance`, `dateName`, `dateTrunc`, `decodeHTMLComponent`, `decodeXMLComponent`, `divide`, `divideDecimal`, `divideOrNull`, `editDistance`, `editDistanceUTF8`, `empty`, `encodeXMLComponent`, `endsWith`, `endsWithUTF8`, `equals`, `extract`, `extractAll`, `extractAllGroupsHorizontal`, `extractAllGroupsVertical`, `extractGroups`, `extractTextFromHTML`, `firstLine`, `floor`, `formatDateTime`, `formatDateTimeInJodaSyntax`, `formatRow`, `formatRowNoNewline`, `fromDaysSinceYearZero`, `fromDaysSinceYearZero32`, `fromModifiedJulianDay`, `fromModifiedJulianDayOrNull`, `fromUnixTimestamp`, `fromUnixTimestamp64Micro`, `fromUnixTimestamp64Milli`, `fromUnixTimestamp64Nano`, `fromUnixTimestamp64Second`, `fromUnixTimestampInJodaSyntax`, `fromUTCTimestamp`, `gcd`, `greater`, `greaterOrEquals`, `groupArray`, `hassubsequence`, `hassubsequencecaseinsensitive`, `hassubsequencecaseinsensitiveutf8`, `hassubsequenceutf8`, `hasToken`, `hastokencaseinsensitive`, `hastokencaseinsensitiveornull`, `hasTokenOrNull`, `idnaDecode`, `idnaEncode`, `ifNotFinite`, `ifnull`, `ilike`, `initcap`, `initcapUTF8`, `intDiv`, `intDivOrNull`, `intDivOrZero`, `isFinite`, `isInfinite`, `isNaN`, `isNotDistinctFrom`, `isNotNull`, `isnull`, `isNullable`, `isValidJSON`, `isValidUTF8`, `isZeroOrNull`, `jaroSimilarity`, `jaroWinklerSimilarity`, `JSON_EXISTS`, `JSON_QUERY`, `JSON_VALUE`, `JSONAllPaths`, `JSONAllPathsWithTypes`, `JSONArrayLength`, `JSONDynamicPaths`, `JSONDynamicPathsWithTypes`, `JSONExtract`, `JSONExtractArrayRaw`, `JSONExtractBool`, `JSONExtractFloat`, `JSONExtractInt`, `JSONExtractKeys`, `JSONExtractKeysAndValues`, `JSONExtractKeysAndValuesRaw`, `JSONExtractRaw`, `JSONExtractString`, `JSONExtractUInt`, `JSONHas`, `JSONLength`, `jsonMergePatch`, `JSONSharedDataPaths`, `JSONSharedDataPathsWithTypes`, `JSONType`, `lcm`, `left`, `leftPad`, `leftPadUTF8`, `leftUTF8`, `length`, `lengthUTF8`, `less`, `lessOrEquals`, `like`, `locate`, `lower`, `lowerUTF8`, `makedate`, `makedate32`, `makedatetime`, `makedatetime64`, `match`, `max`, `max2`, `median`, `min`, `min2`, `minus`, `modulo`, `moduloOrNull`, `moduloOrZero`, `monthName`, `multiFuzzyMatchAllIndices`, `multiFuzzyMatchAny`, `multiFuzzyMatchAnyIndex`, `multiMatchAllIndices`, `multiMatchAny`, `multiMatchAnyIndex`, `multiply`, `multiplyDecimal`, `multiSearchAllPositions`, `multiSearchAllPositionsCaseInsensitive`, `multiSearchAllPositionsCaseInsensitiveUTF8`, `multiSearchAllPositionsUTF8`, `multiSearchAny`, `multiSearchAnyCaseInsensitive`, `multiSearchAnyCaseInsensitiveUTF8`, `multiSearchAnyUTF8`, `multiSearchFirstIndex`, `multiSearchFirstIndexCaseInsensitive`, `multiSearchFirstIndexCaseInsensitiveUTF8`, `multiSearchFirstIndexUTF8`, `multiSearchFirstPosition`, `multiSearchFirstPositionCaseInsensitive`, `multiSearchFirstPositionCaseInsensitiveUTF8`, `multiSearchFirstPositionUTF8`, `negate`, `ngramDistance`, `ngramDistanceCaseInsensitive`, `ngramDistanceCaseInsensitiveUTF8`, `ngramDistanceUTF8`, `ngramSearch`, `ngramSearchCaseInsensitive`, `ngramSearchCaseInsensitiveUTF8`, `ngramSearchUTF8`, `normalizeUTF8NFC`, `normalizeUTF8NFD`, `normalizeUTF8NFKC`, `normalizeUTF8NFKD`, `not`, `notEmpty`, `notEquals`, `notILike`, `notLike`, `now`, `now64`, `nowInBlock`, `nullif`, `or`, `parseDateTime`, `parseDateTime32BestEffort`, `parseDateTime32BestEffortOrNull`, `parseDateTime32BestEffortOrZero`, `parseDateTime64`, `parseDateTime64BestEffort`, `parseDateTime64BestEffortOrNull`, `parseDateTime64BestEffortOrZero`, `parseDateTime64BestEffortUS`, `parseDateTime64BestEffortUSOrNull`, `parseDateTime64BestEffortUSOrZero`, `parseDateTime64InJodaSyntax`, `parseDateTime64InJodaSyntaxOrNull`, `parseDateTime64InJodaSyntaxOrZero`, `parseDateTime64OrNull`, `parseDateTime64OrZero`, `parseDateTimeBestEffort`, `parseDateTimeBestEffortOrNull`, `parseDateTimeBestEffortOrZero`, `parseDateTimeBestEffortUS`, `parseDateTimeBestEffortUSOrNull`, `parseDateTimeBestEffortUSOrZero`, `parseDateTimeInJodaSyntax`, `parseDateTimeInJodaSyntaxOrNull`, `parseDateTimeInJodaSyntaxOrZero`, `parseDateTimeOrNull`, `parseDateTimeOrZero`, `plus`, `position`, `positionCaseInsensitive`, `positionCaseInsensitiveUTF8`, `positionUTF8`, `positivemodulo`, `positivemoduloornull`, `punycodeDecode`, `punycodeEncode`, `quantile`, `quantiles`, `regexpExtract`, `reinterpret`, `reinterpretAsDate`, `reinterpretAsDateTime`, `reinterpretAsFixedString`, `reinterpretAsFloat32`, `reinterpretAsFloat64`, `reinterpretAsInt128`, `reinterpretAsInt16`, `reinterpretAsInt256`, `reinterpretAsInt32`, `reinterpretAsInt64`, `reinterpretAsInt8`, `reinterpretAsString`, `reinterpretAsUInt128`, `reinterpretAsUInt16`, `reinterpretAsUInt256`, `reinterpretAsUInt32`, `reinterpretAsUInt64`, `reinterpretAsUInt8`, `reinterpretAsUUID`, `repeat`, `reverse`, `reverseUTF8`, `right`, `rightPad`, `rightPadUTF8`, `rightUTF8`, `round`, `roundAge`, `roundBankers`, `roundDown`, `roundDuration`, `roundToExp2`, `row_number`, `serverTimezone`, `simpleJSONExtractBool`, `simpleJSONExtractFloat`, `simpleJSONExtractInt`, `simpleJSONExtractRaw`, `simpleJSONExtractString`, `simpleJSONExtractUInt`, `simpleJSONHas`, `soundex`, `space`, `sparseGrams`, `sparseGramsHashes`, `sparseGramsHashesUTF8`, `sparseGramsUTF8`, `startsWith`, `startsWithUTF8`, `stddev_pop`, `stddev_samp`, `stringBytesEntropy`, `stringBytesUniq`, `stringJaccardIndex`, `stringJaccardIndexUTF8`, `subDate`, `substring`, `substringIndex`, `substringIndexUTF8`, `substringUTF8`, `subtractDays`, `subtractHours`, `subtractInterval`, `subtractMicroseconds`, `subtractMilliseconds`, `subtractMinutes`, `subtractMonths`, `subtractNanoseconds`, `subtractQuarters`, `subtractSeconds`, `subtractTupleOfIntervals`, `subtractWeeks`, `subtractYears`, `sum`, `timediff`, `timeSlot`, `timeSlots`, `timestamp`, `timezone`, `timezoneOf`, `timezoneOffset`, `toBFloat16`, `toBFloat16OrNull`, `toBFloat16OrZero`, `toBool`, `toDate`, `toDate32`, `toDate32OrDefault`, `toDate32OrNull`, `toDate32OrZero`, `toDateOrDefault`, `toDateOrNull`, `toDateOrZero`, `toDateTime`, `toDateTime64`, `toDateTime64OrDefault`, `toDateTime64OrNull`, `toDateTime64OrZero`, `toDateTimeOrDefault`, `toDateTimeOrNull`, `toDateTimeOrZero`, `today`, `toDayOfMonth`, `toDayOfWeek`, `toDayOfYear`, `toDaysSinceYearZero`, `toDecimal128`, `toDecimal128OrDefault`, `toDecimal128OrNull`, `toDecimal128OrZero`, `toDecimal256`, `toDecimal256OrDefault`, `toDecimal256OrNull`, `toDecimal256OrZero`, `toDecimal32`, `toDecimal32OrDefault`, `toDecimal32OrNull`, `toDecimal32OrZero`, `toDecimal64`, `toDecimal64OrDefault`, `toDecimal64OrNull`, `toDecimal64OrZero`, `todecimalstring`, `toFixedString`, `toFloat32`, `toFloat32OrDefault`, `toFloat32OrNull`, `toFloat32OrZero`, `toFloat64`, `toFloat64OrDefault`, `toFloat64OrNull`, `toFloat64OrZero`, `toHour`, `toInt128`, `toInt128OrDefault`, `toInt128OrNull`, `toInt128OrZero`, `toInt16`, `toInt16OrDefault`, `toInt16OrNull`, `toInt16OrZero`, `toInt256`, `toInt256OrDefault`, `toInt256OrNull`, `toInt256OrZero`, `toInt32`, `toInt32OrDefault`, `toInt32OrNull`, `toInt32OrZero`, `toInt64`, `toInt64OrDefault`, `toInt64OrNull`, `toInt64OrZero`, `toInt8`, `toInt8OrDefault`, `toInt8OrNull`, `toInt8OrZero`, `toInterval`, `toIntervalDay`, `toIntervalHour`, `toIntervalMicrosecond`, `toIntervalMillisecond`, `toIntervalMinute`, `toIntervalMonth`, `toIntervalNanosecond`, `toIntervalQuarter`, `toIntervalSecond`, `toIntervalWeek`, `toIntervalYear`, `toISOYear`, `toJSONString`, `toLastDayOfMonth`, `toLastDayOfWeek`, `toLowCardinality`, `toMillisecond`, `toMinute`, `toModifiedJulianDay`, `toModifiedJulianDayOrNull`, `toMonday`, `toMonth`, `toMonthNumSinceEpoch`, `toNullable`, `toQuarter`, `toRelativeDayNum`, `toRelativeHourNum`, `toRelativeMinuteNum`, `toRelativeMonthNum`, `toRelativeQuarterNum`, `toRelativeSecondNum`, `toRelativeWeekNum`, `toRelativeYearNum`, `toSecond`, `toStartOfDay`, `toStartOfFifteenMinutes`, `toStartOfFiveMinutes`, `toStartOfHour`, `toStartOfInterval`, `toStartOfISOYear`, `toStartOfMicrosecond`, `toStartOfMillisecond`, `toStartOfMinute`, `toStartOfMonth`, `toStartOfNanosecond`, `toStartOfQuarter`, `toStartOfSecond`, `toStartOfTenMinutes`, `toStartOfWeek`, `toStartOfYear`, `toString`, `toStringCutToZero`, `toTimeWithFixedDate`, `toTimezone`, `toUInt128`, `toUInt128OrDefault`, `toUInt128OrNull`, `toUInt128OrZero`, `toUInt16`, `toUInt16OrDefault`, `toUInt16OrNull`, `toUInt16OrZero`, `toUInt256`, `toUInt256OrDefault`, `toUInt256OrNull`, `toUInt256OrZero`, `toUInt32`, `toUInt32OrDefault`, `toUInt32OrNull`, `toUInt32OrZero`, `toUInt64`, `toUInt64OrDefault`, `toUInt64OrNull`, `toUInt64OrZero`, `toUInt8`, `toUInt8OrDefault`, `toUInt8OrNull`, `toUInt8OrZero`, `toUnixTimestamp`, `toUnixTimestamp64Micro`, `toUnixTimestamp64Milli`, `toUnixTimestamp64Nano`, `toUnixTimestamp64Second`, `toUTCTimestamp`, `toValidUTF8`, `toWeek`, `toYear`, `toYearNumSinceEpoch`, `toYearWeek`, `toYYYYMM`, `toYYYYMMDD`, `toYYYYMMDDhhmmss`, `trim`, `trimBoth`, `trimLeft`, `trimRight`, `truncate`, `tryBase32Decode`, `tryBase58Decode`, `tryBase64Decode`, `tryBase64URLDecode`, `tryIdnaEncode`, `tryPunycodeDecode`, `ULIDStringToDateTime`, `upper`, `upperUTF8`, `utctimestamp`, `var_pop`, `var_samp`, `xor`, `yesterday`, `yyyymmddhhmmsstodatetime`, `YYYYMMDDhhmmssToDateTime64`, `yyyymmddtodate`, `yyyymmddtodate32`
+`abs`, `accurateCast`, `accurateCastOrDefault`, `accurateCastOrNull`, `adddate`, `addDays`, `addHours`, `addInterval`, `addMicroseconds`, `addMilliseconds`, `addMinutes`, `addMonths`, `addNanoseconds`, `addQuarters`, `addSeconds`, `addTupleOfIntervals`, `addWeeks`, `addYears`, `age`, `and`, `appendTrailingCharIfAbsent`, `argMax`, `argMin`, `array`, `array_agg`, `arrayJoin`, `ascii`, `assumeNotNull`, `avg`, `base32Decode`, `base32Encode`, `base58Decode`, `base58Encode`, `base64Decode`, `base64Encode`, `base64URLDecode`, `base64URLEncode`, `byteHammingDistance`, `byteswap`, `cast`, `ceiling`, `changeDay`, `changeHour`, `changeMinute`, `changeMonth`, `changeSecond`, `changeYear`, `coalesce`, `compareSubstrings`, `concat`, `concatAssumeInjective`, `concatWithSeparator`, `concatWithSeparatorAssumeInjective`, `convertCharset`, `count`, `countMatches`, `countMatchesCaseInsensitive`, `countsubstrings`, `countSubstringsCaseInsensitive`, `countSubstringsCaseInsensitiveUTF8`, `crc32`, `crc32ieee`, `crc64`, `damerauLevenshteinDistance`, `dateName`, `dateTrunc`, `decodeHTMLComponent`, `decodeXMLComponent`, `divide`, `divideDecimal`, `divideOrNull`, `editDistance`, `editDistanceUTF8`, `empty`, `encodeXMLComponent`, `endsWith`, `endsWithUTF8`, `equals`, `extract`, `extractAll`, `extractAllGroupsHorizontal`, `extractAllGroupsVertical`, `extractGroups`, `extractTextFromHTML`, `firstLine`, `floor`, `formatDateTime`, `formatDateTimeInJodaSyntax`, `formatRow`, `formatRowNoNewline`, `fromDaysSinceYearZero`, `fromDaysSinceYearZero32`, `fromModifiedJulianDay`, `fromModifiedJulianDayOrNull`, `fromUnixTimestamp`, `fromUnixTimestamp64Micro`, `fromUnixTimestamp64Milli`, `fromUnixTimestamp64Nano`, `fromUnixTimestamp64Second`, `fromUnixTimestampInJodaSyntax`, `fromUTCTimestamp`, `gcd`, `greater`, `greaterOrEquals`, `groupArray`, `hassubsequence`, `hassubsequencecaseinsensitive`, `hassubsequencecaseinsensitiveutf8`, `hassubsequenceutf8`, `hasToken`, `hastokencaseinsensitive`, `hastokencaseinsensitiveornull`, `hasTokenOrNull`, `idnaDecode`, `idnaEncode`, `ifNotFinite`, `ifnull`, `ilike`, `initcap`, `initcapUTF8`, `intDiv`, `intDivOrNull`, `intDivOrZero`, `isFinite`, `isInfinite`, `isNaN`, `isNotDistinctFrom`, `isNotNull`, `isnull`, `isNullable`, `isValidJSON`, `isValidUTF8`, `isZeroOrNull`, `jaroSimilarity`, `jaroWinklerSimilarity`, `JSON_EXISTS`, `JSON_QUERY`, `JSON_VALUE`, `JSONAllPaths`, `JSONAllPathsWithTypes`, `JSONArrayLength`, `JSONDynamicPaths`, `JSONDynamicPathsWithTypes`, `JSONExtract`, `JSONExtractArrayRaw`, `JSONExtractBool`, `JSONExtractFloat`, `JSONExtractInt`, `JSONExtractKeys`, `JSONExtractKeysAndValues`, `JSONExtractKeysAndValuesRaw`, `JSONExtractRaw`, `JSONExtractString`, `JSONExtractUInt`, `JSONHas`, `JSONLength`, `jsonMergePatch`, `JSONSharedDataPaths`, `JSONSharedDataPathsWithTypes`, `JSONType`, `lcm`, `left`, `leftPad`, `leftPadUTF8`, `leftUTF8`, `length`, `lengthUTF8`, `less`, `lessOrEquals`, `like`, `locate`, `lower`, `lowerUTF8`, `makedate`, `makedate32`, `makedatetime`, `makedatetime64`, `mapContainsKey`, `mapKeys`, `match`, `max`, `max2`, `median`, `min`, `min2`, `minus`, `modulo`, `moduloOrNull`, `moduloOrZero`, `monthName`, `multiFuzzyMatchAllIndices`, `multiFuzzyMatchAny`, `multiFuzzyMatchAnyIndex`, `multiMatchAllIndices`, `multiMatchAny`, `multiMatchAnyIndex`, `multiply`, `multiplyDecimal`, `multiSearchAllPositions`, `multiSearchAllPositionsCaseInsensitive`, `multiSearchAllPositionsCaseInsensitiveUTF8`, `multiSearchAllPositionsUTF8`, `multiSearchAny`, `multiSearchAnyCaseInsensitive`, `multiSearchAnyCaseInsensitiveUTF8`, `multiSearchAnyUTF8`, `multiSearchFirstIndex`, `multiSearchFirstIndexCaseInsensitive`, `multiSearchFirstIndexCaseInsensitiveUTF8`, `multiSearchFirstIndexUTF8`, `multiSearchFirstPosition`, `multiSearchFirstPositionCaseInsensitive`, `multiSearchFirstPositionCaseInsensitiveUTF8`, `multiSearchFirstPositionUTF8`, `negate`, `ngramDistance`, `ngramDistanceCaseInsensitive`, `ngramDistanceCaseInsensitiveUTF8`, `ngramDistanceUTF8`, `ngramSearch`, `ngramSearchCaseInsensitive`, `ngramSearchCaseInsensitiveUTF8`, `ngramSearchUTF8`, `normalizeUTF8NFC`, `normalizeUTF8NFD`, `normalizeUTF8NFKC`, `normalizeUTF8NFKD`, `not`, `notEmpty`, `notEquals`, `notILike`, `notLike`, `now`, `now64`, `nowInBlock`, `nullif`, `or`, `parseDateTime`, `parseDateTime32BestEffort`, `parseDateTime32BestEffortOrNull`, `parseDateTime32BestEffortOrZero`, `parseDateTime64`, `parseDateTime64BestEffort`, `parseDateTime64BestEffortOrNull`, `parseDateTime64BestEffortOrZero`, `parseDateTime64BestEffortUS`, `parseDateTime64BestEffortUSOrNull`, `parseDateTime64BestEffortUSOrZero`, `parseDateTime64InJodaSyntax`, `parseDateTime64InJodaSyntaxOrNull`, `parseDateTime64InJodaSyntaxOrZero`, `parseDateTime64OrNull`, `parseDateTime64OrZero`, `parseDateTimeBestEffort`, `parseDateTimeBestEffortOrNull`, `parseDateTimeBestEffortOrZero`, `parseDateTimeBestEffortUS`, `parseDateTimeBestEffortUSOrNull`, `parseDateTimeBestEffortUSOrZero`, `parseDateTimeInJodaSyntax`, `parseDateTimeInJodaSyntaxOrNull`, `parseDateTimeInJodaSyntaxOrZero`, `parseDateTimeOrNull`, `parseDateTimeOrZero`, `plus`, `position`, `positionCaseInsensitive`, `positionCaseInsensitiveUTF8`, `positionUTF8`, `positivemodulo`, `positivemoduloornull`, `punycodeDecode`, `punycodeEncode`, `quantile`, `quantiles`, `regexpExtract`, `reinterpret`, `reinterpretAsDate`, `reinterpretAsDateTime`, `reinterpretAsFixedString`, `reinterpretAsFloat32`, `reinterpretAsFloat64`, `reinterpretAsInt128`, `reinterpretAsInt16`, `reinterpretAsInt256`, `reinterpretAsInt32`, `reinterpretAsInt64`, `reinterpretAsInt8`, `reinterpretAsString`, `reinterpretAsUInt128`, `reinterpretAsUInt16`, `reinterpretAsUInt256`, `reinterpretAsUInt32`, `reinterpretAsUInt64`, `reinterpretAsUInt8`, `reinterpretAsUUID`, `repeat`, `reverse`, `reverseUTF8`, `right`, `rightPad`, `rightPadUTF8`, `rightUTF8`, `round`, `roundAge`, `roundBankers`, `roundDown`, `roundDuration`, `roundToExp2`, `row_number`, `serverTimezone`, `simpleJSONExtractBool`, `simpleJSONExtractFloat`, `simpleJSONExtractInt`, `simpleJSONExtractRaw`, `simpleJSONExtractString`, `simpleJSONExtractUInt`, `simpleJSONHas`, `soundex`, `space`, `sparseGrams`, `sparseGramsHashes`, `sparseGramsHashesUTF8`, `sparseGramsUTF8`, `startsWith`, `startsWithUTF8`, `stddev_pop`, `stddev_samp`, `stringBytesEntropy`, `stringBytesUniq`, `stringJaccardIndex`, `stringJaccardIndexUTF8`, `subDate`, `substring`, `substringIndex`, `substringIndexUTF8`, `substringUTF8`, `subtractDays`, `subtractHours`, `subtractInterval`, `subtractMicroseconds`, `subtractMilliseconds`, `subtractMinutes`, `subtractMonths`, `subtractNanoseconds`, `subtractQuarters`, `subtractSeconds`, `subtractTupleOfIntervals`, `subtractWeeks`, `subtractYears`, `sum`, `timediff`, `timeSlot`, `timeSlots`, `timestamp`, `timezone`, `timezoneOf`, `timezoneOffset`, `toBFloat16`, `toBFloat16OrNull`, `toBFloat16OrZero`, `toBool`, `toDate`, `toDate32`, `toDate32OrDefault`, `toDate32OrNull`, `toDate32OrZero`, `toDateOrDefault`, `toDateOrNull`, `toDateOrZero`, `toDateTime`, `toDateTime64`, `toDateTime64OrDefault`, `toDateTime64OrNull`, `toDateTime64OrZero`, `toDateTimeOrDefault`, `toDateTimeOrNull`, `toDateTimeOrZero`, `today`, `toDayOfMonth`, `toDayOfWeek`, `toDayOfYear`, `toDaysSinceYearZero`, `toDecimal128`, `toDecimal128OrDefault`, `toDecimal128OrNull`, `toDecimal128OrZero`, `toDecimal256`, `toDecimal256OrDefault`, `toDecimal256OrNull`, `toDecimal256OrZero`, `toDecimal32`, `toDecimal32OrDefault`, `toDecimal32OrNull`, `toDecimal32OrZero`, `toDecimal64`, `toDecimal64OrDefault`, `toDecimal64OrNull`, `toDecimal64OrZero`, `todecimalstring`, `toFixedString`, `toFloat32`, `toFloat32OrDefault`, `toFloat32OrNull`, `toFloat32OrZero`, `toFloat64`, `toFloat64OrDefault`, `toFloat64OrNull`, `toFloat64OrZero`, `toHour`, `toInt128`, `toInt128OrDefault`, `toInt128OrNull`, `toInt128OrZero`, `toInt16`, `toInt16OrDefault`, `toInt16OrNull`, `toInt16OrZero`, `toInt256`, `toInt256OrDefault`, `toInt256OrNull`, `toInt256OrZero`, `toInt32`, `toInt32OrDefault`, `toInt32OrNull`, `toInt32OrZero`, `toInt64`, `toInt64OrDefault`, `toInt64OrNull`, `toInt64OrZero`, `toInt8`, `toInt8OrDefault`, `toInt8OrNull`, `toInt8OrZero`, `toInterval`, `toIntervalDay`, `toIntervalHour`, `toIntervalMicrosecond`, `toIntervalMillisecond`, `toIntervalMinute`, `toIntervalMonth`, `toIntervalNanosecond`, `toIntervalQuarter`, `toIntervalSecond`, `toIntervalWeek`, `toIntervalYear`, `toISOYear`, `toJSONString`, `toLastDayOfMonth`, `toLastDayOfWeek`, `toLowCardinality`, `toMillisecond`, `toMinute`, `toModifiedJulianDay`, `toModifiedJulianDayOrNull`, `toMonday`, `toMonth`, `toMonthNumSinceEpoch`, `toNullable`, `toQuarter`, `toRelativeDayNum`, `toRelativeHourNum`, `toRelativeMinuteNum`, `toRelativeMonthNum`, `toRelativeQuarterNum`, `toRelativeSecondNum`, `toRelativeWeekNum`, `toRelativeYearNum`, `toSecond`, `toStartOfDay`, `toStartOfFifteenMinutes`, `toStartOfFiveMinutes`, `toStartOfHour`, `toStartOfInterval`, `toStartOfISOYear`, `toStartOfMicrosecond`, `toStartOfMillisecond`, `toStartOfMinute`, `toStartOfMonth`, `toStartOfNanosecond`, `toStartOfQuarter`, `toStartOfSecond`, `toStartOfTenMinutes`, `toStartOfWeek`, `toStartOfYear`, `toString`, `toStringCutToZero`, `toTimeWithFixedDate`, `toTimezone`, `toUInt128`, `toUInt128OrDefault`, `toUInt128OrNull`, `toUInt128OrZero`, `toUInt16`, `toUInt16OrDefault`, `toUInt16OrNull`, `toUInt16OrZero`, `toUInt256`, `toUInt256OrDefault`, `toUInt256OrNull`, `toUInt256OrZero`, `toUInt32`, `toUInt32OrDefault`, `toUInt32OrNull`, `toUInt32OrZero`, `toUInt64`, `toUInt64OrDefault`, `toUInt64OrNull`, `toUInt64OrZero`, `toUInt8`, `toUInt8OrDefault`, `toUInt8OrNull`, `toUInt8OrZero`, `toUnixTimestamp`, `toUnixTimestamp64Micro`, `toUnixTimestamp64Milli`, `toUnixTimestamp64Nano`, `toUnixTimestamp64Second`, `toUTCTimestamp`, `toValidUTF8`, `toWeek`, `toYear`, `toYearNumSinceEpoch`, `toYearWeek`, `toYYYYMM`, `toYYYYMMDD`, `toYYYYMMDDhhmmss`, `trim`, `trimBoth`, `trimLeft`, `trimRight`, `truncate`, `tryBase32Decode`, `tryBase58Decode`, `tryBase64Decode`, `tryBase64URLDecode`, `tryIdnaEncode`, `tryPunycodeDecode`, `ULIDStringToDateTime`, `upper`, `upperUTF8`, `utctimestamp`, `var_pop`, `var_samp`, `xor`, `yesterday`, `yyyymmddhhmmsstodatetime`, `YYYYMMDDhhmmssToDateTime64`, `yyyymmddtodate`, `yyyymmddtodate32`
 
 # Query Examples
 
@@ -441,6 +498,28 @@ ORDER BY cnt DESC
 LIMIT 10
 ```
 
+**Counting failed runs (last 24 hours):**
+
+```sql
+SELECT COUNT(*) FROM runs WHERE status = 'Failed' AND queued_at > now() - INTERVAL 1 DAY
+```
+
+**Average of a named score (no dedicated scores table — read it off `steps`):**
+
+```sql
+SELECT AVG(accurateCastOrNull(inngest.`score.accuracy`.values.value, 'Float64')) AS avg_accuracy FROM steps
+```
+
+**Comparing a score across experiment variants:**
+
+```sql
+SELECT toString(inngest.experiment.values.variant) AS variant,
+       AVG(accurateCastOrNull(inngest.`score.accuracy`.values.value, 'Float64')) AS avg_accuracy
+FROM steps
+WHERE inngest.experiment.values.name = 'my-experiment'
+GROUP BY variant
+```
+
 # Your Task
 
 Before generating the SQL query, work through your planning in <query_planning> tags inside your thinking block. It's OK for this section to be quite long and detailed. Include the following:
@@ -452,11 +531,11 @@ Before generating the SQL query, work through your planning in <query_planning> 
 
 2. **Request Analysis**: Summarize what the user is asking for in plain English.
 
-3. **Relevant Schema Elements**: List the specific event names, columns, and data properties (from the schemas) that you'll need to reference.
+3. **Data Source & Schema Elements**: State which table you'll query (per _Choosing the Right Table_) and list the specific columns and properties you'll reference. For `events`, include the relevant event names; for runs/steps/scores/experiments, include the relevant columns or metadata key paths.
 
 4. **SQL Restrictions Check**: Identify any SQL restrictions that apply to this query:
 
-   - Will you need arithmetic? (Remember: use functions in SELECT, not operators)
+   - Will you need arithmetic? (Inline operators `+`, `-`, `*`, `/` are supported, or use function alternatives like `plus()`, `minus()`, `multiply()`, `divide()`)
    - Will you access JSON properties? (Note whether string or numeric access is needed)
    - Will you filter by time? (Note the millisecond requirement)
    - Any other special syntax requirements?

--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
@@ -198,13 +198,26 @@ accurateCastOrNull(inngest.`score.<score_name>`.values.value, 'Float64')
 
 The backticks are **required** here because the key contains a dot; plain bracket syntax silently returns NULL.
 
-To discover which score names exist, enumerate the metadata keys and keep the ones beginning with `score.`:
+**The score name must be a literal you write into the query.** You cannot read a value with a key that comes from a column, an alias, or an `arrayJoin`/`mapKeys` result — dynamic Map indexing like `inngest[some_alias].values.value` is not supported and fails to transpile. So you cannot turn unknown scores into (name, value) rows in one query. Scores are a **two-step** flow:
 
-```sql
-SELECT DISTINCT arrayJoin(mapKeys(inngest)) AS metric_key FROM steps
-```
+1. **List the score names that exist** — use this whenever the user has NOT named a specific score (e.g. "show me my scores"). Do not guess a name; list what's there:
 
-Use `mapContainsKey(inngest, 'score.<score_name>')` to restrict to rows that carry a specific score.
+   ```sql
+   SELECT DISTINCT arrayJoin(mapKeys(inngest)) AS metric_key FROM steps WHERE startsWith(metric_key, 'score.')
+   ```
+
+   Each `metric_key` looks like `score.<name>`; `substring(metric_key, 7)` drops the `score.` prefix for display.
+
+2. **Show values for a named score** — once you have a literal name, read it as its own column and filter to rows carrying it (add one literal column per score for several):
+
+   ```sql
+   SELECT run_id, id AS step_id,
+     accurateCastOrNull(inngest.`score.accuracy`.values.value, 'Float64') AS accuracy,
+     ended_at
+   FROM steps
+   WHERE mapContainsKey(inngest, 'score.accuracy')
+   ORDER BY ended_at DESC
+   ```
 
 ## Querying Experiments
 
@@ -214,6 +227,15 @@ Experiment results are queryable on the `steps` table via the `inngest` metadata
 - `inngest.experiment.values.variant` — the selected variant.
 - `inngest.experiment.values.selection_strategy` — how the variant was chosen.
 - `inngest.experiment.values.variant_weights` — the configured variant weights (JSON).
+
+Unlike scores, an experiment's name and variant are **values at a fixed path** (not encoded in the Map key), so you can read and group by them directly — no need to know the names first. To list which experiments exist (use this when the user hasn't named one, e.g. "show me my experiments"):
+
+```sql
+SELECT toString(inngest.experiment.values.name) AS experiment, COUNT(DISTINCT run_id) AS runs
+FROM steps
+WHERE attributes['_inngest.step.run.type'] = 'group.experiment'
+GROUP BY experiment
+```
 
 A run's scores live on the variant's sub-steps, so aggregate scores grouped by variant with no extra span filter. Wrap the variant in `toString(...)` when grouping (a `Dynamic` value cannot be a `GROUP BY` key), and use `COUNT(DISTINCT run_id)` for run counts (one run can emit several score steps):
 

--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/summarizer/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/summarizer/system.md
@@ -33,7 +33,7 @@ Follow these steps to create your summary:
 1. **Analyze the SQL components** to understand what data is being retrieved. Look for:
 
    - **The Metric (SELECT clause):** What is being calculated? Is it counting events, summing a value (like revenue), averaging a duration, or something else?
-   - **The Subject (WHERE clause):** Which specific event names are being queried? Look for event name filters like `name = 'user_signup'` or `name = 'checkout_error'`.
+   - **The Subject (WHERE/filter clause):** What is being filtered on? Depending on the table this may be specific event names (`name = 'user_signup'`), run or step status (`status = 'Failed'`), step types, a named score, or an experiment variant — not only event names.
    - **The Breakdown (GROUP BY clause):** Is the data being segmented or grouped? For example, by browser, by country, by time period, etc.
    - **The Scope (WHERE constraints):** Are there time range filters or other conditions? For example, "last 7 days" or "where status equals failed".
 
@@ -45,7 +45,7 @@ Your summary must follow these requirements:
 
 - **Use natural, non-technical language:** Never use SQL terminology like "clause," "wildcard," "string," "function," "SELECT," "WHERE," or "GROUP BY." Instead use phrases like "calculates the total volume," "broken down by," "over the last 7 days," etc.
 
-- **Be specific about event names:** Always mention the specific event names found in the query, and use single quotes around them (e.g., 'signup', 'purchase', 'login_failed').
+- **Be specific about the subject:** Always mention what the query is about — event names, run/step status, step types, score names, or experiment variants — and use single quotes around named values (e.g., 'signup', 'Failed', 'accuracy').
 
 - **Focus on business value:** Explain what question the query answers, not how the SQL is structured.
 
@@ -65,14 +65,14 @@ Analyze the query components:
 
 - **SELECT clause:** Quote the clause and identify what metric is being calculated
 - **FROM clause:** Identify the table(s)
-- **WHERE conditions:** List each event name and filter explicitly
+- **WHERE conditions:** List each filter explicitly (event names, status, step type, score, experiment, etc.)
 - **GROUP BY clause:** Identify what breakdown dimension is used (if any)
 - **Time filters:** Note any time constraints or other scope limitations
 
 **Synthesis:**
 
 - Metric: [what is being measured]
-- Subject: [which events]
+- Subject: [what the query is about — events, run/step status, step type, score, or experiment]
 - Breakdown: [grouping dimension, if any]
 - Scope: [time range and filters]
 
@@ -84,7 +84,7 @@ This section may be detailed as needed.
 
 Write your final natural language summary here. Your summary should follow this pattern:
 
-> This query [describes the metric] from [specific event name(s)] [any breakdown/grouping] [any scope/filters].
+> This query [describes the metric] from [the subject — event name(s), runs, steps, scores, or an experiment] [any breakdown/grouping] [any scope/filters].
 
 **Examples:**
 
@@ -93,3 +93,7 @@ Write your final natural language summary here. Your summary should follow this 
 > This query sums the 'revenue' value from 'purchase' events, broken down by the country field.
 
 > This query analyzes 'page_view' events and ranks the most common browser types.
+
+> This query counts the function runs that failed over the last 24 hours.
+
+> This query compares the average 'accuracy' score across the variants of an experiment.


### PR DESCRIPTION
## Description

Updated Insights AI to be more schema aware. The updates improve:
- query generation for non-`events` tables `runs`, `steps`, `step_attempts` and `extended_trace_spans`.
- Added system prompt instructions for writing score and experiment queries

## Release note

Fixes and improvements for Insights AI

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
