### PR TITLE
fix(support): fix React hydration — UI interactions unresponsive

### DIFF
--- a/ui/apps/support/package.json
+++ b/ui/apps/support/package.json
@@ -20,7 +20,7 @@
     "@tanstack/query-core": "5.90.2",
     "@tanstack/react-query": "^5.66.5",
     "@tanstack/react-query-devtools": "^5.84.2",
-    "@tanstack/react-router": "^1.170.6",
+    "@tanstack/react-router": "^1.170.16",
     "@tanstack/react-router-devtools": "^1.167.0",
     "@tanstack/react-router-ssr-query": "^1.167.0",
     "@tanstack/react-start": "1.168.26",
@@ -51,6 +51,7 @@
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
     "urql": "^4.0.5",
+    "use-sync-external-store": "1.6.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/ui/apps/support/src/routeTree.gen.ts
+++ b/ui/apps/support/src/routeTree.gen.ts
@@ -58,7 +58,7 @@ export interface FileRoutesByFullPath {
   '/new': typeof AuthedNewRoute
   '/sign-in/$': typeof SignInSplatRoute
   '/case/$ticketId': typeof AuthedCaseTicketIdRoute
-  '/support': typeof AuthedSupportIndexRoute
+  '/support/': typeof AuthedSupportIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -86,7 +86,7 @@ export interface FileRouteTypes {
     | '/new'
     | '/sign-in/$'
     | '/case/$ticketId'
-    | '/support'
+    | '/support/'
   fileRoutesByTo: FileRoutesByTo
   to: '/' | '/sign-out' | '/new' | '/sign-in/$' | '/case/$ticketId' | '/support'
   id:
@@ -119,7 +119,7 @@ declare module '@tanstack/react-router' {
     '/_authed': {
       id: '/_authed'
       path: ''
-      fullPath: ''
+      fullPath: '/'
       preLoaderRoute: typeof AuthedRouteImport
       parentRoute: typeof rootRouteImport
     }
@@ -147,7 +147,7 @@ declare module '@tanstack/react-router' {
     '/_authed/support/': {
       id: '/_authed/support/'
       path: '/support'
-      fullPath: '/support'
+      fullPath: '/support/'
       preLoaderRoute: typeof AuthedSupportIndexRouteImport
       parentRoute: typeof AuthedRoute
     }

--- a/ui/apps/support/vite.config.ts
+++ b/ui/apps/support/vite.config.ts
@@ -14,6 +14,12 @@ export default defineConfig({
       ),
     },
   },
+  optimizeDeps: {
+    include: [
+      "use-sync-external-store/shim/index.js",
+      "use-sync-external-store/shim/with-selector.js",
+    ],
+  },
   ssr: {
     noExternal: ["@headlessui/tailwindcss"],
     external: ["next"],

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -560,7 +560,7 @@ importers:
     dependencies:
       '@clerk/tanstack-react-start':
         specifier: ^0.29.11
-        version: 0.29.13(@tanstack/react-router@1.170.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tanstack/react-start@1.168.26(crossws@0.4.6(srvx@0.11.13))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@7.3.5(@types/node@24.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.99.9))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 0.29.13(@tanstack/react-router@1.170.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tanstack/react-start@1.168.26(crossws@0.4.6(srvx@0.11.13))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@7.3.5(@types/node@24.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.99.9))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.8.1)
@@ -583,14 +583,14 @@ importers:
         specifier: ^5.84.2
         version: 5.90.2(@tanstack/react-query@5.90.2(react@18.2.0))(react@18.2.0)
       '@tanstack/react-router':
-        specifier: ^1.170.6
-        version: 1.170.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^1.170.16
+        version: 1.170.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tanstack/react-router-devtools':
         specifier: ^1.167.0
-        version: 1.167.0(@tanstack/react-router@1.170.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tanstack/router-core@1.171.13)(csstype@3.2.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 1.167.0(@tanstack/react-router@1.170.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tanstack/router-core@1.171.13)(csstype@3.2.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tanstack/react-router-ssr-query':
         specifier: ^1.167.0
-        version: 1.167.0(@tanstack/query-core@5.90.2)(@tanstack/react-query@5.90.2(react@18.2.0))(@tanstack/react-router@1.170.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tanstack/router-core@1.171.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 1.167.0(@tanstack/query-core@5.90.2)(@tanstack/react-query@5.90.2(react@18.2.0))(@tanstack/react-router@1.170.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tanstack/router-core@1.171.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tanstack/react-start':
         specifier: 1.168.26
         version: 1.168.26(crossws@0.4.6(srvx@0.11.13))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@7.3.5(@types/node@24.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.99.9)
@@ -675,6 +675,9 @@ importers:
       urql:
         specifier: ^4.0.5
         version: 4.0.5(graphql@16.8.1)(react@18.2.0)
+      use-sync-external-store:
+        specifier: 1.6.0
+        version: 1.6.0(react@18.2.0)
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -15130,13 +15133,13 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@clerk/tanstack-react-start@0.29.13(@tanstack/react-router@1.170.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tanstack/react-start@1.168.26(crossws@0.4.6(srvx@0.11.13))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@7.3.5(@types/node@24.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.99.9))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@clerk/tanstack-react-start@0.29.13(@tanstack/react-router@1.170.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tanstack/react-start@1.168.26(crossws@0.4.6(srvx@0.11.13))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@7.3.5(@types/node@24.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.99.9))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@clerk/backend': 2.33.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@clerk/clerk-react': 5.61.8(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@clerk/shared': 3.47.7(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@clerk/types': 4.101.25(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@tanstack/react-router': 1.170.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tanstack/react-router': 1.170.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@tanstack/react-start': 1.168.26(crossws@0.4.6(srvx@0.11.13))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(vite@7.3.5(@types/node@24.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.39.0)(tsx@4.20.6)(yaml@2.9.0))(webpack@5.99.9)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -20216,6 +20219,17 @@ snapshots:
       '@tanstack/query-core': 5.90.2
       react: 18.2.0
 
+  '@tanstack/react-router-devtools@1.167.0(@tanstack/react-router@1.170.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tanstack/router-core@1.171.13)(csstype@3.2.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tanstack/react-router': 1.170.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tanstack/router-devtools-core': 1.168.0(@tanstack/router-core@1.171.13)(csstype@3.2.3)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@tanstack/router-core': 1.171.13
+    transitivePeerDependencies:
+      - csstype
+
   '@tanstack/react-router-devtools@1.167.0(@tanstack/react-router@1.170.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tanstack/router-core@1.171.13)(csstype@3.2.3)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@tanstack/react-router': 1.170.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -20226,6 +20240,17 @@ snapshots:
       '@tanstack/router-core': 1.171.13
     transitivePeerDependencies:
       - csstype
+
+  '@tanstack/react-router-ssr-query@1.167.0(@tanstack/query-core@5.90.2)(@tanstack/react-query@5.90.2(react@18.2.0))(@tanstack/react-router@1.170.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tanstack/router-core@1.171.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@tanstack/query-core': 5.90.2
+      '@tanstack/react-query': 5.90.2(react@18.2.0)
+      '@tanstack/react-router': 1.170.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@tanstack/router-ssr-query-core': 1.169.0(@tanstack/query-core@5.90.2)(@tanstack/router-core@1.171.13)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - '@tanstack/router-core'
 
   '@tanstack/react-router-ssr-query@1.167.0(@tanstack/query-core@5.90.2)(@tanstack/react-query@5.90.2(react@18.2.0))(@tanstack/react-router@1.170.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@tanstack/router-core@1.171.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

Two issues prevented React from hydrating SSR'd HTML in the support portal, leaving all interactive elements (dropdowns, file pickers) dead in the browser.

1. use-sync-external-store CJS/ESM interop failure

   @tanstack/react-store imports from use-sync-external-store/shim, a CJS module. Vite serves it raw via /@fs/ without named-export conversion, so the browser sees no useSyncExternalStore named export and React's module graph fails to initialize.

   Fix: add use-sync-external-store as a direct dependency so pnpm creates an accessible symlink, then declare it in optimizeDeps.include so Vite pre-bundles it via esbuild (which properly converts CJS exports to named ESM exports).

2. pnpm strict isolation — optimizeDeps.include silently no-ops

   With pnpm's isolated node_modules, transitive deps are not accessible from the project root. Vite logs "Failed to resolve dependency" and skips the optimizeDeps.include entry entirely. Making use-sync-external-store a direct dep resolves this.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
