### PR TITLE
refactor(api): extract metadata writer

### DIFF
--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -117,6 +117,29 @@ type AddRunMetadataRequest struct {
 	Metadata []metadata.Update `json:"metadata"`
 }
 
+type AddRunMetadataOpts struct {
+	State          statev2.RunService
+	TracerProvider tracing.TracerProvider
+	TraceReader    cqrs.TraceReader
+}
+
+func AddRunMetadata(ctx context.Context, opts AddRunMetadataOpts, auth apiv1auth.V1Auth, runID ulid.ULID, req *AddRunMetadataRequest) error {
+	tracerProvider := opts.TracerProvider
+	if tracerProvider == nil {
+		tracerProvider = tracing.NewNoopTracerProvider()
+	}
+	r := router{
+		API: &API{
+			opts: Opts{
+				State:          opts.State,
+				TracerProvider: tracerProvider,
+				TraceReader:    opts.TraceReader,
+			},
+		},
+	}
+	return r.AddRunMetadata(ctx, auth, runID, req)
+}
+
 func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID ulid.ULID, req *AddRunMetadataRequest) error {
 	if err := metadata.ValidateUpdatesAllowed(req.Metadata); err != nil {
 		return publicerr.Wrap(err, 400, "Invalid metadata")

--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -254,6 +254,15 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 			return err
 		}
 	}
+	if parentSpanRef != nil && parentSpanRef.DynamicSpanID != "" {
+		if err := a.opts.TracerProvider.UpdateSpan(ctx, &tracing.UpdateSpanOptions{
+			Debug:      &tracing.SpanDebugData{Location: "router.AddRunMetadata.refreshTarget"},
+			Metadata:   stateMetadata,
+			TargetSpan: parentSpanRef,
+		}); err != nil {
+			return err
+		}
+	}
 
 	// Persist the cumulative metadata size delta back to the state store.
 	// Only persist when we successfully loaded from state; the fallback
@@ -391,6 +400,15 @@ func (a router) addRunMetadataLegacy(ctx context.Context, auth apiv1auth.V1Auth,
 			addTenantIDs,
 		)
 		if err != nil {
+			return err
+		}
+	}
+	if parentSpanRef != nil && parentSpanRef.DynamicSpanID != "" {
+		if err := a.opts.TracerProvider.UpdateSpan(ctx, &tracing.UpdateSpanOptions{
+			Debug:      &tracing.SpanDebugData{Location: "router.AddRunMetadata.refreshTarget"},
+			Metadata:   stateMetadata,
+			TargetSpan: parentSpanRef,
+		}); err != nil {
 			return err
 		}
 	}

--- a/pkg/api/apiv1/metadata.go
+++ b/pkg/api/apiv1/metadata.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/api/apiv1/apiv1auth"
+	"github.com/inngest/inngest/pkg/api/metadatawriter"
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/enums"
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
@@ -117,29 +118,6 @@ type AddRunMetadataRequest struct {
 	Metadata []metadata.Update `json:"metadata"`
 }
 
-type AddRunMetadataOpts struct {
-	State          statev2.RunService
-	TracerProvider tracing.TracerProvider
-	TraceReader    cqrs.TraceReader
-}
-
-func AddRunMetadata(ctx context.Context, opts AddRunMetadataOpts, auth apiv1auth.V1Auth, runID ulid.ULID, req *AddRunMetadataRequest) error {
-	tracerProvider := opts.TracerProvider
-	if tracerProvider == nil {
-		tracerProvider = tracing.NewNoopTracerProvider()
-	}
-	r := router{
-		API: &API{
-			opts: Opts{
-				State:          opts.State,
-				TracerProvider: tracerProvider,
-				TraceReader:    opts.TraceReader,
-			},
-		},
-	}
-	return r.AddRunMetadata(ctx, auth, runID, req)
-}
-
 func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID ulid.ULID, req *AddRunMetadataRequest) error {
 	if err := metadata.ValidateUpdatesAllowed(req.Metadata); err != nil {
 		return publicerr.Wrap(err, 400, "Invalid metadata")
@@ -162,124 +140,61 @@ func (a router) AddRunMetadata(ctx context.Context, auth apiv1auth.V1Auth, runID
 		},
 	}
 
-	var stateMetadata *statev2.Metadata
-	loadedFromState := false
-	if a.opts.State != nil {
-		md, err := a.opts.State.LoadMetadata(ctx, partialID)
-		if errors.Is(err, statev2.ErrRunNotFound) || errors.Is(err, statev2.ErrMetadataNotFound) {
-			logger.StdlibLogger(ctx).Warn("failed to load run metadata for size limit check, falling back to request-local limit",
-				"error", err,
-				"run_id", runID.String(),
-			)
-		} else if err != nil {
-			return publicerr.Wrap(err, 500, "Unable to load run metadata")
-		} else {
-			stateMetadata = &md
-			loadedFromState = true
-		}
+	err := metadatawriter.Writer{
+		State:          a.opts.State,
+		TracerProvider: a.opts.TracerProvider,
+		PkgName:        pkgName,
+		// Missing state fallback is part of the existing SDK metadata contract.
+		AllowMissingState: true,
+	}.Write(ctx, metadatawriter.WriteRequest{
+		ID: partialID,
+		Items: metadatawriter.NewItems(req.Metadata, func(stateMetadata *statev2.Metadata) (*meta.SpanReference, metadata.Scope) {
+			return deterministicMetadataParent(runID, &req.Target, stateMetadata)
+		}),
+		Location: "router.AddRunMetadata",
+	})
+	if errors.Is(err, metadatawriter.ErrLoadMetadata) {
+		return publicerr.Wrap(err, 500, "Unable to load run metadata")
 	}
+	return err
+}
 
-	// Missing state uses a request-local fallback so this write still enforces
-	// the cumulative size limit within the request.
-	if stateMetadata == nil {
-		stateMetadata = &statev2.Metadata{ID: partialID}
-	}
-	statev2.InitConfig(&stateMetadata.Config)
-
-	// Build the parent span reference and determine scope. For run-scoped and
-	// step-scoped metadata the span reference is computed deterministically from
-	// the run/step IDs, removing any dependency on ClickHouse. The
-	// extended-trace case still looks up the user-created span by its ID.
-	var parentSpanRef *meta.SpanReference
-	var scope metadata.Scope
-
+// deterministicMetadataParent builds the parent span reference and determines
+// scope for runs created after deterministic span IDs were deployed. For
+// run-scoped and step-scoped metadata the span reference is computed from the
+// run/step IDs, removing any dependency on ClickHouse.
+func deterministicMetadataParent(runID ulid.ULID, target *RunMetadataTarget, stateMetadata *statev2.Metadata) (*meta.SpanReference, metadata.Scope) {
 	switch {
-	case req.Target.StepID == nil:
-		scope = enums.MetadataScopeRun
-		parentSpanRef = tracing.RunSpanRefFromMetadata(stateMetadata)
+	case target.StepID == nil:
+		return tracing.RunSpanRefFromMetadata(stateMetadata), enums.MetadataScopeRun
 
-	case req.Target.StepAttempt == nil || req.Target.SpanID == nil:
-		scope = enums.MetadataScopeStep
-
+	case target.StepAttempt == nil || target.SpanID == nil:
 		var hashedStepID string
-		if req.Target.StepIndex == nil || *req.Target.StepIndex == 0 {
-			sum := sha1.Sum([]byte(*req.Target.StepID))
+		if target.StepIndex == nil || *target.StepIndex == 0 {
+			sum := sha1.Sum([]byte(*target.StepID))
 			hashedStepID = hex.EncodeToString(sum[:])
 		} else {
-			sum := sha1.Sum(fmt.Appendf(nil, "%s:%d", *req.Target.StepID, *req.Target.StepIndex))
+			sum := sha1.Sum(fmt.Appendf(nil, "%s:%d", *target.StepID, *target.StepIndex))
 			hashedStepID = hex.EncodeToString(sum[:])
 		}
 
-		if req.Target.StepAttempt == nil || *req.Target.StepAttempt < 0 {
-			parentSpanRef = tracing.FinalizedStepSpanRefFromMetadataAndStepID(stateMetadata, hashedStepID)
-		} else {
-			parentSpanRef = tracing.RetryStepSpanRefFromMetadataAndStepID(stateMetadata, hashedStepID, *req.Target.StepAttempt)
+		if target.StepAttempt == nil || *target.StepAttempt < 0 {
+			return tracing.FinalizedStepSpanRefFromMetadataAndStepID(stateMetadata, hashedStepID), enums.MetadataScopeStep
 		}
+		return tracing.RetryStepSpanRefFromMetadataAndStepID(stateMetadata, hashedStepID, *target.StepAttempt), enums.MetadataScopeStep
 
 	default:
-		scope = enums.MetadataScopeExtendedTrace
 		// The TraceID is the same for all spans in the run and is derived
 		// deterministically from the runID. The span itself is referenced by
 		// the caller-supplied SpanID, so no ClickHouse lookup is needed.
 		traceID := tracing.DeterministicSpanConfig(runID[:]).TraceID.String()
-		spanID := *req.Target.SpanID
-		parentSpanRef = &meta.SpanReference{
+		spanID := *target.SpanID
+		return &meta.SpanReference{
 			TraceParent:            fmt.Sprintf("00-%s-%s-00", traceID, spanID),
 			DynamicSpanID:          spanID,
 			DynamicSpanTraceParent: fmt.Sprintf("00-%s-%s-00", traceID, spanID),
-		}
+		}, enums.MetadataScopeExtendedTrace
 	}
-
-	addTenantIDs := func(cfg *tracing.MetadataSpanConfig) {
-		meta.AddAttr(cfg.Attrs, meta.Attrs.AccountID, util.ToPtr(auth.AccountID()))
-		meta.AddAttr(cfg.Attrs, meta.Attrs.EnvID, util.ToPtr(auth.WorkspaceID()))
-		meta.AddAttr(cfg.Attrs, meta.Attrs.FunctionID, &stateMetadata.ID.FunctionID)
-		meta.AddAttr(cfg.Attrs, meta.Attrs.RunID, &stateMetadata.ID.RunID)
-		meta.AddAttr(cfg.Attrs, meta.Attrs.AppID, &stateMetadata.ID.Tenant.AppID)
-	}
-
-	for _, md := range req.Metadata {
-		_, err := tracing.CreateMetadataSpan(
-			ctx,
-			a.opts.TracerProvider,
-			parentSpanRef,
-			"router.AddRunMetadata",
-			pkgName,
-			stateMetadata,
-			md,
-			scope,
-			addTenantIDs,
-		)
-		if err != nil {
-			return err
-		}
-	}
-	if parentSpanRef != nil && parentSpanRef.DynamicSpanID != "" {
-		if err := a.opts.TracerProvider.UpdateSpan(ctx, &tracing.UpdateSpanOptions{
-			Debug:      &tracing.SpanDebugData{Location: "router.AddRunMetadata.refreshTarget"},
-			Metadata:   stateMetadata,
-			TargetSpan: parentSpanRef,
-		}); err != nil {
-			return err
-		}
-	}
-
-	// Persist the cumulative metadata size delta back to the state store.
-	// Only persist when we successfully loaded from state; the fallback
-	// Metadata is request-local and has no backing store to update.
-	if loadedFromState {
-		if delta := stateMetadata.Metrics.SwapMetadataSizeDelta(); delta > 0 {
-			if err := statev2.TryIncrementMetadataSize(ctx, a.opts.State, stateMetadata.ID, delta); err != nil {
-				logger.StdlibLogger(ctx).Error("failed to persist metadata size delta",
-					"error", err,
-					"run_id", runID.String(),
-					"delta", delta,
-				)
-			}
-		}
-	}
-
-	return nil
 }
 
 // addRunMetadataLegacy is the original implementation for runs created before
@@ -349,86 +264,29 @@ func (a router) addRunMetadataLegacy(ctx context.Context, auth apiv1auth.V1Auth,
 		},
 	}
 
-	var stateMetadata *statev2.Metadata
-	loadedFromState := false
-	if a.opts.State != nil {
-		md, err := a.opts.State.LoadMetadata(ctx, stateID)
-		if errors.Is(err, statev2.ErrRunNotFound) || errors.Is(err, statev2.ErrMetadataNotFound) {
-			logger.StdlibLogger(ctx).Warn("failed to load run metadata for size limit check, falling back to request-local limit",
-				"error", err,
-				"run_id", runID.String(),
-			)
-		} else if err != nil {
-			return publicerr.Wrap(err, 500, "Unable to load run metadata")
-		} else {
-			stateMetadata = &md
-			loadedFromState = true
-		}
-	}
-
-	// Missing state uses a request-local fallback so this write still enforces
-	// the cumulative size limit within the request.
-	if stateMetadata == nil {
-		stateMetadata = &statev2.Metadata{ID: stateID}
-	}
-	statev2.InitConfig(&stateMetadata.Config)
-
 	parentSpanRef := &meta.SpanReference{
 		TraceParent:            fmt.Sprintf("00-%s-%s-00", parentSpan.TraceID, parentSpan.SpanID),
 		DynamicSpanID:          parentSpan.SpanID,
 		DynamicSpanTraceParent: fmt.Sprintf("00-%s-%s-00", parentSpan.TraceID, parentSpan.SpanID),
 	}
 
-	addTenantIDs := func(cfg *tracing.MetadataSpanConfig) {
-		meta.AddAttr(cfg.Attrs, meta.Attrs.AccountID, util.ToPtr(auth.AccountID()))
-		meta.AddAttr(cfg.Attrs, meta.Attrs.EnvID, util.ToPtr(auth.WorkspaceID()))
-		meta.AddAttr(cfg.Attrs, meta.Attrs.FunctionID, &parentSpan.FunctionID)
-		meta.AddAttr(cfg.Attrs, meta.Attrs.RunID, &parentSpan.RunID)
-		meta.AddAttr(cfg.Attrs, meta.Attrs.AppID, &parentSpan.AppID)
+	err = metadatawriter.Writer{
+		State:          a.opts.State,
+		TracerProvider: a.opts.TracerProvider,
+		PkgName:        pkgName,
+		// Missing state fallback is part of the existing SDK metadata contract.
+		AllowMissingState: true,
+	}.Write(ctx, metadatawriter.WriteRequest{
+		ID: stateID,
+		Items: metadatawriter.NewItems(req.Metadata, func(*statev2.Metadata) (*meta.SpanReference, metadata.Scope) {
+			return parentSpanRef, scope
+		}),
+		Location: "router.AddRunMetadata",
+	})
+	if errors.Is(err, metadatawriter.ErrLoadMetadata) {
+		return publicerr.Wrap(err, 500, "Unable to load run metadata")
 	}
-
-	for _, md := range req.Metadata {
-		_, err = tracing.CreateMetadataSpan(
-			ctx,
-			a.opts.TracerProvider,
-			parentSpanRef,
-			"router.AddRunMetadata",
-			pkgName,
-			stateMetadata,
-			md,
-			scope,
-			addTenantIDs,
-		)
-		if err != nil {
-			return err
-		}
-	}
-	if parentSpanRef != nil && parentSpanRef.DynamicSpanID != "" {
-		if err := a.opts.TracerProvider.UpdateSpan(ctx, &tracing.UpdateSpanOptions{
-			Debug:      &tracing.SpanDebugData{Location: "router.AddRunMetadata.refreshTarget"},
-			Metadata:   stateMetadata,
-			TargetSpan: parentSpanRef,
-		}); err != nil {
-			return err
-		}
-	}
-
-	// Persist the cumulative metadata size delta back to the state store.
-	// Only persist when we successfully loaded from state; the fallback
-	// Metadata is request-local and has no backing store to update.
-	if loadedFromState {
-		if delta := stateMetadata.Metrics.SwapMetadataSizeDelta(); delta > 0 {
-			if err := statev2.TryIncrementMetadataSize(ctx, a.opts.State, stateID, delta); err != nil {
-				logger.StdlibLogger(ctx).Error("failed to persist metadata size delta",
-					"error", err,
-					"run_id", runID.String(),
-					"delta", delta,
-				)
-			}
-		}
-	}
-
-	return nil
+	return err
 }
 
 func (a router) getParentSpan(ctx context.Context, auth apiv1auth.V1Auth, runID ulid.ULID, target *RunMetadataTarget) (*cqrs.OtelSpan, metadata.Scope, error) {

--- a/pkg/api/apiv1/metadata_test.go
+++ b/pkg/api/apiv1/metadata_test.go
@@ -36,9 +36,10 @@ func (r metadataTraceReader) GetLatestExecutionSpanByStepID(context.Context, uli
 }
 
 type metadataTracerProvider struct {
-	t      *testing.T
-	wantID statev2.ID
-	called bool
+	t       *testing.T
+	wantID  statev2.ID
+	called  bool
+	updated []*tracing.UpdateSpanOptions
 }
 
 type metadataStateLoader struct {
@@ -70,8 +71,9 @@ func (p *metadataTracerProvider) CreateDroppableSpan(context.Context, string, *t
 	return nil, errors.New("unexpected CreateDroppableSpan call")
 }
 
-func (p *metadataTracerProvider) UpdateSpan(context.Context, *tracing.UpdateSpanOptions) error {
-	return errors.New("unexpected UpdateSpan call")
+func (p *metadataTracerProvider) UpdateSpan(_ context.Context, opts *tracing.UpdateSpanOptions) error {
+	p.updated = append(p.updated, opts)
+	return nil
 }
 
 // newRunID returns a ULID with the current time (new path).
@@ -123,6 +125,8 @@ func TestAddRunMetadataNewPathUsesStateForTenantIDs(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, tp.called)
+	require.Len(t, tp.updated, 1)
+	require.NotNil(t, tp.updated[0].TargetSpan)
 }
 
 // TestAddRunMetadataNewPathFallbackToPartialIDWhenStateMissing verifies that
@@ -159,6 +163,8 @@ func TestAddRunMetadataNewPathFallbackToPartialIDWhenStateMissing(t *testing.T) 
 	})
 	require.NoError(t, err)
 	require.True(t, tp.called)
+	require.Len(t, tp.updated, 1)
+	require.NotNil(t, tp.updated[0].TargetSpan)
 }
 
 func TestAddRunMetadataReturnsTransientStateLoadError(t *testing.T) {

--- a/pkg/api/metadatawriter/writer.go
+++ b/pkg/api/metadatawriter/writer.go
@@ -92,6 +92,8 @@ func (w Writer) Write(ctx context.Context, req WriteRequest) error {
 		meta.AddAttr(cfg.Attrs, meta.Attrs.AppID, &stateMetadata.ID.Tenant.AppID)
 	}
 
+	targetSpans := make([]*meta.SpanReference, 0, len(req.Items))
+	seenTargetSpans := map[string]struct{}{}
 	for _, item := range req.Items {
 		parentSpanRef, scope := item.Parent(stateMetadata)
 		if _, err := tracing.CreateMetadataSpan(
@@ -105,6 +107,21 @@ func (w Writer) Write(ctx context.Context, req WriteRequest) error {
 			scope,
 			addTenantIDs,
 		); err != nil {
+			return err
+		}
+		if parentSpanRef != nil && parentSpanRef.DynamicSpanID != "" {
+			if _, ok := seenTargetSpans[parentSpanRef.DynamicSpanID]; !ok {
+				seenTargetSpans[parentSpanRef.DynamicSpanID] = struct{}{}
+				targetSpans = append(targetSpans, parentSpanRef)
+			}
+		}
+	}
+	for _, targetSpan := range targetSpans {
+		if err := tracerProvider.UpdateSpan(ctx, &tracing.UpdateSpanOptions{
+			Debug:      &tracing.SpanDebugData{Location: req.Location + ".refreshTarget"},
+			Metadata:   stateMetadata,
+			TargetSpan: targetSpan,
+		}); err != nil {
 			return err
 		}
 	}

--- a/pkg/api/metadatawriter/writer.go
+++ b/pkg/api/metadatawriter/writer.go
@@ -1,0 +1,162 @@
+package metadatawriter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
+	"github.com/inngest/inngest/pkg/util"
+)
+
+var ErrLoadMetadata = errors.New("unable to load run metadata")
+var ErrMissingMetadataItems = errors.New("missing metadata items")
+var ErrMissingParentResolver = errors.New("missing metadata parent resolver")
+
+// MissingStateLoader reconstructs run metadata when live execution state is gone.
+// Callers can leave this nil to either reject missing state or, when
+// AllowMissingState is true, use request-local metadata.
+type MissingStateLoader func(ctx context.Context, id statev2.ID) (*statev2.Metadata, error)
+
+// ParentResolver maps loaded run metadata to the metadata span's parent and
+// scope. API layers own target semantics; Writer owns persistence.
+type ParentResolver func(md *statev2.Metadata) (*meta.SpanReference, metadata.Scope)
+
+type Item struct {
+	Metadata metadata.Update
+	Parent   ParentResolver
+}
+
+func NewItems(updates []metadata.Update, parent ParentResolver) []Item {
+	items := make([]Item, 0, len(updates))
+	for _, update := range updates {
+		items = append(items, Item{
+			Metadata: update,
+			Parent:   parent,
+		})
+	}
+	return items
+}
+
+type Writer struct {
+	State              statev2.RunService
+	TracerProvider     tracing.TracerProvider
+	MissingStateLoader MissingStateLoader
+	PkgName            string
+
+	// AllowMissingState preserves SDK metadata behavior for finalized runs
+	// whose execution state has already been deleted. Missing state uses a
+	// request-local metadata value so the write still enforces the cumulative size
+	// limit within the request.
+	AllowMissingState bool
+}
+
+type WriteRequest struct {
+	ID       statev2.ID
+	Items    []Item
+	Location string
+}
+
+func (w Writer) Write(ctx context.Context, req WriteRequest) error {
+	// Load run metadata to enforce the per-run cumulative size limit against
+	// metadata that already exists in the run, not just this request.
+	stateMetadata, loadedFromState, err := w.loadMetadata(ctx, req.ID)
+	if err != nil {
+		return err
+	}
+	statev2.InitConfig(&stateMetadata.Config)
+
+	if len(req.Items) == 0 {
+		return ErrMissingMetadataItems
+	}
+	for _, item := range req.Items {
+		if item.Parent == nil {
+			return ErrMissingParentResolver
+		}
+	}
+
+	tracerProvider := w.TracerProvider
+	if tracerProvider == nil {
+		tracerProvider = tracing.NewNoopTracerProvider()
+	}
+
+	addTenantIDs := func(cfg *tracing.MetadataSpanConfig) {
+		meta.AddAttr(cfg.Attrs, meta.Attrs.AccountID, util.ToPtr(stateMetadata.ID.Tenant.AccountID))
+		meta.AddAttr(cfg.Attrs, meta.Attrs.EnvID, util.ToPtr(stateMetadata.ID.Tenant.EnvID))
+		meta.AddAttr(cfg.Attrs, meta.Attrs.FunctionID, &stateMetadata.ID.FunctionID)
+		meta.AddAttr(cfg.Attrs, meta.Attrs.RunID, &stateMetadata.ID.RunID)
+		meta.AddAttr(cfg.Attrs, meta.Attrs.AppID, &stateMetadata.ID.Tenant.AppID)
+	}
+
+	for _, item := range req.Items {
+		parentSpanRef, scope := item.Parent(stateMetadata)
+		if _, err := tracing.CreateMetadataSpan(
+			ctx,
+			tracerProvider,
+			parentSpanRef,
+			req.Location,
+			w.PkgName,
+			stateMetadata,
+			item.Metadata,
+			scope,
+			addTenantIDs,
+		); err != nil {
+			return err
+		}
+	}
+
+	// Persist the cumulative metadata size delta back to the state store.
+	// Only persist when we successfully loaded from state; reconstructed
+	// metadata has no backing store to update.
+	if delta := stateMetadata.Metrics.SwapMetadataSizeDelta(); loadedFromState && delta > 0 {
+		if err := statev2.TryIncrementMetadataSize(ctx, w.State, stateMetadata.ID, delta); err != nil {
+			logger.StdlibLogger(ctx).Error("failed to persist metadata size delta",
+				"error", err,
+				"run_id", stateMetadata.ID.RunID.String(),
+				"delta", delta,
+			)
+		}
+	}
+
+	return nil
+}
+
+func (w Writer) loadMetadata(ctx context.Context, id statev2.ID) (*statev2.Metadata, bool, error) {
+	var missingErr error
+	if w.State != nil {
+		md, err := w.State.LoadMetadata(ctx, id)
+		if err == nil {
+			return &md, true, nil
+		}
+		if !errors.Is(err, statev2.ErrRunNotFound) && !errors.Is(err, statev2.ErrMetadataNotFound) {
+			return nil, false, fmt.Errorf("%w: %w", ErrLoadMetadata, err)
+		}
+		missingErr = err
+	}
+
+	if w.MissingStateLoader != nil {
+		loaded, err := w.MissingStateLoader(ctx, id)
+		if err != nil {
+			return nil, false, err
+		}
+		if loaded != nil {
+			return loaded, false, nil
+		}
+	}
+
+	if !w.AllowMissingState {
+		return nil, false, statev2.ErrMetadataNotFound
+	}
+
+	if missingErr != nil {
+		logger.StdlibLogger(ctx).Warn("failed to load run metadata for size limit check, falling back to request-local limit",
+			"error", missingErr,
+			"run_id", id.RunID.String(),
+		)
+	}
+	return &statev2.Metadata{ID: id}, false, nil
+}

--- a/pkg/api/metadatawriter/writer_test.go
+++ b/pkg/api/metadatawriter/writer_test.go
@@ -1,0 +1,135 @@
+package metadatawriter
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/enums"
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriterPersistsMetadataSizeDeltaForLiveState(t *testing.T) {
+	runID := ulid.Make()
+	state := &writerState{
+		md: statev2.Metadata{
+			ID: statev2.ID{
+				RunID:      runID,
+				FunctionID: uuid.New(),
+				Tenant: statev2.Tenant{
+					AccountID: uuid.New(),
+					EnvID:     uuid.New(),
+					AppID:     uuid.New(),
+				},
+			},
+		},
+	}
+
+	err := Writer{
+		State:          state,
+		TracerProvider: writerTracer{},
+		PkgName:        "metadatawriter.test",
+	}.Write(context.Background(), WriteRequest{
+		ID: state.md.ID,
+		Items: NewItems([]metadata.Update{testMetadataUpdate(t)}, func(md *statev2.Metadata) (*meta.SpanReference, metadata.Scope) {
+			return &meta.SpanReference{DynamicSpanID: "parent"}, enums.MetadataScopeRun
+		}),
+		Location: "TestWriter",
+	})
+
+	require.NoError(t, err)
+	require.Positive(t, state.incremented)
+}
+
+func TestWriterUsesFallbackWithoutPersistingMetadataSizeDelta(t *testing.T) {
+	runID := ulid.Make()
+	accountID := uuid.New()
+	envID := uuid.New()
+	loaderCalled := false
+	state := &writerState{err: statev2.ErrMetadataNotFound}
+
+	err := Writer{
+		State:          state,
+		TracerProvider: writerTracer{},
+		MissingStateLoader: func(ctx context.Context, id statev2.ID) (*statev2.Metadata, error) {
+			loaderCalled = true
+			require.Equal(t, runID, id.RunID)
+			return &statev2.Metadata{
+				ID: statev2.ID{
+					RunID:      id.RunID,
+					FunctionID: uuid.New(),
+					Tenant: statev2.Tenant{
+						AccountID: id.Tenant.AccountID,
+						EnvID:     id.Tenant.EnvID,
+						AppID:     uuid.New(),
+					},
+				},
+			}, nil
+		},
+		PkgName: "metadatawriter.test",
+	}.Write(context.Background(), WriteRequest{
+		ID: statev2.ID{
+			RunID: runID,
+			Tenant: statev2.Tenant{
+				AccountID: accountID,
+				EnvID:     envID,
+			},
+		},
+		Items: NewItems([]metadata.Update{testMetadataUpdate(t)}, func(md *statev2.Metadata) (*meta.SpanReference, metadata.Scope) {
+			return &meta.SpanReference{DynamicSpanID: "parent"}, enums.MetadataScopeRun
+		}),
+		Location: "TestWriter",
+	})
+
+	require.NoError(t, err)
+	require.True(t, loaderCalled)
+	require.Zero(t, state.incremented)
+}
+
+func testMetadataUpdate(t *testing.T) metadata.Update {
+	t.Helper()
+
+	return metadata.Update{
+		RawUpdate: metadata.RawUpdate{
+			Kind:   metadata.KindInngestScore,
+			Op:     enums.MetadataOpcodeMerge,
+			Values: metadata.Values{"accuracy": json.RawMessage(`{"value":1}`)},
+		},
+	}
+}
+
+type writerState struct {
+	statev2.RunService
+	md          statev2.Metadata
+	err         error
+	incremented int
+}
+
+func (s *writerState) LoadMetadata(ctx context.Context, id statev2.ID, _ ...statev2.LoadMetadataOption) (statev2.Metadata, error) {
+	return s.md, s.err
+}
+
+func (s *writerState) IncrementMetadataSize(ctx context.Context, id statev2.ID, delta int) error {
+	s.incremented += delta
+	return nil
+}
+
+type writerTracer struct{}
+
+func (writerTracer) CreateSpan(ctx context.Context, name string, opts *tracing.CreateSpanOptions) (*meta.SpanReference, error) {
+	return &meta.SpanReference{DynamicSpanID: opts.DynamicSpanIDOverride}, nil
+}
+
+func (writerTracer) CreateDroppableSpan(context.Context, string, *tracing.CreateSpanOptions) (*tracing.DroppableSpan, error) {
+	return nil, nil
+}
+
+func (writerTracer) UpdateSpan(context.Context, *tracing.UpdateSpanOptions) error {
+	return nil
+}

--- a/pkg/api/metadatawriter/writer_test.go
+++ b/pkg/api/metadatawriter/writer_test.go
@@ -30,10 +30,11 @@ func TestWriterPersistsMetadataSizeDeltaForLiveState(t *testing.T) {
 			},
 		},
 	}
