### PR TITLE
chore(sessions): sessions UI feedback

### DIFF
--- a/ui/apps/dashboard/src/components/Sessions/SessionRuns.tsx
+++ b/ui/apps/dashboard/src/components/Sessions/SessionRuns.tsx
@@ -30,7 +30,7 @@ import {
   formatMilliseconds,
   parseDuration,
 } from '@inngest/components/utils/date';
-import { RiRefreshLine } from '@remixicon/react';
+import { RiExternalLinkLine, RiRefreshLine } from '@remixicon/react';
 import { createColumnHelper } from '@tanstack/react-table';
 
 import { useGetTrigger } from '@/components/RunDetails/useGetTrigger';
@@ -39,6 +39,8 @@ import { useAccountFeatures } from '@/utils/useAccountFeatures';
 import { type SessionRun, useSessionRuns } from './useSessionRuns';
 
 const DEFAULT_RANGE = '7d';
+const DOCS_URL =
+  'https://website-git-jakob-sessions-docs-inngest.vercel.app/docs/features/events-triggers/sessions';
 
 const columnHelper = createColumnHelper<SessionRun>();
 
@@ -205,12 +207,12 @@ export function SessionRuns({
               lastDays
                 ? { type: 'relative', duration: parseDuration(lastDays) }
                 : startTimeParam && endTimeParam
-                  ? {
-                      type: 'absolute',
-                      start: new Date(startTimeParam),
-                      end: new Date(endTimeParam),
-                    }
-                  : { type: 'relative', duration: parseDuration(DEFAULT_RANGE) }
+                ? {
+                    type: 'absolute',
+                    start: new Date(startTimeParam),
+                    end: new Date(endTimeParam),
+                  }
+                : { type: 'relative', duration: parseDuration(DEFAULT_RANGE) }
             }
           />
           <RunsStatusFilter
@@ -233,7 +235,15 @@ export function SessionRuns({
                 <TableBlankState
                   icon={<SessionsIcon />}
                   title={`No runs found for ${sessionId}`}
-                  actions={null}
+                  actions={
+                    <Button
+                      label="Go to docs"
+                      href={DOCS_URL}
+                      target="_blank"
+                      icon={<RiExternalLinkLine />}
+                      iconSide="left"
+                    />
+                  }
                 />
               }
               expandedIDs={expandedRunIDs}

--- a/ui/packages/components/src/Sessions/SessionKeys.tsx
+++ b/ui/packages/components/src/Sessions/SessionKeys.tsx
@@ -52,7 +52,7 @@ export function SessionKeys({
 
   return (
     <div className="bg-canvasBase text-basis flex flex-1 flex-col overflow-hidden focus-visible:outline-none">
-      <div className="flex flex-col gap-4 px-3 pb-3 pt-6">
+      <div className="flex flex-col gap-4 px-3 py-3">
         <form
           className="w-full max-w-[360px]"
           onSubmit={(e) => {

--- a/ui/packages/components/src/Sessions/SessionKeys.tsx
+++ b/ui/packages/components/src/Sessions/SessionKeys.tsx
@@ -1,12 +1,16 @@
+import { Button } from '@inngest/components/Button';
 import { ErrorCard } from '@inngest/components/Error/ErrorCard';
 import { Search } from '@inngest/components/Forms/Search';
 import { Table, TableBlankState, TextCell } from '@inngest/components/Table';
 import { Time } from '@inngest/components/Time';
 import { SessionsIcon } from '@inngest/components/icons/sections/Sessions';
 import { type SessionKey } from '@inngest/components/types/session';
+import { RiExternalLinkLine } from '@remixicon/react';
 import { createColumnHelper } from '@tanstack/react-table';
 
 const columnHelper = createColumnHelper<SessionKey>();
+const DOCS_URL =
+  'https://website-git-jakob-sessions-docs-inngest.vercel.app/docs/features/events-triggers/sessions';
 
 const columns = [
   columnHelper.accessor('sessionKey', {
@@ -84,7 +88,15 @@ export function SessionKeys({
             blankState={
               <TableBlankState
                 icon={<SessionsIcon />}
-                actions={null}
+                actions={
+                  <Button
+                    label="Go to docs"
+                    href={DOCS_URL}
+                    target="_blank"
+                    icon={<RiExternalLinkLine />}
+                    iconSide="left"
+                  />
+                }
                 title={search ? `No session key found for "${search}"` : 'No sessions found'}
                 description="Session keys appear here after events are sent with session meta."
               />

--- a/ui/packages/components/src/Sessions/SessionResults.tsx
+++ b/ui/packages/components/src/Sessions/SessionResults.tsx
@@ -19,8 +19,8 @@ import { useColumns } from './columns';
 
 const DEFAULT_RANGE = '7d';
 const SEARCH_DEBOUNCE_MS = 300;
-// TODO: Replace with the sessions docs URL and include a ref param for dashboard traffic.
-const DOCS_URL = 'ui/packages/components/src/Sessions/SessionResults.tsx';
+const DOCS_URL =
+  'https://website-git-jakob-sessions-docs-inngest.vercel.app/docs/features/events-triggers/sessions';
 
 type RoutePath = LinkComponentProps['to'] | string;
 
@@ -93,7 +93,7 @@ export function SessionResults({
         });
       }
     },
-    [batchUpdate],
+    [batchUpdate]
   );
 
   const { data, error, isPending, isFetching, refetch } = useQuery({
@@ -125,12 +125,12 @@ export function SessionResults({
               last
                 ? { type: 'relative', duration: parseDuration(last) }
                 : start && end
-                  ? {
-                      type: 'absolute',
-                      start: new Date(start),
-                      end: new Date(end),
-                    }
-                  : { type: 'relative', duration: parseDuration(DEFAULT_RANGE) }
+                ? {
+                    type: 'absolute',
+                    start: new Date(start),
+                    end: new Date(end),
+                  }
+                : { type: 'relative', duration: parseDuration(DEFAULT_RANGE) }
             }
           />
         </SelectGroup>

--- a/ui/packages/components/src/Sessions/columns.tsx
+++ b/ui/packages/components/src/Sessions/columns.tsx
@@ -24,6 +24,15 @@ export function useColumns({ pathCreator }: { pathCreator: PathCreator }) {
         </TextCell>
       ),
     }),
+    columnHelper.accessor('sessionKey', {
+      header: 'Session Key',
+      enableSorting: false,
+      cell: ({ row }) => (
+        <TextCell>
+          <span className="font-mono">{row.original.sessionKey}</span>
+        </TextCell>
+      ),
+    }),
     columnHelper.accessor('runCount', {
       header: 'Number of runs',
       enableSorting: false,

--- a/ui/packages/components/src/Table/Table.tsx
+++ b/ui/packages/components/src/Table/Table.tsx
@@ -128,7 +128,7 @@ export function Table<T>({
                       key={header.id}
                       className={cn(
                         isIconOnlyColumn ? '' : tableColumnStyles,
-                        'text-muted text-nowrap text-left text-xs font-medium',
+                        'text-muted whitespace-nowrap text-left text-xs font-medium',
                         enableColumnSizing ? 'overflow-hidden text-ellipsis' : ''
                       )}
                       style={


### PR DESCRIPTION
## Description

Feedback from design

1. putting `Session Key` in the table makes each row stand on its own instead of relying on the page title for context, and keeping it second keeps the important identifiers together before the metrics

before:
<img width="2552" height="1376" alt="Screenshot 2026-06-23 at 4 29 20 PM" src="https://github.com/user-attachments/assets/066d6bc1-83eb-48b9-b9bd-6c64b409ae6f" />

after:
<img width="2552" height="1376" alt="Screenshot 2026-06-23 at 4 29 25 PM" src="https://github.com/user-attachments/assets/3ce30001-4781-4f84-9be8-70831d2c5fe1" />

2. fix search bar spacing

before:
<img width="3128" height="708" alt="image" src="https://github.com/user-attachments/assets/30cb684c-c972-40ce-bd47-bebab92ea1de" />

after:
<img width="3128" height="708" alt="image" src="https://github.com/user-attachments/assets/a2d828d9-0493-45de-a37c-db7bfba0fc56" />

3. add docs links to empty states

before:
<img width="3105" height="1805" alt="image" src="https://github.com/user-attachments/assets/c6530477-65a7-4574-a634-4fe7822d2253" />

after:
<img width="5090" height="2662" alt="image" src="https://github.com/user-attachments/assets/57bd51ba-86d5-44cf-a468-37b84243c4d4" />


4. changed the font style of the top of the table to match `/runs` (note that other tables that use this also get their font styles updated like functions, experiment table, etc, this is intended because it makes the design more cohesive across the product)

before:
<img width="1269" height="229" alt="Screenshot 2026-06-23 at 4 33 17 PM" src="https://github.com/user-attachments/assets/a1839803-e869-47f4-b2f0-a14c68e4424b" />

after:
<img width="2538" height="458" alt="image" src="https://github.com/user-attachments/assets/d533adcc-00bb-4e44-8fc6-2b22a756334f" />


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
