### PR TITLE
chore(checkpointing):  improve fn upserting and loading

### DIFF
--- a/pkg/api/apiv1/checkpoint.go
+++ b/pkg/api/apiv1/checkpoint.go
@@ -481,7 +481,7 @@ func (a checkpointAPI) upsertSyncData(ctx context.Context, auth apiv1auth.V1Auth
 	config := input.FnConfig(auth.WorkspaceID())
 	key := fnID.String() + ":" + util.XXHash(config)
 
-	ran, err := a.upserted.Upsert(ctx, key, func(ctx context.Context) error {
+	_, err := a.upserted.Upsert(ctx, key, func(ctx context.Context) error {
 		app, err := a.AppCreator.UpsertApp(ctx, cqrs.UpsertAppParams{
 			ID:     appID,
 			Name:   input.AppSlug(),
@@ -502,6 +502,14 @@ func (a checkpointAPI) upsertSyncData(ctx context.Context, auth apiv1auth.V1Auth
 			Config:    config,
 			CreatedAt: time.UnixMilli(input.Event.Timestamp),
 		})
+
+		if err == nil {
+			logger.StdlibLogger(ctx).Debug("upserted fn",
+				"function_id", fnID,
+				"app_id", appID,
+			)
+		}
+
 		return err
 	})
 	if err != nil {
@@ -510,16 +518,7 @@ func (a checkpointAPI) upsertSyncData(ctx context.Context, auth apiv1auth.V1Auth
 			"function_id", fnID,
 			"app_id", appID,
 		)
-		return
 	}
-	if !ran {
-		return
-	}
-
-	logger.StdlibLogger(ctx).Debug("upserted fn",
-		"function_id", fnID,
-		"app_id", appID,
-	)
 }
 
 func newCheckpointSyncUpserter() ttlupsert.Upserter[string] {

--- a/pkg/api/apiv1/checkpoint.go
+++ b/pkg/api/apiv1/checkpoint.go
@@ -29,7 +29,7 @@ import (
 	"github.com/inngest/inngest/pkg/publicerr"
 	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	"github.com/inngest/inngest/pkg/util"
-	"github.com/karlseguin/ccache/v2"
+	"github.com/inngest/inngest/pkg/util/ttlupsert"
 	"github.com/oklog/ulid/v2"
 )
 
@@ -96,9 +96,9 @@ type checkpointAPI struct {
 
 	checkpointer checkpoint.Checkpointer
 
-	// upserted tracks fn IDs and their associated config in memory once upserted, allowing
-	// us to prevent DB queries from hitting the DB each time a sync fn begins.
-	upserted *ccache.Cache
+	// upserted tracks fn IDs and their associated config in memory once upserted,
+	// allowing us to prevent DB queries from hitting the DB each time a sync fn begins.
+	upserted ttlupsert.Upserter[string]
 	// runClaimsSecret is the secret for creating run claims JWTs
 	runClaimsSecret []byte
 	// outputReader allows us to read run output for a given env / run ID
@@ -122,7 +122,7 @@ func NewCheckpointAPI(o Opts) CheckpointAPI {
 	api := checkpointAPI{
 		Router:          chi.NewRouter(),
 		Opts:            o,
-		upserted:        ccache.New(ccache.Configure().MaxSize(10_000)),
+		upserted:        newCheckpointSyncUpserter(),
 		runClaimsSecret: o.CheckpointOpts.RunJWTSecret,
 		outputReader:    o.CheckpointOpts.RunOutputReader,
 		checkpointer:    c,
@@ -479,66 +479,53 @@ func (a checkpointAPI) upsertSyncData(ctx context.Context, auth apiv1auth.V1Auth
 	fnID := input.FnID(appID)
 
 	config := input.FnConfig(auth.WorkspaceID())
+	key := fnID.String() + ":" + util.XXHash(config)
 
-	if item := a.upserted.Get(fnID.String()); item != nil {
-		// This item is in the LRU cache and has already been inserted;
-		// don't bother to upsert the app and only update the function configuration.
-		if util.XXHash(config) == item.Value().(string) {
-			return
-		}
-		_, err := a.FunctionCreator.UpdateFunctionConfig(ctx, cqrs.UpdateFunctionConfigParams{
-			Config: config,
-			ID:     fnID,
+	ran, err := a.upserted.Upsert(ctx, key, func(ctx context.Context) error {
+		app, err := a.AppCreator.UpsertApp(ctx, cqrs.UpsertAppParams{
+			ID:     appID,
+			Name:   input.AppSlug(),
+			Url:    input.AppURL(),
+			Method: enums.AppMethodAPI.String(),
 		})
 		if err != nil {
-			logger.StdlibLogger(ctx).Error("failed to update fn config",
-				"error", err,
-				"app_id", input.AppID(auth.WorkspaceID()),
-			)
+			return err
 		}
-		return
-	}
 
-	app, err := a.AppCreator.UpsertApp(ctx, cqrs.UpsertAppParams{
-		ID:     appID,
-		Name:   input.AppSlug(),
-		Url:    input.AppURL(),
-		Method: enums.AppMethodAPI.String(),
+		_, err = a.FunctionCreator.UpsertFunction(ctx, cqrs.UpsertFunctionParams{
+			ID:        fnID,
+			AccountID: auth.AccountID(),
+			EnvID:     auth.WorkspaceID(),
+			AppID:     app.ID,
+			Name:      input.FnSlug(),
+			Slug:      input.FnSlug(),
+			Config:    config,
+			CreatedAt: time.UnixMilli(input.Event.Timestamp),
+		})
+		return err
 	})
 	if err != nil {
-		logger.StdlibLogger(ctx).Error("failed to upsert app",
+		logger.StdlibLogger(ctx).Error("failed to upsert sync checkpoint data",
 			"error", err,
-			"app_id", input.AppID(auth.WorkspaceID()),
+			"function_id", fnID,
+			"app_id", appID,
 		)
 		return
 	}
-
-	_, err = a.FunctionCreator.UpsertFunction(ctx, cqrs.UpsertFunctionParams{
-		ID:        fnID,
-		AccountID: auth.AccountID(),
-		EnvID:     auth.WorkspaceID(),
-		AppID:     app.ID,
-		Name:      input.FnSlug(),
-		Slug:      input.FnSlug(),
-		Config:    config,
-		CreatedAt: time.UnixMilli(input.Event.Timestamp),
-	})
-	if err != nil {
-		logger.StdlibLogger(ctx).Error("failed to upsert function",
-			"error", err,
-			"function_id", input.FnID(input.AppID(auth.WorkspaceID())),
-			"app_id", app.ID,
-		)
+	if !ran {
 		return
 	}
-
-	// Hash the config so that we can quickly compare whether we upsert when memoizing
-	// this upsert routine.
-	a.upserted.Set(fnID.String(), util.XXHash(config), time.Hour*24)
 
 	logger.StdlibLogger(ctx).Debug("upserted fn",
-		"error", err,
-		"function_id", input.FnID(input.AppID(auth.WorkspaceID())),
-		"app_id", app.ID,
+		"function_id", fnID,
+		"app_id", appID,
+	)
+}
+
+func newCheckpointSyncUpserter() ttlupsert.Upserter[string] {
+	return ttlupsert.NewWithKey(
+		func(key string) string { return key },
+		ttlupsert.WithTTL(time.Hour*24),
+		ttlupsert.WithCapacity(10_000),
 	)
 }

--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -2,6 +2,7 @@ package checkpoint
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -32,6 +33,7 @@ import (
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/tracing/metadata"
 	"github.com/inngest/inngest/pkg/tracing/metadata/extractors"
+	"github.com/inngest/inngest/pkg/util"
 )
 
 type Checkpointer interface {
@@ -76,7 +78,14 @@ func (a AllowAsyncDispatchValidation) Enabled(ctx context.Context, acctID uuid.U
 // cannot fire before the queue lease expires, so a fresh dispatch is
 // uncontested. The upper bound is the shortest plausible serverless timeout
 // (~10s) — longer windows let a fast-Requeue race slip past unfenced.
-const dispatchValidationSkipDuration = 10 * time.Second
+const (
+	dispatchValidationSkipDuration = 10 * time.Second
+
+	functionLookupRetryAttempts     = 5
+	functionLookupInitialBackoff    = 50 * time.Millisecond
+	functionLookupMaxBackoff        = 400 * time.Millisecond
+	functionLookupBackoffMultiplier = 2
+)
 
 type queueItemLoader interface {
 	LoadQueueItem(ctx context.Context, shardName string, itemID string) (*queue.QueueItem, error)
@@ -804,12 +813,38 @@ func (c checkpointer) finalize(ctx context.Context, md state.Metadata, result ap
 }
 
 func (c checkpointer) fn(ctx context.Context, fnID uuid.UUID) (*inngest.Function, error) {
-	// Load the function config.
-	cfn, err := c.FnReader.GetFunctionByInternalUUID(ctx, fnID)
+	// upserting in durable endpoints is done in a goroutine as this is
+	// in the fast path.  the first time a fn is written, there's a race
+	// between checkpointing and inserting into the db.  we dont want to blcok
+	// every time, so retry loading here on first insert.
+	cfn, err := util.WithRetry(
+		ctx,
+		"checkpoint.load-function",
+		func(ctx context.Context) (*cqrs.Function, error) {
+			return c.FnReader.GetFunctionByInternalUUID(ctx, fnID)
+		},
+		util.NewRetryConf(
+			util.WithRetryConfMaxAttempts(functionLookupRetryAttempts),
+			util.WithRetryConfInitialBackoff(functionLookupInitialBackoff),
+			util.WithRetryConfMaxBackoff(functionLookupMaxBackoff),
+			util.WithRetryConfBackoffFactor(functionLookupBackoffMultiplier),
+			util.WithRetryConfRetryableErrors(isRetryableFunctionLookupError),
+		),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error loading function: %w", err)
 	}
 	return cfn.InngestFunction()
+}
+
+func isRetryableFunctionLookupError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if errors.Is(err, cqrs.ErrNotFound) || errors.Is(err, sql.ErrNoRows) {
+		return true
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
 }
 
 func (c checkpointer) processMetadata(

--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -2,7 +2,9 @@ package checkpoint
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -1036,6 +1038,45 @@ func TestCheckpointSyncSteps_DuplicateSaveSuppressesStepFinishedMetric(t *testin
 	mocks.metrics.AssertNotCalled(t, "OnStepFinished")
 }
 
+func TestCheckpointerFnRetriesNotFoundLookup(t *testing.T) {
+	ctx := context.Background()
+	fnID := uuid.New()
+	reader := &retryFnReader{
+		errs: []error{cqrs.ErrNotFound},
+	}
+	c := checkpointer{Opts: Opts{FnReader: reader}}
+
+	fn, err := c.fn(ctx, fnID)
+
+	require.NoError(t, err)
+	require.NotNil(t, fn)
+	require.Equal(t, 2, reader.calls)
+	require.Equal(t, fnID, reader.seen[0])
+	require.Equal(t, fnID, reader.seen[1])
+}
+
+func TestIsRetryableFunctionLookupError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "context canceled", err: context.Canceled, want: false},
+		{name: "deadline exceeded", err: context.DeadlineExceeded, want: false},
+		{name: "cqrs not found", err: cqrs.ErrNotFound, want: true},
+		{name: "sql no rows", err: sql.ErrNoRows, want: true},
+		{name: "wrapped not found text", err: errors.New("function not found"), want: true},
+		{name: "unrelated", err: errors.New("database unavailable"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isRetryableFunctionLookupError(tt.err))
+		})
+	}
+}
+
 //
 //
 // Testing utils.
@@ -1088,7 +1129,7 @@ func setupSyncCheckpointTest(t *testing.T, ops ...state.GeneratorOpcode) (*testS
 	}
 
 	// Setup mock expectations
-	mocks.fnReader.On("GetFunctionByInternalUUID", ctx, fnID).Return(&mockConfigFunction{}, nil)
+	mocks.fnReader.On("GetFunctionByInternalUUID", mock.Anything, fnID).Return(&mockConfigFunction{}, nil)
 
 	// LoadMetadata should NOT be called since syncCheckpoint.Metadata is already set
 	mocks.state.AssertNotCalled(t, "LoadMetadata")
@@ -1127,6 +1168,28 @@ type testSyncData struct {
 	stepOpcodes    []state.GeneratorOpcode
 	syncCheckpoint SyncCheckpoint
 	checkpointer   Checkpointer
+}
+
+type retryFnReader struct {
+	cqrs.FunctionReader
+	errs  []error
+	calls int
+	seen  []uuid.UUID
+}
+
+func (r *retryFnReader) GetFunctionByInternalUUID(ctx context.Context, fnID uuid.UUID) (*cqrs.Function, error) {
+	r.calls++
+	r.seen = append(r.seen, fnID)
+
+	if len(r.errs) > 0 {
+		err := r.errs[0]
+		r.errs = r.errs[1:]
+		return nil, err
+	}
+
+	return &cqrs.Function{
+		Config: json.RawMessage(`{}`),
+	}, nil
 }
 
 // mockExecutor mocks the executor interface

--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -1085,8 +1085,6 @@ func TestIsRetryableFunctionLookupError(t *testing.T) {
 
 // setupSyncCheckpointTest creates new mocks for sync checkpoint testing
 func setupSyncCheckpointTest(t *testing.T, ops ...state.GeneratorOpcode) (*testSyncMocks, *testSyncData) {
-	ctx := context.Background()
-
 	// Create mock dependencies
 	mocks := &testSyncMocks{
 		state:    &mockRunService{},


### PR DESCRIPTION
## Description

use ttlupsert to simplify the codepath in fn upserting for checkpointing/durable endpoints, and add a retry path for first durable endpoint upsert

## Release note

Fixes a potential race condition for displaying the first trace of a new durable endpoint

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