+	tracer := &writerTracer{}
 
 	err := Writer{
 		State:          state,
-		TracerProvider: writerTracer{},
+		TracerProvider: tracer,
 		PkgName:        "metadatawriter.test",
 	}.Write(context.Background(), WriteRequest{
 		ID: state.md.ID,
@@ -45,6 +46,8 @@ func TestWriterPersistsMetadataSizeDeltaForLiveState(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Positive(t, state.incremented)
+	require.Len(t, tracer.updated, 1)
+	require.Equal(t, "parent", tracer.updated[0].TargetSpan.DynamicSpanID)
 }
 
 func TestWriterUsesFallbackWithoutPersistingMetadataSizeDelta(t *testing.T) {
@@ -53,10 +56,11 @@ func TestWriterUsesFallbackWithoutPersistingMetadataSizeDelta(t *testing.T) {
 	envID := uuid.New()
 	loaderCalled := false
 	state := &writerState{err: statev2.ErrMetadataNotFound}
+	tracer := &writerTracer{}
 
 	err := Writer{
 		State:          state,
-		TracerProvider: writerTracer{},
+		TracerProvider: tracer,
 		MissingStateLoader: func(ctx context.Context, id statev2.ID) (*statev2.Metadata, error) {
 			loaderCalled = true
 			require.Equal(t, runID, id.RunID)
@@ -90,6 +94,8 @@ func TestWriterUsesFallbackWithoutPersistingMetadataSizeDelta(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, loaderCalled)
 	require.Zero(t, state.incremented)
+	require.Len(t, tracer.updated, 1)
+	require.Equal(t, "parent", tracer.updated[0].TargetSpan.DynamicSpanID)
 }
 
 func testMetadataUpdate(t *testing.T) metadata.Update {
@@ -120,16 +126,19 @@ func (s *writerState) IncrementMetadataSize(ctx context.Context, id statev2.ID, 
 	return nil
 }
 
-type writerTracer struct{}
+type writerTracer struct {
+	updated []*tracing.UpdateSpanOptions
+}
 
-func (writerTracer) CreateSpan(ctx context.Context, name string, opts *tracing.CreateSpanOptions) (*meta.SpanReference, error) {
+func (*writerTracer) CreateSpan(ctx context.Context, name string, opts *tracing.CreateSpanOptions) (*meta.SpanReference, error) {
 	return &meta.SpanReference{DynamicSpanID: opts.DynamicSpanIDOverride}, nil
 }
 
-func (writerTracer) CreateDroppableSpan(context.Context, string, *tracing.CreateSpanOptions) (*tracing.DroppableSpan, error) {
+func (*writerTracer) CreateDroppableSpan(context.Context, string, *tracing.CreateSpanOptions) (*tracing.DroppableSpan, error) {
 	return nil, nil
 }
 
-func (writerTracer) UpdateSpan(context.Context, *tracing.UpdateSpanOptions) error {
+func (t *writerTracer) UpdateSpan(_ context.Context, opts *tracing.UpdateSpanOptions) error {
+	t.updated = append(t.updated, opts)
 	return nil
 }

--- a/pkg/api/v2/endpoints_scores.go
+++ b/pkg/api/v2/endpoints_scores.go
@@ -1,0 +1,175 @@
+package apiv2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+
+	"github.com/inngest/inngest/pkg/api/v2/apiv2base"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
+	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
+	"github.com/oklog/ulid/v2"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const maxScoreBatchSize = 100
+
+func (s *Service) CreateScore(ctx context.Context, req *apiv2.CreateScoreRequest) (*apiv2.CreateScoreResponse, error) {
+	if req.RunId == "" {
+		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorMissingField, "Run ID is required")
+	}
+
+	if result := s.rateLimiter.CheckRateLimit(ctx, apiv2.V2_CreateScore_FullMethodName); result.Limited {
+		return nil, s.base.NewError(http.StatusTooManyRequests, apiv2base.ErrorRateLimited, "API rate limit exceeded. The request was rejected and no score was recorded.")
+	}
+
+	if s.scores == nil {
+		return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Create score is not yet implemented")
+	}
+
+	runID, err := ulid.Parse(decodePathParam(req.RunId))
+	if err != nil {
+		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, "Run ID must be a valid ULID")
+	}
+
+	scoreInputs, err := scoreInputsFromRequest(req)
+	if err != nil {
+		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, err.Error())
+	}
+
+	err = s.scores.CreateScores(ctx, CreateScoresParams{
+		RunID:  runID,
+		Scores: scoreInputs,
+	})
+	switch {
+	case errors.Is(err, ErrScoresNotEnabled):
+		return nil, s.base.NewError(http.StatusForbidden, apiv2base.ErrorAccessDenied, "Scores are not enabled for this account")
+	case errors.Is(err, ErrScoreTargetNotFound):
+		return nil, s.base.NewError(http.StatusNotFound, apiv2base.ErrorNotFound, "Run or step not found")
+	case errors.Is(err, metadata.ErrMetadataSpanTooLarge), errors.Is(err, metadata.ErrRunMetadataSizeExceeded):
+		return nil, s.base.NewError(http.StatusRequestEntityTooLarge, apiv2base.ErrorValidationError, "Score exceeds the run metadata size limit")
+	case err != nil:
+		return nil, s.base.NewError(http.StatusInternalServerError, apiv2base.ErrorInternalError, "Unable to record score")
+	}
+
+	scores := make([]*apiv2.Score, 0, len(scoreInputs))
+	for _, score := range scoreInputs {
+		var experiment *apiv2.ScoreExperiment
+		if score.Experiment != nil {
+			experiment = &apiv2.ScoreExperiment{
+				ExperimentName: score.Experiment.ExperimentName,
+				Variant:        score.Experiment.Variant,
+			}
+		}
+		scores = append(scores, &apiv2.Score{
+			RunId:      runID.String(),
+			Name:       score.Name,
+			Value:      scoreProtoValue(score.Value),
+			StepId:     score.StepID,
+			Experiment: experiment,
+		})
+	}
+
+	return &apiv2.CreateScoreResponse{
+		Data: scores,
+		Metadata: &apiv2.ResponseMetadata{
+			FetchedAt: timestamppb.Now(),
+		},
+	}, nil
+}
+
+func scoreInputsFromRequest(req *apiv2.CreateScoreRequest) ([]ScoreInput, error) {
+	if len(req.Scores) == 0 {
+		return nil, fmt.Errorf("At least one score is required")
+	}
+	if len(req.Scores) > maxScoreBatchSize {
+		return nil, fmt.Errorf("At most %d scores are allowed", maxScoreBatchSize)
+	}
+
+	scores := make([]ScoreInput, 0, len(req.Scores))
+	for i, score := range req.Scores {
+		input, err := scoreInputFromFields(score.Name, score.Value, score.StepId, score.Experiment)
+		if err != nil {
+			return nil, fmt.Errorf("scores[%d]: %w", i, err)
+		}
+		scores = append(scores, input)
+	}
+	return scores, nil
+}
+
+func scoreInputFromFields(name string, rawValue *structpb.Value, stepID *string, experiment *apiv2.ScoreExperiment) (ScoreInput, error) {
+	if strings.TrimSpace(name) == "" {
+		return ScoreInput{}, fmt.Errorf("Score name is required")
+	}
+	if rawValue == nil {
+		return ScoreInput{}, fmt.Errorf("Score value is required")
+	}
+
+	value, err := scoreValue(rawValue)
+	if err != nil {
+		return ScoreInput{}, err
+	}
+
+	if stepID != nil && strings.TrimSpace(*stepID) == "" {
+		return ScoreInput{}, fmt.Errorf("Step ID must not be empty when provided")
+	}
+
+	// Apply the same name and value rules as SDK score submission before
+	// handing off to the provider.
+	if _, err := ScoreMetadataUpdate(name, value); err != nil {
+		return ScoreInput{}, fmt.Errorf("Score name or value is invalid; names must be at most %d UTF-8 bytes, must not contain control characters or single quotes, and values must be a finite number or boolean", metadata.MaxScoreNameByteLength)
+	}
+
+	var experimentInput *ScoreExperimentInput
+	if experiment != nil {
+		if strings.TrimSpace(experiment.ExperimentName) == "" {
+			return ScoreInput{}, fmt.Errorf("Experiment name is required when experiment is provided")
+		}
+		if strings.TrimSpace(experiment.Variant) == "" {
+			return ScoreInput{}, fmt.Errorf("Experiment variant is required when experiment is provided")
+		}
+		experimentInput = &ScoreExperimentInput{
+			ExperimentName: experiment.ExperimentName,
+			Variant:        experiment.Variant,
+		}
+		if _, err := ScoreExperimentMetadataUpdate(*experimentInput); err != nil {
+			return ScoreInput{}, fmt.Errorf("Experiment metadata is invalid")
+		}
+	}
+
+	return ScoreInput{
+		StepID:     stepID,
+		Experiment: experimentInput,
+		Name:       name,
+		Value:      value,
+	}, nil
+}
+
+func scoreValue(value *structpb.Value) (any, error) {
+	switch kind := value.GetKind().(type) {
+	case *structpb.Value_NumberValue:
+		if math.IsNaN(kind.NumberValue) || math.IsInf(kind.NumberValue, 0) {
+			return nil, fmt.Errorf("Score value must be a finite number or boolean")
+		}
+		return kind.NumberValue, nil
+	case *structpb.Value_BoolValue:
+		return kind.BoolValue, nil
+	default:
+		return nil, fmt.Errorf("Score value must be a finite number or boolean")
+	}
+}
+
+func scoreProtoValue(value any) *structpb.Value {
+	switch v := value.(type) {
+	case bool:
+		return structpb.NewBoolValue(v)
+	case float64:
+		return structpb.NewNumberValue(v)
+	default:
+		return structpb.NewNullValue()
+	}
+}

--- a/pkg/api/v2/endpoints_scores.go
+++ b/pkg/api/v2/endpoints_scores.go
@@ -16,7 +16,10 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-const maxScoreBatchSize = 100
+const (
+	maxScoreBatchSize                 = 100
+	maxScoreExperimentFieldByteLength = metadata.MaxScoreNameByteLength
+)
 
 func (s *Service) CreateScore(ctx context.Context, req *apiv2.CreateScoreRequest) (*apiv2.CreateScoreResponse, error) {
 	if req.RunId == "" {
@@ -61,8 +64,8 @@ func (s *Service) CreateScore(ctx context.Context, req *apiv2.CreateScoreRequest
 		var experiment *apiv2.ScoreExperiment
 		if score.Experiment != nil {
 			experiment = &apiv2.ScoreExperiment{
-				ExperimentName: score.Experiment.ExperimentName,
-				Variant:        score.Experiment.Variant,
+				Id:      score.Experiment.ExperimentName,
+				Variant: score.Experiment.Variant,
 			}
 		}
 		scores = append(scores, &apiv2.Score{
@@ -121,34 +124,44 @@ func scoreInputFromFields(name string, rawValue *structpb.Value, stepID *string,
 		return ScoreInput{}, fmt.Errorf("Experiment scores must be run-scoped")
 	}
 
-	// Apply the same name and value rules as SDK score submission before
-	// handing off to the provider.
-	if _, err := ScoreMetadataUpdate(name, value); err != nil {
+	scoreUpdate, err := ScoreMetadataUpdate(name, value)
+	if err != nil {
 		return ScoreInput{}, fmt.Errorf("Score name or value is invalid; names must be at most %d UTF-8 bytes, must not contain control characters or single quotes, and values must be a finite number or boolean", metadata.MaxScoreNameByteLength)
 	}
 
+	updates := make([]metadata.Update, 0, 2)
 	var experimentInput *ScoreExperimentInput
 	if experiment != nil {
-		if strings.TrimSpace(experiment.ExperimentName) == "" {
-			return ScoreInput{}, fmt.Errorf("Experiment name is required when experiment is provided")
+		if strings.TrimSpace(experiment.Id) == "" {
+			return ScoreInput{}, fmt.Errorf("Experiment ID is required when experiment is provided")
+		}
+		if len(experiment.Id) > maxScoreExperimentFieldByteLength {
+			return ScoreInput{}, fmt.Errorf("Experiment ID must be at most %d UTF-8 bytes", maxScoreExperimentFieldByteLength)
 		}
 		if strings.TrimSpace(experiment.Variant) == "" {
 			return ScoreInput{}, fmt.Errorf("Experiment variant is required when experiment is provided")
 		}
+		if len(experiment.Variant) > maxScoreExperimentFieldByteLength {
+			return ScoreInput{}, fmt.Errorf("Experiment variant must be at most %d UTF-8 bytes", maxScoreExperimentFieldByteLength)
+		}
 		experimentInput = &ScoreExperimentInput{
-			ExperimentName: experiment.ExperimentName,
+			ExperimentName: experiment.Id,
 			Variant:        experiment.Variant,
 		}
-		if _, err := ScoreExperimentMetadataUpdate(*experimentInput); err != nil {
+		experimentUpdate, err := ScoreExperimentMetadataUpdate(*experimentInput)
+		if err != nil {
 			return ScoreInput{}, fmt.Errorf("Experiment metadata is invalid")
 		}
+		updates = append(updates, experimentUpdate)
 	}
+	updates = append(updates, scoreUpdate)
 
 	return ScoreInput{
 		StepID:     stepID,
 		Experiment: experimentInput,
 		Name:       name,
 		Value:      value,
+		Metadata:   updates,
 	}, nil
 }
 

--- a/pkg/api/v2/endpoints_scores.go
+++ b/pkg/api/v2/endpoints_scores.go
@@ -117,6 +117,9 @@ func scoreInputFromFields(name string, rawValue *structpb.Value, stepID *string,
 	if stepID != nil && strings.TrimSpace(*stepID) == "" {
 		return ScoreInput{}, fmt.Errorf("Step ID must not be empty when provided")
 	}
+	if stepID != nil && experiment != nil {
+		return ScoreInput{}, fmt.Errorf("Experiment scores must be run-scoped")
+	}
 
 	// Apply the same name and value rules as SDK score submission before
 	// handing off to the provider.

--- a/pkg/api/v2/endpoints_scores_test.go
+++ b/pkg/api/v2/endpoints_scores_test.go
@@ -510,20 +510,6 @@ func TestStateScoreProviderValidatesStepTargets(t *testing.T) {
 		require.ErrorIs(t, err, ErrScoreTargetNotFound)
 	})
 
-	t.Run("rejects already hashed step IDs", func(t *testing.T) {
-		provider := NewStateScoreProvider(baseOpts)
-		stepID := scoreTraceStepID(existingStepID)
-
-		err := provider.CreateScores(context.Background(), CreateScoresParams{
-			RunID: runID,
-			Scores: []ScoreInput{
-				testScoreInput(t, ScoreInput{StepID: &stepID, Name: "accuracy", Value: 1.0}),
-			},
-		})
-
-		require.ErrorIs(t, err, ErrScoreTargetNotFound)
-	})
-
 	t.Run("preserves state load errors", func(t *testing.T) {
 		loadErr := errors.New("state unavailable")
 		opts := baseOpts
@@ -568,6 +554,32 @@ func TestStateScoreProviderValidatesStepTargets(t *testing.T) {
 
 		require.NoError(t, err)
 		require.True(t, called)
+	})
+}
+
+func TestScoreStepIDForSpan(t *testing.T) {
+	stepID := "generate-summary"
+	traceStepID := scoreTraceStepID(stepID)
+
+	t.Run("uses hashed step ID from state", func(t *testing.T) {
+		got, ok := scoreStepIDForSpan(&statev2.Metadata{Stack: []string{traceStepID}}, stepID)
+
+		require.True(t, ok)
+		require.Equal(t, traceStepID, got)
+	})
+
+	t.Run("uses raw step ID from state", func(t *testing.T) {
+		got, ok := scoreStepIDForSpan(&statev2.Metadata{Stack: []string{stepID}}, stepID)
+
+		require.True(t, ok)
+		require.Equal(t, stepID, got)
+	})
+
+	t.Run("does not accept already hashed trace step IDs", func(t *testing.T) {
+		got, ok := scoreStepIDForSpan(&statev2.Metadata{Stack: []string{traceStepID}}, traceStepID)
+
+		require.False(t, ok)
+		require.Empty(t, got)
 	})
 }
 

--- a/pkg/api/v2/endpoints_scores_test.go
+++ b/pkg/api/v2/endpoints_scores_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/enums"
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
-	"github.com/inngest/inngest/pkg/tracing"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
 	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
 	"github.com/oklog/ulid/v2"
@@ -245,6 +244,24 @@ func TestCreateScore(t *testing.T) {
 			message: "scores[0]: Experiment variant is required",
 		},
 		{
+			name: "experiment with step id",
+			req: &apiv2.CreateScoreRequest{
+				RunId: runID.String(),
+				Scores: []*apiv2.CreateScoreInput{
+					{
+						Name:   "accuracy",
+						Value:  structpb.NewNumberValue(1),
+						StepId: &stepID,
+						Experiment: &apiv2.ScoreExperiment{
+							ExperimentName: "model-routing",
+							Variant:        "baseline",
+						},
+					},
+				},
+			},
+			message: "scores[0]: Experiment scores must be run-scoped",
+		},
+		{
 			name: "empty scores",
 			req: &apiv2.CreateScoreRequest{
 				RunId: runID.String(),
@@ -346,24 +363,6 @@ func TestScoreExperimentMetadataUpdate(t *testing.T) {
 		"name":    json.RawMessage(`"model-routing"`),
 		"variant": json.RawMessage(`"baseline"`),
 	}, update.RawUpdate.Values)
-}
-
-func TestScoreParentSpanRefHashesSDKStepID(t *testing.T) {
-	runID := ulid.MustParse("01KVDHCS8VTWZHBAHTMYJHBPKJ")
-	stepID := "step 1"
-	stableStepID := "b436f063682815df5b5fd9780200a9e4e8d4f0b3"
-	md := &statev2.Metadata{
-		ID: statev2.ID{RunID: runID},
-	}
-
-	ref, scope := scoreParentSpanRef(md, &stepID)
-	expected := tracing.FinalizedStepSpanRefFromMetadataAndStepID(md, stableStepID)
-
-	require.Equal(t, enums.MetadataScopeStep, scope)
-	require.NotNil(t, ref)
-	require.Equal(t, expected.DynamicSpanID, ref.DynamicSpanID)
-	require.Equal(t, expected.DynamicSpanTraceParent, ref.DynamicSpanTraceParent)
-	require.Equal(t, expected.TraceParent, ref.TraceParent)
 }
 
 func TestStateScoreProviderFlagDisabled(t *testing.T) {
@@ -475,6 +474,24 @@ func TestStateScoreProviderValidatesStepTargets(t *testing.T) {
 		})
 
 		require.ErrorIs(t, err, ErrScoreTargetNotFound)
+	})
+
+	t.Run("preserves state load errors", func(t *testing.T) {
+		loadErr := errors.New("state unavailable")
+		opts := baseOpts
+		opts.State = fakeScoreRunService{err: loadErr}
+		provider := NewStateScoreProvider(opts)
+		stepID := existingStepID
+
+		err := provider.CreateScores(context.Background(), CreateScoresParams{
+			RunID: runID,
+			Scores: []ScoreInput{
+				{StepID: &stepID, Name: "accuracy", Value: 1.0},
+			},
+		})
+
+		require.ErrorIs(t, err, loadErr)
+		require.NotErrorIs(t, err, ErrScoreTargetNotFound)
 	})
 
 	t.Run("falls back to trace validator", func(t *testing.T) {

--- a/pkg/api/v2/endpoints_scores_test.go
+++ b/pkg/api/v2/endpoints_scores_test.go
@@ -88,8 +88,8 @@ func TestCreateScore(t *testing.T) {
 					Name:  "accuracy",
 					Value: structpb.NewNumberValue(0.98),
 					Experiment: &apiv2.ScoreExperiment{
-						ExperimentName: "model-routing",
-						Variant:        "baseline",
+						Id:      "model-routing",
+						Variant: "baseline",
 					},
 				},
 			},
@@ -103,7 +103,7 @@ func TestCreateScore(t *testing.T) {
 		require.Equal(t, "baseline", provider.params.Scores[0].Experiment.Variant)
 		require.Len(t, resp.Data, 1)
 		require.NotNil(t, resp.Data[0].Experiment)
-		require.Equal(t, "model-routing", resp.Data[0].Experiment.ExperimentName)
+		require.Equal(t, "model-routing", resp.Data[0].Experiment.Id)
 		require.Equal(t, "baseline", resp.Data[0].Experiment.Variant)
 	})
 
@@ -224,24 +224,58 @@ func TestCreateScore(t *testing.T) {
 			message: "scores[0]: Step ID must not be empty",
 		},
 		{
-			name: "experiment missing name",
+			name: "experiment missing id",
 			req: &apiv2.CreateScoreRequest{
 				RunId: runID.String(),
 				Scores: []*apiv2.CreateScoreInput{
 					{Name: "accuracy", Value: structpb.NewNumberValue(1), Experiment: &apiv2.ScoreExperiment{Variant: "baseline"}},
 				},
 			},
-			message: "scores[0]: Experiment name is required",
+			message: "scores[0]: Experiment ID is required",
 		},
 		{
 			name: "experiment missing variant",
 			req: &apiv2.CreateScoreRequest{
 				RunId: runID.String(),
 				Scores: []*apiv2.CreateScoreInput{
-					{Name: "accuracy", Value: structpb.NewNumberValue(1), Experiment: &apiv2.ScoreExperiment{ExperimentName: "model-routing"}},
+					{Name: "accuracy", Value: structpb.NewNumberValue(1), Experiment: &apiv2.ScoreExperiment{Id: "model-routing"}},
 				},
 			},
 			message: "scores[0]: Experiment variant is required",
+		},
+		{
+			name: "experiment id too long",
+			req: &apiv2.CreateScoreRequest{
+				RunId: runID.String(),
+				Scores: []*apiv2.CreateScoreInput{
+					{
+						Name:  "accuracy",
+						Value: structpb.NewNumberValue(1),
+						Experiment: &apiv2.ScoreExperiment{
+							Id:      strings.Repeat("a", metadata.MaxScoreNameByteLength+1),
+							Variant: "baseline",
+						},
+					},
+				},
+			},
+			message: "scores[0]: Experiment ID must be at most 128 UTF-8 bytes",
+		},
+		{
+			name: "experiment variant too long",
+			req: &apiv2.CreateScoreRequest{
+				RunId: runID.String(),
+				Scores: []*apiv2.CreateScoreInput{
+					{
+						Name:  "accuracy",
+						Value: structpb.NewNumberValue(1),
+						Experiment: &apiv2.ScoreExperiment{
+							Id:      "model-routing",
+							Variant: strings.Repeat("a", metadata.MaxScoreNameByteLength+1),
+						},
+					},
+				},
+			},
+			message: "scores[0]: Experiment variant must be at most 128 UTF-8 bytes",
 		},
 		{
 			name: "experiment with step id",
@@ -253,8 +287,8 @@ func TestCreateScore(t *testing.T) {
 						Value:  structpb.NewNumberValue(1),
 						StepId: &stepID,
 						Experiment: &apiv2.ScoreExperiment{
-							ExperimentName: "model-routing",
-							Variant:        "baseline",
+							Id:      "model-routing",
+							Variant: "baseline",
 						},
 					},
 				},
@@ -417,7 +451,7 @@ func TestStateScoreProviderUsesMetadataLoaderForFinalizedRun(t *testing.T) {
 	err := provider.CreateScores(context.Background(), CreateScoresParams{
 		RunID: runID,
 		Scores: []ScoreInput{
-			{Name: "accuracy", Value: 1.0},
+			testScoreInput(t, ScoreInput{Name: "accuracy", Value: 1.0}),
 		},
 	})
 	require.NoError(t, err)
@@ -455,7 +489,7 @@ func TestStateScoreProviderValidatesStepTargets(t *testing.T) {
 		err := provider.CreateScores(context.Background(), CreateScoresParams{
 			RunID: runID,
 			Scores: []ScoreInput{
-				{StepID: &stepID, Name: "accuracy", Value: 1.0},
+				testScoreInput(t, ScoreInput{StepID: &stepID, Name: "accuracy", Value: 1.0}),
 			},
 		})
 
@@ -469,7 +503,21 @@ func TestStateScoreProviderValidatesStepTargets(t *testing.T) {
 		err := provider.CreateScores(context.Background(), CreateScoresParams{
 			RunID: runID,
 			Scores: []ScoreInput{
-				{StepID: &stepID, Name: "accuracy", Value: 1.0},
+				testScoreInput(t, ScoreInput{StepID: &stepID, Name: "accuracy", Value: 1.0}),
+			},
+		})
+
+		require.ErrorIs(t, err, ErrScoreTargetNotFound)
+	})
+
+	t.Run("rejects already hashed step IDs", func(t *testing.T) {
+		provider := NewStateScoreProvider(baseOpts)
+		stepID := scoreTraceStepID(existingStepID)
+
+		err := provider.CreateScores(context.Background(), CreateScoresParams{
+			RunID: runID,
+			Scores: []ScoreInput{
+				testScoreInput(t, ScoreInput{StepID: &stepID, Name: "accuracy", Value: 1.0}),
 			},
 		})
 
@@ -486,7 +534,7 @@ func TestStateScoreProviderValidatesStepTargets(t *testing.T) {
 		err := provider.CreateScores(context.Background(), CreateScoresParams{
 			RunID: runID,
 			Scores: []ScoreInput{
-				{StepID: &stepID, Name: "accuracy", Value: 1.0},
+				testScoreInput(t, ScoreInput{StepID: &stepID, Name: "accuracy", Value: 1.0}),
 			},
 		})
 
@@ -514,13 +562,29 @@ func TestStateScoreProviderValidatesStepTargets(t *testing.T) {
 		err := provider.CreateScores(context.Background(), CreateScoresParams{
 			RunID: runID,
 			Scores: []ScoreInput{
-				{StepID: &stepID, Name: "accuracy", Value: 1.0},
+				testScoreInput(t, ScoreInput{StepID: &stepID, Name: "accuracy", Value: 1.0}),
 			},
 		})
 
 		require.NoError(t, err)
 		require.True(t, called)
 	})
+}
+
+func testScoreInput(t *testing.T, input ScoreInput) ScoreInput {
+	t.Helper()
+
+	updates := make([]metadata.Update, 0, 2)
+	if input.Experiment != nil {
+		update, err := ScoreExperimentMetadataUpdate(*input.Experiment)
+		require.NoError(t, err)
+		updates = append(updates, update)
+	}
+
+	update, err := ScoreMetadataUpdate(input.Name, input.Value)
+	require.NoError(t, err)
+	input.Metadata = append(updates, update)
+	return input
 }
 
 func testScoreInputs(count int) []*apiv2.CreateScoreInput {

--- a/pkg/api/v2/endpoints_scores_test.go
+++ b/pkg/api/v2/endpoints_scores_test.go
@@ -1,0 +1,527 @@
+package apiv2
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/enums"
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
+	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type fakeScoreProvider struct {
+	err    error
+	params *CreateScoresParams
+}
+
+func (f *fakeScoreProvider) CreateScores(ctx context.Context, params CreateScoresParams) error {
+	f.params = &params
+	return f.err
+}
+
+func TestCreateScore(t *testing.T) {
+	runID := ulid.MustParse("01HP1ZX8M3NG9VP6QN0XK7J4CY")
+	stepID := "generate-summary"
+
+	t.Run("records a numeric run score", func(t *testing.T) {
+		provider := &fakeScoreProvider{}
+		service := NewService(ServiceOptions{Scores: provider})
+
+		resp, err := service.CreateScore(context.Background(), &apiv2.CreateScoreRequest{
+			RunId: runID.String(),
+			Scores: []*apiv2.CreateScoreInput{
+				{Name: "accuracy", Value: structpb.NewNumberValue(0.95)},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, provider.params)
+		require.Equal(t, runID, provider.params.RunID)
+		require.Len(t, provider.params.Scores, 1)
+		require.Nil(t, provider.params.Scores[0].StepID)
+		require.Equal(t, "accuracy", provider.params.Scores[0].Name)
+		require.Equal(t, 0.95, provider.params.Scores[0].Value)
+		require.Len(t, resp.Data, 1)
+		require.Equal(t, runID.String(), resp.Data[0].RunId)
+		require.Equal(t, "accuracy", resp.Data[0].Name)
+		require.Equal(t, 0.95, resp.Data[0].Value.GetNumberValue())
+		require.Nil(t, resp.Data[0].StepId)
+		require.NotNil(t, resp.Metadata.FetchedAt)
+	})
+
+	t.Run("records a boolean step score", func(t *testing.T) {
+		provider := &fakeScoreProvider{}
+		service := NewService(ServiceOptions{Scores: provider})
+
+		resp, err := service.CreateScore(context.Background(), &apiv2.CreateScoreRequest{
+			RunId: runID.String(),
+			Scores: []*apiv2.CreateScoreInput{
+				{Name: "passed", Value: structpb.NewBoolValue(true), StepId: &stepID},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, provider.params)
+		require.Len(t, provider.params.Scores, 1)
+		require.Equal(t, &stepID, provider.params.Scores[0].StepID)
+		require.Equal(t, true, provider.params.Scores[0].Value)
+		require.Equal(t, &stepID, resp.Data[0].StepId)
+		require.True(t, resp.Data[0].Value.GetBoolValue())
+	})
+
+	t.Run("records an experiment score", func(t *testing.T) {
+		provider := &fakeScoreProvider{}
+		service := NewService(ServiceOptions{Scores: provider})
+
+		resp, err := service.CreateScore(context.Background(), &apiv2.CreateScoreRequest{
+			RunId: runID.String(),
+			Scores: []*apiv2.CreateScoreInput{
+				{
+					Name:  "accuracy",
+					Value: structpb.NewNumberValue(0.98),
+					Experiment: &apiv2.ScoreExperiment{
+						ExperimentName: "model-routing",
+						Variant:        "baseline",
+					},
+				},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, provider.params)
+		require.Len(t, provider.params.Scores, 1)
+		require.NotNil(t, provider.params.Scores[0].Experiment)
+		require.Equal(t, "model-routing", provider.params.Scores[0].Experiment.ExperimentName)
+		require.Equal(t, "baseline", provider.params.Scores[0].Experiment.Variant)
+		require.Len(t, resp.Data, 1)
+		require.NotNil(t, resp.Data[0].Experiment)
+		require.Equal(t, "model-routing", resp.Data[0].Experiment.ExperimentName)
+		require.Equal(t, "baseline", resp.Data[0].Experiment.Variant)
+	})
+
+	t.Run("records multiple step scores", func(t *testing.T) {
+		provider := &fakeScoreProvider{}
+		service := NewService(ServiceOptions{Scores: provider})
+		firstStepID := "extract"
+		secondStepID := "summarize"
+
+		resp, err := service.CreateScore(context.Background(), &apiv2.CreateScoreRequest{
+			RunId: runID.String(),
+			Scores: []*apiv2.CreateScoreInput{
+				{Name: "accuracy", Value: structpb.NewNumberValue(0.95), StepId: &firstStepID},
+				{Name: "passed", Value: structpb.NewBoolValue(true), StepId: &secondStepID},
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, provider.params)
+		require.Len(t, provider.params.Scores, 2)
+		require.Equal(t, &firstStepID, provider.params.Scores[0].StepID)
+		require.Equal(t, "accuracy", provider.params.Scores[0].Name)
+		require.Equal(t, 0.95, provider.params.Scores[0].Value)
+		require.Equal(t, &secondStepID, provider.params.Scores[1].StepID)
+		require.Equal(t, "passed", provider.params.Scores[1].Name)
+		require.Equal(t, true, provider.params.Scores[1].Value)
+		require.Len(t, resp.Data, 2)
+		require.Equal(t, &firstStepID, resp.Data[0].StepId)
+		require.Equal(t, &secondStepID, resp.Data[1].StepId)
+	})
+
+	t.Run("not implemented without a provider", func(t *testing.T) {
+		service := NewService(ServiceOptions{})
+
+		resp, err := service.CreateScore(context.Background(), &apiv2.CreateScoreRequest{
+			RunId: runID.String(),
+			Scores: []*apiv2.CreateScoreInput{
+				{Name: "accuracy", Value: structpb.NewNumberValue(1)},
+			},
+		})
+
+		require.Nil(t, resp)
+		require.ErrorContains(t, err, "not yet implemented")
+	})
+
+	invalid := []struct {
+		name    string
+		req     *apiv2.CreateScoreRequest
+		message string
+	}{
+		{
+			name: "missing run id",
+			req: &apiv2.CreateScoreRequest{
+				Scores: []*apiv2.CreateScoreInput{
+					{Name: "accuracy", Value: structpb.NewNumberValue(1)},
+				},
+			},
+			message: "Run ID is required",
+		},
+		{
+			name:    "missing name",
+			req:     &apiv2.CreateScoreRequest{RunId: runID.String(), Scores: []*apiv2.CreateScoreInput{{Value: structpb.NewNumberValue(1)}}},
+			message: "scores[0]: Score name is required",
+		},
+		{
+			name:    "blank name",
+			req:     &apiv2.CreateScoreRequest{RunId: runID.String(), Scores: []*apiv2.CreateScoreInput{{Name: "   ", Value: structpb.NewNumberValue(1)}}},
+			message: "scores[0]: Score name is required",
+		},
+		{
+			name:    "name too long",
+			req:     &apiv2.CreateScoreRequest{RunId: runID.String(), Scores: []*apiv2.CreateScoreInput{{Name: strings.Repeat("a", metadata.MaxScoreNameByteLength+1), Value: structpb.NewNumberValue(1)}}},
+			message: "scores[0]: Score name or value is invalid",
+		},
+		{
+			name:    "missing value",
+			req:     &apiv2.CreateScoreRequest{RunId: runID.String(), Scores: []*apiv2.CreateScoreInput{{Name: "accuracy"}}},
+			message: "scores[0]: Score value is required",
+		},
+		{
+			name:    "invalid run id",
+			req:     &apiv2.CreateScoreRequest{RunId: "not-a-ulid", Scores: []*apiv2.CreateScoreInput{{Name: "accuracy", Value: structpb.NewNumberValue(1)}}},
+			message: "Run ID must be a valid ULID",
+		},
+		{
+			name:    "string value",
+			req:     &apiv2.CreateScoreRequest{RunId: runID.String(), Scores: []*apiv2.CreateScoreInput{{Name: "accuracy", Value: structpb.NewStringValue("high")}}},
+			message: "scores[0]: Score value must be a finite number or boolean",
+		},
+		{
+			name:    "null value",
+			req:     &apiv2.CreateScoreRequest{RunId: runID.String(), Scores: []*apiv2.CreateScoreInput{{Name: "accuracy", Value: structpb.NewNullValue()}}},
+			message: "scores[0]: Score value must be a finite number or boolean",
+		},
+		{
+			name:    "name with single quote",
+			req:     &apiv2.CreateScoreRequest{RunId: runID.String(), Scores: []*apiv2.CreateScoreInput{{Name: "bad'name", Value: structpb.NewNumberValue(1)}}},
+			message: "scores[0]: Score name or value is invalid",
+		},
+		{
+			name: "empty step id",
+			req: &apiv2.CreateScoreRequest{
+				RunId: runID.String(),
+				Scores: []*apiv2.CreateScoreInput{
+					{Name: "accuracy", Value: structpb.NewNumberValue(1), StepId: func() *string { s := ""; return &s }()},
+				},
+			},
+			message: "scores[0]: Step ID must not be empty",
+		},
+		{
+			name: "blank step id",
+			req: &apiv2.CreateScoreRequest{
+				RunId: runID.String(),
+				Scores: []*apiv2.CreateScoreInput{
+					{Name: "accuracy", Value: structpb.NewNumberValue(1), StepId: func() *string { s := "   "; return &s }()},
+				},
+			},
+			message: "scores[0]: Step ID must not be empty",
+		},
+		{
+			name: "experiment missing name",
+			req: &apiv2.CreateScoreRequest{
+				RunId: runID.String(),
+				Scores: []*apiv2.CreateScoreInput{
+					{Name: "accuracy", Value: structpb.NewNumberValue(1), Experiment: &apiv2.ScoreExperiment{Variant: "baseline"}},
+				},
+			},
+			message: "scores[0]: Experiment name is required",
+		},
+		{
+			name: "experiment missing variant",
+			req: &apiv2.CreateScoreRequest{
+				RunId: runID.String(),
+				Scores: []*apiv2.CreateScoreInput{
+					{Name: "accuracy", Value: structpb.NewNumberValue(1), Experiment: &apiv2.ScoreExperiment{ExperimentName: "model-routing"}},
+				},
+			},
+			message: "scores[0]: Experiment variant is required",
+		},
+		{
+			name: "empty scores",
+			req: &apiv2.CreateScoreRequest{
+				RunId: runID.String(),
+			},
+			message: "At least one score is required",
+		},
+		{
+			name: "too many scores",
+			req: &apiv2.CreateScoreRequest{
+				RunId:  runID.String(),
+				Scores: testScoreInputs(maxScoreBatchSize + 1),
+			},
+			message: "At most 100 scores are allowed",
+		},
+		{
+			name: "batch missing value",
+			req: &apiv2.CreateScoreRequest{
+				RunId: runID.String(),
+				Scores: []*apiv2.CreateScoreInput{
+					{Name: "accuracy"},
+				},
+			},
+			message: "scores[0]: Score value is required",
+		},
+	}
+
+	for _, tc := range invalid {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := &fakeScoreProvider{}
+			service := NewService(ServiceOptions{Scores: provider})
+
+			resp, err := service.CreateScore(context.Background(), tc.req)
+
+			require.Nil(t, resp)
+			require.ErrorContains(t, err, tc.message)
+			require.Nil(t, provider.params)
+		})
+	}
+
+	providerErrors := []struct {
+		name    string
+		err     error
+		message string
+	}{
+		{name: "scores not enabled", err: ErrScoresNotEnabled, message: "Scores are not enabled"},
+		{name: "target not found", err: ErrScoreTargetNotFound, message: "Run or step not found"},
+		{name: "span too large", err: metadata.ErrMetadataSpanTooLarge, message: "metadata size limit"},
+		{name: "run size exceeded", err: metadata.ErrRunMetadataSizeExceeded, message: "metadata size limit"},
+		{name: "internal error", err: errors.New("boom"), message: "Unable to record score"},
+	}
+
+	for _, tc := range providerErrors {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := &fakeScoreProvider{err: tc.err}
+			service := NewService(ServiceOptions{Scores: provider})
+
+			resp, err := service.CreateScore(context.Background(), &apiv2.CreateScoreRequest{
+				RunId: runID.String(),
+				Scores: []*apiv2.CreateScoreInput{
+					{Name: "accuracy", Value: structpb.NewNumberValue(1)},
+				},
+			})
+
+			require.Nil(t, resp)
+			require.ErrorContains(t, err, tc.message)
+		})
+	}
+}
+
+func TestScoreMetadataUpdate(t *testing.T) {
+	update, err := ScoreMetadataUpdate("accuracy", 0.95)
+	require.NoError(t, err)
+	require.Equal(t, metadata.KindInngestScore, update.Kind())
+	require.Equal(t, enums.MetadataOpcodeMerge, update.Op())
+	require.Equal(t, metadata.Values{"accuracy": json.RawMessage(`{"value":0.95}`)}, update.RawUpdate.Values)
+
+	update, err = ScoreMetadataUpdate("passed", true)
+	require.NoError(t, err)
+	require.Equal(t, metadata.KindInngestScore, update.Kind())
+	require.Equal(t, metadata.Values{"passed": json.RawMessage(`{"value":true}`)}, update.RawUpdate.Values)
+
+	_, err = ScoreMetadataUpdate("bad'name", 1.0)
+	require.Error(t, err)
+
+	_, err = ScoreMetadataUpdate(strings.Repeat("a", metadata.MaxScoreNameByteLength+1), 1.0)
+	require.Error(t, err)
+}
+
+func TestScoreExperimentMetadataUpdate(t *testing.T) {
+	update, err := ScoreExperimentMetadataUpdate(ScoreExperimentInput{
+		ExperimentName: "model-routing",
+		Variant:        "baseline",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, metadata.KindInngestExperiment, update.Kind())
+	require.Equal(t, enums.MetadataOpcodeMerge, update.Op())
+	require.Equal(t, metadata.Values{
+		"name":    json.RawMessage(`"model-routing"`),
+		"variant": json.RawMessage(`"baseline"`),
+	}, update.RawUpdate.Values)
+}
+
+func TestScoreParentSpanRefHashesSDKStepID(t *testing.T) {
+	runID := ulid.MustParse("01KVDHCS8VTWZHBAHTMYJHBPKJ")
+	stepID := "step 1"
+	stableStepID := "b436f063682815df5b5fd9780200a9e4e8d4f0b3"
+	md := &statev2.Metadata{
+		ID: statev2.ID{RunID: runID},
+	}
+
+	ref, scope := scoreParentSpanRef(md, &stepID)
+	expected := tracing.FinalizedStepSpanRefFromMetadataAndStepID(md, stableStepID)
+
+	require.Equal(t, enums.MetadataScopeStep, scope)
+	require.NotNil(t, ref)
+	require.Equal(t, expected.DynamicSpanID, ref.DynamicSpanID)
+	require.Equal(t, expected.DynamicSpanTraceParent, ref.DynamicSpanTraceParent)
+	require.Equal(t, expected.TraceParent, ref.TraceParent)
+}
+
+func TestStateScoreProviderFlagDisabled(t *testing.T) {
+	provider := NewStateScoreProvider(StateScoreProviderOptions{
+		Auth: func(ctx context.Context) (uuid.UUID, uuid.UUID, error) {
+			return uuid.New(), uuid.New(), nil
+		},
+		Enabled: func(ctx context.Context, accountID uuid.UUID) bool { return false },
+	})
+
+	err := provider.CreateScores(context.Background(), CreateScoresParams{
+		RunID: ulid.MustParse("01HP1ZX8M3NG9VP6QN0XK7J4CY"),
+		Scores: []ScoreInput{
+			{Name: "accuracy", Value: 1.0},
+		},
+	})
+	require.ErrorIs(t, err, ErrScoresNotEnabled)
+}
+
+func TestStateScoreProviderUsesMetadataLoaderForFinalizedRun(t *testing.T) {
+	runID := ulid.MustParse("01KVBJWM98JHAJPC9K5EXVAQTQ")
+	accountID := uuid.New()
+	envID := uuid.New()
+	functionID := uuid.New()
+	appID := uuid.New()
+	loaderCalled := false
+
+	provider := NewStateScoreProvider(StateScoreProviderOptions{
+		State: fakeScoreRunService{err: statev2.ErrMetadataNotFound},
+		Auth: func(ctx context.Context) (uuid.UUID, uuid.UUID, error) {
+			return accountID, envID, nil
+		},
+		MissingStateLoader: func(ctx context.Context, id statev2.ID) (*statev2.Metadata, error) {
+			loaderCalled = true
+			require.Equal(t, accountID, id.Tenant.AccountID)
+			require.Equal(t, envID, id.Tenant.EnvID)
+			require.Equal(t, runID, id.RunID)
+			return &statev2.Metadata{
+				ID: statev2.ID{
+					RunID:      runID,
+					FunctionID: functionID,
+					Tenant: statev2.Tenant{
+						AccountID: accountID,
+						EnvID:     envID,
+						AppID:     appID,
+					},
+				},
+			}, nil
+		},
+	})
+
+	err := provider.CreateScores(context.Background(), CreateScoresParams{
+		RunID: runID,
+		Scores: []ScoreInput{
+			{Name: "accuracy", Value: 1.0},
+		},
+	})
+	require.NoError(t, err)
+	require.True(t, loaderCalled)
+}
+
+func TestStateScoreProviderValidatesStepTargets(t *testing.T) {
+	runID := ulid.MustParse("01KVBJWM98JHAJPC9K5EXVAQTQ")
+	accountID := uuid.New()
+	envID := uuid.New()
+
+	baseOpts := StateScoreProviderOptions{
+		State: fakeScoreRunService{
+			metadata: statev2.Metadata{
+				ID: statev2.ID{
+					RunID: runID,
+					Tenant: statev2.Tenant{
+						AccountID: accountID,
+						EnvID:     envID,
+					},
+				},
+				Stack: []string{"generate-summary"},
+			},
+		},
+		Auth: func(ctx context.Context) (uuid.UUID, uuid.UUID, error) {
+			return accountID, envID, nil
+		},
+	}
+
+	t.Run("accepts SDK step IDs from live state", func(t *testing.T) {
+		provider := NewStateScoreProvider(baseOpts)
+		stepID := "generate-summary"
+
+		err := provider.CreateScores(context.Background(), CreateScoresParams{
+			RunID: runID,
+			Scores: []ScoreInput{
+				{StepID: &stepID, Name: "accuracy", Value: 1.0},
+			},
+		})
+
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects missing step IDs", func(t *testing.T) {
+		provider := NewStateScoreProvider(baseOpts)
+		stepID := "missing-step"
+
+		err := provider.CreateScores(context.Background(), CreateScoresParams{
+			RunID: runID,
+			Scores: []ScoreInput{
+				{StepID: &stepID, Name: "accuracy", Value: 1.0},
+			},
+		})
+
+		require.ErrorIs(t, err, ErrScoreTargetNotFound)
+	})
+
+	t.Run("falls back to trace validator", func(t *testing.T) {
+		called := false
+		opts := baseOpts
+		opts.State = fakeScoreRunService{err: statev2.ErrMetadataNotFound}
+		opts.StepValidator = func(ctx context.Context, params ScoreStepTargetValidatorParams) error {
+			called = true
+			require.Equal(t, runID, params.RunID)
+			require.Equal(t, "generate-summary", params.StepID)
+			require.Equal(t, scoreTraceStepID("generate-summary"), params.TraceStepID)
+			return nil
+		}
+		opts.MissingStateLoader = func(ctx context.Context, id statev2.ID) (*statev2.Metadata, error) {
+			return &statev2.Metadata{ID: id}, nil
+		}
+		provider := NewStateScoreProvider(opts)
+		stepID := "generate-summary"
+
+		err := provider.CreateScores(context.Background(), CreateScoresParams{
+			RunID: runID,
+			Scores: []ScoreInput{
+				{StepID: &stepID, Name: "accuracy", Value: 1.0},
+			},
+		})
+
+		require.NoError(t, err)
+		require.True(t, called)
+	})
+}
+
+func testScoreInputs(count int) []*apiv2.CreateScoreInput {
+	scores := make([]*apiv2.CreateScoreInput, 0, count)
+	for i := 0; i < count; i++ {
+		scores = append(scores, &apiv2.CreateScoreInput{
+			Name:  "accuracy",
+			Value: structpb.NewNumberValue(1),
+		})
+	}
+	return scores
+}
+
+type fakeScoreRunService struct {
+	statev2.RunService
+	metadata statev2.Metadata
+	err      error
+}
+
+func (f fakeScoreRunService) LoadMetadata(ctx context.Context, id statev2.ID, _ ...statev2.LoadMetadataOption) (statev2.Metadata, error) {
+	return f.metadata, f.err
+}

--- a/pkg/api/v2/endpoints_scores_test.go
+++ b/pkg/api/v2/endpoints_scores_test.go
@@ -429,6 +429,7 @@ func TestStateScoreProviderValidatesStepTargets(t *testing.T) {
 	runID := ulid.MustParse("01KVBJWM98JHAJPC9K5EXVAQTQ")
 	accountID := uuid.New()
 	envID := uuid.New()
+	existingStepID := "generate-summary"
 
 	baseOpts := StateScoreProviderOptions{
 		State: fakeScoreRunService{
@@ -440,7 +441,7 @@ func TestStateScoreProviderValidatesStepTargets(t *testing.T) {
 						EnvID:     envID,
 					},
 				},
-				Stack: []string{"generate-summary"},
+				Stack: []string{scoreTraceStepID(existingStepID)},
 			},
 		},
 		Auth: func(ctx context.Context) (uuid.UUID, uuid.UUID, error) {
@@ -450,7 +451,7 @@ func TestStateScoreProviderValidatesStepTargets(t *testing.T) {
 
 	t.Run("accepts SDK step IDs from live state", func(t *testing.T) {
 		provider := NewStateScoreProvider(baseOpts)
-		stepID := "generate-summary"
+		stepID := existingStepID
 
 		err := provider.CreateScores(context.Background(), CreateScoresParams{
 			RunID: runID,

--- a/pkg/api/v2/errors.go
+++ b/pkg/api/v2/errors.go
@@ -7,4 +7,12 @@ var (
 	ErrAppNotFound           = errors.New("app not found")
 	ErrRunNotFound           = errors.New("run not found")
 	ErrCronRerunNotSupported = errors.New("cron rerun is not supported")
+
+	// ErrScoresNotEnabled is returned by ScoreProvider implementations when
+	// score submission is not enabled for the authenticated account.
+	ErrScoresNotEnabled = errors.New("scores are not enabled")
+
+	// ErrScoreTargetNotFound is returned by ScoreProvider implementations when
+	// the run or step a score targets cannot be found.
+	ErrScoreTargetNotFound = errors.New("score target not found")
 )

--- a/pkg/api/v2/http_test.go
+++ b/pkg/api/v2/http_test.go
@@ -97,6 +97,45 @@ func TestHTTPGateway_Health(t *testing.T) {
 	})
 }
 
+func TestHTTPGateway_CreateScoreAcceptsArrayBody(t *testing.T) {
+	ctx := context.Background()
+	runID := ulid.MustParse("01KVDHCS8VTWZHBAHTMYJHBPKJ")
+	stepID := "b436f063682815df5b5fd9780200a9e4e8d4f0b3"
+	provider := &fakeScoreProvider{}
+	handler, err := newTestHTTPHandler(ctx, ServiceOptions{Scores: provider}, HTTPHandlerOptions{})
+	require.NoError(t, err)
+
+	body := `[{"name":"accuracy","value":0.95,"step_id":"` + stepID + `"}]`
+	req := httptest.NewRequest(http.MethodPost, "/v2/runs/"+runID.String()+"/scores", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	require.NotNil(t, provider.params)
+	require.Equal(t, runID, provider.params.RunID)
+	require.Len(t, provider.params.Scores, 1)
+	require.Equal(t, &stepID, provider.params.Scores[0].StepID)
+	require.Equal(t, "accuracy", provider.params.Scores[0].Name)
+	require.Equal(t, 0.95, provider.params.Scores[0].Value)
+
+	var response struct {
+		Data []struct {
+			RunID  string  `json:"runId"`
+			Name   string  `json:"name"`
+			Value  float64 `json:"value"`
+			StepID string  `json:"stepId"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	require.Len(t, response.Data, 1)
+	require.Equal(t, runID.String(), response.Data[0].RunID)
+	require.Equal(t, "accuracy", response.Data[0].Name)
+	require.Equal(t, 0.95, response.Data[0].Value)
+	require.Equal(t, stepID, response.Data[0].StepID)
+}
+
 func TestHTTPGateway_RunEnumsUseShortJSONNames(t *testing.T) {
 	ctx := context.Background()
 	runID := ulid.MustParse("01hp1zx8m3ng9vp6qn0xk7j4cy")

--- a/pkg/api/v2/interfaces.go
+++ b/pkg/api/v2/interfaces.go
@@ -11,6 +11,7 @@ import (
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/execution"
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -133,7 +134,8 @@ type ScoreInput struct {
 	Experiment *ScoreExperimentInput
 	Name       string
 	// Value is a finite float64 or a bool.
-	Value any
+	Value    any
+	Metadata []metadata.Update
 }
 
 // CreateScoresParams describes one or more scores recorded against a run.

--- a/pkg/api/v2/interfaces.go
+++ b/pkg/api/v2/interfaces.go
@@ -118,4 +118,33 @@ type RerunFromStep struct {
 type FunctionTraceReader interface {
 	GetSpansByRunID(ctx context.Context, runID ulid.ULID) (*cqrs.OtelSpan, error)
 	GetSpanOutput(ctx context.Context, id cqrs.SpanIdentifier) (*cqrs.SpanOutput, error)
+	GetStepSpanByStepID(ctx context.Context, runID ulid.ULID, stepID string, accountID, workspaceID uuid.UUID) (*cqrs.OtelSpan, error)
+}
+
+type ScoreExperimentInput struct {
+	ExperimentName string
+	Variant        string
+}
+
+// ScoreInput describes a single named score recorded against a run, or against
+// a specific step when StepID is set.
+type ScoreInput struct {
+	StepID     *string
+	Experiment *ScoreExperimentInput
+	Name       string
+	// Value is a finite float64 or a bool.
+	Value any
+}
+
+// CreateScoresParams describes one or more scores recorded against a run.
+type CreateScoresParams struct {
+	RunID  ulid.ULID
+	Scores []ScoreInput
+}
+
+type ScoreProvider interface {
+	// CreateScores records one or more scores for a run or step. Implementations return
+	// ErrScoresNotEnabled when the account cannot submit scores and
+	// ErrScoreTargetNotFound when the targeted run or step does not exist.
+	CreateScores(ctx context.Context, params CreateScoresParams) error
 }

--- a/pkg/api/v2/score_provider.go
+++ b/pkg/api/v2/score_provider.go
@@ -240,8 +240,9 @@ func (p *stateScoreProvider) validateStepTargets(ctx context.Context, id statev2
 }
 
 func scoreStepExistsInState(md *statev2.Metadata, stepID string) bool {
+	traceStepID := scoreTraceStepID(stepID)
 	for _, candidate := range md.Stack {
-		if candidate == stepID {
+		if candidate == stepID || candidate == traceStepID {
 			return true
 		}
 	}

--- a/pkg/api/v2/score_provider.go
+++ b/pkg/api/v2/score_provider.go
@@ -9,14 +9,16 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	apiv1 "github.com/inngest/inngest/pkg/api/apiv1"
-	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/api/metadatawriter"
 	"github.com/inngest/inngest/pkg/enums"
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
 	"github.com/oklog/ulid/v2"
 )
+
+const scorePkgName = "apiv2.inngest"
 
 // ScoreAuthResolver returns the account and workspace a score should be
 // recorded under for the current request.
@@ -37,15 +39,12 @@ type ScoreStepTargetValidatorParams struct {
 // cannot prove that the step exists.
 type ScoreStepTargetValidator func(ctx context.Context, params ScoreStepTargetValidatorParams) error
 
-type MissingScoreMetadataLoader func(ctx context.Context, id statev2.ID) (*statev2.Metadata, error)
-
 type StateScoreProviderOptions struct {
 	State              statev2.RunService
 	TracerProvider     tracing.TracerProvider
-	TraceReader        cqrs.TraceReader
 	Auth               ScoreAuthResolver
 	Enabled            ScoresEnabledFlag
-	MissingStateLoader MissingScoreMetadataLoader
+	MissingStateLoader metadatawriter.MissingStateLoader
 	StepValidator      ScoreStepTargetValidator
 }
 
@@ -55,7 +54,6 @@ func NewStateScoreProvider(opts StateScoreProviderOptions) ScoreProvider {
 	return &stateScoreProvider{
 		state:              opts.State,
 		tracerProvider:     opts.TracerProvider,
-		traceReader:        opts.TraceReader,
 		auth:               opts.Auth,
 		enabled:            opts.Enabled,
 		missingStateLoader: opts.MissingStateLoader,
@@ -66,10 +64,9 @@ func NewStateScoreProvider(opts StateScoreProviderOptions) ScoreProvider {
 type stateScoreProvider struct {
 	state              statev2.RunService
 	tracerProvider     tracing.TracerProvider
-	traceReader        cqrs.TraceReader
 	auth               ScoreAuthResolver
 	enabled            ScoresEnabledFlag
-	missingStateLoader MissingScoreMetadataLoader
+	missingStateLoader metadatawriter.MissingStateLoader
 	stepValidator      ScoreStepTargetValidator
 }
 
@@ -99,76 +96,42 @@ func (p *stateScoreProvider) CreateScores(ctx context.Context, params CreateScor
 		return err
 	}
 
+	items := make([]metadatawriter.Item, 0, len(params.Scores)*2)
 	for _, score := range params.Scores {
 		if len(score.Metadata) == 0 {
 			return errors.New("score metadata is required")
 		}
-		err = apiv1.AddRunMetadata(ctx, apiv1.AddRunMetadataOpts{
-			State:          p.metadataState(),
-			TracerProvider: p.tracerProvider,
-			TraceReader:    p.traceReader,
-		}, scoreAuth{accountID: accountID, envID: envID}, params.RunID, &apiv1.AddRunMetadataRequest{
-			Target: apiv1.RunMetadataTarget{
-				StepID: score.StepID,
-			},
-			Metadata: score.Metadata,
-		})
-		switch {
-		case errors.Is(err, statev2.ErrRunNotFound), errors.Is(err, statev2.ErrMetadataNotFound):
-			return fmt.Errorf("%w: %s", ErrScoreTargetNotFound, params.RunID)
-		case err != nil:
-			return err
+		stepID := score.StepID
+		for _, update := range score.Metadata {
+			items = append(items, metadatawriter.Item{
+				Metadata: update,
+				Parent: func(md *statev2.Metadata) (*meta.SpanReference, metadata.Scope) {
+					return scoreParentSpanRef(md, stepID)
+				},
+			})
 		}
 	}
 
+	writer := metadatawriter.Writer{
+		State:              p.state,
+		TracerProvider:     p.tracerProvider,
+		MissingStateLoader: p.missingStateLoader,
+		PkgName:            scorePkgName,
+	}
+
+	err = writer.Write(ctx, metadatawriter.WriteRequest{
+		ID:       stateID,
+		Items:    items,
+		Location: "Service.CreateScore",
+	})
+	switch {
+	case errors.Is(err, statev2.ErrRunNotFound), errors.Is(err, statev2.ErrMetadataNotFound):
+		return fmt.Errorf("%w: %s", ErrScoreTargetNotFound, params.RunID)
+	case err != nil:
+		return err
+	}
+
 	return nil
-}
-
-func (p *stateScoreProvider) metadataState() statev2.RunService {
-	if p.missingStateLoader == nil {
-		return p.state
-	}
-	return scoreMetadataState{
-		RunService: p.state,
-		load:       p.missingStateLoader,
-	}
-}
-
-type scoreMetadataState struct {
-	statev2.RunService
-	load MissingScoreMetadataLoader
-}
-
-func (s scoreMetadataState) LoadMetadata(ctx context.Context, id statev2.ID, opts ...statev2.LoadMetadataOption) (statev2.Metadata, error) {
-	md, err := s.RunService.LoadMetadata(ctx, id, opts...)
-	if err == nil {
-		return md, nil
-	}
-	if !errors.Is(err, statev2.ErrRunNotFound) && !errors.Is(err, statev2.ErrMetadataNotFound) {
-		return statev2.Metadata{}, err
-	}
-
-	loaded, loadErr := s.load(ctx, id)
-	if loadErr != nil {
-		return statev2.Metadata{}, loadErr
-	}
-	if loaded == nil {
-		return statev2.Metadata{}, err
-	}
-	return *loaded, nil
-}
-
-type scoreAuth struct {
-	accountID uuid.UUID
-	envID     uuid.UUID
-}
-
-func (s scoreAuth) AccountID() uuid.UUID {
-	return s.accountID
-}
-
-func (s scoreAuth) WorkspaceID() uuid.UUID {
-	return s.envID
 }
 
 func (p *stateScoreProvider) validateStepTargets(ctx context.Context, id statev2.ID, scores []ScoreInput) error {
@@ -220,18 +183,35 @@ func (p *stateScoreProvider) validateStepTargets(ctx context.Context, id statev2
 }
 
 func scoreStepExistsInState(md *statev2.Metadata, stepID string) bool {
+	_, ok := scoreStepIDForSpan(md, stepID)
+	return ok
+}
+
+func scoreStepIDForSpan(md *statev2.Metadata, stepID string) (string, bool) {
 	traceStepID := scoreTraceStepID(stepID)
 	for _, candidate := range md.Stack {
 		// live run state contains raw sdk step ids while finalized trace lookup
 		// stores step spans under hashed trace step ids.
 		if candidate == stepID && !isSHA1Hex(stepID) {
-			return true
+			return candidate, true
 		}
 		if candidate == traceStepID {
-			return true
+			return traceStepID, true
 		}
 	}
-	return false
+	return "", false
+}
+
+func scoreParentSpanRef(stateMetadata *statev2.Metadata, stepID *string) (*meta.SpanReference, metadata.Scope) {
+	if stepID == nil {
+		return tracing.RunSpanRefFromMetadata(stateMetadata), enums.MetadataScopeRun
+	}
+
+	spanStepID := scoreTraceStepID(*stepID)
+	if matchedStepID, ok := scoreStepIDForSpan(stateMetadata, *stepID); ok {
+		spanStepID = matchedStepID
+	}
+	return tracing.FinalizedStepSpanRefFromMetadataAndStepID(stateMetadata, spanStepID), enums.MetadataScopeStep
 }
 
 func scoreTraceStepID(stepID string) string {

--- a/pkg/api/v2/score_provider.go
+++ b/pkg/api/v2/score_provider.go
@@ -1,0 +1,315 @@
+package apiv2
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	apiv1 "github.com/inngest/inngest/pkg/api/apiv1"
+	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/enums"
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/inngest/inngest/pkg/tracing/metadata"
+	"github.com/oklog/ulid/v2"
+)
+
+// ScoreAuthResolver returns the account and workspace a score should be
+// recorded under for the current request.
+type ScoreAuthResolver func(ctx context.Context) (accountID, envID uuid.UUID, err error)
+
+// ScoresEnabledFlag reports whether score submission is enabled for an account.
+type ScoresEnabledFlag func(ctx context.Context, accountID uuid.UUID) bool
+
+type ScoreStepTargetValidatorParams struct {
+	RunID       ulid.ULID
+	AccountID   uuid.UUID
+	EnvID       uuid.UUID
+	StepID      string
+	TraceStepID string
+}
+
+// ScoreStepTargetValidator validates step-scoped score targets when live state
+// cannot prove that the step exists.
+type ScoreStepTargetValidator func(ctx context.Context, params ScoreStepTargetValidatorParams) error
+
+type MissingScoreMetadataLoader func(ctx context.Context, id statev2.ID) (*statev2.Metadata, error)
+
+type StateScoreProviderOptions struct {
+	State              statev2.RunService
+	TracerProvider     tracing.TracerProvider
+	TraceReader        cqrs.TraceReader
+	Auth               ScoreAuthResolver
+	Enabled            ScoresEnabledFlag
+	MissingStateLoader MissingScoreMetadataLoader
+	StepValidator      ScoreStepTargetValidator
+}
+
+// NewStateScoreProvider returns a ScoreProvider that records scores as
+// inngest.score metadata
+func NewStateScoreProvider(opts StateScoreProviderOptions) ScoreProvider {
+	return &stateScoreProvider{
+		state:              opts.State,
+		tracerProvider:     opts.TracerProvider,
+		traceReader:        opts.TraceReader,
+		auth:               opts.Auth,
+		enabled:            opts.Enabled,
+		missingStateLoader: opts.MissingStateLoader,
+		stepValidator:      opts.StepValidator,
+	}
+}
+
+type stateScoreProvider struct {
+	state              statev2.RunService
+	tracerProvider     tracing.TracerProvider
+	traceReader        cqrs.TraceReader
+	auth               ScoreAuthResolver
+	enabled            ScoresEnabledFlag
+	missingStateLoader MissingScoreMetadataLoader
+	stepValidator      ScoreStepTargetValidator
+}
+
+func (p *stateScoreProvider) CreateScores(ctx context.Context, params CreateScoresParams) error {
+	accountID, envID, err := p.auth(ctx)
+	if err != nil {
+		return err
+	}
+
+	if p.enabled != nil && !p.enabled(ctx, accountID) {
+		return ErrScoresNotEnabled
+	}
+
+	if p.state == nil {
+		return errors.New("score provider state is nil")
+	}
+
+	stateID := statev2.ID{
+		RunID: params.RunID,
+		Tenant: statev2.Tenant{
+			EnvID:     envID,
+			AccountID: accountID,
+		},
+	}
+
+	if err := p.validateStepTargets(ctx, stateID, params.Scores); err != nil {
+		return err
+	}
+
+	for _, score := range params.Scores {
+		updates, err := scoreMetadataUpdates(score)
+		if err != nil {
+			return err
+		}
+		err = apiv1.AddRunMetadata(ctx, apiv1.AddRunMetadataOpts{
+			State:          p.metadataState(),
+			TracerProvider: p.tracerProvider,
+			TraceReader:    p.traceReader,
+		}, scoreAuth{accountID: accountID, envID: envID}, params.RunID, &apiv1.AddRunMetadataRequest{
+			Target: apiv1.RunMetadataTarget{
+				StepID: score.StepID,
+			},
+			Metadata: updates,
+		})
+		switch {
+		case errors.Is(err, statev2.ErrRunNotFound), errors.Is(err, statev2.ErrMetadataNotFound):
+			return fmt.Errorf("%w: %s", ErrScoreTargetNotFound, params.RunID)
+		case err != nil:
+			return err
+		}
+	}
+
+	return nil
+}
+
+func scoreMetadataUpdates(score ScoreInput) ([]metadata.Update, error) {
+	updates := make([]metadata.Update, 0, 2)
+	if score.Experiment != nil {
+		update, err := ScoreExperimentMetadataUpdate(*score.Experiment)
+		if err != nil {
+			return nil, err
+		}
+		updates = append(updates, update)
+	}
+
+	update, err := ScoreMetadataUpdate(score.Name, score.Value)
+	if err != nil {
+		return nil, err
+	}
+	updates = append(updates, update)
+	return updates, nil
+}
+
+func (p *stateScoreProvider) metadataState() statev2.RunService {
+	if p.missingStateLoader == nil {
+		return p.state
+	}
+	return scoreMetadataState{
+		RunService: p.state,
+		load:       p.missingStateLoader,
+	}
+}
+
+type scoreMetadataState struct {
+	statev2.RunService
+	load MissingScoreMetadataLoader
+}
+
+func (s scoreMetadataState) LoadMetadata(ctx context.Context, id statev2.ID, opts ...statev2.LoadMetadataOption) (statev2.Metadata, error) {
+	md, err := s.RunService.LoadMetadata(ctx, id, opts...)
+	if err == nil {
+		return md, nil
+	}
+	if !errors.Is(err, statev2.ErrRunNotFound) && !errors.Is(err, statev2.ErrMetadataNotFound) {
+		return statev2.Metadata{}, err
+	}
+
+	loaded, loadErr := s.load(ctx, id)
+	if loadErr != nil {
+		return statev2.Metadata{}, loadErr
+	}
+	if loaded == nil {
+		return statev2.Metadata{}, err
+	}
+	return *loaded, nil
+}
+
+type scoreAuth struct {
+	accountID uuid.UUID
+	envID     uuid.UUID
+}
+
+func (s scoreAuth) AccountID() uuid.UUID {
+	return s.accountID
+}
+
+func (s scoreAuth) WorkspaceID() uuid.UUID {
+	return s.envID
+}
+
+func (p *stateScoreProvider) validateStepTargets(ctx context.Context, id statev2.ID, scores []ScoreInput) error {
+	stepIDs := map[string]struct{}{}
+	for _, score := range scores {
+		if score.StepID != nil {
+			stepIDs[*score.StepID] = struct{}{}
+		}
+	}
+	if len(stepIDs) == 0 {
+		return nil
+	}
+
+	var md *statev2.Metadata
+	if p.state != nil {
+		loaded, err := p.state.LoadMetadata(ctx, id)
+		if err == nil {
+			md = &loaded
+		} else if !errors.Is(err, statev2.ErrRunNotFound) && !errors.Is(err, statev2.ErrMetadataNotFound) {
+			return fmt.Errorf("%w: %w", ErrScoreTargetNotFound, err)
+		}
+	}
+
+	for stepID := range stepIDs {
+		if md != nil && scoreStepExistsInState(md, stepID) {
+			continue
+		}
+		if p.stepValidator == nil {
+			if md == nil {
+				continue
+			}
+			return fmt.Errorf("%w: %s", ErrScoreTargetNotFound, stepID)
+		}
+		if err := p.stepValidator(ctx, ScoreStepTargetValidatorParams{
+			RunID:       id.RunID,
+			AccountID:   id.Tenant.AccountID,
+			EnvID:       id.Tenant.EnvID,
+			StepID:      stepID,
+			TraceStepID: scoreTraceStepID(stepID),
+		}); err != nil {
+			if errors.Is(err, ErrScoreTargetNotFound) {
+				return fmt.Errorf("%w: %s", ErrScoreTargetNotFound, stepID)
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func scoreStepExistsInState(md *statev2.Metadata, stepID string) bool {
+	for _, candidate := range md.Stack {
+		if candidate == stepID {
+			return true
+		}
+	}
+	return false
+}
+
+func scoreParentSpanRef(stateMetadata *statev2.Metadata, stepID *string) (*meta.SpanReference, metadata.Scope) {
+	if stepID == nil {
+		return tracing.RunSpanRefFromMetadata(stateMetadata), enums.MetadataScopeRun
+	}
+
+	return tracing.FinalizedStepSpanRefFromMetadataAndStepID(stateMetadata, scoreTraceStepID(*stepID)), enums.MetadataScopeStep
+}
+
+func scoreTraceStepID(stepID string) string {
+	sum := sha1.Sum([]byte(stepID))
+	return hex.EncodeToString(sum[:])
+}
+
+// ScoreMetadataUpdate builds and validates the metadata update for a named
+// score, applying the same rules as SDK score submission.
+func ScoreMetadataUpdate(name string, value any) (metadata.Update, error) {
+	raw, err := json.Marshal(struct {
+		Value any `json:"value"`
+	}{
+		Value: value,
+	})
+	if err != nil {
+		return metadata.Update{}, err
+	}
+
+	update := metadata.Update{
+		RawUpdate: metadata.RawUpdate{
+			Kind:   metadata.KindInngestScore,
+			Op:     enums.MetadataOpcodeMerge,
+			Values: metadata.Values{name: raw},
+		},
+	}
+	if err := update.ValidateAllowed(); err != nil {
+		return metadata.Update{}, err
+	}
+
+	return update, nil
+}
+
+func ScoreExperimentMetadataUpdate(experiment ScoreExperimentInput) (metadata.Update, error) {
+	name, err := json.Marshal(experiment.ExperimentName)
+	if err != nil {
+		return metadata.Update{}, err
+	}
+	variant, err := json.Marshal(experiment.Variant)
+	if err != nil {
+		return metadata.Update{}, err
+	}
+
+	update := metadata.Update{
+		RawUpdate: metadata.RawUpdate{
+			Kind: metadata.KindInngestExperiment,
+			Op:   enums.MetadataOpcodeMerge,
+			Values: metadata.Values{
+				"name":    name,
+				"variant": variant,
+			},
+		},
+	}
+	if err := update.ValidateAllowed(); err != nil {
+		return metadata.Update{}, err
+	}
+
+	return update, nil
+}

--- a/pkg/api/v2/score_provider.go
+++ b/pkg/api/v2/score_provider.go
@@ -100,9 +100,8 @@ func (p *stateScoreProvider) CreateScores(ctx context.Context, params CreateScor
 	}
 
 	for _, score := range params.Scores {
-		updates, err := scoreMetadataUpdates(score)
-		if err != nil {
-			return err
+		if len(score.Metadata) == 0 {
+			return errors.New("score metadata is required")
 		}
 		err = apiv1.AddRunMetadata(ctx, apiv1.AddRunMetadataOpts{
 			State:          p.metadataState(),
@@ -112,7 +111,7 @@ func (p *stateScoreProvider) CreateScores(ctx context.Context, params CreateScor
 			Target: apiv1.RunMetadataTarget{
 				StepID: score.StepID,
 			},
-			Metadata: updates,
+			Metadata: score.Metadata,
 		})
 		switch {
 		case errors.Is(err, statev2.ErrRunNotFound), errors.Is(err, statev2.ErrMetadataNotFound):
@@ -123,24 +122,6 @@ func (p *stateScoreProvider) CreateScores(ctx context.Context, params CreateScor
 	}
 
 	return nil
-}
-
-func scoreMetadataUpdates(score ScoreInput) ([]metadata.Update, error) {
-	updates := make([]metadata.Update, 0, 2)
-	if score.Experiment != nil {
-		update, err := ScoreExperimentMetadataUpdate(*score.Experiment)
-		if err != nil {
-			return nil, err
-		}
-		updates = append(updates, update)
-	}
-
-	update, err := ScoreMetadataUpdate(score.Name, score.Value)
-	if err != nil {
-		return nil, err
-	}
-	updates = append(updates, update)
-	return updates, nil
 }
 
 func (p *stateScoreProvider) metadataState() statev2.RunService {
@@ -241,9 +222,12 @@ func (p *stateScoreProvider) validateStepTargets(ctx context.Context, id statev2
 func scoreStepExistsInState(md *statev2.Metadata, stepID string) bool {
 	traceStepID := scoreTraceStepID(stepID)
 	for _, candidate := range md.Stack {
-		// Older callers may send raw SDK step IDs, while finalized state stores
-		// step spans under their trace IDs.
-		if candidate == stepID || candidate == traceStepID {
+		// live run state contains raw sdk step ids while finalized trace lookup
+		// stores step spans under hashed trace step ids.
+		if candidate == stepID && !isSHA1Hex(stepID) {
+			return true
+		}
+		if candidate == traceStepID {
 			return true
 		}
 	}
@@ -253,6 +237,14 @@ func scoreStepExistsInState(md *statev2.Metadata, stepID string) bool {
 func scoreTraceStepID(stepID string) string {
 	sum := sha1.Sum([]byte(stepID))
 	return hex.EncodeToString(sum[:])
+}
+
+func isSHA1Hex(value string) bool {
+	if len(value) != sha1.Size*2 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
 }
 
 // ScoreMetadataUpdate builds and validates the metadata update for a named

--- a/pkg/api/v2/score_provider.go
+++ b/pkg/api/v2/score_provider.go
@@ -14,7 +14,6 @@ import (
 	"github.com/inngest/inngest/pkg/enums"
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/tracing"
-	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
 	"github.com/oklog/ulid/v2"
 )
@@ -208,7 +207,7 @@ func (p *stateScoreProvider) validateStepTargets(ctx context.Context, id statev2
 		if err == nil {
 			md = &loaded
 		} else if !errors.Is(err, statev2.ErrRunNotFound) && !errors.Is(err, statev2.ErrMetadataNotFound) {
-			return fmt.Errorf("%w: %w", ErrScoreTargetNotFound, err)
+			return err
 		}
 	}
 
@@ -242,19 +241,13 @@ func (p *stateScoreProvider) validateStepTargets(ctx context.Context, id statev2
 func scoreStepExistsInState(md *statev2.Metadata, stepID string) bool {
 	traceStepID := scoreTraceStepID(stepID)
 	for _, candidate := range md.Stack {
+		// Older callers may send raw SDK step IDs, while finalized state stores
+		// step spans under their trace IDs.
 		if candidate == stepID || candidate == traceStepID {
 			return true
 		}
 	}
 	return false
-}
-
-func scoreParentSpanRef(stateMetadata *statev2.Metadata, stepID *string) (*meta.SpanReference, metadata.Scope) {
-	if stepID == nil {
-		return tracing.RunSpanRefFromMetadata(stateMetadata), enums.MetadataScopeRun
-	}
-
-	return tracing.FinalizedStepSpanRefFromMetadataAndStepID(stateMetadata, scoreTraceStepID(*stepID)), enums.MetadataScopeStep
 }
 
 func scoreTraceStepID(stepID string) string {

--- a/pkg/api/v2/service.go
+++ b/pkg/api/v2/service.go
@@ -28,6 +28,7 @@ type Service struct {
 	traces         FunctionTraceReader
 	executor       FunctionScheduler
 	eventPublisher EventPublisher
+	scores         ScoreProvider
 	rateLimiter    RateLimitProvider
 	base           *apiv2base.Base
 }
@@ -43,6 +44,7 @@ type ServiceOptions struct {
 	FunctionTraces      FunctionTraceReader
 	Executor            FunctionScheduler
 	EventPublisher      EventPublisher
+	Scores              ScoreProvider
 	RateLimitProvider   RateLimitProvider
 }
 
@@ -61,6 +63,7 @@ func NewService(opts ServiceOptions) *Service {
 		traces:         opts.FunctionTraces,
 		executor:       opts.Executor,
 		eventPublisher: opts.EventPublisher,
+		scores:         opts.Scores,
 		rateLimiter:    rateLimiter,
 		base:           apiv2base.NewBase(),
 	}

--- a/pkg/api/v2/test_mocks_test.go
+++ b/pkg/api/v2/test_mocks_test.go
@@ -3,6 +3,7 @@ package apiv2
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/oklog/ulid/v2"
@@ -83,6 +84,12 @@ func (m *mockFunctionTraceReader) GetSpanOutput(ctx context.Context, id cqrs.Spa
 	args := m.Called(ctx, id)
 	output, _ := args.Get(0).(*cqrs.SpanOutput)
 	return output, args.Error(1)
+}
+
+func (m *mockFunctionTraceReader) GetStepSpanByStepID(ctx context.Context, runID ulid.ULID, stepID string, accountID, workspaceID uuid.UUID) (*cqrs.OtelSpan, error) {
+	args := m.Called(ctx, runID, stepID, accountID, workspaceID)
+	span, _ := args.Get(0).(*cqrs.OtelSpan)
+	return span, args.Error(1)
 }
 
 type mockRateLimitProvider struct {

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -733,7 +733,6 @@ func start(ctx context.Context, opts StartOpts) error {
 		Scores: apiv2.NewStateScoreProvider(apiv2.StateScoreProviderOptions{
 			State:          smv2,
 			TracerProvider: tp,
-			TraceReader:    dbcqrs,
 			Auth: func(ctx context.Context) (uuid.UUID, uuid.UUID, error) {
 				return consts.DevServerAccountID, consts.DevServerEnvID, nil
 			},

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -2,7 +2,9 @@ package devserver
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -728,6 +730,25 @@ func start(ctx context.Context, opts StartOpts) error {
 		FunctionTraces:      NewFunctionTraceReader(dbcqrs),
 		Executor:            exec,
 		EventPublisher:      runner,
+		Scores: apiv2.NewStateScoreProvider(apiv2.StateScoreProviderOptions{
+			State:          smv2,
+			TracerProvider: tp,
+			TraceReader:    dbcqrs,
+			Auth: func(ctx context.Context) (uuid.UUID, uuid.UUID, error) {
+				return consts.DevServerAccountID, consts.DevServerEnvID, nil
+			},
+			Enabled: func(ctx context.Context, accountID uuid.UUID) bool {
+				return enableStepMetadata
+			},
+			MissingStateLoader: scoreMetadataLoader(dbcqrs),
+			StepValidator: func(ctx context.Context, params apiv2.ScoreStepTargetValidatorParams) error {
+				_, err := dbcqrs.GetStepSpanByStepID(ctx, params.RunID, params.TraceStepID, params.AccountID, params.EnvID)
+				if errors.Is(err, sql.ErrNoRows) {
+					return apiv2.ErrScoreTargetNotFound
+				}
+				return err
+			},
+		}),
 	}
 
 	apiv2Base := apiv2base.NewBase()

--- a/pkg/devserver/function_trace_reader.go
+++ b/pkg/devserver/function_trace_reader.go
@@ -3,6 +3,7 @@ package devserver
 import (
 	"context"
 
+	"github.com/google/uuid"
 	apiv2 "github.com/inngest/inngest/pkg/api/v2"
 	"github.com/inngest/inngest/pkg/cqrs"
 	"github.com/oklog/ulid/v2"
@@ -22,4 +23,8 @@ func (r *cqrsFunctionTraceReader) GetSpansByRunID(ctx context.Context, runID uli
 
 func (r *cqrsFunctionTraceReader) GetSpanOutput(ctx context.Context, id cqrs.SpanIdentifier) (*cqrs.SpanOutput, error) {
 	return r.reader.GetSpanOutput(ctx, id)
+}
+
+func (r *cqrsFunctionTraceReader) GetStepSpanByStepID(ctx context.Context, runID ulid.ULID, stepID string, accountID, workspaceID uuid.UUID) (*cqrs.OtelSpan, error) {
+	return r.reader.GetStepSpanByStepID(ctx, runID, stepID, accountID, workspaceID)
 }

--- a/pkg/devserver/run_provider_test.go
+++ b/pkg/devserver/run_provider_test.go
@@ -2,8 +2,10 @@ package devserver
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	apiv2 "github.com/inngest/inngest/pkg/api/v2"
@@ -120,10 +122,72 @@ func TestRunProviderRerunUsesRunIDWhenOriginalRunIDIsMissing(t *testing.T) {
 	require.Equal(t, runID, *scheduler.req.OriginalRunID)
 }
 
+func TestScoreMetadataLoaderReconstructsFinalizedRunMetadata(t *testing.T) {
+	runID := ulid.MustParse("01KVBJWM98JHAJPC9K5EXVAQTQ")
+	eventID := ulid.MustParse("01KVBJWM98JHAJPC9K5EXVAQTR")
+	batchID := ulid.MustParse("01KVBJWM98JHAJPC9K5EXVAQTS")
+	originalRunID := ulid.MustParse("01KVBJWM98JHAJPC9K5EXVAQTT")
+	functionID := uuid.New()
+	appID := uuid.New()
+	startedAt := time.Date(2026, time.June, 18, 12, 0, 0, 0, time.UTC)
+
+	loader := scoreMetadataLoader(&stubRunProviderDataReader{
+		run: &cqrs.FunctionRun{
+			RunID:           runID,
+			RunStartedAt:    startedAt,
+			FunctionID:      functionID,
+			FunctionVersion: 7,
+			EventID:         eventID,
+			BatchID:         &batchID,
+			OriginalRunID:   &originalRunID,
+		},
+		fn: &cqrs.Function{
+			ID:    functionID,
+			AppID: appID,
+		},
+	})
+
+	md, err := loader(context.Background(), sv2.ID{
+		RunID: runID,
+		Tenant: sv2.Tenant{
+			AccountID: consts.DevServerAccountID,
+			EnvID:     consts.DevServerEnvID,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, runID, md.ID.RunID)
+	require.Equal(t, functionID, md.ID.FunctionID)
+	require.Equal(t, consts.DevServerAccountID, md.ID.Tenant.AccountID)
+	require.Equal(t, consts.DevServerEnvID, md.ID.Tenant.EnvID)
+	require.Equal(t, appID, md.ID.Tenant.AppID)
+	require.Equal(t, 7, md.Config.FunctionVersion)
+	require.Equal(t, startedAt, md.Config.StartedAt)
+	require.Equal(t, []ulid.ULID{eventID}, md.Config.EventIDs)
+	require.Equal(t, &batchID, md.Config.BatchID)
+	require.Equal(t, &originalRunID, md.Config.OriginalRunID)
+}
+
+func TestScoreMetadataLoaderMapsMissingRowsToMetadataNotFound(t *testing.T) {
+	loader := scoreMetadataLoader(&stubRunProviderDataReader{runErr: sql.ErrNoRows})
+
+	md, err := loader(context.Background(), sv2.ID{
+		RunID: ulid.Make(),
+		Tenant: sv2.Tenant{
+			AccountID: consts.DevServerAccountID,
+			EnvID:     consts.DevServerEnvID,
+		},
+	})
+	require.Nil(t, md)
+	require.ErrorIs(t, err, sv2.ErrMetadataNotFound)
+}
+
 type stubRunProviderDataReader struct {
-	run *cqrs.FunctionRun
-	fn  *cqrs.Function
-	evt *cqrs.Event
+	run    *cqrs.FunctionRun
+	runErr error
+	fn     *cqrs.Function
+	fnErr  error
+	evt    *cqrs.Event
+	evtErr error
 }
 
 func (s *stubRunProviderDataReader) GetSpansByRunID(ctx context.Context, runID ulid.ULID) (*cqrs.OtelSpan, error) {
@@ -131,14 +195,23 @@ func (s *stubRunProviderDataReader) GetSpansByRunID(ctx context.Context, runID u
 }
 
 func (s *stubRunProviderDataReader) GetFunctionRun(ctx context.Context, accountID uuid.UUID, workspaceID uuid.UUID, runID ulid.ULID) (*cqrs.FunctionRun, error) {
+	if s.runErr != nil {
+		return nil, s.runErr
+	}
 	return s.run, nil
 }
 
 func (s *stubRunProviderDataReader) GetFunctionByInternalUUID(ctx context.Context, fnID uuid.UUID) (*cqrs.Function, error) {
+	if s.fnErr != nil {
+		return nil, s.fnErr
+	}
 	return s.fn, nil
 }
 
 func (s *stubRunProviderDataReader) GetEventByInternalID(ctx context.Context, internalID ulid.ULID) (*cqrs.Event, error) {
+	if s.evtErr != nil {
+		return nil, s.evtErr
+	}
 	return s.evt, nil
 }
 

--- a/pkg/devserver/score_provider.go
+++ b/pkg/devserver/score_provider.go
@@ -1,0 +1,52 @@
+package devserver
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	apiv2 "github.com/inngest/inngest/pkg/api/v2"
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/oklog/ulid/v2"
+)
+
+func scoreMetadataLoader(data runProviderDataReader) apiv2.MissingScoreMetadataLoader {
+	return func(ctx context.Context, id statev2.ID) (*statev2.Metadata, error) {
+		fnrun, err := data.GetFunctionRun(ctx, id.Tenant.AccountID, id.Tenant.EnvID, id.RunID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, statev2.ErrMetadataNotFound
+			}
+			return nil, err
+		}
+
+		fn, err := data.GetFunctionByInternalUUID(ctx, fnrun.FunctionID)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, statev2.ErrMetadataNotFound
+			}
+			return nil, err
+		}
+
+		md := &statev2.Metadata{
+			ID: statev2.ID{
+				RunID:      fnrun.RunID,
+				FunctionID: fnrun.FunctionID,
+				Tenant: statev2.Tenant{
+					AccountID: id.Tenant.AccountID,
+					EnvID:     id.Tenant.EnvID,
+					AppID:     fn.AppID,
+				},
+			},
+			Config: statev2.Config{
+				FunctionVersion: int(fnrun.FunctionVersion),
+				BatchID:         fnrun.BatchID,
+				StartedAt:       fnrun.RunStartedAt,
+				EventIDs:        []ulid.ULID{fnrun.EventID},
+				OriginalRunID:   fnrun.OriginalRunID,
+			},
+		}
+		statev2.InitConfig(&md.Config)
+		return md, nil
+	}
+}

--- a/pkg/devserver/score_provider.go
+++ b/pkg/devserver/score_provider.go
@@ -5,12 +5,12 @@ import (
 	"database/sql"
 	"errors"
 
-	apiv2 "github.com/inngest/inngest/pkg/api/v2"
+	"github.com/inngest/inngest/pkg/api/metadatawriter"
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/oklog/ulid/v2"
 )
 
-func scoreMetadataLoader(data runProviderDataReader) apiv2.MissingScoreMetadataLoader {
+func scoreMetadataLoader(data runProviderDataReader) metadatawriter.MissingStateLoader {
 	return func(ctx context.Context, id statev2.ID) (*statev2.Metadata, error) {
 		fnrun, err := data.GetFunctionRun(ctx, id.Tenant.AccountID, id.Tenant.EnvID, id.RunID)
 		if err != nil {

--- a/pkg/tracing/metadata/kind.go
+++ b/pkg/tracing/metadata/kind.go
@@ -19,6 +19,10 @@ const (
 	KindPrefixUserland = "userland."
 )
 
+const (
+	KindInngestExperiment Kind = "inngest.experiment"
+)
+
 func (k Kind) String() string {
 	return string(k)
 }
@@ -50,8 +54,8 @@ var allowedInngestKinds = map[Kind]bool{
 	"inngest.http.timing":      true,
 	"inngest.response_headers": true,
 	"inngest.warnings":         true,
-	"inngest.experiment":       true,
-	"inngest.score":            true,
+	KindInngestExperiment:      true,
+	KindInngestScore:           true,
 }
 
 // ValidateAllowed checks that the kind is valid and, if it uses the inngest.*

--- a/pkg/tracing/metadata/metadata.go
+++ b/pkg/tracing/metadata/metadata.go
@@ -16,6 +16,7 @@ var (
 	ErrMetadataSpanTooLarge    = errors.New("metadata span exceeds maximum size")
 	ErrRunMetadataSizeExceeded = errors.New("run cumulative metadata size exceeded")
 	ErrScoreNameInvalid        = errors.New("score name contains invalid characters")
+	ErrScoreNameTooLong        = errors.New("score name exceeds maximum length")
 	ErrScoreValueInvalid       = errors.New("score value must be a finite number or boolean")
 )
 

--- a/pkg/tracing/metadata/metadata_test.go
+++ b/pkg/tracing/metadata/metadata_test.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/inngest/inngest/pkg/enums"
@@ -86,9 +87,10 @@ func TestUpdateValidateAllowedNamedScoreValue(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		update  Update
-		wantErr error
+		name       string
+		update     Update
+		wantErr    error
+		wantErrMsg string
 	}{
 		{
 			name: "single finite numeric score is valid",
@@ -140,7 +142,18 @@ func TestUpdateValidateAllowedNamedScoreValue(t *testing.T) {
 				Op:     enums.MetadataOpcodeMerge,
 				Values: Values{"name'with'quotes": json.RawMessage(`{"value":0.5}`)},
 			}},
-			wantErr: ErrScoreNameInvalid,
+			wantErr:    ErrScoreNameInvalid,
+			wantErrMsg: "contains invalid characters",
+		},
+		{
+			name: "score name over byte limit is rejected",
+			update: Update{RawUpdate: RawUpdate{
+				Kind:   KindInngestScore,
+				Op:     enums.MetadataOpcodeMerge,
+				Values: Values{strings.Repeat("a", MaxScoreNameByteLength+1): json.RawMessage(`{"value":0.5}`)},
+			}},
+			wantErr:    ErrScoreNameTooLong,
+			wantErrMsg: "score name exceeds maximum length",
 		},
 		{
 			name: "extra keys alongside value are rejected",
@@ -213,6 +226,9 @@ func TestUpdateValidateAllowedNamedScoreValue(t *testing.T) {
 			err := tt.update.ValidateAllowed()
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
+				if tt.wantErrMsg != "" {
+					require.ErrorContains(t, err, tt.wantErrMsg)
+				}
 				return
 			}
 

--- a/pkg/tracing/metadata/score.go
+++ b/pkg/tracing/metadata/score.go
@@ -24,7 +24,7 @@ const (
 // MetricKeyRegex excludes it for SQL-injection defense).
 func validateScoreName(name string) error {
 	if len(name) > MaxScoreNameByteLength {
-		return fmt.Errorf("invalid score name %q: %w", name, ErrScoreNameInvalid)
+		return fmt.Errorf("invalid score name %q: %w of %d UTF-8 bytes", name, ErrScoreNameTooLong, MaxScoreNameByteLength)
 	}
 
 	for _, r := range name {

--- a/pkg/tracing/metadata/score.go
+++ b/pkg/tracing/metadata/score.go
@@ -12,6 +12,10 @@ const (
 	KindInngestScore Kind = "inngest.score"
 )
 
+const (
+	MaxScoreNameByteLength = 128
+)
+
 // validateScoreName checks a user-supplied score name (a key in the
 // inngest.score values map) for characters that downstream consumers can't
 // safely round-trip. Mirrors the SDK validation and the monorepo
@@ -19,6 +23,10 @@ const (
 // quote (which would silently drop in cloud variant aggregation because
 // MetricKeyRegex excludes it for SQL-injection defense).
 func validateScoreName(name string) error {
+	if len(name) > MaxScoreNameByteLength {
+		return fmt.Errorf("invalid score name %q: %w", name, ErrScoreNameInvalid)
+	}
+
 	for _, r := range name {
 		if r < 0x20 || r == 0x7f || r == '\'' {
 			return fmt.Errorf("invalid score name %q: %w", name, ErrScoreNameInvalid)

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -2564,15 +2564,15 @@ message CreateScoreInput {
   ];
   optional ScoreExperiment experiment = 4 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Optional experiment context. When provided, the score is recorded with the same experiment metadata emitted by the SDK's score.experiment API. Experiment scores should be run-scoped for experiment aggregate and detail APIs."
+      description: "Optional experiment context. When provided, the score is recorded with the same experiment metadata emitted by the SDK's score.experiment API. Experiment scores must be run-scoped for experiment aggregate and detail APIs."
     }
   ];
 }
 
 message ScoreExperiment {
-  string experiment_name = 1 [
+  string id = 1 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Experiment name"
+      description: "Experiment ID"
       example: "\"model-routing\""
     }
   ];

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -1014,6 +1014,25 @@ service V2 {
     };
   }
 
+  rpc CreateScore(CreateScoreRequest) returns (CreateScoreResponse) {
+    option (google.api.http) = {
+      post: "/runs/{run_id}/scores",
+      body: "scores"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Create score"
+      tags: "Runs"
+      tags: "Beta"
+      description: "Submits one or more named scores for a function run, or for specific steps when step IDs are provided. Scores are recorded as run metadata and aggregated for experiments."
+      security: {
+        security_requirement: {
+          key: "BearerAuth"
+          value: {}
+        }
+      }
+    };
+  }
+
   rpc SyncApp(SyncAppRequest) returns (SyncAppResponse) {
     option (google.api.http) = {
       post: "/apps/{app_id}/syncs",
@@ -2506,6 +2525,94 @@ message InvokeFunctionData {
   optional string error = 6 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
       description: "Error message if the function execution failed"
+    }
+  ];
+}
+
+message CreateScoreRequest {
+  string run_id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Run ID (ULID) of the function run to score"
+      example: "\"01JLW1NNJ69KCD1KMJEXAMPLE0\""
+    }
+  ];
+  repeated CreateScoreInput scores = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Scores to record for the run. The REST request body is this array. Writes are applied in order and are not atomic; if a later score fails, earlier scores may already be recorded. Maximum 100 scores."
+    }
+  ];
+}
+
+message CreateScoreInput {
+  string name = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Score name; must be at most 128 UTF-8 bytes"
+      example: "\"accuracy\""
+    }
+  ];
+  google.protobuf.Value value = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Score value; must be a finite number or a boolean"
+      example: "0.95"
+    }
+  ];
+  optional string step_id = 3 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Optional SDK step ID; attaches the score to a specific step instead of the run"
+      example: "\"generate-summary\""
+    }
+  ];
+  optional ScoreExperiment experiment = 4 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Optional experiment context. When provided, the score is recorded with the same experiment metadata emitted by the SDK's score.experiment API. Experiment scores should be run-scoped for experiment aggregate and detail APIs."
+    }
+  ];
+}
+
+message ScoreExperiment {
+  string experiment_name = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Experiment name"
+      example: "\"model-routing\""
+    }
+  ];
+  string variant = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Experiment variant"
+      example: "\"baseline\""
+    }
+  ];
+}
+
+message CreateScoreResponse {
+  repeated Score data = 1;
+  ResponseMetadata metadata = 2;
+}
+
+message Score {
+  string run_id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Run ID the score was recorded against"
+    }
+  ];
+  string name = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Score name"
+    }
+  ];
+  google.protobuf.Value value = 3 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Score value"
+    }
+  ];
+  optional string step_id = 4 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Step ID the score was recorded against, if step-scoped"
+    }
+  ];
+  optional ScoreExperiment experiment = 5 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Experiment context the score was recorded against, if provided"
     }
   ];
 }

--- a/proto/gen/api/v2/apiv2connect/service.connect.go
+++ b/proto/gen/api/v2/apiv2connect/service.connect.go
@@ -67,6 +67,8 @@ const (
 	V2RerunProcedure = "/api.v2.V2/Rerun"
 	// V2GetAppProcedure is the fully-qualified name of the V2's GetApp RPC.
 	V2GetAppProcedure = "/api.v2.V2/GetApp"
+	// V2CreateScoreProcedure is the fully-qualified name of the V2's CreateScore RPC.
+	V2CreateScoreProcedure = "/api.v2.V2/CreateScore"
 	// V2SyncAppProcedure is the fully-qualified name of the V2's SyncApp RPC.
 	V2SyncAppProcedure = "/api.v2.V2/SyncApp"
 	// V2GetFunctionTraceProcedure is the fully-qualified name of the V2's GetFunctionTrace RPC.
@@ -119,6 +121,7 @@ type V2Client interface {
 	GetEventRuns(context.Context, *connect.Request[v2.GetEventRunsRequest]) (*connect.Response[v2.GetEventRunsResponse], error)
 	Rerun(context.Context, *connect.Request[v2.RerunRequest]) (*connect.Response[v2.RerunResponse], error)
 	GetApp(context.Context, *connect.Request[v2.GetAppRequest]) (*connect.Response[v2.GetAppResponse], error)
+	CreateScore(context.Context, *connect.Request[v2.CreateScoreRequest]) (*connect.Response[v2.CreateScoreResponse], error)
 	SyncApp(context.Context, *connect.Request[v2.SyncAppRequest]) (*connect.Response[v2.SyncAppResponse], error)
 	GetFunctionTrace(context.Context, *connect.Request[v2.GetFunctionTraceRequest]) (*connect.Response[v2.GetFunctionTraceResponse], error)
 	GetFunction(context.Context, *connect.Request[v2.GetFunctionRequest]) (*connect.Response[v2.GetFunctionResponse], error)
@@ -242,6 +245,12 @@ func NewV2Client(httpClient connect.HTTPClient, baseURL string, opts ...connect.
 			connect.WithSchema(v2Methods.ByName("GetApp")),
 			connect.WithClientOptions(opts...),
 		),
+		createScore: connect.NewClient[v2.CreateScoreRequest, v2.CreateScoreResponse](
+			httpClient,
+			baseURL+V2CreateScoreProcedure,
+			connect.WithSchema(v2Methods.ByName("CreateScore")),
+			connect.WithClientOptions(opts...),
+		),
 		syncApp: connect.NewClient[v2.SyncAppRequest, v2.SyncAppResponse](
 			httpClient,
 			baseURL+V2SyncAppProcedure,
@@ -347,6 +356,7 @@ type v2Client struct {
 	getEventRuns             *connect.Client[v2.GetEventRunsRequest, v2.GetEventRunsResponse]
 	rerun                    *connect.Client[v2.RerunRequest, v2.RerunResponse]
 	getApp                   *connect.Client[v2.GetAppRequest, v2.GetAppResponse]
+	createScore              *connect.Client[v2.CreateScoreRequest, v2.CreateScoreResponse]
 	syncApp                  *connect.Client[v2.SyncAppRequest, v2.SyncAppResponse]
 	getFunctionTrace         *connect.Client[v2.GetFunctionTraceRequest, v2.GetFunctionTraceResponse]
 	getFunction              *connect.Client[v2.GetFunctionRequest, v2.GetFunctionResponse]
@@ -443,6 +453,11 @@ func (c *v2Client) GetApp(ctx context.Context, req *connect.Request[v2.GetAppReq
 	return c.getApp.CallUnary(ctx, req)
 }
 
+// CreateScore calls api.v2.V2.CreateScore.
+func (c *v2Client) CreateScore(ctx context.Context, req *connect.Request[v2.CreateScoreRequest]) (*connect.Response[v2.CreateScoreResponse], error) {
+	return c.createScore.CallUnary(ctx, req)
+}
+
 // SyncApp calls api.v2.V2.SyncApp.
 func (c *v2Client) SyncApp(ctx context.Context, req *connect.Request[v2.SyncAppRequest]) (*connect.Response[v2.SyncAppResponse], error) {
 	return c.syncApp.CallUnary(ctx, req)
@@ -534,6 +549,7 @@ type V2Handler interface {
 	GetEventRuns(context.Context, *connect.Request[v2.GetEventRunsRequest]) (*connect.Response[v2.GetEventRunsResponse], error)
 	Rerun(context.Context, *connect.Request[v2.RerunRequest]) (*connect.Response[v2.RerunResponse], error)
 	GetApp(context.Context, *connect.Request[v2.GetAppRequest]) (*connect.Response[v2.GetAppResponse], error)
+	CreateScore(context.Context, *connect.Request[v2.CreateScoreRequest]) (*connect.Response[v2.CreateScoreResponse], error)
 	SyncApp(context.Context, *connect.Request[v2.SyncAppRequest]) (*connect.Response[v2.SyncAppResponse], error)
 	GetFunctionTrace(context.Context, *connect.Request[v2.GetFunctionTraceRequest]) (*connect.Response[v2.GetFunctionTraceResponse], error)
 	GetFunction(context.Context, *connect.Request[v2.GetFunctionRequest]) (*connect.Response[v2.GetFunctionResponse], error)
@@ -651,6 +667,12 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 		V2GetAppProcedure,
 		svc.GetApp,
 		connect.WithSchema(v2Methods.ByName("GetApp")),
+		connect.WithHandlerOptions(opts...),
+	)
+	v2CreateScoreHandler := connect.NewUnaryHandler(
+		V2CreateScoreProcedure,
+		svc.CreateScore,
+		connect.WithSchema(v2Methods.ByName("CreateScore")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2SyncAppHandler := connect.NewUnaryHandler(
@@ -771,6 +793,8 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 			v2RerunHandler.ServeHTTP(w, r)
 		case V2GetAppProcedure:
 			v2GetAppHandler.ServeHTTP(w, r)
+		case V2CreateScoreProcedure:
+			v2CreateScoreHandler.ServeHTTP(w, r)
 		case V2SyncAppProcedure:
 			v2SyncAppHandler.ServeHTTP(w, r)
 		case V2GetFunctionTraceProcedure:
@@ -870,6 +894,10 @@ func (UnimplementedV2Handler) Rerun(context.Context, *connect.Request[v2.RerunRe
 
 func (UnimplementedV2Handler) GetApp(context.Context, *connect.Request[v2.GetAppRequest]) (*connect.Response[v2.GetAppResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.GetApp is not implemented"))
+}
+
+func (UnimplementedV2Handler) CreateScore(context.Context, *connect.Request[v2.CreateScoreRequest]) (*connect.Response[v2.CreateScoreResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.CreateScore is not implemented"))
 }
 
 func (UnimplementedV2Handler) SyncApp(context.Context, *connect.Request[v2.SyncAppRequest]) (*connect.Response[v2.SyncAppResponse], error) {

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -5355,6 +5355,306 @@ func (x *InvokeFunctionData) GetError() string {
 	return ""
 }
 
+type CreateScoreRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RunId         string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	Scores        []*CreateScoreInput    `protobuf:"bytes,2,rep,name=scores,proto3" json:"scores,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateScoreRequest) Reset() {
+	*x = CreateScoreRequest{}
+	mi := &file_api_v2_service_proto_msgTypes[77]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateScoreRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateScoreRequest) ProtoMessage() {}
+
+func (x *CreateScoreRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[77]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateScoreRequest.ProtoReflect.Descriptor instead.
+func (*CreateScoreRequest) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{77}
+}
+
+func (x *CreateScoreRequest) GetRunId() string {
+	if x != nil {
+		return x.RunId
+	}
+	return ""
+}
+
+func (x *CreateScoreRequest) GetScores() []*CreateScoreInput {
+	if x != nil {
+		return x.Scores
+	}
+	return nil
+}
+
+type CreateScoreInput struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Value         *structpb.Value        `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+	StepId        *string                `protobuf:"bytes,3,opt,name=step_id,json=stepId,proto3,oneof" json:"step_id,omitempty"`
+	Experiment    *ScoreExperiment       `protobuf:"bytes,4,opt,name=experiment,proto3,oneof" json:"experiment,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateScoreInput) Reset() {
+	*x = CreateScoreInput{}
+	mi := &file_api_v2_service_proto_msgTypes[78]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateScoreInput) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateScoreInput) ProtoMessage() {}
+
+func (x *CreateScoreInput) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[78]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateScoreInput.ProtoReflect.Descriptor instead.
+func (*CreateScoreInput) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{78}
+}
+
+func (x *CreateScoreInput) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *CreateScoreInput) GetValue() *structpb.Value {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+func (x *CreateScoreInput) GetStepId() string {
+	if x != nil && x.StepId != nil {
+		return *x.StepId
+	}
+	return ""
+}
+
+func (x *CreateScoreInput) GetExperiment() *ScoreExperiment {
+	if x != nil {
+		return x.Experiment
+	}
+	return nil
+}
+
+type ScoreExperiment struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	ExperimentName string                 `protobuf:"bytes,1,opt,name=experiment_name,json=experimentName,proto3" json:"experiment_name,omitempty"`
+	Variant        string                 `protobuf:"bytes,2,opt,name=variant,proto3" json:"variant,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *ScoreExperiment) Reset() {
+	*x = ScoreExperiment{}
+	mi := &file_api_v2_service_proto_msgTypes[79]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScoreExperiment) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScoreExperiment) ProtoMessage() {}
+
+func (x *ScoreExperiment) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[79]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScoreExperiment.ProtoReflect.Descriptor instead.
+func (*ScoreExperiment) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{79}
+}
+
+func (x *ScoreExperiment) GetExperimentName() string {
+	if x != nil {
+		return x.ExperimentName
+	}
+	return ""
+}
+
+func (x *ScoreExperiment) GetVariant() string {
+	if x != nil {
+		return x.Variant
+	}
+	return ""
+}
+
+type CreateScoreResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Data          []*Score               `protobuf:"bytes,1,rep,name=data,proto3" json:"data,omitempty"`
+	Metadata      *ResponseMetadata      `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateScoreResponse) Reset() {
+	*x = CreateScoreResponse{}
+	mi := &file_api_v2_service_proto_msgTypes[80]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateScoreResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateScoreResponse) ProtoMessage() {}
+
+func (x *CreateScoreResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[80]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateScoreResponse.ProtoReflect.Descriptor instead.
+func (*CreateScoreResponse) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{80}
+}
+
+func (x *CreateScoreResponse) GetData() []*Score {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+func (x *CreateScoreResponse) GetMetadata() *ResponseMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+type Score struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RunId         string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Value         *structpb.Value        `protobuf:"bytes,3,opt,name=value,proto3" json:"value,omitempty"`
+	StepId        *string                `protobuf:"bytes,4,opt,name=step_id,json=stepId,proto3,oneof" json:"step_id,omitempty"`
+	Experiment    *ScoreExperiment       `protobuf:"bytes,5,opt,name=experiment,proto3,oneof" json:"experiment,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Score) Reset() {
+	*x = Score{}
+	mi := &file_api_v2_service_proto_msgTypes[81]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Score) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Score) ProtoMessage() {}
+
+func (x *Score) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[81]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Score.ProtoReflect.Descriptor instead.
+func (*Score) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{81}
+}
+
+func (x *Score) GetRunId() string {
+	if x != nil {
+		return x.RunId
+	}
+	return ""
+}
+
+func (x *Score) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *Score) GetValue() *structpb.Value {
+	if x != nil {
+		return x.Value
+	}
+	return nil
+}
+
+func (x *Score) GetStepId() string {
+	if x != nil && x.StepId != nil {
+		return *x.StepId
+	}
+	return ""
+}
+
+func (x *Score) GetExperiment() *ScoreExperiment {
+	if x != nil {
+		return x.Experiment
+	}
+	return nil
+}
+
 type SyncAppRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	AppId         string                 `protobuf:"bytes,1,opt,name=app_id,json=appId,proto3" json:"app_id,omitempty"`
@@ -5365,7 +5665,7 @@ type SyncAppRequest struct {
 
 func (x *SyncAppRequest) Reset() {
 	*x = SyncAppRequest{}
-	mi := &file_api_v2_service_proto_msgTypes[77]
+	mi := &file_api_v2_service_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5377,7 +5677,7 @@ func (x *SyncAppRequest) String() string {
 func (*SyncAppRequest) ProtoMessage() {}
 
 func (x *SyncAppRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[77]
+	mi := &file_api_v2_service_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5390,7 +5690,7 @@ func (x *SyncAppRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncAppRequest.ProtoReflect.Descriptor instead.
 func (*SyncAppRequest) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{77}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{82}
 }
 
 func (x *SyncAppRequest) GetAppId() string {
@@ -5417,7 +5717,7 @@ type SyncAppResponse struct {
 
 func (x *SyncAppResponse) Reset() {
 	*x = SyncAppResponse{}
-	mi := &file_api_v2_service_proto_msgTypes[78]
+	mi := &file_api_v2_service_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5429,7 +5729,7 @@ func (x *SyncAppResponse) String() string {
 func (*SyncAppResponse) ProtoMessage() {}
 
 func (x *SyncAppResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[78]
+	mi := &file_api_v2_service_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5442,7 +5742,7 @@ func (x *SyncAppResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncAppResponse.ProtoReflect.Descriptor instead.
 func (*SyncAppResponse) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{78}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{83}
 }
 
 func (x *SyncAppResponse) GetData() *SyncAppData {
@@ -5471,7 +5771,7 @@ type SyncAppData struct {
 
 func (x *SyncAppData) Reset() {
 	*x = SyncAppData{}
-	mi := &file_api_v2_service_proto_msgTypes[79]
+	mi := &file_api_v2_service_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5483,7 +5783,7 @@ func (x *SyncAppData) String() string {
 func (*SyncAppData) ProtoMessage() {}
 
 func (x *SyncAppData) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[79]
+	mi := &file_api_v2_service_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5496,7 +5796,7 @@ func (x *SyncAppData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncAppData.ProtoReflect.Descriptor instead.
 func (*SyncAppData) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{79}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{84}
 }
 
 func (x *SyncAppData) GetId() string {
@@ -5537,7 +5837,7 @@ type SyncAppError struct {
 
 func (x *SyncAppError) Reset() {
 	*x = SyncAppError{}
-	mi := &file_api_v2_service_proto_msgTypes[80]
+	mi := &file_api_v2_service_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5549,7 +5849,7 @@ func (x *SyncAppError) String() string {
 func (*SyncAppError) ProtoMessage() {}
 
 func (x *SyncAppError) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[80]
+	mi := &file_api_v2_service_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5562,7 +5862,7 @@ func (x *SyncAppError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SyncAppError.ProtoReflect.Descriptor instead.
 func (*SyncAppError) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{80}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{85}
 }
 
 func (x *SyncAppError) GetCode() string {
@@ -5588,7 +5888,7 @@ type QueryInsightsRequest struct {
 
 func (x *QueryInsightsRequest) Reset() {
 	*x = QueryInsightsRequest{}
-	mi := &file_api_v2_service_proto_msgTypes[81]
+	mi := &file_api_v2_service_proto_msgTypes[86]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5600,7 +5900,7 @@ func (x *QueryInsightsRequest) String() string {
 func (*QueryInsightsRequest) ProtoMessage() {}
 
 func (x *QueryInsightsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[81]
+	mi := &file_api_v2_service_proto_msgTypes[86]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5613,7 +5913,7 @@ func (x *QueryInsightsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryInsightsRequest.ProtoReflect.Descriptor instead.
 func (*QueryInsightsRequest) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{81}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{86}
 }
 
 func (x *QueryInsightsRequest) GetQuery() string {
@@ -5633,7 +5933,7 @@ type QueryInsightsResponse struct {
 
 func (x *QueryInsightsResponse) Reset() {
 	*x = QueryInsightsResponse{}
-	mi := &file_api_v2_service_proto_msgTypes[82]
+	mi := &file_api_v2_service_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5645,7 +5945,7 @@ func (x *QueryInsightsResponse) String() string {
 func (*QueryInsightsResponse) ProtoMessage() {}
 
 func (x *QueryInsightsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[82]
+	mi := &file_api_v2_service_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5658,7 +5958,7 @@ func (x *QueryInsightsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryInsightsResponse.ProtoReflect.Descriptor instead.
 func (*QueryInsightsResponse) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{82}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{87}
 }
 
 func (x *QueryInsightsResponse) GetData() *QueryInsightsData {
@@ -5686,7 +5986,7 @@ type QueryInsightsData struct {
 
 func (x *QueryInsightsData) Reset() {
 	*x = QueryInsightsData{}
-	mi := &file_api_v2_service_proto_msgTypes[83]
+	mi := &file_api_v2_service_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5698,7 +5998,7 @@ func (x *QueryInsightsData) String() string {
 func (*QueryInsightsData) ProtoMessage() {}
 
 func (x *QueryInsightsData) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[83]
+	mi := &file_api_v2_service_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5711,7 +6011,7 @@ func (x *QueryInsightsData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryInsightsData.ProtoReflect.Descriptor instead.
 func (*QueryInsightsData) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{83}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{88}
 }
 
 func (x *QueryInsightsData) GetColumns() []*InsightsOutputColumn {
@@ -5745,7 +6045,7 @@ type InsightsOutputColumn struct {
 
 func (x *InsightsOutputColumn) Reset() {
 	*x = InsightsOutputColumn{}
-	mi := &file_api_v2_service_proto_msgTypes[84]
+	mi := &file_api_v2_service_proto_msgTypes[89]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5757,7 +6057,7 @@ func (x *InsightsOutputColumn) String() string {
 func (*InsightsOutputColumn) ProtoMessage() {}
 
 func (x *InsightsOutputColumn) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[84]
+	mi := &file_api_v2_service_proto_msgTypes[89]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5770,7 +6070,7 @@ func (x *InsightsOutputColumn) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsightsOutputColumn.ProtoReflect.Descriptor instead.
 func (*InsightsOutputColumn) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{84}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{89}
 }
 
 func (x *InsightsOutputColumn) GetName() string {
@@ -5796,7 +6096,7 @@ type InsightsRow struct {
 
 func (x *InsightsRow) Reset() {
 	*x = InsightsRow{}
-	mi := &file_api_v2_service_proto_msgTypes[85]
+	mi := &file_api_v2_service_proto_msgTypes[90]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5808,7 +6108,7 @@ func (x *InsightsRow) String() string {
 func (*InsightsRow) ProtoMessage() {}
 
 func (x *InsightsRow) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[85]
+	mi := &file_api_v2_service_proto_msgTypes[90]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5821,7 +6121,7 @@ func (x *InsightsRow) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsightsRow.ProtoReflect.Descriptor instead.
 func (*InsightsRow) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{85}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{90}
 }
 
 func (x *InsightsRow) GetValues() []*structpb.Value {
@@ -5843,7 +6143,7 @@ type InsightsDiagnostic struct {
 
 func (x *InsightsDiagnostic) Reset() {
 	*x = InsightsDiagnostic{}
-	mi := &file_api_v2_service_proto_msgTypes[86]
+	mi := &file_api_v2_service_proto_msgTypes[91]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5855,7 +6155,7 @@ func (x *InsightsDiagnostic) String() string {
 func (*InsightsDiagnostic) ProtoMessage() {}
 
 func (x *InsightsDiagnostic) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[86]
+	mi := &file_api_v2_service_proto_msgTypes[91]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5868,7 +6168,7 @@ func (x *InsightsDiagnostic) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsightsDiagnostic.ProtoReflect.Descriptor instead.
 func (*InsightsDiagnostic) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{86}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{91}
 }
 
 func (x *InsightsDiagnostic) GetSeverity() InsightsDiagnosticSeverity {
@@ -5910,7 +6210,7 @@ type InsightsDiagnosticPosition struct {
 
 func (x *InsightsDiagnosticPosition) Reset() {
 	*x = InsightsDiagnosticPosition{}
-	mi := &file_api_v2_service_proto_msgTypes[87]
+	mi := &file_api_v2_service_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5922,7 +6222,7 @@ func (x *InsightsDiagnosticPosition) String() string {
 func (*InsightsDiagnosticPosition) ProtoMessage() {}
 
 func (x *InsightsDiagnosticPosition) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[87]
+	mi := &file_api_v2_service_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5935,7 +6235,7 @@ func (x *InsightsDiagnosticPosition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsightsDiagnosticPosition.ProtoReflect.Descriptor instead.
 func (*InsightsDiagnosticPosition) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{87}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{92}
 }
 
 func (x *InsightsDiagnosticPosition) GetStart() int32 {
@@ -5967,7 +6267,7 @@ type ListInsightsTablesRequest struct {
 
 func (x *ListInsightsTablesRequest) Reset() {
 	*x = ListInsightsTablesRequest{}
-	mi := &file_api_v2_service_proto_msgTypes[88]
+	mi := &file_api_v2_service_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5979,7 +6279,7 @@ func (x *ListInsightsTablesRequest) String() string {
 func (*ListInsightsTablesRequest) ProtoMessage() {}
 
 func (x *ListInsightsTablesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[88]
+	mi := &file_api_v2_service_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5992,7 +6292,7 @@ func (x *ListInsightsTablesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListInsightsTablesRequest.ProtoReflect.Descriptor instead.
 func (*ListInsightsTablesRequest) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{88}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{93}
 }
 
 type ListInsightsTablesResponse struct {
@@ -6005,7 +6305,7 @@ type ListInsightsTablesResponse struct {
 
 func (x *ListInsightsTablesResponse) Reset() {
 	*x = ListInsightsTablesResponse{}
-	mi := &file_api_v2_service_proto_msgTypes[89]
+	mi := &file_api_v2_service_proto_msgTypes[94]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6017,7 +6317,7 @@ func (x *ListInsightsTablesResponse) String() string {
 func (*ListInsightsTablesResponse) ProtoMessage() {}
 
 func (x *ListInsightsTablesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[89]
+	mi := &file_api_v2_service_proto_msgTypes[94]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6030,7 +6330,7 @@ func (x *ListInsightsTablesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListInsightsTablesResponse.ProtoReflect.Descriptor instead.
 func (*ListInsightsTablesResponse) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{89}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{94}
 }
 
 func (x *ListInsightsTablesResponse) GetData() []*InsightsTable {
@@ -6058,7 +6358,7 @@ type InsightsTable struct {
 
 func (x *InsightsTable) Reset() {
 	*x = InsightsTable{}
-	mi := &file_api_v2_service_proto_msgTypes[90]
+	mi := &file_api_v2_service_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6070,7 +6370,7 @@ func (x *InsightsTable) String() string {
 func (*InsightsTable) ProtoMessage() {}
 
 func (x *InsightsTable) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[90]
+	mi := &file_api_v2_service_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6083,7 +6383,7 @@ func (x *InsightsTable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsightsTable.ProtoReflect.Descriptor instead.
 func (*InsightsTable) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{90}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{95}
 }
 
 func (x *InsightsTable) GetName() string {
@@ -6118,7 +6418,7 @@ type InsightsTableColumn struct {
 
 func (x *InsightsTableColumn) Reset() {
 	*x = InsightsTableColumn{}
-	mi := &file_api_v2_service_proto_msgTypes[91]
+	mi := &file_api_v2_service_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6130,7 +6430,7 @@ func (x *InsightsTableColumn) String() string {
 func (*InsightsTableColumn) ProtoMessage() {}
 
 func (x *InsightsTableColumn) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[91]
+	mi := &file_api_v2_service_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6143,7 +6443,7 @@ func (x *InsightsTableColumn) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsightsTableColumn.ProtoReflect.Descriptor instead.
 func (*InsightsTableColumn) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{91}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{96}
 }
 
 func (x *InsightsTableColumn) GetName() string {
@@ -6176,7 +6476,7 @@ type QueryInsightsPromptRequest struct {
 
 func (x *QueryInsightsPromptRequest) Reset() {
 	*x = QueryInsightsPromptRequest{}
-	mi := &file_api_v2_service_proto_msgTypes[92]
+	mi := &file_api_v2_service_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6188,7 +6488,7 @@ func (x *QueryInsightsPromptRequest) String() string {
 func (*QueryInsightsPromptRequest) ProtoMessage() {}
 
 func (x *QueryInsightsPromptRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[92]
+	mi := &file_api_v2_service_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6201,7 +6501,7 @@ func (x *QueryInsightsPromptRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryInsightsPromptRequest.ProtoReflect.Descriptor instead.
 func (*QueryInsightsPromptRequest) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{92}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{97}
 }
 
 func (x *QueryInsightsPromptRequest) GetPrompt() string {
@@ -6221,7 +6521,7 @@ type QueryInsightsPromptResponse struct {
 
 func (x *QueryInsightsPromptResponse) Reset() {
 	*x = QueryInsightsPromptResponse{}
-	mi := &file_api_v2_service_proto_msgTypes[93]
+	mi := &file_api_v2_service_proto_msgTypes[98]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6233,7 +6533,7 @@ func (x *QueryInsightsPromptResponse) String() string {
 func (*QueryInsightsPromptResponse) ProtoMessage() {}
 
 func (x *QueryInsightsPromptResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[93]
+	mi := &file_api_v2_service_proto_msgTypes[98]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6246,7 +6546,7 @@ func (x *QueryInsightsPromptResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryInsightsPromptResponse.ProtoReflect.Descriptor instead.
 func (*QueryInsightsPromptResponse) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{93}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{98}
 }
 
 func (x *QueryInsightsPromptResponse) GetData() *QueryInsightsPromptData {
@@ -6273,7 +6573,7 @@ type QueryInsightsPromptData struct {
 
 func (x *QueryInsightsPromptData) Reset() {
 	*x = QueryInsightsPromptData{}
-	mi := &file_api_v2_service_proto_msgTypes[94]
+	mi := &file_api_v2_service_proto_msgTypes[99]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6285,7 +6585,7 @@ func (x *QueryInsightsPromptData) String() string {
 func (*QueryInsightsPromptData) ProtoMessage() {}
 
 func (x *QueryInsightsPromptData) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[94]
+	mi := &file_api_v2_service_proto_msgTypes[99]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6298,7 +6598,7 @@ func (x *QueryInsightsPromptData) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QueryInsightsPromptData.ProtoReflect.Descriptor instead.
 func (*QueryInsightsPromptData) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{94}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{99}
 }
 
 func (x *QueryInsightsPromptData) GetSql() string {
@@ -6325,7 +6625,7 @@ type ListInsightsEventSchemasRequest struct {
 
 func (x *ListInsightsEventSchemasRequest) Reset() {
 	*x = ListInsightsEventSchemasRequest{}
-	mi := &file_api_v2_service_proto_msgTypes[95]
+	mi := &file_api_v2_service_proto_msgTypes[100]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6337,7 +6637,7 @@ func (x *ListInsightsEventSchemasRequest) String() string {
 func (*ListInsightsEventSchemasRequest) ProtoMessage() {}
 
 func (x *ListInsightsEventSchemasRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[95]
+	mi := &file_api_v2_service_proto_msgTypes[100]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6350,7 +6650,7 @@ func (x *ListInsightsEventSchemasRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListInsightsEventSchemasRequest.ProtoReflect.Descriptor instead.
 func (*ListInsightsEventSchemasRequest) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{95}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{100}
 }
 
 func (x *ListInsightsEventSchemasRequest) GetCursor() string {
@@ -6378,7 +6678,7 @@ type ListInsightsEventSchemasResponse struct {
 
 func (x *ListInsightsEventSchemasResponse) Reset() {
 	*x = ListInsightsEventSchemasResponse{}
-	mi := &file_api_v2_service_proto_msgTypes[96]
+	mi := &file_api_v2_service_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6390,7 +6690,7 @@ func (x *ListInsightsEventSchemasResponse) String() string {
 func (*ListInsightsEventSchemasResponse) ProtoMessage() {}
 
 func (x *ListInsightsEventSchemasResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[96]
+	mi := &file_api_v2_service_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6403,7 +6703,7 @@ func (x *ListInsightsEventSchemasResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListInsightsEventSchemasResponse.ProtoReflect.Descriptor instead.
 func (*ListInsightsEventSchemasResponse) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{96}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{101}
 }
 
 func (x *ListInsightsEventSchemasResponse) GetData() []*InsightsEventSchema {
@@ -6437,7 +6737,7 @@ type InsightsEventSchema struct {
 
 func (x *InsightsEventSchema) Reset() {
 	*x = InsightsEventSchema{}
-	mi := &file_api_v2_service_proto_msgTypes[97]
+	mi := &file_api_v2_service_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6449,7 +6749,7 @@ func (x *InsightsEventSchema) String() string {
 func (*InsightsEventSchema) ProtoMessage() {}
 
 func (x *InsightsEventSchema) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[97]
+	mi := &file_api_v2_service_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6462,7 +6762,7 @@ func (x *InsightsEventSchema) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InsightsEventSchema.ProtoReflect.Descriptor instead.
 func (*InsightsEventSchema) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{97}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{102}
 }
 
 func (x *InsightsEventSchema) GetName() string {
@@ -6493,7 +6793,7 @@ type ListExperimentsRequest struct {
 
 func (x *ListExperimentsRequest) Reset() {
 	*x = ListExperimentsRequest{}
-	mi := &file_api_v2_service_proto_msgTypes[98]
+	mi := &file_api_v2_service_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6505,7 +6805,7 @@ func (x *ListExperimentsRequest) String() string {
 func (*ListExperimentsRequest) ProtoMessage() {}
 
 func (x *ListExperimentsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[98]
+	mi := &file_api_v2_service_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6518,7 +6818,7 @@ func (x *ListExperimentsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListExperimentsRequest.ProtoReflect.Descriptor instead.
 func (*ListExperimentsRequest) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{98}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{103}
 }
 
 func (x *ListExperimentsRequest) GetCursor() string {
@@ -6574,7 +6874,7 @@ type ListExperimentsResponse struct {
 
 func (x *ListExperimentsResponse) Reset() {
 	*x = ListExperimentsResponse{}
-	mi := &file_api_v2_service_proto_msgTypes[99]
+	mi := &file_api_v2_service_proto_msgTypes[104]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6586,7 +6886,7 @@ func (x *ListExperimentsResponse) String() string {
 func (*ListExperimentsResponse) ProtoMessage() {}
 
 func (x *ListExperimentsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[99]
+	mi := &file_api_v2_service_proto_msgTypes[104]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6599,7 +6899,7 @@ func (x *ListExperimentsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListExperimentsResponse.ProtoReflect.Descriptor instead.
 func (*ListExperimentsResponse) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{99}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{104}
 }
 
 func (x *ListExperimentsResponse) GetData() []*Experiment {
@@ -6639,7 +6939,7 @@ type Experiment struct {
 
 func (x *Experiment) Reset() {
 	*x = Experiment{}
-	mi := &file_api_v2_service_proto_msgTypes[100]
+	mi := &file_api_v2_service_proto_msgTypes[105]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6651,7 +6951,7 @@ func (x *Experiment) String() string {
 func (*Experiment) ProtoMessage() {}
 
 func (x *Experiment) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[100]
+	mi := &file_api_v2_service_proto_msgTypes[105]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6664,7 +6964,7 @@ func (x *Experiment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Experiment.ProtoReflect.Descriptor instead.
 func (*Experiment) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{100}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{105}
 }
 
 func (x *Experiment) GetId() string {
@@ -6737,7 +7037,7 @@ type GetExperimentRequest struct {
 
 func (x *GetExperimentRequest) Reset() {
 	*x = GetExperimentRequest{}
-	mi := &file_api_v2_service_proto_msgTypes[101]
+	mi := &file_api_v2_service_proto_msgTypes[106]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6749,7 +7049,7 @@ func (x *GetExperimentRequest) String() string {
 func (*GetExperimentRequest) ProtoMessage() {}
 
 func (x *GetExperimentRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[101]
+	mi := &file_api_v2_service_proto_msgTypes[106]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6762,7 +7062,7 @@ func (x *GetExperimentRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExperimentRequest.ProtoReflect.Descriptor instead.
 func (*GetExperimentRequest) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{101}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{106}
 }
 
 func (x *GetExperimentRequest) GetFunctionId() string {
@@ -6817,7 +7117,7 @@ type GetExperimentResponse struct {
 
 func (x *GetExperimentResponse) Reset() {
 	*x = GetExperimentResponse{}
-	mi := &file_api_v2_service_proto_msgTypes[102]
+	mi := &file_api_v2_service_proto_msgTypes[107]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6829,7 +7129,7 @@ func (x *GetExperimentResponse) String() string {
 func (*GetExperimentResponse) ProtoMessage() {}
 
 func (x *GetExperimentResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[102]
+	mi := &file_api_v2_service_proto_msgTypes[107]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6842,7 +7142,7 @@ func (x *GetExperimentResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetExperimentResponse.ProtoReflect.Descriptor instead.
 func (*GetExperimentResponse) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{102}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{107}
 }
 
 func (x *GetExperimentResponse) GetData() *ExperimentDetail {
@@ -6873,7 +7173,7 @@ type ExperimentDetail struct {
 
 func (x *ExperimentDetail) Reset() {
 	*x = ExperimentDetail{}
-	mi := &file_api_v2_service_proto_msgTypes[103]
+	mi := &file_api_v2_service_proto_msgTypes[108]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6885,7 +7185,7 @@ func (x *ExperimentDetail) String() string {
 func (*ExperimentDetail) ProtoMessage() {}
 
 func (x *ExperimentDetail) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[103]
+	mi := &file_api_v2_service_proto_msgTypes[108]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6898,7 +7198,7 @@ func (x *ExperimentDetail) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExperimentDetail.ProtoReflect.Descriptor instead.
 func (*ExperimentDetail) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{103}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{108}
 }
 
 func (x *ExperimentDetail) GetId() string {
@@ -6954,7 +7254,7 @@ type ExperimentVariantMetrics struct {
 
 func (x *ExperimentVariantMetrics) Reset() {
 	*x = ExperimentVariantMetrics{}
-	mi := &file_api_v2_service_proto_msgTypes[104]
+	mi := &file_api_v2_service_proto_msgTypes[109]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6966,7 +7266,7 @@ func (x *ExperimentVariantMetrics) String() string {
 func (*ExperimentVariantMetrics) ProtoMessage() {}
 
 func (x *ExperimentVariantMetrics) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[104]
+	mi := &file_api_v2_service_proto_msgTypes[109]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6979,7 +7279,7 @@ func (x *ExperimentVariantMetrics) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExperimentVariantMetrics.ProtoReflect.Descriptor instead.
 func (*ExperimentVariantMetrics) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{104}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{109}
 }
 
 func (x *ExperimentVariantMetrics) GetVariantName() string {
@@ -7015,7 +7315,7 @@ type ExperimentVariantMetric struct {
 
 func (x *ExperimentVariantMetric) Reset() {
 	*x = ExperimentVariantMetric{}
-	mi := &file_api_v2_service_proto_msgTypes[105]
+	mi := &file_api_v2_service_proto_msgTypes[110]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7027,7 +7327,7 @@ func (x *ExperimentVariantMetric) String() string {
 func (*ExperimentVariantMetric) ProtoMessage() {}
 
 func (x *ExperimentVariantMetric) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[105]
+	mi := &file_api_v2_service_proto_msgTypes[110]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7040,7 +7340,7 @@ func (x *ExperimentVariantMetric) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExperimentVariantMetric.ProtoReflect.Descriptor instead.
 func (*ExperimentVariantMetric) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{105}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{110}
 }
 
 func (x *ExperimentVariantMetric) GetKey() string {
@@ -7081,7 +7381,7 @@ type ExperimentVariantWeight struct {
 
 func (x *ExperimentVariantWeight) Reset() {
 	*x = ExperimentVariantWeight{}
-	mi := &file_api_v2_service_proto_msgTypes[106]
+	mi := &file_api_v2_service_proto_msgTypes[111]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7093,7 +7393,7 @@ func (x *ExperimentVariantWeight) String() string {
 func (*ExperimentVariantWeight) ProtoMessage() {}
 
 func (x *ExperimentVariantWeight) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[106]
+	mi := &file_api_v2_service_proto_msgTypes[111]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7106,7 +7406,7 @@ func (x *ExperimentVariantWeight) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExperimentVariantWeight.ProtoReflect.Descriptor instead.
 func (*ExperimentVariantWeight) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{106}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{111}
 }
 
 func (x *ExperimentVariantWeight) GetVariantName() string {
@@ -7134,7 +7434,7 @@ type ListSessionKeysRequest struct {
 
 func (x *ListSessionKeysRequest) Reset() {
 	*x = ListSessionKeysRequest{}
-	mi := &file_api_v2_service_proto_msgTypes[107]
+	mi := &file_api_v2_service_proto_msgTypes[112]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7146,7 +7446,7 @@ func (x *ListSessionKeysRequest) String() string {
 func (*ListSessionKeysRequest) ProtoMessage() {}
 
 func (x *ListSessionKeysRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[107]
+	mi := &file_api_v2_service_proto_msgTypes[112]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7159,7 +7459,7 @@ func (x *ListSessionKeysRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSessionKeysRequest.ProtoReflect.Descriptor instead.
 func (*ListSessionKeysRequest) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{107}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{112}
 }
 
 func (x *ListSessionKeysRequest) GetSearch() string {
@@ -7194,7 +7494,7 @@ type ListSessionKeysResponse struct {
 
 func (x *ListSessionKeysResponse) Reset() {
 	*x = ListSessionKeysResponse{}
-	mi := &file_api_v2_service_proto_msgTypes[108]
+	mi := &file_api_v2_service_proto_msgTypes[113]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7206,7 +7506,7 @@ func (x *ListSessionKeysResponse) String() string {
 func (*ListSessionKeysResponse) ProtoMessage() {}
 
 func (x *ListSessionKeysResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[108]
+	mi := &file_api_v2_service_proto_msgTypes[113]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7219,7 +7519,7 @@ func (x *ListSessionKeysResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSessionKeysResponse.ProtoReflect.Descriptor instead.
 func (*ListSessionKeysResponse) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{108}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{113}
 }
 
 func (x *ListSessionKeysResponse) GetData() []*SessionKey {
@@ -7253,7 +7553,7 @@ type SessionKey struct {
 
 func (x *SessionKey) Reset() {
 	*x = SessionKey{}
-	mi := &file_api_v2_service_proto_msgTypes[109]
+	mi := &file_api_v2_service_proto_msgTypes[114]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7265,7 +7565,7 @@ func (x *SessionKey) String() string {
 func (*SessionKey) ProtoMessage() {}
 
 func (x *SessionKey) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[109]
+	mi := &file_api_v2_service_proto_msgTypes[114]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7278,7 +7578,7 @@ func (x *SessionKey) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionKey.ProtoReflect.Descriptor instead.
 func (*SessionKey) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{109}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{114}
 }
 
 func (x *SessionKey) GetId() string {
@@ -7309,7 +7609,7 @@ type ListSessionsRequest struct {
 
 func (x *ListSessionsRequest) Reset() {
 	*x = ListSessionsRequest{}
-	mi := &file_api_v2_service_proto_msgTypes[110]
+	mi := &file_api_v2_service_proto_msgTypes[115]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7321,7 +7621,7 @@ func (x *ListSessionsRequest) String() string {
 func (*ListSessionsRequest) ProtoMessage() {}
 
 func (x *ListSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[110]
+	mi := &file_api_v2_service_proto_msgTypes[115]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7334,7 +7634,7 @@ func (x *ListSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ListSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{110}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{115}
 }
 
 func (x *ListSessionsRequest) GetSessionKey() string {
@@ -7390,7 +7690,7 @@ type ListSessionsResponse struct {
 
 func (x *ListSessionsResponse) Reset() {
 	*x = ListSessionsResponse{}
-	mi := &file_api_v2_service_proto_msgTypes[111]
+	mi := &file_api_v2_service_proto_msgTypes[116]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7402,7 +7702,7 @@ func (x *ListSessionsResponse) String() string {
 func (*ListSessionsResponse) ProtoMessage() {}
 
 func (x *ListSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[111]
+	mi := &file_api_v2_service_proto_msgTypes[116]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7415,7 +7715,7 @@ func (x *ListSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ListSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{111}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{116}
 }
 
 func (x *ListSessionsResponse) GetData() []*SessionGroup {
@@ -7453,7 +7753,7 @@ type SessionGroup struct {
 
 func (x *SessionGroup) Reset() {
 	*x = SessionGroup{}
-	mi := &file_api_v2_service_proto_msgTypes[112]
+	mi := &file_api_v2_service_proto_msgTypes[117]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7465,7 +7765,7 @@ func (x *SessionGroup) String() string {
 func (*SessionGroup) ProtoMessage() {}
 
 func (x *SessionGroup) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[112]
+	mi := &file_api_v2_service_proto_msgTypes[117]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7478,7 +7778,7 @@ func (x *SessionGroup) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionGroup.ProtoReflect.Descriptor instead.
 func (*SessionGroup) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{112}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{117}
 }
 
 func (x *SessionGroup) GetId() string {
@@ -7537,7 +7837,7 @@ type ListSessionRunsRequest struct {
 
 func (x *ListSessionRunsRequest) Reset() {
 	*x = ListSessionRunsRequest{}
-	mi := &file_api_v2_service_proto_msgTypes[113]
+	mi := &file_api_v2_service_proto_msgTypes[118]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7549,7 +7849,7 @@ func (x *ListSessionRunsRequest) String() string {
 func (*ListSessionRunsRequest) ProtoMessage() {}
 
 func (x *ListSessionRunsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[113]
+	mi := &file_api_v2_service_proto_msgTypes[118]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7562,7 +7862,7 @@ func (x *ListSessionRunsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSessionRunsRequest.ProtoReflect.Descriptor instead.
 func (*ListSessionRunsRequest) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{113}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{118}
 }
 
 func (x *ListSessionRunsRequest) GetSessionKey() string {
@@ -7618,7 +7918,7 @@ type ListSessionRunsResponse struct {
 
 func (x *ListSessionRunsResponse) Reset() {
 	*x = ListSessionRunsResponse{}
-	mi := &file_api_v2_service_proto_msgTypes[114]
+	mi := &file_api_v2_service_proto_msgTypes[119]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7630,7 +7930,7 @@ func (x *ListSessionRunsResponse) String() string {
 func (*ListSessionRunsResponse) ProtoMessage() {}
 
 func (x *ListSessionRunsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[114]
+	mi := &file_api_v2_service_proto_msgTypes[119]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7643,7 +7943,7 @@ func (x *ListSessionRunsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSessionRunsResponse.ProtoReflect.Descriptor instead.
 func (*ListSessionRunsResponse) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{114}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{119}
 }
 
 func (x *ListSessionRunsResponse) GetData() []*SessionRun {
@@ -7682,7 +7982,7 @@ type SessionRun struct {
 
 func (x *SessionRun) Reset() {
 	*x = SessionRun{}
-	mi := &file_api_v2_service_proto_msgTypes[115]
+	mi := &file_api_v2_service_proto_msgTypes[120]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7694,7 +7994,7 @@ func (x *SessionRun) String() string {
 func (*SessionRun) ProtoMessage() {}
 
 func (x *SessionRun) ProtoReflect() protoreflect.Message {
-	mi := &file_api_v2_service_proto_msgTypes[115]
+	mi := &file_api_v2_service_proto_msgTypes[120]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7707,7 +8007,7 @@ func (x *SessionRun) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionRun.ProtoReflect.Descriptor instead.
 func (*SessionRun) Descriptor() ([]byte, []int) {
-	return file_api_v2_service_proto_rawDescGZIP(), []int{115}
+	return file_api_v2_service_proto_rawDescGZIP(), []int{120}
 }
 
 func (x *SessionRun) GetId() string {
@@ -8205,7 +8505,40 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\v_started_atB\x0f\n" +
 	"\r_completed_atB\t\n" +
 	"\a_resultB\b\n" +
-	"\x06_error\"\xa1\x01\n" +
+	"\x06_error\"\xfd\x02\n" +
+	"\x12CreateScoreRequest\x12d\n" +
+	"\x06run_id\x18\x01 \x01(\tBM\x92AJ2*Run ID (ULID) of the function run to scoreJ\x1c\"01JLW1NNJ69KCD1KMJEXAMPLE0\"R\x05runId\x12\x80\x02\n" +
+	"\x06scores\x18\x02 \x03(\v2\x18.api.v2.CreateScoreInputB\xcd\x01\x92A\xc9\x012\xc6\x01Scores to record for the run. The REST request body is this array. Writes are applied in order and are not atomic; if a later score fails, earlier scores may already be recorded. Maximum 100 scores.R\x06scores\"\x9b\x05\n" +
+	"\x10CreateScoreInput\x12P\n" +
+	"\x04name\x18\x01 \x01(\tB<\x92A92+Score name; must be at most 128 UTF-8 bytesJ\n" +
+	"\"accuracy\"R\x04name\x12j\n" +
+	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueB<\x92A921Score value; must be a finite number or a booleanJ\x040.95R\x05value\x12\x85\x01\n" +
+	"\astep_id\x18\x03 \x01(\tBg\x92Ad2NOptional SDK step ID; attaches the score to a specific step instead of the runJ\x12\"generate-summary\"H\x00R\x06stepId\x88\x01\x01\x12\xa5\x02\n" +
+	"\n" +
+	"experiment\x18\x04 \x01(\v2\x17.api.v2.ScoreExperimentB\xe6\x01\x92A\xe2\x012\xdf\x01Optional experiment context. When provided, the score is recorded with the same experiment metadata emitted by the SDK's score.experiment API. Experiment scores should be run-scoped for experiment aggregate and detail APIs.H\x01R\n" +
+	"experiment\x88\x01\x01B\n" +
+	"\n" +
+	"\b_step_idB\r\n" +
+	"\v_experiment\"\xa0\x01\n" +
+	"\x0fScoreExperiment\x12N\n" +
+	"\x0fexperiment_name\x18\x01 \x01(\tB%\x92A\"2\x0fExperiment nameJ\x0f\"model-routing\"R\x0eexperimentName\x12=\n" +
+	"\avariant\x18\x02 \x01(\tB#\x92A 2\x12Experiment variantJ\n" +
+	"\"baseline\"R\avariant\"n\n" +
+	"\x13CreateScoreResponse\x12!\n" +
+	"\x04data\x18\x01 \x03(\v2\r.api.v2.ScoreR\x04data\x124\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"\xa9\x03\n" +
+	"\x05Score\x12A\n" +
+	"\x06run_id\x18\x01 \x01(\tB*\x92A'2%Run ID the score was recorded againstR\x05runId\x12#\n" +
+	"\x04name\x18\x02 \x01(\tB\x0f\x92A\f2\n" +
+	"Score nameR\x04name\x12>\n" +
+	"\x05value\x18\x03 \x01(\v2\x16.google.protobuf.ValueB\x10\x92A\r2\vScore valueR\x05value\x12Y\n" +
+	"\astep_id\x18\x04 \x01(\tB;\x92A826Step ID the score was recorded against, if step-scopedH\x00R\x06stepId\x88\x01\x01\x12\x81\x01\n" +
+	"\n" +
+	"experiment\x18\x05 \x01(\v2\x17.api.v2.ScoreExperimentBC\x92A@2>Experiment context the score was recorded against, if providedH\x01R\n" +
+	"experiment\x88\x01\x01B\n" +
+	"\n" +
+	"\b_step_idB\r\n" +
+	"\v_experiment\"\xa1\x01\n" +
 	"\x0eSyncAppRequest\x12,\n" +
 	"\x06app_id\x18\x01 \x01(\tB\x15\x92A\x122\x06App IDJ\b\"my-app\"R\x05appId\x12a\n" +
 	"\x03url\x18\x02 \x01(\tBO\x92AL2'URL for the Inngest endpoint in the appJ!\"https://example.com/api/inngest\"R\x03url\"p\n" +
@@ -8476,7 +8809,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05ERROR\x10\x01\x12\v\n" +
 	"\aWARNING\x10\x02\x12\b\n" +
-	"\x04INFO\x10\x032\x81}\n" +
+	"\x04INFO\x10\x032\xcf\x7f\n" +
 	"\x02V2\x12\xbc\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\x82\x02\x92A\xef\x01\n" +
 	"\bInternal\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
@@ -8748,7 +9081,13 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x04Beta\x12\aGet app\x1aLFetches details for a single app, including sync metadata and function countb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x10\x12\x0e/apps/{app_id}\x12\xca\x06\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x10\x12\x0e/apps/{app_id}\x12\xcb\x02\n" +
+	"\vCreateScore\x12\x1a.api.v2.CreateScoreRequest\x1a\x1b.api.v2.CreateScoreResponse\"\x82\x02\x92A\xd9\x01\n" +
+	"\x04Runs\n" +
+	"\x04Beta\x12\fCreate score\x1a\xaa\x01Submits one or more named scores for a function run, or for specific steps when step IDs are provided. Scores are recorded as run metadata and aggregated for experiments.b\x10\n" +
+	"\x0e\n" +
+	"\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x1f:\x06scores\"\x15/runs/{run_id}/scores\x12\xca\x06\n" +
 	"\aSyncApp\x12\x16.api.v2.SyncAppRequest\x1a\x17.api.v2.SyncAppResponse\"\x8d\x06\x92A\xea\x05\n" +
 	"\x04Apps\n" +
 	"\x04Beta\x12\bSync app\x1a Sync an app at the provided URL.JE\n" +
@@ -8985,7 +9324,7 @@ func file_api_v2_service_proto_rawDescGZIP() []byte {
 }
 
 var file_api_v2_service_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
-var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 117)
+var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 122)
 var file_api_v2_service_proto_goTypes = []any{
 	(FunctionRunStatus)(0),                        // 0: api.v2.FunctionRunStatus
 	(TraceSpanStatus)(0),                          // 1: api.v2.TraceSpanStatus
@@ -9075,60 +9414,65 @@ var file_api_v2_service_proto_goTypes = []any{
 	(*InvokeFunctionRequest)(nil),                 // 85: api.v2.InvokeFunctionRequest
 	(*InvokeFunctionResponse)(nil),                // 86: api.v2.InvokeFunctionResponse
 	(*InvokeFunctionData)(nil),                    // 87: api.v2.InvokeFunctionData
-	(*SyncAppRequest)(nil),                        // 88: api.v2.SyncAppRequest
-	(*SyncAppResponse)(nil),                       // 89: api.v2.SyncAppResponse
-	(*SyncAppData)(nil),                           // 90: api.v2.SyncAppData
-	(*SyncAppError)(nil),                          // 91: api.v2.SyncAppError
-	(*QueryInsightsRequest)(nil),                  // 92: api.v2.QueryInsightsRequest
-	(*QueryInsightsResponse)(nil),                 // 93: api.v2.QueryInsightsResponse
-	(*QueryInsightsData)(nil),                     // 94: api.v2.QueryInsightsData
-	(*InsightsOutputColumn)(nil),                  // 95: api.v2.InsightsOutputColumn
-	(*InsightsRow)(nil),                           // 96: api.v2.InsightsRow
-	(*InsightsDiagnostic)(nil),                    // 97: api.v2.InsightsDiagnostic
-	(*InsightsDiagnosticPosition)(nil),            // 98: api.v2.InsightsDiagnosticPosition
-	(*ListInsightsTablesRequest)(nil),             // 99: api.v2.ListInsightsTablesRequest
-	(*ListInsightsTablesResponse)(nil),            // 100: api.v2.ListInsightsTablesResponse
-	(*InsightsTable)(nil),                         // 101: api.v2.InsightsTable
-	(*InsightsTableColumn)(nil),                   // 102: api.v2.InsightsTableColumn
-	(*QueryInsightsPromptRequest)(nil),            // 103: api.v2.QueryInsightsPromptRequest
-	(*QueryInsightsPromptResponse)(nil),           // 104: api.v2.QueryInsightsPromptResponse
-	(*QueryInsightsPromptData)(nil),               // 105: api.v2.QueryInsightsPromptData
-	(*ListInsightsEventSchemasRequest)(nil),       // 106: api.v2.ListInsightsEventSchemasRequest
-	(*ListInsightsEventSchemasResponse)(nil),      // 107: api.v2.ListInsightsEventSchemasResponse
-	(*InsightsEventSchema)(nil),                   // 108: api.v2.InsightsEventSchema
-	(*ListExperimentsRequest)(nil),                // 109: api.v2.ListExperimentsRequest
-	(*ListExperimentsResponse)(nil),               // 110: api.v2.ListExperimentsResponse
-	(*Experiment)(nil),                            // 111: api.v2.Experiment
-	(*GetExperimentRequest)(nil),                  // 112: api.v2.GetExperimentRequest
-	(*GetExperimentResponse)(nil),                 // 113: api.v2.GetExperimentResponse
-	(*ExperimentDetail)(nil),                      // 114: api.v2.ExperimentDetail
-	(*ExperimentVariantMetrics)(nil),              // 115: api.v2.ExperimentVariantMetrics
-	(*ExperimentVariantMetric)(nil),               // 116: api.v2.ExperimentVariantMetric
-	(*ExperimentVariantWeight)(nil),               // 117: api.v2.ExperimentVariantWeight
-	(*ListSessionKeysRequest)(nil),                // 118: api.v2.ListSessionKeysRequest
-	(*ListSessionKeysResponse)(nil),               // 119: api.v2.ListSessionKeysResponse
-	(*SessionKey)(nil),                            // 120: api.v2.SessionKey
-	(*ListSessionsRequest)(nil),                   // 121: api.v2.ListSessionsRequest
-	(*ListSessionsResponse)(nil),                  // 122: api.v2.ListSessionsResponse
-	(*SessionGroup)(nil),                          // 123: api.v2.SessionGroup
-	(*ListSessionRunsRequest)(nil),                // 124: api.v2.ListSessionRunsRequest
-	(*ListSessionRunsResponse)(nil),               // 125: api.v2.ListSessionRunsResponse
-	(*SessionRun)(nil),                            // 126: api.v2.SessionRun
-	nil,                                           // 127: api.v2.TraceSpanMetadata.ValuesEntry
-	(*timestamppb.Timestamp)(nil),                 // 128: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                       // 129: google.protobuf.Struct
-	(*structpb.ListValue)(nil),                    // 130: google.protobuf.ListValue
-	(*structpb.Value)(nil),                        // 131: google.protobuf.Value
+	(*CreateScoreRequest)(nil),                    // 88: api.v2.CreateScoreRequest
+	(*CreateScoreInput)(nil),                      // 89: api.v2.CreateScoreInput
+	(*ScoreExperiment)(nil),                       // 90: api.v2.ScoreExperiment
+	(*CreateScoreResponse)(nil),                   // 91: api.v2.CreateScoreResponse
+	(*Score)(nil),                                 // 92: api.v2.Score
+	(*SyncAppRequest)(nil),                        // 93: api.v2.SyncAppRequest
+	(*SyncAppResponse)(nil),                       // 94: api.v2.SyncAppResponse
+	(*SyncAppData)(nil),                           // 95: api.v2.SyncAppData
+	(*SyncAppError)(nil),                          // 96: api.v2.SyncAppError
+	(*QueryInsightsRequest)(nil),                  // 97: api.v2.QueryInsightsRequest
+	(*QueryInsightsResponse)(nil),                 // 98: api.v2.QueryInsightsResponse
+	(*QueryInsightsData)(nil),                     // 99: api.v2.QueryInsightsData
+	(*InsightsOutputColumn)(nil),                  // 100: api.v2.InsightsOutputColumn
+	(*InsightsRow)(nil),                           // 101: api.v2.InsightsRow
+	(*InsightsDiagnostic)(nil),                    // 102: api.v2.InsightsDiagnostic
+	(*InsightsDiagnosticPosition)(nil),            // 103: api.v2.InsightsDiagnosticPosition
+	(*ListInsightsTablesRequest)(nil),             // 104: api.v2.ListInsightsTablesRequest
+	(*ListInsightsTablesResponse)(nil),            // 105: api.v2.ListInsightsTablesResponse
+	(*InsightsTable)(nil),                         // 106: api.v2.InsightsTable
+	(*InsightsTableColumn)(nil),                   // 107: api.v2.InsightsTableColumn
+	(*QueryInsightsPromptRequest)(nil),            // 108: api.v2.QueryInsightsPromptRequest
+	(*QueryInsightsPromptResponse)(nil),           // 109: api.v2.QueryInsightsPromptResponse
+	(*QueryInsightsPromptData)(nil),               // 110: api.v2.QueryInsightsPromptData
+	(*ListInsightsEventSchemasRequest)(nil),       // 111: api.v2.ListInsightsEventSchemasRequest
+	(*ListInsightsEventSchemasResponse)(nil),      // 112: api.v2.ListInsightsEventSchemasResponse
+	(*InsightsEventSchema)(nil),                   // 113: api.v2.InsightsEventSchema
+	(*ListExperimentsRequest)(nil),                // 114: api.v2.ListExperimentsRequest
+	(*ListExperimentsResponse)(nil),               // 115: api.v2.ListExperimentsResponse
+	(*Experiment)(nil),                            // 116: api.v2.Experiment
+	(*GetExperimentRequest)(nil),                  // 117: api.v2.GetExperimentRequest
+	(*GetExperimentResponse)(nil),                 // 118: api.v2.GetExperimentResponse
+	(*ExperimentDetail)(nil),                      // 119: api.v2.ExperimentDetail
+	(*ExperimentVariantMetrics)(nil),              // 120: api.v2.ExperimentVariantMetrics
+	(*ExperimentVariantMetric)(nil),               // 121: api.v2.ExperimentVariantMetric
+	(*ExperimentVariantWeight)(nil),               // 122: api.v2.ExperimentVariantWeight
+	(*ListSessionKeysRequest)(nil),                // 123: api.v2.ListSessionKeysRequest
+	(*ListSessionKeysResponse)(nil),               // 124: api.v2.ListSessionKeysResponse
+	(*SessionKey)(nil),                            // 125: api.v2.SessionKey
+	(*ListSessionsRequest)(nil),                   // 126: api.v2.ListSessionsRequest
+	(*ListSessionsResponse)(nil),                  // 127: api.v2.ListSessionsResponse
+	(*SessionGroup)(nil),                          // 128: api.v2.SessionGroup
+	(*ListSessionRunsRequest)(nil),                // 129: api.v2.ListSessionRunsRequest
+	(*ListSessionRunsResponse)(nil),               // 130: api.v2.ListSessionRunsResponse
+	(*SessionRun)(nil),                            // 131: api.v2.SessionRun
+	nil,                                           // 132: api.v2.TraceSpanMetadata.ValuesEntry
+	(*timestamppb.Timestamp)(nil),                 // 133: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                       // 134: google.protobuf.Struct
+	(*structpb.ListValue)(nil),                    // 135: google.protobuf.ListValue
+	(*structpb.Value)(nil),                        // 136: google.protobuf.Value
 }
 var file_api_v2_service_proto_depIdxs = []int32{
 	14,  // 0: api.v2.HealthResponse.data:type_name -> api.v2.HealthData
 	17,  // 1: api.v2.HealthResponse.metadata:type_name -> api.v2.ResponseMetadata
 	15,  // 2: api.v2.ErrorResponse.errors:type_name -> api.v2.Error
-	128, // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
-	128, // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
+	133, // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
+	133, // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
 	18,  // 5: api.v2.ResponseMetadata.time_range:type_name -> api.v2.TimeRange
-	128, // 6: api.v2.TimeRange.from:type_name -> google.protobuf.Timestamp
-	128, // 7: api.v2.TimeRange.until:type_name -> google.protobuf.Timestamp
+	133, // 6: api.v2.TimeRange.from:type_name -> google.protobuf.Timestamp
+	133, // 7: api.v2.TimeRange.until:type_name -> google.protobuf.Timestamp
 	20,  // 8: api.v2.FunctionRef.app:type_name -> api.v2.AppRef
 	3,   // 9: api.v2.FunctionTrigger.type:type_name -> api.v2.FunctionTriggerType
 	4,   // 10: api.v2.FunctionConcurrencyConfiguration.scope:type_name -> api.v2.FunctionConcurrencyScope
@@ -9149,29 +9493,29 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	19,  // 25: api.v2.FunctionRun.function:type_name -> api.v2.FunctionRef
 	20,  // 26: api.v2.FunctionRun.app:type_name -> api.v2.AppRef
 	0,   // 27: api.v2.FunctionRun.status:type_name -> api.v2.FunctionRunStatus
-	128, // 28: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
-	128, // 29: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
-	128, // 30: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
+	133, // 28: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
+	133, // 29: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
+	133, // 30: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
 	35,  // 31: api.v2.FunctionRun.trigger:type_name -> api.v2.RunTrigger
-	129, // 32: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
+	134, // 32: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
 	36,  // 33: api.v2.GetFunctionRunResponse.data:type_name -> api.v2.FunctionRun
 	17,  // 34: api.v2.GetFunctionRunResponse.metadata:type_name -> api.v2.ResponseMetadata
 	36,  // 35: api.v2.GetEventRunsResponse.data:type_name -> api.v2.FunctionRun
 	17,  // 36: api.v2.GetEventRunsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 37: api.v2.GetEventRunsResponse.page:type_name -> api.v2.Page
 	42,  // 38: api.v2.RerunRequest.from_step:type_name -> api.v2.RerunFromStep
-	130, // 39: api.v2.RerunFromStep.input:type_name -> google.protobuf.ListValue
+	135, // 39: api.v2.RerunFromStep.input:type_name -> google.protobuf.ListValue
 	44,  // 40: api.v2.RerunResponse.data:type_name -> api.v2.RerunData
 	17,  // 41: api.v2.RerunResponse.metadata:type_name -> api.v2.ResponseMetadata
-	127, // 42: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
-	128, // 43: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
+	132, // 42: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
+	133, // 43: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
 	1,   // 44: api.v2.TraceSpan.status:type_name -> api.v2.TraceSpanStatus
 	2,   // 45: api.v2.TraceSpan.step_op:type_name -> api.v2.TraceStepOp
-	128, // 46: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
-	128, // 47: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
-	128, // 48: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
-	129, // 49: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
-	129, // 50: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
+	133, // 46: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
+	133, // 47: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
+	133, // 48: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
+	134, // 49: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
+	134, // 50: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
 	45,  // 51: api.v2.TraceSpan.metadata:type_name -> api.v2.TraceSpanMetadata
 	46,  // 52: api.v2.TraceSpan.children:type_name -> api.v2.TraceSpan
 	46,  // 53: api.v2.FunctionTrace.root_span:type_name -> api.v2.TraceSpan
@@ -9180,10 +9524,10 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	34,  // 56: api.v2.GetFunctionResponse.data:type_name -> api.v2.Function
 	17,  // 57: api.v2.GetFunctionResponse.metadata:type_name -> api.v2.ResponseMetadata
 	6,   // 58: api.v2.App.method:type_name -> api.v2.AppMethod
-	128, // 59: api.v2.App.created_at:type_name -> google.protobuf.Timestamp
-	128, // 60: api.v2.App.archived_at:type_name -> google.protobuf.Timestamp
+	133, // 59: api.v2.App.created_at:type_name -> google.protobuf.Timestamp
+	133, // 60: api.v2.App.archived_at:type_name -> google.protobuf.Timestamp
 	53,  // 61: api.v2.App.latest_sync:type_name -> api.v2.AppSync
-	128, // 62: api.v2.AppSync.synced_at:type_name -> google.protobuf.Timestamp
+	133, // 62: api.v2.AppSync.synced_at:type_name -> google.protobuf.Timestamp
 	52,  // 63: api.v2.GetAppResponse.data:type_name -> api.v2.App
 	17,  // 64: api.v2.GetAppResponse.metadata:type_name -> api.v2.ResponseMetadata
 	34,  // 65: api.v2.GetFunctionsResponse.data:type_name -> api.v2.Function
@@ -9194,27 +9538,27 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	62,  // 70: api.v2.CreateEnvResponse.data:type_name -> api.v2.Env
 	17,  // 71: api.v2.CreateEnvResponse.metadata:type_name -> api.v2.ResponseMetadata
 	7,   // 72: api.v2.Env.type:type_name -> api.v2.EnvType
-	128, // 73: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
-	128, // 74: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
-	128, // 75: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
+	133, // 73: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
+	133, // 74: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
+	133, // 75: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
 	67,  // 76: api.v2.FetchAccountsResponse.data:type_name -> api.v2.Account
 	17,  // 77: api.v2.FetchAccountsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 78: api.v2.FetchAccountsResponse.page:type_name -> api.v2.Page
 	67,  // 79: api.v2.FetchAccountResponse.data:type_name -> api.v2.Account
 	17,  // 80: api.v2.FetchAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
-	128, // 81: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
-	128, // 82: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
+	133, // 81: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
+	133, // 82: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
 	71,  // 83: api.v2.FetchAccountEventKeysResponse.data:type_name -> api.v2.EventKey
 	17,  // 84: api.v2.FetchAccountEventKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 85: api.v2.FetchAccountEventKeysResponse.page:type_name -> api.v2.Page
-	128, // 86: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
+	133, // 86: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
 	62,  // 87: api.v2.FetchAccountEnvsResponse.data:type_name -> api.v2.Env
 	17,  // 88: api.v2.FetchAccountEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 89: api.v2.FetchAccountEnvsResponse.page:type_name -> api.v2.Page
 	76,  // 90: api.v2.FetchAccountSigningKeysResponse.data:type_name -> api.v2.SigningKey
 	17,  // 91: api.v2.FetchAccountSigningKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 92: api.v2.FetchAccountSigningKeysResponse.page:type_name -> api.v2.Page
-	128, // 93: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
+	133, // 93: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
 	79,  // 94: api.v2.CreateWebhookRequest.event_filter:type_name -> api.v2.EventFilter
 	82,  // 95: api.v2.CreateWebhookResponse.data:type_name -> api.v2.Webhook
 	17,  // 96: api.v2.CreateWebhookResponse.metadata:type_name -> api.v2.ResponseMetadata
@@ -9223,140 +9567,149 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	17,  // 99: api.v2.ListWebhooksResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 100: api.v2.ListWebhooksResponse.page:type_name -> api.v2.Page
 	79,  // 101: api.v2.Webhook.event_filter:type_name -> api.v2.EventFilter
-	128, // 102: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
-	128, // 103: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
+	133, // 102: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
+	133, // 103: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
 	62,  // 104: api.v2.PatchEnvsResponse.data:type_name -> api.v2.Env
 	17,  // 105: api.v2.PatchEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	129, // 106: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
+	134, // 106: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
 	87,  // 107: api.v2.InvokeFunctionResponse.data:type_name -> api.v2.InvokeFunctionData
 	17,  // 108: api.v2.InvokeFunctionResponse.metadata:type_name -> api.v2.ResponseMetadata
-	128, // 109: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
-	128, // 110: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
-	128, // 111: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
-	90,  // 112: api.v2.SyncAppResponse.data:type_name -> api.v2.SyncAppData
-	17,  // 113: api.v2.SyncAppResponse.metadata:type_name -> api.v2.ResponseMetadata
-	91,  // 114: api.v2.SyncAppData.error:type_name -> api.v2.SyncAppError
-	94,  // 115: api.v2.QueryInsightsResponse.data:type_name -> api.v2.QueryInsightsData
-	17,  // 116: api.v2.QueryInsightsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	95,  // 117: api.v2.QueryInsightsData.columns:type_name -> api.v2.InsightsOutputColumn
-	96,  // 118: api.v2.QueryInsightsData.rows:type_name -> api.v2.InsightsRow
-	97,  // 119: api.v2.QueryInsightsData.diagnostics:type_name -> api.v2.InsightsDiagnostic
-	9,   // 120: api.v2.InsightsOutputColumn.type:type_name -> api.v2.InsightsOutputColumnType
-	131, // 121: api.v2.InsightsRow.values:type_name -> google.protobuf.Value
-	10,  // 122: api.v2.InsightsDiagnostic.severity:type_name -> api.v2.InsightsDiagnosticSeverity
-	98,  // 123: api.v2.InsightsDiagnostic.position:type_name -> api.v2.InsightsDiagnosticPosition
-	101, // 124: api.v2.ListInsightsTablesResponse.data:type_name -> api.v2.InsightsTable
-	17,  // 125: api.v2.ListInsightsTablesResponse.metadata:type_name -> api.v2.ResponseMetadata
-	102, // 126: api.v2.InsightsTable.columns:type_name -> api.v2.InsightsTableColumn
-	105, // 127: api.v2.QueryInsightsPromptResponse.data:type_name -> api.v2.QueryInsightsPromptData
-	17,  // 128: api.v2.QueryInsightsPromptResponse.metadata:type_name -> api.v2.ResponseMetadata
-	108, // 129: api.v2.ListInsightsEventSchemasResponse.data:type_name -> api.v2.InsightsEventSchema
-	17,  // 130: api.v2.ListInsightsEventSchemasResponse.metadata:type_name -> api.v2.ResponseMetadata
-	68,  // 131: api.v2.ListInsightsEventSchemasResponse.page:type_name -> api.v2.Page
-	129, // 132: api.v2.InsightsEventSchema.schema:type_name -> google.protobuf.Struct
-	128, // 133: api.v2.ListExperimentsRequest.from:type_name -> google.protobuf.Timestamp
-	128, // 134: api.v2.ListExperimentsRequest.until:type_name -> google.protobuf.Timestamp
-	111, // 135: api.v2.ListExperimentsResponse.data:type_name -> api.v2.Experiment
-	17,  // 136: api.v2.ListExperimentsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	68,  // 137: api.v2.ListExperimentsResponse.page:type_name -> api.v2.Page
-	19,  // 138: api.v2.Experiment.function:type_name -> api.v2.FunctionRef
-	128, // 139: api.v2.Experiment.first_seen:type_name -> google.protobuf.Timestamp
-	128, // 140: api.v2.Experiment.last_seen:type_name -> google.protobuf.Timestamp
-	128, // 141: api.v2.GetExperimentRequest.from:type_name -> google.protobuf.Timestamp
-	128, // 142: api.v2.GetExperimentRequest.until:type_name -> google.protobuf.Timestamp
-	114, // 143: api.v2.GetExperimentResponse.data:type_name -> api.v2.ExperimentDetail
-	17,  // 144: api.v2.GetExperimentResponse.metadata:type_name -> api.v2.ResponseMetadata
-	115, // 145: api.v2.ExperimentDetail.variants:type_name -> api.v2.ExperimentVariantMetrics
-	117, // 146: api.v2.ExperimentDetail.variant_weights:type_name -> api.v2.ExperimentVariantWeight
-	128, // 147: api.v2.ExperimentDetail.first_seen:type_name -> google.protobuf.Timestamp
-	128, // 148: api.v2.ExperimentDetail.last_seen:type_name -> google.protobuf.Timestamp
-	116, // 149: api.v2.ExperimentVariantMetrics.metrics:type_name -> api.v2.ExperimentVariantMetric
-	120, // 150: api.v2.ListSessionKeysResponse.data:type_name -> api.v2.SessionKey
-	17,  // 151: api.v2.ListSessionKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
-	68,  // 152: api.v2.ListSessionKeysResponse.page:type_name -> api.v2.Page
-	128, // 153: api.v2.SessionKey.created_at:type_name -> google.protobuf.Timestamp
-	128, // 154: api.v2.ListSessionsRequest.from:type_name -> google.protobuf.Timestamp
-	128, // 155: api.v2.ListSessionsRequest.until:type_name -> google.protobuf.Timestamp
-	123, // 156: api.v2.ListSessionsResponse.data:type_name -> api.v2.SessionGroup
-	17,  // 157: api.v2.ListSessionsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	68,  // 158: api.v2.ListSessionsResponse.page:type_name -> api.v2.Page
-	128, // 159: api.v2.SessionGroup.last_active_at:type_name -> google.protobuf.Timestamp
-	19,  // 160: api.v2.SessionGroup.functions:type_name -> api.v2.FunctionRef
-	128, // 161: api.v2.ListSessionRunsRequest.from:type_name -> google.protobuf.Timestamp
-	128, // 162: api.v2.ListSessionRunsRequest.until:type_name -> google.protobuf.Timestamp
-	126, // 163: api.v2.ListSessionRunsResponse.data:type_name -> api.v2.SessionRun
-	17,  // 164: api.v2.ListSessionRunsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	68,  // 165: api.v2.ListSessionRunsResponse.page:type_name -> api.v2.Page
-	19,  // 166: api.v2.SessionRun.function:type_name -> api.v2.FunctionRef
-	0,   // 167: api.v2.SessionRun.status:type_name -> api.v2.FunctionRunStatus
-	128, // 168: api.v2.SessionRun.queued_at:type_name -> google.protobuf.Timestamp
-	128, // 169: api.v2.SessionRun.started_at:type_name -> google.protobuf.Timestamp
-	128, // 170: api.v2.SessionRun.ended_at:type_name -> google.protobuf.Timestamp
-	11,  // 171: api.v2.V2.Health:input_type -> api.v2.HealthRequest
-	11,  // 172: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
-	58,  // 173: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
-	60,  // 174: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
-	64,  // 175: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
-	12,  // 176: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
-	72,  // 177: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
-	69,  // 178: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
-	74,  // 179: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
-	77,  // 180: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
-	80,  // 181: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
-	83,  // 182: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
-	37,  // 183: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
-	39,  // 184: api.v2.V2.GetEventRuns:input_type -> api.v2.GetEventRunsRequest
-	41,  // 185: api.v2.V2.Rerun:input_type -> api.v2.RerunRequest
-	54,  // 186: api.v2.V2.GetApp:input_type -> api.v2.GetAppRequest
-	88,  // 187: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
-	48,  // 188: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
-	50,  // 189: api.v2.V2.GetFunction:input_type -> api.v2.GetFunctionRequest
-	56,  // 190: api.v2.V2.GetFunctions:input_type -> api.v2.GetFunctionsRequest
-	85,  // 191: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
-	99,  // 192: api.v2.V2.ListInsightsTables:input_type -> api.v2.ListInsightsTablesRequest
-	106, // 193: api.v2.V2.ListInsightsEventSchemas:input_type -> api.v2.ListInsightsEventSchemasRequest
-	103, // 194: api.v2.V2.QueryInsightsPrompt:input_type -> api.v2.QueryInsightsPromptRequest
-	92,  // 195: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
-	109, // 196: api.v2.V2.ListExperiments:input_type -> api.v2.ListExperimentsRequest
-	112, // 197: api.v2.V2.GetExperiment:input_type -> api.v2.GetExperimentRequest
-	118, // 198: api.v2.V2.ListSessionKeys:input_type -> api.v2.ListSessionKeysRequest
-	121, // 199: api.v2.V2.ListSessions:input_type -> api.v2.ListSessionsRequest
-	124, // 200: api.v2.V2.ListSessionRuns:input_type -> api.v2.ListSessionRunsRequest
-	13,  // 201: api.v2.V2.Health:output_type -> api.v2.HealthResponse
-	16,  // 202: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
-	59,  // 203: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
-	61,  // 204: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
-	65,  // 205: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
-	66,  // 206: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
-	73,  // 207: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
-	70,  // 208: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
-	75,  // 209: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
-	78,  // 210: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
-	81,  // 211: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
-	84,  // 212: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
-	38,  // 213: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
-	40,  // 214: api.v2.V2.GetEventRuns:output_type -> api.v2.GetEventRunsResponse
-	43,  // 215: api.v2.V2.Rerun:output_type -> api.v2.RerunResponse
-	55,  // 216: api.v2.V2.GetApp:output_type -> api.v2.GetAppResponse
-	89,  // 217: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
-	49,  // 218: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
-	51,  // 219: api.v2.V2.GetFunction:output_type -> api.v2.GetFunctionResponse
-	57,  // 220: api.v2.V2.GetFunctions:output_type -> api.v2.GetFunctionsResponse
-	86,  // 221: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
-	100, // 222: api.v2.V2.ListInsightsTables:output_type -> api.v2.ListInsightsTablesResponse
-	107, // 223: api.v2.V2.ListInsightsEventSchemas:output_type -> api.v2.ListInsightsEventSchemasResponse
-	104, // 224: api.v2.V2.QueryInsightsPrompt:output_type -> api.v2.QueryInsightsPromptResponse
-	93,  // 225: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
-	110, // 226: api.v2.V2.ListExperiments:output_type -> api.v2.ListExperimentsResponse
-	113, // 227: api.v2.V2.GetExperiment:output_type -> api.v2.GetExperimentResponse
-	119, // 228: api.v2.V2.ListSessionKeys:output_type -> api.v2.ListSessionKeysResponse
-	122, // 229: api.v2.V2.ListSessions:output_type -> api.v2.ListSessionsResponse
-	125, // 230: api.v2.V2.ListSessionRuns:output_type -> api.v2.ListSessionRunsResponse
-	201, // [201:231] is the sub-list for method output_type
-	171, // [171:201] is the sub-list for method input_type
-	171, // [171:171] is the sub-list for extension type_name
-	171, // [171:171] is the sub-list for extension extendee
-	0,   // [0:171] is the sub-list for field type_name
+	133, // 109: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
+	133, // 110: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
+	133, // 111: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
+	89,  // 112: api.v2.CreateScoreRequest.scores:type_name -> api.v2.CreateScoreInput
+	136, // 113: api.v2.CreateScoreInput.value:type_name -> google.protobuf.Value
+	90,  // 114: api.v2.CreateScoreInput.experiment:type_name -> api.v2.ScoreExperiment
+	92,  // 115: api.v2.CreateScoreResponse.data:type_name -> api.v2.Score
+	17,  // 116: api.v2.CreateScoreResponse.metadata:type_name -> api.v2.ResponseMetadata
+	136, // 117: api.v2.Score.value:type_name -> google.protobuf.Value
+	90,  // 118: api.v2.Score.experiment:type_name -> api.v2.ScoreExperiment
+	95,  // 119: api.v2.SyncAppResponse.data:type_name -> api.v2.SyncAppData
+	17,  // 120: api.v2.SyncAppResponse.metadata:type_name -> api.v2.ResponseMetadata
+	96,  // 121: api.v2.SyncAppData.error:type_name -> api.v2.SyncAppError
+	99,  // 122: api.v2.QueryInsightsResponse.data:type_name -> api.v2.QueryInsightsData
+	17,  // 123: api.v2.QueryInsightsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	100, // 124: api.v2.QueryInsightsData.columns:type_name -> api.v2.InsightsOutputColumn
+	101, // 125: api.v2.QueryInsightsData.rows:type_name -> api.v2.InsightsRow
+	102, // 126: api.v2.QueryInsightsData.diagnostics:type_name -> api.v2.InsightsDiagnostic
+	9,   // 127: api.v2.InsightsOutputColumn.type:type_name -> api.v2.InsightsOutputColumnType
+	136, // 128: api.v2.InsightsRow.values:type_name -> google.protobuf.Value
+	10,  // 129: api.v2.InsightsDiagnostic.severity:type_name -> api.v2.InsightsDiagnosticSeverity
+	103, // 130: api.v2.InsightsDiagnostic.position:type_name -> api.v2.InsightsDiagnosticPosition
+	106, // 131: api.v2.ListInsightsTablesResponse.data:type_name -> api.v2.InsightsTable
+	17,  // 132: api.v2.ListInsightsTablesResponse.metadata:type_name -> api.v2.ResponseMetadata
+	107, // 133: api.v2.InsightsTable.columns:type_name -> api.v2.InsightsTableColumn
+	110, // 134: api.v2.QueryInsightsPromptResponse.data:type_name -> api.v2.QueryInsightsPromptData
+	17,  // 135: api.v2.QueryInsightsPromptResponse.metadata:type_name -> api.v2.ResponseMetadata
+	113, // 136: api.v2.ListInsightsEventSchemasResponse.data:type_name -> api.v2.InsightsEventSchema
+	17,  // 137: api.v2.ListInsightsEventSchemasResponse.metadata:type_name -> api.v2.ResponseMetadata
+	68,  // 138: api.v2.ListInsightsEventSchemasResponse.page:type_name -> api.v2.Page
+	134, // 139: api.v2.InsightsEventSchema.schema:type_name -> google.protobuf.Struct
+	133, // 140: api.v2.ListExperimentsRequest.from:type_name -> google.protobuf.Timestamp
+	133, // 141: api.v2.ListExperimentsRequest.until:type_name -> google.protobuf.Timestamp
+	116, // 142: api.v2.ListExperimentsResponse.data:type_name -> api.v2.Experiment
+	17,  // 143: api.v2.ListExperimentsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	68,  // 144: api.v2.ListExperimentsResponse.page:type_name -> api.v2.Page
+	19,  // 145: api.v2.Experiment.function:type_name -> api.v2.FunctionRef
+	133, // 146: api.v2.Experiment.first_seen:type_name -> google.protobuf.Timestamp
+	133, // 147: api.v2.Experiment.last_seen:type_name -> google.protobuf.Timestamp
+	133, // 148: api.v2.GetExperimentRequest.from:type_name -> google.protobuf.Timestamp
+	133, // 149: api.v2.GetExperimentRequest.until:type_name -> google.protobuf.Timestamp
+	119, // 150: api.v2.GetExperimentResponse.data:type_name -> api.v2.ExperimentDetail
+	17,  // 151: api.v2.GetExperimentResponse.metadata:type_name -> api.v2.ResponseMetadata
+	120, // 152: api.v2.ExperimentDetail.variants:type_name -> api.v2.ExperimentVariantMetrics
+	122, // 153: api.v2.ExperimentDetail.variant_weights:type_name -> api.v2.ExperimentVariantWeight
+	133, // 154: api.v2.ExperimentDetail.first_seen:type_name -> google.protobuf.Timestamp
+	133, // 155: api.v2.ExperimentDetail.last_seen:type_name -> google.protobuf.Timestamp
+	121, // 156: api.v2.ExperimentVariantMetrics.metrics:type_name -> api.v2.ExperimentVariantMetric
+	125, // 157: api.v2.ListSessionKeysResponse.data:type_name -> api.v2.SessionKey
+	17,  // 158: api.v2.ListSessionKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
+	68,  // 159: api.v2.ListSessionKeysResponse.page:type_name -> api.v2.Page
+	133, // 160: api.v2.SessionKey.created_at:type_name -> google.protobuf.Timestamp
+	133, // 161: api.v2.ListSessionsRequest.from:type_name -> google.protobuf.Timestamp
+	133, // 162: api.v2.ListSessionsRequest.until:type_name -> google.protobuf.Timestamp
+	128, // 163: api.v2.ListSessionsResponse.data:type_name -> api.v2.SessionGroup
+	17,  // 164: api.v2.ListSessionsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	68,  // 165: api.v2.ListSessionsResponse.page:type_name -> api.v2.Page
+	133, // 166: api.v2.SessionGroup.last_active_at:type_name -> google.protobuf.Timestamp
+	19,  // 167: api.v2.SessionGroup.functions:type_name -> api.v2.FunctionRef
+	133, // 168: api.v2.ListSessionRunsRequest.from:type_name -> google.protobuf.Timestamp
+	133, // 169: api.v2.ListSessionRunsRequest.until:type_name -> google.protobuf.Timestamp
+	131, // 170: api.v2.ListSessionRunsResponse.data:type_name -> api.v2.SessionRun
+	17,  // 171: api.v2.ListSessionRunsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	68,  // 172: api.v2.ListSessionRunsResponse.page:type_name -> api.v2.Page
+	19,  // 173: api.v2.SessionRun.function:type_name -> api.v2.FunctionRef
+	0,   // 174: api.v2.SessionRun.status:type_name -> api.v2.FunctionRunStatus
+	133, // 175: api.v2.SessionRun.queued_at:type_name -> google.protobuf.Timestamp
+	133, // 176: api.v2.SessionRun.started_at:type_name -> google.protobuf.Timestamp
+	133, // 177: api.v2.SessionRun.ended_at:type_name -> google.protobuf.Timestamp
+	11,  // 178: api.v2.V2.Health:input_type -> api.v2.HealthRequest
+	11,  // 179: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
+	58,  // 180: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
+	60,  // 181: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
+	64,  // 182: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
+	12,  // 183: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
+	72,  // 184: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
+	69,  // 185: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
+	74,  // 186: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
+	77,  // 187: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
+	80,  // 188: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
+	83,  // 189: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
+	37,  // 190: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
+	39,  // 191: api.v2.V2.GetEventRuns:input_type -> api.v2.GetEventRunsRequest
+	41,  // 192: api.v2.V2.Rerun:input_type -> api.v2.RerunRequest
+	54,  // 193: api.v2.V2.GetApp:input_type -> api.v2.GetAppRequest
+	88,  // 194: api.v2.V2.CreateScore:input_type -> api.v2.CreateScoreRequest
+	93,  // 195: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
+	48,  // 196: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
+	50,  // 197: api.v2.V2.GetFunction:input_type -> api.v2.GetFunctionRequest
+	56,  // 198: api.v2.V2.GetFunctions:input_type -> api.v2.GetFunctionsRequest
+	85,  // 199: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
+	104, // 200: api.v2.V2.ListInsightsTables:input_type -> api.v2.ListInsightsTablesRequest
+	111, // 201: api.v2.V2.ListInsightsEventSchemas:input_type -> api.v2.ListInsightsEventSchemasRequest
+	108, // 202: api.v2.V2.QueryInsightsPrompt:input_type -> api.v2.QueryInsightsPromptRequest
+	97,  // 203: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
+	114, // 204: api.v2.V2.ListExperiments:input_type -> api.v2.ListExperimentsRequest
+	117, // 205: api.v2.V2.GetExperiment:input_type -> api.v2.GetExperimentRequest
+	123, // 206: api.v2.V2.ListSessionKeys:input_type -> api.v2.ListSessionKeysRequest
+	126, // 207: api.v2.V2.ListSessions:input_type -> api.v2.ListSessionsRequest
+	129, // 208: api.v2.V2.ListSessionRuns:input_type -> api.v2.ListSessionRunsRequest
+	13,  // 209: api.v2.V2.Health:output_type -> api.v2.HealthResponse
+	16,  // 210: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
+	59,  // 211: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
+	61,  // 212: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
+	65,  // 213: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
+	66,  // 214: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
+	73,  // 215: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
+	70,  // 216: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
+	75,  // 217: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
+	78,  // 218: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
+	81,  // 219: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
+	84,  // 220: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
+	38,  // 221: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
+	40,  // 222: api.v2.V2.GetEventRuns:output_type -> api.v2.GetEventRunsResponse
+	43,  // 223: api.v2.V2.Rerun:output_type -> api.v2.RerunResponse
+	55,  // 224: api.v2.V2.GetApp:output_type -> api.v2.GetAppResponse
+	91,  // 225: api.v2.V2.CreateScore:output_type -> api.v2.CreateScoreResponse
+	94,  // 226: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
+	49,  // 227: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
+	51,  // 228: api.v2.V2.GetFunction:output_type -> api.v2.GetFunctionResponse
+	57,  // 229: api.v2.V2.GetFunctions:output_type -> api.v2.GetFunctionsResponse
+	86,  // 230: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
+	105, // 231: api.v2.V2.ListInsightsTables:output_type -> api.v2.ListInsightsTablesResponse
+	112, // 232: api.v2.V2.ListInsightsEventSchemas:output_type -> api.v2.ListInsightsEventSchemasResponse
+	109, // 233: api.v2.V2.QueryInsightsPrompt:output_type -> api.v2.QueryInsightsPromptResponse
+	98,  // 234: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
+	115, // 235: api.v2.V2.ListExperiments:output_type -> api.v2.ListExperimentsResponse
+	118, // 236: api.v2.V2.GetExperiment:output_type -> api.v2.GetExperimentResponse
+	124, // 237: api.v2.V2.ListSessionKeys:output_type -> api.v2.ListSessionKeysResponse
+	127, // 238: api.v2.V2.ListSessions:output_type -> api.v2.ListSessionsResponse
+	130, // 239: api.v2.V2.ListSessionRuns:output_type -> api.v2.ListSessionRunsResponse
+	209, // [209:240] is the sub-list for method output_type
+	178, // [178:209] is the sub-list for method input_type
+	178, // [178:178] is the sub-list for extension type_name
+	178, // [178:178] is the sub-list for extension extendee
+	0,   // [0:178] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_service_proto_init() }
@@ -9401,22 +9754,24 @@ func file_api_v2_service_proto_init() {
 	file_api_v2_service_proto_msgTypes[72].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[74].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[76].OneofWrappers = []any{}
-	file_api_v2_service_proto_msgTypes[79].OneofWrappers = []any{}
-	file_api_v2_service_proto_msgTypes[86].OneofWrappers = []any{}
-	file_api_v2_service_proto_msgTypes[95].OneofWrappers = []any{}
-	file_api_v2_service_proto_msgTypes[98].OneofWrappers = []any{}
-	file_api_v2_service_proto_msgTypes[101].OneofWrappers = []any{}
-	file_api_v2_service_proto_msgTypes[107].OneofWrappers = []any{}
-	file_api_v2_service_proto_msgTypes[110].OneofWrappers = []any{}
-	file_api_v2_service_proto_msgTypes[113].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[78].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[81].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[84].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[91].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[100].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[103].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[106].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[112].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[115].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[118].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[120].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v2_service_proto_rawDesc), len(file_api_v2_service_proto_rawDesc)),
 			NumEnums:      11,
-			NumMessages:   117,
+			NumMessages:   122,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -5476,11 +5476,11 @@ func (x *CreateScoreInput) GetExperiment() *ScoreExperiment {
 }
 
 type ScoreExperiment struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	ExperimentName string                 `protobuf:"bytes,1,opt,name=experiment_name,json=experimentName,proto3" json:"experiment_name,omitempty"`
-	Variant        string                 `protobuf:"bytes,2,opt,name=variant,proto3" json:"variant,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Variant       string                 `protobuf:"bytes,2,opt,name=variant,proto3" json:"variant,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ScoreExperiment) Reset() {
@@ -5513,9 +5513,9 @@ func (*ScoreExperiment) Descriptor() ([]byte, []int) {
 	return file_api_v2_service_proto_rawDescGZIP(), []int{79}
 }
 
-func (x *ScoreExperiment) GetExperimentName() string {
+func (x *ScoreExperiment) GetId() string {
 	if x != nil {
-		return x.ExperimentName
+		return x.Id
 	}
 	return ""
 }
@@ -8508,20 +8508,20 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x06_error\"\xfd\x02\n" +
 	"\x12CreateScoreRequest\x12d\n" +
 	"\x06run_id\x18\x01 \x01(\tBM\x92AJ2*Run ID (ULID) of the function run to scoreJ\x1c\"01JLW1NNJ69KCD1KMJEXAMPLE0\"R\x05runId\x12\x80\x02\n" +
-	"\x06scores\x18\x02 \x03(\v2\x18.api.v2.CreateScoreInputB\xcd\x01\x92A\xc9\x012\xc6\x01Scores to record for the run. The REST request body is this array. Writes are applied in order and are not atomic; if a later score fails, earlier scores may already be recorded. Maximum 100 scores.R\x06scores\"\x9b\x05\n" +
+	"\x06scores\x18\x02 \x03(\v2\x18.api.v2.CreateScoreInputB\xcd\x01\x92A\xc9\x012\xc6\x01Scores to record for the run. The REST request body is this array. Writes are applied in order and are not atomic; if a later score fails, earlier scores may already be recorded. Maximum 100 scores.R\x06scores\"\x99\x05\n" +
 	"\x10CreateScoreInput\x12P\n" +
 	"\x04name\x18\x01 \x01(\tB<\x92A92+Score name; must be at most 128 UTF-8 bytesJ\n" +
 	"\"accuracy\"R\x04name\x12j\n" +
 	"\x05value\x18\x02 \x01(\v2\x16.google.protobuf.ValueB<\x92A921Score value; must be a finite number or a booleanJ\x040.95R\x05value\x12\x85\x01\n" +
-	"\astep_id\x18\x03 \x01(\tBg\x92Ad2NOptional SDK step ID; attaches the score to a specific step instead of the runJ\x12\"generate-summary\"H\x00R\x06stepId\x88\x01\x01\x12\xa5\x02\n" +
+	"\astep_id\x18\x03 \x01(\tBg\x92Ad2NOptional SDK step ID; attaches the score to a specific step instead of the runJ\x12\"generate-summary\"H\x00R\x06stepId\x88\x01\x01\x12\xa3\x02\n" +
 	"\n" +
-	"experiment\x18\x04 \x01(\v2\x17.api.v2.ScoreExperimentB\xe6\x01\x92A\xe2\x012\xdf\x01Optional experiment context. When provided, the score is recorded with the same experiment metadata emitted by the SDK's score.experiment API. Experiment scores should be run-scoped for experiment aggregate and detail APIs.H\x01R\n" +
+	"experiment\x18\x04 \x01(\v2\x17.api.v2.ScoreExperimentB\xe4\x01\x92A\xe0\x012\xdd\x01Optional experiment context. When provided, the score is recorded with the same experiment metadata emitted by the SDK's score.experiment API. Experiment scores must be run-scoped for experiment aggregate and detail APIs.H\x01R\n" +
 	"experiment\x88\x01\x01B\n" +
 	"\n" +
 	"\b_step_idB\r\n" +
-	"\v_experiment\"\xa0\x01\n" +
-	"\x0fScoreExperiment\x12N\n" +
-	"\x0fexperiment_name\x18\x01 \x01(\tB%\x92A\"2\x0fExperiment nameJ\x0f\"model-routing\"R\x0eexperimentName\x12=\n" +
+	"\v_experiment\"\x85\x01\n" +
+	"\x0fScoreExperiment\x123\n" +
+	"\x02id\x18\x01 \x01(\tB#\x92A 2\rExperiment IDJ\x0f\"model-routing\"R\x02id\x12=\n" +
 	"\avariant\x18\x02 \x01(\tB#\x92A 2\x12Experiment variantJ\n" +
 	"\"baseline\"R\avariant\"n\n" +
 	"\x13CreateScoreResponse\x12!\n" +

--- a/proto/gen/api/v2/service.pb.gw.go
+++ b/proto/gen/api/v2/service.pb.gw.go
@@ -589,6 +589,51 @@ func local_request_V2_GetApp_0(ctx context.Context, marshaler runtime.Marshaler,
 	return msg, metadata, err
 }
 
+func request_V2_CreateScore_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateScoreRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Scores); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["run_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "run_id")
+	}
+	protoReq.RunId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "run_id", err)
+	}
+	msg, err := client.CreateScore(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_V2_CreateScore_0(ctx context.Context, marshaler runtime.Marshaler, server V2Server, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CreateScoreRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq.Scores); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["run_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "run_id")
+	}
+	protoReq.RunId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "run_id", err)
+	}
+	msg, err := server.CreateScore(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_V2_SyncApp_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq SyncAppRequest
@@ -1638,6 +1683,26 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		}
 		forward_V2_GetApp_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_V2_CreateScore_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/CreateScore", runtime.WithHTTPPathPattern("/runs/{run_id}/scores"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_V2_CreateScore_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_CreateScore_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_V2_SyncApp_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2250,6 +2315,23 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		}
 		forward_V2_GetApp_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_V2_CreateScore_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/CreateScore", runtime.WithHTTPPathPattern("/runs/{run_id}/scores"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_V2_CreateScore_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_CreateScore_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_V2_SyncApp_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2525,6 +2607,7 @@ var (
 	pattern_V2_GetEventRuns_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"events", "event_id", "runs"}, ""))
 	pattern_V2_Rerun_0                    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"runs", "run_id", "rerun"}, ""))
 	pattern_V2_GetApp_0                   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"apps", "app_id"}, ""))
+	pattern_V2_CreateScore_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"runs", "run_id", "scores"}, ""))
 	pattern_V2_SyncApp_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"apps", "app_id", "syncs"}, ""))
 	pattern_V2_GetFunctionTrace_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"runs", "run_id", "trace"}, ""))
 	pattern_V2_GetFunction_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"apps", "app_id", "functions", "function_id"}, ""))
