### PR TITLE
chore: remove unused TotalSystemQueueDepth from QueueManager interface

### DIFF
--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -60,10 +60,6 @@ type QueueManager interface {
 	Dequeue(ctx context.Context, queueShard QueueShard, i QueueItem, opts ...DequeueOptionFn) error
 	Requeue(ctx context.Context, queueShard QueueShard, i QueueItem, at time.Time, opts ...RequeueOptionFn) error
 	RequeueByJobID(ctx context.Context, queueShard QueueShard, jobID string, at time.Time) error
-
-	// PartitionBacklogSize returns the point in time backlog size of the partition.
-	// This will sum the size of all backlogs in that partition
-	PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error)
 }
 
 type KeyQueueProcessor interface {

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -64,9 +64,6 @@ type QueueManager interface {
 	// PartitionBacklogSize returns the point in time backlog size of the partition.
 	// This will sum the size of all backlogs in that partition
 	PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error)
-
-	// Total queue depth of all partitions including backlog and ready state items
-	TotalSystemQueueDepth(ctx context.Context, queueShard QueueShard) (int64, error)
 }
 
 type KeyQueueProcessor interface {

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -315,11 +315,6 @@ func (q *queueProcessor) Enqueue(ctx context.Context, item Item, at time.Time, o
 	return q.queueProducer.Enqueue(ctx, item, at, opts)
 }
 
-// TotalSystemQueueDepth implements QueueManager.
-func (q *queueProcessor) TotalSystemQueueDepth(ctx context.Context, shard QueueShard) (int64, error) {
-	return shard.TotalSystemQueueDepth(ctx)
-}
-
 // OutstandingJobCount implements Queue.
 func (q *queueProcessor) OutstandingJobCount(ctx context.Context, scope Scope, runID ulid.ULID) (int, error) {
 	var totalCount int64

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -265,7 +265,7 @@ func (q *queueProcessor) forAccountShards(ctx context.Context, accountID uuid.UU
 	return fn(ctx, shard)
 }
 
-// PartitionBacklogSize implements QueueManager.
+// PartitionBacklogSize implements JobQueueReader.
 func (q *queueProcessor) PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error) {
 	var totalCount int64
 

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -244,6 +244,10 @@ type JobQueueReader interface {
 	// status queue.
 	StatusCount(ctx context.Context, scope Scope, status string) (int64, error)
 
+	// PartitionBacklogSize returns the point-in-time backlog size of a partition
+	// by summing the size of all backlogs in that partition.
+	PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error)
+
 	// RunJobs reads items in the queue for a specific run.
 	RunJobs(ctx context.Context, queueShardName string, scope Scope, runID ulid.ULID, limit, offset int64) ([]JobResponse, error)
 


### PR DESCRIPTION
## Description

Remove unused TotalSystemQueueDepth from QueueManager interface. Nothing calls this in Cloud either.

Move PartitionBacklogSize to JobQueueReader. This is used only by TenantInstrumentation in Cloud.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
