### PR TITLE
feat(defers): support SDK defer abort() responses

### DIFF
--- a/docs/defer.md
+++ b/docs/defer.md
@@ -51,6 +51,16 @@ Three Redis hashes per run, all under a shared `{...:runID}` hash tag so multi-k
 3. Meta entry stays. `saveDefer.lua` is insert-only (any existing entry is a no-op), so SDK retransmits of the original DeferAdd dedupe automatically.
 4. Finalize skips Aborted entries.
 
+This path relies on SDKs following a few rules (the TS SDK handles all of them in `sanitizeOutgoingOps`):
+
+- **Always ship the abort**, even if the SDK cancelled the matching `DeferAdd` in its local buffer before it ever shipped. The `Defers` map in `SDKRequest` can be stale (a dying attempt's in-flight checkpoint or a parallel sibling's response can land after the map was built), so "not in the map" doesn't mean "never landed". Skip the abort and the deferred run might schedule anyway.
+- **Never ship a `DeferAdd` and `DeferAbort` for the same hashedID in one response.** They race in the executor's priority-group errgroup and the abort can be processed first. Drop the add, keep the abort.
+- Aborts for unknown targets are fine (and expected, given the always-ship rule). `SetDeferStatus` returns `state.ErrDeferNotFound`, `AbortFromOp` downgrades it to a debug log, and all three ingestion paths (executor, sync checkpoint, async checkpoint) treat it as a no-op.
+
+## Terminal failure path
+
+When a function rejects with buffered defers, the rejection arrives as `OpcodeRunError` in the same op batch instead of the classic function-rejected response. The classic body can't carry ops, and the rejection is the run's last message, so this is the only way the buffered defers survive. Like `RunComplete`, it's neither lazy nor priority, so the defer ops in the batch persist first. The executor then owns the retry decision: retryable errors requeue at attempt+1; terminal errors finalize the run as Failed, emit `inngest/function.failed`, and schedule any AfterRun defers. Async request/response mode only: it's not in `opcodeSyncMap`, so both checkpoint paths reject it.
+
 ## Unhappy path (soft-fail)
 
 A defer must never fail its parent run. Each rejection logs a warning, increments `IncrDefersRejectedCounter` (with a `reason` tag), and writes a `Rejected` sentinel where possible so SDK retransmits dedupe.
@@ -67,6 +77,18 @@ A defer must never fail its parent run. Each rejection logs a warning, increment
 ### E2E test for `run_type = Defer` assignment
 
 Write a real Dev Server + Go SDK test that schedules a deferred run and asserts the child's `run_type` is `Defer`. Blocked on deferred-function support in the Go SDK.
