### PR TITLE
perf: reduce sleep queue item payload size

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -1802,12 +1802,15 @@ func (e *executor) Execute(ctx context.Context, id state.Identifier, item queue.
 	// This also marks the sleep item as completed.
 	isSleepResume := item.Kind == queue.KindSleep && item.Attempt == 0
 	if isSleepResume {
+		// New sleep items don't store span refs; reconstruct deterministically and rehydrate
+		// item.Metadata so downstream reads find them.
+		target := tracing.SleepStepSpanRefResolve(&item, id.RunID)
 		err := e.tracerProvider.UpdateSpan(ctx, &tracing.UpdateSpanOptions{
 			EndTime:    e.now(),
 			Debug:      &tracing.SpanDebugData{Location: "executor.SleepResume"},
 			QueueItem:  &item,
 			Status:     enums.StepStatusCompleted,
-			TargetSpan: tracing.SpanRefFromQueueItem(&item),
+			TargetSpan: target,
 		})
 		if err != nil {
 			l.Debug("error updating sleep resume span", "error", err)
@@ -4425,7 +4428,6 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, runCtx execution.Ru
 		Attempt:               0,
 		MaxAttempts:           runCtx.MaxAttempts(),
 		Payload:               queue.PayloadEdge{Edge: nextEdge},
-		Metadata:              make(map[string]any),
 		ParallelMode:          gen.ParallelMode(),
 	}
 
@@ -4437,17 +4439,19 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, runCtx execution.Ru
 
 	// Create a new span that we'll use to record the sleep as complete.
 	// This is going to be attached to the same parent (the discovery step that started this sleep).
+	sleepStepSpanID := tracing.DeterministicSpanConfig(tracing.SleepStepDynamicSeed(gen.ID)).SpanID
+	discoverySpanID := tracing.DeterministicSpanConfig(tracing.SleepDiscoveryDynamicSeed(gen.ID)).SpanID
 	span, err := e.tracerProvider.CreateDroppableSpan(
 		ctx,
 		meta.SpanNameStep,
 		&tracing.CreateSpanOptions{
-			Carriers:    []map[string]any{nextItem.Metadata},
-			FollowsFrom: tracing.SpanRefFromQueueItem(&lifecycleItem),
-			Debug:       &tracing.SpanDebugData{Location: "executor.handleGeneratorSleep"},
-			Metadata:    metadata,
-			QueueItem:   &nextItem,
-			Parent:      runCtx.RootSpan(),
-			Attributes:  attrs,
+			FollowsFrom:           tracing.SpanRefFromQueueItem(&lifecycleItem),
+			Debug:                 &tracing.SpanDebugData{Location: "executor.handleGeneratorSleep"},
+			Metadata:              metadata,
+			QueueItem:             &nextItem,
+			Parent:                runCtx.RootSpan(),
+			Attributes:            attrs,
+			DynamicSpanIDOverride: sleepStepSpanID.String(),
 		},
 	)
 	if err != nil {
@@ -4461,7 +4465,7 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, runCtx execution.Ru
 	// Doing that here allows us to make this deterministic.  In the future, if we had deterministic
 	// span IDs we could remove this.
 	{
-		discoveryRef, err := e.tracerProvider.CreateSpan(
+		_, err := e.tracerProvider.CreateSpan(
 			ctx,
 			meta.SpanNameStepDiscovery,
 			&tracing.CreateSpanOptions{
@@ -4469,17 +4473,15 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, runCtx execution.Ru
 				Metadata:    metadata,
 				FollowsFrom: tracing.SpanRefFromQueueItem(&lifecycleItem),
 				// Always from the root span.
-				Parent:    tracing.RunSpanRefFromMetadata(metadata),
-				QueueItem: &nextItem,
-				StartTime: until,
+				Parent:                tracing.RunSpanRefFromMetadata(metadata),
+				QueueItem:             &nextItem,
+				StartTime:             until,
+				DynamicSpanIDOverride: discoverySpanID.String(),
 			},
 		)
 		if err != nil {
 			e.log.Debug("error creating span discovery step after sleep", "error", err)
 		}
-		// Plumb this into the queue item manually, unfortunately.
-		byt, _ := json.Marshal(discoveryRef)
-		nextItem.Metadata["discovery"] = string(byt)
 	}
 
 	err = e.queue.Enqueue(ctx, nextItem, until, queue.EnqueueOpts{

--- a/pkg/execution/state/v2/state_metadata.go
+++ b/pkg/execution/state/v2/state_metadata.go
@@ -359,14 +359,6 @@ func (c *Config) FunctionTrace() *itrace.TraceCarrier {
 	return nil
 }
 
-func (c *Config) NewSetFunctionTrace(carrier *meta.SpanReference) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.initContext()
-	c.Context[meta.PropagationKey] = *carrier
-}
-
 // RootSpanFromConfig is deprecated.  Use tracing.RunSpanRefFromMetadata.
 func (c *Config) RootSpanFromConfig() *meta.SpanReference {
 	if c == nil || c.mu == nil {

--- a/pkg/tracing/util.go
+++ b/pkg/tracing/util.go
@@ -494,6 +494,72 @@ func NonStepDynamicSeed(item queue.Item) []byte {
 	return fmt.Appendf(nil, "nonstep:%s:%d", item.GroupID, item.Attempt)
 }
 
+// SleepStepDynamicSeed derives the dynamic_span_id seed for a sleep step's
+// own span.
+func SleepStepDynamicSeed(stepID string) []byte {
+	return fmt.Appendf(nil, "sleep-step:%s", stepID)
+}
+
+// SleepDiscoveryDynamicSeed derives the dynamic_span_id seed for the
+// post-sleep discovery placeholder span.
+func SleepDiscoveryDynamicSeed(stepID string) []byte {
+	return fmt.Appendf(nil, "sleep-discovery:%s", stepID)
+}
+
+// SleepStepSpanRef reconstructs the SpanReference for a sleep step's own span
+func SleepStepSpanRef(runID ulid.ULID, stepID string) *meta.SpanReference {
+	cfg := DeterministicSpanConfig(runID[:])
+	stepSpanID := DeterministicSpanConfig(SleepStepDynamicSeed(stepID)).SpanID
+	return &meta.SpanReference{
+		DynamicSpanID:          stepSpanID.String(),
+		DynamicSpanTraceParent: fmt.Sprintf("00-%s-%s-00", cfg.TraceID.String(), cfg.SpanID.String()),
+		TraceParent:            fmt.Sprintf("00-%s-%s-00", cfg.TraceID.String(), stepSpanID.String()),
+	}
+}
+
+// SleepDiscoverySpanRef reconstructs the SpanReference for the post-sleep
+// discovery placeholder span.
+func SleepDiscoverySpanRef(runID ulid.ULID, stepID string) *meta.SpanReference {
+	cfg := DeterministicSpanConfig(runID[:])
+	spanID := DeterministicSpanConfig(SleepDiscoveryDynamicSeed(stepID)).SpanID
+	return &meta.SpanReference{
+		DynamicSpanID:          spanID.String(),
+		DynamicSpanTraceParent: fmt.Sprintf("00-%s-%s-00", cfg.TraceID.String(), cfg.SpanID.String()),
+		TraceParent:            fmt.Sprintf("00-%s-%s-00", cfg.TraceID.String(), spanID.String()),
+	}
+}
+
+// SleepStepSpanRefResolve returns the sleep step's span ref for a resumed
+// sleep item. Legacy items carry the ref in item.Metadata[PropagationKey];
+// new items have it reconstructed deterministically and rehydrated
+// (along with the "discovery" ref) into item.Metadata so
+// downstream reads work uniformly. Returns nil if neither path is available.
+func SleepStepSpanRefResolve(item *queue.Item, runID ulid.ULID) *meta.SpanReference {
+	if ref := SpanRefFromQueueItem(item); ref != nil {
+		return ref
+	}
+	payload, ok := item.Payload.(queue.PayloadEdge)
+	if !ok || payload.Edge.Outgoing == "" {
+		return nil
+	}
+	ref := SleepStepSpanRef(runID, payload.Edge.Outgoing)
+	if ref == nil {
+		return nil
+	}
+	if item.Metadata == nil {
+		item.Metadata = map[string]any{}
+	}
+	if byt, err := json.Marshal(ref); err == nil {
+		item.Metadata[meta.PropagationKey] = string(byt)
+	}
+	if disc := SleepDiscoverySpanRef(runID, payload.Edge.Outgoing); disc != nil {
+		if byt, err := json.Marshal(disc); err == nil {
+			item.Metadata["discovery"] = string(byt)
+		}
+	}
+	return ref
+}
+
 // DeferSpanSeed returns the deterministic seed used to identify the
 // executor.defer span.
 func DeferSpanSeed(parentRunID ulid.ULID, hashedDeferID string) []byte {

--- a/pkg/tracing/util_test.go
+++ b/pkg/tracing/util_test.go
@@ -1,12 +1,15 @@
 package tracing
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -212,5 +215,194 @@ func TestNonStepDynamicSeed(t *testing.T) {
 		a := queue.Item{GroupID: "grp-x", Attempt: 0}
 		b := queue.Item{GroupID: "grp-x", Attempt: 1}
 		assert.NotEqual(t, NonStepDynamicSeed(a), NonStepDynamicSeed(b))
+	})
+}
+
+func TestSleepStepDynamicSeed(t *testing.T) {
+	t.Run("seed encodes sleep-step prefix and step ID", func(t *testing.T) {
+		seed := SleepStepDynamicSeed("my-step")
+		assert.Equal(t, []byte("sleep-step:my-step"), seed)
+	})
+
+	t.Run("same step ID always produces the same seed", func(t *testing.T) {
+		assert.Equal(t, SleepStepDynamicSeed("s1"), SleepStepDynamicSeed("s1"))
+	})
+
+	t.Run("different step IDs produce different seeds", func(t *testing.T) {
+		assert.NotEqual(t, SleepStepDynamicSeed("s1"), SleepStepDynamicSeed("s2"))
+	})
+}
+
+func TestSleepDiscoveryDynamicSeed(t *testing.T) {
+	t.Run("seed encodes sleep-discovery prefix and step ID", func(t *testing.T) {
+		seed := SleepDiscoveryDynamicSeed("my-step")
+		assert.Equal(t, []byte("sleep-discovery:my-step"), seed)
+	})
+
+	t.Run("different step IDs produce different seeds", func(t *testing.T) {
+		assert.NotEqual(t, SleepDiscoveryDynamicSeed("s1"), SleepDiscoveryDynamicSeed("s2"))
+	})
+}
+
+func TestSleepSeedsDoNotCollide(t *testing.T) {
+	// Sleep step, sleep discovery, finalized step, and retry step seeds must all differ
+	// for the same stepID so their derived dynamic span IDs are distinct.
+	stepID := "shared-step"
+	sleepStep := SleepStepDynamicSeed(stepID)
+	sleepDisc := SleepDiscoveryDynamicSeed(stepID)
+	finalized := FinalizedStepDynamicSeed(stepID)
+	retry0 := RetryStepDynamicSeed(stepID, 0)
+
+	assert.NotEqual(t, sleepStep, sleepDisc)
+	assert.NotEqual(t, sleepStep, finalized)
+	assert.NotEqual(t, sleepStep, retry0)
+	assert.NotEqual(t, sleepDisc, finalized)
+	assert.NotEqual(t, sleepDisc, retry0)
+}
+
+func TestSleepStepSpanRef(t *testing.T) {
+	runID := ulid.Make()
+	stepID := "sleep-step-id"
+
+	t.Run("ref contains non-empty fields", func(t *testing.T) {
+		ref := SleepStepSpanRef(runID, stepID)
+		require.NotNil(t, ref)
+		assert.NotEmpty(t, ref.DynamicSpanID)
+		assert.NotEmpty(t, ref.DynamicSpanTraceParent)
+		assert.NotEmpty(t, ref.TraceParent)
+	})
+
+	t.Run("dynamic_span_id is derived purely from step ID", func(t *testing.T) {
+		// Same stepID across different runs must yield the same DynamicSpanID.
+		otherRunID := ulid.Make()
+		assert.Equal(t,
+			SleepStepSpanRef(runID, stepID).DynamicSpanID,
+			SleepStepSpanRef(otherRunID, stepID).DynamicSpanID,
+		)
+	})
+
+	t.Run("dynamic_span_id matches DeterministicSpanConfig of the sleep-step seed", func(t *testing.T) {
+		expected := DeterministicSpanConfig(SleepStepDynamicSeed(stepID)).SpanID.String()
+		assert.Equal(t, expected, SleepStepSpanRef(runID, stepID).DynamicSpanID)
+	})
+
+	t.Run("DynamicSpanTraceParent uses the run trace and run span as parent", func(t *testing.T) {
+		runCfg := DeterministicSpanConfig(runID[:])
+		expected := fmt.Sprintf("00-%s-%s-00", runCfg.TraceID.String(), runCfg.SpanID.String())
+		assert.Equal(t, expected, SleepStepSpanRef(runID, stepID).DynamicSpanTraceParent)
+	})
+
+	t.Run("TraceParent uses the run trace and the sleep step span ID", func(t *testing.T) {
+		runCfg := DeterministicSpanConfig(runID[:])
+		stepSpanID := DeterministicSpanConfig(SleepStepDynamicSeed(stepID)).SpanID.String()
+		expected := fmt.Sprintf("00-%s-%s-00", runCfg.TraceID.String(), stepSpanID)
+		assert.Equal(t, expected, SleepStepSpanRef(runID, stepID).TraceParent)
+	})
+
+	t.Run("different steps produce different refs", func(t *testing.T) {
+		a := SleepStepSpanRef(runID, "s1")
+		b := SleepStepSpanRef(runID, "s2")
+		assert.NotEqual(t, a.DynamicSpanID, b.DynamicSpanID)
+	})
+}
+
+func TestSleepDiscoverySpanRef(t *testing.T) {
+	runID := ulid.Make()
+	stepID := "sleep-step-id"
+
+	t.Run("dynamic_span_id matches DeterministicSpanConfig of the sleep-discovery seed", func(t *testing.T) {
+		expected := DeterministicSpanConfig(SleepDiscoveryDynamicSeed(stepID)).SpanID.String()
+		assert.Equal(t, expected, SleepDiscoverySpanRef(runID, stepID).DynamicSpanID)
+	})
+
+	t.Run("sleep step and sleep discovery refs differ for the same input", func(t *testing.T) {
+		step := SleepStepSpanRef(runID, stepID)
+		disc := SleepDiscoverySpanRef(runID, stepID)
+		assert.NotEqual(t, step.DynamicSpanID, disc.DynamicSpanID)
+	})
+
+	t.Run("dynamic_span_id is derived purely from step ID", func(t *testing.T) {
+		otherRunID := ulid.Make()
+		assert.Equal(t,
+			SleepDiscoverySpanRef(runID, stepID).DynamicSpanID,
+			SleepDiscoverySpanRef(otherRunID, stepID).DynamicSpanID,
+		)
+	})
+}
+
+func TestSleepStepSpanRefResolve(t *testing.T) {
+	runID := ulid.Make()
+	stepID := "resolved-step"
+
+	newSleepItem := func() *queue.Item {
+		return &queue.Item{
+			Kind:    queue.KindSleep,
+			Payload: queue.PayloadEdge{Edge: inngest.Edge{Outgoing: stepID}},
+		}
+	}
+
+	t.Run("legacy carrier wins over deterministic reconstruction", func(t *testing.T) {
+		legacyRef := &meta.SpanReference{
+			DynamicSpanID:          "legacydsid000000",
+			DynamicSpanTraceParent: "00-legacy-trace-id-000000000000-legacypar-00",
+			TraceParent:            "00-legacy-trace-id-000000000000-legacyown-00",
+		}
+		byt, err := json.Marshal(legacyRef)
+		require.NoError(t, err)
+
+		item := newSleepItem()
+		item.Metadata = map[string]any{meta.PropagationKey: string(byt)}
+
+		ref := SleepStepSpanRefResolve(item, runID)
+		require.NotNil(t, ref)
+		assert.Equal(t, legacyRef.DynamicSpanID, ref.DynamicSpanID)
+
+		// Metadata not mutated for legacy items — no discovery key added.
+		_, hasDisc := item.Metadata["discovery"]
+		assert.False(t, hasDisc, "discovery key should not be written when carrier already present")
+	})
+
+	t.Run("deterministic reconstruction on missing carrier", func(t *testing.T) {
+		item := newSleepItem()
+		ref := SleepStepSpanRefResolve(item, runID)
+		require.NotNil(t, ref)
+
+		expected := SleepStepSpanRef(runID, stepID)
+		assert.Equal(t, expected.DynamicSpanID, ref.DynamicSpanID)
+	})
+
+	t.Run("rehydration writes PropagationKey and discovery back into Metadata", func(t *testing.T) {
+		item := newSleepItem()
+		_ = SleepStepSpanRefResolve(item, runID)
+
+		propRaw, ok := item.Metadata[meta.PropagationKey].(string)
+		require.True(t, ok, "PropagationKey should be rehydrated")
+		var propRef meta.SpanReference
+		require.NoError(t, json.Unmarshal([]byte(propRaw), &propRef))
+		assert.Equal(t, SleepStepSpanRef(runID, stepID).DynamicSpanID, propRef.DynamicSpanID)
+
+		discRaw, ok := item.Metadata["discovery"].(string)
+		require.True(t, ok, "discovery should be rehydrated")
+		var discRef meta.SpanReference
+		require.NoError(t, json.Unmarshal([]byte(discRaw), &discRef))
+		assert.Equal(t, SleepDiscoverySpanRef(runID, stepID).DynamicSpanID, discRef.DynamicSpanID)
+	})
+
+	t.Run("corrupt carrier falls through to deterministic path", func(t *testing.T) {
+		item := newSleepItem()
+		item.Metadata = map[string]any{meta.PropagationKey: "{not-json"}
+		ref := SleepStepSpanRefResolve(item, runID)
+		require.NotNil(t, ref)
+		assert.Equal(t, SleepStepSpanRef(runID, stepID).DynamicSpanID, ref.DynamicSpanID)
+	})
+
+	t.Run("non-PayloadEdge payload returns nil", func(t *testing.T) {
+		item := &queue.Item{Kind: queue.KindSleep, Payload: nil}
+		assert.Nil(t, SleepStepSpanRefResolve(item, runID))
+	})
+
+	t.Run("empty edge.Outgoing returns nil", func(t *testing.T) {
+		item := &queue.Item{Kind: queue.KindSleep, Payload: queue.PayloadEdge{Edge: inngest.Edge{Outgoing: ""}}}
+		assert.Nil(t, SleepStepSpanRefResolve(item, runID))
 	})
 }


### PR DESCRIPTION
## Description
This makes the span IDs for the sleep span & post-sleep discovery span deterministic so we can avoid persisting that in the queue (~30% payload size reduction). It should still be backwards compatible with older sleep queue items because we do not hydrate the metadata if they are already set.

## Release note
Reduces the queue memory footprint of sleeps by ~30%.


## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
