### PR TITLE
internal: use generated AIMetadata type for span metadata

### DIFF
--- a/ui/packages/components/src/RunDetails/ScoresAttrs.tsx
+++ b/ui/packages/components/src/RunDetails/ScoresAttrs.tsx
@@ -4,8 +4,12 @@ import { KindInngestScore } from '../generated';
 type ScoreMetadata = {
   kind: string;
   updatedAt: string;
-  // Map of user-supplied score name to its value.
-  values: Record<string, unknown>;
+  // Loose structural supertype of every SpanMetadata arm so both the V3 and V4
+  // Trace types can be passed in. `object` (not Record<string, unknown>) is
+  // required because generated interface value types (e.g. AIMetadata) lack an
+  // implicit index signature; this type only filters by kind and reads via
+  // Object.entries, so the looser bound is sufficient.
+  values: object;
 };
 
 type ScoreRow = {

--- a/ui/packages/components/src/RunDetailsV3/MetadataAttrs.tsx
+++ b/ui/packages/components/src/RunDetailsV3/MetadataAttrs.tsx
@@ -27,13 +27,20 @@ const getKindLabel = (kind: SpanMetadataKind): string => {
   return `User Metadata (${kindName})`;
 };
 
-const MetadataAttrRow = ({
-  kind,
-  scope,
-  values,
-  updatedAt,
-  isLast,
-}: SpanMetadata & { isLast: boolean }) => {
+// Row props are intentionally decoupled from the SpanMetadata discriminated
+// union: the row renders values generically via Object.entries and never relies
+// on the kind/values correlation. Indexing the union keeps it permissive enough
+// to accept any arm's values (including generated interface types like
+// AIMetadata, which lack an implicit index signature).
+type MetadataAttrRowProps = {
+  kind: SpanMetadataKind;
+  scope: SpanMetadata['scope'];
+  values: SpanMetadata['values'];
+  updatedAt: string;
+  isLast: boolean;
+};
+
+const MetadataAttrRow = ({ kind, scope, values, updatedAt, isLast }: MetadataAttrRowProps) => {
   return (
     <div className="flex flex-col justify-start gap-2">
       <div className="flex h-11 w-full flex-row items-center justify-between border-none px-4 pt-2">

--- a/ui/packages/components/src/RunDetailsV3/types.ts
+++ b/ui/packages/components/src/RunDetailsV3/types.ts
@@ -1,3 +1,5 @@
+import { type AIMetadata } from '../generated/index';
+
 export type Trace = {
   attempts: number | null;
   childrenSpans?: Trace[];
@@ -43,13 +45,7 @@ export type SpanMetadataInngestAI = {
   scope: 'step_attempt' | 'extended_trace';
   kind: 'inngest.ai';
   updatedAt: string;
-  values: {
-    input_tokens?: number;
-    output_tokens?: number;
-    model: string;
-    system: string;
-    operation_name: string;
-  };
+  values: AIMetadata;
 };
 
 export type SpanMetadataInngestHTTP = {

--- a/ui/packages/components/src/RunDetailsV4/MetadataAttrs.tsx
+++ b/ui/packages/components/src/RunDetailsV4/MetadataAttrs.tsx
@@ -39,13 +39,20 @@ const getKindLabel = (kind: SpanMetadataKind): string => {
   return `User Metadata (${kindName})`;
 };
 
-const MetadataAttrRow = ({
-  kind,
-  scope,
-  values,
-  updatedAt,
-  isLast,
-}: SpanMetadata & { isLast: boolean }) => {
+// Row props are intentionally decoupled from the SpanMetadata discriminated
+// union: the row renders values generically via Object.entries and never relies
+// on the kind/values correlation. Indexing the union keeps it permissive enough
+// to accept any arm's values (including generated interface types like
+// AIMetadata, which lack an implicit index signature).
+type MetadataAttrRowProps = {
+  kind: SpanMetadataKind;
+  scope: SpanMetadata['scope'];
+  values: SpanMetadata['values'];
+  updatedAt: string;
+  isLast: boolean;
+};
+
+const MetadataAttrRow = ({ kind, scope, values, updatedAt, isLast }: MetadataAttrRowProps) => {
   const sortedEntries = useMemo(
     () =>
       Object.entries(values ?? {}).sort(([a], [b]) => {

--- a/ui/packages/components/src/RunDetailsV4/types.ts
+++ b/ui/packages/components/src/RunDetailsV4/types.ts
@@ -1,5 +1,6 @@
 import {
   KindInngestScore,
+  type AIMetadata,
   type SpanMetadataKind as GeneratedSpanMetadataKind,
   type SpanMetadataKindInngestScore as GeneratedSpanMetadataKindInngestScore,
   type SpanMetadataKindUserland as GeneratedSpanMetadataKindUserland,
@@ -60,13 +61,7 @@ export type SpanMetadataInngestAI = {
   scope: 'step_attempt' | 'extended_trace';
   kind: 'inngest.ai';
   updatedAt: string;
-  values: {
-    input_tokens?: number;
-    output_tokens?: number;
-    model: string;
-    system: string;
-    operation_name: string;
-  };
+  values: AIMetadata;
 };
 
 export type SpanMetadataInngestExperiment = {


### PR DESCRIPTION
## Description

- We've been making changes to AI Metadata's schema and its generated types
- Rather than maintaining the corresponding type in the dashboard by hand, let's use our generated type.
- We're moving from an alias to a type, so we shift a few things around like MetadataAttrRowProps and Record -> Object
- Would love to hear better styles to adhere to.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
