### PR TITLE
feat(sessions): sessions page optimization

### DIFF
--- a/ui/apps/dashboard/src/components/Sessions/useSessionKeys.ts
+++ b/ui/apps/dashboard/src/components/Sessions/useSessionKeys.ts
@@ -1,0 +1,57 @@
+import { useDeferredValue } from 'react';
+import { type SessionKey } from '@inngest/components/types/session';
+import { useQuery } from '@tanstack/react-query';
+import { useClient } from 'urql';
+
+import { useEnvironment } from '@/components/Environments/environment-context';
+
+const sessionKeysQuery = `
+  query SessionKeys($workspaceID: ID!, $search: String) {
+    environment: workspace(id: $workspaceID) {
+      sessionKeys(search: $search) {
+        sessionKey
+        createdAt
+      }
+    }
+  }
+`;
+
+type SessionKeysQueryResult = {
+  environment: {
+    sessionKeys: Array<{
+      sessionKey: string;
+      createdAt: string;
+    }>;
+  } | null;
+};
+
+type SessionKeysQueryVariables = {
+  workspaceID: string;
+  search: string | null;
+};
+
+export function useSessionKeys(search: string) {
+  const client = useClient();
+  const envID = useEnvironment().id;
+  const deferredSearch = useDeferredValue(search.trim());
+
+  return useQuery({
+    queryKey: ['sessionKeys', envID, deferredSearch],
+    queryFn: async (): Promise<SessionKey[]> => {
+      const result = await client
+        .query<
+          SessionKeysQueryResult,
+          SessionKeysQueryVariables
+        >(sessionKeysQuery, { workspaceID: envID, search: deferredSearch || null }, { requestPolicy: 'network-only' })
+        .toPromise();
+
+      if (result.error) throw result.error;
+
+      return (result.data?.environment?.sessionKeys ?? []).map((key) => ({
+        sessionKey: key.sessionKey,
+        createdAt: key.createdAt,
+      }));
+    },
+    refetchOnWindowFocus: false,
+  });
+}

--- a/ui/apps/dashboard/src/routeTree.gen.ts
+++ b/ui/apps/dashboard/src/routeTree.gen.ts
@@ -56,8 +56,8 @@ import { Route as AuthedSettingsIntegrationsNeonIndexRouteImport } from './route
 import { Route as AuthedSettingsIntegrationsDatadogIndexRouteImport } from './routes/_authed/settings/integrations/datadog/index'
 import { Route as AuthedIntegrationsVercelCallbackIndexRouteImport } from './routes/_authed/integrations/vercel/callback/index'
 import { Route as AuthedEnvEnvSlugUnattachedSyncsIndexRouteImport } from './routes/_authed/env/$envSlug/unattached-syncs/index'
-import { Route as AuthedEnvEnvSlugScoresIndexRouteImport } from './routes/_authed/env/$envSlug/scores/index'
 import { Route as AuthedEnvEnvSlugSessionsIndexRouteImport } from './routes/_authed/env/$envSlug/sessions/index'
+import { Route as AuthedEnvEnvSlugScoresIndexRouteImport } from './routes/_authed/env/$envSlug/scores/index'
 import { Route as AuthedEnvEnvSlugRunsIndexRouteImport } from './routes/_authed/env/$envSlug/runs/index'
 import { Route as AuthedEnvEnvSlugMetricsIndexRouteImport } from './routes/_authed/env/$envSlug/metrics/index'
 import { Route as AuthedEnvEnvSlugManageIndexRouteImport } from './routes/_authed/env/$envSlug/manage/index'
@@ -362,16 +362,16 @@ const AuthedEnvEnvSlugUnattachedSyncsIndexRoute =
     path: '/',
     getParentRoute: () => AuthedEnvEnvSlugUnattachedSyncsRouteRoute,
   } as any)
