### PR TITLE
fix(experiments): rename "Experiments List Viewed" tracking event to singular for naming consistency

### DIFF
--- a/ui/apps/dashboard/src/components/Experiments/tracking.ts
+++ b/ui/apps/dashboard/src/components/Experiments/tracking.ts
@@ -8,7 +8,7 @@ import type { ScoreKind } from '@inngest/components/Experiments';
  */
 
 type ExperimentEventName =
-  | 'Experiments List Viewed'
+  | 'Experiment List Viewed'
   | 'Experiment Detail Viewed'
   | 'Experiment Opened In Insights'
   | 'Experiment Scoring Weight Updated'
@@ -57,7 +57,7 @@ export function trackExperimentsListViewed({
   experimentCount: number;
   functionCount: number;
 }) {
-  trackExperimentsEvent('Experiments List Viewed', {
+  trackExperimentsEvent('Experiment List Viewed', {
     experiment_count: experimentCount,
     function_count: functionCount,
     has_experiments: experimentCount > 0,


### PR DESCRIPTION
## Description

Normalize Experiment event naming (remove plural) 

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
