### PR TITLE
fix: the display of extended traces for steps with multiple attempts

### DIFF
--- a/pkg/cqrs/manager/cqrs.go
+++ b/pkg/cqrs/manager/cqrs.go
@@ -655,6 +655,54 @@ func mapRootSpansFromRows[T normalizedSpan](ctx context.Context, spans []T) (*cq
 		dynamicToOtelIDs[dynID] = append(dynamicToOtelIDs[dynID], otelID)
 	}
 
+	// Reparent userland (extended trace) spans by (stepID, attempt).
+	//
+	// The SDK parents userland spans via OTel context, whose parent_span_id
+	// linkage is unreliable across step attempts — e.g. an attempt-0 LLM span
+	// can point at the attempt-1 step span, which resolves fine and would
+	// otherwise leave the span on the wrong attempt. The trustworthy signal is
+	// the (stepID, attempt) attribute pair, so override the parent of each
+	// userland subtree ROOT to its matching step span (preferred) or execution
+	// span (fallback).
+	//
+	// Interior nodes of a userland subtree (whose parent is itself a userland
+	// span) are left untouched. The resolve-then-reparent loop below then
+	// attaches each span to the corrected parent.
+	parentIsUserland := func(parentID string) bool {
+		if parentID == "" {
+			return false
+		}
+		if _, ok := userlandDynIDs[parentID]; ok {
+			return true
+		}
+		if dynID, ok := otelToDynamic[parentID]; ok {
+			_, ok := userlandDynIDs[dynID]
+			return ok
+		}
+		return false
+	}
+	for _, span := range spanMap.AllFromFront() {
+		if span.Attributes == nil ||
+			(span.Attributes.IsUserland == nil || !*span.Attributes.IsUserland) ||
+			(span.Attributes.StepID == nil || *span.Attributes.StepID == "") ||
+			span.Attributes.StepAttempt == nil {
+			continue
+		}
+		// Only reparent roots of userland subtrees; interior nodes keep their parent.
+		if span.ParentSpanID != nil && parentIsUserland(*span.ParentSpanID) {
+			continue
+		}
+		key := newExtendedTraceKey(*span.Attributes.StepID, *span.Attributes.StepAttempt)
+		target, found := stepSpanByKey[key]
+		if !found {
+			target, found = execSpanByKey[key]
+		}
+		if found {
+			tid := target
+			span.ParentSpanID = &tid
+		}
+	}
+
 	for _, span := range spanMap.AllFromFront() {
 		// If we have an output reference for this span, set the appropriate
 		// target span ID here

--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -2802,18 +2802,18 @@ func TestExtendedTraceReparenting(t *testing.T) {
 
 		for _, attempt := range []int{0, 1} {
 			insertTestSpan(t, cm, testSpanFields{
-				RunID:        runIDStr,
+				RunID:         runIDStr,
 				DynamicSpanID: fmt.Sprintf("dyn-step-%d", attempt),
-				Name:         meta.SpanNameStep,
-				ParentSpanID: "dyn-run",
-				Attributes:   stepAttrs("step-retry", attempt),
+				Name:          meta.SpanNameStep,
+				ParentSpanID:  "dyn-run",
+				Attributes:    stepAttrs("step-retry", attempt),
 			})
 			insertTestSpan(t, cm, testSpanFields{
-				RunID:        runIDStr,
+				RunID:         runIDStr,
 				DynamicSpanID: fmt.Sprintf("dyn-userland-%d", attempt),
-				Name:         "userland",
-				ParentSpanID: "stale-otel-id",
-				Attributes:   userlandAttrs("step-retry", attempt),
+				Name:          "userland",
+				ParentSpanID:  "stale-otel-id",
+				Attributes:    userlandAttrs("step-retry", attempt),
 			})
 		}
 

--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -3099,3 +3099,133 @@ func initCQRS(t *testing.T, opts ...withInitCQRSOpt) (cqrs.Manager, func()) {
 
 	return cm, cleanup
 }
+
+// TestCQRSGetSpanReparentsUserland covers userland (extended trace) span
+// reparenting in mapRootSpansFromRows.
+//
+// The SDK parents userland spans via OTel context, whose parent_span_id is
+// unreliable across step attempts — e.g. an attempt-0 LLM span can be
+// physically parented under the attempt-1 step span, which resolves fine and
+// would otherwise leave the span on the wrong attempt.
+//
+// The reader must reparent each userland subtree ROOT to the span matching its
+// (stepID, attempt) attributes, preferring executor.step and falling back to
+// executor.execution.
+func TestCQRSGetSpanReparentsUserland(t *testing.T) {
+	const stepID = "step1"
+	runAttr := []byte(`{"_inngest.dynamic.status":"Running"}`)
+	stepAttrs := func(id string, attempt int) []byte {
+		return fmt.Appendf(nil, `{"_inngest.step.id":%q,"_inngest.step.attempt":%d}`, id, attempt)
+	}
+	userlandAttrs := func(id string, attempt int) []byte {
+		return fmt.Appendf(nil, `{"_inngest.userland":true,"_inngest.step.id":%q,"_inngest.step.attempt":%d}`, id, attempt)
+	}
+	userlandNoAttempt := func(id string) []byte {
+		return fmt.Appendf(nil, `{"_inngest.userland":true,"_inngest.step.id":%q}`, id)
+	}
+
+	// span dynamic-id -> expected parent dynamic-id after the tree is built.
+	type expect struct{ span, parent string }
+
+	cases := []struct {
+		name    string
+		spans   []testSpanFields
+		expects []expect
+	}{
+		{
+			// Both LLM spans land under the attempt-1 step in
+			// the raw data; each must move to the step matching its own attempt.
+			name: "cross-attempt: each userland span moves to its own attempt's step",
+			spans: []testSpanFields{
+				{DynamicSpanID: "root", Name: meta.SpanNameRun, Attributes: runAttr},
+				{DynamicSpanID: "step0", ParentSpanID: "root", Name: meta.SpanNameStep, Attributes: stepAttrs(stepID, 0)},
+				{DynamicSpanID: "step1", ParentSpanID: "root", Name: meta.SpanNameStep, Attributes: stepAttrs(stepID, 1)},
+				{DynamicSpanID: "chat0", ParentSpanID: "step1", Name: "chat", Attributes: userlandAttrs(stepID, 0)},
+				{DynamicSpanID: "chat1", ParentSpanID: "step1", Name: "chat", Attributes: userlandAttrs(stepID, 1)},
+			},
+			expects: []expect{{"chat0", "step0"}, {"chat1", "step1"}},
+		},
+		{
+			name: "prefers executor.step over executor.execution",
+			spans: []testSpanFields{
+				{DynamicSpanID: "root", Name: meta.SpanNameRun, Attributes: runAttr},
+				{DynamicSpanID: "step", ParentSpanID: "root", Name: meta.SpanNameStep, Attributes: stepAttrs(stepID, 0)},
+				{DynamicSpanID: "exec", ParentSpanID: "root", Name: meta.SpanNameExecution, Attributes: stepAttrs(stepID, 0)},
+				{DynamicSpanID: "ul", ParentSpanID: "root", Name: "chat", Attributes: userlandAttrs(stepID, 0)},
+			},
+			expects: []expect{{"ul", "step"}},
+		},
+		{
+			name: "falls back to executor.execution when no step matches",
+			spans: []testSpanFields{
+				{DynamicSpanID: "root", Name: meta.SpanNameRun, Attributes: runAttr},
+				{DynamicSpanID: "exec", ParentSpanID: "root", Name: meta.SpanNameExecution, Attributes: stepAttrs(stepID, 0)},
+				{DynamicSpanID: "ul", ParentSpanID: "root", Name: "chat", Attributes: userlandAttrs(stepID, 0)},
+			},
+			expects: []expect{{"ul", "exec"}},
+		},
+		{
+			name: "no reparent when attempt attribute missing",
+			spans: []testSpanFields{
+				{DynamicSpanID: "root", Name: meta.SpanNameRun, Attributes: runAttr},
+				{DynamicSpanID: "step", ParentSpanID: "root", Name: meta.SpanNameStep, Attributes: stepAttrs(stepID, 0)},
+				{DynamicSpanID: "ul", ParentSpanID: "root", Name: "chat", Attributes: userlandNoAttempt(stepID)},
+			},
+			expects: []expect{{"ul", "root"}},
+		},
+		{
+			name: "no reparent when no step or execution matches the key",
+			spans: []testSpanFields{
+				{DynamicSpanID: "root", Name: meta.SpanNameRun, Attributes: runAttr},
+				{DynamicSpanID: "step", ParentSpanID: "root", Name: meta.SpanNameStep, Attributes: stepAttrs("other", 0)},
+				{DynamicSpanID: "ul", ParentSpanID: "root", Name: "chat", Attributes: userlandAttrs(stepID, 0)},
+			},
+			expects: []expect{{"ul", "root"}},
+		},
+		{
+			// Only the root of a userland subtree is reparented; an interior node
+			// whose parent is itself userland must keep its original parent.
+			name: "only subtree root reparented; interior userland node kept",
+			spans: []testSpanFields{
+				{DynamicSpanID: "root", Name: meta.SpanNameRun, Attributes: runAttr},
+				{DynamicSpanID: "step", ParentSpanID: "root", Name: meta.SpanNameStep, Attributes: stepAttrs(stepID, 0)},
+				{DynamicSpanID: "ulroot", ParentSpanID: "root", Name: "chat", Attributes: userlandAttrs(stepID, 0)},
+				{DynamicSpanID: "ulchild", ParentSpanID: "ulroot", Name: "chat", Attributes: userlandAttrs(stepID, 0)},
+			},
+			expects: []expect{{"ulroot", "step"}, {"ulchild", "ulroot"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cm, cleanup := initCQRS(t)
+			defer cleanup()
+
+			runID := ulid.MustNew(ulid.Now(), rand.Reader).String()
+			for _, s := range tc.spans {
+				s.RunID = runID
+				insertTestSpan(t, cm, s)
+			}
+
+			root, err := cm.GetSpansByRunID(t.Context(), ulid.MustParse(runID))
+			require.NoError(t, err)
+			require.NotNil(t, root)
+
+			// Build a child -> parent map keyed by dynamic span ID.
+			parentOf := map[string]string{}
+			var walk func(s *cqrs.OtelSpan)
+			walk = func(s *cqrs.OtelSpan) {
+				for _, c := range s.Children {
+					parentOf[c.SpanID] = s.SpanID
+					walk(c)
+				}
+			}
+			walk(root)
+
+			for _, e := range tc.expects {
+				assert.Equal(t, e.parent, parentOf[e.span],
+					"span %q should be parented under %q", e.span, e.parent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

- When running extended traces, a step that has multiple attempts will parent all extended traces on to the last attempt.

Before: there are two Extended traces under "Attempt 1"

<img width="758" height="447" alt="Screenshot 2026-06-26 at 2 06 35 PM" src="https://github.com/user-attachments/assets/5b0ee6c5-e3b9-408b-a050-fd7e9b4d95d9" />

- We apply the same fix that we used in https://github.com/inngest/monorepo/pull/7611 where we reparent extended trace spans with their step id and attempt numbers
- We also port over the same tests, and a new one for the bug we encountered in the screenshots

After: each attempt has one extended trace

<img width="758" height="447" alt="Screenshot 2026-06-26 at 2 01 20 PM" src="https://github.com/user-attachments/assets/5ddf3a5b-a841-47a4-be8c-66f989823475" />


## Release note

Fixes the display of parenting of extended traces when there are multiple attempts for a step, each with its set of spans.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