-const AuthedEnvEnvSlugScoresIndexRoute =
-  AuthedEnvEnvSlugScoresIndexRouteImport.update({
-    id: '/scores/',
-    path: '/scores/',
-    getParentRoute: () => AuthedEnvEnvSlugRouteRoute,
-  } as any)
 const AuthedEnvEnvSlugSessionsIndexRoute =
   AuthedEnvEnvSlugSessionsIndexRouteImport.update({
     id: '/sessions/',
     path: '/sessions/',
+    getParentRoute: () => AuthedEnvEnvSlugRouteRoute,
+  } as any)
+const AuthedEnvEnvSlugScoresIndexRoute =
+  AuthedEnvEnvSlugScoresIndexRouteImport.update({
+    id: '/scores/',
+    path: '/scores/',
     getParentRoute: () => AuthedEnvEnvSlugRouteRoute,
   } as any)
 const AuthedEnvEnvSlugRunsIndexRoute =
@@ -1583,18 +1583,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthedEnvEnvSlugUnattachedSyncsIndexRouteImport
       parentRoute: typeof AuthedEnvEnvSlugUnattachedSyncsRouteRoute
     }
-    '/_authed/env/$envSlug/scores/': {
-      id: '/_authed/env/$envSlug/scores/'
-      path: '/scores'
-      fullPath: '/env/$envSlug/scores/'
-      preLoaderRoute: typeof AuthedEnvEnvSlugScoresIndexRouteImport
-      parentRoute: typeof AuthedEnvEnvSlugRouteRoute
-    }
     '/_authed/env/$envSlug/sessions/': {
       id: '/_authed/env/$envSlug/sessions/'
       path: '/sessions'
       fullPath: '/env/$envSlug/sessions/'
       preLoaderRoute: typeof AuthedEnvEnvSlugSessionsIndexRouteImport
+      parentRoute: typeof AuthedEnvEnvSlugRouteRoute
+    }
+    '/_authed/env/$envSlug/scores/': {
+      id: '/_authed/env/$envSlug/scores/'
+      path: '/scores'
+      fullPath: '/env/$envSlug/scores/'
+      preLoaderRoute: typeof AuthedEnvEnvSlugScoresIndexRouteImport
       parentRoute: typeof AuthedEnvEnvSlugRouteRoute
     }
     '/_authed/env/$envSlug/runs/': {

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/sessions/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/sessions/index.tsx
@@ -1,10 +1,12 @@
+import { useState } from 'react';
 import { Header } from '@inngest/components/Header/Header';
-import { SessionsEmptyState } from '@inngest/components/Sessions/SessionsEmptyState';
+import { SessionKeys } from '@inngest/components/Sessions/SessionKeys';
 import { ClientOnly, createFileRoute } from '@tanstack/react-router';
 
 import NotFound from '@/components/Error/NotFound';
 import { useBooleanFlag } from '@/components/FeatureFlags/hooks';
 import { SessionsInfo } from '@/components/Sessions/SessionsInfo';
+import { useSessionKeys } from '@/components/Sessions/useSessionKeys';
 import { pathCreator } from '@/utils/urls';
 
 export const Route = createFileRoute('/_authed/env/$envSlug/sessions/')({
@@ -15,6 +17,13 @@ function SessionsPage() {
   const { envSlug } = Route.useParams();
   const navigate = Route.useNavigate();
   const sessionsEnabled = useBooleanFlag('sessions-ui');
+  const [search, setSearch] = useState('');
+  const { data, error, isPending, isFetching, refetch } =
+    useSessionKeys(search);
+
+  function navigateToSessionKey(sessionKey: string) {
+    navigate({ to: pathCreator.sessions({ envSlug, sessionKey }) });
+  }
 
   if (sessionsEnabled.isReady && !sessionsEnabled.value) {
     return <NotFound />;
@@ -24,9 +33,17 @@ function SessionsPage() {
     <>
       <Header breadcrumb={[{ text: 'Sessions' }]} infoIcon={<SessionsInfo />} />
       <ClientOnly>
-        <SessionsEmptyState
-          onSubmit={(sessionKey) =>
-            navigate({ to: pathCreator.sessions({ envSlug, sessionKey }) })
+        <SessionKeys
+          sessionKeys={data ?? []}
+          isLoading={isPending || isFetching}
+          search={search}
+          error={error}
+          onSearchChange={setSearch}
+          onSubmitSearch={navigateToSessionKey}
+          onRefresh={() => refetch()}
+          onSelectSessionKey={navigateToSessionKey}
+          getSessionKeyHref={(sessionKey) =>
+            pathCreator.sessions({ envSlug, sessionKey })
           }
         />
       </ClientOnly>

--- a/ui/packages/components/src/Sessions/SessionKeys.tsx
+++ b/ui/packages/components/src/Sessions/SessionKeys.tsx
@@ -1,0 +1,99 @@
+import { ErrorCard } from '@inngest/components/Error/ErrorCard';
+import { Search } from '@inngest/components/Forms/Search';
+import { Table, TableBlankState, TextCell } from '@inngest/components/Table';
+import { Time } from '@inngest/components/Time';
+import { SessionsIcon } from '@inngest/components/icons/sections/Sessions';
+import { type SessionKey } from '@inngest/components/types/session';
+import { createColumnHelper } from '@tanstack/react-table';
+
+const columnHelper = createColumnHelper<SessionKey>();
+
+const columns = [
+  columnHelper.accessor('sessionKey', {
+    header: 'Session key',
+    enableSorting: false,
+    cell: ({ row }) => (
+      <TextCell>
+        <span className="font-mono">{row.original.sessionKey}</span>
+      </TextCell>
+    ),
+  }),
+  columnHelper.accessor('createdAt', {
+    header: 'First seen',
+    enableSorting: false,
+    cell: ({ row }) => <Time value={row.original.createdAt} />,
+  }),
+];
+
+type SessionKeysProps = {
+  sessionKeys: SessionKey[];
+  isLoading: boolean;
+  search: string;
+  error?: Error | null;
+  onSearchChange: (value: string) => void;
+  onSubmitSearch: (sessionKey: string) => void;
+  onRefresh: () => void;
+  onSelectSessionKey: (sessionKey: string) => void;
+  getSessionKeyHref: (sessionKey: string) => string;
+};
+
+export function SessionKeys({
+  sessionKeys,
+  isLoading,
+  search,
+  error,
+  onSearchChange,
+  onSubmitSearch,
+  onRefresh,
+  onSelectSessionKey,
+  getSessionKeyHref,
+}: SessionKeysProps) {
+  const trimmedSearch = search.trim();
+
+  return (
+    <div className="bg-canvasBase text-basis flex flex-1 flex-col overflow-hidden focus-visible:outline-none">
+      <div className="flex flex-col gap-4 px-3 pb-3 pt-6">
+        <form
+          className="w-full max-w-[360px]"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (trimmedSearch) {
+              onSubmitSearch(trimmedSearch);
+            }
+          }}
+        >
+          <Search
+            name="sessionKey"
+            placeholder="Search by session key"
+            value={search}
+            maxLength={128}
+            autoFocus
+            className="w-full"
+            onUpdate={onSearchChange}
+          />
+        </form>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        {error ? (
+          <ErrorCard error={error} reset={onRefresh} />
+        ) : (
+          <Table
+            columns={columns}
+            data={sessionKeys}
+            isLoading={isLoading}
+            blankState={
+              <TableBlankState
+                icon={<SessionsIcon />}
+                actions={null}
+                title={search ? `No session key found for "${search}"` : 'No sessions found'}
+                description="Session keys appear here after events are sent with session meta."
+              />
+            }
+            onRowClick={(row) => onSelectSessionKey(row.original.sessionKey)}
+            getRowHref={(row) => getSessionKeyHref(row.original.sessionKey)}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/packages/components/src/types/session.ts
+++ b/ui/packages/components/src/types/session.ts
@@ -12,3 +12,8 @@ export type Session = {
   lastActiveAt: string;
   functions: SessionFunction[];
 };
+
+export type SessionKey = {
+  sessionKey: string;
+  createdAt: string;
+};


### PR DESCRIPTION
## Description

Re-works the sessions list ui view in order to allow them to have a list of sessions when searching for sessions

Cloud PR: https://github.com/inngest/monorepo/pull/7647

Before:
<img width="1798" height="1101" alt="Screenshot 2026-06-01 at 12 13 49 AM" src="https://github.com/user-attachments/assets/83c1782c-b4d1-4094-99b9-5a03f5417b47" />

After:
<img width="2553" height="1376" alt="Screenshot 2026-06-22 at 11 06 35 AM" src="https://github.com/user-attachments/assets/12867d54-6e86-4467-8f1f-6fff66a640d5" />


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
