### PR TITLE
fix(queue): skip constraint lease on missing account

### DIFF
--- a/pkg/constraintapi/errors.go
+++ b/pkg/constraintapi/errors.go
@@ -1,5 +1,9 @@
 package constraintapi
 
+import "errors"
+
+var ErrAccountNotFound = errors.New("constraint api: account not found")
+
 // ConstraintAPIInternalErrorCode represents an internal error code
 type ConstraintAPIInternalErrorCode int
 

--- a/pkg/enums/backlog_refill_constraint_check_fallback_reason.go
+++ b/pkg/enums/backlog_refill_constraint_check_fallback_reason.go
@@ -9,4 +9,5 @@ const (
 	BacklogRefillConstraintCheckReasonIDNil
 	BacklogRefillConstraintCheckReasonAcquireOnRefillDisabled
 	BacklogRefillConstraintCheckReasonConstraintAPIError
+	BacklogRefillConstraintCheckReasonAccountMissing
 )

--- a/pkg/enums/backlogrefillconstraintcheckreason_enumer.go
+++ b/pkg/enums/backlogrefillconstraintcheckreason_enumer.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-const _BacklogRefillConstraintCheckReasonName = "constraint_api_uninitializedid_nilacquire_on_refill_disabledconstraint_api_error"
+const _BacklogRefillConstraintCheckReasonName = "constraint_api_uninitializedid_nilacquire_on_refill_disabledconstraint_api_erroraccount_missing"
 
-var _BacklogRefillConstraintCheckReasonIndex = [...]uint8{0, 28, 34, 60, 80}
+var _BacklogRefillConstraintCheckReasonIndex = [...]uint8{0, 28, 34, 60, 80, 95}
 
