### PR TITLE
fix: lease race causing wasted work

### DIFF
--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -217,6 +217,13 @@ func (q *queueProcessor) ProcessItem(
 				case <-extendCapacityLeaseCtx.Done():
 					return
 				case <-extendCapacityLeaseTick.Chan():
+					if extendCapacityLeaseCtx.Err() != nil {
+						// The capacity lease was released early (or the job
+						// finished) after this tick was buffered. Don't extend
+						// a lease we no longer hold.
+						return
+					}
+
 					if ctx.Err() != nil {
 						// Don't extend lease when the ctx is done.
 						return
@@ -246,6 +253,15 @@ func (q *queueProcessor) ProcessItem(
 						LeaseIssuedAt: capacityLeaseID.issuedAt(),
 					})
 					if err != nil {
+						if extendCapacityLeaseCtx.Err() != nil {
+							// The lease was released early while this extension
+							// was in flight; releaseCapacityLease cancels the
+							// context before releasing, so a failure observed
+							// after cancellation is expected and must not
+							// requeue the item.
+							return
+						}
+
 						l.ReportError(
 							err,
 							"error extending capacity lease",
@@ -264,6 +280,14 @@ func (q *queueProcessor) ProcessItem(
 					}
 
 					if res.LeaseID == nil {
+						if extendCapacityLeaseCtx.Err() != nil {
+							// The lease was released early while this extension
+							// was in flight (release wins over extend on the
+							// capacity manager); this is expected and must not
+							// requeue the item.
+							return
+						}
+
 						// Lease could not be extended
 						l.Error("failed to extend capacity lease, no new lease ID received", "qi", qi, "partition", p)
 						errCh <- AlwaysRetryError(fmt.Errorf("failed to extend capacity lease, no new lease ID received"))

--- a/pkg/execution/state/redis_state/queue_item_process_test.go
+++ b/pkg/execution/state/redis_state/queue_item_process_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -441,7 +442,8 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 			},
 		}, func(ctx context.Context, ri osqueue.RunInfo, i osqueue.Item) (osqueue.RunResult, error) {
 			released := make(chan struct{})
-			go func() {
+			var advancerDone sync.WaitGroup
+			advancerDone.Go(func() {
 				for {
 					select {
 					case <-released:
@@ -455,17 +457,22 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 						clock.Advance(time.Second)
 					}
 				}
-			}()
+			})
 
 			<-time.After(3 * time.Second)
 
 			// Release the capacity early
 			require.NotNil(t, ri.CapacityLease)
 
-			// Stop clock advances before releasing the lease. This prevents
-			// advancing after the lease is released, which would cause the
-			// extend goroutine to see a stale/released lease.
+			// Stop clock advances and wait for the advancer goroutine to exit
+			// before releasing the lease. This prevents advancing after the
+			// lease is released, which would cause the extend goroutine to see
+			// a stale/released lease. Note that a tick fired by the final
+			// advance may still be buffered in the extend ticker's channel;
+			// ProcessItem handles that race by discarding extend failures once
+			// the lease has been released.
 			close(released)
+			advancerDone.Wait()
 
 			err := ri.CapacityLease.Release()
 			require.NoError(t, err)
@@ -486,6 +493,106 @@ func TestQueueItemProcessWithConstraintChecks(t *testing.T) {
 
 		// Expect exactly 2 release calls
 		require.Equal(t, 2, len(cmLifecycles.ReleaseCalls))
+	})
+
+	t.Run("with constraint api and early release racing extend tick", func(t *testing.T) {
+		reset()
+
+		q, shard := newQueue(
+			t, rc,
+			osqueue.WithClock(clock),
+			osqueue.WithAllowKeyQueues(func(ctx context.Context, acctID uuid.UUID, envID, fnID uuid.UUID) bool {
+				return true
+			}),
+			osqueue.WithAcquireCapacityLeaseOnBacklogRefill(true),
+			osqueue.WithCapacityManager(cm),
+			// make lease extensions more frequent
+			osqueue.WithCapacityLeaseExtendInterval(time.Second),
+			osqueue.WithLogger(l),
+		)
+
+		qi, err := shard.EnqueueItem(ctx, item, start, osqueue.EnqueueOpts{})
+		require.NoError(t, err)
+
+		p := osqueue.ItemPartition(ctx, qi)
+
+		// Acquire a lease
+		resp, err := cm.Acquire(ctx, &constraintapi.CapacityAcquireRequest{
+			AccountID:            accountID,
+			EnvID:                envID,
+			IdempotencyKey:       qi.ID,
+			FunctionID:           fnID,
+			LeaseIdempotencyKeys: []string{qi.ID},
+			Amount:               1,
+			Configuration: constraintapi.ConstraintConfig{
+				FunctionVersion: 1,
+				Concurrency: constraintapi.ConcurrencyConfig{
+					AccountConcurrency:  5,
+					FunctionConcurrency: 2,
+				},
+			},
+			Constraints: []constraintapi.ConstraintItem{
+				{
+					Kind: constraintapi.ConstraintKindConcurrency,
+					Concurrency: &constraintapi.ConcurrencyConstraint{
+						Scope: enums.ConcurrencyScopeAccount,
+					},
+				},
+				{
+					Kind: constraintapi.ConstraintKindConcurrency,
+					Concurrency: &constraintapi.ConcurrencyConstraint{
+						Scope: enums.ConcurrencyScopeFn,
+					},
+				},
+			},
+			CurrentTime:     clock.Now(),
+			Duration:        10 * time.Second,
+			MaximumLifetime: time.Minute,
+			Source: constraintapi.LeaseSource{
+				Service:           constraintapi.ServiceExecutor,
+				Location:          constraintapi.CallerLocationItemLease,
+				RunProcessingMode: constraintapi.RunProcessingModeBackground,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Leases, 1)
+
+		var counter int64
+
+		err = q.ProcessItem(ctx, osqueue.ProcessItem{
+			I: qi,
+			P: p,
+			CapacityLease: &osqueue.CapacityLease{
+				LeaseID:    resp.Leases[0].LeaseID,
+				IssuedAtMS: clock.Now().UnixMilli(),
+			},
+		}, func(ctx context.Context, ri osqueue.RunInfo, i osqueue.Item) (osqueue.RunResult, error) {
+			require.NotNil(t, ri.CapacityLease)
+
+			// Fire the capacity-lease extend ticker, then release the lease
+			// immediately, before the extend goroutine has necessarily
+			// consumed the tick. The tick stays buffered in the ticker
+			// channel, so the extend goroutine can observe it after Release()
+			// cancelled the extend context and released the lease.
+			// ProcessItem must treat the resulting stale tick (or in-flight
+			// extension failure) as benign instead of requeueing the item and
+			// aborting the handler.
+			clock.BlockUntil(2)
+			clock.Advance(time.Second)
+
+			err := ri.CapacityLease.Release()
+			require.NoError(t, err)
+
+			// And do some more processing before returning
+			<-time.After(100 * time.Millisecond)
+			atomic.AddInt64(&counter, 1)
+			return osqueue.RunResult{}, nil
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, 1, int(counter))
+
+		service.Wait()
 	})
 }
 


### PR DESCRIPTION
## Description

- We have a goroutine to extend the capacity lease. We use a ticker to extend lease every 15s, while the goroutine is not cancelled. `extendCapacityLeaseCtx` communicates when the goroutine is cancelled.
- We choose between extending the lease and cancelling the goroutine in a select between:
  - `case <-extendCapacityLeaseCtx.Done()` = the goroutine is cancelled
  - `<-extendCapacityLeaseTick.Chan()` = 15s wait period has finished
- Sometimes we will evaluate the select statement when the job is already cancelled and the 15s period is up. In these cases, we race between the options, and may sometimes extend the lease even when the goroutine has been cancelled. This cancellation might've been because the parent `jobCtx` finished/erred or the run fn released the lease early.
- While the goroutine can still be cancelled while extending the lease, we can check the goroutine's cancel status before starting and before logging errors
- [Mendral](https://app.mendral.com/insights/01KN2ZFWTVK2FMKKG4QW5XK2D8) has been flagging this as a flaky test w/ ~10 occurrences in the past week

## Release note

Fix race condition that could cause a completed step to requeue, despite already idempotently saving the outcome

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
