### PR TITLE
fix(experiments): Fix boxplot colors

### DIFF
--- a/ui/apps/dashboard/src/lib/experiments/colors.ts
+++ b/ui/apps/dashboard/src/lib/experiments/colors.ts
@@ -5,11 +5,10 @@
  */
 export const METRIC_PALETTE = [
   'rgb(var(--color-primary-moderate))',
-  'rgb(var(--color-secondary-xSubtle))',
-  'rgb(var(--color-accent-subtle))',
+  'rgb(var(--color-secondary-subtle))',
+  'rgb(var(--color-quaternary-warmer-moderate))',
   'rgb(var(--color-quaternary-cool-moderate))',
   'rgb(var(--color-tertiary-moderate))',
-  'rgb(var(--color-quaternary-warmer-moderate))',
 ] as const;
 
 /**
@@ -19,10 +18,9 @@ export const METRIC_PALETTE = [
 export const METRIC_PALETTE_SUBTLE = [
   'rgb(var(--color-primary-3xSubtle))',
   'rgb(var(--color-secondary-3xSubtle))',
-  'rgb(var(--color-accent-3xSubtle))',
+  'rgb(var(--color-quaternary-warmer-3xSubtle))',
   'rgb(var(--color-quaternary-cool-3xSubtle))',
   'rgb(var(--color-tertiary-3xSubtle))',
-  'rgb(var(--color-quaternary-warmer-3xSubtle))',
 ] as const;
 
 export function colorForMetric(index: number): string {

--- a/ui/apps/dashboard/src/lib/experiments/colors.ts
+++ b/ui/apps/dashboard/src/lib/experiments/colors.ts
@@ -18,9 +18,9 @@ export const METRIC_PALETTE = [
  */
 export const METRIC_PALETTE_SUBTLE = [
   'rgb(var(--color-primary-3xSubtle))',
-  'rgb(var(--color-quaternary-cool-3xSubtle))',
   'rgb(var(--color-secondary-3xSubtle))',
   'rgb(var(--color-accent-3xSubtle))',
+  'rgb(var(--color-quaternary-cool-3xSubtle))',
   'rgb(var(--color-tertiary-3xSubtle))',
   'rgb(var(--color-quaternary-warmer-3xSubtle))',
 ] as const;

--- a/ui/packages/components/src/AppRoot/globals.css
+++ b/ui/packages/components/src/AppRoot/globals.css
@@ -405,23 +405,15 @@ input[type='number'] {
     --color-tertiary-3xIntense: var(--color-ruby-100);
 
     --color-quaternary-cool-3xSubtle: var(--color-purplehaze-900);
-    --color-quaternary-cool-2xSubtle: var(--color-purplehaze-800);
     --color-quaternary-cool-xSubtle: var(--color-purplehaze-700);
-    --color-quaternary-cool-subtle: var(--color-purplehaze-600);
     --color-quaternary-cool-moderate: var(--color-purplehaze-500);
-    --color-quaternary-cool-intense: var(--color-purplehaze-400);
     --color-quaternary-cool-xIntense: var(--color-purplehaze-300);
-    --color-quaternary-cool-2xIntense: var(--color-purplehaze-200);
     --color-quaternary-cool-3xIntense: var(--color-purplehaze-100);
 
     --color-quaternary-warmer-3xSubtle: var(--color-citrus-900);
-    --color-quaternary-warmer-2xSubtle: var(--color-citrus-800);
     --color-quaternary-warmer-xSubtle: var(--color-citrus-700);
-    --color-quaternary-warmer-subtle: var(--color-citrus-600);
     --color-quaternary-warmer-moderate: var(--color-citrus-500);
-    --color-quaternary-warmer-intense: var(--color-citrus-400);
     --color-quaternary-warmer-xIntense: var(--color-citrus-300);
-    --color-quaternary-warmer-2xIntense: var(--color-citrus-200);
     --color-quaternary-warmer-3xIntense: var(--color-citrus-100);
 
     --color-accent-3xSubtle: var(--color-honey-900);

--- a/ui/packages/components/src/AppRoot/globals.css
+++ b/ui/packages/components/src/AppRoot/globals.css
@@ -405,16 +405,24 @@ input[type='number'] {
     --color-tertiary-3xIntense: var(--color-ruby-100);
 
     --color-quaternary-cool-3xSubtle: var(--color-purplehaze-900);
+    --color-quaternary-cool-2xSubtle: var(--color-purplehaze-800);
     --color-quaternary-cool-xSubtle: var(--color-purplehaze-700);
+    --color-quaternary-cool-subtle: var(--color-purplehaze-600);
     --color-quaternary-cool-moderate: var(--color-purplehaze-500);
+    --color-quaternary-cool-intense: var(--color-purplehaze-400);
     --color-quaternary-cool-xIntense: var(--color-purplehaze-300);
+    --color-quaternary-cool-2xIntense: var(--color-purplehaze-200);
     --color-quaternary-cool-3xIntense: var(--color-purplehaze-100);
 
-    --color-quarternary-warmer-3xSubtle: var(--color-citrus-900);
-    --color-quarternary-warmer-xSubtle: var(--color-citrus-700);
-    --color-quarternary-warmer-moderate: var(--color-citrus-500);
-    --color-quarternary-warmer-xIntense: var(--color-citrus-300);
-    --color-quarternary-warmer-3xIntense: var(--color-citrus-100);
+    --color-quaternary-warmer-3xSubtle: var(--color-citrus-900);
+    --color-quaternary-warmer-2xSubtle: var(--color-citrus-800);
+    --color-quaternary-warmer-xSubtle: var(--color-citrus-700);
+    --color-quaternary-warmer-subtle: var(--color-citrus-600);
+    --color-quaternary-warmer-moderate: var(--color-citrus-500);
+    --color-quaternary-warmer-intense: var(--color-citrus-400);
+    --color-quaternary-warmer-xIntense: var(--color-citrus-300);
+    --color-quaternary-warmer-2xIntense: var(--color-citrus-200);
+    --color-quaternary-warmer-3xIntense: var(--color-citrus-100);
 
     --color-accent-3xSubtle: var(--color-honey-900);
     --color-accent-2xSubtle: var(--color-honey-800);

--- a/ui/packages/components/src/Pill/Pill.tsx
+++ b/ui/packages/components/src/Pill/Pill.tsx
@@ -153,7 +153,7 @@ export const getPillColors = ({
   const solidPillStyles = {
     default: `bg-canvasMuted text-basis ${clickable ? 'hover:bg-surfaceMuted' : ''}`,
     primary: `bg-primary-intense text-alwaysWhite ${clickable ? 'hover:bg-primary-xIntense' : ''}`,
-    secondary: `bg-quarternary-warmer-xIntense text-alwaysWhite ${
+    secondary: `bg-quaternary-warmer-xIntense text-alwaysWhite ${
       clickable ? 'hover:bg-primary-xIntense' : ''
     }`,
     warning: `bg-accent-moderate text-alwaysWhite ${clickable ? 'hover:bg-accent-intense' : ''}`,


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

The box plot subtle colors are incorrect. This fixes them (and a typo/incompleteness) in the color definitions.

Before:
<img width="551" height="278" alt="image" src="https://github.com/user-attachments/assets/812ce2f1-5cd2-4660-9366-9fbf0d7ebd05" />


After:
<img width="550" height="269" alt="image" src="https://github.com/user-attachments/assets/f998aac3-b087-4aef-80df-a90621788d4d" />


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
