### PR TITLE
internal: Remove constraint api CI test dimension

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -57,10 +57,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         experimentalKeyQueues: [false, true]
-        enableConstraintAPI: [false, true]
         database: [sqlite, postgres]
     runs-on: ${{ matrix.os }}
-    name: "Test / OS: ${{ matrix.os }}, key-queues: ${{ matrix.experimentalKeyQueues }}, constraint-api: ${{ matrix.enableConstraintAPI }}, db: ${{ matrix.database }}"
+    name: "Test / OS: ${{ matrix.os }}, key-queues: ${{ matrix.experimentalKeyQueues }}, db: ${{ matrix.database }}"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -77,7 +76,6 @@ jobs:
         env:
           TEST_MODE: true
           EXPERIMENTAL_KEY_QUEUES_ENABLE: "${{ matrix.experimentalKeyQueues }}"
-          ENABLE_CONSTRAINT_API: "${{ matrix.enableConstraintAPI }}"
           TEST_DATABASE: "${{ matrix.database }}"
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
## Description

- In CI, we have a test matrix that runs a test set under multiple conditions, such as sqlite vs postgres
- We have a matrix dimension for the constraint API, yet the constraint api is always on and nothing seems to read the ENABLE_CONSTRAINT_API env var
- Let's disable this and remove 4 test jobs (2 x 2 x 2 => 2 x 2)

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
