### PR TITLE
feat(api): add v2 runs list endpoints

### DIFF
--- a/pkg/api/v2/endpoints_runs.go
+++ b/pkg/api/v2/endpoints_runs.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/inngest/inngest/pkg/api/v2/apiv2base"
@@ -23,6 +24,8 @@ import (
 const (
 	defaultEventRunsLimit = 20
 	maxEventRunsLimit     = 40
+	defaultRunsLimit      = 20
+	maxRunsLimit          = 100
 )
 
 func (s *Service) GetFunctionRun(ctx context.Context, req *apiv2.GetFunctionRunRequest) (*apiv2.GetFunctionRunResponse, error) {
@@ -63,6 +66,87 @@ func (s *Service) GetFunctionRun(ctx context.Context, req *apiv2.GetFunctionRunR
 	}, nil
 }
 
+func (s *Service) ListRuns(ctx context.Context, req *apiv2.ListRunsRequest) (*apiv2.ListRunsResponse, error) {
+	if result := s.rateLimiter.CheckRateLimit(ctx, apiv2.V2_ListRuns_FullMethodName); result.Limited {
+		return nil, s.base.NewError(http.StatusTooManyRequests, apiv2base.ErrorRateLimited,
+			"API rate limit exceeded. The request was rejected and no runs were fetched.")
+	}
+
+	if s.runs == nil {
+		return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "List runs is not yet implemented")
+	}
+
+	opts, err := listRunsOpts(req)
+	if err != nil {
+		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, err.Error())
+	}
+
+	return s.listRuns(ctx, opts)
+}
+
+func (s *Service) ListFunctionRuns(ctx context.Context, req *apiv2.ListFunctionRunsRequest) (*apiv2.ListFunctionRunsResponse, error) {
+	if req.AppId == "" || req.FunctionId == "" {
+		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorMissingField, "App ID and function ID are required")
+	}
+
+	if result := s.rateLimiter.CheckRateLimit(ctx, apiv2.V2_ListFunctionRuns_FullMethodName); result.Limited {
+		return nil, s.base.NewError(http.StatusTooManyRequests, apiv2base.ErrorRateLimited,
+			"API rate limit exceeded. The request was rejected and no runs were fetched.")
+	}
+
+	if s.runs == nil {
+		return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "List runs is not yet implemented")
+	}
+
+	opts, err := listRunsOpts(&apiv2.ListRunsRequest{
+		IncludeOutput: req.IncludeOutput,
+		Cursor:        req.Cursor,
+		Limit:         req.Limit,
+		From:          req.From,
+		Until:         req.Until,
+		TimeField:     req.TimeField,
+		Status:        req.Status,
+		AppId:         []string{decodePathParam(req.AppId)},
+		FunctionId:    []string{decodePathParam(req.FunctionId)},
+		IsDeferred:    req.IsDeferred,
+		Order:         req.Order,
+	})
+	if err != nil {
+		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, err.Error())
+	}
+
+	resp, err := s.listRuns(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return &apiv2.ListFunctionRunsResponse{
+		Data:     resp.Data,
+		Metadata: resp.Metadata,
+		Page:     resp.Page,
+	}, nil
+}
+
+func (s *Service) listRuns(ctx context.Context, opts GetRunsOpts) (*apiv2.ListRunsResponse, error) {
+	result, err := s.runs.GetRuns(ctx, opts)
+	if err != nil {
+		return nil, s.base.NewError(http.StatusInternalServerError, apiv2base.ErrorInternalError, "Unable to fetch runs")
+	}
+	if result == nil {
+		result = &GetRunsResult{}
+	}
+
+	data := make([]*apiv2.FunctionRun, 0, len(result.Runs))
+	for _, run := range result.Runs {
+		data = append(data, toAPIRunListItem(run))
+	}
+
+	return &apiv2.ListRunsResponse{
+		Data:     data,
+		Metadata: runsResponseMetadata(opts.From, opts.Until),
+		Page:     runsPage(result.Runs, opts.Limit, result.HasMore),
+	}, nil
+}
+
 func (s *Service) GetEventRuns(ctx context.Context, req *apiv2.GetEventRunsRequest) (*apiv2.GetEventRunsResponse, error) {
 	if req.EventId == "" {
 		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorMissingField, "Event ID is required")
@@ -86,7 +170,6 @@ func (s *Service) GetEventRuns(ctx context.Context, req *apiv2.GetEventRunsReque
 	if err != nil {
 		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, err.Error())
 	}
-
 	result, err := s.runs.GetRuns(ctx, GetRunsOpts{
 		EventID:       eventID,
 		Cursor:        cursor,
@@ -155,26 +238,84 @@ func (s *Service) Rerun(ctx context.Context, req *apiv2.RerunRequest) (*apiv2.Re
 	}, nil
 }
 
+func listRunsOpts(req *apiv2.ListRunsRequest) (GetRunsOpts, error) {
+	if len(req.GetFunctionId()) > 0 && len(req.GetAppId()) == 0 {
+		return GetRunsOpts{}, fmt.Errorf("appId is required when filtering by functionId")
+	}
+
+	cursor, limit, err := listRunsPageOpts(req.GetCursor(), req.GetLimit())
+	if err != nil {
+		return GetRunsOpts{}, err
+	}
+
+	from, err := optionalTimestamp(req.GetFrom(), "from")
+	if err != nil {
+		return GetRunsOpts{}, err
+	}
+	until, err := optionalTimestamp(req.GetUntil(), "until")
+	if err != nil {
+		return GetRunsOpts{}, err
+	}
+	if from != nil && until != nil && !from.Before(*until) {
+		return GetRunsOpts{}, fmt.Errorf("from must be before until")
+	}
+
+	status, err := runStatusesFromAPI(req.GetStatus())
+	if err != nil {
+		return GetRunsOpts{}, err
+	}
+	timeField, err := runTimeFieldFromAPI(req.GetTimeField())
+	if err != nil {
+		return GetRunsOpts{}, err
+	}
+	order, err := orderDirectionFromAPI(req.GetOrder())
+	if err != nil {
+		return GetRunsOpts{}, err
+	}
+
+	return GetRunsOpts{
+		Cursor:        cursor,
+		Limit:         limit,
+		IncludeOutput: req.GetIncludeOutput(),
+		From:          from,
+		Until:         until,
+		TimeField:     timeField,
+		Status:        status,
+		AppIDs:        req.GetAppId(),
+		FunctionIDs:   req.GetFunctionId(),
+		IsDeferred:    req.IsDeferred,
+		Order:         order,
+	}, nil
+}
+
+func listRunsPageOpts(cursor string, requestedLimit int32) (string, int, error) {
+	return parseRunsPageOpts(cursor, requestedLimit, defaultRunsLimit, maxRunsLimit)
+}
+
 func runsPageOpts(cursor string, requestedLimit int32) (string, int, error) {
+	return parseRunsPageOpts(cursor, requestedLimit, defaultEventRunsLimit, maxEventRunsLimit)
+}
+
+func parseRunsPageOpts(cursor string, requestedLimit int32, defaultLimit, maxLimit int) (string, int, error) {
 	limit := int(requestedLimit)
 	if limit == 0 {
-		limit = defaultEventRunsLimit
+		limit = defaultLimit
 	}
 	if limit < 1 {
 		return "", 0, fmt.Errorf("Limit must be at least 1")
 	}
-	if limit > maxEventRunsLimit {
-		return "", 0, fmt.Errorf("Limit cannot exceed %d", maxEventRunsLimit)
+	if limit > maxLimit {
+		return "", 0, fmt.Errorf("Limit cannot exceed %d", maxLimit)
 	}
-
-	if cursor != "" {
-		pageCursor := cqrs.TracePageCursor{}
-		if err := pageCursor.Decode(cursor); err != nil || pageCursor.ID == "" || len(pageCursor.Cursors) == 0 {
-			return "", 0, fmt.Errorf("Cursor is invalid")
-		}
+	if cursor != "" && !validRunsCursor(cursor) {
+		return "", 0, fmt.Errorf("Cursor is invalid")
 	}
-
 	return cursor, limit, nil
+}
+
+func validRunsCursor(cursor string) bool {
+	pageCursor := cqrs.TracePageCursor{}
+	return pageCursor.Decode(cursor) == nil && pageCursor.ID != "" && len(pageCursor.Cursors) > 0
 }
 
 func runsPage(runs []*RunListItem, limit int, hasMore bool) *apiv2.Page {
@@ -187,6 +328,77 @@ func runsPage(runs []*RunListItem, limit int, hasMore bool) *apiv2.Page {
 		page.Cursor = &nextCursor
 	}
 	return page
+}
+
+func optionalTimestamp(ts *timestamppb.Timestamp, field string) (*time.Time, error) {
+	if ts == nil {
+		return nil, nil
+	}
+	if err := ts.CheckValid(); err != nil {
+		return nil, fmt.Errorf("%s must be a valid timestamp", field)
+	}
+	value := ts.AsTime().UTC()
+	return &value, nil
+}
+
+func runStatusesFromAPI(statuses []string) ([]enums.RunStatus, error) {
+	result := make([]enums.RunStatus, 0, len(statuses))
+	for _, status := range statuses {
+		switch strings.ToUpper(strings.TrimSpace(status)) {
+		case "QUEUED":
+			result = append(result, enums.RunStatusScheduled)
+		case "RUNNING":
+			result = append(result, enums.RunStatusRunning)
+		case "COMPLETED":
+			result = append(result, enums.RunStatusCompleted)
+		case "FAILED":
+			result = append(result, enums.RunStatusFailed)
+		case "CANCELLED":
+			result = append(result, enums.RunStatusCancelled)
+		default:
+			return nil, fmt.Errorf("Status is invalid")
+		}
+	}
+	return result, nil
+}
+
+func runTimeFieldFromAPI(field string) (RunTimeField, error) {
+	switch normalizeRunFilterToken(field) {
+	case "", "QUEUEDAT", "QUEUED_AT":
+		return RunTimeFieldQueuedAt, nil
+	case "STARTEDAT", "STARTED_AT":
+		return RunTimeFieldStartedAt, nil
+	case "ENDEDAT", "ENDED_AT":
+		return RunTimeFieldEndedAt, nil
+	default:
+		return RunTimeFieldQueuedAt, fmt.Errorf("timeField is invalid")
+	}
+}
+
+func orderDirectionFromAPI(direction string) (OrderDirection, error) {
+	switch normalizeRunFilterToken(direction) {
+	case "", "DESC":
+		return OrderDirectionDesc, nil
+	case "ASC":
+		return OrderDirectionAsc, nil
+	default:
+		return OrderDirectionDesc, fmt.Errorf("order is invalid")
+	}
+}
+
+func normalizeRunFilterToken(value string) string {
+	return strings.ToUpper(strings.TrimSpace(value))
+}
+
+func runsResponseMetadata(from, until *time.Time) *apiv2.ResponseMetadata {
+	metadata := &apiv2.ResponseMetadata{FetchedAt: timestamppb.Now()}
+	if from != nil && until != nil {
+		metadata.TimeRange = &apiv2.TimeRange{
+			From:  timestamppb.New(*from),
+			Until: timestamppb.New(*until),
+		}
+	}
+	return metadata
 }
 
 func (s *Service) GetFunctionTrace(ctx context.Context, req *apiv2.GetFunctionTraceRequest) (*apiv2.GetFunctionTraceResponse, error) {

--- a/pkg/api/v2/http_test.go
+++ b/pkg/api/v2/http_test.go
@@ -189,6 +189,54 @@ func TestHTTPGateway_RunEnumsUseShortJSONNames(t *testing.T) {
 	require.Equal(t, "COMPLETED", run["status"])
 }
 
+func TestHTTPGateway_RunListRoutes(t *testing.T) {
+	t.Run("binds list filters", func(t *testing.T) {
+		isDeferred := true
+		runs := &mockRunProvider{}
+		runs.On("GetRuns", mock.Anything, GetRunsOpts{
+			Limit:       3,
+			TimeField:   RunTimeFieldStartedAt,
+			Status:      []enums.RunStatus{enums.RunStatusCompleted, enums.RunStatusFailed},
+			AppIDs:      []string{"my-app"},
+			FunctionIDs: []string{"test-fn"},
+			IsDeferred:  &isDeferred,
+			Order:       OrderDirectionAsc,
+		}).Return(&GetRunsResult{}, nil).Once()
+
+		handler, err := newTestHTTPHandler(t.Context(), ServiceOptions{Runs: runs}, HTTPHandlerOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() { runs.AssertExpectations(t) })
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/runs?limit=3&timeField=STARTED_AT&status=COMPLETED&status=FAILED&appId=my-app&functionId=test-fn&isDeferred=true&order=ASC", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	})
+
+	t.Run("binds function path", func(t *testing.T) {
+		runs := &mockRunProvider{}
+		runs.On("GetRuns", mock.Anything, GetRunsOpts{
+			Limit:       defaultRunsLimit,
+			TimeField:   RunTimeFieldQueuedAt,
+			Status:      []enums.RunStatus{},
+			AppIDs:      []string{"my-app"},
+			FunctionIDs: []string{"test-fn"},
+			Order:       OrderDirectionDesc,
+		}).Return(&GetRunsResult{}, nil).Once()
+
+		handler, err := newTestHTTPHandler(t.Context(), ServiceOptions{Runs: runs}, HTTPHandlerOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() { runs.AssertExpectations(t) })
+
+		req := httptest.NewRequest(http.MethodGet, "/api/v2/apps/my-app/functions/test-fn/runs", nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	})
+}
+
 func TestHTTPGateway_Rerun(t *testing.T) {
 	ctx := context.Background()
 	runID := ulid.MustParse("01hp1zx8m3ng9vp6qn0xk7j4cy")

--- a/pkg/api/v2/interfaces.go
+++ b/pkg/api/v2/interfaces.go
@@ -79,7 +79,30 @@ type GetRunsOpts struct {
 	Cursor        string
 	Limit         int
 	IncludeOutput bool
+	From          *time.Time
+	Until         *time.Time
+	TimeField     RunTimeField
+	Status        []enums.RunStatus
+	AppIDs        []string
+	FunctionIDs   []string
+	IsDeferred    *bool
+	Order         OrderDirection
 }
+
+type RunTimeField int
+
+const (
+	RunTimeFieldQueuedAt RunTimeField = iota
+	RunTimeFieldStartedAt
+	RunTimeFieldEndedAt
+)
+
+type OrderDirection int
+
+const (
+	OrderDirectionDesc OrderDirection = iota
+	OrderDirectionAsc
+)
 
 type RunListItem struct {
 	RunID        ulid.ULID

--- a/pkg/api/v2/service_test.go
+++ b/pkg/api/v2/service_test.go
@@ -920,6 +920,231 @@ func TestService_GetFunctionRun(t *testing.T) {
 	})
 }
 
+func TestService_ListRuns(t *testing.T) {
+	runID := ulid.MustParse("01hp1zx8m3ng9vp6qn0xk7j4cy")
+	eventID := ulid.MustParse("01hp1zyb8p2nb5kvm2a6x1h9ae")
+	startedAt := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	endedAt := startedAt.Add(5 * time.Second)
+	from := startedAt.Add(-time.Hour)
+	until := startedAt.Add(time.Hour)
+	isDeferred := false
+	limit := int32(1)
+	pageCursor, err := (&cqrs.TracePageCursor{
+		ID: runID.String(),
+		Cursors: map[string]cqrs.TraceCursor{
+			"start_time": {Field: "start_time", Value: startedAt.UnixMicro()},
+		},
+	}).Encode()
+	require.NoError(t, err)
+
+	run := &RunListItem{
+		RunID:        runID,
+		Cursor:       "opaque-cursor",
+		RunStartedAt: startedAt,
+		EventID:      eventID,
+		Status:       enums.RunStatusCompleted,
+		EndedAt:      &endedAt,
+		FunctionID:   "test-fn",
+		FunctionName: "Test function",
+		AppID:        "my-app",
+	}
+
+	t.Run("returns mapped runs with filters", func(t *testing.T) {
+		reader := &mockRunProvider{}
+		reader.On("GetRuns", mock.Anything, GetRunsOpts{
+			Cursor:        pageCursor,
+			Limit:         1,
+			IncludeOutput: true,
+			From:          &from,
+			Until:         &until,
+			TimeField:     RunTimeFieldStartedAt,
+			Status:        []enums.RunStatus{enums.RunStatusCompleted},
+			AppIDs:        []string{"my-app"},
+			FunctionIDs:   []string{"test-fn"},
+			IsDeferred:    &isDeferred,
+			Order:         OrderDirectionAsc,
+		}).Return(&GetRunsResult{Runs: []*RunListItem{run}, HasMore: true}, nil).Once()
+		t.Cleanup(func() {
+			reader.AssertExpectations(t)
+		})
+
+		service := NewService(ServiceOptions{Runs: reader})
+		resp, err := service.ListRuns(context.Background(), &apiv2.ListRunsRequest{
+			Cursor:        strPtr(pageCursor),
+			Limit:         &limit,
+			IncludeOutput: boolPtr(true),
+			From:          timestamppb.New(from),
+			Until:         timestamppb.New(until),
+			TimeField:     "startedAt",
+			Status:        []string{"COMPLETED"},
+			AppId:         []string{"my-app"},
+			FunctionId:    []string{"test-fn"},
+			IsDeferred:    &isDeferred,
+			Order:         "asc",
+		})
+
+		require.NoError(t, err)
+		require.Len(t, resp.Data, 1)
+		require.Equal(t, runID.String(), resp.Data[0].Id)
+		require.Equal(t, "test-fn", resp.Data[0].Function.Id)
+		require.Equal(t, "my-app", resp.Data[0].App.Id)
+		require.Equal(t, apiv2.FunctionRunStatus_FUNCTION_RUN_STATUS_COMPLETED, resp.Data[0].Status)
+		require.NotNil(t, resp.Metadata.TimeRange)
+		require.Equal(t, from, resp.Metadata.TimeRange.From.AsTime())
+		require.Equal(t, until, resp.Metadata.TimeRange.Until.AsTime())
+		require.True(t, resp.Page.HasMore)
+		require.Equal(t, "opaque-cursor", resp.Page.GetCursor())
+		require.Equal(t, int32(1), resp.Page.Limit)
+	})
+
+	t.Run("validates time range", func(t *testing.T) {
+		service := NewService(ServiceOptions{Runs: &mockRunProvider{}})
+		resp, err := service.ListRuns(context.Background(), &apiv2.ListRunsRequest{
+			From:  timestamppb.New(until),
+			Until: timestamppb.New(from),
+		})
+
+		require.Nil(t, resp)
+		require.ErrorContains(t, err, "from must be before until")
+	})
+
+	t.Run("validates status", func(t *testing.T) {
+		service := NewService(ServiceOptions{Runs: &mockRunProvider{}})
+		resp, err := service.ListRuns(context.Background(), &apiv2.ListRunsRequest{
+			Status: []string{"FUNCTION_RUN_STATUS_UNSPECIFIED"},
+		})
+
+		require.Nil(t, resp)
+		require.ErrorContains(t, err, "Status is invalid")
+	})
+
+	t.Run("requires app filter with function filter", func(t *testing.T) {
+		service := NewService(ServiceOptions{Runs: &mockRunProvider{}})
+		resp, err := service.ListRuns(context.Background(), &apiv2.ListRunsRequest{
+			FunctionId: []string{"test-fn"},
+		})
+
+		require.Nil(t, resp)
+		require.ErrorContains(t, err, "appId is required when filtering by functionId")
+	})
+
+	t.Run("validates cursor", func(t *testing.T) {
+		service := NewService(ServiceOptions{Runs: &mockRunProvider{}})
+		resp, err := service.ListRuns(context.Background(), &apiv2.ListRunsRequest{
+			Cursor: strPtr("not-a-cursor"),
+		})
+
+		require.Nil(t, resp)
+		require.ErrorContains(t, err, "Cursor is invalid")
+	})
+}
+
+func TestService_ListFunctionRuns(t *testing.T) {
+	runID := ulid.MustParse("01hp1zx8m3ng9vp6qn0xk7j4cy")
+	eventID := ulid.MustParse("01hp1zyb8p2nb5kvm2a6x1h9ae")
+	startedAt := time.Date(2026, 7, 14, 12, 0, 0, 0, time.UTC)
+	limit := int32(20)
+	run := &RunListItem{
+		RunID:        runID,
+		Cursor:       "next-cursor",
+		RunStartedAt: startedAt,
+		EventID:      eventID,
+		Status:       enums.RunStatusCompleted,
+		FunctionID:   "hello-world",
+		FunctionName: "Hello world",
+		AppID:        "inngest-ai",
+	}
+
+	reader := &mockRunProvider{}
+	reader.On("GetRuns", mock.Anything, GetRunsOpts{
+		Cursor:      "",
+		Limit:       20,
+		TimeField:   RunTimeFieldQueuedAt,
+		Status:      []enums.RunStatus{},
+		AppIDs:      []string{"inngest ai"},
+		FunctionIDs: []string{"hello/world"},
+		Order:       OrderDirectionDesc,
+	}).Return(&GetRunsResult{Runs: []*RunListItem{run}}, nil).Once()
+	t.Cleanup(func() {
+		reader.AssertExpectations(t)
+	})
+
+	service := NewService(ServiceOptions{Runs: reader})
+	resp, err := service.ListFunctionRuns(context.Background(), &apiv2.ListFunctionRunsRequest{
+		AppId:      "inngest%20ai",
+		FunctionId: "hello%2Fworld",
+		Limit:      &limit,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, resp.Data, 1)
+	require.Equal(t, runID.String(), resp.Data[0].Id)
+	require.Equal(t, "hello-world", resp.Data[0].Function.Id)
+	require.Equal(t, "inngest-ai", resp.Data[0].App.Id)
+}
+
+func TestRunStatusesFromAPI(t *testing.T) {
+	got, err := runStatusesFromAPI([]string{"COMPLETED", "failed", "RUNNING", " queued "})
+
+	require.NoError(t, err)
+	require.Equal(t, []enums.RunStatus{
+		enums.RunStatusCompleted,
+		enums.RunStatusFailed,
+		enums.RunStatusRunning,
+		enums.RunStatusScheduled,
+	}, got)
+
+	_, err = runStatusesFromAPI([]string{"FUNCTION_RUN_STATUS_COMPLETED"})
+	require.ErrorContains(t, err, "Status is invalid")
+}
+
+func TestRunTimeFieldFromAPI(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  RunTimeField
+	}{
+		{name: "default", value: "", want: RunTimeFieldQueuedAt},
+		{name: "camel queued", value: "queuedAt", want: RunTimeFieldQueuedAt},
+		{name: "snake started", value: "started_at", want: RunTimeFieldStartedAt},
+		{name: "camel ended", value: "endedAt", want: RunTimeFieldEndedAt},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := runTimeFieldFromAPI(tc.value)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	_, err := runTimeFieldFromAPI("FUNCTION_RUN_TIME_FIELD_STARTED_AT")
+	require.ErrorContains(t, err, "timeField is invalid")
+}
+
+func TestOrderDirectionFromAPI(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  OrderDirection
+	}{
+		{name: "default", value: "", want: OrderDirectionDesc},
+		{name: "lower asc", value: "asc", want: OrderDirectionAsc},
+		{name: "upper desc", value: "DESC", want: OrderDirectionDesc},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := orderDirectionFromAPI(tc.value)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	_, err := orderDirectionFromAPI("ORDER_DIRECTION_ASC")
+	require.ErrorContains(t, err, "order is invalid")
+}
+
 func TestService_GetEventRuns(t *testing.T) {
 	eventID := ulid.MustParse("01hp1zyb8p2nb5kvm2a6x1h9ae")
 	runID := ulid.MustParse("01hp1zx8m3ng9vp6qn0xk7j4cy")

--- a/pkg/cqrs/manager/cqrs.go
+++ b/pkg/cqrs/manager/cqrs.go
@@ -3925,7 +3925,7 @@ func spanRunRootPredicates(opt cqrs.GetTraceRunOpt, h driverhelp.DialectHelpers)
 			sq.I("spans.status").IsNull(),
 			sq.I("spans.status").Neq(enums.RunStatusSkipped.String()),
 		),
-		sq.I("spans.start_time").Lt(opt.Filter.Until.UTC()),
+		sq.I("spans.start_time").Lte(opt.Filter.Until.UTC()),
 	}
 	if opt.Filter.AccountID != uuid.Nil {
 		preds = append(preds, sq.I("spans.account_id").Eq(opt.Filter.AccountID))
@@ -4009,7 +4009,7 @@ func spanRunAggregatePredicates(opt cqrs.GetTraceRunOpt, cursor *cqrs.TracePageC
 		// UTC preserves the SQLite timestamp ordering described in spanRunRootPredicates.
 		preds = append(preds,
 			aggregate.Gte(opt.Filter.From.UTC()),
-			aggregate.Lt(opt.Filter.Until.UTC()),
+			aggregate.Lte(opt.Filter.Until.UTC()),
 		)
 	}
 	if cursor == nil {

--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -2729,7 +2729,46 @@ func TestCQRSGetRunsMapsScheduledStatusFilter(t *testing.T) {
 	assert.Equal(t, enums.RunStatusScheduled, runs[0].Status)
 }
 
-func TestCQRSGetRunsFiltersByFinalEndedAt(t *testing.T) {
+func TestCQRSGetRunsIncludesStartedAtRangeBoundaries(t *testing.T) {
+	cm, cleanup := initCQRS(t)
+	defer cleanup()
+
+	accountID := uuid.New()
+	workspaceID := uuid.New()
+	appID := uuid.New()
+	functionID := uuid.New()
+	from := time.Now().UTC().Truncate(time.Second)
+	until := from.Add(time.Minute)
+
+	for i, startedAt := range []time.Time{from, until} {
+		insertTestSpan(t, cm, testSpanFields{
+			RunID:         ulid.Make().String(),
+			DynamicSpanID: fmt.Sprintf("dyn-boundary-%d", i),
+			Name:          meta.SpanNameRun,
+			Status:        enums.StepStatusQueued.String(),
+			StartTime:     startedAt,
+			AccountID:     accountID.String(),
+			AppID:         appID.String(),
+			FunctionID:    functionID.String(),
+			EnvID:         workspaceID.String(),
+		})
+	}
+
+	runs, err := cm.GetRuns(t.Context(), cqrs.GetTraceRunOpt{
+		Filter: cqrs.GetTraceRunFilter{
+			AccountID: accountID, WorkspaceID: workspaceID,
+			TimeField: enums.TraceRunTimeStartedAt,
+			From:      from,
+			Until:     until,
+		},
+		Order: []cqrs.GetTraceRunOrder{{Field: enums.TraceRunTimeStartedAt, Direction: enums.TraceRunOrderAsc}},
+		Items: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, runs, 2)
+}
+
+func TestCQRSGetRunsIncludesFinalEndedAtUntilBoundary(t *testing.T) {
 	cm, cleanup := initCQRS(t)
 	defer cleanup()
 
@@ -2759,7 +2798,7 @@ func TestCQRSGetRunsFiltersByFinalEndedAt(t *testing.T) {
 			AccountID: accountID.String(), AppID: appID.String(), FunctionID: functionID.String(), EnvID: workspaceID.String(),
 		})
 	}
-	insertLifecycle(insideRunID, "dyn-ended-inside", baseTime.Add(5*time.Second))
+	insertLifecycle(insideRunID, "dyn-ended-inside", baseTime.Add(10*time.Second-100*time.Millisecond))
 	insertLifecycle(outsideRunID, "dyn-ended-outside", baseTime.Add(15*time.Second))
 
 	runs, err := cm.GetRuns(t.Context(), cqrs.GetTraceRunOpt{

--- a/pkg/devserver/run_provider.go
+++ b/pkg/devserver/run_provider.go
@@ -50,22 +50,35 @@ func (p *runProvider) GetRun(ctx context.Context, runID ulid.ULID, _ apiv2.GetRu
 }
 
 func (p *runProvider) GetRuns(ctx context.Context, opts apiv2.GetRunsOpts) (*apiv2.GetRunsResult, error) {
+	from := time.Time{}
+	if opts.From != nil {
+		from = *opts.From
+	}
+	until := maxRunListTime
+	if opts.Until != nil {
+		until = *opts.Until
+	}
 	eventIDs := []ulid.ULID{}
 	if opts.EventID != ulid.Zero {
 		eventIDs = append(eventIDs, opts.EventID)
 	}
+
 	rows, err := p.data.GetRuns(ctx, cqrs.GetTraceRunOpt{
 		Filter: cqrs.GetTraceRunFilter{
-			AccountID:   consts.DevServerAccountID,
-			WorkspaceID: consts.DevServerEnvID,
-			EventID:     eventIDs,
-			TimeField:   enums.TraceRunTimeQueuedAt,
-			From:        time.Time{},
-			Until:       maxRunListTime,
+			AccountID:    consts.DevServerAccountID,
+			WorkspaceID:  consts.DevServerEnvID,
+			AppName:      opts.AppIDs,
+			FunctionSlug: opts.FunctionIDs,
+			EventID:      eventIDs,
+			TimeField:    cqrsRunTimeField(opts.TimeField),
+			From:         from,
+			Until:        until,
+			Status:       opts.Status,
+			IsDeferred:   opts.IsDeferred,
 		},
 		Order: []cqrs.GetTraceRunOrder{{
-			Field:     enums.TraceRunTimeQueuedAt,
-			Direction: enums.TraceRunOrderDesc,
+			Field:     cqrsRunTimeField(opts.TimeField),
+			Direction: cqrsRunOrder(opts.Order),
 		}},
 		Cursor:        opts.Cursor,
 		Items:         uint(opts.Limit + 1),
@@ -89,6 +102,24 @@ func (p *runProvider) GetRuns(ctx context.Context, opts apiv2.GetRunsOpts) (*api
 		Runs:    runs,
 		HasMore: hasMore,
 	}, nil
+}
+
+func cqrsRunTimeField(field apiv2.RunTimeField) enums.TraceRunTime {
+	switch field {
+	case apiv2.RunTimeFieldStartedAt:
+		return enums.TraceRunTimeStartedAt
+	case apiv2.RunTimeFieldEndedAt:
+		return enums.TraceRunTimeEndedAt
+	default:
+		return enums.TraceRunTimeQueuedAt
+	}
+}
+
+func cqrsRunOrder(order apiv2.OrderDirection) enums.TraceRunOrder {
+	if order == apiv2.OrderDirectionAsc {
+		return enums.TraceRunOrderAsc
+	}
+	return enums.TraceRunOrderDesc
 }
 
 func (p *runProvider) Rerun(ctx context.Context, runID ulid.ULID, opts apiv2.RerunOpts) (ulid.ULID, error) {

--- a/pkg/devserver/run_provider.go
+++ b/pkg/devserver/run_provider.go
@@ -50,6 +50,11 @@ func (p *runProvider) GetRun(ctx context.Context, runID ulid.ULID, _ apiv2.GetRu
 }
 
 func (p *runProvider) GetRuns(ctx context.Context, opts apiv2.GetRunsOpts) (*apiv2.GetRunsResult, error) {
+	timeField, err := cqrsRunTimeField(opts.TimeField)
+	if err != nil {
+		return nil, err
+	}
+
 	from := time.Time{}
 	if opts.From != nil {
 		from = *opts.From
@@ -70,14 +75,14 @@ func (p *runProvider) GetRuns(ctx context.Context, opts apiv2.GetRunsOpts) (*api
 			AppName:      opts.AppIDs,
 			FunctionSlug: opts.FunctionIDs,
 			EventID:      eventIDs,
-			TimeField:    cqrsRunTimeField(opts.TimeField),
+			TimeField:    timeField,
 			From:         from,
 			Until:        until,
 			Status:       opts.Status,
 			IsDeferred:   opts.IsDeferred,
 		},
 		Order: []cqrs.GetTraceRunOrder{{
-			Field:     cqrsRunTimeField(opts.TimeField),
+			Field:     timeField,
 			Direction: cqrsRunOrder(opts.Order),
 		}},
 		Cursor:        opts.Cursor,
@@ -104,14 +109,16 @@ func (p *runProvider) GetRuns(ctx context.Context, opts apiv2.GetRunsOpts) (*api
 	}, nil
 }
 
-func cqrsRunTimeField(field apiv2.RunTimeField) enums.TraceRunTime {
+func cqrsRunTimeField(field apiv2.RunTimeField) (enums.TraceRunTime, error) {
 	switch field {
+	case apiv2.RunTimeFieldQueuedAt:
+		return enums.TraceRunTimeQueuedAt, nil
 	case apiv2.RunTimeFieldStartedAt:
-		return enums.TraceRunTimeStartedAt
+		return enums.TraceRunTimeStartedAt, nil
 	case apiv2.RunTimeFieldEndedAt:
-		return enums.TraceRunTimeEndedAt
+		return enums.TraceRunTimeEndedAt, nil
 	default:
-		return enums.TraceRunTimeQueuedAt
+		return enums.TraceRunTimeQueuedAt, fmt.Errorf("unsupported run time field: %d", field)
 	}
 }
 

--- a/pkg/devserver/run_provider_test.go
+++ b/pkg/devserver/run_provider_test.go
@@ -229,6 +229,68 @@ func TestRunProviderGetEventRunsUsesSharedRunList(t *testing.T) {
 	assert.Equal(t, "next-cursor", result.Runs[0].Cursor)
 }
 
+func TestRunProviderGetRunsResolvesPublicFilters(t *testing.T) {
+	appID := uuid.New()
+	functionID := uuid.New()
+	runID := ulid.Make()
+	eventID := ulid.Make()
+	startedAt := time.Now().UTC()
+
+	data := &stubRunProviderDataReader{
+		listedRuns: []*cqrs.TraceRun{{
+			RunID:        runID.String(),
+			Cursor:       "next-cursor",
+			AppID:        appID,
+			AppName:      "inngest-ai",
+			FunctionID:   functionID,
+			FunctionSlug: "hello-world",
+			FunctionName: "Hello",
+			StartedAt:    startedAt,
+			Status:       enums.RunStatusCompleted,
+			TriggerIDs:   []string{eventID.String()},
+		}},
+	}
+	provider := &runProvider{data: data}
+	deferred := false
+
+	result, err := provider.GetRuns(t.Context(), apiv2.GetRunsOpts{
+		Limit:       20,
+		AppIDs:      []string{"inngest-ai"},
+		FunctionIDs: []string{"hello-world"},
+		IsDeferred:  &deferred,
+		Order:       apiv2.OrderDirectionAsc,
+		TimeField:   apiv2.RunTimeFieldStartedAt,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Runs, 1)
+	require.NotNil(t, data.listOpts)
+	assert.Equal(t, []string{"inngest-ai"}, data.listOpts.Filter.AppName)
+	assert.Equal(t, []string{"hello-world"}, data.listOpts.Filter.FunctionSlug)
+	assert.Equal(t, &deferred, data.listOpts.Filter.IsDeferred)
+	assert.Equal(t, uint(21), data.listOpts.Items)
+	assert.Equal(t, enums.TraceRunTimeStartedAt, data.listOpts.Filter.TimeField)
+	assert.Equal(t, enums.TraceRunOrderAsc, data.listOpts.Order[0].Direction)
+	assert.Equal(t, "inngest-ai", result.Runs[0].AppID)
+	assert.Equal(t, "hello-world", result.Runs[0].FunctionID)
+	assert.Equal(t, "Hello", result.Runs[0].FunctionName)
+	assert.Equal(t, eventID, result.Runs[0].EventID)
+	assert.Equal(t, "next-cursor", result.Runs[0].Cursor)
+}
+
+func TestRunProviderGetRunsSkipsUnknownPublicFilter(t *testing.T) {
+	data := &stubRunProviderDataReader{}
+	provider := &runProvider{data: data}
+
+	result, err := provider.GetRuns(t.Context(), apiv2.GetRunsOpts{
+		Limit:  20,
+		AppIDs: []string{"unknown-app"},
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.Runs)
+	require.NotNil(t, data.listOpts)
+	assert.Equal(t, []string{"unknown-app"}, data.listOpts.Filter.AppName)
+}
+
 type stubRunProviderDataReader struct {
 	run        *cqrs.FunctionRun
 	runErr     error

--- a/pkg/devserver/run_provider_test.go
+++ b/pkg/devserver/run_provider_test.go
@@ -291,6 +291,29 @@ func TestRunProviderGetRunsSkipsUnknownPublicFilter(t *testing.T) {
 	assert.Equal(t, []string{"unknown-app"}, data.listOpts.Filter.AppName)
 }
 
+func TestCQRSRunTimeField(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    apiv2.RunTimeField
+		expected enums.TraceRunTime
+	}{
+		{name: "queued", field: apiv2.RunTimeFieldQueuedAt, expected: enums.TraceRunTimeQueuedAt},
+		{name: "started", field: apiv2.RunTimeFieldStartedAt, expected: enums.TraceRunTimeStartedAt},
+		{name: "ended", field: apiv2.RunTimeFieldEndedAt, expected: enums.TraceRunTimeEndedAt},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := cqrsRunTimeField(tt.field)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, actual)
+		})
+	}
+
+	_, err := cqrsRunTimeField(apiv2.RunTimeField(99))
+	require.ErrorContains(t, err, "unsupported run time field")
+}
+
 type stubRunProviderDataReader struct {
 	run        *cqrs.FunctionRun
 	runErr     error

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -3115,18 +3115,18 @@ message ListRunsRequest {
   ];
   optional google.protobuf.Timestamp from = 4 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Start of the run time range"
+      description: "Inclusive start of the run time range"
     }
   ];
   optional google.protobuf.Timestamp until = 5 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "End of the run time range"
+      description: "Exclusive end of the run time range"
     }
   ];
   string time_field = 6 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Run timestamp field used for filtering and ordering. Accepts queuedAt, startedAt, or endedAt."
-      default: "queuedAt"
+      description: "Run timestamp field used for filtering and ordering. Accepts QUEUED_AT, STARTED_AT, or ENDED_AT."
+      default: "QUEUED_AT"
     }
   ];
   repeated string status = 7 [
@@ -3174,18 +3174,18 @@ message ListFunctionRunsRequest {
   ];
   optional google.protobuf.Timestamp from = 6 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Start of the run time range"
+      description: "Inclusive start of the run time range"
     }
   ];
   optional google.protobuf.Timestamp until = 7 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "End of the run time range"
+      description: "Exclusive end of the run time range"
     }
   ];
   string time_field = 8 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Run timestamp field used for filtering and ordering. Accepts queuedAt, startedAt, or endedAt."
-      default: "queuedAt"
+      description: "Run timestamp field used for filtering and ordering. Accepts QUEUED_AT, STARTED_AT, or ENDED_AT."
+      default: "QUEUED_AT"
     }
   ];
   repeated string status = 9 [

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -3120,13 +3120,13 @@ message ListRunsRequest {
   ];
   optional google.protobuf.Timestamp until = 5 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Exclusive end of the run time range"
+      description: "Inclusive end of the run time range"
     }
   ];
   string time_field = 6 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Run timestamp field used for filtering and ordering. Accepts QUEUED_AT, STARTED_AT, or ENDED_AT."
-      default: "QUEUED_AT"
+      description: "Run timestamp field used for filtering and ordering. Accepts queuedAt, startedAt, or endedAt. Snake case aliases such as QUEUED_AT, STARTED_AT, and ENDED_AT are also accepted."
+      default: "queuedAt"
     }
   ];
   repeated string status = 7 [
@@ -3179,13 +3179,13 @@ message ListFunctionRunsRequest {
   ];
   optional google.protobuf.Timestamp until = 7 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Exclusive end of the run time range"
+      description: "Inclusive end of the run time range"
     }
   ];
   string time_field = 8 [
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Run timestamp field used for filtering and ordering. Accepts QUEUED_AT, STARTED_AT, or ENDED_AT."
-      default: "QUEUED_AT"
+      description: "Run timestamp field used for filtering and ordering. Accepts queuedAt, startedAt, or endedAt. Snake case aliases such as QUEUED_AT, STARTED_AT, and ENDED_AT are also accepted."
+      default: "queuedAt"
     }
   ];
   repeated string status = 9 [

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -959,6 +959,42 @@ service V2 {
     };
   }
 
+  rpc ListRuns(ListRunsRequest) returns (ListRunsResponse) {
+    option (google.api.http) = {
+      get: "/runs"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List function runs"
+      tags: "Runs"
+      tags: "Beta"
+      description: "Lists function runs in the authenticated environment"
+      security: {
+        security_requirement: {
+          key: "BearerAuth"
+          value: {}
+        }
+      }
+    };
+  }
+
+  rpc ListFunctionRuns(ListFunctionRunsRequest) returns (ListFunctionRunsResponse) {
+    option (google.api.http) = {
+      get: "/apps/{app_id}/functions/{function_id}/runs"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List function runs"
+      tags: "Runs"
+      tags: "Beta"
+      description: "Lists runs for a function in the authenticated environment"
+      security: {
+        security_requirement: {
+          key: "BearerAuth"
+          value: {}
+        }
+      }
+    };
+  }
+
   rpc GetEventRuns(GetEventRunsRequest) returns (GetEventRunsResponse) {
     option (google.api.http) = {
       get: "/events/{event_id}/runs"
@@ -3062,4 +3098,122 @@ message SessionRun {
   google.protobuf.Timestamp queued_at = 5;
   optional google.protobuf.Timestamp started_at = 6;
   optional google.protobuf.Timestamp ended_at = 7;
+}
+
+message ListRunsRequest {
+  optional bool include_output = 1;
+  optional string cursor = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Pagination cursor from previous response"
+    }
+  ];
+  optional int32 limit = 3 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Number of runs to return per page (min: 1, max: 100)"
+      default: "20"
+    }
+  ];
+  optional google.protobuf.Timestamp from = 4 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Start of the run time range"
+    }
+  ];
+  optional google.protobuf.Timestamp until = 5 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "End of the run time range"
+    }
+  ];
+  string time_field = 6 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Run timestamp field used for filtering and ordering. Accepts queuedAt, startedAt, or endedAt."
+      default: "queuedAt"
+    }
+  ];
+  repeated string status = 7 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Statuses to include, using response status values such as COMPLETED, FAILED, RUNNING, QUEUED, or CANCELLED"
+    }
+  ];
+  repeated string app_id = 8 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "App IDs to include"
+    }
+  ];
+  repeated string function_id = 9 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Function IDs to include"
+    }
+  ];
+  optional bool is_deferred = 10 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Whether to include only deferred or non-deferred runs"
+    }
+  ];
+  string order = 11 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Sort direction. Accepts ASC or DESC."
+      default: "DESC"
+    }
+  ];
+}
+
+message ListFunctionRunsRequest {
+  string app_id = 1;
+  string function_id = 2;
+  optional bool include_output = 3;
+  optional string cursor = 4 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Pagination cursor from previous response"
+    }
+  ];
+  optional int32 limit = 5 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Number of runs to return per page (min: 1, max: 100)"
+      default: "20"
+    }
+  ];
+  optional google.protobuf.Timestamp from = 6 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Start of the run time range"
+    }
+  ];
+  optional google.protobuf.Timestamp until = 7 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "End of the run time range"
+    }
+  ];
+  string time_field = 8 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Run timestamp field used for filtering and ordering. Accepts queuedAt, startedAt, or endedAt."
+      default: "queuedAt"
+    }
+  ];
+  repeated string status = 9 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Statuses to include, using response status values such as COMPLETED, FAILED, RUNNING, QUEUED, or CANCELLED"
+    }
+  ];
+  optional bool is_deferred = 10 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Whether to include only deferred or non-deferred runs"
+    }
+  ];
+  string order = 11 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Sort direction. Accepts ASC or DESC."
+      default: "DESC"
+    }
+  ];
+}
+
+message ListRunsResponse {
+  repeated FunctionRun data = 1;
+  ResponseMetadata metadata = 2;
+  Page page = 3;
+}
+
+message ListFunctionRunsResponse {
+  repeated FunctionRun data = 1;
+  ResponseMetadata metadata = 2;
+  Page page = 3;
 }

