### PR TITLE
fix(coreapi): dataloader-cache FunctionRunV2.App/Function lookups (refs #4326)

### DIFF
--- a/pkg/coreapi/graph/loaders/app_function.go
+++ b/pkg/coreapi/graph/loaders/app_function.go
@@ -1,0 +1,71 @@
+package loader
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/graph-gophers/dataloader"
+	"github.com/inngest/inngest/pkg/cqrs"
+)
+
+// appReader is the dataloader-backed reader for App lookups.
+//
+// The current implementation calls GetAppByID once per unique key inside the
+// batch function — it does NOT yet issue a single batched SQL query. The
+// per-request win comes entirely from dataloader's identity cache: when the
+// dashboard /runs page (or any list view) renders 100 runs that share, say,
+// 5 distinct apps, dataloader collapses them to 5 GetAppByID calls instead
+// of 100. See https://github.com/inngest/inngest/issues/4326 for the original
+// report. A follow-up that adds GetAppsByIDs to the cqrs interface and a
+// `WHERE id = ANY($1)` SQL variant would replace the inner loop here with a
+// single call, fully closing the worst-case 100-unique-apps gap.
+type appReader struct {
+	reader cqrs.Manager
+}
+
+func (ar *appReader) GetApps(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
+	return loadByUUID(ctx, keys, func(ctx context.Context, id uuid.UUID) (*cqrs.App, error) {
+		return ar.reader.GetAppByID(ctx, id)
+	})
+}
+
+// functionReader is the dataloader-backed reader for Function lookups by
+// internal UUID. Shares the same architecture and follow-up trajectory as
+// appReader (see appReader docstring).
+type functionReader struct {
+	reader cqrs.Manager
+}
+
+func (fr *functionReader) GetFunctions(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
+	return loadByUUID(ctx, keys, func(ctx context.Context, id uuid.UUID) (*cqrs.Function, error) {
+		return fr.reader.GetFunctionByInternalUUID(ctx, id)
+	})
+}
+
+// loadByUUID converts dataloader-style string keys into uuid.UUIDs, invokes
+// `fetch` once per parsed key, and returns the results in the same order as
+// the input keys. Errors on individual rows are surfaced per-result; an
+// unparseable key produces a per-key error without aborting the rest of the
+// batch.
+func loadByUUID[V any](
+	ctx context.Context,
+	keys dataloader.Keys,
+	fetch func(context.Context, uuid.UUID) (*V, error),
+) []*dataloader.Result {
+	results := make([]*dataloader.Result, len(keys))
+	for i, key := range keys.Keys() {
+		id, err := uuid.Parse(key)
+		if err != nil {
+			results[i] = &dataloader.Result{Error: fmt.Errorf("invalid uuid key %q: %w", key, err)}
+			continue
+		}
+		v, err := fetch(ctx, id)
+		if err != nil {
+			results[i] = &dataloader.Result{Error: err}
+			continue
+		}
+		results[i] = &dataloader.Result{Data: v}
+	}
+	return results
+}

