### PR TITLE
fix(state): preserve large integer precision in step output round-trip (closes #4058)

### DIFF
--- a/pkg/execution/executor/reconstruct.go
+++ b/pkg/execution/executor/reconstruct.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -109,7 +110,12 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 		}
 
 		var data any
-		_ = json.Unmarshal(output.Data, &data)
+		// Decode with UseNumber so large integers in step output (e.g.
+		// snowflake IDs) survive the reconstruct path without being
+		// truncated through float64. Same gap as #4058 in redis_state.Load.
+		dec := json.NewDecoder(bytes.NewReader(output.Data))
+		dec.UseNumber()
+		_ = dec.Decode(&data)
 
 		memoizedStep := state.MemoizedStep{
 			ID:   stepID,

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -877,7 +877,14 @@ func (m shardedMgr) Load(ctx context.Context, accountId uuid.UUID, runID ulid.UL
 
 	for stepID, marshalled := range rmap {
 		var data any
-		err = json.Unmarshal([]byte(marshalled), &data)
+		// Decode with UseNumber so JSON integers larger than 2^53 (e.g.
+		// snowflake IDs) survive the round-trip back to the SDK. Without
+		// UseNumber, json.Unmarshal decodes JSON numbers into the `any`
+		// bucket as float64, which silently truncates the bottom digits
+		// of large integers (see https://github.com/inngest/inngest/issues/4058).
+		dec := json.NewDecoder(strings.NewReader(marshalled))
+		dec.UseNumber()
+		err = dec.Decode(&data)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal step \"%s\" with data \"%s\"; %w", stepID, marshalled, err)
 		}

--- a/pkg/execution/state/redis_state/redis_state_test.go
+++ b/pkg/execution/state/redis_state/redis_state_test.go
@@ -1029,3 +1029,84 @@ func BenchmarkNew(b *testing.B) {
 	}
 
 }
+
+// TestLoadPreservesLargeIntegerStepOutput pins the fix for
+// https://github.com/inngest/inngest/issues/4058: when a step returns an
+// integer larger than 2^53 (e.g. a snowflake ID), reloading the state must
+// not silently truncate the trailing digits via float64.
+//
+// Before the fix, Load unmarshalled the action's raw JSON into `var data any`,
+// which decodes JSON numbers as float64 — losing precision past ~15-16 digits.
+// The fix decodes with json.Number so the integer survives round-trip.
+func TestLoadPreservesLargeIntegerStepOutput(t *testing.T) {
+	ctx := context.Background()
+
+	_, rc := initRedis(t)
+	defer rc.Close()
+
+	unshardedClient := NewUnshardedClient(rc, StateDefaultKey, QueueDefaultKey)
+	shardedClient := NewShardedClient(ShardedClientOpts{
+		UnshardedClient:        unshardedClient,
+		FunctionRunStateClient: rc,
+		BatchClient:            rc,
+		StateDefaultKey:        StateDefaultKey,
+		QueueDefaultKey:        QueueDefaultKey,
+		FnRunIsSharded:         AlwaysShardOnRun,
+	})
+
+	pauseStore := NewPauseStore(unshardedClient)
+
+	sm, err := New(
+		ctx,
+		WithShardedClient(shardedClient),
+		WithPauseDeleter(pauseStore),
+	)
+	require.NoError(t, err)
+
+	mgr := sm.(*mgr)
+
+	acctID, wsID, appID, fnID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	runID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+	id := state.Identifier{
+		AccountID:   acctID,
+		WorkspaceID: wsID,
+		AppID:       appID,
+		WorkflowID:  fnID,
+		RunID:       runID,
+	}
+
+	_, err = mgr.New(ctx, state.Input{
+		Identifier:     id,
+		EventBatchData: []map[string]any{{"test": "event"}},
+	})
+	require.NoError(t, err)
+
+	// Snowflake-style ID: > 2^53 (~9.0e15) where float64 loses integer precision.
+	// Float64 round-trip of this value is 616581622363398100 (last two digits drop to zero).
+	const snowflakeID uint64 = 616581622363398142
+
+	// SaveResponse stores the raw marshalled JSON in Redis hash. Stripping the
+	// SDK envelope so the action value is a bare JSON number — that's the shape
+	// step.Run produces for a scalar return type.
+	raw := strconv.FormatUint(snowflakeID, 10)
+	_, err = mgr.shardedMgr.SaveResponse(ctx, id, "snowflake-step", raw)
+	require.NoError(t, err)
+
+	loaded, err := mgr.shardedMgr.Load(ctx, acctID, runID)
+	require.NoError(t, err)
+
+	actionData, ok := loaded.Actions()["snowflake-step"]
+	require.True(t, ok, "expected snowflake-step in Load() actions")
+
+	// Re-marshalling Data is what eventually happens when state is shipped
+	// back to the SDK as part of the next invocation payload. That's the
+	// surface where precision loss would become observable to user code.
+	out, mErr := json.Marshal(actionData)
+	require.NoError(t, mErr)
+	assert.Equal(t, raw, string(out),
+		"large integer step output must round-trip losslessly; "+
+			"got %q, want %q", string(out), raw)
+
+	require.NoError(t, mgr.Delete(ctx, id))
+}

