### PR TITLE
fix: revert always SavePending after parallel ops to coalesce discovery (#4021)

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3595,8 +3595,8 @@ func (e *executor) HandleGeneratorResponse(ctx context.Context, i *runInstance, 
 	}
 
 	// We only save pending steps if there's >= 1 step planned op.
-	if hasPlanOp(resp.Generator) && len(nonLazyIDs) > 1 && i.md.ShouldCoalesceParallelism(resp) {
-		if err := e.smv2.SavePending(ctx, i.md.ID, nonLazyIDs); err != nil {
+	if hasPlanOp(resp.Generator) && i.md.ShouldCoalesceParallelism(resp) {
+		if err := e.smv2.SavePending(ctx, i.md.ID, groups.NonLazyIDs()); err != nil {
 			return fmt.Errorf("error saving pending steps: %w", err)
 		}
 	}


### PR DESCRIPTION
## Description

maybe reverts commit 062d25d69b8aeaaab961a85dcf6495ffaf88c57a.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