--- a/proto/gen/api/v2/apiv2connect/service.connect.go
+++ b/proto/gen/api/v2/apiv2connect/service.connect.go
@@ -61,6 +61,10 @@ const (
 	V2PatchEnvProcedure = "/api.v2.V2/PatchEnv"
 	// V2GetFunctionRunProcedure is the fully-qualified name of the V2's GetFunctionRun RPC.
 	V2GetFunctionRunProcedure = "/api.v2.V2/GetFunctionRun"
+	// V2ListRunsProcedure is the fully-qualified name of the V2's ListRuns RPC.
+	V2ListRunsProcedure = "/api.v2.V2/ListRuns"
+	// V2ListFunctionRunsProcedure is the fully-qualified name of the V2's ListFunctionRuns RPC.
+	V2ListFunctionRunsProcedure = "/api.v2.V2/ListFunctionRuns"
 	// V2GetEventRunsProcedure is the fully-qualified name of the V2's GetEventRuns RPC.
 	V2GetEventRunsProcedure = "/api.v2.V2/GetEventRuns"
 	// V2RerunProcedure is the fully-qualified name of the V2's Rerun RPC.
@@ -118,6 +122,8 @@ type V2Client interface {
 	ListWebhooks(context.Context, *connect.Request[v2.ListWebhooksRequest]) (*connect.Response[v2.ListWebhooksResponse], error)
 	PatchEnv(context.Context, *connect.Request[v2.PatchEnvRequest]) (*connect.Response[v2.PatchEnvsResponse], error)
 	GetFunctionRun(context.Context, *connect.Request[v2.GetFunctionRunRequest]) (*connect.Response[v2.GetFunctionRunResponse], error)
+	ListRuns(context.Context, *connect.Request[v2.ListRunsRequest]) (*connect.Response[v2.ListRunsResponse], error)
+	ListFunctionRuns(context.Context, *connect.Request[v2.ListFunctionRunsRequest]) (*connect.Response[v2.ListFunctionRunsResponse], error)
 	GetEventRuns(context.Context, *connect.Request[v2.GetEventRunsRequest]) (*connect.Response[v2.GetEventRunsResponse], error)
 	Rerun(context.Context, *connect.Request[v2.RerunRequest]) (*connect.Response[v2.RerunResponse], error)
 	GetApp(context.Context, *connect.Request[v2.GetAppRequest]) (*connect.Response[v2.GetAppResponse], error)
@@ -225,6 +231,18 @@ func NewV2Client(httpClient connect.HTTPClient, baseURL string, opts ...connect.
 			httpClient,
 			baseURL+V2GetFunctionRunProcedure,
 			connect.WithSchema(v2Methods.ByName("GetFunctionRun")),
+			connect.WithClientOptions(opts...),
+		),
+		listRuns: connect.NewClient[v2.ListRunsRequest, v2.ListRunsResponse](
+			httpClient,
+			baseURL+V2ListRunsProcedure,
+			connect.WithSchema(v2Methods.ByName("ListRuns")),
+			connect.WithClientOptions(opts...),
+		),
+		listFunctionRuns: connect.NewClient[v2.ListFunctionRunsRequest, v2.ListFunctionRunsResponse](
+			httpClient,
+			baseURL+V2ListFunctionRunsProcedure,
+			connect.WithSchema(v2Methods.ByName("ListFunctionRuns")),
 			connect.WithClientOptions(opts...),
 		),
 		getEventRuns: connect.NewClient[v2.GetEventRunsRequest, v2.GetEventRunsResponse](
@@ -353,6 +371,8 @@ type v2Client struct {
 	listWebhooks             *connect.Client[v2.ListWebhooksRequest, v2.ListWebhooksResponse]
 	patchEnv                 *connect.Client[v2.PatchEnvRequest, v2.PatchEnvsResponse]
 	getFunctionRun           *connect.Client[v2.GetFunctionRunRequest, v2.GetFunctionRunResponse]
+	listRuns                 *connect.Client[v2.ListRunsRequest, v2.ListRunsResponse]
+	listFunctionRuns         *connect.Client[v2.ListFunctionRunsRequest, v2.ListFunctionRunsResponse]
 	getEventRuns             *connect.Client[v2.GetEventRunsRequest, v2.GetEventRunsResponse]
 	rerun                    *connect.Client[v2.RerunRequest, v2.RerunResponse]
 	getApp                   *connect.Client[v2.GetAppRequest, v2.GetAppResponse]
@@ -436,6 +456,16 @@ func (c *v2Client) PatchEnv(ctx context.Context, req *connect.Request[v2.PatchEn
 // GetFunctionRun calls api.v2.V2.GetFunctionRun.
 func (c *v2Client) GetFunctionRun(ctx context.Context, req *connect.Request[v2.GetFunctionRunRequest]) (*connect.Response[v2.GetFunctionRunResponse], error) {
 	return c.getFunctionRun.CallUnary(ctx, req)
+}
+
+// ListRuns calls api.v2.V2.ListRuns.
+func (c *v2Client) ListRuns(ctx context.Context, req *connect.Request[v2.ListRunsRequest]) (*connect.Response[v2.ListRunsResponse], error) {
+	return c.listRuns.CallUnary(ctx, req)
+}
+
+// ListFunctionRuns calls api.v2.V2.ListFunctionRuns.
+func (c *v2Client) ListFunctionRuns(ctx context.Context, req *connect.Request[v2.ListFunctionRunsRequest]) (*connect.Response[v2.ListFunctionRunsResponse], error) {
+	return c.listFunctionRuns.CallUnary(ctx, req)
 }
 
 // GetEventRuns calls api.v2.V2.GetEventRuns.
@@ -546,6 +576,8 @@ type V2Handler interface {
 	ListWebhooks(context.Context, *connect.Request[v2.ListWebhooksRequest]) (*connect.Response[v2.ListWebhooksResponse], error)
 	PatchEnv(context.Context, *connect.Request[v2.PatchEnvRequest]) (*connect.Response[v2.PatchEnvsResponse], error)
 	GetFunctionRun(context.Context, *connect.Request[v2.GetFunctionRunRequest]) (*connect.Response[v2.GetFunctionRunResponse], error)
+	ListRuns(context.Context, *connect.Request[v2.ListRunsRequest]) (*connect.Response[v2.ListRunsResponse], error)
+	ListFunctionRuns(context.Context, *connect.Request[v2.ListFunctionRunsRequest]) (*connect.Response[v2.ListFunctionRunsResponse], error)
 	GetEventRuns(context.Context, *connect.Request[v2.GetEventRunsRequest]) (*connect.Response[v2.GetEventRunsResponse], error)
 	Rerun(context.Context, *connect.Request[v2.RerunRequest]) (*connect.Response[v2.RerunResponse], error)
 	GetApp(context.Context, *connect.Request[v2.GetAppRequest]) (*connect.Response[v2.GetAppResponse], error)
@@ -649,6 +681,18 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 		V2GetFunctionRunProcedure,
 		svc.GetFunctionRun,
 		connect.WithSchema(v2Methods.ByName("GetFunctionRun")),
+		connect.WithHandlerOptions(opts...),
+	)
+	v2ListRunsHandler := connect.NewUnaryHandler(
+		V2ListRunsProcedure,
+		svc.ListRuns,
+		connect.WithSchema(v2Methods.ByName("ListRuns")),
+		connect.WithHandlerOptions(opts...),
+	)
+	v2ListFunctionRunsHandler := connect.NewUnaryHandler(
+		V2ListFunctionRunsProcedure,
+		svc.ListFunctionRuns,
+		connect.WithSchema(v2Methods.ByName("ListFunctionRuns")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2GetEventRunsHandler := connect.NewUnaryHandler(
@@ -787,6 +831,10 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 			v2PatchEnvHandler.ServeHTTP(w, r)
 		case V2GetFunctionRunProcedure:
 			v2GetFunctionRunHandler.ServeHTTP(w, r)
+		case V2ListRunsProcedure:
+			v2ListRunsHandler.ServeHTTP(w, r)
+		case V2ListFunctionRunsProcedure:
+			v2ListFunctionRunsHandler.ServeHTTP(w, r)
 		case V2GetEventRunsProcedure:
 			v2GetEventRunsHandler.ServeHTTP(w, r)
 		case V2RerunProcedure:
@@ -882,6 +930,14 @@ func (UnimplementedV2Handler) PatchEnv(context.Context, *connect.Request[v2.Patc
 
 func (UnimplementedV2Handler) GetFunctionRun(context.Context, *connect.Request[v2.GetFunctionRunRequest]) (*connect.Response[v2.GetFunctionRunResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.GetFunctionRun is not implemented"))
+}
+
+func (UnimplementedV2Handler) ListRuns(context.Context, *connect.Request[v2.ListRunsRequest]) (*connect.Response[v2.ListRunsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.ListRuns is not implemented"))
+}
+
+func (UnimplementedV2Handler) ListFunctionRuns(context.Context, *connect.Request[v2.ListFunctionRunsRequest]) (*connect.Response[v2.ListFunctionRunsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.ListFunctionRuns is not implemented"))
 }
 
 func (UnimplementedV2Handler) GetEventRuns(context.Context, *connect.Request[v2.GetEventRunsRequest]) (*connect.Response[v2.GetEventRunsResponse], error) {

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -8059,6 +8059,374 @@ func (x *SessionRun) GetEndedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+type ListRunsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	IncludeOutput *bool                  `protobuf:"varint,1,opt,name=include_output,json=includeOutput,proto3,oneof" json:"include_output,omitempty"`
+	Cursor        *string                `protobuf:"bytes,2,opt,name=cursor,proto3,oneof" json:"cursor,omitempty"`
+	Limit         *int32                 `protobuf:"varint,3,opt,name=limit,proto3,oneof" json:"limit,omitempty"`
+	From          *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=from,proto3,oneof" json:"from,omitempty"`
+	Until         *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=until,proto3,oneof" json:"until,omitempty"`
+	TimeField     string                 `protobuf:"bytes,6,opt,name=time_field,json=timeField,proto3" json:"time_field,omitempty"`
+	Status        []string               `protobuf:"bytes,7,rep,name=status,proto3" json:"status,omitempty"`
+	AppId         []string               `protobuf:"bytes,8,rep,name=app_id,json=appId,proto3" json:"app_id,omitempty"`
+	FunctionId    []string               `protobuf:"bytes,9,rep,name=function_id,json=functionId,proto3" json:"function_id,omitempty"`
+	IsDeferred    *bool                  `protobuf:"varint,10,opt,name=is_deferred,json=isDeferred,proto3,oneof" json:"is_deferred,omitempty"`
+	Order         string                 `protobuf:"bytes,11,opt,name=order,proto3" json:"order,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRunsRequest) Reset() {
+	*x = ListRunsRequest{}
+	mi := &file_api_v2_service_proto_msgTypes[121]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRunsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRunsRequest) ProtoMessage() {}
+
+func (x *ListRunsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[121]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRunsRequest.ProtoReflect.Descriptor instead.
+func (*ListRunsRequest) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{121}
+}
+
+func (x *ListRunsRequest) GetIncludeOutput() bool {
+	if x != nil && x.IncludeOutput != nil {
+		return *x.IncludeOutput
+	}
+	return false
+}
+
+func (x *ListRunsRequest) GetCursor() string {
+	if x != nil && x.Cursor != nil {
+		return *x.Cursor
+	}
+	return ""
+}
+
+func (x *ListRunsRequest) GetLimit() int32 {
+	if x != nil && x.Limit != nil {
+		return *x.Limit
+	}
+	return 0
+}
+
+func (x *ListRunsRequest) GetFrom() *timestamppb.Timestamp {
+	if x != nil {
+		return x.From
+	}
+	return nil
+}
+
+func (x *ListRunsRequest) GetUntil() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Until
+	}
+	return nil
+}
+
+func (x *ListRunsRequest) GetTimeField() string {
+	if x != nil {
+		return x.TimeField
+	}
+	return ""
+}
+
+func (x *ListRunsRequest) GetStatus() []string {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+func (x *ListRunsRequest) GetAppId() []string {
+	if x != nil {
+		return x.AppId
+	}
+	return nil
+}
+
+func (x *ListRunsRequest) GetFunctionId() []string {
+	if x != nil {
+		return x.FunctionId
+	}
+	return nil
+}
+
+func (x *ListRunsRequest) GetIsDeferred() bool {
+	if x != nil && x.IsDeferred != nil {
+		return *x.IsDeferred
+	}
+	return false
+}
+
+func (x *ListRunsRequest) GetOrder() string {
+	if x != nil {
+		return x.Order
+	}
+	return ""
+}
+
+type ListFunctionRunsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	AppId         string                 `protobuf:"bytes,1,opt,name=app_id,json=appId,proto3" json:"app_id,omitempty"`
+	FunctionId    string                 `protobuf:"bytes,2,opt,name=function_id,json=functionId,proto3" json:"function_id,omitempty"`
+	IncludeOutput *bool                  `protobuf:"varint,3,opt,name=include_output,json=includeOutput,proto3,oneof" json:"include_output,omitempty"`
+	Cursor        *string                `protobuf:"bytes,4,opt,name=cursor,proto3,oneof" json:"cursor,omitempty"`
+	Limit         *int32                 `protobuf:"varint,5,opt,name=limit,proto3,oneof" json:"limit,omitempty"`
+	From          *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=from,proto3,oneof" json:"from,omitempty"`
+	Until         *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=until,proto3,oneof" json:"until,omitempty"`
+	TimeField     string                 `protobuf:"bytes,8,opt,name=time_field,json=timeField,proto3" json:"time_field,omitempty"`
+	Status        []string               `protobuf:"bytes,9,rep,name=status,proto3" json:"status,omitempty"`
+	IsDeferred    *bool                  `protobuf:"varint,10,opt,name=is_deferred,json=isDeferred,proto3,oneof" json:"is_deferred,omitempty"`
+	Order         string                 `protobuf:"bytes,11,opt,name=order,proto3" json:"order,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListFunctionRunsRequest) Reset() {
+	*x = ListFunctionRunsRequest{}
+	mi := &file_api_v2_service_proto_msgTypes[122]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListFunctionRunsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListFunctionRunsRequest) ProtoMessage() {}
+
+func (x *ListFunctionRunsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[122]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListFunctionRunsRequest.ProtoReflect.Descriptor instead.
+func (*ListFunctionRunsRequest) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{122}
+}
+
+func (x *ListFunctionRunsRequest) GetAppId() string {
+	if x != nil {
+		return x.AppId
+	}
+	return ""
+}
+
+func (x *ListFunctionRunsRequest) GetFunctionId() string {
+	if x != nil {
+		return x.FunctionId
+	}
+	return ""
+}
+
+func (x *ListFunctionRunsRequest) GetIncludeOutput() bool {
+	if x != nil && x.IncludeOutput != nil {
+		return *x.IncludeOutput
+	}
+	return false
+}
+
+func (x *ListFunctionRunsRequest) GetCursor() string {
+	if x != nil && x.Cursor != nil {
+		return *x.Cursor
+	}
+	return ""
+}
+
+func (x *ListFunctionRunsRequest) GetLimit() int32 {
+	if x != nil && x.Limit != nil {
+		return *x.Limit
+	}
+	return 0
+}
+
+func (x *ListFunctionRunsRequest) GetFrom() *timestamppb.Timestamp {
+	if x != nil {
+		return x.From
+	}
+	return nil
+}
+
+func (x *ListFunctionRunsRequest) GetUntil() *timestamppb.Timestamp {
+	if x != nil {
+		return x.Until
+	}
+	return nil
+}
+
+func (x *ListFunctionRunsRequest) GetTimeField() string {
+	if x != nil {
+		return x.TimeField
+	}
+	return ""
+}
+
+func (x *ListFunctionRunsRequest) GetStatus() []string {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+func (x *ListFunctionRunsRequest) GetIsDeferred() bool {
+	if x != nil && x.IsDeferred != nil {
+		return *x.IsDeferred
+	}
+	return false
+}
+
+func (x *ListFunctionRunsRequest) GetOrder() string {
+	if x != nil {
+		return x.Order
+	}
+	return ""
+}
+
+type ListRunsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Data          []*FunctionRun         `protobuf:"bytes,1,rep,name=data,proto3" json:"data,omitempty"`
+	Metadata      *ResponseMetadata      `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	Page          *Page                  `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListRunsResponse) Reset() {
+	*x = ListRunsResponse{}
+	mi := &file_api_v2_service_proto_msgTypes[123]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListRunsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListRunsResponse) ProtoMessage() {}
+
+func (x *ListRunsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[123]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListRunsResponse.ProtoReflect.Descriptor instead.
+func (*ListRunsResponse) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{123}
+}
+
+func (x *ListRunsResponse) GetData() []*FunctionRun {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+func (x *ListRunsResponse) GetMetadata() *ResponseMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *ListRunsResponse) GetPage() *Page {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+type ListFunctionRunsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Data          []*FunctionRun         `protobuf:"bytes,1,rep,name=data,proto3" json:"data,omitempty"`
+	Metadata      *ResponseMetadata      `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	Page          *Page                  `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListFunctionRunsResponse) Reset() {
+	*x = ListFunctionRunsResponse{}
+	mi := &file_api_v2_service_proto_msgTypes[124]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListFunctionRunsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListFunctionRunsResponse) ProtoMessage() {}
+
+func (x *ListFunctionRunsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[124]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListFunctionRunsResponse.ProtoReflect.Descriptor instead.
+func (*ListFunctionRunsResponse) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{124}
+}
+
+func (x *ListFunctionRunsResponse) GetData() []*FunctionRun {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+func (x *ListFunctionRunsResponse) GetMetadata() *ResponseMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *ListFunctionRunsResponse) GetPage() *Page {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
 var File_api_v2_service_proto protoreflect.FileDescriptor
 
 const file_api_v2_service_proto_rawDesc = "" +
@@ -8743,7 +9111,59 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\bended_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampH\x02R\aendedAt\x88\x01\x01B\r\n" +
 	"\v_event_nameB\r\n" +
 	"\v_started_atB\v\n" +
-	"\t_ended_at*\xdf\x01\n" +
+	"\t_ended_at\"\x8c\b\n" +
+	"\x0fListRunsRequest\x12*\n" +
+	"\x0einclude_output\x18\x01 \x01(\bH\x00R\rincludeOutput\x88\x01\x01\x12J\n" +
+	"\x06cursor\x18\x02 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x01R\x06cursor\x88\x01\x01\x12X\n" +
+	"\x05limit\x18\x03 \x01(\x05B=\x92A:24Number of runs to return per page (min: 1, max: 100):\x0220H\x02R\x05limit\x88\x01\x01\x12U\n" +
+	"\x04from\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampB \x92A\x1d2\x1bStart of the run time rangeH\x03R\x04from\x88\x01\x01\x12U\n" +
+	"\x05until\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampB\x1e\x92A\x1b2\x19End of the run time rangeH\x04R\x05until\x88\x01\x01\x12\x8b\x01\n" +
+	"\n" +
+	"time_field\x18\x06 \x01(\tBl\x92Ai2]Run timestamp field used for filtering and ordering. Accepts queuedAt, startedAt, or endedAt.:\bqueuedAtR\ttimeField\x12\x87\x01\n" +
+	"\x06status\x18\a \x03(\tBo\x92Al2jStatuses to include, using response status values such as COMPLETED, FAILED, RUNNING, QUEUED, or CANCELLEDR\x06status\x12.\n" +
+	"\x06app_id\x18\b \x03(\tB\x17\x92A\x142\x12App IDs to includeR\x05appId\x12=\n" +
+	"\vfunction_id\x18\t \x03(\tB\x1c\x92A\x192\x17Function IDs to includeR\n" +
+	"functionId\x12`\n" +
+	"\vis_deferred\x18\n" +
+	" \x01(\bB:\x92A725Whether to include only deferred or non-deferred runsH\x05R\n" +
+	"isDeferred\x88\x01\x01\x12E\n" +
+	"\x05order\x18\v \x01(\tB/\x92A,2$Sort direction. Accepts ASC or DESC.:\x04DESCR\x05orderB\x11\n" +
+	"\x0f_include_outputB\t\n" +
+	"\a_cursorB\b\n" +
+	"\x06_limitB\a\n" +
+	"\x05_fromB\b\n" +
+	"\x06_untilB\x0e\n" +
+	"\f_is_deferred\"\xdd\a\n" +
+	"\x17ListFunctionRunsRequest\x12\x15\n" +
+	"\x06app_id\x18\x01 \x01(\tR\x05appId\x12\x1f\n" +
+	"\vfunction_id\x18\x02 \x01(\tR\n" +
+	"functionId\x12*\n" +
+	"\x0einclude_output\x18\x03 \x01(\bH\x00R\rincludeOutput\x88\x01\x01\x12J\n" +
+	"\x06cursor\x18\x04 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x01R\x06cursor\x88\x01\x01\x12X\n" +
+	"\x05limit\x18\x05 \x01(\x05B=\x92A:24Number of runs to return per page (min: 1, max: 100):\x0220H\x02R\x05limit\x88\x01\x01\x12U\n" +
+	"\x04from\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampB \x92A\x1d2\x1bStart of the run time rangeH\x03R\x04from\x88\x01\x01\x12U\n" +
+	"\x05until\x18\a \x01(\v2\x1a.google.protobuf.TimestampB\x1e\x92A\x1b2\x19End of the run time rangeH\x04R\x05until\x88\x01\x01\x12\x8b\x01\n" +
+	"\n" +
+	"time_field\x18\b \x01(\tBl\x92Ai2]Run timestamp field used for filtering and ordering. Accepts queuedAt, startedAt, or endedAt.:\bqueuedAtR\ttimeField\x12\x87\x01\n" +
+	"\x06status\x18\t \x03(\tBo\x92Al2jStatuses to include, using response status values such as COMPLETED, FAILED, RUNNING, QUEUED, or CANCELLEDR\x06status\x12`\n" +
+	"\vis_deferred\x18\n" +
+	" \x01(\bB:\x92A725Whether to include only deferred or non-deferred runsH\x05R\n" +
+	"isDeferred\x88\x01\x01\x12E\n" +
+	"\x05order\x18\v \x01(\tB/\x92A,2$Sort direction. Accepts ASC or DESC.:\x04DESCR\x05orderB\x11\n" +
+	"\x0f_include_outputB\t\n" +
+	"\a_cursorB\b\n" +
+	"\x06_limitB\a\n" +
+	"\x05_fromB\b\n" +
+	"\x06_untilB\x0e\n" +
+	"\f_is_deferred\"\x93\x01\n" +
+	"\x10ListRunsResponse\x12'\n" +
+	"\x04data\x18\x01 \x03(\v2\x13.api.v2.FunctionRunR\x04data\x124\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\x12 \n" +
+	"\x04page\x18\x03 \x01(\v2\f.api.v2.PageR\x04page\"\x9b\x01\n" +
+	"\x18ListFunctionRunsResponse\x12'\n" +
+	"\x04data\x18\x01 \x03(\v2\x13.api.v2.FunctionRunR\x04data\x124\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\x12 \n" +
+	"\x04page\x18\x03 \x01(\v2\f.api.v2.PageR\x04page*\xdf\x01\n" +
 	"\x11FunctionRunStatus\x12#\n" +
 	"\x1fFUNCTION_RUN_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aFUNCTION_RUN_STATUS_QUEUED\x10\x01\x12\x1f\n" +
@@ -8809,7 +9229,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05ERROR\x10\x01\x12\v\n" +
 	"\aWARNING\x10\x02\x12\b\n" +
-	"\x04INFO\x10\x032\xcf\x7f\n" +
+	"\x04INFO\x10\x032\x88\x83\x01\n" +
 	"\x02V2\x12\xbc\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\x82\x02\x92A\xef\x01\n" +
 	"\bInternal\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
@@ -9063,7 +9483,19 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x04Beta\x12\x10Get function run\x1a;Fetches the canonical run summary for a single function runb\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x10\x12\x0e/runs/{run_id}\x12\xcf\x01\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x10\x12\x0e/runs/{run_id}\x12\xb7\x01\n" +
+	"\bListRuns\x12\x17.api.v2.ListRunsRequest\x1a\x18.api.v2.ListRunsResponse\"x\x92Ah\n" +
+	"\x04Runs\n" +
+	"\x04Beta\x12\x12List function runs\x1a4Lists function runs in the authenticated environmentb\x10\n" +
+	"\x0e\n" +
+	"\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\a\x12\x05/runs\x12\xfc\x01\n" +
+	"\x10ListFunctionRuns\x12\x1f.api.v2.ListFunctionRunsRequest\x1a .api.v2.ListFunctionRunsResponse\"\xa4\x01\x92An\n" +
+	"\x04Runs\n" +
+	"\x04Beta\x12\x12List function runs\x1a:Lists runs for a function in the authenticated environmentb\x10\n" +
+	"\x0e\n" +
+	"\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02-\x12+/apps/{app_id}/functions/{function_id}/runs\x12\xcf\x01\n" +
 	"\fGetEventRuns\x12\x1b.api.v2.GetEventRunsRequest\x1a\x1c.api.v2.GetEventRunsResponse\"\x83\x01\x92Aa\n" +
 	"\x04Runs\n" +
 	"\x04Beta\x12\x0eGet event runs\x1a1Lists function runs triggered by a specific eventb\x10\n" +
@@ -9324,7 +9756,7 @@ func file_api_v2_service_proto_rawDescGZIP() []byte {
 }
 
 var file_api_v2_service_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
-var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 122)
+var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 126)
 var file_api_v2_service_proto_goTypes = []any{
 	(FunctionRunStatus)(0),                        // 0: api.v2.FunctionRunStatus
 	(TraceSpanStatus)(0),                          // 1: api.v2.TraceSpanStatus
@@ -9458,21 +9890,25 @@ var file_api_v2_service_proto_goTypes = []any{
 	(*ListSessionRunsRequest)(nil),                // 129: api.v2.ListSessionRunsRequest
 	(*ListSessionRunsResponse)(nil),               // 130: api.v2.ListSessionRunsResponse
 	(*SessionRun)(nil),                            // 131: api.v2.SessionRun
-	nil,                                           // 132: api.v2.TraceSpanMetadata.ValuesEntry
-	(*timestamppb.Timestamp)(nil),                 // 133: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                       // 134: google.protobuf.Struct
-	(*structpb.ListValue)(nil),                    // 135: google.protobuf.ListValue
-	(*structpb.Value)(nil),                        // 136: google.protobuf.Value
+	(*ListRunsRequest)(nil),                       // 132: api.v2.ListRunsRequest
+	(*ListFunctionRunsRequest)(nil),               // 133: api.v2.ListFunctionRunsRequest
+	(*ListRunsResponse)(nil),                      // 134: api.v2.ListRunsResponse
+	(*ListFunctionRunsResponse)(nil),              // 135: api.v2.ListFunctionRunsResponse
+	nil,                                           // 136: api.v2.TraceSpanMetadata.ValuesEntry
+	(*timestamppb.Timestamp)(nil),                 // 137: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                       // 138: google.protobuf.Struct
+	(*structpb.ListValue)(nil),                    // 139: google.protobuf.ListValue
+	(*structpb.Value)(nil),                        // 140: google.protobuf.Value
 }
 var file_api_v2_service_proto_depIdxs = []int32{
 	14,  // 0: api.v2.HealthResponse.data:type_name -> api.v2.HealthData
 	17,  // 1: api.v2.HealthResponse.metadata:type_name -> api.v2.ResponseMetadata
 	15,  // 2: api.v2.ErrorResponse.errors:type_name -> api.v2.Error
-	133, // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
-	133, // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
+	137, // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
+	137, // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
 	18,  // 5: api.v2.ResponseMetadata.time_range:type_name -> api.v2.TimeRange
-	133, // 6: api.v2.TimeRange.from:type_name -> google.protobuf.Timestamp
-	133, // 7: api.v2.TimeRange.until:type_name -> google.protobuf.Timestamp
+	137, // 6: api.v2.TimeRange.from:type_name -> google.protobuf.Timestamp
+	137, // 7: api.v2.TimeRange.until:type_name -> google.protobuf.Timestamp
 	20,  // 8: api.v2.FunctionRef.app:type_name -> api.v2.AppRef
 	3,   // 9: api.v2.FunctionTrigger.type:type_name -> api.v2.FunctionTriggerType
 	4,   // 10: api.v2.FunctionConcurrencyConfiguration.scope:type_name -> api.v2.FunctionConcurrencyScope
@@ -9493,29 +9929,29 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	19,  // 25: api.v2.FunctionRun.function:type_name -> api.v2.FunctionRef
 	20,  // 26: api.v2.FunctionRun.app:type_name -> api.v2.AppRef
 	0,   // 27: api.v2.FunctionRun.status:type_name -> api.v2.FunctionRunStatus
-	133, // 28: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
-	133, // 29: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
-	133, // 30: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
+	137, // 28: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
+	137, // 29: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
+	137, // 30: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
 	35,  // 31: api.v2.FunctionRun.trigger:type_name -> api.v2.RunTrigger
-	134, // 32: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
+	138, // 32: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
 	36,  // 33: api.v2.GetFunctionRunResponse.data:type_name -> api.v2.FunctionRun
 	17,  // 34: api.v2.GetFunctionRunResponse.metadata:type_name -> api.v2.ResponseMetadata
 	36,  // 35: api.v2.GetEventRunsResponse.data:type_name -> api.v2.FunctionRun
 	17,  // 36: api.v2.GetEventRunsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 37: api.v2.GetEventRunsResponse.page:type_name -> api.v2.Page
 	42,  // 38: api.v2.RerunRequest.from_step:type_name -> api.v2.RerunFromStep
-	135, // 39: api.v2.RerunFromStep.input:type_name -> google.protobuf.ListValue
+	139, // 39: api.v2.RerunFromStep.input:type_name -> google.protobuf.ListValue
 	44,  // 40: api.v2.RerunResponse.data:type_name -> api.v2.RerunData
 	17,  // 41: api.v2.RerunResponse.metadata:type_name -> api.v2.ResponseMetadata
-	132, // 42: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
-	133, // 43: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
+	136, // 42: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
+	137, // 43: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
 	1,   // 44: api.v2.TraceSpan.status:type_name -> api.v2.TraceSpanStatus
 	2,   // 45: api.v2.TraceSpan.step_op:type_name -> api.v2.TraceStepOp
-	133, // 46: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
-	133, // 47: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
-	133, // 48: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
-	134, // 49: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
-	134, // 50: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
+	137, // 46: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
+	137, // 47: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
+	137, // 48: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
+	138, // 49: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
+	138, // 50: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
 	45,  // 51: api.v2.TraceSpan.metadata:type_name -> api.v2.TraceSpanMetadata
 	46,  // 52: api.v2.TraceSpan.children:type_name -> api.v2.TraceSpan
 	46,  // 53: api.v2.FunctionTrace.root_span:type_name -> api.v2.TraceSpan
@@ -9524,10 +9960,10 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	34,  // 56: api.v2.GetFunctionResponse.data:type_name -> api.v2.Function
 	17,  // 57: api.v2.GetFunctionResponse.metadata:type_name -> api.v2.ResponseMetadata
 	6,   // 58: api.v2.App.method:type_name -> api.v2.AppMethod
-	133, // 59: api.v2.App.created_at:type_name -> google.protobuf.Timestamp
-	133, // 60: api.v2.App.archived_at:type_name -> google.protobuf.Timestamp
+	137, // 59: api.v2.App.created_at:type_name -> google.protobuf.Timestamp
+	137, // 60: api.v2.App.archived_at:type_name -> google.protobuf.Timestamp
 	53,  // 61: api.v2.App.latest_sync:type_name -> api.v2.AppSync
-	133, // 62: api.v2.AppSync.synced_at:type_name -> google.protobuf.Timestamp
+	137, // 62: api.v2.AppSync.synced_at:type_name -> google.protobuf.Timestamp
 	52,  // 63: api.v2.GetAppResponse.data:type_name -> api.v2.App
 	17,  // 64: api.v2.GetAppResponse.metadata:type_name -> api.v2.ResponseMetadata
 	34,  // 65: api.v2.GetFunctionsResponse.data:type_name -> api.v2.Function
@@ -9538,27 +9974,27 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	62,  // 70: api.v2.CreateEnvResponse.data:type_name -> api.v2.Env
 	17,  // 71: api.v2.CreateEnvResponse.metadata:type_name -> api.v2.ResponseMetadata
 	7,   // 72: api.v2.Env.type:type_name -> api.v2.EnvType
-	133, // 73: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
-	133, // 74: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
-	133, // 75: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
+	137, // 73: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
+	137, // 74: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
+	137, // 75: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
 	67,  // 76: api.v2.FetchAccountsResponse.data:type_name -> api.v2.Account
 	17,  // 77: api.v2.FetchAccountsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 78: api.v2.FetchAccountsResponse.page:type_name -> api.v2.Page
 	67,  // 79: api.v2.FetchAccountResponse.data:type_name -> api.v2.Account
 	17,  // 80: api.v2.FetchAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
-	133, // 81: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
-	133, // 82: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
+	137, // 81: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
+	137, // 82: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
 	71,  // 83: api.v2.FetchAccountEventKeysResponse.data:type_name -> api.v2.EventKey
 	17,  // 84: api.v2.FetchAccountEventKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 85: api.v2.FetchAccountEventKeysResponse.page:type_name -> api.v2.Page
-	133, // 86: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
+	137, // 86: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
 	62,  // 87: api.v2.FetchAccountEnvsResponse.data:type_name -> api.v2.Env
 	17,  // 88: api.v2.FetchAccountEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 89: api.v2.FetchAccountEnvsResponse.page:type_name -> api.v2.Page
 	76,  // 90: api.v2.FetchAccountSigningKeysResponse.data:type_name -> api.v2.SigningKey
 	17,  // 91: api.v2.FetchAccountSigningKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 92: api.v2.FetchAccountSigningKeysResponse.page:type_name -> api.v2.Page
-	133, // 93: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
+	137, // 93: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
 	79,  // 94: api.v2.CreateWebhookRequest.event_filter:type_name -> api.v2.EventFilter
 	82,  // 95: api.v2.CreateWebhookResponse.data:type_name -> api.v2.Webhook
 	17,  // 96: api.v2.CreateWebhookResponse.metadata:type_name -> api.v2.ResponseMetadata
@@ -9567,22 +10003,22 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	17,  // 99: api.v2.ListWebhooksResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 100: api.v2.ListWebhooksResponse.page:type_name -> api.v2.Page
 	79,  // 101: api.v2.Webhook.event_filter:type_name -> api.v2.EventFilter
-	133, // 102: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
-	133, // 103: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
+	137, // 102: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
+	137, // 103: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
 	62,  // 104: api.v2.PatchEnvsResponse.data:type_name -> api.v2.Env
 	17,  // 105: api.v2.PatchEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	134, // 106: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
+	138, // 106: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
 	87,  // 107: api.v2.InvokeFunctionResponse.data:type_name -> api.v2.InvokeFunctionData
 	17,  // 108: api.v2.InvokeFunctionResponse.metadata:type_name -> api.v2.ResponseMetadata
-	133, // 109: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
-	133, // 110: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
-	133, // 111: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
+	137, // 109: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
+	137, // 110: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
+	137, // 111: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
 	89,  // 112: api.v2.CreateScoreRequest.scores:type_name -> api.v2.CreateScoreInput
-	136, // 113: api.v2.CreateScoreInput.value:type_name -> google.protobuf.Value
+	140, // 113: api.v2.CreateScoreInput.value:type_name -> google.protobuf.Value
 	90,  // 114: api.v2.CreateScoreInput.experiment:type_name -> api.v2.ScoreExperiment
 	92,  // 115: api.v2.CreateScoreResponse.data:type_name -> api.v2.Score
 	17,  // 116: api.v2.CreateScoreResponse.metadata:type_name -> api.v2.ResponseMetadata
-	136, // 117: api.v2.Score.value:type_name -> google.protobuf.Value
+	140, // 117: api.v2.Score.value:type_name -> google.protobuf.Value
 	90,  // 118: api.v2.Score.experiment:type_name -> api.v2.ScoreExperiment
 	95,  // 119: api.v2.SyncAppResponse.data:type_name -> api.v2.SyncAppData
 	17,  // 120: api.v2.SyncAppResponse.metadata:type_name -> api.v2.ResponseMetadata
@@ -9593,7 +10029,7 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	101, // 125: api.v2.QueryInsightsData.rows:type_name -> api.v2.InsightsRow
 	102, // 126: api.v2.QueryInsightsData.diagnostics:type_name -> api.v2.InsightsDiagnostic
 	9,   // 127: api.v2.InsightsOutputColumn.type:type_name -> api.v2.InsightsOutputColumnType
-	136, // 128: api.v2.InsightsRow.values:type_name -> google.protobuf.Value
+	140, // 128: api.v2.InsightsRow.values:type_name -> google.protobuf.Value
 	10,  // 129: api.v2.InsightsDiagnostic.severity:type_name -> api.v2.InsightsDiagnosticSeverity
 	103, // 130: api.v2.InsightsDiagnostic.position:type_name -> api.v2.InsightsDiagnosticPosition
 	106, // 131: api.v2.ListInsightsTablesResponse.data:type_name -> api.v2.InsightsTable
@@ -9604,112 +10040,126 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	113, // 136: api.v2.ListInsightsEventSchemasResponse.data:type_name -> api.v2.InsightsEventSchema
 	17,  // 137: api.v2.ListInsightsEventSchemasResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 138: api.v2.ListInsightsEventSchemasResponse.page:type_name -> api.v2.Page
-	134, // 139: api.v2.InsightsEventSchema.schema:type_name -> google.protobuf.Struct
-	133, // 140: api.v2.ListExperimentsRequest.from:type_name -> google.protobuf.Timestamp
-	133, // 141: api.v2.ListExperimentsRequest.until:type_name -> google.protobuf.Timestamp
+	138, // 139: api.v2.InsightsEventSchema.schema:type_name -> google.protobuf.Struct
+	137, // 140: api.v2.ListExperimentsRequest.from:type_name -> google.protobuf.Timestamp
+	137, // 141: api.v2.ListExperimentsRequest.until:type_name -> google.protobuf.Timestamp
 	116, // 142: api.v2.ListExperimentsResponse.data:type_name -> api.v2.Experiment
 	17,  // 143: api.v2.ListExperimentsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 144: api.v2.ListExperimentsResponse.page:type_name -> api.v2.Page
 	19,  // 145: api.v2.Experiment.function:type_name -> api.v2.FunctionRef
-	133, // 146: api.v2.Experiment.first_seen:type_name -> google.protobuf.Timestamp
-	133, // 147: api.v2.Experiment.last_seen:type_name -> google.protobuf.Timestamp
-	133, // 148: api.v2.GetExperimentRequest.from:type_name -> google.protobuf.Timestamp
-	133, // 149: api.v2.GetExperimentRequest.until:type_name -> google.protobuf.Timestamp
+	137, // 146: api.v2.Experiment.first_seen:type_name -> google.protobuf.Timestamp
+	137, // 147: api.v2.Experiment.last_seen:type_name -> google.protobuf.Timestamp
+	137, // 148: api.v2.GetExperimentRequest.from:type_name -> google.protobuf.Timestamp
+	137, // 149: api.v2.GetExperimentRequest.until:type_name -> google.protobuf.Timestamp
 	119, // 150: api.v2.GetExperimentResponse.data:type_name -> api.v2.ExperimentDetail
 	17,  // 151: api.v2.GetExperimentResponse.metadata:type_name -> api.v2.ResponseMetadata
 	120, // 152: api.v2.ExperimentDetail.variants:type_name -> api.v2.ExperimentVariantMetrics
 	122, // 153: api.v2.ExperimentDetail.variant_weights:type_name -> api.v2.ExperimentVariantWeight
-	133, // 154: api.v2.ExperimentDetail.first_seen:type_name -> google.protobuf.Timestamp
-	133, // 155: api.v2.ExperimentDetail.last_seen:type_name -> google.protobuf.Timestamp
+	137, // 154: api.v2.ExperimentDetail.first_seen:type_name -> google.protobuf.Timestamp
+	137, // 155: api.v2.ExperimentDetail.last_seen:type_name -> google.protobuf.Timestamp
 	121, // 156: api.v2.ExperimentVariantMetrics.metrics:type_name -> api.v2.ExperimentVariantMetric
 	125, // 157: api.v2.ListSessionKeysResponse.data:type_name -> api.v2.SessionKey
 	17,  // 158: api.v2.ListSessionKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 159: api.v2.ListSessionKeysResponse.page:type_name -> api.v2.Page
-	133, // 160: api.v2.SessionKey.created_at:type_name -> google.protobuf.Timestamp
-	133, // 161: api.v2.ListSessionsRequest.from:type_name -> google.protobuf.Timestamp
-	133, // 162: api.v2.ListSessionsRequest.until:type_name -> google.protobuf.Timestamp
+	137, // 160: api.v2.SessionKey.created_at:type_name -> google.protobuf.Timestamp
+	137, // 161: api.v2.ListSessionsRequest.from:type_name -> google.protobuf.Timestamp
+	137, // 162: api.v2.ListSessionsRequest.until:type_name -> google.protobuf.Timestamp
 	128, // 163: api.v2.ListSessionsResponse.data:type_name -> api.v2.SessionGroup
 	17,  // 164: api.v2.ListSessionsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 165: api.v2.ListSessionsResponse.page:type_name -> api.v2.Page
-	133, // 166: api.v2.SessionGroup.last_active_at:type_name -> google.protobuf.Timestamp
+	137, // 166: api.v2.SessionGroup.last_active_at:type_name -> google.protobuf.Timestamp
 	19,  // 167: api.v2.SessionGroup.functions:type_name -> api.v2.FunctionRef
-	133, // 168: api.v2.ListSessionRunsRequest.from:type_name -> google.protobuf.Timestamp
-	133, // 169: api.v2.ListSessionRunsRequest.until:type_name -> google.protobuf.Timestamp
+	137, // 168: api.v2.ListSessionRunsRequest.from:type_name -> google.protobuf.Timestamp
+	137, // 169: api.v2.ListSessionRunsRequest.until:type_name -> google.protobuf.Timestamp
 	131, // 170: api.v2.ListSessionRunsResponse.data:type_name -> api.v2.SessionRun
 	17,  // 171: api.v2.ListSessionRunsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 172: api.v2.ListSessionRunsResponse.page:type_name -> api.v2.Page
 	19,  // 173: api.v2.SessionRun.function:type_name -> api.v2.FunctionRef
 	0,   // 174: api.v2.SessionRun.status:type_name -> api.v2.FunctionRunStatus
-	133, // 175: api.v2.SessionRun.queued_at:type_name -> google.protobuf.Timestamp
-	133, // 176: api.v2.SessionRun.started_at:type_name -> google.protobuf.Timestamp
-	133, // 177: api.v2.SessionRun.ended_at:type_name -> google.protobuf.Timestamp
-	11,  // 178: api.v2.V2.Health:input_type -> api.v2.HealthRequest
-	11,  // 179: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
-	58,  // 180: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
-	60,  // 181: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
-	64,  // 182: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
-	12,  // 183: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
-	72,  // 184: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
-	69,  // 185: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
-	74,  // 186: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
-	77,  // 187: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
-	80,  // 188: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
-	83,  // 189: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
-	37,  // 190: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
-	39,  // 191: api.v2.V2.GetEventRuns:input_type -> api.v2.GetEventRunsRequest
-	41,  // 192: api.v2.V2.Rerun:input_type -> api.v2.RerunRequest
-	54,  // 193: api.v2.V2.GetApp:input_type -> api.v2.GetAppRequest
-	88,  // 194: api.v2.V2.CreateScore:input_type -> api.v2.CreateScoreRequest
-	93,  // 195: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
-	48,  // 196: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
-	50,  // 197: api.v2.V2.GetFunction:input_type -> api.v2.GetFunctionRequest
-	56,  // 198: api.v2.V2.GetFunctions:input_type -> api.v2.GetFunctionsRequest
-	85,  // 199: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
-	104, // 200: api.v2.V2.ListInsightsTables:input_type -> api.v2.ListInsightsTablesRequest
-	111, // 201: api.v2.V2.ListInsightsEventSchemas:input_type -> api.v2.ListInsightsEventSchemasRequest
-	108, // 202: api.v2.V2.QueryInsightsPrompt:input_type -> api.v2.QueryInsightsPromptRequest
-	97,  // 203: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
-	114, // 204: api.v2.V2.ListExperiments:input_type -> api.v2.ListExperimentsRequest
-	117, // 205: api.v2.V2.GetExperiment:input_type -> api.v2.GetExperimentRequest
-	123, // 206: api.v2.V2.ListSessionKeys:input_type -> api.v2.ListSessionKeysRequest
-	126, // 207: api.v2.V2.ListSessions:input_type -> api.v2.ListSessionsRequest
-	129, // 208: api.v2.V2.ListSessionRuns:input_type -> api.v2.ListSessionRunsRequest
-	13,  // 209: api.v2.V2.Health:output_type -> api.v2.HealthResponse
-	16,  // 210: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
-	59,  // 211: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
-	61,  // 212: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
-	65,  // 213: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
-	66,  // 214: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
-	73,  // 215: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
-	70,  // 216: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
-	75,  // 217: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
-	78,  // 218: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
-	81,  // 219: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
-	84,  // 220: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
-	38,  // 221: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
-	40,  // 222: api.v2.V2.GetEventRuns:output_type -> api.v2.GetEventRunsResponse
-	43,  // 223: api.v2.V2.Rerun:output_type -> api.v2.RerunResponse
-	55,  // 224: api.v2.V2.GetApp:output_type -> api.v2.GetAppResponse
-	91,  // 225: api.v2.V2.CreateScore:output_type -> api.v2.CreateScoreResponse
-	94,  // 226: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
-	49,  // 227: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
-	51,  // 228: api.v2.V2.GetFunction:output_type -> api.v2.GetFunctionResponse
-	57,  // 229: api.v2.V2.GetFunctions:output_type -> api.v2.GetFunctionsResponse
-	86,  // 230: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
-	105, // 231: api.v2.V2.ListInsightsTables:output_type -> api.v2.ListInsightsTablesResponse
-	112, // 232: api.v2.V2.ListInsightsEventSchemas:output_type -> api.v2.ListInsightsEventSchemasResponse
-	109, // 233: api.v2.V2.QueryInsightsPrompt:output_type -> api.v2.QueryInsightsPromptResponse
-	98,  // 234: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
-	115, // 235: api.v2.V2.ListExperiments:output_type -> api.v2.ListExperimentsResponse
-	118, // 236: api.v2.V2.GetExperiment:output_type -> api.v2.GetExperimentResponse
-	124, // 237: api.v2.V2.ListSessionKeys:output_type -> api.v2.ListSessionKeysResponse
-	127, // 238: api.v2.V2.ListSessions:output_type -> api.v2.ListSessionsResponse
-	130, // 239: api.v2.V2.ListSessionRuns:output_type -> api.v2.ListSessionRunsResponse
-	209, // [209:240] is the sub-list for method output_type
-	178, // [178:209] is the sub-list for method input_type
-	178, // [178:178] is the sub-list for extension type_name
-	178, // [178:178] is the sub-list for extension extendee
-	0,   // [0:178] is the sub-list for field type_name
+	137, // 175: api.v2.SessionRun.queued_at:type_name -> google.protobuf.Timestamp
+	137, // 176: api.v2.SessionRun.started_at:type_name -> google.protobuf.Timestamp
+	137, // 177: api.v2.SessionRun.ended_at:type_name -> google.protobuf.Timestamp
+	137, // 178: api.v2.ListRunsRequest.from:type_name -> google.protobuf.Timestamp
+	137, // 179: api.v2.ListRunsRequest.until:type_name -> google.protobuf.Timestamp
+	137, // 180: api.v2.ListFunctionRunsRequest.from:type_name -> google.protobuf.Timestamp
+	137, // 181: api.v2.ListFunctionRunsRequest.until:type_name -> google.protobuf.Timestamp
+	36,  // 182: api.v2.ListRunsResponse.data:type_name -> api.v2.FunctionRun
+	17,  // 183: api.v2.ListRunsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	68,  // 184: api.v2.ListRunsResponse.page:type_name -> api.v2.Page
+	36,  // 185: api.v2.ListFunctionRunsResponse.data:type_name -> api.v2.FunctionRun
+	17,  // 186: api.v2.ListFunctionRunsResponse.metadata:type_name -> api.v2.ResponseMetadata
+	68,  // 187: api.v2.ListFunctionRunsResponse.page:type_name -> api.v2.Page
+	11,  // 188: api.v2.V2.Health:input_type -> api.v2.HealthRequest
+	11,  // 189: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
+	58,  // 190: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
+	60,  // 191: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
+	64,  // 192: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
+	12,  // 193: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
+	72,  // 194: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
+	69,  // 195: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
+	74,  // 196: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
+	77,  // 197: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
+	80,  // 198: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
+	83,  // 199: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
+	37,  // 200: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
+	132, // 201: api.v2.V2.ListRuns:input_type -> api.v2.ListRunsRequest
+	133, // 202: api.v2.V2.ListFunctionRuns:input_type -> api.v2.ListFunctionRunsRequest
+	39,  // 203: api.v2.V2.GetEventRuns:input_type -> api.v2.GetEventRunsRequest
+	41,  // 204: api.v2.V2.Rerun:input_type -> api.v2.RerunRequest
+	54,  // 205: api.v2.V2.GetApp:input_type -> api.v2.GetAppRequest
+	88,  // 206: api.v2.V2.CreateScore:input_type -> api.v2.CreateScoreRequest
+	93,  // 207: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
+	48,  // 208: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
+	50,  // 209: api.v2.V2.GetFunction:input_type -> api.v2.GetFunctionRequest
+	56,  // 210: api.v2.V2.GetFunctions:input_type -> api.v2.GetFunctionsRequest
+	85,  // 211: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
+	104, // 212: api.v2.V2.ListInsightsTables:input_type -> api.v2.ListInsightsTablesRequest
+	111, // 213: api.v2.V2.ListInsightsEventSchemas:input_type -> api.v2.ListInsightsEventSchemasRequest
+	108, // 214: api.v2.V2.QueryInsightsPrompt:input_type -> api.v2.QueryInsightsPromptRequest
+	97,  // 215: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
+	114, // 216: api.v2.V2.ListExperiments:input_type -> api.v2.ListExperimentsRequest
+	117, // 217: api.v2.V2.GetExperiment:input_type -> api.v2.GetExperimentRequest
+	123, // 218: api.v2.V2.ListSessionKeys:input_type -> api.v2.ListSessionKeysRequest
+	126, // 219: api.v2.V2.ListSessions:input_type -> api.v2.ListSessionsRequest
+	129, // 220: api.v2.V2.ListSessionRuns:input_type -> api.v2.ListSessionRunsRequest
+	13,  // 221: api.v2.V2.Health:output_type -> api.v2.HealthResponse
+	16,  // 222: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
+	59,  // 223: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
+	61,  // 224: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
+	65,  // 225: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
+	66,  // 226: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
+	73,  // 227: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
+	70,  // 228: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
+	75,  // 229: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
+	78,  // 230: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
+	81,  // 231: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
+	84,  // 232: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
+	38,  // 233: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
+	134, // 234: api.v2.V2.ListRuns:output_type -> api.v2.ListRunsResponse
+	135, // 235: api.v2.V2.ListFunctionRuns:output_type -> api.v2.ListFunctionRunsResponse
+	40,  // 236: api.v2.V2.GetEventRuns:output_type -> api.v2.GetEventRunsResponse
+	43,  // 237: api.v2.V2.Rerun:output_type -> api.v2.RerunResponse
+	55,  // 238: api.v2.V2.GetApp:output_type -> api.v2.GetAppResponse
+	91,  // 239: api.v2.V2.CreateScore:output_type -> api.v2.CreateScoreResponse
+	94,  // 240: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
+	49,  // 241: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
+	51,  // 242: api.v2.V2.GetFunction:output_type -> api.v2.GetFunctionResponse
+	57,  // 243: api.v2.V2.GetFunctions:output_type -> api.v2.GetFunctionsResponse
+	86,  // 244: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
+	105, // 245: api.v2.V2.ListInsightsTables:output_type -> api.v2.ListInsightsTablesResponse
+	112, // 246: api.v2.V2.ListInsightsEventSchemas:output_type -> api.v2.ListInsightsEventSchemasResponse
+	109, // 247: api.v2.V2.QueryInsightsPrompt:output_type -> api.v2.QueryInsightsPromptResponse
+	98,  // 248: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
+	115, // 249: api.v2.V2.ListExperiments:output_type -> api.v2.ListExperimentsResponse
+	118, // 250: api.v2.V2.GetExperiment:output_type -> api.v2.GetExperimentResponse
+	124, // 251: api.v2.V2.ListSessionKeys:output_type -> api.v2.ListSessionKeysResponse
+	127, // 252: api.v2.V2.ListSessions:output_type -> api.v2.ListSessionsResponse
+	130, // 253: api.v2.V2.ListSessionRuns:output_type -> api.v2.ListSessionRunsResponse
+	221, // [221:254] is the sub-list for method output_type
+	188, // [188:221] is the sub-list for method input_type
+	188, // [188:188] is the sub-list for extension type_name
+	188, // [188:188] is the sub-list for extension extendee
+	0,   // [0:188] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_service_proto_init() }
@@ -9765,13 +10215,15 @@ func file_api_v2_service_proto_init() {
 	file_api_v2_service_proto_msgTypes[115].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[118].OneofWrappers = []any{}
 	file_api_v2_service_proto_msgTypes[120].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[121].OneofWrappers = []any{}
+	file_api_v2_service_proto_msgTypes[122].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v2_service_proto_rawDesc), len(file_api_v2_service_proto_rawDesc)),
 			NumEnums:      11,
-			NumMessages:   122,
+			NumMessages:   126,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -9111,15 +9111,15 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\bended_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampH\x02R\aendedAt\x88\x01\x01B\r\n" +
 	"\v_event_nameB\r\n" +
 	"\v_started_atB\v\n" +
-	"\t_ended_at\"\x8c\b\n" +
+	"\t_ended_at\"\xa4\b\n" +
 	"\x0fListRunsRequest\x12*\n" +
 	"\x0einclude_output\x18\x01 \x01(\bH\x00R\rincludeOutput\x88\x01\x01\x12J\n" +
 	"\x06cursor\x18\x02 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x01R\x06cursor\x88\x01\x01\x12X\n" +
-	"\x05limit\x18\x03 \x01(\x05B=\x92A:24Number of runs to return per page (min: 1, max: 100):\x0220H\x02R\x05limit\x88\x01\x01\x12U\n" +
-	"\x04from\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampB \x92A\x1d2\x1bStart of the run time rangeH\x03R\x04from\x88\x01\x01\x12U\n" +
-	"\x05until\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampB\x1e\x92A\x1b2\x19End of the run time rangeH\x04R\x05until\x88\x01\x01\x12\x8b\x01\n" +
+	"\x05limit\x18\x03 \x01(\x05B=\x92A:24Number of runs to return per page (min: 1, max: 100):\x0220H\x02R\x05limit\x88\x01\x01\x12_\n" +
+	"\x04from\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampB*\x92A'2%Inclusive start of the run time rangeH\x03R\x04from\x88\x01\x01\x12_\n" +
+	"\x05until\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampB(\x92A%2#Exclusive end of the run time rangeH\x04R\x05until\x88\x01\x01\x12\x8f\x01\n" +
 	"\n" +
-	"time_field\x18\x06 \x01(\tBl\x92Ai2]Run timestamp field used for filtering and ordering. Accepts queuedAt, startedAt, or endedAt.:\bqueuedAtR\ttimeField\x12\x87\x01\n" +
+	"time_field\x18\x06 \x01(\tBp\x92Am2`Run timestamp field used for filtering and ordering. Accepts QUEUED_AT, STARTED_AT, or ENDED_AT.:\tQUEUED_ATR\ttimeField\x12\x87\x01\n" +
 	"\x06status\x18\a \x03(\tBo\x92Al2jStatuses to include, using response status values such as COMPLETED, FAILED, RUNNING, QUEUED, or CANCELLEDR\x06status\x12.\n" +
 	"\x06app_id\x18\b \x03(\tB\x17\x92A\x142\x12App IDs to includeR\x05appId\x12=\n" +
 	"\vfunction_id\x18\t \x03(\tB\x1c\x92A\x192\x17Function IDs to includeR\n" +
@@ -9133,18 +9133,18 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x06_limitB\a\n" +
 	"\x05_fromB\b\n" +
 	"\x06_untilB\x0e\n" +
-	"\f_is_deferred\"\xdd\a\n" +
+	"\f_is_deferred\"\xf5\a\n" +
 	"\x17ListFunctionRunsRequest\x12\x15\n" +
 	"\x06app_id\x18\x01 \x01(\tR\x05appId\x12\x1f\n" +
 	"\vfunction_id\x18\x02 \x01(\tR\n" +
 	"functionId\x12*\n" +
 	"\x0einclude_output\x18\x03 \x01(\bH\x00R\rincludeOutput\x88\x01\x01\x12J\n" +
 	"\x06cursor\x18\x04 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x01R\x06cursor\x88\x01\x01\x12X\n" +
-	"\x05limit\x18\x05 \x01(\x05B=\x92A:24Number of runs to return per page (min: 1, max: 100):\x0220H\x02R\x05limit\x88\x01\x01\x12U\n" +
-	"\x04from\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampB \x92A\x1d2\x1bStart of the run time rangeH\x03R\x04from\x88\x01\x01\x12U\n" +
-	"\x05until\x18\a \x01(\v2\x1a.google.protobuf.TimestampB\x1e\x92A\x1b2\x19End of the run time rangeH\x04R\x05until\x88\x01\x01\x12\x8b\x01\n" +
+	"\x05limit\x18\x05 \x01(\x05B=\x92A:24Number of runs to return per page (min: 1, max: 100):\x0220H\x02R\x05limit\x88\x01\x01\x12_\n" +
+	"\x04from\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampB*\x92A'2%Inclusive start of the run time rangeH\x03R\x04from\x88\x01\x01\x12_\n" +
+	"\x05until\x18\a \x01(\v2\x1a.google.protobuf.TimestampB(\x92A%2#Exclusive end of the run time rangeH\x04R\x05until\x88\x01\x01\x12\x8f\x01\n" +
 	"\n" +
-	"time_field\x18\b \x01(\tBl\x92Ai2]Run timestamp field used for filtering and ordering. Accepts queuedAt, startedAt, or endedAt.:\bqueuedAtR\ttimeField\x12\x87\x01\n" +
+	"time_field\x18\b \x01(\tBp\x92Am2`Run timestamp field used for filtering and ordering. Accepts QUEUED_AT, STARTED_AT, or ENDED_AT.:\tQUEUED_ATR\ttimeField\x12\x87\x01\n" +
 	"\x06status\x18\t \x03(\tBo\x92Al2jStatuses to include, using response status values such as COMPLETED, FAILED, RUNNING, QUEUED, or CANCELLEDR\x06status\x12`\n" +
 	"\vis_deferred\x18\n" +
 	" \x01(\bB:\x92A725Whether to include only deferred or non-deferred runsH\x05R\n" +

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -9111,15 +9111,15 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\bended_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampH\x02R\aendedAt\x88\x01\x01B\r\n" +
 	"\v_event_nameB\r\n" +
 	"\v_started_atB\v\n" +
-	"\t_ended_at\"\xa4\b\n" +
+	"\t_ended_at\"\xf5\b\n" +
 	"\x0fListRunsRequest\x12*\n" +
 	"\x0einclude_output\x18\x01 \x01(\bH\x00R\rincludeOutput\x88\x01\x01\x12J\n" +
 	"\x06cursor\x18\x02 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x01R\x06cursor\x88\x01\x01\x12X\n" +
 	"\x05limit\x18\x03 \x01(\x05B=\x92A:24Number of runs to return per page (min: 1, max: 100):\x0220H\x02R\x05limit\x88\x01\x01\x12_\n" +
 	"\x04from\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampB*\x92A'2%Inclusive start of the run time rangeH\x03R\x04from\x88\x01\x01\x12_\n" +
-	"\x05until\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampB(\x92A%2#Exclusive end of the run time rangeH\x04R\x05until\x88\x01\x01\x12\x8f\x01\n" +
+	"\x05until\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampB(\x92A%2#Inclusive end of the run time rangeH\x04R\x05until\x88\x01\x01\x12\xe0\x01\n" +
 	"\n" +
-	"time_field\x18\x06 \x01(\tBp\x92Am2`Run timestamp field used for filtering and ordering. Accepts QUEUED_AT, STARTED_AT, or ENDED_AT.:\tQUEUED_ATR\ttimeField\x12\x87\x01\n" +
+	"time_field\x18\x06 \x01(\tB\xc0\x01\x92A\xbc\x012\xaf\x01Run timestamp field used for filtering and ordering. Accepts queuedAt, startedAt, or endedAt. Snake case aliases such as QUEUED_AT, STARTED_AT, and ENDED_AT are also accepted.:\bqueuedAtR\ttimeField\x12\x87\x01\n" +
 	"\x06status\x18\a \x03(\tBo\x92Al2jStatuses to include, using response status values such as COMPLETED, FAILED, RUNNING, QUEUED, or CANCELLEDR\x06status\x12.\n" +
 	"\x06app_id\x18\b \x03(\tB\x17\x92A\x142\x12App IDs to includeR\x05appId\x12=\n" +
 	"\vfunction_id\x18\t \x03(\tB\x1c\x92A\x192\x17Function IDs to includeR\n" +
@@ -9133,7 +9133,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x06_limitB\a\n" +
 	"\x05_fromB\b\n" +
 	"\x06_untilB\x0e\n" +
-	"\f_is_deferred\"\xf5\a\n" +
+	"\f_is_deferred\"\xc6\b\n" +
 	"\x17ListFunctionRunsRequest\x12\x15\n" +
 	"\x06app_id\x18\x01 \x01(\tR\x05appId\x12\x1f\n" +
 	"\vfunction_id\x18\x02 \x01(\tR\n" +
@@ -9142,9 +9142,9 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x06cursor\x18\x04 \x01(\tB-\x92A*2(Pagination cursor from previous responseH\x01R\x06cursor\x88\x01\x01\x12X\n" +
 	"\x05limit\x18\x05 \x01(\x05B=\x92A:24Number of runs to return per page (min: 1, max: 100):\x0220H\x02R\x05limit\x88\x01\x01\x12_\n" +
 	"\x04from\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampB*\x92A'2%Inclusive start of the run time rangeH\x03R\x04from\x88\x01\x01\x12_\n" +
-	"\x05until\x18\a \x01(\v2\x1a.google.protobuf.TimestampB(\x92A%2#Exclusive end of the run time rangeH\x04R\x05until\x88\x01\x01\x12\x8f\x01\n" +
+	"\x05until\x18\a \x01(\v2\x1a.google.protobuf.TimestampB(\x92A%2#Inclusive end of the run time rangeH\x04R\x05until\x88\x01\x01\x12\xe0\x01\n" +
 	"\n" +
-	"time_field\x18\b \x01(\tBp\x92Am2`Run timestamp field used for filtering and ordering. Accepts QUEUED_AT, STARTED_AT, or ENDED_AT.:\tQUEUED_ATR\ttimeField\x12\x87\x01\n" +
+	"time_field\x18\b \x01(\tB\xc0\x01\x92A\xbc\x012\xaf\x01Run timestamp field used for filtering and ordering. Accepts queuedAt, startedAt, or endedAt. Snake case aliases such as QUEUED_AT, STARTED_AT, and ENDED_AT are also accepted.:\bqueuedAtR\ttimeField\x12\x87\x01\n" +
 	"\x06status\x18\t \x03(\tBo\x92Al2jStatuses to include, using response status values such as COMPLETED, FAILED, RUNNING, QUEUED, or CANCELLEDR\x06status\x12`\n" +
 	"\vis_deferred\x18\n" +
 	" \x01(\bB:\x92A725Whether to include only deferred or non-deferred runsH\x05R\n" +

--- a/proto/gen/api/v2/service.pb.gw.go
+++ b/proto/gen/api/v2/service.pb.gw.go
@@ -452,6 +452,110 @@ func local_request_V2_GetFunctionRun_0(ctx context.Context, marshaler runtime.Ma
 	return msg, metadata, err
 }
 
+var filter_V2_ListRuns_0 = &utilities.DoubleArray{Encoding: map[string]int{}, Base: []int(nil), Check: []int(nil)}
+
+func request_V2_ListRuns_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListRunsRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_V2_ListRuns_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.ListRuns(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_V2_ListRuns_0(ctx context.Context, marshaler runtime.Marshaler, server V2Server, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListRunsRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_V2_ListRuns_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ListRuns(ctx, &protoReq)
+	return msg, metadata, err
+}
+
+var filter_V2_ListFunctionRuns_0 = &utilities.DoubleArray{Encoding: map[string]int{"app_id": 0, "function_id": 1}, Base: []int{1, 1, 2, 0, 0}, Check: []int{0, 1, 1, 2, 3}}
+
+func request_V2_ListFunctionRuns_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListFunctionRunsRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["app_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "app_id")
+	}
+	protoReq.AppId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "app_id", err)
+	}
+	val, ok = pathParams["function_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "function_id")
+	}
+	protoReq.FunctionId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "function_id", err)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_V2_ListFunctionRuns_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := client.ListFunctionRuns(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_V2_ListFunctionRuns_0(ctx context.Context, marshaler runtime.Marshaler, server V2Server, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq ListFunctionRunsRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	val, ok := pathParams["app_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "app_id")
+	}
+	protoReq.AppId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "app_id", err)
+	}
+	val, ok = pathParams["function_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "function_id")
+	}
+	protoReq.FunctionId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "function_id", err)
+	}
+	if err := req.ParseForm(); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if err := runtime.PopulateQueryParameters(&protoReq, req.Form, filter_V2_ListFunctionRuns_0); err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.ListFunctionRuns(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 var filter_V2_GetEventRuns_0 = &utilities.DoubleArray{Encoding: map[string]int{"event_id": 0}, Base: []int{1, 1, 0}, Check: []int{0, 1, 2}}
 
 func request_V2_GetEventRuns_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
@@ -1623,6 +1727,46 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		}
 		forward_V2_GetFunctionRun_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_V2_ListRuns_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/ListRuns", runtime.WithHTTPPathPattern("/runs"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_V2_ListRuns_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_ListRuns_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_V2_ListFunctionRuns_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/ListFunctionRuns", runtime.WithHTTPPathPattern("/apps/{app_id}/functions/{function_id}/runs"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_V2_ListFunctionRuns_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_ListFunctionRuns_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_V2_GetEventRuns_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2264,6 +2408,40 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		}
 		forward_V2_GetFunctionRun_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_V2_ListRuns_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/ListRuns", runtime.WithHTTPPathPattern("/runs"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_V2_ListRuns_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_ListRuns_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
+	mux.Handle(http.MethodGet, pattern_V2_ListFunctionRuns_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/ListFunctionRuns", runtime.WithHTTPPathPattern("/apps/{app_id}/functions/{function_id}/runs"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_V2_ListFunctionRuns_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_ListFunctionRuns_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_V2_GetEventRuns_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2604,6 +2782,8 @@ var (
 	pattern_V2_ListWebhooks_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"env", "webhooks"}, ""))
 	pattern_V2_PatchEnv_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"envs", "id"}, ""))
 	pattern_V2_GetFunctionRun_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"runs", "run_id"}, ""))
+	pattern_V2_ListRuns_0                 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0}, []string{"runs"}, ""))
+	pattern_V2_ListFunctionRuns_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"apps", "app_id", "functions", "function_id", "runs"}, ""))
 	pattern_V2_GetEventRuns_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"events", "event_id", "runs"}, ""))
 	pattern_V2_Rerun_0                    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"runs", "run_id", "rerun"}, ""))
 	pattern_V2_GetApp_0                   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"apps", "app_id"}, ""))
