### PR TITLE
cloud(dashboard): add experiments empty state

### DIFF
--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/experiments/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/experiments/index.tsx
@@ -77,7 +77,7 @@ function ExperimentsComponent() {
           breadcrumb={[{ text: 'All experiments' }]}
           infoIcon={<ExperimentsInfo />}
         />
-        <ExperimentsEmptyState onRefresh={() => refetch()} />
+        <ExperimentsEmptyState />
       </>
     );
   }

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/experiments/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/experiments/index.tsx
@@ -77,7 +77,7 @@ function ExperimentsComponent() {
           breadcrumb={[{ text: 'All experiments' }]}
           infoIcon={<ExperimentsInfo />}
         />
-        <ExperimentsEmptyState />
+        <ExperimentsEmptyState onRefresh={() => refetch()} />
       </>
     );
   }

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/experiments/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/experiments/index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, useNavigate } from '@tanstack/react-router';
 
 import { InlineCode } from '@inngest/components/Code';
 import {
+  ExperimentsEmptyState,
   ExperimentsTable,
   type ExperimentListItem,
 } from '@inngest/components/Experiments';
@@ -64,6 +65,21 @@ function ExperimentsComponent() {
 
   if (experimentsEnabled.isReady && !experimentsEnabled.value) {
     return <NotFound />;
+  }
+
+  const showEmptyState =
+    !isPending && !error && Array.isArray(data) && data.length === 0;
+
+  if (showEmptyState) {
+    return (
+      <>
+        <Header
+          breadcrumb={[{ text: 'All experiments' }]}
+          infoIcon={<ExperimentsInfo />}
+        />
+        <ExperimentsEmptyState />
+      </>
+    );
   }
 
   return (

--- a/ui/packages/components/src/CodeBlock/CommandBlock.tsx
+++ b/ui/packages/components/src/CodeBlock/CommandBlock.tsx
@@ -120,7 +120,11 @@ const CommandBlock = ({
               },
               scrollbar: {
                 verticalScrollbarSize: 10,
-                alwaysConsumeMouseWheel: false,
+                // When pinned to a fixed height the editor scrolls internally,
+                // so it should consume the wheel rather than leak it to the
+                // page. Auto-height blocks don't scroll, so let the page handle
+                // the wheel as before.
+                alwaysConsumeMouseWheel: height != null,
                 vertical: height != null ? 'auto' : 'hidden',
                 horizontal: 'hidden',
               },

--- a/ui/packages/components/src/CodeBlock/CommandBlock.tsx
+++ b/ui/packages/components/src/CodeBlock/CommandBlock.tsx
@@ -53,6 +53,15 @@ const CommandBlock = ({ currentTabContent }: { currentTabContent?: TabsProps }) 
 
     monaco.languages.register({ id: 'shell' });
     monaco.languages.setMonarchTokensProvider('shell', shellLanguageTokens);
+
+    // These are read-only snippet viewers, so suppress the TypeScript worker's
+    // diagnostics. Without this, free identifiers like `event` resolve to the
+    // deprecated DOM global and render with a strikethrough.
+    monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
+      noSemanticValidation: true,
+      noSyntaxValidation: true,
+      noSuggestionDiagnostics: true,
+    });
   }, [monaco, dark]);
 
   const handleEditorDidMount = (editor: MonacoEditorType) => {
@@ -81,6 +90,9 @@ const CommandBlock = ({ currentTabContent }: { currentTabContent?: TabsProps }) 
             onChange={updateEditorHeight}
             options={{
               readOnly: activeTabContent.readOnly || true,
+              // Deprecated symbols render with a strikethrough via semantic
+              // tokens; disable semantic highlighting for these static snippets.
+              'semanticHighlighting.enabled': false,
               minimap: {
                 enabled: false,
               },

--- a/ui/packages/components/src/CodeBlock/CommandBlock.tsx
+++ b/ui/packages/components/src/CodeBlock/CommandBlock.tsx
@@ -24,7 +24,15 @@ export type TabsProps = {
 
 type MonacoEditorType = editor.IStandaloneCodeEditor | null;
 
-const CommandBlock = ({ currentTabContent }: { currentTabContent?: TabsProps }) => {
+const CommandBlock = ({
+  currentTabContent,
+  height,
+}: {
+  currentTabContent?: TabsProps;
+  // When set, the editor is pinned to this fixed pixel height (content scrolls
+  // internally) instead of growing to fit. Keeps tabbed snippets from jumping.
+  height?: number;
+}) => {
   const [dark, setDark] = useState(isDark());
   const editorRef = useRef<MonacoEditorType>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -72,7 +80,7 @@ const CommandBlock = ({ currentTabContent }: { currentTabContent?: TabsProps }) 
   const updateEditorHeight = () => {
     const editor = editorRef.current;
     if (editor) {
-      const contentHeight = Math.min(1000, editor.getContentHeight());
+      const contentHeight = height != null ? height : Math.min(1000, editor.getContentHeight());
       wrapperRef.current!.style.height = `${contentHeight}px`;
       editor.layout();
     }
@@ -113,7 +121,7 @@ const CommandBlock = ({ currentTabContent }: { currentTabContent?: TabsProps }) 
               scrollbar: {
                 verticalScrollbarSize: 10,
                 alwaysConsumeMouseWheel: false,
-                vertical: 'hidden',
+                vertical: height != null ? 'auto' : 'hidden',
                 horizontal: 'hidden',
               },
               padding: {

--- a/ui/packages/components/src/CodeBlock/CommandBlock.tsx
+++ b/ui/packages/components/src/CodeBlock/CommandBlock.tsx
@@ -62,9 +62,14 @@ const CommandBlock = ({
     monaco.languages.register({ id: 'shell' });
     monaco.languages.setMonarchTokensProvider('shell', shellLanguageTokens);
 
-    // These are read-only snippet viewers, so suppress the TypeScript worker's
-    // diagnostics. Without this, free identifiers like `event` resolve to the
-    // deprecated DOM global and render with a strikethrough.
+    // These are read-only snippet viewers showing intentionally-incomplete
+    // code (free identifiers, fragments). Suppress the TypeScript worker's
+    // diagnostics so they don't render error squiggles, and the deprecated-
+    // symbol strikethrough (e.g. bare `event` resolving to the deprecated DOM
+    // global, which comes from suggestion diagnostics, not semantic tokens).
+    // typescriptDefaults is a global singleton, but this app has no TypeScript
+    // editing surfaces that need diagnostics (CodeSearch uses `cel`, event
+    // editors use `json`), so disabling them globally is safe.
     monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({
       noSemanticValidation: true,
       noSyntaxValidation: true,
@@ -98,9 +103,6 @@ const CommandBlock = ({
             onChange={updateEditorHeight}
             options={{
               readOnly: activeTabContent.readOnly || true,
-              // Deprecated symbols render with a strikethrough via semantic
-              // tokens; disable semantic highlighting for these static snippets.
-              'semanticHighlighting.enabled': false,
               minimap: {
                 enabled: false,
               },

--- a/ui/packages/components/src/Experiments/ExperimentsEmptyState.stories.tsx
+++ b/ui/packages/components/src/Experiments/ExperimentsEmptyState.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ExperimentsEmptyState } from './ExperimentsEmptyState';
+
+const meta = {
+  title: 'Components/ExperimentsEmptyState',
+  component: ExperimentsEmptyState,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<typeof ExperimentsEmptyState>;
+
+export default meta;
+
+type Story = StoryObj<typeof ExperimentsEmptyState>;
+
+export const Default: Story = {};

--- a/ui/packages/components/src/Experiments/ExperimentsEmptyState.tsx
+++ b/ui/packages/components/src/Experiments/ExperimentsEmptyState.tsx
@@ -1,16 +1,20 @@
 import { useState } from 'react';
+import { RiRefreshLine } from '@remixicon/react';
 
+import { Button } from '../Button';
 import CommandBlock, { type TabsProps } from '../CodeBlock/CommandBlock';
 import { Link } from '../Link';
-import { IconSpinner } from '../icons/Spinner';
 import {
   DOCS_URL,
   INTRO_DESCRIPTION,
   STEPS,
-  TRACK_OUTCOME_TAB,
   USE_CASES,
   VARIANT_TABS,
 } from './experimentsEmptyStateContent';
+
+type Props = {
+  onRefresh?: () => void;
+};
 
 function CodeExample({ tabs }: { tabs: TabsProps[] }) {
   const [activeTab, setActiveTab] = useState(tabs[0]?.title ?? '');
@@ -36,7 +40,7 @@ function Step({
   number: number;
   title: string;
   description: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }) {
   return (
     <div className="flex flex-col gap-4">
@@ -51,7 +55,7 @@ function Step({
   );
 }
 
-export function ExperimentsEmptyState() {
+export function ExperimentsEmptyState({ onRefresh }: Props) {
   return (
     <div className="bg-canvasBase flex flex-1 flex-col items-center overflow-auto px-6 py-12">
       <div className="mx-auto flex w-full max-w-[800px] flex-col gap-10">
@@ -77,10 +81,20 @@ export function ExperimentsEmptyState() {
           ))}
         </div>
 
-        {/* Empty / still-looking indicator */}
-        <div className="bg-info text-info dark:bg-info/40 flex items-center gap-2 rounded-md px-4 py-3 text-sm">
-          <IconSpinner className="fill-info h-4 w-4" />
-          No experiments found
+        {/* Empty-results indicator */}
+        <div className="bg-info text-info dark:bg-info/40 flex items-center justify-between gap-2 rounded-md px-4 py-3 text-sm">
+          No experiments available
+          {onRefresh && (
+            <Button
+              kind="secondary"
+              appearance="outlined"
+              size="small"
+              label="Refresh"
+              icon={<RiRefreshLine />}
+              iconSide="left"
+              onClick={onRefresh}
+            />
+          )}
         </div>
 
         <hr className="border-subtle" />
@@ -93,9 +107,7 @@ export function ExperimentsEmptyState() {
             <CodeExample tabs={VARIANT_TABS} />
           </Step>
 
-          <Step number={2} title={STEPS.two.title} description={STEPS.two.description}>
-            <CodeExample tabs={[TRACK_OUTCOME_TAB]} />
-          </Step>
+          <Step number={2} title={STEPS.two.title} description={STEPS.two.description} />
         </div>
       </div>
     </div>

--- a/ui/packages/components/src/Experiments/ExperimentsEmptyState.tsx
+++ b/ui/packages/components/src/Experiments/ExperimentsEmptyState.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 
 import CommandBlock, { type TabsProps } from '../CodeBlock/CommandBlock';
 import { Link } from '../Link';
-import { IconSpinner } from '../icons/Spinner';
 import {
   DOCS_URL,
   INTRO_DESCRIPTION,
@@ -66,9 +65,8 @@ export function ExperimentsEmptyState() {
         </div>
 
         {/* Empty-results indicator */}
-        <div className="border-subtle text-subtle flex items-center gap-2 rounded-md border border-dashed px-4 py-3 text-sm">
-          <IconSpinner className="fill-subtle h-4 w-4" />
-          No experiments found
+        <div className="border-subtle text-subtle rounded-md border border-dashed px-4 py-3 text-sm">
+          No experiments to show
         </div>
 
         {/* Use cases */}

--- a/ui/packages/components/src/Experiments/ExperimentsEmptyState.tsx
+++ b/ui/packages/components/src/Experiments/ExperimentsEmptyState.tsx
@@ -16,6 +16,10 @@ type Props = {
   onRefresh?: () => void;
 };
 
+// Fixed snippet viewport so the box keeps a stable height across tabs and the
+// whole page stays compact; taller variants scroll internally.
+const CODE_HEIGHT = 280;
+
 function CodeExample({ tabs }: { tabs: TabsProps[] }) {
   const [activeTab, setActiveTab] = useState(tabs[0]?.title ?? '');
   const current = tabs.find((tab) => tab.title === activeTab) ?? tabs[0];
@@ -26,7 +30,7 @@ function CodeExample({ tabs }: { tabs: TabsProps[] }) {
         <CommandBlock.Tabs tabs={tabs} activeTab={activeTab} setActiveTab={setActiveTab} />
         <CommandBlock.CopyButton content={current?.content} />
       </CommandBlock.Header>
-      <CommandBlock currentTabContent={current} />
+      <CommandBlock currentTabContent={current} height={CODE_HEIGHT} />
     </CommandBlock.Wrapper>
   );
 }

--- a/ui/packages/components/src/Experiments/ExperimentsEmptyState.tsx
+++ b/ui/packages/components/src/Experiments/ExperimentsEmptyState.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+
+import CommandBlock, { type TabsProps } from '../CodeBlock/CommandBlock';
+import { Link } from '../Link';
+import { IconSpinner } from '../icons/Spinner';
+import {
+  DOCS_URL,
+  INTRO_DESCRIPTION,
+  STEPS,
+  TRACK_OUTCOME_TAB,
+  USE_CASES,
+  VARIANT_TABS,
+} from './experimentsEmptyStateContent';
+
+function CodeExample({ tabs }: { tabs: TabsProps[] }) {
+  const [activeTab, setActiveTab] = useState(tabs[0]?.title ?? '');
+  const current = tabs.find((tab) => tab.title === activeTab) ?? tabs[0];
+
+  return (
+    <CommandBlock.Wrapper>
+      <CommandBlock.Header className="flex items-center justify-between pr-2">
+        <CommandBlock.Tabs tabs={tabs} activeTab={activeTab} setActiveTab={setActiveTab} />
+        <CommandBlock.CopyButton content={current?.content} />
+      </CommandBlock.Header>
+      <CommandBlock currentTabContent={current} />
+    </CommandBlock.Wrapper>
+  );
+}
+
+function Step({
+  number,
+  title,
+  description,
+  children,
+}: {
+  number: number;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1.5">
+        <p className="text-basis text-sm font-medium">
+          {number}. {title}
+        </p>
+        <p className="text-subtle text-sm leading-relaxed">{description}</p>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+export function ExperimentsEmptyState() {
+  return (
+    <div className="bg-canvasBase flex flex-1 flex-col items-center overflow-auto px-6 py-12">
+      <div className="mx-auto flex w-full max-w-[800px] flex-col gap-10">
+        {/* Intro */}
+        <div className="flex flex-col gap-2">
+          <h1 className="text-basis text-2xl">Experiments</h1>
+          <p className="text-subtle text-sm leading-relaxed">{INTRO_DESCRIPTION}</p>
+          <Link href={DOCS_URL}>Learn more about experiments</Link>
+        </div>
+
+        {/* Use cases */}
+        <div className="grid grid-cols-2 gap-x-8 gap-y-6">
+          {USE_CASES.map(({ Icon, title, description }) => (
+            <div key={title} className="flex items-start gap-3">
+              <div className="border-subtle bg-canvasSubtle text-basis flex h-10 w-10 shrink-0 items-center justify-center rounded-md border">
+                <Icon className="h-5 w-5" />
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <p className="text-basis text-sm font-medium">{title}</p>
+                <p className="text-muted text-sm leading-relaxed">{description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Empty / still-looking indicator */}
+        <div className="bg-info text-info dark:bg-info/40 flex items-center gap-2 rounded-md px-4 py-3 text-sm">
+          <IconSpinner className="fill-info h-4 w-4" />
+          No experiments found
+        </div>
+
+        <hr className="border-subtle" />
+
+        {/* Get started */}
+        <div className="flex flex-col gap-6">
+          <h2 className="text-basis text-lg">Get started</h2>
+
+          <Step number={1} title={STEPS.one.title} description={STEPS.one.description}>
+            <CodeExample tabs={VARIANT_TABS} />
+          </Step>
+
+          <Step number={2} title={STEPS.two.title} description={STEPS.two.description}>
+            <CodeExample tabs={[TRACK_OUTCOME_TAB]} />
+          </Step>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/packages/components/src/Experiments/ExperimentsEmptyState.tsx
+++ b/ui/packages/components/src/Experiments/ExperimentsEmptyState.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
-import { RiRefreshLine } from '@remixicon/react';
 
-import { Button } from '../Button';
 import CommandBlock, { type TabsProps } from '../CodeBlock/CommandBlock';
 import { Link } from '../Link';
+import { IconSpinner } from '../icons/Spinner';
 import {
   DOCS_URL,
   INTRO_DESCRIPTION,
@@ -11,10 +10,6 @@ import {
   USE_CASES,
   VARIANT_TABS,
 } from './experimentsEmptyStateContent';
-
-type Props = {
-  onRefresh?: () => void;
-};
 
 // Fixed snippet viewport so the box keeps a stable height across tabs and the
 // whole page stays compact; taller variants scroll internally.
@@ -59,7 +54,7 @@ function Step({
   );
 }
 
-export function ExperimentsEmptyState({ onRefresh }: Props) {
+export function ExperimentsEmptyState() {
   return (
     <div className="bg-canvasBase flex flex-1 flex-col items-center overflow-auto px-6 py-12">
       <div className="mx-auto flex w-full max-w-[800px] flex-col gap-10">
@@ -68,6 +63,12 @@ export function ExperimentsEmptyState({ onRefresh }: Props) {
           <h1 className="text-basis text-2xl">Experiments</h1>
           <p className="text-subtle text-sm leading-relaxed">{INTRO_DESCRIPTION}</p>
           <Link href={DOCS_URL}>Learn more about experiments</Link>
+        </div>
+
+        {/* Empty-results indicator */}
+        <div className="border-subtle text-subtle flex items-center gap-2 rounded-md border border-dashed px-4 py-3 text-sm">
+          <IconSpinner className="fill-subtle h-4 w-4" />
+          No experiments found
         </div>
 
         {/* Use cases */}
@@ -83,22 +84,6 @@ export function ExperimentsEmptyState({ onRefresh }: Props) {
               </div>
             </div>
           ))}
-        </div>
-
-        {/* Empty-results indicator */}
-        <div className="bg-info text-info dark:bg-info/40 flex items-center justify-between gap-2 rounded-md px-4 py-3 text-sm">
-          No experiments available
-          {onRefresh && (
-            <Button
-              kind="secondary"
-              appearance="outlined"
-              size="small"
-              label="Refresh"
-              icon={<RiRefreshLine />}
-              iconSide="left"
-              onClick={onRefresh}
-            />
-          )}
         </div>
 
         <hr className="border-subtle" />

--- a/ui/packages/components/src/Experiments/experimentsEmptyStateContent.tsx
+++ b/ui/packages/components/src/Experiments/experimentsEmptyStateContent.tsx
@@ -1,0 +1,166 @@
+import type { ComponentType } from 'react';
+import { RiEqualizerLine, RiGroupLine, RiLineChartLine, RiScalesLine } from '@remixicon/react';
+
+import type { TabsProps } from '../CodeBlock/CommandBlock';
+
+export const DOCS_URL =
+  'https://www.inngest.com/docs/features/inngest-functions/steps-workflows/step-experiments';
+
+export const INTRO_DESCRIPTION =
+  'Experiments let you compare different versions of logic on real traffic without building a separate A/B testing system.';
+
+type UseCase = {
+  Icon: ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+};
+
+export const USE_CASES: UseCase[] = [
+  {
+    Icon: RiScalesLine,
+    title: 'Compare models',
+    description: 'Run two models or prompts side by side on live data.',
+  },
+  {
+    Icon: RiLineChartLine,
+    title: 'Canary a rewrite',
+    description: 'Ship a refactor to 1% of runs, then ramp it up.',
+  },
+  {
+    Icon: RiEqualizerLine,
+    title: 'Tune costly operations',
+    description: 'Trial a batch size or temperature per run.',
+  },
+  {
+    Icon: RiGroupLine,
+    title: 'Migrate a cohort',
+    description: 'Keep an account on one experience through a rollout.',
+  },
+];
+
+const WEIGHTED = `import { experiment } from "inngest";
+import { inngest } from "./client";
+export default inngest.createFunction(
+  {
+    id: "generate-invoice",
+    triggers: { event: "billing/invoice.requested" },
+  },
+  async ({ event, step, group }) => {
+    return await group.experiment("invoice-engine", {
+      variants: {
+        current: () =>
+          step.run("generate-current", () =>
+            generateInvoiceV1(event.data)
+          ),
+        rewrite: () =>
+          step.run("generate-rewrite", () =>
+            generateInvoiceV2(event.data)
+          ),
+      },
+      select: experiment.weighted({ current: 99, rewrite: 1 }),
+    });
+  }
+);`;
+
+const BUCKET = `const charge = await group.experiment("payments-provider", {
+  variants: {
+    stripe: () =>
+      step.run("charge-stripe", () =>
+        chargeStripe(event.data.order)
+      ),
+    adyen: () =>
+      step.run("charge-adyen", () =>
+        chargeAdyen(event.data.order)
+      ),
+  },
+  select: experiment.bucket(event.data.accountId, {
+    weights: { stripe: 90, adyen: 10 },
+  }),
+});`;
+
+const CUSTOM = `const invoice = await group.experiment("invoice-engine", {
+  variants: {
+    current: () =>
+      step.run("generate-current", () =>
+        generateInvoiceV1(event.data)
+      ),
+    rewrite: () =>
+      step.run("generate-rewrite", () =>
+        generateInvoiceV2(event.data)
+      ),
+  },
+  select: experiment.custom(async () => {
+    const assignment = await rolloutAssignments.get(event.data.accountId);
+    return assignment ?? "current";
+  }),
+});`;
+
+const FIXED = `import { experiment } from "inngest";
+import { inngest } from "./client";
+export default inngest.createFunction(
+  {
+    id: "generate-invoice",
+    triggers: { event: "billing/invoice.requested" },
+  },
+  async ({ event, step, group }) => {
+    return await group.experiment("invoice-engine", {
+      variants: {
+        current: () =>
+          step.run("generate-current", () =>
+            generateInvoiceV1(event.data)
+          ),
+        rewrite: () =>
+          step.run("generate-rewrite", () =>
+            generateInvoiceV2(event.data)
+          ),
+      },
+      select: experiment.fixed("rewrite"),
+    });
+  }
+);`;
+
+export const VARIANT_TABS: TabsProps[] = [
+  { title: 'weighted ( )', content: WEIGHTED, language: 'typescript', readOnly: true },
+  { title: 'bucket ( )', content: BUCKET, language: 'typescript', readOnly: true },
+  { title: 'custom ( )', content: CUSTOM, language: 'typescript', readOnly: true },
+  { title: 'fixed ( )', content: FIXED, language: 'typescript', readOnly: true },
+];
+
+const TRACK_OUTCOME = `const outcome = await group.experiment("email-copy", {
+  variants: {
+    short: () => step.run("short-copy", () => generateShortCopy(event.data)),
+    detailed: () =>
+      step.run("detailed-copy", () => generateDetailedCopy(event.data)),
+  },
+  select: experiment.bucket(event.data.userId, {
+    weights: { short: 50, detailed: 50 },
+  }),
+  withVariant: true,
+});
+await step.run("track-selected-variant", () =>
+  analytics.track("experiment.variant_selected", {
+    experiment: "email-copy",
+    variant: outcome.variant,
+    userId: event.data.userId,
+  })
+);`;
+
+export const TRACK_OUTCOME_TAB: TabsProps = {
+  title: 'track-outcome.ts',
+  content: TRACK_OUTCOME,
+  language: 'typescript',
+  readOnly: true,
+};
+
+export const STEPS = {
+  one: {
+    title: 'Declare your variants inside an inngest function and choose how runs are selected',
+    description:
+      'Wrap the paths you’re comparing in group.experiment( ). Each variant calls a step so the work stays durable. Every strategy returns exactly one variant per run.',
+  },
+  two: {
+    title: 'Track the outcome',
+    description:
+      'Compare latency, errors and traces. You can also emit your own score from inside the selected variant.',
+  },
+};

--- a/ui/packages/components/src/Experiments/experimentsEmptyStateContent.tsx
+++ b/ui/packages/components/src/Experiments/experimentsEmptyStateContent.tsx
@@ -126,32 +126,6 @@ export const VARIANT_TABS: TabsProps[] = [
   { title: 'fixed ( )', content: FIXED, language: 'typescript', readOnly: true },
 ];
 
-const TRACK_OUTCOME = `const outcome = await group.experiment("email-copy", {
-  variants: {
-    short: () => step.run("short-copy", () => generateShortCopy(event.data)),
-    detailed: () =>
-      step.run("detailed-copy", () => generateDetailedCopy(event.data)),
-  },
-  select: experiment.bucket(event.data.userId, {
-    weights: { short: 50, detailed: 50 },
-  }),
-  withVariant: true,
-});
-await step.run("track-selected-variant", () =>
-  analytics.track("experiment.variant_selected", {
-    experiment: "email-copy",
-    variant: outcome.variant,
-    userId: event.data.userId,
-  })
-);`;
-
-export const TRACK_OUTCOME_TAB: TabsProps = {
-  title: 'track-outcome.ts',
-  content: TRACK_OUTCOME,
-  language: 'typescript',
-  readOnly: true,
-};
-
 export const STEPS = {
   one: {
     title: 'Declare your variants inside an inngest function and choose how runs are selected',

--- a/ui/packages/components/src/Experiments/index.ts
+++ b/ui/packages/components/src/Experiments/index.ts
@@ -1,5 +1,6 @@
 export { ExperimentsTable } from './ExperimentsTable';
 export { ExperimentsBlankState } from './ExperimentsBlankState';
+export { ExperimentsEmptyState } from './ExperimentsEmptyState';
 export { formatVariantWeight } from './format';
 export { isActive, getActiveThreshold, ACTIVE_THRESHOLD_DAYS } from './status';
 export type {


### PR DESCRIPTION
Add a rich empty state for the Experiments page shown when an environment has no experiments yet. It explains what experiments are with a docs link, shows the four use cases, an empty-results indicator, and a Get started section with tabbed code examples (weighted/bucket/custom/fixed) and an outcome-tracking snippet.

Wired into the experiments route to render when the list is empty, falling back to ExperimentsTable once experiments exist.


## Description

<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
