### PR TITLE
fix(traces): Deduplicate nonstep/step spans in trace view

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
@@ -318,6 +318,10 @@ export function traceRollup(root: Trace): Trace {
       continue;
     }
 
+    if (finalSpan?.groupID == child.groupID) {
+      finalSpan = null;
+    }
+
     if (!steps.get(child.stepID)) {
       stepOrder.push(child.stepID);
     }


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This removes non-step (network error/similar) spans that are part of a set of step attempts from consideration as a finalization span.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