@@ -2639,6 +2819,8 @@ var (
 	forward_V2_ListWebhooks_0             = runtime.ForwardResponseMessage
 	forward_V2_PatchEnv_0                 = runtime.ForwardResponseMessage
 	forward_V2_GetFunctionRun_0           = runtime.ForwardResponseMessage
+	forward_V2_ListRuns_0                 = runtime.ForwardResponseMessage
+	forward_V2_ListFunctionRuns_0         = runtime.ForwardResponseMessage
 	forward_V2_GetEventRuns_0             = runtime.ForwardResponseMessage
 	forward_V2_Rerun_0                    = runtime.ForwardResponseMessage
 	forward_V2_GetApp_0                   = runtime.ForwardResponseMessage

--- a/proto/gen/api/v2/service_grpc.pb.go
+++ b/proto/gen/api/v2/service_grpc.pb.go
@@ -32,6 +32,8 @@ const (
 	V2_ListWebhooks_FullMethodName             = "/api.v2.V2/ListWebhooks"
 	V2_PatchEnv_FullMethodName                 = "/api.v2.V2/PatchEnv"
 	V2_GetFunctionRun_FullMethodName           = "/api.v2.V2/GetFunctionRun"
+	V2_ListRuns_FullMethodName                 = "/api.v2.V2/ListRuns"
+	V2_ListFunctionRuns_FullMethodName         = "/api.v2.V2/ListFunctionRuns"
 	V2_GetEventRuns_FullMethodName             = "/api.v2.V2/GetEventRuns"
 	V2_Rerun_FullMethodName                    = "/api.v2.V2/Rerun"
 	V2_GetApp_FullMethodName                   = "/api.v2.V2/GetApp"
@@ -72,6 +74,8 @@ type V2Client interface {
 	ListWebhooks(ctx context.Context, in *ListWebhooksRequest, opts ...grpc.CallOption) (*ListWebhooksResponse, error)
 	PatchEnv(ctx context.Context, in *PatchEnvRequest, opts ...grpc.CallOption) (*PatchEnvsResponse, error)
 	GetFunctionRun(ctx context.Context, in *GetFunctionRunRequest, opts ...grpc.CallOption) (*GetFunctionRunResponse, error)
+	ListRuns(ctx context.Context, in *ListRunsRequest, opts ...grpc.CallOption) (*ListRunsResponse, error)
+	ListFunctionRuns(ctx context.Context, in *ListFunctionRunsRequest, opts ...grpc.CallOption) (*ListFunctionRunsResponse, error)
 	GetEventRuns(ctx context.Context, in *GetEventRunsRequest, opts ...grpc.CallOption) (*GetEventRunsResponse, error)
 	Rerun(ctx context.Context, in *RerunRequest, opts ...grpc.CallOption) (*RerunResponse, error)
 	GetApp(ctx context.Context, in *GetAppRequest, opts ...grpc.CallOption) (*GetAppResponse, error)
@@ -224,6 +228,26 @@ func (c *v2Client) GetFunctionRun(ctx context.Context, in *GetFunctionRunRequest
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetFunctionRunResponse)
 	err := c.cc.Invoke(ctx, V2_GetFunctionRun_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *v2Client) ListRuns(ctx context.Context, in *ListRunsRequest, opts ...grpc.CallOption) (*ListRunsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListRunsResponse)
+	err := c.cc.Invoke(ctx, V2_ListRuns_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *v2Client) ListFunctionRuns(ctx context.Context, in *ListFunctionRunsRequest, opts ...grpc.CallOption) (*ListFunctionRunsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListFunctionRunsResponse)
+	err := c.cc.Invoke(ctx, V2_ListFunctionRuns_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -430,6 +454,8 @@ type V2Server interface {
 	ListWebhooks(context.Context, *ListWebhooksRequest) (*ListWebhooksResponse, error)
 	PatchEnv(context.Context, *PatchEnvRequest) (*PatchEnvsResponse, error)
 	GetFunctionRun(context.Context, *GetFunctionRunRequest) (*GetFunctionRunResponse, error)
+	ListRuns(context.Context, *ListRunsRequest) (*ListRunsResponse, error)
+	ListFunctionRuns(context.Context, *ListFunctionRunsRequest) (*ListFunctionRunsResponse, error)
 	GetEventRuns(context.Context, *GetEventRunsRequest) (*GetEventRunsResponse, error)
 	Rerun(context.Context, *RerunRequest) (*RerunResponse, error)
 	GetApp(context.Context, *GetAppRequest) (*GetAppResponse, error)
@@ -496,6 +522,12 @@ func (UnimplementedV2Server) PatchEnv(context.Context, *PatchEnvRequest) (*Patch
 }
 func (UnimplementedV2Server) GetFunctionRun(context.Context, *GetFunctionRunRequest) (*GetFunctionRunResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetFunctionRun not implemented")
+}
+func (UnimplementedV2Server) ListRuns(context.Context, *ListRunsRequest) (*ListRunsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListRuns not implemented")
+}
+func (UnimplementedV2Server) ListFunctionRuns(context.Context, *ListFunctionRunsRequest) (*ListFunctionRunsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListFunctionRuns not implemented")
 }
 func (UnimplementedV2Server) GetEventRuns(context.Context, *GetEventRunsRequest) (*GetEventRunsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetEventRuns not implemented")
@@ -802,6 +834,42 @@ func _V2_GetFunctionRun_Handler(srv interface{}, ctx context.Context, dec func(i
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(V2Server).GetFunctionRun(ctx, req.(*GetFunctionRunRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _V2_ListRuns_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListRunsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(V2Server).ListRuns(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: V2_ListRuns_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(V2Server).ListRuns(ctx, req.(*ListRunsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _V2_ListFunctionRuns_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListFunctionRunsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(V2Server).ListFunctionRuns(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: V2_ListFunctionRuns_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(V2Server).ListFunctionRuns(ctx, req.(*ListFunctionRunsRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -1188,6 +1256,14 @@ var V2_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetFunctionRun",
 			Handler:    _V2_GetFunctionRun_Handler,
+		},
+		{
+			MethodName: "ListRuns",
+			Handler:    _V2_ListRuns_Handler,
+		},
+		{
+			MethodName: "ListFunctionRuns",
+			Handler:    _V2_ListFunctionRuns_Handler,
 		},
 		{
 			MethodName: "GetEventRuns",


### PR DESCRIPTION
## Description

Adds beta v2 REST endpoints for listing function runs:

- `GET /v2/runs`
- `GET /v2/apps/{appId}/functions/{functionId}/runs`

Supports cursor pagination, time ranges and fields, status, public app/function IDs, deferred-run filters, ordering, and optional outputs.

Depends on [#4623](https://github.com/inngest/inngest/pull/4623).

### Examples

```bash
# Failed or cancelled runs
curl -G "$API/runs" \
  --data-urlencode status=FAILED \
  --data-urlencode status=CANCELLED

# Function runs started within a time range
curl -G "$API/apps/inngest-ai/functions/hello-world/runs" \
  --data-urlencode from=2026-07-01T00:00:00Z \
  --data-urlencode until=2026-07-15T00:00:00Z \
  --data-urlencode timeField=startedAt \
  --data-urlencode order=ASC
```
note you can also pass app id and function id as params to `/v2/runs` in addition to using `/v2/apps/{appId}/functions/{functionId}/runs`, see:

```
curl -sS "${AUTH[@]}" -G "$API/runs" \
  --data-urlencode appId="inngest-ai" \
  --data-urlencode functionId="hello-world" \
  --data-urlencode limit=20 
```

## Release note

Adds beta v2 REST endpoints for listing function runs:

- `GET /v2/runs`
- `GET /v2/apps/{appId}/functions/{functionId}/runs`

Supports cursor pagination, time ranges and fields, status, public app/function IDs, deferred-run filters, ordering, and optional outputs.

## Migration note

None.