### PR TITLE
feat(api): v2 api cancel run

### DIFF
--- a/pkg/api/v2/apiv2base/errors.go
+++ b/pkg/api/v2/apiv2base/errors.go
@@ -30,6 +30,8 @@ const (
 	// 409 Conflict errors
 	ErrorResourceAlreadyExists = "resource_already_exists"
 	ErrorIdempotencyConflict   = "idempotency_conflict"
+	ErrorRunAlreadyCancelled   = "run_already_cancelled"
+	ErrorRunAlreadyEnded       = "run_already_ended"
 
 	// 429 Too Many Requests errors
 	ErrorRateLimited = "rate_limited"

--- a/pkg/api/v2/endpoints_runs.go
+++ b/pkg/api/v2/endpoints_runs.go
@@ -309,6 +309,45 @@ func listRunsPageOpts(cursor string, requestedLimit int32) (string, int, error) 
 	return parseRunsPageOpts(cursor, requestedLimit, defaultRunsLimit, maxRunsLimit)
 }
 
+func (s *Service) CancelRun(ctx context.Context, req *apiv2.CancelRunRequest) (*apiv2.CancelRunResponse, error) {
+	if req.RunId == "" {
+		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorMissingField, "Run ID is required")
+	}
+
+	if result := s.rateLimiter.CheckRateLimit(ctx, apiv2.V2_CancelRun_FullMethodName); result.Limited {
+		return nil, s.base.NewError(http.StatusTooManyRequests, apiv2base.ErrorRateLimited,
+			"API rate limit exceeded. The request was rejected and no run was cancelled.")
+	}
+
+	if s.runs == nil {
+		return nil, s.base.NewError(http.StatusNotImplemented, apiv2base.ErrorNotImplemented, "Cancel run is not yet implemented")
+	}
+
+	runID, err := ulid.Parse(req.RunId)
+	if err != nil {
+		return nil, s.base.NewError(http.StatusBadRequest, apiv2base.ErrorInvalidFieldFormat, "Run ID must be a valid ULID")
+	}
+
+	if err := s.runs.Cancel(ctx, runID); err != nil {
+		switch {
+		case errors.Is(err, ErrRunNotFound):
+			return nil, s.base.NewError(http.StatusNotFound, apiv2base.ErrorNotFound, "Run not found")
+		case errors.Is(err, ErrRunAlreadyCancelled):
+			return nil, s.base.NewError(http.StatusConflict, apiv2base.ErrorRunAlreadyCancelled, "Run is already cancelled")
+		case errors.Is(err, ErrRunEnded):
+			return nil, s.base.NewError(http.StatusConflict, apiv2base.ErrorRunAlreadyEnded, "Cannot cancel an ended run")
+		}
+		return nil, s.base.NewError(http.StatusInternalServerError, apiv2base.ErrorInternalError, "Unable to cancel run")
+	}
+
+	return &apiv2.CancelRunResponse{
+		Data: &apiv2.CancelRunData{
+			RunId: runID.String(),
+		},
+		Metadata: &apiv2.ResponseMetadata{FetchedAt: timestamppb.Now()},
+	}, nil
+}
+
 func runsPageOpts(cursor string, requestedLimit int32) (string, int, error) {
 	return parseRunsPageOpts(cursor, requestedLimit, defaultEventRunsLimit, maxEventRunsLimit)
 }

--- a/pkg/api/v2/endpoints_runs_test.go
+++ b/pkg/api/v2/endpoints_runs_test.go
@@ -65,6 +65,30 @@ func TestToFunctionRun(t *testing.T) {
 	require.Nil(t, result.Output)
 }
 
+func TestRunCancellability(t *testing.T) {
+	tests := []struct {
+		name   string
+		status enums.RunStatus
+		err    error
+	}{
+		{name: "cancelled", status: enums.RunStatusCancelled, err: ErrRunAlreadyCancelled},
+		{name: "completed", status: enums.RunStatusCompleted, err: ErrRunEnded},
+		{name: "running", status: enums.RunStatusRunning},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := RunCancellability(test.status)
+
+			if test.err == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, test.err)
+		})
+	}
+}
+
 func TestToFunctionRunOmitsOptionalFields(t *testing.T) {
 	runID := ulid.MustParse("01hp1zx8m3ng9vp6qn0xk7j4cy")
 

--- a/pkg/api/v2/errors.go
+++ b/pkg/api/v2/errors.go
@@ -1,6 +1,10 @@
 package apiv2
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/inngest/inngest/pkg/enums"
+)
 
 var (
 	ErrFunctionNotFound      = errors.New("function not found")
@@ -16,3 +20,16 @@ var (
 	// score submission is not enabled for the authenticated account.
 	ErrScoresNotEnabled = errors.New("scores are not enabled")
 )
+
+// RunCancellability returns an error when a run's status prevents cancellation.
+func RunCancellability(status enums.RunStatus) error {
+	//
+	// RunStatusEnded includes cancelled runs, so preserve the more specific error.
+	if status == enums.RunStatusCancelled {
+		return ErrRunAlreadyCancelled
+	}
+	if enums.RunStatusEnded(status) {
+		return ErrRunEnded
+	}
+	return nil
+}

--- a/pkg/api/v2/errors.go
+++ b/pkg/api/v2/errors.go
@@ -9,6 +9,8 @@ var (
 	ErrCronRerunNotSupported = errors.New("cron rerun is not supported")
 	ErrRerunStepNotFound     = errors.New("rerun step not found")
 	ErrRerunStepAmbiguous    = errors.New("rerun step name is ambiguous")
+	ErrRunAlreadyCancelled   = errors.New("run is already cancelled")
+	ErrRunEnded              = errors.New("run has already ended")
 
 	// ErrScoresNotEnabled is returned by ScoreProvider implementations when
 	// score submission is not enabled for the authenticated account.

--- a/pkg/api/v2/http_test.go
+++ b/pkg/api/v2/http_test.go
@@ -352,6 +352,34 @@ func TestHTTPGateway_RerunFromStepErrors(t *testing.T) {
 	}
 }
 
+func TestHTTPGateway_CancelRun(t *testing.T) {
+	ctx := context.Background()
+	runID := ulid.MustParse("01hp1zx8m3ng9vp6qn0xk7j4cy")
+
+	provider := &mockRunProvider{}
+	provider.On("Cancel", mock.Anything, runID).Return(nil).Once()
+
+	handler, err := newTestHTTPHandler(ctx, ServiceOptions{Runs: provider}, HTTPHandlerOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		provider.AssertExpectations(t)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v2/runs/"+runID.String()+"/cancel", nil)
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var response map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &response))
+	data := response["data"].(map[string]any)
+	require.Equal(t, runID.String(), data["runId"])
+}
+
 func TestHTTPGateway_GetApp(t *testing.T) {
 	ctx := context.Background()
 	appID := uuid.MustParse("22222222-2222-2222-2222-222222222222")

--- a/pkg/api/v2/interfaces.go
+++ b/pkg/api/v2/interfaces.go
@@ -129,6 +129,7 @@ type RunProvider interface {
 	GetRun(ctx context.Context, runID ulid.ULID, opts GetRunOpts) (*cqrs.FunctionRun, error)
 	GetRuns(ctx context.Context, opts GetRunsOpts) (*GetRunsResult, error)
 	Rerun(ctx context.Context, runID ulid.ULID, opts RerunOpts) (ulid.ULID, error)
+	Cancel(ctx context.Context, runID ulid.ULID) error
 }
 
 type RerunOpts struct {

--- a/pkg/api/v2/service_test.go
+++ b/pkg/api/v2/service_test.go
@@ -1482,6 +1482,95 @@ func TestService_Rerun(t *testing.T) {
 	})
 }
 
