### PR TITLE
fix: should not coalesce parallel steps for the V1 execution engine

### DIFF
--- a/pkg/execution/executor/discovery_coalesce_test.go
+++ b/pkg/execution/executor/discovery_coalesce_test.go
@@ -177,6 +177,110 @@ func TestResumeCoalesceJobID(t *testing.T) {
 	}
 }
 
+// trackingRunSvc records SavePending invocations so tests can assert whether
+// pending-step tracking was populated for a given batch.
+type trackingRunSvc struct {
+	sv2.RunService
+	savePendingCalls [][]string
+}
+
+func (s *trackingRunSvc) UpdateMetadata(_ context.Context, _ sv2.ID, _ sv2.MutableConfig) error {
+	return nil
+}
+func (s *trackingRunSvc) SavePending(_ context.Context, _ sv2.ID, pending []string) error {
+	s.savePendingCalls = append(s.savePendingCalls, pending)
+	return nil
+}
+
+// Regression: when ShouldCoalesceParallelism is false (SDK reports V1),
+// the coalesce key must stay off the queue items. Otherwise concurrent
+// fan-in completions silently dedup on the same JobID while SaveSteps are
+// still in flight, and the surviving discovery runs against incomplete state.
+func TestHandleGeneratorResponse_NoCoalesceKeyWhenSDKReportsV1(t *testing.T) {
+	runID := ulid.MustNew(ulid.Now(), nil)
+	wsID, fnID, aID := uuid.New(), uuid.New(), uuid.New()
+
+	svc := &trackingRunSvc{}
+	q := &dedupeQueue{}
+	e := &executor{
+		smv2:           svc,
+		queue:          q,
+		log:            logger.From(context.Background()),
+		tracerProvider: tracing.NewNoopTracerProvider(),
+	}
+
+	md := sv2.Metadata{
+		ID:     sv2.ID{RunID: runID, FunctionID: fnID, Tenant: sv2.Tenant{EnvID: wsID, AccountID: aID}},
+		Config: *sv2.InitConfig(&sv2.Config{RequestVersion: 1}),
+	}
+	i := &runInstance{
+		md:   md,
+		edge: inngest.Edge{Incoming: "step"},
+		item: queue.Item{Payload: queue.PayloadEdge{Edge: inngest.Edge{Incoming: "step"}}},
+	}
+
+	stepIDs := []string{"step-a", "step-b", "step-c"}
+	gen := make([]*state.GeneratorOpcode, 0, len(stepIDs))
+	for _, id := range stepIDs {
+		gen = append(gen, &state.GeneratorOpcode{Op: enums.OpcodeStepPlanned, ID: id})
+	}
+	resp := &state.DriverResponse{Generator: gen, RequestVersion: 1}
+
+	require.NoError(t, e.HandleGeneratorResponse(context.Background(), i, resp))
+
+	require.Empty(t, svc.savePendingCalls, "SavePending must not be called when SDK reports V1")
+	require.Len(t, q.enqueued, len(stepIDs))
+	for _, item := range q.enqueued {
+		require.Nil(t, item.ParallelCoalesceKey,
+			"queue items must not carry a ParallelCoalesceKey when SDK reports V1 — silent dedup would wedge the run")
+	}
+}
+
+// Under V2, SavePending is called and every queue item carries the same
+// coalesce key, so concurrent fan-in completions safely dedup on one discovery.
+func TestHandleGeneratorResponse_StampsCoalesceKeyWhenSDKReportsV2(t *testing.T) {
+	runID := ulid.MustNew(ulid.Now(), nil)
+	wsID, fnID, aID := uuid.New(), uuid.New(), uuid.New()
+
+	svc := &trackingRunSvc{}
+	q := &dedupeQueue{}
+	e := &executor{
+		smv2:           svc,
+		queue:          q,
+		log:            logger.From(context.Background()),
+		tracerProvider: tracing.NewNoopTracerProvider(),
+	}
+
+	md := sv2.Metadata{
+		ID:     sv2.ID{RunID: runID, FunctionID: fnID, Tenant: sv2.Tenant{EnvID: wsID, AccountID: aID}},
+		Config: *sv2.InitConfig(&sv2.Config{RequestVersion: 2}),
+	}
+	i := &runInstance{
+		md:   md,
+		edge: inngest.Edge{Incoming: "step"},
+		item: queue.Item{Payload: queue.PayloadEdge{Edge: inngest.Edge{Incoming: "step"}}},
+	}
+
+	stepIDs := []string{"step-a", "step-b", "step-c"}
+	gen := make([]*state.GeneratorOpcode, 0, len(stepIDs))
+	for _, id := range stepIDs {
+		gen = append(gen, &state.GeneratorOpcode{Op: enums.OpcodeStepPlanned, ID: id})
+	}
+	resp := &state.DriverResponse{Generator: gen, RequestVersion: 2}
+
+	require.NoError(t, e.HandleGeneratorResponse(context.Background(), i, resp))
+
+	require.Len(t, svc.savePendingCalls, 1, "SavePending must be called exactly once for a parallel batch under V2")
+	require.ElementsMatch(t, stepIDs, svc.savePendingCalls[0])
+
+	expectedCK := computeParallelCoalesceKey(runID.String(), stepIDs)
+	require.Len(t, q.enqueued, len(stepIDs))
+	for _, item := range q.enqueued {
+		require.NotNil(t, item.ParallelCoalesceKey, "queue items must carry a ParallelCoalesceKey under V2")
+		require.Equal(t, expectedCK, *item.ParallelCoalesceKey, "all items in the batch must share the same coalesce key")
+	}
+}
+
 // TestAIGatewayCoalesceJobID verifies that concurrent AIGateway completions in the same
 // parallel batch coalesce to a single discovery enqueue even when SaveStep's non-atomic
 // pending check lets both see hasPendingSteps=false.

