### PR TITLE
internal: ReceiveEvent resolves propagated and manual sessions

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -259,6 +259,9 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 				evt.User = map[string]any{}
 			}
 
+			// Merge propagated sessions into the manual layer before validation
+			evt.Meta.ResolveSessions()
+
 			if err := evt.Validate(ctx); err != nil {
 				return err
 			}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/stretchr/testify/require"
+)
+
+// postEvent drives ReceiveEvent directly (white-box) with the chi "key" route
+// param injected, capturing the event the stub handler receives. This exercises
+// the real ingest path — including the ResolveSessions() call before Validate —
+// without standing up the full router/config.
+func postEvent(t *testing.T, body string) (*httptest.ResponseRecorder, *event.Event) {
+	t.Helper()
+
+	var got *event.Event
+	a := API{
+		handler: func(_ context.Context, e *event.Event, _ *event.SeededID) (string, error) {
+			got = e
+			return "01HZTESTEVENTID", nil
+		},
+		log: logger.StdlibLogger(t.Context()),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/e/test-key", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+
+	// ReceiveEvent reads the event key from the chi route param.
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("key", "test-key")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	a.ReceiveEvent(w, req)
+	return w, got
+}
+
+// TestReceiveEvent_ResolvesPropagatedSessions proves the ingest path folds the
+// propagated session layer into meta.sessions (manual wins per key, disjoint
+// keys fill) and clears the propagated layer before the event reaches the
+// handler
+func TestReceiveEvent_ResolvesPropagatedSessions(t *testing.T) {
+	w, got := postEvent(t, `{
+		"name": "test/session-prop",
+		"data": {},
+		"meta": {
+			"sessions": {"conv_id": "manual"},
+			"propagatedSessions": {"conv_id": "propagated", "org_id": "42"}
+		}
+	}`)
+
+	require.Equal(t, 200, w.Code, w.Body.String())
+	require.NotNil(t, got)
+	require.Equal(t, event.Sessions{"conv_id": "manual", "org_id": "42"}, got.Meta.Sessions)
+	require.Nil(t, got.Meta.PropagatedSessions, "propagated layer must not persist past ingest")
+}

--- a/pkg/event/sessions.go
+++ b/pkg/event/sessions.go
@@ -5,18 +5,93 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
+	"sort"
 
 	"github.com/inngest/inngest/pkg/consts"
 )
 
 // EventMeta carries event meta shared across runs triggered by this event.
 type EventMeta struct {
-	// Sessions groups runs triggered by this event.
+	// Sessions groups runs triggered by this event. These are the manual
+	// (user-set) sessions and always win over propagated sessions on merge.
 	Sessions Sessions `json:"sessions,omitempty"`
+
+	// PropagatedSessions carries sessions inherited from the parent run that
+	// emitted this event (SDK-stamped during a run). It is an un-merged layer:
+	// ResolveSessions folds it into Sessions at ingest and clears it, so it is
+	// never persisted or forwarded downstream.
+	PropagatedSessions Sessions `json:"propagatedSessions,omitempty"`
 }
 
 func (m EventMeta) IsZero() bool {
-	return len(m.Sessions) == 0
+	return len(m.Sessions) == 0 && len(m.PropagatedSessions) == 0
+}
+
+// ResolveSessions folds the propagated (inherited) session layer into the
+// manual layer, producing the single Sessions map carried downstream. Manual
+// keys always win and are never evicted; remaining slots up to
+// consts.MaxEventSessions are filled from propagated sessions in
+// lexicographic key order (matching run-level session truncation) for
+// deterministic output. PropagatedSessions is cleared so it never persists.
+//
+// Called at API ingest before Event.Validate: each layer may independently be
+// up to MaxEventSessions, so the pre-merge union can exceed the cap —
+// validating the raw fields would falsely reject; validating the merged result
+// does not.
+func (m *EventMeta) ResolveSessions() {
+	if len(m.PropagatedSessions) == 0 {
+		// Nothing to merge; drop the (empty) propagated layer defensively.
+		m.PropagatedSessions = nil
+		return
+	}
+
+	m.Sessions = mergeSessions(m.PropagatedSessions, m.Sessions)
+	m.PropagatedSessions = nil
+}
+
+// mergeSessions folds the propagated (inherited) session candidates into the
+// manual (user-set) map, producing the final per-event session set. Manual
+// keys always win and are never evicted; remaining slots up to
+// consts.MaxEventSessions are filled from propagatedCandidates deterministically
+// (lexicographic key order) so output is stable across retries and map
+// iteration order. Returns nil when the merged result is empty.
+func mergeSessions(propagatedCandidates, manualMap Sessions) Sessions {
+	out := Sessions{}
+
+	// Manual keys always win and are never evicted — even when they alone
+	// exceed consts.MaxEventSessions. An oversized manual layer is rejected by
+	// the post-merge Validate rather than silently truncated here, so user-set
+	// keys are never dropped in favour of inherited ones.
+	maps.Copy(out, manualMap)
+
+	// Fill any remaining slots from the propagated candidates in lexicographic
+	// key order. Go's native string ordering is byte-wise over UTF-8, matching
+	// run-level truncation (normalizeRunSessions) and the SDK's aggregate — so
+	// the chosen subset is deterministic and identical across implementations,
+	// independent of map iteration order.
+	if remaining := consts.MaxEventSessions - len(out); remaining > 0 && len(propagatedCandidates) > 0 {
+		keys := make([]string, 0, len(propagatedCandidates))
+		for k := range propagatedCandidates {
+			if _, manual := out[k]; manual {
+				continue // manual wins; a shadowed propagated key consumes no slot
+			}
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if remaining <= 0 {
+				break
+			}
+			out[k] = propagatedCandidates[k]
+			remaining--
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // Sessions maps a session key to a session ID.

--- a/pkg/event/sessions_test.go
+++ b/pkg/event/sessions_test.go
@@ -1,0 +1,134 @@
+package event
+
+import (
+	"context"
+	"testing"
+
+	"github.com/inngest/inngest/pkg/consts"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveSessions exercises the public merge entrypoint end to end: with no
+// propagated layer the manual sessions pass through untouched; otherwise manual
+// (user-set) keys win, remaining slots up to MaxEventSessions fill from the
+// propagated layer in UTF-8 byte order (matching the SDK's aggregateMetadata and
+// run-level normalizeRunSessions), and the propagated layer is always cleared so
+// it never persists downstream.
+//
+// The byte-order cases — including the non-BMP one — are the cross-language
+// parity vectors; the SDK verifies the same selection in
+// packages/inngest/src/helpers/sessions.parity.test.ts. Keep the two in sync.
+func TestResolveSessions(t *testing.T) {
+	cases := []struct {
+		name       string
+		manual     Sessions
+		propagated Sessions
+		want       Sessions
+	}{
+		{
+			name: "both layers empty stays nil",
+			want: nil,
+		},
+		{
+			name:   "manual only passes through (no propagated layer)",
+			manual: Sessions{"a": "1"},
+			want:   Sessions{"a": "1"},
+		},
+		{
+			name:       "propagated only passes through",
+			propagated: Sessions{"a": "1"},
+			want:       Sessions{"a": "1"},
+		},
+		{
+			name:       "manual wins on key collision, disjoint propagated fills",
+			manual:     Sessions{"conv_id": "manual"},
+			propagated: Sessions{"conv_id": "propagated", "org_id": "42"},
+			want:       Sessions{"conv_id": "manual", "org_id": "42"},
+		},
+		{
+			name:       "disjoint keys are unioned",
+			manual:     Sessions{"b": "2"},
+			propagated: Sessions{"a": "1"},
+			want:       Sessions{"a": "1", "b": "2"},
+		},
+		{
+			name:       "manual reserved first, propagated fills in byte order, overflow dropped",
+			manual:     Sessions{"f": "9"},
+			propagated: Sessions{"a": "1", "b": "1", "c": "1", "d": "1", "e": "1"},
+			// f reserved; a,b,c,d fill; e is byte-last, dropped at the cap.
+			want: Sessions{"f": "9", "a": "1", "b": "1", "c": "1", "d": "1"},
+		},
+		{
+			name:       "full manual layer evicts all propagated",
+			manual:     Sessions{"f": "9", "g": "9", "h": "9", "i": "9", "j": "9"},
+			propagated: Sessions{"a": "1", "b": "1", "c": "1", "d": "1", "e": "1"},
+			want:       Sessions{"f": "9", "g": "9", "h": "9", "i": "9", "j": "9"},
+		},
+		{
+			name:       "shadowed propagated key consumes no slot",
+			manual:     Sessions{"a": "2", "f": "9"},
+			propagated: Sessions{"a": "1", "b": "1", "c": "1", "d": "1", "e": "1"},
+			// a,f reserved (a shadows propagated a, freeing a slot); b,c,d fill.
+			want: Sessions{"a": "2", "f": "9", "b": "1", "c": "1", "d": "1"},
+		},
+		{
+			name: "oversized manual layer is preserved for post-merge Validate to reject",
+			// Manual alone exceeds the cap; it is never truncated here and no
+			// propagated key is added.
+			manual:     Sessions{"a": "1", "b": "1", "c": "1", "d": "1", "e": "1", "f": "1"},
+			propagated: Sessions{"z": "1"},
+			want:       Sessions{"a": "1", "b": "1", "c": "1", "d": "1", "e": "1", "f": "1"},
+		},
+		{
+			name: "fill order is UTF-8 byte order, not locale/rune order",
+			// 'Z' (0x5A) < 'a' (0x61) < 'z' (0x7A) < 'é' (0xC3 0xA9). Six keys,
+			// cap 5 → 'é' is dropped.
+			propagated: Sessions{"Z": "1", "a": "1", "b": "1", "c": "1", "z": "1", "é": "1"},
+			want:       Sessions{"Z": "1", "a": "1", "b": "1", "c": "1", "z": "1"},
+		},
+		{
+			name: "non-BMP truncation follows UTF-8 bytes, not UTF-16 code units",
+			// U+E000 encodes as 0xEE.. and 🍎 (U+1F34E) as 0xF0.., so by UTF-8 bytes
+			// U+E000 sorts first and 🍎 is dropped at the cap. A UTF-16 code-unit
+			// sort (JavaScript's default) would order them the other way — this
+			// vector pins the SDK/server agreement.
+			propagated: Sessions{
+				"a": "1", "b": "1", "c": "1", "d": "1", "\ue000": "5", "\U0001F34E": "6",
+			},
+			want: Sessions{"a": "1", "b": "1", "c": "1", "d": "1", "\ue000": "5"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			m := &EventMeta{Sessions: tc.manual, PropagatedSessions: tc.propagated}
+
+			m.ResolveSessions()
+
+			r.Equal(tc.want, m.Sessions)
+			r.Nil(m.PropagatedSessions, "propagated layer is always cleared")
+		})
+	}
+}
+
+// TestResolveSessionsThenValidate ensures that we resolve sessions before
+// validation.
+func TestResolveSessionsThenValidate(t *testing.T) {
+	r := require.New(t)
+	manual := Sessions{"a": "1", "b": "1", "c": "1"}               // 3
+	propagated := Sessions{"d": "1", "e": "1", "f": "1", "g": "1"} // 4 → raw union 7 > cap
+	r.Greater(len(manual)+len(propagated), consts.MaxEventSessions)
+
+	evt := Event{
+		Name: "test/session-prop",
+		Meta: EventMeta{Sessions: manual, PropagatedSessions: propagated},
+	}
+	evt.Meta.ResolveSessions()
+
+	r.Len(evt.Meta.Sessions, consts.MaxEventSessions) // capped
+	for k := range manual {
+		r.Contains(evt.Meta.Sessions, k, "manual keys always survive the merge")
+	}
+	r.NoError(evt.Validate(context.Background()))
+}


### PR DESCRIPTION
## Description

- Clients can send propagated events alongside their manual events. Server-side, we will merge them together.
- We do not address null tombstones here.
- This feature is not yet supported by SDKs.
- https://linear.app/inngest/issue/EXE-2033/stepsendevent-propagates-sessions

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
