### PR TITLE
fix(trace view): Fix the ordering/timestamps of finalization spans

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
@@ -3,7 +3,7 @@
  * Feature: 001-composable-timeline-bar
  */
 
-import { toMaybeDate } from '@inngest/components/utils/date';
+import { maxDateString, toMaybeDate } from '@inngest/components/utils/date';
 import { max, min } from 'date-fns';
 
 import { KindInngestExperiment } from '../../generated';
@@ -302,6 +302,8 @@ export function traceRollup(root: Trace): Trace {
   const steps = new Map<string, Map<number, Trace>>();
   const rolledUpRunChildren: Trace[] = [];
   const groupedSpans = new Map<string, Map<number, Trace>>();
+  let lastStepEndedAt: Date | null = null;
+  let lastStep: Trace | null = null;
   let finalSpan: Trace | null = null;
   for (const child of root.childrenSpans ?? []) {
     if (child.outputID && !child.stepID) {
@@ -324,6 +326,12 @@ export function traceRollup(root: Trace): Trace {
 
     if (!steps.get(child.stepID)) {
       stepOrder.push(child.stepID);
+    }
+
+    const endedAt = toMaybeDate(child.endedAt);
+    if (!lastStepEndedAt || (endedAt && endedAt > lastStepEndedAt)) {
+      lastStepEndedAt = endedAt;
+      lastStep = child;
     }
 
     const attempts = steps.get(child.stepID) ?? new Map<number, Trace>();
@@ -394,6 +402,9 @@ export function traceRollup(root: Trace): Trace {
     const maxAttemptTrace = attempts.get(maxAttempt) as Trace;
     if (attempts.size == 1) {
       maxAttemptTrace.name = 'Finalization';
+      maxAttemptTrace.queuedAt = maxDateString(maxAttemptTrace.queuedAt, lastStep?.endedAt);
+      maxAttemptTrace.scheduledAt = maxDateString(maxAttemptTrace.scheduledAt, lastStep?.endedAt);
+      maxAttemptTrace.startedAt = maxDateString(maxAttemptTrace.startedAt, lastStep?.endedAt);
       rolledUpRunChildren.push(maxAttemptTrace);
     } else {
       // Create a virtual span to represent the finalization as a whole with all attempts
@@ -404,9 +415,9 @@ export function traceRollup(root: Trace): Trace {
         spanID: `final-rollup`, // virtual span
         groupID: maxAttemptTrace.groupID,
         attempts: maxAttemptTrace.attempts,
-        queuedAt: minAttemptTrace.queuedAt,
-        scheduledAt: minAttemptTrace.scheduledAt,
-        startedAt: minAttemptTrace.startedAt,
+        queuedAt: maxDateString(minAttemptTrace.queuedAt, lastStep?.endedAt),
+        scheduledAt: maxDateString(minAttemptTrace.scheduledAt, lastStep?.endedAt),
+        startedAt: maxDateString(minAttemptTrace.startedAt, lastStep?.endedAt),
         endedAt: maxAttemptTrace.endedAt,
         status: maxAttemptTrace.status,
         outputID: maxAttemptTrace.outputID,

--- a/ui/packages/components/src/utils/date.ts
+++ b/ui/packages/components/src/utils/date.ts
@@ -172,6 +172,24 @@ export function toMaybeDate<T extends string | null | undefined>(value: T): Date
   return new Date(value);
 }
 
+export function maxDateString<T extends string | null | undefined>(
+  date1: T,
+  date2: T | null | undefined
+): T {
+  if (!date2) {
+    return date1;
+  }
+
+  const d1 = toMaybeDate(date1);
+  const d2 = toMaybeDate(date2);
+
+  if (!d1 || !d2) {
+    return date1;
+  }
+
+  return d1 > d2 ? date1 : date2;
+}
+
 export const parseDuration = (duration: string): Duration => {
   if (!DURATION_STRING_REGEX.test(duration)) {
     throw Error(


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

Currently we emit finalization spans with timestamps derived from the execution as a whole. If there were steps checkpointed during the execution, these timestamps are too early which causes display issues. This just bumps the timestamps visually so that the view is correct until we do SDK-side plumbing to emit better timestamps after checkpointing.

Before:
<img width="868" height="255" alt="image" src="https://github.com/user-attachments/assets/b35fb0bf-d115-4cc2-b4d2-9e62774cdc56" />

After: (notice the sleep bar bumps the finalization bar)
<img width="877" height="244" alt="image" src="https://github.com/user-attachments/assets/72a06887-2b79-489e-97d6-2e9436d67c7e" />


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
