### PR TITLE
chore: dashboard listen to all private hosts

### DIFF
--- a/ui/apps/dashboard/vite.config.ts
+++ b/ui/apps/dashboard/vite.config.ts
@@ -55,4 +55,10 @@ export default defineConfig({
     viteReact(),
     svgrPlugin(),
   ],
+  server: {
+    // Listen to all private hosts. We added this so the app listens to both
+    // localhost and 127.0.0.1. We need 127.0.0.1 for Vercel/DigitalOcean
+    // marketplace testing.
+    host: true,
+  },
 });


### PR DESCRIPTION
## Description

Make the Dashboard UI listen on all private hosts.

```
[vite]   ➜  Local:   http://localhost:5173/
[vite]   ➜  Network: http://192.168.0.81:5173/
[vite]   ➜  Network: http://192.168.139.3:5173/
[vite]   ➜  Network: http://192.168.215.0:5173/
[vite]   ➜  Network: http://10.30.0.0:5173/
```