### PR TITLE
feat: WIP queue-proxy interface

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -585,6 +585,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		executor.WithExecutionManager(dbcqrs),
 		executor.WithState(sm),
 		executor.WithServiceQueue(rq),
+		executor.WithServiceQueueProcessor(rq),
 		executor.WithServiceExecutor(exec),
 		executor.WithServiceBatcher(batcher),
 		executor.WithServiceDebouncer(debouncer),

--- a/pkg/execution/cron/manager_test.go
+++ b/pkg/execution/cron/manager_test.go
@@ -675,6 +675,14 @@ func (p *captureProducer) Enqueue(_ context.Context, item queue.Item, at time.Ti
 	return nil
 }
 
+func (p *captureProducer) Requeue(context.Context, queue.QueueShard, queue.QueueItem, time.Time, ...queue.RequeueOptionFn) error {
+	return nil
+}
+
+func (p *captureProducer) RequeueByJobID(context.Context, queue.QueueShard, string, time.Time) error {
+	return nil
+}
+
 func TestScheduleNextQueueName(t *testing.T) {
 	ctx := context.Background()
 	accountID := uuid.New()

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -70,6 +70,12 @@ func WithServiceQueue(q queue.Queue) func(s *svc) {
 	}
 }
 
+func WithServiceQueueProcessor(q queue.QueueProcessor) func(s *svc) {
+	return func(s *svc) {
+		s.queueProcessor = q
+	}
+}
+
 func WithServiceDebouncer(d debounce.Debouncer) func(s *svc) {
 	return func(s *svc) {
 		s.debouncer = d
@@ -138,6 +144,8 @@ type svc struct {
 	state state.Manager
 	// queue allows us to enqueue next steps.
 	queue queue.Queue
+	// queueProcessor runs the function queue.
+	queueProcessor queue.QueueProcessor
 	// exec runs the specific actions.
 	exec      execution.Executor
 	debouncer debounce.Debouncer
@@ -168,6 +176,9 @@ func (s *svc) Pre(ctx context.Context) error {
 
 	if s.queue == nil {
 		return fmt.Errorf("no queue provided")
+	}
+	if s.queueProcessor == nil {
+		return fmt.Errorf("no queue processor provided")
 	}
 
 	finishHandler, err := s.getFinishHandler(ctx)
@@ -255,7 +266,7 @@ func (s *svc) isUnexpectedRunError(err error) bool {
 
 func (s *svc) Run(ctx context.Context) error {
 	s.log.Info("subscribing to function queue")
-	return s.queue.Run(logger.WithStdlib(ctx, s.log), func(ctx context.Context, info queue.RunInfo, item queue.Item) (queue.RunResult, error) {
+	return s.queueProcessor.Run(logger.WithStdlib(ctx, s.log), func(ctx context.Context, info queue.RunInfo, item queue.Item) (queue.RunResult, error) {
 		// Don't stop the service on errors.
 		s.wg.Add(1)
 		defer s.wg.Done()

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -55,63 +55,14 @@ type PartitionLeaseOptions struct{}
 type PartitionLeaseOpt func(o *PartitionLeaseOptions)
 
 type QueueManager interface {
-	JobQueueReader
 	Queue
-
-	Dequeue(ctx context.Context, queueShard QueueShard, i QueueItem, opts ...DequeueOptionFn) error
-	Requeue(ctx context.Context, queueShard QueueShard, i QueueItem, at time.Time, opts ...RequeueOptionFn) error
-	RequeueByJobID(ctx context.Context, queueShard QueueShard, jobID string, at time.Time) error
 
 	// ResetAttemptsByJobID sets retries to zero given a single job ID.  This is important for
 	// checkpointing;  a single job becomes shared amongst many  steps.
 	ResetAttemptsByJobID(ctx context.Context, shard string, scope Scope, jobID string) error
+}
 
-	// ItemsByPartition returns a queue item iterator for a function within a specific time range
-	ItemsByPartition(ctx context.Context, queueShard QueueShard, scope Scope, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
-	// ItemsByBacklog returns a queue item iterator for a backlog within a specific time range
-	ItemsByBacklog(ctx context.Context, queueShard QueueShard, backlogID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
-	// BacklogsByPartition returns an iterator for the partition's backlogs
-	BacklogsByPartition(ctx context.Context, queueShard QueueShard, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueBacklog], error)
-	// BacklogSize retrieves the number of items in the specified backlog
-	BacklogSize(ctx context.Context, queueShard QueueShard, backlogID string) (int64, error)
-	// BacklogByID retrieves a single backlog by its ID
-	BacklogByID(ctx context.Context, queueShard QueueShard, backlogID string) (*QueueBacklog, error)
-	// PartitionByID retrieves the partition by the partition ID
-	PartitionByID(ctx context.Context, queueShard QueueShard, scope Scope, partitionID string) (*PartitionInspectionResult, error)
-	// LoadQueueItem retrieves the queue item by the item ID.
-	LoadQueueItem(ctx context.Context, shardName string, itemID string) (*QueueItem, error)
-
-	// ItemExists checks if an item with jobID exists in the queue
-	ItemExists(ctx context.Context, queueShard QueueShard, scope Scope, jobID string) (bool, error)
-	// ItemsByRunID retrieves all queue items via runID
-	//
-	// NOTE
-	// The queue technically shouldn't know about runIDs, so we should make this more generic with certain type of indices in the future
-	ItemsByRunID(ctx context.Context, queueShard QueueShard, scope Scope, runID ulid.ULID) ([]*QueueItem, error)
-
-	// PartitionBacklogSize returns the point in time backlog size of the partition.
-	// This will sum the size of all backlogs in that partition
-	PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error)
-
-	// Total queue depth of all partitions including backlog and ready state items
-	TotalSystemQueueDepth(ctx context.Context, queueShard QueueShard) (int64, error)
-
-	NormalizeBacklog(ctx context.Context, backlog *QueueBacklog, sp *QueueShadowPartition, latestConstraints PartitionConstraintConfig) error
-	NormalizeItem(
-		ctx context.Context,
-		sp *QueueShadowPartition,
-		latestConstraints PartitionConstraintConfig,
-		sourceBacklog *QueueBacklog,
-		item QueueItem,
-	) (QueueItem, error)
-
-	ProcessItem(
-		ctx context.Context,
-		i ProcessItem,
-		f RunFunc,
-	) error
-	ProcessPartition(ctx context.Context, p *QueuePartition, continuationCount uint, randomOffset bool) error
-
+type KeyQueueProcessor interface {
 	ScanShadowPartitions(ctx context.Context, until time.Time, qspc chan ShadowPartitionChanMsg) error
 	ProcessShadowPartition(ctx context.Context, shadowPart *QueueShadowPartition, continuationCount uint) error
 
@@ -122,14 +73,15 @@ type QueueManager interface {
 		refillUntil time.Time,
 		constraints PartitionConstraintConfig,
 	) (*BacklogRefillResult, enums.QueueConstraint, error)
-}
 
-type QueueProcessor interface {
-	Shard() QueueShard
-	Clock() clockwork.Clock
-	Semaphore() util.TrackingSemaphore
-	Options() *QueueOptions
-	Workers() chan ProcessItem
+	NormalizeBacklog(ctx context.Context, backlog *QueueBacklog, sp *QueueShadowPartition, latestConstraints PartitionConstraintConfig) error
+	NormalizeItem(
+		ctx context.Context,
+		sp *QueueShadowPartition,
+		latestConstraints PartitionConstraintConfig,
+		sourceBacklog *QueueBacklog,
+		item QueueItem,
+	) (QueueItem, error)
 
 	ShadowPartitionWorkers() chan ShadowPartitionChanMsg
 	AddShadowContinue(ctx context.Context, p *QueueShadowPartition, ctr uint)
@@ -145,6 +97,27 @@ type QueueProcessor interface {
 		operationIdempotencyKey string,
 		now time.Time,
 	) (*BacklogRefillConstraintCheckResult, error)
+}
+
+type QueueProcessor interface {
+	KeyQueueProcessor
+
+	Shard() QueueShard
+	Clock() clockwork.Clock
+	Semaphore() util.TrackingSemaphore
+	Options() *QueueOptions
+	Workers() chan ProcessItem
+
+	// Run is a blocking function which listens to the queue and executes the
+	// given function each time a new Item becomes available.
+	//
+	// If the error from RunFunc is of type QuitError, the Run function will
+	// always requeue the job as a retry and terminate.
+	//
+	// If the error from RunFunc is of type RetryableError, the job will be
+	// re-enqueued if Retryable() returns true.  For all other errors, the
+	// job will automatically be retried.
+	Run(context.Context, RunFunc) error
 
 	ItemLeaseConstraintCheck(
 		ctx context.Context,
@@ -154,6 +127,13 @@ type QueueProcessor interface {
 		item *QueueItem,
 		now time.Time,
 	) (ItemLeaseConstraintCheckResult, error)
+
+	ProcessItem(
+		ctx context.Context,
+		i ProcessItem,
+		f RunFunc,
+	) error
+	ProcessPartition(ctx context.Context, p *QueuePartition, continuationCount uint, randomOffset bool) error
 }
 
 // SingletonOperations is the per-shard surface for singleton lock state.

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -300,19 +300,17 @@ func (q *queueProcessor) RemoveQueueItem(ctx context.Context, shardName string, 
 	return shard.RemoveQueueItem(ctx, scope, partitionID, itemID)
 }
 
-// Requeue implements QueueManager.
-func (q *queueProcessor) Requeue(ctx context.Context, shard QueueShard, i QueueItem, at time.Time, opts ...RequeueOptionFn) error {
-	return shard.Requeue(ctx, i, at, opts...)
-}
-
-// RequeueByJobID implements QueueManager.
-func (q *queueProcessor) RequeueByJobID(ctx context.Context, shard QueueShard, jobID string, at time.Time) error {
-	return shard.RequeueByJobID(ctx, jobID, at)
-}
-
 // Enqueue implements QueueManager.
 func (q *queueProcessor) Enqueue(ctx context.Context, item Item, at time.Time, opts EnqueueOpts) error {
 	return q.queueProducer.Enqueue(ctx, item, at, opts)
+}
+
+func (q *queueProcessor) Requeue(ctx context.Context, shard QueueShard, i QueueItem, at time.Time, opts ...RequeueOptionFn) error {
+	return q.queueProducer.Requeue(ctx, shard, i, at, opts...)
+}
+
+func (q *queueProcessor) RequeueByJobID(ctx context.Context, shard QueueShard, jobID string, at time.Time) error {
+	return q.queueProducer.RequeueByJobID(ctx, shard, jobID, at)
 }
 
 // TotalSystemQueueDepth implements QueueManager.

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -41,6 +41,38 @@ func (m *mockQueueProcessor) ShadowPartitionWorkers() chan ShadowPartitionChanMs
 func (m *mockQueueProcessor) AddShadowContinue(ctx context.Context, p *QueueShadowPartition, ctr uint) {
 }
 
+func (m *mockQueueProcessor) Run(context.Context, RunFunc) error {
+	return nil
+}
+
+func (m *mockQueueProcessor) ProcessItem(context.Context, ProcessItem, RunFunc) error {
+	return nil
+}
+
+func (m *mockQueueProcessor) ProcessPartition(context.Context, *QueuePartition, uint, bool) error {
+	return nil
+}
+
+func (m *mockQueueProcessor) ScanShadowPartitions(context.Context, time.Time, chan ShadowPartitionChanMsg) error {
+	return nil
+}
+
+func (m *mockQueueProcessor) ProcessShadowPartition(context.Context, *QueueShadowPartition, uint) error {
+	return nil
+}
+
+func (m *mockQueueProcessor) ProcessShadowPartitionBacklog(context.Context, *QueueShadowPartition, *QueueBacklog, time.Time, PartitionConstraintConfig) (*BacklogRefillResult, enums.QueueConstraint, error) {
+	return nil, enums.QueueConstraintNotLimited, nil
+}
+
+func (m *mockQueueProcessor) NormalizeBacklog(context.Context, *QueueBacklog, *QueueShadowPartition, PartitionConstraintConfig) error {
+	return nil
+}
+
+func (m *mockQueueProcessor) NormalizeItem(context.Context, *QueueShadowPartition, PartitionConstraintConfig, *QueueBacklog, QueueItem) (QueueItem, error) {
+	return QueueItem{}, nil
+}
+
 func (m *mockQueueProcessor) GetShadowContinuations() map[string]ShadowContinuation {
 	m.shadowMu.Lock()
 	defer m.shadowMu.Unlock()

--- a/pkg/execution/queue/processor_test.go
+++ b/pkg/execution/queue/processor_test.go
@@ -20,6 +20,14 @@ func (m *mockProducer) Enqueue(context.Context, Item, time.Time, EnqueueOpts) er
 	return nil
 }
 
+func (m *mockProducer) Requeue(context.Context, QueueShard, QueueItem, time.Time, ...RequeueOptionFn) error {
+	return nil
+}
+
+func (m *mockProducer) RequeueByJobID(context.Context, QueueShard, string, time.Time) error {
+	return nil
+}
+
 func TestProcessorWithQueueProducerOverridesDefaultProducer(t *testing.T) {
 	ctx := context.Background()
 	shard := &mockShardForIterator{name: "shard-a"}

--- a/pkg/execution/queue/producer.go
+++ b/pkg/execution/queue/producer.go
@@ -1,6 +1,9 @@
 package queue
 
 import (
+	"context"
+	"time"
+
 	"github.com/inngest/inngest/pkg/telemetry/trace"
 	"github.com/jonboulle/clockwork"
 )
@@ -60,4 +63,14 @@ func NewProducer(
 
 func (q *queueProducer) Clock() clockwork.Clock {
 	return q.clock
+}
+
+// Requeue implements QueueManager.
+func (q *queueProducer) Requeue(ctx context.Context, shard QueueShard, i QueueItem, at time.Time, opts ...RequeueOptionFn) error {
+	return shard.Requeue(ctx, i, at, opts...)
+}
+
+// RequeueByJobID implements QueueManager.
+func (q *queueProducer) RequeueByJobID(ctx context.Context, shard QueueShard, jobID string, at time.Time) error {
+	return shard.RequeueByJobID(ctx, jobID, at)
 }

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"time"
 
 	"github.com/google/uuid"
@@ -66,19 +67,16 @@ type EnqueueOpts struct {
 type Producer interface {
 	// Enqueue allows an item to be enqueued ton run at the given time.
 	Enqueue(context.Context, Item, time.Time, EnqueueOpts) error
+
+	// TODO(lakshmi) Document, and change queueShard to queue.Scope/shardName/remove it
+	Requeue(ctx context.Context, queueShard QueueShard, i QueueItem, at time.Time, opts ...RequeueOptionFn) error
+
+	// TODO(lakshmi) Document, and change queueShard to queue.Scope/shardName/remove it
+	RequeueByJobID(ctx context.Context, queueShard QueueShard, jobID string, at time.Time) error
 }
 
 type Consumer interface {
-	// Run is a blocking function which listens to the queue and executes the
-	// given function each time a new Item becomes available.
-	//
-	// If the error from RunFunc is of type QuitError, the Run function will
-	// always requeue the job as a retry and terminate.
-	//
-	// If the error from RunFunc is of type RetryableError, the job will be
-	// re-enqueued if Retryable() returns true.  For all other errors, the
-	// job will automatically be retried.
-	Run(context.Context, RunFunc) error
+	Dequeue(ctx context.Context, queueShard QueueShard, i QueueItem, opts ...DequeueOptionFn) error
 }
 
 type RoleStatusReader interface {
@@ -244,6 +242,36 @@ type JobQueueReader interface {
 
 	// RunJobs reads items in the queue for a specific run.
 	RunJobs(ctx context.Context, queueShardName string, scope Scope, runID ulid.ULID, limit, offset int64) ([]JobResponse, error)
+
+	// ItemsByPartition returns a queue item iterator for a function within a specific time range
+	ItemsByPartition(ctx context.Context, queueShard QueueShard, scope Scope, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
+	// ItemsByBacklog returns a queue item iterator for a backlog within a specific time range
+	ItemsByBacklog(ctx context.Context, queueShard QueueShard, backlogID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error)
+	// BacklogsByPartition returns an iterator for the partition's backlogs
+	BacklogsByPartition(ctx context.Context, queueShard QueueShard, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueBacklog], error)
+	// BacklogSize retrieves the number of items in the specified backlog
+	BacklogSize(ctx context.Context, queueShard QueueShard, backlogID string) (int64, error)
+	// BacklogByID retrieves a single backlog by its ID
+	BacklogByID(ctx context.Context, queueShard QueueShard, backlogID string) (*QueueBacklog, error)
+	// PartitionByID retrieves the partition by the partition ID
+	PartitionByID(ctx context.Context, queueShard QueueShard, scope Scope, partitionID string) (*PartitionInspectionResult, error)
+	// LoadQueueItem retrieves the queue item by the item ID.
+	LoadQueueItem(ctx context.Context, shardName string, itemID string) (*QueueItem, error)
+
+	// ItemExists checks if an item with jobID exists in the queue
+	ItemExists(ctx context.Context, queueShard QueueShard, scope Scope, jobID string) (bool, error)
+	// ItemsByRunID retrieves all queue items via runID
+	//
+	// NOTE
+	// The queue technically shouldn't know about runIDs, so we should make this more generic with certain type of indices in the future
+	ItemsByRunID(ctx context.Context, queueShard QueueShard, scope Scope, runID ulid.ULID) ([]*QueueItem, error)
+
+	// PartitionBacklogSize returns the point in time backlog size of the partition.
+	// This will sum the size of all backlogs in that partition
+	PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error)
+
+	// Total queue depth of all partitions including backlog and ready state items
+	TotalSystemQueueDepth(ctx context.Context, queueShard QueueShard) (int64, error)
 }
 
 // MigratePayload stores the information to be used when migrating a queue shard to another one

--- a/tests/execution/executor/executor_test.go
+++ b/tests/execution/executor/executor_test.go
@@ -101,10 +101,9 @@ func (fq *fakeQueue) reset() {
 	fq.lock.Unlock()
 }
 
-func (fq *fakeQueue) Dequeue(ctx context.Context, queueShard redis_state.RedisQueueShard, i queue.QueueItem) error {
-	qm := fq.Queue.(queue.QueueManager)
+func (fq *fakeQueue) Dequeue(ctx context.Context, queueShard queue.QueueShard, i queue.QueueItem, opts ...queue.DequeueOptionFn) error {
 
-	err := qm.Dequeue(ctx, queueShard, i)
+	err := fq.Queue.Dequeue(ctx, queueShard, i, opts...)
 
 	fq.lock.Lock()
 	logger.StdlibLogger(ctx).Info("called fakeQueue.Dequeue()", "i", i, "err", err)

--- a/tests/execution/queue/role_e2e_test.go
+++ b/tests/execution/queue/role_e2e_test.go
@@ -26,7 +26,7 @@ func TestQueueRoleRequiresRoleLease(t *testing.T) {
 		runInterval:   20 * time.Millisecond,
 	}
 
-	_, rc, q, shard := newRoleQueue(t, role, osqueue.QueueRunMode{})
+	_, rc, qp, qm, shard := newRoleQueue(t, role, osqueue.QueueRunMode{})
 	defer rc.Close()
 
 	leaseID, err := shard.RoleLease(ctx, role.Name(), role.LeaseDuration())
@@ -34,7 +34,7 @@ func TestQueueRoleRequiresRoleLease(t *testing.T) {
 	require.NotNil(t, leaseID)
 
 	runCtx, cancel := context.WithCancel(ctx)
-	done := runQueueForRoleTest(runCtx, q, nil)
+	done := runQueueForRoleTest(runCtx, qp, nil)
 	defer func() {
 		cancel()
 		requireQueueStopped(t, done)
@@ -43,7 +43,7 @@ func TestQueueRoleRequiresRoleLease(t *testing.T) {
 	require.Never(t, func() bool {
 		return role.runCount.Load() > 0
 	}, 100*time.Millisecond, 5*time.Millisecond)
-	require.Nil(t, activeRoleStatus(q, role.Name()))
+	require.Nil(t, activeRoleStatus(qm, role.Name()))
 }
 
 func TestQueueRoleRenewKeepsRoleActive(t *testing.T) {
@@ -54,24 +54,24 @@ func TestQueueRoleRenewKeepsRoleActive(t *testing.T) {
 		runInterval:   25 * time.Millisecond,
 	}
 
-	_, rc, q, _ := newRoleQueue(t, role, osqueue.QueueRunMode{})
+	_, rc, qp, qm, _ := newRoleQueue(t, role, osqueue.QueueRunMode{})
 	defer rc.Close()
 
 	runCtx, cancel := context.WithCancel(ctx)
-	done := runQueueForRoleTest(runCtx, q, nil)
+	done := runQueueForRoleTest(runCtx, qp, nil)
 	defer func() {
 		cancel()
 		requireQueueStopped(t, done)
 	}()
 
 	require.Eventually(t, func() bool {
-		return activeRoleStatus(q, role.Name()) != nil && role.runCount.Load() > 0
+		return activeRoleStatus(qm, role.Name()) != nil && role.runCount.Load() > 0
 	}, time.Second, 5*time.Millisecond)
 
-	firstLease := activeRoleStatus(q, role.Name()).LeaseID
+	firstLease := activeRoleStatus(qm, role.Name()).LeaseID
 
 	require.Eventually(t, func() bool {
-		status := activeRoleStatus(q, role.Name())
+		status := activeRoleStatus(qm, role.Name())
 		return status != nil && status.LeaseID != firstLease
 	}, time.Second, 5*time.Millisecond)
 	require.Greater(t, role.runCount.Load(), int32(1))
@@ -85,25 +85,25 @@ func TestQueueRoleStopsRunningAfterLeaseLoss(t *testing.T) {
 		runInterval:   20 * time.Millisecond,
 	}
 
-	r, rc, q, _ := newRoleQueue(t, role, osqueue.QueueRunMode{})
+	r, rc, qp, qm, _ := newRoleQueue(t, role, osqueue.QueueRunMode{})
 	defer rc.Close()
 
 	runCtx, cancel := context.WithCancel(ctx)
-	done := runQueueForRoleTest(runCtx, q, nil)
+	done := runQueueForRoleTest(runCtx, qp, nil)
 	defer func() {
 		cancel()
 		requireQueueStopped(t, done)
 	}()
 
 	require.Eventually(t, func() bool {
-		return activeRoleStatus(q, role.Name()) != nil && role.runCount.Load() > 0
+		return activeRoleStatus(qm, role.Name()) != nil && role.runCount.Load() > 0
 	}, time.Second, 5*time.Millisecond)
 
 	otherLease := ulid.MustNew(ulid.Timestamp(time.Now().Add(time.Second)), rand.Reader)
 	require.NoError(t, r.Set(roleLeaseKey(role.Name()), otherLease.String()))
 
 	require.Eventually(t, func() bool {
-		return activeRoleStatus(q, role.Name()) == nil
+		return activeRoleStatus(qm, role.Name()) == nil
 	}, time.Second, 5*time.Millisecond)
 
 	afterLoss := role.runCount.Load()
@@ -121,14 +121,14 @@ func TestQueueRoleCanExcludeScanning(t *testing.T) {
 		excludesScanning: true,
 	}
 
-	_, rc, q, _ := newRoleQueue(t, role, osqueue.QueueRunMode{
+	_, rc, qp, qm, _ := newRoleQueue(t, role, osqueue.QueueRunMode{
 		Partition: true,
 	})
 	defer rc.Close()
 
 	var processed atomic.Int32
 	runCtx, cancel := context.WithCancel(ctx)
-	done := runQueueForRoleTest(runCtx, q, func(ctx context.Context, info osqueue.RunInfo, item osqueue.Item) (osqueue.RunResult, error) {
+	done := runQueueForRoleTest(runCtx, qp, func(ctx context.Context, info osqueue.RunInfo, item osqueue.Item) (osqueue.RunResult, error) {
 		processed.Add(1)
 		return osqueue.RunResult{}, nil
 	})
@@ -138,11 +138,11 @@ func TestQueueRoleCanExcludeScanning(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return activeRoleStatus(q, role.Name()) != nil
+		return activeRoleStatus(qm, role.Name()) != nil
 	}, time.Second, 5*time.Millisecond)
 
 	item := roleTestItem()
-	require.NoError(t, q.Enqueue(ctx, item, time.Now(), osqueue.EnqueueOpts{}))
+	require.NoError(t, qm.Enqueue(ctx, item, time.Now(), osqueue.EnqueueOpts{}))
 
 	require.Never(t, func() bool {
 		return processed.Load() > 0
@@ -181,7 +181,7 @@ func (r *testQueueRole) Run(ctx context.Context, shard osqueue.QueueShard) error
 func (r *testQueueRole) OnLeaseTick(ctx context.Context, shard osqueue.QueueShard) {
 }
 
-func newRoleQueue(t *testing.T, role osqueue.QueueRole, runMode osqueue.QueueRunMode) (*miniredis.Miniredis, rueidis.Client, osqueue.Queue, osqueue.QueueShard) {
+func newRoleQueue(t *testing.T, role osqueue.QueueRole, runMode osqueue.QueueRunMode) (*miniredis.Miniredis, rueidis.Client, osqueue.QueueProcessor, osqueue.QueueManager, osqueue.QueueShard) {
 	t.Helper()
 
 	r := miniredis.RunT(t)
@@ -205,10 +205,10 @@ func newRoleQueue(t *testing.T, role osqueue.QueueRole, runMode osqueue.QueueRun
 	q, err := osqueue.New(context.Background(), "test", registry, options...)
 	require.NoError(t, err)
 
-	return r, rc, q, shard
+	return r, rc, q, q, shard
 }
 
-func runQueueForRoleTest(ctx context.Context, q osqueue.Queue, f osqueue.RunFunc) chan struct{} {
+func runQueueForRoleTest(ctx context.Context, q osqueue.QueueProcessor, f osqueue.RunFunc) chan struct{} {
 	if f == nil {
 		f = func(ctx context.Context, info osqueue.RunInfo, item osqueue.Item) (osqueue.RunResult, error) {
 			return osqueue.RunResult{}, nil


### PR DESCRIPTION
## Description

Separate QueueManager and QueueProcessor interfaces based on their respective responsibilities.

All pure access to queue remains on the QueueManager interface.

All processing functions are now on the QueueProcessor interface.

TODO:
- [ ] construct separate qp and qm concrete objects
- [ ] add a grpc interface for QueueManager

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
