### PR TITLE
internal: Add persistence support for sessions with defer

### DIFF
--- a/pkg/execution/defers/defers.go
+++ b/pkg/execution/defers/defers.go
@@ -85,6 +85,7 @@ func SaveFromOp(
 			HashedID:       op.ID,
 			ScheduleStatus: enums.DeferStatusAfterRun,
 			Input:          opts.Input,
+			Meta:           opts.Meta,
 		})
 		switch {
 		case errors.Is(saveErr, statev2.ErrDeferLimitExceeded):

--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -312,12 +312,17 @@ func (e *executor) buildDeferEvents(
 	now := e.now()
 	var events []event.Event
 
+	l := logger.StdlibLogger(ctx).With(
+		"run_id", util.SanitizeLogField(opts.Metadata.ID.RunID.String()),
+	)
+
 	for _, d := range defers {
+		l := l.With("fn_slug", d.FnSlug, "hashed_id", d.HashedID)
+
 		if err := d.Validate(); err != nil {
-			logger.StdlibLogger(ctx).Error(
+			l.Error(
 				"invalid defer",
 				"error", err,
-				"run_id", opts.Metadata.ID.RunID,
 			)
 			metrics.IncrDefersFinalizedCounter(ctx, "invalid", metrics.CounterOpt{PkgName: pkgName})
 			continue
@@ -331,11 +336,9 @@ func (e *executor) buildDeferEvents(
 
 		eventID, err := event.DeferEventID(opts.Metadata.ID.RunID, d.HashedID)
 		if err != nil {
-			logger.StdlibLogger(ctx).Error(
+			l.Error(
 				"failed to create defer event ID",
 				"error", err,
-				"hashed_id", d.HashedID,
-				"run_id", opts.Metadata.ID.RunID,
 			)
 			metrics.IncrDefersFinalizedCounter(ctx, "invalid", metrics.CounterOpt{PkgName: pkgName})
 			continue
@@ -344,10 +347,9 @@ func (e *executor) buildDeferEvents(
 		data := map[string]any{}
 		if len(d.Input) > 0 {
 			if err := json.Unmarshal(d.Input, &data); err != nil {
-				logger.StdlibLogger(ctx).Error(
+				l.Error(
 					"deferred input is not a JSON object",
 					"error", err,
-					"run_id", opts.Metadata.ID.RunID,
 				)
 				metrics.IncrDefersFinalizedCounter(ctx, "invalid", metrics.CounterOpt{PkgName: pkgName})
 				continue
@@ -368,10 +370,9 @@ func (e *executor) buildDeferEvents(
 			ParentRunID:     opts.Metadata.ID.RunID,
 		}
 		if err := deferredMeta.Validate(); err != nil {
-			logger.StdlibLogger(ctx).Error(
+			l.Error(
 				"invalid deferred event metadata",
 				"error", err,
-				"run_id", opts.Metadata.ID.RunID,
 			)
 			metrics.IncrDefersFinalizedCounter(ctx, "invalid", metrics.CounterOpt{PkgName: pkgName})
 			continue
@@ -382,10 +383,9 @@ func (e *executor) buildDeferEvents(
 		var evtMeta event.EventMeta
 		if len(d.Meta) > 0 {
 			if err := json.Unmarshal(d.Meta, &evtMeta); err != nil {
-				logger.StdlibLogger(ctx).Error(
+				l.Error(
 					"deferred meta is not valid JSON",
 					"error", err,
-					"run_id", opts.Metadata.ID.RunID,
 				)
 				metrics.IncrDefersFinalizedCounter(ctx, "invalid", metrics.CounterOpt{PkgName: pkgName})
 				continue
@@ -408,10 +408,9 @@ func (e *executor) buildDeferEvents(
 		//
 		// Failures are unexpected as we also validate sessions SDK side.
 		if err := evtMeta.Sessions.Validate(); err != nil {
-			logger.StdlibLogger(ctx).Error(
+			l.Error(
 				"deferred sessions failed validation after merge",
 				"error", err,
-				"run_id", opts.Metadata.ID.RunID,
 			)
 			metrics.IncrDefersFinalizedCounter(ctx, "invalid", metrics.CounterOpt{PkgName: pkgName})
 			continue

--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -317,7 +317,10 @@ func (e *executor) buildDeferEvents(
 	)
 
 	for _, d := range defers {
-		l := l.With("fn_slug", d.FnSlug, "hashed_id", d.HashedID)
+		l := l.With(
+			"fn_slug", util.SanitizeLogField(d.FnSlug),
+			"hashed_id", d.HashedID,
+		)
 
 		if err := d.Validate(); err != nil {
 			l.Error(

--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -401,6 +401,22 @@ func (e *executor) buildDeferEvents(
 			metrics.CounterOpt{PkgName: pkgName},
 		)
 
+		// Validate the sessions after the merge.
+		//
+		// Failure to validate will drop the event, rather than truncate sessions or
+		// fail the parent run.
+		//
+		// Failures are unexpected as we also validate sessions SDK side.
+		if err := evtMeta.Sessions.Validate(); err != nil {
+			logger.StdlibLogger(ctx).Error(
+				"deferred sessions failed validation after merge",
+				"error", err,
+				"run_id", opts.Metadata.ID.RunID,
+			)
+			metrics.IncrDefersFinalizedCounter(ctx, "invalid", metrics.CounterOpt{PkgName: pkgName})
+			continue
+		}
+
 		events = append(events, event.Event{
 			ID:        eventID.String(),
 			Name:      consts.FnDeferScheduleName,

--- a/pkg/execution/executor/finalize.go
+++ b/pkg/execution/executor/finalize.go
@@ -378,11 +378,35 @@ func (e *executor) buildDeferEvents(
 		}
 		data[consts.InngestEventDataPrefix] = deferredMeta
 
+		// Resolve the defer's session layers onto the deferred event.
+		var evtMeta event.EventMeta
+		if len(d.Meta) > 0 {
+			if err := json.Unmarshal(d.Meta, &evtMeta); err != nil {
+				logger.StdlibLogger(ctx).Error(
+					"deferred meta is not valid JSON",
+					"error", err,
+					"run_id", opts.Metadata.ID.RunID,
+				)
+				metrics.IncrDefersFinalizedCounter(ctx, "invalid", metrics.CounterOpt{PkgName: pkgName})
+				continue
+			}
+		}
+		sessionsMetrics := evtMeta.ResolveSessions()
+		metrics.IncrEventSessionsResolvedCounter(
+			ctx,
+			"defer",
+			sessionsMetrics.Manual,
+			sessionsMetrics.Propagated,
+			sessionsMetrics.Nulling,
+			metrics.CounterOpt{PkgName: pkgName},
+		)
+
 		events = append(events, event.Event{
 			ID:        eventID.String(),
 			Name:      consts.FnDeferScheduleName,
 			Timestamp: now.UnixMilli(),
 			Data:      data,
+			Meta:      evtMeta,
 		})
 		metrics.IncrDefersFinalizedCounter(ctx, "after_run", metrics.CounterOpt{PkgName: pkgName})
 	}

--- a/pkg/execution/state/opcode.go
+++ b/pkg/execution/state/opcode.go
@@ -424,6 +424,12 @@ func (g GeneratorOpcode) DeferAddOpts() (*DeferAddOpts, error) {
 type DeferAddOpts struct {
 	FnSlug string          `json:"fn_slug"`
 	Input  json.RawMessage `json:"input,omitempty"`
+
+	// Meta carries control metadata (SDK-stamped session layers) for the
+	// deferred run. Opaque here: persisted with the defer and resolved onto
+	// the inngest/deferred.schedule event at finalize. Distinct from Input,
+	// which is the user payload.
+	Meta json.RawMessage `json:"meta,omitempty"`
 }
 
 func (d *DeferAddOpts) Validate() error {

--- a/pkg/execution/state/redis_state/defer_test.go
+++ b/pkg/execution/state/redis_state/defer_test.go
@@ -95,6 +95,29 @@ func TestSaveDefer(t *testing.T) {
 		require.Equal(t, d, defers[d.HashedID])
 	})
 
+	t.Run("meta round-trips through save and load", func(t *testing.T) {
+		v2svc, id := newDeferTestRunService(t)
+
+		d := statev2.Defer{
+			FnSlug:         "onDefer-score",
+			HashedID:       "hash-step-1",
+			ScheduleStatus: enums.DeferStatusAfterRun,
+			Input:          json.RawMessage(`{"user_id":"u_123"}`),
+			Meta:           json.RawMessage(`{"propagated_sessions":{"tenant":"acme"}}`),
+		}
+		require.NoError(t, v2svc.SaveDefer(ctx, id, d))
+
+		// Meta must survive the full-view load...
+		defers, err := v2svc.LoadDefers(ctx, id)
+		require.NoError(t, err)
+		require.JSONEq(t, string(d.Meta), string(defers[d.HashedID].Meta))
+
+		// ...and the Input-less metadata view, which is what finalize reads.
+		metas, err := v2svc.LoadDefersMeta(ctx, id)
+		require.NoError(t, err)
+		require.JSONEq(t, string(d.Meta), string(metas[d.HashedID].Meta))
+	})
+
 	t.Run("idempotent", func(t *testing.T) {
 		v2svc, id := newDeferTestRunService(t)
 

--- a/pkg/execution/state/redis_state/lua/saveDefer.lua
+++ b/pkg/execution/state/redis_state/lua/saveDefer.lua
@@ -12,7 +12,9 @@ KEYS[1] - defers meta hash key
 KEYS[2] - defers input hash key
 KEYS[3] - run metadata hash key
 ARGV[1] - hashedID
-ARGV[2] - meta JSON ({FnSlug, HashedID, ScheduleStatus} only)
+ARGV[2] - meta JSON ({FnSlug, HashedID, ScheduleStatus, Meta}), where Meta is
+          an opaque control-metadata blob (e.g. session layers). Meta is not
+          counted toward the aggregate-input cap below.
 ARGV[3] - raw Input bytes (HSET verbatim, never decoded by Lua). Empty for rejected defers.
 ARGV[4] - integer max defers per run
 ARGV[5] - integer max defer input aggregate size (bytes)

--- a/pkg/execution/state/redis_state/redis_state.go
+++ b/pkg/execution/state/redis_state/redis_state.go
@@ -564,6 +564,17 @@ type deferMeta struct {
 	// this field as a number via cjson. Conversion to the typed enum happens
 	// at the LoadDefers/SaveDefer boundary.
 	ScheduleStatus int
+
+	// Meta is an opaque JSON blob (SDK-stamped session layers) that must
+	// survive to the parent run's finalize.
+	//
+	// It is exempt from the cjson-safe rule above: a schedulable (AfterRun)
+	// defer's meta is only ever written verbatim by saveDefer.lua (HSET, no
+	// cjson), and buildDeferEvents reads only AfterRun defers. cjson round-trips
+	// the blob solely on terminal transitions (setDeferStatus.lua Aborted,
+	// saveDefer.lua aggregate-cap Rejected), whose Meta is never read. omitempty
+	// keeps the stored payload byte-identical for defers without sessions.
+	Meta json.RawMessage `json:",omitempty"`
 }
 
 // LoadDefersMeta returns each defer's metadata without loading Input. Use this
@@ -633,6 +644,7 @@ func (m shardedMgr) LoadDefersMeta(
 			FnSlug:         meta.FnSlug,
 			HashedID:       meta.HashedID,
 			ScheduleStatus: enums.DeferStatus(meta.ScheduleStatus),
+			Meta:           meta.Meta,
 		}
 	}
 	return metas, nil
@@ -677,6 +689,7 @@ func (m shardedMgr) LoadDefers(
 			FnSlug:         meta.FnSlug,
 			HashedID:       meta.HashedID,
 			ScheduleStatus: meta.ScheduleStatus,
+			Meta:           meta.Meta,
 		}
 		if raw, ok := inputs[hashedID]; ok && len(raw) > 0 {
 			d.Input = json.RawMessage(raw)
@@ -938,6 +951,7 @@ func (m shardedMgr) SaveDefer(ctx context.Context, accountId uuid.UUID, fnID uui
 		FnSlug:         d.FnSlug,
 		HashedID:       d.HashedID,
 		ScheduleStatus: int(d.ScheduleStatus),
+		Meta:           d.Meta,
 	})
 	if err != nil {
 		return err

--- a/pkg/execution/state/v2/state.go
+++ b/pkg/execution/state/v2/state.go
@@ -35,6 +35,12 @@ type DeferMeta struct {
 	FnSlug         string
 	HashedID       string
 	ScheduleStatus enums.DeferStatus
+
+	// Meta carries control metadata (e.g. propagated session layers) from
+	// defer call-time to the parent run's finalize, where buildDeferEvents
+	// stamps it onto the inngest/deferred.schedule event. Opaque JSON blob;
+	// kept separate from Input (the user payload). Keep in sync with Defer.
+	Meta json.RawMessage
 }
 
 type Defer struct {
@@ -58,6 +64,13 @@ type Defer struct {
 
 	// Data passed to the defer
 	Input json.RawMessage
+
+	// Meta carries control metadata (e.g. propagated session layers) from
+	// defer call-time to the parent run's finalize, where buildDeferEvents
+	// stamps it onto the inngest/deferred.schedule event. Opaque JSON blob;
+	// kept separate from Input (the user payload) so it is not size-capped
+	// or nulled on abort. Keep in sync with DeferMeta.
+	Meta json.RawMessage
 }
 
 func (d Defer) Validate() error {

--- a/proto/gen/state/v2/state.pb.go
+++ b/proto/gen/state/v2/state.pb.go
@@ -1547,6 +1547,7 @@ type Defer struct {
 	HashedId       string                 `protobuf:"bytes,2,opt,name=hashed_id,json=hashedId,proto3" json:"hashed_id,omitempty"`
 	ScheduleStatus DeferStatus            `protobuf:"varint,3,opt,name=schedule_status,json=scheduleStatus,proto3,enum=state.v2.DeferStatus" json:"schedule_status,omitempty"`
 	Input          []byte                 `protobuf:"bytes,4,opt,name=input,proto3" json:"input,omitempty"`
+	Meta           []byte                 `protobuf:"bytes,5,opt,name=meta,proto3" json:"meta,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -1609,11 +1610,19 @@ func (x *Defer) GetInput() []byte {
 	return nil
 }
 
+func (x *Defer) GetMeta() []byte {
+	if x != nil {
+		return x.Meta
+	}
+	return nil
+}
+
 type DeferMeta struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	FnSlug         string                 `protobuf:"bytes,1,opt,name=fn_slug,json=fnSlug,proto3" json:"fn_slug,omitempty"`
 	HashedId       string                 `protobuf:"bytes,2,opt,name=hashed_id,json=hashedId,proto3" json:"hashed_id,omitempty"`
 	ScheduleStatus DeferStatus            `protobuf:"varint,3,opt,name=schedule_status,json=scheduleStatus,proto3,enum=state.v2.DeferStatus" json:"schedule_status,omitempty"`
+	Meta           []byte                 `protobuf:"bytes,4,opt,name=meta,proto3" json:"meta,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -1667,6 +1676,13 @@ func (x *DeferMeta) GetScheduleStatus() DeferStatus {
 		return x.ScheduleStatus
 	}
 	return DeferStatus_DEFER_STATUS_UNKNOWN
+}
+
+func (x *DeferMeta) GetMeta() []byte {
+	if x != nil {
+		return x.Meta
+	}
+	return nil
 }
 
 type SaveDeferRequest struct {
@@ -2567,16 +2583,18 @@ const file_state_v2_state_proto_rawDesc = "" +
 	"\n" +
 	"StepsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"\x93\x01\n" +
+	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01\"\xa7\x01\n" +
 	"\x05Defer\x12\x17\n" +
 	"\afn_slug\x18\x01 \x01(\tR\x06fnSlug\x12\x1b\n" +
 	"\thashed_id\x18\x02 \x01(\tR\bhashedId\x12>\n" +
 	"\x0fschedule_status\x18\x03 \x01(\x0e2\x15.state.v2.DeferStatusR\x0escheduleStatus\x12\x14\n" +
-	"\x05input\x18\x04 \x01(\fR\x05input\"\x81\x01\n" +
+	"\x05input\x18\x04 \x01(\fR\x05input\x12\x12\n" +
+	"\x04meta\x18\x05 \x01(\fR\x04meta\"\x95\x01\n" +
 	"\tDeferMeta\x12\x17\n" +
 	"\afn_slug\x18\x01 \x01(\tR\x06fnSlug\x12\x1b\n" +
 	"\thashed_id\x18\x02 \x01(\tR\bhashedId\x12>\n" +
-	"\x0fschedule_status\x18\x03 \x01(\x0e2\x15.state.v2.DeferStatusR\x0escheduleStatus\"W\n" +
+	"\x0fschedule_status\x18\x03 \x01(\x0e2\x15.state.v2.DeferStatusR\x0escheduleStatus\x12\x12\n" +
+	"\x04meta\x18\x04 \x01(\fR\x04meta\"W\n" +
 	"\x10SaveDeferRequest\x12\x1c\n" +
 	"\x02id\x18\x01 \x01(\v2\f.state.v2.IDR\x02id\x12%\n" +
 	"\x05defer\x18\x02 \x01(\v2\x0f.state.v2.DeferR\x05defer\"\x13\n" +

--- a/proto/state/v2/state.proto
+++ b/proto/state/v2/state.proto
@@ -169,12 +169,14 @@ message Defer {
   string      hashed_id       = 2;
   DeferStatus schedule_status = 3;
   bytes       input           = 4;
+  bytes       meta            = 5;
 }
 
 message DeferMeta {
   string      fn_slug         = 1;
   string      hashed_id       = 2;
   DeferStatus schedule_status = 3;
+  bytes       meta            = 4;
 }
 
 message SaveDeferRequest {

--- a/tests/execution/executor/defer_test.go
+++ b/tests/execution/executor/defer_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -1015,6 +1016,84 @@ func TestDeferPropagatesSessions(t *testing.T) {
 	r.Equal("o_9", evt.Meta.Sessions["org"], "propagated-only key fills a free slot")
 	r.Len(evt.Meta.Sessions, 3)
 	r.Empty(evt.Meta.PropagatedSessions, "propagated layer consumed by ResolveSessions")
+}
+
+// TestDeferRejectsOversizedManualSessions asserts the post-merge validation.
+//
+// Invalid sessions should drop the event rather than scheduling with an
+// invalid session set or failing the parent run.
+func TestDeferRejectsOversizedManualSessions(t *testing.T) {
+	r := require.New(t)
+	infra := newExecTestInfra(t, "step-defer")
+
+	const hashedID = "hash-oversized"
+
+	// consts.MaxEventSessions + 1 manual keys: too many to be a valid event.
+	oversized := map[string]any{}
+	for k := 0; k <= consts.MaxEventSessions; k++ {
+		oversized[fmt.Sprintf("k%d", k)] = fmt.Sprintf("v%d", k)
+	}
+	r.Greater(len(oversized), consts.MaxEventSessions)
+
+	ops := []*state.GeneratorOpcode{
+		{
+			Op: enums.OpcodeDeferAdd,
+			ID: hashedID,
+			Opts: map[string]any{
+				"fn_slug": infra.fn.Slug,
+				"input":   map[string]any{},
+				"meta":    map[string]any{"sessions": oversized},
+			},
+		},
+		{
+			Op:   enums.OpcodeRunComplete,
+			ID:   "run-complete",
+			Data: json.RawMessage(`{"data": {}}`),
+		},
+	}
+
+	driver := &mockDriverV1{
+		t:        t,
+		response: &state.DriverResponse{StatusCode: 206, Generator: ops},
+	}
+	exec := infra.newExecutor(t, executor.WithDriverV1(driver))
+
+	var finalizationEvents []event.Event
+	exec.SetFinalizer(func(_ context.Context, _ statev2.ID, events []event.Event) error {
+		finalizationEvents = append(finalizationEvents, events...)
+		return nil
+	})
+
+	parentRun := infra.scheduleRun(t, exec)
+	_, err := exec.Execute(infra.ctx, state.Identifier{
+		WorkflowID: infra.fnID, RunID: parentRun.ID.RunID, AccountID: infra.aID,
+	}, queue.Item{
+		Identifier:  state.Identifier{WorkflowID: infra.fnID, RunID: parentRun.ID.RunID, AccountID: infra.aID},
+		Kind:        queue.KindStart,
+		Payload:     queue.PayloadEdge{Edge: inngest.Edge{Incoming: "$trigger", Outgoing: hashedID}},
+		WorkspaceID: infra.wsID,
+	}, inngest.Edge{Incoming: "$trigger", Outgoing: hashedID})
+	r.NoError(err, "parent run still finalizes cleanly")
+
+	r.False(hasDeferEvent(finalizationEvents, parentRun.ID.RunID, hashedID),
+		"deferred.schedule event should be dropped for an invalid session set")
+}
+
+// hasDeferEvent reports whether a deferred.schedule event was emitted for
+// (parentRunID, hashedID). Unlike findDeferEvent it does not fail the test on
+// absence, so it can assert an event was dropped.
+func hasDeferEvent(events []event.Event, parentRunID ulid.ULID, hashedID string) bool {
+	wantSpanID := tracing.DeferSpanRef(parentRunID, hashedID).DynamicSpanID
+	for _, e := range events {
+		md, err := e.DeferredScheduleMetadata()
+		if err != nil || md.ParentDeferSpan == nil {
+			continue
+		}
+		if md.ParentDeferSpan.DynamicSpanID == wantSpanID {
+			return true
+		}
+	}
+	return false
 }
 
 // findDeferEvent picks the deferred.schedule event whose ParentDeferSpan

--- a/tests/execution/executor/defer_test.go
+++ b/tests/execution/executor/defer_test.go
@@ -1018,15 +1018,20 @@ func TestDeferPropagatesSessions(t *testing.T) {
 	r.Empty(evt.Meta.PropagatedSessions, "propagated layer consumed by ResolveSessions")
 }
 
-// TestDeferRejectsOversizedManualSessions asserts the post-merge validation.
+// TestDeferRejectsOversizedManualSessions asserts the post-merge validation
+// and its per-defer isolation.
 //
-// Invalid sessions should drop the event rather than scheduling with an
-// invalid session set or failing the parent run.
+// Invalid sessions should drop only that defer's event — rather than
+// scheduling with an invalid session set, failing the parent run, or taking
+// sibling defers down with it: buildDeferEvents `continue`s past each
+// rejected defer, so a valid sibling registered in the same run must still
+// schedule.
 func TestDeferRejectsOversizedManualSessions(t *testing.T) {
 	r := require.New(t)
 	infra := newExecTestInfra(t, "step-defer")
 
 	const hashedID = "hash-oversized"
+	const siblingID = "hash-valid-sibling"
 
 	// consts.MaxEventSessions + 1 manual keys: too many to be a valid event.
 	oversized := map[string]any{}
@@ -1043,6 +1048,15 @@ func TestDeferRejectsOversizedManualSessions(t *testing.T) {
 				"fn_slug": infra.fn.Slug,
 				"input":   map[string]any{},
 				"meta":    map[string]any{"sessions": oversized},
+			},
+		},
+		{
+			Op: enums.OpcodeDeferAdd,
+			ID: siblingID,
+			Opts: map[string]any{
+				"fn_slug": infra.fn.Slug,
+				"input":   map[string]any{},
+				"meta":    map[string]any{"sessions": map[string]any{"tenant": "t_1"}},
 			},
 		},
 		{
@@ -1077,6 +1091,18 @@ func TestDeferRejectsOversizedManualSessions(t *testing.T) {
 
 	r.False(hasDeferEvent(finalizationEvents, parentRun.ID.RunID, hashedID),
 		"deferred.schedule event should be dropped for an invalid session set")
+
+	evt := findDeferEvent(t, finalizationEvents, parentRun.ID.RunID, siblingID)
+	r.Equal("t_1", evt.Meta.Sessions["tenant"], "valid sibling keeps its own sessions")
+	r.Len(evt.Meta.Sessions, 1)
+
+	deferEvents := 0
+	for _, e := range finalizationEvents {
+		if e.Name == consts.FnDeferScheduleName {
+			deferEvents++
+		}
+	}
+	r.Equal(1, deferEvents, "only the valid sibling schedules")
 }
 
 // TestDeferSessionTombstones pins the tombstone single-hop invariant: RFC 7386

--- a/tests/execution/executor/defer_test.go
+++ b/tests/execution/executor/defer_test.go
@@ -1079,6 +1079,136 @@ func TestDeferRejectsOversizedManualSessions(t *testing.T) {
 		"deferred.schedule event should be dropped for an invalid session set")
 }
 
+// TestDeferSessionTombstones pins the tombstone single-hop invariant: RFC 7386
+// null tombstones stamped into a defer's meta must survive persistence
+// byte-preserved and take effect at finalize. The meta is an opaque blob from
+// SaveFromOp through redis_state to LoadDefers; it is unmarshaled exactly once
+// in buildDeferEvents, where EventMeta.UnmarshalJSON captures the nulls that a
+// plain map[string]string cannot represent. Any intermediate materialize or
+// re-marshal would silently drop the JSON nulls (Go serializes an absent key
+// and a null-valued key identically once decoded into a map), so this asserts
+// the tombstones actually cut propagated keys on the emitted event.
+func TestDeferSessionTombstones(t *testing.T) {
+	t.Run("per-key tombstone cuts the matching propagated key", func(t *testing.T) {
+		// Manual layer: `cut` is a null tombstone, `keep` is a real id. Parent
+		// propagated `cut` (must be cut) and `survive` (must pass through). The
+		// tombstone itself must never surface as a session key.
+		r := require.New(t)
+		infra := newExecTestInfra(t, "step-defer")
+
+		const hashedID = "hash-tombstone-perkey"
+
+		ops := []*state.GeneratorOpcode{
+			{
+				Op: enums.OpcodeDeferAdd,
+				ID: hashedID,
+				Opts: map[string]any{
+					"fn_slug": infra.fn.Slug,
+					"input":   map[string]any{},
+					"meta": map[string]any{
+						// nil marshals to JSON null: the per-key tombstone.
+						"sessions":           map[string]any{"cut": nil, "keep": "manual-id"},
+						"propagated_sessions": map[string]any{"cut": "inherited-cut", "survive": "prop-id"},
+					},
+				},
+			},
+			{
+				Op:   enums.OpcodeRunComplete,
+				ID:   "run-complete",
+				Data: json.RawMessage(`{"data": {}}`),
+			},
+		}
+
+		driver := &mockDriverV1{
+			t:        t,
+			response: &state.DriverResponse{StatusCode: 206, Generator: ops},
+		}
+		exec := infra.newExecutor(t, executor.WithDriverV1(driver))
+
+		var finalizationEvents []event.Event
+		exec.SetFinalizer(func(_ context.Context, _ statev2.ID, events []event.Event) error {
+			finalizationEvents = append(finalizationEvents, events...)
+			return nil
+		})
+
+		parentRun := infra.scheduleRun(t, exec)
+		_, err := exec.Execute(infra.ctx, state.Identifier{
+			WorkflowID: infra.fnID, RunID: parentRun.ID.RunID, AccountID: infra.aID,
+		}, queue.Item{
+			Identifier:  state.Identifier{WorkflowID: infra.fnID, RunID: parentRun.ID.RunID, AccountID: infra.aID},
+			Kind:        queue.KindStart,
+			Payload:     queue.PayloadEdge{Edge: inngest.Edge{Incoming: "$trigger", Outgoing: hashedID}},
+			WorkspaceID: infra.wsID,
+		}, inngest.Edge{Incoming: "$trigger", Outgoing: hashedID})
+		r.NoError(err)
+
+		evt := findDeferEvent(t, finalizationEvents, parentRun.ID.RunID, hashedID)
+		r.NotContains(evt.Meta.Sessions, "cut", "tombstone cuts the matching propagated key")
+		r.Equal("manual-id", evt.Meta.Sessions["keep"], "manual-only key survives")
+		r.Equal("prop-id", evt.Meta.Sessions["survive"], "untombstoned propagated key survives")
+		r.Len(evt.Meta.Sessions, 2, "tombstone consumed: only keep + survive remain")
+		r.Empty(evt.Meta.PropagatedSessions, "propagated layer consumed by ResolveSessions")
+	})
+
+	t.Run("whole-field null clears all propagated sessions", func(t *testing.T) {
+		// Manual `sessions` is JSON null (RFC 7386 whole-document tombstone):
+		// clear every inherited session. Distinct from an absent field, which
+		// would keep the propagated layer.
+		r := require.New(t)
+		infra := newExecTestInfra(t, "step-defer")
+
+		const hashedID = "hash-tombstone-clearall"
+
+		ops := []*state.GeneratorOpcode{
+			{
+				Op: enums.OpcodeDeferAdd,
+				ID: hashedID,
+				Opts: map[string]any{
+					"fn_slug": infra.fn.Slug,
+					"input":   map[string]any{},
+					"meta": map[string]any{
+						// nil marshals to JSON null: the whole-field clear-all.
+						"sessions":           nil,
+						"propagated_sessions": map[string]any{"org": "o_9", "tenant": "acme"},
+					},
+				},
+			},
+			{
+				Op:   enums.OpcodeRunComplete,
+				ID:   "run-complete",
+				Data: json.RawMessage(`{"data": {}}`),
+			},
+		}
+
+		driver := &mockDriverV1{
+			t:        t,
+			response: &state.DriverResponse{StatusCode: 206, Generator: ops},
+		}
+		exec := infra.newExecutor(t, executor.WithDriverV1(driver))
+
+		var finalizationEvents []event.Event
+		exec.SetFinalizer(func(_ context.Context, _ statev2.ID, events []event.Event) error {
+			finalizationEvents = append(finalizationEvents, events...)
+			return nil
+		})
+
+		parentRun := infra.scheduleRun(t, exec)
+		_, err := exec.Execute(infra.ctx, state.Identifier{
+			WorkflowID: infra.fnID, RunID: parentRun.ID.RunID, AccountID: infra.aID,
+		}, queue.Item{
+			Identifier:  state.Identifier{WorkflowID: infra.fnID, RunID: parentRun.ID.RunID, AccountID: infra.aID},
+			Kind:        queue.KindStart,
+			Payload:     queue.PayloadEdge{Edge: inngest.Edge{Incoming: "$trigger", Outgoing: hashedID}},
+			WorkspaceID: infra.wsID,
+		}, inngest.Edge{Incoming: "$trigger", Outgoing: hashedID})
+		r.NoError(err)
+
+		evt := findDeferEvent(t, finalizationEvents, parentRun.ID.RunID, hashedID)
+		r.Empty(evt.Meta.Sessions, "whole-field null clears all inherited sessions")
+		r.Empty(evt.Meta.PropagatedSessions, "propagated layer consumed by ResolveSessions")
+	})
+}
+
 // hasDeferEvent reports whether a deferred.schedule event was emitted for
 // (parentRunID, hashedID). Unlike findDeferEvent it does not fail the test on
 // absence, so it can assert an event was dropped.

--- a/tests/execution/executor/defer_test.go
+++ b/tests/execution/executor/defer_test.go
@@ -951,11 +951,13 @@ func (i *execTestInfra) runParentDefer(t *testing.T, hashedIDs ...string) (ulid.
 }
 
 // TestDeferPropagatesSessions drives the full defer session-propagation path:
-// a DeferAdd op carrying meta.propagated_sessions rides through SaveFromOp and
-// the persisted Defer to Finalize, where buildDeferEvents resolves the
-// propagated layer onto the emitted deferred.schedule event. Propagated folds
-// into the manual layer, so the inherited session surfaces on Meta.Sessions
-// and the propagated layer is consumed.
+// a DeferAdd op carrying both a manual meta.sessions layer and a
+// meta.propagated_sessions layer rides through SaveFromOp and the persisted
+// Defer to Finalize, where buildDeferEvents resolves the two layers onto the
+// emitted deferred.schedule event. ResolveSessions folds propagated into
+// manual: manual wins on a key collision (tenant), manual-only keys pass
+// through (user), and propagated-only keys fill free slots (org). The
+// propagated layer is consumed in the process.
 func TestDeferPropagatesSessions(t *testing.T) {
 	r := require.New(t)
 	infra := newExecTestInfra(t, "step-defer")
@@ -972,7 +974,8 @@ func TestDeferPropagatesSessions(t *testing.T) {
 				// The SDK stamps the inherited session layer here at defer
 				// call-time.
 				"meta": map[string]any{
-					"propagated_sessions": map[string]any{"tenant": "acme"},
+					"sessions":            map[string]any{"tenant": "manual-wins", "user": "u_1"},
+					"propagated_sessions": map[string]any{"tenant": "acme", "org": "o_9"},
 				},
 			},
 		},
@@ -1007,10 +1010,11 @@ func TestDeferPropagatesSessions(t *testing.T) {
 	r.NoError(err)
 
 	evt := findDeferEvent(t, finalizationEvents, parentRun.ID.RunID, hashedID)
-	r.Equal("acme", evt.Meta.Sessions["tenant"],
-		"propagated session should fold into the resolved manual layer")
-	r.Empty(evt.Meta.PropagatedSessions,
-		"propagated layer should be consumed by ResolveSessions")
+	r.Equal("manual-wins", evt.Meta.Sessions["tenant"], "manual layer wins on key collision")
+	r.Equal("u_1", evt.Meta.Sessions["user"], "manual-only key survives")
+	r.Equal("o_9", evt.Meta.Sessions["org"], "propagated-only key fills a free slot")
+	r.Len(evt.Meta.Sessions, 3)
+	r.Empty(evt.Meta.PropagatedSessions, "propagated layer consumed by ResolveSessions")
 }
 
 // findDeferEvent picks the deferred.schedule event whose ParentDeferSpan

--- a/tests/execution/executor/defer_test.go
+++ b/tests/execution/executor/defer_test.go
@@ -950,6 +950,69 @@ func (i *execTestInfra) runParentDefer(t *testing.T, hashedIDs ...string) (ulid.
 	return parentRun.ID.RunID, deferEvents
 }
 
+// TestDeferPropagatesSessions drives the full defer session-propagation path:
+// a DeferAdd op carrying meta.propagated_sessions rides through SaveFromOp and
+// the persisted Defer to Finalize, where buildDeferEvents resolves the
+// propagated layer onto the emitted deferred.schedule event. Propagated folds
+// into the manual layer, so the inherited session surfaces on Meta.Sessions
+// and the propagated layer is consumed.
+func TestDeferPropagatesSessions(t *testing.T) {
+	r := require.New(t)
+	infra := newExecTestInfra(t, "step-defer")
+
+	const hashedID = "hash-session"
+
+	ops := []*state.GeneratorOpcode{
+		{
+			Op: enums.OpcodeDeferAdd,
+			ID: hashedID,
+			Opts: map[string]any{
+				"fn_slug": infra.fn.Slug,
+				"input":   map[string]any{},
+				// The SDK stamps the inherited session layer here at defer
+				// call-time.
+				"meta": map[string]any{
+					"propagated_sessions": map[string]any{"tenant": "acme"},
+				},
+			},
+		},
+		{
+			Op:   enums.OpcodeRunComplete,
+			ID:   "run-complete",
+			Data: json.RawMessage(`{"data": {}}`),
+		},
+	}
+
+	driver := &mockDriverV1{
+		t:        t,
+		response: &state.DriverResponse{StatusCode: 206, Generator: ops},
+	}
+	exec := infra.newExecutor(t, executor.WithDriverV1(driver))
+
+	var finalizationEvents []event.Event
+	exec.SetFinalizer(func(_ context.Context, _ statev2.ID, events []event.Event) error {
+		finalizationEvents = append(finalizationEvents, events...)
+		return nil
+	})
+
+	parentRun := infra.scheduleRun(t, exec)
+	_, err := exec.Execute(infra.ctx, state.Identifier{
+		WorkflowID: infra.fnID, RunID: parentRun.ID.RunID, AccountID: infra.aID,
+	}, queue.Item{
+		Identifier:  state.Identifier{WorkflowID: infra.fnID, RunID: parentRun.ID.RunID, AccountID: infra.aID},
+		Kind:        queue.KindStart,
+		Payload:     queue.PayloadEdge{Edge: inngest.Edge{Incoming: "$trigger", Outgoing: hashedID}},
+		WorkspaceID: infra.wsID,
+	}, inngest.Edge{Incoming: "$trigger", Outgoing: hashedID})
+	r.NoError(err)
+
+	evt := findDeferEvent(t, finalizationEvents, parentRun.ID.RunID, hashedID)
+	r.Equal("acme", evt.Meta.Sessions["tenant"],
+		"propagated session should fold into the resolved manual layer")
+	r.Empty(evt.Meta.PropagatedSessions,
+		"propagated layer should be consumed by ResolveSessions")
+}
+
 // findDeferEvent picks the deferred.schedule event whose ParentDeferSpan
 // matches (parentRunID, hashedID). buildDeferEvents emits in
 // non-deterministic order, so we can't rely on slice position.


### PR DESCRIPTION
## Description

- We're adding sessions support for defer. Deferred functions should be able to use both manual and propagated sessions
- In this PR, we add piping so that meta.sessions can be travel from the SDK's opcode -> persistence in Redis -> executor attaches it on to the `deferred.schedule` event
- In later monorepo PRs, we'll add scylladb support
- EXE-2035

## Release note

<!-- User-facing release note. Use "None" if this does not need release notes. -->
None.

## Migration note

<!-- Upgrade, deployment, config, schema, or compatibility notes. Use "None" if none. -->
None.

*[Check our Pull Request Guidelines](https://github.com/inngest/inngest/blob/main/docs/PULL_REQUEST_GUIDELINES.md)*

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>