### PR TITLE
internal: Add a Anthropic AI Metadata test case (EXE-1837)

### DIFF
--- a/pkg/tracing/metadata/extractors/testdata/README.md
+++ b/pkg/tracing/metadata/extractors/testdata/README.md
@@ -1,10 +1,10 @@
 # AI metadata OTLP fixtures
 
 Real OTLP/JSON `ExportTraceServiceRequest` payloads captured from instrumented
-OpenAI SDK calls, one directory per instrumentation. Each directory holds one
-fixture per call variant (`params_chat`, `tools_chat`, `stream_chat`,
-`basic_responses`, `reasoning_responses`, `embeddings`) where the
-instrumentation emits a span for it.
+AI SDK calls, one directory per instrumentation. Each directory holds one
+fixture per call variant (OpenAI: `params_chat`, `tools_chat`, `stream_chat`,
+`basic_responses`, `reasoning_responses`, `embeddings`; Anthropic:
+`reasoning_messages`) where the instrumentation emits a span for it.
 
 `TestAIMetadataExtractor_CapturedFixtures` extracts `AIMetadata` from every
 span of every fixture and asserts against the `<fixture>.out` golden file
@@ -71,3 +71,15 @@ The Responses API variants omit finish reasons entirely. No embeddings or
 stream_chat fixtures: `wrapOpenAI` (langsmith 0.7.3) wraps neither
 `embeddings.create` nor streaming chat completions, so those variants emit no
 span.
+
+### anthropic_otel_traceloop — `@traceloop/instrumentation-anthropic`
+
+Anthropic Messages API (`messages.create`), `gen_ai.*` attributes, one span per
+call. Like the OpenAI Traceloop emitter it uses the current
+`gen_ai.provider.name` (`anthropic`) and emits `gen_ai.usage.total_tokens`
+directly (not derived). `response_id` is empty — the instrumentation emits no
+`gen_ai.response.id`. The single `reasoning_messages` fixture uses adaptive
+extended thinking: Anthropic has no separate reasoning-token field, so thinking
+folds into `output_tokens` (hence the large count); the thinking text is carried
+as a `reasoning` part inside `gen_ai.output.messages`, which the extractor does
+not map.

