### PR TITLE
refactor(ui): decompose traceRollup into focused helpers

### DIFF
--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.test.ts
@@ -6,7 +6,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { Trace } from '../types';
-import { traceToTimelineData } from './traceConversion';
+import { traceRollup, traceToTimelineData } from './traceConversion';
 
 describe('traceConversion', () => {
   // Helper to create a minimal valid trace
@@ -18,6 +18,7 @@ describe('traceConversion', () => {
     name: 'test-step',
     outputID: null,
     queuedAt: '2024-01-01T00:00:00Z',
+    scheduledAt: null,
     spanID: 'span-1',
     stepID: 'step-1',
     startedAt: '2024-01-01T00:00:02Z',
@@ -481,6 +482,231 @@ describe('traceConversion', () => {
     });
   });
 
+  describe('traceRollup', () => {
+    it('passes single-attempt steps through unchanged, sorted by queuedAt', () => {
+      const step1 = createTrace({
+        spanID: 's1',
+        stepID: 'step-1',
+        attempts: 0,
+        queuedAt: '2024-01-01T00:00:05Z',
+        endedAt: '2024-01-01T00:00:06Z',
+      });
+      const step2 = createTrace({
+        spanID: 's2',
+        stepID: 'step-2',
+        attempts: 0,
+        queuedAt: '2024-01-01T00:00:01Z',
+        endedAt: '2024-01-01T00:00:02Z',
+      });
+      const root = createTrace({ isRoot: true, childrenSpans: [step1, step2] });
+
+      const result = traceRollup(root);
+
+      expect(result.childrenSpans?.map((c) => c.spanID)).toEqual(['s2', 's1']);
+      expect(result.childrenSpans?.[1]).toBe(step1);
+      expect(step1.name).toBe('test-step'); // no "Attempt N" renaming
+    });
+
+    it('rolls up a multi-attempt step into a virtual span', () => {
+      const attempt0 = createTrace({
+        spanID: 'a0',
+        stepID: 'step-1',
+        attempts: 0,
+        name: 'my-step',
+        queuedAt: '2024-01-01T00:00:00Z',
+        startedAt: '2024-01-01T00:00:01Z',
+        endedAt: '2024-01-01T00:00:02Z',
+        status: 'FAILED',
+      });
+      const attempt1 = createTrace({
+        spanID: 'a1',
+        stepID: 'step-1',
+        attempts: 1,
+        name: 'my-step',
+        queuedAt: '2024-01-01T00:00:02Z',
+        startedAt: '2024-01-01T00:00:03Z',
+        endedAt: '2024-01-01T00:00:04Z',
+        status: 'COMPLETED',
+        outputID: 'out-1',
+      });
+      const root = createTrace({ isRoot: true, childrenSpans: [attempt0, attempt1] });
+
+      const result = traceRollup(root);
+
+      expect(result.childrenSpans).toHaveLength(1);
+      const rollup = result.childrenSpans?.[0];
+      expect(rollup?.spanID).toBe('step-1-rollup');
+      expect(rollup?.name).toBe('my-step');
+      expect(rollup?.stepID).toBe('step-1');
+      expect(rollup?.attempts).toBe(1);
+      // Start fields come from the first attempt, end fields from the last
+      expect(rollup?.queuedAt).toBe('2024-01-01T00:00:00Z');
+      expect(rollup?.startedAt).toBe('2024-01-01T00:00:01Z');
+      expect(rollup?.endedAt).toBe('2024-01-01T00:00:04Z');
+      expect(rollup?.status).toBe('COMPLETED');
+      expect(rollup?.outputID).toBe('out-1');
+      // Attempts are renamed and nested in order
+      expect(rollup?.childrenSpans?.map((c) => c.name)).toEqual(['Attempt 0', 'Attempt 1']);
+      expect(rollup?.childrenSpans?.map((c) => c.spanID)).toEqual(['a0', 'a1']);
+    });
+
+    it('adopts grouped no-step spans as attempts of the step sharing their groupID', () => {
+      // e.g. a network failure: has an output but never resolved to a stepID
+      const failure = createTrace({
+        spanID: 'f0',
+        stepID: null,
+        groupID: 'g1',
+        attempts: 0,
+        outputID: 'out-f',
+        queuedAt: '2024-01-01T00:00:00Z',
+        endedAt: '2024-01-01T00:00:01Z',
+        status: 'FAILED',
+      });
+      const step = createTrace({
+        spanID: 's1',
+        stepID: 'step-1',
+        groupID: 'g1',
+        attempts: 1,
+        queuedAt: '2024-01-01T00:00:01Z',
+        endedAt: '2024-01-01T00:00:02Z',
+        outputID: 'out-1',
+      });
+      const root = createTrace({ isRoot: true, childrenSpans: [failure, step] });
+
+      const result = traceRollup(root);
+
+      // One rollup span; the grouped failure is not treated as finalization
+      expect(result.childrenSpans).toHaveLength(1);
+      const rollup = result.childrenSpans?.[0];
+      expect(rollup?.spanID).toBe('step-1-rollup');
+      expect(rollup?.childrenSpans?.map((c) => c.spanID)).toEqual(['f0', 's1']);
+      expect(rollup?.childrenSpans?.map((c) => c.name)).toEqual(['Attempt 0', 'Attempt 1']);
+    });
+
+    it('turns a trailing unmatched group into a Finalization span with clamped timestamps', () => {
+      const step = createTrace({
+        spanID: 's1',
+        stepID: 'step-1',
+        attempts: 0,
+        queuedAt: '2024-01-01T00:00:00Z',
+        endedAt: '2024-01-01T00:00:10Z',
+      });
+      const fin = createTrace({
+        spanID: 'fin-0',
+        stepID: null,
+        groupID: 'g-final',
+        attempts: 0,
+        outputID: 'out-fin',
+        // Queued before the last step ended; should be clamped to the step's end
+        queuedAt: '2024-01-01T00:00:05Z',
+        startedAt: '2024-01-01T00:00:06Z',
+        endedAt: '2024-01-01T00:00:11Z',
+      });
+      const root = createTrace({ isRoot: true, childrenSpans: [step, fin] });
+
+      const result = traceRollup(root);
+
+      expect(result.childrenSpans).toHaveLength(2);
+      const finalization = result.childrenSpans?.[1];
+      expect(finalization?.spanID).toBe('fin-0');
+      expect(finalization?.name).toBe('Finalization');
+      expect(finalization?.queuedAt).toBe('2024-01-01T00:00:10Z');
+      expect(finalization?.startedAt).toBe('2024-01-01T00:00:10Z');
+      expect(finalization?.endedAt).toBe('2024-01-01T00:00:11Z');
+    });
+
+    it('rolls up a multi-attempt finalization into a final-rollup virtual span', () => {
+      const step = createTrace({
+        spanID: 's1',
+        stepID: 'step-1',
+        attempts: 0,
+        queuedAt: '2024-01-01T00:00:00Z',
+        endedAt: '2024-01-01T00:00:10Z',
+      });
+      const fin0 = createTrace({
+        spanID: 'fin-0',
+        stepID: null,
+        groupID: 'g-final',
+        attempts: 0,
+        outputID: 'out-f0',
+        queuedAt: '2024-01-01T00:00:05Z',
+        startedAt: '2024-01-01T00:00:06Z',
+        endedAt: '2024-01-01T00:00:11Z',
+        status: 'FAILED',
+      });
+      const fin1 = createTrace({
+        spanID: 'fin-1',
+        stepID: null,
+        groupID: 'g-final',
+        attempts: 1,
+        outputID: 'out-f1',
+        queuedAt: '2024-01-01T00:00:11Z',
+        startedAt: '2024-01-01T00:00:12Z',
+        endedAt: '2024-01-01T00:00:13Z',
+        status: 'COMPLETED',
+      });
+      const root = createTrace({ isRoot: true, childrenSpans: [step, fin0, fin1] });
+
+      const result = traceRollup(root);
+
+      expect(result.childrenSpans).toHaveLength(2);
+      const finalization = result.childrenSpans?.[1];
+      expect(finalization?.spanID).toBe('final-rollup');
+      expect(finalization?.name).toBe('Finalization');
+      // Start clamped to the last step's end, end from the last attempt
+      expect(finalization?.queuedAt).toBe('2024-01-01T00:00:10Z');
+      expect(finalization?.endedAt).toBe('2024-01-01T00:00:13Z');
+      expect(finalization?.status).toBe('COMPLETED');
+      expect(finalization?.outputID).toBe('out-f1');
+      expect(finalization?.childrenSpans?.map((c) => c.name)).toEqual(['Attempt 0', 'Attempt 1']);
+    });
+
+    it('passes through output spans without stepID or groupID unchanged', () => {
+      const outputSpan = createTrace({
+        spanID: 'out-span',
+        stepID: null,
+        groupID: null,
+        attempts: null,
+        outputID: 'out-1',
+      });
+      const root = createTrace({ isRoot: true, childrenSpans: [outputSpan] });
+
+      const result = traceRollup(root);
+
+      expect(result.childrenSpans).toHaveLength(1);
+      expect(result.childrenSpans?.[0]).toBe(outputSpan);
+      expect(outputSpan.name).toBe('test-step');
+    });
+
+    it('drops spans without a stepID/outputID and step spans with null attempts', () => {
+      const noStepNoOutput = createTrace({
+        spanID: 'x',
+        stepID: null,
+        outputID: null,
+        attempts: 0,
+      });
+      const nullAttempts = createTrace({
+        spanID: 'y',
+        stepID: 'step-y',
+        outputID: null,
+        attempts: null,
+      });
+      const root = createTrace({ isRoot: true, childrenSpans: [noStepNoOutput, nullAttempts] });
+
+      const result = traceRollup(root);
+
+      expect(result.childrenSpans).toEqual([]);
+    });
+
+    it('handles a root with no children', () => {
+      const root = createTrace({ isRoot: true, childrenSpans: undefined });
+
+      const result = traceRollup(root);
+
+      expect(result.childrenSpans).toEqual([]);
+    });
+  });
+
   describe('nested children conversion', () => {
     it('converts nested children recursively', () => {
       const trace = createTrace({
@@ -514,6 +740,401 @@ describe('traceConversion', () => {
 
       expect(result.bars[0]?.id).toBe('root-span-id');
       expect(result.bars[0]?.children?.[0]?.id).toBe('child-span-id');
+    });
+  });
+
+  // Realistic server shapes, captured from live runs. A step-execution
+  // request can fail before the SDK returns a step opcode/ID, producing
+  // "non-step" attempt spans with no stepID. These tests lock in the current
+  // rendering of those shapes.
+  describe('traceRollup — pre-stepID failed attempts', () => {
+    const childNames = (t: Trace): string[] => (t.childrenSpans ?? []).map((c) => c.name);
+
+    // Case A: attempts 0 and 1 fail with no step ID, attempt 2 succeeds. We DO
+    // learn the step ID, so the attempts roll up under the resolved step and it
+    // keeps its real name.
+    it('groups failed pre-stepID attempts under the resolved step when it succeeds', () => {
+      const root = createTrace({
+        isRoot: true,
+        spanID: 'run',
+        name: 'Run',
+        stepID: null,
+        stepOp: null,
+        groupID: 'g-root',
+        childrenSpans: [
+          createTrace({
+            spanID: 'n0',
+            name: 'executor.nonstep',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            attempts: 0,
+            groupID: 'g-step',
+            outputID: 'o0',
+          }),
+          createTrace({
+            spanID: 'n1',
+            name: 'executor.nonstep',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            attempts: 1,
+            groupID: 'g-step',
+            outputID: 'o1',
+          }),
+          createTrace({
+            spanID: 'step-ok',
+            name: 'the-only-step',
+            stepID: 'c031',
+            attempts: 2,
+            groupID: 'g-step',
+            outputID: 'o2',
+          }),
+          createTrace({
+            spanID: 'final',
+            name: 'executor.nonstep',
+            status: 'COMPLETED',
+            stepID: null,
+            stepOp: null,
+            attempts: 0,
+            groupID: 'g-root',
+            outputID: 'o-final',
+          }),
+        ],
+      });
+
+      const out = traceRollup(structuredClone(root));
+
+      const step = out.childrenSpans?.find((c) => c.stepID === 'c031');
+      expect(step?.name).toBe('the-only-step');
+      expect(step?.childrenSpans?.map((c) => c.status)).toEqual(['FAILED', 'FAILED', 'COMPLETED']);
+
+      // The terminal function output renders as "Finalization"; nothing is
+      // labeled "Function error".
+      expect(childNames(out)).toContain('Finalization');
+      expect(childNames(out)).not.toContain('Function error');
+    });
+
+    // A stepless function whose body throws a real SDK error on every attempt:
+    // the SDK responded each time (the outputs hold the user's actual error),
+    // so this is the run's terminal work. The span shape is identical to Case
+    // B's pre-SDK deaths minus the backend group span — the client cannot
+    // tell them apart — but the intended label differs. Locks in the current
+    // "Finalization" label for exhausted-retry function errors.
+    it('labels an exhausted-retry function error as "Finalization"', () => {
+      const root = createTrace({
+        isRoot: true,
+        spanID: 'run',
+        name: 'Run',
+        status: 'FAILED',
+        stepID: null,
+        stepOp: null,
+        groupID: 'g-root',
+        childrenSpans: [
+          createTrace({
+            spanID: 'n0',
+            name: 'executor.nonstep',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            attempts: 0,
+            groupID: 'g-root',
+            outputID: 'o0',
+          }),
+          createTrace({
+            spanID: 'n1',
+            name: 'executor.nonstep',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            attempts: 1,
+            groupID: 'g-root',
+            outputID: 'o1',
+          }),
+          createTrace({
+            spanID: 'n2',
+            name: 'executor.nonstep',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            attempts: 2,
+            groupID: 'g-root',
+            outputID: 'o2',
+          }),
+        ],
+      });
+
+      const out = traceRollup(structuredClone(root));
+      const rollup = out.childrenSpans?.find((c) => c.spanID === 'final-rollup');
+
+      expect(out.childrenSpans).toHaveLength(1);
+      expect(rollup?.name).toBe('Finalization');
+      expect(rollup?.childrenSpans?.map((c) => c.name)).toEqual([
+        'Attempt 0',
+        'Attempt 1',
+        'Attempt 2',
+      ]);
+    });
+
+    // Case B: the step 5xx's on every attempt, so its ID is never learned. The
+    // server emits a pre-grouped backend span (no groupID, holds the attempts)
+    // plus loose per-attempt spans. Current behavior: the loose attempts roll
+    // into a "Finalization" group, so the run renders two "Finalization"
+    // spans — the backend passthrough duplicates the rollup.
+    it('rolls never-resolved failed attempts into a "Finalization" group', () => {
+      const root = createTrace({
+        isRoot: true,
+        spanID: 'run',
+        name: 'Run',
+        status: 'FAILED',
+        stepID: null,
+        stepOp: null,
+        groupID: 'g-root',
+        childrenSpans: [
+          createTrace({
+            spanID: 'backend-group',
+            name: 'Finalization',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            groupID: null,
+            outputID: 'og',
+            attempts: 2,
+            childrenSpans: [
+              createTrace({
+                spanID: 'a0',
+                name: 'Attempt 0',
+                status: 'FAILED',
+                stepID: null,
+                stepOp: null,
+                attempts: 0,
+              }),
+              createTrace({
+                spanID: 'a1',
+                name: 'Attempt 1',
+                status: 'FAILED',
+                stepID: null,
+                stepOp: null,
+                attempts: 1,
+              }),
+              createTrace({
+                spanID: 'a2',
+                name: 'Attempt 2',
+                status: 'FAILED',
+                stepID: null,
+                stepOp: null,
+                attempts: 2,
+              }),
+            ],
+          }),
+          createTrace({
+            spanID: 'n0',
+            name: 'executor.nonstep',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            attempts: 0,
+            groupID: 'g-root',
+            outputID: 'o0',
+          }),
+          createTrace({
+            spanID: 'n1',
+            name: 'executor.nonstep',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            attempts: 1,
+            groupID: 'g-root',
+            outputID: 'o1',
+          }),
+          createTrace({
+            spanID: 'n2',
+            name: 'executor.nonstep',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            attempts: 2,
+            groupID: 'g-root',
+            outputID: 'o2',
+          }),
+        ],
+      });
+
+      const out = traceRollup(structuredClone(root));
+      const rollup = out.childrenSpans?.find((c) => c.spanID === 'final-rollup');
+
+      expect(rollup?.name).toBe('Finalization');
+      expect(rollup?.childrenSpans).toHaveLength(3);
+
+      // Current behavior: the backend passthrough is kept, duplicating the
+      // rolled-up group.
+      expect(childNames(out)).toEqual(['Finalization', 'Finalization']);
+    });
+
+    // The final discovery itself can retry: the request after the last step
+    // completes 500s once, then succeeds. Fixture mirrors a real dev-server
+    // trace: the server emits a pre-grouped "Finalization" span (with a stepID
+    // and no groupID) plus the loose per-attempt spans. Current behavior: the
+    // pre-grouped span passes through via the steps map and the loose attempts
+    // roll into a second "Finalization" group.
+    it('rolls a retried-but-successful finalization into a "Finalization" group', () => {
+      const root = createTrace({
+        isRoot: true,
+        spanID: 'run',
+        name: 'flaky-finalization-probe',
+        status: 'COMPLETED',
+        stepID: 'fn-hash',
+        stepOp: null,
+        groupID: 'g-root',
+        queuedAt: '2024-01-01T00:00:00Z',
+        startedAt: '2024-01-01T00:00:00.050Z',
+        endedAt: '2024-01-01T00:00:38Z',
+        childrenSpans: [
+          // Server-grouped finalization span: carries a stepID (the function
+          // hash) and no groupID, so traceRollup passes it through untouched.
+          createTrace({
+            spanID: 'backend-final-group',
+            name: 'Finalization',
+            status: 'COMPLETED',
+            stepID: 'fn-hash',
+            stepOp: null,
+            groupID: null,
+            attempts: 1,
+            outputID: 'og',
+            queuedAt: '2024-01-01T00:00:00Z',
+            endedAt: '2024-01-01T00:00:38Z',
+          }),
+          createTrace({
+            spanID: 'n0',
+            name: 'executor.nonstep',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            attempts: 0,
+            groupID: 'g-root',
+            outputID: 'o0',
+            queuedAt: '2024-01-01T00:00:00Z',
+            endedAt: '2024-01-01T00:00:00.400Z',
+          }),
+          createTrace({
+            spanID: 'step-work',
+            name: 'work',
+            status: 'COMPLETED',
+            stepID: 'step-hash',
+            stepOp: 'RUN',
+            attempts: 0,
+            groupID: null,
+            outputID: 'ow',
+            queuedAt: '2024-01-01T00:00:00.349Z',
+            endedAt: '2024-01-01T00:00:00.350Z',
+          }),
+          createTrace({
+            spanID: 'n1',
+            name: 'executor.nonstep',
+            status: 'COMPLETED',
+            stepID: null,
+            stepOp: null,
+            attempts: 1,
+            groupID: 'g-root',
+            outputID: 'o1',
+            queuedAt: '2024-01-01T00:00:00.400Z',
+            endedAt: '2024-01-01T00:00:38Z',
+          }),
+        ],
+      });
+
+      const out = traceRollup(structuredClone(root));
+      const rollup = out.childrenSpans?.find((c) => c.spanID === 'final-rollup');
+
+      expect(rollup?.name).toBe('Finalization');
+      expect(rollup?.status).toBe('COMPLETED');
+      expect(rollup?.childrenSpans?.map((c) => c.name)).toEqual(['Attempt 0', 'Attempt 1']);
+
+      // Current behavior: the backend pre-grouped span renders alongside the
+      // rollup, so the finalization appears twice.
+      expect(childNames(out)).toEqual(['Finalization', 'work', 'Finalization']);
+    });
+
+    // Case C: a single pre-SDK failure (e.g. retries: 0). The lone nonstep is
+    // relabeled "Finalization" via the single-attempt branch, and the backend
+    // passthrough renders alongside it — the same duplication as above with a
+    // single attempt.
+    it('renders a single failed pre-stepID attempt alongside its backend passthrough', () => {
+      const root = createTrace({
+        isRoot: true,
+        spanID: 'run',
+        name: 'Run',
+        status: 'FAILED',
+        stepID: null,
+        stepOp: null,
+        groupID: 'g-root',
+        childrenSpans: [
+          createTrace({
+            spanID: 'backend-group',
+            name: 'Finalization',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            groupID: null,
+            outputID: 'og',
+            attempts: 0,
+          }),
+          createTrace({
+            spanID: 'n0',
+            name: 'executor.nonstep',
+            status: 'FAILED',
+            stepID: null,
+            stepOp: null,
+            attempts: 0,
+            groupID: 'g-root',
+            outputID: 'o0',
+          }),
+        ],
+      });
+
+      const out = traceRollup(structuredClone(root));
+
+      expect(out.childrenSpans).toHaveLength(2);
+      expect(childNames(out)).toEqual(['Finalization', 'Finalization']);
+    });
+
+    // Case D: a groupID-less finalization span with NO failed pre-SDK attempt
+    // group to duplicate is kept — the happy path depends on it.
+    it('keeps a groupID-less finalization when no terminal failure is rendered', () => {
+      const root = createTrace({
+        isRoot: true,
+        spanID: 'run',
+        name: 'Run',
+        status: 'COMPLETED',
+        stepID: null,
+        stepOp: null,
+        groupID: 'g-root',
+        childrenSpans: [
+          createTrace({
+            spanID: 'step-ok',
+            name: 'the-only-step',
+            status: 'COMPLETED',
+            stepID: 'c031',
+            attempts: 0,
+            groupID: 'g-step',
+            outputID: 'os',
+          }),
+          createTrace({
+            spanID: 'lone-final',
+            name: 'Finalization',
+            status: 'COMPLETED',
+            stepID: null,
+            stepOp: null,
+            groupID: null,
+            outputID: 'of',
+            attempts: 0,
+          }),
+        ],
+      });
+
+      const out = traceRollup(structuredClone(root));
+
+      expect(childNames(out)).toContain('Finalization');
     });
   });
 });

--- a/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
+++ b/ui/packages/components/src/RunDetailsV4/utils/traceConversion.ts
@@ -291,21 +291,41 @@ function traceToBarData(
   };
 }
 
-// traceRollup groups attempts by stepID and groupID
-// (for spans without stepIDs, typically finalization spans or failures hitting the SDK entirely)
-// and creates virtual "rollup" spans that represent the entire step/finalization
-// with all attempts grouped together. This simplifies the trace for
-// display in the timeline while still allowing users to see
-// individual attempts when they expand the step details.
-export function traceRollup(root: Trace): Trace {
+/**
+ * Attempt spans bucketed for rollup, produced by a single pass over the
+ * run's direct children.
+ */
+type RollupGroups = {
+  /** stepIDs in first-seen order, so rollups keep the original span order */
+  stepOrder: string[];
+  /** attempt spans per stepID, keyed by attempt number */
+  steps: Map<string, Map<number, Trace>>;
+  /** spans emitted unchanged (output spans with no stepID or groupID) */
+  passthrough: Trace[];
+  /** attempt spans of the trailing group that never matched a step, if any */
+  finalizationAttempts: Map<number, Trace> | null;
+  /** step span with the latest endedAt; finalization can't start before it ends */
+  lastStep: Trace | null;
+};
+
+/**
+ * Classify the run's direct children for rollup.
+ *
+ * Spans with an outputID but no stepID (network failures, finalization) are
+ * grouped by groupID. A group later claimed by a step span becomes extra
+ * attempts of that step; a group that never matches a step is the run's
+ * finalization.
+ */
+function collectRollupGroups(children: Trace[]): RollupGroups {
   const stepOrder: string[] = [];
   const steps = new Map<string, Map<number, Trace>>();
-  const rolledUpRunChildren: Trace[] = [];
+  const passthrough: Trace[] = [];
   const groupedSpans = new Map<string, Map<number, Trace>>();
   let lastStepEndedAt: Date | null = null;
   let lastStep: Trace | null = null;
   let finalSpan: Trace | null = null;
-  for (const child of root.childrenSpans ?? []) {
+
+  for (const child of children) {
     if (child.outputID && !child.stepID) {
       if (child.groupID) {
         finalSpan = child;
@@ -313,13 +333,15 @@ export function traceRollup(root: Trace): Trace {
         attempts.set(child.attempts ?? 0, child);
         groupedSpans.set(child.groupID, attempts);
       } else {
-        rolledUpRunChildren.push(child);
+        passthrough.push(child);
       }
       continue;
-    } else if (!child.stepID || child.attempts === null) {
+    }
+    if (!child.stepID || child.attempts === null) {
       continue;
     }
 
+    // The grouped spans we saw belong to this step, not finalization
     if (finalSpan?.groupID == child.groupID) {
       finalSpan = null;
     }
@@ -346,102 +368,137 @@ export function traceRollup(root: Trace): Trace {
     steps.set(child.stepID, attempts);
   }
 
+  const finalizationAttempts = finalSpan?.groupID
+    ? groupedSpans.get(finalSpan.groupID) ?? null
+    : null;
+
+  return { stepOrder, steps, passthrough, finalizationAttempts, lastStep };
+}
+
+/** First (lowest attempt number) and last (highest) attempt spans of a group */
+function attemptBounds(attempts: Map<number, Trace>): {
+  first: Trace;
+  last: Trace;
+  lastAttempt: number;
+} {
+  const lastAttempt = Math.max(...attempts.keys());
+  return {
+    first: attempts.get(Math.min(...attempts.keys())) as Trace,
+    last: attempts.get(lastAttempt) as Trace,
+    lastAttempt,
+  };
+}
+
+/**
+ * Rename each attempt span (in place) to "Attempt N" and return them ordered
+ * by attempt number, for nesting under a rollup span.
+ */
+function toAttemptChildren(attempts: Map<number, Trace>): Trace[] {
+  for (const attempt of attempts.values()) {
+    attempt.name = `Attempt ${attempt.attempts}`;
+  }
+  return Array.from(attempts.values()).sort((a, b) => (a.attempts ?? 0) - (b.attempts ?? 0));
+}
+
+/**
+ * Roll up a step's attempts into a single span: a single attempt passes
+ * through unchanged; multiple attempts get a virtual span that spans the
+ * first attempt's queue time to the last attempt's end, carries the last
+ * attempt's status/output, and nests the attempts as children.
+ */
+function rollupStepAttempts(stepID: string, attempts: Map<number, Trace>): Trace {
+  const { first, last, lastAttempt } = attemptBounds(attempts);
+  if (attempts.size === 1) {
+    return last;
+  }
+
+  const name = last.name; // capture before toAttemptChildren renames the attempts
+  return {
+    isRoot: false,
+    isUserland: false,
+    spanID: `${stepID}-rollup`, // virtual span
+    groupID: last.groupID,
+    name,
+    attempts: lastAttempt,
+    stepID: stepID,
+    queuedAt: first.queuedAt,
+    scheduledAt: first.scheduledAt,
+    startedAt: first.startedAt,
+    endedAt: last.endedAt,
+    status: last.status,
+    outputID: last.outputID,
+    debugRunID: last.debugRunID,
+    debugSessionID: last.debugSessionID,
+    stepInfo: last.stepInfo,
+    childrenSpans: toAttemptChildren(attempts),
+    metadata: last.metadata,
+    userlandSpan: null,
+  };
+}
+
+/**
+ * Roll up the finalization group's attempts into a single "Finalization"
+ * span. Finalization spans can carry queue timestamps from before the last
+ * step finished, so start timestamps are clamped to the last step's end to
+ * keep the timeline ordered.
+ */
+function rollupFinalization(attempts: Map<number, Trace>, lastStep: Trace | null): Trace {
+  const { first, last } = attemptBounds(attempts);
+  const notBefore = lastStep?.endedAt;
+
+  if (attempts.size === 1) {
+    last.name = 'Finalization';
+    last.queuedAt = maxDateString(last.queuedAt, notBefore);
+    last.scheduledAt = maxDateString(last.scheduledAt, notBefore);
+    last.startedAt = maxDateString(last.startedAt, notBefore);
+    return last;
+  }
+
+  return {
+    isRoot: false,
+    isUserland: false,
+    name: 'Finalization',
+    spanID: `final-rollup`, // virtual span
+    groupID: last.groupID,
+    attempts: last.attempts,
+    queuedAt: maxDateString(first.queuedAt, notBefore),
+    scheduledAt: maxDateString(first.scheduledAt, notBefore),
+    startedAt: maxDateString(first.startedAt, notBefore),
+    endedAt: last.endedAt,
+    status: last.status,
+    outputID: last.outputID,
+    debugRunID: last.debugRunID,
+    debugSessionID: last.debugSessionID,
+    childrenSpans: toAttemptChildren(attempts),
+    metadata: last.metadata,
+    stepInfo: null,
+    userlandSpan: null,
+  };
+}
+
+// traceRollup groups attempts by stepID and groupID
+// (for spans without stepIDs, typically finalization spans or failures hitting the SDK entirely)
+// and creates virtual "rollup" spans that represent the entire step/finalization
+// with all attempts grouped together. This simplifies the trace for
+// display in the timeline while still allowing users to see
+// individual attempts when they expand the step details.
+export function traceRollup(root: Trace): Trace {
+  const { stepOrder, steps, passthrough, finalizationAttempts, lastStep } = collectRollupGroups(
+    root.childrenSpans ?? []
+  );
+
+  const rolledUpRunChildren: Trace[] = [...passthrough];
+
   for (const stepID of stepOrder) {
     const attempts = steps.get(stepID);
     if (!attempts) {
       continue;
     }
-
-    const minAttempt = Math.min(...attempts.keys());
-    const minAttemptTrace = attempts.get(minAttempt) as Trace;
-    const maxAttempt = Math.max(...attempts.keys());
-    const maxAttemptTrace = attempts.get(maxAttempt) as Trace;
-    if (attempts.size == 1) {
-      rolledUpRunChildren.push(maxAttemptTrace);
-      continue;
-    }
-
-    // Create a virtual span to represent the step as a whole with all attempts
-    const virtualSpan: Trace = {
-      isRoot: false,
-      isUserland: false,
-      spanID: `${stepID}-rollup`, // virtual span
-      groupID: maxAttemptTrace.groupID,
-      name: maxAttemptTrace.name,
-      attempts: maxAttempt,
-      stepID: stepID,
-      queuedAt: minAttemptTrace.queuedAt,
-      scheduledAt: minAttemptTrace.scheduledAt,
-      startedAt: minAttemptTrace.startedAt,
-      endedAt: maxAttemptTrace.endedAt,
-      status: maxAttemptTrace.status,
-      outputID: maxAttemptTrace.outputID,
-      debugRunID: maxAttemptTrace.debugRunID,
-      debugSessionID: maxAttemptTrace.debugSessionID,
-      stepInfo: maxAttemptTrace.stepInfo,
-
-      childrenSpans: Array.from(attempts.values()).sort(
-        (a, b) => (a.attempts ?? 0) - (b.attempts ?? 0)
-      ),
-
-      metadata: maxAttemptTrace.metadata,
-
-      userlandSpan: null,
-    };
-
-    for (const attempt of attempts.values()) {
-      attempt.name = `Attempt ${attempt.attempts}`;
-    }
-
-    rolledUpRunChildren.push(virtualSpan);
+    rolledUpRunChildren.push(rollupStepAttempts(stepID, attempts));
   }
 
-  if (finalSpan && finalSpan.groupID && groupedSpans.has(finalSpan.groupID)) {
-    const attempts = groupedSpans.get(finalSpan.groupID) as Map<number, Trace>;
-    const minAttempt = Math.min(...attempts.keys());
-    const minAttemptTrace = attempts.get(minAttempt) as Trace;
-    const maxAttempt = Math.max(...attempts.keys());
-    const maxAttemptTrace = attempts.get(maxAttempt) as Trace;
-    if (attempts.size == 1) {
-      maxAttemptTrace.name = 'Finalization';
-      maxAttemptTrace.queuedAt = maxDateString(maxAttemptTrace.queuedAt, lastStep?.endedAt);
-      maxAttemptTrace.scheduledAt = maxDateString(maxAttemptTrace.scheduledAt, lastStep?.endedAt);
-      maxAttemptTrace.startedAt = maxDateString(maxAttemptTrace.startedAt, lastStep?.endedAt);
-      rolledUpRunChildren.push(maxAttemptTrace);
-    } else {
-      // Create a virtual span to represent the finalization as a whole with all attempts
-      const virtualSpan: Trace = {
-        isRoot: false,
-        isUserland: false,
-        name: 'Finalization',
-        spanID: `final-rollup`, // virtual span
-        groupID: maxAttemptTrace.groupID,
-        attempts: maxAttemptTrace.attempts,
-        queuedAt: maxDateString(minAttemptTrace.queuedAt, lastStep?.endedAt),
-        scheduledAt: maxDateString(minAttemptTrace.scheduledAt, lastStep?.endedAt),
-        startedAt: maxDateString(minAttemptTrace.startedAt, lastStep?.endedAt),
-        endedAt: maxAttemptTrace.endedAt,
-        status: maxAttemptTrace.status,
-        outputID: maxAttemptTrace.outputID,
-        debugRunID: maxAttemptTrace.debugRunID,
-        debugSessionID: maxAttemptTrace.debugSessionID,
-
-        childrenSpans: Array.from(attempts.values()).sort(
-          (a, b) => (a.attempts ?? 0) - (b.attempts ?? 0)
-        ),
-
-        metadata: maxAttemptTrace.metadata,
-
-        stepInfo: null,
-        userlandSpan: null,
-      };
-
-      for (const attempt of attempts.values()) {
-        attempt.name = `Attempt ${attempt.attempts}`;
-      }
-
-      rolledUpRunChildren.push(virtualSpan);
-    }
+  if (finalizationAttempts) {
+    rolledUpRunChildren.push(rollupFinalization(finalizationAttempts, lastStep));
   }
 
   const sortingKey = (trace: Trace) =>


### PR DESCRIPTION
## Description

- We've observed a few bugs with how the dashboard is rolling up traces
- This logic goes through `traceRollup` which is quite long and complex
- Let's split this up into some simpler functions that preserve behavior. Then our follow up bug fixes become much simpler PRs!
- We lock in behavior with unit tests, including unwanted behavior that we'll be fixing up in [future PRs.](https://github.com/inngest/inngest/pull/4598)

## Release note

None.

## Migration note

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)