### PR TITLE
refactor(queue): break up queueProcessor

### DIFF
--- a/pkg/devserver/devserver.go
+++ b/pkg/devserver/devserver.go
@@ -592,9 +592,6 @@ func start(ctx context.Context, opts StartOpts) error {
 		executor.WithServiceLogger(l),
 		executor.WithServiceShardRegistry(shardRegistry),
 		executor.WithServicePublisher(pb),
-		executor.WithServiceEnableKeyQueues(func(ctx context.Context, acctID uuid.UUID) bool {
-			return enableKeyQueues
-		}),
 	)
 
 	runner := runner.NewService(

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -101,12 +101,6 @@ func WithServiceShardRegistry(shards queue.ShardRegistry) func(s *svc) {
 	}
 }
 
-func WithServiceEnableKeyQueues(kq func(ctx context.Context, acctID uuid.UUID) bool) func(*svc) {
-	return func(s *svc) {
-		s.allowKeyQueues = kq
-	}
-}
-
 func WithServicePublisher(p pubsub.Publisher) func(*svc) {
 	return func(s *svc) {
 		s.publisher = p
@@ -117,9 +111,6 @@ func NewService(c config.Config, opts ...Opt) service.Service {
 	svc := &svc{
 		config: c,
 		log:    logger.StdlibLogger(context.Background()),
-		allowKeyQueues: func(ctx context.Context, acctID uuid.UUID) bool {
-			return false
-		},
 	}
 	for _, o := range opts {
 		o(svc)
@@ -160,8 +151,6 @@ type svc struct {
 	shards queue.ShardRegistry
 
 	publisher pubsub.Publisher
-
-	allowKeyQueues func(ctx context.Context, acctID uuid.UUID) bool
 }
 
 func (s *svc) Name() string {

--- a/pkg/execution/queue/attempt_resetter.go
+++ b/pkg/execution/queue/attempt_resetter.go
@@ -1,0 +1,20 @@
+package queue
+
+import "context"
+
+type attemptResetter struct {
+	shards QueueShardRegistry
+}
+
+func newAttemptResetter(shards QueueShardRegistry) AttemptResetter {
+	return &attemptResetter{shards: shards}
+}
+
+func (r *attemptResetter) ResetAttemptsByJobID(ctx context.Context, shardName string, scope Scope, jobID string) error {
+	shard, err := r.shards.ByName(shardName)
+	if err != nil {
+		return err
+	}
+
+	return shard.ResetAttemptsByJobID(ctx, scope, jobID)
+}

--- a/pkg/execution/queue/consumer.go
+++ b/pkg/execution/queue/consumer.go
@@ -1,0 +1,21 @@
+package queue
+
+import "context"
+
+type queueConsumer struct {
+	shards QueueShardRegistry
+}
+
+func newQueueConsumer(shards QueueShardRegistry) Consumer {
+	return &queueConsumer{shards: shards}
+}
+
+// Dequeue implements Consumer.
+func (c *queueConsumer) Dequeue(ctx context.Context, shardName string, i QueueItem, opts ...DequeueOptionFn) error {
+	shard, err := c.shards.ByName(shardName)
+	if err != nil {
+		return err
+	}
+
+	return shard.Dequeue(ctx, i, opts...)
+}

--- a/pkg/execution/queue/job_queue_reader.go
+++ b/pkg/execution/queue/job_queue_reader.go
@@ -1,0 +1,173 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"iter"
+	"sync/atomic"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/oklog/ulid/v2"
+)
+
+type jobQueueReader struct {
+	shards                       QueueShardRegistry
+	accountShardIterationEnabled AccountShardIterationEnabled
+}
+
+func newJobQueueReader(shards QueueShardRegistry, accountShardIterationEnabled AccountShardIterationEnabled) JobQueueReader {
+	return &jobQueueReader{
+		shards:                       shards,
+		accountShardIterationEnabled: accountShardIterationEnabled,
+	}
+}
+
+// BacklogSize implements JobQueueReader.
+func (r *jobQueueReader) BacklogSize(ctx context.Context, shard QueueShard, backlogID string) (int64, error) {
+	return shard.BacklogSize(ctx, backlogID)
+}
+
+// BacklogByID implements JobQueueReader.
+func (r *jobQueueReader) BacklogByID(ctx context.Context, shard QueueShard, backlogID string) (*QueueBacklog, error) {
+	return shard.BacklogByID(ctx, backlogID)
+}
+
+// BacklogsByPartition implements JobQueueReader.
+func (r *jobQueueReader) BacklogsByPartition(ctx context.Context, shard QueueShard, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueBacklog], error) {
+	return shard.BacklogsByPartition(ctx, partitionID, from, until, opts...)
+}
+
+// ItemExists implements JobQueueReader.
+func (r *jobQueueReader) ItemExists(ctx context.Context, shard QueueShard, scope Scope, jobID string) (bool, error) {
+	return shard.ItemExists(ctx, scope, jobID)
+}
+
+// ItemsByBacklog implements JobQueueReader.
+func (r *jobQueueReader) ItemsByBacklog(ctx context.Context, shard QueueShard, backlogID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error) {
+	return shard.ItemsByBacklog(ctx, backlogID, from, until, opts...)
+}
+
+// ItemsByPartition implements JobQueueReader.
+func (r *jobQueueReader) ItemsByPartition(ctx context.Context, shard QueueShard, scope Scope, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error) {
+	return shard.ItemsByPartition(ctx, scope, partitionID, from, until, opts...)
+}
+
+// ItemsByRunID implements JobQueueReader.
+func (r *jobQueueReader) ItemsByRunID(ctx context.Context, shard QueueShard, scope Scope, runID ulid.ULID) ([]*QueueItem, error) {
+	return shard.ItemsByRunID(ctx, scope, runID)
+}
+
+// LoadQueueItem implements JobQueueReader.
+func (r *jobQueueReader) LoadQueueItem(ctx context.Context, shardName string, itemID string) (*QueueItem, error) {
+	shard, err := r.shards.ByName(shardName)
+	if err != nil {
+		return nil, err
+	}
+
+	return shard.LoadQueueItem(ctx, itemID)
+}
+
+func (r *jobQueueReader) forAccountShards(ctx context.Context, accountID uuid.UUID, fn func(context.Context, QueueShard) error) error {
+	// Fan-out is feature-flagged because querying every shard increases
+	// latency and makes a single shard failure affect the whole read.
+	if r.accountShardIterationEnabled != nil && r.accountShardIterationEnabled(ctx, accountID) {
+		return r.shards.ForEach(ctx, fn)
+	}
+
+	shard, err := r.shards.Resolve(ctx, Scope{AccountID: accountID}, nil)
+	if err != nil {
+		return fmt.Errorf("could not resolve account shard: %w", err)
+	}
+	return fn(ctx, shard)
+}
+
+// PartitionBacklogSize implements JobQueueReader.
+func (r *jobQueueReader) PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error) {
+	var totalCount int64
+
+	err := r.forAccountShards(ctx, scope.AccountID, func(ctx context.Context, shard QueueShard) error {
+		backlogSize, err := shard.PartitionBacklogSize(ctx, scope, partitionID)
+		if err != nil {
+			return fmt.Errorf("could not load partition backlog size: %w", err)
+		}
+		l := logger.StdlibLogger(ctx)
+		l.Trace("retrieved backlog size", "size", backlogSize)
+		atomic.AddInt64(&totalCount, int64(backlogSize))
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("could not load partition backlog size: %w", err)
+	}
+	return totalCount, nil
+}
+
+// PartitionByID implements JobQueueReader.
+func (r *jobQueueReader) PartitionByID(ctx context.Context, shard QueueShard, scope Scope, partitionID string) (*PartitionInspectionResult, error) {
+	return shard.PartitionByID(ctx, scope, partitionID)
+}
+
+// OutstandingJobCount implements JobQueueReader.
+func (r *jobQueueReader) OutstandingJobCount(ctx context.Context, scope Scope, runID ulid.ULID) (int, error) {
+	var totalCount int64
+
+	err := r.forAccountShards(ctx, scope.AccountID, func(ctx context.Context, shard QueueShard) error {
+		outstanding, err := shard.OutstandingJobCount(ctx, scope, runID)
+		if err != nil {
+			return fmt.Errorf("could not load outstanding job count: %w", err)
+		}
+		atomic.AddInt64(&totalCount, int64(outstanding))
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("could not load outstanding count: %w", err)
+	}
+	return int(totalCount), nil
+}
+
+// RunJobs implements JobQueueReader.
+func (r *jobQueueReader) RunJobs(ctx context.Context, shardName string, scope Scope, runID ulid.ULID, limit int64, offset int64) ([]JobResponse, error) {
+	shard, err := r.shards.ByName(shardName)
+	if err != nil {
+		return nil, err
+	}
+
+	return shard.RunJobs(ctx, scope, runID, limit, offset)
+}
+
+// RunningCount implements JobQueueReader.
+func (r *jobQueueReader) RunningCount(ctx context.Context, scope Scope) (int64, error) {
+	var totalCount int64
+
+	err := r.forAccountShards(ctx, scope.AccountID, func(ctx context.Context, shard QueueShard) error {
+		running, err := shard.RunningCount(ctx, scope)
+		if err != nil {
+			return fmt.Errorf("could not load running count: %w", err)
+		}
+		atomic.AddInt64(&totalCount, int64(running))
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("could not load running count: %w", err)
+	}
+	return totalCount, nil
+}
+
+// StatusCount implements JobQueueReader.
+func (r *jobQueueReader) StatusCount(ctx context.Context, scope Scope, status string) (int64, error) {
+	var totalCount int64
+
+	err := r.forAccountShards(ctx, scope.AccountID, func(ctx context.Context, shard QueueShard) error {
+		running, err := shard.StatusCount(ctx, scope, status)
+		if err != nil {
+			return fmt.Errorf("could not load status count: %w", err)
+		}
+		atomic.AddInt64(&totalCount, int64(running))
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("could not load status count: %w", err)
+	}
+	return totalCount, nil
+}

--- a/pkg/execution/queue/migrate.go
+++ b/pkg/execution/queue/migrate.go
@@ -9,22 +9,44 @@ import (
 
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/telemetry/redis_telemetry"
+	"github.com/jonboulle/clockwork"
 	"github.com/redis/rueidis"
 	"golang.org/x/sync/errgroup"
 )
 
-func (q *queueProcessor) Migrate(ctx context.Context, sourceShardName string, scope Scope, limit int64, concurrency int, handler QueueMigrationHandler) (int64, error) {
+type queueMigrator struct {
+	shards QueueShardRegistry
+	clock  clockwork.Clock
+}
+
+func newQueueMigrator(shards QueueShardRegistry, clock clockwork.Clock) Migrator {
+	return &queueMigrator{
+		shards: shards,
+		clock:  clock,
+	}
+}
+
+func (m *queueMigrator) SetFunctionMigrate(ctx context.Context, sourceShard string, scope Scope, migrateLockUntil *time.Time) error {
+	shard, err := m.shards.ByName(sourceShard)
+	if err != nil {
+		return fmt.Errorf("could not find shard %q", sourceShard)
+	}
+
+	return shard.SetFunctionMigrate(ctx, scope, migrateLockUntil)
+}
+
+func (m *queueMigrator) Migrate(ctx context.Context, sourceShardName string, scope Scope, limit int64, concurrency int, handler QueueMigrationHandler) (int64, error) {
 	l := logger.StdlibLogger(ctx)
 	ctx = redis_telemetry.WithScope(redis_telemetry.WithOpName(ctx, "MigrationPeek"), redis_telemetry.ScopeQueue)
 
-	shard, err := q.shards.ByName(sourceShardName)
+	shard, err := m.shards.ByName(sourceShardName)
 	if err != nil {
 		return -1, fmt.Errorf("no queue shard available for '%s'", sourceShardName)
 	}
 
 	from := time.Time{}
 	// setting it to 5 years ahead should be enough to cover all queue items in the partition
-	until := q.Clock().Now().Add(24 * time.Hour * 365 * 5)
+	until := m.clock.Now().Add(24 * time.Hour * 365 * 5)
 	items, err := shard.ItemsByPartition(ctx, scope, scope.FunctionID.String(), from, until,
 		WithQueueItemIterBatchSize(limit),
 	)

--- a/pkg/execution/queue/option.go
+++ b/pkg/execution/queue/option.go
@@ -476,6 +476,7 @@ type QueueOptions struct {
 	// queueKindMapping stores a map of job kind => queue names
 	queueKindMapping        map[string]string
 	queueProducer           Producer
+	queueConsumer           Consumer
 	disableFifoForFunctions map[string]struct{}
 	disableFifoForAccounts  map[string]struct{}
 	peekSizeForFunctions    map[string]int64
@@ -641,6 +642,12 @@ func WithEnableJobPromotion(enable bool) QueueOpt {
 func WithQueueProducer(producer Producer) QueueOpt {
 	return func(q *QueueOptions) {
 		q.queueProducer = producer
+	}
+}
+
+func WithQueueConsumer(consumer Consumer) QueueOpt {
+	return func(q *QueueOptions) {
+		q.queueConsumer = consumer
 	}
 }
 

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -3,13 +3,10 @@ package queue
 import (
 	"context"
 	"fmt"
-	"iter"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/VividCortex/ewma"
-	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/jonboulle/clockwork"
@@ -49,8 +46,7 @@ func New(
 	}
 
 	qp := &queueProcessor{
-		name: name,
-
+		name:         name,
 		QueueOptions: o,
 
 		wg:             &sync.WaitGroup{},
@@ -68,13 +64,18 @@ func New(
 		quit:         make(chan error, o.numWorkers),
 
 		shards: shards,
-		queueProducer: NewProducer(
+		Producer: newProducer(
 			shards,
-			WithProducerClock(o.Clock),
-			WithProducerKindToQueueMapping(o.queueKindMapping),
-			WithProducerJobPromotion(o.enableJobPromotion),
-			WithProducerConditionalTracer(o.ConditionalTracer),
+			withProducerClock(o.Clock),
+			withProducerKindToQueueMapping(o.queueKindMapping),
+			withProducerJobPromotion(o.enableJobPromotion),
+			withProducerConditionalTracer(o.ConditionalTracer),
 		),
+		Consumer:        newQueueConsumer(shards),
+		JobQueueReader:  newJobQueueReader(shards, o.AccountShardIterationEnabled),
+		Migrator:        newQueueMigrator(shards, o.Clock),
+		Unpauser:        newQueueUnpauser(shards),
+		AttemptResetter: newAttemptResetter(shards),
 
 		peekSizeCache: ccache.New(ccache.Configure[int64]().MaxSize(50_000)),
 
@@ -94,9 +95,8 @@ func New(
 		}
 	}
 	if o.queueProducer != nil {
-		qp.queueProducer = o.queueProducer
+		qp.Producer = o.queueProducer
 	}
-
 	qp.configureQueueRoles()
 
 	return qp, nil
@@ -105,14 +105,19 @@ func New(
 type queueProcessor struct {
 	*QueueOptions
 
+	Producer
+	Consumer
+	JobQueueReader
+	Migrator
+	Unpauser
+	AttemptResetter
+
 	// name is the identifiable name for this worker, for logging.
 	name string
 
 	// shards owns the {shards map, selector, primary} trio. Topology can be
 	// mutated at runtime via shards.SetPrimary.
 	shards QueueShardRegistry
-
-	queueProducer Producer
 
 	// quit is a channel that any method can send on to trigger termination
 	// of the Run loop.  This typically accepts an error, but a nil error
@@ -205,199 +210,6 @@ func (q *queueProcessor) Queue() Queue {
 	return q
 }
 
-// BacklogSize implements JobQueueReader.
-func (q *queueProcessor) BacklogSize(ctx context.Context, shard QueueShard, backlogID string) (int64, error) {
-	return shard.BacklogSize(ctx, backlogID)
-}
-
-// BacklogByID implements JobQueueReader.
-func (q *queueProcessor) BacklogByID(ctx context.Context, shard QueueShard, backlogID string) (*QueueBacklog, error) {
-	return shard.BacklogByID(ctx, backlogID)
-}
-
-// BacklogsByPartition implements JobQueueReader.
-func (q *queueProcessor) BacklogsByPartition(ctx context.Context, shard QueueShard, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueBacklog], error) {
-	return shard.BacklogsByPartition(ctx, partitionID, from, until, opts...)
-}
-
-// Dequeue implements Consumer.
-func (q *queueProcessor) Dequeue(ctx context.Context, shardName string, i QueueItem, opts ...DequeueOptionFn) error {
-	shard, err := q.shards.ByName(shardName)
-	if err != nil {
-		return err
-	}
-
-	return shard.Dequeue(ctx, i, opts...)
-}
-
-// ItemExists implements JobQueueReader.
-func (q *queueProcessor) ItemExists(ctx context.Context, shard QueueShard, scope Scope, jobID string) (bool, error) {
-	return shard.ItemExists(ctx, scope, jobID)
-}
-
-// ItemsByBacklog implements JobQueueReader.
-func (q *queueProcessor) ItemsByBacklog(ctx context.Context, shard QueueShard, backlogID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error) {
-	return shard.ItemsByBacklog(ctx, backlogID, from, until, opts...)
-}
-
-// ItemsByPartition implements JobQueueReader.
-func (q *queueProcessor) ItemsByPartition(ctx context.Context, shard QueueShard, scope Scope, partitionID string, from time.Time, until time.Time, opts ...QueueIterOpt) (iter.Seq[*QueueItem], error) {
-	return shard.ItemsByPartition(ctx, scope, partitionID, from, until, opts...)
-}
-
-// ItemsByRunID implements JobQueueReader.
-func (q *queueProcessor) ItemsByRunID(ctx context.Context, shard QueueShard, scope Scope, runID ulid.ULID) ([]*QueueItem, error) {
-	return shard.ItemsByRunID(ctx, scope, runID)
-}
-
-// LoadQueueItem implements JobQueueReader.
-func (q *queueProcessor) LoadQueueItem(ctx context.Context, shardName string, itemID string) (*QueueItem, error) {
-	shard, err := q.shards.ByName(shardName)
-	if err != nil {
-		return nil, err
-	}
-
-	return shard.LoadQueueItem(ctx, itemID)
-}
-
-func (q *queueProcessor) forAccountShards(ctx context.Context, accountID uuid.UUID, fn func(context.Context, QueueShard) error) error {
-	// Fan-out is feature-flagged because querying every shard increases
-	// latency and makes a single shard failure affect the whole read.
-	if q.AccountShardIterationEnabled != nil && q.AccountShardIterationEnabled(ctx, accountID) {
-		return q.shards.ForEach(ctx, fn)
-	}
-
-	shard, err := q.shards.Resolve(ctx, Scope{AccountID: accountID}, nil)
-	if err != nil {
-		return fmt.Errorf("could not resolve account shard: %w", err)
-	}
-	return fn(ctx, shard)
-}
-
-// PartitionBacklogSize implements JobQueueReader.
-func (q *queueProcessor) PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error) {
-	var totalCount int64
-
-	err := q.forAccountShards(ctx, scope.AccountID, func(ctx context.Context, shard QueueShard) error {
-		backlogSize, err := shard.PartitionBacklogSize(ctx, scope, partitionID)
-		if err != nil {
-			return fmt.Errorf("could not load partition backlog size: %w", err)
-		}
-		l := logger.StdlibLogger(ctx)
-		l.Trace("retrieved backlog size", "size", backlogSize)
-		atomic.AddInt64(&totalCount, int64(backlogSize))
-		return nil
-	})
-	if err != nil {
-		return 0, fmt.Errorf("could not load partition backlog size: %w", err)
-	}
-	return totalCount, nil
-}
-
-// PartitionByID implements JobQueueReader.
-func (q *queueProcessor) PartitionByID(ctx context.Context, shard QueueShard, scope Scope, partitionID string) (*PartitionInspectionResult, error) {
-	return shard.PartitionByID(ctx, scope, partitionID)
-}
-
-// RemoveQueueItem implements JobQueueReader.
-func (q *queueProcessor) RemoveQueueItem(ctx context.Context, shardName string, scope Scope, partitionID string, itemID string) error {
-	shard, err := q.shards.ByName(shardName)
-	if err != nil {
-		return err
-	}
-
-	return shard.RemoveQueueItem(ctx, scope, partitionID, itemID)
-}
-
-// Requeue implements Producer.
-func (q *queueProcessor) Requeue(ctx context.Context, shardName string, i QueueItem, at time.Time, opts ...RequeueOptionFn) error {
-	return q.queueProducer.Requeue(ctx, shardName, i, at, opts...)
-}
-
-// RequeueByJobID implements Producer.
-func (q *queueProcessor) RequeueByJobID(ctx context.Context, shardName string, jobID string, at time.Time) error {
-	return q.queueProducer.RequeueByJobID(ctx, shardName, jobID, at)
-}
-
-// Enqueue implements Producer.
-func (q *queueProcessor) Enqueue(ctx context.Context, item Item, at time.Time, opts EnqueueOpts) error {
-	return q.queueProducer.Enqueue(ctx, item, at, opts)
-}
-
-// OutstandingJobCount implements Queue.
-func (q *queueProcessor) OutstandingJobCount(ctx context.Context, scope Scope, runID ulid.ULID) (int, error) {
-	var totalCount int64
-
-	err := q.forAccountShards(ctx, scope.AccountID, func(ctx context.Context, shard QueueShard) error {
-		outstanding, err := shard.OutstandingJobCount(ctx, scope, runID)
-		if err != nil {
-			return fmt.Errorf("could not load outstanding job count: %w", err)
-		}
-		atomic.AddInt64(&totalCount, int64(outstanding))
-		return nil
-	})
-	if err != nil {
-		return 0, fmt.Errorf("could not load outstanding count: %w", err)
-	}
-	return int(totalCount), nil
-}
-
-// RunJobs implements Queue.
-func (q *queueProcessor) RunJobs(ctx context.Context, shardName string, scope Scope, runID ulid.ULID, limit int64, offset int64) ([]JobResponse, error) {
-	shard, err := q.shards.ByName(shardName)
-	if err != nil {
-		return nil, err
-	}
-
-	return shard.RunJobs(ctx, scope, runID, limit, offset)
-}
-
-// RunningCount implements Queue.
-func (q *queueProcessor) RunningCount(ctx context.Context, scope Scope) (int64, error) {
-	var totalCount int64
-
-	err := q.forAccountShards(ctx, scope.AccountID, func(ctx context.Context, shard QueueShard) error {
-		running, err := shard.RunningCount(ctx, scope)
-		if err != nil {
-			return fmt.Errorf("could not load running count: %w", err)
-		}
-		atomic.AddInt64(&totalCount, int64(running))
-		return nil
-	})
-	if err != nil {
-		return 0, fmt.Errorf("could not load running count: %w", err)
-	}
-	return totalCount, nil
-}
-
-// StatusCount implements Queue.
-func (q *queueProcessor) StatusCount(ctx context.Context, scope Scope, status string) (int64, error) {
-	var totalCount int64
-
-	err := q.forAccountShards(ctx, scope.AccountID, func(ctx context.Context, shard QueueShard) error {
-		running, err := shard.StatusCount(ctx, scope, status)
-		if err != nil {
-			return fmt.Errorf("could not load status count: %w", err)
-		}
-		atomic.AddInt64(&totalCount, int64(running))
-		return nil
-	})
-	if err != nil {
-		return 0, fmt.Errorf("could not load status count: %w", err)
-	}
-	return totalCount, nil
-}
-
-// ResetAttemptsByJobID implements Queue.
-func (q *queueProcessor) ResetAttemptsByJobID(ctx context.Context, shardName string, scope Scope, jobID string) error {
-	shard, err := q.shards.ByName(shardName)
-	if err != nil {
-		return err
-	}
-
-	return shard.ResetAttemptsByJobID(ctx, scope, jobID)
-}
-
 func (q *queueProcessor) Run(ctx context.Context, f RunFunc) error {
 	// claimShardLease will block until a shard lease is obtained to process the primary shard.
 	l := logger.StdlibLogger(ctx)
@@ -436,25 +248,6 @@ func (q *queueProcessor) Run(ctx context.Context, f RunFunc) error {
 	}
 
 	return eg.Wait()
-}
-
-// SetFunctionMigrate implements Queue.
-func (q *queueProcessor) SetFunctionMigrate(ctx context.Context, sourceShard string, scope Scope, migrateLockUntil *time.Time) error {
-	shard, err := q.shards.ByName(sourceShard)
-	if err != nil {
-		return fmt.Errorf("could not find shard %q", sourceShard)
-	}
-
-	return shard.SetFunctionMigrate(ctx, scope, migrateLockUntil)
-}
-
-// UnpauseFunction implements Queue.
-func (q *queueProcessor) UnpauseFunction(ctx context.Context, shardName string, scope Scope) error {
-	shard, err := q.shards.ByName(shardName)
-	if err != nil {
-		return err
-	}
-	return shard.UnpauseFunction(ctx, scope)
 }
 
 func (q *queueProcessor) capacity() int64 {

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -97,6 +97,9 @@ func New(
 	if o.queueProducer != nil {
 		qp.Producer = o.queueProducer
 	}
+	if o.queueConsumer != nil {
+		qp.Consumer = o.queueConsumer
+	}
 	qp.configureQueueRoles()
 
 	return qp, nil

--- a/pkg/execution/queue/processor_test.go
+++ b/pkg/execution/queue/processor_test.go
@@ -28,6 +28,17 @@ func (m *mockProducer) RequeueByJobID(context.Context, string, string, time.Time
 	return nil
 }
 
+type mockConsumer struct {
+	called    atomic.Bool
+	shardName atomic.Value
+}
+
+func (m *mockConsumer) Dequeue(_ context.Context, shardName string, _ QueueItem, _ ...DequeueOptionFn) error {
+	m.called.Store(true)
+	m.shardName.Store(shardName)
+	return nil
+}
+
 func TestProcessorWithQueueProducerOverridesDefaultProducer(t *testing.T) {
 	ctx := context.Background()
 	shard := &mockShardForIterator{name: "shard-a"}
@@ -41,6 +52,22 @@ func TestProcessorWithQueueProducerOverridesDefaultProducer(t *testing.T) {
 	err = q.Enqueue(ctx, Item{}, time.Now(), EnqueueOpts{})
 	require.NoError(t, err)
 	require.True(t, producer.called.Load())
+}
+
+func TestProcessorWithQueueConsumerOverridesDefaultConsumer(t *testing.T) {
+	ctx := context.Background()
+	shard := &mockShardForIterator{name: "shard-a"}
+	registry, err := NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+
+	consumer := &mockConsumer{}
+	q, err := New(ctx, "test", registry, WithQueueConsumer(consumer))
+	require.NoError(t, err)
+
+	err = q.Dequeue(ctx, "custom-shard", QueueItem{})
+	require.NoError(t, err)
+	require.True(t, consumer.called.Load())
+	require.Equal(t, "custom-shard", consumer.shardName.Load())
 }
 
 func TestProcessorAccountShardReadsResolveByDefault(t *testing.T) {

--- a/pkg/execution/queue/producer.go
+++ b/pkg/execution/queue/producer.go
@@ -16,35 +16,35 @@ type queueProducer struct {
 	shards ShardRegistry
 }
 
-type ProducerOpt func(*queueProducer)
+type producerOpt func(*queueProducer)
 
-func WithProducerClock(clock clockwork.Clock) ProducerOpt {
+func withProducerClock(clock clockwork.Clock) producerOpt {
 	return func(q *queueProducer) {
 		q.clock = clock
 	}
 }
 
-func WithProducerKindToQueueMapping(mapping map[string]string) ProducerOpt {
+func withProducerKindToQueueMapping(mapping map[string]string) producerOpt {
 	return func(q *queueProducer) {
 		q.queueKindMapping = mapping
 	}
 }
 
-func WithProducerJobPromotion(enable bool) ProducerOpt {
+func withProducerJobPromotion(enable bool) producerOpt {
 	return func(q *queueProducer) {
 		q.enableJobPromotion = enable
 	}
 }
 
-func WithProducerConditionalTracer(tracer trace.ConditionalTracer) ProducerOpt {
+func withProducerConditionalTracer(tracer trace.ConditionalTracer) producerOpt {
 	return func(q *queueProducer) {
 		q.conditionalTracer = tracer
 	}
 }
 
-func NewProducer(
+func newProducer(
 	shards ShardRegistry,
-	opts ...ProducerOpt,
+	opts ...producerOpt,
 ) Producer {
 	q := &queueProducer{
 		clock:             clockwork.NewRealClock(),

--- a/pkg/execution/queue/unpauser.go
+++ b/pkg/execution/queue/unpauser.go
@@ -1,0 +1,19 @@
+package queue
+
+import "context"
+
+type queueUnpauser struct {
+	shards QueueShardRegistry
+}
+
+func newQueueUnpauser(shards QueueShardRegistry) Unpauser {
+	return &queueUnpauser{shards: shards}
+}
+
+func (u *queueUnpauser) UnpauseFunction(ctx context.Context, shardName string, scope Scope) error {
+	shard, err := u.shards.ByName(shardName)
+	if err != nil {
+		return err
+	}
+	return shard.UnpauseFunction(ctx, scope)
+}


### PR DESCRIPTION
## Description

break up queueProcessor into smaller objects that can be independently constructed.

Right now, moves some of the queue implementations to separate objects that are embedded in queueProcessor, and allows configuring a separate consumer client if needed.

This is the minimum interface required for queue-proxy. In the future, we should also split up queueProcessor itself into separate objects that independently implement Queue and QueueProcessor (today it implements both)

Also, remove WithServiceEnableKeyQueues from executor service since it seems to be unused.
## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
