### PR TITLE
internal: instrument when runs are started with manual and propagated sessions

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -18,6 +18,7 @@ import (
 	"github.com/inngest/inngest/pkg/headers"
 	"github.com/inngest/inngest/pkg/logger"
 	"github.com/inngest/inngest/pkg/publicerr"
+	"github.com/inngest/inngest/pkg/telemetry/metrics"
 	itrace "github.com/inngest/inngest/pkg/telemetry/trace"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
@@ -259,8 +260,12 @@ func (a API) ReceiveEvent(w http.ResponseWriter, r *http.Request) {
 				evt.User = map[string]any{}
 			}
 
-			// Merge propagated sessions into the manual layer before validation
+			// Merge propagated sessions into the manual layer before validation,
+			// recording which layers were present for adoption metrics (read
+			// before the merge nils the propagated layer).
+			manualSessions, propagatedSessions := len(evt.Meta.Sessions) > 0, len(evt.Meta.PropagatedSessions) > 0
 			evt.Meta.ResolveSessions()
+			metrics.IncrEventSessionsResolvedCounter(ctx, "ingest", manualSessions, propagatedSessions, metrics.CounterOpt{PkgName: metricsPkgName})
 
 			if err := evt.Validate(ctx); err != nil {
 				return err
@@ -347,8 +352,11 @@ func (a API) Invoke(w http.ResponseWriter, r *http.Request) {
 	}
 	evt := event.NewInvocationEvent(newInvOpts)
 
-	// Merge the two session layers before the event is handled
+	// Merge the two session layers before the event is handled, recording which
+	// layers were present for adoption metrics (read before the merge).
+	manualSessions, propagatedSessions := len(evt.Event.Meta.Sessions) > 0, len(evt.Event.Meta.PropagatedSessions) > 0
 	evt.Event.Meta.ResolveSessions()
+	metrics.IncrEventSessionsResolvedCounter(r.Context(), "invoke_http", manualSessions, propagatedSessions, metrics.CounterOpt{PkgName: metricsPkgName})
 
 	// Validate after the merge
 	if err := evt.Event.Validate(r.Context()); err != nil {

--- a/pkg/event/sessions.go
+++ b/pkg/event/sessions.go
@@ -128,6 +128,9 @@ func parseManualSessions(raw json.RawMessage) (sessions Sessions, tombstones []s
 // lexicographic key order (matching run-level session truncation) for
 // deterministic output. PropagatedSessions is cleared so it never persists.
 //
+// Callers that want adoption metrics read len(Sessions)/len(PropagatedSessions)
+// before calling this (the propagated layer is nil afterwards).
+//
 // Called at API ingest before Event.Validate: each layer may independently be
 // up to MaxEventSessions, so the pre-merge union can exceed the cap —
 // validating the raw fields would falsely reject; validating the merged result

--- a/pkg/execution/executor/executor.go
+++ b/pkg/execution/executor/executor.go
@@ -5216,8 +5216,11 @@ func (e *executor) handleGeneratorInvokeFunction(ctx context.Context, runCtx exe
 	})
 
 	// Merge the invocation payload's two session layers before the event is
-	// published.
+	// published, recording which layers were present for adoption metrics (read
+	// before the merge nils the propagated layer).
+	manualSessions, propagatedSessions := len(evt.Event.Meta.Sessions) > 0, len(evt.Event.Meta.PropagatedSessions) > 0
 	evt.Event.Meta.ResolveSessions()
+	metrics.IncrEventSessionsResolvedCounter(ctx, "invoke_executor", manualSessions, propagatedSessions, metrics.CounterOpt{PkgName: pkgName})
 
 	// Validate the sessions after the merge
 	if err := evt.Event.Meta.Sessions.Validate(); err != nil {

--- a/pkg/telemetry/metrics/sessions.go
+++ b/pkg/telemetry/metrics/sessions.go
@@ -1,0 +1,30 @@
+package metrics
+
+import "context"
+
+// IncrEventSessionsResolvedCounter records one session resolution (one call to
+// event.EventMeta.ResolveSessions), tagged by source and by whether each layer
+// was present. It is emitted on every resolve — including the neither-present
+// case — so the {manual=false,propagated=false} series is a self-contained
+// denominator: manual-set rate = sum(manual=true)/sum(all), propagated rate =
+// sum(propagated=true)/sum(all).
+//
+// The server merge is the single vantage point that sees both layers for every
+// spawn primitive and SDK version. Tags are low-cardinality only (source, two
+// bools); per-account/per-session detail belongs in the analytics plane
+// (Insights runs.sessions), never here.
+func IncrEventSessionsResolvedCounter(ctx context.Context, source string, manual, propagated bool, opts CounterOpt) {
+	if opts.Tags == nil {
+		opts.Tags = map[string]any{}
+	}
+	opts.Tags["source"] = source
+	opts.Tags["manual"] = manual
+	opts.Tags["propagated"] = propagated
+
+	RecordCounterMetric(ctx, 1, CounterOpt{
+		PkgName:     opts.PkgName,
+		MetricName:  "event_sessions_resolved_total",
+		Description: "Total event session resolutions, tagged by source and which layers were present",
+		Tags:        opts.Tags,
+	})
+}


### PR DESCRIPTION
## Description

- We would like to know when sessions are manually added vs propagated
- Add a metric, and also note which path we're taking: step.invoke, step.sendEvent, ...
- We don't record the number of sessions: that's accessible through ClickHoues
- EXE-2037

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>