### PR TITLE
refactor(queue): route processor dequeue and requeue through queue interfaces

### DIFF
--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -461,7 +461,7 @@ func (e *executor) doRemoveRunJobs(ctx context.Context, l logger.Logger, shard q
 			continue
 		}
 
-		err := shard.Dequeue(ctx, *qi)
+		err := e.queue.Dequeue(ctx, shard.Name(), *qi)
 		if err != nil && !errors.Is(err, queue.ErrQueueItemNotFound) {
 			l.Error(
 				"error dequeueing run job",

--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -422,7 +422,7 @@ func (e *executor) finalizeRemoveJobs(ctx context.Context, opts execution.Finali
 
 // doRemoveRunJobs performs a single pass of removing all queue items for the given run.
 // Returns the number of items successfully dequeued.
-func (e *executor) doRemoveRunJobs(ctx context.Context, l logger.Logger, shard queue.ShardOperations, opts execution.FinalizeOpts) int {
+func (e *executor) doRemoveRunJobs(ctx context.Context, l logger.Logger, shard queue.QueueShard, opts execution.FinalizeOpts) int {
 	// We may be cancelling an in-progress run.  If that's the case, we want to delete any
 	// outstanding jobs from the queue, if possible.
 	//

--- a/pkg/execution/executor/finalize_test.go
+++ b/pkg/execution/executor/finalize_test.go
@@ -99,6 +99,15 @@ func (s *racingQueueShard) ShardAssignmentConfig() queue.ShardAssignmentConfig {
 	return queue.ShardAssignmentConfig{}
 }
 
+type racingQueue struct {
+	queue.Queue
+	shard *racingQueueShard
+}
+
+func (q *racingQueue) Dequeue(ctx context.Context, shardName string, i queue.QueueItem, opts ...queue.DequeueOptionFn) error {
+	return q.shard.Dequeue(ctx, i, opts...)
+}
+
 func TestFinalizeRemoveJobs_CatchesPostSweepEnqueue(t *testing.T) {
 	// Setup: an initial item exists in the queue. After the first sweep removes
 	// it, a new item is injected (simulating a concurrent enqueue during the
@@ -118,6 +127,7 @@ func TestFinalizeRemoveJobs_CatchesPostSweepEnqueue(t *testing.T) {
 	e := &executor{
 		log:    logger.VoidLogger(),
 		shards: &racingShardRegistry{shard: queueShard},
+		queue:  &racingQueue{shard: queueShard},
 	}
 
 	runID := ulid.Make()
@@ -211,6 +221,7 @@ func TestFinalizeRemoveJobs_CatchesMultipleRaceWindows(t *testing.T) {
 	e := &executor{
 		log:    logger.VoidLogger(),
 		shards: &racingShardRegistry{shard: queueShard},
+		queue:  &racingQueue{shard: queueShard},
 	}
 
 	opts := execution.FinalizeOpts{
@@ -256,6 +267,7 @@ func TestFinalizeRemoveJobs_BoundsAtMaxSweeps(t *testing.T) {
 	e := &executor{
 		log:    logger.VoidLogger(),
 		shards: &racingShardRegistry{shard: queueShard},
+		queue:  &racingQueue{shard: queueShard},
 	}
 
 	opts := execution.FinalizeOpts{
@@ -297,6 +309,7 @@ func TestFinalizeRemoveJobs_NoItemsNoSweep(t *testing.T) {
 	e := &executor{
 		log:    logger.VoidLogger(),
 		shards: &racingShardRegistry{shard: queueShard},
+		queue:  &racingQueue{shard: queueShard},
 	}
 
 	opts := execution.FinalizeOpts{

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -793,7 +793,7 @@ func (s *svc) handleEagerCancelBacklog(ctx context.Context, c cqrs.Cancellation)
 		}
 
 		// dequeue the item
-		if err := shard.Dequeue(ctx, *qi); err != nil {
+		if err := s.queue.Dequeue(ctx, shard.Name(), *qi); err != nil {
 			return err
 		}
 	}

--- a/pkg/execution/executor/service.go
+++ b/pkg/execution/executor/service.go
@@ -1208,7 +1208,7 @@ func (s *svc) handleJobPromote(ctx context.Context, item queue.Item) error {
 	// Grab the score, which already handles promotion by fudigng the time to
 	// be that of the actual run ID, prioritizing older runs.
 	nextTime := time.UnixMilli(qi.Score(time.Now()))
-	err = shard.Requeue(ctx, *qi, nextTime)
+	err = s.queue.Requeue(ctx, shard.Name(), *qi, nextTime)
 	if err != nil && !errors.Is(err, queue.ErrQueueItemNotFound) {
 		return fmt.Errorf("could not requeue job with promoted time: %w", err)
 	}

--- a/pkg/execution/queue/backlog_normalization.go
+++ b/pkg/execution/queue/backlog_normalization.go
@@ -326,7 +326,7 @@ func (q *queueProcessor) NormalizeItem(
 
 	cleanupItem := func() {
 		// If event for item cannot be found, remove it from the backlog
-		err := shard.Dequeue(ctx, item)
+		err := q.Dequeue(ctx, shard.Name(), item)
 		if err != nil {
 			log.Warn("could not dequeue queue item with missing event", "err", err)
 		}

--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -500,7 +500,7 @@ func (q *queueProcessor) ProcessItem(
 
 		// Dequeue this entirely, as this permanently failed.
 		// XXX: Increase permanently failed counter here.
-		if err := shard.Dequeue(context.WithoutCancel(ctx), itemWithCurrentLease(qi)); err != nil {
+		if err := q.Dequeue(context.WithoutCancel(ctx), shard.Name(), itemWithCurrentLease(qi)); err != nil {
 			if err == ErrQueueItemNotFound {
 				// Safe. The executor may have dequeued.
 				return nil
@@ -515,7 +515,7 @@ func (q *queueProcessor) ProcessItem(
 		}
 	case <-jobCtx.Done():
 		stopItemLeaseRenewal()
-		if err := shard.Dequeue(context.WithoutCancel(ctx), itemWithCurrentLease(qi)); err != nil {
+		if err := q.Dequeue(context.WithoutCancel(ctx), shard.Name(), itemWithCurrentLease(qi)); err != nil {
 			if err == ErrQueueItemNotFound {
 				// Safe. The executor may have dequeued.
 				return nil

--- a/pkg/execution/queue/process.go
+++ b/pkg/execution/queue/process.go
@@ -482,7 +482,7 @@ func (q *queueProcessor) ProcessItem(
 
 			qi.AtMS = at.UnixMilli()
 			requeueItem := itemWithCurrentLease(qi)
-			if err := shard.Requeue(context.WithoutCancel(ctx), requeueItem, at); err != nil {
+			if err := q.Requeue(context.WithoutCancel(ctx), shard.Name(), requeueItem, at); err != nil {
 				if err == ErrQueueItemNotFound {
 					// Safe. The executor may have dequeued.
 					return nil


### PR DESCRIPTION
## Summary
- route executor and queue-processor dequeue paths through the queue consumer interface
- route executor and queue-processor requeue paths through the queue producer interface
- leave migrator-specific direct shard calls unchanged

## Testing
n/a