### PR TITLE
fix(execution): improve copy for error responses that do not come from the SDK

### DIFF
--- a/pkg/execution/driver/httpdriver/httpdriver.go
+++ b/pkg/execution/driver/httpdriver/httpdriver.go
@@ -269,6 +269,15 @@ func HandleHttpResponse(ctx context.Context, r Request, resp *Response) (*state.
 		// - The function fails or errors (these are not *yet* opcodes, but should be).
 		err = fmt.Errorf("invalid status code: %d", resp.StatusCode)
 		dr.SetError(err)
+		// Synthesize a clear user-facing error only when the response did not
+		// come from an SDK (per its headers): a proxy/gateway 5xx, crash, or
+		// timeout before the SDK responded. SDK responses are left untouched —
+		// SDKs return real function/step errors as non-2xx with a serialized
+		// error body. Only Output is changed; dr.Err (set above) is left as-is
+		// so retry behavior is unchanged.
+		if !resp.IsSDK {
+			dr.Output = state.FatalUpstreamError(resp.StatusCode, resp.Body, resp.Header.Get("Content-Type"))
+		}
 	}
 	if resp.NoRetry {
 		// Ensure we return a NonRetriableError to indicate that

--- a/pkg/execution/driver/httpdriver/httpdriver_test.go
+++ b/pkg/execution/driver/httpdriver/httpdriver_test.go
@@ -299,6 +299,56 @@ func TestExecuteDriverRequest_DecodesBrotliGeneratorResponse(t *testing.T) {
 	require.Equal(t, "step-id", dr.Generator[0].ID)
 }
 
+// A transport-level 5xx with no structured Inngest error (proxy/gateway error,
+// crash, timeout) must surface a clear synthesized error in the trace, while
+// leaving dr.Err intact so retry behavior is unchanged.
+func TestHandleHttpResponse_FatalUpstreamError(t *testing.T) {
+	r := require.New(t)
+
+	resp := &Response{
+		Body:       []byte("Bad Gateway"),
+		StatusCode: 502,
+		IsSDK:      false,
+		Header:     http.Header{"Content-Type": []string{"text/plain"}},
+	}
+
+	dr, _ := HandleHttpResponse(context.Background(), Request{}, resp)
+	r.NotNil(dr)
+
+	// Retry signal preserved.
+	r.NotNil(dr.Err)
+	r.Contains(*dr.Err, "invalid status code: 502")
+
+	// Output replaced with the synthesized user-facing error.
+	se := dr.StandardError()
+	r.Equal(state.FatalServerErrorName, se.Name)
+	r.Contains(se.Message, "HTTP 502")
+	r.Contains(se.Stack, "Bad Gateway")
+}
+
+// A 5xx from an SDK must be preserved, not overwritten with the synthesized
+// fatal-upstream copy. SDKs return real function/step errors as non-2xx with a
+// top-level serialized error body (not wrapped under an "error" key), so the
+// guard is the SDK-header check, not the body shape.
+func TestHandleHttpResponse_SDKErrorNotClobbered(t *testing.T) {
+	r := require.New(t)
+
+	resp := &Response{
+		Body:       []byte(`{"name":"MyError","message":"boom","stack":"at fn (app.ts:1:1)","__serialized":true}`),
+		StatusCode: 500,
+		IsSDK:      true,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+
+	dr, _ := HandleHttpResponse(context.Background(), Request{}, resp)
+	r.NotNil(dr)
+
+	se := dr.StandardError()
+	r.Equal("MyError", se.Name)
+	r.Equal("boom", se.Message)
+	r.NotEqual(state.FatalServerErrorName, se.Name)
+}
+
 func TestHandleHttpResponse_DecompressesGzipBody(t *testing.T) {
 	r := require.New(t)
 

--- a/pkg/execution/driver/httpv2/httpv2.go
+++ b/pkg/execution/driver/httpv2/httpv2.go
@@ -186,7 +186,15 @@ func (d httpv2) sync(ctx context.Context, sl sv2.StateLoader, opts driver.V2Requ
 
 	// We must also assert that we had an Inngest-specific response.
 	if !headers.IsSDK(resp.Header) {
-		return nil, errs.WrapResponseAsUser(0, true, resp.Body, "didn't receive SDK response: %w", err), nil
+		raw := resp.Body
+		if resp.StatusCode < 200 || resp.StatusCode > 299 {
+			// A non-2xx with no SDK headers means a proxy/gateway error or a
+			// crash before the SDK could respond. Synthesize a clear
+			// user-facing error; the executor moves Raw() into
+			// DriverResponse.Output, so this is what the trace shows.
+			raw = state.FatalUpstreamError(resp.StatusCode, resp.Body, resp.Header.Get("Content-Type"))
+		}
+		return nil, errs.WrapResponseAsUser(0, true, raw, "didn't receive SDK response: %w", err), nil
 	}
 
 	// We always expect opcodes from the API endpoint.  Whenever we re-enter a sync function,

--- a/pkg/execution/driver/httpv2/httpv2_test.go
+++ b/pkg/execution/driver/httpv2/httpv2_test.go
@@ -245,6 +245,58 @@ func TestSyncNonSDKResponse(t *testing.T) {
 	require.NotNil(t, userErr)
 	require.NoError(t, internalErr)
 	require.Contains(t, userErr.Error(), "didn't receive SDK response")
+
+	// A non-SDK 2xx keeps the raw body untouched — no synthesized error.
+	require.Equal(t, []byte("not an SDK response"), userErr.Raw())
+}
+
+// A non-2xx response without SDK headers (proxy/gateway error, crash before
+// the SDK responded) must carry the synthesized fatal-upstream error as the
+// UserError's raw payload — the executor moves Raw() into
+// DriverResponse.Output, which is what the trace displays.
+func TestSyncNonSDKErrorResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(502)
+		_, _ = w.Write([]byte("Bad Gateway"))
+	}))
+	defer ts.Close()
+
+	client := exechttp.Client(exechttp.SecureDialerOpts{AllowPrivate: true})
+	d := &httpv2{Client: client}
+
+	u, _ := url.Parse(ts.URL)
+	fn := inngest.Function{
+		Driver: inngest.FunctionDriver{
+			URI: u.String(),
+			Metadata: map[string]any{
+				"type": "sync",
+			},
+		},
+	}
+
+	opts := driver.V2RequestOpts{
+		Fn:         fn,
+		SigningKey: []byte("test-key"),
+		Metadata: sv2.Metadata{
+			ID: sv2.ID{
+				RunID: ulid.MustNew(ulid.Now(), rand.Reader),
+			},
+		},
+		URL: u.String(),
+	}
+
+	resp, userErr, internalErr := d.Do(context.Background(), nil, opts)
+	require.Nil(t, resp)
+	require.NotNil(t, userErr)
+	require.NoError(t, internalErr)
+	require.Contains(t, userErr.Error(), "didn't receive SDK response")
+
+	var se sv1.StandardError
+	require.NoError(t, json.Unmarshal(userErr.Raw(), &se))
+	require.Equal(t, sv1.FatalServerErrorName, se.Name)
+	require.Contains(t, se.Message, "HTTP 502")
+	require.Contains(t, se.Stack, "Bad Gateway")
 }
 
 func TestSyncRequestErrors(t *testing.T) {

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -19,6 +19,15 @@ const (
 	DefaultErrorName        = "Error"
 	DefaultErrorMessage     = "Function execution error"
 	DefaultStepErrorMessage = "Step execution error"
+
+	// FatalServerErrorName is the error name shown for a transport-level non-2xx
+	// response that did not carry a structured Inngest error (see
+	// FatalUpstreamError).
+	FatalServerErrorName = "Server returned a fatal error"
+
+	// maxFatalUpstreamBodyBytes caps how much of an upstream response body we
+	// preserve in the synthesized error's stack, to avoid bloating span storage.
+	maxFatalUpstreamBodyBytes = 8192
 )
 
 type Retryable interface {
@@ -532,6 +541,53 @@ func (s StandardError) Serialize(key string) string {
 	}
 
 	return string(b)
+}
+
+// FatalUpstreamError constructs the serialized error output for a non-2xx
+// response that did not come from an SDK (per its headers) — e.g. a
+// proxy/gateway 5xx, or the app crashing or timing out before the SDK returned
+// a step response. In these cases the executor has a failed attempt but no
+// step output to attribute it to, which previously surfaced as an empty error
+// in the trace.
+//
+// The raw upstream body, if any, is preserved (truncated, content-type
+// labelled) in the error's stack so the user can see which layer failed.
+// Callers should set only DriverResponse.Output with this value and leave Err
+// untouched, so retry semantics are unchanged.
+func FatalUpstreamError(statusCode int, body []byte, contentType string) json.RawMessage {
+	// Keep the message to a single concise line — it renders in the truncated
+	// short-error row. The fuller explanation and the raw upstream body live in
+	// the stack, which renders in a full details block.
+	message := fmt.Sprintf("Your server returned HTTP %d before the SDK responded.", statusCode)
+
+	detail := "No step output was produced before the request failed — this can " +
+		"mean a proxy or load balancer in front of your app returned an error, " +
+		"or your app was unable to respond."
+
+	stack := detail
+	if len(body) > 0 {
+		b := body
+		truncated := ""
+		if len(b) > maxFatalUpstreamBodyBytes {
+			b = b[:maxFatalUpstreamBodyBytes]
+			truncated = "\n… (truncated)"
+		}
+		ct := contentType
+		if ct == "" {
+			ct = "unknown content-type"
+		}
+		stack = fmt.Sprintf("%s\n\nUpstream response (%s):\n%s%s", detail, ct, string(b), truncated)
+	}
+
+	se := StandardError{
+		Error:   message,
+		Name:    FatalServerErrorName,
+		Message: message,
+		Stack:   stack,
+	}
+	// Marshal of a string-only struct cannot fail.
+	out, _ := json.Marshal(se)
+	return out
 }
 
 func (r *DriverResponse) StandardError() StandardError {

--- a/pkg/execution/state/driver_response_test.go
+++ b/pkg/execution/state/driver_response_test.go
@@ -152,6 +152,75 @@ func TestDriverResponseFormatError(t *testing.T) {
 	}
 }
 
+func TestFatalUpstreamError(t *testing.T) {
+	t.Run("empty body: message + detail, no upstream section", func(t *testing.T) {
+		out := FatalUpstreamError(502, nil, "")
+
+		var se StandardError
+		require.NoError(t, json.Unmarshal(out, &se))
+		require.Equal(t, FatalServerErrorName, se.Name)
+		require.Equal(t, "Your server returned HTTP 502 before the SDK responded.", se.Message)
+		require.Contains(t, se.Stack, "No step output was produced")
+		require.NotContains(t, se.Stack, "Upstream response", "no body -> no upstream section")
+	})
+
+	t.Run("plain-text body preserved verbatim with content-type", func(t *testing.T) {
+		out := FatalUpstreamError(502, []byte("Bad Gateway"), "text/plain")
+
+		var se StandardError
+		require.NoError(t, json.Unmarshal(out, &se))
+		require.Equal(t, "Your server returned HTTP 502 before the SDK responded.", se.Message)
+		require.Contains(t, se.Stack, "Upstream response (text/plain):")
+		require.Contains(t, se.Stack, "Bad Gateway")
+	})
+
+	t.Run("html body is preserved as text (not parsed)", func(t *testing.T) {
+		body := []byte("<html><body>502 Bad Gateway</body></html>")
+		out := FatalUpstreamError(502, body, "text/html")
+
+		var se StandardError
+		require.NoError(t, json.Unmarshal(out, &se))
+		require.Contains(t, se.Stack, "Upstream response (text/html):")
+		require.Contains(t, se.Stack, string(body))
+	})
+
+	t.Run("empty content-type is labelled", func(t *testing.T) {
+		out := FatalUpstreamError(500, []byte("oops"), "")
+
+		var se StandardError
+		require.NoError(t, json.Unmarshal(out, &se))
+		require.Contains(t, se.Stack, "Upstream response (unknown content-type):")
+	})
+
+	t.Run("oversized body is truncated", func(t *testing.T) {
+		big := make([]byte, maxFatalUpstreamBodyBytes+500)
+		for i := range big {
+			big[i] = 'a'
+		}
+		out := FatalUpstreamError(503, big, "text/plain")
+
+		var se StandardError
+		require.NoError(t, json.Unmarshal(out, &se))
+		require.Contains(t, se.Stack, "… (truncated)")
+		// We must not preserve more than the cap (plus our label/detail text).
+		require.Less(t, len(se.Stack), maxFatalUpstreamBodyBytes+1000)
+	})
+
+	t.Run("round-trips through StandardError() as displayed to the user", func(t *testing.T) {
+		out := FatalUpstreamError(502, []byte("Bad Gateway"), "text/plain")
+
+		// This mirrors what the driver does: set Output + keep the status Err.
+		dr := DriverResponse{
+			Output: json.RawMessage(out),
+			Err:    strptr("invalid status code: 502"),
+		}
+		se := dr.StandardError()
+		require.Equal(t, FatalServerErrorName, se.Name)
+		require.Equal(t, "Your server returned HTTP 502 before the SDK responded.", se.Message)
+		require.Contains(t, se.Stack, "Bad Gateway")
+	})
+}
+
 func TestGeneratorSleepDuration(t *testing.T) {
 	// Check that this works with a timestamp
 	at := time.Now().Truncate(time.Second).Add(time.Minute)

--- a/tests/golang/non_json_output_test.go
+++ b/tests/golang/non_json_output_test.go
@@ -2,6 +2,7 @@ package golang
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/inngest/inngest/pkg/execution/state"
 	"github.com/inngest/inngest/tests/client"
 	"github.com/inngest/inngestgo"
 )
@@ -96,6 +98,15 @@ func TestNonJSONOutput(t *testing.T) {
 		}, 5*time.Second, 100*time.Millisecond)
 
 		run := c.WaitForRunStatus(ctx, t, "FAILED", runID)
