### PR TITLE
internal: support null tombstones with session propagation

### DIFF
--- a/pkg/event/event_test.go
+++ b/pkg/event/event_test.go
@@ -56,12 +56,14 @@ func TestUnmarshalJSON(t *testing.T) {
 		r.Error(err)
 	})
 
-	t.Run("invalid session value type returns error", func(t *testing.T) {
+	t.Run("null manual session value is a tombstone, not an error", func(t *testing.T) {
 		r := require.New(t)
 
 		var evt Event
 		err := json.Unmarshal([]byte(`{"name":"test/event","data":{},"meta":{"sessions":{"conversation_id":null}}}`), &evt)
-		r.EqualError(err, `event session "conversation_id" must be a string or number`)
+		r.NoError(err)
+		// The tombstone is captured off the wire, not surfaced as a session id.
+		r.Empty(evt.Meta.Sessions)
 	})
 
 	t.Run("boolean session value returns error", func(t *testing.T) {
@@ -69,7 +71,7 @@ func TestUnmarshalJSON(t *testing.T) {
 
 		var evt Event
 		err := json.Unmarshal([]byte(`{"name":"test/event","data":{},"meta":{"sessions":{"active":true}}}`), &evt)
-		r.EqualError(err, `event session "active" must be a string or number`)
+		r.EqualError(err, `event session "active" must be a string, number, or null`)
 	})
 
 	t.Run("preserves numeric session precision", func(t *testing.T) {

--- a/pkg/event/sessions.go
+++ b/pkg/event/sessions.go
@@ -22,10 +22,103 @@ type EventMeta struct {
 	// ResolveSessions folds it into Sessions at ingest and clears it, so it is
 	// never persisted or forwarded downstream.
 	PropagatedSessions Sessions `json:"propagated_sessions,omitempty"`
+
+	// sessionTombstones holds manual session keys explicitly set to JSON null — RFC
+	// 7386 per-key tombstones. Each cuts the matching key from the propagated
+	// layer at ResolveSessions; tombstones are consumed there (never merged into
+	// Sessions, never counted against MaxEventSessions, never persisted). They
+	// are captured transiently in UnmarshalJSON so Sessions stays a plain
+	// map[string]string for every downstream reader — see [null-tombstone
+	// typing] in the session-propagation design.
+	sessionTombstones []string
+
+	// clearPropagated is set when the manual `sessions` field is JSON null
+	// (RFC 7386 whole-document null): "clear all inherited sessions". It is
+	// distinct from an absent field (keep propagated) and from an empty object
+	// (keep propagated), which is why the manual layer needs a custom
+	// UnmarshalJSON. Consumed and reset at ResolveSessions.
+	clearPropagated bool
 }
 
 func (m EventMeta) IsZero() bool {
-	return len(m.Sessions) == 0 && len(m.PropagatedSessions) == 0
+	return len(m.Sessions) == 0 && len(m.PropagatedSessions) == 0 &&
+		len(m.sessionTombstones) == 0 && !m.clearPropagated
+}
+
+// UnmarshalJSON parses the two session layers, capturing null tombstones on the
+// manual layer separately so Sessions itself stays a plain map[string]string.
+//
+// The manual `sessions` field distinguishes three JSON states that a
+// map[string]string cannot: absent (keep propagated), null (clear all
+// propagated), and an object whose values may include per-key null tombstones.
+// The propagated layer is machine-stamped and admits no tombstones, so it uses
+// the ordinary Sessions decoding (which rejects null values).
+func (m *EventMeta) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Sessions           json.RawMessage `json:"sessions"`
+		PropagatedSessions Sessions        `json:"propagated_sessions"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	sessions, tombstones, clearAll, err := parseManualSessions(raw.Sessions)
+	if err != nil {
+		return err
+	}
+
+	m.Sessions = sessions
+	m.PropagatedSessions = raw.PropagatedSessions
+	m.sessionTombstones = tombstones
+	m.clearPropagated = clearAll
+	return nil
+}
+
+// parseManualSessions decodes the raw manual `sessions` field into its real
+// (non-null) entries, the set of per-key null tombstones, and whether the whole
+// field was JSON null. Numeric ids are stringified, matching Sessions
+// decoding; booleans (and other non-string/number/null values) are rejected.
+func parseManualSessions(raw json.RawMessage) (sessions Sessions, tombstones []string, clearAll bool, err error) {
+	// Absent field: nothing set, keep any propagated layer untouched.
+	if len(raw) == 0 {
+		return nil, nil, false, nil
+	}
+	// Whole-field null (RFC 7386): clear all inherited sessions.
+	if string(raw) == "null" {
+		return nil, nil, true, nil
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+
+	obj := map[string]any{}
+	if err := dec.Decode(&obj); err != nil {
+		return nil, nil, false, err
+	}
+
+	for name, value := range obj {
+		switch v := value.(type) {
+		case nil:
+			// Per-key null tombstone (RFC 7386): cut this inherited key.
+			tombstones = append(tombstones, name)
+		case string:
+			if sessions == nil {
+				sessions = Sessions{}
+			}
+			sessions[name] = v
+		case json.Number:
+			if sessions == nil {
+				sessions = Sessions{}
+			}
+			sessions[name] = v.String()
+		default:
+			// Booleans etc. are rejected — a session id is a string or number,
+			// and null is the only accepted non-value (a tombstone).
+			return nil, nil, false, fmt.Errorf("event session %q must be a string, number, or null", name)
+		}
+	}
+
+	return sessions, tombstones, false, nil
 }
 
 // ResolveSessions folds the propagated (inherited) session layer into the
@@ -39,10 +132,32 @@ func (m EventMeta) IsZero() bool {
 // up to MaxEventSessions, so the pre-merge union can exceed the cap —
 // validating the raw fields would falsely reject; validating the merged result
 // does not.
+//
+// Null tombstones (RFC 7386) are applied against the propagated layer first and
+// are always consumed here: a whole-field-null manual layer clears every
+// inherited session, and per-key nulls cut the matching inherited keys.
+// Tombstones never survive into Sessions and so never count against the cap.
 func (m *EventMeta) ResolveSessions() {
-	if len(m.PropagatedSessions) == 0 {
-		// Nothing to merge; drop the (empty) propagated layer defensively.
+	// Apply the manual layer's tombstones to the inherited candidates before
+	// merging. Whole-field null wins over individual tombstones (there is nothing
+	// left to cut once everything is cleared).
+	if m.clearPropagated {
 		m.PropagatedSessions = nil
+	} else {
+		for _, key := range m.sessionTombstones {
+			delete(m.PropagatedSessions, key)
+		}
+	}
+	m.sessionTombstones = nil
+	m.clearPropagated = false
+
+	if len(m.PropagatedSessions) == 0 {
+		// Nothing to merge; drop the (empty) propagated layer defensively and
+		// normalize an empty manual layer to nil.
+		m.PropagatedSessions = nil
+		if len(m.Sessions) == 0 {
+			m.Sessions = nil
+		}
 		return
 	}
 

--- a/pkg/event/sessions_test.go
+++ b/pkg/event/sessions_test.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/inngest/inngest/pkg/consts"
@@ -131,4 +132,90 @@ func TestResolveSessionsThenValidate(t *testing.T) {
 		r.Contains(evt.Meta.Sessions, k, "manual keys always survive the merge")
 	}
 	r.NoError(evt.Validate(context.Background()))
+}
+
+// TestResolveSessionsTombstones exercises the RFC 7386 null-tombstone paths.
+// Tombstones are captured during JSON unmarshalling (a plain map[string]string
+// cannot hold null), so these cases start from wire JSON and resolve.
+func TestResolveSessionsTombstones(t *testing.T) {
+	cases := []struct {
+		name string
+		// meta is the raw JSON of an event's `meta` object.
+		meta string
+		want Sessions
+	}{
+		{
+			name: "per-key null cuts the matching propagated key",
+			meta: `{"sessions":{"conv_id":null},"propagated_sessions":{"conv_id":"123"}}`,
+			want: nil,
+		},
+		{
+			name: "per-key null leaves other propagated keys intact",
+			meta: `{"sessions":{"conv_id":null},"propagated_sessions":{"conv_id":"123","org_id":"42"}}`,
+			want: Sessions{"org_id": "42"},
+		},
+		{
+			name: "cut one and add another (manual value wins)",
+			meta: `{"sessions":{"conv_id":null,"new_id":"456"},"propagated_sessions":{"conv_id":"123"}}`,
+			want: Sessions{"new_id": "456"},
+		},
+		{
+			name: "whole-field null clears all propagated",
+			meta: `{"sessions":null,"propagated_sessions":{"a":"1","b":"2"}}`,
+			want: nil,
+		},
+		{
+			name: "empty object keeps propagated (RFC 7386 empty patch)",
+			meta: `{"sessions":{},"propagated_sessions":{"a":"1"}}`,
+			want: Sessions{"a": "1"},
+		},
+		{
+			name: "absent manual keeps propagated",
+			meta: `{"propagated_sessions":{"a":"1"}}`,
+			want: Sessions{"a": "1"},
+		},
+		{
+			name: "tombstone with no matching propagated key is a no-op",
+			meta: `{"sessions":{"ghost":null},"propagated_sessions":{"a":"1"}}`,
+			want: Sessions{"a": "1"},
+		},
+		{
+			name: "cuts never count against the cap: 4 cuts + 5 fills still yields 5",
+			meta: `{"sessions":{"w":null,"x":null,"y":null,"z":null},` +
+				`"propagated_sessions":{"a":"1","b":"1","c":"1","d":"1","e":"1"}}`,
+			want: Sessions{"a": "1", "b": "1", "c": "1", "d": "1", "e": "1"},
+		},
+		{
+			name: "numeric manual id is stringified alongside a cut",
+			meta: `{"sessions":{"conv_id":null,"n":7},"propagated_sessions":{"conv_id":"9"}}`,
+			want: Sessions{"n": "7"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+
+			var m EventMeta
+			r.NoError(json.Unmarshal([]byte(tc.meta), &m))
+
+			m.ResolveSessions()
+
+			r.Equal(tc.want, m.Sessions)
+			r.Nil(m.PropagatedSessions, "propagated layer is always cleared")
+			r.Empty(m.sessionTombstones, "tombstones are consumed")
+			r.False(m.clearPropagated, "clear flag is reset")
+			r.NoError(m.Sessions.Validate(), "resolved manual layer is valid")
+		})
+	}
+}
+
+// TestParseManualSessionsRejectsBool ensures non-string/number/null manual
+// values are rejected, mirroring the propagated-layer decoding.
+func TestParseManualSessionsRejectsBool(t *testing.T) {
+	r := require.New(t)
+	var m EventMeta
+	err := json.Unmarshal([]byte(`{"sessions":{"flag":true}}`), &m)
+	r.Error(err)
+	r.Contains(err.Error(), "must be a string, number, or null")
 }


### PR DESCRIPTION
## Description

- Users should be able to clear propagated session keys with a manual `key: null`
- Users should also be able to clear all propagated session keys by setting the sessions object to `null`
- https://linear.app/inngest/issue/EXE-2032/users-can-use-null-to-cancel-out-propagated-sessions

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>