### PR TITLE
ci: cache our pnpm installation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -49,7 +49,11 @@ jobs:
         with:
           node-version: "20"
           cache: pnpm
-          cache-dependency-path: tests/js/pnpm-lock.yaml
+          # Key on both lockfiles this job installs: the UI build (the largest
+          # install, via make build-ui) and the tests/js E2E deps.
+          cache-dependency-path: |
+            ui/pnpm-lock.yaml
+            tests/js/pnpm-lock.yaml
 
       - name: Build UI
         run: make build-ui

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -38,14 +38,18 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@v1.13.0
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
+      # pnpm must be set up before setup-node so the "pnpm" cache can resolve
+      # the pnpm store path.
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10.18.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: tests/js/pnpm-lock.yaml
 
       - name: Build UI
         run: make build-ui


### PR DESCRIPTION
## Description

- Let's cache these pnpm installations
- Shave 10s of download off our TS E2E jobs when the cache is warm

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
