### PR TITLE
fix(queue): ignore already-leased partitions during scan

### DIFF
--- a/pkg/execution/queue/scan.go
+++ b/pkg/execution/queue/scan.go
@@ -287,7 +287,7 @@ func (q *queueProcessor) processScannedPartitions(
 			})
 
 			if err != nil {
-				if err == ErrPartitionNotFound || err == ErrPartitionGarbageCollected {
+				if err == ErrPartitionNotFound || err == ErrPartitionGarbageCollected || err == ErrPartitionAlreadyLeased {
 					// Another worker grabbed the partition, or the partition was deleted
 					// during the scan by an another worker.
 					// TODO: Increase internal metrics


### PR DESCRIPTION
## Summary

Treat `ErrPartitionAlreadyLeased` from scanned partition processing as normal scan contention instead of returning it as a fatal scan error.

In the FDB-backed queue path, a partition owner can outlive the short partition lease and then lose the right to requeue that partition. FDB correctly reports `ErrPartitionAlreadyLeased`, but the scan errgroup currently propagates that error up to the executor scan loop.

This matches the existing handling for `ErrPartitionNotFound` and `ErrPartitionGarbageCollected`: another worker won the race, so this scan should move on.

## Validation

- `go test ./pkg/execution/queue -run '^$' -count=1`

## Context

Upstream for monorepo hotfix PR: https://github.com/inngest/monorepo/pull/7590
