### PR TITLE
fix: fix the ordering and queue time of async opcodes

### DIFF
--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3698,6 +3698,17 @@ func (e *executor) HandleGenerator(ctx context.Context, runCtx execution.RunCont
 	return e.handleGeneratorOp(ctx, runCtx, gen, OpcodeGroup{})
 }
 
+// opcodeHandledAt returns the time async-opcode handlers stamp as their step
+// span's queue time: the group's shared handling time when the opcode arrived
+// in an SDK response (keeping parallel opcodes' trace order deterministic),
+// else the handler's own clock (e.g. opcodes fed via the checkpoint API).
+func (e *executor) opcodeHandledAt(group OpcodeGroup) time.Time {
+	if !group.HandledAt.IsZero() {
+		return group.HandledAt
+	}
+	return e.now()
+}
+
 func (e *executor) handleGeneratorOp(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, group OpcodeGroup) error {
 	// Grab the edge that triggered this step execution.
 	lifecycleItem := runCtx.LifecycleItem()
@@ -3727,7 +3738,7 @@ func (e *executor) handleGeneratorOp(ctx context.Context, runCtx execution.RunCo
 	case enums.OpcodeStepPlanned:
 		return e.handleGeneratorStepPlanned(ctx, runCtx, gen, edge, group)
 	case enums.OpcodeSleep:
-		return e.handleGeneratorSleep(ctx, runCtx, gen, edge)
+		return e.handleGeneratorSleep(ctx, runCtx, gen, edge, group)
 	case enums.OpcodeWaitForEvent:
 		return e.handleGeneratorWaitForEvent(ctx, runCtx, gen, edge, group)
 	case enums.OpcodeInvokeFunction:
@@ -4369,7 +4380,15 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, runCtx execut
 	}
 
 	attrs := tracing.GeneratorAttrs(&gen)
-	tracing.AddQueueTimestampAttrs(attrs, runCtx.LifecycleItem())
+	// The planned step is queued the moment this opcode is handled (its own
+	// queue item's EnqueuedAt is only stamped at Enqueue, below). The queued
+	// segment still covers any wait for a concurrency slot: handling time →
+	// execution start. See OpcodeGroup.HandledAt, which avoids a stale
+	// queuedAt inherited from the request.
+	{
+		handledAt := e.opcodeHandledAt(group)
+		tracing.AddTimingAttrs(attrs, handledAt, handledAt, time.Time{}, time.Time{})
+	}
 
 	span, err := e.tracerProvider.CreateDroppableSpan(
 		ctx,
@@ -4406,7 +4425,7 @@ func (e *executor) handleGeneratorStepPlanned(ctx context.Context, runCtx execut
 
 // handleSleep handles the sleep opcode, ensuring that we enqueue the function to rerun
 // at the correct time.
-func (e *executor) handleGeneratorSleep(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge) error {
+func (e *executor) handleGeneratorSleep(ctx context.Context, runCtx execution.RunContext, gen state.GeneratorOpcode, edge queue.PayloadEdge, group OpcodeGroup) error {
 	dur, err := gen.SleepDuration()
 	if err != nil {
 		return err
@@ -4446,7 +4465,13 @@ func (e *executor) handleGeneratorSleep(ctx context.Context, runCtx execution.Ru
 	lifecycleItem := runCtx.LifecycleItem()
 	metadata := runCtx.Metadata()
 	attrs := tracing.GeneratorAttrs(&gen)
-	tracing.AddQueueTimestampAttrs(attrs, runCtx.LifecycleItem())
+	// The sleep begins the moment this opcode is handled — not when the
+	// reporting request was enqueued. See OpcodeGroup.HandledAt, which avoids
+	// a stale queuedAt inherited from the request.
+	{
+		handledAt := e.opcodeHandledAt(group)
+		tracing.AddTimingAttrs(attrs, handledAt, handledAt, time.Time{}, time.Time{})
+	}
 	meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusSleeping))
 
 	// Create a new span that we'll use to record the sleep as complete.
@@ -4870,7 +4895,13 @@ func (e *executor) handleGeneratorWaitForSignal(ctx context.Context, runCtx exec
 
 	lifecycleItem := runCtx.LifecycleItem()
 	attrs := tracing.GeneratorAttrs(&gen)
-	tracing.AddQueueTimestampAttrs(attrs, lifecycleItem)
+	// The wait begins the moment this opcode is handled — not when the
+	// reporting request was enqueued. See OpcodeGroup.HandledAt, which avoids
+	// a stale queuedAt inherited from the request.
+	{
+		handledAt := e.opcodeHandledAt(group)
+		tracing.AddTimingAttrs(attrs, handledAt, handledAt, time.Time{}, time.Time{})
+	}
 	meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusWaiting))
 
 	span, err := e.tracerProvider.CreateDroppableSpan(
@@ -5076,11 +5107,7 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx exe
 	// request predates sibling steps executed within it, and the trace UI
 	// sorts run children by queuedAt — a stale stamp prepends the invoke span
 	// with a phantom queued segment.
-	handledAt := group.HandledAt
-	if handledAt.IsZero() {
-		// Not handled as part of a response group (e.g. checkpoint API).
-		handledAt = now
-	}
+	handledAt := e.opcodeHandledAt(group)
 	tracing.AddTimingAttrs(attrs, handledAt, handledAt, time.Time{}, time.Time{})
 	// Always correlate the triggering event ID with the invoked step.
 	meta.AddAttr(attrs, meta.Attrs.StepInvokeTriggerEventID, &evt.ID)
@@ -5307,7 +5334,13 @@ func (e *executor) handleGeneratorWaitForEvent(ctx context.Context, runCtx execu
 		ParallelMode: gen.ParallelMode(),
 	}
 	attrs := tracing.GeneratorAttrs(&gen)
-	tracing.AddQueueTimestampAttrs(attrs, runCtx.LifecycleItem())
+	// The wait begins the moment this opcode is handled — not when the
+	// reporting request was enqueued. See OpcodeGroup.HandledAt, which avoids
+	// a stale queuedAt inherited from the request.
+	{
+		handledAt := e.opcodeHandledAt(group)
+		tracing.AddTimingAttrs(attrs, handledAt, handledAt, time.Time{}, time.Time{})
+	}
 	meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusWaiting))
 
 	lifecycleItem := runCtx.LifecycleItem()

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -3610,6 +3610,13 @@ func (e *executor) HandleGeneratorResponse(ctx context.Context, i *runInstance, 
 
 	groups := opGroups(resp.Generator)
 
+	// One handling timestamp for the whole response: handlers run
+	// concurrently below, so per-handler clocks would give parallel opcodes
+	// distinct span queue times and a nondeterministic trace order.
+	handledAt := e.now()
+	groups.PriorityGroup.HandledAt = handledAt
+	groups.OtherGroup.HandledAt = handledAt
+
 	nonLazyIDs := groups.NonLazyIDs()
 
 	// When scheduling multiple parallel steps, compute a stable coalesceKey
@@ -5064,7 +5071,17 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx exe
 		ParallelMode: gen.ParallelMode(),
 	}
 	attrs := tracing.GeneratorAttrs(&gen)
-	tracing.AddQueueTimestampAttrs(attrs, runCtx.LifecycleItem())
+	// The invoke is queued the moment this opcode is handled. Do NOT stamp
+	// the reporting request's queue times here: with checkpointing that
+	// request predates sibling steps executed within it, and the trace UI
+	// sorts run children by queuedAt — a stale stamp prepends the invoke span
+	// with a phantom queued segment.
+	handledAt := group.HandledAt
+	if handledAt.IsZero() {
+		// Not handled as part of a response group (e.g. checkpoint API).
+		handledAt = now
+	}
+	tracing.AddTimingAttrs(attrs, handledAt, handledAt, time.Time{}, time.Time{})
 	// Always correlate the triggering event ID with the invoked step.
 	meta.AddAttr(attrs, meta.Attrs.StepInvokeTriggerEventID, &evt.ID)
 	meta.AddAttr(attrs, meta.Attrs.DynamicStatus, inngestgo.Ptr(enums.StepStatusInvoking))

--- a/pkg/execution/executor/util.go
+++ b/pkg/execution/executor/util.go
@@ -42,6 +42,18 @@ type OpcodeGroup struct {
 	// start a new history group. This is true if the overall list of opcodes
 	// received from an SDK Call Request contains more than one opcode.
 	ShouldStartHistoryGroup bool
+	// HandledAt is when the executor began handling the SDK response this
+	// group came from. Async-opcode handlers stamp it as their step span's
+	// queuedAt: it is the moment the executor creates the op's event, pause,
+	// or queue item — the earliest instant the step exists to wait on
+	// anything — so the span's queued segment measures real wait (handling →
+	// execution/resume start). The reporting request's enqueue time would be
+	// wrong here: it can predate sibling steps executed within that request
+	// (stale inherited queuedAt). A single timestamp shared across the group keeps the trace
+	// order of concurrently-handled parallel opcodes deterministic. Zero when
+	// an opcode is handled outside a response group (e.g. the checkpoint
+	// API); handlers fall back to their own clock.
+	HandledAt time.Time
 	// ParallelCoalesceKey is a stable key shared by all items in this parallel
 	// batch.  When non-empty, handlers use it to derive a deterministic
 	// discovery JobID so concurrent fan-in completions deduplicate to one step.

--- a/tests/execution/executor/defer_test.go
+++ b/tests/execution/executor/defer_test.go
@@ -9,20 +9,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/cqrs"
-	cqrsmanager "github.com/inngest/inngest/pkg/cqrs/manager"
-	dbsqlite "github.com/inngest/inngest/pkg/db/sqlite"
 	"github.com/inngest/inngest/pkg/enums"
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/checkpoint"
 	"github.com/inngest/inngest/pkg/execution/executor"
-	"github.com/inngest/inngest/pkg/execution/pauses"
 	"github.com/inngest/inngest/pkg/execution/queue"
 	"github.com/inngest/inngest/pkg/execution/state"
-	"github.com/inngest/inngest/pkg/execution/state/redis_state"
 	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/inngest"
 	"github.com/inngest/inngest/pkg/logger"
@@ -42,147 +37,10 @@ func (s *loadDefersFailingState) LoadDefers(ctx context.Context, id statev2.ID) 
 	return nil, s.err
 }
 
-// deferTestInfra holds the shared state manager, queue, and loader used by the
-// checkpoint-vs-executor consistency tests so each test can spin up 3 runs
-// against the same backing store.
-type deferTestInfra struct {
-	ctx           context.Context
-	fn            inngest.Function
-	fnID          uuid.UUID
-	wsID          uuid.UUID
-	appID         uuid.UUID
-	aID           uuid.UUID
-	smv2          statev2.RunService
-	pauseMgr      pauses.Manager
-	loader        state.FunctionLoader
-	dbcqrs        cqrs.Manager
-	adapter       *dbsqlite.Adapter
-	queueShard    redis_state.RedisQueueShard
-	shardRegistry queue.ShardRegistryController
-	rq            queue.Queue
-}
-
-func newDeferTestInfra(t *testing.T) *deferTestInfra {
-	t.Helper()
-	ctx := logger.WithStdlib(context.Background(), logger.VoidLogger())
-
-	db, err := dbsqlite.Open(ctx, dbsqlite.Options{Persist: false, ForTest: true})
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-	adapter := dbsqlite.New(db)
-	dbcqrs := cqrsmanager.New(adapter)
-	loader := dbcqrs.(state.FunctionLoader)
-
-	fnID, wsID, appID, aID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
-
-	fn := inngest.Function{
-		ID:              fnID,
-		FunctionVersion: 1,
-		Name:            "test-fn",
-		Slug:            "test-fn",
-		Steps: []inngest.Step{
-			{ID: "step-defer", Name: "step-defer", URI: "/step-defer"},
-		},
-	}
-
-	config, err := json.Marshal(fn)
-	require.NoError(t, err)
-
-	_, err = dbcqrs.UpsertApp(ctx, cqrs.UpsertAppParams{ID: appID, Name: "test-app"})
-	require.NoError(t, err)
-	_, err = dbcqrs.UpsertFunction(ctx, cqrs.UpsertFunctionParams{
-		ID: fnID, AppID: appID, Name: fn.Name, Slug: fn.Slug, Config: string(config),
-	})
-	require.NoError(t, err)
-
-	_, shardedRc, err := createInmemoryRedis(t)
-	require.NoError(t, err)
-	t.Cleanup(func() { shardedRc.Close() })
-
-	_, unshardedRc, err := createInmemoryRedis(t)
-	require.NoError(t, err)
-	t.Cleanup(func() { unshardedRc.Close() })
-
-	unshardedClient := redis_state.NewUnshardedClient(unshardedRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
-	shardedClient := redis_state.NewShardedClient(redis_state.ShardedClientOpts{
-		UnshardedClient:        unshardedClient,
-		FunctionRunStateClient: shardedRc,
-		StateDefaultKey:        redis_state.StateDefaultKey,
-		FnRunIsSharded:         redis_state.AlwaysShardOnRun,
-		BatchClient:            shardedRc,
-		QueueDefaultKey:        redis_state.QueueDefaultKey,
-	})
-
-	pauseMgr := pauses.NewPauseStoreManager(unshardedClient)
-	sm, err := redis_state.New(ctx,
-		redis_state.WithShardedClient(shardedClient),
-		redis_state.WithPauseDeleter(pauseMgr),
-	)
-	require.NoError(t, err)
-	smv2 := redis_state.MustRunServiceV2(sm)
-
-	queueOpts := []queue.QueueOpt{queue.WithIdempotencyTTL(time.Hour)}
-	queueShard := redis_state.NewQueueShard(consts.DefaultQueueShardName, unshardedClient.Queue(), queueOpts...)
-
-	shardRegistry, err := queue.NewSingleShardRegistry(queueShard)
-	require.NoError(t, err)
-
-	rq, err := queue.New(ctx, "test-queue", shardRegistry, queueOpts...)
-	require.NoError(t, err)
-
-	return &deferTestInfra{
-		ctx:           ctx,
-		fn:            fn,
-		fnID:          fnID,
-		wsID:          wsID,
-		appID:         appID,
-		aID:           aID,
-		smv2:          smv2,
-		pauseMgr:      pauseMgr,
-		loader:        loader,
-		dbcqrs:        dbcqrs,
-		adapter:       adapter,
-		queueShard:    queueShard,
-		shardRegistry: shardRegistry,
-		rq:            rq,
-	}
-}
-
-// newExecutor builds an executor wired to the shared infra. Pass a non-nil
-// driver to drive Execute() calls; pass nil when only the checkpointer will
-// be used.
-func (i *deferTestInfra) newExecutor(t *testing.T, driver *mockDriverV1) execution.Executor {
-	t.Helper()
-	return i.newExecutorWithQueue(t, i.rq, driver)
-}
-
-// newExecutorWithQueue is newExecutor with an overridable queue, used by the
-// discovery-enqueue tests that wrap the shared queue in enqueueCountingQueue.
-func (i *deferTestInfra) newExecutorWithQueue(t *testing.T, q queue.Queue, driver *mockDriverV1) execution.Executor {
-	t.Helper()
-
-	opts := []executor.ExecutorOpt{
-		executor.WithStateManager(i.smv2),
-		executor.WithPauseManager(i.pauseMgr),
-		executor.WithQueue(q),
-		executor.WithLogger(logger.StdlibLogger(i.ctx)),
-		executor.WithFunctionLoader(i.loader),
-		executor.WithShardRegistry(i.shardRegistry),
-		executor.WithTracerProvider(tracing.NewSqlcTracerProvider(i.adapter.Q())),
-	}
-	if driver != nil {
-		opts = append(opts, executor.WithDriverV1(driver))
-	}
-
-	exec, err := executor.NewExecutor(opts...)
-	require.NoError(t, err)
-	return exec
-}
-
 // newCheckpointer builds a Checkpointer using the shared infra. The Executor
 // is passed in so the checkpointer can reuse the same handler for non-Defer
 // async opcodes; for Defer-only tests, any executor works.
-func (i *deferTestInfra) newCheckpointer(t *testing.T, exec execution.Executor) checkpoint.Checkpointer {
+func (i *execTestInfra) newCheckpointer(t *testing.T, exec execution.Executor) checkpoint.Checkpointer {
 	t.Helper()
 	return checkpoint.New(checkpoint.Opts{
 		State:          i.smv2,
@@ -191,22 +49,6 @@ func (i *deferTestInfra) newCheckpointer(t *testing.T, exec execution.Executor) 
 		TracerProvider: tracing.NewSqlcTracerProvider(i.adapter.Q()),
 		Queue:          i.rq,
 	})
-}
-
-// scheduleRun kicks off a fresh run and returns its metadata.
-func (i *deferTestInfra) scheduleRun(t *testing.T, exec execution.Executor) *statev2.Metadata {
-	t.Helper()
-	now := time.Now()
-	evtID := ulid.MustNew(ulid.Timestamp(now), rand.Reader)
-
-	_, run, err := exec.Schedule(i.ctx, execution.ScheduleRequest{
-		Function: i.fn, At: &now, AccountID: i.aID, WorkspaceID: i.wsID, AppID: i.appID,
-		Events: []event.TrackedEvent{
-			event.NewBaseTrackedEventWithID(event.Event{Name: "test/event"}, evtID),
-		},
-	})
-	require.NoError(t, err)
-	return run
 }
 
 // enqueueCountingQueue wraps a queue.Queue and counts Enqueue calls. Reads
@@ -254,10 +96,10 @@ func (s *pendingCapturingState) calls() [][]string {
 func TestDeferFinalize(t *testing.T) {
 	t.Run("emits schedule events for AfterRun defers", func(t *testing.T) {
 		r := require.New(t)
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 		ctx := infra.ctx
 
-		exec := infra.newExecutor(t, nil)
+		exec := infra.newExecutor(t)
 		var capturedEvents []event.Event
 		exec.SetFinalizer(func(ctx context.Context, id statev2.ID, events []event.Event) error {
 			capturedEvents = append(capturedEvents, events...)
@@ -334,7 +176,7 @@ func TestDeferFinalize(t *testing.T) {
 	t.Run("continues on LoadDefers error", func(t *testing.T) {
 		// Better to miss deferred runs than to block the run from finalizing.
 		r := require.New(t)
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 		ctx := infra.ctx
 
 		failingState := &loadDefersFailingState{
@@ -386,10 +228,10 @@ func TestDeferFinalize(t *testing.T) {
 
 	t.Run("rejected defers do not emit schedule events", func(t *testing.T) {
 		r := require.New(t)
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 		ctx := infra.ctx
 
-		exec := infra.newExecutor(t, nil)
+		exec := infra.newExecutor(t)
 		var capturedEvents []event.Event
 		exec.SetFinalizer(func(ctx context.Context, id statev2.ID, events []event.Event) error {
 			capturedEvents = append(capturedEvents, events...)
@@ -440,7 +282,7 @@ func TestDeferAdd(t *testing.T) {
 	t.Run("consistent across executor and checkpoint paths", func(t *testing.T) {
 		// Originally added to catch a regression where DeferAdd worked in
 		// non-checkpointing codepaths but not in checkpointing.
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 		ctx := infra.ctx
 
 		op := state.GeneratorOpcode{
@@ -469,7 +311,7 @@ func TestDeferAdd(t *testing.T) {
 						response: &state.DriverResponse{StatusCode: 206, Generator: []*state.GeneratorOpcode{&op}},
 						t:        t,
 					}
-					exec := infra.newExecutor(t, driver)
+					exec := infra.newExecutor(t, executor.WithDriverV1(driver))
 					run := infra.scheduleRun(t, exec)
 					_, err := exec.Execute(ctx, state.Identifier{
 						WorkflowID: infra.fnID, RunID: run.ID.RunID, AccountID: infra.aID,
@@ -486,7 +328,7 @@ func TestDeferAdd(t *testing.T) {
 			{
 				name: "sync-checkpoint",
 				run: func(t *testing.T) statev2.ID {
-					exec := infra.newExecutor(t, nil)
+					exec := infra.newExecutor(t)
 					run := infra.scheduleRun(t, exec)
 					cp := infra.newCheckpointer(t, exec)
 					err := cp.CheckpointSyncSteps(ctx, checkpoint.SyncCheckpoint{
@@ -505,7 +347,7 @@ func TestDeferAdd(t *testing.T) {
 			{
 				name: "async-checkpoint",
 				run: func(t *testing.T) statev2.ID {
-					exec := infra.newExecutor(t, nil)
+					exec := infra.newExecutor(t)
 					run := infra.scheduleRun(t, exec)
 					cp := infra.newCheckpointer(t, exec)
 					// No QueueItemRef → async path skips the ResetAttemptsByJobID call.
@@ -547,7 +389,7 @@ func TestDeferAdd(t *testing.T) {
 		// a deferred.schedule event for the defer. Observing the event
 		// proves SaveDefer ran before state cleanup.
 		r := require.New(t)
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 		countingQ := &enqueueCountingQueue{Queue: infra.rq}
 
 		stepID := "step-defer"
@@ -573,7 +415,7 @@ func TestDeferAdd(t *testing.T) {
 			},
 		}
 
-		exec := infra.newExecutorWithQueue(t, countingQ, driver)
+		exec := infra.newExecutorWithQueue(t, countingQ, executor.WithDriverV1(driver))
 
 		var capturedEvents []event.Event
 		exec.SetFinalizer(func(ctx context.Context, id statev2.ID, events []event.Event) error {
@@ -620,7 +462,7 @@ func TestDeferAdd(t *testing.T) {
 		// run can progress. "Shouldn't happen" in normal operation (the
 		// SDK piggybacks lazy ops), but the fallback path must stay safe.
 		r := require.New(t)
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 		countingQ := &enqueueCountingQueue{Queue: infra.rq}
 
 		stepID := "step-defer"
@@ -641,7 +483,7 @@ func TestDeferAdd(t *testing.T) {
 			},
 		}
 
-		exec := infra.newExecutorWithQueue(t, countingQ, driver)
+		exec := infra.newExecutorWithQueue(t, countingQ, executor.WithDriverV1(driver))
 		run := infra.scheduleRun(t, exec)
 		countBeforeExecute := countingQ.enqueues
 
@@ -669,7 +511,7 @@ func TestDeferAdd(t *testing.T) {
 		// Lazy ops do not decrement the pending step count, so including
 		// them in the pending set wedges the run.
 		r := require.New(t)
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 		ctx := infra.ctx
 
 		const (
@@ -742,7 +584,7 @@ func TestDeferAdd(t *testing.T) {
 		// retransmits. Bare DeferAdd (no RunComplete) so the run doesn't
 		// finalize during Execute, leaving state inspectable afterward.
 		r := require.New(t)
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 		ctx := infra.ctx
 
 		const stepID = "step-oversized"
@@ -769,7 +611,7 @@ func TestDeferAdd(t *testing.T) {
 			},
 		}
 
-		exec := infra.newExecutor(t, driver)
+		exec := infra.newExecutor(t, executor.WithDriverV1(driver))
 		run := infra.scheduleRun(t, exec)
 
 		_, err := exec.Execute(ctx, state.Identifier{
@@ -795,7 +637,7 @@ func TestDeferAdd(t *testing.T) {
 		// MaxDeferInputAggregateSize is rejected via sentinel without
 		// failing the run. The earlier accepted defer remains valid.
 		r := require.New(t)
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 		ctx := infra.ctx
 
 		const (
@@ -838,7 +680,7 @@ func TestDeferAdd(t *testing.T) {
 			},
 		}
 
-		exec := infra.newExecutor(t, driver)
+		exec := infra.newExecutor(t, executor.WithDriverV1(driver))
 		run := infra.scheduleRun(t, exec)
 
 		_, err := exec.Execute(ctx, state.Identifier{
@@ -879,7 +721,7 @@ func TestDeferAbort(t *testing.T) {
 	t.Run("consistent across executor and checkpoint paths", func(t *testing.T) {
 		// Originally added to catch a regression where DeferAbort worked
 		// in non-checkpointing codepaths but not in checkpointing.
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 		ctx := infra.ctx
 
 		const (
@@ -917,7 +759,7 @@ func TestDeferAbort(t *testing.T) {
 						response: &state.DriverResponse{StatusCode: 206, Generator: []*state.GeneratorOpcode{&abortOp}},
 						t:        t,
 					}
-					exec := infra.newExecutor(t, driver)
+					exec := infra.newExecutor(t, executor.WithDriverV1(driver))
 					run := infra.scheduleRun(t, exec)
 					require.NoError(t, infra.smv2.SaveDefer(ctx, run.ID, seed))
 					_, err := exec.Execute(ctx, state.Identifier{
@@ -935,7 +777,7 @@ func TestDeferAbort(t *testing.T) {
 			{
 				name: "sync-checkpoint",
 				run: func(t *testing.T) statev2.ID {
-					exec := infra.newExecutor(t, nil)
+					exec := infra.newExecutor(t)
 					run := infra.scheduleRun(t, exec)
 					require.NoError(t, infra.smv2.SaveDefer(ctx, run.ID, seed))
 					cp := infra.newCheckpointer(t, exec)
@@ -955,7 +797,7 @@ func TestDeferAbort(t *testing.T) {
 			{
 				name: "async-checkpoint",
 				run: func(t *testing.T) statev2.ID {
-					exec := infra.newExecutor(t, nil)
+					exec := infra.newExecutor(t)
 					run := infra.scheduleRun(t, exec)
 					require.NoError(t, infra.smv2.SaveDefer(ctx, run.ID, seed))
 					cp := infra.newCheckpointer(t, exec)
@@ -991,7 +833,7 @@ func TestDeferAbort(t *testing.T) {
 		// actually reached (an error there would short-circuit before the
 		// OnlyHasLazyOps check).
 		r := require.New(t)
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 		countingQ := &enqueueCountingQueue{Queue: infra.rq}
 
 		const (
@@ -1015,7 +857,7 @@ func TestDeferAbort(t *testing.T) {
 			},
 		}
 
-		exec := infra.newExecutorWithQueue(t, countingQ, driver)
+		exec := infra.newExecutorWithQueue(t, countingQ, executor.WithDriverV1(driver))
 		run := infra.scheduleRun(t, exec)
 
 		r.NoError(infra.smv2.SaveDefer(infra.ctx, run.ID, statev2.Defer{
@@ -1051,7 +893,7 @@ func TestDeferAbort(t *testing.T) {
 // DeferAdd hashedIDs piggybacked on RunComplete, and returns the parent run
 // ID and the deferred.schedule events emitted by Finalize. Each hashedID gets
 // its own DeferAdd op targeting the same child fn_slug.
-func (i *deferTestInfra) runParentDefer(t *testing.T, hashedIDs ...string) (ulid.ULID, []event.Event) {
+func (i *execTestInfra) runParentDefer(t *testing.T, hashedIDs ...string) (ulid.ULID, []event.Event) {
 	t.Helper()
 	r := require.New(t)
 	r.NotEmpty(hashedIDs)
@@ -1076,7 +918,7 @@ func (i *deferTestInfra) runParentDefer(t *testing.T, hashedIDs ...string) (ulid
 		t:        t,
 		response: &state.DriverResponse{StatusCode: 206, Generator: ops},
 	}
-	exec := i.newExecutor(t, driver)
+	exec := i.newExecutor(t, executor.WithDriverV1(driver))
 
 	// Capture finalization events
 	var finalizationEvents []event.Event
@@ -1129,11 +971,11 @@ func findDeferEvent(t *testing.T, events []event.Event, parentRunID ulid.ULID, h
 
 // scheduleChildRun schedules a child run with the given deferred.schedule
 // events as its triggering batch.
-func (i *deferTestInfra) scheduleChildRun(t *testing.T, deferSchedules ...event.Event) ulid.ULID {
+func (i *execTestInfra) scheduleChildRun(t *testing.T, deferSchedules ...event.Event) ulid.ULID {
 	t.Helper()
 	require.NotEmpty(t, deferSchedules)
 
-	exec := i.newExecutor(t, nil)
+	exec := i.newExecutor(t)
 	now := time.Now()
 	events := make([]event.TrackedEvent, len(deferSchedules))
 	for k, s := range deferSchedules {
@@ -1190,7 +1032,7 @@ func toParentRunIDs(got map[ulid.ULID][]cqrs.RunDeferredFrom) map[ulid.ULID][]ul
 func TestDeferLinkage(t *testing.T) {
 	t.Run("1 parent to 1 child", func(t *testing.T) {
 		r := require.New(t)
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 
 		parentRunID, evts := infra.runParentDefer(t, "hash-1")
 		childRunID := infra.scheduleChildRun(t,
@@ -1225,7 +1067,7 @@ func TestDeferLinkage(t *testing.T) {
 	// 1 parent run calls defer() twice, triggering 2 child runs.
 	t.Run("1 parent to 2 children", func(t *testing.T) {
 		r := require.New(t)
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 
 		parentRunID, evts := infra.runParentDefer(t, "hash-a", "hash-b")
 		child1ID := infra.scheduleChildRun(t,
@@ -1271,7 +1113,7 @@ func TestDeferLinkage(t *testing.T) {
 	// 2 parent runs call defer() and both events batch into 1 child run.
 	t.Run("2 parents to 1 child", func(t *testing.T) {
 		r := require.New(t)
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 
 		parent1ID, evts1 := infra.runParentDefer(t, "hash-a")
 		parent2ID, evts2 := infra.runParentDefer(t, "hash-b")
@@ -1314,7 +1156,7 @@ func TestDeferLinkage(t *testing.T) {
 	// 1 parent run calls defer() twice and both events batch into 1 child run.
 	t.Run("1 parent batches 2 defers to 1 child", func(t *testing.T) {
 		r := require.New(t)
-		infra := newDeferTestInfra(t)
+		infra := newExecTestInfra(t, "step-defer")
 
 		parentRunID, evts := infra.runParentDefer(t, "hash-a", "hash-b")
 		childID := infra.scheduleChildRun(t,

--- a/tests/execution/executor/helpers_test.go
+++ b/tests/execution/executor/helpers_test.go
@@ -1,0 +1,187 @@
+package executor
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/inngest/inngest/pkg/cqrs"
+	cqrsmanager "github.com/inngest/inngest/pkg/cqrs/manager"
+	dbsqlite "github.com/inngest/inngest/pkg/db/sqlite"
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/execution"
+	"github.com/inngest/inngest/pkg/execution/executor"
+	"github.com/inngest/inngest/pkg/execution/pauses"
+	"github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state"
+	"github.com/inngest/inngest/pkg/execution/state/redis_state"
+	statev2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// execTestInfra holds the shared state manager, queue, and loader used by
+// tests in this package so each test can spin up runs against the same
+// backing store without re-wiring cqrs/redis/queue by hand.
+type execTestInfra struct {
+	ctx           context.Context
+	fn            inngest.Function
+	fnID          uuid.UUID
+	wsID          uuid.UUID
+	appID         uuid.UUID
+	aID           uuid.UUID
+	smv2          statev2.RunService
+	pauseMgr      pauses.Manager
+	loader        state.FunctionLoader
+	dbcqrs        cqrs.Manager
+	adapter       *dbsqlite.Adapter
+	queueShard    redis_state.RedisQueueShard
+	shardRegistry queue.ShardRegistryController
+	rq            queue.Queue
+}
+
+// newExecTestInfra builds the shared executor test infra. stepID is
+// parameterized so callers can pin their function's single step to whatever
+// ID their opcodes/fixtures target.
+func newExecTestInfra(t *testing.T, stepID string) *execTestInfra {
+	t.Helper()
+	ctx := logger.WithStdlib(context.Background(), logger.VoidLogger())
+
+	db, err := dbsqlite.Open(ctx, dbsqlite.Options{Persist: false, ForTest: true})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	adapter := dbsqlite.New(db)
+	dbcqrs := cqrsmanager.New(adapter)
+	loader := dbcqrs.(state.FunctionLoader)
+
+	fnID, wsID, appID, aID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+
+	fn := inngest.Function{
+		ID:              fnID,
+		FunctionVersion: 1,
+		Name:            "test-fn",
+		Slug:            "test-fn",
+		Steps: []inngest.Step{
+			{ID: stepID, Name: stepID, URI: "/" + stepID},
+		},
+	}
+
+	config, err := json.Marshal(fn)
+	require.NoError(t, err)
+
+	_, err = dbcqrs.UpsertApp(ctx, cqrs.UpsertAppParams{ID: appID, Name: "test-app"})
+	require.NoError(t, err)
+	_, err = dbcqrs.UpsertFunction(ctx, cqrs.UpsertFunctionParams{
+		ID: fnID, AppID: appID, Name: fn.Name, Slug: fn.Slug, Config: string(config),
+	})
+	require.NoError(t, err)
+
+	_, shardedRc, err := createInmemoryRedis(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { shardedRc.Close() })
+
+	_, unshardedRc, err := createInmemoryRedis(t)
+	require.NoError(t, err)
+	t.Cleanup(func() { unshardedRc.Close() })
+
+	unshardedClient := redis_state.NewUnshardedClient(unshardedRc, redis_state.StateDefaultKey, redis_state.QueueDefaultKey)
+	shardedClient := redis_state.NewShardedClient(redis_state.ShardedClientOpts{
+		UnshardedClient:        unshardedClient,
+		FunctionRunStateClient: shardedRc,
+		StateDefaultKey:        redis_state.StateDefaultKey,
+		FnRunIsSharded:         redis_state.AlwaysShardOnRun,
+		BatchClient:            shardedRc,
+		QueueDefaultKey:        redis_state.QueueDefaultKey,
+	})
+
+	pauseMgr := pauses.NewPauseStoreManager(unshardedClient)
+	sm, err := redis_state.New(ctx,
+		redis_state.WithShardedClient(shardedClient),
+		redis_state.WithPauseDeleter(pauseMgr),
+	)
+	require.NoError(t, err)
+	smv2 := redis_state.MustRunServiceV2(sm)
+
+	queueOpts := []queue.QueueOpt{queue.WithIdempotencyTTL(time.Hour)}
+	queueShard := redis_state.NewQueueShard(consts.DefaultQueueShardName, unshardedClient.Queue(), queueOpts...)
+
+	shardRegistry, err := queue.NewSingleShardRegistry(queueShard)
+	require.NoError(t, err)
+
+	rq, err := queue.New(ctx, "test-queue", shardRegistry, queueOpts...)
+	require.NoError(t, err)
+
+	return &execTestInfra{
+		ctx:           ctx,
+		fn:            fn,
+		fnID:          fnID,
+		wsID:          wsID,
+		appID:         appID,
+		aID:           aID,
+		smv2:          smv2,
+		pauseMgr:      pauseMgr,
+		loader:        loader,
+		dbcqrs:        dbcqrs,
+		adapter:       adapter,
+		queueShard:    queueShard,
+		shardRegistry: shardRegistry,
+		rq:            rq,
+	}
+}
+
+// newExecutor builds an executor wired to the shared infra's default queue.
+// Base opts (state, pause manager, queue, logger, loader, shard registry,
+// tracer provider) are set first; extra is appended last so scalar setters
+// (e.g. WithTracerProvider, WithInvokeEventHandler) can override the
+// defaults, and callers can add WithLifecycleListeners (additive) or
+// WithDriverV1. The base opts intentionally never register a driver:
+// WithDriverV1 errors on a duplicate driver name, so the driver must always
+// come from the caller's extra opts.
+func (i *execTestInfra) newExecutor(t *testing.T, extra ...executor.ExecutorOpt) execution.Executor {
+	t.Helper()
+	return i.newExecutorWithQueue(t, i.rq, extra...)
+}
+
+// newExecutorWithQueue is newExecutor with an overridable queue, used by the
+// discovery-enqueue tests that wrap the shared queue in enqueueCountingQueue.
+func (i *execTestInfra) newExecutorWithQueue(t *testing.T, q queue.Queue, extra ...executor.ExecutorOpt) execution.Executor {
+	t.Helper()
+
+	opts := []executor.ExecutorOpt{
+		executor.WithStateManager(i.smv2),
+		executor.WithPauseManager(i.pauseMgr),
+		executor.WithQueue(q),
+		executor.WithLogger(logger.StdlibLogger(i.ctx)),
+		executor.WithFunctionLoader(i.loader),
+		executor.WithShardRegistry(i.shardRegistry),
+		executor.WithTracerProvider(tracing.NewSqlcTracerProvider(i.adapter.Q())),
+	}
+	opts = append(opts, extra...)
+
+	exec, err := executor.NewExecutor(opts...)
+	require.NoError(t, err)
+	return exec
+}
+
+// scheduleRun kicks off a fresh run and returns its metadata.
+func (i *execTestInfra) scheduleRun(t *testing.T, exec execution.Executor) *statev2.Metadata {
+	t.Helper()
+	now := time.Now()
+	evtID := ulid.MustNew(ulid.Timestamp(now), rand.Reader)
+
+	_, run, err := exec.Schedule(i.ctx, execution.ScheduleRequest{
+		Function: i.fn, At: &now, AccountID: i.aID, WorkspaceID: i.wsID, AppID: i.appID,
+		Events: []event.TrackedEvent{
+			event.NewBaseTrackedEventWithID(event.Event{Name: "test/event"}, evtID),
+		},
+	})
+	require.NoError(t, err)
+	return run
+}

--- a/tests/execution/executor/queuedat_test.go
+++ b/tests/execution/executor/queuedat_test.go
@@ -1,0 +1,412 @@
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/inngest/inngest/pkg/cqrs"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/execution/executor"
+	"github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state"
+	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/tracing/meta"
+	"github.com/inngest/inngest/pkg/util/interval"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression tests to prevent stale inherited queuedAt on async opcodes
+//
+// An async opcode (invoke / sleep / waitForEvent / planned step) reported by a
+// request whose queue item was enqueued earlier — e.g. because preceding steps
+// executed inline in that request under checkpointing — must NOT inherit the
+// item's enqueue time as its step span's queuedAt.
+//
+// We provide Opcode payloads from JS SDK runs. We replay them through the
+// executor with a mock driver. We backdate the queue item's EnqueuedAt to set
+// the bug's trigger.
+
+// queuedAtScenario replays a captured opcode fixture through the executor and
+// returns the persisted span tree plus the timing anchors assertions need.
+type queuedAtScenario struct {
+	root *cqrs.OtelSpan
+	// itemEnqueuedAt is the (backdated) enqueue time of the queue item whose
+	// execution reported the opcodes — the value the bug leaked into queuedAt.
+	itemEnqueuedAt time.Time
+	// executeStart is just before exec.Execute ran; opcode handling (and so
+	// the fixed queuedAt) can only happen after this.
+	executeStart time.Time
+}
+
+func runQueuedAtScenario(t *testing.T, opcodes []*state.GeneratorOpcode) queuedAtScenario {
+	t.Helper()
+
+	require.NotEmpty(t, opcodes)
+
+	infra := newExecTestInfra(t, "step")
+	ctx := infra.ctx
+
+	mockDriver := &mockDriverV1{
+		t: t,
+		response: &state.DriverResponse{
+			StatusCode:     206,
+			RequestVersion: 2,
+			Generator:      opcodes,
+		},
+	}
+
+	exec := infra.newExecutor(t,
+		executor.WithInvokeEventHandler(func(ctx context.Context, evt event.TrackedEvent) error { return nil }),
+		executor.WithDriverV1(mockDriver),
+	)
+
+	run := infra.scheduleRun(t, exec)
+
+	jobs, err := infra.rq.RunJobs(ctx, infra.queueShard.Name(), queue.Scope{
+		AccountID:  run.ID.Tenant.AccountID,
+		EnvID:      run.ID.Tenant.EnvID,
+		FunctionID: run.ID.FunctionID,
+	}, run.ID.RunID, 1000, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, jobs)
+
+	// The bug's trigger: the request that reports the opcodes was enqueued
+	// well before the opcodes are handled (in the wild: the request ran
+	// checkpointed sibling steps first; the captured fixtures record ~2s).
+	// Backdate far enough that inheriting it is unmistakable.
+	itemEnqueuedAt := time.Now().Add(-2 * time.Minute).Truncate(time.Millisecond)
+
+	// Execute with the item Schedule actually enqueued — its Metadata carries
+	// the otel propagation carrier that parents the step spans — overriding
+	// only its enqueue time.
+	rawItem, ok := jobs[0].Raw.(*queue.QueueItem)
+	require.True(t, ok, "RunJobs Raw must be a *queue.QueueItem, got %T", jobs[0].Raw)
+	item := rawItem.Data
+	item.EnqueuedAt = itemEnqueuedAt
+
+	jobCtx := queue.WithJobID(ctx, jobs[0].JobID)
+	id := sv2.V1FromMetadata(*run)
+	edge := inngest.Edge{Incoming: "$trigger", Outgoing: "step"}
+
+	executeStart := time.Now()
+	_, err = exec.Execute(jobCtx, id, item, edge)
+	require.NoError(t, err)
+
+	// Span writes flush on the sqlc exporter's batching interval; poll until
+	// every opcode's step span is present with a queuedAt.
+	var root *cqrs.OtelSpan
+	require.Eventually(t, func() bool {
+		root, err = infra.dbcqrs.GetSpansByRunID(ctx, run.ID.RunID)
+		if err != nil || root == nil {
+			return false
+		}
+		found := 0
+		for _, op := range opcodes {
+			if span := findStepSpan(root, op.ID); span != nil && span.Attributes != nil && span.Attributes.QueuedAt != nil {
+				found++
+			}
+		}
+		return found == len(opcodes)
+	}, 10*time.Second, 100*time.Millisecond, "step spans for all fixture opcodes must be persisted with a queuedAt attribute")
+
+	return queuedAtScenario{root: root, itemEnqueuedAt: itemEnqueuedAt, executeStart: executeStart}
+}
+
+// findStepSpan walks the span tree for the "executor.step" span whose stepID
+// attribute matches the opcode ID.
+func findStepSpan(span *cqrs.OtelSpan, stepID string) *cqrs.OtelSpan {
+	if span == nil {
+		return nil
+	}
+	if span.Name == meta.SpanNameStep && span.Attributes != nil &&
+		span.Attributes.StepID != nil && *span.Attributes.StepID == stepID {
+		return span
+	}
+	for _, child := range span.Children {
+		if found := findStepSpan(child, stepID); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// findSpanByName walks the span tree for the first span with the given name.
+func findSpanByName(span *cqrs.OtelSpan, name string) *cqrs.OtelSpan {
+	if span == nil {
+		return nil
+	}
+	if span.Name == name {
+		return span
+	}
+	for _, child := range span.Children {
+		if found := findSpanByName(child, name); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// queuedAtFixtureInvoke is the captured single-invoke scenario.
+//
+//	await step.run("step-before", async () => {
+//		await new Promise((r) => setTimeout(r, 2000));
+//	});
+//	const child = await step.invoke("invoke-child", { // -> the opcode below
+//		function: invokedChild, // -> Opts.function_id
+//		data: { testCase: "capture/invoke", childSleep: "8s" },
+//	});
+var queuedAtFixtureInvoke = []*state.GeneratorOpcode{
+	{
+		Op:   enums.OpcodeInvokeFunction,
+		ID:   "7ff123e6431be676220df2842b3ee0fd2b288a86",
+		Name: "",
+		Opts: map[string]any{
+			"function_id": "test-app-invoked-child",
+			"payload": map[string]any{
+				"data": map[string]any{
+					"childSleep": "8s",
+					"testCase":   "capture/invoke",
+				},
+			},
+		},
+		Data:        nil,
+		Error:       nil,
+		DisplayName: new("invoke-child"),
+		Timing:      interval.Interval{A: 0, B: 0},
+	},
+}
+
+// queuedAtFixtureSleep is the captured sleep scenario.
+//
+// Producing JS:
+//
+//	await step.run("step-before", async () => {
+//		await new Promise((r) => setTimeout(r, 2000));
+//	});
+//	await step.sleep("nap", "5s"); // -> the opcode below
+var queuedAtFixtureSleep = []*state.GeneratorOpcode{
+	{
+		Op:          enums.OpcodeSleep,
+		ID:          "c2640f79b4ed481b838ce4ad75330aa3f825d4d9",
+		Name:        "5s",
+		Opts:        map[string]any{},
+		Data:        nil,
+		Error:       nil,
+		DisplayName: new("nap"),
+		Timing:      interval.Interval{A: 0, B: 0},
+	},
+}
+
+// queuedAtFixtureWaitForEvent is the captured waitForEvent scenario.
+//
+// Producing JS:
+//
+//	await step.run("step-before", async () => {
+//		await new Promise((r) => setTimeout(r, 2000));
+//	});
+//	await step.waitForEvent("wait", { // -> the opcode below
+//		event: "exe1997-never", // never sent; times out
+//		timeout: "5s",
+//	});
+var queuedAtFixtureWaitForEvent = []*state.GeneratorOpcode{
+	{
+		Op:   enums.OpcodeWaitForEvent,
+		ID:   "daaad336276d15594d0e765f96c17cd746bf4971",
+		Name: "exe1997-never",
+		Opts: map[string]any{
+			"timeout": "5s",
+		},
+		Data:        nil,
+		Error:       nil,
+		DisplayName: new("wait"),
+		Timing:      interval.Interval{A: 0, B: 0},
+	},
+}
+
+// TestAsyncOpQueuedAtNotInheritedFromRequest is the stale-inherited-queuedAt
+// regression: each async opcode's step span must be stamped queuedAt at
+// opcode-handling time, not with the reporting request's (older) enqueue
+// time.
+func TestAsyncOpQueuedAtNotInheritedFromRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		opcodes []*state.GeneratorOpcode
+	}{
+		{name: "invoke", opcodes: queuedAtFixtureInvoke},
+		{name: "sleep", opcodes: queuedAtFixtureSleep},
+		{name: "waitforevent", opcodes: queuedAtFixtureWaitForEvent},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := runQueuedAtScenario(t, tc.opcodes)
+
+			for _, op := range tc.opcodes {
+				span := findStepSpan(sc.root, op.ID)
+				require.NotNil(t, span, "step span for opcode %s", op.ID)
+
+				queuedAt := span.GetQueuedAtTime()
+				// Stored queuedAt is millisecond-granular; truncate the anchor
+				// so sub-ms rounding can't flake the comparison.
+				assert.False(t,
+					queuedAt.Before(sc.executeStart.Truncate(time.Millisecond)),
+					"async op queuedAt (%s) must not predate opcode handling (execute started %s); inheriting the request's enqueue time (%s) is a stale-inherited-queuedAt bug",
+					queuedAt, sc.executeStart, sc.itemEnqueuedAt)
+			}
+		})
+	}
+}
+
+// queuedAtFixtureParallelInvoke is the captured parallel two-invoke scenario.
+//
+// Producing JS
+// - no preceding step: both invokes arrive as one opcode group
+// on the run's first request
+//
+//	await Promise.all([
+//		step.invoke("invoke-a", { // -> opcode [0]
+//			function: invokedChild, // -> Opts.function_id
+//			data: { testCase: "capture/parallel-invoke", childSleep: "5s" },
+//		}),
+//		step.invoke("invoke-b", { // -> opcode [1]
+//			function: invokedChild,
+//			data: { testCase: "capture/parallel-invoke", childSleep: "5s" },
+//		}),
+//	]);
+var queuedAtFixtureParallelInvoke = []*state.GeneratorOpcode{
+	{
+		Op:   enums.OpcodeInvokeFunction,
+		ID:   "017fd6c24a110fb73efa99fc93fc99a591775192",
+		Name: "",
+		Opts: map[string]any{
+			"function_id": "test-app-invoked-child",
+			"payload": map[string]any{
+				"data": map[string]any{
+					"childSleep": "5s",
+					"testCase":   "capture/parallel-invoke",
+				},
+			},
+		},
+		Data:        nil,
+		Error:       nil,
+		DisplayName: new("invoke-a"),
+		Timing:      interval.Interval{A: 0, B: 0},
+	},
+	{
+		Op:   enums.OpcodeInvokeFunction,
+		ID:   "98f8c99b8a4344641386da72ded706eacedfaf0b",
+		Name: "",
+		Opts: map[string]any{
+			"function_id": "test-app-invoked-child",
+			"payload": map[string]any{
+				"data": map[string]any{
+					"childSleep": "5s",
+					"testCase":   "capture/parallel-invoke",
+				},
+			},
+		},
+		Data:        nil,
+		Error:       nil,
+		DisplayName: new("invoke-b"),
+		Timing:      interval.Interval{A: 0, B: 0},
+	},
+}
+
+// queuedAtFixtureParallelStepPlanned is the captured parallel two-planned-steps scenario.
+//
+// Producing JS
+// - no preceding step: parallel step.run calls are first reported as planned
+// steps, one opcode group on the run's first request
+//
+//	await Promise.all([
+//		step.run("step-a", async () => "a"), // -> opcode [0] (OpcodeStepPlanned)
+//		step.run("step-b", async () => "b"), // -> opcode [1]
+//	]);
+var queuedAtFixtureParallelStepPlanned = []*state.GeneratorOpcode{
+	{
+		Op:          enums.OpcodeStepPlanned,
+		ID:          "1419522417cff8c6ddd205cc9882d16411490c09",
+		Name:        "step-a",
+		Opts:        map[string]any{},
+		Data:        nil,
+		Error:       nil,
+		DisplayName: new("step-a"),
+		Timing:      interval.Interval{A: 0, B: 0},
+	},
+	{
+		Op:          enums.OpcodeStepPlanned,
+		ID:          "fe0ff3a9f16e8030660e5c6c446c04439143a0d1",
+		Name:        "step-b",
+		Opts:        map[string]any{},
+		Data:        nil,
+		Error:       nil,
+		DisplayName: new("step-b"),
+		Timing:      interval.Interval{A: 0, B: 0},
+	},
+}
+
+// TestParallelOpcodesShareQueuedAt pins the fan-out mitigation and nets the
+// stale-inherited-queuedAt bug for the parallel handlers. It asserts BOTH
+// properties:
+//   - (a) siblings must not inherit the reporting request's enqueue time
+//     (netting the stepPlanned handler that the single-opcode test does not
+//     exercise); and
+//   - (b) opcodes arriving in one SDK response share a single queuedAt so the
+//     trace order of parallel siblings stays deterministic under the UI's
+//     stable sort.
+func TestParallelOpcodesShareQueuedAt(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		opcodes []*state.GeneratorOpcode
+	}{
+		{name: "parallel_invoke", opcodes: queuedAtFixtureParallelInvoke},
+		{name: "parallel_stepplanned", opcodes: queuedAtFixtureParallelStepPlanned},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sc := runQueuedAtScenario(t, tc.opcodes)
+			require.GreaterOrEqual(t, len(tc.opcodes), 2, "parallel fixture must carry multiple opcodes")
+
+			var first time.Time
+			for i, op := range tc.opcodes {
+				span := findStepSpan(sc.root, op.ID)
+				require.NotNil(t, span, "step span for opcode %s", op.ID)
+				queuedAt := span.GetQueuedAtTime()
+
+				// Stale-inherited-queuedAt non-inheritance net for the
+				// stepPlanned and parallel-invoke handlers (the single-opcode
+				// test covers invoke/sleep/waitForEvent). Applies to every sibling,
+				// including index 0: pre-fix all siblings inherit the SAME
+				// stale time, so the share-queuedAt check alone would pass.
+				assert.False(t, queuedAt.Before(sc.executeStart.Truncate(time.Millisecond)),
+					"parallel op %s queuedAt (%s) must not predate opcode handling (execute started %s); inheriting the request's enqueue time (%s) is a stale-inherited-queuedAt bug",
+					op.ID, queuedAt, sc.executeStart, sc.itemEnqueuedAt)
+
+				if i == 0 {
+					first = queuedAt
+					continue
+				}
+				assert.True(t, first.Equal(queuedAt),
+					"parallel opcode %s queuedAt (%s) must equal its first sibling's (%s): opcodes in one response share one queuedAt (sibling order is goroutine-scheduling-dependent otherwise)",
+					op.ID, queuedAt, first)
+			}
+		})
+	}
+}
+
+// TestExecutionSpanKeepsItemEnqueuedAt pins the path the
+// stale-inherited-queuedAt fix must NOT change: the execution (attempt)
+// span's queuedAt is the queue item's real enqueue time — that is a genuine
+// queue wait, unlike the async-op spans'.
+func TestExecutionSpanKeepsItemEnqueuedAt(t *testing.T) {
+	sc := runQueuedAtScenario(t, queuedAtFixtureInvoke)
+
+	execSpan := findSpanByName(sc.root, meta.SpanNameExecution)
+	require.NotNil(t, execSpan, "execution span must exist")
+	require.NotNil(t, execSpan.Attributes)
+	require.NotNil(t, execSpan.Attributes.QueuedAt)
+
+	assert.Equal(t, sc.itemEnqueuedAt.UnixMilli(), execSpan.Attributes.QueuedAt.UnixMilli(),
+		"execution span queuedAt must remain the queue item's enqueue time")
+}


### PR DESCRIPTION
## Description

- When checkpointing is on, the async opcodes set their queuedAt at times based on queuedAt of their discovery span. However, other steps may execute between the start of discovery and the async opcode. This leads to displaying too long of queue times and incorrect order

invoke-child should be between step-before and step-after, and its queue time should not precede step-before

<img width="738" height="206" alt="Screenshot 2026-07-13 at 3 26 03 PM" src="https://github.com/user-attachments/assets/6429fe13-1846-4153-9d23-5eae9d699fcf" />

- We adjust the queuedAt of invoke-child's queued at instead. This fixes queueing and ordering

<img width="738" height="206" alt="Screenshot 2026-07-13 at 3 27 06 PM" src="https://github.com/user-attachments/assets/88bd29f2-cc4f-457f-bc30-d7580194407f" />

- We make our change server-side in the executor. This applies to our async opcodes: invoke, sleep, waitForEvent, waitForSignal, and Promise.all
  - Promise.all doesn't suffer from the same bug before this change, due to the overwrites we perform. We adjust it anyway for consistency.
- We introduce testing at the opcode -> trace layer to validate our change and prevent regressions

## Release note

Fix the ordering and display of queueing delay for invoke, sleep, waitForEvent, waitForSignal, and Promise.all when checkpointing is on

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
