### PR TITLE
fix(insights): fixes based on user prompts

### DIFF
--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
@@ -46,8 +46,8 @@ Pick the table that matches the user's intent before writing SQL. The selected e
 
 - `events` — the raw event stream (one row per event ingested). Use for event volumes, event payload fields (`data.*`), and what triggered runs.
 - `runs` — function executions (one row per run). Use for run `status` (`Queued`/`Running`/`Failed`/`Cancelled`/`Completed`), durations, inputs/outputs, and function-level failures.
-- `steps` — the latest attempt of each step. Use for step `status`/`type`, step-level failures, **scores**, and **experiments** (see below).
-- `step_attempts` — every step attempt including retries (same schema as `steps`). Use for retry analysis.
+- `steps` — the latest attempt of each step. Use for step `status`/`type`, step-level failures, **scores**, **experiments**, and **AI token usage / model / cost** (see below).
+- `step_attempts` — every step attempt including retries (same schema as `steps`). Use for retry analysis and for true **token usage / cost totals** (retries consume tokens too).
 - `extended_trace_spans` — OpenTelemetry spans for runs/steps. Use for low-level span timing and hierarchy; also carries scores.
 
 Scores and experiments have **no dedicated table** — query them on `steps` (or `extended_trace_spans` for scores) via the `inngest` metadata column, as described in _Querying Scores_ and _Querying Experiments_ below.
@@ -106,8 +106,12 @@ You may **only** query the following tables:
 
 ## Common columns
 
-- `app_id` - The app ID as defined in your app
-- `function_id` - The "fully qualified" function ID. This is the app ID concatenated to the function ID as defined in your app with a `-` (e.g., `my-app-my-function`)
+`app_id` and `function_id` are stored as **UUIDs** on `runs`, `steps`, `step_attempts`, and `extended_trace_spans`. **Write them as slug strings** with `=` or `IN` and the system translates the slug to the UUID for you — never compare them against a raw UUID.
+
+- `app_id` - The app slug as defined in your app
+- `function_id` - The "fully qualified" function slug: the app slug concatenated to the function slug with a `-` (e.g., `my-app-my-function`)
+
+Because these are UUIDs underneath, slug translation only happens for `=` / `IN` with a **complete** slug. See _Pattern Matching_ for why partial matches (`LIKE`) on these columns fail.
 
 ## Metadata columns
 
@@ -251,6 +255,40 @@ GROUP BY variant
 
 The experiment's `selection_strategy`/`variant_weights` live only on the selection span — read them with the filter `attributes['_inngest.step.run.type'] = 'group.experiment'`.
 
+## Querying AI / Token Usage
+
+Token usage, model, latency, and cost from `step.ai` / AI Gateway calls live in the `inngest` metadata column under the `ai` key, on the **`steps`** and **`step_attempts`** tables (one entry per inference step). They are **not** on `runs` or `events` — querying those for tokens returns no results.
+
+Available fields under `inngest['ai'].values[...]` (read numeric ones with a `::Float64` cast):
+
+- `input_tokens` — prompt tokens (always present)
+- `output_tokens` — completion tokens (always present)
+- `total_tokens` — **often absent**; do not rely on it (a missing value yields `0`/`NaN`). Compute the total as `input_tokens + output_tokens` instead.
+- `model` / `response_model` — the requested / serving model name
+- `latency_ms`, `estimated_cost`
+
+Use `step_attempts` for true usage/cost totals (retries consume tokens too); use `steps` for the latest attempt only. Only inference steps carry the `ai` key — other rows return NULL for these and are ignored by `SUM`.
+
+**Total token usage over the last 1 day** (compute total from input + output, not `total_tokens`):
+
+```sql
+SELECT SUM(inngest['ai'].values['input_tokens']::Float64)
+     + SUM(inngest['ai'].values['output_tokens']::Float64) AS total_tokens
+FROM step_attempts
+WHERE queued_at >= now() - INTERVAL 1 DAY
+```
+
+**Token usage broken down by model:**
+
+```sql
+SELECT inngest['ai'].values['model'] AS model,
+       SUM(inngest['ai'].values['input_tokens']::Float64) AS input_tokens,
+       SUM(inngest['ai'].values['output_tokens']::Float64) AS output_tokens
+FROM step_attempts
+WHERE queued_at >= now() - INTERVAL 7 DAY
+GROUP BY model
+```
+
 # Critical SQL Restrictions
 
 You are working with a **restricted subset of ClickHouse SQL**. The parser has severe limitations. Violating these rules will cause the query to fail.
