### PR TITLE
chore: track partition processing that yielded 0 peeks

### DIFF
--- a/pkg/execution/queue/process_partition.go
+++ b/pkg/execution/queue/process_partition.go
@@ -355,6 +355,8 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 		return nil
 	}
 
+	noPeek := len(queue) == 0
+
 	// XXX: If we haven't been able to lease a single item, ensure we enqueue this
 	// for a minimum of 5 seconds.
 
@@ -362,10 +364,10 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 	// time with jitter. This is why we have to lease items above, else this may
 	// return an item that is about to be leased and processed by the worker.
 	requeueExtension := partitionRequeueExtensionWithJitter()
-	_, err = Duration(ctx, shard.Name(), "partition_requeue", q.Clock().Now(), func(ctx context.Context) (any, error) {
+	_, err = DurationWithTags(ctx, shard.Name(), "partition_requeue", q.Clock().Now(), func(ctx context.Context) (any, error) {
 		err = shard.PartitionRequeue(ctx, p, q.Clock().Now().Add(requeueExtension), false)
 		return nil, err
-	})
+	}, map[string]any{"no_peek": noPeek})
 	if err == ErrPartitionGarbageCollected {
 		q.removeContinue(ctx, p, false)
 		// Safe;  we're preventing this from wasting cycles in the future.
@@ -376,6 +378,7 @@ func (q *queueProcessor) ProcessPartition(ctx context.Context, p *QueuePartition
 		return err
 	}
 	span.SetAttributes(attribute.String("status", "requeue_default"))
+	span.SetAttributes(attribute.Bool("no_peek", noPeek))
 	span.SetAttributes(attribute.Int64("requeue_ms", requeueExtension.Milliseconds()))
 	return nil
 }


### PR DESCRIPTION
## Description
Looking into if this wasted work is potentially affecting systems with a
large amount of partitions.
<!-- What changed? Include screenshots if you modify the UI. -->

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
