### PR TITLE
fix: Display errored attempts without step as `Function Error` rather than Finalization

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
@@ -503,8 +503,8 @@ describe('traceConversion', () => {
       const result = traceRollup(root);
 
       expect(result.childrenSpans?.map((c) => c.spanID)).toEqual(['s2', 's1']);
-      expect(result.childrenSpans?.[1]).toBe(step1);
-      expect(step1.name).toBe('test-step'); // no "Attempt N" renaming
+      expect(result.childrenSpans?.[1]).toEqual(step1); // clone of the input span
+      expect(result.childrenSpans?.[1]?.name).toBe('test-step'); // no "Attempt N" renaming
     });
 
     it('rolls up a multi-attempt step into a virtual span', () => {
@@ -676,8 +676,8 @@ describe('traceConversion', () => {
       const result = traceRollup(root);
 
       expect(result.childrenSpans).toHaveLength(1);
-      expect(result.childrenSpans?.[0]).toBe(outputSpan);
-      expect(outputSpan.name).toBe('test-step');
+      expect(result.childrenSpans?.[0]).toEqual(outputSpan); // clone of the input span
+      expect(result.childrenSpans?.[0]?.name).toBe('test-step');
     });
 
     it('drops spans without a stepID/outputID and step spans with null attempts', () => {
@@ -1136,6 +1136,65 @@ describe('traceConversion', () => {
       const out = traceRollup(structuredClone(root));
 
       expect(childNames(out)).toContain('Finalization');
+    });
+    // traceRollup must NOT mutate its input. The result is memoized against the
+    // trace object, so on a re-render the memo re-runs traceRollup(trace) on the
+    // same object; if that object had been mutated into the rolled-up shape, the
+    // "Function error" group would collapse to a single span and get relabeled
+    // "Finalization". Non-mutation keeps every call operating on pristine input.
+    it('does not mutate its input, so repeated calls are stable', () => {
+      const root = createTrace({
+        isRoot: true,
+        spanID: 'run',
+        name: 'Run',
+        status: 'FAILED',
+        stepID: null,
+        stepOp: null,
+        groupID: 'g-root',
+        childrenSpans: [
+          createTrace({
+            spanID: 'n0',
+            name: 'executor.nonstep',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            attempts: 0,
+            groupID: 'g-root',
+            outputID: 'o0',
+          }),
+          createTrace({
+            spanID: 'n1',
+            name: 'executor.nonstep',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            attempts: 1,
+            groupID: 'g-root',
+            outputID: 'o1',
+          }),
+          createTrace({
+            spanID: 'n2',
+            name: 'executor.nonstep',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            attempts: 2,
+            groupID: 'g-root',
+            outputID: 'o2',
+          }),
+        ],
+      });
+      const frozen = JSON.stringify(root);
+
+      const first = traceRollup(root);
+      // Input is untouched: the rollup operates on a clone.
+      expect(JSON.stringify(root)).toBe(frozen);
+      expect(childNames(first)).toContain('Function error');
+
+      // Re-running on the same (still-pristine) input yields the same labels —
+      // this is what the memoized render does across re-renders/polls.
+      const second = traceRollup(root);
+      expect(childNames(second)).toEqual(childNames(first));
     });
   });
 });

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
@@ -18,7 +18,7 @@ describe('traceConversion', () => {
     name: 'test-step',
     outputID: null,
     queuedAt: '2024-01-01T00:00:00Z',
-    scheduledAt: null,
+    scheduledAt: '2024-01-01T00:00:00Z',
     spanID: 'span-1',
     stepID: 'step-1',
     startedAt: '2024-01-01T00:00:02Z',
@@ -615,7 +615,7 @@ describe('traceConversion', () => {
       expect(finalization?.endedAt).toBe('2024-01-01T00:00:11Z');
     });
 
-    it('rolls up a multi-attempt finalization into a final-rollup virtual span', () => {
+    it('rolls up a multi-attempt unmatched group into a final-rollup virtual span', () => {
       const step = createTrace({
         spanID: 's1',
         stepID: 'step-1',
@@ -652,6 +652,8 @@ describe('traceConversion', () => {
       expect(result.childrenSpans).toHaveLength(2);
       const finalization = result.childrenSpans?.[1];
       expect(finalization?.spanID).toBe('final-rollup');
+      // The group ends COMPLETED, so this is a genuine (retried) finalization
+      // — not a "Function error"
       expect(finalization?.name).toBe('Finalization');
       // Start clamped to the last step's end, end from the last attempt
       expect(finalization?.queuedAt).toBe('2024-01-01T00:00:10Z');
@@ -819,9 +821,10 @@ describe('traceConversion', () => {
     // the SDK responded each time (the outputs hold the user's actual error),
     // so this is the run's terminal work. The span shape is identical to Case
     // B's pre-SDK deaths minus the backend group span — the client cannot
-    // tell them apart — but the intended label differs. Locks in the current
-    // "Finalization" label for exhausted-retry function errors.
-    it('labels an exhausted-retry function error as "Finalization"', () => {
+    // tell them apart — which is exactly why the label is the neutral
+    // "Function error": truthful whether the group holds the function's own
+    // error or attempts that died before the SDK responded.
+    it('labels an exhausted-retry function error as "Function error"', () => {
       const root = createTrace({
         isRoot: true,
         spanID: 'run',
@@ -868,7 +871,7 @@ describe('traceConversion', () => {
       const rollup = out.childrenSpans?.find((c) => c.spanID === 'final-rollup');
 
       expect(out.childrenSpans).toHaveLength(1);
-      expect(rollup?.name).toBe('Finalization');
+      expect(rollup?.name).toBe('Function error');
       expect(rollup?.childrenSpans?.map((c) => c.name)).toEqual([
         'Attempt 0',
         'Attempt 1',
@@ -878,10 +881,10 @@ describe('traceConversion', () => {
 
     // Case B: the step 5xx's on every attempt, so its ID is never learned. The
     // server emits a pre-grouped backend span (no groupID, holds the attempts)
-    // plus loose per-attempt spans. Current behavior: the loose attempts roll
-    // into a "Finalization" group, so the run renders two "Finalization"
-    // spans — the backend passthrough duplicates the rollup.
-    it('rolls never-resolved failed attempts into a "Finalization" group', () => {
+    // plus loose per-attempt spans. The grouped attempts have no step to
+    // attribute to -> "Function error"; the backend passthrough still renders
+    // alongside it (de-duping it is intentionally out of scope here).
+    it('labels never-resolved failed attempts "Function error", not "Finalization"', () => {
       const root = createTrace({
         isRoot: true,
         spanID: 'run',
@@ -963,12 +966,10 @@ describe('traceConversion', () => {
       const out = traceRollup(structuredClone(root));
       const rollup = out.childrenSpans?.find((c) => c.spanID === 'final-rollup');
 
-      expect(rollup?.name).toBe('Finalization');
+      // The rolled-up loose attempts are now surfaced as a function error.
+      expect(rollup?.name).toBe('Function error');
       expect(rollup?.childrenSpans).toHaveLength(3);
-
-      // Current behavior: the backend passthrough is kept, duplicating the
-      // rolled-up group.
-      expect(childNames(out)).toEqual(['Finalization', 'Finalization']);
+      expect(childNames(out)).toEqual(['Finalization', 'Function error']);
     });
 
     // The final discovery itself can retry: the request after the last step
@@ -976,8 +977,9 @@ describe('traceConversion', () => {
     // trace: the server emits a pre-grouped "Finalization" span (with a stepID
     // and no groupID) plus the loose per-attempt spans. Current behavior: the
     // pre-grouped span passes through via the steps map and the loose attempts
-    // roll into a second "Finalization" group.
-    it('rolls a retried-but-successful finalization into a "Finalization" group', () => {
+    // roll into a group ending COMPLETED — a genuine (retried) finalization,
+    // not an unresolved step.
+    it('labels a retried-but-successful finalization "Finalization", not "Function error"', () => {
       const root = createTrace({
         isRoot: true,
         spanID: 'run',
@@ -1050,15 +1052,14 @@ describe('traceConversion', () => {
       expect(rollup?.status).toBe('COMPLETED');
       expect(rollup?.childrenSpans?.map((c) => c.name)).toEqual(['Attempt 0', 'Attempt 1']);
 
-      // Current behavior: the backend pre-grouped span renders alongside the
-      // rollup, so the finalization appears twice.
+      // The backend pre-grouped span still renders alongside the rollup
+      // (de-duped server-side; out of scope for the client rollup).
       expect(childNames(out)).toEqual(['Finalization', 'work', 'Finalization']);
     });
 
-    // Case C: a single pre-SDK failure (e.g. retries: 0). The lone nonstep is
-    // relabeled "Finalization" via the single-attempt branch, and the backend
-    // passthrough renders alongside it — the same duplication as above with a
-    // single attempt.
+    // Case C: a single pre-SDK failure (e.g. retries: 0). The lone FAILED
+    // nonstep is labeled "Function error" (status-based naming: the group is
+    // where the run failed); the backend passthrough renders alongside it.
     it('renders a single failed pre-stepID attempt alongside its backend passthrough', () => {
       const root = createTrace({
         isRoot: true,
@@ -1095,7 +1096,7 @@ describe('traceConversion', () => {
       const out = traceRollup(structuredClone(root));
 
       expect(out.childrenSpans).toHaveLength(2);
-      expect(childNames(out)).toEqual(['Finalization', 'Finalization']);
+      expect(childNames(out)).toEqual(['Finalization', 'Function error']);
     });
 
     // Case D: a groupID-less finalization span with NO failed pre-SDK attempt

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
@@ -437,17 +437,32 @@ function rollupStepAttempts(stepID: string, attempts: Map<number, Trace>): Trace
 }
 
 /**
- * Roll up the finalization group's attempts into a single "Finalization"
- * span. Finalization spans can carry queue timestamps from before the last
- * step finished, so start timestamps are clamped to the last step's end to
- * keep the timeline ordered.
+ * Roll up the trailing unmatched group's attempts into a single span. These
+ * spans can carry queue timestamps from before the last step finished, so
+ * start timestamps are clamped to the last step's end to keep the timeline
+ * ordered.
+ *
+ * Naming is decided by how the group ended, not by attempt count — the final
+ * discovery itself can retry (e.g. the app 500s on the final request, then
+ * succeeds), so multiple attempts don't imply an unresolved step:
+ * - Ends COMPLETED: only the finalization can produce the function's output
+ *   with no stepID (a step that succeeds gets a stepID and is claimed out of
+ *   the trailing group), so this is genuinely "Finalization".
+ * - Ends FAILED: this group is the site of the run's failure, but the client
+ *   can't tell why — the attempts may have died before the SDK identified the
+ *   work, or the SDK may have returned the function's own terminal error.
+ *   "Function error" is neutral and truthful for both, unlike "Finalization",
+ *   which implies a normal wind-down.
+ * - Still running: default to "Finalization" rather than flickering "Function
+ *   error" on in-flight runs.
  */
 function rollupFinalization(attempts: Map<number, Trace>, lastStep: Trace | null): Trace {
   const { first, last } = attemptBounds(attempts);
   const notBefore = lastStep?.endedAt;
+  const name = last.status === 'FAILED' ? 'Function error' : 'Finalization';
 
   if (attempts.size === 1) {
-    last.name = 'Finalization';
+    last.name = name;
     last.queuedAt = maxDateString(last.queuedAt, notBefore);
     last.scheduledAt = maxDateString(last.scheduledAt, notBefore);
     last.startedAt = maxDateString(last.startedAt, notBefore);
@@ -457,7 +472,7 @@ function rollupFinalization(attempts: Map<number, Trace>, lastStep: Trace | null
   return {
     isRoot: false,
     isUserland: false,
-    name: 'Finalization',
+    name,
     spanID: `final-rollup`, // virtual span
     groupID: last.groupID,
     attempts: last.attempts,

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
@@ -498,6 +498,15 @@ function rollupFinalization(attempts: Map<number, Trace>, lastStep: Trace | null
 // display in the timeline while still allowing users to see
 // individual attempts when they expand the step details.
 export function traceRollup(root: Trace): Trace {
+  // Operate on a clone so we never mutate the caller's (cached) trace. The
+  // rolled-up result is memoized against the trace object; without this, a
+  // re-render would feed our own output back in and roll it up a second time
+  // (which, e.g., collapses the multi-attempt "Function error" group into a
+  // single-span group and relabels it — see rollupFinalization's size === 1
+  // branch). The helpers below rename/reshape spans in place, which is safe
+  // precisely because they only ever see this clone.
+  root = structuredClone(root);
+
   const { stepOrder, steps, passthrough, finalizationAttempts, lastStep } = collectRollupGroups(
     root.childrenSpans ?? []
   );


### PR DESCRIPTION
## Description

- Currently, we may have attempts that error before reaching the SDK, and thus do not contain which step they're a part of. These steps are wrapped under the name finalization today, which is misleading.
- Let's rename these as `Function Error`. I originally named them `Unknown Step` given they match a step, however on the rendering side, we cannot distinguish these errors from a stepless function that errors and exhausts retries. `Function Error` provides a name that can apply to both and does not require adding identifiers server-side.
- There is still a duplicate "finalization" containing clones of all the failed attempts. We address that separately in https://github.com/inngest/inngest/pull/4598

<img width="735" height="470" alt="Screenshot 2026-07-10 at 10 57 04 AM" src="https://github.com/user-attachments/assets/0295f185-fc65-4e8e-b686-6ea3e212d2af" />


https://linear.app/inngest/issue/EXE-1725/unknown-step-attempts-are-shown-as-finalization


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
Errored attempts that never resolved to a step are displayed as "Function error" rather than "Finalization" in the trace view.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*