--- a/pkg/execution/executor/discovery_coalesce_test.go
+++ b/pkg/execution/executor/discovery_coalesce_test.go
@@ -192,13 +192,14 @@ func (s *trackingRunSvc) SavePending(_ context.Context, _ sv2.ID, pending []stri
 	return nil
 }
 
-// Regression: when ShouldCoalesceParallelism is false (SDK reports V1),
-// the coalesce key must stay off the queue items. Otherwise concurrent
-// fan-in completions silently dedup on the same JobID while SaveSteps are
-// still in flight, and the surviving discovery runs against incomplete state.
-func TestHandleGeneratorResponse_NoCoalesceKeyWhenSDKReportsV1(t *testing.T) {
+func TestHandleGeneratorResponse_CoalesceKeyBySDKRequestVersion(t *testing.T) {
 	runID := ulid.MustNew(ulid.Now(), nil)
 	wsID, fnID, aID := uuid.New(), uuid.New(), uuid.New()
+	stepIDs := []string{"step-a", "step-b", "step-c"}
+	gen := make([]*state.GeneratorOpcode, 0, len(stepIDs))
+	for _, id := range stepIDs {
+		gen = append(gen, &state.GeneratorOpcode{Op: enums.OpcodeStepPlanned, ID: id})
+	}
 
 	svc := &trackingRunSvc{}
 	q := &dedupeQueue{}
@@ -211,74 +212,51 @@ func TestHandleGeneratorResponse_NoCoalesceKeyWhenSDKReportsV1(t *testing.T) {
 
 	md := sv2.Metadata{
 		ID:     sv2.ID{RunID: runID, FunctionID: fnID, Tenant: sv2.Tenant{EnvID: wsID, AccountID: aID}},
-		Config: *sv2.InitConfig(&sv2.Config{RequestVersion: 1}),
+		Config: *sv2.InitConfig(&sv2.Config{}),
 	}
 	i := &runInstance{
 		md:   md,
 		edge: inngest.Edge{Incoming: "step"},
 		item: queue.Item{Payload: queue.PayloadEdge{Edge: inngest.Edge{Incoming: "step"}}},
 	}
+	resp := &state.DriverResponse{Generator: gen}
 
-	stepIDs := []string{"step-a", "step-b", "step-c"}
-	gen := make([]*state.GeneratorOpcode, 0, len(stepIDs))
-	for _, id := range stepIDs {
-		gen = append(gen, &state.GeneratorOpcode{Op: enums.OpcodeStepPlanned, ID: id})
-	}
-	resp := &state.DriverResponse{Generator: gen, RequestVersion: 1}
+	t.Run("omits coalesce key for SDK request version 1", func(t *testing.T) {
+		sdkRequestVersion := 1
+		svc.savePendingCalls = nil
+		q.enqueued = nil
+		i.md.Config.RequestVersion = sdkRequestVersion
+		resp.RequestVersion = sdkRequestVersion
 
-	require.NoError(t, e.HandleGeneratorResponse(context.Background(), i, resp))
+		require.NoError(t, e.HandleGeneratorResponse(context.Background(), i, resp))
 
-	require.Empty(t, svc.savePendingCalls, "SavePending must not be called when SDK reports V1")
-	require.Len(t, q.enqueued, len(stepIDs))
-	for _, item := range q.enqueued {
-		require.Nil(t, item.ParallelCoalesceKey,
-			"queue items must not carry a ParallelCoalesceKey when SDK reports V1 — silent dedup would wedge the run")
-	}
-}
+		require.Empty(t, svc.savePendingCalls, "SavePending must not be called when SDK reports V1")
+		require.Len(t, q.enqueued, len(stepIDs))
+		for _, item := range q.enqueued {
+			require.Nil(t, item.ParallelCoalesceKey,
+				"queue items must not carry a ParallelCoalesceKey when SDK reports V1 — silent dedup would wedge the run")
+		}
+	})
 
-// Under V2, SavePending is called and every queue item carries the same
-// coalesce key, so concurrent fan-in completions safely dedup on one discovery.
-func TestHandleGeneratorResponse_StampsCoalesceKeyWhenSDKReportsV2(t *testing.T) {
-	runID := ulid.MustNew(ulid.Now(), nil)
-	wsID, fnID, aID := uuid.New(), uuid.New(), uuid.New()
+	t.Run("stamps shared coalesce key for SDK request version 2", func(t *testing.T) {
+		sdkRequestVersion := 2
+		svc.savePendingCalls = nil
+		q.enqueued = nil
+		i.md.Config.RequestVersion = sdkRequestVersion
+		resp.RequestVersion = sdkRequestVersion
 
-	svc := &trackingRunSvc{}
-	q := &dedupeQueue{}
-	e := &executor{
-		smv2:           svc,
-		queue:          q,
-		log:            logger.From(context.Background()),
-		tracerProvider: tracing.NewNoopTracerProvider(),
-	}
+		require.NoError(t, e.HandleGeneratorResponse(context.Background(), i, resp))
 
-	md := sv2.Metadata{
-		ID:     sv2.ID{RunID: runID, FunctionID: fnID, Tenant: sv2.Tenant{EnvID: wsID, AccountID: aID}},
-		Config: *sv2.InitConfig(&sv2.Config{RequestVersion: 2}),
-	}
-	i := &runInstance{
-		md:   md,
-		edge: inngest.Edge{Incoming: "step"},
-		item: queue.Item{Payload: queue.PayloadEdge{Edge: inngest.Edge{Incoming: "step"}}},
-	}
+		require.Len(t, svc.savePendingCalls, 1, "SavePending must be called exactly once for a parallel batch under V2")
+		require.ElementsMatch(t, stepIDs, svc.savePendingCalls[0])
 
-	stepIDs := []string{"step-a", "step-b", "step-c"}
-	gen := make([]*state.GeneratorOpcode, 0, len(stepIDs))
-	for _, id := range stepIDs {
-		gen = append(gen, &state.GeneratorOpcode{Op: enums.OpcodeStepPlanned, ID: id})
-	}
-	resp := &state.DriverResponse{Generator: gen, RequestVersion: 2}
-
-	require.NoError(t, e.HandleGeneratorResponse(context.Background(), i, resp))
-
-	require.Len(t, svc.savePendingCalls, 1, "SavePending must be called exactly once for a parallel batch under V2")
-	require.ElementsMatch(t, stepIDs, svc.savePendingCalls[0])
-
-	expectedCK := computeParallelCoalesceKey(runID.String(), stepIDs)
-	require.Len(t, q.enqueued, len(stepIDs))
-	for _, item := range q.enqueued {
-		require.NotNil(t, item.ParallelCoalesceKey, "queue items must carry a ParallelCoalesceKey under V2")
-		require.Equal(t, expectedCK, *item.ParallelCoalesceKey, "all items in the batch must share the same coalesce key")
-	}
+		expectedCK := computeParallelCoalesceKey(runID.String(), stepIDs)
+		require.Len(t, q.enqueued, len(stepIDs))
+		for _, item := range q.enqueued {
+			require.NotNil(t, item.ParallelCoalesceKey, "queue items must carry a ParallelCoalesceKey under V2")
+			require.Equal(t, expectedCK, *item.ParallelCoalesceKey, "all items in the batch must share the same coalesce key")
+		}
+	})
 }
 
 // TestAIGatewayCoalesceJobID verifies that concurrent AIGateway completions in the same

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3644,10 +3644,11 @@ func (e *executor) handleGeneratorGroup(ctx context.Context, i *runInstance, gro
 			continue
 		}
 		copied := *op
+		runInstanceCopy := *i
 		if group.ShouldStartHistoryGroup {
 			// Give each opcode its own group ID, since we want to track each
 			// parallel step individually.
-			i.item.GroupID = uuid.New().String()
+			runInstanceCopy.item.GroupID = uuid.New().String()
 		}
 		eg.Go(func() error {
 			defer func() {
@@ -3659,7 +3660,7 @@ func (e *executor) handleGeneratorGroup(ctx context.Context, i *runInstance, gro
 					)
 				}
 			}()
-			return e.handleGeneratorOp(ctx, i, copied, group)
+			return e.handleGeneratorOp(ctx, &runInstanceCopy, copied, group)
 		})
 	}
 	if err := eg.Wait(); err != nil {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3276,6 +3276,13 @@ func (e *executor) ResumePauseTimeout(ctx context.Context, pause state.Pause, r 
 		err = e.queue.Enqueue(ctx, nextItem, e.now(), queue.EnqueueOpts{})
 		if err != nil {
 			if errors.Is(err, queue.ErrQueueItemExists) {
+				if pause.ParallelCoalesceKey != "" && pause.ParallelMode != enums.ParallelModeRace {
+					e.log.Debug("discovery enqueue after pause timeout deduped via coalesce key",
+						"run_id", md.ID.RunID.String(),
+						"job_id", jobID,
+						"coalesce_key", pause.ParallelCoalesceKey,
+					)
+				}
 				nextStepSpan.Drop()
 			} else {
 				_ = nextStepSpan.Send()
@@ -3452,12 +3459,25 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 				return nil
 			}
 
-			if err != nil && !errors.Is(err, queue.ErrQueueItemExists) {
-				nextStepSpan.Drop()
-				return fmt.Errorf("error enqueueing after pause: %w", err)
+			if err != nil {
+				if errors.Is(err, queue.ErrQueueItemExists) {
+					if pause.ParallelCoalesceKey != "" && pause.ParallelMode != enums.ParallelModeRace {
+						e.log.Debug("discovery enqueue after pause resume deduped via coalesce key",
+							"run_id", md.ID.RunID.String(),
+							"job_id", jobID,
+							"coalesce_key", pause.ParallelCoalesceKey,
+							"parallel_mode", pause.ParallelMode,
+						)
+					}
+					// Another handler enqueued the discovery item; let it emit the span.
+					nextStepSpan.Drop()
+				} else {
+					nextStepSpan.Drop()
+					return fmt.Errorf("error enqueueing after pause: %w", err)
+				}
+			} else {
+				_ = nextStepSpan.Send()
 			}
-			// on successful enqueue, send the span
-			_ = nextStepSpan.Send()
 		}
 
 		// Only run lifecycles if we consumed the pause and enqueued next step.
@@ -3588,14 +3608,17 @@ func (e *executor) HandleGeneratorResponse(ctx context.Context, i *runInstance, 
 	// shared by all queue items in this batch.  Every concurrent fan-in
 	// completion will derive the same discovery JobID from this key, so the
 	// queue's idempotency check ensures only one discovery step is enqueued.
-	if len(nonLazyIDs) > 1 {
+	//
+	// Coalesce key and SavePending must agree.  Without SavePending populating
+	// pending_steps, every completion sees hasPendingSteps=false and races to
+	// enqueue discovery on the same coalesced JobID; one wins and the rest are
+	// silently deduped while their SaveSteps are still in flight, so the
+	// surviving discovery executes against incomplete state and the run wedges.
+	if hasPlanOp(resp.Generator) && len(nonLazyIDs) > 1 && i.md.ShouldCoalesceParallelism(resp) {
 		ck := computeParallelCoalesceKey(i.md.ID.RunID.String(), nonLazyIDs)
 		groups.PriorityGroup.ParallelCoalesceKey = ck
 		groups.OtherGroup.ParallelCoalesceKey = ck
-	}
 
-	// We only save pending steps if there's >= 1 step planned op.
-	if hasPlanOp(resp.Generator) && len(nonLazyIDs) > 1 && i.md.ShouldCoalesceParallelism(resp) {
 		if err := e.smv2.SavePending(ctx, i.md.ID, nonLazyIDs); err != nil {
 			return fmt.Errorf("error saving pending steps: %w", err)
 		}
@@ -3839,6 +3862,12 @@ func (e *executor) maybeEnqueueDiscoveryStep(ctx context.Context, runCtx executi
 
 			if errors.Is(err, queue.ErrQueueItemExists) {
 				if coalesceKey != nil && gen.ParallelMode() != enums.ParallelModeRace {
+					e.log.Debug("discovery enqueue deduped via coalesce key",
+						"run_id", runCtx.Metadata().ID.RunID.String(),
+						"job_id", jobID,
+						"coalesce_key", *coalesceKey,
+						"parallel_mode", gen.ParallelMode(),
+					)
 					metrics.IncrDiscoveryCoalesceDedupCount(ctx, metrics.CounterOpt{PkgName: pkgName})
 				}
 				return nil


### PR DESCRIPTION
## Description
V1 expects that each parallel step completion to emit its own discovery
step and I broke that by coalescing them to the same idempotency key in
the queue. It was fine for a while because https://github.com/inngest/inngest/pull/4021
forced the `SavePending` call on V1 thus making the synchronization
happen at the state store level (atomic updated on the pending set in
Redis) but as soon as I reverted it in https://github.com/inngest/inngest/pull/4534
it made it that only one discovery step is allowed to be enqueued in the
queue which executed too early (other pending steps are still ongoing)
and did not pick up the runs after the fan-in thus hanging the runs
forever.

The logs would have really helped for recovery so I added them now
I don't expect them to be too noisy and if they are, there is likely an issue
but I'll remove them if they are noisy.


<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
