### PR TITLE
feat(experiments): Reduce the default experiments timerange to 7 days

### DIFF
--- a/ui/apps/dashboard/src/components/Experiments/ExperimentDetailPage.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/ExperimentDetailPage.tsx
@@ -59,9 +59,11 @@ const INFO_PANEL = 'Info';
 const SCORING_PANEL = 'Scoring formula';
 type PanelKey = typeof INFO_PANEL | typeof SCORING_PANEL;
 
-// TimeFilter's longest preset is "Last 30 days". Don't default the range
-// past that even if the account's history retention is longer.
-const MAX_DEFAULT_DAYS = 30;
+// TimeFilter's longest preset is "Last 30 days", but we want to default
+// to 7 days to improve initial page load time.
+// Don't default the range past that even if the account's
+// history retention is longer.
+const MAX_DEFAULT_DAYS = 7;
 
 function rangeToTimeRange(range: RangeChangeProps): ExperimentTimeRange {
   if (range.type === 'absolute') return { from: range.start, to: range.end };


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This changes the default time range for the experiments detail page from 30 days to 7 days to improve initial page load time

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
