### PR TITLE
docs: EXE-2021 Add CLI callout to API docs

### DIFF
--- a/docs/api-docs/content/docs/index.mdx
+++ b/docs/api-docs/content/docs/index.mdx
@@ -5,6 +5,19 @@ description: Complete reference documentation for the Inngest REST API.
 
 The Inngest REST API lets you interact with events, function runs, environments, and more programmatically.
 
+<Callout title="Inngest CLI" type="idea">
+  You can use the API from your terminal or coding agent with the Inngest CLI:
+
+  ```shell
+  $ inngest api --help
+  ```
+
+  Every API endpoint is automatically exposed in the CLI which can connect to Inngest Cloud and the Dev Server.
+
+  [Learn how to install the CLI and key commands here](https://www.inngest.com/docs/cli?ref=api-docs).
+</Callout>
+
+
 ## Versions
 
 | Version | Status | Base URL |

--- a/docs/api-docs/src/components/SegmentPageTracking.tsx
+++ b/docs/api-docs/src/components/SegmentPageTracking.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from 'react';
+import { useRouterState } from '@tanstack/react-router';
+
+/**
+ * Fires a Segment `page` call on the initial load and on every client-side
+ * navigation. TanStack Router navigates without a full page reload, so the
+ * Segment loader snippet's one-time `page()` call would otherwise miss all
+ * subsequent route changes.
+ *
+ * The path/url are passed explicitly rather than letting Segment infer them
+ * from the DOM: this effect is triggered by TanStack's router state, which
+ * updates a tick before `window.location`/`document.title` are committed, so a
+ * bare `page()` would read the *previous* page's location.
+ */
+export function SegmentPageTracking() {
+  const location = useRouterState({ select: (state) => state.location });
+
+  useEffect(() => {
+    window.analytics?.page({
+      path: location.pathname,
+      // location.href is relative (path+search+hash); origin is stable across
+      // SPA navigation, so this yields a correct absolute URL.
+      url: window.location.origin + location.href,
+      search: location.searchStr,
+    });
+  }, [location.pathname, location.href, location.searchStr]);
+
+  return null;
+}

--- a/docs/api-docs/src/lib/analytics.ts
+++ b/docs/api-docs/src/lib/analytics.ts
@@ -1,0 +1,24 @@
+export const SEGMENT_WRITE_KEY = 'dF78LfPkOzXoe9LXps7i4I9Et0MHuRBB';
+
+// Minimal type surface for the Segment analytics.js stub/loaded object. The
+// snippet defines `window.analytics` synchronously and queues calls until the
+// real library loads, so these methods are always safe to call.
+export interface SegmentAnalytics {
+  page: (...args: unknown[]) => void;
+  track: (...args: unknown[]) => void;
+  identify: (...args: unknown[]) => void;
+}
+
+declare global {
+  interface Window {
+    analytics?: SegmentAnalytics;
+  }
+}
+
+// Segment analytics.js loader snippet. This is the official snippet with the
+// trailing `analytics.page()` removed: page views are tracked reactively via
+// SegmentPageTracking so that initial and client-side navigations are counted
+// consistently (and not double-counted on first load).
+export const segmentLoaderSnippet = `!function(){var i="analytics",analytics=window[i]=window[i]||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"];analytics.factory=function(e){return function(){if(window[i].initialized)return window[i][e].apply(window[i],arguments);var n=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(e)>-1){var c=document.querySelector("link[rel='canonical']");n.push({__t:"bpc",c:c&&c.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}n.unshift(e);analytics.push(n);return analytics}};for(var n=0;n<analytics.methods.length;n++){var key=analytics.methods[n];analytics[key]=analytics.factory(key)}analytics.load=function(key,n){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.setAttribute("data-global-segment-analytics-key",i);t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r);analytics._loadOptions=n};analytics._writeKey="${SEGMENT_WRITE_KEY}";analytics.SNIPPET_VERSION="5.2.0";
+analytics.load("${SEGMENT_WRITE_KEY}");
+}}();`;

--- a/docs/api-docs/src/routes/__root.tsx
+++ b/docs/api-docs/src/routes/__root.tsx
@@ -3,8 +3,13 @@ import { HeadContent, Outlet, Scripts, createRootRoute } from '@tanstack/react-r
 import { RootProvider } from 'fumadocs-ui/provider/tanstack';
 
 import '@/app.css';
+import { SegmentPageTracking } from '@/components/SegmentPageTracking';
+import { segmentLoaderSnippet } from '@/lib/analytics';
 
 export const Route = createRootRoute({
+  head: () => ({
+    scripts: [{ children: segmentLoaderSnippet }],
+  }),
   component: RootComponent,
 });
 
@@ -26,6 +31,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
       </head>
       <body className="flex min-h-screen flex-col">
         <RootProvider>{children}</RootProvider>
+        <SegmentPageTracking />
         <Scripts />
       </body>
     </html>


### PR DESCRIPTION
## Description

Add a CLI callout and track page views.

<img width="917" height="425" alt="Screen Shot 2026-07-15 at 12 51 53 PM" src="https://github.com/user-attachments/assets/b96beb2f-fcaf-4400-ae20-697b898f7dbc" />


EXE-2021

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
