### PR TITLE
cloud(dashboard): added floating feedback icons on beta features

### DIFF
--- a/ui/apps/dashboard/src/components/Feedback/FeedbackFloatingButton.tsx
+++ b/ui/apps/dashboard/src/components/Feedback/FeedbackFloatingButton.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@inngest/components/Button';
+import { RiQuestionAnswerLine } from '@remixicon/react';
+
+import FeedbackPopover from './FeedbackPopover';
+
+// A fixed, icon-only primary button anchored to the bottom-right corner that
+// opens the shared feedback dialog. Reuses FeedbackPopover so submission
+// behaves identically to the bottom-bar entry point.
+export default function FeedbackFloatingButton() {
+  return (
+    <FeedbackPopover
+      align="end"
+      side="top"
+      trigger={
+        <Button
+          kind="primary"
+          size="large"
+          icon={<RiQuestionAnswerLine />}
+          aria-label="Send feedback"
+          className="fixed bottom-10 right-8 z-50 shadow-lg"
+        />
+      }
+    />
+  );
+}

--- a/ui/apps/dashboard/src/components/Feedback/FeedbackPopover.tsx
+++ b/ui/apps/dashboard/src/components/Feedback/FeedbackPopover.tsx
@@ -1,16 +1,31 @@
-import { Fragment, useState } from 'react';
+import { Fragment, useState, type ReactNode } from 'react';
 import { useOrganization, useUser } from '@clerk/tanstack-react-start';
-import { Button } from '@inngest/components/Button';
 import { Textarea } from '@inngest/components/Forms/Textarea';
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from '@inngest/components/Popover';
+import { Button } from '@inngest/components/Button';
 import { RiCheckLine } from '@remixicon/react';
 import { toast } from 'sonner';
 
-export default function FeedbackPopover() {
+type Props = {
+  // Element rendered as the popover trigger (asChild), e.g. a bottom-bar link
+  // or a floating icon button. Lets multiple entry points share one dialog.
+  trigger: ReactNode;
+  align?: 'start' | 'center' | 'end';
+  side?: 'top' | 'bottom' | 'left' | 'right';
+  // Renders a leading "|" divider before the trigger (used in the bottom bar).
+  leadingDivider?: boolean;
+};
+
+export default function FeedbackPopover({
+  trigger,
+  align = 'start',
+  side = 'top',
+  leadingDivider = false,
+}: Props) {
   const { user } = useUser();
   const { organization } = useOrganization();
 
@@ -66,7 +81,7 @@ export default function FeedbackPopover() {
 
   return (
     <Fragment>
-      <span className="text-disabled">|</span>
+      {leadingDivider && <span className="text-disabled">|</span>}
       <Popover
         open={open}
         onOpenChange={(next) => {
@@ -77,8 +92,8 @@ export default function FeedbackPopover() {
           }
         }}
       >
-        <PopoverTrigger className="hover:text-basis">Feedback</PopoverTrigger>
-        <PopoverContent align="start" side="top" className="w-[380px] p-4">
+        <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+        <PopoverContent align={align} side={side} className="w-[380px] p-4">
           <form onSubmit={onSubmit} className="flex flex-col gap-3">
             <p className="text-basis text-sm font-medium">Feedback</p>
             <Textarea

--- a/ui/apps/dashboard/src/components/Layout/BottomBar.tsx
+++ b/ui/apps/dashboard/src/components/Layout/BottomBar.tsx
@@ -29,7 +29,14 @@ export default function BottomBar() {
             </a>
           </Fragment>
         ))}
-        <FeedbackPopover />
+        <FeedbackPopover
+          leadingDivider
+          trigger={
+            <button type="button" className="hover:text-basis">
+              Feedback
+            </button>
+          }
+        />
         <span className="text-disabled">|</span>
         <a
           href="https://status.inngest.com"

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/experiments/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/experiments/index.tsx
@@ -11,6 +11,7 @@ import { Header } from '@inngest/components/Header/Header';
 import { Info } from '@inngest/components/Info/Info';
 import { Link } from '@inngest/components/Link';
 
+import FeedbackFloatingButton from '@/components/Feedback/FeedbackFloatingButton';
 import { useExperimentsList } from '@/components/Experiments/useExperiments';
 import { pathCreator } from '@/utils/urls';
 
@@ -70,6 +71,7 @@ function ExperimentsComponent() {
           infoIcon={<ExperimentsInfo />}
         />
         <ExperimentsEmptyState />
+        <FeedbackFloatingButton />
       </>
     );
   }
@@ -95,6 +97,7 @@ function ExperimentsComponent() {
           </>
         }
       />
+      <FeedbackFloatingButton />
     </>
   );
 }

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/scores/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/scores/index.tsx
@@ -5,6 +5,8 @@ import { Link } from '@inngest/components/Link';
 import { RefreshButton } from '@inngest/components/Refresh/RefreshButton';
 import { ClientOnly, createFileRoute } from '@tanstack/react-router';
 
+import FeedbackFloatingButton from '@/components/Feedback/FeedbackFloatingButton';
+
 const ScoresDashboard = lazy(() =>
   import('@/components/Scores/Dashboard').then((m) => ({
     default: m.ScoresDashboard,
@@ -47,6 +49,7 @@ function ScoresComponent() {
           <ScoresDashboard envSlug={envSlug} />
         </ClientOnly>
       </div>
+      <FeedbackFloatingButton />
     </>
   );
 }

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/sessions/index.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/sessions/index.tsx
@@ -3,6 +3,7 @@ import { Header } from '@inngest/components/Header/Header';
 import { SessionKeys } from '@inngest/components/Sessions/SessionKeys';
 import { ClientOnly, createFileRoute } from '@tanstack/react-router';
 
+import FeedbackFloatingButton from '@/components/Feedback/FeedbackFloatingButton';
 import { SessionsInfo } from '@/components/Sessions/SessionsInfo';
 import { useSessionKeys } from '@/components/Sessions/useSessionKeys';
 import { pathCreator } from '@/utils/urls';
@@ -40,6 +41,7 @@ function SessionsPage() {
           }
         />
       </ClientOnly>
+      <FeedbackFloatingButton />
     </>
   );
 }


### PR DESCRIPTION
## Description

Get more feedback on the new AI releases [experiments/Scores/Sessions], by adding a floating feedback button.

<img width="453" height="341" alt="Screenshot 2026-07-08 at 16 12 23" src="https://github.com/user-attachments/assets/52cf09e7-4261-40bb-8fa8-14aee671aff6" />


## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
