### PR TITLE
fix(extended traces): Reparent orphaned extended trace spans using span attributes

### DIFF
--- a/pkg/cqrs/manager/cqrs.go
+++ b/pkg/cqrs/manager/cqrs.go
@@ -573,6 +573,9 @@ func mapRootSpansFromRows[T normalizedSpan](ctx context.Context, spans []T) (*cq
 	// executor.step is the preferred parent; executor.execution is the fallback.
 	stepSpanByKey := make(map[extendedTraceKey]string)
 	execSpanByKey := make(map[extendedTraceKey]string)
+	// Dynamic span IDs of all userland spans, used to detect interior nodes of
+	// extended trace subtrees during the parent-child pass.
+	userlandDynIDs := make(map[string]struct{})
 
 	var root *cqrs.OtelSpan
 	var runID ulid.ULID
@@ -599,19 +602,25 @@ func mapRootSpansFromRows[T normalizedSpan](ctx context.Context, spans []T) (*cq
 
 		spanMap.Set(newSpan.SpanID, newSpan)
 
-		// Index step and execution spans so orphaned extended trace spans can be
-		// reparented to their matching attempt during the parent-child pass below.
-		// Both stepID and attempt must be present; without attempt there is no
-		// unambiguous target to attach to.
-		if newSpan.Attributes != nil &&
-			newSpan.Attributes.StepID != nil && *newSpan.Attributes.StepID != "" &&
-			newSpan.Attributes.StepAttempt != nil {
-			key := newExtendedTraceKey(*newSpan.Attributes.StepID, *newSpan.Attributes.StepAttempt)
-			switch newSpan.Name {
-			case meta.SpanNameStep:
-				stepSpanByKey[key] = newSpan.SpanID
-			case meta.SpanNameExecution:
-				execSpanByKey[key] = newSpan.SpanID
+		if newSpan.Attributes != nil {
+			// Track all userland spans so we can detect interior subtree nodes later.
+			if newSpan.Attributes.IsUserland != nil && *newSpan.Attributes.IsUserland {
+				userlandDynIDs[newSpan.SpanID] = struct{}{}
+			}
+
+			// Index step and execution spans so orphaned extended trace spans can be
+			// reparented to their matching attempt during the parent-child pass below.
+			// Both stepID and attempt must be present; without attempt there is no
+			// unambiguous target to attach to.
+			if newSpan.Attributes.StepID != nil && *newSpan.Attributes.StepID != "" &&
+				newSpan.Attributes.StepAttempt != nil {
+				key := newExtendedTraceKey(*newSpan.Attributes.StepID, *newSpan.Attributes.StepAttempt)
+				switch newSpan.Name {
+				case meta.SpanNameStep:
+					stepSpanByKey[key] = newSpan.SpanID
+				case meta.SpanNameExecution:
+					execSpanByKey[key] = newSpan.SpanID
+				}
 			}
 		}
 	}
@@ -698,25 +707,48 @@ func mapRootSpansFromRows[T normalizedSpan](ctx context.Context, spans []T) (*cq
 			span.Attributes.IsUserland != nil && *span.Attributes.IsUserland &&
 			span.Attributes.StepID != nil && *span.Attributes.StepID != "" &&
 			span.Attributes.StepAttempt != nil {
-			// Orphaned extended trace (userland) span: try reparenting to the
-			// matching step or execution span by stepID+attempt.
-			// Attempt must be present; without it there is no unambiguous target.
-			key := newExtendedTraceKey(*span.Attributes.StepID, *span.Attributes.StepAttempt)
-			parentDynID, found := stepSpanByKey[key]
-			if !found {
-				parentDynID, found = execSpanByKey[key]
+			// Orphaned extended trace (userland) span. Only reparent if this is
+			// the root of its subtree: if the unresolvable parent is itself a
+			// userland span, this is an interior node and must not be lifted to a
+			// step/execution parent.
+			parentID := ""
+			if span.ParentSpanID != nil {
+				parentID = *span.ParentSpanID
 			}
-			if found {
-				parent, _ := spanMap.Get(parentDynID)
-				item, _ := spanMap.Get(span.SpanID)
-				parent.Children = append(parent.Children, item)
-			} else {
+			parentIsUserland := false
+			if parentID != "" {
+				if _, ok := userlandDynIDs[parentID]; ok {
+					parentIsUserland = true
+				} else if dynID, ok := otelToDynamic[parentID]; ok {
+					_, parentIsUserland = userlandDynIDs[dynID]
+				}
+			}
+			if parentIsUserland {
 				logger.StdlibLogger(ctx).Warn(
-					"lost lineage detected for extended trace span",
+					"lost lineage detected",
 					"spanID", span.SpanID,
-					"stepID", *span.Attributes.StepID,
-					"stepAttempt", *span.Attributes.StepAttempt,
+					"parentSpanID", parentID,
 				)
+			} else {
+				// Subtree root: reparent to the matching step or execution span.
+				// Attempt must be present; without it there is no unambiguous target.
+				key := newExtendedTraceKey(*span.Attributes.StepID, *span.Attributes.StepAttempt)
+				parentDynID, found := stepSpanByKey[key]
+				if !found {
+					parentDynID, found = execSpanByKey[key]
+				}
+				if found {
+					parent, _ := spanMap.Get(parentDynID)
+					item, _ := spanMap.Get(span.SpanID)
+					parent.Children = append(parent.Children, item)
+				} else {
+					logger.StdlibLogger(ctx).Warn(
+						"lost lineage detected for extended trace span",
+						"spanID", span.SpanID,
+						"stepID", *span.Attributes.StepID,
+						"stepAttempt", *span.Attributes.StepAttempt,
+					)
+				}
 			}
 		} else {
 			logger.StdlibLogger(ctx).Warn(

--- a/pkg/cqrs/manager/cqrs.go
+++ b/pkg/cqrs/manager/cqrs.go
@@ -893,7 +893,7 @@ func walkMetadataSize(span *cqrs.OtelSpan, total *int) {
 // extended trace spans. A zero Attempt means no attempt was recorded.
 type extendedTraceKey struct {
 	StepID  string
-	Attempt int // 0 when unknown
+	Attempt int
 }
 
 func newExtendedTraceKey(stepID string, attempt int) extendedTraceKey {

--- a/pkg/cqrs/manager/cqrs.go
+++ b/pkg/cqrs/manager/cqrs.go
@@ -568,6 +568,12 @@ func mapRootSpansFromRows[T normalizedSpan](ctx context.Context, spans []T) (*cq
 	// in the DB use OTEL span IDs, but the span tree is keyed by dynamic IDs.
 	otelToDynamic := make(map[string]string)
 
+	// Lookup maps for reparenting orphaned extended trace (userland) spans.
+	// Keyed by stepID+attempt → dynamic span ID, populated during the first pass.
+	// executor.step is the preferred parent; executor.execution is the fallback.
+	stepSpanByKey := make(map[extendedTraceKey]string)
+	execSpanByKey := make(map[extendedTraceKey]string)
+
 	var root *cqrs.OtelSpan
 	var runID ulid.ULID
 	var err error
@@ -592,6 +598,22 @@ func mapRootSpansFromRows[T normalizedSpan](ctx context.Context, spans []T) (*cq
 		}
 
 		spanMap.Set(newSpan.SpanID, newSpan)
+
+		// Index step and execution spans so orphaned extended trace spans can be
+		// reparented to their matching attempt during the parent-child pass below.
+		// Both stepID and attempt must be present; without attempt there is no
+		// unambiguous target to attach to.
+		if newSpan.Attributes != nil &&
+			newSpan.Attributes.StepID != nil && *newSpan.Attributes.StepID != "" &&
+			newSpan.Attributes.StepAttempt != nil {
+			key := newExtendedTraceKey(*newSpan.Attributes.StepID, *newSpan.Attributes.StepAttempt)
+			switch newSpan.Name {
+			case meta.SpanNameStep:
+				stepSpanByKey[key] = newSpan.SpanID
+			case meta.SpanNameExecution:
+				execSpanByKey[key] = newSpan.SpanID
+			}
+		}
 	}
 
 	// resolveDynamic looks up a dynamic span ID for the given ID, which may
@@ -672,6 +694,30 @@ func mapRootSpansFromRows[T normalizedSpan](ctx context.Context, spans []T) (*cq
 
 			item, _ := spanMap.Get(span.SpanID)
 			parent.Children = append(parent.Children, item)
+		} else if span.Attributes != nil &&
+			span.Attributes.IsUserland != nil && *span.Attributes.IsUserland &&
+			span.Attributes.StepID != nil && *span.Attributes.StepID != "" &&
+			span.Attributes.StepAttempt != nil {
+			// Orphaned extended trace (userland) span: try reparenting to the
+			// matching step or execution span by stepID+attempt.
+			// Attempt must be present; without it there is no unambiguous target.
+			key := newExtendedTraceKey(*span.Attributes.StepID, *span.Attributes.StepAttempt)
+			parentDynID, found := stepSpanByKey[key]
+			if !found {
+				parentDynID, found = execSpanByKey[key]
+			}
+			if found {
+				parent, _ := spanMap.Get(parentDynID)
+				item, _ := spanMap.Get(span.SpanID)
+				parent.Children = append(parent.Children, item)
+			} else {
+				logger.StdlibLogger(ctx).Warn(
+					"lost lineage detected for extended trace span",
+					"spanID", span.SpanID,
+					"stepID", *span.Attributes.StepID,
+					"stepAttempt", *span.Attributes.StepAttempt,
+				)
+			}
 		} else {
 			logger.StdlibLogger(ctx).Warn(
 				"lost lineage detected",
@@ -809,6 +855,17 @@ func walkMetadataSize(span *cqrs.OtelSpan, total *int) {
 	for _, child := range span.Children {
 		walkMetadataSize(child, total)
 	}
+}
+
+// extendedTraceKey is the map key used when indexing and reparenting orphaned
+// extended trace spans. A zero Attempt means no attempt was recorded.
+type extendedTraceKey struct {
+	StepID  string
+	Attempt int // 0 when unknown
+}
+
+func newExtendedTraceKey(stepID string, attempt int) extendedTraceKey {
+	return extendedTraceKey{StepID: stepID, Attempt: attempt}
 }
 
 func encodeSpanOutputID(runID string, outputSpanID *string, inputSpanID *string) (*string, error) {

--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -2878,6 +2878,58 @@ func TestExtendedTraceReparenting(t *testing.T) {
 		require.Len(t, step.Children, 1, "userland span with valid parent should attach via normal lineage")
 		assert.Equal(t, "dyn-userland", step.Children[0].SpanID)
 	})
+
+	t.Run("only subtree root is reparented, not interior nodes", func(t *testing.T) {
+		// A three-span userland subtree: root → child → grandchild.
+		// root's inngest parent ("stale-otel-id") is absent from the tree.
+		// child and grandchild have parents within the userland subtree.
+		// Only root should be reparented; child and grandchild attach normally.
+		cm, cleanup := initCQRS(t)
+		defer cleanup()
+
+		runID := ulid.MustNew(ulid.Now(), rand.Reader)
+		runIDStr := runID.String()
+
+		insertTestSpan(t, cm, testSpanFields{RunID: runIDStr, DynamicSpanID: "dyn-run", Name: meta.SpanNameRun})
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runIDStr, DynamicSpanID: "dyn-step", Name: meta.SpanNameStep,
+			ParentSpanID: "dyn-run", Attributes: stepAttrs("step-sub", 0),
+		})
+		// Subtree root: orphaned from inngest tree, should be reparented to dyn-step.
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runIDStr, DynamicSpanID: "dyn-ul-root", Name: "userland",
+			ParentSpanID: "stale-otel-id", Attributes: userlandAttrs("step-sub", 0),
+		})
+		// Interior node: parent is the userland root above; resolves via spanMap normally.
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runIDStr, DynamicSpanID: "dyn-ul-child", Name: "userland",
+			ParentSpanID: "dyn-ul-root", Attributes: userlandAttrs("step-sub", 0),
+		})
+		// Leaf: parent is the interior node; resolves via spanMap normally.
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runIDStr, DynamicSpanID: "dyn-ul-grandchild", Name: "userland",
+			ParentSpanID: "dyn-ul-child", Attributes: userlandAttrs("step-sub", 0),
+		})
+
+		result, err := cm.GetSpansByRunID(t.Context(), runID)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		require.Len(t, result.Children, 1)
+		step := result.Children[0]
+		assert.Equal(t, "dyn-step", step.SpanID)
+
+		require.Len(t, step.Children, 1, "only the userland subtree root should be reparented under executor.step")
+		root := step.Children[0]
+		assert.Equal(t, "dyn-ul-root", root.SpanID)
+
+		require.Len(t, root.Children, 1, "interior node should be attached under the subtree root")
+		child := root.Children[0]
+		assert.Equal(t, "dyn-ul-child", child.SpanID)
+
+		require.Len(t, child.Children, 1, "grandchild should be attached under the interior node")
+		assert.Equal(t, "dyn-ul-grandchild", child.Children[0].SpanID)
+	})
 }
 
 //

--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -2673,6 +2673,213 @@ func TestSpanOutputReadBack(t *testing.T) {
 	assert.Contains(t, string(out.Data), `"num":42`, "output should contain raw JSON, not double-encoded")
 }
 
+// TestExtendedTraceReparenting verifies that orphaned userland spans (extended
+// trace spans whose parent OTEL span ID is no longer in the tree) are
+// reparented to their matching step or execution span by stepID + attempt.
+func TestExtendedTraceReparenting(t *testing.T) {
+	// stepAttrs returns JSON attributes for a step/exec span.
+	stepAttrs := func(stepID string, attempt int) []byte {
+		b, _ := json.Marshal(map[string]any{
+			"_inngest.step.id":      stepID,
+			"_inngest.step.attempt": attempt,
+		})
+		return b
+	}
+
+	// userlandAttrs returns JSON attributes for an orphaned extended trace span.
+	userlandAttrs := func(stepID string, attempt int) []byte {
+		b, _ := json.Marshal(map[string]any{
+			"_inngest.userland":     true,
+			"_inngest.step.id":      stepID,
+			"_inngest.step.attempt": attempt,
+		})
+		return b
+	}
+
+	t.Run("reparents to executor.step by stepID and attempt", func(t *testing.T) {
+		cm, cleanup := initCQRS(t)
+		defer cleanup()
+
+		runID := ulid.MustNew(ulid.Now(), rand.Reader)
+		runIDStr := runID.String()
+
+		insertTestSpan(t, cm, testSpanFields{RunID: runIDStr, DynamicSpanID: "dyn-run", Name: meta.SpanNameRun})
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runIDStr, DynamicSpanID: "dyn-step", Name: meta.SpanNameStep,
+			ParentSpanID: "dyn-run", Attributes: stepAttrs("step-abc", 0),
+		})
+		// Orphaned: parent "stale-otel-id" is not in the span map.
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runIDStr, DynamicSpanID: "dyn-userland", Name: "userland",
+			ParentSpanID: "stale-otel-id", Attributes: userlandAttrs("step-abc", 0),
+		})
+
+		result, err := cm.GetSpansByRunID(t.Context(), runID)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		require.Len(t, result.Children, 1)
+		step := result.Children[0]
+		assert.Equal(t, "dyn-step", step.SpanID)
+		require.Len(t, step.Children, 1, "extended trace span should be reparented under executor.step")
+		assert.Equal(t, "dyn-userland", step.Children[0].SpanID)
+	})
+
+	t.Run("falls back to executor.execution when no executor.step exists", func(t *testing.T) {
+		cm, cleanup := initCQRS(t)
+		defer cleanup()
+
+		runID := ulid.MustNew(ulid.Now(), rand.Reader)
+		runIDStr := runID.String()
+
+		insertTestSpan(t, cm, testSpanFields{RunID: runIDStr, DynamicSpanID: "dyn-run", Name: meta.SpanNameRun})
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runIDStr, DynamicSpanID: "dyn-exec", Name: meta.SpanNameExecution,
+			ParentSpanID: "dyn-run", Attributes: stepAttrs("step-xyz", 0),
+		})
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runIDStr, DynamicSpanID: "dyn-userland", Name: "userland",
+			ParentSpanID: "stale-otel-id", Attributes: userlandAttrs("step-xyz", 0),
+		})
+
+		result, err := cm.GetSpansByRunID(t.Context(), runID)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		require.Len(t, result.Children, 1)
+		exec := result.Children[0]
+		assert.Equal(t, "dyn-exec", exec.SpanID)
+		require.Len(t, exec.Children, 1, "extended trace span should fall back to executor.execution")
+		assert.Equal(t, "dyn-userland", exec.Children[0].SpanID)
+	})
+
+	t.Run("drops orphaned span when no matching step or execution span exists", func(t *testing.T) {
+		cm, cleanup := initCQRS(t)
+		defer cleanup()
+
+		runID := ulid.MustNew(ulid.Now(), rand.Reader)
+		runIDStr := runID.String()
+
+		insertTestSpan(t, cm, testSpanFields{RunID: runIDStr, DynamicSpanID: "dyn-run", Name: meta.SpanNameRun})
+		// No step or exec span for "step-no-match".
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runIDStr, DynamicSpanID: "dyn-userland", Name: "userland",
+			ParentSpanID: "stale-otel-id", Attributes: userlandAttrs("step-no-match", 0),
+		})
+
+		result, err := cm.GetSpansByRunID(t.Context(), runID)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Empty(t, result.Children, "orphaned extended trace span with no match should be dropped")
+	})
+
+	t.Run("each attempt's span is reparented to its own attempt", func(t *testing.T) {
+		cm, cleanup := initCQRS(t)
+		defer cleanup()
+
+		runID := ulid.MustNew(ulid.Now(), rand.Reader)
+		runIDStr := runID.String()
+
+		insertTestSpan(t, cm, testSpanFields{RunID: runIDStr, DynamicSpanID: "dyn-run", Name: meta.SpanNameRun})
+
+		for _, attempt := range []int{0, 1} {
+			insertTestSpan(t, cm, testSpanFields{
+				RunID:        runIDStr,
+				DynamicSpanID: fmt.Sprintf("dyn-step-%d", attempt),
+				Name:         meta.SpanNameStep,
+				ParentSpanID: "dyn-run",
+				Attributes:   stepAttrs("step-retry", attempt),
+			})
+			insertTestSpan(t, cm, testSpanFields{
+				RunID:        runIDStr,
+				DynamicSpanID: fmt.Sprintf("dyn-userland-%d", attempt),
+				Name:         "userland",
+				ParentSpanID: "stale-otel-id",
+				Attributes:   userlandAttrs("step-retry", attempt),
+			})
+		}
+
+		result, err := cm.GetSpansByRunID(t.Context(), runID)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Len(t, result.Children, 2)
+
+		bySpanID := make(map[string]*cqrs.OtelSpan, 2)
+		for _, child := range result.Children {
+			bySpanID[child.SpanID] = child
+		}
+
+		step0 := bySpanID["dyn-step-0"]
+		require.NotNil(t, step0)
+		require.Len(t, step0.Children, 1, "attempt 0 extended trace span should be under attempt 0 step")
+		assert.Equal(t, "dyn-userland-0", step0.Children[0].SpanID)
+
+		step1 := bySpanID["dyn-step-1"]
+		require.NotNil(t, step1)
+		require.Len(t, step1.Children, 1, "attempt 1 extended trace span should be under attempt 1 step")
+		assert.Equal(t, "dyn-userland-1", step1.Children[0].SpanID)
+	})
+
+	t.Run("does not reparent when attempt attribute is missing", func(t *testing.T) {
+		cm, cleanup := initCQRS(t)
+		defer cleanup()
+
+		runID := ulid.MustNew(ulid.Now(), rand.Reader)
+		runIDStr := runID.String()
+
+		insertTestSpan(t, cm, testSpanFields{RunID: runIDStr, DynamicSpanID: "dyn-run", Name: meta.SpanNameRun})
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runIDStr, DynamicSpanID: "dyn-step", Name: meta.SpanNameStep,
+			ParentSpanID: "dyn-run", Attributes: stepAttrs("step-abc", 0),
+		})
+		// Orphaned userland span with stepID but no attempt attribute.
+		noAttemptAttrs, _ := json.Marshal(map[string]any{
+			"_inngest.userland": true,
+			"_inngest.step.id":  "step-abc",
+		})
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runIDStr, DynamicSpanID: "dyn-userland", Name: "userland",
+			ParentSpanID: "stale-otel-id", Attributes: noAttemptAttrs,
+		})
+
+		result, err := cm.GetSpansByRunID(t.Context(), runID)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		require.Len(t, result.Children, 1)
+		assert.Empty(t, result.Children[0].Children, "userland span missing attempt should not be reparented")
+	})
+
+	t.Run("userland span with valid parent reference uses normal lineage", func(t *testing.T) {
+		cm, cleanup := initCQRS(t)
+		defer cleanup()
+
+		runID := ulid.MustNew(ulid.Now(), rand.Reader)
+		runIDStr := runID.String()
+
+		insertTestSpan(t, cm, testSpanFields{RunID: runIDStr, DynamicSpanID: "dyn-run", Name: meta.SpanNameRun})
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runIDStr, DynamicSpanID: "dyn-step", Name: meta.SpanNameStep,
+			ParentSpanID: "dyn-run", Attributes: stepAttrs("step-linked", 0),
+		})
+		// Valid parent reference — should use normal lineage, not reparenting.
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runIDStr, DynamicSpanID: "dyn-userland", Name: "userland",
+			ParentSpanID: "dyn-step", Attributes: userlandAttrs("step-linked", 0),
+		})
+
+		result, err := cm.GetSpansByRunID(t.Context(), runID)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		require.Len(t, result.Children, 1)
+		step := result.Children[0]
+		assert.Equal(t, "dyn-step", step.SpanID)
+		require.Len(t, step.Children, 1, "userland span with valid parent should attach via normal lineage")
+		assert.Equal(t, "dyn-userland", step.Children[0].SpanID)
+	})
+}
+
 //
 // Helpers
 //


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This reparents orphaned extended trace spans using their step ID and attempt number attributes.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
