### PR TITLE
test: regression tests for parallel step in V3 SDK

### DIFF
--- a/tests/dsl.go
+++ b/tests/dsl.go
@@ -1,13 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"reflect"
+	"regexp"
 	"testing"
 	"time"
 
@@ -15,6 +19,7 @@ import (
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/driver"
 	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/sdk"
 	"github.com/inngest/inngestgo"
 	"github.com/stretchr/testify/require"
 )
@@ -67,6 +72,63 @@ func (t *Test) SetAssertions(items ...func()) {
 // SendTrigger sends the triggering event, kicking off the function run.
 func (t *Test) SendTrigger() func() {
 	return t.Send(t.EventTrigger)
+}
+
+// registerDirect fetches all functions from the JS introspect endpoint and
+// registers them with the dev server pointing at the real SDK URL.
+func registerDirect(t *testing.T) {
+	t.Helper()
+
+	url := sdkURL
+	url.Path = "/api/introspect"
+	resp, err := http.Get(url.String())
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	fns := []sdk.SDKFunction{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&fns))
+
+	rr := sdk.RegisterRequest{
+		URL:       "http://127.0.0.1:3000/api/inngest",
+		AppName:   "test-suite",
+		Functions: fns,
+	}
+
+	byt, err := json.Marshal(rr)
+	require.NoError(t, err)
+
+	regURL := apiURL
+	regURL.Path = "/fn/register"
+	req, err := http.NewRequest(http.MethodPost, regURL.String(), bytes.NewReader(byt))
+	require.NoError(t, err)
+
+	key := regexp.MustCompile(`^signkey-[\w]+-`).ReplaceAllString(signingKey, "")
+	keyBytes, _ := hex.DecodeString(key)
+	sum := sha256.Sum256(keyBytes)
+	keyHash := hex.EncodeToString(sum[:])
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer signkey-test-%s", keyHash))
+
+	regResp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer regResp.Body.Close()
+	require.Less(t, regResp.StatusCode, 300, "register returned %d", regResp.StatusCode)
+}
+
+// deregisterDirect removes the app registered by registerDirect.
+func deregisterDirect(t *testing.T) {
+	t.Helper()
+	u := apiURL
+	u.Path = "/fn/remove"
+	fv := u.Query()
+	fv.Add("url", "http://127.0.0.1:3000/api/inngest")
+	u.RawQuery = fv.Encode()
+	req, err := http.NewRequest(http.MethodDelete, u.String(), nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
 }
 
 func (t *Test) Func(f func() error) func() {

--- a/tests/js/src/inngest/sdk_parallel_fan_in_test.ts
+++ b/tests/js/src/inngest/sdk_parallel_fan_in_test.ts
@@ -12,11 +12,11 @@ export const sleepRandom = inngest.createFunction(
   }
 );
 
-// Regression test for parallel fan-in runs wedging.  Drives 100 concurrent
-// ops (50 step.run, 50 step.invoke) through one Promise.all and asserts the
+// Regression test for parallel fan-in runs hanging.  Drives 40 concurrent
+// ops (20 step.run, 20 step.invoke) through one Promise.all and asserts the
 // parent run completes with the expected aggregate.  step.run results sum to
 // a known constant; the invoke count confirms every child finished — so the
-// Go driver catches both "run wedged" and "step ran the wrong number of
+// Go driver catches both "run stalled" and "step ran the wrong number of
 // times" regressions.
 export const testParallelFanIn = inngest.createFunction(
   { id: "parallel-fan-in" },
@@ -24,7 +24,7 @@ export const testParallelFanIn = inngest.createFunction(
   async ({ step }) => {
     const tasks: Promise<unknown>[] = [];
 
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < 20; i++) {
       tasks.push(
         step.invoke(`invoke-${i}`, {
           function: sleepRandom,
@@ -33,17 +33,17 @@ export const testParallelFanIn = inngest.createFunction(
       );
     }
 
-    for (let i = 0; i < 50; i++) {
+    for (let i = 0; i < 20; i++) {
       tasks.push(step.run(`run-${i}`, () => i * i));
     }
 
     const results = await Promise.all(tasks);
 
-    // First 50 results are invokes (random sleep duration); last 50 are
-    // step.run squares.  Sum the squares — 0² + 1² + … + 49² = 40425 — and
+    // First 20 results are invokes (random sleep duration); last 20 are
+    // step.run squares.  Sum the squares — 0² + 1² + … + 19² = 2470 — and
     // count completed invokes by checking the response shape.
-    const invokeResults = results.slice(0, 50);
-    const stepResults = results.slice(50) as number[];
+    const invokeResults = results.slice(0, 20);
+    const stepResults = results.slice(20) as number[];
 
     const stepSquares = stepResults.reduce((a, b) => a + b, 0);
     const invokeCount = invokeResults.filter(

--- a/tests/js/src/inngest/sdk_parallel_fan_in_test.ts
+++ b/tests/js/src/inngest/sdk_parallel_fan_in_test.ts
@@ -1,0 +1,55 @@
+import { inngest } from "@/inngest/client";
+
+// Helper function invoked by testParallelFanIn.  Sleeps a random 1-5s so
+// concurrent invokes complete at different times, widening the race window.
+export const sleepRandom = inngest.createFunction(
+  { id: "sleep-random" },
+  { event: "tests/sleep-random.test" },
+  async ({ step }) => {
+    const ms = 1000 + Math.floor(Math.random() * 4000);
+    await step.sleep("zzz", `${ms}ms`);
+    return { slept: ms };
+  }
+);
+
+// Regression test for parallel fan-in runs wedging.  Drives 100 concurrent
+// ops (50 step.run, 50 step.invoke) through one Promise.all and asserts the
+// parent run completes with the expected aggregate.  step.run results sum to
+// a known constant; the invoke count confirms every child finished — so the
+// Go driver catches both "run wedged" and "step ran the wrong number of
+// times" regressions.
+export const testParallelFanIn = inngest.createFunction(
+  { id: "parallel-fan-in" },
+  { event: "tests/parallel-fan-in.test" },
+  async ({ step }) => {
+    const tasks: Promise<unknown>[] = [];
+
+    for (let i = 0; i < 50; i++) {
+      tasks.push(
+        step.invoke(`invoke-${i}`, {
+          function: sleepRandom,
+          data: { name: "tests/sleep-random.test", data: {} },
+        })
+      );
+    }
+
+    for (let i = 0; i < 50; i++) {
+      tasks.push(step.run(`run-${i}`, () => i * i));
+    }
+
+    const results = await Promise.all(tasks);
+
+    // First 50 results are invokes (random sleep duration); last 50 are
+    // step.run squares.  Sum the squares — 0² + 1² + … + 49² = 40425 — and
+    // count completed invokes by checking the response shape.
+    const invokeResults = results.slice(0, 50);
+    const stepResults = results.slice(50) as number[];
+
+    const stepSquares = stepResults.reduce((a, b) => a + b, 0);
+    const invokeCount = invokeResults.filter(
+      (r: any) => r && typeof r.slept === "number"
+    ).length;
+
+    return { stepSquares, invokeCount };
+  }
+);

--- a/tests/js/src/inngest/sdk_promise_race_waits_test.ts
+++ b/tests/js/src/inngest/sdk_promise_race_waits_test.ts
@@ -1,0 +1,30 @@
+import { inngest } from "@/inngest/client";
+
+// Regression: Promise.race over parallel step.waitForEvent calls used to
+// hang — when one wait resolved, the others were still tracked as pending,
+// so the function never continued past the race.
+export const testPromiseRaceWaits = inngest.createFunction(
+  { id: "promise-race-waits" },
+  { event: "tests/promise-race-waits.test" },
+  async ({ step }) => {
+    const winner: any = await Promise.race([
+      step.waitForEvent("answer", {
+        event: "tests/promise-race-waits.answer",
+        if: "async.data.id == event.data.id",
+        timeout: "5m",
+      }),
+      step.waitForEvent("completed", {
+        event: "tests/promise-race-waits.completed",
+        if: "async.data.id == event.data.id",
+        timeout: "5m",
+      }),
+      step.waitForEvent("deleted", {
+        event: "tests/promise-race-waits.deleted",
+        if: "async.data.id == event.data.id",
+        timeout: "5m",
+      }),
+    ]);
+
+    return { winner: winner?.name ?? null };
+  }
+);

--- a/tests/js/src/pages/api/inngest.ts
+++ b/tests/js/src/pages/api/inngest.ts
@@ -7,6 +7,8 @@ import { testCancel } from "@/inngest/sdk_cancel_test";
 import { testRetry } from "@/inngest/sdk_retry_test";
 import { testNonRetriableError } from "@/inngest/non_retryable";
 import { testParallelism } from "@/inngest/sdk_parallel_test";
+import { testParallelFanIn, sleepRandom } from "@/inngest/sdk_parallel_fan_in_test";
+import { testPromiseRaceWaits } from "@/inngest/sdk_promise_race_waits_test";
 import { testWaitForEvent } from "@/inngest/sdk_wait_for_event_test";
 
 export default serve({
@@ -18,6 +20,9 @@ export default serve({
     testRetry,
     testNonRetriableError,
     testParallelism,
+    testParallelFanIn,
+    sleepRandom,
+    testPromiseRaceWaits,
     testWaitForEvent,
   ],
 });

--- a/tests/js/src/pages/api/introspect.ts
+++ b/tests/js/src/pages/api/introspect.ts
@@ -4,6 +4,8 @@ import { testCancel } from "@/inngest/sdk_cancel_test";
 import { testRetry } from "@/inngest/sdk_retry_test";
 import { testNonRetriableError } from "@/inngest/non_retryable";
 import { testParallelism } from "@/inngest/sdk_parallel_test";
+import { testParallelFanIn, sleepRandom } from "@/inngest/sdk_parallel_fan_in_test";
+import { testPromiseRaceWaits } from "@/inngest/sdk_promise_race_waits_test";
 import { testWaitForEvent } from "@/inngest/sdk_wait_for_event_test";
 
 export default function(_req: any, res: any) {
@@ -16,6 +18,9 @@ export default function(_req: any, res: any) {
     testRetry,
     testNonRetriableError,
     testParallelism,
+    testParallelFanIn,
+    sleepRandom,
+    testPromiseRaceWaits,
     testWaitForEvent,
   ].forEach(f => {
     const data = f["getConfig"](new URL("http://127.0.0.1:3000/api/inngest"), "test-suite");

--- a/tests/sdk_parallel_fan_in_test.go
+++ b/tests/sdk_parallel_fan_in_test.go
@@ -11,22 +11,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestParallelFanIn is a regression test for parallel fan-in runs wedging.
-// It drives the JS testParallelFanIn function (100 concurrent ops in one
-// Promise.all: 50 step.run + 50 step.invoke of sleepRandom) and asserts the
+// TestParallelFanIn is a regression test for parallel fan-in runs hanging.
+// It drives the JS testParallelFanIn function (40 concurrent ops in one
+// Promise.all: 20 step.run + 20 step.invoke of sleepRandom) and asserts the
 // parent run completes with the expected aggregate.  If discovery dedup ever
-// decouples from pending-step tracking again, the run hangs and this test
+// decouples from pending-step tracking again, the run stalls and this test
 // fails on the wait-for-status timeout.  If a step runs the wrong number of
 // times the aggregate assertions catch it.
 func TestParallelFanIn(t *testing.T) {
+	registerDirect(t)
+	defer deregisterDirect(t)
+
 	cli := client.New(t)
 	ctx := context.Background()
 	start := time.Now().Add(-2 * time.Second)
-
-	evt := inngestgo.Event{
-		Name: "tests/parallel-fan-in.test",
-		Data: map[string]any{},
-	}
 
 	eventURLStr := eventURL.String()
 	ic, err := inngestgo.NewClient(inngestgo.ClientOpts{
@@ -35,12 +33,12 @@ func TestParallelFanIn(t *testing.T) {
 		EventURL: &eventURLStr,
 	})
 	require.NoError(t, err)
-	_, err = ic.Send(ctx, evt)
+	_, err = ic.Send(ctx, inngestgo.Event{
+		Name: "tests/parallel-fan-in.test",
+		Data: map[string]any{},
+	})
 	require.NoError(t, err)
 
-	// Generous timeout: invokes sleep up to 5s each, and there's queue
-	// scheduling overhead for 100 concurrent ops.  If the wedge regresses
-	// the run never completes and the test fails here.
 	runID := waitForRecentRun(t, cli, ctx, "parallel-fan-in", start, "COMPLETED", 60*time.Second)
 	run := cli.Run(ctx, runID)
 	require.Equal(t, "COMPLETED", run.Status)
@@ -51,7 +49,7 @@ func TestParallelFanIn(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal([]byte(run.Output), &out), "run output: %s", run.Output)
 
-	// 0² + 1² + ... + 49² = 40425
-	require.Equal(t, 40425, out.StepSquares, "sum of step.run squares — wrong value means a step ran the wrong number of times or returned the wrong value")
-	require.Equal(t, 50, out.InvokeCount, "every step.invoke must return a {slept: number} response")
+	// 0² + 1² + ... + 19² = 2470
+	require.Equal(t, 2470, out.StepSquares, "sum of step.run squares — wrong value means a step ran the wrong number of times or returned the wrong value")
+	require.Equal(t, 20, out.InvokeCount, "every step.invoke must return a {slept: number} response")
 }

--- a/tests/sdk_parallel_fan_in_test.go
+++ b/tests/sdk_parallel_fan_in_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/tests/client"
+	"github.com/inngest/inngestgo"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParallelFanIn is a regression test for parallel fan-in runs wedging.
+// It drives the JS testParallelFanIn function (100 concurrent ops in one
+// Promise.all: 50 step.run + 50 step.invoke of sleepRandom) and asserts the
+// parent run completes with the expected aggregate.  If discovery dedup ever
+// decouples from pending-step tracking again, the run hangs and this test
+// fails on the wait-for-status timeout.  If a step runs the wrong number of
+// times the aggregate assertions catch it.
+func TestParallelFanIn(t *testing.T) {
+	cli := client.New(t)
+	ctx := context.Background()
+	start := time.Now().Add(-2 * time.Second)
+
+	evt := inngestgo.Event{
+		Name: "tests/parallel-fan-in.test",
+		Data: map[string]any{},
+	}
+
+	eventURLStr := eventURL.String()
+	ic, err := inngestgo.NewClient(inngestgo.ClientOpts{
+		AppID:    "test",
+		EventKey: &eventKey,
+		EventURL: &eventURLStr,
+	})
+	require.NoError(t, err)
+	_, err = ic.Send(ctx, evt)
+	require.NoError(t, err)
+
+	// Generous timeout: invokes sleep up to 5s each, and there's queue
+	// scheduling overhead for 100 concurrent ops.  If the wedge regresses
+	// the run never completes and the test fails here.
+	runID := waitForRecentRun(t, cli, ctx, "parallel-fan-in", start, "COMPLETED", 60*time.Second)
+	run := cli.Run(ctx, runID)
+	require.Equal(t, "COMPLETED", run.Status)
+
+	var out struct {
+		StepSquares int `json:"stepSquares"`
+		InvokeCount int `json:"invokeCount"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(run.Output), &out), "run output: %s", run.Output)
+
+	// 0² + 1² + ... + 49² = 40425
+	require.Equal(t, 40425, out.StepSquares, "sum of step.run squares — wrong value means a step ran the wrong number of times or returned the wrong value")
+	require.Equal(t, 50, out.InvokeCount, "every step.invoke must return a {slept: number} response")
+}

--- a/tests/sdk_promise_race_waits_test.go
+++ b/tests/sdk_promise_race_waits_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/tests/client"
+	"github.com/inngest/inngestgo"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromiseRaceWaits(t *testing.T) {
+	registerDirect(t)
+	defer deregisterDirect(t)
+
+	cli := client.New(t)
+	ctx := context.Background()
+	start := time.Now().Add(-2 * time.Second)
+
+	id := uuid.New().String()
+	eventURLStr := eventURL.String()
+
+	ic, err := inngestgo.NewClient(inngestgo.ClientOpts{
+		AppID:    "test",
+		EventKey: &eventKey,
+		EventURL: &eventURLStr,
+	})
+	require.NoError(t, err)
+
+	_, err = ic.Send(ctx, inngestgo.Event{
+		Name: "tests/promise-race-waits.test",
+		Data: map[string]any{"id": id},
+	})
+	require.NoError(t, err)
+
+	// Fire the answer event periodically until the run completes.  Each JS
+	// waitForEvent uses a 5m timeout, so if Promise.race over parallel waits
+	// regresses, the two unanswered calls won't expire within this window —
+	// the run stays RUNNING and the test fails here instead of silently
+	// passing minutes later.
+	require.Eventually(t, func() bool {
+		_, sendErr := ic.Send(ctx, inngestgo.Event{
+			Name: "tests/promise-race-waits.answer",
+			Data: map[string]any{"id": id},
+		})
+		require.NoError(t, sendErr)
+
+		fnID, ok := lookupFunctionID(ctx, cli, "promise-race-waits")
+		if !ok {
+			return false
+		}
+		edges, _, _ := cli.FunctionRuns(ctx, client.FunctionRunOpt{
+			Items:       1,
+			Status:      []string{"COMPLETED"},
+			Start:       start,
+			End:         time.Now().Add(time.Minute),
+			FunctionIDs: []uuid.UUID{fnID},
+		})
+		return len(edges) > 0
+	}, 60*time.Second, 2*time.Second, "Promise.race over parallel step.waitForEvent regressed — run never completed")
+
+	fnID, _ := lookupFunctionID(ctx, cli, "promise-race-waits")
+	edges, _, _ := cli.FunctionRuns(ctx, client.FunctionRunOpt{
+		Items:       1,
+		Status:      []string{"COMPLETED"},
+		Start:       start,
+		End:         time.Now().Add(time.Minute),
+		FunctionIDs: []uuid.UUID{fnID},
+	})
+	require.NotEmpty(t, edges)
+	run := cli.Run(ctx, edges[0].Node.ID)
+
+	var out struct {
+		Winner string `json:"winner"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(run.Output), &out), "run output: %s", run.Output)
+	require.Equal(t, "tests/promise-race-waits.answer", out.Winner, "the fired event must be the winner; if other legs won, the race semantics regressed")
+}


### PR DESCRIPTION
## Description
Add regression tests for parallel steps in the V3 SDK which have a sligthly different behavior than V4 because `optimizeParallelism` default to `false` in that version and it doesn't end up coalescing discovery steps. Fix is: https://github.com/inngest/inngest/pull/4538

<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
