### PR TITLE
fix(rerun-from-step): enable rerun from step everywhere

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -613,16 +613,18 @@ func idempotencyKey(req execution.ScheduleRequest, runID ulid.ULID) string {
 	return fmt.Sprintf("%s-%s", util.XXHash(req.Function.ID.String()), util.XXHash(key))
 }
 
-func rerunFromStepEdge(req execution.ScheduleRequest, memoizedSteps []state.MemoizedStep) inngest.Edge {
+func rerunFromStepEdge(req execution.ScheduleRequest, memoizedSteps []state.MemoizedStep, result *reconstructResult) inngest.Edge {
 	if req.FromStep == nil || req.FromStep.StepID == "" {
 		return inngest.SourceEdge
 	}
 
-	//
-	// IncomingGeneratorStep makes the first rerun request execute FromStep.
 	edge := inngest.Edge{
-		Incoming:              inngest.TriggerName,
-		IncomingGeneratorStep: req.FromStep.StepID,
+		Incoming: inngest.TriggerName,
+	}
+	if shouldTargetRerunFromStep(result) {
+		//
+		// Runnable steps should execute directly with any FromStep input override.
+		edge.IncomingGeneratorStep = req.FromStep.StepID
 	}
 	if len(memoizedSteps) > 0 {
 		//
@@ -630,6 +632,14 @@ func rerunFromStepEdge(req execution.ScheduleRequest, memoizedSteps []state.Memo
 		edge.Outgoing = memoizedSteps[len(memoizedSteps)-1].ID
 	}
 	return edge
+}
+
+func shouldTargetRerunFromStep(result *reconstructResult) bool {
+	if result == nil || result.fromStepOp == nil {
+		return true
+	}
+
+	return *result.fromStepOp == enums.OpcodeStep || *result.fromStepOp == enums.OpcodeStepRun
 }
 
 func (e *executor) createCancellationPauses(ctx context.Context, l logger.Logger, idempontenceKey string, evtMap map[string]any, id sv2.ID, req execution.ScheduleRequest) error {
@@ -1298,9 +1308,11 @@ func (e *executor) schedule(
 		Metadata: metadata,
 		Steps:    []state.MemoizedStep{},
 	}
+	var reconstructed *reconstructResult
 
 	if req.OriginalRunID != nil && req.FromStep != nil && req.FromStep.StepID != "" {
-		if err := reconstruct(ctx, e.traceReader, req, &newState); err != nil {
+		reconstructed, err = reconstruct(ctx, e.traceReader, req, &newState)
+		if err != nil {
 			return nil, nil, fmt.Errorf("error reconstructing input state: %w", err)
 		}
 	}
@@ -1511,8 +1523,8 @@ func (e *executor) schedule(
 		Payload: queue.PayloadEdge{
 			//
 			// Reconstruction already populated state before FromStep, so the
-			// first queue item should execute FromStep itself.
-			Edge: rerunFromStepEdge(req, newState.Steps),
+			// first queue item should start at FromStep.
+			Edge: rerunFromStepEdge(req, newState.Steps, reconstructed),
 		},
 		Throttle:  throttle,
 		Metadata:  map[string]any{},

--- a/pkg/execution/executor/reconstruct.go
+++ b/pkg/execution/executor/reconstruct.go
@@ -15,13 +15,17 @@ import (
 	"github.com/inngest/inngest/pkg/tracing/meta"
 )
 
-func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.ScheduleRequest, newState *sv2.CreateState) error {
+type reconstructResult struct {
+	fromStepOp *enums.Opcode
+}
+
+func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.ScheduleRequest, newState *sv2.CreateState) (*reconstructResult, error) {
 	root, err := tr.GetSpansByRunID(ctx, *req.OriginalRunID)
 	if err != nil {
-		return fmt.Errorf("error loading original trace spans: %w", err)
+		return nil, fmt.Errorf("error loading original trace spans: %w", err)
 	}
 	if root == nil {
-		return fmt.Errorf("original run trace not found")
+		return nil, fmt.Errorf("original run trace not found")
 	}
 
 	//
@@ -29,7 +33,11 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 	stepsToCopy, foundStepToRunFrom := reconstructSteps(root, req.FromStep.StepID)
 
 	if !foundStepToRunFrom {
-		return fmt.Errorf("step to run from not found in original run")
+		return nil, fmt.Errorf("step to run from not found in original run")
+	}
+
+	result := &reconstructResult{
+		fromStepOp: stepsToCopy.fromStepOp(),
 	}
 
 	steps := []state.MemoizedStep{}
@@ -46,20 +54,20 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 				continue
 			}
 
-			return fmt.Errorf("step output not found in original run")
+			return nil, fmt.Errorf("step output not found in original run")
 		}
 
 		var outputIdentifier cqrs.SpanIdentifier
 		if err := outputIdentifier.Decode(*outputID); err != nil {
-			return fmt.Errorf("error decoding span output ID: %w", err)
+			return nil, fmt.Errorf("error decoding span output ID: %w", err)
 		}
 		if outputIdentifier.Preview == nil || !*outputIdentifier.Preview {
-			return fmt.Errorf("span output is not trace-v2 output")
+			return nil, fmt.Errorf("span output is not trace-v2 output")
 		}
 
 		output, err := tr.GetSpanOutput(ctx, outputIdentifier)
 		if err != nil {
-			return fmt.Errorf("error loading span output: %w", err)
+			return nil, fmt.Errorf("error loading span output: %w", err)
 		}
 
 		var data any
@@ -89,17 +97,21 @@ func reconstruct(ctx context.Context, tr cqrs.TraceReader, req execution.Schedul
 		}
 	}
 
-	return nil
+	return result, nil
 }
+
+type reconstructStepsResult []reconstructStep
 
 type reconstructStep struct {
-	id       string
-	at       time.Time
-	attempt  int
-	stepSpan *cqrs.OtelSpan
+	id         string
+	at         time.Time
+	attempt    int
+	isFromStep bool
+	stepOp     *enums.Opcode
+	stepSpan   *cqrs.OtelSpan
 }
 
-func reconstructSteps(root *cqrs.OtelSpan, fromStepID string) ([]reconstructStep, bool) {
+func reconstructSteps(root *cqrs.OtelSpan, fromStepID string) (reconstructStepsResult, bool) {
 	stepsByID := map[string]reconstructStep{}
 	foundStepToRunFrom := false
 
@@ -122,10 +134,12 @@ func reconstructSteps(root *cqrs.OtelSpan, fromStepID string) ([]reconstructStep
 		}
 
 		next := reconstructStep{
-			id:       stepID,
-			at:       span.StartTime,
-			attempt:  reconstructStepAttempt(span),
-			stepSpan: span,
+			id:         stepID,
+			at:         span.StartTime,
+			attempt:    reconstructStepAttempt(span),
+			isFromStep: stepID == fromStepID,
+			stepOp:     span.Attributes.StepOp,
+			stepSpan:   span,
 		}
 
 		//
@@ -145,6 +159,15 @@ func reconstructSteps(root *cqrs.OtelSpan, fromStepID string) ([]reconstructStep
 	})
 
 	return steps, foundStepToRunFrom
+}
+
+func (r reconstructStepsResult) fromStepOp() *enums.Opcode {
+	for _, step := range r {
+		if step.isFromStep {
+			return step.stepOp
+		}
+	}
+	return nil
 }
 
 func reconstructStepPreferred(current, next reconstructStep) bool {

--- a/pkg/execution/executor/reconstruct_test.go
+++ b/pkg/execution/executor/reconstruct_test.go
@@ -33,7 +33,7 @@ func TestReconstructUsesExecutorStepSpans(t *testing.T) {
 	}
 
 	newState := &sv2.CreateState{}
-	err := reconstruct(context.Background(), fakeReconstructTraceReader{
+	_, err := reconstruct(context.Background(), fakeReconstructTraceReader{
 		root: root,
 		outputs: map[string]*cqrs.SpanOutput{
 			outputSpanID: {Data: []byte(`{"ok":true}`)},
@@ -75,7 +75,7 @@ func TestReconstructUsesHighestAttemptStepSpanForDuplicateStepIDs(t *testing.T) 
 	}
 
 	newState := &sv2.CreateState{}
-	err := reconstruct(context.Background(), fakeReconstructTraceReader{
+	_, err := reconstruct(context.Background(), fakeReconstructTraceReader{
 		root: root,
 		outputs: map[string]*cqrs.SpanOutput{
 			attempt0OutputSpanID: {Data: []byte(`"attempt 0"`)},
@@ -115,7 +115,7 @@ func TestReconstructOrdersStepsDeterministicallyWhenStartTimesMatch(t *testing.T
 	}
 
 	newState := &sv2.CreateState{}
-	err := reconstruct(context.Background(), fakeReconstructTraceReader{
+	_, err := reconstruct(context.Background(), fakeReconstructTraceReader{
 		root: root,
 		outputs: map[string]*cqrs.SpanOutput{
 			firstOutputSpanID:  {Data: []byte(`"first"`)},
@@ -150,7 +150,7 @@ func TestReconstructMemoizesSleepWithoutOutput(t *testing.T) {
 	}
 
 	newState := &sv2.CreateState{}
-	err := reconstruct(context.Background(), fakeReconstructTraceReader{root: root}, execution.ScheduleRequest{
+	_, err := reconstruct(context.Background(), fakeReconstructTraceReader{root: root}, execution.ScheduleRequest{
 		OriginalRunID: &runID,
 		FromStep: &execution.ScheduleRequestFromStep{
 			StepID: fromStepID,
@@ -179,7 +179,7 @@ func TestReconstructMemoizesTimedOutWaitWithoutOutput(t *testing.T) {
 	}
 
 	newState := &sv2.CreateState{}
-	err := reconstruct(context.Background(), fakeReconstructTraceReader{root: root}, execution.ScheduleRequest{
+	_, err := reconstruct(context.Background(), fakeReconstructTraceReader{root: root}, execution.ScheduleRequest{
 		OriginalRunID: &runID,
 		FromStep: &execution.ScheduleRequestFromStep{
 			StepID: fromStepID,
@@ -201,7 +201,7 @@ func TestReconstructPreservesFromStepInput(t *testing.T) {
 	}
 
 	newState := &sv2.CreateState{}
-	err := reconstruct(context.Background(), fakeReconstructTraceReader{root: root}, execution.ScheduleRequest{
+	_, err := reconstruct(context.Background(), fakeReconstructTraceReader{root: root}, execution.ScheduleRequest{
 		OriginalRunID: &runID,
 		FromStep: &execution.ScheduleRequestFromStep{
 			StepID: fromStepID,
@@ -215,7 +215,8 @@ func TestReconstructPreservesFromStepInput(t *testing.T) {
 	require.JSONEq(t, `[6,false]`, string(newState.StepInputs[0].Data.(json.RawMessage)))
 }
 
-func TestRerunFromStepEdgeTargetsSelectedGeneratorStep(t *testing.T) {
+func TestRerunFromStepEdgeTargetsRunnableStep(t *testing.T) {
+	stepOp := enums.OpcodeStepRun
 	edge := rerunFromStepEdge(execution.ScheduleRequest{
 		FromStep: &execution.ScheduleRequestFromStep{
 			StepID: "step-4",
@@ -224,6 +225,8 @@ func TestRerunFromStepEdgeTargetsSelectedGeneratorStep(t *testing.T) {
 		{ID: "step-1"},
 		{ID: "step-2"},
 		{ID: "step-3"},
+	}, &reconstructResult{
+		fromStepOp: &stepOp,
 	})
 
 	require.Equal(t, "step-3", edge.Outgoing)
@@ -231,12 +234,29 @@ func TestRerunFromStepEdgeTargetsSelectedGeneratorStep(t *testing.T) {
 	require.Equal(t, "step-4", edge.IncomingGeneratorStep)
 }
 
+func TestRerunFromStepEdgeDoesNotTargetPlannedStep(t *testing.T) {
+	stepOp := enums.OpcodeSleep
+	edge := rerunFromStepEdge(execution.ScheduleRequest{
+		FromStep: &execution.ScheduleRequestFromStep{
+			StepID: "sleep-step",
+		},
+	}, []state.MemoizedStep{
+		{ID: "step-1"},
+	}, &reconstructResult{
+		fromStepOp: &stepOp,
+	})
+
+	require.Equal(t, "step-1", edge.Outgoing)
+	require.Equal(t, "$trigger", edge.Incoming)
+	require.Empty(t, edge.IncomingGeneratorStep)
+}
+
 func TestRerunFromStepEdgeTargetsFirstStep(t *testing.T) {
 	edge := rerunFromStepEdge(execution.ScheduleRequest{
 		FromStep: &execution.ScheduleRequestFromStep{
 			StepID: "step-1",
 		},
-	}, nil)
+	}, nil, nil)
 
 	require.Empty(t, edge.Outgoing)
 	require.Equal(t, "$trigger", edge.Incoming)
@@ -244,7 +264,7 @@ func TestRerunFromStepEdgeTargetsFirstStep(t *testing.T) {
 }
 
 func TestRerunFromStepEdgeDefaultsToSource(t *testing.T) {
-	require.Equal(t, inngest.SourceEdge, rerunFromStepEdge(execution.ScheduleRequest{}, nil))
+	require.Equal(t, inngest.SourceEdge, rerunFromStepEdge(execution.ScheduleRequest{}, nil, nil))
 }
 
 type stepSpanOption func(*cqrs.OtelSpan)

--- a/ui/packages/components/src/RunDetailsV4/StepInfo.tsx
+++ b/ui/packages/components/src/RunDetailsV4/StepInfo.tsx
@@ -15,7 +15,6 @@ import {
 import { Pill } from '../Pill/Pill';
 import { RerunModal } from '../Rerun/RerunModal';
 import { ScoresAttrs } from '../RunDetails/ScoresAttrs';
-import { useShared } from '../SharedContext/SharedContext';
 import { useGetTraceResult } from '../SharedContext/useGetTraceResult';
 import { usePathCreator } from '../SharedContext/usePathCreator';
 import { getStatusBackgroundClass, getStatusTextClass } from '../Status/statusClasses';
@@ -179,7 +178,6 @@ export const StepInfo = ({
   debug?: boolean;
   isDurableEndpoint?: boolean;
 }) => {
-  const { cloud } = useShared();
   const [expanded, setExpanded] = useState(true);
   const [rerunModalOpen, setRerunModalOpen] = useState(false);
   const { runID, trace } = selectedStep;
@@ -215,8 +213,7 @@ export const StepInfo = ({
   const prettyOutput = usePrettyJson(result?.data ?? '') || (result?.data ?? '');
   const prettyErrorBody = usePrettyErrorBody(result?.error);
   const prettyShortError = usePrettyShortError(result?.error);
-  const showRerunFromStep =
-    !isDurableEndpoint && !debug && runID && trace.stepID && (!cloud || prettyInput);
+  const showRerunFromStep = !isDurableEndpoint && !debug && runID && trace.stepID;
   const editableInput =
     trace.stepOp === 'RUN' || trace.stepOp === 'AI_GATEWAY' || Boolean(result?.input);
 


### PR DESCRIPTION
## Description

When we got rerun from step working again we regressed non direct runnable (`step.run`) step opcodes, e.g. `sleep`, `waitFor*`. This gets those working again. 

## Release note

Enable support for rerun from step for all step types. 

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
