### PR TITLE
fix(execution): recover from unpaired surrogate escapes in JCS canonicalization

### DIFF
--- a/pkg/execution/driver/canonicalize.go
+++ b/pkg/execution/driver/canonicalize.go
@@ -1,0 +1,129 @@
+package driver
+
+import (
+	"github.com/gowebpki/jcs"
+)
+
+// canonicalize transforms marshalled JSON into its RFC 8785 canonical form.
+//
+// jcs rejects JSON containing unpaired UTF-16 surrogate escapes (eg. `\ud83d`
+// not followed by a low surrogate) with "Unexpected non-ASCII character" or
+// "Missing surrogate". These escapes are valid JSON, and JavaScript's
+// JSON.stringify produces them whenever a string was truncated mid surrogate
+// pair (emoji, astral-plane CJK, etc.), so they show up in real event and
+// step data. Because the transform runs on every step invocation, a single
+// such value poisons the run: every attempt fails identically and the run
+// dead-letters.
+//
+// When the transform fails, unpaired surrogate escapes are replaced with
+// `\ufffd` (the escaped Unicode replacement character) and the transform is retried
+// once. The repair only runs on the failure path, so well-formed payloads pay
+// no extra cost, and the output stays deterministic: the same input always
+// produces the same canonical bytes, which is what request signing requires.
+func canonicalize(j []byte) ([]byte, error) {
+	b, err := jcs.Transform(j)
+	if err == nil {
+		return b, nil
+	}
+	repaired := repairUnpairedSurrogateEscapes(j)
+	if repaired == nil {
+		// Nothing to repair; the input is broken in some other way.
+		return nil, err
+	}
+	return jcs.Transform(repaired)
+}
+
+// repairUnpairedSurrogateEscapes replaces unpaired `\uXXXX` surrogate escapes
+// inside JSON string literals with the escaped Unicode replacement character
+// `\ufffd`. Paired surrogates and all other content are left untouched.
+// Returns nil when the input needs no repairs.
+func repairUnpairedSurrogateEscapes(j []byte) []byte {
+	out := make([]byte, 0, len(j))
+	repaired := false
+	inString := false
+
+	for i := 0; i < len(j); i++ {
+		c := j[i]
+
+		if !inString {
+			if c == '"' {
+				inString = true
+			}
+			out = append(out, c)
+			continue
+		}
+
+		switch {
+		case c == '"':
+			inString = false
+			out = append(out, c)
+		case c == '\\':
+			if i+1 < len(j) && j[i+1] != 'u' {
+				// A simple escape such as \\ or \" — copy both bytes so the
+				// escaped character can't be misread as a string delimiter.
+				out = append(out, c, j[i+1])
+				i++
+				continue
+			}
+			first, ok := parseUEscape(j, i)
+			if !ok {
+				// Truncated or malformed escape; copy it through and let
+				// jcs report it.
+				out = append(out, c)
+				continue
+			}
+			if isHighSurrogate(first) {
+				if second, ok := parseUEscape(j, i+6); ok && isLowSurrogate(second) {
+					// A valid pair; copy both escapes untouched.
+					out = append(out, j[i:i+12]...)
+					i += 11
+					continue
+				}
+			}
+			if isHighSurrogate(first) || isLowSurrogate(first) {
+				out = append(out, '\\', 'u', 'f', 'f', 'f', 'd')
+				repaired = true
+				i += 5
+				continue
+			}
+			// An ordinary \uXXXX escape.
+			out = append(out, j[i:i+6]...)
+			i += 5
+		default:
+			out = append(out, c)
+		}
+	}
+
+	if !repaired {
+		return nil
+	}
+	return out
+}
+
+// parseUEscape parses a `\uXXXX` escape starting at offset i and returns its
+// UTF-16 code unit. ok is false when the bytes at i do not form a full escape.
+func parseUEscape(j []byte, i int) (uint16, bool) {
+	if i+5 >= len(j) || j[i] != '\\' || j[i+1] != 'u' {
+		return 0, false
+	}
+	var v uint16
+	for _, c := range j[i+2 : i+6] {
+		var d uint16
+		switch {
+		case c >= '0' && c <= '9':
+			d = uint16(c - '0')
+		case c >= 'a' && c <= 'f':
+			d = uint16(c-'a') + 10
+		case c >= 'A' && c <= 'F':
+			d = uint16(c-'A') + 10
+		default:
+			return 0, false
+		}
+		v = v<<4 | d
+	}
+	return v, true
+}
+
+func isHighSurrogate(u uint16) bool { return u >= 0xD800 && u <= 0xDBFF }
+
+func isLowSurrogate(u uint16) bool { return u >= 0xDC00 && u <= 0xDFFF }