--- a/pkg/execution/state/testharness/testharness.go
+++ b/pkg/execution/state/testharness/testharness.go
@@ -311,10 +311,14 @@ func checkSaveResponse_output(t *testing.T, m state.Manager) {
 	ctx := context.Background()
 	s := setup(t, m)
 
+	// Numeric fixtures use json.Number so the load-side round-trip (which now
+	// decodes with json.Decoder.UseNumber to preserve large-integer precision,
+	// see #4058) deep-equals the input. The JSON wire form is identical to
+	// float64(200) because json.Number marshals as its raw digit string.
 	r := state.DriverResponse{
 		Step: w.Steps[0],
 		Output: map[string]interface{}{
-			"status": float64(200),
+			"status": json.Number("200"),
 			"body": map[string]any{
 				"ok": true,
 			},
@@ -356,10 +360,10 @@ func checkSaveResponse_output(t *testing.T, m state.Manager) {
 			ID: anotherStepID,
 		},
 		Output: map[string]interface{}{
-			"status": float64(200),
+			"status": json.Number("200"),
 			"body": map[string]any{
 				"another": "yea",
-				"lol":     float64(1),
+				"lol":     json.Number("1"),
 			},
 		},
 	}
@@ -403,7 +407,7 @@ func checkSaveResponse_stack(t *testing.T, m state.Manager) {
 	s := setup(t, m)
 
 	output := map[string]interface{}{
-		"status": float64(200),
+		"status": json.Number("200"),
 		"body": map[string]any{
 			"ok": true,
 		},


### PR DESCRIPTION
## Description

Closes #4058. \`step.Run\` returning an integer larger than 2^53 (e.g. a snowflake ID) silently came back to the next invocation with the bottom digits zeroed: the reporter saw \`616581622363398142\` go in and \`616581622363398100\` come out.

### Root cause

Two server-side load paths materialize stored step output by decoding the JSON into \`var data any\`:

\`\`\`go
var data any
err = json.Unmarshal([]byte(marshalled), &data)
\`\`\`

Go's \`encoding/json\` decodes JSON numbers into the \`any\` bucket as \`float64\`. \`float64\` can only safely represent integers up to 2^53 ≈ 9.0e15. The reporter's value (6.17e17) is past that boundary, so the decode loses the bottom digits and the subsequent re-marshal emits the truncated value.

\`MemoizedStep.Data\` is typed \`any\`, which gives us a choice of decoded representation. Switching the decoder to \`json.NewDecoder(...).UseNumber()\` lands JSON numbers in the \`any\` bucket as \`json.Number\` (a string-backed type). On re-marshal, \`json.Number\` emits its original digit string, so round-trip is lossless.

### Why \`UseNumber\` is safe here

Verified that no production caller of \`state.State.Actions()\` type-asserts a numeric value as \`float64\`:

\`\`\`
$ grep -rn '\.Actions()\[' pkg --include=*.go | grep -v _test.go
pkg/execution/state/state_instance.go:95:  data, hasAction := s.Actions()[id]
pkg/execution/state/state_instance.go:104: _, hasAction := s.Actions()[id]
\`\`\`

Both call sites just check for presence and pass the value through. The only callers that index into nested keys are test fixtures, updated below.

### Changes

- **\`pkg/execution/state/redis_state/redis_state.go\`** — \`shardedMgr.Load\` now uses \`UseNumber\` when decoding action outputs from the Redis hash. The sibling action-input branch already uses \`json.RawMessage\` and is unaffected.
- **\`pkg/execution/executor/reconstruct.go\`** — same fix on the reconstruct path that materializes step state from spans. Same lossy \`var data any\` + \`json.Unmarshal\` pattern.
- **\`pkg/execution/state/redis_state/redis_state_test.go\`** — new \`TestLoadPreservesLargeIntegerStepOutput\` that saves a \`uint64\` snowflake ID via \`SaveResponse\`, reloads via \`Load\`, re-marshals the action data, and asserts the bytes equal the original. Fails on unpatched source with the exact symptom from #4058 (\`616581622363398100\` vs \`616581622363398142\`).
- **\`pkg/execution/state/testharness/testharness.go\`** — numeric fixtures in \`checkSaveResponse_output\` and \`checkSaveResponse_stack\` switch from \`float64(N)\` to \`json.Number(\"N\")\` so the post-fix \`Load\` result deep-equals the fixture. The JSON wire form is identical; this is a test-shape change, not a behavior change.

### Verification

\`\`\`
$ go test ./pkg/execution/state/redis_state/ -run \"TestLoadPreservesLargeIntegerStepOutput|TestStateHarness\" -count=1
ok    github.com/inngest/inngest/pkg/execution/state/redis_state    2.342s

$ go test ./pkg/execution/executor/ -run \"TestReconstruct|TestSchedule\" -count=1
ok    github.com/inngest/inngest/pkg/execution/executor    0.789s
\`\`\`

Confirmed the new regression fails on unpatched source:
\`\`\`
expected: \"616581622363398142\"
actual  : \"616581622363398100\"
\`\`\`

## Release note

Fix silent integer truncation for step outputs larger than 2^53 (e.g. snowflake IDs). Step outputs now round-trip losslessly through state storage.

## Migration note

None. The wire format and the public \`State.Actions()\` API are unchanged. Existing consumers that previously received \`float64\` values for small integers will continue to function — \`json.Number\` and \`float64\` both marshal back to the same JSON. Only consumers that internally cast \`Actions()[step].(float64)\` would observe a behavior change, and a code scan shows no such callers in this repo.