### PR TITLE
fix(ui): Remove bulk cancellation feature flag

### DIFF
--- a/ui/apps/dashboard/src/components/Functions/ActionMenu.tsx
+++ b/ui/apps/dashboard/src/components/Functions/ActionMenu.tsx
@@ -15,8 +15,6 @@ import {
   RiPlayCircleLine,
 } from '@remixicon/react';
 
-import { useBooleanFlag } from '../FeatureFlags/hooks';
-
 export type FunctionActions = {
   showCancel: () => void;
   showInvoke: () => void;
@@ -34,8 +32,6 @@ export const ActionsMenu = ({
   archived,
   paused,
 }: FunctionActions) => {
-  const { value: cancelEnabled } = useBooleanFlag('bulk-cancellation-ui');
-
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -90,12 +86,10 @@ export const ActionsMenu = ({
             Replay
           </DropdownMenuItem>
         </OptionalTooltip>
-        {cancelEnabled && (
-          <DropdownMenuItem onSelect={showCancel} className="text-error">
-            <RiCloseCircleLine className="h-4 w-4" />
-            Bulk Cancel
-          </DropdownMenuItem>
-        )}
+        <DropdownMenuItem onSelect={showCancel} className="text-error">
+          <RiCloseCircleLine className="h-4 w-4" />
+          Bulk Cancel
+        </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/ui/apps/dashboard/src/routes/_authed/env/$envSlug/functions/$slug/route.tsx
+++ b/ui/apps/dashboard/src/routes/_authed/env/$envSlug/functions/$slug/route.tsx
@@ -9,7 +9,6 @@ import { useFunction } from '@/queries/functions';
 import { Header } from '@inngest/components/Header/Header';
 import { InvokeModal } from '@inngest/components/InvokeButton';
 import { Pill } from '@inngest/components/Pill';
-import { useBooleanFlag } from '@/components/FeatureFlags/hooks';
 import { RiPauseCircleLine } from '@remixicon/react';
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { useCallback, useState } from 'react';
@@ -34,8 +33,6 @@ function FunctionComponent() {
   const [{ data, error, fetching }] = useFunction({ functionSlug });
   const [, invokeFunction] = useMutation(InvokeFunctionOnboardingDocument);
   const env = useEnvironment();
-
-  const isBulkCancellationEnabled = useBooleanFlag('bulk-cancellation-ui');
 
   const fn = data?.workspace.workflow;
   const { isArchived = false, isPaused } = fn ?? {};
@@ -154,17 +151,12 @@ function FunctionComponent() {
               slug,
             )}/replays`,
           },
-          ...(isBulkCancellationEnabled.isReady &&
-          isBulkCancellationEnabled.value
-            ? [
-                {
-                  children: 'Cancellations',
-                  href: `/env/${envSlug}/functions/${encodeURIComponent(
-                    slug,
-                  )}/cancellations`,
-                },
-              ]
-            : []),
+          {
+            children: 'Cancellations',
+            href: `/env/${envSlug}/functions/${encodeURIComponent(
+              slug,
+            )}/cancellations`,
+          },
         ]}
       />
       <Outlet />


### PR DESCRIPTION
## Description

<!-- What changed? Include screenshots if you modify the UI. -->

This removes the `bulk-cancellation-ui` feature flag that is enabled unconditionally anyways. This flag was causing issues if LD is unreachable for any reason.

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*
