### PR TITLE
fix(cli): honor `--json=false` in non-TTY contexts (closes #4379)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,9 +58,24 @@ func execute() {
 		)),
 		Version: inngestversion.Print(),
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			// Set LOG_HANDLER environment variable based on --json flag
-			// This ensures the logger respects the JSON output setting
-			if cmd.Bool("json") {
+			// Resolve LOG_HANDLER with three-way precedence so an explicit
+			// `--json=false` actually takes effect (issue #4379). Done
+			// here in `Before` rather than alongside `app.Run` so the
+			// flag has already been parsed and `cmd.IsSet` can
+			// distinguish "explicitly set" from "absent":
+			//
+			//   1. `--json` explicitly set → honor user choice
+			//      (true → JSON, false → dev/pretty)
+			//   2. `--json` absent + non-TTY → auto-detect JSON
+			//      (preserves prior non-TTY default)
+			//   3. `--json` absent + TTY → leave unset, defaults to dev
+			if cmd.IsSet("json") {
+				if cmd.Bool("json") {
+					os.Setenv("LOG_HANDLER", "json")
+				} else {
+					os.Setenv("LOG_HANDLER", "dev")
+				}
+			} else if !isatty.IsTerminal(os.Stdout.Fd()) {
 				os.Setenv("LOG_HANDLER", "json")
 			}
 
@@ -100,10 +115,10 @@ func execute() {
 		},
 	}
 
-	if !isatty.IsTerminal(os.Stdout.Fd()) {
-		// Always use JSON when not in a terminal
-		os.Setenv("LOG_HANDLER", "json")
-	}
+	// Non-TTY → JSON auto-detection moved into the `Before` hook above so
+	// it can be overridden by `--json=false` (issue #4379). Was previously
+	// here, unconditionally set before flag parsing, which made the flag a
+	// no-op in any non-TTY context (CI, piped output, Docker logs).
 
 	if err := app.Run(context.Background(), os.Args); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
## Description

Closes #4379.

Setting \`--json=false\` had no effect on the dev CLI because the non-TTY detection ran *before* flag parsing. When stdout isn't a terminal (CI, Docker, piped output), the unconditional pre-\`app.Run\` block set \`LOG_HANDLER=json\` first, and the \`Before\` hook's \`if cmd.Bool(\"json\")\` could only *enable* JSON mode — never disable the auto-detected one. Net effect: in any non-TTY context, the documented opt-out had no path.

\`\`\`go
// before — pre-flag-parse, unconditional
Before: func(ctx, cmd) {
    if cmd.Bool(\"json\") {                  // only enables
        os.Setenv(\"LOG_HANDLER\", \"json\")
    }
    ...
}
// ... later, before app.Run ...
if !isatty.IsTerminal(os.Stdout.Fd()) {
    os.Setenv(\"LOG_HANDLER\", \"json\")     // runs first; --json=false can't undo this
}
\`\`\`

## Fix

Move the non-TTY detection into the \`Before\` hook so flags are parsed first, with three-way precedence:

1. \`--json\` **explicitly set** → honor user choice (\`true\` → JSON, \`false\` → dev/pretty)
2. \`--json\` **absent + non-TTY** → auto-detect JSON (preserves prior behavior so CI logs stay JSON by default)
3. \`--json\` **absent + TTY** → leave unset, defaults to dev

\`\`\`go
if cmd.IsSet(\"json\") {
    if cmd.Bool(\"json\") {
        os.Setenv(\"LOG_HANDLER\", \"json\")
    } else {
        os.Setenv(\"LOG_HANDLER\", \"dev\")
    }
} else if !isatty.IsTerminal(os.Stdout.Fd()) {
    os.Setenv(\"LOG_HANDLER\", \"json\")
}
\`\`\`

\`cmd.IsSet(\"json\")\` is the lever that lets a user write \`--json=false\` and have it observed — \`cmd.Bool(\"json\")\` alone collapses \"absent\" and \"set to false\" into the same case.

## User-facing effect

\`\`\`bash
# Before (any non-TTY context):
$ inngest dev --json=false -u http://localhost:3000/api/inngest 2>&1 | head -3
{\"level\":\"info\",\"msg\":\"...\",...}    # JSON, --json=false ignored

# After:
$ inngest dev --json=false -u http://localhost:3000/api/inngest 2>&1 | head -3
INFO ...                                    # pretty, opt-out honored
\`\`\`

## Credit

[themavik](https://github.com/themavik)'s earlier [#3658](https://github.com/inngest/inngest/pull/3658) proposed the same three-way precedence and was self-closed on 2026-02-25 with *\"If this issue is still relevant, happy to resubmit a focused PR.\"* This PR is that focused resubmission against the current \`cmd/root.go\` shape — the original issue (now #4379) was re-filed by a different user a few weeks ago, so the bug still bites.

## Release note

Fix \`--json=false\` being ignored on the \`inngest\` CLI in non-TTY contexts (CI, Docker, piped output). The flag now reliably forces dev/pretty output regardless of stdout TTY state.

## Migration note

None. Default behavior is preserved — non-TTY contexts without \`--json\` set still auto-detect JSON. Only callers that explicitly pass \`--json=false\` see a behavior change, and that change is the documented opt-out finally taking effect.