### PR TITLE
fix: share more test setup for v1/v2 parallel coalescing

### DIFF
--- a/pkg/execution/executor/discovery_coalesce_test.go
+++ b/pkg/execution/executor/discovery_coalesce_test.go
@@ -192,13 +192,14 @@ func (s *trackingRunSvc) SavePending(_ context.Context, _ sv2.ID, pending []stri
 	return nil
 }
 
-// Regression: when ShouldCoalesceParallelism is false (SDK reports V1),
-// the coalesce key must stay off the queue items. Otherwise concurrent
-// fan-in completions silently dedup on the same JobID while SaveSteps are
-// still in flight, and the surviving discovery runs against incomplete state.
-func TestHandleGeneratorResponse_NoCoalesceKeyWhenSDKReportsV1(t *testing.T) {
+func TestHandleGeneratorResponse_CoalesceKeyBySDKRequestVersion(t *testing.T) {
 	runID := ulid.MustNew(ulid.Now(), nil)
 	wsID, fnID, aID := uuid.New(), uuid.New(), uuid.New()
+	stepIDs := []string{"step-a", "step-b", "step-c"}
+	gen := make([]*state.GeneratorOpcode, 0, len(stepIDs))
+	for _, id := range stepIDs {
+		gen = append(gen, &state.GeneratorOpcode{Op: enums.OpcodeStepPlanned, ID: id})
+	}
 
 	svc := &trackingRunSvc{}
 	q := &dedupeQueue{}
@@ -211,74 +212,51 @@ func TestHandleGeneratorResponse_NoCoalesceKeyWhenSDKReportsV1(t *testing.T) {
 
 	md := sv2.Metadata{
 		ID:     sv2.ID{RunID: runID, FunctionID: fnID, Tenant: sv2.Tenant{EnvID: wsID, AccountID: aID}},
-		Config: *sv2.InitConfig(&sv2.Config{RequestVersion: 1}),
+		Config: *sv2.InitConfig(&sv2.Config{}),
 	}
 	i := &runInstance{
 		md:   md,
 		edge: inngest.Edge{Incoming: "step"},
 		item: queue.Item{Payload: queue.PayloadEdge{Edge: inngest.Edge{Incoming: "step"}}},
 	}
+	resp := &state.DriverResponse{Generator: gen}
 
-	stepIDs := []string{"step-a", "step-b", "step-c"}
-	gen := make([]*state.GeneratorOpcode, 0, len(stepIDs))
-	for _, id := range stepIDs {
-		gen = append(gen, &state.GeneratorOpcode{Op: enums.OpcodeStepPlanned, ID: id})
-	}
-	resp := &state.DriverResponse{Generator: gen, RequestVersion: 1}
+	t.Run("omits coalesce key for SDK request version 1", func(t *testing.T) {
+		sdkRequestVersion := 1
+		svc.savePendingCalls = nil
+		q.enqueued = nil
+		i.md.Config.RequestVersion = sdkRequestVersion
+		resp.RequestVersion = sdkRequestVersion
 
-	require.NoError(t, e.HandleGeneratorResponse(context.Background(), i, resp))
+		require.NoError(t, e.HandleGeneratorResponse(context.Background(), i, resp))
 
-	require.Empty(t, svc.savePendingCalls, "SavePending must not be called when SDK reports V1")
-	require.Len(t, q.enqueued, len(stepIDs))
-	for _, item := range q.enqueued {
-		require.Nil(t, item.ParallelCoalesceKey,
-			"queue items must not carry a ParallelCoalesceKey when SDK reports V1 — silent dedup would wedge the run")
-	}
-}
+		require.Empty(t, svc.savePendingCalls, "SavePending must not be called when SDK reports V1")
+		require.Len(t, q.enqueued, len(stepIDs))
+		for _, item := range q.enqueued {
+			require.Nil(t, item.ParallelCoalesceKey,
+				"queue items must not carry a ParallelCoalesceKey when SDK reports V1 — silent dedup would wedge the run")
+		}
+	})
 
-// Under V2, SavePending is called and every queue item carries the same
-// coalesce key, so concurrent fan-in completions safely dedup on one discovery.
-func TestHandleGeneratorResponse_StampsCoalesceKeyWhenSDKReportsV2(t *testing.T) {
-	runID := ulid.MustNew(ulid.Now(), nil)
-	wsID, fnID, aID := uuid.New(), uuid.New(), uuid.New()
+	t.Run("stamps shared coalesce key for SDK request version 2", func(t *testing.T) {
+		sdkRequestVersion := 2
+		svc.savePendingCalls = nil
+		q.enqueued = nil
+		i.md.Config.RequestVersion = sdkRequestVersion
+		resp.RequestVersion = sdkRequestVersion
 
-	svc := &trackingRunSvc{}
-	q := &dedupeQueue{}
-	e := &executor{
-		smv2:           svc,
-		queue:          q,
-		log:            logger.From(context.Background()),
-		tracerProvider: tracing.NewNoopTracerProvider(),
-	}
+		require.NoError(t, e.HandleGeneratorResponse(context.Background(), i, resp))
 
-	md := sv2.Metadata{
-		ID:     sv2.ID{RunID: runID, FunctionID: fnID, Tenant: sv2.Tenant{EnvID: wsID, AccountID: aID}},
-		Config: *sv2.InitConfig(&sv2.Config{RequestVersion: 2}),
-	}
-	i := &runInstance{
-		md:   md,
-		edge: inngest.Edge{Incoming: "step"},
-		item: queue.Item{Payload: queue.PayloadEdge{Edge: inngest.Edge{Incoming: "step"}}},
-	}
+		require.Len(t, svc.savePendingCalls, 1, "SavePending must be called exactly once for a parallel batch under V2")
+		require.ElementsMatch(t, stepIDs, svc.savePendingCalls[0])
 
-	stepIDs := []string{"step-a", "step-b", "step-c"}
-	gen := make([]*state.GeneratorOpcode, 0, len(stepIDs))
-	for _, id := range stepIDs {
-		gen = append(gen, &state.GeneratorOpcode{Op: enums.OpcodeStepPlanned, ID: id})
-	}
-	resp := &state.DriverResponse{Generator: gen, RequestVersion: 2}
-
-	require.NoError(t, e.HandleGeneratorResponse(context.Background(), i, resp))
-
-	require.Len(t, svc.savePendingCalls, 1, "SavePending must be called exactly once for a parallel batch under V2")
-	require.ElementsMatch(t, stepIDs, svc.savePendingCalls[0])
-
-	expectedCK := computeParallelCoalesceKey(runID.String(), stepIDs)
-	require.Len(t, q.enqueued, len(stepIDs))
-	for _, item := range q.enqueued {
-		require.NotNil(t, item.ParallelCoalesceKey, "queue items must carry a ParallelCoalesceKey under V2")
-		require.Equal(t, expectedCK, *item.ParallelCoalesceKey, "all items in the batch must share the same coalesce key")
-	}
+		expectedCK := computeParallelCoalesceKey(runID.String(), stepIDs)
+		require.Len(t, q.enqueued, len(stepIDs))
+		for _, item := range q.enqueued {
+			require.NotNil(t, item.ParallelCoalesceKey, "queue items must carry a ParallelCoalesceKey under V2")
+			require.Equal(t, expectedCK, *item.ParallelCoalesceKey, "all items in the batch must share the same coalesce key")
+		}
+	})
 }
 
 // TestAIGatewayCoalesceJobID verifies that concurrent AIGateway completions in the same


### PR DESCRIPTION
## Description

Test refactoring to make it more obvious what the differences between these tests are

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
