### PR TITLE
fix: Update Learn More About Scores link on dashboard

### DIFF
--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/scores/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/scores/index.tsx
@@ -24,7 +24,7 @@ function ScoresInfo() {
       text="View score variants across your functions."
       action={
         <Link
-          href="https://www.inngest.com/docs/features/scoring" // TODO: actual docs URL
+          href="https://www.inngest.com/changelog/2026-06-30-scoring?unreleased=score"
           target="_blank"
         >
           Learn about scores


### PR DESCRIPTION
## Description

- We have this link for users to learn more about scoring. However, currently it leads to a 404

<img width="1280" height="662" alt="Screenshot 2026-06-26 at 3 30 03 PM" src="https://github.com/user-attachments/assets/c62bad1e-5c3d-4f8a-bdae-8eb2d6343e89" />

- Instead, let's direct users to <https://www.inngest.com/changelog/2026-06-30-scoring?unreleased=score>, which seems to be the most holistic overview of scoring. Happy to repoint it elsewhere too


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
