### PR TITLE
refactor(queue): resolve shards by scope instead of acctID

### DIFF
--- a/pkg/api/apiv1/runs.go
+++ b/pkg/api/apiv1/runs.go
@@ -110,7 +110,12 @@ func (a router) GetFunctionRunJobs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	shard, err := a.opts.QueueShards.Resolve(ctx, auth.AccountID(), nil)
+	scope := queue.Scope{
+		AccountID:  auth.AccountID(),
+		EnvID:      auth.WorkspaceID(),
+		FunctionID: fr.FunctionID,
+	}
+	shard, err := a.opts.QueueShards.Resolve(ctx, scope, nil)
 	if err != nil {
 		_ = publicerr.WriteHTTP(w, publicerr.Wrapf(err, 500, "Internal server error"))
 		return
@@ -118,11 +123,7 @@ func (a router) GetFunctionRunJobs(w http.ResponseWriter, r *http.Request) {
 
 	jobs, err := shard.RunJobs(
 		ctx,
-		queue.Scope{
-			AccountID:  auth.AccountID(),
-			EnvID:      auth.WorkspaceID(),
-			FunctionID: fr.FunctionID,
-		},
+		scope,
 		runID,
 		10,
 		0,

--- a/pkg/debugapi/debugapi_test.go
+++ b/pkg/debugapi/debugapi_test.go
@@ -131,8 +131,8 @@ func TestGetQueueItemByRunIDResolvesShardFromScope(t *testing.T) {
 			accountShard.Name(): accountShard,
 		},
 		queue.WithPrimary(defaultShard),
-		queue.WithShardSelector(func(ctx context.Context, id uuid.UUID, queueName *string) (queue.QueueShard, error) {
-			if id == accountID {
+		queue.WithShardSelector(func(ctx context.Context, scope queue.Scope, queueName *string) (queue.QueueShard, error) {
+			if scope.AccountID == accountID {
 				return accountShard, nil
 			}
 			return defaultShard, nil

--- a/pkg/debugapi/key_queue.go
+++ b/pkg/debugapi/key_queue.go
@@ -15,17 +15,16 @@ import (
 )
 
 func (d *debugAPI) GetShadowPartition(ctx context.Context, req *pb.ShadowPartitionRequest) (*pb.ShadowPartitionResponse, error) {
-	shard, err := d.shards.Resolve(ctx, consts.DevServerAccountID, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error finding shard: %w", err)
-	}
-
 	scope := queue.Scope{
 		AccountID: consts.DevServerAccountID,
 		EnvID:     consts.DevServerEnvID,
 	}
 	if fnID, parseErr := uuid.Parse(req.GetPartitionId()); parseErr == nil {
 		scope.FunctionID = fnID
+	}
+	shard, err := d.shards.Resolve(ctx, scope, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error finding shard: %w", err)
 	}
 	pt, err := d.queue.PartitionByID(ctx, shard, scope, req.GetPartitionId())
 	if err != nil {
@@ -65,7 +64,7 @@ func (d *debugAPI) GetShadowPartition(ctx context.Context, req *pb.ShadowPartiti
 }
 
 func (d *debugAPI) GetBacklogs(ctx context.Context, req *pb.BacklogsRequest) (*pb.BacklogsResponse, error) {
-	shard, err := d.shards.Resolve(ctx, consts.DevServerAccountID, nil)
+	shard, err := d.shards.Resolve(ctx, queue.Scope{AccountID: consts.DevServerAccountID}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error finding shard: %w", err)
 	}
@@ -100,7 +99,7 @@ func (d *debugAPI) GetBacklogs(ctx context.Context, req *pb.BacklogsRequest) (*p
 }
 
 func (d *debugAPI) GetBacklogSize(ctx context.Context, req *pb.BacklogSizeRequest) (*pb.BacklogSizeResponse, error) {
-	shard, err := d.shards.Resolve(ctx, consts.DevServerAccountID, nil)
+	shard, err := d.shards.Resolve(ctx, queue.Scope{AccountID: consts.DevServerAccountID}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error finding shard: %w", err)
 	}

--- a/pkg/debugapi/queue_item.go
+++ b/pkg/debugapi/queue_item.go
@@ -67,7 +67,7 @@ func (d *debugAPI) GetQueueItem(ctx context.Context, req *pb.QueueItemRequest) (
 			return nil, fmt.Errorf("could not find queue shard %q", req.QueueShard)
 		}
 	} else {
-		shard, err = d.shards.Resolve(ctx, scope.AccountID, nil)
+		shard, err = d.shards.Resolve(ctx, scope, nil)
 		if err != nil {
 			return nil, fmt.Errorf("could not resolve queue shard for account %q: %w", scope.AccountID, err)
 		}

--- a/pkg/debugapi/queue_partition.go
+++ b/pkg/debugapi/queue_partition.go
@@ -35,7 +35,11 @@ func (d *debugAPI) GetPartition(ctx context.Context, req *pb.PartitionRequest) (
 		return nil, status.Error(codes.Unknown, fmt.Errorf("error retrieving function: %w", err).Error())
 	}
 
-	shard, err := d.shards.Resolve(ctx, consts.DevServerAccountID, nil)
+	shard, err := d.shards.Resolve(ctx, queue.Scope{
+		AccountID:  consts.DevServerAccountID,
+		EnvID:      consts.DevServerEnvID,
+		FunctionID: fn.ID,
+	}, nil)
 	if err != nil {
 		return nil, status.Error(codes.Unknown, fmt.Errorf("error finding shard: %w", err).Error())
 	}
@@ -80,17 +84,16 @@ func (d *debugAPI) GetPartitionStatus(ctx context.Context, req *pb.PartitionRequ
 		queueName = &req.Id
 	}
 
-	shard, err := d.shards.Resolve(ctx, consts.DevServerAccountID, queueName)
-	if err != nil {
-		return nil, fmt.Errorf("error finding shard for GetPartition: %w", err)
-	}
-
 	scope := queue.Scope{
 		AccountID: consts.DevServerAccountID,
 		EnvID:     consts.DevServerEnvID,
 	}
 	if fnID, parseErr := uuid.Parse(req.GetId()); parseErr == nil {
 		scope.FunctionID = fnID
+	}
+	shard, err := d.shards.Resolve(ctx, scope, queueName)
+	if err != nil {
+		return nil, fmt.Errorf("error finding shard for GetPartition: %w", err)
 	}
 	pt, err := d.queue.PartitionByID(ctx, shard, scope, req.GetId())
 	if err != nil {

--- a/pkg/debugapi/singleton.go
+++ b/pkg/debugapi/singleton.go
@@ -20,7 +20,7 @@ func (d *debugAPI) GetSingletonInfo(ctx context.Context, req *pb.SingletonInfoRe
 		singletonKey = scope.FunctionID.String() + "-" + req.GetSingletonKey()
 	}
 
-	shard, err := d.shards.Resolve(ctx, scope.AccountID, nil)
+	shard, err := d.shards.Resolve(ctx, scope, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve shard: %w", err)
 	}
@@ -56,7 +56,7 @@ func (d *debugAPI) DeleteSingletonLock(ctx context.Context, req *pb.DeleteSingle
 		singletonKey = scope.FunctionID.String() + "-" + req.GetSingletonKey()
 	}
 
-	shard, err := d.shards.Resolve(ctx, scope.AccountID, nil)
+	shard, err := d.shards.Resolve(ctx, scope, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve shard: %w", err)
 	}

--- a/pkg/execution/debounce/debounce_test.go
+++ b/pkg/execution/debounce/debounce_test.go
@@ -70,8 +70,8 @@ func (s *removeQueueItemFailingShard) DebounceDeleteMigratingFlag(ctx context.Co
 
 // migrationShardSelector routes system queue items (queueName != nil) to the
 // new system shard and everything else to the default shard.
-func migrationShardSelector(defaultShard, newSystemShard queue.QueueShard) func(ctx context.Context, accountID uuid.UUID, queueName *string) (queue.QueueShard, error) {
-	return func(ctx context.Context, accountID uuid.UUID, queueName *string) (queue.QueueShard, error) {
+func migrationShardSelector(defaultShard, newSystemShard queue.QueueShard) func(ctx context.Context, scope queue.Scope, queueName *string) (queue.QueueShard, error) {
+	return func(ctx context.Context, scope queue.Scope, queueName *string) (queue.QueueShard, error) {
 		if queueName != nil {
 			return newSystemShard, nil
 		}

--- a/pkg/execution/executor/cancel_test.go
+++ b/pkg/execution/executor/cancel_test.go
@@ -106,7 +106,7 @@ type missingShardRegistry struct {
 	queue.ShardRegistry
 }
 
-func (missingShardRegistry) Resolve(context.Context, uuid.UUID, *string) (queue.QueueShard, error) {
+func (missingShardRegistry) Resolve(context.Context, queue.Scope, *string) (queue.QueueShard, error) {
 	return nil, errors.New("missing shard")
 }
 

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3440,7 +3440,11 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 		if q, ok := e.queue.(queue.QueueManager); ok {
 			// timeout jobs are enqueued to the workflow partition (see handleGeneratorWaitForEvent)
 			// this is _not_ a system partition and lives on the account shard, which we need to retrieve
-			shard, err := e.shards.Resolve(ctx, md.ID.Tenant.AccountID, nil)
+			shard, err := e.shards.Resolve(ctx, queue.Scope{
+				AccountID:  md.ID.Tenant.AccountID,
+				EnvID:      md.ID.Tenant.EnvID,
+				FunctionID: md.ID.FunctionID,
+			}, nil)
 			if err != nil {
 				return fmt.Errorf("could not find shard for pause timeout item for account %q: %w", md.ID.Tenant.AccountID, err)
 			}

--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -335,7 +335,11 @@ func (e *executor) buildDeferEvents(
 func (e *executor) finalizeRemoveJobs(ctx context.Context, opts execution.FinalizeOpts) {
 	l := logger.StdlibLogger(ctx)
 
-	shard, err := e.shards.Resolve(ctx, opts.Metadata.ID.Tenant.AccountID, nil)
+	shard, err := e.shards.Resolve(ctx, queue.Scope{
+		AccountID:  opts.Metadata.ID.Tenant.AccountID,
+		EnvID:      opts.Metadata.ID.Tenant.EnvID,
+		FunctionID: opts.Metadata.ID.FunctionID,
+	}, nil)
 	if err != nil {
 		return
 	}

--- a/pkg/execution/executor/finalize_test.go
+++ b/pkg/execution/executor/finalize_test.go
@@ -22,9 +22,9 @@ import (
 type racingShard struct {
 	queue.ShardOperations // embed to satisfy the large interface
 
-	mu       sync.Mutex
+	mu sync.Mutex
 	// items currently in the queue, keyed by ID
-	items    map[string]*queue.QueueItem
+	items map[string]*queue.QueueItem
 	// sweepCount tracks how many times RunJobs has been called
 	sweepCount int
 	// injectAfterSweep maps sweep number -> items to inject after that sweep completes
@@ -81,7 +81,7 @@ func (r *racingShardRegistry) ByName(name string) (queue.QueueShard, error) {
 	return r.shard, nil
 }
 func (r *racingShardRegistry) ByGroup(string) []queue.QueueShard { return nil }
-func (r *racingShardRegistry) Resolve(_ context.Context, _ uuid.UUID, _ *string) (queue.QueueShard, error) {
+func (r *racingShardRegistry) Resolve(_ context.Context, _ queue.Scope, _ *string) (queue.QueueShard, error) {
 	return r.shard, nil
 }
 func (r *racingShardRegistry) ForEach(ctx context.Context, fn func(context.Context, queue.QueueShard) error) error {
@@ -93,8 +93,8 @@ type racingQueueShard struct {
 	*racingShard
 }
 
-func (s *racingQueueShard) Name() string                 { return "test" }
-func (s *racingQueueShard) Kind() enums.QueueShardKind   { return enums.QueueShardKindRedis }
+func (s *racingQueueShard) Name() string               { return "test" }
+func (s *racingQueueShard) Kind() enums.QueueShardKind { return enums.QueueShardKindRedis }
 func (s *racingQueueShard) ShardAssignmentConfig() queue.ShardAssignmentConfig {
 	return queue.ShardAssignmentConfig{}
 }
@@ -108,7 +108,7 @@ func TestFinalizeRemoveJobs_CatchesPostSweepEnqueue(t *testing.T) {
 	racedItem := &queue.QueueItem{ID: "item-raced"}
 
 	shard := &racingShard{
-		items:            map[string]*queue.QueueItem{"item-1": initialItem},
+		items: map[string]*queue.QueueItem{"item-1": initialItem},
 		injectAfterSweep: map[int][]*queue.QueueItem{
 			1: {racedItem}, // inject after first sweep
 		},

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -1183,7 +1183,11 @@ func (s *svc) handleJobPromote(ctx context.Context, item queue.Item) error {
 
 	// Retrieve current queue shard for sleep item. The account might have been migrated
 	// to a different shard since the original sleep item was enqueued, so we must fetch the shard now.
-	shard, err := s.shards.Resolve(ctx, queue.Scope{AccountID: item.Identifier.AccountID}, nil)
+	shard, err := s.shards.Resolve(ctx, queue.Scope{
+		AccountID:  item.Identifier.AccountID,
+		FunctionID: item.Identifier.WorkflowID,
+		EnvID:      item.Identifier.WorkspaceID,
+	}, nil)
 	if err != nil {
 		return fmt.Errorf("could not retrieve queue shard for job promotion:%w", err)
 	}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -740,7 +740,11 @@ func (s *svc) handleEagerCancelBacklog(ctx context.Context, c cqrs.Cancellation)
 		from = *c.StartedAfter
 	}
 
-	shard, err := s.shards.Resolve(ctx, c.AccountID, c.QueueName)
+	shard, err := s.shards.Resolve(ctx, queue.Scope{
+		AccountID:  c.AccountID,
+		EnvID:      c.WorkspaceID,
+		FunctionID: c.FunctionID,
+	}, c.QueueName)
 	if err != nil {
 		return fmt.Errorf("error selecting shard for cancellation: %w", err)
 	}
@@ -836,7 +840,12 @@ func (s *svc) handleEagerCancelBulkRun(ctx context.Context, c cqrs.Cancellation)
 		from = *c.StartedAfter
 	}
 
-	shard, err := s.shards.Resolve(ctx, c.AccountID, c.QueueName)
+	scope := queue.Scope{
+		AccountID:  c.AccountID,
+		EnvID:      c.WorkspaceID,
+		FunctionID: c.FunctionID,
+	}
+	shard, err := s.shards.Resolve(ctx, scope, c.QueueName)
 	if err != nil {
 		return fmt.Errorf("error selecting shard for cancellation: %w", err)
 	}
@@ -1174,7 +1183,7 @@ func (s *svc) handleJobPromote(ctx context.Context, item queue.Item) error {
 
 	// Retrieve current queue shard for sleep item. The account might have been migrated
 	// to a different shard since the original sleep item was enqueued, so we must fetch the shard now.
-	shard, err := s.shards.Resolve(ctx, item.Identifier.AccountID, nil)
+	shard, err := s.shards.Resolve(ctx, queue.Scope{AccountID: item.Identifier.AccountID}, nil)
 	if err != nil {
 		return fmt.Errorf("could not retrieve queue shard for job promotion:%w", err)
 	}

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -258,7 +258,7 @@ func (q *queueProcessor) forAccountShards(ctx context.Context, accountID uuid.UU
 		return q.shards.ForEach(ctx, fn)
 	}
 
-	shard, err := q.shards.Resolve(ctx, accountID, nil)
+	shard, err := q.shards.Resolve(ctx, Scope{AccountID: accountID}, nil)
 	if err != nil {
 		return fmt.Errorf("could not resolve account shard: %w", err)
 	}

--- a/pkg/execution/queue/processor_test.go
+++ b/pkg/execution/queue/processor_test.go
@@ -58,8 +58,8 @@ func TestProcessorAccountShardReadsResolveByDefault(t *testing.T) {
 			shardB.Name(): shardB,
 		},
 		WithPrimary(shardA),
-		WithShardSelector(func(_ context.Context, id uuid.UUID, _ *string) (QueueShard, error) {
-			require.Equal(t, accountID, id)
+		WithShardSelector(func(_ context.Context, scope Scope, _ *string) (QueueShard, error) {
+			require.Equal(t, accountID, scope.AccountID)
 			return shardB, nil
 		}),
 	)
@@ -119,7 +119,7 @@ func TestProcessorAccountShardReadsForEachWhenEnabled(t *testing.T) {
 			shardB.Name(): shardB,
 		},
 		WithPrimary(shardA),
-		WithShardSelector(func(context.Context, uuid.UUID, *string) (QueueShard, error) {
+		WithShardSelector(func(context.Context, Scope, *string) (QueueShard, error) {
 			return shardB, nil
 		}),
 	)

--- a/pkg/execution/queue/shard.go
+++ b/pkg/execution/queue/shard.go
@@ -46,7 +46,7 @@ func (q *queueProducer) selectShard(ctx context.Context, shardName string, qi Qu
 		queueItemKind = &qi.Data.Kind
 	}
 
-	selected, err := q.shards.Resolve(ctx, qi.Data.Identifier.AccountID, queueItemKind)
+	selected, err := q.shards.Resolve(ctx, ScopeFromQueueItem(qi), queueItemKind)
 	if err != nil {
 		l.Error("error selecting shard", "error", err, "item", qi)
 		return nil, fmt.Errorf("could not select shard: %w", err)

--- a/pkg/execution/queue/shard_registry.go
+++ b/pkg/execution/queue/shard_registry.go
@@ -6,18 +6,17 @@ import (
 	"maps"
 	"sync"
 
-	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/logger"
 	"golang.org/x/sync/errgroup"
 )
 
 // shardSelector returns a shard reference for the given queue item. It
 // applies a caller-supplied policy to route enqueues to different shards.
-type shardSelector func(ctx context.Context, accountID uuid.UUID, queueName *string) (QueueShard, error)
+type shardSelector func(ctx context.Context, scope Scope, queueName *string) (QueueShard, error)
 
 // ShardRegistry is the read-only surface for components that need to look up
 // shards, fan out across the active set, or resolve a shard for a given
-// account/queue. It replaces the trio of (queueShardClients map, selector,
+// scope/queue. It replaces the trio of (queueShardClients map, selector,
 // primaryQueueShard) that used to be passed independently into queue.New,
 // the executor, the singleton store, and various API surfaces.
 type ShardRegistry interface {
@@ -36,7 +35,7 @@ type ShardRegistry interface {
 
 	// Resolve picks a shard for a given enqueue, applying the registry's
 	// shard selector. Resolve errors if no selector has been configured.
-	Resolve(ctx context.Context, accountID uuid.UUID, queueItemKind *string) (QueueShard, error)
+	Resolve(ctx context.Context, scope Scope, queueItemKind *string) (QueueShard, error)
 
 	// ForEach runs fn against every active shard concurrently, returning
 	// the first error encountered. The shard set is snapshotted at call
@@ -142,7 +141,7 @@ func NewSingleShardRegistry(shard QueueShard) (ShardRegistryController, error) {
 	return NewShardRegistry(
 		map[string]QueueShard{shard.Name(): shard},
 		WithPrimary(shard),
-		WithShardSelector(func(context.Context, uuid.UUID, *string) (QueueShard, error) {
+		WithShardSelector(func(context.Context, Scope, *string) (QueueShard, error) {
 			return shard, nil
 		}),
 	)
@@ -176,8 +175,8 @@ func (r *shardRegistry) ByGroup(groupName string) []QueueShard {
 	return out
 }
 
-func (r *shardRegistry) Resolve(ctx context.Context, accountID uuid.UUID, queueItemKind *string) (QueueShard, error) {
-	return r.selector(ctx, accountID, queueItemKind)
+func (r *shardRegistry) Resolve(ctx context.Context, scope Scope, queueItemKind *string) (QueueShard, error) {
+	return r.selector(ctx, scope, queueItemKind)
 }
 
 func (r *shardRegistry) ForEach(ctx context.Context, fn func(context.Context, QueueShard) error) error {

--- a/pkg/execution/queue/shard_registry_test.go
+++ b/pkg/execution/queue/shard_registry_test.go
@@ -31,7 +31,7 @@ func newTestShard(name, group string) *registryTestShard {
 
 // alwaysShard returns a selector that always resolves to the given shard.
 func alwaysShard(s QueueShard) shardSelector {
-	return func(context.Context, uuid.UUID, *string) (QueueShard, error) {
+	return func(context.Context, Scope, *string) (QueueShard, error) {
 		return s, nil
 	}
 }
@@ -171,7 +171,7 @@ func TestShardRegistry_Resolve_DelegatesToSelector(t *testing.T) {
 	a := newTestShard("a", "")
 	b := newTestShard("b", "")
 	called := false
-	sel := func(_ context.Context, _ uuid.UUID, _ *string) (QueueShard, error) {
+	sel := func(_ context.Context, _ Scope, _ *string) (QueueShard, error) {
 		called = true
 		return b, nil
 	}
@@ -180,7 +180,7 @@ func TestShardRegistry_Resolve_DelegatesToSelector(t *testing.T) {
 		WithShardSelector(sel),
 	)
 
-	got, err := r.Resolve(context.Background(), uuid.New(), nil)
+	got, err := r.Resolve(context.Background(), Scope{AccountID: uuid.New()}, nil)
 	require.NoError(t, err)
 	require.Equal(t, QueueShard(b), got)
 	require.True(t, called)
@@ -258,12 +258,12 @@ func TestNewSingleShardRegistry(t *testing.T) {
 		s := newTestShard("only", "g")
 		r := mustSingleShardRegistry(t, s)
 
-		got, err := r.Resolve(context.Background(), uuid.New(), nil)
+		got, err := r.Resolve(context.Background(), Scope{AccountID: uuid.New()}, nil)
 		require.NoError(t, err)
 		require.Equal(t, QueueShard(s), got)
 
 		qn := "ignored"
-		got, err = r.Resolve(context.Background(), uuid.Nil, &qn)
+		got, err = r.Resolve(context.Background(), Scope{}, &qn)
 		require.NoError(t, err)
 		require.Equal(t, QueueShard(s), got)
 	})

--- a/pkg/execution/singleton/singleton.go
+++ b/pkg/execution/singleton/singleton.go
@@ -70,7 +70,7 @@ func hash(res any, id uuid.UUID) string {
 //
 // - If the mode is SingletonModeCancel, it attempts to release the lock and returns the run ID that was released.
 func singleton(ctx context.Context, shards queue.ShardRegistry, scope queue.Scope, key string, s inngest.Singleton) (*ulid.ULID, error) {
-	shard, err := shards.Resolve(ctx, scope.AccountID, nil)
+	shard, err := shards.Resolve(ctx, scope, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/execution/state/redis_state/util_test.go
+++ b/pkg/execution/state/redis_state/util_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/consts"
 	osqueue "github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/redis/rueidis"
@@ -38,8 +37,8 @@ func mapFromShards(shards ...osqueue.QueueShard) map[string]osqueue.QueueShard {
 	return shardMap
 }
 
-func alwaysSelectShard(shard osqueue.QueueShard) func(ctx context.Context, accountID uuid.UUID, queueName *string) (osqueue.QueueShard, error) {
-	return func(ctx context.Context, accountID uuid.UUID, queueName *string) (osqueue.QueueShard, error) {
+func alwaysSelectShard(shard osqueue.QueueShard) func(ctx context.Context, scope osqueue.Scope, queueName *string) (osqueue.QueueShard, error) {
+	return func(ctx context.Context, scope osqueue.Scope, queueName *string) (osqueue.QueueShard, error) {
 		return shard, nil
 	}
 }

--- a/pkg/testapi/api.go
+++ b/pkg/testapi/api.go
@@ -83,18 +83,19 @@ func (t *TestAPI) GetQueueSize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	shard, err := t.options.QueueShards.Resolve(ctx, parsedAccountId, nil)
+	scope := queue.Scope{
+		AccountID:  parsedAccountId,
+		EnvID:      consts.DevServerEnvID,
+		FunctionID: parsedFnId,
+	}
+	shard, err := t.options.QueueShards.Resolve(ctx, scope, nil)
 	if err != nil {
 		w.WriteHeader(500)
 		_, _ = w.Write([]byte("Internal server error"))
 		return
 	}
 
-	count, err := shard.PartitionSize(ctx, queue.Scope{
-		AccountID:  parsedAccountId,
-		EnvID:      consts.DevServerEnvID,
-		FunctionID: parsedFnId,
-	}, parsedFnId.String(), time.Now().Add(2*365*24*time.Hour))
+	count, err := shard.PartitionSize(ctx, scope, parsedFnId.String(), time.Now().Add(2*365*24*time.Hour))
 	if err != nil {
 		w.WriteHeader(500)
 		_, _ = w.Write([]byte("Internal server error"))

--- a/tests/execution/queue/queue_shard_lease_e2e_test.go
+++ b/tests/execution/queue/queue_shard_lease_e2e_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state/redis_state"
 	"github.com/jonboulle/clockwork"
@@ -15,8 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func alwaysSelect(s queue.QueueShard) func(context.Context, uuid.UUID, *string) (queue.QueueShard, error) {
-	return func(context.Context, uuid.UUID, *string) (queue.QueueShard, error) {
+func alwaysSelect(s queue.QueueShard) func(context.Context, queue.Scope, *string) (queue.QueueShard, error) {
+	return func(context.Context, queue.Scope, *string) (queue.QueueShard, error) {
 		return s, nil
 	}
 }


### PR DESCRIPTION
## Description

Refactor `ShardSelector` and `ShardRegistry.Resolve` interfaces to take `queue.Scope` instead of `accountID`

This will allow us to more granularly select the appropriate shard instead of mapping directly by account.

Dev Server shard selection remains unchanged.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
