### PR TITLE
fix(dockerfile): build the cmd package, not cmd/main.go alone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 ARG TARGETARCH
 ARG TARGETOS
 RUN --mount=type=cache,target=/root/.cache/go-build \
-    GOFLAGS=-mod=vendor GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /go/bin/inngest cmd/main.go
+    GOFLAGS=-mod=vendor GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /go/bin/inngest ./cmd
 
 FROM alpine:3.21 AS inngest
 RUN apk add --no-cache ca-certificates tzdata && update-ca-certificates


### PR DESCRIPTION
## Description

`go build cmd/main.go` only compiles `main.go` — but `cmd/main.go` calls `execute()` which is defined in `cmd/root.go` under the same `package main`, so `docker build .` from the repo root aborts on every architecture with:

```
cmd/main.go:17:2: undefined: execute
```

The e2e workflow already builds the package correctly at four sites (`.github/workflows/e2e.yml:52,142,233,320`):

```
go build -cover -o ./inngest-bin ./cmd
```

This PR matches the Dockerfile to that pattern (`./cmd` instead of `cmd/main.go`). `docker build .` succeeds on this branch and the produced binary is byte-identical to the e2e one modulo `-cover`.

## Release note

Restore `docker build .` from the repo root.

## Migration note

None.

Closes #4471.