### PR TITLE
fix(dashboard): Scoring formula slider interaction

### DIFF
--- a/ui/apps/dashboard/src/components/Experiments/ExperimentDetailPage.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/ExperimentDetailPage.tsx
@@ -227,11 +227,13 @@ export function ExperimentDetailPage({
   const helperItems: HelperItem[] = [
     {
       title: INFO_PANEL,
+      label: 'INFO',
       icon: <RiFlaskLine className="h-4 w-4" />,
       action: () => togglePanel(INFO_PANEL),
     },
     {
       title: SCORING_PANEL,
+      label: 'SCORING FORMULA',
       icon: <RiListOrdered2 className="h-4 w-4" />,
       action: () => togglePanel(SCORING_PANEL),
     },
@@ -258,7 +260,7 @@ export function ExperimentDetailPage({
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <div className="flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto px-6 pb-10 pt-4">
-          <h1 className="text-basis text-lg font-semibold">{experimentName}</h1>
+          <h1 className="text-basis text-lg">{experimentName}</h1>
 
           {!rangeReady ? (
             <>

--- a/ui/apps/dashboard/src/components/Experiments/ExperimentDetailPage.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/ExperimentDetailPage.tsx
@@ -366,7 +366,6 @@ export function ExperimentDetailPage({
                         scoringConfig={scoring.metrics}
                         metricRanges={metricRanges}
                         onUpdateMetric={scoring.updateMetric}
-                        pointsLeft={scoring.pointsLeft}
                         onOpenInsights={onOpenInsights}
                         showInactive={showInactive}
                         onShowInactiveChange={setShowInactive}
@@ -398,7 +397,6 @@ export function ExperimentDetailPage({
                   metrics={scoring.metrics}
                   metricRanges={metricRanges}
                   onUpdateMetric={scoring.updateMetric}
-                  pointsLeft={scoring.pointsLeft}
                 />
               )}
             </HelperPanelFrame>

--- a/ui/apps/dashboard/src/components/Experiments/MetricPanel.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/MetricPanel.tsx
@@ -138,9 +138,7 @@ export function MetricPanel({ metric, variants }: Props) {
   return (
     <Card className="overflow-visible" contentClassName="overflow-visible">
       <Card.Header className="flex-row items-center justify-between rounded-t-md border-b-0 py-2 pl-3 pr-2">
-        <span className="text-basis text-sm font-medium">
-          {metric.displayName}
-        </span>
+        <span className="text-basis text-sm">{metric.displayName}</span>
         {winner && (
           <Pill
             kind="default"

--- a/ui/apps/dashboard/src/components/Experiments/ScoreSummaryCard.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/ScoreSummaryCard.tsx
@@ -144,6 +144,13 @@ export function ScoreSummaryCard({
                 iconType="circle"
                 iconSize={8}
                 wrapperStyle={{ fontSize: 12 }}
+                // Keep the colored dot but render the label in the muted text
+                // tone instead of the series color (recharts' default).
+                formatter={(value: string) => (
+                  <span style={{ color: 'rgb(var(--color-foreground-muted))' }}>
+                    {value}
+                  </span>
+                )}
               />
               {enabledMetrics.map((m, i) => (
                 <Bar

--- a/ui/apps/dashboard/src/components/Experiments/ScoreSummaryCard.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/ScoreSummaryCard.tsx
@@ -103,11 +103,11 @@ export function ScoreSummaryCard({
     >
       <Card.Header className="rounded-t-md border-b-0 py-2 pl-3 pr-2">
         <div className="flex items-center gap-1.5">
-          <span className="text-basis text-sm font-medium">Score Summary</span>
+          <span className="text-basis text-sm">Score Summary</span>
           <ScoreCalculationExplainer />
         </div>
       </Card.Header>
-      <Card.Content className="flex gap-6 rounded-b-md px-2 py-0">
+      <Card.Content className="flex gap-6 rounded-b-md px-2 py-2">
         <div className="min-w-0 flex-1">
           <ResponsiveContainer width="100%" height={chartHeight}>
             <BarChart

--- a/ui/apps/dashboard/src/components/Experiments/ScoringFormulaSidebar.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/ScoringFormulaSidebar.tsx
@@ -1,7 +1,14 @@
 import { useState } from 'react';
 import { Button } from '@inngest/components/Button';
+import { Checkbox } from '@inngest/components/Checkbox';
 import type { ExperimentScoringMetric } from '@inngest/components/Experiments';
 import { Input } from '@inngest/components/Forms/Input';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@inngest/components/Popover';
+import { Slider } from '@inngest/components/Slider';
 import { Switch } from '@inngest/components/Switch';
 import {
   Tooltip,
@@ -10,17 +17,14 @@ import {
   TooltipTrigger,
 } from '@inngest/components/Tooltip';
 import { cn } from '@inngest/components/utils/classNames';
-import {
-  RiAddLine,
-  RiArrowDownSLine,
-  RiArrowUpSLine,
-  RiErrorWarningLine,
-  RiSubtractLine,
-} from '@remixicon/react';
+import { RiErrorWarningLine, RiPencilLine } from '@remixicon/react';
 
+import { buildMetricColorMap } from '@/lib/experiments/colors';
 import { roundMetricValue } from './variantsTable/metricStats';
 
 type MetricRange = { min: number; max: number };
+
+const MAX_WEIGHT = 100;
 
 type Props = {
   metrics: ExperimentScoringMetric[];
@@ -29,298 +33,322 @@ type Props = {
     key: string,
     patch: Partial<ExperimentScoringMetric>,
   ) => void;
-  pointsLeft: number;
 };
 
 export function ScoringFormulaSidebar({
   metrics,
   metricRanges,
   onUpdateMetric,
-  pointsLeft,
 }: Props) {
-  const barPercent = Math.max(0, Math.min(100, 100 - pointsLeft));
+  const colorMap = buildMetricColorMap(metrics);
 
   return (
     <div className="flex min-w-[320px] flex-col gap-4 p-4">
       <div>
         <h3 className="text-basis text-sm font-medium">Scoring formula</h3>
         <p className="text-muted mt-1 text-xs">
-          Distribute 100 points across active metrics — toggle a metric off to
-          exclude it from the score entirely. Higher points means more
-          influence.
+          Assign importance to each metric to find the best variant based on
+          your preferences. Toggle a metric off to exclude it from the score
+          entirely.
         </p>
-        <div className="mt-3 flex items-center justify-between">
-          <span
-            className={cn(
-              'text-xs font-medium tabular-nums',
-              pointsLeft < 0 ? 'text-error' : 'text-muted',
-            )}
-          >
-            Points left: {pointsLeft}
-          </span>
-        </div>
-        <div className="bg-canvasSubtle mt-1.5 h-1 w-full overflow-hidden rounded-full">
-          <div
-            className={cn(
-              'h-full rounded-full transition-all',
-              pointsLeft < 0 ? 'bg-error' : 'bg-contrast',
-            )}
-            style={{ width: `${barPercent}%` }}
-          />
-        </div>
       </div>
 
-      <div className="flex flex-col gap-1">
+      <WeightDistributionBar metrics={metrics} colorMap={colorMap} />
+
+      <div className="divide-subtle border-subtle flex flex-col divide-y border-y">
         {metrics.map((metric) => (
-          <MetricAccordionItem
+          <MetricWeightRow
             key={metric.key}
             metric={metric}
             range={metricRanges?.[metric.key]}
-            pointsLeft={pointsLeft}
+            color={colorMap[metric.key]}
             onUpdate={(patch) => onUpdateMetric(metric.key, patch)}
           />
         ))}
       </div>
-
-      <p className="text-muted text-xs">
-        The unallocated points won&apos;t count towards the score.
-      </p>
     </div>
   );
 }
 
-export function MetricAccordionItem({
+function WeightDistributionBar({
+  metrics,
+  colorMap,
+}: {
+  metrics: ExperimentScoringMetric[];
+  colorMap: Record<string, string>;
+}) {
+  const enabled = metrics.filter((m) => m.enabled);
+  const total = enabled.reduce((sum, m) => sum + m.points, 0);
+
+  if (enabled.length === 0 || total === 0) {
+    return (
+      <div className="flex flex-col gap-2">
+        <div className="bg-canvasSubtle h-2.5 w-full overflow-hidden rounded-full" />
+        <p className="text-muted text-xs">
+          Enable a metric and assign weight to see its distribution.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="bg-canvasSubtle flex h-2.5 w-full overflow-hidden rounded-full">
+        {enabled.map((m) => (
+          <div
+            key={m.key}
+            style={{
+              width: `${(m.points / total) * 100}%`,
+              backgroundColor: colorMap[m.key],
+            }}
+          />
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-x-3 gap-y-1">
+        {enabled.map((m) => (
+          <span key={m.key} className="flex items-center gap-1.5 text-xs">
+            <span
+              className="h-2 w-2 shrink-0 rounded-sm"
+              style={{ backgroundColor: colorMap[m.key] }}
+            />
+            <span className="text-basis">{m.displayName}</span>
+            <span className="text-muted tabular-nums">
+              {Math.round((m.points / total) * 100)}%
+            </span>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MetricWeightRow({
   metric,
   onUpdate,
-  disabled,
-  pointsLeft,
+  color,
   range,
-  defaultExpanded = false,
-  collapsible = true,
-  isPopover = false,
+  disabled,
 }: {
   metric: ExperimentScoringMetric;
   onUpdate: (patch: Partial<ExperimentScoringMetric>) => void;
-  disabled?: boolean;
-  pointsLeft: number;
+  color?: string;
   range?: MetricRange;
-  defaultExpanded?: boolean;
-  collapsible?: boolean;
-  isPopover?: boolean;
+  disabled?: boolean;
 }) {
-  const [internalExpanded, setInternalExpanded] = useState(
-    defaultExpanded ?? false,
-  );
-  const expanded = isPopover ? true : collapsible ? internalExpanded : true;
-  const toggle =
-    !isPopover && collapsible
-      ? () => setInternalExpanded((v) => !v)
-      : undefined;
-
   return (
-    <div className="border-subtle rounded-md border">
-      {!isPopover && (
-        <div className="flex items-center gap-2 px-3 py-2">
-          <EnableSwitch
-            checked={metric.enabled}
-            onCheckedChange={(checked) => onUpdate({ enabled: checked })}
-            disabled={disabled}
-          />
+    <div className="flex items-start gap-2.5 py-3">
+      <Switch
+        checked={metric.enabled}
+        onCheckedChange={(checked) => onUpdate({ enabled: checked })}
+        disabled={disabled}
+        checkedColor={color}
+        className="mt-0.5 shrink-0 scale-75"
+      />
 
-          <button
-            type="button"
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <div className="flex items-center gap-2">
+          <span
             className={cn(
-              'min-w-0 flex-1 truncate text-left text-sm',
+              'min-w-0 flex-1 truncate text-sm',
               metric.enabled ? 'text-basis' : 'text-muted',
-              !collapsible && 'cursor-default',
             )}
-            onClick={toggle}
           >
             {metric.displayName}
-          </button>
+          </span>
 
-          <PointsControl
-            points={metric.points}
-            pointsLeft={pointsLeft}
+          <WeightInput
+            value={metric.points}
             onChange={(points) => onUpdate({ points })}
-            disabled={disabled}
+            disabled={disabled || !metric.enabled}
           />
 
-          {collapsible && (
-            <button
-              type="button"
-              className="text-muted shrink-0"
-              onClick={toggle}
-            >
-              {expanded ? (
-                <RiArrowUpSLine className="h-4 w-4" />
-              ) : (
-                <RiArrowDownSLine className="h-4 w-4" />
-              )}
-            </button>
-          )}
-        </div>
-      )}
-
-      {expanded && (
-        <div
-          className={cn(
-            'flex flex-col gap-3 px-3 pb-3 pt-3',
-            !isPopover && 'bg-canvasSubtle border-subtle rounded-b-md border-t',
-          )}
-        >
-          <Input
-            label="Name"
-            inngestSize="small"
-            className="bg-canvasBase"
-            value={metric.displayName}
-            onChange={(e) => onUpdate({ displayName: e.target.value })}
-            disabled={disabled}
-          />
-
-          {isPopover && (
-            <>
-              <div className="flex items-center justify-between">
-                <span className="text-basis text-sm font-medium">
-                  Include metrics
-                </span>
-                <EnableSwitch
-                  checked={metric.enabled}
-                  onCheckedChange={(checked) => onUpdate({ enabled: checked })}
-                  disabled={disabled}
-                />
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-basis text-sm font-medium">
-                  Point allocation
-                </span>
-                <PointsControl
-                  points={metric.points}
-                  pointsLeft={pointsLeft}
-                  onChange={(points) => onUpdate({ points })}
-                  disabled={disabled}
-                />
-              </div>
-            </>
-          )}
-
-          <div className="flex flex-col gap-1">
-            <span className="text-basis text-sm font-medium">
-              Min. & Max scores
-            </span>
-            <p className="text-muted mb-2 text-xs">
-              Assign the lowest &amp; highest score for this metric
-            </p>
-            <div className="grid grid-cols-2 gap-2">
-              <div className="flex flex-col gap-1">
-                <span className="text-subtle text-xs uppercase">Min score</span>
-                <Input
-                  inngestSize="small"
-                  className="bg-canvasBase"
-                  type="number"
-                  value={roundMetricValue(metric.minValue)}
-                  onChange={(e) =>
-                    onUpdate({ minValue: parseFloat(e.target.value) || 0 })
-                  }
-                  disabled={disabled}
-                />
-              </div>
-              <div className="flex flex-col gap-1">
-                <span className="text-subtle text-xs uppercase">Max score</span>
-                <Input
-                  inngestSize="small"
-                  className="bg-canvasBase"
-                  type="number"
-                  value={roundMetricValue(metric.maxValue)}
-                  onChange={(e) =>
-                    onUpdate({ maxValue: parseFloat(e.target.value) || 0 })
-                  }
-                  disabled={disabled}
-                />
-              </div>
-            </div>
-          </div>
-
-          <div className="flex items-center justify-between gap-1">
-            <div className="flex items-center gap-1">
-              <label className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={metric.invert}
-                  onChange={(e) => onUpdate({ invert: e.target.checked })}
-                  disabled={disabled}
-                  className="accent-primary-moderate h-3.5 w-3.5 rounded"
-                />
-                <span className="text-basis text-xs">Invert</span>
-              </label>
-              <InfoTooltip>
-                Enable when a lower metric value represents better performance
-                (for example, latency or error rate). The score will be inverted
-                so smaller values map to the max score.
-              </InfoTooltip>
-            </div>
-            <div className="flex items-center gap-1">
+          <Popover>
+            <PopoverTrigger asChild>
               <Button
                 kind="secondary"
                 appearance="outlined"
                 size="small"
-                label="Fit to data"
-                disabled={
-                  disabled ||
-                  !range ||
-                  (metric.minValue === roundMetricValue(range.min) &&
-                    metric.maxValue === roundMetricValue(range.max))
-                }
-                onClick={() =>
-                  range &&
-                  onUpdate({
-                    minValue: roundMetricValue(range.min),
-                    maxValue: roundMetricValue(range.max),
-                  })
-                }
+                icon={<RiPencilLine />}
+                className="shrink-0"
+                aria-label={`Edit ${metric.displayName} settings`}
               />
-              <InfoTooltip>
-                Snap min and max to the range observed in this time window.
-              </InfoTooltip>
-            </div>
-          </div>
+            </PopoverTrigger>
+            <PopoverContent side="bottom" align="end" className="w-[340px] p-4">
+              <MetricConfigForm
+                metric={metric}
+                range={range}
+                onUpdate={onUpdate}
+                disabled={disabled}
+              />
+            </PopoverContent>
+          </Popover>
+        </div>
 
-          <div className="flex flex-col gap-1">
-            <span className="text-basis text-sm font-medium">
-              Performance Labels
+        <Slider
+          value={[metric.points]}
+          onValueChange={([points]) => onUpdate({ points: points ?? 0 })}
+          min={0}
+          max={MAX_WEIGHT}
+          step={1}
+          color={color}
+          disabled={disabled || !metric.enabled}
+          aria-label={`${metric.displayName} weight`}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function MetricConfigForm({
+  metric,
+  onUpdate,
+  range,
+  disabled,
+}: {
+  metric: ExperimentScoringMetric;
+  onUpdate: (patch: Partial<ExperimentScoringMetric>) => void;
+  range?: MetricRange;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <Input
+        inngestSize="base"
+        className="bg-canvasBase"
+        value={metric.displayName}
+        onChange={(e) => onUpdate({ displayName: e.target.value })}
+        disabled={disabled}
+      />
+
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-basis text-sm font-medium">
+            Min. &amp; Max. scores
+          </span>
+          <p className="text-muted text-xs">
+            Assign the lowest &amp; highest score for this metric
+          </p>
+        </div>
+        <div className="flex items-end gap-2">
+          <div className="flex flex-1 flex-col gap-1">
+            <span className="text-muted text-[11px] font-medium uppercase tracking-wide">
+              Min score
             </span>
-            <p className="text-muted mb-2 text-xs">
-              Shown next to the best and worst values in the table
-            </p>
-            <div className="grid grid-cols-2 gap-2">
-              <div className="flex flex-col gap-1">
-                <span className="text-subtle text-xs uppercase">
-                  Worst label
-                </span>
-                <Input
-                  inngestSize="small"
-                  className="bg-canvasBase"
-                  value={metric.labelWorst}
-                  onChange={(e) => onUpdate({ labelWorst: e.target.value })}
-                  disabled={disabled}
-                />
-              </div>
-              <div className="flex flex-col gap-1">
-                <span className="text-subtle text-xs uppercase">
-                  Best label
-                </span>
-                <Input
-                  inngestSize="small"
-                  className="bg-canvasBase"
-                  value={metric.labelBest}
-                  onChange={(e) => onUpdate({ labelBest: e.target.value })}
-                  disabled={disabled}
-                />
-              </div>
-            </div>
+            <Input
+              inngestSize="base"
+              className="bg-canvasBase"
+              type="number"
+              value={roundMetricValue(metric.minValue)}
+              onChange={(e) =>
+                onUpdate({ minValue: parseFloat(e.target.value) || 0 })
+              }
+              disabled={disabled}
+            />
+          </div>
+          <span className="text-disabled pb-2 text-sm">–</span>
+          <div className="flex flex-1 flex-col gap-1">
+            <span className="text-muted text-[11px] font-medium uppercase tracking-wide">
+              Max score
+            </span>
+            <Input
+              inngestSize="base"
+              className="bg-canvasBase"
+              type="number"
+              value={roundMetricValue(metric.maxValue)}
+              onChange={(e) =>
+                onUpdate({ maxValue: parseFloat(e.target.value) || 0 })
+              }
+              disabled={disabled}
+            />
           </div>
         </div>
-      )}
+      </div>
+
+      <div className="flex items-center justify-between gap-1">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id={`invert-${metric.key}`}
+            checked={metric.invert}
+            onCheckedChange={(checked) =>
+              onUpdate({ invert: checked === true })
+            }
+            disabled={disabled}
+          />
+          <label
+            htmlFor={`invert-${metric.key}`}
+            className="text-basis text-sm"
+          >
+            Invert score
+          </label>
+          <InfoTooltip>
+            Enable when a lower metric value represents better performance (for
+            example, latency or error rate). The score will be inverted so
+            smaller values map to the max score.
+          </InfoTooltip>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            kind="secondary"
+            appearance="outlined"
+            size="small"
+            label="Fit to data"
+            disabled={
+              disabled ||
+              !range ||
+              (metric.minValue === roundMetricValue(range.min) &&
+                metric.maxValue === roundMetricValue(range.max))
+            }
+            onClick={() =>
+              range &&
+              onUpdate({
+                minValue: roundMetricValue(range.min),
+                maxValue: roundMetricValue(range.max),
+              })
+            }
+          />
+          <InfoTooltip>
+            Snap min and max to the range observed in this time window.
+          </InfoTooltip>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-0.5">
+          <span className="text-basis text-sm font-medium">
+            Performance labels
+          </span>
+          <p className="text-muted text-xs">
+            Shown next to the best and worst values in the table
+          </p>
+        </div>
+        <div className="flex items-end gap-2">
+          <div className="flex flex-1 flex-col gap-1">
+            <span className="text-muted text-[11px] font-medium uppercase tracking-wide">
+              Worst label
+            </span>
+            <Input
+              inngestSize="base"
+              className="bg-canvasBase"
+              value={metric.labelWorst}
+              onChange={(e) => onUpdate({ labelWorst: e.target.value })}
+              disabled={disabled}
+            />
+          </div>
+          <span className="text-disabled pb-2 text-sm">–</span>
+          <div className="flex flex-1 flex-col gap-1">
+            <span className="text-muted text-[11px] font-medium uppercase tracking-wide">
+              Best label
+            </span>
+            <Input
+              inngestSize="base"
+              className="bg-canvasBase"
+              value={metric.labelBest}
+              onChange={(e) => onUpdate({ labelBest: e.target.value })}
+              disabled={disabled}
+            />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
@@ -334,7 +362,14 @@ function InfoTooltip({ children }: { children: React.ReactNode }) {
             <RiErrorWarningLine className="h-[14px] w-[14px]" />
           </button>
         </TooltipTrigger>
-        <TooltipContent side="top" align="end" hasArrow={false}>
+        {/* Above the edit Popover (z-[100]) so info tooltips opened inside it
+            aren't clipped behind the panel. */}
+        <TooltipContent
+          side="top"
+          align="end"
+          hasArrow={false}
+          className="z-[101]"
+        >
           {children}
         </TooltipContent>
       </Tooltip>
@@ -342,14 +377,12 @@ function InfoTooltip({ children }: { children: React.ReactNode }) {
   );
 }
 
-function PointsInput({
+function WeightInput({
   value,
-  maxValue,
   onChange,
   disabled,
 }: {
   value: number;
-  maxValue: number;
   onChange: (v: number) => void;
   disabled?: boolean;
 }) {
@@ -386,7 +419,7 @@ function PointsInput({
     const current = input.value;
     const next = current.slice(0, start) + e.key + current.slice(end);
     const parsed = parseInt(next, 10);
-    if (isNaN(parsed) || parsed < 0 || parsed > maxValue) {
+    if (isNaN(parsed) || parsed < 0 || parsed > MAX_WEIGHT) {
       e.preventDefault();
     }
   };
@@ -399,7 +432,7 @@ function PointsInput({
       return;
     }
     const parsed = parseInt(raw, 10);
-    if (!isNaN(parsed) && parsed >= 0 && parsed <= maxValue) {
+    if (!isNaN(parsed) && parsed >= 0 && parsed <= MAX_WEIGHT) {
       setLocalValue(String(parsed));
       onChange(parsed);
     }
@@ -413,86 +446,12 @@ function PointsInput({
     <input
       type="text"
       inputMode="numeric"
-      className="text-muted w-8 bg-transparent text-center text-xs tabular-nums outline-none"
+      className="border-subtle text-basis h-7 w-11 shrink-0 rounded border bg-transparent text-center text-xs tabular-nums outline-none disabled:opacity-50"
       value={localValue}
       onKeyDown={handleKeyDown}
       onChange={handleChange}
       onBlur={handleBlur}
       disabled={disabled}
     />
-  );
-}
-
-function EnableSwitch({
-  checked,
-  onCheckedChange,
-  disabled,
-}: {
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
-  disabled?: boolean;
-}) {
-  return (
-    <Switch
-      checked={checked}
-      onCheckedChange={onCheckedChange}
-      disabled={disabled}
-      className="shrink-0 scale-75"
-    />
-  );
-}
-
-function PointsControl({
-  points,
-  pointsLeft,
-  onChange,
-  disabled,
-}: {
-  points: number;
-  pointsLeft: number;
-  onChange: (points: number) => void;
-  disabled?: boolean;
-}) {
-  return (
-    <div className="border-subtle flex shrink-0 items-center gap-1 rounded border px-1.5 py-1">
-      <PointsStepperButton
-        icon={<RiSubtractLine className="h-3 w-3" />}
-        disabled={disabled || points <= 0}
-        onClick={() => onChange(Math.max(0, points - 1))}
-      />
-      <PointsInput
-        value={points}
-        maxValue={points + pointsLeft}
-        onChange={onChange}
-        disabled={disabled}
-      />
-      <span className="text-muted text-xs">pts</span>
-      <PointsStepperButton
-        icon={<RiAddLine className="h-3 w-3" />}
-        disabled={disabled || pointsLeft <= 0}
-        onClick={() => onChange(points + 1)}
-      />
-    </div>
-  );
-}
-
-function PointsStepperButton({
-  icon,
-  disabled,
-  onClick,
-}: {
-  icon: React.ReactNode;
-  disabled?: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={onClick}
-      className="text-muted hover:text-basis hover:bg-canvasSubtle flex h-4 w-4 shrink-0 items-center justify-center rounded-sm disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
-    >
-      {icon}
-    </button>
   );
 }

--- a/ui/apps/dashboard/src/components/Experiments/VariantsTable.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/VariantsTable.tsx
@@ -34,7 +34,6 @@ type Props = {
     key: string,
     patch: Partial<ExperimentScoringMetric>,
   ) => void;
-  pointsLeft: number;
   onOpenInsights: () => void;
   showInactive: boolean;
   onShowInactiveChange: (v: boolean) => void;
@@ -54,7 +53,6 @@ export function VariantsTable({
   scoringConfig,
   metricRanges,
   onUpdateMetric,
-  pointsLeft,
   onOpenInsights,
   showInactive,
   onShowInactiveChange,
@@ -77,13 +75,11 @@ export function VariantsTable({
   // render, so they read the latest values.
   const liveRef = useRef({
     enabledMetrics,
-    pointsLeft,
     onUpdateMetric,
     metricRanges,
   });
   liveRef.current = {
     enabledMetrics,
-    pointsLeft,
     onUpdateMetric,
     metricRanges,
   };
@@ -181,7 +177,6 @@ export function VariantsTable({
             return (
               <MetricColumnHeader
                 metric={metric}
-                pointsLeft={liveRef.current.pointsLeft}
                 onUpdateMetric={liveRef.current.onUpdateMetric}
                 range={liveRef.current.metricRanges?.[metricKey]}
               />

--- a/ui/apps/dashboard/src/components/Experiments/useScoringConfig.ts
+++ b/ui/apps/dashboard/src/components/Experiments/useScoringConfig.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ExperimentScoringMetric } from '@inngest/components/Experiments';
 import useDebounce from '@inngest/components/hooks/useDebounce';
 
@@ -12,9 +12,9 @@ const DEBOUNCE_MS = 600;
 /**
  * Manages local scoring-config state with debounced persistence.
  *
- * Every mutator (`updateMetric`, `enableMetric`) applies optimistically and
- * schedules a save after DEBOUNCE_MS of inactivity. The save is skipped when
- * the local state matches the last-known server state.
+ * Every `updateMetric` call applies optimistically and schedules a save after
+ * DEBOUNCE_MS of inactivity. The save is skipped when the local state matches
+ * the last-known server state.
  */
 export function useScoringConfig(functionID: string, experimentName: string) {
   const scoring = useExperimentScoringConfig(functionID, experimentName);
@@ -73,27 +73,9 @@ export function useScoringConfig(functionID: string, experimentName: string) {
     [],
   );
 
-  const enableMetric = useCallback((key: string) => {
-    setLocalMetrics((prev) =>
-      prev
-        ? prev.map((m) => (m.key === key ? { ...m, enabled: true } : m))
-        : prev,
-    );
-  }, []);
-
-  const pointsLeft = useMemo(() => {
-    if (!localMetrics) return 100;
-    const allocated = localMetrics
-      .filter((m) => m.enabled)
-      .reduce((sum, m) => sum + m.points, 0);
-    return 100 - allocated;
-  }, [localMetrics]);
-
   return {
     metrics: localMetrics,
     updateMetric,
-    enableMetric,
-    pointsLeft,
     isSaving: updateScoring.isPending,
     isPending: scoring.isPending,
     error: updateScoring.error ?? scoring.error,

--- a/ui/apps/dashboard/src/components/Experiments/variantsTable/parts.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/variantsTable/parts.tsx
@@ -6,7 +6,7 @@ import {
 } from '@inngest/components/Popover';
 import { RiSettings3Line } from '@remixicon/react';
 
-import { MetricAccordionItem } from '@/components/Experiments/ScoringFormulaSidebar';
+import { MetricConfigForm } from '@/components/Experiments/ScoringFormulaSidebar';
 
 import type { MetricStats } from './metricStats';
 
@@ -56,18 +56,19 @@ export function MetricSubLabel({
 
 export function MetricColumnHeader({
   metric,
-  pointsLeft,
   onUpdateMetric,
   range,
 }: {
   metric: ExperimentScoringMetric;
-  pointsLeft: number;
   onUpdateMetric: (
     key: string,
     patch: Partial<ExperimentScoringMetric>,
   ) => void;
   range?: { min: number; max: number };
 }) {
+  const onUpdate = (patch: Partial<ExperimentScoringMetric>) =>
+    onUpdateMetric(metric.key, patch);
+
   return (
     <div className="flex w-full items-center gap-1">
       <span className="text-muted min-w-0 flex-1 truncate text-xs font-medium">
@@ -82,14 +83,8 @@ export function MetricColumnHeader({
             <RiSettings3Line className="h-3.5 w-3.5" />
           </button>
         </PopoverTrigger>
-        <PopoverContent align="start">
-          <MetricAccordionItem
-            metric={metric}
-            pointsLeft={pointsLeft}
-            range={range}
-            isPopover
-            onUpdate={(patch) => onUpdateMetric(metric.key, patch)}
-          />
+        <PopoverContent align="start" className="w-[340px] p-4">
+          <MetricConfigForm metric={metric} range={range} onUpdate={onUpdate} />
         </PopoverContent>
       </Popover>
     </div>

--- a/ui/apps/dashboard/src/lib/experiments/colors.test.ts
+++ b/ui/apps/dashboard/src/lib/experiments/colors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { colorForMetric, METRIC_PALETTE } from './colors';
+import { buildMetricColorMap, colorForMetric, METRIC_PALETTE } from './colors';
 
 describe('colorForMetric', () => {
   it('returns a palette color', () => {
@@ -20,5 +20,26 @@ describe('colorForMetric', () => {
 
   it('wraps around the palette', () => {
     expect(colorForMetric(METRIC_PALETTE.length)).toBe(colorForMetric(0));
+  });
+});
+
+describe('buildMetricColorMap', () => {
+  it('colors enabled metrics by their enabled-position, skipping disabled ones', () => {
+    const map = buildMetricColorMap([
+      { key: 'tokens', enabled: true },
+      { key: 'cost', enabled: false },
+      { key: 'accuracy', enabled: true },
+    ]);
+    // 'cost' is disabled, so 'accuracy' takes enabled-index 1 (matching the
+    // Score Summary chart, which only renders enabled segments).
+    expect(map.tokens).toBe(colorForMetric(0));
+    expect(map.accuracy).toBe(colorForMetric(1));
+    expect(map.cost).toBeUndefined();
+  });
+
+  it('returns an empty map when nothing is enabled', () => {
+    expect(buildMetricColorMap([{ key: 'tokens', enabled: false }])).toEqual(
+      {},
+    );
   });
 });

--- a/ui/apps/dashboard/src/lib/experiments/colors.ts
+++ b/ui/apps/dashboard/src/lib/experiments/colors.ts
@@ -5,9 +5,9 @@
  */
 export const METRIC_PALETTE = [
   'rgb(var(--color-primary-moderate))',
+  'rgb(var(--color-secondary-xSubtle))',
+  'rgb(var(--color-accent-subtle))',
   'rgb(var(--color-quaternary-cool-moderate))',
-  'rgb(var(--color-secondary-moderate))',
-  'rgb(var(--color-accent-moderate))',
   'rgb(var(--color-tertiary-moderate))',
   'rgb(var(--color-quaternary-warmer-moderate))',
 ] as const;
@@ -35,4 +35,25 @@ export function colorForVariant(index: number): string {
 
 export function subtleColorForVariant(index: number): string {
   return METRIC_PALETTE_SUBTLE[index % METRIC_PALETTE_SUBTLE.length];
+}
+
+type MetricLike = { key: string; enabled: boolean };
+
+/**
+ * Maps each enabled metric's key to its chart color. Colors are assigned by
+ * position among *enabled* metrics (not the full list) so the result lines up
+ * exactly with the Score Summary chart, which colors its stacked segments the
+ * same way. Disabled metrics are omitted (callers fall back to a neutral tone).
+ */
+export function buildMetricColorMap(
+  metrics: MetricLike[],
+): Record<string, string> {
+  const map: Record<string, string> = {};
+  let enabledIndex = 0;
+  for (const metric of metrics) {
+    if (!metric.enabled) continue;
+    map[metric.key] = colorForMetric(enabledIndex);
+    enabledIndex += 1;
+  }
+  return map;
 }

--- a/ui/packages/components/package.json
+++ b/ui/packages/components/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-popover": "^1.0.7",
     "@radix-ui/react-portal": "^1.1.6",
     "@radix-ui/react-progress": "^1.1.0",
+    "@radix-ui/react-slider": "^1.2.0",
     "@radix-ui/react-switch": "^1.0.3",
     "@radix-ui/react-tabs": "^1.0.4",
     "@radix-ui/react-toggle-group": "^1.0.4",

--- a/ui/packages/components/src/Slider/Slider.tsx
+++ b/ui/packages/components/src/Slider/Slider.tsx
@@ -1,0 +1,45 @@
+import { forwardRef } from 'react';
+import * as SliderPrimitive from '@radix-ui/react-slider';
+
+import { cn } from '../utils/classNames';
+
+export const Slider = forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
+    // Tints the filled range and the thumb border. Falls back to a neutral
+    // contrast tone when omitted. Threaded through a CSS var so it overrides the
+    // base class reliably (a second bg-*/border-* class would race on source
+    // order).
+    color?: string;
+  }
+>(({ className, color, style, ...props }, forwardedRef) => {
+  return (
+    <SliderPrimitive.Root
+      {...props}
+      ref={forwardedRef}
+      style={color ? ({ ...style, '--slider-color': color } as React.CSSProperties) : style}
+      className={cn(
+        'relative flex w-full touch-none select-none items-center',
+        props.disabled && 'pointer-events-none opacity-50',
+        className
+      )}
+    >
+      <SliderPrimitive.Track className="bg-surfaceMuted relative h-1 w-full grow overflow-hidden rounded-full">
+        <SliderPrimitive.Range
+          className={cn(
+            'absolute h-full rounded-full',
+            color ? 'bg-[var(--slider-color)]' : 'bg-contrast'
+          )}
+        />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        className={cn(
+          'bg-canvasBase block h-3.5 w-3.5 rounded-full border-2 shadow-sm outline-none transition-colors',
+          color ? 'border-[var(--slider-color)]' : 'border-contrast'
+        )}
+      />
+    </SliderPrimitive.Root>
+  );
+});
+
+Slider.displayName = 'Slider';

--- a/ui/packages/components/src/Slider/index.ts
+++ b/ui/packages/components/src/Slider/index.ts
@@ -1,0 +1,1 @@
+export { Slider } from './Slider';

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -790,6 +790,9 @@ importers:
       '@radix-ui/react-progress':
         specifier: ^1.1.0
         version: 1.1.0(@types/react-dom@19.2.2(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slider':
+        specifier: ^1.2.0
+        version: 1.4.1(@types/react-dom@19.2.2(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@radix-ui/react-switch':
         specifier: ^1.0.3
         version: 1.0.3(@types/react-dom@19.2.2(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -4686,6 +4689,9 @@ packages:
   '@radix-ui/number@1.0.1':
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
 
+  '@radix-ui/number@1.1.2':
+    resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
+
   '@radix-ui/primitive@1.0.1':
     resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
 
@@ -4697,6 +4703,9 @@ packages:
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/primitive@1.1.4':
+    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
 
   '@radix-ui/react-accordion@1.1.2':
     resolution: {integrity: sha512-fDG7jcoNKVjSK6yfmuAs0EnPDro0WMXIhMtXdTBWqEioVW206ku+4Lw07e+13lUkFkpoEQ2PdeMIAGpdqEAmDg==}
@@ -4789,6 +4798,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.10':
+    resolution: {integrity: sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
@@ -4838,6 +4860,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-context@1.0.1':
     resolution: {integrity: sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==}
     peerDependencies:
@@ -4867,6 +4898,15 @@ packages:
 
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -4920,6 +4960,15 @@ packages:
 
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.2':
+    resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -5271,6 +5320,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.6':
+    resolution: {integrity: sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-progress@1.1.0':
     resolution: {integrity: sha512-aSzvnYpP725CROcxAOEBVZZSIQVQdHgBr2QQFKySsaD14u8dNT0batuXI+AAGDdAHfXH8rbnHmjYFqVJ21KkRg==}
     peerDependencies:
@@ -5336,6 +5398,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-slider@1.4.1':
+    resolution: {integrity: sha512-r91WSpQucNGFKAIxT8FT0H0zyjd5tJlqObLp7LOMV4z49KoDCwjy01w3vDOU4e1wxhF9IgjYco7SB6byOW7Buw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.0.2':
     resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
     peerDependencies:
@@ -5374,6 +5449,15 @@ packages:
 
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -5526,8 +5610,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -5580,11 +5682,29 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-previous@1.0.1':
     resolution: {integrity: sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.2':
+    resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5603,6 +5723,15 @@ packages:
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.2':
+    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -18443,6 +18572,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.0
 
+  '@radix-ui/number@1.1.2': {}
+
   '@radix-ui/primitive@1.0.1':
     dependencies:
       '@babel/runtime': 7.27.0
@@ -18452,6 +18583,8 @@ snapshots:
   '@radix-ui/primitive@1.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/primitive@1.1.4': {}
 
   '@radix-ui/react-accordion@1.1.2(@types/react-dom@19.2.2(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -18578,6 +18711,18 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 19.2.2(@types/react@18.3.28)
 
+  '@radix-ui/react-collection@1.1.10(@types/react-dom@19.2.2(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.2(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-slot': 1.3.0(@types/react@18.3.28)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.2.2(@types/react@18.3.28)
+
   '@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.2.0)
@@ -18615,6 +18760,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@18.3.28)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.28
+
   '@radix-ui/react-context@1.0.1(@types/react@18.3.28)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.27.0
@@ -18635,6 +18786,12 @@ snapshots:
       '@types/react': 18.3.28
 
   '@radix-ui/react-context@1.1.2(@types/react@18.3.28)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-context@1.1.4(@types/react@18.3.28)(react@18.2.0)':
     dependencies:
       react: 18.2.0
     optionalDependencies:
@@ -18699,6 +18856,12 @@ snapshots:
       '@types/react': 18.3.28
 
   '@radix-ui/react-direction@1.1.1(@types/react@18.3.28)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-direction@1.1.2(@types/react@18.3.28)(react@18.2.0)':
     dependencies:
       react: 18.2.0
     optionalDependencies:
@@ -19098,6 +19261,15 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-primitive@2.1.6(@types/react-dom@19.2.2(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@18.3.28)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.2.2(@types/react@18.3.28)
+
   '@radix-ui/react-progress@1.1.0(@types/react-dom@19.2.2(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@radix-ui/react-context': 1.1.0(@types/react@18.3.28)(react@18.2.0)
@@ -19190,6 +19362,25 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-slider@1.4.1(@types/react-dom@19.2.2(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.2(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.2.0)
+      '@radix-ui/react-context': 1.1.4(@types/react@18.3.28)(react@18.2.0)
+      '@radix-ui/react-direction': 1.1.2(@types/react@18.3.28)(react@18.2.0)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.2(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@18.3.28)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.2.0)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@18.3.28)(react@18.2.0)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@18.3.28)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 19.2.2(@types/react@18.3.28)
+
   '@radix-ui/react-slot@1.0.2(@types/react@18.3.28)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.27.0
@@ -19222,6 +19413,13 @@ snapshots:
   '@radix-ui/react-slot@1.2.3(@types/react@18.3.28)(react@18.2.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-slot@1.3.0(@types/react@18.3.28)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.28)(react@18.2.0)
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.3.28
@@ -19374,9 +19572,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@18.3.28)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@18.3.28)(react@18.2.0)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.28
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.28)(react@18.2.0)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.28)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@18.3.28)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.2.0)
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.3.28
@@ -19415,9 +19628,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@18.3.28)(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.28
+
   '@radix-ui/react-use-previous@1.0.1(@types/react@18.3.28)(react@18.2.0)':
     dependencies:
       '@babel/runtime': 7.27.0
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-previous@1.1.2(@types/react@18.3.28)(react@18.2.0)':
+    dependencies:
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.3.28
@@ -19434,6 +19659,13 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.0
       '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.28)(react@18.2.0)
+      react: 18.2.0
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-use-size@1.1.2(@types/react@18.3.28)(react@18.2.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.28)(react@18.2.0)
       react: 18.2.0
     optionalDependencies:
       '@types/react': 18.3.28


### PR DESCRIPTION
## Description

Redesigns the experiment "Scoring formula" panel on the experiment detail page.

- Replaces the per-metric `+/-` point stepper with a **slider + numeric text box**, and removes the accordion — advanced config (name, min/max, invert, performance labels) now opens in a **popover** anchored below the row via an edit (pencil) button.
- Adds a **weight-distribution bar + percentage key** at the top of the panel so relative weighting is visible at a glance.
- Each metric's toggle, slider, and distribution segment are colored to match its segment in the Score Summary chart. Colors are derived by enabled-position via a new `buildMetricColorMap` helper so the sidebar, table, and chart stay in sync.
- Moves from a fixed 100-point budget to **independent 0–100 weights** with normalized percentages; removes the now-dead `pointsLeft` plumbing. Rankings are unaffected since weights are relative.

New shared `Slider` primitive added to `@inngest/components` (built on `@radix-ui/react-slider`).

<img width="1723" height="945" alt="Screenshot 2026-06-22 at 23 32 10" src="https://github.com/user-attachments/assets/29498e9d-5518-4712-8955-d88feca7a3a5" />


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
