### PR TITLE
ci: Use a depot runner for linting

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -18,7 +18,7 @@ jobs:
     name: Lint
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [depot-ubuntu-22.04-4]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

- Let's trial using Depot in OSS
- Depot should skip the GitHub Action runners queueing time that we hit

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
