### PR TITLE
fix(insights): keep final-iteration text for agent summary

### DIFF
--- a/ui/apps/dashboard/src/lib/inngest/functions/agent/loop.test.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agent/loop.test.ts
@@ -142,6 +142,21 @@ describe('runAgentLoop', () => {
     expect(lastMessage?.content).toContain('final iteration');
   });
 
+  it('keeps text that accompanies a tool call on the final iteration', async () => {
+    const client = fakeClient([
+      {
+        content: [
+          { type: 'text', text: 'Here is your query.' },
+          { type: 'tool_use', id: 't1', name: 'echo', input: { msg: 'x' } },
+        ],
+        usage: { input_tokens: 10, output_tokens: 5 },
+      },
+    ]);
+    const res = await runAgentLoop({ ...baseArgs(), client, maxIterations: 1 });
+
+    expect(res.summary).toBe('Here is your query.');
+  });
+
   describe('validate_query', () => {
     const validateTool: ToolDef = {
       tool: {

--- a/ui/apps/dashboard/src/lib/inngest/functions/agent/loop.ts
+++ b/ui/apps/dashboard/src/lib/inngest/functions/agent/loop.ts
@@ -172,8 +172,10 @@ export async function runAgentLoop(
       .map((block) => block.text)
       .join('\n');
 
-    if (toolUses.length === 0) {
+    if (text) {
       summary = text;
+    }
+    if (toolUses.length === 0) {
       break;
     }
 


### PR DESCRIPTION
## Description

The agent loop only captured the model's text when a turn had no tool calls. Now any non-empty text is kept as the summary, but a later text-only turn still overwrites it.

Adds a test for the tool+text final turn.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
