### PR TITLE
feat(constraintapi):  apply new constraint to semaphores

### DIFF
--- a/pkg/constraintapi/SEMAPHORES.md
+++ b/pkg/constraintapi/SEMAPHORES.md
@@ -9,6 +9,7 @@ capacity checks.  They power worker concurrency and function concurrency.
 Semaphore names are always prefixed to avoid collisions:
 
 - `app:<uuid>` — worker concurrency (one per app, capacity managed by connect lifecycle)
+- `acct:<uuid>` — account-scoped concurrency
 - `fn:<uuid>` — function concurrency (one per function)
 - `hash:<xxhash>` — user-defined names (xxhash of user string)
 

--- a/pkg/constraintapi/acquire.go
+++ b/pkg/constraintapi/acquire.go
@@ -162,23 +162,35 @@ type acquireScriptResponse struct {
 		LeaseID             ulid.ULID `json:"lid"`
 		LeaseIdempotencyKey string    `json:"lik"`
 	} `json:"l"`
-	LimitingConstraints  flexibleIntArray          `json:"lc"`
-	ExhaustedConstraints flexibleIntArray          `json:"ec"`
-	FairnessReduction    int                       `json:"fr"`
-	RetryAt              int                       `json:"ra"`
-	Debug                flexibleStringArray       `json:"d"`
-	CacheHit             int                       `json:"ch"`
+	LimitingConstraints  flexibleIntArray    `json:"lc"`
+	ExhaustedConstraints flexibleIntArray    `json:"ec"`
+	FairnessReduction    int                 `json:"fr"`
+	RetryAt              int                 `json:"ra"`
+	Debug                flexibleStringArray `json:"d"`
+	CacheHit             int                 `json:"ch"`
 }
 
 func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquireRequest) (*CapacityAcquireResponse, errs.InternalError) {
 	l := logger.StdlibLogger(ctx)
+	originalReq := req
 
 	requestID, err := ulid.New(ulid.Timestamp(r.clock.Now()), rand.Reader)
 	if err != nil {
 		return nil, errs.Wrap(0, false, "could not generate request ID: %w", err)
 	}
 
-	// Validate request
+	req = r.filterDisabledAccountSemaphoreAcquireRequest(ctx, req)
+	if len(req.Constraints) == 0 {
+		if err := originalReq.Valid(); err != nil {
+			return nil, errs.Wrap(0, false, "invalid request: %w", err)
+		}
+		// the only requested constraint was a filtered acct semaphore so this is ok
+		return &CapacityAcquireResponse{
+			RequestID: requestID,
+		}, nil
+	}
+
+	// validate after filtering so disabled acct semaphores are ignored
 	if err := req.Valid(); err != nil {
 		return nil, errs.Wrap(0, false, "invalid request: %w", err)
 	}
@@ -544,4 +556,16 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 	default:
 		return nil, errs.Wrap(0, false, "unexpected status code %v", parsedResponse.Status)
 	}
+}
+
+func (r *redisCapacityManager) filterDisabledAccountSemaphoreAcquireRequest(ctx context.Context, req *CapacityAcquireRequest) *CapacityAcquireRequest {
+	filteredConstraints, filteredConfig, changed := filterDisabledAccountSemaphoreRequest(ctx, req.AccountID, req.Constraints, req.Configuration)
+	if !changed {
+		return req
+	}
+
+	filteredReq := *req
+	filteredReq.Constraints = filteredConstraints
+	filteredReq.Configuration = filteredConfig
+	return &filteredReq
 }

--- a/pkg/constraintapi/acquire.go
+++ b/pkg/constraintapi/acquire.go
@@ -432,6 +432,9 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 				EnvID:                req.EnvID,
 				AppID:                req.AppID,
 				FunctionID:           req.FunctionID,
+				Status:               parsedResponse.Status,
+				CacheEnabled:         cacheEnabled,
+				CacheHit:             parsedResponse.CacheHit != 0,
 				Configuration:        req.Configuration,
 				Constraints:          req.Constraints,
 				LimitingConstraints:  limitingConstraints,
