### PR TITLE
fix(cron): Set envid on health check resync path

### DIFF
--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -935,7 +935,7 @@ func (s *svc) handleCronHealthCheck(ctx context.Context, item queue.Item) error 
 		_ = json.Unmarshal([]byte(cqrsFn.Config), &fn)
 
 		accountID := consts.DevServerAccountID
-		envID := cqrsFn.EnvID
+		envID := consts.DevServerEnvID
 		appID := cqrsFn.AppID
 
 		for _, cronExpr := range fn.ScheduleExpressions() {

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -1033,7 +1033,7 @@ func (s *svc) handleCron(ctx context.Context, item queue.Item) error {
 	fn, err := s.data.GetFunctionByInternalUUID(ctx, ci.FunctionID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			l.Info("Breaking cron cycle, function does not exist")
+			l.Debug("Breaking cron cycle, function does not exist")
 			// function doesn't exist, no action needed
 			return nil
 		}
@@ -1041,7 +1041,7 @@ func (s *svc) handleCron(ctx context.Context, item queue.Item) error {
 	}
 	// function is archived/deleted, so don't do anything
 	if fn.IsArchived() {
-		l.Info("Breaking cron cycle, function is archived")
+		l.Debug("Breaking cron cycle, function is archived")
 		return nil
 	}
 
@@ -1051,13 +1051,13 @@ func (s *svc) handleCron(ctx context.Context, item queue.Item) error {
 		return fmt.Errorf("error converting function to config: %w", err)
 	}
 	if conf.FunctionVersion > ci.FunctionVersion {
-		l.Info("Breaking cron cycle, function version was upgraded")
+		l.Debug("Breaking cron cycle, function version was upgraded")
 		return nil
 	}
 
 	// ensure that the function has the same cron expression.
 	if !conf.HasCronExpression(ci.Expression) {
-		l.Info("Breaking cron cycle, cron trigger no longer exists")
+		l.Debug("Breaking cron cycle, cron trigger no longer exists")
 		return nil
 	}
 


### PR DESCRIPTION
## Description

Set envid on health check resync path to the [same ID we use when we start the cron cycle](https://github.com/inngest/inngest/blob/17af0d8bec6277d1955e96de05c28da111295c91/pkg/execution/runner/runner.go#L277) after app re-syncs

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
fix(cron): Set CronItem.EnvID on health check triggered cron syncs

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
