### PR TITLE
feat: dogfood insights ai scoring

### DIFF
--- a/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorSaveQueryButton.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsSQLEditor/InsightsSQLEditorSaveQueryButton.tsx
@@ -7,7 +7,10 @@ import {
 } from '@inngest/components/Tooltip';
 import { cn } from '@inngest/components/utils/classNames';
 import { RiSaveLine } from '@remixicon/react';
+import { useCallback } from 'react';
 
+import { useInsightsChatProviderOptional } from '../InsightsTabManager/InsightsHelperPanel/features/InsightsChat/InsightsChatProvider';
+import { postQueryFeedback, sqlWasEdited } from '../queryFeedback';
 import { KeyboardShortcutTooltip } from '../KeyboardShortcutTooltip';
 import type { Tab } from '../types';
 import { useSaveTab } from './SaveTabContext';
@@ -21,11 +24,23 @@ export function InsightsSQLEditorSaveQueryButton({
   tab,
 }: InsightsSQLEditorSaveQueryButtonProps) {
   const { canSave, isSaving, saveTab } = useSaveTab(tab);
+  const chat = useInsightsChatProviderOptional();
+
+  // Saving an unmodified AI-generated query is a strong positive signal.
+  const handleSave = useCallback(() => {
+    saveTab();
+    const threadId = chat?.currentThreadId;
+    if (!chat || !threadId) return;
+    const runId = chat.getLatestRunId(threadId);
+    if (!runId) return;
+    if (sqlWasEdited(chat.getLatestGeneratedSql(threadId), tab.query)) return;
+    void postQueryFeedback({ runId, saved: true });
+  }, [saveTab, chat, tab.query]);
 
   useDocumentShortcuts([
     {
       combo: { alt: true, code: 'KeyS', metaOrCtrl: true },
-      handler: saveTab,
+      handler: handleSave,
     },
   ]);
 
@@ -48,7 +63,7 @@ export function InsightsSQLEditorSaveQueryButton({
             label="Save"
             loading={isSaving}
             onClick={() => {
-              saveTab();
+              handleSave();
             }}
             size="medium"
           />

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/InsightsChat.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/InsightsChat.tsx
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useSQLEditorActions } from '@/components/Insights/InsightsSQLEditor/SQLEditorContext';
 import { useInsightsStateMachineContext } from '@/components/Insights/InsightsStateMachineContext/InsightsStateMachineContext';
+import {
+  postQueryFeedback,
+  sqlWasEdited,
+} from '@/components/Insights/queryFeedback';
 import { Conversation, ConversationContent } from './Conversation';
 import { EmptyState } from './EmptyState';
 import { useInsightsChatProvider } from './InsightsChatProvider';
@@ -72,8 +76,12 @@ type InsightsChatProps = {
 };
 
 export function InsightsChat({ agentThreadId, className }: InsightsChatProps) {
-  const { query: currentSql, queryName: tabTitle } =
-    useInsightsStateMachineContext();
+  const {
+    query: currentSql,
+    queryName: tabTitle,
+    status: executionStatus,
+    data: executionData,
+  } = useInsightsStateMachineContext();
 
   const editorActions = useSQLEditorActions();
 
@@ -86,6 +94,7 @@ export function InsightsChat({ agentThreadId, className }: InsightsChatProps) {
     sendMessageToThread,
     getThreadFlags,
     getLatestGeneratedSql,
+    getLatestRunId,
     latestSqlVersion,
     setThreadClientState,
     eventTypes,
@@ -110,6 +119,37 @@ export function InsightsChat({ agentThreadId, className }: InsightsChatProps) {
 
     editorActions.setQueryAndRun(latest);
   }, [currentThreadId, agentThreadId, latestSqlVersion]);
+
+  // Report each execution outcome as deferred feedback on the originating run.
+  const reportedFeedbackRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (currentThreadId !== agentThreadId) return;
+    if (executionStatus !== 'success' && executionStatus !== 'error') return;
+    const runId = getLatestRunId(agentThreadId);
+    if (!runId) return;
+
+    const key = `${runId}:${executionStatus}:${currentSql}`;
+    if (reportedFeedbackRef.current === key) return;
+    reportedFeedbackRef.current = key;
+
+    void postQueryFeedback({
+      runId,
+      executedOk: executionStatus === 'success',
+      rowCount: executionData?.rows?.length ?? 0,
+      userEdited: sqlWasEdited(
+        getLatestGeneratedSql(agentThreadId),
+        currentSql,
+      ),
+    });
+  }, [
+    currentThreadId,
+    agentThreadId,
+    executionStatus,
+    executionData,
+    currentSql,
+    getLatestRunId,
+    getLatestGeneratedSql,
+  ]);
 
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/InsightsChatProvider.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/InsightsChatProvider.tsx
@@ -35,6 +35,7 @@ type ContextValue = {
   // Per-thread UI flags and derived SQL
   getThreadFlags: (threadId: string) => ThreadFlags;
   getLatestGeneratedSql: (threadId: string) => string | undefined;
+  getLatestRunId: (threadId: string) => string | undefined;
   latestSqlVersion: number;
 
   // Client-state per thread
@@ -73,6 +74,8 @@ export function InsightsChatProvider({
   // Latest generated SQL per thread
   const latestSqlByThreadRef = useRef<Map<string, string>>(new Map());
   const [latestSqlVersion, setLatestSqlVersion] = useState(0);
+  // Latest Inngest run id per thread, for attributing query feedback to a run
+  const latestRunIdByThreadRef = useRef<Map<string, string>>(new Map());
 
   // Per-thread client state map
   const threadClientStateRef = useRef<Map<string, ClientState>>(new Map());
@@ -94,6 +97,10 @@ export function InsightsChatProvider({
     },
     [],
   );
+
+  const getLatestRunId = useCallback((threadId: string): string | undefined => {
+    return latestRunIdByThreadRef.current.get(threadId);
+  }, []);
 
   // Realtime subscription
   const { messages: realtimeMessages, connectionStatus } = useInsightsRealtime({
@@ -142,6 +149,12 @@ export function InsightsChatProvider({
           }
 
           case 'run.completed': {
+            const completedRunId =
+              typeof evt.data.runId === 'string' ? evt.data.runId : undefined;
+            if (completedRunId) {
+              latestRunIdByThreadRef.current.set(tid, completedRunId);
+            }
+
             // Build assistant message from the completed run
             const parts: Message['parts'] = [];
 
@@ -369,6 +382,7 @@ export function InsightsChatProvider({
       return next;
     });
     latestSqlByThreadRef.current.delete(threadId);
+    latestRunIdByThreadRef.current.delete(threadId);
   }, []);
 
   const messages = useMemo(
@@ -386,6 +400,7 @@ export function InsightsChatProvider({
       sendMessageToThread,
       getThreadFlags: getFlags,
       getLatestGeneratedSql,
+      getLatestRunId,
       latestSqlVersion,
       setThreadClientState,
       eventTypes: eventsData?.names ?? [],
@@ -400,6 +415,7 @@ export function InsightsChatProvider({
       sendMessageToThread,
       getFlags,
       getLatestGeneratedSql,
+      getLatestRunId,
       latestSqlVersion,
       setThreadClientState,
       eventsData?.names,

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/InsightsChatProvider.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsHelperPanel/features/InsightsChat/InsightsChatProvider.tsx
@@ -438,3 +438,9 @@ export function useInsightsChatProvider(): ContextValue {
     );
   return ctx;
 }
+
+// Non-throwing variant for components that also render outside the chat
+// provider (e.g. the editor when the AI helper is disabled).
+export function useInsightsChatProviderOptional(): ContextValue | undefined {
+  return useContext(InsightsChatContext);
+}

--- a/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
+++ b/ui/apps/dashboard/src/components/Insights/InsightsTabManager/InsightsTabManager.tsx
@@ -18,6 +18,7 @@ import type { InsightsQueryStatement } from '@/gql/graphql';
 import { isQuerySnapshot, isQueryTemplate } from '../queries';
 import { SHOW_DOCS_CONTROL_PANEL_BUTTON } from '../temp-flags';
 import { InsightsAIHelperProvider } from '../InsightsAIHelperContext';
+import { postQueryFeedback } from '../queryFeedback';
 import { InsightsHelperPanel } from './InsightsHelperPanel/InsightsHelperPanel';
 import {
   InsightsHelperPanelControl,
@@ -482,6 +483,10 @@ function TabsWithAIHelper({
     async (prompt: string) => {
       // Get the thread ID for the active tab
       const threadId = getAgentThreadIdForTab(activeTabId);
+
+      // The sole caller is "Fix with AI" — a strong negative signal on the run.
+      const runId = chatProvider.getLatestRunId(threadId);
+      if (runId) void postQueryFeedback({ runId, fixWithAi: true });
 
       // Set the current thread ID FIRST, before opening the panel
       // This ensures the InsightsChat component has the correct thread ID when it mounts

--- a/ui/apps/dashboard/src/components/Insights/queryFeedback.test.ts
+++ b/ui/apps/dashboard/src/components/Insights/queryFeedback.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { sqlWasEdited } from './queryFeedback';
+
+describe('sqlWasEdited', () => {
+  it('is false when only formatting, whitespace, or case differ', () => {
+    expect(
+      sqlWasEdited('select count() from runs', 'SELECT count()\nFROM   runs'),
+    ).toBe(false);
+  });
+
+  it('is false for an exact match', () => {
+    expect(sqlWasEdited('SELECT 1', 'SELECT 1')).toBe(false);
+  });
+
+  it('tolerates a trailing-semicolon difference', () => {
+    expect(sqlWasEdited('SELECT 1', 'SELECT 1;')).toBe(false);
+  });
+
+  it('is true when the query was materially changed', () => {
+    expect(sqlWasEdited('SELECT 1', 'SELECT 2')).toBe(true);
+  });
+
+  it('is true when there is no suggestion to compare against', () => {
+    expect(sqlWasEdited(undefined, 'SELECT 1')).toBe(true);
+  });
+});

--- a/ui/apps/dashboard/src/components/Insights/queryFeedback.ts
+++ b/ui/apps/dashboard/src/components/Insights/queryFeedback.ts
@@ -1,0 +1,36 @@
+export interface QueryFeedbackPayload {
+  runId: string;
+  executedOk?: boolean;
+  rowCount?: number;
+  userEdited?: boolean;
+  saved?: boolean;
+  fixWithAi?: boolean;
+}
+
+function normalizeSqlForCompare(sql: string): string {
+  return sql.replace(/;\s*$/, '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+// Heuristic: the editor SQL is formatSQL-formatted while the suggestion is raw,
+// so compare on a normalized form. No suggestion → treat as edited.
+export function sqlWasEdited(
+  suggested: string | undefined,
+  executed: string,
+): boolean {
+  if (suggested === undefined) return true;
+  return normalizeSqlForCompare(suggested) !== normalizeSqlForCompare(executed);
+}
+
+export async function postQueryFeedback(
+  payload: QueryFeedbackPayload,
+): Promise<void> {
+  try {
+    await fetch('/api/query-feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch {
+    // Best-effort: feedback scoring must never disrupt the user.
+  }
+}

--- a/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { inngest } from '../client';
 import { insightsChannel } from '../realtime';
+import { insightsJudgeScorer } from './scoring/insights-judge';
 import { buildImmediateScores } from './scoring/insights-scores';
 import {
   buildSystemPrompt as buildEventMatcherPrompt,
@@ -43,7 +44,7 @@ export const runInsightsAgent = inngest.createFunction(
     name: 'Insights SQL Agent',
     triggers: [{ event: 'insights-agent/chat.requested' }],
   },
-  async ({ event, step, group, runId }) => {
+  async ({ event, step, group, runId, defer }) => {
     const {
       threadId: providedThreadId,
       userMessage,
@@ -336,6 +337,18 @@ export const runInsightsAgent = inngest.createFunction(
       },
       timestamp: Date.now(),
     });
+
+    // Defer the LLM-as-judge off the critical path.
+    if (sqlResult.sql) {
+      defer('judge', {
+        function: insightsJudgeScorer,
+        data: {
+          question: userMessage.content,
+          sql: sqlResult.sql,
+          summary,
+        },
+      });
+    }
 
     return {
       success: true,

--- a/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/run-insights.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { inngest } from '../client';
 import { insightsChannel } from '../realtime';
+import { buildImmediateScores } from './scoring/insights-scores';
 import {
   buildSystemPrompt as buildEventMatcherPrompt,
   parseToolResult as parseEventMatcherResult,
@@ -42,7 +43,7 @@ export const runInsightsAgent = inngest.createFunction(
     name: 'Insights SQL Agent',
     triggers: [{ event: 'insights-agent/chat.requested' }],
   },
-  async ({ event, step, group }) => {
+  async ({ event, step, group, runId }) => {
     const {
       threadId: providedThreadId,
       userMessage,
@@ -180,85 +181,100 @@ export const runInsightsAgent = inngest.createFunction(
 
     const anthropicClient = new Anthropic();
 
-    const queryWriterResult = await group.experiment('query-writer-model', {
-      variants: {
-        'claude-sonnet-4-5': () =>
-          step.run('query-writer', async () => {
-            const startedAt = Date.now();
-            const result = await anthropicClient.messages.create({
-              model: 'claude-sonnet-4-5',
-              max_tokens: 4096,
-              ...queryWriterBody,
-            });
-            const latencyMs = Date.now() - startedAt;
+    const { result: queryWriterResult, variant } = await group.experiment(
+      'query-writer-model',
+      {
+        variants: {
+          'claude-sonnet-4-5': () =>
+            step.run('query-writer', async () => {
+              const startedAt = Date.now();
+              const result = await anthropicClient.messages.create({
+                model: 'claude-sonnet-4-5',
+                max_tokens: 4096,
+                ...queryWriterBody,
+              });
+              const latencyMs = Date.now() - startedAt;
 
-            const inputTokens = result.usage.input_tokens;
-            const outputTokens = result.usage.output_tokens;
-            const pricing = QUERY_WRITER_PRICING['claude-sonnet-4-5'];
-            const costUsd = calculateCostUsd(
-              inputTokens,
-              outputTokens,
-              pricing,
-            );
+              const inputTokens = result.usage.input_tokens;
+              const outputTokens = result.usage.output_tokens;
+              const pricing = QUERY_WRITER_PRICING['claude-sonnet-4-5'];
+              const costUsd = calculateCostUsd(
+                inputTokens,
+                outputTokens,
+                pricing,
+              );
 
-            await inngest.score({
-              name: 'query_writer_latency_ms',
-              value: latencyMs,
-            });
-            await inngest.score({
-              name: 'query_writer_output_tokens',
-              value: outputTokens,
-            });
-            await inngest.score({
-              name: 'query_writer_cost_usd',
-              value: costUsd,
-            });
+              await inngest.score({
+                name: 'query_writer_latency_ms',
+                value: latencyMs,
+              });
+              await inngest.score({
+                name: 'query_writer_output_tokens',
+                value: outputTokens,
+              });
+              await inngest.score({
+                name: 'query_writer_cost_usd',
+                value: costUsd,
+              });
 
-            return result;
-          }),
-        'claude-opus-4-8': () =>
-          step.run('query-writer', async () => {
-            const startedAt = Date.now();
-            const result = await anthropicClient.messages.create({
-              model: 'claude-opus-4-8',
-              max_tokens: 4096,
-              ...queryWriterBody,
-            });
-            const latencyMs = Date.now() - startedAt;
+              return result;
+            }),
+          'claude-opus-4-8': () =>
+            step.run('query-writer', async () => {
+              const startedAt = Date.now();
+              const result = await anthropicClient.messages.create({
+                model: 'claude-opus-4-8',
+                max_tokens: 4096,
+                ...queryWriterBody,
+              });
+              const latencyMs = Date.now() - startedAt;
 
-            const inputTokens = result.usage.input_tokens;
-            const outputTokens = result.usage.output_tokens;
-            const pricing = QUERY_WRITER_PRICING['claude-opus-4-8'];
-            const costUsd = calculateCostUsd(
-              inputTokens,
-              outputTokens,
-              pricing,
-            );
+              const inputTokens = result.usage.input_tokens;
+              const outputTokens = result.usage.output_tokens;
+              const pricing = QUERY_WRITER_PRICING['claude-opus-4-8'];
+              const costUsd = calculateCostUsd(
+                inputTokens,
+                outputTokens,
+                pricing,
+              );
 
-            await inngest.score({
-              name: 'query_writer_latency_ms',
-              value: latencyMs,
-            });
-            await inngest.score({
-              name: 'query_writer_output_tokens',
-              value: outputTokens,
-            });
-            await inngest.score({
-              name: 'query_writer_cost_usd',
-              value: costUsd,
-            });
+              await inngest.score({
+                name: 'query_writer_latency_ms',
+                value: latencyMs,
+              });
+              await inngest.score({
+                name: 'query_writer_output_tokens',
+                value: outputTokens,
+              });
+              await inngest.score({
+                name: 'query_writer_cost_usd',
+                value: costUsd,
+              });
 
-            return result;
-          }),
+              return result;
+            }),
+        },
+        select: experiment.weighted({
+          'claude-sonnet-4-5': 50,
+          'claude-opus-4-8': 50,
+        }),
+        withVariant: true,
       },
-      select: experiment.weighted({
-        'claude-sonnet-4-5': 50,
-        'claude-opus-4-8': 50,
-      }),
-    });
+    );
 
     const sqlResult = await step.run('extract-query-writer-result', () => {
       return parseQueryWriterResult(queryWriterResult);
+    });
+
+    // Immediate, run-scoped success scores (decoupled from the experiment;
+    // variant rides along as the `isOpus` bool). Memoized so they write once.
+    await step.run('emit-immediate-scores', async () => {
+      for (const score of buildImmediateScores({
+        sql: sqlResult.sql,
+        variant,
+      })) {
+        await inngest.score(score);
+      }
     });
 
     await step.realtime.publish(
@@ -308,6 +324,7 @@ export const runInsightsAgent = inngest.createFunction(
       event: 'run.completed',
       data: {
         threadId,
+        runId,
         sql: sqlResult.sql,
         title: sqlResult.title,
         reasoning: sqlResult.reasoning,

--- a/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-feedback.test.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-feedback.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFeedbackScores } from './insights-feedback';
+
+describe('buildFeedbackScores', () => {
+  it('maps a successful execution to executed_ok, returned_rows, and user_accepted', () => {
+    expect(
+      buildFeedbackScores({
+        runId: 'r1',
+        executedOk: true,
+        rowCount: 5,
+        userEdited: false,
+      }),
+    ).toEqual([
+      { name: 'insights_executed_ok', value: true },
+      { name: 'insights_returned_rows', value: true },
+      { name: 'insights_user_accepted', value: true },
+    ]);
+  });
+
+  it('treats zero rows as returned_rows=false and an edit as not accepted', () => {
+    expect(
+      buildFeedbackScores({
+        runId: 'r1',
+        executedOk: false,
+        rowCount: 0,
+        userEdited: true,
+      }),
+    ).toEqual([
+      { name: 'insights_executed_ok', value: false },
+      { name: 'insights_returned_rows', value: false },
+      { name: 'insights_user_accepted', value: false },
+    ]);
+  });
+
+  it('maps an explicit save to query_saved', () => {
+    expect(buildFeedbackScores({ runId: 'r1', saved: true })).toEqual([
+      { name: 'insights_query_saved', value: true },
+    ]);
+  });
+
+  it('maps a fix-with-AI click to fix_with_ai_requested', () => {
+    expect(buildFeedbackScores({ runId: 'r1', fixWithAi: true })).toEqual([
+      { name: 'insights_fix_with_ai_requested', value: true },
+    ]);
+  });
+
+  it('only emits scores for fields that are present', () => {
+    expect(buildFeedbackScores({ runId: 'r1' })).toEqual([]);
+  });
+});

--- a/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-feedback.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-feedback.ts
@@ -1,0 +1,39 @@
+export interface QueryFeedback {
+  runId: string;
+  executedOk?: boolean;
+  rowCount?: number;
+  userEdited?: boolean;
+  saved?: boolean;
+  fixWithAi?: boolean;
+}
+
+export function buildFeedbackScores(
+  feedback: QueryFeedback,
+): { name: string; value: boolean }[] {
+  const scores: { name: string; value: boolean }[] = [];
+  if (feedback.executedOk !== undefined) {
+    scores.push({ name: 'insights_executed_ok', value: feedback.executedOk });
+  }
+  if (feedback.rowCount !== undefined) {
+    scores.push({
+      name: 'insights_returned_rows',
+      value: feedback.rowCount > 0,
+    });
+  }
+  if (feedback.userEdited !== undefined) {
+    scores.push({
+      name: 'insights_user_accepted',
+      value: !feedback.userEdited,
+    });
+  }
+  if (feedback.saved !== undefined) {
+    scores.push({ name: 'insights_query_saved', value: feedback.saved });
+  }
+  if (feedback.fixWithAi !== undefined) {
+    scores.push({
+      name: 'insights_fix_with_ai_requested',
+      value: feedback.fixWithAi,
+    });
+  }
+  return scores;
+}

--- a/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-judge-prompt.test.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-judge-prompt.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseJudgeRelevance } from './insights-judge-prompt';
+
+const toolUse = (input: unknown) => ({
+  content: [{ type: 'tool_use', name: 'submit_score', input }],
+});
+
+describe('parseJudgeRelevance', () => {
+  it('reads relevance from the submit_score tool call', () => {
+    expect(parseJudgeRelevance(toolUse({ relevance: 0.8 }))).toBe(0.8);
+  });
+
+  it('clamps to [0, 1]', () => {
+    expect(parseJudgeRelevance(toolUse({ relevance: 1.5 }))).toBe(1);
+    expect(parseJudgeRelevance(toolUse({ relevance: -0.4 }))).toBe(0);
+  });
+
+  it('returns null when there is no submit_score tool call', () => {
+    expect(
+      parseJudgeRelevance({ content: [{ type: 'text', text: 'hi' }] }),
+    ).toBe(null);
+  });
+
+  it('returns null when relevance is missing or not a number', () => {
+    expect(parseJudgeRelevance(toolUse({ reasoning: 'x' }))).toBe(null);
+    expect(parseJudgeRelevance(toolUse({ relevance: 'high' }))).toBe(null);
+    expect(parseJudgeRelevance(toolUse({ relevance: NaN }))).toBe(null);
+  });
+
+  it('returns null defensively for empty or malformed responses', () => {
+    expect(parseJudgeRelevance({ content: [] })).toBe(null);
+    expect(parseJudgeRelevance(null)).toBe(null);
+    expect(parseJudgeRelevance(undefined)).toBe(null);
+  });
+});

--- a/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-judge-prompt.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-judge-prompt.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod';
+
+import judgeSystemPrompt from './insights-judge-system.md?raw';
+
+export interface JudgeInput {
+  question: string;
+  sql: string;
+  summary: string;
+}
+
+export const JUDGE_SYSTEM_PROMPT = judgeSystemPrompt;
+
+export const SubmitScoreParams = z.object({
+  relevance: z
+    .number()
+    .describe(
+      'How well the response answers the question, from 0 (irrelevant/wrong) to 1 (fully answers).',
+    ),
+  reasoning: z.string().describe('One-sentence justification for the score.'),
+});
+
+export const submitScoreTool = {
+  name: 'submit_score' as const,
+  description:
+    'Record the relevance score for the AI response. Call exactly once.',
+  input_schema: z.toJSONSchema(SubmitScoreParams) as {
+    type: 'object';
+    [k: string]: unknown;
+  },
+};
+
+export function buildJudgeUserPrompt({
+  question,
+  sql,
+  summary,
+}: JudgeInput): string {
+  return [
+    "User's question:",
+    question,
+    '',
+    'SQL the assistant produced:',
+    '```sql',
+    sql,
+    '```',
+    '',
+    "Assistant's summary:",
+    summary,
+  ].join('\n');
+}
+
+function clamp01(n: number): number {
+  return Math.min(1, Math.max(0, n));
+}
+
+interface MaybeToolUse {
+  type?: string;
+  name?: string;
+  input?: { relevance?: unknown };
+}
+
+/**
+ * Returns null (not 0) on malformed/absent output,
+ * so the scorer no-ops rather than writing a misleading score.
+ */
+export function parseJudgeRelevance(
+  response: { content?: unknown } | null | undefined,
+): number | null {
+  const blocks = response?.content;
+  if (!Array.isArray(blocks)) return null;
+  const toolUse = (blocks as MaybeToolUse[]).find(
+    (b) => b?.type === 'tool_use' && b?.name === 'submit_score',
+  );
+  const relevance = toolUse?.input?.relevance;
+  if (typeof relevance !== 'number' || Number.isNaN(relevance)) return null;
+  return clamp01(relevance);
+}

--- a/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-judge-system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-judge-system.md
@@ -1,0 +1,11 @@
+You are an impartial evaluator of an AI assistant that turns natural-language
+questions into ClickHouse SQL for the Inngest Insights product.
+
+Given the user's question, the SQL the assistant produced, and the assistant's
+plain-language summary, judge how well the response ANSWERS THE QUESTION:
+relevance to the intent, whether the SQL plausibly computes what was asked, and
+whether the summary matches the SQL. You do NOT see the query results, so judge
+plausibility and intent-match, not the returned data.
+
+Call submit_score exactly once with a relevance score from 0 (irrelevant or
+wrong) to 1 (fully answers the question), and a one-sentence reasoning.

--- a/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-judge.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-judge.ts
@@ -1,0 +1,53 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { createScorer } from 'inngest/experimental';
+import { z } from 'zod';
+
+import { inngest } from '../../client';
+import {
+  buildJudgeUserPrompt,
+  JUDGE_SYSTEM_PROMPT,
+  parseJudgeRelevance,
+  submitScoreTool,
+} from './insights-judge-prompt';
+
+// Runs off the critical path (deferred), so a capable model is fine.
+const JUDGE_MODEL = 'claude-sonnet-4-5';
+
+export const insightsJudgeSchema = z.object({
+  question: z.string(),
+  sql: z.string(),
+  summary: z.string(),
+});
+
+export const insightsJudgeScorer = createScorer(
+  inngest,
+  {
+    id: 'score-insights-judge',
+    name: 'Insights AI judge',
+    schema: insightsJudgeSchema,
+  },
+  async ({ event, step }) => {
+    const { question, sql, summary } = event.data;
+
+    const relevance = await step.run('judge', async () => {
+      const client = new Anthropic();
+      const response = await client.messages.create({
+        model: JUDGE_MODEL,
+        max_tokens: 1024,
+        system: JUDGE_SYSTEM_PROMPT,
+        messages: [
+          {
+            role: 'user',
+            content: buildJudgeUserPrompt({ question, sql, summary }),
+          },
+        ],
+        tools: [submitScoreTool],
+        tool_choice: { type: 'tool' as const, name: 'submit_score' },
+      });
+      return parseJudgeRelevance(response);
+    });
+
+    if (relevance === null) return null; // nullish return → createScorer writes no score
+    return { name: 'insights_judge_relevance', value: relevance };
+  },
+);

--- a/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-scores.test.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-scores.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildImmediateScores,
+  isOpusVariant,
+  isParseableSelect,
+  producedSql,
+} from './insights-scores';
+
+describe('producedSql', () => {
+  it('is true when SQL is non-empty', () => {
+    expect(producedSql('SELECT 1')).toBe(true);
+  });
+
+  it('is false for empty, whitespace, or missing SQL', () => {
+    expect(producedSql('')).toBe(false);
+    expect(producedSql('   ')).toBe(false);
+    expect(producedSql(undefined)).toBe(false);
+  });
+});
+
+describe('isParseableSelect', () => {
+  it('accepts a single SELECT (case-insensitive)', () => {
+    expect(isParseableSelect('SELECT 1')).toBe(true);
+    expect(isParseableSelect('select count() from runs')).toBe(true);
+  });
+
+  it('accepts a WITH … SELECT CTE', () => {
+    expect(isParseableSelect('WITH x AS (SELECT 1) SELECT * FROM x')).toBe(
+      true,
+    );
+  });
+
+  it('tolerates a trailing semicolon and surrounding whitespace', () => {
+    expect(isParseableSelect('  SELECT 1;  ')).toBe(true);
+  });
+
+  it('rejects multiple statements', () => {
+    expect(isParseableSelect('SELECT 1; SELECT 2')).toBe(false);
+  });
+
+  it('rejects non-SELECT statements', () => {
+    expect(isParseableSelect('DROP TABLE runs')).toBe(false);
+  });
+
+  it('rejects empty or missing SQL', () => {
+    expect(isParseableSelect('')).toBe(false);
+    expect(isParseableSelect(undefined)).toBe(false);
+  });
+});
+
+describe('isOpusVariant', () => {
+  it('is true only for the opus variant', () => {
+    expect(isOpusVariant('claude-opus-4-8')).toBe(true);
+    expect(isOpusVariant('claude-sonnet-4-5')).toBe(false);
+  });
+});
+
+describe('buildImmediateScores', () => {
+  it('emits produced_sql, sql_parseable, and isOpus for a valid opus run', () => {
+    expect(
+      buildImmediateScores({ sql: 'SELECT 1', variant: 'claude-opus-4-8' }),
+    ).toEqual([
+      { name: 'insights_produced_sql', value: true },
+      { name: 'insights_sql_parseable', value: true },
+      { name: 'isOpus', value: true },
+    ]);
+  });
+
+  it('reflects a clarification turn (no SQL) on a sonnet run', () => {
+    expect(
+      buildImmediateScores({ sql: '', variant: 'claude-sonnet-4-5' }),
+    ).toEqual([
+      { name: 'insights_produced_sql', value: false },
+      { name: 'insights_sql_parseable', value: false },
+      { name: 'isOpus', value: false },
+    ]);
+  });
+});

--- a/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-scores.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/scoring/insights-scores.ts
@@ -1,0 +1,43 @@
+// Pure helpers for the immediate (in-run) Insights AI success scores.
+// Kept side-effect-free so they're unit-testable; the function handler emits
+// the results via `inngest.score()`.
+
+const OPUS_VARIANT = 'claude-opus-4-8';
+
+/** Did the agent emit any SQL at all (vs. a clarification / failure)? */
+export function producedSql(sql: string | undefined): boolean {
+  return typeof sql === 'string' && sql.trim().length > 0;
+}
+
+/**
+ * Cheap static check: a single SELECT (or WITH … SELECT CTE) statement.
+ * Not a full parse — just enough to flag obviously non-runnable output.
+ */
+export function isParseableSelect(sql: string | undefined): boolean {
+  if (!producedSql(sql)) return false;
+  const trimmed = sql!.trim().replace(/;\s*$/, ''); // drop one trailing semicolon
+  if (trimmed.includes(';')) return false; // any remaining ; => multiple statements
+  return /^(select|with)\b/i.test(trimmed);
+}
+
+/** Companion variant tag (boolean, since scores can't carry a string). */
+export function isOpusVariant(variant: string): boolean {
+  return variant === OPUS_VARIANT;
+}
+
+export interface ImmediateScoreInput {
+  sql: string | undefined;
+  variant: string;
+}
+
+/** The run-scoped immediate scores for one Insights AI run. */
+export function buildImmediateScores({
+  sql,
+  variant,
+}: ImmediateScoreInput): { name: string; value: boolean }[] {
+  return [
+    { name: 'insights_produced_sql', value: producedSql(sql) },
+    { name: 'insights_sql_parseable', value: isParseableSelect(sql) },
+    { name: 'isOpus', value: isOpusVariant(variant) },
+  ];
+}

--- a/ui/apps/dashboard/src/lib/inngest/functions/scoring/score-insights-feedback.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/scoring/score-insights-feedback.ts
@@ -1,0 +1,25 @@
+import { inngest } from '../../client';
+import { buildFeedbackScores, type QueryFeedback } from './insights-feedback';
+
+export const scoreInsightsFeedback = inngest.createFunction(
+  {
+    id: 'score-insights-feedback',
+    name: 'Insights AI feedback scorer',
+    triggers: [{ event: 'insights-agent/query.feedback' }],
+  },
+  async ({ event, step }) => {
+    const feedback = event.data as QueryFeedback;
+    const scores = buildFeedbackScores(feedback);
+    if (scores.length === 0) {
+      return { runId: feedback.runId, scoresWritten: 0 };
+    }
+
+    await step.run('write-feedback-scores', async () => {
+      for (const { name, value } of scores) {
+        await inngest.score({ runId: feedback.runId, name, value });
+      }
+    });
+
+    return { runId: feedback.runId, scoresWritten: scores.length };
+  },
+);

--- a/ui/apps/dashboard/src/routeTree.gen.ts
+++ b/ui/apps/dashboard/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as SupportIndexRouteImport } from './routes/support/index'
 import { Route as ApiSupportTicketsRouteImport } from './routes/api/support-tickets'
 import { Route as ApiSentryRouteImport } from './routes/api/sentry'
+import { Route as ApiQueryFeedbackRouteImport } from './routes/api/query-feedback'
 import { Route as ApiInngestRouteImport } from './routes/api/inngest'
 import { Route as ApiCspReportRouteImport } from './routes/api/csp-report'
 import { Route as ApiChatRouteImport } from './routes/api/chat'
@@ -126,6 +127,11 @@ const ApiSupportTicketsRoute = ApiSupportTicketsRouteImport.update({
 const ApiSentryRoute = ApiSentryRouteImport.update({
   id: '/api/sentry',
   path: '/api/sentry',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiQueryFeedbackRoute = ApiQueryFeedbackRouteImport.update({
+  id: '/api/query-feedback',
+  path: '/api/query-feedback',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiInngestRoute = ApiInngestRouteImport.update({
@@ -655,6 +661,7 @@ export interface FileRoutesByFullPath {
   '/api/chat': typeof ApiChatRoute
   '/api/csp-report': typeof ApiCspReportRoute
   '/api/inngest': typeof ApiInngestRoute
+  '/api/query-feedback': typeof ApiQueryFeedbackRoute
   '/api/sentry': typeof ApiSentryRoute
   '/api/support-tickets': typeof ApiSupportTicketsRoute
   '/support/': typeof SupportIndexRoute
@@ -749,6 +756,7 @@ export interface FileRoutesByTo {
   '/api/chat': typeof ApiChatRoute
   '/api/csp-report': typeof ApiCspReportRoute
   '/api/inngest': typeof ApiInngestRoute
+  '/api/query-feedback': typeof ApiQueryFeedbackRoute
   '/api/sentry': typeof ApiSentryRoute
   '/api/support-tickets': typeof ApiSupportTicketsRoute
   '/support': typeof SupportIndexRoute
@@ -834,6 +842,7 @@ export interface FileRoutesById {
   '/api/chat': typeof ApiChatRoute
   '/api/csp-report': typeof ApiCspReportRoute
   '/api/inngest': typeof ApiInngestRoute
+  '/api/query-feedback': typeof ApiQueryFeedbackRoute
   '/api/sentry': typeof ApiSentryRoute
   '/api/support-tickets': typeof ApiSupportTicketsRoute
   '/support/': typeof SupportIndexRoute
@@ -931,6 +940,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/api/csp-report'
     | '/api/inngest'
+    | '/api/query-feedback'
     | '/api/sentry'
     | '/api/support-tickets'
     | '/support/'
@@ -1025,6 +1035,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/api/csp-report'
     | '/api/inngest'
+    | '/api/query-feedback'
     | '/api/sentry'
     | '/api/support-tickets'
     | '/support'
@@ -1109,6 +1120,7 @@ export interface FileRouteTypes {
     | '/api/chat'
     | '/api/csp-report'
     | '/api/inngest'
+    | '/api/query-feedback'
     | '/api/sentry'
     | '/api/support-tickets'
     | '/support/'
@@ -1203,6 +1215,7 @@ export interface RootRouteChildren {
   ApiChatRoute: typeof ApiChatRoute
   ApiCspReportRoute: typeof ApiCspReportRoute
   ApiInngestRoute: typeof ApiInngestRoute
+  ApiQueryFeedbackRoute: typeof ApiQueryFeedbackRoute
   ApiSentryRoute: typeof ApiSentryRoute
   ApiSupportTicketsRoute: typeof ApiSupportTicketsRoute
   SupportIndexRoute: typeof SupportIndexRoute
@@ -1248,6 +1261,13 @@ declare module '@tanstack/react-router' {
       path: '/api/sentry'
       fullPath: '/api/sentry'
       preLoaderRoute: typeof ApiSentryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/query-feedback': {
+      id: '/api/query-feedback'
+      path: '/api/query-feedback'
+      fullPath: '/api/query-feedback'
+      preLoaderRoute: typeof ApiQueryFeedbackRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/inngest': {
@@ -2276,6 +2296,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiChatRoute: ApiChatRoute,
   ApiCspReportRoute: ApiCspReportRoute,
   ApiInngestRoute: ApiInngestRoute,
+  ApiQueryFeedbackRoute: ApiQueryFeedbackRoute,
   ApiSentryRoute: ApiSentryRoute,
   ApiSupportTicketsRoute: ApiSupportTicketsRoute,
   SupportIndexRoute: SupportIndexRoute,

--- a/ui/apps/dashboard/src/routes/api/inngest.ts
+++ b/ui/apps/dashboard/src/routes/api/inngest.ts
@@ -2,11 +2,12 @@ import { serve } from 'inngest/edge';
 import { inngest } from '@/lib/inngest/client';
 import { runInsightsAgent } from '@/lib/inngest/functions/run-insights';
 import { insightsJudgeScorer } from '@/lib/inngest/functions/scoring/insights-judge';
+import { scoreInsightsFeedback } from '@/lib/inngest/functions/scoring/score-insights-feedback';
 import { createFileRoute } from '@tanstack/react-router';
 
 const handler = serve({
   client: inngest,
-  functions: [runInsightsAgent, insightsJudgeScorer],
+  functions: [runInsightsAgent, insightsJudgeScorer, scoreInsightsFeedback],
 });
 
 export const Route = createFileRoute('/api/inngest')({

--- a/ui/apps/dashboard/src/routes/api/inngest.ts
+++ b/ui/apps/dashboard/src/routes/api/inngest.ts
@@ -1,9 +1,13 @@
 import { serve } from 'inngest/edge';
 import { inngest } from '@/lib/inngest/client';
 import { runInsightsAgent } from '@/lib/inngest/functions/run-insights';
+import { insightsJudgeScorer } from '@/lib/inngest/functions/scoring/insights-judge';
 import { createFileRoute } from '@tanstack/react-router';
 
-const handler = serve({ client: inngest, functions: [runInsightsAgent] });
+const handler = serve({
+  client: inngest,
+  functions: [runInsightsAgent, insightsJudgeScorer],
+});
 
 export const Route = createFileRoute('/api/inngest')({
   server: {

--- a/ui/apps/dashboard/src/routes/api/query-feedback.ts
+++ b/ui/apps/dashboard/src/routes/api/query-feedback.ts
@@ -1,0 +1,64 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { auth } from '@clerk/tanstack-react-start/server';
+import { z } from 'zod/v3';
+import { inngest } from '@/lib/inngest/client';
+
+const feedbackRequestSchema = z.object({
+  runId: z.string().min(1, 'runId is required'),
+  executedOk: z.boolean().optional(),
+  rowCount: z.number().optional(),
+  userEdited: z.boolean().optional(),
+  saved: z.boolean().optional(),
+  fixWithAi: z.boolean().optional(),
+});
+
+export const Route = createFileRoute('/api/query-feedback')({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        try {
+          const { userId } = await auth();
+          if (!userId) {
+            return new Response(JSON.stringify({ error: 'Please sign in' }), {
+              status: 401,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+
+          const body = await request.json();
+          const validationResult = feedbackRequestSchema.safeParse(body);
+          if (!validationResult.success) {
+            return new Response(
+              JSON.stringify({
+                error:
+                  validationResult.error.errors[0]?.message ??
+                  'Invalid request',
+              }),
+              { status: 400, headers: { 'Content-Type': 'application/json' } },
+            );
+          }
+
+          await inngest.send({
+            name: 'insights-agent/query.feedback',
+            data: validationResult.data,
+          });
+
+          return new Response(JSON.stringify({ success: true }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        } catch (error) {
+          return new Response(
+            JSON.stringify({
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to record feedback',
+            }),
+            { status: 500, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+      },
+    },
+  },
+});

--- a/ui/apps/dashboard/src/routes/api/query-feedback.ts
+++ b/ui/apps/dashboard/src/routes/api/query-feedback.ts
@@ -48,13 +48,11 @@ export const Route = createFileRoute('/api/query-feedback')({
             headers: { 'Content-Type': 'application/json' },
           });
         } catch (error) {
+          // Log the detail server-side; return a generic message so internal
+          // error specifics (upstream URLs, client internals) don't leak.
+          console.error('query-feedback handler failed', error);
           return new Response(
-            JSON.stringify({
-              error:
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to record feedback',
-            }),
+            JSON.stringify({ error: 'Failed to record feedback' }),
             { status: 500, headers: { 'Content-Type': 'application/json' } },
           );
         }


### PR DESCRIPTION
## Description

- Added run-level scores on each run: produced SQL, SQL parseable, and an `isOpus` variant tag (workaround for experiments).
- Added a deferred LLM-as-judge that rates each response off the critical path.
- Built a feedback pipeline (event + route + handler) to score what happened to a query back onto its run.
- Wired the dashboard to send those signals, execution outcome, save ai-generated query (positive), and "Fix with AI" (negative).

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
