### PR TITLE
fix: Update AI Metadata field names

### DIFF
--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -25,7 +25,7 @@ type AIMetadata struct {
 	InputTokens   int64  `json:"input_tokens"`
 	OutputTokens  int64  `json:"output_tokens"`
 	Model         string `json:"model"`
-	Provider      string `json:"system"`
+	Provider      string `json:"provider"`
 	OperationName string `json:"operation_name"`
 
 	// Response identity. ResponseModel is the model that served the request (may

--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -24,7 +24,7 @@ const (
 type AIMetadata struct {
 	InputTokens   int64  `json:"input_tokens"`
 	OutputTokens  int64  `json:"output_tokens"`
-	Model         string `json:"model"`
+	RequestModel  string `json:"model"`
 	Provider      string `json:"provider"`
 	OperationName string `json:"operation_name"`
 
@@ -94,7 +94,7 @@ func ExtractAIGatewayMetadata(req aigateway.Request, respStatus int, resp []byte
 	}
 
 	aiMd := &AIMetadata{
-		Model:         parsedInput.Model,
+		RequestModel:  parsedInput.Model,
 		Provider:      req.Format,
 		OperationName: "",
 
@@ -227,7 +227,7 @@ func ExtractAIOutputMetadata(output []byte, stepDurationMs int64) ([]metadata.St
 		InputTokens:   inputTokens,
 		OutputTokens:  outputTokens,
 		TotalTokens:   &totalTokens,
-		Model:         model,
+		RequestModel:  model,
 		Provider:      "vercel-ai",
 		LatencyMs:     latencyMs,
 		EstimatedCost: EstimateCost(model, inputTokens, outputTokens),

--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -24,7 +24,7 @@ const (
 type AIMetadata struct {
 	InputTokens   int64  `json:"input_tokens"`
 	OutputTokens  int64  `json:"output_tokens"`
-	RequestModel  string `json:"model"`
+	RequestModel  string `json:"request_model"`
 	Provider      string `json:"provider"`
 	OperationName string `json:"operation_name"`
 

--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -25,7 +25,7 @@ type AIMetadata struct {
 	InputTokens   int64  `json:"input_tokens"`
 	OutputTokens  int64  `json:"output_tokens"`
 	Model         string `json:"model"`
-	System        string `json:"system"`
+	Provider      string `json:"system"`
 	OperationName string `json:"operation_name"`
 
 	// Response identity. ResponseModel is the model that served the request (may
@@ -95,7 +95,7 @@ func ExtractAIGatewayMetadata(req aigateway.Request, respStatus int, resp []byte
 
 	aiMd := &AIMetadata{
 		Model:         parsedInput.Model,
-		System:        req.Format,
+		Provider:      req.Format,
 		OperationName: "",
 
 		InputTokens:   inputTokens,
@@ -228,7 +228,7 @@ func ExtractAIOutputMetadata(output []byte, stepDurationMs int64) ([]metadata.St
 		OutputTokens:  outputTokens,
 		TotalTokens:   &totalTokens,
 		Model:         model,
-		System:        "vercel-ai",
+		Provider:      "vercel-ai",
 		LatencyMs:     latencyMs,
 		EstimatedCost: EstimateCost(model, inputTokens, outputTokens),
 	}

--- a/pkg/tracing/metadata/extractors/ai_test.go
+++ b/pkg/tracing/metadata/extractors/ai_test.go
@@ -94,9 +94,9 @@ func TestAIMetadataExtractor_OpenAISpan(t *testing.T) {
 	assert.Equal(t, 97.0, data["output_tokens"], "Should extract output tokens")
 
 	// Verify model and operation data
-	assert.Equal(t, "gpt-4", data["model"], "Should extract request model")
+	assert.Equal(t, "gpt-4", data["request_model"], "Should extract request model")
 	assert.Equal(t, "chat", data["operation_name"], "Should extract operation name")
-	assert.Equal(t, "openai", data["system"], "Should extract AI system")
+	assert.Equal(t, "openai", data["provider"], "Should extract AI provider")
 }
 
 func TestAIMetadataExtractor_NonAISpan(t *testing.T) {
@@ -251,11 +251,11 @@ func TestExtractAIOutputMetadata_VercelAISDK(t *testing.T) {
 	assert.Equal(t, 429.0, data["output_tokens"], "Should extract output tokens")
 	assert.Equal(t, 440.0, data["total_tokens"], "Should extract total tokens")
 
-	// Verify model
-	assert.Equal(t, "gpt-4-turbo-2024-04-09", data["model"], "Should extract model from response.modelId")
+	// Verify request model
+	assert.Equal(t, "gpt-4-turbo-2024-04-09", data["request_model"], "Should extract request model from response.modelId")
 
-	// Verify system
-	assert.Equal(t, "vercel-ai", data["system"], "Should set system to vercel-ai")
+	// Verify provider
+	assert.Equal(t, "vercel-ai", data["provider"], "Should set provider to vercel-ai")
 
 	// Verify latency (from openai-processing-ms header)
 	assert.Equal(t, 24314.0, data["latency_ms"], "Should extract latency from OpenAI header")

--- a/pkg/tracing/metadata/extractors/aimetadata.go
+++ b/pkg/tracing/metadata/extractors/aimetadata.go
@@ -41,7 +41,7 @@ func (e *AIMetadataExtractor) extractAIMetadata(span *tracev1.Span) (md AIMetada
 		md.TotalTokens = &totalTokens
 	}
 
-	md.EstimatedCost = EstimateCost(md.Model, md.InputTokens, md.OutputTokens)
+	md.EstimatedCost = EstimateCost(md.RequestModel, md.InputTokens, md.OutputTokens)
 
 	return md, true
 }

--- a/pkg/tracing/metadata/extractors/aimetadata_test.go
+++ b/pkg/tracing/metadata/extractors/aimetadata_test.go
@@ -77,7 +77,7 @@ func TestAIMetadataExtractor_CapturedFixtures(t *testing.T) {
 				enc := json.NewEncoder(&buf)
 				enc.SetIndent("", "  ")
 				require.NoError(t, enc.Encode(goldenAIMetadata{
-					Model:         md.Model,
+					Model:         md.RequestModel,
 					System:        md.Provider,
 					OperationName: md.OperationName,
 					ResponseModel: md.ResponseModel,

--- a/pkg/tracing/metadata/extractors/aimetadata_test.go
+++ b/pkg/tracing/metadata/extractors/aimetadata_test.go
@@ -78,7 +78,7 @@ func TestAIMetadataExtractor_CapturedFixtures(t *testing.T) {
 				enc.SetIndent("", "  ")
 				require.NoError(t, enc.Encode(goldenAIMetadata{
 					Model:         md.Model,
-					System:        md.System,
+					System:        md.Provider,
 					OperationName: md.OperationName,
 					ResponseModel: md.ResponseModel,
 					ResponseID:    md.ResponseID,

--- a/pkg/tracing/metadata/extractors/attributes.go
+++ b/pkg/tracing/metadata/extractors/attributes.go
@@ -58,8 +58,8 @@ func extractAIMetadataFromAttributes(attributes []*v1.KeyValue, md *AIMetadata) 
 	// Provider: gen_ai.provider.name is canonical and gen_ai.system is its
 	// deprecated predecessor. Read system first so the canonical key overwrites
 	// it whenever both are present.
-	read("gen_ai.system", func(v *v1.AnyValue) { md.System = v.GetStringValue() })
-	read("gen_ai.provider.name", func(v *v1.AnyValue) { md.System = v.GetStringValue() })
+	read("gen_ai.system", func(v *v1.AnyValue) { md.Provider = v.GetStringValue() })
+	read("gen_ai.provider.name", func(v *v1.AnyValue) { md.Provider = v.GetStringValue() })
 
 	return foundAny
 }

--- a/pkg/tracing/metadata/extractors/attributes.go
+++ b/pkg/tracing/metadata/extractors/attributes.go
@@ -25,7 +25,7 @@ func extractAIMetadataFromAttributes(attributes []*v1.KeyValue, md *AIMetadata) 
 		}
 	}
 
-	read("gen_ai.request.model", func(v *v1.AnyValue) { md.Model = v.GetStringValue() })
+	read("gen_ai.request.model", func(v *v1.AnyValue) { md.RequestModel = v.GetStringValue() })
 	read("gen_ai.operation.name", func(v *v1.AnyValue) { md.OperationName = v.GetStringValue() })
 	read("gen_ai.response.model", func(v *v1.AnyValue) { md.ResponseModel = v.GetStringValue() })
 	read("gen_ai.response.id", func(v *v1.AnyValue) { md.ResponseID = v.GetStringValue() })

--- a/pkg/tracing/metadata/extractors/attributes_test.go
+++ b/pkg/tracing/metadata/extractors/attributes_test.go
@@ -49,7 +49,7 @@ func TestProviderPrefersProviderNameOverDeprecatedSystem(t *testing.T) {
 		var md AIMetadata
 		foundAny := extractAIMetadataFromAttributes(attrs, &md)
 		assert.True(t, foundAny)
-		assert.Equal(t, "anthropic", md.System,
+		assert.Equal(t, "anthropic", md.Provider,
 			"gen_ai.provider.name should win over deprecated gen_ai.system")
 	}
 }

--- a/pkg/tracing/metadata/types/types_gen.go
+++ b/pkg/tracing/metadata/types/types_gen.go
@@ -25,7 +25,7 @@ const (
 type AIMetadata struct {
 	InputTokens	int64	`json:"input_tokens"`
 	OutputTokens	int64	`json:"output_tokens"`
-	Model		string	`json:"model"`
+	RequestModel	string	`json:"request_model"`
 	Provider	string	`json:"provider"`
 	OperationName	string	`json:"operation_name"`
 

--- a/pkg/tracing/metadata/types/types_gen.go
+++ b/pkg/tracing/metadata/types/types_gen.go
@@ -26,7 +26,7 @@ type AIMetadata struct {
 	InputTokens	int64	`json:"input_tokens"`
 	OutputTokens	int64	`json:"output_tokens"`
 	Model		string	`json:"model"`
-	System		string	`json:"system"`
+	Provider	string	`json:"provider"`
 	OperationName	string	`json:"operation_name"`
 
 	// Response identity. ResponseModel is the model that served the request (may

--- a/ui/packages/components/src/generated/index.ts
+++ b/ui/packages/components/src/generated/index.ts
@@ -44,7 +44,7 @@ export interface AIMetadata {
   input_tokens: number /* int64 */;
   output_tokens: number /* int64 */;
   model: string;
-  system: string;
+  provider: string;
   operation_name: string;
   /**
    * Response identity. ResponseModel is the model that served the request (may

--- a/ui/packages/components/src/generated/index.ts
+++ b/ui/packages/components/src/generated/index.ts
@@ -43,7 +43,7 @@ export const KindInngestAI = 'inngest.ai';
 export interface AIMetadata {
   input_tokens: number /* int64 */;
   output_tokens: number /* int64 */;
-  model: string;
+  request_model: string;
   provider: string;
   operation_name: string;
   /**


### PR DESCRIPTION
## Description

- Currently, we have the model and system fields
- model -> request model to remove ambiguity of what model this is (request vs response) and match OTel and OI standards
- system -> provider to match OTel and OI standards
- These bring OSS into alignment with the JS SDK as well
- This is a breaking change for Insights queries that utilize AI Metadata

## Release note

For AI Metadata extracted from extended traces, step.ai.wrap, and step.ai.infer, the .model field has been renamed to .request_model and .system has been renamed .provider to better match the OpenTelemetry GenAI standards.

## Migration note

Insights queries that use AI Metadata fields of .model and .system should be updated to use .request_model and .provider, respectively.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
