### PR TITLE
internal: invoke supports session propagation

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -347,6 +347,9 @@ func (a API) Invoke(w http.ResponseWriter, r *http.Request) {
 	}
 	evt := event.NewInvocationEvent(newInvOpts)
 
+	// Merge the two session layers before the event is handled
+	evt.Event.Meta.ResolveSessions()
+
 	seed := event.SeededIDFromString(
 		r.Header.Get(headers.HeaderEventIDSeed),
 		0,

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -350,6 +350,12 @@ func (a API) Invoke(w http.ResponseWriter, r *http.Request) {
 	// Merge the two session layers before the event is handled
 	evt.Event.Meta.ResolveSessions()
 
+	// Validate after the merge
+	if err := evt.Event.Validate(r.Context()); err != nil {
+		_ = publicerr.WriteHTTP(w, publicerr.Wrap(err, 400, "Invalid invocation event"))
+		return
+	}
+
 	seed := event.SeededIDFromString(
 		r.Header.Get(headers.HeaderEventIDSeed),
 		0,

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -109,3 +109,19 @@ func TestInvoke_ResolvesPropagatedSessions(t *testing.T) {
 	require.Nil(t, got.Meta.PropagatedSessions, "propagated layer must not persist past invoke")
 	require.Equal(t, event.InvokeFnName, got.Name, "invoke path rewrites the event name")
 }
+
+// TestInvoke_ValidatesAfterResolve proves the HTTP invoke path validates the
+// merged sessions and rejects an oversized manual layer, mirroring the
+// ReceiveEvent behaviour this entrypoint bypasses.
+func TestInvoke_ValidatesAfterResolve(t *testing.T) {
+	// 6 manual keys > MaxEventSessions (5); all survive the merge.
+	w, got := postInvoke(t, `{
+		"data": {},
+		"meta": {
+			"sessions": {"a":"1","b":"1","c":"1","d":"1","e":"1","f":"1"}
+		}
+	}`)
+
+	require.Equal(t, 400, w.Code, w.Body.String())
+	require.Nil(t, got, "an invalid invocation event must never reach the handler")
+}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -61,3 +61,51 @@ func TestReceiveEvent_ResolvesPropagatedSessions(t *testing.T) {
 	require.Equal(t, event.Sessions{"conv_id": "manual", "org_id": "42"}, got.Meta.Sessions)
 	require.Nil(t, got.Meta.PropagatedSessions, "propagated layer must not persist past ingest")
 }
+
+// postInvoke drives Invoke directly with the chi "slug" route param
+// injected, capturing the invocation event the stub handler receives.
+func postInvoke(t *testing.T, body string) (*httptest.ResponseRecorder, *event.Event) {
+	t.Helper()
+
+	var got *event.Event
+	a := API{
+		handler: func(_ context.Context, e *event.Event, _ *event.SeededID) (string, error) {
+			got = e
+			return "01HZTESTEVENTID", nil
+		},
+		log: logger.StdlibLogger(t.Context()),
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/invoke/my-fn", bytes.NewReader([]byte(body)))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Invoke reads the target function slug from the chi route param.
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("slug", "my-fn")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+	w := httptest.NewRecorder()
+	a.Invoke(w, req)
+	return w, got
+}
+
+// TestInvoke_ResolvesPropagatedSessions proves the HTTP invoke path folds the
+// propagated session layer into meta.sessions (manual wins per key, disjoint
+// keys fill), applies null tombstones, and clears the propagated layer before
+// the invocation event reaches the handler — mirroring ReceiveEvent, which this
+// entrypoint bypasses.
+func TestInvoke_ResolvesPropagatedSessions(t *testing.T) {
+	w, got := postInvoke(t, `{
+		"data": {},
+		"meta": {
+			"sessions": {"conv_id": "manual", "cut_me": null},
+			"propagated_sessions": {"conv_id": "propagated", "org_id": "42", "cut_me": "inherited"}
+		}
+	}`)
+
+	require.Equal(t, 200, w.Code, w.Body.String())
+	require.NotNil(t, got)
+	require.Equal(t, event.Sessions{"conv_id": "manual", "org_id": "42"}, got.Meta.Sessions)
+	require.Nil(t, got.Meta.PropagatedSessions, "propagated layer must not persist past invoke")
+	require.Equal(t, event.InvokeFnName, got.Name, "invoke path rewrites the event name")
+}

--- a/pkg/event/invoke_test.go
+++ b/pkg/event/invoke_test.go
@@ -1,12 +1,54 @@
 package event
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/inngest/inngest/pkg/consts"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/stretchr/testify/require"
 )
+
+// TestNewInvocationEventResolveSessions verifies the step.invoke server path:
+// the invocation payload carries two session layers (manual meta.sessions and
+// SDK-stamped meta.propagated_sessions), NewInvocationEvent copies both onto the
+// built event, and ResolveSessions (called by the executor before publishing)
+// folds them together the same way API ingest does for step.sendEvent.
+func TestNewInvocationEventResolveSessions(t *testing.T) {
+	// Simulate the wire payload the SDK stamps for an invoke: a manual key plus a
+	// propagated layer inherited from the parent run. Decoding through
+	// event.Event exercises EventMeta.UnmarshalJSON (tombstone capture).
+	raw := []byte(`{
+		"name": "some/event",
+		"data": {"foo": "bar"},
+		"meta": {
+			"sessions": {"conv_id": "manual", "cut_me": null},
+			"propagated_sessions": {"conv_id": "parent", "org_id": "42", "cut_me": "inherited"}
+		}
+	}`)
+
+	var payload Event
+	require.NoError(t, json.Unmarshal(raw, &payload))
+
+	evt := NewInvocationEvent(NewInvocationEventOpts{
+		Event: payload,
+		FnID:  "target-fn",
+	})
+
+	// The point of this test: NewInvocationEvent must carry BOTH un-merged
+	// session layers (and the captured tombstone) through onto the built event
+	// untouched — it must not merge or drop them. That passthrough is what lets
+	// the executor resolve later; the merge itself is covered exhaustively by
+	// TestResolveSessions / TestResolveSessionsTombstones, so we don't re-assert
+	// it here beyond a smoke check.
+	require.Equal(t, Sessions{"conv_id": "manual"}, evt.Event.Meta.Sessions,
+		"manual layer preserved (the null tombstone is captured off-map, not stored)")
+	require.Equal(t, Sessions{"conv_id": "parent", "org_id": "42", "cut_me": "inherited"},
+		evt.Event.Meta.PropagatedSessions, "propagated layer preserved untouched")
+	require.Equal(t, []string{"cut_me"}, evt.Event.Meta.sessionTombstones,
+		"null tombstone captured during Event unmarshal and carried through")
+	require.Equal(t, InvokeFnName, evt.Event.Name)
+}
 
 func TestEvent_SetInvokeSpanRef(t *testing.T) {
 	ref := &meta.SpanReference{TraceParent: "00-00112233445566778899aabbccddeeff-0011223344556677-01"}

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -5219,6 +5219,11 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx exe
 	// published.
 	evt.Event.Meta.ResolveSessions()
 
+	// Validate the sessions after the merge
+	if err := evt.Event.Meta.Sessions.Validate(); err != nil {
+		return execError{err: fmt.Errorf("invalid step.invoke sessions: %w", err), final: true}
+	}
+
 	pause := state.Pause{
 		ID:                  pauseID,
 		WorkspaceID:         runCtx.Metadata().ID.Tenant.EnvID,

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -5215,6 +5215,10 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx exe
 		SourceFnVersion: runCtx.Metadata().Config.FunctionVersion,
 	})
 
+	// Merge the invocation payload's two session layers before the event is
+	// published.
+	evt.Event.Meta.ResolveSessions()
+
 	pause := state.Pause{
 		ID:                  pauseID,
 		WorkspaceID:         runCtx.Metadata().ID.Tenant.EnvID,

--- a/pkg/execution/executor/handle_generator_invoke_test.go
+++ b/pkg/execution/executor/handle_generator_invoke_test.go
@@ -81,3 +81,49 @@ func TestHandleGeneratorInvokeFunction_ResolvesSessionsBeforePublish(t *testing.
 	require.Equal(t, event.Sessions{"conv_id": "manual", "org_id": "42"}, got.Meta.Sessions)
 	require.Nil(t, got.Meta.PropagatedSessions, "propagated layer must be cleared before publish")
 }
+
+// TestHandleGeneratorInvokeFunction_ValidatesSessionsAfterResolve proves the
+// executor validates sessions *after* the merge, closing a gap the pre-merge
+// InvokeFunctionOpts.Validate() (manual layer only) leaves open
+//
+// The error must be non-retryable (a bad payload never self-heals).
+func TestHandleGeneratorInvokeFunction_ValidatesSessionsAfterResolve(t *testing.T) {
+	var called bool
+	e := &executor{
+		log:            logger.From(context.Background()),
+		tracerProvider: tracing.NewNoopTracerProvider(),
+		pm:             &stubPauseManager{},
+		queue:          &stubQueue{},
+		handleInvokeEvent: func(_ context.Context, _ event.TrackedEvent) error {
+			called = true
+			return nil
+		},
+	}
+
+	rc := &mockRunContext{
+		md: sv2.Metadata{
+			ID:     sv2.ID{RunID: ulid.MustNew(ulid.Now(), nil), FunctionID: uuid.New()},
+			Config: *sv2.InitConfig(&sv2.Config{}),
+		},
+	}
+
+	// Legal manual layer (empty), but the propagated layer has an empty id. The
+	// pre-merge manual-only check passes; only the post-merge validate catches it.
+	gen := state.GeneratorOpcode{
+		Op: enums.OpcodeInvokeFunction,
+		ID: "step-invoke",
+		Opts: []byte(`{"function_id":"app-fn","payload":{
+			"name":"some/event","data":{"foo":"bar"},
+			"meta":{"propagated_sessions":{"org_id":""}}
+		}}`),
+	}
+	edge := queue.PayloadEdge{Edge: inngest.Edge{Incoming: "step"}}
+
+	err := e.handleGeneratorInvokeFunction(context.Background(), rc, gen, edge, OpcodeGroup{})
+	require.Error(t, err)
+	require.False(t, called, "an invalid invocation event must never be published")
+
+	var execErr execError
+	require.ErrorAs(t, err, &execErr)
+	require.False(t, execErr.Retryable(), "session validation failure is a final user error")
+}

--- a/pkg/execution/executor/handle_generator_invoke_test.go
+++ b/pkg/execution/executor/handle_generator_invoke_test.go
@@ -1,0 +1,83 @@
+package executor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/inngest/inngest/pkg/enums"
+	"github.com/inngest/inngest/pkg/event"
+	"github.com/inngest/inngest/pkg/execution/pauses"
+	"github.com/inngest/inngest/pkg/execution/queue"
+	"github.com/inngest/inngest/pkg/execution/state"
+	sv2 "github.com/inngest/inngest/pkg/execution/state/v2"
+	"github.com/inngest/inngest/pkg/inngest"
+	"github.com/inngest/inngest/pkg/logger"
+	"github.com/inngest/inngest/pkg/tracing"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// stubPauseManager satisfies pauses.Manager for tests that only need Write to
+// succeed (the invoke path writes one pause before publishing the event).
+type stubPauseManager struct{ pauses.Manager }
+
+func (s *stubPauseManager) Write(_ context.Context, _ pauses.Index, _ ...*state.Pause) (int, error) {
+	return 1, nil
+}
+
+// TestHandleGeneratorInvokeFunction_ResolvesSessionsBeforePublish proves the
+// executor's step.invoke path actually calls EventMeta.ResolveSessions() on the
+// invocation event before publishing it — the internal invocation event never
+// passes through the API ingest path (ReceiveEvent) that resolves regular
+// events, so this is the only fast guard for that wiring.
+//
+// It captures the published event via the injected handleInvokeEvent seam and
+// asserts the merge happened (manual wins per key, disjoint propagated fills,
+// propagated layer cleared). The merge *semantics* are covered exhaustively in
+// pkg/event/sessions_test.go; here we only assert the executor invokes them.
+func TestHandleGeneratorInvokeFunction_ResolvesSessionsBeforePublish(t *testing.T) {
+	var captured event.TrackedEvent
+	e := &executor{
+		log:            logger.From(context.Background()),
+		tracerProvider: tracing.NewNoopTracerProvider(),
+		pm:             &stubPauseManager{},
+		queue:          &stubQueue{},
+		handleInvokeEvent: func(_ context.Context, evt event.TrackedEvent) error {
+			captured = evt
+			return nil
+		},
+	}
+
+	rc := &mockRunContext{
+		md: sv2.Metadata{
+			ID:     sv2.ID{RunID: ulid.MustNew(ulid.Now(), nil), FunctionID: uuid.New()},
+			Config: *sv2.InitConfig(&sv2.Config{}),
+		},
+	}
+
+	// Raw-bytes Opts round-trips through EventMeta.UnmarshalJSON, exercising the
+	// same two-layer wire (and null-tombstone capture) the SDK stamps.
+	gen := state.GeneratorOpcode{
+		Op: enums.OpcodeInvokeFunction,
+		ID: "step-invoke",
+		Opts: []byte(`{"function_id":"app-fn","payload":{
+			"name":"some/event","data":{"foo":"bar"},
+			"meta":{
+				"sessions":{"conv_id":"manual","cut_me":null},
+				"propagated_sessions":{"conv_id":"parent","org_id":"42","cut_me":"inherited"}
+			}}}`),
+	}
+	edge := queue.PayloadEdge{Edge: inngest.Edge{Incoming: "step"}}
+
+	err := e.handleGeneratorInvokeFunction(context.Background(), rc, gen, edge, OpcodeGroup{})
+	require.NoError(t, err)
+	require.NotNil(t, captured, "handleInvokeEvent must be called with the invocation event")
+
+	got := captured.GetEvent()
+	require.Equal(t, event.InvokeFnName, got.Name)
+	// Manual wins conv_id; org_id fills from propagated; the null tombstone cuts
+	// the inherited cut_me; the propagated layer is consumed.
+	require.Equal(t, event.Sessions{"conv_id": "manual", "org_id": "42"}, got.Meta.Sessions)
+	require.Nil(t, got.Meta.PropagatedSessions, "propagated layer must be cleared before publish")
+}


### PR DESCRIPTION
## Description

- `step.Invoke` should support session propagation
- We cover the two different entry points for `step.Invoke`
- Somewhat elegantly, this is a two line change and the rest is tests. We built out the foundation earlier.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>