### PR TITLE
chore: dedup parallel fan-in discovery via coalesce key

### DIFF
--- a/pkg/execution/executor/create_metadata_span_test.go
+++ b/pkg/execution/executor/create_metadata_span_test.go
@@ -26,12 +26,13 @@ import (
 type mockRunContext struct {
 	md            sv2.Metadata
 	lifecycleItem queue.Item
+	httpClient    exechttp.RequestExecutor
 }
 
 func (m *mockRunContext) Metadata() *sv2.Metadata                                              { return &m.md }
 func (m *mockRunContext) DriverResponse() *state.DriverResponse                                { return nil }
 func (m *mockRunContext) Events() []json.RawMessage                                            { return nil }
-func (m *mockRunContext) HTTPClient() exechttp.RequestExecutor                                 { return nil }
+func (m *mockRunContext) HTTPClient() exechttp.RequestExecutor                                 { return m.httpClient }
 func (m *mockRunContext) ExecutionSpan() *meta.SpanReference                                   { return &meta.SpanReference{} }
 func (m *mockRunContext) ParentSpan() *meta.SpanReference                                      { return &meta.SpanReference{} }
 func (m *mockRunContext) GroupID() string                                                      { return "" }

--- a/pkg/execution/executor/create_metadata_span_test.go
+++ b/pkg/execution/executor/create_metadata_span_test.go
@@ -24,7 +24,8 @@ import (
 
 // mockRunContext is a minimal RunContext implementation for testing createMetadataSpan.
 type mockRunContext struct {
-	md sv2.Metadata
+	md            sv2.Metadata
+	lifecycleItem queue.Item
 }
 
 func (m *mockRunContext) Metadata() *sv2.Metadata                                              { return &m.md }
@@ -42,7 +43,7 @@ func (m *mockRunContext) OnlyHasLazyOps() bool                                  
 func (m *mockRunContext) PriorityFactor() *int64                                               { return nil }
 func (m *mockRunContext) ConcurrencyKeys() []state.CustomConcurrency                           { return nil }
 func (m *mockRunContext) ParallelMode() enums.ParallelMode                                     { return 0 }
-func (m *mockRunContext) LifecycleItem() queue.Item                                            { return queue.Item{} }
+func (m *mockRunContext) LifecycleItem() queue.Item                                            { return m.lifecycleItem }
 func (m *mockRunContext) SetStatusCode(code int)                                               {}
 func (m *mockRunContext) UpdateOpcodeError(op *state.GeneratorOpcode, err state.UserError)     {}
 func (m *mockRunContext) UpdateOpcodeOutput(op *state.GeneratorOpcode, output json.RawMessage) {}

--- a/pkg/execution/executor/discovery_coalesce_test.go
+++ b/pkg/execution/executor/discovery_coalesce_test.go
@@ -2,19 +2,33 @@ package executor
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution"
+	"github.com/inngest/inngest/pkg/execution/exechttp"
 	"github.com/inngest/inngest/pkg/execution/pauses"
+	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/tracing"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/require"
 )
+
+type stubHTTPClient struct {
+	statusCode int
+	body       []byte
+}
+
+func (s *stubHTTPClient) DoRequest(_ context.Context, _ exechttp.SerializableRequest) (*exechttp.Response, error) {
+	return &exechttp.Response{StatusCode: s.statusCode, Body: s.body}, nil
+}
 
 type stubRunServiceMD struct {
 	sv2.RunService
@@ -161,4 +175,47 @@ func TestResumeCoalesceJobID(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAIGatewayCoalesceJobID verifies that concurrent AIGateway completions in the same
+// parallel batch coalesce to a single discovery enqueue even when SaveStep's non-atomic
+// pending check lets both see hasPendingSteps=false.
+func TestAIGatewayCoalesceJobID(t *testing.T) {
+	runID := ulid.MustNew(ulid.Now(), nil)
+	stepIDs := []string{"infer-a", "infer-b"}
+	ck := computeParallelCoalesceKey(runID.String(), stepIDs)
+
+	q := &dedupeQueue{}
+	e := &executor{
+		smv2:           &stubRunService{}, // always returns hasPendingSteps=false
+		queue:          q,
+		log:            logger.From(context.Background()),
+		tracerProvider: tracing.NewNoopTracerProvider(),
+	}
+
+	rc := &mockRunContext{
+		md: sv2.Metadata{
+			ID:     sv2.ID{RunID: runID, FunctionID: uuid.New()},
+			Config: *sv2.InitConfig(&sv2.Config{}),
+		},
+		// No coalesce key on the lifecycle item — gateway steps run inline, not as
+		// separate queue items, so the key arrives via OpcodeGroup, not the item.
+		httpClient: &stubHTTPClient{statusCode: 200, body: json.RawMessage(`{"result":"ok"}`)},
+	}
+
+	group := OpcodeGroup{ParallelCoalesceKey: ck}
+	edge := queue.PayloadEdge{Edge: inngest.Edge{Incoming: "trigger"}}
+
+	for _, id := range stepIDs {
+		gen := state.GeneratorOpcode{
+			Op:   enums.OpcodeAIGateway,
+			ID:   id,
+			Opts: json.RawMessage(`{"url":"","format":"openai-chat","body":{}}`),
+		}
+		err := e.handleGeneratorAIGateway(context.Background(), rc, gen, edge, group)
+		require.NoError(t, err)
+	}
+
+	require.Len(t, q.enqueued, 1, "concurrent AIGateway completions must coalesce to a single discovery enqueue")
+	require.Equal(t, fmt.Sprintf("%s-%s-discover", runID, ck), *q.enqueued[0].JobID)
 }

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3555,7 +3555,7 @@ func (e *executor) HandleGeneratorResponse(ctx context.Context, i *runInstance, 
 	// pending set every step completion saw hasPendingSteps=false and
 	// enqueued its own discovery step, causing the final sequential step
 	// after a parallel group to execute more than once.
-	if hasPlanOp(resp.Generator) {
+	if hasPlanOp(resp.Generator) && len(nonLazyIDs) > 1 {
 		if err := e.smv2.SavePending(ctx, i.md.ID, nonLazyIDs); err != nil {
 			return fmt.Errorf("error saving pending steps: %w", err)
 		}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1562,7 +1562,7 @@ func (e *executor) schedule(
 			}
 
 			if !keepState {
-				if deleteErr := e.smv2.Delete(ctx, sv2.IDFromV1(stv1ID)); deleteErr != nil {
+				if deleteErr := e.smv2.Delete(context.Background(), sv2.IDFromV1(stv1ID)); deleteErr != nil {
 					l.Error("error deleting run state after queue duplicate, this has likely leaked state", deleteErr,
 						"run_id", metadata.ID.RunID.String(),
 						"account_id", req.AccountID.String(),
@@ -1618,7 +1618,7 @@ func (e *executor) schedule(
 		return &metadata.ID.RunID, nil, state.ErrIdentifierExists
 
 	case errors.Is(err, queue.ErrQueueItemSingletonExists):
-		deleteErr := e.smv2.Delete(ctx, sv2.IDFromV1(stv1ID))
+		deleteErr := e.smv2.Delete(context.Background(), sv2.IDFromV1(stv1ID))
 		if deleteErr != nil {
 			l.ReportError(deleteErr, "error deleting function state, this has likely leaked state")
 		}
@@ -3654,9 +3654,9 @@ func (e *executor) handleGeneratorOp(ctx context.Context, runCtx execution.RunCo
 	case enums.OpcodeInvokeFunction:
 		return e.handleGeneratorInvokeFunction(ctx, runCtx, gen, edge, group)
 	case enums.OpcodeAIGateway:
-		return e.handleGeneratorAIGateway(ctx, runCtx, gen, edge)
+		return e.handleGeneratorAIGateway(ctx, runCtx, gen, edge, group)
 	case enums.OpcodeGateway:
-		return e.handleGeneratorGateway(ctx, runCtx, gen, edge)
+		return e.handleGeneratorGateway(ctx, runCtx, gen, edge, group)
 	case enums.OpcodeWaitForSignal:
 		return e.handleGeneratorWaitForSignal(ctx, runCtx, gen, edge, group)
 	case enums.OpcodeRunComplete:
@@ -3732,10 +3732,11 @@ func (e *executor) restartDiscovery(ctx context.Context, i *runInstance) error {
 		queue.PayloadEdge{Edge: i.edge},
 		groupID,
 		false,
+		i.LifecycleItem().ParallelCoalesceKey,
 	)
 }
 
-func (e *executor) maybeEnqueueDiscoveryStep(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge, groupID string, hasPendingSteps bool) error {
+func (e *executor) maybeEnqueueDiscoveryStep(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge, groupID string, hasPendingSteps bool, coalesceKey *string) error {
 	// Enqueue the next discovery step to continue execution.
 	nextEdge := inngest.Edge{
 		Outgoing: gen.ID,             // Going from the current step
@@ -3743,12 +3744,11 @@ func (e *executor) maybeEnqueueDiscoveryStep(ctx context.Context, runCtx executi
 	}
 
 	now := e.now()
-	ck := runCtx.LifecycleItem().ParallelCoalesceKey
 	var jobID string
 	// Race mode fires discovery after every completion, not just the last — skip
 	// coalescing so each branch schedules its own independent discovery step.
-	if ck != nil && *ck != "" && gen.ParallelMode() != enums.ParallelModeRace {
-		jobID = fmt.Sprintf("%s-%s-discover", runCtx.Metadata().ID.RunID, *ck)
+	if coalesceKey != nil && *coalesceKey != "" && gen.ParallelMode() != enums.ParallelModeRace {
+		jobID = fmt.Sprintf("%s-%s-discover", runCtx.Metadata().ID.RunID, *coalesceKey)
 	} else {
 		jobID = fmt.Sprintf("%s-%s", runCtx.Metadata().IdempotencyKey(), gen.ID)
 	}
@@ -3798,7 +3798,7 @@ func (e *executor) maybeEnqueueDiscoveryStep(ctx context.Context, runCtx executi
 			span.Drop()
 
 			if errors.Is(err, queue.ErrQueueItemExists) {
-				if ck != nil && gen.ParallelMode() != enums.ParallelModeRace {
+				if coalesceKey != nil && gen.ParallelMode() != enums.ParallelModeRace {
 					metrics.IncrDiscoveryCoalesceDedupCount(ctx, metrics.CounterOpt{PkgName: pkgName})
 				}
 				return nil
@@ -3848,6 +3848,7 @@ func (e *executor) handleGeneratorDiscoveryRequest(ctx context.Context, runCtx e
 		edge,
 		groupID,
 		false,
+		runCtx.LifecycleItem().ParallelCoalesceKey,
 	)
 }
 
@@ -3904,6 +3905,7 @@ func (e *executor) enqueueLazyOpFallback(
 		edge,
 		groupID,
 		hasPendingSteps,
+		runCtx.LifecycleItem().ParallelCoalesceKey,
 	)
 }
 
@@ -3970,6 +3972,7 @@ func (e *executor) handleGeneratorStep(ctx context.Context, runCtx execution.Run
 		edge,
 		groupID,
 		hasPendingSteps,
+		runCtx.LifecycleItem().ParallelCoalesceKey,
 	)
 
 	// NOTE: Default topics are not yet implemented and are a V2 realtime feature.
@@ -4426,7 +4429,7 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, runCtx execution.Ru
 	return err
 }
 
-func (e *executor) handleGeneratorGateway(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge) error {
+func (e *executor) handleGeneratorGateway(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge, group OpcodeGroup) error {
 	start := e.now()
 	gen.Timing.A = start.UnixNano()
 
@@ -4535,83 +4538,10 @@ func (e *executor) handleGeneratorGateway(ctx context.Context, runCtx execution.
 
 	groupID := uuid.New().String()
 	ctx = state.WithGroupID(ctx, groupID)
-
-	// Enqueue the next step
-	nextEdge := inngest.Edge{
-		Outgoing: gen.ID,             // Going from the current step
-		Incoming: edge.Edge.Incoming, // And re-calling the incoming function in a loop
-	}
-	jobID := fmt.Sprintf("%s-%s", runCtx.Metadata().IdempotencyKey(), gen.ID)
-	now := e.now()
-	nextItem := queue.Item{
-		JobID:                 &jobID,
-		WorkspaceID:           runCtx.Metadata().ID.Tenant.EnvID,
-		GroupID:               groupID,
-		Kind:                  queue.KindEdge,
-		Identifier:            sv2.V1FromMetadata(*runCtx.Metadata()),
-		PriorityFactor:        runCtx.PriorityFactor(),
-		CustomConcurrencyKeys: runCtx.ConcurrencyKeys(),
-		Semaphores:            stepSemaphores(*runCtx.Metadata()),
-		Attempt:               0,
-		MaxAttempts:           runCtx.MaxAttempts(),
-		Payload:               queue.PayloadEdge{Edge: nextEdge},
-		Metadata:              make(map[string]any),
-		ParallelMode:          gen.ParallelMode(),
-	}
-
-	if shouldEnqueueDiscovery(hasPendingSteps, gen.ParallelMode()) {
-		if err := e.maybeResetForceStepPlan(ctx, runCtx.Metadata()); err != nil {
-			return fmt.Errorf("error resetting force step plan: %w", err)
-		}
-		lifecycleItem := runCtx.LifecycleItem()
-		metadata := runCtx.Metadata()
-		span, err := e.tracerProvider.CreateDroppableSpan(
-			ctx,
-			meta.SpanNameStepDiscovery,
-
-			&tracing.CreateSpanOptions{
-				Carriers:    []map[string]any{nextItem.Metadata},
-				FollowsFrom: tracing.SpanRefFromQueueItem(&lifecycleItem),
-				Debug:       &tracing.SpanDebugData{Location: "executor.handleGeneratorGateway"},
-				Metadata:    metadata,
-				Parent:      tracing.RunSpanRefFromMetadata(metadata),
-				QueueItem:   &nextItem,
-			},
-		)
-		if err != nil {
-			e.log.Debug("error creating span for next step after Gateway", "error", err)
-		}
-
-		err = e.queue.Enqueue(ctx, nextItem, now, queue.EnqueueOpts{})
-		if err != nil {
-			if span != nil {
-				span.Drop()
-			}
-
-			if errors.Is(err, queue.ErrQueueItemExists) {
-				return nil
-			}
-
-			logger.StdlibLogger(ctx).Error("error scheduling Gateway step queue item", "error", err)
-			return err
-		}
-
-		if span != nil {
-			_ = span.Send()
-		}
-	}
-
-	for _, l := range e.lifecycles {
-		// We can't specify step name here since that will result in the
-		// "followup discovery step" having the same name as its predecessor.
-		var stepName *string = nil
-		go l.OnStepScheduled(ctx, *runCtx.Metadata(), nextItem, stepName)
-	}
-
-	return err
+	return e.maybeEnqueueDiscoveryStep(ctx, runCtx, gen, edge, groupID, hasPendingSteps, &group.ParallelCoalesceKey)
 }
 
-func (e *executor) handleGeneratorAIGateway(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge) error {
+func (e *executor) handleGeneratorAIGateway(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge, group OpcodeGroup) error {
 	start := e.now()
 	gen.Timing.A = start.UnixNano()
 
@@ -4779,79 +4709,7 @@ func (e *executor) handleGeneratorAIGateway(ctx context.Context, runCtx executio
 	// XXX: Remove once deprecated from history.
 	groupID := uuid.New().String()
 	ctx = state.WithGroupID(ctx, groupID)
-
-	// Enqueue the next step
-	nextEdge := inngest.Edge{
-		Outgoing: gen.ID,             // Going from the current step
-		Incoming: edge.Edge.Incoming, // And re-calling the incoming function in a loop
-	}
-	jobID := fmt.Sprintf("%s-%s", runCtx.Metadata().IdempotencyKey(), gen.ID)
-	now := e.now()
-	nextItem := queue.Item{
-		JobID:                 &jobID,
-		WorkspaceID:           runCtx.Metadata().ID.Tenant.EnvID,
-		GroupID:               groupID,
-		Kind:                  queue.KindEdge,
-		Identifier:            sv2.V1FromMetadata(*runCtx.Metadata()), // Convert from v2 metadata
-		PriorityFactor:        runCtx.PriorityFactor(),
-		CustomConcurrencyKeys: runCtx.ConcurrencyKeys(),
-		Semaphores:            stepSemaphores(*runCtx.Metadata()),
-		Attempt:               0,
-		MaxAttempts:           runCtx.MaxAttempts(),
-		Payload:               queue.PayloadEdge{Edge: nextEdge},
-		Metadata:              make(map[string]any),
-		ParallelMode:          gen.ParallelMode(),
-	}
-
-	if shouldEnqueueDiscovery(hasPendingSteps, runCtx.ParallelMode()) {
-		if err := e.maybeResetForceStepPlan(ctx, runCtx.Metadata()); err != nil {
-			return fmt.Errorf("error resetting force step plan: %w", err)
-		}
-		lifecycleItem := runCtx.LifecycleItem()
-		metadata := runCtx.Metadata()
-		span, err := e.tracerProvider.CreateDroppableSpan(
-			ctx,
-			meta.SpanNameStepDiscovery,
-			&tracing.CreateSpanOptions{
-				Carriers:    []map[string]any{nextItem.Metadata},
-				FollowsFrom: tracing.SpanRefFromQueueItem(&lifecycleItem),
-				Debug:       &tracing.SpanDebugData{Location: "executor.handleGeneratorAIGateway"},
-				Metadata:    metadata,
-				Parent:      tracing.RunSpanRefFromMetadata(metadata),
-				QueueItem:   &nextItem,
-			},
-		)
-		if err != nil {
-			e.log.Debug("error creating span for next step after AI Gateway", "error", err)
-		}
-
-		err = e.queue.Enqueue(ctx, nextItem, now, queue.EnqueueOpts{})
-		if err != nil {
-			if span != nil {
-				span.Drop()
-			}
-
-			if errors.Is(err, queue.ErrQueueItemExists) {
-				return nil
-			}
-
-			logger.StdlibLogger(ctx).Error("error scheduling AI Gateway step queue item", "error", err)
-			return err
-		}
-
-		if span != nil {
-			_ = span.Send()
-		}
-	}
-
-	for _, l := range e.lifecycles {
-		// We can't specify step name here since that will result in the
-		// "followup discovery step" having the same name as its predecessor.
-		var stepName *string = nil
-		go l.OnStepScheduled(ctx, *runCtx.Metadata(), nextItem, stepName)
-	}
-
-	return err
+	return e.maybeEnqueueDiscoveryStep(ctx, runCtx, gen, edge, groupID, hasPendingSteps, &group.ParallelCoalesceKey)
 }
 
 func (e *executor) handleGeneratorWaitForSignal(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge, group OpcodeGroup) error {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3184,7 +3184,12 @@ func (e *executor) ResumePauseTimeout(ctx context.Context, pause state.Pause, r 
 		}
 		// If there are no parallel steps ongoing, we must enqueue the next SDK ping to continue on with
 		// execution.
-		jobID := fmt.Sprintf("%s-%s-timeout", md.IdempotencyKey(), pause.DataKey)
+		var jobID string
+		if pause.ParallelCoalesceKey != "" && pause.ParallelMode != enums.ParallelModeRace {
+			jobID = fmt.Sprintf("%s-%s-discover", md.ID.RunID, pause.ParallelCoalesceKey)
+		} else {
+			jobID = fmt.Sprintf("%s-%s-timeout", md.IdempotencyKey(), pause.DataKey)
+		}
 		nextItem := queue.Item{
 			JobID: &jobID,
 			// Add a new group ID for the child;  this will be a new step.
@@ -3351,8 +3356,14 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 			// running the job may occur prior to saving state data.
 			//
 			// NOTE: This has an "-event" prefix so that it does not conflict
-			// with the timeout job ID.
-			jobID := fmt.Sprintf("%s-%s-event", md.IdempotencyKey(), pause.DataKey)
+			// with the timeout job ID. When a coalesce key is present, both
+			// paths share the same "-discover" job ID so ErrQueueItemExists deduplicates.
+			var jobID string
+			if pause.ParallelCoalesceKey != "" && pause.ParallelMode != enums.ParallelModeRace {
+				jobID = fmt.Sprintf("%s-%s-discover", md.ID.RunID, pause.ParallelCoalesceKey)
+			} else {
+				jobID = fmt.Sprintf("%s-%s-event", md.IdempotencyKey(), pause.DataKey)
+			}
 			nextItem := queue.Item{
 				JobID: &jobID,
 				// Add a new group ID for the child;  this will be a new step.
@@ -3639,15 +3650,15 @@ func (e *executor) handleGeneratorOp(ctx context.Context, runCtx execution.RunCo
 	case enums.OpcodeSleep:
 		return e.handleGeneratorSleep(ctx, runCtx, gen, edge)
 	case enums.OpcodeWaitForEvent:
-		return e.handleGeneratorWaitForEvent(ctx, runCtx, gen, edge)
+		return e.handleGeneratorWaitForEvent(ctx, runCtx, gen, edge, group)
 	case enums.OpcodeInvokeFunction:
-		return e.handleGeneratorInvokeFunction(ctx, runCtx, gen, edge)
+		return e.handleGeneratorInvokeFunction(ctx, runCtx, gen, edge, group)
 	case enums.OpcodeAIGateway:
 		return e.handleGeneratorAIGateway(ctx, runCtx, gen, edge)
 	case enums.OpcodeGateway:
 		return e.handleGeneratorGateway(ctx, runCtx, gen, edge)
 	case enums.OpcodeWaitForSignal:
-		return e.handleGeneratorWaitForSignal(ctx, runCtx, gen, edge)
+		return e.handleGeneratorWaitForSignal(ctx, runCtx, gen, edge, group)
 	case enums.OpcodeRunComplete:
 		return e.handleGeneratorFunctionFinished(ctx, runCtx, gen, edge)
 	case enums.OpcodeSyncRunComplete:
@@ -4843,7 +4854,7 @@ func (e *executor) handleGeneratorAIGateway(ctx context.Context, runCtx executio
 	return err
 }
 
-func (e *executor) handleGeneratorWaitForSignal(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge) error {
+func (e *executor) handleGeneratorWaitForSignal(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge, group OpcodeGroup) error {
 	opts, err := gen.SignalOpts()
 	if err != nil {
 		return fmt.Errorf("unable to parse signal opts: %w", err)
@@ -4890,8 +4901,9 @@ func (e *executor) handleGeneratorWaitForSignal(ctx context.Context, runCtx exec
 		Metadata: map[string]any{
 			consts.OtelPropagationKey: carrier,
 		},
-		ParallelMode: gen.ParallelMode(),
-		CreatedAt:    now,
+		ParallelMode:        gen.ParallelMode(),
+		ParallelCoalesceKey: group.ParallelCoalesceKey,
+		CreatedAt:           now,
 	}
 
 	// Enqueue a job that will timeout the pause.
@@ -5019,7 +5031,7 @@ func (e *executor) handleGeneratorWaitForSignal(ctx context.Context, runCtx exec
 	return err
 }
 
-func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge) error {
+func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge, group OpcodeGroup) error {
 	if e.handleInvokeEvent == nil {
 		return fmt.Errorf("no handleSendingEvent function specified")
 	}
@@ -5090,8 +5102,9 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx exe
 		Metadata: map[string]any{
 			consts.OtelPropagationKey: carrier,
 		},
-		ParallelMode: gen.ParallelMode(),
-		CreatedAt:    now,
+		ParallelMode:        gen.ParallelMode(),
+		ParallelCoalesceKey: group.ParallelCoalesceKey,
+		CreatedAt:           now,
 	}
 
 	// Enqueue a job that will timeout the pause.
@@ -5203,7 +5216,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx exe
 	return err
 }
 
-func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge) error {
+func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge, group OpcodeGroup) error {
 	opts, err := gen.WaitForEventOpts()
 	if err != nil {
 		return fmt.Errorf("unable to parse wait for event opts: %w", err)
@@ -5312,8 +5325,9 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, runCtx execu
 		Metadata: map[string]any{
 			consts.OtelPropagationKey: carrier,
 		},
-		ParallelMode: gen.ParallelMode(),
-		CreatedAt:    now,
+		ParallelMode:        gen.ParallelMode(),
+		ParallelCoalesceKey: group.ParallelCoalesceKey,
+		CreatedAt:           now,
 	}
 
 	// SDK-based event coordination is called both when an event is received

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3522,6 +3522,18 @@ func (e *executor) HandleGeneratorResponse(ctx context.Context, i *runInstance, 
 
 	groups := opGroups(resp.Generator)
 
+	nonLazyIDs := groups.NonLazyIDs()
+
+	// When scheduling multiple parallel steps, compute a stable coalesceKey
+	// shared by all queue items in this batch.  Every concurrent fan-in
+	// completion will derive the same discovery JobID from this key, so the
+	// queue's idempotency check ensures only one discovery step is enqueued.
+	if len(nonLazyIDs) > 1 {
+		ck := computeParallelCoalesceKey(i.md.ID.RunID.String(), nonLazyIDs)
+		groups.PriorityGroup.ParallelCoalesceKey = ck
+		groups.OtherGroup.ParallelCoalesceKey = ck
+	}
+
 	// Save pending step IDs so that SaveStep can atomically track which
 	// parallel branches are still outstanding.  When the last branch
 	// completes, SaveStep returns hasPendingSteps=false and a single
@@ -3533,7 +3545,7 @@ func (e *executor) HandleGeneratorResponse(ctx context.Context, i *runInstance, 
 	// enqueued its own discovery step, causing the final sequential step
 	// after a parallel group to execute more than once.
 	if hasPlanOp(resp.Generator) {
-		if err := e.smv2.SavePending(ctx, i.md.ID, groups.NonLazyIDs()); err != nil {
+		if err := e.smv2.SavePending(ctx, i.md.ID, nonLazyIDs); err != nil {
 			return fmt.Errorf("error saving pending steps: %w", err)
 		}
 	}
@@ -3573,7 +3585,7 @@ func (e *executor) handleGeneratorGroup(ctx context.Context, i *runInstance, gro
 					)
 				}
 			}()
-			return e.HandleGenerator(ctx, i, copied)
+			return e.handleGeneratorOp(ctx, i, copied, group)
 		})
 	}
 	if err := eg.Wait(); err != nil {
@@ -3593,6 +3605,10 @@ func (e *executor) handleGeneratorGroup(ctx context.Context, i *runInstance, gro
 }
 
 func (e *executor) HandleGenerator(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode) error {
+	return e.handleGeneratorOp(ctx, runCtx, gen, OpcodeGroup{})
+}
+
+func (e *executor) handleGeneratorOp(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, group OpcodeGroup) error {
 	// Grab the edge that triggered this step execution.
 	lifecycleItem := runCtx.LifecycleItem()
 	edge, ok := lifecycleItem.Payload.(queue.PayloadEdge)
@@ -3619,7 +3635,7 @@ func (e *executor) HandleGenerator(ctx context.Context, runCtx execution.RunCont
 	case enums.OpcodeStepError:
 		return e.handleStepError(ctx, runCtx, gen, edge)
 	case enums.OpcodeStepPlanned:
-		return e.handleGeneratorStepPlanned(ctx, runCtx, gen, edge)
+		return e.handleGeneratorStepPlanned(ctx, runCtx, gen, edge, group)
 	case enums.OpcodeSleep:
 		return e.handleGeneratorSleep(ctx, runCtx, gen, edge)
 	case enums.OpcodeWaitForEvent:
@@ -3716,7 +3732,15 @@ func (e *executor) maybeEnqueueDiscoveryStep(ctx context.Context, runCtx executi
 	}
 
 	now := e.now()
-	jobID := fmt.Sprintf("%s-%s", runCtx.Metadata().IdempotencyKey(), gen.ID)
+	ck := runCtx.LifecycleItem().ParallelCoalesceKey
+	var jobID string
+	// Race mode fires discovery after every completion, not just the last — skip
+	// coalescing so each branch schedules its own independent discovery step.
+	if ck != nil && *ck != "" && gen.ParallelMode() != enums.ParallelModeRace {
+		jobID = fmt.Sprintf("%s-%s-discover", runCtx.Metadata().ID.RunID, *ck)
+	} else {
+		jobID = fmt.Sprintf("%s-%s", runCtx.Metadata().IdempotencyKey(), gen.ID)
+	}
 
 	nextItem := queue.Item{
 		JobID:                 &jobID,
@@ -3763,6 +3787,9 @@ func (e *executor) maybeEnqueueDiscoveryStep(ctx context.Context, runCtx executi
 			span.Drop()
 
 			if errors.Is(err, queue.ErrQueueItemExists) {
+				if ck != nil && gen.ParallelMode() != enums.ParallelModeRace {
+					metrics.IncrDiscoveryCoalesceDedupCount(ctx, metrics.CounterOpt{PkgName: pkgName})
+				}
 				return nil
 			}
 
@@ -4173,7 +4200,7 @@ func (e *executor) handleGeneratorSyncFunctionFinished(ctx context.Context, runC
 	return err
 }
 
-func (e *executor) handleGeneratorStepPlanned(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge) error {
+func (e *executor) handleGeneratorStepPlanned(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge, group OpcodeGroup) error {
 	nextEdge := inngest.Edge{
 		// Planned generator IDs are the same as the actual OpcodeStep IDs.
 		// We can't set edge.Edge.Outgoing here because the step hasn't yet ran.
@@ -4216,6 +4243,10 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, runCtx execut
 		},
 		Metadata:     make(map[string]any),
 		ParallelMode: gen.ParallelMode(),
+	}
+	if group.ParallelCoalesceKey != "" {
+		ck := group.ParallelCoalesceKey
+		nextItem.ParallelCoalesceKey = &ck
 	}
 
 	md := runCtx.Metadata()

--- a/pkg/execution/executor/handle_generator_step_test.go
+++ b/pkg/execution/executor/handle_generator_step_test.go
@@ -90,6 +90,42 @@ func TestMaybeEnqueueDiscoveryStepCoalesces(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%s-%s-discover", runID, ck), *q.enqueued[0].JobID)
 }
 
+// A non-atomic SaveStep lets all N concurrent completions see hasPendingSteps=false.
+// The coalesce key must still reduce them to one discovery enqueue.
+func TestHandleGeneratorStep_ConcurrentCompletionsCoalesce(t *testing.T) {
+	runID := ulid.MustNew(ulid.Now(), nil)
+	ck := computeParallelCoalesceKey(runID.String(), []string{"step-a", "step-b"})
+
+	q := &dedupeQueue{}
+	e := &executor{
+		smv2:           &stubRunService{}, // always returns hasPendingSteps=false
+		queue:          q,
+		log:            logger.From(context.Background()),
+		tracerProvider: tracing.NewNoopTracerProvider(),
+	}
+
+	rc := &mockRunContext{
+		md: sv2.Metadata{
+			ID:     sv2.ID{RunID: runID, FunctionID: uuid.New()},
+			Config: *sv2.InitConfig(&sv2.Config{}),
+		},
+		lifecycleItem: queue.Item{ParallelCoalesceKey: &ck},
+	}
+
+	edge := queue.PayloadEdge{Edge: inngest.Edge{Incoming: "step"}}
+	for _, stepID := range []string{"step-a", "step-b"} {
+		err := e.handleGeneratorStep(
+			context.Background(), rc,
+			state.GeneratorOpcode{Op: enums.OpcodeStepRun, ID: stepID, Data: json.RawMessage(`null`)},
+			edge,
+		)
+		require.NoError(t, err)
+	}
+
+	require.Len(t, q.enqueued, 1)
+	require.Equal(t, fmt.Sprintf("%s-%s-discover", runID, ck), *q.enqueued[0].JobID)
+}
+
 func TestHandleGeneratorStepPlanned_StampsCoalesceKey(t *testing.T) {
 	runID := ulid.MustNew(ulid.Now(), nil)
 	stepIDs := []string{"step-a", "step-b", "step-c"}

--- a/pkg/execution/executor/handle_generator_step_test.go
+++ b/pkg/execution/executor/handle_generator_step_test.go
@@ -82,7 +82,7 @@ func TestMaybeEnqueueDiscoveryStepCoalesces(t *testing.T) {
 	edge := queue.PayloadEdge{Edge: inngest.Edge{Incoming: "step"}}
 
 	for i := 0; i < 3; i++ {
-		err := e.maybeEnqueueDiscoveryStep(context.Background(), rc, gen, edge, uuid.New().String(), false)
+		err := e.maybeEnqueueDiscoveryStep(context.Background(), rc, gen, edge, uuid.New().String(), false, rc.LifecycleItem().ParallelCoalesceKey)
 		require.NoError(t, err)
 	}
 

--- a/pkg/execution/executor/handle_generator_step_test.go
+++ b/pkg/execution/executor/handle_generator_step_test.go
@@ -90,6 +90,42 @@ func TestMaybeEnqueueDiscoveryStepCoalesces(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("%s-%s-discover", runID, ck), *q.enqueued[0].JobID)
 }
 
+func TestHandleGeneratorStepPlanned_StampsCoalesceKey(t *testing.T) {
+	runID := ulid.MustNew(ulid.Now(), nil)
+	stepIDs := []string{"step-a", "step-b", "step-c"}
+	ck := computeParallelCoalesceKey(runID.String(), stepIDs)
+
+	q := &stubQueue{}
+	e := &executor{
+		queue:          q,
+		log:            logger.From(context.Background()),
+		tracerProvider: tracing.NewNoopTracerProvider(),
+	}
+
+	rc := &mockRunContext{md: sv2.Metadata{
+		ID:     sv2.ID{RunID: runID, FunctionID: uuid.New()},
+		Config: *sv2.InitConfig(&sv2.Config{}),
+	}}
+
+	group := OpcodeGroup{ParallelCoalesceKey: ck}
+	edge := queue.PayloadEdge{Edge: inngest.Edge{Incoming: "step"}}
+
+	for _, id := range stepIDs {
+		err := e.handleGeneratorStepPlanned(
+			context.Background(), rc,
+			state.GeneratorOpcode{Op: enums.OpcodeStepPlanned, ID: id},
+			edge, group,
+		)
+		require.NoError(t, err)
+	}
+
+	require.Len(t, q.enqueued, len(stepIDs))
+	for _, item := range q.enqueued {
+		require.NotNil(t, item.ParallelCoalesceKey)
+		require.Equal(t, ck, *item.ParallelCoalesceKey)
+	}
+}
+
 // EXE-1625: when the SDK responds with a step that the checkpoint path
 // already saved with different bytes, SaveStep returns ErrDuplicateResponse.
 // The executor must still enqueue the next discovery edge or the run

--- a/pkg/execution/executor/handle_generator_step_test.go
+++ b/pkg/execution/executor/handle_generator_step_test.go
@@ -3,6 +3,8 @@ package executor
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -35,6 +37,57 @@ type stubQueue struct {
 func (q *stubQueue) Enqueue(_ context.Context, item queue.Item, _ time.Time, _ queue.EnqueueOpts) error {
 	q.enqueued = append(q.enqueued, item)
 	return nil
+}
+
+// dedupeQueue mimics queue-level dedup: the first enqueue for a given JobID
+// succeeds; subsequent calls for the same ID return ErrQueueItemExists.
+type dedupeQueue struct {
+	queue.Queue
+	mu       sync.Mutex
+	enqueued []queue.Item
+}
+
+func (q *dedupeQueue) Enqueue(_ context.Context, item queue.Item, _ time.Time, _ queue.EnqueueOpts) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for _, e := range q.enqueued {
+		if e.JobID != nil && item.JobID != nil && *e.JobID == *item.JobID {
+			return queue.ErrQueueItemExists
+		}
+	}
+	q.enqueued = append(q.enqueued, item)
+	return nil
+}
+
+func TestMaybeEnqueueDiscoveryStepCoalesces(t *testing.T) {
+	runID := ulid.MustNew(ulid.Now(), nil)
+	ck := computeParallelCoalesceKey(runID.String(), []string{"step-a", "step-b"})
+
+	q := &dedupeQueue{}
+	e := &executor{
+		queue:          q,
+		log:            logger.From(context.Background()),
+		tracerProvider: tracing.NewNoopTracerProvider(),
+	}
+
+	rc := &mockRunContext{
+		md: sv2.Metadata{
+			ID:     sv2.ID{RunID: runID, FunctionID: uuid.New()},
+			Config: *sv2.InitConfig(&sv2.Config{}),
+		},
+		lifecycleItem: queue.Item{ParallelCoalesceKey: &ck},
+	}
+
+	gen := state.GeneratorOpcode{Op: enums.OpcodeStepRun, ID: "step-a"}
+	edge := queue.PayloadEdge{Edge: inngest.Edge{Incoming: "step"}}
+
+	for i := 0; i < 3; i++ {
+		err := e.maybeEnqueueDiscoveryStep(context.Background(), rc, gen, edge, uuid.New().String(), false)
+		require.NoError(t, err)
+	}
+
+	require.Len(t, q.enqueued, 1, "all parallel completions must coalesce to a single discovery enqueue")
+	require.Equal(t, fmt.Sprintf("%s-%s-discover", runID, ck), *q.enqueued[0].JobID)
 }
 
 // EXE-1625: when the SDK responds with a step that the checkpoint path

--- a/pkg/execution/executor/resume_coalesce_test.go
+++ b/pkg/execution/executor/resume_coalesce_test.go
@@ -1,0 +1,164 @@
+package executor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/execution"
+	"github.com/inngest/inngest/pkg/execution/pauses"
+	"github.com/inngest/inngest/pkg/execution/state"
+	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type stubRunServiceMD struct {
+	sv2.RunService
+	saveStepHasPending bool
+	saveStepErr        error
+	md                 sv2.Metadata
+}
+
+func (s *stubRunServiceMD) LoadMetadata(_ context.Context, _ sv2.ID, _ ...sv2.LoadMetadataOption) (sv2.Metadata, error) {
+	return s.md, nil
+}
+
+func (s *stubRunServiceMD) SaveStep(_ context.Context, _ sv2.ID, _ string, _ []byte) (bool, error) {
+	return s.saveStepHasPending, s.saveStepErr
+}
+
+type stubPauseMgr struct {
+	pauses.Manager
+	consumeResult state.ConsumePauseResult
+}
+
+func (s *stubPauseMgr) ConsumePause(_ context.Context, _ sv2.RunService, _ state.Pause, _ state.ConsumePauseOpts) (state.ConsumePauseResult, func() error, error) {
+	return s.consumeResult, func() error { return nil }, nil
+}
+
+func (s *stubPauseMgr) Delete(_ context.Context, _ pauses.Index, _ state.Pause, _ ...state.DeletePauseOpt) error {
+	return nil
+}
+
+func TestResumePauseTimeoutCoalesceJobID(t *testing.T) {
+	cases := []struct {
+		name string
+		ck   string
+	}{
+		{name: "coalesce key set", ck: "abc123"},
+		{name: "no coalesce key", ck: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runID := ulid.MustNew(ulid.Now(), nil)
+			wsID, fnID, aID := uuid.New(), uuid.New(), uuid.New()
+
+			md := sv2.Metadata{
+				ID: sv2.ID{
+					RunID:      runID,
+					FunctionID: fnID,
+					Tenant:     sv2.Tenant{EnvID: wsID, AccountID: aID},
+				},
+				Config: *sv2.InitConfig(&sv2.Config{}),
+			}
+
+			q := &stubQueue{}
+			e := &executor{
+				smv2:           &stubRunServiceMD{md: md},
+				pm:             &stubPauseMgr{},
+				queue:          q,
+				log:            logger.From(context.Background()),
+				tracerProvider: tracing.NewNoopTracerProvider(),
+			}
+
+			pause := state.Pause{
+				ID:          uuid.New(),
+				WorkspaceID: wsID,
+				DataKey:     "wait-step",
+				Identifier: state.PauseIdentifier{
+					RunID:      runID,
+					FunctionID: fnID,
+					AccountID:  aID,
+				},
+				ParallelCoalesceKey: tc.ck,
+			}
+
+			err := e.ResumePauseTimeout(context.Background(), pause, execution.ResumeRequest{})
+			require.NoError(t, err)
+			require.Len(t, q.enqueued, 1)
+
+			got := *q.enqueued[0].JobID
+			if tc.ck != "" {
+				require.Equal(t, fmt.Sprintf("%s-%s-discover", runID, tc.ck), got)
+			} else {
+				require.Equal(t, fmt.Sprintf("%s-%s-timeout", md.IdempotencyKey(), pause.DataKey), got)
+			}
+		})
+	}
+}
+
+func TestResumeCoalesceJobID(t *testing.T) {
+	cases := []struct {
+		name string
+		ck   string
+	}{
+		{name: "coalesce key set", ck: "def456"},
+		{name: "no coalesce key", ck: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runID := ulid.MustNew(ulid.Now(), nil)
+			wsID, fnID, aID := uuid.New(), uuid.New(), uuid.New()
+
+			md := sv2.Metadata{
+				ID: sv2.ID{
+					RunID:      runID,
+					FunctionID: fnID,
+					Tenant:     sv2.Tenant{EnvID: wsID, AccountID: aID},
+				},
+				Config: *sv2.InitConfig(&sv2.Config{}),
+			}
+
+			q := &stubQueue{}
+			e := &executor{
+				smv2: &stubRunServiceMD{md: md},
+				pm: &stubPauseMgr{consumeResult: state.ConsumePauseResult{
+					DidConsume:      true,
+					HasPendingSteps: false,
+				}},
+				queue:          q,
+				log:            logger.From(context.Background()),
+				tracerProvider: tracing.NewNoopTracerProvider(),
+			}
+
+			pause := state.Pause{
+				ID:          uuid.New(),
+				WorkspaceID: wsID,
+				DataKey:     "wait-step",
+				Identifier: state.PauseIdentifier{
+					RunID:      runID,
+					FunctionID: fnID,
+					AccountID:  aID,
+				},
+				ParallelCoalesceKey: tc.ck,
+			}
+
+			err := e.Resume(context.Background(), pause, execution.ResumeRequest{})
+			require.NoError(t, err)
+			require.Len(t, q.enqueued, 1)
+
+			got := *q.enqueued[0].JobID
+			if tc.ck != "" {
+				require.Equal(t, fmt.Sprintf("%s-%s-discover", runID, tc.ck), got)
+			} else {
+				require.Equal(t, fmt.Sprintf("%s-%s-event", md.IdempotencyKey(), pause.DataKey), got)
+			}
+		})
+	}
+}

--- a/pkg/execution/executor/util.go
+++ b/pkg/execution/executor/util.go
@@ -3,8 +3,11 @@ package executor
 import (
 	"context"
 	"crypto/rand"
+	"encoding/hex"
+	"sort"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/event"
@@ -14,6 +17,23 @@ import (
 	"github.com/oklog/ulid/v2"
 )
 
+// computeParallelCoalesceKey returns a stable hex string derived from the runID and
+// the sorted set of step IDs in a parallel batch.  Sorting ensures the key is
+// identical regardless of the order the SDK returns the opcodes.
+func computeParallelCoalesceKey(runID string, stepIDs []string) string {
+	sorted := make([]string, len(stepIDs))
+	copy(sorted, stepIDs)
+	sort.Strings(sorted)
+
+	h := xxhash.New()
+	_, _ = h.Write([]byte(runID))
+	for _, id := range sorted {
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(id))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
 // OpcodeGroup is a group of opcodes that can be processed in parallel.
 type OpcodeGroup struct {
 	// Opcodes is the list of opcodes in the group.
@@ -22,6 +42,10 @@ type OpcodeGroup struct {
 	// start a new history group. This is true if the overall list of opcodes
 	// received from an SDK Call Request contains more than one opcode.
 	ShouldStartHistoryGroup bool
+	// ParallelCoalesceKey is a stable key shared by all items in this parallel
+	// batch.  When non-empty, handlers use it to derive a deterministic
+	// discovery JobID so concurrent fan-in completions deduplicate to one step.
+	ParallelCoalesceKey string
 }
 
 // OpcodeGroups groups opcodes by processing priority. The priority group runs

--- a/pkg/execution/executor/util_test.go
+++ b/pkg/execution/executor/util_test.go
@@ -362,6 +362,38 @@ func TestOpcodeGroups_IDs_ExcludesLazyOps(t *testing.T) {
 	}
 }
 
+func TestComputeParallelCoalesceKey(t *testing.T) {
+	t.Run("deterministic", func(t *testing.T) {
+		a := computeParallelCoalesceKey("run-1", []string{"step-a", "step-b"})
+		b := computeParallelCoalesceKey("run-1", []string{"step-a", "step-b"})
+		require.Equal(t, a, b)
+	})
+
+	t.Run("order independent", func(t *testing.T) {
+		a := computeParallelCoalesceKey("run-1", []string{"step-a", "step-b"})
+		b := computeParallelCoalesceKey("run-1", []string{"step-b", "step-a"})
+		require.Equal(t, a, b)
+	})
+
+	t.Run("different step sets produce different keys", func(t *testing.T) {
+		a := computeParallelCoalesceKey("run-1", []string{"step-a", "step-b"})
+		b := computeParallelCoalesceKey("run-1", []string{"step-a", "step-c"})
+		require.NotEqual(t, a, b)
+	})
+
+	t.Run("different run IDs produce different keys", func(t *testing.T) {
+		a := computeParallelCoalesceKey("run-1", []string{"step-a"})
+		b := computeParallelCoalesceKey("run-2", []string{"step-a"})
+		require.NotEqual(t, a, b)
+	})
+
+	t.Run("no length extension collision", func(t *testing.T) {
+		a := computeParallelCoalesceKey("run-1", []string{"ab", "c"})
+		b := computeParallelCoalesceKey("run-1", []string{"a", "bc"})
+		require.NotEqual(t, a, b)
+	})
+}
+
 func TestAllEmptyNoneOps(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/execution/queue/item.go
+++ b/pkg/execution/queue/item.go
@@ -373,6 +373,11 @@ type Item struct {
 	// ends
 	ParallelMode enums.ParallelMode `json:"pm,omitempty"`
 
+	// ParallelCoalesceKey is a stable key shared by all queue items in the same
+	// parallel batch.  When set, all fan-in completions derive the same
+	// discovery job ID so that only one succeeds via queue-level idempotency.
+	ParallelCoalesceKey *string `json:"pck,omitempty"`
+
 	// Semaphores stores evaluated semaphore constraints for this queue item.
 	// Only present on start jobs for function concurrency, or on all items
 	// for worker concurrency (app-scoped semaphores).
@@ -497,6 +502,7 @@ func (i *Item) UnmarshalJSON(b []byte) error {
 		CustomConcurrencyKeys []state.CustomConcurrency `json:"cck,omitempty"`
 		PriorityFactor        *int64                    `json:"pf,omitempty"`
 		ParallelMode          enums.ParallelMode        `json:"pm,omitempty"`
+		ParallelCoalesceKey   *string                   `json:"pck,omitempty"`
 		Semaphores            []constraintapi.Semaphore `json:"sem,omitempty"`
 	}
 	temp := &kind{}
@@ -519,6 +525,7 @@ func (i *Item) UnmarshalJSON(b []byte) error {
 	i.PriorityFactor = temp.PriorityFactor
 	i.QueueName = temp.QueueName
 	i.ParallelMode = temp.ParallelMode
+	i.ParallelCoalesceKey = temp.ParallelCoalesceKey
 	i.Semaphores = temp.Semaphores
 
 	// Save this for custom unmarshalling of other jobs.  This is overwritten

--- a/pkg/execution/state/pause.go
+++ b/pkg/execution/state/pause.go
@@ -253,6 +253,11 @@ type Pause struct {
 	// ends
 	ParallelMode enums.ParallelMode `json:"pm,omitempty"`
 
+	// ParallelCoalesceKey, when non-empty, matches the key stored on the parallel
+	// step queue items in the same batch. Resume paths use it to produce the same
+	// discovery JobID as step.run completions, enabling ErrQueueItemExists dedup.
+	ParallelCoalesceKey string `json:"pck,omitempty"`
+
 	// CreatedAt is the timestamp when the pause was saved. This field may
 	// be empty for older pauses created before this field was added. It's used to
 	// determine which time-based storage blocks contain this pause, as block

--- a/pkg/telemetry/metrics/counter.go
+++ b/pkg/telemetry/metrics/counter.go
@@ -981,6 +981,15 @@ func IncrExecutorHandleGeneratorCount(ctx context.Context, op string, opts Count
 	})
 }
 
+func IncrDiscoveryCoalesceDedupCount(ctx context.Context, opts CounterOpt) {
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "executor_discovery_coalesce_dedup_total",
+		Description: "Total number of duplicate discovery steps deduplicated via parallel coalesce key",
+		Tags:        opts.Tags,
+	})
+}
+
 func IncrConnectProxyLeaseExpiredCount(ctx context.Context, opts CounterOpt) {
 	RecordCounterMetric(ctx, 1, CounterOpt{
 		PkgName:     opts.PkgName,

--- a/tests/execution/executor/defer_test.go
+++ b/tests/execution/executor/defer_test.go
@@ -673,8 +673,9 @@ func TestDeferAdd(t *testing.T) {
 		ctx := infra.ctx
 
 		const (
-			plannedStepID = "planned-step"
-			deferStepID   = "defer-add-step"
+			plannedStepID  = "planned-step"
+			plannedStepID2 = "planned-step-2"
+			deferStepID    = "defer-add-step"
 		)
 
 		spy := &pendingCapturingState{RunService: infra.smv2}
@@ -683,11 +684,12 @@ func TestDeferAdd(t *testing.T) {
 			t: t,
 			response: &state.DriverResponse{
 				StatusCode: 206,
-				// ShouldCoalesceParallelism returns true for >= 2; required for
-				// the executor to invoke SavePending.
+				// Two non-lazy ops are required for len(nonLazyIDs) > 1, which
+				// is the condition that triggers SavePending.
 				RequestVersion: 2,
 				Generator: []*state.GeneratorOpcode{
 					{Op: enums.OpcodeStepPlanned, ID: plannedStepID, Name: plannedStepID},
+					{Op: enums.OpcodeStepPlanned, ID: plannedStepID2, Name: plannedStepID2},
 					{
 						Op: enums.OpcodeDeferAdd,
 						ID: deferStepID,


### PR DESCRIPTION
## Description

  When N parallel steps complete concurrently against a non-serializable state store, all N can see hasPendingSteps=false and each schedule a discovery step. Existing queue dedup doesn't help because each branch uses its own gen.ID in the job ID.

  Fix: compute xxhash(runID, sorted(stepIDs)) once per parallel batch and stamp it on every branch's queue item + pause. All branches in the same batch produce the same {runID}-{ck}-discover job ID → first enqueue wins, rest hit ErrQueueItemExists. Redis is unaffected (serializable). Old items without the key fall back to existing behavior.

<!-- What changed? Include screenshots if you modify the UI. -->
## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
