### PR TITLE
internal: Make our metadata parsing of Vercel AI SDK spans more robust (EXE-1963)

### DIFF
--- a/pkg/tracing/metadata/extractors/attributes.go
+++ b/pkg/tracing/metadata/extractors/attributes.go
@@ -127,12 +127,15 @@ var keyFieldMap = map[string]attrMapping{
 	// ---------------------------------------------------------------------------
 	// Vercel AI SDK (native telemetry, `ai.*`)
 	// ---------------------------------------------------------------------------
-	// The AI SDK emits its own spans. A call produces a parent ai.<op> span
-	// (ai.* only) plus a child ai.<op>.do<Op> span that ALSO carries a partial
-	// gen_ai.* set. vercel ranks below semconv/openinference so gen_ai.* stays
-	// authoritative on the child where both are present (their values agree);
-	// these mappings are what make the ai.*-only parent and embeddings spans
-	// extractable, and they supply ai.usage.totalTokens (gen_ai omits a total).
+	// The Vercel AI SDK emits its own spans. A call produces an outer ai.<op> span
+	// (ai.* only) plus an inner ai.<op>.do<Op> span that ALSO carries a partial
+	// gen_ai.* set; the ai.* usage values are duplicated on both.
+	//
+	// For most Vercel spans, we only use gen_ai.* attributes and ignore ai.*
+	// attributes to avoid double counting when we aggregate.
+	//
+	// However, Vercel's embedding spans lack any gen_ai.* attributes. For this
+	// special case, we do parse ai.* attributes.
 	"ai.model.id": {
 		field:      "model",
 		convention: vercel,
@@ -330,6 +333,26 @@ func extractAIMetadataFromAttributes(attributes []*v1.KeyValue, md *AIMetadata) 
 
 	potentialAttrs := map[string][]parsedAttr{}
 
+	// The Vercel AI SDK emits its own spans. A call produces an outer ai.<op> span
+	// (ai.* only) plus an inner ai.<op>.do<Op> span that ALSO carries a partial
+	// gen_ai.* set; the ai.* usage values are duplicated on both.
+	//
+	// For most Vercel spans, we only use gen_ai.* attributes and ignore ai.*
+	// attributes to avoid double counting when we aggregate.
+	//
+	// However, Vercel's embedding spans lack any gen_ai.* attributes. For this
+	// special case, we do parse ai.* attributes.
+	//
+	// We parse only the inner embed to avoid double counting.
+	isVercelEmbedInner := false
+	for _, attr := range attributes {
+		if attr.Key == "ai.operationId" &&
+			attr.Value.GetStringValue() == "ai.embed.doEmbed" {
+			isVercelEmbedInner = true
+			break
+		}
+	}
+
 	// addAttr records a matched attribute as a candidate for its canonical field.
 	addAttr := func(m attrMapping, value *v1.AnyValue) {
 		potentialAttrs[m.field] = append(
@@ -345,6 +368,11 @@ func extractAIMetadataFromAttributes(attributes []*v1.KeyValue, md *AIMetadata) 
 	for _, attr := range attributes {
 		mapping, ok := keyFieldMap[attr.Key]
 		if !ok {
+			continue
+		}
+
+		// Honor vercel ai.* keys only on the inner embeddings span (see above).
+		if mapping.convention == vercel && !isVercelEmbedInner {
 			continue
 		}
 

--- a/pkg/tracing/metadata/extractors/attributes.go
+++ b/pkg/tracing/metadata/extractors/attributes.go
@@ -3,7 +3,6 @@ package extractors
 import (
 	"cmp"
 	"encoding/json"
-	"regexp"
 	"slices"
 
 	"github.com/inngest/inngest/pkg/util"
@@ -296,41 +295,7 @@ func compareByRank(a, b parsedAttr) int {
 	)
 }
 
-// vercelProviderCallSegment matches the `.do<Op>` segment (e.g. `.doGenerate`,
-// `.doStream`, `.doEmbed`) that the Vercel AI SDK appends to the provider-call
-// (leaf) span's operationId. The framework rollup span lacks this segment.
-//
-// @see https://ai-sdk.dev/docs/ai-sdk-core/telemetry
-var vercelProviderCallSegment = regexp.MustCompile(`\.do[A-Z]`)
-
-// isVercelRollupSpan reports whether the span is a Vercel AI SDK framework
-// rollup (wrapper) span.
-//
-// The Vercel AI SDK emits a span *tree*: a framework rollup span
-// (`ai.generateText`) whose children are the provider-call (leaf) spans
-// (`ai.generateText.doGenerate`). Both carry overlapping usage data, so
-// extracting from both would double count. We choose to skip the rollup span.
-//
-// Only Vercel AI SDK spans carry `ai.operationId`; among them, the
-// provider-call leaf has a `.do*` segment and the rollup does not.
-func isVercelRollupSpan(attributes []*v1.KeyValue) bool {
-	for _, attr := range attributes {
-		if attr.Key != "ai.operationId" {
-			continue
-		}
-		op := attr.Value.GetStringValue()
-		return op != "" && !vercelProviderCallSegment.MatchString(op)
-	}
-	return false
-}
-
 func extractAIMetadataFromAttributes(attributes []*v1.KeyValue, md *AIMetadata) (foundAny bool) {
-	// The Vercel AI SDK's rollup span duplicates its provider-call child's
-	// usage; skip it to avoid double counting.
-	if isVercelRollupSpan(attributes) {
-		return false
-	}
-
 	potentialAttrs := map[string][]parsedAttr{}
 
 	// The Vercel AI SDK emits its own spans. A call produces an outer ai.<op> span

--- a/pkg/tracing/metadata/extractors/attributes_test.go
+++ b/pkg/tracing/metadata/extractors/attributes_test.go
@@ -116,32 +116,3 @@ func TestLangfusePrecedenceAndUsageExpansion(t *testing.T) {
 		}
 	}
 }
-
-// TestSkipsVercelRollupSpan verifies that the Vercel AI SDK's framework rollup
-// span (e.g. `ai.generateText`) extracts to nothing so its `ai.usage.*` isn't
-// double-counted against its provider-call child (`ai.generateText.doGenerate`),
-// which carries the same usage and the documented `.do*` segment.
-func TestSkipsVercelRollupSpan(t *testing.T) {
-	t.Parallel()
-
-	// The rollup span (no `.do*` segment) is skipped entirely.
-	rollup := []*v1.KeyValue{
-		strAttr("ai.operationId", "ai.generateText"),
-		strAttr("ai.model.id", "gpt-4.1-nano"),
-		intAttr("ai.usage.inputTokens", 17),
-	}
-	var rollupMd AIMetadata
-	assert.False(t, extractAIMetadataFromAttributes(rollup, &rollupMd))
-	assert.Equal(t, AIMetadata{}, rollupMd)
-
-	// The provider-call (leaf) span is still extracted normally.
-	leaf := []*v1.KeyValue{
-		strAttr("ai.operationId", "ai.generateText.doGenerate"),
-		strAttr("ai.model.id", "gpt-4.1-nano"),
-		intAttr("ai.usage.inputTokens", 17),
-	}
-	var leafMd AIMetadata
-	assert.True(t, extractAIMetadataFromAttributes(leaf, &leafMd))
-	assert.Equal(t, "gpt-4.1-nano", leafMd.Model)
-	assert.Equal(t, int64(17), leafMd.InputTokens)
-}


### PR DESCRIPTION
## Description

- We had a problem where we were double counting Vercel AI SDK spans by counting their parent and child spans. We created a fix in https://github.com/inngest/inngest/pull/4399 by parsing them only if their operationId contained ".id"
- This is a rather brittle fix, as we discussed in https://inngest.slack.com/archives/C0AFJB68X99/p1781530008585629
- In this PR, I switch approaches. Vercel AI SDK child spans (not parents) contain standard gen_ai.* that we can use to power our metadata. 
- This presents a nicely simple solution - however Vercel embedding parent and child calls lack any gen_ai.* attributes. Thus we add a special case where we only consider Vercel's ai.* attributes if the operationId is `ai.embed.doEmbed`. We unfortunately retain most of our complexity, but we are more robust for Vercel and their future changes. 

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