@@ -316,6 +354,13 @@ WHERE ts_dt > now() - INTERVAL 30 MINUTE
 WHERE ts > toUnixTimestamp(subtractDays(now(), 7)) * 1000
 ```
 
+**Method 3 - Absolute date ranges (recommended for specific dates)**: compare the DateTime/`_dt` column to a **plain string literal**. Do **not** wrap the literal in `toDateTime`, `parseDateTime*`, `parseDateTime64BestEffort`, or `toUnixTimestamp` — those cannot be used as a DateTime here and will fail.
+
+```sql
+WHERE queued_at >= '2026-06-01 00:00:00' AND queued_at < '2026-06-02 00:00:00'
+WHERE received_at_dt BETWEEN '2026-06-14' AND '2026-06-15'
+```
+
 Supported INTERVAL units: `YEAR`, `QUARTER`, `MONTH`, `WEEK`, `DAY`, `HOUR`, `MINUTE`, `SECOND`, `MILLISECOND`, `MICROSECOND`, `NANOSECOND`
 
 ### WITH Expression Aliases
@@ -354,6 +399,8 @@ WHERE like(name, 'user%')
 WHERE ilike(data.email, '%@example.com')
 ```
 
+**Never** use `LIKE`, `ILIKE`, `match`, `position`, `substring`, or any string function on `function_id` or `app_id` (or their aliases). These are UUID columns; slug→UUID translation only happens for `=` / `IN` with a **complete** slug, so a partial pattern is compared against a UUID and fails with _"Illegal type UUID of argument of function like"_. To match a full function/app name, use `function_id = 'my-app-my-function'` or `function_id IN ('app-a-fn-x', 'app-b-fn-y')`. To match _part_ of a name, filter a name-bearing column instead — `triggering_event_name` on `runs`, `name` on `events` — never the id.
+
 ### IN Operator
 
 ```sql
@@ -380,6 +427,8 @@ Always use **single quotes** (`'`) for string literals. Never use double quotes 
 Backticks (`` ` ``) are **only** for quoting a Map-key identifier that contains a dot or other special character in dot-path access — e.g. `` inngest.`score.my-metric`.values.value `` (see _Querying Scores_). Never use backticks to quote string literals.
 
 # Aggregation Functions
+
+Every selected column that is **not** inside an aggregate function must appear in `GROUP BY` (otherwise the query fails with _"... is not under aggregate function and not in GROUP BY"_). The simplest safe option is **`GROUP BY ALL`**, which groups by every non-aggregated select expression.
 
 ## Basic Aggregates
 

--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
@@ -284,7 +284,7 @@ WHERE queued_at >= now() - INTERVAL 1 DAY
 **Token usage broken down by model:**
 
 ```sql
-SELECT inngest.ai.values.model AS model,
+SELECT coalesce(inngest.ai.values.request_model, inngest.ai.values.model) AS model,
        SUM(inngest.ai.values.input_tokens) AS input_tokens,
        SUM(inngest.ai.values.output_tokens) AS output_tokens
 FROM step_attempts

--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
@@ -257,7 +257,7 @@ The experiment's `selection_strategy`/`variant_weights` live only on the selecti
 
 ## Querying AI / Token Usage
 
-Token usage and model for LLM calls live in the `inngest` metadata column under the `ai` key, on the **`steps`** and **`step_attempts`** tables. This metadata comes from two sources that normalize into the same `ai` key: `step.ai.wrap`/`step.ai.infer`, and the **OTel AI-metadata extractor** for any LLM call instrumented with OpenTelemetry `gen_ai.*` / `ai.usage.*` / `llm.token_count.*` attributes (e.g. an LLM call inside a `step.run`). Token data is **not** on `runs` or `events` — querying those returns no results.
+Token usage and model for LLM calls live in the `inngest` metadata column under the `ai` key, on the **`steps`** and **`step_attempts`** tables. This metadata comes from two sources that normalize into the same `ai` key: `step.ai.wrap`/`step.ai.infer`, and the **OTel AI-metadata extractor** for any LLM call instrumented with OpenTelemetry `gen_ai.*` attributes (e.g. an LLM call inside a `step.run`). Token data is **not** on `runs` or `events` — querying those returns no results.
 
 Available fields, read with **dot syntax** (`inngest.ai.values.<field>`) like the other metadata sections above — not bracket indexing:
 

--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
@@ -259,7 +259,7 @@ The experiment's `selection_strategy`/`variant_weights` live only on the selecti
 
 Token usage, model, latency, and cost from `step.ai` / AI Gateway calls live in the `inngest` metadata column under the `ai` key, on the **`steps`** and **`step_attempts`** tables (one entry per inference step). They are **not** on `runs` or `events` — querying those for tokens returns no results.
 
-Available fields under `inngest['ai'].values[...]` (read numeric ones with a `::Float64` cast):
+Available fields, read with **dot syntax** (`inngest.ai.values.<field>`) like the other metadata sections above — not bracket indexing. Cast numeric ones with `::Float64`:
 
 - `input_tokens` — prompt tokens (always present)
 - `output_tokens` — completion tokens (always present)
@@ -272,8 +272,8 @@ Use `step_attempts` for true usage/cost totals (retries consume tokens too); use
 **Total token usage over the last 1 day** (compute total from input + output, not `total_tokens`):
 
 ```sql
-SELECT SUM(inngest['ai'].values['input_tokens']::Float64)
-     + SUM(inngest['ai'].values['output_tokens']::Float64) AS total_tokens
+SELECT SUM(inngest.ai.values.input_tokens::Float64)
+     + SUM(inngest.ai.values.output_tokens::Float64) AS total_tokens
 FROM step_attempts
 WHERE queued_at >= now() - INTERVAL 1 DAY
 ```
@@ -281,9 +281,9 @@ WHERE queued_at >= now() - INTERVAL 1 DAY
 **Token usage broken down by model:**
 
 ```sql
-SELECT inngest['ai'].values['model'] AS model,
-       SUM(inngest['ai'].values['input_tokens']::Float64) AS input_tokens,
-       SUM(inngest['ai'].values['output_tokens']::Float64) AS output_tokens
+SELECT inngest.ai.values.model AS model,
+       SUM(inngest.ai.values.input_tokens::Float64) AS input_tokens,
+       SUM(inngest.ai.values.output_tokens::Float64) AS output_tokens
 FROM step_attempts
 WHERE queued_at >= now() - INTERVAL 7 DAY
 GROUP BY model
@@ -399,7 +399,9 @@ WHERE like(name, 'user%')
 WHERE ilike(data.email, '%@example.com')
 ```
 
-**Never** use `LIKE`, `ILIKE`, `match`, `position`, `substring`, or any string function on `function_id` or `app_id` (or their aliases). These are UUID columns; slug→UUID translation only happens for `=` / `IN` with a **complete** slug, so a partial pattern is compared against a UUID and fails with _"Illegal type UUID of argument of function like"_. To match a full function/app name, use `function_id = 'my-app-my-function'` or `function_id IN ('app-a-fn-x', 'app-b-fn-y')`. To match _part_ of a name, filter a name-bearing column instead — `triggering_event_name` on `runs`, `name` on `events` — never the id.
+`function_id` and `app_id` (and their aliases) are **UUID** columns. They may appear **only** as `= '<slug>'` or `IN ('<slug>', …)`; slug→UUID translation happens only for those operators with a **complete** slug. You must **never** wrap them in any function. That includes `LIKE`/`ILIKE`/`match`/`position`/`substring`/`lower`/`upper`/`concat` and every other string or scalar function. Any of these fails with _"Illegal type UUID of argument of function …"_.
+
+There is **no** function-name or app-name text column, so you **cannot substring-match a function or app by name**. If the user gives a partial or approximate function name, match the full slug exactly with `function_id = 'my-app-my-function'` (or list likely slugs with `IN (...)`) — never improvise a pattern match. Substring matching is only possible on genuine name columns: `triggering_event_name` on `runs`, `name` on `events` (those are event names, not function names).
 
 ### IN Operator
 

--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
@@ -267,7 +267,7 @@ Available fields, read with **dot syntax** (`inngest.ai.values.<field>`) like th
 - `model` / `response_model` — the requested / serving model name
 - `latency_ms`, `estimated_cost`
 
-Use `step_attempts` for true usage/cost totals (retries consume tokens too); use `steps` for the latest attempt only. Only inference steps carry the `ai` key — other rows return NULL for these and are ignored by `SUM`.
+Use `step_attempts` for true usage/cost totals (retries consume tokens too); use `steps` for the latest attempt only. Step attempts without the `ai` key return NULL for these and are ignored by `SUM`.
 
 **Total token usage over the last 1 day** (compute total from input + output, not `total_tokens`):
 

--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
@@ -272,8 +272,8 @@ Use `step_attempts` for true usage/cost totals (retries consume tokens too); use
 **Total token usage over the last 1 day** (compute total from input + output, not `total_tokens`):
 
 ```sql
-SELECT SUM(inngest.ai.values.input_tokens::Float64)
-     + SUM(inngest.ai.values.output_tokens::Float64) AS total_tokens
+SELECT SUM(inngest.ai.values.input_tokens)
+     + SUM(inngest.ai.values.output_tokens) AS total_tokens
 FROM step_attempts
 WHERE queued_at >= now() - INTERVAL 1 DAY
 ```

--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
@@ -257,15 +257,18 @@ The experiment's `selection_strategy`/`variant_weights` live only on the selecti
 
 ## Querying AI / Token Usage
 
-Token usage, model, latency, and cost from `step.ai` / AI Gateway calls live in the `inngest` metadata column under the `ai` key, on the **`steps`** and **`step_attempts`** tables (one entry per inference step). They are **not** on `runs` or `events` — querying those for tokens returns no results.
+Token usage and model for LLM calls live in the `inngest` metadata column under the `ai` key, on the **`steps`** and **`step_attempts`** tables. This metadata comes from two sources that normalize into the same `ai` key: `step.ai.wrap`/`step.ai.infer`, and the **OTel AI-metadata extractor** for any LLM call instrumented with OpenTelemetry `gen_ai.*` / `ai.usage.*` / `llm.token_count.*` attributes (e.g. an LLM call inside a `step.run`). Token data is **not** on `runs` or `events` — querying those returns no results.
 
-Available fields, read with **dot syntax** (`inngest.ai.values.<field>`) like the other metadata sections above — not bracket indexing. Cast numeric ones with `::Float64`:
+Available fields, read with **dot syntax** (`inngest.ai.values.<field>`) like the other metadata sections above — not bracket indexing:
 
-- `input_tokens` — prompt tokens (always present)
-- `output_tokens` — completion tokens (always present)
-- `total_tokens` — **often absent**; do not rely on it (a missing value yields `0`/`NaN`). Compute the total as `input_tokens + output_tokens` instead.
+- `input_tokens` — prompt tokens
+- `output_tokens` — completion tokens
+- `total_tokens` — **often absent**; do not rely on it. Compute the total as `input_tokens + output_tokens` instead.
 - `model` / `response_model` — the requested / serving model name
-- `latency_ms`, `estimated_cost`
+
+Reference these fields **bare** in numeric and aggregate contexts (e.g. `SUM(inngest.ai.values.input_tokens)`) — the transpiler infers a null-safe `accurateCastOrNull(…, 'Float64')` for them. Do **not** add an explicit `::Float64` cast: it maps to a non-nullable `CAST` that errors when a value is missing or NULL. If you ever need an explicit cast, use `accurateCastOrNull(…, 'Float64')`.
+
+(Latency and cost are intentionally omitted: they exist only on the `step.ai` schema, which is still being unified with the OTel-extractor schema.)
 
 Use `step_attempts` for true usage/cost totals (retries consume tokens too); use `steps` for the latest attempt only. Step attempts without the `ai` key return NULL for these and are ignored by `SUM`.
 
@@ -399,7 +402,7 @@ WHERE like(name, 'user%')
 WHERE ilike(data.email, '%@example.com')
 ```
 
-`function_id` and `app_id` (and their aliases) are **UUID** columns. They may appear **only** as `= '<slug>'` or `IN ('<slug>', …)`; slug→UUID translation happens only for those operators with a **complete** slug. You must **never** wrap them in any function. That includes `LIKE`/`ILIKE`/`match`/`position`/`substring`/`lower`/`upper`/`concat` and every other string or scalar function. Any of these fails with _"Illegal type UUID of argument of function …"_.
+`function_id` and `app_id` (and their aliases) are **UUID** columns. You may select them, `GROUP BY` them, filter with `= '<slug>'` / `IN ('<slug>', …)` (slug→UUID translation happens for those operators with a **complete** slug), and aggregate them with counting/collecting functions — `COUNT(DISTINCT function_id)`, `uniq(function_id)`, `any(function_id)`, `groupArray(function_id)`, `groupUniqArray(function_id)`. What you must **never** do is apply a **string, pattern, or scalar** function to them — `LIKE`/`ILIKE`/`match`/`position`/`substring`/`lower`/`upper`/`concat`, arithmetic, etc. — each fails with _"Illegal type UUID of argument of function …"_.
 
 There is **no** function-name or app-name text column, so you **cannot substring-match a function or app by name**. If the user gives a partial or approximate function name, match the full slug exactly with `function_id = 'my-app-my-function'` (or list likely slugs with `IN (...)`) — never improvise a pattern match. Substring matching is only possible on genuine name columns: `triggering_event_name` on `runs`, `name` on `events` (those are event names, not function names).
 

--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
@@ -282,8 +282,8 @@ WHERE queued_at >= now() - INTERVAL 1 DAY
 
 ```sql
 SELECT inngest.ai.values.model AS model,
-       SUM(inngest.ai.values.input_tokens::Float64) AS input_tokens,
-       SUM(inngest.ai.values.output_tokens::Float64) AS output_tokens
+       SUM(inngest.ai.values.input_tokens) AS input_tokens,
+       SUM(inngest.ai.values.output_tokens) AS output_tokens
 FROM step_attempts
 WHERE queued_at >= now() - INTERVAL 7 DAY
 GROUP BY model

--- a/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agents/query-writer/system.md
@@ -264,7 +264,7 @@ Available fields, read with **dot syntax** (`inngest.ai.values.<field>`) like th
 - `input_tokens` — prompt tokens
 - `output_tokens` — completion tokens
 - `total_tokens` — **often absent**; do not rely on it. Compute the total as `input_tokens + output_tokens` instead.
-- `model` / `response_model` — the requested / serving model name
+- either `model` (the request or response model) or `request_model` and `response_model`. Response models usually look like request models with a date version suffix.
 
 Reference these fields **bare** in numeric and aggregate contexts (e.g. `SUM(inngest.ai.values.input_tokens)`) — the transpiler infers a null-safe `accurateCastOrNull(…, 'Float64')` for them. Do **not** add an explicit `::Float64` cast: it maps to a non-nullable `CAST` that errors when a value is missing or NULL. If you ever need an explicit cast, use `accurateCastOrNull(…, 'Float64')`.
 


### PR DESCRIPTION
## Description

Prompt-only changes to `query-writer/system.md`. No transpiler or app code touched.

### Method

Took the agent's "Fix with AI" log (208 query failures, each with the real error + failing SQL), classified by error type, and correlated against transpiler/agent git history. Kept only the classes still failing that the prompt can fix.

### Fixes

- **`function_id`/`app_id` LIKE on UUID columns** (9): prompt called them readable strings, model wrote `LIKE '%name%'`, engine rejects it. Now: match full slug with `=`/`IN`, use name columns for partial matches.
- **Absolute date ranges** (22): model wrapped literals in `toDateTime()`/`toUnixTimestamp()`, which fail. Now: compare to bare string literals (`queued_at >= '2026-06-01'`).
- **Token usage** (NaN/0/no results): prompt never said where tokens live. Now: documented `inngest['ai'].values[...]` on steps, and compute total as `input_tokens + output_tokens` (`total_tokens` is often absent).
- **GROUP BY** (5): stated the rule and pointed at `GROUP BY ALL`.

## Release note

Insights AI generates more reliable queries for function/app filtering, date ranges, and token usage.

## Migration note

None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
