### PR TITLE
feat(score): Make score kind constant

### DIFF
--- a/pkg/api/apiv1/metadata_test.go
+++ b/pkg/api/apiv1/metadata_test.go
@@ -221,9 +221,9 @@ func TestAddRunMetadataAllowsScoreMetadata(t *testing.T) {
 	err = r.AddRunMetadata(ctx, auth, runID, &AddRunMetadataRequest{
 		Target: RunMetadataTarget{StepID: &stepID},
 		Metadata: []metadata.Update{{RawUpdate: metadata.RawUpdate{
-			Kind:   metadata.KindInngestScore + ".passed",
+			Kind:   metadata.KindInngestScore,
 			Op:     enums.MetadataOpcodeMerge,
-			Values: metadata.Values{"value": json.RawMessage(`true`)},
+			Values: metadata.Values{"passed": json.RawMessage(`{"value": true}`)},
 		}}},
 	})
 	require.NoError(t, err)
@@ -245,9 +245,9 @@ func TestAddRunMetadataRejectsInvalidScoreMetadata(t *testing.T) {
 
 	err = r.AddRunMetadata(ctx, auth, runID, &AddRunMetadataRequest{
 		Metadata: []metadata.Update{{RawUpdate: metadata.RawUpdate{
-			Kind:   metadata.KindInngestScore + ".score",
+			Kind:   metadata.KindInngestScore,
 			Op:     enums.MetadataOpcodeMerge,
-			Values: metadata.Values{"value": json.RawMessage(`{"nested":1}`)},
+			Values: metadata.Values{"score": json.RawMessage(`{"value": {"nested":1}}`)},
 		}}},
 	})
 	require.ErrorIs(t, err, metadata.ErrScoreValueInvalid)
@@ -281,9 +281,9 @@ func TestAddRunMetadataAllowsRunScopedScoreMetadata(t *testing.T) {
 
 	err = r.AddRunMetadata(ctx, auth, runID, &AddRunMetadataRequest{
 		Metadata: []metadata.Update{{RawUpdate: metadata.RawUpdate{
-			Kind:   metadata.KindInngestScore + ".accuracy",
+			Kind:   metadata.KindInngestScore,
 			Op:     enums.MetadataOpcodeMerge,
-			Values: metadata.Values{"value": json.RawMessage(`1`)},
+			Values: metadata.Values{"accuracy": json.RawMessage(`{"value": 1}`)},
 		}}},
 	})
 	require.NoError(t, err)

--- a/pkg/tracing/metadata/kind.go
+++ b/pkg/tracing/metadata/kind.go
@@ -51,6 +51,7 @@ var allowedInngestKinds = map[Kind]bool{
 	"inngest.response_headers": true,
 	"inngest.warnings":         true,
 	"inngest.experiment":       true,
+	"inngest.score":            true,
 }
 
 // ValidateAllowed checks that the kind is valid and, if it uses the inngest.*
@@ -69,15 +70,5 @@ func (k Kind) ValidateAllowed() error {
 	if allowedInngestKinds[k] {
 		return nil
 	}
-	if k.IsScoped(KindInngestScore) {
-		return validateScoreName(string(k)[len(KindInngestScore)+1:])
-	}
 	return ErrKindNotAllowed
-}
-
-// IsScoped reports whether k uses base + "." as a prefix and carries a
-// non-empty suffix (e.g. base="inngest.score", k="inngest.score.accuracy").
-func (k Kind) IsScoped(base Kind) bool {
-	prefix := string(base) + "."
-	return len(string(k)) > len(prefix) && strings.HasPrefix(string(k), prefix)
 }

--- a/pkg/tracing/metadata/kind_test.go
+++ b/pkg/tracing/metadata/kind_test.go
@@ -47,59 +47,14 @@ func TestKind_ValidateAllowed(t *testing.T) {
 			wantErr: nil,
 		},
 		{
-			name:    "bare inngest.score is rejected (name must live in suffix)",
+			name:    "bare inngest.score is allowed",
 			kind:    KindInngestScore,
-			wantErr: ErrKindNotAllowed,
+			wantErr: nil,
 		},
 		{
-			name:    "inngest.score.<name> with simple suffix is allowed",
+			name:    "inngest.score.<name> with simple suffix is not allowed",
 			kind:    "inngest.score.accuracy",
-			wantErr: nil,
-		},
-		{
-			name:    "inngest.score.<name> with arbitrary characters is allowed",
-			kind:    "inngest.score.checkout success rate (variant A) %",
-			wantErr: nil,
-		},
-		{
-			name:    "inngest.score. with empty suffix is rejected",
-			kind:    "inngest.score.",
 			wantErr: ErrKindNotAllowed,
-		},
-		{
-			name:    "inngest.score.<name> with a single quote is rejected",
-			kind:    "inngest.score.it's-broken",
-			wantErr: ErrScoreNameInvalid,
-		},
-		{
-			name:    "inngest.score.<name> with a newline is rejected",
-			kind:    "inngest.score.foo\nbar",
-			wantErr: ErrScoreNameInvalid,
-		},
-		{
-			name:    "inngest.score.<name> with a tab is rejected",
-			kind:    "inngest.score.foo\tbar",
-			wantErr: ErrScoreNameInvalid,
-		},
-		{
-			name:    "inngest.score.<name> with DEL (0x7F) is rejected",
-			kind:    "inngest.score.foo\x7fbar",
-			wantErr: ErrScoreNameInvalid,
-		},
-		{
-			name:    "inngest.score.<name> with multi-byte UTF-8 is allowed",
-			kind:    "inngest.score.checkout-✓",
-			wantErr: nil,
-		},
-		{
-			name:    "inngest.score.<name> with a trailing backslash is allowed",
-			kind:    "inngest.score.trailing\\",
-			wantErr: nil,
-		},
-		{
-			name:    "inngest.score.<name> with a backtick is allowed",
-			kind:    "inngest.score.has`backtick",
-			wantErr: nil,
 		},
 		{
 			name:    "inngest.unknown is rejected",

--- a/pkg/tracing/metadata/metadata.go
+++ b/pkg/tracing/metadata/metadata.go
@@ -158,6 +158,13 @@ func (m Update) ValidateAllowed() error {
 		return err
 	}
 
+	switch m.Kind() {
+	case KindInngestScore:
+		if err := validateNamedScoreValue(m.Values); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/tracing/metadata/metadata.go
+++ b/pkg/tracing/metadata/metadata.go
@@ -158,10 +158,6 @@ func (m Update) ValidateAllowed() error {
 		return err
 	}
 
-	if m.Kind().IsScoped(KindInngestScore) {
-		return validateNamedScoreValue(m.Kind(), m.RawUpdate.Values)
-	}
-
 	return nil
 }
 

--- a/pkg/tracing/metadata/metadata_test.go
+++ b/pkg/tracing/metadata/metadata_test.go
@@ -91,72 +91,108 @@ func TestUpdateValidateAllowedNamedScoreValue(t *testing.T) {
 		wantErr error
 	}{
 		{
-			name: "finite numeric value is valid",
+			name: "single finite numeric score is valid",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   "inngest.score.accuracy",
+				Kind:   KindInngestScore,
 				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{"value": json.RawMessage(`0.95`)},
+				Values: Values{"accuracy": json.RawMessage(`{"value":0.95}`)},
 			}},
 		},
 		{
-			name: "arbitrary name in kind is accepted",
+			name: "boolean score value is valid",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   "inngest.score.click-through rate (variant A)",
+				Kind:   KindInngestScore,
 				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{"value": json.RawMessage(`0.23`)},
+				Values: Values{"passed": json.RawMessage(`{"value":true}`)},
 			}},
 		},
 		{
-			name: "missing value key is rejected",
+			name: "multiple scores in one update are valid",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   "inngest.score.accuracy",
-				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{"score": json.RawMessage(`1`)},
+				Kind: KindInngestScore,
+				Op:   enums.MetadataOpcodeMerge,
+				Values: Values{
+					"accuracy":  json.RawMessage(`{"value":0.95}`),
+					"relevance": json.RawMessage(`{"value":0.8}`),
+				},
 			}},
