### PR TITLE
feat: bring AI Metadata extraction from extended traces to parity with JS SDK

### DIFF
--- a/pkg/tracing/metadata/extractors/ai.go
+++ b/pkg/tracing/metadata/extractors/ai.go
@@ -39,6 +39,22 @@ type AIMetadata struct {
 	LatencyMs     *int64   `json:"latency_ms,omitempty"`
 	TotalTokens   *int64   `json:"total_tokens,omitempty"`
 	EstimatedCost *float64 `json:"estimated_cost,omitempty"`
+
+	// Granular token usage. Cache semantics differ by provider: OpenAI reports
+	// cached tokens as a subset of InputTokens, whereas Anthropic reports them
+	// additively — values are stored raw and left unreconciled.
+	CacheReadTokens     *int64 `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens *int64 `json:"cache_creation_tokens,omitempty"`
+	ReasoningTokens     *int64 `json:"reasoning_tokens,omitempty"`
+
+	// Request parameters. Pointers so an explicit zero (e.g. temperature 0 or
+	// seed 0) is distinguishable from an absent attribute.
+	Temperature      *float64 `json:"temperature,omitempty"`
+	TopP             *float64 `json:"top_p,omitempty"`
+	MaxTokens        *int64   `json:"max_tokens,omitempty"`
+	FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
+	PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
+	Seed             *int64   `json:"seed,omitempty"`
 }
 
 func (ms AIMetadata) Kind() metadata.Kind {

--- a/pkg/tracing/metadata/extractors/aimetadata_test.go
+++ b/pkg/tracing/metadata/extractors/aimetadata_test.go
@@ -30,6 +30,16 @@ type goldenAIMetadata struct {
 	InputTokens   int64    `json:"input_tokens"`
 	OutputTokens  int64    `json:"output_tokens"`
 	TotalTokens   *int64   `json:"total_tokens"`
+
+	CacheReadTokens     *int64   `json:"cache_read_tokens"`
+	CacheCreationTokens *int64   `json:"cache_creation_tokens"`
+	ReasoningTokens     *int64   `json:"reasoning_tokens"`
+	Temperature         *float64 `json:"temperature"`
+	TopP                *float64 `json:"top_p"`
+	MaxTokens           *int64   `json:"max_tokens"`
+	FrequencyPenalty    *float64 `json:"frequency_penalty"`
+	PresencePenalty     *float64 `json:"presence_penalty"`
+	Seed                *int64   `json:"seed"`
 }
 
 // TestAIMetadataExtractor_CapturedFixtures asserts AIMetadata extraction
@@ -38,10 +48,10 @@ type goldenAIMetadata struct {
 // order. Regenerate with `go test -update`; see testdata/README.md for how
 // fixtures were captured and per-instrumentation quirks.
 func TestAIMetadataExtractor_CapturedFixtures(t *testing.T) {
-	// goldenAIMetadata must mirror every asserted field of AIMetadata (9
+	// goldenAIMetadata must mirror every asserted field of AIMetadata (18
 	// rendered + the 2 deliberately-blanked LatencyMs/EstimatedCost). If this
 	// fails, a field was added: update goldenAIMetadata and regenerate.
-	require.Equal(t, 11, reflect.TypeFor[extractors.AIMetadata]().NumField(),
+	require.Equal(t, 20, reflect.TypeFor[extractors.AIMetadata]().NumField(),
 		"AIMetadata changed shape; update goldenAIMetadata and the goldens")
 
 	paths, err := fs.Glob(fixtures, "testdata/*/*.otlp.json")
@@ -86,6 +96,16 @@ func TestAIMetadataExtractor_CapturedFixtures(t *testing.T) {
 					InputTokens:   md.InputTokens,
 					OutputTokens:  md.OutputTokens,
 					TotalTokens:   md.TotalTokens,
+
+					CacheReadTokens:     md.CacheReadTokens,
+					CacheCreationTokens: md.CacheCreationTokens,
+					ReasoningTokens:     md.ReasoningTokens,
+					Temperature:         md.Temperature,
+					TopP:                md.TopP,
+					MaxTokens:           md.MaxTokens,
+					FrequencyPenalty:    md.FrequencyPenalty,
+					PresencePenalty:     md.PresencePenalty,
+					Seed:                md.Seed,
 				}))
 			}
 

--- a/pkg/tracing/metadata/extractors/attributes.go
+++ b/pkg/tracing/metadata/extractors/attributes.go
@@ -1,6 +1,8 @@
 package extractors
 
 import (
+	"strconv"
+
 	v1 "go.opentelemetry.io/proto/otlp/common/v1"
 
 	"github.com/inngest/inngest/pkg/util"
@@ -61,5 +63,53 @@ func extractAIMetadataFromAttributes(attributes []*v1.KeyValue, md *AIMetadata) 
 	read("gen_ai.system", func(v *v1.AnyValue) { md.Provider = v.GetStringValue() })
 	read("gen_ai.provider.name", func(v *v1.AnyValue) { md.Provider = v.GetStringValue() })
 
+	// Granular token usage.
+	read("gen_ai.usage.cache_read.input_tokens", func(v *v1.AnyValue) { md.CacheReadTokens = intFromAny(v) })
+	read("gen_ai.usage.cache_creation.input_tokens", func(v *v1.AnyValue) { md.CacheCreationTokens = intFromAny(v) })
+	read("gen_ai.usage.reasoning.output_tokens", func(v *v1.AnyValue) { md.ReasoningTokens = intFromAny(v) })
+
+	// Request parameters.
+	read("gen_ai.request.temperature", func(v *v1.AnyValue) { md.Temperature = floatFromAny(v) })
+	read("gen_ai.request.top_p", func(v *v1.AnyValue) { md.TopP = floatFromAny(v) })
+	read("gen_ai.request.max_tokens", func(v *v1.AnyValue) { md.MaxTokens = intFromAny(v) })
+	read("gen_ai.request.frequency_penalty", func(v *v1.AnyValue) { md.FrequencyPenalty = floatFromAny(v) })
+	read("gen_ai.request.presence_penalty", func(v *v1.AnyValue) { md.PresencePenalty = floatFromAny(v) })
+	read("gen_ai.request.seed", func(v *v1.AnyValue) { md.Seed = intFromAny(v) })
+
 	return foundAny
+}
+
+// intFromAny coerces an OTLP attribute to *int64. OTLP encoders are
+// inconsistent about int-vs-double-vs-string for numeric values, so we accept
+// an int, a double, or a numeric string (mirroring the JS SDK's Number()
+// coercion). Returns nil when the value can't be read as a number.
+func intFromAny(v *v1.AnyValue) *int64 {
+	switch v.GetValue().(type) {
+	case *v1.AnyValue_IntValue:
+		return util.ToPtr(v.GetIntValue())
+	case *v1.AnyValue_DoubleValue:
+		return util.ToPtr(int64(v.GetDoubleValue()))
+	case *v1.AnyValue_StringValue:
+		if n, err := strconv.ParseFloat(v.GetStringValue(), 64); err == nil {
+			return util.ToPtr(int64(n))
+		}
+	}
+	return nil
+}
+
+// floatFromAny coerces an OTLP attribute to *float64, accepting a double, an
+// int, or a numeric string. Returns nil when the value can't be read as a
+// number.
+func floatFromAny(v *v1.AnyValue) *float64 {
+	switch v.GetValue().(type) {
+	case *v1.AnyValue_DoubleValue:
+		return util.ToPtr(v.GetDoubleValue())
+	case *v1.AnyValue_IntValue:
+		return util.ToPtr(float64(v.GetIntValue()))
+	case *v1.AnyValue_StringValue:
+		if n, err := strconv.ParseFloat(v.GetStringValue(), 64); err == nil {
+			return util.ToPtr(n)
+		}
+	}
+	return nil
 }

--- a/pkg/tracing/metadata/extractors/attributes_test.go
+++ b/pkg/tracing/metadata/extractors/attributes_test.go
@@ -21,6 +21,13 @@ func intAttr(key string, value int64) *v1.KeyValue {
 	}
 }
 
+func dblAttr(key string, value float64) *v1.KeyValue {
+	return &v1.KeyValue{
+		Key:   key,
+		Value: &v1.AnyValue{Value: &v1.AnyValue_DoubleValue{DoubleValue: value}},
+	}
+}
+
 func arrAttr(key string, values ...string) *v1.KeyValue {
 	vals := make([]*v1.AnyValue, len(values))
 	for i, s := range values {
@@ -80,5 +87,71 @@ func TestFinishReasons(t *testing.T) {
 		extractAIMetadataFromAttributes(
 			[]*v1.KeyValue{strAttr("gen_ai.response.finish_reasons", "")}, &md)
 		assert.Nil(t, md.FinishReasons)
+	})
+}
+
+// TestGranularUsageAndRequestParams verifies extraction of the granular usage
+// and request-parameter attributes into their pointer fields.
+func TestGranularUsageAndRequestParams(t *testing.T) {
+	t.Parallel()
+
+	var md AIMetadata
+	ok := extractAIMetadataFromAttributes([]*v1.KeyValue{
+		intAttr("gen_ai.usage.cache_read.input_tokens", 100),
+		intAttr("gen_ai.usage.cache_creation.input_tokens", 25),
+		intAttr("gen_ai.usage.reasoning.output_tokens", 40),
+		dblAttr("gen_ai.request.temperature", 0.7),
+		dblAttr("gen_ai.request.top_p", 0.9),
+		intAttr("gen_ai.request.max_tokens", 1024),
+		dblAttr("gen_ai.request.frequency_penalty", 0.5),
+		dblAttr("gen_ai.request.presence_penalty", -0.25),
+		intAttr("gen_ai.request.seed", 42),
+	}, &md)
+
+	assert.True(t, ok)
+	assert.Equal(t, int64(100), *md.CacheReadTokens)
+	assert.Equal(t, int64(25), *md.CacheCreationTokens)
+	assert.Equal(t, int64(40), *md.ReasoningTokens)
+	assert.Equal(t, 0.7, *md.Temperature)
+	assert.Equal(t, 0.9, *md.TopP)
+	assert.Equal(t, int64(1024), *md.MaxTokens)
+	assert.Equal(t, 0.5, *md.FrequencyPenalty)
+	assert.Equal(t, -0.25, *md.PresencePenalty)
+	assert.Equal(t, int64(42), *md.Seed)
+}
+
+// TestNumericCoercion verifies the int/double/string fallbacks, since OTLP
+// encoders are inconsistent about how they encode numeric attribute values.
+func TestNumericCoercion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("int field accepts double and string", func(t *testing.T) {
+		var md AIMetadata
+		ok := extractAIMetadataFromAttributes([]*v1.KeyValue{
+			dblAttr("gen_ai.request.max_tokens", 2048),
+			strAttr("gen_ai.request.seed", "7"),
+		}, &md)
+		assert.True(t, ok)
+		assert.Equal(t, int64(2048), *md.MaxTokens)
+		assert.Equal(t, int64(7), *md.Seed)
+	})
+
+	t.Run("float field accepts int and string", func(t *testing.T) {
+		var md AIMetadata
+		ok := extractAIMetadataFromAttributes([]*v1.KeyValue{
+			intAttr("gen_ai.request.temperature", 1),
+			strAttr("gen_ai.request.top_p", "0.95"),
+		}, &md)
+		assert.True(t, ok)
+		assert.Equal(t, 1.0, *md.Temperature)
+		assert.Equal(t, 0.95, *md.TopP)
+	})
+
+	t.Run("unparseable string leaves field unset", func(t *testing.T) {
+		var md AIMetadata
+		extractAIMetadataFromAttributes([]*v1.KeyValue{
+			strAttr("gen_ai.request.max_tokens", "not-a-number"),
+		}, &md)
+		assert.Nil(t, md.MaxTokens)
 	})
 }

--- a/pkg/tracing/metadata/extractors/testdata/anthropic_otel_traceloop/reasoning_messages.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/anthropic_otel_traceloop/reasoning_messages.otlp.json.out
@@ -10,5 +10,14 @@ SPAN chat claude-sonnet-4-6
   ],
   "input_tokens": 52,
   "output_tokens": 500,
-  "total_tokens": 552
+  "total_tokens": 552,
+  "cache_read_tokens": 0,
+  "cache_creation_tokens": 0,
+  "reasoning_tokens": null,
+  "temperature": null,
+  "top_p": null,
+  "max_tokens": 4096,
+  "frequency_penalty": null,
+  "presence_penalty": null,
+  "seed": null
 }

--- a/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/basic_responses.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/basic_responses.otlp.json.out
@@ -8,5 +8,14 @@ SPAN ChatOpenAI
   "finish_reasons": null,
   "input_tokens": 17,
   "output_tokens": 35,
-  "total_tokens": 52
+  "total_tokens": 52,
+  "cache_read_tokens": null,
+  "cache_creation_tokens": null,
+  "reasoning_tokens": null,
+  "temperature": null,
+  "top_p": null,
+  "max_tokens": null,
+  "frequency_penalty": null,
+  "presence_penalty": null,
+  "seed": null
 }

--- a/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/params_chat.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/params_chat.otlp.json.out
@@ -10,5 +10,14 @@ SPAN ChatOpenAI
   ],
   "input_tokens": 22,
   "output_tokens": 6,
-  "total_tokens": 28
+  "total_tokens": 28,
+  "cache_read_tokens": null,
+  "cache_creation_tokens": null,
+  "reasoning_tokens": null,
+  "temperature": null,
+  "top_p": null,
+  "max_tokens": null,
+  "frequency_penalty": null,
+  "presence_penalty": null,
+  "seed": null
 }

--- a/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/reasoning_responses.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/reasoning_responses.otlp.json.out
@@ -8,5 +8,14 @@ SPAN ChatOpenAI
   "finish_reasons": null,
   "input_tokens": 17,
   "output_tokens": 12,
-  "total_tokens": 29
+  "total_tokens": 29,
+  "cache_read_tokens": null,
+  "cache_creation_tokens": null,
+  "reasoning_tokens": null,
+  "temperature": null,
+  "top_p": null,
+  "max_tokens": null,
+  "frequency_penalty": null,
+  "presence_penalty": null,
+  "seed": null
 }

--- a/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/tools_chat.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_langsmith_otel/tools_chat.otlp.json.out
@@ -10,5 +10,14 @@ SPAN ChatOpenAI
   ],
   "input_tokens": 56,
   "output_tokens": 30,
-  "total_tokens": 86
+  "total_tokens": 86,
+  "cache_read_tokens": null,
+  "cache_creation_tokens": null,
+  "reasoning_tokens": null,
+  "temperature": null,
+  "top_p": null,
+  "max_tokens": null,
+  "frequency_penalty": null,
+  "presence_penalty": null,
+  "seed": null
 }

--- a/pkg/tracing/metadata/extractors/testdata/openai_otel_official/embeddings.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_otel_official/embeddings.otlp.json.out
@@ -8,5 +8,14 @@ SPAN embeddings text-embedding-3-small
   "finish_reasons": null,
   "input_tokens": 10,
   "output_tokens": 0,
-  "total_tokens": 10
+  "total_tokens": 10,
+  "cache_read_tokens": null,
+  "cache_creation_tokens": null,
+  "reasoning_tokens": null,
+  "temperature": null,
+  "top_p": null,
+  "max_tokens": null,
+  "frequency_penalty": null,
+  "presence_penalty": null,
+  "seed": null
 }

--- a/pkg/tracing/metadata/extractors/testdata/openai_otel_official/params_chat.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_otel_official/params_chat.otlp.json.out
@@ -10,5 +10,14 @@ SPAN chat gpt-4.1-nano
   ],
   "input_tokens": 22,
   "output_tokens": 6,
-  "total_tokens": 28
+  "total_tokens": 28,
+  "cache_read_tokens": null,
+  "cache_creation_tokens": null,
+  "reasoning_tokens": null,
+  "temperature": 0.7,
+  "top_p": 0.9,
+  "max_tokens": 64,
+  "frequency_penalty": 0.2,
+  "presence_penalty": 0.1,
+  "seed": null
 }

--- a/pkg/tracing/metadata/extractors/testdata/openai_otel_official/stream_chat.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_otel_official/stream_chat.otlp.json.out
@@ -10,5 +10,14 @@ SPAN chat gpt-4.1-nano
   ],
   "input_tokens": 11,
   "output_tokens": 10,
-  "total_tokens": 21
+  "total_tokens": 21,
+  "cache_read_tokens": null,
+  "cache_creation_tokens": null,
+  "reasoning_tokens": null,
+  "temperature": null,
+  "top_p": null,
+  "max_tokens": null,
+  "frequency_penalty": null,
+  "presence_penalty": null,
+  "seed": null
 }

--- a/pkg/tracing/metadata/extractors/testdata/openai_otel_official/tools_chat.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_otel_official/tools_chat.otlp.json.out
@@ -10,5 +10,14 @@ SPAN chat gpt-4.1-nano
   ],
   "input_tokens": 56,
   "output_tokens": 14,
-  "total_tokens": 70
+  "total_tokens": 70,
+  "cache_read_tokens": null,
+  "cache_creation_tokens": null,
+  "reasoning_tokens": null,
+  "temperature": null,
+  "top_p": null,
+  "max_tokens": null,
+  "frequency_penalty": null,
+  "presence_penalty": null,
+  "seed": null
 }

--- a/pkg/tracing/metadata/extractors/testdata/openai_otel_traceloop/basic_responses.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_otel_traceloop/basic_responses.otlp.json.out
@@ -10,5 +10,14 @@ SPAN chat gpt-5.4-nano
   ],
   "input_tokens": 17,
   "output_tokens": 44,
-  "total_tokens": 61
+  "total_tokens": 61,
+  "cache_read_tokens": null,
+  "cache_creation_tokens": null,
+  "reasoning_tokens": null,
+  "temperature": null,
+  "top_p": null,
+  "max_tokens": null,
+  "frequency_penalty": null,
+  "presence_penalty": null,
+  "seed": null
 }

--- a/pkg/tracing/metadata/extractors/testdata/openai_otel_traceloop/params_chat.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_otel_traceloop/params_chat.otlp.json.out
@@ -10,5 +10,14 @@ SPAN chat gpt-4.1-nano
   ],
   "input_tokens": 22,
   "output_tokens": 6,
-  "total_tokens": 28
+  "total_tokens": 28,
+  "cache_read_tokens": null,
+  "cache_creation_tokens": null,
+  "reasoning_tokens": null,
+  "temperature": 0.7,
+  "top_p": 0.9,
+  "max_tokens": 64,
+  "frequency_penalty": 0.2,
+  "presence_penalty": 0.1,
+  "seed": null
 }

--- a/pkg/tracing/metadata/extractors/testdata/openai_otel_traceloop/reasoning_responses.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_otel_traceloop/reasoning_responses.otlp.json.out
@@ -10,5 +10,14 @@ SPAN chat gpt-5.4-nano
   ],
   "input_tokens": 17,
   "output_tokens": 13,
-  "total_tokens": 30
+  "total_tokens": 30,
+  "cache_read_tokens": null,
+  "cache_creation_tokens": null,
+  "reasoning_tokens": null,
+  "temperature": null,
+  "top_p": null,
+  "max_tokens": null,
+  "frequency_penalty": null,
+  "presence_penalty": null,
+  "seed": null
 }

--- a/pkg/tracing/metadata/extractors/testdata/openai_otel_traceloop/stream_chat.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_otel_traceloop/stream_chat.otlp.json.out
@@ -10,5 +10,14 @@ SPAN chat gpt-4.1-nano
   ],
   "input_tokens": 0,
   "output_tokens": 0,
-  "total_tokens": null
+  "total_tokens": null,
+  "cache_read_tokens": null,
+  "cache_creation_tokens": null,
+  "reasoning_tokens": null,
+  "temperature": null,
+  "top_p": null,
+  "max_tokens": null,
+  "frequency_penalty": null,
+  "presence_penalty": null,
+  "seed": null
 }

--- a/pkg/tracing/metadata/extractors/testdata/openai_otel_traceloop/tools_chat.otlp.json.out
+++ b/pkg/tracing/metadata/extractors/testdata/openai_otel_traceloop/tools_chat.otlp.json.out
@@ -10,5 +10,14 @@ SPAN chat gpt-4.1-nano
   ],
   "input_tokens": 56,
   "output_tokens": 14,
-  "total_tokens": 70
+  "total_tokens": 70,
+  "cache_read_tokens": null,
+  "cache_creation_tokens": null,
+  "reasoning_tokens": null,
+  "temperature": null,
+  "top_p": null,
+  "max_tokens": null,
+  "frequency_penalty": null,
+  "presence_penalty": null,
+  "seed": null
 }

--- a/pkg/tracing/metadata/types/types_gen.go
+++ b/pkg/tracing/metadata/types/types_gen.go
@@ -40,6 +40,22 @@ type AIMetadata struct {
 	LatencyMs     *int64   `json:"latency_ms,omitempty"`
 	TotalTokens   *int64   `json:"total_tokens,omitempty"`
 	EstimatedCost *float64 `json:"estimated_cost,omitempty"`
+
+	// Granular token usage. Cache semantics differ by provider: OpenAI reports
+	// cached tokens as a subset of InputTokens, whereas Anthropic reports them
+	// additively — values are stored raw and left unreconciled.
+	CacheReadTokens     *int64 `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens *int64 `json:"cache_creation_tokens,omitempty"`
+	ReasoningTokens     *int64 `json:"reasoning_tokens,omitempty"`
+
+	// Request parameters. Pointers so an explicit zero (e.g. temperature 0 or
+	// seed 0) is distinguishable from an absent attribute.
+	Temperature      *float64 `json:"temperature,omitempty"`
+	TopP             *float64 `json:"top_p,omitempty"`
+	MaxTokens        *int64   `json:"max_tokens,omitempty"`
+	FrequencyPenalty *float64 `json:"frequency_penalty,omitempty"`
+	PresencePenalty  *float64 `json:"presence_penalty,omitempty"`
+	Seed             *int64   `json:"seed,omitempty"`
 }
 
 // From experiment.go

