### PR TITLE
test: capture WaitForRunStatus status-transition history on timeout

### DIFF
--- a/tests/client/function_run.go
+++ b/tests/client/function_run.go
@@ -264,12 +264,23 @@ func (c *Client) WaitForRunStatus(
 		timeout = o.Timeout
 	}
 
+	type statusObs struct {
+		at     time.Duration
+		status string
+	}
+
 	start := time.Now()
 	var run Run
+	var observations []statusObs
+	lastStatus := ""
 	for {
 		r, err := c.RunOrError(ctx, runID)
 		if err == nil {
 			run = r
+			if r.Status != lastStatus {
+				observations = append(observations, statusObs{at: time.Since(start), status: r.Status})
+				lastStatus = r.Status
+			}
 			if r.Status == expectedStatus {
 				return r
 			}
@@ -281,7 +292,13 @@ func (c *Client) WaitForRunStatus(
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	require.Failf(t, "status didn't match", "didn't get expected status: %s, got %s (runID: %s)", expectedStatus, run.Status, runID)
+	var hist strings.Builder
+	for _, o := range observations {
+		fmt.Fprintf(&hist, "[%s] %s -> ", o.at.Round(100*time.Millisecond), o.status)
+	}
+	hist.WriteString("end")
+
+	require.Failf(t, "status didn't match", "didn't get expected status: %s, got %s (runID: %s); history: %s", expectedStatus, run.Status, runID, hist.String())
 	return run
 }
 

--- a/tests/client/function_run_test.go
+++ b/tests/client/function_run_test.go
@@ -96,7 +96,56 @@ func TestWaitForRunStatus_PermanentError(t *testing.T) {
 	require.True(t, mockT.failed, "expected WaitForRunStatus to fail on permanent errors")
 	assert.Contains(t, mockT.failMsg, "run-456", "failure message should contain the runID")
 	assert.Contains(t, mockT.failMsg, "COMPLETED", "failure message should mention expected status")
+	assert.Contains(t, mockT.failMsg, "history:", "failure message should contain status history")
+	assert.Contains(t, mockT.failMsg, "end", "failure message history should end with 'end'")
 	assert.GreaterOrEqual(t, int(callCount.Load()), 2, "expected multiple retry attempts before failing")
+}
+
+// TestWaitForRunStatus_HistoryShowsTransitions verifies that the timeout message
+// includes the status-transition history with timestamps.
+func TestWaitForRunStatus_HistoryShowsTransitions(t *testing.T) {
+	var callCount atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+
+		// Simulate QUEUED -> RUNNING but never COMPLETED.
+		status := "RUNNING"
+		if n <= 2 {
+			status = "QUEUED"
+		}
+
+		resp := map[string]any{
+			"data": map[string]any{
+				"functionRun": map[string]any{
+					"output": `""`,
+					"status": status,
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	c := &Client{
+		Client:  srv.Client(),
+		T:       t,
+		APIHost: srv.URL,
+	}
+
+	mockT := &mockTestingT{}
+
+	ctx := context.Background()
+	c.WaitForRunStatus(ctx, mockT, "COMPLETED", "run-789", WaitForRunStatusOpts{
+		Timeout: 500 * time.Millisecond,
+	})
+
+	require.True(t, mockT.failed, "expected WaitForRunStatus to fail")
+	assert.Contains(t, mockT.failMsg, "history:")
+	assert.Contains(t, mockT.failMsg, "QUEUED")
+	assert.Contains(t, mockT.failMsg, "RUNNING")
+	assert.Contains(t, mockT.failMsg, "end")
 }
 
 // TestRunOrError_EmptyRunID verifies that RunOrError returns an error for empty runIDs.
@@ -126,3 +175,5 @@ func (m *mockTestingT) Errorf(format string, args ...interface{}) {
 func (m *mockTestingT) FailNow() {
 	m.failed = true
 }
+
+func (m *mockTestingT) Helper() {}


### PR DESCRIPTION
## Summary

Capture each status change during the `WaitForRunStatus` polling loop and dump the full history on timeout failure. This disambiguates between runs that stalled in a single status (executor / checkpoint-transition issue) vs runs that progressed normally but ran out of polling budget (test-stack backlog).

Diagnostic before:
```
didn't get expected status: COMPLETED, got RUNNING (runID: 01KV9...)
```

Diagnostic after:
```
didn't get expected status: COMPLETED, got RUNNING (runID: 01KV9...); history: [0s] QUEUED -> [0.4s] RUNNING -> end
```

The first form (snap-to-RUNNING with no further transitions) suggests a stuck checkpoint transition. The second form (slow-leave-QUEUED) suggests executor backlog. We can grep the daily CI scan for either pattern and drive the next investigation from real evidence.

## Why

This was prompted by a 24h scan of recent CI logs (via the diagnostic-emission scanner in `~/workloads/CI/`) which found **7/7 hits** on the existing `didn't get expected status` diagnostic all mapping to one test, `tests/golang/TestFnCheckpoint`, all on `Go SDK / split: 1` across all four (db × key-queues) combos. With only the final status captured, we couldn't tell whether the runs were genuinely stalled or just slow. See FLAKEY.md active priority #8 for the full evidence.

## Provenance

Cherry-picked from Mendral's `3ec676f7996d184ba83341df098581ab4e05f5a9`. The original commit was pushed to the already-merged branch `mendral/tolerate-transient-not-found-gql` from PR #4206, so a fresh PR off `main` was needed to actually ship the change. Authored-by attribution preserved via `git cherry-pick -x`.

## Test plan

- [x] `go test ./tests/client/ -run TestWaitForRunStatus -v` — all 3 tests pass locally (including the new `TestWaitForRunStatus_HistoryShowsTransitions`).
- [ ] CI green.
- [ ] Once merged, watch the next daily `~/workloads/CI/` scan for richer `rate_limited_with_count`-style emissions and start triaging by history shape.