-			wantErr: ErrScoreValueInvalid,
+		},
+		{
+			name: "arbitrary score name is accepted",
+			update: Update{RawUpdate: RawUpdate{
+				Kind:   KindInngestScore,
+				Op:     enums.MetadataOpcodeMerge,
+				Values: Values{"click-through rate (variant A)": json.RawMessage(`{"value":0.23}`)},
+			}},
+		},
+		{
+			name: "empty values map is valid",
+			update: Update{RawUpdate: RawUpdate{
+				Kind:   KindInngestScore,
+				Op:     enums.MetadataOpcodeMerge,
+				Values: Values{},
+			}},
+		},
+		{
+			name: "score name with single quote is rejected",
+			update: Update{RawUpdate: RawUpdate{
+				Kind:   KindInngestScore,
+				Op:     enums.MetadataOpcodeMerge,
+				Values: Values{"name'with'quotes": json.RawMessage(`{"value":0.5}`)},
+			}},
+			wantErr: ErrScoreNameInvalid,
 		},
 		{
 			name: "extra keys alongside value are rejected",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   "inngest.score.accuracy",
+				Kind:   KindInngestScore,
 				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{"value": json.RawMessage(`1`), "extra": json.RawMessage(`2`)},
+				Values: Values{"accuracy": json.RawMessage(`{"value":0.95,"extra":2}`)},
 			}},
 			wantErr: ErrScoreValueInvalid,
 		},
 		{
-			name: "empty values map is rejected",
+			name: "missing nested value key is rejected",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   "inngest.score.accuracy",
+				Kind:   KindInngestScore,
 				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{},
+				Values: Values{"accuracy": json.RawMessage(`{"score":0.95}`)},
 			}},
 			wantErr: ErrScoreValueInvalid,
 		},
 		{
-			name: "null value is rejected",
+			name: "bare scalar instead of value object is rejected",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   "inngest.score.accuracy",
+				Kind:   KindInngestScore,
 				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{"value": json.RawMessage(`null`)},
+				Values: Values{"accuracy": json.RawMessage(`0.95`)},
 			}},
 			wantErr: ErrScoreValueInvalid,
 		},
 		{
-			name: "string value is rejected",
+			name: "null score value is rejected",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   "inngest.score.accuracy",
+				Kind:   KindInngestScore,
 				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{"value": json.RawMessage(`"high"`)},
+				Values: Values{"accuracy": json.RawMessage(`{"value":null}`)},
 			}},
 			wantErr: ErrScoreValueInvalid,
 		},
 		{
-			name: "object value is rejected",
+			name: "string score value is rejected",
 			update: Update{RawUpdate: RawUpdate{
-				Kind:   "inngest.score.accuracy",
+				Kind:   KindInngestScore,
 				Op:     enums.MetadataOpcodeMerge,
-				Values: Values{"value": json.RawMessage(`{"nested":1}`)},
+				Values: Values{"accuracy": json.RawMessage(`{"value":"high"}`)},
+			}},
+			wantErr: ErrScoreValueInvalid,
+		},
+		{
+			name: "object score value is rejected",
+			update: Update{RawUpdate: RawUpdate{
+				Kind:   KindInngestScore,
+				Op:     enums.MetadataOpcodeMerge,
+				Values: Values{"accuracy": json.RawMessage(`{"value":{"nested":1}}`)},
 			}},
 			wantErr: ErrScoreValueInvalid,
 		},

