### PR TITLE
fix(tracing): stop dev server finalization group spans from duplicating in the trace UI

### DIFF
--- a/pkg/coreapi/graph/loaders/trace.go
+++ b/pkg/coreapi/graph/loaders/trace.go
@@ -485,6 +485,19 @@ func (tr *traceReader) convertRunSpanToGQL(ctx context.Context, span *cqrs.OtelS
 			gqlSpan.ChildrenSpans = append(gqlSpan.ChildrenSpans, child)
 		}
 
+		// A discovery-derived finalization group aggregates the run's terminal
+		// attempts, but the loose executor.nonstep siblings (emitted once per
+		// attempt, parented to the run root) carry the same attempts and
+		// output. Clear StepID and OutputID so this group matches the cloud
+		// renderer's shape and clients render finalization from the nonstep
+		// spans instead of showing the same work twice; the per-attempt
+		// children keep their own output IDs.
+		if gqlSpan.Name == FinalizationSpanName &&
+			(span.Name == meta.SpanNameStepDiscovery || span.Name == meta.SpanNameStep) {
+			gqlSpan.StepID = nil
+			gqlSpan.OutputID = nil
+		}
+
 		// If we only have a single child, this span isn't a userland span,
 		// but the single child is the SDK's `"inngest.execution"` wrapper,
 		// collapse it by returning its children (if any).

--- a/pkg/coreapi/graph/loaders/trace_test.go
+++ b/pkg/coreapi/graph/loaders/trace_test.go
@@ -394,3 +394,99 @@ func TestConvertRunSpanToGQL_MetadataPromotion(t *testing.T) {
 		assert.Empty(t, result.ChildrenSpans[0].Metadata, "step should not have trailing discovery metadata")
 	})
 }
+
+func TestConvertRunSpanToGQL_FinalizationGroup(t *testing.T) {
+	tr := &traceReader{}
+	ctx := context.Background()
+
+	completed := enums.StepStatusCompleted
+	failed := enums.StepStatusFailed
+
+	intPtr := func(i int) *int { return &i }
+
+	execChild := func(spanID string, attempt int, status enums.StepStatus, functionOutput bool, outputID string) *cqrs.OtelSpan {
+		attrs := &meta.ExtractedValues{
+			DynamicStatus: &status,
+			StepAttempt:   intPtr(attempt),
+		}
+		if functionOutput {
+			attrs.IsFunctionOutput = boolPtr(true)
+			attrs.StepID = strPtr("fn-hash")
+		}
+		return &cqrs.OtelSpan{
+			RawOtelSpan: cqrs.RawOtelSpan{Name: meta.SpanNameExecution, SpanID: spanID},
+			Attributes:  attrs,
+			OutputID:    strPtr(outputID),
+		}
+	}
+
+	t.Run("retried finalization group carries no StepID or OutputID", func(t *testing.T) {
+		// The final discovery request fails once and succeeds on retry: the
+		// discovery span has one FAILED exec child and one COMPLETED exec
+		// child marked as function output. The loose executor.nonstep
+		// siblings (parented to the run root, not present here) carry the
+		// same attempts, so this group must not masquerade as a step or
+		// carry the output — clients render finalization from the nonstep
+		// spans and drop this shape (matching the cloud renderer).
+		discovery := &cqrs.OtelSpan{
+			RawOtelSpan: cqrs.RawOtelSpan{Name: meta.SpanNameStepDiscovery, SpanID: "disc"},
+			Attributes:  &meta.ExtractedValues{},
+			Children: []*cqrs.OtelSpan{
+				execChild("exec-0", 0, failed, false, "output-0"),
+				execChild("exec-1", 1, completed, true, "output-1"),
+			},
+		}
+
+		result, err := tr.convertRunSpanToGQL(ctx, discovery)
+		require.NoError(t, err)
+		assert.Equal(t, FinalizationSpanName, result.Name)
+		assert.Nil(t, result.StepID, "finalization group must not carry a step ID")
+		assert.Nil(t, result.OutputID, "finalization group must not carry an output ID")
+		// The per-attempt children keep their identity and outputs.
+		require.Len(t, result.ChildrenSpans, 2)
+		assert.Equal(t, "Attempt 0", result.ChildrenSpans[0].Name)
+		assert.Equal(t, "Attempt 1", result.ChildrenSpans[1].Name)
+		require.NotNil(t, result.ChildrenSpans[1].OutputID)
+		assert.Equal(t, "output-1", *result.ChildrenSpans[1].OutputID)
+	})
+
+	t.Run("single-attempt finalization group is also cleared", func(t *testing.T) {
+		discovery := &cqrs.OtelSpan{
+			RawOtelSpan: cqrs.RawOtelSpan{Name: meta.SpanNameStepDiscovery, SpanID: "disc"},
+			Attributes:  &meta.ExtractedValues{},
+			Children: []*cqrs.OtelSpan{
+				execChild("exec-0", 0, completed, true, "output-0"),
+			},
+		}
+
+		result, err := tr.convertRunSpanToGQL(ctx, discovery)
+		require.NoError(t, err)
+		assert.Equal(t, FinalizationSpanName, result.Name)
+		assert.Nil(t, result.StepID)
+		assert.Nil(t, result.OutputID)
+	})
+
+	t.Run("real step keeps its StepID and OutputID", func(t *testing.T) {
+		// Guard against over-clearing: a step span whose exec child is NOT a
+		// function output must keep step identity and output.
+		child := execChild("exec-0", 0, completed, false, "step-output")
+		child.Attributes.StepID = strPtr("step-1")
+
+		step := &cqrs.OtelSpan{
+			RawOtelSpan: cqrs.RawOtelSpan{Name: meta.SpanNameStep, SpanID: "step"},
+			Attributes: &meta.ExtractedValues{
+				StepName: strPtr("my-step"),
+				StepID:   strPtr("step-1"),
+			},
+			Children: []*cqrs.OtelSpan{child},
+		}
+
+		result, err := tr.convertRunSpanToGQL(ctx, step)
+		require.NoError(t, err)
+		assert.Equal(t, "my-step", result.Name)
+		require.NotNil(t, result.StepID)
+		assert.Equal(t, "step-1", *result.StepID)
+		require.NotNil(t, result.OutputID)
+		assert.Equal(t, "step-output", *result.OutputID)
+	})
+}


### PR DESCRIPTION
## Description

- In the dev-cli only, we have duplicate finalization groups when discovery fails and the succeeds
- This stems from oss and cloud having different renderer behaviors. Only oss emits a finalization group span that comes from discovery with the `stepId` and the `outputID`. 
- We can fix the bug and converge behavior by having oss clear the `stepID` and `outputID` on the finalization group.
- Verified end-to-end against a local dev server with a function that throws a retriable error on its first post-step attempt

## Release note

Dev server: runs whose finalization request failed and was retried no longer show a duplicate "Finalization" span in the trace view.

## Migration note

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)