### PR TITLE
feat(cron): support custom partition queue names

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -430,9 +430,7 @@ func start(ctx context.Context, opts StartOpts) error {
 	if err != nil {
 		return fmt.Errorf("could not create debounce manager: %w", err)
 	}
-	croner := cron.NewManager(queueShard, rq, l, cron.WithSplitCronPartitionByWorkspace(func(_ context.Context, _ uuid.UUID) bool {
-		return true
-	}))
+	croner := cron.NewManager(queueShard, rq, l)
 
 	sn := singleton.New(ctx, shardRegistry)
 

--- a/pkg/execution/cron/manager.go
+++ b/pkg/execution/cron/manager.go
@@ -46,10 +46,15 @@ type managerOpt struct {
 	healthCheckLeadTimeSeconds int
 	healthCheckInterval        time.Duration
 
-	// splitCronPartitionByWorkspace, when non-nil and returning true for a
-	// given accountID, causes ScheduleNext to enqueue cron jobs to a
-	// workspace-scoped system partition rather than the shared cron partition.
-	splitCronPartitionByWorkspace func(ctx context.Context, accountID uuid.UUID) (enable bool)
+	// splitGlobalCronPartition, when non-nil and returning true for a
+	// given accountID, allows ScheduleNext to use queueNameForCronItem
+	// rather than the shared global cron partition.
+	splitGlobalCronPartition func(ctx context.Context, accountID uuid.UUID) (enable bool)
+
+	// queueNameForCronItem returns the queue name to use when
+	// splitGlobalCronPartition is enabled. If nil or empty, ScheduleNext
+	// falls back to the shared cron partition.
+	queueNameForCronItem func(ctx context.Context, item CronItem) (queueName string)
 }
 
 func (opts *managerOpt) validate() {
@@ -108,12 +113,21 @@ func WithHealthCheckLeadTimeSeconds(leadTime int) ManagerOpt {
 	}
 }
 
-// WithSplitCronPartitionByWorkspace registers a gate that controls whether
-// cron jobs are enqueued to a workspace-scoped system partition
-// (queue.KindCron:<workspaceID>) instead of the single shared cron partition.
-func WithSplitCronPartitionByWorkspace(fn func(ctx context.Context, accountID uuid.UUID) (enable bool)) ManagerOpt {
+// WithsplitGlobalCronPartition registers a gate that controls whether
+// cron jobs can be enqueued to a custom cron partition instead of the single
+// shared cron partition.
+func WithSplitGlobalCronPartition(fn func(ctx context.Context, accountID uuid.UUID) (enable bool)) ManagerOpt {
 	return func(c *managerOpt) {
-		c.splitCronPartitionByWorkspace = fn
+		c.splitGlobalCronPartition = fn
+	}
+}
+
+// WithQueueNameForCronItem registers a queue-name resolver used when
+// WithsplitGlobalCronPartition is enabled for the account. The resolver
+// receives the cron item and must return the full queue name to enqueue to.
+func WithQueueNameForCronItem(fn func(ctx context.Context, item CronItem) (queueName string)) ManagerOpt {
+	return func(c *managerOpt) {
+		c.queueNameForCronItem = fn
 	}
 }
 
@@ -359,9 +373,12 @@ func (c *manager) ScheduleNext(ctx context.Context, ci CronItem) (*CronItem, err
 
 	// enqueue new schedule
 	maxAttempts := consts.MaxRetries + 1
+	// kind here is "cron", and a queueName of "cron" is the global cron partition for all cron items.
 	queueName := kind
-	if c.opt.splitCronPartitionByWorkspace != nil && c.opt.splitCronPartitionByWorkspace(ctx, ci.AccountID) {
-		queueName = fmt.Sprintf("%s:%s", queue.KindCron, ci.WorkspaceID)
+	if c.opt.splitGlobalCronPartition != nil && c.opt.splitGlobalCronPartition(ctx, ci.AccountID) && c.opt.queueNameForCronItem != nil {
+		if resolved := c.opt.queueNameForCronItem(ctx, nextItem); resolved != "" {
+			queueName = resolved
+		}
 	}
 
 	err = c.q.Enqueue(ctx, queue.Item{

--- a/pkg/execution/cron/manager_test.go
+++ b/pkg/execution/cron/manager_test.go
@@ -151,13 +151,26 @@ func TestOptions(t *testing.T) {
 		assert.Equal(t, 0, opt.healthCheckLeadTimeSeconds)
 	})
 
-	t.Run("WithSplitCronPartitionByWorkspace sets callback", func(t *testing.T) {
+	t.Run("WithSplitGlobalCronPartition sets callback", func(t *testing.T) {
 		opt := managerOpt{}
-		WithSplitCronPartitionByWorkspace(func(context.Context, uuid.UUID) bool {
+		WithSplitGlobalCronPartition(func(context.Context, uuid.UUID) bool {
 			return true
 		})(&opt)
 
-		require.NotNil(t, opt.splitCronPartitionByWorkspace)
+		require.NotNil(t, opt.splitGlobalCronPartition)
+		require.True(t, opt.splitGlobalCronPartition(context.Background(), uuid.New()))
+	})
+
+	t.Run("WithQueueNameForCronItem sets callback", func(t *testing.T) {
+		opt := managerOpt{}
+		WithQueueNameForCronItem(func(context.Context, CronItem) string {
+			return "hello"
+		})(&opt)
+
+		require.NotNil(t, opt.queueNameForCronItem)
+		var ci CronItem
+		require.Equal(t, "hello", opt.queueNameForCronItem(context.Background(), ci))
+
 	})
 
 	t.Run("validate options", func(t *testing.T) {
@@ -683,31 +696,52 @@ func TestScheduleNextQueueName(t *testing.T) {
 	functionID := uuid.New()
 
 	tests := []struct {
-		name      string
-		gate      func(context.Context, uuid.UUID) bool
-		queueName string
+		name              string
+		gate              func(context.Context, uuid.UUID) bool
+		queueNameResolver func(context.Context, CronItem) string
+		expectedQueueName string
 	}{
 		{
-			name:      "flag gate unset",
-			queueName: queue.KindCron,
+			name:              "flag gate unset",
+			expectedQueueName: queue.KindCron,
 		}, {
-			name:      "flag gate nil",
-			gate:      nil,
-			queueName: queue.KindCron,
+			name:              "flag gate nil",
+			gate:              nil,
+			expectedQueueName: queue.KindCron,
 		},
 		{
-			name: "workspace scoped cron partition disabled",
+			name: "flag gate disabled",
 			gate: func(_ context.Context, acctID uuid.UUID) bool {
 				return false
 			},
-			queueName: queue.KindCron,
+			expectedQueueName: queue.KindCron,
 		},
 		{
-			name: "workspace scoped cron partition enabled",
+			name: "flag gate enabled without custom queue name",
 			gate: func(_ context.Context, acctID uuid.UUID) bool {
 				return true
 			},
-			queueName: queue.KindCron + ":" + workspaceID.String(),
+			expectedQueueName: queue.KindCron,
+		},
+		{
+			name: "flag gate enabled with empty custom queue name",
+			gate: func(_ context.Context, acctID uuid.UUID) bool {
+				return true
+			},
+			queueNameResolver: func(context.Context, CronItem) string {
+				return ""
+			},
+			expectedQueueName: queue.KindCron,
+		},
+		{
+			name: "flag gate enabled with custom queue name",
+			gate: func(_ context.Context, acctID uuid.UUID) bool {
+				return true
+			},
+			queueNameResolver: func(_ context.Context, item CronItem) string {
+				return "cron:lol:0"
+			},
+			expectedQueueName: "cron:lol:0",
 		},
 	}
 
@@ -718,7 +752,10 @@ func TestScheduleNextQueueName(t *testing.T) {
 				WithJitterRange(0, 0),
 			}
 			if tt.gate != nil {
-				opts = append(opts, WithSplitCronPartitionByWorkspace(tt.gate))
+				opts = append(opts, WithSplitGlobalCronPartition(tt.gate))
+			}
+			if tt.queueNameResolver != nil {
+				opts = append(opts, WithQueueNameForCronItem(tt.queueNameResolver))
 			}
 			mgr := NewManager(nil, producer, logger.StdlibLogger(ctx), opts...)
 
@@ -734,7 +771,7 @@ func TestScheduleNextQueueName(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, producer.item.QueueName)
-			require.Equal(t, tt.queueName, *producer.item.QueueName)
+			require.Equal(t, tt.expectedQueueName, *producer.item.QueueName)
 			require.Equal(t, queue.KindCron, producer.item.Kind)
 		})
 	}


### PR DESCRIPTION
## Description

Add support for custom partition queue names.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
