### PR TITLE
revert: always SavePending after parallel ops to coalesce discovery (#4021)

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3594,17 +3594,8 @@ func (e *executor) HandleGeneratorResponse(ctx context.Context, i *runInstance, 
 		groups.OtherGroup.ParallelCoalesceKey = ck
 	}
 
-	// Save pending step IDs so that SaveStep can atomically track which
-	// parallel branches are still outstanding.  When the last branch
-	// completes, SaveStep returns hasPendingSteps=false and a single
-	// discovery step is enqueued.
-	//
-	// Previously this was gated on ShouldCoalesceParallelism (RequestVersion
-	// >= 2), which left the pending set empty for older SDKs.  With an empty
-	// pending set every step completion saw hasPendingSteps=false and
-	// enqueued its own discovery step, causing the final sequential step
-	// after a parallel group to execute more than once.
-	if hasPlanOp(resp.Generator) && len(nonLazyIDs) > 1 {
+	// We only save pending steps if there's >= 1 step planned op.
+	if hasPlanOp(resp.Generator) && len(nonLazyIDs) > 1 && i.md.ShouldCoalesceParallelism(resp) {
 		if err := e.smv2.SavePending(ctx, i.md.ID, nonLazyIDs); err != nil {
 			return fmt.Errorf("error saving pending steps: %w", err)
 		}

--- a/tests/golang/parallel_test.go
+++ b/tests/golang/parallel_test.go
@@ -319,8 +319,13 @@ func TestParallelSequential(t *testing.T) {
 	r.Equal(int32(1), atomic.LoadInt32(&counterB2))
 
 	// a2 completes after b1 because "optimized parallelism" doesn't continue
-	// until all parallel steps end.
-	r.Equal([]string{"a1", "b1", "a2", "b2", "end"}, stepOrder)
+	// until all parallel steps end.  The trailing "end" evaluation can replay
+	// during discovery, so only the step ordering itself is stable.
+	r.GreaterOrEqual(len(stepOrder), 5)
+	r.Equal([]string{"a1", "b1", "a2", "b2"}, stepOrder[:4])
+	for _, item := range stepOrder[4:] {
+		r.Equal("end", item)
+	}
 }
 
 func TestParallelDisabledOptimization(t *testing.T) {


### PR DESCRIPTION

## Description
Reverts: #4021 because of parallel steps behavior regression for old request versions

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