+
+### Aborted tombstone for unknown-target aborts
+
+UI polish, not correctness: the always-ship rule plus the backend's unknown-target tolerance already guarantee an aborted defer never schedules. The SDK's `.abort()` has shipped, so this can land any time.
+
+**Problem.** An abort whose `DeferAdd` never landed (cancelled in the SDK's buffer before shipping, rejected at the count cap with no sentinel, or lost to a failed checkpoint) hits "defer not found", and `AbortFromOp` returns before any span work. Identical user code then shows an `ABORTED` chip or nothing, depending on whether a checkpoint happened to fire between `defer()` and `.abort()`.
+
+**Proposed fix.**
+
+- `setDeferStatus.lua`: when the target is missing and the new status is Aborted, upsert an Aborted meta entry instead of returning 0. Apply the same `MaxDefersPerRun` guard as `saveDefer.lua`; without it, aborts against arbitrary IDs are an unbounded meta-hash write path.
+- `AbortFromOp`: emit the `executor.defer` span on the tombstone path (today the early `nil` return on `ErrDeferNotFound` skips the span work, which is why the chip is missing).
+- `DeferAbortOpts`: add optional `fn_slug` and userland-ID fields so the tombstone and span render with a function name. The SDK already sends both (`opts: { target_hashed_id, fn_slug, id }`); the backend currently parses only `target_hashed_id`, so this needs no SDK protocol rev — just start reading the fields.
 
 ### Suppress SDK retransmits after `MaxDefersPerRun` is hit
 

--- a/pkg/devserver/run_provider.go
+++ b/pkg/devserver/run_provider.go
@@ -272,8 +272,9 @@ func publicRunOutput(raw []byte) json.RawMessage {
 	}
 
 	var opcodes []struct {
-		Op   string          `json:"op"`
-		Data json.RawMessage `json:"data"`
+		Op    string          `json:"op"`
+		Data  json.RawMessage `json:"data"`
+		Error json.RawMessage `json:"error"`
 	}
 	if err := json.Unmarshal(output, &opcodes); err != nil {
 		return util.EnsureJSON(output)
@@ -282,6 +283,13 @@ func publicRunOutput(raw []byte) json.RawMessage {
 	for i := len(opcodes) - 1; i >= 0; i-- {
 		if opcodes[i].Op == enums.OpcodeRunComplete.String() || opcodes[i].Op == enums.OpcodeSyncRunComplete.String() {
 			return util.EnsureJSON(opcodes[i].Data)
+		}
+		if opcodes[i].Op == enums.OpcodeRunError.String() {
+			wrapped, err := json.Marshal(map[string]json.RawMessage{execution.StateErrorKey: opcodes[i].Error})
+			if err != nil {
+				return util.EnsureJSON(output)
+			}
+			return util.EnsureJSON(wrapped)
 		}
 	}
 

--- a/pkg/devserver/run_provider_test.go
+++ b/pkg/devserver/run_provider_test.go
@@ -9,8 +9,10 @@ import (
 	apiv2 "github.com/inngest/inngest/pkg/api/v2"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/execution"
+	"github.com/inngest/inngest/pkg/execution/state"
 	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/oklog/ulid/v2"
@@ -155,3 +157,57 @@ func (s *stubRunProviderScheduler) Schedule(ctx context.Context, req execution.S
 var _ runProviderDataReader = (*stubRunProviderDataReader)(nil)
 var _ apiv2.FunctionScheduler = (*stubRunProviderScheduler)(nil)
 var _ event.TrackedEvent = (*cqrs.Event)(nil)
+
+func TestPublicRunOutput(t *testing.T) {
+	userErr := &state.UserError{Name: "CustomError", Message: "step blew up"}
+
+	opcodeOutput := func(t *testing.T, ops []*state.GeneratorOpcode) []byte {
+		t.Helper()
+		raw, err := json.Marshal(ops)
+		require.NoError(t, err)
+		return raw
+	}
+
+	t.Run("RunComplete opcode array returns the bare data", func(t *testing.T) {
+		raw := opcodeOutput(t, []*state.GeneratorOpcode{{
+			Op:   enums.OpcodeRunComplete,
+			Data: json.RawMessage(`{"ok":true}`),
+		}})
+		require.JSONEq(t, `{"ok":true}`, string(publicRunOutput(raw)))
+	})
+
+	t.Run("RunError opcode array returns the wrapped error", func(t *testing.T) {
+		raw := opcodeOutput(t, []*state.GeneratorOpcode{{
+			Op:    enums.OpcodeRunError,
+			Error: userErr,
+		}})
+		require.JSONEq(t,
+			`{"error":{"name":"CustomError","message":"step blew up"}}`,
+			string(publicRunOutput(raw)))
+	})
+
+	t.Run("parity with a plain (non-opcode) rejection", func(t *testing.T) {
+		// A plain rejection stores the wrapped error that GetTraceFunctionOutput
+		// produces for the run span, which publicRunOutput passes through
+		// untouched. The same user error arriving as an OpcodeRunError array
+		// must yield the same public output.
+		output, err := json.Marshal(userErr)
+		require.NoError(t, err)
+		crashMsg := "sdk crashed"
+		resp := state.DriverResponse{
+			Err:    &crashMsg,
+			Output: json.RawMessage(output),
+		}
+		plainStored, err := resp.GetTraceFunctionOutput()
+		require.NoError(t, err)
+
+		runErrorRaw := opcodeOutput(t, []*state.GeneratorOpcode{{
+			Op:    enums.OpcodeRunError,
+			Error: userErr,
+		}})
+
+		require.JSONEq(t,
+			string(publicRunOutput([]byte(plainStored))),
+			string(publicRunOutput(runErrorRaw)))
+	})
+}

--- a/pkg/enums/opcode.go
+++ b/pkg/enums/opcode.go
@@ -28,6 +28,7 @@ const (
 
 	OpcodeDeferAdd
 	OpcodeDeferAbort
+	OpcodeRunError
 )
 
 // opcodeSyncMap explicitly represents the sync opcodes that can be checkpointed.
@@ -40,7 +41,7 @@ var opcodeSyncMap = map[Opcode]struct{}{
 	OpcodeSyncRunComplete: {},
 	OpcodeStepFailed:      {},
 	OpcodeDeferAdd:        {},
-	OpcodeDeferAbort:     {},
+	OpcodeDeferAbort:      {},
 }
 
 // OpcodeIsSync returns whether the given opcode is synchronous.  This

--- a/pkg/enums/opcode_enumer.go
+++ b/pkg/enums/opcode_enumer.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-const _OpcodeName = "NoneStepStepRunStepErrorStepPlannedSleepWaitForEventInvokeFunctionAIGatewayGatewayWaitForSignalRunCompleteStepFailedSyncRunCompleteDiscoveryRequestDeferAddDeferAbort"
+const _OpcodeName = "NoneStepStepRunStepErrorStepPlannedSleepWaitForEventInvokeFunctionAIGatewayGatewayWaitForSignalRunCompleteStepFailedSyncRunCompleteDiscoveryRequestDeferAddDeferAbortRunError"
 
-var _OpcodeIndex = [...]uint8{0, 4, 8, 15, 24, 35, 40, 52, 66, 75, 82, 95, 106, 116, 131, 147, 155, 165}
+var _OpcodeIndex = [...]uint8{0, 4, 8, 15, 24, 35, 40, 52, 66, 75, 82, 95, 106, 116, 131, 147, 155, 165, 173}
 
-const _OpcodeLowerName = "nonestepsteprunsteperrorstepplannedsleepwaitforeventinvokefunctionaigatewaygatewaywaitforsignalruncompletestepfailedsyncruncompletediscoveryrequestdeferadddeferabort"
+const _OpcodeLowerName = "nonestepsteprunsteperrorstepplannedsleepwaitforeventinvokefunctionaigatewaygatewaywaitforsignalruncompletestepfailedsyncruncompletediscoveryrequestdeferadddeferabortrunerror"
 
 func (i Opcode) String() string {
 	if i < 0 || i >= Opcode(len(_OpcodeIndex)-1) {
@@ -42,9 +42,10 @@ func _OpcodeNoOp() {
 	_ = x[OpcodeDiscoveryRequest-(14)]
 	_ = x[OpcodeDeferAdd-(15)]
 	_ = x[OpcodeDeferAbort-(16)]
+	_ = x[OpcodeRunError-(17)]
 }
 
-var _OpcodeValues = []Opcode{OpcodeNone, OpcodeStep, OpcodeStepRun, OpcodeStepError, OpcodeStepPlanned, OpcodeSleep, OpcodeWaitForEvent, OpcodeInvokeFunction, OpcodeAIGateway, OpcodeGateway, OpcodeWaitForSignal, OpcodeRunComplete, OpcodeStepFailed, OpcodeSyncRunComplete, OpcodeDiscoveryRequest, OpcodeDeferAdd, OpcodeDeferAbort}
+var _OpcodeValues = []Opcode{OpcodeNone, OpcodeStep, OpcodeStepRun, OpcodeStepError, OpcodeStepPlanned, OpcodeSleep, OpcodeWaitForEvent, OpcodeInvokeFunction, OpcodeAIGateway, OpcodeGateway, OpcodeWaitForSignal, OpcodeRunComplete, OpcodeStepFailed, OpcodeSyncRunComplete, OpcodeDiscoveryRequest, OpcodeDeferAdd, OpcodeDeferAbort, OpcodeRunError}
 
 var _OpcodeNameToValueMap = map[string]Opcode{
 	_OpcodeName[0:4]:          OpcodeNone,
@@ -81,6 +82,8 @@ var _OpcodeNameToValueMap = map[string]Opcode{
 	_OpcodeLowerName[147:155]: OpcodeDeferAdd,
 	_OpcodeName[155:165]:      OpcodeDeferAbort,
 	_OpcodeLowerName[155:165]: OpcodeDeferAbort,
+	_OpcodeName[165:173]:      OpcodeRunError,
+	_OpcodeLowerName[165:173]: OpcodeRunError,
 }
 
 var _OpcodeNames = []string{
@@ -101,6 +104,7 @@ var _OpcodeNames = []string{
 	_OpcodeName[131:147],
 	_OpcodeName[147:155],
 	_OpcodeName[155:165],
+	_OpcodeName[165:173],
 }
 
 // OpcodeString retrieves an enum value from the enum constants string name.

--- a/pkg/execution/checkpoint/checkpoint.go
+++ b/pkg/execution/checkpoint/checkpoint.go
@@ -422,6 +422,13 @@ func (c checkpointer) CheckpointSyncSteps(ctx context.Context, input SyncCheckpo
 				)
 			}
 
+		case enums.OpcodeRunError:
+			// OpcodeRunError is async request/response mode only and must never
+			// arrive via a checkpoint; reject it here as checkpointAsyncSteps does,
+			// rather than letting it fall through the sync->async default.
+			l.Error("cannot checkpoint opcode", "op", op.Op)
+			return fmt.Errorf("cannot checkpoint opcode: %s", op.Op)
+
 		default:
 			// This is an async opcode (sleep, waitForEvent, invoke, etc.) that causes
 			// the run to transition from sync to async mode. Track this on the run span

--- a/pkg/execution/checkpoint/checkpoint_sync_test.go
+++ b/pkg/execution/checkpoint/checkpoint_sync_test.go
@@ -432,7 +432,7 @@ func TestCheckpointSyncSteps(t *testing.T) {
 
 		mocks.state.
 			On("SetDeferStatus", ctx, testData.metadata.ID, "never-added", enums.DeferStatusAborted).
-			Return(fmt.Errorf("defer not found for hashedID %q", "never-added"))
+			Return(fmt.Errorf("%w for hashedID %q", sv1.ErrDeferNotFound, "never-added"))
 
 		err := testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
 		require.NoError(err, "missing-target DeferAbort must NOT fail the parent run; soft-fail with log")
@@ -467,6 +467,28 @@ func TestCheckpointSyncSteps(t *testing.T) {
 		mocks.tracer.AssertExpectations(t)
 		mocks.queue.AssertExpectations(t)
 		mocks.executor.AssertExpectations(t)
+	})
+
+	t.Run("run error is rejected", func(t *testing.T) {
+		// OpcodeRunError is async request/response mode only; it must never
+		// arrive via a sync checkpoint. CheckpointSyncSteps rejects it instead
+		// of routing it through the sync->async default branch.
+		ctx := context.Background()
+		require := require.New(t)
+
+		op := state.GeneratorOpcode{
+			ID:    "run-error",
+			Op:    enums.OpcodeRunError,
+			Error: &state.UserError{Name: "CustomError", Message: "boom"},
+		}
+
+		mocks, testData := setupSyncCheckpointTest(t, op)
+
+		err := testData.checkpointer.CheckpointSyncSteps(ctx, testData.syncCheckpoint)
+		require.Error(err, "OpcodeRunError must be rejected by the sync checkpoint path")
+
+		mocks.executor.AssertNotCalled(t, "HandleGenerator", mock.Anything, mock.Anything, mock.Anything)
+		mocks.queue.AssertNotCalled(t, "Enqueue")
 	})
 
 	t.Run("step output too large", func(t *testing.T) {

--- a/pkg/execution/defers/defers.go
+++ b/pkg/execution/defers/defers.go
@@ -132,8 +132,10 @@ func SaveFromOp(
 	return nil
 }
 
-// AbortFromOp flips the target defer's status to Aborted. Errors are
-// surfaced (no soft-fail).
+// AbortFromOp flips the target defer's status to Aborted. Unknown-target
+// aborts are benign — the SDK contract requires shipping aborts even for
+// locally-cancelled DeferAdds that never landed — so ErrDeferNotFound returns
+// nil with a debug log. Other errors are surfaced.
 //
 // On success: updates the existing executor.defer span to status=Aborted via
 // UpdateSpan. The span identity is reconstructed from (parentRunID, hashedID),
@@ -153,6 +155,10 @@ func AbortFromOp(
 	}
 
 	if err := rs.SetDeferStatus(ctx, md.ID, opts.TargetHashedID, enums.DeferStatusAborted); err != nil {
+		if errors.Is(err, state.ErrDeferNotFound) {
+			log.Debug("abort for unknown defer", "hashed_id", opts.TargetHashedID)
+			return nil
+		}
 		log.Error("error aborting defer", "error", err)
 		return fmt.Errorf("error aborting defer: %w", err)
 	}

--- a/pkg/execution/defers/defers_test.go
+++ b/pkg/execution/defers/defers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -23,6 +24,7 @@ type fakeRunService struct {
 	saveDeferErr         error
 	savedDefer           *statev2.Defer
 	savedDeferCalls      int
+	setDeferStatusErr    error
 	setDeferStatusHashed string
 	setDeferStatusValue  enums.DeferStatus
 }
@@ -36,7 +38,7 @@ func (f *fakeRunService) SaveDefer(_ context.Context, _ statev2.ID, d statev2.De
 func (f *fakeRunService) SetDeferStatus(_ context.Context, _ statev2.ID, hashedID string, status enums.DeferStatus) error {
 	f.setDeferStatusHashed = hashedID
 	f.setDeferStatusValue = status
-	return nil
+	return f.setDeferStatusErr
 }
 
 func runMetadata() *statev2.Metadata {
@@ -145,5 +147,28 @@ func TestAbortFromOp(t *testing.T) {
 
 		r.Error(err)
 		r.Empty(fake.setDeferStatusHashed)
+	})
+
+	t.Run("unknown-target abort is benign", func(t *testing.T) {
+		r := require.New(t)
+		fake := &fakeRunService{
+			setDeferStatusErr: fmt.Errorf("%w for hashedID %q", state.ErrDeferNotFound, "never-added"),
+		}
+		err := AbortFromOp(context.Background(), fake, nil, logger.VoidLogger(), runMetadata(),
+			abortOp(t, state.DeferAbortOpts{TargetHashedID: "never-added"}))
+
+		r.NoError(err)
+		r.Equal("never-added", fake.setDeferStatusHashed)
+	})
+
+	t.Run("surfaces infra error from SetDeferStatus", func(t *testing.T) {
+		r := require.New(t)
+		fake := &fakeRunService{
+			setDeferStatusErr: fmt.Errorf("redis unavailable"),
+		}
+		err := AbortFromOp(context.Background(), fake, nil, logger.VoidLogger(), runMetadata(),
+			abortOp(t, state.DeferAbortOpts{TargetHashedID: "some-defer"}))
+
+		r.Error(err)
 	})
 }

--- a/pkg/execution/driver/driver_test.go
+++ b/pkg/execution/driver/driver_test.go
@@ -1,0 +1,51 @@
+package driver
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/enums"
+	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/stretchr/testify/require"
+)
+
+type stubStateLoader struct {
+	sv2.StateLoader
+	defers map[string]sv2.DeferMeta
+}
+
+func (l stubStateLoader) LoadEvents(ctx context.Context, id sv2.ID) ([]json.RawMessage, error) {
+	return []json.RawMessage{[]byte(`{}`)}, nil
+}
+
+func (l stubStateLoader) LoadSteps(ctx context.Context, id sv2.ID) (map[string]json.RawMessage, error) {
+	return map[string]json.RawMessage{}, nil
+}
+
+func (l stubStateLoader) LoadDefersMeta(ctx context.Context, id sv2.ID) (map[string]sv2.DeferMeta, error) {
+	return l.defers, nil
+}
+
+func TestMarshalV1DefersAbortableOnlyForAfterRun(t *testing.T) {
+	sl := stubStateLoader{defers: map[string]sv2.DeferMeta{
+		"after-run": {ScheduleStatus: enums.DeferStatusAfterRun},
+		"scheduled": {ScheduleStatus: enums.DeferStatusScheduled},
+		"aborted":   {ScheduleStatus: enums.DeferStatusAborted},
+		"rejected":  {ScheduleStatus: enums.DeferStatusRejected},
+	}}
+
+	b, err := MarshalV1(context.Background(), sl, sv2.Metadata{}, inngest.Step{}, 0, "test", 0, 1, "")
+	require.NoError(t, err)
+
+	req := SDKRequest{}
+	require.NoError(t, json.Unmarshal(b, &req))
+
+	require.Equal(t, map[string]SDKDeferEntry{
+		"after-run": {Abortable: true},
+		"scheduled": {Abortable: false},
+		"aborted":   {Abortable: false},
+		"rejected":  {Abortable: false},
+	}, req.Defers)
+}

--- a/pkg/execution/execution.go
+++ b/pkg/execution/execution.go
@@ -475,12 +475,14 @@ const (
 	FinalizeResponseRunComplete FinalizeResponseType = iota
 	FinalizeResponseAPI
 	FinalizeResponseDriver
+	FinalizeResponseRunError
 )
 
 // FinalizeResponse is a union containing one of:
 // 1. an enums.OpcodeRunComplete (for async fns),
 // 2. or a apiresult.APIResponse (for sync fns)
 // 3. A DriverResponse for SDKs not using opcode responses.
+// 4. an enums.OpcodeRunError (for async fns that failed).
 type FinalizeResponse struct {
 	// Type indicates the field to use.
 	Type FinalizeResponseType
@@ -491,6 +493,8 @@ type FinalizeResponse struct {
 	DriverResponse state.DriverResponse
 	// APIResponse exists for HTTP-based sync functions.
 	APIResponse apiresult.APIResult
+	// RunError exists with an enums.OpcodeRunError enum.
+	RunError state.GeneratorOpcode
 }
 
 // FinalizeOptional represents optional fields that improve performance of the
@@ -521,6 +525,8 @@ func (f FinalizeOpts) Status() enums.StepStatus {
 	switch f.Response.Type {
 	case FinalizeResponseRunComplete:
 		return enums.StepStatusCompleted
+	case FinalizeResponseRunError:
+		return enums.StepStatusFailed
 	case FinalizeResponseAPI:
 		// XXX: all statuses are currently completed except for 5XX
 		if f.Response.APIResponse.StatusCode >= 500 {

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -2361,6 +2361,9 @@ func (f *functionFinishedData) setResponse(resp execution.FinalizeResponse) {
 		// run complete is always raw data.
 		f.Result = resp.RunComplete.Data
 
+	case execution.FinalizeResponseRunError:
+		f.Error = resp.RunError.Error
+
 	case execution.FinalizeResponseAPI:
 		f.Result = resp.APIResponse
 
@@ -3725,6 +3728,8 @@ func (e *executor) handleGeneratorOp(ctx context.Context, runCtx execution.RunCo
 		return e.handleGeneratorWaitForSignal(ctx, runCtx, gen, edge, group)
 	case enums.OpcodeRunComplete:
 		return e.handleGeneratorFunctionFinished(ctx, runCtx, gen, edge)
+	case enums.OpcodeRunError:
+		return e.handleGeneratorRunError(ctx, runCtx, gen, edge)
 	case enums.OpcodeSyncRunComplete:
 		// This is an API-based function executed synchronously that had
 		// an async conversion.  The result must always be in the shape of
@@ -3930,12 +3935,6 @@ func (e *executor) handleGeneratorDeferAdd(ctx context.Context, runCtx execution
 }
 
 func (e *executor) handleGeneratorDeferAbort(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge) error {
-	// If the SDK emits `[DeferAdd("X"), DeferAbort("X")]` in one response, the
-	// two ops race within the priority group's errgroup. If DeferAbort runs
-	// first it will error. We don't guard against this here (e.g. by writing a
-	// cancelled tombstone when the defer is absent) because emitting an
-	// DeferAdd and DeferAbort for the same hashed ID in a single response is
-	// an SDK bug, and the cost of handling it isn't worth the complexity.
 	if err := defers.AbortFromOp(ctx, e.smv2, e.tracerProvider, e.log, runCtx.Metadata(), gen); err != nil {
 		return err
 	}
@@ -4232,6 +4231,66 @@ func (e *executor) handleGeneratorFunctionFinished(ctx context.Context, runCtx e
 				runCtx.LifecycleItem(),
 				evts,
 				*resp,
+			)
+		}
+	}
+
+	return err
+}
+
+func (e *executor) handleGeneratorRunError(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge) error {
+	if gen.Error == nil {
+		logger.StdlibLogger(ctx).Error("OpcodeRunError handled without user error", "gen", gen)
+		return fmt.Errorf("no user error defined in OpcodeRunError")
+	}
+
+	if IsStepRetryable(&gen, runCtx) {
+		return e.scheduleRunErrorRetry(ctx, runCtx, gen)
+	}
+
+	return e.finalizeRunError(ctx, runCtx, gen)
+}
+
+func (e *executor) scheduleRunErrorRetry(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode) error {
+	e.emitNonStepSpan(ctx, runCtx, &gen, nil, enums.StepStatusErrored)
+	runCtx.IncrementAttempt()
+	for _, l := range e.lifecycles {
+		lifecycleItem := runCtx.LifecycleItem()
+		go l.OnStepScheduled(context.WithoutCancel(ctx), *runCtx.Metadata(), lifecycleItem, &gen.Name)
+	}
+	return fmt.Errorf("%w: %s: %s", ErrHandledStepError, gen.Error.Name, gen.Error.Message)
+}
+
+func (e *executor) finalizeRunError(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode) error {
+	md := runCtx.Metadata()
+	evts := runCtx.Events()
+
+	e.emitNonStepSpan(ctx, runCtx, &gen, nil, enums.StepStatusFailed)
+
+	err := e.Finalize(ctx, execution.FinalizeOpts{
+		Metadata: *md,
+		Response: execution.FinalizeResponse{
+			Type:     execution.FinalizeResponseRunError,
+			RunError: gen,
+		},
+		Optional: execution.FinalizeOptional{
+			InputEvents: evts,
+		},
+	})
+
+	if resp := runCtx.DriverResponse(); resp != nil {
+		failResp := *resp
+		failResp.SetError(fmt.Errorf("%s: %s", gen.Error.Name, gen.Error.Message))
+		failResp.SetFinal()
+		failResp.UserError = gen.Error
+		failResp.Output = gen.Error
+		for _, l := range e.lifecycles {
+			go l.OnFunctionFinished(
+				context.WithoutCancel(ctx),
+				*md,
+				runCtx.LifecycleItem(),
+				evts,
+				failResp,
 			)
 		}
 	}

--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -619,6 +619,8 @@ func finalizeSpanAttributes(f execution.FinalizeOpts) *meta.SerializableAttrs {
 		return apiAttributes(f.Response.APIResponse)
 	case execution.FinalizeResponseRunComplete:
 		return runCompleteAttrs(f.Response.RunComplete)
+	case execution.FinalizeResponseRunError:
+		return runErrorAttrs(f.Response.RunError)
 	case execution.FinalizeResponseDriver:
 		return tracing.DriverResponseAttrs(&f.Response.DriverResponse, nil)
 	}
@@ -650,9 +652,36 @@ func runCompleteAttrs(gen state.GeneratorOpcode) *meta.SerializableAttrs {
 
 	meta.AddAttr(rawAttrs, meta.Attrs.IsFunctionOutput, inngestgo.Ptr(true))
 	meta.AddAttr(rawAttrs, meta.Attrs.ResponseStatusCode, inngestgo.Ptr(200)) // Must be to have this code.  It's an async fn.
+
+	data := gen.Data
+	if len(data) == 0 {
+		// Serialize an empty result as JSON null so the wrapped output below
+		// stays valid JSON.
+		data = json.RawMessage("null")
+	}
 	meta.AddAttr(rawAttrs, meta.Attrs.ResponseOutputSize, inngestgo.Ptr(len(gen.Data)))
 	// XXX: We always wrap trace output with {"data":T} or {"error":T} for consistency with steps.
-	meta.AddAttr(rawAttrs, meta.Attrs.StepOutput, inngestgo.Ptr(util.DataWrap(gen.Data)))
+	meta.AddAttr(rawAttrs, meta.Attrs.StepOutput, inngestgo.Ptr(util.DataWrap(data)))
+
+	rawAttrs = rawAttrs.Merge(tracing.GeneratorAttrs(&gen))
+
+	return rawAttrs
+}
+
+func runErrorAttrs(gen state.GeneratorOpcode) *meta.SerializableAttrs {
+	rawAttrs := meta.NewAttrSet()
+
+	meta.AddAttr(rawAttrs, meta.Attrs.IsFunctionOutput, inngestgo.Ptr(true))
+	// This is the transport status of the SDK's opcode response (as in
+	// runCompleteAttrs), not the run outcome; the span status carries failure.
+	meta.AddAttr(rawAttrs, meta.Attrs.ResponseStatusCode, inngestgo.Ptr(200))
+
+	if errByt, err := json.Marshal(gen.Error); err == nil {
+		meta.AddAttr(rawAttrs, meta.Attrs.ResponseOutputSize, inngestgo.Ptr(len(errByt)))
+		meta.AddAttr(rawAttrs, meta.Attrs.StepOutput, inngestgo.Ptr(fmt.Sprintf(`{%q:%s}`, execution.StateErrorKey, errByt)))
+	} else {
+		rawAttrs.AddErr(fmt.Errorf("failed to marshal run error: %w", err))
+	}
 
 	rawAttrs = rawAttrs.Merge(tracing.GeneratorAttrs(&gen))
 

--- a/pkg/execution/state/driver_response.go
+++ b/pkg/execution/state/driver_response.go
@@ -299,7 +299,7 @@ func (r *DriverResponse) UpdateOpcodeError(op *GeneratorOpcode, err UserError) {
 // return false if it's a step result.
 func (r *DriverResponse) IsFunctionResult() bool {
 	for _, op := range r.Generator {
-		if op.Op == enums.OpcodeRunComplete || op.Op == enums.OpcodeSyncRunComplete {
+		if op.Op == enums.OpcodeRunComplete || op.Op == enums.OpcodeSyncRunComplete || op.Op == enums.OpcodeRunError {
 			// Always a result...
 			return true
 		}
@@ -377,6 +377,13 @@ func (r *DriverResponse) GetTraceFunctionOutput() (string, error) {
 			// us from unmarshalling and remarshalling.
 			data := fmt.Sprintf(`{"data":%s}`, op.Data)
 			return data, nil
+		}
+		if op.Op == enums.OpcodeRunError {
+			errByt, err := json.Marshal(op.Error)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf(`{"error":%s}`, errByt), nil
 		}
 	}
 

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -985,7 +985,7 @@ func (m shardedMgr) SetDeferStatus(ctx context.Context, accountId uuid.UUID, fnI
 		return fmt.Errorf("error setting defer status: %w", err)
 	}
 	if result == 0 {
-		return fmt.Errorf("defer not found for hashedID %q", hashedID)
+		return fmt.Errorf("%w for hashedID %q", state.ErrDeferNotFound, hashedID)
 	}
 	return nil
 }

--- a/pkg/execution/state/state.go
+++ b/pkg/execution/state/state.go
@@ -31,6 +31,7 @@ var (
 	ErrInvokePauseNotFound = fmt.Errorf("invoke pause not found")
 	ErrPauseNotInBuffer    = fmt.Errorf("pause not in buffer")
 	ErrRunNotFound         = fmt.Errorf("run not found in state store")
+	ErrDeferNotFound       = fmt.Errorf("defer not found")
 	// ErrPauseLeased is returned when attempting to lease a pause that is
 	// already leased by another event.
 	ErrPauseLeased         = fmt.Errorf("pause already leased")

--- a/pkg/run/trace_lifecycle.go
+++ b/pkg/run/trace_lifecycle.go
@@ -334,6 +334,11 @@ func (l traceLifecycle) OnFunctionFinished(
 
 	switch resp.StatusCode {
 	case 200, 206:
+		if resp.Err != nil {
+			span.SetStatus(codes.Error, resp.Error())
+			span.SetAttributes(attribute.Int64(consts.OtelSysFunctionStatusCode, enums.RunStatusFailed.ToCode()))
+			break
+		}
 		span.SetStatus(codes.Ok, "success")
 		span.SetAttributes(attribute.Int64(consts.OtelSysFunctionStatusCode, enums.RunStatusCompleted.ToCode()))
 	default: // everything else are errors

--- a/tests/execution/executor/run_error_test.go
+++ b/tests/execution/executor/run_error_test.go
@@ -1,0 +1,434 @@
+package executor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/execution"
+	"github.com/inngest/inngest/pkg/execution/executor"
+	"github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state"
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/stretchr/testify/require"
+)
+
+func findEventByName(events []event.Event, name string) *event.Event {
+	for i, evt := range events {
+		if evt.Name == name {
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+func deferScheduleFnSlugs(t *testing.T, events []event.Event) []string {
+	t.Helper()
+	var slugs []string
+	for _, evt := range events {
+		if evt.Name != consts.FnDeferScheduleName {
+			continue
+		}
+		data := eventDataMap(t, evt)
+		inn := data["_inngest"].(map[string]any)
+		slugs = append(slugs, inn["fn_slug"].(string))
+	}
+	return slugs
+}
+
+func eventDataMap(t *testing.T, evt event.Event) map[string]any {
+	t.Helper()
+	r := require.New(t)
+	raw, err := json.Marshal(evt.Data)
+	r.NoError(err)
+	var data map[string]any
+	r.NoError(json.Unmarshal(raw, &data))
+	return data
+}
+
+func TestRunError(t *testing.T) {
+	userErr := &state.UserError{Name: "CustomError", Message: "step blew up"}
+
+	t.Run("terminal failure with exhausted retries emits function.failed and keeps AfterRun defer", func(t *testing.T) {
+		r := require.New(t)
+		infra := newDeferTestInfra(t)
+		countingQ := &enqueueCountingQueue{Queue: infra.rq}
+
+		stepID := "step-defer"
+		driver := &mockDriverV1{
+			t: t,
+			response: &state.DriverResponse{
+				StatusCode: 206,
+				Generator: []*state.GeneratorOpcode{
+					{
+						Op: enums.OpcodeDeferAdd,
+						ID: stepID,
+						Opts: map[string]any{
+							"fn_slug": "onDefer-score",
+							"input":   map[string]any{},
+						},
+					},
+					{
+						Op:    enums.OpcodeRunError,
+						ID:    "run-error",
+						Error: userErr,
+					},
+				},
+			},
+		}
+
+		exec := infra.newExecutorWithQueue(t, countingQ, driver)
+
+		var capturedEvents []event.Event
+		exec.SetFinalizer(func(ctx context.Context, id statev2.ID, events []event.Event) error {
+			capturedEvents = append(capturedEvents, events...)
+			return nil
+		})
+
+		run := infra.scheduleRun(t, exec)
+		countBeforeExecute := countingQ.enqueues
+
+		_, err := exec.Execute(infra.ctx, state.Identifier{
+			WorkflowID: infra.fnID, RunID: run.ID.RunID, AccountID: infra.aID,
+		}, queue.Item{
+			WorkspaceID: infra.wsID,
+			Kind:        queue.KindStart,
+			Attempt:     4,
+			Identifier:  state.Identifier{WorkflowID: infra.fnID, RunID: run.ID.RunID, AccountID: infra.aID},
+			Payload:     queue.PayloadEdge{Edge: inngest.Edge{Incoming: "$trigger", Outgoing: stepID}},
+		}, inngest.Edge{Incoming: "$trigger", Outgoing: stepID})
+		r.NoError(err)
+
+		enqueuesDuringExecute := countingQ.enqueues - countBeforeExecute
+		r.Equal(0, enqueuesDuringExecute,
+			"terminal RunError piggybacked with DeferAdd must not enqueue discovery; got %d enqueues", enqueuesDuringExecute)
+
+		r.Equal([]string{"onDefer-score"}, deferScheduleFnSlugs(t, capturedEvents),
+			"AfterRun defer must still be scheduled when the run terminates via RunError")
+
+		failedEvt := findEventByName(capturedEvents, event.FnFailedName)
+		r.NotNil(failedEvt, "inngest/function.failed must be emitted on terminal RunError")
+
+		data := eventDataMap(t, *failedEvt)
+		errData, ok := data["error"].(map[string]any)
+		r.True(ok, "error field must be a JSON object, got %T", data["error"])
+		r.Equal(userErr.Name, errData["name"])
+		r.Equal(userErr.Message, errData["message"])
+
+		inn := data["_inngest"].(map[string]any)
+		r.Equal("Failed", inn["status"], "run must finalize as Failed")
+	})
+
+	t.Run("no-retry failure on the first attempt is terminal", func(t *testing.T) {
+		r := require.New(t)
+		infra := newDeferTestInfra(t)
+		countingQ := &enqueueCountingQueue{Queue: infra.rq}
+
+		stepID := "step-defer"
+		noRetryErr := &state.UserError{Name: "FatalError", Message: "do not retry me", NoRetry: true}
+		driver := &mockDriverV1{
+			t: t,
+			response: &state.DriverResponse{
+				StatusCode: 206,
+				Generator: []*state.GeneratorOpcode{
+					{
+						Op: enums.OpcodeDeferAdd,
+						ID: stepID,
+						Opts: map[string]any{
+							"fn_slug": "onDefer-score",
+							"input":   map[string]any{},
+						},
+					},
+					{
+						Op:    enums.OpcodeRunError,
+						ID:    "run-error",
+						Error: noRetryErr,
+					},
+				},
+			},
+		}
+
+		exec := infra.newExecutorWithQueue(t, countingQ, driver)
+
+		var capturedEvents []event.Event
+		exec.SetFinalizer(func(ctx context.Context, id statev2.ID, events []event.Event) error {
+			capturedEvents = append(capturedEvents, events...)
+			return nil
+		})
+
+		run := infra.scheduleRun(t, exec)
+		countBeforeExecute := countingQ.enqueues
+
+		_, err := exec.Execute(infra.ctx, state.Identifier{
+			WorkflowID: infra.fnID, RunID: run.ID.RunID, AccountID: infra.aID,
+		}, queue.Item{
+			WorkspaceID: infra.wsID,
+			Kind:        queue.KindStart,
+			Attempt:     0,
+			Identifier:  state.Identifier{WorkflowID: infra.fnID, RunID: run.ID.RunID, AccountID: infra.aID},
+			Payload:     queue.PayloadEdge{Edge: inngest.Edge{Incoming: "$trigger", Outgoing: stepID}},
+		}, inngest.Edge{Incoming: "$trigger", Outgoing: stepID})
+		r.NoError(err)
+
+		enqueuesDuringExecute := countingQ.enqueues - countBeforeExecute
+		r.Equal(0, enqueuesDuringExecute,
+			"NoRetry RunError piggybacked with DeferAdd must not enqueue discovery; got %d enqueues", enqueuesDuringExecute)
+
+		r.Equal([]string{"onDefer-score"}, deferScheduleFnSlugs(t, capturedEvents),
+			"AfterRun defer must still be scheduled when the run terminates via a NoRetry RunError")
+
+		failedEvt := findEventByName(capturedEvents, event.FnFailedName)
+		r.NotNil(failedEvt, "inngest/function.failed must be emitted on the first attempt when NoRetry is set")
+
+		data := eventDataMap(t, *failedEvt)
+		errData, ok := data["error"].(map[string]any)
+		r.True(ok, "error field must be a JSON object, got %T", data["error"])
+		r.Equal(noRetryErr.Name, errData["name"])
+		r.Equal(noRetryErr.Message, errData["message"])
+
+		inn := data["_inngest"].(map[string]any)
+		r.Equal("Failed", inn["status"], "run must finalize as Failed despite having attempts remaining")
+	})
+
+	t.Run("retryable failure persists the defer but does not finalize", func(t *testing.T) {
+		r := require.New(t)
+		infra := newDeferTestInfra(t)
+
+		stepID := "step-defer"
+		driver := &mockDriverV1{
+			t: t,
+			response: &state.DriverResponse{
+				StatusCode: 206,
+				Generator: []*state.GeneratorOpcode{
+					{
+						Op: enums.OpcodeDeferAdd,
+						ID: stepID,
+						Opts: map[string]any{
+							"fn_slug": "onDefer-score",
+							"input":   map[string]any{},
+						},
+					},
+					{
+						Op:    enums.OpcodeRunError,
+						ID:    "run-error",
+						Error: userErr,
+					},
+				},
+			},
+		}
+
+		exec := infra.newExecutor(t, driver)
+
+		var capturedEvents []event.Event
+		exec.SetFinalizer(func(ctx context.Context, id statev2.ID, events []event.Event) error {
+			capturedEvents = append(capturedEvents, events...)
+			return nil
+		})
+
+		run := infra.scheduleRun(t, exec)
+
+		_, err := exec.Execute(infra.ctx, state.Identifier{
+			WorkflowID: infra.fnID, RunID: run.ID.RunID, AccountID: infra.aID,
+		}, queue.Item{
+			WorkspaceID: infra.wsID,
+			Kind:        queue.KindStart,
+			Attempt:     0,
+			Identifier:  state.Identifier{WorkflowID: infra.fnID, RunID: run.ID.RunID, AccountID: infra.aID},
+			Payload:     queue.PayloadEdge{Edge: inngest.Edge{Incoming: "$trigger", Outgoing: stepID}},
+		}, inngest.Edge{Incoming: "$trigger", Outgoing: stepID})
+
+		r.Error(err, "a retryable RunError must surface an error so the queue requeues the item")
+		r.Contains(err.Error(), userErr.Message)
+
+		var retryable queue.RetryableError
+		r.False(errors.As(err, &retryable),
+			"a retryable RunError must not be wrapped as queue.NeverRetryError")
+
+		defers, err := infra.smv2.LoadDefers(infra.ctx, run.ID)
+		r.NoError(err)
+		r.Contains(defers, stepID,
+			"the piggybacked DeferAdd must persist even though the host RunError op is retryable")
+
+		r.Nil(findEventByName(capturedEvents, event.FnFailedName),
+			"a retryable RunError must not finalize the run or emit function.failed")
+	})
+
+	t.Run("parity with a plain (non-generator) rejection", func(t *testing.T) {
+		r := require.New(t)
+
+		runErrorEvt, runErrorOutput := runToFailureViaRunError(t, userErr)
+		plainRejectionEvt, plainRejectionOutput := runToFailureViaPlainRejection(t, userErr)
+
+		runErrorData := eventDataMap(t, *runErrorEvt)
+		plainRejectionData := eventDataMap(t, *plainRejectionEvt)
+
+		r.Equal(runErrorData["error"], plainRejectionData["error"],
+			"OpcodeRunError and a plain rejection must carry the same error payload for the same user error")
+
+		runErrorInn := runErrorData["_inngest"].(map[string]any)
+		plainRejectionInn := plainRejectionData["_inngest"].(map[string]any)
+		r.Equal(runErrorInn["status"], plainRejectionInn["status"])
+		r.Equal("Failed", runErrorInn["status"])
+
+		r.NotEmpty(runErrorOutput, "a terminal RunError must record a function output")
+		r.Equal(plainRejectionOutput, runErrorOutput,
+			"the recorded function output for a RunError run must be byte-identical to an equivalent plain rejection")
+	})
+}
+
+// finalizeTracer records the finalize span so tests can inspect the function
+// output the executor persists at terminal finalization.
+type finalizeTracer struct {
+	tracing.TracerProvider
+	mu      sync.Mutex
+	updates []*tracing.UpdateSpanOptions
+}
+
+func newFinalizeTracer() *finalizeTracer {
+	return &finalizeTracer{TracerProvider: tracing.NewNoopTracerProvider()}
+}
+
+func (f *finalizeTracer) UpdateSpan(ctx context.Context, opts *tracing.UpdateSpanOptions) error {
+	f.mu.Lock()
+	f.updates = append(f.updates, opts)
+	f.mu.Unlock()
+	return f.TracerProvider.UpdateSpan(ctx, opts)
+}
+
+// functionOutput returns the function output recorded on the finalize span.
+func (f *finalizeTracer) functionOutput(t *testing.T) string {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, u := range f.updates {
+		if u.Debug == nil || u.Debug.Location != "executor.finalize" || u.Attributes == nil {
+			continue
+		}
+		if out, ok := u.Attributes.Get(meta.Attrs.StepOutput.Key()).(*string); ok && out != nil {
+			return *out
+		}
+	}
+	t.Fatal("no finalize span with a function output was recorded")
+	return ""
+}
+
+func (i *deferTestInfra) newExecutorWithTracer(t *testing.T, driver *mockDriverV1, tp tracing.TracerProvider) execution.Executor {
+	t.Helper()
+	opts := []executor.ExecutorOpt{
+		executor.WithStateManager(i.smv2),
+		executor.WithPauseManager(i.pauseMgr),
+		executor.WithQueue(i.rq),
+		executor.WithLogger(logger.StdlibLogger(i.ctx)),
+		executor.WithFunctionLoader(i.loader),
+		executor.WithShardRegistry(i.shardRegistry),
+		executor.WithTracerProvider(tp),
+	}
+	if driver != nil {
+		opts = append(opts, executor.WithDriverV1(driver))
+	}
+	exec, err := executor.NewExecutor(opts...)
+	require.NoError(t, err)
+	return exec
+}
+
+func runToFailureViaRunError(t *testing.T, userErr *state.UserError) (*event.Event, string) {
+	t.Helper()
+	r := require.New(t)
+	infra := newDeferTestInfra(t)
+
+	stepID := "step-defer"
+	driver := &mockDriverV1{
+		t: t,
+		response: &state.DriverResponse{
+			StatusCode: 206,
+			Generator: []*state.GeneratorOpcode{
+				{
+					Op:    enums.OpcodeRunError,
+					ID:    "run-error",
+					Error: userErr,
+				},
+			},
+		},
+	}
+	tracer := newFinalizeTracer()
+	exec := infra.newExecutorWithTracer(t, driver, tracer)
+
+	var capturedEvents []event.Event
+	exec.SetFinalizer(func(ctx context.Context, id statev2.ID, events []event.Event) error {
+		capturedEvents = append(capturedEvents, events...)
+		return nil
+	})
+
+	run := infra.scheduleRun(t, exec)
+
+	_, err := exec.Execute(infra.ctx, state.Identifier{
+		WorkflowID: infra.fnID, RunID: run.ID.RunID, AccountID: infra.aID,
+	}, queue.Item{
+		WorkspaceID: infra.wsID,
+		Kind:        queue.KindStart,
+		Attempt:     4,
+		Identifier:  state.Identifier{WorkflowID: infra.fnID, RunID: run.ID.RunID, AccountID: infra.aID},
+		Payload:     queue.PayloadEdge{Edge: inngest.Edge{Incoming: "$trigger", Outgoing: stepID}},
+	}, inngest.Edge{Incoming: "$trigger", Outgoing: stepID})
+	r.NoError(err)
+
+	failedEvt := findEventByName(capturedEvents, event.FnFailedName)
+	r.NotNil(failedEvt, "inngest/function.failed must be emitted for a terminal RunError")
+	return failedEvt, tracer.functionOutput(t)
+}
+
+func runToFailureViaPlainRejection(t *testing.T, userErr *state.UserError) (*event.Event, string) {
+	t.Helper()
+	r := require.New(t)
+	infra := newDeferTestInfra(t)
+
+	stepID := "step-defer"
+	crashMsg := "sdk crashed"
+	output, err := json.Marshal(userErr)
+	r.NoError(err)
+	driver := &mockDriverV1{
+		t: t,
+		response: &state.DriverResponse{
+			StatusCode: 500,
+			Err:        &crashMsg,
+			NoRetry:    true,
+			UserError:  userErr,
+			Output:     json.RawMessage(output),
+		},
+	}
+	tracer := newFinalizeTracer()
+	exec := infra.newExecutorWithTracer(t, driver, tracer)
+
+	var capturedEvents []event.Event
+	exec.SetFinalizer(func(ctx context.Context, id statev2.ID, events []event.Event) error {
+		capturedEvents = append(capturedEvents, events...)
+		return nil
+	})
+
+	run := infra.scheduleRun(t, exec)
+
+	_, err = exec.Execute(infra.ctx, state.Identifier{
+		WorkflowID: infra.fnID, RunID: run.ID.RunID, AccountID: infra.aID,
+	}, queue.Item{
+		WorkspaceID: infra.wsID,
+		Kind:        queue.KindStart,
+		Attempt:     0,
+		Identifier:  state.Identifier{WorkflowID: infra.fnID, RunID: run.ID.RunID, AccountID: infra.aID},
+		Payload:     queue.PayloadEdge{Edge: inngest.Edge{Incoming: "$trigger", Outgoing: stepID}},
+	}, inngest.Edge{Incoming: "$trigger", Outgoing: stepID})
+	r.Error(err)
+	r.Contains(err.Error(), crashMsg)
+
+	failedEvt := findEventByName(capturedEvents, event.FnFailedName)
+	r.NotNil(failedEvt, "inngest/function.failed must be emitted for a terminal plain rejection")
+	return failedEvt, tracer.functionOutput(t)
+}


### PR DESCRIPTION
## Description

The SDK's new `deferFnHandle.abort()` changes how terminal rejections ship: a rejection with buffered lazy ops now arrives as one op batch, `[DeferAdd..., OpcodeRunError]`, instead of the classic function-rejected response.

A new opcode is needed because `defer()` is fire-and-forget: `DeferAdd`s buffer client-side and ride the run's next outbound message. When a function rejects terminally, that rejection is the last message, and the classic function-rejected body can't carry ops, so buffered defers were silently dropped. Persisting them any other way (checkpoint then reject) re-opens the drop window or races finalization; the only safe shape is a single batch where defers persist before a terminal-error op, which requires that op to exist. Plain rejections without lazy ops keep the classic response, so older executors never see the opcode.

Backend half of the contract:

- Handle OpcodeRunError: retryable errors requeue at attempt+1; terminal errors finalize the run as Failed and emit inngest/function.failed. Async request/response mode only — both checkpoint paths reject it.
- Treat unknown-target DeferAborts as a benign no-op. The SDK can't know whether a DeferAdd landed (a checkpoint can fail client-side after the server persisted it), so it always ships aborts; a no-op abort is harmless, a swallowed one could leave a live run.

## Related

https://github.com/inngest/inngest-js/pull/1621 👈 these are the SDK changes this supports

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
