### PR TITLE
ci: Align auto-labels with Linear

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -20,3 +20,4 @@ jobs:
         with:
           # Keep this list aligned with cliff.toml.
           task_types: '["feat","fix","doc","docs","test","ci","refactor","perf","chore","revert","style","security","cloud","internal","noop"]'
+          custom_labels: '{"feat": "feature", "fix": "fix", "doc": "documentation", "docs": "documentation", "test": "test", "ci": "ci", "refactor": "refactor", "perf": "performance", "chore": "chore", "revert": "revert", "cloud": "Cloud"}'


### PR DESCRIPTION
## Description

Auto-labeling was causing duplicate labels. Team flagged that we had 3 "docs" labels which surfaced this.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