--- a/pkg/tracing/metadata/score.go
+++ b/pkg/tracing/metadata/score.go
@@ -51,8 +51,8 @@ func validateNamedScoreValue(values Values) error {
 		case bool:
 			continue
 		case float64:
-			if !math.IsNaN(v) && !math.IsInf(v, 0) {
-				continue
+			if math.IsNaN(v) || math.IsInf(v, 0) {
+				return fmt.Errorf("invalid score value: %w", ErrScoreValueInvalid)
 			}
 		default:
 			return fmt.Errorf("invalid score value: %w", ErrScoreValueInvalid)

--- a/pkg/tracing/metadata/score.go
+++ b/pkg/tracing/metadata/score.go
@@ -30,29 +30,31 @@ func validateScoreName(name string) error {
 // inngest.score.<name> kind family. The user-supplied name lives in the kind
 // suffix (analogous to userland.<name>), so values carries exactly one entry
 // keyed "value" containing a finite number or boolean.
-func validateNamedScoreValue(kind Kind, values Values) error {
-	if len(values) != 1 {
-		return fmt.Errorf("score %q must have exactly one entry keyed \"value\": %w", kind, ErrScoreValueInvalid)
-	}
+func validateNamedScoreValue(values Values) error {
+	for name, raw := range values {
+		var valueHolder struct {
+			Value any `json:"value"`
+		}
 
-	raw, ok := values["value"]
-	if !ok {
-		return fmt.Errorf("score %q value key must be \"value\": %w", kind, ErrScoreValueInvalid)
-	}
+		if err := json.Unmarshal(raw, &valueHolder); err != nil {
+			return fmt.Errorf("invalid score value: %w", ErrScoreValueInvalid)
+		}
 
-	var value any
-	if err := json.Unmarshal(raw, &value); err != nil {
-		return fmt.Errorf("invalid score value for kind %q: %w", kind, ErrScoreValueInvalid)
-	}
+		if err := validateScoreName(name); err != nil {
+			return fmt.Errorf("invalid score value: %w", err)
+		}
 
-	switch v := value.(type) {
-	case bool:
-		return nil
-	case float64:
-		if !math.IsNaN(v) && !math.IsInf(v, 0) {
+		switch v := valueHolder.Value.(type) {
+		case bool:
 			return nil
+		case float64:
+			if !math.IsNaN(v) && !math.IsInf(v, 0) {
+				return nil
+			}
+		default:
+			return fmt.Errorf("invalid score value: %w", ErrScoreValueInvalid)
 		}
 	}
 
-	return fmt.Errorf("invalid score value for kind %q: %w", kind, ErrScoreValueInvalid)
+	return fmt.Errorf("invalid score values: %w", ErrScoreValueInvalid)
 }

--- a/pkg/tracing/metadata/score.go
+++ b/pkg/tracing/metadata/score.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"strings"
 )
 
 //tygo:generate
@@ -36,7 +37,9 @@ func validateNamedScoreValue(values Values) error {
 			Value any `json:"value"`
 		}
 
-		if err := json.Unmarshal(raw, &valueHolder); err != nil {
+		dec := json.NewDecoder(strings.NewReader(string(raw)))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&valueHolder); err != nil {
 			return fmt.Errorf("invalid score value: %w", ErrScoreValueInvalid)
 		}
 
@@ -46,15 +49,15 @@ func validateNamedScoreValue(values Values) error {
 
 		switch v := valueHolder.Value.(type) {
 		case bool:
-			return nil
+			continue
 		case float64:
 			if !math.IsNaN(v) && !math.IsInf(v, 0) {
-				return nil
+				continue
 			}
 		default:
 			return fmt.Errorf("invalid score value: %w", ErrScoreValueInvalid)
 		}
 	}
 
-	return fmt.Errorf("invalid score values: %w", ErrScoreValueInvalid)
+	return nil
 }


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This makes the score kind constant and changes the underlying scores shape to 

```json
{"<name>": {"value": <value>}}
```

with kind `inngest.score`

instead of 

```json
{"value": <value>}
```

with kind `inngest.score.name`

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
