### PR TITLE
feat(queue): route RequeueByJobID through producer

### DIFF
--- a/pkg/execution/cron/manager_test.go
+++ b/pkg/execution/cron/manager_test.go
@@ -679,7 +679,7 @@ func (p *captureProducer) Requeue(context.Context, string, queue.QueueItem, time
 	return nil
 }
 
-func (p *captureProducer) RequeueByJobID(context.Context, string, string, time.Time) error {
+func (p *captureProducer) RequeueByJobID(context.Context, queue.Scope, string, string, time.Time) error {
 	return nil
 }
 

--- a/pkg/execution/debounce/debounce.go
+++ b/pkg/execution/debounce/debounce.go
@@ -1008,8 +1008,10 @@ func (d debouncer) updateDebounce(ctx context.Context, di DebounceItem, fn innge
 		// Debounces should have a maximum timeout;  updating the debounce returns
 		// the timeout to use.
 		actualTTL := time.Second * time.Duration(newTTL)
-		err = queueShard.RequeueByJobID(
+		err = d.queue.RequeueByJobID(
 			ctx,
+			scopeForDebounceItem(di),
+			queueShard.Name(),
 			debounceID.String(),
 			now.Add(actualTTL).Add(buffer).Add(time.Second),
 		)
@@ -1225,8 +1227,10 @@ func (d debouncer) RunDebounce(ctx context.Context, opts RunDebounceOpts) (*RunD
 	}
 
 	// Requeue the debounce to run in 1 second
-	err = queueShard.RequeueByJobID(
+	err = d.queue.RequeueByJobID(
 		ctx,
+		scope,
+		queueShard.Name(),
 		debounceID.String(),
 		time.Now().Add(time.Second),
 	)

--- a/pkg/execution/queue/consumer.go
+++ b/pkg/execution/queue/consumer.go
@@ -6,7 +6,7 @@ type queueConsumer struct {
 	shards QueueShardRegistry
 }
 
-func newQueueConsumer(shards QueueShardRegistry) Consumer {
+func NewConsumer(shards QueueShardRegistry) Consumer {
 	return &queueConsumer{shards: shards}
 }
 

--- a/pkg/execution/queue/convert.go
+++ b/pkg/execution/queue/convert.go
@@ -90,6 +90,44 @@ func QueueItemFromProto(msg *pb.QueueItem) (QueueItem, error) {
 	return item, nil
 }
 
+func ScopeToProto(scope Scope) *pb.Scope {
+	return &pb.Scope{
+		IsSystem:   scope.IsSystem,
+		AccountId:  scope.AccountID.String(),
+		EnvId:      scope.EnvID.String(),
+		FunctionId: scope.FunctionID.String(),
+	}
+}
+
+func ScopeFromProto(msg *pb.Scope) (Scope, error) {
+	if msg == nil {
+		return Scope{}, fmt.Errorf("scope is required")
+	}
+
+	scope := Scope{IsSystem: msg.GetIsSystem()}
+	if scope.IsSystem {
+		return scope, nil
+	}
+
+	accountID, err := parseUUID(msg.GetAccountId(), "scope account_id")
+	if err != nil {
+		return Scope{}, err
+	}
+	envID, err := parseUUID(msg.GetEnvId(), "scope env_id")
+	if err != nil {
+		return Scope{}, err
+	}
+	functionID, err := parseUUID(msg.GetFunctionId(), "scope function_id")
+	if err != nil {
+		return Scope{}, err
+	}
+
+	scope.AccountID = accountID
+	scope.EnvID = envID
+	scope.FunctionID = functionID
+	return scope, nil
+}
+
 func ItemToProto(item Item) (*pb.Item, error) {
 	identifier, err := IdentifierToProto(item.Identifier)
 	if err != nil {

--- a/pkg/execution/queue/convert.go
+++ b/pkg/execution/queue/convert.go
@@ -105,10 +105,6 @@ func ScopeFromProto(msg *pb.Scope) (Scope, error) {
 	}
 
 	scope := Scope{IsSystem: msg.GetIsSystem()}
-	if scope.IsSystem {
-		return scope, nil
-	}
-
 	accountID, err := parseUUID(msg.GetAccountId(), "scope account_id")
 	if err != nil {
 		return Scope{}, err

--- a/pkg/execution/queue/convert_test.go
+++ b/pkg/execution/queue/convert_test.go
@@ -173,6 +173,254 @@ func TestQueueItemProtoRoundTrip(t *testing.T) {
 	assertItemEqual(t, original.Data, roundTripped.Data)
 }
 
+func TestScopeProtoConversion(t *testing.T) {
+	accountID := uuid.New()
+	envID := uuid.New()
+	functionID := uuid.New()
+
+	tests := []struct {
+		name string
+		msg  *pb.Scope
+		want Scope
+	}{
+		{
+			name: "user scope",
+			msg: &pb.Scope{
+				AccountId:  accountID.String(),
+				EnvId:      envID.String(),
+				FunctionId: functionID.String(),
+			},
+			want: Scope{
+				AccountID:  accountID,
+				EnvID:      envID,
+				FunctionID: functionID,
+			},
+		},
+		{
+			name: "system scope preserves ids",
+			msg: &pb.Scope{
+				IsSystem:   true,
+				AccountId:  accountID.String(),
+				EnvId:      envID.String(),
+				FunctionId: functionID.String(),
+			},
+			want: Scope{
+				IsSystem:   true,
+				AccountID:  accountID,
+				EnvID:      envID,
+				FunctionID: functionID,
+			},
+		},
+		{
+			name: "system scope false with ids",
+			msg: &pb.Scope{
+				IsSystem:   false,
+				AccountId:  accountID.String(),
+				EnvId:      envID.String(),
+				FunctionId: functionID.String(),
+			},
+			want: Scope{
+				IsSystem:   false,
+				AccountID:  accountID,
+				EnvID:      envID,
+				FunctionID: functionID,
+			},
+		},
+		{
+			name: "system scope without ids",
+			msg: &pb.Scope{
+				IsSystem: true,
+			},
+			want: Scope{IsSystem: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scope, err := ScopeFromProto(tt.msg)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, scope)
+
+			roundTripped := ScopeToProto(scope)
+			require.Equal(t, tt.want.IsSystem, roundTripped.GetIsSystem())
+			require.Equal(t, tt.want.AccountID.String(), roundTripped.GetAccountId())
+			require.Equal(t, tt.want.EnvID.String(), roundTripped.GetEnvId())
+			require.Equal(t, tt.want.FunctionID.String(), roundTripped.GetFunctionId())
+		})
+	}
+}
+
+func TestScopeToProto(t *testing.T) {
+	accountID := uuid.New()
+	envID := uuid.New()
+	functionID := uuid.New()
+
+	tests := []struct {
+		name string
+		give Scope
+		want *pb.Scope
+	}{
+		{
+			name: "valid ids",
+			give: Scope{
+				AccountID:  accountID,
+				EnvID:      envID,
+				FunctionID: functionID,
+			},
+			want: &pb.Scope{
+				AccountId:  accountID.String(),
+				EnvId:      envID.String(),
+				FunctionId: functionID.String(),
+			},
+		},
+		{
+			name: "unset ids",
+			give: Scope{},
+			want: &pb.Scope{
+				AccountId:  uuid.Nil.String(),
+				EnvId:      uuid.Nil.String(),
+				FunctionId: uuid.Nil.String(),
+			},
+		},
+		{
+			name: "nil ids",
+			give: Scope{
+				AccountID:  uuid.Nil,
+				EnvID:      uuid.Nil,
+				FunctionID: uuid.Nil,
+			},
+			want: &pb.Scope{
+				AccountId:  uuid.Nil.String(),
+				EnvId:      uuid.Nil.String(),
+				FunctionId: uuid.Nil.String(),
+			},
+		},
+		{
+			name: "system with unset ids",
+			give: Scope{IsSystem: true},
+			want: &pb.Scope{
+				IsSystem:   true,
+				AccountId:  uuid.Nil.String(),
+				EnvId:      uuid.Nil.String(),
+				FunctionId: uuid.Nil.String(),
+			},
+		},
+		{
+			name: "system with nil ids",
+			give: Scope{
+				IsSystem:   true,
+				AccountID:  uuid.Nil,
+				EnvID:      uuid.Nil,
+				FunctionID: uuid.Nil,
+			},
+			want: &pb.Scope{
+				IsSystem:   true,
+				AccountId:  uuid.Nil.String(),
+				EnvId:      uuid.Nil.String(),
+				FunctionId: uuid.Nil.String(),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ScopeToProto(tt.give))
+		})
+	}
+}
+
+func TestScopeFromProto(t *testing.T) {
+	accountID := uuid.New()
+	envID := uuid.New()
+	functionID := uuid.New()
+
+	tests := []struct {
+		name    string
+		msg     *pb.Scope
+		want    Scope
+		wantErr string
+	}{
+		{
+			name: "valid user scope",
+			msg: &pb.Scope{
+				AccountId:  accountID.String(),
+				EnvId:      envID.String(),
+				FunctionId: functionID.String(),
+			},
+			want: Scope{
+				AccountID:  accountID,
+				EnvID:      envID,
+				FunctionID: functionID,
+			},
+		},
+		{
+			name: "valid system scope without ids",
+			msg: &pb.Scope{
+				IsSystem: true,
+			},
+			want: Scope{
+				IsSystem: true,
+			},
+		},
+		{
+			name: "valid system scope with ids",
+			msg: &pb.Scope{
+				IsSystem:   true,
+				AccountId:  accountID.String(),
+				EnvId:      envID.String(),
+				FunctionId: functionID.String(),
+			},
+			want: Scope{
+				IsSystem:   true,
+				AccountID:  accountID,
+				EnvID:      envID,
+				FunctionID: functionID,
+			},
+		},
+		{
+			name: "invalid account id",
+			msg: &pb.Scope{
+				AccountId: "bad",
+			},
+			wantErr: "scope account_id",
+		},
+		{
+			name: "invalid env id",
+			msg: &pb.Scope{
+				EnvId: "bad",
+			},
+			wantErr: "scope env_id",
+		},
+		{
+			name: "invalid function id",
+			msg: &pb.Scope{
+				FunctionId: "bad",
+			},
+			wantErr: "scope function_id",
+		},
+		{
+			name: "invalid system scope account id",
+			msg: &pb.Scope{
+				IsSystem:  true,
+				AccountId: "bad",
+			},
+			wantErr: "scope account_id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ScopeFromProto(tt.msg)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // TestItemProtoRoundTrip_NilOptionalFields guards nil optional fields so the
 // proxy does not materialize absent queue data as non-nil zero values.
 func TestItemProtoRoundTrip_NilOptionalFields(t *testing.T) {

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -71,7 +71,7 @@ func New(
 			WithProducerJobPromotion(o.enableJobPromotion),
 			WithProducerConditionalTracer(o.ConditionalTracer),
 		),
-		Consumer:        newQueueConsumer(shards),
+		Consumer:        NewConsumer(shards),
 		JobQueueReader:  newJobQueueReader(shards, o.AccountShardIterationEnabled),
 		Migrator:        newQueueMigrator(shards, o.Clock),
 		Unpauser:        newQueueUnpauser(shards),

--- a/pkg/execution/queue/processor.go
+++ b/pkg/execution/queue/processor.go
@@ -64,12 +64,12 @@ func New(
 		quit:         make(chan error, o.numWorkers),
 
 		shards: shards,
-		Producer: newProducer(
+		Producer: NewProducer(
 			shards,
-			withProducerClock(o.Clock),
-			withProducerKindToQueueMapping(o.queueKindMapping),
-			withProducerJobPromotion(o.enableJobPromotion),
-			withProducerConditionalTracer(o.ConditionalTracer),
+			WithProducerClock(o.Clock),
+			WithProducerKindToQueueMapping(o.queueKindMapping),
+			WithProducerJobPromotion(o.enableJobPromotion),
+			WithProducerConditionalTracer(o.ConditionalTracer),
 		),
 		Consumer:        newQueueConsumer(shards),
 		JobQueueReader:  newJobQueueReader(shards, o.AccountShardIterationEnabled),

--- a/pkg/execution/queue/processor_test.go
+++ b/pkg/execution/queue/processor_test.go
@@ -24,7 +24,7 @@ func (m *mockProducer) Requeue(context.Context, string, QueueItem, time.Time, ..
 	return nil
 }
 
-func (m *mockProducer) RequeueByJobID(context.Context, string, string, time.Time) error {
+func (m *mockProducer) RequeueByJobID(context.Context, Scope, string, string, time.Time) error {
 	return nil
 }
 

--- a/pkg/execution/queue/producer.go
+++ b/pkg/execution/queue/producer.go
@@ -18,10 +18,20 @@ type queueProducer struct {
 
 type producerOpt func(*queueProducer)
 
+type ProducerOpt = producerOpt
+
+func WithProducerClock(clock clockwork.Clock) ProducerOpt {
+	return withProducerClock(clock)
+}
+
 func withProducerClock(clock clockwork.Clock) producerOpt {
 	return func(q *queueProducer) {
 		q.clock = clock
 	}
+}
+
+func WithProducerKindToQueueMapping(mapping map[string]string) ProducerOpt {
+	return withProducerKindToQueueMapping(mapping)
 }
 
 func withProducerKindToQueueMapping(mapping map[string]string) producerOpt {
@@ -30,10 +40,18 @@ func withProducerKindToQueueMapping(mapping map[string]string) producerOpt {
 	}
 }
 
+func WithProducerJobPromotion(enable bool) ProducerOpt {
+	return withProducerJobPromotion(enable)
+}
+
 func withProducerJobPromotion(enable bool) producerOpt {
 	return func(q *queueProducer) {
 		q.enableJobPromotion = enable
 	}
+}
+
+func WithProducerConditionalTracer(tracer trace.ConditionalTracer) ProducerOpt {
+	return withProducerConditionalTracer(tracer)
 }
 
 func withProducerConditionalTracer(tracer trace.ConditionalTracer) producerOpt {
@@ -42,9 +60,9 @@ func withProducerConditionalTracer(tracer trace.ConditionalTracer) producerOpt {
 	}
 }
 
-func newProducer(
+func NewProducer(
 	shards ShardRegistry,
-	opts ...producerOpt,
+	opts ...ProducerOpt,
 ) Producer {
 	q := &queueProducer{
 		clock:             clockwork.NewRealClock(),

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -69,6 +69,10 @@ type Producer interface {
 	Enqueue(context.Context, Item, time.Time, EnqueueOpts) error
 
 	Requeue(ctx context.Context, shardName string, i QueueItem, at time.Time, opts ...RequeueOptionFn) error
+
+	// RequeueByJobID reschedules an outstanding, unleased job by ID on the
+	// named shard. scope must identify the job's tenant/function namespace and
+	// must include account, environment, and function IDs.
 	RequeueByJobID(ctx context.Context, scope Scope, shardName string, jobID string, at time.Time) error
 }
 

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -69,7 +69,7 @@ type Producer interface {
 	Enqueue(context.Context, Item, time.Time, EnqueueOpts) error
 
 	Requeue(ctx context.Context, shardName string, i QueueItem, at time.Time, opts ...RequeueOptionFn) error
-	RequeueByJobID(ctx context.Context, shardName string, jobID string, at time.Time) error
+	RequeueByJobID(ctx context.Context, scope Scope, shardName string, jobID string, at time.Time) error
 }
 
 type Consumer interface {

--- a/pkg/execution/queue/requeue.go
+++ b/pkg/execution/queue/requeue.go
@@ -15,9 +15,11 @@ func (q *queueProducer) Requeue(ctx context.Context, shardName string, i QueueIt
 }
 
 // RequeueByJobID requires scope to include account, environment, and function
-// IDs. The scope is validated before dispatching to the shard so callers cannot
-// accidentally requeue by ID without tenant/function context.
-// Scope is not used for shard selection; shardName always selects the shard.
+// IDs, preserving the producer interface contract used by wrappers. This
+// producer does not use scope for lookup or shard selection: shardName selects
+// the shard and jobID identifies the item within that shard. Other producer
+// implementations, such as Cloud rollout wrappers, may use scope before
+// delegating for account-level feature flag or routing decisions.
 func (q *queueProducer) RequeueByJobID(ctx context.Context, scope Scope, shardName string, jobID string, at time.Time) error {
 	if err := scope.ValidateIDs(); err != nil {
 		return err

--- a/pkg/execution/queue/requeue.go
+++ b/pkg/execution/queue/requeue.go
@@ -14,8 +14,12 @@ func (q *queueProducer) Requeue(ctx context.Context, shardName string, i QueueIt
 	return shard.Requeue(ctx, i, at, opts...)
 }
 
+// RequeueByJobID requires scope to include account, environment, and function
+// IDs. The scope is validated before dispatching to the shard so callers cannot
+// accidentally requeue by ID without tenant/function context.
+// Scope is not used for shard selection; shardName always selects the shard.
 func (q *queueProducer) RequeueByJobID(ctx context.Context, scope Scope, shardName string, jobID string, at time.Time) error {
-	if err := scope.Validate(); err != nil {
+	if err := scope.ValidateIDs(); err != nil {
 		return err
 	}
 

--- a/pkg/execution/queue/requeue.go
+++ b/pkg/execution/queue/requeue.go
@@ -14,7 +14,11 @@ func (q *queueProducer) Requeue(ctx context.Context, shardName string, i QueueIt
 	return shard.Requeue(ctx, i, at, opts...)
 }
 
-func (q *queueProducer) RequeueByJobID(ctx context.Context, shardName string, jobID string, at time.Time) error {
+func (q *queueProducer) RequeueByJobID(ctx context.Context, scope Scope, shardName string, jobID string, at time.Time) error {
+	if err := scope.Validate(); err != nil {
+		return err
+	}
+
 	shard, err := q.shards.ByName(shardName)
 	if err != nil {
 		return err

--- a/pkg/execution/queue/requeue_test.go
+++ b/pkg/execution/queue/requeue_test.go
@@ -1,0 +1,58 @@
+package queue
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProducerRequeueByJobIDRejectsInvalidScope(t *testing.T) {
+	ctx := context.Background()
+	shard := &mockShardForIterator{name: "shard-a"}
+	registry, err := NewSingleShardRegistry(shard)
+	require.NoError(t, err)
+
+	producer, err := New(ctx, "test", registry)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		scope   Scope
+		wantErr string
+	}{
+		{
+			name:    "missing account ID",
+			scope:   Scope{EnvID: uuid.New(), FunctionID: uuid.New()},
+			wantErr: "missing account ID",
+		},
+		{
+			name:    "missing env ID",
+			scope:   Scope{AccountID: uuid.New(), FunctionID: uuid.New()},
+			wantErr: "missing env ID",
+		},
+		{
+			name:    "missing function ID",
+			scope:   Scope{AccountID: uuid.New(), EnvID: uuid.New()},
+			wantErr: "missing function ID",
+		},
+		{
+			name:    "missing all IDs",
+			scope:   Scope{},
+			wantErr: "missing account ID",
+		},
+	}
+
+	for _, isSystem := range []bool{true, false} {
+		for _, tt := range tests {
+			t.Run(fmt.Sprintf("%s/system=%t", tt.name, isSystem), func(t *testing.T) {
+				tt.scope.IsSystem = isSystem
+				err := producer.RequeueByJobID(ctx, tt.scope, shard.Name(), "job-id", time.Now())
+				require.EqualError(t, err, tt.wantErr)
+			})
+		}
+	}
+}

--- a/pkg/execution/queue/scope.go
+++ b/pkg/execution/queue/scope.go
@@ -14,10 +14,20 @@ type Scope struct {
 	FunctionID uuid.UUID
 }
 
+// Validate checks whether the scope is valid for general queue operations.
+// System scopes are queue-name scoped and may omit tenant/function IDs; non-system
+// scopes must include account, environment, and function IDs.
 func (s Scope) Validate() error {
 	if s.IsSystem {
 		return nil
 	}
+	return s.ValidateIDs()
+}
+
+// ValidateIDs checks that account, environment, and function IDs are all set.
+// Use this for APIs that always require tenant/function context, even when the
+// scope is marked as system.
+func (s Scope) ValidateIDs() error {
 	if s.AccountID == uuid.Nil {
 		return fmt.Errorf("missing account ID")
 	}

--- a/pkg/execution/queue/scope_test.go
+++ b/pkg/execution/queue/scope_test.go
@@ -1,0 +1,128 @@
+package queue
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScopeValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		scope   Scope
+		wantErr string
+	}{
+		{
+			name: "valid user scope",
+			scope: Scope{
+				AccountID:  uuid.New(),
+				EnvID:      uuid.New(),
+				FunctionID: uuid.New(),
+			},
+		},
+		{
+			name:  "system scope allows missing ids",
+			scope: Scope{IsSystem: true},
+		},
+		{
+			name: "system scope allows missing accountID",
+			scope: Scope{
+				IsSystem:   true,
+				EnvID:      uuid.New(),
+				FunctionID: uuid.New(),
+			},
+		},
+		{
+			name: "system scope allows missing envID",
+			scope: Scope{
+				IsSystem:   true,
+				AccountID:  uuid.New(),
+				FunctionID: uuid.New(),
+			},
+		},
+		{
+			name: "system scope allows missing functionID",
+			scope: Scope{
+				IsSystem:  true,
+				AccountID: uuid.New(),
+				EnvID:     uuid.New(),
+			},
+		},
+		{
+			name:    "missing account id",
+			scope:   Scope{EnvID: uuid.New(), FunctionID: uuid.New()},
+			wantErr: "missing account ID",
+		},
+		{
+			name:    "missing env id",
+			scope:   Scope{AccountID: uuid.New(), FunctionID: uuid.New()},
+			wantErr: "missing env ID",
+		},
+		{
+			name:    "missing function id",
+			scope:   Scope{AccountID: uuid.New(), EnvID: uuid.New()},
+			wantErr: "missing function ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.scope.Validate()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestScopeValidateIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		scope   Scope
+		wantErr string
+	}{
+		{
+			name: "valid ids",
+			scope: Scope{
+				AccountID:  uuid.New(),
+				EnvID:      uuid.New(),
+				FunctionID: uuid.New(),
+			},
+		},
+		{
+			name:    "missing account id",
+			scope:   Scope{EnvID: uuid.New(), FunctionID: uuid.New()},
+			wantErr: "missing account ID",
+		},
+		{
+			name:    "missing env id",
+			scope:   Scope{AccountID: uuid.New(), FunctionID: uuid.New()},
+			wantErr: "missing env ID",
+		},
+		{
+			name:    "missing function id",
+			scope:   Scope{AccountID: uuid.New(), EnvID: uuid.New()},
+			wantErr: "missing function ID",
+		},
+	}
+
+	for _, tt := range tests {
+		for _, isSystem := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/system=%t", tt.name, isSystem), func(t *testing.T) {
+				scope := tt.scope
+				scope.IsSystem = isSystem
+
+				err := scope.ValidateIDs()
+				if tt.wantErr != "" {
+					require.ErrorContains(t, err, tt.wantErr)
+					return
+				}
+				require.NoError(t, err)
+			})
+		}
+	}
+}

--- a/pkg/execution/state/redis_state/queue.go
+++ b/pkg/execution/state/redis_state/queue.go
@@ -788,6 +788,9 @@ func (q *queue) RequeueByJobID(ctx context.Context, jobID string, at time.Time) 
 	// Find the queue item so that we can fetch the shard info.
 	i := osqueue.QueueItem{}
 	if err := q.RedisClient.unshardedRc.Do(ctx, q.RedisClient.unshardedRc.B().Hget().Key(q.RedisClient.kg.QueueItem()).Field(jobID).Build()).DecodeJSON(&i); err != nil {
+		if err == rueidis.Nil {
+			return osqueue.ErrQueueItemNotFound
+		}
 		return err
 	}
 

--- a/pkg/execution/state/redis_state/queue_test.go
+++ b/pkg/execution/state/redis_state/queue_test.go
@@ -1915,7 +1915,7 @@ func TestQueueRequeueByJobID(t *testing.T) {
 			require.NoError(t, err)
 
 			err = shard.RequeueByJobID(ctx, "no bruv", time.Now().Add(5*time.Second))
-			require.NotNil(t, err)
+			require.ErrorIs(t, err, osqueue.ErrQueueItemNotFound)
 		})
 
 		t.Run("It fails if the job is leased", func(t *testing.T) {

--- a/proto/gen/queue/v1/producer.pb.go
+++ b/proto/gen/queue/v1/producer.pb.go
@@ -220,6 +220,7 @@ type RequeueByJobIDRequest struct {
 	ShardName     string                 `protobuf:"bytes,1,opt,name=shard_name,json=shardName,proto3" json:"shard_name,omitempty"`
 	JobId         string                 `protobuf:"bytes,2,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`
 	At            *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=at,proto3" json:"at,omitempty"`
+	Scope         *Scope                 `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -271,6 +272,13 @@ func (x *RequeueByJobIDRequest) GetJobId() string {
 func (x *RequeueByJobIDRequest) GetAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.At
+	}
+	return nil
+}
+
+func (x *RequeueByJobIDRequest) GetScope() *Scope {
+	if x != nil {
+		return x.Scope
 	}
 	return nil
 }
@@ -394,12 +402,13 @@ const file_queue_v1_producer_proto_rawDesc = "" +
 	"shard_name\x18\x01 \x01(\tR\tshardName\x12'\n" +
 	"\x04item\x18\x02 \x01(\v2\x13.queue.v1.QueueItemR\x04item\x12*\n" +
 	"\x02at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x02at\"\x11\n" +
-	"\x0fRequeueResponse\"y\n" +
+	"\x0fRequeueResponse\"\xa0\x01\n" +
 	"\x15RequeueByJobIDRequest\x12\x1d\n" +
 	"\n" +
 	"shard_name\x18\x01 \x01(\tR\tshardName\x12\x15\n" +
 	"\x06job_id\x18\x02 \x01(\tR\x05jobId\x12*\n" +
-	"\x02at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x02at\"\x18\n" +
+	"\x02at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\x02at\x12%\n" +
+	"\x05scope\x18\x04 \x01(\v2\x0f.queue.v1.ScopeR\x05scope\"\x18\n" +
 	"\x16RequeueByJobIDResponse\"\x94\x02\n" +
 	"\x0eEnqueueOptions\x12,\n" +
 	"\x12passthrough_job_id\x18\x01 \x01(\bR\x10passthroughJobId\x123\n" +
@@ -436,7 +445,8 @@ var file_queue_v1_producer_proto_goTypes = []any{
 	(*Item)(nil),                   // 7: queue.v1.Item
 	(*timestamppb.Timestamp)(nil),  // 8: google.protobuf.Timestamp
 	(*QueueItem)(nil),              // 9: queue.v1.QueueItem
-	(*durationpb.Duration)(nil),    // 10: google.protobuf.Duration
+	(*Scope)(nil),                  // 10: queue.v1.Scope
+	(*durationpb.Duration)(nil),    // 11: google.protobuf.Duration
 }
 var file_queue_v1_producer_proto_depIdxs = []int32{
 	7,  // 0: queue.v1.EnqueueRequest.item:type_name -> queue.v1.Item
@@ -445,18 +455,19 @@ var file_queue_v1_producer_proto_depIdxs = []int32{
 	9,  // 3: queue.v1.RequeueRequest.item:type_name -> queue.v1.QueueItem
 	8,  // 4: queue.v1.RequeueRequest.at:type_name -> google.protobuf.Timestamp
 	8,  // 5: queue.v1.RequeueByJobIDRequest.at:type_name -> google.protobuf.Timestamp
-	10, // 6: queue.v1.EnqueueOptions.idempotency_period:type_name -> google.protobuf.Duration
-	0,  // 7: queue.v1.ProducerService.Enqueue:input_type -> queue.v1.EnqueueRequest
-	2,  // 8: queue.v1.ProducerService.Requeue:input_type -> queue.v1.RequeueRequest
-	4,  // 9: queue.v1.ProducerService.RequeueByJobID:input_type -> queue.v1.RequeueByJobIDRequest
-	1,  // 10: queue.v1.ProducerService.Enqueue:output_type -> queue.v1.EnqueueResponse
-	3,  // 11: queue.v1.ProducerService.Requeue:output_type -> queue.v1.RequeueResponse
-	5,  // 12: queue.v1.ProducerService.RequeueByJobID:output_type -> queue.v1.RequeueByJobIDResponse
-	10, // [10:13] is the sub-list for method output_type
-	7,  // [7:10] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	10, // 6: queue.v1.RequeueByJobIDRequest.scope:type_name -> queue.v1.Scope
+	11, // 7: queue.v1.EnqueueOptions.idempotency_period:type_name -> google.protobuf.Duration
+	0,  // 8: queue.v1.ProducerService.Enqueue:input_type -> queue.v1.EnqueueRequest
+	2,  // 9: queue.v1.ProducerService.Requeue:input_type -> queue.v1.RequeueRequest
+	4,  // 10: queue.v1.ProducerService.RequeueByJobID:input_type -> queue.v1.RequeueByJobIDRequest
+	1,  // 11: queue.v1.ProducerService.Enqueue:output_type -> queue.v1.EnqueueResponse
+	3,  // 12: queue.v1.ProducerService.Requeue:output_type -> queue.v1.RequeueResponse
+	5,  // 13: queue.v1.ProducerService.RequeueByJobID:output_type -> queue.v1.RequeueByJobIDResponse
+	11, // [11:14] is the sub-list for method output_type
+	8,  // [8:11] is the sub-list for method input_type
+	8,  // [8:8] is the sub-list for extension type_name
+	8,  // [8:8] is the sub-list for extension extendee
+	0,  // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_queue_v1_producer_proto_init() }

--- a/proto/gen/queue/v1/types.pb.go
+++ b/proto/gen/queue/v1/types.pb.go
@@ -235,6 +235,74 @@ func (x *QueueItem) GetCapacityLease() *CapacityLease {
 	return nil
 }
 
+type Scope struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	IsSystem      bool                   `protobuf:"varint,1,opt,name=is_system,json=isSystem,proto3" json:"is_system,omitempty"`
+	AccountId     string                 `protobuf:"bytes,2,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	EnvId         string                 `protobuf:"bytes,3,opt,name=env_id,json=envId,proto3" json:"env_id,omitempty"`
+	FunctionId    string                 `protobuf:"bytes,4,opt,name=function_id,json=functionId,proto3" json:"function_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Scope) Reset() {
+	*x = Scope{}
+	mi := &file_queue_v1_types_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Scope) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Scope) ProtoMessage() {}
+
+func (x *Scope) ProtoReflect() protoreflect.Message {
+	mi := &file_queue_v1_types_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Scope.ProtoReflect.Descriptor instead.
+func (*Scope) Descriptor() ([]byte, []int) {
+	return file_queue_v1_types_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *Scope) GetIsSystem() bool {
+	if x != nil {
+		return x.IsSystem
+	}
+	return false
+}
+
+func (x *Scope) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *Scope) GetEnvId() string {
+	if x != nil {
+		return x.EnvId
+	}
+	return ""
+}
+
+func (x *Scope) GetFunctionId() string {
+	if x != nil {
+		return x.FunctionId
+	}
+	return ""
+}
+
 type CapacityLease struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	LeaseId       string                 `protobuf:"bytes,1,opt,name=lease_id,json=leaseId,proto3" json:"lease_id,omitempty"`
@@ -245,7 +313,7 @@ type CapacityLease struct {
 
 func (x *CapacityLease) Reset() {
 	*x = CapacityLease{}
-	mi := &file_queue_v1_types_proto_msgTypes[1]
+	mi := &file_queue_v1_types_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -257,7 +325,7 @@ func (x *CapacityLease) String() string {
 func (*CapacityLease) ProtoMessage() {}
 
 func (x *CapacityLease) ProtoReflect() protoreflect.Message {
-	mi := &file_queue_v1_types_proto_msgTypes[1]
+	mi := &file_queue_v1_types_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -270,7 +338,7 @@ func (x *CapacityLease) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CapacityLease.ProtoReflect.Descriptor instead.
 func (*CapacityLease) Descriptor() ([]byte, []int) {
-	return file_queue_v1_types_proto_rawDescGZIP(), []int{1}
+	return file_queue_v1_types_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *CapacityLease) GetLeaseId() string {
@@ -313,7 +381,7 @@ type Item struct {
 
 func (x *Item) Reset() {
 	*x = Item{}
-	mi := &file_queue_v1_types_proto_msgTypes[2]
+	mi := &file_queue_v1_types_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -325,7 +393,7 @@ func (x *Item) String() string {
 func (*Item) ProtoMessage() {}
 
 func (x *Item) ProtoReflect() protoreflect.Message {
-	mi := &file_queue_v1_types_proto_msgTypes[2]
+	mi := &file_queue_v1_types_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -338,7 +406,7 @@ func (x *Item) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Item.ProtoReflect.Descriptor instead.
 func (*Item) Descriptor() ([]byte, []int) {
-	return file_queue_v1_types_proto_rawDescGZIP(), []int{2}
+	return file_queue_v1_types_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *Item) GetJobId() string {
@@ -490,7 +558,7 @@ type Identifier struct {
 
 func (x *Identifier) Reset() {
 	*x = Identifier{}
-	mi := &file_queue_v1_types_proto_msgTypes[3]
+	mi := &file_queue_v1_types_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -502,7 +570,7 @@ func (x *Identifier) String() string {
 func (*Identifier) ProtoMessage() {}
 
 func (x *Identifier) ProtoReflect() protoreflect.Message {
-	mi := &file_queue_v1_types_proto_msgTypes[3]
+	mi := &file_queue_v1_types_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -515,7 +583,7 @@ func (x *Identifier) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Identifier.ProtoReflect.Descriptor instead.
 func (*Identifier) Descriptor() ([]byte, []int) {
-	return file_queue_v1_types_proto_rawDescGZIP(), []int{3}
+	return file_queue_v1_types_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *Identifier) GetRunId() string {
@@ -635,7 +703,7 @@ type CustomConcurrency struct {
 
 func (x *CustomConcurrency) Reset() {
 	*x = CustomConcurrency{}
-	mi := &file_queue_v1_types_proto_msgTypes[4]
+	mi := &file_queue_v1_types_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -647,7 +715,7 @@ func (x *CustomConcurrency) String() string {
 func (*CustomConcurrency) ProtoMessage() {}
 
 func (x *CustomConcurrency) ProtoReflect() protoreflect.Message {
-	mi := &file_queue_v1_types_proto_msgTypes[4]
+	mi := &file_queue_v1_types_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -660,7 +728,7 @@ func (x *CustomConcurrency) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CustomConcurrency.ProtoReflect.Descriptor instead.
 func (*CustomConcurrency) Descriptor() ([]byte, []int) {
-	return file_queue_v1_types_proto_rawDescGZIP(), []int{4}
+	return file_queue_v1_types_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *CustomConcurrency) GetKey() string {
@@ -703,7 +771,7 @@ type Semaphore struct {
 
 func (x *Semaphore) Reset() {
 	*x = Semaphore{}
-	mi := &file_queue_v1_types_proto_msgTypes[5]
+	mi := &file_queue_v1_types_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -715,7 +783,7 @@ func (x *Semaphore) String() string {
 func (*Semaphore) ProtoMessage() {}
 
 func (x *Semaphore) ProtoReflect() protoreflect.Message {
-	mi := &file_queue_v1_types_proto_msgTypes[5]
+	mi := &file_queue_v1_types_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -728,7 +796,7 @@ func (x *Semaphore) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Semaphore.ProtoReflect.Descriptor instead.
 func (*Semaphore) Descriptor() ([]byte, []int) {
-	return file_queue_v1_types_proto_rawDescGZIP(), []int{5}
+	return file_queue_v1_types_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *Semaphore) GetId() string {
@@ -775,7 +843,7 @@ type RunInfo struct {
 
 func (x *RunInfo) Reset() {
 	*x = RunInfo{}
-	mi := &file_queue_v1_types_proto_msgTypes[6]
+	mi := &file_queue_v1_types_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -787,7 +855,7 @@ func (x *RunInfo) String() string {
 func (*RunInfo) ProtoMessage() {}
 
 func (x *RunInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_queue_v1_types_proto_msgTypes[6]
+	mi := &file_queue_v1_types_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -800,7 +868,7 @@ func (x *RunInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RunInfo.ProtoReflect.Descriptor instead.
 func (*RunInfo) Descriptor() ([]byte, []int) {
-	return file_queue_v1_types_proto_rawDescGZIP(), []int{6}
+	return file_queue_v1_types_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *RunInfo) GetLatency() *durationpb.Duration {
@@ -873,7 +941,7 @@ type Throttle struct {
 
 func (x *Throttle) Reset() {
 	*x = Throttle{}
-	mi := &file_queue_v1_types_proto_msgTypes[7]
+	mi := &file_queue_v1_types_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -885,7 +953,7 @@ func (x *Throttle) String() string {
 func (*Throttle) ProtoMessage() {}
 
 func (x *Throttle) ProtoReflect() protoreflect.Message {
-	mi := &file_queue_v1_types_proto_msgTypes[7]
+	mi := &file_queue_v1_types_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -898,7 +966,7 @@ func (x *Throttle) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Throttle.ProtoReflect.Descriptor instead.
 func (*Throttle) Descriptor() ([]byte, []int) {
-	return file_queue_v1_types_proto_rawDescGZIP(), []int{7}
+	return file_queue_v1_types_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Throttle) GetKey() string {
@@ -953,7 +1021,7 @@ type Singleton struct {
 
 func (x *Singleton) Reset() {
 	*x = Singleton{}
-	mi := &file_queue_v1_types_proto_msgTypes[8]
+	mi := &file_queue_v1_types_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -965,7 +1033,7 @@ func (x *Singleton) String() string {
 func (*Singleton) ProtoMessage() {}
 
 func (x *Singleton) ProtoReflect() protoreflect.Message {
-	mi := &file_queue_v1_types_proto_msgTypes[8]
+	mi := &file_queue_v1_types_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -978,7 +1046,7 @@ func (x *Singleton) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Singleton.ProtoReflect.Descriptor instead.
 func (*Singleton) Descriptor() ([]byte, []int) {
-	return file_queue_v1_types_proto_rawDescGZIP(), []int{8}
+	return file_queue_v1_types_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Singleton) GetKey() string {
@@ -1026,7 +1094,14 @@ const file_queue_v1_types_proto_rawDesc = "" +
 	"\t_lease_idB\r\n" +
 	"\v_queue_nameB\x15\n" +
 	"\x13_idempotency_periodB\x11\n" +
-	"\x0f_capacity_lease\"L\n" +
+	"\x0f_capacity_lease\"{\n" +
+	"\x05Scope\x12\x1b\n" +
+	"\tis_system\x18\x01 \x01(\bR\bisSystem\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x02 \x01(\tR\taccountId\x12\x15\n" +
+	"\x06env_id\x18\x03 \x01(\tR\x05envId\x12\x1f\n" +
+	"\vfunction_id\x18\x04 \x01(\tR\n" +
+	"functionId\"L\n" +
 	"\rCapacityLease\x12\x19\n" +
 	"\blease_id\x18\x01 \x01(\tR\aleaseId\x12 \n" +
 	"\fissued_at_ms\x18\x02 \x01(\x03R\n" +
@@ -1140,36 +1215,37 @@ func file_queue_v1_types_proto_rawDescGZIP() []byte {
 }
 
 var file_queue_v1_types_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_queue_v1_types_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_queue_v1_types_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_queue_v1_types_proto_goTypes = []any{
 	(SemaphoreReleaseMode)(0),   // 0: queue.v1.SemaphoreReleaseMode
 	(*QueueItem)(nil),           // 1: queue.v1.QueueItem
-	(*CapacityLease)(nil),       // 2: queue.v1.CapacityLease
-	(*Item)(nil),                // 3: queue.v1.Item
-	(*Identifier)(nil),          // 4: queue.v1.Identifier
-	(*CustomConcurrency)(nil),   // 5: queue.v1.CustomConcurrency
-	(*Semaphore)(nil),           // 6: queue.v1.Semaphore
-	(*RunInfo)(nil),             // 7: queue.v1.RunInfo
-	(*Throttle)(nil),            // 8: queue.v1.Throttle
-	(*Singleton)(nil),           // 9: queue.v1.Singleton
-	(*durationpb.Duration)(nil), // 10: google.protobuf.Duration
+	(*Scope)(nil),               // 2: queue.v1.Scope
+	(*CapacityLease)(nil),       // 3: queue.v1.CapacityLease
+	(*Item)(nil),                // 4: queue.v1.Item
+	(*Identifier)(nil),          // 5: queue.v1.Identifier
+	(*CustomConcurrency)(nil),   // 6: queue.v1.CustomConcurrency
+	(*Semaphore)(nil),           // 7: queue.v1.Semaphore
+	(*RunInfo)(nil),             // 8: queue.v1.RunInfo
+	(*Throttle)(nil),            // 9: queue.v1.Throttle
+	(*Singleton)(nil),           // 10: queue.v1.Singleton
+	(*durationpb.Duration)(nil), // 11: google.protobuf.Duration
 }
 var file_queue_v1_types_proto_depIdxs = []int32{
-	3,  // 0: queue.v1.QueueItem.data:type_name -> queue.v1.Item
-	10, // 1: queue.v1.QueueItem.idempotency_period:type_name -> google.protobuf.Duration
-	2,  // 2: queue.v1.QueueItem.capacity_lease:type_name -> queue.v1.CapacityLease
-	4,  // 3: queue.v1.Item.identifier:type_name -> queue.v1.Identifier
-	7,  // 4: queue.v1.Item.run_info:type_name -> queue.v1.RunInfo
-	8,  // 5: queue.v1.Item.throttle:type_name -> queue.v1.Throttle
-	9,  // 6: queue.v1.Item.singleton:type_name -> queue.v1.Singleton
-	5,  // 7: queue.v1.Item.custom_concurrency_keys:type_name -> queue.v1.CustomConcurrency
-	6,  // 8: queue.v1.Item.semaphores:type_name -> queue.v1.Semaphore
-	5,  // 9: queue.v1.Identifier.custom_concurrency_keys:type_name -> queue.v1.CustomConcurrency
-	6,  // 10: queue.v1.Identifier.semaphores:type_name -> queue.v1.Semaphore
+	4,  // 0: queue.v1.QueueItem.data:type_name -> queue.v1.Item
+	11, // 1: queue.v1.QueueItem.idempotency_period:type_name -> google.protobuf.Duration
+	3,  // 2: queue.v1.QueueItem.capacity_lease:type_name -> queue.v1.CapacityLease
+	5,  // 3: queue.v1.Item.identifier:type_name -> queue.v1.Identifier
+	8,  // 4: queue.v1.Item.run_info:type_name -> queue.v1.RunInfo
+	9,  // 5: queue.v1.Item.throttle:type_name -> queue.v1.Throttle
+	10, // 6: queue.v1.Item.singleton:type_name -> queue.v1.Singleton
+	6,  // 7: queue.v1.Item.custom_concurrency_keys:type_name -> queue.v1.CustomConcurrency
+	7,  // 8: queue.v1.Item.semaphores:type_name -> queue.v1.Semaphore
+	6,  // 9: queue.v1.Identifier.custom_concurrency_keys:type_name -> queue.v1.CustomConcurrency
+	7,  // 10: queue.v1.Identifier.semaphores:type_name -> queue.v1.Semaphore
 	0,  // 11: queue.v1.Semaphore.release:type_name -> queue.v1.SemaphoreReleaseMode
-	10, // 12: queue.v1.RunInfo.latency:type_name -> google.protobuf.Duration
-	10, // 13: queue.v1.RunInfo.sojourn_delay:type_name -> google.protobuf.Duration
-	2,  // 14: queue.v1.RunInfo.capacity_lease:type_name -> queue.v1.CapacityLease
+	11, // 12: queue.v1.RunInfo.latency:type_name -> google.protobuf.Duration
+	11, // 13: queue.v1.RunInfo.sojourn_delay:type_name -> google.protobuf.Duration
+	3,  // 14: queue.v1.RunInfo.capacity_lease:type_name -> queue.v1.CapacityLease
 	15, // [15:15] is the sub-list for method output_type
 	15, // [15:15] is the sub-list for method input_type
 	15, // [15:15] is the sub-list for extension type_name
@@ -1183,16 +1259,16 @@ func file_queue_v1_types_proto_init() {
 		return
 	}
 	file_queue_v1_types_proto_msgTypes[0].OneofWrappers = []any{}
-	file_queue_v1_types_proto_msgTypes[2].OneofWrappers = []any{}
 	file_queue_v1_types_proto_msgTypes[3].OneofWrappers = []any{}
-	file_queue_v1_types_proto_msgTypes[6].OneofWrappers = []any{}
+	file_queue_v1_types_proto_msgTypes[4].OneofWrappers = []any{}
+	file_queue_v1_types_proto_msgTypes[7].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_queue_v1_types_proto_rawDesc), len(file_queue_v1_types_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   9,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/proto/queue/v1/producer.proto
+++ b/proto/queue/v1/producer.proto
@@ -33,6 +33,7 @@ message RequeueByJobIDRequest {
   string shard_name = 1;
   string job_id = 2;
   google.protobuf.Timestamp at = 3;
+  Scope scope = 4;
 }
 
 message RequeueByJobIDResponse {}

--- a/proto/queue/v1/types.proto
+++ b/proto/queue/v1/types.proto
@@ -24,6 +24,13 @@ message QueueItem {
   optional CapacityLease capacity_lease = 16;
 }
 
+message Scope {
+  bool is_system = 1;
+  string account_id = 2;
+  string env_id = 3;
+  string function_id = 4;
+}
+
 message CapacityLease {
   string lease_id = 1;
   int64 issued_at_ms = 2;


### PR DESCRIPTION
## Description

 ### Summary

  - Export the queue producer constructor/options for reuse outside the queue processor.
  - Add `queue.Scope` to `Producer.RequeueByJobID`.
  - Route debounce `RequeueByJobID` calls through the producer instead of directly through the shard.

All three changes are no-op in OSS and Cloud


###  Why

  Queue proxy routing needs account/workspace/function scope to decide whether a producer operation should go through the proxy or stay local. `RequeueByJobID` previously only carried shard/job/time, so it could
  not be account feature-flagged.

  Keeping shard-level `RequeueByJobID` scope-free preserves the low-level backend primitive, while moving production callers through the producer gives routing layers enough context.



## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
