### PR TITLE
fix(dashboard): consistent colors for all the scoring metrics

### DIFF
--- a/ui/apps/dashboard/src/components/Experiments/ScoreSummaryCard.tsx
+++ b/ui/apps/dashboard/src/components/Experiments/ScoreSummaryCard.tsx
@@ -14,7 +14,7 @@ import {
 } from 'recharts';
 
 import { computeChartSizing } from '@/lib/experiments/chart';
-import { colorForMetric } from '@/lib/experiments/colors';
+import { buildMetricColorMap } from '@/lib/experiments/colors';
 import type { ScoredVariant } from '@/lib/experiments/score';
 import { ChartTooltip } from './ChartTooltip';
 import { ScoreCalculationExplainer } from './ScoreCalculationExplainer';
@@ -71,15 +71,23 @@ export function ScoreSummaryCard({
   hoveredVariantName,
   onVariantHover,
 }: Props) {
-  const [activeVariantName, setActiveVariantName] = useState<string | null>(null);
+  const [activeVariantName, setActiveVariantName] = useState<string | null>(
+    null,
+  );
 
   const enabledMetrics = useMemo(
     () => metrics.filter((m) => m.enabled),
     [metrics],
   );
 
+  // Color by each metric's stable position in the full list so segment colors
+  // match the Scoring formula sidebar and don't shift when a metric is toggled.
+  const colorMap = useMemo(() => buildMetricColorMap(metrics), [metrics]);
+
   // Only dim when the highlight comes from another chart (not from this one).
-  const effectiveHighlight = activeVariantName ? null : (hoveredVariantName ?? null);
+  const effectiveHighlight = activeVariantName
+    ? null
+    : hoveredVariantName ?? null;
 
   const rows = useMemo(() => {
     return scoredVariants.map(({ variant, result }) => {
@@ -87,7 +95,10 @@ export function ScoreSummaryCard({
         variantName: variant.variantName,
         total: result.total,
         runCount: variant.runCount,
-        opacity: effectiveHighlight && variant.variantName !== effectiveHighlight ? 0.25 : 1,
+        opacity:
+          effectiveHighlight && variant.variantName !== effectiveHighlight
+            ? 0.25
+            : 1,
       };
       for (const seg of result.segments) {
         row[seg.metricKey] = seg.contribution;
@@ -132,7 +143,9 @@ export function ScoreSummaryCard({
                   onVariantHover?.(null);
                   return;
                 }
-                const name = (state.activePayload?.[0]?.payload as RowData | undefined)?.variantName ?? null;
+                const name =
+                  (state.activePayload?.[0]?.payload as RowData | undefined)
+                    ?.variantName ?? null;
                 setActiveVariantName(name);
                 onVariantHover?.(name);
               }}
@@ -184,12 +197,16 @@ export function ScoreSummaryCard({
                   key={m.key}
                   dataKey={m.key}
                   stackId="score"
-                  fill={colorForMetric(i)}
+                  fill={colorMap[m.key]}
                   name={m.displayName}
                   background={i === 0 ? <BackgroundLineShape /> : undefined}
                 >
                   {rows.map((row) => (
-                    <Cell key={row.variantName} fill={colorForMetric(i)} opacity={row.opacity} />
+                    <Cell
+                      key={row.variantName}
+                      fill={colorMap[m.key]}
+                      opacity={row.opacity}
+                    />
                   ))}
                 </Bar>
               ))}

--- a/ui/apps/dashboard/src/lib/experiments/colors.test.ts
+++ b/ui/apps/dashboard/src/lib/experiments/colors.test.ts
@@ -24,22 +24,29 @@ describe('colorForMetric', () => {
 });
 
 describe('buildMetricColorMap', () => {
-  it('colors enabled metrics by their enabled-position, skipping disabled ones', () => {
+  it('colors metrics by their position in the full list', () => {
     const map = buildMetricColorMap([
-      { key: 'tokens', enabled: true },
-      { key: 'cost', enabled: false },
-      { key: 'accuracy', enabled: true },
+      { key: 'tokens' },
+      { key: 'cost' },
+      { key: 'accuracy' },
     ]);
-    // 'cost' is disabled, so 'accuracy' takes enabled-index 1 (matching the
-    // Score Summary chart, which only renders enabled segments).
     expect(map.tokens).toBe(colorForMetric(0));
-    expect(map.accuracy).toBe(colorForMetric(1));
-    expect(map.cost).toBeUndefined();
+    expect(map.cost).toBe(colorForMetric(1));
+    expect(map.accuracy).toBe(colorForMetric(2));
   });
 
-  it('returns an empty map when nothing is enabled', () => {
-    expect(buildMetricColorMap([{ key: 'tokens', enabled: false }])).toEqual(
-      {},
-    );
+  it('keeps each color stable regardless of enabled state', () => {
+    // A metric's color depends only on its list position, so disabling any
+    // metric never reshuffles the others' colors.
+    const map = buildMetricColorMap([
+      { key: 'tokens' },
+      { key: 'cost' },
+      { key: 'accuracy' },
+    ]);
+    expect(map.accuracy).toBe(colorForMetric(2));
+  });
+
+  it('returns an empty map for no metrics', () => {
+    expect(buildMetricColorMap([])).toEqual({});
   });
 });

--- a/ui/apps/dashboard/src/lib/experiments/colors.ts
+++ b/ui/apps/dashboard/src/lib/experiments/colors.ts
@@ -35,23 +35,20 @@ export function subtleColorForVariant(index: number): string {
   return METRIC_PALETTE_SUBTLE[index % METRIC_PALETTE_SUBTLE.length];
 }
 
-type MetricLike = { key: string; enabled: boolean };
+type MetricLike = { key: string };
 
 /**
- * Maps each enabled metric's key to its chart color. Colors are assigned by
- * position among *enabled* metrics (not the full list) so the result lines up
- * exactly with the Score Summary chart, which colors its stacked segments the
- * same way. Disabled metrics are omitted (callers fall back to a neutral tone).
+ * Maps each metric's key to its chart color. Colors are assigned by position in
+ * the full metrics list so a metric keeps the same color regardless of whether
+ * it (or any other metric) is enabled. The Score Summary chart builds its
+ * segment colors from the same map, so the two views stay in sync.
  */
 export function buildMetricColorMap(
   metrics: MetricLike[],
 ): Record<string, string> {
   const map: Record<string, string> = {};
-  let enabledIndex = 0;
-  for (const metric of metrics) {
-    if (!metric.enabled) continue;
-    map[metric.key] = colorForMetric(enabledIndex);
-    enabledIndex += 1;
-  }
+  metrics.forEach((metric, index) => {
+    map[metric.key] = colorForMetric(index);
+  });
   return map;
 }


### PR DESCRIPTION
## Description

The colors were being assigned by position among the enabled metrics, so toggling one off renumbered the rest and shifted their colors. I changed it to assign each metric a color by its stable position in the full metrics list, so a metric always keeps the same color regardless of what's enabled.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
