### PR TITLE
chore(release): for homebrew installed inngest-cli, use homebrew-tap for latest version

### DIFF
--- a/pkg/update/check.go
+++ b/pkg/update/check.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -19,9 +20,10 @@ import (
 )
 
 const (
-	releasesURL  = "https://api.github.com/repos/inngest/inngest/releases/latest"
-	cacheTTL     = 24 * time.Hour
-	checkTimeout = 3 * time.Second
+	releasesURL     = "https://api.github.com/repos/inngest/inngest/releases/latest"
+	homebrewCaskURL = "https://raw.githubusercontent.com/inngest/homebrew-tap/main/Casks/inngest.rb"
+	cacheTTL        = 24 * time.Hour
+	checkTimeout    = 3 * time.Second
 )
 
 type cacheFile struct {
@@ -31,10 +33,12 @@ type cacheFile struct {
 }
 
 var (
-	cacheMu      sync.Mutex
-	httpClient   = &http.Client{Timeout: checkTimeout}
-	cachePathFn  = defaultCachePath
-	releasesAddr = releasesURL
+	cacheMu          sync.Mutex
+	httpClient       = &http.Client{Timeout: checkTimeout}
+	cachePathFn      = defaultCachePath
+	releasesAddr     = releasesURL
+	homebrewCaskAddr = homebrewCaskURL
+	caskVersionRE    = regexp.MustCompile(`(?m)^\s*version\s+"([^"]+)"`)
 )
 
 // Check refreshes the cached "latest version" record if the cache is stale.
@@ -47,10 +51,11 @@ func Check(ctx context.Context, currentVersion string) {
 	if disabled(currentVersion) {
 		return
 	}
+	installMethod := Detect()
 	if !shouldFetch() {
 		return
 	}
-	latest, url, err := fetchLatest(ctx)
+	latest, url, err := fetchLatest(ctx, installMethod)
 	if err != nil || latest == "" {
 		return
 	}
@@ -79,7 +84,14 @@ func shouldFetch() bool {
 	return time.Since(c.CheckedAt) > cacheTTL
 }
 
-func fetchLatest(ctx context.Context) (string, string, error) {
+func fetchLatest(ctx context.Context, method Method) (string, string, error) {
+	if method == MethodHomebrew {
+		return fetchHomebrewLatest(ctx)
+	}
+	return fetchGitHubLatest(ctx)
+}
+
+func fetchGitHubLatest(ctx context.Context) (string, string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releasesAddr, nil)
 	if err != nil {
 		return "", "", err
@@ -102,6 +114,33 @@ func fetchLatest(ctx context.Context) (string, string, error) {
 		return "", "", err
 	}
 	return strings.TrimPrefix(body.TagName, "v"), body.HTMLURL, nil
+}
+
+func fetchHomebrewLatest(ctx context.Context) (string, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, homebrewCaskAddr, nil)
+	if err != nil {
+		return "", "", err
+	}
+	req.Header.Set("Accept", "text/plain")
+	req.Header.Set("User-Agent", "inngest-cli")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("homebrew cask: status %d", resp.StatusCode)
+	}
+	byt, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", "", err
+	}
+	match := caskVersionRE.FindSubmatch(byt)
+	if len(match) < 2 {
+		return "", "", errors.New("homebrew cask: version not found")
+	}
+	version := string(match[1])
+	return version, "https://github.com/inngest/inngest/releases/tag/v" + version, nil
 }
 
 func defaultCachePath() (string, error) {

--- a/pkg/update/check_test.go
+++ b/pkg/update/check_test.go
@@ -99,12 +99,8 @@ func TestShouldFetch(t *testing.T) {
 	}
 }
 