--- a/pkg/tracing/metadata/extractors/testdata/anthropic_otel_traceloop/reasoning_messages.otlp.json
+++ b/pkg/tracing/metadata/extractors/testdata/anthropic_otel_traceloop/reasoning_messages.otlp.json
@@ -1,0 +1,148 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "unknown_service:node"
+            }
+          },
+          {
+            "key": "telemetry.sdk.language",
+            "value": {
+              "stringValue": "nodejs"
+            }
+          },
+          {
+            "key": "telemetry.sdk.name",
+            "value": {
+              "stringValue": "opentelemetry"
+            }
+          },
+          {
+            "key": "telemetry.sdk.version",
+            "value": {
+              "stringValue": "2.8.0"
+            }
+          }
+        ],
+        "droppedAttributesCount": 0
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "@traceloop/instrumentation-anthropic",
+            "version": "0.27.0"
+          },
+          "spans": [
+            {
+              "traceId": "f69e04513cc76197fff7206b8cf9209f",
+              "spanId": "dfcd00d601e4ccf3",
+              "name": "chat claude-sonnet-4-6",
+              "kind": 3,
+              "startTimeUnixNano": "1781567313401000000",
+              "endTimeUnixNano": "1781567320707424750",
+              "attributes": [
+                {
+                  "key": "gen_ai.provider.name",
+                  "value": {
+                    "stringValue": "anthropic"
+                  }
+                },
+                {
+                  "key": "gen_ai.operation.name",
+                  "value": {
+                    "stringValue": "chat"
+                  }
+                },
+                {
+                  "key": "gen_ai.request.model",
+                  "value": {
+                    "stringValue": "claude-sonnet-4-6"
+                  }
+                },
+                {
+                  "key": "gen_ai.request.max_tokens",
+                  "value": {
+                    "intValue": 4096
+                  }
+                },
+                {
+                  "key": "gen_ai.input.messages",
+                  "value": {
+                    "stringValue": "[{\"role\":\"user\",\"parts\":[{\"type\":\"text\",\"content\":\"A bat and a ball cost $1.10 in total. The bat costs $1.00 more than the ball. How much does the ball cost? Reason step by step before giving your final answer.\"}]}]"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.model",
+                  "value": {
+                    "stringValue": "claude-sonnet-4-6"
+                  }
+                },
+                {
+                  "key": "gen_ai.response.finish_reasons",
+                  "value": {
+                    "arrayValue": {
+                      "values": [
+                        {
+                          "stringValue": "stop"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.total_tokens",
+                  "value": {
+                    "intValue": 552
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.output_tokens",
+                  "value": {
+                    "intValue": 500
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.input_tokens",
+                  "value": {
+                    "intValue": 52
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.cache_creation.input_tokens",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "gen_ai.usage.cache_read.input_tokens",
+                  "value": {
+                    "intValue": 0
+                  }
+                },
+                {
+                  "key": "gen_ai.output.messages",
+                  "value": {
+                    "stringValue": "[{\"role\":\"assistant\",\"finish_reason\":\"stop\",\"parts\":[{\"type\":\"reasoning\",\"content\":\"Let me denote the cost of the ball as x and the cost of the bat as y.\\n\\nWe have two equations:\\n1. x + y = 1.10\\n2. y = x + 1.00\\n\\nSubstituting equation 2 into equation 1:\\nx + (x + 1.00) = 1.10\\n2x + 1.00 = 1.10\\n2x = 0.10\\nx = 0.05\\n\\nSo the ball costs $0.05. The bat then costs $1.05, and together they total $1.10, which checks out.\"},{\"type\":\"text\",\"content\":\"## Setting Up the Equations\\n\\nLet me define variables:\\n- Let **b** = cost of the ball\\n- Let **bat** = cost of the bat\\n\\n**From the given information:**\\n1. `bat + b = $1.10` (total cost)\\n2. `bat = b + $1.00` (bat costs $1.00 more than the ball)\\n\\n## Solving\\n\\nSubstitute equation 2 into equation 1:\\n\\n`(b + $1.00) + b = $1.10`\\n\\n`2b + $1.00 = $1.10`\\n\\n`2b = $0.10`\\n\\n`b = $0.05`\\n\\n## Verification\\n\\n- Ball = **$0.05**\\n- Bat = $0.05 + $1.00 = **$1.05**\\n- Total = $1.05 + $0.05 = **$1.10** ✓\\n- Difference = $1.05 - $0.05 = **$1.00** ✓\\n\\n## Answer\\n\\nThe ball costs **$0.05 (5 cents)**.\\n\\n> **Note:** The intuitive answer of $0.10 is a common mistake — if the ball were $0.10, the bat would be $1.10, and the total would be $1.20, not $1.10.\"}]}]"
+                  }
+                }
+              ],
+              "droppedAttributesCount": 0,
+              "events": [],
+              "droppedEventsCount": 0,
+              "status": {
+                "code": 0
+              },
+              "links": [],
+              "droppedLinksCount": 0,
+              "flags": 257
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/tracing/metadata/extractors/testdata/anthropic_otel_traceloop/reasoning_messages.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/anthropic_otel_traceloop/reasoning_messages.otlp.json.out
@@ -1,0 +1,14 @@
+SPAN chat claude-sonnet-4-6
+{
+  "model": "claude-sonnet-4-6",
+  "system": "anthropic",
+  "operation_name": "chat",
+  "response_model": "claude-sonnet-4-6",
+  "response_id": "",
+  "finish_reasons": [
+    "stop"
+  ],
+  "input_tokens": 52,
+  "output_tokens": 500,
+  "total_tokens": 552
+}


### PR DESCRIPTION
## Description

- Previously, we created test apps to determine what OTel data instrumenters would emit with OpenAI.
- Let's add one test case for Anthropic, using Traceloop, matching our new instrumentation package

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
