### PR TITLE
ci(go): drop key-queues test matrix dimension

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -56,10 +56,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        experimentalKeyQueues: [false, true]
         database: [sqlite, postgres]
     runs-on: ${{ matrix.os }}
-    name: "Test / OS: ${{ matrix.os }}, key-queues: ${{ matrix.experimentalKeyQueues }}, db: ${{ matrix.database }}"
+    name: "Test / OS: ${{ matrix.os }}, db: ${{ matrix.database }}"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -75,11 +74,10 @@ jobs:
           go test -v $(find . -iname "*_test.go" | xargs -I {} dirname {} | uniq | grep -v "./tests") -race -count=1 -coverprofile=coverage.txt
         env:
           TEST_MODE: true
-          EXPERIMENTAL_KEY_QUEUES_ENABLE: "${{ matrix.experimentalKeyQueues }}"
           TEST_DATABASE: "${{ matrix.database }}"
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          flags: unit,kq-${{ matrix.experimentalKeyQueues }},db-${{ matrix.database }}
+          flags: unit,db-${{ matrix.database }}


### PR DESCRIPTION
## Description

- We run `test-linux-race` tests with a matrix, so we repeat the tests with different variants, such as the backing database (postgres, sqlite) and key queues on and off
- Our key queues dimension toggles the EXPERIMENTAL_KEY_QUEUES_ENABLE env var, but we don't actually read or use that env var during tests.
- Let's remove the dimension and reduce the tests for this matrix by half

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