@@ -439,9 +442,12 @@ func (r *redisCapacityManager) Acquire(ctx context.Context, req *CapacityAcquire
 				FairnessReduction:    parsedResponse.FairnessReduction,
 				RetryAfter:           retryAfter,
 				RequestedAmount:      req.Amount,
+				GrantedAmount:        parsedResponse.Granted,
 				Duration:             req.Duration,
 				Source:               req.Source,
+				RequestAttempt:       req.RequestAttempt,
 				GrantedLeases:        leases,
+				Debug:                []string(parsedResponse.Debug),
 			})
 			if err != nil {
 				return nil, errs.Wrap(0, false, "acquire lifecycle failed: %w", err)

--- a/pkg/constraintapi/check.go
+++ b/pkg/constraintapi/check.go
@@ -93,8 +93,18 @@ type checkScriptResponse struct {
 // Check implements CapacityManager.
 func (r *redisCapacityManager) Check(ctx context.Context, req *CapacityCheckRequest) (*CapacityCheckResponse, errs.UserError, errs.InternalError) {
 	l := logger.StdlibLogger(ctx)
+	originalReq := req
 
-	// Validate request
+	req = r.filterDisabledAccountSemaphoreCheckRequest(ctx, req)
+	if len(req.Constraints) == 0 {
+		if err := originalReq.Valid(); err != nil {
+			return nil, nil, errs.Wrap(0, false, "invalid request: %w", err)
+		}
+		// the only requested constraint was a filtered acct semaphore so this is ok
+		return &CapacityCheckResponse{}, nil, nil
+	}
+
+	// validate after filtering so disabled acct semaphores are ignored
 	if err := req.Valid(); err != nil {
 		return nil, nil, errs.Wrap(0, false, "invalid request: %w", err)
 	}
@@ -212,4 +222,17 @@ func (r *redisCapacityManager) Check(ctx context.Context, req *CapacityCheckRequ
 	default:
 		return nil, nil, errs.Wrap(0, false, "unexpected status code %v", parsedResponse.Status)
 	}
+}
+
+func (r *redisCapacityManager) filterDisabledAccountSemaphoreCheckRequest(ctx context.Context, req *CapacityCheckRequest) *CapacityCheckRequest {
+	// Keep account semaphore rollout decisions centralized in constraintapi.
+	filteredConstraints, filteredConfig, changed := filterDisabledAccountSemaphoreRequest(ctx, req.AccountID, req.Constraints, req.Configuration)
+	if !changed {
+		return req
+	}
+
+	filteredReq := *req
+	filteredReq.Constraints = filteredConstraints
+	filteredReq.Configuration = filteredConfig
+	return &filteredReq
 }

--- a/pkg/constraintapi/config.go
+++ b/pkg/constraintapi/config.go
@@ -7,12 +7,13 @@ import "github.com/inngest/inngest/pkg/enums"
 type Semaphore struct {
 	// ID is the semaphore identifier, always prefixed:
 	//   app:<uuid>                — worker concurrency
+	//   acct:<uuid>               — account concurrency
 	//   fn:<uuid>                 — function concurrency (no key)
 	//   fnkey:<xxhash(fnID+expr)> — function concurrency with key expression
 	ID string `json:"id"`
 
 	// EvaluatedKeyHash is the xxhash of the evaluated expression result.
-	// Empty for keyless semaphores (app:, fn:).
+	// Empty for keyless semaphores (app:, acct:, fn:).
 	EvaluatedKeyHash string `json:"uv,omitempty"`
 
 	// Weight is the number of units to acquire (default 1).

--- a/pkg/constraintapi/constraints.go
+++ b/pkg/constraintapi/constraints.go
@@ -2,7 +2,6 @@ package constraintapi
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -217,10 +216,7 @@ func (ci ConstraintItem) IsFunctionLevelConstraint() bool {
 	case ConstraintKindConcurrency:
 		return ci.Concurrency != nil && ci.Concurrency.Scope == enums.ConcurrencyScopeFn
 	case ConstraintKindSemaphore:
-		// XXX: Revisit when we add scopes to semaphores.
-		// For now, app-scoped semaphores (worker concurrency) are not function-level;
-		// all others (fn:, hash:) are.
-		return ci.Semaphore != nil && !strings.HasPrefix(ci.Semaphore.ID, "app:")
+		return ci.Semaphore.IsFunctionScoped()
 	default:
 		return false
 	}

--- a/pkg/constraintapi/constraints_test.go
+++ b/pkg/constraintapi/constraints_test.go
@@ -1982,6 +1982,61 @@ func TestConstraintItem_IsFunctionLevelConstraint(t *testing.T) {
 			description: "concurrency with nil pointer should not be function-level",
 		},
 
+		// Semaphore Constraints
+		{
+			name: "semaphore account scope",
+			constraint: ConstraintItem{
+				Kind: ConstraintKindSemaphore,
+				Semaphore: &SemaphoreConstraint{
+					ID: SemaphoreIDAccount(uuid.New()),
+				},
+			},
+			expected:    false,
+			description: "account-scoped semaphore should not be function-level",
+		},
+		{
+			name: "semaphore function scope",
+			constraint: ConstraintItem{
+				Kind: ConstraintKindSemaphore,
+				Semaphore: &SemaphoreConstraint{
+					ID: SemaphoreIDFn(uuid.New()),
+				},
+			},
+			expected:    true,
+			description: "function-scoped semaphore should be function-level",
+		},
+		{
+			name: "semaphore function key scope",
+			constraint: ConstraintItem{
+				Kind: ConstraintKindSemaphore,
+				Semaphore: &SemaphoreConstraint{
+					ID: SemaphoreIDFnKey(uuid.New(), "event.data.user_id"),
+				},
+			},
+			expected:    true,
+			description: "function-keyed semaphore should be function-level",
+		},
+		{
+			name: "semaphore app scope",
+			constraint: ConstraintItem{
+				Kind: ConstraintKindSemaphore,
+				Semaphore: &SemaphoreConstraint{
+					ID: SemaphoreIDApp(uuid.New()),
+				},
+			},
+			expected:    false,
+			description: "app-scoped semaphore should not be function-level",
+		},
+		{
+			name: "semaphore constraint with nil pointer",
+			constraint: ConstraintItem{
+				Kind:      ConstraintKindSemaphore,
+				Semaphore: nil,
+			},
+			expected:    false,
+			description: "semaphore with nil pointer should not be function-level",
+		},
+
 		// Unknown/Default Cases
 		{
 			name: "unknown constraint kind",

--- a/pkg/constraintapi/lifecycle.go
+++ b/pkg/constraintapi/lifecycle.go
@@ -15,18 +15,25 @@ type OnCapacityLeaseAcquiredData struct {
 	AppID      uuid.UUID
 	FunctionID uuid.UUID
 
+	Status       int
+	CacheEnabled bool
+	CacheHit     bool
+
 	Configuration ConstraintConfig
 	Constraints   []ConstraintItem
 
 	RequestedAmount int
+	GrantedAmount   int
 	Duration        time.Duration
 	Source          LeaseSource
+	RequestAttempt  int
 
 	GrantedLeases        []CapacityLease
 	LimitingConstraints  []ConstraintItem
 	ExhaustedConstraints []ConstraintItem
 	FairnessReduction    int
 	RetryAfter           time.Time
+	Debug                []string
 }
 
 type OnCapacityLeaseExtendedData struct {

--- a/pkg/constraintapi/semaphore.go
+++ b/pkg/constraintapi/semaphore.go
@@ -2,6 +2,7 @@ package constraintapi
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/util"
@@ -11,7 +12,7 @@ type SemaphoreReleaseMode int
 
 const (
 	// SemaphoreReleaseAuto decrements the semaphore counter when the constraint lease is released.
-	// Used for worker concurrency where each step independently acquires and releases.
+	// Used for per-item worker and account concurrency.
 	SemaphoreReleaseAuto SemaphoreReleaseMode = 0
 
 	// SemaphoreReleaseManual requires explicit release via the SemaphoreManager API.
@@ -19,20 +20,33 @@ const (
 	SemaphoreReleaseManual SemaphoreReleaseMode = 1
 )
 
+const (
+	semaphorePrefixApp     = "app:"
+	semaphorePrefixAccount = "acct:"
+	semaphorePrefixFn      = "fn:"
+	semaphorePrefixFnKey   = "fnkey:"
+	semaphorePrefixHash    = "hash:"
+)
+
 // SemaphoreIDApp returns the semaphore ID for worker concurrency (per-app).
 func SemaphoreIDApp(appID uuid.UUID) string {
-	return fmt.Sprintf("app:%s", appID)
+	return fmt.Sprintf("%s%s", semaphorePrefixApp, appID)
+}
+
+// SemaphoreIDAccount returns the semaphore ID for account-scoped concurrency.
+func SemaphoreIDAccount(accountID uuid.UUID) string {
+	return fmt.Sprintf("%s%s", semaphorePrefixAccount, accountID)
 }
 
 // SemaphoreIDFn returns the semaphore ID for function concurrency (no key).
 func SemaphoreIDFn(functionID uuid.UUID) string {
-	return fmt.Sprintf("fn:%s", functionID)
+	return fmt.Sprintf("%s%s", semaphorePrefixFn, functionID)
 }
 
 // SemaphoreIDFnKey returns the semaphore ID for function concurrency with a key expression.
 // The ID is a hash of the function ID + the raw (unevaluated) expression.
 func SemaphoreIDFnKey(functionID uuid.UUID, expression string) string {
-	return fmt.Sprintf("fnkey:%s", util.XXHash(functionID.String()+expression))
+	return fmt.Sprintf("%s%s", semaphorePrefixFnKey, util.XXHash(functionID.String()+expression))
 }
 
 // SemaphoreConstraint represents a semaphore-based capacity constraint.
@@ -41,6 +55,7 @@ func SemaphoreIDFnKey(functionID uuid.UUID, expression string) string {
 type SemaphoreConstraint struct {
 	// ID is the unevaluated semaphore name, always prefixed:
 	//   app:<uuid>    — worker concurrency
+	//   acct:<uuid>   — account concurrency
 	//   fn:<uuid>     — function concurrency
 	//   fnkey:<xxhash(fnID + expression)> — hash of function ID & unevaluated expression
 	ID string
@@ -62,6 +77,33 @@ func (s *SemaphoreConstraint) UsageKey(accountID uuid.UUID) string {
 
 func (s *SemaphoreConstraint) CapacityKey(accountID uuid.UUID) string {
 	return fmt.Sprintf("{cs}:%s:sem:%s:cap", accountScope(accountID), s.ID)
+}
+
+func (s *SemaphoreConstraint) IsAccountConcurrency() bool {
+	return s != nil && isAccountConcurrencySemaphore(s.ID, s.EvaluatedKeyHash)
+}
+
+func (s *SemaphoreConstraint) IsFunctionConcurrency() bool {
+	return s != nil && isFunctionConcurrencySemaphore(s.ID, s.EvaluatedKeyHash)
+}
+
+func (s *SemaphoreConstraint) IsFunctionScoped() bool {
+	return s != nil &&
+		(strings.HasPrefix(s.ID, semaphorePrefixFn) ||
+			strings.HasPrefix(s.ID, semaphorePrefixFnKey) ||
+			strings.HasPrefix(s.ID, semaphorePrefixHash))
+}
+
+func (s Semaphore) IsAccountConcurrency() bool {
+	return isAccountConcurrencySemaphore(s.ID, s.EvaluatedKeyHash)
+}
+
+func isAccountConcurrencySemaphore(id, evaluatedKeyHash string) bool {
+	return evaluatedKeyHash == "" && strings.HasPrefix(id, semaphorePrefixAccount)
+}
+
+func isFunctionConcurrencySemaphore(id, evaluatedKeyHash string) bool {
+	return evaluatedKeyHash == "" && strings.HasPrefix(id, semaphorePrefixFn)
 }
 
 func (s *SemaphoreConstraint) PrettyString() string {

--- a/pkg/constraintapi/semaphore_flags.go
+++ b/pkg/constraintapi/semaphore_flags.go
@@ -1,0 +1,71 @@
+package constraintapi
+
+import (
+	"context"
+	"slices"
+
+	"github.com/google/uuid"
+)
+
+// UseAccountSemaphoreFn gates account-scoped semaphore concurrency for an account.
+type UseAccountSemaphoreFn func(ctx context.Context, accountID uuid.UUID) (enable bool)
+
+// AccountSemaphoreEnabled is the package-wide gate for account-scoped semaphore concurrency.
+// Nil means account semaphores are disabled.
+var AccountSemaphoreEnabled UseAccountSemaphoreFn
+
+// AccountSemaphoreConcurrencyEnabled returns whether account-scoped semaphore concurrency is enabled.
+func AccountSemaphoreConcurrencyEnabled(ctx context.Context, accountID uuid.UUID) bool {
+	return AccountSemaphoreEnabled != nil && AccountSemaphoreEnabled(ctx, accountID)
+}
+
+func FilterDisabledAccountSemaphores(
+	ctx context.Context,
+	accountID uuid.UUID,
+	semaphores []Semaphore,
+) []Semaphore {
+	// Account semaphores have their own rollout gate; all other semaphores stay active.
+	if AccountSemaphoreConcurrencyEnabled(ctx, accountID) {
+		return semaphores
+	}
+
+	return slices.DeleteFunc(slices.Clone(semaphores), Semaphore.IsAccountConcurrency)
+}
+
+func FilterDisabledAccountSemaphoreConstraints(
+	ctx context.Context,
+	accountID uuid.UUID,
+	constraints []ConstraintItem,
+) []ConstraintItem {
+	// Existing queue items may still carry acct: semaphores after the flag is disabled.
+	if AccountSemaphoreConcurrencyEnabled(ctx, accountID) {
+		return constraints
+	}
+
+	return slices.DeleteFunc(slices.Clone(constraints), func(constraint ConstraintItem) bool {
+		return constraint.Kind == ConstraintKindSemaphore && constraint.Semaphore.IsAccountConcurrency()
+	})
+}
+
+func FilterDisabledAccountSemaphoreConfig(
+	ctx context.Context,
+	accountID uuid.UUID,
+	config ConstraintConfig,
+) ConstraintConfig {
+	config.Semaphores = FilterDisabledAccountSemaphores(ctx, accountID, config.Semaphores)
+	return config
+}
+
+func filterDisabledAccountSemaphoreRequest(
+	ctx context.Context,
+	accountID uuid.UUID,
+	constraints []ConstraintItem,
+	config ConstraintConfig,
+) ([]ConstraintItem, ConstraintConfig, bool) {
+	filteredConstraints := FilterDisabledAccountSemaphoreConstraints(ctx, accountID, constraints)
+	filteredConfig := FilterDisabledAccountSemaphoreConfig(ctx, accountID, config)
+	changed := len(filteredConstraints) != len(constraints) ||
+		len(filteredConfig.Semaphores) != len(config.Semaphores)
+
+	return filteredConstraints, filteredConfig, changed
+}

--- a/pkg/constraintapi/semaphore_test.go
+++ b/pkg/constraintapi/semaphore_test.go
@@ -40,6 +40,123 @@ func newSemaphoreTestEnv(t *testing.T) (*redisCapacityManager, *miniredis.Minire
 	return cm, r, rc, clock
 }
 
+func setAccountSemaphoreEnabled(t *testing.T, fn UseAccountSemaphoreFn) {
+	t.Helper()
+	previous := AccountSemaphoreEnabled
+	AccountSemaphoreEnabled = fn
+	t.Cleanup(func() {
+		AccountSemaphoreEnabled = previous
+	})
+}
+
+func TestSemaphoreIDAccount(t *testing.T) {
+	accountID := uuid.New()
+	require.Equal(t, fmt.Sprintf("acct:%s", accountID), SemaphoreIDAccount(accountID))
+}
+
+func TestAccountSemaphoreAcquireFeatureFlag(t *testing.T) {
+	ctx := context.Background()
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+
+	sem := SemaphoreConstraint{
+		ID:      SemaphoreIDAccount(accountID),
+		Weight:  1,
+		Release: SemaphoreReleaseAuto,
+	}
+	config := ConstraintConfig{
+		FunctionVersion: 1,
+		Semaphores: []Semaphore{{
+			ID:      sem.ID,
+			Weight:  1,
+			Release: SemaphoreReleaseAuto,
+		}},
+	}
+	constraints := []ConstraintItem{{Kind: ConstraintKindSemaphore, Semaphore: &sem}}
+
+	t.Run("disabled filters account semaphore", func(t *testing.T) {
+		cm, r, _, clock := newSemaphoreTestEnv(t)
+		setAccountSemaphoreEnabled(t, func(context.Context, uuid.UUID) bool { return false })
+
+		resp, err := cm.Acquire(ctx, &CapacityAcquireRequest{
+			AccountID:            accountID,
+			IdempotencyKey:       "disabled",
+			Constraints:          constraints,
+			Amount:               1,
+			EnvID:                envID,
+			FunctionID:           fnID,
+			Configuration:        config,
+			LeaseIdempotencyKeys: []string{"disabled-lease"},
+			CurrentTime:          clock.Now(),
+			Duration:             5 * time.Second,
+			MaximumLifetime:      time.Hour,
+			Source: LeaseSource{
+				Service:           ServiceExecutor,
+				Location:          CallerLocationItemLease,
+				RunProcessingMode: RunProcessingModeBackground,
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, resp.Leases)
+		require.Empty(t, resp.ExhaustedConstraints)
+		require.False(t, r.Exists(sem.UsageKey(accountID)))
+	})
+
+	t.Run("enabled checks account semaphore", func(t *testing.T) {
+		cm, r, _, clock := newSemaphoreTestEnv(t)
+		setAccountSemaphoreEnabled(t, func(context.Context, uuid.UUID) bool { return true })
+		require.NoError(t, r.Set(sem.CapacityKey(accountID), "1"))
+
+		resp := acquireWithSemaphore(t, cm, clock, accountID, envID, fnID, config, constraints, "enabled-1")
+		require.Len(t, resp.Leases, 1)
+		usage, err := r.Get(sem.UsageKey(accountID))
+		require.NoError(t, err)
+		require.Equal(t, "1", usage)
+
+		clock.Advance(time.Second)
+		resp = acquireWithSemaphore(t, cm, clock, accountID, envID, fnID, config, constraints, "enabled-2")
+		require.Empty(t, resp.Leases)
+		require.Len(t, resp.ExhaustedConstraints, 1)
+		require.Equal(t, ConstraintKindSemaphore, resp.ExhaustedConstraints[0].Kind)
+	})
+}
+
+func TestAccountSemaphoreCheckFeatureFlag(t *testing.T) {
+	ctx := context.Background()
+	accountID, envID, fnID := uuid.New(), uuid.New(), uuid.New()
+
+	sem := SemaphoreConstraint{
+		ID:      SemaphoreIDAccount(accountID),
+		Weight:  1,
+		Release: SemaphoreReleaseAuto,
+	}
+	config := ConstraintConfig{
+		FunctionVersion: 1,
+		Semaphores: []Semaphore{{
+			ID:      sem.ID,
+			Weight:  1,
+			Release: SemaphoreReleaseAuto,
+		}},
+	}
+	constraints := []ConstraintItem{{Kind: ConstraintKindSemaphore, Semaphore: &sem}}
+
+	cm, r, _, _ := newSemaphoreTestEnv(t)
+	setAccountSemaphoreEnabled(t, func(context.Context, uuid.UUID) bool { return false })
+
+	resp, userErr, internalErr := cm.Check(ctx, &CapacityCheckRequest{
+		AccountID:     accountID,
+		Constraints:   constraints,
+		EnvID:         envID,
+		FunctionID:    fnID,
+		Configuration: config,
+	})
+	require.NoError(t, userErr)
+	require.NoError(t, internalErr)
+	require.NotNil(t, resp)
+	require.Empty(t, resp.ExhaustedConstraints)
+	require.Empty(t, resp.LimitingConstraints)
+	require.False(t, r.Exists(sem.UsageKey(accountID)))
+}
+
 func acquireWithSemaphore(
 	t *testing.T,
 	cm *redisCapacityManager,

--- a/pkg/enums/queue_constraint.go
+++ b/pkg/enums/queue_constraint.go
@@ -17,5 +17,10 @@ const (
 	QueueConstraintCustomConcurrencyKey1 QueueConstraint = 3
 	QueueConstraintCustomConcurrencyKey2 QueueConstraint = 4
 	QueueConstraintThrottle              QueueConstraint = 5
-	QueueConstraintSemaphore             QueueConstraint = 6
+	// QueueConstraintSemaphore is an item-local semaphore limit. Processors may
+	// skip the current item and continue scanning the partition.
+	QueueConstraintSemaphore QueueConstraint = 6
+	// QueueConstraintHaltingSemaphore is a semaphore limit with partition-wide
+	// FIFO semantics. Processors must stop scanning the partition.
+	QueueConstraintHaltingSemaphore QueueConstraint = 7
 )

--- a/pkg/enums/queueconstraint_enumer.go
+++ b/pkg/enums/queueconstraint_enumer.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-const _QueueConstraintName = "not_limitedaccount_concurrencyfunction_concurrencycustom_concurrency_key1custom_concurrency_key2throttlesemaphore"
+const _QueueConstraintName = "not_limitedaccount_concurrencyfunction_concurrencycustom_concurrency_key1custom_concurrency_key2throttlesemaphorehalting_semaphore"
 
-var _QueueConstraintIndex = [...]uint8{0, 11, 30, 50, 73, 96, 104, 113}
+var _QueueConstraintIndex = [...]uint8{0, 11, 30, 50, 73, 96, 104, 113, 130}
 
-const _QueueConstraintLowerName = "not_limitedaccount_concurrencyfunction_concurrencycustom_concurrency_key1custom_concurrency_key2throttlesemaphore"
+const _QueueConstraintLowerName = "not_limitedaccount_concurrencyfunction_concurrencycustom_concurrency_key1custom_concurrency_key2throttlesemaphorehalting_semaphore"
 
 func (i QueueConstraint) String() string {
 	if i < 0 || i >= QueueConstraint(len(_QueueConstraintIndex)-1) {
@@ -32,9 +32,10 @@ func _QueueConstraintNoOp() {
 	_ = x[QueueConstraintCustomConcurrencyKey2-(4)]
 	_ = x[QueueConstraintThrottle-(5)]
 	_ = x[QueueConstraintSemaphore-(6)]
+	_ = x[QueueConstraintHaltingSemaphore-(7)]
 }
 
-var _QueueConstraintValues = []QueueConstraint{QueueConstraintNotLimited, QueueConstraintAccountConcurrency, QueueConstraintFunctionConcurrency, QueueConstraintCustomConcurrencyKey1, QueueConstraintCustomConcurrencyKey2, QueueConstraintThrottle, QueueConstraintSemaphore}
+var _QueueConstraintValues = []QueueConstraint{QueueConstraintNotLimited, QueueConstraintAccountConcurrency, QueueConstraintFunctionConcurrency, QueueConstraintCustomConcurrencyKey1, QueueConstraintCustomConcurrencyKey2, QueueConstraintThrottle, QueueConstraintSemaphore, QueueConstraintHaltingSemaphore}
 
 var _QueueConstraintNameToValueMap = map[string]QueueConstraint{
 	_QueueConstraintName[0:11]:         QueueConstraintNotLimited,
@@ -51,6 +52,8 @@ var _QueueConstraintNameToValueMap = map[string]QueueConstraint{
 	_QueueConstraintLowerName[96:104]:  QueueConstraintThrottle,
 	_QueueConstraintName[104:113]:      QueueConstraintSemaphore,
 	_QueueConstraintLowerName[104:113]: QueueConstraintSemaphore,
+	_QueueConstraintName[113:130]:      QueueConstraintHaltingSemaphore,
+	_QueueConstraintLowerName[113:130]: QueueConstraintHaltingSemaphore,
 }
 
 var _QueueConstraintNames = []string{
@@ -61,6 +64,7 @@ var _QueueConstraintNames = []string{
 	_QueueConstraintName[73:96],
 	_QueueConstraintName[96:104],
 	_QueueConstraintName[104:113],
+	_QueueConstraintName[113:130],
 }
 
 // QueueConstraintString retrieves an enum value from the enum constants string name.

--- a/pkg/execution/executor/constraints.go
+++ b/pkg/execution/executor/constraints.go
@@ -273,24 +273,33 @@ type checkResult struct {
 
 // stepSemaphores returns the auto-release semaphores from run metadata that should
 // be added to every step queue item (not just the start job). This is used for
-// worker concurrency where each step independently acquires and releases a slot.
+// per-item concurrency where each queue item independently acquires and releases a slot.
 func stepSemaphores(md sv2.Metadata) []constraintapi.Semaphore {
 	return constraintapi.AutoReleaseSemaphores(md.Config.Semaphores)
 }
 
-// evaluateFnConcurrency evaluates function concurrency limits against event data
-// and returns the corresponding semaphore entries to store in run metadata.
-func (e *executor) evaluateFnConcurrency(
+// evaluateConcurrencySemaphores returns semaphore entries to store in run metadata.
+// Auto-release semaphores are copied onto every queue item and released per item.
+func (e *executor) evaluateConcurrencySemaphores(
 	ctx context.Context,
 	accountID, functionID uuid.UUID,
 	fnLimits []inngest.FnConcurrency,
 	evtMap map[string]any,
 ) []constraintapi.Semaphore {
-	if len(fnLimits) == 0 {
+	useAccountSemaphore := constraintapi.AccountSemaphoreConcurrencyEnabled(ctx, accountID)
+	if len(fnLimits) == 0 && !useAccountSemaphore {
 		return nil
 	}
 
-	semaphores := make([]constraintapi.Semaphore, 0, len(fnLimits))
+	semaphores := make([]constraintapi.Semaphore, 0, len(fnLimits)+1)
+	if useAccountSemaphore {
+		semaphores = append(semaphores, constraintapi.Semaphore{
+			ID:      constraintapi.SemaphoreIDAccount(accountID),
+			Weight:  1,
+			Release: constraintapi.SemaphoreReleaseAuto,
+		})
+	}
+
 	for _, fc := range fnLimits {
 		scope := fc.EffectiveScope()
 

--- a/pkg/execution/executor/constraints_test.go
+++ b/pkg/execution/executor/constraints_test.go
@@ -84,6 +84,31 @@ func TestRateLimitKeyExpressionHashConsistency(t *testing.T) {
 	}
 }
 
+func TestEvaluateConcurrencySemaphoresAccountFlag(t *testing.T) {
+	ctx := context.Background()
+	accountID, fnID := uuid.New(), uuid.New()
+	previous := constraintapi.AccountSemaphoreEnabled
+	constraintapi.AccountSemaphoreEnabled = nil
+	t.Cleanup(func() {
+		constraintapi.AccountSemaphoreEnabled = previous
+	})
+
+	e := &executor{}
+	require.Empty(t, e.evaluateConcurrencySemaphores(ctx, accountID, fnID, nil, nil))
+
+	constraintapi.AccountSemaphoreEnabled = func(context.Context, uuid.UUID) bool { return true }
+	semaphores := e.evaluateConcurrencySemaphores(ctx, accountID, fnID, []inngest.FnConcurrency{{Limit: 2}}, nil)
+	require.Len(t, semaphores, 2)
+
+	require.Equal(t, constraintapi.SemaphoreIDAccount(accountID), semaphores[0].ID)
+	require.Equal(t, constraintapi.SemaphoreReleaseAuto, semaphores[0].Release)
+	require.Equal(t, int64(1), semaphores[0].Weight)
+
+	require.Equal(t, constraintapi.SemaphoreIDFn(fnID), semaphores[1].ID)
+	require.Equal(t, constraintapi.SemaphoreReleaseManual, semaphores[1].Release)
+	require.Equal(t, int64(1), semaphores[1].Weight)
+}
+
 // TestScheduleConstraintCacheDoesNotDropRetriesOnExhaustion exercises the
 // silent-drop-on-retry case (SYS-820): when a Schedule attempt is rate
 // limited, the in-process constraint cache stores the "exhausted" decision.

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1182,10 +1182,12 @@ func (e *executor) schedule(
 	}
 
 	// Evaluate concurrency keys to use initially
+	var fnConcurrency []inngest.FnConcurrency
 	if req.Function.Concurrency != nil {
 		metadata.Config.CustomConcurrencyKeys = queue.GetCustomConcurrencyKeys(ctx, metadata.ID, req.Function.Concurrency.Limits, evtMap)
-		metadata.Config.Semaphores = e.evaluateFnConcurrency(ctx, req.AccountID, req.Function.ID, req.Function.Concurrency.Fn, evtMap)
+		fnConcurrency = req.Function.Concurrency.Fn
 	}
+	metadata.Config.Semaphores = e.evaluateConcurrencySemaphores(ctx, req.AccountID, req.Function.ID, fnConcurrency, evtMap)
 
 	//
 	// Create throttle information prior to creating state.  This is used in the queue.

--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -116,6 +116,7 @@ func ConvertLimitingConstraint(
 		// Account concurrency
 		case
 			c.Kind == constraintapi.ConstraintKindConcurrency &&
+				c.Concurrency != nil &&
 				c.Concurrency.Scope == enums.ConcurrencyScopeAccount &&
 				c.Concurrency.KeyExpressionHash == "":
 			constraint = enums.QueueConstraintAccountConcurrency
@@ -123,6 +124,7 @@ func ConvertLimitingConstraint(
 		// Function concurrency
 		case
 			c.Kind == constraintapi.ConstraintKindConcurrency &&
+				c.Concurrency != nil &&
 				c.Concurrency.Scope == enums.ConcurrencyScopeFn &&
 				c.Concurrency.KeyExpressionHash == "":
 			constraint = enums.QueueConstraintFunctionConcurrency
@@ -131,6 +133,7 @@ func ConvertLimitingConstraint(
 		case
 			len(constraints.Concurrency.CustomConcurrencyKeys) > 0 &&
 				c.Kind == constraintapi.ConstraintKindConcurrency &&
+				c.Concurrency != nil &&
 				c.Concurrency.Mode == constraints.Concurrency.CustomConcurrencyKeys[0].Mode &&
 				c.Concurrency.Scope == constraints.Concurrency.CustomConcurrencyKeys[0].Scope &&
 				c.Concurrency.KeyExpressionHash == constraints.Concurrency.CustomConcurrencyKeys[0].HashedKeyExpression:
@@ -140,6 +143,7 @@ func ConvertLimitingConstraint(
 		case
 			len(constraints.Concurrency.CustomConcurrencyKeys) > 1 &&
 				c.Kind == constraintapi.ConstraintKindConcurrency &&
+				c.Concurrency != nil &&
 				c.Concurrency.Mode == constraints.Concurrency.CustomConcurrencyKeys[1].Mode &&
 				c.Concurrency.Scope == constraints.Concurrency.CustomConcurrencyKeys[1].Scope &&
 				c.Concurrency.KeyExpressionHash == constraints.Concurrency.CustomConcurrencyKeys[1].HashedKeyExpression:
@@ -152,8 +156,17 @@ func ConvertLimitingConstraint(
 
 		// Semaphore
 		case
-			c.Kind == constraintapi.ConstraintKindSemaphore:
-			constraint = enums.QueueConstraintSemaphore
+			c.Kind == constraintapi.ConstraintKindSemaphore &&
+				c.Semaphore != nil:
+
+			switch {
+			case c.Semaphore.IsAccountConcurrency():
+				return enums.QueueConstraintHaltingSemaphore
+			case c.Semaphore.IsFunctionConcurrency():
+				return enums.QueueConstraintHaltingSemaphore
+			default:
+				constraint = enums.QueueConstraintSemaphore
+			}
 		}
 	}
 
@@ -306,6 +319,12 @@ func (q *queueProcessor) BacklogRefillConstraintCheck(
 	}
 
 	if len(res.Leases) == 0 {
+		if constraint == enums.QueueConstraintNotLimited {
+			return &BacklogRefillConstraintCheckResult{
+				ItemsToRefill: itemIDs,
+			}, nil
+		}
+
 		return &BacklogRefillConstraintCheckResult{
 			ItemsToRefill:      nil,
 			LimitingConstraint: constraint,
@@ -510,6 +529,10 @@ func (q *queueProcessor) ItemLeaseConstraintCheck(
 	span.SetAttributes(attribute.String("limiting_constraint", constraint.String()))
 
 	if len(res.Leases) == 0 {
+		if constraint == enums.QueueConstraintNotLimited {
+			return ItemLeaseConstraintCheckResult{}, nil
+		}
+
 		span.SetAttributes(attribute.Bool("constrained", true))
 
 		return ItemLeaseConstraintCheckResult{

--- a/pkg/execution/queue/constraints_test.go
+++ b/pkg/execution/queue/constraints_test.go
@@ -566,6 +566,8 @@ func TestConstraintItemsFromBacklog(t *testing.T) {
 }
 
 func TestConvertLimitingConstraint(t *testing.T) {
+	accountID, fnID := uuid.New(), uuid.New()
+
 	tests := []struct {
 		name                string
 		constraints         PartitionConstraintConfig
@@ -605,6 +607,91 @@ func TestConvertLimitingConstraint(t *testing.T) {
 				},
 			},
 			expected: enums.QueueConstraintFunctionConcurrency,
+		},
+		{
+			name:        "account scoped semaphore constraint",
+			constraints: PartitionConstraintConfig{},
+			limitingConstraints: []constraintapi.ConstraintItem{
+				{
+					Kind: constraintapi.ConstraintKindSemaphore,
+					Semaphore: &constraintapi.SemaphoreConstraint{
+						ID: constraintapi.SemaphoreIDAccount(accountID),
+					},
+				},
+			},
+			expected: enums.QueueConstraintHaltingSemaphore,
+		},
+		{
+			name:        "function scoped semaphore constraint",
+			constraints: PartitionConstraintConfig{},
+			limitingConstraints: []constraintapi.ConstraintItem{
+				{
+					Kind: constraintapi.ConstraintKindSemaphore,
+					Semaphore: &constraintapi.SemaphoreConstraint{
+						ID: constraintapi.SemaphoreIDFn(fnID),
+					},
+				},
+			},
+			expected: enums.QueueConstraintHaltingSemaphore,
+		},
+		{
+			name:        "keyed function scoped semaphore constraint",
+			constraints: PartitionConstraintConfig{},
+			limitingConstraints: []constraintapi.ConstraintItem{
+				{
+					Kind: constraintapi.ConstraintKindSemaphore,
+					Semaphore: &constraintapi.SemaphoreConstraint{
+						ID:               constraintapi.SemaphoreIDFn(fnID),
+						EvaluatedKeyHash: "user-hash",
+					},
+				},
+			},
+			expected: enums.QueueConstraintSemaphore,
+		},
+		{
+			name:        "function key semaphore constraint",
+			constraints: PartitionConstraintConfig{},
+			limitingConstraints: []constraintapi.ConstraintItem{
+				{
+					Kind: constraintapi.ConstraintKindSemaphore,
+					Semaphore: &constraintapi.SemaphoreConstraint{
+						ID: constraintapi.SemaphoreIDFnKey(fnID, "event.data.user_id"),
+					},
+				},
+			},
+			expected: enums.QueueConstraintSemaphore,
+		},
+		{
+			name:        "app scoped semaphore constraint",
+			constraints: PartitionConstraintConfig{},
+			limitingConstraints: []constraintapi.ConstraintItem{
+				{
+					Kind: constraintapi.ConstraintKindSemaphore,
+					Semaphore: &constraintapi.SemaphoreConstraint{
+						ID: constraintapi.SemaphoreIDApp(uuid.New()),
+					},
+				},
+			},
+			expected: enums.QueueConstraintSemaphore,
+		},
+		{
+			name:        "halting semaphore takes precedence over item semaphore",
+			constraints: PartitionConstraintConfig{},
+			limitingConstraints: []constraintapi.ConstraintItem{
+				{
+					Kind: constraintapi.ConstraintKindSemaphore,
+					Semaphore: &constraintapi.SemaphoreConstraint{
+						ID: constraintapi.SemaphoreIDAccount(accountID),
+					},
+				},
+				{
+					Kind: constraintapi.ConstraintKindSemaphore,
+					Semaphore: &constraintapi.SemaphoreConstraint{
+						ID: constraintapi.SemaphoreIDApp(uuid.New()),
+					},
+				},
+			},
+			expected: enums.QueueConstraintHaltingSemaphore,
 		},
 		{
 			name: "custom concurrency key 1",

--- a/pkg/execution/queue/errors.go
+++ b/pkg/execution/queue/errors.go
@@ -95,6 +95,10 @@ var (
 	// Unlike partition/account limits, this is per-item (only start jobs carry semaphores),
 	// so the iterator should skip the item and continue scanning.
 	ErrSemaphoreLimit = fmt.Errorf("at semaphore capacity limit")
+
+	// ErrHaltingSemaphoreLimit represents a semaphore limit which halts
+	// partition processing.
+	ErrHaltingSemaphoreLimit = fmt.Errorf("at halting semaphore limit")
 )
 
 var (

--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -332,6 +332,8 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 		err = NewKeyError(ErrConcurrencyLimitCustomKey, backlog.CustomConcurrencyKeyID(1))
 	case enums.QueueConstraintCustomConcurrencyKey2:
 		err = NewKeyError(ErrConcurrencyLimitCustomKey, backlog.CustomConcurrencyKeyID(2))
+	case enums.QueueConstraintHaltingSemaphore:
+		err = ErrHaltingSemaphoreLimit
 	case enums.QueueConstraintSemaphore:
 		err = ErrSemaphoreLimit
 	default:
@@ -425,7 +427,7 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 		}
 
 		return nil
-	case ErrPartitionConcurrencyLimit, ErrAccountConcurrencyLimit, ErrSystemConcurrencyLimit:
+	case ErrPartitionConcurrencyLimit, ErrAccountConcurrencyLimit, ErrSystemConcurrencyLimit, ErrHaltingSemaphoreLimit:
 		p.IsCustomKeyLimitOnly.Store(false)
 		p.IsSemaphoreLimitOnly.Store(false)
 
@@ -458,6 +460,8 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 				p.Partition.AccountID,
 				p.Partition.EnvID,
 			)
+		case ErrHaltingSemaphoreLimit:
+			status = "halting_semaphore_limit"
 		}
 
 		metrics.IncrQueueItemProcessedCounter(ctx, metrics.CounterOpt{

--- a/pkg/execution/queue/processor_iterator.go
+++ b/pkg/execution/queue/processor_iterator.go
@@ -429,7 +429,12 @@ func (p *ProcessorIterator) Process(ctx context.Context, item *QueueItem) error 
 		return nil
 	case ErrPartitionConcurrencyLimit, ErrAccountConcurrencyLimit, ErrSystemConcurrencyLimit, ErrHaltingSemaphoreLimit:
 		p.IsCustomKeyLimitOnly.Store(false)
-		p.IsSemaphoreLimitOnly.Store(false)
+
+		if cause != ErrHaltingSemaphoreLimit {
+			// halting semaphores should only delay by 1s so that we repeek relatively quickly.  if this
+			// is another concurrency limit, mark this as non-semaphore so we can delay > 1s
+			p.IsSemaphoreLimitOnly.Store(false)
+		}
 
 		p.CtrConcurrency.Add(1)
 		// Since the queue is at capacity on a fn or account level, no

--- a/pkg/execution/queue/shadow_process.go
+++ b/pkg/execution/queue/shadow_process.go
@@ -280,7 +280,7 @@ func (q *queueProcessor) ProcessShadowPartition(ctx context.Context, shadowPart 
 			switch limitingConstraint {
 			case enums.QueueConstraintNotLimited:
 				// continue with next backlog
-			case enums.QueueConstraintAccountConcurrency, enums.QueueConstraintFunctionConcurrency:
+			case enums.QueueConstraintAccountConcurrency, enums.QueueConstraintFunctionConcurrency, enums.QueueConstraintHaltingSemaphore:
 				l.Trace("limited by concurrency, requeueing shadow partition in the future",
 					"scope", limitingConstraint,
 				)

--- a/pkg/inngest/concurrency.go
+++ b/pkg/inngest/concurrency.go
@@ -186,7 +186,7 @@ type FnConcurrency struct {
 
 	// ID represents the pre-computed semaphore ID for this concurrency limit.
 	// Set internally during registration (e.g., "app:<appID>" for connect apps).
-	// For fn-scoped limits without a pre-set ID, evaluateFnConcurrency computes it.
+	// For fn-scoped limits without a pre-set ID, the executor computes it.
 	ID string `json:"id,omitempty"`
 }
 

--- a/tests/golang/concurrency_fn_concurrency_test.go
+++ b/tests/golang/concurrency_fn_concurrency_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestFnConcurrency tests function-level concurrency via semaphores.
+// TestSemaphoreFnConcurrency tests function-level concurrency via semaphores.
 // Unlike step concurrency, the limit is held for the ENTIRE run — across
 // all steps. Only one run should execute at a time with limit=1.
-func TestFnConcurrency(t *testing.T) {
+func TestSemaphoreFnConcurrency(t *testing.T) {
 	c := client.New(t)
 	c.ResetAll(t)
 


### PR DESCRIPTION
this change allows us to use semaphores to manage account level concurrency limits.  we can roll this out as a feature flag via the package-level variable (for ease of use) selectively

note that this requires semaphore capacity to be updated per account, which is out of scope for this change