### PR TITLE
refactor(queue): subsume QueueManager APIs into other appropriate narrow interfaces

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -585,6 +585,7 @@ func start(ctx context.Context, opts StartOpts) error {
 		executor.WithExecutionManager(dbcqrs),
 		executor.WithState(sm),
 		executor.WithServiceQueue(rq),
+		executor.WithServiceQueueProcessor(rq),
 		executor.WithServiceExecutor(exec),
 		executor.WithServiceBatcher(batcher),
 		executor.WithServiceDebouncer(debouncer),

--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -584,7 +584,6 @@ func start(ctx context.Context, opts StartOpts) error {
 		opts.Config,
 		executor.WithExecutionManager(dbcqrs),
 		executor.WithState(sm),
-		executor.WithServiceQueue(rq),
 		executor.WithServiceQueueProcessor(rq),
 		executor.WithServiceExecutor(exec),
 		executor.WithServiceBatcher(batcher),

--- a/pkg/execution/cron/manager_test.go
+++ b/pkg/execution/cron/manager_test.go
@@ -675,6 +675,14 @@ func (p *captureProducer) Enqueue(_ context.Context, item queue.Item, at time.Ti
 	return nil
 }
 
+func (p *captureProducer) Requeue(context.Context, string, queue.QueueItem, time.Time, ...queue.RequeueOptionFn) error {
+	return nil
+}
+
+func (p *captureProducer) RequeueByJobID(context.Context, string, string, time.Time) error {
+	return nil
+}
+
 func TestScheduleNextQueueName(t *testing.T) {
 	ctx := context.Background()
 	accountID := uuid.New()

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3510,7 +3510,7 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 		}
 
 		// And dequeue the timeout job to remove unneeded work from the queue, etc.
-		if q, ok := e.queue.(queue.QueueManager); ok {
+		if e.shards != nil {
 			// timeout jobs are enqueued to the workflow partition (see handleGeneratorWaitForEvent)
 			// this is _not_ a system partition and lives on the account shard, which we need to retrieve
 			shard, err := e.shards.Resolve(ctx, queue.Scope{
@@ -3523,7 +3523,7 @@ func (e *executor) Resume(ctx context.Context, pause state.Pause, r execution.Re
 			}
 
 			jobID := fmt.Sprintf("%s-%s", md.IdempotencyKey(), pause.DataKey)
-			err = q.Dequeue(ctx, shard, queue.QueueItem{
+			err = e.queue.Dequeue(ctx, shard.Name(), queue.QueueItem{
 				ID:         queue.HashID(ctx, jobID),
 				FunctionID: md.ID.FunctionID,
 				Data: queue.Item{

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -64,15 +64,10 @@ func WithExecutorOpts(opts ...ExecutorOpt) func(s *svc) {
 	}
 }
 
-func WithServiceQueue(q queue.Queue) func(s *svc) {
-	return func(s *svc) {
-		s.queue = q
-	}
-}
-
 func WithServiceQueueProcessor(qp queue.QueueProcessor) func(s *svc) {
 	return func(s *svc) {
 		s.queueProcessor = qp
+		s.queue = qp.Queue()
 	}
 }
 

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -130,6 +130,9 @@ func NewService(c config.Config, opts ...Opt) service.Service {
 	if svc.queueProcessor == nil {
 		panic("queue processor must be provided for executor service")
 	}
+	if svc.queue == nil {
+		panic("queue must be provided for executor service")
+	}
 
 	return svc
 }

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -70,6 +70,12 @@ func WithServiceQueue(q queue.Queue) func(s *svc) {
 	}
 }
 
+func WithServiceQueueProcessor(qp queue.QueueProcessor) func(s *svc) {
+	return func(s *svc) {
+		s.queueProcessor = qp
+	}
+}
+
 func WithServiceDebouncer(d debounce.Debouncer) func(s *svc) {
 	return func(s *svc) {
 		s.debouncer = d
@@ -126,6 +132,9 @@ func NewService(c config.Config, opts ...Opt) service.Service {
 	if svc.shards == nil {
 		panic("shard registry must be provided for executor service")
 	}
+	if svc.queueProcessor == nil {
+		panic("queue processor must be provided for executor service")
+	}
 
 	return svc
 }
@@ -138,6 +147,8 @@ type svc struct {
 	state state.Manager
 	// queue allows us to enqueue next steps.
 	queue queue.Queue
+	// queueProcessor owns queue worker lifecycle.
+	queueProcessor queue.QueueProcessor
 	// exec runs the specific actions.
 	exec      execution.Executor
 	debouncer debounce.Debouncer
@@ -255,7 +266,7 @@ func (s *svc) isUnexpectedRunError(err error) bool {
 
 func (s *svc) Run(ctx context.Context) error {
 	s.log.Info("subscribing to function queue")
-	return s.queue.Run(logger.WithStdlib(ctx, s.log), func(ctx context.Context, info queue.RunInfo, item queue.Item) (queue.RunResult, error) {
+	return s.queueProcessor.Run(logger.WithStdlib(ctx, s.log), func(ctx context.Context, info queue.RunInfo, item queue.Item) (queue.RunResult, error) {
 		// Don't stop the service on errors.
 		s.wg.Add(1)
 		defer s.wg.Done()

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -97,6 +97,7 @@ type QueueProcessor interface {
 	// job will automatically be retried.
 	Run(context.Context, RunFunc) error
 
+	Queue() Queue
 	Shard() QueueShard
 	Clock() clockwork.Clock
 	Semaphore() util.TrackingSemaphore

--- a/pkg/execution/queue/interface.go
+++ b/pkg/execution/queue/interface.go
@@ -54,14 +54,6 @@ type PartitionLeaseOptions struct{}
 
 type PartitionLeaseOpt func(o *PartitionLeaseOptions)
 
-type QueueManager interface {
-	Queue
-
-	Dequeue(ctx context.Context, queueShard QueueShard, i QueueItem, opts ...DequeueOptionFn) error
-	Requeue(ctx context.Context, queueShard QueueShard, i QueueItem, at time.Time, opts ...RequeueOptionFn) error
-	RequeueByJobID(ctx context.Context, queueShard QueueShard, jobID string, at time.Time) error
-}
-
 type KeyQueueProcessor interface {
 	ScanShadowPartitions(ctx context.Context, until time.Time, qspc chan ShadowPartitionChanMsg) error
 	ProcessShadowPartition(ctx context.Context, shadowPart *QueueShadowPartition, continuationCount uint) error
@@ -93,6 +85,17 @@ type KeyQueueProcessor interface {
 
 type QueueProcessor interface {
 	KeyQueueProcessor
+
+	// Run is a blocking function which listens to the queue and executes the
+	// given function each time a new Item becomes available.
+	//
+	// If the error from RunFunc is of type QuitError, the Run function will
+	// always requeue the job as a retry and terminate.
+	//
+	// If the error from RunFunc is of type RetryableError, the job will be
+	// re-enqueued if Retryable() returns true. For all other errors, the
+	// job will automatically be retried.
+	Run(context.Context, RunFunc) error
 
 	Shard() QueueShard
 	Clock() clockwork.Clock

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -201,6 +201,10 @@ func (q *queueProcessor) Workers() chan ProcessItem {
 	return q.workers
 }
 
+func (q *queueProcessor) Queue() Queue {
+	return q
+}
+
 // BacklogSize implements JobQueueReader.
 func (q *queueProcessor) BacklogSize(ctx context.Context, shard QueueShard, backlogID string) (int64, error) {
 	return shard.BacklogSize(ctx, backlogID)

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -201,47 +201,52 @@ func (q *queueProcessor) Workers() chan ProcessItem {
 	return q.workers
 }
 
-// BacklogSize implements QueueManager.
+// BacklogSize implements JobQueueReader.
 func (q *queueProcessor) BacklogSize(ctx context.Context, shard QueueShard, backlogID string) (int64, error) {
 	return shard.BacklogSize(ctx, backlogID)
 }
 
-// BacklogByID implements QueueManager.
+// BacklogByID implements JobQueueReader.
 func (q *queueProcessor) BacklogByID(ctx context.Context, shard QueueShard, backlogID string) (*QueueBacklog, error) {
 	return shard.BacklogByID(ctx, backlogID)
 }
 
-// BacklogsByPartition implements QueueManager.
+// BacklogsByPartition implements JobQueueReader.
 func (q *queueProcessor) BacklogsByPartition(ctx context.Context, shard QueueShard, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueBacklog], error) {
 	return shard.BacklogsByPartition(ctx, partitionID, from, until, opts...)
 }
 
-// Dequeue implements QueueManager.
-func (q *queueProcessor) Dequeue(ctx context.Context, shard QueueShard, i QueueItem, opts ...DequeueOptionFn) error {
+// Dequeue implements Consumer.
+func (q *queueProcessor) Dequeue(ctx context.Context, shardName string, i QueueItem, opts ...DequeueOptionFn) error {
+	shard, err := q.shards.ByName(shardName)
+	if err != nil {
+		return err
+	}
+
 	return shard.Dequeue(ctx, i, opts...)
 }
 
-// ItemExists implements QueueManager.
+// ItemExists implements JobQueueReader.
 func (q *queueProcessor) ItemExists(ctx context.Context, shard QueueShard, scope Scope, jobID string) (bool, error) {
 	return shard.ItemExists(ctx, scope, jobID)
 }
 
-// ItemsByBacklog implements QueueManager.
+// ItemsByBacklog implements JobQueueReader.
 func (q *queueProcessor) ItemsByBacklog(ctx context.Context, shard QueueShard, backlogID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error) {
 	return shard.ItemsByBacklog(ctx, backlogID, from, until, opts...)
 }
 
-// ItemsByPartition implements QueueManager.
+// ItemsByPartition implements JobQueueReader.
 func (q *queueProcessor) ItemsByPartition(ctx context.Context, shard QueueShard, scope Scope, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error) {
 	return shard.ItemsByPartition(ctx, scope, partitionID, from, until, opts...)
 }
 
-// ItemsByRunID implements QueueManager.
+// ItemsByRunID implements JobQueueReader.
 func (q *queueProcessor) ItemsByRunID(ctx context.Context, shard QueueShard, scope Scope, runID ulid.ULID) ([]*QueueItem, error) {
 	return shard.ItemsByRunID(ctx, scope, runID)
 }
 
-// LoadQueueItem implements QueueManager.
+// LoadQueueItem implements JobQueueReader.
 func (q *queueProcessor) LoadQueueItem(ctx context.Context, shardName string, itemID string) (*QueueItem, error) {
 	shard, err := q.shards.ByName(shardName)
 	if err != nil {
@@ -285,12 +290,12 @@ func (q *queueProcessor) PartitionBacklogSize(ctx context.Context, scope Scope, 
 	return totalCount, nil
 }
 
-// PartitionByID implements QueueManager.
+// PartitionByID implements JobQueueReader.
 func (q *queueProcessor) PartitionByID(ctx context.Context, shard QueueShard, scope Scope, partitionID string) (*PartitionInspectionResult, error) {
 	return shard.PartitionByID(ctx, scope, partitionID)
 }
 
-// RemoveQueueItem implements QueueManager.
+// RemoveQueueItem implements JobQueueReader.
 func (q *queueProcessor) RemoveQueueItem(ctx context.Context, shardName string, scope Scope, partitionID string, itemID string) error {
 	shard, err := q.shards.ByName(shardName)
 	if err != nil {
@@ -300,17 +305,17 @@ func (q *queueProcessor) RemoveQueueItem(ctx context.Context, shardName string, 
 	return shard.RemoveQueueItem(ctx, scope, partitionID, itemID)
 }
 
-// Requeue implements QueueManager.
-func (q *queueProcessor) Requeue(ctx context.Context, shard QueueShard, i QueueItem, at time.Time, opts ...RequeueOptionFn) error {
-	return shard.Requeue(ctx, i, at, opts...)
+// Requeue implements Producer.
+func (q *queueProcessor) Requeue(ctx context.Context, shardName string, i QueueItem, at time.Time, opts ...RequeueOptionFn) error {
+	return q.queueProducer.Requeue(ctx, shardName, i, at, opts...)
 }
 
-// RequeueByJobID implements QueueManager.
-func (q *queueProcessor) RequeueByJobID(ctx context.Context, shard QueueShard, jobID string, at time.Time) error {
-	return shard.RequeueByJobID(ctx, jobID, at)
+// RequeueByJobID implements Producer.
+func (q *queueProcessor) RequeueByJobID(ctx context.Context, shardName string, jobID string, at time.Time) error {
+	return q.queueProducer.RequeueByJobID(ctx, shardName, jobID, at)
 }
 
-// Enqueue implements QueueManager.
+// Enqueue implements Producer.
 func (q *queueProcessor) Enqueue(ctx context.Context, item Item, at time.Time, opts EnqueueOpts) error {
 	return q.queueProducer.Enqueue(ctx, item, at, opts)
 }

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -81,6 +81,10 @@ func (m *mockQueueProcessor) ProcessPartition(ctx context.Context, p *QueueParti
 	return nil
 }
 
+func (m *mockQueueProcessor) Run(ctx context.Context, f RunFunc) error {
+	return nil
+}
+
 // mockShardForIterator implements the minimal QueueShard interface methods used by ProcessorIterator
 type mockShardForIterator struct {
 	name                    string

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -85,6 +85,10 @@ func (m *mockQueueProcessor) Run(ctx context.Context, f RunFunc) error {
 	return nil
 }
 
+func (m *mockQueueProcessor) Queue() Queue {
+	return nil
+}
+
 // mockShardForIterator implements the minimal QueueShard interface methods used by ProcessorIterator
 type mockShardForIterator struct {
 	name                    string

--- a/pkg/execution/queue/processor_test.go
+++ b/pkg/execution/queue/processor_test.go
@@ -20,6 +20,14 @@ func (m *mockProducer) Enqueue(context.Context, Item, time.Time, EnqueueOpts) er
 	return nil
 }
 
+func (m *mockProducer) Requeue(context.Context, string, QueueItem, time.Time, ...RequeueOptionFn) error {
+	return nil
+}
+
+func (m *mockProducer) RequeueByJobID(context.Context, string, string, time.Time) error {
+	return nil
+}
+
 func TestProcessorWithQueueProducerOverridesDefaultProducer(t *testing.T) {
 	ctx := context.Background()
 	shard := &mockShardForIterator{name: "shard-a"}

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -67,19 +67,13 @@ type EnqueueOpts struct {
 type Producer interface {
 	// Enqueue allows an item to be enqueued ton run at the given time.
 	Enqueue(context.Context, Item, time.Time, EnqueueOpts) error
+
+	Requeue(ctx context.Context, shardName string, i QueueItem, at time.Time, opts ...RequeueOptionFn) error
+	RequeueByJobID(ctx context.Context, shardName string, jobID string, at time.Time) error
 }
 
 type Consumer interface {
-	// Run is a blocking function which listens to the queue and executes the
-	// given function each time a new Item becomes available.
-	//
-	// If the error from RunFunc is of type QuitError, the Run function will
-	// always requeue the job as a retry and terminate.
-	//
-	// If the error from RunFunc is of type RetryableError, the job will be
-	// re-enqueued if Retryable() returns true.  For all other errors, the
-	// job will automatically be retried.
-	Run(context.Context, RunFunc) error
+	Dequeue(ctx context.Context, shardName string, i QueueItem, opts ...DequeueOptionFn) error
 }
 
 type RoleStatusReader interface {

--- a/pkg/execution/queue/requeue.go
+++ b/pkg/execution/queue/requeue.go
@@ -1,0 +1,24 @@
+package queue
+
+import (
+	"context"
+	"time"
+)
+
+func (q *queueProducer) Requeue(ctx context.Context, shardName string, i QueueItem, at time.Time, opts ...RequeueOptionFn) error {
+	shard, err := q.shards.ByName(shardName)
+	if err != nil {
+		return err
+	}
+
+	return shard.Requeue(ctx, i, at, opts...)
+}
+
+func (q *queueProducer) RequeueByJobID(ctx context.Context, shardName string, jobID string, at time.Time) error {
+	shard, err := q.shards.ByName(shardName)
+	if err != nil {
+		return err
+	}
+
+	return shard.RequeueByJobID(ctx, jobID, at)
+}

--- a/pkg/execution/state/redis_state/queue_dequeue_test.go
+++ b/pkg/execution/state/redis_state/queue_dequeue_test.go
@@ -444,7 +444,7 @@ func TestQueueDequeueWithDisabledConstraintUpdates(t *testing.T) {
 	require.False(t, r.Exists(kg.Concurrency("p", fnID.String())))
 	require.False(t, r.Exists(kg.Concurrency("account", accountID.String())))
 
-	err = q.Dequeue(ctx, shard, item)
+	err = q.Dequeue(ctx, shard.Name(), item)
 	require.NoError(t, err)
 
 	require.False(t, r.Exists(kg.Concurrency("p", fnID.String())))

--- a/pkg/execution/state/redis_state/queue_scavenge_test.go
+++ b/pkg/execution/state/redis_state/queue_scavenge_test.go
@@ -90,7 +90,7 @@ func TestQueueScavenge(t *testing.T) {
 		require.False(t, r.Exists(kg.Concurrency("p", fnID.String())))
 
 		// Dequeue item and check scavenger index was cleaned up
-		err = q.Dequeue(ctx, shard, item)
+		err = q.Dequeue(ctx, shard.Name(), item)
 		require.NoError(t, err)
 
 		require.False(t, r.Exists(kg.PartitionScavengerIndex(fnID.String())))
@@ -393,7 +393,7 @@ func TestQueueScavenge(t *testing.T) {
 
 			require.False(t, r.Exists(kg.Concurrency("p", fnID.String())))
 
-			err = q.Requeue(ctx, shard, item1, clock.Now().Add(time.Minute))
+			err = q.Requeue(ctx, shard.Name(), item1, clock.Now().Add(time.Minute))
 			require.NoError(t, err)
 			require.NotNil(t, leaseID2)
 
@@ -469,7 +469,7 @@ func TestQueueScavenge(t *testing.T) {
 
 			require.False(t, r.Exists(kg.Concurrency("p", fnID.String())))
 
-			err = q.Dequeue(ctx, shard, item1)
+			err = q.Dequeue(ctx, shard.Name(), item1)
 			require.NoError(t, err)
 			require.NotNil(t, leaseID2)
 

--- a/pkg/execution/state/redis_state/reader_test.go
+++ b/pkg/execution/state/redis_state/reader_test.go
@@ -1481,7 +1481,7 @@ func TestItemExists(t *testing.T) {
 		require.True(t, exists)
 
 		// Dequeue the item
-		err = q.Dequeue(ctx, shard, enqueued)
+		err = q.Dequeue(ctx, shard.Name(), enqueued)
 		require.NoError(t, err)
 
 		// Should no longer exist

--- a/pkg/execution/state/redis_state/util_test.go
+++ b/pkg/execution/state/redis_state/util_test.go
@@ -44,7 +44,7 @@ func alwaysSelectShard(shard osqueue.QueueShard) func(ctx context.Context, scope
 }
 
 type queueImpl interface {
-	osqueue.QueueManager
+	osqueue.Queue
 	osqueue.QueueProcessor
 }
 

--- a/tests/execution/executor/executor_test.go
+++ b/tests/execution/executor/executor_test.go
@@ -101,10 +101,8 @@ func (fq *fakeQueue) reset() {
 	fq.lock.Unlock()
 }
 
-func (fq *fakeQueue) Dequeue(ctx context.Context, queueShard redis_state.RedisQueueShard, i queue.QueueItem) error {
-	qm := fq.Queue.(queue.QueueManager)
-
-	err := qm.Dequeue(ctx, queueShard, i)
+func (fq *fakeQueue) Dequeue(ctx context.Context, shardName string, i queue.QueueItem, opts ...queue.DequeueOptionFn) error {
+	err := fq.Queue.Dequeue(ctx, shardName, i, opts...)
 
 	fq.lock.Lock()
 	logger.StdlibLogger(ctx).Info("called fakeQueue.Dequeue()", "i", i, "err", err)
@@ -694,10 +692,10 @@ func TestFinalize(t *testing.T) {
 		require.Equal(t, int64(1), testQueue.dequeuedCalledRun[run2.ID.RunID])
 		testQueue.lock.Unlock()
 
-		err = rq.Dequeue(ctx, queueShard, item2)
+		err = rq.Dequeue(ctx, queueShard.Name(), item2)
 		require.ErrorIs(t, err, queue.ErrQueueItemNotFound)
 
-		err = rq.Requeue(ctx, queueShard, item2, time.Now())
+		err = rq.Requeue(ctx, queueShard.Name(), item2, time.Now())
 		require.ErrorIs(t, err, queue.ErrQueueItemNotFound)
 	})
 }

--- a/tests/execution/queue/lua_compatibility_test.go
+++ b/tests/execution/queue/lua_compatibility_test.go
@@ -191,7 +191,7 @@ func TestLuaCompatibility(t *testing.T) {
 
 				// - Requeue item
 				requeueTime := now.Add(5 * time.Second)
-				err = q.Requeue(ctx, shard, enqueuedItem, requeueTime)
+				err = q.Requeue(ctx, shard.Name(), enqueuedItem, requeueTime)
 				require.NoError(t, err)
 
 				// - Requeue partition
@@ -203,7 +203,7 @@ func TestLuaCompatibility(t *testing.T) {
 				require.NoError(t, err, "Failed to peek partition after requeue on %s", serverType)
 				require.NotEmpty(t, peekedAfterRequeue, "Should find items in partition after requeue on %s", serverType)
 
-				err = q.Dequeue(ctx, shard, enqueuedItem)
+				err = q.Dequeue(ctx, shard.Name(), enqueuedItem)
 				require.NoError(t, err)
 
 				peekedAfterDequeue, err := shard.Peek(ctx, qp, requeueTime.Add(5*time.Second), 10)

--- a/tests/execution/queue/role_e2e_test.go
+++ b/tests/execution/queue/role_e2e_test.go
@@ -43,7 +43,7 @@ func TestQueueRoleRequiresRoleLease(t *testing.T) {
 	require.Never(t, func() bool {
 		return role.runCount.Load() > 0
 	}, 100*time.Millisecond, 5*time.Millisecond)
-	require.Nil(t, activeRoleStatus(q, role.Name()))
+	require.Nil(t, activeRoleStatus(q.Queue(), role.Name()))
 }
 
 func TestQueueRoleRenewKeepsRoleActive(t *testing.T) {
@@ -65,13 +65,13 @@ func TestQueueRoleRenewKeepsRoleActive(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return activeRoleStatus(q, role.Name()) != nil && role.runCount.Load() > 0
+		return activeRoleStatus(q.Queue(), role.Name()) != nil && role.runCount.Load() > 0
 	}, time.Second, 5*time.Millisecond)
 
-	firstLease := activeRoleStatus(q, role.Name()).LeaseID
+	firstLease := activeRoleStatus(q.Queue(), role.Name()).LeaseID
 
 	require.Eventually(t, func() bool {
-		status := activeRoleStatus(q, role.Name())
+		status := activeRoleStatus(q.Queue(), role.Name())
 		return status != nil && status.LeaseID != firstLease
 	}, time.Second, 5*time.Millisecond)
 	require.Greater(t, role.runCount.Load(), int32(1))
@@ -96,14 +96,14 @@ func TestQueueRoleStopsRunningAfterLeaseLoss(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return activeRoleStatus(q, role.Name()) != nil && role.runCount.Load() > 0
+		return activeRoleStatus(q.Queue(), role.Name()) != nil && role.runCount.Load() > 0
 	}, time.Second, 5*time.Millisecond)
 
 	otherLease := ulid.MustNew(ulid.Timestamp(time.Now().Add(time.Second)), rand.Reader)
 	require.NoError(t, r.Set(roleLeaseKey(role.Name()), otherLease.String()))
 
 	require.Eventually(t, func() bool {
-		return activeRoleStatus(q, role.Name()) == nil
+		return activeRoleStatus(q.Queue(), role.Name()) == nil
 	}, time.Second, 5*time.Millisecond)
 
 	afterLoss := role.runCount.Load()
@@ -138,11 +138,11 @@ func TestQueueRoleCanExcludeScanning(t *testing.T) {
 	}()
 
 	require.Eventually(t, func() bool {
-		return activeRoleStatus(q, role.Name()) != nil
+		return activeRoleStatus(q.Queue(), role.Name()) != nil
 	}, time.Second, 5*time.Millisecond)
 
 	item := roleTestItem()
-	require.NoError(t, q.Enqueue(ctx, item, time.Now(), osqueue.EnqueueOpts{}))
+	require.NoError(t, q.Queue().Enqueue(ctx, item, time.Now(), osqueue.EnqueueOpts{}))
 
 	require.Never(t, func() bool {
 		return processed.Load() > 0
@@ -181,7 +181,7 @@ func (r *testQueueRole) Run(ctx context.Context, shard osqueue.QueueShard) error
 func (r *testQueueRole) OnLeaseTick(ctx context.Context, shard osqueue.QueueShard) {
 }
 
-func newRoleQueue(t *testing.T, role osqueue.QueueRole, runMode osqueue.QueueRunMode) (*miniredis.Miniredis, rueidis.Client, osqueue.Queue, osqueue.QueueShard) {
+func newRoleQueue(t *testing.T, role osqueue.QueueRole, runMode osqueue.QueueRunMode) (*miniredis.Miniredis, rueidis.Client, osqueue.QueueProcessor, osqueue.QueueShard) {
 	t.Helper()
 
 	r := miniredis.RunT(t)
@@ -208,7 +208,7 @@ func newRoleQueue(t *testing.T, role osqueue.QueueRole, runMode osqueue.QueueRun
 	return r, rc, q, shard
 }
 
-func runQueueForRoleTest(ctx context.Context, q osqueue.Queue, f osqueue.RunFunc) chan struct{} {
+func runQueueForRoleTest(ctx context.Context, q osqueue.QueueProcessor, f osqueue.RunFunc) chan struct{} {
 	if f == nil {
 		f = func(ctx context.Context, info osqueue.RunInfo, item osqueue.Item) (osqueue.RunResult, error) {
 			return osqueue.RunResult{}, nil


### PR DESCRIPTION
## Description


  Refactors the queue-facing interfaces so QueueManager is no longer the broad access surface for queue mutation and processing APIs.

  This change:

  - moves Run to QueueProcessor
  - moves queue-level Dequeue to Consumer with shardName
  - moves queue-level Requeue and RequeueByJobID to Producer with shardName
  - adds QueueProcessor.Queue() so processor owners can access the queue surface explicitly
  - updates executor service wiring to receive QueueProcessor and derive queue access from it
  - updates OSS tests and integration call sites for the new queue-level method signatures
 
## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