-const _BacklogRefillConstraintCheckReasonLowerName = "constraint_api_uninitializedid_nilacquire_on_refill_disabledconstraint_api_error"
+const _BacklogRefillConstraintCheckReasonLowerName = "constraint_api_uninitializedid_nilacquire_on_refill_disabledconstraint_api_erroraccount_missing"
 
 func (i BacklogRefillConstraintCheckReason) String() string {
 	if i < 0 || i >= BacklogRefillConstraintCheckReason(len(_BacklogRefillConstraintCheckReasonIndex)-1) {
@@ -29,9 +29,10 @@ func _BacklogRefillConstraintCheckReasonNoOp() {
 	_ = x[BacklogRefillConstraintCheckReasonIDNil-(1)]
 	_ = x[BacklogRefillConstraintCheckReasonAcquireOnRefillDisabled-(2)]
 	_ = x[BacklogRefillConstraintCheckReasonConstraintAPIError-(3)]
+	_ = x[BacklogRefillConstraintCheckReasonAccountMissing-(4)]
 }
 
-var _BacklogRefillConstraintCheckReasonValues = []BacklogRefillConstraintCheckReason{BacklogRefillConstraintCheckReasonConstraintAPIUninitialized, BacklogRefillConstraintCheckReasonIDNil, BacklogRefillConstraintCheckReasonAcquireOnRefillDisabled, BacklogRefillConstraintCheckReasonConstraintAPIError}
+var _BacklogRefillConstraintCheckReasonValues = []BacklogRefillConstraintCheckReason{BacklogRefillConstraintCheckReasonConstraintAPIUninitialized, BacklogRefillConstraintCheckReasonIDNil, BacklogRefillConstraintCheckReasonAcquireOnRefillDisabled, BacklogRefillConstraintCheckReasonConstraintAPIError, BacklogRefillConstraintCheckReasonAccountMissing}
 
 var _BacklogRefillConstraintCheckReasonNameToValueMap = map[string]BacklogRefillConstraintCheckReason{
 	_BacklogRefillConstraintCheckReasonName[0:28]:       BacklogRefillConstraintCheckReasonConstraintAPIUninitialized,
@@ -42,6 +43,8 @@ var _BacklogRefillConstraintCheckReasonNameToValueMap = map[string]BacklogRefill
 	_BacklogRefillConstraintCheckReasonLowerName[34:60]: BacklogRefillConstraintCheckReasonAcquireOnRefillDisabled,
 	_BacklogRefillConstraintCheckReasonName[60:80]:      BacklogRefillConstraintCheckReasonConstraintAPIError,
 	_BacklogRefillConstraintCheckReasonLowerName[60:80]: BacklogRefillConstraintCheckReasonConstraintAPIError,
+	_BacklogRefillConstraintCheckReasonName[80:95]:      BacklogRefillConstraintCheckReasonAccountMissing,
+	_BacklogRefillConstraintCheckReasonLowerName[80:95]: BacklogRefillConstraintCheckReasonAccountMissing,
 }
 
 var _BacklogRefillConstraintCheckReasonNames = []string{
@@ -49,6 +52,7 @@ var _BacklogRefillConstraintCheckReasonNames = []string{
 	_BacklogRefillConstraintCheckReasonName[28:34],
 	_BacklogRefillConstraintCheckReasonName[34:60],
 	_BacklogRefillConstraintCheckReasonName[60:80],
+	_BacklogRefillConstraintCheckReasonName[80:95],
 }
 
 // BacklogRefillConstraintCheckReasonString retrieves an enum value from the enum constants string name.

--- a/pkg/enums/queue_item_constraint_reason.go
+++ b/pkg/enums/queue_item_constraint_reason.go
@@ -9,4 +9,5 @@ const (
 	QueueItemConstraintReasonIdNil
 	QueueItemConstraintReasonFeatureFlagDisabled
 	QueueItemConstraintReasonConstraintAPIError
+	QueueItemConstraintReasonAccountMissing
 )

--- a/pkg/enums/queueitemconstraintreason_enumer.go
+++ b/pkg/enums/queueitemconstraintreason_enumer.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 )
 
-const _QueueItemConstraintReasonName = "constraint_api_uninitializedid_nilfeature_flag_disabledconstraint_api_error"
+const _QueueItemConstraintReasonName = "constraint_api_uninitializedid_nilfeature_flag_disabledconstraint_api_erroraccount_missing"
 
-var _QueueItemConstraintReasonIndex = [...]uint8{0, 28, 34, 55, 75}
+var _QueueItemConstraintReasonIndex = [...]uint8{0, 28, 34, 55, 75, 90}
 
-const _QueueItemConstraintReasonLowerName = "constraint_api_uninitializedid_nilfeature_flag_disabledconstraint_api_error"
+const _QueueItemConstraintReasonLowerName = "constraint_api_uninitializedid_nilfeature_flag_disabledconstraint_api_erroraccount_missing"
 
 func (i QueueItemConstraintReason) String() string {
 	if i < 0 || i >= QueueItemConstraintReason(len(_QueueItemConstraintReasonIndex)-1) {
@@ -29,9 +29,10 @@ func _QueueItemConstraintReasonNoOp() {
 	_ = x[QueueItemConstraintReasonIdNil-(1)]
 	_ = x[QueueItemConstraintReasonFeatureFlagDisabled-(2)]
 	_ = x[QueueItemConstraintReasonConstraintAPIError-(3)]
+	_ = x[QueueItemConstraintReasonAccountMissing-(4)]
 }
 
-var _QueueItemConstraintReasonValues = []QueueItemConstraintReason{QueueItemConstraintReasonConstraintAPIUninitialized, QueueItemConstraintReasonIdNil, QueueItemConstraintReasonFeatureFlagDisabled, QueueItemConstraintReasonConstraintAPIError}
+var _QueueItemConstraintReasonValues = []QueueItemConstraintReason{QueueItemConstraintReasonConstraintAPIUninitialized, QueueItemConstraintReasonIdNil, QueueItemConstraintReasonFeatureFlagDisabled, QueueItemConstraintReasonConstraintAPIError, QueueItemConstraintReasonAccountMissing}
 
 var _QueueItemConstraintReasonNameToValueMap = map[string]QueueItemConstraintReason{
 	_QueueItemConstraintReasonName[0:28]:       QueueItemConstraintReasonConstraintAPIUninitialized,
@@ -42,6 +43,8 @@ var _QueueItemConstraintReasonNameToValueMap = map[string]QueueItemConstraintRea
 	_QueueItemConstraintReasonLowerName[34:55]: QueueItemConstraintReasonFeatureFlagDisabled,
 	_QueueItemConstraintReasonName[55:75]:      QueueItemConstraintReasonConstraintAPIError,
 	_QueueItemConstraintReasonLowerName[55:75]: QueueItemConstraintReasonConstraintAPIError,
+	_QueueItemConstraintReasonName[75:90]:      QueueItemConstraintReasonAccountMissing,
+	_QueueItemConstraintReasonLowerName[75:90]: QueueItemConstraintReasonAccountMissing,
 }
 
 var _QueueItemConstraintReasonNames = []string{
@@ -49,6 +52,7 @@ var _QueueItemConstraintReasonNames = []string{
 	_QueueItemConstraintReasonName[28:34],
 	_QueueItemConstraintReasonName[34:55],
 	_QueueItemConstraintReasonName[55:75],
+	_QueueItemConstraintReasonName[75:90],
 }
 
 // QueueItemConstraintReasonString retrieves an enum value from the enum constants string name.

--- a/pkg/execution/queue/account_exists.go
+++ b/pkg/execution/queue/account_exists.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -53,6 +54,42 @@ func (q *queueProcessor) requeueDeletedAccountPartition(ctx context.Context, sha
 		"requeued partition for deleted account",
 		"account_id", p.AccountID.String(),
 		"partition_id", p.ID,
+		"queue_shard", shard.Name(),
+		"requeue_at", requeueAt,
+	)
+
+	return nil
+}
+
+func (q *queueProcessor) requeueDeletedAccountShadowPartition(ctx context.Context, shard QueueShard, p *QueueShadowPartition) error {
+	requeueAt := q.Clock().Now().Add(PartitionDeletedAccountRequeueExtension)
+	if err := shard.ShadowPartitionRequeue(ctx, p, &requeueAt); err != nil {
+		if errors.Is(err, ErrShadowPartitionNotFound) {
+			return nil
+		}
+
+		metrics.IncrQueueDeletedAccountPartitionCounter(ctx, metrics.CounterOpt{
+			PkgName: pkgName,
+			Tags: map[string]any{
+				"queue_shard": shard.Name(),
+				"action":      deletedAccountPartitionActionQuarantineError,
+			},
+		})
+		return fmt.Errorf("error requeueing deleted account shadow partition: %w", err)
+	}
+
+	metrics.IncrQueueDeletedAccountPartitionCounter(ctx, metrics.CounterOpt{
+		PkgName: pkgName,
+		Tags: map[string]any{
+			"queue_shard": shard.Name(),
+			"action":      deletedAccountPartitionActionQuarantined,
+		},
+	})
+
+	logger.StdlibLogger(ctx).Warn(
+		"requeued shadow partition for deleted account",
+		"account_id", p.AccountID.String(),
+		"partition_id", p.PartitionID,
 		"queue_shard", shard.Name(),
 		"requeue_at", requeueAt,
 	)

--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -298,7 +298,9 @@ func (q *queueProcessor) BacklogRefillConstraintCheck(
 			metrics.IncrBacklogRefillConstraintCheckCounter(ctx, enums.BacklogRefillConstraintCheckReasonAccountMissing.String(), metrics.CounterOpt{
 				PkgName: pkgName,
 			})
-			return nil, nil
+			return &BacklogRefillConstraintCheckResult{
+				ItemsToRefill: nil,
+			}, nil
 		}
 
 		logger.StdlibLogger(ctx).Error("acquiring capacity lease failed", "err", err, "method", "backlogRefillConstraintCheck", "functionID", *shadowPart.FunctionID)

--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -2,7 +2,9 @@ package queue
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -488,6 +490,13 @@ func (q *queueProcessor) ItemLeaseConstraintCheck(
 		},
 	})
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			metrics.IncrQueueItemConstraintCheckCounter(ctx, enums.QueueItemConstraintReasonConstraintAPIError.String(), metrics.CounterOpt{
+				PkgName: pkgName,
+			})
+			return ItemLeaseConstraintCheckResult{}, nil
+		}
+
 		span.RecordError(err)
 		l.Error("acquiring capacity lease failed", "err", err, "method", "itemLeaseConstraintCheck", "constraints", constraints, "item", item, "function_id", *shadowPart.FunctionID)
 		metrics.IncrQueueItemConstraintCheckCounter(ctx, enums.QueueItemConstraintReasonConstraintAPIError.String(), metrics.CounterOpt{

--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -2,7 +2,6 @@ package queue
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -490,7 +489,7 @@ func (q *queueProcessor) ItemLeaseConstraintCheck(
 		},
 	})
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
+		if errors.Is(err, constraintapi.ErrAccountNotFound) {
 			metrics.IncrQueueItemConstraintCheckCounter(ctx, enums.QueueItemConstraintReasonAccountMissing.String(), metrics.CounterOpt{
 				PkgName: pkgName,
 			})

--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -491,7 +491,7 @@ func (q *queueProcessor) ItemLeaseConstraintCheck(
 	})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			metrics.IncrQueueItemConstraintCheckCounter(ctx, enums.QueueItemConstraintReasonConstraintAPIError.String(), metrics.CounterOpt{
+			metrics.IncrQueueItemConstraintCheckCounter(ctx, enums.QueueItemConstraintReasonAccountMissing.String(), metrics.CounterOpt{
 				PkgName: pkgName,
 			})
 			return ItemLeaseConstraintCheckResult{}, nil

--- a/pkg/execution/queue/constraints.go
+++ b/pkg/execution/queue/constraints.go
@@ -294,6 +294,13 @@ func (q *queueProcessor) BacklogRefillConstraintCheck(
 		},
 	})
 	if err != nil {
+		if errors.Is(err, constraintapi.ErrAccountNotFound) {
+			metrics.IncrBacklogRefillConstraintCheckCounter(ctx, enums.BacklogRefillConstraintCheckReasonAccountMissing.String(), metrics.CounterOpt{
+				PkgName: pkgName,
+			})
+			return nil, nil
+		}
+
 		logger.StdlibLogger(ctx).Error("acquiring capacity lease failed", "err", err, "method", "backlogRefillConstraintCheck", "functionID", *shadowPart.FunctionID)
 		metrics.IncrBacklogRefillConstraintCheckCounter(ctx, enums.BacklogRefillConstraintCheckReasonConstraintAPIError.String(), metrics.CounterOpt{
 			PkgName: pkgName,

--- a/pkg/execution/queue/constraints_backlog_refill_test.go
+++ b/pkg/execution/queue/constraints_backlog_refill_test.go
@@ -1,0 +1,113 @@
+package queue
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/constraintapi"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/util/errs"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBacklogRefillConstraintCheckMissingAccountReturnsEmptyResult(t *testing.T) {
+	ctx := context.Background()
+	accountID := uuid.New()
+	envID := uuid.New()
+	fnID := uuid.New()
+	appID := uuid.New()
+
+	shard := &mockShardForIterator{name: "test-shard"}
+	registry, err := NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+
+	q, err := New(
+		ctx,
+		"test",
+		registry,
+		WithCapacityManager(backlogRefillMissingAccountCapacityManager{}),
+		WithAcquireCapacityLeaseOnBacklogRefill(true),
+	)
+	require.NoError(t, err)
+
+	res, err := q.BacklogRefillConstraintCheck(
+		ctx,
+		&QueueShadowPartition{
+			PartitionID: fnID.String(),
+			AccountID:   &accountID,
+			EnvID:       &envID,
+			FunctionID:  &fnID,
+		},
+		&QueueBacklog{
+			ShadowPartitionID: fnID.String(),
+		},
+		PartitionConstraintConfig{
+			Concurrency: PartitionConcurrency{
+				AccountConcurrency: 1,
+			},
+		},
+		[]*QueueItem{
+			{
+				ID: "item-1",
+				Data: Item{
+					Identifier: state.Identifier{
+						RunID: ulid.Make(),
+						AppID: appID,
+					},
+				},
+			},
+		},
+		"op-1",
+		time.Now(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Empty(t, res.ItemsToRefill)
+}
+
+type backlogRefillMissingAccountCapacityManager struct{}
+
+func (backlogRefillMissingAccountCapacityManager) Check(context.Context, *constraintapi.CapacityCheckRequest) (*constraintapi.CapacityCheckResponse, errs.UserError, errs.InternalError) {
+	return nil, nil, nil
+}
+
+func (backlogRefillMissingAccountCapacityManager) Acquire(context.Context, *constraintapi.CapacityAcquireRequest) (*constraintapi.CapacityAcquireResponse, errs.InternalError) {
+	return nil, wrappedConstraintAPIInternalError{err: constraintapi.ErrAccountNotFound}
+}
+
+func (backlogRefillMissingAccountCapacityManager) ExtendLease(context.Context, *constraintapi.CapacityExtendLeaseRequest) (*constraintapi.CapacityExtendLeaseResponse, errs.InternalError) {
+	return nil, nil
+}
+
+func (backlogRefillMissingAccountCapacityManager) Release(context.Context, *constraintapi.CapacityReleaseRequest) (*constraintapi.CapacityReleaseResponse, errs.InternalError) {
+	return nil, nil
+}
+
+type wrappedConstraintAPIInternalError struct {
+	err error
+}
+
+func (e wrappedConstraintAPIInternalError) Error() string {
+	return e.err.Error()
+}
+
+func (e wrappedConstraintAPIInternalError) Unwrap() error {
+	return e.err
+}
+
+func (wrappedConstraintAPIInternalError) ErrorCode() int {
+	return 0
+}
+
+func (wrappedConstraintAPIInternalError) Retryable() bool {
+	return false
+}
+
+func (wrappedConstraintAPIInternalError) RetryAfter() time.Duration {
+	return 0
+}
+
+func (wrappedConstraintAPIInternalError) InternalError() {}

--- a/pkg/execution/queue/process_partition_deleted_account_test.go
+++ b/pkg/execution/queue/process_partition_deleted_account_test.go
@@ -49,3 +49,44 @@ func TestProcessPartitionRequeuesDeletedAccount(t *testing.T) {
 	require.True(t, shard.partitionRequeueForceAt)
 	require.Equal(t, now.Now().Add(PartitionDeletedAccountRequeueExtension), shard.partitionRequeueAt)
 }
+
+func TestProcessShadowPartitionRequeuesDeletedAccountBeforePeek(t *testing.T) {
+	ctx := context.Background()
+	now := clockwork.NewFakeClock()
+	accountID := uuid.New()
+	envID := uuid.New()
+	fnID := uuid.New()
+
+	shard := &mockShardForIterator{name: "test-shard"}
+	registry, err := NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+
+	var checks int32
+	q, err := New(
+		ctx,
+		"test",
+		registry,
+		WithClock(now),
+		WithAccountExists(func(context.Context, uuid.UUID) (bool, error) {
+			atomic.AddInt32(&checks, 1)
+			return false, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	err = q.ProcessShadowPartition(ctx, &QueueShadowPartition{
+		PartitionID: fnID.String(),
+		FunctionID:  &fnID,
+		AccountID:   &accountID,
+		EnvID:       &envID,
+	}, 0)
+	require.NoError(t, err)
+
+	require.Equal(t, int32(1), atomic.LoadInt32(&checks))
+	require.Equal(t, int32(0), atomic.LoadInt32(&shard.shadowPartitionLeaseCount))
+	require.Equal(t, int32(1), atomic.LoadInt32(&shard.shadowPartitionRequeueCount))
+	require.Equal(t, int32(0), atomic.LoadInt32(&shard.shadowPartitionPeekCount))
+	require.Equal(t, int32(0), atomic.LoadInt32(&shard.backlogPeekCount))
+	require.NotNil(t, shard.shadowPartitionRequeueAt)
+	require.Equal(t, now.Now().Add(PartitionDeletedAccountRequeueExtension), *shard.shadowPartitionRequeueAt)
+}

--- a/pkg/execution/queue/processor_iterator_test.go
+++ b/pkg/execution/queue/processor_iterator_test.go
@@ -92,22 +92,27 @@ func (m *mockQueueProcessor) Queue() Queue {
 
 // mockShardForIterator implements the minimal QueueShard interface methods used by ProcessorIterator
 type mockShardForIterator struct {
-	name                    string
-	partitionLeaseCount     int32
-	partitionRequeueCount   int32
-	partitionRequeueAt      time.Time
-	partitionRequeueForceAt bool
-	partitionBacklogSize    int64
-	partitionBacklogCalls   int32
-	outstandingJobCount     int
-	outstandingJobCalls     int32
-	runningCount            int64
-	runningCountCalls       int32
-	statusCount             int64
-	statusCountCalls        int32
-	earliestPeekTimes       sync.Map
-	earliestPeekTimeCalls   int32
-	earliestPeekTimeErr     error
+	name                        string
+	partitionLeaseCount         int32
+	partitionRequeueCount       int32
+	partitionRequeueAt          time.Time
+	partitionRequeueForceAt     bool
+	shadowPartitionLeaseCount   int32
+	shadowPartitionRequeueCount int32
+	shadowPartitionRequeueAt    *time.Time
+	shadowPartitionPeekCount    int32
+	backlogPeekCount            int32
+	partitionBacklogSize        int64
+	partitionBacklogCalls       int32
+	outstandingJobCount         int
+	outstandingJobCalls         int32
+	runningCount                int64
+	runningCountCalls           int32
+	statusCount                 int64
+	statusCountCalls            int32
+	earliestPeekTimes           sync.Map
+	earliestPeekTimeCalls       int32
+	earliestPeekTimeErr         error
 }
 
 func (m *mockShardForIterator) Name() string {
@@ -342,11 +347,15 @@ func (m *mockShardForIterator) PeekGlobalShadowPartitionAccounts(ctx context.Con
 }
 
 func (m *mockShardForIterator) ShadowPartitionRequeue(ctx context.Context, sp *QueueShadowPartition, requeueAt *time.Time) error {
+	atomic.AddInt32(&m.shadowPartitionRequeueCount, 1)
+	m.shadowPartitionRequeueAt = requeueAt
 	return nil
 }
 
 func (m *mockShardForIterator) ShadowPartitionLease(ctx context.Context, sp *QueueShadowPartition, duration time.Duration) (*ulid.ULID, error) {
-	return nil, nil
+	atomic.AddInt32(&m.shadowPartitionLeaseCount, 1)
+	id := ulid.Make()
+	return &id, nil
 }
 
 func (m *mockShardForIterator) ShadowPartitionExtendLease(ctx context.Context, sp *QueueShadowPartition, leaseID ulid.ULID, duration time.Duration) (*ulid.ULID, error) {
@@ -354,6 +363,7 @@ func (m *mockShardForIterator) ShadowPartitionExtendLease(ctx context.Context, s
 }
 
 func (m *mockShardForIterator) ShadowPartitionPeek(ctx context.Context, sp *QueueShadowPartition, sequential bool, until time.Time, limit int64, opts ...PeekOpt) ([]*QueueBacklog, int, error) {
+	atomic.AddInt32(&m.shadowPartitionPeekCount, 1)
 	return nil, 0, nil
 }
 
@@ -362,6 +372,7 @@ func (m *mockShardForIterator) BacklogPrepareNormalize(ctx context.Context, b *Q
 }
 
 func (m *mockShardForIterator) BacklogPeek(ctx context.Context, b *QueueBacklog, from time.Time, until time.Time, limit int64, opts ...PeekOpt) (*BacklogPeekResult, error) {
+	atomic.AddInt32(&m.backlogPeekCount, 1)
 	return &BacklogPeekResult{}, nil
 }
 

--- a/pkg/execution/queue/shadow_process.go
+++ b/pkg/execution/queue/shadow_process.go
@@ -32,6 +32,30 @@ func (q *queueProcessor) ProcessShadowPartition(ctx context.Context, shadowPart 
 	metrics.ActiveShadowScannerCount(ctx, 1, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": shard.Name()}})
 	defer metrics.ActiveShadowScannerCount(ctx, -1, metrics.CounterOpt{PkgName: pkgName, Tags: map[string]any{"queue_shard": shard.Name()}})
 
+	if shadowPart.AccountID != nil {
+		accountExists, err := q.accountExists(ctx, *shadowPart.AccountID)
+		if err != nil {
+			metrics.IncrQueueDeletedAccountPartitionCounter(ctx, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags: map[string]any{
+					"queue_shard": shard.Name(),
+					"action":      deletedAccountPartitionActionCheckError,
+				},
+			})
+			l.Warn("error checking account existence for shadow partition", "error", err, "account_id", shadowPart.AccountID.String(), "partition_id", shadowPart.PartitionID)
+		} else if !accountExists {
+			metrics.IncrQueueDeletedAccountPartitionCounter(ctx, metrics.CounterOpt{
+				PkgName: pkgName,
+				Tags: map[string]any{
+					"queue_shard": shard.Name(),
+					"action":      deletedAccountPartitionActionFound,
+				},
+			})
+			q.removeShadowContinue(ctx, shadowPart, false)
+			return q.requeueDeletedAccountShadowPartition(ctx, shard, shadowPart)
+		}
+	}
+
 	// Check if shadow partition cannot be processed (paused/refill disabled, etc.)
 	if shadowPart.FunctionID != nil && shadowPart.AccountID != nil && shadowPart.EnvID != nil {
 		lockedUntil, err := shard.IsMigrationLocked(ctx, Scope{


### PR DESCRIPTION
## Summary

- treats a confirmed missing account during Constraint API item lease as non-blocking
- lets the executor continue to its inactive-account cleanup path instead of retrying constraint lease forever
- keeps transient Constraint API/network errors fail-closed

## Testing

- `go test ./pkg/execution/queue -run '^$' -count=0`