### PR TITLE
chore: remove beta label from insights

### DIFF
--- a/ui/apps/dashboard/src/components/NavigationV2/navItems.ts
+++ b/ui/apps/dashboard/src/components/NavigationV2/navItems.ts
@@ -42,7 +42,7 @@ export const monitor: NavGroupConfig = {
   heading: 'Monitor',
   items: [
     { label: 'Metrics', route: 'metrics', Icon: MetricsIcon },
-    { label: 'Insights', route: 'insights', Icon: InsightsIcon, beta: true },
+    { label: 'Insights', route: 'insights', Icon: InsightsIcon },
   ],
 };
 


### PR DESCRIPTION
## Description
Remove beta label from insights on sidebar

## Release note

None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
