### PR TITLE
fix(dashboard): remove breadcrumb

### DIFF
--- a/ui/apps/dashboard/src/components/Experiments/ExperimentDetailPage.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/ExperimentDetailPage.tsx
@@ -263,13 +263,6 @@ export function ExperimentDetailPage({
             text: 'All experiments',
             href: pathCreator.experiments({ envSlug: environment.slug }),
           },
-          {
-            text: functionName,
-            href: pathCreator.function({
-              envSlug: environment.slug,
-              functionSlug,
-            }),
-          },
           { text: experimentName },
         ]}
       />
@@ -436,6 +429,11 @@ export function ExperimentDetailPage({
                   detail={detail.data}
                   topVariantName={topVariantName}
                   variantOrder={sortedVariants.map((v) => v.variantName)}
+                  functionName={functionName}
+                  functionHref={pathCreator.function({
+                    envSlug: environment.slug,
+                    functionSlug,
+                  })}
                 />
               )}
               {activePanel === SCORING_PANEL && scoring.metrics && (

--- a/ui/apps/dashboard/src/components/Experiments/InfoSidebar.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/InfoSidebar.tsx
@@ -1,4 +1,5 @@
 import { Card } from '@inngest/components/Card';
+import { Link } from '@inngest/components/Link/Link';
 import { Pill } from '@inngest/components/Pill';
 import {
   formatVariantWeight,
@@ -7,9 +8,11 @@ import {
   type ExperimentVariantMetrics,
 } from '@inngest/components/Experiments';
 import { truncateCenter } from '@/lib/experiments/chart';
+import { FunctionsIcon } from '@inngest/components/icons/sections/Functions';
 import { cn } from '@inngest/components/utils/classNames';
 import {
   RiArrowLeftLine,
+  RiExternalLinkLine,
   RiFlaskLine,
   RiScalesLine,
   RiTrophyLine,
@@ -36,6 +39,8 @@ type Props = {
   detail: ExperimentDetail;
   topVariantName: string | null;
   variantOrder?: string[];
+  functionName: string;
+  functionHref: string;
 };
 
 function SectionLabel({ children }: { children: React.ReactNode }) {
@@ -54,7 +59,9 @@ function IconTile({ children }: { children: React.ReactNode }) {
   );
 }
 
-export function InfoSidebar({ detail, topVariantName, variantOrder }: Props) {
+export function InfoSidebar({
+  detail,
+  topVariantName, variantOrder, functionName, functionHref, }: Props) {
   const active = isActive(detail.lastSeen);
 
   return (
@@ -83,21 +90,38 @@ export function InfoSidebar({ detail, topVariantName, variantOrder }: Props) {
       </section>
 
       <section>
+        <SectionLabel>Function</SectionLabel>
+        <Card>
+          <Card.Content className="flex items-center gap-2 p-2">
+            <IconTile>
+              <FunctionsIcon className="text-muted h-[18px] w-[18px]" />
+            </IconTile>
+            <span
+              className="text-basis min-w-0 flex-1 truncate text-sm"
+              title={functionName}
+            >
+              {functionName}
+            </span>
+            <Link
+              href={functionHref}
+              iconAfter={<RiExternalLinkLine className="h-4 w-4" />}
+            >
+              View
+            </Link>
+          </Card.Content>
+        </Card>
+      </section>
+
+      <section>
         <SectionLabel>Type</SectionLabel>
         <Card>
-          <Card.Content className="flex flex-col gap-2 p-2">
-            <div className="flex items-center gap-2">
-              <IconTile>
-                <RiScalesLine className="text-muted h-[18px] w-[18px]" />
-              </IconTile>
-              <span className="text-basis min-w-0 flex-1 truncate text-sm">
-                {detail.selectionStrategy}
-              </span>
-            </div>
-            <Pill kind="default" appearance="solid">
-              {detail.variants.length} variant
-              {detail.variants.length !== 1 ? 's' : ''}
-            </Pill>
+          <Card.Content className="flex items-center gap-2 p-2">
+            <IconTile>
+              <RiScalesLine className="text-muted h-[18px] w-[18px]" />
+            </IconTile>
+            <span className="text-basis min-w-0 flex-1 truncate text-sm">
+              {detail.selectionStrategy}
+            </span>
           </Card.Content>
         </Card>
       </section>


### PR DESCRIPTION
## Description
removed bradcrumb and added functions to the details panel

<img width="365" height="101" alt="Screenshot 2026-07-01 at 13 18 41" src="https://github.com/user-attachments/assets/e1636bf8-a4a2-4cbd-8b4c-fe7058010d28" />

<img width="528" height="89" alt="Screenshot 2026-07-01 at 13 18 38" src="https://github.com/user-attachments/assets/6f118eb2-8737-4329-bb2e-aebabfab71bb" />


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