@@ -2559,6 +2642,7 @@ var (
 	forward_V2_GetEventRuns_0             = runtime.ForwardResponseMessage
 	forward_V2_Rerun_0                    = runtime.ForwardResponseMessage
 	forward_V2_GetApp_0                   = runtime.ForwardResponseMessage
+	forward_V2_CreateScore_0              = runtime.ForwardResponseMessage
 	forward_V2_SyncApp_0                  = runtime.ForwardResponseMessage
 	forward_V2_GetFunctionTrace_0         = runtime.ForwardResponseMessage
 	forward_V2_GetFunction_0              = runtime.ForwardResponseMessage

--- a/proto/gen/api/v2/service_grpc.pb.go
+++ b/proto/gen/api/v2/service_grpc.pb.go
@@ -35,6 +35,7 @@ const (
 	V2_GetEventRuns_FullMethodName             = "/api.v2.V2/GetEventRuns"
 	V2_Rerun_FullMethodName                    = "/api.v2.V2/Rerun"
 	V2_GetApp_FullMethodName                   = "/api.v2.V2/GetApp"
+	V2_CreateScore_FullMethodName              = "/api.v2.V2/CreateScore"
 	V2_SyncApp_FullMethodName                  = "/api.v2.V2/SyncApp"
 	V2_GetFunctionTrace_FullMethodName         = "/api.v2.V2/GetFunctionTrace"
 	V2_GetFunction_FullMethodName              = "/api.v2.V2/GetFunction"
@@ -74,6 +75,7 @@ type V2Client interface {
 	GetEventRuns(ctx context.Context, in *GetEventRunsRequest, opts ...grpc.CallOption) (*GetEventRunsResponse, error)
 	Rerun(ctx context.Context, in *RerunRequest, opts ...grpc.CallOption) (*RerunResponse, error)
 	GetApp(ctx context.Context, in *GetAppRequest, opts ...grpc.CallOption) (*GetAppResponse, error)
+	CreateScore(ctx context.Context, in *CreateScoreRequest, opts ...grpc.CallOption) (*CreateScoreResponse, error)
 	SyncApp(ctx context.Context, in *SyncAppRequest, opts ...grpc.CallOption) (*SyncAppResponse, error)
 	GetFunctionTrace(ctx context.Context, in *GetFunctionTraceRequest, opts ...grpc.CallOption) (*GetFunctionTraceResponse, error)
 	GetFunction(ctx context.Context, in *GetFunctionRequest, opts ...grpc.CallOption) (*GetFunctionResponse, error)
@@ -258,6 +260,16 @@ func (c *v2Client) GetApp(ctx context.Context, in *GetAppRequest, opts ...grpc.C
 	return out, nil
 }
 
+func (c *v2Client) CreateScore(ctx context.Context, in *CreateScoreRequest, opts ...grpc.CallOption) (*CreateScoreResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateScoreResponse)
+	err := c.cc.Invoke(ctx, V2_CreateScore_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *v2Client) SyncApp(ctx context.Context, in *SyncAppRequest, opts ...grpc.CallOption) (*SyncAppResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(SyncAppResponse)
@@ -421,6 +433,7 @@ type V2Server interface {
 	GetEventRuns(context.Context, *GetEventRunsRequest) (*GetEventRunsResponse, error)
 	Rerun(context.Context, *RerunRequest) (*RerunResponse, error)
 	GetApp(context.Context, *GetAppRequest) (*GetAppResponse, error)
+	CreateScore(context.Context, *CreateScoreRequest) (*CreateScoreResponse, error)
 	SyncApp(context.Context, *SyncAppRequest) (*SyncAppResponse, error)
 	GetFunctionTrace(context.Context, *GetFunctionTraceRequest) (*GetFunctionTraceResponse, error)
 	GetFunction(context.Context, *GetFunctionRequest) (*GetFunctionResponse, error)
@@ -492,6 +505,9 @@ func (UnimplementedV2Server) Rerun(context.Context, *RerunRequest) (*RerunRespon
 }
 func (UnimplementedV2Server) GetApp(context.Context, *GetAppRequest) (*GetAppResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetApp not implemented")
+}
+func (UnimplementedV2Server) CreateScore(context.Context, *CreateScoreRequest) (*CreateScoreResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateScore not implemented")
 }
 func (UnimplementedV2Server) SyncApp(context.Context, *SyncAppRequest) (*SyncAppResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SyncApp not implemented")
@@ -844,6 +860,24 @@ func _V2_GetApp_Handler(srv interface{}, ctx context.Context, dec func(interface
 	return interceptor(ctx, in, info, handler)
 }
 
+func _V2_CreateScore_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateScoreRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(V2Server).CreateScore(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: V2_CreateScore_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(V2Server).CreateScore(ctx, req.(*CreateScoreRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _V2_SyncApp_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(SyncAppRequest)
 	if err := dec(in); err != nil {
@@ -1166,6 +1200,10 @@ var V2_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetApp",
 			Handler:    _V2_GetApp_Handler,
+		},
+		{
+			MethodName: "CreateScore",
+			Handler:    _V2_CreateScore_Handler,
 		},
 		{
 			MethodName: "SyncApp",


### PR DESCRIPTION
## Description

Scoring api PR called the existing metadata writing code in place to keep the diff there free of refactoring, see [here](https://github.com/inngest/inngest/pull/4453). This extracts that code into a shared metadata write so v2 does not depend on v1 directly.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