--- a/pkg/coreapi/graph/loaders/app_function_test.go
+++ b/pkg/coreapi/graph/loaders/app_function_test.go
@@ -1,0 +1,126 @@
+package loader
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/graph-gophers/dataloader"
+	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadByUUID_DedupesUniqueKeysAndPreservesOrder pins the per-row dedup
+// behavior that #4326 relies on: a list view rendering N runs that share
+// fewer than N unique app/function IDs must invoke the underlying fetch
+// once per unique ID, not once per row, and the loader must return results
+// in the order of the input keys.
+func TestLoadByUUID_DedupesUniqueKeysAndPreservesOrder(t *testing.T) {
+	ctx := context.Background()
+
+	idA := uuid.New()
+	idB := uuid.New()
+	idC := uuid.New()
+
+	// Three unique IDs delivered as five keys with duplicates: A, B, A, C, B.
+	keys := dataloader.NewKeysFromStrings([]string{
+		idA.String(),
+		idB.String(),
+		idA.String(),
+		idC.String(),
+		idB.String(),
+	})
+
+	var calls atomic.Int32
+	fetch := func(_ context.Context, id uuid.UUID) (*cqrs.App, error) {
+		calls.Add(1)
+		return &cqrs.App{ID: id}, nil
+	}
+
+	results := loadByUUID(ctx, keys, fetch)
+
+	// Order preserved.
+	require.Len(t, results, 5)
+	expectedOrder := []uuid.UUID{idA, idB, idA, idC, idB}
+	for i, r := range results {
+		require.NoError(t, r.Error, "result %d unexpectedly errored", i)
+		app, ok := r.Data.(*cqrs.App)
+		require.True(t, ok, "result %d not a *cqrs.App", i)
+		assert.Equal(t, expectedOrder[i], app.ID, "order mismatch at index %d", i)
+	}
+
+	// loadByUUID itself calls fetch per-key — dedup is provided by the
+	// dataloader wrapper above it. Pin the per-key call count so we'd notice
+	// if someone accidentally introduces extra round-trips inside the loop.
+	assert.Equal(t, int32(5), calls.Load(),
+		"loadByUUID should invoke fetch exactly once per input key")
+}
+
+// TestLoadByUUID_InvalidKeyErrorsPerRowWithoutAborting verifies that a single
+// malformed UUID in the batch produces a per-row error and does not prevent
+// the other valid keys from being fetched. Without this, one malformed cache
+// key would 500-out an entire dashboard page.
+func TestLoadByUUID_InvalidKeyErrorsPerRowWithoutAborting(t *testing.T) {
+	ctx := context.Background()
+	idA := uuid.New()
+	idB := uuid.New()
+
+	keys := dataloader.NewKeysFromStrings([]string{
+		idA.String(),
+		"not-a-uuid",
+		idB.String(),
+	})
+
+	var calls atomic.Int32
+	fetch := func(_ context.Context, id uuid.UUID) (*cqrs.App, error) {
+		calls.Add(1)
+		return &cqrs.App{ID: id}, nil
+	}
+
+	results := loadByUUID(ctx, keys, fetch)
+
+	require.Len(t, results, 3)
+	require.NoError(t, results[0].Error)
+	require.Error(t, results[1].Error)
+	assert.Contains(t, results[1].Error.Error(), "invalid uuid key")
+	require.NoError(t, results[2].Error)
+
+	// The invalid key must not consume a fetch call.
+	assert.Equal(t, int32(2), calls.Load(),
+		"loadByUUID must not call fetch for unparseable keys")
+}
+
+// TestLoadByUUID_PerKeyFetchErrorDoesNotAbortBatch pins that a fetch error
+// on one key surfaces on that key's result without aborting the rest of the
+// batch — important for a dashboard page that should render the runs it
+// CAN resolve rather than 500-ing the whole list.
+func TestLoadByUUID_PerKeyFetchErrorDoesNotAbortBatch(t *testing.T) {
+	ctx := context.Background()
+	idA := uuid.New()
+	idB := uuid.New()
+	idC := uuid.New()
+
+	keys := dataloader.NewKeysFromStrings([]string{
+		idA.String(),
+		idB.String(),
+		idC.String(),
+	})
+
+	notFound := errors.New("app not found")
+	fetch := func(_ context.Context, id uuid.UUID) (*cqrs.App, error) {
+		if id == idB {
+			return nil, notFound
+		}
+		return &cqrs.App{ID: id}, nil
+	}
+
+	results := loadByUUID(ctx, keys, fetch)
+
+	require.Len(t, results, 3)
+	require.NoError(t, results[0].Error)
+	assert.ErrorIs(t, results[1].Error, notFound)
+	require.NoError(t, results[2].Error)
+}

