### PR TITLE
fix(experiments): Boxplot tweaks

### DIFF
--- a/ui/apps/dashboard/src/components/Experiments/BoxPlot.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/BoxPlot.tsx
@@ -19,7 +19,8 @@ import { makeBoxPlotTooltip } from './BoxPlotTooltip';
 import { VariantAxisTick } from './VariantAxisTick';
 
 const BOX_HEIGHT = 10;
-const LINE_HEIGHT = 2;
+const LINE_HEIGHT = 1;
+const LINE_WIDTH = 1;
 /** Snap within this many pixels of a named data point. */
 const SNAP_PX = 4;
 
@@ -116,12 +117,6 @@ function BoxShape({
   );
   const quantileXs = quantileOffsets.map((offset) => x + offset);
 
-  const zscores = [-1, 0, 1].map((z) => payload.avg + z * payload.stddev);
-  const zOffsets = zscores
-    .filter((z) => z >= payload.min && z <= payload.max)
-    .map((z) => ((z - payload.min) / range) * width);
-  const zXs = zOffsets.map((offset) => x + offset);
-
   return (
     <g>
       <rect
@@ -131,7 +126,7 @@ function BoxShape({
         height={height}
         fill={payload?.subtleColor}
         stroke={payload?.color}
-        strokeWidth={2}
+        strokeWidth={LINE_WIDTH}
       />
       {quantileXs.map((qx, i) => (
         <line
@@ -141,7 +136,7 @@ function BoxShape({
           y1={y}
           y2={y + height}
           stroke={payload?.color}
-          strokeWidth={2}
+          strokeWidth={LINE_WIDTH}
         />
       ))}
       <line
@@ -158,20 +153,8 @@ function BoxShape({
         y1={cyLine}
         y2={cyLine}
         stroke={payload?.color}
-        strokeWidth={2}
+        strokeWidth={LINE_HEIGHT}
       />
-      {zXs.map((zx, i) => (
-        <line
-          key={`zscore-${i}`}
-          x1={zx}
-          x2={zx}
-          y1={y}
-          y2={y + height}
-          stroke={payload?.color}
-          strokeWidth={2}
-          strokeDasharray="2 2"
-        />
-      ))}
     </g>
   );
 }
@@ -200,9 +183,6 @@ const SNAP_VALUE_FNS: ((r: RowData) => number)[] = [
   (r) => r.med,
   (r) => r.q3,
   (r) => r.max,
-  (r) => r.avg,
-  (r) => r.avg - r.stddev,
-  (r) => r.avg + r.stddev,
 ];
 
 type RechartScale = { (v: number): number; invert?: (px: number) => number };

--- a/ui/apps/dashboard/src/components/Experiments/BoxPlotTooltip.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/BoxPlotTooltip.tsx
@@ -26,26 +26,6 @@ type StatEntry = {
 };
 
 const ALL_STATS: StatEntry[] = [
-  { key: 'avg', label: 'Avg', valueFn: (p) => p.avg },
-  { key: 'stddev', label: 'StdDev', valueFn: (p) => p.stddev },
-  {
-    key: 'z_neg1',
-    label: (
-      <>
-        Z<sub>-1</sub>
-      </>
-    ),
-    valueFn: (p) => p.avg - p.stddev,
-  },
-  {
-    key: 'z_pos1',
-    label: (
-      <>
-        Z<sub>+1</sub>
-      </>
-    ),
-    valueFn: (p) => p.avg + p.stddev,
-  },
   { key: 'min', label: 'Min', valueFn: (p) => p.min },
   { key: 'q1', label: 'Q1', valueFn: (p) => p.q1 },
   { key: 'med', label: 'Median', valueFn: (p) => p.med },


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This reduces box plot stroke to 1 and removes the z-1/mean/z1 lines

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
