### PR TITLE
refactor(runs): new shared run list contract

### DIFF
--- a/pkg/cqrs/cqrs.go
+++ b/pkg/cqrs/cqrs.go
@@ -29,6 +29,7 @@ type Manager interface {
 	EventManager
 	HistoryReader
 	HistoryWriter
+	RunReader
 
 	// Trace / dev only
 	TraceReadWriter

--- a/pkg/cqrs/manager/cqrs.go
+++ b/pkg/cqrs/manager/cqrs.go
@@ -2628,7 +2628,7 @@ func (w wrapper) GetTraceRunsCount(ctx context.Context, opt cqrs.GetTraceRunOpt)
 	opt.Cursor = ""
 	opt.Items = 0
 	if opt.Preview && !canReadEndedAtFromTraceRuns(opt) {
-		return w.getSpanRunsCount(ctx, opt)
+		return w.getSpanRunsCount(ctx, listRunsOptions(opt))
 	}
 	if opt.Filter.CEL == "" {
 		return w.countTraceRunsFromTable(ctx, opt)
@@ -2644,10 +2644,19 @@ func (w wrapper) GetTraceRunsCount(ctx context.Context, opt cqrs.GetTraceRunOpt)
 
 func (w wrapper) GetTraceRuns(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*cqrs.TraceRun, error) {
 	if opt.Preview && !canReadEndedAtFromTraceRuns(opt) {
-		return w.GetSpanRuns(ctx, opt)
+		return w.ListRuns(ctx, listRunsOptions(opt))
 	}
 
 	return w.getTraceRunsFromTable(ctx, opt)
+}
+
+func listRunsOptions(opt cqrs.GetTraceRunOpt) cqrs.ListRunsOptions {
+	return cqrs.ListRunsOptions{
+		Filter: opt.Filter,
+		Order:  opt.Order,
+		Cursor: opt.Cursor,
+		Items:  opt.Items,
+	}
 }
 
 // trace_runs is complete for ended runs and avoids span aggregation.
@@ -3387,9 +3396,9 @@ func (w wrapper) GetWorkerConnections(ctx context.Context, opt cqrs.GetWorkerCon
 	return res, nil
 }
 
-// GetSpanRuns loads runs from spans.  querying by start time can use executor.run
+// ListRuns loads runs from spans.  querying by start time can use executor.run
 // spans (which have start embedded).  everything else needs an aggregation...
-func (w wrapper) GetSpanRuns(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*cqrs.TraceRun, error) {
+func (w wrapper) ListRuns(ctx context.Context, opt cqrs.ListRunsOptions) ([]*cqrs.RunListItem, error) {
 	if canPushDownRootPage(opt) {
 		return w.getSpanRunsPushdown(ctx, opt)
 	}
@@ -3398,7 +3407,7 @@ func (w wrapper) GetSpanRuns(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*c
 
 // Required for ended_at ordering and CEL filters, which depend on data outside
 // the root span.
-func (w wrapper) getSpanRunsFullAggregate(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*cqrs.TraceRun, error) {
+func (w wrapper) getSpanRunsFullAggregate(ctx context.Context, opt cqrs.ListRunsOptions) ([]*cqrs.RunListItem, error) {
 	l := logger.StdlibLogger(ctx)
 	h := w.helpers()
 
@@ -3429,6 +3438,9 @@ func (w wrapper) getSpanRunsFullAggregate(ctx context.Context, opt cqrs.GetTrace
 		sq.L(`(SELECT s3.is_deferred FROM spans s3
 			WHERE s3.run_id = spans.run_id AND s3.name = ?
 			ORDER BY s3.start_time ASC LIMIT 1)`, meta.SpanNameRun).As("is_deferred"),
+		sq.L(`(SELECT CAST(s4.attributes AS TEXT) FROM spans s4
+			WHERE s4.run_id = spans.run_id AND s4.name = ?
+			ORDER BY s4.start_time ASC LIMIT 1)`, meta.SpanNameRun).As("attributes"),
 		h.EventIDsExpr(), // DB-specific due to storage differences
 	}
 
@@ -3477,10 +3489,11 @@ func (w wrapper) getSpanRunsFullAggregate(ctx context.Context, opt cqrs.GetTrace
 	allFilters = append(allFilters, spanRunFinalStatusPredicates(opt)...)
 	q = q.Select(selectCols...).
 		Where(sq.L("spans.dynamic_span_id").In(
-			sq.Dialect(h.GoquDialect()).Select("dynamic_span_id").From("spans").Where(spanRunRootPredicates(opt)...),
+			sq.Dialect(h.GoquDialect()).Select("dynamic_span_id").From("spans").Where(spanRunRootPredicates(opt, h)...),
 		)).
 		Where(allFilters...).
 		GroupBy(groupByCols...).
+		Having(spanRunAggregatePredicates(opt, builder.cursor)...).
 		Order(orderExprs...)
 
 	if opt.Items > 0 {
@@ -3492,19 +3505,26 @@ func (w wrapper) getSpanRunsFullAggregate(ctx context.Context, opt cqrs.GetTrace
 		return nil, err
 	}
 
-	l.Debug("GetSpanRuns query", "sql", sqlQuery, "args", args)
+	l.Debug("ListRuns query", "sql", sqlQuery, "args", args)
 
 	rows, err := w.adapter.Conn().QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
-		l.Debug("GetSpanRuns query error", "error", err)
+		l.Debug("ListRuns query error", "error", err)
 		return nil, err
 	}
 	defer rows.Close()
 
-	return w.convertSpanRunRows(ctx, rows, builder.cursorLayout, h, opt.Items)
+	runs, err := w.convertSpanRunRows(ctx, rows, builder.cursorLayout, h, opt.Items)
+	if err != nil {
+		return nil, err
+	}
+	if err := w.loadSpanRunPageOutput(ctx, runs, opt.IncludeOutput); err != nil {
+		return nil, err
+	}
+	return runs, nil
 }
 
-func (w wrapper) getSpanRunsCount(ctx context.Context, opt cqrs.GetTraceRunOpt) (int, error) {
+func (w wrapper) getSpanRunsCount(ctx context.Context, opt cqrs.ListRunsOptions) (int, error) {
 	// Total counts should ignore pagination state.
 	opt.Cursor = ""
 	opt.Items = 0
@@ -3516,11 +3536,11 @@ func (w wrapper) getSpanRunsCount(ctx context.Context, opt cqrs.GetTraceRunOpt) 
 }
 
 // One executor.run root is one run, so counts can avoid grouping spans.
-func (w wrapper) countSpanRunRoots(ctx context.Context, opt cqrs.GetTraceRunOpt) (int, error) {
+func (w wrapper) countSpanRunRoots(ctx context.Context, opt cqrs.ListRunsOptions) (int, error) {
 	l := logger.StdlibLogger(ctx)
 	h := w.helpers()
 
-	preds := spanRunRootPredicates(opt)
+	preds := spanRunRootPredicates(opt, h)
 	preds = append(preds, spanRunFinalStatusPredicates(opt)...)
 
 	sqlQuery, args, err := sq.Dialect(h.GoquDialect()).
@@ -3532,11 +3552,11 @@ func (w wrapper) countSpanRunRoots(ctx context.Context, opt cqrs.GetTraceRunOpt)
 		return 0, err
 	}
 
-	l.Debug("GetSpanRunsCount root query", "sql", sqlQuery, "args", args)
+	l.Debug("ListRuns count root query", "sql", sqlQuery, "args", args)
 
 	var count int
 	if err := w.adapter.Conn().QueryRowContext(ctx, sqlQuery, args...).Scan(&count); err != nil {
-		l.Debug("GetSpanRunsCount root query error", "error", err)
+		l.Debug("ListRuns count root query error", "error", err)
 		return 0, err
 	}
 
@@ -3545,7 +3565,7 @@ func (w wrapper) countSpanRunRoots(ctx context.Context, opt cqrs.GetTraceRunOpt)
 
 // getSpanRunsCountFullAggregate is a complex query that has to aggregate spans based
 // off of filters to get accurate counts
-func (w wrapper) getSpanRunsCountFullAggregate(ctx context.Context, opt cqrs.GetTraceRunOpt) (int, error) {
+func (w wrapper) getSpanRunsCountFullAggregate(ctx context.Context, opt cqrs.ListRunsOptions) (int, error) {
 	l := logger.StdlibLogger(ctx)
 	h := w.helpers()
 
@@ -3565,10 +3585,11 @@ func (w wrapper) getSpanRunsCountFullAggregate(ctx context.Context, opt cqrs.Get
 
 	grouped := q.Select(sq.L("1")).
 		Where(sq.L("spans.dynamic_span_id").In(
-			sq.Dialect(h.GoquDialect()).Select("dynamic_span_id").From("spans").Where(spanRunRootPredicates(opt)...),
+			sq.Dialect(h.GoquDialect()).Select("dynamic_span_id").From("spans").Where(spanRunRootPredicates(opt, h)...),
 		)).
 		Where(groupedFilters...).
-		GroupBy(spanRunGroupByCols()...)
+		GroupBy(spanRunGroupByCols()...).
+		Having(spanRunAggregatePredicates(opt, nil)...)
 
 	sqlQuery, args, err := sq.Dialect(h.GoquDialect()).
 		From(grouped.As("span_runs")).
@@ -3578,11 +3599,11 @@ func (w wrapper) getSpanRunsCountFullAggregate(ctx context.Context, opt cqrs.Get
 		return 0, err
 	}
 
-	l.Debug("GetSpanRunsCount query", "sql", sqlQuery, "args", args)
+	l.Debug("ListRuns count query", "sql", sqlQuery, "args", args)
 
 	var count int
 	if err := w.adapter.Conn().QueryRowContext(ctx, sqlQuery, args...).Scan(&count); err != nil {
-		l.Debug("GetSpanRunsCount query error", "error", err)
+		l.Debug("ListRuns count query error", "error", err)
 		return 0, err
 	}
 
@@ -3590,13 +3611,13 @@ func (w wrapper) getSpanRunsCountFullAggregate(ctx context.Context, opt cqrs.Get
 }
 
 // getSpanRunsPushdown pages executor spans first so we ignore work outside of the page size
-func (w wrapper) getSpanRunsPushdown(ctx context.Context, opt cqrs.GetTraceRunOpt) ([]*cqrs.TraceRun, error) {
+func (w wrapper) getSpanRunsPushdown(ctx context.Context, opt cqrs.ListRunsOptions) ([]*cqrs.RunListItem, error) {
 	l := logger.StdlibLogger(ctx)
 	h := w.helpers()
 
 	builder := newSpanRunsQueryBuilder(ctx, opt)
 
-	rootPreds := spanRunRootPredicates(opt)
+	rootPreds := spanRunRootPredicates(opt, h)
 	rootPreds = append(rootPreds, spanRunFinalStatusPredicates(opt)...)
 
 	rootQuery := sq.Dialect(h.GoquDialect()).
@@ -3613,6 +3634,7 @@ func (w wrapper) getSpanRunsPushdown(ctx context.Context, opt cqrs.GetTraceRunOp
 			"end_time",
 			"status",
 			"is_deferred",
+			sq.L("CAST(attributes AS TEXT)").As("attributes"),
 			h.RootEventIDsExpr(),
 		).
 		Where(rootPreds...).
@@ -3627,11 +3649,11 @@ func (w wrapper) getSpanRunsPushdown(ctx context.Context, opt cqrs.GetTraceRunOp
 		return nil, err
 	}
 
-	l.Debug("GetSpanRuns root-page query", "sql", sqlQuery, "args", args)
+	l.Debug("ListRuns root-page query", "sql", sqlQuery, "args", args)
 
 	rows, err := w.adapter.Conn().QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
-		l.Debug("GetSpanRuns root-page query error", "error", err)
+		l.Debug("ListRuns root-page query error", "error", err)
 		return nil, err
 	}
 
@@ -3651,14 +3673,14 @@ func (w wrapper) getSpanRunsPushdown(ctx context.Context, opt cqrs.GetTraceRunOp
 	rows.Close()
 
 	if len(pageRows) == 0 {
-		return []*cqrs.TraceRun{}, nil
+		return []*cqrs.RunListItem{}, nil
 	}
 
 	if err := w.loadSpanRunPageDetails(ctx, h, pageRows); err != nil {
 		return nil, err
 	}
 
-	res := make([]*cqrs.TraceRun, 0, len(pageRows))
+	res := make([]*cqrs.RunListItem, 0, len(pageRows))
 	var count uint
 	for i := range pageRows {
 		traceRun, ok := convertSpanRunRow(ctx, pageRows[i], builder.cursorLayout, h)
@@ -3671,8 +3693,89 @@ func (w wrapper) getSpanRunsPushdown(ctx context.Context, opt cqrs.GetTraceRunOp
 			break
 		}
 	}
+	if err := w.loadSpanRunPageOutput(ctx, res, opt.IncludeOutput); err != nil {
+		return nil, err
+	}
 
 	return res, nil
+}
+
+func (w wrapper) loadSpanRunPageOutput(
+	ctx context.Context,
+	runs []*cqrs.RunListItem,
+	includeOutput bool,
+) error {
+	if len(runs) == 0 || !includeOutput {
+		return nil
+	}
+
+	runIDs := make([]string, len(runs))
+	byID := make(map[string]*cqrs.RunListItem, len(runs))
+	for i, run := range runs {
+		runIDs[i] = run.RunID
+		byID[run.RunID] = run
+	}
+
+	q := sq.Dialect(w.dialect()).
+		From("spans").
+		Select("spans.run_id", w.helpers().RunOutputExpr()).
+		Where(
+			sq.C("name").Eq(meta.SpanNameRun),
+			sq.C("debug_run_id").IsNull(),
+			sq.C("run_id").In(runIDs),
+		).
+		Order(sq.C("start_time").Asc())
+
+	sqlQuery, args, err := q.ToSQL()
+	if err != nil {
+		return err
+	}
+	rows, err := w.adapter.Conn().QueryContext(ctx, sqlQuery, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var runID string
+		var output *string
+		err = rows.Scan(&runID, &output)
+		if err != nil {
+			return err
+		}
+
+		run := byID[runID]
+		if run == nil {
+			continue
+		}
+		if output != nil && *output != "" {
+			run.Output = []byte(*output)
+		}
+	}
+	return rows.Err()
+}
+
+func decodeSpanAttributes(raw *string) map[string]any {
+	if raw == nil || *raw == "" {
+		return nil
+	}
+
+	var decoded any
+	if err := json.Unmarshal([]byte(*raw), &decoded); err != nil {
+		return nil
+	}
+	if encoded, ok := decoded.(string); ok {
+		if err := json.Unmarshal([]byte(encoded), &decoded); err != nil {
+			return nil
+		}
+	}
+	attrs, _ := decoded.(map[string]any)
+	return attrs
+}
+
+func stringAttribute(attrs map[string]any, key string) (string, bool) {
+	value, ok := attrs[key].(string)
+	return value, ok && value != ""
 }
 
 // loadSpanRunPageDetails fills in end_time and status for the selected roots.
@@ -3720,11 +3823,11 @@ func (w wrapper) loadSpanRunPageDetails(
 		return err
 	}
 
-	l.Debug("GetSpanRuns enrich query", "sql", sqlQuery, "args", args)
+	l.Debug("ListRuns enrich query", "sql", sqlQuery, "args", args)
 
 	rows, err := w.adapter.Conn().QueryContext(ctx, sqlQuery, args...)
 	if err != nil {
-		l.Debug("GetSpanRuns enrich query error", "error", err)
+		l.Debug("ListRuns enrich query error", "error", err)
 		return err
 	}
 	defer rows.Close()
@@ -3758,7 +3861,7 @@ func (w wrapper) loadSpanRunPageDetails(
 
 func spanRunCELFilters(
 	ctx context.Context,
-	opt cqrs.GetTraceRunOpt,
+	opt cqrs.ListRunsOptions,
 	h driverhelp.DialectHelpers,
 ) ([]sq.Expression, bool, error) {
 	var celFilters []sq.Expression
@@ -3788,7 +3891,7 @@ func spanRunCELFilters(
 	return celFilters, useJoin, nil
 }
 
-func spanRunRootPredicates(opt cqrs.GetTraceRunOpt) []sq.Expression {
+func spanRunRootPredicates(opt cqrs.ListRunsOptions, h driverhelp.DialectHelpers) []sq.Expression {
 	// the root subquery is bounded by Until (an executor.run always exists,
 	// before any EXTEND that adds finalization, etc.)
 	//
@@ -3796,6 +3899,13 @@ func spanRunRootPredicates(opt cqrs.GetTraceRunOpt) []sq.Expression {
 	// inner scan stops growing O(total executor.run history) as runs grow...
 	// at the cost of excluding runs whose root started before From but
 	// was EXTENDed inside the window.  that's fine, given start time shit.
+	//
+	// Convert times to UTC to match spans storage format in SQLite
+	// We currently store SQLite timestamps as Go's time.Time string: "2025-07-13 19:32:24.939517 +0000 UTC m=+..."
+	// SQLite compares these as strings, so filter times must also serialize with "+0000 UTC" suffix to correctly use
+	// lexicographic comparisons.
+	// The UTC conversion was not strictly necessary for Postgres because the timestamp columns are timestamptz, so
+	// type and timezone conversion were handled for us
 	preds := []sq.Expression{
 		sq.C("name").Eq(meta.SpanNameRun),
 		sq.C("debug_run_id").IsNull(),
@@ -3816,6 +3926,13 @@ func spanRunRootPredicates(opt cqrs.GetTraceRunOpt) []sq.Expression {
 	}
 	if len(opt.Filter.FunctionID) > 0 {
 		preds = append(preds, sq.C("function_id").In(opt.Filter.FunctionID))
+	}
+	if len(opt.Filter.EventID) > 0 {
+		eventIDs := make([]string, len(opt.Filter.EventID))
+		for i, id := range opt.Filter.EventID {
+			eventIDs[i] = id.String()
+		}
+		preds = append(preds, h.EventIDsContain(eventIDs))
 	}
 	if opt.Filter.IsDeferred != nil {
 		if *opt.Filter.IsDeferred {
@@ -3843,8 +3960,52 @@ func spanRunGroupByCols() []interface{} {
 	}
 }
 
+func spanRunAggregatePredicates(opt cqrs.ListRunsOptions, cursor *cqrs.RunPageCursor) []sq.Expression {
+	fieldName := "start_time"
+	aggregate := sq.L("MIN(spans.start_time)")
+	preds := []sq.Expression{}
+	if opt.Filter.TimeField == enums.TraceRunTimeEndedAt {
+		fieldName = "end_time"
+		aggregate = sq.L("MAX(spans.end_time)")
+		preds = append(preds,
+			aggregate.Gte(opt.Filter.From.UTC()),
+			aggregate.Lt(opt.Filter.Until.UTC()),
+		)
+	}
+	if cursor == nil {
+		return preds
+	}
+	fieldCursor := cursor.Find(fieldName)
+	if fieldCursor == nil {
+		return preds
+	}
+
+	cursorTime := time.UnixMicro(fieldCursor.Value).UTC()
+	direction := enums.TraceRunOrderDesc
+	for _, order := range opt.Order {
+		if (fieldName == "end_time" && order.Field == enums.TraceRunTimeEndedAt) ||
+			(fieldName == "start_time" && order.Field != enums.TraceRunTimeEndedAt) {
+			direction = order.Direction
+			break
+		}
+	}
+	var after sq.Expression
+	if direction == enums.TraceRunOrderAsc {
+		after = aggregate.Gt(cursorTime)
+	} else {
+		after = aggregate.Lt(cursorTime)
+	}
+	if cursor.ID != "" {
+		after = sq.Or(
+			after,
+			sq.And(aggregate.Eq(cursorTime), sq.C("run_id").Gt(cursor.ID)),
+		)
+	}
+	return append(preds, after)
+}
+
 // ended_at and CEL depend on data outside the root span.
-func canPushDownRootPage(opt cqrs.GetTraceRunOpt) bool {
+func canPushDownRootPage(opt cqrs.ListRunsOptions) bool {
 	if opt.Filter.CEL != "" {
 		return false
 	}
@@ -3863,23 +4024,47 @@ func canPushDownRootPage(opt cqrs.GetTraceRunOpt) bool {
 }
 
 // Status filters use final run status, not any matching span row.
-func spanRunFinalStatusPredicates(opt cqrs.GetTraceRunOpt) []sq.Expression {
+func spanRunFinalStatusPredicates(opt cqrs.ListRunsOptions) []sq.Expression {
 	if len(opt.Filter.Status) == 0 {
 		return nil
 	}
-	statusStrings := make([]string, 0, len(opt.Filter.Status))
+	statusStrings := make([]string, 0, len(opt.Filter.Status)*2)
+	includeMissing := false
 	for _, s := range opt.Filter.Status {
-		statusStrings = append(statusStrings, s.String())
+		switch s {
+		case enums.RunStatusScheduled:
+			statusStrings = append(statusStrings, enums.StepStatusScheduled.String(), enums.StepStatusQueued.String())
+		case enums.RunStatusRunning:
+			statusStrings = append(statusStrings,
+				enums.StepStatusUnknown.String(),
+				enums.StepStatusRunning.String(),
+				enums.StepStatusWaiting.String(),
+				enums.StepStatusSleeping.String(),
+				enums.StepStatusInvoking.String(),
+			)
+			includeMissing = true
+		case enums.RunStatusCompleted:
+			statusStrings = append(statusStrings, enums.StepStatusCompleted.String())
+		case enums.RunStatusFailed, enums.RunStatusOverflowed:
+			statusStrings = append(statusStrings, enums.StepStatusFailed.String(), enums.StepStatusErrored.String())
+		case enums.RunStatusCancelled:
+			statusStrings = append(statusStrings, enums.StepStatusCancelled.String(), enums.StepStatusTimedOut.String())
+		case enums.RunStatusSkipped:
+			statusStrings = append(statusStrings, enums.StepStatusSkipped.String())
+		}
 	}
-	return []sq.Expression{
-		sq.L(`(SELECT s2.status FROM spans s2
+	statusExpr := sq.L(`(SELECT s2.status FROM spans s2
 			WHERE s2.run_id = spans.run_id AND s2.dynamic_span_id = spans.dynamic_span_id
-			ORDER BY s2.end_time DESC NULLS LAST, s2.span_id DESC LIMIT 1)`).In(statusStrings),
+			ORDER BY s2.end_time DESC NULLS LAST, s2.span_id DESC LIMIT 1)`)
+	predicate := sq.Expression(statusExpr.In(statusStrings))
+	if includeMissing {
+		predicate = sq.Or(statusExpr.IsNull(), predicate)
 	}
+	return []sq.Expression{predicate}
 }
 
 // queued_at and started_at both map to root start_time.
-func spanRunRootOrder(opt cqrs.GetTraceRunOpt) []sqexp.OrderedExpression {
+func spanRunRootOrder(opt cqrs.ListRunsOptions) []sqexp.OrderedExpression {
 	order := make([]sqexp.OrderedExpression, 0, len(opt.Order)+1)
 	for _, o := range opt.Order {
 		if o.Direction == enums.TraceRunOrderAsc {
@@ -3907,6 +4092,7 @@ type spanRunRow struct {
 	EndTime       *string
 	Status        *string
 	IsDeferred    sql.NullBool
+	Attributes    *string
 	EventIDs      *string
 }
 
@@ -3924,6 +4110,7 @@ func scanSpanRunRow(rows *sql.Rows) (spanRunRow, error) {
 		&row.EndTime,
 		&row.Status,
 		&row.IsDeferred,
+		&row.Attributes,
 		&row.EventIDs,
 	)
 	return row, err
@@ -4020,6 +4207,16 @@ func convertSpanRunRow(
 		Cursor:      cursor,
 		TriggerIDs:  triggerIDs,
 	}
+	attrs := decodeSpanAttributes(row.Attributes)
+	if batchID, ok := stringAttribute(attrs, meta.Attrs.BatchID.Key()); ok {
+		if parsed, err := ulid.Parse(batchID); err == nil {
+			traceRun.BatchID = &parsed
+			traceRun.IsBatch = true
+		}
+	}
+	if cron, ok := stringAttribute(attrs, meta.Attrs.CronSchedule.Key()); ok {
+		traceRun.CronSchedule = &cron
+	}
 
 	if endTime != nil {
 		traceRun.EndedAt = *endTime
@@ -4064,7 +4261,7 @@ func (w wrapper) convertSpanRunRows(
 
 // newSpanRunsQueryBuilder creates a query builder for span-based runs Similar
 // to newRunsQueryBuilder but adapted for spans table structure
-func newSpanRunsQueryBuilder(ctx context.Context, opt cqrs.GetTraceRunOpt) *runsQueryBuilder {
+func newSpanRunsQueryBuilder(ctx context.Context, opt cqrs.ListRunsOptions) *runsQueryBuilder {
 	l := logger.StdlibLogger(ctx)
 
 	// filters
@@ -4104,15 +4301,6 @@ func newSpanRunsQueryBuilder(ctx context.Context, opt cqrs.GetTraceRunOpt) *runs
 		tsfield = "start_time"
 	}
 
-	// Convert times to UTC to match spans storage format in SQLite
-	// We currently store SQLite timestamps as Go's time.Time string: "2025-07-13 19:32:24.939517 +0000 UTC m=+..."
-	// SQLite compares these as strings, so filter times must also serialize with "+0000 UTC" suffix to correctly use
-	// lexicographic comparisons.
-	// The UTC conversion was not strictly necessary for Postgres because the timestamp columns are timestamptz, so
-	// type and timezone conversion were handled for us
-	filter = append(filter, sq.C(tsfield).Gte(opt.Filter.From.UTC()))
-	filter = append(filter, sq.C(tsfield).Lt(opt.Filter.Until.UTC()))
-
 	// cursor
 	resCursorLayout := &cqrs.TracePageCursor{
 		Cursors: map[string]cqrs.TraceCursor{},
@@ -4123,8 +4311,19 @@ func newSpanRunsQueryBuilder(ctx context.Context, opt cqrs.GetTraceRunOpt) *runs
 	if len(opt.Cursor) > 0 {
 		reqCursor = &cqrs.TracePageCursor{Cursors: map[string]cqrs.TraceCursor{}}
 		if err := reqCursor.Decode(opt.Cursor); err != nil {
-			l.Debug("cursor decode failed", "error", err)
-			reqCursor = nil
+			//
+			// The existing event-runs endpoint issued run IDs before composite cursors.
+			legacyRunID, legacyErr := ulid.Parse(opt.Cursor)
+			if legacyErr != nil {
+				l.Debug("cursor decode failed", "error", err)
+				reqCursor = nil
+			} else {
+				reqCursor.ID = legacyRunID.String()
+				reqCursor.Cursors[tsfield] = cqrs.TraceCursor{
+					Field: tsfield,
+					Value: ulid.Time(legacyRunID.Time()).UnixMicro(),
+				}
+			}
 		}
 	}
 
@@ -4221,7 +4420,6 @@ func newSpanRunsQueryBuilder(ctx context.Context, opt cqrs.GetTraceRunOpt) *runs
 
 		if len(cursorFilters) > 0 {
 			cursorPred = []sq.Expression{sq.Or(cursorFilters...)}
-			filter = append(filter, cursorPred...)
 		}
 	}
 

--- a/pkg/cqrs/manager/cqrs_test.go
+++ b/pkg/cqrs/manager/cqrs_test.go
@@ -1724,7 +1724,7 @@ func TestCQRSInsertTraceRun_TerminalMonotonicityUnderAllOrderings(t *testing.T) 
 }
 
 func TestCQRSGetTraceRunsPagination(t *testing.T) {
-	// This test verifies that cursor-based pagination works correctly for the GetSpanRuns
+	// This test verifies that cursor-based pagination works correctly for the span-backed runs list.
 	ctx := context.Background()
 	appID := uuid.New()
 
@@ -1735,7 +1735,7 @@ func TestCQRSGetTraceRunsPagination(t *testing.T) {
 	workspaceID := uuid.New()
 	functionID := uuid.New()
 
-	// Create 3 spans with "executor.run" name (required for GetSpanRuns) with distinct start_time
+	// Create 3 spans with "executor.run" name (required for ListRuns) with distinct start_time.
 	baseTime := time.Now().UTC().Truncate(time.Second)
 	runIDs := make([]string, 3)
 	for i := 0; i < 3; i++ {
@@ -2515,6 +2515,205 @@ func TestCQRSGetSpanRunsFastPathPagination(t *testing.T) {
 	assert.Equal(t, wantOrder, got, "every run returned once, in descending start order")
 }
 
+func TestCQRSListRunsUsesModernSpanData(t *testing.T) {
+	ctx := t.Context()
+	cm, cleanup := initCQRS(t)
+	defer cleanup()
+
+	accountID := uuid.New()
+	workspaceID := uuid.New()
+	appID := uuid.New()
+	functionID := uuid.New()
+	firstEventID := ulid.Make()
+	eventID := ulid.Make()
+	thirdEventID := ulid.Make()
+	runID := ulid.Make()
+	batchID := ulid.Make()
+	baseTime := time.Now().UTC().Truncate(time.Second)
+	deferred := true
+
+	attrs, err := json.Marshal(map[string]any{
+		meta.Attrs.BatchID.Key():      batchID.String(),
+		meta.Attrs.CronSchedule.Key(): "*/5 * * * *",
+	})
+	require.NoError(t, err)
+	eventIDs, err := json.Marshal([]string{firstEventID.String(), eventID.String(), thirdEventID.String()})
+	require.NoError(t, err)
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runID.String(),
+		DynamicSpanID: "dyn-list-run",
+		Name:          meta.SpanNameRun,
+		Status:        enums.StepStatusQueued.String(),
+		StartTime:     baseTime,
+		AccountID:     accountID.String(),
+		AppID:         appID.String(),
+		FunctionID:    functionID.String(),
+		EnvID:         workspaceID.String(),
+		Attributes:    attrs,
+		Output:        []byte(`{"data":{"source":"root"}}`),
+		EventIDs:      eventIDs,
+		IsDeferred:    &deferred,
+	})
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runID.String(),
+		DynamicSpanID: "dyn-list-run",
+		Name:          meta.SpanNameDynamicExtension,
+		Status:        enums.StepStatusCompleted.String(),
+		StartTime:     baseTime.Add(time.Second),
+		AccountID:     accountID.String(),
+		AppID:         appID.String(),
+		FunctionID:    functionID.String(),
+		EnvID:         workspaceID.String(),
+	})
+	outputAttrs, err := json.Marshal(map[string]any{meta.Attrs.IsFunctionOutput.Key(): true})
+	require.NoError(t, err)
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runID.String(),
+		DynamicSpanID: "dyn-list-output",
+		Name:          meta.SpanNameExecution,
+		StartTime:     baseTime.Add(500 * time.Millisecond),
+		AccountID:     accountID.String(),
+		AppID:         appID.String(),
+		FunctionID:    functionID.String(),
+		EnvID:         workspaceID.String(),
+		Attributes:    outputAttrs,
+		Output:        []byte(`{"data":{"source":"function"}}`),
+	})
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runID.String(),
+		DynamicSpanID: "dyn-list-step-output",
+		Name:          meta.SpanNameExecution,
+		StartTime:     baseTime.Add(750 * time.Millisecond),
+		AccountID:     accountID.String(),
+		AppID:         appID.String(),
+		FunctionID:    functionID.String(),
+		EnvID:         workspaceID.String(),
+		Attributes:    []byte(`{}`),
+		Output:        []byte(`{"data":{"source":"step"}}`),
+	})
+
+	runs, err := cm.ListRuns(ctx, cqrs.ListRunsOptions{
+		Filter: cqrs.RunListFilter{
+			AccountID:   accountID,
+			WorkspaceID: workspaceID,
+			AppID:       []uuid.UUID{appID},
+			FunctionID:  []uuid.UUID{functionID},
+			EventID:     []ulid.ULID{eventID},
+			TimeField:   enums.TraceRunTimeStartedAt,
+			From:        baseTime.Add(-time.Hour),
+			Until:       baseTime.Add(time.Hour),
+			Status:      []enums.RunStatus{enums.RunStatusCompleted},
+			IsDeferred:  &deferred,
+		},
+		Order: []cqrs.RunListOrder{{
+			Field:     enums.TraceRunTimeStartedAt,
+			Direction: enums.TraceRunOrderDesc,
+		}},
+		Items:         10,
+		IncludeOutput: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	assert.Equal(t, runID.String(), runs[0].RunID)
+	assert.Equal(t, enums.RunStatusCompleted, runs[0].Status)
+	assert.True(t, runs[0].IsDeferred)
+	assert.Equal(t, []string{firstEventID.String(), eventID.String(), thirdEventID.String()}, runs[0].TriggerIDs)
+	require.NotNil(t, runs[0].BatchID)
+	assert.Equal(t, batchID, *runs[0].BatchID)
+	require.NotNil(t, runs[0].CronSchedule)
+	assert.Equal(t, "*/5 * * * *", *runs[0].CronSchedule)
+	assert.JSONEq(t, `{"data":{"source":"function"}}`, string(runs[0].Output))
+	assert.NotEmpty(t, runs[0].Cursor)
+}
+
+func TestCQRSListRunsMapsScheduledStatusFilter(t *testing.T) {
+	cm, cleanup := initCQRS(t)
+	defer cleanup()
+
+	accountID := uuid.New()
+	workspaceID := uuid.New()
+	appID := uuid.New()
+	functionID := uuid.New()
+	baseTime := time.Now().UTC().Truncate(time.Second)
+	runID := ulid.Make()
+	insertTestSpan(t, cm, testSpanFields{
+		RunID:         runID.String(),
+		DynamicSpanID: "dyn-scheduled-run",
+		Name:          meta.SpanNameRun,
+		Status:        enums.StepStatusQueued.String(),
+		StartTime:     baseTime,
+		AccountID:     accountID.String(),
+		AppID:         appID.String(),
+		FunctionID:    functionID.String(),
+		EnvID:         workspaceID.String(),
+	})
+
+	runs, err := cm.ListRuns(t.Context(), cqrs.ListRunsOptions{
+		Filter: cqrs.RunListFilter{
+			AccountID:   accountID,
+			WorkspaceID: workspaceID,
+			TimeField:   enums.TraceRunTimeStartedAt,
+			From:        baseTime.Add(-time.Hour),
+			Until:       baseTime.Add(time.Hour),
+			Status:      []enums.RunStatus{enums.RunStatusScheduled},
+		},
+		Order: []cqrs.RunListOrder{{Field: enums.TraceRunTimeStartedAt, Direction: enums.TraceRunOrderDesc}},
+		Items: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	assert.Equal(t, runID.String(), runs[0].RunID)
+	assert.Equal(t, enums.RunStatusScheduled, runs[0].Status)
+}
+
+func TestCQRSListRunsFiltersByFinalEndedAt(t *testing.T) {
+	cm, cleanup := initCQRS(t)
+	defer cleanup()
+
+	accountID := uuid.New()
+	workspaceID := uuid.New()
+	appID := uuid.New()
+	functionID := uuid.New()
+	baseTime := time.Now().UTC().Truncate(time.Second)
+	insideRunID := ulid.Make()
+	outsideRunID := ulid.Make()
+
+	insertLifecycle := func(runID ulid.ULID, dynamicID string, finalAt time.Time) {
+		traceID := "trace-" + runID.String()
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runID.String(), TraceID: traceID, DynamicSpanID: dynamicID, Name: meta.SpanNameRun,
+			Status: enums.StepStatusQueued.String(), StartTime: baseTime.Add(-time.Second),
+			AccountID: accountID.String(), AppID: appID.String(), FunctionID: functionID.String(), EnvID: workspaceID.String(),
+		})
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runID.String(), TraceID: traceID, DynamicSpanID: dynamicID, Name: meta.SpanNameDynamicExtension,
+			Status: enums.StepStatusRunning.String(), StartTime: baseTime.Add(4 * time.Second),
+			AccountID: accountID.String(), AppID: appID.String(), FunctionID: functionID.String(), EnvID: workspaceID.String(),
+		})
+		insertTestSpan(t, cm, testSpanFields{
+			RunID: runID.String(), TraceID: traceID, DynamicSpanID: dynamicID, Name: meta.SpanNameDynamicExtension,
+			Status: enums.StepStatusCompleted.String(), StartTime: finalAt,
+			AccountID: accountID.String(), AppID: appID.String(), FunctionID: functionID.String(), EnvID: workspaceID.String(),
+		})
+	}
+	insertLifecycle(insideRunID, "dyn-ended-inside", baseTime.Add(5*time.Second))
+	insertLifecycle(outsideRunID, "dyn-ended-outside", baseTime.Add(15*time.Second))
+
+	runs, err := cm.ListRuns(t.Context(), cqrs.ListRunsOptions{
+		Filter: cqrs.RunListFilter{
+			AccountID: accountID, WorkspaceID: workspaceID,
+			TimeField: enums.TraceRunTimeEndedAt,
+			From:      baseTime,
+			Until:     baseTime.Add(10 * time.Second),
+		},
+		Order: []cqrs.RunListOrder{{Field: enums.TraceRunTimeEndedAt, Direction: enums.TraceRunOrderDesc}},
+		Items: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, runs, 1)
+	assert.Equal(t, insideRunID.String(), runs[0].RunID)
+}
+
 //
 // Span Tests
 //
@@ -2955,7 +3154,8 @@ func TestExtendedTraceReparenting(t *testing.T) {
 //
 
 type testSpanFields struct {
-	RunID          string    // required
+	RunID          string // required
+	TraceID        string
 	DynamicSpanID  string    // required for GROUP BY tests
 	ParentSpanID   string    // for child spans (references parent's DynamicSpanID)
 	DebugRunID     string    // for debug run tests
@@ -2970,6 +3170,7 @@ type testSpanFields struct {
 	Attributes     []byte    // JSON attributes (optional)
 	Output         []byte    // JSON output (optional)
 	EventIDs       []byte    // JSON array of event IDs (optional)
+	IsDeferred     *bool
 }
 
 // There aren't any functions exposed on cqrs.Manager that write to the new spans table
@@ -2978,7 +3179,10 @@ func insertTestSpan(t *testing.T, cm cqrs.Manager, spanFields testSpanFields) {
 	t.Helper()
 
 	spanID := ulid.MustNew(ulid.Now(), rand.Reader).String()
-	traceID := ulid.MustNew(ulid.Now(), rand.Reader).String()
+	traceID := spanFields.TraceID
+	if traceID == "" {
+		traceID = ulid.MustNew(ulid.Now(), rand.Reader).String()
+	}
 
 	// Apply defaults
 	if spanFields.Name == "" {
@@ -3021,6 +3225,10 @@ func insertTestSpan(t *testing.T, cm cqrs.Manager, spanFields testSpanFields) {
 		Attributes:     spanFields.Attributes,
 		Output:         spanFields.Output,
 		EventIds:       spanFields.EventIDs,
+		IsDeferred: sql.NullBool{
+			Bool:  spanFields.IsDeferred != nil && *spanFields.IsDeferred,
+			Valid: spanFields.IsDeferred != nil,
+		},
 	})
 	require.NoError(t, err)
 }

--- a/pkg/cqrs/runs.go
+++ b/pkg/cqrs/runs.go
@@ -1,0 +1,139 @@
+package cqrs
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/oklog/ulid/v2"
+)
+
+// a shared contract for all by run list consumers
+// across oss and cloud, rest api  and graphql
+type RunListItem struct {
+	AccountID    uuid.UUID       `json:"account_id"`
+	WorkspaceID  uuid.UUID       `json:"workspace_id"`
+	AppID        uuid.UUID       `json:"app_id"`
+	FunctionID   uuid.UUID       `json:"function_id"`
+	TraceID      string          `json:"trace_id"`
+	RunID        string          `json:"run_id"`
+	QueuedAt     time.Time       `json:"queued_at"`
+	StartedAt    time.Time       `json:"started_at,omitempty"`
+	EndedAt      time.Time       `json:"ended_at,omitempty"`
+	Duration     time.Duration   `json:"duration"`
+	SourceID     string          `json:"source_id,omitempty"`
+	TriggerIDs   []string        `json:"trigger_ids"`
+	Triggers     [][]byte        `json:"triggers"`
+	Output       []byte          `json:"output,omitempty"`
+	Status       enums.RunStatus `json:"status"`
+	IsDeferred   bool            `json:"is_deferred"`
+	IsBatch      bool            `json:"is_batch"`
+	IsDebounce   bool            `json:"is_debounce"`
+	HasAI        bool            `json:"has_ai"`
+	BatchID      *ulid.ULID      `json:"batch_id,omitempty"`
+	CronSchedule *string         `json:"cron_schedule,omitempty"`
+	Cursor       string          `json:"cursor"`
+}
+
+type RunReader interface {
+	ListRuns(ctx context.Context, opts ListRunsOptions) ([]*RunListItem, error)
+}
+
+type ListRunsOptions struct {
+	Filter        RunListFilter
+	Order         []RunListOrder
+	Cursor        string
+	Items         uint
+	IncludeOutput bool
+}
+
+type RunListTimeField = enums.TraceRunTime
+
+const (
+	RunListTimeFieldQueuedAt  = enums.TraceRunTimeQueuedAt
+	RunListTimeFieldStartedAt = enums.TraceRunTimeStartedAt
+	RunListTimeFieldEndedAt   = enums.TraceRunTimeEndedAt
+)
+
+type RunListOrderDirection = enums.TraceRunOrder
+
+const (
+	RunListOrderAsc  = enums.TraceRunOrderAsc
+	RunListOrderDesc = enums.TraceRunOrderDesc
+)
+
+type RunListFilter struct {
+	AccountID   uuid.UUID
+	WorkspaceID uuid.UUID
+	AppID       []uuid.UUID
+	FunctionID  []uuid.UUID
+	EventID     []ulid.ULID
+	TimeField   RunListTimeField
+	From        time.Time
+	Until       time.Time
+	Status      []enums.RunStatus
+	CEL         string
+	IsDeferred  *bool
+}
+
+type RunListOrder struct {
+	Field     RunListTimeField
+	Direction RunListOrderDirection
+}
+
+// RunPageCursor is the composite cursor used for stable run pagination.
+type RunPageCursor struct {
+	ID      string               `json:"id"`
+	Cursors map[string]RunCursor `json:"c"`
+}
+
+func (c *RunPageCursor) IsEmpty() bool {
+	return len(c.Cursors) == 0
+}
+
+func (c *RunPageCursor) Find(field string) *RunCursor {
+	if c.IsEmpty() {
+		return nil
+	}
+
+	f := strings.ToLower(field)
+	if v, ok := c.Cursors[f]; ok {
+		return &v
+	}
+	return nil
+}
+
+func (c *RunPageCursor) Add(field string) {
+	f := strings.ToLower(field)
+	if _, ok := c.Cursors[f]; !ok {
+		c.Cursors[f] = RunCursor{Field: f}
+	}
+}
+
+func (c *RunPageCursor) Encode() (string, error) {
+	byt, err := json.Marshal(c)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(byt), nil
+}
+
+func (c *RunPageCursor) Decode(val string) error {
+	if c.Cursors == nil {
+		c.Cursors = map[string]RunCursor{}
+	}
+	byt, err := base64.StdEncoding.DecodeString(val)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(byt, c)
+}
+
+type RunCursor struct {
+	Field string `json:"f"`
+	Value int64  `json:"v"`
+}

--- a/pkg/cqrs/traces.go
+++ b/pkg/cqrs/traces.go
@@ -357,32 +357,8 @@ type SpanMetadata struct {
 	UpdatedAt time.Time       `json:"updated_at"`
 }
 
-// TraceRun represents a function run backed by a trace
-type TraceRun struct {
-	AccountID    uuid.UUID       `json:"account_id"`
-	WorkspaceID  uuid.UUID       `json:"workspace_id"`
-	AppID        uuid.UUID       `json:"app_id"`
-	FunctionID   uuid.UUID       `json:"function_id"`
-	TraceID      string          `json:"trace_id"`
-	RunID        string          `json:"run_id"`
-	QueuedAt     time.Time       `json:"queued_at"`
-	StartedAt    time.Time       `json:"started_at,omitempty"`
-	EndedAt      time.Time       `json:"ended_at,omitempty"`
-	Duration     time.Duration   `json:"duration"`
-	SourceID     string          `json:"source_id,omitempty"`
-	TriggerIDs   []string        `json:"trigger_ids"`
-	Triggers     [][]byte        `json:"triggers"`
-	Output       []byte          `json:"output,omitempty"`
-	Status       enums.RunStatus `json:"status"`
-	IsDeferred   bool            `json:"is_deferred"`
-	IsBatch      bool            `json:"is_batch"`
-	IsDebounce   bool            `json:"is_debounce"`
-	HasAI        bool            `json:"has_ai"`
-	BatchID      *ulid.ULID      `json:"batch_id,omitempty"`
-	CronSchedule *string         `json:"cron_schedule,omitempty"`
-	// Cursor is a composite cursor used for pagination
-	Cursor string `json:"cursor"`
-}
+// TraceRun remains an alias for existing TraceReader, GraphQL, and devserver callers.
+type TraceRun = RunListItem
 
 type SpanOutput struct {
 	Input            []byte
@@ -490,23 +466,11 @@ func GetRunOptFromContext(ctx context.Context) GetRunOpt {
 	return opt
 }
 
-type GetTraceRunFilter struct {
-	AccountID   uuid.UUID
-	WorkspaceID uuid.UUID
-	AppID       []uuid.UUID
-	FunctionID  []uuid.UUID
-	TimeField   enums.TraceRunTime
-	From        time.Time
-	Until       time.Time
-	Status      []enums.RunStatus
-	CEL         string
-	IsDeferred  *bool
-}
+// GetTraceRunFilter and GetTraceRunOrder remain aliases for the existing
+// TraceReader and GraphQL runs list APIs.
+type GetTraceRunFilter = RunListFilter
 
-type GetTraceRunOrder struct {
-	Field     enums.TraceRunTime
-	Direction enums.TraceRunOrder
-}
+type GetTraceRunOrder = RunListOrder
 
 type TraceRunIdentifier struct {
 	AccountID   uuid.UUID
@@ -554,59 +518,8 @@ func (si *SpanIdentifier) Decode(data string) error {
 	return json.Unmarshal(byt, si)
 }
 
-// TracePageCursor represents the composite cursor used to handle pagination
-type TracePageCursor struct {
-	ID      string                 `json:"id"`
-	Cursors map[string]TraceCursor `json:"c"`
-}
+// TracePageCursor and TraceCursor preserve the cursor types used by
+// GetTraceRuns and the GraphQL runs list.
+type TracePageCursor = RunPageCursor
 
-func (c *TracePageCursor) IsEmpty() bool {
-	return len(c.Cursors) == 0
-}
-
-// Find finds a cusor with the provided name
-func (c *TracePageCursor) Find(field string) *TraceCursor {
-	if c.IsEmpty() {
-		return nil
-	}
-
-	f := strings.ToLower(field)
-	if v, ok := c.Cursors[f]; ok {
-		return &v
-	}
-	return nil
-}
-
-func (c *TracePageCursor) Add(field string) {
-	f := strings.ToLower(field)
-	if _, ok := c.Cursors[f]; !ok {
-		c.Cursors[f] = TraceCursor{Field: f}
-	}
-}
-
-func (c *TracePageCursor) Encode() (string, error) {
-	byt, err := json.Marshal(c)
-	if err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString(byt), nil
-}
-
-func (c *TracePageCursor) Decode(val string) error {
-	if c.Cursors == nil {
-		c.Cursors = map[string]TraceCursor{}
-	}
-	byt, err := base64.StdEncoding.DecodeString(val)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(byt, c)
-}
-
-// TraceCursor represents a cursor that is used as part of the pagination cursor
-type TraceCursor struct {
-	// Field represents the field used for this cursor
-	Field string `json:"f"`
-	// Value represents the value used for this cursor
-	Value int64 `json:"v"`
-}
+type TraceCursor = RunCursor

--- a/pkg/db/driverhelp/driverhelp.go
+++ b/pkg/db/driverhelp/driverhelp.go
@@ -28,6 +28,12 @@ type DialectHelpers interface {
 	// RootEventIDsExpr selects root-only event IDs without aggregation.
 	RootEventIDsExpr() sqexp.Expression
 
+	// EventIDsContain filters a span JSON event_ids column by one or more IDs.
+	EventIDsContain(ids []string) sqexp.Expression
+
+	// RunOutputExpr selects the preferred function output for a run page row.
+	RunOutputExpr() sqexp.Expression
+
 	// BuildEventJoin adds the dialect-specific event join to a span query.
 	BuildEventJoin(q *sq.SelectDataset) *sq.SelectDataset
 

--- a/pkg/db/postgres/helpers.go
+++ b/pkg/db/postgres/helpers.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"encoding/json"
+	"strings"
 	"time"
 
 	sq "github.com/doug-martin/goqu/v9"
@@ -28,6 +29,32 @@ func (h *helpers) RootEventIDsExpr() sqexp.Expression {
 	return sq.L("spans.event_ids::text").As("event_ids")
 }
 
+func (h *helpers) EventIDsContain(ids []string) sqexp.Expression {
+	values := make([]any, len(ids))
+	for i, id := range ids {
+		values[i] = id
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
+	return sq.L(
+		"EXISTS (SELECT 1 FROM jsonb_array_elements_text(NULLIF(spans.event_ids#>>'{}', '')::jsonb) AS eid(event_id) WHERE eid.event_id IN ("+placeholders+"))",
+		values...,
+	)
+}
+
+func (h *helpers) RunOutputExpr() sqexp.Expression {
+	return sq.L(`COALESCE((
+		SELECT CAST(output_lookup.output AS TEXT)
+		FROM spans output_lookup
+		WHERE output_lookup.run_id = spans.run_id
+			AND output_lookup.output IS NOT NULL
+			AND output_lookup.debug_run_id IS NULL
+		ORDER BY
+			CASE WHEN COALESCE((output_lookup.attributes#>>'{}')::json->>'_inngest.is.function.output', '') IN ('true', '1') THEN 0 ELSE 1 END,
+			output_lookup.end_time DESC NULLS LAST
+		LIMIT 1
+	), '')`).As("output")
+}
+
 func (h *helpers) BuildEventJoin(q *sq.SelectDataset) *sq.SelectDataset {
 	// PostgreSQL: jsonb_array_elements_text for unnesting.
 	// event_ids is JSONB containing a JSON string (double-encoded), e.g. "[\"uuid\"]" or ""
@@ -39,13 +66,17 @@ func (h *helpers) BuildEventJoin(q *sq.SelectDataset) *sq.SelectDataset {
 }
 
 func (h *helpers) ParseEventIDs(raw *string) []string {
-	// PostgreSQL: double-encoded JSON (a JSON string containing a JSON array)
 	var ids []string
-	if raw != nil && *raw != "" {
-		var innerStr string
-		if err := json.Unmarshal([]byte(*raw), &innerStr); err == nil {
-			_ = json.Unmarshal([]byte(innerStr), &ids)
-		}
+	if raw == nil || *raw == "" {
+		return ids
+	}
+	if err := json.Unmarshal([]byte(*raw), &ids); err == nil {
+		return ids
+	}
+
+	var encoded string
+	if err := json.Unmarshal([]byte(*raw), &encoded); err == nil {
+		_ = json.Unmarshal([]byte(encoded), &ids)
 	}
 	return ids
 }

--- a/pkg/db/sqlite/helpers.go
+++ b/pkg/db/sqlite/helpers.go
@@ -28,6 +28,32 @@ func (h *helpers) RootEventIDsExpr() sqexp.Expression {
 	return sq.L("spans.event_ids").As("event_ids")
 }
 
+func (h *helpers) EventIDsContain(ids []string) sqexp.Expression {
+	values := make([]any, len(ids))
+	for i, id := range ids {
+		values[i] = id
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
+	return sq.L(
+		"EXISTS (SELECT 1 FROM json_each(NULLIF(spans.event_ids, '')) WHERE value IN ("+placeholders+"))",
+		values...,
+	)
+}
+
+func (h *helpers) RunOutputExpr() sqexp.Expression {
+	return sq.L(`COALESCE((
+		SELECT CAST(output_lookup.output AS TEXT)
+		FROM spans output_lookup
+		WHERE output_lookup.run_id = spans.run_id
+			AND output_lookup.output IS NOT NULL
+			AND output_lookup.debug_run_id IS NULL
+		ORDER BY
+			CASE WHEN COALESCE(CAST(output_lookup.attributes->>'$."_inngest.is.function.output"' AS TEXT), '') IN ('true', '1') THEN 0 ELSE 1 END,
+			output_lookup.end_time DESC
+		LIMIT 1
+	), '')`).As("output")
+}
+
 func (h *helpers) BuildEventJoin(q *sq.SelectDataset) *sq.SelectDataset {
 	// SQLite: json_each for unnesting.
 	// json_each('') errors with "malformed JSON", so we use NULLIF to convert empty strings


### PR DESCRIPTION
## Description

A prerequisite for the new v2 runs api so we can more easily consolidate the event/runs, runs and gql paths and share the fetch, pagination, filtering etc. 

## Release note

None.

## Migration note

None.