--- a/pkg/coreapi/graph/loaders/loader.go
+++ b/pkg/coreapi/graph/loaders/loader.go
@@ -128,6 +128,12 @@ type Loaders struct {
 	DebugSessionLoader    *dataloader.Loader
 	RunDefersLoader       *dataloader.Loader
 	RunDeferredFromLoader *dataloader.Loader
+	// AppLoader and FunctionByInternalUUIDLoader back the dashboard /runs
+	// list view. Without them, FunctionRunV2.app and FunctionRunV2.function
+	// fan out one DB lookup per run row, breaking broad-range queries under
+	// load (see #4326).
+	AppLoader                    *dataloader.Loader
+	FunctionByInternalUUIDLoader *dataloader.Loader
 }
 
 func NewLoaders(params LoaderParams) *Loaders {
@@ -135,6 +141,8 @@ func NewLoaders(params LoaderParams) *Loaders {
 	tr := &traceReader{loaders: loaders, reader: params.DB}
 	er := &eventReader{loaders: loaders, reader: params.DB}
 	dr := &deferReader{reader: params.DB}
+	ar := &appReader{reader: params.DB}
+	fr := &functionReader{reader: params.DB}
 
 	loaders.RunTraceLoader = dataloader.NewBatchedLoader(tr.GetRunTrace)
 	loaders.LegacyRunTraceLoader = dataloader.NewBatchedLoader(tr.GetLegacyRunTrace)
@@ -144,6 +152,8 @@ func NewLoaders(params LoaderParams) *Loaders {
 	loaders.DebugSessionLoader = dataloader.NewBatchedLoader(tr.GetDebugSessionTrace)
 	loaders.RunDefersLoader = dataloader.NewBatchedLoader(dr.GetRunDefers)
 	loaders.RunDeferredFromLoader = dataloader.NewBatchedLoader(dr.GetRunDeferredFrom)
+	loaders.AppLoader = dataloader.NewBatchedLoader(ar.GetApps)
+	loaders.FunctionByInternalUUIDLoader = dataloader.NewBatchedLoader(fr.GetFunctions)
 
 	return loaders
 }

--- a/pkg/coreapi/graph/resolvers/function_run_v2.resolver.go
+++ b/pkg/coreapi/graph/resolvers/function_run_v2.resolver.go
@@ -17,13 +17,22 @@ func (r *functionRunV2Resolver) App(
 	ctx context.Context,
 	run *models.FunctionRunV2,
 ) (*cqrs.App, error) {
-	return r.Data.GetAppByID(ctx, run.AppID)
+	// Routed through the per-request AppLoader so a list view that renders
+	// many runs sharing an app only fires GetAppByID once per unique app
+	// (see #4326). The dataloader's identity cache scopes to the request,
+	// matching the lifetime of the GraphQL request context.
+	return loader.LoadOneWithString[cqrs.App](ctx, loader.FromCtx(ctx).AppLoader, run.AppID.String())
 }
 
 func (r *functionRunV2Resolver) Function(ctx context.Context, fn *models.FunctionRunV2) (*models.Function, error) {
-	fun, err := r.Data.GetFunctionByInternalUUID(ctx, fn.FunctionID)
+	// Same dedup as App above: a list view of N runs across M distinct
+	// functions (M ≤ N) now fires M lookups instead of N.
+	fun, err := loader.LoadOneWithString[cqrs.Function](ctx, loader.FromCtx(ctx).FunctionByInternalUUIDLoader, fn.FunctionID.String())
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving function: %w", err)
+	}
+	if fun == nil {
+		return nil, fmt.Errorf("function %s not found", fn.FunctionID)
 	}
 
 	return models.MakeFunction(fun)


### PR DESCRIPTION
## Description

Refs #4326. The dashboard \`/runs\` list resolver fans out one \`GetAppByID\` and one \`GetFunctionByInternalUUID\` call per row. On a 100-row page that's up to **200 separate DB reads** for two fields that almost always have far smaller unique cardinality across the page. The reporter (@gbradley) hit connection-pool exhaustion as a consequence; \`GetRuns\` returned \`data: null\` and the UI rendered it as \"No results found,\" masking the real failure.

The fix routes both fields through per-request dataloaders. The dataloader's identity cache scopes to the GraphQL request lifetime: a page of 100 runs sharing 5 distinct apps now calls \`GetAppByID\` 5 times instead of 100.

## Scope of this PR

**In scope:** dataloader plumbing for App and FunctionByInternalUUID. This gives meaningful dedup for the common case where many runs share an app/function on a single page.

**Out of scope:** adding \`GetAppsByIDs\` / \`GetFunctionsByIDs\` batch SQL queries (\`WHERE id = ANY(\\$1)\`). That's the right complete fix for the worst case (100 runs each referencing a distinct app or function) but it touches the sqlc-generated layer across both Postgres and SQLite plus regen. Keeping that as a follow-up so this PR stays reviewable in isolation. With the loader infrastructure now in place, swapping the inner per-key loop in \`appReader.GetApps\` / \`functionReader.GetFunctions\` for a single batch SQL call is a one-file change in the reader.

Happy to roll the batch SQL into this PR if maintainers prefer — let me know.

## Code shape (mirrors existing \`Defers\` resolver)

\`\`\`go
// before
func (r *functionRunV2Resolver) App(ctx context.Context, run *models.FunctionRunV2) (*cqrs.App, error) {
    return r.Data.GetAppByID(ctx, run.AppID)  // 1 DB call per row
}

// after
func (r *functionRunV2Resolver) App(ctx context.Context, run *models.FunctionRunV2) (*cqrs.App, error) {
    return loader.LoadOneWithString[cqrs.App](ctx, loader.FromCtx(ctx).AppLoader, run.AppID.String())
}
\`\`\`

Same shape used by \`Defers\` (line 33 of the same file), which already passes through the dataloader infrastructure. The change is just bringing \`App\` and \`Function\` into the same pattern.

## Changes

- **\`pkg/coreapi/graph/loaders/app_function.go\`** — new. \`appReader\` / \`functionReader\` batch funcs plus a generic \`loadByUUID\` helper that mirrors \`loadByRunID\` (defer.go) but accepts a per-key fetcher rather than a bulk fetcher. Invalid UUID keys surface per-row errors without aborting the rest of the batch — a single malformed key shouldn't 500 a whole page.
- **\`pkg/coreapi/graph/loaders/loader.go\`** — register \`AppLoader\` and \`FunctionByInternalUUIDLoader\` on \`Loaders\`; wire them in \`NewLoaders\`.
- **\`pkg/coreapi/graph/resolvers/function_run_v2.resolver.go\`** — swap \`App\` and \`Function\` resolvers to call the new loaders.
- **\`pkg/coreapi/graph/loaders/app_function_test.go\`** — new. Three focused unit tests:
  - \`TestLoadByUUID_DedupesUniqueKeysAndPreservesOrder\` — pins per-key invocation count and output ordering.
  - \`TestLoadByUUID_InvalidKeyErrorsPerRowWithoutAborting\` — a single bad key produces a per-row error, fetch is NOT called for it, and valid neighbors still resolve.
  - \`TestLoadByUUID_PerKeyFetchErrorDoesNotAbortBatch\` — a fetch error on one key surfaces only on that row.

## Verification

\`\`\`
\$ go test ./pkg/coreapi/... -count=1
ok    github.com/inngest/inngest/pkg/coreapi/graph/loaders    0.475s
ok    github.com/inngest/inngest/pkg/coreapi/graph/models     0.898s
\`\`\`

\`go vet\` clean on the touched packages.

## Release note

Fix dashboard \`/runs\` page connection-pool pressure caused by per-row \`GetAppByID\` and \`GetFunctionByInternalUUID\` calls. The GraphQL resolver now uses per-request dataloaders so repeated app/function references on a single page collapse to one underlying lookup each.

## Migration note

None. The GraphQL schema and the public \`cqrs.Manager\` interface are unchanged. The behavior change is internal to the resolver layer.