### PR TITLE
fix(connect): advertise a routable gateway gRPC IP for multi-replica self-hosting

### DIFF
--- a/pkg/connect/grpc/grpc.go
+++ b/pkg/connect/grpc/grpc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -18,8 +19,29 @@ import (
 const (
 	DefaultConnectGatewayGRPCPort  = 50052
 	DefaultConnectExecutorGRPCPort = 50053
-	DefaultConnectGRPCIP           = "127.0.0.1"
 )
+
+// DefaultConnectGRPCIP is the IP a gateway/executor advertises to its peers for
+// inter-replica connect forwarding, so it must be routable from other replicas.
+// Resolution: INNGEST_CONNECT_GATEWAY_GRPC_IP, else the outbound interface IP,
+// else 127.0.0.1 (which only works single-replica).
+var DefaultConnectGRPCIP = resolveConnectGRPCIP()
+
+func resolveConnectGRPCIP() string {
+	if ip := os.Getenv("INNGEST_CONNECT_GATEWAY_GRPC_IP"); ip != "" {
+		return ip
+	}
+	// UDP dial selects the egress interface without sending packets.
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		return "127.0.0.1"
+	}
+	defer conn.Close()
+	if addr, ok := conn.LocalAddr().(*net.UDPAddr); ok {
+		return addr.IP.String()
+	}
+	return "127.0.0.1"
+}
 
 type GatewayGRPCForwarder interface {
 	ConnectToGateways(ctx context.Context) error

--- a/pkg/connect/grpc/grpc.go
+++ b/pkg/connect/grpc/grpc.go
@@ -23,13 +23,17 @@ const (
 
 // DefaultConnectGRPCIP is the IP a gateway/executor advertises to its peers for
 // inter-replica connect forwarding, so it must be routable from other replicas.
-// Resolution: INNGEST_CONNECT_GATEWAY_GRPC_IP, else the outbound interface IP,
-// else 127.0.0.1 (which only works single-replica).
+// Resolution: INNGEST_CONNECT_GATEWAY_GRPC_IP (if a valid IP), else the outbound
+// interface IP, else 127.0.0.1 (which only works single-replica).
 var DefaultConnectGRPCIP = resolveConnectGRPCIP()
 
 func resolveConnectGRPCIP() string {
+	// An explicit override wins, but only if it parses as an IP; a bad value
+	// falls through to auto-detect rather than advertising an unreachable address.
 	if ip := os.Getenv("INNGEST_CONNECT_GATEWAY_GRPC_IP"); ip != "" {
-		return ip
+		if parsed := net.ParseIP(ip); parsed != nil {
+			return parsed.String()
+		}
 	}
 	// UDP dial selects the egress interface without sending packets.
 	conn, err := net.Dial("udp", "8.8.8.8:80")

--- a/pkg/connect/grpc/resolve_ip_test.go
+++ b/pkg/connect/grpc/resolve_ip_test.go
@@ -1,0 +1,24 @@
+package grpc
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveConnectGRPCIP(t *testing.T) {
+	t.Run("uses INNGEST_CONNECT_GATEWAY_GRPC_IP when set", func(t *testing.T) {
+		t.Setenv("INNGEST_CONNECT_GATEWAY_GRPC_IP", "10.1.2.3")
+		require.Equal(t, "10.1.2.3", resolveConnectGRPCIP())
+	})
+
+	t.Run("falls back to a routable IP when the env var is unset", func(t *testing.T) {
+		// Empty means unset for our purposes; this exercises the auto-detect /
+		// loopback-fallback path. Either way the result must be a valid IP.
+		t.Setenv("INNGEST_CONNECT_GATEWAY_GRPC_IP", "")
+		got := resolveConnectGRPCIP()
+		require.NotEmpty(t, got)
+		require.NotNil(t, net.ParseIP(got), "expected a valid IP, got %q", got)
+	})
+}

--- a/pkg/connect/grpc/resolve_ip_test.go
+++ b/pkg/connect/grpc/resolve_ip_test.go
@@ -21,4 +21,11 @@ func TestResolveConnectGRPCIP(t *testing.T) {
 		require.NotEmpty(t, got)
 		require.NotNil(t, net.ParseIP(got), "expected a valid IP, got %q", got)
 	})
+
+	t.Run("ignores an invalid override and falls through to a valid IP", func(t *testing.T) {
+		t.Setenv("INNGEST_CONNECT_GATEWAY_GRPC_IP", "not-an-ip")
+		got := resolveConnectGRPCIP()
+		require.NotEqual(t, "not-an-ip", got)
+		require.NotNil(t, net.ParseIP(got), "expected a valid IP, got %q", got)
+	})
 }


### PR DESCRIPTION
## Description

The all-in-one server (`inngest start`) hardcodes the connect-gateway gRPC advertise address to `127.0.0.1` (`DefaultConnectGRPCIP` in `pkg/connect/grpc/grpc.go`). Each replica registers that loopback address in the shared gateway registry (`{connect}:gateways`), so with more than one replica an executor always dials its **own** local gateway (`127.0.0.1:50052`) and never the peer that holds the worker's WebSocket. The forward then fails:

```
WARN  forward to gateway failed, re-routing  ... err="gateway could not forward to connection <id>: connection not available"
WARN  connection not found in wsConnections  conn_id=<id>
```

Connect runs fail 100% of the time whenever the control plane runs more than one replica. It only works single-replica, where the executor and the gateway share a process and `127.0.0.1` happens to be correct. This affects any horizontally-scaled self-hosted deployment using the connect pathway (for example the Helm chart's default `replicaCount: 3`).

This PR makes the advertised IP resolvable instead of hardcoded:

1. `INNGEST_CONNECT_GATEWAY_GRPC_IP` if set (e.g. Kubernetes downward-API `status.podIP`),
2. otherwise the primary outbound-interface IP (correct on most hosts, including ECS `awsvpc` and K8s pods),
3. otherwise `127.0.0.1`.

Single-node behaviour is unchanged when the env var is unset. Adds a unit test for the resolver. The gateways must already be able to reach each other on the connect gRPC ports (50052/50053).

Open question for maintainers: I defaulted to auto-detecting the outbound IP so multi-replica self-hosting works with no extra config. If you would rather keep the default at `127.0.0.1` and make this strictly opt-in via the env var, I am happy to change it.

Closes #4528.

## Release note

Fix self-hosted connect failing across multiple server replicas: the connect-gateway now advertises a routable gRPC address (auto-detected, or set `INNGEST_CONNECT_GATEWAY_GRPC_IP`) instead of always `127.0.0.1`, so executors can forward runs to the gateway that holds the worker connection.

## Migration note

No action required for single-replica deployments. For multi-replica self-hosted deployments the gateway now advertises its outbound-interface IP automatically; set `INNGEST_CONNECT_GATEWAY_GRPC_IP` (for example to the pod/task IP) to override. Ensure the server replicas can reach each other on the connect gRPC ports (50052/50053).

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
