### PR TITLE
refactor(queue): clean up queue manager interface

### DIFF
--- a/pkg/debugapi/key_queue.go
+++ b/pkg/debugapi/key_queue.go
@@ -22,11 +22,7 @@ func (d *debugAPI) GetShadowPartition(ctx context.Context, req *pb.ShadowPartiti
 	if fnID, parseErr := uuid.Parse(req.GetPartitionId()); parseErr == nil {
 		scope.FunctionID = fnID
 	}
-	shard, err := d.shards.Resolve(ctx, scope, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error finding shard: %w", err)
-	}
-	pt, err := d.queue.PartitionByID(ctx, shard, scope, req.GetPartitionId())
+	pt, err := shard.PartitionByID(ctx, scope, req.GetPartitionId())
 	if err != nil {
 		if errors.Is(err, queue.ErrPartitionNotFound) {
 			return nil, status.Error(codes.NotFound, queue.ErrPartitionNotFound.Error())
@@ -70,7 +66,7 @@ func (d *debugAPI) GetBacklogs(ctx context.Context, req *pb.BacklogsRequest) (*p
 	}
 
 	until := time.Now().Add(365 * 24 * time.Hour)
-	iter, err := d.queue.BacklogsByPartition(ctx, shard, req.GetPartitionId(), time.Time{}, until)
+	iter, err := shard.BacklogsByPartition(ctx, req.GetPartitionId(), time.Time{}, until)
 	if err != nil {
 		return nil, fmt.Errorf("error listing backlogs: %w", err)
 	}
@@ -88,7 +84,7 @@ func (d *debugAPI) GetBacklogs(ctx context.Context, req *pb.BacklogsRequest) (*p
 			continue // keep counting but stop collecting
 		}
 
-		size, _ := d.queue.BacklogSize(ctx, shard, bl.BacklogID)
+		size, _ := shard.BacklogSize(ctx, bl.BacklogID)
 		backlogs = append(backlogs, mapBacklogToProto(bl, size))
 	}
 
@@ -104,7 +100,7 @@ func (d *debugAPI) GetBacklogSize(ctx context.Context, req *pb.BacklogSizeReques
 		return nil, fmt.Errorf("error finding shard: %w", err)
 	}
 
-	size, err := d.queue.BacklogSize(ctx, shard, req.GetBacklogId())
+	size, err := shard.BacklogSize(ctx, req.GetBacklogId())
 	if err != nil {
 		return nil, fmt.Errorf("error getting backlog size: %w", err)
 	}
@@ -114,7 +110,7 @@ func (d *debugAPI) GetBacklogSize(ctx context.Context, req *pb.BacklogSizeReques
 		ItemCount: size,
 	}
 
-	bl, err := d.queue.BacklogByID(ctx, shard, req.GetBacklogId())
+	bl, err := shard.BacklogByID(ctx, req.GetBacklogId())
 	if err == nil {
 		resp.Backlog = mapBacklogToProto(bl, size)
 	}

--- a/pkg/debugapi/key_queue.go
+++ b/pkg/debugapi/key_queue.go
@@ -22,6 +22,10 @@ func (d *debugAPI) GetShadowPartition(ctx context.Context, req *pb.ShadowPartiti
 	if fnID, parseErr := uuid.Parse(req.GetPartitionId()); parseErr == nil {
 		scope.FunctionID = fnID
 	}
+	shard, err := d.shards.Resolve(ctx, scope, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error finding shard: %w", err)
+	}
 	pt, err := shard.PartitionByID(ctx, scope, req.GetPartitionId())
 	if err != nil {
 		if errors.Is(err, queue.ErrPartitionNotFound) {

--- a/pkg/debugapi/queue_item.go
+++ b/pkg/debugapi/queue_item.go
@@ -73,7 +73,7 @@ func (d *debugAPI) GetQueueItem(ctx context.Context, req *pb.QueueItemRequest) (
 		}
 	}
 
-	items, err := d.queue.ItemsByRunID(ctx, shard, scope, runID)
+	items, err := shard.ItemsByRunID(ctx, scope, runID)
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Errorf("error retrieving queue items by runID: %w", err).Error())
 	}

--- a/pkg/debugapi/queue_partition.go
+++ b/pkg/debugapi/queue_partition.go
@@ -95,7 +95,7 @@ func (d *debugAPI) GetPartitionStatus(ctx context.Context, req *pb.PartitionRequ
 	if err != nil {
 		return nil, fmt.Errorf("error finding shard for GetPartition: %w", err)
 	}
-	pt, err := d.queue.PartitionByID(ctx, shard, scope, req.GetId())
+	pt, err := shard.PartitionByID(ctx, scope, req.GetId())
 	if err != nil {
 		if errors.Is(err, queue.ErrPartitionNotFound) {
 			return nil, status.Error(codes.NotFound, queue.ErrPartitionNotFound.Error())

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3437,8 +3437,12 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 		}
 
 		// And dequeue the timeout job to remove unneeded work from the queue, etc.
-		// timeout jobs are enqueued to the workflow partition (see handleGeneratorWaitForEvent)
-		// this is _not_ a system partition and lives on the account shard, which we need to retrieve
+		if e.shards == nil {
+			return cleanup()
+		}
+
+		// Timeout jobs are enqueued to the workflow partition (see handleGeneratorWaitForEvent).
+		// This is not a system partition and lives on the account shard.
 		shard, err := e.shards.Resolve(ctx, queue.Scope{
 			AccountID:  md.ID.Tenant.AccountID,
 			EnvID:      md.ID.Tenant.EnvID,

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3437,33 +3437,31 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 		}
 
 		// And dequeue the timeout job to remove unneeded work from the queue, etc.
-		if q, ok := e.queue.(queue.QueueManager); ok {
-			// timeout jobs are enqueued to the workflow partition (see handleGeneratorWaitForEvent)
-			// this is _not_ a system partition and lives on the account shard, which we need to retrieve
-			shard, err := e.shards.Resolve(ctx, queue.Scope{
-				AccountID:  md.ID.Tenant.AccountID,
-				EnvID:      md.ID.Tenant.EnvID,
-				FunctionID: md.ID.FunctionID,
-			}, nil)
-			if err != nil {
-				return fmt.Errorf("could not find shard for pause timeout item for account %q: %w", md.ID.Tenant.AccountID, err)
-			}
+		// timeout jobs are enqueued to the workflow partition (see handleGeneratorWaitForEvent)
+		// this is _not_ a system partition and lives on the account shard, which we need to retrieve
+		shard, err := e.shards.Resolve(ctx, queue.Scope{
+			AccountID:  md.ID.Tenant.AccountID,
+			EnvID:      md.ID.Tenant.EnvID,
+			FunctionID: md.ID.FunctionID,
+		}, nil)
+		if err != nil {
+			return fmt.Errorf("could not find shard for pause timeout item for account %q: %w", md.ID.Tenant.AccountID, err)
+		}
 
-			jobID := fmt.Sprintf("%s-%s", md.IdempotencyKey(), pause.DataKey)
-			err = q.Dequeue(ctx, shard, queue.QueueItem{
-				ID:         queue.HashID(ctx, jobID),
-				FunctionID: md.ID.FunctionID,
-				Data: queue.Item{
-					Kind:       queue.KindPause,
-					Identifier: sv2.V1FromMetadata(md),
-				},
-			})
-			if err != nil {
-				if errors.Is(err, queue.ErrQueueItemNotFound) {
-					logger.StdlibLogger(ctx).Warn("missing pause timeout item", "shard", shard.Name, "pause", pause)
-				} else {
-					logger.StdlibLogger(ctx).Error("error dequeueing consumed pause job when resuming", "error", err)
-				}
+		jobID := fmt.Sprintf("%s-%s", md.IdempotencyKey(), pause.DataKey)
+		err = shard.Dequeue(ctx, queue.QueueItem{
+			ID:         queue.HashID(ctx, jobID),
+			FunctionID: md.ID.FunctionID,
+			Data: queue.Item{
+				Kind:       queue.KindPause,
+				Identifier: sv2.V1FromMetadata(md),
+			},
+		})
+		if err != nil {
+			if errors.Is(err, queue.ErrQueueItemNotFound) {
+				logger.StdlibLogger(ctx).Warn("missing pause timeout item", "shard", shard.Name(), "pause", pause)
+			} else {
+				logger.StdlibLogger(ctx).Error("error dequeueing consumed pause job when resuming", "error", err)
 			}
 		}
 

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -850,12 +850,7 @@ func (s *svc) handleEagerCancelBulkRun(ctx context.Context, c cqrs.Cancellation)
 		return fmt.Errorf("error selecting shard for cancellation: %w", err)
 	}
 
-	items, err := shard.ItemsByPartition(ctx, queue.Scope{
-	items, err := shard.ItemsByPartition(ctx, queue.Scope{
-		AccountID:  c.AccountID,
-		EnvID:      c.WorkspaceID,
-		FunctionID: c.FunctionID,
-	}, c.FunctionID.String(), from, c.StartedBefore)
+	items, err := shard.ItemsByPartition(ctx, scope, c.FunctionID.String(), from, c.StartedBefore)
 	if err != nil {
 		return fmt.Errorf("error retrieving partition items: %w", err)
 	}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -851,6 +851,7 @@ func (s *svc) handleEagerCancelBulkRun(ctx context.Context, c cqrs.Cancellation)
 	}
 
 	items, err := shard.ItemsByPartition(ctx, queue.Scope{
+	items, err := shard.ItemsByPartition(ctx, queue.Scope{
 		AccountID:  c.AccountID,
 		EnvID:      c.WorkspaceID,
 		FunctionID: c.FunctionID,

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -57,44 +57,12 @@ type PartitionLeaseOpt func(o *PartitionLeaseOptions)
 type QueueManager interface {
 	JobQueueReader
 	Queue
-
-	Dequeue(ctx context.Context, queueShard QueueShard, i QueueItem, opts ...DequeueOptionFn) error
-	Requeue(ctx context.Context, queueShard QueueShard, i QueueItem, at time.Time, opts ...RequeueOptionFn) error
-	RequeueByJobID(ctx context.Context, queueShard QueueShard, jobID string, at time.Time) error
-
+	// Used by Checkpointing
 	// ResetAttemptsByJobID sets retries to zero given a single job ID.  This is important for
 	// checkpointing;  a single job becomes shared amongst many  steps.
 	ResetAttemptsByJobID(ctx context.Context, shard string, scope Scope, jobID string) error
-
-	// ItemsByPartition returns a queue item iterator for a function within a specific time range
-	ItemsByPartition(ctx context.Context, queueShard QueueShard, scope Scope, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
-	// ItemsByBacklog returns a queue item iterator for a backlog within a specific time range
-	ItemsByBacklog(ctx context.Context, queueShard QueueShard, backlogID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
-	// BacklogsByPartition returns an iterator for the partition's backlogs
-	BacklogsByPartition(ctx context.Context, queueShard QueueShard, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueBacklog], error)
-	// BacklogSize retrieves the number of items in the specified backlog
-	BacklogSize(ctx context.Context, queueShard QueueShard, backlogID string) (int64, error)
-	// BacklogByID retrieves a single backlog by its ID
-	BacklogByID(ctx context.Context, queueShard QueueShard, backlogID string) (*QueueBacklog, error)
-	// PartitionByID retrieves the partition by the partition ID
-	PartitionByID(ctx context.Context, queueShard QueueShard, scope Scope, partitionID string) (*PartitionInspectionResult, error)
 	// LoadQueueItem retrieves the queue item by the item ID.
 	LoadQueueItem(ctx context.Context, shardName string, itemID string) (*QueueItem, error)
-
-	// ItemExists checks if an item with jobID exists in the queue
-	ItemExists(ctx context.Context, queueShard QueueShard, scope Scope, jobID string) (bool, error)
-	// ItemsByRunID retrieves all queue items via runID
-	//
-	// NOTE
-	// The queue technically shouldn't know about runIDs, so we should make this more generic with certain type of indices in the future
-	ItemsByRunID(ctx context.Context, queueShard QueueShard, scope Scope, runID ulid.ULID) ([]*QueueItem, error)
-
-	// PartitionBacklogSize returns the point in time backlog size of the partition.
-	// This will sum the size of all backlogs in that partition
-	PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error)
-
-	// Total queue depth of all partitions including backlog and ready state items
-	TotalSystemQueueDepth(ctx context.Context, queueShard QueueShard) (int64, error)
 
 	NormalizeBacklog(ctx context.Context, backlog *QueueBacklog, sp *QueueShadowPartition, latestConstraints PartitionConstraintConfig) error
 	NormalizeItem(

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -200,6 +200,11 @@ func (q *queueProcessor) Workers() chan ProcessItem {
 	return q.workers
 }
 
+// Enqueue implements Producer.
+func (q *queueProcessor) Enqueue(ctx context.Context, item Item, at time.Time, opts EnqueueOpts) error {
+	return q.queueProducer.Enqueue(ctx, item, at, opts)
+}
+
 // LoadQueueItem implements QueueManager.
 func (q *queueProcessor) LoadQueueItem(ctx context.Context, shardName string, itemID string) (*QueueItem, error) {
 	shard, err := q.shards.ByName(shardName)

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -3,7 +3,6 @@ package queue
 import (
 	"context"
 	"fmt"
-	"iter"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -201,46 +200,6 @@ func (q *queueProcessor) Workers() chan ProcessItem {
 	return q.workers
 }
 
-// BacklogSize implements QueueManager.
-func (q *queueProcessor) BacklogSize(ctx context.Context, shard QueueShard, backlogID string) (int64, error) {
-	return shard.BacklogSize(ctx, backlogID)
-}
-
-// BacklogByID implements QueueManager.
-func (q *queueProcessor) BacklogByID(ctx context.Context, shard QueueShard, backlogID string) (*QueueBacklog, error) {
-	return shard.BacklogByID(ctx, backlogID)
-}
-
-// BacklogsByPartition implements QueueManager.
-func (q *queueProcessor) BacklogsByPartition(ctx context.Context, shard QueueShard, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueBacklog], error) {
-	return shard.BacklogsByPartition(ctx, partitionID, from, until, opts...)
-}
-
-// Dequeue implements QueueManager.
-func (q *queueProcessor) Dequeue(ctx context.Context, shard QueueShard, i QueueItem, opts ...DequeueOptionFn) error {
-	return shard.Dequeue(ctx, i, opts...)
-}
-
-// ItemExists implements QueueManager.
-func (q *queueProcessor) ItemExists(ctx context.Context, shard QueueShard, scope Scope, jobID string) (bool, error) {
-	return shard.ItemExists(ctx, scope, jobID)
-}
-
-// ItemsByBacklog implements QueueManager.
-func (q *queueProcessor) ItemsByBacklog(ctx context.Context, shard QueueShard, backlogID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error) {
-	return shard.ItemsByBacklog(ctx, backlogID, from, until, opts...)
-}
-
-// ItemsByPartition implements QueueManager.
-func (q *queueProcessor) ItemsByPartition(ctx context.Context, shard QueueShard, scope Scope, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error) {
-	return shard.ItemsByPartition(ctx, scope, partitionID, from, until, opts...)
-}
-
-// ItemsByRunID implements QueueManager.
-func (q *queueProcessor) ItemsByRunID(ctx context.Context, shard QueueShard, scope Scope, runID ulid.ULID) ([]*QueueItem, error) {
-	return shard.ItemsByRunID(ctx, scope, runID)
-}
-
 // LoadQueueItem implements QueueManager.
 func (q *queueProcessor) LoadQueueItem(ctx context.Context, shardName string, itemID string) (*QueueItem, error) {
 	shard, err := q.shards.ByName(shardName)
@@ -265,7 +224,7 @@ func (q *queueProcessor) forAccountShards(ctx context.Context, accountID uuid.UU
 	return fn(ctx, shard)
 }
 
-// PartitionBacklogSize implements QueueManager.
+// PartitionBacklogSize implements JobQueueReader.
 func (q *queueProcessor) PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error) {
 	var totalCount int64
 
@@ -283,41 +242,6 @@ func (q *queueProcessor) PartitionBacklogSize(ctx context.Context, scope Scope, 
 		return 0, fmt.Errorf("could not load partition backlog size: %w", err)
 	}
 	return totalCount, nil
-}
-
-// PartitionByID implements QueueManager.
-func (q *queueProcessor) PartitionByID(ctx context.Context, shard QueueShard, scope Scope, partitionID string) (*PartitionInspectionResult, error) {
-	return shard.PartitionByID(ctx, scope, partitionID)
-}
-
-// RemoveQueueItem implements QueueManager.
-func (q *queueProcessor) RemoveQueueItem(ctx context.Context, shardName string, scope Scope, partitionID string, itemID string) error {
-	shard, err := q.shards.ByName(shardName)
-	if err != nil {
-		return err
-	}
-
-	return shard.RemoveQueueItem(ctx, scope, partitionID, itemID)
-}
-
-// Requeue implements QueueManager.
-func (q *queueProcessor) Requeue(ctx context.Context, shard QueueShard, i QueueItem, at time.Time, opts ...RequeueOptionFn) error {
-	return shard.Requeue(ctx, i, at, opts...)
-}
-
-// RequeueByJobID implements QueueManager.
-func (q *queueProcessor) RequeueByJobID(ctx context.Context, shard QueueShard, jobID string, at time.Time) error {
-	return shard.RequeueByJobID(ctx, jobID, at)
-}
-
-// Enqueue implements QueueManager.
-func (q *queueProcessor) Enqueue(ctx context.Context, item Item, at time.Time, opts EnqueueOpts) error {
-	return q.queueProducer.Enqueue(ctx, item, at, opts)
-}
-
-// TotalSystemQueueDepth implements QueueManager.
-func (q *queueProcessor) TotalSystemQueueDepth(ctx context.Context, shard QueueShard) (int64, error) {
-	return shard.TotalSystemQueueDepth(ctx)
 }
 
 // OutstandingJobCount implements Queue.

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -242,6 +242,10 @@ type JobQueueReader interface {
 	// status queue.
 	StatusCount(ctx context.Context, scope Scope, status string) (int64, error)
 
+	// PartitionBacklogSize returns the point-in-time backlog size of the partition.
+	// This sums the size of all backlogs in that partition.
+	PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error)
+
 	// RunJobs reads items in the queue for a specific run.
 	RunJobs(ctx context.Context, queueShardName string, scope Scope, runID ulid.ULID, limit, offset int64) ([]JobResponse, error)
 }

--- a/pkg/execution/state/redis_state/backlog_test.go
+++ b/pkg/execution/state/redis_state/backlog_test.go
@@ -1157,7 +1157,7 @@ func TestBacklogsByPartition(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r.FlushAll()
 
-			q, shard := newQueue(
+			_, shard := newQueue(
 				t, rc,
 				osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 					return true
@@ -1200,7 +1200,7 @@ func TestBacklogsByPartition(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			items, err := q.BacklogsByPartition(ctx, shard, fnID.String(), tc.from, tc.until,
+			items, err := shard.BacklogsByPartition(ctx, fnID.String(), tc.from, tc.until,
 				osqueue.WithQueueItemIterBatchSize(tc.batchSize),
 			)
 			require.NoError(t, err)
@@ -1219,7 +1219,7 @@ func TestBacklogSize(t *testing.T) {
 	_, rc := initRedis(t)
 	defer rc.Close()
 
-	q, shard := newQueue(
+	_, shard := newQueue(
 		t, rc,
 		osqueue.WithPartitionConstraintConfigGetter(func(ctx context.Context, p osqueue.PartitionIdentifier) osqueue.PartitionConstraintConfig {
 			return osqueue.PartitionConstraintConfig{
@@ -1270,7 +1270,7 @@ func TestBacklogSize(t *testing.T) {
 	}
 	require.NotEmpty(t, backlogID)
 
-	size, err := q.BacklogSize(ctx, shard, backlogID)
+	size, err := shard.BacklogSize(ctx, backlogID)
 	require.NoError(t, err)
 
 	require.EqualValues(t, count, size)

--- a/pkg/execution/state/redis_state/debug_test.go
+++ b/pkg/execution/state/redis_state/debug_test.go
@@ -68,7 +68,7 @@ func TestPartitionByID(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r.FlushAll()
 
-			q, shard := newQueue(
+			_, shard := newQueue(
 				t, rc,
 				osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 					return tc.keyQueues
@@ -100,7 +100,7 @@ func TestPartitionByID(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			res, err := q.PartitionByID(ctx, shard, osqueue.Scope{
+			res, err := shard.PartitionByID(ctx, osqueue.Scope{
 				AccountID:  acctId,
 				EnvID:      wsID,
 				FunctionID: fnID,

--- a/pkg/execution/state/redis_state/queue_dequeue_test.go
+++ b/pkg/execution/state/redis_state/queue_dequeue_test.go
@@ -406,7 +406,7 @@ func TestQueueDequeueWithDisabledConstraintUpdates(t *testing.T) {
 
 	clock := clockwork.NewFakeClock()
 
-	q, shard := newQueue(
+	_, shard := newQueue(
 		t, rc,
 		osqueue.WithClock(clock),
 		osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
@@ -444,7 +444,7 @@ func TestQueueDequeueWithDisabledConstraintUpdates(t *testing.T) {
 	require.False(t, r.Exists(kg.Concurrency("p", fnID.String())))
 	require.False(t, r.Exists(kg.Concurrency("account", accountID.String())))
 
-	err = q.Dequeue(ctx, shard, item)
+	err = shard.Dequeue(ctx, item)
 	require.NoError(t, err)
 
 	require.False(t, r.Exists(kg.Concurrency("p", fnID.String())))

--- a/pkg/execution/state/redis_state/queue_scavenge_test.go
+++ b/pkg/execution/state/redis_state/queue_scavenge_test.go
@@ -29,7 +29,7 @@ func TestQueueScavenge(t *testing.T) {
 	t.Run("in-progress items must be added to scavenger index", func(t *testing.T) {
 		r.FlushAll()
 
-		q, shard := newQueue(
+		_, shard := newQueue(
 			t, rc,
 			osqueue.WithClock(clock),
 			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
@@ -90,7 +90,7 @@ func TestQueueScavenge(t *testing.T) {
 		require.False(t, r.Exists(kg.Concurrency("p", fnID.String())))
 
 		// Dequeue item and check scavenger index was cleaned up
-		err = q.Dequeue(ctx, shard, item)
+		err = shard.Dequeue(ctx, item)
 		require.NoError(t, err)
 
 		require.False(t, r.Exists(kg.PartitionScavengerIndex(fnID.String())))
@@ -338,7 +338,7 @@ func TestQueueScavenge(t *testing.T) {
 		t.Run("update to next earliest item in scavenger index", func(t *testing.T) {
 			r.FlushAll()
 
-			q, shard := newQueue(
+			_, shard := newQueue(
 				t, rc,
 				osqueue.WithClock(clock),
 				osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
@@ -393,7 +393,7 @@ func TestQueueScavenge(t *testing.T) {
 
 			require.False(t, r.Exists(kg.Concurrency("p", fnID.String())))
 
-			err = q.Requeue(ctx, shard, item1, clock.Now().Add(time.Minute))
+			err = shard.Requeue(ctx, item1, clock.Now().Add(time.Minute))
 			require.NoError(t, err)
 			require.NotNil(t, leaseID2)
 
@@ -414,7 +414,7 @@ func TestQueueScavenge(t *testing.T) {
 		t.Run("update to next earliest item in scavenger index", func(t *testing.T) {
 			r.FlushAll()
 
-			q, shard := newQueue(
+			_, shard := newQueue(
 				t, rc,
 				osqueue.WithClock(clock),
 				osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
@@ -469,7 +469,7 @@ func TestQueueScavenge(t *testing.T) {
 
 			require.False(t, r.Exists(kg.Concurrency("p", fnID.String())))
 
-			err = q.Dequeue(ctx, shard, item1)
+			err = shard.Dequeue(ctx, item1)
 			require.NoError(t, err)
 			require.NotNil(t, leaseID2)
 

--- a/pkg/execution/state/redis_state/reader_test.go
+++ b/pkg/execution/state/redis_state/reader_test.go
@@ -29,7 +29,7 @@ func TestItemsByPartitionOnEmptyPartition(t *testing.T) {
 	t.Run("test empty partition", func(t *testing.T) {
 		r.FlushAll()
 
-		q, shard := newQueue(
+		_, shard := newQueue(
 			t, rc,
 			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 				return true
@@ -37,7 +37,7 @@ func TestItemsByPartitionOnEmptyPartition(t *testing.T) {
 			osqueue.WithClock(clock),
 		)
 
-		_, err := q.ItemsByPartition(ctx, shard, osqueue.Scope{
+		_, err := shard.ItemsByPartition(ctx, osqueue.Scope{
 			AccountID:  uuid.New(),
 			EnvID:      uuid.New(),
 			FunctionID: uuid.New(),
@@ -144,7 +144,7 @@ func TestItemsByPartition(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			r.FlushAll()
 
-			q, shard := newQueue(
+			_, shard := newQueue(
 				t, rc,
 				osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 					return tc.keyQueuesEnabled
@@ -179,7 +179,7 @@ func TestItemsByPartition(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), tc.from, tc.until,
+			items, err := shard.ItemsByPartition(ctx, scope, fnID.String(), tc.from, tc.until,
 				osqueue.WithQueueItemIterBatchSize(tc.batchSize),
 			)
 			require.NoError(t, err)
@@ -204,7 +204,7 @@ func TestItemsByPartitionWithSystemQueue(t *testing.T) {
 	acctID, wsID := uuid.New(), uuid.New()
 	systemScope := osqueue.Scope{IsSystem: true, AccountID: acctID, EnvID: wsID}
 
-	q, shard := newQueue(
+	_, shard := newQueue(
 		t, rc,
 		osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 			return false
@@ -239,7 +239,7 @@ func TestItemsByPartitionWithSystemQueue(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	items, err := q.ItemsByPartition(ctx, shard, systemScope, systemQueueName, time.Time{}, clock.Now().Add(1*time.Hour),
+	items, err := shard.ItemsByPartition(ctx, systemScope, systemQueueName, time.Time{}, clock.Now().Add(1*time.Hour),
 		osqueue.WithQueueItemIterBatchSize(100),
 		osqueue.WithQueueItemIterEnableBacklog(false),
 	)
@@ -331,7 +331,7 @@ func TestItemsByPartitionLeasedItems(t *testing.T) {
 	t.Run("should skip leased items but continue iterating remaining items", func(t *testing.T) {
 		r.FlushAll()
 
-		q, shard := newQueue(
+		_, shard := newQueue(
 			t, rc,
 			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 				return false
@@ -351,7 +351,7 @@ func TestItemsByPartitionLeasedItems(t *testing.T) {
 			leaseQueueItem(t, rc, kg, id, leaseExpiry)
 		}
 
-		items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
+		items, err := shard.ItemsByPartition(ctx, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
 			osqueue.WithQueueItemIterBatchSize(100),
 			osqueue.WithQueueItemIterEnableBacklog(false),
 		)
@@ -368,7 +368,7 @@ func TestItemsByPartitionLeasedItems(t *testing.T) {
 	t.Run("should iterate past a fully-leased first batch to reach unleased items", func(t *testing.T) {
 		r.FlushAll()
 
-		q, shard := newQueue(
+		_, shard := newQueue(
 			t, rc,
 			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 				return false
@@ -391,7 +391,7 @@ func TestItemsByPartitionLeasedItems(t *testing.T) {
 			leaseQueueItem(t, rc, kg, id, leaseExpiry)
 		}
 
-		items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
+		items, err := shard.ItemsByPartition(ctx, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
 			osqueue.WithQueueItemIterBatchSize(batchSize),
 			osqueue.WithQueueItemIterEnableBacklog(false),
 		)
@@ -407,7 +407,7 @@ func TestItemsByPartitionLeasedItems(t *testing.T) {
 	t.Run("items at different milliseconds with leased entries across batch boundary", func(t *testing.T) {
 		r.FlushAll()
 
-		q, shard := newQueue(
+		_, shard := newQueue(
 			t, rc,
 			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 				return false
@@ -428,7 +428,7 @@ func TestItemsByPartitionLeasedItems(t *testing.T) {
 		leaseQueueItem(t, rc, kg, ids[2], leaseExpiry)
 		leaseQueueItem(t, rc, kg, ids[3], leaseExpiry)
 
-		items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
+		items, err := shard.ItemsByPartition(ctx, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
 			osqueue.WithQueueItemIterBatchSize(batchSize),
 			osqueue.WithQueueItemIterEnableBacklog(false),
 		)
@@ -501,7 +501,7 @@ func TestItemsByPartitionMissingHashItems(t *testing.T) {
 	t.Run("should iterate past items missing from hash to reach remaining items", func(t *testing.T) {
 		r.FlushAll()
 
-		q, shard := newQueue(
+		_, shard := newQueue(
 			t, rc,
 			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 				return false
@@ -525,7 +525,7 @@ func TestItemsByPartitionMissingHashItems(t *testing.T) {
 			deleteQueueItemFromHash(t, rc, kg, id)
 		}
 
-		items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
+		items, err := shard.ItemsByPartition(ctx, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
 			osqueue.WithQueueItemIterBatchSize(batchSize),
 			osqueue.WithQueueItemIterEnableBacklog(false),
 		)
@@ -543,7 +543,7 @@ func TestItemsByPartitionMissingHashItems(t *testing.T) {
 	t.Run("should handle all items missing from hash without panicking", func(t *testing.T) {
 		r.FlushAll()
 
-		q, shard := newQueue(
+		_, shard := newQueue(
 			t, rc,
 			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 				return false
@@ -561,7 +561,7 @@ func TestItemsByPartitionMissingHashItems(t *testing.T) {
 			deleteQueueItemFromHash(t, rc, kg, id)
 		}
 
-		items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
+		items, err := shard.ItemsByPartition(ctx, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Minute),
 			osqueue.WithQueueItemIterBatchSize(100),
 			osqueue.WithQueueItemIterEnableBacklog(false),
 		)
@@ -626,7 +626,7 @@ func TestItemsByPartitionScoreParsing(t *testing.T) {
 		// would regress to epoch+1ms and the iterator would loop forever.
 		r.FlushAll()
 
-		q, shard := newQueue(
+		_, shard := newQueue(
 			t, rc,
 			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 				return false
@@ -658,7 +658,7 @@ func TestItemsByPartitionScoreParsing(t *testing.T) {
 		// Use a channel + timeout to detect an infinite loop.
 		done := make(chan int, 1)
 		go func() {
-			items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
+			items, err := shard.ItemsByPartition(ctx, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
 				osqueue.WithQueueItemIterBatchSize(batchSize),
 				osqueue.WithQueueItemIterEnableBacklog(false),
 			)
@@ -683,7 +683,7 @@ func TestItemsByPartitionScoreParsing(t *testing.T) {
 		// will be 0. The iterator must break instead of regressing to epoch+1ms.
 		r.FlushAll()
 
-		q, shard := newQueue(
+		_, shard := newQueue(
 			t, rc,
 			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 				return false
@@ -713,7 +713,7 @@ func TestItemsByPartitionScoreParsing(t *testing.T) {
 
 		done := make(chan int, 1)
 		go func() {
-			items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
+			items, err := shard.ItemsByPartition(ctx, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
 				osqueue.WithQueueItemIterBatchSize(100),
 				osqueue.WithQueueItemIterEnableBacklog(false),
 			)
@@ -813,7 +813,7 @@ func TestItemsByPartitionAtMSDivergence(t *testing.T) {
 		// causing the iterator cursor to jump past all remaining items.
 		r.FlushAll()
 
-		q, shard := newQueue(
+		_, shard := newQueue(
 			t, rc,
 			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 				return false
@@ -840,7 +840,7 @@ func TestItemsByPartitionAtMSDivergence(t *testing.T) {
 
 		done := make(chan int, 1)
 		go func() {
-			items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
+			items, err := shard.ItemsByPartition(ctx, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
 				osqueue.WithQueueItemIterBatchSize(batchSize),
 				osqueue.WithQueueItemIterEnableBacklog(false),
 			)
@@ -866,7 +866,7 @@ func TestItemsByPartitionAtMSDivergence(t *testing.T) {
 		// later batches because the cursor jumped ahead.
 		r.FlushAll()
 
-		q, shard := newQueue(
+		_, shard := newQueue(
 			t, rc,
 			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 				return false
@@ -890,7 +890,7 @@ func TestItemsByPartitionAtMSDivergence(t *testing.T) {
 
 		done := make(chan int, 1)
 		go func() {
-			items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
+			items, err := shard.ItemsByPartition(ctx, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
 				osqueue.WithQueueItemIterBatchSize(batchSize),
 				osqueue.WithQueueItemIterEnableBacklog(false),
 			)
@@ -920,7 +920,7 @@ func TestItemsByBacklog(t *testing.T) {
 
 	acctId, fnID, wsID := uuid.New(), uuid.New(), uuid.New()
 
-	q, shard := newQueue(
+	_, shard := newQueue(
 		t, rc,
 		osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 			return true
@@ -1010,7 +1010,7 @@ func TestItemsByBacklog(t *testing.T) {
 			}
 			require.NotEmpty(t, backlogID)
 
-			items, err := q.ItemsByBacklog(ctx, shard, backlogID, tc.from, tc.until,
+			items, err := shard.ItemsByBacklog(ctx, backlogID, tc.from, tc.until,
 				osqueue.WithQueueItemIterBatchSize(tc.batchSize),
 			)
 			require.NoError(t, err)
@@ -1038,7 +1038,7 @@ func TestItemsByBacklogZeroCursor(t *testing.T) {
 
 	acctId, fnID, wsID := uuid.New(), uuid.New(), uuid.New()
 
-	q, shard := newQueue(
+	_, shard := newQueue(
 		t, rc,
 		osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 			return true
@@ -1092,7 +1092,7 @@ func TestItemsByBacklogZeroCursor(t *testing.T) {
 
 		done := make(chan int, 1)
 		go func() {
-			items, err := q.ItemsByBacklog(ctx, shard, backlogID, time.Time{}, clock.Now().Add(time.Hour),
+			items, err := shard.ItemsByBacklog(ctx, backlogID, time.Time{}, clock.Now().Add(time.Hour),
 				osqueue.WithQueueItemIterBatchSize(100),
 			)
 			if err != nil {
@@ -1160,7 +1160,7 @@ func TestItemsByBacklogZeroCursor(t *testing.T) {
 
 		done := make(chan int, 1)
 		go func() {
-			items, err := q.ItemsByBacklog(ctx, shard, backlogID, time.Time{}, clock.Now().Add(time.Hour),
+			items, err := shard.ItemsByBacklog(ctx, backlogID, time.Time{}, clock.Now().Add(time.Hour),
 				osqueue.WithQueueItemIterBatchSize(batchSize),
 			)
 			if err != nil {
@@ -1201,7 +1201,7 @@ func TestItemsByPartitionBacklogZeroCursor(t *testing.T) {
 	acctId, fnID, wsID := uuid.New(), uuid.New(), uuid.New()
 	scope := osqueue.Scope{AccountID: acctId, EnvID: wsID, FunctionID: fnID}
 
-	q, shard := newQueue(
+	_, shard := newQueue(
 		t, rc,
 		osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 			return true
@@ -1251,7 +1251,7 @@ func TestItemsByPartitionBacklogZeroCursor(t *testing.T) {
 
 		done := make(chan int, 1)
 		go func() {
-			items, err := q.ItemsByPartition(ctx, shard, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
+			items, err := shard.ItemsByPartition(ctx, scope, fnID.String(), time.Time{}, clock.Now().Add(time.Hour),
 				osqueue.WithQueueItemIterBatchSize(100),
 				osqueue.WithQueueItemIterEnableBacklog(true),
 			)
@@ -1419,7 +1419,7 @@ func TestItemExists(t *testing.T) {
 	acctId, fnID, wsID := uuid.New(), uuid.New(), uuid.New()
 	scope := osqueue.Scope{AccountID: acctId, EnvID: wsID, FunctionID: fnID}
 
-	q, shard := newQueue(
+	_, shard := newQueue(
 		t, rc,
 		osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
 			return false
@@ -1453,7 +1453,7 @@ func TestItemExists(t *testing.T) {
 		enqueued, err := enqueue(ctx, shard, jobID)
 		require.NoError(t, err)
 
-		exists, err := q.ItemExists(ctx, shard, scope, enqueued.ID)
+		exists, err := shard.ItemExists(ctx, scope, enqueued.ID)
 		require.NoError(t, err)
 		require.True(t, exists, "item should exist")
 	})
@@ -1463,7 +1463,7 @@ func TestItemExists(t *testing.T) {
 
 		nonExistentJobID := ulid.MustNew(ulid.Now(), rand.Reader).String()
 
-		exists, err := q.ItemExists(ctx, shard, scope, nonExistentJobID)
+		exists, err := shard.ItemExists(ctx, scope, nonExistentJobID)
 		require.NoError(t, err)
 		require.False(t, exists, "item should not exist")
 	})
@@ -1476,16 +1476,16 @@ func TestItemExists(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify it exists
-		exists, err := q.ItemExists(ctx, shard, scope, enqueued.ID)
+		exists, err := shard.ItemExists(ctx, scope, enqueued.ID)
 		require.NoError(t, err)
 		require.True(t, exists)
 
 		// Dequeue the item
-		err = q.Dequeue(ctx, shard, enqueued)
+		err = shard.Dequeue(ctx, enqueued)
 		require.NoError(t, err)
 
 		// Should no longer exist
-		exists, err = q.ItemExists(ctx, shard, scope, enqueued.ID)
+		exists, err = shard.ItemExists(ctx, scope, enqueued.ID)
 		require.NoError(t, err)
 		require.False(t, exists, "dequeued item should not exist")
 	})

--- a/tests/execution/executor/executor_test.go
+++ b/tests/execution/executor/executor_test.go
@@ -102,9 +102,7 @@ func (fq *fakeQueue) reset() {
 }
 
 func (fq *fakeQueue) Dequeue(ctx context.Context, queueShard redis_state.RedisQueueShard, i queue.QueueItem) error {
-	qm := fq.Queue.(queue.QueueManager)
-
-	err := qm.Dequeue(ctx, queueShard, i)
+	err := queueShard.Dequeue(ctx, i)
 
 	fq.lock.Lock()
 	logger.StdlibLogger(ctx).Info("called fakeQueue.Dequeue()", "i", i, "err", err)
@@ -694,10 +692,10 @@ func TestFinalize(t *testing.T) {
 		require.Equal(t, int64(1), testQueue.dequeuedCalledRun[run2.ID.RunID])
 		testQueue.lock.Unlock()
 
-		err = rq.Dequeue(ctx, queueShard, item2)
+		err = queueShard.Dequeue(ctx, item2)
 		require.ErrorIs(t, err, queue.ErrQueueItemNotFound)
 
-		err = rq.Requeue(ctx, queueShard, item2, time.Now())
+		err = queueShard.Requeue(ctx, item2, time.Now())
 		require.ErrorIs(t, err, queue.ErrQueueItemNotFound)
 	})
 }

--- a/tests/execution/queue/lua_compatibility_test.go
+++ b/tests/execution/queue/lua_compatibility_test.go
@@ -131,7 +131,7 @@ func TestLuaCompatibility(t *testing.T) {
 				// Initialize queue
 				shardRegistry, err := queue.NewSingleShardRegistry(shard)
 				require.NoError(t, err)
-				q, err := queue.New(
+				_, err = queue.New(
 					context.Background(),
 					"test-queue",
 					shardRegistry)
@@ -191,7 +191,7 @@ func TestLuaCompatibility(t *testing.T) {
 
 				// - Requeue item
 				requeueTime := now.Add(5 * time.Second)
-				err = q.Requeue(ctx, shard, enqueuedItem, requeueTime)
+				err = shard.Requeue(ctx, enqueuedItem, requeueTime)
 				require.NoError(t, err)
 
 				// - Requeue partition
@@ -203,7 +203,7 @@ func TestLuaCompatibility(t *testing.T) {
 				require.NoError(t, err, "Failed to peek partition after requeue on %s", serverType)
 				require.NotEmpty(t, peekedAfterRequeue, "Should find items in partition after requeue on %s", serverType)
 
-				err = q.Dequeue(ctx, shard, enqueuedItem)
+				err = shard.Dequeue(ctx, enqueuedItem)
 				require.NoError(t, err)
 
 				peekedAfterDequeue, err := shard.Peek(ctx, qp, requeueTime.Add(5*time.Second), 10)


### PR DESCRIPTION
## Description

We have a bunch of methods on the QueueManager interface that simply delegate to the provided shard.

If the caller has the shard, surely they can call those methods themselves?

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