--- a/ui/packages/components/src/generated/index.ts
+++ b/ui/packages/components/src/generated/index.ts
@@ -58,6 +58,24 @@ export interface AIMetadata {
   latency_ms?: number /* int64 */;
   total_tokens?: number /* int64 */;
   estimated_cost?: number /* float64 */;
+  /**
+   * Granular token usage. Cache semantics differ by provider: OpenAI reports
+   * cached tokens as a subset of InputTokens, whereas Anthropic reports them
+   * additively — values are stored raw and left unreconciled.
+   */
+  cache_read_tokens?: number /* int64 */;
+  cache_creation_tokens?: number /* int64 */;
+  reasoning_tokens?: number /* int64 */;
+  /**
+   * Request parameters. Pointers so an explicit zero (e.g. temperature 0 or
+   * seed 0) is distinguishable from an absent attribute.
+   */
+  temperature?: number /* float64 */;
+  top_p?: number /* float64 */;
+  max_tokens?: number /* int64 */;
+  frequency_penalty?: number /* float64 */;
+  presence_penalty?: number /* float64 */;
+  seed?: number /* int64 */;
 }
 /**
  * From experiment.go


### PR DESCRIPTION
## Description

- The JS SDK extracts many fields that OSS does not for extended traces
- Let's add them in

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
Extract granular token usage and request parameter information from extended traces for AI Metadata

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
