### PR TITLE
feat: Differentiate between request and response model for AI Metadata extraction with ai.step.*

### DIFF
--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -93,15 +93,23 @@ func ExtractAIGatewayMetadata(req aigateway.Request, respStatus int, resp []byte
 		latencyMs = &serverProcessingMs
 	}
 
+	// prefer the response model (the model that actually served the request)
+	// for cost estimation, falling back to the requested model.
+	costModel := parsedOutput.Model
+	if costModel == "" {
+		costModel = parsedInput.Model
+	}
+
 	aiMd := &AIMetadata{
 		RequestModel:  parsedInput.Model,
+		ResponseModel: parsedOutput.Model,
 		Provider:      req.Format,
 		OperationName: "",
 
 		InputTokens:   inputTokens,
 		OutputTokens:  outputTokens,
 		TotalTokens:   &totalTokens,
-		EstimatedCost: EstimateCost(parsedInput.Model, inputTokens, outputTokens),
+		EstimatedCost: EstimateCost(costModel, inputTokens, outputTokens),
 		LatencyMs:     latencyMs,
 	}
 

--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -195,13 +195,15 @@ func ExtractAIOutputMetadata(output []byte, stepDurationMs int64) ([]metadata.St
 		return nil, nil
 	}
 
-	// get model name, try response.modelId first, then request.body.model
-	var model string
+	var requestModel string
+	var responseModel string
 	if firstStep != nil {
 		if firstStep.Response != nil && firstStep.Response.ModelID != "" {
-			model = firstStep.Response.ModelID
-		} else if firstStep.Request != nil && firstStep.Request.Body.Model != "" {
-			model = firstStep.Request.Body.Model
+			responseModel = firstStep.Response.ModelID
+		}
+
+		if firstStep.Request != nil && firstStep.Request.Body.Model != "" {
+			requestModel = firstStep.Request.Body.Model
 		}
 	}
 
@@ -223,14 +225,22 @@ func ExtractAIOutputMetadata(output []byte, stepDurationMs int64) ([]metadata.St
 		latencyMs = &stepDurationMs
 	}
 
+	// prefer the response model (the model that actually served the request)
+	// for cost estimation, falling back to the requested model.
+	costModel := responseModel
+	if costModel == "" {
+		costModel = requestModel
+	}
+
 	aiMd := &AIMetadata{
 		InputTokens:   inputTokens,
 		OutputTokens:  outputTokens,
 		TotalTokens:   &totalTokens,
-		RequestModel:  model,
+		RequestModel:  requestModel,
+		ResponseModel: responseModel,
 		Provider:      "vercel-ai",
 		LatencyMs:     latencyMs,
-		EstimatedCost: EstimateCost(model, inputTokens, outputTokens),
+		EstimatedCost: EstimateCost(costModel, inputTokens, outputTokens),
 	}
 
 	return []metadata.Structured{aiMd}, nil