-func TestCheckFetchesAndCaches(t *testing.T) {
+func TestFetchLatestCachesLatest(t *testing.T) {
 	withTempCache(t)
-	// Force the env-var gate off so the test doesn't depend on host env.
-	for _, k := range []string{"INNGEST_NO_UPDATE_NOTIFIER", "NO_UPDATE_NOTIFIER", "DO_NOT_TRACK", "CI"} {
-		t.Setenv(k, "")
-	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]string{
@@ -118,14 +114,9 @@ func TestCheckFetchesAndCaches(t *testing.T) {
 	releasesAddr = srv.URL
 	t.Cleanup(func() { releasesAddr = oldAddr })
 
-	// Bypass the TTY gate inside disabled() — the fetch logic itself does
-	// not require a TTY, only the shared opt-out helper does. We test that
-	// helper separately; here we exercise the network path by calling the
-	// internals directly.
-	if !shouldFetch() {
-		t.Fatal("shouldFetch returned false with empty cache")
-	}
-	latest, url, err := fetchLatest(context.Background())
+	// Check() also applies opt-out and TTY gates. This covers the fetch ->
+	// writeCache -> Latest path underneath those gates.
+	latest, url, err := fetchLatest(context.Background(), MethodBinary)
 	if err != nil {
 		t.Fatalf("fetchLatest: %v", err)
 	}
@@ -142,6 +133,64 @@ func TestCheckFetchesAndCaches(t *testing.T) {
 	}
 }
 
+func TestFetchGitHubLatest(t *testing.T) {
+	withTempCache(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"tag_name": "v0.36.0",
+			"html_url": "https://example.test/releases/v0.36.0",
+		})
+	}))
+	defer srv.Close()
+
+	oldAddr := releasesAddr
+	releasesAddr = srv.URL
+	t.Cleanup(func() { releasesAddr = oldAddr })
+
+	// All non-Homebrew install methods should continue using GitHub releases.
+	for _, method := range []Method{MethodNPM, MethodBash, MethodBinary} {
+		t.Run(string(method), func(t *testing.T) {
+			latest, url, err := fetchLatest(context.Background(), method)
+			if err != nil {
+				t.Fatalf("fetchLatest: %v", err)
+			}
+			if latest != "0.36.0" {
+				t.Errorf("Latest version = %q, want %q", latest, "0.36.0")
+			}
+			if url != "https://example.test/releases/v0.36.0" {
+				t.Errorf("Latest url = %q", url)
+			}
+		})
+	}
+}
+
+func TestFetchHomebrewLatest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`cask "inngest" do
+  version "0.37.0"
+  sha256 "abc123"
+end
+`))
+	}))
+	defer srv.Close()
+
+	oldAddr := homebrewCaskAddr
+	homebrewCaskAddr = srv.URL
+	t.Cleanup(func() { homebrewCaskAddr = oldAddr })
+
+	latest, url, err := fetchLatest(context.Background(), MethodHomebrew)
+	if err != nil {
+		t.Fatalf("fetchLatest: %v", err)
+	}
+	if latest != "0.37.0" {
+		t.Errorf("Latest version = %q, want %q", latest, "0.37.0")
+	}
+	if url != "https://github.com/inngest/inngest/releases/tag/v0.37.0" {
+		t.Errorf("Latest url = %q", url)
+	}
+}
+
 func TestCheckSilentOnHTTPError(t *testing.T) {
 	withTempCache(t)
 
@@ -155,7 +204,7 @@ func TestCheckSilentOnHTTPError(t *testing.T) {
 	t.Cleanup(func() { releasesAddr = oldAddr })
 
 	// Even calling the fetch directly, an HTTP error must not write cache.
-	if _, _, err := fetchLatest(context.Background()); err == nil {
+	if _, _, err := fetchLatest(context.Background(), MethodBinary); err == nil {
 		t.Fatal("fetchLatest succeeded on 500, want error")
 	}
 	if v, _ := Latest(); v != "" {

--- a/pkg/update/detect.go
+++ b/pkg/update/detect.go
@@ -16,8 +16,8 @@ const (
 	MethodBinary   Method = "binary"
 )
 
-// EnvInstallMethod lets installers declare the channel explicitly,
-// bypassing path-based heuristics. Homebrew formula and install.sh set this.
+// EnvInstallMethod lets callers override install-method detection.
+// Packaged installs are normally detected from os.Executable().
 const EnvInstallMethod = "INNGEST_INSTALL_METHOD"
 
 // Detect returns the install method, preferring the env override and


### PR DESCRIPTION
## Description

Because of notarization delay, we will have a github release available sooner than the homebrew-tap is updated, so we should rely on the homebrew-tap directly for what is the latest available version rather than github releases

## Testing

1. delete any cached version
```
rm ~/.config/inngest/update-check.json
```
2. compile a non dev build with a fake version
```
go build -ldflags "-X github.com/inngest/inngest/pkg/inngest/version.Version=0.1.0" -o ./inngest ./cmd
```
3. Run the CLI and fake the install method to be homebrew
```
INNGEST_INSTALL_METHOD=homebrew ./inngest dev
```
4. Kill the CLI and check the cached version. It should match the latest in https://github.com/inngest/homebrew-tap/blob/main/Casks/inngest.rb#L3 not in https://github.com/inngest/inngest/releases
```
cat ~/.config/inngest/update-check.json
```
5. Run the CLI again to see the notice if we didn't see it the first time (possible due to race condition with background goroutine)

## Release note

Fix homebrew update notifier to use what's actually available in homebrew

## Migration note

None.