+func TestService_CancelRun(t *testing.T) {
+	runID := ulid.MustParse("01ARZ3NDEKTSV4RRFFQ69G5FAV")
+
+	t.Run("cancels a run", func(t *testing.T) {
+		provider := &mockRunProvider{}
+		provider.On("Cancel", mock.Anything, runID).Return(nil).Once()
+		t.Cleanup(func() {
+			provider.AssertExpectations(t)
+		})
+
+		service := NewService(ServiceOptions{Runs: provider})
+		resp, err := service.CancelRun(context.Background(), &apiv2.CancelRunRequest{
+			RunId: runID.String(),
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, runID.String(), resp.Data.RunId)
+		require.NotNil(t, resp.Metadata.FetchedAt)
+	})
+
+	t.Run("validates run id", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			runID   string
+			message string
+		}{
+			{name: "missing", message: "Run ID is required"},
+			{name: "invalid", runID: "not-a-ulid", message: "Run ID must be a valid ULID"},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				service := NewService(ServiceOptions{Runs: &mockRunProvider{}})
+				resp, err := service.CancelRun(context.Background(), &apiv2.CancelRunRequest{RunId: test.runID})
+
+				require.Nil(t, resp)
+				require.ErrorContains(t, err, test.message)
+			})
+		}
+	})
+
+	t.Run("maps provider errors", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			err     error
+			message string
+		}{
+			{name: "missing run", err: ErrRunNotFound, message: "Run not found"},
+			{name: "already cancelled", err: ErrRunAlreadyCancelled, message: "Run is already cancelled"},
+			{name: "ended run", err: ErrRunEnded, message: "Cannot cancel an ended run"},
+			{name: "internal error", err: errors.New("failed"), message: "Unable to cancel run"},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				provider := &mockRunProvider{}
+				provider.On("Cancel", mock.Anything, runID).Return(test.err).Once()
+				t.Cleanup(func() {
+					provider.AssertExpectations(t)
+				})
+
+				service := NewService(ServiceOptions{Runs: provider})
+				resp, err := service.CancelRun(context.Background(), &apiv2.CancelRunRequest{RunId: runID.String()})
+
+				require.Nil(t, resp)
+				require.ErrorContains(t, err, test.message)
+			})
+		}
+	})
+
+	t.Run("applies rate limit", func(t *testing.T) {
+		rateLimiter := &mockRateLimitProvider{}
+		rateLimiter.On("CheckRateLimit", mock.Anything, apiv2.V2_CancelRun_FullMethodName).
+			Return(RateLimitResult{Limited: true}).Once()
+		t.Cleanup(func() {
+			rateLimiter.AssertExpectations(t)
+		})
+
+		service := NewService(ServiceOptions{
+			Runs:              &mockRunProvider{},
+			RateLimitProvider: rateLimiter,
+		})
+		resp, err := service.CancelRun(context.Background(), &apiv2.CancelRunRequest{RunId: runID.String()})
+
+		require.Nil(t, resp)
+		require.ErrorContains(t, err, "API rate limit exceeded")
+	})
+}
+
 func TestToTraceSpanStatus(t *testing.T) {
 	require.Equal(t, apiv2.TraceSpanStatus_TRACE_SPAN_STATUS_COMPLETED, toTraceSpanStatus(models.RunTraceSpanStatusCompleted))
 	require.Equal(t, apiv2.TraceSpanStatus_TRACE_SPAN_STATUS_FAILED, toTraceSpanStatus(models.RunTraceSpanStatusFailed))

--- a/pkg/api/v2/test_mocks_test.go
+++ b/pkg/api/v2/test_mocks_test.go
@@ -70,6 +70,10 @@ func (m *mockRunProvider) Rerun(ctx context.Context, runID ulid.ULID, opts Rerun
 	return runID, args.Error(1)
 }
 
+func (m *mockRunProvider) Cancel(ctx context.Context, runID ulid.ULID) error {
+	return m.Called(ctx, runID).Error(0)
+}
+
 type mockFunctionTraceReader struct {
 	mock.Mock
 }

--- a/pkg/devserver/run_provider.go
+++ b/pkg/devserver/run_provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/inngest/inngest/pkg/event"
 	"github.com/inngest/inngest/pkg/execution"
 	"github.com/inngest/inngest/pkg/execution/executor"
+	state "github.com/inngest/inngest/pkg/execution/state/v2"
 	"github.com/inngest/inngest/pkg/tracing/meta"
 	"github.com/inngest/inngest/pkg/util"
 	"github.com/oklog/ulid/v2"
@@ -24,7 +25,12 @@ import (
 
 type runProvider struct {
 	data      runProviderDataReader
-	scheduler apiv2.FunctionScheduler
+	scheduler runProviderExecutor
+}
+
+type runProviderExecutor interface {
+	apiv2.FunctionScheduler
+	Cancel(ctx context.Context, id state.ID, req execution.CancelRequest) error
 }
 
 // Run filters use an exclusive upper bound, so this represents no requested bound.
@@ -42,8 +48,34 @@ type runSpanReader interface {
 	GetSpansByRunID(ctx context.Context, runID ulid.ULID) (*cqrs.OtelSpan, error)
 }
 
-func NewRunProvider(data runProviderDataReader, scheduler apiv2.FunctionScheduler) apiv2.RunProvider {
+func NewRunProvider(data runProviderDataReader, scheduler runProviderExecutor) apiv2.RunProvider {
 	return &runProvider{data: data, scheduler: scheduler}
+}
+
+func (p *runProvider) Cancel(ctx context.Context, runID ulid.ULID) error {
+	fnrun, err := p.data.GetFunctionRun(ctx, consts.DevServerAccountID, consts.DevServerEnvID, runID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return apiv2.ErrRunNotFound
+		}
+		return err
+	}
+
+	if fnrun.Status == enums.RunStatusCancelled {
+		return apiv2.ErrRunAlreadyCancelled
+	}
+	if enums.RunStatusEnded(fnrun.Status) {
+		return apiv2.ErrRunEnded
+	}
+
+	return p.scheduler.Cancel(ctx, state.ID{
+		RunID:      runID,
+		FunctionID: fnrun.FunctionID,
+		Tenant: state.Tenant{
+			EnvID:     consts.DevServerEnvID,
+			AccountID: consts.DevServerAccountID,
+		},
+	}, execution.CancelRequest{})
 }
 
 func (p *runProvider) GetRun(ctx context.Context, runID ulid.ULID, _ apiv2.GetRunOpts) (*cqrs.FunctionRun, error) {

--- a/pkg/devserver/run_provider.go
+++ b/pkg/devserver/run_provider.go
@@ -61,11 +61,8 @@ func (p *runProvider) Cancel(ctx context.Context, runID ulid.ULID) error {
 		return err
 	}
 
-	if fnrun.Status == enums.RunStatusCancelled {
-		return apiv2.ErrRunAlreadyCancelled
-	}
-	if enums.RunStatusEnded(fnrun.Status) {
-		return apiv2.ErrRunEnded
+	if err := apiv2.RunCancellability(fnrun.Status); err != nil {
+		return err
 	}
 
 	return p.scheduler.Cancel(ctx, state.ID{

--- a/pkg/devserver/run_provider.go
+++ b/pkg/devserver/run_provider.go
@@ -72,7 +72,9 @@ func (p *runProvider) Cancel(ctx context.Context, runID ulid.ULID) error {
 			EnvID:     consts.DevServerEnvID,
 			AccountID: consts.DevServerAccountID,
 		},
-	}, execution.CancelRequest{})
+	}, execution.CancelRequest{
+		ForceLifecycleHook: true,
+	})
 }
 
 func (p *runProvider) GetRun(ctx context.Context, runID ulid.ULID, _ apiv2.GetRunOpts) (*cqrs.FunctionRun, error) {

--- a/pkg/devserver/run_provider_test.go
+++ b/pkg/devserver/run_provider_test.go
@@ -173,6 +173,19 @@ func TestRunProviderCancel(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("returns not found for a missing run", func(t *testing.T) {
+		scheduler := &stubRunProviderScheduler{}
+		provider := &runProvider{
+			data:      &stubRunProviderDataReader{runErr: sql.ErrNoRows},
+			scheduler: scheduler,
+		}
+
+		err := provider.Cancel(context.Background(), runID)
+
+		require.ErrorIs(t, err, apiv2.ErrRunNotFound)
+		require.Nil(t, scheduler.cancelID)
+	})
 }
 
 func TestScoreMetadataLoaderReconstructsFinalizedRunMetadata(t *testing.T) {

--- a/pkg/devserver/run_provider_test.go
+++ b/pkg/devserver/run_provider_test.go
@@ -124,6 +124,57 @@ func TestRunProviderRerunUsesRunIDWhenOriginalRunIDIsMissing(t *testing.T) {
 	require.Equal(t, runID, *scheduler.req.OriginalRunID)
 }
 
+func TestRunProviderCancel(t *testing.T) {
+	runID := ulid.MustParse("01HR3ZJ4Z4E0MZ6PRP7Z3A4T00")
+	functionID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	t.Run("cancels an active run", func(t *testing.T) {
+		scheduler := &stubRunProviderScheduler{}
+		provider := &runProvider{
+			data: &stubRunProviderDataReader{run: &cqrs.FunctionRun{
+				RunID:      runID,
+				FunctionID: functionID,
+				Status:     enums.RunStatusRunning,
+			}},
+			scheduler: scheduler,
+		}
+
+		err := provider.Cancel(context.Background(), runID)
+
+		require.NoError(t, err)
+		require.NotNil(t, scheduler.cancelID)
+		require.Equal(t, runID, scheduler.cancelID.RunID)
+		require.Equal(t, functionID, scheduler.cancelID.FunctionID)
+		require.Equal(t, consts.DevServerAccountID, scheduler.cancelID.Tenant.AccountID)
+		require.Equal(t, consts.DevServerEnvID, scheduler.cancelID.Tenant.EnvID)
+	})
+
+	t.Run("rejects non-cancellable runs", func(t *testing.T) {
+		tests := []struct {
+			name   string
+			status enums.RunStatus
+			err    error
+		}{
+			{name: "cancelled", status: enums.RunStatusCancelled, err: apiv2.ErrRunAlreadyCancelled},
+			{name: "completed", status: enums.RunStatusCompleted, err: apiv2.ErrRunEnded},
+			{name: "failed", status: enums.RunStatusFailed, err: apiv2.ErrRunEnded},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				provider := &runProvider{
+					data:      &stubRunProviderDataReader{run: &cqrs.FunctionRun{Status: test.status}},
+					scheduler: &stubRunProviderScheduler{},
+				}
+
+				err := provider.Cancel(context.Background(), runID)
+
+				require.ErrorIs(t, err, test.err)
+			})
+		}
+	})
+}
+
 func TestScoreMetadataLoaderReconstructsFinalizedRunMetadata(t *testing.T) {
 	runID := ulid.MustParse("01KVBJWM98JHAJPC9K5EXVAQTQ")
 	eventID := ulid.MustParse("01KVBJWM98JHAJPC9K5EXVAQTR")
@@ -356,8 +407,11 @@ func (s *stubRunProviderDataReader) GetEventByInternalID(ctx context.Context, in
 }
 
 type stubRunProviderScheduler struct {
-	runID ulid.ULID
-	req   *execution.ScheduleRequest
+	runID     ulid.ULID
+	req       *execution.ScheduleRequest
+	cancelID  *sv2.ID
+	cancelReq *execution.CancelRequest
+	cancelErr error
 }
 
 func (s *stubRunProviderScheduler) Schedule(ctx context.Context, req execution.ScheduleRequest) (*ulid.ULID, *sv2.Metadata, error) {
@@ -365,6 +419,12 @@ func (s *stubRunProviderScheduler) Schedule(ctx context.Context, req execution.S
 	return &s.runID, nil, nil
 }
 
+func (s *stubRunProviderScheduler) Cancel(ctx context.Context, id sv2.ID, req execution.CancelRequest) error {
+	s.cancelID = &id
+	s.cancelReq = &req
+	return s.cancelErr
+}
+
 var _ runProviderDataReader = (*stubRunProviderDataReader)(nil)
-var _ apiv2.FunctionScheduler = (*stubRunProviderScheduler)(nil)
+var _ runProviderExecutor = (*stubRunProviderScheduler)(nil)
 var _ event.TrackedEvent = (*cqrs.Event)(nil)

--- a/pkg/devserver/run_provider_test.go
+++ b/pkg/devserver/run_provider_test.go
@@ -147,6 +147,8 @@ func TestRunProviderCancel(t *testing.T) {
 		require.Equal(t, functionID, scheduler.cancelID.FunctionID)
 		require.Equal(t, consts.DevServerAccountID, scheduler.cancelID.Tenant.AccountID)
 		require.Equal(t, consts.DevServerEnvID, scheduler.cancelID.Tenant.EnvID)
+		require.NotNil(t, scheduler.cancelReq)
+		require.True(t, scheduler.cancelReq.ForceLifecycleHook)
 	})
 
 	t.Run("rejects non-cancellable runs", func(t *testing.T) {

--- a/proto/api/v2/service.proto
+++ b/proto/api/v2/service.proto
@@ -1032,6 +1032,25 @@ service V2 {
     };
   }
 
+  rpc CancelRun(CancelRunRequest) returns (CancelRunResponse) {
+    option (google.api.http) = {
+      post: "/runs/{run_id}/cancel"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Cancel function run"
+      tags: "Runs"
+      tags: "Beta"
+      description: "Cancels an in-progress function run"
+      security: {
+        security_requirement: {
+          key: "BearerAuth"
+          value: {}
+        }
+      }
+    };
+  }
+
   rpc GetApp(GetAppRequest) returns (GetAppResponse) {
     option (google.api.http) = {
       get: "/apps/{app_id}"
@@ -3220,4 +3239,22 @@ message ListFunctionRunsResponse {
   repeated FunctionRun data = 1;
   ResponseMetadata metadata = 2;
   Page page = 3;
+}
+
+message CancelRunRequest {
+  string run_id = 1;
+}
+
+message CancelRunResponse {
+  CancelRunData data = 1;
+  ResponseMetadata metadata = 2;
+}
+
+message CancelRunData {
+  string run_id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
+      description: "Cancelled run ID"
+      example: "\"01hp1zx8m3ng9vp6qn0xk7j4cy\""
+    }
+  ];
 }

--- a/proto/gen/api/v2/apiv2connect/service.connect.go
+++ b/proto/gen/api/v2/apiv2connect/service.connect.go
@@ -69,6 +69,8 @@ const (
 	V2GetEventRunsProcedure = "/api.v2.V2/GetEventRuns"
 	// V2RerunProcedure is the fully-qualified name of the V2's Rerun RPC.
 	V2RerunProcedure = "/api.v2.V2/Rerun"
+	// V2CancelRunProcedure is the fully-qualified name of the V2's CancelRun RPC.
+	V2CancelRunProcedure = "/api.v2.V2/CancelRun"
 	// V2GetAppProcedure is the fully-qualified name of the V2's GetApp RPC.
 	V2GetAppProcedure = "/api.v2.V2/GetApp"
 	// V2CreateScoreProcedure is the fully-qualified name of the V2's CreateScore RPC.
@@ -126,6 +128,7 @@ type V2Client interface {
 	ListFunctionRuns(context.Context, *connect.Request[v2.ListFunctionRunsRequest]) (*connect.Response[v2.ListFunctionRunsResponse], error)
 	GetEventRuns(context.Context, *connect.Request[v2.GetEventRunsRequest]) (*connect.Response[v2.GetEventRunsResponse], error)
 	Rerun(context.Context, *connect.Request[v2.RerunRequest]) (*connect.Response[v2.RerunResponse], error)
+	CancelRun(context.Context, *connect.Request[v2.CancelRunRequest]) (*connect.Response[v2.CancelRunResponse], error)
 	GetApp(context.Context, *connect.Request[v2.GetAppRequest]) (*connect.Response[v2.GetAppResponse], error)
 	CreateScore(context.Context, *connect.Request[v2.CreateScoreRequest]) (*connect.Response[v2.CreateScoreResponse], error)
 	SyncApp(context.Context, *connect.Request[v2.SyncAppRequest]) (*connect.Response[v2.SyncAppResponse], error)
@@ -257,6 +260,12 @@ func NewV2Client(httpClient connect.HTTPClient, baseURL string, opts ...connect.
 			connect.WithSchema(v2Methods.ByName("Rerun")),
 			connect.WithClientOptions(opts...),
 		),
+		cancelRun: connect.NewClient[v2.CancelRunRequest, v2.CancelRunResponse](
+			httpClient,
+			baseURL+V2CancelRunProcedure,
+			connect.WithSchema(v2Methods.ByName("CancelRun")),
+			connect.WithClientOptions(opts...),
+		),
 		getApp: connect.NewClient[v2.GetAppRequest, v2.GetAppResponse](
 			httpClient,
 			baseURL+V2GetAppProcedure,
@@ -375,6 +384,7 @@ type v2Client struct {
 	listFunctionRuns         *connect.Client[v2.ListFunctionRunsRequest, v2.ListFunctionRunsResponse]
 	getEventRuns             *connect.Client[v2.GetEventRunsRequest, v2.GetEventRunsResponse]
 	rerun                    *connect.Client[v2.RerunRequest, v2.RerunResponse]
+	cancelRun                *connect.Client[v2.CancelRunRequest, v2.CancelRunResponse]
 	getApp                   *connect.Client[v2.GetAppRequest, v2.GetAppResponse]
 	createScore              *connect.Client[v2.CreateScoreRequest, v2.CreateScoreResponse]
 	syncApp                  *connect.Client[v2.SyncAppRequest, v2.SyncAppResponse]
@@ -476,6 +486,11 @@ func (c *v2Client) GetEventRuns(ctx context.Context, req *connect.Request[v2.Get
 // Rerun calls api.v2.V2.Rerun.
 func (c *v2Client) Rerun(ctx context.Context, req *connect.Request[v2.RerunRequest]) (*connect.Response[v2.RerunResponse], error) {
 	return c.rerun.CallUnary(ctx, req)
+}
+
+// CancelRun calls api.v2.V2.CancelRun.
+func (c *v2Client) CancelRun(ctx context.Context, req *connect.Request[v2.CancelRunRequest]) (*connect.Response[v2.CancelRunResponse], error) {
+	return c.cancelRun.CallUnary(ctx, req)
 }
 
 // GetApp calls api.v2.V2.GetApp.
@@ -580,6 +595,7 @@ type V2Handler interface {
 	ListFunctionRuns(context.Context, *connect.Request[v2.ListFunctionRunsRequest]) (*connect.Response[v2.ListFunctionRunsResponse], error)
 	GetEventRuns(context.Context, *connect.Request[v2.GetEventRunsRequest]) (*connect.Response[v2.GetEventRunsResponse], error)
 	Rerun(context.Context, *connect.Request[v2.RerunRequest]) (*connect.Response[v2.RerunResponse], error)
+	CancelRun(context.Context, *connect.Request[v2.CancelRunRequest]) (*connect.Response[v2.CancelRunResponse], error)
 	GetApp(context.Context, *connect.Request[v2.GetAppRequest]) (*connect.Response[v2.GetAppResponse], error)
 	CreateScore(context.Context, *connect.Request[v2.CreateScoreRequest]) (*connect.Response[v2.CreateScoreResponse], error)
 	SyncApp(context.Context, *connect.Request[v2.SyncAppRequest]) (*connect.Response[v2.SyncAppResponse], error)
@@ -705,6 +721,12 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 		V2RerunProcedure,
 		svc.Rerun,
 		connect.WithSchema(v2Methods.ByName("Rerun")),
+		connect.WithHandlerOptions(opts...),
+	)
+	v2CancelRunHandler := connect.NewUnaryHandler(
+		V2CancelRunProcedure,
+		svc.CancelRun,
+		connect.WithSchema(v2Methods.ByName("CancelRun")),
 		connect.WithHandlerOptions(opts...),
 	)
 	v2GetAppHandler := connect.NewUnaryHandler(
@@ -839,6 +861,8 @@ func NewV2Handler(svc V2Handler, opts ...connect.HandlerOption) (string, http.Ha
 			v2GetEventRunsHandler.ServeHTTP(w, r)
 		case V2RerunProcedure:
 			v2RerunHandler.ServeHTTP(w, r)
+		case V2CancelRunProcedure:
+			v2CancelRunHandler.ServeHTTP(w, r)
 		case V2GetAppProcedure:
 			v2GetAppHandler.ServeHTTP(w, r)
 		case V2CreateScoreProcedure:
@@ -946,6 +970,10 @@ func (UnimplementedV2Handler) GetEventRuns(context.Context, *connect.Request[v2.
 
 func (UnimplementedV2Handler) Rerun(context.Context, *connect.Request[v2.RerunRequest]) (*connect.Response[v2.RerunResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.Rerun is not implemented"))
+}
+
+func (UnimplementedV2Handler) CancelRun(context.Context, *connect.Request[v2.CancelRunRequest]) (*connect.Response[v2.CancelRunResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("api.v2.V2.CancelRun is not implemented"))
 }
 
 func (UnimplementedV2Handler) GetApp(context.Context, *connect.Request[v2.GetAppRequest]) (*connect.Response[v2.GetAppResponse], error) {

--- a/proto/gen/api/v2/service.pb.go
+++ b/proto/gen/api/v2/service.pb.go
@@ -8427,6 +8427,146 @@ func (x *ListFunctionRunsResponse) GetPage() *Page {
 	return nil
 }
 
+type CancelRunRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RunId         string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelRunRequest) Reset() {
+	*x = CancelRunRequest{}
+	mi := &file_api_v2_service_proto_msgTypes[125]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelRunRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelRunRequest) ProtoMessage() {}
+
+func (x *CancelRunRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[125]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelRunRequest.ProtoReflect.Descriptor instead.
+func (*CancelRunRequest) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{125}
+}
+
+func (x *CancelRunRequest) GetRunId() string {
+	if x != nil {
+		return x.RunId
+	}
+	return ""
+}
+
+type CancelRunResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Data          *CancelRunData         `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	Metadata      *ResponseMetadata      `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelRunResponse) Reset() {
+	*x = CancelRunResponse{}
+	mi := &file_api_v2_service_proto_msgTypes[126]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelRunResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelRunResponse) ProtoMessage() {}
+
+func (x *CancelRunResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[126]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelRunResponse.ProtoReflect.Descriptor instead.
+func (*CancelRunResponse) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{126}
+}
+
+func (x *CancelRunResponse) GetData() *CancelRunData {
+	if x != nil {
+		return x.Data
+	}
+	return nil
+}
+
+func (x *CancelRunResponse) GetMetadata() *ResponseMetadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+type CancelRunData struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RunId         string                 `protobuf:"bytes,1,opt,name=run_id,json=runId,proto3" json:"run_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CancelRunData) Reset() {
+	*x = CancelRunData{}
+	mi := &file_api_v2_service_proto_msgTypes[127]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CancelRunData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CancelRunData) ProtoMessage() {}
+
+func (x *CancelRunData) ProtoReflect() protoreflect.Message {
+	mi := &file_api_v2_service_proto_msgTypes[127]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CancelRunData.ProtoReflect.Descriptor instead.
+func (*CancelRunData) Descriptor() ([]byte, []int) {
+	return file_api_v2_service_proto_rawDescGZIP(), []int{127}
+}
+
+func (x *CancelRunData) GetRunId() string {
+	if x != nil {
+		return x.RunId
+	}
+	return ""
+}
+
 var File_api_v2_service_proto protoreflect.FileDescriptor
 
 const file_api_v2_service_proto_rawDesc = "" +
@@ -9163,7 +9303,14 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x18ListFunctionRunsResponse\x12'\n" +
 	"\x04data\x18\x01 \x03(\v2\x13.api.v2.FunctionRunR\x04data\x124\n" +
 	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\x12 \n" +
-	"\x04page\x18\x03 \x01(\v2\f.api.v2.PageR\x04page*\xdf\x01\n" +
+	"\x04page\x18\x03 \x01(\v2\f.api.v2.PageR\x04page\")\n" +
+	"\x10CancelRunRequest\x12\x15\n" +
+	"\x06run_id\x18\x01 \x01(\tR\x05runId\"t\n" +
+	"\x11CancelRunResponse\x12)\n" +
+	"\x04data\x18\x01 \x01(\v2\x15.api.v2.CancelRunDataR\x04data\x124\n" +
+	"\bmetadata\x18\x02 \x01(\v2\x18.api.v2.ResponseMetadataR\bmetadata\"[\n" +
+	"\rCancelRunData\x12J\n" +
+	"\x06run_id\x18\x01 \x01(\tB3\x92A02\x10Cancelled run IDJ\x1c\"01hp1zx8m3ng9vp6qn0xk7j4cy\"R\x05runId*\xdf\x01\n" +
 	"\x11FunctionRunStatus\x12#\n" +
 	"\x1fFUNCTION_RUN_STATUS_UNSPECIFIED\x10\x00\x12\x1e\n" +
 	"\x1aFUNCTION_RUN_STATUS_QUEUED\x10\x01\x12\x1f\n" +
@@ -9229,7 +9376,7 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x14SEVERITY_UNSPECIFIED\x10\x00\x12\t\n" +
 	"\x05ERROR\x10\x01\x12\v\n" +
 	"\aWARNING\x10\x02\x12\b\n" +
-	"\x04INFO\x10\x032\xf7\x83\x01\n" +
+	"\x04INFO\x10\x032\xb7\x85\x01\n" +
 	"\x02V2\x12\xbc\x02\n" +
 	"\x06Health\x12\x15.api.v2.HealthRequest\x1a\x16.api.v2.HealthResponse\"\x82\x02\x92A\xef\x01\n" +
 	"\bInternal\x12\fHealth check\x1a,Returns the health status of the API serviceJR\n" +
@@ -9507,7 +9654,13 @@ const file_api_v2_service_proto_rawDesc = "" +
 	"\x04Beta\x12\x12Rerun function run\x1a@Creates a new run using the original run's triggering event datab\x10\n" +
 	"\x0e\n" +
 	"\n" +
-	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x19:\x01*\"\x14/runs/{run_id}/rerun\x12\xc8\x01\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x19:\x01*\"\x14/runs/{run_id}/rerun\x12\xbd\x01\n" +
+	"\tCancelRun\x12\x18.api.v2.CancelRunRequest\x1a\x19.api.v2.CancelRunResponse\"{\x92AX\n" +
+	"\x04Runs\n" +
+	"\x04Beta\x12\x13Cancel function run\x1a#Cancels an in-progress function runb\x10\n" +
+	"\x0e\n" +
+	"\n" +
+	"BearerAuth\x12\x00\x82\xd3\xe4\x93\x02\x1a:\x01*\"\x15/runs/{run_id}/cancel\x12\xc8\x01\n" +
 	"\x06GetApp\x12\x15.api.v2.GetAppRequest\x1a\x16.api.v2.GetAppResponse\"\x8e\x01\x92Au\n" +
 	"\x04Apps\n" +
 	"\x04Beta\x12\aGet app\x1aLFetches details for a single app, including sync metadata and function countb\x10\n" +
@@ -9756,7 +9909,7 @@ func file_api_v2_service_proto_rawDescGZIP() []byte {
 }
 
 var file_api_v2_service_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
-var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 126)
+var file_api_v2_service_proto_msgTypes = make([]protoimpl.MessageInfo, 129)
 var file_api_v2_service_proto_goTypes = []any{
 	(FunctionRunStatus)(0),                        // 0: api.v2.FunctionRunStatus
 	(TraceSpanStatus)(0),                          // 1: api.v2.TraceSpanStatus
@@ -9894,21 +10047,24 @@ var file_api_v2_service_proto_goTypes = []any{
 	(*ListFunctionRunsRequest)(nil),               // 133: api.v2.ListFunctionRunsRequest
 	(*ListRunsResponse)(nil),                      // 134: api.v2.ListRunsResponse
 	(*ListFunctionRunsResponse)(nil),              // 135: api.v2.ListFunctionRunsResponse
-	nil,                                           // 136: api.v2.TraceSpanMetadata.ValuesEntry
-	(*timestamppb.Timestamp)(nil),                 // 137: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),                       // 138: google.protobuf.Struct
-	(*structpb.ListValue)(nil),                    // 139: google.protobuf.ListValue
-	(*structpb.Value)(nil),                        // 140: google.protobuf.Value
+	(*CancelRunRequest)(nil),                      // 136: api.v2.CancelRunRequest
+	(*CancelRunResponse)(nil),                     // 137: api.v2.CancelRunResponse
+	(*CancelRunData)(nil),                         // 138: api.v2.CancelRunData
+	nil,                                           // 139: api.v2.TraceSpanMetadata.ValuesEntry
+	(*timestamppb.Timestamp)(nil),                 // 140: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),                       // 141: google.protobuf.Struct
+	(*structpb.ListValue)(nil),                    // 142: google.protobuf.ListValue
+	(*structpb.Value)(nil),                        // 143: google.protobuf.Value
 }
 var file_api_v2_service_proto_depIdxs = []int32{
 	14,  // 0: api.v2.HealthResponse.data:type_name -> api.v2.HealthData
 	17,  // 1: api.v2.HealthResponse.metadata:type_name -> api.v2.ResponseMetadata
 	15,  // 2: api.v2.ErrorResponse.errors:type_name -> api.v2.Error
-	137, // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
-	137, // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
+	140, // 3: api.v2.ResponseMetadata.fetched_at:type_name -> google.protobuf.Timestamp
+	140, // 4: api.v2.ResponseMetadata.cached_until:type_name -> google.protobuf.Timestamp
 	18,  // 5: api.v2.ResponseMetadata.time_range:type_name -> api.v2.TimeRange
-	137, // 6: api.v2.TimeRange.from:type_name -> google.protobuf.Timestamp
-	137, // 7: api.v2.TimeRange.until:type_name -> google.protobuf.Timestamp
+	140, // 6: api.v2.TimeRange.from:type_name -> google.protobuf.Timestamp
+	140, // 7: api.v2.TimeRange.until:type_name -> google.protobuf.Timestamp
 	20,  // 8: api.v2.FunctionRef.app:type_name -> api.v2.AppRef
 	3,   // 9: api.v2.FunctionTrigger.type:type_name -> api.v2.FunctionTriggerType
 	4,   // 10: api.v2.FunctionConcurrencyConfiguration.scope:type_name -> api.v2.FunctionConcurrencyScope
@@ -9929,29 +10085,29 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	19,  // 25: api.v2.FunctionRun.function:type_name -> api.v2.FunctionRef
 	20,  // 26: api.v2.FunctionRun.app:type_name -> api.v2.AppRef
 	0,   // 27: api.v2.FunctionRun.status:type_name -> api.v2.FunctionRunStatus
-	137, // 28: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
-	137, // 29: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
-	137, // 30: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
+	140, // 28: api.v2.FunctionRun.queued_at:type_name -> google.protobuf.Timestamp
+	140, // 29: api.v2.FunctionRun.started_at:type_name -> google.protobuf.Timestamp
+	140, // 30: api.v2.FunctionRun.ended_at:type_name -> google.protobuf.Timestamp
 	35,  // 31: api.v2.FunctionRun.trigger:type_name -> api.v2.RunTrigger
-	138, // 32: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
+	141, // 32: api.v2.FunctionRun.output:type_name -> google.protobuf.Struct
 	36,  // 33: api.v2.GetFunctionRunResponse.data:type_name -> api.v2.FunctionRun
 	17,  // 34: api.v2.GetFunctionRunResponse.metadata:type_name -> api.v2.ResponseMetadata
 	36,  // 35: api.v2.GetEventRunsResponse.data:type_name -> api.v2.FunctionRun
 	17,  // 36: api.v2.GetEventRunsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 37: api.v2.GetEventRunsResponse.page:type_name -> api.v2.Page
 	42,  // 38: api.v2.RerunRequest.from_step:type_name -> api.v2.RerunFromStep
-	139, // 39: api.v2.RerunFromStep.input:type_name -> google.protobuf.ListValue
+	142, // 39: api.v2.RerunFromStep.input:type_name -> google.protobuf.ListValue
 	44,  // 40: api.v2.RerunResponse.data:type_name -> api.v2.RerunData
 	17,  // 41: api.v2.RerunResponse.metadata:type_name -> api.v2.ResponseMetadata
-	136, // 42: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
-	137, // 43: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
+	139, // 42: api.v2.TraceSpanMetadata.values:type_name -> api.v2.TraceSpanMetadata.ValuesEntry
+	140, // 43: api.v2.TraceSpanMetadata.updated_at:type_name -> google.protobuf.Timestamp
 	1,   // 44: api.v2.TraceSpan.status:type_name -> api.v2.TraceSpanStatus
 	2,   // 45: api.v2.TraceSpan.step_op:type_name -> api.v2.TraceStepOp
-	137, // 46: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
-	137, // 47: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
-	137, // 48: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
-	138, // 49: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
-	138, // 50: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
+	140, // 46: api.v2.TraceSpan.queued_at:type_name -> google.protobuf.Timestamp
+	140, // 47: api.v2.TraceSpan.started_at:type_name -> google.protobuf.Timestamp
+	140, // 48: api.v2.TraceSpan.ended_at:type_name -> google.protobuf.Timestamp
+	141, // 49: api.v2.TraceSpan.input:type_name -> google.protobuf.Struct
+	141, // 50: api.v2.TraceSpan.output:type_name -> google.protobuf.Struct
 	45,  // 51: api.v2.TraceSpan.metadata:type_name -> api.v2.TraceSpanMetadata
 	46,  // 52: api.v2.TraceSpan.children:type_name -> api.v2.TraceSpan
 	46,  // 53: api.v2.FunctionTrace.root_span:type_name -> api.v2.TraceSpan
@@ -9960,10 +10116,10 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	34,  // 56: api.v2.GetFunctionResponse.data:type_name -> api.v2.Function
 	17,  // 57: api.v2.GetFunctionResponse.metadata:type_name -> api.v2.ResponseMetadata
 	6,   // 58: api.v2.App.method:type_name -> api.v2.AppMethod
-	137, // 59: api.v2.App.created_at:type_name -> google.protobuf.Timestamp
-	137, // 60: api.v2.App.archived_at:type_name -> google.protobuf.Timestamp
+	140, // 59: api.v2.App.created_at:type_name -> google.protobuf.Timestamp
+	140, // 60: api.v2.App.archived_at:type_name -> google.protobuf.Timestamp
 	53,  // 61: api.v2.App.latest_sync:type_name -> api.v2.AppSync
-	137, // 62: api.v2.AppSync.synced_at:type_name -> google.protobuf.Timestamp
+	140, // 62: api.v2.AppSync.synced_at:type_name -> google.protobuf.Timestamp
 	52,  // 63: api.v2.GetAppResponse.data:type_name -> api.v2.App
 	17,  // 64: api.v2.GetAppResponse.metadata:type_name -> api.v2.ResponseMetadata
 	34,  // 65: api.v2.GetFunctionsResponse.data:type_name -> api.v2.Function
@@ -9974,27 +10130,27 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	62,  // 70: api.v2.CreateEnvResponse.data:type_name -> api.v2.Env
 	17,  // 71: api.v2.CreateEnvResponse.metadata:type_name -> api.v2.ResponseMetadata
 	7,   // 72: api.v2.Env.type:type_name -> api.v2.EnvType
-	137, // 73: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
-	137, // 74: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
-	137, // 75: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
+	140, // 73: api.v2.Env.createdAt:type_name -> google.protobuf.Timestamp
+	140, // 74: api.v2.CreateAccountData.createdAt:type_name -> google.protobuf.Timestamp
+	140, // 75: api.v2.CreateAccountData.updatedAt:type_name -> google.protobuf.Timestamp
 	67,  // 76: api.v2.FetchAccountsResponse.data:type_name -> api.v2.Account
 	17,  // 77: api.v2.FetchAccountsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 78: api.v2.FetchAccountsResponse.page:type_name -> api.v2.Page
 	67,  // 79: api.v2.FetchAccountResponse.data:type_name -> api.v2.Account
 	17,  // 80: api.v2.FetchAccountResponse.metadata:type_name -> api.v2.ResponseMetadata
-	137, // 81: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
-	137, // 82: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
+	140, // 81: api.v2.Account.createdAt:type_name -> google.protobuf.Timestamp
+	140, // 82: api.v2.Account.updatedAt:type_name -> google.protobuf.Timestamp
 	71,  // 83: api.v2.FetchAccountEventKeysResponse.data:type_name -> api.v2.EventKey
 	17,  // 84: api.v2.FetchAccountEventKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 85: api.v2.FetchAccountEventKeysResponse.page:type_name -> api.v2.Page
-	137, // 86: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
+	140, // 86: api.v2.EventKey.createdAt:type_name -> google.protobuf.Timestamp
 	62,  // 87: api.v2.FetchAccountEnvsResponse.data:type_name -> api.v2.Env
 	17,  // 88: api.v2.FetchAccountEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 89: api.v2.FetchAccountEnvsResponse.page:type_name -> api.v2.Page
 	76,  // 90: api.v2.FetchAccountSigningKeysResponse.data:type_name -> api.v2.SigningKey
 	17,  // 91: api.v2.FetchAccountSigningKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 92: api.v2.FetchAccountSigningKeysResponse.page:type_name -> api.v2.Page
-	137, // 93: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
+	140, // 93: api.v2.SigningKey.createdAt:type_name -> google.protobuf.Timestamp
 	79,  // 94: api.v2.CreateWebhookRequest.event_filter:type_name -> api.v2.EventFilter
 	82,  // 95: api.v2.CreateWebhookResponse.data:type_name -> api.v2.Webhook
 	17,  // 96: api.v2.CreateWebhookResponse.metadata:type_name -> api.v2.ResponseMetadata
@@ -10003,22 +10159,22 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	17,  // 99: api.v2.ListWebhooksResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 100: api.v2.ListWebhooksResponse.page:type_name -> api.v2.Page
 	79,  // 101: api.v2.Webhook.event_filter:type_name -> api.v2.EventFilter
-	137, // 102: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
-	137, // 103: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
+	140, // 102: api.v2.Webhook.createdAt:type_name -> google.protobuf.Timestamp
+	140, // 103: api.v2.Webhook.updatedAt:type_name -> google.protobuf.Timestamp
 	62,  // 104: api.v2.PatchEnvsResponse.data:type_name -> api.v2.Env
 	17,  // 105: api.v2.PatchEnvsResponse.metadata:type_name -> api.v2.ResponseMetadata
-	138, // 106: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
+	141, // 106: api.v2.InvokeFunctionRequest.data:type_name -> google.protobuf.Struct
 	87,  // 107: api.v2.InvokeFunctionResponse.data:type_name -> api.v2.InvokeFunctionData
 	17,  // 108: api.v2.InvokeFunctionResponse.metadata:type_name -> api.v2.ResponseMetadata
-	137, // 109: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
-	137, // 110: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
-	137, // 111: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
+	140, // 109: api.v2.InvokeFunctionData.queued_at:type_name -> google.protobuf.Timestamp
+	140, // 110: api.v2.InvokeFunctionData.started_at:type_name -> google.protobuf.Timestamp
+	140, // 111: api.v2.InvokeFunctionData.completed_at:type_name -> google.protobuf.Timestamp
 	89,  // 112: api.v2.CreateScoreRequest.scores:type_name -> api.v2.CreateScoreInput
-	140, // 113: api.v2.CreateScoreInput.value:type_name -> google.protobuf.Value
+	143, // 113: api.v2.CreateScoreInput.value:type_name -> google.protobuf.Value
 	90,  // 114: api.v2.CreateScoreInput.experiment:type_name -> api.v2.ScoreExperiment
 	92,  // 115: api.v2.CreateScoreResponse.data:type_name -> api.v2.Score
 	17,  // 116: api.v2.CreateScoreResponse.metadata:type_name -> api.v2.ResponseMetadata
-	140, // 117: api.v2.Score.value:type_name -> google.protobuf.Value
+	143, // 117: api.v2.Score.value:type_name -> google.protobuf.Value
 	90,  // 118: api.v2.Score.experiment:type_name -> api.v2.ScoreExperiment
 	95,  // 119: api.v2.SyncAppResponse.data:type_name -> api.v2.SyncAppData
 	17,  // 120: api.v2.SyncAppResponse.metadata:type_name -> api.v2.ResponseMetadata
@@ -10029,7 +10185,7 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	101, // 125: api.v2.QueryInsightsData.rows:type_name -> api.v2.InsightsRow
 	102, // 126: api.v2.QueryInsightsData.diagnostics:type_name -> api.v2.InsightsDiagnostic
 	9,   // 127: api.v2.InsightsOutputColumn.type:type_name -> api.v2.InsightsOutputColumnType
-	140, // 128: api.v2.InsightsRow.values:type_name -> google.protobuf.Value
+	143, // 128: api.v2.InsightsRow.values:type_name -> google.protobuf.Value
 	10,  // 129: api.v2.InsightsDiagnostic.severity:type_name -> api.v2.InsightsDiagnosticSeverity
 	103, // 130: api.v2.InsightsDiagnostic.position:type_name -> api.v2.InsightsDiagnosticPosition
 	106, // 131: api.v2.ListInsightsTablesResponse.data:type_name -> api.v2.InsightsTable
@@ -10040,126 +10196,130 @@ var file_api_v2_service_proto_depIdxs = []int32{
 	113, // 136: api.v2.ListInsightsEventSchemasResponse.data:type_name -> api.v2.InsightsEventSchema
 	17,  // 137: api.v2.ListInsightsEventSchemasResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 138: api.v2.ListInsightsEventSchemasResponse.page:type_name -> api.v2.Page
-	138, // 139: api.v2.InsightsEventSchema.schema:type_name -> google.protobuf.Struct
-	137, // 140: api.v2.ListExperimentsRequest.from:type_name -> google.protobuf.Timestamp
-	137, // 141: api.v2.ListExperimentsRequest.until:type_name -> google.protobuf.Timestamp
+	141, // 139: api.v2.InsightsEventSchema.schema:type_name -> google.protobuf.Struct
+	140, // 140: api.v2.ListExperimentsRequest.from:type_name -> google.protobuf.Timestamp
+	140, // 141: api.v2.ListExperimentsRequest.until:type_name -> google.protobuf.Timestamp
 	116, // 142: api.v2.ListExperimentsResponse.data:type_name -> api.v2.Experiment
 	17,  // 143: api.v2.ListExperimentsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 144: api.v2.ListExperimentsResponse.page:type_name -> api.v2.Page
 	19,  // 145: api.v2.Experiment.function:type_name -> api.v2.FunctionRef
-	137, // 146: api.v2.Experiment.first_seen:type_name -> google.protobuf.Timestamp
-	137, // 147: api.v2.Experiment.last_seen:type_name -> google.protobuf.Timestamp
-	137, // 148: api.v2.GetExperimentRequest.from:type_name -> google.protobuf.Timestamp
-	137, // 149: api.v2.GetExperimentRequest.until:type_name -> google.protobuf.Timestamp
+	140, // 146: api.v2.Experiment.first_seen:type_name -> google.protobuf.Timestamp
+	140, // 147: api.v2.Experiment.last_seen:type_name -> google.protobuf.Timestamp
+	140, // 148: api.v2.GetExperimentRequest.from:type_name -> google.protobuf.Timestamp
+	140, // 149: api.v2.GetExperimentRequest.until:type_name -> google.protobuf.Timestamp
 	119, // 150: api.v2.GetExperimentResponse.data:type_name -> api.v2.ExperimentDetail
 	17,  // 151: api.v2.GetExperimentResponse.metadata:type_name -> api.v2.ResponseMetadata
 	120, // 152: api.v2.ExperimentDetail.variants:type_name -> api.v2.ExperimentVariantMetrics
 	122, // 153: api.v2.ExperimentDetail.variant_weights:type_name -> api.v2.ExperimentVariantWeight
-	137, // 154: api.v2.ExperimentDetail.first_seen:type_name -> google.protobuf.Timestamp
-	137, // 155: api.v2.ExperimentDetail.last_seen:type_name -> google.protobuf.Timestamp
+	140, // 154: api.v2.ExperimentDetail.first_seen:type_name -> google.protobuf.Timestamp
+	140, // 155: api.v2.ExperimentDetail.last_seen:type_name -> google.protobuf.Timestamp
 	121, // 156: api.v2.ExperimentVariantMetrics.metrics:type_name -> api.v2.ExperimentVariantMetric
 	125, // 157: api.v2.ListSessionKeysResponse.data:type_name -> api.v2.SessionKey
 	17,  // 158: api.v2.ListSessionKeysResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 159: api.v2.ListSessionKeysResponse.page:type_name -> api.v2.Page
-	137, // 160: api.v2.SessionKey.created_at:type_name -> google.protobuf.Timestamp
-	137, // 161: api.v2.ListSessionsRequest.from:type_name -> google.protobuf.Timestamp
-	137, // 162: api.v2.ListSessionsRequest.until:type_name -> google.protobuf.Timestamp
+	140, // 160: api.v2.SessionKey.created_at:type_name -> google.protobuf.Timestamp
+	140, // 161: api.v2.ListSessionsRequest.from:type_name -> google.protobuf.Timestamp
+	140, // 162: api.v2.ListSessionsRequest.until:type_name -> google.protobuf.Timestamp
 	128, // 163: api.v2.ListSessionsResponse.data:type_name -> api.v2.SessionGroup
 	17,  // 164: api.v2.ListSessionsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 165: api.v2.ListSessionsResponse.page:type_name -> api.v2.Page
-	137, // 166: api.v2.SessionGroup.last_active_at:type_name -> google.protobuf.Timestamp
+	140, // 166: api.v2.SessionGroup.last_active_at:type_name -> google.protobuf.Timestamp
 	19,  // 167: api.v2.SessionGroup.functions:type_name -> api.v2.FunctionRef
-	137, // 168: api.v2.ListSessionRunsRequest.from:type_name -> google.protobuf.Timestamp
-	137, // 169: api.v2.ListSessionRunsRequest.until:type_name -> google.protobuf.Timestamp
+	140, // 168: api.v2.ListSessionRunsRequest.from:type_name -> google.protobuf.Timestamp
+	140, // 169: api.v2.ListSessionRunsRequest.until:type_name -> google.protobuf.Timestamp
 	131, // 170: api.v2.ListSessionRunsResponse.data:type_name -> api.v2.SessionRun
 	17,  // 171: api.v2.ListSessionRunsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 172: api.v2.ListSessionRunsResponse.page:type_name -> api.v2.Page
 	19,  // 173: api.v2.SessionRun.function:type_name -> api.v2.FunctionRef
 	0,   // 174: api.v2.SessionRun.status:type_name -> api.v2.FunctionRunStatus
-	137, // 175: api.v2.SessionRun.queued_at:type_name -> google.protobuf.Timestamp
-	137, // 176: api.v2.SessionRun.started_at:type_name -> google.protobuf.Timestamp
-	137, // 177: api.v2.SessionRun.ended_at:type_name -> google.protobuf.Timestamp
-	137, // 178: api.v2.ListRunsRequest.from:type_name -> google.protobuf.Timestamp
-	137, // 179: api.v2.ListRunsRequest.until:type_name -> google.protobuf.Timestamp
-	137, // 180: api.v2.ListFunctionRunsRequest.from:type_name -> google.protobuf.Timestamp
-	137, // 181: api.v2.ListFunctionRunsRequest.until:type_name -> google.protobuf.Timestamp
+	140, // 175: api.v2.SessionRun.queued_at:type_name -> google.protobuf.Timestamp
+	140, // 176: api.v2.SessionRun.started_at:type_name -> google.protobuf.Timestamp
+	140, // 177: api.v2.SessionRun.ended_at:type_name -> google.protobuf.Timestamp
+	140, // 178: api.v2.ListRunsRequest.from:type_name -> google.protobuf.Timestamp
+	140, // 179: api.v2.ListRunsRequest.until:type_name -> google.protobuf.Timestamp
+	140, // 180: api.v2.ListFunctionRunsRequest.from:type_name -> google.protobuf.Timestamp
+	140, // 181: api.v2.ListFunctionRunsRequest.until:type_name -> google.protobuf.Timestamp
 	36,  // 182: api.v2.ListRunsResponse.data:type_name -> api.v2.FunctionRun
 	17,  // 183: api.v2.ListRunsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 184: api.v2.ListRunsResponse.page:type_name -> api.v2.Page
 	36,  // 185: api.v2.ListFunctionRunsResponse.data:type_name -> api.v2.FunctionRun
 	17,  // 186: api.v2.ListFunctionRunsResponse.metadata:type_name -> api.v2.ResponseMetadata
 	68,  // 187: api.v2.ListFunctionRunsResponse.page:type_name -> api.v2.Page
-	11,  // 188: api.v2.V2.Health:input_type -> api.v2.HealthRequest
-	11,  // 189: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
-	58,  // 190: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
-	60,  // 191: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
-	64,  // 192: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
-	12,  // 193: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
-	72,  // 194: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
-	69,  // 195: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
-	74,  // 196: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
-	77,  // 197: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
-	80,  // 198: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
-	83,  // 199: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
-	37,  // 200: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
-	132, // 201: api.v2.V2.ListRuns:input_type -> api.v2.ListRunsRequest
-	133, // 202: api.v2.V2.ListFunctionRuns:input_type -> api.v2.ListFunctionRunsRequest
-	39,  // 203: api.v2.V2.GetEventRuns:input_type -> api.v2.GetEventRunsRequest
-	41,  // 204: api.v2.V2.Rerun:input_type -> api.v2.RerunRequest
-	54,  // 205: api.v2.V2.GetApp:input_type -> api.v2.GetAppRequest
-	88,  // 206: api.v2.V2.CreateScore:input_type -> api.v2.CreateScoreRequest
-	93,  // 207: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
-	48,  // 208: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
-	50,  // 209: api.v2.V2.GetFunction:input_type -> api.v2.GetFunctionRequest
-	56,  // 210: api.v2.V2.GetFunctions:input_type -> api.v2.GetFunctionsRequest
-	85,  // 211: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
-	104, // 212: api.v2.V2.ListInsightsTables:input_type -> api.v2.ListInsightsTablesRequest
-	111, // 213: api.v2.V2.ListInsightsEventSchemas:input_type -> api.v2.ListInsightsEventSchemasRequest
-	108, // 214: api.v2.V2.QueryInsightsPrompt:input_type -> api.v2.QueryInsightsPromptRequest
-	97,  // 215: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
-	114, // 216: api.v2.V2.ListExperiments:input_type -> api.v2.ListExperimentsRequest
-	117, // 217: api.v2.V2.GetExperiment:input_type -> api.v2.GetExperimentRequest
-	123, // 218: api.v2.V2.ListSessionKeys:input_type -> api.v2.ListSessionKeysRequest
-	126, // 219: api.v2.V2.ListSessions:input_type -> api.v2.ListSessionsRequest
-	129, // 220: api.v2.V2.ListSessionRuns:input_type -> api.v2.ListSessionRunsRequest
-	13,  // 221: api.v2.V2.Health:output_type -> api.v2.HealthResponse
-	16,  // 222: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
-	59,  // 223: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
-	61,  // 224: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
-	65,  // 225: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
-	66,  // 226: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
-	73,  // 227: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
-	70,  // 228: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
-	75,  // 229: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
-	78,  // 230: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
-	81,  // 231: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
-	84,  // 232: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
-	38,  // 233: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
-	134, // 234: api.v2.V2.ListRuns:output_type -> api.v2.ListRunsResponse
-	135, // 235: api.v2.V2.ListFunctionRuns:output_type -> api.v2.ListFunctionRunsResponse
-	40,  // 236: api.v2.V2.GetEventRuns:output_type -> api.v2.GetEventRunsResponse
-	43,  // 237: api.v2.V2.Rerun:output_type -> api.v2.RerunResponse
-	55,  // 238: api.v2.V2.GetApp:output_type -> api.v2.GetAppResponse
-	91,  // 239: api.v2.V2.CreateScore:output_type -> api.v2.CreateScoreResponse
-	94,  // 240: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
-	49,  // 241: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
-	51,  // 242: api.v2.V2.GetFunction:output_type -> api.v2.GetFunctionResponse
-	57,  // 243: api.v2.V2.GetFunctions:output_type -> api.v2.GetFunctionsResponse
-	86,  // 244: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
-	105, // 245: api.v2.V2.ListInsightsTables:output_type -> api.v2.ListInsightsTablesResponse
-	112, // 246: api.v2.V2.ListInsightsEventSchemas:output_type -> api.v2.ListInsightsEventSchemasResponse
-	109, // 247: api.v2.V2.QueryInsightsPrompt:output_type -> api.v2.QueryInsightsPromptResponse
-	98,  // 248: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
-	115, // 249: api.v2.V2.ListExperiments:output_type -> api.v2.ListExperimentsResponse
-	118, // 250: api.v2.V2.GetExperiment:output_type -> api.v2.GetExperimentResponse
-	124, // 251: api.v2.V2.ListSessionKeys:output_type -> api.v2.ListSessionKeysResponse
-	127, // 252: api.v2.V2.ListSessions:output_type -> api.v2.ListSessionsResponse
-	130, // 253: api.v2.V2.ListSessionRuns:output_type -> api.v2.ListSessionRunsResponse
-	221, // [221:254] is the sub-list for method output_type
-	188, // [188:221] is the sub-list for method input_type
-	188, // [188:188] is the sub-list for extension type_name
-	188, // [188:188] is the sub-list for extension extendee
-	0,   // [0:188] is the sub-list for field type_name
+	138, // 188: api.v2.CancelRunResponse.data:type_name -> api.v2.CancelRunData
+	17,  // 189: api.v2.CancelRunResponse.metadata:type_name -> api.v2.ResponseMetadata
+	11,  // 190: api.v2.V2.Health:input_type -> api.v2.HealthRequest
+	11,  // 191: api.v2.V2._SchemaOnly:input_type -> api.v2.HealthRequest
+	58,  // 192: api.v2.V2.CreatePartnerAccount:input_type -> api.v2.CreateAccountRequest
+	60,  // 193: api.v2.V2.CreateEnv:input_type -> api.v2.CreateEnvRequest
+	64,  // 194: api.v2.V2.FetchPartnerAccounts:input_type -> api.v2.FetchAccountsRequest
+	12,  // 195: api.v2.V2.FetchAccount:input_type -> api.v2.FetchAccountRequest
+	72,  // 196: api.v2.V2.FetchAccountEnvs:input_type -> api.v2.FetchAccountEnvsRequest
+	69,  // 197: api.v2.V2.FetchAccountEventKeys:input_type -> api.v2.FetchAccountEventKeysRequest
+	74,  // 198: api.v2.V2.FetchAccountSigningKeys:input_type -> api.v2.FetchAccountSigningKeysRequest
+	77,  // 199: api.v2.V2.CreateWebhook:input_type -> api.v2.CreateWebhookRequest
+	80,  // 200: api.v2.V2.ListWebhooks:input_type -> api.v2.ListWebhooksRequest
+	83,  // 201: api.v2.V2.PatchEnv:input_type -> api.v2.PatchEnvRequest
+	37,  // 202: api.v2.V2.GetFunctionRun:input_type -> api.v2.GetFunctionRunRequest
+	132, // 203: api.v2.V2.ListRuns:input_type -> api.v2.ListRunsRequest
+	133, // 204: api.v2.V2.ListFunctionRuns:input_type -> api.v2.ListFunctionRunsRequest
+	39,  // 205: api.v2.V2.GetEventRuns:input_type -> api.v2.GetEventRunsRequest
+	41,  // 206: api.v2.V2.Rerun:input_type -> api.v2.RerunRequest
+	136, // 207: api.v2.V2.CancelRun:input_type -> api.v2.CancelRunRequest
+	54,  // 208: api.v2.V2.GetApp:input_type -> api.v2.GetAppRequest
+	88,  // 209: api.v2.V2.CreateScore:input_type -> api.v2.CreateScoreRequest
+	93,  // 210: api.v2.V2.SyncApp:input_type -> api.v2.SyncAppRequest
+	48,  // 211: api.v2.V2.GetFunctionTrace:input_type -> api.v2.GetFunctionTraceRequest
+	50,  // 212: api.v2.V2.GetFunction:input_type -> api.v2.GetFunctionRequest
+	56,  // 213: api.v2.V2.GetFunctions:input_type -> api.v2.GetFunctionsRequest
+	85,  // 214: api.v2.V2.InvokeFunction:input_type -> api.v2.InvokeFunctionRequest
+	104, // 215: api.v2.V2.ListInsightsTables:input_type -> api.v2.ListInsightsTablesRequest
+	111, // 216: api.v2.V2.ListInsightsEventSchemas:input_type -> api.v2.ListInsightsEventSchemasRequest
+	108, // 217: api.v2.V2.QueryInsightsPrompt:input_type -> api.v2.QueryInsightsPromptRequest
+	97,  // 218: api.v2.V2.QueryInsights:input_type -> api.v2.QueryInsightsRequest
+	114, // 219: api.v2.V2.ListExperiments:input_type -> api.v2.ListExperimentsRequest
+	117, // 220: api.v2.V2.GetExperiment:input_type -> api.v2.GetExperimentRequest
+	123, // 221: api.v2.V2.ListSessionKeys:input_type -> api.v2.ListSessionKeysRequest
+	126, // 222: api.v2.V2.ListSessions:input_type -> api.v2.ListSessionsRequest
+	129, // 223: api.v2.V2.ListSessionRuns:input_type -> api.v2.ListSessionRunsRequest
+	13,  // 224: api.v2.V2.Health:output_type -> api.v2.HealthResponse
+	16,  // 225: api.v2.V2._SchemaOnly:output_type -> api.v2.ErrorResponse
+	59,  // 226: api.v2.V2.CreatePartnerAccount:output_type -> api.v2.CreateAccountResponse
+	61,  // 227: api.v2.V2.CreateEnv:output_type -> api.v2.CreateEnvResponse
+	65,  // 228: api.v2.V2.FetchPartnerAccounts:output_type -> api.v2.FetchAccountsResponse
+	66,  // 229: api.v2.V2.FetchAccount:output_type -> api.v2.FetchAccountResponse
+	73,  // 230: api.v2.V2.FetchAccountEnvs:output_type -> api.v2.FetchAccountEnvsResponse
+	70,  // 231: api.v2.V2.FetchAccountEventKeys:output_type -> api.v2.FetchAccountEventKeysResponse
+	75,  // 232: api.v2.V2.FetchAccountSigningKeys:output_type -> api.v2.FetchAccountSigningKeysResponse
+	78,  // 233: api.v2.V2.CreateWebhook:output_type -> api.v2.CreateWebhookResponse
+	81,  // 234: api.v2.V2.ListWebhooks:output_type -> api.v2.ListWebhooksResponse
+	84,  // 235: api.v2.V2.PatchEnv:output_type -> api.v2.PatchEnvsResponse
+	38,  // 236: api.v2.V2.GetFunctionRun:output_type -> api.v2.GetFunctionRunResponse
+	134, // 237: api.v2.V2.ListRuns:output_type -> api.v2.ListRunsResponse
+	135, // 238: api.v2.V2.ListFunctionRuns:output_type -> api.v2.ListFunctionRunsResponse
+	40,  // 239: api.v2.V2.GetEventRuns:output_type -> api.v2.GetEventRunsResponse
+	43,  // 240: api.v2.V2.Rerun:output_type -> api.v2.RerunResponse
+	137, // 241: api.v2.V2.CancelRun:output_type -> api.v2.CancelRunResponse
+	55,  // 242: api.v2.V2.GetApp:output_type -> api.v2.GetAppResponse
+	91,  // 243: api.v2.V2.CreateScore:output_type -> api.v2.CreateScoreResponse
+	94,  // 244: api.v2.V2.SyncApp:output_type -> api.v2.SyncAppResponse
+	49,  // 245: api.v2.V2.GetFunctionTrace:output_type -> api.v2.GetFunctionTraceResponse
+	51,  // 246: api.v2.V2.GetFunction:output_type -> api.v2.GetFunctionResponse
+	57,  // 247: api.v2.V2.GetFunctions:output_type -> api.v2.GetFunctionsResponse
+	86,  // 248: api.v2.V2.InvokeFunction:output_type -> api.v2.InvokeFunctionResponse
+	105, // 249: api.v2.V2.ListInsightsTables:output_type -> api.v2.ListInsightsTablesResponse
+	112, // 250: api.v2.V2.ListInsightsEventSchemas:output_type -> api.v2.ListInsightsEventSchemasResponse
+	109, // 251: api.v2.V2.QueryInsightsPrompt:output_type -> api.v2.QueryInsightsPromptResponse
+	98,  // 252: api.v2.V2.QueryInsights:output_type -> api.v2.QueryInsightsResponse
+	115, // 253: api.v2.V2.ListExperiments:output_type -> api.v2.ListExperimentsResponse
+	118, // 254: api.v2.V2.GetExperiment:output_type -> api.v2.GetExperimentResponse
+	124, // 255: api.v2.V2.ListSessionKeys:output_type -> api.v2.ListSessionKeysResponse
+	127, // 256: api.v2.V2.ListSessions:output_type -> api.v2.ListSessionsResponse
+	130, // 257: api.v2.V2.ListSessionRuns:output_type -> api.v2.ListSessionRunsResponse
+	224, // [224:258] is the sub-list for method output_type
+	190, // [190:224] is the sub-list for method input_type
+	190, // [190:190] is the sub-list for extension type_name
+	190, // [190:190] is the sub-list for extension extendee
+	0,   // [0:190] is the sub-list for field type_name
 }
 
 func init() { file_api_v2_service_proto_init() }
@@ -10223,7 +10383,7 @@ func file_api_v2_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_v2_service_proto_rawDesc), len(file_api_v2_service_proto_rawDesc)),
 			NumEnums:      11,
-			NumMessages:   126,
+			NumMessages:   129,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/proto/gen/api/v2/service.pb.gw.go
+++ b/proto/gen/api/v2/service.pb.gw.go
@@ -654,6 +654,51 @@ func local_request_V2_Rerun_0(ctx context.Context, marshaler runtime.Marshaler, 
 	return msg, metadata, err
 }
 
+func request_V2_CancelRun_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CancelRunRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	val, ok := pathParams["run_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "run_id")
+	}
+	protoReq.RunId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "run_id", err)
+	}
+	msg, err := client.CancelRun(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_V2_CancelRun_0(ctx context.Context, marshaler runtime.Marshaler, server V2Server, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CancelRunRequest
+		metadata runtime.ServerMetadata
+		err      error
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	val, ok := pathParams["run_id"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "run_id")
+	}
+	protoReq.RunId, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "run_id", err)
+	}
+	msg, err := server.CancelRun(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_V2_GetApp_0(ctx context.Context, marshaler runtime.Marshaler, client V2Client, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq GetAppRequest
@@ -1807,6 +1852,26 @@ func RegisterV2HandlerServer(ctx context.Context, mux *runtime.ServeMux, server 
 		}
 		forward_V2_Rerun_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_V2_CancelRun_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/api.v2.V2/CancelRun", runtime.WithHTTPPathPattern("/runs/{run_id}/cancel"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_V2_CancelRun_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_CancelRun_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_V2_GetApp_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2476,6 +2541,23 @@ func RegisterV2HandlerClient(ctx context.Context, mux *runtime.ServeMux, client 
 		}
 		forward_V2_Rerun_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_V2_CancelRun_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/api.v2.V2/CancelRun", runtime.WithHTTPPathPattern("/runs/{run_id}/cancel"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_V2_CancelRun_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_V2_CancelRun_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_V2_GetApp_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2786,6 +2868,7 @@ var (
 	pattern_V2_ListFunctionRuns_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2, 1, 0, 4, 1, 5, 3, 2, 4}, []string{"apps", "app_id", "functions", "function_id", "runs"}, ""))
 	pattern_V2_GetEventRuns_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"events", "event_id", "runs"}, ""))
 	pattern_V2_Rerun_0                    = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"runs", "run_id", "rerun"}, ""))
+	pattern_V2_CancelRun_0                = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"runs", "run_id", "cancel"}, ""))
 	pattern_V2_GetApp_0                   = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1}, []string{"apps", "app_id"}, ""))
 	pattern_V2_CreateScore_0              = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"runs", "run_id", "scores"}, ""))
 	pattern_V2_SyncApp_0                  = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 1, 0, 4, 1, 5, 1, 2, 2}, []string{"apps", "app_id", "syncs"}, ""))
@@ -2823,6 +2906,7 @@ var (
 	forward_V2_ListFunctionRuns_0         = runtime.ForwardResponseMessage
 	forward_V2_GetEventRuns_0             = runtime.ForwardResponseMessage
 	forward_V2_Rerun_0                    = runtime.ForwardResponseMessage
+	forward_V2_CancelRun_0                = runtime.ForwardResponseMessage
 	forward_V2_GetApp_0                   = runtime.ForwardResponseMessage
 	forward_V2_CreateScore_0              = runtime.ForwardResponseMessage
 	forward_V2_SyncApp_0                  = runtime.ForwardResponseMessage

--- a/proto/gen/api/v2/service_grpc.pb.go
+++ b/proto/gen/api/v2/service_grpc.pb.go
@@ -36,6 +36,7 @@ const (
 	V2_ListFunctionRuns_FullMethodName         = "/api.v2.V2/ListFunctionRuns"
 	V2_GetEventRuns_FullMethodName             = "/api.v2.V2/GetEventRuns"
 	V2_Rerun_FullMethodName                    = "/api.v2.V2/Rerun"
+	V2_CancelRun_FullMethodName                = "/api.v2.V2/CancelRun"
 	V2_GetApp_FullMethodName                   = "/api.v2.V2/GetApp"
 	V2_CreateScore_FullMethodName              = "/api.v2.V2/CreateScore"
 	V2_SyncApp_FullMethodName                  = "/api.v2.V2/SyncApp"
@@ -78,6 +79,7 @@ type V2Client interface {
 	ListFunctionRuns(ctx context.Context, in *ListFunctionRunsRequest, opts ...grpc.CallOption) (*ListFunctionRunsResponse, error)
 	GetEventRuns(ctx context.Context, in *GetEventRunsRequest, opts ...grpc.CallOption) (*GetEventRunsResponse, error)
 	Rerun(ctx context.Context, in *RerunRequest, opts ...grpc.CallOption) (*RerunResponse, error)
+	CancelRun(ctx context.Context, in *CancelRunRequest, opts ...grpc.CallOption) (*CancelRunResponse, error)
 	GetApp(ctx context.Context, in *GetAppRequest, opts ...grpc.CallOption) (*GetAppResponse, error)
 	CreateScore(ctx context.Context, in *CreateScoreRequest, opts ...grpc.CallOption) (*CreateScoreResponse, error)
 	SyncApp(ctx context.Context, in *SyncAppRequest, opts ...grpc.CallOption) (*SyncAppResponse, error)
@@ -274,6 +276,16 @@ func (c *v2Client) Rerun(ctx context.Context, in *RerunRequest, opts ...grpc.Cal
 	return out, nil
 }
 
+func (c *v2Client) CancelRun(ctx context.Context, in *CancelRunRequest, opts ...grpc.CallOption) (*CancelRunResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CancelRunResponse)
+	err := c.cc.Invoke(ctx, V2_CancelRun_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *v2Client) GetApp(ctx context.Context, in *GetAppRequest, opts ...grpc.CallOption) (*GetAppResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(GetAppResponse)
@@ -458,6 +470,7 @@ type V2Server interface {
 	ListFunctionRuns(context.Context, *ListFunctionRunsRequest) (*ListFunctionRunsResponse, error)
 	GetEventRuns(context.Context, *GetEventRunsRequest) (*GetEventRunsResponse, error)
 	Rerun(context.Context, *RerunRequest) (*RerunResponse, error)
+	CancelRun(context.Context, *CancelRunRequest) (*CancelRunResponse, error)
 	GetApp(context.Context, *GetAppRequest) (*GetAppResponse, error)
 	CreateScore(context.Context, *CreateScoreRequest) (*CreateScoreResponse, error)
 	SyncApp(context.Context, *SyncAppRequest) (*SyncAppResponse, error)
@@ -534,6 +547,9 @@ func (UnimplementedV2Server) GetEventRuns(context.Context, *GetEventRunsRequest)
 }
 func (UnimplementedV2Server) Rerun(context.Context, *RerunRequest) (*RerunResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Rerun not implemented")
+}
+func (UnimplementedV2Server) CancelRun(context.Context, *CancelRunRequest) (*CancelRunResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CancelRun not implemented")
 }
 func (UnimplementedV2Server) GetApp(context.Context, *GetAppRequest) (*GetAppResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetApp not implemented")
@@ -910,6 +926,24 @@ func _V2_Rerun_Handler(srv interface{}, ctx context.Context, dec func(interface{
 	return interceptor(ctx, in, info, handler)
 }
 
+func _V2_CancelRun_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CancelRunRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(V2Server).CancelRun(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: V2_CancelRun_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(V2Server).CancelRun(ctx, req.(*CancelRunRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _V2_GetApp_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(GetAppRequest)
 	if err := dec(in); err != nil {
@@ -1272,6 +1306,10 @@ var V2_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Rerun",
 			Handler:    _V2_Rerun_Handler,
+		},
+		{
+			MethodName: "CancelRun",
+			Handler:    _V2_CancelRun_Handler,
 		},
 		{
 			MethodName: "GetApp",


### PR DESCRIPTION
## Summary

Adds `POST /api/v2/runs/{run_id}/cancel` to the v2 rest api. 

cloud pr [here](https://github.com/inngest/monorepo/pull/7876).

# Release Notes

Adds cancel run to the  v2 rest api and cli.

`POST /api/v2/runs/{run_id}/cancel`

`inngest api POST /api/v2/runs/{run_id}/cancel`

## Migration note

None