--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -29,7 +29,7 @@ type AIMetadata struct {
 	OperationName string `json:"operation_name"`
 
 	// Response identity. ResponseModel is the model that served the request (may
-	// differ from the requested Model, e.g. a dated snapshot). FinishReasons is
+	// differ from the RequestModel, e.g. a dated snapshot). FinishReasons is
 	// stored raw per emitter — note OpenAI's native "tool_calls" is emitted as
 	// the singular "tool_call" by some instrumentations.
 	ResponseModel string   `json:"response_model,omitempty"`

--- a/pkg/tracing/metadata/extractors/ai_test.go
+++ b/pkg/tracing/metadata/extractors/ai_test.go
@@ -252,7 +252,8 @@ func TestExtractAIOutputMetadata_VercelAISDK(t *testing.T) {
 	assert.Equal(t, 440.0, data["total_tokens"], "Should extract total tokens")
 
 	// Verify request model
-	assert.Equal(t, "gpt-4-turbo-2024-04-09", data["request_model"], "Should extract request model from response.modelId")
+	assert.Equal(t, "gpt-4-turbo", data["request_model"], "Should extract request model from request.modelId")
+	assert.Equal(t, "gpt-4-turbo-2024-04-09", data["response_model"], "Should extract response model from response.modelId")
 
 	// Verify provider
 	assert.Equal(t, "vercel-ai", data["provider"], "Should set provider to vercel-ai")

--- a/pkg/tracing/metadata/extractors/aimetadata.go
+++ b/pkg/tracing/metadata/extractors/aimetadata.go
@@ -41,7 +41,13 @@ func (e *AIMetadataExtractor) extractAIMetadata(span *tracev1.Span) (md AIMetada
 		md.TotalTokens = &totalTokens
 	}
 
-	md.EstimatedCost = EstimateCost(md.RequestModel, md.InputTokens, md.OutputTokens)
+	// prefer the response model (the model that actually served the request)
+	// for cost estimation, falling back to the requested model.
+	costModel := md.ResponseModel
+	if costModel == "" {
+		costModel = md.RequestModel
+	}
+	md.EstimatedCost = EstimateCost(costModel, md.InputTokens, md.OutputTokens)
 
 	return md, true
 }

--- a/pkg/tracing/metadata/types/types_gen.go
+++ b/pkg/tracing/metadata/types/types_gen.go
@@ -30,7 +30,7 @@ type AIMetadata struct {
 	OperationName string `json:"operation_name"`
 
 	// Response identity. ResponseModel is the model that served the request (may
-	// differ from the requested Model, e.g. a dated snapshot). FinishReasons is
+	// differ from the RequestModel, e.g. a dated snapshot). FinishReasons is
 	// stored raw per emitter — note OpenAI's native "tool_calls" is emitted as
 	// the singular "tool_call" by some instrumentations.
 	ResponseModel string   `json:"response_model,omitempty"`

--- a/pkg/tracing/metadata/types/types_gen.go
+++ b/pkg/tracing/metadata/types/types_gen.go
@@ -23,23 +23,23 @@ const (
 
 // From ai.go
 type AIMetadata struct {
-	InputTokens	int64	`json:"input_tokens"`
-	OutputTokens	int64	`json:"output_tokens"`
-	RequestModel	string	`json:"request_model"`
-	Provider	string	`json:"provider"`
-	OperationName	string	`json:"operation_name"`
+	InputTokens   int64  `json:"input_tokens"`
+	OutputTokens  int64  `json:"output_tokens"`
+	RequestModel  string `json:"request_model"`
+	Provider      string `json:"provider"`
+	OperationName string `json:"operation_name"`
 
 	// Response identity. ResponseModel is the model that served the request (may
 	// differ from the requested Model, e.g. a dated snapshot). FinishReasons is
 	// stored raw per emitter — note OpenAI's native "tool_calls" is emitted as
 	// the singular "tool_call" by some instrumentations.
-	ResponseModel	string		`json:"response_model,omitempty"`
-	ResponseID	string		`json:"response_id,omitempty"`
-	FinishReasons	[]string	`json:"finish_reasons,omitempty"`
+	ResponseModel string   `json:"response_model,omitempty"`
+	ResponseID    string   `json:"response_id,omitempty"`
+	FinishReasons []string `json:"finish_reasons,omitempty"`
 
-	LatencyMs	*int64		`json:"latency_ms,omitempty"`
-	TotalTokens	*int64		`json:"total_tokens,omitempty"`
-	EstimatedCost	*float64	`json:"estimated_cost,omitempty"`
+	LatencyMs     *int64   `json:"latency_ms,omitempty"`
+	TotalTokens   *int64   `json:"total_tokens,omitempty"`
+	EstimatedCost *float64 `json:"estimated_cost,omitempty"`
 }
 
 // From experiment.go
@@ -49,11 +49,11 @@ const (
 
 // From experiment.go
 type ExperimentMetadata struct {
-	ExperimentName		string			`json:"name"`
-	Variant			string			`json:"variant"`
-	SelectionStrategy	string			`json:"selection_strategy"`
-	AvailableVariants	[]string		`json:"available_variants,omitempty"`
-	VariantWeights		map[string]float64	`json:"variant_weights,omitempty"`
+	ExperimentName    string             `json:"name"`
+	Variant           string             `json:"variant"`
+	SelectionStrategy string             `json:"selection_strategy"`
+	AvailableVariants []string           `json:"available_variants,omitempty"`
+	VariantWeights    map[string]float64 `json:"variant_weights,omitempty"`
 }
 
 // From http.go
@@ -63,14 +63,14 @@ const (
 
 // From http.go
 type HTTPMetadata struct {
-	ResponseContentType	*string	`json:"response_content_type,omitempty"`
-	RequestContentType	*string	`json:"request_content_type,omitempty"`
-	Method			string	`json:"method"`
-	RequestSize		*int64	`json:"request_size,omitempty"`
-	ResponseSize		*int64	`json:"response_size,omitempty"`
-	ResponseStatus		*int64	`json:"response_status,omitempty"`
-	Domain			*string	`json:"domain,omitempty"`
-	Path			*string	`json:"path,omitempty"`
+	ResponseContentType *string `json:"response_content_type,omitempty"`
+	RequestContentType  *string `json:"request_content_type,omitempty"`
+	Method              string  `json:"method"`
+	RequestSize         *int64  `json:"request_size,omitempty"`
+	ResponseSize        *int64  `json:"response_size,omitempty"`
+	ResponseStatus      *int64  `json:"response_status,omitempty"`
+	Domain              *string `json:"domain,omitempty"`
+	Path                *string `json:"path,omitempty"`
 }
 
 // From httptiming.go
@@ -82,20 +82,19 @@ const (
 // HTTPTimingMetadata contains detailed HTTP connection timing phases
 // from httpstat, capturing the duration of each phase in the HTTP
 // request lifecycle.
-//
 type HTTPTimingMetadata struct {
 	// DNSLookupMs is the time spent resolving the domain name.
-	DNSLookupMs	int64	`json:"dns_lookup_ms"`
+	DNSLookupMs int64 `json:"dns_lookup_ms"`
 	// TCPConnectionMs is the time spent establishing the TCP connection.
-	TCPConnectionMs	int64	`json:"tcp_connection_ms"`
+	TCPConnectionMs int64 `json:"tcp_connection_ms"`
 	// TLSHandshakeMs is the time spent on TLS negotiation.
-	TLSHandshakeMs	int64	`json:"tls_handshake_ms"`
+	TLSHandshakeMs int64 `json:"tls_handshake_ms"`
 	// ServerProcessingMs is the time from request sent to first byte received (TTFB).
-	ServerProcessingMs	int64	`json:"server_processing_ms"`
+	ServerProcessingMs int64 `json:"server_processing_ms"`
 	// ContentTransferMs is the time spent downloading the response body.
-	ContentTransferMs	int64	`json:"content_transfer_ms"`
+	ContentTransferMs int64 `json:"content_transfer_ms"`
 	// TotalMs is the total request duration.
-	TotalMs	int64	`json:"total_ms"`
+	TotalMs int64 `json:"total_ms"`
 }
 
 // From response_headers.go
@@ -114,18 +113,16 @@ const (
 // From timing.go
 // TimingMetadata contains high-level timing categories for a step execution:
 // queue delay, system processing overhead, and network total.
-//
 type TimingMetadata struct {
 	// QueueDelayMs is the sojourn delay caused by concurrency limits, throttle,
 	// or other user-defined concurrency constraints.
-	QueueDelayMs	*int64	`json:"queue_delay_ms,omitempty"`
+	QueueDelayMs *int64 `json:"queue_delay_ms,omitempty"`
 	// SystemLatencyMs is the processing delay excluding sojourn latency
 	// (time from queue lease to execution start).
-	SystemLatencyMs	*int64	`json:"system_latency_ms,omitempty"`
+	SystemLatencyMs *int64 `json:"system_latency_ms,omitempty"`
 	// NetworkTotalMs is the total HTTP request duration from httpstat,
 	// covering the full SDK call lifecycle.
-	NetworkTotalMs	*int64	`json:"network_total_ms,omitempty"`
+	NetworkTotalMs *int64 `json:"network_total_ms,omitempty"`
 	// TotalInngestMs is the sum of Inngest-side overhead (queue delay + system latency).
-	TotalInngestMs	*int64	`json:"total_inngest_ms,omitempty"`
+	TotalInngestMs *int64 `json:"total_inngest_ms,omitempty"`
 }
-

--- a/pkg/tracing/metadata/types/types_gen.go
+++ b/pkg/tracing/metadata/types/types_gen.go
@@ -23,23 +23,23 @@ const (
 
 // From ai.go
 type AIMetadata struct {
-	InputTokens   int64  `json:"input_tokens"`
-	OutputTokens  int64  `json:"output_tokens"`
-	RequestModel  string `json:"request_model"`
-	Provider      string `json:"provider"`
-	OperationName string `json:"operation_name"`
+	InputTokens	int64	`json:"input_tokens"`
+	OutputTokens	int64	`json:"output_tokens"`
+	RequestModel	string	`json:"request_model"`
+	Provider	string	`json:"provider"`
+	OperationName	string	`json:"operation_name"`
 
 	// Response identity. ResponseModel is the model that served the request (may
 	// differ from the RequestModel, e.g. a dated snapshot). FinishReasons is
 	// stored raw per emitter — note OpenAI's native "tool_calls" is emitted as
 	// the singular "tool_call" by some instrumentations.
-	ResponseModel string   `json:"response_model,omitempty"`
-	ResponseID    string   `json:"response_id,omitempty"`
-	FinishReasons []string `json:"finish_reasons,omitempty"`
+	ResponseModel	string		`json:"response_model,omitempty"`
+	ResponseID	string		`json:"response_id,omitempty"`
+	FinishReasons	[]string	`json:"finish_reasons,omitempty"`
 
-	LatencyMs     *int64   `json:"latency_ms,omitempty"`
-	TotalTokens   *int64   `json:"total_tokens,omitempty"`
-	EstimatedCost *float64 `json:"estimated_cost,omitempty"`
+	LatencyMs	*int64		`json:"latency_ms,omitempty"`
+	TotalTokens	*int64		`json:"total_tokens,omitempty"`
+	EstimatedCost	*float64	`json:"estimated_cost,omitempty"`
 }
 
 // From experiment.go
@@ -49,11 +49,11 @@ const (
 
 // From experiment.go
 type ExperimentMetadata struct {
-	ExperimentName    string             `json:"name"`
-	Variant           string             `json:"variant"`
-	SelectionStrategy string             `json:"selection_strategy"`
-	AvailableVariants []string           `json:"available_variants,omitempty"`
-	VariantWeights    map[string]float64 `json:"variant_weights,omitempty"`
+	ExperimentName		string			`json:"name"`
+	Variant			string			`json:"variant"`
+	SelectionStrategy	string			`json:"selection_strategy"`
+	AvailableVariants	[]string		`json:"available_variants,omitempty"`
+	VariantWeights		map[string]float64	`json:"variant_weights,omitempty"`
 }
 
 // From http.go
@@ -63,14 +63,14 @@ const (
 
 // From http.go
 type HTTPMetadata struct {
-	ResponseContentType *string `json:"response_content_type,omitempty"`
-	RequestContentType  *string `json:"request_content_type,omitempty"`
-	Method              string  `json:"method"`
-	RequestSize         *int64  `json:"request_size,omitempty"`
-	ResponseSize        *int64  `json:"response_size,omitempty"`
-	ResponseStatus      *int64  `json:"response_status,omitempty"`
-	Domain              *string `json:"domain,omitempty"`
-	Path                *string `json:"path,omitempty"`
+	ResponseContentType	*string	`json:"response_content_type,omitempty"`
+	RequestContentType	*string	`json:"request_content_type,omitempty"`
+	Method			string	`json:"method"`
+	RequestSize		*int64	`json:"request_size,omitempty"`
+	ResponseSize		*int64	`json:"response_size,omitempty"`
+	ResponseStatus		*int64	`json:"response_status,omitempty"`
+	Domain			*string	`json:"domain,omitempty"`
+	Path			*string	`json:"path,omitempty"`
 }
 
 // From httptiming.go
@@ -82,19 +82,20 @@ const (
 // HTTPTimingMetadata contains detailed HTTP connection timing phases
 // from httpstat, capturing the duration of each phase in the HTTP
 // request lifecycle.
+//
 type HTTPTimingMetadata struct {
 	// DNSLookupMs is the time spent resolving the domain name.
-	DNSLookupMs int64 `json:"dns_lookup_ms"`
+	DNSLookupMs	int64	`json:"dns_lookup_ms"`
 	// TCPConnectionMs is the time spent establishing the TCP connection.
-	TCPConnectionMs int64 `json:"tcp_connection_ms"`
+	TCPConnectionMs	int64	`json:"tcp_connection_ms"`
 	// TLSHandshakeMs is the time spent on TLS negotiation.
-	TLSHandshakeMs int64 `json:"tls_handshake_ms"`
+	TLSHandshakeMs	int64	`json:"tls_handshake_ms"`
 	// ServerProcessingMs is the time from request sent to first byte received (TTFB).
-	ServerProcessingMs int64 `json:"server_processing_ms"`
+	ServerProcessingMs	int64	`json:"server_processing_ms"`
 	// ContentTransferMs is the time spent downloading the response body.
-	ContentTransferMs int64 `json:"content_transfer_ms"`
+	ContentTransferMs	int64	`json:"content_transfer_ms"`
 	// TotalMs is the total request duration.
-	TotalMs int64 `json:"total_ms"`
+	TotalMs	int64	`json:"total_ms"`
 }
 
 // From response_headers.go
@@ -113,16 +114,18 @@ const (
 // From timing.go
 // TimingMetadata contains high-level timing categories for a step execution:
 // queue delay, system processing overhead, and network total.
+//
 type TimingMetadata struct {
 	// QueueDelayMs is the sojourn delay caused by concurrency limits, throttle,
 	// or other user-defined concurrency constraints.
-	QueueDelayMs *int64 `json:"queue_delay_ms,omitempty"`
+	QueueDelayMs	*int64	`json:"queue_delay_ms,omitempty"`
 	// SystemLatencyMs is the processing delay excluding sojourn latency
 	// (time from queue lease to execution start).
-	SystemLatencyMs *int64 `json:"system_latency_ms,omitempty"`
+	SystemLatencyMs	*int64	`json:"system_latency_ms,omitempty"`
 	// NetworkTotalMs is the total HTTP request duration from httpstat,
 	// covering the full SDK call lifecycle.
-	NetworkTotalMs *int64 `json:"network_total_ms,omitempty"`
+	NetworkTotalMs	*int64	`json:"network_total_ms,omitempty"`
 	// TotalInngestMs is the sum of Inngest-side overhead (queue delay + system latency).
-	TotalInngestMs *int64 `json:"total_inngest_ms,omitempty"`
+	TotalInngestMs	*int64	`json:"total_inngest_ms,omitempty"`
 }
+

--- a/pkg/util/aigateway/aigateway.go
+++ b/pkg/util/aigateway/aigateway.go
@@ -35,6 +35,9 @@ type ParsedInferenceRequest struct {
 // ParsedInferenceResponse represents the parsed output for a given inference request.
 type ParsedInferenceResponse struct {
 	ID         string            `json:"id"`
+	// Model is the model that actually served the request, as reported by the
+	// provider. This may differ from the requested model (e.g. a dated snapshot).
+	Model      string            `json:"model,omitempty"`
 	TokensIn   int32             `json:"tokens_in"`
 	TokensOut  int32             `json:"tokens_out"`
 	StopReason string            `json:"stop_reason,omitempty"`
@@ -179,6 +182,7 @@ func ParseOutput(format string, response []byte) (ParsedInferenceResponse, error
 
 		return ParsedInferenceResponse{
 			ID:         r.ID,
+			Model:      string(r.Model),
 			TokensIn:   int32(r.Usage.InputTokens),
 			TokensOut:  int32(r.Usage.OutputTokens),
 			StopReason: string(r.StopReason),
@@ -197,6 +201,7 @@ func ParseOutput(format string, response []byte) (ParsedInferenceResponse, error
 		if len(r.Choices) == 0 {
 			return ParsedInferenceResponse{
 				ID:        r.ID,
+				Model:     r.Model,
 				TokensIn:  int32(r.Usage.PromptTokens),
 				TokensOut: int32(r.Usage.CompletionTokens),
 			}, fmt.Errorf("no choices returned in openai api response")
@@ -216,6 +221,7 @@ func ParseOutput(format string, response []byte) (ParsedInferenceResponse, error
 
 		return ParsedInferenceResponse{
 			ID:         r.ID,
+			Model:      r.Model,
 			TokensIn:   int32(r.Usage.PromptTokens),
 			TokensOut:  int32(r.Usage.CompletionTokens),
 			StopReason: string(choice.FinishReason),

--- a/pkg/util/aigateway/aigateway_test.go
+++ b/pkg/util/aigateway/aigateway_test.go
@@ -25,6 +25,7 @@ func TestParseOutput(t *testing.T) {
 			input:       `{"id":"msg_01AWkeVsTqhLbsS2MDmjGJxj","type":"message","role":"assistant","model":"claude-3-5-haiku-20241022","content":[{"type":"text","text":"I see 'pvlib/pvsystem.py' looks relevant. Let's examine the exact code for the PVSystem class:"},{"type":"tool_use","id":"toolu_014WnC1qhZZRtKf4kENoVEnx","name":"read_file","input":{"filename":"pvlib/pvsystem.py"}}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":7947,"output_tokens":90}} `,
 			expected: ParsedInferenceResponse{
 				ID:         "msg_01AWkeVsTqhLbsS2MDmjGJxj",
+				Model:      "claude-3-5-haiku-20241022",
 				TokensIn:   7947,
 				TokensOut:  90,
 				StopReason: "tool_use",

--- a/ui/packages/components/src/generated/index.ts
+++ b/ui/packages/components/src/generated/index.ts
@@ -48,7 +48,7 @@ export interface AIMetadata {
   operation_name: string;
   /**
    * Response identity. ResponseModel is the model that served the request (may
-   * differ from the requested Model, e.g. a dated snapshot). FinishReasons is
+   * differ from the RequestModel, e.g. a dated snapshot). FinishReasons is
    * stored raw per emitter — note OpenAI's native "tool_calls" is emitted as
    * the singular "tool_call" by some instrumentations.
    */


### PR DESCRIPTION
## Description

- Previously, with ai.step.*, we only extracted a single model
- Now, we would like to extract both the request and the response model

## Release note

- AI Metadata extracted with ai.step.wrap or ai.step.infer will now differentiate between request and response models

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
