### PR TITLE
fix: bug where custom concurrency cache keys are always account level

### DIFF
--- a/pkg/constraintapi/constraints.go
+++ b/pkg/constraintapi/constraints.go
@@ -296,6 +296,9 @@ func (ci ConstraintItem) CacheKey(accountID, envID, functionID uuid.UUID) string
 
 		// Custom key uses expression and evaluated hashes
 		if c.KeyExpressionHash != "" {
+			if entityID != uuid.Nil {
+				return fmt.Sprintf("%s:c:%s:%s:%s:%s", accountID, scopeLetter, entityID, c.KeyExpressionHash, c.EvaluatedKeyHash)
+			}
 			return fmt.Sprintf("%s:c:%s:%s:%s", accountID, scopeLetter, c.KeyExpressionHash, c.EvaluatedKeyHash)
 		}
 
@@ -328,6 +331,9 @@ func (ci ConstraintItem) CacheKey(accountID, envID, functionID uuid.UUID) string
 
 		// Custom key uses expression and evaluated hashes
 		if t.KeyExpressionHash != "" {
+			if entityID != uuid.Nil {
+				return fmt.Sprintf("%s:t:%s:%s:%s:%s", accountID, scopeLetter, entityID, t.KeyExpressionHash, t.EvaluatedKeyHash)
+			}
 			return fmt.Sprintf("%s:t:%s:%s:%s", accountID, scopeLetter, t.KeyExpressionHash, t.EvaluatedKeyHash)
 		}
 
@@ -360,6 +366,9 @@ func (ci ConstraintItem) CacheKey(accountID, envID, functionID uuid.UUID) string
 
 		// Custom key uses expression and evaluated hashes
 		if r.KeyExpressionHash != "" {
+			if entityID != uuid.Nil {
+				return fmt.Sprintf("%s:r:%s:%s:%s:%s", accountID, scopeLetter, entityID, r.KeyExpressionHash, r.EvaluatedKeyHash)
+			}
 			return fmt.Sprintf("%s:r:%s:%s:%s", accountID, scopeLetter, r.KeyExpressionHash, r.EvaluatedKeyHash)
 		}
 

--- a/pkg/constraintapi/constraints_test.go
+++ b/pkg/constraintapi/constraints_test.go
@@ -2690,7 +2690,7 @@ func TestConstraintItem_CacheKey(t *testing.T) {
 					EvaluatedKeyHash:  "eval_env",
 				},
 			},
-			expected:    "550e8400-e29b-41d4-a716-446655440001:c:e:expr_env:eval_env",
+			expected:    "550e8400-e29b-41d4-a716-446655440001:c:e:550e8400-e29b-41d4-a716-446655440002:expr_env:eval_env",
 			description: "env concurrency with custom key should include both hashes",
 		},
 		{
@@ -2703,7 +2703,7 @@ func TestConstraintItem_CacheKey(t *testing.T) {
 					EvaluatedKeyHash:  "eval_fn",
 				},
 			},
-			expected:    "550e8400-e29b-41d4-a716-446655440001:c:f:expr_fn:eval_fn",
+			expected:    "550e8400-e29b-41d4-a716-446655440001:c:f:550e8400-e29b-41d4-a716-446655440003:expr_fn:eval_fn",
 			description: "function concurrency with custom key should include both hashes",
 		},
 
@@ -2766,7 +2766,7 @@ func TestConstraintItem_CacheKey(t *testing.T) {
 					EvaluatedKeyHash:  "throttle_env_eval",
 				},
 			},
-			expected:    "550e8400-e29b-41d4-a716-446655440001:t:e:throttle_env_expr:throttle_env_eval",
+			expected:    "550e8400-e29b-41d4-a716-446655440001:t:e:550e8400-e29b-41d4-a716-446655440002:throttle_env_expr:throttle_env_eval",
 			description: "env throttle with custom key should include both hashes",
 		},
 		{
@@ -2779,7 +2779,7 @@ func TestConstraintItem_CacheKey(t *testing.T) {
 					EvaluatedKeyHash:  "throttle_fn_eval",
 				},
 			},
