### PR TITLE
cloud: EXE-2015 create scores empty state page

### DIFF
--- a/ui/apps/dashboard/src/components/Scores/Dashboard.tsx
+++ b/ui/apps/dashboard/src/components/Scores/Dashboard.tsx
@@ -27,6 +27,7 @@ import { graphql } from '@/gql';
 import { GetAccountEntitlementsDocument, ScoreKind } from '@/gql/graphql';
 import { Legend } from './Legend';
 import { ScoreCard } from './ScoreCard';
+import { ScoresEmptyState } from './ScoresEmptyState';
 import type { ScoreSeries } from './types';
 
 const DEFAULT_DURATION = { hours: 24 };
@@ -250,6 +251,19 @@ export const ScoresDashboard = ({ envSlug }: { envSlug: string }) => {
   const isLoading = namesFetching || seriesFetching;
 
   const filterError = lookupError ?? namesError;
+
+  // Show the onboarding empty state only for a true first-run view: no scores
+  // exist AND the user hasn't narrowed the view. When they're actively
+  // filtering (function or custom time range) and get zero, the inline "No
+  // scores…" message below covers it instead.
+  const isDefaultView =
+    (selectedFns?.length ?? 0) === 0 && !start && !end && !duration;
+  const showEmptyState =
+    isDefaultView && availableScores.length === 0 && !isLoading && !namesError;
+
+  if (showEmptyState) {
+    return <ScoresEmptyState />;
+  }
 
   return (
     <div className="flex min-h-0 w-full flex-1 flex-row overflow-hidden">

--- a/ui/apps/dashboard/src/components/Scores/ScoresEmptyState.tsx
+++ b/ui/apps/dashboard/src/components/Scores/ScoresEmptyState.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useRef } from 'react';
+import { InlineCode } from '@inngest/components/Code';
+import CommandBlock from '@inngest/components/CodeBlock/CommandBlock';
+import { Link } from '@inngest/components/Link';
+import {
+  RiCheckboxCircleLine,
+  RiFilterLine,
+  RiLineChartLine,
+  RiQuestionLine,
+} from '@remixicon/react';
+
+import { analytics } from '@/utils/segment';
+
+const DOCS_URL =
+  'https://www.inngest.com/docs/features/inngest-functions/steps-workflows/scoring?ref=app-empty-scores';
+
+const example = `import { Inngest } from 'inngest';
+import { scoreMiddleware } from 'inngest/experimental';
+
+const inngest = new Inngest({
+  id: 'my-app',
+  middleware: [scoreMiddleware()],
+});
+
+export default inngest.createFunction(
+  { id: 'grade-response' },
+  { event: 'ai/response.generated' },
+  async ({ event, step }) => {
+    const result = step.run('agent-result', () => {/* ... */});
+
+    // Numeric and boolean scores both chart on the Scores tab
+    await step.score('quality', { name: 'response_quality', value: result.qualityScore });
+    await step.score('budget', { name: 'in_budget', value: result.tokens_used < TOKEN_BUDGET });
+  },
+);`;
+
+const prompt = `Read the docs about Inngest scores @https://www.inngest.com/docs-markdown/features/inngest-functions/steps-workflows/scoring and show me how to implement scores using scoreMiddleware(), step.score(), and inngest.score() and explore what scores might be ideal for my existing functions including quality, performance, tool use.`;
+
+const benefits = [
+  {
+    icon: RiCheckboxCircleLine,
+    title: 'Grade AI & evals',
+    description: 'Record boolean or numeric scores to track quality.',
+  },
+  {
+    icon: RiLineChartLine,
+    title: 'Trend any metric',
+    description: 'Chart latency, eval results, or confidence over time.',
+  },
+  {
+    icon: RiQuestionLine,
+    title: 'Query with Insights',
+    description: 'Extract datasets by querying score data directly.',
+  },
+  {
+    icon: RiFilterLine,
+    title: 'Slice by function',
+    description: 'Filter scores per function to spot regressions fast.',
+  },
+];
+
+export function ScoresEmptyState() {
+  // Fire once on view. The ref guards against React 18 StrictMode's
+  // double-invoke so we don't double-count.
+  const tracked = useRef(false);
+  useEffect(() => {
+    if (tracked.current) return;
+    tracked.current = true;
+    analytics.track('Empty State Viewed', { feature: 'scores' });
+  }, []);
+
+  return (
+    <div className="bg-canvasBase flex flex-1 flex-col items-center overflow-auto px-6 py-12">
+      <div className="mx-auto flex w-full max-w-[800px] flex-col gap-10">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-basis text-2xl">Scores</h1>
+          <p className="text-subtle text-sm leading-relaxed">
+            Use scores to track and evaluate custom metrics from inside your
+            functions. Record numeric or boolean scores on any run - eval
+            pass/fail, confidence intervals, latency, tool use. Use Inngest to
+            measure quality and performance trends over time.
+          </p>
+          <Link href={DOCS_URL} target="_blank">
+            Learn more about scores
+          </Link>
+        </div>
+
+        <div className="grid grid-cols-2 gap-x-8 gap-y-6">
+          {benefits.map(({ icon: Icon, title, description }) => (
+            <div key={title} className="flex items-start gap-3">
+              <div className="border-subtle bg-canvasSubtle text-basis flex h-10 w-10 shrink-0 items-center justify-center rounded-md border">
+                <Icon className="h-5 w-5" />
+              </div>
+              <div className="flex flex-col gap-0.5">
+                <p className="text-basis text-sm font-medium">{title}</p>
+                <p className="text-muted text-sm leading-relaxed">
+                  {description}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <hr className="border-subtle" />
+
+        <div className="flex flex-col gap-6">
+          <h2 className="text-basis text-lg">Get started</h2>
+
+          <CommandBlock.Wrapper>
+            <CommandBlock.Header className="flex items-center justify-between px-4 py-2.5">
+              <p className="text-subtle text-sm">
+                Copy this prompt to learn about this feature and implement
+                scores
+              </p>
+              <CommandBlock.CopyButton
+                content={prompt}
+                onCopy={() => {
+                  analytics.track('Empty State Prompt Copied', {
+                    feature: 'scores',
+                  });
+                }}
+              />
+            </CommandBlock.Header>
+            <CommandBlock
+              height={124}
+              currentTabContent={{
+                title: 'Code',
+                content: prompt,
+                readOnly: true,
+                language: 'shell',
+                wordWrap: 'on',
+              }}
+            />
+          </CommandBlock.Wrapper>
+
+          <CommandBlock.Wrapper>
+            <CommandBlock.Header className="flex items-center justify-between px-4 py-2.5">
+              <p className="text-subtle text-sm">
+                add <InlineCode>inngest.score()</InlineCode> to any function
+              </p>
+              <CommandBlock.CopyButton content={example} />
+            </CommandBlock.Header>
+            <CommandBlock
+              currentTabContent={{
+                title: 'Code',
+                content: example,
+                readOnly: true,
+                language: 'typescript',
+              }}
+            />
+          </CommandBlock.Wrapper>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/apps/dashboard/src/components/Scores/ScoresEmptyState.tsx
+++ b/ui/apps/dashboard/src/components/Scores/ScoresEmptyState.tsx
@@ -26,7 +26,7 @@ export default inngest.createFunction(
   { id: 'grade-response' },
   { event: 'ai/response.generated' },
   async ({ event, step }) => {
-    const result = step.run('agent-result', () => {/* ... */});
+    const result = await step.run('agent-result', () => {/* ... */});
 
     // Numeric and boolean scores both chart on the Scores tab
     await step.score('quality', { name: 'response_quality', value: result.qualityScore });

--- a/ui/packages/components/src/CodeBlock/CommandBlock.tsx
+++ b/ui/packages/components/src/CodeBlock/CommandBlock.tsx
@@ -162,14 +162,25 @@ CommandBlock.Header = ({
   return <div className={cn('border-subtle border-b', className)}>{children}</div>;
 };
 
-function CommandBlockCopyButton({ content }: { content?: string }) {
+function CommandBlockCopyButton({
+  content,
+  onCopy,
+}: {
+  content?: string;
+  // Fired after a successful copy so callers can hook in side effects (e.g.
+  // analytics) without this shared component depending on any app.
+  onCopy?: () => void;
+}) {
   const { handleCopyClick, isCopying } = useCopyToClipboard();
   return (
     <CopyButton
       size="small"
       code={content}
       isCopying={isCopying}
-      handleCopyClick={handleCopyClick}
+      handleCopyClick={(code) => {
+        handleCopyClick(code);
+        onCopy?.();
+      }}
       appearance="outlined"
     />
   );


### PR DESCRIPTION
## Description

New empty state for scores w/ a coding agent prompt.

EXE-2015

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
