### PR TITLE
ci(go): Move one unit test job to Depot

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [depot-ubuntu-22.04-4]
         database: [sqlite, postgres]
     runs-on: ${{ matrix.os }}
     name: "Test / OS: ${{ matrix.os }}, db: ${{ matrix.database }}"


### PR DESCRIPTION


## Description

- Move one unit test job to Depot from GitHub Action Runners
- These are the longest step slightly more than 50% of the time
- Let's utilize depot to gain caching for compilation, particularly the longer `-race` ones
- This improves time to completion by ~2m comparing with another recent PR, not counting when GitHub Action Runner queue time is outlandish

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
