### PR TITLE
refactor: better errors on SDK version skew

### DIFF
--- a/pkg/enums/opcode.go
+++ b/pkg/enums/opcode.go
@@ -2,7 +2,40 @@
 
 package enums
 
+import "fmt"
+
 type Opcode int
+
+// UnknownOpcodeError indicates the SDK returned an opcode this server version
+// doesn't recognize, which almost always means the server is older than the
+// SDK. Its message prompts a server upgrade rather than surfacing the opaque
+// decode error.
+type UnknownOpcodeError struct {
+	Opcode string
+}
+
+func (e *UnknownOpcodeError) Error() string {
+	return fmt.Sprintf(
+		"this Inngest server does not recognize the %q operation returned by the SDK. This usually means the server is older than the SDK; update your Inngest server to the latest version.",
+		e.Opcode,
+	)
+}
+
+// Retryable satisfies the execution queue's structural RetryableError interface
+// without importing it: version skew is deterministic, so retrying never helps.
+func (e *UnknownOpcodeError) Retryable() bool { return false }
+
+// ParseOpcode is like OpcodeString but distinguishes an otherwise valid opcode
+// name that this server version doesn't know about from a malformed value,
+// returning an *UnknownOpcodeError so callers can detect server/SDK version
+// skew.
+func ParseOpcode(s string) (Opcode, error) {
+	op, err := OpcodeString(s)
+	if err != nil {
+		return op, &UnknownOpcodeError{Opcode: s}
+	}
+	return op, nil
+}
 
 const (
 	// OpcodeNone represents the default opcode 0, which does nothing

--- a/pkg/execution/driver/httpdriver/parse.go
+++ b/pkg/execution/driver/httpdriver/parse.go
@@ -58,6 +58,10 @@ func parseGenerator(ctx context.Context, byt []byte, noRetry bool) (ops []*state
 	case '{':
 		gen := &state.GeneratorOpcode{}
 		if err = json.Unmarshal(trimmed, gen); err != nil {
+			if ue := unknownOpcodeErr(trimmed); ue != nil {
+				err = ue
+				return
+			}
 			err = fmt.Errorf("error reading generator opcode response: %w", err)
 			return
 		}
@@ -66,6 +70,10 @@ func parseGenerator(ctx context.Context, byt []byte, noRetry bool) (ops []*state
 	case '[':
 		gen := []*state.GeneratorOpcode{}
 		if err = json.Unmarshal(trimmed, &gen); err != nil {
+			if ue := unknownOpcodeErr(trimmed); ue != nil {
+				err = ue
+				return
+			}
 			err = fmt.Errorf("error reading generator opcode response: %w", err)
 			return
 		}
@@ -99,6 +107,44 @@ func parseGenerator(ctx context.Context, byt []byte, noRetry bool) (ops []*state
 	}
 
 	return
+}
+
+// unknownOpcodeErr re-scans a 206 body that failed to decode, returning an
+// *enums.UnknownOpcodeError if the cause was an opcode this server doesn't
+// recognize, or nil for any other decode failure.
+func unknownOpcodeErr(trimmed []byte) error {
+	var p fastjson.Parser
+	v, err := p.ParseBytes(trimmed)
+	if err != nil {
+		return nil
+	}
+
+	check := func(item *fastjson.Value) error {
+		op := item.Get("op")
+		if op == nil {
+			return nil
+		}
+		name, err := op.StringBytes()
+		if err != nil || len(name) == 0 {
+			return nil
+		}
+		if _, err := enums.ParseOpcode(string(name)); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	switch v.Type() {
+	case fastjson.TypeObject:
+		return check(v)
+	case fastjson.TypeArray:
+		for _, item := range v.GetArray() {
+			if ue := check(item); ue != nil {
+				return ue
+			}
+		}
+	}
+	return nil
 }
 
 func ParseStream(resp []byte) (*StreamResponse, error) {

--- a/pkg/execution/driver/httpdriver/parse_test.go
+++ b/pkg/execution/driver/httpdriver/parse_test.go
@@ -3,9 +3,11 @@ package httpdriver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,6 +66,30 @@ func TestParseGeneratorRejectsInvalidJSON(t *testing.T) {
 	_, err := ParseGenerator(context.Background(), []byte("not-json"), false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "error reading generator opcode response")
+}
+
+func TestParseGeneratorUnknownOpcodePromptsUpgrade(t *testing.T) {
+	t.Parallel()
+
+	// An opcode a future SDK might return, in both the single-object and array
+	// response shapes.
+	for _, body := range []string{
+		`{"op":"SomeFutureOpcode","id":"x"}`,
+		`[{"op":"SomeFutureOpcode","id":"x"}]`,
+	} {
+		_, err := ParseGenerator(context.Background(), []byte(body), false)
+		require.Error(t, err)
+
+		require.Contains(t, err.Error(), "update your Inngest server")
+		require.NotContains(t, err.Error(), "error reading generator opcode response")
+
+		var ue *enums.UnknownOpcodeError
+		require.True(t, errors.As(err, &ue))
+		require.Equal(t, "SomeFutureOpcode", ue.Opcode)
+
+		// Non-retriable: version skew is deterministic.
+		require.False(t, queue.ShouldRetry(err, 0, 10))
+	}
 }
 
 func TestParseGeneratorRejectsNullArrayItem(t *testing.T) {


### PR DESCRIPTION
## Description

When an SDK returns a step opcode that this server version doesn't recognize, the response previously failed with an opaque JSON decode error (`error reading generator opcode response: ...`) and was treated as a normal, retryable failure.

This change detects that case and surfaces an actionable error instead:

- Adds `enums.ParseOpcode`, which distinguishes a valid-but-unknown opcode name from a malformed value, returning a typed `*enums.UnknownOpcodeError`.
- `UnknownOpcodeError.Error()` tells the operator the server is likely older than the SDK and to upgrade.
- `UnknownOpcodeError` reports `Retryable() bool = false`, so the queue stops retrying version-skew failures.
- In `httpdriver.parseGenerator,` when a 206 body (object or array form) fails to decode, `unknownOpcodeErr `re-scans it and returns the typed error if an unrecognized op is the cause; any other decode failure keeps the original error.

## Release note

Inngest servers now return a clear "unknown operation / server may be older than the SDK — please upgrade" error instead of an opaque decode failure, and no deterministic case.

## Migration note

None.
*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