--- a/pkg/execution/driver/canonicalize_test.go
+++ b/pkg/execution/driver/canonicalize_test.go
@@ -1,0 +1,102 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalize(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			// The exact failure from the issue: a lone high surrogate escape
+			// immediately followed by raw non-ASCII UTF-8 makes jcs read the
+			// next byte with its ASCII-only reader ("Unexpected non-ASCII
+			// character").
+			name:     "lone high surrogate followed by non-ASCII",
+			input:    `{"a":"\ud83dé"}`,
+			expected: `{"a":"` + "�" + `é"}`,
+		},
+		{
+			// Same family: jcs reports "Missing surrogate".
+			name:     "lone high surrogate at end of string",
+			input:    `{"a":"\ud83d"}`,
+			expected: `{"a":"` + "�" + `"}`,
+		},
+		{
+			name:     "lone high surrogate followed by ASCII",
+			input:    `{"a":"\ud83dx"}`,
+			expected: `{"a":"` + "�" + `x"}`,
+		},
+		{
+			name:     "lone low surrogate",
+			input:    `{"a":"\udc00x"}`,
+			expected: `{"a":"` + "�" + `x"}`,
+		},
+		{
+			name:     "uppercase hex lone surrogate",
+			input:    `{"a":"\uD83D"}`,
+			expected: `{"a":"` + "�" + `"}`,
+		},
+		{
+			name:     "lone surrogate in an object key",
+			input:    `{"\ud83d":1}`,
+			expected: `{"` + "�" + `":1}`,
+		},
+		{
+			// A valid escaped pair must be preserved, decoded to its code point.
+			name:     "valid surrogate pair is untouched",
+			input:    `{"a":"\ud83d\ude00"}`,
+			expected: `{"a":"😀"}`,
+		},
+		{
+			name:     "valid pair followed by a lone high surrogate",
+			input:    `{"a":"\ud83d\ude00\ud83d"}`,
+			expected: `{"a":"😀` + "�" + `"}`,
+		},
+		{
+			// `\\ud83d` is an escaped backslash followed by the literal text
+			// "ud83d", not a surrogate escape. It must pass through as-is.
+			name:     "escaped backslash decoy",
+			input:    `{"a":"\\ud83d"}`,
+			expected: `{"a":"\\ud83d"}`,
+		},
+		{
+			// Plain UTF-8 was never affected; first-try path.
+			name:     "plain accented text",
+			input:    `{"a":"péché"}`,
+			expected: `{"a":"péché"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, err := canonicalize([]byte(tt.input))
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(out))
+		})
+	}
+}
+
+func TestCanonicalizeInvalidJSON(t *testing.T) {
+	_, err := canonicalize([]byte(`{"a":`))
+	require.Error(t, err)
+}
+
+func TestRepairUnpairedSurrogateEscapes(t *testing.T) {
+	// No repairs needed returns nil so callers can skip the retry.
+	assert.Nil(t, repairUnpairedSurrogateEscapes([]byte(`{"a":"😀"}`)))
+	assert.Nil(t, repairUnpairedSurrogateEscapes([]byte(`{"a":"plain"}`)))
+	assert.Nil(t, repairUnpairedSurrogateEscapes([]byte(`{"a":"\\ud83d"}`)))
+
+	// Repairs emit the ASCII-safe `\ufffd` escape; jcs decodes it on the retry.
+	assert.Equal(t,
+		`{"a":"\ufffd"}`,
+		string(repairUnpairedSurrogateEscapes([]byte(`{"a":"\ud83d"}`))),
+	)
+}

--- a/pkg/execution/driver/driver.go
+++ b/pkg/execution/driver/driver.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/gowebpki/jcs"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/execution/queue"
@@ -260,7 +259,7 @@ func MarshalV1(
 
 	}
 
-	b, err := jcs.Transform(j)
+	b, err := canonicalize(j)
 	if err != nil {
 		return nil, fmt.Errorf("error transforming request with JCS: %w", err)
 	}


### PR DESCRIPTION
## Description

A function run whose event or memoized step data contains an unpaired UTF-16 surrogate escape (for example `\ud83d` with no low surrogate after it) fails every attempt with `error transforming request with JCS: Unexpected non-ASCII character` and dead-letters. Reported in #4558, reproduced on both the dev server and Cloud.

Root cause: these escapes are valid JSON, and JavaScript's `JSON.stringify` produces them whenever a string was truncated mid surrogate pair (emoji, astral-plane text; common with OCR'd or user-generated content that gets sliced to a length limit). Go's JSON encoder passes them through untouched inside `json.RawMessage` step data. `gowebpki/jcs` then chokes in `parseQuotedString`: after decoding a `\uXXXX` high surrogate it reads the next byte with an ASCII-only reader while expecting a `\u` continuation, so a following non-ASCII byte yields "Unexpected non-ASCII character" (and end-of-string yields "Missing surrogate"). Minimal repro:

```go
_, err := jcs.Transform([]byte(`{"a":"\ud83dé"}`))
// err: Unexpected non-ASCII character
```

The fix wraps the transform in a `canonicalize` helper: if `jcs.Transform` fails, unpaired surrogate escapes inside string literals are replaced with `�` (the Unicode replacement character, which is what an unpaired half of a character is) and the transform is retried once. Valid pairs and everything else pass through byte-for-byte.

Why this shape, since the fix direction was open to a few options:

- Not swapping the canonicalization library: signatures are verified by SDKs that re-serialize the body with their own RFC 8785 implementation when they can't access raw bytes (#392), so replacing the Go implementation risks byte-level divergence across every payload, not just the broken ones.
- Not sanitizing every request: `MarshalV1` runs on every step invocation and bodies can be large; an unconditional decode or scan taxes the hot path for a defect that is rare. The repair only runs after a failure, so well-formed payloads are untouched.
- Not vendoring a patched jcs: ECMAScript's `JSON.stringify` (which RFC 8785 defers to) round-trips lone surrogates as escape sequences, so patching the library to do the same would also be spec-defensible, but it means owning a fork of an unmaintained dependency. Happy to go that way instead if you'd rather preserve the original bytes.

Determinism holds either way: the same input always produces the same repaired bytes, the signature is computed over exactly what is sent, and an SDK that re-canonicalizes sees only the repaired body, so verification stays consistent.

Fixes #4558.

## Release note

Fixed function runs failing with `error transforming request with JCS: Unexpected non-ASCII character` when event or step data contained unpaired UTF-16 surrogate escapes (produced by JavaScript when a string is truncated mid emoji or other astral-plane character). Such runs previously exhausted retries and dead-lettered.

## Migration note

None.
