### PR TITLE
ci: Upload test results to CodeCov to analyze flake rates

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           go-version-file: ./go.mod
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.13.0
+
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -64,7 +67,7 @@ jobs:
           echo "Ran dev server"
           sleep 5
           curl http://127.0.0.1:8288/dev > /dev/null 2> /dev/null
-          go test ./tests -v
+          gotestsum --junitfile=junit.xml --format=standard-verbose -- ./tests
         env:
           INNGEST_SIGNING_KEY: test
           API_URL: http://127.0.0.1:8288
@@ -92,6 +95,15 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ts-e2e,kq-${{ matrix.experimentalKeyQueues }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./junit.xml
+          flags: ts-e2e,kq-${{ matrix.experimentalKeyQueues }}
+          report_type: test_results
 
   # refs:
   #  - https://go.dev/doc/build-cover
@@ -157,7 +169,7 @@ jobs:
           sleep 5
           curl http://127.0.0.1:8288/dev > /dev/null 2> /dev/null
 
-          gotesplit -total ${{ matrix.parallelism }} -index ${{ matrix.index }} ./tests/golang -- -v -count=1
+          gotesplit -total ${{ matrix.parallelism }} -index ${{ matrix.index }} -junit-dir test-results ./tests/golang -- -v -count=1
         env:
           API_URL: http://127.0.0.1:8288
           INNGEST_EVENT_KEY: test
@@ -188,6 +200,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: go-e2e,split-${{ matrix.index }},kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }}
 
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./test-results/junit-${{ matrix.index }}-0.xml
+          flags: go-e2e,split-${{ matrix.index }},kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }}
+          report_type: test_results
+
   batch:
     name: "Batch / OS: (${{ matrix.os }}), key-queues: ${{ matrix.experimentalKeyQueues }}, db: ${{ matrix.database }}, split-batch-partition: ${{ matrix.splitBatchPartition }}"
     strategy:
@@ -207,6 +228,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: ./go.mod
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Start postgres container
         if: matrix.database == 'postgres'
@@ -246,7 +270,7 @@ jobs:
           sleep 5
           curl http://127.0.0.1:8288/dev > /dev/null 2> /dev/null
 
-          go test ./tests/batch/... -v -count=1
+          gotestsum --junitfile=junit.xml --format=standard-verbose -- ./tests/batch/... -count=1
         env:
           API_URL: http://127.0.0.1:8288
           INNGEST_EVENT_KEY: test
@@ -276,6 +300,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: batch-e2e,kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }},split-${{ matrix.splitBatchPartition }}
 
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./junit.xml
+          flags: batch-e2e,kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }},split-${{ matrix.splitBatchPartition }}
+          report_type: test_results
+
   api:
     name: "API / OS: (${{ matrix.os }}), key-queues: ${{ matrix.experimentalKeyQueues }}, db: ${{ matrix.database }}"
     strategy:
@@ -294,6 +327,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: ./go.mod
+
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Start postgres container
         if: matrix.database == 'postgres'
@@ -333,7 +369,7 @@ jobs:
           sleep 5
           curl http://127.0.0.1:8288/dev > /dev/null 2> /dev/null
 
-          go test ./tests/api/... -v -count=1
+          gotestsum --junitfile=junit.xml --format=standard-verbose -- ./tests/api/... -count=1
         env:
           API_URL: http://127.0.0.1:8288
           INNGEST_EVENT_KEY: test
@@ -362,6 +398,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: api-e2e,kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }}
 
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./junit.xml
+          flags: api-e2e,kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }}
+          report_type: test_results
+
   execution:
     name: "Execution / OS: (${{ matrix.os }}), key-queues: ${{ matrix.experimentalKeyQueues }}"
     strategy:
@@ -380,8 +425,11 @@ jobs:
         with:
           go-version-file: ./go.mod
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.13.0
+
       - name: Run execution tests
-        run: go test ./tests/execution/... -v -count=1 -coverprofile=coverage.txt
+        run: gotestsum --junitfile=junit.xml --format=standard-verbose -- ./tests/execution/... -count=1 -coverprofile=coverage.txt
         env:
           EXPERIMENTAL_KEY_QUEUES_ENABLE: "${{ matrix.experimentalKeyQueues }}"
 
@@ -390,3 +438,12 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: exec,kq-${{ matrix.experimentalKeyQueues }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./junit.xml
+          flags: exec,kq-${{ matrix.experimentalKeyQueues }}
+          report_type: test_results

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,14 +91,14 @@ jobs:
           retention-days: 7
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: ts-e2e,kq-${{ matrix.experimentalKeyQueues }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./junit.xml
@@ -195,14 +195,14 @@ jobs:
           retention-days: 7
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: go-e2e,split-${{ matrix.index }},kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./test-results/junit-${{ matrix.index }}-0.xml
@@ -295,14 +295,14 @@ jobs:
           retention-days: 7
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: batch-e2e,kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }},split-${{ matrix.splitBatchPartition }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./junit.xml
@@ -393,14 +393,14 @@ jobs:
           retention-days: 7
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: api-e2e,kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./junit.xml
@@ -434,14 +434,14 @@ jobs:
           EXPERIMENTAL_KEY_QUEUES_ENABLE: "${{ matrix.experimentalKeyQueues }}"
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: exec,kq-${{ matrix.experimentalKeyQueues }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./junit.xml

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -82,14 +82,14 @@ jobs:
           TEST_DATABASE: "${{ matrix.database }}"
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit,db-${{ matrix.database }}
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./junit.xml

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -69,9 +69,14 @@ jobs:
         with:
           go-version-file: ./go.mod
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.13.0
+
       - name: Test
         run: |
-          go test -v $(find . -iname "*_test.go" | xargs -I {} dirname {} | uniq | grep -v "./tests") -race -count=1 -coverprofile=coverage.txt
+          gotestsum --junitfile=junit.xml --format=standard-verbose -- \
+            $(find . -iname "*_test.go" | xargs -I {} dirname {} | uniq | grep -v "./tests") \
+            -race -count=1 -coverprofile=coverage.txt
         env:
           TEST_MODE: true
           TEST_DATABASE: "${{ matrix.database }}"
@@ -81,3 +86,12 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit,db-${{ matrix.database }}
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./junit.xml
+          flags: unit,db-${{ matrix.database }}
+          report_type: test_results


### PR DESCRIPTION
## Description

- I want to know how our test flake rate changes over time
- Mendral does know about flakes, but doesn't give us detailed data.
- CodeCov can give this to us: https://app.codecov.io/gh/inngest/inngest/tests

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
