### PR TITLE
ci(e2e): check that the dev server comes up

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,14 +59,13 @@ jobs:
           cd ./tests/js
           pnpm install --frozen-lockfile
           pnpm dev &
-          sleep 5
+          "$GITHUB_WORKSPACE/scripts/wait-for-healthy.sh" "SDK app" "$SDK_URL"
           cd ../../
           echo "Running dev server"
           mkdir $GOCOVERDIR
           nohup ./inngest-bin dev --no-discovery --no-poll 2> /tmp/devserver-logs-kq-${{ matrix.experimentalKeyQueues }}-api.txt &
           echo "Ran dev server"
-          sleep 5
-          curl http://127.0.0.1:8288/dev > /dev/null 2> /dev/null
+          ./scripts/wait-for-healthy.sh "dev server" http://127.0.0.1:8288/health
           gotestsum --junitfile=junit.xml --format=standard-verbose -- ./tests
         env:
           INNGEST_SIGNING_KEY: test
@@ -166,8 +165,7 @@ jobs:
             nohup ./inngest-bin dev --no-discovery --no-poll 2> /tmp/dev-output.txt &
           fi
           echo "Ran dev server"
-          sleep 5
-          curl http://127.0.0.1:8288/dev > /dev/null 2> /dev/null
+          ./scripts/wait-for-healthy.sh "dev server" http://127.0.0.1:8288/health
 
           gotesplit -total ${{ matrix.parallelism }} -index ${{ matrix.index }} -junit-dir test-results ./tests/golang -- -v -count=1
         env:
@@ -267,8 +265,7 @@ jobs:
             nohup ./inngest-bin dev --no-discovery --no-poll 2> /tmp/dev-output.txt &
           fi
           echo "Ran dev server"
-          sleep 5
-          curl http://127.0.0.1:8288/dev > /dev/null 2> /dev/null
+          ./scripts/wait-for-healthy.sh "dev server" http://127.0.0.1:8288/health
 
           gotestsum --junitfile=junit.xml --format=standard-verbose -- ./tests/batch/... -count=1
         env:
@@ -366,8 +363,7 @@ jobs:
             nohup ./inngest-bin dev --no-discovery --no-poll 2> /tmp/dev-output.txt &
           fi
           echo "Ran dev server"
-          sleep 5
-          curl http://127.0.0.1:8288/dev > /dev/null 2> /dev/null
+          ./scripts/wait-for-healthy.sh "dev server" http://127.0.0.1:8288/health
 
           gotestsum --junitfile=junit.xml --format=standard-verbose -- ./tests/api/... -count=1
         env:

--- a/scripts/wait-for-healthy.sh
+++ b/scripts/wait-for-healthy.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Poll an HTTP endpoint until it returns success, failing loudly if it never does.
+# Replaces blind `sleep N` waits in CI so a server that never booted fails fast
+# and attributably instead of letting tests run against a dead server.
+#
+# Usage: wait-for-healthy.sh <name> <url> [max_seconds]
+set -euo pipefail
+
+name="$1"
+url="$2"
+tries="${3:-10}"
+
+for i in $(seq 1 "$tries"); do
+  if curl -fsS "$url" >/dev/null 2>&1; then
+    echo "$name is ready (after ${i}s): $url"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "ERROR: $name failed to become healthy after ${tries}s: $url" >&2
+exit 1

--- a/scripts/wait-for-healthy.sh
+++ b/scripts/wait-for-healthy.sh
@@ -8,9 +8,9 @@ set -euo pipefail
 
 name="$1"
 url="$2"
-tries="${3:-10}"
+max_seconds="${3:-10}"
 
-for i in $(seq 1 "$tries"); do
+for i in $(seq 1 "$max_seconds"); do
   if curl -fsS "$url" >/dev/null 2>&1; then
     echo "$name is ready (after ${i}s): $url"
     exit 0
@@ -18,5 +18,5 @@ for i in $(seq 1 "$tries"); do
   sleep 1
 done
 
-echo "ERROR: $name failed to become healthy after ${tries}s: $url" >&2
+echo "ERROR: $name failed to become healthy after ${max_seconds}s: $url" >&2
 exit 1


### PR DESCRIPTION
## Description

- Currently, we don't have great checks that the dev server actually came up. 5XX and 4XX requests are accepted
- Let's switch to a reusable script that will poll so we can move on faster and reject >= 400 status codes for correctness

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