-		r.Equal("<html>502 Bad Gateway</html>", run.Output)
+
+		// The upstream (proxy) returned a non-2xx without SDK headers, so the
+		// executor synthesizes a structured error instead of surfacing the raw
+		// HTML body. The raw body is preserved (content-type labelled) inside
+		// the stack so the user can still see what the upstream returned.
+		var se state.StandardError
+		r.NoError(json.Unmarshal([]byte(run.Output), &se))
+		r.Equal(state.FatalServerErrorName, se.Name)
+		r.Contains(se.Message, "HTTP 504")
+		r.Contains(se.Stack, "<html>502 Bad Gateway</html>")
 	})
 }


### PR DESCRIPTION
## Description

- While responding to a request from the executor, we may receive an error response that did not come from the SDK. Maybe an intermediary proxy or load balancer timed out, or maybe the app timed out before responding.
- Previously, our trace displayed a raw upstream body, and it looks like Inngest server-side had a failure
- In this PR, we improve response to provide more informative copy to the user that clarifies the error occurred on the side of the app or proxy.

We provide the following:

```
- name: "Server returned a fatal error"
- message: "Your server returned HTTP <code> before the SDK responded."
- stack: an explanation plus the raw upstream body, content-type labelled and truncated at 8KB
```

<img width="1356" height="735" alt="Screenshot 2026-07-07 at 11 30 23 AM" src="https://github.com/user-attachments/assets/c926badb-cdee-4da3-9635-38dc9d21859a" />

We'll address where spans roll up in the UI in a separate PR.

https://linear.app/inngest/issue/EXE-1725/unknown-step-attempts-are-shown-as-finalization

## Release note

Augment responses to better identify when error responses do not come the SDK but rather intermediary proxies or app timeouts.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
