### PR TITLE
feat(cli): add API command usage metrics

### DIFF
--- a/cmd/apiv2cli/cmd.go
+++ b/cmd/apiv2cli/cmd.go
@@ -22,6 +22,7 @@ import (
 	openapiv2 "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options"
 	localconfig "github.com/inngest/inngest/cmd/internal/config"
 	"github.com/inngest/inngest/pkg/api"
+	"github.com/inngest/inngest/pkg/api/tel"
 	apiv2 "github.com/inngest/inngest/proto/gen/api/v2"
 	"github.com/urfave/cli/v3"
 	"google.golang.org/genproto/googleapis/api/annotations"
@@ -96,12 +97,29 @@ func endpointCommands() []*cli.Command {
 			Flags:       endpointFlags(ep),
 			Arguments:   endpointArguments(ep),
 			Action: func(ctx context.Context, cmd *cli.Command) error {
+				tel.SendCommandExecutedEvent(ctx, "inngest api", commandTelemetryContext(cmd, ep))
 				return callEndpoint(ctx, cmd, ep)
 			},
 		})
 	}
 
 	return cmds
+}
+
+func commandTelemetryContext(cmd *cli.Command, ep endpoint) map[string]any {
+	flags := []string{}
+	for _, flag := range append(commonFlags(), endpointFlags(ep)...) {
+		name := flag.Names()[0]
+		if cmd.IsSet(name) {
+			flags = append(flags, name)
+		}
+	}
+	slices.Sort(flags)
+
+	return map[string]any{
+		"endpoint": ep.name,
+		"flags":    flags,
+	}
 }
 
 func commonFlags() []cli.Flag {

--- a/cmd/apiv2cli/cmd_test.go
+++ b/cmd/apiv2cli/cmd_test.go
@@ -94,6 +94,47 @@ func TestEndpointCommandsIncludeOperationAndInheritedFlagHelp(t *testing.T) {
 	require.Contains(t, invoke.Description, "/v2")
 }
 
+func TestCommandTelemetryContextIncludesEndpointAndFlagNamesOnly(t *testing.T) {
+	var getEventRuns endpoint
+	for _, ep := range discoverEndpoints() {
+		if ep.name == "get-event-runs" {
+			getEventRuns = ep
+			break
+		}
+	}
+	require.NotEmpty(t, getEventRuns.name)
+
+	var endpointCommand *cli.Command
+	for _, command := range endpointCommands() {
+		if command.Name == getEventRuns.name {
+			endpointCommand = command
+			break
+		}
+	}
+	require.NotNil(t, endpointCommand)
+
+	app := Command()
+	endpointCommand.Action = func(_ context.Context, cmd *cli.Command) error {
+		require.Equal(t, map[string]any{
+			"endpoint": "get-event-runs",
+			"flags":    []string{"include-output", "limit", "prod"},
+		}, commandTelemetryContext(cmd, getEventRuns))
+		return nil
+	}
+	app.Commands = []*cli.Command{endpointCommand}
+
+	err := app.Run(context.Background(), []string{
+		"api",
+		"--prod",
+		"get-event-runs",
+		"01KTCTWSZJEKAFEDA4F9GYHFQW",
+		"--include-output",
+		"--limit", "5",
+	})
+
+	require.NoError(t, err)
+}
+
 func TestEndpointFlagsUseProtoFieldDescriptions(t *testing.T) {
 	var invoke endpoint
 	for _, ep := range discoverEndpoints() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,7 +75,9 @@ func execute() {
 				}
 			}
 
-			tel.SendCmdExecutedEvent(ctx, cmd)
+			if cmd.Args().Len() == 0 || cmd.Args().Get(0) != "api" {
+				tel.SendCmdExecutedEvent(ctx, cmd)
+			}
 
 			// Best-effort background refresh of the cached "latest version"
 			// record. Dedup'd by the cache TTL, so cheap on every invocation.

--- a/pkg/api/tel/tel.go
+++ b/pkg/api/tel/tel.go
@@ -103,8 +103,15 @@ func SendEvent(ctx context.Context, name string, m *Metadata) {
 }
 
 func SendCmdExecutedEvent(ctx context.Context, cmd *cli.Command) {
+	SendCommandExecutedEvent(ctx, FormatCommand(cmd), nil)
+}
+
+func SendCommandExecutedEvent(ctx context.Context, command string, eventContext map[string]any) {
 	m := NewMetadata(ctx)
-	m.Cmd = FormatCommand(cmd)
+	m.Cmd = command
+	if eventContext != nil {
+		m.Context = eventContext
+	}
 	name := CommandExecutedEventName
 	if isCI() {
 		name = CICommandExecutedEventName


### PR DESCRIPTION
## Description

Add additional args to to telemetry so we can know which api cli commands are being run. Note we collect only flag names and never values. 

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
