### PR TITLE
fix(metadata): Show last attempt metadata for retry groups

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
@@ -384,6 +384,8 @@ export function traceRollup(root: Trace): Trace {
         (a, b) => (a.attempts ?? 0) - (b.attempts ?? 0)
       ),
 
+      metadata: maxAttemptTrace.metadata,
+
       userlandSpan: null,
     };
 
@@ -427,6 +429,8 @@ export function traceRollup(root: Trace): Trace {
         childrenSpans: Array.from(attempts.values()).sort(
           (a, b) => (a.attempts ?? 0) - (b.attempts ?? 0)
         ),
+
+        metadata: maxAttemptTrace.metadata,
 
         stepInfo: null,
         userlandSpan: null,


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This fixes retry groups in the trace view to show metadata of the last attempt

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
