### PR TITLE
feat(conformance): add JUnit report renderer

### DIFF
--- a/cmd/conformance/common.go
+++ b/cmd/conformance/common.go
@@ -5,8 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/inngest/inngest/pkg/cli/output"
+	clioutput "github.com/inngest/inngest/pkg/cli/output"
 	conf "github.com/inngest/inngest/pkg/conformance"
+	confoutput "github.com/inngest/inngest/pkg/conformance/output"
 	"github.com/inngest/inngest/pkg/conformance/runner/serve"
 	"github.com/urfave/cli/v3"
 )
@@ -154,7 +155,9 @@ func newServeRunner() *serve.Runner {
 	return serve.NewRunner(nil)
 }
 
-// renderReport prints a report using the Phase 2 terminal renderers.
+// renderReport prints a report using the selected output format.
+// JSON is the canonical machine-readable artifact; pretty is for local triage;
+// junit is for CI integration (GitHub Actions, Jenkins, etc.).
 func renderReport(report conf.Report, format conf.ReportFormat, forceJSON bool) error {
 	if forceJSON || format == conf.ReportFormatJSON {
 		byt, err := json.MarshalIndent(report, "", "  ")
@@ -167,9 +170,21 @@ func renderReport(report conf.Report, format conf.ReportFormat, forceJSON bool) 
 
 	switch format {
 	case "", conf.ReportFormatPretty:
-		return output.TextConformanceReport(report)
-	case conf.ReportFormatJUnit, conf.ReportFormatMarkdown:
+		return clioutput.TextConformanceReport(report)
+
+	case conf.ReportFormatJUnit:
+		// RenderJUnit lives in pkg/conformance/output to keep the CLI thin and
+		// allow unit tests without spinning up the full command tree.
+		byt, err := confoutput.RenderJUnit(report)
+		if err != nil {
+			return err
+		}
+		fmt.Print(string(byt))
+		return nil
+
+	case conf.ReportFormatMarkdown:
 		return fmt.Errorf("report format %q is not implemented yet", format)
+
 	default:
 		return fmt.Errorf("unknown report format %q", format)
 	}
@@ -185,7 +200,7 @@ func renderDoctor(checks []serve.Check, forceJSON bool) error {
 		return nil
 	}
 
-	return output.TextConformanceDoctor(checks)
+	return clioutput.TextConformanceDoctor(checks)
 }
 
 func runServe(ctx context.Context, plan conf.RunPlan, runtime conf.RuntimeConfig) (conf.Report, error) {

--- a/pkg/conformance/output/junit.go
+++ b/pkg/conformance/output/junit.go
@@ -1,0 +1,220 @@
+package output
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"sort"
+
+	"github.com/inngest/inngest/pkg/conformance"
+)
+
+// RenderJUnit converts a conformance Report into JUnit XML suitable for CI systems
+// such as GitHub Actions, GitLab CI, and Jenkins.
+//
+// Design goals for v1:
+//   - One <testsuite> per conformance suite_id (e.g. "core", "negative").
+//   - One <testcase> per conformance case_id.
+//   - Map conformance statuses to JUnit elements in a CI-friendly way:
+//     passed          -> plain <testcase>
+//     failed          -> <failure>   (should fail the pipeline)
+//     not_evaluable   -> <error>     (environment/setup problem)
+//     not_implemented -> <skipped>   (SDK gap, not a regression)
+//     skipped         -> <skipped>
+//
+// Feature-level rollups from report.Features are intentionally omitted in v1.
+// CI tools operate on testcases; features remain in the JSON artifact.
+func RenderJUnit(report conformance.Report) ([]byte, error) {
+	root := junitTestsuites{
+		Name: "inngest-conformance",
+	}
+
+	// Group cases by suite so CI output mirrors the conformance suite layout.
+	suiteCases := groupCasesBySuite(report.Cases)
+
+	// Stable ordering makes output deterministic across runs and platforms.
+	suiteIDs := sortedKeys(suiteCases)
+
+	for _, suiteID := range suiteIDs {
+		cases := suiteCases[suiteID]
+		suite := buildTestsuite(suiteID, report.Transport, cases)
+		root.addSuite(suite)
+	}
+
+	var buf bytes.Buffer
+
+	// XML declaration is required by many CI parsers even though encoding/xml
+	// does not emit it automatically.
+	buf.WriteString(xml.Header)
+
+	enc := xml.NewEncoder(&buf)
+	enc.Indent("", "  ")
+	if err := enc.Encode(root); err != nil {
+		return nil, fmt.Errorf("encode junit xml: %w", err)
+	}
+	if err := enc.Flush(); err != nil {
+		return nil, fmt.Errorf("flush junit xml: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+// --- XML model (kept local to avoid coupling to vendor junit helpers) ---
+
+type junitTestsuites struct {
+	XMLName  xml.Name         `xml:"testsuites"`
+	Name     string           `xml:"name,attr"`
+	Tests    int              `xml:"tests,attr"`
+	Failures int              `xml:"failures,attr"`
+	Errors   int              `xml:"errors,attr"`
+	Skipped  int              `xml:"skipped,attr"`
+	Suites   []junitTestsuite `xml:"testsuite"`
+}
+
+func (t *junitTestsuites) addSuite(s junitTestsuite) {
+	t.Suites = append(t.Suites, s)
+	t.Tests += s.Tests
+	t.Failures += s.Failures
+	t.Errors += s.Errors
+	t.Skipped += s.Skipped
+}
+
+type junitTestsuite struct {
+	XMLName  xml.Name        `xml:"testsuite"`
+	Name     string          `xml:"name,attr"`
+	Tests    int             `xml:"tests,attr"`
+	Failures int             `xml:"failures,attr"`
+	Errors   int             `xml:"errors,attr"`
+	Skipped  int             `xml:"skipped,attr"`
+	Cases    []junitTestcase `xml:"testcase"`
+}
+
+type junitTestcase struct {
+	XMLName   xml.Name      `xml:"testcase"`
+	Classname string        `xml:"classname,attr"`
+	Name      string        `xml:"name,attr"`
+	Failure   *junitFailure `xml:"failure,omitempty"`
+	Error     *junitError   `xml:"error,omitempty"`
+	Skipped   *junitSkipped `xml:"skipped,omitempty"`
+}
+
+type junitFailure struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr,omitempty"`
+	Body    string `xml:",chardata"`
+}
+
+type junitError struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr,omitempty"`
+	Body    string `xml:",chardata"`
+}
+
+type junitSkipped struct {
+	Message string `xml:"message,attr,omitempty"`
+}
+
+// buildTestsuite materializes one JUnit testsuite from all cases in a conformance suite.
+func buildTestsuite(suiteID string, transport conformance.Transport, cases []conformance.CaseResult) junitTestsuite {
+	suite := junitTestsuite{
+		Name: suiteID,
+	}
+
+	// Sort cases by ID for stable XML ordering (matches pretty printer behavior).
+	sort.Slice(cases, func(i, j int) bool {
+		return cases[i].CaseID < cases[j].CaseID
+	})
+
+	for _, result := range cases {
+		tc := junitTestcase{
+			// Classname gives CI UIs a hierarchical name: inngest.conformance.<suite>.<transport>
+			Classname: junitClassname(suiteID, transport),
+			Name:      result.CaseID,
+		}
+
+		switch result.Status {
+		case conformance.CaseStatusPassed:
+			// No child element: JUnit interprets this as a passing test.
+
+		case conformance.CaseStatusFailed:
+			suite.Failures++
+			tc.Failure = &junitFailure{
+				Message: junitMessage(result),
+				Type:    string(result.ReasonCode),
+				Body:    result.Reason,
+			}
+
+		case conformance.CaseStatusNotEvaluable:
+			// Treat transport/setup failures as <error> so CI alerts infra problems.
+			suite.Errors++
+			tc.Error = &junitError{
+				Message: junitMessage(result),
+				Type:    string(result.ReasonCode),
+				Body:    result.Reason,
+			}
+
+		case conformance.CaseStatusNotImplemented, conformance.CaseStatusSkipped:
+			// Missing SDK support is not a regression; mark as skipped.
+			suite.Skipped++
+			tc.Skipped = &junitSkipped{
+				Message: junitMessage(result),
+			}
+
+		default:
+			// Unknown future status: fail safe as error so CI does not silently pass.
+			suite.Errors++
+			tc.Error = &junitError{
+				Message: fmt.Sprintf("unknown case status %q", result.Status),
+				Type:    "unknown_status",
+			}
+		}
+
+		suite.Cases = append(suite.Cases, tc)
+		suite.Tests++
+	}
+
+	return suite
+}
+
+// junitClassname builds a stable, dot-separated classname for CI dashboards.
+func junitClassname(suiteID string, transport conformance.Transport) string {
+	if transport == "" {
+		return "inngest.conformance." + suiteID
+	}
+	return fmt.Sprintf("inngest.conformance.%s.%s", suiteID, transport)
+}
+
+// junitMessage prefers the human reason, then falls back to the machine reason code.
+func junitMessage(result conformance.CaseResult) string {
+	if result.Reason != "" {
+		return result.Reason
+	}
+	if result.ReasonCode != "" {
+		return string(result.ReasonCode)
+	}
+	return string(result.Status)
+}
+
+// groupCasesBySuite indexes case results by their suite_id field.
+func groupCasesBySuite(cases []conformance.CaseResult) map[string][]conformance.CaseResult {
+	out := make(map[string][]conformance.CaseResult, len(cases))
+	for _, result := range cases {
+		suiteID := result.SuiteID
+		if suiteID == "" {
+			// Fallback bucket for malformed reports; should not happen in practice.
+			suiteID = "unknown"
+		}
+		out[suiteID] = append(out[suiteID], result)
+	}
+	return out
+}
+
+// sortedKeys returns map keys in lexicographic order.
+func sortedKeys[V any](m map[string][]V) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/conformance/output/junit_test.go
+++ b/pkg/conformance/output/junit_test.go
@@ -1,0 +1,132 @@
+package output
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/conformance"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRenderJUnit_MapsStatuses verifies the conformance-to-JUnit status mapping
+// that CI pipelines rely on: failures and errors should be countable separately
+// from skipped (not-implemented) cases.
+func TestRenderJUnit_MapsStatuses(t *testing.T) {
+	t.Parallel()
+
+	report := conformance.Report{
+		SchemaVersion: conformance.ReportSchemaVersion,
+		Transport:     conformance.TransportServe,
+		Compatibility: conformance.CompatibilityPartial,
+		Cases: []conformance.CaseResult{
+			{
+				CaseID:  "basic-invoke",
+				SuiteID: "core",
+				Status:  conformance.CaseStatusPassed,
+			},
+			{
+				CaseID:     "retry-basic",
+				SuiteID:    "core",
+				Status:     conformance.CaseStatusNotImplemented,
+				ReasonCode: conformance.ReasonCodeNotImplemented,
+				Reason:     "no Phase 2 serve executor is defined for this case",
+			},
+			{
+				CaseID:     "steps-serial",
+				SuiteID:    "core",
+				Status:     conformance.CaseStatusFailed,
+				ReasonCode: conformance.ReasonCodeBehaviorMismatch,
+				Reason:     "unexpected generator response",
+			},
+			{
+				CaseID:     "malformed-payload",
+				SuiteID:    "negative",
+				Status:     conformance.CaseStatusNotEvaluable,
+				ReasonCode: conformance.ReasonCodeTransportSetup,
+				Reason:     "sdk.url is required",
+			},
+		},
+	}
+
+	byt, err := RenderJUnit(report)
+	require.NoError(t, err)
+	require.Contains(t, string(byt), `<?xml version="1.0" encoding="UTF-8"?>`)
+
+	// Round-trip through xml.Unmarshal to ensure the output is well-formed XML.
+	var parsed junitTestsuites
+	require.NoError(t, xml.Unmarshal(byt, &parsed))
+
+	require.Equal(t, "inngest-conformance", parsed.Name)
+	require.Equal(t, 4, parsed.Tests)
+	require.Equal(t, 1, parsed.Failures)
+	require.Equal(t, 1, parsed.Errors)
+	require.Equal(t, 1, parsed.Skipped)
+	require.Len(t, parsed.Suites, 2)
+
+	// Locate the "core" suite and inspect individual testcases.
+	var coreSuite *junitTestsuite
+	for i := range parsed.Suites {
+		if parsed.Suites[i].Name == "core" {
+			coreSuite = &parsed.Suites[i]
+			break
+		}
+	}
+	require.NotNil(t, coreSuite)
+	require.Equal(t, 3, coreSuite.Tests)
+	require.Equal(t, 1, coreSuite.Failures)
+	require.Equal(t, 1, coreSuite.Skipped)
+
+	byName := map[string]junitTestcase{}
+	for _, tc := range coreSuite.Cases {
+		byName[tc.Name] = tc
+	}
+
+	require.Nil(t, byName["basic-invoke"].Failure)
+	require.Nil(t, byName["basic-invoke"].Skipped)
+
+	require.NotNil(t, byName["retry-basic"].Skipped)
+	require.Contains(t, byName["retry-basic"].Skipped.Message, "no Phase 2 serve executor")
+
+	require.NotNil(t, byName["steps-serial"].Failure)
+	require.Equal(t, "behavior_mismatch", byName["steps-serial"].Failure.Type)
+	require.Equal(t, "unexpected generator response", byName["steps-serial"].Failure.Body)
+}
+
+// TestRenderJUnit_EmptyReport ensures an empty report still produces valid XML.
+// Useful when a suite selection resolves to zero cases (edge case / future guard).
+func TestRenderJUnit_EmptyReport(t *testing.T) {
+	t.Parallel()
+
+	byt, err := RenderJUnit(conformance.Report{
+		SchemaVersion: conformance.ReportSchemaVersion,
+	})
+	require.NoError(t, err)
+
+	var parsed junitTestsuites
+	require.NoError(t, xml.Unmarshal(byt, &parsed))
+	require.Equal(t, 0, parsed.Tests)
+	require.Empty(t, parsed.Suites)
+}
+
+// TestRenderJUnit_DeterministicOrdering verifies that repeated renders produce
+// identical output. CI diff tools and golden snapshots depend on this property.
+func TestRenderJUnit_DeterministicOrdering(t *testing.T) {
+	t.Parallel()
+
+	report := conformance.Report{
+		SchemaVersion: conformance.ReportSchemaVersion,
+		Cases: []conformance.CaseResult{
+			{CaseID: "z-case", SuiteID: "core", Status: conformance.CaseStatusPassed},
+			{CaseID: "a-case", SuiteID: "core", Status: conformance.CaseStatusPassed},
+			{CaseID: "b-case", SuiteID: "alpha", Status: conformance.CaseStatusPassed},
+		},
+	}
+
+	first, err := RenderJUnit(report)
+	require.NoError(t, err)
+
+	second, err := RenderJUnit(report)
+	require.NoError(t, err)
+
+	require.Equal(t, string(first), string(second))
+}


### PR DESCRIPTION
## Description

The conformance runner already produces a stable JSON report (`report.json`) and
documents JUnit as a supported `--report-format`, but the CLI returned
`report format "junit" is not implemented yet` when that format was requested.

This PR adds `pkg/conformance/output.RenderJUnit`, which converts conformance
case results into JUnit XML so SDK repositories can plug `inngest conformance`
into standard CI pipelines (GitHub Actions, Jenkins, GitLab) without writing a
custom JSON parser.

### Where this came from

- **Plan 002 — CLI Conformance Runner** (`docs/plans/002-cli-conformance-runner.org`):
  Phase 4 explicitly calls for JUnit and Markdown output renderers for CI
  ergonomics. Phase 2 already emits JSON + pretty terminal output; JUnit was
  the next missing piece for adoption in external SDK repos.
- **Existing CLI surface** (`cmd/conformance/common.go`): `--report-format`
  already accepts `junit`, and `conformance report` is wired to `renderReport`,
  but the switch case was a stub.
- **Report model** (`pkg/conformance/report.go`, `pkg/conformance/types.go`):
  case statuses (`passed`, `failed`, `not_implemented`, `not_evaluable`,
  `skipped`) and reason codes are already defined — the renderer only maps
  them to JUnit elements.

### Why JUnit first (and not a new conformance case)

Conformance measures SDK protocol compatibility; JUnit solves a **CI
integration** problem: CI systems consume JUnit XML natively. This change is
isolated, fully unit-testable, and unblocks SDK maintainers without touching
execution, queue, or SDK protocol logic.

### Status mapping

| Conformance status   | JUnit element | CI intent                          |
|----------------------|---------------|------------------------------------|
| `passed`             | (none)        | Green                              |
| `failed`             | `<failure>`   | Fail pipeline (behavior regression)|
| `not_evaluable`      | `<error>`     | Fail pipeline (setup/infra issue)  |
| `not_implemented`    | `<skipped>`   | Do not fail (SDK gap, not regression)|
| `skipped`            | `<skipped>`   | Do not fail                        |

Feature-level rollups remain in the JSON artifact only (v1 scope).

### Changes

- `pkg/conformance/output/junit.go` — JUnit XML renderer
- `pkg/conformance/output/junit_test.go` — status mapping, empty report, deterministic ordering
- `cmd/conformance/common.go` — wire `confoutput.RenderJUnit` into `renderReport`

Note: `conformance` is currently exposed under `inngest alpha conformance`
(`cmd/alpha.go`).

## Release note

`inngest alpha conformance report` and `conformance run --report-format junit`
now emit JUnit XML suitable for CI consumption.

## Migration note

None

## Test plan

- [x] `go test ./pkg/conformance/output/... -v -count=1`
- [x] `go build ./cmd/...`
- [x] Manual smoke test:

  ```bash
  go run ./cmd alpha conformance report \
    --path /tmp/report.json \
    --report-format junit