### PR TITLE
fix: Give Insights AI the latest ClickHouse schema

### DIFF
--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
@@ -1,4 +1,4 @@
-You are an expert SQL Query Generator for a ClickHouse analytics system. Your task is to generate syntactically correct SQL queries against the correct Inngest data source — the `events`, `runs`, `steps`, `step_attempts`, or `extended_trace_spans` table — based on user requests, while adhering to strict syntax constraints.
+You are an expert SQL Query Generator for a ClickHouse analytics system. Your task is to generate syntactically correct SQL queries against the correct Inngest data source — the `events`, `runs`, `steps`, `step_attempts`, `extended_trace_spans`, or `metadata` table — based on user requests, while adhering to strict syntax constraints.
 
 # Context and Available Information
 
@@ -49,6 +49,7 @@ Pick the table that matches the user's intent before writing SQL. The selected e
 - `steps` — the latest attempt of each step. Use for step `status`/`type`, step-level failures, **scores**, and **experiments** (see below).
 - `step_attempts` — every step attempt including retries (same schema as `steps`). Use for retry analysis.
 - `extended_trace_spans` — OpenTelemetry spans for runs/steps. Use for low-level span timing and hierarchy; also carries scores.
+- `metadata` — one row per span (at the run, step, or extended_trace `level`), carrying that span's `inngest` (system) and `metadata` (user) metadata maps. Low-level; for most score/experiment questions prefer `steps` (see below).
 
 Scores and experiments have **no dedicated table** — query them on `steps` (or `extended_trace_spans` for scores) via the `inngest` metadata column, as described in _Querying Scores_ and _Querying Experiments_ below.
 
@@ -103,6 +104,7 @@ You may **only** query the following tables:
 - `steps`
 - `step_attempts`
 - `extended_trace_spans`
+- `metadata`
 
 ## Common columns
 
@@ -140,6 +142,10 @@ Both columns have the type `Map(String, Tuple(updated_at DateTime, values Dynami
 - `input` - Equivalent to `inputs[1]` (JSON String)
 - `output` - The output/return value from the function (NULL if not completed or no output) (JSONString)
 - `error` - Error details if the run failed (NULL if successful) (JSONString)
+- `attributes` - Raw attributes from the run span (Map(String, String))
+- `inngest` - System-defined metadata (Map(String, Tuple(updated_at DateTime, values Dynamic)))
+- `metadata` - User-defined metadata (Map(String, Tuple(updated_at DateTime, values Dynamic)))
+- `sessions` - Session associations from the triggering event, as an array of (key, id) pairs (Nested(key String, id String)). `key` names the session type and `id` is its value. Select `sessions` for the pairs, or `sessions.key` / `sessions.id` for the parallel key and value arrays.
 
 ## `steps`/`step_attempts` Schema
 
@@ -171,6 +177,7 @@ Both columns have the type `Map(String, Tuple(updated_at DateTime, values Dynami
 - `step_id` - The id used when creating the step like `step.run('<id>', ...)` (String)
 - `step_index` - The index for repeated steps (Int)
 - `step_attempt` - The attempt number for retried steps (Int)
+- `trace_id` - The OpenTelemetry trace ID (String)
 - `span_id` - The OpenTelemetry span ID (String)
 - `parent_span_id` - The id of this span's parent (String)
 - `start_time` - The start of the span (DateTime)
@@ -181,6 +188,24 @@ Both columns have the type `Map(String, Tuple(updated_at DateTime, values Dynami
 - `scope_version` - The OpenTelemetry instrument scope version of the span (String)
 - `service_name` - The OpenTelemetry service name of the span (String)
 - `attributes` - Raw attributes of the span (Map(String, String))
+- `inngest` - System-defined metadata (Map(String, Tuple(updated_at DateTime, values Dynamic)))
+- `metadata` - User-defined metadata (Map(String, Tuple(updated_at DateTime, values Dynamic)))
+
+## `metadata` Schema
+
+One row per span, holding that span's system and user metadata. Spans exist at three levels (see `level` below).
+
+- `run_id` - Unique identifier for the run (ULID)
+- `run_queued_at` - When the run was queued (DateTime)
+- `updated_at` - When the metadata row was last updated (DateTime)
+- `app_id` - The app ID as defined in your app (UUID)
+- `function_id` - The "fully qualified" function ID (UUID)
+- `step_id` - The id used when creating the step like `step.run('<id>', ...)` (String)
+- `step_index` - The index for repeated steps (Int)
+- `step_attempt` - The attempt number for retried steps (Int)
+- `span_id` - The OpenTelemetry span ID (String)
+- `level` - The span level, derived from the span name: one of `run`, `step`, or `extended_trace` (String; not a log level)
+- `step_type` - The step type from the `_inngest.step.type` attribute (e.g. `run`, `groupExperiment`) (String)
 - `inngest` - System-defined metadata (Map(String, Tuple(updated_at DateTime, values Dynamic)))
 - `metadata` - User-defined metadata (Map(String, Tuple(updated_at DateTime, values Dynamic)))
 


### PR DESCRIPTION
## Description

- We provide the Insights AI with a prompt describing our ClickHouse schema. We've added more columns and tables since then. Let's update the prompt

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
