### PR TITLE
fix(queue): expose partition size on job queue reader

### DIFF
--- a/pkg/execution/queue/job_queue_reader.go
+++ b/pkg/execution/queue/job_queue_reader.go
@@ -103,6 +103,24 @@ func (r *jobQueueReader) PartitionBacklogSize(ctx context.Context, scope Scope, 
 	return totalCount, nil
 }
 
+// PartitionSize implements JobQueueReader.
+func (r *jobQueueReader) PartitionSize(ctx context.Context, scope Scope, partitionID string, until time.Time) (int64, error) {
+	var totalCount int64
+
+	err := r.forAccountShards(ctx, scope.AccountID, func(ctx context.Context, shard QueueShard) error {
+		partitionSize, err := shard.PartitionSize(ctx, scope, partitionID, until)
+		if err != nil {
+			return fmt.Errorf("could not load partition size: %w", err)
+		}
+		atomic.AddInt64(&totalCount, partitionSize)
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("could not load partition size: %w", err)
+	}
+	return totalCount, nil
+}
+
 // PartitionByID implements JobQueueReader.
 func (r *jobQueueReader) PartitionByID(ctx context.Context, shard QueueShard, scope Scope, partitionID string) (*PartitionInspectionResult, error) {
 	return shard.PartitionByID(ctx, scope, partitionID)

--- a/pkg/execution/queue/queue.go
+++ b/pkg/execution/queue/queue.go
@@ -242,6 +242,9 @@ type JobQueueReader interface {
 	// by summing the size of all backlogs in that partition.
 	PartitionBacklogSize(ctx context.Context, scope Scope, partitionID string) (int64, error)
 
+	// PartitionSize returns the point-in-time ready queue size of a partition.
+	PartitionSize(ctx context.Context, scope Scope, partitionID string, until time.Time) (int64, error)
+
 	// RunJobs reads items in the queue for a specific run.
 	RunJobs(ctx context.Context, queueShardName string, scope Scope, runID ulid.ULID, limit, offset int64) ([]JobResponse, error)
 


### PR DESCRIPTION
## Summary
- add `PartitionSize` to `JobQueueReader`
- fan out partition size reads across account shards, matching `PartitionBacklogSize`

## Context
This supports the monorepo key-queue scheduled metric fix, which needs to count ready function-queue items in addition to key-queue backlog items. The monorepo PR should vendor this after merge instead of carrying an ungrounded vendor edit.

## Test Plan
- `go test ./pkg/execution/queue`