### PR TITLE
fix(dashboard): use distinct speedometer icon for sidebar Overview

### DIFF
--- a/ui/apps/dashboard/src/components/NavigationV2/navItems.ts
+++ b/ui/apps/dashboard/src/components/NavigationV2/navItems.ts
@@ -6,6 +6,7 @@ import { ExperimentsIcon } from '@inngest/components/icons/sections/Experiments'
 import { FunctionsIcon } from '@inngest/components/icons/sections/Functions';
 import { InsightsIcon } from '@inngest/components/icons/sections/Insights';
 import { MetricsIcon } from '@inngest/components/icons/sections/Metrics';
+import { OverviewIcon } from '@inngest/components/icons/sections/Overview';
 import { RunsIcon } from '@inngest/components/icons/sections/Runs';
 import { WebhooksIcon } from '@inngest/components/icons/sections/Webhooks';
 
@@ -26,7 +27,7 @@ export type NavGroupConfig = {
 export const workflow: NavGroupConfig = {
   heading: 'Workflow',
   items: [
-    { label: 'Overview', route: '', Icon: MetricsIcon, exact: true },
+    { label: 'Overview', route: '', Icon: OverviewIcon, exact: true },
     { label: 'Apps', route: 'apps', Icon: AppsIcon },
     { label: 'Functions', route: 'functions', Icon: FunctionsIcon },
     { label: 'Runs', route: 'runs', Icon: RunsIcon },

--- a/ui/packages/components/src/icons/sections/Overview.tsx
+++ b/ui/packages/components/src/icons/sections/Overview.tsx
@@ -1,0 +1,26 @@
+export const OverviewIcon = ({ className }: { className?: string }) => {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+    >
+      <path
+        d="M2.5 12.5a6.5 6.5 0 1 1 13 0"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinecap="round"
+      />
+      <path
+        d="M9 11 12.4 7.6"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinecap="round"
+      />
+      <circle cx="9" cy="11" r="1.4" fill="currentColor" />
+    </svg>
+  );
+};

--- a/ui/packages/components/src/icons/sections/Overview.tsx
+++ b/ui/packages/components/src/icons/sections/Overview.tsx
@@ -3,24 +3,15 @@ export const OverviewIcon = ({ className }: { className?: string }) => {
     <svg
       width="18"
       height="18"
-      viewBox="0 0 18 18"
+      viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
       className={className}
     >
       <path
-        d="M2.5 12.5a6.5 6.5 0 1 1 13 0"
-        stroke="currentColor"
-        strokeWidth="1.3"
-        strokeLinecap="round"
+        d="M20 13C20 15.2091 19.1046 17.2091 17.6569 18.6569L19.0711 20.0711C20.8807 18.2614 22 15.7614 22 13 22 7.47715 17.5228 3 12 3 6.47715 3 2 7.47715 2 13 2 15.7614 3.11929 18.2614 4.92893 20.0711L6.34315 18.6569C4.89543 17.2091 4 15.2091 4 13 4 8.58172 7.58172 5 12 5 16.4183 5 20 8.58172 20 13ZM15.293 8.29297 10.793 12.793 12.2072 14.2072 16.7072 9.70718 15.293 8.29297Z"
+        fill="currentColor"
       />
-      <path
-        d="M9 11 12.4 7.6"
-        stroke="currentColor"
-        strokeWidth="1.3"
-        strokeLinecap="round"
-      />
-      <circle cx="9" cy="11" r="1.4" fill="currentColor" />
     </svg>
   );
 };


### PR DESCRIPTION
## Description
The Overview nav item reused MetricsIcon, making it visually collide with the Metrics item. Add a dedicated speedometer OverviewIcon and point the Overview nav item at it.

<img width="200" height="89" alt="image" src="https://github.com/user-attachments/assets/f6cd5cac-37c2-4116-92b8-13dbeacba9c2" />


## Release note
None.

## Migration note
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
