### PR TITLE
test(cqrs): cover all terminal trace run statuses

### DIFF
--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -1561,64 +1561,82 @@ func TestCQRSGetTraceRunsByTriggerID(t *testing.T) {
 }
 
 func TestCQRSInsertTraceRun_PreservesTerminalStateAgainstStaleNonTerminalWrite(t *testing.T) {
-	ctx := context.Background()
-	appID := uuid.New()
-
-	cm, cleanup := initCQRS(t, withInitCQRSOptApp(appID))
-	defer cleanup()
-
-	accountID := uuid.New()
-	workspaceID := uuid.New()
-	functionID := uuid.New()
-	runID := ulid.MustNew(ulid.Now(), rand.Reader)
-
-	now := time.Now().UTC().Truncate(time.Second)
-	terminalOutput := []byte(`{"status":"done"}`)
-
-	terminal := &cqrs.TraceRun{
-		AccountID:   accountID,
-		WorkspaceID: workspaceID,
-		AppID:       appID,
-		FunctionID:  functionID,
-		TraceID:     "trace-terminal-" + runID.String(),
-		RunID:       runID.String(),
-		QueuedAt:    now.Add(-2 * time.Minute),
-		StartedAt:   now.Add(-1 * time.Minute),
-		EndedAt:     now,
-		SourceID:    "terminal-source",
-		TriggerIDs:  []string{"evt-terminal"},
-		Output:      terminalOutput,
-		Status:      enums.RunStatusCompleted,
+	terminalStatuses := []enums.RunStatus{
+		enums.RunStatusCompleted,
+		enums.RunStatusFailed,
+		enums.RunStatusCancelled,
+		enums.RunStatusOverflowed,
+		enums.RunStatusSkipped,
+	}
+	staleStatuses := []enums.RunStatus{
+		enums.RunStatusScheduled,
+		enums.RunStatusRunning,
 	}
 
-	stale := &cqrs.TraceRun{
-		AccountID:   accountID,
-		WorkspaceID: workspaceID,
-		AppID:       appID,
-		FunctionID:  functionID,
-		TraceID:     "trace-stale-" + runID.String(),
-		RunID:       runID.String(),
-		QueuedAt:    now.Add(-3 * time.Minute),
-		StartedAt:   now.Add(-2 * time.Minute),
-		SourceID:    "stale-source",
-		TriggerIDs:  []string{"evt-stale"},
-		Status:      enums.RunStatusRunning,
+	for _, terminalStatus := range terminalStatuses {
+		for _, staleStatus := range staleStatuses {
+			t.Run(fmt.Sprintf("%s_then_%s", terminalStatus, staleStatus), func(t *testing.T) {
+				ctx := context.Background()
+				appID := uuid.New()
+
+				cm, cleanup := initCQRS(t, withInitCQRSOptApp(appID))
+				defer cleanup()
+
+				accountID := uuid.New()
+				workspaceID := uuid.New()
+				functionID := uuid.New()
+				runID := ulid.MustNew(ulid.Now(), rand.Reader)
+
+				now := time.Now().UTC().Truncate(time.Second)
+				terminalOutput := []byte(fmt.Sprintf(`{"status":%q}`, terminalStatus.String()))
+
+				terminal := &cqrs.TraceRun{
+					AccountID:   accountID,
+					WorkspaceID: workspaceID,
+					AppID:       appID,
+					FunctionID:  functionID,
+					TraceID:     "trace-terminal-" + runID.String(),
+					RunID:       runID.String(),
+					QueuedAt:    now.Add(-2 * time.Minute),
+					StartedAt:   now.Add(-1 * time.Minute),
+					EndedAt:     now,
+					SourceID:    "terminal-source",
+					TriggerIDs:  []string{"evt-terminal"},
+					Output:      terminalOutput,
+					Status:      terminalStatus,
+				}
+
+				stale := &cqrs.TraceRun{
+					AccountID:   accountID,
+					WorkspaceID: workspaceID,
+					AppID:       appID,
+					FunctionID:  functionID,
+					TraceID:     "trace-stale-" + runID.String(),
+					RunID:       runID.String(),
+					QueuedAt:    now.Add(-3 * time.Minute),
+					StartedAt:   now.Add(-2 * time.Minute),
+					SourceID:    "stale-source",
+					TriggerIDs:  []string{"evt-stale"},
+					Status:      staleStatus,
+				}
+
+				require.NoError(t, cm.InsertTraceRun(ctx, terminal))
+				require.NoError(t, cm.InsertTraceRun(ctx, stale))
+
+				got, err := cm.GetTraceRun(ctx, cqrs.TraceRunIdentifier{RunID: runID})
+				require.NoError(t, err)
+
+				assert.Equal(t, terminal.TraceID, got.TraceID)
+				assert.Equal(t, terminal.QueuedAt.UnixMilli(), got.QueuedAt.UnixMilli())
+				assert.Equal(t, terminal.StartedAt.UnixMilli(), got.StartedAt.UnixMilli())
+				assert.Equal(t, terminal.EndedAt.UnixMilli(), got.EndedAt.UnixMilli())
+				assert.Equal(t, terminal.SourceID, got.SourceID)
+				assert.Equal(t, terminal.TriggerIDs, got.TriggerIDs)
+				assert.Equal(t, terminalOutput, got.Output)
+				assert.Equal(t, terminalStatus, got.Status)
+			})
+		}
 	}
-
-	require.NoError(t, cm.InsertTraceRun(ctx, terminal))
-	require.NoError(t, cm.InsertTraceRun(ctx, stale))
-
-	got, err := cm.GetTraceRun(ctx, cqrs.TraceRunIdentifier{RunID: runID})
-	require.NoError(t, err)
-
-	assert.Equal(t, terminal.TraceID, got.TraceID)
-	assert.Equal(t, terminal.QueuedAt.UnixMilli(), got.QueuedAt.UnixMilli())
-	assert.Equal(t, terminal.StartedAt.UnixMilli(), got.StartedAt.UnixMilli())
-	assert.Equal(t, terminal.EndedAt.UnixMilli(), got.EndedAt.UnixMilli())
-	assert.Equal(t, terminal.SourceID, got.SourceID)
-	assert.Equal(t, terminal.TriggerIDs, got.TriggerIDs)
-	assert.Equal(t, terminalOutput, got.Output)
-	assert.Equal(t, enums.RunStatusCompleted, got.Status)
 }
 
 // Invariant from TLA RunStateProjection ("terminal states are monotonic"):


### PR DESCRIPTION
## Summary

Extends the `trace_runs` terminal monotonicity regression coverage from #4247.

Once a run projection reaches a terminal status, a later stale non-terminal write must not move it backward. The SQL guard protects all terminal status codes, but the direct stale-write test only exercised `COMPLETED`.

This PR expands that test to cover every terminal status against stale `SCHEDULED` and `RUNNING` writes:

- `COMPLETED`
- `FAILED`
- `CANCELLED`
- `OVERFLOWED`
- `SKIPPED`

No runtime behavior change; this is regression coverage for the existing guard.

## Validation

- `go test ./pkg/cqrs/manager -run 'TestCQRSInsertTraceRun_(PreservesTerminalStateAgainstStaleNonTerminalWrite|TerminalMonotonicityUnderAllOrderings)$' -count=1`\n\nNote: local commit used `--no-verify` because this worktree is missing `ui/.husky/_/husky.sh`; the focused Go check above passed.\n