-			expected:    "550e8400-e29b-41d4-a716-446655440001:t:f:throttle_fn_expr:throttle_fn_eval",
+			expected:    "550e8400-e29b-41d4-a716-446655440001:t:f:550e8400-e29b-41d4-a716-446655440003:throttle_fn_expr:throttle_fn_eval",
 			description: "function throttle with custom key should include both hashes",
 		},
 
@@ -2842,7 +2842,7 @@ func TestConstraintItem_CacheKey(t *testing.T) {
 					EvaluatedKeyHash:  "rl_env_eval",
 				},
 			},
-			expected:    "550e8400-e29b-41d4-a716-446655440001:r:e:rl_env_expr:rl_env_eval",
+			expected:    "550e8400-e29b-41d4-a716-446655440001:r:e:550e8400-e29b-41d4-a716-446655440002:rl_env_expr:rl_env_eval",
 			description: "env rate limit with custom key should include both hashes",
 		},
 		{
@@ -2855,7 +2855,7 @@ func TestConstraintItem_CacheKey(t *testing.T) {
 					EvaluatedKeyHash:  "rl_fn_eval",
 				},
 			},
-			expected:    "550e8400-e29b-41d4-a716-446655440001:r:f:rl_fn_expr:rl_fn_eval",
+			expected:    "550e8400-e29b-41d4-a716-446655440001:r:f:550e8400-e29b-41d4-a716-446655440003:rl_fn_expr:rl_fn_eval",
 			description: "function rate limit with custom key should include both hashes",
 		},
 

--- a/pkg/constraintapi/lua/release.lua
+++ b/pkg/constraintapi/lua/release.lua
@@ -159,7 +159,13 @@ if enableCacheInvalidation then
 			local sl = (scope == 2 and "a") or (scope == 1 and "e") or "f"
 			local cacheKey
 			if c.c.h ~= nil and c.c.h ~= "" then
-				cacheKey = accountID .. ":c:" .. sl .. ":" .. c.c.h .. ":" .. (c.c.eh or "")
+				if scope == 0 then
+					cacheKey = accountID .. ":c:" .. sl .. ":" .. requestDetails.f .. ":" .. c.c.h .. ":" .. (c.c.eh or "")
+				elseif scope == 1 then
+					cacheKey = accountID .. ":c:" .. sl .. ":" .. requestDetails.e .. ":" .. c.c.h .. ":" .. (c.c.eh or "")
+				else
+					cacheKey = accountID .. ":c:" .. sl .. ":" .. c.c.h .. ":" .. (c.c.eh or "")
+				end
 			elseif scope == 0 then
 				cacheKey = accountID .. ":c:" .. sl .. ":" .. requestDetails.f
 			elseif scope == 1 then

--- a/pkg/constraintapi/testdata/snapshots/release.lua
+++ b/pkg/constraintapi/testdata/snapshots/release.lua
@@ -101,7 +101,13 @@ if enableCacheInvalidation then
 			local sl = (scope == 2 and "a") or (scope == 1 and "e") or "f"
 			local cacheKey
 			if c.c.h ~= nil and c.c.h ~= "" then
-				cacheKey = accountID .. ":c:" .. sl .. ":" .. c.c.h .. ":" .. (c.c.eh or "")
+				if scope == 0 then
+					cacheKey = accountID .. ":c:" .. sl .. ":" .. requestDetails.f .. ":" .. c.c.h .. ":" .. (c.c.eh or "")
+				elseif scope == 1 then
+					cacheKey = accountID .. ":c:" .. sl .. ":" .. requestDetails.e .. ":" .. c.c.h .. ":" .. (c.c.eh or "")
+				else
+					cacheKey = accountID .. ":c:" .. sl .. ":" .. c.c.h .. ":" .. (c.c.eh or "")
+				end
 			elseif scope == 0 then
 				cacheKey = accountID .. ":c:" .. sl .. ":" .. requestDetails.f
 			elseif scope == 1 then


### PR DESCRIPTION
## Description
i think Missing entityID in constraint API cache keys is making all custom concurrency keys account scoped 


<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

fixes a custom concurrency bug that could be lowering throughput


## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
